### PR TITLE
feat: add admin tenant pool

### DIFF
--- a/cmd/drive9/cli/admin.go
+++ b/cmd/drive9/cli/admin.go
@@ -469,7 +469,7 @@ func adminTenantPool(args []string) error {
 }
 
 func adminTenantPoolCreate(args []string) error {
-	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolCreateUsage(), true, true)
+	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolCreateUsage(), true)
 	if err != nil {
 		if errors.Is(err, errHelpRequested{}) {
 			return nil
@@ -487,7 +487,7 @@ func adminTenantPoolCreate(args []string) error {
 }
 
 func adminTenantPoolGet(args []string) error {
-	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolGetUsage(), false, false)
+	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolGetUsage(), false)
 	if err != nil {
 		if errors.Is(err, errHelpRequested{}) {
 			return nil
@@ -502,7 +502,7 @@ func adminTenantPoolGet(args []string) error {
 }
 
 func adminTenantPoolUpdate(args []string) error {
-	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolUpdateUsage(), true, true)
+	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolUpdateUsage(), true)
 	if err != nil {
 		if errors.Is(err, errHelpRequested{}) {
 			return nil
@@ -520,7 +520,7 @@ func adminTenantPoolUpdate(args []string) error {
 }
 
 func adminTenantPoolDelete(args []string) error {
-	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolDeleteUsage(), false, false)
+	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolDeleteUsage(), false)
 	if err != nil {
 		if errors.Is(err, errHelpRequested{}) {
 			return nil
@@ -534,7 +534,7 @@ func adminTenantPoolDelete(args []string) error {
 	return printAdminTenantPoolResponse(out, asJSON)
 }
 
-func parseAdminTenantPoolCommand(args []string, usage string, allowPoolSize, allowSpendingLimit bool) (req client.AdminTenantPoolRequest, server string, asJSON bool, err error) {
+func parseAdminTenantPoolCommand(args []string, usage string, allowPoolSize bool) (req client.AdminTenantPoolRequest, server string, asJSON bool, err error) {
 	serverFlag := ""
 	serverGiven := false
 	regionCodeFlag := ""
@@ -592,19 +592,6 @@ func parseAdminTenantPoolCommand(args []string, usage string, allowPoolSize, all
 			poolSize := int(v)
 			req.PoolSize = &poolSize
 			poolSizeGiven = true
-		case "--tidbcloud-spending-limit":
-			if !allowSpendingLimit {
-				return req, "", false, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
-			}
-			if i+1 >= len(args) {
-				return req, "", false, fmt.Errorf("--tidbcloud-spending-limit requires an argument")
-			}
-			i++
-			v, parseErr := parseNonNegativeQuotaInt64Flag("--tidbcloud-spending-limit", args[i])
-			if parseErr != nil {
-				return req, "", false, parseErr
-			}
-			req.TiDBCloudSpendingLimit = &v
 		case "--json":
 			asJSON = true
 		default:
@@ -928,7 +915,6 @@ flags:
   --pool-size N                    pool target free tenant count
   --tidbcloud-public-key KEY       TiDB Cloud public key
   --tidbcloud-private-key KEY      TiDB Cloud private key
-  --tidbcloud-spending-limit N     create/update TiDB Cloud Cluster Spending Limit for new pool clusters
   --json                           output result as JSON
 
 examples:
@@ -960,7 +946,6 @@ flags:
   --pool-size N                    number of free tenants to pre-create; must be positive
   --tidbcloud-public-key KEY       TiDB Cloud public key
   --tidbcloud-private-key KEY      TiDB Cloud private key
-  --tidbcloud-spending-limit N     TiDB Cloud Cluster Spending Limit for pool clusters
   --json                           output result as JSON`
 }
 
@@ -989,7 +974,6 @@ flags:
   --pool-size N                    target free tenant count; must be positive
   --tidbcloud-public-key KEY       TiDB Cloud public key
   --tidbcloud-private-key KEY      TiDB Cloud private key
-  --tidbcloud-spending-limit N     TiDB Cloud Cluster Spending Limit for newly-created pool clusters
   --json                           output result as JSON`
 }
 

--- a/cmd/drive9/cli/admin.go
+++ b/cmd/drive9/cli/admin.go
@@ -22,6 +22,8 @@ func Admin(args []string) error {
 		return nil
 	case "tenant", "tenants":
 		return adminTenant(args[1:])
+	case "pool":
+		return adminTenantPool(args[1:])
 	default:
 		return fmt.Errorf("unknown admin command %q\n%s", args[0], adminUsage())
 	}
@@ -45,6 +47,8 @@ func adminTenant(args []string) error {
 		return adminTenantDelete(args[1:])
 	case "set-quota":
 		return quotaSet(args[1:])
+	case "pool":
+		return adminTenantPool(args[1:])
 	default:
 		return fmt.Errorf("unknown admin tenant command %q\n%s", args[0], adminTenantUsage())
 	}
@@ -443,6 +447,193 @@ func adminTenantDelete(args []string) error {
 	return printAdminTenantDeleteResponse(out)
 }
 
+func adminTenantPool(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("%s", adminTenantPoolUsage())
+	}
+	switch args[0] {
+	case "-h", "-help", "--help", "help":
+		_, _ = fmt.Fprintln(os.Stdout, adminTenantPoolUsage())
+		return nil
+	case "create":
+		return adminTenantPoolCreate(args[1:])
+	case "get":
+		return adminTenantPoolGet(args[1:])
+	case "update":
+		return adminTenantPoolUpdate(args[1:])
+	case "delete":
+		return adminTenantPoolDelete(args[1:])
+	default:
+		return fmt.Errorf("unknown admin pool command %q\n%s", args[0], adminTenantPoolUsage())
+	}
+}
+
+func adminTenantPoolCreate(args []string) error {
+	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolCreateUsage(), true, true)
+	if err != nil {
+		if errors.Is(err, errHelpRequested{}) {
+			return nil
+		}
+		return err
+	}
+	if req.PoolSize <= 0 {
+		return fmt.Errorf("--pool-size must be positive")
+	}
+	out, err := client.New(server, "").AdminCreateTenantPool(context.Background(), req)
+	if err != nil {
+		return quotaAPIError("create admin tenant pool", err)
+	}
+	return printAdminTenantPoolResponse(out, asJSON)
+}
+
+func adminTenantPoolGet(args []string) error {
+	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolGetUsage(), false, false)
+	if err != nil {
+		if errors.Is(err, errHelpRequested{}) {
+			return nil
+		}
+		return err
+	}
+	out, err := client.New(server, "").AdminGetTenantPool(context.Background(), req)
+	if err != nil {
+		return quotaAPIError("get admin tenant pool", err)
+	}
+	return printAdminTenantPoolResponse(out, asJSON)
+}
+
+func adminTenantPoolUpdate(args []string) error {
+	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolUpdateUsage(), true, true)
+	if err != nil {
+		if errors.Is(err, errHelpRequested{}) {
+			return nil
+		}
+		return err
+	}
+	out, err := client.New(server, "").AdminUpdateTenantPool(context.Background(), req)
+	if err != nil {
+		return quotaAPIError("update admin tenant pool", err)
+	}
+	return printAdminTenantPoolResponse(out, asJSON)
+}
+
+func adminTenantPoolDelete(args []string) error {
+	req, server, asJSON, err := parseAdminTenantPoolCommand(args, adminTenantPoolDeleteUsage(), false, false)
+	if err != nil {
+		if errors.Is(err, errHelpRequested{}) {
+			return nil
+		}
+		return err
+	}
+	out, err := client.New(server, "").AdminDeleteTenantPool(context.Background(), req)
+	if err != nil {
+		return quotaAPIError("delete admin tenant pool", err)
+	}
+	return printAdminTenantPoolResponse(out, asJSON)
+}
+
+func parseAdminTenantPoolCommand(args []string, usage string, allowPoolSize, allowSpendingLimit bool) (req client.AdminTenantPoolRequest, server string, asJSON bool, err error) {
+	serverFlag := ""
+	serverGiven := false
+	regionCodeFlag := ""
+	regionCodeGiven := false
+	publicKeyFlag := ""
+	publicKeyGiven := false
+	privateKeyFlag := ""
+	privateKeyGiven := false
+	poolSizeGiven := false
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-h", "-help", "--help", "help":
+			_, _ = fmt.Fprintln(os.Stdout, usage)
+			return req, "", false, errHelpRequested{}
+		case "--server":
+			if i+1 >= len(args) {
+				return req, "", false, fmt.Errorf("--server requires an argument")
+			}
+			i++
+			serverFlag = args[i]
+			serverGiven = true
+		case "--region-code":
+			if i+1 >= len(args) {
+				return req, "", false, fmt.Errorf("--region-code requires an argument")
+			}
+			i++
+			regionCodeFlag = args[i]
+			regionCodeGiven = true
+		case "--tidbcloud-public-key":
+			if i+1 >= len(args) {
+				return req, "", false, fmt.Errorf("--tidbcloud-public-key requires an argument")
+			}
+			i++
+			publicKeyFlag = args[i]
+			publicKeyGiven = true
+		case "--tidbcloud-private-key":
+			if i+1 >= len(args) {
+				return req, "", false, fmt.Errorf("--tidbcloud-private-key requires an argument")
+			}
+			i++
+			privateKeyFlag = args[i]
+			privateKeyGiven = true
+		case "--pool-size":
+			if !allowPoolSize {
+				return req, "", false, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+			}
+			if i+1 >= len(args) {
+				return req, "", false, fmt.Errorf("--pool-size requires an argument")
+			}
+			i++
+			v, parseErr := parseNonNegativeQuotaInt64Flag("--pool-size", args[i])
+			if parseErr != nil {
+				return req, "", false, parseErr
+			}
+			req.PoolSize = int(v)
+			poolSizeGiven = true
+		case "--tidbcloud-spending-limit":
+			if !allowSpendingLimit {
+				return req, "", false, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+			}
+			if i+1 >= len(args) {
+				return req, "", false, fmt.Errorf("--tidbcloud-spending-limit requires an argument")
+			}
+			i++
+			v, parseErr := parseNonNegativeQuotaInt64Flag("--tidbcloud-spending-limit", args[i])
+			if parseErr != nil {
+				return req, "", false, parseErr
+			}
+			req.TiDBCloudSpendingLimit = &v
+		case "--json":
+			asJSON = true
+		default:
+			return req, "", false, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+		}
+	}
+	if allowPoolSize && !poolSizeGiven {
+		return req, "", false, fmt.Errorf("--pool-size is required")
+	}
+	if err := rejectEmptyFlag("server", strings.TrimSpace(serverFlag), serverGiven); err != nil {
+		return req, "", false, err
+	}
+	if err := rejectEmptyFlag("region-code", strings.TrimSpace(regionCodeFlag), regionCodeGiven); err != nil {
+		return req, "", false, err
+	}
+	if err := rejectEmptyFlag("tidbcloud-public-key", strings.TrimSpace(publicKeyFlag), publicKeyGiven); err != nil {
+		return req, "", false, err
+	}
+	if err := rejectEmptyFlag("tidbcloud-private-key", strings.TrimSpace(privateKeyFlag), privateKeyGiven); err != nil {
+		return req, "", false, err
+	}
+	r := ResolveCredentials()
+	server, err = quotaServer(serverFlag, regionCodeFlag, r.Server, true)
+	if err != nil {
+		return req, "", false, err
+	}
+	req.PublicKey, req.PrivateKey = adminTiDBCloudKeys(publicKeyFlag, privateKeyFlag)
+	if strings.TrimSpace(req.PublicKey) == "" || strings.TrimSpace(req.PrivateKey) == "" {
+		return req, "", false, fmt.Errorf("TiDB Cloud credentials are required; pass --tidbcloud-public-key and --tidbcloud-private-key or set %s/%s", EnvTiDBCloudPublicKey, EnvTiDBCloudPrivateKey)
+	}
+	return req, server, asJSON, nil
+}
+
 func parseAdminTenantIDCommand(args []string, usage string) (tenantID, server, publicKey, privateKey string, asJSON bool, err error) {
 	serverFlag := ""
 	serverGiven := false
@@ -546,14 +737,15 @@ type errHelpRequested struct{}
 func (errHelpRequested) Error() string { return "help requested" }
 
 func adminUsage() string {
-	return `usage: drive9 admin tenant <command> [arguments]
+	return `usage: drive9 admin <command> [arguments]
 
 commands:
-  tenant create [flags]            create a TiDBCloud Mode tenant
-  tenant list [flags]              list TiDBCloud Mode tenants
-  tenant get --tenant-id ID        show one tenant and quota
-  tenant delete --tenant-id ID     delete one tenant
-  tenant set-quota --tenant-id ID  set quota for one tenant
+  tenant create [flags]             create a TiDBCloud Mode tenant
+  tenant list [flags]               list TiDBCloud Mode tenants
+  tenant get --tenant-id ID         show one tenant and quota
+  tenant delete --tenant-id ID      delete one tenant
+  tenant set-quota --tenant-id ID   set quota for one tenant
+  pool <command> [flags]            manage the tenant pool
 
 global admin flags:
   --server URL                     server URL (default: active context server)
@@ -563,6 +755,10 @@ global admin flags:
   --json                           output result as JSON when supported
 
 examples:
+  drive9 admin tenant create --region-code aws-ap-southeast-1 \
+    --tidbcloud-public-key <public-key> \
+    --tidbcloud-private-key <private-key>
+
   drive9 admin tenant list --region-code aws-ap-southeast-1 \
     --tidbcloud-public-key <public-key> \
     --tidbcloud-private-key <private-key>
@@ -572,6 +768,14 @@ examples:
     --tidbcloud-private-key <private-key>
 
   drive9 admin tenant set-quota --tenant-id tnt_xxx --max-storage-size 102400 \
+    --tidbcloud-public-key <public-key> \
+    --tidbcloud-private-key <private-key>
+
+  drive9 admin tenant delete --tenant-id tnt_xxx \
+    --tidbcloud-public-key <public-key> \
+    --tidbcloud-private-key <private-key>
+
+  drive9 admin pool create --pool-size 10 \
     --tidbcloud-public-key <public-key> \
     --tidbcloud-private-key <private-key>`
 }
@@ -705,6 +909,99 @@ example:
     --tidbcloud-private-key <private-key>`
 }
 
+func adminTenantPoolUsage() string {
+	return `usage: drive9 admin pool <command> [arguments]
+
+commands:
+  create --pool-size N             create a tenant pool
+  get                              show the tenant pool
+  update --pool-size N             update tenant pool size
+  delete                           delete the tenant pool's free tenants
+
+flags:
+  --server URL                     server URL (default: active context server)
+  --region-code CODE               TiDBCloud Mode region code; ignored when --server is set
+  --pool-size N                    pool target free tenant count
+  --tidbcloud-public-key KEY       TiDB Cloud public key
+  --tidbcloud-private-key KEY      TiDB Cloud private key
+  --tidbcloud-spending-limit N     create/update TiDB Cloud Cluster Spending Limit for new pool clusters
+  --json                           output result as JSON
+
+examples:
+  drive9 admin pool create --pool-size 10 \
+    --tidbcloud-public-key <public-key> \
+    --tidbcloud-private-key <private-key>
+
+  drive9 admin pool get \
+    --tidbcloud-public-key <public-key> \
+    --tidbcloud-private-key <private-key>
+
+  drive9 admin pool update --pool-size 20 \
+    --tidbcloud-public-key <public-key> \
+    --tidbcloud-private-key <private-key>
+
+  drive9 admin pool delete \
+    --tidbcloud-public-key <public-key> \
+    --tidbcloud-private-key <private-key>`
+}
+
+func adminTenantPoolCreateUsage() string {
+	return `usage: drive9 admin pool create --pool-size N [flags]
+
+create a TiDBCloud Mode tenant pool. New pool clusters are labeled free.
+
+flags:
+  --server URL                     server URL (default: active context server)
+  --region-code CODE               TiDBCloud Mode region code; ignored when --server is set
+  --pool-size N                    number of free tenants to pre-create; must be positive
+  --tidbcloud-public-key KEY       TiDB Cloud public key
+  --tidbcloud-private-key KEY      TiDB Cloud private key
+  --tidbcloud-spending-limit N     TiDB Cloud Cluster Spending Limit for pool clusters
+  --json                           output result as JSON`
+}
+
+func adminTenantPoolGetUsage() string {
+	return `usage: drive9 admin pool get [flags]
+
+show the TiDBCloud Mode tenant pool.
+
+flags:
+  --server URL                     server URL (default: active context server)
+  --region-code CODE               TiDBCloud Mode region code; ignored when --server is set
+  --tidbcloud-public-key KEY       TiDB Cloud public key
+  --tidbcloud-private-key KEY      TiDB Cloud private key
+  --json                           output result as JSON`
+}
+
+func adminTenantPoolUpdateUsage() string {
+	return `usage: drive9 admin pool update --pool-size N [flags]
+
+update TiDBCloud Mode tenant pool size. Increasing creates free tenants;
+decreasing deletes newest free tenants.
+
+flags:
+  --server URL                     server URL (default: active context server)
+  --region-code CODE               TiDBCloud Mode region code; ignored when --server is set
+  --pool-size N                    target free tenant count; must be non-negative
+  --tidbcloud-public-key KEY       TiDB Cloud public key
+  --tidbcloud-private-key KEY      TiDB Cloud private key
+  --tidbcloud-spending-limit N     TiDB Cloud Cluster Spending Limit for newly-created pool clusters
+  --json                           output result as JSON`
+}
+
+func adminTenantPoolDeleteUsage() string {
+	return `usage: drive9 admin pool delete [flags]
+
+delete the TiDBCloud Mode tenant pool's free tenants and remove the pool.
+
+flags:
+  --server URL                     server URL (default: active context server)
+  --region-code CODE               TiDBCloud Mode region code; ignored when --server is set
+  --tidbcloud-public-key KEY       TiDB Cloud public key
+  --tidbcloud-private-key KEY      TiDB Cloud private key
+  --json                           output result as JSON`
+}
+
 func printAdminTenantCreateResponse(out *client.AdminTenantCreateResponse) error {
 	if out == nil {
 		return fmt.Errorf("admin tenant create response is empty")
@@ -717,6 +1014,27 @@ func printAdminTenantCreateResponse(out *client.AdminTenantCreateResponse) error
 		emptyAsDash(out.CloudProvider),
 		emptyAsDash(out.Region),
 		out.APIKey,
+	)
+	return w.Flush()
+}
+
+func printAdminTenantPoolResponse(out *client.AdminTenantPoolResponse, asJSON bool) error {
+	if out == nil {
+		return fmt.Errorf("admin tenant pool response is empty")
+	}
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "POOL_ID\tORGANIZATION_ID\tPOOL_SIZE\tFREE_SIZE\tSTATUS")
+	_, _ = fmt.Fprintf(w, "%s\t%s\t%d\t%d\t%s\n",
+		out.PoolID,
+		emptyAsDash(out.OrganizationID),
+		out.PoolSize,
+		out.FreeSize,
+		out.Status,
 	)
 	return w.Flush()
 }

--- a/cmd/drive9/cli/admin.go
+++ b/cmd/drive9/cli/admin.go
@@ -476,7 +476,7 @@ func adminTenantPoolCreate(args []string) error {
 		}
 		return err
 	}
