### PR TITLE
fix: initialize notifyPoller cursor synchronously before live traffic

### DIFF
--- a/pkg/server/notify_poller.go
+++ b/pkg/server/notify_poller.go
@@ -61,23 +61,32 @@ func newNotifyPoller(metaStore *meta.Store, buses *eventBuses, interval time.Dur
 	}
 }
 
-// run starts the poller goroutine. It blocks until ctx is cancelled.
-func (np *notifyPoller) run(ctx context.Context) {
-	// Initialize cursor to current max id so we skip historical outbox rows.
-	// Events written before this pod started are delivered to clients via
-	// Phase-1 EventsSince replay on SSE reconnect, not via the poller.
+// initCursor synchronously initializes the poller's lastID to the current max
+// outbox id. This MUST be called before run() starts and before the server
+// accepts live traffic, so that a write between poller construction and the
+// first poll tick is not skipped. If the init query fails, lastID stays 0
+// (reads some historical rows but Publish is a no-op for tenants without
+// subscribers — not harmful).
+func (np *notifyPoller) initCursor(ctx context.Context) {
 	maxID, err := np.metaStore.MaxSSENotifyID(ctx)
 	if err != nil {
 		logger.Warn(ctx, "notify_poller_init_cursor_failed",
 			zap.Error(err))
-		// Start from 0 — worst case we read some historical rows and find no
-		// matching buses (Publish is a no-op). Not harmful.
 		maxID = 0
 	}
 	np.lastID = maxID
+	logger.Info(ctx, "notify_poller_cursor_initialized",
+		zap.Uint64("cursor", np.lastID))
+}
+
+// run starts the poller goroutine. It blocks until ctx is cancelled.
+// The cursor (lastID) must already be initialized by initCursor before run
+// is called, so that no outbox rows are skipped between construction and
+// the first poll tick.
+func (np *notifyPoller) run(ctx context.Context) {
 	logger.Info(ctx, "notify_poller_started",
 		zap.Duration("interval", np.interval),
-		zap.Uint64("initial_cursor", np.lastID))
+		zap.Uint64("cursor", np.lastID))
 
 	ticker := time.NewTicker(np.interval)
 	defer ticker.Stop()

--- a/pkg/server/notify_poller_test.go
+++ b/pkg/server/notify_poller_test.go
@@ -43,15 +43,16 @@ func TestNotifyPollerDiscoversCrossPodEvents(t *testing.T) {
 	defer bus.Unsubscribe(id)
 
 	np := newNotifyPoller(metaStore, buses, 50*time.Millisecond)
-	// Initialize cursor to 0 so we don't skip the row we're about to insert
-	// (run() would set it to MaxSSENotifyID which races with the insert).
-	np.lastID = 0
+	// Initialize cursor synchronously (as startNotifyInfrastructure does).
+	// At this point the outbox is empty, so lastID = 0.
+	np.initCursor(context.Background())
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	go np.run(ctx)
 
-	// Simulate a cross-pod write: insert an outbox row (as a peer pod would).
-	// The poller should discover it within ~100ms and Publish to wake notify.
+	// Simulate a cross-pod write: insert an outbox row AFTER the poller is
+	// ready. The poller should discover it within ~100ms and Publish to wake
+	// notify. This proves no race between cursor init and the insert.
 	if err := metaStore.InsertSSENotify(context.Background(), "T", 1); err != nil {
 		t.Fatal(err)
 	}
@@ -81,12 +82,13 @@ func TestNotifyPollerSkipsTenantsWithoutSubscribers(t *testing.T) {
 	defer bus1.Unsubscribe(id1)
 
 	np := newNotifyPoller(metaStore, buses, 50*time.Millisecond)
-	np.lastID = 0 // start from beginning to avoid cursor race with insert
+	np.initCursor(context.Background())
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
 	go np.run(ctx)
 
-	// Insert outbox rows for T1 (has subscriber) and T2 (no subscriber).
+	// Insert outbox rows for T1 (has subscriber) and T2 (no subscriber)
+	// AFTER the poller cursor is initialized.
 	if err := metaStore.InsertSSENotify(context.Background(), "T1", 1); err != nil {
 		t.Fatal(err)
 	}
@@ -144,8 +146,12 @@ func TestNotifyPollerBatchDrain(t *testing.T) {
 	np := newNotifyPoller(metaStore, buses, 50*time.Millisecond)
 	ctx, cancel := context.WithCancel(context.Background())
 	t.Cleanup(cancel)
+	// Initialize cursor synchronously — the outbox already has burstSize rows,
+	// so initCursor sets lastID to the max (skipping them all). Then we reset
+	// to 0 to drain from the beginning for the test.
+	np.initCursor(ctx)
+	np.lastID = 0 // override to drain all rows for the test
 	// Manually call pollOnce once to drain all batches synchronously.
-	np.lastID = 0 // start from the beginning
 	np.pollOnce(ctx)
 
 	// All rows should have been consumed. Verify by checking that the poller's

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -502,6 +502,12 @@ func (s *Server) startNotifyInfrastructure(cfg Config) {
 
 	// Fallback poller: reads the central outbox on every pod.
 	poller := newNotifyPoller(s.meta, s.events, cfg.SSENotifyPollInterval)
+	// Initialize the poller cursor synchronously BEFORE starting the goroutine
+	// and BEFORE the server accepts live traffic. This prevents a race where a
+	// write between poller construction and the first MaxSSENotifyID call inside
+	// run() would be skipped (the poller would set lastID to the already-written
+	// row's id and never deliver it). See PR #647 adversary-1 re-review B1.
+	poller.initCursor(context.Background())
 	s.notifyWG.Add(1)
 	go func() {
 		defer s.notifyWG.Done()


### PR DESCRIPTION
## Motivation

Fixes the remaining blocker from qiffang's adversary-1 re-review on PR #647 (the review was posted before merge but the issue was not addressed at that time).

### The race

`notifyPoller.run()` initialized its cursor (`lastID = MaxSSENotifyID()`) **inside the background goroutine**, asynchronously after `startNotifyInfrastructure` returned. A write between poller construction and cursor initialization would be skipped:

1. Pod B starts; poller goroutine has not yet executed `MaxSSENotifyID()`.
2. A client opens `/v1/events` on Pod B and receives a Phase-1 heartbeat at the current head seq.
3. Pod A writes a new `fs_events` + `sse_notify_outbox` row.
4. Pod B's poller finally runs `MaxSSENotifyID()`, sees that new row as the max, sets `lastID` to it, and **never publishes it**.
5. If direct push is also unavailable/stale, the already-open SSE stream on Pod B is stale until reconnect or a later event.

This is a real race that triggers on pod startup/restart (rolling updates, rescheduling) — exactly the scenario the outbox scheme is designed to handle correctly.

## Fix

Extract cursor initialization into a synchronous `initCursor()` method, called in `startNotifyInfrastructure` **before** launching the poller goroutine and before the server accepts live traffic:

```go
poller := newNotifyPoller(s.meta, s.events, cfg.SSENotifyPollInterval)
poller.initCursor(context.Background())  // synchronous — cursor ready before any traffic
s.notifyWG.Add(1)
go func() {
    defer s.notifyWG.Done()
    poller.run(notifyCtx)
}()
```

`run()` no longer initializes the cursor itself — it only logs and starts the ticker loop. The cursor is guaranteed to be set before any SSE connection or write can reach the poller.

## Files changed

| File | Change |
|------|--------|
| `pkg/server/notify_poller.go` | Extract `initCursor()` method; `run()` no longer initializes cursor |
| `pkg/server/server.go` | Call `poller.initCursor()` synchronously before `go poller.run()` |
| `pkg/server/notify_poller_test.go` | Tests call `initCursor()` before `run()`; removed `np.lastID = 0` workaround |

## Testing

All 10 poller + integration tests pass:
- `TestNotifyPollerDiscoversCrossPodEvents` — row inserted after `initCursor` is delivered
- `TestNotifyPollerSkipsTenantsWithoutSubscribers` — same, with skip verification
- `TestNotifyPollerBatchDrain` — full batch drain with `initCursor` + override
- All 7 `TestSSEOutbox*` integration tests pass (these use `NewWithConfig` which calls `initCursor` via `startNotifyInfrastructure`)