### PR TITLE
e2e: product-quality feedback loop + Feishu notifications (#641, slice 1)

### DIFF
--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -478,6 +478,53 @@ jobs:
             echo "pjdfstest POSIX suite: \`RUN_POSIX_FEATURE_MATRIX=${RUN_POSIX_FEATURE_MATRIX}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # Turn the raw per-suite outcomes into one product-quality report: a richer
+      # step summary grouped by product promise, an aggregated JSON for the
+      # notifier, a signature-led issue body, and outputs (notify/signature/...).
+      - name: Aggregate e2e product-quality report
+        id: aggregate
+        if: always()
+        run: |
+          cat > /tmp/e2e-outcomes.json <<JSON
+          {
+            "api-smoke": "${{ steps.api-smoke.outcome }}",
+            "existing-key-smoke": "${{ steps.existing-key-smoke.outcome }}",
+            "cli-smoke": "${{ steps.cli-smoke.outcome }}",
+            "layer-fs-smoke": "${{ steps.layer-fs-smoke.outcome }}",
+            "fuse-smoke": "${{ steps.fuse-smoke.outcome }}",
+            "git-ops-smoke": "${{ steps.git-ops-smoke.outcome }}",
+            "portable-pack-unpack-e2e": "${{ steps.portable-pack-unpack-e2e.outcome }}",
+            "fuse-crash-recovery": "${{ steps.fuse-crash-recovery.outcome }}",
+            "fuse-write-perf-budget": "${{ steps.fuse-write-perf-budget.outcome }}",
+            "fuse_performance_compare": "${{ steps.fuse_performance_compare.outcome }}",
+            "fuse-concurrency-stress": "${{ steps.fuse-concurrency-stress.outcome }}",
+            "fuse-posix-fsx": "${{ steps.fuse-posix-fsx.outcome }}",
+            "smoke-all": "${{ steps.smoke-all.outcome }}",
+            "git-feature-matrix": "${{ steps.git-feature-matrix.outcome }}",
+            "pjdfstest-suite": "${{ steps.pjdfstest-suite.outcome }}"
+          }
+          JSON
+          go run ./cmd/e2e-aggregate \
+            --manifest e2e/suite-manifest.json \
+            --outcomes /tmp/e2e-outcomes.json \
+            --summaries e2e/reports/summary \
+            --out /tmp/e2e-report.json \
+            --issue-body /tmp/e2e-issue-body.md
+
+      # Push failures/regressions that warrant attention to Feishu/Lark. PR-tier
+      # failures stay in GitHub by policy; the notifier no-ops when no Feishu
+      # secret is configured, so this never blocks a fork/PR without secrets.
+      - name: Notify Feishu on post-merge/nightly failure or perf regression
+        if: always() && steps.aggregate.outputs.notify == 'true'
+        continue-on-error: true
+        env:
+          FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
+          FEISHU_APP_SECRET: ${{ secrets.FEISHU_APP_SECRET }}
+          FEISHU_CHAT_ID: ${{ secrets.FEISHU_CHAT_ID }}
+          FEISHU_WEBHOOK: ${{ secrets.FEISHU_WEBHOOK }}
+        run: |
+          go run ./cmd/feishu-notify --report /tmp/e2e-report.json
+
       - name: Dump TiDB playground logs
         if: always()
         run: |
@@ -560,16 +607,37 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           EVENT_NAME: ${{ github.event_name }}
           SHA: ${{ github.sha }}
+          SIGNATURE: ${{ steps.aggregate.outputs.signature }}
         run: |
           gh label create ci-e2e-failure --repo "$REPO" \
             --description "Automated: local-e2e scheduled/post-merge run failed" \
             --color D93F0B --force || true
-          body="local-e2e \`$EVENT_NAME\` run failed on \`main\` at $SHA: $RUN_URL"
-          existing="$(gh issue list --repo "$REPO" --label ci-e2e-failure --state open \
-            --json number --jq '.[0].number // empty')"
+
+          # Prefer the structured, signature-led body from the aggregator; fall
+          # back to a one-liner if it is missing for any reason.
+          if [ -s /tmp/e2e-issue-body.md ]; then
+            body="$(cat /tmp/e2e-issue-body.md)"
+            body="$body"$'\n\n'"_run: $RUN_URL_"
+          else
+            body="local-e2e \`$EVENT_NAME\` run failed on \`main\` at $SHA: $RUN_URL"
+          fi
+
+          # Group recurring failures by signature: an open issue carrying the same
+          # signature is reused; a new signature opens its own tracking issue. With
+          # no signature we keep the legacy single-issue behaviour.
+          if [ -n "$SIGNATURE" ]; then
+            existing="$(gh issue list --repo "$REPO" --label ci-e2e-failure --state open \
+              --search "in:title $SIGNATURE" --json number --jq '.[0].number // empty')"
+            title="local-e2e failure on main [sig: $SIGNATURE]"
+          else
+            existing="$(gh issue list --repo "$REPO" --label ci-e2e-failure --state open \
+              --json number --jq '.[0].number // empty')"
+            title="local-e2e $EVENT_NAME run failing on main"
+          fi
+
           if [ -n "$existing" ]; then
             gh issue comment "$existing" --repo "$REPO" --body "$body"
           else
             gh issue create --repo "$REPO" --label ci-e2e-failure \
-              --title "local-e2e $EVENT_NAME run failing on main" --body "$body"
+              --title "$title" --body "$body"
           fi

--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -497,6 +497,10 @@ jobs:
       - name: Aggregate e2e product-quality report
         id: aggregate
         if: always()
+        env:
+          # True when a prior step hard-failed (e.g. TiDB/server setup) before the
+          # suites produced outcomes; the aggregator then fails closed.
+          AGG_DEGRADED: ${{ failure() }}
         run: |
           cat > /tmp/e2e-outcomes.json <<JSON
           {
@@ -521,13 +525,17 @@ jobs:
           if [ "${FEISHU_PROOF}" = "1" ]; then
             proof_arg="--proof-fail-suite e2e-feishu-proof"
           fi
+          degraded_arg=""
+          if [ "${AGG_DEGRADED}" = "true" ]; then
+            degraded_arg="--degraded"
+          fi
           go run ./cmd/e2e-aggregate \
             --manifest e2e/suite-manifest.json \
             --outcomes /tmp/e2e-outcomes.json \
             --summaries e2e/reports/summary \
             --out /tmp/e2e-report.json \
             --issue-body /tmp/e2e-issue-body.md \
-            $proof_arg
+            $proof_arg $degraded_arg
 
       # Push failures/regressions that warrant attention to Feishu/Lark. PR-tier
       # failures stay in GitHub by policy; the notifier no-ops when no Feishu

--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -39,6 +39,10 @@ on:
         required: false
         default: "0"
         type: string
+      feishu_proof:
+        required: false
+        default: "0"
+        type: string
   workflow_dispatch:
     inputs:
       run_all_e2e:
@@ -129,6 +133,14 @@ on:
         options:
           - "0"
           - "1"
+      feishu_proof:
+        description: "Prove the Feishu notification path: inject a synthetic failed suite so a card is sent on this (green) run. Does not fail the job or file an issue."
+        required: false
+        default: "0"
+        type: choice
+        options:
+          - "0"
+          - "1"
 
 permissions:
   contents: read
@@ -164,6 +176,7 @@ env:
   # Deterministic perf gating lives in e2e/fuse-write-perf-budget-test.sh.
   FUSE_PERF_COMPARE_FAIL_ON_REGRESSION: "0"
   FUSE_CONCURRENCY_STRESS_REQUIRED: ${{ (github.event_name == 'schedule' || github.event_name == 'push' || ((github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && (inputs.run_all_e2e == '1' || inputs.run_fuse_concurrency_stress == '1'))) && '1' || '0' }}
+  FEISHU_PROOF: ${{ (github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call') && inputs.feishu_proof == '1' && '1' || '0' }}
   FUSE_PERF_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/fuse-performance
   FUSE_CONCURRENCY_ARTIFACT_DIR: ${{ github.workspace }}/e2e-artifacts/fuse-concurrency
   FEATURE_MATRIX_REPORT_DIR: ${{ github.workspace }}/e2e-artifacts/feature-matrix
@@ -504,12 +517,17 @@ jobs:
             "pjdfstest-suite": "${{ steps.pjdfstest-suite.outcome }}"
           }
           JSON
+          proof_arg=""
+          if [ "${FEISHU_PROOF}" = "1" ]; then
+            proof_arg="--proof-fail-suite e2e-feishu-proof"
+          fi
           go run ./cmd/e2e-aggregate \
             --manifest e2e/suite-manifest.json \
             --outcomes /tmp/e2e-outcomes.json \
             --summaries e2e/reports/summary \
             --out /tmp/e2e-report.json \
-            --issue-body /tmp/e2e-issue-body.md
+            --issue-body /tmp/e2e-issue-body.md \
+            $proof_arg
 
       # Push failures/regressions that warrant attention to Feishu/Lark. PR-tier
       # failures stay in GitHub by policy; the notifier no-ops when no Feishu

--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -655,6 +655,8 @@ jobs:
           # fuzzy, so narrow with it but confirm an exact "[sig: <signature>]"
           # marker client-side with jq; a new signature opens its own tracking
           # issue. With no signature we keep the legacy single-issue behaviour.
+          # The search+create is not atomic, but the workflow concurrency group
+          # serializes main runs, so a duplicate-issue race is not expected here.
           if [ -n "$SIGNATURE" ]; then
             existing="$(gh issue list --repo "$REPO" --label ci-e2e-failure --state open \
               --search "in:title $SIGNATURE" --json number,title \

--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -541,8 +541,17 @@ jobs:
       # Push failures/regressions that warrant attention to Feishu/Lark. PR-tier
       # failures stay in GitHub by policy; the notifier no-ops when no Feishu
       # secret is configured, so this never blocks a fork/PR without secrets.
+      #
+      # SECURITY: only run on trusted events. A pull_request runs code from the PR
+      # checkout, and a PR-controlled aggregator can set notify=true (e.g. a perf
+      # regression notifies regardless of tier); exposing the Feishu secrets to
+      # `go run` on a PR would let a same-repo PR exfiltrate them. push/schedule
+      # are main-only; workflow_dispatch/workflow_call require a trusted actor.
       - name: Notify Feishu on post-merge/nightly failure or perf regression
-        if: always() && steps.aggregate.outputs.notify == 'true'
+        if: >-
+          always() && steps.aggregate.outputs.notify == 'true' &&
+          (github.event_name == 'push' || github.event_name == 'schedule' ||
+          github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_call')
         continue-on-error: true
         env:
           FEISHU_APP_ID: ${{ secrets.FEISHU_APP_ID }}
@@ -657,7 +666,9 @@ jobs:
           # issue. With no signature we keep the legacy single-issue behaviour.
           # The search+create is not atomic, but the workflow concurrency group
           # serializes main runs, so a duplicate-issue race is not expected here.
-          if [ -n "$SIGNATURE" ]; then
+          # The signature is a sha256 hex slice; require [0-9a-f] before splicing
+          # it into the jq filter (defense-in-depth against jq metacharacters).
+          if [[ "$SIGNATURE" =~ ^[0-9a-f]+$ ]]; then
             existing="$(gh issue list --repo "$REPO" --label ci-e2e-failure --state open \
               --search "in:title $SIGNATURE" --json number,title \
               --jq "[.[] | select(.title | contains(\"[sig: $SIGNATURE]\"))][0].number // empty")"

--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -494,13 +494,15 @@ jobs:
       # Turn the raw per-suite outcomes into one product-quality report: a richer
       # step summary grouped by product promise, an aggregated JSON for the
       # notifier, a signature-led issue body, and outputs (notify/signature/...).
+      # failure() is only valid in `if:`, so capture "a prior step hard-failed"
+      # (e.g. TiDB/server setup) as a marker file the aggregator can read.
+      - name: Detect degraded pipeline
+        if: failure()
+        run: touch /tmp/e2e-degraded
+
       - name: Aggregate e2e product-quality report
         id: aggregate
         if: always()
-        env:
-          # True when a prior step hard-failed (e.g. TiDB/server setup) before the
-          # suites produced outcomes; the aggregator then fails closed.
-          AGG_DEGRADED: ${{ failure() }}
         run: |
           cat > /tmp/e2e-outcomes.json <<JSON
           {
@@ -526,7 +528,7 @@ jobs:
             proof_arg="--proof-fail-suite e2e-feishu-proof"
           fi
           degraded_arg=""
-          if [ "${AGG_DEGRADED}" = "true" ]; then
+          if [ -f /tmp/e2e-degraded ]; then
             degraded_arg="--degraded"
           fi
           go run ./cmd/e2e-aggregate \

--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -523,13 +523,12 @@ jobs:
             "pjdfstest-suite": "${{ steps.pjdfstest-suite.outcome }}"
           }
           JSON
-          proof_arg=""
+          args=()
           if [ "${FEISHU_PROOF}" = "1" ]; then
-            proof_arg="--proof-fail-suite e2e-feishu-proof"
+            args+=(--proof-fail-suite e2e-feishu-proof)
           fi
-          degraded_arg=""
           if [ -f /tmp/e2e-degraded ]; then
-            degraded_arg="--degraded"
+            args+=(--degraded)
           fi
           go run ./cmd/e2e-aggregate \
             --manifest e2e/suite-manifest.json \
@@ -537,7 +536,7 @@ jobs:
             --summaries e2e/reports/summary \
             --out /tmp/e2e-report.json \
             --issue-body /tmp/e2e-issue-body.md \
-            $proof_arg $degraded_arg
+            "${args[@]}"
 
       # Push failures/regressions that warrant attention to Feishu/Lark. PR-tier
       # failures stay in GitHub by policy; the notifier no-ops when no Feishu
@@ -641,21 +640,25 @@ jobs:
             --description "Automated: local-e2e scheduled/post-merge run failed" \
             --color D93F0B --force || true
 
-          # Prefer the structured, signature-led body from the aggregator; fall
-          # back to a one-liner if it is missing for any reason.
-          if [ -s /tmp/e2e-issue-body.md ]; then
-            body="$(cat /tmp/e2e-issue-body.md)"
-            body="$body"$'\n\n'"_run: $RUN_URL_"
+          # Prefer the structured, signature-led body from the aggregator; fall back
+          # to a one-liner if it is missing. Use a file (--body-file) so suite names
+          # or failure detail containing shell metacharacters/backticks cannot break
+          # or inject into the gh call.
+          body_file=/tmp/e2e-issue-body.md
+          if [ -s "$body_file" ]; then
+            printf '\n\n_run: %s_\n' "$RUN_URL" >> "$body_file"
           else
-            body="local-e2e \`$EVENT_NAME\` run failed on \`main\` at $SHA: $RUN_URL"
+            printf 'local-e2e `%s` run failed on `main` at %s: %s\n' "$EVENT_NAME" "$SHA" "$RUN_URL" > "$body_file"
           fi
 
-          # Group recurring failures by signature: an open issue carrying the same
-          # signature is reused; a new signature opens its own tracking issue. With
-          # no signature we keep the legacy single-issue behaviour.
+          # Group recurring failures by signature. GitHub's `in:title` search is
+          # fuzzy, so narrow with it but confirm an exact "[sig: <signature>]"
+          # marker client-side with jq; a new signature opens its own tracking
+          # issue. With no signature we keep the legacy single-issue behaviour.
           if [ -n "$SIGNATURE" ]; then
             existing="$(gh issue list --repo "$REPO" --label ci-e2e-failure --state open \
-              --search "in:title $SIGNATURE" --json number --jq '.[0].number // empty')"
+              --search "in:title $SIGNATURE" --json number,title \
+              --jq "[.[] | select(.title | contains(\"[sig: $SIGNATURE]\"))][0].number // empty")"
             title="local-e2e failure on main [sig: $SIGNATURE]"
           else
             existing="$(gh issue list --repo "$REPO" --label ci-e2e-failure --state open \
@@ -664,8 +667,8 @@ jobs:
           fi
 
           if [ -n "$existing" ]; then
-            gh issue comment "$existing" --repo "$REPO" --body "$body"
+            gh issue comment "$existing" --repo "$REPO" --body-file "$body_file"
           else
             gh issue create --repo "$REPO" --label ci-e2e-failure \
-              --title "$title" --body "$body"
+              --title "$title" --body-file "$body_file"
           fi

--- a/cmd/e2e-aggregate/main.go
+++ b/cmd/e2e-aggregate/main.go
@@ -32,16 +32,17 @@ func main() {
 		outPath       = flag.String("out", "", "write the aggregated RunReport JSON here")
 		issueBodyPath = flag.String("issue-body", "", "write the GitHub issue body here")
 		tierOverride  = flag.String("tier", "", "override automation tier (pr|post-merge|nightly|manual)")
+		proofSuite    = flag.String("proof-fail-suite", "", "inject a synthetic failed suite to prove the notification path end to end (manual CI proof)")
 	)
 	flag.Parse()
 
-	if err := run(*manifestPath, *outcomesPath, *summariesDir, *outPath, *issueBodyPath, *tierOverride); err != nil {
+	if err := run(*manifestPath, *outcomesPath, *summariesDir, *outPath, *issueBodyPath, *tierOverride, *proofSuite); err != nil {
 		fmt.Fprintln(os.Stderr, "e2e-aggregate:", err)
 		os.Exit(1)
 	}
 }
 
-func run(manifestPath, outcomesPath, summariesDir, outPath, issueBodyPath, tierOverride string) error {
+func run(manifestPath, outcomesPath, summariesDir, outPath, issueBodyPath, tierOverride, proofSuite string) error {
 	tier := e2ereport.TierFromEvent(os.Getenv("GITHUB_EVENT_NAME"))
 	if tierOverride != "" {
 		tier = e2ereport.Tier(tierOverride)
@@ -51,6 +52,13 @@ func run(manifestPath, outcomesPath, summariesDir, outPath, issueBodyPath, tierO
 	outcomes, err := loadOutcomes(outcomesPath)
 	if err != nil {
 		return err
+	}
+	if proofSuite != "" {
+		// Manual proof: a synthetic failed suite makes notify=true so the whole
+		// path (aggregate -> card -> Feishu) is exercised on a green CI run. It
+		// only affects this report; the real job gate reads actual step outcomes.
+		outcomes[proofSuite] = string(e2ereport.StatusFailure)
+		fmt.Fprintf(os.Stderr, "e2e-aggregate: proof mode — injected synthetic failed suite %q\n", proofSuite)
 	}
 	adopted := loadAdoptedSummaries(summariesDir)
 

--- a/cmd/e2e-aggregate/main.go
+++ b/cmd/e2e-aggregate/main.go
@@ -33,19 +33,24 @@ func main() {
 		issueBodyPath = flag.String("issue-body", "", "write the GitHub issue body here")
 		tierOverride  = flag.String("tier", "", "override automation tier (pr|post-merge|nightly|manual)")
 		proofSuite    = flag.String("proof-fail-suite", "", "inject a synthetic failed suite to prove the notification path end to end (manual CI proof)")
+		degraded      = flag.Bool("degraded", false, "the run is degraded (e.g. a required setup step hard-failed before suites ran): if no suite failure is otherwise detected, inject a synthetic pipeline failure so it is still reported and notified. Wire from GitHub failure().")
 	)
 	flag.Parse()
 
-	if err := run(*manifestPath, *outcomesPath, *summariesDir, *outPath, *issueBodyPath, *tierOverride, *proofSuite); err != nil {
+	if err := run(*manifestPath, *outcomesPath, *summariesDir, *outPath, *issueBodyPath, *tierOverride, *proofSuite, *degraded); err != nil {
 		fmt.Fprintln(os.Stderr, "e2e-aggregate:", err)
 		os.Exit(1)
 	}
 }
 
-func run(manifestPath, outcomesPath, summariesDir, outPath, issueBodyPath, tierOverride, proofSuite string) error {
+func run(manifestPath, outcomesPath, summariesDir, outPath, issueBodyPath, tierOverride, proofSuite string, degraded bool) error {
 	tier := e2ereport.TierFromEvent(os.Getenv("GITHUB_EVENT_NAME"))
 	if tierOverride != "" {
-		tier = e2ereport.Tier(tierOverride)
+		parsed, err := parseTierOverride(tierOverride)
+		if err != nil {
+			return err
+		}
+		tier = parsed
 	}
 
 	manifest := loadManifest(manifestPath)
@@ -64,6 +69,24 @@ func run(manifestPath, outcomesPath, summariesDir, outPath, issueBodyPath, tierO
 
 	summaries := e2ereport.SynthesizeSummaries(manifest, tier, outcomes, adopted)
 	report := e2ereport.Aggregate(runContextFromEnv(tier), summaries)
+
+	if degraded && report.OverallSuccess {
+		// A required step hard-failed before suite outcomes were collected, so the
+		// per-suite view looks clean while the job will fail. Fail closed: inject a
+		// pipeline failure so the run still gets a signature, issue, and notification.
+		summaries = append(summaries, e2ereport.SuiteSummary{
+			Suite:          "e2e-pipeline",
+			Status:         e2ereport.StatusFailure,
+			Tier:           tier,
+			ProductArea:    "ci",
+			ProductPromise: "the e2e pipeline runs to completion",
+			FailureClass:   e2ereport.FailureInfrastructure,
+			OwnerHint:      "ci",
+			Detail:         "a required step failed before per-suite results were collected",
+		})
+		report = e2ereport.Aggregate(runContextFromEnv(tier), summaries)
+		fmt.Fprintln(os.Stderr, "e2e-aggregate: degraded run — injected synthetic pipeline failure")
+	}
 
 	if err := appendStepSummary(report.Markdown()); err != nil {
 		return err
@@ -95,6 +118,15 @@ func run(manifestPath, outcomesPath, summariesDir, outPath, issueBodyPath, tierO
 	fmt.Printf("e2e-aggregate: %d suites, %d failed, %d perf-regressed, notify=%v (%s)\n",
 		len(report.Suites), len(report.Failed), len(report.PerfRegressed), decision.Notify, decision.Reason)
 	return nil
+}
+
+func parseTierOverride(value string) (e2ereport.Tier, error) {
+	switch tier := e2ereport.Tier(strings.TrimSpace(value)); tier {
+	case e2ereport.TierPR, e2ereport.TierPostMerge, e2ereport.TierNightly, e2ereport.TierManual:
+		return tier, nil
+	default:
+		return "", fmt.Errorf("invalid --tier %q (want pr|post-merge|nightly|manual)", value)
+	}
 }
 
 func loadManifest(path string) e2ereport.SuiteManifest {

--- a/cmd/e2e-aggregate/main.go
+++ b/cmd/e2e-aggregate/main.go
@@ -70,10 +70,13 @@ func run(manifestPath, outcomesPath, summariesDir, outPath, issueBodyPath, tierO
 	summaries := e2ereport.SynthesizeSummaries(manifest, tier, outcomes, adopted)
 	report := e2ereport.Aggregate(runContextFromEnv(tier), summaries)
 
-	if degraded && report.OverallSuccess {
+	if degraded && report.OverallSuccess && len(report.PerfRegressed) == 0 {
 		// A required step hard-failed before suite outcomes were collected, so the
-		// per-suite view looks clean while the job will fail. Fail closed: inject a
-		// pipeline failure so the run still gets a signature, issue, and notification.
+		// per-suite view is completely empty while the job will fail. Fail closed:
+		// inject a pipeline failure so the run still gets a signature, issue, and
+		// notification. Only when there is no other signal — a perf-only regression
+		// already notifies and must keep its own signature/routing, not be masked
+		// as an infrastructure failure.
 		summaries = append(summaries, e2ereport.SuiteSummary{
 			Suite:          "e2e-pipeline",
 			Status:         e2ereport.StatusFailure,

--- a/cmd/e2e-aggregate/main.go
+++ b/cmd/e2e-aggregate/main.go
@@ -1,0 +1,206 @@
+// Command e2e-aggregate turns one local-e2e run into a single product-quality
+// report. It reads the suite manifest plus the per-suite step outcomes (and any
+// structured suite summaries that have adopted the JSON contract), then emits:
+//
+//   - a markdown report appended to $GITHUB_STEP_SUMMARY,
+//   - the aggregated RunReport JSON (--out) for the notifier/dashboard,
+//   - a GitHub issue body (--issue-body) led by a stable failure signature,
+//   - workflow outputs (notify, signature, overall_success, reason) to
+//     $GITHUB_OUTPUT for downstream steps.
+//
+// It is intentionally tolerant: a missing manifest or summaries directory is a
+// warning, not a failure, so adoption can be incremental.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/mem9-ai/drive9/internal/e2ereport"
+)
+
+func main() {
+	var (
+		manifestPath  = flag.String("manifest", "e2e/suite-manifest.json", "path to the suite manifest JSON")
+		outcomesPath  = flag.String("outcomes", "", "path to JSON object mapping suite id -> GitHub step outcome")
+		summariesDir  = flag.String("summaries", "e2e/reports/summary", "directory of adopted per-suite summary JSON files")
+		outPath       = flag.String("out", "", "write the aggregated RunReport JSON here")
+		issueBodyPath = flag.String("issue-body", "", "write the GitHub issue body here")
+		tierOverride  = flag.String("tier", "", "override automation tier (pr|post-merge|nightly|manual)")
+	)
+	flag.Parse()
+
+	if err := run(*manifestPath, *outcomesPath, *summariesDir, *outPath, *issueBodyPath, *tierOverride); err != nil {
+		fmt.Fprintln(os.Stderr, "e2e-aggregate:", err)
+		os.Exit(1)
+	}
+}
+
+func run(manifestPath, outcomesPath, summariesDir, outPath, issueBodyPath, tierOverride string) error {
+	tier := e2ereport.TierFromEvent(os.Getenv("GITHUB_EVENT_NAME"))
+	if tierOverride != "" {
+		tier = e2ereport.Tier(tierOverride)
+	}
+
+	manifest := loadManifest(manifestPath)
+	outcomes, err := loadOutcomes(outcomesPath)
+	if err != nil {
+		return err
+	}
+	adopted := loadAdoptedSummaries(summariesDir)
+
+	summaries := e2ereport.SynthesizeSummaries(manifest, tier, outcomes, adopted)
+	report := e2ereport.Aggregate(runContextFromEnv(tier), summaries)
+
+	if err := appendStepSummary(report.Markdown()); err != nil {
+		return err
+	}
+	if outPath != "" {
+		raw, _ := json.MarshalIndent(report, "", "  ")
+		if err := os.WriteFile(outPath, raw, 0o644); err != nil {
+			return fmt.Errorf("write report: %w", err)
+		}
+	}
+	if issueBodyPath != "" && len(report.Failed) > 0 {
+		if err := os.WriteFile(issueBodyPath, []byte(report.IssueBody()), 0o644); err != nil {
+			return fmt.Errorf("write issue body: %w", err)
+		}
+	}
+
+	decision := report.ShouldNotifyFeishu()
+	if err := writeOutputs(map[string]string{
+		"notify":          boolStr(decision.Notify),
+		"reason":          decision.Reason,
+		"signature":       report.FailureSignature(),
+		"overall_success": boolStr(report.OverallSuccess),
+		"failed_count":    fmt.Sprintf("%d", len(report.Failed)),
+		"perf_regressed":  fmt.Sprintf("%d", len(report.PerfRegressed)),
+	}); err != nil {
+		return err
+	}
+
+	fmt.Printf("e2e-aggregate: %d suites, %d failed, %d perf-regressed, notify=%v (%s)\n",
+		len(report.Suites), len(report.Failed), len(report.PerfRegressed), decision.Notify, decision.Reason)
+	return nil
+}
+
+func loadManifest(path string) e2ereport.SuiteManifest {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e-aggregate: no manifest at %s (%v); synthesizing without product metadata\n", path, err)
+		return e2ereport.SuiteManifest{Suites: map[string]e2ereport.SuiteMeta{}}
+	}
+	m, err := e2ereport.LoadManifest(data)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "e2e-aggregate: bad manifest %s (%v); ignoring\n", path, err)
+		return e2ereport.SuiteManifest{Suites: map[string]e2ereport.SuiteMeta{}}
+	}
+	return m
+}
+
+func loadOutcomes(path string) (map[string]string, error) {
+	if path == "" {
+		return map[string]string{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read outcomes: %w", err)
+	}
+	var out map[string]string
+	if err := json.Unmarshal(data, &out); err != nil {
+		return nil, fmt.Errorf("parse outcomes: %w", err)
+	}
+	return out, nil
+}
+
+func loadAdoptedSummaries(dir string) []e2ereport.SuiteSummary {
+	matches, _ := filepath.Glob(filepath.Join(dir, "*.json"))
+	sort.Strings(matches)
+	var out []e2ereport.SuiteSummary
+	for _, p := range matches {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "e2e-aggregate: skip %s (%v)\n", p, err)
+			continue
+		}
+		s, err := e2ereport.ParseSuiteSummary(data)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "e2e-aggregate: skip %s (%v)\n", p, err)
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func runContextFromEnv(tier e2ereport.Tier) e2ereport.RunContext {
+	get := os.Getenv
+	ctx := e2ereport.RunContext{
+		Trigger:  tier,
+		Repo:     get("GITHUB_REPOSITORY"),
+		SHA:      get("GITHUB_SHA"),
+		Workflow: get("GITHUB_WORKFLOW"),
+		Branch:   get("GITHUB_REF_NAME"),
+	}
+	if server, repo, runID := get("GITHUB_SERVER_URL"), get("GITHUB_REPOSITORY"), get("GITHUB_RUN_ID"); server != "" && repo != "" && runID != "" {
+		ctx.RunURL = fmt.Sprintf("%s/%s/actions/runs/%s", server, repo, runID)
+	}
+	return ctx
+}
+
+func appendStepSummary(md string) error {
+	path := os.Getenv("GITHUB_STEP_SUMMARY")
+	if path == "" {
+		fmt.Print(md)
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return fmt.Errorf("open step summary: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString("\n" + md + "\n"); err != nil {
+		return fmt.Errorf("write step summary: %w", err)
+	}
+	return nil
+}
+
+func writeOutputs(kv map[string]string) error {
+	path := os.Getenv("GITHUB_OUTPUT")
+	keys := make([]string, 0, len(kv))
+	for k := range kv {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var b strings.Builder
+	for _, k := range keys {
+		// Single-line values only; safe for the key=value GITHUB_OUTPUT form.
+		fmt.Fprintf(&b, "%s=%s\n", k, strings.ReplaceAll(kv[k], "\n", " "))
+	}
+	if path == "" {
+		fmt.Print(b.String())
+		return nil
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0o644)
+	if err != nil {
+		return fmt.Errorf("open github output: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	if _, err := f.WriteString(b.String()); err != nil {
+		return fmt.Errorf("write github output: %w", err)
+	}
+	return nil
+}
+
+func boolStr(b bool) string {
+	if b {
+		return "true"
+	}
+	return "false"
+}

--- a/cmd/e2e-aggregate/main.go
+++ b/cmd/e2e-aggregate/main.go
@@ -87,6 +87,9 @@ func run(manifestPath, outcomesPath, summariesDir, outPath, issueBodyPath, tierO
 			OwnerHint:      "ci",
 			Detail:         "a required step failed before per-suite results were collected",
 		})
+		// Re-aggregate intentionally: the first Aggregate decided there was no
+		// signal; rebuild the report so the injected suite flows into Failed,
+		// the signature, and the notify decision.
 		report = e2ereport.Aggregate(runContextFromEnv(tier), summaries)
 		fmt.Fprintln(os.Stderr, "e2e-aggregate: degraded run — injected synthetic pipeline failure")
 	}

--- a/cmd/feishu-notify/main.go
+++ b/cmd/feishu-notify/main.go
@@ -1,0 +1,67 @@
+// Command feishu-notify sends a drive9 e2e product-quality card to Feishu/Lark
+// for runs that warrant a push (post-merge/nightly failures and performance
+// regressions). It reads the aggregated RunReport JSON produced by e2e-aggregate.
+//
+// It never fails the build for a configuration gap: if no Feishu transport is
+// configured (no FEISHU_WEBHOOK and no FEISHU_APP_* secrets), or the run does not
+// warrant notification, it logs the reason and exits 0. A genuine send error
+// (network/API) is reported and exits non-zero so the delivery problem is
+// visible.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/mem9-ai/drive9/internal/e2ereport"
+	"github.com/mem9-ai/drive9/internal/feishu"
+)
+
+func main() {
+	reportPath := flag.String("report", "", "path to the aggregated RunReport JSON (from e2e-aggregate --out)")
+	force := flag.Bool("force", false, "send even if policy would not notify (for testing the wiring)")
+	flag.Parse()
+
+	if err := run(*reportPath, *force); err != nil {
+		fmt.Fprintln(os.Stderr, "feishu-notify:", err)
+		os.Exit(1)
+	}
+}
+
+func run(reportPath string, force bool) error {
+	if reportPath == "" {
+		return fmt.Errorf("--report is required")
+	}
+	data, err := os.ReadFile(reportPath)
+	if err != nil {
+		return fmt.Errorf("read report: %w", err)
+	}
+	var report e2ereport.RunReport
+	if err := json.Unmarshal(data, &report); err != nil {
+		return fmt.Errorf("parse report: %w", err)
+	}
+
+	decision := report.ShouldNotifyFeishu()
+	if !decision.Notify && !force {
+		fmt.Printf("feishu-notify: no notification needed (%s)\n", decision.Reason)
+		return nil
+	}
+
+	cfg := feishu.ConfigFromEnv(os.Getenv)
+	if cfg.Transport() == feishu.TransportNone {
+		fmt.Println("feishu-notify: no Feishu transport configured (set FEISHU_WEBHOOK or FEISHU_APP_ID/SECRET/CHAT_ID); skipping send")
+		return nil
+	}
+
+	sent, err := feishu.Send(context.Background(), cfg, report.FeishuCard())
+	if err != nil {
+		return fmt.Errorf("send via %s: %w", cfg.Transport(), err)
+	}
+	if sent {
+		fmt.Printf("feishu-notify: sent via %s (%s)\n", cfg.Transport(), decision.Reason)
+	}
+	return nil
+}

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -53,6 +53,34 @@ without adding it to `.github/workflows/local-e2e.yml`.
 Scheduled and post-merge failures auto-file/append to a `ci-e2e-failure`
 GitHub issue, since GitHub only notifies the workflow author otherwise.
 
+## Product-quality report & Feishu notifications
+
+After the suites run, `cmd/e2e-aggregate` turns the per-suite outcomes into one
+product-quality report (`internal/e2ereport`). It is driven by
+`e2e/suite-manifest.json`, which maps each `local-e2e.yml` step id to its product
+area, product promise, owner hint, and default failure class. The aggregator:
+
+- appends a richer summary (grouped by product promise, with failed suites and
+  any performance regressions) to the workflow step summary;
+- computes a stable **failure signature** so a recurring failure pattern groups
+  into one `ci-e2e-failure` issue instead of spawning new ones, and writes a
+  structured, signature-led issue body;
+- decides whether to notify Feishu/Lark: PR-tier failures stay in GitHub;
+  post-merge/nightly/manual failures and explicit performance regressions are
+  pushed.
+
+`cmd/feishu-notify` sends the notification card. It auto-detects the transport
+from repo secrets and **no-ops (never fails the run) when none is configured**:
+
+- custom-bot webhook — set `FEISHU_WEBHOOK`;
+- app (tenant) API — set `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_CHAT_ID`.
+
+A suite can opt into richer reporting (durations, metrics with budgets/baselines
+for soft performance regressions, artifact links) by writing a
+`SuiteSummary` JSON to `e2e/reports/summary/<suite>.json`; the aggregator uses it
+in place of the synthesized-from-outcome summary. When adding a suite to
+`.github/workflows/local-e2e.yml`, also add its entry to `suite-manifest.json`.
+
 ## Run
 
 Use a hosted deployment by default. For local development on this machine, use

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -79,7 +79,7 @@ A suite can opt into richer reporting (durations, metrics with budgets/baselines
 for soft performance regressions, artifact links) by writing a
 `SuiteSummary` JSON to `e2e/reports/summary/<suite>.json`; the aggregator uses it
 in place of the synthesized-from-outcome summary. When adding a suite to
-`.github/workflows/local-e2e.yml`, also add its entry to `suite-manifest.json`.
+`.github/workflows/local-e2e.yml`, also add its entry to `e2e/suite-manifest.json`.
 
 ## Run
 

--- a/e2e/suite-manifest.json
+++ b/e2e/suite-manifest.json
@@ -1,0 +1,103 @@
+{
+  "_comment": "Product metadata for drive9 e2e suites, keyed by the local-e2e.yml step id. Consumed by cmd/e2e-aggregate to turn raw step outcomes into a product-quality report (owner routing, failure signatures, Feishu notifications). Suites that adopt the structured summary contract (e2e/reports/summary/<suite>.json) override these defaults. Keep in sync when adding suites to .github/workflows/local-e2e.yml.",
+  "suites": {
+    "api-smoke": {
+      "title": "API smoke",
+      "product_area": "api",
+      "product_promise": "HTTP API works end to end",
+      "owner_hint": "api"
+    },
+    "existing-key-smoke": {
+      "title": "Existing-key smoke",
+      "product_area": "api",
+      "product_promise": "existing API keys keep working",
+      "owner_hint": "api"
+    },
+    "cli-smoke": {
+      "title": "CLI smoke",
+      "product_area": "cli",
+      "product_promise": "drive9 CLI works end to end",
+      "owner_hint": "cli"
+    },
+    "layer-fs-smoke": {
+      "title": "Layer FS smoke",
+      "product_area": "filesystem",
+      "product_promise": "layered filesystem reads/writes are correct",
+      "owner_hint": "fs"
+    },
+    "fuse-smoke": {
+      "title": "FUSE release gate",
+      "product_area": "fuse",
+      "product_promise": "FUSE mount works for release",
+      "owner_hint": "fs"
+    },
+    "git-ops-smoke": {
+      "title": "Git operations smoke",
+      "product_area": "git",
+      "product_promise": "core git operations work on drive9",
+      "owner_hint": "git",
+      "failure_class": "correctness"
+    },
+    "portable-pack-unpack-e2e": {
+      "title": "Portable pack/unpack e2e",
+      "product_area": "portability",
+      "product_promise": "pack/unpack round-trips losslessly",
+      "owner_hint": "fs"
+    },
+    "fuse-crash-recovery": {
+      "title": "FUSE crash recovery e2e",
+      "product_area": "fuse",
+      "product_promise": "FUSE recovers cleanly after a crash",
+      "owner_hint": "fs",
+      "failure_class": "correctness"
+    },
+    "fuse-write-perf-budget": {
+      "title": "FUSE write perf budget e2e",
+      "product_area": "fuse",
+      "product_promise": "FUSE write latency stays within budget",
+      "owner_hint": "fs",
+      "failure_class": "performance"
+    },
+    "fuse_performance_compare": {
+      "title": "FUSE performance compare",
+      "product_area": "fuse",
+      "product_promise": "FUSE performance does not regress vs baseline",
+      "owner_hint": "fs",
+      "failure_class": "performance"
+    },
+    "fuse-concurrency-stress": {
+      "title": "FUSE concurrency stress",
+      "product_area": "fuse",
+      "product_promise": "FUSE stays correct under concurrency",
+      "owner_hint": "fs",
+      "failure_class": "correctness"
+    },
+    "fuse-posix-fsx": {
+      "title": "FUSE POSIX/fsx gate",
+      "product_area": "fuse",
+      "product_promise": "FUSE upholds POSIX semantics",
+      "owner_hint": "fs",
+      "failure_class": "correctness"
+    },
+    "smoke-all": {
+      "title": "Full smoke-all suite",
+      "product_area": "platform",
+      "product_promise": "the full smoke suite passes",
+      "owner_hint": "platform"
+    },
+    "git-feature-matrix": {
+      "title": "Git feature matrix",
+      "product_area": "git",
+      "product_promise": "git feature matrix is compatible",
+      "owner_hint": "git",
+      "failure_class": "correctness"
+    },
+    "pjdfstest-suite": {
+      "title": "pjdfstest POSIX suite",
+      "product_area": "posix",
+      "product_promise": "drive9 passes the pjdfstest POSIX suite",
+      "owner_hint": "fs",
+      "failure_class": "correctness"
+    }
+  }
+}

--- a/e2e/suite-manifest.json
+++ b/e2e/suite-manifest.json
@@ -98,6 +98,13 @@
       "product_promise": "drive9 passes the pjdfstest POSIX suite",
       "owner_hint": "fs",
       "failure_class": "correctness"
+    },
+    "e2e-feishu-proof": {
+      "title": "Feishu notification proof",
+      "product_area": "ci",
+      "product_promise": "Feishu notification delivery works",
+      "owner_hint": "ci",
+      "failure_class": "infrastructure"
     }
   }
 }

--- a/internal/e2ereport/event.go
+++ b/internal/e2ereport/event.go
@@ -1,0 +1,18 @@
+package e2ereport
+
+// TierFromEvent maps a GitHub Actions event name to the automation tier it
+// represents, so notification policy can distinguish a PR gate from a post-merge
+// or nightly run.
+func TierFromEvent(event string) Tier {
+	switch event {
+	case "pull_request", "pull_request_target", "merge_group":
+		return TierPR
+	case "push":
+		return TierPostMerge
+	case "schedule":
+		return TierNightly
+	default:
+		// workflow_dispatch, workflow_call, and anything else are manual.
+		return TierManual
+	}
+}

--- a/internal/e2ereport/event_test.go
+++ b/internal/e2ereport/event_test.go
@@ -1,0 +1,21 @@
+package e2ereport
+
+import "testing"
+
+func TestTierFromEvent(t *testing.T) {
+	cases := map[string]Tier{
+		"pull_request":        TierPR,
+		"pull_request_target": TierPR,
+		"merge_group":         TierPR,
+		"push":                TierPostMerge,
+		"schedule":            TierNightly,
+		"workflow_dispatch":   TierManual,
+		"workflow_call":       TierManual,
+		"":                    TierManual,
+	}
+	for in, want := range cases {
+		if got := TierFromEvent(in); got != want {
+			t.Errorf("TierFromEvent(%q)=%q want %q", in, got, want)
+		}
+	}
+}

--- a/internal/e2ereport/manifest.go
+++ b/internal/e2ereport/manifest.go
@@ -72,31 +72,26 @@ func SynthesizeSummaries(m SuiteManifest, defaultTier Tier, outcomes map[string]
 
 	for _, id := range ids {
 		seen[id] = true
-		if s, ok := byID[id]; ok {
+		meta := m.Suites[id]
+		status := NormalizeStatus(outcomes[id])
+		if adopted, ok := byID[id]; ok {
+			// Adopted summary wins for its dynamic fields, but manifest defaults
+			// fill any it left blank, and the GitHub step outcome is authoritative
+			// for failure: a script that exits non-zero (or leaves a stale success
+			// summary behind) must not be reported as passing.
+			s := fillFromManifest(adopted, meta, defaultTier)
+			if status == StatusFailure {
+				s = markFailed(s, meta, "step outcome reported failure")
+			}
 			out = append(out, s)
 			continue
 		}
-		meta := m.Suites[id]
-		status := NormalizeStatus(outcomes[id])
-		s := SuiteSummary{
-			Suite:          id,
-			Status:         status,
-			Tier:           pickTier(meta.Tier, defaultTier),
-			ProductArea:    meta.ProductArea,
-			ProductPromise: meta.ProductPromise,
-			OwnerHint:      meta.OwnerHint,
-		}
-		if status == StatusFailure {
-			s.FailureClass = pickFailureClass(meta.FailureClass)
-			if meta.Title != "" {
-				s.Detail = meta.Title + " did not succeed"
-			}
-		}
-		out = append(out, s)
+		out = append(out, synthesize(id, status, meta, defaultTier))
 	}
 
 	// Adopted summaries for suites not in the outcomes map (e.g. emitted by a
-	// suite the workflow table does not enumerate) are still included.
+	// suite the workflow table does not enumerate) are still included, with
+	// manifest defaults filled in.
 	extra := make([]string, 0)
 	for id := range byID {
 		if !seen[id] {
@@ -105,9 +100,66 @@ func SynthesizeSummaries(m SuiteManifest, defaultTier Tier, outcomes map[string]
 	}
 	sort.Strings(extra)
 	for _, id := range extra {
-		out = append(out, byID[id])
+		out = append(out, fillFromManifest(byID[id], m.Suites[id], defaultTier))
 	}
 	return out
+}
+
+func synthesize(id string, status Status, meta SuiteMeta, defaultTier Tier) SuiteSummary {
+	s := SuiteSummary{
+		Suite:          id,
+		Status:         status,
+		Tier:           pickTier(meta.Tier, defaultTier),
+		ProductArea:    meta.ProductArea,
+		ProductPromise: meta.ProductPromise,
+		OwnerHint:      meta.OwnerHint,
+	}
+	if status == StatusFailure {
+		s = markFailed(s, meta, "")
+	}
+	return s
+}
+
+// fillFromManifest fills zero-valued metadata fields of an adopted summary from
+// the manifest, so signatures and rendering stay complete even when a producer
+// emits only dynamic fields (status/metrics) and relies on manifest defaults.
+func fillFromManifest(s SuiteSummary, meta SuiteMeta, defaultTier Tier) SuiteSummary {
+	if s.Tier == "" {
+		s.Tier = pickTier(meta.Tier, defaultTier)
+	}
+	if s.ProductArea == "" {
+		s.ProductArea = meta.ProductArea
+	}
+	if s.ProductPromise == "" {
+		s.ProductPromise = meta.ProductPromise
+	}
+	if s.OwnerHint == "" {
+		s.OwnerHint = meta.OwnerHint
+	}
+	if s.Status == StatusFailure && s.FailureClass == FailureNone {
+		s.FailureClass = pickFailureClass(meta.FailureClass)
+	}
+	return s
+}
+
+// markFailed forces a suite to failed, classifying it from the manifest and
+// adding a default detail when the summary did not supply one.
+func markFailed(s SuiteSummary, meta SuiteMeta, reason string) SuiteSummary {
+	s.Status = StatusFailure
+	if s.FailureClass == FailureNone {
+		s.FailureClass = pickFailureClass(meta.FailureClass)
+	}
+	if s.Detail == "" {
+		title := meta.Title
+		if title == "" {
+			title = s.Suite
+		}
+		s.Detail = title + " did not succeed"
+		if reason != "" {
+			s.Detail += " (" + reason + ")"
+		}
+	}
+	return s
 }
 
 func pickTier(specific, fallback Tier) Tier {

--- a/internal/e2ereport/manifest.go
+++ b/internal/e2ereport/manifest.go
@@ -1,0 +1,125 @@
+package e2ereport
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// SuiteMeta is the declarative product metadata for one e2e suite, keyed by the
+// workflow step id. It lets the aggregator synthesize a SuiteSummary for suites
+// that have not yet adopted the structured JSON contract — bridging the existing
+// `steps.<id>.outcome` table to the product-quality report.
+type SuiteMeta struct {
+	Title          string       `json:"title"`
+	ProductArea    string       `json:"product_area,omitempty"`
+	ProductPromise string       `json:"product_promise,omitempty"`
+	OwnerHint      string       `json:"owner_hint,omitempty"`
+	Tier           Tier         `json:"tier,omitempty"`
+	FailureClass   FailureClass `json:"failure_class,omitempty"`
+}
+
+// SuiteManifest is the set of known suites and their product metadata.
+type SuiteManifest struct {
+	Suites map[string]SuiteMeta `json:"suites"`
+}
+
+// LoadManifest parses the suite manifest JSON.
+func LoadManifest(data []byte) (SuiteManifest, error) {
+	var m SuiteManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return SuiteManifest{}, fmt.Errorf("parse suite manifest: %w", err)
+	}
+	if len(m.Suites) == 0 {
+		return SuiteManifest{}, fmt.Errorf("suite manifest has no suites")
+	}
+	return m, nil
+}
+
+// NormalizeStatus maps a GitHub Actions step outcome (success/failure/skipped/
+// cancelled, or empty) to a Status. Unknown non-empty outcomes are failures so
+// they are never silently treated as passing.
+func NormalizeStatus(outcome string) Status {
+	switch strings.ToLower(strings.TrimSpace(outcome)) {
+	case "success":
+		return StatusSuccess
+	case "", "skipped":
+		return StatusSkipped
+	default:
+		return StatusFailure
+	}
+}
+
+// SynthesizeSummaries builds the suite summaries for a run. For each suite in
+// outcomes (step id -> GitHub outcome): if an adopted structured summary exists
+// it is used as-is; otherwise one is synthesized from the manifest metadata plus
+// the step outcome. Suites present only in adopted summaries are also included.
+func SynthesizeSummaries(m SuiteManifest, defaultTier Tier, outcomes map[string]string, adopted []SuiteSummary) []SuiteSummary {
+	byID := make(map[string]SuiteSummary, len(adopted))
+	for _, s := range adopted {
+		byID[s.Suite] = s
+	}
+
+	out := make([]SuiteSummary, 0, len(outcomes)+len(adopted))
+	seen := make(map[string]bool)
+
+	ids := make([]string, 0, len(outcomes))
+	for id := range outcomes {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		seen[id] = true
+		if s, ok := byID[id]; ok {
+			out = append(out, s)
+			continue
+		}
+		meta := m.Suites[id]
+		status := NormalizeStatus(outcomes[id])
+		s := SuiteSummary{
+			Suite:          id,
+			Status:         status,
+			Tier:           pickTier(meta.Tier, defaultTier),
+			ProductArea:    meta.ProductArea,
+			ProductPromise: meta.ProductPromise,
+			OwnerHint:      meta.OwnerHint,
+		}
+		if status == StatusFailure {
+			s.FailureClass = pickFailureClass(meta.FailureClass)
+			if meta.Title != "" {
+				s.Detail = meta.Title + " did not succeed"
+			}
+		}
+		out = append(out, s)
+	}
+
+	// Adopted summaries for suites not in the outcomes map (e.g. emitted by a
+	// suite the workflow table does not enumerate) are still included.
+	extra := make([]string, 0)
+	for id := range byID {
+		if !seen[id] {
+			extra = append(extra, id)
+		}
+	}
+	sort.Strings(extra)
+	for _, id := range extra {
+		out = append(out, byID[id])
+	}
+	return out
+}
+
+func pickTier(specific, fallback Tier) Tier {
+	if specific != "" {
+		return specific
+	}
+	return fallback
+}
+
+func pickFailureClass(c FailureClass) FailureClass {
+	if c != FailureNone {
+		return c
+	}
+	return FailureUnknown
+}

--- a/internal/e2ereport/manifest.go
+++ b/internal/e2ereport/manifest.go
@@ -44,7 +44,10 @@ func NormalizeStatus(outcome string) Status {
 	switch strings.ToLower(strings.TrimSpace(outcome)) {
 	case "success":
 		return StatusSuccess
-	case "", "skipped":
+	case "", "skipped", "cancelled":
+		// A cancelled step (job/concurrency cancellation) is an operational
+		// non-event, not a product failure — treat it like skipped so it does not
+		// raise a false Feishu alarm. Truly unknown outcomes still fail closed.
 		return StatusSkipped
 	default:
 		return StatusFailure

--- a/internal/e2ereport/manifest_test.go
+++ b/internal/e2ereport/manifest_test.go
@@ -29,8 +29,8 @@ func TestLoadManifest(t *testing.T) {
 func TestNormalizeStatus(t *testing.T) {
 	cases := map[string]Status{
 		"success": StatusSuccess, "Success": StatusSuccess,
-		"failure": StatusFailure, "cancelled": StatusFailure, "weird": StatusFailure,
-		"": StatusSkipped, "skipped": StatusSkipped,
+		"failure": StatusFailure, "weird": StatusFailure,
+		"": StatusSkipped, "skipped": StatusSkipped, "cancelled": StatusSkipped,
 	}
 	for in, want := range cases {
 		if got := NormalizeStatus(in); got != want {

--- a/internal/e2ereport/manifest_test.go
+++ b/internal/e2ereport/manifest_test.go
@@ -1,0 +1,79 @@
+package e2ereport
+
+import "testing"
+
+const sampleManifest = `{
+  "suites": {
+    "api-smoke":         {"title": "API smoke", "product_area": "api", "product_promise": "control surface works", "owner_hint": "api-team"},
+    "git-feature-matrix":{"title": "Git feature matrix", "product_area": "git", "product_promise": "git compatibility", "owner_hint": "git-team", "failure_class": "correctness"},
+    "fuse-write-perf-budget": {"title": "FUSE write perf budget", "product_area": "fuse", "product_promise": "performance", "owner_hint": "fs-team", "failure_class": "performance"}
+  }
+}`
+
+func TestLoadManifest(t *testing.T) {
+	m, err := LoadManifest([]byte(sampleManifest))
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if len(m.Suites) != 3 || m.Suites["git-feature-matrix"].OwnerHint != "git-team" {
+		t.Fatalf("unexpected manifest: %+v", m.Suites)
+	}
+	if _, err := LoadManifest([]byte(`{"suites":{}}`)); err == nil {
+		t.Fatal("expected error for empty suites")
+	}
+	if _, err := LoadManifest([]byte(`bad`)); err == nil {
+		t.Fatal("expected error for bad json")
+	}
+}
+
+func TestNormalizeStatus(t *testing.T) {
+	cases := map[string]Status{
+		"success": StatusSuccess, "Success": StatusSuccess,
+		"failure": StatusFailure, "cancelled": StatusFailure, "weird": StatusFailure,
+		"": StatusSkipped, "skipped": StatusSkipped,
+	}
+	for in, want := range cases {
+		if got := NormalizeStatus(in); got != want {
+			t.Errorf("NormalizeStatus(%q)=%q want %q", in, got, want)
+		}
+	}
+}
+
+func TestSynthesizeSummaries(t *testing.T) {
+	m, _ := LoadManifest([]byte(sampleManifest))
+	outcomes := map[string]string{
+		"api-smoke":              "success",
+		"git-feature-matrix":     "failure",
+		"fuse-write-perf-budget": "skipped",
+	}
+	// One adopted structured summary overrides synthesis for its suite.
+	adopted := []SuiteSummary{
+		{Suite: "fuse-write-perf-budget", Status: StatusSuccess, ProductPromise: "performance",
+			Metrics: []Metric{{Name: "p99_write_ms", Value: 50, Budget: f64(30)}}},
+	}
+	got := SynthesizeSummaries(m, TierPostMerge, outcomes, adopted)
+	if len(got) != 3 {
+		t.Fatalf("want 3 summaries, got %d", len(got))
+	}
+
+	bySuite := map[string]SuiteSummary{}
+	for _, s := range got {
+		bySuite[s.Suite] = s
+	}
+	// Synthesized failure picks up manifest metadata + failure class + default tier.
+	gfm := bySuite["git-feature-matrix"]
+	if gfm.Status != StatusFailure || gfm.FailureClass != FailureCorrectness || gfm.OwnerHint != "git-team" || gfm.Tier != TierPostMerge {
+		t.Fatalf("git-feature-matrix synth wrong: %+v", gfm)
+	}
+	// Adopted summary wins (carries metrics) instead of being synthesized from "skipped".
+	perf := bySuite["fuse-write-perf-budget"]
+	if len(perf.Metrics) != 1 || perf.Status != StatusSuccess {
+		t.Fatalf("adopted summary not used: %+v", perf)
+	}
+
+	// End-to-end: aggregate flags the synthesized failure and the adopted perf regression.
+	r := Aggregate(RunContext{Trigger: TierPostMerge}, got)
+	if r.OverallSuccess || len(r.Failed) != 1 || len(r.PerfRegressed) != 1 {
+		t.Fatalf("aggregate wrong: failed=%d perf=%d ok=%v", len(r.Failed), len(r.PerfRegressed), r.OverallSuccess)
+	}
+}

--- a/internal/e2ereport/manifest_test.go
+++ b/internal/e2ereport/manifest_test.go
@@ -70,10 +70,31 @@ func TestSynthesizeSummaries(t *testing.T) {
 	if len(perf.Metrics) != 1 || perf.Status != StatusSuccess {
 		t.Fatalf("adopted summary not used: %+v", perf)
 	}
+	// ...but manifest defaults fill the fields the adopted summary left blank.
+	if perf.OwnerHint != "fs-team" || perf.ProductArea != "fuse" || perf.Tier != TierPostMerge {
+		t.Fatalf("manifest defaults not merged into adopted summary: %+v", perf)
+	}
 
 	// End-to-end: aggregate flags the synthesized failure and the adopted perf regression.
 	r := Aggregate(RunContext{Trigger: TierPostMerge}, got)
 	if r.OverallSuccess || len(r.Failed) != 1 || len(r.PerfRegressed) != 1 {
 		t.Fatalf("aggregate wrong: failed=%d perf=%d ok=%v", len(r.Failed), len(r.PerfRegressed), r.OverallSuccess)
+	}
+}
+
+func TestSynthesizeFailureOutcomeOverridesAdoptedSuccess(t *testing.T) {
+	m, _ := LoadManifest([]byte(sampleManifest))
+	// Suite self-reported success, but the GitHub step exited non-zero.
+	adopted := []SuiteSummary{{Suite: "git-feature-matrix", Status: StatusSuccess}}
+	got := SynthesizeSummaries(m, TierNightly, map[string]string{"git-feature-matrix": "failure"}, adopted)
+	if len(got) != 1 {
+		t.Fatalf("want 1, got %d", len(got))
+	}
+	s := got[0]
+	if s.Status != StatusFailure {
+		t.Fatalf("failing step outcome must override adopted success: %+v", s)
+	}
+	if s.FailureClass != FailureCorrectness { // from manifest default
+		t.Fatalf("failure class not classified from manifest: %+v", s)
 	}
 }

--- a/internal/e2ereport/render.go
+++ b/internal/e2ereport/render.go
@@ -1,0 +1,177 @@
+package e2ereport
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Markdown renders the run report for GITHUB_STEP_SUMMARY: a status table grouped
+// by product promise, plus concrete failed suites and any perf regressions.
+func (r RunReport) Markdown() string {
+	var b strings.Builder
+	overall := "✅ success"
+	if !r.OverallSuccess {
+		overall = "❌ failure"
+	}
+	fmt.Fprintf(&b, "## drive9 e2e product-quality report\n\n")
+	fmt.Fprintf(&b, "- overall: **%s**\n- trigger: `%s`\n", overall, triggerName(r.Context.Trigger))
+	if r.Context.RunURL != "" {
+		fmt.Fprintf(&b, "- run: %s\n", r.Context.RunURL)
+	}
+	if sig := r.FailureSignature(); sig != "" {
+		fmt.Fprintf(&b, "- failure signature: `%s`\n", sig)
+	}
+	b.WriteString("\n### Suites by product promise\n\n")
+	b.WriteString("| Suite | Promise | Status | Class | Owner |\n|---|---|---|---|---|\n")
+	for _, s := range r.byPromise() {
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s |\n",
+			dash(s.Suite), dash(s.ProductPromise), statusIcon(s.Status), dash(string(s.FailureClass)), dash(s.OwnerHint))
+	}
+	if len(r.Failed) > 0 {
+		b.WriteString("\n### Failed suites\n\n")
+		for _, s := range r.Failed {
+			fmt.Fprintf(&b, "- **%s** (%s) — %s\n", s.Suite, dash(string(s.FailureClass)), dash(s.Detail))
+		}
+	}
+	if len(r.PerfRegressed) > 0 {
+		b.WriteString("\n### Performance regressions\n\n")
+		for _, s := range r.PerfRegressed {
+			for _, m := range s.PerfRegressions() {
+				fmt.Fprintf(&b, "- **%s** %s = %.2f%s (budget %s, baseline %s)\n",
+					s.Suite, m.Name, m.Value, m.Unit, fmtPtr(m.Budget), fmtPtr(m.Baseline))
+			}
+		}
+	}
+	return b.String()
+}
+
+// IssueBody renders the structured tracking-issue body, led by the failure
+// signature so recurring patterns group into one thread.
+func (r RunReport) IssueBody() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "### drive9 e2e %s failure\n\n", triggerName(r.Context.Trigger))
+	fmt.Fprintf(&b, "- signature: `%s`\n", r.FailureSignature())
+	if r.Context.SHA != "" {
+		fmt.Fprintf(&b, "- commit: `%s`\n", r.Context.SHA)
+	}
+	if r.Context.RunURL != "" {
+		fmt.Fprintf(&b, "- run: %s\n", r.Context.RunURL)
+	}
+	b.WriteString("\n**Failed suites:**\n\n")
+	for _, s := range r.Failed {
+		fmt.Fprintf(&b, "- `%s` — class=%s, promise=%s, owner=%s", s.Suite, dash(string(s.FailureClass)), dash(s.ProductPromise), dash(s.OwnerHint))
+		if s.ArtifactURL != "" {
+			fmt.Fprintf(&b, ", artifact=%s", s.ArtifactURL)
+		}
+		b.WriteString("\n")
+		if s.Detail != "" {
+			fmt.Fprintf(&b, "  - %s\n", s.Detail)
+		}
+	}
+	for _, s := range r.PerfRegressed {
+		for _, m := range s.PerfRegressions() {
+			fmt.Fprintf(&b, "- ⏱ perf `%s` %s=%.2f%s budget=%s baseline=%s\n",
+				s.Suite, m.Name, m.Value, m.Unit, fmtPtr(m.Budget), fmtPtr(m.Baseline))
+		}
+	}
+	return b.String()
+}
+
+// FeishuCard builds the Feishu/Lark interactive card payload for a run report.
+// Returns the object to be JSON-marshalled as the message `content` (msg_type
+// "interactive"). Compact and actionable per PRD: suite/signature/area/owner,
+// run URL, artifact URL, blocking level.
+func (r RunReport) FeishuCard() map[string]any {
+	headerColor := "red"
+	title := fmt.Sprintf("drive9 e2e %s failure", triggerName(r.Context.Trigger))
+	if r.OverallSuccess && len(r.PerfRegressed) > 0 {
+		headerColor = "orange"
+		title = fmt.Sprintf("drive9 e2e %s performance regression", triggerName(r.Context.Trigger))
+	}
+
+	var lines []string
+	if sig := r.FailureSignature(); sig != "" {
+		lines = append(lines, fmt.Sprintf("**signature:** `%s`", sig))
+	}
+	lines = append(lines, fmt.Sprintf("**trigger:** %s", triggerName(r.Context.Trigger)))
+	if len(r.Failed) > 0 {
+		lines = append(lines, fmt.Sprintf("**failed (%d):**", len(r.Failed)))
+		for _, s := range r.Failed {
+			lines = append(lines, fmt.Sprintf("• %s — %s / %s (owner: %s)",
+				s.Suite, dash(string(s.FailureClass)), dash(s.ProductPromise), dash(s.OwnerHint)))
+		}
+	}
+	for _, s := range r.PerfRegressed {
+		for _, m := range s.PerfRegressions() {
+			lines = append(lines, fmt.Sprintf("• ⏱ %s %s=%.2f%s (budget %s, baseline %s)",
+				s.Suite, m.Name, m.Value, m.Unit, fmtPtr(m.Budget), fmtPtr(m.Baseline)))
+		}
+	}
+
+	elements := []any{
+		map[string]any{
+			"tag":  "div",
+			"text": map[string]any{"tag": "lark_md", "content": strings.Join(lines, "\n")},
+		},
+	}
+	var actions []any
+	if r.Context.RunURL != "" {
+		actions = append(actions, map[string]any{
+			"tag":  "button",
+			"text": map[string]any{"tag": "plain_text", "content": "Run"},
+			"url":  r.Context.RunURL,
+			"type": "primary",
+		})
+	}
+	if len(actions) > 0 {
+		elements = append(elements, map[string]any{"tag": "action", "actions": actions})
+	}
+
+	return map[string]any{
+		"config": map[string]any{"wide_screen_mode": true},
+		"header": map[string]any{
+			"template": headerColor,
+			"title":    map[string]any{"tag": "plain_text", "content": title},
+		},
+		"elements": elements,
+	}
+}
+
+func (r RunReport) byPromise() []SuiteSummary {
+	out := append([]SuiteSummary(nil), r.Suites...)
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].ProductPromise != out[j].ProductPromise {
+			return out[i].ProductPromise < out[j].ProductPromise
+		}
+		return out[i].Suite < out[j].Suite
+	})
+	return out
+}
+
+func statusIcon(s Status) string {
+	switch s {
+	case StatusSuccess:
+		return "✅ success"
+	case StatusFailure:
+		return "❌ failure"
+	case StatusSkipped:
+		return "⏭ skipped"
+	default:
+		return string(s)
+	}
+}
+
+func dash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
+}
+
+func fmtPtr(p *float64) string {
+	if p == nil {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f", *p)
+}

--- a/internal/e2ereport/render.go
+++ b/internal/e2ereport/render.go
@@ -99,33 +99,30 @@ func (r RunReport) FeishuCard() map[string]any {
 		title = fmt.Sprintf("drive9 e2e %s performance regression", triggerName(r.Context.Trigger))
 	}
 
-	var lines []string
+	var summary []string
 	if sig := r.FailureSignature(); sig != "" {
-		lines = append(lines, fmt.Sprintf("**signature:** `%s`", sig))
+		summary = append(summary, fmt.Sprintf("**signature:** `%s`", sig))
 	}
-	lines = append(lines, fmt.Sprintf("**trigger:** %s", triggerName(r.Context.Trigger)))
+	summary = append(summary, fmt.Sprintf("**trigger:** %s", triggerName(r.Context.Trigger)))
+	elements := []any{mdDiv(strings.Join(summary, "  ·  "))}
+
 	if len(r.Failed) > 0 {
-		lines = append(lines, fmt.Sprintf("**failed (%d):**", len(r.Failed)))
+		fl := []string{fmt.Sprintf("**failed (%d):**", len(r.Failed))}
 		for _, s := range r.Failed {
-			lines = append(lines, fmt.Sprintf("• **%s** — <font color='red'>%s</font> / %s (owner: %s)",
-				s.Suite, dash(string(s.FailureClass)), dash(s.ProductPromise), dash(s.OwnerHint)))
+			fl = append(fl, fmt.Sprintf("• **%s** — <font color='%s'>%s</font> / %s (owner: %s)",
+				s.Suite, failClassColor(s.FailureClass), dash(string(s.FailureClass)), dash(s.ProductPromise), dash(s.OwnerHint)))
 		}
+		elements = append(elements, mdDiv(strings.Join(fl, "\n")))
 	}
 	if len(r.PerfRegressed) > 0 {
-		lines = append(lines, "**performance regressions:**")
+		elements = append(elements, mdDiv("**performance regressions:**"))
 		for _, s := range r.PerfRegressed {
 			for _, m := range s.PerfRegressions() {
-				lines = append(lines, feishuPerfLine(s.Suite, m))
+				elements = append(elements, perfFieldsDiv(s.Suite, m))
 			}
 		}
 	}
 
-	elements := []any{
-		map[string]any{
-			"tag":  "div",
-			"text": map[string]any{"tag": "lark_md", "content": strings.Join(lines, "\n")},
-		},
-	}
 	var actions []any
 	if r.Context.RunURL != "" {
 		actions = append(actions, map[string]any{
@@ -187,31 +184,58 @@ func fmtPtr(p *float64) string {
 	return fmt.Sprintf("%.2f", *p)
 }
 
-// feishuPerfLine renders one regressed metric with rich lark_md emphasis on the
-// numbers an operator acts on: the measured value is bold red, and the deltas
-// against budget and baseline are bold and coloured (worse=red, better=green).
-func feishuPerfLine(suite string, m Metric) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "• ⏱ **%s** · %s = <font color='red'>**%.2f%s**</font>", suite, m.Name, m.Value, m.Unit)
-	if m.Budget != nil {
-		fmt.Fprintf(&b, " — budget %.2f%s%s", *m.Budget, m.Unit, pctDelta(m.Value, *m.Budget))
-	}
-	if m.Baseline != nil {
-		fmt.Fprintf(&b, " · baseline %.2f%s%s", *m.Baseline, m.Unit, pctDelta(m.Value, *m.Baseline))
-	}
-	return b.String()
+// mdDiv is a lark_md text block element.
+func mdDiv(content string) map[string]any {
+	return map[string]any{"tag": "div", "text": map[string]any{"tag": "lark_md", "content": content}}
 }
 
-// pctDelta renders a coloured, bold percentage difference of value vs ref
-// (worse=red with +, better=green). Empty when ref is zero.
-func pctDelta(value, ref float64) string {
+// shortField is a half-width lark_md field for the two-column metric layout.
+func shortField(content string) map[string]any {
+	return map[string]any{"is_short": true, "text": map[string]any{"tag": "lark_md", "content": content}}
+}
+
+// perfFieldsDiv lays one regressed metric out in aligned columns so the numbers
+// an operator acts on stand out: a full-width suite/metric header, then the
+// measured value (bold red) beside budget and baseline, each with a coloured
+// arrow + percentage delta (worse=red ▲, better=green ▼).
+func perfFieldsDiv(suite string, m Metric) map[string]any {
+	fields := []any{
+		map[string]any{"is_short": false, "text": map[string]any{"tag": "lark_md", "content": fmt.Sprintf("⏱ **%s** · %s", suite, m.Name)}},
+		shortField(fmt.Sprintf("**value**\n<font color='red'>**%.2f%s**</font>", m.Value, m.Unit)),
+	}
+	if m.Budget != nil {
+		fields = append(fields, shortField(fmt.Sprintf("**budget**\n%.2f%s %s", *m.Budget, m.Unit, arrowPct(m.Value, *m.Budget))))
+	}
+	if m.Baseline != nil {
+		fields = append(fields, shortField(fmt.Sprintf("**baseline**\n%.2f%s %s", *m.Baseline, m.Unit, arrowPct(m.Value, *m.Baseline))))
+	}
+	return map[string]any{"tag": "div", "fields": fields}
+}
+
+// arrowPct renders a coloured arrow + bold percentage difference of value vs ref:
+// an increase is ▲ red (worse for budgeted latency metrics), a decrease is ▼
+// green. Empty when ref is zero.
+func arrowPct(value, ref float64) string {
 	if ref == 0 {
 		return ""
 	}
 	pct := (value - ref) / ref * 100
-	color, sign := "red", "+"
-	if pct < 0 {
-		color, sign = "green", ""
+	if pct >= 0 {
+		return fmt.Sprintf("<font color='red'>▲ **+%.0f%%**</font>", pct)
 	}
-	return fmt.Sprintf(" (<font color='%s'>**%s%.0f%%**</font>)", color, sign, pct)
+	return fmt.Sprintf("<font color='green'>▼ **%.0f%%**</font>", pct)
+}
+
+// failClassColor maps a failure class to a lark_md font colour for quick triage.
+func failClassColor(c FailureClass) string {
+	switch c {
+	case FailureCorrectness:
+		return "red"
+	case FailureInfrastructure, FailureDependency, FailurePerformance:
+		return "orange"
+	case FailureFlaky:
+		return "grey"
+	default:
+		return "grey"
+	}
 }

--- a/internal/e2ereport/render.go
+++ b/internal/e2ereport/render.go
@@ -107,14 +107,16 @@ func (r RunReport) FeishuCard() map[string]any {
 	if len(r.Failed) > 0 {
 		lines = append(lines, fmt.Sprintf("**failed (%d):**", len(r.Failed)))
 		for _, s := range r.Failed {
-			lines = append(lines, fmt.Sprintf("• %s — %s / %s (owner: %s)",
+			lines = append(lines, fmt.Sprintf("• **%s** — <font color='red'>%s</font> / %s (owner: %s)",
 				s.Suite, dash(string(s.FailureClass)), dash(s.ProductPromise), dash(s.OwnerHint)))
 		}
 	}
-	for _, s := range r.PerfRegressed {
-		for _, m := range s.PerfRegressions() {
-			lines = append(lines, fmt.Sprintf("• ⏱ %s %s=%.2f%s (budget %s, baseline %s)",
-				s.Suite, m.Name, m.Value, m.Unit, fmtPtr(m.Budget), fmtPtr(m.Baseline)))
+	if len(r.PerfRegressed) > 0 {
+		lines = append(lines, "**performance regressions:**")
+		for _, s := range r.PerfRegressed {
+			for _, m := range s.PerfRegressions() {
+				lines = append(lines, feishuPerfLine(s.Suite, m))
+			}
 		}
 	}
 
@@ -183,4 +185,33 @@ func fmtPtr(p *float64) string {
 		return "-"
 	}
 	return fmt.Sprintf("%.2f", *p)
+}
+
+// feishuPerfLine renders one regressed metric with rich lark_md emphasis on the
+// numbers an operator acts on: the measured value is bold red, and the deltas
+// against budget and baseline are bold and coloured (worse=red, better=green).
+func feishuPerfLine(suite string, m Metric) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "• ⏱ **%s** · %s = <font color='red'>**%.2f%s**</font>", suite, m.Name, m.Value, m.Unit)
+	if m.Budget != nil {
+		fmt.Fprintf(&b, " — budget %.2f%s%s", *m.Budget, m.Unit, pctDelta(m.Value, *m.Budget))
+	}
+	if m.Baseline != nil {
+		fmt.Fprintf(&b, " · baseline %.2f%s%s", *m.Baseline, m.Unit, pctDelta(m.Value, *m.Baseline))
+	}
+	return b.String()
+}
+
+// pctDelta renders a coloured, bold percentage difference of value vs ref
+// (worse=red with +, better=green). Empty when ref is zero.
+func pctDelta(value, ref float64) string {
+	if ref == 0 {
+		return ""
+	}
+	pct := (value - ref) / ref * 100
+	color, sign := "red", "+"
+	if pct < 0 {
+		color, sign = "green", ""
+	}
+	return fmt.Sprintf(" (<font color='%s'>**%s%.0f%%**</font>)", color, sign, pct)
 }

--- a/internal/e2ereport/render.go
+++ b/internal/e2ereport/render.go
@@ -213,8 +213,12 @@ func perfFieldsDiv(suite string, m Metric) map[string]any {
 }
 
 // arrowPct renders a coloured arrow + bold percentage difference of value vs ref:
-// an increase is ▲ red (worse for budgeted latency metrics), a decrease is ▼
-// green. Empty when ref is zero.
+// an increase is ▲ red, a decrease is ▼ green. Empty when ref is zero.
+//
+// This assumes lower-is-better, which holds for the latency budgets in the suite
+// manifest today (e.g. p99_write_ms). If a higher-is-better metric (e.g.
+// throughput) ever gets a budget, add a HigherIsBetter flag to Metric and invert
+// the colours here, or the arrow will read inverted for it.
 func arrowPct(value, ref float64) string {
 	if ref == 0 {
 		return ""

--- a/internal/e2ereport/render.go
+++ b/internal/e2ereport/render.go
@@ -11,8 +11,11 @@ import (
 func (r RunReport) Markdown() string {
 	var b strings.Builder
 	overall := "✅ success"
-	if !r.OverallSuccess {
+	switch {
+	case !r.OverallSuccess:
 		overall = "❌ failure"
+	case len(r.PerfRegressed) > 0:
+		overall = "⚠️ performance regression"
 	}
 	fmt.Fprintf(&b, "## drive9 e2e product-quality report\n\n")
 	fmt.Fprintf(&b, "- overall: **%s**\n- trigger: `%s`\n", overall, triggerName(r.Context.Trigger))
@@ -50,7 +53,11 @@ func (r RunReport) Markdown() string {
 // signature so recurring patterns group into one thread.
 func (r RunReport) IssueBody() string {
 	var b strings.Builder
-	fmt.Fprintf(&b, "### drive9 e2e %s failure\n\n", triggerName(r.Context.Trigger))
+	kind := "failure"
+	if r.OverallSuccess && len(r.PerfRegressed) > 0 {
+		kind = "performance regression"
+	}
+	fmt.Fprintf(&b, "### drive9 e2e %s %s\n\n", triggerName(r.Context.Trigger), kind)
 	fmt.Fprintf(&b, "- signature: `%s`\n", r.FailureSignature())
 	if r.Context.SHA != "" {
 		fmt.Fprintf(&b, "- commit: `%s`\n", r.Context.SHA)
@@ -58,7 +65,9 @@ func (r RunReport) IssueBody() string {
 	if r.Context.RunURL != "" {
 		fmt.Fprintf(&b, "- run: %s\n", r.Context.RunURL)
 	}
-	b.WriteString("\n**Failed suites:**\n\n")
+	if len(r.Failed) > 0 {
+		b.WriteString("\n**Failed suites:**\n\n")
+	}
 	for _, s := range r.Failed {
 		fmt.Fprintf(&b, "- `%s` — class=%s, promise=%s, owner=%s", s.Suite, dash(string(s.FailureClass)), dash(s.ProductPromise), dash(s.OwnerHint))
 		if s.ArtifactURL != "" {

--- a/internal/e2ereport/report.go
+++ b/internal/e2ereport/report.go
@@ -76,7 +76,36 @@ type SuiteSummary struct {
 	Detail         string       `json:"detail,omitempty"`
 }
 
-// ParseSuiteSummary parses one suite-summary JSON document.
+func (s Status) valid() bool {
+	switch s {
+	case StatusSuccess, StatusFailure, StatusSkipped:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c FailureClass) valid() bool {
+	switch c {
+	case FailureNone, FailureCorrectness, FailureInfrastructure, FailureDependency, FailureFlaky, FailurePerformance, FailureUnknown:
+		return true
+	default:
+		return false
+	}
+}
+
+func (t Tier) valid() bool {
+	switch t {
+	case "", TierPR, TierPostMerge, TierNightly, TierManual:
+		return true
+	default:
+		return false
+	}
+}
+
+// ParseSuiteSummary parses and validates one suite-summary JSON document. Enum
+// fields are validated so a producer that omits or misspells status (or another
+// enum) fails closed instead of flowing through as a zero-value "not failure".
 func ParseSuiteSummary(data []byte) (SuiteSummary, error) {
 	var s SuiteSummary
 	if err := json.Unmarshal(data, &s); err != nil {
@@ -84,6 +113,15 @@ func ParseSuiteSummary(data []byte) (SuiteSummary, error) {
 	}
 	if strings.TrimSpace(s.Suite) == "" {
 		return SuiteSummary{}, fmt.Errorf("suite summary missing required field: suite")
+	}
+	if !s.Status.valid() {
+		return SuiteSummary{}, fmt.Errorf("suite %q has invalid status %q (want success|failure|skipped)", s.Suite, s.Status)
+	}
+	if !s.FailureClass.valid() {
+		return SuiteSummary{}, fmt.Errorf("suite %q has invalid failure_class %q", s.Suite, s.FailureClass)
+	}
+	if !s.Tier.valid() {
+		return SuiteSummary{}, fmt.Errorf("suite %q has invalid tier %q", s.Suite, s.Tier)
 	}
 	return s, nil
 }
@@ -137,20 +175,28 @@ func Aggregate(ctx RunContext, summaries []SuiteSummary) RunReport {
 	return r
 }
 
-// FailureSignature is a stable short id for the set of failed suites and their
-// failure classes, so a recurring failure pattern groups into one issue thread
-// instead of spawning new ones. Empty when nothing failed.
+// FailureSignature is a stable short id for what went wrong — the set of failed
+// suites (with failure class) plus any performance-only regressions — so a
+// recurring pattern groups into one issue thread instead of spawning new ones.
+// Empty only when nothing failed and nothing regressed.
 func (r RunReport) FailureSignature() string {
-	if len(r.Failed) == 0 {
-		return ""
-	}
-	parts := make([]string, 0, len(r.Failed))
+	parts := make([]string, 0, len(r.Failed)+len(r.PerfRegressed))
 	for _, s := range r.Failed {
 		fc := s.FailureClass
 		if fc == FailureNone {
 			fc = FailureUnknown
 		}
 		parts = append(parts, s.Suite+":"+string(fc))
+	}
+	for _, s := range r.PerfRegressed {
+		// Failed suites are already represented above; add perf-only regressions
+		// so a regression-only run still gets a stable, groupable signature.
+		if s.Status != StatusFailure {
+			parts = append(parts, s.Suite+":"+string(FailurePerformance))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
 	}
 	sort.Strings(parts)
 	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))

--- a/internal/e2ereport/report.go
+++ b/internal/e2ereport/report.go
@@ -1,0 +1,188 @@
+// Package e2ereport defines the structured drive9 e2e suite-summary contract and
+// the run-level aggregator that turns many suite outputs into one product-quality
+// report: a workflow summary, a GitHub issue body with a stable failure
+// signature, a Feishu/Lark notification decision, and the notification card.
+//
+// It is intentionally dependency-free (no AWS/MySQL/HTTP) so it is fully unit
+// testable with fixtures and golden output, per PRD #641.
+package e2ereport
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Status is a suite outcome, aligned with GitHub Actions step outcomes.
+type Status string
+
+const (
+	StatusSuccess Status = "success"
+	StatusFailure Status = "failure"
+	StatusSkipped Status = "skipped"
+)
+
+// Tier is the automation tier that ran the suite.
+type Tier string
+
+const (
+	TierPR        Tier = "pr"
+	TierPostMerge Tier = "post-merge"
+	TierNightly   Tier = "nightly"
+	TierManual    Tier = "manual"
+)
+
+// FailureClass categorizes why a suite failed, so failures route to the right owner.
+type FailureClass string
+
+const (
+	FailureNone           FailureClass = ""
+	FailureCorrectness    FailureClass = "correctness"
+	FailureInfrastructure FailureClass = "infrastructure"
+	FailureDependency     FailureClass = "dependency"
+	FailureFlaky          FailureClass = "flaky"
+	FailurePerformance    FailureClass = "performance"
+	FailureUnknown        FailureClass = "unknown"
+)
+
+// Metric is a measured value a suite reports, optionally budgeted/baselined so a
+// performance regression can be detected explicitly (not from raw variance).
+type Metric struct {
+	Name       string   `json:"name"`
+	Value      float64  `json:"value"`
+	Unit       string   `json:"unit,omitempty"`
+	Budget     *float64 `json:"budget,omitempty"`
+	Baseline   *float64 `json:"baseline,omitempty"`
+	Regression bool     `json:"regression,omitempty"`
+}
+
+// SuiteSummary is the structured per-suite reporting contract. Each participating
+// e2e suite emits one of these (JSON); suites that have not adopted it yet are
+// synthesized by the aggregator from the workflow step outcome + manifest.
+type SuiteSummary struct {
+	Suite          string       `json:"suite"`
+	Status         Status       `json:"status"`
+	DurationS      float64      `json:"duration_s,omitempty"`
+	Tier           Tier         `json:"tier,omitempty"`
+	ProductArea    string       `json:"product_area,omitempty"`
+	ProductPromise string       `json:"product_promise,omitempty"`
+	FailureClass   FailureClass `json:"failure_class,omitempty"`
+	OwnerHint      string       `json:"owner_hint,omitempty"`
+	Metrics        []Metric     `json:"metrics,omitempty"`
+	ArtifactURL    string       `json:"artifact_url,omitempty"`
+	ReportURL      string       `json:"report_url,omitempty"`
+	Detail         string       `json:"detail,omitempty"`
+}
+
+// ParseSuiteSummary parses one suite-summary JSON document.
+func ParseSuiteSummary(data []byte) (SuiteSummary, error) {
+	var s SuiteSummary
+	if err := json.Unmarshal(data, &s); err != nil {
+		return SuiteSummary{}, fmt.Errorf("parse suite summary: %w", err)
+	}
+	if strings.TrimSpace(s.Suite) == "" {
+		return SuiteSummary{}, fmt.Errorf("suite summary missing required field: suite")
+	}
+	return s, nil
+}
+
+// PerfRegression reports a budget/baseline breach within a suite's metrics.
+func (s SuiteSummary) PerfRegressions() []Metric {
+	var out []Metric
+	for _, m := range s.Metrics {
+		if m.Regression || (m.Budget != nil && m.Value > *m.Budget) {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// RunContext describes the workflow run the summaries came from.
+type RunContext struct {
+	Trigger  Tier   `json:"trigger"`
+	Repo     string `json:"repo"`
+	SHA      string `json:"sha,omitempty"`
+	RunURL   string `json:"run_url,omitempty"`
+	Workflow string `json:"workflow,omitempty"`
+	Branch   string `json:"branch,omitempty"`
+}
+
+// RunReport is the aggregated product-quality view of one e2e run.
+type RunReport struct {
+	Context        RunContext     `json:"context"`
+	Suites         []SuiteSummary `json:"suites"`
+	Failed         []SuiteSummary `json:"failed"`
+	PerfRegressed  []SuiteSummary `json:"perf_regressed"`
+	OverallSuccess bool           `json:"overall_success"`
+}
+
+// Aggregate combines suite summaries into a single run report. Summaries are
+// sorted by suite for deterministic output.
+func Aggregate(ctx RunContext, summaries []SuiteSummary) RunReport {
+	sorted := append([]SuiteSummary(nil), summaries...)
+	sort.SliceStable(sorted, func(i, j int) bool { return sorted[i].Suite < sorted[j].Suite })
+
+	r := RunReport{Context: ctx, Suites: sorted, OverallSuccess: true}
+	for _, s := range sorted {
+		if s.Status == StatusFailure {
+			r.Failed = append(r.Failed, s)
+			r.OverallSuccess = false
+		}
+		if len(s.PerfRegressions()) > 0 {
+			r.PerfRegressed = append(r.PerfRegressed, s)
+		}
+	}
+	return r
+}
+
+// FailureSignature is a stable short id for the set of failed suites and their
+// failure classes, so a recurring failure pattern groups into one issue thread
+// instead of spawning new ones. Empty when nothing failed.
+func (r RunReport) FailureSignature() string {
+	if len(r.Failed) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(r.Failed))
+	for _, s := range r.Failed {
+		fc := s.FailureClass
+		if fc == FailureNone {
+			fc = FailureUnknown
+		}
+		parts = append(parts, s.Suite+":"+string(fc))
+	}
+	sort.Strings(parts)
+	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return fmt.Sprintf("%x", sum[:6])
+}
+
+// NotifyDecision is whether to push this run to Feishu/Lark and why.
+type NotifyDecision struct {
+	Notify bool
+	Reason string
+}
+
+// ShouldNotifyFeishu encodes the notification policy: PR failures stay in GitHub;
+// post-merge/nightly/manual failures and explicit performance regressions are
+// pushed. Successful runs are never pushed.
+func (r RunReport) ShouldNotifyFeishu() NotifyDecision {
+	if r.OverallSuccess && len(r.PerfRegressed) == 0 {
+		return NotifyDecision{false, "run succeeded with no performance regression"}
+	}
+	if len(r.PerfRegressed) > 0 {
+		return NotifyDecision{true, "explicit performance regression"}
+	}
+	// A failure exists.
+	if r.Context.Trigger == TierPR {
+		return NotifyDecision{false, "PR-tier failure stays in GitHub by policy"}
+	}
+	return NotifyDecision{true, fmt.Sprintf("%s-tier failure", triggerName(r.Context.Trigger))}
+}
+
+func triggerName(t Tier) string {
+	if t == "" {
+		return "unknown"
+	}
+	return string(t)
+}

--- a/internal/e2ereport/report_test.go
+++ b/internal/e2ereport/report_test.go
@@ -23,6 +23,34 @@ func TestParseSuiteSummary(t *testing.T) {
 	if _, err := ParseSuiteSummary([]byte(`not json`)); err == nil {
 		t.Fatal("expected error for bad json")
 	}
+	// Enum fields must fail closed.
+	if _, err := ParseSuiteSummary([]byte(`{"suite":"x"}`)); err == nil {
+		t.Fatal("expected error for missing status")
+	}
+	if _, err := ParseSuiteSummary([]byte(`{"suite":"x","status":"passed"}`)); err == nil {
+		t.Fatal("expected error for invalid status")
+	}
+	if _, err := ParseSuiteSummary([]byte(`{"suite":"x","status":"failure","failure_class":"bogus"}`)); err == nil {
+		t.Fatal("expected error for invalid failure_class")
+	}
+	if _, err := ParseSuiteSummary([]byte(`{"suite":"x","status":"failure","tier":"weekly"}`)); err == nil {
+		t.Fatal("expected error for invalid tier")
+	}
+}
+
+func TestPerfOnlySignature(t *testing.T) {
+	// A regression-only run (everything passed, one budget breach) still gets a
+	// stable, non-empty signature so it can group/notify.
+	r := Aggregate(RunContext{Trigger: TierNightly}, []SuiteSummary{
+		{Suite: "fuse-write-perf-budget", Status: StatusSuccess,
+			Metrics: []Metric{{Name: "p99_write_ms", Value: 40, Budget: f64(30)}}},
+	})
+	if !r.OverallSuccess {
+		t.Fatal("perf-only run should still be OverallSuccess")
+	}
+	if r.FailureSignature() == "" {
+		t.Fatal("perf-only run should have a non-empty signature")
+	}
 }
 
 func sampleSuites() []SuiteSummary {
@@ -124,5 +152,24 @@ func TestRenderContainsKeyFacts(t *testing.T) {
 	}
 	if !strings.Contains(cs, "git-feature-matrix") {
 		t.Errorf("card missing failed suite: %s", cs)
+	}
+}
+
+func TestPerfOnlyRenderIsConsistent(t *testing.T) {
+	r := Aggregate(RunContext{Trigger: TierNightly, RunURL: "https://x/run/3"}, []SuiteSummary{
+		{Suite: "fuse-write-perf-budget", Status: StatusSuccess, ProductPromise: "performance",
+			Metrics: []Metric{{Name: "p99_write_ms", Value: 40, Unit: "ms", Budget: f64(30)}}},
+	})
+	md := strings.ToLower(r.Markdown())
+	if !strings.Contains(md, "performance regression") || strings.Contains(md, "❌ failure") {
+		t.Errorf("perf-only markdown should read as performance regression, not failure:\n%s", r.Markdown())
+	}
+	issue := r.IssueBody()
+	if !strings.Contains(issue, "performance regression") {
+		t.Errorf("perf-only issue body should say performance regression:\n%s", issue)
+	}
+	// No empty "Failed suites" section when nothing failed.
+	if strings.Contains(issue, "Failed suites") {
+		t.Errorf("perf-only issue body should not have a Failed suites section:\n%s", issue)
 	}
 }

--- a/internal/e2ereport/report_test.go
+++ b/internal/e2ereport/report_test.go
@@ -1,0 +1,128 @@
+package e2ereport
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func f64(v float64) *float64 { return &v }
+
+func TestParseSuiteSummary(t *testing.T) {
+	good := `{"suite":"api-smoke","status":"failure","tier":"post-merge","failure_class":"correctness","product_promise":"durable worksite"}`
+	s, err := ParseSuiteSummary([]byte(good))
+	if err != nil {
+		t.Fatalf("parse good: %v", err)
+	}
+	if s.Suite != "api-smoke" || s.Status != StatusFailure || s.FailureClass != FailureCorrectness {
+		t.Fatalf("unexpected parse: %+v", s)
+	}
+	if _, err := ParseSuiteSummary([]byte(`{"status":"failure"}`)); err == nil {
+		t.Fatal("expected error for missing suite")
+	}
+	if _, err := ParseSuiteSummary([]byte(`not json`)); err == nil {
+		t.Fatal("expected error for bad json")
+	}
+}
+
+func sampleSuites() []SuiteSummary {
+	return []SuiteSummary{
+		{Suite: "git-feature-matrix", Status: StatusFailure, Tier: TierPostMerge, FailureClass: FailureCorrectness,
+			ProductPromise: "git/fuse correctness", OwnerHint: "git-team", Detail: "11 cases failed"},
+		{Suite: "api-smoke", Status: StatusSuccess, ProductPromise: "durable worksite"},
+		{Suite: "fuse-write-perf-budget", Status: StatusSuccess, ProductPromise: "performance",
+			Metrics: []Metric{{Name: "p99_write_ms", Value: 42, Unit: "ms", Budget: f64(30)}}},
+	}
+}
+
+func TestAggregateAndSignature(t *testing.T) {
+	ctx := RunContext{Trigger: TierPostMerge, Repo: "mem9-ai/drive9", RunURL: "https://x/run/1", SHA: "abc"}
+	r := Aggregate(ctx, sampleSuites())
+	if r.OverallSuccess {
+		t.Fatal("should be failure (git-feature-matrix failed)")
+	}
+	if len(r.Failed) != 1 || r.Failed[0].Suite != "git-feature-matrix" {
+		t.Fatalf("failed = %+v", r.Failed)
+	}
+	if len(r.PerfRegressed) != 1 || r.PerfRegressed[0].Suite != "fuse-write-perf-budget" {
+		t.Fatalf("perf regressed = %+v", r.PerfRegressed)
+	}
+	// Suites sorted deterministically.
+	if r.Suites[0].Suite != "api-smoke" {
+		t.Fatalf("not sorted: %s", r.Suites[0].Suite)
+	}
+	sig := r.FailureSignature()
+	if sig == "" {
+		t.Fatal("expected non-empty signature")
+	}
+	// Signature is stable regardless of input order.
+	rev := append([]SuiteSummary(nil), sampleSuites()...)
+	rev[0], rev[2] = rev[2], rev[0]
+	if Aggregate(ctx, rev).FailureSignature() != sig {
+		t.Fatal("signature should be order-independent")
+	}
+}
+
+func TestNotifyPolicy(t *testing.T) {
+	cases := []struct {
+		name    string
+		trigger Tier
+		suites  []SuiteSummary
+		want    bool
+	}{
+		{"pr failure stays in github", TierPR, []SuiteSummary{{Suite: "a", Status: StatusFailure}}, false},
+		{"post-merge failure notifies", TierPostMerge, []SuiteSummary{{Suite: "a", Status: StatusFailure}}, true},
+		{"nightly failure notifies", TierNightly, []SuiteSummary{{Suite: "a", Status: StatusFailure}}, true},
+		{"all success no notify", TierNightly, []SuiteSummary{{Suite: "a", Status: StatusSuccess}}, false},
+		{"perf regression notifies even on PR success", TierPR, []SuiteSummary{
+			{Suite: "p", Status: StatusSuccess, Metrics: []Metric{{Name: "x", Value: 10, Budget: f64(5)}}}}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d := Aggregate(RunContext{Trigger: tc.trigger}, tc.suites).ShouldNotifyFeishu()
+			if d.Notify != tc.want {
+				t.Fatalf("notify=%v want %v (reason: %s)", d.Notify, tc.want, d.Reason)
+			}
+		})
+	}
+}
+
+func TestPerfRegressionDetection(t *testing.T) {
+	// Explicit Regression flag OR value over budget.
+	s := SuiteSummary{Metrics: []Metric{
+		{Name: "ok", Value: 5, Budget: f64(10)},
+		{Name: "over_budget", Value: 20, Budget: f64(10)},
+		{Name: "flagged", Value: 1, Regression: true},
+	}}
+	got := s.PerfRegressions()
+	if len(got) != 2 {
+		t.Fatalf("expected 2 regressions, got %d: %+v", len(got), got)
+	}
+}
+
+func TestRenderContainsKeyFacts(t *testing.T) {
+	r := Aggregate(RunContext{Trigger: TierNightly, RunURL: "https://x/run/9", SHA: "deadbeef"}, sampleSuites())
+	md := r.Markdown()
+	for _, want := range []string{"git-feature-matrix", "performance regression", "failure signature", "https://x/run/9"} {
+		if !strings.Contains(strings.ToLower(md), strings.ToLower(want)) {
+			t.Errorf("markdown missing %q", want)
+		}
+	}
+	issue := r.IssueBody()
+	if !strings.Contains(issue, r.FailureSignature()) || !strings.Contains(issue, "git-feature-matrix") {
+		t.Errorf("issue body missing signature/suite:\n%s", issue)
+	}
+	// Feishu card is valid JSON-marshalable and carries the run URL + title.
+	card := r.FeishuCard()
+	raw, err := json.Marshal(card)
+	if err != nil {
+		t.Fatalf("card marshal: %v", err)
+	}
+	cs := string(raw)
+	if !strings.Contains(cs, "https://x/run/9") || !strings.Contains(cs, "header") {
+		t.Errorf("card missing run url/header: %s", cs)
+	}
+	if !strings.Contains(cs, "git-feature-matrix") {
+		t.Errorf("card missing failed suite: %s", cs)
+	}
+}

--- a/internal/feishu/feishu.go
+++ b/internal/feishu/feishu.go
@@ -108,7 +108,7 @@ func Send(ctx context.Context, c Config, card map[string]any) (sent bool, err er
 }
 
 func (c Config) sendWebhook(ctx context.Context, card map[string]any) error {
-	return postJSON(ctx, c.Webhook, nil, webhookBody(card))
+	return postJSON(ctx, "Feishu webhook", c.Webhook, nil, webhookBody(card))
 }
 
 func (c Config) sendApp(ctx context.Context, card map[string]any) error {
@@ -121,7 +121,7 @@ func (c Config) sendApp(ctx context.Context, card map[string]any) error {
 		return err
 	}
 	url := c.baseURL() + "/open-apis/im/v1/messages?receive_id_type=chat_id"
-	return postJSON(ctx, url, map[string]string{"Authorization": "Bearer " + token}, body)
+	return postJSON(ctx, "Feishu message API", url, map[string]string{"Authorization": "Bearer " + token}, body)
 }
 
 func (c Config) tenantToken(ctx context.Context) (string, error) {
@@ -152,14 +152,17 @@ func (c Config) tenantToken(ctx context.Context) (string, error) {
 	return out.Token, nil
 }
 
-func postJSON(ctx context.Context, url string, headers map[string]string, body any) error {
+// postJSON posts body to url and validates the Feishu response. Errors carry the
+// endpoint label, never the URL: the custom-bot webhook URL embeds the bot token,
+// so logging it on a transient failure would leak the secret into CI logs.
+func postJSON(ctx context.Context, endpoint, url string, headers map[string]string, body any) error {
 	raw, err := json.Marshal(body)
 	if err != nil {
-		return fmt.Errorf("marshal request: %w", err)
+		return fmt.Errorf("marshal %s request: %w", endpoint, err)
 	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
 	if err != nil {
-		return err
+		return fmt.Errorf("build %s request: %w", endpoint, err)
 	}
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	for k, v := range headers {
@@ -167,22 +170,41 @@ func postJSON(ctx context.Context, url string, headers map[string]string, body a
 	}
 	resp, err := httpClient().Do(req)
 	if err != nil {
-		return fmt.Errorf("post %s: %w", url, err)
+		return fmt.Errorf("post %s: %w", endpoint, err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	data, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode/100 != 2 {
-		return fmt.Errorf("post %s: status %d: %s", url, resp.StatusCode, strings.TrimSpace(string(data)))
+		return fmt.Errorf("post %s: status %d: %s", endpoint, resp.StatusCode, snippet(data))
 	}
-	// Feishu returns 200 with a non-zero `code` on logical errors.
+	// Feishu reports logical failures in the body while returning HTTP 200. The
+	// app API uses {code,msg}; the custom-bot webhook uses {StatusCode,
+	// StatusMessage}. A 2xx body that is not valid JSON (proxy, wrong host, HTML
+	// error page) must fail closed rather than look delivered.
 	var out struct {
-		Code int    `json:"code"`
-		Msg  string `json:"msg"`
+		Code          int    `json:"code"`
+		Msg           string `json:"msg"`
+		StatusCode    int    `json:"StatusCode"`
+		StatusMessage string `json:"StatusMessage"`
 	}
-	if err := json.Unmarshal(data, &out); err == nil && out.Code != 0 {
-		return fmt.Errorf("post %s: feishu code=%d msg=%s", url, out.Code, out.Msg)
+	if err := json.Unmarshal(data, &out); err != nil {
+		return fmt.Errorf("post %s: unexpected non-JSON 2xx response: %s", endpoint, snippet(data))
+	}
+	if out.Code != 0 {
+		return fmt.Errorf("post %s: feishu code=%d msg=%s", endpoint, out.Code, out.Msg)
+	}
+	if out.StatusCode != 0 {
+		return fmt.Errorf("post %s: feishu StatusCode=%d msg=%s", endpoint, out.StatusCode, out.StatusMessage)
 	}
 	return nil
+}
+
+func snippet(b []byte) string {
+	s := strings.TrimSpace(string(b))
+	if len(s) > 200 {
+		return s[:200] + "…"
+	}
+	return s
 }
 
 func httpClient() *http.Client { return &http.Client{Timeout: httpTimeout} }

--- a/internal/feishu/feishu.go
+++ b/internal/feishu/feishu.go
@@ -1,0 +1,188 @@
+// Package feishu sends drive9 e2e notification cards to Feishu/Lark. It supports
+// two transports, auto-detected from the environment, so the deployment can use
+// whichever the team has set up:
+//
+//   - custom-bot webhook: set FEISHU_WEBHOOK to the bot hook URL.
+//   - app (tenant) API:   set FEISHU_APP_ID, FEISHU_APP_SECRET, FEISHU_CHAT_ID.
+//
+// If neither is configured, callers should skip silently — a missing secret must
+// never fail the CI run.
+package feishu
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const (
+	defaultBaseURL = "https://open.feishu.cn"
+	httpTimeout    = 15 * time.Second
+)
+
+// Transport identifies which Feishu send mechanism is configured.
+type Transport string
+
+const (
+	TransportNone    Transport = ""
+	TransportWebhook Transport = "webhook"
+	TransportApp     Transport = "app"
+)
+
+// Config holds Feishu connection settings, typically sourced from CI secrets.
+type Config struct {
+	Webhook   string
+	AppID     string
+	AppSecret string
+	ChatID    string
+	// BaseURL overrides the app-API base (tests). Empty means the public host.
+	BaseURL string
+}
+
+// ConfigFromEnv reads Feishu settings from the standard environment variables.
+func ConfigFromEnv(getenv func(string) string) Config {
+	return Config{
+		Webhook:   strings.TrimSpace(getenv("FEISHU_WEBHOOK")),
+		AppID:     strings.TrimSpace(getenv("FEISHU_APP_ID")),
+		AppSecret: strings.TrimSpace(getenv("FEISHU_APP_SECRET")),
+		ChatID:    strings.TrimSpace(getenv("FEISHU_CHAT_ID")),
+		BaseURL:   strings.TrimSpace(getenv("FEISHU_BASE_URL")),
+	}
+}
+
+// Transport reports which mechanism this config selects. Webhook takes
+// precedence when both are present.
+func (c Config) Transport() Transport {
+	switch {
+	case c.Webhook != "":
+		return TransportWebhook
+	case c.AppID != "" && c.AppSecret != "" && c.ChatID != "":
+		return TransportApp
+	default:
+		return TransportNone
+	}
+}
+
+func (c Config) baseURL() string {
+	if c.BaseURL != "" {
+		return c.BaseURL
+	}
+	return defaultBaseURL
+}
+
+// webhookBody is the custom-bot webhook payload for an interactive card.
+func webhookBody(card map[string]any) map[string]any {
+	return map[string]any{"msg_type": "interactive", "card": card}
+}
+
+// appMessageBody is the im/v1/messages payload for an interactive card. Feishu
+// requires `content` to be a JSON string, not a nested object.
+func appMessageBody(chatID string, card map[string]any) (map[string]any, error) {
+	raw, err := json.Marshal(card)
+	if err != nil {
+		return nil, fmt.Errorf("marshal card: %w", err)
+	}
+	return map[string]any{
+		"receive_id": chatID,
+		"msg_type":   "interactive",
+		"content":    string(raw),
+	}, nil
+}
+
+// Send delivers the card via the configured transport. It returns (false, nil)
+// when no transport is configured so callers can skip without failing.
+func Send(ctx context.Context, c Config, card map[string]any) (sent bool, err error) {
+	switch c.Transport() {
+	case TransportWebhook:
+		return true, c.sendWebhook(ctx, card)
+	case TransportApp:
+		return true, c.sendApp(ctx, card)
+	default:
+		return false, nil
+	}
+}
+
+func (c Config) sendWebhook(ctx context.Context, card map[string]any) error {
+	return postJSON(ctx, c.Webhook, nil, webhookBody(card))
+}
+
+func (c Config) sendApp(ctx context.Context, card map[string]any) error {
+	token, err := c.tenantToken(ctx)
+	if err != nil {
+		return err
+	}
+	body, err := appMessageBody(c.ChatID, card)
+	if err != nil {
+		return err
+	}
+	url := c.baseURL() + "/open-apis/im/v1/messages?receive_id_type=chat_id"
+	return postJSON(ctx, url, map[string]string{"Authorization": "Bearer " + token}, body)
+}
+
+func (c Config) tenantToken(ctx context.Context) (string, error) {
+	url := c.baseURL() + "/open-apis/auth/v3/tenant_access_token/internal"
+	reqBody, _ := json.Marshal(map[string]string{"app_id": c.AppID, "app_secret": c.AppSecret})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(reqBody))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("request tenant token: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(resp.Body)
+	var out struct {
+		Code  int    `json:"code"`
+		Msg   string `json:"msg"`
+		Token string `json:"tenant_access_token"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		return "", fmt.Errorf("decode tenant token (status %d): %w", resp.StatusCode, err)
+	}
+	if out.Code != 0 || out.Token == "" {
+		return "", fmt.Errorf("tenant token error: code=%d msg=%s", out.Code, out.Msg)
+	}
+	return out.Token, nil
+}
+
+func postJSON(ctx context.Context, url string, headers map[string]string, body any) error {
+	raw, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(raw))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return fmt.Errorf("post %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	data, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		return fmt.Errorf("post %s: status %d: %s", url, resp.StatusCode, strings.TrimSpace(string(data)))
+	}
+	// Feishu returns 200 with a non-zero `code` on logical errors.
+	var out struct {
+		Code int    `json:"code"`
+		Msg  string `json:"msg"`
+	}
+	if err := json.Unmarshal(data, &out); err == nil && out.Code != 0 {
+		return fmt.Errorf("post %s: feishu code=%d msg=%s", url, out.Code, out.Msg)
+	}
+	return nil
+}
+
+func httpClient() *http.Client { return &http.Client{Timeout: httpTimeout} }

--- a/internal/feishu/feishu.go
+++ b/internal/feishu/feishu.go
@@ -112,6 +112,8 @@ func (c Config) sendWebhook(ctx context.Context, card map[string]any) error {
 }
 
 func (c Config) sendApp(ctx context.Context, card map[string]any) error {
+	// Fetches a fresh tenant token per send. Fine for the one-send-per-CI-run use
+	// case; TODO: cache the token (2h TTL) if this is ever used for multi-send.
 	token, err := c.tenantToken(ctx)
 	if err != nil {
 		return err

--- a/internal/feishu/feishu_test.go
+++ b/internal/feishu/feishu_test.go
@@ -1,0 +1,134 @@
+package feishu
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestTransportSelection(t *testing.T) {
+	if got := (Config{}).Transport(); got != TransportNone {
+		t.Errorf("empty config = %q, want none", got)
+	}
+	if got := (Config{Webhook: "https://h"}).Transport(); got != TransportWebhook {
+		t.Errorf("webhook = %q", got)
+	}
+	app := Config{AppID: "a", AppSecret: "s", ChatID: "c"}
+	if got := app.Transport(); got != TransportApp {
+		t.Errorf("app = %q", got)
+	}
+	// Incomplete app config is not selectable.
+	if got := (Config{AppID: "a", AppSecret: "s"}).Transport(); got != TransportNone {
+		t.Errorf("incomplete app = %q, want none", got)
+	}
+	// Webhook wins when both present.
+	both := Config{Webhook: "https://h", AppID: "a", AppSecret: "s", ChatID: "c"}
+	if got := both.Transport(); got != TransportWebhook {
+		t.Errorf("both = %q, want webhook", got)
+	}
+}
+
+func TestConfigFromEnv(t *testing.T) {
+	env := map[string]string{
+		"FEISHU_APP_ID":     " app123 ",
+		"FEISHU_APP_SECRET": "secret",
+		"FEISHU_CHAT_ID":    "oc_x",
+	}
+	c := ConfigFromEnv(func(k string) string { return env[k] })
+	if c.AppID != "app123" || c.AppSecret != "secret" || c.ChatID != "oc_x" {
+		t.Fatalf("config from env wrong: %+v", c)
+	}
+	if c.Transport() != TransportApp {
+		t.Fatalf("transport = %q", c.Transport())
+	}
+}
+
+func TestAppMessageBodyContentIsJSONString(t *testing.T) {
+	card := map[string]any{"header": map[string]any{"title": "x"}}
+	body, err := appMessageBody("oc_chat", card)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body["receive_id"] != "oc_chat" || body["msg_type"] != "interactive" {
+		t.Fatalf("body wrong: %+v", body)
+	}
+	content, ok := body["content"].(string)
+	if !ok || !strings.Contains(content, "\"header\"") {
+		t.Fatalf("content must be a JSON string: %#v", body["content"])
+	}
+}
+
+func TestSendNoneSkips(t *testing.T) {
+	sent, err := Send(context.Background(), Config{}, map[string]any{})
+	if sent || err != nil {
+		t.Fatalf("unconfigured send should skip: sent=%v err=%v", sent, err)
+	}
+}
+
+func TestSendWebhook(t *testing.T) {
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(b, &got)
+		_, _ = w.Write([]byte(`{"code":0,"msg":"success"}`))
+	}))
+	defer srv.Close()
+
+	sent, err := Send(context.Background(), Config{Webhook: srv.URL}, map[string]any{"header": "h"})
+	if !sent || err != nil {
+		t.Fatalf("webhook send: sent=%v err=%v", sent, err)
+	}
+	if got["msg_type"] != "interactive" || got["card"] == nil {
+		t.Fatalf("webhook payload wrong: %+v", got)
+	}
+}
+
+func TestSendAppFlow(t *testing.T) {
+	var tokenHits, msgHits int
+	var msgAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "tenant_access_token"):
+			tokenHits++
+			_, _ = w.Write([]byte(`{"code":0,"tenant_access_token":"t-abc","expire":7200}`))
+		case strings.Contains(r.URL.Path, "/im/v1/messages"):
+			msgHits++
+			msgAuth = r.Header.Get("Authorization")
+			if r.URL.Query().Get("receive_id_type") != "chat_id" {
+				t.Errorf("missing receive_id_type=chat_id")
+			}
+			_, _ = w.Write([]byte(`{"code":0,"msg":"ok"}`))
+		default:
+			t.Errorf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer srv.Close()
+
+	cfg := Config{AppID: "a", AppSecret: "s", ChatID: "oc_x", BaseURL: srv.URL}
+	sent, err := Send(context.Background(), cfg, map[string]any{"header": "h"})
+	if !sent || err != nil {
+		t.Fatalf("app send: sent=%v err=%v", sent, err)
+	}
+	if tokenHits != 1 || msgHits != 1 {
+		t.Fatalf("expected 1 token + 1 message hit, got %d/%d", tokenHits, msgHits)
+	}
+	if msgAuth != "Bearer t-abc" {
+		t.Fatalf("auth header = %q", msgAuth)
+	}
+}
+
+func TestPostJSONSurfacesFeishuLogicalError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"code":9499,"msg":"bad chat id"}`))
+	}))
+	defer srv.Close()
+
+	_, err := Send(context.Background(), Config{Webhook: srv.URL}, map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "9499") {
+		t.Fatalf("expected logical error surfaced, got %v", err)
+	}
+}

--- a/internal/feishu/feishu_test.go
+++ b/internal/feishu/feishu_test.go
@@ -131,4 +131,34 @@ func TestPostJSONSurfacesFeishuLogicalError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "9499") {
 		t.Fatalf("expected logical error surfaced, got %v", err)
 	}
+	// The webhook URL is a secret and must never appear in errors/logs.
+	if strings.Contains(err.Error(), srv.URL) {
+		t.Fatalf("error leaked the webhook URL (secret): %v", err)
+	}
+}
+
+func TestWebhookStatusCodeLogicalError(t *testing.T) {
+	// Custom-bot webhooks report failures in StatusCode while returning HTTP 200.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"StatusCode":19001,"StatusMessage":"param invalid"}`))
+	}))
+	defer srv.Close()
+
+	_, err := Send(context.Background(), Config{Webhook: srv.URL}, map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "19001") {
+		t.Fatalf("expected StatusCode logical error, got %v", err)
+	}
+}
+
+func TestNonJSON2xxFailsClosed(t *testing.T) {
+	// A 200 that is not JSON (proxy/HTML/wrong host) must not look delivered.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`<html>gateway</html>`))
+	}))
+	defer srv.Close()
+
+	_, err := Send(context.Background(), Config{Webhook: srv.URL}, map[string]any{})
+	if err == nil || !strings.Contains(err.Error(), "non-JSON") {
+		t.Fatalf("expected non-JSON 2xx to fail closed, got %v", err)
+	}
 }


### PR DESCRIPTION
Implements the **first vertical slice** of #641 — turning raw e2e signal into a product-quality loop, plus Feishu/Lark notifications for the failures that matter.

## What this does
1. **Structured suite-summary contract + run aggregator** (`internal/e2ereport`, pure & dependency-free): per-suite status / tier / product area+promise / failure class / owner hint / metrics (budget+baseline), aggregated into a `RunReport` with a stable **failure signature**.
2. **`e2e/suite-manifest.json`**: product metadata for each `local-e2e.yml` suite (keyed by step id) so the aggregator can synthesize summaries for suites that haven't adopted the JSON contract yet — incremental adoption.
3. **`cmd/e2e-aggregate`**: reads the manifest + step outcomes (+ any adopted `e2e/reports/summary/*.json`) → richer step summary (grouped by product promise), aggregated JSON, a signature-led GitHub issue body, and workflow outputs (`notify`/`signature`/`overall_success`/…).
4. **Upgraded issue filing**: the existing `ci-e2e-failure` step now uses the structured body and **groups recurring failures by signature** instead of piling everything onto one generic issue.
5. **Feishu/Lark notifications** (`internal/feishu` + `cmd/feishu-notify`): interactive card with signature, failed suites, owners, perf regressions, and a run link. **Dual transport, auto-detected from secrets** — custom-bot webhook (`FEISHU_WEBHOOK`) or app API (`FEISHU_APP_ID`/`FEISHU_APP_SECRET`/`FEISHU_CHAT_ID`).

## Notification policy
PR-tier failures stay in GitHub. Post-merge / nightly / manual failures and explicit performance regressions push to Feishu. Successful runs never notify.

## Safety / blast radius
- Workflow changes are **additive and non-gating**: the existing suite steps and the `Enforce smoke results` gate are untouched. The Feishu step is `continue-on-error` and gated on the aggregator's `notify` output.
- The notifier **no-ops (never fails the run)** when no Feishu secret is configured, so forks/PRs without secrets are unaffected.

## Tests
- `internal/e2ereport`: parse, aggregation, signature stability (order-independent), notify policy, perf-regression detection, manifest synthesis (adopted overrides synthesized), event→tier mapping, rendering.
- `internal/feishu`: transport selection, env parsing, payload shape, and `httptest` round-trips for **both** webhook and app-API transports.
- `gofmt`, `go vet`, and `golangci-lint v2.5.0` clean on all new packages.
- **Live-validated**: a synthesized nightly-failure card was sent end to end via the app-API transport and delivered to the target chat.

## To activate live CI delivery
Add repo secrets (app API): `FEISHU_APP_ID`, `FEISHU_APP_SECRET`, `FEISHU_CHAT_ID` — or `FEISHU_WEBHOOK` for the custom-bot path.

## Follow-ups (out of slice)
Suite adoption of the structured summary JSON (durations + soft-regression metrics + artifact links), e2e inventory/dashboard, and scenario-coverage/dedup analysis (later steps of #641).

Refs #641.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added product-quality e2e aggregation that produces unified JSON/markdown reports with stable failure signatures and performance regression detection.
  * Added Feishu/Lark notifications driven by the aggregated report, including signature-led routing and conditional sending.
  * Introduced a CI toggle to enable Feishu proof behavior and improved degraded-pipeline detection/issue grouping.
* **Documentation**
  * Documented the new product-quality report flow, suite opt-in via suite summaries/manifest, and notification behavior.
* **Tests**
  * Added unit tests covering aggregation/tier-signature behavior, notification policy decisions, and Feishu card/message handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->