### PR TITLE
fix: e2e cleanup sweeps all active mounts before rm

### DIFF
--- a/e2e/git-workspace-smoke-test.sh
+++ b/e2e/git-workspace-smoke-test.sh
@@ -314,7 +314,7 @@ dump_mount_log() {
   fi
   # Also dump any other mount logs under RUN_ROOT that weren't the last one.
   if [ -n "${RUN_ROOT:-}" ] && [ -d "$RUN_ROOT" ]; then
-    find "$RUN_ROOT" -name '*.log' -type f 2>/dev/null | while read -r logf; do
+    find "$RUN_ROOT" -xdev -name '*.log' -type f 2>/dev/null | while read -r logf; do
       [ "$logf" = "${MOUNT_LOG:-}" ] && continue
       echo "=== drive9 mount log: $logf ==="
       cat "$logf"
@@ -667,7 +667,7 @@ cleanup() {
       [ -z "$mp" ] && continue
       MOUNT_POINT="$mp"
       stop_mount
-    done < <(find "$RUN_ROOT" -maxdepth 3 -name mount -type d 2>/dev/null | while read -r d; do
+    done < <(find "$RUN_ROOT" -maxdepth 2 -name mount -type d -prune 2>/dev/null | while read -r d; do
       if is_mounted "$d" 2>/dev/null; then
         printf '%s\n' "$d"
       fi

--- a/e2e/git-workspace-smoke-test.sh
+++ b/e2e/git-workspace-smoke-test.sh
@@ -312,6 +312,14 @@ dump_mount_log() {
     echo "=== drive9 mount log: $MOUNT_LOG ==="
     cat "$MOUNT_LOG"
   fi
+  # Also dump any other mount logs under RUN_ROOT that weren't the last one.
+  if [ -n "${RUN_ROOT:-}" ] && [ -d "$RUN_ROOT" ]; then
+    find "$RUN_ROOT" -name '*.log' -type f 2>/dev/null | while read -r logf; do
+      [ "$logf" = "${MOUNT_LOG:-}" ] && continue
+      echo "=== drive9 mount log: $logf ==="
+      cat "$logf"
+    done
+  fi
 }
 
 audit_mount_log() {
@@ -649,7 +657,22 @@ run_repo_scenario() {
 }
 
 cleanup() {
+  # First, unmount the currently tracked mount (if any).
   stop_mount
+  # Then sweep RUN_ROOT for any leftover FUSE mounts that were not cleaned
+  # up — e.g. when set -e triggers exit between start_mount and stop_mount
+  # in a multi-mount scenario (sandbox_restore, fast_worktree).
+  if [ -n "${RUN_ROOT:-}" ] && [ -d "$RUN_ROOT" ]; then
+    while IFS= read -r mp; do
+      [ -z "$mp" ] && continue
+      MOUNT_POINT="$mp"
+      stop_mount
+    done < <(find "$RUN_ROOT" -maxdepth 3 -name mount -type d 2>/dev/null | while read -r d; do
+      if is_mounted "$d" 2>/dev/null; then
+        printf '%s\n' "$d"
+      fi
+    done)
+  fi
   if [ -n "${CLI_BIN:-}" ]; then
     rm -f "$CLI_BIN"
   fi


### PR DESCRIPTION
## Summary
- **Root cause**: `cleanup()` only unmounted the last tracked `$MOUNT_POINT`, leaving earlier mounts from multi-mount scenarios (`sandbox_restore`, `fast_worktree`) still active
- When `set -e` triggered exit mid-scenario, `rm -rf $RUN_ROOT` hit "Device or resource busy" and in-flight HTTP requests got context-canceled
- Now `cleanup()` sweeps `$RUN_ROOT` for any remaining FUSE mounts and unmounts each before removing the directory
- Also dumps all mount logs on failure, not just the last one

## Context
From e2e failure:
```
rm: cannot remove '.../drive9-sandbox_restore/mount': Device or resource busy
git workspace refresh failed: context canceled
```

## Test plan
- [ ] Run git-workspace e2e on CI
- [ ] Verify multi-mount scenarios (sandbox_restore, fast_worktree) clean up properly on early exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved smoke-test log collection to include additional related log files, not only the most recent mount log.
  * Enhanced cleanup to better detect and stop any remaining mounted filesystem(s) when failures occur between mount operations, reducing leftover mount issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->