### PR TITLE
fix(prod-cd): deploy drive9-server to drive9-tidbcloud namespace in aws-us-east-1

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -129,6 +129,22 @@ jobs:
           kubectl --context us -n "${{ env.DEPLOY_NAMESPACE }}" \
             rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
 
+      - name: Deploy drive9-tidbcloud to aws-us-east-1
+        id: deploy-us-native
+        if: inputs.region == 'all' || inputs.region == 'aws-us-east-1'
+        run: |
+          kubectl --context us -n drive9-tidbcloud \
+            set image deployment/drive9-server \
+            drive9-server=$IMAGE
+          kubectl --context us -n drive9-tidbcloud \
+            rollout status deployment/drive9-server --timeout=180s
+
+      - name: Rollback drive9-tidbcloud aws-us-east-1 on failure
+        if: failure() && steps.deploy-us-native.outcome == 'failure'
+        run: |
+          kubectl --context us -n drive9-tidbcloud \
+            rollout undo deployment/drive9-server
+
       - name: Configure Alibaba Cloud credentials
         if: inputs.region == 'all' || inputs.region == 'alicloud-ap-southeast-1'
         uses: aliyun/configure-aliyun-credentials-action@v1


### PR DESCRIPTION
## Problem

`drive9 create --region-code aws-us-east-1 --tidbcloud-public-key ... --tidbcloud-private-key ...` returns HTTP 400: `invalid JSON body: json: unknown field "tidbcloud_spending_limit"`

## Root cause

The `aws-us-east-1` section in `prod-cd.yml` only deployed `dat9-server` (in the `dat9` namespace) and was missing the `drive9-server` deployment (in the `drive9-tidbcloud` namespace). As a result, `drive9-server` in us-east-1 was running a stale image that does not recognize the `tidbcloud_spending_limit` field.

The `aws-ap-southeast-1` section had both deployments — us-east-1 was missing the second one.

## Fix

Added a deploy step and a rollback step for `drive9-server` in the `drive9-tidbcloud` namespace for `aws-us-east-1`, matching the existing pattern in `aws-ap-southeast-1`.