### PR TITLE
Fix provision create tenant pool claim

### DIFF
--- a/docs/guides/go-sdk-integration.md
+++ b/docs/guides/go-sdk-integration.md
@@ -136,6 +136,91 @@ _ = quota
 Quota query and update require TiDB Cloud API keys and a Drive9 tenant id. A
 Drive9 tenant API key cannot authorize quota operations for its own tenant.
 
+## Admin Tenant Pool API
+
+The SDK exposes tenant pool helpers for `tidb_cloud_native` organizations:
+
+- `AdminCreateTenantPool`
+- `AdminGetTenantPool`
+- `AdminUpdateTenantPool`
+- `AdminDeleteTenantPool`
+
+Tenant pool operations are authorized with TiDB Cloud API keys. Use
+`drive9.New(serverURL, "")`; a Drive9 tenant API key is not used for these
+admin pool calls.
+
+Create a pool with a target free size:
+
+```go
+poolSize := 20
+
+pool, err := drive9.New(serverURL, "").AdminCreateTenantPool(ctx, drive9.AdminTenantPoolRequest{
+	PublicKey:  tidbCloudPublicKey,
+	PrivateKey: tidbCloudPrivateKey,
+	PoolSize:   &poolSize,
+})
+if err != nil {
+	return err
+}
+_ = pool.PoolID
+_ = pool.OrganizationID
+_ = pool.PoolSize
+_ = pool.FreeSize
+_ = pool.Status
+```
+
+Get the current pool state:
+
+```go
+pool, err := drive9.New(serverURL, "").AdminGetTenantPool(ctx, drive9.AdminTenantPoolRequest{
+	PublicKey:  tidbCloudPublicKey,
+	PrivateKey: tidbCloudPrivateKey,
+})
+if err != nil {
+	return err
+}
+_ = pool.FreeSize
+```
+
+`AdminGetTenantPool` is read-only. It returns pool metadata and free capacity;
+it does not claim a tenant, mark a TiDB Cloud cluster as used, or replenish the
+pool.
+
+Update the target pool size:
+
+```go
+poolSize = 30
+
+pool, err = drive9.New(serverURL, "").AdminUpdateTenantPool(ctx, drive9.AdminTenantPoolRequest{
+	PublicKey:  tidbCloudPublicKey,
+	PrivateKey: tidbCloudPrivateKey,
+	PoolSize:   &poolSize,
+})
+if err != nil {
+	return err
+}
+_ = pool
+```
+
+Delete the pool and its remaining free tenants:
+
+```go
+pool, err = drive9.New(serverURL, "").AdminDeleteTenantPool(ctx, drive9.AdminTenantPoolRequest{
+	PublicKey:  tidbCloudPublicKey,
+	PrivateKey: tidbCloudPrivateKey,
+})
+if err != nil {
+	return err
+}
+_ = pool.Status
+```
+
+After a pool exists, tenant creation automatically tries to claim an active free
+tenant from the pool before falling back to normal TiDB Cloud cluster creation.
+This applies to `AdminCreateTenant` and to the public `/v1/provision` path used
+by `drive9 create`. Pool tenants are claimed only by create/provision flows,
+not by pool get/update/delete calls.
+
 ## Run the included smoke test
 
 This repository includes a minimal external-style example under

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -698,6 +698,10 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "reason", "pool_manager_unavailable", "duration_ms", durationMillis(claimStarted))...)
 		return nil, nil, false, nil
 	}
