### PR TITLE
fix: clarify tenant pool warming status and observability

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -105,6 +105,10 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	createStarted := time.Now()
+	metricResult := "ok"
+	defer func() {
+		metrics.RecordOperation(adminTenantPoolMetricsComponent, "create", metricResult, time.Since(createStarted))
+	}()
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_create_requested",
 		"provider", tenant.ProviderTiDBCloudNative,
 		"pool_size", *req.PoolSize)...)
@@ -119,6 +123,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 				"provider", tenant.ProviderTiDBCloudNative,
 				"duration_ms", durationMillis(stageStarted),
 				"error", err)...)
+			metricResult = "cluster_error"
 			writeAdminTiDBCloudError(w, ctx, err, "create tenant pool")
 			return nil
 		}
@@ -128,9 +133,11 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 			"duration_ms", durationMillis(stageStarted))...)
 		if orgID != "" {
 			if _, err := s.meta.GetTenantPoolByOrganization(ctx, orgID); err == nil {
+				metricResult = "conflict"
 				errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
 				return nil
 			} else if !errors.Is(err, meta.ErrNotFound) {
+				metricResult = "error"
 				errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
 				return nil
 			}
@@ -147,9 +154,11 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 			UpdatedAt:      now,
 		}); err != nil {
 			if errors.Is(err, meta.ErrDuplicate) {
+				metricResult = "conflict"
 				errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
 				return nil
 			}
+			metricResult = "error"
 			errJSON(w, http.StatusInternalServerError, "failed to persist tenant pool")
 			return nil
 		}
@@ -176,6 +185,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 				"duration_ms", durationMillis(stageStarted),
 				"error", err)...)
 			s.deleteTenantPoolMetadata(ctx, poolID, "create_free_tenants_error")
+			metricResult = "cluster_error"
 			errJSON(w, http.StatusBadGateway, fmt.Sprintf("create tenant pool failed: %v", err))
 			return nil
 		}
@@ -194,9 +204,11 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 					s.cleanupCreatedPoolTenants(ctx, results, cred, "update_pool_org_error")
 					s.deleteTenantPoolMetadata(ctx, poolID, "update_pool_org_error")
 					if errors.Is(err, meta.ErrDuplicate) {
+						metricResult = "conflict"
 						errJSON(w, http.StatusConflict, "tenant pool already exists for organization")
 						return nil
 					}
+					metricResult = "error"
 					errJSON(w, http.StatusInternalServerError, "failed to update tenant pool organization")
 					return nil
 				}
@@ -243,6 +255,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 			"pool_size", *req.PoolSize,
 			"duration_ms", durationMillis(createStarted),
 			"error", err)...)
+		metricResult = adminTenantPoolMetricResult(err)
 		writeAdminTenantPoolError(w, err)
 		return
 	}
@@ -516,6 +529,10 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	deleteStarted := time.Now()
+	metricResult := "ok"
+	defer func() {
+		metrics.RecordOperation(adminTenantPoolMetricsComponent, "delete", metricResult, time.Since(deleteStarted))
+	}()
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_delete_requested",
 		"provider", tenant.ProviderTiDBCloudNative,
 		"pool_id", pool.PoolID,
@@ -577,6 +594,7 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 			"organization_id", pool.OrganizationID,
 			"duration_ms", durationMillis(deleteStarted),
 			"error", err)...)
+		metricResult = adminTenantPoolMetricResult(err)
 		writeAdminTenantPoolError(w, err)
 		return
 	}
@@ -1284,6 +1302,11 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 	}
 	workerCtx := backgroundWithTrace(ctx)
 	s.startServerWorker(workerCtx, func(ctx context.Context) {
+		replenishStarted := time.Now()
+		metricResult := "ok"
+		defer func() {
+			metrics.RecordOperation(adminTenantPoolMetricsComponent, "replenish", metricResult, time.Since(replenishStarted))
+		}()
 		lock := s.tenantPoolLock(pool.PoolID)
 		lock.Lock()
 		defer lock.Unlock()
@@ -1292,24 +1315,31 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			if err != nil {
 				if !errors.Is(err, meta.ErrNotFound) {
 					logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
+					metricResult = "error"
+				} else {
+					metricResult = "not_found"
 				}
 				return nil
 			}
 			if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
+				metricResult = "skipped"
 				return nil
 			}
 			slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+				metricResult = "error"
 				return nil
 			}
 			missing := current.Size - slotSize
 			if missing <= 0 {
+				metricResult = "noop"
 				return nil
 			}
 			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+				metricResult = "cluster_error"
 				return nil
 			}
 			for _, res := range results {
@@ -1318,6 +1348,7 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			return nil
 		}); err != nil {
 			logger.Warn(ctx, "admin_tenant_pool_replenish_lock_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
+			metricResult = adminTenantPoolMetricResult(err)
 		}
 	})
 }

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/tenant/token"
 )
@@ -41,7 +42,10 @@ type tenantPoolResumeJob struct {
 	rerun atomic.Bool
 }
 