-	if req.PoolSize <= 0 {
+	if req.PoolSize == nil || *req.PoolSize <= 0 {
 		return fmt.Errorf("--pool-size must be positive")
 	}
 	out, err := client.New(server, "").AdminCreateTenantPool(context.Background(), req)
@@ -508,6 +508,9 @@ func adminTenantPoolUpdate(args []string) error {
 			return nil
 		}
 		return err
+	}
+	if req.PoolSize == nil || *req.PoolSize <= 0 {
+		return fmt.Errorf("--pool-size must be positive")
 	}
 	out, err := client.New(server, "").AdminUpdateTenantPool(context.Background(), req)
 	if err != nil {
@@ -586,7 +589,8 @@ func parseAdminTenantPoolCommand(args []string, usage string, allowPoolSize, all
 			if parseErr != nil {
 				return req, "", false, parseErr
 			}
-			req.PoolSize = int(v)
+			poolSize := int(v)
+			req.PoolSize = &poolSize
 			poolSizeGiven = true
 		case "--tidbcloud-spending-limit":
 			if !allowSpendingLimit {
@@ -982,7 +986,7 @@ decreasing deletes newest free tenants.
 flags:
   --server URL                     server URL (default: active context server)
   --region-code CODE               TiDBCloud Mode region code; ignored when --server is set
-  --pool-size N                    target free tenant count; must be non-negative
+  --pool-size N                    target free tenant count; must be positive
   --tidbcloud-public-key KEY       TiDB Cloud public key
   --tidbcloud-private-key KEY      TiDB Cloud private key
   --tidbcloud-spending-limit N     TiDB Cloud Cluster Spending Limit for newly-created pool clusters

--- a/cmd/drive9/cli/admin_test.go
+++ b/cmd/drive9/cli/admin_test.go
@@ -11,19 +11,20 @@ import (
 
 func TestAdminTenantHelpIncludesCommandsFlagsAndExamples(t *testing.T) {
 	stdout, err := captureStdoutE(t, func() error {
-		return Admin([]string{"tenant", "--help"})
+		return Admin([]string{"--help"})
 	})
 	if err != nil {
-		t.Fatalf("Admin tenant help: %v", err)
+		t.Fatalf("Admin help: %v", err)
 	}
 	for _, want := range []string{
-		"usage: drive9 admin tenant <command> [arguments]",
+		"usage: drive9 admin <command> [arguments]",
 		"commands:",
-		"create [flags]",
-		"list [flags]",
-		"get --tenant-id ID",
-		"delete --tenant-id ID",
-		"set-quota --tenant-id ID",
+		"tenant create [flags]",
+		"tenant list [flags]",
+		"tenant get --tenant-id ID",
+		"tenant delete --tenant-id ID",
+		"tenant set-quota --tenant-id ID",
+		"pool <command>",
 		"--server URL",
 		"--region-code CODE",
 		"--tidbcloud-public-key KEY",
@@ -31,6 +32,7 @@ func TestAdminTenantHelpIncludesCommandsFlagsAndExamples(t *testing.T) {
 		"examples:",
 		"drive9 admin tenant create",
 		"drive9 admin tenant delete",
+		"drive9 admin pool create",
 		"drive9 admin tenant set-quota",
 	} {
 		if !strings.Contains(stdout, want) {
@@ -93,6 +95,124 @@ func TestAdminTenantCreatePrintsTable(t *testing.T) {
 		if strings.Contains(stdout, banned) {
 			t.Fatalf("stdout should use table output, found %q:\n%s", banned, stdout)
 		}
+	}
+}
+
+func TestAdminPoolHelpUsesTopLevelCommand(t *testing.T) {
+	stdout, err := captureStdoutE(t, func() error {
+		return Admin([]string{"pool", "--help"})
+	})
+	if err != nil {
+		t.Fatalf("Admin pool help: %v", err)
+	}
+	for _, want := range []string{
+		"usage: drive9 admin pool <command> [arguments]",
+		"create --pool-size N",
+		"get",
+		"update --pool-size N",
+		"delete",
+		"drive9 admin pool create",
+		"drive9 admin pool get",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "drive9 admin tenant pool") {
+		t.Fatalf("stdout should prefer top-level admin pool usage:\n%s", stdout)
+	}
+}
+
+func TestAdminTenantPoolCreatePrintsTable(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/admin/tenant-pool" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatal(err)
+		}
+		if body["public_key"] != "public-1" || body["private_key"] != "private-1" {
+			t.Fatalf("body credentials = %#v", body)
+		}
+		if body["pool_size"] != float64(3) || body["tidbcloud_spending_limit"] != float64(10000) {
+			t.Fatalf("body pool fields = %#v", body)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"pool_id":         "pool-1",
+			"organization_id": "org-1",
+			"pool_size":       3,
+			"free_size":       3,
+			"status":          "active",
+		})
+	}))
+	defer ts.Close()
+
+	stdout, err := captureStdoutE(t, func() error {
+		return Admin([]string{
+			"pool", "create",
+			"--server", ts.URL,
+			"--pool-size", "3",
+			"--tidbcloud-spending-limit", "10000",
+			"--tidbcloud-public-key", "public-1",
+			"--tidbcloud-private-key", "private-1",
+		})
+	})
+	if err != nil {
+		t.Fatalf("Admin tenant pool create: %v", err)
+	}
+	for _, want := range []string{
+		"POOL_ID", "ORGANIZATION_ID", "POOL_SIZE", "FREE_SIZE", "STATUS",
+		"pool-1", "org-1", "3", "active",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestAdminTenantPoolGetUsesCredentialHeadersAndJSON(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/admin/tenant-pool" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
+			t.Fatalf("missing tidbcloud headers")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"pool_id":         "pool-1",
+			"organization_id": "org-1",
+			"pool_size":       5,
+			"free_size":       4,
+			"status":          "active",
+		})
+	}))
+	defer ts.Close()
+
+	stdout, err := captureStdoutE(t, func() error {
+		return Admin([]string{
+			"pool", "get",
+			"--server", ts.URL,
+			"--tidbcloud-public-key", "public-1",
+			"--tidbcloud-private-key", "private-1",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("Admin tenant pool get: %v", err)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("decode stdout json: %v\n%s", err, stdout)
+	}
+	if out["pool_id"] != "pool-1" || out["free_size"] != float64(4) {
+		t.Fatalf("stdout json = %#v", out)
 	}
 }
 

--- a/cmd/drive9/cli/admin_test.go
+++ b/cmd/drive9/cli/admin_test.go
@@ -138,8 +138,11 @@ func TestAdminTenantPoolCreatePrintsTable(t *testing.T) {
 		if body["public_key"] != "public-1" || body["private_key"] != "private-1" {
 			t.Fatalf("body credentials = %#v", body)
 		}
-		if body["pool_size"] != float64(3) || body["tidbcloud_spending_limit"] != float64(10000) {
+		if body["pool_size"] != float64(3) {
 			t.Fatalf("body pool fields = %#v", body)
+		}
+		if _, ok := body["tidbcloud_spending_limit"]; ok {
+			t.Fatalf("body should not contain tidbcloud_spending_limit: %#v", body)
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"pool_id":         "pool-1",
@@ -156,7 +159,6 @@ func TestAdminTenantPoolCreatePrintsTable(t *testing.T) {
 			"pool", "create",
 			"--server", ts.URL,
 			"--pool-size", "3",
-			"--tidbcloud-spending-limit", "10000",
 			"--tidbcloud-public-key", "public-1",
 			"--tidbcloud-private-key", "private-1",
 		})

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -416,7 +416,7 @@ func usage(code int) {
 			"  delete [--server URL] [--api-key KEY] [--json]\n"+
 			"                         [--tidbcloud-public-key KEY] [--tidbcloud-private-key KEY]\n"+
 			"                         delete current tenant with owner API key\n"+
-			"  admin tenant <command> [arguments]\n"+
+			"  admin <tenant|pool> <command> [arguments]\n"+
 			"                         TiDBCloud Mode admin operations\n"+
 			"  ctx show [--json] [--reveal]\n"+
 			"                         show current context\n"+

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -83,7 +83,7 @@ func TestDispatchLongHelpFlagShowsUsage(t *testing.T) {
 		"usage: drive9 <command> [arguments]",
 		"create [--name NAME] [--region-code CODE] [--server URL] [--json]",
 		"delete [--server URL] [--api-key KEY] [--json]",
-		"admin tenant <command> [arguments]",
+		"admin <tenant|pool> <command> [arguments]",
 		"ctx show [--json] [--reveal]",
 		"ctx use <name>",
 		"token <issue|revoke>",

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -489,7 +489,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 				{Name: "--max-storage-size Mi", Desc: "set-quota: max confirmed+reserved storage size in Mi"},
 				{Name: "--max-file-size Mi", Desc: "set-quota: max single file size in Mi"},
 				{Name: "--max-file-count N", Desc: "set-quota: max confirmed file count; 0 means unlimited"},
-				{Name: "--tidbcloud-spending-limit N", Desc: "set-quota: TiDB Cloud Cluster Spending Limit"},
+				{Name: "--tidbcloud-spending-limit N", Desc: "tenant set-quota or pool create/update TiDB Cloud Cluster Spending Limit"},
 				{Name: "--json", Desc: "output result as JSON"},
 			},
 			Examples: []visualHelpExample{

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -489,7 +489,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 				{Name: "--max-storage-size Mi", Desc: "set-quota: max confirmed+reserved storage size in Mi"},
 				{Name: "--max-file-size Mi", Desc: "set-quota: max single file size in Mi"},
 				{Name: "--max-file-count N", Desc: "set-quota: max confirmed file count; 0 means unlimited"},
-				{Name: "--tidbcloud-spending-limit N", Desc: "tenant set-quota or pool create/update TiDB Cloud Cluster Spending Limit"},
+				{Name: "--tidbcloud-spending-limit N", Desc: "tenant create/set-quota TiDB Cloud Cluster Spending Limit"},
 				{Name: "--json", Desc: "output result as JSON"},
 			},
 			Examples: []visualHelpExample{

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -471,17 +471,19 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 		},
 		{
 			Name:    "admin",
-			Args:    "tenant <command> [arguments]",
-			Summary: "manage TiDBCloud Mode tenants and quota",
+			Args:    "<tenant|pool> <command> [arguments]",
+			Summary: "manage TiDBCloud Mode tenants, pools, and quota",
 			Details: []string{
 				"requires TiDB Cloud keys; Drive9 API keys are not accepted",
 				"tenant list/get is read-authorized through TiDB Cloud managed cluster listing",
 				"tenant delete and tenant set-quota require TiDB Cloud cluster label patch permission",
+				"pool commands manage pre-created free tenants for faster admin tenant create",
 			},
 			Flags: []visualHelpFlag{
 				{Name: "--server URL", Desc: "server URL; defaults to active context server"},
 				{Name: "--region-code CODE", Desc: "TiDBCloud Mode region code; ignored when --server is set"},
 				{Name: "--tenant-id ID", Desc: "drive9 tenant id for tenant get/delete/set-quota"},
+				{Name: "--pool-size N", Desc: "pool create/update target free tenant count"},
 				{Name: "--tidbcloud-public-key KEY", Desc: "TiDB Cloud public key"},
 				{Name: "--tidbcloud-private-key KEY", Desc: "TiDB Cloud private key"},
 				{Name: "--max-storage-size Mi", Desc: "set-quota: max confirmed+reserved storage size in Mi"},
@@ -495,6 +497,8 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 				{Command: "drive9 admin tenant list --region-code aws-ap-southeast-1 --tidbcloud-public-key <public-key> --tidbcloud-private-key <private-key> --json", Desc: "list managed TiDBCloud Mode tenants"},
 				{Command: "drive9 admin tenant get --region-code aws-ap-southeast-1 --tenant-id tnt_xxx --tidbcloud-public-key <public-key> --tidbcloud-private-key <private-key>", Desc: "query TiDBCloud Mode tenant info and quota"},
 				{Command: "drive9 admin tenant set-quota --region-code aws-ap-southeast-1 --tenant-id tnt_xxx --max-storage-size 102400 --tidbcloud-spending-limit 10000 --tidbcloud-public-key <public-key> --tidbcloud-private-key <private-key>", Desc: "set TiDBCloud Mode tenant quota"},
+				{Command: "drive9 admin pool create --region-code aws-ap-southeast-1 --pool-size 10 --tidbcloud-public-key <public-key> --tidbcloud-private-key <private-key>", Desc: "create a TiDBCloud Mode tenant pool"},
+				{Command: "drive9 admin pool get --region-code aws-ap-southeast-1 --tidbcloud-public-key <public-key> --tidbcloud-private-key <private-key>", Desc: "show tenant pool free size"},
 			},
 		},
 		{

--- a/examples/go-sdk-cookbook/cookbook_test.go
+++ b/examples/go-sdk-cookbook/cookbook_test.go
@@ -260,6 +260,33 @@ func ExampleClient_quota() {
 		MaxFileCount:           &fileCount,
 		TiDBCloudSpendingLimit: &spendingLimit,
 	})
+
+	poolSize := 10
+	_, _ = credentialClient.AdminCreateTenantPool(ctx, drive9.AdminTenantPoolRequest{
+		PublicKey:              tidbCloudPublicKey,
+		PrivateKey:             tidbCloudPrivateKey,
+		PoolSize:               &poolSize,
+		TiDBCloudSpendingLimit: &spendingLimit,
+	})
+	pool, err := credentialClient.AdminGetTenantPool(ctx, drive9.AdminTenantPoolRequest{
+		PublicKey:  tidbCloudPublicKey,
+		PrivateKey: tidbCloudPrivateKey,
+	})
+	if err == nil {
+		_ = pool.PoolID
+		_ = pool.FreeSize
+	}
+	updatedPoolSize := 20
+	_, _ = credentialClient.AdminUpdateTenantPool(ctx, drive9.AdminTenantPoolRequest{
+		PublicKey:              tidbCloudPublicKey,
+		PrivateKey:             tidbCloudPrivateKey,
+		PoolSize:               &updatedPoolSize,
+		TiDBCloudSpendingLimit: &spendingLimit,
+	})
+	_, _ = credentialClient.AdminDeleteTenantPool(ctx, drive9.AdminTenantPoolRequest{
+		PublicKey:  tidbCloudPublicKey,
+		PrivateKey: tidbCloudPrivateKey,
+	})
 }
 
 func ExampleClient_eventsLayersGitAndJournal() {
@@ -416,10 +443,14 @@ func Example_localFileTransferShape() {
 
 var coveredClientMethods = map[string]bool{
 	"AdminCreateTenant":                    true,
+	"AdminCreateTenantPool":                true,
 	"AdminDeleteTenant":                    true,
+	"AdminDeleteTenantPool":                true,
 	"AdminGetTenant":                       true,
+	"AdminGetTenantPool":                   true,
 	"AdminListTenants":                     true,
 	"AdminSetTenantQuota":                  true,
+	"AdminUpdateTenantPool":                true,
 	"AppendJournalEntries":                 true,
 	"AppendStream":                         true,
 	"APIKey":                               true,

--- a/examples/go-sdk-cookbook/cookbook_test.go
+++ b/examples/go-sdk-cookbook/cookbook_test.go
@@ -263,10 +263,9 @@ func ExampleClient_quota() {
 
 	poolSize := 10
 	_, _ = credentialClient.AdminCreateTenantPool(ctx, drive9.AdminTenantPoolRequest{
-		PublicKey:              tidbCloudPublicKey,
-		PrivateKey:             tidbCloudPrivateKey,
-		PoolSize:               &poolSize,
-		TiDBCloudSpendingLimit: &spendingLimit,
+		PublicKey:  tidbCloudPublicKey,
+		PrivateKey: tidbCloudPrivateKey,
+		PoolSize:   &poolSize,
 	})
 	pool, err := credentialClient.AdminGetTenantPool(ctx, drive9.AdminTenantPoolRequest{
 		PublicKey:  tidbCloudPublicKey,
@@ -278,10 +277,9 @@ func ExampleClient_quota() {
 	}
 	updatedPoolSize := 20
 	_, _ = credentialClient.AdminUpdateTenantPool(ctx, drive9.AdminTenantPoolRequest{
-		PublicKey:              tidbCloudPublicKey,
-		PrivateKey:             tidbCloudPrivateKey,
-		PoolSize:               &updatedPoolSize,
-		TiDBCloudSpendingLimit: &spendingLimit,
+		PublicKey:  tidbCloudPublicKey,
+		PrivateKey: tidbCloudPrivateKey,
+		PoolSize:   &updatedPoolSize,
 	})
 	_, _ = credentialClient.AdminDeleteTenantPool(ctx, drive9.AdminTenantPoolRequest{
 		PublicKey:  tidbCloudPublicKey,

--- a/internal/testmysql/testmysql.go
+++ b/internal/testmysql/testmysql.go
@@ -113,6 +113,7 @@ func ResetMetaDB(t *testing.T, db *sql.DB) {
 		"DELETE FROM tenant_api_keys",
 		"DELETE FROM tenant_external_bindings",
 		"DELETE FROM tenant_tidbcloud_org_bindings",
+		"DELETE FROM tenant_tidbcloud_pools",
 		"DELETE FROM tenants",
 	}
 	for _, q := range queries {

--- a/pkg/client/admin_tenants.go
+++ b/pkg/client/admin_tenants.go
@@ -57,7 +57,7 @@ type AdminTenantCreateResponse struct {
 type AdminTenantPoolRequest struct {
 	PublicKey              string `json:"public_key"`
 	PrivateKey             string `json:"private_key"`
-	PoolSize               int    `json:"pool_size,omitempty"`
+	PoolSize               *int   `json:"pool_size,omitempty"`
 	TiDBCloudSpendingLimit *int64 `json:"tidbcloud_spending_limit,omitempty"`
 }
 

--- a/pkg/client/admin_tenants.go
+++ b/pkg/client/admin_tenants.go
@@ -54,6 +54,21 @@ type AdminTenantCreateResponse struct {
 	Region        string `json:"region,omitempty"`
 }
 
+type AdminTenantPoolRequest struct {
+	PublicKey              string `json:"public_key"`
+	PrivateKey             string `json:"private_key"`
+	PoolSize               int    `json:"pool_size,omitempty"`
+	TiDBCloudSpendingLimit *int64 `json:"tidbcloud_spending_limit,omitempty"`
+}
+
+type AdminTenantPoolResponse struct {
+	PoolID         string `json:"pool_id"`
+	OrganizationID string `json:"organization_id,omitempty"`
+	PoolSize       int    `json:"pool_size"`
+	FreeSize       int    `json:"free_size"`
+	Status         string `json:"status"`
+}
+
 type AdminTenantDeleteRequest struct {
 	TenantID   string `json:"tenant_id"`
 	PublicKey  string `json:"public_key"`
@@ -121,6 +136,71 @@ func (c *Client) AdminCreateTenant(ctx context.Context, req AdminTenantCreateReq
 	var out AdminTenantCreateResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		return nil, fmt.Errorf("decode admin tenant create response: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) AdminCreateTenantPool(ctx context.Context, req AdminTenantPoolRequest) (*AdminTenantPoolResponse, error) {
+	return c.adminTenantPoolWithBody(ctx, http.MethodPost, req, "admin tenant pool create")
+}
+
+func (c *Client) AdminUpdateTenantPool(ctx context.Context, req AdminTenantPoolRequest) (*AdminTenantPoolResponse, error) {
+	return c.adminTenantPoolWithBody(ctx, http.MethodPatch, req, "admin tenant pool update")
+}
+
+func (c *Client) AdminDeleteTenantPool(ctx context.Context, req AdminTenantPoolRequest) (*AdminTenantPoolResponse, error) {
+	body := struct {
+		PublicKey  string `json:"public_key"`
+		PrivateKey string `json:"private_key"`
+	}{
+		PublicKey:  req.PublicKey,
+		PrivateKey: req.PrivateKey,
+	}
+	return c.adminTenantPoolWithBody(ctx, http.MethodDelete, body, "admin tenant pool delete")
+}
+
+func (c *Client) AdminGetTenantPool(ctx context.Context, req AdminTenantPoolRequest) (*AdminTenantPoolResponse, error) {
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/v1/admin/tenant-pool", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create admin tenant pool get request: %w", err)
+	}
+	setQuotaHeaders(httpReq, req.PublicKey, req.PrivateKey)
+	resp, err := c.do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("admin tenant pool get request: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var out AdminTenantPoolResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode admin tenant pool get response: %w", err)
+	}
+	return &out, nil
+}
+
+func (c *Client) adminTenantPoolWithBody(ctx context.Context, method string, body any, operation string) (*AdminTenantPoolResponse, error) {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal %s request: %w", operation, err)
+	}
+	httpReq, err := http.NewRequestWithContext(ctx, method, c.baseURL+"/v1/admin/tenant-pool", bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("create %s request: %w", operation, err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("%s request: %w", operation, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var out AdminTenantPoolResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode %s response: %w", operation, err)
 	}
 	return &out, nil
 }

--- a/pkg/client/admin_tenants.go
+++ b/pkg/client/admin_tenants.go
@@ -55,10 +55,9 @@ type AdminTenantCreateResponse struct {
 }
 
 type AdminTenantPoolRequest struct {
-	PublicKey              string `json:"public_key"`
-	PrivateKey             string `json:"private_key"`
-	PoolSize               *int   `json:"pool_size,omitempty"`
-	TiDBCloudSpendingLimit *int64 `json:"tidbcloud_spending_limit,omitempty"`
+	PublicKey  string `json:"public_key"`
+	PrivateKey string `json:"private_key"`
+	PoolSize   *int   `json:"pool_size,omitempty"`
 }
 
 type AdminTenantPoolResponse struct {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -286,6 +286,8 @@ const metaSchemaMigrateLockNamePrefix = "dat9_meta_schema_migrate:"
 const metaSchemaMigrateLockTimeoutSeconds = 30
 const externalBindingLockTimeoutSeconds = 90
 const externalBindingReleaseLockTimeout = 5 * time.Second
+const tenantPoolLockTimeoutSeconds = 300
+const tenantPoolReleaseLockTimeout = 5 * time.Second
 
 func (s *Store) migrate() (err error) {
 	ctx := context.Background()
@@ -1835,9 +1837,65 @@ func (s *Store) WithExternalBindingLock(ctx context.Context, provider, subjectKe
 	return fn(ctx)
 }
 
+func (s *Store) WithTenantPoolLock(ctx context.Context, poolID string, fn func(context.Context) error) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "tenant_pool_lock", start, &err)
+	if fn == nil {
+		return fmt.Errorf("tenant pool lock callback is required")
+	}
+	lockName := tenantPoolLockName(poolID)
+	if lockName == "" {
+		return fmt.Errorf("pool_id is required")
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	var got sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(CONCAT(?, DATABASE()), ?)", lockName, tenantPoolLockTimeoutSeconds).Scan(&got); err != nil {
+		return err
+	}
+	if !got.Valid {
+		return fmt.Errorf("tenant pool named lock returned NULL")
+	}
+	if got.Int64 != 1 {
+		return fmt.Errorf("timed out waiting for tenant pool named lock")
+	}
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), tenantPoolReleaseLockTimeout)
+		defer cancel()
+		var released sql.NullInt64
+		releaseErr := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(CONCAT(?, DATABASE()))", lockName).Scan(&released)
+		if releaseErr != nil {
+			err = errors.Join(err, releaseErr)
+			return
+		}
+		if !released.Valid {
+			err = errors.Join(err, fmt.Errorf("tenant pool named lock release returned NULL"))
+			return
+		}
+		if released.Int64 != 1 {
+			err = errors.Join(err, fmt.Errorf("tenant pool named lock was not held by current connection"))
+		}
+	}()
+
+	return fn(ctx)
+}
+
 func externalBindingLockName(provider, subjectKey string) string {
 	sum := sha256.Sum256([]byte(provider + "\x00" + subjectKey))
 	return "d9_extbind:" + hex.EncodeToString(sum[:20])
+}
+
+func tenantPoolLockName(poolID string) string {
+	poolID = strings.TrimSpace(poolID)
+	if poolID == "" {
+		return ""
+	}
+	sum := sha256.Sum256([]byte(poolID))
+	return "d9_tenant_pool:" + hex.EncodeToString(sum[:20])
 }
 
 func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *TenantWithAPIKey, err error) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1853,8 +1853,14 @@ func (s *Store) WithTenantPoolLock(ctx context.Context, poolID string, fn func(c
 	}
 	defer func() { _ = conn.Close() }()
 
+	var databaseName sql.NullString
+	if err := conn.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&databaseName); err != nil {
+		return err
+	}
+	lockName = tenantPoolDatabaseLockName(lockName, databaseName.String)
+
 	var got sql.NullInt64
-	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(CONCAT(?, DATABASE()), ?)", lockName, tenantPoolLockTimeoutSeconds).Scan(&got); err != nil {
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, tenantPoolLockTimeoutSeconds).Scan(&got); err != nil {
 		return err
 	}
 	if !got.Valid {
@@ -1867,7 +1873,7 @@ func (s *Store) WithTenantPoolLock(ctx context.Context, poolID string, fn func(c
 		releaseCtx, cancel := context.WithTimeout(context.Background(), tenantPoolReleaseLockTimeout)
 		defer cancel()
 		var released sql.NullInt64
-		releaseErr := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(CONCAT(?, DATABASE()))", lockName).Scan(&released)
+		releaseErr := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&released)
 		if releaseErr != nil {
 			err = errors.Join(err, releaseErr)
 			return
@@ -1896,6 +1902,11 @@ func tenantPoolLockName(poolID string) string {
 	}
 	sum := sha256.Sum256([]byte(poolID))
 	return "d9_tenant_pool:" + hex.EncodeToString(sum[:20])
+}
+
+func tenantPoolDatabaseLockName(baseLockName, databaseName string) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(databaseName)))
+	return baseLockName + ":" + hex.EncodeToString(sum[:4])
 }
 
 func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *TenantWithAPIKey, err error) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -220,6 +220,9 @@ type TenantTiDBCloudOrgBinding struct {
 	TenantID       string
 	OrganizationID string
 	ClusterID      string
+	PoolID         string
+	PoolStatus     TenantPoolBindingStatus
+	UsedAt         *time.Time
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 }
@@ -227,6 +230,29 @@ type TenantTiDBCloudOrgBinding struct {
 type TenantWithTiDBCloudOrgBinding struct {
 	Tenant  Tenant
 	Binding TenantTiDBCloudOrgBinding
+}
+
+type TenantPoolBindingStatus string
+
+const (
+	TenantPoolBindingUsed TenantPoolBindingStatus = "used"
+	TenantPoolBindingFree TenantPoolBindingStatus = "free"
+)
+
+type TenantPoolStatus string
+
+const (
+	TenantPoolActive   TenantPoolStatus = "active"
+	TenantPoolDeleting TenantPoolStatus = "deleting"
+)
+
+type TenantPool struct {
+	PoolID         string
+	OrganizationID string
+	Size           int
+	Status         TenantPoolStatus
+	CreatedAt      time.Time
+	UpdatedAt      time.Time
 }
 
 type Store struct {
@@ -530,11 +556,25 @@ func metaInitSchemaStatements() []string {
 				tenant_id       VARCHAR(64) PRIMARY KEY,
 				organization_id VARCHAR(64) NOT NULL,
 				cluster_id      VARCHAR(255) NOT NULL,
+				pool_id         VARCHAR(64) NOT NULL DEFAULT '',
+				pool_status     VARCHAR(20) NOT NULL DEFAULT 'used',
+				used_at         DATETIME(3) NULL,
 				created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 				updated_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 				INDEX idx_tidbcloud_org_cluster (organization_id, cluster_id, created_at, tenant_id),
-				INDEX idx_tidbcloud_org_created (organization_id, created_at, tenant_id)
+				INDEX idx_tidbcloud_org_created (organization_id, created_at, tenant_id),
+				INDEX idx_tidbcloud_pool_free (organization_id, pool_status, created_at, tenant_id)
 			)`,
+		`CREATE TABLE IF NOT EXISTS tenant_tidbcloud_pools (
+			pool_id         VARCHAR(64) PRIMARY KEY,
+			organization_id VARCHAR(64) NULL,
+			size            INT NOT NULL,
+			status          VARCHAR(20) NOT NULL DEFAULT 'active',
+			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			UNIQUE INDEX uk_tidbcloud_pool_org (organization_id),
+			INDEX idx_tidbcloud_pool_status (status, created_at)
+		)`,
 		`CREATE TABLE IF NOT EXISTS tenant_api_key_fs_scopes (
 			tenant_id   VARCHAR(64) NOT NULL,
 			api_key_id  VARCHAR(64) NOT NULL,
@@ -1274,30 +1314,318 @@ func (s *Store) UpsertTenantTiDBCloudOrgBinding(ctx context.Context, b *TenantTi
 		updatedAt = now
 	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_tidbcloud_org_bindings
-		(tenant_id, organization_id, cluster_id, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?)
+		(tenant_id, organization_id, cluster_id, pool_id, pool_status, used_at, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		ON DUPLICATE KEY UPDATE
 			organization_id = VALUES(organization_id),
 			cluster_id = VALUES(cluster_id),
+			pool_id = VALUES(pool_id),
+			pool_status = VALUES(pool_status),
+			used_at = VALUES(used_at),
 			updated_at = VALUES(updated_at)`,
-		tenantID, organizationID, clusterID, createdAt.UTC(), updatedAt.UTC())
+		tenantID, organizationID, clusterID, strings.TrimSpace(b.PoolID), tenantPoolBindingStatusForInsert(b.PoolStatus), b.UsedAt,
+		createdAt.UTC(), updatedAt.UTC())
 	return err
 }
 
 func (s *Store) GetTenantTiDBCloudOrgBinding(ctx context.Context, tenantID string) (out *TenantTiDBCloudOrgBinding, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "get_tidbcloud_org_binding", start, &err)
-	row := s.db.QueryRowContext(ctx, `SELECT tenant_id, organization_id, cluster_id, created_at, updated_at
+	row := s.db.QueryRowContext(ctx, `SELECT tenant_id, organization_id, cluster_id, pool_id, pool_status, used_at, created_at, updated_at
 		FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?`, tenantID)
 	var rec TenantTiDBCloudOrgBinding
-	if err = row.Scan(&rec.TenantID, &rec.OrganizationID, &rec.ClusterID, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
+	var usedAt sql.NullTime
+	if err = row.Scan(&rec.TenantID, &rec.OrganizationID, &rec.ClusterID, &rec.PoolID, &rec.PoolStatus, &usedAt, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
 			return nil, err
 		}
 		return nil, err
 	}
+	if usedAt.Valid {
+		t := usedAt.Time.UTC()
+		rec.UsedAt = &t
+	}
 	return &rec, nil
+}
+
+func (s *Store) UpsertTenantPool(ctx context.Context, p *TenantPool) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "upsert_tidbcloud_pool", start, &err)
+	if p == nil {
+		return fmt.Errorf("tenant pool is required")
+	}
+	poolID := strings.TrimSpace(p.PoolID)
+	if poolID == "" {
+		return fmt.Errorf("pool_id is required")
+	}
+	if p.Size < 0 {
+		return fmt.Errorf("pool size must be non-negative")
+	}
+	now := time.Now().UTC()
+	createdAt := p.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = now
+	}
+	updatedAt := p.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = now
+	}
+	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_tidbcloud_pools
+		(pool_id, organization_id, size, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		poolID, nullStr(strings.TrimSpace(p.OrganizationID)), p.Size, tenantPoolStatusForInsert(p.Status),
+		createdAt.UTC(), updatedAt.UTC())
+	if isDuplicateEntry(err) {
+		return ErrDuplicate
+	}
+	return err
+}
+
+func (s *Store) GetTenantPoolByOrganization(ctx context.Context, organizationID string) (out *TenantPool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "get_tidbcloud_pool_by_org", start, &err)
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" {
+		return nil, fmt.Errorf("organization_id is required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, status, created_at, updated_at
+		FROM tenant_tidbcloud_pools WHERE organization_id = ?`, organizationID)
+	return scanTenantPoolRow(row)
+}
+
+func (s *Store) GetTenantPoolByID(ctx context.Context, poolID string) (out *TenantPool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "get_tidbcloud_pool_by_id", start, &err)
+	poolID = strings.TrimSpace(poolID)
+	if poolID == "" {
+		return nil, fmt.Errorf("pool_id is required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, status, created_at, updated_at
+		FROM tenant_tidbcloud_pools WHERE pool_id = ?`, poolID)
+	return scanTenantPoolRow(row)
+}
+
+func (s *Store) UpdateTenantPoolOrganization(ctx context.Context, poolID, organizationID string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_tidbcloud_pool_org", start, &err)
+	poolID = strings.TrimSpace(poolID)
+	organizationID = strings.TrimSpace(organizationID)
+	if poolID == "" || organizationID == "" {
+		return fmt.Errorf("pool_id and organization_id are required")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_tidbcloud_pools
+		SET organization_id = ?, updated_at = ? WHERE pool_id = ?`, organizationID, time.Now().UTC(), poolID)
+	if err != nil {
+		if isDuplicateEntry(err) {
+			return ErrDuplicate
+		}
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) CountFreeTenantPoolBindings(ctx context.Context, organizationID string) (out int, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "count_free_tidbcloud_pool_bindings", start, &err)
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" {
+		return 0, fmt.Errorf("organization_id is required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM tenant_tidbcloud_org_bindings b
+		JOIN tenants t ON t.id = b.tenant_id
+		WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = 'tidb_cloud_native'
+			AND t.status IN (?, ?)`,
+		organizationID, TenantPoolBindingFree, TenantProvisioning, TenantActive)
+	if err = row.Scan(&out); err != nil {
+		return 0, err
+	}
+	return out, nil
+}
+
+func (s *Store) ListFreeTenantPoolBindings(ctx context.Context, organizationID string, newestFirst bool, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_free_tidbcloud_pool_bindings", start, &err)
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" {
+		return nil, fmt.Errorf("organization_id is required")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	order := "ASC"
+	if newestFirst {
+		order = "DESC"
+	}
+	query := `SELECT
+			t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
+			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
+			t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
+			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
+			b.tenant_id, b.organization_id, b.cluster_id, b.pool_id, b.pool_status, b.used_at, b.created_at, b.updated_at
+		FROM tenant_tidbcloud_org_bindings b
+		JOIN tenants t ON t.id = b.tenant_id
+		WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = 'tidb_cloud_native'
+			AND t.status IN (?, ?)
+		ORDER BY b.created_at ` + order + `, b.tenant_id ` + order + `
+		LIMIT ?`
+	rows, err := s.db.QueryContext(ctx, query, organizationID, TenantPoolBindingFree, TenantProvisioning, TenantActive, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	return scanTenantBindingRows(rows)
+}
+
+func (s *Store) ClaimOldestFreeTenantPoolBinding(ctx context.Context, organizationID string) (out *TenantWithTiDBCloudOrgBinding, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "claim_free_tidbcloud_pool_binding", start, &err)
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" {
+		return nil, fmt.Errorf("organization_id is required")
+	}
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		query := `SELECT
+				t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
+				t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
+				t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
+				t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
+				b.tenant_id, b.organization_id, b.cluster_id, b.pool_id, b.pool_status, b.used_at, b.created_at, b.updated_at
+			FROM tenant_tidbcloud_org_bindings b
+			JOIN tenants t ON t.id = b.tenant_id
+			WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = 'tidb_cloud_native'
+				AND t.status IN (?, ?)
+			ORDER BY b.created_at ASC, b.tenant_id ASC
+			LIMIT 1 FOR UPDATE`
+		row := tx.QueryRowContext(ctx, query, organizationID, TenantPoolBindingFree, TenantProvisioning, TenantActive)
+		rec, scanErr := scanTenantBindingRow(row)
+		if scanErr != nil {
+			return scanErr
+		}
+		now := time.Now().UTC()
+		res, execErr := tx.ExecContext(ctx, `UPDATE tenant_tidbcloud_org_bindings
+			SET pool_status = ?, used_at = ?, updated_at = ?
+			WHERE tenant_id = ? AND pool_status = ?`,
+			TenantPoolBindingUsed, now, now, rec.Binding.TenantID, TenantPoolBindingFree)
+		if execErr != nil {
+			return execErr
+		}
+		n, _ := res.RowsAffected()
+		if n == 0 {
+			return ErrNotFound
+		}
+		rec.Binding.PoolStatus = TenantPoolBindingUsed
+		rec.Binding.UsedAt = &now
+		rec.Binding.UpdatedAt = now
+		out = rec
+		return nil
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil, ErrNotFound
+	}
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *Store) UpdateTenantPoolSize(ctx context.Context, poolID string, size int) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_tidbcloud_pool_size", start, &err)
+	poolID = strings.TrimSpace(poolID)
+	if poolID == "" {
+		return fmt.Errorf("pool_id is required")
+	}
+	if size < 0 {
+		return fmt.Errorf("pool size must be non-negative")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_tidbcloud_pools SET size = ?, updated_at = ? WHERE pool_id = ?`, size, time.Now().UTC(), poolID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) DeleteTenantPool(ctx context.Context, poolID string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_tidbcloud_pool", start, &err)
+	poolID = strings.TrimSpace(poolID)
+	if poolID == "" {
+		return fmt.Errorf("pool_id is required")
+	}
+	res, err := s.db.ExecContext(ctx, `DELETE FROM tenant_tidbcloud_pools WHERE pool_id = ?`, poolID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) UpdateTenantPoolBindingStatus(ctx context.Context, tenantID string, status TenantPoolBindingStatus, usedAt *time.Time) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_tidbcloud_pool_binding_status", start, &err)
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return fmt.Errorf("tenant_id is required")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_tidbcloud_org_bindings
+		SET pool_status = ?, used_at = ?, updated_at = ? WHERE tenant_id = ?`,
+		tenantPoolBindingStatusForInsert(status), usedAt, time.Now().UTC(), tenantID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) MarkFreeTenantPoolTenantDeleting(ctx context.Context, tenantID string, from TenantStatus) (updated bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "mark_free_tidbcloud_pool_tenant_deleting", start, &err)
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return false, fmt.Errorf("tenant_id is required")
+	}
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		var id string
+		row := tx.QueryRowContext(ctx, `SELECT t.id
+			FROM tenants t
+			JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = t.id
+			WHERE t.id = ? AND t.status = ? AND b.pool_status = ?
+			LIMIT 1 FOR UPDATE`, tenantID, from, TenantPoolBindingFree)
+		if scanErr := row.Scan(&id); scanErr != nil {
+			return scanErr
+		}
+		res, execErr := tx.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ? WHERE id = ? AND status = ?`,
+			TenantDeleting, time.Now().UTC(), tenantID, from)
+		if execErr != nil {
+			return execErr
+		}
+		n, _ := res.RowsAffected()
+		updated = n > 0
+		return nil
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return updated, nil
 }
 
 func (s *Store) ListTenantsByTiDBCloudOrganizations(ctx context.Context, organizationIDs []string, offset, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
@@ -1325,11 +1653,12 @@ func (s *Store) ListTenantsByTiDBCloudOrganizations(ctx context.Context, organiz
 			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
 			t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
 			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
-			b.tenant_id, b.organization_id, b.cluster_id, b.created_at, b.updated_at
+			b.tenant_id, b.organization_id, b.cluster_id, b.pool_id, b.pool_status, b.used_at, b.created_at, b.updated_at
 		FROM tenant_tidbcloud_org_bindings b
 		JOIN tenants t ON t.id = b.tenant_id
 		WHERE b.organization_id IN (` + strings.Join(placeholders, ",") + `)
 			AND t.provider = 'tidb_cloud_native'
+			AND b.pool_status <> 'free'
 			AND t.status <> 'deleted'
 		ORDER BY t.created_at DESC, t.id DESC
 		LIMIT ? OFFSET ?`
@@ -1366,11 +1695,12 @@ func (s *Store) ListTenantsByTiDBCloudOrgClusterBindings(ctx context.Context, bi
 			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
 			t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
 			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
-			b.tenant_id, b.organization_id, b.cluster_id, b.created_at, b.updated_at
+			b.tenant_id, b.organization_id, b.cluster_id, b.pool_id, b.pool_status, b.used_at, b.created_at, b.updated_at
 		FROM tenant_tidbcloud_org_bindings b
 		JOIN tenants t ON t.id = b.tenant_id
 		WHERE (b.organization_id, b.cluster_id) IN (` + strings.Join(placeholders, ",") + `)
 			AND t.provider = 'tidb_cloud_native'
+			AND b.pool_status <> 'free'
 			AND t.status <> 'deleted'
 		ORDER BY t.created_at DESC, t.id DESC
 		LIMIT ? OFFSET ?`
@@ -1817,45 +2147,67 @@ func scanTenantRows(rows *sql.Rows) ([]Tenant, error) {
 func scanTenantBindingRows(rows *sql.Rows) ([]TenantWithTiDBCloudOrgBinding, error) {
 	out := make([]TenantWithTiDBCloudOrgBinding, 0)
 	for rows.Next() {
-		var rec TenantWithTiDBCloudOrgBinding
-		var dbTLS int
-		var clusterID sql.NullString
-		var parentTenantID sql.NullString
-		var storageNamespaceID sql.NullString
-		var claimURL sql.NullString
-		var claimExp sql.NullTime
-		var s3BucketKeyEnabled int
-		if err := rows.Scan(&rec.Tenant.ID, &rec.Tenant.Status, &rec.Tenant.Kind, &parentTenantID, &storageNamespaceID,
-			&rec.Tenant.DBHost, &rec.Tenant.DBPort, &rec.Tenant.DBUser, &rec.Tenant.DBPasswordCipher,
-			&rec.Tenant.DBName, &dbTLS, &rec.Tenant.Provider, &clusterID, &rec.Tenant.BranchID, &claimURL, &claimExp, &rec.Tenant.SchemaVersion,
-			&rec.Tenant.S3EncryptionMode, &rec.Tenant.S3KMSKeyID, &s3BucketKeyEnabled, &rec.Tenant.CreatedAt, &rec.Tenant.UpdatedAt,
-			&rec.Binding.TenantID, &rec.Binding.OrganizationID, &rec.Binding.ClusterID, &rec.Binding.CreatedAt, &rec.Binding.UpdatedAt); err != nil {
+		rec, err := scanTenantBindingScanner(rows)
+		if err != nil {
 			return nil, err
 		}
-		rec.Tenant.DBTLS = dbTLS == 1
-		rec.Tenant.S3BucketKeyEnabled = boolPtr(s3BucketKeyEnabled == 1)
-		if clusterID.Valid {
-			rec.Tenant.ClusterID = clusterID.String
-		}
-		if parentTenantID.Valid {
-			rec.Tenant.ParentTenantID = parentTenantID.String
-		}
-		if storageNamespaceID.Valid {
-			rec.Tenant.StorageNamespaceID = storageNamespaceID.String
-		}
-		if claimURL.Valid {
-			rec.Tenant.ClaimURL = claimURL.String
-		}
-		if claimExp.Valid {
-			ts := claimExp.Time.UTC()
-			rec.Tenant.ClaimExpiresAt = &ts
-		}
-		out = append(out, rec)
+		out = append(out, *rec)
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
 	return out, nil
+}
+
+type tenantBindingScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanTenantBindingRow(row tenantBindingScanner) (*TenantWithTiDBCloudOrgBinding, error) {
+	return scanTenantBindingScanner(row)
+}
+
+func scanTenantBindingScanner(row tenantBindingScanner) (*TenantWithTiDBCloudOrgBinding, error) {
+	var rec TenantWithTiDBCloudOrgBinding
+	var dbTLS int
+	var clusterID sql.NullString
+	var parentTenantID sql.NullString
+	var storageNamespaceID sql.NullString
+	var claimURL sql.NullString
+	var claimExp sql.NullTime
+	var s3BucketKeyEnabled int
+	var usedAt sql.NullTime
+	if err := row.Scan(&rec.Tenant.ID, &rec.Tenant.Status, &rec.Tenant.Kind, &parentTenantID, &storageNamespaceID,
+		&rec.Tenant.DBHost, &rec.Tenant.DBPort, &rec.Tenant.DBUser, &rec.Tenant.DBPasswordCipher,
+		&rec.Tenant.DBName, &dbTLS, &rec.Tenant.Provider, &clusterID, &rec.Tenant.BranchID, &claimURL, &claimExp, &rec.Tenant.SchemaVersion,
+		&rec.Tenant.S3EncryptionMode, &rec.Tenant.S3KMSKeyID, &s3BucketKeyEnabled, &rec.Tenant.CreatedAt, &rec.Tenant.UpdatedAt,
+		&rec.Binding.TenantID, &rec.Binding.OrganizationID, &rec.Binding.ClusterID, &rec.Binding.PoolID, &rec.Binding.PoolStatus, &usedAt,
+		&rec.Binding.CreatedAt, &rec.Binding.UpdatedAt); err != nil {
+		return nil, err
+	}
+	rec.Tenant.DBTLS = dbTLS == 1
+	rec.Tenant.S3BucketKeyEnabled = boolPtr(s3BucketKeyEnabled == 1)
+	if clusterID.Valid {
+		rec.Tenant.ClusterID = clusterID.String
+	}
+	if parentTenantID.Valid {
+		rec.Tenant.ParentTenantID = parentTenantID.String
+	}
+	if storageNamespaceID.Valid {
+		rec.Tenant.StorageNamespaceID = storageNamespaceID.String
+	}
+	if claimURL.Valid {
+		rec.Tenant.ClaimURL = claimURL.String
+	}
+	if claimExp.Valid {
+		ts := claimExp.Time.UTC()
+		rec.Tenant.ClaimExpiresAt = &ts
+	}
+	if usedAt.Valid {
+		ts := usedAt.Time.UTC()
+		rec.Binding.UsedAt = &ts
+	}
+	return &rec, nil
 }
 
 func (s *Store) UpdateTenantStatus(ctx context.Context, id string, status TenantStatus) (err error) {
@@ -2586,6 +2938,35 @@ func tenantS3BucketKeyEnabledForInsert(t *Tenant) bool {
 		return true
 	}
 	return *t.S3BucketKeyEnabled
+}
+
+func tenantPoolBindingStatusForInsert(status TenantPoolBindingStatus) TenantPoolBindingStatus {
+	if status == "" {
+		return TenantPoolBindingUsed
+	}
+	return status
+}
+
+func tenantPoolStatusForInsert(status TenantPoolStatus) TenantPoolStatus {
+	if status == "" {
+		return TenantPoolActive
+	}
+	return status
+}
+
+func scanTenantPoolRow(row tenantBindingScanner) (*TenantPool, error) {
+	var rec TenantPool
+	var orgID sql.NullString
+	if err := row.Scan(&rec.PoolID, &orgID, &rec.Size, &rec.Status, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	if orgID.Valid {
+		rec.OrganizationID = orgID.String
+	}
+	return &rec, nil
 }
 
 func boolPtr(v bool) *bool {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1901,7 +1901,7 @@ func tenantPoolLockName(poolID string) string {
 		return ""
 	}
 	sum := sha256.Sum256([]byte(poolID))
-	return "d9_tenant_pool:" + hex.EncodeToString(sum[:20])
+	return "d9_tenant_pool:" + hex.EncodeToString(sum[:16])
 }
 
 func tenantPoolDatabaseLockName(baseLockName, databaseName string) string {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -250,7 +250,6 @@ type TenantPool struct {
 	PoolID         string
 	OrganizationID string
 	Size           int
-	SpendingLimit  *int64
 	Status         TenantPoolStatus
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
@@ -570,7 +569,6 @@ func metaInitSchemaStatements() []string {
 			pool_id         VARCHAR(64) PRIMARY KEY,
 			organization_id VARCHAR(64) NULL,
 			size            INT NOT NULL,
-			spending_limit  BIGINT NULL,
 			status          VARCHAR(20) NOT NULL DEFAULT 'active',
 			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
@@ -1364,9 +1362,6 @@ func (s *Store) CreateTenantPool(ctx context.Context, p *TenantPool) (err error)
 	if p.Size < 0 {
 		return fmt.Errorf("pool size must be non-negative")
 	}
-	if p.SpendingLimit != nil && *p.SpendingLimit < 0 {
-		return fmt.Errorf("spending limit must be non-negative")
-	}
 	now := time.Now().UTC()
 	createdAt := p.CreatedAt
 	if createdAt.IsZero() {
@@ -1377,9 +1372,9 @@ func (s *Store) CreateTenantPool(ctx context.Context, p *TenantPool) (err error)
 		updatedAt = now
 	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_tidbcloud_pools
-		(pool_id, organization_id, size, spending_limit, status, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		poolID, nullStr(strings.TrimSpace(p.OrganizationID)), p.Size, nullableInt64(p.SpendingLimit), tenantPoolStatusForInsert(p.Status),
+		(pool_id, organization_id, size, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`,
+		poolID, nullStr(strings.TrimSpace(p.OrganizationID)), p.Size, tenantPoolStatusForInsert(p.Status),
 		createdAt.UTC(), updatedAt.UTC())
 	if isDuplicateEntry(err) {
 		return ErrDuplicate
@@ -1394,7 +1389,7 @@ func (s *Store) GetTenantPoolByOrganization(ctx context.Context, organizationID 
 	if organizationID == "" {
 		return nil, fmt.Errorf("organization_id is required")
 	}
-	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, spending_limit, status, created_at, updated_at
+	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, status, created_at, updated_at
 		FROM tenant_tidbcloud_pools WHERE organization_id = ?`, organizationID)
 	return scanTenantPoolRow(row)
 }
@@ -1406,7 +1401,7 @@ func (s *Store) GetTenantPoolByID(ctx context.Context, poolID string) (out *Tena
 	if poolID == "" {
 		return nil, fmt.Errorf("pool_id is required")
 	}
-	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, spending_limit, status, created_at, updated_at
+	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, status, created_at, updated_at
 		FROM tenant_tidbcloud_pools WHERE pool_id = ?`, poolID)
 	return scanTenantPoolRow(row)
 }
@@ -1570,32 +1565,6 @@ func (s *Store) UpdateTenantPoolSize(ctx context.Context, poolID string, size in
 		return fmt.Errorf("pool size must be non-negative")
 	}
 	res, err := s.db.ExecContext(ctx, `UPDATE tenant_tidbcloud_pools SET size = ?, updated_at = ? WHERE pool_id = ?`, size, time.Now().UTC(), poolID)
-	if err != nil {
-		return err
-	}
-	n, _ := res.RowsAffected()
-	if n == 0 {
-		return ErrNotFound
-	}
-	return nil
-}
-
-func (s *Store) UpdateTenantPoolSettings(ctx context.Context, poolID string, size *int, spendingLimit *int64) (err error) {
-	start := time.Now()
-	defer observeMeta(ctx, "update_tidbcloud_pool_settings", start, &err)
-	poolID = strings.TrimSpace(poolID)
-	if poolID == "" {
-		return fmt.Errorf("pool_id is required")
-	}
-	if size != nil && *size < 0 {
-		return fmt.Errorf("pool size must be non-negative")
-	}
-	if spendingLimit != nil && *spendingLimit < 0 {
-		return fmt.Errorf("spending limit must be non-negative")
-	}
-	res, err := s.db.ExecContext(ctx, `UPDATE tenant_tidbcloud_pools
-		SET size = COALESCE(?, size), spending_limit = COALESCE(?, spending_limit), updated_at = ?
-		WHERE pool_id = ?`, nullableInt(size), nullableInt64(spendingLimit), time.Now().UTC(), poolID)
 	if err != nil {
 		return err
 	}
@@ -3027,8 +2996,7 @@ func tenantPoolStatusForInsert(status TenantPoolStatus) TenantPoolStatus {
 func scanTenantPoolRow(row tenantBindingScanner) (*TenantPool, error) {
 	var rec TenantPool
 	var orgID sql.NullString
-	var spendingLimit sql.NullInt64
-	if err := row.Scan(&rec.PoolID, &orgID, &rec.Size, &spendingLimit, &rec.Status, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
+	if err := row.Scan(&rec.PoolID, &orgID, &rec.Size, &rec.Status, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
 		}
@@ -3036,10 +3004,6 @@ func scanTenantPoolRow(row tenantBindingScanner) (*TenantPool, error) {
 	}
 	if orgID.Valid {
 		rec.OrganizationID = orgID.String
-	}
-	if spendingLimit.Valid {
-		v := spendingLimit.Int64
-		rec.SpendingLimit = &v
 	}
 	return &rec, nil
 }
@@ -3053,20 +3017,6 @@ func nullStr(v string) any {
 		return nil
 	}
 	return v
-}
-
-func nullableInt(v *int) any {
-	if v == nil {
-		return nil
-	}
-	return *v
-}
-
-func nullableInt64(v *int64) any {
-	if v == nil {
-		return nil
-	}
-	return *v
 }
 
 func nullableBytes(v []byte) any {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -250,6 +250,7 @@ type TenantPool struct {
 	PoolID         string
 	OrganizationID string
 	Size           int
+	SpendingLimit  *int64
 	Status         TenantPoolStatus
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
@@ -569,6 +570,7 @@ func metaInitSchemaStatements() []string {
 			pool_id         VARCHAR(64) PRIMARY KEY,
 			organization_id VARCHAR(64) NULL,
 			size            INT NOT NULL,
+			spending_limit  BIGINT NULL,
 			status          VARCHAR(20) NOT NULL DEFAULT 'active',
 			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
@@ -1349,9 +1351,9 @@ func (s *Store) GetTenantTiDBCloudOrgBinding(ctx context.Context, tenantID strin
 	return &rec, nil
 }
 
-func (s *Store) UpsertTenantPool(ctx context.Context, p *TenantPool) (err error) {
+func (s *Store) CreateTenantPool(ctx context.Context, p *TenantPool) (err error) {
 	start := time.Now()
-	defer observeMeta(ctx, "upsert_tidbcloud_pool", start, &err)
+	defer observeMeta(ctx, "create_tidbcloud_pool", start, &err)
 	if p == nil {
 		return fmt.Errorf("tenant pool is required")
 	}
@@ -1361,6 +1363,9 @@ func (s *Store) UpsertTenantPool(ctx context.Context, p *TenantPool) (err error)
 	}
 	if p.Size < 0 {
 		return fmt.Errorf("pool size must be non-negative")
+	}
+	if p.SpendingLimit != nil && *p.SpendingLimit < 0 {
+		return fmt.Errorf("spending limit must be non-negative")
 	}
 	now := time.Now().UTC()
 	createdAt := p.CreatedAt
@@ -1372,9 +1377,9 @@ func (s *Store) UpsertTenantPool(ctx context.Context, p *TenantPool) (err error)
 		updatedAt = now
 	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_tidbcloud_pools
-		(pool_id, organization_id, size, status, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?)`,
-		poolID, nullStr(strings.TrimSpace(p.OrganizationID)), p.Size, tenantPoolStatusForInsert(p.Status),
+		(pool_id, organization_id, size, spending_limit, status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		poolID, nullStr(strings.TrimSpace(p.OrganizationID)), p.Size, nullableInt64(p.SpendingLimit), tenantPoolStatusForInsert(p.Status),
 		createdAt.UTC(), updatedAt.UTC())
 	if isDuplicateEntry(err) {
 		return ErrDuplicate
@@ -1389,7 +1394,7 @@ func (s *Store) GetTenantPoolByOrganization(ctx context.Context, organizationID 
 	if organizationID == "" {
 		return nil, fmt.Errorf("organization_id is required")
 	}
-	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, status, created_at, updated_at
+	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, spending_limit, status, created_at, updated_at
 		FROM tenant_tidbcloud_pools WHERE organization_id = ?`, organizationID)
 	return scanTenantPoolRow(row)
 }
@@ -1401,7 +1406,7 @@ func (s *Store) GetTenantPoolByID(ctx context.Context, poolID string) (out *Tena
 	if poolID == "" {
 		return nil, fmt.Errorf("pool_id is required")
 	}
-	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, status, created_at, updated_at
+	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, spending_limit, status, created_at, updated_at
 		FROM tenant_tidbcloud_pools WHERE pool_id = ?`, poolID)
 	return scanTenantPoolRow(row)
 }
@@ -1451,9 +1456,22 @@ func (s *Store) CountFreeTenantPoolBindings(ctx context.Context, organizationID 
 func (s *Store) ListFreeTenantPoolBindings(ctx context.Context, organizationID string, newestFirst bool, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "list_free_tidbcloud_pool_bindings", start, &err)
+	return s.listFreeTenantPoolBindings(ctx, organizationID, newestFirst, limit, []TenantStatus{TenantProvisioning, TenantActive})
+}
+
+func (s *Store) ListFreeTenantPoolBindingsForDelete(ctx context.Context, organizationID string, newestFirst bool, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_free_tidbcloud_pool_bindings_for_delete", start, &err)
+	return s.listFreeTenantPoolBindings(ctx, organizationID, newestFirst, limit, []TenantStatus{TenantProvisioning, TenantActive, TenantFailed})
+}
+
+func (s *Store) listFreeTenantPoolBindings(ctx context.Context, organizationID string, newestFirst bool, limit int, statuses []TenantStatus) (out []TenantWithTiDBCloudOrgBinding, err error) {
 	organizationID = strings.TrimSpace(organizationID)
 	if organizationID == "" {
 		return nil, fmt.Errorf("organization_id is required")
+	}
+	if len(statuses) == 0 {
+		return nil, fmt.Errorf("tenant statuses are required")
 	}
 	if limit <= 0 {
 		limit = 100
@@ -1462,6 +1480,7 @@ func (s *Store) ListFreeTenantPoolBindings(ctx context.Context, organizationID s
 	if newestFirst {
 		order = "DESC"
 	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(statuses)), ",")
 	query := `SELECT
 			t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
 			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
@@ -1471,10 +1490,16 @@ func (s *Store) ListFreeTenantPoolBindings(ctx context.Context, organizationID s
 		FROM tenant_tidbcloud_org_bindings b
 		JOIN tenants t ON t.id = b.tenant_id
 		WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = 'tidb_cloud_native'
-			AND t.status IN (?, ?)
+			AND t.status IN (` + placeholders + `)
 		ORDER BY b.created_at ` + order + `, b.tenant_id ` + order + `
 		LIMIT ?`
-	rows, err := s.db.QueryContext(ctx, query, organizationID, TenantPoolBindingFree, TenantProvisioning, TenantActive, limit)
+	args := make([]any, 0, 3+len(statuses))
+	args = append(args, organizationID, TenantPoolBindingFree)
+	for _, status := range statuses {
+		args = append(args, status)
+	}
+	args = append(args, limit)
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -1545,6 +1570,51 @@ func (s *Store) UpdateTenantPoolSize(ctx context.Context, poolID string, size in
 		return fmt.Errorf("pool size must be non-negative")
 	}
 	res, err := s.db.ExecContext(ctx, `UPDATE tenant_tidbcloud_pools SET size = ?, updated_at = ? WHERE pool_id = ?`, size, time.Now().UTC(), poolID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) UpdateTenantPoolSettings(ctx context.Context, poolID string, size *int, spendingLimit *int64) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_tidbcloud_pool_settings", start, &err)
+	poolID = strings.TrimSpace(poolID)
+	if poolID == "" {
+		return fmt.Errorf("pool_id is required")
+	}
+	if size != nil && *size < 0 {
+		return fmt.Errorf("pool size must be non-negative")
+	}
+	if spendingLimit != nil && *spendingLimit < 0 {
+		return fmt.Errorf("spending limit must be non-negative")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_tidbcloud_pools
+		SET size = COALESCE(?, size), spending_limit = COALESCE(?, spending_limit), updated_at = ?
+		WHERE pool_id = ?`, nullableInt(size), nullableInt64(spendingLimit), time.Now().UTC(), poolID)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) UpdateTenantPoolStatus(ctx context.Context, poolID string, status TenantPoolStatus) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_tidbcloud_pool_status", start, &err)
+	poolID = strings.TrimSpace(poolID)
+	if poolID == "" {
+		return fmt.Errorf("pool_id is required")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_tidbcloud_pools SET status = ?, updated_at = ? WHERE pool_id = ?`,
+		tenantPoolStatusForInsert(status), time.Now().UTC(), poolID)
 	if err != nil {
 		return err
 	}
@@ -2957,7 +3027,8 @@ func tenantPoolStatusForInsert(status TenantPoolStatus) TenantPoolStatus {
 func scanTenantPoolRow(row tenantBindingScanner) (*TenantPool, error) {
 	var rec TenantPool
 	var orgID sql.NullString
-	if err := row.Scan(&rec.PoolID, &orgID, &rec.Size, &rec.Status, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
+	var spendingLimit sql.NullInt64
+	if err := row.Scan(&rec.PoolID, &orgID, &rec.Size, &spendingLimit, &rec.Status, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
 		}
@@ -2965,6 +3036,10 @@ func scanTenantPoolRow(row tenantBindingScanner) (*TenantPool, error) {
 	}
 	if orgID.Valid {
 		rec.OrganizationID = orgID.String
+	}
+	if spendingLimit.Valid {
+		v := spendingLimit.Int64
+		rec.SpendingLimit = &v
 	}
 	return &rec, nil
 }
@@ -2978,6 +3053,20 @@ func nullStr(v string) any {
 		return nil
 	}
 	return v
+}
+
+func nullableInt(v *int) any {
+	if v == nil {
+		return nil
+	}
+	return *v
+}
+
+func nullableInt64(v *int64) any {
+	if v == nil {
+		return nil
+	}
+	return *v
 }
 
 func nullableBytes(v []byte) any {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1524,10 +1524,10 @@ func (s *Store) ClaimOldestFreeTenantPoolBinding(ctx context.Context, organizati
 			FROM tenant_tidbcloud_org_bindings b
 			JOIN tenants t ON t.id = b.tenant_id
 			WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = 'tidb_cloud_native'
-				AND t.status IN (?, ?)
+				AND t.status = ?
 			ORDER BY b.created_at ASC, b.tenant_id ASC
 			LIMIT 1 FOR UPDATE`
-		row := tx.QueryRowContext(ctx, query, organizationID, TenantPoolBindingFree, TenantProvisioning, TenantActive)
+		row := tx.QueryRowContext(ctx, query, organizationID, TenantPoolBindingFree, TenantActive)
 		rec, scanErr := scanTenantBindingRow(row)
 		if scanErr != nil {
 			return scanErr

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1188,6 +1188,100 @@ func TestUpsertTenantTiDBCloudOrgBindingAllowsSharedCluster(t *testing.T) {
 	}
 }
 
+func TestClaimOldestFreeTenantPoolBindingRequiresActiveTenant(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := s.CreateTenantPool(ctx, &TenantPool{
+		PoolID:         "pool-claim-active",
+		OrganizationID: "org-claim-active",
+		Size:           2,
+		Status:         TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create tenant pool: %v", err)
+	}
+	provisioningCreated := now.Add(-2 * time.Minute)
+	if err := s.InsertTenant(ctx, &Tenant{
+		ID:               "pool-tenant-provisioning",
+		Status:           TenantProvisioning,
+		Kind:             TenantKindLive,
+		DBHost:           "db.example.com",
+		DBPort:           4000,
+		DBUser:           "u.root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         "tidb_cloud_native",
+		ClusterID:        "cluster-provisioning",
+		SchemaVersion:    1,
+		CreatedAt:        provisioningCreated,
+		UpdatedAt:        provisioningCreated,
+	}); err != nil {
+		t.Fatalf("insert provisioning tenant: %v", err)
+	}
+	if err := s.UpsertTenantTiDBCloudOrgBinding(ctx, &TenantTiDBCloudOrgBinding{
+		TenantID:       "pool-tenant-provisioning",
+		OrganizationID: "org-claim-active",
+		ClusterID:      "cluster-provisioning",
+		PoolID:         "pool-claim-active",
+		PoolStatus:     TenantPoolBindingFree,
+		CreatedAt:      provisioningCreated,
+		UpdatedAt:      provisioningCreated,
+	}); err != nil {
+		t.Fatalf("upsert provisioning binding: %v", err)
+	}
+	if _, err := s.ClaimOldestFreeTenantPoolBinding(ctx, "org-claim-active"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("claim provisioning tenant err = %v, want ErrNotFound", err)
+	}
+
+	activeCreated := now.Add(-time.Minute)
+	if err := s.InsertTenant(ctx, &Tenant{
+		ID:               "pool-tenant-active",
+		Status:           TenantActive,
+		Kind:             TenantKindLive,
+		DBHost:           "db.example.com",
+		DBPort:           4000,
+		DBUser:           "u.root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         "tidb_cloud_native",
+		ClusterID:        "cluster-active",
+		SchemaVersion:    1,
+		CreatedAt:        activeCreated,
+		UpdatedAt:        activeCreated,
+	}); err != nil {
+		t.Fatalf("insert active tenant: %v", err)
+	}
+	if err := s.UpsertTenantTiDBCloudOrgBinding(ctx, &TenantTiDBCloudOrgBinding{
+		TenantID:       "pool-tenant-active",
+		OrganizationID: "org-claim-active",
+		ClusterID:      "cluster-active",
+		PoolID:         "pool-claim-active",
+		PoolStatus:     TenantPoolBindingFree,
+		CreatedAt:      activeCreated,
+		UpdatedAt:      activeCreated,
+	}); err != nil {
+		t.Fatalf("upsert active binding: %v", err)
+	}
+	row, err := s.ClaimOldestFreeTenantPoolBinding(ctx, "org-claim-active")
+	if err != nil {
+		t.Fatalf("claim active tenant: %v", err)
+	}
+	if row.Tenant.ID != "pool-tenant-active" {
+		t.Fatalf("claimed tenant = %q, want pool-tenant-active", row.Tenant.ID)
+	}
+	provisioningBinding, err := s.GetTenantTiDBCloudOrgBinding(ctx, "pool-tenant-provisioning")
+	if err != nil {
+		t.Fatalf("get provisioning binding: %v", err)
+	}
+	if provisioningBinding.PoolStatus != TenantPoolBindingFree {
+		t.Fatalf("provisioning pool status = %s, want %s", provisioningBinding.PoolStatus, TenantPoolBindingFree)
+	}
+}
+
 func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
 	spec := mustMetaTableSpec(t, mustMetaSpec(t), "tenant_quota_config")
 	meta := metaTableMeta{

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -402,8 +402,8 @@ func TestWithTenantPoolLockSerializesCallbacks(t *testing.T) {
 func TestTenantPoolDatabaseLockNameStaysWithinMySQLLimit(t *testing.T) {
 	base := tenantPoolLockName("pool-lock-test")
 	got := tenantPoolDatabaseLockName(base, "drive9_test_with_a_long_database_name")
-	if len(got) != 64 {
-		t.Fatalf("lock name length = %d, want 64", len(got))
+	if len(got) >= 64 {
+		t.Fatalf("lock name length = %d, want below 64", len(got))
 	}
 	if !strings.HasPrefix(got, base+":") {
 		t.Fatalf("lock name = %q, want base prefix %q", got, base+":")

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -367,6 +367,38 @@ func TestWithExternalBindingLockSerializesCallbacks(t *testing.T) {
 	}
 }
 
+func TestWithTenantPoolLockSerializesCallbacks(t *testing.T) {
+	s := newControlStore(t)
+	var running int32
+	var maxRunning int32
+	var wg sync.WaitGroup
+	for i := 0; i < 5; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := s.WithTenantPoolLock(context.Background(), "pool-lock-test", func(context.Context) error {
+				n := atomic.AddInt32(&running, 1)
+				for {
+					max := atomic.LoadInt32(&maxRunning)
+					if n <= max || atomic.CompareAndSwapInt32(&maxRunning, max, n) {
+						break
+					}
+				}
+				time.Sleep(20 * time.Millisecond)
+				atomic.AddInt32(&running, -1)
+				return nil
+			})
+			if err != nil {
+				t.Errorf("WithTenantPoolLock: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if maxRunning != 1 {
+		t.Fatalf("max concurrent lock holders = %d, want 1", maxRunning)
+	}
+}
+
 func TestInsertAPIKeyAllowsRepeatedKeyName(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC()

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -399,6 +399,21 @@ func TestWithTenantPoolLockSerializesCallbacks(t *testing.T) {
 	}
 }
 
+func TestTenantPoolDatabaseLockNameStaysWithinMySQLLimit(t *testing.T) {
+	base := tenantPoolLockName("pool-lock-test")
+	got := tenantPoolDatabaseLockName(base, "drive9_test_with_a_long_database_name")
+	if len(got) != 64 {
+		t.Fatalf("lock name length = %d, want 64", len(got))
+	}
+	if !strings.HasPrefix(got, base+":") {
+		t.Fatalf("lock name = %q, want base prefix %q", got, base+":")
+	}
+	other := tenantPoolDatabaseLockName(base, "drive9_test_other")
+	if got == other {
+		t.Fatalf("database-scoped lock names should differ: %q", got)
+	}
+}
+
 func TestInsertAPIKeyAllowsRepeatedKeyName(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC()
@@ -1265,7 +1280,7 @@ func TestClaimOldestFreeTenantPoolBindingRequiresActiveTenant(t *testing.T) {
 		t.Fatalf("upsert provisioning binding: %v", err)
 	}
 	if _, err := s.ClaimOldestFreeTenantPoolBinding(ctx, "org-claim-active"); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("claim provisioning tenant err = %v, want ErrNotFound", err)
+		t.Errorf("claim provisioning tenant err = %v, want ErrNotFound", err)
 	}
 
 	activeCreated := now.Add(-time.Minute)
@@ -1300,17 +1315,16 @@ func TestClaimOldestFreeTenantPoolBindingRequiresActiveTenant(t *testing.T) {
 	}
 	row, err := s.ClaimOldestFreeTenantPoolBinding(ctx, "org-claim-active")
 	if err != nil {
-		t.Fatalf("claim active tenant: %v", err)
-	}
-	if row.Tenant.ID != "pool-tenant-active" {
-		t.Fatalf("claimed tenant = %q, want pool-tenant-active", row.Tenant.ID)
+		t.Errorf("claim active tenant: %v", err)
+	} else if row.Tenant.ID != "pool-tenant-active" {
+		t.Errorf("claimed tenant = %q, want pool-tenant-active", row.Tenant.ID)
 	}
 	provisioningBinding, err := s.GetTenantTiDBCloudOrgBinding(ctx, "pool-tenant-provisioning")
 	if err != nil {
 		t.Fatalf("get provisioning binding: %v", err)
 	}
 	if provisioningBinding.PoolStatus != TenantPoolBindingFree {
-		t.Fatalf("provisioning pool status = %s, want %s", provisioningBinding.PoolStatus, TenantPoolBindingFree)
+		t.Errorf("provisioning pool status = %s, want %s", provisioningBinding.PoolStatus, TenantPoolBindingFree)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -692,41 +692,55 @@ func (s *Server) tenantPoolCreateLock(cred tenant.CredentialProvisionRequest) *s
 }
 
 func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) (*provisionTenantResult, *meta.TenantPool, bool, error) {
+	claimStarted := time.Now()
 	manager, ok := s.provisioner.(tenant.TenantPoolClusterManager)
 	if !ok {
+		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "reason", "pool_manager_unavailable", "duration_ms", durationMillis(claimStarted))...)
 		return nil, nil, false, nil
 	}
+	stageStarted := time.Now()
 	orgID, err := s.firstManagedOrganization(ctx, cred)
 	if err != nil || orgID == "" {
+		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_org_lookup_done", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "duration_ms", durationMillis(stageStarted), "has_error", err != nil)...)
 		return nil, nil, false, err
 	}
+	logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_org_lookup_done", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
+	stageStarted = time.Now()
 	pool, err := s.meta.GetTenantPoolByOrganization(ctx, orgID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
+			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_pool_lookup_missed", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
 			return nil, nil, false, nil
 		}
 		return nil, nil, false, err
 	}
+	logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_pool_lookup_done", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "pool_size", pool.Size, "pool_status", pool.Status, "duration_ms", durationMillis(stageStarted))...)
 	if pool.Status != meta.TenantPoolActive {
+		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "reason", "pool_inactive", "pool_status", pool.Status, "duration_ms", durationMillis(claimStarted))...)
 		return nil, nil, false, nil
 	}
+	stageStarted = time.Now()
 	row, err := s.meta.ClaimOldestFreeTenantPoolBinding(ctx, orgID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
+			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_free_tenant_missed", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
 			return nil, pool, false, nil
 		}
 		return nil, nil, false, err
 	}
+	logProvisionStage(ctx, "admin_tenant_pool_claim_free_tenant_claimed", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "cluster_id", row.Binding.ClusterID, "status", row.Tenant.Status)
 	usedAt := time.Now().UTC()
 	var opts tenant.QuotaUpdateOptions
 	if quotaOpt != nil {
 		opts.TiDBCloudSpendingLimitMonthly = quotaOpt.TiDBCloudSpendingLimit
 	}
 	cluster := clusterInfoFromTenant(&row.Tenant)
+	stageStarted = time.Now()
 	if _, err := manager.MarkClusterPoolUsed(ctx, cluster, cred, usedAt, opts); err != nil {
 		s.releaseClaimedPoolTenant(ctx, manager, cluster, cred, row.Tenant.ID, "mark_used_error")
 		return nil, nil, false, err
 	}
+	logProvisionStage(ctx, "admin_tenant_pool_claim_cluster_marked_used", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "cluster_id", cluster.ClusterID, "quota_requested", quotaOpt != nil)
 	success := false
 	defer func() {
 		if !success {
@@ -734,22 +748,29 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		}
 	}()
 	if quotaOpt != nil {
+		stageStarted = time.Now()
 		quotaReq := *quotaOpt
 		quotaReq.TenantID = row.Tenant.ID
 		if err := s.applyQuotaLocalConfig(ctx, row.Tenant.ID, quotaReq); err != nil {
 			return nil, nil, false, err
 		}
+		logProvisionStage(ctx, "admin_tenant_pool_claim_quota_local_config_applied", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID)
 	}
+	stageStarted = time.Now()
 	plainPass, err := s.pool.Decrypt(ctx, row.Tenant.DBPasswordCipher)
 	if err != nil {
 		return nil, nil, false, err
 	}
+	logProvisionStage(ctx, "admin_tenant_pool_claim_db_password_decrypted", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID)
+	stageStarted = time.Now()
 	apiToken, apiKeyID, err := s.issueOwnerAPIKey(ctx, row.Tenant.ID, "default", 1, apiKeyIssueSource{})
 	if err != nil {
 		return nil, nil, false, err
 	}
+	logProvisionStage(ctx, "admin_tenant_pool_claim_api_key_issued", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "api_key_id", apiKeyID)
 	cloudProvider, region := provisioningCloudRegion(s.provisioner)
 	success = true
+	logProvisionStage(ctx, "admin_tenant_pool_claim_done", row.Tenant.ID, row.Tenant.Provider, claimStarted, "pool_id", pool.PoolID, "organization_id", orgID, "cluster_id", cluster.ClusterID, "api_key_id", apiKeyID, "status", row.Tenant.Status)
 	return &provisionTenantResult{
 		TenantID:       row.Tenant.ID,
 		APIKey:         apiToken,

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -31,6 +31,28 @@ type adminTenantPoolResponse struct {
 	Status         string `json:"status"`
 }
 
+type adminTenantPoolHTTPError struct {
+	status  int
+	message string
+}
+
+func (e *adminTenantPoolHTTPError) Error() string {
+	return e.message
+}
+
+func adminTenantPoolError(status int, message string) error {
+	return &adminTenantPoolHTTPError{status: status, message: message}
+}
+
+func writeAdminTenantPoolError(w http.ResponseWriter, err error) {
+	var httpErr *adminTenantPoolHTTPError
+	if errors.As(err, &httpErr) {
+		errJSON(w, httpErr.status, httpErr.message)
+		return
+	}
+	errJSON(w, http.StatusInternalServerError, err.Error())
+}
+
 func (s *Server) adminTenantPoolHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if !s.adminTenantAPIEnabled() {
@@ -185,48 +207,58 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 	lock := s.tenantPoolLock(pool.PoolID)
 	lock.Lock()
 	defer lock.Unlock()
-	if pool, err = s.meta.GetTenantPoolByID(r.Context(), pool.PoolID); err != nil {
-		errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
-		return
-	}
-	if pool.Status != meta.TenantPoolActive {
-		errJSON(w, http.StatusConflict, "tenant pool is not active")
-		return
-	}
-	freeSize, err := s.meta.CountFreeTenantPoolBindings(r.Context(), pool.OrganizationID)
-	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "tenant pool free size lookup failed")
-		return
-	}
-	targetSize := *req.PoolSize
-	if targetSize > freeSize {
-		results, err := s.createFreePoolTenants(r.Context(), pool.PoolID, targetSize-freeSize, cred, nil)
+
+	var out adminTenantPoolResponse
+	if err := s.meta.WithTenantPoolLock(r.Context(), pool.PoolID, func(ctx context.Context) error {
+		if pool, err = s.meta.GetTenantPoolByID(ctx, pool.PoolID); err != nil {
+			return adminTenantPoolError(http.StatusInternalServerError, "tenant pool lookup failed")
+		}
+		if pool.Status != meta.TenantPoolActive {
+			return adminTenantPoolError(http.StatusConflict, "tenant pool is not active")
+		}
+		freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID)
 		if err != nil {
-			errJSON(w, http.StatusBadGateway, fmt.Sprintf("grow tenant pool failed: %v", err))
-			return
+			return adminTenantPoolError(http.StatusInternalServerError, "tenant pool free size lookup failed")
 		}
-		for _, res := range results {
-			s.startProvisionedTenantSchemaInit(r.Context(), res)
+		targetSize := *req.PoolSize
+		if targetSize > freeSize {
+			results, err := s.createFreePoolTenants(ctx, pool.PoolID, targetSize-freeSize, cred, nil)
+			if err != nil {
+				return adminTenantPoolError(http.StatusBadGateway, fmt.Sprintf("grow tenant pool failed: %v", err))
+			}
+			for _, res := range results {
+				s.startProvisionedTenantSchemaInit(ctx, res)
+			}
+			freeSize += len(results)
+		} else if targetSize < freeSize {
+			if err := s.deleteNewestFreePoolTenants(ctx, pool.OrganizationID, freeSize-targetSize, cred, false); err != nil {
+				if actualFreeSize, countErr := s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID); countErr == nil {
+					if updateErr := s.meta.UpdateTenantPoolSize(ctx, pool.PoolID, actualFreeSize); updateErr != nil {
+						logger.Warn(ctx, "admin_tenant_pool_shrink_partial_size_update_failed", zap.String("pool_id", pool.PoolID), zap.Int("free_size", actualFreeSize), zap.Error(updateErr))
+					}
+				} else {
+					logger.Warn(ctx, "admin_tenant_pool_shrink_partial_count_failed", zap.String("pool_id", pool.PoolID), zap.Error(countErr))
+				}
+				return adminTenantPoolError(http.StatusBadGateway, fmt.Sprintf("shrink tenant pool failed: %v", err))
+			}
+			freeSize = targetSize
 		}
-		freeSize += len(results)
-	} else if targetSize < freeSize {
-		if err := s.deleteNewestFreePoolTenants(r.Context(), pool.OrganizationID, freeSize-targetSize, cred, false); err != nil {
-			errJSON(w, http.StatusBadGateway, fmt.Sprintf("shrink tenant pool failed: %v", err))
-			return
+		if err := s.meta.UpdateTenantPoolSize(ctx, pool.PoolID, targetSize); err != nil {
+			return adminTenantPoolError(http.StatusInternalServerError, "failed to update tenant pool")
 		}
-		freeSize = targetSize
-	}
-	if err := s.meta.UpdateTenantPoolSize(r.Context(), pool.PoolID, targetSize); err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to update tenant pool")
+		out = adminTenantPoolResponse{
+			PoolID:         pool.PoolID,
+			OrganizationID: pool.OrganizationID,
+			PoolSize:       targetSize,
+			FreeSize:       freeSize,
+			Status:         string(pool.Status),
+		}
+		return nil
+	}); err != nil {
+		writeAdminTenantPoolError(w, err)
 		return
 	}
-	writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
-		PoolID:         pool.PoolID,
-		OrganizationID: pool.OrganizationID,
-		PoolSize:       targetSize,
-		FreeSize:       freeSize,
-		Status:         string(pool.Status),
-	})
+	writeJSON(w, http.StatusAccepted, out)
 }
 
 func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Request) {
@@ -250,25 +282,31 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 	lock := s.tenantPoolLock(pool.PoolID)
 	lock.Lock()
 	defer lock.Unlock()
-	if err := s.meta.UpdateTenantPoolStatus(r.Context(), pool.PoolID, meta.TenantPoolDeleting); err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to mark tenant pool deleting")
+
+	var out adminTenantPoolResponse
+	if err := s.meta.WithTenantPoolLock(r.Context(), pool.PoolID, func(ctx context.Context) error {
+		if err := s.meta.UpdateTenantPoolStatus(ctx, pool.PoolID, meta.TenantPoolDeleting); err != nil {
+			return adminTenantPoolError(http.StatusInternalServerError, "failed to mark tenant pool deleting")
+		}
+		if err := s.deleteNewestFreePoolTenants(ctx, pool.OrganizationID, 0, cred, true); err != nil {
+			return adminTenantPoolError(http.StatusBadGateway, fmt.Sprintf("delete tenant pool failed: %v", err))
+		}
+		if err := s.meta.DeleteTenantPool(ctx, pool.PoolID); err != nil {
+			return adminTenantPoolError(http.StatusInternalServerError, "failed to delete tenant pool")
+		}
+		out = adminTenantPoolResponse{
+			PoolID:         pool.PoolID,
+			OrganizationID: pool.OrganizationID,
+			PoolSize:       pool.Size,
+			FreeSize:       0,
+			Status:         string(meta.TenantPoolDeleting),
+		}
+		return nil
+	}); err != nil {
+		writeAdminTenantPoolError(w, err)
 		return
 	}
-	if err := s.deleteNewestFreePoolTenants(r.Context(), pool.OrganizationID, 0, cred, true); err != nil {
-		errJSON(w, http.StatusBadGateway, fmt.Sprintf("delete tenant pool failed: %v", err))
-		return
-	}
-	if err := s.meta.DeleteTenantPool(r.Context(), pool.PoolID); err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to delete tenant pool")
-		return
-	}
-	writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
-		PoolID:         pool.PoolID,
-		OrganizationID: pool.OrganizationID,
-		PoolSize:       pool.Size,
-		FreeSize:       0,
-		Status:         string(meta.TenantPoolDeleting),
-	})
+	writeJSON(w, http.StatusAccepted, out)
 }
 
 func (s *Server) authorizedTenantPool(w http.ResponseWriter, r *http.Request, cred tenant.CredentialProvisionRequest) (*meta.TenantPool, int, bool) {
@@ -599,32 +637,37 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 		lock := s.tenantPoolLock(pool.PoolID)
 		lock.Lock()
 		defer lock.Unlock()
-		current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
-		if err != nil {
-			if !errors.Is(err, meta.ErrNotFound) {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
+		if err := s.meta.WithTenantPoolLock(ctx, pool.PoolID, func(ctx context.Context) error {
+			current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
+			if err != nil {
+				if !errors.Is(err, meta.ErrNotFound) {
+					logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
+				}
+				return nil
 			}
-			return
-		}
-		if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
-			return
-		}
-		freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
-		if err != nil {
-			logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-			return
-		}
-		missing := current.Size - freeSize
-		if missing <= 0 {
-			return
-		}
-		results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
-		if err != nil {
-			logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-			return
-		}
-		for _, res := range results {
-			s.startProvisionedTenantSchemaInit(ctx, res)
+			if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
+				return nil
+			}
+			freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
+			if err != nil {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+				return nil
+			}
+			missing := current.Size - freeSize
+			if missing <= 0 {
+				return nil
+			}
+			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
+			if err != nil {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+				return nil
+			}
+			for _, res := range results {
+				s.startProvisionedTenantSchemaInit(ctx, res)
+			}
+			return nil
+		}); err != nil {
+			logger.Warn(ctx, "admin_tenant_pool_replenish_lock_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
 		}
 	})
 }

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -21,7 +21,6 @@ type adminTenantPoolRequest struct {
 	PublicKey  string `json:"public_key"`
 	PrivateKey string `json:"private_key"`
 	PoolSize   *int   `json:"pool_size,omitempty"`
-	quotaFields
 }
 
 type adminTenantPoolResponse struct {
@@ -68,15 +67,6 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	quotaReq := quotaRequest{TenantID: "pool", quotaFields: req.quotaFields}
-	var quotaOpt *quotaRequest
-	if quotaReq.anySet() {
-		if err := s.validateQuotaSetRequest(quotaReq); err != nil {
-			errJSON(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		quotaOpt = &quotaReq
-	}
 	createLock := s.tenantPoolCreateLock(cred)
 	createLock.Lock()
 	defer createLock.Unlock()
@@ -100,7 +90,6 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 		PoolID:         poolID,
 		OrganizationID: orgID,
 		Size:           *req.PoolSize,
-		SpendingLimit:  quotaReq.TiDBCloudSpendingLimit,
 		Status:         meta.TenantPoolActive,
 		CreatedAt:      now,
 		UpdatedAt:      now,
@@ -112,7 +101,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusInternalServerError, "failed to persist tenant pool")
 		return
 	}
-	results, err := s.createFreePoolTenants(r.Context(), poolID, *req.PoolSize, cred, quotaOpt)
+	results, err := s.createFreePoolTenants(r.Context(), poolID, *req.PoolSize, cred, nil)
 	if err != nil {
 		s.deleteTenantPoolMetadata(r.Context(), poolID, "create_free_tenants_error")
 		errJSON(w, http.StatusBadGateway, fmt.Sprintf("create tenant pool failed: %v", err))
@@ -180,6 +169,10 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, "pool_size must be positive")
 		return
 	}
