### PR TITLE
Tune quota worker metrics and create hot path

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -842,6 +842,11 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 	}
 	v, err := time.ParseDuration(raw)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid %s=%q: %v; using %s\n", key, raw, err, fallback)
+		return fallback
+	}
+	if v < 0 {
+		fmt.Fprintf(os.Stderr, "invalid %s=%q: duration must be non-negative; using %s\n", key, raw, fallback)
 		return fallback
 	}
 	return v

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -127,6 +127,10 @@ func main() {
 	logLocalStartupStep(startupCtx, startupStart, stepStart, "open_local_datastore")
 
 	stepStart = time.Now()
+	backend.InitQuotaAdmissionCacheTTLs(
+		envDuration("DRIVE9_QUOTA_USAGE_CACHE_TTL", 0),
+		envDuration("DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL", 0),
+	)
 	backendOpts, err := buildBackendOptionsFromEnv()
 	if err != nil {
 		die(err)
@@ -366,6 +370,8 @@ environment:
   DRIVE9_VAULT_MASTER_KEY 32-byte hex key for vault DEK wrapping (omit to disable vault)
   DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
+  DRIVE9_QUOTA_USAGE_CACHE_TTL soft small-write central usage cache TTL, e.g. 250ms or 1s
+  DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL soft small-write tenant pending-outbox aggregate cache TTL, e.g. 250ms or 1s
 
   S3 storage:
   Set DRIVE9_S3_BUCKET to enable AWS S3 mode.
@@ -823,6 +829,18 @@ func envInt64(key string, fallback int64) int64 {
 		return fallback
 	}
 	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return fallback
+	}
+	return v
+}
+
+func envDuration(key string, fallback time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	v, err := time.ParseDuration(raw)
 	if err != nil {
 		return fallback
 	}

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -125,6 +125,10 @@ func main() {
 	// P1-3: Configurable quota cache refresh interval (default 30s).
 	// In multi-pod deployments, increasing this reduces per-tenant-per-pod DB reads.
 	backend.InitQuotaConfigCacheRefreshInterval(envInt("DRIVE9_QUOTA_CACHE_REFRESH_SECONDS", 0))
+	backend.InitQuotaAdmissionCacheTTLs(
+		envDuration("DRIVE9_QUOTA_USAGE_CACHE_TTL", 0),
+		envDuration("DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL", 0),
+	)
 
 	store, err := openControlPlaneStoreWithRetry(context.Background(), metaDSN, defaultStartupRetryOptions())
 	if err != nil {
@@ -478,6 +482,8 @@ environment:
   DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
   DRIVE9_QUOTA_SOURCE tenant|server quota enforcement source (default: tenant)
+  DRIVE9_QUOTA_USAGE_CACHE_TTL soft small-write central usage cache TTL, e.g. 250ms or 1s
+  DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL soft small-write tenant pending-outbox aggregate cache TTL, e.g. 250ms or 1s
   DRIVE9_DISABLE_AUTO_EMBEDDING true|false disable TiDB database-managed auto-embedding (default: false)
                                 set to true when the TiDB Cloud cluster has no supported embedding provider
   DRIVE9_TIDB_AUTO_EMBEDDING_MODEL TiDB EMBED_TEXT model for auto-embedding generated columns
@@ -865,6 +871,18 @@ func envInt64(key string, fallback int64) int64 {
 		return fallback
 	}
 	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return fallback
+	}
+	return v
+}
+
+func envDuration(key string, fallback time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(key))
+	if raw == "" {
+		return fallback
+	}
+	v, err := time.ParseDuration(raw)
 	if err != nil {
 		return fallback
 	}

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -884,6 +884,11 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 	}
 	v, err := time.ParseDuration(raw)
 	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid %s=%q: %v; using %s\n", key, raw, err, fallback)
+		return fallback
+	}
+	if v < 0 {
+		fmt.Fprintf(os.Stderr, "invalid %s=%q: duration must be non-negative; using %s\n", key, raw, fallback)
 		return fallback
 	}
 	return v

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -686,6 +686,25 @@ func (b *Dat9Backend) WriteCtxIfRevisionWithTagsResult(ctx context.Context, path
 		return 0, 0, err
 	}
 
