### PR TITLE
Fix quota worker noise and pending delta cache races

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -119,6 +119,7 @@ type Dat9Backend struct {
 	quotaOutboxNotify chan struct{}
 	quotaOutboxWG     sync.WaitGroup
 	quotaOutboxStop   context.CancelFunc
+	claimQuotaOutbox  quotaOutboxBatchClaimer
 
 	s3EncryptionPolicy meta.ResolvedS3EncryptionPolicy
 

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -291,10 +291,11 @@ type quotaPendingDeltasCache struct {
 	load     quotaPendingDeltasLoader
 	ttl      time.Duration
 
-	mu         sync.RWMutex
-	snapshot   *quotaPendingDeltasSnapshot
-	generation uint64
-	loadMu     sync.Mutex
+	mu                  sync.RWMutex
+	snapshot            *quotaPendingDeltasSnapshot
+	generation          uint64
+	localPositiveDeltas quotaPendingDeltas
+	loadMu              sync.Mutex
 }
 
 func newQuotaPendingDeltasCache(tenantID string, load quotaPendingDeltasLoader, ttl time.Duration) *quotaPendingDeltasCache {
@@ -322,6 +323,7 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 
 	c.mu.RLock()
 	generation := c.generation
+	localPositiveDeltas := c.localPositiveDeltas
 	c.mu.RUnlock()
 
 	start := time.Now()
@@ -339,12 +341,19 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 	expiresAt := time.Now().Add(c.ttl)
 	c.mu.Lock()
 	if c.generation != generation {
+		deltas.add(c.localPositiveDeltas.sub(localPositiveDeltas))
+		c.snapshot = &quotaPendingDeltasSnapshot{
+			deltas:    deltas,
+			expiresAt: expiresAt,
+		}
 		c.mu.Unlock()
-		// A local enqueue or ack raced this DB load. Do not merge blindly:
-		// the SELECT may or may not have observed that row. Let the caller
-		// fall back to a live tenant-DB read for this check.
+		// A local enqueue or ack raced this DB load. The SELECT may or may not
+		// have observed those rows. Merge only positive local deltas from the
+		// race window: that may double-count this process's newest writes for
+		// one short TTL, but it avoids undercounting quota and keeps small-write
+		// admission off the expensive in-transaction SUM(quota_outbox) path.
 		metrics.RecordTenantOperation(c.tenantID, "server_quota", "pending_delta_cache", "raced_local_delta", time.Since(start))
-		return quotaPendingDeltas{}, false
+		return deltas, true
 	}
 	c.snapshot = &quotaPendingDeltasSnapshot{
 		deltas:    deltas,
@@ -371,14 +380,41 @@ func (c *quotaPendingDeltasCache) add(storageDelta, fileDelta, mediaDelta int64)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.generation++
-	// If the snapshot is missing or expired, leave it cold. The generation bump
-	// prevents any concurrent loader from publishing a pre-delta snapshot; the
-	// next soft admission check reloads from quota_outbox and sees this
-	// backend's queued row along with rows from other servers.
+	c.localPositiveDeltas.add(quotaPendingDeltas{
+		storageDelta: maxInt64(storageDelta, 0),
+		fileDelta:    maxInt64(fileDelta, 0),
+		mediaDelta:   maxInt64(mediaDelta, 0),
+	})
+	// If the snapshot is missing or expired, leave it cold. A concurrent loader
+	// publishes a conservative snapshot by merging positive local deltas from
+	// the race window; otherwise the next soft admission check reloads from
+	// quota_outbox and sees this backend's queued row along with rows from
+	// other servers.
 	if c.snapshot == nil || time.Now().After(c.snapshot.expiresAt) {
 		return
 	}
 	c.snapshot.deltas.storageDelta += storageDelta
 	c.snapshot.deltas.fileDelta += fileDelta
 	c.snapshot.deltas.mediaDelta += mediaDelta
+}
+
+func (d *quotaPendingDeltas) add(other quotaPendingDeltas) {
+	d.storageDelta += other.storageDelta
+	d.fileDelta += other.fileDelta
+	d.mediaDelta += other.mediaDelta
+}
+
+func (d quotaPendingDeltas) sub(other quotaPendingDeltas) quotaPendingDeltas {
+	return quotaPendingDeltas{
+		storageDelta: d.storageDelta - other.storageDelta,
+		fileDelta:    d.fileDelta - other.fileDelta,
+		mediaDelta:   d.mediaDelta - other.mediaDelta,
+	}
+}
+
+func maxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -314,9 +314,8 @@ func TestQuotaPendingDeltasCacheUsesTTLAndLocalAdjustments(t *testing.T) {
 	}
 }
 
-func TestQuotaPendingDeltasCacheDoesNotPublishSnapshotWhenLocalDeltaRacesLoad(t *testing.T) {
+func TestQuotaPendingDeltasCachePublishesConservativeSnapshotWhenLocalDeltaRacesLoad(t *testing.T) {
 	var calls atomic.Int64
-	storage := int64(10)
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var once sync.Once
@@ -324,7 +323,7 @@ func TestQuotaPendingDeltasCacheDoesNotPublishSnapshotWhenLocalDeltaRacesLoad(t 
 		calls.Add(1)
 		once.Do(func() { close(started) })
 		<-release
-		return storage, 1, 0, nil
+		return 10, 1, 0, nil
 	}, time.Hour)
 
 	type result struct {
@@ -339,22 +338,69 @@ func TestQuotaPendingDeltasCacheDoesNotPublishSnapshotWhenLocalDeltaRacesLoad(t 
 
 	<-started
 	c.add(5, 1, 0)
-	storage = 15
 	close(release)
 
 	got := <-done
-	if got.ok {
-		t.Fatalf("racing get ok=true deltas=%+v, want fallback", got.deltas)
+	if !got.ok {
+		t.Fatal("racing get failed")
+	}
+	if got.deltas.storageDelta != 15 || got.deltas.fileDelta != 2 || got.deltas.mediaDelta != 0 {
+		t.Fatalf("racing deltas = %+v, want 15/2/0", got.deltas)
 	}
 	next, ok := c.get(context.Background())
 	if !ok {
 		t.Fatal("second get failed")
 	}
-	if next.storageDelta != 15 || next.fileDelta != 1 || next.mediaDelta != 0 {
-		t.Fatalf("second deltas = %+v, want 15/1/0", next)
+	if next.storageDelta != 15 || next.fileDelta != 2 || next.mediaDelta != 0 {
+		t.Fatalf("second deltas = %+v, want 15/2/0", next)
 	}
-	if got := calls.Load(); got != 2 {
-		t.Fatalf("loader calls = %d, want 2", got)
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("loader calls = %d, want 1", got)
+	}
+}
+
+func TestQuotaPendingDeltasCacheIgnoresNegativeRaceDeltasWhenPublishing(t *testing.T) {
+	var calls atomic.Int64
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var once sync.Once
+	c := newQuotaPendingDeltasCache("test-tenant", func(context.Context) (int64, int64, int64, error) {
+		calls.Add(1)
+		once.Do(func() { close(started) })
+		<-release
+		return 10, 2, 1, nil
+	}, time.Hour)
+
+	type result struct {
+		deltas quotaPendingDeltas
+		ok     bool
+	}
+	done := make(chan result, 1)
+	go func() {
+		deltas, ok := c.get(context.Background())
+		done <- result{deltas: deltas, ok: ok}
+	}()
+
+	<-started
+	c.add(-5, -1, -1)
+	close(release)
+
+	got := <-done
+	if !got.ok {
+		t.Fatal("racing get failed")
+	}
+	if got.deltas.storageDelta != 10 || got.deltas.fileDelta != 2 || got.deltas.mediaDelta != 1 {
+		t.Fatalf("racing deltas = %+v, want 10/2/1", got.deltas)
+	}
+	next, ok := c.get(context.Background())
+	if !ok {
+		t.Fatal("second get failed")
+	}
+	if next.storageDelta != 10 || next.fileDelta != 2 || next.mediaDelta != 1 {
+		t.Fatalf("second deltas = %+v, want 10/2/1", next)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("loader calls = %d, want 1", got)
 	}
 }
 

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -106,6 +107,49 @@ func TestServerQuotaOutboxBatchProcessesDifferentFiles(t *testing.T) {
 	}
 	if usage.StorageBytes != int64(len("aaaa")+len("bb")) || usage.FileCount != 2 || usage.MediaFileCount != 1 {
 		t.Fatalf("central usage after batch = %+v", usage)
+	}
+}
+
+func TestQuotaOutboxBatchConflictExhaustedRecordsTenantMetrics(t *testing.T) {
+	b, _ := newCentralQuotaBackend(t)
+	b.stopQuotaOutboxWorker()
+	ctx := context.Background()
+
+	var called int
+	b.claimQuotaOutbox = func(claimCtx context.Context, now time.Time, lease time.Duration, limit int) (datastore.QuotaOutboxBatchClaimResult, error) {
+		called++
+		if claimCtx != ctx {
+			t.Fatal("claim context was not passed through")
+		}
+		if now.IsZero() {
+			t.Fatal("claim time is zero")
+		}
+		if lease != quotaOutboxLeaseDuration {
+			t.Fatalf("claim lease = %s, want %s", lease, quotaOutboxLeaseDuration)
+		}
+		if limit != 7 {
+			t.Fatalf("claim limit = %d, want 7", limit)
+		}
+		return datastore.QuotaOutboxBatchClaimResult{ConflictExhausted: true}, nil
+	}
+
+	processed, err := b.ProcessQuotaOutboxBatch(ctx, 7)
+	if err != nil {
+		t.Fatalf("process quota outbox batch: %v", err)
+	}
+	if processed != 0 {
+		t.Fatalf("processed = %d, want 0", processed)
+	}
+	if called != 1 {
+		t.Fatalf("claim calls = %d, want 1", called)
+	}
+
+	metricsText := readBackendMetrics()
+	if !strings.Contains(metricsText, `drive9_service_operations_total{component="quota_outbox",operation="claim",result="conflict",tenant_id="tenant-a"}`) {
+		t.Fatalf("metrics missing tenant-scoped claim conflict counter: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, `drive9_service_operations_total{component="quota_outbox",operation="claim_conflict_exhausted",result="conflict",tenant_id="tenant-a"}`) {
+		t.Fatalf("metrics missing tenant-scoped claim_conflict_exhausted counter: %s", metricsText)
 	}
 }
 

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -234,15 +234,22 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 	if limit <= 0 {
 		limit = 1
 	}
-	entries, err := b.store.ClaimQuotaOutboxBatch(ctx, time.Now().UTC(), quotaOutboxLeaseDuration, limit)
+	claim, err := b.store.ClaimQuotaOutboxBatchResult(ctx, time.Now().UTC(), quotaOutboxLeaseDuration, limit)
 	if err != nil {
 		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "claim", "error", time.Since(start))
 		return 0, err
 	}
+	if claim.ConflictExhausted {
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "claim", "conflict", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "claim_conflict_exhausted", "conflict", time.Since(start))
+		return 0, nil
+	}
+	entries := claim.Entries
 	if len(entries) == 0 {
 		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "claim", "empty", time.Since(start))
 		return 0, nil
 	}
+	metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "claim", "ok", time.Since(start))
 
 	appliedEntries := make([]datastore.QuotaOutboxEntry, 0, len(entries))
 	var batchApplyErr error

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -32,6 +32,8 @@ const (
 	quotaMutationTypeUploadComplete     = "upload_complete"
 )
 
+type quotaOutboxBatchClaimer func(context.Context, time.Time, time.Duration, int) (datastore.QuotaOutboxBatchClaimResult, error)
+
 func (b *Dat9Backend) startQuotaOutboxWorker() {
 	if b.quotaOutboxNotify != nil {
 		return
@@ -228,13 +230,20 @@ func (b *Dat9Backend) ProcessOneQuotaOutbox(ctx context.Context) (processed bool
 // converge in one tenant admission-lock window.
 func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (processed int, err error) {
 	start := time.Now()
-	if b.store == nil || b.metaStore == nil || b.tenantID == "" {
+	if b.metaStore == nil || b.tenantID == "" {
 		return 0, nil
 	}
 	if limit <= 0 {
 		limit = 1
 	}
-	claim, err := b.store.ClaimQuotaOutboxBatchResult(ctx, time.Now().UTC(), quotaOutboxLeaseDuration, limit)
+	claimQuotaOutbox := b.claimQuotaOutbox
+	if claimQuotaOutbox == nil {
+		if b.store == nil {
+			return 0, nil
+		}
+		claimQuotaOutbox = b.store.ClaimQuotaOutboxBatchResult
+	}
+	claim, err := claimQuotaOutbox(ctx, time.Now().UTC(), quotaOutboxLeaseDuration, limit)
 	if err != nil {
 		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "claim", "error", time.Since(start))
 		return 0, err

--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -10,8 +10,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
-	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 // defaultQuotaOutboxMaxAttempts bounds how long a poisoned quota mutation can
@@ -53,6 +51,15 @@ type QuotaOutboxEntry struct {
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 	CompletedAt  *time.Time
+}
+
+// QuotaOutboxBatchClaimResult reports the outcome of a batch claim. An
+// exhausted claim conflict means concurrent workers repeatedly won the same
+// claim race; callers can treat it like an empty poll while recording
+// tenant-scoped observability.
+type QuotaOutboxBatchClaimResult struct {
+	Entries           []QuotaOutboxEntry
+	ConflictExhausted bool
 }
 
 // ErrQuotaOutboxLeaseMismatch means a worker tried to ack/retry an outbox row
@@ -107,19 +114,39 @@ func (s *Store) ClaimQuotaOutboxBatch(ctx context.Context, now time.Time, leaseD
 	start := time.Now()
 	defer observeStoreOp(ctx, "claim_quota_outbox_batch", start, &err)
 
-	return s.claimQuotaOutboxBatch(ctx, now, leaseDuration, limit)
+	result, err := s.claimQuotaOutboxBatchResult(ctx, now, leaseDuration, limit)
+	if err != nil {
+		return nil, err
+	}
+	return result.Entries, nil
+}
+
+// ClaimQuotaOutboxBatchResult claims queued quota mutations and returns whether
+// repeated benign claim conflicts exhausted the bounded retry loop.
+func (s *Store) ClaimQuotaOutboxBatchResult(ctx context.Context, now time.Time, leaseDuration time.Duration, limit int) (result QuotaOutboxBatchClaimResult, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "claim_quota_outbox_batch", start, &err)
+
+	return s.claimQuotaOutboxBatchResult(ctx, now, leaseDuration, limit)
 }
 
 func (s *Store) claimQuotaOutboxBatch(ctx context.Context, now time.Time, leaseDuration time.Duration, limit int) ([]QuotaOutboxEntry, error) {
+	result, err := s.claimQuotaOutboxBatchResult(ctx, now, leaseDuration, limit)
+	if err != nil {
+		return nil, err
+	}
+	return result.Entries, nil
+}
+
+func (s *Store) claimQuotaOutboxBatchResult(ctx context.Context, now time.Time, leaseDuration time.Duration, limit int) (QuotaOutboxBatchClaimResult, error) {
 	for attempt := 0; attempt < quotaOutboxClaimMaxAttempts; attempt++ {
 		entries, err := s.claimQuotaOutboxBatchOnce(ctx, now, leaseDuration, limit)
 		if errors.Is(err, errQuotaOutboxClaimConflict) {
 			continue
 		}
-		return entries, err
+		return QuotaOutboxBatchClaimResult{Entries: entries}, err
 	}
-	metrics.RecordOperation("datastore", "claim_quota_outbox_conflict_exhausted", "conflict", 0)
-	return nil, nil
+	return QuotaOutboxBatchClaimResult{ConflictExhausted: true}, nil
 }
 
 func (s *Store) claimQuotaOutboxBatchOnce(ctx context.Context, now time.Time, leaseDuration time.Duration, limit int) ([]QuotaOutboxEntry, error) {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -1061,13 +1061,31 @@ func closeEntry(e *entry) {
 func observePool(ctx context.Context, op, tenantID string, errp *error, start time.Time) {
 	result := "ok"
 	if errp != nil && *errp != nil {
-		switch {
-		case errors.Is(*errp, meta.ErrNotFound):
-			result = "not_found"
-		default:
-			result = "error"
+		result = tenantPoolErrorResult(*errp)
+		fields := []zap.Field{zap.String("operation", op), zap.String("tenant_id", tenantID), zap.String("result", result), zap.Error(*errp)}
+		if result == "error" {
+			logger.Error(ctx, "tenant_pool_op_failed", fields...)
+		} else {
+			logger.Warn(ctx, "tenant_pool_op_failed", fields...)
 		}
-		logger.Error(ctx, "tenant_pool_op_failed", zap.String("operation", op), zap.String("tenant_id", tenantID), zap.String("result", result), zap.Error(*errp))
 	}
 	metrics.RecordOperation("tenant_pool", op, result, time.Since(start))
+}
+
+func tenantPoolErrorResult(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case errors.Is(err, meta.ErrNotFound):
+		return "not_found"
+	}
+	msg := strings.ToLower(err.Error())
+	switch {
+	case strings.Contains(msg, "please check your user name and password"):
+		return "auth_failed"
+	case strings.Contains(msg, "due to the usage quota being exhausted"):
+		return "usage_quota_exhausted"
+	default:
+		return "error"
+	}
 }

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -12,6 +12,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/drive9/pkg/backend"
 	"github.com/mem9-ai/drive9/pkg/datastore"
 	"github.com/mem9-ai/drive9/pkg/encrypt"
@@ -1058,34 +1059,57 @@ func closeEntry(e *entry) {
 	}
 }
 
+type tenantPoolResult string
+
+const (
+	tenantPoolResultOK                   tenantPoolResult = "ok"
+	tenantPoolResultNotFound             tenantPoolResult = "not_found"
+	tenantPoolResultAuthFailed           tenantPoolResult = "auth_failed"
+	tenantPoolResultUsageQuotaExhausted  tenantPoolResult = "usage_quota_exhausted"
+	tenantPoolResultError                tenantPoolResult = "error"
+	mysqlErrAccessDenied                 uint16           = 1045
+	mysqlErrUsageQuotaExhaustedCandidate uint16           = 1105
+)
+
 func observePool(ctx context.Context, op, tenantID string, errp *error, start time.Time) {
-	result := "ok"
+	result := tenantPoolResultOK
 	if errp != nil && *errp != nil {
 		result = tenantPoolErrorResult(*errp)
-		fields := []zap.Field{zap.String("operation", op), zap.String("tenant_id", tenantID), zap.String("result", result), zap.Error(*errp)}
-		if result == "error" {
+		fields := []zap.Field{zap.String("operation", op), zap.String("tenant_id", tenantID), zap.String("result", string(result)), zap.Error(*errp)}
+		if result == tenantPoolResultError {
 			logger.Error(ctx, "tenant_pool_op_failed", fields...)
 		} else {
 			logger.Warn(ctx, "tenant_pool_op_failed", fields...)
 		}
 	}
-	metrics.RecordOperation("tenant_pool", op, result, time.Since(start))
+	metrics.RecordOperation("tenant_pool", op, string(result), time.Since(start))
 }
 
-func tenantPoolErrorResult(err error) string {
+func tenantPoolErrorResult(err error) tenantPoolResult {
 	switch {
 	case err == nil:
-		return "ok"
+		return tenantPoolResultOK
 	case errors.Is(err, meta.ErrNotFound):
-		return "not_found"
+		return tenantPoolResultNotFound
+	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		switch mysqlErr.Number {
+		case mysqlErrAccessDenied:
+			return tenantPoolResultAuthFailed
+		case mysqlErrUsageQuotaExhaustedCandidate:
+			if strings.Contains(strings.ToLower(mysqlErr.Message), "usage quota") {
+				return tenantPoolResultUsageQuotaExhausted
+			}
+		}
 	}
 	msg := strings.ToLower(err.Error())
 	switch {
 	case strings.Contains(msg, "please check your user name and password"):
-		return "auth_failed"
+		return tenantPoolResultAuthFailed
 	case strings.Contains(msg, "due to the usage quota being exhausted"):
-		return "usage_quota_exhausted"
+		return tenantPoolResultUsageQuotaExhausted
 	default:
-		return "error"
+		return tenantPoolResultError
 	}
 }

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -553,32 +553,37 @@ func TestTenantPoolErrorResultClassifiesExpectedDatabaseErrors(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
-		want string
+		want tenantPoolResult
 	}{
 		{
 			name: "tidb auth failed",
+			err:  fmt.Errorf("open db: %w", &mysql.MySQLError{Number: 1045, Message: "Access denied for user"}),
+			want: tenantPoolResultAuthFailed,
+		},
+		{
+			name: "tidb auth failed legacy message",
 			err:  fmt.Errorf("open db: Error 1045 (28000): Please check your user name and password and try again"),
-			want: "auth_failed",
+			want: tenantPoolResultAuthFailed,
 		},
 		{
 			name: "tidb usage quota exhausted",
-			err:  fmt.Errorf("open db: Error 1105 (HY000): Due to the usage quota being exhausted, access to the cluster has been restricted"),
-			want: "usage_quota_exhausted",
+			err:  fmt.Errorf("open db: %w", &mysql.MySQLError{Number: 1105, Message: "Due to the usage quota being exhausted, access to the cluster has been restricted"}),
+			want: tenantPoolResultUsageQuotaExhausted,
 		},
 		{
 			name: "tidb usage quota exhausted lowercase",
 			err:  fmt.Errorf("open db: error 1105 (hy000): due to the usage quota being exhausted"),
-			want: "usage_quota_exhausted",
+			want: tenantPoolResultUsageQuotaExhausted,
 		},
 		{
 			name: "not found",
 			err:  meta.ErrNotFound,
-			want: "not_found",
+			want: tenantPoolResultNotFound,
 		},
 		{
 			name: "unexpected",
 			err:  fmt.Errorf("open db: invalid connection"),
-			want: "error",
+			want: tenantPoolResultError,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -549,6 +549,47 @@ func TestRecordTenantSchemaVersionUpdateFailureRecordsMetric(t *testing.T) {
 	}
 }
 
+func TestTenantPoolErrorResultClassifiesExpectedDatabaseErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "tidb auth failed",
+			err:  fmt.Errorf("open db: Error 1045 (28000): Please check your user name and password and try again"),
+			want: "auth_failed",
+		},
+		{
+			name: "tidb usage quota exhausted",
+			err:  fmt.Errorf("open db: Error 1105 (HY000): Due to the usage quota being exhausted, access to the cluster has been restricted"),
+			want: "usage_quota_exhausted",
+		},
+		{
+			name: "tidb usage quota exhausted lowercase",
+			err:  fmt.Errorf("open db: error 1105 (hy000): due to the usage quota being exhausted"),
+			want: "usage_quota_exhausted",
+		},
+		{
+			name: "not found",
+			err:  meta.ErrNotFound,
+			want: "not_found",
+		},
+		{
+			name: "unexpected",
+			err:  fmt.Errorf("open db: invalid connection"),
+			want: "error",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tenantPoolErrorResult(tt.err); got != tt.want {
+				t.Fatalf("tenantPoolErrorResult() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func operationMetricValue(t *testing.T, output, labels string) uint64 {
 	t.Helper()
 	prefix := `drive9_service_operations_total{` + labels + `} `


### PR DESCRIPTION
## Summary
- make quota outbox worker metrics tenant-scoped
- classify expected tenant pool database errors as auth/quota/not_found labels instead of generic error noise
- avoid live quota pending-delta scans when local cache loads race with small-write enqueue/ack activity

## Tests
- go test ./pkg/backend -run 'TestQuotaPendingDeltasCache|TestQuotaUsageCache|TestQuotaConfigCache' -count=1
- go test ./pkg/backend -run 'Test.*QuotaOutbox|TestServerQuotaUploadReserveUsesLivePendingOutboxDeltas' -count=1
- go test ./pkg/backend -count=1
- go test ./pkg/server -run 'Test.*Provision|TestAdmin' -count=1
- make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of quota processing under concurrency, with more reliable results when updates race with reads.
  * Added clearer outcome reporting for quota outbox batch claims, including when retries are exhausted.

* **Bug Fixes**
  * Reduced unnecessary failures during quota cache refreshes and kept published values stable in more race conditions.
  * Better classified tenant pool errors so logs and metrics are more accurate and easier to interpret.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->