+	if req.PoolSize == nil {
+		errJSON(w, http.StatusBadRequest, "pool_size is required")
+		return
+	}
 	cred, err := adminCredentials(req.PublicKey, req.PrivateKey, r)
 	if err != nil {
 		errJSON(w, http.StatusBadRequest, err.Error())
@@ -205,37 +198,25 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusInternalServerError, "tenant pool free size lookup failed")
 		return
 	}
-	quotaReq := quotaRequest{TenantID: "pool", quotaFields: req.quotaFields}
-	var quotaOpt *quotaRequest
-	if quotaReq.anySet() {
-		if err := s.validateQuotaSetRequest(quotaReq); err != nil {
-			errJSON(w, http.StatusBadRequest, err.Error())
+	targetSize := *req.PoolSize
+	if targetSize > freeSize {
+		results, err := s.createFreePoolTenants(r.Context(), pool.PoolID, targetSize-freeSize, cred, nil)
+		if err != nil {
+			errJSON(w, http.StatusBadGateway, fmt.Sprintf("grow tenant pool failed: %v", err))
 			return
 		}
-		quotaOpt = &quotaReq
-	}
-	targetSize := pool.Size
-	if req.PoolSize != nil {
-		targetSize = *req.PoolSize
-		if targetSize > freeSize {
-			results, err := s.createFreePoolTenants(r.Context(), pool.PoolID, targetSize-freeSize, cred, quotaOpt)
-			if err != nil {
-				errJSON(w, http.StatusBadGateway, fmt.Sprintf("grow tenant pool failed: %v", err))
-				return
-			}
-			for _, res := range results {
-				s.startProvisionedTenantSchemaInit(r.Context(), res)
-			}
-			freeSize += len(results)
-		} else if targetSize < freeSize {
-			if err := s.deleteNewestFreePoolTenants(r.Context(), pool.OrganizationID, freeSize-targetSize, cred, false); err != nil {
-				errJSON(w, http.StatusBadGateway, fmt.Sprintf("shrink tenant pool failed: %v", err))
-				return
-			}
-			freeSize = targetSize
+		for _, res := range results {
+			s.startProvisionedTenantSchemaInit(r.Context(), res)
 		}
+		freeSize += len(results)
+	} else if targetSize < freeSize {
+		if err := s.deleteNewestFreePoolTenants(r.Context(), pool.OrganizationID, freeSize-targetSize, cred, false); err != nil {
+			errJSON(w, http.StatusBadGateway, fmt.Sprintf("shrink tenant pool failed: %v", err))
+			return
+		}
+		freeSize = targetSize
 	}
-	if err := s.meta.UpdateTenantPoolSettings(r.Context(), pool.PoolID, req.PoolSize, quotaReq.TiDBCloudSpendingLimit); err != nil {
+	if err := s.meta.UpdateTenantPoolSize(r.Context(), pool.PoolID, targetSize); err != nil {
 		errJSON(w, http.StatusInternalServerError, "failed to update tenant pool")
 		return
 	}
@@ -637,7 +618,7 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 		if missing <= 0 {
 			return
 		}
-		results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, tenantPoolQuotaRequest(current))
+		results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
 		if err != nil {
 			logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
 			return
@@ -665,18 +646,6 @@ func (s *Server) tenantPoolCreateLock(cred tenant.CredentialProvisionRequest) *s
 	// first-create path before the org id is discoverable from managed clusters.
 	v, _ := s.tenantPoolCreateLocks.LoadOrStore(key, &sync.Mutex{})
 	return v.(*sync.Mutex)
-}
-
-func tenantPoolQuotaRequest(pool *meta.TenantPool) *quotaRequest {
-	if pool == nil || pool.SpendingLimit == nil {
-		return nil
-	}
-	return &quotaRequest{
-		TenantID: "pool",
-		quotaFields: quotaFields{
-			TiDBCloudSpendingLimit: pool.SpendingLimit,
-		},
-	}
 }
 
 func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) (*provisionTenantResult, *meta.TenantPool, bool, error) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -77,6 +77,9 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 		}
 		quotaOpt = &quotaReq
 	}