+	if isCreateIfAbsentWrite(offset, flags, expectedRevision) {
+		operation = "create"
+		implementationStart := time.Time{}
+		if timingEnabled {
+			implementationStart = time.Now()
+		}
+		n, err := b.createAndWriteCtx(ctx, path, data, tags, description)
+		if timingEnabled {
+			implementationDuration = time.Since(implementationStart)
+		}
+		if errors.Is(err, datastore.ErrPathConflict) {
+			return 0, 0, datastore.ErrRevisionConflict
+		}
+		if err != nil {
+			return 0, 0, err
+		}
+		return n, 1, nil
+	}
+
 	statStart := time.Time{}
 	if timingEnabled {
 		statStart = time.Now()
@@ -746,6 +765,13 @@ func (b *Dat9Backend) WriteCtxIfRevisionWithTagsResult(ctx context.Context, path
 		implementationDuration = time.Since(implementationStart)
 	}
 	return n, rev, err
+}
+
+func isCreateIfAbsentWrite(offset int64, flags filesystem.WriteFlag, expectedRevision int64) bool {
+	return expectedRevision == 0 &&
+		offset == 0 &&
+		flags&filesystem.WriteFlagCreate != 0 &&
+		flags&filesystem.WriteFlagAppend == 0
 }
 
 func backendWriteResult(err error) string {
@@ -904,7 +930,7 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 		quotaOutboxEnqueued = false
 
 		done := backendTimingStep(timingEnabled, &quotaStorageCheckDuration)
-		err := b.ensureStorageQuota(ctx, tx, path, int64(len(data)))
+		err := b.ensureCreateStorageQuota(ctx, tx, int64(len(data)))
 		done()
 		if err != nil {
 			return err

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -688,6 +688,13 @@ func (b *Dat9Backend) WriteCtxIfRevisionWithTagsResult(ctx context.Context, path
 
 	if isCreateIfAbsentWrite(offset, flags, expectedRevision) {
 		operation = "create"
+		exists, err := b.store.NodeExists(ctx, path)
+		if err != nil {
+			return 0, 0, err
+		}
+		if exists {
+			return 0, 0, datastore.ErrRevisionConflict
+		}
 		implementationStart := time.Time{}
 		if timingEnabled {
 			implementationStart = time.Now()

--- a/pkg/backend/expiry_sweep.go
+++ b/pkg/backend/expiry_sweep.go
@@ -85,7 +85,7 @@ func (w *ExpirySweepWorker) sweep(ctx context.Context) (fatal bool) {
 			return true
 		}
 		logger.Error(ctx, "expiry_sweep_error", zap.Error(err), zap.Duration("elapsed", elapsed))
-		metrics.RecordOperation("expiry_sweep", "sweep", "error", elapsed)
+		metrics.RecordOperation("expiry_sweep", "sweep", metrics.ResultForError(err), elapsed)
 		return false
 	}
 	if released > 0 {

--- a/pkg/backend/file_gc_worker.go
+++ b/pkg/backend/file_gc_worker.go
@@ -128,7 +128,7 @@ func (w *FileGCWorker) processAvailable(ctx context.Context) {
 			return
 		}
 		logger.Warn(ctx, "file_gc_recover_expired_failed", zap.String("tenant_id", tenantID), zap.Error(err))
-		metrics.RecordTenantOperation(tenantID, "file_gc", "recover_expired", "error", 0)
+		metrics.RecordTenantOperation(tenantID, "file_gc", "recover_expired", metrics.ResultForError(err), 0)
 	}
 	for i := 0; i < w.opts.BatchSize; i++ {
 		if ctx.Err() != nil {
@@ -164,7 +164,7 @@ func (b *Dat9Backend) processOneFileGCTask(ctx context.Context, opts FileGCWorke
 	tenantID := b.tenantID
 	task, found, err := b.store.ClaimFileGCTask(ctx, time.Now().UTC(), opts.LeaseDuration)
 	if err != nil {
-		metrics.RecordTenantOperation(tenantID, "file_gc", "claim", "error", time.Since(start))
+		metrics.RecordTenantOperation(tenantID, "file_gc", "claim", metrics.ResultForError(err), time.Since(start))
 		return false, err
 	}
 	if !found {
@@ -175,7 +175,7 @@ func (b *Dat9Backend) processOneFileGCTask(ctx context.Context, opts FileGCWorke
 	err = b.processFileGCTask(ctx, task)
 	if err == nil {
 		if ackErr := b.store.AckFileGCTask(ctx, task.TaskID, task.Receipt); ackErr != nil {
-			metrics.RecordTenantOperation(tenantID, "file_gc", "ack", "error", time.Since(start))
+			metrics.RecordTenantOperation(tenantID, "file_gc", "ack", metrics.ResultForError(ackErr), time.Since(start))
 			return true, ackErr
 		}
 		metrics.RecordTenantOperation(tenantID, "file_gc", "process", "ok", time.Since(start))
@@ -184,10 +184,10 @@ func (b *Dat9Backend) processOneFileGCTask(ctx context.Context, opts FileGCWorke
 
 	retryAt := time.Now().UTC().Add(fileGCRetryDelay(task.AttemptCount, opts.RetryBase, opts.RetryMax))
 	if retryErr := b.store.RetryFileGCTask(ctx, task.TaskID, task.Receipt, retryAt, err.Error()); retryErr != nil {
-		metrics.RecordTenantOperation(tenantID, "file_gc", "retry", "error", time.Since(start))
+		metrics.RecordTenantOperation(tenantID, "file_gc", "retry", metrics.ResultForError(retryErr), time.Since(start))
 		return true, fmt.Errorf("process file gc task %s: %w; update retry: %v", task.TaskID, err, retryErr)
 	}
-	metrics.RecordTenantOperation(tenantID, "file_gc", "process", "error", time.Since(start))
+	metrics.RecordTenantOperation(tenantID, "file_gc", "process", metrics.ResultForError(err), time.Since(start))
 	return true, err
 }
 

--- a/pkg/backend/mutation_replay.go
+++ b/pkg/backend/mutation_replay.go
@@ -85,7 +85,7 @@ func (w *MutationReplayWorker) replayBatch(ctx context.Context) (fatal bool) {
 			return true
 		}
 		logger.Warn(ctx, "mutation_replay_list_failed", zap.Error(err))
-		metrics.RecordOperation("mutation_replay", "list", "error", time.Since(start))
+		metrics.RecordOperation("mutation_replay", "list", metrics.ResultForError(err), time.Since(start))
 		return false
 	}
 	if len(entries) == 0 {
@@ -121,7 +121,7 @@ func (w *MutationReplayWorker) replayBatch(ctx context.Context) (fatal bool) {
 					zap.Int64("log_id", entry.ID),
 					zap.Error(rErr))
 			}
-			metrics.RecordTenantOperation(entry.TenantID, "mutation_replay", entry.MutationType, "error", 0)
+			metrics.RecordTenantOperation(entry.TenantID, "mutation_replay", entry.MutationType, metrics.ResultForError(err), 0)
 			blockedTenants[entry.TenantID] = struct{}{}
 			failed++
 		} else {

--- a/pkg/backend/mutation_replay.go
+++ b/pkg/backend/mutation_replay.go
@@ -121,11 +121,11 @@ func (w *MutationReplayWorker) replayBatch(ctx context.Context) (fatal bool) {
 					zap.Int64("log_id", entry.ID),
 					zap.Error(rErr))
 			}
-			metrics.RecordTenantOperation(entry.TenantID, "mutation_replay", entry.MutationType, metrics.ResultForError(err), 0)
+			metrics.RecordTenantOperationCount(entry.TenantID, "mutation_replay", entry.MutationType, metrics.ResultForError(err))
 			blockedTenants[entry.TenantID] = struct{}{}
 			failed++
 		} else {
-			metrics.RecordTenantOperation(entry.TenantID, "mutation_replay", entry.MutationType, "ok", 0)
+			metrics.RecordTenantOperationCount(entry.TenantID, "mutation_replay", entry.MutationType, "ok")
 			applied++
 		}
 	}

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -63,6 +63,16 @@ func (b *Dat9Backend) ensureStorageQuota(ctx context.Context, tx *sql.Tx, path s
 	return b.ensureTenantStorageQuotaTx(tx, path, newSize)
 }
 
+// ensureCreateStorageQuota is the create-only variant of ensureStorageQuota.
+// The caller has not attached a dentry yet, so the current path size is known
+// to be zero; path conflicts later in the transaction roll back the write.
+func (b *Dat9Backend) ensureCreateStorageQuota(ctx context.Context, tx *sql.Tx, newSize int64) error {
+	if b.UseServerQuota() {
+		return b.ensureStorageQuotaServer(ctx, tx, newSize)
+	}
+	return b.ensureTenantCreateStorageQuotaTx(tx, newSize)
+}
+
 // mediaLLMQuotaExceededCheckTx dispatches the media LLM quota check
 // (transactional variant). currentMediaDelta is only applied to server quota,
 // where the current write may not be visible in central usage or pending outbox
@@ -444,6 +454,26 @@ func (b *Dat9Backend) ensureTenantStorageQuotaTx(tx *sql.Tx, path string, newSiz
 		return fmt.Errorf("%w: limit=%d used=%d reserved=%d current_path=%d requested=%d delta=%d",
 			ErrStorageQuotaExceeded, b.maxTenantStorageBytes, confirmedBytes, reservedBytes,
 			currentPathBytes, newSize, deltaBytes)
+	}
+	return nil
+}
+
+func (b *Dat9Backend) ensureTenantCreateStorageQuotaTx(tx *sql.Tx, newSize int64) error {
+	if newSize <= 0 || b.maxTenantStorageBytes <= 0 {
+		return nil
+	}
+	confirmedBytes, err := b.store.ConfirmedStorageBytesTx(tx)
+	if err != nil {
+		return fmt.Errorf("load confirmed storage usage: %w", err)
+	}
+	reservedBytes, err := b.store.ActiveUploadReservedBytesTx(tx)
+	if err != nil {
+		return fmt.Errorf("load upload reservations: %w", err)
+	}
+	totalBytes := confirmedBytes + reservedBytes + newSize
+	if totalBytes > b.maxTenantStorageBytes {
+		return fmt.Errorf("%w: limit=%d used=%d reserved=%d requested=%d delta=%d",
+			ErrStorageQuotaExceeded, b.maxTenantStorageBytes, confirmedBytes, reservedBytes, newSize, newSize)
 	}
 	return nil
 }

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -19,17 +19,21 @@ const (
 	// quotaUsageCacheTTL bounds how long soft small-write quota checks may
 	// reuse central usage counters. Strict upload reservations still read
 	// central usage directly.
-	quotaUsageCacheTTL = 100 * time.Millisecond
+	defaultQuotaUsageCacheTTL = 250 * time.Millisecond
 	// quotaPendingDeltasCacheTTL bounds tenant-local pending outbox aggregate
 	// reuse for soft small-write checks. The cache is adjusted for mutations
 	// enqueued/acked by this backend instance and periodically reloads to see
 	// other servers.
-	quotaPendingDeltasCacheTTL = 100 * time.Millisecond
+	defaultQuotaPendingDeltasCacheTTL = 250 * time.Millisecond
 )
 
 // quotaConfigCacheRefreshInterval is the resolved refresh interval (package-level
 // var so it can be set from env at startup).
-var quotaConfigCacheRefreshInterval = defaultQuotaConfigCacheRefreshInterval
+var (
+	quotaConfigCacheRefreshInterval = defaultQuotaConfigCacheRefreshInterval
+	quotaUsageCacheTTL              = defaultQuotaUsageCacheTTL
+	quotaPendingDeltasCacheTTL      = defaultQuotaPendingDeltasCacheTTL
+)
 
 // InitQuotaConfigCacheRefreshInterval overrides the default refresh interval.
 // seconds <= 0 keeps the default (30s). Must be called before any backend
@@ -37,6 +41,18 @@ var quotaConfigCacheRefreshInterval = defaultQuotaConfigCacheRefreshInterval
 func InitQuotaConfigCacheRefreshInterval(seconds int) {
 	if seconds > 0 {
 		quotaConfigCacheRefreshInterval = time.Duration(seconds) * time.Second
+	}
+}
+
+// InitQuotaAdmissionCacheTTLs overrides soft quota admission cache TTLs. The
+// caches are used only for small-write admission; strict upload reservations
+// continue to read current central and tenant-local quota state directly.
+func InitQuotaAdmissionCacheTTLs(usageTTL, pendingDeltasTTL time.Duration) {
+	if usageTTL > 0 {
+		quotaUsageCacheTTL = usageTTL
+	}
+	if pendingDeltasTTL > 0 {
+		quotaPendingDeltasCacheTTL = pendingDeltasTTL
 	}
 }
 

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -48,10 +48,14 @@ func InitQuotaConfigCacheRefreshInterval(seconds int) {
 // caches are used only for small-write admission; strict upload reservations
 // continue to read current central and tenant-local quota state directly.
 func InitQuotaAdmissionCacheTTLs(usageTTL, pendingDeltasTTL time.Duration) {
-	if usageTTL > 0 {
+	if usageTTL < 0 {
+		logger.Warn(context.Background(), "quota_usage_cache_ttl_invalid", zap.Duration("ttl", usageTTL))
+	} else if usageTTL > 0 {
 		quotaUsageCacheTTL = usageTTL
 	}
-	if pendingDeltasTTL > 0 {
+	if pendingDeltasTTL < 0 {
+		logger.Warn(context.Background(), "quota_pending_deltas_cache_ttl_invalid", zap.Duration("ttl", pendingDeltasTTL))
+	} else if pendingDeltasTTL > 0 {
 		quotaPendingDeltasCacheTTL = pendingDeltasTTL
 	}
 }

--- a/pkg/backend/quota_integration_test.go
+++ b/pkg/backend/quota_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+	"github.com/mem9-ai/drive9/pkg/datastore"
 	"github.com/mem9-ai/drive9/pkg/meta"
 )
 
@@ -82,6 +83,36 @@ func TestServerQuotaFeatureFlagRejectsOverLimitWrite(t *testing.T) {
 	}
 }
 
+func TestCreateIfAbsentExistingPathReturnsConflictBeforeStorageQuota(t *testing.T) {
+	opts := Options{}
+	opts.QuotaSource = QuotaSourceServer
+	b := newTestBackendWithOptions(t, opts)
+	fake := newFakeMetaQuotaStore()
+	fake.config["tenant-a"] = &QuotaConfigView{
+		TenantID:         "tenant-a",
+		MaxStorageBytes:  10,
+		MaxFileSizeBytes: meta.DefaultMaxFileSizeBytes(),
+		MaxMediaLLMFiles: 1000,
+		MaxMonthlyCostMC: 1 << 30,
+	}
+	b.SetMetaQuotaStore(context.Background(), "tenant-a", fake)
+
+	if _, err := b.WriteCtxIfRevision(context.Background(), "/exists.txt", []byte("ok"), 0, filesystem.WriteFlagCreate, 0); err != nil {
+		t.Fatalf("seed create-if-absent: %v", err)
+	}
+	fake.mu.Lock()
+	fake.usage["tenant-a"] = &QuotaUsageView{
+		TenantID:     "tenant-a",
+		StorageBytes: 10,
+	}
+	fake.mu.Unlock()
+	b.quotaUsageCache.invalidate()
+
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(context.Background(), "/exists.txt", []byte("too-large"), 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, 0, nil, ""); !errors.Is(err, datastore.ErrRevisionConflict) {
+		t.Fatalf("duplicate create-if-absent error = %v, want ErrRevisionConflict", err)
+	}
+}
+
 func TestServerQuotaRejectsOverFileSizeLimit(t *testing.T) {
 	b, fake := newServerQuotaBackend(t, Options{})
 	ctx := context.Background()
@@ -100,6 +131,23 @@ func TestServerQuotaRejectsOverFileSizeLimit(t *testing.T) {
 	}
 	if usage.StorageBytes != 0 || usage.FileCount != 0 {
 		t.Fatalf("usage after rejected write = %+v, want zero", usage)
+	}
+}
+
+func TestCreateIfAbsentExistingPathReturnsConflictBeforeFileSizeQuota(t *testing.T) {
+	b, fake := newServerQuotaBackend(t, Options{})
+	ctx := context.Background()
+
+	if _, err := b.WriteCtxIfRevision(ctx, "/size-exists.txt", []byte("ok"), 0, filesystem.WriteFlagCreate, 0); err != nil {
+		t.Fatalf("seed create-if-absent: %v", err)
+	}
+	fake.mu.Lock()
+	fake.config["tenant-a"].MaxFileSizeBytes = 4
+	fake.mu.Unlock()
+	b.quotaConfigCache.refresh(ctx)
+
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(ctx, "/size-exists.txt", []byte("12345"), 0, filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, 0, nil, ""); !errors.Is(err, datastore.ErrRevisionConflict) {
+		t.Fatalf("duplicate create-if-absent error = %v, want ErrRevisionConflict", err)
 	}
 }
 

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -124,6 +124,56 @@ func TestServerQuotaOutboxBatchProcessesDifferentFiles(t *testing.T) {
 	}
 }
 
+func TestQuotaOutboxFallbackFailureRecordsProcessDurationOnly(t *testing.T) {
+	b, _ := newServerQuotaBackend(t, Options{})
+	b.stopQuotaOutboxWorker()
+	ctx := context.Background()
+
+	if _, err := b.store.EnqueueQuotaOutboxTx(b.store.DB(), &datastore.QuotaOutboxEntry{
+		FileID:       "bad-json",
+		MutationType: quotaMutationTypeFileCreate,
+		MutationData: []byte(`{"file_id":123}`),
+		StorageDelta: 1,
+		FileDelta:    1,
+	}); err != nil {
+		t.Fatalf("enqueue bad create: %v", err)
+	}
+	if _, err := b.store.EnqueueQuotaOutboxTx(b.store.DB(), &datastore.QuotaOutboxEntry{
+		FileID:       "good-file",
+		MutationType: quotaMutationTypeFileCreate,
+		MutationData: mustQuotaMutationJSON(t, fileCreateMutationData{
+			FileID:    "good-file",
+			SizeBytes: 2,
+		}),
+		StorageDelta: 2,
+		FileDelta:    1,
+	}); err != nil {
+		t.Fatalf("enqueue good create: %v", err)
+	}
+
+	processed, err := b.ProcessQuotaOutboxBatch(ctx, 100)
+	if err == nil {
+		t.Fatal("process quota outbox batch error = nil, want fallback apply error")
+	}
+	if processed != 2 {
+		t.Fatalf("processed rows = %d, want 2", processed)
+	}
+
+	metricsText := readBackendMetrics()
+	if !strings.Contains(metricsText, `drive9_service_operations_total{component="quota_outbox",operation="process",result="error",tenant_id="tenant-a"}`) {
+		t.Fatalf("metrics missing quota_outbox process error counter: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, `drive9_service_operation_duration_seconds_count{component="quota_outbox",operation="process",result="error",tenant_id="tenant-a"}`) {
+		t.Fatalf("metrics missing quota_outbox process error duration: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, `drive9_service_operations_total{component="quota_outbox",operation="file_create",result="error",tenant_id="tenant-a"}`) {
+		t.Fatalf("metrics missing quota_outbox file_create error counter: %s", metricsText)
+	}
+	if strings.Contains(metricsText, `drive9_service_operation_duration_seconds_count{component="quota_outbox",operation="file_create",result="error",tenant_id="tenant-a"}`) {
+		t.Fatalf("quota_outbox file_create error should not record per-entry duration: %s", metricsText)
+	}
+}
+
 func TestQuotaOutboxBatchConflictExhaustedRecordsTenantMetrics(t *testing.T) {
 	b, _ := newCentralQuotaBackend(t)
 	b.stopQuotaOutboxWorker()

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -108,6 +108,20 @@ func TestServerQuotaOutboxBatchProcessesDifferentFiles(t *testing.T) {
 	if usage.StorageBytes != int64(len("aaaa")+len("bb")) || usage.FileCount != 2 || usage.MediaFileCount != 1 {
 		t.Fatalf("central usage after batch = %+v", usage)
 	}
+
+	metricsText := readBackendMetrics()
+	if !strings.Contains(metricsText, `drive9_service_operations_total{component="quota_outbox",operation="process",result="ok",tenant_id="tenant-a"}`) {
+		t.Fatalf("metrics missing quota_outbox process success counter: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, `drive9_service_operation_duration_seconds_count{component="quota_outbox",operation="process",result="ok",tenant_id="tenant-a"}`) {
+		t.Fatalf("metrics missing quota_outbox process success duration: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, `drive9_service_operations_total{component="quota_outbox",operation="file_create",result="ok",tenant_id="tenant-a"}`) {
+		t.Fatalf("metrics missing quota_outbox file_create success counter: %s", metricsText)
+	}
+	if strings.Contains(metricsText, `drive9_service_operation_duration_seconds_count{component="quota_outbox",operation="file_create",result="ok",tenant_id="tenant-a"}`) {
+		t.Fatalf("quota_outbox file_create should not record per-entry duration: %s", metricsText)
+	}
 }
 
 func TestQuotaOutboxBatchConflictExhaustedRecordsTenantMetrics(t *testing.T) {
@@ -150,6 +164,29 @@ func TestQuotaOutboxBatchConflictExhaustedRecordsTenantMetrics(t *testing.T) {
 	}
 	if !strings.Contains(metricsText, `drive9_service_operations_total{component="quota_outbox",operation="claim_conflict_exhausted",result="conflict",tenant_id="tenant-a"}`) {
 		t.Fatalf("metrics missing tenant-scoped claim_conflict_exhausted counter: %s", metricsText)
+	}
+}
+
+func TestQuotaOutboxBatchClaimInvalidConnectionRecordsBadConn(t *testing.T) {
+	b, _ := newCentralQuotaBackend(t)
+	b.stopQuotaOutboxWorker()
+	ctx := context.Background()
+
+	b.claimQuotaOutbox = func(context.Context, time.Time, time.Duration, int) (datastore.QuotaOutboxBatchClaimResult, error) {
+		return datastore.QuotaOutboxBatchClaimResult{}, fmt.Errorf("claim quota outbox: invalid connection")
+	}
+
+	processed, err := b.ProcessQuotaOutboxBatch(ctx, 7)
+	if err == nil {
+		t.Fatal("process quota outbox batch error = nil, want invalid connection")
+	}
+	if processed != 0 {
+		t.Fatalf("processed = %d, want 0", processed)
+	}
+
+	metricsText := readBackendMetrics()
+	if !strings.Contains(metricsText, `drive9_service_operations_total{component="quota_outbox",operation="claim",result="bad_conn",tenant_id="tenant-a"}`) {
+		t.Fatalf("metrics missing tenant-scoped claim bad_conn counter: %s", metricsText)
 	}
 }
 

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -308,9 +308,10 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 			appliedEntries = append(appliedEntries, entries[i])
 		}
 		if entryErr != nil {
-			metrics.RecordTenantOperation(b.tenantID, "quota_outbox", entries[i].MutationType, metrics.ResultForError(entryErr), time.Since(start))
+			metrics.RecordTenantOperationCount(b.tenantID, "quota_outbox", entries[i].MutationType, metrics.ResultForError(entryErr))
 			if !entryProcessed {
 				b.recordAppliedQuotaOutboxEntries(appliedEntries)
+				metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "process", metrics.ResultForError(entryErr), time.Since(start))
 				return processed, entryErr
 			}
 			if fallbackErr == nil {
@@ -320,6 +321,7 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 	}
 	b.recordAppliedQuotaOutboxEntries(appliedEntries)
 	if fallbackErr != nil {
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "process", metrics.ResultForError(fallbackErr), time.Since(start))
 		return processed, fallbackErr
 	}
 	if processed > 0 {

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -128,7 +128,7 @@ func (b *Dat9Backend) processQuotaOutboxAvailable(ctx context.Context) {
 		logger.Warn(ctx, "quota_outbox_recover_expired_failed",
 			zap.String("tenant_id", b.tenantID),
 			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "recover_expired", "error", 0)
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "recover_expired", metrics.ResultForError(err), 0)
 	}
 	processedTotal := 0
 	for processedTotal < quotaOutboxBatchSize {
@@ -245,7 +245,7 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 	}
 	claim, err := claimQuotaOutbox(ctx, time.Now().UTC(), quotaOutboxLeaseDuration, limit)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "claim", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "claim", metrics.ResultForError(err), time.Since(start))
 		return 0, err
 	}
 	if claim.ConflictExhausted {
@@ -283,11 +283,12 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 		return nil
 	})
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "process", "error", time.Since(start))
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "process", metrics.ResultForError(err), time.Since(start))
 		return processed, err
 	}
 	if batchApplyErr == nil && processed > 0 {
-		b.recordAppliedQuotaOutboxEntries(start, appliedEntries)
+		b.recordAppliedQuotaOutboxEntries(appliedEntries)
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "process", "ok", time.Since(start))
 		return processed, nil
 	}
 	if len(entries) > 1 && batchApplyErr != nil {
@@ -307,9 +308,9 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 			appliedEntries = append(appliedEntries, entries[i])
 		}
 		if entryErr != nil {
-			metrics.RecordTenantOperation(b.tenantID, "quota_outbox", entries[i].MutationType, "error", time.Since(start))
+			metrics.RecordTenantOperation(b.tenantID, "quota_outbox", entries[i].MutationType, metrics.ResultForError(entryErr), time.Since(start))
 			if !entryProcessed {
-				b.recordAppliedQuotaOutboxEntries(start, appliedEntries)
+				b.recordAppliedQuotaOutboxEntries(appliedEntries)
 				return processed, entryErr
 			}
 			if fallbackErr == nil {
@@ -317,9 +318,12 @@ func (b *Dat9Backend) ProcessQuotaOutboxBatch(ctx context.Context, limit int) (p
 			}
 		}
 	}
-	b.recordAppliedQuotaOutboxEntries(start, appliedEntries)
+	b.recordAppliedQuotaOutboxEntries(appliedEntries)
 	if fallbackErr != nil {
 		return processed, fallbackErr
+	}
+	if processed > 0 {
+		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", "process", "ok", time.Since(start))
 	}
 	return processed, nil
 }