-const adminTenantPoolStatusCreating = "creating"
+const (
+	adminTenantPoolStatusCreating   = "creating"
+	adminTenantPoolMetricsComponent = "admin_tenant_pool"
+)
 
 func (e *adminTenantPoolHTTPError) Error() string {
 	return e.message
@@ -286,10 +290,24 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	pool, _, _, ok := s.authorizedTenantPool(w, r, cred)
+	pool, initialFreeSize, initialSlotSize, ok := s.authorizedTenantPool(w, r, cred)
 	if !ok {
 		return
 	}
+	updateStarted := time.Now()
+	metricResult := "ok"
+	defer func() {
+		metrics.RecordOperation(adminTenantPoolMetricsComponent, "update", metricResult, time.Since(updateStarted))
+	}()
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_update_requested",
+		"provider", tenant.ProviderTiDBCloudNative,
+		"pool_id", pool.PoolID,
+		"organization_id", pool.OrganizationID,
+		"current_pool_size", pool.Size,
+		"target_pool_size", *req.PoolSize,
+		"free_size", initialFreeSize,
+		"slot_size", initialSlotSize,
+		"pool_status", pool.Status)...)
 	lock := s.tenantPoolLock(pool.PoolID)
 	lock.Lock()
 	defer lock.Unlock()
@@ -312,18 +330,57 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		}
 		targetSize := *req.PoolSize
 		if targetSize > slotSize {
-			results, err := s.createFreePoolTenants(ctx, pool.PoolID, targetSize-slotSize, cred, nil)
+			stageStarted := time.Now()
+			growCount := targetSize - slotSize
+			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_grow_started",
+				"provider", tenant.ProviderTiDBCloudNative,
+				"pool_id", pool.PoolID,
+				"organization_id", pool.OrganizationID,
+				"current_pool_size", pool.Size,
+				"target_pool_size", targetSize,
+				"free_size", freeSize,
+				"slot_size", slotSize,
+				"grow_count", growCount)...)
+			results, err := s.createFreePoolTenants(ctx, pool.PoolID, growCount, cred, nil)
 			if err != nil {
+				logger.Error(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_grow_failed",
+					"provider", tenant.ProviderTiDBCloudNative,
+					"pool_id", pool.PoolID,
+					"organization_id", pool.OrganizationID,
+					"target_pool_size", targetSize,
+					"grow_count", growCount,
+					"duration_ms", durationMillis(stageStarted),
+					"error", err)...)
 				return adminTenantPoolError(http.StatusBadGateway, fmt.Sprintf("grow tenant pool failed: %v", err))
 			}
 			for _, res := range results {
 				s.startProvisionedTenantSchemaInit(ctx, res)
 			}
+			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_grow_done",
+				"provider", tenant.ProviderTiDBCloudNative,
+				"pool_id", pool.PoolID,
+				"organization_id", pool.OrganizationID,
+				"target_pool_size", targetSize,
+				"grow_count", growCount,
+				"created_count", len(results),
+				"duration_ms", durationMillis(stageStarted))...)
 			if freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID); err != nil {
 				return adminTenantPoolError(http.StatusInternalServerError, "tenant pool free size lookup failed")
 			}
 		} else if targetSize < slotSize {
-			if _, err := s.deleteNewestFreePoolTenants(ctx, pool.PoolID, pool.OrganizationID, slotSize-targetSize, cred, false); err != nil {
+			stageStarted := time.Now()
+			shrinkCount := slotSize - targetSize
+			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_shrink_started",
+				"provider", tenant.ProviderTiDBCloudNative,
+				"pool_id", pool.PoolID,
+				"organization_id", pool.OrganizationID,
+				"current_pool_size", pool.Size,
+				"target_pool_size", targetSize,
+				"free_size", freeSize,
+				"slot_size", slotSize,
+				"shrink_count", shrinkCount)...)
+			deleted, err := s.deleteNewestFreePoolTenants(ctx, pool.PoolID, pool.OrganizationID, shrinkCount, cred, false)
+			if err != nil {
 				if actualSlotSize, countErr := s.meta.CountTenantPoolFreeSlots(ctx, pool.OrganizationID); countErr == nil {
 					if updateErr := s.meta.UpdateTenantPoolSize(ctx, pool.PoolID, actualSlotSize); updateErr != nil {
 						logger.Warn(ctx, "admin_tenant_pool_shrink_partial_size_update_failed", zap.String("pool_id", pool.PoolID), zap.Int("slot_size", actualSlotSize), zap.Error(updateErr))
@@ -331,15 +388,48 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 				} else {
 					logger.Warn(ctx, "admin_tenant_pool_shrink_partial_count_failed", zap.String("pool_id", pool.PoolID), zap.Error(countErr))
 				}
+				logger.Error(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_shrink_failed",
+					"provider", tenant.ProviderTiDBCloudNative,
+					"pool_id", pool.PoolID,
+					"organization_id", pool.OrganizationID,
+					"target_pool_size", targetSize,
+					"shrink_count", shrinkCount,
+					"deleted_count", deleted,
+					"duration_ms", durationMillis(stageStarted),
+					"error", err)...)
 				return adminTenantPoolError(http.StatusBadGateway, fmt.Sprintf("shrink tenant pool failed: %v", err))
 			}
+			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_shrink_done",
+				"provider", tenant.ProviderTiDBCloudNative,
+				"pool_id", pool.PoolID,
+				"organization_id", pool.OrganizationID,
+				"target_pool_size", targetSize,
+				"shrink_count", shrinkCount,
+				"deleted_count", deleted,
+				"duration_ms", durationMillis(stageStarted))...)
 			if freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID); err != nil {
 				return adminTenantPoolError(http.StatusInternalServerError, "tenant pool free size lookup failed")
 			}
+		} else {
+			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_noop",
+				"provider", tenant.ProviderTiDBCloudNative,
+				"pool_id", pool.PoolID,
+				"organization_id", pool.OrganizationID,
+				"current_pool_size", pool.Size,
+				"target_pool_size", targetSize,
+				"free_size", freeSize,
+				"slot_size", slotSize)...)
 		}
