### PR TITLE
fix: tune user DB pool observability

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -149,12 +149,17 @@ func main() {
 	// register. The startup ping above only proves reachability at boot.
 	probeInterval := time.Duration(envInt("DRIVE9_DB_HEALTH_PROBE_INTERVAL_SECONDS", 15)) * time.Second
 	probeTimeout := time.Duration(envInt("DRIVE9_DB_HEALTH_PROBE_TIMEOUT_SECONDS", 3)) * time.Second
-	metrics.StartDBHealthProbe(context.Background(), probeInterval, probeTimeout, func(role string, up bool, err error) {
+	metrics.StartDBHealthProbe(context.Background(), probeInterval, probeTimeout, func(info metrics.DBPoolInfo, up bool, err error) {
+		fields := []zap.Field{zap.String("role", info.Role)}
+		if info.TenantID != "" {
+			fields = append(fields, zap.String("tenant_id", info.TenantID))
+		}
 		if up {
-			logger.Info(context.Background(), "db_recovered", zap.String("role", role))
+			logger.Info(context.Background(), "db_recovered", fields...)
 			return
 		}
-		logger.Error(context.Background(), "db_unavailable", zap.String("role", role), zap.Error(err))
+		fields = append(fields, zap.Error(err))
+		logger.Error(context.Background(), "db_unavailable", fields...)
 	})
 
 	if s3cfg.Bucket == "" {
@@ -414,9 +419,9 @@ func main() {
 		Leader:                       leaderManager,
 		SSENotifyPollInterval:        sseNotifyPollInterval,
 		SSENotifyRetention:           sseNotifyRetention,
-		PodID:                         podID,
-		PodAddr:                       podAddr,
-		PodNotifySecret:               podNotifySecret,
+		PodID:                        podID,
+		PodAddr:                      podAddr,
+		PodNotifySecret:              podNotifySecret,
 	}).ListenAndServe(addr))
 }
 
@@ -513,6 +518,13 @@ environment:
   DRIVE9_LISTEN_ADDR serve listen address (default: :9009)
   DRIVE9_PUBLIC_URL  externally reachable base URL for presigned URLs (required for remote clients)
   DRIVE9_META_DSN    control-plane MySQL DSN (required)
+  DRIVE9_POOL_MAX_TENANTS max cached tenant user DB pools per pod (default: 1024)
+  DRIVE9_META_DB_MAX_OPEN_CONNS max open connections for the per-pod meta DB pool
+  DRIVE9_META_DB_MAX_IDLE_CONNS max idle connections for the per-pod meta DB pool
+  DRIVE9_USER_DB_MAX_OPEN_CONNS max open connections for each cached tenant user DB pool (default: 4)
+  DRIVE9_USER_DB_MAX_IDLE_CONNS max idle connections for each cached tenant user DB pool (default: 1)
+  DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS max open connections for tenant schema-init DB pools
+  DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS max idle connections for tenant schema-init DB pools
   DRIVE9_ENCRYPT_TYPE local_aes|kms|aliyun_kms|tencent_kms
   DRIVE9_MASTER_KEY  32-byte hex key for local_aes encryptor
   DRIVE9_ENCRYPT_KEY KMS key id or alias (required for kms/aliyun_kms/tencent_kms)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -519,12 +519,12 @@ environment:
   DRIVE9_PUBLIC_URL  externally reachable base URL for presigned URLs (required for remote clients)
   DRIVE9_META_DSN    control-plane MySQL DSN (required)
   DRIVE9_POOL_MAX_TENANTS max cached tenant user DB pools per pod (default: 1024)
-  DRIVE9_META_DB_MAX_OPEN_CONNS max open connections for the per-pod meta DB pool
-  DRIVE9_META_DB_MAX_IDLE_CONNS max idle connections for the per-pod meta DB pool
+  DRIVE9_META_DB_MAX_OPEN_CONNS max open connections for the per-pod meta DB pool (default: 100)
+  DRIVE9_META_DB_MAX_IDLE_CONNS max idle connections for the per-pod meta DB pool (default: 20)
   DRIVE9_USER_DB_MAX_OPEN_CONNS max open connections for each cached tenant user DB pool (default: 4)
   DRIVE9_USER_DB_MAX_IDLE_CONNS max idle connections for each cached tenant user DB pool (default: 1)
-  DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS max open connections for tenant schema-init DB pools
-  DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS max idle connections for tenant schema-init DB pools
+  DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS max open connections for tenant schema-init DB pools (default: 8)
+  DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS max idle connections for tenant schema-init DB pools (default: 0)
   DRIVE9_ENCRYPT_TYPE local_aes|kms|aliyun_kms|tencent_kms
   DRIVE9_MASTER_KEY  32-byte hex key for local_aes encryptor
   DRIVE9_ENCRYPT_KEY KMS key id or alias (required for kms/aliyun_kms/tencent_kms)

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -158,11 +158,15 @@ type Store struct {
 }
 
 func Open(dsn string) (*Store, error) {
+	return OpenForTenant(dsn, "")
+}
+
+func OpenForTenant(dsn, tenantID string) (*Store, error) {
 	lower := strings.ToLower(dsn)
 	if strings.Contains(lower, "multistatements=true") || strings.Contains(lower, "multistatements=1") {
 		return nil, fmt.Errorf("multiStatements is not allowed in production DSN")
 	}
-	db, err := mysqlutil.OpenInstrumented(context.Background(), dsn, mysqlutil.RoleUser)
+	db, err := mysqlutil.OpenInstrumentedForTenant(context.Background(), dsn, mysqlutil.RoleUser, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -180,14 +180,13 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 		unreachable int
 		firstErr    error
 	}
-	results := map[string]*roleAgg{}
+	results := map[dbMetricKey]*roleAgg{}
 	for _, pool := range dbByPool {
 		key := pool.metricKey()
-		keyString := key.string()
-		if results[keyString] == nil {
-			results[keyString] = &roleAgg{}
+		if results[key] == nil {
+			results[key] = &roleAgg{}
 		}
-		results[keyString].total++
+		results[key].total++
 	}
 
 	// Ping pools concurrently with a fixed bound so one slow/unreachable pool
@@ -197,11 +196,11 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 	sem := make(chan struct{}, probeConcurrency)
 	var wg sync.WaitGroup
 	var aggMu sync.Mutex
-	poolsByKeyString := map[string]registeredDB{}
+	poolsByKey := map[dbMetricKey]registeredDB{}
 	for db, pool := range dbByPool {
 		db, pool := db, pool
-		keyString := pool.metricKey().string()
-		poolsByKeyString[keyString] = pool
+		key := pool.metricKey()
+		poolsByKey[key] = pool
 		wg.Add(1)
 		sem <- struct{}{}
 		go func() {
@@ -214,27 +213,28 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 			// pool — at most probeConcurrency in flight cluster-wide. Any opened
 			// conn is later reaped by ConnMaxIdleTime.
 			//
-			// Caveat: on a pool with MaxOpenConns fully checked out, PingContext
-			// blocks for a free slot and may hit `timeout`, recording the pool as
-			// unreachable when it is merely saturated. The pool-saturation alert
-			// covers that condition directly.
-			pingCtx, cancel := context.WithTimeout(ctx, timeout)
 			start := time.Now()
+			result := "ok"
+			if isTenantPoolSaturated(db, key) {
+				result = "pool_saturated"
+				observeDBProbeDuration(start, key, result)
+				return
+			}
+
+			pingCtx, cancel := context.WithTimeout(ctx, timeout)
 			err := db.PingContext(pingCtx)
 			cancel()
-
-			result := "ok"
 			if err != nil {
 				result = "error"
 				aggMu.Lock()
-				agg := results[keyString]
+				agg := results[key]
 				agg.unreachable++
 				if agg.firstErr == nil {
 					agg.firstErr = err
 				}
 				aggMu.Unlock()
 			}
-			dbProbeDuration.Observe(time.Since(start).Seconds(), Attr("role", cleanMetricValue(pool.role, "unknown")), Attr("result", result))
+			observeDBProbeDuration(start, key, result)
 		}()
 	}
 	wg.Wait()
@@ -250,9 +250,8 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 	m.mu.Lock()
 	prevProbe := m.probe
 	nextProbe := make(map[dbMetricKey]dbProbeState, len(results))
-	for keyString, agg := range results {
-		pool := poolsByKeyString[keyString]
-		key := pool.metricKey()
+	for key, agg := range results {
+		pool := poolsByKey[key]
 		up := agg.unreachable == 0
 		prev, existed := prevProbe[key]
 		nextProbe[key] = dbProbeState{
@@ -387,8 +386,23 @@ func (p registeredDB) info() DBPoolInfo {
 	return info
 }
 
-func (k dbMetricKey) string() string {
-	return k.role + "\x00" + k.tenantID
+func isTenantPoolSaturated(db *sql.DB, key dbMetricKey) bool {
+	if key.tenantID == "" || key.tenantID == "unknown" {
+		return false
+	}
+	stats := db.Stats()
+	return stats.MaxOpenConnections > 0 && stats.Idle == 0 && stats.InUse >= stats.MaxOpenConnections
+}
+
+func observeDBProbeDuration(start time.Time, key dbMetricKey, result string) {
+	attrs := []Attribute{
+		Attr("role", key.role),
+		Attr("result", result),
+	}
+	if key.tenantID != "" && key.tenantID != "unknown" {
+		attrs = append(attrs, Attr("tenant_id", key.tenantID))
+	}
+	dbProbeDuration.Observe(time.Since(start).Seconds(), attrs...)
 }
 
 func dbLabels(key dbMetricKey) string {

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -214,12 +214,10 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 			// pool — at most probeConcurrency in flight cluster-wide. Any opened
 			// conn is later reaped by ConnMaxIdleTime.
 			//
-			// Caveat: on a pool with an explicit MaxOpenConns that is fully checked
-			// out, PingContext blocks for a free slot and may hit `timeout`,
-			// recording the pool as unreachable when it is merely saturated. This is
-			// rarely hit because ApplyPoolDefaults leaves MaxOpenConns unlimited
-			// unless the role-specific max-open env var is set; the pool-saturation
-			// alert covers that condition directly.
+			// Caveat: on a pool with MaxOpenConns fully checked out, PingContext
+			// blocks for a free slot and may hit `timeout`, recording the pool as
+			// unreachable when it is merely saturated. The pool-saturation alert
+			// covers that condition directly.
 			pingCtx, cancel := context.WithTimeout(ctx, timeout)
 			start := time.Now()
 			err := db.PingContext(pingCtx)
@@ -250,15 +248,14 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 	now := time.Now()
 
 	m.mu.Lock()
-	if m.probe == nil {
-		m.probe = map[dbMetricKey]dbProbeState{}
-	}
+	prevProbe := m.probe
+	nextProbe := make(map[dbMetricKey]dbProbeState, len(results))
 	for keyString, agg := range results {
 		pool := poolsByKeyString[keyString]
 		key := pool.metricKey()
 		up := agg.unreachable == 0
-		prev, existed := m.probe[key]
-		m.probe[key] = dbProbeState{
+		prev, existed := prevProbe[key]
+		nextProbe[key] = dbProbeState{
 			up:               up,
 			unreachablePools: agg.unreachable,
 			totalPools:       agg.total,
@@ -271,6 +268,7 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 			transitions = append(transitions, transition{info: pool.info(), up: up, err: agg.firstErr})
 		}
 	}
+	m.probe = nextProbe
 	m.mu.Unlock()
 
 	for _, t := range transitions {

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -77,19 +77,11 @@ const (
 )
 
 func RecordDBOperation(role, operation, result string, d time.Duration) {
-	RecordTenantDBOperation(role, "", operation, result, d)
-}
-
-func RecordTenantDBOperation(role, tenantID, operation, result string, d time.Duration) {
 	RegisterModule("db")
 	attrs := []Attribute{
 		Attr("role", cleanMetricValue(role, "unknown")),
 		Attr("operation", cleanMetricValue(operation, "unknown")),
 		Attr("result", cleanMetricValue(result, "unknown")),
-	}
-	tenantID = cleanMetricValue(tenantID, "unknown")
-	if tenantID != "unknown" {
-		attrs = append(attrs, Attr("tenant_id", tenantID))
 	}
 	dbOperationsTotal.Add(1, attrs...)
 	dbOperationDuration.Observe(d.Seconds(), attrs...)

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -5,9 +5,17 @@ import (
 	"database/sql"
 	"fmt"
 	"net/http"
+	"sort"
 	"sync"
 	"time"
 )
+
+// DBPoolInfo identifies a registered database pool for metrics and health
+// transition logging.
+type DBPoolInfo struct {
+	Role     string
+	TenantID string
+}
 
 // dbProbeState is the cached result of the most recent health probe for a role.
 type dbProbeState struct {
@@ -18,10 +26,20 @@ type dbProbeState struct {
 	known            bool
 }
 
+type registeredDB struct {
+	role     string
+	tenantID string
+}
+
+type dbMetricKey struct {
+	role     string
+	tenantID string
+}
+
 type dbMetrics struct {
 	mu      sync.RWMutex
-	dbs     map[*sql.DB]string
-	probe   map[string]dbProbeState
+	dbs     map[*sql.DB]registeredDB
+	probe   map[dbMetricKey]dbProbeState
 	started bool
 }
 
@@ -42,8 +60,8 @@ var dbOperationDurationBounds = []float64{0.0005, 0.001, 0.0025, 0.005, 0.01, 0.
 var dbProbeDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10}
 
 var globalDB = &dbMetrics{
-	dbs:   map[*sql.DB]string{},
-	probe: map[string]dbProbeState{},
+	dbs:   map[*sql.DB]registeredDB{},
+	probe: map[dbMetricKey]dbProbeState{},
 }
 
 var dbMeter = globalMeterProvider.Meter("db")
@@ -59,23 +77,35 @@ const (
 )
 
 func RecordDBOperation(role, operation, result string, d time.Duration) {
+	RecordTenantDBOperation(role, "", operation, result, d)
+}
+
+func RecordTenantDBOperation(role, tenantID, operation, result string, d time.Duration) {
 	RegisterModule("db")
 	attrs := []Attribute{
 		Attr("role", cleanMetricValue(role, "unknown")),
 		Attr("operation", cleanMetricValue(operation, "unknown")),
 		Attr("result", cleanMetricValue(result, "unknown")),
 	}
+	tenantID = cleanMetricValue(tenantID, "unknown")
+	if tenantID != "unknown" {
+		attrs = append(attrs, Attr("tenant_id", tenantID))
+	}
 	dbOperationsTotal.Add(1, attrs...)
 	dbOperationDuration.Observe(d.Seconds(), attrs...)
 }
 
 func RegisterDB(role string, db *sql.DB) {
+	RegisterTenantDB(role, "", db)
+}
+
+func RegisterTenantDB(role, tenantID string, db *sql.DB) {
 	if db == nil {
 		return
 	}
 	RegisterModule("db")
 	globalDB.mu.Lock()
-	globalDB.dbs[db] = role
+	globalDB.dbs[db] = registeredDB{role: role, tenantID: tenantID}
 	globalDB.mu.Unlock()
 }
 
@@ -89,22 +119,22 @@ func UnregisterDB(db *sql.DB) {
 }
 
 // StartDBHealthProbe launches a background goroutine that periodically pings every
-// registered *sql.DB and publishes a per-role availability signal as the
-// drive9_db_up gauge. It is the active dependency-health probe for the metadata
-// store ("meta") and tenant data stores ("user"): pool/operation metrics only move
-// while there is live traffic, so an idle-but-unreachable database is otherwise
-// invisible.
+// registered *sql.DB and publishes availability as the drive9_db_up gauge. It is
+// the active dependency-health probe for the metadata store ("meta") and tenant
+// data stores ("user"): pool/operation metrics only move while there is live
+// traffic, so an idle-but-unreachable database is otherwise invisible. User DB
+// pool series include tenant_id when the pool was registered with one.
 //
 // The probe never blocks the /metrics scrape path — scrapes read the cached probe
-// state. onChange (optional) is invoked outside the lock on a role's first observed
-// failure and on every subsequent up<->down transition, so callers can emit a log
-// without coupling this package to a logger. The goroutine stops when ctx is done;
-// repeat calls after the first are no-ops.
+// state. onChange (optional) is invoked outside the lock on a pool key's first
+// observed failure and on every subsequent up<->down transition, so callers can
+// emit a log without coupling this package to a logger. The goroutine stops when
+// ctx is done; repeat calls after the first are no-ops.
 //
 // Example alert (critical — control-plane DB unreachable):
 //
 //	max(drive9_db_up{role="meta"}) == 0
-func StartDBHealthProbe(ctx context.Context, interval, timeout time.Duration, onChange func(role string, up bool, err error)) {
+func StartDBHealthProbe(ctx context.Context, interval, timeout time.Duration, onChange func(info DBPoolInfo, up bool, err error)) {
 	if interval <= 0 {
 		interval = DefaultDBHealthProbeInterval
 	}
@@ -137,11 +167,11 @@ func StartDBHealthProbe(ctx context.Context, interval, timeout time.Duration, on
 
 // probeOnce runs a single probe cycle across all registered pools and updates the
 // cached per-role state. Exported indirectly for tests via probeOnce.
-func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChange func(role string, up bool, err error)) {
+func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChange func(info DBPoolInfo, up bool, err error)) {
 	m.mu.RLock()
-	dbByRole := make(map[*sql.DB]string, len(m.dbs))
-	for db, role := range m.dbs {
-		dbByRole[db] = role
+	dbByPool := make(map[*sql.DB]registeredDB, len(m.dbs))
+	for db, pool := range m.dbs {
+		dbByPool[db] = pool
 	}
 	m.mu.RUnlock()
 
@@ -151,11 +181,13 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 		firstErr    error
 	}
 	results := map[string]*roleAgg{}
-	for _, role := range dbByRole {
-		if results[role] == nil {
-			results[role] = &roleAgg{}
+	for _, pool := range dbByPool {
+		key := pool.metricKey()
+		keyString := key.string()
+		if results[keyString] == nil {
+			results[keyString] = &roleAgg{}
 		}
-		results[role].total++
+		results[keyString].total++
 	}
 
 	// Ping pools concurrently with a fixed bound so one slow/unreachable pool
@@ -165,8 +197,11 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 	sem := make(chan struct{}, probeConcurrency)
 	var wg sync.WaitGroup
 	var aggMu sync.Mutex
-	for db, role := range dbByRole {
-		db, role := db, role
+	poolsByKeyString := map[string]registeredDB{}
+	for db, pool := range dbByPool {
+		db, pool := db, pool
+		keyString := pool.metricKey().string()
+		poolsByKeyString[keyString] = pool
 		wg.Add(1)
 		sem <- struct{}{}
 		go func() {
@@ -183,8 +218,8 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 			// out, PingContext blocks for a free slot and may hit `timeout`,
 			// recording the pool as unreachable when it is merely saturated. This is
 			// rarely hit because ApplyPoolDefaults leaves MaxOpenConns unlimited
-			// unless DRIVE9_DB_MAX_OPEN_CONNS is set; the pool-saturation alert
-			// covers that condition directly.
+			// unless the role-specific max-open env var is set; the pool-saturation
+			// alert covers that condition directly.
 			pingCtx, cancel := context.WithTimeout(ctx, timeout)
 			start := time.Now()
 			err := db.PingContext(pingCtx)
@@ -194,20 +229,20 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 			if err != nil {
 				result = "error"
 				aggMu.Lock()
-				agg := results[role]
+				agg := results[keyString]
 				agg.unreachable++
 				if agg.firstErr == nil {
 					agg.firstErr = err
 				}
 				aggMu.Unlock()
 			}
-			dbProbeDuration.Observe(time.Since(start).Seconds(), Attr("role", cleanMetricValue(role, "unknown")), Attr("result", result))
+			dbProbeDuration.Observe(time.Since(start).Seconds(), Attr("role", cleanMetricValue(pool.role, "unknown")), Attr("result", result))
 		}()
 	}
 	wg.Wait()
 
 	type transition struct {
-		role string
+		info DBPoolInfo
 		up   bool
 		err  error
 	}
@@ -216,12 +251,14 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 
 	m.mu.Lock()
 	if m.probe == nil {
-		m.probe = map[string]dbProbeState{}
+		m.probe = map[dbMetricKey]dbProbeState{}
 	}
-	for role, agg := range results {
+	for keyString, agg := range results {
+		pool := poolsByKeyString[keyString]
+		key := pool.metricKey()
 		up := agg.unreachable == 0
-		prev, existed := m.probe[role]
-		m.probe[role] = dbProbeState{
+		prev, existed := m.probe[key]
+		m.probe[key] = dbProbeState{
 			up:               up,
 			unreachablePools: agg.unreachable,
 			totalPools:       agg.total,
@@ -231,28 +268,29 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 		// Fire on the first observed failure, and on every up<->down change
 		// thereafter. A first observation that is healthy is not a transition.
 		if onChange != nil && ((!existed && !up) || (existed && prev.up != up)) {
-			transitions = append(transitions, transition{role: role, up: up, err: agg.firstErr})
+			transitions = append(transitions, transition{info: pool.info(), up: up, err: agg.firstErr})
 		}
 	}
 	m.mu.Unlock()
 
 	for _, t := range transitions {
-		onChange(t.role, t.up, t.err)
+		onChange(t.info, t.up, t.err)
 	}
 }
 
 func writeDBPrometheus(w http.ResponseWriter) {
 	globalDB.mu.RLock()
-	dbByRole := make(map[*sql.DB]string, len(globalDB.dbs))
-	for db, role := range globalDB.dbs {
-		dbByRole[db] = role
+	dbByPool := make(map[*sql.DB]registeredDB, len(globalDB.dbs))
+	for db, pool := range globalDB.dbs {
+		dbByPool[db] = pool
 	}
 	globalDB.mu.RUnlock()
 
-	poolTotals := make(map[string]dbPoolTotals)
-	for db, role := range dbByRole {
+	poolTotals := make(map[dbMetricKey]dbPoolTotals)
+	for db, pool := range dbByPool {
+		key := pool.metricKey()
 		stats := db.Stats()
-		totals := poolTotals[role]
+		totals := poolTotals[key]
 		totals.registered++
 		totals.openConnections += int64(stats.OpenConnections)
 		totals.inUseConnections += int64(stats.InUse)
@@ -263,14 +301,14 @@ func writeDBPrometheus(w http.ResponseWriter) {
 		totals.maxIdleClosed += stats.MaxIdleClosed
 		totals.maxIdleTimeClosed += stats.MaxIdleTimeClosed
 		totals.maxLifetimeClosed += stats.MaxLifetimeClosed
-		poolTotals[role] = totals
+		poolTotals[key] = totals
 	}
-	roles := SortedKeys(poolTotals)
+	keys := sortedDBMetricKeys(poolTotals)
 
 	globalDB.mu.RLock()
-	probeByRole := make(map[string]dbProbeState, len(globalDB.probe))
-	for role, state := range globalDB.probe {
-		probeByRole[role] = state
+	probeByKey := make(map[dbMetricKey]dbProbeState, len(globalDB.probe))
+	for key, state := range globalDB.probe {
+		probeByKey[key] = state
 	}
 	globalDB.mu.RUnlock()
 
@@ -280,60 +318,99 @@ func writeDBPrometheus(w http.ResponseWriter) {
 	// `== 0` alert never fires on a cold series.
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_up Database availability by role (1 = all registered pools reachable on last probe)")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_up gauge")
-	for _, role := range roles {
+	for _, key := range keys {
 		up := 1.0
-		if state, ok := probeByRole[role]; ok && state.known && !state.up {
+		if state, ok := probeByKey[key]; ok && state.known && !state.up {
 			up = 0.0
 		}
-		_, _ = fmt.Fprintf(w, "drive9_db_up{role=\"%s\"} %s\n", EscapePromLabel(role), formatFloat(up))
+		_, _ = fmt.Fprintf(w, "drive9_db_up{%s} %s\n", dbLabels(key), formatFloat(up))
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_unreachable_pools Registered pools that failed their last health probe by role")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_unreachable_pools gauge")
-	for _, role := range roles {
+	for _, key := range keys {
 		unreachable := 0
-		if state, ok := probeByRole[role]; ok && state.known {
+		if state, ok := probeByKey[key]; ok && state.known {
 			unreachable = state.unreachablePools
 		}
-		_, _ = fmt.Fprintf(w, "drive9_db_unreachable_pools{role=\"%s\"} %d\n", EscapePromLabel(role), unreachable)
+		_, _ = fmt.Fprintf(w, "drive9_db_unreachable_pools{%s} %d\n", dbLabels(key), unreachable)
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_registered Database pools currently registered for metrics by role")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_registered gauge")
-	for _, role := range roles {
-		_, _ = fmt.Fprintf(w, "drive9_db_pool_registered{role=\"%s\"} %d\n", EscapePromLabel(role), poolTotals[role].registered)
+	for _, key := range keys {
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_registered{%s} %d\n", dbLabels(key), poolTotals[key].registered)
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_connections Aggregated database pool connections by role/state")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_connections gauge")
-	for _, role := range roles {
-		totals := poolTotals[role]
-		escapedRole := EscapePromLabel(role)
-		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{role=\"%s\",state=\"open\"} %d\n", escapedRole, totals.openConnections)
-		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{role=\"%s\",state=\"in_use\"} %d\n", escapedRole, totals.inUseConnections)
-		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{role=\"%s\",state=\"idle\"} %d\n", escapedRole, totals.idleConnections)
-		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{role=\"%s\",state=\"max_open\"} %d\n", escapedRole, totals.maxOpenConnections)
+	for _, key := range keys {
+		totals := poolTotals[key]
+		labels := dbLabels(key)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"open\"} %d\n", labels, totals.openConnections)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"in_use\"} %d\n", labels, totals.inUseConnections)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"idle\"} %d\n", labels, totals.idleConnections)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"max_open\"} %d\n", labels, totals.maxOpenConnections)
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_wait_count_total Aggregated database pool wait count by role")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_wait_count_total counter")
-	for _, role := range roles {
-		_, _ = fmt.Fprintf(w, "drive9_db_pool_wait_count_total{role=\"%s\"} %d\n", EscapePromLabel(role), poolTotals[role].waitCount)
+	for _, key := range keys {
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_wait_count_total{%s} %d\n", dbLabels(key), poolTotals[key].waitCount)
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_wait_duration_seconds_total Aggregated database pool wait duration by role")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_wait_duration_seconds_total counter")
-	for _, role := range roles {
-		_, _ = fmt.Fprintf(w, "drive9_db_pool_wait_duration_seconds_total{role=\"%s\"} %.6f\n", EscapePromLabel(role), poolTotals[role].waitDuration)
+	for _, key := range keys {
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_wait_duration_seconds_total{%s} %.6f\n", dbLabels(key), poolTotals[key].waitDuration)
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_closes_total Aggregated database pool closes by role/reason")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_closes_total counter")
-	for _, role := range roles {
-		totals := poolTotals[role]
-		escapedRole := EscapePromLabel(role)
-		_, _ = fmt.Fprintf(w, "drive9_db_pool_closes_total{role=\"%s\",reason=\"max_idle\"} %d\n", escapedRole, totals.maxIdleClosed)
-		_, _ = fmt.Fprintf(w, "drive9_db_pool_closes_total{role=\"%s\",reason=\"max_idle_time\"} %d\n", escapedRole, totals.maxIdleTimeClosed)
-		_, _ = fmt.Fprintf(w, "drive9_db_pool_closes_total{role=\"%s\",reason=\"max_lifetime\"} %d\n", escapedRole, totals.maxLifetimeClosed)
+	for _, key := range keys {
+		totals := poolTotals[key]
+		labels := dbLabels(key)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_closes_total{%s,reason=\"max_idle\"} %d\n", labels, totals.maxIdleClosed)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_closes_total{%s,reason=\"max_idle_time\"} %d\n", labels, totals.maxIdleTimeClosed)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_closes_total{%s,reason=\"max_lifetime\"} %d\n", labels, totals.maxLifetimeClosed)
 	}
+}
+
+func (p registeredDB) metricKey() dbMetricKey {
+	return dbMetricKey{role: cleanMetricValue(p.role, "unknown"), tenantID: cleanMetricValue(p.tenantID, "unknown")}
+}
+
+func (p registeredDB) info() DBPoolInfo {
+	key := p.metricKey()
+	info := DBPoolInfo{Role: key.role}
+	if key.tenantID != "unknown" {
+		info.TenantID = key.tenantID
+	}
+	return info
+}
+
+func (k dbMetricKey) string() string {
+	return k.role + "\x00" + k.tenantID
+}
+
+func dbLabels(key dbMetricKey) string {
+	labels := fmt.Sprintf("role=\"%s\"", EscapePromLabel(key.role))
+	if key.tenantID != "" && key.tenantID != "unknown" {
+		labels += fmt.Sprintf(",tenant_id=\"%s\"", EscapePromLabel(key.tenantID))
+	}
+	return labels
+}
+
+func sortedDBMetricKeys(totals map[dbMetricKey]dbPoolTotals) []dbMetricKey {
+	keys := make([]dbMetricKey, 0, len(totals))
+	for key := range totals {
+		keys = append(keys, key)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].role != keys[j].role {
+			return keys[i].role < keys[j].role
+		}
+		return keys[i].tenantID < keys[j].tenantID
+	})
+	return keys
 }

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -215,7 +215,11 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 			//
 			start := time.Now()
 			result := "ok"
-			if isTenantPoolSaturated(db, key) {
+			// A saturated bounded pool cannot lend a connection to PingContext,
+			// so probing through it would report a false database outage. Keep
+			// drive9_db_up unchanged and let pool wait/saturation metrics cover
+			// this state, even if the database is also unreachable underneath.
+			if isDBPoolSaturated(db) {
 				result = "pool_saturated"
 				observeDBProbeDuration(start, key, result)
 				return
@@ -386,10 +390,7 @@ func (p registeredDB) info() DBPoolInfo {
 	return info
 }
 
-func isTenantPoolSaturated(db *sql.DB, key dbMetricKey) bool {
-	if key.tenantID == "" || key.tenantID == "unknown" {
-		return false
-	}
+func isDBPoolSaturated(db *sql.DB) bool {
 	stats := db.Stats()
 	return stats.MaxOpenConnections > 0 && stats.Idle == 0 && stats.InUse >= stats.MaxOpenConnections
 }

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -134,7 +134,11 @@ func TestDBMetricsIncludeTenantIDForTenantPools(t *testing.T) {
 	healthy.Store(true)
 	db := sql.OpenDB(fakeConnector{healthy: healthy})
 	db.SetMaxIdleConns(0)
-	t.Cleanup(func() { UnregisterDB(db); _ = db.Close() })
+	t.Cleanup(func() {
+		UnregisterDB(db)
+		globalDB.probeOnce(context.Background(), time.Second, nil)
+		_ = db.Close()
+	})
 
 	RegisterTenantDB(role, tenantID, db)
 	globalDB.probeOnce(context.Background(), time.Second, nil)
@@ -164,7 +168,11 @@ func TestDBHealthProbeDropsUnregisteredTenantState(t *testing.T) {
 	healthy.Store(false)
 	db := sql.OpenDB(fakeConnector{healthy: healthy})
 	db.SetMaxIdleConns(0)
-	t.Cleanup(func() { _ = db.Close() })
+	t.Cleanup(func() {
+		UnregisterDB(db)
+		globalDB.probeOnce(context.Background(), time.Second, nil)
+		_ = db.Close()
+	})
 
 	RegisterTenantDB("user", tenantID, db)
 	globalDB.probeOnce(context.Background(), time.Second, nil)
@@ -187,7 +195,11 @@ func TestDBHealthProbeDoesNotMarkSaturatedTenantPoolDown(t *testing.T) {
 	db := sql.OpenDB(fakeConnector{healthy: healthy})
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(0)
-	t.Cleanup(func() { UnregisterDB(db); _ = db.Close() })
+	t.Cleanup(func() {
+		UnregisterDB(db)
+		globalDB.probeOnce(context.Background(), time.Second, nil)
+		_ = db.Close()
+	})
 
 	conn, err := db.Conn(context.Background())
 	if err != nil {

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -149,6 +149,12 @@ func TestDBMetricsIncludeTenantIDForTenantPools(t *testing.T) {
 	if !strings.Contains(out, `drive9_db_pool_wait_count_total{role="user",tenant_id="`+tenantID+`"} 0`) {
 		t.Fatalf("expected tenant pool wait series, got:\n%s", out)
 	}
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	fullText := rec.Body.String()
+	if !strings.Contains(fullText, `drive9_db_probe_duration_seconds_bucket{result="ok",role="user",tenant_id="`+tenantID+`"`) {
+		t.Fatalf("expected tenant probe duration series, got:\n%s", fullText)
+	}
 }
 
 func TestDBHealthProbeDropsUnregisteredTenantState(t *testing.T) {
@@ -170,5 +176,44 @@ func TestDBHealthProbeDropsUnregisteredTenantState(t *testing.T) {
 	globalDB.probeOnce(context.Background(), time.Second, nil)
 	if _, ok := globalDB.probe[dbMetricKey{role: "user", tenantID: tenantID}]; ok {
 		t.Fatalf("expected tenant probe state to be removed after unregister")
+	}
+}
+
+func TestDBHealthProbeDoesNotMarkSaturatedTenantPoolDown(t *testing.T) {
+	const tenantID = "tenant-db-saturated-test"
+
+	healthy := &atomic.Bool{}
+	healthy.Store(true)
+	db := sql.OpenDB(fakeConnector{healthy: healthy})
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() { UnregisterDB(db); _ = db.Close() })
+
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open held conn: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	RegisterTenantDB("user", tenantID, db)
+	globalDB.probeOnce(context.Background(), 10*time.Millisecond, func(info DBPoolInfo, up bool, err error) {
+		if info.TenantID == tenantID {
+			t.Fatalf("expected no down transition for saturated tenant pool, got up=%v err=%v", up, err)
+		}
+	})
+
+	out := renderDB(t)
+	if !strings.Contains(out, `drive9_db_up{role="user",tenant_id="`+tenantID+`"} 1`) {
+		t.Fatalf("expected saturated tenant pool to remain up, got:\n%s", out)
+	}
+	if !strings.Contains(out, `drive9_db_unreachable_pools{role="user",tenant_id="`+tenantID+`"} 0`) {
+		t.Fatalf("expected saturated tenant pool not to count as unreachable, got:\n%s", out)
+	}
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	fullText := rec.Body.String()
+	if !strings.Contains(fullText, `drive9_db_probe_duration_seconds_bucket{result="pool_saturated",role="user",tenant_id="`+tenantID+`"`) {
+		t.Fatalf("expected saturated probe duration series, got:\n%s", fullText)
 	}
 }

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -217,3 +217,47 @@ func TestDBHealthProbeDoesNotMarkSaturatedTenantPoolDown(t *testing.T) {
 		t.Fatalf("expected saturated probe duration series, got:\n%s", fullText)
 	}
 }
+
+func TestDBHealthProbeDoesNotMarkSaturatedMetaPoolDown(t *testing.T) {
+	healthy := &atomic.Bool{}
+	healthy.Store(true)
+	db := sql.OpenDB(fakeConnector{healthy: healthy})
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() {
+		UnregisterDB(db)
+		globalDB.probeOnce(context.Background(), time.Second, nil)
+		_ = db.Close()
+	})
+
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open held conn: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	RegisterDB("meta", db)
+	globalDB.probeOnce(context.Background(), 10*time.Millisecond, func(info DBPoolInfo, up bool, err error) {
+		if info.Role == "meta" {
+			t.Fatalf("expected no down transition for saturated meta pool, got up=%v err=%v", up, err)
+		}
+	})
+
+	out := renderDB(t)
+	if !strings.Contains(out, `drive9_db_up{role="meta"} 1`) {
+		t.Fatalf("expected saturated meta pool to remain up, got:\n%s", out)
+	}
+	if !strings.Contains(out, `drive9_db_unreachable_pools{role="meta"} 0`) {
+		t.Fatalf("expected saturated meta pool not to count as unreachable, got:\n%s", out)
+	}
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	fullText := rec.Body.String()
+	if !strings.Contains(fullText, `drive9_db_probe_duration_seconds_bucket{result="pool_saturated",role="meta"`) {
+		t.Fatalf("expected saturated meta probe duration series, got:\n%s", fullText)
+	}
+	if strings.Contains(fullText, `role="meta",tenant_id=`) {
+		t.Fatalf("expected meta probe duration series to omit tenant_id, got:\n%s", fullText)
+	}
+}

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -72,8 +72,8 @@ func TestDBHealthProbeFlipsDriveDBUp(t *testing.T) {
 		err error
 	}
 	var changes []change
-	onChange := func(r string, up bool, err error) {
-		if r != role {
+	onChange := func(info DBPoolInfo, up bool, err error) {
+		if info.Role != role {
 			return
 		}
 		mu.Lock()
@@ -121,5 +121,32 @@ func TestDBHealthProbeFlipsDriveDBUp(t *testing.T) {
 	}
 	if !changes[1].up {
 		t.Fatalf("expected second transition to be up, got %+v", changes[1])
+	}
+}
+
+func TestDBMetricsIncludeTenantIDForTenantPools(t *testing.T) {
+	const (
+		role     = "user"
+		tenantID = "tenant-db-metrics-test"
+	)
+
+	healthy := &atomic.Bool{}
+	healthy.Store(true)
+	db := sql.OpenDB(fakeConnector{healthy: healthy})
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() { UnregisterDB(db); _ = db.Close() })
+
+	RegisterTenantDB(role, tenantID, db)
+	globalDB.probeOnce(context.Background(), time.Second, nil)
+	out := renderDB(t)
+
+	if !strings.Contains(out, `drive9_db_up{role="user",tenant_id="`+tenantID+`"} 1`) {
+		t.Fatalf("expected tenant db_up series, got:\n%s", out)
+	}
+	if !strings.Contains(out, `drive9_db_pool_registered{role="user",tenant_id="`+tenantID+`"} 1`) {
+		t.Fatalf("expected tenant pool_registered series, got:\n%s", out)
+	}
+	if !strings.Contains(out, `drive9_db_pool_wait_count_total{role="user",tenant_id="`+tenantID+`"} 0`) {
+		t.Fatalf("expected tenant pool wait series, got:\n%s", out)
 	}
 }

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -150,3 +150,25 @@ func TestDBMetricsIncludeTenantIDForTenantPools(t *testing.T) {
 		t.Fatalf("expected tenant pool wait series, got:\n%s", out)
 	}
 }
+
+func TestDBHealthProbeDropsUnregisteredTenantState(t *testing.T) {
+	const tenantID = "tenant-db-unregister-test"
+
+	healthy := &atomic.Bool{}
+	healthy.Store(false)
+	db := sql.OpenDB(fakeConnector{healthy: healthy})
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() { _ = db.Close() })
+
+	RegisterTenantDB("user", tenantID, db)
+	globalDB.probeOnce(context.Background(), time.Second, nil)
+	if _, ok := globalDB.probe[dbMetricKey{role: "user", tenantID: tenantID}]; !ok {
+		t.Fatalf("expected tenant probe state to be recorded")
+	}
+
+	UnregisterDB(db)
+	globalDB.probeOnce(context.Background(), time.Second, nil)
+	if _, ok := globalDB.probe[dbMetricKey{role: "user", tenantID: tenantID}]; ok {
+		t.Fatalf("expected tenant probe state to be removed after unregister")
+	}
+}

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -51,15 +51,18 @@ func TestRecordTenantOperationCountDoesNotRecordDuration(t *testing.T) {
 	}
 }
 
-func TestRecordTenantDBOperationIncludesTenantID(t *testing.T) {
+func TestRecordDBOperationOmitsTenantID(t *testing.T) {
 	const tenantID = "tenant-db-operation-test"
 
-	RecordTenantDBOperation("user", tenantID, "query", "ok", 0)
+	RecordDBOperation("user", "query", "ok", 0)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_db_operations_total{operation="query",result="ok",role="user",tenant_id="`+tenantID+`"} 1`) {
-		t.Fatalf("missing tenant db operation total:\n%s", text)
+	if !strings.Contains(text, `drive9_db_operations_total{operation="query",result="ok",role="user"} 1`) {
+		t.Fatalf("missing db operation total:\n%s", text)
+	}
+	if strings.Contains(text, `tenant_id="`+tenantID+`"`) {
+		t.Fatalf("db operation metrics must not carry tenant_id:\n%s", text)
 	}
 }

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -50,3 +50,16 @@ func TestRecordTenantOperationCountDoesNotRecordDuration(t *testing.T) {
 		t.Fatalf("counter-only operation unexpectedly recorded a duration:\n%s", text)
 	}
 }
+
+func TestRecordTenantDBOperationIncludesTenantID(t *testing.T) {
+	const tenantID = "tenant-db-operation-test"
+
+	RecordTenantDBOperation("user", tenantID, "query", "ok", 0)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_db_operations_total{operation="query",result="ok",role="user",tenant_id="`+tenantID+`"} 1`) {
+		t.Fatalf("missing tenant db operation total:\n%s", text)
+	}
+}

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -272,8 +272,8 @@ func (tx instrumentedTx) Rollback() error {
 	return err
 }
 
-func observeDBOperation(ctx context.Context, role, tenantID, operation string, start time.Time, err error) {
-	metrics.RecordTenantDBOperation(role, tenantID, operation, dbResult(err), time.Since(start))
+func observeDBOperation(ctx context.Context, role, _ string, operation string, start time.Time, err error) {
+	metrics.RecordDBOperation(role, operation, dbResult(err), time.Since(start))
 }
 
 func dbResult(err error) string {

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -14,18 +14,23 @@ import (
 )
 
 const (
-	RoleMeta = "meta"
-	RoleUser = "user"
+	RoleMeta       = "meta"
+	RoleUser       = "user"
+	RoleUserSchema = "user_schema"
 )
 
 func OpenInstrumented(ctx context.Context, dsn, role string) (*sql.DB, error) {
+	return OpenInstrumentedForTenant(ctx, dsn, role, "")
+}
+
+func OpenInstrumentedForTenant(ctx context.Context, dsn, role, tenantID string) (*sql.DB, error) {
 	connector, err := (&mysql.MySQLDriver{}).OpenConnector(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open mysql connector: %w", err)
 	}
-	db := sql.OpenDB(instrumentedConnector{base: connector, role: role})
-	ApplyPoolDefaults(db)
-	metrics.RegisterDB(role, db)
+	db := sql.OpenDB(instrumentedConnector{base: connector, role: role, tenantID: tenantID})
+	ApplyPoolDefaults(db, role)
+	metrics.RegisterTenantDB(role, tenantID, db)
 	if err := db.PingContext(ctx); err != nil {
 		metrics.UnregisterDB(db)
 		_ = db.Close()
@@ -43,20 +48,21 @@ func CloseInstrumented(db *sql.DB) error {
 }
 
 type instrumentedConnector struct {
-	base driver.Connector
-	role string
+	base     driver.Connector
+	role     string
+	tenantID string
 }
 
 func (c instrumentedConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	start := time.Now()
 	conn, err := c.base.Connect(ctx)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, c.role, "connect", start, err)
+		observeDBOperation(ctx, c.role, c.tenantID, "connect", start, err)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return instrumentedConn{base: conn, role: c.role}, nil
+	return instrumentedConn{base: conn, role: c.role, tenantID: c.tenantID}, nil
 }
 
 func (c instrumentedConnector) Driver() driver.Driver {
@@ -64,20 +70,21 @@ func (c instrumentedConnector) Driver() driver.Driver {
 }
 
 type instrumentedConn struct {
-	base driver.Conn
-	role string
+	base     driver.Conn
+	role     string
+	tenantID string
 }
 
 func (c instrumentedConn) Prepare(query string) (driver.Stmt, error) {
 	start := time.Now()
 	stmt, err := c.base.Prepare(query)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(context.Background(), c.role, "prepare", start, err)
+		observeDBOperation(context.Background(), c.role, c.tenantID, "prepare", start, err)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return instrumentedStmt{base: stmt, role: c.role}, nil
+	return instrumentedStmt{base: stmt, role: c.role, tenantID: c.tenantID}, nil
 }
 
 func (c instrumentedConn) Close() error {
@@ -96,7 +103,7 @@ func (c instrumentedConn) Ping(ctx context.Context) error {
 	start := time.Now()
 	err := pinger.Ping(ctx)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, c.role, "ping", start, err)
+		observeDBOperation(ctx, c.role, c.tenantID, "ping", start, err)
 	}
 	return err
 }
@@ -109,12 +116,12 @@ func (c instrumentedConn) PrepareContext(ctx context.Context, query string) (dri
 	start := time.Now()
 	stmt, err := prep.PrepareContext(ctx, query)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, c.role, "prepare", start, err)
+		observeDBOperation(ctx, c.role, c.tenantID, "prepare", start, err)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return instrumentedStmt{base: stmt, role: c.role}, nil
+	return instrumentedStmt{base: stmt, role: c.role, tenantID: c.tenantID}, nil
 }
 
 func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
@@ -122,12 +129,12 @@ func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (d
 		start := time.Now()
 		tx, err := beginner.BeginTx(ctx, opts)
 		if !errors.Is(err, driver.ErrSkip) {
-			observeDBOperation(ctx, c.role, "begin", start, err)
+			observeDBOperation(ctx, c.role, c.tenantID, "begin", start, err)
 		}
 		if err != nil {
 			return nil, err
 		}
-		return instrumentedTx{base: tx, role: c.role}, nil
+		return instrumentedTx{base: tx, role: c.role, tenantID: c.tenantID}, nil
 	}
 	if opts.Isolation != driver.IsolationLevel(0) || opts.ReadOnly {
 		return nil, fmt.Errorf("driver does not support non-default transaction options")
@@ -143,7 +150,7 @@ func (c instrumentedConn) ExecContext(ctx context.Context, query string, args []
 	start := time.Now()
 	res, err := execer.ExecContext(ctx, query, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, c.role, "exec", start, err)
+		observeDBOperation(ctx, c.role, c.tenantID, "exec", start, err)
 	}
 	return res, err
 }
@@ -156,7 +163,7 @@ func (c instrumentedConn) QueryContext(ctx context.Context, query string, args [
 	start := time.Now()
 	rows, err := queryer.QueryContext(ctx, query, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, c.role, "query", start, err)
+		observeDBOperation(ctx, c.role, c.tenantID, "query", start, err)
 	}
 	return rows, err
 }
@@ -186,8 +193,9 @@ func (c instrumentedConn) CheckNamedValue(nv *driver.NamedValue) error {
 }
 
 type instrumentedStmt struct {
-	base driver.Stmt
-	role string
+	base     driver.Stmt
+	role     string
+	tenantID string
 }
 
 func (s instrumentedStmt) Close() error {
@@ -214,7 +222,7 @@ func (s instrumentedStmt) ExecContext(ctx context.Context, args []driver.NamedVa
 	start := time.Now()
 	res, err := execer.ExecContext(ctx, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, s.role, "exec", start, err)
+		observeDBOperation(ctx, s.role, s.tenantID, "exec", start, err)
 	}
 	return res, err
 }
@@ -227,7 +235,7 @@ func (s instrumentedStmt) QueryContext(ctx context.Context, args []driver.NamedV
 	start := time.Now()
 	rows, err := queryer.QueryContext(ctx, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, s.role, "query", start, err)
+		observeDBOperation(ctx, s.role, s.tenantID, "query", start, err)
 	}
 	return rows, err
 }
@@ -241,15 +249,16 @@ func (s instrumentedStmt) CheckNamedValue(nv *driver.NamedValue) error {
 }
 
 type instrumentedTx struct {
-	base driver.Tx
-	role string
+	base     driver.Tx
+	role     string
+	tenantID string
 }
 
 func (tx instrumentedTx) Commit() error {
 	start := time.Now()
 	err := tx.base.Commit()
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(context.Background(), tx.role, "commit", start, err)
+		observeDBOperation(context.Background(), tx.role, tx.tenantID, "commit", start, err)
 	}
 	return err
 }
@@ -258,13 +267,13 @@ func (tx instrumentedTx) Rollback() error {
 	start := time.Now()
 	err := tx.base.Rollback()
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(context.Background(), tx.role, "rollback", start, err)
+		observeDBOperation(context.Background(), tx.role, tx.tenantID, "rollback", start, err)
 	}
 	return err
 }
 
-func observeDBOperation(ctx context.Context, role, operation string, start time.Time, err error) {
-	metrics.RecordDBOperation(role, operation, dbResult(err), time.Since(start))
+func observeDBOperation(ctx context.Context, role, tenantID, operation string, start time.Time, err error) {
+	metrics.RecordTenantDBOperation(role, tenantID, operation, dbResult(err), time.Since(start))
 }
 
 func dbResult(err error) string {

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -9,34 +9,99 @@ import (
 )
 
 const (
-	defaultConnMaxLifetime = 5 * time.Minute
-	defaultConnMaxIdleTime = 45 * time.Second
+	defaultMetaConnMaxLifetime       = 5 * time.Minute
+	defaultMetaConnMaxIdleTime       = 45 * time.Second
+	defaultMetaMaxOpenConns          = 100
+	defaultMetaMaxIdleConns          = 20
+	defaultUserConnMaxLifetime       = 30 * time.Second
+	defaultUserConnMaxIdleTime       = 30 * time.Second
+	defaultUserMaxOpenConns          = 4
+	defaultUserMaxIdleConns          = 1
+	defaultUserSchemaConnMaxLifetime = 1 * time.Minute
+	defaultUserSchemaConnMaxIdleTime = 10 * time.Second
+	defaultUserSchemaMaxOpenConns    = 8
+	defaultUserSchemaMaxIdleConns    = 0
 )
 
 // ApplyPoolDefaults rotates and prunes idle connections before common LB/NAT
 // idle timeout windows. It also applies configurable open/idle connection
-// limits via DRIVE9_DB_MAX_OPEN_CONNS and DRIVE9_DB_MAX_IDLE_CONNS env vars
-// (default 0 = unlimited, backward compatible). In a multi-pod deployment,
-// set these to ensure N_pods × maxOpenConns ≤ TiDB max_connections.
-func ApplyPoolDefaults(db *sql.DB) {
-	db.SetConnMaxLifetime(defaultConnMaxLifetime)
-	db.SetConnMaxIdleTime(defaultConnMaxIdleTime)
-	if v := envInt("DRIVE9_DB_MAX_OPEN_CONNS", 0); v > 0 {
+// limits via role-specific env vars.
+//
+// Supported role-specific env vars:
+//   - DRIVE9_META_DB_MAX_OPEN_CONNS / DRIVE9_META_DB_MAX_IDLE_CONNS
+//   - DRIVE9_USER_DB_MAX_OPEN_CONNS / DRIVE9_USER_DB_MAX_IDLE_CONNS
+//   - DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS / DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS
+//
+// The limits apply to each *sql.DB pool, not to all pools in the process. In a
+// multi-pod deployment, set these so pod_count * pools_per_pod * maxOpenConns
+// stays within TiDB max_connections.
+func ApplyPoolDefaults(db *sql.DB, role string) {
+	lifetime, idleTime := defaultPoolLifetime(role)
+	db.SetConnMaxLifetime(lifetime)
+	db.SetConnMaxIdleTime(idleTime)
+	maxOpen, maxIdle := defaultPoolLimits(role)
+	if v := poolEnvInt(role, "MAX_OPEN_CONNS", maxOpen); v > 0 {
 		db.SetMaxOpenConns(v)
 	}
-	if v := envInt("DRIVE9_DB_MAX_IDLE_CONNS", 0); v > 0 {
+	if v := poolEnvInt(role, "MAX_IDLE_CONNS", maxIdle); v >= 0 {
 		db.SetMaxIdleConns(v)
 	}
 }
 
-func envInt(key string, def int) int {
+func defaultPoolLifetime(role string) (time.Duration, time.Duration) {
+	switch role {
+	case RoleUser:
+		return defaultUserConnMaxLifetime, defaultUserConnMaxIdleTime
+	case RoleUserSchema:
+		return defaultUserSchemaConnMaxLifetime, defaultUserSchemaConnMaxIdleTime
+	default:
+		return defaultMetaConnMaxLifetime, defaultMetaConnMaxIdleTime
+	}
+}
+
+func defaultPoolLimits(role string) (int, int) {
+	switch role {
+	case RoleMeta:
+		return defaultMetaMaxOpenConns, defaultMetaMaxIdleConns
+	case RoleUser:
+		return defaultUserMaxOpenConns, defaultUserMaxIdleConns
+	case RoleUserSchema:
+		return defaultUserSchemaMaxOpenConns, defaultUserSchemaMaxIdleConns
+	default:
+		return 0, 0
+	}
+}
+
+func poolEnvInt(role, suffix string, def int) int {
+	if key := rolePoolEnvKey(role, suffix); key != "" {
+		if v, ok := lookupEnvInt(key); ok {
+			return v
+		}
+	}
+	return def
+}
+
+func rolePoolEnvKey(role, suffix string) string {
+	switch role {
+	case RoleMeta:
+		return "DRIVE9_META_DB_" + suffix
+	case RoleUser:
+		return "DRIVE9_USER_DB_" + suffix
+	case RoleUserSchema:
+		return "DRIVE9_USER_SCHEMA_DB_" + suffix
+	default:
+		return ""
+	}
+}
+
+func lookupEnvInt(key string) (int, bool) {
 	s := os.Getenv(key)
 	if s == "" {
-		return def
+		return 0, false
 	}
 	v, err := strconv.Atoi(s)
 	if err != nil {
-		return def
+		return 0, false
 	}
-	return v
+	return v, true
 }

--- a/pkg/mysqlutil/pool_test.go
+++ b/pkg/mysqlutil/pool_test.go
@@ -1,0 +1,88 @@
+package mysqlutil
+
+import "testing"
+
+func TestPoolEnvIntUsesRoleSpecificValue(t *testing.T) {
+	t.Setenv("DRIVE9_META_DB_MAX_OPEN_CONNS", "20")
+	t.Setenv("DRIVE9_USER_DB_MAX_OPEN_CONNS", "5")
+	t.Setenv("DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS", "2")
+
+	if got := poolEnvInt(RoleMeta, "MAX_OPEN_CONNS", 0); got != 20 {
+		t.Fatalf("meta max open = %d, want 20", got)
+	}
+	if got := poolEnvInt(RoleUser, "MAX_OPEN_CONNS", 0); got != 5 {
+		t.Fatalf("user max open = %d, want 5", got)
+	}
+	if got := poolEnvInt(RoleUserSchema, "MAX_OPEN_CONNS", 0); got != 2 {
+		t.Fatalf("user schema max open = %d, want 2", got)
+	}
+}
+
+func TestPoolEnvIntUsesDefaultWhenRoleSpecificValueUnset(t *testing.T) {
+	maxOpen, maxIdle := defaultPoolLimits(RoleMeta)
+	if got := poolEnvInt(RoleMeta, "MAX_OPEN_CONNS", maxOpen); got != defaultMetaMaxOpenConns {
+		t.Fatalf("meta max open = %d, want %d", got, defaultMetaMaxOpenConns)
+	}
+	if got := poolEnvInt(RoleMeta, "MAX_IDLE_CONNS", maxIdle); got != defaultMetaMaxIdleConns {
+		t.Fatalf("meta max idle = %d, want %d", got, defaultMetaMaxIdleConns)
+	}
+	maxOpen, maxIdle = defaultPoolLimits(RoleUser)
+	if got := poolEnvInt(RoleUser, "MAX_OPEN_CONNS", maxOpen); got != defaultUserMaxOpenConns {
+		t.Fatalf("user max open = %d, want %d", got, defaultUserMaxOpenConns)
+	}
+	if got := poolEnvInt(RoleUser, "MAX_IDLE_CONNS", maxIdle); got != defaultUserMaxIdleConns {
+		t.Fatalf("user max idle = %d, want %d", got, defaultUserMaxIdleConns)
+	}
+}
+
+func TestPoolEnvIntIgnoresInvalidRoleSpecificValue(t *testing.T) {
+	t.Setenv("DRIVE9_USER_DB_MAX_IDLE_CONNS", "bad")
+
+	if got := poolEnvInt(RoleUser, "MAX_IDLE_CONNS", defaultUserMaxIdleConns); got != defaultUserMaxIdleConns {
+		t.Fatalf("user max idle = %d, want %d", got, defaultUserMaxIdleConns)
+	}
+}
+
+func TestDefaultPoolLifetime(t *testing.T) {
+	lifetime, idleTime := defaultPoolLifetime(RoleUser)
+	if lifetime != defaultUserConnMaxLifetime {
+		t.Fatalf("user lifetime = %s, want %s", lifetime, defaultUserConnMaxLifetime)
+	}
+	if idleTime != defaultUserConnMaxIdleTime {
+		t.Fatalf("user idle time = %s, want %s", idleTime, defaultUserConnMaxIdleTime)
+	}
+
+	lifetime, idleTime = defaultPoolLifetime(RoleUserSchema)
+	if lifetime != defaultUserSchemaConnMaxLifetime {
+		t.Fatalf("user schema lifetime = %s, want %s", lifetime, defaultUserSchemaConnMaxLifetime)
+	}
+	if idleTime != defaultUserSchemaConnMaxIdleTime {
+		t.Fatalf("user schema idle time = %s, want %s", idleTime, defaultUserSchemaConnMaxIdleTime)
+	}
+}
+
+func TestDefaultPoolLimits(t *testing.T) {
+	maxOpen, maxIdle := defaultPoolLimits(RoleMeta)
+	if maxOpen != defaultMetaMaxOpenConns {
+		t.Fatalf("meta max open = %d, want %d", maxOpen, defaultMetaMaxOpenConns)
+	}
+	if maxIdle != defaultMetaMaxIdleConns {
+		t.Fatalf("meta max idle = %d, want %d", maxIdle, defaultMetaMaxIdleConns)
+	}
+
+	maxOpen, maxIdle = defaultPoolLimits(RoleUser)
+	if maxOpen != defaultUserMaxOpenConns {
+		t.Fatalf("user max open = %d, want %d", maxOpen, defaultUserMaxOpenConns)
+	}
+	if maxIdle != defaultUserMaxIdleConns {
+		t.Fatalf("user max idle = %d, want %d", maxIdle, defaultUserMaxIdleConns)
+	}
+
+	maxOpen, maxIdle = defaultPoolLimits(RoleUserSchema)
+	if maxOpen != defaultUserSchemaMaxOpenConns {
+		t.Fatalf("user schema max open = %d, want %d", maxOpen, defaultUserSchemaMaxOpenConns)
+	}
+	if maxIdle != defaultUserSchemaMaxIdleConns {
+		t.Fatalf("user schema max idle = %d, want %d", maxIdle, defaultUserSchemaMaxIdleConns)
+	}
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2126,12 +2126,7 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `drive9_db_operations_total{operation="`) || !strings.Contains(text, `role="user"`) {
 		t.Fatalf("expected user db operation metric in response: %s", text)
 	}
-	for _, line := range strings.Split(text, "\n") {
-		if strings.HasPrefix(line, "drive9_db_") && strings.Contains(line, `tenant_id="`) {
-			t.Fatalf("expected db operation metrics to avoid tenant_id labels: %s", line)
-		}
-	}
-	if !strings.Contains(text, `drive9_db_pool_registered{role="user"}`) {
+	if !strings.Contains(text, `drive9_db_pool_registered{role="user"`) {
 		t.Fatalf("expected user db pool metric in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_requests_total{action="write",result="ok",status="200",status_class="2xx",surface="fs",tenant_id="local"}`) {

--- a/pkg/server/testmain_test.go
+++ b/pkg/server/testmain_test.go
@@ -12,6 +12,13 @@ import (
 var testDSN string
 
 func TestMain(m *testing.M) {
+	_ = os.Setenv("DRIVE9_META_DB_MAX_OPEN_CONNS", "8")
+	_ = os.Setenv("DRIVE9_META_DB_MAX_IDLE_CONNS", "0")
+	_ = os.Setenv("DRIVE9_USER_DB_MAX_OPEN_CONNS", "2")
+	_ = os.Setenv("DRIVE9_USER_DB_MAX_IDLE_CONNS", "0")
+	_ = os.Setenv("DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS", "4")
+	_ = os.Setenv("DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS", "0")
+
 	inst, err := testmysql.Start(context.Background())
 	if err != nil {
 		log.Fatalf("setup mysql test instance: %v", err)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -186,6 +186,7 @@ var (
 	// full schema diff on every tenant open.
 	periodicTiDBSchemaValidationEvery uint64 = 32
 	defaultTenantPoolDrainTimeout            = 30 * time.Second
+	defaultTenantPoolMaxTenants              = 1024
 )
 
 type entry struct {
@@ -202,7 +203,7 @@ type entry struct {
 func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 	max := cfg.MaxTenants
 	if max <= 0 {
-		max = 128
+		max = defaultTenantPoolMaxTenants
 	}
 	return &Pool{
 		cfg:     cfg,
@@ -709,7 +710,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
 	openStoreStart := time.Now()
-	store, err := datastore.Open(dsn)
+	store, err := datastore.OpenForTenant(dsn, t.ID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open datastore: %w", err)
 	}

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -23,6 +23,13 @@ import (
 	"github.com/mem9-ai/drive9/pkg/tenant/schema"
 )
 
+func TestNewPoolUsesDefaultMaxTenants(t *testing.T) {
+	pool := NewPool(PoolConfig{}, nil)
+	if pool.maxSize != defaultTenantPoolMaxTenants {
+		t.Fatalf("max size = %d, want %d", pool.maxSize, defaultTenantPoolMaxTenants)
+	}
+}
+
 func TestPoolAcquireInvalidateDefersCloseUntilRelease(t *testing.T) {
 	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-a")
 	ctx := context.Background()

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -1282,7 +1282,7 @@ func OpenTiDBSchemaDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	if HasMultiStatements(dsn) {
 		return nil, fmt.Errorf("multiStatements is not allowed")
 	}
-	db, err := mysqlutil.OpenInstrumented(ctx, dsn, mysqlutil.RoleUser)
+	db, err := mysqlutil.OpenInstrumented(ctx, dsn, mysqlutil.RoleUserSchema)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- split DB pool defaults by role and tune user/user_schema/meta defaults
- pass tenant_id through bounded user DB pool/probe metrics and health probe logs
- keep hot-path DB operation metrics aggregated by role/namespace to avoid tenant_id cardinality
- add tests for role-specific pool defaults, tenant-scoped DB pool/probe metrics, probe-state cleanup, and saturated bounded-pool probes

## Operational notes
- User DB pool/probe metrics intentionally carry tenant_id for tenant attribution, bounded by DRIVE9_POOL_MAX_TENANTS per pod. With the current defaults that is 1024 tenant pools * DRIVE9_USER_DB_MAX_OPEN_CONNS=4.
- Hot-path DB operation counters/histograms intentionally do not carry tenant_id. `drive9_db_operations_total` and `drive9_db_operation_duration_seconds_*` are role-level signals; use tenant-scoped DB pool/probe alerts and logs for tenant attribution.
- DRIVE9_DB_MAX_OPEN_CONNS and DRIVE9_DB_MAX_IDLE_CONNS are intentionally removed. Operators must migrate to role-specific settings: DRIVE9_META_DB_*, DRIVE9_USER_DB_*, and DRIVE9_USER_SCHEMA_DB_*.
- Bounded DB pool saturation is not treated as DB unavailability by the health probe; it is recorded as probe result="pool_saturated" and should be covered by pool wait/saturation alerts. This applies to meta, user, and user_schema pools.
- Alert rule follow-up: tidbcloud/runbooks#2629 updates user DB operation latency/error alerts to namespace-level aggregation and keeps tenant attribution on pool/probe alerts.

## Validation
- go test ./pkg/metrics
- go test ./pkg/server -run 'TestMetricsEndpoint|TestLeaderGatedWorkersOnLoseRacesOnLead'
- go test -p 1 ./pkg/metrics ./pkg/mysqlutil ./pkg/datastore ./pkg/tenant ./pkg/server ./cmd/drive9-server
- go test -p 1 ./pkg/metrics ./pkg/mysqlutil ./pkg/tenant ./cmd/drive9-server
- go test ./pkg/metrics ./pkg/mysqlutil ./pkg/tenant ./cmd/drive9-server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tenant-aware database opening and tenant-scoped Prometheus metrics for DB health and operations (including `tenant_id` when applicable).
  * Expanded metrics labeling and health probe behavior to track state per role/tenant.
  * Updated help/usage text with additional environment variables for tenant pool and per-role DB connection pool sizing.

* **Bug Fixes**
  * Improved DB recovery/unavailable logging to include tenant context when available.

* **Refactor**
  * Connection pool defaults are now role-aware, using role-specific environment variables and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->