+	if _, ok := s.provisioner.(tenant.ManagedClusterLister); !ok {
+		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "reason", "managed_cluster_lister_unavailable", "duration_ms", durationMillis(claimStarted))...)
+		return nil, nil, false, nil
+	}
 	stageStarted := time.Now()
 	orgID, err := s.firstManagedOrganization(ctx, cred)
 	if err != nil || orgID == "" {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -220,17 +220,17 @@ type tenantPoolNoListProvisioner struct {
 
 func (p *tenantPoolNoListProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(context.Context, []string, tenant.CredentialProvisionRequest, tenant.QuotaUpdateOptions) ([]*tenant.ClusterInfo, *tenant.QuotaCloudConfig, error) {
 	p.batchPoolCalls.Add(1)
-	return nil, nil, errors.New("pool batch should not be called")
+	return nil, nil, nil
 }
 
 func (p *tenantPoolNoListProvisioner) MarkClusterPoolUsed(context.Context, *tenant.ClusterInfo, tenant.CredentialProvisionRequest, time.Time, tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
 	p.markPoolUsedCalls.Add(1)
-	return nil, errors.New("pool mark used should not be called")
+	return nil, nil
 }
 
 func (p *tenantPoolNoListProvisioner) MarkClusterPoolFree(context.Context, *tenant.ClusterInfo, tenant.CredentialProvisionRequest) error {
 	p.markPoolFreeCalls.Add(1)
-	return errors.New("pool mark free should not be called")
+	return nil
 }
 
 func newQuotaRuntime(t *testing.T, provider string) *quotaRuntime {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1858,9 +1858,11 @@ func TestProvisionClaimsFreePoolTenant(t *testing.T) {
 
 	ts := httptest.NewServer(rt.server)
 	t.Cleanup(ts.Close)
+	maxStorageSize := int64(100)
 	resp := postJSON(t, ts.URL+"/v1/provision", map[string]any{
 		"public_key":               "public-1",
 		"private_key":              "private-1",
+		"max_storage_size":         maxStorageSize,
 		"tidbcloud_spending_limit": 123,
 	}, "")
 	defer func() { _ = resp.Body.Close() }()
@@ -1873,19 +1875,26 @@ func TestProvisionClaimsFreePoolTenant(t *testing.T) {
 		t.Fatalf("decode response: %v", err)
 	}
 	if out["tenant_id"] != tenantID || out["api_key"] == "" || out["status"] != string(meta.TenantActive) {
-		t.Fatalf("provision response = %#v", out)
+		t.Errorf("provision response = %#v", out)
 	}
 	if got := rt.prov.markPoolUsedCalls.Load(); got != 1 {
-		t.Fatalf("mark pool used calls = %d, want 1", got)
+		t.Errorf("mark pool used calls = %d, want 1", got)
 	}
 	if rt.prov.batchPoolCalls.Load() != 0 {
-		t.Fatalf("batch pool calls = %d, want 0", rt.prov.batchPoolCalls.Load())
+		t.Errorf("batch pool calls = %d, want 0", rt.prov.batchPoolCalls.Load())
 	}
 	if rt.prov.lastCluster == nil || rt.prov.lastCluster.ClusterID != "cluster-free-1" {
-		t.Fatalf("last cluster = %#v", rt.prov.lastCluster)
+		t.Errorf("last cluster = %#v", rt.prov.lastCluster)
 	}
 	if rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly == nil || *rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly != 123 {
-		t.Fatalf("last spending limit = %#v", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly)
+		t.Errorf("last spending limit = %#v", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly)
+	}
+	quotaCfg, err := rt.meta.GetQuotaConfig(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("get quota config: %v", err)
+	}
+	if quotaCfg.MaxStorageBytes != maxStorageSize*quotaStorageSizeBytes {
+		t.Errorf("quota max storage = %d, want %d", quotaCfg.MaxStorageBytes, maxStorageSize*quotaStorageSizeBytes)
 	}
 	binding, err := rt.meta.GetTenantTiDBCloudOrgBinding(ctx, tenantID)
 	if err != nil {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1802,6 +1802,107 @@ func TestAdminTenantCreateClaimsFreePoolTenant(t *testing.T) {
 	}
 }
 
+func TestProvisionClaimsFreePoolTenant(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{
+			ClusterID:      "cluster-free-1",
+			OrganizationID: "org-1",
+		}},
+	}}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           0,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert pool: %v", err)
+	}
+	passCipher, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
+	if err != nil {
+		t.Fatalf("encrypt password: %v", err)
+	}
+	tenantID := "pool-tenant-provision-1"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           "db.example.com",
+		DBPort:           4000,
+		DBUser:           "u.root",
+		DBPasswordCipher: passCipher,
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-free-1",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       tenantID,
+		OrganizationID: "org-1",
+		ClusterID:      "cluster-free-1",
+		PoolID:         "pool-1",
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	resp := postJSON(t, ts.URL+"/v1/provision", map[string]any{
+		"public_key":               "public-1",
+		"private_key":              "private-1",
+		"tidbcloud_spending_limit": 123,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var out map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out["tenant_id"] != tenantID || out["api_key"] == "" || out["status"] != string(meta.TenantActive) {
+		t.Fatalf("provision response = %#v", out)
+	}
+	if got := rt.prov.markPoolUsedCalls.Load(); got != 1 {
+		t.Fatalf("mark pool used calls = %d, want 1", got)
+	}
+	if rt.prov.batchPoolCalls.Load() != 0 {
+		t.Fatalf("batch pool calls = %d, want 0", rt.prov.batchPoolCalls.Load())
+	}
+	if rt.prov.lastCluster == nil || rt.prov.lastCluster.ClusterID != "cluster-free-1" {
+		t.Fatalf("last cluster = %#v", rt.prov.lastCluster)
+	}
+	if rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly == nil || *rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly != 123 {
+		t.Fatalf("last spending limit = %#v", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly)
+	}
+	binding, err := rt.meta.GetTenantTiDBCloudOrgBinding(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("get binding: %v", err)
+	}
+	if binding.PoolStatus != meta.TenantPoolBindingUsed || binding.UsedAt == nil {
+		t.Fatalf("binding = %#v, want used with used_at", binding)
+	}
+	resolved, err := rt.meta.ResolveByAPIKeyHash(ctx, token.HashToken(out["api_key"]))
+	if err != nil {
+		t.Fatalf("resolve issued api key: %v", err)
+	}
+	if resolved.Tenant.ID != tenantID {
+		t.Fatalf("resolved tenant = %q, want %q", resolved.Tenant.ID, tenantID)
+	}
+}
+
 func TestAdminTenantQuotaSetRequiresPatchLabelAuthorization(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -211,6 +211,28 @@ type quotaRuntime struct {
 	server   *Server
 }
 
+type tenantPoolNoListProvisioner struct {
+	fakeProvisioner
+	batchPoolCalls    atomic.Int32
+	markPoolUsedCalls atomic.Int32
+	markPoolFreeCalls atomic.Int32
+}
+
+func (p *tenantPoolNoListProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(context.Context, []string, tenant.CredentialProvisionRequest, tenant.QuotaUpdateOptions) ([]*tenant.ClusterInfo, *tenant.QuotaCloudConfig, error) {
+	p.batchPoolCalls.Add(1)
+	return nil, nil, errors.New("pool batch should not be called")
+}
+
+func (p *tenantPoolNoListProvisioner) MarkClusterPoolUsed(context.Context, *tenant.ClusterInfo, tenant.CredentialProvisionRequest, time.Time, tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
+	p.markPoolUsedCalls.Add(1)
+	return nil, errors.New("pool mark used should not be called")
+}
+
+func (p *tenantPoolNoListProvisioner) MarkClusterPoolFree(context.Context, *tenant.ClusterInfo, tenant.CredentialProvisionRequest) error {
+	p.markPoolFreeCalls.Add(1)
+	return errors.New("pool mark free should not be called")
+}
+
 func newQuotaRuntime(t *testing.T, provider string) *quotaRuntime {
 	t.Helper()
 	db := newTenantDeleteDBInfo(t)
@@ -1909,6 +1931,55 @@ func TestProvisionClaimsFreePoolTenant(t *testing.T) {
 	}
 	if resolved.Tenant.ID != tenantID {
 		t.Fatalf("resolved tenant = %q, want %q", resolved.Tenant.ID, tenantID)
+	}
+}
+
+func TestProvisionFallsBackWhenTenantPoolClaimCannotListManagedClusters(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	prov := &tenantPoolNoListProvisioner{
+		fakeProvisioner: fakeProvisioner{
+			provider:      tenant.ProviderTiDBCloudNative,
+			cloudProvider: "aws",
+			region:        "us-east-1",
+			cluster: &tenant.ClusterInfo{
+				ClusterID:      "native-cluster-fallback",
+				OrganizationID: "org-1",
+				Host:           "db.example.com",
+				Port:           4000,
+				Username:       "u.root",
+				Password:       "db-pass",
+				DBName:         "tidbcloud_fs",
+			},
+		},
+	}
+	rt.server.provisioner = prov
+
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	resp := postJSON(t, ts.URL+"/v1/provision", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var out map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out["tenant_id"] == "" || out["api_key"] == "" || out["status"] != string(meta.TenantProvisioning) {
+		t.Errorf("provision response = %#v", out)
+	}
+	if got := prov.credentialCalls.Load(); got != 1 {
+		t.Errorf("credential provision calls = %d, want 1", got)
+	}
+	if got := prov.markPoolUsedCalls.Load(); got != 0 {
+		t.Errorf("mark pool used calls = %d, want 0", got)
+	}
+	if got := prov.batchPoolCalls.Load(); got != 0 {
+		t.Errorf("batch pool calls = %d, want 0", got)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3908,6 +3908,13 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		}
 		credentialReq = decoded.Credential
 		quotaReq = decoded.Quota
+		if quotaReq != nil {
+			quotaReq.TenantID = "pending"
+			if err := s.validateQuotaSetRequest(*quotaReq); err != nil {
+				errJSON(w, http.StatusBadRequest, err.Error())
+				return
+			}
+		}
 	} else {
 		if err := rejectCredentialProvisionBody(r); err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_credential_rejected", "provider", provider, "error", err)...)
@@ -3915,6 +3922,26 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 			errJSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
+	}
+	if provider == tenant.ProviderTiDBCloudNative && credentialReq != nil {
+		poolClaimStarted := time.Now()
+		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_started", "provider", provider, "quota_requested", quotaReq != nil)...)
+		if res, pool, claimed, err := s.claimAdminTenantFromPool(r.Context(), *credentialReq, quotaReq); err != nil {
+			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_failed", "provider", provider, "duration_ms", durationMillis(poolClaimStarted), "error", err)...)
+			errJSON(w, http.StatusBadGateway, fmt.Sprintf("claim tenant pool tenant failed: %v", err))
+			return
+		} else if claimed {
+			logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
+			setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+			if res.Status == meta.TenantProvisioning {
+				s.startProvisionedTenantSchemaInit(r.Context(), res)
+			}
+			s.replenishTenantPoolAsync(r.Context(), pool, *credentialReq)
+			writeProvisionTenantAccepted(w, res)
+			logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_create_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted))...)
+			return
+		}
+		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_missed", "provider", provider, "duration_ms", durationMillis(poolClaimStarted))...)
 	}
 	res, err := s.provisionTenant(r.Context(), provisionTenantOptions{
 		KeyName:               "default",
@@ -3933,7 +3960,10 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	}
 	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
 	s.startProvisionedTenantSchemaInit(r.Context(), res)
+	writeProvisionTenantAccepted(w, res)
+}
 
+func writeProvisionTenantAccepted(w http.ResponseWriter, res *provisionTenantResult) {
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
 	response := map[string]string{
@@ -4649,6 +4679,10 @@ func (s *Server) handleLocalTenantProvision(w http.ResponseWriter, r *http.Reque
 
 func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN, provider string, schemaInit func(context.Context, string) error) {
 	ctx = ensureTrace(ctx)
+	schemaCtx := logger.WithContext(ctx, logger.FromContext(ctx).With(
+		zap.String("tenant_id", tenantID),
+		zap.String("provider", provider),
+	))
 	logger.Info(ctx, "server_event", eventFields(ctx, "schema_init_started", "tenant_id", tenantID, "provider", provider)...)
 	deadline := time.Now().Add(schemaInitRetryWindow)
 	backoff := schemaInitInitialBackoff
@@ -4663,7 +4697,7 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			return
 		default:
 		}
-		err := schemaInit(ctx, tenantDSN)
+		err := schemaInit(schemaCtx, tenantDSN)
 		if err == nil {
 			err = s.finalizeTenantSchemaInit(ctx, tenantID, tenantDSN, provider)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3909,7 +3909,6 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		credentialReq = decoded.Credential
 		quotaReq = decoded.Quota
 		if quotaReq != nil {
-			quotaReq.TenantID = "pending"
 			if err := s.validateQuotaSetRequest(*quotaReq); err != nil {
 				errJSON(w, http.StatusBadRequest, err.Error())
 				return
@@ -3928,7 +3927,8 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_started", "provider", provider, "quota_requested", quotaReq != nil)...)
 		if res, pool, claimed, err := s.claimAdminTenantFromPool(r.Context(), *credentialReq, quotaReq); err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_failed", "provider", provider, "duration_ms", durationMillis(poolClaimStarted), "error", err)...)
-			errJSON(w, http.StatusBadGateway, fmt.Sprintf("claim tenant pool tenant failed: %v", err))
+			metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", provisionTenantPoolClaimMetricResult(err))
+			errJSON(w, http.StatusBadGateway, "claim tenant pool tenant failed")
 			return
 		} else if claimed {
 			logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
@@ -3937,6 +3937,10 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 				s.startProvisionedTenantSchemaInit(r.Context(), res)
 			}
 			s.replenishTenantPoolAsync(r.Context(), pool, *credentialReq)
+			if quotaReq != nil && quotaReq.TiDBCloudSpendingLimit != nil {
+				metricEvent(r.Context(), "tenant_provision", "provider", provider, "quota", "create_time_spending_limit")
+			}
+			metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "accepted")
 			writeProvisionTenantAccepted(w, res)
 			logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_create_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted))...)
 			return
@@ -3961,6 +3965,13 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
 	s.startProvisionedTenantSchemaInit(r.Context(), res)
 	writeProvisionTenantAccepted(w, res)
+}
+
+func provisionTenantPoolClaimMetricResult(err error) string {
+	if errors.Is(err, tenant.ErrQuotaPermissionDenied) || errors.Is(err, tenant.ErrQuotaBackendNotFound) {
+		return "cluster_error"
+	}
+	return "error"
 }
 
 func writeProvisionTenantAccepted(w http.ResponseWriter, res *provisionTenantResult) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3910,6 +3910,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		quotaReq = decoded.Quota
 		if quotaReq != nil {
 			if err := s.validateQuotaSetRequest(*quotaReq); err != nil {
+				metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", "error")
 				errJSON(w, http.StatusBadRequest, err.Error())
 				return
 			}
@@ -4690,7 +4691,7 @@ func (s *Server) handleLocalTenantProvision(w http.ResponseWriter, r *http.Reque
 
 func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN, provider string, schemaInit func(context.Context, string) error) {
 	ctx = ensureTrace(ctx)
-	schemaCtx := logger.WithContext(ctx, logger.FromContext(ctx).With(
+	ctx = logger.WithContext(ctx, logger.FromContext(ctx).With(
 		zap.String("tenant_id", tenantID),
 		zap.String("provider", provider),
 	))
@@ -4708,7 +4709,7 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			return
 		default:
 		}
-		err := schemaInit(schemaCtx, tenantDSN)
+		err := schemaInit(ctx, tenantDSN)
 		if err == nil {
 			err = s.finalizeTenantSchemaInit(ctx, tenantID, tenantDSN, provider)
 		}


### PR DESCRIPTION
## Summary
- make /v1/provision claim an active free tenant from the TiDB Cloud tenant pool before falling back to normal cluster provisioning
- preserve admin pool get as read-only pool info lookup
- include tenant/provider fields in schema init logger context so schema SQL logs carry tenant identity
- add coverage for ordinary provision consuming a free pool tenant and applying requested spending limit

## Tests
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -run 'TestProvisionClaimsFreePoolTenant|TestAdminTenantCreateClaimsFreePoolTenant|TestAdminTenantPool|TestProvision' -count=1
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -count=1
- GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Provisioning now returns a consistent “accepted” response including tenant ID, non-empty API key, and status.
  * Free-pool tenants can now be claimed via the standard `/v1/provision` flow.
* **Bug Fixes**
  * Improved quota validation timing during provisioning for the TiDBCloudNative provider.
  * Tenant pool claims now transition to `Used` with accurate usage timestamps.
* **Documentation**
  * Added an “Admin Tenant Pool API” section to the Go SDK integration guide.
* **Tests**
  * Updated and extended provisioning quota/pool-claim coverage, including fallback behavior when managed cluster listing is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->