+		stageStarted := time.Now()
 		if err := s.meta.UpdateTenantPoolSize(ctx, pool.PoolID, targetSize); err != nil {
 			return adminTenantPoolError(http.StatusInternalServerError, "failed to update tenant pool")
 		}
+		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_size_persisted",
+			"provider", tenant.ProviderTiDBCloudNative,
+			"pool_id", pool.PoolID,
+			"organization_id", pool.OrganizationID,
+			"target_pool_size", targetSize,
+			"duration_ms", durationMillis(stageStarted))...)
 		if freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID); err != nil {
 			return adminTenantPoolError(http.StatusInternalServerError, "tenant pool free size lookup failed")
 		}
@@ -355,9 +445,26 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		}
 		return nil
 	}); err != nil {
+		metricResult = adminTenantPoolMetricResult(err)
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_update_failed",
+			"provider", tenant.ProviderTiDBCloudNative,
+			"pool_id", pool.PoolID,
+			"organization_id", pool.OrganizationID,
+			"current_pool_size", pool.Size,
+			"target_pool_size", *req.PoolSize,
+			"duration_ms", durationMillis(updateStarted),
+			"error", err)...)
 		writeAdminTenantPoolError(w, err)
 		return
 	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_update_done",
+		"provider", tenant.ProviderTiDBCloudNative,
+		"pool_id", out.PoolID,
+		"organization_id", out.OrganizationID,
+		"target_pool_size", out.PoolSize,
+		"free_size", out.FreeSize,
+		"status", out.Status,
+		"duration_ms", durationMillis(updateStarted))...)
 	writeJSON(w, http.StatusAccepted, out)
 }
 
@@ -377,6 +484,17 @@ func adminTenantPoolDisplayStatus(status meta.TenantPoolStatus, freeSize, slotSi
 		return adminTenantPoolStatusCreating
 	}
 	return string(status)
+}
+
+func adminTenantPoolMetricResult(err error) string {
+	if err == nil {
+		return "ok"
+	}
+	var httpErr *adminTenantPoolHTTPError
+	if errors.As(err, &httpErr) && httpErr.status == http.StatusBadGateway {
+		return "cluster_error"
+	}
+	return metrics.ResultForError(err)
 }
 
 func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -26,11 +26,11 @@ type adminTenantPoolRequest struct {
 }
 
 type adminTenantPoolResponse struct {
-	PoolID         string `json:"pool_id"`
-	OrganizationID string `json:"organization_id,omitempty"`
-	PoolSize       int    `json:"pool_size"`
-	FreeSize       int    `json:"free_size"`
-	Status         string `json:"status"`
+	PoolID         string                `json:"pool_id"`
+	OrganizationID string                `json:"organization_id,omitempty"`
+	PoolSize       int                   `json:"pool_size"`
+	FreeSize       int                   `json:"free_size"`
+	Status         adminTenantPoolStatus `json:"status"`
 }
 
 type adminTenantPoolHTTPError struct {
@@ -42,10 +42,11 @@ type tenantPoolResumeJob struct {
 	rerun atomic.Bool
 }
 
-const (
-	adminTenantPoolStatusCreating   = "creating"
-	adminTenantPoolMetricsComponent = "admin_tenant_pool"
-)
+type adminTenantPoolStatus string
+
+const adminTenantPoolStatusCreating adminTenantPoolStatus = "creating"
+
+const adminTenantPoolMetricsComponent = "admin_tenant_pool"
 
 func (e *adminTenantPoolHTTPError) Error() string {
 	return e.message
@@ -223,13 +224,15 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 			s.startProvisionedTenantSchemaInit(ctx, res)
 		}
 		freeSize := 0
-		slotSize := 0
+		slotSize := len(results)
 		if orgID != "" {
 			if n, err := s.meta.CountFreeTenantPoolBindings(ctx, orgID); err == nil {
 				freeSize = n
-			}
-			if n, err := s.meta.CountTenantPoolFreeSlots(ctx, orgID); err == nil {
-				slotSize = n
+			} else {
+				logger.Warn(ctx, "admin_tenant_pool_create_free_size_lookup_failed",
+					zap.String("pool_id", poolID),
+					zap.String("organization_id", orgID),
+					zap.Error(err))
 			}
 		}
 		writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
@@ -267,8 +270,13 @@ func (s *Server) handleAdminTenantPoolGet(w http.ResponseWriter, r *http.Request
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	pool, freeSize, slotSize, ok := s.authorizedTenantPool(w, r, cred)
+	pool, ok := s.authorizedTenantPool(w, r, cred)
 	if !ok {
+		return
+	}
+	freeSize, slotSize, err := s.tenantPoolSizes(r.Context(), pool.OrganizationID)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
 	writeJSON(w, http.StatusOK, adminTenantPoolResponse{
@@ -303,7 +311,7 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	pool, initialFreeSize, initialSlotSize, ok := s.authorizedTenantPool(w, r, cred)
+	pool, ok := s.authorizedTenantPool(w, r, cred)
 	if !ok {
 		return
 	}
@@ -318,8 +326,6 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		"organization_id", pool.OrganizationID,
 		"current_pool_size", pool.Size,
 		"target_pool_size", *req.PoolSize,
-		"free_size", initialFreeSize,
-		"slot_size", initialSlotSize,
 		"pool_status", pool.Status)...)
 	lock := s.tenantPoolLock(pool.PoolID)
 	lock.Lock()
@@ -377,9 +383,6 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 				"grow_count", growCount,
 				"created_count", len(results),
 				"duration_ms", durationMillis(stageStarted))...)