@@ -357,7 +361,7 @@ func (b *Dat9Backend) processQuotaOutboxEntry(ctx context.Context, entry *datast
 	return true, true, nil
 }
 
-func (b *Dat9Backend) recordAppliedQuotaOutboxEntries(start time.Time, entries []datastore.QuotaOutboxEntry) {
+func (b *Dat9Backend) recordAppliedQuotaOutboxEntries(entries []datastore.QuotaOutboxEntry) {
 	if len(entries) == 0 {
 		return
 	}
@@ -366,7 +370,7 @@ func (b *Dat9Backend) recordAppliedQuotaOutboxEntries(start time.Time, entries [
 	}
 	for _, entry := range entries {
 		b.addLocalQuotaPendingDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
-		metrics.RecordTenantOperation(b.tenantID, "quota_outbox", entry.MutationType, "ok", time.Since(start))
+		metrics.RecordTenantOperationCount(b.tenantID, "quota_outbox", entry.MutationType, "ok")
 	}
 }
 

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -278,6 +278,25 @@ func (s *Store) GetNode(ctx context.Context, path string) (*FileNode, error) {
 	return n, err
 }
 
+// NodeExists reports whether any dentry occupies path without loading file
+// metadata. It is used by create-if-absent paths that only need conflict
+// precedence before doing heavier quota/storage work.
+func (s *Store) NodeExists(ctx context.Context, path string) (exists bool, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "node_exists", start, &err)
+
+	var one int
+	err = s.db.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE path_hash = ? AND path = ? LIMIT 1`,
+		fileNodePathHash(path), path).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (s *Store) ListNodes(ctx context.Context, parentPath string) (out []*FileNode, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "list_nodes", start, &err)

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -3,6 +3,9 @@
 package metrics
 
 import (
+	"context"
+	"database/sql/driver"
+	"errors"
 	"net/http"
 	"strconv"
 	"strings"
@@ -116,6 +119,46 @@ func RecordTenantOperation(tenantID, component, operation, result string, d time
 	}
 	serviceOperationsTotal.Add(1, attrs...)
 	serviceOperationDuration.Observe(d.Seconds(), attrs...)
+}
+
+// ResultForError returns a stable metric result label for common infrastructure
+// errors. Callers should use this when recording generic worker/DB failures so
+// transient bad connections do not get bucketed with semantic operation errors.
+func ResultForError(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	case errors.Is(err, driver.ErrBadConn):
+		return "bad_conn"
+	case strings.Contains(strings.ToLower(err.Error()), "invalid connection"):
+		return "bad_conn"
+	default:
+		return "error"
+	}
+}
+
+// RecordTenantOperationCount records an operation outcome without adding a
+// duration sample. Use it for per-entry counters when one wall-clock duration
+// would be duplicated across many logical items in the same batch.
+func RecordTenantOperationCount(tenantID, component, operation, result string) {
+	component = cleanMetricValue(component, "unknown")
+	operation = cleanMetricValue(operation, "unknown")
+	result = cleanMetricValue(result, "unknown")
+	tenantID = cleanMetricValue(tenantID, "unknown")
+	RegisterModule(component)
+	attrs := []Attribute{
+		Attr("component", component),
+		Attr("operation", operation),
+		Attr("result", result),
+	}
+	if tenantID != "unknown" {
+		attrs = append(attrs, Attr("tenant_id", tenantID))
+	}
+	serviceOperationsTotal.Add(1, attrs...)
 }
 
 func RecordGauge(component, name string, value float64) {

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -124,6 +124,7 @@ func RecordTenantOperation(tenantID, component, operation, result string, d time
 // ResultForError returns a stable metric result label for common infrastructure
 // errors. Callers should use this when recording generic worker/DB failures so
 // transient bad connections do not get bucketed with semantic operation errors.
+// Keep mysqlutil.dbResult delegated here so DB and worker labels stay aligned.
 func ResultForError(err error) string {
 	switch {
 	case err == nil:

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -1,0 +1,52 @@
+package metrics
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestResultForError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: "ok"},
+		{name: "context canceled", err: context.Canceled, want: "canceled"},
+		{name: "context deadline", err: fmt.Errorf("query: %w", context.DeadlineExceeded), want: "deadline_exceeded"},
+		{name: "bad conn sentinel", err: fmt.Errorf("query: %w", driver.ErrBadConn), want: "bad_conn"},
+		{name: "invalid connection string", err: errors.New("driver: invalid connection"), want: "bad_conn"},
+		{name: "invalid connection mixed case", err: errors.New("driver: Invalid Connection"), want: "bad_conn"},
+		{name: "generic", err: errors.New("quota outbox lease mismatch"), want: "error"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ResultForError(tt.err); got != tt.want {
+				t.Fatalf("ResultForError(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRecordTenantOperationCountDoesNotRecordDuration(t *testing.T) {
+	const component = "counter_only_test_component"
+	const operation = "counter_only_test_operation"
+
+	RecordTenantOperationCount("tenant-a", component, operation, "ok")
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-a"} 1`) {
+		t.Fatalf("missing counter-only operation total:\n%s", text)
+	}
+	if strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-a"}`) {
+		t.Fatalf("counter-only operation unexpectedly recorded a duration:\n%s", text)
+	}
+}

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -268,6 +268,8 @@ func observeDBOperation(ctx context.Context, role, operation string, start time.
 }
 
 func dbResult(err error) string {
+	// Delegate to metrics.ResultForError so DB operation labels match worker
+	// labels, especially for transient bad connections.
 	return metrics.ResultForError(err)
 }
 

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -268,18 +268,7 @@ func observeDBOperation(ctx context.Context, role, operation string, start time.
 }
 
 func dbResult(err error) string {
-	switch {
-	case err == nil:
-		return "ok"
-	case errors.Is(err, context.Canceled):
-		return "canceled"
-	case errors.Is(err, context.DeadlineExceeded):
-		return "deadline_exceeded"
-	case errors.Is(err, driver.ErrBadConn):
-		return "bad_conn"
-	default:
-		return "error"
-	}
+	return metrics.ResultForError(err)
 }
 
 func toNamedValues(args []driver.Value) []driver.NamedValue {

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -16,9 +16,9 @@ import (
 type ChangeEvent struct {
 	Seq   uint64 `json:"seq"`             // monotonic per-tenant seq (fs_events.seq AUTO_INCREMENT)
 	Path  string `json:"path"`            // affected path
-	Op    string `json:"op"`             // "write" | "delete" | "rename" | "mkdir" | "copy" | "upload_complete"
+	Op    string `json:"op"`              // "write" | "delete" | "rename" | "mkdir" | "copy" | "upload_complete"
 	Actor string `json:"actor,omitempty"` // X-Dat9-Actor header value (per-mount ID)
-	Ts    int64  `json:"ts"`             // unix milliseconds
+	Ts    int64  `json:"ts"`              // unix milliseconds
 }
 
 const (
@@ -36,8 +36,8 @@ const (
 // The store field is an atomic pointer so it can be safely refreshed by
 // eventBuses.get (when the pool recreates a backend) while SSE handlers read it.
 type EventBus struct {
-	tenantID string
-	store    atomic.Pointer[datastore.Store]
+	tenantID  string
+	store     atomic.Pointer[datastore.Store]
 	mu        sync.Mutex
 	listeners map[uint64]chan struct{}
 	nextID    uint64
@@ -251,7 +251,7 @@ func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []Cha
 			zap.Uint64("since", since),
 			zap.Float64("query_ms", float64(time.Since(queryStart).Microseconds())/1000),
 			zap.Error(err))
-		metrics.RecordTenantOperation(eb.tenantID, "event_bus", "query", "error", 0)
+		metrics.RecordTenantOperation(eb.tenantID, "event_bus", "query", metrics.ResultForError(err), 0)
 		headSeq = since // keep the client's cursor unchanged
 		return nil, headSeq, true
 	}
@@ -344,10 +344,7 @@ func oldestSeqSafeWithMetric(ctx context.Context, store *datastore.Store, tenant
 
 // queryResult maps a query error to a metric result label.
 func queryResult(err error) string {
-	if err != nil {
-		return "error"
-	}
-	return "ok"
+	return metrics.ResultForError(err)
 }
 
 // clampNonNegative returns v if v >= 0, else 0.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1377,6 +1377,55 @@ func TestWriteWithExpectedRevisionConflict(t *testing.T) {
 	}
 }
 
+func TestWriteCreateIfAbsentSkipsPreStat(t *testing.T) {
+	logger.ResetBenchTimingLogEnabledForTest()
+	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "true")
+
+	core, recorded := observer.New(zap.InfoLevel)
+	s := newTestServerWithLogger(t, zap.New(core))
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/create-fast.txt", strings.NewReader("v1"))
+	req.Header.Set("X-Dat9-Expected-Revision", "0")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("create-if-absent status = %d, want 200", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/create-fast.txt", strings.NewReader("duplicate"))
+	req.Header.Set("X-Dat9-Expected-Revision", "0")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("duplicate create-if-absent status = %d, want 409", resp.StatusCode)
+	}
+
+	entries := recorded.FilterMessage("backend_write_timing").AllUntimed()
+	for _, entry := range entries {
+		ctx := entry.ContextMap()
+		if ctx["path"] != "/create-fast.txt" || ctx["result"] != "ok" {
+			continue
+		}
+		if got := ctx["operation"]; got != "create" {
+			t.Fatalf("operation = %v, want create", got)
+		}
+		if got := ctx["stat_ms"]; got != float64(0) {
+			t.Fatalf("stat_ms = %v, want 0 for create-if-absent fast path", got)
+		}
+		return
+	}
+	t.Fatalf("missing successful backend_write_timing for create-if-absent; got %#v", entries)
+}
+
 func TestDelete(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -182,7 +182,7 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 				zap.String("path", path),
 				zap.String("op", op),
 				zap.Error(err))
-			metrics.RecordTenantOperation(bus.tenantID, "event_bus", "publish", "error", 0)
+			metrics.RecordTenantOperation(bus.tenantID, "event_bus", "publish", metrics.ResultForError(err), 0)
 			metrics.RecordEventBusPublishError(bus.tenantID)
 		}
 	}

