### PR TITLE
feat: central outbox SSE scheme to avoid per-tenant TiDB polling

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -368,13 +368,14 @@ func main() {
 	podID := strings.TrimSpace(os.Getenv("DRIVE9_POD_ID"))
 	podAddr := strings.TrimSpace(os.Getenv("DRIVE9_POD_ADDR"))
 	// Default podAddr to the listen addr only if it's a real, non-wildcard
-	// address. Wildcard binds like ":9009", "0.0.0.0:9009", or "[::]:9009" are
-	// not dialable by peers, so we leave podAddr empty in that case — the
+	// address. The notifier requires a full base URL (http://host:port) for
+	// http.NewRequest. Wildcard binds like ":9009", "0.0.0.0:9009", or "[::]:9009"
+	// are not dialable by peers, so we leave podAddr empty in that case — the
 	// podRegistry still reports subscriptions and the leader sweeps stale pods,
 	// but cross-pod HTTP push is disabled until an explicit address is set.
 	if podAddr == "" && podID != "" {
 		if host, port, err := net.SplitHostPort(addr); err == nil && host != "" && host != "0.0.0.0" && host != "::" {
-			podAddr = net.JoinHostPort(host, port)
+			podAddr = "http://" + net.JoinHostPort(host, port)
 		}
 	}
 	var podNotifySecret []byte
@@ -556,11 +557,12 @@ environment:
   SSE cross-pod notification (set DRIVE9_POD_ID to enable; required for large multi-tenant deployments):
   DRIVE9_POD_ID     unique pod identifier; when set, this pod registers in the central
                     pod_registry and reports its SSE subscriber tenant set so peers can
-                    route push notifications. Enables the new SSE scheme that avoids
-                    polling every tenant's TiDB (idle tenant TiDBs can scale to zero).
-  DRIVE9_POD_ADDR   internally reachable address (host:port) for peer push notifications
-                    (default: DRIVE9_LISTEN_ADDR; in multi-host deployments set to the
-                    address reachable by other pods)
+                    route push notifications. The outbox poller runs on all multi-tenant
+                    pods regardless; cross-pod HTTP push requires DRIVE9_POD_NOTIFY_SECRET.
+  DRIVE9_POD_ADDR   full base URL (e.g. http://10.0.0.5:9009) reachable by other pods for
+                    peer push notifications. Defaults to http://<listen-addr> when the
+                    listen address is a non-wildcard host; must be set explicitly in
+                    multi-host deployments.
   DRIVE9_POD_NOTIFY_SECRET  shared bearer token for /v1/internal/sse-notify pod-to-pod
                     push authentication. When set, enables the <10ms cross-pod HTTP push
                     path; when unset, only the 200ms fallback poller is used.

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -357,6 +357,34 @@ func main() {
 		logger.Info(context.Background(), "slock_oauth_disabled")
 	}
 
+	// SSE cross-pod notification configuration. These enable the new scheme
+	// that avoids polling every tenant's TiDB. The notify poller reads the
+	// central sse_notify_outbox (always-provisioned meta DB) at 200ms; the
+	// pod-to-pod HTTP push provides <10ms latency when PodID/PodAddr/secret
+	// are set. See pkg/server/notify_poller.go and pod_notifier.go.
+	sseNotifyPollInterval := envDuration("DRIVE9_SSE_NOTIFY_POLL_INTERVAL", 200*time.Millisecond)
+	sseNotifyRetention := envDuration("DRIVE9_SSE_NOTIFY_RETENTION", time.Hour)
+	podID := strings.TrimSpace(os.Getenv("DRIVE9_POD_ID"))
+	podAddr := strings.TrimSpace(os.Getenv("DRIVE9_POD_ADDR"))
+	// Default podAddr to the listen addr if not explicitly set, so single-host
+	// deployments work without extra configuration. Multi-host deployments must
+	// set DRIVE9_POD_ADDR to the internally reachable address.
+	if podAddr == "" && podID != "" {
+		podAddr = addr
+	}
+	var podNotifySecret []byte
+	if raw := strings.TrimSpace(os.Getenv("DRIVE9_POD_NOTIFY_SECRET")); raw != "" {
+		podNotifySecret = []byte(raw)
+	}
+	if podID != "" {
+		logger.Info(context.Background(), "sse_notify_config",
+			zap.String("pod_id", podID),
+			zap.String("pod_addr", podAddr),
+			zap.Duration("poll_interval", sseNotifyPollInterval),
+			zap.Duration("retention", sseNotifyRetention),
+			zap.Bool("push_enabled", podNotifySecret != nil))
+	}
+
 	die(server.NewWithConfig(server.Config{
 		Meta:                         store,
 		Pool:                         pool,
@@ -378,6 +406,11 @@ func main() {
 		TiDBAutoEmbeddingAPIBase:     autoEmbeddingAPIBase,
 		DisableDatabaseAutoEmbedding: disableDatabaseAutoEmbedding,
 		Leader:                       leaderManager,
+		SSENotifyPollInterval:        sseNotifyPollInterval,
+		SSENotifyRetention:           sseNotifyRetention,
+		PodID:                         podID,
+		PodAddr:                       podAddr,
+		PodNotifySecret:               podNotifySecret,
 	}).ListenAndServe(addr))
 }
 
@@ -514,6 +547,21 @@ environment:
   DRIVE9_SLOCK_API_ORIGIN Slock API origin (required when DRIVE9_SLOCK_ORIGIN is set)
   DRIVE9_SLOCK_CLIENT_ID Slock connected-app client id (required when DRIVE9_SLOCK_ORIGIN is set)
   DRIVE9_SLOCK_CLIENT_SECRET Slock connected-app client secret (required when DRIVE9_SLOCK_ORIGIN is set)
+
+  SSE cross-pod notification (set DRIVE9_POD_ID to enable; required for large multi-tenant deployments):
+  DRIVE9_POD_ID     unique pod identifier; when set, this pod registers in the central
+                    pod_registry and reports its SSE subscriber tenant set so peers can
+                    route push notifications. Enables the new SSE scheme that avoids
+                    polling every tenant's TiDB (idle tenant TiDBs can scale to zero).
+  DRIVE9_POD_ADDR   internally reachable address (host:port) for peer push notifications
+                    (default: DRIVE9_LISTEN_ADDR; in multi-host deployments set to the
+                    address reachable by other pods)
+  DRIVE9_POD_NOTIFY_SECRET  shared bearer token for /v1/internal/sse-notify pod-to-pod
+                    push authentication. When set, enables the <10ms cross-pod HTTP push
+                    path; when unset, only the 200ms fallback poller is used.
+  DRIVE9_SSE_NOTIFY_POLL_INTERVAL  fallback outbox poll interval (default: 200ms)
+  DRIVE9_SSE_NOTIFY_RETENTION      how long outbox rows are kept before leader pruning
+                    (default: 1h)
 
   S3 storage (set DRIVE9_S3_BUCKET to enable AWS S3, otherwise local mock):
   DRIVE9_S3_BUCKET   S3 bucket name (enables AWS S3 mode)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"strconv"
 	"strings"
@@ -366,11 +367,15 @@ func main() {
 	sseNotifyRetention := envDuration("DRIVE9_SSE_NOTIFY_RETENTION", time.Hour)
 	podID := strings.TrimSpace(os.Getenv("DRIVE9_POD_ID"))
 	podAddr := strings.TrimSpace(os.Getenv("DRIVE9_POD_ADDR"))
-	// Default podAddr to the listen addr if not explicitly set, so single-host
-	// deployments work without extra configuration. Multi-host deployments must
-	// set DRIVE9_POD_ADDR to the internally reachable address.
+	// Default podAddr to the listen addr only if it's a real, non-wildcard
+	// address. Wildcard binds like ":9009", "0.0.0.0:9009", or "[::]:9009" are
+	// not dialable by peers, so we leave podAddr empty in that case — the
+	// podRegistry still reports subscriptions and the leader sweeps stale pods,
+	// but cross-pod HTTP push is disabled until an explicit address is set.
 	if podAddr == "" && podID != "" {
-		podAddr = addr
+		if host, port, err := net.SplitHostPort(addr); err == nil && host != "" && host != "0.0.0.0" && host != "::" {
+			podAddr = net.JoinHostPort(host, port)
+		}
 	}
 	var podNotifySecret []byte
 	if raw := strings.TrimSpace(os.Getenv("DRIVE9_POD_NOTIFY_SECRET")); raw != "" {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -3331,11 +3331,19 @@ func (s *Store) MarkStalePods(ctx context.Context, before time.Time) (n int64, e
 
 // DeletePod removes a pod and its subscriptions from the registry. Used when a
 // pod is decommissioned. Best-effort: stale pod cleanup handles the common case.
+// DeletePod removes a pod and its subscriptions from the registry. Both
+// deletions run in a single transaction so a partial failure doesn't leave
+// orphaned subscription rows. Used when a pod is decommissioned.
 func (s *Store) DeletePod(ctx context.Context, podID string) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "delete_pod", start, &err)
-	_, err = s.db.ExecContext(ctx, `DELETE FROM pod_registry WHERE pod_id = ?`, podID)
-	return err
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM pod_subscriptions WHERE pod_id = ?`, podID); err != nil {
+			return err
+		}
+		_, err := tx.ExecContext(ctx, `DELETE FROM pod_registry WHERE pod_id = ?`, podID)
+		return err
+	})
 }
 
 // ---------------------------------------------------------------------------
@@ -3477,4 +3485,22 @@ func (s *Store) ListStalePods(ctx context.Context) (out []string, err error) {
 		out = append(out, podID)
 	}
 	return out, rows.Err()
+}
+
+// DeleteSubscriptionsForStalePods deletes pod_subscriptions rows whose pod is
+// currently stale, using a subquery join so the stale check and the delete are
+// atomic. This avoids a TOCTOU race where a pod recovers to active between
+// ListStalePods and DeletePodSubscriptions, which would delete subscriptions for
+// a live pod. Returns the number of deleted rows.
+func (s *Store) DeleteSubscriptionsForStalePods(ctx context.Context) (n int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_subscriptions_for_stale_pods", start, &err)
+	res, err := s.db.ExecContext(ctx,
+		`DELETE ps FROM pod_subscriptions ps
+		 INNER JOIN pod_registry pr ON ps.pod_id = pr.pod_id
+		 WHERE pr.status = 'stale'`)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
 }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -672,6 +672,45 @@ func metaInitSchemaStatements() []string {
 			INDEX idx_pending (status, created_at),
 			INDEX idx_tenant_order (tenant_id, id)
 		)`,
+		// sse_notify_outbox is a central notification pointer table for cross-pod
+		// SSE event fan-out. Each FS mutation writes a lightweight row here (tenant_id
+		// + seq) so that pods can discover which tenants have new events without
+		// polling every tenant's own TiDB. The event content stays in the per-tenant
+		// fs_events table; this table only signals "tenant T has new rows after seq".
+		// The central meta DB is always provisioned (not serverless), so polling it
+		// does not incur per-tenant RCU. Retention pruning is leader-gated.
+		`CREATE TABLE IF NOT EXISTS sse_notify_outbox (
+			id         BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			tenant_id  VARCHAR(64) NOT NULL,
+			seq        BIGINT UNSIGNED NOT NULL,
+			created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			INDEX idx_sse_notify_created (created_at)
+		)`,
+		// pod_registry tracks all drive9-server pods for cross-pod SSE push
+		// notification routing. Each pod upserts its row on startup and heartbeats
+		// every ~10s. The leader marks pods with stale heartbeats as inactive so
+		// writers don't push to dead pods. This table lives in the central meta DB
+		// (always provisioned).
+		`CREATE TABLE IF NOT EXISTS pod_registry (
+			pod_id         VARCHAR(64) PRIMARY KEY,
+			addr           VARCHAR(255) NOT NULL,
+			last_heartbeat DATETIME(3) NOT NULL,
+			status         VARCHAR(20) NOT NULL DEFAULT 'active',
+			created_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			INDEX idx_pod_heartbeat (last_heartbeat)
+		)`,
+		// pod_subscriptions maps each pod to the tenant IDs for which it has active
+		// SSE subscribers. Writers consult this (via a locally cached reverse index)
+		// to push notifications only to pods that care about a given tenant, avoiding
+		// wasteful fan-out to pods with no subscribers for that tenant. Each pod
+		// periodically upserts its current subscriber set and prunes stale entries.
+		`CREATE TABLE IF NOT EXISTS pod_subscriptions (
+			pod_id     VARCHAR(64) NOT NULL,
+			tenant_id VARCHAR(64) NOT NULL,
+			updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (pod_id, tenant_id)
+		)`,
 	}
 }
 
@@ -3131,4 +3170,311 @@ func isDuplicateEntry(err error) bool {
 	}
 	msg := err.Error()
 	return strings.Contains(msg, "Duplicate entry") || strings.Contains(msg, "UNIQUE constraint failed")
+}
+
+// ---------------------------------------------------------------------------
+// SSE notify outbox
+// ---------------------------------------------------------------------------
+
+// SSENotifyRow mirrors a row in sse_notify_outbox. It is a lightweight pointer
+// (tenant_id + seq) to the actual event content stored in the per-tenant
+// fs_events table. The central meta DB holds this table so pods can discover
+// cross-pod events without polling every tenant's own TiDB.
+type SSENotifyRow struct {
+	ID        uint64
+	TenantID  string
+	Seq       uint64
+	CreatedAt time.Time
+}
+
+// PodRegistryStatus is the lifecycle state of a pod in pod_registry.
+type PodRegistryStatus string
+
+const (
+	PodRegistryActive PodRegistryStatus = "active"
+	PodRegistryStale  PodRegistryStatus = "stale"
+)
+
+// PodRow mirrors a row in pod_registry.
+type PodRow struct {
+	PodID  string
+	Addr   string
+	Status PodRegistryStatus
+}
+
+// InsertSSENotify writes a notification pointer to sse_notify_outbox. This is
+// best-effort: if the INSERT fails, the event is still durable in the
+// per-tenant fs_events table and will be discovered on SSE client reconnect
+// replay. The central meta DB is always provisioned so this write never wakes
+// a serverless tenant TiDB.
+func (s *Store) InsertSSENotify(ctx context.Context, tenantID string, seq uint64) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "insert_sse_notify", start, &err)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO sse_notify_outbox (tenant_id, seq) VALUES (?, ?)`,
+		tenantID, seq)
+	return err
+}
+
+// ListSSENotifySince returns outbox rows with id > afterID, ordered by id, up to
+// limit. The consumer advances its cursor to the last row's id so subsequent
+// calls do not re-read the same rows.
+func (s *Store) ListSSENotifySince(ctx context.Context, afterID uint64, limit int) (out []SSENotifyRow, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_sse_notify_since", start, &err)
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, tenant_id, seq, created_at FROM sse_notify_outbox WHERE id > ? ORDER BY id LIMIT ?`,
+		afterID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var rec SSENotifyRow
+		if err = rows.Scan(&rec.ID, &rec.TenantID, &rec.Seq, &rec.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+// MaxSSENotifyID returns the current maximum id in sse_notify_outbox, or 0 if
+// the table is empty. Used by the notify poller to initialize its cursor on
+// startup (skipping historical rows — SSE client reconnect replay covers those).
+func (s *Store) MaxSSENotifyID(ctx context.Context) (out uint64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "max_sse_notify_id", start, &err)
+	row := s.db.QueryRowContext(ctx, `SELECT COALESCE(MAX(id), 0) FROM sse_notify_outbox`)
+	if err = row.Scan(&out); err != nil {
+		return 0, err
+	}
+	return out, nil
+}
+
+// DeleteSSENotifyBefore prunes outbox rows older than the given threshold.
+// Leader-gated; retention is relative to DB insert time (created_at).
+func (s *Store) DeleteSSENotifyBefore(ctx context.Context, before time.Time) (n int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_sse_notify_before", start, &err)
+	res, err := s.db.ExecContext(ctx, `DELETE FROM sse_notify_outbox WHERE created_at < ?`, before)
+	if err != nil {
+		return 0, err
+	}
+	n, err = res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// ---------------------------------------------------------------------------
+// Pod registry
+// ---------------------------------------------------------------------------
+
+// UpsertPod registers or refreshes this pod's heartbeat in pod_registry. On
+// first insert the row is created with status='active'; on subsequent calls
+// the addr, last_heartbeat, and status are updated (reviving a stale pod).
+func (s *Store) UpsertPod(ctx context.Context, podID, addr string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "upsert_pod", start, &err)
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO pod_registry (pod_id, addr, last_heartbeat, status)
+		 VALUES (?, ?, NOW(3), 'active')
+		 ON DUPLICATE KEY UPDATE addr = VALUES(addr), last_heartbeat = NOW(3), status = 'active'`,
+		podID, addr)
+	return err
+}
+
+// ListActivePods returns all active pods excluding selfID. Used by the pod
+// notifier to build its peer list for cross-pod HTTP push.
+func (s *Store) ListActivePods(ctx context.Context, selfID string) (out []PodRow, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_active_pods", start, &err)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT pod_id, addr, status FROM pod_registry WHERE status = 'active' AND pod_id != ?`,
+		selfID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var rec PodRow
+		if err = rows.Scan(&rec.PodID, &rec.Addr, &rec.Status); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+// MarkStalePods marks pods with heartbeats older than the threshold as stale.
+// Leader-gated: prevents writers from pushing notifications to dead pods.
+func (s *Store) MarkStalePods(ctx context.Context, before time.Time) (n int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "mark_stale_pods", start, &err)
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE pod_registry SET status = 'stale' WHERE last_heartbeat < ? AND status = 'active'`,
+		before)
+	if err != nil {
+		return 0, err
+	}
+	n, err = res.RowsAffected()
+	if err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// DeletePod removes a pod and its subscriptions from the registry. Used when a
+// pod is decommissioned. Best-effort: stale pod cleanup handles the common case.
+func (s *Store) DeletePod(ctx context.Context, podID string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_pod", start, &err)
+	_, err = s.db.ExecContext(ctx, `DELETE FROM pod_registry WHERE pod_id = ?`, podID)
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// Pod subscriptions
+// ---------------------------------------------------------------------------
+
+// UpsertPodSubscriptions records the set of tenant IDs for which podID has
+// active SSE subscribers. Each (pod_id, tenant_id) pair is upserted with the
+// current timestamp. Callers should call PrunePodSubscriptions to remove
+// tenants that are no longer active.
+func (s *Store) UpsertPodSubscriptions(ctx context.Context, podID string, tenantIDs []string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "upsert_pod_subscriptions", start, &err)
+	if len(tenantIDs) == 0 {
+		return nil
+	}
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		for _, tenantID := range tenantIDs {
+			if _, err := tx.ExecContext(ctx,
+				`INSERT INTO pod_subscriptions (pod_id, tenant_id)
+				 VALUES (?, ?)
+				 ON DUPLICATE KEY UPDATE updated_at = NOW(3)`,
+				podID, tenantID); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}
+
+// PrunePodSubscriptions removes pod_subscriptions rows for podID whose
+// tenant_id is not in keepSet. This lets a pod prune tenants whose SSE
+// subscribers have all disconnected. keepSet may be empty (prunes all).
+func (s *Store) PrunePodSubscriptions(ctx context.Context, podID string, keepSet []string) (n int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "prune_pod_subscriptions", start, &err)
+	if len(keepSet) == 0 {
+		res, err := s.db.ExecContext(ctx,
+			`DELETE FROM pod_subscriptions WHERE pod_id = ?`, podID)
+		if err != nil {
+			return 0, err
+		}
+		return res.RowsAffected()
+	}
+	// Build a NOT IN clause with placeholders. keepSet is bounded by the number
+	// of tenants with active SSE connections on this pod (typically small).
+	placeholders := make([]string, len(keepSet))
+	args := make([]any, 0, len(keepSet)+1)
+	args = append(args, podID)
+	for i, t := range keepSet {
+		placeholders[i] = "?"
+		args = append(args, t)
+	}
+	query := fmt.Sprintf(
+		`DELETE FROM pod_subscriptions WHERE pod_id = ? AND tenant_id NOT IN (%s)`,
+		strings.Join(placeholders, ","))
+	res, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// ListPodSubscriptions returns the tenant IDs for which podID has active SSE
+// subscribers. Used by the route cache builder to compute which peers care
+// about each tenant.
+func (s *Store) ListPodSubscriptions(ctx context.Context, podID string) (out []string, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_pod_subscriptions", start, &err)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT tenant_id FROM pod_subscriptions WHERE pod_id = ?`, podID)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var tenantID string
+		if err = rows.Scan(&tenantID); err != nil {
+			return nil, err
+		}
+		out = append(out, tenantID)
+	}
+	return out, rows.Err()
+}
+
+// ListAllPodSubscriptions returns all (pod_id, tenant_id) pairs from
+// pod_subscriptions. Used by the route cache builder to construct a
+// tenant→pods reverse index for push notification routing.
+func (s *Store) ListAllPodSubscriptions(ctx context.Context) (out []PodSubscriptionRow, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_all_pod_subscriptions", start, &err)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT pod_id, tenant_id FROM pod_subscriptions`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var rec PodSubscriptionRow
+		if err = rows.Scan(&rec.PodID, &rec.TenantID); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+// PodSubscriptionRow mirrors a row in pod_subscriptions.
+type PodSubscriptionRow struct {
+	PodID    string
+	TenantID string
+}
+
+// DeletePodSubscriptions removes all subscription rows for podID. Called when
+// a pod is decommissioned or marked stale by the leader sweeper.
+func (s *Store) DeletePodSubscriptions(ctx context.Context, podID string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_pod_subscriptions", start, &err)
+	_, err = s.db.ExecContext(ctx, `DELETE FROM pod_subscriptions WHERE pod_id = ?`, podID)
+	return err
+}
+
+// ListStalePods returns pod IDs with status='stale'. Used by the leader sweeper
+// to clean up subscriptions for dead pods.
+func (s *Store) ListStalePods(ctx context.Context) (out []string, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_stale_pods", start, &err)
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT pod_id FROM pod_registry WHERE status = 'stale'`)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var podID string
+		if err = rows.Scan(&podID); err != nil {
+			return nil, err
+		}
+		out = append(out, podID)
+	}
+	return out, rows.Err()
 }

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -23,31 +23,31 @@ type ChangeEvent struct {
 
 const (
 	eventBusListenerChanSize = 1 // signal-only channel
-	// eventBusPollInterval is how often the per-bus poll goroutine queries
-	// fs_events for cross-pod events. Matches the fs_layer_events poll interval.
-	eventBusPollInterval = 1 * time.Second
 )
 
 // EventBus is a per-tenant event hub backed by the durable fs_events table.
 // Events are stored in the shared tenant database so that they propagate across
-// all pods. The local notify channel provides instant push to same-pod SSE clients;
-// cross-pod events are discovered via a single per-bus poll goroutine (not
-// per-connection) to minimize TiDB RCU consumption.
+// all pods. The local notify channel provides instant push to same-pod SSE
+// clients; cross-pod events are discovered via the central sse_notify_outbox
+// table in the meta DB (polled by a single global notifyPoller per pod, not a
+// per-bus goroutine) and optionally via direct pod-to-pod HTTP push.
+//
 // The store field is an atomic pointer so it can be safely refreshed by
 // eventBuses.get (when the pool recreates a backend) while SSE handlers read it.
+//
+// Design note: prior to the outbox redesign, each EventBus ran its own 1s poll
+// goroutine querying the tenant's fs_events table. With ~100k tenants this
+// kept every serverless tenant TiDB awake (RCU cost). Now cross-pod discovery is
+// centralized: a single notifyPoller reads the lightweight sse_notify_outbox
+// (in the always-provisioned meta DB) and calls Publish() on matching buses.
+// A podNotifier additionally pushes notifications to peers for <10ms latency.
+// Neither path touches a tenant TiDB unless that tenant actually has new events.
 type EventBus struct {
-	tenantID  string
-	store     atomic.Pointer[datastore.Store]
-	mu        sync.Mutex
+	tenantID string
+	store    atomic.Pointer[datastore.Store]
+	mu       sync.Mutex
 	listeners map[uint64]chan struct{}
 	nextID    uint64
-
-	// poll goroutine lifecycle: starts on first Subscribe, stops on last Unsubscribe.
-	// pollDone is a per-generation done channel: the last Unsubscribe captures it
-	// and waits on it, while non-last Unsubscribers return immediately.
-	pollCancel context.CancelFunc
-	pollDone   chan struct{}
-	pollLast   uint64 // last seq seen by the poll goroutine
 }
 
 // NewEventBus creates a new EventBus backed by the given tenant store.
@@ -60,6 +60,11 @@ func NewEventBus(tenantID string, store *datastore.Store) *EventBus {
 	return eb
 }
 
+// TenantID returns the tenant identifier for this bus.
+func (eb *EventBus) TenantID() string {
+	return eb.tenantID
+}
+
 // SetStore atomically updates the backing store. Called by eventBuses.get
 // when the pool invalidates and recreates a backend (closing the old store
 // and opening a new one).
@@ -67,10 +72,20 @@ func (eb *EventBus) SetStore(store *datastore.Store) {
 	eb.store.Store(store)
 }
 
+// HasListeners returns true if this bus currently has at least one subscriber.
+// Used by the notify poller and pod notifier to skip tenants with no local SSE
+// connections (avoiding unnecessary wakeups).
+func (eb *EventBus) HasListeners() bool {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	return len(eb.listeners) > 0
+}
+
 // Publish signals all local subscribers that a new event is available.
 // The actual event row is inserted into fs_events by the caller (publishEvent)
 // before calling Publish; this method only wakes same-pod SSE clients for instant
-// delivery. Cross-pod clients discover new rows via periodic polling.
+// delivery. Cross-pod clients discover new rows via the central notifyPoller
+// or pod-to-pod HTTP push.
 func (eb *EventBus) Publish() {
 	eb.mu.Lock()
 	for _, ch := range eb.listeners {
@@ -84,11 +99,7 @@ func (eb *EventBus) Publish() {
 
 // Subscribe registers a new listener. Returns a unique ID and a signal channel.
 // The channel receives a signal whenever new events are published locally or
-// discovered by the per-bus cross-pod poll goroutine.
-// On the first Subscribe, the poll goroutine is started to discover cross-pod
-// events. pollLast is initialized synchronously to the current head seq before
-// the goroutine starts, so no cross-pod events are missed between initial replay
-// and poll loop startup. On the last Unsubscribe, the poll goroutine is stopped.
+// discovered by the central notifyPoller / received via pod-to-pod push.
 func (eb *EventBus) Subscribe() (uint64, chan struct{}) {
 	eb.mu.Lock()
 	defer eb.mu.Unlock()
@@ -98,39 +109,10 @@ func (eb *EventBus) Subscribe() (uint64, chan struct{}) {
 	ch := make(chan struct{}, eventBusListenerChanSize)
 	eb.listeners[id] = ch
 	metrics.RecordSSEInFlight(eb.tenantID, float64(len(eb.listeners)))
-
-	// Start the cross-pod poll goroutine on first subscriber.
-	if eb.pollCancel == nil {
-		// Initialize pollLast synchronously to the current head seq so the
-		// poll goroutine doesn't miss events inserted between Subscribe
-		// returning and pollLoop starting. Events written while no subscriber
-		// existed are not signaled by the poll loop (no listeners to signal);
-		// a fresh Subscribe's Phase-1 EventsSince replay from the client's
-		// since cursor is the authoritative delivery path for those.
-		store := eb.store.Load()
-		if store != nil {
-			if seq, err := store.LatestFSEventSeq(context.Background()); err == nil && seq > 0 {
-				eb.pollLast = uint64(seq)
-			}
-		}
-		ctx, cancel := context.WithCancel(context.Background())
-		eb.pollCancel = cancel
-		done := make(chan struct{})
-		eb.pollDone = done
-		go eb.pollLoop(ctx, done)
-	}
 	return id, ch
 }
 
 // Unsubscribe removes a listener and closes its channel.
-// On the last Unsubscribe, the poll goroutine is stopped and the caller waits
-// for it to exit. Non-last Unsubscribers return immediately without waiting.
-//
-// Concurrency note: if a new Subscribe arrives between Unsubscribe releasing
-// the lock and waiting on doneCh, the new Subscribe starts a fresh poll
-// goroutine while the old one is still draining. Both goroutines briefly
-// coexist — this is safe (idempotent wakeups, each reads pollLast under the
-// lock) and the old goroutine exits within one tick interval.
 func (eb *EventBus) Unsubscribe(id uint64) {
 	eb.mu.Lock()
 	if ch, ok := eb.listeners[id]; ok {
@@ -138,80 +120,7 @@ func (eb *EventBus) Unsubscribe(id uint64) {
 		close(ch)
 	}
 	metrics.RecordSSEInFlight(eb.tenantID, float64(len(eb.listeners)))
-	// Stop the poll goroutine when no subscribers remain.
-	var doneCh chan struct{}
-	if len(eb.listeners) == 0 && eb.pollCancel != nil {
-		eb.pollCancel()
-		eb.pollCancel = nil
-		doneCh = eb.pollDone
-		eb.pollDone = nil
-	}
 	eb.mu.Unlock()
-
-	// Only the last unsubscriber waits for the poll goroutine to exit.
-	// Non-last unsubscribers return immediately.
-	if doneCh != nil {
-		<-doneCh
-	}
-}
-
-// pollLoop is the per-bus cross-pod poll goroutine. It periodically queries
-// fs_events for new rows (written by other pods) and signals all local
-// subscribers via Publish(). This replaces per-SSE-connection polling, reducing
-// idle RCU from N-mounts×QPS to 1-poll-per-bus.
-// pollLast is initialized synchronously in Subscribe before this goroutine starts.
-func (eb *EventBus) pollLoop(ctx context.Context, done chan struct{}) {
-	defer close(done)
-
-	ticker := time.NewTicker(eventBusPollInterval)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			eb.pollOnce(ctx)
-		}
-	}
-}
-
-// pollOnce queries fs_events for rows after pollLast and signals subscribers
-// if any new rows are found. Note: SetStore may swap the store between the
-// Load() here and the ListFSEventsSince call — a stale reference may hit a
-// closed DB. The error is logged (not silently swallowed) so operators can
-// detect pool-churn-induced stale-store hits.
-func (eb *EventBus) pollOnce(ctx context.Context) {
-	store := eb.store.Load()
-	if store == nil {
-		return
-	}
-	eb.mu.Lock()
-	since := eb.pollLast
-	eb.mu.Unlock()
-
-	queryStart := time.Now()
-	rows, err := store.ListFSEventsSince(ctx, int64(since), 1000)
-	metrics.RecordEventBusQuery(eb.tenantID, "poll", queryResult(err), time.Since(queryStart))
-	if err != nil {
-		// Log so operators can detect persistent failures or pool-churn-induced
-		// stale-store hits. Don't send reset — just skip this tick.
-		logger.Warn(ctx, "event_bus_poll_failed",
-			zap.String("tenant_id", eb.tenantID),
-			zap.Uint64("since", since),
-			zap.Float64("query_ms", float64(time.Since(queryStart).Microseconds())/1000),
-			zap.Error(err))
-		metrics.RecordEventBusPollFailure(eb.tenantID)
-		return
-	}
-	if len(rows) == 0 {
-		return
-	}
-	// Update pollLast to the last row's seq and signal subscribers.
-	eb.mu.Lock()
-	eb.pollLast = rows[len(rows)-1].Seq
-	eb.mu.Unlock()
-	eb.Publish()
 }
 
 // Seq returns the current maximum fs_events seq, or 0 if no events exist.

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -244,8 +244,10 @@ func TestEventBusEventsSinceQueryErrorReturnsCaughtUp(t *testing.T) {
 
 // TestEventBusUnsubscribeOneOfManyReturnsImmediately verifies that unsubscribing
 // while other subscribers remain connected returns immediately (B1 regression test).
-// Before the fix, Unsubscribe unconditionally waited on pollWG, blocking until
-// all other subscribers left.
+// Before the original fix, Unsubscribe unconditionally waited on the poll goroutine,
+// blocking until all other subscribers left. (The per-bus poll goroutine has since
+// been removed entirely — cross-pod discovery is now centralized in the notifyPoller
+// — but the fast-return property is still asserted here.)
 func TestEventBusUnsubscribeOneOfManyReturnsImmediately(t *testing.T) {
 	store := newTestStoreForEventBus(t)
 	bus := NewEventBus("test-tenant", store)
@@ -267,79 +269,5 @@ func TestEventBusUnsubscribeOneOfManyReturnsImmediately(t *testing.T) {
 		// Success: returned immediately.
 	case <-time.After(time.Second):
 		t.Fatal("Unsubscribe blocked while another subscriber remained connected")
-	}
-}
-
-// TestEventBusPollLoopStopsAfterLastUnsubscribe verifies that the poll goroutine
-// stops after the last Unsubscribe and can restart cleanly on a later Subscribe.
-func TestEventBusPollLoopStopsAfterLastUnsubscribe(t *testing.T) {
-	store := newTestStoreForEventBus(t)
-	bus := NewEventBus("test-tenant", store)
-
-	// Subscribe then unsubscribe — poll should stop.
-	id, _ := bus.Subscribe()
-	bus.Unsubscribe(id)
-
-	// pollCancel should be nil after last unsubscribe.
-	bus.mu.Lock()
-	cancelNil := bus.pollCancel == nil
-	bus.mu.Unlock()
-	if !cancelNil {
-		t.Fatal("pollCancel should be nil after last Unsubscribe")
-	}
-
-	// Resubscribe — poll should restart.
-	id2, notify := bus.Subscribe()
-	defer bus.Unsubscribe(id2)
-
-	bus.mu.Lock()
-	cancelSet := bus.pollCancel != nil
-	bus.mu.Unlock()
-	if !cancelSet {
-		t.Fatal("pollCancel should be set after Subscribe restarts poll")
-	}
-
-	// Verify notify still works.
-	bus.Publish()
-	select {
-	case _, open := <-notify:
-		if !open {
-			t.Fatal("notify channel closed unexpectedly")
-		}
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for notify signal after poll restart")
-	}
-}
-
-// TestEventBusPollLoopSignalsCrossPodEvents verifies that the per-bus poll
-// goroutine discovers new fs_events rows and signals subscribers via Publish.
-func TestEventBusPollLoopSignalsCrossPodEvents(t *testing.T) {
-	store := newTestStoreForEventBus(t)
-	bus := NewEventBus("test-tenant", store)
-
-	// Insert an initial event so pollLast initializes to it.
-	if _, err := store.InsertFSEvent(context.Background(), "/init.txt", "write", "", time.Now().UnixMilli()); err != nil {
-		t.Fatal(err)
-	}
-
-	id, notify := bus.Subscribe()
-	defer bus.Unsubscribe(id)
-
-	// Simulate a cross-pod write: insert a new row directly into fs_events
-	// (not via publishEvent), bypassing the local notify channel.
-	if _, err := store.InsertFSEvent(context.Background(), "/cross-pod.txt", "write", "remote", time.Now().UnixMilli()); err != nil {
-		t.Fatal(err)
-	}
-
-	// The per-bus poll goroutine should discover the new row within ~2s
-	// (1s poll interval + margin) and signal via Publish.
-	select {
-	case _, open := <-notify:
-		if !open {
-			t.Fatal("notify channel closed")
-		}
-		// Signal received — poll goroutine discovered the cross-pod event.
-	case <-time.After(3 * time.Second):
-		t.Fatal("timed out waiting for cross-pod event signal from poll goroutine")
 	}
 }

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -403,6 +403,8 @@ func requestRoute(path string) string {
 		return "/v1/sql"
 	case path == sseEventsRoute:
 		return sseEventsRoute
+	case path == sseNotifyInternalRoute:
+		return sseNotifyInternalRoute
 	case path == "/v1/fork":
 		return "/v1/fork"
 	case path == "/v1/fs:batch-stat":

--- a/pkg/server/notify_poller.go
+++ b/pkg/server/notify_poller.go
@@ -1,0 +1,124 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"go.uber.org/zap"
+)
+
+// notifyPoller is a single per-pod goroutine that reads the central
+// sse_notify_outbox table (in the always-provisioned meta DB) to discover
+// which tenants have new fs_events rows written by other pods. For each
+// notification row, it looks up the local EventBus (if one exists with active
+// subscribers) and calls Publish() to wake SSE handlers. If no local bus
+// exists for the tenant, the notification is silently skipped — the tenant's
+// TiDB is never queried.
+//
+// This replaces the old per-bus pollLoop (one 1s goroutine per tenant) with a
+// single 200ms goroutine targeting the central meta DB. With ~100k tenants the
+// old scheme generated ~100k QPS against 100k separate serverless TiDBs,
+// preventing scale-to-zero. The new scheme generates 1 QPS per pod against a
+// single always-provisioned meta DB, and idle tenant TiDBs can sleep.
+//
+// The poller is the fallback path. The primary cross-pod path is the podNotifier
+// (direct HTTP push, <10ms). If the push is lost or the notifier is disabled,
+// the poller catches the notification within its tick interval (200ms default).
+type notifyPoller struct {
+	metaStore *meta.Store
+	buses     *eventBuses
+	interval  time.Duration
+	lastID    uint64
+}
+
+const (
+	// defaultNotifyPollInterval is the fallback poller's tick interval. At
+	// 200ms, cross-pod delivery via the fallback path is bounded to ~200ms
+	// (vs ~10ms via the push path). The target is the always-provisioned meta
+	// DB, so 5 QPS per pod is negligible.
+	defaultNotifyPollInterval = 200 * time.Millisecond
+	// notifyPollBatchSize is the max rows read per ListSSENotifySince call.
+	// If a batch is full, the poller immediately reads the next batch without
+	// waiting for the next tick, so a burst of writes is drained quickly.
+	notifyPollBatchSize = 1000
+)
+
+// newNotifyPoller creates a notifyPoller. metaStore must be non-nil. The
+// poller initializes its cursor to the current max outbox id so it skips
+// historical rows (SSE client reconnect replay covers those).
+func newNotifyPoller(metaStore *meta.Store, buses *eventBuses, interval time.Duration) *notifyPoller {
+	if interval <= 0 {
+		interval = defaultNotifyPollInterval
+	}
+	return &notifyPoller{
+		metaStore: metaStore,
+		buses:     buses,
+		interval:  interval,
+	}
+}
+
+// run starts the poller goroutine. It blocks until ctx is cancelled.
+func (np *notifyPoller) run(ctx context.Context) {
+	// Initialize cursor to current max id so we skip historical outbox rows.
+	// Events written before this pod started are delivered to clients via
+	// Phase-1 EventsSince replay on SSE reconnect, not via the poller.
+	maxID, err := np.metaStore.MaxSSENotifyID(ctx)
+	if err != nil {
+		logger.Warn(ctx, "notify_poller_init_cursor_failed",
+			zap.Error(err))
+		// Start from 0 — worst case we read some historical rows and find no
+		// matching buses (Publish is a no-op). Not harmful.
+		maxID = 0
+	}
+	np.lastID = maxID
+	logger.Info(ctx, "notify_poller_started",
+		zap.Duration("interval", np.interval),
+		zap.Uint64("initial_cursor", np.lastID))
+
+	ticker := time.NewTicker(np.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			np.pollOnce(ctx)
+		}
+	}
+}
+
+// pollOnce reads new outbox rows and wakes matching local buses. If a full
+// batch is returned, it immediately reads the next batch (drain mode) so a
+// burst of events is processed without waiting for the next tick.
+func (np *notifyPoller) pollOnce(ctx context.Context) {
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		rows, err := np.metaStore.ListSSENotifySince(ctx, np.lastID, notifyPollBatchSize)
+		if err != nil {
+			logger.Warn(ctx, "notify_poller_list_failed",
+				zap.Uint64("after_id", np.lastID),
+				zap.Error(err))
+			metrics.RecordEventBusPollFailure("notify_poller")
+			return
+		}
+		for _, row := range rows {
+			// Only wake buses that exist (have local SSE subscribers). If no
+			// bus exists for this tenant, skip — we never touch the tenant's
+			// TiDB, allowing it to scale to zero.
+			if bus := np.buses.getIfExists(row.TenantID); bus != nil {
+				bus.Publish()
+			}
+			np.lastID = row.ID
+		}
+		// If we got fewer rows than the batch size, we're caught up — wait
+		// for the next tick. Otherwise drain the remaining rows immediately.
+		if len(rows) < notifyPollBatchSize {
+			return
+		}
+	}
+}

--- a/pkg/server/notify_poller.go
+++ b/pkg/server/notify_poller.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/zap"
+
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/meta"
-	"go.uber.org/zap"
 )
 
 // notifyPoller is a single per-pod goroutine that reads the central

--- a/pkg/server/notify_poller_test.go
+++ b/pkg/server/notify_poller_test.go
@@ -1,0 +1,165 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/internal/testmysql"
+	"github.com/mem9-ai/drive9/pkg/meta"
+)
+
+// newTestMetaStoreForNotify opens the shared test DSN as a meta store and
+// resets the SSE-notify-related tables for isolation between tests.
+func newTestMetaStoreForNotify(t *testing.T) *meta.Store {
+	t.Helper()
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	// Also clear SSE notify tables (ResetMetaDB may not know about new tables).
+	_, _ = metaStore.DB().Exec("DELETE FROM sse_notify_outbox")
+	_, _ = metaStore.DB().Exec("DELETE FROM pod_subscriptions")
+	_, _ = metaStore.DB().Exec("DELETE FROM pod_registry")
+	return metaStore
+}
+
+// TestNotifyPollerDiscoversCrossPodEvents verifies that the notify poller
+// reads new sse_notify_outbox rows and wakes matching local EventBus
+// subscribers via Publish. This replaces the old per-bus pollLoop test.
+func TestNotifyPollerDiscoversCrossPodEvents(t *testing.T) {
+	metaStore := newTestMetaStoreForNotify(t)
+	store := newTestStoreForEventBus(t)
+	buses := newEventBuses()
+	// Create a bus for tenant "T" with a subscriber.
+	bus := buses.get("T", store)
+	id, notify := bus.Subscribe()
+	defer bus.Unsubscribe(id)
+
+	np := newNotifyPoller(metaStore, buses, 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go np.run(ctx)
+
+	// Simulate a cross-pod write: insert an outbox row (as a peer pod would).
+	// The poller should discover it within ~100ms and Publish to wake notify.
+	if err := metaStore.InsertSSENotify(context.Background(), "T", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case _, open := <-notify:
+		if !open {
+			t.Fatal("notify channel closed")
+		}
+		// Signal received — poller discovered the cross-pod outbox row.
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for cross-pod event signal from notify poller")
+	}
+}
+
+// TestNotifyPollerSkipsTenantsWithoutSubscribers verifies that outbox rows for
+// tenants with no local bus (no SSE subscribers) are silently skipped — they
+// don't panic and don't touch the tenant's TiDB. This is the key property that
+// allows idle tenant TiDBs to scale to zero.
+func TestNotifyPollerSkipsTenantsWithoutSubscribers(t *testing.T) {
+	metaStore := newTestMetaStoreForNotify(t)
+	store := newTestStoreForEventBus(t)
+	buses := newEventBuses()
+	// Create a bus for tenant "T1" with a subscriber.
+	bus1 := buses.get("T1", store)
+	id1, notify1 := bus1.Subscribe()
+	defer bus1.Unsubscribe(id1)
+
+	np := newNotifyPoller(metaStore, buses, 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go np.run(ctx)
+
+	// Insert outbox rows for T1 (has subscriber) and T2 (no subscriber).
+	if err := metaStore.InsertSSENotify(context.Background(), "T1", 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.InsertSSENotify(context.Background(), "T2", 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// T1's subscriber should be woken.
+	select {
+	case _, open := <-notify1:
+		if !open {
+			t.Fatal("notify channel closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for T1 event signal")
+	}
+
+	// Verify the poller advanced past both rows (T2 was skipped without error).
+	// After a short delay, the poller's lastID should be >= the T2 row id.
+	// We check indirectly: insert another T1 row and confirm it's discovered
+	// (proving the cursor advanced past T2 without getting stuck).
+	if err := metaStore.InsertSSENotify(context.Background(), "T1", 2); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case _, open := <-notify1:
+		if !open {
+			t.Fatal("notify channel closed")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for second T1 event — poller may have stalled on T2")
+	}
+}
+
+// TestNotifyPollerBatchDrain verifies that when a full batch is returned, the
+// poller immediately reads the next batch without waiting for the next tick,
+// so a burst of outbox rows is processed quickly.
+func TestNotifyPollerBatchDrain(t *testing.T) {
+	metaStore := newTestMetaStoreForNotify(t)
+	store := newTestStoreForEventBus(t)
+	buses := newEventBuses()
+	bus := buses.get("drain-tenant", store)
+	id, notify := bus.Subscribe()
+	defer bus.Unsubscribe(id)
+
+	// Insert more rows than the batch size (1000) so the poller must drain
+	// multiple batches in a single pollOnce.
+	const burstSize = notifyPollBatchSize + 500
+	for i := 0; i < burstSize; i++ {
+		if err := metaStore.InsertSSENotify(context.Background(), "drain-tenant", uint64(i+1)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	np := newNotifyPoller(metaStore, buses, 50*time.Millisecond)
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	// Manually call pollOnce once to drain all batches synchronously.
+	np.lastID = 0 // start from the beginning
+	np.pollOnce(ctx)
+
+	// All rows should have been consumed. Verify by checking that the poller's
+	// cursor advanced past all rows: a subsequent pollOnce should find 0 rows.
+	maxID, err := metaStore.MaxSSENotifyID(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if np.lastID < maxID {
+		t.Fatalf("poller cursor %d did not drain to max %d", np.lastID, maxID)
+	}
+
+	// The subscriber should have been woken (at least once). Drain the notify
+	// channel to confirm it received a signal.
+	select {
+	case _, open := <-notify:
+		if !open {
+			t.Fatal("notify channel closed")
+		}
+	case <-time.After(2 * time.Second):
+		// It's possible the notify signal was already consumed or dropped due
+		// to the coalescing buffer (size 1). That's acceptable — the key
+		// assertion is that all rows were drained (checked above).
+	}
+}

--- a/pkg/server/notify_poller_test.go
+++ b/pkg/server/notify_poller_test.go
@@ -19,10 +19,14 @@ func newTestMetaStoreForNotify(t *testing.T) *meta.Store {
 	}
 	t.Cleanup(func() { _ = metaStore.Close() })
 	testmysql.ResetMetaDB(t, metaStore.DB())
-	// Also clear SSE notify tables (ResetMetaDB may not know about new tables).
-	_, _ = metaStore.DB().Exec("DELETE FROM sse_notify_outbox")
-	_, _ = metaStore.DB().Exec("DELETE FROM pod_subscriptions")
-	_, _ = metaStore.DB().Exec("DELETE FROM pod_registry")
+	// Clean up SSE notify tables (ResetMetaDB may not know about new tables).
+	// Fail on error so stale rows don't leak between tests.
+	ctx := context.Background()
+	for _, table := range []string{"sse_notify_outbox", "pod_subscriptions", "pod_registry"} {
+		if _, err := metaStore.DB().ExecContext(ctx, "DELETE FROM "+table); err != nil {
+			t.Fatalf("clean up %s: %v", table, err)
+		}
+	}
 	return metaStore
 }
 
@@ -39,6 +43,9 @@ func TestNotifyPollerDiscoversCrossPodEvents(t *testing.T) {
 	defer bus.Unsubscribe(id)
 
 	np := newNotifyPoller(metaStore, buses, 50*time.Millisecond)
+	// Initialize cursor to 0 so we don't skip the row we're about to insert
+	// (run() would set it to MaxSSENotifyID which races with the insert).
+	np.lastID = 0
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	go np.run(ctx)
@@ -74,6 +81,7 @@ func TestNotifyPollerSkipsTenantsWithoutSubscribers(t *testing.T) {
 	defer bus1.Unsubscribe(id1)
 
 	np := newNotifyPoller(metaStore, buses, 50*time.Millisecond)
+	np.lastID = 0 // start from beginning to avoid cursor race with insert
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	go np.run(ctx)
@@ -150,16 +158,15 @@ func TestNotifyPollerBatchDrain(t *testing.T) {
 		t.Fatalf("poller cursor %d did not drain to max %d", np.lastID, maxID)
 	}
 
-	// The subscriber should have been woken (at least once). Drain the notify
-	// channel to confirm it received a signal.
+	// The subscriber should have been woken at least once by the synchronous
+	// pollOnce call (which calls Publish for each row; the coalescing channel
+	// buffer size 1 means the first signal is retained).
 	select {
 	case _, open := <-notify:
 		if !open {
 			t.Fatal("notify channel closed")
 		}
 	case <-time.After(2 * time.Second):
-		// It's possible the notify signal was already consumed or dropped due
-		// to the coalescing buffer (size 1). That's acceptable — the key
-		// assertion is that all rows were drained (checked above).
+		t.Fatal("timed out waiting for notify signal after batch drain")
 	}
 }

--- a/pkg/server/pod_notifier.go
+++ b/pkg/server/pod_notifier.go
@@ -1,0 +1,239 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"go.uber.org/zap"
+)
+
+// podRouteTable is a snapshot of the pod-to-pod push routing table. It maps
+// tenant IDs to the set of peer pod addresses that have SSE subscribers for
+// that tenant. The notifier refreshes this from the central pod_subscriptions
+// table periodically so writers can target push notifications precisely.
+type podRouteTable struct {
+	// tenantToPods maps tenant_id → list of peer pod base URLs that have
+	// subscribers for that tenant. A tenant with no subscribers in any peer
+	// is absent from the map; pushing to peers that don't care is wasteful.
+	tenantToPods map[string][]string
+	// allPeers is the full list of active peer addresses. Used for logging.
+	allPeers []string
+}
+
+// podNotifier sends cross-pod SSE push notifications via HTTP. When a local
+// FS mutation writes an event, the notifier asynchronously POSTs a lightweight
+// {tenant_id, seq} body to each peer pod that has SSE subscribers for that
+// tenant. The push is fire-and-forget (no retry, no response waiting) — the
+// central outbox + notifyPoller is the durable fallback that catches any lost
+// pushes within 200ms.
+//
+// This provides <10ms cross-pod latency in the normal case while keeping the
+// cost model unchanged: idle tenant TiDBs are never queried (push is
+// demand-driven; the receiving pod only calls Publish() which wakes local SSE
+// handlers, which then call EventsSince against the tenant TiDB only if the
+// tenant actually has new events).
+type podNotifier struct {
+	metaStore *meta.Store
+	client    *http.Client
+	selfID    string
+	secret    []byte
+
+	// routeCache is the current podRouteTable. Refreshed by refreshLoop.
+	routeCache atomic.Pointer[podRouteTable]
+
+	// Lifecycle: Start spawns the refresh goroutine; Stop cancels it.
+	refreshCtx    context.Context
+	refreshCancel context.CancelFunc
+	wg            sync.WaitGroup
+
+	// routeRefreshInterval is how often the route table is refreshed from
+	// the central pod_subscriptions table. Stale routes are harmless: an
+	// erroneous push to a pod with no subscribers is a no-op (getIfExists
+	// returns nil); a missed push is caught by the 200ms notifyPoller.
+	routeRefreshInterval time.Duration
+
+	// pushTimeout is the per-HTTP-request timeout. Fire-and-forget: we don't
+	// retry on failure, but we don't want to block goroutines indefinitely on
+	// a dead peer.
+	pushTimeout time.Duration
+}
+
+const (
+	// defaultRouteRefreshInterval is the route table refresh cadence. At 5s,
+	// a newly subscribed tenant's pod becomes visible to writers within 5s.
+	// Before that, pushes for the new subscriber are missed but the 200ms
+	// notifyPoller catches them.
+	defaultRouteRefreshInterval = 5 * time.Second
+	// defaultPushTimeout bounds each fire-and-forget HTTP POST so a dead peer
+	// doesn't leak goroutines.
+	defaultPushTimeout = 2 * time.Second
+)
+
+// newPodNotifier creates a podNotifier. selfID is this pod's identifier;
+// secret is the shared bearer token for internal endpoint auth.
+func newPodNotifier(metaStore *meta.Store, selfID string, secret []byte) *podNotifier {
+	return &podNotifier{
+		metaStore:            metaStore,
+		client:               &http.Client{Timeout: defaultPushTimeout},
+		selfID:               selfID,
+		secret:               secret,
+		routeRefreshInterval: defaultRouteRefreshInterval,
+		pushTimeout:          defaultPushTimeout,
+	}
+}
+
+// Start launches the route table refresh goroutine.
+func (pn *podNotifier) Start(ctx context.Context) {
+	pn.refreshCtx, pn.refreshCancel = context.WithCancel(ctx)
+	pn.wg.Add(1)
+	go func() {
+		defer pn.wg.Done()
+		pn.refreshLoop(pn.refreshCtx)
+	}()
+}
+
+// Stop cancels the refresh goroutine and waits for it to exit.
+func (pn *podNotifier) Stop() {
+	if pn.refreshCancel != nil {
+		pn.refreshCancel()
+	}
+	pn.wg.Wait()
+}
+
+// refreshLoop periodically reads the central pod_registry and
+// pod_subscriptions tables to build a fresh route table. The table is stored
+// in routeCache as an atomic pointer so Notify reads it lock-free.
+func (pn *podNotifier) refreshLoop(ctx context.Context) {
+	// Initial refresh before the first tick so Notify has a route table
+	// immediately on startup.
+	pn.refresh(ctx)
+	ticker := time.NewTicker(pn.routeRefreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pn.refresh(ctx)
+		}
+	}
+}
+
+// refresh reads pod_registry (active peers) and pod_subscriptions (which
+// tenants each pod cares about) from the central meta DB and builds a
+// tenant→peer-address reverse index. The result is published atomically.
+func (pn *podNotifier) refresh(ctx context.Context) {
+	pods, err := pn.metaStore.ListActivePods(ctx, pn.selfID)
+	if err != nil {
+		logger.Warn(ctx, "pod_notifier_refresh_pods_failed", zap.Error(err))
+		return
+	}
+	if len(pods) == 0 {
+		// No peers — publish an empty table so Notify is a no-op.
+		pn.routeCache.Store(&podRouteTable{
+			tenantToPods: make(map[string][]string),
+		})
+		return
+	}
+	// Build podID → addr lookup for active peers.
+	podAddr := make(map[string]string, len(pods))
+	for _, p := range pods {
+		podAddr[p.PodID] = p.Addr
+	}
+	// Read all pod_subscriptions and build tenant → []peerAddr reverse index.
+	subs, err := pn.metaStore.ListAllPodSubscriptions(ctx)
+	if err != nil {
+		logger.Warn(ctx, "pod_notifier_refresh_subs_failed", zap.Error(err))
+		return
+	}
+	tenantToPods := make(map[string][]string)
+	for _, s := range subs {
+		addr, ok := podAddr[s.PodID]
+		if !ok {
+			// Subscription references a pod that's not active (stale or self).
+			// Skip — pushing to an inactive pod is wasteful.
+			continue
+		}
+		tenantToPods[s.TenantID] = append(tenantToPods[s.TenantID], addr)
+	}
+	allAddrs := make([]string, 0, len(pods))
+	for _, p := range pods {
+		allAddrs = append(allAddrs, p.Addr)
+	}
+	pn.routeCache.Store(&podRouteTable{
+		tenantToPods: tenantToPods,
+		allPeers:     allAddrs,
+	})
+	logger.Debug(ctx, "pod_notifier_route_refreshed",
+		zap.Int("peers", len(allAddrs)),
+		zap.Int("tenant_routes", len(tenantToPods)))
+}
+
+// notifyPushRequest is the JSON body for POST /v1/internal/sse-notify.
+type notifyPushRequest struct {
+	TenantID string `json:"tenant_id"`
+	Seq      uint64 `json:"seq"`
+}
+
+// Notify sends a fire-and-forget HTTP push to all peer pods that have SSE
+// subscribers for the given tenant. It never blocks the caller — each push
+// is dispatched in a goroutine. If the route table is empty or the tenant has
+// no peer subscribers, Notify is a no-op (the notifyPoller fallback covers it).
+func (pn *podNotifier) Notify(tenantID string, seq uint64) {
+	rt := pn.routeCache.Load()
+	if rt == nil {
+		return
+	}
+	targets, ok := rt.tenantToPods[tenantID]
+	if !ok || len(targets) == 0 {
+		// No peer pod has subscribers for this tenant — skip. The notifyPoller
+		// will still catch this event for any peer that starts subscribing
+		// before the next 200ms tick.
+		return
+	}
+	payload, err := json.Marshal(notifyPushRequest{
+		TenantID: tenantID,
+		Seq:      seq,
+	})
+	if err != nil {
+		logger.Warn(context.Background(), "pod_notifier_marshal_failed",
+			zap.String("tenant_id", tenantID),
+			zap.Error(err))
+		return
+	}
+	for _, addr := range targets {
+		pn.dispatchPush(addr, payload)
+	}
+}
+
+// dispatchPush sends a single fire-and-forget POST to a peer. It runs in its
+// own goroutine so the caller is never blocked by a slow/dead peer. Errors
+// are logged at debug level (the notifyPoller is the durable fallback).
+func (pn *podNotifier) dispatchPush(addr string, payload []byte) {
+	go func() {
+		url := addr + sseNotifyInternalRoute
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+		if err != nil {
+			return
+		}
+		req.Header.Set("Content-Type", "application/json")
+		if len(pn.secret) > 0 {
+			req.Header.Set("Authorization", "Bearer "+string(pn.secret))
+		}
+		resp, err := pn.client.Do(req)
+		if err != nil {
+			logger.Debug(context.Background(), "pod_notifier_push_failed",
+				zap.String("peer", addr),
+				zap.Error(err))
+			return
+		}
+		_ = resp.Body.Close()
+	}()
+}

--- a/pkg/server/pod_notifier.go
+++ b/pkg/server/pod_notifier.go
@@ -51,11 +51,17 @@ type podNotifier struct {
 	// Lifecycle: Start spawns the refresh goroutine; Stop cancels it and waits
 	// for all in-flight dispatch goroutines to exit so shutdown doesn't race
 	// with HTTP requests accessing pn.client/pn.secret.
-	refreshCtx    context.Context
-	refreshCancel context.CancelFunc
-	wg            sync.WaitGroup      // tracks refreshLoop + all dispatchPush goroutines
-	dispatchCtx   context.Context     // context for dispatch goroutines
+	refreshCtx     context.Context
+	refreshCancel  context.CancelFunc
+	wg             sync.WaitGroup      // tracks refreshLoop + all dispatchPush goroutines
+	dispatchCtx    context.Context     // context for dispatch goroutines
 	dispatchCancel context.CancelFunc // cancels all in-flight dispatches
+
+	// pushSem bounds the number of concurrent in-flight push goroutines,
+	// preventing goroutine explosion under burst writes with many peer
+	// subscribers. If the semaphore is exhausted, excess pushes are dropped
+	// (fire-and-forget) — the 200ms notifyPoller is the durable fallback.
+	pushSem chan struct{}
 
 	// routeRefreshInterval is how often the route table is refreshed from
 	// the central pod_subscriptions table. Stale routes are harmless: an
@@ -76,6 +82,10 @@ const (
 	// defaultPushTimeout bounds each fire-and-forget HTTP POST so a dead peer
 	// doesn't leak goroutines.
 	defaultPushTimeout = 2 * time.Second
+	// maxConcurrentPushes bounds the number of in-flight push goroutines.
+	// When exhausted, excess pushes are silently dropped (fire-and-forget);
+	// the notifyPoller fallback ensures no events are lost.
+	maxConcurrentPushes = 64
 )
 
 // newPodNotifier creates a podNotifier. selfID is this pod's identifier;
@@ -86,6 +96,7 @@ func newPodNotifier(metaStore *meta.Store, selfID string, secret []byte) *podNot
 		client:               &http.Client{}, // no client-level timeout; per-request context timeout used instead
 		selfID:               selfID,
 		secret:               secret,
+		pushSem:              make(chan struct{}, maxConcurrentPushes),
 		routeRefreshInterval: defaultRouteRefreshInterval,
 		pushTimeout:          defaultPushTimeout,
 	}
@@ -225,13 +236,22 @@ func (pn *podNotifier) Notify(tenantID string, seq uint64) {
 
 // dispatchPush sends a single fire-and-forget POST to a peer. It runs in its
 // own goroutine (tracked by wg) so the caller is never blocked by a slow/dead
-// peer. The request uses a per-request context with pushTimeout so a dead peer
-// doesn't leak the goroutine. Errors are logged at debug level (the notifyPoller
-// is the durable fallback).
+// peer. Concurrency is bounded by pushSem (maxConcurrentPushes); if the
+// semaphore is exhausted, the push is silently dropped — the notifyPoller is
+// the durable fallback. The request uses a per-request context with pushTimeout
+// so a dead peer doesn't leak the goroutine.
 func (pn *podNotifier) dispatchPush(addr string, payload []byte) {
+	// Non-blocking semaphore acquire: if at capacity, drop this push.
+	// The 200ms notifyPoller fallback ensures the event is still delivered.
+	select {
+	case pn.pushSem <- struct{}{}:
+	default:
+		return
+	}
 	pn.wg.Add(1)
 	go func() {
 		defer pn.wg.Done()
+		defer func() { <-pn.pushSem }()
 		ctx, cancel := context.WithTimeout(pn.dispatchCtx, pn.pushTimeout)
 		defer cancel()
 		url := addr + sseNotifyInternalRoute

--- a/pkg/server/pod_notifier.go
+++ b/pkg/server/pod_notifier.go
@@ -48,10 +48,14 @@ type podNotifier struct {
 	// routeCache is the current podRouteTable. Refreshed by refreshLoop.
 	routeCache atomic.Pointer[podRouteTable]
 
-	// Lifecycle: Start spawns the refresh goroutine; Stop cancels it.
+	// Lifecycle: Start spawns the refresh goroutine; Stop cancels it and waits
+	// for all in-flight dispatch goroutines to exit so shutdown doesn't race
+	// with HTTP requests accessing pn.client/pn.secret.
 	refreshCtx    context.Context
 	refreshCancel context.CancelFunc
-	wg            sync.WaitGroup
+	wg            sync.WaitGroup      // tracks refreshLoop + all dispatchPush goroutines
+	dispatchCtx   context.Context     // context for dispatch goroutines
+	dispatchCancel context.CancelFunc // cancels all in-flight dispatches
 
 	// routeRefreshInterval is how often the route table is refreshed from
 	// the central pod_subscriptions table. Stale routes are harmless: an
@@ -59,9 +63,7 @@ type podNotifier struct {
 	// returns nil); a missed push is caught by the 200ms notifyPoller.
 	routeRefreshInterval time.Duration
 
-	// pushTimeout is the per-HTTP-request timeout. Fire-and-forget: we don't
-	// retry on failure, but we don't want to block goroutines indefinitely on
-	// a dead peer.
+	// pushTimeout is the per-HTTP-request timeout, enforced via context.
 	pushTimeout time.Duration
 }
 
@@ -81,7 +83,7 @@ const (
 func newPodNotifier(metaStore *meta.Store, selfID string, secret []byte) *podNotifier {
 	return &podNotifier{
 		metaStore:            metaStore,
-		client:               &http.Client{Timeout: defaultPushTimeout},
+		client:               &http.Client{}, // no client-level timeout; per-request context timeout used instead
 		selfID:               selfID,
 		secret:               secret,
 		routeRefreshInterval: defaultRouteRefreshInterval,
@@ -89,9 +91,12 @@ func newPodNotifier(metaStore *meta.Store, selfID string, secret []byte) *podNot
 	}
 }
 
-// Start launches the route table refresh goroutine.
+// Start launches the route table refresh goroutine and initializes the
+// dispatch context. All goroutines (refresh + dispatch) are tracked by wg so
+// Stop can wait for them.
 func (pn *podNotifier) Start(ctx context.Context) {
 	pn.refreshCtx, pn.refreshCancel = context.WithCancel(ctx)
+	pn.dispatchCtx, pn.dispatchCancel = context.WithCancel(ctx)
 	pn.wg.Add(1)
 	go func() {
 		defer pn.wg.Done()
@@ -99,10 +104,15 @@ func (pn *podNotifier) Start(ctx context.Context) {
 	}()
 }
 
-// Stop cancels the refresh goroutine and waits for it to exit.
+// Stop cancels the refresh goroutine and all in-flight dispatch goroutines,
+// then waits for them to exit. This ensures no goroutine is accessing
+// pn.client/pn.secret after Stop returns.
 func (pn *podNotifier) Stop() {
 	if pn.refreshCancel != nil {
 		pn.refreshCancel()
+	}
+	if pn.dispatchCancel != nil {
+		pn.dispatchCancel()
 	}
 	pn.wg.Wait()
 }
@@ -214,12 +224,18 @@ func (pn *podNotifier) Notify(tenantID string, seq uint64) {
 }
 
 // dispatchPush sends a single fire-and-forget POST to a peer. It runs in its
-// own goroutine so the caller is never blocked by a slow/dead peer. Errors
-// are logged at debug level (the notifyPoller is the durable fallback).
+// own goroutine (tracked by wg) so the caller is never blocked by a slow/dead
+// peer. The request uses a per-request context with pushTimeout so a dead peer
+// doesn't leak the goroutine. Errors are logged at debug level (the notifyPoller
+// is the durable fallback).
 func (pn *podNotifier) dispatchPush(addr string, payload []byte) {
+	pn.wg.Add(1)
 	go func() {
+		defer pn.wg.Done()
+		ctx, cancel := context.WithTimeout(pn.dispatchCtx, pn.pushTimeout)
+		defer cancel()
 		url := addr + sseNotifyInternalRoute
-		req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(payload))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
 		if err != nil {
 			return
 		}

--- a/pkg/server/pod_notifier_test.go
+++ b/pkg/server/pod_notifier_test.go
@@ -1,0 +1,191 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestPodNotifierPushWakesSubscriber verifies the pod-to-pod HTTP push path:
+// when Notify is called with a tenant that has subscribers on a peer pod, the
+// peer receives the POST and wakes its local SSE subscribers via Publish.
+func TestPodNotifierPushWakesSubscriber(t *testing.T) {
+	metaStore := newTestMetaStoreForNotify(t)
+	store := newTestStoreForEventBus(t)
+
+	// Simulate the receiving pod: an EventBus for tenant "push-tenant" with a
+	// subscriber, and an HTTP handler that mimics handleInternalSSENotify.
+	receiverBuses := newEventBuses()
+	receiverBus := receiverBuses.get("push-tenant", store)
+	subID, notify := receiverBus.Subscribe()
+	defer receiverBus.Unsubscribe(subID)
+
+	var receivedCount int
+	receiver := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != sseNotifyInternalRoute {
+			http.NotFound(w, r)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var req notifyPushRequest
+		_ = json.Unmarshal(body, &req)
+		if bus := receiverBuses.getIfExists(req.TenantID); bus != nil {
+			bus.Publish()
+		}
+		receivedCount++
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer receiver.Close()
+
+	// Register the receiver pod in pod_registry and its subscription for the tenant.
+	if err := metaStore.UpsertPod(context.Background(), "receiver-pod", receiver.URL); err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.UpsertPodSubscriptions(context.Background(), "receiver-pod", []string{"push-tenant"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create the notifier on the "sender" pod. It will read the route table
+	// from the central DB and push to the receiver.
+	notifier := newPodNotifier(metaStore, "sender-pod", []byte("test-secret"))
+	notifier.Start(context.Background())
+	defer notifier.Stop()
+
+	// Wait for the route table to refresh (the notifier refreshes on Start).
+	// Give it a moment to read pod_registry + pod_subscriptions.
+	time.Sleep(6 * time.Second)
+
+	// Notify should push to the receiver, which wakes the subscriber.
+	notifier.Notify("push-tenant", 42)
+
+	select {
+	case _, open := <-notify:
+		if !open {
+			t.Fatal("notify channel closed")
+		}
+		// Success: the push woke the subscriber.
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for push to wake subscriber")
+	}
+}
+
+// TestPodNotifierFireAndForget verifies that Notify does not block even when the
+// peer is unreachable. The push is dispatched in a goroutine with a timeout.
+func TestPodNotifierFireAndForget(t *testing.T) {
+	metaStore := newTestMetaStoreForNotify(t)
+
+	// Register a peer with an unreachable address.
+	if err := metaStore.UpsertPod(context.Background(), "dead-pod", "http://127.0.0.1:1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.UpsertPodSubscriptions(context.Background(), "dead-pod", []string{"fire-forget-tenant"}); err != nil {
+		t.Fatal(err)
+	}
+
+	notifier := newPodNotifier(metaStore, "sender-pod", []byte("test-secret"))
+	// Use a short push timeout so the test doesn't hang waiting for the
+	// unreachable peer's goroutine to time out.
+	notifier.pushTimeout = 500 * time.Millisecond
+	notifier.Start(context.Background())
+	defer notifier.Stop()
+
+	// Wait for route refresh.
+	time.Sleep(6 * time.Second)
+
+	// Notify must return immediately (fire-and-forget), even though the peer
+	// is unreachable. The goroutine handling the failed POST will time out in
+	// the background.
+	done := make(chan struct{})
+	go func() {
+		notifier.Notify("fire-forget-tenant", 1)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// Success: returned without blocking.
+	case <-time.After(time.Second):
+		t.Fatal("Notify blocked on unreachable peer")
+	}
+}
+
+// TestPodNotifierNoPeersIsNoop verifies that when no peers are registered (or
+// no peers subscribe to the tenant), Notify is a no-op.
+func TestPodNotifierNoPeersIsNoop(t *testing.T) {
+	metaStore := newTestMetaStoreForNotify(t)
+	notifier := newNotifyPoller(metaStore, newEventBuses(), 50*time.Millisecond)
+	_ = notifier // just ensure it constructs without error
+
+	pn := newPodNotifier(metaStore, "self-pod", []byte("test-secret"))
+	pn.Start(context.Background())
+	defer pn.Stop()
+
+	// No peers registered — Notify should be a no-op (no panic, no block).
+	pn.Notify("no-peers-tenant", 1)
+}
+
+// TestHandleInternalSSENotify verifies the internal HTTP endpoint: a POST with
+// valid auth and a tenant_id wakes the local EventBus subscriber; a POST with
+// invalid auth is rejected.
+func TestHandleInternalSSENotify(t *testing.T) {
+	store := newTestStoreForEventBus(t)
+	buses := newEventBuses()
+	bus := buses.get("notify-tenant", store)
+	subID, notify := bus.Subscribe()
+	defer bus.Unsubscribe(subID)
+
+	srv := &Server{
+		events:          buses,
+		podNotifySecret: []byte("shared-secret"),
+	}
+
+	// Valid request should wake the subscriber.
+	body := `{"tenant_id":"notify-tenant","seq":1}`
+	req := httptest.NewRequest(http.MethodPost, sseNotifyInternalRoute, strings.NewReader(body))
+	req.Header.Set("Authorization", "Bearer shared-secret")
+	w := httptest.NewRecorder()
+	srv.handleInternalSSENotify(w, req)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+
+	select {
+	case _, open := <-notify:
+		if !open {
+			t.Fatal("notify channel closed")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for notify after internal push")
+	}
+
+	// Invalid auth should be rejected.
+	req2 := httptest.NewRequest(http.MethodPost, sseNotifyInternalRoute, strings.NewReader(body))
+	req2.Header.Set("Authorization", "Bearer wrong-secret")
+	w2 := httptest.NewRecorder()
+	srv.handleInternalSSENotify(w2, req2)
+	if w2.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for invalid secret, got %d", w2.Code)
+	}
+
+	// Missing auth should be rejected.
+	req3 := httptest.NewRequest(http.MethodPost, sseNotifyInternalRoute, strings.NewReader(body))
+	w3 := httptest.NewRecorder()
+	srv.handleInternalSSENotify(w3, req3)
+	if w3.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for missing token, got %d", w3.Code)
+	}
+
+	// No secret configured should return 404.
+	srv2 := &Server{events: buses}
+	req4 := httptest.NewRequest(http.MethodPost, sseNotifyInternalRoute, strings.NewReader(body))
+	req4.Header.Set("Authorization", "Bearer shared-secret")
+	w4 := httptest.NewRecorder()
+	srv2.handleInternalSSENotify(w4, req4)
+	if w4.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 when no secret configured, got %d", w4.Code)
+	}
+}

--- a/pkg/server/pod_notifier_test.go
+++ b/pkg/server/pod_notifier_test.go
@@ -56,9 +56,9 @@ func TestPodNotifierPushWakesSubscriber(t *testing.T) {
 	notifier.Start(context.Background())
 	defer notifier.Stop()
 
-	// Wait for the route table to refresh (the notifier refreshes on Start).
-	// Give it a moment to read pod_registry + pod_subscriptions.
-	time.Sleep(6 * time.Second)
+	// Refresh the route table synchronously instead of waiting for the 5s
+	// ticker. This is deterministic and avoids the 6s sleep.
+	notifier.refresh(context.Background())
 
 	// Notify should push to the receiver, which wakes the subscriber.
 	notifier.Notify("push-tenant", 42)
@@ -94,8 +94,8 @@ func TestPodNotifierFireAndForget(t *testing.T) {
 	notifier.Start(context.Background())
 	defer notifier.Stop()
 
-	// Wait for route refresh.
-	time.Sleep(6 * time.Second)
+	// Refresh the route table synchronously.
+	notifier.refresh(context.Background())
 
 	// Notify must return immediately (fire-and-forget), even though the peer
 	// is unreachable. The goroutine handling the failed POST will time out in

--- a/pkg/server/pod_registry.go
+++ b/pkg/server/pod_registry.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"go.uber.org/zap"
+)
+
+// podRegistry manages this pod's presence in the central pod_registry and
+// pod_subscriptions tables. It runs two background loops:
+//
+//  1. heartbeatLoop: upserts this pod's row every ~10s so the leader's stale-pod
+//     sweeper knows the pod is alive.
+//
+//  2. subscriptionLoop: periodically reports the set of tenant IDs for which
+//     this pod has active SSE subscribers, and prunes tenants that are no
+//     longer active. Writers consult this table (via the podNotifier's route
+//     cache) to push notifications only to pods that care about each tenant.
+//
+// The leader additionally runs stalePodSweepLoop to mark pods with expired
+// heartbeats as stale and clean up their subscription rows.
+type podRegistry struct {
+	metaStore *meta.Store
+	podID     string
+	addr      string
+	buses     *eventBuses
+}
+
+const (
+	// podHeartbeatInterval is how often this pod refreshes its pod_registry row.
+	podHeartbeatInterval = 10 * time.Second
+	// podSubscriptionRefreshInterval is how often this pod reports its SSE
+	// subscriber tenant set to pod_subscriptions.
+	podSubscriptionRefreshInterval = 5 * time.Second
+	// podStaleThreshold is the age after which a pod's heartbeat is considered
+	// stale. The leader marks such pods as inactive so writers stop pushing to
+	// them. 3× the heartbeat interval gives tolerance for brief GC pauses.
+	podStaleThreshold = 30 * time.Second
+	// stalePodSweepInterval is how often the leader marks stale pods and
+	// cleans up their subscription rows.
+	stalePodSweepInterval = 30 * time.Second
+)
+
+// newPodRegistry creates a podRegistry. podID is the unique pod identifier;
+// addr is the internally reachable address (host:port) for peer push.
+func newPodRegistry(metaStore *meta.Store, podID, addr string, buses *eventBuses) *podRegistry {
+	return &podRegistry{
+		metaStore: metaStore,
+		podID:     podID,
+		addr:      addr,
+		buses:     buses,
+	}
+}
+
+// Start launches the heartbeat and subscription-reporting goroutines. Both
+// run on every pod (not leader-gated). They block until ctx is cancelled.
+func (pr *podRegistry) Start(ctx context.Context) {
+	// Initial heartbeat so this pod appears in pod_registry immediately.
+	if err := pr.metaStore.UpsertPod(ctx, pr.podID, pr.addr); err != nil {
+		logger.Warn(ctx, "pod_registry_initial_heartbeat_failed",
+			zap.String("pod_id", pr.podID),
+			zap.Error(err))
+	}
+	go pr.heartbeatLoop(ctx)
+	go pr.subscriptionLoop(ctx)
+}
+
+// heartbeatLoop upserts this pod's row in pod_registry at a fixed interval.
+func (pr *podRegistry) heartbeatLoop(ctx context.Context) {
+	ticker := time.NewTicker(podHeartbeatInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := pr.metaStore.UpsertPod(ctx, pr.podID, pr.addr); err != nil {
+				logger.Warn(ctx, "pod_registry_heartbeat_failed",
+					zap.String("pod_id", pr.podID),
+					zap.Error(err))
+			}
+		}
+	}
+}
+
+// subscriptionLoop periodically reports this pod's active SSE subscriber
+// tenant set to pod_subscriptions and prunes tenants that no longer have
+// subscribers. This lets the podNotifier build an accurate tenant→peer route
+// table for push targeting.
+func (pr *podRegistry) subscriptionLoop(ctx context.Context) {
+	ticker := time.NewTicker(podSubscriptionRefreshInterval)
+	defer ticker.Stop()
+	pr.reportSubscriptions(ctx) // initial report
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pr.reportSubscriptions(ctx)
+		}
+	}
+}
+
+// reportSubscriptions upserts the current active tenant set and prunes stale
+// entries. Best-effort: errors are logged and retried on the next tick.
+func (pr *podRegistry) reportSubscriptions(ctx context.Context) {
+	tenantIDs := pr.buses.activeTenantIDs()
+	if err := pr.metaStore.UpsertPodSubscriptions(ctx, pr.podID, tenantIDs); err != nil {
+		logger.Warn(ctx, "pod_registry_upsert_subscriptions_failed",
+			zap.String("pod_id", pr.podID),
+			zap.Int("tenant_count", len(tenantIDs)),
+			zap.Error(err))
+		return
+	}
+	n, err := pr.metaStore.PrunePodSubscriptions(ctx, pr.podID, tenantIDs)
+	if err != nil {
+		logger.Warn(ctx, "pod_registry_prune_subscriptions_failed",
+			zap.String("pod_id", pr.podID),
+			zap.Error(err))
+		return
+	}
+	if n > 0 {
+		logger.Debug(ctx, "pod_registry_pruned_subscriptions",
+			zap.String("pod_id", pr.podID),
+			zap.Int64("pruned", n))
+	}
+}
+
+// SweepStalePods marks pods with expired heartbeats as stale and cleans up
+// their subscription rows. Leader-gated: only the leader runs this to avoid
+// concurrent sweeps. Best-effort: errors are logged and retried next sweep.
+func (pr *podRegistry) SweepStalePods(ctx context.Context) {
+	before := time.Now().Add(-podStaleThreshold)
+	n, err := pr.metaStore.MarkStalePods(ctx, before)
+	if err != nil {
+		logger.Warn(ctx, "pod_registry_mark_stale_failed", zap.Error(err))
+		return
+	}
+	if n > 0 {
+		logger.Info(ctx, "pod_registry_marked_stale",
+			zap.Int64("stale_pods", n))
+	}
+	// Clean up subscription rows for stale pods so writers stop routing pushes
+	// to dead pods.
+	stalePods, err := pr.metaStore.ListStalePods(ctx)
+	if err != nil {
+		logger.Warn(ctx, "pod_registry_list_stale_failed", zap.Error(err))
+		return
+	}
+	for _, podID := range stalePods {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := pr.metaStore.DeletePodSubscriptions(ctx, podID); err != nil {
+			logger.Warn(ctx, "pod_registry_delete_stale_subscriptions_failed",
+				zap.String("pod_id", podID),
+				zap.Error(err))
+		}
+	}
+}

--- a/pkg/server/pod_registry.go
+++ b/pkg/server/pod_registry.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
@@ -22,11 +23,19 @@ import (
 //
 // The leader additionally runs stalePodSweepLoop to mark pods with expired
 // heartbeats as stale and clean up their subscription rows.
+//
+// All goroutines are tracked by wg so shutdown (Stop) waits for in-flight DB
+// calls to complete before returning, preventing use-after-close races on the
+// shared meta store.
 type podRegistry struct {
 	metaStore *meta.Store
 	podID     string
 	addr      string
 	buses     *eventBuses
+
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg    sync.WaitGroup
 }
 
 const (
@@ -55,29 +64,53 @@ func newPodRegistry(metaStore *meta.Store, podID, addr string, buses *eventBuses
 	}
 }
 
-// Start launches the subscription-reporting goroutine (heartbeat is handled
-// by the caller via RegisterBeforeStart for synchronous initial registration).
-// Runs on every pod (not leader-gated). Blocks until ctx is cancelled.
+// Start launches the subscription-reporting and heartbeat goroutines. All
+// goroutines are tracked by wg so Stop can wait for them. Runs on every pod
+// (not leader-gated). Blocks until ctx is cancelled (via Stop).
 func (pr *podRegistry) Start(ctx context.Context) {
-	go pr.subscriptionLoop(ctx)
+	pr.ctx, pr.cancel = context.WithCancel(ctx)
+	pr.wg.Add(2)
+	go func() {
+		defer pr.wg.Done()
+		pr.subscriptionLoop(pr.ctx)
+	}()
 	if pr.addr != "" {
-		go pr.heartbeatLoop(ctx)
+		go func() {
+			defer pr.wg.Done()
+			pr.heartbeatLoop(pr.ctx)
+		}()
+	} else {
+		// addr is empty — no heartbeat. Still need to decrement wg for balance.
+		pr.wg.Done()
 	}
 }
 
 // RegisterBeforeStart performs the initial synchronous heartbeat so this pod
 // appears in pod_registry immediately (before any background goroutine). This
 // lets callers (and tests) observe the pod in ListActivePods without waiting
-// for the first ticker. Skip if addr is empty.
-func (pr *podRegistry) RegisterBeforeStart(ctx context.Context) {
+// for the first ticker. Returns an error if the registration fails so callers
+// can decide whether to retry or fail. Skip if addr is empty.
+func (pr *podRegistry) RegisterBeforeStart(ctx context.Context) error {
 	if pr.addr == "" {
-		return
+		return nil
 	}
 	if err := pr.metaStore.UpsertPod(ctx, pr.podID, pr.addr); err != nil {
 		logger.Warn(ctx, "pod_registry_initial_heartbeat_failed",
 			zap.String("pod_id", pr.podID),
 			zap.Error(err))
+		return err
 	}
+	return nil
+}
+
+// Stop cancels the context and waits for all registry goroutines (heartbeat,
+// subscription) to exit. This ensures in-flight DB calls complete before the
+// caller tears down the meta store.
+func (pr *podRegistry) Stop() {
+	if pr.cancel != nil {
+		pr.cancel()
+	}
+	pr.wg.Wait()
 }
 
 // heartbeatLoop upserts this pod's row in pod_registry at a fixed interval.
@@ -148,9 +181,11 @@ func (pr *podRegistry) reportSubscriptions(ctx context.Context) {
 	}
 }
 
-// SweepStalePods marks pods with expired heartbeats as stale and cleans up
-// their subscription rows. Leader-gated: only the leader runs this to avoid
-// concurrent sweeps. Best-effort: errors are logged and retried next sweep.
+// SweepStalePods marks pods with expired heartbeats as stale and atomically
+// cleans up subscription rows for currently-stale pods (via a conditional
+// delete join, avoiding a TOCTOU race where a pod recovers between marking and
+// deleting). Leader-gated: only the leader runs this to avoid concurrent sweeps.
+// Best-effort: errors are logged and retried next sweep.
 func (pr *podRegistry) SweepStalePods(ctx context.Context) {
 	before := time.Now().Add(-podStaleThreshold)
 	n, err := pr.metaStore.MarkStalePods(ctx, before)
@@ -162,21 +197,17 @@ func (pr *podRegistry) SweepStalePods(ctx context.Context) {
 		logger.Info(ctx, "pod_registry_marked_stale",
 			zap.Int64("stale_pods", n))
 	}
-	// Clean up subscription rows for stale pods so writers stop routing pushes
-	// to dead pods.
-	stalePods, err := pr.metaStore.ListStalePods(ctx)
+	// Atomically delete subscriptions for pods that are currently stale.
+	// The conditional join ensures we only delete for pods that are still
+	// stale at delete time — a pod that recovered between MarkStalePods and
+	// this call retains its subscriptions.
+	deleted, err := pr.metaStore.DeleteSubscriptionsForStalePods(ctx)
 	if err != nil {
-		logger.Warn(ctx, "pod_registry_list_stale_failed", zap.Error(err))
+		logger.Warn(ctx, "pod_registry_delete_stale_subscriptions_failed", zap.Error(err))
 		return
 	}
-	for _, podID := range stalePods {
-		if ctx.Err() != nil {
-			return
-		}
-		if err := pr.metaStore.DeletePodSubscriptions(ctx, podID); err != nil {
-			logger.Warn(ctx, "pod_registry_delete_stale_subscriptions_failed",
-				zap.String("pod_id", podID),
-				zap.Error(err))
-		}
+	if deleted > 0 {
+		logger.Info(ctx, "pod_registry_deleted_stale_subscriptions",
+			zap.Int64("deleted_rows", deleted))
 	}
 }

--- a/pkg/server/pod_registry.go
+++ b/pkg/server/pod_registry.go
@@ -55,21 +55,40 @@ func newPodRegistry(metaStore *meta.Store, podID, addr string, buses *eventBuses
 	}
 }
 
-// Start launches the heartbeat and subscription-reporting goroutines. Both
-// run on every pod (not leader-gated). They block until ctx is cancelled.
+// Start launches the subscription-reporting goroutine (heartbeat is handled
+// by the caller via RegisterBeforeStart for synchronous initial registration).
+// Runs on every pod (not leader-gated). Blocks until ctx is cancelled.
 func (pr *podRegistry) Start(ctx context.Context) {
-	// Initial heartbeat so this pod appears in pod_registry immediately.
+	go pr.subscriptionLoop(ctx)
+	if pr.addr != "" {
+		go pr.heartbeatLoop(ctx)
+	}
+}
+
+// RegisterBeforeStart performs the initial synchronous heartbeat so this pod
+// appears in pod_registry immediately (before any background goroutine). This
+// lets callers (and tests) observe the pod in ListActivePods without waiting
+// for the first ticker. Skip if addr is empty.
+func (pr *podRegistry) RegisterBeforeStart(ctx context.Context) {
+	if pr.addr == "" {
+		return
+	}
 	if err := pr.metaStore.UpsertPod(ctx, pr.podID, pr.addr); err != nil {
 		logger.Warn(ctx, "pod_registry_initial_heartbeat_failed",
 			zap.String("pod_id", pr.podID),
 			zap.Error(err))
 	}
-	go pr.heartbeatLoop(ctx)
-	go pr.subscriptionLoop(ctx)
 }
 
 // heartbeatLoop upserts this pod's row in pod_registry at a fixed interval.
+// Skips if addr is empty (pod has no reachable address yet).
 func (pr *podRegistry) heartbeatLoop(ctx context.Context) {
+	if pr.addr == "" {
+		// No address to register — don't poll. The subscription loop still
+		// runs so this pod reports its subscriber set.
+		<-ctx.Done()
+		return
+	}
 	ticker := time.NewTicker(podHeartbeatInterval)
 	defer ticker.Stop()
 	for {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -507,8 +507,11 @@ func (s *Server) startNotifyInfrastructure(cfg Config) {
 		poller.run(notifyCtx)
 	}()
 
-	// Pod registry: heartbeat + subscription reporting.
-	if cfg.PodID != "" && cfg.PodAddr != "" {
+	// Pod registry: heartbeat + subscription reporting. Created when PodID is
+	// set; PodAddr may be empty initially (e.g. when the listen address is not
+	// known yet) — the heartbeat is a no-op in that case, but subscription
+	// reporting and the leader's stale-pod sweep still function.
+	if cfg.PodID != "" {
 		reg := newPodRegistry(s.meta, cfg.PodID, cfg.PodAddr, s.events)
 		s.podRegistry = reg
 		go reg.Start(notifyCtx)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -79,6 +79,31 @@ type Config struct {
 	// per-tenant FileGC) to run only on the leader pod. When nil or disabled, all
 	// workers start unconditionally (single-pod mode).
 	Leader *leader.Manager
+
+	// SSE notification outbox + pod-to-pod push configuration. These enable the
+	// new cross-pod SSE scheme that avoids polling every tenant's TiDB. When
+	// Meta is nil (single-tenant mode), these are unused.
+	//
+	// SSENotifyPollInterval is the fallback poller tick (default 200ms). The
+	// poller reads the central sse_notify_outbox table (always-provisioned meta
+	// DB) — not per-tenant TiDBs — so idle tenant TiDBs can scale to zero.
+	//
+	// SSENotifyRetention is how long outbox rows are kept before leader-gated
+	// pruning (default 1h).
+	//
+	// PodID uniquely identifies this pod in the central pod_registry. PodAddr
+	// is the internally reachable address (host:port) for peer push notifications.
+	// When both are set, this pod registers itself and reports its SSE subscriber
+	// tenant set so peers can route push notifications.
+	//
+	// PodNotifySecret is the shared bearer token for /v1/internal/sse-notify
+	// authentication. When set, the pod-to-pod push path is enabled; when nil,
+	// only the 200ms poller fallback is used (no push).
+	SSENotifyPollInterval time.Duration
+	SSENotifyRetention     time.Duration
+	PodID                  string
+	PodAddr                string
+	PodNotifySecret        []byte
 }
 
 type SlockOAuthClient interface {
@@ -163,6 +188,23 @@ type Server struct {
 	// leadership transitions rather than being wired separately in main.go.
 	replayWorker      *backend.MutationReplayWorker
 	expirySweepWorker *backend.ExpirySweepWorker
+
+	// SSE cross-pod notification components. The notifyPoller reads the central
+	// sse_notify_outbox table (in the always-provisioned meta DB) on every pod
+	// to discover which tenants have new fs_events rows — replacing the old
+	// per-bus 1s poll that kept every serverless tenant TiDB awake. The
+	// podNotifier sends fire-and-forget HTTP pushes to peers for <10ms latency.
+	// The podRegistry maintains this pod's presence and subscriber set in the
+	// central DB. All three run on every pod (not leader-gated); the leader
+	// additionally sweeps stale pods and prunes the outbox.
+	podNotifier    *podNotifier
+	podRegistry    *podRegistry
+	podNotifySecret []byte
+	notifyCtx       context.Context
+	notifyCancel    context.CancelFunc
+	notifyWG        sync.WaitGroup
+	// sseNotifyRetention is how long outbox rows are kept before leader pruning.
+	sseNotifyRetention time.Duration
 }
 
 type tenantAutoEmbeddingDefault struct {
@@ -276,6 +318,12 @@ func NewWithConfig(cfg Config) *Server {
 		forkWorkerCtx:       forkWorkerCtx,
 		forkWorkerCancel:    forkWorkerCancel,
 		leader:              cfg.Leader,
+		podNotifySecret:     cfg.PodNotifySecret,
+		sseNotifyRetention:  cfg.SSENotifyRetention,
+		}
+	// Default SSE notify retention.
+	if s.sseNotifyRetention <= 0 {
+		s.sseNotifyRetention = defaultSSENotifyRetention
 	}
 	mux := http.NewServeMux()
 
@@ -336,6 +384,12 @@ func NewWithConfig(cfg Config) *Server {
 	mux.HandleFunc("/v1/auth/slock/callback", s.handleSlockCallback)
 	mux.HandleFunc("/healthz", s.handleHealthz)
 	mux.HandleFunc("/metrics", s.handleMetrics)
+	// Internal pod-to-pod SSE push endpoint. Authenticated via a shared
+	// internal bearer secret (not tenant auth). Only registered when a secret
+	// is configured; the handler rejects all requests if no secret is set.
+	if len(cfg.PodNotifySecret) > 0 {
+		mux.HandleFunc(sseNotifyInternalRoute, s.handleInternalSSENotify)
+	}
 
 	local := cfg.LocalS3
 	if local == nil && cfg.Backend != nil {
@@ -390,6 +444,13 @@ func NewWithConfig(cfg Config) *Server {
 	}
 	s.objectGCWorker = newObjectGCWorker(cfg.Meta, cfg.Pool)
 
+	// Start SSE cross-pod notification infrastructure. These run on every pod
+	// (not leader-gated) because each pod needs to discover cross-pod events
+	// for its own SSE subscribers. Only enabled in multi-tenant mode (Meta != nil).
+	if s.meta != nil {
+		s.startNotifyInfrastructure(cfg)
+	}
+
 	appManagedTaskTypes := semanticWorkerLogTaskTypesFromTypes(appManagedSemanticTaskTypes(cfg.SemanticEmbedder))
 	var fallbackTaskTypes, poolAutoTaskTypes []string
 	if cfg.Backend != nil {
@@ -423,6 +484,59 @@ func NewWithConfig(cfg Config) *Server {
 	return s
 }
 
+// startNotifyInfrastructure launches the SSE cross-pod notification components
+// that run on every pod (not leader-gated):
+//   - notifyPoller: reads the central sse_notify_outbox table at 200ms intervals
+//     to discover which tenants have new fs_events rows written by other pods.
+//   - podRegistry: maintains this pod's presence in pod_registry and reports its
+//     SSE subscriber tenant set to pod_subscriptions for push routing.
+//   - podNotifier: sends fire-and-forget HTTP pushes to peers for <10ms latency.
+//
+// Only called in multi-tenant mode (Meta != nil). In single-tenant mode the
+// fallback EventBus handles delivery without any cross-pod mechanism.
+func (s *Server) startNotifyInfrastructure(cfg Config) {
+	notifyCtx, notifyCancel := context.WithCancel(backgroundWithTrace(context.Background()))
+	s.notifyCtx = notifyCtx
+	s.notifyCancel = notifyCancel
+
+	// Fallback poller: reads the central outbox on every pod.
+	poller := newNotifyPoller(s.meta, s.events, cfg.SSENotifyPollInterval)
+	s.notifyWG.Add(1)
+	go func() {
+		defer s.notifyWG.Done()
+		poller.run(notifyCtx)
+	}()
+
+	// Pod registry: heartbeat + subscription reporting.
+	if cfg.PodID != "" && cfg.PodAddr != "" {
+		reg := newPodRegistry(s.meta, cfg.PodID, cfg.PodAddr, s.events)
+		s.podRegistry = reg
+		go reg.Start(notifyCtx)
+	}
+
+	// Pod-to-pod push notifier: only when a shared secret is configured.
+	if len(cfg.PodNotifySecret) > 0 && cfg.PodID != "" {
+		notifier := newPodNotifier(s.meta, cfg.PodID, cfg.PodNotifySecret)
+		s.podNotifier = notifier
+		notifier.Start(notifyCtx)
+	}
+}
+
+// stopNotifyInfrastructure cancels the notify context and waits for all notify
+// goroutines (poller, registry, notifier) to exit. Called from Close.
+func (s *Server) stopNotifyInfrastructure() {
+	if s.notifyCancel != nil {
+		s.notifyCancel()
+	}
+	s.notifyWG.Wait()
+	if s.podNotifier != nil {
+		s.podNotifier.Stop()
+	}
+	s.notifyCancel = nil
+	s.podNotifier = nil
+	s.podRegistry = nil
+}
+
 func (s *Server) Close() {
 	s.forkWorkerMu.Lock()
 	if !s.forkWorkerClosed {
@@ -433,6 +547,8 @@ func (s *Server) Close() {
 	}
 	s.forkWorkerMu.Unlock()
 	s.forkWorkerWG.Wait()
+	// Stop SSE cross-pod notification infrastructure (runs on every pod).
+	s.stopNotifyInfrastructure()
 	// Stop the leader manager first so any in-flight onLead/onLose callbacks
 	// finish before we tear down local workers. leader.Stop() waits for the
 	// heartbeat goroutine to exit, so no further callback can fire after it
@@ -556,6 +672,40 @@ func (s *Server) startLeaderWorkers() {
 			}
 		}
 	})
+	// Periodic SSE notify outbox cleanup (leader-only). Prunes old
+	// sse_notify_outbox rows so the central table doesn't grow unbounded.
+	// Only runs in multi-tenant mode (Meta != nil).
+	if s.meta != nil {
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			ticker := time.NewTicker(sseNotifyCleanupInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-workerCtx.Done():
+					return
+				case <-ticker.C:
+					s.cleanupSSENotifyOutbox(workerCtx)
+				}
+			}
+		})
+	}
+	// Periodic stale pod sweep (leader-only). Marks pods with expired heartbeats
+	// as stale and cleans up their subscription rows so writers stop pushing to
+	// dead pods. Only runs when pod registry is configured.
+	if s.podRegistry != nil {
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			ticker := time.NewTicker(stalePodSweepInterval)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-workerCtx.Done():
+					return
+				case <-ticker.C:
+					s.podRegistry.SweepStalePods(workerCtx)
+				}
+			}
+		})
+	}
 }
 
 // fsEventsCleanupInterval is how often the leader prunes old fs_events rows.
@@ -563,6 +713,14 @@ const fsEventsCleanupInterval = 5 * time.Minute
 
 // fsEventsRetention is how long event rows are kept before pruning.
 const fsEventsRetention = 1 * time.Hour
+
+// defaultSSENotifyRetention is how long sse_notify_outbox rows are kept before
+// the leader prunes them. Matches fs_events retention so the outbox doesn't
+// outlive the event content it points to.
+const defaultSSENotifyRetention = 1 * time.Hour
+
+// sseNotifyCleanupInterval is how often the leader prunes old outbox rows.
+const sseNotifyCleanupInterval = 5 * time.Minute
 
 // cleanupFSEvents prunes old fs_events rows from accessible stores.
 // Single-tenant mode cleans the fallback store. Multi-tenant mode iterates
@@ -646,6 +804,35 @@ func (s *Server) cleanupFSEvents(ctx context.Context) {
 		} else {
 			metrics.RecordFSEventsPruned(te.TenantID, n)
 		}
+	}
+}
+
+// cleanupSSENotifyOutbox prunes old sse_notify_outbox rows from the central meta
+// DB. Leader-gated; runs on the sseNotifyCleanupInterval ticker. The outbox is
+// a lightweight pointer table (tenant_id + seq), not event content — pruning
+// old rows doesn't lose events because SSE clients use fs_events seq cursors
+// for replay, and the outbox is only a cross-pod wake-up signal.
+func (s *Server) cleanupSSENotifyOutbox(ctx context.Context) {
+	if ctx.Err() != nil {
+		logger.Warn(ctx, "sse_notify_cleanup_skipped_shutdown", zap.Error(ctx.Err()))
+		return
+	}
+	if s.meta == nil {
+		return
+	}
+	n, err := s.meta.DeleteSSENotifyBefore(ctx, time.Now().Add(-s.sseNotifyRetention))
+	if err != nil {
+		if ctx.Err() != nil {
+			logger.Warn(ctx, "sse_notify_cleanup_interrupted_by_shutdown", zap.Error(err))
+		} else {
+			logger.Warn(ctx, "sse_notify_cleanup_failed", zap.Error(err))
+		}
+		return
+	}
+	if n > 0 {
+		logger.Info(ctx, "sse_notify_outbox_pruned",
+			zap.Int64("rows", n),
+			zap.Duration("retention", s.sseNotifyRetention))
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -197,10 +197,9 @@ type Server struct {
 	// The podRegistry maintains this pod's presence and subscriber set in the
 	// central DB. All three run on every pod (not leader-gated); the leader
 	// additionally sweeps stale pods and prunes the outbox.
-	podNotifier    *podNotifier
-	podRegistry    *podRegistry
+	podNotifier     *podNotifier
+	podRegistry     *podRegistry
 	podNotifySecret []byte
-	notifyCtx       context.Context
 	notifyCancel    context.CancelFunc
 	notifyWG        sync.WaitGroup
 	// sseNotifyRetention is how long outbox rows are kept before leader pruning.
@@ -495,8 +494,10 @@ func NewWithConfig(cfg Config) *Server {
 // Only called in multi-tenant mode (Meta != nil). In single-tenant mode the
 // fallback EventBus handles delivery without any cross-pod mechanism.
 func (s *Server) startNotifyInfrastructure(cfg Config) {
+	// Create a single context for all notify components. We store only the
+	// cancel func (not the context itself) on Server, per coding guidelines:
+	// "Pass context through call chains; do not store context in structs."
 	notifyCtx, notifyCancel := context.WithCancel(backgroundWithTrace(context.Background()))
-	s.notifyCtx = notifyCtx
 	s.notifyCancel = notifyCancel
 
 	// Fallback poller: reads the central outbox on every pod.
@@ -516,8 +517,10 @@ func (s *Server) startNotifyInfrastructure(cfg Config) {
 		s.podRegistry = reg
 		// Synchronous initial registration so this pod is visible in
 		// ListActivePods immediately (not after the first heartbeat tick).
-		reg.RegisterBeforeStart(context.Background())
-		go reg.Start(notifyCtx)
+		_ = reg.RegisterBeforeStart(context.Background())
+		// Start the registry's goroutines. They are tracked by the registry's
+		// own WaitGroup and stopped via reg.Stop() in stopNotifyInfrastructure.
+		reg.Start(notifyCtx)
 	}
 
 	// Pod-to-pod push notifier: only when a shared secret is configured.
@@ -528,13 +531,19 @@ func (s *Server) startNotifyInfrastructure(cfg Config) {
 	}
 }
 
-// stopNotifyInfrastructure cancels the notify context and waits for all notify
-// goroutines (poller, registry, notifier) to exit. Called from Close.
+// stopNotifyInfrastructure stops the notify poller, pod registry, and pod
+// notifier. Called from Close AFTER stopLeaderWorkers so the leader-gated
+// stale-pod sweep (which dereferences s.podRegistry) can't race with clearing
+// podRegistry. The poller is stopped via notifyCancel; the registry and notifier
+// have their own Stop methods that wait for all goroutines to exit.
 func (s *Server) stopNotifyInfrastructure() {
 	if s.notifyCancel != nil {
 		s.notifyCancel()
 	}
 	s.notifyWG.Wait()
+	if s.podRegistry != nil {
+		s.podRegistry.Stop()
+	}
 	if s.podNotifier != nil {
 		s.podNotifier.Stop()
 	}
@@ -553,8 +562,6 @@ func (s *Server) Close() {
 	}
 	s.forkWorkerMu.Unlock()
 	s.forkWorkerWG.Wait()
-	// Stop SSE cross-pod notification infrastructure (runs on every pod).
-	s.stopNotifyInfrastructure()
 	// Stop the leader manager first so any in-flight onLead/onLose callbacks
 	// finish before we tear down local workers. leader.Stop() waits for the
 	// heartbeat goroutine to exit, so no further callback can fire after it
@@ -576,6 +583,10 @@ func (s *Server) Close() {
 	// modes (they are started by startLeaderWorkers), so no separate Stop calls
 	// are needed here.
 	s.stopLeaderWorkers()
+	// Stop SSE cross-pod notification infrastructure AFTER leader-gated workers
+	// are stopped, so the stale-pod sweep (which dereferences s.podRegistry)
+	// cannot race with clearing podRegistry during shutdown.
+	s.stopNotifyInfrastructure()
 }
 
 // startLeaderWorkers launches the background schedulers that should run only

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -514,6 +514,9 @@ func (s *Server) startNotifyInfrastructure(cfg Config) {
 	if cfg.PodID != "" {
 		reg := newPodRegistry(s.meta, cfg.PodID, cfg.PodAddr, s.events)
 		s.podRegistry = reg
+		// Synchronous initial registration so this pod is visible in
+		// ListActivePods immediately (not after the first heartbeat tick).
+		reg.RegisterBeforeStart(context.Background())
 		go reg.Start(notifyCtx)
 	}
 

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -238,14 +238,19 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 	// without polling the tenant's own TiDB. Best-effort: if this fails, the
 	// pod-to-pod push (step 4) may still deliver, and SSE client reconnect replay
 	// is the ultimate fallback. Only write if we got a valid seq from step 1.
+	// Use a non-cancelable context so a client disconnect after the fs_events
+	// write doesn't abort the outbox pointer (which would leave the poller
+	// fallback missing the event for cross-pod subscribers).
 	if seq > 0 && s.meta != nil {
-		if err := s.meta.InsertSSENotify(ctx, bus.tenantID, uint64(seq)); err != nil {
+		outboxCtx, outboxCancel := context.WithTimeout(context.WithoutCancel(ctx), 5*time.Second)
+		if err := s.meta.InsertSSENotify(outboxCtx, bus.tenantID, uint64(seq)); err != nil {
 			logger.Warn(ctx, "sse_publish_outbox_insert_failed",
 				zap.String("tenant_id", bus.tenantID),
 				zap.Int64("seq", seq),
 				zap.Error(err))
 			metrics.RecordTenantOperation(bus.tenantID, "event_bus", "outbox_publish", metrics.ResultForError(err), 0)
 		}
+		outboxCancel()
 	}
 
 	// Step 3: Wake same-pod SSE subscribers instantly (in-memory, sub-ms).

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bufio"
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -26,6 +27,14 @@ const (
 	// sseStreamEstablished context flag) to distinguish real SSE connection
 	// lifetimes from bounded error responses on the same route.
 	sseEventsRoute = "/v1/events"
+
+	// sseNotifyInternalRoute is the pod-to-pod SSE push endpoint. It receives
+	// a lightweight {tenant_id, seq} POST from a peer pod that just wrote an
+	// fs_events row, so this pod can wake its local SSE subscribers for that
+	// tenant without waiting for the 200ms notifyPoller fallback. Registered
+	// directly on the mux (not through the tenant auth middleware chain) and
+	// authenticated via a shared internal bearer secret.
+	sseNotifyInternalRoute = "/v1/internal/sse-notify"
 )
 
 // stopTimer drains a timer's channel after stopping it to prevent spurious
@@ -148,6 +157,36 @@ func (ebs *eventBuses) get(tenantID string, store *datastore.Store) *EventBus {
 	return bus
 }
 
+// getIfExists returns the EventBus for tenantID if one already exists, or nil
+// if no bus has been created for that tenant. Unlike get, it does NOT create a
+// new bus. Used by the notifyPoller and pod notifier to wake only tenants that
+// have local SSE subscribers — skipping idle tenants avoids touching their TiDB.
+func (ebs *eventBuses) getIfExists(tenantID string) *EventBus {
+	ebs.mu.RLock()
+	defer ebs.mu.RUnlock()
+	return ebs.buses[tenantID]
+}
+
+// activeTenantIDs returns the tenant IDs for which this pod has EventBus
+// instances (and thus potentially SSE subscribers). Used by the pod registry
+// to periodically report this pod's subscription set to the central DB so
+// writers can route push notifications to the right pods.
+func (ebs *eventBuses) activeTenantIDs() []string {
+	ebs.mu.RLock()
+	defer ebs.mu.RUnlock()
+	ids := make([]string, 0, len(ebs.buses))
+	for id, bus := range ebs.buses {
+		// Only report buses that currently have listeners. A bus without
+		// listeners means all SSE connections for that tenant disconnected;
+		// reporting it would cause peers to push notifications to a pod that
+		// has no one to deliver them to.
+		if bus.HasListeners() {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
 func (s *Server) tenantEventBus(r *http.Request) *EventBus {
 	scope := ScopeFromContext(r.Context())
 	if scope != nil && scope.Backend != nil {
@@ -164,20 +203,26 @@ func (s *Server) tenantEventBus(r *http.Request) *EventBus {
 func (s *Server) publishEvent(r *http.Request, path, op string) {
 	actor := r.Header.Get("X-Dat9-Actor")
 	bus := s.tenantEventBus(r)
-	// Best-effort durable insert. If the INSERT fails (network blip, table
-	// missing pre-migration, conn pool exhaustion), the event is lost for
-	// cross-pod SSE clients — they won't see it via the 1s poll since there's
-	// no DB row. However, local SSE clients still get instant delivery via
-	// the notify channel below (their poll will find no new rows but the
-	// notify signal wakes them to re-check, which returns empty = caught up).
-	// FUSE correctness is maintained by HEAD revalidation regardless.
+	ctx := r.Context()
+	// Step 1: Insert the durable event row into the per-tenant fs_events table.
+	// This is the authoritative event content (path/op/actor/ts) and the source
+	// of the monotonic seq cursor. Best-effort: if the INSERT fails (network
+	// blip, table missing pre-migration, conn pool exhaustion), the event is
+	// lost for cross-pod SSE clients — they won't see it via the outbox or push
+	// since there's no DB row. However, local SSE clients still get instant
+	// delivery via the notify channel below (their EventsSince will find no new
+	// rows but the notify signal wakes them to re-check, returning empty =
+	// caught up). FUSE correctness is maintained by HEAD revalidation regardless.
 	// For existing tenants without the fs_events table (pre-migration), the
-	// INSERT will fail until EnsureTiDBSchemaForAutoEmbeddingProfile creates
-	// the table (triggered automatically by the CRC32 schema version bump).
+	// INSERT will fail until EnsureTiDBSchemaForAutoEmbeddingProfile creates the
+	// table (triggered automatically by the CRC32 schema version bump).
+	var seq int64
 	store := bus.store.Load()
 	if store != nil {
-		if _, err := store.InsertFSEvent(r.Context(), path, op, actor, time.Now().UnixMilli()); err != nil {
-			logger.Warn(r.Context(), "sse_publish_fs_event_insert_failed",
+		var err error
+		seq, err = store.InsertFSEvent(ctx, path, op, actor, time.Now().UnixMilli())
+		if err != nil {
+			logger.Warn(ctx, "sse_publish_fs_event_insert_failed",
 				zap.String("tenant_id", bus.tenantID),
 				zap.String("path", path),
 				zap.String("op", op),
@@ -186,7 +231,80 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 			metrics.RecordEventBusPublishError(bus.tenantID)
 		}
 	}
+
+	// Step 2: Write a lightweight pointer to the central sse_notify_outbox
+	// table (in the always-provisioned meta DB). This lets other pods discover
+	// that tenant T has new fs_events rows via the 200ms notifyPoller fallback,
+	// without polling the tenant's own TiDB. Best-effort: if this fails, the
+	// pod-to-pod push (step 4) may still deliver, and SSE client reconnect replay
+	// is the ultimate fallback. Only write if we got a valid seq from step 1.
+	if seq > 0 && s.meta != nil {
+		if err := s.meta.InsertSSENotify(ctx, bus.tenantID, uint64(seq)); err != nil {
+			logger.Warn(ctx, "sse_publish_outbox_insert_failed",
+				zap.String("tenant_id", bus.tenantID),
+				zap.Int64("seq", seq),
+				zap.Error(err))
+			metrics.RecordTenantOperation(bus.tenantID, "event_bus", "outbox_publish", metrics.ResultForError(err), 0)
+		}
+	}
+
+	// Step 3: Wake same-pod SSE subscribers instantly (in-memory, sub-ms).
 	bus.Publish()
+
+	// Step 4: Push to peer pods that have SSE subscribers for this tenant.
+	// This is the <10ms cross-pod fast path. Fire-and-forget: the outbox (step 2)
+	// + notifyPoller is the durable fallback. Only push if we got a valid seq.
+	if seq > 0 && s.podNotifier != nil {
+		s.podNotifier.Notify(bus.tenantID, uint64(seq))
+	}
+}
+
+// handleInternalSSENotify receives a pod-to-pod push notification from a
+// peer pod. The peer just wrote an fs_events row for tenant_id and is
+// notifying this pod (which has SSE subscribers for that tenant) to wake them
+// immediately rather than waiting for the 200ms notifyPoller fallback.
+//
+// Authenticated via a shared internal bearer secret (PodNotifySecret) compared
+// in constant time. Registered directly on the mux, NOT through the tenant auth
+// middleware — this endpoint has no tenant scope.
+//
+// Fire-and-forget semantics: the peer does not wait for a response. If this
+// pod's bus for the tenant no longer exists (all subscribers disconnected),
+// Publish is a no-op. EventsSince on the next wake reads the actual event
+// content from the tenant's fs_events table.
+func (s *Server) handleInternalSSENotify(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		errJSON(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	// Validate the shared internal secret. If no secret is configured, the
+	// internal endpoint is disabled (404-equivalent: reject all requests).
+	if len(s.podNotifySecret) == 0 {
+		errJSON(w, http.StatusNotFound, "not found")
+		return
+	}
+	tok := bearerToken(r)
+	if tok == "" || subtle.ConstantTimeCompare([]byte(tok), s.podNotifySecret) != 1 {
+		errJSON(w, http.StatusUnauthorized, "unauthorized")
+		return
+	}
+	var req notifyPushRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		errJSON(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.TenantID == "" {
+		errJSON(w, http.StatusBadRequest, "missing tenant_id")
+		return
+	}
+	// Wake local SSE subscribers for this tenant. If no bus exists (no local
+	// subscribers), this is a no-op — the peer's route table was slightly stale.
+	// The tenant's TiDB is NOT queried here; the SSE handler will call
+	// EventsSince only when it actually has a subscriber to deliver to.
+	if bus := s.events.getIfExists(req.TenantID); bus != nil {
+		bus.Publish()
+	}
+	w.WriteHeader(http.StatusNoContent)
 }
 
 func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/sse_outbox_integration_test.go
+++ b/pkg/server/sse_outbox_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -154,8 +155,22 @@ func newSSEOutboxTestCluster(t *testing.T) *sseOutboxTestCluster {
 		return pool
 	}
 
-	// Pod A: create server first, then wire the httptest server's handler to
-	// delegate to it. This avoids forward-reference issues.
+	// Pre-allocate httptest listeners so we know the addresses before creating
+	// the servers. This lets us pass the correct PodAddr to NewWithConfig.
+	lnA, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lnA.Close() })
+	lnB, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = lnB.Close() })
+	podAAddr := "http://" + lnA.Addr().String()
+	podBAddr := "http://" + lnB.Addr().String()
+
+	// Pod A: create server with the pre-allocated address.
 	leaderMgrA := leader.NewManager(nil, leader.WithDisabled())
 	podA := NewWithConfig(Config{
 		Meta:            metaStore,
@@ -164,26 +179,23 @@ func newSSEOutboxTestCluster(t *testing.T) *sseOutboxTestCluster {
 		TokenSecret:     tokenSecret,
 		S3Dir:           s3Dir,
 		PodID:           "pod-a",
+		PodAddr:         podAAddr,
 		PodNotifySecret: podNotifySecret,
 		Leader:          leaderMgrA,
 		Logger:          zap.NewNop(),
 	})
 	t.Cleanup(func() { podA.Close() })
 
-	podASrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	podASrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == sseNotifyInternalRoute {
 			podA.handleInternalSSENotify(w, r)
 			return
 		}
 		http.NotFound(w, r)
 	}))
+	podASrv.Listener = lnA
+	podASrv.Start()
 	t.Cleanup(podASrv.Close)
-	// Update PodA's addr now that we know the test server's address.
-	// The podRegistry and podNotifier were started with PodAddr="" initially;
-	// we manually register the correct address.
-	if err := metaStore.UpsertPod(context.Background(), "pod-a", podASrv.URL); err != nil {
-		t.Fatal(err)
-	}
 
 	// Pod B.
 	leaderMgrB := leader.NewManager(nil, leader.WithDisabled())
@@ -194,23 +206,23 @@ func newSSEOutboxTestCluster(t *testing.T) *sseOutboxTestCluster {
 		TokenSecret:     tokenSecret,
 		S3Dir:           s3Dir,
 		PodID:           "pod-b",
+		PodAddr:         podBAddr,
 		PodNotifySecret: podNotifySecret,
 		Leader:          leaderMgrB,
 		Logger:          zap.NewNop(),
 	})
 	t.Cleanup(func() { podB.Close() })
 
-	podBSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	podBSrv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == sseNotifyInternalRoute {
 			podB.handleInternalSSENotify(w, r)
 			return
 		}
 		http.NotFound(w, r)
 	}))
+	podBSrv.Listener = lnB
+	podBSrv.Start()
 	t.Cleanup(podBSrv.Close)
-	if err := metaStore.UpsertPod(context.Background(), "pod-b", podBSrv.URL); err != nil {
-		t.Fatal(err)
-	}
 
 	return &sseOutboxTestCluster{
 		metaStore: metaStore,
@@ -317,8 +329,8 @@ func TestSSEOutboxCrossPodPushDelivery(t *testing.T) {
 func TestSSEOutboxPodRegistryHeartbeat(t *testing.T) {
 	tc := newSSEOutboxTestCluster(t)
 
-	// Both pods were manually registered with UpsertPod in newSSEOutboxTestCluster.
-	// Verify they appear in ListActivePods.
+	// Both pods auto-register via the heartbeat loop on Start (initial
+	// heartbeat is synchronous). Verify they appear in ListActivePods.
 	pods, err := tc.metaStore.ListActivePods(context.Background(), "pod-a")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/server/sse_outbox_integration_test.go
+++ b/pkg/server/sse_outbox_integration_test.go
@@ -33,7 +33,6 @@ type sseOutboxTestCluster struct {
 	podBAddr  string
 	tenantID  string
 	token     string
-	pool      *tenant.Pool
 }
 
 // newSSEOutboxTestCluster creates two server instances with SSE cross-pod

--- a/pkg/server/sse_outbox_integration_test.go
+++ b/pkg/server/sse_outbox_integration_test.go
@@ -49,11 +49,14 @@ func newSSEOutboxTestCluster(t *testing.T) *sseOutboxTestCluster {
 	}
 	t.Cleanup(func() { _ = metaStore.Close() })
 	testmysql.ResetMetaDB(t, metaStore.DB())
-	_, _ = metaStore.DB().Exec("DELETE FROM sse_notify_outbox")
-	_, _ = metaStore.DB().Exec("DELETE FROM pod_subscriptions")
-	_, _ = metaStore.DB().Exec("DELETE FROM pod_registry")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	// Clean up SSE notify tables (ResetMetaDB may not know about new tables).
+	// Fail on error so stale rows don't leak between tests.
+	ctx := context.Background()
+	for _, table := range []string{"sse_notify_outbox", "pod_subscriptions", "pod_registry", "tenant_api_keys", "tenants"} {
+		if _, err := metaStore.DB().ExecContext(ctx, "DELETE FROM "+table); err != nil {
+			t.Fatalf("clean up %s: %v", table, err)
+		}
+	}
 
 	parsed, err := mysql.ParseDSN(testDSN)
 	if err != nil {
@@ -305,9 +308,9 @@ func TestSSEOutboxCrossPodPushDelivery(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Wait for Pod A's podNotifier to refresh its route table (5s interval,
-	// plus an initial refresh on Start).
-	time.Sleep(6 * time.Second)
+	// Refresh Pod A's podNotifier route table synchronously instead of
+	// waiting for the 5s ticker. This is deterministic and avoids the 6s sleep.
+	tc.podA.podNotifier.refresh(context.Background())
 
 	// Pod A notifies its peers — should push to Pod B.
 	tc.podA.podNotifier.Notify(tc.tenantID, 1)

--- a/pkg/server/sse_outbox_integration_test.go
+++ b/pkg/server/sse_outbox_integration_test.go
@@ -1,0 +1,507 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/drive9/internal/testmysql"
+	"github.com/mem9-ai/drive9/pkg/encrypt"
+	"github.com/mem9-ai/drive9/pkg/leader"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+	"github.com/mem9-ai/drive9/pkg/tenant/token"
+	"go.uber.org/zap"
+)
+
+// sseOutboxTestCluster sets up two drive9 server instances (simulating two pods)
+// sharing the same central meta DB, each with its own eventBuses and the new SSE
+// notify infrastructure (poller + pod notifier + pod registry). A single tenant
+// is provisioned so both pods can serve SSE events for it.
+type sseOutboxTestCluster struct {
+	metaStore *meta.Store
+	podA      *Server
+	podB      *Server
+	podAAddr  string
+	podBAddr  string
+	tenantID  string
+	token     string
+	pool      *tenant.Pool
+}
+
+// newSSEOutboxTestCluster creates two server instances with SSE cross-pod
+// notification enabled. Both share the same MySQL meta DB and the same tenant
+// (whose data DB is also the test MySQL). Each pod runs its own notifyPoller
+// and the pods are registered as peers of each other.
+func newSSEOutboxTestCluster(t *testing.T) *sseOutboxTestCluster {
+	t.Helper()
+
+	// Open the shared meta store and reset it.
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	_, _ = metaStore.DB().Exec("DELETE FROM sse_notify_outbox")
+	_, _ = metaStore.DB().Exec("DELETE FROM pod_subscriptions")
+	_, _ = metaStore.DB().Exec("DELETE FROM pod_registry")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			if n, err2 := parseInt(p); err2 == nil {
+				port = n
+			}
+		}
+	}
+
+	// Encryption for tenant DB password.
+	masterKey := make([]byte, 32)
+	for i := range masterKey {
+		masterKey[i] = 0xAB
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(masterKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Provision a tenant.
+	tenantID := token.NewID()
+	now := time.Now().UTC()
+	passCipher, err := enc.Encrypt(context.Background(), []byte(parsed.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Token signing key.
+	tokenSecret := make([]byte, 32)
+	for i := range tokenSecret {
+		tokenSecret[i] = 0xCD
+	}
+	// Issue an API key for the tenant.
+	tok, err := token.IssueToken(tokenSecret, tenantID, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tokCipher, err := enc.Encrypt(context.Background(), []byte(tok))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.InsertAPIKey(context.Background(), &meta.APIKey{
+		ID:            token.NewID(),
+		TenantID:      tenantID,
+		KeyName:       "default",
+		JWTCiphertext: tokCipher,
+		JWTHash:       token.HashToken(tok),
+		TokenVersion:  1,
+		Status:        meta.APIKeyActive,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Shared SSE config for both pods.
+	podNotifySecret := []byte("test-pod-secret")
+	s3Dir := t.TempDir()
+
+	// Helper to create a pool for each pod (each pool needs its own enc).
+	newPool := func() *tenant.Pool {
+		poolEnc, err := encrypt.NewLocalAESEncryptor(masterKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		pool := tenant.NewPool(tenant.PoolConfig{
+			S3Dir:     s3Dir,
+			PublicURL: "http://127.0.0.1",
+		}, poolEnc)
+		pool.SetMetaStore(metaStore)
+		t.Cleanup(func() { pool.Close() })
+		return pool
+	}
+
+	// Pod A: create server first, then wire the httptest server's handler to
+	// delegate to it. This avoids forward-reference issues.
+	leaderMgrA := leader.NewManager(nil, leader.WithDisabled())
+	podA := NewWithConfig(Config{
+		Meta:            metaStore,
+		Pool:            newPool(),
+		Provisioner:     &fakeProvisioner{provider: tenant.ProviderDB9},
+		TokenSecret:     tokenSecret,
+		S3Dir:           s3Dir,
+		PodID:           "pod-a",
+		PodNotifySecret: podNotifySecret,
+		Leader:          leaderMgrA,
+		Logger:          zap.NewNop(),
+	})
+	t.Cleanup(func() { podA.Close() })
+
+	podASrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == sseNotifyInternalRoute {
+			podA.handleInternalSSENotify(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(podASrv.Close)
+	// Update PodA's addr now that we know the test server's address.
+	// The podRegistry and podNotifier were started with PodAddr="" initially;
+	// we manually register the correct address.
+	if err := metaStore.UpsertPod(context.Background(), "pod-a", podASrv.URL); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pod B.
+	leaderMgrB := leader.NewManager(nil, leader.WithDisabled())
+	podB := NewWithConfig(Config{
+		Meta:            metaStore,
+		Pool:            newPool(),
+		Provisioner:     &fakeProvisioner{provider: tenant.ProviderDB9},
+		TokenSecret:     tokenSecret,
+		S3Dir:           s3Dir,
+		PodID:           "pod-b",
+		PodNotifySecret: podNotifySecret,
+		Leader:          leaderMgrB,
+		Logger:          zap.NewNop(),
+	})
+	t.Cleanup(func() { podB.Close() })
+
+	podBSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == sseNotifyInternalRoute {
+			podB.handleInternalSSENotify(w, r)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(podBSrv.Close)
+	if err := metaStore.UpsertPod(context.Background(), "pod-b", podBSrv.URL); err != nil {
+		t.Fatal(err)
+	}
+
+	return &sseOutboxTestCluster{
+		metaStore: metaStore,
+		podA:      podA,
+		podB:      podB,
+		podAAddr:  podASrv.URL,
+		podBAddr:  podBSrv.URL,
+		tenantID:  tenantID,
+		token:     tok,
+	}
+}
+
+// parseInt is a small helper to avoid importing strconv in this test file.
+func parseInt(s string) (int, error) {
+	var n int
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return 0, fmt.Errorf("not a digit: %c", c)
+		}
+		n = n*10 + int(c-'0')
+	}
+	return n, nil
+}
+
+// TestSSEOutboxCrossPodPollerDelivery verifies the end-to-end flow:
+//  1. Pod B has an SSE subscriber for a tenant (bus with listener).
+//  2. Pod A writes an fs_events row + sse_notify_outbox row (simulating a
+//     cross-pod write via publishEvent).
+//  3. Pod B's notifyPoller discovers the outbox row and wakes its local
+//     subscriber via Publish.
+//
+// This tests the 200ms fallback poller path.
+func TestSSEOutboxCrossPodPollerDelivery(t *testing.T) {
+	tc := newSSEOutboxTestCluster(t)
+
+	// Pod B: create a bus for the tenant and subscribe.
+	busB := tc.podB.events.get(tc.tenantID, nil)
+	subID, notify := busB.Subscribe()
+	defer busB.Unsubscribe(subID)
+
+	// Pod A: write an outbox row (simulating publishEvent's outbox step).
+	// We don't need to actually write to fs_events for the poller test — the
+	// poller only reads the outbox pointer and wakes the bus. The SSE handler
+	// would then call EventsSince to read fs_events, but here we just verify
+	// the notify signal fires.
+	if err := tc.metaStore.InsertSSENotify(context.Background(), tc.tenantID, 1); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pod B's notifyPoller should discover the outbox row within ~2s and
+	// wake the subscriber.
+	select {
+	case _, open := <-notify:
+		if !open {
+			t.Fatal("notify channel closed")
+		}
+		// Success: cross-pod outbox delivery via the poller.
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for cross-pod outbox delivery via poller")
+	}
+}
+
+// TestSSEOutboxCrossPodPushDelivery verifies the HTTP push path:
+//  1. Pod B has an SSE subscriber for a tenant.
+//  2. Pod B reports its subscription (pod_subscriptions) so Pod A's
+//     podNotifier route table includes it.
+//  3. Pod A calls podNotifier.Notify, which pushes HTTP to Pod B.
+//  4. Pod B's handleInternalSSENotify wakes the subscriber.
+func TestSSEOutboxCrossPodPushDelivery(t *testing.T) {
+	tc := newSSEOutboxTestCluster(t)
+
+	// Pod B: create a bus and subscribe.
+	busB := tc.podB.events.get(tc.tenantID, nil)
+	subID, notify := busB.Subscribe()
+	defer busB.Unsubscribe(subID)
+
+	// Register Pod B's subscription in pod_subscriptions (simulating what
+	// podRegistry.subscriptionLoop does). Both pods are already registered
+	// in pod_registry by newSSEOutboxTestCluster.
+	if err := tc.metaStore.UpsertPodSubscriptions(context.Background(), "pod-b", []string{tc.tenantID}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for Pod A's podNotifier to refresh its route table (5s interval,
+	// plus an initial refresh on Start).
+	time.Sleep(6 * time.Second)
+
+	// Pod A notifies its peers — should push to Pod B.
+	tc.podA.podNotifier.Notify(tc.tenantID, 1)
+
+	select {
+	case _, open := <-notify:
+		if !open {
+			t.Fatal("notify channel closed")
+		}
+		// Success: cross-pod push delivery.
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for cross-pod push delivery")
+	}
+}
+
+// TestSSEOutboxPodRegistryHeartbeat verifies that the pod_registry goroutine
+// writes heartbeat rows and that the leader can list active pods.
+func TestSSEOutboxPodRegistryHeartbeat(t *testing.T) {
+	tc := newSSEOutboxTestCluster(t)
+
+	// Both pods were manually registered with UpsertPod in newSSEOutboxTestCluster.
+	// Verify they appear in ListActivePods.
+	pods, err := tc.metaStore.ListActivePods(context.Background(), "pod-a")
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundPodB := false
+	for _, p := range pods {
+		if p.PodID == "pod-b" {
+			foundPodB = true
+			break
+		}
+	}
+	if !foundPodB {
+		t.Fatalf("pod-b not found in active pods; got %d pods", len(pods))
+	}
+
+	// Also verify pod-a is there (query as pod-b).
+	podsFromB, err := tc.metaStore.ListActivePods(context.Background(), "pod-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundPodA := false
+	for _, p := range podsFromB {
+		if p.PodID == "pod-a" {
+			foundPodA = true
+			break
+		}
+	}
+	if !foundPodA {
+		t.Fatalf("pod-a not found in active pods from pod-b perspective; got %d pods", len(podsFromB))
+	}
+}
+
+// TestSSEOutboxSubscriptionReporting verifies that the subscription loop
+// reports the active tenant set to pod_subscriptions and prunes stale entries.
+func TestSSEOutboxSubscriptionReporting(t *testing.T) {
+	tc := newSSEOutboxTestCluster(t)
+
+	// Pod B: create a bus with a subscriber for the tenant.
+	busB := tc.podB.events.get(tc.tenantID, nil)
+	subID, _ := busB.Subscribe()
+	defer busB.Unsubscribe(subID)
+
+	// Manually report subscriptions (simulating the subscriptionLoop ticker).
+	tc.podB.podRegistry.reportSubscriptions(context.Background())
+
+	// Verify pod_subscriptions has the tenant for pod-b.
+	subs, err := tc.metaStore.ListPodSubscriptions(context.Background(), "pod-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, s := range subs {
+		if s == tc.tenantID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("tenant %s not in pod-b subscriptions; got %v", tc.tenantID, subs)
+	}
+
+	// Now unsubscribe and report again — the subscription should be pruned.
+	busB.Unsubscribe(subID)
+	tc.podB.podRegistry.reportSubscriptions(context.Background())
+
+	subsAfter, err := tc.metaStore.ListPodSubscriptions(context.Background(), "pod-b")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, s := range subsAfter {
+		if s == tc.tenantID {
+			t.Fatalf("tenant %s should have been pruned from pod-b subscriptions", tc.tenantID)
+		}
+	}
+}
+
+// TestSSEOutboxInternalEndpointRejection verifies that the internal endpoint
+// rejects requests with wrong/missing auth and wrong method.
+func TestSSEOutboxInternalEndpointRejection(t *testing.T) {
+	tc := newSSEOutboxTestCluster(t)
+
+	// Wrong method.
+	req := httptest.NewRequest(http.MethodGet, sseNotifyInternalRoute, nil)
+	w := httptest.NewRecorder()
+	tc.podA.handleInternalSSENotify(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405 for GET, got %d", w.Code)
+	}
+
+	// Missing auth.
+	body := `{"tenant_id":"x","seq":1}`
+	req2 := httptest.NewRequest(http.MethodPost, sseNotifyInternalRoute, bytes.NewReader([]byte(body)))
+	w2 := httptest.NewRecorder()
+	tc.podA.handleInternalSSENotify(w2, req2)
+	if w2.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for missing auth, got %d", w2.Code)
+	}
+
+	// Wrong auth.
+	req3 := httptest.NewRequest(http.MethodPost, sseNotifyInternalRoute, bytes.NewReader([]byte(body)))
+	req3.Header.Set("Authorization", "Bearer wrong")
+	w3 := httptest.NewRecorder()
+	tc.podA.handleInternalSSENotify(w3, req3)
+	if w3.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for wrong auth, got %d", w3.Code)
+	}
+}
+
+// TestSSEOutboxStalePodSweep verifies that the leader's SweepStalePods marks
+// pods with expired heartbeats as stale and cleans up their subscriptions.
+func TestSSEOutboxStalePodSweep(t *testing.T) {
+	tc := newSSEOutboxTestCluster(t)
+
+	// Register a "dead" pod with a stale heartbeat and a subscription.
+	if err := tc.metaStore.UpsertPod(context.Background(), "dead-pod", "http://127.0.0.1:1"); err != nil {
+		t.Fatal(err)
+	}
+	if err := tc.metaStore.UpsertPodSubscriptions(context.Background(), "dead-pod", []string{tc.tenantID}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Manually set its heartbeat to be old enough to be stale.
+	_, err := tc.metaStore.DB().ExecContext(context.Background(),
+		`UPDATE pod_registry SET last_heartbeat = ? WHERE pod_id = ?`,
+		time.Now().Add(-2*time.Minute), "dead-pod")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run the sweep (as the leader would).
+	tc.podA.podRegistry.SweepStalePods(context.Background())
+
+	// The dead pod should now be stale.
+	pods, err := tc.metaStore.ListActivePods(context.Background(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range pods {
+		if p.PodID == "dead-pod" {
+			t.Fatal("dead-pod should have been marked stale, but is still active")
+		}
+	}
+
+	// Its subscriptions should be cleaned up.
+	subs, err := tc.metaStore.ListPodSubscriptions(context.Background(), "dead-pod")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subs) != 0 {
+		t.Fatalf("dead-pod subscriptions should be empty after sweep; got %v", subs)
+	}
+}
+
+// TestSSEOutboxOutboxCleanup verifies that the leader's cleanupSSENotifyOutbox
+// prunes old outbox rows.
+func TestSSEOutboxOutboxCleanup(t *testing.T) {
+	tc := newSSEOutboxTestCluster(t)
+
+	// Insert an outbox row with an old created_at.
+	_, err := tc.metaStore.DB().ExecContext(context.Background(),
+		`INSERT INTO sse_notify_outbox (tenant_id, seq, created_at) VALUES (?, ?, ?)`,
+		tc.tenantID, 1, time.Now().Add(-2*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert a fresh row that should be retained.
+	if err := tc.metaStore.InsertSSENotify(context.Background(), tc.tenantID, 2); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run cleanup with the default retention (1h). The old row should be pruned.
+	tc.podA.cleanupSSENotifyOutbox(context.Background())
+
+	// Verify only the fresh row remains.
+	rows, err := tc.metaStore.ListSSENotifySince(context.Background(), 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 outbox row after cleanup, got %d", len(rows))
+	}
+	if rows[0].Seq != 2 {
+		t.Fatalf("expected remaining row seq=2, got %d", rows[0].Seq)
+	}
+}


### PR DESCRIPTION
## Motivation

drive9 is preparing for deployments with a very large number of tenants. The current SSE cross-pod event notification scheme runs a **per-bus 1s poll goroutine** for every tenant that has an SSE subscriber (`EventBus.pollLoop` → `store.ListFSEventsSince` against that tenant's own TiDB). At this scale this means:

- A high QPS spread across many separate serverless tenant TiDBs
- Every tenant TiDB is kept awake by continuous polling, preventing **scale-to-zero**
- Idle tenant TiDBs consume **RCU continuously** even with zero actual workload — a cost increase that is unacceptable

## Design

Replace the per-bus TiDB polling with a **centralized three-layer scheme** that routes the "which tenants have new events" signal through the always-provisioned central meta DB instead of N separate serverless tenant TiDBs.

### Architecture

```
                    ┌──────────────────────────────────┐
                    │     Central Meta DB (always on)   │
                    │  sse_notify_outbox  (outbox)      │
                    │  pod_registry       (peer table)  │
                    │  pod_subscriptions  (routing)      │
                    └──────────────────────────────────┘
                          ▲                    ▲
        write (outbox)    │                    │ poll every 200ms (all pods)
                          │                    │
┌─────────────────────────┴──┐    ┌────────────┴──────────────────┐
│   Pod A (writer)            │    │   Pod B (subscriber)           │
│                             │    │                               │
│  publishEvent:              │    │  notifyPoller (200ms fallback) │
│   1. INSERT fs_events       │    │   → ListSSENotifySince(lastID) │
│      (tenant TiDB —         │    │   → getIfExists(tenantID)     │
│       unavoidable, this     │    │   → bus.Publish()             │
│       is a real write)      │    │   → EventsSince() reads       │
│   2. INSERT sse_notify_     │    │      tenant fs_events         │
│      outbox (meta DB)       │    │                               │
│   3. bus.Publish()          │    │  /v1/internal/sse-notify      │
│      (same-pod instant)     │    │   ← receives HTTP push        │
│   4. podNotifier.Notify()   │    │   → bus.Publish()             │
│      (cross-pod HTTP push)  │    │   → EventsSince() reads       │
│      fire-and-forget        │    │      tenant fs_events         │
└─────────────────────────────┘    └───────────────────────────────┘
```

### Layer 1: Central outbox (`sse_notify_outbox`)

A new lightweight table in the **central meta DB** (always provisioned, not serverless). Each FS mutation writes a single pointer row `{tenant_id, seq}` — the event content stays in the per-tenant `fs_events` table. This table only answers "tenant T has new events after seq S".

```sql
CREATE TABLE IF NOT EXISTS sse_notify_outbox (
    id         BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
    tenant_id  VARCHAR(64) NOT NULL,
    seq        BIGINT UNSIGNED NOT NULL,
    created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
    INDEX idx_sse_notify_created (created_at)
);
```

Writing to this table never wakes a serverless tenant TiDB — the meta DB is always provisioned.

### Layer 2: Fallback poller (`notifyPoller`)

A **single per-pod goroutine** (`notify_poller.go`) reads the central outbox every **200ms** (default). For each outbox row, it calls `eventBuses.getIfExists(tenantID)` — if no local EventBus exists (no SSE subscribers for that tenant), the row is **silently skipped** and the tenant's TiDB is never queried. If a bus exists, `bus.Publish()` wakes the SSE handlers, which then call `EventsSince(lastSeen)` to read the actual event content from the tenant `fs_events` table (demand-driven, not poll-driven).

Key properties:
- **One goroutine per pod** (was one goroutine per tenant)
- Low QPS per pod against the always-provisioned meta DB (was per-tenant QPS against many TiDBs)
- **Idle tenant TiDBs are never queried** → they scale to zero
- Full batch drain: if a batch is full (1000 rows), immediately read the next batch without waiting for the tick

### Layer 3: Pod-to-pod HTTP push (`podNotifier`)

For **<10ms cross-pod latency**, a pod-to-pod HTTP push path (`pod_notifier.go`) runs alongside the poller. When `publishEvent` writes an event, it asynchronously POSTs `{tenant_id, seq}` to peer pods that have SSE subscribers for that tenant. The push is **fire-and-forget** (no retry, no response waiting) — the 200ms poller is the durable fallback.

Dynamic peer discovery via two new central tables:

```sql
CREATE TABLE IF NOT EXISTS pod_registry (
    pod_id         VARCHAR(64) PRIMARY KEY,
    addr           VARCHAR(255) NOT NULL,
    last_heartbeat DATETIME(3) NOT NULL,
    status         VARCHAR(20) NOT NULL DEFAULT 'active',
    INDEX idx_pod_heartbeat (last_heartbeat)
);

CREATE TABLE IF NOT EXISTS pod_subscriptions (
    pod_id     VARCHAR(64) NOT NULL,
    tenant_id  VARCHAR(64) NOT NULL,
    PRIMARY KEY (pod_id, tenant_id)
);
```

Each pod:
- **Heartbeats** (`pod_registry.go`) every 10s so peers know it's alive
- **Reports its subscriber set** every 5s to `pod_subscriptions` (which tenants have local SSE connections)
- The pod notifier builds a **tenant→peer reverse index** from `pod_subscriptions` every 5s and caches it for lock-free reads in `Notify`

The leader additionally sweeps stale pods (30s heartbeat threshold) and cleans their subscription rows.

### Internal endpoint

```
POST /v1/internal/sse-notify
Authorization: Bearer <DRIVE9_POD_NOTIFY_SECRET>
Content-Type: application/json

{"tenant_id": "T", "seq": 42}
```

Registered directly on the mux (not through tenant auth middleware). Authenticated via a shared internal bearer secret compared in constant time. The handler calls `eventBuses.getIfExists(tenantID)` → `bus.Publish()`.

## Correctness guarantees

| Property | Mechanism |
|----------|-----------|
| **No missed events** | Triple fallback: HTTP push (<10ms) + outbox poller (200ms) + `fs_events` replay on SSE client reconnect (Phase 1 `EventsSince(since)`) |
| **No duplicate delivery** | `EventsSince(lastSeen)` uses `WHERE seq > lastSeen` — idempotent. Multiple `Publish` wakeups coalesce (notify channel buffer=1) into a single `pollAndSend` |
| **No misrouted events** | `getIfExists(tenantID)` does exact string match. Each bus reads only its own tenant's `fs_events` table. Physical tenant isolation unchanged |
| **Real-time delivery** | Same-pod: <1ms (in-memory channel). Cross-pod: <10ms (HTTP push) or ~200ms (poller fallback) |
| **Idle tenant RCU = 0** | No per-bus poll. Tenant TiDB is only touched when (a) a write actually happens (unavoidable) and (b) a subscriber exists to read it (demand-driven) |

## Cost analysis

| Metric | Before | After |
|--------|--------|-------|
| Cross-pod polling | N_tenants × 1 QPS against N separate TiDBs | N_pods × 5 QPS against 1 always-provisioned meta DB |
| Idle tenant TiDB RCU | **Continuous** (prevents scale-to-zero) | **Zero** (no queries → TiDB sleeps) |
| Cost reduction | — | **~4 orders of magnitude** |

## EventBus simplification

The `EventBus` struct no longer runs a per-bus poll goroutine:
- **Removed**: `pollLoop`, `pollOnce`, `pollCancel`, `pollDone`, `pollLast` fields and methods
- **Simplified**: `Subscribe()` / `Unsubscribe()` only manage listener registration (no goroutine lifecycle)
- **Unchanged**: `Publish()`, `EventsSince()`, `Seq()` — the durable cursor logic and replay/reset semantics are identical
- **New**: `HasListeners()` (for `activeTenantIDs`), `TenantID()` (for logging)

The SSE handler (`handleEvents`) flow is unchanged — Phase 1 replay + Phase 2 live stream. The only difference is that `notify` channel wakeups now come from two sources (same-pod `Publish` + `notifyPoller`/`podNotifier`), but the handler doesn't distinguish them.

## Configuration

New environment variables:

| Env var | Default | Purpose |
|---------|---------|---------|
| `DRIVE9_POD_ID` | (unset) | Unique pod identifier. When set, enables the new SSE scheme (pod registry + notifier). When unset, the old same-pod-only behavior is used (single-tenant / fallback mode) |
| `DRIVE9_POD_ADDR` | `DRIVE9_LISTEN_ADDR` | Internally reachable address (host:port) for peer push notifications |
| `DRIVE9_POD_NOTIFY_SECRET` | (unset) | Shared bearer token for `/v1/internal/sse-notify`. When set, enables the <10ms HTTP push path; when unset, only the 200ms poller fallback is used |
| `DRIVE9_SSE_NOTIFY_POLL_INTERVAL` | `200ms` | Fallback outbox poll interval |
| `DRIVE9_SSE_NOTIFY_RETENTION` | `1h` | How long outbox rows are kept before leader pruning |

All components are opt-in: in single-tenant mode (no `DRIVE9_META_DSN`) or when `DRIVE9_POD_ID` is unset, the server behaves exactly as before. The notify infrastructure is only activated when `cfg.Meta != nil` (multi-tenant mode).

## Files changed

| File | Change |
|------|--------|
| `pkg/meta/meta.go` | +3 tables (`sse_notify_outbox`, `pod_registry`, `pod_subscriptions`) + CRUD methods |
| `pkg/server/eventbus.go` | Removed per-bus poll goroutine; simplified `Subscribe`/`Unsubscribe`; added `HasListeners`/`TenantID` |
| `pkg/server/sse.go` | Added `getIfExists`/`activeTenantIDs`; rewrote `publishEvent` (4-step: fs_events → outbox → same-pod Publish → cross-pod push); new `handleInternalSSENotify` handler |
| `pkg/server/notify_poller.go` | **New**: global 200ms fallback poller |
| `pkg/server/pod_notifier.go` | **New**: pod-to-pod HTTP push with route cache |
| `pkg/server/pod_registry.go` | **New**: pod heartbeat + subscription reporting + stale-pod sweep |
| `pkg/server/server.go` | Config fields; Server struct fields; `startNotifyInfrastructure`/`stopNotifyInfrastructure`; `cleanupSSENotifyOutbox`; leader-gated outbox cleanup + stale pod sweep tickers; route registration |
| `pkg/server/instrumentation.go` | Route label for `/v1/internal/sse-notify` |
| `cmd/drive9-server/main.go` | Env var reading + Config passing + usage docs |

## Testing

**Unit tests** (`notify_poller_test.go`, `pod_notifier_test.go`):
- Poller discovers cross-pod outbox rows and wakes subscribers
- Poller skips tenants with no local subscribers (no TiDB query)
- Poller drains full batches immediately
- Notifier pushes to peers and wakes subscribers via HTTP
- Notifier is fire-and-forget (doesn't block on unreachable peers)
- Internal endpoint auth (valid/invalid/missing/no-secret)

**Integration tests** (`sse_outbox_integration_test.go`) — two-pod simulation with shared Meta DB:
- Cross-pod outbox poller delivery (200ms fallback path)
- Cross-pod HTTP push delivery (<10ms primary path)
- Pod registry heartbeat + active pod listing
- Subscription reporting + stale entry pruning
- Internal endpoint auth rejection
- Stale pod sweep (leader marks expired pods + cleans subscriptions)
- Outbox retention cleanup (leader prunes old rows)

All 37 SSE-related tests pass (16 unit + 7 integration + 14 existing regression). Verified on the `drive9-test` machine with a real MySQL instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cross-pod SSE delivery, so event updates can reach subscribers even when they’re connected to a different server pod.
  * Added internal pod coordination for faster notification routing and automatic cleanup of old event data.
  * Improved startup handling to configure SSE notification behavior through new environment settings.

* **Bug Fixes**
  * Reduced missed or delayed SSE notifications by adding a fallback poller and direct push path between pods.
  * Improved handling of inactive pods and stale subscription data to keep notifications accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->