-			if freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID); err != nil {
-				return adminTenantPoolError(http.StatusInternalServerError, "tenant pool free size lookup failed")
-			}
 		} else if targetSize < slotSize {
 			stageStarted := time.Now()
 			shrinkCount := slotSize - targetSize
@@ -420,9 +423,6 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 				"shrink_count", shrinkCount,
 				"deleted_count", deleted,
 				"duration_ms", durationMillis(stageStarted))...)
-			if freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID); err != nil {
-				return adminTenantPoolError(http.StatusInternalServerError, "tenant pool free size lookup failed")
-			}
 		} else {
 			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_noop",
 				"provider", tenant.ProviderTiDBCloudNative,
@@ -492,11 +492,11 @@ func (s *Server) validateTenantPoolSize(size int) error {
 	return nil
 }
 
-func adminTenantPoolDisplayStatus(status meta.TenantPoolStatus, freeSize, slotSize int) string {
+func adminTenantPoolDisplayStatus(status meta.TenantPoolStatus, freeSize, slotSize int) adminTenantPoolStatus {
 	if status == meta.TenantPoolActive && freeSize == 0 && slotSize > 0 {
 		return adminTenantPoolStatusCreating
 	}
-	return string(status)
+	return adminTenantPoolStatus(status)
 }
 
 func adminTenantPoolMetricResult(err error) string {
@@ -524,7 +524,7 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	pool, _, _, ok := s.authorizedTenantPool(w, r, cred)
+	pool, ok := s.authorizedTenantPool(w, r, cred)
 	if !ok {
 		return
 	}
@@ -584,7 +584,7 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 			OrganizationID: pool.OrganizationID,
 			PoolSize:       pool.Size,
 			FreeSize:       0,
-			Status:         string(meta.TenantPoolDeleting),
+			Status:         adminTenantPoolStatus(meta.TenantPoolDeleting),
 		}
 		return nil
 	}); err != nil {
@@ -609,36 +609,38 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusAccepted, out)
 }
 
-func (s *Server) authorizedTenantPool(w http.ResponseWriter, r *http.Request, cred tenant.CredentialProvisionRequest) (*meta.TenantPool, int, int, bool) {
+func (s *Server) authorizedTenantPool(w http.ResponseWriter, r *http.Request, cred tenant.CredentialProvisionRequest) (*meta.TenantPool, bool) {
 	orgID, err := s.firstManagedOrganization(r.Context(), cred)
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant pool")
-		return nil, 0, 0, false
+		return nil, false
 	}
 	if orgID == "" {
 		errJSON(w, http.StatusNotFound, "tenant pool not found")
-		return nil, 0, 0, false
+		return nil, false
 	}
 	pool, err := s.meta.GetTenantPoolByOrganization(r.Context(), orgID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "tenant pool not found")
-			return nil, 0, 0, false
+			return nil, false
 		}
 		errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
-		return nil, 0, 0, false
+		return nil, false
 	}
-	freeSize, err := s.meta.CountFreeTenantPoolBindings(r.Context(), orgID)
+	return pool, true
+}
+
+func (s *Server) tenantPoolSizes(ctx context.Context, organizationID string) (int, int, error) {
+	freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, organizationID)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "tenant pool free size lookup failed")
-		return nil, 0, 0, false
+		return 0, 0, fmt.Errorf("tenant pool free size lookup failed")
 	}
-	slotSize, err := s.meta.CountTenantPoolFreeSlots(r.Context(), orgID)
+	slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, organizationID)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "tenant pool slot size lookup failed")
-		return nil, 0, 0, false
+		return 0, 0, fmt.Errorf("tenant pool slot size lookup failed")
 	}
-	return pool, freeSize, slotSize, true
+	return freeSize, slotSize, nil
 }
 
 func (s *Server) firstManagedOrganization(ctx context.Context, cred tenant.CredentialProvisionRequest) (string, error) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -41,6 +41,8 @@ type tenantPoolResumeJob struct {
 	rerun atomic.Bool
 }
 
+const adminTenantPoolStatusCreating = "creating"
+
 func (e *adminTenantPoolHTTPError) Error() string {
 	return e.message
 }
@@ -205,9 +207,13 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 			s.startProvisionedTenantSchemaInit(ctx, res)
 		}
 		freeSize := 0
+		slotSize := 0
 		if orgID != "" {
 			if n, err := s.meta.CountFreeTenantPoolBindings(ctx, orgID); err == nil {
 				freeSize = n
+			}
+			if n, err := s.meta.CountTenantPoolFreeSlots(ctx, orgID); err == nil {
+				slotSize = n
 			}
 		}
 		writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
@@ -215,7 +221,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 			OrganizationID: orgID,
 			PoolSize:       *req.PoolSize,
 			FreeSize:       freeSize,
-			Status:         string(meta.TenantPoolActive),
+			Status:         adminTenantPoolDisplayStatus(meta.TenantPoolActive, freeSize, slotSize),
 		})
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_create_done",
 			"provider", tenant.ProviderTiDBCloudNative,
@@ -223,7 +229,8 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 			"organization_id", orgID,
 			"pool_size", *req.PoolSize,
 			"free_size", freeSize,