--- a/pkg/tenant/schema/quota_outbox.go
+++ b/pkg/tenant/schema/quota_outbox.go
@@ -32,6 +32,7 @@ func QuotaOutboxTiDBSchemaStatements() []string {
 		`CREATE INDEX idx_quota_outbox_processing ON quota_outbox(status, lease_until)`,
 		`CREATE INDEX idx_quota_outbox_file_order ON quota_outbox(file_id, status, id)`,
 		`CREATE INDEX idx_quota_outbox_file_pending ON quota_outbox(file_id, status, mutation_type)`,
+		`CREATE INDEX idx_quota_outbox_pending_deltas ON quota_outbox(status, storage_delta, file_delta, media_delta)`,
 	}
 }
 
@@ -67,5 +68,6 @@ func QuotaOutboxDB9SchemaStatements() []string {
 		`CREATE INDEX IF NOT EXISTS idx_quota_outbox_processing ON quota_outbox(status, lease_until)`,
 		`CREATE INDEX IF NOT EXISTS idx_quota_outbox_file_order ON quota_outbox(file_id, status, id)`,
 		`CREATE INDEX IF NOT EXISTS idx_quota_outbox_file_pending ON quota_outbox(file_id, status, mutation_type)`,
+		`CREATE INDEX IF NOT EXISTS idx_quota_outbox_pending_deltas ON quota_outbox(status, storage_delta, file_delta, media_delta)`,
 	}
 }


