### PR TITLE
feat: write-back disk protection with free-ratio and byte-quota guards

### DIFF
--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -62,6 +62,8 @@ type mountFuseOptions struct {
 	UploadConcurrency       int
 	DirCacheMaxEntries      int
 	CommitQueueMaxPending   int
+	WriteCacheFreeRatio     float64
+	WriteCacheSizeMB        int64
 	ReadConcurrency         int
 	ParallelReadConcurrency int
 	ParallelReadBlockSize   int64

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -55,6 +55,8 @@ func mountFuseImpl(opts *mountFuseOptions) error {
 		UploadConcurrency:       opts.UploadConcurrency,
 		DirCacheMaxEntries:      opts.DirCacheMaxEntries,
 		CommitQueueMaxPending:   opts.CommitQueueMaxPending,
+		WriteCacheFreeRatio:     opts.WriteCacheFreeRatio,
+		WriteCacheSizeMB:        opts.WriteCacheSizeMB,
 		ReadConcurrency:         opts.ReadConcurrency,
 		ParallelReadConcurrency: opts.ParallelReadConcurrency,
 		ParallelReadBlockSize:   opts.ParallelReadBlockSize,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -154,6 +154,8 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	fs.Var(&unpackArchives, "unpack", "restore a drive9 pack archive into --local-root before mounting (repeatable)")
 	uploadConcurrency := fs.Int("upload-concurrency", 16, "maximum concurrent background uploads issued by FUSE")
 	dirCacheMaxEntries := fs.Int("dir-cache-max-entries", 200000, "maximum entries per directory in namespace cache before complete marking is disabled")
+	writeCacheFreeRatio := fs.Float64("write-cache-free-ratio", 0.10, "minimum filesystem free-space ratio before write-back refuses writes with ENOSPC (0 disables)")
+	writeCacheSizeMB := fs.Int64("write-cache-size-mb", 0, "byte quota for write-back pending data in MB (0 = disabled); writes exceeding this return ENOSPC")
 	commitQueueMaxPending := fs.Int("commit-queue-max-pending", 100, "maximum pending entries in CommitQueue before backpressure")
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
 	readOnly := fs.Bool("read-only", false, "mount as read-only")
@@ -322,6 +324,12 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	}
 	if *diskReadCacheFreeRatio <= 0 || *diskReadCacheFreeRatio >= 1 {
 		return fmt.Errorf("drive9 mount: --disk-read-cache-free-ratio must be > 0 and < 1")
+	}
+	if *writeCacheFreeRatio < 0 || *writeCacheFreeRatio >= 1 {
+		return fmt.Errorf("drive9 mount: --write-cache-free-ratio must be >= 0 and < 1")
+	}
+	if *writeCacheSizeMB < 0 {
+		return fmt.Errorf("drive9 mount: --write-cache-size-mb must be >= 0")
 	}
 	normalizedLookupRetryCount := lookupRetryCountFlagValue(lookupRetryCountGiven, *lookupRetryCount)
 	normalizedLookupRetryTimeout := durationFlagValue(fs, "lookup-retry-timeout", *lookupRetryTimeout)
@@ -525,6 +533,8 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 		UploadConcurrency:       *uploadConcurrency,
 		DirCacheMaxEntries:      *dirCacheMaxEntries,
 		CommitQueueMaxPending:   *commitQueueMaxPending,
+		WriteCacheFreeRatio:     *writeCacheFreeRatio,
+		WriteCacheSizeMB:        *writeCacheSizeMB,
 		ReadConcurrency:         *readConcurrency,
 		ParallelReadConcurrency: *parallelReadConcurrency,
 		ParallelReadBlockSize:   *parallelReadBlockSize << 20,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -331,6 +331,12 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	if *writeCacheSizeMB < 0 {
 		return fmt.Errorf("drive9 mount: --write-cache-size-mb must be >= 0")
 	}
+	// Map CLI 0 → -1 sentinel so MountOptions.setDefaults() knows the user
+	// explicitly disabled the guard rather than left it unset.
+	normalizedWriteCacheFreeRatio := *writeCacheFreeRatio
+	if normalizedWriteCacheFreeRatio == 0 {
+		normalizedWriteCacheFreeRatio = -1
+	}
 	normalizedLookupRetryCount := lookupRetryCountFlagValue(lookupRetryCountGiven, *lookupRetryCount)
 	normalizedLookupRetryTimeout := durationFlagValue(fs, "lookup-retry-timeout", *lookupRetryTimeout)
 	normalizedDirTTL := durationFlagValue(fs, "dir-ttl", *dirTTL)
@@ -533,7 +539,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 		UploadConcurrency:       *uploadConcurrency,
 		DirCacheMaxEntries:      *dirCacheMaxEntries,
 		CommitQueueMaxPending:   *commitQueueMaxPending,
-		WriteCacheFreeRatio:     *writeCacheFreeRatio,
+		WriteCacheFreeRatio:     normalizedWriteCacheFreeRatio,
 		WriteCacheSizeMB:        *writeCacheSizeMB,
 		ReadConcurrency:         *readConcurrency,
 		ParallelReadConcurrency: *parallelReadConcurrency,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -155,7 +155,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	uploadConcurrency := fs.Int("upload-concurrency", 16, "maximum concurrent background uploads issued by FUSE")
 	dirCacheMaxEntries := fs.Int("dir-cache-max-entries", 200000, "maximum entries per directory in namespace cache before complete marking is disabled")
 	writeCacheFreeRatio := fs.Float64("write-cache-free-ratio", 0.10, "minimum filesystem free-space ratio before write-back refuses writes with ENOSPC (0 disables)")
-	writeCacheSizeMB := fs.Int64("write-cache-size-mb", 0, "byte quota for write-back pending data in MB (0 = disabled); writes exceeding this return ENOSPC")
+	writeCacheSizeMB := fs.Int64("write-cache-size-mb", 0, "shadow cache byte quota in MB (0 = disabled); shadow writes exceeding this return ENOSPC")
 	commitQueueMaxPending := fs.Int("commit-queue-max-pending", 100, "maximum pending entries in CommitQueue before backpressure")
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
 	readOnly := fs.Bool("read-only", false, "mount as read-only")

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -277,7 +277,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		readFlight:        NewSingleFlight(),
 		remoteReadTimeout: fuseTimeout,
 		xattrs:            NewXAttrStore(),
-		deletedPaths:     make(map[string]time.Time),
+		deletedPaths:      make(map[string]time.Time),
 	}
 }
 
@@ -2925,7 +2925,12 @@ func (fs *Dat9FS) snapshotWriteBackLocked(fh *FileHandle) error {
 		return syscall.ENOTSUP
 	}
 