-			"status", meta.TenantPoolActive,
+			"slot_size", slotSize,
+			"status", adminTenantPoolDisplayStatus(meta.TenantPoolActive, freeSize, slotSize),
 			"duration_ms", durationMillis(createStarted))...)
 		return nil
 	}); err != nil {
@@ -243,7 +250,7 @@ func (s *Server) handleAdminTenantPoolGet(w http.ResponseWriter, r *http.Request
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	pool, freeSize, ok := s.authorizedTenantPool(w, r, cred)
+	pool, freeSize, slotSize, ok := s.authorizedTenantPool(w, r, cred)
 	if !ok {
 		return
 	}
@@ -252,7 +259,7 @@ func (s *Server) handleAdminTenantPoolGet(w http.ResponseWriter, r *http.Request
 		OrganizationID: pool.OrganizationID,
 		PoolSize:       pool.Size,
 		FreeSize:       freeSize,
-		Status:         string(pool.Status),
+		Status:         adminTenantPoolDisplayStatus(pool.Status, freeSize, slotSize),
 	})
 }
 
@@ -279,7 +286,7 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	pool, _, ok := s.authorizedTenantPool(w, r, cred)
+	pool, _, _, ok := s.authorizedTenantPool(w, r, cred)
 	if !ok {
 		return
 	}
@@ -333,12 +340,18 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 		if err := s.meta.UpdateTenantPoolSize(ctx, pool.PoolID, targetSize); err != nil {
 			return adminTenantPoolError(http.StatusInternalServerError, "failed to update tenant pool")
 		}
+		if freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID); err != nil {
+			return adminTenantPoolError(http.StatusInternalServerError, "tenant pool free size lookup failed")
+		}
+		if slotSize, err = s.meta.CountTenantPoolFreeSlots(ctx, pool.OrganizationID); err != nil {
+			return adminTenantPoolError(http.StatusInternalServerError, "tenant pool slot size lookup failed")
+		}
 		out = adminTenantPoolResponse{
 			PoolID:         pool.PoolID,
 			OrganizationID: pool.OrganizationID,
 			PoolSize:       targetSize,
 			FreeSize:       freeSize,
-			Status:         string(pool.Status),
+			Status:         adminTenantPoolDisplayStatus(pool.Status, freeSize, slotSize),
 		}
 		return nil
 	}); err != nil {
@@ -359,6 +372,13 @@ func (s *Server) validateTenantPoolSize(size int) error {
 	return nil
 }
 
+func adminTenantPoolDisplayStatus(status meta.TenantPoolStatus, freeSize, slotSize int) string {
+	if status == meta.TenantPoolActive && freeSize == 0 && slotSize > 0 {
+		return adminTenantPoolStatusCreating
+	}
+	return string(status)
+}
+
 func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Request) {
 	var raw struct {
 		PublicKey  string `json:"public_key"`
@@ -373,7 +393,7 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	pool, _, ok := s.authorizedTenantPool(w, r, cred)
+	pool, _, _, ok := s.authorizedTenantPool(w, r, cred)
 	if !ok {
 		return
 	}
@@ -453,31 +473,36 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusAccepted, out)
 }
 
-func (s *Server) authorizedTenantPool(w http.ResponseWriter, r *http.Request, cred tenant.CredentialProvisionRequest) (*meta.TenantPool, int, bool) {
+func (s *Server) authorizedTenantPool(w http.ResponseWriter, r *http.Request, cred tenant.CredentialProvisionRequest) (*meta.TenantPool, int, int, bool) {
 	orgID, err := s.firstManagedOrganization(r.Context(), cred)
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant pool")
-		return nil, 0, false
+		return nil, 0, 0, false
 	}
 	if orgID == "" {
 		errJSON(w, http.StatusNotFound, "tenant pool not found")
-		return nil, 0, false
+		return nil, 0, 0, false
 	}
 	pool, err := s.meta.GetTenantPoolByOrganization(r.Context(), orgID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "tenant pool not found")
-			return nil, 0, false
+			return nil, 0, 0, false
 		}
 		errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
-		return nil, 0, false
+		return nil, 0, 0, false
 	}
 	freeSize, err := s.meta.CountFreeTenantPoolBindings(r.Context(), orgID)
 	if err != nil {
 		errJSON(w, http.StatusInternalServerError, "tenant pool free size lookup failed")
-		return nil, 0, false
+		return nil, 0, 0, false
 	}
