### PR TITLE
fix: treat quota outbox claim races as benign

### DIFF
--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -17,6 +17,7 @@ import (
 // current capped exponential backoff this is roughly tens of minutes, while
 // still allowing normal transient central-store failures to recover.
 const defaultQuotaOutboxMaxAttempts = 100
+const quotaOutboxClaimMaxAttempts = 3
 const quotaAdmissionLockName = "default"
 
 type QuotaOutboxStatus string
@@ -55,6 +56,8 @@ type QuotaOutboxEntry struct {
 // ErrQuotaOutboxLeaseMismatch means a worker tried to ack/retry an outbox row
 // it no longer owns.
 var ErrQuotaOutboxLeaseMismatch = errors.New("quota outbox lease mismatch")
+
+var errQuotaOutboxClaimConflict = errors.New("quota outbox claim conflict")
 
 // EnqueueQuotaOutboxTx inserts a queued quota mutation inside an existing
 // tenant metadata transaction.
@@ -106,6 +109,17 @@ func (s *Store) ClaimQuotaOutboxBatch(ctx context.Context, now time.Time, leaseD
 }
 
 func (s *Store) claimQuotaOutboxBatch(ctx context.Context, now time.Time, leaseDuration time.Duration, limit int) ([]QuotaOutboxEntry, error) {
+	for attempt := 0; attempt < quotaOutboxClaimMaxAttempts; attempt++ {
+		entries, err := s.claimQuotaOutboxBatchOnce(ctx, now, leaseDuration, limit)
+		if errors.Is(err, errQuotaOutboxClaimConflict) {
+			continue
+		}
+		return entries, err
+	}
+	return nil, nil
+}
+
+func (s *Store) claimQuotaOutboxBatchOnce(ctx context.Context, now time.Time, leaseDuration time.Duration, limit int) ([]QuotaOutboxEntry, error) {
 	if limit <= 0 {
 		limit = 1
 	}
@@ -183,7 +197,12 @@ func (s *Store) claimQuotaOutboxBatch(ctx context.Context, now time.Time, leaseD
 		return nil, err
 	}
 	if rowsAffected != int64(len(entries)) {
-		return nil, ErrQuotaOutboxLeaseMismatch
+		// In multi-server deployments TiDB can report that fewer rows were
+		// claimed than the preceding SKIP LOCKED read selected. Treat that as a
+		// benign claim race: rollback this tx and let this worker retry or let
+		// another worker process the rows. Ack/retry paths still use
+		// ErrQuotaOutboxLeaseMismatch for real ownership failures.
+		return nil, errQuotaOutboxClaimConflict
 	}
 
 	for i := range entries {

--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -10,6 +10,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 // defaultQuotaOutboxMaxAttempts bounds how long a poisoned quota mutation can
@@ -116,6 +118,7 @@ func (s *Store) claimQuotaOutboxBatch(ctx context.Context, now time.Time, leaseD
 		}
 		return entries, err
 	}
+	metrics.RecordOperation("datastore", "claim_quota_outbox_conflict_exhausted", "conflict", 0)
 	return nil, nil
 }
 
@@ -197,10 +200,10 @@ func (s *Store) claimQuotaOutboxBatchOnce(ctx context.Context, now time.Time, le
 		return nil, err
 	}
 	if rowsAffected != int64(len(entries)) {
-		// In multi-server deployments TiDB can report that fewer rows were
-		// claimed than the preceding SKIP LOCKED read selected. Treat that as a
-		// benign claim race: rollback this tx and let this worker retry or let
-		// another worker process the rows. Ack/retry paths still use
+		// Under concurrent SKIP LOCKED claims, TiDB can report that fewer rows
+		// were claimed than the preceding read selected. Treat that as a benign
+		// claim race: rollback this tx and let this worker retry or let another
+		// worker process the rows. Ack/retry paths still use
 		// ErrQuotaOutboxLeaseMismatch for real ownership failures.
 		return nil, errQuotaOutboxClaimConflict
 	}

--- a/pkg/datastore/quota_outbox_test.go
+++ b/pkg/datastore/quota_outbox_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
+	"sync"
 	"testing"
 	"time"
 )
@@ -66,6 +68,63 @@ func TestQuotaOutboxLifecycle(t *testing.T) {
 	}
 	if storageDelta != 0 || fileDelta != 0 || mediaDelta != 0 {
 		t.Fatalf("pending deltas after ack = %d/%d/%d, want 0/0/0", storageDelta, fileDelta, mediaDelta)
+	}
+}
+
+func TestQuotaOutboxConcurrentBatchClaimNoDuplicates(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+
+	const totalRows = 20
+	for i := 0; i < totalRows; i++ {
+		if _, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+			FileID:       fmt.Sprintf("file-%02d", i),
+			MutationType: "file_create",
+			MutationData: json.RawMessage(`{"file_id":"file"}`),
+			AvailableAt:  now.Add(-time.Second),
+		}); err != nil {
+			t.Fatalf("enqueue %d: %v", i, err)
+		}
+	}
+
+	var mu sync.Mutex
+	seen := make(map[int64]struct{})
+	errCh := make(chan error, 8)
+	var wg sync.WaitGroup
+	for i := 0; i < cap(errCh); i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				claimed, err := s.ClaimQuotaOutboxBatch(ctx, now, time.Minute, 5)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if len(claimed) == 0 {
+					return
+				}
+				mu.Lock()
+				for _, entry := range claimed {
+					if _, ok := seen[entry.ID]; ok {
+						mu.Unlock()
+						errCh <- fmt.Errorf("duplicate claim for row %d", entry.ID)
+						return
+					}
+					seen[entry.ID] = struct{}{}
+				}
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+	if len(seen) != totalRows {
+		t.Fatalf("claimed rows = %d, want %d", len(seen), totalRows)
 	}
 }
 


### PR DESCRIPTION
## Summary
- handle quota outbox claim-stage row-count mismatches as benign multi-server claim races instead of surfacing ErrQuotaOutboxLeaseMismatch
- retry claim conflicts a few times, then return an empty batch so another worker or the next poll can continue
- keep ErrQuotaOutboxLeaseMismatch semantics for ack/retry ownership failures
- add concurrent batch-claim coverage to assert no duplicate claims

## Context
Production logs showed quota_outbox_process_failed caused by claim_quota_outbox_batch returning quota outbox lease mismatch across multiple drive9-server pods. This happens before apply/ack, so it should not be treated as an ownership failure for an already claimed row.

## Tests
- make test TEST_PKGS='./pkg/datastore' TEST_RUN='TestQuotaOutbox'
- make test TEST_PKGS='./pkg/backend' TEST_RUN='Test.*QuotaOutbox|TestDrainQuotaOutboxForFile'
- make lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when claiming queued quota outbox items under concurrent load.
  * Reduced false ownership/lease errors by treating benign claim races as retryable.
  * Added limited automatic retries so claim attempts can recover from temporary conflicts without failing immediately.
  * Strengthened concurrency handling to help prevent duplicate processing of the same queued item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->