+	createLock := s.tenantPoolCreateLock(cred)
+	createLock.Lock()
+	defer createLock.Unlock()
 	orgID, err := s.firstManagedOrganization(r.Context(), cred)
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "create tenant pool")
@@ -650,6 +653,17 @@ func (s *Server) tenantPoolLock(poolID string) *sync.Mutex {
 		return &sync.Mutex{}
 	}
 	v, _ := s.tenantPoolLocks.LoadOrStore(poolID, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+func (s *Server) tenantPoolCreateLock(cred tenant.CredentialProvisionRequest) *sync.Mutex {
+	key := strings.TrimSpace(cred.PublicKey)
+	if key == "" {
+		return &sync.Mutex{}
+	}
+	// A TiDB Cloud public key belongs to a single org, so this serializes the
+	// first-create path before the org id is discoverable from managed clusters.
+	v, _ := s.tenantPoolCreateLocks.LoadOrStore(key, &sync.Mutex{})
 	return v.(*sync.Mutex)
 }
 

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1,0 +1,676 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+	"github.com/mem9-ai/drive9/pkg/tenant/token"
+)
+
+type adminTenantPoolRequest struct {
+	PublicKey  string `json:"public_key"`
+	PrivateKey string `json:"private_key"`
+	PoolSize   int    `json:"pool_size"`
+	quotaFields
+}
+
+type adminTenantPoolResponse struct {
+	PoolID         string `json:"pool_id"`
+	OrganizationID string `json:"organization_id,omitempty"`
+	PoolSize       int    `json:"pool_size"`
+	FreeSize       int    `json:"free_size"`
+	Status         string `json:"status"`
+}
+
+func (s *Server) adminTenantPoolHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.adminTenantAPIEnabled() {
+			errJSON(w, http.StatusNotFound, "admin tenant API not enabled")
+			return
+		}
+		switch r.Method {
+		case http.MethodPost:
+			s.handleAdminTenantPoolCreate(w, r)
+		case http.MethodGet:
+			s.handleAdminTenantPoolGet(w, r)
+		case http.MethodPatch:
+			s.handleAdminTenantPoolUpdate(w, r)
+		case http.MethodDelete:
+			s.handleAdminTenantPoolDelete(w, r)
+		default:
+			errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		}
+	})
+}
+
+func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Request) {
+	var req adminTenantPoolRequest
+	if err := decodeJSONBody(w, r, &req, true); err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.PoolSize <= 0 {
+		errJSON(w, http.StatusBadRequest, "pool_size must be positive")
+		return
+	}
+	cred, err := adminCredentials(req.PublicKey, req.PrivateKey, r)
+	if err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	quotaReq := quotaRequest{TenantID: "pool", quotaFields: req.quotaFields}
+	var quotaOpt *quotaRequest
+	if quotaReq.anySet() {
+		if err := s.validateQuotaSetRequest(quotaReq); err != nil {
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		quotaOpt = &quotaReq
+	}
+	orgID, err := s.firstManagedOrganization(r.Context(), cred)
+	if err != nil {
+		writeAdminTiDBCloudError(w, r.Context(), err, "create tenant pool")
+		return
+	}
+	if orgID != "" {
+		if _, err := s.meta.GetTenantPoolByOrganization(r.Context(), orgID); err == nil {
+			errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
+			return
+		} else if !errors.Is(err, meta.ErrNotFound) {
+			errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
+			return
+		}
+	}
+	poolID := token.NewID()
+	now := time.Now().UTC()
+	if err := s.meta.UpsertTenantPool(r.Context(), &meta.TenantPool{
+		PoolID:         poolID,
+		OrganizationID: orgID,
+		Size:           req.PoolSize,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		if errors.Is(err, meta.ErrDuplicate) {
+			errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
+			return
+		}
+		errJSON(w, http.StatusInternalServerError, "failed to persist tenant pool")
+		return
+	}
+	results, err := s.createFreePoolTenants(r.Context(), poolID, req.PoolSize, cred, quotaOpt)
+	if err != nil {
+		s.deleteTenantPoolMetadata(r.Context(), poolID, "create_free_tenants_error")
+		errJSON(w, http.StatusBadGateway, fmt.Sprintf("create tenant pool failed: %v", err))
+		return
+	}
+	if orgID == "" {
+		orgID = firstResultOrganizationID(results)
+		if orgID != "" {
+			if err := s.meta.UpdateTenantPoolOrganization(r.Context(), poolID, orgID); err != nil {
+				s.cleanupCreatedPoolTenants(r.Context(), results, cred, "update_pool_org_error")
+				s.deleteTenantPoolMetadata(r.Context(), poolID, "update_pool_org_error")
+				if errors.Is(err, meta.ErrDuplicate) {
+					errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
+					return
+				}
+				errJSON(w, http.StatusInternalServerError, "failed to update tenant pool organization")
+				return
+			}
+		}
+	}
+	for _, res := range results {
+		s.startProvisionedTenantSchemaInit(r.Context(), res)
+	}
+	freeSize := len(results)
+	if orgID != "" {
+		if n, err := s.meta.CountFreeTenantPoolBindings(r.Context(), orgID); err == nil {
+			freeSize = n
+		}
+	}
+	writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
+		PoolID:         poolID,
+		OrganizationID: orgID,
+		PoolSize:       req.PoolSize,
+		FreeSize:       freeSize,
+		Status:         string(meta.TenantPoolActive),
+	})
+}
+
+func (s *Server) handleAdminTenantPoolGet(w http.ResponseWriter, r *http.Request) {
+	cred, err := adminCredentialsFromHeaders(r)
+	if err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	pool, freeSize, ok := s.authorizedTenantPool(w, r, cred)
+	if !ok {
+		return
+	}
+	writeJSON(w, http.StatusOK, adminTenantPoolResponse{
+		PoolID:         pool.PoolID,
+		OrganizationID: pool.OrganizationID,
+		PoolSize:       pool.Size,
+		FreeSize:       freeSize,
+		Status:         string(pool.Status),
+	})
+}
+
+func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Request) {
+	var req adminTenantPoolRequest
+	if err := decodeJSONBody(w, r, &req, true); err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	if req.PoolSize < 0 {
+		errJSON(w, http.StatusBadRequest, "pool_size must be non-negative")
+		return
+	}
+	cred, err := adminCredentials(req.PublicKey, req.PrivateKey, r)
+	if err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	pool, freeSize, ok := s.authorizedTenantPool(w, r, cred)
+	if !ok {
+		return
+	}
+	quotaReq := quotaRequest{TenantID: "pool", quotaFields: req.quotaFields}
+	var quotaOpt *quotaRequest
+	if quotaReq.anySet() {
+		if err := s.validateQuotaSetRequest(quotaReq); err != nil {
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		quotaOpt = &quotaReq
+	}
+	if req.PoolSize > freeSize {
+		results, err := s.createFreePoolTenants(r.Context(), pool.PoolID, req.PoolSize-freeSize, cred, quotaOpt)
+		if err != nil {
+			errJSON(w, http.StatusBadGateway, fmt.Sprintf("grow tenant pool failed: %v", err))
+			return
+		}
+		for _, res := range results {
+			s.startProvisionedTenantSchemaInit(r.Context(), res)
+		}
+		freeSize += len(results)
+	} else if req.PoolSize < freeSize {
+		if err := s.deleteNewestFreePoolTenants(r.Context(), pool.OrganizationID, freeSize-req.PoolSize, cred); err != nil {
+			errJSON(w, http.StatusBadGateway, fmt.Sprintf("shrink tenant pool failed: %v", err))
+			return
+		}
+		freeSize = req.PoolSize
+	}
+	if err := s.meta.UpdateTenantPoolSize(r.Context(), pool.PoolID, req.PoolSize); err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to update tenant pool")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
+		PoolID:         pool.PoolID,
+		OrganizationID: pool.OrganizationID,
+		PoolSize:       req.PoolSize,
+		FreeSize:       freeSize,
+		Status:         string(pool.Status),
+	})
+}
+
+func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Request) {
+	var raw struct {
+		PublicKey  string `json:"public_key"`
+		PrivateKey string `json:"private_key"`
+	}
+	if err := decodeJSONBody(w, r, &raw, false); err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	cred, err := adminCredentials(raw.PublicKey, raw.PrivateKey, r)
+	if err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	pool, freeSize, ok := s.authorizedTenantPool(w, r, cred)
+	if !ok {
+		return
+	}
+	if err := s.deleteNewestFreePoolTenants(r.Context(), pool.OrganizationID, freeSize, cred); err != nil {
+		errJSON(w, http.StatusBadGateway, fmt.Sprintf("delete tenant pool failed: %v", err))
+		return
+	}
+	if err := s.meta.DeleteTenantPool(r.Context(), pool.PoolID); err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to delete tenant pool")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
+		PoolID:         pool.PoolID,
+		OrganizationID: pool.OrganizationID,
+		PoolSize:       pool.Size,
+		FreeSize:       0,
+		Status:         string(meta.TenantPoolDeleting),
+	})
+}
+
+func (s *Server) authorizedTenantPool(w http.ResponseWriter, r *http.Request, cred tenant.CredentialProvisionRequest) (*meta.TenantPool, int, bool) {
+	orgID, err := s.firstManagedOrganization(r.Context(), cred)
+	if err != nil {
+		writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant pool")
+		return nil, 0, false
+	}
+	if orgID == "" {
+		errJSON(w, http.StatusNotFound, "tenant pool not found")
+		return nil, 0, false
+	}
+	pool, err := s.meta.GetTenantPoolByOrganization(r.Context(), orgID)
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "tenant pool not found")
+			return nil, 0, false
+		}
+		errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
+		return nil, 0, false
+	}
+	freeSize, err := s.meta.CountFreeTenantPoolBindings(r.Context(), orgID)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "tenant pool free size lookup failed")
+		return nil, 0, false
+	}
+	return pool, freeSize, true
+}
+
+func (s *Server) firstManagedOrganization(ctx context.Context, cred tenant.CredentialProvisionRequest) (string, error) {
+	lister, ok := s.provisioner.(tenant.ManagedClusterLister)
+	if !ok {
+		return "", fmt.Errorf("managed cluster list not enabled")
+	}
+	page, err := lister.ListManagedClusters(ctx, cred, tenant.ManagedClusterListOptions{PageSize: 1})
+	if err != nil || page == nil || len(page.Clusters) == 0 {
+		return "", err
+	}
+	return strings.TrimSpace(page.Clusters[0].OrganizationID), nil
+}
+
+func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count int, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*provisionTenantResult, error) {
+	manager, ok := s.provisioner.(tenant.TenantPoolClusterManager)
+	if !ok {
+		return nil, fmt.Errorf("tenant pool provisioning not enabled")
+	}
+	if count <= 0 {
+		return []*provisionTenantResult{}, nil
+	}
+	provider := tenant.ProviderTiDBCloudNative
+	tenantIDs := make([]string, 0, count)
+	now := time.Now().UTC()
+	for i := 0; i < count; i++ {
+		tenantID := token.NewID()
+		if err := s.insertPendingPoolTenant(ctx, tenantID, provider, now); err != nil {
+			return nil, err
+		}
+		tenantIDs = append(tenantIDs, tenantID)
+	}
+	var opts tenant.QuotaUpdateOptions
+	if quotaOpt != nil {
+		opts.TiDBCloudSpendingLimitMonthly = quotaOpt.TiDBCloudSpendingLimit
+	}
+	clusters, _, err := manager.BatchProvisionFreeClustersWithCredentialsAndQuota(ctx, tenantIDs, cred, opts)
+	if err != nil {
+		s.cleanupPoolProvisionedClusters(ctx, clusters, cred, tenantIDs, "batch_provision_error")
+		for _, tenantID := range tenantIDs {
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+		}
+		return nil, err
+	}
+	cleanupOnError := true
+	defer func() {
+		if cleanupOnError {
+			s.cleanupPoolProvisionedClusters(ctx, clusters, cred, tenantIDs, "metadata_error")
+		}
+	}()
+	results := make([]*provisionTenantResult, 0, len(clusters))
+	cloudProvider, region := provisioningCloudRegion(s.provisioner)
+	for _, cluster := range clusters {
+		if cluster == nil {
+			continue
+		}
+		if strings.TrimSpace(cluster.OrganizationID) == "" {
+			return nil, fmt.Errorf("tidbcloud organization label is missing")
+		}
+		if err := s.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+			TenantID:       cluster.TenantID,
+			OrganizationID: cluster.OrganizationID,
+			ClusterID:      cluster.ClusterID,
+			PoolID:         poolID,
+			PoolStatus:     meta.TenantPoolBindingFree,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}); err != nil {
+			return nil, err
+		}
+		cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
+		if err != nil {
+			return nil, err
+		}
+		if err := s.meta.UpdateTenantConnection(ctx, cluster.TenantID, &meta.Tenant{
+			DBHost:           cluster.Host,
+			DBPort:           cluster.Port,
+			DBUser:           cluster.Username,
+			DBPasswordCipher: cipherPass,
+			DBName:           cluster.DBName,
+			DBTLS:            true,
+			Provider:         provider,
+			ClusterID:        cluster.ClusterID,
+		}); err != nil {
+			return nil, err
+		}
+		if err := s.meta.UpdateTenantStatus(ctx, cluster.TenantID, meta.TenantProvisioning); err != nil {
+			return nil, err
+		}
+		results = append(results, &provisionTenantResult{
+			TenantID:       cluster.TenantID,
+			Status:         meta.TenantProvisioning,
+			Provider:       provider,
+			TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true),
+			CloudProvider:  cloudProvider,
+			Region:         region,
+			OrganizationID: strings.TrimSpace(cluster.OrganizationID),
+		})
+	}
+	cleanupOnError = false
+	return results, nil
+}
+
+func (s *Server) cleanupPoolProvisionedClusters(ctx context.Context, clusters []*tenant.ClusterInfo, cred tenant.CredentialProvisionRequest, tenantIDs []string, reason string) {
+	cleanupCtx := backgroundWithTrace(ctx)
+	seenTenants := make(map[string]struct{}, len(tenantIDs)+len(clusters))
+	for _, tenantID := range tenantIDs {
+		tenantID = strings.TrimSpace(tenantID)
+		if tenantID == "" {
+			continue
+		}
+		seenTenants[tenantID] = struct{}{}
+		if err := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); err != nil {
+			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_mark_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
+		}
+	}
+	for _, cluster := range clusters {
+		if cluster == nil {
+			continue
+		}
+		tenantID := strings.TrimSpace(cluster.TenantID)
+		if tenantID != "" {
+			if _, ok := seenTenants[tenantID]; !ok {
+				if err := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); err != nil {
+					logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_mark_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
+				}
+			}
+		}
+		if strings.TrimSpace(cluster.ClusterID) == "" {
+			continue
+		}
+		t := &meta.Tenant{
+			ID:        tenantID,
+			Provider:  tenant.ProviderTiDBCloudNative,
+			ClusterID: strings.TrimSpace(cluster.ClusterID),
+			DBHost:    cluster.Host,
+			DBPort:    cluster.Port,
+			DBUser:    cluster.Username,
+			DBName:    cluster.DBName,
+		}
+		if err := s.deprovisionTenantCluster(cleanupCtx, t, cred); err != nil {
+			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_cluster_failed", zap.String("tenant_id", tenantID), zap.String("cluster_id", cluster.ClusterID), zap.String("reason", reason), zap.Error(err))
+		}
+	}
+}
+
+func (s *Server) insertPendingPoolTenant(ctx context.Context, tenantID, provider string, now time.Time) error {
+	autoProfile, err := s.defaultAutoEmbeddingProfileForTenant(ctx, tenantID, provider, now)
+	if err != nil {
+		return fmt.Errorf("build tenant auto-embedding profile: %w", err)
+	}
+	if err := s.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantPending,
+		DBHost:           "",
+		DBPort:           0,
+		DBUser:           "",
+		DBPasswordCipher: []byte{},
+		DBName:           "",
+		DBTLS:            true,
+		Provider:         provider,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		return fmt.Errorf("persist tenant: %w", err)
+	}
+	if autoProfile != nil {
+		if err := s.meta.UpsertTenantAutoEmbeddingProfile(ctx, autoProfile); err != nil {
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			return fmt.Errorf("persist tenant auto-embedding profile: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Server) deleteNewestFreePoolTenants(ctx context.Context, organizationID string, count int, cred tenant.CredentialProvisionRequest) error {
+	if count <= 0 {
+		return nil
+	}
+	remaining := count
+	for remaining > 0 {
+		rows, err := s.meta.ListFreeTenantPoolBindings(ctx, organizationID, true, remaining)
+		if err != nil {
+			return err
+		}
+		if len(rows) == 0 {
+			return fmt.Errorf("not enough free tenants to delete")
+		}
+		progressed := false
+		for _, row := range rows {
+			t := row.Tenant
+			updated, err := s.meta.MarkFreeTenantPoolTenantDeleting(ctx, t.ID, t.Status)
+			if err != nil {
+				return err
+			}
+			if !updated {
+				continue
+			}
+			progressed = true
+			if err := s.deprovisionTenantCluster(ctx, &t, cred); err != nil {
+				_, _ = s.meta.UpdateTenantStatusIf(context.Background(), t.ID, meta.TenantDeleting, t.Status)
+				return err
+			}
+			_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
+			if err := s.meta.MarkTenantDeleted(ctx, t.ID); err != nil {
+				_, _ = s.meta.UpdateTenantStatusIf(context.Background(), t.ID, meta.TenantDeleting, t.Status)
+				return err
+			}
+			remaining--
+			if remaining == 0 {
+				break
+			}
+		}
+		if !progressed {
+			return fmt.Errorf("not enough free tenants to delete")
+		}
+	}
+	return nil
+}
+
+func (s *Server) cleanupCreatedPoolTenants(ctx context.Context, results []*provisionTenantResult, cred tenant.CredentialProvisionRequest, reason string) {
+	cleanupCtx := backgroundWithTrace(ctx)
+	for _, res := range results {
+		if res == nil || strings.TrimSpace(res.TenantID) == "" {
+			continue
+		}
+		tenantID := strings.TrimSpace(res.TenantID)
+		t, err := s.meta.GetTenant(cleanupCtx, tenantID)
+		if err != nil {
+			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_get_tenant_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
+			continue
+		}
+		if err := s.deprovisionTenantCluster(cleanupCtx, t, cred); err != nil {
+			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_created_cluster_failed", zap.String("tenant_id", tenantID), zap.String("cluster_id", t.ClusterID), zap.String("reason", reason), zap.Error(err))
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			continue
+		}
+		_ = s.meta.RevokeTenantAPIKeys(cleanupCtx, tenantID)
+		if err := s.meta.MarkTenantDeleted(cleanupCtx, tenantID); err != nil {
+			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_mark_deleted_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
+		}
+	}
+}
+
+func (s *Server) deleteTenantPoolMetadata(ctx context.Context, poolID, reason string) {
+	if strings.TrimSpace(poolID) == "" {
+		return
+	}
+	cleanupCtx := backgroundWithTrace(ctx)
+	if err := s.meta.DeleteTenantPool(cleanupCtx, poolID); err != nil && !errors.Is(err, meta.ErrNotFound) {
+		logger.Warn(cleanupCtx, "admin_tenant_pool_delete_metadata_failed", zap.String("pool_id", poolID), zap.String("reason", reason), zap.Error(err))
+	}
+}
+
+func firstResultOrganizationID(results []*provisionTenantResult) string {
+	for _, res := range results {
+		if res != nil && strings.TrimSpace(res.OrganizationID) != "" {
+			return strings.TrimSpace(res.OrganizationID)
+		}
+	}
+	return ""
+}
+
+func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {
+	if pool == nil || pool.OrganizationID == "" || pool.Size <= 0 {
+		return
+	}
+	workerCtx := backgroundWithTrace(ctx)
+	s.startServerWorker(workerCtx, func(ctx context.Context) {
+		current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
+		if err != nil {
+			if !errors.Is(err, meta.ErrNotFound) {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
+			}
+			return
+		}
+		if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
+			return
+		}
+		freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
+		if err != nil {
+			logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+			return
+		}
+		missing := current.Size - freeSize
+		if missing <= 0 {
+			return
+		}
+		results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
+		if err != nil {
+			logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+			return
+		}
+		for _, res := range results {
+			s.startProvisionedTenantSchemaInit(ctx, res)
+		}
+	})
+}
+
+func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) (*provisionTenantResult, *meta.TenantPool, bool, error) {
+	manager, ok := s.provisioner.(tenant.TenantPoolClusterManager)
+	if !ok {
+		return nil, nil, false, nil
+	}
+	orgID, err := s.firstManagedOrganization(ctx, cred)
+	if err != nil || orgID == "" {
+		return nil, nil, false, err
+	}
+	pool, err := s.meta.GetTenantPoolByOrganization(ctx, orgID)
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			return nil, nil, false, nil
+		}
+		return nil, nil, false, err
+	}
+	if pool.Status != meta.TenantPoolActive {
+		return nil, nil, false, nil
+	}
+	row, err := s.meta.ClaimOldestFreeTenantPoolBinding(ctx, orgID)
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			return nil, pool, false, nil
+		}
+		return nil, nil, false, err
+	}
+	usedAt := time.Now().UTC()
+	var opts tenant.QuotaUpdateOptions
+	if quotaOpt != nil {
+		opts.TiDBCloudSpendingLimitMonthly = quotaOpt.TiDBCloudSpendingLimit
+	}
+	cluster := clusterInfoFromTenant(&row.Tenant)
+	if _, err := manager.MarkClusterPoolUsed(ctx, cluster, cred, usedAt, opts); err != nil {
+		s.releaseClaimedPoolTenant(ctx, manager, cluster, cred, row.Tenant.ID, "mark_used_error")
+		return nil, nil, false, err
+	}
+	success := false
+	defer func() {
+		if !success {
+			s.releaseClaimedPoolTenant(ctx, manager, cluster, cred, row.Tenant.ID, "claim_error")
+		}
+	}()
+	if quotaOpt != nil {
+		quotaReq := *quotaOpt
+		quotaReq.TenantID = row.Tenant.ID
+		if err := s.applyQuotaLocalConfig(ctx, row.Tenant.ID, quotaReq); err != nil {
+			return nil, nil, false, err
+		}
+	}
+	plainPass, err := s.pool.Decrypt(ctx, row.Tenant.DBPasswordCipher)
+	if err != nil {
+		return nil, nil, false, err
+	}
+	apiToken, apiKeyID, err := s.issueOwnerAPIKey(ctx, row.Tenant.ID, "default", 1, apiKeyIssueSource{})
+	if err != nil {
+		return nil, nil, false, err
+	}
+	cloudProvider, region := provisioningCloudRegion(s.provisioner)
+	success = true
+	return &provisionTenantResult{
+		TenantID:       row.Tenant.ID,
+		APIKey:         apiToken,
+		APIKeyID:       apiKeyID,
+		Status:         row.Tenant.Status,
+		Provider:       tenant.ProviderTiDBCloudNative,
+		TenantDSN:      tenantDSN(row.Tenant.DBUser, string(plainPass), row.Tenant.DBHost, row.Tenant.DBPort, row.Tenant.DBName, row.Tenant.DBTLS),
+		CloudProvider:  cloudProvider,
+		Region:         region,
+		OrganizationID: row.Binding.OrganizationID,
+	}, pool, true, nil
+}
+
+func (s *Server) releaseClaimedPoolTenant(ctx context.Context, manager tenant.TenantPoolClusterManager, cluster *tenant.ClusterInfo, cred tenant.CredentialProvisionRequest, tenantID, reason string) {
+	releaseCtx := backgroundWithTrace(ctx)
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" && cluster != nil {
+		tenantID = strings.TrimSpace(cluster.TenantID)
+	}
+	if tenantID != "" {
+		if err := s.meta.UpdateTenantPoolBindingStatus(releaseCtx, tenantID, meta.TenantPoolBindingFree, nil); err != nil {
+			logger.Warn(releaseCtx, "admin_tenant_pool_release_binding_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
+		}
+	}
+	if err := manager.MarkClusterPoolFree(releaseCtx, cluster, cred); err != nil {
+		clusterID := ""
+		if cluster != nil {
+			clusterID = cluster.ClusterID
+		}
+		logger.Warn(releaseCtx, "admin_tenant_pool_release_cluster_failed", zap.String("tenant_id", tenantID), zap.String("cluster_id", clusterID), zap.String("reason", reason), zap.Error(err))
+	}
+}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"go.uber.org/zap"
@@ -19,7 +20,7 @@ import (
 type adminTenantPoolRequest struct {
 	PublicKey  string `json:"public_key"`
 	PrivateKey string `json:"private_key"`
-	PoolSize   int    `json:"pool_size"`
+	PoolSize   *int   `json:"pool_size,omitempty"`
 	quotaFields
 }
 
@@ -58,7 +59,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if req.PoolSize <= 0 {
+	if req.PoolSize == nil || *req.PoolSize <= 0 {
 		errJSON(w, http.StatusBadRequest, "pool_size must be positive")
 		return
 	}
@@ -92,10 +93,11 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 	}
 	poolID := token.NewID()
 	now := time.Now().UTC()
-	if err := s.meta.UpsertTenantPool(r.Context(), &meta.TenantPool{
+	if err := s.meta.CreateTenantPool(r.Context(), &meta.TenantPool{
 		PoolID:         poolID,
 		OrganizationID: orgID,
-		Size:           req.PoolSize,
+		Size:           *req.PoolSize,
+		SpendingLimit:  quotaReq.TiDBCloudSpendingLimit,
 		Status:         meta.TenantPoolActive,
 		CreatedAt:      now,
 		UpdatedAt:      now,
@@ -107,7 +109,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusInternalServerError, "failed to persist tenant pool")
 		return
 	}
-	results, err := s.createFreePoolTenants(r.Context(), poolID, req.PoolSize, cred, quotaOpt)
+	results, err := s.createFreePoolTenants(r.Context(), poolID, *req.PoolSize, cred, quotaOpt)
 	if err != nil {
 		s.deleteTenantPoolMetadata(r.Context(), poolID, "create_free_tenants_error")
 		errJSON(w, http.StatusBadGateway, fmt.Sprintf("create tenant pool failed: %v", err))
@@ -140,7 +142,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
 		PoolID:         poolID,
 		OrganizationID: orgID,
-		PoolSize:       req.PoolSize,
+		PoolSize:       *req.PoolSize,
 		FreeSize:       freeSize,
 		Status:         string(meta.TenantPoolActive),
 	})
@@ -171,8 +173,8 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if req.PoolSize < 0 {
-		errJSON(w, http.StatusBadRequest, "pool_size must be non-negative")
+	if req.PoolSize != nil && *req.PoolSize <= 0 {
+		errJSON(w, http.StatusBadRequest, "pool_size must be positive")
 		return
 	}
 	cred, err := adminCredentials(req.PublicKey, req.PrivateKey, r)
@@ -180,8 +182,24 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	pool, freeSize, ok := s.authorizedTenantPool(w, r, cred)
+	pool, _, ok := s.authorizedTenantPool(w, r, cred)
 	if !ok {
+		return
+	}
+	lock := s.tenantPoolLock(pool.PoolID)
+	lock.Lock()
+	defer lock.Unlock()
+	if pool, err = s.meta.GetTenantPoolByID(r.Context(), pool.PoolID); err != nil {
+		errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
+		return
+	}
+	if pool.Status != meta.TenantPoolActive {
+		errJSON(w, http.StatusConflict, "tenant pool is not active")
+		return
+	}
+	freeSize, err := s.meta.CountFreeTenantPoolBindings(r.Context(), pool.OrganizationID)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "tenant pool free size lookup failed")
 		return
 	}
 	quotaReq := quotaRequest{TenantID: "pool", quotaFields: req.quotaFields}
@@ -193,31 +211,35 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		}
 		quotaOpt = &quotaReq
 	}