-	return pool, freeSize, true
+	slotSize, err := s.meta.CountTenantPoolFreeSlots(r.Context(), orgID)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "tenant pool slot size lookup failed")
+		return nil, 0, 0, false
+	}
+	return pool, freeSize, slotSize, true
 }
 
 func (s *Server) firstManagedOrganization(ctx context.Context, cred tenant.CredentialProvisionRequest) (string, error) {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -2249,6 +2249,10 @@ func TestAdminTenantPoolUpdateShrinkPartialFailureReconcilesSize(t *testing.T) {
 	if reverted.Status != meta.TenantActive {
 		t.Fatalf("failed tenant status = %s, want %s", reverted.Status, meta.TenantActive)
 	}
+	metricsText := readServerMetrics(t, rt.server)
+	if !strings.Contains(metricsText, `drive9_service_operations_total{component="admin_tenant_pool",operation="update",result="cluster_error"}`) {
+		t.Fatalf("metrics missing admin tenant pool update cluster_error: %s", metricsText)
+	}
 }
 
 func TestAdminTenantPoolReplenishUsesDefaultSpendingLimit(t *testing.T) {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1521,33 +1521,79 @@ func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 		t.Fatalf("free slots = %d, want 2", slots)
 	}
 
-	getResp := getAdminTenantPool(t, ts.URL, "public-1", "private-1")
-	defer func() { _ = getResp.Body.Close() }()
-	if getResp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(getResp.Body)
-		t.Fatalf("get pool status = %d body=%s", getResp.StatusCode, body)
-	}
-	var got adminTenantPoolResponse
-	if err := json.NewDecoder(getResp.Body).Decode(&got); err != nil {
-		t.Fatalf("decode get response: %v", err)
-	}
-	if got.PoolID != out.PoolID || got.FreeSize != 0 || got.Status != adminTenantPoolStatusCreating {
-		t.Fatalf("get pool response = %#v", got)
-	}
 }
 
 func TestAdminTenantPoolDisplayStatusCreating(t *testing.T) {
 	if got := adminTenantPoolDisplayStatus(meta.TenantPoolActive, 0, 2); got != adminTenantPoolStatusCreating {
 		t.Fatalf("pending slots status = %q, want %q", got, adminTenantPoolStatusCreating)
 	}
-	if got := adminTenantPoolDisplayStatus(meta.TenantPoolActive, 1, 2); got != string(meta.TenantPoolActive) {
+	if got := adminTenantPoolDisplayStatus(meta.TenantPoolActive, 1, 2); got != adminTenantPoolStatus(meta.TenantPoolActive) {
 		t.Fatalf("free slots status = %q, want %q", got, meta.TenantPoolActive)
 	}
-	if got := adminTenantPoolDisplayStatus(meta.TenantPoolActive, 0, 0); got != string(meta.TenantPoolActive) {
+	if got := adminTenantPoolDisplayStatus(meta.TenantPoolActive, 0, 0); got != adminTenantPoolStatus(meta.TenantPoolActive) {
 		t.Fatalf("empty slots status = %q, want %q", got, meta.TenantPoolActive)
 	}
-	if got := adminTenantPoolDisplayStatus(meta.TenantPoolDeleting, 0, 2); got != string(meta.TenantPoolDeleting) {
+	if got := adminTenantPoolDisplayStatus(meta.TenantPoolDeleting, 0, 2); got != adminTenantPoolStatus(meta.TenantPoolDeleting) {
 		t.Fatalf("deleting status = %q, want %q", got, meta.TenantPoolDeleting)
+	}
+}
+
+func TestAdminTenantPoolGetShowsCreatingForPendingSlots(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{OrganizationID: "org-1"}},
+	}}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           1,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               "pool-tenant-pending",
+		Status:           meta.TenantPending,
+		DBPasswordCipher: []byte{},
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-pending",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       "pool-tenant-pending",
+		OrganizationID: "org-1",
+		ClusterID:      "cluster-pending",
+		PoolID:         "pool-1",
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	resp := getAdminTenantPool(t, ts.URL, "public-1", "private-1")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("get pool status = %d body=%s", resp.StatusCode, body)
+	}
+	var got adminTenantPoolResponse
+	if err := json.NewDecoder(resp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if got.PoolID != "pool-1" || got.FreeSize != 0 || got.Status != adminTenantPoolStatusCreating {
+		t.Fatalf("get pool response = %#v", got)
 	}
 }
 