### PR DESCRIPTION
## Summary
- classify transient DB connection failures as `bad_conn` across background workers, event bus, DB instrumentation, and quota outbox claim paths so worker error alerts stop paging on `invalid connection` noise after deploy
- record quota outbox batch latency only at `quota_outbox/process`; per-mutation success/failure metrics are count-only, including fallback failures
- add configurable soft quota admission cache TTLs, defaulting usage and pending-delta caches to 250ms, with visible warnings for malformed or negative duration overrides
- speed up create-if-absent writes (`X-Dat9-Expected-Revision: 0`) by skipping the pre-`Stat` round trip and relying on the path unique constraint to preserve conflict semantics
- use create-specific quota admission so new-file creates no longer query current path size inside the write transaction
- add `idx_quota_outbox_pending_deltas(status, storage_delta, file_delta, media_delta)` so `PendingQuotaOutboxDeltas` can satisfy the pending SUM query from a covering index instead of scanning status and doing row lookups
- keep DB and worker result-label classification aligned by documenting that `mysqlutil.dbResult` delegates to `metrics.ResultForError`

## Operational impact
- `Drive9BackgroundWorkerErrorsHigh` matches `result=~"error|.+_error"`, so `bad_conn` is excluded from worker error paging after this deploy
- DB connection failures remain visible via DB/store operation metrics with `result="bad_conn"`
- CLS check during the active alert window showed tenant `7ed99094-202f-4261-8843-a090b61e672d` was still failing `claim_quota_outbox_batch` with `invalid connection`; on the currently deployed image this still records as generic `error`, so the alert can continue until this PR is deployed
- The create fast path targets write-back new-file uploads where clients send expected revision `0`; ordinary unconditional overwrite behavior still uses the existing stat/overwrite path