-	if req.PoolSize > freeSize {
-		results, err := s.createFreePoolTenants(r.Context(), pool.PoolID, req.PoolSize-freeSize, cred, quotaOpt)
-		if err != nil {
-			errJSON(w, http.StatusBadGateway, fmt.Sprintf("grow tenant pool failed: %v", err))
-			return
+	targetSize := pool.Size
+	if req.PoolSize != nil {
+		targetSize = *req.PoolSize
+		if targetSize > freeSize {
+			results, err := s.createFreePoolTenants(r.Context(), pool.PoolID, targetSize-freeSize, cred, quotaOpt)
+			if err != nil {
+				errJSON(w, http.StatusBadGateway, fmt.Sprintf("grow tenant pool failed: %v", err))
+				return
+			}
+			for _, res := range results {
+				s.startProvisionedTenantSchemaInit(r.Context(), res)
+			}
+			freeSize += len(results)
+		} else if targetSize < freeSize {
+			if err := s.deleteNewestFreePoolTenants(r.Context(), pool.OrganizationID, freeSize-targetSize, cred, false); err != nil {
+				errJSON(w, http.StatusBadGateway, fmt.Sprintf("shrink tenant pool failed: %v", err))
+				return
+			}
+			freeSize = targetSize
 		}
-		for _, res := range results {
-			s.startProvisionedTenantSchemaInit(r.Context(), res)
-		}
-		freeSize += len(results)
-	} else if req.PoolSize < freeSize {
-		if err := s.deleteNewestFreePoolTenants(r.Context(), pool.OrganizationID, freeSize-req.PoolSize, cred); err != nil {
-			errJSON(w, http.StatusBadGateway, fmt.Sprintf("shrink tenant pool failed: %v", err))
-			return
-		}
-		freeSize = req.PoolSize
 	}
-	if err := s.meta.UpdateTenantPoolSize(r.Context(), pool.PoolID, req.PoolSize); err != nil {
+	if err := s.meta.UpdateTenantPoolSettings(r.Context(), pool.PoolID, req.PoolSize, quotaReq.TiDBCloudSpendingLimit); err != nil {
 		errJSON(w, http.StatusInternalServerError, "failed to update tenant pool")
 		return
 	}
 	writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
 		PoolID:         pool.PoolID,
 		OrganizationID: pool.OrganizationID,
-		PoolSize:       req.PoolSize,
+		PoolSize:       targetSize,
 		FreeSize:       freeSize,
 		Status:         string(pool.Status),
 	})
@@ -237,11 +259,18 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	pool, freeSize, ok := s.authorizedTenantPool(w, r, cred)
+	pool, _, ok := s.authorizedTenantPool(w, r, cred)
 	if !ok {
 		return
 	}
-	if err := s.deleteNewestFreePoolTenants(r.Context(), pool.OrganizationID, freeSize, cred); err != nil {
+	lock := s.tenantPoolLock(pool.PoolID)
+	lock.Lock()
+	defer lock.Unlock()
+	if err := s.meta.UpdateTenantPoolStatus(r.Context(), pool.PoolID, meta.TenantPoolDeleting); err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to mark tenant pool deleting")
+		return
+	}
+	if err := s.deleteNewestFreePoolTenants(r.Context(), pool.OrganizationID, 0, cred, true); err != nil {
 		errJSON(w, http.StatusBadGateway, fmt.Sprintf("delete tenant pool failed: %v", err))
 		return
 	}
@@ -311,6 +340,7 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 	for i := 0; i < count; i++ {
 		tenantID := token.NewID()
 		if err := s.insertPendingPoolTenant(ctx, tenantID, provider, now); err != nil {
+			s.cleanupPoolProvisionedClusters(ctx, nil, cred, tenantIDs, "insert_pending_tenant_error")
 			return nil, err
 		}
 		tenantIDs = append(tenantIDs, tenantID)
@@ -376,7 +406,7 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			TenantID:       cluster.TenantID,
 			Status:         meta.TenantProvisioning,
 			Provider:       provider,
-			TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true),
+			TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true, provider),
 			CloudProvider:  cloudProvider,
 			Region:         region,
 			OrganizationID: strings.TrimSpace(cluster.OrganizationID),