@@ -1583,6 +1629,9 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 	}
 	if pool.PoolID != out.PoolID {
 		t.Fatalf("stored pool id = %q, want %q", pool.PoolID, out.PoolID)
+	}
+	if pool.Status != meta.TenantPoolActive {
+		t.Fatalf("stored pool status = %s, want %s", pool.Status, meta.TenantPoolActive)
 	}
 	rows, err := rt.meta.ListPendingTenantPoolBindingsForResume(context.Background(), "org-1", 10)
 	if err != nil {
@@ -1654,6 +1703,9 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissi
 	if pool.PoolID != out.PoolID {
 		t.Fatalf("stored pool id = %q, want %q", pool.PoolID, out.PoolID)
 	}
+	if pool.Status != meta.TenantPoolActive {
+		t.Fatalf("stored pool status = %s, want %s", pool.Status, meta.TenantPoolActive)
+	}
 	rows, err := rt.meta.ListPendingTenantPoolBindingsForResume(context.Background(), "org-1", 10)
 	if err != nil {
 		t.Fatalf("list pending bindings: %v", err)
@@ -1696,6 +1748,13 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneTenantLabelMissin
 	}
 	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 || out.Status != adminTenantPoolStatusCreating {
 		t.Fatalf("pool response = %#v", out)
+	}
+	pool, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1")
+	if err != nil {
+		t.Fatalf("get pool: %v", err)
+	}
+	if pool.Status != meta.TenantPoolActive {
+		t.Fatalf("stored pool status = %s, want %s", pool.Status, meta.TenantPoolActive)
 	}
 	rows, err := rt.meta.ListPendingTenantPoolBindingsForResume(context.Background(), "org-1", 10)
 	if err != nil {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1468,7 +1468,10 @@ func TestAdminTenantQuotaGetIsNotExposed(t *testing.T) {
 
 func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{
+		{},
+		{Clusters: []tenant.CloudClusterInfo{{OrganizationID: "org-1"}}},
+	}
 	ts := httptest.NewServer(rt.server)
 	t.Cleanup(ts.Close)
 
@@ -1486,7 +1489,7 @@ func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 {
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 || out.Status != adminTenantPoolStatusCreating {
 		t.Fatalf("pool response = %#v", out)
 	}
 	if rt.prov.batchPoolCalls.Load() != 1 {
@@ -1500,7 +1503,7 @@ func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get pool: %v", err)
 	}
-	if pool.PoolID != out.PoolID || pool.Size != 2 {
+	if pool.PoolID != out.PoolID || pool.Size != 2 || pool.Status != meta.TenantPoolActive {
 		t.Fatalf("stored pool = %#v", pool)
 	}
 	free, err := rt.meta.CountFreeTenantPoolBindings(context.Background(), "org-1")
@@ -1516,6 +1519,35 @@ func TestAdminTenantPoolCreateBatchProvisionsFreeTenants(t *testing.T) {
 	}
 	if slots != 2 {
 		t.Fatalf("free slots = %d, want 2", slots)
+	}
+
+	getResp := getAdminTenantPool(t, ts.URL, "public-1", "private-1")
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(getResp.Body)
+		t.Fatalf("get pool status = %d body=%s", getResp.StatusCode, body)
+	}
+	var got adminTenantPoolResponse
+	if err := json.NewDecoder(getResp.Body).Decode(&got); err != nil {
+		t.Fatalf("decode get response: %v", err)
+	}
+	if got.PoolID != out.PoolID || got.FreeSize != 0 || got.Status != adminTenantPoolStatusCreating {
+		t.Fatalf("get pool response = %#v", got)
+	}
+}
+
+func TestAdminTenantPoolDisplayStatusCreating(t *testing.T) {
+	if got := adminTenantPoolDisplayStatus(meta.TenantPoolActive, 0, 2); got != adminTenantPoolStatusCreating {
+		t.Fatalf("pending slots status = %q, want %q", got, adminTenantPoolStatusCreating)
+	}
+	if got := adminTenantPoolDisplayStatus(meta.TenantPoolActive, 1, 2); got != string(meta.TenantPoolActive) {
+		t.Fatalf("free slots status = %q, want %q", got, meta.TenantPoolActive)
+	}
+	if got := adminTenantPoolDisplayStatus(meta.TenantPoolActive, 0, 0); got != string(meta.TenantPoolActive) {
+		t.Fatalf("empty slots status = %q, want %q", got, meta.TenantPoolActive)
+	}
+	if got := adminTenantPoolDisplayStatus(meta.TenantPoolDeleting, 0, 2); got != string(meta.TenantPoolDeleting) {
+		t.Fatalf("deleting status = %q, want %q", got, meta.TenantPoolDeleting)
 	}
 }
 
@@ -1542,7 +1574,7 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 {
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 || out.Status != adminTenantPoolStatusCreating {
 		t.Fatalf("pool response = %#v", out)
 	}
 	pool, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1")
@@ -1612,7 +1644,7 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissi
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 {
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 || out.Status != adminTenantPoolStatusCreating {
 		t.Fatalf("pool response = %#v", out)
 	}
 	pool, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-1")
@@ -1662,7 +1694,7 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneTenantLabelMissin
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatalf("decode response: %v", err)
 	}
-	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 {
+	if out.PoolID == "" || out.OrganizationID != "org-1" || out.PoolSize != 2 || out.FreeSize != 0 || out.Status != adminTenantPoolStatusCreating {
 		t.Fatalf("pool response = %#v", out)
 	}
 	rows, err := rt.meta.ListPendingTenantPoolBindingsForResume(context.Background(), "org-1", 10)
@@ -2875,6 +2907,21 @@ func getQuota(t *testing.T, baseURL, tenantID, publicKey, privateKey, apiKey str
 	if apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+apiKey)
 	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+func getAdminTenantPool(t *testing.T, baseURL, publicKey, privateKey string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/admin/tenant-pool", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set(quotaPublicKeyHeader, publicKey)
+	req.Header.Set(quotaPrivateKeyHeader, privateKey)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -42,6 +42,7 @@ type quotaTestProvisioner struct {
 	batchPoolCalls              atomic.Int32
 	markPoolUsedCalls           atomic.Int32
 	markPoolFreeCalls           atomic.Int32
+	ensureSystemUserCalls       atomic.Int32
 	mu                          sync.Mutex
 	lastCluster                 *tenant.ClusterInfo
 	lastCredentials             tenant.CredentialProvisionRequest
@@ -158,6 +159,7 @@ func (p *quotaTestProvisioner) Provision(context.Context, string) (*tenant.Clust
 func (p *quotaTestProvisioner) InitSchema(context.Context, string) error { return nil }
 
 func (p *quotaTestProvisioner) EnsureSystemUser(context.Context, string, string) (string, string, error) {
+	p.ensureSystemUserCalls.Add(1)
 	return "u.tdc_fs_sys", "pool-pass", nil
 }
 
@@ -1594,6 +1596,70 @@ func TestAdminTenantPoolGetShowsCreatingForPendingSlots(t *testing.T) {
 	}
 	if got.PoolID != "pool-1" || got.FreeSize != 0 || got.Status != adminTenantPoolStatusCreating {
 		t.Fatalf("get pool response = %#v", got)
+	}
+}
+
+func TestTenantSchemaInitStopsWhenTenantLeavesProvisioning(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	tenantID := "schema-init-shrunk-tenant"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantProvisioning,
+		DBHost:           "db.example.com",
+		DBPort:           4000,
+		DBUser:           "u.root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-schema-init",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+
+	done := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(done)
+		rt.server.initTenantSchemaAsync(ctx, tenantID, "u.root:pass@tcp(db.example.com:4000)/tidbcloud_fs", tenant.ProviderTiDBCloudNative, func(ctx context.Context, _ string) error {
+			updated, err := rt.meta.UpdateTenantStatusIf(ctx, tenantID, meta.TenantProvisioning, meta.TenantDeleting)
+			if err != nil {
+				errCh <- err
+				return err
+			}
+			if !updated {
+				err := fmt.Errorf("tenant status was not provisioning")
+				errCh <- err
+				return err
+			}
+			return nil
+		})
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("schema init did not stop after tenant left provisioning")
+	}
+	select {
+	case err := <-errCh:
+		t.Fatalf("schema init setup failed: %v", err)
+	default:
+	}
+	if calls := rt.prov.ensureSystemUserCalls.Load(); calls != 0 {
+		t.Fatalf("ensure system user calls = %d, want 0", calls)
+	}
+	got, err := rt.meta.GetTenant(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("get tenant: %v", err)
+	}
+	if got.Status != meta.TenantDeleting {
+		t.Fatalf("tenant status = %s, want %s", got.Status, meta.TenantDeleting)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4783,8 +4783,14 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			return
 		default:
 		}
+		if !s.tenantSchemaInitStillProvisioning(ctx, tenantID, provider, "before_attempt") {
+			return
+		}
 		err := schemaInit(ctx, tenantDSN)
 		if err == nil {
+			if !s.tenantSchemaInitStillProvisioning(ctx, tenantID, provider, "before_finalize") {
+				return
+			}
 			err = s.finalizeTenantSchemaInit(ctx, tenantID, tenantDSN, provider)
 		}
 		if err == nil {
@@ -4804,6 +4810,9 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			}
 			return
 		} else {
+			if !s.tenantSchemaInitStillProvisioning(ctx, tenantID, provider, "after_error") {
+				return
+			}
 			s.schemaInitErrors.Store(tenantID, schemaInitStatusErrorMessage(err))
 			logger.Error(ctx, "server_event", eventFields(ctx, "schema_init_failed", "tenant_id", tenantID, "provider", provider, "attempt", attempt, "error", err)...)
 			if s.metrics != nil {
@@ -4855,6 +4864,41 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 		backoff *= 2
 		attempt++
 	}
+}
+
+func (s *Server) tenantSchemaInitStillProvisioning(ctx context.Context, tenantID, provider, stage string) bool {
+	if s.meta == nil {
+		return true
+	}
+	if ctx.Err() != nil {
+		return false
+	}
+	t, err := s.meta.GetTenant(ctx, tenantID)
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			logger.Info(ctx, "server_event", eventFields(ctx, "schema_init_stopped_status_changed",
+				"tenant_id", tenantID,
+				"provider", provider,
+				"stage", stage,
+				"status", "missing")...)
+			return false
+		}
+		logger.Warn(ctx, "schema_init_status_lookup_failed",
+			zap.String("tenant_id", tenantID),
+			zap.String("provider", provider),
+			zap.String("stage", stage),
+			zap.Error(err))
+		return true
+	}
+	if t.Status != meta.TenantProvisioning {
+		logger.Info(ctx, "server_event", eventFields(ctx, "schema_init_stopped_status_changed",
+			"tenant_id", tenantID,
+			"provider", provider,
+			"stage", stage,
+			"status", t.Status)...)
+		return false
+	}
+	return true
 }
 
 func (s *Server) finalizeTenantSchemaInit(ctx context.Context, tenantID, tenantDSN, provider string) error {


### PR DESCRIPTION
## Summary
- Return `creating` for admin tenant pools that already have reserved free slots but no active free tenant yet, so `pool create/get` no longer reports `active` with `free_size=0` during warmup.
- Keep the stored tenant-pool DB status as `active`; the `creating` value is response-only, so claim/replenish/delete state checks keep using the existing lifecycle.
- Stop tenant schema initialization when a pool resize/delete moves the tenant out of `provisioning`, avoiding repeated TiDB Cloud 1105 retries after shrink deletes a warming free tenant.
- Document and extend the tenant-pool lifecycle log surface: create/delete already emit `admin_tenant_pool_create_*` and `admin_tenant_pool_delete_*`; this PR adds `slot_size` to create completion and adds set-size `admin_tenant_pool_update_*` stage logs for grow/shrink/no-op/persist/fail paths.
- Record `drive9_service_operations_total` and `drive9_service_operation_duration_seconds` for `component="admin_tenant_pool"` across `operation="create|update|delete|replenish"`.
- Classify TiDB Cloud grow/shrink/delete/create failures as `result="cluster_error"` so lifecycle alerts can distinguish cloud/API failures from local metadata errors.

## Related Runbook Change
- Updated tenant-pool alerts in `tidbcloud/runbooks` branch `fix/drive9-worker-bad-conn-alert` / PR #2626.
- The failure alert now covers tenant pool `create|update|delete|replenish`, not just update/set-size.
- The latency alert remains focused on `operation="update"` because set-size holds the pool mutation lock around slow grow/shrink work.

## Tests
- `make lint`
- `make test TEST_PKGS='./pkg/server' TEST_RUN='TestTenantSchemaInitStopsWhenTenantLeavesProvisioning'`
- `make test TEST_PKGS='./pkg/server' TEST_RUN='TestAdminTenantPool|TestTenantSchemaInitStopsWhenTenantLeavesProvisioning'`
- YAML parse check for `/home/sweetqiu/project/runbooks/rules/mem9/mnemos/drive9-alerts.yaml`

## Notes
- `promtool` is not installed locally, so Prometheus rule validation was limited to YAML parsing.