-	// Write-back disk protection: check quota before writing snapshot.
+	// Write-back disk protection: best-effort quota pre-check before writing
+	// the snapshot to the writeBack cache directory. This uses shadowStore's
+	// quota config (same partition in typical deployments) as a proxy for the
+	// writeBack dir. All callers treat ENOSPC as degraded (fallback to sync
+	// upload), so the check is advisory — it prevents filling the disk when
+	// possible but does not guarantee hard enforcement.
 	if fs.shadowStore != nil {
 		if err := fs.shadowStore.CheckWriteBackQuota(fh.Dirty.Size()); err != nil {
 			return err
@@ -10116,13 +10121,19 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 	}
 	written = n
 
-	// Non-ShadowSpill: write-through to shadow after Dirty (best-effort).
+	// Non-ShadowSpill: write-through to shadow after Dirty (best-effort for
+	// I/O errors, but ENOSPC from quota guard is propagated to the caller so
+	// write-back disk protection is enforced).
 	if !fh.ShadowSpill && fh.ShadowReady && fs.shadowStore != nil {
 		shadowStart := time.Now()
 		unlockShadowWrite := fs.lockHandleRemoteCommitPathLocked(fh)
 		_, err := fs.shadowStore.WriteAt(fh.Path, writeOffset, data, fh.BaseRev)
 		unlockShadowWrite()
 		if err != nil {
+			if errors.Is(err, syscall.ENOSPC) {
+				source = "shadow-through-nospace"
+				return 0, gofuse.Status(syscall.ENOSPC)
+			}
 			log.Printf("shadow write-through failed for %s: %v", fh.Path, err)
 			fs.shadowStore.Remove(fh.Path)
 			fh.ShadowReady = false

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2849,9 +2849,6 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 		fh.ShadowReady = true
 	}
 
-	// Track pending bytes for byte quota enforcement.
-	fs.shadowStore.AddPendingBytes(size)
-
 	if durable {
 		if err := fs.shadowStore.Sync(fh.Path); err != nil {
 			return err
@@ -12519,10 +12516,6 @@ func (fs *Dat9FS) onWriteBackUploadSuccess(meta WriteBackMeta, committedRev int6
 func (fs *Dat9FS) onCommitQueueCleanup(entry *CommitEntry) {
 	if entry == nil || entry.Inode == 0 {
 		return
-	}
-	// Release pending byte quota after successful commit cleanup.
-	if fs.shadowStore != nil && entry.Size > 0 {
-		fs.shadowStore.SubPendingBytes(entry.Size)
 	}
 	fs.clearRemovedCommittedShadowForOpenHandles(entry.Path, fs.latestCommittedRevision(entry.Path), entry.Size)
 	fs.cleanupCommittedInode(entry.Inode, entry.Path)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2833,11 +2833,6 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 
 	size := fh.Dirty.Size()
 
-	// Write-back disk protection: check quota before writing shadow.
-	if err := fs.shadowStore.CheckWriteBackQuota(size); err != nil {
-		return err
-	}
-
 	if fh.ShadowReady && fh.ShadowSpill {
 		if err := fs.shadowStore.Truncate(fh.Path, size, fh.BaseRev); err != nil {
 			return err
@@ -10095,15 +10090,15 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 	// EIO without touching Dirty — OnPartFull may evict the part, so writing
 	// Dirty first could lose data if shadow then fails.
 	if fh.ShadowSpill && fh.ShadowReady && fs.shadowStore != nil {
-		if err := fs.shadowStore.CheckWriteBackQuotaThrottled(int64(len(data))); err != nil {
-			source = "shadow-spill-nospace"
-			return 0, gofuse.Status(syscall.ENOSPC)
-		}
 		shadowStart := time.Now()
 		unlockShadowWrite := fs.lockHandleRemoteCommitPathLocked(fh)
 		_, err := fs.shadowStore.WriteAt(fh.Path, writeOffset, data, fh.BaseRev)
 		unlockShadowWrite()
 		if err != nil {
+			if errors.Is(err, syscall.ENOSPC) {
+				source = "shadow-spill-nospace"
+				return 0, gofuse.Status(syscall.ENOSPC)
+			}
 			log.Printf("shadow write failed for ShadowSpill %s: %v", fh.Path, err)
 			source = "shadow-spill-error"
 			return 0, gofuse.EIO

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2832,6 +2832,12 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 	fs.adoptCommittedRevisionLocked(fh)
 
 	size := fh.Dirty.Size()
+
+	// Write-back disk protection: check quota before writing shadow.
+	if err := fs.shadowStore.CheckWriteBackQuota(size); err != nil {
+		return err
+	}
+
 	if fh.ShadowReady && fh.ShadowSpill {
 		if err := fs.shadowStore.Truncate(fh.Path, size, fh.BaseRev); err != nil {
 			return err
@@ -2842,6 +2848,9 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 		}
 		fh.ShadowReady = true
 	}
+
+	// Track pending bytes for byte quota enforcement.
+	fs.shadowStore.AddPendingBytes(size)
 
 	if durable {
 		if err := fs.shadowStore.Sync(fh.Path); err != nil {
@@ -2923,6 +2932,14 @@ func (fs *Dat9FS) snapshotWriteBackLocked(fh *FileHandle) error {
 	if !fh.ShadowReady && !fh.IsNew && !fh.Dirty.CanMaterializeFull() {
 		return syscall.ENOTSUP
 	}
+
+	// Write-back disk protection: check quota before writing snapshot.
+	if fs.shadowStore != nil {
+		if err := fs.shadowStore.CheckWriteBackQuota(fh.Dirty.Size()); err != nil {
+			return err
+		}
+	}
+
 	mode, hasMode := fs.modeForPendingHandle(fh)
 
 	bvStart := time.Now()
@@ -10081,8 +10098,7 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 	// EIO without touching Dirty — OnPartFull may evict the part, so writing
 	// Dirty first could lose data if shadow then fails.
 	if fh.ShadowSpill && fh.ShadowReady && fs.shadowStore != nil {
-		if !fs.shadowStore.CheckDiskSpaceThrottled() {
-			log.Printf("shadow write rejected for %s: disk space below watermark", fh.Path)
+		if err := fs.shadowStore.CheckWriteBackQuotaThrottled(int64(len(data))); err != nil {
 			source = "shadow-spill-nospace"
 			return 0, gofuse.Status(syscall.ENOSPC)
 		}
@@ -12503,6 +12519,10 @@ func (fs *Dat9FS) onWriteBackUploadSuccess(meta WriteBackMeta, committedRev int6
 func (fs *Dat9FS) onCommitQueueCleanup(entry *CommitEntry) {
 	if entry == nil || entry.Inode == 0 {
 		return
+	}
+	// Release pending byte quota after successful commit cleanup.
+	if fs.shadowStore != nil && entry.Size > 0 {
+		fs.shadowStore.SubPendingBytes(entry.Size)
 	}
 	fs.clearRemovedCommittedShadowForOpenHandles(entry.Path, fs.latestCommittedRevision(entry.Path), entry.Size)
 	fs.cleanupCommittedInode(entry.Inode, entry.Path)

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -58,7 +58,7 @@ type MountOptions struct {
 	RemoteOnlyPatterns      []string      // remote-persistent override path patterns for overlay-profile mounts
 	PackPaths               []string      // local overlay paths auto-packed after unmount
 	CommitQueueMaxPending   int           // maximum pending entries in CommitQueue before backpressure (default 100); 0 uses default
-	WriteCacheFreeRatio     float64       // minimum free-space ratio on cache-dir partition before write-back refuses writes (default 0.10); 0 disables
+	WriteCacheFreeRatio     float64       // minimum free-space ratio on cache-dir partition before write-back refuses writes (default 0.10); negative disables
 	WriteCacheSizeMB        int64         // byte quota for write-back pending data in MB (default 0 = disabled); when set, writes exceeding this return ENOSPC
 	UploadConcurrency       int           // number of background upload workers (default 4)
 	ReadConcurrency         int           // maximum concurrent backend reads issued by FUSE (default 24)
@@ -138,6 +138,12 @@ func (o *MountOptions) setDefaults() {
 	}
 	if o.ParallelReadBlockSize <= 0 {
 		o.ParallelReadBlockSize = defaultParallelReadBlockSize
+	}
+	if o.WriteCacheFreeRatio < 0 {
+		// Negative values explicitly disable the write-back free-ratio guard.
+		o.WriteCacheFreeRatio = 0
+	} else if o.WriteCacheFreeRatio == 0 {
+		o.WriteCacheFreeRatio = defaultWriteCacheFreeRatio
 	}
 	if o.LookupRetryCount < 0 {
 		// Negative values are CLI-internal sentinels meaning retries were

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -59,7 +59,7 @@ type MountOptions struct {
 	PackPaths               []string      // local overlay paths auto-packed after unmount
 	CommitQueueMaxPending   int           // maximum pending entries in CommitQueue before backpressure (default 100); 0 uses default
 	WriteCacheFreeRatio     float64       // minimum free-space ratio on cache-dir partition before write-back refuses writes (default 0.10); negative disables
-	WriteCacheSizeMB        int64         // byte quota for write-back pending data in MB (default 0 = disabled); when set, writes exceeding this return ENOSPC
+	WriteCacheSizeMB        int64         // shadow cache byte quota in MB (default 0 = disabled); shadow writes exceeding this return ENOSPC
 	UploadConcurrency       int           // number of background upload workers (default 4)
 	ReadConcurrency         int           // maximum concurrent backend reads issued by FUSE (default 24)
 	ParallelReadConcurrency int           // maximum concurrent block reads for one large FUSE read (default 4)

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -58,6 +58,8 @@ type MountOptions struct {
 	RemoteOnlyPatterns      []string      // remote-persistent override path patterns for overlay-profile mounts
 	PackPaths               []string      // local overlay paths auto-packed after unmount
 	CommitQueueMaxPending   int           // maximum pending entries in CommitQueue before backpressure (default 100); 0 uses default
+	WriteCacheFreeRatio     float64       // minimum free-space ratio on cache-dir partition before write-back refuses writes (default 0.10); 0 disables
+	WriteCacheSizeMB        int64         // byte quota for write-back pending data in MB (default 0 = disabled); when set, writes exceeding this return ENOSPC
 	UploadConcurrency       int           // number of background upload workers (default 4)
 	ReadConcurrency         int           // maximum concurrent backend reads issued by FUSE (default 24)
 	ParallelReadConcurrency int           // maximum concurrent block reads for one large FUSE read (default 4)
@@ -357,8 +359,12 @@ func Mount(opts *MountOptions) error {
 				dat9fs.pendingIndex = pendingIdx
 			}
 
-			// Initialize ShadowStore.
-			shadowStore, err := NewShadowStore(shadowDir)
+			// Initialize ShadowStore with write-back disk protection.
+			var writeCacheMaxBytes int64
+			if opts.WriteCacheSizeMB > 0 {
+				writeCacheMaxBytes = opts.WriteCacheSizeMB << 20
+			}
+			shadowStore, err := NewShadowStoreWithQuota(shadowDir, opts.WriteCacheFreeRatio, writeCacheMaxBytes)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "drive9: shadow store init failed: %v (continuing without)\n", err)
 			} else {
@@ -418,6 +424,7 @@ func Mount(opts *MountOptions) error {
 				cq.OnCleanup = dat9fs.onCommitQueueCleanup
 				cq.PathLock = dat9fs.lockRemoteCommitPath
 				cq.RecoverPending()
+				shadowStore.RecoverPendingBytes()
 				if opts.LayerRef != "" {
 					if err := restoreLayerEntries(context.Background(), c, opts, shadowStore, pendingIdx, dat9fs); err != nil {
 						return fmt.Errorf("mount: restore fs layer entries: %w", err)

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -74,9 +74,9 @@ type ShadowStore struct {
 	pendingBytes        atomic.Int64 // current shadow bytes on disk; updated internally by write/remove methods
 
 	// Throttled disk space check state (atomic for lock-free fast path).
-	lastDiskCheck  atomic.Int64 // unix nano of last check
-	diskOK         atomic.Bool  // cached result of last check
-	cachedFreeBytes atomic.Int64 // cached Statfs free bytes (Bavail*Bsize)
+	lastDiskCheck    atomic.Int64 // unix nano of last check
+	diskOK           atomic.Bool  // cached result of last check
+	cachedFreeBytes  atomic.Int64 // cached Statfs free bytes (Bavail*Bsize)
 	cachedTotalBytes atomic.Int64 // cached Statfs total bytes (Blocks*Bsize)
 }
 

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -78,10 +78,6 @@ type ShadowStore struct {
 	cachedFreeBytes  atomic.Int64 // cached Statfs free bytes (Bavail*Bsize)
 	cachedTotalBytes atomic.Int64 // cached Statfs total bytes (Blocks*Bsize)
 
-	// supersededFds holds old file descriptors replaced by WriteStream.
-	// They are kept open so concurrent readers that grabbed the fd before
-	// the swap don't hit EBADF. Drained on Close.
-	supersededFds []*os.File
 }
 
 // NewShadowStore creates a ShadowStore rooted at dir.
@@ -491,9 +487,10 @@ func (s *ShadowStore) checkFreeRatioThrottled(requiredBytes int64) error {
 // Statfs values). On quota breach the temp file is removed and the original
 // shadow is untouched.
 //
-// Concurrency note: WriteStream swaps sf.fd under s.mu. The old fd is kept
-// open in supersededFds (not closed) so concurrent readers that grabbed it
-// before the swap don't hit EBADF. Superseded fds are closed on Close().
+// Concurrency note: WriteStream swaps sf.fd under full Lock and closes the
+// old fd after releasing the lock. This is safe because ReadAt/ReadAll
+// perform the actual fd.ReadAt call under RLock, so no concurrent reader
+// can be using the old fd when WriteStream releases Lock.
 func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64) (int64, error) {
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
@@ -549,13 +546,11 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 	sf.fd = newFd
 	sf.size = n
 	sf.baseRev = baseRev
-	// Keep oldFd open so concurrent readers that grabbed it before the swap
-	// don't hit EBADF. The fd is appended to supersededFds and closed when
-	// the ShadowStore is closed.
-	if oldFd != nil {
-		s.supersededFds = append(s.supersededFds, oldFd)
-	}
 	s.mu.Unlock()
+	// Safe to close: ReadAt/ReadAll hold RLock during the actual fd.ReadAt
+	// call, and WriteStream holds full Lock during the swap, so no concurrent
+	// reader can be using oldFd after we release Lock.
+	_ = oldFd.Close()
 	s.pendingBytes.Add(delta)
 	return n, nil
 }
@@ -715,61 +710,65 @@ func (s *ShadowStore) SizeGen(gen uint64) int64 {
 
 // ReadAt reads from a shadow file at the given offset. Uses pread for
 // efficient partial reads without seeking.
+// The read is performed under RLock to prevent WriteStream from closing the
+// fd mid-read (pread is safe under RLock as it doesn't modify fd state).
 func (s *ShadowStore) ReadAt(remotePath string, offset int64, buf []byte) (int, error) {
 	s.mu.RLock()
 	sf, ok := s.files[remotePath]
+	if ok {
+		n, err := sf.fd.ReadAt(buf, offset)
+		s.mu.RUnlock()
+		return n, err
+	}
 	s.mu.RUnlock()
 
-	if !ok {
-		// Not in memory — try opening from disk.
-		sp := s.shadowPath(remotePath)
-		fd, err := os.Open(sp)
-		if err != nil {
-			return 0, fmt.Errorf("shadow file not found: %s", remotePath)
-		}
-		s.mu.Lock()
-		// Re-check after acquiring write lock.
-		if existingSf, exists := s.files[remotePath]; exists {
-			_ = fd.Close()
-			sf = existingSf
-		} else {
-			fi, err := fd.Stat()
-			if err != nil {
-				_ = fd.Close()
-				s.mu.Unlock()
-				return 0, fmt.Errorf("shadow stat: %w", err)
-			}
-			sf = &ShadowFile{fd: fd, size: fi.Size()}
-			s.files[remotePath] = sf
-		}
-		s.mu.Unlock()
+	// Not in memory — try opening from disk.
+	sp := s.shadowPath(remotePath)
+	fd, err := os.Open(sp)
+	if err != nil {
+		return 0, fmt.Errorf("shadow file not found: %s", remotePath)
 	}
-
-	return sf.fd.ReadAt(buf, offset)
+	s.mu.Lock()
+	// Re-check after acquiring write lock.
+	if existingSf, exists := s.files[remotePath]; exists {
+		_ = fd.Close()
+		sf = existingSf
+	} else {
+		fi, err := fd.Stat()
+		if err != nil {
+			_ = fd.Close()
+			s.mu.Unlock()
+			return 0, fmt.Errorf("shadow stat: %w", err)
+		}
+		sf = &ShadowFile{fd: fd, size: fi.Size()}
+		s.files[remotePath] = sf
+	}
+	// Perform read under lock so fd stays valid.
+	n, readErr := sf.fd.ReadAt(buf, offset)
+	s.mu.Unlock()
+	return n, readErr
 }
 
 // ReadAll reads the entire shadow file for the given path.
+// The read is performed under RLock to prevent WriteStream from closing the
+// fd mid-read.
 func (s *ShadowStore) ReadAll(remotePath string) ([]byte, error) {
 	s.mu.RLock()
 	sf, ok := s.files[remotePath]
-	var size int64
 	if ok {
-		size = sf.size
+		data := make([]byte, sf.size)
+		_, err := sf.fd.ReadAt(data, 0)
+		s.mu.RUnlock()
+		if err != nil {
+			return nil, err
+		}
+		return data, nil
 	}
 	s.mu.RUnlock()
 
-	if !ok {
-		// Try reading from disk.
-		sp := s.shadowPath(remotePath)
-		return os.ReadFile(sp)
-	}
-
-	data := make([]byte, size)
-	_, err := sf.fd.ReadAt(data, 0)
-	if err != nil {
-		return nil, err
-	}
-	return data, nil
+	// Try reading from disk.
+	sp := s.shadowPath(remotePath)
+	return os.ReadFile(sp)
 }
 
 // Open opens the current shadow file for remotePath for streaming reads.
@@ -1057,8 +1056,7 @@ func (s *ShadowStore) Has(remotePath string) bool {
 	return err == nil
 }
 
-// Close closes all open shadow file descriptors, including superseded fds
-// kept alive for concurrent reader safety.
+// Close closes all open shadow file descriptors.
 func (s *ShadowStore) Close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1069,15 +1067,11 @@ func (s *ShadowStore) Close() {
 	for _, rt := range s.retired {
 		_ = rt.fd.Close()
 	}
-	for _, fd := range s.supersededFds {
-		_ = fd.Close()
-	}
 	s.files = make(map[string]*ShadowFile)
 	s.active = make(map[string]uint64)
 	s.genFile = make(map[uint64]*ShadowFile)
 	s.refs = make(map[uint64]int32)
 	s.retired = make(map[uint64]*retiredShadow)
-	s.supersededFds = nil
 }
 
 // RecoverFromDisk scans the shadow directory and loads shadow files into memory.

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -303,6 +303,14 @@ func (s *ShadowStore) Ensure(remotePath string, size int64, baseRev int64) error
 		return err
 	}
 
+	s.mu.RLock()
+	oldSize := sf.size
+	s.mu.RUnlock()
+	delta := size - oldSize
+	if err := s.checkQuotaForDelta(delta); err != nil {
+		return err
+	}
+
 	s.mu.Lock()
 	if err := sf.fd.Truncate(size); err != nil {
 		s.mu.Unlock()
@@ -313,6 +321,7 @@ func (s *ShadowStore) Ensure(remotePath string, size int64, baseRev int64) error
 		sf.baseRev = baseRev
 	}
 	s.mu.Unlock()
+	s.pendingBytes.Add(delta)
 	return nil
 }
 

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -75,7 +75,6 @@ type ShadowStore struct {
 
 	// Throttled disk space check state (atomic for lock-free fast path).
 	lastDiskCheck    atomic.Int64 // unix nano of last check
-	diskOK           atomic.Bool  // cached result of last check
 	cachedFreeBytes  atomic.Int64 // cached Statfs free bytes (Bavail*Bsize)
 	cachedTotalBytes atomic.Int64 // cached Statfs total bytes (Blocks*Bsize)
 }
@@ -113,7 +112,6 @@ func NewShadowStoreWithQuota(dir string, freeRatio float64, maxBytes int64) (*Sh
 		writeCacheFreeRatio: freeRatio,
 		writeCacheMaxBytes:  maxBytes,
 	}
-	ss.diskOK.Store(true)
 	return ss, nil
 }
 
@@ -138,6 +136,11 @@ func (s *ShadowStore) CheckWriteBackQuota(requiredBytes int64) error {
 }
 
 // checkByteQuota checks the byte quota only (cheap, no syscall).
+// Note: this is a best-effort soft limit. The check is not serialized with
+// pendingBytes.Add, so two concurrent writers on different paths may both
+// pass the check and then both Add, briefly exceeding the quota. This is
+// acceptable because the quota is a safety margin, not a hard guarantee,
+// and the overshoot is bounded by the size of a single write.
 func (s *ShadowStore) checkByteQuota(requiredBytes int64) error {
 	if s.writeCacheMaxBytes > 0 {
 		currentPending := s.pendingBytes.Load()
@@ -183,14 +186,13 @@ func (s *ShadowStore) evalFreeRatio(freeBytes, totalBytes, requiredBytes int64) 
 
 // checkQuotaForDelta checks both byte quota and free-ratio for a shadow write
 // that will change disk usage by delta bytes. Called internally before shadow
-// writes. If delta <= 0 (shrink or no change), only free-ratio is checked.
+// writes. If delta <= 0 (shrink or no change), the check is skipped entirely
+// because shrinks never consume additional disk space.
 func (s *ShadowStore) checkQuotaForDelta(delta int64) error {
 	if delta > 0 {
 		if err := s.checkByteQuota(delta); err != nil {
 			return err
 		}
-	}
-	if delta > 0 {
 		return s.checkFreeRatio(delta)
 	}
 	return nil
@@ -407,9 +409,8 @@ const quotaCopyBufSize = 32 << 10 // 32KB
 // alongside the growing temp file, so peak disk usage is oldSize + tempSize.
 // Both checks use the full temp size (written+nr) as required bytes.
 // The byte quota check runs on every chunk (cheap atomic load). The
-// free-ratio check is throttled via the same diskOK/lastDiskCheck mechanism
-// used by CheckWriteBackQuotaThrottled, so Statfs runs at most once per
-// diskCheckInterval.
+// free-ratio check is throttled via checkFreeRatioThrottled (Statfs cached
+// for diskCheckInterval, re-evaluated against current requiredBytes).
 func (s *ShadowStore) quotaCopy(dst io.Writer, r io.Reader, oldSize int64) (int64, error) {
 	buf := make([]byte, quotaCopyBufSize)
 	var written int64
@@ -467,9 +468,7 @@ func (s *ShadowStore) checkFreeRatioThrottled(requiredBytes int64) error {
 		return nil
 	}
 	if s.lastDiskCheck.CompareAndSwap(last, now) {
-		err := s.checkFreeRatio(requiredBytes)
-		s.diskOK.Store(err == nil)
-		return err
+		return s.checkFreeRatio(requiredBytes)
 	}
 	// CAS loser: use cached capacity values.
 	freeBytes := s.cachedFreeBytes.Load()
@@ -483,9 +482,16 @@ func (s *ShadowStore) checkFreeRatioThrottled(requiredBytes int64) error {
 // WriteStream replaces the shadow contents by streaming from r.
 // Returns ENOSPC if the streamed data would breach disk protection limits.
 // Both byte quota and free-ratio are checked incrementally during streaming
-// via quotaCopy (byte quota every chunk, free-ratio throttled via diskOK).
-// On quota breach the temp file is removed and the original shadow is
-// untouched.
+// via quotaCopy (byte quota every chunk, free-ratio throttled via cached
+// Statfs values). On quota breach the temp file is removed and the original
+// shadow is untouched.
+//
+// Concurrency note: WriteStream swaps sf.fd under s.mu and closes the old fd
+// after releasing the lock. Callers that read the same path concurrently
+// should use Pin/ReadAtGen (generation-pinned reads) rather than ReadAt to
+// avoid a use-after-close race on the fd. All current callers hold the file
+// handle lock during WriteStream, so concurrent unpinned ReadAt on the same
+// path does not occur in practice.
 func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64) (int64, error) {
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
@@ -968,24 +974,32 @@ func (s *ShadowStore) Remove(remotePath string) {
 	_ = os.Remove(sp)
 }
 
-// Rename moves a shadow file from oldPath to newPath.
+// Rename moves a shadow file from oldPath to newPath. If a shadow already
+// exists at newPath, it is replaced and its size is subtracted from
+// pendingBytes (the replacement shadow's disk file is overwritten by the
+// os.Rename).
 func (s *ShadowStore) Rename(oldPath, newPath string) bool {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 
 	sf, ok := s.files[oldPath]
 	if !ok {
+		s.mu.Unlock()
 		return false
 	}
 
 	oldSP := s.shadowPath(oldPath)
 	newSP := s.shadowPath(newPath)
 	if err := os.Rename(oldSP, newSP); err != nil {
+		s.mu.Unlock()
 		return false
 	}
 
 	replacedSF := s.files[newPath]
 	replacedGen := s.active[newPath]
+	var replacedSize int64
+	if replacedSF != nil {
+		replacedSize = replacedSF.size
+	}
 
 	delete(s.files, oldPath)
 	s.files[newPath] = sf
@@ -1012,6 +1026,12 @@ func (s *ShadowStore) Rename(oldPath, newPath string) bool {
 		}
 	} else if replacedSF != nil && replacedSF != sf {
 		_ = replacedSF.fd.Close()
+	}
+	s.mu.Unlock()
+
+	// Adjust pendingBytes: the replaced shadow's disk file is gone.
+	if replacedSize > 0 {
+		s.pendingBytes.Add(-replacedSize)
 	}
 	return true
 }

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -1,6 +1,7 @@
 package fuse
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -95,7 +96,7 @@ func NewShadowStoreWithQuota(dir string, freeRatio float64, maxBytes int64) (*Sh
 	// nothing else ever deletes these files.
 	if entries, err := os.ReadDir(dir); err == nil {
 		for _, e := range entries {
-			if strings.Contains(e.Name(), ".shadow.retired.") {
+			if strings.Contains(e.Name(), ".shadow.retired.") || strings.HasSuffix(e.Name(), ".shadow.tmp") {
 				_ = os.Remove(filepath.Join(dir, e.Name()))
 			}
 		}
@@ -406,11 +407,50 @@ func (s *ShadowStore) WriteFull(remotePath string, data []byte, baseRev int64) e
 	return nil
 }
 
+// quotaCopyBufSize is the chunk size for quota-aware streaming copies.
+const quotaCopyBufSize = 32 << 10 // 32KB
+
+// quotaCopy copies from r to dst, checking the byte quota after each chunk.
+// oldSize is the current shadow size used to compute the delta. Returns the
+// total bytes written and ENOSPC if the byte quota is breached mid-stream.
+func (s *ShadowStore) quotaCopy(dst io.Writer, r io.Reader, oldSize int64) (int64, error) {
+	buf := make([]byte, quotaCopyBufSize)
+	var written int64
+	for {
+		nr, readErr := r.Read(buf)
+		if nr > 0 {
+			// Check byte quota based on cumulative delta before writing.
+			delta := (written + int64(nr)) - oldSize
+			if delta > 0 {
+				if err := s.checkByteQuota(delta); err != nil {
+					return written, err
+				}
+			}
+			nw, writeErr := dst.Write(buf[:nr])
+			written += int64(nw)
+			if writeErr != nil {
+				return written, writeErr
+			}
+			if nw != nr {
+				return written, io.ErrShortWrite
+			}
+		}
+		if readErr != nil {
+			if readErr == io.EOF {
+				return written, nil
+			}
+			return written, readErr
+		}
+	}
+}
+
 // WriteStream replaces the shadow contents by streaming from r.
 // Returns ENOSPC if the streamed data would breach disk protection limits.
-// Because the final size is unknown before streaming, the data is streamed
-// to a temp file first; on quota breach the temp file is removed and the
-// original shadow is untouched.
+// The byte quota is checked incrementally during streaming so that peak disk
+// usage of the temp file is bounded by the quota. The free-ratio check runs
+// once after streaming completes (Statfs per chunk would be too expensive).
+// On quota breach the temp file is removed and the original shadow is
+// untouched.
 func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64) (int64, error) {
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
@@ -427,24 +467,30 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 	if err != nil {
 		return 0, fmt.Errorf("shadow stream tmp create: %w", err)
 	}
-	n, err := io.Copy(tmpFd, r)
+
+	// Use a quota-aware copy: check byte quota every 32KB so the temp file
+	// never grows far beyond the quota limit.
+	n, err := s.quotaCopy(tmpFd, r, oldSize)
 	if err != nil {
-		tmpFd.Close()
-		os.Remove(tmpPath)
+		_ = tmpFd.Close()
+		_ = os.Remove(tmpPath)
+		if errors.Is(err, syscall.ENOSPC) {
+			return 0, err
+		}
 		return n, fmt.Errorf("shadow write stream: %w", err)
 	}
 	if err := tmpFd.Sync(); err != nil {
-		tmpFd.Close()
-		os.Remove(tmpPath)
+		_ = tmpFd.Close()
+		_ = os.Remove(tmpPath)
 		return n, fmt.Errorf("shadow stream sync: %w", err)
 	}
-	tmpFd.Close()
+	_ = tmpFd.Close()
 
-	// Post-stream quota check before committing.
+	// Post-stream free-ratio check (Statfs is too expensive to run per chunk).
 	delta := n - oldSize
 	if delta > 0 {
-		if err := s.checkQuotaForDelta(delta); err != nil {
-			os.Remove(tmpPath)
+		if err := s.checkFreeRatio(delta); err != nil {
+			_ = os.Remove(tmpPath)
 			return 0, err
 		}
 	}
@@ -452,7 +498,7 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 	// Commit: swap temp file over the shadow file.
 	shadowFile := s.shadowPath(remotePath)
 	if err := os.Rename(tmpPath, shadowFile); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return 0, fmt.Errorf("shadow stream rename: %w", err)
 	}
 
@@ -468,7 +514,7 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 	sf.size = n
 	sf.baseRev = baseRev
 	s.mu.Unlock()
-	oldFd.Close()
+	_ = oldFd.Close()
 	s.pendingBytes.Add(delta)
 	return n, nil
 }

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -122,14 +122,20 @@ func (s *ShadowStore) shadowPath(remotePath string) string {
 // CheckWriteBackQuota checks whether a write of requiredBytes would violate
 // the write-back disk protection policy. Returns nil if the write is allowed,
 // or syscall.ENOSPC if it would breach either the free-space ratio or the
-// byte quota. The check is atomic: it predicts the post-write state and
-// rejects before any bytes are written.
+// byte quota.
 //
-// This is the single guard checkpoint for all write-back local disk writes
-// (shadow, pending, journal). Callers should invoke this before creating or
-// extending shadow files.
+// For external callers (non-shadow write paths like WriteBackCache snapshots),
+// requiredBytes is the full write size. For internal shadow writes, the
+// ShadowStore methods call checkQuotaForDelta with the actual delta.
 func (s *ShadowStore) CheckWriteBackQuota(requiredBytes int64) error {
-	// Check 1: byte quota (if enabled).
+	if err := s.checkByteQuota(requiredBytes); err != nil {
+		return err
+	}
+	return s.checkFreeRatio(requiredBytes)
+}
+
+// checkByteQuota checks the byte quota only (cheap, no syscall).
+func (s *ShadowStore) checkByteQuota(requiredBytes int64) error {
 	if s.writeCacheMaxBytes > 0 {
 		currentPending := s.pendingBytes.Load()
 		if currentPending+requiredBytes > s.writeCacheMaxBytes {
@@ -138,8 +144,11 @@ func (s *ShadowStore) CheckWriteBackQuota(requiredBytes int64) error {
 			return syscall.ENOSPC
 		}
 	}
+	return nil
+}
 
-	// Check 2: free-space ratio (if enabled).
+// checkFreeRatio checks the free-space ratio (requires Statfs syscall).
+func (s *ShadowStore) checkFreeRatio(requiredBytes int64) error {
 	if s.writeCacheFreeRatio > 0 {
 		var stat syscall.Statfs_t
 		if err := syscall.Statfs(s.dir, &stat); err == nil {
@@ -157,43 +166,50 @@ func (s *ShadowStore) CheckWriteBackQuota(requiredBytes int64) error {
 		}
 		// If Statfs fails, allow the write (cannot check).
 	}
-
 	return nil
 }
 
-// CheckWriteBackQuotaThrottled is a throttled version of CheckWriteBackQuota
-// that caches the result for diskCheckInterval. Safe for hot-path use.
-// requiredBytes is used for the actual Statfs check but the cached result
-// applies to all callers during the throttle window.
+// checkQuotaForDelta checks both byte quota and free-ratio for a shadow write
+// that will change disk usage by delta bytes. Called internally before shadow
+// writes. If delta <= 0 (shrink or no change), only free-ratio is checked.
+func (s *ShadowStore) checkQuotaForDelta(delta int64) error {
+	if delta > 0 {
+		if err := s.checkByteQuota(delta); err != nil {
+			return err
+		}
+	}
+	if delta > 0 {
+		return s.checkFreeRatio(delta)
+	}
+	return nil
+}
+
+// CheckWriteBackQuotaThrottled is a throttled version of CheckWriteBackQuota.
+// The Statfs result is cached for diskCheckInterval; the byte quota check
+// always runs fresh (it is cheap — just an atomic load).
 func (s *ShadowStore) CheckWriteBackQuotaThrottled(requiredBytes int64) error {
+	// Byte quota check always runs (cheap, no syscall).
+	if err := s.checkByteQuota(requiredBytes); err != nil {
+		return err
+	}
+
+	// Free-ratio check is throttled via CAS.
 	now := time.Now().UnixNano()
 	last := s.lastDiskCheck.Load()
 	if now-last < int64(diskCheckInterval) {
 		if !s.diskOK.Load() {
 			return syscall.ENOSPC
 		}
-		// Cached OK but still check byte quota (cheap, no syscall).
-		if s.writeCacheMaxBytes > 0 {
-			if s.pendingBytes.Load()+requiredBytes > s.writeCacheMaxBytes {
-				return syscall.ENOSPC
-			}
-		}
 		return nil
 	}
-	// CAS to avoid concurrent syscalls.
 	if s.lastDiskCheck.CompareAndSwap(last, now) {
-		err := s.CheckWriteBackQuota(requiredBytes)
+		err := s.checkFreeRatio(requiredBytes)
 		s.diskOK.Store(err == nil)
 		return err
 	}
+	// CAS loser: use cached Statfs result.
 	if !s.diskOK.Load() {
 		return syscall.ENOSPC
-	}
-	// CAS loser: still check byte quota (cheap, no syscall).
-	if s.writeCacheMaxBytes > 0 {
-		if s.pendingBytes.Load()+requiredBytes > s.writeCacheMaxBytes {
-			return syscall.ENOSPC
-		}
 	}
 	return nil
 }
@@ -308,34 +324,56 @@ func (s *ShadowStore) WriteAt(remotePath string, offset int64, data []byte, base
 		return 0, err
 	}
 
+	// Pre-check: estimate growth delta.
+	end := offset + int64(len(data))
+	s.mu.RLock()
+	oldSize := sf.size
+	s.mu.RUnlock()
+	if delta := end - oldSize; delta > 0 {
+		if err := s.checkQuotaForDelta(delta); err != nil {
+			return 0, err
+		}
+	}
+
 	n, err := sf.fd.WriteAt(data, offset)
 	if err != nil {
 		return n, fmt.Errorf("shadow write at %d: %w", offset, err)
 	}
 
-	end := offset + int64(n)
+	actualEnd := offset + int64(n)
 	s.mu.Lock()
-	oldSize := sf.size
-	if end > sf.size {
-		sf.size = end
+	prevSize := sf.size
+	if actualEnd > sf.size {
+		sf.size = actualEnd
 	}
 	if baseRev != 0 {
 		sf.baseRev = baseRev
 	}
 	newSize := sf.size
 	s.mu.Unlock()
-	if delta := newSize - oldSize; delta > 0 {
+	if delta := newSize - prevSize; delta > 0 {
 		s.pendingBytes.Add(delta)
 	}
 	return n, nil
 }
 
 // WriteFull replaces the shadow contents with a full snapshot.
+// Returns ENOSPC if the write would breach disk protection limits.
 func (s *ShadowStore) WriteFull(remotePath string, data []byte, baseRev int64) error {
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
 		return err
 	}
+
+	newSize := int64(len(data))
+	s.mu.RLock()
+	oldSize := sf.size
+	s.mu.RUnlock()
+	delta := newSize - oldSize
+	if err := s.checkQuotaForDelta(delta); err != nil {
+		return err
+	}
+
 	if err := sf.fd.Truncate(0); err != nil {
 		return fmt.Errorf("shadow reset truncate: %w", err)
 	}
@@ -348,17 +386,15 @@ func (s *ShadowStore) WriteFull(remotePath string, data []byte, baseRev int64) e
 			return fmt.Errorf("shadow write full: short write %d/%d", n, len(data))
 		}
 	}
-	if err := sf.fd.Truncate(int64(len(data))); err != nil {
+	if err := sf.fd.Truncate(newSize); err != nil {
 		return fmt.Errorf("shadow final truncate: %w", err)
 	}
 
-	newSize := int64(len(data))
 	s.mu.Lock()
-	oldSize := sf.size
 	sf.size = newSize
 	sf.baseRev = baseRev
 	s.mu.Unlock()
-	s.pendingBytes.Add(newSize - oldSize)
+	s.pendingBytes.Add(delta)
 	return nil
 }
 
@@ -392,23 +428,32 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 }
 
 // Truncate updates the shadow file length without syncing it.
+// Returns ENOSPC if the growth would breach disk protection limits.
 func (s *ShadowStore) Truncate(remotePath string, size int64, baseRev int64) error {
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
 		return err
 	}
+
+	s.mu.RLock()
+	oldSize := sf.size
+	s.mu.RUnlock()
+	delta := size - oldSize
+	if err := s.checkQuotaForDelta(delta); err != nil {
+		return err
+	}
+
 	if err := sf.fd.Truncate(size); err != nil {
 		return fmt.Errorf("shadow truncate: %w", err)
 	}
 
 	s.mu.Lock()
-	oldSize := sf.size
 	sf.size = size
 	if baseRev != 0 {
 		sf.baseRev = baseRev
 	}
 	s.mu.Unlock()
-	s.pendingBytes.Add(size - oldSize)
+	s.pendingBytes.Add(delta)
 	return nil
 }
 
@@ -431,6 +476,17 @@ func (s *ShadowStore) WriteExtents(remotePath string, wb *WriteBuffer, baseRev i
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
 		return err
+	}
+
+	// Pre-check quota for the growth delta.
+	newSize := wb.Size()
+	s.mu.RLock()
+	oldSizeEst := sf.size
+	s.mu.RUnlock()
+	if delta := newSize - oldSizeEst; delta > 0 {
+		if err := s.checkQuotaForDelta(delta); err != nil {
+			return err
+		}
 	}
 
 	// Write each dirty part at its correct offset.
@@ -466,7 +522,6 @@ func (s *ShadowStore) WriteExtents(remotePath string, wb *WriteBuffer, baseRev i
 	}
 
 	// Update shadow file metadata.
-	newSize := wb.Size()
 	s.mu.Lock()
 	oldSize := sf.size
 	sf.size = newSize

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -411,18 +411,22 @@ func (s *ShadowStore) WriteFull(remotePath string, data []byte, baseRev int64) e
 const quotaCopyBufSize = 32 << 10 // 32KB
 
 // quotaCopy copies from r to dst, checking the byte quota after each chunk.
-// oldSize is the current shadow size used to compute the delta. Returns the
-// total bytes written and ENOSPC if the byte quota is breached mid-stream.
+// During streaming the old shadow file still exists on disk alongside the
+// growing temp file, so peak disk usage is oldSize + tempSize. To bound
+// peak usage, the check uses the full temp size (written+nr) as the
+// required bytes — not just the delta — because both files coexist until
+// the atomic rename.
 func (s *ShadowStore) quotaCopy(dst io.Writer, r io.Reader, oldSize int64) (int64, error) {
 	buf := make([]byte, quotaCopyBufSize)
 	var written int64
 	for {
 		nr, readErr := r.Read(buf)
 		if nr > 0 {
-			// Check byte quota based on cumulative delta before writing.
-			delta := (written + int64(nr)) - oldSize
-			if delta > 0 {
-				if err := s.checkByteQuota(delta); err != nil {
+			// Check byte quota using the full temp file size (not delta)
+			// because the old shadow still occupies disk until rename.
+			tmpSize := written + int64(nr)
+			if tmpSize > 0 {
+				if err := s.checkByteQuota(tmpSize); err != nil {
 					return written, err
 				}
 			}
@@ -487,13 +491,14 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 	_ = tmpFd.Close()
 
 	// Post-stream free-ratio check (Statfs is too expensive to run per chunk).
-	delta := n - oldSize
-	if delta > 0 {
-		if err := s.checkFreeRatio(delta); err != nil {
+	// Use the full temp size (not delta) because old shadow + temp coexist.
+	if n > 0 {
+		if err := s.checkFreeRatio(n); err != nil {
 			_ = os.Remove(tmpPath)
 			return 0, err
 		}
 	}
+	delta := n - oldSize
 
 	// Commit: swap temp file over the shadow file.
 	shadowFile := s.shadowPath(remotePath)

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -70,7 +70,7 @@ type ShadowStore struct {
 	// optional byte quota. See CheckWriteBackQuota.
 	writeCacheFreeRatio float64      // minimum free-space ratio (default 0.10); 0 disables
 	writeCacheMaxBytes  int64        // byte quota for write-back pending (0 = disabled)
-	pendingBytes        atomic.Int64 // current pending bytes tracked by Add/SubPendingBytes
+	pendingBytes        atomic.Int64 // current shadow bytes on disk; updated internally by write/remove methods
 
 	// Throttled disk space check state (atomic for lock-free fast path).
 	lastDiskCheck atomic.Int64 // unix nano of last check

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -3,6 +3,7 @@ package fuse
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,9 +16,10 @@ import (
 // smallFileShadowThreshold is the maximum file size for cached I/O mode.
 const smallFileShadowThreshold = 64 << 20 // 64MB
 
-// diskWatermarkBytes is the minimum free disk space before ShadowStore
-// refuses to stage new writes and logs a warning.
-const diskWatermarkBytes = 1 << 30 // 1GB
+// defaultWriteCacheFreeRatio is the default minimum free-space ratio for
+// the cache-dir partition. When the ratio would drop below this after a
+// write, ShadowStore refuses the write with ENOSPC.
+const defaultWriteCacheFreeRatio = 0.10
 
 // diskCheckInterval is the minimum time between disk space checks.
 const diskCheckInterval = 5 * time.Second
@@ -64,6 +66,12 @@ type ShadowStore struct {
 	refs    map[uint64]int32          // generation → active pin count
 	retired map[uint64]*retiredShadow // generation → retired shadow awaiting unpin
 
+	// Write-back disk protection: configurable free-space ratio guard and
+	// optional byte quota. See CheckWriteBackQuota.
+	writeCacheFreeRatio float64      // minimum free-space ratio (default 0.10); 0 disables
+	writeCacheMaxBytes  int64        // byte quota for write-back pending (0 = disabled)
+	pendingBytes        atomic.Int64 // current pending bytes tracked by Add/SubPendingBytes
+
 	// Throttled disk space check state (atomic for lock-free fast path).
 	lastDiskCheck atomic.Int64 // unix nano of last check
 	diskOK        atomic.Bool  // cached result of last check
@@ -71,6 +79,14 @@ type ShadowStore struct {
 
 // NewShadowStore creates a ShadowStore rooted at dir.
 func NewShadowStore(dir string) (*ShadowStore, error) {
+	return NewShadowStoreWithQuota(dir, defaultWriteCacheFreeRatio, 0)
+}
+
+// NewShadowStoreWithQuota creates a ShadowStore with configurable write-back
+// disk protection. freeRatio is the minimum free-space ratio on the cache-dir
+// partition (0 disables the check). maxBytes is an optional byte quota for
+// total pending write-back data (0 disables).
+func NewShadowStoreWithQuota(dir string, freeRatio float64, maxBytes int64) (*ShadowStore, error) {
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return nil, fmt.Errorf("shadow store dir: %w", err)
 	}
@@ -85,12 +101,14 @@ func NewShadowStore(dir string) (*ShadowStore, error) {
 		}
 	}
 	ss := &ShadowStore{
-		dir:     dir,
-		files:   make(map[string]*ShadowFile),
-		active:  make(map[string]uint64),
-		genFile: make(map[uint64]*ShadowFile),
-		refs:    make(map[uint64]int32),
-		retired: make(map[uint64]*retiredShadow),
+		dir:                 dir,
+		files:               make(map[string]*ShadowFile),
+		active:              make(map[string]uint64),
+		genFile:             make(map[uint64]*ShadowFile),
+		refs:                make(map[uint64]int32),
+		retired:             make(map[uint64]*retiredShadow),
+		writeCacheFreeRatio: freeRatio,
+		writeCacheMaxBytes:  maxBytes,
 	}
 	ss.diskOK.Store(true)
 	return ss, nil
@@ -101,31 +119,129 @@ func (s *ShadowStore) shadowPath(remotePath string) string {
 	return filepath.Join(s.dir, hashPath(remotePath)+".shadow")
 }
 
-// CheckDiskSpace returns true if there is sufficient disk space for writes.
-func (s *ShadowStore) CheckDiskSpace() bool {
-	var stat syscall.Statfs_t
-	if err := syscall.Statfs(s.dir, &stat); err != nil {
-		return true // cannot check, assume OK
+// CheckWriteBackQuota checks whether a write of requiredBytes would violate
+// the write-back disk protection policy. Returns nil if the write is allowed,
+// or syscall.ENOSPC if it would breach either the free-space ratio or the
+// byte quota. The check is atomic: it predicts the post-write state and
+// rejects before any bytes are written.
+//
+// This is the single guard checkpoint for all write-back local disk writes
+// (shadow, pending, journal). Callers should invoke this before creating or
+// extending shadow files.
+func (s *ShadowStore) CheckWriteBackQuota(requiredBytes int64) error {
+	// Check 1: byte quota (if enabled).
+	if s.writeCacheMaxBytes > 0 {
+		currentPending := s.pendingBytes.Load()
+		if currentPending+requiredBytes > s.writeCacheMaxBytes {
+			log.Printf("write-back quota rejected: cache_dir=%s pending_bytes=%d required_bytes=%d quota_bytes=%d reason=byte_quota_exceeded",
+				s.dir, currentPending, requiredBytes, s.writeCacheMaxBytes)
+			return syscall.ENOSPC
+		}
 	}
-	avail := int64(stat.Bavail) * int64(stat.Bsize)
-	return avail >= diskWatermarkBytes
+
+	// Check 2: free-space ratio (if enabled).
+	if s.writeCacheFreeRatio > 0 {
+		var stat syscall.Statfs_t
+		if err := syscall.Statfs(s.dir, &stat); err == nil {
+			totalBytes := int64(stat.Blocks) * int64(stat.Bsize)
+			freeBytes := int64(stat.Bavail) * int64(stat.Bsize)
+			freeAfterWrite := freeBytes - requiredBytes
+			if totalBytes > 0 {
+				ratioAfterWrite := float64(freeAfterWrite) / float64(totalBytes)
+				if ratioAfterWrite < s.writeCacheFreeRatio {
+					log.Printf("write-back quota rejected: cache_dir=%s free_bytes=%d required_bytes=%d free_ratio=%.4f threshold=%.4f reason=free_ratio_exceeded",
+						s.dir, freeBytes, requiredBytes, ratioAfterWrite, s.writeCacheFreeRatio)
+					return syscall.ENOSPC
+				}
+			}
+		}
+		// If Statfs fails, allow the write (cannot check).
+	}
+
+	return nil
+}
+
+// CheckWriteBackQuotaThrottled is a throttled version of CheckWriteBackQuota
+// that caches the result for diskCheckInterval. Safe for hot-path use.
+// requiredBytes is used for the actual Statfs check but the cached result
+// applies to all callers during the throttle window.
+func (s *ShadowStore) CheckWriteBackQuotaThrottled(requiredBytes int64) error {
+	now := time.Now().UnixNano()
+	last := s.lastDiskCheck.Load()
+	if now-last < int64(diskCheckInterval) {
+		if !s.diskOK.Load() {
+			return syscall.ENOSPC
+		}
+		// Cached OK but still check byte quota (cheap, no syscall).
+		if s.writeCacheMaxBytes > 0 {
+			if s.pendingBytes.Load()+requiredBytes > s.writeCacheMaxBytes {
+				return syscall.ENOSPC
+			}
+		}
+		return nil
+	}
+	// CAS to avoid concurrent syscalls.
+	if s.lastDiskCheck.CompareAndSwap(last, now) {
+		err := s.CheckWriteBackQuota(requiredBytes)
+		s.diskOK.Store(err == nil)
+		return err
+	}
+	if !s.diskOK.Load() {
+		return syscall.ENOSPC
+	}
+	return nil
+}
+
+// AddPendingBytes adds n bytes to the pending write-back byte counter.
+// Called when shadow data is staged for upload.
+func (s *ShadowStore) AddPendingBytes(n int64) {
+	s.pendingBytes.Add(n)
+}
+
+// SubPendingBytes subtracts n bytes from the pending write-back byte counter.
+// Called when a commit succeeds and local pending data is cleaned up.
+func (s *ShadowStore) SubPendingBytes(n int64) {
+	s.pendingBytes.Add(-n)
+}
+
+// PendingBytes returns the current pending write-back byte count.
+func (s *ShadowStore) PendingBytes() int64 {
+	return s.pendingBytes.Load()
+}
+
+// RecoverPendingBytes scans the shadow directory and sets the pending byte
+// counter to the sum of all shadow file sizes. Called once at startup after
+// crash recovery to restore the accurate byte count.
+func (s *ShadowStore) RecoverPendingBytes() {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return
+	}
+	var total int64
+	for _, e := range entries {
+		if e.IsDir() || filepath.Ext(e.Name()) != ".shadow" {
+			continue
+		}
+		fi, err := e.Info()
+		if err != nil {
+			continue
+		}
+		total += fi.Size()
+	}
+	s.pendingBytes.Store(total)
+}
+
+// CheckDiskSpace returns true if there is sufficient disk space for writes.
+// Deprecated: use CheckWriteBackQuota for configurable protection.
+func (s *ShadowStore) CheckDiskSpace() bool {
+	return s.CheckWriteBackQuota(0) == nil
 }
 
 // CheckDiskSpaceThrottled returns the cached disk space result, refreshing at
 // most once per diskCheckInterval. Safe for hot-path use (lock-free fast path).
+// Deprecated: use CheckWriteBackQuotaThrottled for configurable protection.
 func (s *ShadowStore) CheckDiskSpaceThrottled() bool {
-	now := time.Now().UnixNano()
-	last := s.lastDiskCheck.Load()
-	if now-last < int64(diskCheckInterval) {
-		return s.diskOK.Load()
-	}
-	// CAS to avoid concurrent syscalls.
-	if s.lastDiskCheck.CompareAndSwap(last, now) {
-		ok := s.CheckDiskSpace()
-		s.diskOK.Store(ok)
-		return ok
-	}
-	return s.diskOK.Load()
+	return s.CheckWriteBackQuotaThrottled(0) == nil
 }
 
 func (s *ShadowStore) ensureShadowFile(remotePath string, baseRev int64) (*ShadowFile, error) {

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -74,8 +74,10 @@ type ShadowStore struct {
 	pendingBytes        atomic.Int64 // current shadow bytes on disk; updated internally by write/remove methods
 
 	// Throttled disk space check state (atomic for lock-free fast path).
-	lastDiskCheck atomic.Int64 // unix nano of last check
-	diskOK        atomic.Bool  // cached result of last check
+	lastDiskCheck  atomic.Int64 // unix nano of last check
+	diskOK         atomic.Bool  // cached result of last check
+	cachedFreeBytes atomic.Int64 // cached Statfs free bytes (Bavail*Bsize)
+	cachedTotalBytes atomic.Int64 // cached Statfs total bytes (Blocks*Bsize)
 }
 
 // NewShadowStore creates a ShadowStore rooted at dir.
@@ -149,23 +151,32 @@ func (s *ShadowStore) checkByteQuota(requiredBytes int64) error {
 }
 
 // checkFreeRatio checks the free-space ratio (requires Statfs syscall).
+// Also caches the Statfs values for use by checkFreeRatioThrottled.
 func (s *ShadowStore) checkFreeRatio(requiredBytes int64) error {
 	if s.writeCacheFreeRatio > 0 {
 		var stat syscall.Statfs_t
 		if err := syscall.Statfs(s.dir, &stat); err == nil {
 			totalBytes := int64(stat.Blocks) * int64(stat.Bsize)
 			freeBytes := int64(stat.Bavail) * int64(stat.Bsize)
-			freeAfterWrite := freeBytes - requiredBytes
-			if totalBytes > 0 {
-				ratioAfterWrite := float64(freeAfterWrite) / float64(totalBytes)
-				if ratioAfterWrite < s.writeCacheFreeRatio {
-					log.Printf("write-back quota rejected: cache_dir=%s free_bytes=%d required_bytes=%d free_ratio=%.4f threshold=%.4f reason=free_ratio_exceeded",
-						s.dir, freeBytes, requiredBytes, ratioAfterWrite, s.writeCacheFreeRatio)
-					return syscall.ENOSPC
-				}
-			}
+			s.cachedFreeBytes.Store(freeBytes)
+			s.cachedTotalBytes.Store(totalBytes)
+			return s.evalFreeRatio(freeBytes, totalBytes, requiredBytes)
 		}
 		// If Statfs fails, allow the write (cannot check).
+	}
+	return nil
+}
+
+// evalFreeRatio evaluates the free-ratio check against given capacity values.
+func (s *ShadowStore) evalFreeRatio(freeBytes, totalBytes, requiredBytes int64) error {
+	freeAfterWrite := freeBytes - requiredBytes
+	if totalBytes > 0 {
+		ratioAfterWrite := float64(freeAfterWrite) / float64(totalBytes)
+		if ratioAfterWrite < s.writeCacheFreeRatio {
+			log.Printf("write-back quota rejected: cache_dir=%s free_bytes=%d required_bytes=%d free_ratio=%.4f threshold=%.4f reason=free_ratio_exceeded",
+				s.dir, freeBytes, requiredBytes, ratioAfterWrite, s.writeCacheFreeRatio)
+			return syscall.ENOSPC
+		}
 	}
 	return nil
 }
@@ -434,9 +445,11 @@ func (s *ShadowStore) quotaCopy(dst io.Writer, r io.Reader, oldSize int64) (int6
 	}
 }
 
-// checkFreeRatioThrottled checks the free-ratio guard using the same
-// throttle mechanism as CheckWriteBackQuotaThrottled. Returns ENOSPC if
-// the cached or fresh Statfs result indicates insufficient free space.
+// checkFreeRatioThrottled checks the free-ratio guard using cached Statfs
+// values. Within the throttle window, re-evaluates the ratio using the
+// cached free/total bytes against the current requiredBytes so that
+// increasing write sizes are correctly bounded without a fresh Statfs.
+// Outside the window, performs a fresh Statfs and caches the result.
 func (s *ShadowStore) checkFreeRatioThrottled(requiredBytes int64) error {
 	if s.writeCacheFreeRatio <= 0 {
 		return nil
@@ -444,9 +457,13 @@ func (s *ShadowStore) checkFreeRatioThrottled(requiredBytes int64) error {
 	now := time.Now().UnixNano()
 	last := s.lastDiskCheck.Load()
 	if now-last < int64(diskCheckInterval) {
-		if !s.diskOK.Load() {
-			return syscall.ENOSPC
+		// Within throttle window: re-evaluate with cached capacity.
+		freeBytes := s.cachedFreeBytes.Load()
+		totalBytes := s.cachedTotalBytes.Load()
+		if totalBytes > 0 {
+			return s.evalFreeRatio(freeBytes, totalBytes, requiredBytes)
 		}
+		// No cached values yet — allow (first call will populate).
 		return nil
 	}
 	if s.lastDiskCheck.CompareAndSwap(last, now) {
@@ -454,8 +471,11 @@ func (s *ShadowStore) checkFreeRatioThrottled(requiredBytes int64) error {
 		s.diskOK.Store(err == nil)
 		return err
 	}
-	if !s.diskOK.Load() {
-		return syscall.ENOSPC
+	// CAS loser: use cached capacity values.
+	freeBytes := s.cachedFreeBytes.Load()
+	totalBytes := s.cachedTotalBytes.Load()
+	if totalBytes > 0 {
+		return s.evalFreeRatio(freeBytes, totalBytes, requiredBytes)
 	}
 	return nil
 }

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -677,18 +677,23 @@ func (s *ShadowStore) WriteExtents(remotePath string, wb *WriteBuffer, baseRev i
 // Works for both active generations (shadow still in files map) and retired
 // generations (shadow moved to retired map by Remove). Returns (0, error)
 // if the generation is unknown.
+// The read is performed under RLock to prevent WriteStream from swapping
+// the fd mid-read on active generations.
 func (s *ShadowStore) ReadAtGen(gen uint64, offset int64, buf []byte) (int, error) {
 	s.mu.RLock()
 	if sf, ok := s.genFile[gen]; ok {
+		n, err := sf.fd.ReadAt(buf, offset)
 		s.mu.RUnlock()
-		return sf.fd.ReadAt(buf, offset)
+		return n, err
 	}
 	rt, ok := s.retired[gen]
-	s.mu.RUnlock()
-	if !ok {
-		return 0, fmt.Errorf("shadow gen %d not found", gen)
+	if ok {
+		n, err := rt.fd.ReadAt(buf, offset)
+		s.mu.RUnlock()
+		return n, err
 	}
-	return rt.fd.ReadAt(buf, offset)
+	s.mu.RUnlock()
+	return 0, fmt.Errorf("shadow gen %d not found", gen)
 }
 
 // SizeGen returns the size of a shadow file by generation token. Works for

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -77,6 +77,11 @@ type ShadowStore struct {
 	lastDiskCheck    atomic.Int64 // unix nano of last check
 	cachedFreeBytes  atomic.Int64 // cached Statfs free bytes (Bavail*Bsize)
 	cachedTotalBytes atomic.Int64 // cached Statfs total bytes (Blocks*Bsize)
+
+	// supersededFds holds old file descriptors replaced by WriteStream.
+	// They are kept open so concurrent readers that grabbed the fd before
+	// the swap don't hit EBADF. Drained on Close.
+	supersededFds []*os.File
 }
 
 // NewShadowStore creates a ShadowStore rooted at dir.
@@ -486,12 +491,9 @@ func (s *ShadowStore) checkFreeRatioThrottled(requiredBytes int64) error {
 // Statfs values). On quota breach the temp file is removed and the original
 // shadow is untouched.
 //
-// Concurrency note: WriteStream swaps sf.fd under s.mu and closes the old fd
-// after releasing the lock. Callers that read the same path concurrently
-// should use Pin/ReadAtGen (generation-pinned reads) rather than ReadAt to
-// avoid a use-after-close race on the fd. All current callers hold the file
-// handle lock during WriteStream, so concurrent unpinned ReadAt on the same
-// path does not occur in practice.
+// Concurrency note: WriteStream swaps sf.fd under s.mu. The old fd is kept
+// open in supersededFds (not closed) so concurrent readers that grabbed it
+// before the swap don't hit EBADF. Superseded fds are closed on Close().
 func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64) (int64, error) {
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
@@ -547,8 +549,13 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 	sf.fd = newFd
 	sf.size = n
 	sf.baseRev = baseRev
+	// Keep oldFd open so concurrent readers that grabbed it before the swap
+	// don't hit EBADF. The fd is appended to supersededFds and closed when
+	// the ShadowStore is closed.
+	if oldFd != nil {
+		s.supersededFds = append(s.supersededFds, oldFd)
+	}
 	s.mu.Unlock()
-	_ = oldFd.Close()
 	s.pendingBytes.Add(delta)
 	return n, nil
 }
@@ -1050,7 +1057,8 @@ func (s *ShadowStore) Has(remotePath string) bool {
 	return err == nil
 }
 
-// Close closes all open shadow file descriptors.
+// Close closes all open shadow file descriptors, including superseded fds
+// kept alive for concurrent reader safety.
 func (s *ShadowStore) Close() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -1061,11 +1069,15 @@ func (s *ShadowStore) Close() {
 	for _, rt := range s.retired {
 		_ = rt.fd.Close()
 	}
+	for _, fd := range s.supersededFds {
+		_ = fd.Close()
+	}
 	s.files = make(map[string]*ShadowFile)
 	s.active = make(map[string]uint64)
 	s.genFile = make(map[uint64]*ShadowFile)
 	s.refs = make(map[uint64]int32)
 	s.retired = make(map[uint64]*retiredShadow)
+	s.supersededFds = nil
 }
 
 // RecoverFromDisk scans the shadow directory and loads shadow files into memory.

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -400,8 +400,9 @@ func (s *ShadowStore) WriteFull(remotePath string, data []byte, baseRev int64) e
 
 // WriteStream replaces the shadow contents by streaming from r.
 // Returns ENOSPC if the streamed data would breach disk protection limits.
-// Because the final size is unknown before streaming, the quota check runs
-// post-write; on breach the shadow is truncated back to its previous size.
+// Because the final size is unknown before streaming, the data is streamed
+// to a temp file first; on quota breach the temp file is removed and the
+// original shadow is untouched.
 func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64) (int64, error) {
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
@@ -412,37 +413,54 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 	oldSize := sf.size
 	s.mu.RUnlock()
 
-	if err := sf.fd.Truncate(0); err != nil {
-		return 0, fmt.Errorf("shadow reset truncate: %w", err)
-	}
-	if _, err := sf.fd.Seek(0, 0); err != nil {
-		return 0, fmt.Errorf("shadow reset seek: %w", err)
-	}
-	n, err := io.Copy(sf.fd, r)
+	// Stream to a temp file so the original shadow is untouched on failure.
+	tmpPath := s.shadowPath(remotePath) + ".tmp"
+	tmpFd, err := os.Create(tmpPath)
 	if err != nil {
+		return 0, fmt.Errorf("shadow stream tmp create: %w", err)
+	}
+	n, err := io.Copy(tmpFd, r)
+	if err != nil {
+		tmpFd.Close()
+		os.Remove(tmpPath)
 		return n, fmt.Errorf("shadow write stream: %w", err)
 	}
-	if err := sf.fd.Truncate(n); err != nil {
-		return n, fmt.Errorf("shadow final truncate: %w", err)
+	if err := tmpFd.Sync(); err != nil {
+		tmpFd.Close()
+		os.Remove(tmpPath)
+		return n, fmt.Errorf("shadow stream sync: %w", err)
 	}
+	tmpFd.Close()
 
-	// Post-write quota check: rollback if breached.
+	// Post-stream quota check before committing.
 	delta := n - oldSize
 	if delta > 0 {
 		if err := s.checkQuotaForDelta(delta); err != nil {
-			// Rollback: restore previous size.
-			_ = sf.fd.Truncate(oldSize)
-			s.mu.Lock()
-			sf.size = oldSize
-			s.mu.Unlock()
+			os.Remove(tmpPath)
 			return 0, err
 		}
 	}
 
+	// Commit: swap temp file over the shadow file.
+	shadowFile := s.shadowPath(remotePath)
+	if err := os.Rename(tmpPath, shadowFile); err != nil {
+		os.Remove(tmpPath)
+		return 0, fmt.Errorf("shadow stream rename: %w", err)
+	}
+
+	// Reopen the fd for the shadow file.
+	newFd, err := os.OpenFile(shadowFile, os.O_RDWR, 0o644)
+	if err != nil {
+		return 0, fmt.Errorf("shadow stream reopen: %w", err)
+	}
+
 	s.mu.Lock()
+	oldFd := sf.fd
+	sf.fd = newFd
 	sf.size = n
 	sf.baseRev = baseRev
 	s.mu.Unlock()
+	oldFd.Close()
 	s.pendingBytes.Add(delta)
 	return n, nil
 }

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -269,9 +269,8 @@ func (s *ShadowStore) ensureShadowFile(remotePath string, baseRev int64) (*Shado
 	defer s.mu.Unlock()
 
 	if sf, ok := s.files[remotePath]; ok {
-		if baseRev != 0 {
-			sf.baseRev = baseRev
-		}
+		// Do not update baseRev here — callers update it in their
+		// success path after the write and quota check pass.
 		return sf, nil
 	}
 

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -194,15 +194,15 @@ func (s *ShadowStore) CheckWriteBackQuotaThrottled(requiredBytes int64) error {
 
 // AddPendingBytes adds n bytes to the pending write-back byte counter.
 // Called when shadow data is staged for upload.
-func (s *ShadowStore) AddPendingBytes(n int64) {
-	s.pendingBytes.Add(n)
-}
+// AddPendingBytes is a no-op. Pending byte accounting is now managed
+// internally by ShadowStore write/remove methods.
+// Deprecated: do not call; kept for backward compatibility.
+func (s *ShadowStore) AddPendingBytes(n int64) {}
 
-// SubPendingBytes subtracts n bytes from the pending write-back byte counter.
-// Called when a commit succeeds and local pending data is cleaned up.
-func (s *ShadowStore) SubPendingBytes(n int64) {
-	s.pendingBytes.Add(-n)
-}
+// SubPendingBytes is a no-op. Pending byte accounting is now managed
+// internally by ShadowStore write/remove methods.
+// Deprecated: do not call; kept for backward compatibility.
+func (s *ShadowStore) SubPendingBytes(n int64) {}
 
 // PendingBytes returns the current pending write-back byte count.
 func (s *ShadowStore) PendingBytes() int64 {
@@ -311,13 +311,18 @@ func (s *ShadowStore) WriteAt(remotePath string, offset int64, data []byte, base
 
 	end := offset + int64(n)
 	s.mu.Lock()
+	oldSize := sf.size
 	if end > sf.size {
 		sf.size = end
 	}
 	if baseRev != 0 {
 		sf.baseRev = baseRev
 	}
+	newSize := sf.size
 	s.mu.Unlock()
+	if delta := newSize - oldSize; delta > 0 {
+		s.pendingBytes.Add(delta)
+	}
 	return n, nil
 }
 
@@ -343,10 +348,13 @@ func (s *ShadowStore) WriteFull(remotePath string, data []byte, baseRev int64) e
 		return fmt.Errorf("shadow final truncate: %w", err)
 	}
 
+	newSize := int64(len(data))
 	s.mu.Lock()
-	sf.size = int64(len(data))
+	oldSize := sf.size
+	sf.size = newSize
 	sf.baseRev = baseRev
 	s.mu.Unlock()
+	s.pendingBytes.Add(newSize - oldSize)
 	return nil
 }
 
@@ -371,9 +379,11 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 	}
 
 	s.mu.Lock()
+	oldSize := sf.size
 	sf.size = n
 	sf.baseRev = baseRev
 	s.mu.Unlock()
+	s.pendingBytes.Add(n - oldSize)
 	return n, nil
 }
 
@@ -388,11 +398,13 @@ func (s *ShadowStore) Truncate(remotePath string, size int64, baseRev int64) err
 	}
 
 	s.mu.Lock()
+	oldSize := sf.size
 	sf.size = size
 	if baseRev != 0 {
 		sf.baseRev = baseRev
 	}
 	s.mu.Unlock()
+	s.pendingBytes.Add(size - oldSize)
 	return nil
 }
 
@@ -450,17 +462,19 @@ func (s *ShadowStore) WriteExtents(remotePath string, wb *WriteBuffer, baseRev i
 	}
 
 	// Update shadow file metadata.
+	newSize := wb.Size()
 	s.mu.Lock()
-	sf.size = wb.Size()
+	oldSize := sf.size
+	sf.size = newSize
 	sf.extents = extents
 	if baseRev != 0 {
 		sf.baseRev = baseRev
 	}
-	targetSize := sf.size
 	s.mu.Unlock()
+	s.pendingBytes.Add(newSize - oldSize)
 
 	// Truncate to exact size if needed (handle shrinks).
-	if err := sf.fd.Truncate(targetSize); err != nil {
+	if err := sf.fd.Truncate(newSize); err != nil {
 		return fmt.Errorf("shadow truncate: %w", err)
 	}
 
@@ -733,7 +747,9 @@ func (s *ShadowStore) Remove(remotePath string) {
 			_ = os.Remove(diskPath)
 			retiredPath = diskPath // fd still valid, disk file gone
 		}
+		var removedSize int64
 		if sf != nil {
+			removedSize = sf.size
 			s.retired[gen] = &retiredShadow{
 				fd:       sf.fd,
 				diskPath: retiredPath,
@@ -741,6 +757,9 @@ func (s *ShadowStore) Remove(remotePath string) {
 			}
 		}
 		s.mu.Unlock()
+		if removedSize > 0 {
+			s.pendingBytes.Add(-removedSize)
+		}
 		return
 	}
 	// No active pins — remove immediately.
@@ -749,12 +768,17 @@ func (s *ShadowStore) Remove(remotePath string) {
 		delete(s.genFile, gen)
 		delete(s.refs, gen)
 	}
+	var removedSize int64
 	sf, ok := s.files[remotePath]
 	if ok {
+		removedSize = sf.size
 		_ = sf.fd.Close()
 		delete(s.files, remotePath)
 	}
 	s.mu.Unlock()
+	if removedSize > 0 {
+		s.pendingBytes.Add(-removedSize)
+	}
 
 	// Always attempt disk cleanup — the shadow may exist only on disk
 	// (e.g. after crash/restart recovery where it was never loaded into

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -186,33 +186,14 @@ func (s *ShadowStore) checkQuotaForDelta(delta int64) error {
 }
 
 // CheckWriteBackQuotaThrottled is a throttled version of CheckWriteBackQuota.
-// The Statfs result is cached for diskCheckInterval; the byte quota check
-// always runs fresh (it is cheap — just an atomic load).
+// The byte quota check always runs fresh (cheap atomic load). The free-ratio
+// check is throttled via checkFreeRatioThrottled (Statfs cached for
+// diskCheckInterval).
 func (s *ShadowStore) CheckWriteBackQuotaThrottled(requiredBytes int64) error {
-	// Byte quota check always runs (cheap, no syscall).
 	if err := s.checkByteQuota(requiredBytes); err != nil {
 		return err
 	}
-
-	// Free-ratio check is throttled via CAS.
-	now := time.Now().UnixNano()
-	last := s.lastDiskCheck.Load()
-	if now-last < int64(diskCheckInterval) {
-		if !s.diskOK.Load() {
-			return syscall.ENOSPC
-		}
-		return nil
-	}
-	if s.lastDiskCheck.CompareAndSwap(last, now) {
-		err := s.checkFreeRatio(requiredBytes)
-		s.diskOK.Store(err == nil)
-		return err
-	}
-	// CAS loser: use cached Statfs result.
-	if !s.diskOK.Load() {
-		return syscall.ENOSPC
-	}
-	return nil
+	return s.checkFreeRatioThrottled(requiredBytes)
 }
 
 // AddPendingBytes is a no-op. Pending byte accounting is now managed
@@ -410,23 +391,28 @@ func (s *ShadowStore) WriteFull(remotePath string, data []byte, baseRev int64) e
 // quotaCopyBufSize is the chunk size for quota-aware streaming copies.
 const quotaCopyBufSize = 32 << 10 // 32KB
 
-// quotaCopy copies from r to dst, checking the byte quota after each chunk.
-// During streaming the old shadow file still exists on disk alongside the
-// growing temp file, so peak disk usage is oldSize + tempSize. To bound
-// peak usage, the check uses the full temp size (written+nr) as the
-// required bytes — not just the delta — because both files coexist until
-// the atomic rename.
+// quotaCopy copies from r to dst, checking both byte quota and free-ratio
+// incrementally. During streaming the old shadow file still exists on disk
+// alongside the growing temp file, so peak disk usage is oldSize + tempSize.
+// Both checks use the full temp size (written+nr) as required bytes.
+// The byte quota check runs on every chunk (cheap atomic load). The
+// free-ratio check is throttled via the same diskOK/lastDiskCheck mechanism
+// used by CheckWriteBackQuotaThrottled, so Statfs runs at most once per
+// diskCheckInterval.
 func (s *ShadowStore) quotaCopy(dst io.Writer, r io.Reader, oldSize int64) (int64, error) {
 	buf := make([]byte, quotaCopyBufSize)
 	var written int64
 	for {
 		nr, readErr := r.Read(buf)
 		if nr > 0 {
-			// Check byte quota using the full temp file size (not delta)
+			// Check both quotas using the full temp file size (not delta)
 			// because the old shadow still occupies disk until rename.
 			tmpSize := written + int64(nr)
 			if tmpSize > 0 {
 				if err := s.checkByteQuota(tmpSize); err != nil {
+					return written, err
+				}
+				if err := s.checkFreeRatioThrottled(tmpSize); err != nil {
 					return written, err
 				}
 			}
@@ -448,11 +434,36 @@ func (s *ShadowStore) quotaCopy(dst io.Writer, r io.Reader, oldSize int64) (int6
 	}
 }
 
+// checkFreeRatioThrottled checks the free-ratio guard using the same
+// throttle mechanism as CheckWriteBackQuotaThrottled. Returns ENOSPC if
+// the cached or fresh Statfs result indicates insufficient free space.
+func (s *ShadowStore) checkFreeRatioThrottled(requiredBytes int64) error {
+	if s.writeCacheFreeRatio <= 0 {
+		return nil
+	}
+	now := time.Now().UnixNano()
+	last := s.lastDiskCheck.Load()
+	if now-last < int64(diskCheckInterval) {
+		if !s.diskOK.Load() {
+			return syscall.ENOSPC
+		}
+		return nil
+	}
+	if s.lastDiskCheck.CompareAndSwap(last, now) {
+		err := s.checkFreeRatio(requiredBytes)
+		s.diskOK.Store(err == nil)
+		return err
+	}
+	if !s.diskOK.Load() {
+		return syscall.ENOSPC
+	}
+	return nil
+}
+
 // WriteStream replaces the shadow contents by streaming from r.
 // Returns ENOSPC if the streamed data would breach disk protection limits.
-// The byte quota is checked incrementally during streaming so that peak disk
-// usage of the temp file is bounded by the quota. The free-ratio check runs
-// once after streaming completes (Statfs per chunk would be too expensive).
+// Both byte quota and free-ratio are checked incrementally during streaming
+// via quotaCopy (byte quota every chunk, free-ratio throttled via diskOK).
 // On quota breach the temp file is removed and the original shadow is
 // untouched.
 func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64) (int64, error) {
@@ -472,8 +483,8 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 		return 0, fmt.Errorf("shadow stream tmp create: %w", err)
 	}
 
-	// Use a quota-aware copy: check byte quota every 32KB so the temp file
-	// never grows far beyond the quota limit.
+	// Use a quota-aware copy: check byte quota + free-ratio every chunk so
+	// the temp file never grows far beyond the protection limit.
 	n, err := s.quotaCopy(tmpFd, r, oldSize)
 	if err != nil {
 		_ = tmpFd.Close()
@@ -490,14 +501,6 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 	}
 	_ = tmpFd.Close()
 
-	// Post-stream free-ratio check (Statfs is too expensive to run per chunk).
-	// Use the full temp size (not delta) because old shadow + temp coexist.
-	if n > 0 {
-		if err := s.checkFreeRatio(n); err != nil {
-			_ = os.Remove(tmpPath)
-			return 0, err
-		}
-	}
 	delta := n - oldSize
 
 	// Commit: swap temp file over the shadow file.

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -189,11 +189,15 @@ func (s *ShadowStore) CheckWriteBackQuotaThrottled(requiredBytes int64) error {
 	if !s.diskOK.Load() {
 		return syscall.ENOSPC
 	}
+	// CAS loser: still check byte quota (cheap, no syscall).
+	if s.writeCacheMaxBytes > 0 {
+		if s.pendingBytes.Load()+requiredBytes > s.writeCacheMaxBytes {
+			return syscall.ENOSPC
+		}
+	}
 	return nil
 }
 
-// AddPendingBytes adds n bytes to the pending write-back byte counter.
-// Called when shadow data is staged for upload.
 // AddPendingBytes is a no-op. Pending byte accounting is now managed
 // internally by ShadowStore write/remove methods.
 // Deprecated: do not call; kept for backward compatibility.

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -399,11 +399,19 @@ func (s *ShadowStore) WriteFull(remotePath string, data []byte, baseRev int64) e
 }
 
 // WriteStream replaces the shadow contents by streaming from r.
+// Returns ENOSPC if the streamed data would breach disk protection limits.
+// Because the final size is unknown before streaming, the quota check runs
+// post-write; on breach the shadow is truncated back to its previous size.
 func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64) (int64, error) {
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
 		return 0, err
 	}
+
+	s.mu.RLock()
+	oldSize := sf.size
+	s.mu.RUnlock()
+
 	if err := sf.fd.Truncate(0); err != nil {
 		return 0, fmt.Errorf("shadow reset truncate: %w", err)
 	}
@@ -418,12 +426,24 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 		return n, fmt.Errorf("shadow final truncate: %w", err)
 	}
 
+	// Post-write quota check: rollback if breached.
+	delta := n - oldSize
+	if delta > 0 {
+		if err := s.checkQuotaForDelta(delta); err != nil {
+			// Rollback: restore previous size.
+			_ = sf.fd.Truncate(oldSize)
+			s.mu.Lock()
+			sf.size = oldSize
+			s.mu.Unlock()
+			return 0, err
+		}
+	}
+
 	s.mu.Lock()
-	oldSize := sf.size
 	sf.size = n
 	sf.baseRev = baseRev
 	s.mu.Unlock()
-	s.pendingBytes.Add(n - oldSize)
+	s.pendingBytes.Add(delta)
 	return n, nil
 }
 

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -724,8 +724,10 @@ func TestCheckWriteBackQuotaByteQuotaExceeded(t *testing.T) {
 	}
 	defer ss.Close()
 
-	// Simulate 800 bytes already pending.
-	ss.AddPendingBytes(800)
+	// Write an 800-byte shadow file to accumulate pending bytes internally.
+	if err := ss.WriteFull("/big.txt", make([]byte, 800), 1); err != nil {
+		t.Fatal(err)
+	}
 
 	// Writing 300 more bytes (total 1100 > 1024) should be rejected.
 	err = ss.CheckWriteBackQuota(300)
@@ -742,8 +744,10 @@ func TestCheckWriteBackQuotaByteQuotaDisabled(t *testing.T) {
 	}
 	defer ss.Close()
 
-	ss.AddPendingBytes(999999999)
-	// With quota disabled, any write should pass.
+	// Write a large shadow file; with quota disabled, any further write should pass.
+	if err := ss.WriteFull("/big.txt", make([]byte, 10000), 1); err != nil {
+		t.Fatal(err)
+	}
 	if err := ss.CheckWriteBackQuota(999999999); err != nil {
 		t.Fatalf("expected write to be allowed with quota disabled, got %v", err)
 	}
@@ -799,7 +803,7 @@ func TestCheckWriteBackQuotaFreeRatioDisabled(t *testing.T) {
 	}
 }
 
-func TestPendingBytesAddSubRecover(t *testing.T) {
+func TestPendingBytesWriteFullAndRemove(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStoreWithQuota(dir, 0, 0)
 	if err != nil {
@@ -812,44 +816,51 @@ func TestPendingBytesAddSubRecover(t *testing.T) {
 		t.Fatalf("expected initial pending 0, got %d", p)
 	}
 
-	// Add and sub.
-	ss.AddPendingBytes(1000)
+	// WriteFull should increase pending bytes.
+	if err := ss.WriteFull("/a.txt", make([]byte, 1000), 1); err != nil {
+		t.Fatal(err)
+	}
 	if p := ss.PendingBytes(); p != 1000 {
-		t.Fatalf("expected pending 1000 after add, got %d", p)
+		t.Fatalf("expected pending 1000 after write, got %d", p)
 	}
 
-	ss.SubPendingBytes(400)
+	// Overwriting with a smaller file should decrease pending.
+	if err := ss.WriteFull("/a.txt", make([]byte, 600), 2); err != nil {
+		t.Fatal(err)
+	}
 	if p := ss.PendingBytes(); p != 600 {
-		t.Fatalf("expected pending 600 after sub, got %d", p)
+		t.Fatalf("expected pending 600 after overwrite, got %d", p)
+	}
+
+	// Remove should bring it back to 0.
+	ss.Remove("/a.txt")
+	if p := ss.PendingBytes(); p != 0 {
+		t.Fatalf("expected pending 0 after remove, got %d", p)
 	}
 }
 
 func TestRecoverPendingBytesFromDisk(t *testing.T) {
 	dir := t.TempDir()
-	ss, err := NewShadowStoreWithQuota(dir, 0, 0)
-	if err != nil {
-		t.Fatal(err)
-	}
 
-	// Write some shadow files.
-	if err := ss.WriteFull("/a.txt", []byte("hello"), 1); err != nil {
+	// Manually create shadow files on disk to simulate a crash scenario
+	// where the in-memory ShadowStore state is lost.
+	if err := os.WriteFile(filepath.Join(dir, "aaa.shadow"), []byte("hello"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := ss.WriteFull("/b.txt", []byte("world!!"), 2); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "bbb.shadow"), []byte("world!!"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	ss.Close()
 
 	// Create a new store and recover pending bytes.
-	ss2, err := NewShadowStoreWithQuota(dir, 0, 100)
+	ss, err := NewShadowStoreWithQuota(dir, 0, 100)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ss2.Close()
+	defer ss.Close()
 
-	ss2.RecoverPendingBytes()
+	ss.RecoverPendingBytes()
 	// Should recover 5 + 7 = 12 bytes.
-	if p := ss2.PendingBytes(); p != 12 {
+	if p := ss.PendingBytes(); p != 12 {
 		t.Fatalf("expected recovered pending 12, got %d", p)
 	}
 }
@@ -862,18 +873,61 @@ func TestByteQuotaRecoveryAfterCommitCleanup(t *testing.T) {
 	}
 	defer ss.Close()
 
-	// Simulate staging a 80-byte file.
-	ss.AddPendingBytes(80)
+	// Stage an 80-byte shadow file.
+	if err := ss.WriteFull("/file.txt", make([]byte, 80), 1); err != nil {
+		t.Fatal(err)
+	}
 	if err := ss.CheckWriteBackQuota(30); err != syscall.ENOSPC {
 		t.Fatalf("expected ENOSPC when 80+30>100, got %v", err)
 	}
 
-	// Simulate commit cleanup (sub bytes).
-	ss.SubPendingBytes(80)
+	// Simulate commit cleanup: Remove releases pending bytes.
+	ss.Remove("/file.txt")
 
 	// Now writing 30 should succeed again.
 	if err := ss.CheckWriteBackQuota(30); err != nil {
 		t.Fatalf("expected write to succeed after cleanup, got %v", err)
+	}
+}
+
+func TestPendingBytesNoDoubleCount(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Write a 500-byte shadow file.
+	if err := ss.WriteFull("/f.txt", make([]byte, 500), 1); err != nil {
+		t.Fatal(err)
+	}
+	if p := ss.PendingBytes(); p != 500 {
+		t.Fatalf("expected pending 500, got %d", p)
+	}
+
+	// Overwrite the same path with 500 bytes again — pending must stay 500, not 1000.
+	if err := ss.WriteFull("/f.txt", make([]byte, 500), 2); err != nil {
+		t.Fatal(err)
+	}
+	if p := ss.PendingBytes(); p != 500 {
+		t.Fatalf("expected pending 500 after re-stage, got %d (double-count bug)", p)
+	}
+
+	// A third stage that grows the file to 700 should bring pending to 700.
+	if err := ss.WriteFull("/f.txt", make([]byte, 700), 3); err != nil {
+		t.Fatal(err)
+	}
+	if p := ss.PendingBytes(); p != 700 {
+		t.Fatalf("expected pending 700 after grow, got %d", p)
+	}
+
+	// Shrink back to 200.
+	if err := ss.WriteFull("/f.txt", make([]byte, 200), 4); err != nil {
+		t.Fatal(err)
+	}
+	if p := ss.PendingBytes(); p != 200 {
+		t.Fatalf("expected pending 200 after shrink, got %d", p)
 	}
 }
 

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -1190,3 +1190,69 @@ func TestRenamePendingBytesReplacesTarget(t *testing.T) {
 		t.Fatalf("after rename: pendingBytes=%d, want 5", pb)
 	}
 }
+
+// TestWriteStreamConcurrentReadAt verifies no data race between WriteStream
+// and ReadAt on the same path. Run with -race to detect.
+func TestWriteStreamConcurrentReadAt(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Seed initial shadow.
+	if err := ss.WriteFull("/f", []byte("initial"), 1); err != nil {
+		t.Fatal(err)
+	}
+
+	done := make(chan struct{})
+	// Concurrent reader.
+	go func() {
+		defer close(done)
+		buf := make([]byte, 64)
+		for i := 0; i < 200; i++ {
+			_, _ = ss.ReadAt("/f", 0, buf)
+		}
+	}()
+	// Concurrent writer.
+	for i := 0; i < 50; i++ {
+		data := bytes.Repeat([]byte("x"), i+1)
+		_, _ = ss.WriteStream("/f", bytes.NewReader(data), int64(i+2))
+	}
+	<-done
+}
+
+// TestWriteStreamConcurrentReadAtGen verifies no data race between WriteStream
+// and ReadAtGen on a pinned active generation. Run with -race to detect.
+func TestWriteStreamConcurrentReadAtGen(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Seed initial shadow and pin it.
+	if err := ss.WriteFull("/f", []byte("initial"), 1); err != nil {
+		t.Fatal(err)
+	}
+	gen := ss.Pin("/f")
+	defer ss.Unpin(gen)
+
+	done := make(chan struct{})
+	// Concurrent reader via pinned generation.
+	go func() {
+		defer close(done)
+		buf := make([]byte, 64)
+		for i := 0; i < 200; i++ {
+			_, _ = ss.ReadAtGen(gen, 0, buf)
+		}
+	}()
+	// Concurrent writer.
+	for i := 0; i < 50; i++ {
+		data := bytes.Repeat([]byte("x"), i+1)
+		_, _ = ss.WriteStream("/f", bytes.NewReader(data), int64(i+2))
+	}
+	<-done
+}

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -976,7 +976,8 @@ func TestWriteStreamQuotaEnforcement(t *testing.T) {
 	defer ss.Close()
 
 	// WriteStream within quota should succeed.
-	n, err := ss.WriteStream("/f.txt", bytes.NewReader(make([]byte, 50)), 1)
+	origData := bytes.Repeat([]byte("A"), 50)
+	n, err := ss.WriteStream("/f.txt", bytes.NewReader(origData), 1)
 	if err != nil {
 		t.Fatalf("WriteStream within quota should succeed: %v", err)
 	}
@@ -987,14 +988,22 @@ func TestWriteStreamQuotaEnforcement(t *testing.T) {
 		t.Fatalf("expected pending 50, got %d", p)
 	}
 
-	// WriteStream exceeding quota should ENOSPC and rollback.
+	// WriteStream exceeding quota should ENOSPC and preserve original shadow.
 	_, err = ss.WriteStream("/f.txt", bytes.NewReader(make([]byte, 200)), 2)
 	if err != syscall.ENOSPC {
 		t.Fatalf("WriteStream exceeding quota should ENOSPC, got %v", err)
 	}
-	// Pending should be rolled back to 50 (previous successful size).
+	// Pending should still be 50 (original shadow untouched).
 	if p := ss.PendingBytes(); p != 50 {
-		t.Fatalf("expected pending 50 after rollback, got %d", p)
+		t.Fatalf("expected pending 50 after failed stream, got %d", p)
+	}
+	// Original content must be preserved.
+	data, err := ss.ReadAll("/f.txt")
+	if err != nil {
+		t.Fatalf("ReadAll after failed stream: %v", err)
+	}
+	if !bytes.Equal(data, origData) {
+		t.Fatalf("shadow content corrupted: got %d bytes of %q, want 50 bytes of 'A'", len(data), data[:1])
 	}
 }
 

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -967,6 +967,37 @@ func TestReStageNoFalseENOSPC(t *testing.T) {
 	}
 }
 
+func TestWriteStreamQuotaEnforcement(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 100) // 100 byte quota
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// WriteStream within quota should succeed.
+	n, err := ss.WriteStream("/f.txt", bytes.NewReader(make([]byte, 50)), 1)
+	if err != nil {
+		t.Fatalf("WriteStream within quota should succeed: %v", err)
+	}
+	if n != 50 {
+		t.Fatalf("expected 50 bytes written, got %d", n)
+	}
+	if p := ss.PendingBytes(); p != 50 {
+		t.Fatalf("expected pending 50, got %d", p)
+	}
+
+	// WriteStream exceeding quota should ENOSPC and rollback.
+	_, err = ss.WriteStream("/f.txt", bytes.NewReader(make([]byte, 200)), 2)
+	if err != syscall.ENOSPC {
+		t.Fatalf("WriteStream exceeding quota should ENOSPC, got %v", err)
+	}
+	// Pending should be rolled back to 50 (previous successful size).
+	if p := ss.PendingBytes(); p != 50 {
+		t.Fatalf("expected pending 50 after rollback, got %d", p)
+	}
+}
+
 func TestCheckWriteBackQuotaThrottled(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStoreWithQuota(dir, 0.10, 0)

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -931,6 +931,42 @@ func TestPendingBytesNoDoubleCount(t *testing.T) {
 	}
 }
 
+func TestReStageNoFalseENOSPC(t *testing.T) {
+	dir := t.TempDir()
+	// Quota is 1000 bytes.
+	ss, err := NewShadowStoreWithQuota(dir, 0, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Write 800 bytes — within quota.
+	if err := ss.WriteFull("/f.txt", make([]byte, 800), 1); err != nil {
+		t.Fatalf("first write should succeed: %v", err)
+	}
+
+	// Re-stage same path with same 800 bytes — delta is 0, should NOT reject.
+	if err := ss.WriteFull("/f.txt", make([]byte, 800), 2); err != nil {
+		t.Fatalf("re-stage same size should succeed (delta=0): %v", err)
+	}
+
+	// Re-stage with 900 bytes — delta is 100, total 900 < 1000, should succeed.
+	if err := ss.WriteFull("/f.txt", make([]byte, 900), 3); err != nil {
+		t.Fatalf("re-stage with 100 byte growth should succeed: %v", err)
+	}
+
+	// Re-stage with 1100 bytes — delta is 200, total 1100 > 1000, should ENOSPC.
+	err = ss.WriteFull("/f.txt", make([]byte, 1100), 4)
+	if err != syscall.ENOSPC {
+		t.Fatalf("re-stage exceeding quota should ENOSPC, got %v", err)
+	}
+
+	// Pending should still be 900 (last successful write).
+	if p := ss.PendingBytes(); p != 900 {
+		t.Fatalf("expected pending 900 after rejected write, got %d", p)
+	}
+}
+
 func TestCheckWriteBackQuotaThrottled(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStoreWithQuota(dir, 0.10, 0)

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -1007,6 +1007,36 @@ func TestWriteStreamQuotaEnforcement(t *testing.T) {
 	}
 }
 
+func TestWriteStreamPeakDiskBounded(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 100) // 100 byte quota
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Attempt to stream 200 bytes which exceeds the 100-byte quota.
+	// The incremental quota check should abort mid-stream so the temp
+	// file never reaches 200 bytes.
+	_, err = ss.WriteStream("/f.txt", bytes.NewReader(make([]byte, 200)), 1)
+	if err != syscall.ENOSPC {
+		t.Fatalf("expected ENOSPC, got %v", err)
+	}
+
+	// Verify no temp file residue.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) == ".tmp" {
+			t.Fatalf("temp file residue found: %s", e.Name())
+		}
+	}
+
+	// pendingBytes should be 0 (nothing was committed).
+	if p := ss.PendingBytes(); p != 0 {
+		t.Fatalf("expected pending 0, got %d", p)
+	}
+}
+
 func TestEnsureQuotaEnforcement(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStoreWithQuota(dir, 0, 100) // 100 byte quota

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestShadowStoreWriteExtentsReadAt(t *testing.T) {
@@ -1072,6 +1073,36 @@ func TestWriteStreamReplacementPeakBounded(t *testing.T) {
 	}
 	if !bytes.Equal(data, origData) {
 		t.Fatalf("shadow content corrupted after rejected replacement")
+	}
+}
+
+func TestFreeRatioThrottledReEvaluatesCachedCapacity(t *testing.T) {
+	dir := t.TempDir()
+	// free-ratio=0.50 (50% must remain free); no byte quota.
+	ss, err := NewShadowStoreWithQuota(dir, 0.50, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Directly prime the cached Statfs values to simulate a known disk geometry.
+	// Simulated: 1000 bytes total, 600 bytes free (60% free).
+	ss.cachedFreeBytes.Store(600)
+	ss.cachedTotalBytes.Store(1000)
+	// Set lastDiskCheck to now so throttled path uses cached values.
+	ss.lastDiskCheck.Store(time.Now().UnixNano())
+
+	// Small requiredBytes=100: freeAfter=500, ratio=0.50 → pass (barely).
+	if err := ss.checkFreeRatioThrottled(100); err != nil {
+		t.Fatalf("small requiredBytes should pass: %v", err)
+	}
+
+	// Large requiredBytes=200: freeAfter=400, ratio=0.40 < 0.50 → ENOSPC.
+	// This verifies that cached capacity is re-evaluated with the new
+	// requiredBytes, not just returning the cached bool from the first check.
+	err = ss.checkFreeRatioThrottled(200)
+	if err != syscall.ENOSPC {
+		t.Fatalf("large requiredBytes should ENOSPC with cached capacity, got %v", err)
 	}
 }
 

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -1007,6 +1007,43 @@ func TestWriteStreamQuotaEnforcement(t *testing.T) {
 	}
 }
 
+func TestEnsureQuotaEnforcement(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 100) // 100 byte quota
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Ensure within quota should succeed and track pendingBytes.
+	if err := ss.Ensure("/f.txt", 80, 1); err != nil {
+		t.Fatalf("Ensure within quota should succeed: %v", err)
+	}
+	if p := ss.PendingBytes(); p != 80 {
+		t.Fatalf("expected pending 80 after Ensure, got %d", p)
+	}
+
+	// Ensure exceeding quota should ENOSPC.
+	err = ss.Ensure("/f.txt", 200, 2)
+	if err != syscall.ENOSPC {
+		t.Fatalf("Ensure exceeding quota should ENOSPC, got %v", err)
+	}
+	// Pending should still be 80.
+	if p := ss.PendingBytes(); p != 80 {
+		t.Fatalf("expected pending 80 after rejected Ensure, got %d", p)
+	}
+
+	// WriteAt within the Ensured range should not bypass quota.
+	// (delta=0 since WriteAt doesn't grow beyond Ensured size)
+	_, err = ss.WriteAt("/f.txt", 0, make([]byte, 80), 1)
+	if err != nil {
+		t.Fatalf("WriteAt within Ensured size should succeed: %v", err)
+	}
+	if p := ss.PendingBytes(); p != 80 {
+		t.Fatalf("expected pending 80 after WriteAt, got %d", p)
+	}
+}
+
 func TestCheckWriteBackQuotaThrottled(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStoreWithQuota(dir, 0.10, 0)

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -1160,3 +1160,33 @@ func TestCheckWriteBackQuotaThrottled(t *testing.T) {
 		t.Fatalf("throttled results differ: %v vs %v", err1, err2)
 	}
 }
+
+// TestRenamePendingBytesReplacesTarget verifies that Rename subtracts the
+// replaced target's size from pendingBytes.
+func TestRenamePendingBytesReplacesTarget(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Write src=5B, dst=3B.
+	if err := ss.WriteFull("/src", []byte("hello"), 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := ss.WriteFull("/dst", []byte("bye"), 1); err != nil {
+		t.Fatal(err)
+	}
+	if pb := ss.PendingBytes(); pb != 8 {
+		t.Fatalf("before rename: pendingBytes=%d, want 8", pb)
+	}
+
+	// Rename /src → /dst replaces the 3B dst shadow.
+	if !ss.Rename("/src", "/dst") {
+		t.Fatal("Rename returned false")
+	}
+	if pb := ss.PendingBytes(); pb != 5 {
+		t.Fatalf("after rename: pendingBytes=%d, want 5", pb)
+	}
+}

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -1037,6 +1037,44 @@ func TestWriteStreamPeakDiskBounded(t *testing.T) {
 	}
 }
 
+func TestWriteStreamReplacementPeakBounded(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 100) // 100 byte quota
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Write an initial 50-byte shadow.
+	origData := bytes.Repeat([]byte("A"), 50)
+	if _, err := ss.WriteStream("/f.txt", bytes.NewReader(origData), 1); err != nil {
+		t.Fatalf("initial WriteStream: %v", err)
+	}
+	if p := ss.PendingBytes(); p != 50 {
+		t.Fatalf("expected pending 50, got %d", p)
+	}
+
+	// Replace with 100 bytes. Final pending would be 100 (within quota),
+	// but peak disk is old(50) + tmp(100) = 150 which exceeds quota=100.
+	// The quota check uses the full temp size, so this must ENOSPC.
+	_, err = ss.WriteStream("/f.txt", bytes.NewReader(make([]byte, 100)), 2)
+	if err != syscall.ENOSPC {
+		t.Fatalf("expected ENOSPC for replacement peak exceeding quota, got %v", err)
+	}
+
+	// Original shadow must be preserved.
+	if p := ss.PendingBytes(); p != 50 {
+		t.Fatalf("expected pending 50 after rejected replacement, got %d", p)
+	}
+	data, err := ss.ReadAll("/f.txt")
+	if err != nil {
+		t.Fatalf("ReadAll after rejected replacement: %v", err)
+	}
+	if !bytes.Equal(data, origData) {
+		t.Fatalf("shadow content corrupted after rejected replacement")
+	}
+}
+
 func TestEnsureQuotaEnforcement(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStoreWithQuota(dir, 0, 100) // 100 byte quota

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 )
 
@@ -696,5 +697,200 @@ func TestNewShadowStoreSweepsRetiredFiles(t *testing.T) {
 	}
 	if !ss2.Has("/live.txt") {
 		t.Error("live shadow was swept")
+	}
+}
+
+// --- Write-back disk protection tests (Issue #651) ---
+
+func TestCheckWriteBackQuotaByteQuotaAllowed(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 1024) // 1KB quota, no free ratio
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Writing 500 bytes with 0 pending should succeed.
+	if err := ss.CheckWriteBackQuota(500); err != nil {
+		t.Fatalf("expected write to be allowed, got %v", err)
+	}
+}
+
+func TestCheckWriteBackQuotaByteQuotaExceeded(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 1024) // 1KB quota, no free ratio
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Simulate 800 bytes already pending.
+	ss.AddPendingBytes(800)
+
+	// Writing 300 more bytes (total 1100 > 1024) should be rejected.
+	err = ss.CheckWriteBackQuota(300)
+	if err != syscall.ENOSPC {
+		t.Fatalf("expected ENOSPC, got %v", err)
+	}
+}
+
+func TestCheckWriteBackQuotaByteQuotaDisabled(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 0) // both disabled
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	ss.AddPendingBytes(999999999)
+	// With quota disabled, any write should pass.
+	if err := ss.CheckWriteBackQuota(999999999); err != nil {
+		t.Fatalf("expected write to be allowed with quota disabled, got %v", err)
+	}
+}
+
+func TestCheckWriteBackQuotaFreeRatioAllowed(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0.10, 0) // 10% free ratio, no byte quota
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// A small write should succeed (test machine has > 10% free space).
+	if err := ss.CheckWriteBackQuota(1); err != nil {
+		t.Fatalf("expected small write to be allowed, got %v", err)
+	}
+}
+
+func TestCheckWriteBackQuotaFreeRatioExceeded(t *testing.T) {
+	dir := t.TempDir()
+	// Use a free ratio of 0.9999 so any write triggers rejection
+	// (the test machine would need 99.99% free space after the write).
+	ss, err := NewShadowStoreWithQuota(dir, 0.9999, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// A large write should fail because it can't keep 99.99% free.
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(dir, &stat); err != nil {
+		t.Skip("cannot statfs temp dir")
+	}
+	totalBytes := int64(stat.Blocks) * int64(stat.Bsize)
+	err = ss.CheckWriteBackQuota(totalBytes / 2)
+	if err != syscall.ENOSPC {
+		t.Fatalf("expected ENOSPC for large write with 99.99%% free ratio, got %v", err)
+	}
+}
+
+func TestCheckWriteBackQuotaFreeRatioDisabled(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 0) // both disabled
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// With free ratio disabled, write should pass.
+	if err := ss.CheckWriteBackQuota(1 << 30); err != nil {
+		t.Fatalf("expected write allowed with free ratio disabled, got %v", err)
+	}
+}
+
+func TestPendingBytesAddSubRecover(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Initial pending should be 0.
+	if p := ss.PendingBytes(); p != 0 {
+		t.Fatalf("expected initial pending 0, got %d", p)
+	}
+
+	// Add and sub.
+	ss.AddPendingBytes(1000)
+	if p := ss.PendingBytes(); p != 1000 {
+		t.Fatalf("expected pending 1000 after add, got %d", p)
+	}
+
+	ss.SubPendingBytes(400)
+	if p := ss.PendingBytes(); p != 600 {
+		t.Fatalf("expected pending 600 after sub, got %d", p)
+	}
+}
+
+func TestRecoverPendingBytesFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Write some shadow files.
+	if err := ss.WriteFull("/a.txt", []byte("hello"), 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := ss.WriteFull("/b.txt", []byte("world!!"), 2); err != nil {
+		t.Fatal(err)
+	}
+	ss.Close()
+
+	// Create a new store and recover pending bytes.
+	ss2, err := NewShadowStoreWithQuota(dir, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss2.Close()
+
+	ss2.RecoverPendingBytes()
+	// Should recover 5 + 7 = 12 bytes.
+	if p := ss2.PendingBytes(); p != 12 {
+		t.Fatalf("expected recovered pending 12, got %d", p)
+	}
+}
+
+func TestByteQuotaRecoveryAfterCommitCleanup(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0, 100) // 100 byte quota
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// Simulate staging a 80-byte file.
+	ss.AddPendingBytes(80)
+	if err := ss.CheckWriteBackQuota(30); err != syscall.ENOSPC {
+		t.Fatalf("expected ENOSPC when 80+30>100, got %v", err)
+	}
+
+	// Simulate commit cleanup (sub bytes).
+	ss.SubPendingBytes(80)
+
+	// Now writing 30 should succeed again.
+	if err := ss.CheckWriteBackQuota(30); err != nil {
+		t.Fatalf("expected write to succeed after cleanup, got %v", err)
+	}
+}
+
+func TestCheckWriteBackQuotaThrottled(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStoreWithQuota(dir, 0.10, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	// First call should run the real check.
+	err1 := ss.CheckWriteBackQuotaThrottled(1)
+
+	// Second call within interval should return cached result.
+	err2 := ss.CheckWriteBackQuotaThrottled(1)
+	if (err1 == nil) != (err2 == nil) {
+		t.Fatalf("throttled results differ: %v vs %v", err1, err2)
 	}
 }


### PR DESCRIPTION
## Summary

Closes #651

- **Default-on `--write-cache-free-ratio=0.10`**: Statfs check before shadow write, returns `ENOSPC` if free space would drop below threshold after write
- **Opt-in `--write-cache-size-mb=0`**: byte quota disabled by default; only active when explicitly set
- **Guards in all 3 write paths**: `stageShadowLocked`, `snapshotWriteBackLocked`, ShadowSpill write handler — atomic fail before writing, never half-written
- **Atomic pending byte tracking** with `RecoverPendingBytes()` crash-recovery via directory scan on startup
- **CAS-throttled Statfs** (5s interval) on hot paths to avoid syscall overhead
- **Rejection log**: `cache_dir/free_bytes/free_ratio/required_bytes/reason` — no user file path/token

## Test plan

- [x] `TestCheckWriteBackQuotaByteQuotaAllowed` — normal write under quota
- [x] `TestCheckWriteBackQuotaByteQuotaExceeded` — write exceeding byte quota → ENOSPC
- [x] `TestCheckWriteBackQuotaByteQuotaDisabled` — quota=0 allows any write
- [x] `TestCheckWriteBackQuotaFreeRatioAllowed` — small write passes 10% ratio
- [x] `TestCheckWriteBackQuotaFreeRatioExceeded` — 99.99% ratio rejects large writes
- [x] `TestCheckWriteBackQuotaFreeRatioDisabled` — ratio=0 allows any write
- [x] `TestPendingBytesAddSubRecover` — Add/Sub/PendingBytes arithmetic
- [x] `TestRecoverPendingBytesFromDisk` — RecoverPendingBytes scans shadow dir
- [x] `TestByteQuotaRecoveryAfterCommitCleanup` — quota exceeded → sub bytes → write succeeds again
- [x] `TestCheckWriteBackQuotaThrottled` — throttled check returns consistent results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `drive9 mount` flags to tune write-back cache protection: `--write-cache-free-ratio` and `--write-cache-size-mb`.
  * Write-back cache now enforces configurable quota-based space checks with improved pending-write tracking and recovery on restart.
* **Bug Fixes**
  * Improved quota/space failure handling: writes now more consistently return `ENOSPC` when limits are exceeded, with safer pending-bytes accounting across shadow write paths and cleanup.
* **Tests**
  * Expanded coverage for quota/free-ratio enforcement, pending-bytes correctness, throttling behavior, and streaming/write-path edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->