@@ -389,15 +419,13 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 func (s *Server) cleanupPoolProvisionedClusters(ctx context.Context, clusters []*tenant.ClusterInfo, cred tenant.CredentialProvisionRequest, tenantIDs []string, reason string) {
 	cleanupCtx := backgroundWithTrace(ctx)
 	seenTenants := make(map[string]struct{}, len(tenantIDs)+len(clusters))
+	deprovisionFailed := make(map[string]struct{}, len(clusters))
 	for _, tenantID := range tenantIDs {
 		tenantID = strings.TrimSpace(tenantID)
 		if tenantID == "" {
 			continue
 		}
 		seenTenants[tenantID] = struct{}{}
-		if err := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); err != nil {
-			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_mark_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
-		}
 	}
 	for _, cluster := range clusters {
 		if cluster == nil {
@@ -424,7 +452,23 @@ func (s *Server) cleanupPoolProvisionedClusters(ctx context.Context, clusters []
 			DBName:    cluster.DBName,
 		}
 		if err := s.deprovisionTenantCluster(cleanupCtx, t, cred); err != nil {
+			if tenantID != "" {
+				deprovisionFailed[tenantID] = struct{}{}
+			}
 			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_cluster_failed", zap.String("tenant_id", tenantID), zap.String("cluster_id", cluster.ClusterID), zap.String("reason", reason), zap.Error(err))
+		}
+	}
+	for tenantID := range seenTenants {
+		if _, failed := deprovisionFailed[tenantID]; failed {
+			if err := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); err != nil {
+				logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_mark_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
+			}
+			continue
+		}
+		_ = s.meta.RevokeTenantAPIKeys(cleanupCtx, tenantID)
+		if err := s.meta.MarkTenantDeleted(cleanupCtx, tenantID); err != nil {
+			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_mark_deleted_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 		}
 	}
 }
@@ -459,17 +503,30 @@ func (s *Server) insertPendingPoolTenant(ctx context.Context, tenantID, provider
 	return nil
 }
 
-func (s *Server) deleteNewestFreePoolTenants(ctx context.Context, organizationID string, count int, cred tenant.CredentialProvisionRequest) error {
-	if count <= 0 {
+func (s *Server) deleteNewestFreePoolTenants(ctx context.Context, organizationID string, count int, cred tenant.CredentialProvisionRequest, deleteAll bool) error {
+	if count <= 0 && !deleteAll {
 		return nil
 	}
 	remaining := count
-	for remaining > 0 {
-		rows, err := s.meta.ListFreeTenantPoolBindings(ctx, organizationID, true, remaining)
+	for deleteAll || remaining > 0 {
+		limit := remaining
+		if deleteAll {
+			limit = 100
+		}
+		var rows []meta.TenantWithTiDBCloudOrgBinding
+		var err error
+		if deleteAll {
+			rows, err = s.meta.ListFreeTenantPoolBindingsForDelete(ctx, organizationID, true, limit)
+		} else {
+			rows, err = s.meta.ListFreeTenantPoolBindings(ctx, organizationID, true, limit)
+		}
 		if err != nil {
 			return err
 		}
 		if len(rows) == 0 {
+			if deleteAll {
+				return nil
+			}
 			return fmt.Errorf("not enough free tenants to delete")
 		}
 		progressed := false
@@ -489,11 +546,13 @@ func (s *Server) deleteNewestFreePoolTenants(ctx context.Context, organizationID
 			}
 			_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
 			if err := s.meta.MarkTenantDeleted(ctx, t.ID); err != nil {
-				_, _ = s.meta.UpdateTenantStatusIf(context.Background(), t.ID, meta.TenantDeleting, t.Status)
+				_ = s.meta.UpdateTenantStatus(context.Background(), t.ID, meta.TenantFailed)
 				return err
 			}
-			remaining--
-			if remaining == 0 {
+			if !deleteAll {
+				remaining--
+			}
+			if !deleteAll && remaining == 0 {
 				break
 			}
 		}
@@ -553,6 +612,9 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 	}
 	workerCtx := backgroundWithTrace(ctx)
 	s.startServerWorker(workerCtx, func(ctx context.Context) {
+		lock := s.tenantPoolLock(pool.PoolID)
+		lock.Lock()
+		defer lock.Unlock()
 		current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
 		if err != nil {
 			if !errors.Is(err, meta.ErrNotFound) {
@@ -572,7 +634,7 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 		if missing <= 0 {
 			return
 		}
-		results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
+		results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, tenantPoolQuotaRequest(current))
 		if err != nil {
 			logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
 			return
@@ -581,6 +643,26 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			s.startProvisionedTenantSchemaInit(ctx, res)
 		}
 	})
+}
+
+func (s *Server) tenantPoolLock(poolID string) *sync.Mutex {
+	if strings.TrimSpace(poolID) == "" {
+		return &sync.Mutex{}
+	}
+	v, _ := s.tenantPoolLocks.LoadOrStore(poolID, &sync.Mutex{})
+	return v.(*sync.Mutex)
+}
+
+func tenantPoolQuotaRequest(pool *meta.TenantPool) *quotaRequest {
+	if pool == nil || pool.SpendingLimit == nil {
+		return nil
+	}
+	return &quotaRequest{
+		TenantID: "pool",
+		quotaFields: quotaFields{
+			TiDBCloudSpendingLimit: pool.SpendingLimit,
+		},
+	}
 }
 
 func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) (*provisionTenantResult, *meta.TenantPool, bool, error) {
@@ -648,7 +730,7 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		APIKeyID:       apiKeyID,
 		Status:         row.Tenant.Status,
 		Provider:       tenant.ProviderTiDBCloudNative,
-		TenantDSN:      tenantDSN(row.Tenant.DBUser, string(plainPass), row.Tenant.DBHost, row.Tenant.DBPort, row.Tenant.DBName, row.Tenant.DBTLS),
+		TenantDSN:      tenantDSN(row.Tenant.DBUser, string(plainPass), row.Tenant.DBHost, row.Tenant.DBPort, row.Tenant.DBName, row.Tenant.DBTLS, row.Tenant.Provider),
 		CloudProvider:  cloudProvider,
 		Region:         region,
 		OrganizationID: row.Binding.OrganizationID,

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -172,6 +172,9 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		return
 	} else if claimed {
 		setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+		if res.Status == meta.TenantProvisioning {
+			s.startProvisionedTenantSchemaInit(r.Context(), res)
+		}
 		s.replenishTenantPoolAsync(r.Context(), pool, cred)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -167,10 +168,14 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		}
 		quotaOpt = &quotaReq
 	}
+	poolClaimStarted := time.Now()
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_started", "provider", tenant.ProviderTiDBCloudNative, "quota_requested", quotaOpt != nil)...)
 	if res, pool, claimed, err := s.claimAdminTenantFromPool(r.Context(), cred, quotaOpt); err != nil {
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_failed", "provider", tenant.ProviderTiDBCloudNative, "duration_ms", durationMillis(poolClaimStarted), "error", err)...)
 		errJSON(w, http.StatusBadGateway, fmt.Sprintf("claim tenant pool tenant failed: %v", err))
 		return
 	} else if claimed {
+		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
 		setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
 		if res.Status == meta.TenantProvisioning {
 			s.startProvisionedTenantSchemaInit(r.Context(), res)
@@ -185,8 +190,10 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 			CloudProvider: res.CloudProvider,
 			Region:        res.Region,
 		})
+		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_create_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted))...)
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_missed", "provider", tenant.ProviderTiDBCloudNative, "duration_ms", durationMillis(poolClaimStarted))...)
 	res, err := s.provisionTenant(r.Context(), provisionTenantOptions{
 		KeyName:               "default",
 		TokenVersion:          1,

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -167,6 +167,23 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		}
 		quotaOpt = &quotaReq
 	}
