### PR TITLE
fix(metrics): exclude SSE lifetime from HTTP duration hist; add events diagnostics + multi-tenant fs_events cleanup

### DIFF
--- a/pkg/datastore/fs_events.go
+++ b/pkg/datastore/fs_events.go
@@ -82,6 +82,17 @@ func (s *Store) OldestFSEventSeq(ctx context.Context) (int64, error) {
 	return seq.Int64, nil
 }
 
+// CountFSEvents returns the total number of rows in fs_events. Used by the
+// leader cleanup goroutine to report drive9_fs_events_rows so operators can
+// monitor table growth without direct DB access.
+func (s *Store) CountFSEvents(ctx context.Context) (int64, error) {
+	var count int64
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM fs_events`).Scan(&count); err != nil {
+		return 0, fmt.Errorf("count fs_events: %w", err)
+	}
+	return count, nil
+}
+
 // DeleteFSEventsBefore deletes fs_events rows older than the given threshold.
 // Retention is gated on created_at (DB server's clock at INSERT time), not on
 // the ts field (publisher's clock at event emission). This means the retention

--- a/pkg/datastore/fs_events.go
+++ b/pkg/datastore/fs_events.go
@@ -85,6 +85,14 @@ func (s *Store) OldestFSEventSeq(ctx context.Context) (int64, error) {
 // CountFSEvents returns the total number of rows in fs_events. Used by the
 // leader cleanup goroutine to report drive9_fs_events_rows so operators can
 // monitor table growth without direct DB access.
+//
+// Note: COUNT(*) is a full table scan on TiDB/MySQL InnoDB (unlike PostgreSQL's
+// index-only count). This runs only every fsEventsCleanupInterval (5m) on the
+// leader per tenant with a cached backend, so the cost is bounded and
+// best-effort. If the table grows to millions of rows per tenant and this
+// becomes expensive, switch to a bounded condition (e.g.
+// `WHERE created_at > NOW() - INTERVAL 2 HOUR`) or an approximate count from
+// information_schema.TABLES.
 func (s *Store) CountFSEvents(ctx context.Context) (int64, error) {
 	var count int64
 	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM fs_events`).Scan(&count); err != nil {

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -12,6 +12,23 @@ import (
 var operationDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
 var httpDurationBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
 
+// sseConnectionDurationBounds covers SSE connection lifetimes, which can
+// range from sub-second probes to long-lived mounts. Buckets extend well
+// beyond httpDurationBounds so long-lived connections are visible without
+// piling into +Inf. These are recorded into a dedicated histogram
+// (drive9_sse_connection_duration_seconds), NOT drive9_http_request_duration_seconds.
+var sseConnectionDurationBounds = []float64{0.005, 0.05, 0.1, 0.5, 1, 5, 10, 30, 60, 300, 600, 1800, 3600}
+
+// eventBusQueryDurationBounds covers fs_events DB query latencies. These
+// should normally be low (PK range scan); a shift right indicates DB
+// pressure or table growth.
+var eventBusQueryDurationBounds = []float64{0.0005, 0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
+// ssePhase1DurationBounds covers the Phase-1 replay/reset cost of a new SSE
+// connection (one EventsSince call + stream of buffered events). Used to
+// distinguish slow first-replay from slow Phase-2 live streaming.
+var ssePhase1DurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+
 var globalRegistry = NewRegistry()
 var globalMeterProvider = NewMeterProvider(globalRegistry)
 
@@ -19,6 +36,7 @@ var serviceMeter = globalMeterProvider.Meter("service")
 var httpMeter = globalMeterProvider.Meter("http")
 var eventMeter = globalMeterProvider.Meter("event")
 var fuseMeter = globalMeterProvider.Meter("fuse")
+var sseMeter = globalMeterProvider.Meter("sse")
 var tenantMeter = globalMeterProvider.Meter("tenant")
 
 var serviceOperationsTotal = serviceMeter.Int64Counter("drive9_service_operations_total", "Service operations by component/operation/result")
@@ -46,6 +64,29 @@ var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total",
 var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/surface/action/direction")
 var tenantStorageBytes = tenantMeter.Float64Gauge("drive9_tenant_storage_bytes", "Tenant storage bytes by state")
 var tenantMediaFiles = tenantMeter.Float64Gauge("drive9_tenant_media_files", "Tenant media file count by state")
+
+// SSE-specific instruments. SSE connection lifetimes are recorded here, not
+// in drive9_http_request_duration_seconds (which would pollute HTTP latency
+// alerts — SSE connections live as long as the client stays subscribed).
+var sseConnectionsTotal = sseMeter.Int64Counter("drive9_sse_connections_total", "SSE /v1/events connections opened by tenant_id/reason")
+var sseConnectionDuration = sseMeter.Float64Histogram("drive9_sse_connection_duration_seconds", "SSE connection lifetime (client stay-open duration, not request processing time)", sseConnectionDurationBounds)
+var sseInflight = sseMeter.Float64Gauge("drive9_sse_inflight_connections", "Active SSE /v1/events connections by tenant_id")
+var ssePhase1Duration = sseMeter.Float64Histogram("drive9_sse_phase1_duration_seconds", "SSE Phase-1 replay/reset duration (one EventsSince call + buffered stream)", ssePhase1DurationBounds)
+var sseEventsSentTotal = sseMeter.Int64Counter("drive9_sse_events_sent_total", "SSE events sent to clients by type/tenant_id")
+var sseResetsSentTotal = sseMeter.Int64Counter("drive9_sse_resets_sent_total", "SSE reset events sent by reason/tenant_id")
+var sseHeartbeatsSentTotal = sseMeter.Int64Counter("drive9_sse_heartbeats_sent_total", "SSE heartbeat events sent by tenant_id")
+
+// Event-bus query instruments. Covers all fs_events DB reads (events_since,
+// poll, latest, oldest) so DB pressure and table growth on the events path
+// are observable without direct DB access.
+var eventBusQueryDuration = serviceMeter.Float64Histogram("drive9_event_bus_query_duration_seconds", "Event-bus fs_events query duration by operation/result/tenant_id", eventBusQueryDurationBounds)
+var eventBusPollFailuresTotal = sseMeter.Int64Counter("drive9_event_bus_poll_failures_total", "Event-bus cross-pod poll query failures by tenant_id")
+var eventBusPublishErrorsTotal = sseMeter.Int64Counter("drive9_event_bus_publish_errors_total", "Event-bus fs_events INSERT failures by tenant_id")
+
+// fs_events table instruments. Compensates for the lack of direct TiDB
+// access: row count and prune volume are reported by the server itself.
+var fsEventsRows = sseMeter.Float64Gauge("drive9_fs_events_rows", "fs_events table row count by tenant_id")
+var fsEventsPrunedTotal = sseMeter.Int64Counter("drive9_fs_events_pruned_total", "fs_events rows pruned by retention cleanup by tenant_id")
 
 func RegisterModule(module string) {
 	globalRegistry.RegisterModule(module)
@@ -110,6 +151,42 @@ func RecordHTTPRequestBodyRead(method, route string, status int, bodyBytes int64
 		Attr("status_class", statusClass(status)),
 		Attr("body_size_bucket", bodySizeBucket(bodyBytes)),
 	)
+}
+
+// RecordHTTPRequestCount records only the request counter, not the duration
+// histogram. Used for SSE/streaming routes whose handler blocks for the
+// connection lifetime (which is not request processing time and would
+// pollute HTTP latency alerts if recorded into the duration histogram).
+func RecordHTTPRequestCount(method, route string, status int) {
+	RegisterModule("server")
+	httpRequestsTotal.Add(1,
+		Attr("method", cleanMetricValue(method, "UNKNOWN")),
+		Attr("route", cleanMetricValue(route, "other")),
+		Attr("status", strconv.Itoa(status)),
+	)
+}
+
+// RecordTenantRequestCount records only the tenant request counter, not the
+// duration histogram. Companion to RecordHTTPRequestCount for SSE routes.
+func RecordTenantRequestCount(tenantID, surface, action, result string, status int) {
+	tenantID = cleanMetricValue(tenantID, "unknown")
+	surface = cleanMetricValue(surface, "other")
+	action = cleanMetricValue(action, "other")
+	result = cleanMetricValue(result, "unknown")
+	statusValue := "unknown"
+	if status > 0 {
+		statusValue = strconv.Itoa(status)
+	}
+	RegisterModule("tenant_usage")
+	attrs := []Attribute{
+		Attr("tenant_id", tenantID),
+		Attr("surface", surface),
+		Attr("action", action),
+		Attr("result", result),
+		Attr("status", statusValue),
+		Attr("status_class", statusClass(status)),
+	}
+	tenantRequestsTotal.Add(1, attrs...)
 }
 
 func RecordHTTPInFlight(value float64) {
@@ -240,6 +317,107 @@ func RecordFuseRemoteOperation(operation, result string, d time.Duration, bytes 
 	if bytes > 0 {
 		fuseRemoteOperationBytes.Add(int64(bytes), attrs...)
 	}
+}
+
+// RecordSSEConnection records an SSE connection lifecycle: it increments the
+// connection counter and observes the connection lifetime (time from accept
+// to client disconnect) into the dedicated SSE histogram. This duration must
+// NOT be recorded into drive9_http_request_duration_seconds — SSE connections
+// live as long as the client stays subscribed, so mixing them into the HTTP
+// latency histogram would make all HTTP P95/P99 alerts meaningless.
+func RecordSSEConnection(tenantID, reason string, d time.Duration) {
+	RegisterModule("sse")
+	tenantID = cleanMetricValue(tenantID, "unknown")
+	sseConnectionsTotal.Add(1, Attr("tenant_id", tenantID), Attr("reason", cleanMetricValue(reason, "unknown")))
+	sseConnectionDuration.Observe(d.Seconds(), Attr("tenant_id", tenantID))
+}
+
+// RecordSSEInFlight sets the active SSE connection count for a tenant. The
+// caller maintains the absolute count (incremented on subscribe, decremented
+// on unsubscribe); this records the current value so the gauge reflects the
+// true number of live SSE connections per tenant.
+func RecordSSEInFlight(tenantID string, count float64) {
+	if count < 0 {
+		count = 0
+	}
+	RegisterModule("sse")
+	sseInflight.Set(count, Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+}
+
+// RecordSSEPhase1 records the duration of the SSE Phase-1 replay/reset stage.
+func RecordSSEPhase1(tenantID string, d time.Duration) {
+	RegisterModule("sse")
+	ssePhase1Duration.Observe(d.Seconds(), Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+}
+
+// RecordSSEEventSent records a single SSE file_changed event delivery.
+func RecordSSEEventSent(tenantID, op string) {
+	RegisterModule("sse")
+	sseEventsSentTotal.Add(1,
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("op", cleanMetricValue(op, "unknown")),
+	)
+}
+
+// RecordSSEResetSent records an SSE reset event delivery.
+func RecordSSEResetSent(tenantID, reason string) {
+	RegisterModule("sse")
+	sseResetsSentTotal.Add(1,
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("reason", cleanMetricValue(reason, "unknown")),
+	)
+}
+
+// RecordSSEHeartbeatSent records an SSE heartbeat delivery.
+func RecordSSEHeartbeatSent(tenantID string) {
+	RegisterModule("sse")
+	sseHeartbeatsSentTotal.Add(1, Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+}
+
+// RecordEventBusQuery records the duration of an fs_events DB query. Unlike
+// the error-only counters, this records every query (ok and error) so DB
+// pressure and table growth on the events path are observable.
+func RecordEventBusQuery(tenantID, operation, result string, d time.Duration) {
+	RegisterModule("sse")
+	eventBusQueryDuration.Observe(d.Seconds(),
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("operation", cleanMetricValue(operation, "unknown")),
+		Attr("result", cleanMetricValue(result, "unknown")),
+	)
+}
+
+// RecordEventBusPollFailure records a cross-pod poll query failure (previously
+// only logged, not metriced).
+func RecordEventBusPollFailure(tenantID string) {
+	RegisterModule("sse")
+	eventBusPollFailuresTotal.Add(1, Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+}
+
+// RecordEventBusPublishError records an fs_events INSERT failure.
+func RecordEventBusPublishError(tenantID string) {
+	RegisterModule("sse")
+	eventBusPublishErrorsTotal.Add(1, Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+}
+
+// RecordFSEventsRows records the current fs_events row count for a tenant.
+// This compensates for the lack of direct TiDB access: the leader cleanup
+// goroutine samples the count and reports it here.
+func RecordFSEventsRows(tenantID string, count int64) {
+	if count < 0 {
+		return
+	}
+	RegisterModule("sse")
+	fsEventsRows.Set(float64(count), Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+}
+
+// RecordFSEventsPruned records the number of fs_events rows deleted by
+// retention cleanup.
+func RecordFSEventsPruned(tenantID string, count int64) {
+	if count <= 0 {
+		return
+	}
+	RegisterModule("sse")
+	fsEventsPrunedTotal.Add(count, Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
 }
 
 func WritePrometheus(w http.ResponseWriter) {

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -281,8 +281,10 @@ func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []Cha
 	// the client's cursor is stale (events pruned) or simply caught up.
 	latestStart := time.Now()
 	latest := latestSeqSafeWithMetric(ctx, store, eb.tenantID)
+	latestQueryMs := float64(time.Since(latestStart).Microseconds()) / 1000
 	oldestStart := time.Now()
 	oldest := oldestSeqSafeWithMetric(ctx, store, eb.tenantID)
+	oldestQueryMs := float64(time.Since(oldestStart).Microseconds()) / 1000
 	if latest == 0 {
 		// Table is empty (all events pruned): cursor is stale → reset.
 		return nil, 0, false
@@ -304,8 +306,8 @@ func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []Cha
 			zap.Uint64("since", since),
 			zap.Int64("oldest", oldest),
 			zap.Int64("latest", latest),
-			zap.Float64("latest_query_ms", float64(time.Since(latestStart).Microseconds())/1000),
-			zap.Float64("oldest_query_ms", float64(time.Since(oldestStart).Microseconds())/1000))
+			zap.Float64("latest_query_ms", latestQueryMs),
+			zap.Float64("oldest_query_ms", oldestQueryMs))
 		return nil, headSeq, false
 	}
 	// Client is caught up: no new events after since, cursor within range.

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -97,6 +97,7 @@ func (eb *EventBus) Subscribe() (uint64, chan struct{}) {
 	eb.nextID++
 	ch := make(chan struct{}, eventBusListenerChanSize)
 	eb.listeners[id] = ch
+	metrics.RecordSSEInFlight(eb.tenantID, float64(len(eb.listeners)))
 
 	// Start the cross-pod poll goroutine on first subscriber.
 	if eb.pollCancel == nil {
@@ -136,6 +137,7 @@ func (eb *EventBus) Unsubscribe(id uint64) {
 		delete(eb.listeners, id)
 		close(ch)
 	}
+	metrics.RecordSSEInFlight(eb.tenantID, float64(len(eb.listeners)))
 	// Stop the poll goroutine when no subscribers remain.
 	var doneCh chan struct{}
 	if len(eb.listeners) == 0 && eb.pollCancel != nil {
@@ -188,14 +190,18 @@ func (eb *EventBus) pollOnce(ctx context.Context) {
 	since := eb.pollLast
 	eb.mu.Unlock()
 
+	queryStart := time.Now()
 	rows, err := store.ListFSEventsSince(ctx, int64(since), 1000)
+	metrics.RecordEventBusQuery(eb.tenantID, "poll", queryResult(err), time.Since(queryStart))
 	if err != nil {
 		// Log so operators can detect persistent failures or pool-churn-induced
 		// stale-store hits. Don't send reset — just skip this tick.
 		logger.Warn(ctx, "event_bus_poll_failed",
 			zap.String("tenant_id", eb.tenantID),
 			zap.Uint64("since", since),
+			zap.Float64("query_ms", float64(time.Since(queryStart).Microseconds())/1000),
 			zap.Error(err))
+		metrics.RecordEventBusPollFailure(eb.tenantID)
 		return
 	}
 	if len(rows) == 0 {
@@ -210,18 +216,7 @@ func (eb *EventBus) pollOnce(ctx context.Context) {
 
 // Seq returns the current maximum fs_events seq, or 0 if no events exist.
 func (eb *EventBus) Seq(ctx context.Context) uint64 {
-	store := eb.store.Load()
-	if store == nil {
-		return 0
-	}
-	seq, err := store.LatestFSEventSeq(ctx)
-	if err != nil {
-		return 0
-	}
-	if seq < 0 {
-		return 0
-	}
-	return uint64(seq)
+	return uint64(clampNonNegative(latestSeqSafeWithMetric(ctx, eb.store.Load(), eb.tenantID)))
 }
 
 // EventsSince returns all events with seq > since and the current head seq.
@@ -237,10 +232,12 @@ func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []Cha
 	}
 	if since == 0 {
 		// Initial sync: send reset so client starts fresh.
-		headSeq = uint64(clampNonNegative(latestSeqSafe(ctx, store)))
+		headSeq = uint64(clampNonNegative(latestSeqSafeWithMetric(ctx, store, eb.tenantID)))
 		return nil, headSeq, false
 	}
+	queryStart := time.Now()
 	rows, err := store.ListFSEventsSince(ctx, int64(since), 1000)
+	metrics.RecordEventBusQuery(eb.tenantID, "events_since", queryResult(err), time.Since(queryStart))
 	if err != nil {
 		// Table missing or query failed: don't send reset on every poll —
 		// that would cause continuous full-cache invalidation. Instead, return
@@ -252,6 +249,7 @@ func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []Cha
 		logger.Warn(ctx, "event_bus_query_failed",
 			zap.String("tenant_id", eb.tenantID),
 			zap.Uint64("since", since),
+			zap.Float64("query_ms", float64(time.Since(queryStart).Microseconds())/1000),
 			zap.Error(err))
 		metrics.RecordTenantOperation(eb.tenantID, "event_bus", "query", "error", 0)
 		headSeq = since // keep the client's cursor unchanged
@@ -281,8 +279,10 @@ func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []Cha
 	}
 	// No rows after since. Check the actual table state to determine whether
 	// the client's cursor is stale (events pruned) or simply caught up.
-	latest := latestSeqSafe(ctx, store)
-	oldest := oldestSeqSafe(ctx, store)
+	latestStart := time.Now()
+	latest := latestSeqSafeWithMetric(ctx, store, eb.tenantID)
+	oldestStart := time.Now()
+	oldest := oldestSeqSafeWithMetric(ctx, store, eb.tenantID)
 	if latest == 0 {
 		// Table is empty (all events pruned): cursor is stale → reset.
 		return nil, 0, false
@@ -296,34 +296,56 @@ func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []Cha
 		// Client cursor is behind the oldest retained event: events between
 		// since+1 and oldest-1 were pruned, so the client has a gap → reset
 		// to avoid silently missing those events.
+		// Log the gap with table bounds so operators can detect table growth
+		// without direct DB access (oldest-seq - since delta indicates how
+		// much was pruned).
+		logger.Info(ctx, "event_bus_cursor_gap",
+			zap.String("tenant_id", eb.tenantID),
+			zap.Uint64("since", since),
+			zap.Int64("oldest", oldest),
+			zap.Int64("latest", latest),
+			zap.Float64("latest_query_ms", float64(time.Since(latestStart).Microseconds())/1000),
+			zap.Float64("oldest_query_ms", float64(time.Since(oldestStart).Microseconds())/1000))
 		return nil, headSeq, false
 	}
 	// Client is caught up: no new events after since, cursor within range.
 	return nil, headSeq, true
 }
 
-// latestSeqSafe returns LatestFSEventSeq, or 0 on error.
-func latestSeqSafe(ctx context.Context, store *datastore.Store) int64 {
+// latestSeqSafeWithMetric is latestSeqSafe plus a per-query duration metric.
+func latestSeqSafeWithMetric(ctx context.Context, store *datastore.Store, tenantID string) int64 {
 	if store == nil {
 		return 0
 	}
+	start := time.Now()
 	seq, err := store.LatestFSEventSeq(ctx)
+	metrics.RecordEventBusQuery(tenantID, "latest", queryResult(err), time.Since(start))
 	if err != nil {
 		return 0
 	}
 	return seq
 }
 
-// oldestSeqSafe returns OldestFSEventSeq, or 0 on error.
-func oldestSeqSafe(ctx context.Context, store *datastore.Store) int64 {
+// oldestSeqSafeWithMetric is oldestSeqSafe plus a per-query duration metric.
+func oldestSeqSafeWithMetric(ctx context.Context, store *datastore.Store, tenantID string) int64 {
 	if store == nil {
 		return 0
 	}
+	start := time.Now()
 	seq, err := store.OldestFSEventSeq(ctx)
+	metrics.RecordEventBusQuery(tenantID, "oldest", queryResult(err), time.Since(start))
 	if err != nil {
 		return 0
 	}
 	return seq
+}
+
+// queryResult maps a query error to a metric result label.
+func queryResult(err error) string {
+	if err != nil {
+		return "error"
+	}
+	return "ok"
 }
 
 // clampNonNegative returns v if v >= 0, else 0.

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -57,6 +57,15 @@ type requestMetricState struct {
 	bodyReadRoute    string
 	bodyReadBytes    int64
 	bodyReadDuration time.Duration
+
+	// sseStreamEstablished is set by an SSE handler (handleEvents) once it has
+	// written the 200 streaming headers and entered its long-lived select
+	// loop. observe uses it to distinguish a real SSE connection lifetime
+	// (skip HTTP duration, record SSE metrics) from a bounded error response
+	// on the same route (bad auth, invalid since, non-GET) that must still be
+	// recorded into the HTTP/tenant duration histograms. See the route guard
+	// in observe.
+	sseStreamEstablished bool
 }
 
 func withMetrics(ctx context.Context, m *serverMetrics) context.Context {
@@ -75,6 +84,46 @@ func metricsFromContext(ctx context.Context) *serverMetrics {
 func requestMetricStateFromContext(ctx context.Context) *requestMetricState {
 	v, _ := ctx.Value(requestMetricsKey).(*requestMetricState)
 	return v
+}
+
+// markSSEStreamEstablished signals that the SSE handler has written the
+// streaming response headers and entered its long-lived loop, so observe
+// should treat this as a real SSE connection lifetime (skip the HTTP
+// duration histogram) rather than a bounded error response. Safe to call
+// from the SSE handler after WriteHeader(200).
+func markSSEStreamEstablished(ctx context.Context) {
+	if st := requestMetricStateFromContext(ctx); st != nil {
+		st.mu.Lock()
+		st.sseStreamEstablished = true
+		st.mu.Unlock()
+	}
+}
+
+// sseStreamEstablished reports whether the SSE handler marked the response
+// as an established streaming connection. observe uses this to decide whether
+// to skip the HTTP duration histogram.
+func sseStreamEstablished(ctx context.Context) bool {
+	if st := requestMetricStateFromContext(ctx); st != nil {
+		st.mu.Lock()
+		defer st.mu.Unlock()
+		return st.sseStreamEstablished
+	}
+	return false
+}
+
+// recordTenantHTTPResponseBytes records the response body bytes for a request
+// without the duration histogram (used for established SSE streams where the
+// duration is excluded but byte accounting is still wanted).
+func recordTenantHTTPResponseBytes(r *http.Request, responseBytes int) {
+	tenantID := requestTenantID(r)
+	if tenantID == "" || responseBytes <= 0 {
+		return
+	}
+	class := classifyTenantRequest(r)
+	if scopedClass, ok := requestMetricClass(r.Context()); ok {
+		class = scopedClass
+	}
+	metrics.RecordTenantHTTPBytes(tenantID, class.surface, class.action, "response", int64(responseBytes))
 }
 
 func setRequestMetricScope(ctx context.Context, scope *TenantScope, class tenantRequestClass) {
@@ -352,8 +401,8 @@ func requestRoute(path string) string {
 		return "/v1/tokens/*"
 	case path == "/v1/sql":
 		return "/v1/sql"
-	case path == "/v1/events":
-		return "/v1/events"
+	case path == sseEventsRoute:
+		return sseEventsRoute
 	case path == "/v1/fork":
 		return "/v1/fork"
 	case path == "/v1/fs:batch-stat":
@@ -415,7 +464,7 @@ func classifyTenantRequest(r *http.Request) tenantRequestClass {
 		return tenantRequestClass{surface: "upload", action: classifyV2UploadAction(r)}
 	case path == "/v1/sql":
 		return tenantRequestClass{surface: "sql", action: strings.ToLower(r.Method)}
-	case path == "/v1/events":
+	case path == sseEventsRoute:
 		return tenantRequestClass{surface: "events", action: strings.ToLower(r.Method)}
 	case path == "/v1/tokens" || strings.HasPrefix(path, "/v1/tokens/"):
 		return tenantRequestClass{surface: "tokens", action: classifyTokenAction(r)}
@@ -691,16 +740,23 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	}
 
 	dur := time.Since(start)
-	// SSE routes (/v1/events) block in a select loop for the entire client
-	// connection lifetime — recording that lifetime into the HTTP request
-	// duration histogram would pollute all HTTP P95/P99 alerts (a 40s SSE
-	// connection would look like a 40s "request"). For SSE routes, record
-	// only the request counter (and tenant request counter + bytes); the
-	// connection lifetime goes into the dedicated SSE metrics recorded by
-	// handleEvents instead. duration_ms is still logged below for debugging.
-	if route == "/v1/events" {
+	// An established SSE stream (/v1/events) blocks in a select loop for the
+	// entire client connection lifetime — recording that lifetime into the
+	// HTTP request duration histogram would pollute all HTTP P95/P99 alerts
+	// (a 40s SSE connection would look like a 40s "request"). handleEvents sets
+	// the sseStreamEstablished flag only after it has written the 200 streaming
+	// headers, so bounded error responses on the same route (bad auth, invalid
+	// since, non-GET, backend setup failures) are still recorded as normal
+	// HTTP requests. For an established stream, record only the request counter
+	// (+ tenant request counter + response bytes); the connection lifetime goes
+	// into the dedicated SSE metrics recorded by handleEvents. duration_ms is
+	// still logged below for debugging.
+	if route == sseEventsRoute && sseStreamEstablished(r.Context()) {
 		s.metrics.recordCount(r.Method, route, ow.status)
 		recordTenantHTTPRequestCount(r, ow.status)
+		if ow.size > 0 {
+			recordTenantHTTPResponseBytes(r, ow.size)
+		}
 	} else {
 		s.metrics.record(r.Method, route, ow.status, dur)
 		if method, bodyRoute, bodyBytes, bodyReadDuration, ok := requestBodyReadMetric(r.Context()); ok {

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -241,6 +241,14 @@ func (m *serverMetrics) recordBodyRead(method, route string, status int, bodyByt
 	metrics.RecordHTTPRequestBodyRead(method, route, status, bodyBytes, d)
 }
 
+// recordCount records only the request counter (no duration histogram).
+// Used for SSE/streaming routes whose handler blocks for the connection
+// lifetime — recording that lifetime into the HTTP duration histogram would
+// pollute all HTTP P95/P99 alerts. See observe for the route guard.
+func (m *serverMetrics) recordCount(method, route string, status int) {
+	metrics.RecordHTTPRequestCount(method, route, status)
+}
+
 func (m *serverMetrics) recordEvent(tenantID, event string, labels ...string) {
 	metrics.RecordTenantEvent(tenantID, event, labels...)
 }
@@ -619,6 +627,23 @@ func recordTenantHTTPRequest(r *http.Request, status int, d time.Duration, respo
 	}
 }
 
+// recordTenantHTTPRequestCount records only the tenant request counter (no
+// duration histogram) for SSE/streaming routes. Companion to recordCount.
+func recordTenantHTTPRequestCount(r *http.Request, status int) {
+	tenantID := requestTenantID(r)
+	if tenantID == "" {
+		return
+	}
+	class := classifyTenantRequest(r)
+	if scopedClass, ok := requestMetricClass(r.Context()); ok {
+		class = scopedClass
+	}
+	metrics.RecordTenantRequestCount(tenantID, class.surface, class.action, tenantRequestResult(status), status)
+	if r.ContentLength > 0 {
+		metrics.RecordTenantHTTPBytes(tenantID, class.surface, class.action, "request", r.ContentLength)
+	}
+}
+
 func recordTenantFileBytes(ctx context.Context, surface, action, direction string, bytes int64) {
 	tenantID, _, _ := requestMetricScope(ctx)
 	if tenantID == "" || bytes <= 0 {
@@ -666,17 +691,29 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	}
 
 	dur := time.Since(start)
-	s.metrics.record(r.Method, route, ow.status, dur)
-	if method, bodyRoute, bodyBytes, bodyReadDuration, ok := requestBodyReadMetric(r.Context()); ok {
-		if method == "" {
-			method = r.Method
+	// SSE routes (/v1/events) block in a select loop for the entire client
+	// connection lifetime — recording that lifetime into the HTTP request
+	// duration histogram would pollute all HTTP P95/P99 alerts (a 40s SSE
+	// connection would look like a 40s "request"). For SSE routes, record
+	// only the request counter (and tenant request counter + bytes); the
+	// connection lifetime goes into the dedicated SSE metrics recorded by
+	// handleEvents instead. duration_ms is still logged below for debugging.
+	if route == "/v1/events" {
+		s.metrics.recordCount(r.Method, route, ow.status)
+		recordTenantHTTPRequestCount(r, ow.status)
+	} else {
+		s.metrics.record(r.Method, route, ow.status, dur)
+		if method, bodyRoute, bodyBytes, bodyReadDuration, ok := requestBodyReadMetric(r.Context()); ok {
+			if method == "" {
+				method = r.Method
+			}
+			if bodyRoute == "" {
+				bodyRoute = route
+			}
+			s.metrics.recordBodyRead(method, bodyRoute, ow.status, bodyBytes, bodyReadDuration)
 		}
-		if bodyRoute == "" {
-			bodyRoute = route
-		}
-		s.metrics.recordBodyRead(method, bodyRoute, ow.status, bodyBytes, bodyReadDuration)
+		recordTenantHTTPRequest(r, ow.status, dur, ow.size)
 	}
-	recordTenantHTTPRequest(r, ow.status, dur, ow.size)
 
 	tenantID, apiKeyID, _ := requestMetricScope(r.Context())
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -591,6 +591,20 @@ func (s *Server) cleanupFSEvents(ctx context.Context) {
 	// a stale-reference COUNT/DELETE logs a warning and is retried next tick —
 	// this is acceptable for best-effort retention pruning and matches the
 	// StartAllFileGC iteration pattern.
+	//
+	// Limitation (deliberate, best-effort): a tenant that served traffic, was
+	// evicted from the pool cache, and went dormant before the next cleanup tick
+	// is not pruned here until it is re-acquired (its backend re-enters the
+	// cache, and the following tick cleans it). This is acceptable because:
+	//   1. EventsSince's stale-cursor reset logic (reset when since < oldestSeq)
+	//      already makes pruned-rows correctness independent of timely pruning.
+	//   2. Evicted-dormant tenants accumulate at most their pre-eviction write
+	//      rate × the window until next acquire, bounded by fsEventsRetention.
+	// Pruning on every Acquire was rejected to avoid coupling a DELETE (with
+	// its RTT and lock cost) into the request hot path. A bounded tenant scan
+	// (meta-driven, like the semantic worker's keyset pagination) is a future
+	// option if the active set grows large enough to matter; for now the cached
+	// snapshot covers the tenants that actually accumulate rows.
 	if s.pool == nil {
 		return
 	}
@@ -925,7 +939,7 @@ func (s *Server) handleBusiness(w http.ResponseWriter, r *http.Request) {
 		s.handleFork(w, r)
 	case r.URL.Path == "/v1/sql":
 		s.handleSQL(w, r)
-	case r.URL.Path == "/v1/events":
+	case r.URL.Path == sseEventsRoute:
 		s.handleEvents(w, r)
 	case r.URL.Path == "/v1/journals" || strings.HasPrefix(r.URL.Path, "/v1/journals/") || r.URL.Path == "/v1/journal-entries":
 		s.handleJournal(w, r)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -553,6 +553,9 @@ const fsEventsRetention = 1 * time.Hour
 // rows correctly (reset when since < oldestSeq). The table grows bounded by
 // event write rate; a separate task should add per-tenant cleanup via pool
 // iteration or on Acquire. See issue #599 P1-2.
+// In both modes the row count is sampled and reported as
+// drive9_fs_events_rows so operators can monitor table growth without direct
+// DB access.
 func (s *Server) cleanupFSEvents(ctx context.Context) {
 	if ctx.Err() != nil {
 		// Context already cancelled (shutdown in progress): skip cleanup to
@@ -564,12 +567,18 @@ func (s *Server) cleanupFSEvents(ctx context.Context) {
 	if s.fallback != nil && s.meta == nil {
 		store := s.fallback.Store()
 		if store != nil {
-			if _, err := store.DeleteFSEventsBefore(ctx, time.Now().Add(-fsEventsRetention)); err != nil {
+			// Sample row count before pruning so operators can track growth.
+			if count, err := store.CountFSEvents(ctx); err == nil {
+				metrics.RecordFSEventsRows("", count)
+			}
+			if n, err := store.DeleteFSEventsBefore(ctx, time.Now().Add(-fsEventsRetention)); err != nil {
 				if ctx.Err() != nil {
 					logger.Warn(ctx, "fs_events_cleanup_interrupted_by_shutdown", zap.Error(err))
 				} else {
 					logger.Warn(ctx, "fs_events_cleanup_failed", zap.Error(err))
 				}
+			} else {
+				metrics.RecordFSEventsPruned("", n)
 			}
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -546,16 +546,19 @@ const fsEventsCleanupInterval = 5 * time.Minute
 // fsEventsRetention is how long event rows are kept before pruning.
 const fsEventsRetention = 1 * time.Hour
 
+// fsEventsCleanupTenantLimit bounds the number of active tenants scanned per
+// cleanup cycle. The 5m ticker covers many tenants over successive cycles;
+// the cap keeps each tick bounded and resumable (keyset-style pagination can
+// be added later if the active set grows beyond this).
+const fsEventsCleanupTenantLimit = 1000
+
 // cleanupFSEvents prunes old fs_events rows from accessible stores.
-// Single-tenant mode cleans the fallback store. Multi-tenant cleanup is
-// intentionally deferred: iterating all tenant stores on every tick is
-// expensive, and the stale-cursor reset logic in EventsSince handles pruned
-// rows correctly (reset when since < oldestSeq). The table grows bounded by
-// event write rate; a separate task should add per-tenant cleanup via pool
-// iteration or on Acquire. See issue #599 P1-2.
-// In both modes the row count is sampled and reported as
-// drive9_fs_events_rows so operators can monitor table growth without direct
-// DB access.
+// Single-tenant mode cleans the fallback store. Multi-tenant mode iterates
+// active tenants via the meta store + pool, pruning each tenant's fs_events
+// table and sampling the row count into drive9_fs_events_rows so operators
+// can monitor table growth without direct DB access. The stale-cursor reset
+// logic in EventsSince handles pruned rows correctly (reset when since <
+// oldestSeq). See issue #599 P1-2.
 func (s *Server) cleanupFSEvents(ctx context.Context) {
 	if ctx.Err() != nil {
 		// Context already cancelled (shutdown in progress): skip cleanup to
@@ -581,9 +584,60 @@ func (s *Server) cleanupFSEvents(ctx context.Context) {
 				metrics.RecordFSEventsPruned("", n)
 			}
 		}
+		return
 	}
-	// Multi-tenant: deferred to a separate task. The fs_events table grows
-	// unbounded in multi-tenant mode until per-tenant cleanup is implemented.
+	// Multi-tenant mode: iterate active tenants, prune each fs_events table
+	// and sample row counts. The scan is bounded by fsEventsCleanupTenantLimit
+	// and runs on the fsEventsCleanupInterval (5m) ticker, so the per-tick
+	// cost is proportional to active tenants (bounded) — not "expensive" as the
+	// old comment feared. pool.Acquire pins each backend so a concurrent
+	// retirement cannot close the store mid-DELETE.
+	if s.meta == nil || s.pool == nil {
+		return
+	}
+	tenants, err := s.meta.ListTenantsByStatus(ctx, meta.TenantActive, fsEventsCleanupTenantLimit)
+	if err != nil {
+		if ctx.Err() != nil {
+			logger.Warn(ctx, "fs_events_cleanup_list_interrupted_by_shutdown", zap.Error(err))
+		} else {
+			logger.Warn(ctx, "fs_events_cleanup_list_failed", zap.Error(err))
+		}
+		return
+	}
+	for i := range tenants {
+		if ctx.Err() != nil {
+			logger.Warn(ctx, "fs_events_cleanup_loop_interrupted_by_shutdown", zap.Error(ctx.Err()))
+			return
+		}
+		t := tenants[i]
+		b, release, err := s.pool.Acquire(ctx, &t)
+		if err != nil {
+			// Backend may not be cached/openable (e.g. credentials pending);
+			// skip this tenant rather than failing the whole cycle.
+			logger.Warn(ctx, "fs_events_cleanup_acquire_failed",
+				zap.String("tenant_id", t.ID), zap.Error(err))
+			continue
+		}
+		store := b.Store()
+		if store != nil {
+			if count, err := store.CountFSEvents(ctx); err == nil {
+				metrics.RecordFSEventsRows(t.ID, count)
+			}
+			if n, err := store.DeleteFSEventsBefore(ctx, time.Now().Add(-fsEventsRetention)); err != nil {
+				if ctx.Err() != nil {
+					logger.Warn(ctx, "fs_events_cleanup_interrupted_by_shutdown",
+						zap.String("tenant_id", t.ID), zap.Error(err))
+					release()
+					return
+				}
+				logger.Warn(ctx, "fs_events_cleanup_failed",
+					zap.String("tenant_id", t.ID), zap.Error(err))
+			} else {
+				metrics.RecordFSEventsPruned(t.ID, n)
+			}
+		}
+		release()
+	}
 }
 
 // stopLeaderWorkers stops the background schedulers started by startLeaderWorkers.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -523,9 +523,9 @@ func (s *Server) startLeaderWorkers() {
 	}
 	// Periodic fs_events cleanup (leader-only). Prunes old event rows so the
 	// table doesn't grow unbounded. In single-tenant mode, cleans the fallback
-	// store. Multi-tenant cleanup is deferred to a separate task (see comment
-	// in cleanupFSEvents) — the table grows but bounded by event write rate
-	// and the 1h retention applies once multi-tenant cleanup is implemented.
+	// store. In multi-tenant mode, iterates tenants with a cached backend via
+	// pool.ActiveTenantStores and prunes each fs_events table. See
+	// cleanupFSEvents for details.
 	s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
 		ticker := time.NewTicker(fsEventsCleanupInterval)
 		defer ticker.Stop()
@@ -545,12 +545,6 @@ const fsEventsCleanupInterval = 5 * time.Minute
 
 // fsEventsRetention is how long event rows are kept before pruning.
 const fsEventsRetention = 1 * time.Hour
-
-// fsEventsCleanupTenantLimit bounds the number of active tenants scanned per
-// cleanup cycle. The 5m ticker covers many tenants over successive cycles;
-// the cap keeps each tick bounded and resumable (keyset-style pagination can
-// be added later if the active set grows beyond this).
-const fsEventsCleanupTenantLimit = 1000
 
 // cleanupFSEvents prunes old fs_events rows from accessible stores.
 // Single-tenant mode cleans the fallback store. Multi-tenant mode iterates
@@ -586,57 +580,40 @@ func (s *Server) cleanupFSEvents(ctx context.Context) {
 		}
 		return
 	}
-	// Multi-tenant mode: iterate active tenants, prune each fs_events table
-	// and sample row counts. The scan is bounded by fsEventsCleanupTenantLimit
-	// and runs on the fsEventsCleanupInterval (5m) ticker, so the per-tick
-	// cost is proportional to active tenants (bounded) — not "expensive" as the
-	// old comment feared. pool.Acquire pins each backend so a concurrent
-	// retirement cannot close the store mid-DELETE.
-	if s.meta == nil || s.pool == nil {
+	// Multi-tenant mode: iterate tenants with a cached backend, prune each
+	// fs_events table and sample row counts. fs_events rows only accumulate for
+	// tenants that have served traffic (and thus have a cached backend), so
+	// iterating ActiveTenantStores (a cheap cache snapshot) covers the tenants
+	// that need cleanup without forcing backend creation for dormant tenants
+	// (which would exhaust connections and fail for tenants whose credentials
+	// are not materialized). Runs on the fsEventsCleanupInterval (5m) ticker.
+	// A concurrent retirement may close the store after the snapshot returns;
+	// a stale-reference COUNT/DELETE logs a warning and is retried next tick —
+	// this is acceptable for best-effort retention pruning and matches the
+	// StartAllFileGC iteration pattern.
+	if s.pool == nil {
 		return
 	}
-	tenants, err := s.meta.ListTenantsByStatus(ctx, meta.TenantActive, fsEventsCleanupTenantLimit)
-	if err != nil {
-		if ctx.Err() != nil {
-			logger.Warn(ctx, "fs_events_cleanup_list_interrupted_by_shutdown", zap.Error(err))
-		} else {
-			logger.Warn(ctx, "fs_events_cleanup_list_failed", zap.Error(err))
-		}
-		return
-	}
-	for i := range tenants {
+	for _, te := range s.pool.ActiveTenantStores() {
 		if ctx.Err() != nil {
 			logger.Warn(ctx, "fs_events_cleanup_loop_interrupted_by_shutdown", zap.Error(ctx.Err()))
 			return
 		}
-		t := tenants[i]
-		b, release, err := s.pool.Acquire(ctx, &t)
-		if err != nil {
-			// Backend may not be cached/openable (e.g. credentials pending);
-			// skip this tenant rather than failing the whole cycle.
-			logger.Warn(ctx, "fs_events_cleanup_acquire_failed",
-				zap.String("tenant_id", t.ID), zap.Error(err))
-			continue
+		// Sample row count before pruning so operators can track growth.
+		if count, err := te.Store.CountFSEvents(ctx); err == nil {
+			metrics.RecordFSEventsRows(te.TenantID, count)
 		}
-		store := b.Store()
-		if store != nil {
-			if count, err := store.CountFSEvents(ctx); err == nil {
-				metrics.RecordFSEventsRows(t.ID, count)
+		if n, err := te.Store.DeleteFSEventsBefore(ctx, time.Now().Add(-fsEventsRetention)); err != nil {
+			if ctx.Err() != nil {
+				logger.Warn(ctx, "fs_events_cleanup_interrupted_by_shutdown",
+					zap.String("tenant_id", te.TenantID), zap.Error(err))
+				return
 			}
-			if n, err := store.DeleteFSEventsBefore(ctx, time.Now().Add(-fsEventsRetention)); err != nil {
-				if ctx.Err() != nil {
-					logger.Warn(ctx, "fs_events_cleanup_interrupted_by_shutdown",
-						zap.String("tenant_id", t.ID), zap.Error(err))
-					release()
-					return
-				}
-				logger.Warn(ctx, "fs_events_cleanup_failed",
-					zap.String("tenant_id", t.ID), zap.Error(err))
-			} else {
-				metrics.RecordFSEventsPruned(t.ID, n)
-			}
+			logger.Warn(ctx, "fs_events_cleanup_failed",
+				zap.String("tenant_id", te.TenantID), zap.Error(err))
+		} else {
+			metrics.RecordFSEventsPruned(te.TenantID, n)
 		}
-		release()
 	}
 }
 

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -177,6 +177,7 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 				zap.String("op", op),
 				zap.Error(err))
 			metrics.RecordTenantOperation(bus.tenantID, "event_bus", "publish", "error", 0)
+			metrics.RecordEventBusPublishError(bus.tenantID)
 		}
 	}
 	bus.Publish()
@@ -206,6 +207,17 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	}
 
 	bus := s.tenantEventBus(r)
+	tenantID := bus.tenantID
+	connStart := time.Now()
+	// Track SSE inflight and connection lifetime. The inflight count is
+	// derived from the EventBus listener set (adjusted in Subscribe/
+	// Unsubscribe); here we record the connection lifecycle into the
+	// dedicated SSE metrics (NOT the HTTP duration histogram — see the
+	// route guard in observe).
+	defer func() {
+		metrics.RecordSSEConnection(tenantID, "closed", time.Since(connStart))
+	}()
+
 	subID, notify := bus.Subscribe()
 	defer bus.Unsubscribe(subID)
 
@@ -221,6 +233,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// Phase 1: Replay or Reset.
 	// EventsSince reads from the durable fs_events table, so events written
 	// by other pods are visible here (cross-pod propagation).
+	phase1Start := time.Now()
 	events, headSeq, ok := bus.EventsSince(ctx, since)
 	lastSeen := since
 
@@ -235,10 +248,12 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		sendSSEReset(bw, headSeq, reason)
+		metrics.RecordSSEResetSent(tenantID, reason)
 		lastSeen = headSeq
 	} else {
 		for _, ev := range events {
 			sendSSEEvent(bw, ev)
+			metrics.RecordSSEEventSent(tenantID, ev.Op)
 			lastSeen = ev.Seq
 		}
 	}
@@ -247,11 +262,13 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// were marked unverified on disconnect become verified without waiting
 	// for the periodic heartbeat.
 	sendSSEHeartbeat(bw, lastSeen)
+	metrics.RecordSSEHeartbeatSent(tenantID)
 	// Flush initial replay/reset immediately so the client receives the
 	// cursor position without waiting for the periodic heartbeat.
 	if err := bw.Flush(); err != nil {
 		return
 	}
+	metrics.RecordSSEPhase1(tenantID, time.Since(phase1Start))
 
 	// Phase 2: Live stream with micro-batching.
 	// The notify channel catches same-pod events instantly. A 1s poll ticker
@@ -280,6 +297,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		liveEvents, liveHead, liveOK := bus.EventsSince(ctx, lastSeen)
 		if !liveOK {
 			sendSSEReset(bw, liveHead, "seq_too_old")
+			metrics.RecordSSEResetSent(tenantID, "seq_too_old")
 			lastSeen = liveHead
 			if err := bw.Flush(); err != nil {
 				return false
@@ -292,6 +310,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, ev := range liveEvents {
 			sendSSEEvent(bw, ev)
+			metrics.RecordSSEEventSent(tenantID, ev.Op)
 			lastSeen = ev.Seq
 		}
 		if bw.count > 0 {
@@ -322,6 +341,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			return
 		case <-heartbeat.C:
 			sendSSEHeartbeat(bw, lastSeen)
+			metrics.RecordSSEHeartbeatSent(tenantID)
 			if err := bw.Flush(); err != nil {
 				return
 			}

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -20,6 +20,12 @@ const (
 	sseHeartbeatInterval = 30 * time.Second
 	sseFlushBatchSize    = 10
 	sseFlushMaxDelay     = 1 * time.Millisecond
+
+	// sseEventsRoute is the SSE change-notification stream endpoint. It is the
+	// only SSE route today; observe uses this constant (plus the
+	// sseStreamEstablished context flag) to distinguish real SSE connection
+	// lifetimes from bounded error responses on the same route.
+	sseEventsRoute = "/v1/events"
 )
 
 // stopTimer drains a timer's channel after stopping it to prevent spurious
@@ -227,6 +233,11 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("X-Accel-Buffering", "no") // disable nginx buffering
 	w.WriteHeader(http.StatusOK)
 	flusher.Flush()
+	// Mark the stream as established so observe treats this as a real SSE
+	// connection lifetime (skip HTTP duration histogram, record SSE metrics
+	// instead of normal HTTP/tenant durations). Bounded error responses that
+	// return before this point are still recorded as normal HTTP requests.
+	markSSEStreamEstablished(r.Context())
 
 	ctx := r.Context()
 
@@ -253,7 +264,13 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	} else {
 		for _, ev := range events {
 			sendSSEEvent(bw, ev)
-			metrics.RecordSSEEventSent(tenantID, ev.Op)
+			if isStructuralOp(ev.Op) {
+				// Structural ops are emitted as reset events (see sendSSEEvent),
+				// so count them as resets, not file_changed deliveries.
+				metrics.RecordSSEResetSent(tenantID, "structural_change")
+			} else {
+				metrics.RecordSSEEventSent(tenantID, ev.Op)
+			}
 			lastSeen = ev.Seq
 		}
 	}
@@ -310,7 +327,11 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		}
 		for _, ev := range liveEvents {
 			sendSSEEvent(bw, ev)
-			metrics.RecordSSEEventSent(tenantID, ev.Op)
+			if isStructuralOp(ev.Op) {
+				metrics.RecordSSEResetSent(tenantID, "structural_change")
+			} else {
+				metrics.RecordSSEEventSent(tenantID, ev.Op)
+			}
 			lastSeen = ev.Seq
 		}
 		if bw.count > 0 {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -114,6 +114,43 @@ func (p *Pool) StopAllFileGC() {
 	}
 }
 
+// ActiveTenantStores snapshots the (tenantID, store) pairs currently cached in
+// the pool. It is intended for leader-only background maintenance (e.g. the
+// fs_events cleanup goroutine) that should operate only on tenants with a
+// live backend — fs_events rows only accumulate for tenants that have served
+// traffic and thus have a cached backend. Unlike ListTenantsByStatus +
+// Acquire, this does NOT open backends for dormant tenants (which would
+// exhaust connections and fail for tenants whose credentials are not
+// materialized), so it is cheap and safe to call on every cleanup tick.
+// The returned stores are pinned only for the duration of the snapshot call;
+// callers must not retain them past the cleanup operation (a concurrent
+// retirement may close the underlying DB once this returns). In practice the
+// leader cleanup runs briefly and the entry's refs prevent close mid-use only
+// while Acquire is held — for a read-only COUNT/DELETE that tolerates a stale
+// reference error, this snapshot is sufficient and matches the existing
+// StartAllFileGC iteration pattern.
+func (p *Pool) ActiveTenantStores() []TenantStoreEntry {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	out := make([]TenantStoreEntry, 0, len(p.items))
+	for _, e := range p.items {
+		if e.store == nil || e.retired {
+			continue
+		}
+		out = append(out, TenantStoreEntry{TenantID: e.tenantID, Store: e.store})
+	}
+	p.mu.Unlock()
+	return out
+}
+
+// TenantStoreEntry is a (tenantID, store) pair returned by ActiveTenantStores.
+type TenantStoreEntry struct {
+	TenantID string
+	Store    *datastore.Store
+}
+
 type Pool struct {
 	mu                        sync.Mutex
 	cfg                       PoolConfig


### PR DESCRIPTION
## Problem

The `/v1/events` endpoint triggered "tens-of-seconds" latency alerts. Investigation confirmed this is a **measurement artifact**, not a real latency regression.

The `observe` middleware records `time.Since(start)` into `drive9_http_request_duration_seconds` only after the handler returns. But `handleEvents` is an SSE long-lived connection — after the Phase-1 replay it enters a `select` loop and blocks as long as the client stays subscribed. So the SSE connection lifetime was recorded as an HTTP request duration: a connection held open for 40s was logged as a 40s "request", falling into the 10s `+Inf` histogram bucket — exactly the alert band.

**Decisive dev experiment**: hold an SSE connection open for 15s → `drive9_http_request_duration_seconds{route="/v1/events"}` `+Inf` bucket +1, sum +14.96s — proving the alert is SSE connection lifetime leaking into the HTTP duration histogram, not a real latency regression. This artifact has existed since SSE shipped (4824b60, 2026-04-14), over two months before the multi-pod refactor — it was not introduced by the refactor.

## Changes

### Fix A — Exclude SSE lifetime from the HTTP duration histogram
`pkg/server/instrumentation.go`: for route `/v1/events`, record only the request counter and inflight gauge, **skipping** the `drive9_http_request_duration_seconds` histogram (added `RecordHTTPRequestCount`/`RecordTenantRequestCount`). SSE connection lifetime now goes into dedicated metrics. **Dev verification**: after the fix, holding an SSE connection for 15s no longer changes the HTTP duration histogram count/+Inf/sum — the alert will no longer fire.

### Fix B — SSE / event-bus / fs_events diagnostic metrics + logs
Compensates for the lack of direct TiDB access — everything is observable from `/metrics` and logs:

- `drive9_sse_connection_duration_seconds` (connection lifetime; buckets include 60s/300s/600s/1800s/3600s)
- `drive9_sse_inflight_connections{tenant_id}` (active SSE connections)
- `drive9_sse_phase1_duration_seconds{tenant_id}` (Phase-1 replay/reset cost — **key for distinguishing "slow first replay" from "Phase-2 client holding open"**)
- `drive9_sse_events_sent_total{op,tenant_id}` / `drive9_sse_resets_sent_total{reason,tenant_id}` / `drive9_sse_heartbeats_sent_total{tenant_id}`
- `drive9_event_bus_query_duration_seconds{operation=events_since|poll|latest|oldest, result=ok|error, tenant_id}` (all fs_events DB query latency, success included)
- `drive9_event_bus_poll_failures_total{tenant_id}` / `drive9_event_bus_publish_errors_total{tenant_id}`
- `drive9_fs_events_rows{tenant_id}` / `drive9_fs_events_pruned_total{tenant_id}` (table size + prune volume, no direct DB access needed)
- `event_bus_cursor_gap` log with oldest/latest/since + query_ms (log-side table-growth detection)

Adds `Store.CountFSEvents` (`pkg/datastore/fs_events.go`).

### Multi-tenant fs_events cleanup (issue #599 P1-2)
`cleanupFSEvents` in `pkg/server/server.go` previously ran only in single-tenant mode; in multi-tenant mode the table grew unbounded. Adds a multi-tenant branch using `pool.ActiveTenantStores()` (new in `pkg/tenant/pool.go`, mirroring `StartAllFileGC`'s cache-snapshot pattern) to iterate tenants with a **cached backend** (only these accumulate fs_events rows), calling `CountFSEvents`/`DeleteFSEventsBefore` per tenant and reporting row count + prune volume.

> Not using `ListTenantsByStatus + pool.Acquire`: that forces `createBackend` for every listed tenant, exhausting connections and failing for dormant tenants without materialized credentials (observed on dev: 205 acquire errors). `ActiveTenantStores` snapshots only cached backends — zero extra connection overhead. **Dev verification**: `drive9_fs_events_rows{tenant_id="d03e99aa..."} 8` now reported per tenant, cleanup tick working.

## Dev verification results

| Item | Result |
|---|---|
| SSE lifetime no longer in HTTP duration histogram | ✅ after fix, +Inf/count/sum unchanged |
| SSE lifetime in dedicated `drive9_sse_connection_duration_seconds` | ✅ 15s connection lands in `le=30` bucket |
| Phase-1 slow? | ✅ 4.6–12.9ms (not slow — alert is pure Phase-2 client hold-open) |
| event-bus query latency | ✅ events_since 5.4ms / poll avg ~7ms / latest/oldest 3.5–4.6ms |
| poll/publish failures | ✅ 0 |
| SSE event delivery | ✅ real-time write events pushed correctly, `drive9_sse_events_sent_total` counting correctly |
| multi-tenant `fs_events_rows` reporting | ✅ reported per tenant, cleanup tick normal |

**Conclusion**: the alert was a measurement artifact; Fix A stops the bleeding. Phase-1 and queries are not slow — no real latency regression. Multi-tenant cleanup closes the blind spot of not seeing table size without TiDB access, and eliminates the slow-burn regression.

## Remaining / follow-up (not in this PR)

- **3a DB pool `max_open=0`** (default unlimited): dev shows `drive9_db_pool_connections{role="user",state="max_open"} 0`. N_pods × unlimited connections risks exhausting TiDB `max_connections` (not triggered at dev's low load). This is a deployment config (`DRIVE9_DB_MAX_OPEN_CONNS` env), not in this repo — recommend setting `TiDB_max_connections / N_pods` on the cluster side.
- poll-interval adaptive backoff (3c) and quota_admission_lock contention (3d) — defer based on production data.

## Testing

- `go build ./...` ✅
- `go vet` ✅
- `golangci-lint` (zero new warnings in this PR's source files; pre-existing test-file SA5011 unaffected)
- `go test ./pkg/metrics/ ./pkg/datastore/ ./pkg/tenant/ ./pkg/server/` (incl. SSE/eventbus/cleanup/leader cases) ✅
- dev-cd deploy + dev online verification ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer streaming and event-bus metrics, including connection counts, in-flight tracking, event delivery, heartbeats, resets, and query timing.
  * Added tenant-aware request counting for long-lived streams without affecting duration histograms.
  * Added active tenant store snapshot support for pool-wide maintenance tasks.

* **Bug Fixes**
  * Improved SSE handling so established streams are tracked separately from normal requests.
  * Updated event-stream cleanup and reset handling to better reflect retained event counts and pruning results.
  * Added a total event-row count check for datastore maintenance and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->