### PR TITLE
Cap and harden tenant pool provisioning

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -509,7 +509,7 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME default tidb_cloud_native database name (default: tidbcloud_fs)
   DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY optional default TiDB Cloud API public key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY optional default TiDB Cloud API private key for tidb_cloud_native create/delete when caller omits it
-  DRIVE9_TENANT_POOL_MAX_SIZE maximum admin tenant pool size; unset means no server-side cap
+  DRIVE9_TENANT_POOL_MAX_SIZE maximum admin tenant pool size (default: %d)
   DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*
   DRIVE9_SLOCK_API_ORIGIN Slock API origin (required when DRIVE9_SLOCK_ORIGIN is set)
   DRIVE9_SLOCK_CLIENT_ID Slock connected-app client id (required when DRIVE9_SLOCK_ORIGIN is set)
@@ -583,7 +583,7 @@ environment:
 schema tooling:
   dump-init-sql writes the exact init schema SQL to stdout so external systems
   such as tidb_cloud_starter can stay in sync with drive9's schema source of truth.
-`, server.DefaultMaxUploadBytes, meta.DefaultMaxStorageBytes())
+`, server.DefaultMaxUploadBytes, meta.DefaultMaxStorageBytes(), server.DefaultTenantPoolMaxSize)
 	os.Exit(exitCode)
 }
 