+	if res, pool, claimed, err := s.claimAdminTenantFromPool(r.Context(), cred, quotaOpt); err != nil {
+		errJSON(w, http.StatusBadGateway, fmt.Sprintf("claim tenant pool tenant failed: %v", err))
+		return
+	} else if claimed {
+		setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+		s.replenishTenantPoolAsync(r.Context(), pool, cred)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(adminTenantCreateResponse{
+			TenantID:      res.TenantID,
+			APIKey:        res.APIKey,
+			Status:        string(res.Status),
+			CloudProvider: res.CloudProvider,
+			Region:        res.Region,
+		})
+		return
+	}
 	res, err := s.provisionTenant(r.Context(), provisionTenantOptions{
 		KeyName:               "default",
 		TokenVersion:          1,
@@ -420,6 +437,10 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 			return nil, nil, nil, false
 		}
 		errJSON(w, http.StatusInternalServerError, "tenant organization binding lookup failed")
+		return nil, nil, nil, false
+	}
+	if binding.PoolStatus == meta.TenantPoolBindingFree {
+		errJSON(w, http.StatusNotFound, "tenant not found")
 		return nil, nil, nil, false
 	}
 	clusters, err := s.listAllManagedClusters(r.Context(), cred, binding.ClusterID)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -32,6 +32,7 @@ type quotaTestProvisioner struct {
 	defaultPublicKey  string
 	defaultPrivateKey string
 	markHook          func() error
+	deprovisionHook   func(call int, cluster *tenant.ClusterInfo) error
 	updateCalls       atomic.Int32
 	markCalls         atomic.Int32
 	getCalls          atomic.Int32
@@ -124,12 +125,17 @@ func (p *quotaTestProvisioner) GetQuota(_ context.Context, cluster *tenant.Clust
 }
 
 func (p *quotaTestProvisioner) DeprovisionWithCredentials(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) error {
-	p.deprovisionCalls.Add(1)
+	call := int(p.deprovisionCalls.Add(1))
 	p.calls = append(p.calls, "deprovision")
 	p.lastCredentials = req
 	if cluster != nil {
 		out := *cluster
 		p.lastDeprovision = &out
+	}
+	if p.deprovisionHook != nil {
+		if err := p.deprovisionHook(call, cluster); err != nil {
+			return err
+		}
 	}
 	return p.deprovisionErr
 }
@@ -1477,6 +1483,111 @@ func TestAdminTenantPoolUpdateRequiresPoolSize(t *testing.T) {
 	}
 	if pool.Size != 2 {
 		t.Fatalf("pool size = %d, want 2", pool.Size)
+	}
+}
+
+func TestAdminTenantPoolUpdateShrinkPartialFailureReconcilesSize(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{
+			ClusterID:      "cluster-free-1",
+			OrganizationID: "org-1",
+		}},
+	}}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           3,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	for i := 1; i <= 3; i++ {
+		tenantID := fmt.Sprintf("pool-tenant-shrink-%d", i)
+		clusterID := fmt.Sprintf("cluster-free-%d", i)
+		createdAt := now.Add(time.Duration(i) * time.Minute)
+		if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+			ID:               tenantID,
+			Status:           meta.TenantActive,
+			DBHost:           "db.example.com",
+			DBPort:           4000,
+			DBUser:           "u.root",
+			DBPasswordCipher: []byte("cipher"),
+			DBName:           "tidbcloud_fs",
+			DBTLS:            true,
+			Provider:         tenant.ProviderTiDBCloudNative,
+			ClusterID:        clusterID,
+			SchemaVersion:    1,
+			CreatedAt:        createdAt,
+			UpdatedAt:        createdAt,
+		}); err != nil {
+			t.Fatalf("insert tenant %s: %v", tenantID, err)
+		}
+		if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+			TenantID:       tenantID,
+			OrganizationID: "org-1",
+			ClusterID:      clusterID,
+			PoolID:         "pool-1",
+			PoolStatus:     meta.TenantPoolBindingFree,
+			CreatedAt:      createdAt,
+			UpdatedAt:      createdAt,
+		}); err != nil {
+			t.Fatalf("upsert binding %s: %v", tenantID, err)
+		}
+	}
+	rt.prov.deprovisionHook = func(call int, _ *tenant.ClusterInfo) error {
+		if call == 2 {
+			return fmt.Errorf("tidbcloud deprovision failed")
+		}
+		return nil
+	}
+
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	resp := patchJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+		"pool_size":   1,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 502 body=%s", resp.StatusCode, body)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 2 {
+		t.Fatalf("deprovision calls = %d, want 2", got)
+	}
+	pool, err := rt.meta.GetTenantPoolByID(ctx, "pool-1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if pool.Size != 2 {
+		t.Fatalf("pool size = %d, want reconciled actual free size 2", pool.Size)
+	}
+	free, err := rt.meta.CountFreeTenantPoolBindings(ctx, "org-1")
+	if err != nil {
+		t.Fatalf("count free: %v", err)
+	}
+	if free != 2 {
+		t.Fatalf("free size = %d, want 2", free)
+	}
+	deleted, err := rt.meta.GetTenant(ctx, "pool-tenant-shrink-3")
+	if err != nil {
+		t.Fatalf("get deleted tenant: %v", err)
+	}
+	if deleted.Status != meta.TenantDeleted {
+		t.Fatalf("newest tenant status = %s, want %s", deleted.Status, meta.TenantDeleted)
+	}
+	reverted, err := rt.meta.GetTenant(ctx, "pool-tenant-shrink-2")
+	if err != nil {
+		t.Fatalf("get reverted tenant: %v", err)
+	}
+	if reverted.Status != meta.TenantActive {
+		t.Fatalf("failed tenant status = %s, want %s", reverted.Status, meta.TenantActive)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1470,9 +1470,15 @@ func TestAdminTenantPoolUpdateRequiresPoolSize(t *testing.T) {
 		"private_key": "private-1",
 	}, "")
 	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
 	if resp.StatusCode != http.StatusBadRequest {
-		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 400 body=%s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), "pool_size is required") {
+		t.Fatalf("body = %s, want pool_size validation error", body)
 	}
 	if got := rt.prov.batchPoolCalls.Load(); got != 0 {
 		t.Fatalf("batch pool calls = %d, want 0", got)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1361,7 +1361,7 @@ func TestAdminTenantPoolCreateCleansUpWhenOrganizationBackfillConflicts(t *testi
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
 	ctx := context.Background()
 	now := time.Now().UTC()
-	if err := rt.meta.UpsertTenantPool(ctx, &meta.TenantPool{
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
 		PoolID:         "existing-pool",
 		OrganizationID: "org-1",
 		Size:           1,
@@ -1418,7 +1418,7 @@ func TestAdminTenantPoolReplenishSkipsDeletedOrShrunkPool(t *testing.T) {
 		CreatedAt:      now,
 		UpdatedAt:      now,
 	}
-	if err := rt.meta.UpsertTenantPool(ctx, stalePool); err != nil {
+	if err := rt.meta.CreateTenantPool(ctx, stalePool); err != nil {
 		t.Fatalf("upsert pool: %v", err)
 	}
 	if err := rt.meta.UpdateTenantPoolSize(ctx, stalePool.PoolID, 0); err != nil {
@@ -1436,6 +1436,83 @@ func TestAdminTenantPoolReplenishSkipsDeletedOrShrunkPool(t *testing.T) {
 	}
 }
 
+func TestAdminTenantPoolUpdateQuotaOnlyDoesNotResize(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{
+			ClusterID:      "cluster-1",
+			OrganizationID: "org-1",
+		}},
+	}}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           2,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	resp := patchJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":               "public-1",
+		"private_key":              "private-1",
+		"tidbcloud_spending_limit": 9000,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	if got := rt.prov.batchPoolCalls.Load(); got != 0 {
+		t.Fatalf("batch pool calls = %d, want 0", got)
+	}
+	pool, err := rt.meta.GetTenantPoolByID(ctx, "pool-1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if pool.Size != 2 || pool.SpendingLimit == nil || *pool.SpendingLimit != 9000 {
+		t.Fatalf("pool = %#v, want size 2 and spending limit 9000", pool)
+	}
+}
+
+func TestAdminTenantPoolReplenishUsesStoredSpendingLimit(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	limit := int64(7000)
+	pool := &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           1,
+		SpendingLimit:  &limit,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	rt.server.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	rt.server.forkWorkerWG.Wait()
+
+	if got := rt.prov.batchPoolCalls.Load(); got != 1 {
+		t.Fatalf("batch pool calls = %d, want 1", got)
+	}
+	if rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly == nil || *rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly != limit {
+		t.Fatalf("replenish spending limit = %#v, want %d", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly, limit)
+	}
+}
+
 func TestAdminTenantCreateDoesNotIssueAPIKeyWhenPoolPasswordDecryptFails(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
@@ -1446,7 +1523,7 @@ func TestAdminTenantCreateDoesNotIssueAPIKeyWhenPoolPasswordDecryptFails(t *test
 	}}
 	ctx := context.Background()
 	now := time.Now().UTC()
-	if err := rt.meta.UpsertTenantPool(ctx, &meta.TenantPool{
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
 		PoolID:         "pool-1",
 		OrganizationID: "org-1",
 		Size:           1,
@@ -1523,7 +1600,7 @@ func TestAdminTenantCreateClaimsFreePoolTenant(t *testing.T) {
 	}}
 	ctx := context.Background()
 	now := time.Now().UTC()
-	if err := rt.meta.UpsertTenantPool(ctx, &meta.TenantPool{
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
 		PoolID:         "pool-1",
 		OrganizationID: "org-1",
 		Size:           0,
@@ -1856,11 +1933,21 @@ func TestAdminPaginationRejectsOffsetOverflow(t *testing.T) {
 
 func postJSON(t *testing.T, url string, body map[string]any, apiKey string) *http.Response {
 	t.Helper()
+	return sendJSON(t, http.MethodPost, url, body, apiKey)
+}
+
+func patchJSON(t *testing.T, url string, body map[string]any, apiKey string) *http.Response {
+	t.Helper()
+	return sendJSON(t, http.MethodPatch, url, body, apiKey)
+}
+
+func sendJSON(t *testing.T, method, url string, body map[string]any, apiKey string) *http.Response {
+	t.Helper()
 	raw, err := json.Marshal(body)
 	if err != nil {
 		t.Fatal(err)
 	}
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(raw))
+	req, err := http.NewRequest(method, url, bytes.NewReader(raw))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1436,7 +1436,7 @@ func TestAdminTenantPoolReplenishSkipsDeletedOrShrunkPool(t *testing.T) {
 	}
 }
 
-func TestAdminTenantPoolUpdateQuotaOnlyDoesNotResize(t *testing.T) {
+func TestAdminTenantPoolUpdateRequiresPoolSize(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
 		Clusters: []tenant.CloudClusterInfo{{
@@ -1460,14 +1460,13 @@ func TestAdminTenantPoolUpdateQuotaOnlyDoesNotResize(t *testing.T) {
 	ts := httptest.NewServer(rt.server)
 	t.Cleanup(ts.Close)
 	resp := patchJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
-		"public_key":               "public-1",
-		"private_key":              "private-1",
-		"tidbcloud_spending_limit": 9000,
+		"public_key":  "public-1",
+		"private_key": "private-1",
 	}, "")
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusAccepted {
+	if resp.StatusCode != http.StatusBadRequest {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+		t.Fatalf("status = %d, want 400 body=%s", resp.StatusCode, body)
 	}
 	if got := rt.prov.batchPoolCalls.Load(); got != 0 {
 		t.Fatalf("batch pool calls = %d, want 0", got)
@@ -1476,21 +1475,19 @@ func TestAdminTenantPoolUpdateQuotaOnlyDoesNotResize(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get pool: %v", err)
 	}
-	if pool.Size != 2 || pool.SpendingLimit == nil || *pool.SpendingLimit != 9000 {
-		t.Fatalf("pool = %#v, want size 2 and spending limit 9000", pool)
+	if pool.Size != 2 {
+		t.Fatalf("pool size = %d, want 2", pool.Size)
 	}
 }
 
-func TestAdminTenantPoolReplenishUsesStoredSpendingLimit(t *testing.T) {
+func TestAdminTenantPoolReplenishUsesDefaultSpendingLimit(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
 	now := time.Now().UTC()
-	limit := int64(7000)
 	pool := &meta.TenantPool{
 		PoolID:         "pool-1",
 		OrganizationID: "org-1",
 		Size:           1,
-		SpendingLimit:  &limit,
 		Status:         meta.TenantPoolActive,
 		CreatedAt:      now,
 		UpdatedAt:      now,
@@ -1508,8 +1505,8 @@ func TestAdminTenantPoolReplenishUsesStoredSpendingLimit(t *testing.T) {
 	if got := rt.prov.batchPoolCalls.Load(); got != 1 {
 		t.Fatalf("batch pool calls = %d, want 1", got)
 	}
-	if rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly == nil || *rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly != limit {
-		t.Fatalf("replenish spending limit = %#v, want %d", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly, limit)
+	if rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly != nil {
+		t.Fatalf("replenish spending limit = %#v, want nil", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -37,6 +37,9 @@ type quotaTestProvisioner struct {
 	getCalls          atomic.Int32
 	listCalls         atomic.Int32
 	deprovisionCalls  atomic.Int32
+	batchPoolCalls    atomic.Int32
+	markPoolUsedCalls atomic.Int32
+	markPoolFreeCalls atomic.Int32
 	lastCluster       *tenant.ClusterInfo
 	lastCredentials   tenant.CredentialProvisionRequest
 	lastOptions       tenant.QuotaUpdateOptions
@@ -64,6 +67,10 @@ func (p *quotaTestProvisioner) Provision(context.Context, string) (*tenant.Clust
 }
 
 func (p *quotaTestProvisioner) InitSchema(context.Context, string) error { return nil }
+
+func (p *quotaTestProvisioner) EnsureSystemUser(context.Context, string, string) (string, string, error) {
+	return "u.tdc_fs_sys", "pool-pass", nil
+}
 
 func (p *quotaTestProvisioner) UpdateQuota(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
 	p.updateCalls.Add(1)
@@ -143,6 +150,51 @@ func (p *quotaTestProvisioner) ListManagedClusters(_ context.Context, req tenant
 		return &tenant.ManagedClusterListResult{}, nil
 	}
 	return p.listPages[idx], nil
+}
+
+func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(_ context.Context, tenantIDs []string, req tenant.CredentialProvisionRequest, opts tenant.QuotaUpdateOptions) ([]*tenant.ClusterInfo, *tenant.QuotaCloudConfig, error) {
+	p.batchPoolCalls.Add(1)
+	p.calls = append(p.calls, "batch_pool")
+	p.lastCredentials = req
+	p.lastOptions = opts
+	out := make([]*tenant.ClusterInfo, 0, len(tenantIDs))
+	for i, tenantID := range tenantIDs {
+		out = append(out, &tenant.ClusterInfo{
+			TenantID:       tenantID,
+			ClusterID:      fmt.Sprintf("pool-cluster-%d", i+1),
+			OrganizationID: "org-1",
+			Host:           "db.example.com",
+			Port:           4000,
+			Username:       "u.root",
+			Password:       "pool-pass",
+			DBName:         "tidbcloud_fs",
+			Provider:       tenant.ProviderTiDBCloudNative,
+		})
+	}
+	return out, nil, nil
+}
+
+func (p *quotaTestProvisioner) MarkClusterPoolUsed(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, _ time.Time, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
+	p.markPoolUsedCalls.Add(1)
+	p.calls = append(p.calls, "mark_pool_used")
+	p.lastCredentials = req
+	p.lastOptions = opts
+	if cluster != nil {
+		out := *cluster
+		p.lastCluster = &out
+	}
+	return &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: opts.TiDBCloudSpendingLimitMonthly}, nil
+}
+
+func (p *quotaTestProvisioner) MarkClusterPoolFree(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) error {
+	p.markPoolFreeCalls.Add(1)
+	p.calls = append(p.calls, "mark_pool_free")
+	p.lastCredentials = req
+	if cluster != nil {
+		out := *cluster
+		p.lastCluster = &out
+	}
+	return nil
 }
 
 type quotaRuntime struct {
@@ -956,9 +1008,42 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	freeTenantID := "tenant-free-pool"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               freeTenantID,
+		Status:           meta.TenantActive,
+		Kind:             meta.TenantKindLive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_db_free",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-free",
+		SchemaVersion:    1,
+		CreatedAt:        now.Add(2 * time.Second),
+		UpdatedAt:        now.Add(2 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       freeTenantID,
+		OrganizationID: "org-1",
+		ClusterID:      "cluster-free",
+		PoolID:         "pool-1",
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
 		Clusters: []tenant.CloudClusterInfo{{
 			ClusterID:      "cluster-allowed",
+			OrganizationID: "org-1",
+		}, {
+			ClusterID:      "cluster-free",
 			OrganizationID: "org-1",
 		}},
 	}}
@@ -986,6 +1071,69 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	}
 	if len(out.Tenants) != 1 || out.Tenants[0].TenantID != rt.tenantID {
 		t.Fatalf("tenants = %#v, want only authorized tenant %s", out.Tenants, rt.tenantID)
+	}
+}
+
+func TestAdminTenantGetHidesFreePoolTenant(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	freeTenantID := "tenant-free-pool"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               freeTenantID,
+		Status:           meta.TenantActive,
+		Kind:             meta.TenantKindLive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_db_free",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-free",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       freeTenantID,
+		OrganizationID: "org-1",
+		ClusterID:      "cluster-free",
+		PoolID:         "pool-1",
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{
+			ClusterID:      "cluster-free",
+			OrganizationID: "org-1",
+		}},
+	}}
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/admin/tenants/"+freeTenantID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set(quotaPublicKeyHeader, "public-1")
+	req.Header.Set(quotaPrivateKeyHeader, "private-1")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 404: %s", resp.StatusCode, body)
+	}
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("list calls = %d, want 0 because free tenant is rejected before cloud lookup", got)
 	}
 }
 
@@ -1163,6 +1311,303 @@ func TestAdminTenantQuotaGetIsNotExposed(t *testing.T) {
 	}
 	if got := rt.prov.markCalls.Load(); got != 0 {
 		t.Fatalf("mark calls = %d, want 0", got)
+	}
+}
+
+func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+
+	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+		"pool_size":   2,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var out adminTenantPoolResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 2 {
+		t.Fatalf("pool response = %#v", out)
+	}
+	if rt.prov.batchPoolCalls.Load() != 1 {
+		t.Fatalf("batch pool calls = %d, want 1", rt.prov.batchPoolCalls.Load())
+	}
+	pool, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if pool.PoolID != out.PoolID || pool.Size != 2 {
+		t.Fatalf("stored pool = %#v", pool)
+	}
+	free, err := rt.meta.CountFreeTenantPoolBindings(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("count free: %v", err)
+	}
+	if free != 2 {
+		t.Fatalf("free = %d, want 2", free)
+	}
+}
+
+func TestAdminTenantPoolCreateCleansUpWhenOrganizationBackfillConflicts(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.UpsertTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "existing-pool",
+		OrganizationID: "org-1",
+		Size:           1,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert existing pool: %v", err)
+	}
+
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+		"pool_size":   2,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, body)
+	}
+	if got := rt.prov.batchPoolCalls.Load(); got != 1 {
+		t.Fatalf("batch pool calls = %d, want 1", got)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 2 {
+		t.Fatalf("deprovision calls = %d, want 2", got)
+	}
+	free, err := rt.meta.CountFreeTenantPoolBindings(ctx, "org-1")
+	if err != nil {
+		t.Fatalf("count free: %v", err)
+	}
+	if free != 0 {
+		t.Fatalf("free = %d, want 0 after cleanup", free)
+	}
+	pool, err := rt.meta.GetTenantPoolByOrganization(ctx, "org-1")
+	if err != nil {
+		t.Fatalf("get existing pool: %v", err)
+	}
+	if pool.PoolID != "existing-pool" {
+		t.Fatalf("pool id = %q, want existing-pool", pool.PoolID)
+	}
+}
+
+func TestAdminTenantPoolReplenishSkipsDeletedOrShrunkPool(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	stalePool := &meta.TenantPool{
+		PoolID:         "pool-stale",
+		OrganizationID: "org-1",
+		Size:           2,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := rt.meta.UpsertTenantPool(ctx, stalePool); err != nil {
+		t.Fatalf("upsert pool: %v", err)
+	}
+	if err := rt.meta.UpdateTenantPoolSize(ctx, stalePool.PoolID, 0); err != nil {
+		t.Fatalf("shrink pool: %v", err)
+	}
+
+	rt.server.replenishTenantPoolAsync(ctx, stalePool, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	rt.server.forkWorkerWG.Wait()
+
+	if got := rt.prov.batchPoolCalls.Load(); got != 0 {
+		t.Fatalf("batch pool calls = %d, want 0", got)
+	}
+}
+
+func TestAdminTenantCreateDoesNotIssueAPIKeyWhenPoolPasswordDecryptFails(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{
+			ClusterID:      "cluster-free-1",
+			OrganizationID: "org-1",
+		}},
+	}}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.UpsertTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           1,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert pool: %v", err)
+	}
+	tenantID := "pool-tenant-bad-pass"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           "db.example.com",
+		DBPort:           4000,
+		DBUser:           "u.root",
+		DBPasswordCipher: []byte("not-valid-ciphertext"),
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-free-1",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       tenantID,
+		OrganizationID: "org-1",
+		ClusterID:      "cluster-free-1",
+		PoolID:         "pool-1",
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	resp := postJSON(t, ts.URL+"/v1/admin/tenants", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 502: %s", resp.StatusCode, body)
+	}
+	binding, err := rt.meta.GetTenantTiDBCloudOrgBinding(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("get binding: %v", err)
+	}
+	if binding.PoolStatus != meta.TenantPoolBindingFree || binding.UsedAt != nil {
+		t.Fatalf("binding = %#v, want released free", binding)
+	}
+	var activeKeys int
+	if err := rt.meta.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND status = ?`, tenantID, meta.APIKeyActive).Scan(&activeKeys); err != nil {
+		t.Fatalf("count active api keys: %v", err)
+	}
+	if activeKeys != 0 {
+		t.Fatalf("active api keys = %d, want 0", activeKeys)
+	}
+}
+
+func TestAdminTenantCreateClaimsFreePoolTenant(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{
+			ClusterID:      "cluster-free-1",
+			OrganizationID: "org-1",
+		}},
+	}}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.UpsertTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           0,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert pool: %v", err)
+	}
+	passCipher, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
+	if err != nil {
+		t.Fatalf("encrypt password: %v", err)
+	}
+	tenantID := "pool-tenant-1"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           "db.example.com",
+		DBPort:           4000,
+		DBUser:           "u.root",
+		DBPasswordCipher: passCipher,
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-free-1",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       tenantID,
+		OrganizationID: "org-1",
+		ClusterID:      "cluster-free-1",
+		PoolID:         "pool-1",
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	resp := postJSON(t, ts.URL+"/v1/admin/tenants", map[string]any{
+		"public_key":               "public-1",
+		"private_key":              "private-1",
+		"tidbcloud_spending_limit": 123,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var out adminTenantCreateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out.TenantID != tenantID || out.APIKey == "" || out.Status != string(meta.TenantActive) {
+		t.Fatalf("create response = %#v", out)
+	}
+	if rt.prov.markPoolUsedCalls.Load() != 1 {
+		t.Fatalf("mark pool used calls = %d, want 1", rt.prov.markPoolUsedCalls.Load())
+	}
+	if rt.prov.lastCluster == nil || rt.prov.lastCluster.ClusterID != "cluster-free-1" {
+		t.Fatalf("last cluster = %#v", rt.prov.lastCluster)
+	}
+	if rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly == nil || *rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly != 123 {
+		t.Fatalf("last spending limit = %#v", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly)
+	}
+	binding, err := rt.meta.GetTenantTiDBCloudOrgBinding(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("get binding: %v", err)
+	}
+	if binding.PoolStatus != meta.TenantPoolBindingUsed || binding.UsedAt == nil {
+		t.Fatalf("binding = %#v, want used with used_at", binding)
+	}
+	resolved, err := rt.meta.ResolveByAPIKeyHash(ctx, token.HashToken(out.APIKey))
+	if err != nil {
+		t.Fatalf("resolve issued api key: %v", err)
+	}
+	if resolved.Tenant.ID != tenantID {
+		t.Fatalf("resolved tenant = %q, want %q", resolved.Tenant.ID, tenantID)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -112,35 +112,36 @@ type nativeSystemUserProvisioner interface {
 }
 
 type Server struct {
-	fallback            *backend.Dat9Backend
-	meta                *meta.Store
-	pool                *tenant.Pool
-	provisioner         tenant.Provisioner
-	tokenSecret         []byte
-	localTenantAPIKey   string
-	vaultMK             *vault.MasterKey
-	vaultIssuerURL      string
-	publicURL           string
-	maxUploadBytes      int64
-	inlineThreshold     int64
-	metrics             *serverMetrics
-	logger              *zap.Logger
-	mux                 *http.ServeMux
-	events              *eventBuses
-	semanticWorker      *semanticWorkerManager
-	journalCursorSecret []byte
-	objectGCWorker      *objectGCWorker
-	slockOAuth          SlockOAuthClient
-	tidbAutoEmbedding   tenantAutoEmbeddingDefault
-	disableDBAutoEmbed  bool
-	forkWorkerCtx       context.Context
-	forkWorkerCancel    context.CancelFunc
-	forkWorkerWG        sync.WaitGroup
-	forkWorkerMu        sync.Mutex
-	forkWorkerClosed    bool
-	tenantPoolLocks     sync.Map
-	schemaInitErrors    sync.Map
-	leader              *leader.Manager
+	fallback              *backend.Dat9Backend
+	meta                  *meta.Store
+	pool                  *tenant.Pool
+	provisioner           tenant.Provisioner
+	tokenSecret           []byte
+	localTenantAPIKey     string
+	vaultMK               *vault.MasterKey
+	vaultIssuerURL        string
+	publicURL             string
+	maxUploadBytes        int64
+	inlineThreshold       int64
+	metrics               *serverMetrics
+	logger                *zap.Logger
+	mux                   *http.ServeMux
+	events                *eventBuses
+	semanticWorker        *semanticWorkerManager
+	journalCursorSecret   []byte
+	objectGCWorker        *objectGCWorker
+	slockOAuth            SlockOAuthClient
+	tidbAutoEmbedding     tenantAutoEmbeddingDefault
+	disableDBAutoEmbed    bool
+	forkWorkerCtx         context.Context
+	forkWorkerCancel      context.CancelFunc
+	forkWorkerWG          sync.WaitGroup
+	forkWorkerMu          sync.Mutex
+	forkWorkerClosed      bool
+	tenantPoolLocks       sync.Map
+	tenantPoolCreateLocks sync.Map
+	schemaInitErrors      sync.Map
+	leader                *leader.Manager
 	// leaderWorkerCtx gates leader-only background schedulers. When leadership
 	// changes, this context is cancelled and recreated. Workers that use it
 	// (pending tenant reconciler, tenant delete cleanup, one-time resume tasks)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4008,6 +4008,16 @@ func newProvisionTenantError(status int, message string, err error) *provisionTe
 	return &provisionTenantError{status: status, message: message, err: err}
 }
 
+func logProvisionStage(ctx context.Context, event, tenantID, provider string, started time.Time, kv ...any) {
+	fields := []any{
+		"tenant_id", tenantID,
+		"provider", provider,
+		"duration_ms", float64(time.Since(started).Microseconds()) / 1000,
+	}
+	fields = append(fields, kv...)
+	logger.Info(ctx, "server_event", eventFields(ctx, event, fields...)...)
+}
+
 func defaultTiDBAutoEmbeddingConfig(cfg tenantschema.TiDBAutoEmbeddingConfig) tenantschema.TiDBAutoEmbeddingConfig {
 	if cfg.Model == "" && cfg.Dimensions == 0 {
 		return tenantschema.CurrentTiDBAutoEmbeddingConfig()
@@ -4157,6 +4167,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		}
 	}
 	tenantID := token.NewID()
+	provisionStarted := time.Now()
 	logger.Info(ctx, "server_event", eventFields(ctx, "provision_requested", "tenant_id", tenantID, "provider", provider)...)
 	setRequestMetricTenant(ctx, tenantID, "", provider, tenantRequestClass{surface: "provision", action: "post"})
 
@@ -4165,12 +4176,15 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		keyName = "default"
 	}
 	now := time.Now().UTC()
+	stageStarted := time.Now()
 	autoProfile, err := s.defaultAutoEmbeddingProfileForTenant(ctx, tenantID, provider, now)
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_auto_embedding_profile_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to build tenant auto-embedding profile", err)
 	}
+	logProvisionStage(ctx, "provision_auto_embedding_profile_built", tenantID, provider, stageStarted, "enabled", autoProfile != nil)
+	stageStarted = time.Now()
 	if err := s.meta.InsertTenant(ctx, &meta.Tenant{
 		ID:               tenantID,
 		Status:           meta.TenantPending,
@@ -4191,8 +4205,10 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist tenant", err)
 	}
 	metricEvent(ctx, "metadb_query", "api", "insert_tenant", "result", "ok")
+	logProvisionStage(ctx, "provision_tenant_inserted", tenantID, provider, stageStarted, "status", meta.TenantPending)
 
 	if autoProfile != nil {
+		stageStarted = time.Now()
 		if err := s.meta.UpsertTenantAutoEmbeddingProfile(ctx, autoProfile); err != nil {
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_insert_auto_embedding_profile_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 			metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
@@ -4201,12 +4217,17 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			}
 			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist tenant auto-embedding profile", err)
 		}
+		logProvisionStage(ctx, "provision_auto_embedding_profile_inserted", tenantID, provider, stageStarted)
 	}
 
 	var cluster *tenant.ClusterInfo
 	var provisionCloudCfg *tenant.QuotaCloudConfig
+	stageStarted = time.Now()
+	provisionMode := "default"
+	logProvisionStart := false
 	if provider == tenant.ProviderTiDBCloudNative {
 		if opts.Quota != nil {
+			provisionMode = "tidb_cloud_native_credentials_quota"
 			quotaReq := *opts.Quota
 			quotaReq.TenantID = tenantID
 			if err := s.validateQuotaSetRequest(quotaReq); err != nil {
@@ -4218,6 +4239,8 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 				return nil, newProvisionTenantError(http.StatusBadRequest, tenant.ErrCredentialsRequired.Error(), tenant.ErrCredentialsRequired)
 			}
 			if quotaProvisioner, ok := s.provisioner.(tenant.CredentialQuotaProvisioner); ok {
+				logProvisionStage(ctx, "provision_cluster_provision_started", tenantID, provider, stageStarted, "mode", provisionMode)
+				logProvisionStart = true
 				cluster, provisionCloudCfg, err = quotaProvisioner.ProvisionWithCredentialsAndQuota(ctx, tenantID, *opts.CredentialProvisioner, tenant.QuotaUpdateOptions{
 					TiDBCloudSpendingLimitMonthly: quotaReq.TiDBCloudSpendingLimit,
 				})
@@ -4231,12 +4254,21 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 				return nil, newProvisionTenantError(http.StatusInternalServerError, "provisioner does not support create-time quota", err)
 			}
 		} else if credentialProvisioner, ok := s.provisioner.(tenant.CredentialProvisioner); ok {
+			provisionMode = "tidb_cloud_native_credentials"
+			logProvisionStage(ctx, "provision_cluster_provision_started", tenantID, provider, stageStarted, "mode", provisionMode)
+			logProvisionStart = true
 			cluster, err = credentialProvisioner.ProvisionWithCredentials(ctx, tenantID, *opts.CredentialProvisioner)
 		} else {
 			err = fmt.Errorf("provisioner does not support request credentials")
 		}
 	} else {
+		provisionMode = "provisioner_default"
+		logProvisionStage(ctx, "provision_cluster_provision_started", tenantID, provider, stageStarted, "mode", provisionMode)
+		logProvisionStart = true
 		cluster, err = s.provisioner.Provision(ctx, tenantID)
+	}
+	if !logProvisionStart {
+		logProvisionStage(ctx, "provision_cluster_provision_started", tenantID, provider, stageStarted, "mode", provisionMode)
 	}
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
@@ -4259,8 +4291,10 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		}
 		return nil, newProvisionTenantError(http.StatusBadGateway, msg, err)
 	}
+	logProvisionStage(ctx, "provision_cluster_provisioned", tenantID, provider, stageStarted, "mode", provisionMode, "cluster_id", cluster.ClusterID, "organization_id", cluster.OrganizationID)
 	cluster.Provider = provider
 	if provider == tenant.ProviderTiDBCloudNative {
+		stageStarted = time.Now()
 		if strings.TrimSpace(cluster.OrganizationID) == "" {
 			err := fmt.Errorf("tidbcloud organization label is missing")
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_tidbcloud_org_binding_missing", "tenant_id", tenantID, "provider", provider, "cluster_id", cluster.ClusterID, "error", err)...)
@@ -4280,8 +4314,10 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "org_binding_error")
 			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist tidbcloud organization binding", err)
 		}
+		logProvisionStage(ctx, "provision_tidbcloud_org_binding_persisted", tenantID, provider, stageStarted, "cluster_id", cluster.ClusterID, "organization_id", cluster.OrganizationID)
 	}
 
+	stageStarted = time.Now()
 	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_encrypt_db_password_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
@@ -4291,6 +4327,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		}
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encrypt db password", err)
 	}
+	logProvisionStage(ctx, "provision_db_password_encrypted", tenantID, provider, stageStarted)
 	dbtls := true
 	if provider == tenant.ProviderTiDBCloudNative {
 		v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
@@ -4298,6 +4335,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			dbtls = false
 		}
 	}
+	stageStarted = time.Now()
 	if err := s.meta.UpdateTenantConnection(ctx, tenantID, &meta.Tenant{
 		DBHost:           cluster.Host,
 		DBPort:           cluster.Port,
@@ -4317,6 +4355,8 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		}
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist tenant connection", err)
 	}
+	logProvisionStage(ctx, "provision_tenant_connection_persisted", tenantID, provider, stageStarted, "cluster_id", cluster.ClusterID, "db_tls", dbtls)
+	stageStarted = time.Now()
 	if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantProvisioning); err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_update_tenant_status_failed", "tenant_id", tenantID, "provider", provider, "status", meta.TenantProvisioning, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
@@ -4325,8 +4365,10 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		}
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to update tenant status", err)
 	}
+	logProvisionStage(ctx, "provision_tenant_status_updated", tenantID, provider, stageStarted, "status", meta.TenantProvisioning)
 
 	if opts.Quota != nil {
+		stageStarted = time.Now()
 		quotaReq := *opts.Quota
 		quotaReq.TenantID = tenantID
 		if err := s.applyQuotaLocalConfig(ctx, tenantID, quotaReq); err != nil {
@@ -4340,8 +4382,10 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		if provisionCloudCfg != nil && provisionCloudCfg.TiDBCloudSpendingLimitMonthly != nil {
 			metricEvent(ctx, "tenant_provision", "provider", provider, "quota", "create_time_spending_limit")
 		}
+		logProvisionStage(ctx, "provision_quota_local_config_applied", tenantID, provider, stageStarted, "create_time_spending_limit", provisionCloudCfg != nil && provisionCloudCfg.TiDBCloudSpendingLimitMonthly != nil)
 	}
 
+	stageStarted = time.Now()
 	apiToken, apiKeyID, err := s.issueOwnerAPIKey(ctx, tenantID, keyName, opts.TokenVersion, opts.APIKeySource)
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_insert_api_key_failed", "tenant_id", tenantID, "api_key_id", apiKeyID, "error", err)...)
@@ -4350,8 +4394,9 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist api key", err)
 	}
+	logProvisionStage(ctx, "provision_api_key_issued", tenantID, provider, stageStarted, "api_key_id", apiKeyID)
 
-	logger.Info(ctx, "server_event", eventFields(ctx, "provision_accepted", "tenant_id", tenantID, "provider", provider)...)
+	logger.Info(ctx, "server_event", eventFields(ctx, "provision_accepted", "tenant_id", tenantID, "provider", provider, "duration_ms", float64(time.Since(provisionStarted).Microseconds())/1000)...)
 	metricEvent(ctx, "tenant_provision", "provider", provider, "result", "accepted")
 
 	cloudProvider, region := "", ""

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -311,6 +311,7 @@ func NewWithConfig(cfg Config) *Server {
 	mux.HandleFunc("/v1/status", s.handleTenantStatus)
 	mux.HandleFunc("/v1/provision", s.handleProvision)
 	mux.Handle("/v1/quota", s.quotaRootHandler(cfg))
+	mux.Handle("/v1/admin/tenant-pool", s.adminTenantPoolHandler())
 	mux.Handle("/v1/admin/tenants", s.adminTenantsRootHandler())
 	mux.Handle("/v1/admin/tenants/", s.adminTenantsItemHandler())
 	mux.HandleFunc("/v1/auth/slock/login", s.handleSlockLogin)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4008,11 +4008,15 @@ func newProvisionTenantError(status int, message string, err error) *provisionTe
 	return &provisionTenantError{status: status, message: message, err: err}
 }
 
+func durationMillis(started time.Time) float64 {
+	return float64(time.Since(started).Microseconds()) / 1000
+}
+
 func logProvisionStage(ctx context.Context, event, tenantID, provider string, started time.Time, kv ...any) {
 	fields := []any{
 		"tenant_id", tenantID,
 		"provider", provider,
-		"duration_ms", float64(time.Since(started).Microseconds()) / 1000,
+		"duration_ms", durationMillis(started),
 	}
 	fields = append(fields, kv...)
 	logger.Info(ctx, "server_event", eventFields(ctx, event, fields...)...)
@@ -4396,7 +4400,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	}
 	logProvisionStage(ctx, "provision_api_key_issued", tenantID, provider, stageStarted, "api_key_id", apiKeyID)
 
-	logger.Info(ctx, "server_event", eventFields(ctx, "provision_accepted", "tenant_id", tenantID, "provider", provider, "duration_ms", float64(time.Since(provisionStarted).Microseconds())/1000)...)
+	logger.Info(ctx, "server_event", eventFields(ctx, "provision_accepted", "tenant_id", tenantID, "provider", provider, "duration_ms", durationMillis(provisionStarted))...)
 	metricEvent(ctx, "tenant_provision", "provider", provider, "result", "accepted")
 
 	cloudProvider, region := "", ""

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4228,7 +4228,6 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	var provisionCloudCfg *tenant.QuotaCloudConfig
 	stageStarted = time.Now()
 	provisionMode := "default"
-	logProvisionStart := false
 	if provider == tenant.ProviderTiDBCloudNative {
 		if opts.Quota != nil {
 			provisionMode = "tidb_cloud_native_credentials_quota"
@@ -4244,7 +4243,6 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			}
 			if quotaProvisioner, ok := s.provisioner.(tenant.CredentialQuotaProvisioner); ok {
 				logProvisionStage(ctx, "provision_cluster_provision_started", tenantID, provider, stageStarted, "mode", provisionMode)
-				logProvisionStart = true
 				cluster, provisionCloudCfg, err = quotaProvisioner.ProvisionWithCredentialsAndQuota(ctx, tenantID, *opts.CredentialProvisioner, tenant.QuotaUpdateOptions{
 					TiDBCloudSpendingLimitMonthly: quotaReq.TiDBCloudSpendingLimit,
 				})
@@ -4260,7 +4258,6 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		} else if credentialProvisioner, ok := s.provisioner.(tenant.CredentialProvisioner); ok {
 			provisionMode = "tidb_cloud_native_credentials"
 			logProvisionStage(ctx, "provision_cluster_provision_started", tenantID, provider, stageStarted, "mode", provisionMode)
-			logProvisionStart = true
 			cluster, err = credentialProvisioner.ProvisionWithCredentials(ctx, tenantID, *opts.CredentialProvisioner)
 		} else {
 			err = fmt.Errorf("provisioner does not support request credentials")
@@ -4268,11 +4265,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	} else {
 		provisionMode = "provisioner_default"
 		logProvisionStage(ctx, "provision_cluster_provision_started", tenantID, provider, stageStarted, "mode", provisionMode)
-		logProvisionStart = true
 		cluster, err = s.provisioner.Provision(ctx, tenantID)
-	}
-	if !logProvisionStart {
-		logProvisionStage(ctx, "provision_cluster_provision_started", tenantID, provider, stageStarted, "mode", provisionMode)
 	}
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -138,6 +138,7 @@ type Server struct {
 	forkWorkerWG        sync.WaitGroup
 	forkWorkerMu        sync.Mutex
 	forkWorkerClosed    bool
+	tenantPoolLocks     sync.Map
 	schemaInitErrors    sync.Map
 	leader              *leader.Manager
 	// leaderWorkerCtx gates leader-only background schedulers. When leadership

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -65,6 +65,13 @@ type CredentialQuotaProvisioner interface {
 	ProvisionWithCredentialsAndQuota(ctx context.Context, tenantID string, req CredentialProvisionRequest, opts QuotaUpdateOptions) (*ClusterInfo, *QuotaCloudConfig, error)
 }
 
+type TenantPoolClusterManager interface {
+	Provisioner
+	BatchProvisionFreeClustersWithCredentialsAndQuota(ctx context.Context, tenantIDs []string, req CredentialProvisionRequest, opts QuotaUpdateOptions) ([]*ClusterInfo, *QuotaCloudConfig, error)
+	MarkClusterPoolUsed(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest, usedAt time.Time, opts QuotaUpdateOptions) (*QuotaCloudConfig, error)
+	MarkClusterPoolFree(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) error
+}
+
 type CredentialDeprovisioner interface {
 	Provisioner
 	DeprovisionWithCredentials(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) error

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -418,10 +418,17 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 		info := created.Clusters[i]
 		tenantID := strings.TrimSpace(info.Labels[Drive9TenantIDLabel])
 		if tenantID == "" {
-			tenantID = strings.TrimSpace(tenantIDs[i])
+			errs[i] = fmt.Errorf("tidbcloud native batch response missing %s label for cluster %q", Drive9TenantIDLabel, info.ClusterID)
+			continue
 		}
-		if info.ClusterID == "" {
-			return nil, nil, fmt.Errorf("tidbcloud native batch response missing cluster id")
+		password, ok := passwords[tenantID]
+		if !ok {
+			errs[i] = fmt.Errorf("tidbcloud native batch response returned unknown tenant id %q", tenantID)
+			continue
+		}
+		if strings.TrimSpace(info.ClusterID) == "" {
+			errs[i] = fmt.Errorf("tidbcloud native batch response missing cluster id for tenant %q", tenantID)
+			continue
 		}
 		wg.Add(1)
 		go func() {
@@ -435,13 +442,13 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 				}
 				clusterInfo = waited
 			}
-			out[i] = p.clusterInfoFromResponse(tenantID, dbName, passwords[tenantID], clusterInfo)
+			out[i] = p.clusterInfoFromResponse(tenantID, dbName, password, clusterInfo)
 		}()
 	}
 	wg.Wait()
 	for _, err := range errs {
 		if err != nil {
-			return fallbackBatchClusterInfos(created.Clusters, tenantIDs, dbName), nil, err
+			return fallbackBatchClusterInfos(created.Clusters, dbName), nil, err
 		}
 	}
 	cloudCfg := &tenant.QuotaCloudConfig{Labels: map[string]string{
@@ -454,14 +461,11 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 	return out, cloudCfg, nil
 }
 
-func fallbackBatchClusterInfos(clusters []clusterInfo, tenantIDs []string, dbName string) []*tenant.ClusterInfo {
+func fallbackBatchClusterInfos(clusters []clusterInfo, dbName string) []*tenant.ClusterInfo {
 	out := make([]*tenant.ClusterInfo, 0, len(clusters))
 	for i := range clusters {
 		info := clusters[i]
 		tenantID := strings.TrimSpace(info.Labels[Drive9TenantIDLabel])
-		if tenantID == "" && i < len(tenantIDs) {
-			tenantID = strings.TrimSpace(tenantIDs[i])
-		}
 		out = append(out, &tenant.ClusterInfo{
 			TenantID:       tenantID,
 			ClusterID:      strings.TrimSpace(info.ClusterID),

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -43,6 +44,8 @@ const (
 
 	Drive9ManagedLabel         = "drive9.ai/managed"
 	Drive9TenantIDLabel        = "drive9.ai/tenant_id"
+	Drive9PoolStatusLabel      = "drive9.ai/status"
+	Drive9PoolUsedAtLabel      = "drive9.ai/used_at"
 	Drive9QuotaUpdateAtLabel   = "drive9.ai/update_quota_at"
 	TiDBCloudOrganizationLabel = "tidb.cloud/organization"
 
@@ -324,6 +327,221 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 		cloudCfg.TiDBCloudSpendingLimitMonthly = ptrInt64(*spendingLimit)
 	}
 	return out, cloudCfg, nil
+}
+
+func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx context.Context, tenantIDs []string, req tenant.CredentialProvisionRequest, opts tenant.QuotaUpdateOptions) ([]*tenant.ClusterInfo, *tenant.QuotaCloudConfig, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, nil, fmt.Errorf("public_key and private_key are required")
+	}
+	if len(tenantIDs) == 0 {
+		return []*tenant.ClusterInfo{}, nil, nil
+	}
+	dbName, err := p.resolveDatabaseName("")
+	if err != nil {
+		return nil, nil, err
+	}
+	if opts.TiDBCloudSpendingLimitMonthly != nil {
+		if err := validateTiDBCloudSpendingLimit(*opts.TiDBCloudSpendingLimitMonthly); err != nil {
+			return nil, nil, err
+		}
+	}
+	var spendingLimit *int64
+	requests := make([]map[string]any, 0, len(tenantIDs))
+	passwords := make(map[string]string, len(tenantIDs))
+	for _, tenantID := range tenantIDs {
+		tenantID = strings.TrimSpace(tenantID)
+		if tenantID == "" {
+			return nil, nil, fmt.Errorf("tenant id is required")
+		}
+		password, err := generateRandomPassword(24)
+		if err != nil {
+			return nil, nil, err
+		}
+		passwords[tenantID] = password
+		cluster := map[string]any{
+			"displayName":  clusterDisplayName(tenantID),
+			"rootPassword": password,
+			"region": map[string]string{
+				"name": p.regionName(),
+			},
+			"labels": map[string]string{
+				Drive9ManagedLabel:    "true",
+				Drive9TenantIDLabel:   tenantID,
+				Drive9PoolStatusLabel: "free",
+			},
+		}
+		if opts.TiDBCloudSpendingLimitMonthly != nil {
+			spendingLimit = opts.TiDBCloudSpendingLimitMonthly
+			cluster["spendingLimit"] = map[string]int32{"monthly": int32(*spendingLimit)}
+		} else if p.defaultSpendLimit != nil {
+			defaultLimit := int64(*p.defaultSpendLimit)
+			spendingLimit = &defaultLimit
+			cluster["spendingLimit"] = map[string]int32{"monthly": *p.defaultSpendLimit}
+		}
+		requests = append(requests, map[string]any{"cluster": cluster})
+	}
+	body, err := json.Marshal(map[string]any{"requests": requests})
+	if err != nil {
+		return nil, nil, err
+	}
+	endpoint := p.apiURL + "/v1beta1/clusters:batchCreate"
+	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodPost, endpoint, body)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
+		if readErr != nil {
+			return nil, nil, readErr
+		}
+		return nil, nil, fmt.Errorf("%s", statusError("batch provision", resp.StatusCode, sanitizeUpstreamBody(raw)))
+	}
+	raw, readErr := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
+	if readErr != nil {
+		return nil, nil, readErr
+	}
+	var created clusterListResponse
+	if err := json.Unmarshal(raw, &created); err != nil {
+		return nil, nil, err
+	}
+	if len(created.Clusters) != len(tenantIDs) {
+		return nil, nil, fmt.Errorf("tidbcloud native batch provision returned %d clusters, want %d", len(created.Clusters), len(tenantIDs))
+	}
+	out := make([]*tenant.ClusterInfo, len(created.Clusters))
+	var wg sync.WaitGroup
+	errs := make([]error, len(created.Clusters))
+	for i := range created.Clusters {
+		i := i
+		info := created.Clusters[i]
+		tenantID := strings.TrimSpace(info.Labels[Drive9TenantIDLabel])
+		if tenantID == "" {
+			tenantID = strings.TrimSpace(tenantIDs[i])
+		}
+		if info.ClusterID == "" {
+			return nil, nil, fmt.Errorf("tidbcloud native batch response missing cluster id")
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			clusterInfo := &info
+			if clusterProvisionMetadataIncomplete(clusterInfo, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
+				waited, waitErr := p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, info.ClusterID)
+				if waitErr != nil {
+					errs[i] = waitErr
+					return
+				}
+				clusterInfo = waited
+			}
+			out[i] = p.clusterInfoFromResponse(tenantID, dbName, passwords[tenantID], clusterInfo)
+		}()
+	}
+	wg.Wait()
+	for _, err := range errs {
+		if err != nil {
+			return fallbackBatchClusterInfos(created.Clusters, tenantIDs, dbName), nil, err
+		}
+	}
+	cloudCfg := &tenant.QuotaCloudConfig{Labels: map[string]string{
+		Drive9ManagedLabel:    "true",
+		Drive9PoolStatusLabel: "free",
+	}}
+	if spendingLimit != nil {
+		cloudCfg.TiDBCloudSpendingLimitMonthly = ptrInt64(*spendingLimit)
+	}
+	return out, cloudCfg, nil
+}
+
+func fallbackBatchClusterInfos(clusters []clusterInfo, tenantIDs []string, dbName string) []*tenant.ClusterInfo {
+	out := make([]*tenant.ClusterInfo, 0, len(clusters))
+	for i := range clusters {
+		info := clusters[i]
+		tenantID := strings.TrimSpace(info.Labels[Drive9TenantIDLabel])
+		if tenantID == "" && i < len(tenantIDs) {
+			tenantID = strings.TrimSpace(tenantIDs[i])
+		}
+		out = append(out, &tenant.ClusterInfo{
+			TenantID:       tenantID,
+			ClusterID:      strings.TrimSpace(info.ClusterID),
+			OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
+			DBName:         dbName,
+			Provider:       tenant.ProviderTiDBCloudNative,
+		})
+	}
+	return out
+}
+
+func (p *Provisioner) MarkClusterPoolUsed(ctx context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, usedAt time.Time, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, fmt.Errorf("public_key and private_key are required")
+	}
+	if cluster == nil || strings.TrimSpace(cluster.ClusterID) == "" {
+		return nil, fmt.Errorf("cluster id is required")
+	}
+	if opts.TiDBCloudSpendingLimitMonthly != nil {
+		if err := validateTiDBCloudSpendingLimit(*opts.TiDBCloudSpendingLimitMonthly); err != nil {
+			return nil, err
+		}
+	}
+	clusterID := strings.TrimSpace(cluster.ClusterID)
+	labels, cloudCfg, err := p.clusterQuotaInfo(ctx, publicKey, privateKey, clusterID)
+	if err != nil {
+		return nil, fmt.Errorf("load cluster pool label info: %w", err)
+	}
+	labels[Drive9ManagedLabel] = "true"
+	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
+		labels[Drive9TenantIDLabel] = tenantID
+	}
+	labels[Drive9PoolStatusLabel] = "used"
+	labels[Drive9PoolUsedAtLabel] = usedAt.UTC().Format(time.RFC3339)
+	for _, k := range immutableLabelKeys {
+		delete(labels, k)
+	}
+	if err := p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels); err != nil {
+		return nil, fmt.Errorf("update cluster pool labels: %w", err)
+	}
+	if cloudCfg == nil {
+		cloudCfg = &tenant.QuotaCloudConfig{}
+	}
+	cloudCfg.Labels = labels
+	if opts.TiDBCloudSpendingLimitMonthly != nil {
+		monthly := *opts.TiDBCloudSpendingLimitMonthly
+		if err := p.updateSpendingLimitWithCredentials(ctx, publicKey, privateKey, clusterID, monthly); err != nil {
+			return nil, fmt.Errorf("update cluster spending limit: %w", err)
+		}
+		cloudCfg.TiDBCloudSpendingLimitMonthly = ptrInt64(monthly)
+	}
+	return cloudCfg, nil
+}
+
+func (p *Provisioner) MarkClusterPoolFree(ctx context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) error {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return fmt.Errorf("public_key and private_key are required")
+	}
+	if cluster == nil || strings.TrimSpace(cluster.ClusterID) == "" {
+		return fmt.Errorf("cluster id is required")
+	}
+	clusterID := strings.TrimSpace(cluster.ClusterID)
+	labels, _, err := p.clusterQuotaInfo(ctx, publicKey, privateKey, clusterID)
+	if err != nil {
+		return fmt.Errorf("load cluster pool label info: %w", err)
+	}
+	labels[Drive9ManagedLabel] = "true"
+	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
+		labels[Drive9TenantIDLabel] = tenantID
+	}
+	labels[Drive9PoolStatusLabel] = "free"
+	delete(labels, Drive9PoolUsedAtLabel)
+	for _, k := range immutableLabelKeys {
+		delete(labels, k)
+	}
+	return p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels)
 }
 
 func (p *Provisioner) ProvisionBranch(ctx context.Context, forkTenantID string, source *tenant.ClusterInfo) (*tenant.ClusterInfo, error) {
@@ -1053,6 +1271,43 @@ func cloudClusterInfoFromClusterInfo(info clusterInfo) tenant.CloudClusterInfo {
 	}
 	if info.SpendingLimit != nil {
 		out.TiDBCloudSpendingLimitMonthly = ptrInt64(int64(info.SpendingLimit.Monthly))
+	}
+	return out
+}
+
+func (p *Provisioner) clusterInfoFromResponse(tenantID, dbName, password string, info *clusterInfo) *tenant.ClusterInfo {
+	if info == nil {
+		return &tenant.ClusterInfo{
+			TenantID: tenantID,
+			Password: password,
+			DBName:   dbName,
+			Provider: tenant.ProviderTiDBCloudNative,
+		}
+	}
+	var host string
+	var port int
+	if p.usePrivateEndpoint {
+		host = info.Endpoints.Private.Host
+		port = info.Endpoints.Private.Port
+		if host == "" && p.tencentPrivateEndpointHost != "" {
+			host = p.tencentPrivateEndpointHost
+		}
+	} else {
+		host = info.Endpoints.Public.Host
+		port = info.Endpoints.Public.Port
+	}
+	out := &tenant.ClusterInfo{
+		TenantID:       tenantID,
+		ClusterID:      info.ClusterID,
+		OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
+		Host:           host,
+		Port:           port,
+		Password:       password,
+		DBName:         dbName,
+		Provider:       tenant.ProviderTiDBCloudNative,
+	}
+	if info.UserPrefix != "" {
+		out.Username = info.UserPrefix + ".root"
 	}
 	return out
 }

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -282,6 +284,170 @@ func TestProvisionWithCredentialsAndQuotaSendsCreateTimeSpendingLimit(t *testing
 	}
 	if cloudCfg == nil || cloudCfg.TiDBCloudSpendingLimitMonthly == nil || *cloudCfg.TiDBCloudSpendingLimitMonthly != monthly {
 		t.Fatalf("cloud config = %#v, want spending limit %d", cloudCfg, monthly)
+	}
+}
+
+func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
+	var gotBody struct {
+		Requests []struct {
+			Cluster struct {
+				DisplayName  string            `json:"displayName"`
+				RootPassword string            `json:"rootPassword"`
+				Labels       map[string]string `json:"labels"`
+				Region       struct {
+					Name string `json:"name"`
+				} `json:"region"`
+				SpendingLimit struct {
+					Monthly int32 `json:"monthly"`
+				} `json:"spendingLimit"`
+			} `json:"cluster"`
+		} `json:"requests"`
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/v1beta1/clusters:batchCreate" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"clusters": []map[string]any{
+				{
+					"clusterId":  "cluster-1",
+					"state":      "ACTIVE",
+					"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-1"},
+					"userPrefix": "u1",
+					"endpoints":  map[string]any{"public": map[string]any{"host": "db1.example", "port": 4000}},
+				},
+				{
+					"clusterId":  "cluster-2",
+					"state":      "ACTIVE",
+					"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-2"},
+					"userPrefix": "u2",
+					"endpoints":  map[string]any{"public": map[string]any{"host": "db2.example", "port": 4000}},
+				},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		cloudProvider:       "aws",
+		region:              "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+		client:              ts.Client(),
+	}
+	monthly := int64(10000)
+	out, cloudCfg, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(context.Background(), []string{"tenant-1", "tenant-2"}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	}, tenant.QuotaUpdateOptions{TiDBCloudSpendingLimitMonthly: &monthly})
+	if err != nil {
+		t.Fatalf("BatchProvisionFreeClustersWithCredentialsAndQuota: %v", err)
+	}
+	if len(gotBody.Requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(gotBody.Requests))
+	}
+	for i, req := range gotBody.Requests {
+		wantTenantID := fmt.Sprintf("tenant-%d", i+1)
+		if req.Cluster.Labels[Drive9ManagedLabel] != "true" ||
+			req.Cluster.Labels[Drive9TenantIDLabel] != wantTenantID ||
+			req.Cluster.Labels[Drive9PoolStatusLabel] != "free" {
+			t.Fatalf("request %d labels = %#v", i, req.Cluster.Labels)
+		}
+		if req.Cluster.RootPassword == "" {
+			t.Fatalf("request %d rootPassword empty", i)
+		}
+		if req.Cluster.Region.Name != "regions/aws-us-east-1" {
+			t.Fatalf("request %d region = %q", i, req.Cluster.Region.Name)
+		}
+		if req.Cluster.SpendingLimit.Monthly != int32(monthly) {
+			t.Fatalf("request %d spending = %d", i, req.Cluster.SpendingLimit.Monthly)
+		}
+	}
+	if len(out) != 2 || out[0].TenantID != "tenant-1" || out[0].ClusterID != "cluster-1" || out[1].TenantID != "tenant-2" || out[1].ClusterID != "cluster-2" {
+		t.Fatalf("clusters = %#v", out)
+	}
+	if cloudCfg == nil || cloudCfg.Labels[Drive9PoolStatusLabel] != "free" {
+		t.Fatalf("cloud config = %#v", cloudCfg)
+	}
+}
+
+func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFails(t *testing.T) {
+	origPoll := tidbCloudNativePollInterval
+	tidbCloudNativePollInterval = time.Millisecond
+	t.Cleanup(func() { tidbCloudNativePollInterval = origPoll })
+
+	var getCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1beta1/clusters:batchCreate":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusters": []map[string]any{
+					{
+						"clusterId":  "cluster-1",
+						"state":      "ACTIVE",
+						"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-1"},
+						"userPrefix": "u1",
+						"endpoints":  map[string]any{"public": map[string]any{"host": "db1.example", "port": 4000}},
+					},
+					{
+						"clusterId":  "cluster-2",
+						"state":      "CREATING",
+						"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-2"},
+						"userPrefix": "u2",
+					},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters/cluster-2":
+			getCalls.Add(1)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusterId":  "cluster-2",
+				"state":      "CREATING",
+				"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-2"},
+				"userPrefix": "u2",
+			})
+		default:
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+		}
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		cloudProvider:       "aws",
+		region:              "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+		client:              ts.Client(),
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+	defer cancel()
+	out, _, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(ctx, []string{"tenant-1", "tenant-2"}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	}, tenant.QuotaUpdateOptions{})
+	if err == nil {
+		t.Fatal("BatchProvisionFreeClustersWithCredentialsAndQuota error = nil, want metadata wait error")
+	}
+	if getCalls.Load() == 0 {
+		t.Fatal("cluster metadata GET was not called")
+	}
+	if len(out) != 2 {
+		t.Fatalf("clusters = %d, want 2 fallback clusters for cleanup: %#v", len(out), out)
+	}
+	if out[0].TenantID != "tenant-1" || out[0].ClusterID != "cluster-1" || out[1].TenantID != "tenant-2" || out[1].ClusterID != "cluster-2" {
+		t.Fatalf("fallback clusters = %#v", out)
 	}
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -288,6 +288,7 @@ func TestProvisionWithCredentialsAndQuotaSendsCreateTimeSpendingLimit(t *testing
 }
 
 func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
+	handlerErrs := make(chan error, 2)
 	var gotBody struct {
 		Requests []struct {
 			Cluster struct {
@@ -310,10 +311,14 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 			return
 		}
 		if r.Method != http.MethodPost || r.URL.Path != "/v1beta1/clusters:batchCreate" {
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
 		}
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			t.Fatalf("decode request body: %v", err)
+			handlerErrs <- fmt.Errorf("decode request body: %w", err)
+			http.Error(w, "invalid request", http.StatusBadRequest)
+			return
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"clusters": []map[string]any{
@@ -351,6 +356,7 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 	if err != nil {
 		t.Fatalf("BatchProvisionFreeClustersWithCredentialsAndQuota: %v", err)
 	}
+	assertNoHandlerError(t, handlerErrs)
 	if len(gotBody.Requests) != 2 {
 		t.Fatalf("requests = %d, want 2", len(gotBody.Requests))
 	}
@@ -385,6 +391,9 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 	t.Cleanup(func() { tidbCloudNativePollInterval = origPoll })
 
 	var getCalls atomic.Int32
+	handlerErrs := make(chan error, 2)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {
 			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
@@ -412,6 +421,7 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters/cluster-2":
 			getCalls.Add(1)
+			cancel()
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"clusterId":  "cluster-2",
 				"state":      "CREATING",
@@ -419,7 +429,8 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 				"userPrefix": "u2",
 			})
 		default:
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.String())
+			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
 		}
 	}))
 	defer ts.Close()
@@ -431,8 +442,6 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 		defaultDatabaseName: DefaultDatabaseName,
 		client:              ts.Client(),
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
-	defer cancel()
 	out, _, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(ctx, []string{"tenant-1", "tenant-2"}, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
@@ -440,6 +449,7 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 	if err == nil {
 		t.Fatal("BatchProvisionFreeClustersWithCredentialsAndQuota error = nil, want metadata wait error")
 	}
+	assertNoHandlerError(t, handlerErrs)
 	if getCalls.Load() == 0 {
 		t.Fatal("cluster metadata GET was not called")
 	}
@@ -448,6 +458,62 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 	}
 	if out[0].TenantID != "tenant-1" || out[0].ClusterID != "cluster-1" || out[1].TenantID != "tenant-2" || out[1].ClusterID != "cluster-2" {
 		t.Fatalf("fallback clusters = %#v", out)
+	}
+}
+
+func TestBatchProvisionFreeClustersRequiresTenantIDLabel(t *testing.T) {
+	handlerErrs := make(chan error, 2)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/v1beta1/clusters:batchCreate" {
+			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"clusters": []map[string]any{
+				{
+					"clusterId":  "cluster-1",
+					"state":      "ACTIVE",
+					"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1"},
+					"userPrefix": "u1",
+					"endpoints":  map[string]any{"public": map[string]any{"host": "db1.example", "port": 4000}},
+				},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		cloudProvider:       "aws",
+		region:              "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+		client:              ts.Client(),
+	}
+	out, _, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(context.Background(), []string{"tenant-1"}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	}, tenant.QuotaUpdateOptions{})
+	if err == nil || !strings.Contains(err.Error(), "missing "+Drive9TenantIDLabel) {
+		t.Fatalf("error = %v, want missing tenant id label", err)
+	}
+	assertNoHandlerError(t, handlerErrs)
+	if len(out) != 1 || out[0].TenantID != "" || out[0].ClusterID != "cluster-1" {
+		t.Fatalf("fallback clusters = %#v", out)
+	}
+}
+
+func assertNoHandlerError(t *testing.T, errs <-chan error) {
+	t.Helper()
+	select {
+	case err := <-errs:
+		t.Fatal(err)
+	default:
 	}
 }
 


### PR DESCRIPTION
## Summary
- add admin tenant pool APIs for TiDB Cloud native mode (`/v1/admin/tenant-pool`)
- add batch free-cluster provisioning, pool claim/release, replenish, shrink, and delete flows
- add `drive9 admin pool <create|get|update|delete>` CLI commands and client methods
- add pool metadata/status tracking and hide free pool tenants from normal admin tenant views

## Tests
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant/tidbcloudnative -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./cmd/drive9/cli -run 'TestAdmin|TestQuota' -count=1`\n- `GOCACHE=/tmp/drive9-go-cache go test ./cmd/drive9 -run 'TestHelp|TestDispatchAdmin' -count=1`\n- `GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint`\n\n## Notes\n- `pkg/server` and `pkg/meta` MySQL integration tests require Docker/testcontainers; local sandbox runs were blocked by `/var/run/docker.sock` permission errors. Earlier target runs passed before the final review hardening changes, and new regression coverage is included in the commit for CI to run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `drive9 admin pool` commands to create, get, update, and delete tenant pools, including JSON or table output.
  * Added `--pool-size` for pool capacity, plus spending-limit handling for pool provisioning and tenant creation from free-pool capacity with automatic background replenishment.
* **Documentation**
  * Updated `drive9 admin` help/visual help and examples to include the new `pool` workflow.
* **Bug Fixes**
  * Free-pool tenants are hidden from tenant access/list/get results to prevent unintended operations.
  * Improved validation and cleanup for pool lifecycle operations, including safer failure handling and state transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->