## Rollout notes
- The TiDB quota outbox index is emitted as a normal `CREATE INDEX`. For existing tenants with large `quota_outbox` tables, this will run TiDB online add-index backfill and consume TiKV resources while it catches up
- Re-running schema sync should be safe: duplicate index errors are treated as ignorable by the existing schema repair flow, but rollout should still be staged if old tenant outbox tables are large

## Performance notes
- This is the low-risk part of the QPS work: reduce fixed DB round trips on create and make the pending outbox aggregate cheaper
- It targets the observed `pending_quota_outbox_deltas` cost and removes one provably unnecessary create-time lookup
- It does not reduce TiDB per-transaction 2PC/commit latency such as the observed `in_tx≈514ms` slow samples; if that remains dominant under load, micro-batching/group commit is the larger follow-up

## Tests
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant/schema ./cmd/drive9-server -run 'TestQuotaOutboxMissingFileOrderIndexIsRepairable|TestSchemaDumpInitSQLByProvider|TestSchemaDumpInitSQLByProviderIncludesVault|TestSchemaDumpInitSQLUsesTiDBAutoEmbeddingEnv' -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/metrics ./pkg/backend ./pkg/server ./pkg/mysqlutil ./cmd/drive9-server ./cmd/drive9-server-local -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/metrics ./pkg/mysqlutil -count=1`
- `GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring quota cache TTLs at startup through environment variables, with clearer command-line help.
  * Improved create-if-absent write behavior so existing paths return a conflict faster, before quota checks.

* **Bug Fixes**
  * Standardized error reporting in metrics and logs for database, event, quota, and background processing operations.
  * Updated quota handling to better distinguish create-only writes and avoid unnecessary quota validation in conflict cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->