@@ -886,7 +886,7 @@ func envInt64(key string, fallback int64) int64 {
 func tenantPoolMaxSizeFromEnv() (int, error) {
 	raw := strings.TrimSpace(os.Getenv("DRIVE9_TENANT_POOL_MAX_SIZE"))
 	if raw == "" {
-		return 0, nil
+		return server.DefaultTenantPoolMaxSize, nil
 	}
 	v, err := strconv.Atoi(raw)
 	if err != nil || v <= 0 {

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -178,6 +178,10 @@ func main() {
 	tokenHex := os.Getenv("DRIVE9_TOKEN_SIGNING_KEY")
 	vaultMKHex := os.Getenv("DRIVE9_VAULT_MASTER_KEY")
 	providerType := envOr("DRIVE9_TENANT_PROVIDER", tenant.ProviderTiDBZero)
+	tenantPoolMaxSize, err := tenantPoolMaxSizeFromEnv()
+	if err != nil {
+		die(err)
+	}
 	maxUploadBytes := server.DefaultMaxUploadBytes
 	if raw := os.Getenv("DRIVE9_MAX_UPLOAD_BYTES"); raw != "" {
 		maxUploadBytes, err = strconv.ParseInt(raw, 10, 64)
@@ -363,6 +367,7 @@ func main() {
 		PublicURL:                    publicBaseURL(addr),
 		S3Dir:                        s3cfg.Dir,
 		MaxUploadBytes:               maxUploadBytes,
+		TenantPoolMaxSize:            tenantPoolMaxSize,
 		InlineThreshold:              backendOptions.InlineThreshold,
 		Logger:                       srvLogger,
 		SemanticEmbedder:             semanticEmbedder,
@@ -504,6 +509,7 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME default tidb_cloud_native database name (default: tidbcloud_fs)
   DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY optional default TiDB Cloud API public key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY optional default TiDB Cloud API private key for tidb_cloud_native create/delete when caller omits it
+  DRIVE9_TENANT_POOL_MAX_SIZE maximum admin tenant pool size; unset means no server-side cap
   DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*
   DRIVE9_SLOCK_API_ORIGIN Slock API origin (required when DRIVE9_SLOCK_ORIGIN is set)
   DRIVE9_SLOCK_CLIENT_ID Slock connected-app client id (required when DRIVE9_SLOCK_ORIGIN is set)
@@ -875,6 +881,18 @@ func envInt64(key string, fallback int64) int64 {
 		return fallback
 	}
 	return v
+}
+
+func tenantPoolMaxSizeFromEnv() (int, error) {
+	raw := strings.TrimSpace(os.Getenv("DRIVE9_TENANT_POOL_MAX_SIZE"))
+	if raw == "" {
+		return 0, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return 0, fmt.Errorf("invalid DRIVE9_TENANT_POOL_MAX_SIZE: must be a positive integer")
+	}
+	return v, nil
 }
 
 func envDuration(key string, fallback time.Duration) time.Duration {

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -890,7 +890,7 @@ func tenantPoolMaxSizeFromEnv() (int, error) {
 	}
 	v, err := strconv.Atoi(raw)
 	if err != nil || v <= 0 {
-		return 0, fmt.Errorf("invalid DRIVE9_TENANT_POOL_MAX_SIZE: must be a positive integer")
+		return 0, fmt.Errorf("invalid DRIVE9_TENANT_POOL_MAX_SIZE=%q: must be a positive integer", raw)
 	}
 	return v, nil
 }

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -81,6 +81,37 @@ func TestSlockOAuthFromEnvEnabled(t *testing.T) {
 	}
 }
 
+func TestTenantPoolMaxSizeFromEnv(t *testing.T) {
+	const key = "DRIVE9_TENANT_POOL_MAX_SIZE"
+	restore := snapshotEnv(t, []string{key})
+	t.Cleanup(func() { restoreEnv(t, restore) })
+
+	unsetEnv(t, []string{key})
+	got, err := tenantPoolMaxSizeFromEnv()
+	if err != nil {
+		t.Fatalf("tenantPoolMaxSizeFromEnv empty: %v", err)
+	}
+	if got != 0 {
+		t.Fatalf("empty max size = %d, want 0", got)
+	}
+
+	setEnv(t, key, "25")
+	got, err = tenantPoolMaxSizeFromEnv()
+	if err != nil {
+		t.Fatalf("tenantPoolMaxSizeFromEnv valid: %v", err)
+	}
+	if got != 25 {
+		t.Fatalf("max size = %d, want 25", got)
+	}
+
+	for _, raw := range []string{"0", "-1", "bad"} {
+		setEnv(t, key, raw)
+		if _, err := tenantPoolMaxSizeFromEnv(); err == nil {
+			t.Fatalf("tenantPoolMaxSizeFromEnv(%q) error = nil, want error", raw)
+		}
+	}
+}
+
 func TestBuildBackendOptionsFromEnvAudioDisabled(t *testing.T) {
 	keys := []string{
 		"DRIVE9_QUERY_EMBED_API_BASE",

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/backend"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/server"
 )
 
 func TestVersionTextUsesDrive9ServerComponent(t *testing.T) {
@@ -91,8 +92,8 @@ func TestTenantPoolMaxSizeFromEnv(t *testing.T) {
 	if err != nil {
 		t.Fatalf("tenantPoolMaxSizeFromEnv empty: %v", err)
 	}
-	if got != 0 {
-		t.Fatalf("empty max size = %d, want 0", got)
+	if got != server.DefaultTenantPoolMaxSize {
+		t.Fatalf("empty max size = %d, want %d", got, server.DefaultTenantPoolMaxSize)
 	}
 
 	setEnv(t, key, "25")

--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -175,43 +175,57 @@ func (s *Store) claimQuotaOutboxBatchOnce(ctx context.Context, now time.Time, le
 	// outbox tables. Lock a bounded candidate window first, then use indexed
 	// minimum-id checks below to preserve the same ordering semantics.
 	scanLimit := quotaOutboxClaimScanLimit(limit)
-	rows, err := tx.QueryContext(ctx, quotaOutboxSelectSQL+`
-		FROM quota_outbox q FORCE INDEX (idx_quota_outbox_claim)
-		WHERE q.status = ? AND q.available_at <= ?
-		ORDER BY q.id
-		LIMIT ?
-		FOR UPDATE SKIP LOCKED`, QuotaOutboxQueued, now, scanLimit)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	entries := make([]QuotaOutboxEntry, 0, limit)
-	for rows.Next() {
-		entry, err := scanQuotaOutbox(rows)
+	var entries []QuotaOutboxEntry
+	var lastCandidateID int64
+	for {
+		rows, err := tx.QueryContext(ctx, quotaOutboxSelectSQL+`
+			FROM quota_outbox q FORCE INDEX (idx_quota_outbox_claim)
+			WHERE q.status = ? AND q.available_at <= ? AND q.id > ?
+			ORDER BY q.id
+			LIMIT ?
+			FOR UPDATE SKIP LOCKED`, QuotaOutboxQueued, now, lastCandidateID, scanLimit)
 		if err != nil {
 			return nil, err
 		}
-		entries = append(entries, *entry)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	if len(entries) == 0 {
-		if err := tx.Commit(); err != nil {
+
+		candidates := make([]QuotaOutboxEntry, 0, scanLimit)
+		for rows.Next() {
+			entry, err := scanQuotaOutbox(rows)
+			if err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			candidates = append(candidates, *entry)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
 			return nil, err
 		}
-		return nil, nil
-	}
-	entries, err = s.claimableQuotaOutboxEntries(ctx, tx, entries, limit)
-	if err != nil {
-		return nil, err
-	}
-	if len(entries) == 0 {
-		if err := tx.Commit(); err != nil {
+		if err := rows.Close(); err != nil {
 			return nil, err
 		}
-		return nil, nil
+
+		if len(candidates) == 0 {
+			if err := tx.Commit(); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		}
+		lastCandidateID = candidates[len(candidates)-1].ID
+
+		entries, err = s.claimableQuotaOutboxEntries(ctx, tx, candidates, limit)
+		if err != nil {
+			return nil, err
+		}
+		if len(entries) > 0 {
+			break
+		}
+		if len(candidates) < scanLimit {
+			if err := tx.Commit(); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		}
 	}
 
 	receipt := uuid.NewString()
@@ -306,9 +320,10 @@ func (s *Store) claimableQuotaOutboxEntries(ctx context.Context, tx *sql.Tx, can
 			if err != nil {
 				return nil, err
 			}
-			if blocked {
-				continue
+			if !blocked {
+				out = append(out, candidate)
 			}
+			break
 		} else {
 			if minID, ok := minPendingByFile[candidate.FileID]; !ok || minID != candidate.ID {
 				continue

--- a/pkg/datastore/quota_outbox.go
+++ b/pkg/datastore/quota_outbox.go
@@ -19,6 +19,7 @@ import (
 const defaultQuotaOutboxMaxAttempts = 100
 const quotaOutboxClaimMaxAttempts = 3
 const quotaAdmissionLockName = "default"
+const quotaOutboxClaimScanMultiplier = 64
 
 type QuotaOutboxStatus string
 
@@ -168,19 +169,18 @@ func (s *Store) claimQuotaOutboxBatchOnce(ctx context.Context, now time.Time, le
 	}
 	defer func() { _ = tx.Rollback() }()
 
+	// Keep the first step as a simple claim-index scan. The original single
+	// NOT EXISTS query had to encode both per-file ordering and NULL-file global
+	// barriers in SQL; TiDB can plan that as a large cartesian anti join on hot
+	// outbox tables. Lock a bounded candidate window first, then use indexed
+	// minimum-id checks below to preserve the same ordering semantics.
+	scanLimit := quotaOutboxClaimScanLimit(limit)
 	rows, err := tx.QueryContext(ctx, quotaOutboxSelectSQL+`
-		FROM quota_outbox q
+		FROM quota_outbox q FORCE INDEX (idx_quota_outbox_claim)
 		WHERE q.status = ? AND q.available_at <= ?
-		  AND NOT EXISTS (
-		    SELECT 1 FROM quota_outbox older
-		     WHERE older.id < q.id
-		       AND older.status IN (?, ?)
-		       AND (older.file_id = q.file_id OR older.file_id IS NULL OR q.file_id IS NULL)
-		  )
-		ORDER BY id
+		ORDER BY q.id
 		LIMIT ?
-		FOR UPDATE SKIP LOCKED`, QuotaOutboxQueued, now,
-		QuotaOutboxQueued, QuotaOutboxProcessing, limit)
+		FOR UPDATE SKIP LOCKED`, QuotaOutboxQueued, now, scanLimit)
 	if err != nil {
 		return nil, err
 	}
@@ -195,6 +195,16 @@ func (s *Store) claimQuotaOutboxBatchOnce(ctx context.Context, now time.Time, le
 		entries = append(entries, *entry)
 	}
 	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(entries) == 0 {
+		if err := tx.Commit(); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+	entries, err = s.claimableQuotaOutboxEntries(ctx, tx, entries, limit)
+	if err != nil {
 		return nil, err
 	}
 	if len(entries) == 0 {
@@ -248,6 +258,142 @@ func (s *Store) claimQuotaOutboxBatchOnce(ctx context.Context, now time.Time, le
 		return nil, err
 	}
 	return entries, nil
+}
+
+func quotaOutboxClaimScanLimit(limit int) int {
+	if limit <= 0 {
+		limit = 1
+	}
+	scanLimit := limit * quotaOutboxClaimScanMultiplier
+	if scanLimit < limit {
+		return limit
+	}
+	return scanLimit
+}
+
+func (s *Store) claimableQuotaOutboxEntries(ctx context.Context, tx *sql.Tx, candidates []QuotaOutboxEntry, limit int) ([]QuotaOutboxEntry, error) {
+	if len(candidates) == 0 || limit <= 0 {
+		return nil, nil
+	}
+
+	fileIDs := make([]string, 0, len(candidates))
+	fileIDSeen := make(map[string]struct{}, len(candidates))
+	for i := range candidates {
+		if candidates[i].FileID == "" {
+			continue
+		}
+		if _, ok := fileIDSeen[candidates[i].FileID]; ok {
+			continue
+		}
+		fileIDSeen[candidates[i].FileID] = struct{}{}
+		fileIDs = append(fileIDs, candidates[i].FileID)
+	}
+
+	minPendingByFile, err := s.minPendingQuotaOutboxIDByFile(ctx, tx, fileIDs)
+	if err != nil {
+		return nil, err
+	}
+	minNullPendingID, err := s.minNullFilePendingQuotaOutboxID(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]QuotaOutboxEntry, 0, minInt(limit, len(candidates)))
+	for i := range candidates {
+		candidate := candidates[i]
+		if candidate.FileID == "" {
+			blocked, err := s.hasPendingQuotaOutboxBeforeID(ctx, tx, candidate.ID)
+			if err != nil {
+				return nil, err
+			}
+			if blocked {
+				continue
+			}
+		} else {
+			if minID, ok := minPendingByFile[candidate.FileID]; !ok || minID != candidate.ID {
+				continue
+			}
+			if minNullPendingID > 0 && minNullPendingID < candidate.ID {
+				continue
+			}
+		}
+		out = append(out, candidate)
+		if len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func (s *Store) minPendingQuotaOutboxIDByFile(ctx context.Context, tx *sql.Tx, fileIDs []string) (map[string]int64, error) {
+	out := make(map[string]int64, len(fileIDs))
+	if len(fileIDs) == 0 {
+		return out, nil
+	}
+	args := make([]any, 0, len(fileIDs)+2)
+	for _, fileID := range fileIDs {
+		args = append(args, fileID)
+	}
+	args = append(args, QuotaOutboxQueued, QuotaOutboxProcessing)
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`SELECT file_id, MIN(id)
+		FROM quota_outbox FORCE INDEX (idx_quota_outbox_file_order)
+		WHERE file_id IN (%s) AND status IN (?, ?)
+		GROUP BY file_id`, sqlPlaceholders(len(fileIDs))), args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var fileID string
+		var id int64
+		if err := rows.Scan(&fileID, &id); err != nil {
+			return nil, err
+		}
+		out[fileID] = id
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (s *Store) minNullFilePendingQuotaOutboxID(ctx context.Context, tx *sql.Tx) (int64, error) {
+	var id sql.NullInt64
+	err := tx.QueryRowContext(ctx, `SELECT MIN(id)
+		FROM quota_outbox FORCE INDEX (idx_quota_outbox_file_order)
+		WHERE file_id IS NULL AND status IN (?, ?)`,
+		QuotaOutboxQueued, QuotaOutboxProcessing).Scan(&id)
+	if err != nil {
+		return 0, err
+	}
+	if !id.Valid {
+		return 0, nil
+	}
+	return id.Int64, nil
+}
+
+func (s *Store) hasPendingQuotaOutboxBeforeID(ctx context.Context, tx *sql.Tx, id int64) (bool, error) {
+	var olderID int64
+	err := tx.QueryRowContext(ctx, `SELECT id
+		FROM quota_outbox FORCE INDEX (PRIMARY)
+		WHERE id < ? AND status IN (?, ?)
+		ORDER BY id
+		LIMIT 1`,
+		id, QuotaOutboxQueued, QuotaOutboxProcessing).Scan(&olderID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
 }
 
 // AckQuotaOutbox marks a leased quota outbox row as successfully applied.

--- a/pkg/datastore/quota_outbox_test.go
+++ b/pkg/datastore/quota_outbox_test.go
@@ -623,6 +623,59 @@ func TestQuotaOutboxBatchClaimBlocksNullFileIDBehindOlderPendingRow(t *testing.T
 	}
 }
 
+func TestQuotaOutboxBatchClaimScansPastBlockedWindow(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	availableNow := now.Add(-time.Second)
+
+	hotFileID := "hot-file"
+	blockingID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       hotFileID,
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"hot-file"}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	blocking, found, err := s.ClaimQuotaOutbox(ctx, now, time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || blocking.ID != blockingID {
+		t.Fatalf("blocking claim = %+v found=%v, want id %d", blocking, found, blockingID)
+	}
+
+	for i := 0; i < quotaOutboxClaimScanLimit(1); i++ {
+		if _, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+			FileID:       hotFileID,
+			MutationType: "file_overwrite",
+			MutationData: json.RawMessage(`{"file_id":"hot-file"}`),
+			AvailableAt:  availableNow,
+		}); err != nil {
+			t.Fatalf("enqueue blocked hot row %d: %v", i, err)
+		}
+	}
+	coldID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "cold-file",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"cold-file"}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimed, err := s.ClaimQuotaOutboxBatch(ctx, now.Add(time.Second), time.Minute, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != coldID {
+		t.Fatalf("claimed past blocked window = %+v, want cold id %d", claimed, coldID)
+	}
+}
+
 func TestQuotaOutboxDeadLetteredOlderRowUnblocksLaterClaim(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/datastore/quota_outbox_test.go
+++ b/pkg/datastore/quota_outbox_test.go
@@ -555,6 +555,74 @@ func TestQuotaOutboxBatchClaimTreatsNullFileIDAsGlobalBarrier(t *testing.T) {
 	}
 }
 
+func TestQuotaOutboxBatchClaimBlocksNullFileIDBehindOlderPendingRow(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Microsecond)
+	availableNow := now.Add(-time.Second)
+
+	file1ID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-1",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-1"}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	globalID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		MutationType: "global_legacy",
+		MutationData: json.RawMessage(`{}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	file2ID, err := s.EnqueueQuotaOutboxTx(s.DB(), &QuotaOutboxEntry{
+		FileID:       "file-2",
+		MutationType: "file_create",
+		MutationData: json.RawMessage(`{"file_id":"file-2"}`),
+		AvailableAt:  availableNow,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	claimed, err := s.ClaimQuotaOutboxBatch(ctx, now, time.Minute, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != file1ID {
+		t.Fatalf("claimed with later NULL file_id = %+v, want only older file id %d", claimed, file1ID)
+	}
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.AckQuotaOutboxBatchTx(ctx, tx, claimed)
+	}); err != nil {
+		t.Fatalf("ack file row: %v", err)
+	}
+
+	claimed, err = s.ClaimQuotaOutboxBatch(ctx, now.Add(time.Second), time.Minute, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != globalID {
+		t.Fatalf("claimed after older file ack = %+v, want NULL file id %d", claimed, globalID)
+	}
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.AckQuotaOutboxBatchTx(ctx, tx, claimed)
+	}); err != nil {
+		t.Fatalf("ack global row: %v", err)
+	}
+
+	claimed, err = s.ClaimQuotaOutboxBatch(ctx, now.Add(2*time.Second), time.Minute, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(claimed) != 1 || claimed[0].ID != file2ID {
+		t.Fatalf("claimed after global ack = %+v, want later file id %d", claimed, file2ID)
+	}
+}
+
 func TestQuotaOutboxDeadLetteredOlderRowUnblocksLaterClaim(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -40,6 +40,8 @@ const (
 	TenantDeleted      TenantStatus = "deleted"
 )
 
+const tidbCloudNativeProvider = "tidb_cloud_native"
+
 type TenantKind string
 
 const (
@@ -1450,15 +1452,15 @@ func (s *Store) countFreeTenantPoolBindingsByStatus(ctx context.Context, organiz
 		return 0, fmt.Errorf("tenant statuses are required")
 	}
 	placeholders := strings.TrimRight(strings.Repeat("?,", len(statuses)), ",")
-	args := make([]any, 0, 2+len(statuses))
-	args = append(args, organizationID, TenantPoolBindingFree)
+	args := make([]any, 0, 3+len(statuses))
+	args = append(args, organizationID, TenantPoolBindingFree, tidbCloudNativeProvider)
 	for _, status := range statuses {
 		args = append(args, status)
 	}
 	row := s.db.QueryRowContext(ctx, `SELECT COUNT(*)
 		FROM tenant_tidbcloud_org_bindings b
 		JOIN tenants t ON t.id = b.tenant_id
-		WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = 'tidb_cloud_native'
+		WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = ?
 			AND t.status IN (`+placeholders+`)`, args...)
 	if err = row.Scan(&out); err != nil {
 		return 0, err
@@ -1514,12 +1516,12 @@ func (s *Store) listFreeTenantPoolBindings(ctx context.Context, organizationID s
 			b.tenant_id, b.organization_id, b.cluster_id, b.pool_id, b.pool_status, b.used_at, b.created_at, b.updated_at
 		FROM tenant_tidbcloud_org_bindings b
 		JOIN tenants t ON t.id = b.tenant_id
-		WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = 'tidb_cloud_native'
-			AND t.status IN (` + placeholders + `)
-		ORDER BY b.created_at ` + order + `, b.tenant_id ` + order + `
-		LIMIT ?`
-	args := make([]any, 0, 3+len(statuses))
-	args = append(args, organizationID, TenantPoolBindingFree)
+			WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = ?
+				AND t.status IN (` + placeholders + `)
+			ORDER BY b.created_at ` + order + `, b.tenant_id ` + order + `
+			LIMIT ?`
+	args := make([]any, 0, 4+len(statuses))
+	args = append(args, organizationID, TenantPoolBindingFree, tidbCloudNativeProvider)
 	for _, status := range statuses {
 		args = append(args, status)
 	}
@@ -1548,11 +1550,11 @@ func (s *Store) ClaimOldestFreeTenantPoolBinding(ctx context.Context, organizati
 				b.tenant_id, b.organization_id, b.cluster_id, b.pool_id, b.pool_status, b.used_at, b.created_at, b.updated_at
 			FROM tenant_tidbcloud_org_bindings b
 			JOIN tenants t ON t.id = b.tenant_id
-			WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = 'tidb_cloud_native'
-				AND t.status = ?
-			ORDER BY b.created_at ASC, b.tenant_id ASC
-			LIMIT 1 FOR UPDATE`
-		row := tx.QueryRowContext(ctx, query, organizationID, TenantPoolBindingFree, TenantActive)
+				WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = ?
+					AND t.status = ?
+				ORDER BY b.created_at ASC, b.tenant_id ASC
+				LIMIT 1 FOR UPDATE`
+		row := tx.QueryRowContext(ctx, query, organizationID, TenantPoolBindingFree, tidbCloudNativeProvider, TenantActive)
 		rec, scanErr := scanTenantBindingRow(row)
 		if scanErr != nil {
 			return scanErr
@@ -1711,26 +1713,26 @@ func (s *Store) ListTenantsByTiDBCloudOrganizations(ctx context.Context, organiz
 		limit = 10
 	}
 	placeholders := make([]string, len(organizationIDs))
-	args := make([]any, 0, len(organizationIDs)+2)
+	args := make([]any, 0, len(organizationIDs)+5)
 	for i, id := range organizationIDs {
 		placeholders[i] = "?"
 		args = append(args, id)
 	}
-	args = append(args, limit, offset)
+	args = append(args, tidbCloudNativeProvider, TenantPoolBindingFree, TenantDeleted, limit, offset)
 	query := `SELECT
 			t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
 			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
 			t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
 			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
 			b.tenant_id, b.organization_id, b.cluster_id, b.pool_id, b.pool_status, b.used_at, b.created_at, b.updated_at
-		FROM tenant_tidbcloud_org_bindings b
-		JOIN tenants t ON t.id = b.tenant_id
-		WHERE b.organization_id IN (` + strings.Join(placeholders, ",") + `)
-			AND t.provider = 'tidb_cloud_native'
-			AND b.pool_status <> 'free'
-			AND t.status <> 'deleted'
-		ORDER BY t.created_at DESC, t.id DESC
-		LIMIT ? OFFSET ?`
+			FROM tenant_tidbcloud_org_bindings b
+			JOIN tenants t ON t.id = b.tenant_id
+			WHERE b.organization_id IN (` + strings.Join(placeholders, ",") + `)
+				AND t.provider = ?
+				AND b.pool_status <> ?
+				AND t.status <> ?
+			ORDER BY t.created_at DESC, t.id DESC
+			LIMIT ? OFFSET ?`
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err
@@ -1753,26 +1755,26 @@ func (s *Store) ListTenantsByTiDBCloudOrgClusterBindings(ctx context.Context, bi
 		limit = 10
 	}
 	placeholders := make([]string, 0, len(bindings))
-	args := make([]any, 0, len(bindings)*2+2)
+	args := make([]any, 0, len(bindings)*2+5)
 	for _, binding := range bindings {
 		placeholders = append(placeholders, "(?, ?)")
 		args = append(args, binding.OrganizationID, binding.ClusterID)
 	}
-	args = append(args, limit, offset)
+	args = append(args, tidbCloudNativeProvider, TenantPoolBindingFree, TenantDeleted, limit, offset)
 	query := `SELECT
 			t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
 			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
 			t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
 			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
 			b.tenant_id, b.organization_id, b.cluster_id, b.pool_id, b.pool_status, b.used_at, b.created_at, b.updated_at
-		FROM tenant_tidbcloud_org_bindings b
-		JOIN tenants t ON t.id = b.tenant_id
-		WHERE (b.organization_id, b.cluster_id) IN (` + strings.Join(placeholders, ",") + `)
-			AND t.provider = 'tidb_cloud_native'
-			AND b.pool_status <> 'free'
-			AND t.status <> 'deleted'
-		ORDER BY t.created_at DESC, t.id DESC
-		LIMIT ? OFFSET ?`
+			FROM tenant_tidbcloud_org_bindings b
+			JOIN tenants t ON t.id = b.tenant_id
+			WHERE (b.organization_id, b.cluster_id) IN (` + strings.Join(placeholders, ",") + `)
+				AND t.provider = ?
+				AND b.pool_status <> ?
+				AND t.status <> ?
+			ORDER BY t.created_at DESC, t.id DESC
+			LIMIT ? OFFSET ?`
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, err

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1432,18 +1432,34 @@ func (s *Store) UpdateTenantPoolOrganization(ctx context.Context, poolID, organi
 }
 
 func (s *Store) CountFreeTenantPoolBindings(ctx context.Context, organizationID string) (out int, err error) {
+	return s.countFreeTenantPoolBindingsByStatus(ctx, organizationID, []TenantStatus{TenantActive})
+}
+
+func (s *Store) CountTenantPoolFreeSlots(ctx context.Context, organizationID string) (out int, err error) {
+	return s.countFreeTenantPoolBindingsByStatus(ctx, organizationID, []TenantStatus{TenantPending, TenantProvisioning, TenantActive})
+}
+
+func (s *Store) countFreeTenantPoolBindingsByStatus(ctx context.Context, organizationID string, statuses []TenantStatus) (out int, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "count_free_tidbcloud_pool_bindings", start, &err)
 	organizationID = strings.TrimSpace(organizationID)
 	if organizationID == "" {
 		return 0, fmt.Errorf("organization_id is required")
 	}
+	if len(statuses) == 0 {
+		return 0, fmt.Errorf("tenant statuses are required")
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(statuses)), ",")
+	args := make([]any, 0, 2+len(statuses))
+	args = append(args, organizationID, TenantPoolBindingFree)
+	for _, status := range statuses {
+		args = append(args, status)
+	}
 	row := s.db.QueryRowContext(ctx, `SELECT COUNT(*)
 		FROM tenant_tidbcloud_org_bindings b
 		JOIN tenants t ON t.id = b.tenant_id
 		WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = 'tidb_cloud_native'
-			AND t.status IN (?, ?)`,
-		organizationID, TenantPoolBindingFree, TenantProvisioning, TenantActive)
+			AND t.status IN (`+placeholders+`)`, args...)
 	if err = row.Scan(&out); err != nil {
 		return 0, err
 	}
@@ -1453,13 +1469,25 @@ func (s *Store) CountFreeTenantPoolBindings(ctx context.Context, organizationID 
 func (s *Store) ListFreeTenantPoolBindings(ctx context.Context, organizationID string, newestFirst bool, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "list_free_tidbcloud_pool_bindings", start, &err)
-	return s.listFreeTenantPoolBindings(ctx, organizationID, newestFirst, limit, []TenantStatus{TenantProvisioning, TenantActive})
+	return s.listFreeTenantPoolBindings(ctx, organizationID, newestFirst, limit, []TenantStatus{TenantActive})
 }
 
 func (s *Store) ListFreeTenantPoolBindingsForDelete(ctx context.Context, organizationID string, newestFirst bool, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "list_free_tidbcloud_pool_bindings_for_delete", start, &err)
-	return s.listFreeTenantPoolBindings(ctx, organizationID, newestFirst, limit, []TenantStatus{TenantProvisioning, TenantActive, TenantFailed})
+	return s.listFreeTenantPoolBindings(ctx, organizationID, newestFirst, limit, []TenantStatus{TenantPending, TenantProvisioning, TenantActive, TenantFailed})
+}
+
+func (s *Store) ListTenantPoolFreeSlotsForDelete(ctx context.Context, organizationID string, newestFirst bool, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_tidbcloud_pool_free_slots_for_delete", start, &err)
+	return s.listFreeTenantPoolBindings(ctx, organizationID, newestFirst, limit, []TenantStatus{TenantPending, TenantProvisioning, TenantActive})
+}
+
+func (s *Store) ListPendingTenantPoolBindingsForResume(ctx context.Context, organizationID string, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_pending_tidbcloud_pool_bindings_for_resume", start, &err)
+	return s.listFreeTenantPoolBindings(ctx, organizationID, false, limit, []TenantStatus{TenantPending})
 }
 
 func (s *Store) listFreeTenantPoolBindings(ctx context.Context, organizationID string, newestFirst bool, limit int, statuses []TenantStatus) (out []TenantWithTiDBCloudOrgBinding, err error) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -84,6 +84,10 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, "pool_size must be positive")
 		return
 	}
+	if err := s.validateTenantPoolSize(*req.PoolSize); err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	cred, err := adminCredentials(req.PublicKey, req.PrivateKey, r)
 	if err != nil {
 		errJSON(w, http.StatusBadRequest, err.Error())
@@ -195,6 +199,10 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, "pool_size is required")
 		return
 	}
+	if err := s.validateTenantPoolSize(*req.PoolSize); err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	cred, err := adminCredentials(req.PublicKey, req.PrivateKey, r)
 	if err != nil {
 		errJSON(w, http.StatusBadRequest, err.Error())
@@ -259,6 +267,13 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	writeJSON(w, http.StatusAccepted, out)
+}
+
+func (s *Server) validateTenantPoolSize(size int) error {
+	if s.tenantPoolMaxSize > 0 && size > s.tenantPoolMaxSize {
+		return fmt.Errorf("pool_size must be less than or equal to %d", s.tenantPoolMaxSize)
+	}
+	return nil
 }
 
 func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -492,6 +492,9 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 		}
 		results = append(results, res)
 	}
+	// A partial TiDB Cloud response can omit some requested tenant IDs. Those
+	// pending local tenants have no recoverable cluster metadata, so fail them
+	// while preserving tenants that were persisted above.
 	for _, tenantID := range tenantIDs {
 		if _, ok := persistedTenants[tenantID]; ok {
 			continue

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -151,7 +151,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 	for _, res := range results {
 		s.startProvisionedTenantSchemaInit(r.Context(), res)
 	}
-	freeSize := len(results)
+	freeSize := 0
 	if orgID != "" {
 		if n, err := s.meta.CountFreeTenantPoolBindings(r.Context(), orgID); err == nil {
 			freeSize = n
@@ -228,28 +228,36 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		if err != nil {
 			return adminTenantPoolError(http.StatusInternalServerError, "tenant pool free size lookup failed")
 		}
+		slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
+		if err != nil {
+			return adminTenantPoolError(http.StatusInternalServerError, "tenant pool slot size lookup failed")
+		}
 		targetSize := *req.PoolSize
-		if targetSize > freeSize {
-			results, err := s.createFreePoolTenants(ctx, pool.PoolID, targetSize-freeSize, cred, nil)
+		if targetSize > slotSize {
+			results, err := s.createFreePoolTenants(ctx, pool.PoolID, targetSize-slotSize, cred, nil)
 			if err != nil {
 				return adminTenantPoolError(http.StatusBadGateway, fmt.Sprintf("grow tenant pool failed: %v", err))
 			}
 			for _, res := range results {
 				s.startProvisionedTenantSchemaInit(ctx, res)
 			}
-			freeSize += len(results)
-		} else if targetSize < freeSize {
-			if err := s.deleteNewestFreePoolTenants(ctx, pool.OrganizationID, freeSize-targetSize, cred, false); err != nil {
-				if actualFreeSize, countErr := s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID); countErr == nil {
-					if updateErr := s.meta.UpdateTenantPoolSize(ctx, pool.PoolID, actualFreeSize); updateErr != nil {
-						logger.Warn(ctx, "admin_tenant_pool_shrink_partial_size_update_failed", zap.String("pool_id", pool.PoolID), zap.Int("free_size", actualFreeSize), zap.Error(updateErr))
+			if freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID); err != nil {
+				return adminTenantPoolError(http.StatusInternalServerError, "tenant pool free size lookup failed")
+			}
+		} else if targetSize < slotSize {
+			if err := s.deleteNewestFreePoolTenants(ctx, pool.OrganizationID, slotSize-targetSize, cred, false); err != nil {
+				if actualSlotSize, countErr := s.meta.CountTenantPoolFreeSlots(ctx, pool.OrganizationID); countErr == nil {
+					if updateErr := s.meta.UpdateTenantPoolSize(ctx, pool.PoolID, actualSlotSize); updateErr != nil {
+						logger.Warn(ctx, "admin_tenant_pool_shrink_partial_size_update_failed", zap.String("pool_id", pool.PoolID), zap.Int("slot_size", actualSlotSize), zap.Error(updateErr))
 					}
 				} else {
 					logger.Warn(ctx, "admin_tenant_pool_shrink_partial_count_failed", zap.String("pool_id", pool.PoolID), zap.Error(countErr))
 				}
 				return adminTenantPoolError(http.StatusBadGateway, fmt.Sprintf("shrink tenant pool failed: %v", err))
 			}
-			freeSize = targetSize
+			if freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID); err != nil {
+				return adminTenantPoolError(http.StatusInternalServerError, "tenant pool free size lookup failed")
+			}
 		}
 		if err := s.meta.UpdateTenantPoolSize(ctx, pool.PoolID, targetSize); err != nil {
 			return adminTenantPoolError(http.StatusInternalServerError, "failed to update tenant pool")
@@ -412,6 +420,7 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 		}
 	}()
 	results := make([]*provisionTenantResult, 0, len(clusters))
+	pendingResume := make([]*tenant.ClusterInfo, 0, len(clusters))
 	persistedTenants := make(map[string]struct{}, len(clusters))
 	discardedTenants := make(map[string]struct{}, len(clusters))
 	cloudProvider, region := provisioningCloudRegion(s.provisioner)
@@ -465,30 +474,31 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			cleanupOnError = true
 			return nil, err
 		}
-		if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantProvisioning); err != nil {
-			cleanupOnError = true
-			return nil, err
-		}
 		res := &provisionTenantResult{
 			TenantID:       tenantID,
-			Status:         meta.TenantProvisioning,
+			Status:         meta.TenantPending,
 			Provider:       provider,
 			CloudProvider:  cloudProvider,
 			Region:         region,
 			OrganizationID: orgID,
 		}
 		if poolClusterConnectionReady(cluster) {
+			if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantProvisioning); err != nil {
+				cleanupOnError = true
+				return nil, err
+			}
 			if err := s.persistPoolTenantConnection(ctx, cluster, provider); err != nil {
 				cleanupOnError = true
 				return nil, err
 			}
+			res.Status = meta.TenantProvisioning
 			res.TenantDSN = tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true, provider)
 		} else {
 			if err := s.persistPoolTenantProvisionSeed(ctx, cluster, provider); err != nil {
 				cleanupOnError = true
 				return nil, err
 			}
-			s.startPoolClusterMetadataResume(ctx, cluster, cred)
+			pendingResume = append(pendingResume, cluster)
 		}
 		results = append(results, res)
 	}
@@ -509,6 +519,7 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 		return nil, fmt.Errorf("no tenant pool clusters could be persisted")
 	}
 	cleanupOnError = false
+	s.startPoolClustersMetadataResume(ctx, poolID, pendingResume, cred)
 	return results, nil
 }
 
@@ -576,53 +587,119 @@ func poolClusterConnectionReady(cluster *tenant.ClusterInfo) bool {
 		strings.TrimSpace(cluster.DBName) != ""
 }
 
-func (s *Server) startPoolClusterMetadataResume(ctx context.Context, cluster *tenant.ClusterInfo, cred tenant.CredentialProvisionRequest) {
-	waiter, ok := s.provisioner.(tenant.TenantPoolClusterMetadataWaiter)
-	if !ok {
-		logger.Warn(ctx, "admin_tenant_pool_metadata_resume_skipped",
-			zap.String("tenant_id", cluster.TenantID),
-			zap.String("cluster_id", cluster.ClusterID),
-			zap.String("reason", "metadata_waiter_unavailable"))
+func (s *Server) startPoolClustersMetadataResume(ctx context.Context, poolID string, clusters []*tenant.ClusterInfo, cred tenant.CredentialProvisionRequest) {
+	clusters = compactPoolResumeClusters(clusters)
+	if len(clusters) == 0 {
 		return
 	}
-	clusterCopy := *cluster
+	if poolID != "" {
+		if _, loaded := s.tenantPoolResumeJobs.LoadOrStore(poolID, struct{}{}); loaded {
+			logger.Info(ctx, "admin_tenant_pool_metadata_resume_skipped",
+				zap.String("pool_id", poolID),
+				zap.String("reason", "metadata_resume_already_running"),
+				zap.Int("cluster_count", len(clusters)))
+			return
+		}
+	}
+	clusterCopies := make([]*tenant.ClusterInfo, 0, len(clusters))
+	for _, cluster := range clusters {
+		copy := *cluster
+		clusterCopies = append(clusterCopies, &copy)
+	}
 	s.startServerWorker(ctx, func(workerCtx context.Context) {
+		if poolID != "" {
+			defer s.tenantPoolResumeJobs.Delete(poolID)
+		}
 		workerCtx, cancel := context.WithTimeout(workerCtx, 10*time.Minute)
 		defer cancel()
 
 		started := time.Now()
-		updated, err := waiter.WaitForPoolClusterMetadata(workerCtx, &clusterCopy, cred)
+		updated, err := s.waitForPoolClustersMetadata(workerCtx, clusterCopies, cred)
 		if err != nil {
-			logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_failed",
-				zap.String("tenant_id", clusterCopy.TenantID),
-				zap.String("cluster_id", clusterCopy.ClusterID),
+			logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_batch_failed",
+				zap.String("pool_id", poolID),
+				zap.Int("cluster_count", len(clusterCopies)),
 				zap.Error(err))
-			return
 		}
-		if !poolClusterConnectionReady(updated) {
-			logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_incomplete",
-				zap.String("tenant_id", clusterCopy.TenantID),
-				zap.String("cluster_id", clusterCopy.ClusterID))
-			return
+		for _, cluster := range updated {
+			s.completePoolClusterMetadataResume(workerCtx, started, cluster)
 		}
-		if err := s.persistPoolTenantConnection(workerCtx, updated, tenant.ProviderTiDBCloudNative); err != nil {
-			logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_persist_failed",
+	})
+}
+
+func compactPoolResumeClusters(clusters []*tenant.ClusterInfo) []*tenant.ClusterInfo {
+	out := clusters[:0]
+	for _, cluster := range clusters {
+		if cluster == nil || strings.TrimSpace(cluster.TenantID) == "" || strings.TrimSpace(cluster.ClusterID) == "" {
+			continue
+		}
+		out = append(out, cluster)
+	}
+	return out
+}
+
+func (s *Server) waitForPoolClustersMetadata(ctx context.Context, clusters []*tenant.ClusterInfo, cred tenant.CredentialProvisionRequest) ([]*tenant.ClusterInfo, error) {
+	if batchWaiter, ok := s.provisioner.(tenant.TenantPoolClusterMetadataBatchWaiter); ok {
+		return batchWaiter.WaitForPoolClustersMetadata(ctx, clusters, cred)
+	}
+	waiter, ok := s.provisioner.(tenant.TenantPoolClusterMetadataWaiter)
+	if !ok {
+		return nil, fmt.Errorf("metadata waiter unavailable")
+	}
+	updated := make([]*tenant.ClusterInfo, 0, len(clusters))
+	var errs []error
+	for _, cluster := range clusters {
+		got, err := waiter.WaitForPoolClusterMetadata(ctx, cluster, cred)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("tenant %s cluster %s: %w", cluster.TenantID, cluster.ClusterID, err))
+			continue
+		}
+		updated = append(updated, got)
+	}
+	return updated, errors.Join(errs...)
+}
+
+func (s *Server) completePoolClusterMetadataResume(ctx context.Context, started time.Time, updated *tenant.ClusterInfo) {
+	if !poolClusterConnectionReady(updated) {
+		if updated != nil {
+			logger.Warn(ctx, "admin_tenant_pool_metadata_resume_incomplete",
 				zap.String("tenant_id", updated.TenantID),
-				zap.String("cluster_id", updated.ClusterID),
-				zap.Error(err))
-			return
+				zap.String("cluster_id", updated.ClusterID))
 		}
-		cloudProvider, region := provisioningCloudRegion(s.provisioner)
-		logProvisionStage(workerCtx, "admin_tenant_pool_metadata_resume_done", updated.TenantID, tenant.ProviderTiDBCloudNative, started, "cluster_id", updated.ClusterID, "organization_id", updated.OrganizationID)
-		s.startProvisionedTenantSchemaInit(workerCtx, &provisionTenantResult{
-			TenantID:       updated.TenantID,
-			Status:         meta.TenantProvisioning,
-			Provider:       tenant.ProviderTiDBCloudNative,
-			TenantDSN:      tenantDSN(updated.Username, updated.Password, updated.Host, updated.Port, updated.DBName, true, tenant.ProviderTiDBCloudNative),
-			CloudProvider:  cloudProvider,
-			Region:         region,
-			OrganizationID: strings.TrimSpace(updated.OrganizationID),
-		})
+		return
+	}
+	if err := s.persistPoolTenantConnection(ctx, updated, tenant.ProviderTiDBCloudNative); err != nil {
+		logger.Warn(ctx, "admin_tenant_pool_metadata_resume_persist_failed",
+			zap.String("tenant_id", updated.TenantID),
+			zap.String("cluster_id", updated.ClusterID),
+			zap.Error(err))
+		return
+	}
+	statusUpdated, err := s.meta.UpdateTenantStatusIf(ctx, updated.TenantID, meta.TenantPending, meta.TenantProvisioning)
+	if err != nil {
+		logger.Warn(ctx, "admin_tenant_pool_metadata_resume_status_failed",
+			zap.String("tenant_id", updated.TenantID),
+			zap.String("cluster_id", updated.ClusterID),
+			zap.Error(err))
+		return
+	}
+	if !statusUpdated {
+		logger.Info(ctx, "admin_tenant_pool_metadata_resume_status_skipped",
+			zap.String("tenant_id", updated.TenantID),
+			zap.String("cluster_id", updated.ClusterID),
+			zap.String("reason", "status_changed"))
+		return
+	}
+	cloudProvider, region := provisioningCloudRegion(s.provisioner)
+	logProvisionStage(ctx, "admin_tenant_pool_metadata_resume_done", updated.TenantID, tenant.ProviderTiDBCloudNative, started, "cluster_id", updated.ClusterID, "organization_id", updated.OrganizationID)
+	s.startProvisionedTenantSchemaInit(ctx, &provisionTenantResult{
+		TenantID:       updated.TenantID,
+		Status:         meta.TenantProvisioning,
+		Provider:       tenant.ProviderTiDBCloudNative,
+		TenantDSN:      tenantDSN(updated.Username, updated.Password, updated.Host, updated.Port, updated.DBName, true, tenant.ProviderTiDBCloudNative),
+		CloudProvider:  cloudProvider,
+		Region:         region,
+		OrganizationID: strings.TrimSpace(updated.OrganizationID),
 	})
 }
 
@@ -728,7 +805,7 @@ func (s *Server) deleteNewestFreePoolTenants(ctx context.Context, organizationID
 		if deleteAll {
 			rows, err = s.meta.ListFreeTenantPoolBindingsForDelete(ctx, organizationID, true, limit)
 		} else {
-			rows, err = s.meta.ListFreeTenantPoolBindings(ctx, organizationID, true, limit)
+			rows, err = s.meta.ListTenantPoolFreeSlotsForDelete(ctx, organizationID, true, limit)
 		}
 		if err != nil {
 			return err
@@ -836,12 +913,12 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
 				return nil
 			}
-			freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
+			slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
 				return nil
 			}
-			missing := current.Size - freeSize
+			missing := current.Size - slotSize
 			if missing <= 0 {
 				return nil
 			}
@@ -857,6 +934,35 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 		}); err != nil {
 			logger.Warn(ctx, "admin_tenant_pool_replenish_lock_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
 		}
+	})
+}
+
+func (s *Server) resumePendingTenantPoolAsync(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {
+	if pool == nil || pool.OrganizationID == "" || pool.PoolID == "" {
+		return
+	}
+	workerCtx := backgroundWithTrace(ctx)
+	s.startServerWorker(workerCtx, func(ctx context.Context) {
+		rows, err := s.meta.ListPendingTenantPoolBindingsForResume(ctx, pool.OrganizationID, pool.Size)
+		if err != nil {
+			logger.Warn(ctx, "admin_tenant_pool_pending_resume_list_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
+			return
+		}
+		clusters := make([]*tenant.ClusterInfo, 0, len(rows))
+		for _, row := range rows {
+			plainPass, err := s.pool.Decrypt(ctx, row.Tenant.DBPasswordCipher)
+			if err != nil || strings.TrimSpace(string(plainPass)) == "" {
+				logger.Warn(ctx, "admin_tenant_pool_pending_resume_password_failed",
+					zap.String("tenant_id", row.Tenant.ID),
+					zap.String("pool_id", pool.PoolID),
+					zap.Error(err))
+				continue
+			}
+			cluster := clusterInfoFromTenant(&row.Tenant)
+			cluster.Password = string(plainPass)
+			clusters = append(clusters, cluster)
+		}
+		s.startPoolClustersMetadataResume(ctx, pool.PoolID, clusters, cred)
 	})
 }
 
@@ -911,6 +1017,7 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "reason", "pool_inactive", "pool_status", pool.Status, "duration_ms", durationMillis(claimStarted))...)
 		return nil, nil, false, nil
 	}
+	s.resumePendingTenantPoolAsync(ctx, pool, cred)
 	stageStarted = time.Now()
 	row, err := s.meta.ClaimOldestFreeTenantPoolBinding(ctx, orgID)
 	if err != nil {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -409,23 +409,46 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 	}()
 	results := make([]*provisionTenantResult, 0, len(clusters))
 	persistedTenants := make(map[string]struct{}, len(clusters))
+	discardedTenants := make(map[string]struct{}, len(clusters))
 	cloudProvider, region := provisioningCloudRegion(s.provisioner)
+	poolOrgID := ""
 	for _, cluster := range clusters {
 		if cluster == nil {
 			continue
 		}
-		if strings.TrimSpace(cluster.TenantID) == "" {
+		tenantID := strings.TrimSpace(cluster.TenantID)
+		if tenantID == "" {
 			cleanupOnError = true
 			return nil, fmt.Errorf("tidbcloud tenant id label is missing")
 		}
-		if strings.TrimSpace(cluster.OrganizationID) == "" {
-			cleanupOnError = true
-			return nil, fmt.Errorf("tidbcloud organization label is missing")
+		orgID := strings.TrimSpace(cluster.OrganizationID)
+		if orgID == "" {
+			if poolOrgID == "" {
+				pool, lookupErr := s.meta.GetTenantPoolByID(ctx, poolID)
+				if lookupErr != nil && !errors.Is(lookupErr, meta.ErrNotFound) {
+					cleanupOnError = true
+					return nil, lookupErr
+				}
+				if pool != nil {
+					poolOrgID = strings.TrimSpace(pool.OrganizationID)
+				}
+			}
+			orgID = poolOrgID
 		}
-		persistedTenants[strings.TrimSpace(cluster.TenantID)] = struct{}{}
+		if orgID == "" {
+			logger.Warn(ctx, "admin_tenant_pool_cluster_org_missing",
+				zap.String("pool_id", poolID),
+				zap.String("tenant_id", tenantID),
+				zap.String("cluster_id", cluster.ClusterID))
+			s.cleanupPoolProvisionedClusters(ctx, []*tenant.ClusterInfo{cluster}, cred, []string{tenantID}, "cluster_org_missing")
+			discardedTenants[tenantID] = struct{}{}
+			continue
+		}
+		cluster.OrganizationID = orgID
+		persistedTenants[tenantID] = struct{}{}
 		if err := s.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
-			TenantID:       cluster.TenantID,
-			OrganizationID: cluster.OrganizationID,
+			TenantID:       tenantID,
+			OrganizationID: orgID,
 			ClusterID:      cluster.ClusterID,
 			PoolID:         poolID,
 			PoolStatus:     meta.TenantPoolBindingFree,
@@ -439,17 +462,17 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			cleanupOnError = true
 			return nil, err
 		}
-		if err := s.meta.UpdateTenantStatus(ctx, cluster.TenantID, meta.TenantProvisioning); err != nil {
+		if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantProvisioning); err != nil {
 			cleanupOnError = true
 			return nil, err
 		}
 		res := &provisionTenantResult{
-			TenantID:       cluster.TenantID,
+			TenantID:       tenantID,
 			Status:         meta.TenantProvisioning,
 			Provider:       provider,
 			CloudProvider:  cloudProvider,
 			Region:         region,
-			OrganizationID: strings.TrimSpace(cluster.OrganizationID),
+			OrganizationID: orgID,
 		}
 		if poolClusterConnectionReady(cluster) {
 			res.TenantDSN = tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true, provider)
@@ -462,7 +485,14 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 		if _, ok := persistedTenants[tenantID]; ok {
 			continue
 		}
+		if _, ok := discardedTenants[tenantID]; ok {
+			continue
+		}
 		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+	}
+	if len(clusters) > 0 && len(results) == 0 {
+		cleanupOnError = false
+		return nil, fmt.Errorf("no tenant pool clusters could be persisted")
 	}
 	cleanupOnError = false
 	return results, nil

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -283,7 +283,7 @@ func (s *Server) validateTenantPoolSize(size int) error {
 		maxSize = DefaultTenantPoolMaxSize
 	}
 	if size > maxSize {
-		return fmt.Errorf("pool_size must be less than or equal to %d", maxSize)
+		return fmt.Errorf("pool_size %d exceeds maximum %d", size, maxSize)
 	}
 	return nil
 }

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -101,74 +101,80 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 	createLock := s.tenantPoolCreateLock(cred)
 	createLock.Lock()
 	defer createLock.Unlock()
-	orgID, err := s.firstManagedOrganization(r.Context(), cred)
-	if err != nil {
-		writeAdminTiDBCloudError(w, r.Context(), err, "create tenant pool")
-		return
-	}
-	if orgID != "" {
-		if _, err := s.meta.GetTenantPoolByOrganization(r.Context(), orgID); err == nil {
-			errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
-			return
-		} else if !errors.Is(err, meta.ErrNotFound) {
-			errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
-			return
+	if err := s.meta.WithTenantPoolLock(r.Context(), tenantPoolCreateDatabaseLockKey(cred), func(ctx context.Context) error {
+		orgID, err := s.firstManagedOrganization(ctx, cred)
+		if err != nil {
+			writeAdminTiDBCloudError(w, ctx, err, "create tenant pool")
+			return nil
 		}
-	}
-	poolID := token.NewID()
-	now := time.Now().UTC()
-	if err := s.meta.CreateTenantPool(r.Context(), &meta.TenantPool{
-		PoolID:         poolID,
-		OrganizationID: orgID,
-		Size:           *req.PoolSize,
-		Status:         meta.TenantPoolActive,
-		CreatedAt:      now,
-		UpdatedAt:      now,
-	}); err != nil {
-		if errors.Is(err, meta.ErrDuplicate) {
-			errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
-			return
-		}
-		errJSON(w, http.StatusInternalServerError, "failed to persist tenant pool")
-		return
-	}
-	results, err := s.createFreePoolTenants(r.Context(), poolID, *req.PoolSize, cred, nil)
-	if err != nil {
-		s.deleteTenantPoolMetadata(r.Context(), poolID, "create_free_tenants_error")
-		errJSON(w, http.StatusBadGateway, fmt.Sprintf("create tenant pool failed: %v", err))
-		return
-	}
-	if orgID == "" {
-		orgID = firstResultOrganizationID(results)
 		if orgID != "" {
-			if err := s.meta.UpdateTenantPoolOrganization(r.Context(), poolID, orgID); err != nil {
-				s.cleanupCreatedPoolTenants(r.Context(), results, cred, "update_pool_org_error")
-				s.deleteTenantPoolMetadata(r.Context(), poolID, "update_pool_org_error")
-				if errors.Is(err, meta.ErrDuplicate) {
-					errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
-					return
-				}
-				errJSON(w, http.StatusInternalServerError, "failed to update tenant pool organization")
-				return
+			if _, err := s.meta.GetTenantPoolByOrganization(ctx, orgID); err == nil {
+				errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
+				return nil
+			} else if !errors.Is(err, meta.ErrNotFound) {
+				errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
+				return nil
 			}
 		}
-	}
-	for _, res := range results {
-		s.startProvisionedTenantSchemaInit(r.Context(), res)
-	}
-	freeSize := 0
-	if orgID != "" {
-		if n, err := s.meta.CountFreeTenantPoolBindings(r.Context(), orgID); err == nil {
-			freeSize = n
+		poolID := token.NewID()
+		now := time.Now().UTC()
+		if err := s.meta.CreateTenantPool(ctx, &meta.TenantPool{
+			PoolID:         poolID,
+			OrganizationID: orgID,
+			Size:           *req.PoolSize,
+			Status:         meta.TenantPoolActive,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}); err != nil {
+			if errors.Is(err, meta.ErrDuplicate) {
+				errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
+				return nil
+			}
+			errJSON(w, http.StatusInternalServerError, "failed to persist tenant pool")
+			return nil
 		}
+		results, err := s.createFreePoolTenants(ctx, poolID, *req.PoolSize, cred, nil)
+		if err != nil {
+			s.deleteTenantPoolMetadata(ctx, poolID, "create_free_tenants_error")
+			errJSON(w, http.StatusBadGateway, fmt.Sprintf("create tenant pool failed: %v", err))
+			return nil
+		}
+		if orgID == "" {
+			orgID = firstResultOrganizationID(results)
+			if orgID != "" {
+				if err := s.meta.UpdateTenantPoolOrganization(ctx, poolID, orgID); err != nil {
+					s.cleanupCreatedPoolTenants(ctx, results, cred, "update_pool_org_error")
+					s.deleteTenantPoolMetadata(ctx, poolID, "update_pool_org_error")
+					if errors.Is(err, meta.ErrDuplicate) {
+						errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
+						return nil
+					}
+					errJSON(w, http.StatusInternalServerError, "failed to update tenant pool organization")
+					return nil
+				}
+			}
+		}
+		for _, res := range results {
+			s.startProvisionedTenantSchemaInit(ctx, res)
+		}
+		freeSize := 0
+		if orgID != "" {
+			if n, err := s.meta.CountFreeTenantPoolBindings(ctx, orgID); err == nil {
+				freeSize = n
+			}
+		}
+		writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
+			PoolID:         poolID,
+			OrganizationID: orgID,
+			PoolSize:       *req.PoolSize,
+			FreeSize:       freeSize,
+			Status:         string(meta.TenantPoolActive),
+		})
+		return nil
+	}); err != nil {
+		writeAdminTenantPoolError(w, err)
+		return
 	}
-	writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
-		PoolID:         poolID,
-		OrganizationID: orgID,
-		PoolSize:       *req.PoolSize,
-		FreeSize:       freeSize,
-		Status:         string(meta.TenantPoolActive),
-	})
 }
 
 func (s *Server) handleAdminTenantPoolGet(w http.ResponseWriter, r *http.Request) {
@@ -1040,6 +1046,14 @@ func (s *Server) tenantPoolCreateLock(cred tenant.CredentialProvisionRequest) *s
 	// first-create path before the org id is discoverable from managed clusters.
 	v, _ := s.tenantPoolCreateLocks.LoadOrStore(key, &sync.Mutex{})
 	return v.(*sync.Mutex)
+}
+
+func tenantPoolCreateDatabaseLockKey(cred tenant.CredentialProvisionRequest) string {
+	key := strings.TrimSpace(cred.PublicKey)
+	if key == "" {
+		return ""
+	}
+	return "create:" + key
 }
 
 func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) (*provisionTenantResult, *meta.TenantPool, bool, error) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -270,8 +270,12 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 }
 
 func (s *Server) validateTenantPoolSize(size int) error {
-	if s.tenantPoolMaxSize > 0 && size > s.tenantPoolMaxSize {
-		return fmt.Errorf("pool_size must be less than or equal to %d", s.tenantPoolMaxSize)
+	maxSize := s.tenantPoolMaxSize
+	if maxSize <= 0 {
+		maxSize = DefaultTenantPoolMaxSize
+	}
+	if size > maxSize {
+		return fmt.Errorf("pool_size must be less than or equal to %d", maxSize)
 	}
 	return nil
 }
@@ -580,6 +584,9 @@ func (s *Server) startPoolClusterMetadataResume(ctx context.Context, cluster *te
 	}
 	clusterCopy := *cluster
 	s.startServerWorker(ctx, func(workerCtx context.Context) {
+		workerCtx, cancel := context.WithTimeout(workerCtx, 10*time.Minute)
+		defer cancel()
+
 		started := time.Now()
 		updated, err := waiter.WaitForPoolClusterMetadata(workerCtx, &clusterCopy, cred)
 		if err != nil {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"go.uber.org/zap"
@@ -34,6 +35,10 @@ type adminTenantPoolResponse struct {
 type adminTenantPoolHTTPError struct {
 	status  int
 	message string
+}
+
+type tenantPoolResumeJob struct {
+	rerun atomic.Bool
 }
 
 func (e *adminTenantPoolHTTPError) Error() string {
@@ -403,7 +408,7 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 	if err != nil && len(clusters) == 0 {
 		s.cleanupPoolProvisionedClusters(ctx, clusters, cred, tenantIDs, "batch_provision_error")
 		for _, tenantID := range tenantIDs {
-			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			s.markTenantPoolTenantFailed(ctx, tenantID, "batch_provision_error")
 		}
 		return nil, err
 	}
@@ -483,11 +488,11 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			OrganizationID: orgID,
 		}
 		if poolClusterConnectionReady(cluster) {
-			if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantProvisioning); err != nil {
+			if err := s.persistPoolTenantConnection(ctx, cluster, provider); err != nil {
 				cleanupOnError = true
 				return nil, err
 			}
-			if err := s.persistPoolTenantConnection(ctx, cluster, provider); err != nil {
+			if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantProvisioning); err != nil {
 				cleanupOnError = true
 				return nil, err
 			}
@@ -512,7 +517,7 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 		if _, ok := discardedTenants[tenantID]; ok {
 			continue
 		}
-		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+		s.markTenantPoolTenantFailed(ctx, tenantID, "missing_cluster_response")
 	}
 	if len(clusters) > 0 && len(results) == 0 {
 		cleanupOnError = false
@@ -521,6 +526,19 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 	cleanupOnError = false
 	s.startPoolClustersMetadataResume(ctx, poolID, pendingResume, cred)
 	return results, nil
+}
+
+func (s *Server) markTenantPoolTenantFailed(ctx context.Context, tenantID, reason string) {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return
+	}
+	if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantFailed); err != nil {
+		logger.Warn(ctx, "admin_tenant_pool_mark_failed_failed",
+			zap.String("tenant_id", tenantID),
+			zap.String("reason", reason),
+			zap.Error(err))
+	}
 }
 
 func (s *Server) persistPoolTenantProvisionSeed(ctx context.Context, cluster *tenant.ClusterInfo, provider string) error {
@@ -592,11 +610,16 @@ func (s *Server) startPoolClustersMetadataResume(ctx context.Context, poolID str
 	if len(clusters) == 0 {
 		return
 	}
+	job := &tenantPoolResumeJob{}
 	if poolID != "" {
-		if _, loaded := s.tenantPoolResumeJobs.LoadOrStore(poolID, struct{}{}); loaded {
+		actual, loaded := s.tenantPoolResumeJobs.LoadOrStore(poolID, job)
+		if loaded {
+			if existing, ok := actual.(*tenantPoolResumeJob); ok {
+				existing.rerun.Store(true)
+			}
 			logger.Info(ctx, "admin_tenant_pool_metadata_resume_skipped",
 				zap.String("pool_id", poolID),
-				zap.String("reason", "metadata_resume_already_running"),
+				zap.String("reason", "metadata_resume_already_running_rerun_requested"),
 				zap.Int("cluster_count", len(clusters)))
 			return
 		}
@@ -613,16 +636,32 @@ func (s *Server) startPoolClustersMetadataResume(ctx context.Context, poolID str
 		workerCtx, cancel := context.WithTimeout(workerCtx, 10*time.Minute)
 		defer cancel()
 
-		started := time.Now()
-		updated, err := s.waitForPoolClustersMetadata(workerCtx, clusterCopies, cred)
-		if err != nil {
-			logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_batch_failed",
-				zap.String("pool_id", poolID),
-				zap.Int("cluster_count", len(clusterCopies)),
-				zap.Error(err))
-		}
-		for _, cluster := range updated {
-			s.completePoolClusterMetadataResume(workerCtx, started, cluster)
+		for {
+			started := time.Now()
+			updated, err := s.waitForPoolClustersMetadata(workerCtx, clusterCopies, cred)
+			if err != nil {
+				logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_batch_failed",
+					zap.String("pool_id", poolID),
+					zap.Int("cluster_count", len(clusterCopies)),
+					zap.Error(err))
+			}
+			for _, cluster := range updated {
+				s.completePoolClusterMetadataResume(workerCtx, started, cluster)
+			}
+			if poolID == "" || !job.rerun.Swap(false) {
+				return
+			}
+			next, err := s.pendingTenantPoolResumeClusters(workerCtx, poolID, len(clusterCopies))
+			if err != nil {
+				logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_rerun_list_failed",
+					zap.String("pool_id", poolID),
+					zap.Error(err))
+				return
+			}
+			clusterCopies = next
+			if len(clusterCopies) == 0 {
+				return
+			}
 		}
 	})
 }
@@ -943,27 +982,45 @@ func (s *Server) resumePendingTenantPoolAsync(ctx context.Context, pool *meta.Te
 	}
 	workerCtx := backgroundWithTrace(ctx)
 	s.startServerWorker(workerCtx, func(ctx context.Context) {
-		rows, err := s.meta.ListPendingTenantPoolBindingsForResume(ctx, pool.OrganizationID, pool.Size)
+		clusters, err := s.pendingTenantPoolResumeClusters(ctx, pool.PoolID, pool.Size)
 		if err != nil {
 			logger.Warn(ctx, "admin_tenant_pool_pending_resume_list_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
 			return
 		}
-		clusters := make([]*tenant.ClusterInfo, 0, len(rows))
-		for _, row := range rows {
-			plainPass, err := s.pool.Decrypt(ctx, row.Tenant.DBPasswordCipher)
-			if err != nil || strings.TrimSpace(string(plainPass)) == "" {
-				logger.Warn(ctx, "admin_tenant_pool_pending_resume_password_failed",
-					zap.String("tenant_id", row.Tenant.ID),
-					zap.String("pool_id", pool.PoolID),
-					zap.Error(err))
-				continue
-			}
-			cluster := clusterInfoFromTenant(&row.Tenant)
-			cluster.Password = string(plainPass)
-			clusters = append(clusters, cluster)
-		}
 		s.startPoolClustersMetadataResume(ctx, pool.PoolID, clusters, cred)
 	})
+}
+
+func (s *Server) pendingTenantPoolResumeClusters(ctx context.Context, poolID string, limit int) ([]*tenant.ClusterInfo, error) {
+	pool, err := s.meta.GetTenantPoolByID(ctx, poolID)
+	if err != nil {
+		return nil, err
+	}
+	if pool.OrganizationID == "" || pool.Status != meta.TenantPoolActive {
+		return []*tenant.ClusterInfo{}, nil
+	}
+	if limit <= 0 || limit < pool.Size {
+		limit = pool.Size
+	}
+	rows, err := s.meta.ListPendingTenantPoolBindingsForResume(ctx, pool.OrganizationID, limit)
+	if err != nil {
+		return nil, err
+	}
+	clusters := make([]*tenant.ClusterInfo, 0, len(rows))
+	for _, row := range rows {
+		plainPass, err := s.pool.Decrypt(ctx, row.Tenant.DBPasswordCipher)
+		if err != nil || strings.TrimSpace(string(plainPass)) == "" {
+			logger.Warn(ctx, "admin_tenant_pool_pending_resume_password_failed",
+				zap.String("tenant_id", row.Tenant.ID),
+				zap.String("pool_id", pool.PoolID),
+				zap.Error(err))
+			continue
+		}
+		cluster := clusterInfoFromTenant(&row.Tenant)
+		cluster.Password = string(plainPass)
+		clusters = append(clusters, cluster)
+	}
+	return clusters, nil
 }
 
 func (s *Server) tenantPoolLock(poolID string) *sync.Mutex {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -386,29 +386,41 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 	if quotaOpt != nil {
 		opts.TiDBCloudSpendingLimitMonthly = quotaOpt.TiDBCloudSpendingLimit
 	}
+	opts.TenantPoolID = poolID
 	clusters, _, err := manager.BatchProvisionFreeClustersWithCredentialsAndQuota(ctx, tenantIDs, cred, opts)
-	if err != nil {
+	if err != nil && len(clusters) == 0 {
 		s.cleanupPoolProvisionedClusters(ctx, clusters, cred, tenantIDs, "batch_provision_error")
 		for _, tenantID := range tenantIDs {
 			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 		}
 		return nil, err
 	}
-	cleanupOnError := true
+	if err != nil {
+		logger.Warn(ctx, "admin_tenant_pool_batch_metadata_incomplete",
+			zap.String("pool_id", poolID),
+			zap.Int("cluster_count", len(clusters)),
+			zap.Error(err))
+	}
+	cleanupOnError := err == nil
 	defer func() {
 		if cleanupOnError {
 			s.cleanupPoolProvisionedClusters(ctx, clusters, cred, tenantIDs, "metadata_error")
 		}
 	}()
 	results := make([]*provisionTenantResult, 0, len(clusters))
+	persistedTenants := make(map[string]struct{}, len(clusters))
 	cloudProvider, region := provisioningCloudRegion(s.provisioner)
 	for _, cluster := range clusters {
 		if cluster == nil {
 			continue
 		}
+		if strings.TrimSpace(cluster.TenantID) == "" {
+			return nil, fmt.Errorf("tidbcloud tenant id label is missing")
+		}
 		if strings.TrimSpace(cluster.OrganizationID) == "" {
 			return nil, fmt.Errorf("tidbcloud organization label is missing")
 		}
+		persistedTenants[strings.TrimSpace(cluster.TenantID)] = struct{}{}
 		if err := s.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
 			TenantID:       cluster.TenantID,
 			OrganizationID: cluster.OrganizationID,
@@ -420,37 +432,114 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 		}); err != nil {
 			return nil, err
 		}
-		cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
-		if err != nil {
-			return nil, err
-		}
-		if err := s.meta.UpdateTenantConnection(ctx, cluster.TenantID, &meta.Tenant{
-			DBHost:           cluster.Host,
-			DBPort:           cluster.Port,
-			DBUser:           cluster.Username,
-			DBPasswordCipher: cipherPass,
-			DBName:           cluster.DBName,
-			DBTLS:            true,
-			Provider:         provider,
-			ClusterID:        cluster.ClusterID,
-		}); err != nil {
+		if err := s.persistPoolTenantConnection(ctx, cluster, provider); err != nil {
 			return nil, err
 		}
 		if err := s.meta.UpdateTenantStatus(ctx, cluster.TenantID, meta.TenantProvisioning); err != nil {
 			return nil, err
 		}
-		results = append(results, &provisionTenantResult{
+		res := &provisionTenantResult{
 			TenantID:       cluster.TenantID,
 			Status:         meta.TenantProvisioning,
 			Provider:       provider,
-			TenantDSN:      tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true, provider),
 			CloudProvider:  cloudProvider,
 			Region:         region,
 			OrganizationID: strings.TrimSpace(cluster.OrganizationID),
-		})
+		}
+		if poolClusterConnectionReady(cluster) {
+			res.TenantDSN = tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true, provider)
+		} else {
+			s.startPoolClusterMetadataResume(ctx, cluster, cred)
+		}
+		results = append(results, res)
+	}
+	for _, tenantID := range tenantIDs {
+		if _, ok := persistedTenants[tenantID]; ok {
+			continue
+		}
+		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 	}
 	cleanupOnError = false
 	return results, nil
+}
+
+func (s *Server) persistPoolTenantConnection(ctx context.Context, cluster *tenant.ClusterInfo, provider string) error {
+	if cluster == nil {
+		return fmt.Errorf("cluster info is required")
+	}
+	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
+	if err != nil {
+		return err
+	}
+	return s.meta.UpdateTenantConnection(ctx, cluster.TenantID, &meta.Tenant{
+		DBHost:           cluster.Host,
+		DBPort:           cluster.Port,
+		DBUser:           cluster.Username,
+		DBPasswordCipher: cipherPass,
+		DBName:           cluster.DBName,
+		DBTLS:            true,
+		Provider:         provider,
+		ClusterID:        cluster.ClusterID,
+	})
+}
+
+func poolClusterConnectionReady(cluster *tenant.ClusterInfo) bool {
+	return cluster != nil &&
+		strings.TrimSpace(cluster.TenantID) != "" &&
+		strings.TrimSpace(cluster.ClusterID) != "" &&
+		strings.TrimSpace(cluster.OrganizationID) != "" &&
+		strings.TrimSpace(cluster.Host) != "" &&
+		cluster.Port > 0 &&
+		strings.TrimSpace(cluster.Username) != "" &&
+		strings.TrimSpace(cluster.Password) != "" &&
+		strings.TrimSpace(cluster.DBName) != ""
+}
+
+func (s *Server) startPoolClusterMetadataResume(ctx context.Context, cluster *tenant.ClusterInfo, cred tenant.CredentialProvisionRequest) {
+	waiter, ok := s.provisioner.(tenant.TenantPoolClusterMetadataWaiter)
+	if !ok {
+		logger.Warn(ctx, "admin_tenant_pool_metadata_resume_skipped",
+			zap.String("tenant_id", cluster.TenantID),
+			zap.String("cluster_id", cluster.ClusterID),
+			zap.String("reason", "metadata_waiter_unavailable"))
+		return
+	}
+	clusterCopy := *cluster
+	s.startServerWorker(ctx, func(workerCtx context.Context) {
+		started := time.Now()
+		updated, err := waiter.WaitForPoolClusterMetadata(workerCtx, &clusterCopy, cred)
+		if err != nil {
+			logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_failed",
+				zap.String("tenant_id", clusterCopy.TenantID),
+				zap.String("cluster_id", clusterCopy.ClusterID),
+				zap.Error(err))
+			return
+		}
+		if !poolClusterConnectionReady(updated) {
+			logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_incomplete",
+				zap.String("tenant_id", clusterCopy.TenantID),
+				zap.String("cluster_id", clusterCopy.ClusterID))
+			return
+		}
+		if err := s.persistPoolTenantConnection(workerCtx, updated, tenant.ProviderTiDBCloudNative); err != nil {
+			logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_persist_failed",
+				zap.String("tenant_id", updated.TenantID),
+				zap.String("cluster_id", updated.ClusterID),
+				zap.Error(err))
+			return
+		}
+		cloudProvider, region := provisioningCloudRegion(s.provisioner)
+		logProvisionStage(workerCtx, "admin_tenant_pool_metadata_resume_done", updated.TenantID, tenant.ProviderTiDBCloudNative, started, "cluster_id", updated.ClusterID, "organization_id", updated.OrganizationID)
+		s.startProvisionedTenantSchemaInit(workerCtx, &provisionTenantResult{
+			TenantID:       updated.TenantID,
+			Status:         meta.TenantProvisioning,
+			Provider:       tenant.ProviderTiDBCloudNative,
+			TenantDSN:      tenantDSN(updated.Username, updated.Password, updated.Host, updated.Port, updated.DBName, true, tenant.ProviderTiDBCloudNative),
+			CloudProvider:  cloudProvider,
+			Region:         region,
+			OrganizationID: strings.TrimSpace(updated.OrganizationID),
+		})
+	})
 }
 
 func (s *Server) cleanupPoolProvisionedClusters(ctx context.Context, clusters []*tenant.ClusterInfo, cred tenant.CredentialProvisionRequest, tenantIDs []string, reason string) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -418,8 +418,11 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 		}
 		tenantID := strings.TrimSpace(cluster.TenantID)
 		if tenantID == "" {
-			cleanupOnError = true
-			return nil, fmt.Errorf("tidbcloud tenant id label is missing")
+			logger.Warn(ctx, "admin_tenant_pool_cluster_tenant_missing",
+				zap.String("pool_id", poolID),
+				zap.String("cluster_id", cluster.ClusterID))
+			s.cleanupPoolProvisionedClusters(ctx, []*tenant.ClusterInfo{cluster}, cred, nil, "cluster_tenant_missing")
+			continue
 		}
 		orgID := strings.TrimSpace(cluster.OrganizationID)
 		if orgID == "" {
@@ -458,10 +461,6 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			cleanupOnError = true
 			return nil, err
 		}
-		if err := s.persistPoolTenantConnection(ctx, cluster, provider); err != nil {
-			cleanupOnError = true
-			return nil, err
-		}
 		if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantProvisioning); err != nil {
 			cleanupOnError = true
 			return nil, err
@@ -475,8 +474,16 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			OrganizationID: orgID,
 		}
 		if poolClusterConnectionReady(cluster) {
+			if err := s.persistPoolTenantConnection(ctx, cluster, provider); err != nil {
+				cleanupOnError = true
+				return nil, err
+			}
 			res.TenantDSN = tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true, provider)
 		} else {
+			if err := s.persistPoolTenantProvisionSeed(ctx, cluster, provider); err != nil {
+				cleanupOnError = true
+				return nil, err
+			}
 			s.startPoolClusterMetadataResume(ctx, cluster, cred)
 		}
 		results = append(results, res)
@@ -498,9 +505,38 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 	return results, nil
 }
 
+func (s *Server) persistPoolTenantProvisionSeed(ctx context.Context, cluster *tenant.ClusterInfo, provider string) error {
+	if cluster == nil {
+		return fmt.Errorf("cluster info is required")
+	}
+	if strings.TrimSpace(cluster.TenantID) == "" {
+		return fmt.Errorf("cluster tenant id is required")
+	}
+	if strings.TrimSpace(cluster.ClusterID) == "" {
+		return fmt.Errorf("cluster id is required")
+	}
+	if strings.TrimSpace(cluster.Password) == "" {
+		return fmt.Errorf("cluster password is required")
+	}
+	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
+	if err != nil {
+		return err
+	}
+	return s.meta.UpdateTenantConnection(ctx, cluster.TenantID, &meta.Tenant{
+		DBPasswordCipher: cipherPass,
+		DBName:           cluster.DBName,
+		DBTLS:            true,
+		Provider:         provider,
+		ClusterID:        cluster.ClusterID,
+	})
+}
+
 func (s *Server) persistPoolTenantConnection(ctx context.Context, cluster *tenant.ClusterInfo, provider string) error {
 	if cluster == nil {
 		return fmt.Errorf("cluster info is required")
+	}
+	if !poolClusterConnectionReady(cluster) {
+		return fmt.Errorf("cluster connection metadata is incomplete")
 	}
 	if strings.TrimSpace(cluster.Password) == "" {
 		return fmt.Errorf("cluster password is required")

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -401,7 +401,7 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			zap.Int("cluster_count", len(clusters)),
 			zap.Error(err))
 	}
-	cleanupOnError := err == nil
+	cleanupOnError := true
 	defer func() {
 		if cleanupOnError {
 			s.cleanupPoolProvisionedClusters(ctx, clusters, cred, tenantIDs, "metadata_error")
@@ -415,9 +415,11 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			continue
 		}
 		if strings.TrimSpace(cluster.TenantID) == "" {
+			cleanupOnError = true
 			return nil, fmt.Errorf("tidbcloud tenant id label is missing")
 		}
 		if strings.TrimSpace(cluster.OrganizationID) == "" {
+			cleanupOnError = true
 			return nil, fmt.Errorf("tidbcloud organization label is missing")
 		}
 		persistedTenants[strings.TrimSpace(cluster.TenantID)] = struct{}{}
@@ -430,12 +432,15 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			CreatedAt:      now,
 			UpdatedAt:      now,
 		}); err != nil {
+			cleanupOnError = true
 			return nil, err
 		}
 		if err := s.persistPoolTenantConnection(ctx, cluster, provider); err != nil {
+			cleanupOnError = true
 			return nil, err
 		}
 		if err := s.meta.UpdateTenantStatus(ctx, cluster.TenantID, meta.TenantProvisioning); err != nil {
+			cleanupOnError = true
 			return nil, err
 		}
 		res := &provisionTenantResult{
@@ -466,6 +471,9 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 func (s *Server) persistPoolTenantConnection(ctx context.Context, cluster *tenant.ClusterInfo, provider string) error {
 	if cluster == nil {
 		return fmt.Errorf("cluster info is required")
+	}
+	if strings.TrimSpace(cluster.Password) == "" {
+		return fmt.Errorf("cluster password is required")
 	}
 	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -1854,6 +1854,118 @@ func TestStartupKeepsFreshPendingTenant(t *testing.T) {
 	}
 }
 
+func TestReconcilePendingNativePoolTenantWithoutConnectionStaysPending(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	tenantID := token.NewID()
+	now := time.Now().UTC().Add(-2 * time.Minute)
+	origStaleAfter := pendingTenantStaleAfter
+	pendingTenantStaleAfter = time.Minute
+	defer func() { pendingTenantStaleAfter = origStaleAfter }()
+	pendingTenant := meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantPending,
+		DBPasswordCipher: []byte{},
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-1",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := metaStore.InsertTenant(context.Background(), &pendingTenant); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{meta: metaStore}
+	srv.reconcilePendingTenant(context.Background(), pendingTenant)
+
+	row := metaStore.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", tenantID)
+	var status string
+	if err := row.Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantPending) {
+		t.Fatalf("status after reconcile = %s, want %s", status, meta.TenantPending)
+	}
+}
+
+func TestReconcilePendingNativeTenantWithConnectionResumesSchemaInit(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	passCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID := token.NewID()
+	now := time.Now().UTC().Add(-2 * time.Minute)
+	origStaleAfter := pendingTenantStaleAfter
+	pendingTenantStaleAfter = time.Minute
+	defer func() { pendingTenantStaleAfter = origStaleAfter }()
+	pendingTenant := meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantPending,
+		DBHost:           "db.example",
+		DBPort:           4000,
+		DBUser:           "u1.root",
+		DBPasswordCipher: passCipher,
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-1",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := metaStore.InsertTenant(context.Background(), &pendingTenant); err != nil {
+		t.Fatal(err)
+	}
+
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov}
+	srv.reconcilePendingTenant(context.Background(), pendingTenant)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		row := metaStore.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", tenantID)
+		var status string
+		if err := row.Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status == string(meta.TenantActive) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("pending native tenant did not resume schema init, status=%s", status)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if prov.systemUserCalls.Load() != 1 {
+		t.Fatalf("system user calls = %d, want 1", prov.systemUserCalls.Load())
+	}
+}
+
 func TestReconcilePendingTenantDoesNotOverwriteChangedStatus(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1851,7 +1851,7 @@ func TestAdminTenantPoolCreateRejectsAboveMaxSize(t *testing.T) {
 		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, body)
 	}
 	body, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(body), "pool_size must be less than or equal to 2") {
+	if !strings.Contains(string(body), "pool_size 3 exceeds maximum 2") {
 		t.Fatalf("body = %s", body)
 	}
 	if got := rt.prov.listCalls.Load(); got != 0 {
@@ -1879,7 +1879,7 @@ func TestAdminTenantPoolUpdateRejectsAboveMaxSize(t *testing.T) {
 		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, body)
 	}
 	body, _ := io.ReadAll(resp.Body)
-	if !strings.Contains(string(body), "pool_size must be less than or equal to 2") {
+	if !strings.Contains(string(body), "pool_size 3 exceeds maximum 2") {
 		t.Fatalf("body = %s", body)
 	}
 	if got := rt.prov.listCalls.Load(); got != 0 {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -56,6 +56,7 @@ type quotaTestProvisioner struct {
 	batchPoolMissingOrg      map[int]bool
 	batchPoolMissingTenant   map[int]bool
 	metadataWaitCalls        atomic.Int32
+	metadataBatchWaitCalls   atomic.Int32
 	metadataWaitErr          error
 	calls                    []string
 }
@@ -278,6 +279,30 @@ func (p *quotaTestProvisioner) WaitForPoolClusterMetadata(_ context.Context, clu
 		out.DBName = "tidbcloud_fs"
 	}
 	return &out, nil
+}
+
+func (p *quotaTestProvisioner) WaitForPoolClustersMetadata(_ context.Context, clusters []*tenant.ClusterInfo, req tenant.CredentialProvisionRequest) ([]*tenant.ClusterInfo, error) {
+	p.metadataBatchWaitCalls.Add(1)
+	p.recordCall("wait_pool_metadata_batch", req, nil, nil)
+	if p.metadataWaitErr != nil {
+		return nil, p.metadataWaitErr
+	}
+	out := make([]*tenant.ClusterInfo, 0, len(clusters))
+	for _, cluster := range clusters {
+		if cluster == nil {
+			continue
+		}
+		next := *cluster
+		next.OrganizationID = "org-1"
+		next.Host = "db.example.com"
+		next.Port = 4000
+		next.Username = "u.root"
+		if next.DBName == "" {
+			next.DBName = "tidbcloud_fs"
+		}
+		out = append(out, &next)
+	}
+	return out, nil
 }
 
 func (p *quotaTestProvisioner) MarkClusterPoolUsed(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, _ time.Time, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
@@ -1464,7 +1489,7 @@ func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 2 {
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 {
 		t.Fatalf("pool response = %#v", out)
 	}
 	if rt.prov.batchPoolCalls.Load() != 1 {
@@ -1485,8 +1510,15 @@ func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("count free: %v", err)
 	}
-	if free != 2 {
-		t.Fatalf("free = %d, want 2", free)
+	if free != 0 {
+		t.Fatalf("active free = %d, want 0 before schema init", free)
+	}
+	slots, err := rt.meta.CountTenantPoolFreeSlots(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("count free slots: %v", err)
+	}
+	if slots != 2 {
+		t.Fatalf("free slots = %d, want 2", slots)
 	}
 }
 
@@ -1512,7 +1544,7 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 2 {
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 {
 		t.Fatalf("pool response = %#v", out)
 	}
 	pool, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1")
@@ -1522,16 +1554,16 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 	if pool.PoolID != out.PoolID {
 		t.Fatalf("stored pool id = %q, want %q", pool.PoolID, out.PoolID)
 	}
-	rows, err := rt.meta.ListFreeTenantPoolBindings(context.Background(), "org-1", false, 10)
+	rows, err := rt.meta.ListPendingTenantPoolBindingsForResume(context.Background(), "org-1", 10)
 	if err != nil {
-		t.Fatalf("list free bindings: %v", err)
+		t.Fatalf("list pending bindings: %v", err)
 	}
 	if len(rows) != 2 {
-		t.Fatalf("free bindings = %d, want 2", len(rows))
+		t.Fatalf("pending bindings = %d, want 2", len(rows))
 	}
 	for _, row := range rows {
-		if row.Tenant.Status != meta.TenantProvisioning {
-			t.Fatalf("tenant %s status = %s, want provisioning", row.Tenant.ID, row.Tenant.Status)
+		if row.Tenant.Status != meta.TenantPending {
+			t.Fatalf("tenant %s status = %s, want pending", row.Tenant.ID, row.Tenant.Status)
 		}
 		if row.Tenant.DBUser != "" || row.Tenant.DBHost != "" {
 			t.Fatalf("tenant %s connection = host %q user %q, want incomplete", row.Tenant.ID, row.Tenant.DBHost, row.Tenant.DBUser)
@@ -1547,11 +1579,14 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 		t.Fatalf("deprovision calls = %d, want 0", got)
 	}
 	deadline := time.Now().Add(5 * time.Second)
-	for rt.prov.metadataWaitCalls.Load() < 2 && time.Now().Before(deadline) {
+	for rt.prov.metadataBatchWaitCalls.Load() < 1 && time.Now().Before(deadline) {
 		time.Sleep(10 * time.Millisecond)
 	}
-	if got := rt.prov.metadataWaitCalls.Load(); got < 2 {
-		t.Fatalf("metadata wait calls = %d, want at least 2", got)
+	if got := rt.prov.metadataBatchWaitCalls.Load(); got < 1 {
+		t.Fatalf("metadata batch wait calls = %d, want at least 1", got)
+	}
+	if got := rt.prov.metadataWaitCalls.Load(); got != 0 {
+		t.Fatalf("single metadata wait calls = %d, want 0", got)
 	}
 }
 
@@ -1578,7 +1613,7 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissi
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 1 {
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 {
 		t.Fatalf("pool response = %#v", out)
 	}
 	pool, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1")
@@ -1588,12 +1623,12 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissi
 	if pool.PoolID != out.PoolID {
 		t.Fatalf("stored pool id = %q, want %q", pool.PoolID, out.PoolID)
 	}
-	rows, err := rt.meta.ListFreeTenantPoolBindings(context.Background(), "org-1", false, 10)
+	rows, err := rt.meta.ListPendingTenantPoolBindingsForResume(context.Background(), "org-1", 10)
 	if err != nil {
-		t.Fatalf("list free bindings: %v", err)
+		t.Fatalf("list pending bindings: %v", err)
 	}
 	if len(rows) != 1 {
-		t.Fatalf("free bindings = %d, want 1", len(rows))
+		t.Fatalf("pending bindings = %d, want 1", len(rows))
 	}
 	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
 		t.Fatalf("deprovision calls = %d, want 1", got)
@@ -1627,15 +1662,15 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneTenantLabelMissin
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 1 {
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 {
 		t.Fatalf("pool response = %#v", out)
 	}
-	rows, err := rt.meta.ListFreeTenantPoolBindings(context.Background(), "org-1", false, 10)
+	rows, err := rt.meta.ListPendingTenantPoolBindingsForResume(context.Background(), "org-1", 10)
 	if err != nil {
-		t.Fatalf("list free bindings: %v", err)
+		t.Fatalf("list pending bindings: %v", err)
 	}
 	if len(rows) != 1 {
-		t.Fatalf("free bindings = %d, want 1", len(rows))
+		t.Fatalf("pending bindings = %d, want 1", len(rows))
 	}
 	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
 		t.Fatalf("deprovision calls = %d, want 1", got)
@@ -1672,7 +1707,7 @@ func TestAdminTenantPoolCreateCleansUpWhenPartialMetadataPersistenceFails(t *tes
 	}
 }
 
-func TestResumeProvisioningNativeWithoutConnectionUsesDefaultCredentials(t *testing.T) {
+func TestResumeProvisioningNativeWithoutConnectionSkipsMetadataResume(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.defaultPublicKey = "default-public"
 	rt.prov.defaultPrivateKey = "default-private"
@@ -1703,29 +1738,99 @@ func TestResumeProvisioningNativeWithoutConnectionUsesDefaultCredentials(t *test
 	}
 
 	rt.server.resumeProvisioningTenantsWithCtx(ctx)
+	tnt, err := rt.meta.GetTenant(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tnt.Status != meta.TenantProvisioning || tnt.DBUser != "" || tnt.DBHost != "" {
+		t.Fatalf("tenant after resume = status %s host %q user %q, want unchanged provisioning without connection", tnt.Status, tnt.DBHost, tnt.DBUser)
+	}
+	if got := rt.prov.metadataWaitCalls.Load(); got != 0 {
+		t.Fatalf("metadata wait calls = %d, want 0", got)
+	}
+	if got := rt.prov.metadataBatchWaitCalls.Load(); got != 0 {
+		t.Fatalf("metadata batch wait calls = %d, want 0", got)
+	}
+}
+
+func TestTenantPoolClaimMissTriggersPendingMetadataResume(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{
+			ClusterID:      "cluster-pending-1",
+			OrganizationID: "org-1",
+		}},
+	}}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           1,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	passCipher, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
+	if err != nil {
+		t.Fatalf("encrypt password: %v", err)
+	}
+	tenantID := "pool-pending-resume-1"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantPending,
+		DBPasswordCipher: passCipher,
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-pending-1",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       tenantID,
+		OrganizationID: "org-1",
+		ClusterID:      "cluster-pending-1",
+		PoolID:         "pool-1",
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+
+	res, pool, claimed, err := rt.server.claimAdminTenantFromPool(ctx, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	}, nil)
+	if err != nil {
+		t.Fatalf("claim from pool: %v", err)
+	}
+	if claimed || res != nil || pool == nil || pool.PoolID != "pool-1" {
+		t.Fatalf("claim result res=%#v pool=%#v claimed=%v, want miss with pool", res, pool, claimed)
+	}
+	if got := rt.prov.markPoolUsedCalls.Load(); got != 0 {
+		t.Fatalf("mark pool used calls = %d, want 0 for pending tenant", got)
+	}
+
 	deadline := time.Now().Add(5 * time.Second)
 	for {
 		tnt, err := rt.meta.GetTenant(ctx, tenantID)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if tnt.Status == meta.TenantActive {
-			if tnt.DBHost != "db.example.com" || tnt.DBUser != "u.tdc_fs_sys" {
-				t.Fatalf("tenant connection = host %q user %q", tnt.DBHost, tnt.DBUser)
-			}
+		if rt.prov.metadataBatchWaitCalls.Load() >= 1 && tnt.DBHost == "db.example.com" && tnt.DBUser == "u.tdc_fs_sys" && tnt.Status == meta.TenantActive {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("tenant status = %s, want active", tnt.Status)
+			t.Fatalf("tenant after pending resume = status %s host %q user %q, metadata batch waits=%d", tnt.Status, tnt.DBHost, tnt.DBUser, rt.prov.metadataBatchWaitCalls.Load())
 		}
 		time.Sleep(10 * time.Millisecond)
-	}
-	if got := rt.prov.metadataWaitCalls.Load(); got < 1 {
-		t.Fatalf("metadata wait calls = %d, want at least 1", got)
-	}
-	lastCredentials := rt.prov.lastCredentialsSnapshot()
-	if lastCredentials.PublicKey != "default-public" || lastCredentials.PrivateKey != "default-private" {
-		t.Fatalf("credentials = %#v, want default credentials", lastCredentials)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -51,6 +51,7 @@ type quotaTestProvisioner struct {
 	batchPoolErr           error
 	batchPoolReady         bool
 	batchPoolEmptyPassword bool
+	batchPoolMissingOrg    map[int]bool
 	metadataWaitCalls      atomic.Int32
 	metadataWaitErr        error
 	calls                  []string
@@ -182,6 +183,9 @@ func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota
 			DBName:         "tidbcloud_fs",
 			Provider:       tenant.ProviderTiDBCloudNative,
 		})
+		if p.batchPoolMissingOrg[i] {
+			out[len(out)-1].OrganizationID = ""
+		}
 		if p.batchPoolReady {
 			out[len(out)-1].Host = "db.example.com"
 			out[len(out)-1].Port = 4000
@@ -1485,6 +1489,54 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 	}
 	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
 		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+}
+
+func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissing(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
+	rt.prov.batchPoolErr = errors.New("tidbcloud native cluster get status 429")
+	rt.prov.batchPoolMissingOrg = map[int]bool{1: true}
+	rt.prov.metadataWaitErr = errors.New("metadata still unavailable")
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+
+	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+		"pool_size":   2,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var out adminTenantPoolResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 1 {
+		t.Fatalf("pool response = %#v", out)
+	}
+	pool, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if pool.PoolID != out.PoolID {
+		t.Fatalf("stored pool id = %q, want %q", pool.PoolID, out.PoolID)
+	}
+	rows, err := rt.meta.ListFreeTenantPoolBindings(context.Background(), "org-1", false, 10)
+	if err != nil {
+		t.Fatalf("list free bindings: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("free bindings = %d, want 1", len(rows))
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	if rt.prov.lastDeprovision == nil || rt.prov.lastDeprovision.ClusterID != "pool-cluster-2" {
+		t.Fatalf("last deprovision = %#v, want pool-cluster-2", rt.prov.lastDeprovision)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -57,6 +57,7 @@ type quotaTestProvisioner struct {
 	batchPoolMissingTenant      map[int]bool
 	metadataWaitCalls           atomic.Int32
 	metadataBatchWaitCalls      atomic.Int32
+	metadataBatchWaitHook       func(call int, clusters []*tenant.ClusterInfo)
 	metadataWaitErr             error
 	calls                       []string
 }
@@ -275,8 +276,11 @@ func (p *quotaTestProvisioner) WaitForPoolClusterMetadata(_ context.Context, clu
 }
 
 func (p *quotaTestProvisioner) WaitForPoolClustersMetadata(_ context.Context, clusters []*tenant.ClusterInfo, req tenant.CredentialProvisionRequest) ([]*tenant.ClusterInfo, error) {
-	p.metadataBatchWaitCalls.Add(1)
+	call := int(p.metadataBatchWaitCalls.Add(1))
 	p.recordCall("wait_pool_metadata_batch", req, nil, nil)
+	if p.metadataBatchWaitHook != nil {
+		p.metadataBatchWaitHook(call, clusters)
+	}
 	if p.metadataWaitErr != nil {
 		return nil, p.metadataWaitErr
 	}
@@ -1825,6 +1829,103 @@ func TestTenantPoolClaimMissTriggersPendingMetadataResume(t *testing.T) {
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("tenant after pending resume = status %s host %q user %q, metadata batch waits=%d", tnt.Status, tnt.DBHost, tnt.DBUser, rt.prov.metadataBatchWaitCalls.Load())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestTenantPoolMetadataResumeRerunsWhenTriggeredWhileActive(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           2,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	var closeFirstStarted sync.Once
+	rt.prov.metadataBatchWaitHook = func(call int, _ []*tenant.ClusterInfo) {
+		if call != 1 {
+			return
+		}
+		closeFirstStarted.Do(func() { close(firstStarted) })
+		<-releaseFirst
+	}
+	makePending := func(tenantID, clusterID string) *tenant.ClusterInfo {
+		t.Helper()
+		passCipher, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
+		if err != nil {
+			t.Fatalf("encrypt password: %v", err)
+		}
+		if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+			ID:               tenantID,
+			Status:           meta.TenantPending,
+			DBPasswordCipher: passCipher,
+			DBName:           "tidbcloud_fs",
+			DBTLS:            true,
+			Provider:         tenant.ProviderTiDBCloudNative,
+			ClusterID:        clusterID,
+			SchemaVersion:    1,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}); err != nil {
+			t.Fatalf("insert tenant %s: %v", tenantID, err)
+		}
+		if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+			TenantID:       tenantID,
+			OrganizationID: "org-1",
+			ClusterID:      clusterID,
+			PoolID:         "pool-1",
+			PoolStatus:     meta.TenantPoolBindingFree,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}); err != nil {
+			t.Fatalf("upsert binding %s: %v", tenantID, err)
+		}
+		return &tenant.ClusterInfo{
+			TenantID:       tenantID,
+			ClusterID:      clusterID,
+			OrganizationID: "org-1",
+			Password:       "pool-pass",
+			DBName:         "tidbcloud_fs",
+			Provider:       tenant.ProviderTiDBCloudNative,
+		}
+	}
+	first := makePending("pool-pending-rerun-1", "cluster-pending-rerun-1")
+	rt.server.startPoolClustersMetadataResume(ctx, "pool-1", []*tenant.ClusterInfo{first}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	select {
+	case <-firstStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first metadata resume did not start")
+	}
+	second := makePending("pool-pending-rerun-2", "cluster-pending-rerun-2")
+	rt.server.startPoolClustersMetadataResume(ctx, "pool-1", []*tenant.ClusterInfo{second}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	close(releaseFirst)
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		secondTenant, err := rt.meta.GetTenant(ctx, second.TenantID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if rt.prov.metadataBatchWaitCalls.Load() >= 2 && secondTenant.DBHost == "db.example.com" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("second tenant after rerun = status %s host %q, metadata batch waits=%d", secondTenant.Status, secondTenant.DBHost, rt.prov.metadataBatchWaitCalls.Load())
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -23,34 +23,37 @@ import (
 )
 
 type quotaTestProvisioner struct {
-	provider          string
-	updateErr         error
-	markErr           error
-	getErr            error
-	deprovisionErr    error
-	cloudCfg          *tenant.QuotaCloudConfig
-	defaultPublicKey  string
-	defaultPrivateKey string
-	markHook          func() error
-	deprovisionHook   func(call int, cluster *tenant.ClusterInfo) error
-	updateCalls       atomic.Int32
-	markCalls         atomic.Int32
-	getCalls          atomic.Int32
-	listCalls         atomic.Int32
-	deprovisionCalls  atomic.Int32
-	batchPoolCalls    atomic.Int32
-	markPoolUsedCalls atomic.Int32
-	markPoolFreeCalls atomic.Int32
-	lastCluster       *tenant.ClusterInfo
-	lastCredentials   tenant.CredentialProvisionRequest
-	lastOptions       tenant.QuotaUpdateOptions
-	lastListOptions   tenant.ManagedClusterListOptions
-	lastDeprovision   *tenant.ClusterInfo
-	listErr           error
-	listPages         []*tenant.ManagedClusterListResult
-	batchPoolErr      error
-	batchPoolReady    bool
-	calls             []string
+	provider               string
+	updateErr              error
+	markErr                error
+	getErr                 error
+	deprovisionErr         error
+	cloudCfg               *tenant.QuotaCloudConfig
+	defaultPublicKey       string
+	defaultPrivateKey      string
+	markHook               func() error
+	deprovisionHook        func(call int, cluster *tenant.ClusterInfo) error
+	updateCalls            atomic.Int32
+	markCalls              atomic.Int32
+	getCalls               atomic.Int32
+	listCalls              atomic.Int32
+	deprovisionCalls       atomic.Int32
+	batchPoolCalls         atomic.Int32
+	markPoolUsedCalls      atomic.Int32
+	markPoolFreeCalls      atomic.Int32
+	lastCluster            *tenant.ClusterInfo
+	lastCredentials        tenant.CredentialProvisionRequest
+	lastOptions            tenant.QuotaUpdateOptions
+	lastListOptions        tenant.ManagedClusterListOptions
+	lastDeprovision        *tenant.ClusterInfo
+	listErr                error
+	listPages              []*tenant.ManagedClusterListResult
+	batchPoolErr           error
+	batchPoolReady         bool
+	batchPoolEmptyPassword bool
+	metadataWaitCalls      atomic.Int32
+	metadataWaitErr        error
+	calls                  []string
 }
 
 func (p *quotaTestProvisioner) ProviderType() string { return p.provider }
@@ -167,11 +170,15 @@ func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota
 	p.lastOptions = opts
 	out := make([]*tenant.ClusterInfo, 0, len(tenantIDs))
 	for i, tenantID := range tenantIDs {
+		password := "pool-pass"
+		if p.batchPoolEmptyPassword {
+			password = ""
+		}
 		out = append(out, &tenant.ClusterInfo{
 			TenantID:       tenantID,
 			ClusterID:      fmt.Sprintf("pool-cluster-%d", i+1),
 			OrganizationID: "org-1",
-			Password:       "pool-pass",
+			Password:       password,
 			DBName:         "tidbcloud_fs",
 			Provider:       tenant.ProviderTiDBCloudNative,
 		})
@@ -189,6 +196,31 @@ func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota
 		}
 	}
 	return out, nil, p.batchPoolErr
+}
+
+func (p *quotaTestProvisioner) WaitForPoolClusterMetadata(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) (*tenant.ClusterInfo, error) {
+	p.metadataWaitCalls.Add(1)
+	p.calls = append(p.calls, "wait_pool_metadata")
+	p.lastCredentials = req
+	if cluster != nil {
+		out := *cluster
+		p.lastCluster = &out
+	}
+	if p.metadataWaitErr != nil {
+		return nil, p.metadataWaitErr
+	}
+	if cluster == nil {
+		return nil, fmt.Errorf("cluster is required")
+	}
+	out := *cluster
+	out.OrganizationID = "org-1"
+	out.Host = "db.example.com"
+	out.Port = 4000
+	out.Username = "u.root"
+	if out.DBName == "" {
+		out.DBName = "tidbcloud_fs"
+	}
+	return &out, nil
 }
 
 func (p *quotaTestProvisioner) MarkClusterPoolUsed(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, _ time.Time, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
@@ -1402,6 +1434,7 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
 	rt.prov.batchPoolErr = errors.New("tidbcloud native cluster get status 429")
+	rt.prov.metadataWaitErr = errors.New("metadata still unavailable")
 	ts := httptest.NewServer(rt.server)
 	t.Cleanup(ts.Close)
 
@@ -1452,6 +1485,88 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 	}
 	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
 		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+}
+
+func TestAdminTenantPoolCreateCleansUpWhenPartialMetadataPersistenceFails(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
+	rt.prov.batchPoolErr = errors.New("tidbcloud native cluster get status 429")
+	rt.prov.batchPoolEmptyPassword = true
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+
+	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+		"pool_size":   2,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 502: %s", resp.StatusCode, body)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 2 {
+		t.Fatalf("deprovision calls = %d, want 2", got)
+	}
+	if _, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1"); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("pool lookup err = %v, want not found", err)
+	}
+}
+
+func TestResumeProvisioningNativeWithoutConnectionUsesDefaultCredentials(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.defaultPublicKey = "default-public"
+	rt.prov.defaultPrivateKey = "default-private"
+	ctx := context.Background()
+	now := time.Now().UTC()
+	tenantID := "pool-resume-native"
+	cipherPass, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantProvisioning,
+		Kind:             meta.TenantKindLive,
+		DBHost:           "",
+		DBPort:           0,
+		DBUser:           "",
+		DBPasswordCipher: cipherPass,
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "pool-cluster-resume",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rt.server.resumeProvisioningTenantsWithCtx(ctx)
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		tnt, err := rt.meta.GetTenant(ctx, tenantID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tnt.Status == meta.TenantActive {
+			if tnt.DBHost != "db.example.com" || tnt.DBUser != "u.tdc_fs_sys" {
+				t.Fatalf("tenant connection = host %q user %q", tnt.DBHost, tnt.DBUser)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("tenant status = %s, want active", tnt.Status)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := rt.prov.metadataWaitCalls.Load(); got != 1 {
+		t.Fatalf("metadata wait calls = %d, want 1", got)
+	}
+	if rt.prov.lastCredentials.PublicKey != "default-public" || rt.prov.lastCredentials.PrivateKey != "default-private" {
+		t.Fatalf("credentials = %#v, want default credentials", rt.prov.lastCredentials)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -24,41 +24,41 @@ import (
 )
 
 type quotaTestProvisioner struct {
-	provider                 string
-	updateErr                error
-	markErr                  error
-	getErr                   error
-	deprovisionErr           error
-	cloudCfg                 *tenant.QuotaCloudConfig
-	defaultPublicKey         string
-	defaultPrivateKey        string
-	markHook                 func() error
-	deprovisionHook          func(call int, cluster *tenant.ClusterInfo) error
-	updateCalls              atomic.Int32
-	markCalls                atomic.Int32
-	getCalls                 atomic.Int32
-	listCalls                atomic.Int32
-	deprovisionCalls         atomic.Int32
-	batchPoolCalls           atomic.Int32
-	markPoolUsedCalls        atomic.Int32
-	markPoolFreeCalls        atomic.Int32
-	mu                       sync.Mutex
-	lastCluster              *tenant.ClusterInfo
-	lastCredentials          tenant.CredentialProvisionRequest
-	lastOptions              tenant.QuotaUpdateOptions
-	lastListOptions          tenant.ManagedClusterListOptions
-	lastDeprovision          *tenant.ClusterInfo
-	listErr                  error
-	listPages                []*tenant.ManagedClusterListResult
-	batchPoolErr             error
-	batchPoolConnectionReady bool
-	batchPoolEmptyPassword   bool
-	batchPoolMissingOrg      map[int]bool
-	batchPoolMissingTenant   map[int]bool
-	metadataWaitCalls        atomic.Int32
-	metadataBatchWaitCalls   atomic.Int32
-	metadataWaitErr          error
-	calls                    []string
+	provider                    string
+	updateErr                   error
+	markErr                     error
+	getErr                      error
+	deprovisionErr              error
+	cloudCfg                    *tenant.QuotaCloudConfig
+	defaultPublicKey            string
+	defaultPrivateKey           string
+	markHook                    func() error
+	deprovisionHook             func(call int, cluster *tenant.ClusterInfo) error
+	updateCalls                 atomic.Int32
+	markCalls                   atomic.Int32
+	getCalls                    atomic.Int32
+	listCalls                   atomic.Int32
+	deprovisionCalls            atomic.Int32
+	batchPoolCalls              atomic.Int32
+	markPoolUsedCalls           atomic.Int32
+	markPoolFreeCalls           atomic.Int32
+	mu                          sync.Mutex
+	lastCluster                 *tenant.ClusterInfo
+	lastCredentials             tenant.CredentialProvisionRequest
+	lastOptions                 tenant.QuotaUpdateOptions
+	lastListOptions             tenant.ManagedClusterListOptions
+	lastDeprovision             *tenant.ClusterInfo
+	listErr                     error
+	listPages                   []*tenant.ManagedClusterListResult
+	batchPoolErr                error
+	batchPoolOmitConnectionInfo bool
+	batchPoolEmptyPassword      bool
+	batchPoolMissingOrg         map[int]bool
+	batchPoolMissingTenant      map[int]bool
+	metadataWaitCalls           atomic.Int32
+	metadataBatchWaitCalls      atomic.Int32
+	metadataWaitErr             error
+	calls                       []string
 }
 
 func (p *quotaTestProvisioner) recordCall(name string, req tenant.CredentialProvisionRequest, cluster *tenant.ClusterInfo, opts *tenant.QuotaUpdateOptions) {
@@ -245,17 +245,10 @@ func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota
 		if p.batchPoolMissingOrg[i] {
 			out[len(out)-1].OrganizationID = ""
 		}
-		if p.batchPoolConnectionReady {
+		if !p.batchPoolOmitConnectionInfo {
 			out[len(out)-1].Host = "db.example.com"
 			out[len(out)-1].Port = 4000
 			out[len(out)-1].Username = "u.root"
-		}
-	}
-	if !p.batchPoolConnectionReady && p.batchPoolErr == nil {
-		for _, cluster := range out {
-			cluster.Host = "db.example.com"
-			cluster.Port = 4000
-			cluster.Username = "u.root"
 		}
 	}
 	return out, nil, p.batchPoolErr
@@ -1526,6 +1519,7 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
 	rt.prov.batchPoolErr = errors.New("tidbcloud native cluster get status 429")
+	rt.prov.batchPoolOmitConnectionInfo = true
 	rt.prov.metadataWaitErr = errors.New("metadata still unavailable")
 	ts := httptest.NewServer(rt.server)
 	t.Cleanup(ts.Close)
@@ -1594,6 +1588,7 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissi
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
 	rt.prov.batchPoolErr = errors.New("tidbcloud native cluster get status 429")
+	rt.prov.batchPoolOmitConnectionInfo = true
 	rt.prov.batchPoolMissingOrg = map[int]bool{1: true}
 	rt.prov.metadataWaitErr = errors.New("metadata still unavailable")
 	ts := httptest.NewServer(rt.server)
@@ -1643,6 +1638,7 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneTenantLabelMissin
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
 	rt.prov.batchPoolErr = errors.New("tidbcloud native cluster get status 429")
+	rt.prov.batchPoolOmitConnectionInfo = true
 	rt.prov.batchPoolMissingTenant = map[int]bool{1: true}
 	rt.prov.metadataWaitErr = errors.New("metadata still unavailable")
 	ts := httptest.NewServer(rt.server)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1494,6 +1494,13 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
 		t.Fatalf("deprovision calls = %d, want 0", got)
 	}
+	deadline := time.Now().Add(5 * time.Second)
+	for rt.prov.metadataWaitCalls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := rt.prov.metadataWaitCalls.Load(); got < 2 {
+		t.Fatalf("metadata wait calls = %d, want at least 2", got)
+	}
 }
 
 func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissing(t *testing.T) {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	neturl "net/url"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -41,6 +42,7 @@ type quotaTestProvisioner struct {
 	batchPoolCalls           atomic.Int32
 	markPoolUsedCalls        atomic.Int32
 	markPoolFreeCalls        atomic.Int32
+	mu                       sync.Mutex
 	lastCluster              *tenant.ClusterInfo
 	lastCredentials          tenant.CredentialProvisionRequest
 	lastOptions              tenant.QuotaUpdateOptions
@@ -56,6 +58,83 @@ type quotaTestProvisioner struct {
 	metadataWaitCalls        atomic.Int32
 	metadataWaitErr          error
 	calls                    []string
+}
+
+func (p *quotaTestProvisioner) recordCall(name string, req tenant.CredentialProvisionRequest, cluster *tenant.ClusterInfo, opts *tenant.QuotaUpdateOptions) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, name)
+	p.lastCredentials = req
+	if opts != nil {
+		p.lastOptions = *opts
+	}
+	if cluster != nil {
+		out := *cluster
+		p.lastCluster = &out
+	}
+}
+
+func (p *quotaTestProvisioner) recordListCall(req tenant.CredentialProvisionRequest, opts tenant.ManagedClusterListOptions) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, "list")
+	p.lastCredentials = req
+	p.lastListOptions = opts
+}
+
+func (p *quotaTestProvisioner) recordDeprovisionCall(req tenant.CredentialProvisionRequest, cluster *tenant.ClusterInfo) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.calls = append(p.calls, "deprovision")
+	p.lastCredentials = req
+	if cluster != nil {
+		out := *cluster
+		p.lastDeprovision = &out
+	}
+}
+
+func (p *quotaTestProvisioner) callsSnapshot() []string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return append([]string(nil), p.calls...)
+}
+
+func (p *quotaTestProvisioner) lastCredentialsSnapshot() tenant.CredentialProvisionRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastCredentials
+}
+
+func (p *quotaTestProvisioner) lastOptionsSnapshot() tenant.QuotaUpdateOptions {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastOptions
+}
+
+func (p *quotaTestProvisioner) lastListOptionsSnapshot() tenant.ManagedClusterListOptions {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastListOptions
+}
+
+func (p *quotaTestProvisioner) lastClusterSnapshot() *tenant.ClusterInfo {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.lastCluster == nil {
+		return nil
+	}
+	out := *p.lastCluster
+	return &out
+}
+
+func (p *quotaTestProvisioner) lastDeprovisionSnapshot() *tenant.ClusterInfo {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.lastDeprovision == nil {
+		return nil
+	}
+	out := *p.lastDeprovision
+	return &out
 }
 
 func (p *quotaTestProvisioner) ProviderType() string { return p.provider }
@@ -82,13 +161,7 @@ func (p *quotaTestProvisioner) EnsureSystemUser(context.Context, string, string)
 
 func (p *quotaTestProvisioner) UpdateQuota(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
 	p.updateCalls.Add(1)
-	p.calls = append(p.calls, "update")
-	p.lastCredentials = req
-	p.lastOptions = opts
-	if cluster != nil {
-		out := *cluster
-		p.lastCluster = &out
-	}
+	p.recordCall("update", req, cluster, &opts)
 	if p.updateErr != nil {
 		return nil, p.updateErr
 	}
@@ -100,12 +173,7 @@ func (p *quotaTestProvisioner) UpdateQuota(_ context.Context, cluster *tenant.Cl
 
 func (p *quotaTestProvisioner) MarkQuotaUpdateStarted(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) (*tenant.QuotaCloudConfig, error) {
 	p.markCalls.Add(1)
-	p.calls = append(p.calls, "mark")
-	p.lastCredentials = req
-	if cluster != nil {
-		out := *cluster
-		p.lastCluster = &out
-	}
+	p.recordCall("mark", req, cluster, nil)
 	if p.markHook != nil {
 		if err := p.markHook(); err != nil {
 			return nil, err
@@ -119,12 +187,7 @@ func (p *quotaTestProvisioner) MarkQuotaUpdateStarted(_ context.Context, cluster
 
 func (p *quotaTestProvisioner) GetQuota(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) (*tenant.QuotaCloudConfig, error) {
 	p.getCalls.Add(1)
-	p.calls = append(p.calls, "get")
-	p.lastCredentials = req
-	if cluster != nil {
-		out := *cluster
-		p.lastCluster = &out
-	}
+	p.recordCall("get", req, cluster, nil)
 	if p.getErr != nil {
 		return nil, p.getErr
 	}
@@ -133,12 +196,7 @@ func (p *quotaTestProvisioner) GetQuota(_ context.Context, cluster *tenant.Clust
 
 func (p *quotaTestProvisioner) DeprovisionWithCredentials(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) error {
 	call := int(p.deprovisionCalls.Add(1))
-	p.calls = append(p.calls, "deprovision")
-	p.lastCredentials = req
-	if cluster != nil {
-		out := *cluster
-		p.lastDeprovision = &out
-	}
+	p.recordDeprovisionCall(req, cluster)
 	if p.deprovisionHook != nil {
 		if err := p.deprovisionHook(call, cluster); err != nil {
 			return err
@@ -149,9 +207,7 @@ func (p *quotaTestProvisioner) DeprovisionWithCredentials(_ context.Context, clu
 
 func (p *quotaTestProvisioner) ListManagedClusters(_ context.Context, req tenant.CredentialProvisionRequest, opts tenant.ManagedClusterListOptions) (*tenant.ManagedClusterListResult, error) {
 	call := int(p.listCalls.Add(1))
-	p.calls = append(p.calls, "list")
-	p.lastCredentials = req
-	p.lastListOptions = opts
+	p.recordListCall(req, opts)
 	if p.listErr != nil {
 		return nil, p.listErr
 	}
@@ -167,9 +223,7 @@ func (p *quotaTestProvisioner) ListManagedClusters(_ context.Context, req tenant
 
 func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(_ context.Context, tenantIDs []string, req tenant.CredentialProvisionRequest, opts tenant.QuotaUpdateOptions) ([]*tenant.ClusterInfo, *tenant.QuotaCloudConfig, error) {
 	p.batchPoolCalls.Add(1)
-	p.calls = append(p.calls, "batch_pool")
-	p.lastCredentials = req
-	p.lastOptions = opts
+	p.recordCall("batch_pool", req, nil, &opts)
 	out := make([]*tenant.ClusterInfo, 0, len(tenantIDs))
 	for i, tenantID := range tenantIDs {
 		password := "pool-pass"
@@ -208,12 +262,7 @@ func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota
 
 func (p *quotaTestProvisioner) WaitForPoolClusterMetadata(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) (*tenant.ClusterInfo, error) {
 	p.metadataWaitCalls.Add(1)
-	p.calls = append(p.calls, "wait_pool_metadata")
-	p.lastCredentials = req
-	if cluster != nil {
-		out := *cluster
-		p.lastCluster = &out
-	}
+	p.recordCall("wait_pool_metadata", req, cluster, nil)
 	if p.metadataWaitErr != nil {
 		return nil, p.metadataWaitErr
 	}
@@ -233,24 +282,13 @@ func (p *quotaTestProvisioner) WaitForPoolClusterMetadata(_ context.Context, clu
 
 func (p *quotaTestProvisioner) MarkClusterPoolUsed(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, _ time.Time, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
 	p.markPoolUsedCalls.Add(1)
-	p.calls = append(p.calls, "mark_pool_used")
-	p.lastCredentials = req
-	p.lastOptions = opts
-	if cluster != nil {
-		out := *cluster
-		p.lastCluster = &out
-	}
+	p.recordCall("mark_pool_used", req, cluster, &opts)
 	return &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: opts.TiDBCloudSpendingLimitMonthly}, nil
 }
 
 func (p *quotaTestProvisioner) MarkClusterPoolFree(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) error {
 	p.markPoolFreeCalls.Add(1)
-	p.calls = append(p.calls, "mark_pool_free")
-	p.lastCredentials = req
-	if cluster != nil {
-		out := *cluster
-		p.lastCluster = &out
-	}
+	p.recordCall("mark_pool_free", req, cluster, nil)
 	return nil
 }
 
@@ -397,8 +435,9 @@ func TestQuotaGetDoesNotFallbackToDefaultTiDBCloudCredentials(t *testing.T) {
 	if got := rt.prov.getCalls.Load(); got != 0 {
 		t.Fatalf("get calls = %d, want 0", got)
 	}
-	if rt.prov.lastCredentials.PublicKey == "default-pk" || rt.prov.lastCredentials.PrivateKey == "default-sk" {
-		t.Fatalf("quota get used default credentials: %#v", rt.prov.lastCredentials)
+	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	if lastCredentials.PublicKey == "default-pk" || lastCredentials.PrivateKey == "default-sk" {
+		t.Fatalf("quota get used default credentials: %#v", lastCredentials)
 	}
 }
 
@@ -417,8 +456,9 @@ func TestQuotaGetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	if got := rt.prov.getCalls.Load(); got != 1 {
 		t.Fatalf("get calls = %d, want 1", got)
 	}
-	if rt.prov.lastCredentials.PublicKey != "default-pk" || rt.prov.lastCredentials.PrivateKey != "default-sk" {
-		t.Fatalf("last credentials = %#v", rt.prov.lastCredentials)
+	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	if lastCredentials.PublicKey != "default-pk" || lastCredentials.PrivateKey != "default-sk" {
+		t.Fatalf("last credentials = %#v", lastCredentials)
 	}
 }
 
@@ -493,11 +533,13 @@ func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
 	}
-	if rt.prov.lastCluster == nil || rt.prov.lastCluster.ClusterID != "cluster-quota-1" || rt.prov.lastCluster.TenantID != rt.tenantID {
-		t.Fatalf("last cluster = %#v", rt.prov.lastCluster)
+	lastCluster := rt.prov.lastClusterSnapshot()
+	if lastCluster == nil || lastCluster.ClusterID != "cluster-quota-1" || lastCluster.TenantID != rt.tenantID {
+		t.Fatalf("last cluster = %#v", lastCluster)
 	}
-	if rt.prov.lastCredentials.PublicKey != "public-1" || rt.prov.lastCredentials.PrivateKey != "private-1" {
-		t.Fatalf("last credentials = %#v", rt.prov.lastCredentials)
+	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	if lastCredentials.PublicKey != "public-1" || lastCredentials.PrivateKey != "private-1" {
+		t.Fatalf("last credentials = %#v", lastCredentials)
 	}
 }
 
@@ -562,8 +604,9 @@ func TestQuotaSetChecksClusterWritePermissionBeforeMaxStorageUpdate(t *testing.T
 	if got := rt.prov.markCalls.Load(); got != 1 {
 		t.Fatalf("mark calls = %d, want 1", got)
 	}
-	if len(rt.prov.calls) != 1 || rt.prov.calls[0] != "mark" {
-		t.Fatalf("calls = %#v, want mark only", rt.prov.calls)
+	calls := rt.prov.callsSnapshot()
+	if len(calls) != 1 || calls[0] != "mark" {
+		t.Fatalf("calls = %#v, want mark only", calls)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
 	if err != nil {
@@ -668,8 +711,9 @@ func TestQuotaSetChecksClusterWritePermissionBeforeFileLimitUpdate(t *testing.T)
 	if got := rt.prov.markCalls.Load(); got != 1 {
 		t.Fatalf("mark calls = %d, want 1", got)
 	}
-	if len(rt.prov.calls) != 1 || rt.prov.calls[0] != "mark" {
-		t.Fatalf("calls = %#v, want mark only", rt.prov.calls)
+	calls := rt.prov.callsSnapshot()
+	if len(calls) != 1 || calls[0] != "mark" {
+		t.Fatalf("calls = %#v, want mark only", calls)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
 	if err != nil {
@@ -703,11 +747,13 @@ func TestQuotaSetSpendingLimitOnlyDoesNotWriteStorageConfig(t *testing.T) {
 	if got := rt.prov.markCalls.Load(); got != 1 {
 		t.Fatalf("mark calls = %d, want 1", got)
 	}
-	if len(rt.prov.calls) != 2 || rt.prov.calls[0] != "mark" || rt.prov.calls[1] != "update" {
-		t.Fatalf("calls = %#v, want mark before update", rt.prov.calls)
+	calls := rt.prov.callsSnapshot()
+	if len(calls) != 2 || calls[0] != "mark" || calls[1] != "update" {
+		t.Fatalf("calls = %#v, want mark before update", calls)
 	}
-	if rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly == nil || *rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly != spendingLimit {
-		t.Fatalf("spending limit option = %#v, want %d", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly, spendingLimit)
+	lastOptions := rt.prov.lastOptionsSnapshot()
+	if lastOptions.TiDBCloudSpendingLimitMonthly == nil || *lastOptions.TiDBCloudSpendingLimitMonthly != spendingLimit {
+		t.Fatalf("spending limit option = %#v, want %d", lastOptions.TiDBCloudSpendingLimitMonthly, spendingLimit)
 	}
 	version, err := rt.meta.GetQuotaConfigVersion(context.Background(), rt.tenantID)
 	if err != nil {
@@ -781,8 +827,9 @@ func TestQuotaSetDoesNotFallbackToDefaultTiDBCloudCredentials(t *testing.T) {
 	if got := rt.prov.markCalls.Load(); got != 0 {
 		t.Fatalf("mark calls = %d, want 0", got)
 	}
-	if rt.prov.lastCredentials.PublicKey == "default-pk" || rt.prov.lastCredentials.PrivateKey == "default-sk" {
-		t.Fatalf("quota set used default credentials: %#v", rt.prov.lastCredentials)
+	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	if lastCredentials.PublicKey == "default-pk" || lastCredentials.PrivateKey == "default-sk" {
+		t.Fatalf("quota set used default credentials: %#v", lastCredentials)
 	}
 }
 
@@ -809,11 +856,13 @@ func TestQuotaSetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	if got := rt.prov.markCalls.Load(); got != 1 {
 		t.Fatalf("mark calls = %d, want 1", got)
 	}
-	if len(rt.prov.calls) != 1 || rt.prov.calls[0] != "mark" {
-		t.Fatalf("calls = %#v, want mark only", rt.prov.calls)
+	calls := rt.prov.callsSnapshot()
+	if len(calls) != 1 || calls[0] != "mark" {
+		t.Fatalf("calls = %#v, want mark only", calls)
 	}
-	if rt.prov.lastCredentials.PublicKey != "default-pk" || rt.prov.lastCredentials.PrivateKey != "default-sk" {
-		t.Fatalf("last credentials = %#v", rt.prov.lastCredentials)
+	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	if lastCredentials.PublicKey != "default-pk" || lastCredentials.PrivateKey != "default-sk" {
+		t.Fatalf("last credentials = %#v", lastCredentials)
 	}
 }
 
@@ -1041,8 +1090,9 @@ func TestAdminTenantListReturnsEmptyWithoutDBLookupWhenNoManagedClusters(t *test
 	if got := rt.prov.listCalls.Load(); got != 1 {
 		t.Fatalf("list calls = %d, want 1", got)
 	}
-	if rt.prov.lastListOptions.ClusterID != "" {
-		t.Fatalf("cluster filter = %q, want empty", rt.prov.lastListOptions.ClusterID)
+	lastListOptions := rt.prov.lastListOptionsSnapshot()
+	if lastListOptions.ClusterID != "" {
+		t.Fatalf("cluster filter = %q, want empty", lastListOptions.ClusterID)
 	}
 }
 
@@ -1357,8 +1407,9 @@ func TestAdminTenantGetUsesListClusterAuthorizationAndReturnsQuota(t *testing.T)
 	if got := rt.prov.listCalls.Load(); got != 1 {
 		t.Fatalf("list calls = %d, want 1", got)
 	}
-	if rt.prov.lastListOptions.ClusterID != "cluster-quota-1" {
-		t.Fatalf("cluster filter = %q, want cluster-quota-1", rt.prov.lastListOptions.ClusterID)
+	lastListOptions := rt.prov.lastListOptionsSnapshot()
+	if lastListOptions.ClusterID != "cluster-quota-1" {
+		t.Fatalf("cluster filter = %q, want cluster-quota-1", lastListOptions.ClusterID)
 	}
 	if got := rt.prov.markCalls.Load(); got != 0 {
 		t.Fatalf("mark calls = %d, want 0", got)
@@ -1419,8 +1470,9 @@ func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 	if rt.prov.batchPoolCalls.Load() != 1 {
 		t.Fatalf("batch pool calls = %d, want 1", rt.prov.batchPoolCalls.Load())
 	}
-	if rt.prov.lastOptions.TenantPoolID != out.PoolID {
-		t.Fatalf("batch pool id option = %q, want %q", rt.prov.lastOptions.TenantPoolID, out.PoolID)
+	lastOptions := rt.prov.lastOptionsSnapshot()
+	if lastOptions.TenantPoolID != out.PoolID {
+		t.Fatalf("batch pool id option = %q, want %q", lastOptions.TenantPoolID, out.PoolID)
 	}
 	pool, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1")
 	if err != nil {
@@ -1546,8 +1598,9 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissi
 	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
 		t.Fatalf("deprovision calls = %d, want 1", got)
 	}
-	if rt.prov.lastDeprovision == nil || rt.prov.lastDeprovision.ClusterID != "pool-cluster-2" {
-		t.Fatalf("last deprovision = %#v, want pool-cluster-2", rt.prov.lastDeprovision)
+	lastDeprovision := rt.prov.lastDeprovisionSnapshot()
+	if lastDeprovision == nil || lastDeprovision.ClusterID != "pool-cluster-2" {
+		t.Fatalf("last deprovision = %#v, want pool-cluster-2", lastDeprovision)
 	}
 }
 
@@ -1587,8 +1640,9 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneTenantLabelMissin
 	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
 		t.Fatalf("deprovision calls = %d, want 1", got)
 	}
-	if rt.prov.lastDeprovision == nil || rt.prov.lastDeprovision.ClusterID != "pool-cluster-2" {
-		t.Fatalf("last deprovision = %#v, want pool-cluster-2", rt.prov.lastDeprovision)
+	lastDeprovision := rt.prov.lastDeprovisionSnapshot()
+	if lastDeprovision == nil || lastDeprovision.ClusterID != "pool-cluster-2" {
+		t.Fatalf("last deprovision = %#v, want pool-cluster-2", lastDeprovision)
 	}
 }
 
@@ -1666,11 +1720,12 @@ func TestResumeProvisioningNativeWithoutConnectionUsesDefaultCredentials(t *test
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	if got := rt.prov.metadataWaitCalls.Load(); got != 1 {
-		t.Fatalf("metadata wait calls = %d, want 1", got)
+	if got := rt.prov.metadataWaitCalls.Load(); got < 1 {
+		t.Fatalf("metadata wait calls = %d, want at least 1", got)
 	}
-	if rt.prov.lastCredentials.PublicKey != "default-public" || rt.prov.lastCredentials.PrivateKey != "default-private" {
-		t.Fatalf("credentials = %#v, want default credentials", rt.prov.lastCredentials)
+	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	if lastCredentials.PublicKey != "default-public" || lastCredentials.PrivateKey != "default-private" {
+		t.Fatalf("credentials = %#v, want default credentials", lastCredentials)
 	}
 }
 
@@ -1987,8 +2042,9 @@ func TestAdminTenantPoolReplenishUsesDefaultSpendingLimit(t *testing.T) {
 	if got := rt.prov.batchPoolCalls.Load(); got != 1 {
 		t.Fatalf("batch pool calls = %d, want 1", got)
 	}
-	if rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly != nil {
-		t.Fatalf("replenish spending limit = %#v, want nil", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly)
+	lastOptions := rt.prov.lastOptionsSnapshot()
+	if lastOptions.TiDBCloudSpendingLimitMonthly != nil {
+		t.Fatalf("replenish spending limit = %#v, want nil", lastOptions.TiDBCloudSpendingLimitMonthly)
 	}
 }
 
@@ -2145,11 +2201,13 @@ func TestAdminTenantCreateClaimsFreePoolTenant(t *testing.T) {
 	if rt.prov.markPoolUsedCalls.Load() != 1 {
 		t.Fatalf("mark pool used calls = %d, want 1", rt.prov.markPoolUsedCalls.Load())
 	}
-	if rt.prov.lastCluster == nil || rt.prov.lastCluster.ClusterID != "cluster-free-1" {
-		t.Fatalf("last cluster = %#v", rt.prov.lastCluster)
+	lastCluster := rt.prov.lastClusterSnapshot()
+	if lastCluster == nil || lastCluster.ClusterID != "cluster-free-1" {
+		t.Fatalf("last cluster = %#v", lastCluster)
 	}
-	if rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly == nil || *rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly != 123 {
-		t.Fatalf("last spending limit = %#v", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly)
+	lastOptions := rt.prov.lastOptionsSnapshot()
+	if lastOptions.TiDBCloudSpendingLimitMonthly == nil || *lastOptions.TiDBCloudSpendingLimitMonthly != 123 {
+		t.Fatalf("last spending limit = %#v", lastOptions.TiDBCloudSpendingLimitMonthly)
 	}
 	binding, err := rt.meta.GetTenantTiDBCloudOrgBinding(ctx, tenantID)
 	if err != nil {
@@ -2248,11 +2306,13 @@ func TestProvisionClaimsFreePoolTenant(t *testing.T) {
 	if rt.prov.batchPoolCalls.Load() != 0 {
 		t.Errorf("batch pool calls = %d, want 0", rt.prov.batchPoolCalls.Load())
 	}
-	if rt.prov.lastCluster == nil || rt.prov.lastCluster.ClusterID != "cluster-free-1" {
-		t.Errorf("last cluster = %#v", rt.prov.lastCluster)
+	lastCluster := rt.prov.lastClusterSnapshot()
+	if lastCluster == nil || lastCluster.ClusterID != "cluster-free-1" {
+		t.Errorf("last cluster = %#v", lastCluster)
 	}
-	if rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly == nil || *rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly != 123 {
-		t.Errorf("last spending limit = %#v", rt.prov.lastOptions.TiDBCloudSpendingLimitMonthly)
+	lastOptions := rt.prov.lastOptionsSnapshot()
+	if lastOptions.TiDBCloudSpendingLimitMonthly == nil || *lastOptions.TiDBCloudSpendingLimitMonthly != 123 {
+		t.Errorf("last spending limit = %#v", lastOptions.TiDBCloudSpendingLimitMonthly)
 	}
 	quotaCfg, err := rt.meta.GetQuotaConfig(ctx, tenantID)
 	if err != nil {
@@ -2396,8 +2456,9 @@ func TestAdminTenantQuotaSetRequiresPatchLabelAuthorization(t *testing.T) {
 	if cfg.MaxStorageBytes != 200*quotaStorageSizeBytes {
 		t.Fatalf("max storage bytes = %d, want %d", cfg.MaxStorageBytes, 200*quotaStorageSizeBytes)
 	}
-	if len(rt.prov.calls) < 2 || rt.prov.calls[0] != "list" || rt.prov.calls[1] != "mark" {
-		t.Fatalf("calls = %#v, want list then mark", rt.prov.calls)
+	calls := rt.prov.callsSnapshot()
+	if len(calls) < 2 || calls[0] != "list" || calls[1] != "mark" {
+		t.Fatalf("calls = %#v, want list then mark", calls)
 	}
 }
 
@@ -2543,8 +2604,9 @@ func TestAdminTenantDeleteRemovesTiDBCloudOrgBinding(t *testing.T) {
 	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
 		t.Fatalf("deprovision calls = %d, want 1", got)
 	}
-	if rt.prov.lastDeprovision == nil || rt.prov.lastDeprovision.ClusterID != "cluster-quota-1" {
-		t.Fatalf("deprovision cluster = %#v", rt.prov.lastDeprovision)
+	lastDeprovision := rt.prov.lastDeprovisionSnapshot()
+	if lastDeprovision == nil || lastDeprovision.ClusterID != "cluster-quota-1" {
+		t.Fatalf("deprovision cluster = %#v", lastDeprovision)
 	}
 	got, err := rt.meta.GetTenant(ctx, rt.tenantID)
 	if err != nil {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -23,38 +23,39 @@ import (
 )
 
 type quotaTestProvisioner struct {
-	provider               string
-	updateErr              error
-	markErr                error
-	getErr                 error
-	deprovisionErr         error
-	cloudCfg               *tenant.QuotaCloudConfig
-	defaultPublicKey       string
-	defaultPrivateKey      string
-	markHook               func() error
-	deprovisionHook        func(call int, cluster *tenant.ClusterInfo) error
-	updateCalls            atomic.Int32
-	markCalls              atomic.Int32
-	getCalls               atomic.Int32
-	listCalls              atomic.Int32
-	deprovisionCalls       atomic.Int32
-	batchPoolCalls         atomic.Int32
-	markPoolUsedCalls      atomic.Int32
-	markPoolFreeCalls      atomic.Int32
-	lastCluster            *tenant.ClusterInfo
-	lastCredentials        tenant.CredentialProvisionRequest
-	lastOptions            tenant.QuotaUpdateOptions
-	lastListOptions        tenant.ManagedClusterListOptions
-	lastDeprovision        *tenant.ClusterInfo
-	listErr                error
-	listPages              []*tenant.ManagedClusterListResult
-	batchPoolErr           error
-	batchPoolReady         bool
-	batchPoolEmptyPassword bool
-	batchPoolMissingOrg    map[int]bool
-	metadataWaitCalls      atomic.Int32
-	metadataWaitErr        error
-	calls                  []string
+	provider                 string
+	updateErr                error
+	markErr                  error
+	getErr                   error
+	deprovisionErr           error
+	cloudCfg                 *tenant.QuotaCloudConfig
+	defaultPublicKey         string
+	defaultPrivateKey        string
+	markHook                 func() error
+	deprovisionHook          func(call int, cluster *tenant.ClusterInfo) error
+	updateCalls              atomic.Int32
+	markCalls                atomic.Int32
+	getCalls                 atomic.Int32
+	listCalls                atomic.Int32
+	deprovisionCalls         atomic.Int32
+	batchPoolCalls           atomic.Int32
+	markPoolUsedCalls        atomic.Int32
+	markPoolFreeCalls        atomic.Int32
+	lastCluster              *tenant.ClusterInfo
+	lastCredentials          tenant.CredentialProvisionRequest
+	lastOptions              tenant.QuotaUpdateOptions
+	lastListOptions          tenant.ManagedClusterListOptions
+	lastDeprovision          *tenant.ClusterInfo
+	listErr                  error
+	listPages                []*tenant.ManagedClusterListResult
+	batchPoolErr             error
+	batchPoolConnectionReady bool
+	batchPoolEmptyPassword   bool
+	batchPoolMissingOrg      map[int]bool
+	batchPoolMissingTenant   map[int]bool
+	metadataWaitCalls        atomic.Int32
+	metadataWaitErr          error
+	calls                    []string
 }
 
 func (p *quotaTestProvisioner) ProviderType() string { return p.provider }
@@ -183,16 +184,19 @@ func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota
 			DBName:         "tidbcloud_fs",
 			Provider:       tenant.ProviderTiDBCloudNative,
 		})
+		if p.batchPoolMissingTenant[i] {
+			out[len(out)-1].TenantID = ""
+		}
 		if p.batchPoolMissingOrg[i] {
 			out[len(out)-1].OrganizationID = ""
 		}
-		if p.batchPoolReady {
+		if p.batchPoolConnectionReady {
 			out[len(out)-1].Host = "db.example.com"
 			out[len(out)-1].Port = 4000
 			out[len(out)-1].Username = "u.root"
 		}
 	}
-	if !p.batchPoolReady && p.batchPoolErr == nil {
+	if !p.batchPoolConnectionReady && p.batchPoolErr == nil {
 		for _, cluster := range out {
 			cluster.Host = "db.example.com"
 			cluster.Port = 4000
@@ -1524,6 +1528,47 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissi
 	}
 	if pool.PoolID != out.PoolID {
 		t.Fatalf("stored pool id = %q, want %q", pool.PoolID, out.PoolID)
+	}
+	rows, err := rt.meta.ListFreeTenantPoolBindings(context.Background(), "org-1", false, 10)
+	if err != nil {
+		t.Fatalf("list free bindings: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("free bindings = %d, want 1", len(rows))
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	if rt.prov.lastDeprovision == nil || rt.prov.lastDeprovision.ClusterID != "pool-cluster-2" {
+		t.Fatalf("last deprovision = %#v, want pool-cluster-2", rt.prov.lastDeprovision)
+	}
+}
+
+func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneTenantLabelMissing(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
+	rt.prov.batchPoolErr = errors.New("tidbcloud native cluster get status 429")
+	rt.prov.batchPoolMissingTenant = map[int]bool{1: true}
+	rt.prov.metadataWaitErr = errors.New("metadata still unavailable")
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+
+	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+		"pool_size":   2,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var out adminTenantPoolResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 1 {
+		t.Fatalf("pool response = %#v", out)
 	}
 	rows, err := rt.meta.ListFreeTenantPoolBindings(context.Background(), "org-1", false, 10)
 	if err != nil {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -48,6 +48,8 @@ type quotaTestProvisioner struct {
 	lastDeprovision   *tenant.ClusterInfo
 	listErr           error
 	listPages         []*tenant.ManagedClusterListResult
+	batchPoolErr      error
+	batchPoolReady    bool
 	calls             []string
 }
 
@@ -169,15 +171,24 @@ func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota
 			TenantID:       tenantID,
 			ClusterID:      fmt.Sprintf("pool-cluster-%d", i+1),
 			OrganizationID: "org-1",
-			Host:           "db.example.com",
-			Port:           4000,
-			Username:       "u.root",
 			Password:       "pool-pass",
 			DBName:         "tidbcloud_fs",
 			Provider:       tenant.ProviderTiDBCloudNative,
 		})
+		if p.batchPoolReady {
+			out[len(out)-1].Host = "db.example.com"
+			out[len(out)-1].Port = 4000
+			out[len(out)-1].Username = "u.root"
+		}
 	}
-	return out, nil, nil
+	if !p.batchPoolReady && p.batchPoolErr == nil {
+		for _, cluster := range out {
+			cluster.Host = "db.example.com"
+			cluster.Port = 4000
+			cluster.Username = "u.root"
+		}
+	}
+	return out, nil, p.batchPoolErr
 }
 
 func (p *quotaTestProvisioner) MarkClusterPoolUsed(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, _ time.Time, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
@@ -1368,6 +1379,9 @@ func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 	if rt.prov.batchPoolCalls.Load() != 1 {
 		t.Fatalf("batch pool calls = %d, want 1", rt.prov.batchPoolCalls.Load())
 	}
+	if rt.prov.lastOptions.TenantPoolID != out.PoolID {
+		t.Fatalf("batch pool id option = %q, want %q", rt.prov.lastOptions.TenantPoolID, out.PoolID)
+	}
 	pool, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1")
 	if err != nil {
 		t.Fatalf("get pool: %v", err)
@@ -1381,6 +1395,63 @@ func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 	}
 	if free != 2 {
 		t.Fatalf("free = %d, want 2", free)
+	}
+}
+
+func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
+	rt.prov.batchPoolErr = errors.New("tidbcloud native cluster get status 429")
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+
+	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+		"pool_size":   2,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+	var out adminTenantPoolResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 2 {
+		t.Fatalf("pool response = %#v", out)
+	}
+	pool, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if pool.PoolID != out.PoolID {
+		t.Fatalf("stored pool id = %q, want %q", pool.PoolID, out.PoolID)
+	}
+	rows, err := rt.meta.ListFreeTenantPoolBindings(context.Background(), "org-1", false, 10)
+	if err != nil {
+		t.Fatalf("list free bindings: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("free bindings = %d, want 2", len(rows))
+	}
+	for _, row := range rows {
+		if row.Tenant.Status != meta.TenantProvisioning {
+			t.Fatalf("tenant %s status = %s, want provisioning", row.Tenant.ID, row.Tenant.Status)
+		}
+		if row.Tenant.DBUser != "" || row.Tenant.DBHost != "" {
+			t.Fatalf("tenant %s connection = host %q user %q, want incomplete", row.Tenant.ID, row.Tenant.DBHost, row.Tenant.DBUser)
+		}
+		if row.Tenant.ClusterID == "" || len(row.Tenant.DBPasswordCipher) == 0 {
+			t.Fatalf("tenant %s cluster/password not persisted: %#v", row.Tenant.ID, row.Tenant)
+		}
+		if row.Binding.PoolStatus != meta.TenantPoolBindingFree {
+			t.Fatalf("tenant %s pool status = %s, want free", row.Tenant.ID, row.Binding.PoolStatus)
+		}
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1384,6 +1384,59 @@ func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 	}
 }
 
+func TestAdminTenantPoolCreateRejectsAboveMaxSize(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.server.tenantPoolMaxSize = 2
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+
+	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+		"pool_size":   3,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "pool_size must be less than or equal to 2") {
+		t.Fatalf("body = %s", body)
+	}
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("list calls = %d, want 0", got)
+	}
+	if got := rt.prov.batchPoolCalls.Load(); got != 0 {
+		t.Fatalf("batch pool calls = %d, want 0", got)
+	}
+}
+
+func TestAdminTenantPoolUpdateRejectsAboveMaxSize(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.server.tenantPoolMaxSize = 2
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+
+	resp := patchJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+		"pool_size":   3,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadRequest {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 400: %s", resp.StatusCode, body)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "pool_size must be less than or equal to 2") {
+		t.Fatalf("body = %s", body)
+	}
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("list calls = %d, want 0", got)
+	}
+}
+
 func TestAdminTenantPoolCreateCleansUpWhenOrganizationBackfillConflicts(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -145,6 +145,7 @@ type Server struct {
 	forkWorkerClosed      bool
 	tenantPoolLocks       sync.Map
 	tenantPoolCreateLocks sync.Map
+	tenantPoolResumeJobs  sync.Map
 	schemaInitErrors      sync.Map
 	leader                *leader.Manager
 	// leaderWorkerCtx gates leader-only background schedulers. When leadership
@@ -744,52 +745,15 @@ func (s *Server) resumeProvisioningTenantsWithCtx(ctx context.Context) {
 			continue
 		}
 		if t.Provider == tenant.ProviderTiDBCloudNative && t.DBUser == "" {
-			s.resumeNativeProvisioningWithoutConnection(ctx, t)
+			logger.Warn(ctx, "resume_provisioning_native_no_connection",
+				zap.String("tenant_id", t.ID),
+				zap.String("provider", t.Provider),
+				zap.String("cluster_id", t.ClusterID),
+				zap.String("reason", "tidbcloud_credentials_unavailable"))
 			continue
 		}
 		s.startTenantSchemaInitResume(ctx, t)
 	}
-}
-
-func (s *Server) resumeNativeProvisioningWithoutConnection(ctx context.Context, t meta.Tenant) {
-	logFields := []zap.Field{
-		zap.String("tenant_id", t.ID),
-		zap.String("provider", t.Provider),
-		zap.String("cluster_id", t.ClusterID),
-	}
-	markFailed := func(fields []zap.Field) {
-		if err := s.meta.UpdateTenantStatus(ctx, t.ID, meta.TenantFailed); err != nil {
-			logger.Error(ctx, "resume_provisioning_native_mark_failed", append(fields, zap.Error(err))...)
-		}
-	}
-	if strings.TrimSpace(t.ClusterID) == "" {
-		logger.Warn(ctx, "resume_provisioning_native_no_cluster", logFields...)
-		markFailed(logFields)
-		return
-	}
-	plain, err := s.pool.Decrypt(ctx, t.DBPasswordCipher)
-	if err != nil || strings.TrimSpace(string(plain)) == "" {
-		fields := append(logFields, zap.Error(err))
-		logger.Warn(ctx, "resume_provisioning_native_no_password", fields...)
-		markFailed(fields)
-		return
-	}
-	defaultReq := resolveDefaultCredentials(s.provisioner)
-	if defaultReq == nil {
-		logger.Warn(ctx, "resume_provisioning_native_no_credentials", logFields...)
-		markFailed(logFields)
-		return
-	}
-	cluster := &tenant.ClusterInfo{
-		TenantID:  t.ID,
-		ClusterID: t.ClusterID,
-		Password:  string(plain),
-		DBName:    t.DBName,
-		Provider:  t.Provider,
-	}
-	logger.Info(ctx, "resume_provisioning_native_metadata",
-		append(logFields, zap.String("db_name", t.DBName))...)
-	s.startPoolClusterMetadataResume(ctx, cluster, *defaultReq)
 }
 
 // resumeDeletingForkTenantsWithCtx resumes cleanup for deleting/failed fork tenants.
@@ -867,6 +831,14 @@ func (s *Server) startTenantSchemaInitResume(ctx context.Context, t meta.Tenant)
 }
 
 func (s *Server) reconcilePendingTenant(ctx context.Context, t meta.Tenant) {
+	if t.Provider == tenant.ProviderTiDBCloudNative && strings.TrimSpace(t.ClusterID) != "" {
+		logger.Info(ctx, "resume_pending_pool_tenant_skipped",
+			zap.String("tenant_id", t.ID),
+			zap.String("provider", t.Provider),
+			zap.String("cluster_id", t.ClusterID),
+			zap.String("reason", "tidbcloud_credentials_unavailable"))
+		return
+	}
 	if !isStalePendingTenant(time.Now().UTC(), t) {
 		return
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,7 +55,7 @@ type Config struct {
 	S3Dir             string
 	MaxUploadBytes    int64
 	// TenantPoolMaxSize caps admin tenant pool create/update target size.
-	// Values <= 0 leave the pool size uncapped.
+	// Values <= 0 use DefaultTenantPoolMaxSize.
 	TenantPoolMaxSize int
 	// InlineThreshold is the server-wide DB-inline vs S3 cutoff surfaced to
 	// clients via /v1/status. When 0, the value is inferred from
@@ -743,14 +743,47 @@ func (s *Server) resumeProvisioningTenantsWithCtx(ctx context.Context) {
 			continue
 		}
 		if t.Provider == tenant.ProviderTiDBCloudNative && t.DBUser == "" {
-			logger.Warn(ctx, "resume_provisioning_native_no_connection",
-				zap.String("tenant_id", t.ID),
-				zap.String("provider", t.Provider),
-				zap.String("cluster_id", t.ClusterID))
+			s.resumeNativeProvisioningWithoutConnection(ctx, t)
 			continue
 		}
 		s.startTenantSchemaInitResume(ctx, t)
 	}
+}
+
+func (s *Server) resumeNativeProvisioningWithoutConnection(ctx context.Context, t meta.Tenant) {
+	logFields := []zap.Field{
+		zap.String("tenant_id", t.ID),
+		zap.String("provider", t.Provider),
+		zap.String("cluster_id", t.ClusterID),
+	}
+	if strings.TrimSpace(t.ClusterID) == "" {
+		logger.Warn(ctx, "resume_provisioning_native_no_cluster", logFields...)
+		_ = s.meta.UpdateTenantStatus(context.Background(), t.ID, meta.TenantFailed)
+		return
+	}
+	plain, err := s.pool.Decrypt(ctx, t.DBPasswordCipher)
+	if err != nil || strings.TrimSpace(string(plain)) == "" {
+		fields := append(logFields, zap.Error(err))
+		logger.Warn(ctx, "resume_provisioning_native_no_password", fields...)
+		_ = s.meta.UpdateTenantStatus(context.Background(), t.ID, meta.TenantFailed)
+		return
+	}
+	defaultReq := resolveDefaultCredentials(s.provisioner)
+	if defaultReq == nil {
+		logger.Warn(ctx, "resume_provisioning_native_no_credentials", logFields...)
+		_ = s.meta.UpdateTenantStatus(context.Background(), t.ID, meta.TenantFailed)
+		return
+	}
+	cluster := &tenant.ClusterInfo{
+		TenantID:  t.ID,
+		ClusterID: t.ClusterID,
+		Password:  string(plain),
+		DBName:    t.DBName,
+		Provider:  t.Provider,
+	}
+	logger.Info(ctx, "resume_provisioning_native_metadata",
+		append(logFields, zap.String("db_name", t.DBName))...)
+	s.startPoolClusterMetadataResume(ctx, cluster, *defaultReq)
 }
 
 // resumeDeletingForkTenantsWithCtx resumes cleanup for deleting/failed fork tenants.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -756,22 +756,27 @@ func (s *Server) resumeNativeProvisioningWithoutConnection(ctx context.Context, 
 		zap.String("provider", t.Provider),
 		zap.String("cluster_id", t.ClusterID),
 	}
+	markFailed := func(fields []zap.Field) {
+		if err := s.meta.UpdateTenantStatus(ctx, t.ID, meta.TenantFailed); err != nil {
+			logger.Error(ctx, "resume_provisioning_native_mark_failed", append(fields, zap.Error(err))...)
+		}
+	}
 	if strings.TrimSpace(t.ClusterID) == "" {
 		logger.Warn(ctx, "resume_provisioning_native_no_cluster", logFields...)
-		_ = s.meta.UpdateTenantStatus(context.Background(), t.ID, meta.TenantFailed)
+		markFailed(logFields)
 		return
 	}
 	plain, err := s.pool.Decrypt(ctx, t.DBPasswordCipher)
 	if err != nil || strings.TrimSpace(string(plain)) == "" {
 		fields := append(logFields, zap.Error(err))
 		logger.Warn(ctx, "resume_provisioning_native_no_password", fields...)
-		_ = s.meta.UpdateTenantStatus(context.Background(), t.ID, meta.TenantFailed)
+		markFailed(fields)
 		return
 	}
 	defaultReq := resolveDefaultCredentials(s.provisioner)
 	if defaultReq == nil {
 		logger.Warn(ctx, "resume_provisioning_native_no_credentials", logFields...)
-		_ = s.meta.UpdateTenantStatus(context.Background(), t.ID, meta.TenantFailed)
+		markFailed(logFields)
 		return
 	}
 	cluster := &tenant.ClusterInfo{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -54,6 +54,9 @@ type Config struct {
 	LocalS3           *s3client.LocalS3Client
 	S3Dir             string
 	MaxUploadBytes    int64
+	// TenantPoolMaxSize caps admin tenant pool create/update target size.
+	// Values <= 0 leave the pool size uncapped.
+	TenantPoolMaxSize int
 	// InlineThreshold is the server-wide DB-inline vs S3 cutoff surfaced to
 	// clients via /v1/status. When 0, the value is inferred from
 	// cfg.Backend.InlineThreshold() (or omitted in responses if no backend).
@@ -122,6 +125,7 @@ type Server struct {
 	vaultIssuerURL        string
 	publicURL             string
 	maxUploadBytes        int64
+	tenantPoolMaxSize     int
 	inlineThreshold       int64
 	metrics               *serverMetrics
 	logger                *zap.Logger
@@ -246,6 +250,7 @@ func NewWithConfig(cfg Config) *Server {
 		publicURL:         strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
 		provisioner:       cfg.Provisioner,
 		maxUploadBytes:    maxUpload,
+		tenantPoolMaxSize: cfg.TenantPoolMaxSize,
 		inlineThreshold:   inlineThreshold,
 		metrics:           newServerMetrics(),
 		logger:            logger,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -745,11 +745,18 @@ func (s *Server) resumeProvisioningTenantsWithCtx(ctx context.Context) {
 			continue
 		}
 		if t.Provider == tenant.ProviderTiDBCloudNative && t.DBUser == "" {
+			// TiDB Cloud native metadata resume is gated by request-scoped customer credentials.
 			logger.Warn(ctx, "resume_provisioning_native_no_connection",
 				zap.String("tenant_id", t.ID),
 				zap.String("provider", t.Provider),
 				zap.String("cluster_id", t.ClusterID),
 				zap.String("reason", "tidbcloud_credentials_unavailable"))
+			if s.metrics != nil {
+				s.metrics.recordEvent(t.ID, "tenant_pool_pending_resume",
+					"provider", t.Provider,
+					"result", "skipped",
+					"reason", "tidbcloud_credentials_unavailable")
+			}
 			continue
 		}
 		s.startTenantSchemaInitResume(ctx, t)
@@ -831,15 +838,43 @@ func (s *Server) startTenantSchemaInitResume(ctx context.Context, t meta.Tenant)
 }
 
 func (s *Server) reconcilePendingTenant(ctx context.Context, t meta.Tenant) {
-	if t.Provider == tenant.ProviderTiDBCloudNative && strings.TrimSpace(t.ClusterID) != "" {
+	if t.Provider == tenant.ProviderTiDBCloudNative && strings.TrimSpace(t.ClusterID) != "" && strings.TrimSpace(t.DBUser) == "" {
 		logger.Info(ctx, "resume_pending_pool_tenant_skipped",
 			zap.String("tenant_id", t.ID),
 			zap.String("provider", t.Provider),
 			zap.String("cluster_id", t.ClusterID),
 			zap.String("reason", "tidbcloud_credentials_unavailable"))
+		if s.metrics != nil {
+			s.metrics.recordEvent(t.ID, "tenant_pool_pending_resume",
+				"provider", t.Provider,
+				"result", "skipped",
+				"reason", "tidbcloud_credentials_unavailable")
+		}
 		return
 	}
 	if !isStalePendingTenant(time.Now().UTC(), t) {
+		return
+	}
+	if pendingTenantConnectionReady(t) {
+		updated, err := s.meta.UpdateTenantStatusIf(ctx, t.ID, meta.TenantPending, meta.TenantProvisioning)
+		if err != nil {
+			logger.Error(ctx, "resume_pending_schema_init_status_update_error",
+				zap.String("tenant_id", t.ID),
+				zap.Error(err))
+			return
+		}
+		if !updated {
+			logger.Info(ctx, "resume_pending_schema_init_skipped",
+				zap.String("tenant_id", t.ID),
+				zap.String("reason", "status_changed"))
+			return
+		}
+		t.Status = meta.TenantProvisioning
+		logger.Info(ctx, "resume_pending_schema_init_started",
+			zap.String("tenant_id", t.ID),
+			zap.String("provider", t.Provider),
+			zap.String("cluster_id", t.ClusterID))
+		s.startTenantSchemaInitResume(ctx, t)
 		return
 	}
 	logger.Warn(ctx, "resume_pending_mark_failed",
@@ -859,6 +894,14 @@ func (s *Server) reconcilePendingTenant(ctx context.Context, t meta.Tenant) {
 			zap.String("tenant_id", t.ID),
 			zap.String("reason", "status_changed"))
 	}
+}
+
+func pendingTenantConnectionReady(t meta.Tenant) bool {
+	return strings.TrimSpace(t.DBHost) != "" &&
+		t.DBPort > 0 &&
+		strings.TrimSpace(t.DBUser) != "" &&
+		len(t.DBPasswordCipher) > 0 &&
+		strings.TrimSpace(t.DBName) != ""
 }
 
 func isStalePendingTenant(now time.Time, t meta.Tenant) bool {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -54,8 +54,9 @@ type Config struct {
 	LocalS3           *s3client.LocalS3Client
 	S3Dir             string
 	MaxUploadBytes    int64
-	// TenantPoolMaxSize caps admin tenant pool create/update target size.
-	// Values <= 0 use DefaultTenantPoolMaxSize.
+	// TenantPoolMaxSize caps admin tenant pool create/update target size. Values
+	// <= 0 are normalized to DefaultTenantPoolMaxSize; the pool is never
+	// intentionally uncapped.
 	TenantPoolMaxSize int
 	// InlineThreshold is the server-wide DB-inline vs S3 cutoff surfaced to
 	// clients via /v1/status. When 0, the value is inferred from
@@ -182,7 +183,7 @@ var (
 const DefaultMaxUploadBytes int64 = 10 * (1 << 30) // 10 GiB
 
 // DefaultTenantPoolMaxSize caps admin tenant pools unless overridden by server
-// configuration.
+// configuration with a positive value.
 const DefaultTenantPoolMaxSize = 200
 
 // TenantStatusResponse is the JSON body of GET /v1/status. Fields are filled

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -181,6 +181,10 @@ var (
 // Keep callers on this exported constant so the default stays consistent.
 const DefaultMaxUploadBytes int64 = 10 * (1 << 30) // 10 GiB
 
+// DefaultTenantPoolMaxSize caps admin tenant pools unless overridden by server
+// configuration.
+const DefaultTenantPoolMaxSize = 200
+
 // TenantStatusResponse is the JSON body of GET /v1/status. Fields are filled
 // per authenticated tenant so callers can discover their effective limits
 // before initiating uploads. MaxUploadBytes is currently process-wide but the
@@ -238,6 +242,10 @@ func NewWithConfig(cfg Config) *Server {
 	if inlineThreshold <= 0 {
 		inlineThreshold = backend.DefaultInlineThreshold
 	}
+	tenantPoolMaxSize := cfg.TenantPoolMaxSize
+	if tenantPoolMaxSize <= 0 {
+		tenantPoolMaxSize = DefaultTenantPoolMaxSize
+	}
 	forkWorkerCtx, forkWorkerCancel := context.WithCancel(context.Background())
 	s := &Server{
 		fallback:          cfg.Backend,
@@ -250,7 +258,7 @@ func NewWithConfig(cfg Config) *Server {
 		publicURL:         strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
 		provisioner:       cfg.Provisioner,
 		maxUploadBytes:    maxUpload,
-		tenantPoolMaxSize: cfg.TenantPoolMaxSize,
+		tenantPoolMaxSize: tenantPoolMaxSize,
 		inlineThreshold:   inlineThreshold,
 		metrics:           newServerMetrics(),
 		logger:            logger,
@@ -732,6 +740,13 @@ func (s *Server) resumeProvisioningTenantsWithCtx(ctx context.Context) {
 				continue
 			}
 			s.startForkProvision(ctx, t.ID)
+			continue
+		}
+		if t.Provider == tenant.ProviderTiDBCloudNative && t.DBUser == "" {
+			logger.Warn(ctx, "resume_provisioning_native_no_connection",
+				zap.String("tenant_id", t.ID),
+				zap.String("provider", t.Provider),
+				zap.String("cluster_id", t.ClusterID))
 			continue
 		}
 		s.startTenantSchemaInitResume(ctx, t)

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -1387,6 +1387,13 @@ func TestNewWithConfigUsesDefaultMaxUploadBytes(t *testing.T) {
 	}
 }
 
+func TestNewWithConfigUsesDefaultTenantPoolMaxSize(t *testing.T) {
+	s := NewWithConfig(Config{})
+	if s.tenantPoolMaxSize != DefaultTenantPoolMaxSize {
+		t.Fatalf("default tenantPoolMaxSize = %d, want %d", s.tenantPoolMaxSize, DefaultTenantPoolMaxSize)
+	}
+}
+
 func TestDeclaredContentLengthOverMaxRejected(t *testing.T) {
 	base, _ := newTestServerWithS3(t)
 	s := NewWithConfig(Config{Backend: base.fallback, MaxUploadBytes: 10})

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -77,6 +77,11 @@ type TenantPoolClusterMetadataWaiter interface {
 	WaitForPoolClusterMetadata(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) (*ClusterInfo, error)
 }
 
+type TenantPoolClusterMetadataBatchWaiter interface {
+	Provisioner
+	WaitForPoolClustersMetadata(ctx context.Context, clusters []*ClusterInfo, req CredentialProvisionRequest) ([]*ClusterInfo, error)
+}
+
 type CredentialDeprovisioner interface {
 	Provisioner
 	DeprovisionWithCredentials(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) error

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -72,6 +72,11 @@ type TenantPoolClusterManager interface {
 	MarkClusterPoolFree(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) error
 }
 
+type TenantPoolClusterMetadataWaiter interface {
+	Provisioner
+	WaitForPoolClusterMetadata(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) (*ClusterInfo, error)
+}
+
 type CredentialDeprovisioner interface {
 	Provisioner
 	DeprovisionWithCredentials(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) error
@@ -90,6 +95,7 @@ type QuotaGetter interface {
 
 type QuotaUpdateOptions struct {
 	TiDBCloudSpendingLimitMonthly *int64
+	TenantPoolID                  string
 }
 
 type ManagedClusterListOptions struct {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1023,7 +1023,15 @@ func (p *Provisioner) listClusterInfosPageWithCredentials(ctx context.Context, p
 	filter := fmt.Sprintf(`labels.%q = "true"`, Drive9ManagedLabel)
 	clusterIDFilter := compactNonEmptyStrings(clusterIDs)
 	if len(clusterIDFilter) > 0 {
-		filter = fmt.Sprintf(`clusterId = %s AND %s`, strings.Join(clusterIDFilter, ","), filter)
+		parts := make([]string, 0, len(clusterIDFilter))
+		for _, clusterID := range clusterIDFilter {
+			parts = append(parts, fmt.Sprintf("clusterId = %s", clusterID))
+		}
+		if len(parts) == 1 {
+			filter = fmt.Sprintf("%s AND %s", parts[0], filter)
+		} else {
+			filter = fmt.Sprintf("(%s) AND %s", strings.Join(parts, " OR "), filter)
+		}
 	}
 	values.Set("filter", filter)
 	endpoint := p.apiURL + "/v1beta1/clusters?" + values.Encode()

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1023,15 +1023,7 @@ func (p *Provisioner) listClusterInfosPageWithCredentials(ctx context.Context, p
 	filter := fmt.Sprintf(`labels.%q = "true"`, Drive9ManagedLabel)
 	clusterIDFilter := compactNonEmptyStrings(clusterIDs)
 	if len(clusterIDFilter) > 0 {
-		parts := make([]string, 0, len(clusterIDFilter))
-		for _, clusterID := range clusterIDFilter {
-			parts = append(parts, fmt.Sprintf("clusterId = %s", clusterID))
-		}
-		if len(parts) == 1 {
-			filter = fmt.Sprintf("%s AND %s", parts[0], filter)
-		} else {
-			filter = fmt.Sprintf("(%s) AND %s", strings.Join(parts, " OR "), filter)
-		}
+		filter = fmt.Sprintf("clusterId = %q AND %s", strings.Join(clusterIDFilter, ","), filter)
 	}
 	values.Set("filter", filter)
 	endpoint := p.apiURL + "/v1beta1/clusters?" + values.Encode()

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1023,7 +1023,7 @@ func (p *Provisioner) listClusterInfosPageWithCredentials(ctx context.Context, p
 	filter := fmt.Sprintf(`labels.%q = "true"`, Drive9ManagedLabel)
 	clusterIDFilter := compactNonEmptyStrings(clusterIDs)
 	if len(clusterIDFilter) > 0 {
-		filter = fmt.Sprintf(`clusterId = %q AND %s`, strings.Join(clusterIDFilter, ","), filter)
+		filter = fmt.Sprintf(`clusterId = %s AND %s`, strings.Join(clusterIDFilter, ","), filter)
 	}
 	values.Set("filter", filter)
 	endpoint := p.apiURL + "/v1beta1/clusters?" + values.Encode()

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -45,6 +46,7 @@ const (
 	Drive9ManagedLabel         = "drive9.ai/managed"
 	Drive9TenantIDLabel        = "drive9.ai/tenant_id"
 	Drive9PoolStatusLabel      = "drive9.ai/status"
+	Drive9PoolIDLabel          = "drive9.ai/pool_id"
 	Drive9PoolUsedAtLabel      = "drive9.ai/used_at"
 	Drive9QuotaUpdateAtLabel   = "drive9.ai/update_quota_at"
 	TiDBCloudOrganizationLabel = "tidb.cloud/organization"
@@ -64,8 +66,10 @@ var databaseNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)
 var displayNameCharPattern = regexp.MustCompile(`[^A-Za-z0-9-]`)
 
 var (
-	ensureDatabaseFunc          = ensureDatabase
-	tidbCloudNativePollInterval = 5 * time.Second
+	ensureDatabaseFunc                       = ensureDatabase
+	tidbCloudNativePollInterval              = 5 * time.Second
+	tidbCloudNativeBatchMetadataGroupSize    = 10
+	tidbCloudNativeBatchMetadataPollInterval = 15 * time.Second
 )
 
 type Provisioner struct {
@@ -360,17 +364,21 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 			return nil, nil, err
 		}
 		passwords[tenantID] = password
+		labels := map[string]string{
+			Drive9ManagedLabel:    "true",
+			Drive9TenantIDLabel:   tenantID,
+			Drive9PoolStatusLabel: "free",
+		}
+		if poolID := strings.TrimSpace(opts.TenantPoolID); poolID != "" {
+			labels[Drive9PoolIDLabel] = poolID
+		}
 		cluster := map[string]any{
 			"displayName":  clusterDisplayName(tenantID),
 			"rootPassword": password,
 			"region": map[string]string{
 				"name": p.regionName(),
 			},
-			"labels": map[string]string{
-				Drive9ManagedLabel:    "true",
-				Drive9TenantIDLabel:   tenantID,
-				Drive9PoolStatusLabel: "free",
-			},
+			"labels": labels,
 		}
 		if opts.TiDBCloudSpendingLimitMonthly != nil {
 			spendingLimit = opts.TiDBCloudSpendingLimitMonthly
@@ -411,7 +419,7 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 		return nil, nil, fmt.Errorf("tidbcloud native batch provision returned %d clusters, want %d", len(created.Clusters), len(tenantIDs))
 	}
 	out := make([]*tenant.ClusterInfo, len(created.Clusters))
-	var wg sync.WaitGroup
+	pending := make([]batchClusterMetadataTarget, 0, len(created.Clusters))
 	errs := make([]error, len(created.Clusters))
 	for i := range created.Clusters {
 		i := i
@@ -430,38 +438,136 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 			errs[i] = fmt.Errorf("tidbcloud native batch response missing cluster id for tenant %q", tenantID)
 			continue
 		}
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			clusterInfo := &info
-			if clusterProvisionMetadataIncomplete(clusterInfo, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
-				waited, waitErr := p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, info.ClusterID)
-				if waitErr != nil {
-					errs[i] = waitErr
-					return
-				}
-				clusterInfo = waited
-			}
-			out[i] = p.clusterInfoFromResponse(tenantID, dbName, password, clusterInfo)
-		}()
+		if clusterProvisionMetadataIncomplete(&info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
+			pending = append(pending, batchClusterMetadataTarget{index: i, tenantID: tenantID, password: password, initial: info})
+			continue
+		}
+		out[i] = p.clusterInfoFromResponse(tenantID, dbName, password, &info)
 	}
-	wg.Wait()
+	if len(pending) > 0 {
+		p.waitForBatchClusterProvisionMetadata(ctx, publicKey, privateKey, dbName, strings.TrimSpace(opts.TenantPoolID), pending, out, errs)
+	}
 	for _, err := range errs {
 		if err != nil {
-			return fallbackBatchClusterInfos(created.Clusters, dbName), nil, err
+			return fallbackBatchClusterInfos(created.Clusters, dbName, passwords), nil, err
 		}
 	}
 	cloudCfg := &tenant.QuotaCloudConfig{Labels: map[string]string{
 		Drive9ManagedLabel:    "true",
 		Drive9PoolStatusLabel: "free",
 	}}
+	if poolID := strings.TrimSpace(opts.TenantPoolID); poolID != "" {
+		cloudCfg.Labels[Drive9PoolIDLabel] = poolID
+	}
 	if spendingLimit != nil {
 		cloudCfg.TiDBCloudSpendingLimitMonthly = ptrInt64(*spendingLimit)
 	}
 	return out, cloudCfg, nil
 }
 
-func fallbackBatchClusterInfos(clusters []clusterInfo, dbName string) []*tenant.ClusterInfo {
+type batchClusterMetadataTarget struct {
+	index    int
+	tenantID string
+	password string
+	initial  clusterInfo
+}
+
+func (p *Provisioner) waitForBatchClusterProvisionMetadata(ctx context.Context, publicKey, privateKey, dbName, poolID string, pending []batchClusterMetadataTarget, out []*tenant.ClusterInfo, errs []error) {
+	groupSize := tidbCloudNativeBatchMetadataGroupSize
+	if groupSize <= 0 {
+		groupSize = 10
+	}
+	var wg sync.WaitGroup
+	for start := 0; start < len(pending); start += groupSize {
+		end := start + groupSize
+		if end > len(pending) {
+			end = len(pending)
+		}
+		group := pending[start:end]
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.waitForBatchClusterProvisionMetadataGroup(ctx, publicKey, privateKey, dbName, poolID, group, out, errs)
+		}()
+	}
+	wg.Wait()
+}
+
+func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Context, publicKey, privateKey, dbName, poolID string, group []batchClusterMetadataTarget, out []*tenant.ClusterInfo, errs []error) {
+	deadline := time.Now().Add(10 * time.Minute)
+	pending := make(map[string]batchClusterMetadataTarget, len(group))
+	clusterIDs := make([]string, 0, len(group))
+	for _, target := range group {
+		clusterID := strings.TrimSpace(target.initial.ClusterID)
+		if clusterID == "" {
+			errs[target.index] = fmt.Errorf("tidbcloud native batch response missing cluster id for tenant %q", target.tenantID)
+			continue
+		}
+		pending[clusterID] = target
+		clusterIDs = append(clusterIDs, clusterID)
+	}
+	for len(pending) > 0 {
+		infos, err := p.listClusterInfosWithCredentials(ctx, publicKey, privateKey, clusterIDs, len(clusterIDs))
+		if err != nil {
+			if !isTiDBCloudStatus(err, http.StatusTooManyRequests) || time.Now().After(deadline) {
+				for _, target := range pending {
+					errs[target.index] = err
+				}
+				return
+			}
+		} else {
+			for i := range infos {
+				info := infos[i]
+				clusterID := strings.TrimSpace(info.ClusterID)
+				target, ok := pending[clusterID]
+				if !ok {
+					continue
+				}
+				if tenantID := strings.TrimSpace(info.Labels[Drive9TenantIDLabel]); tenantID != target.tenantID {
+					errs[target.index] = fmt.Errorf("tidbcloud native batch metadata tenant label mismatch for cluster %q: got %q, want %q", clusterID, tenantID, target.tenantID)
+					delete(pending, clusterID)
+					continue
+				}
+				if poolID != "" && strings.TrimSpace(info.Labels[Drive9PoolIDLabel]) != poolID {
+					errs[target.index] = fmt.Errorf("tidbcloud native batch metadata pool label mismatch for cluster %q", clusterID)
+					delete(pending, clusterID)
+					continue
+				}
+				if clusterProvisionMetadataIncomplete(&info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
+					continue
+				}
+				out[target.index] = p.clusterInfoFromResponse(target.tenantID, dbName, target.password, &info)
+				delete(pending, clusterID)
+			}
+		}
+		if len(pending) == 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			for clusterID, target := range pending {
+				errs[target.index] = fmt.Errorf("tidbcloud native cluster %s missing connection metadata or organization label before timeout", clusterID)
+			}
+			return
+		}
+		select {
+		case <-ctx.Done():
+			for _, target := range pending {
+				errs[target.index] = ctx.Err()
+			}
+			return
+		case <-time.After(batchMetadataPollInterval()):
+		}
+	}
+}
+
+func batchMetadataPollInterval() time.Duration {
+	if tidbCloudNativeBatchMetadataPollInterval <= 0 {
+		return tidbCloudNativePollInterval
+	}
+	return tidbCloudNativeBatchMetadataPollInterval
+}
+
+func fallbackBatchClusterInfos(clusters []clusterInfo, dbName string, passwords map[string]string) []*tenant.ClusterInfo {
 	out := make([]*tenant.ClusterInfo, 0, len(clusters))
 	for i := range clusters {
 		info := clusters[i]
@@ -470,11 +576,36 @@ func fallbackBatchClusterInfos(clusters []clusterInfo, dbName string) []*tenant.
 			TenantID:       tenantID,
 			ClusterID:      strings.TrimSpace(info.ClusterID),
 			OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
+			Password:       passwords[tenantID],
 			DBName:         dbName,
 			Provider:       tenant.ProviderTiDBCloudNative,
 		})
 	}
 	return out
+}
+
+func (p *Provisioner) WaitForPoolClusterMetadata(ctx context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) (*tenant.ClusterInfo, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, fmt.Errorf("public_key and private_key are required")
+	}
+	if cluster == nil || strings.TrimSpace(cluster.ClusterID) == "" {
+		return nil, fmt.Errorf("cluster id is required")
+	}
+	dbName := strings.TrimSpace(cluster.DBName)
+	if dbName == "" {
+		var err error
+		dbName, err = p.resolveDatabaseName("")
+		if err != nil {
+			return nil, err
+		}
+	}
+	info, err := p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, strings.TrimSpace(cluster.ClusterID))
+	if err != nil {
+		return nil, err
+	}
+	return p.clusterInfoFromResponse(strings.TrimSpace(cluster.TenantID), dbName, cluster.Password, info), nil
 }
 
 func (p *Provisioner) MarkClusterPoolUsed(ctx context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, usedAt time.Time, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
@@ -850,45 +981,73 @@ func (p *Provisioner) ListManagedClusters(ctx context.Context, req tenant.Creden
 	if pageSize <= 0 {
 		pageSize = 100
 	}
+	infos, nextPageToken, err := p.listClusterInfosPageWithCredentials(ctx, publicKey, privateKey, []string{opts.ClusterID}, pageSize, opts.PageToken)
+	if err != nil {
+		return nil, fmt.Errorf("list managed clusters: %w", err)
+	}
+	out := &tenant.ManagedClusterListResult{
+		Clusters:      make([]tenant.CloudClusterInfo, 0, len(infos)),
+		NextPageToken: strings.TrimSpace(nextPageToken),
+	}
+	for _, info := range infos {
+		out.Clusters = append(out.Clusters, cloudClusterInfoFromClusterInfo(info))
+	}
+	return out, nil
+}
+
+func (p *Provisioner) listClusterInfosWithCredentials(ctx context.Context, publicKey, privateKey string, clusterIDs []string, pageSize int) ([]clusterInfo, error) {
+	var out []clusterInfo
+	pageToken := ""
+	for {
+		infos, nextPageToken, err := p.listClusterInfosPageWithCredentials(ctx, publicKey, privateKey, clusterIDs, pageSize, pageToken)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, infos...)
+		if nextPageToken == "" {
+			return out, nil
+		}
+		pageToken = nextPageToken
+	}
+}
+
+func (p *Provisioner) listClusterInfosPageWithCredentials(ctx context.Context, publicKey, privateKey string, clusterIDs []string, pageSize int, pageToken string) ([]clusterInfo, string, error) {
+	if pageSize <= 0 {
+		pageSize = 100
+	}
 	values := url.Values{}
 	values.Set("pageSize", strconv.Itoa(pageSize))
-	if token := strings.TrimSpace(opts.PageToken); token != "" {
+	if token := strings.TrimSpace(pageToken); token != "" {
 		values.Set("pageToken", token)
 	}
 	filter := fmt.Sprintf(`labels.%q = "true"`, Drive9ManagedLabel)
-	if clusterID := strings.TrimSpace(opts.ClusterID); clusterID != "" {
-		filter = fmt.Sprintf(`clusterId = %q AND %s`, clusterID, filter)
+	clusterIDFilter := compactNonEmptyStrings(clusterIDs)
+	if len(clusterIDFilter) > 0 {
+		filter = fmt.Sprintf(`clusterId = %q AND %s`, strings.Join(clusterIDFilter, ","), filter)
 	}
 	values.Set("filter", filter)
 	endpoint := p.apiURL + "/v1beta1/clusters?" + values.Encode()
 	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return nil, fmt.Errorf("list managed clusters: %w", err)
+		return nil, "", err
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 		if readErr != nil {
-			return nil, fmt.Errorf("read cluster list error body: %w", readErr)
+			return nil, "", fmt.Errorf("read cluster list error body: %w", readErr)
 		}
-		return nil, quotaStatusError("cluster list", resp.StatusCode, sanitizeUpstreamBody(raw))
+		return nil, "", &tidbCloudStatusError{operation: "cluster list", code: resp.StatusCode, upstreamBody: sanitizeUpstreamBody(raw)}
 	}
 	raw, readErr := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
 	if readErr != nil {
-		return nil, fmt.Errorf("read cluster list body: %w", readErr)
+		return nil, "", fmt.Errorf("read cluster list body: %w", readErr)
 	}
 	list, err := parseClusterList(raw)
 	if err != nil {
-		return nil, fmt.Errorf("parse cluster list: %w", err)
+		return nil, "", fmt.Errorf("parse cluster list: %w", err)
 	}
-	out := &tenant.ManagedClusterListResult{
-		Clusters:      make([]tenant.CloudClusterInfo, 0, len(list.Clusters)),
-		NextPageToken: strings.TrimSpace(list.NextPageToken),
-	}
-	for _, info := range list.Clusters {
-		out.Clusters = append(out.Clusters, cloudClusterInfoFromClusterInfo(info))
-	}
-	return out, nil
+	return list.Clusters, strings.TrimSpace(list.NextPageToken), nil
 }
 
 func (p *Provisioner) clusterQuotaInfo(ctx context.Context, publicKey, privateKey, clusterID string) (map[string]string, *tenant.QuotaCloudConfig, error) {
@@ -1110,6 +1269,24 @@ func readUpstreamBody(r io.Reader, limit int64) ([]byte, error) {
 	return raw, nil
 }
 
+type tidbCloudStatusError struct {
+	operation    string
+	code         int
+	upstreamBody string
+}
+
+func (e *tidbCloudStatusError) Error() string {
+	if e == nil {
+		return ""
+	}
+	return statusError(e.operation, e.code, e.upstreamBody)
+}
+
+func isTiDBCloudStatus(err error, code int) bool {
+	var statusErr *tidbCloudStatusError
+	return errors.As(err, &statusErr) && statusErr.code == code
+}
+
 func statusError(operation string, code int, upstreamBody string) string {
 	msg := fmt.Sprintf("tidbcloud native %s status %d", operation, code)
 	if upstreamBody != "" {
@@ -1282,6 +1459,23 @@ func cloudClusterInfoFromClusterInfo(info clusterInfo) tenant.CloudClusterInfo {
 	return out
 }
 
+func compactNonEmptyStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
 func (p *Provisioner) clusterInfoFromResponse(tenantID, dbName, password string, info *clusterInfo) *tenant.ClusterInfo {
 	if info == nil {
 		return &tenant.ClusterInfo{
@@ -1399,7 +1593,15 @@ func (p *Provisioner) waitForClusterProvisionMetadata(ctx context.Context, publi
 			return nil, readErr
 		}
 		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("%s", statusError("cluster get", resp.StatusCode, sanitizeUpstreamBody(raw)))
+			if resp.StatusCode != http.StatusTooManyRequests || time.Now().After(deadline) {
+				return nil, fmt.Errorf("%s", statusError("cluster get", resp.StatusCode, sanitizeUpstreamBody(raw)))
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(tidbCloudNativePollInterval):
+				continue
+			}
 		}
 		info, err := parseClusterInfo(raw)
 		if err != nil {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -419,7 +419,6 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 		return nil, nil, fmt.Errorf("tidbcloud native batch provision returned %d clusters, want %d", len(created.Clusters), len(tenantIDs))
 	}
 	out := make([]*tenant.ClusterInfo, len(created.Clusters))
-	pending := make([]batchClusterMetadataTarget, 0, len(created.Clusters))
 	errs := make([]error, len(created.Clusters))
 	for i := range created.Clusters {
 		i := i
@@ -438,14 +437,7 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 			errs[i] = fmt.Errorf("tidbcloud native batch response missing cluster id for tenant %q", tenantID)
 			continue
 		}
-		if clusterProvisionMetadataIncomplete(&info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
-			pending = append(pending, batchClusterMetadataTarget{index: i, tenantID: tenantID, password: password, initial: info})
-			continue
-		}
 		out[i] = p.clusterInfoFromResponse(tenantID, dbName, password, &info)
-	}
-	if len(pending) > 0 {
-		p.waitForBatchClusterProvisionMetadata(ctx, publicKey, privateKey, dbName, strings.TrimSpace(opts.TenantPoolID), pending, out, errs)
 	}
 	for _, err := range errs {
 		if err != nil {
@@ -469,10 +461,11 @@ type batchClusterMetadataTarget struct {
 	index    int
 	tenantID string
 	password string
+	dbName   string
 	initial  clusterInfo
 }
 
-func (p *Provisioner) waitForBatchClusterProvisionMetadata(ctx context.Context, publicKey, privateKey, dbName, poolID string, pending []batchClusterMetadataTarget, out []*tenant.ClusterInfo, errs []error) {
+func (p *Provisioner) waitForBatchClusterProvisionMetadata(ctx context.Context, publicKey, privateKey, poolID string, pending []batchClusterMetadataTarget, out []*tenant.ClusterInfo, errs []error) {
 	groupSize := tidbCloudNativeBatchMetadataGroupSize
 	if groupSize <= 0 {
 		groupSize = 10
@@ -487,13 +480,13 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadata(ctx context.Context, 
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			p.waitForBatchClusterProvisionMetadataGroup(ctx, publicKey, privateKey, dbName, poolID, group, out, errs)
+			p.waitForBatchClusterProvisionMetadataGroup(ctx, publicKey, privateKey, poolID, group, out, errs)
 		}()
 	}
 	wg.Wait()
 }
 
-func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Context, publicKey, privateKey, dbName, poolID string, group []batchClusterMetadataTarget, out []*tenant.ClusterInfo, errs []error) {
+func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Context, publicKey, privateKey, poolID string, group []batchClusterMetadataTarget, out []*tenant.ClusterInfo, errs []error) {
 	deadline := time.Now().Add(10 * time.Minute)
 	pending := make(map[string]batchClusterMetadataTarget, len(group))
 	clusterIDs := make([]string, 0, len(group))
@@ -536,7 +529,7 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Cont
 				if clusterProvisionMetadataIncomplete(&info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
 					continue
 				}
-				out[target.index] = p.clusterInfoFromResponse(target.tenantID, dbName, target.password, &info)
+				out[target.index] = p.clusterInfoFromResponse(target.tenantID, target.dbName, target.password, &info)
 				delete(pending, clusterID)
 			}
 		}
@@ -606,6 +599,60 @@ func (p *Provisioner) WaitForPoolClusterMetadata(ctx context.Context, cluster *t
 		return nil, err
 	}
 	return p.clusterInfoFromResponse(strings.TrimSpace(cluster.TenantID), dbName, cluster.Password, info), nil
+}
+
+func (p *Provisioner) WaitForPoolClustersMetadata(ctx context.Context, clusters []*tenant.ClusterInfo, req tenant.CredentialProvisionRequest) ([]*tenant.ClusterInfo, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, fmt.Errorf("public_key and private_key are required")
+	}
+	if len(clusters) == 0 {
+		return []*tenant.ClusterInfo{}, nil
+	}
+	out := make([]*tenant.ClusterInfo, len(clusters))
+	pending := make([]batchClusterMetadataTarget, 0, len(clusters))
+	errs := make([]error, len(clusters))
+	for i, cluster := range clusters {
+		if cluster == nil {
+			errs[i] = fmt.Errorf("cluster is required")
+			continue
+		}
+		tenantID := strings.TrimSpace(cluster.TenantID)
+		if tenantID == "" {
+			errs[i] = fmt.Errorf("cluster tenant id is required")
+			continue
+		}
+		if strings.TrimSpace(cluster.ClusterID) == "" {
+			errs[i] = fmt.Errorf("cluster id is required for tenant %q", tenantID)
+			continue
+		}
+		dbName := strings.TrimSpace(cluster.DBName)
+		if dbName == "" {
+			var err error
+			dbName, err = p.resolveDatabaseName("")
+			if err != nil {
+				errs[i] = err
+				continue
+			}
+		}
+		pending = append(pending, batchClusterMetadataTarget{
+			index:    i,
+			tenantID: tenantID,
+			password: cluster.Password,
+			dbName:   dbName,
+			initial: clusterInfo{
+				ClusterID: strings.TrimSpace(cluster.ClusterID),
+				Labels: map[string]string{
+					Drive9TenantIDLabel: tenantID,
+				},
+			},
+		})
+	}
+	if len(pending) > 0 {
+		p.waitForBatchClusterProvisionMetadata(ctx, publicKey, privateKey, "", pending, out, errs)
+	}
+	return out, errors.Join(errs...)
 }
 
 func (p *Provisioner) MarkClusterPoolUsed(ctx context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, usedAt time.Time, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1070,6 +1070,7 @@ func (p *Provisioner) listClusterInfosPageWithCredentials(ctx context.Context, p
 	filter := fmt.Sprintf(`labels.%q = "true"`, Drive9ManagedLabel)
 	clusterIDFilter := compactNonEmptyStrings(clusterIDs)
 	if len(clusterIDFilter) > 0 {
+		// TiDB Cloud serverless cvtGlobalFilter splits comma-separated clusterId values server-side.
 		filter = fmt.Sprintf("clusterId = %q AND %s", strings.Join(clusterIDFilter, ","), filter)
 	}
 	values.Set("filter", filter)

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -513,7 +513,7 @@ func TestBatchProvisionFreeClustersWaitsForMetadataByList(t *testing.T) {
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			listCalls.Add(1)
-			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = cluster-1,cluster-2`) || !strings.Contains(filter, Drive9ManagedLabel) {
+			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `(clusterId = cluster-1 OR clusterId = cluster-2)`) || !strings.Contains(filter, Drive9ManagedLabel) {
 				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
 				http.Error(w, "unexpected filter", http.StatusBadRequest)
 				return

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -387,9 +387,9 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 }
 
 func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFails(t *testing.T) {
-	origPoll := tidbCloudNativePollInterval
-	tidbCloudNativePollInterval = time.Millisecond
-	t.Cleanup(func() { tidbCloudNativePollInterval = origPoll })
+	origPoll := tidbCloudNativeBatchMetadataPollInterval
+	tidbCloudNativeBatchMetadataPollInterval = time.Millisecond
+	t.Cleanup(func() { tidbCloudNativeBatchMetadataPollInterval = origPoll })
 
 	var listCalls atomic.Int32
 	handlerErrs := make(chan error, 2)
@@ -422,7 +422,7 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			listCalls.Add(1)
-			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-2"`) || !strings.Contains(filter, Drive9ManagedLabel) {
+			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = cluster-2`) || !strings.Contains(filter, Drive9ManagedLabel) {
 				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
 				http.Error(w, "unexpected filter", http.StatusBadRequest)
 				return
@@ -500,11 +500,20 @@ func TestBatchProvisionFreeClustersWaitsForMetadataByList(t *testing.T) {
 							Drive9PoolIDLabel:          "pool-1",
 						},
 					},
+					{
+						"clusterId": "cluster-2",
+						"state":     "CREATING",
+						"labels": map[string]string{
+							TiDBCloudOrganizationLabel: "org-1",
+							Drive9TenantIDLabel:        "tenant-2",
+							Drive9PoolIDLabel:          "pool-1",
+						},
+					},
 				},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			listCalls.Add(1)
-			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-1"`) || !strings.Contains(filter, Drive9ManagedLabel) {
+			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = cluster-1,cluster-2`) || !strings.Contains(filter, Drive9ManagedLabel) {
 				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
 				http.Error(w, "unexpected filter", http.StatusBadRequest)
 				return
@@ -522,6 +531,17 @@ func TestBatchProvisionFreeClustersWaitsForMetadataByList(t *testing.T) {
 						"userPrefix": "u1",
 						"endpoints":  map[string]any{"public": map[string]any{"host": "db1.example", "port": 4000}},
 					},
+					{
+						"clusterId": "cluster-2",
+						"state":     "ACTIVE",
+						"labels": map[string]string{
+							TiDBCloudOrganizationLabel: "org-1",
+							Drive9TenantIDLabel:        "tenant-2",
+							Drive9PoolIDLabel:          "pool-1",
+						},
+						"userPrefix": "u2",
+						"endpoints":  map[string]any{"public": map[string]any{"host": "db2.example", "port": 4000}},
+					},
 				},
 			})
 		default:
@@ -538,7 +558,7 @@ func TestBatchProvisionFreeClustersWaitsForMetadataByList(t *testing.T) {
 		defaultDatabaseName: DefaultDatabaseName,
 		client:              ts.Client(),
 	}
-	out, _, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(context.Background(), []string{"tenant-1"}, tenant.CredentialProvisionRequest{
+	out, _, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(context.Background(), []string{"tenant-1", "tenant-2"}, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	}, tenant.QuotaUpdateOptions{TenantPoolID: "pool-1"})
@@ -549,7 +569,9 @@ func TestBatchProvisionFreeClustersWaitsForMetadataByList(t *testing.T) {
 	if listCalls.Load() != 1 {
 		t.Fatalf("metadata list calls = %d, want 1", listCalls.Load())
 	}
-	if len(out) != 1 || out[0].Host != "db1.example" || out[0].Username != "u1.root" || out[0].OrganizationID != "org-1" {
+	if len(out) != 2 ||
+		out[0].Host != "db1.example" || out[0].Username != "u1.root" || out[0].OrganizationID != "org-1" ||
+		out[1].Host != "db2.example" || out[1].Username != "u2.root" || out[1].OrganizationID != "org-1" {
 		t.Fatalf("clusters = %#v", out)
 	}
 }

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -386,15 +386,9 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 	}
 }
 
-func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFails(t *testing.T) {
-	origPoll := tidbCloudNativeBatchMetadataPollInterval
-	tidbCloudNativeBatchMetadataPollInterval = time.Millisecond
-	t.Cleanup(func() { tidbCloudNativeBatchMetadataPollInterval = origPoll })
-
+func TestBatchProvisionFreeClustersReturnsCreatedClustersWithoutMetadataWait(t *testing.T) {
 	var listCalls atomic.Int32
 	handlerErrs := make(chan error, 2)
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {
 			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
@@ -422,22 +416,8 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			listCalls.Add(1)
-			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-2"`) || !strings.Contains(filter, Drive9ManagedLabel) {
-				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
-				http.Error(w, "unexpected filter", http.StatusBadRequest)
-				return
-			}
-			cancel()
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"clusters": []map[string]any{
-					{
-						"clusterId":  "cluster-2",
-						"state":      "CREATING",
-						"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-2"},
-						"userPrefix": "u2",
-					},
-				},
-			})
+			handlerErrs <- fmt.Errorf("unexpected metadata wait request %q", r.URL.String())
+			http.Error(w, "unexpected metadata wait", http.StatusInternalServerError)
 		default:
 			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.String())
 			http.Error(w, "unexpected request", http.StatusInternalServerError)
@@ -452,29 +432,32 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 		defaultDatabaseName: DefaultDatabaseName,
 		client:              ts.Client(),
 	}
-	out, _, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(ctx, []string{"tenant-1", "tenant-2"}, tenant.CredentialProvisionRequest{
+	out, _, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(context.Background(), []string{"tenant-1", "tenant-2"}, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	}, tenant.QuotaUpdateOptions{})
-	if err == nil {
-		t.Fatal("BatchProvisionFreeClustersWithCredentialsAndQuota error = nil, want metadata wait error")
+	if err != nil {
+		t.Fatalf("BatchProvisionFreeClustersWithCredentialsAndQuota: %v", err)
 	}
 	assertNoHandlerError(t, handlerErrs)
-	if listCalls.Load() == 0 {
-		t.Fatal("cluster metadata list was not called")
+	if listCalls.Load() != 0 {
+		t.Fatalf("metadata list calls = %d, want 0", listCalls.Load())
 	}
 	if len(out) != 2 {
-		t.Fatalf("clusters = %d, want 2 fallback clusters for cleanup: %#v", len(out), out)
+		t.Fatalf("clusters = %d, want 2: %#v", len(out), out)
 	}
 	if out[0].TenantID != "tenant-1" || out[0].ClusterID != "cluster-1" || out[1].TenantID != "tenant-2" || out[1].ClusterID != "cluster-2" {
-		t.Fatalf("fallback clusters = %#v", out)
+		t.Fatalf("clusters = %#v", out)
 	}
 	if out[0].Password == "" || out[1].Password == "" {
-		t.Fatalf("fallback clusters did not preserve generated passwords: %#v", out)
+		t.Fatalf("clusters did not preserve generated passwords: %#v", out)
+	}
+	if out[1].Host != "" || out[1].Port != 0 {
+		t.Fatalf("incomplete cluster connection = %#v, want no endpoint", out[1])
 	}
 }
 
-func TestBatchProvisionFreeClustersWaitsForMetadataByList(t *testing.T) {
+func TestWaitForPoolClustersMetadataUsesList(t *testing.T) {
 	origPoll := tidbCloudNativeBatchMetadataPollInterval
 	tidbCloudNativeBatchMetadataPollInterval = time.Millisecond
 	t.Cleanup(func() { tidbCloudNativeBatchMetadataPollInterval = origPoll })
@@ -488,29 +471,6 @@ func TestBatchProvisionFreeClustersWaitsForMetadataByList(t *testing.T) {
 			return
 		}
 		switch {
-		case r.Method == http.MethodPost && r.URL.Path == "/v1beta1/clusters:batchCreate":
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"clusters": []map[string]any{
-					{
-						"clusterId": "cluster-1",
-						"state":     "CREATING",
-						"labels": map[string]string{
-							TiDBCloudOrganizationLabel: "org-1",
-							Drive9TenantIDLabel:        "tenant-1",
-							Drive9PoolIDLabel:          "pool-1",
-						},
-					},
-					{
-						"clusterId": "cluster-2",
-						"state":     "CREATING",
-						"labels": map[string]string{
-							TiDBCloudOrganizationLabel: "org-1",
-							Drive9TenantIDLabel:        "tenant-2",
-							Drive9PoolIDLabel:          "pool-1",
-						},
-					},
-				},
-			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			listCalls.Add(1)
 			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-1,cluster-2"`) || !strings.Contains(filter, Drive9ManagedLabel) {
@@ -558,12 +518,15 @@ func TestBatchProvisionFreeClustersWaitsForMetadataByList(t *testing.T) {
 		defaultDatabaseName: DefaultDatabaseName,
 		client:              ts.Client(),
 	}
-	out, _, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(context.Background(), []string{"tenant-1", "tenant-2"}, tenant.CredentialProvisionRequest{
+	out, err := p.WaitForPoolClustersMetadata(context.Background(), []*tenant.ClusterInfo{
+		{TenantID: "tenant-1", ClusterID: "cluster-1", Password: "pass-1", DBName: DefaultDatabaseName},
+		{TenantID: "tenant-2", ClusterID: "cluster-2", Password: "pass-2", DBName: DefaultDatabaseName},
+	}, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
-	}, tenant.QuotaUpdateOptions{TenantPoolID: "pool-1"})
+	})
 	if err != nil {
-		t.Fatalf("BatchProvisionFreeClustersWithCredentialsAndQuota: %v", err)
+		t.Fatalf("WaitForPoolClustersMetadata: %v", err)
 	}
 	assertNoHandlerError(t, handlerErrs)
 	if listCalls.Load() != 1 {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -422,7 +422,7 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			listCalls.Add(1)
-			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = cluster-2`) || !strings.Contains(filter, Drive9ManagedLabel) {
+			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-2"`) || !strings.Contains(filter, Drive9ManagedLabel) {
 				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
 				http.Error(w, "unexpected filter", http.StatusBadRequest)
 				return
@@ -513,7 +513,7 @@ func TestBatchProvisionFreeClustersWaitsForMetadataByList(t *testing.T) {
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			listCalls.Add(1)
-			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `(clusterId = cluster-1 OR clusterId = cluster-2)`) || !strings.Contains(filter, Drive9ManagedLabel) {
+			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-1,cluster-2"`) || !strings.Contains(filter, Drive9ManagedLabel) {
 				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
 				http.Error(w, "unexpected filter", http.StatusBadRequest)
 				return

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -352,7 +352,7 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 	out, cloudCfg, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(context.Background(), []string{"tenant-1", "tenant-2"}, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
-	}, tenant.QuotaUpdateOptions{TiDBCloudSpendingLimitMonthly: &monthly})
+	}, tenant.QuotaUpdateOptions{TiDBCloudSpendingLimitMonthly: &monthly, TenantPoolID: "pool-1"})
 	if err != nil {
 		t.Fatalf("BatchProvisionFreeClustersWithCredentialsAndQuota: %v", err)
 	}
@@ -364,7 +364,8 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 		wantTenantID := fmt.Sprintf("tenant-%d", i+1)
 		if req.Cluster.Labels[Drive9ManagedLabel] != "true" ||
 			req.Cluster.Labels[Drive9TenantIDLabel] != wantTenantID ||
-			req.Cluster.Labels[Drive9PoolStatusLabel] != "free" {
+			req.Cluster.Labels[Drive9PoolStatusLabel] != "free" ||
+			req.Cluster.Labels[Drive9PoolIDLabel] != "pool-1" {
 			t.Fatalf("request %d labels = %#v", i, req.Cluster.Labels)
 		}
 		if req.Cluster.RootPassword == "" {
@@ -380,7 +381,7 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 	if len(out) != 2 || out[0].TenantID != "tenant-1" || out[0].ClusterID != "cluster-1" || out[1].TenantID != "tenant-2" || out[1].ClusterID != "cluster-2" {
 		t.Fatalf("clusters = %#v", out)
 	}
-	if cloudCfg == nil || cloudCfg.Labels[Drive9PoolStatusLabel] != "free" {
+	if cloudCfg == nil || cloudCfg.Labels[Drive9PoolStatusLabel] != "free" || cloudCfg.Labels[Drive9PoolIDLabel] != "pool-1" {
 		t.Fatalf("cloud config = %#v", cloudCfg)
 	}
 }
@@ -390,7 +391,7 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 	tidbCloudNativePollInterval = time.Millisecond
 	t.Cleanup(func() { tidbCloudNativePollInterval = origPoll })
 
-	var getCalls atomic.Int32
+	var listCalls atomic.Int32
 	handlerErrs := make(chan error, 2)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -419,14 +420,23 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 					},
 				},
 			})
-		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters/cluster-2":
-			getCalls.Add(1)
+		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
+			listCalls.Add(1)
+			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-2"`) || !strings.Contains(filter, Drive9ManagedLabel) {
+				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
+				http.Error(w, "unexpected filter", http.StatusBadRequest)
+				return
+			}
 			cancel()
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"clusterId":  "cluster-2",
-				"state":      "CREATING",
-				"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-2"},
-				"userPrefix": "u2",
+				"clusters": []map[string]any{
+					{
+						"clusterId":  "cluster-2",
+						"state":      "CREATING",
+						"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-2"},
+						"userPrefix": "u2",
+					},
+				},
 			})
 		default:
 			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.String())
@@ -450,14 +460,149 @@ func TestBatchProvisionFreeClustersReturnsAllCreatedClustersWhenMetadataWaitFail
 		t.Fatal("BatchProvisionFreeClustersWithCredentialsAndQuota error = nil, want metadata wait error")
 	}
 	assertNoHandlerError(t, handlerErrs)
-	if getCalls.Load() == 0 {
-		t.Fatal("cluster metadata GET was not called")
+	if listCalls.Load() == 0 {
+		t.Fatal("cluster metadata list was not called")
 	}
 	if len(out) != 2 {
 		t.Fatalf("clusters = %d, want 2 fallback clusters for cleanup: %#v", len(out), out)
 	}
 	if out[0].TenantID != "tenant-1" || out[0].ClusterID != "cluster-1" || out[1].TenantID != "tenant-2" || out[1].ClusterID != "cluster-2" {
 		t.Fatalf("fallback clusters = %#v", out)
+	}
+	if out[0].Password == "" || out[1].Password == "" {
+		t.Fatalf("fallback clusters did not preserve generated passwords: %#v", out)
+	}
+}
+
+func TestBatchProvisionFreeClustersWaitsForMetadataByList(t *testing.T) {
+	origPoll := tidbCloudNativeBatchMetadataPollInterval
+	tidbCloudNativeBatchMetadataPollInterval = time.Millisecond
+	t.Cleanup(func() { tidbCloudNativeBatchMetadataPollInterval = origPoll })
+
+	var listCalls atomic.Int32
+	handlerErrs := make(chan error, 2)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1beta1/clusters:batchCreate":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusters": []map[string]any{
+					{
+						"clusterId": "cluster-1",
+						"state":     "CREATING",
+						"labels": map[string]string{
+							TiDBCloudOrganizationLabel: "org-1",
+							Drive9TenantIDLabel:        "tenant-1",
+							Drive9PoolIDLabel:          "pool-1",
+						},
+					},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
+			listCalls.Add(1)
+			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-1"`) || !strings.Contains(filter, Drive9ManagedLabel) {
+				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
+				http.Error(w, "unexpected filter", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusters": []map[string]any{
+					{
+						"clusterId": "cluster-1",
+						"state":     "ACTIVE",
+						"labels": map[string]string{
+							TiDBCloudOrganizationLabel: "org-1",
+							Drive9TenantIDLabel:        "tenant-1",
+							Drive9PoolIDLabel:          "pool-1",
+						},
+						"userPrefix": "u1",
+						"endpoints":  map[string]any{"public": map[string]any{"host": "db1.example", "port": 4000}},
+					},
+				},
+			})
+		default:
+			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		cloudProvider:       "aws",
+		region:              "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+		client:              ts.Client(),
+	}
+	out, _, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(context.Background(), []string{"tenant-1"}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	}, tenant.QuotaUpdateOptions{TenantPoolID: "pool-1"})
+	if err != nil {
+		t.Fatalf("BatchProvisionFreeClustersWithCredentialsAndQuota: %v", err)
+	}
+	assertNoHandlerError(t, handlerErrs)
+	if listCalls.Load() != 1 {
+		t.Fatalf("metadata list calls = %d, want 1", listCalls.Load())
+	}
+	if len(out) != 1 || out[0].Host != "db1.example" || out[0].Username != "u1.root" || out[0].OrganizationID != "org-1" {
+		t.Fatalf("clusters = %#v", out)
+	}
+}
+
+func TestWaitForClusterProvisionMetadataRetriesRateLimit(t *testing.T) {
+	origPoll := tidbCloudNativePollInterval
+	tidbCloudNativePollInterval = time.Millisecond
+	t.Cleanup(func() { tidbCloudNativePollInterval = origPoll })
+
+	var authorizedGets atomic.Int32
+	handlerErrs := make(chan error, 2)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodGet || r.URL.Path != "/v1beta1/clusters/cluster-1" {
+			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		if authorizedGets.Add(1) == 1 {
+			http.Error(w, "rate limited", http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"clusterId":  "cluster-1",
+			"state":      "ACTIVE",
+			"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-1"},
+			"userPrefix": "u1",
+			"endpoints":  map[string]any{"public": map[string]any{"host": "db1.example", "port": 4000}},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		cloudProvider:       "aws",
+		region:              "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+		client:              ts.Client(),
+	}
+	out, err := p.waitForClusterProvisionMetadata(context.Background(), "public-1", "private-1", "cluster-1")
+	if err != nil {
+		t.Fatalf("waitForClusterProvisionMetadata: %v", err)
+	}
+	assertNoHandlerError(t, handlerErrs)
+	if authorizedGets.Load() != 2 {
+		t.Fatalf("authorized GETs = %d, want 2", authorizedGets.Load())
+	}
+	if out == nil || out.ClusterID != "cluster-1" || out.Endpoints.Public.Host != "db1.example" {
+		t.Fatalf("cluster metadata = %#v", out)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a server-side admin tenant pool size cap via `DRIVE9_TENANT_POOL_MAX_SIZE`
- default the cap to `200` when the env var is unset
- tag pool-created TiDB Cloud clusters with `drive9.ai/pool_id=<poolID>`
- reduce TiDB Cloud metadata polling pressure by waiting for batch-created clusters through grouped `ListClusters` calls instead of one GET per cluster
- preserve pool/tenant/binding metadata when TiDB Cloud batch create succeeds but connection metadata polling later fails, including 429 rate-limit failures

## Behavior
- `DRIVE9_TENANT_POOL_MAX_SIZE` defaults to `200`; positive values override the default, and invalid values fail server startup
- admin pool create/update rejects `pool_size` above the configured cap before TiDB Cloud lookup or pool mutation
- batch-created pool clusters carry:
  - `drive9.ai/managed=true`
  - `drive9.ai/tenant_id=<tenantID>`
  - `drive9.ai/status=free`
  - `drive9.ai/pool_id=<poolID>`
- if TiDB Cloud returns created clusters but metadata wait fails, the server now persists those tenants as `provisioning` + pool binding `free` and returns `202` instead of deleting pool metadata
- incomplete `provisioning` pool tenants are not claimable by normal create, because claim still only selects `active` free tenants
- background metadata resume fills connection info and starts schema init once TiDB Cloud metadata becomes available
- provisioning native tenants without connection info are skipped during restart resume instead of running schema init with empty DB fields

## Tests
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant/tidbcloudnative -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -run 'TestAdminTenantPool|TestNewWithConfigUsesDefaultTenantPoolMaxSize' -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant/... -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./cmd/drive9-server -count=1`
- `GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `DRIVE9_TENANT_POOL_MAX_SIZE` to cap admin tenant pool create/update size (with a built-in default when unset).

* **Bug Fixes**
  * Admin tenant pool provisioning/update now enforces `pool_size` against available “free slots”.
  * Improved resilience for partial metadata: preserves persisted clusters, cleans up failed tenant state, and resumes pending pool claims asynchronously.
  * Refined tenant resume behavior for TiDB Cloud Native provisioning and pending reconciliation.

* **Tests**
  * Expanded/updated coverage for env parsing, max-size validation, pool resume paths, and quota outbox claim edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
