### PR TITLE
Limit DB health probes to metadata store

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -142,18 +142,14 @@ func main() {
 	}
 	defer func() { _ = store.Close() }()
 
-	// Continuously probe registered databases so that a metadata ("meta") or tenant
-	// ("user") store that becomes unreachable *after* startup is visible via the
-	// drive9_db_up gauge and the access log, not just indirectly through failing
-	// traffic. The probe covers the meta store immediately and tenant pools as they
-	// register. The startup ping above only proves reachability at boot.
+	// Continuously probe the long-lived metadata ("meta") store so a control-plane
+	// DB outage after startup is visible via drive9_db_up and logs. Tenant user
+	// and user_schema pools are workload pools; probing them would only keep
+	// short-lived connections warm and compete with business traffic.
 	probeInterval := time.Duration(envInt("DRIVE9_DB_HEALTH_PROBE_INTERVAL_SECONDS", 15)) * time.Second
 	probeTimeout := time.Duration(envInt("DRIVE9_DB_HEALTH_PROBE_TIMEOUT_SECONDS", 3)) * time.Second
-	metrics.StartDBHealthProbe(context.Background(), probeInterval, probeTimeout, func(info metrics.DBPoolInfo, up bool, err error) {
-		fields := []zap.Field{zap.String("role", info.Role)}
-		if info.TenantID != "" {
-			fields = append(fields, zap.String("tenant_id", info.TenantID))
-		}
+	metrics.StartDBHealthProbeWithOptions(context.Background(), probeInterval, probeTimeout, dbHealthProbeOptionsFromEnv(), func(role string, up bool, err error) {
+		fields := []zap.Field{zap.String("role", role)}
 		if up {
 			logger.Info(context.Background(), "db_recovered", fields...)
 			return
@@ -525,6 +521,9 @@ environment:
   DRIVE9_USER_DB_MAX_IDLE_CONNS max idle connections for each cached tenant user DB pool (default: 1)
   DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS max open connections for tenant schema-init DB pools (default: 8)
   DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS max idle connections for tenant schema-init DB pools (default: 0)
+  DRIVE9_DB_HEALTH_PROBE_INTERVAL_SECONDS DB health probe interval seconds (default: 15)
+  DRIVE9_DB_HEALTH_PROBE_TIMEOUT_SECONDS DB health probe timeout seconds (default: 3)
+  DRIVE9_DB_HEALTH_PROBE_META_ENABLED true|false to probe the control-plane DB (default: true)
   DRIVE9_ENCRYPT_TYPE local_aes|kms|aliyun_kms|tencent_kms
   DRIVE9_MASTER_KEY  32-byte hex key for local_aes encryptor
   DRIVE9_ENCRYPT_KEY KMS key id or alias (required for kms/aliyun_kms/tencent_kms)
@@ -923,6 +922,12 @@ func envBool(key string, fallback bool) bool {
 		return false
 	default:
 		return fallback
+	}
+}
+
+func dbHealthProbeOptionsFromEnv() metrics.DBHealthProbeOptions {
+	return metrics.DBHealthProbeOptions{
+		ProbeMeta: envBool("DRIVE9_DB_HEALTH_PROBE_META_ENABLED", true),
 	}
 }
 

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -113,6 +113,36 @@ func TestTenantPoolMaxSizeFromEnv(t *testing.T) {
 	}
 }
 
+func TestDBHealthProbeOptionsFromEnvDefaults(t *testing.T) {
+	keys := []string{
+		"DRIVE9_DB_HEALTH_PROBE_META_ENABLED",
+	}
+	restore := snapshotEnv(t, keys)
+	t.Cleanup(func() { restoreEnv(t, restore) })
+	unsetEnv(t, keys)
+
+	opts := dbHealthProbeOptionsFromEnv()
+	if !opts.ProbeMeta {
+		t.Fatal("ProbeMeta=false, want true")
+	}
+}
+
+func TestDBHealthProbeOptionsFromEnvOverrides(t *testing.T) {
+	keys := []string{
+		"DRIVE9_DB_HEALTH_PROBE_META_ENABLED",
+	}
+	restore := snapshotEnv(t, keys)
+	t.Cleanup(func() { restoreEnv(t, restore) })
+	unsetEnv(t, keys)
+
+	setEnv(t, "DRIVE9_DB_HEALTH_PROBE_META_ENABLED", "false")
+
+	opts := dbHealthProbeOptionsFromEnv()
+	if opts.ProbeMeta {
+		t.Fatal("ProbeMeta=true, want false")
+	}
+}
+
 func TestBuildBackendOptionsFromEnvAudioDisabled(t *testing.T) {
 	keys := []string{
 		"DRIVE9_QUERY_EMBED_API_BASE",

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -278,12 +278,20 @@ func (m *dbMetrics) probeOnceWithOptions(ctx context.Context, timeout time.Durat
 	prevProbe := m.probe
 	nextProbe := make(map[string]dbProbeState, len(results))
 	for role, agg := range results {
+		if !m.hasProbePoolLocked(role, opts) {
+			continue
+		}
 		up := agg.unreachable == 0
 		prev, existed := prevProbe[role]
 		unreachablePools := agg.unreachable
+		transitionErr := agg.firstErr
 		if existed && agg.saturated > 0 && agg.unreachable == 0 {
 			up = prev.up
 			unreachablePools = prev.unreachablePools
+		} else if !existed && agg.saturated > 0 && agg.unreachable == 0 {
+			up = false
+			unreachablePools = agg.total
+			transitionErr = fmt.Errorf("all %s DB probe pools are saturated", role)
 		}
 		nextProbe[role] = dbProbeState{
 			up:               up,
@@ -295,7 +303,7 @@ func (m *dbMetrics) probeOnceWithOptions(ctx context.Context, timeout time.Durat
 		// Fire on the first observed failure, and on every up<->down change
 		// thereafter. A first observation that is healthy is not a transition.
 		if onChange != nil && ((!existed && !up) || (existed && prev.up != up)) {
-			transitions = append(transitions, transition{role: role, up: up, err: agg.firstErr})
+			transitions = append(transitions, transition{role: role, up: up, err: transitionErr})
 		}
 	}
 	m.probe = nextProbe
@@ -419,6 +427,15 @@ func (p registeredDB) metricRole() string {
 func (m *dbMetrics) hasPoolLocked(role string) bool {
 	for _, pool := range m.dbs {
 		if pool.metricRole() == role {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *dbMetrics) hasProbePoolLocked(role string, opts DBHealthProbeOptions) bool {
+	for _, pool := range m.dbs {
+		if pool.metricRole() == role && m.shouldProbePool(pool, opts) {
 			return true
 		}
 	}

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -65,9 +65,9 @@ var dbProbeDuration = dbMeter.Float64Histogram("drive9_db_probe_duration_seconds
 // DefaultDBHealthProbeInterval and DefaultDBHealthProbeTimeout are the fallbacks
 // used by StartDBHealthProbe when callers pass non-positive values.
 const (
-	DefaultDBHealthProbeInterval = 15 * time.Second
-	DefaultDBHealthProbeTimeout  = 3 * time.Second
-	dbRoleMeta                   = "meta"
+	DefaultDBHealthProbeInterval        = 15 * time.Second
+	DefaultDBHealthProbeTimeout         = 3 * time.Second
+	dbRoleMeta                   string = "meta"
 )
 
 // DBHealthProbeOptions controls which registered DB pools are actively pinged.
@@ -199,6 +199,7 @@ func (m *dbMetrics) probeOnceWithOptions(ctx context.Context, timeout time.Durat
 	type roleAgg struct {
 		total       int
 		unreachable int
+		saturated   int
 		firstErr    error
 	}
 	results := map[string]*roleAgg{}
@@ -240,6 +241,9 @@ func (m *dbMetrics) probeOnceWithOptions(ctx context.Context, timeout time.Durat
 			// this state, even if the database is also unreachable underneath.
 			if isDBPoolSaturated(db) {
 				result = "pool_saturated"
+				aggMu.Lock()
+				results[role].saturated++
+				aggMu.Unlock()
 				observeDBProbeDuration(start, role, result)
 				return
 			}
@@ -276,9 +280,14 @@ func (m *dbMetrics) probeOnceWithOptions(ctx context.Context, timeout time.Durat
 	for role, agg := range results {
 		up := agg.unreachable == 0
 		prev, existed := prevProbe[role]
+		unreachablePools := agg.unreachable
+		if existed && agg.saturated > 0 && agg.unreachable == 0 {
+			up = prev.up
+			unreachablePools = prev.unreachablePools
+		}
 		nextProbe[role] = dbProbeState{
 			up:               up,
-			unreachablePools: agg.unreachable,
+			unreachablePools: unreachablePools,
 			totalPools:       agg.total,
 			lastProbe:        now,
 			known:            true,

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -67,6 +67,7 @@ var dbProbeDuration = dbMeter.Float64Histogram("drive9_db_probe_duration_seconds
 const (
 	DefaultDBHealthProbeInterval = 15 * time.Second
 	DefaultDBHealthProbeTimeout  = 3 * time.Second
+	dbRoleMeta                   = "meta"
 )
 
 // DBHealthProbeOptions controls which registered DB pools are actively pinged.
@@ -145,6 +146,12 @@ func StartDBHealthProbeWithOptions(ctx context.Context, interval, timeout time.D
 	}
 	if timeout <= 0 {
 		timeout = DefaultDBHealthProbeTimeout
+	}
+	if !opts.hasEnabledProbes() {
+		globalDB.mu.Lock()
+		globalDB.probe = map[string]dbProbeState{}
+		globalDB.mu.Unlock()
+		return
 	}
 
 	globalDB.mu.Lock()
@@ -410,7 +417,11 @@ func (m *dbMetrics) hasPoolLocked(role string) bool {
 }
 
 func (m *dbMetrics) shouldProbePool(pool registeredDB, opts DBHealthProbeOptions) bool {
-	return pool.metricRole() == "meta" && opts.ProbeMeta
+	return pool.metricRole() == dbRoleMeta && opts.ProbeMeta
+}
+
+func (opts DBHealthProbeOptions) hasEnabledProbes() bool {
+	return opts.ProbeMeta
 }
 
 func isDBPoolSaturated(db *sql.DB) bool {

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -10,13 +10,6 @@ import (
 	"time"
 )
 
-// DBPoolInfo identifies a registered database pool for metrics and health
-// transition logging.
-type DBPoolInfo struct {
-	Role     string
-	TenantID string
-}
-
 // dbProbeState is the cached result of the most recent health probe for a role.
 type dbProbeState struct {
 	up               bool
@@ -39,7 +32,7 @@ type dbMetricKey struct {
 type dbMetrics struct {
 	mu      sync.RWMutex
 	dbs     map[*sql.DB]registeredDB
-	probe   map[dbMetricKey]dbProbeState
+	probe   map[string]dbProbeState
 	started bool
 }
 
@@ -61,7 +54,7 @@ var dbProbeDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25
 
 var globalDB = &dbMetrics{
 	dbs:   map[*sql.DB]registeredDB{},
-	probe: map[dbMetricKey]dbProbeState{},
+	probe: map[string]dbProbeState{},
 }
 
 var dbMeter = globalMeterProvider.Meter("db")
@@ -75,6 +68,13 @@ const (
 	DefaultDBHealthProbeInterval = 15 * time.Second
 	DefaultDBHealthProbeTimeout  = 3 * time.Second
 )
+
+// DBHealthProbeOptions controls which registered DB pools are actively pinged.
+// drive9-server only probes the long-lived control-plane DB; tenant user DB
+// pools are short-lived workload pools and are observed through normal traffic.
+type DBHealthProbeOptions struct {
+	ProbeMeta bool
+}
 
 func RecordDBOperation(role, operation, result string, d time.Duration) {
 	RegisterModule("db")
@@ -106,19 +106,25 @@ func UnregisterDB(db *sql.DB) {
 		return
 	}
 	globalDB.mu.Lock()
+	pool, ok := globalDB.dbs[db]
 	delete(globalDB.dbs, db)
+	if ok {
+		role := pool.metricRole()
+		if !globalDB.hasPoolLocked(role) {
+			delete(globalDB.probe, role)
+		}
+	}
 	globalDB.mu.Unlock()
 }
 
 // StartDBHealthProbe launches a background goroutine that periodically pings every
-// registered *sql.DB and publishes availability as the drive9_db_up gauge. It is
-// the active dependency-health probe for the metadata store ("meta") and tenant
-// data stores ("user"): pool/operation metrics only move while there is live
-// traffic, so an idle-but-unreachable database is otherwise invisible. User DB
-// pool series include tenant_id when the pool was registered with one.
+// registered long-lived dependency *sql.DB and publishes availability as the
+// drive9_db_up gauge. In drive9-server this means the metadata store ("meta").
+// Tenant user/user_schema pools are short-lived workload pools, so probing them
+// would only keep connections warm and compete with business traffic.
 //
 // The probe never blocks the /metrics scrape path — scrapes read the cached probe
-// state. onChange (optional) is invoked outside the lock on a pool key's first
+// state. onChange (optional) is invoked outside the lock on a role's first
 // observed failure and on every subsequent up<->down transition, so callers can
 // emit a log without coupling this package to a logger. The goroutine stops when
 // ctx is done; repeat calls after the first are no-ops.
@@ -126,7 +132,14 @@ func UnregisterDB(db *sql.DB) {
 // Example alert (critical — control-plane DB unreachable):
 //
 //	max(drive9_db_up{role="meta"}) == 0
-func StartDBHealthProbe(ctx context.Context, interval, timeout time.Duration, onChange func(info DBPoolInfo, up bool, err error)) {
+func StartDBHealthProbe(ctx context.Context, interval, timeout time.Duration, onChange func(role string, up bool, err error)) {
+	StartDBHealthProbeWithOptions(ctx, interval, timeout, DBHealthProbeOptions{
+		ProbeMeta: true,
+	}, onChange)
+}
+
+// StartDBHealthProbeWithOptions is StartDBHealthProbe with role filtering.
+func StartDBHealthProbeWithOptions(ctx context.Context, interval, timeout time.Duration, opts DBHealthProbeOptions, onChange func(role string, up bool, err error)) {
 	if interval <= 0 {
 		interval = DefaultDBHealthProbeInterval
 	}
@@ -145,13 +158,13 @@ func StartDBHealthProbe(ctx context.Context, interval, timeout time.Duration, on
 	go func() {
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
-		globalDB.probeOnce(ctx, timeout, onChange)
+		globalDB.probeOnceWithOptions(ctx, timeout, opts, onChange)
 		for {
 			select {
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				globalDB.probeOnce(ctx, timeout, onChange)
+				globalDB.probeOnceWithOptions(ctx, timeout, opts, onChange)
 			}
 		}
 	}()
@@ -159,10 +172,19 @@ func StartDBHealthProbe(ctx context.Context, interval, timeout time.Duration, on
 
 // probeOnce runs a single probe cycle across all registered pools and updates the
 // cached per-role state. Exported indirectly for tests via probeOnce.
-func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChange func(info DBPoolInfo, up bool, err error)) {
+func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChange func(role string, up bool, err error)) {
+	m.probeOnceWithOptions(ctx, timeout, DBHealthProbeOptions{
+		ProbeMeta: true,
+	}, onChange)
+}
+
+func (m *dbMetrics) probeOnceWithOptions(ctx context.Context, timeout time.Duration, opts DBHealthProbeOptions, onChange func(role string, up bool, err error)) {
 	m.mu.RLock()
 	dbByPool := make(map[*sql.DB]registeredDB, len(m.dbs))
 	for db, pool := range m.dbs {
+		if !m.shouldProbePool(pool, opts) {
+			continue
+		}
 		dbByPool[db] = pool
 	}
 	m.mu.RUnlock()
@@ -172,27 +194,25 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 		unreachable int
 		firstErr    error
 	}
-	results := map[dbMetricKey]*roleAgg{}
+	results := map[string]*roleAgg{}
 	for _, pool := range dbByPool {
-		key := pool.metricKey()
-		if results[key] == nil {
-			results[key] = &roleAgg{}
+		role := pool.metricRole()
+		if results[role] == nil {
+			results[role] = &roleAgg{}
 		}
-		results[key].total++
+		results[role].total++
 	}
 
 	// Ping pools concurrently with a fixed bound so one slow/unreachable pool
-	// cannot serialize the whole cycle: with many unreachable tenant ("user")
-	// pools a serial loop would burn timeout*N and leave drive9_db_up stale.
+	// cannot serialize the whole cycle if multiple long-lived DB dependencies
+	// are registered in tests or future server modes.
 	const probeConcurrency = 8
 	sem := make(chan struct{}, probeConcurrency)
 	var wg sync.WaitGroup
 	var aggMu sync.Mutex
-	poolsByKey := map[dbMetricKey]registeredDB{}
 	for db, pool := range dbByPool {
 		db, pool := db, pool
-		key := pool.metricKey()
-		poolsByKey[key] = pool
+		role := pool.metricRole()
 		wg.Add(1)
 		sem <- struct{}{}
 		go func() {
@@ -213,7 +233,7 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 			// this state, even if the database is also unreachable underneath.
 			if isDBPoolSaturated(db) {
 				result = "pool_saturated"
-				observeDBProbeDuration(start, key, result)
+				observeDBProbeDuration(start, role, result)
 				return
 			}
 
@@ -223,20 +243,20 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 			if err != nil {
 				result = "error"
 				aggMu.Lock()
-				agg := results[key]
+				agg := results[role]
 				agg.unreachable++
 				if agg.firstErr == nil {
 					agg.firstErr = err
 				}
 				aggMu.Unlock()
 			}
-			observeDBProbeDuration(start, key, result)
+			observeDBProbeDuration(start, role, result)
 		}()
 	}
 	wg.Wait()
 
 	type transition struct {
-		info DBPoolInfo
+		role string
 		up   bool
 		err  error
 	}
@@ -245,12 +265,11 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 
 	m.mu.Lock()
 	prevProbe := m.probe
-	nextProbe := make(map[dbMetricKey]dbProbeState, len(results))
-	for key, agg := range results {
-		pool := poolsByKey[key]
+	nextProbe := make(map[string]dbProbeState, len(results))
+	for role, agg := range results {
 		up := agg.unreachable == 0
-		prev, existed := prevProbe[key]
-		nextProbe[key] = dbProbeState{
+		prev, existed := prevProbe[role]
+		nextProbe[role] = dbProbeState{
 			up:               up,
 			unreachablePools: agg.unreachable,
 			totalPools:       agg.total,
@@ -260,14 +279,14 @@ func (m *dbMetrics) probeOnce(ctx context.Context, timeout time.Duration, onChan
 		// Fire on the first observed failure, and on every up<->down change
 		// thereafter. A first observation that is healthy is not a transition.
 		if onChange != nil && ((!existed && !up) || (existed && prev.up != up)) {
-			transitions = append(transitions, transition{info: pool.info(), up: up, err: agg.firstErr})
+			transitions = append(transitions, transition{role: role, up: up, err: agg.firstErr})
 		}
 	}
 	m.probe = nextProbe
 	m.mu.Unlock()
 
 	for _, t := range transitions {
-		onChange(t.info, t.up, t.err)
+		onChange(t.role, t.up, t.err)
 	}
 }
 
@@ -299,34 +318,35 @@ func writeDBPrometheus(w http.ResponseWriter) {
 	keys := sortedDBMetricKeys(poolTotals)
 
 	globalDB.mu.RLock()
-	probeByKey := make(map[dbMetricKey]dbProbeState, len(globalDB.probe))
-	for key, state := range globalDB.probe {
-		probeByKey[key] = state
+	probeByRole := make(map[string]dbProbeState, len(globalDB.probe))
+	for role, state := range globalDB.probe {
+		probeByRole[role] = state
 	}
 	globalDB.mu.RUnlock()
 
-	// drive9_db_up is the active availability signal: 1 when every registered pool
+	probeRoles := SortedKeys(probeByRole)
+
+	// drive9_db_up is the active availability signal: 1 when every probed pool
 	// for the role answered its last health ping, 0 when any pool is unreachable.
-	// Roles not yet probed default to 1 (the startup ping already succeeded), so the
-	// `== 0` alert never fires on a cold series.
-	_, _ = fmt.Fprintln(w, "# HELP drive9_db_up Database availability by role (1 = all registered pools reachable on last probe)")
+	// Unprobed roles/pools do not emit a cold availability series.
+	_, _ = fmt.Fprintln(w, "# HELP drive9_db_up Database availability by role (1 = all probed pools reachable on last probe)")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_up gauge")
-	for _, key := range keys {
+	for _, role := range probeRoles {
 		up := 1.0
-		if state, ok := probeByKey[key]; ok && state.known && !state.up {
+		if state, ok := probeByRole[role]; ok && state.known && !state.up {
 			up = 0.0
 		}
-		_, _ = fmt.Fprintf(w, "drive9_db_up{%s} %s\n", dbLabels(key), formatFloat(up))
+		_, _ = fmt.Fprintf(w, "drive9_db_up{role=\"%s\"} %s\n", EscapePromLabel(role), formatFloat(up))
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_unreachable_pools Registered pools that failed their last health probe by role")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_unreachable_pools gauge")
-	for _, key := range keys {
+	for _, role := range probeRoles {
 		unreachable := 0
-		if state, ok := probeByKey[key]; ok && state.known {
+		if state, ok := probeByRole[role]; ok && state.known {
 			unreachable = state.unreachablePools
 		}
-		_, _ = fmt.Fprintf(w, "drive9_db_unreachable_pools{%s} %d\n", dbLabels(key), unreachable)
+		_, _ = fmt.Fprintf(w, "drive9_db_unreachable_pools{role=\"%s\"} %d\n", EscapePromLabel(role), unreachable)
 	}
 
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_registered Database pools currently registered for metrics by role")
@@ -370,16 +390,27 @@ func writeDBPrometheus(w http.ResponseWriter) {
 }
 
 func (p registeredDB) metricKey() dbMetricKey {
-	return dbMetricKey{role: cleanMetricValue(p.role, "unknown"), tenantID: cleanMetricValue(p.tenantID, "unknown")}
+	return dbMetricKey{
+		role:     cleanMetricValue(p.role, "unknown"),
+		tenantID: cleanMetricValue(p.tenantID, "unknown"),
+	}
 }
 
-func (p registeredDB) info() DBPoolInfo {
-	key := p.metricKey()
-	info := DBPoolInfo{Role: key.role}
-	if key.tenantID != "unknown" {
-		info.TenantID = key.tenantID
+func (p registeredDB) metricRole() string {
+	return cleanMetricValue(p.role, "unknown")
+}
+
+func (m *dbMetrics) hasPoolLocked(role string) bool {
+	for _, pool := range m.dbs {
+		if pool.metricRole() == role {
+			return true
+		}
 	}
-	return info
+	return false
+}
+
+func (m *dbMetrics) shouldProbePool(pool registeredDB, opts DBHealthProbeOptions) bool {
+	return pool.metricRole() == "meta" && opts.ProbeMeta
 }
 
 func isDBPoolSaturated(db *sql.DB) bool {
@@ -387,13 +418,10 @@ func isDBPoolSaturated(db *sql.DB) bool {
 	return stats.MaxOpenConnections > 0 && stats.Idle == 0 && stats.InUse >= stats.MaxOpenConnections
 }
 
-func observeDBProbeDuration(start time.Time, key dbMetricKey, result string) {
+func observeDBProbeDuration(start time.Time, role, result string) {
 	attrs := []Attribute{
-		Attr("role", key.role),
+		Attr("role", role),
 		Attr("result", result),
-	}
-	if key.tenantID != "" && key.tenantID != "unknown" {
-		attrs = append(attrs, Attr("tenant_id", key.tenantID))
 	}
 	dbProbeDuration.Observe(time.Since(start).Seconds(), attrs...)
 }

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -230,13 +230,19 @@ func TestDBHealthProbeDropsUnregisteredState(t *testing.T) {
 
 	RegisterDB(role, db)
 	globalDB.probeOnce(context.Background(), time.Second, nil)
-	if _, ok := globalDB.probe[role]; !ok {
+	globalDB.mu.RLock()
+	_, ok := globalDB.probe[role]
+	globalDB.mu.RUnlock()
+	if !ok {
 		t.Fatalf("expected probe state to be recorded")
 	}
 
 	UnregisterDB(db)
 	globalDB.probeOnce(context.Background(), time.Second, nil)
-	if _, ok := globalDB.probe[role]; ok {
+	globalDB.mu.RLock()
+	_, ok = globalDB.probe[role]
+	globalDB.mu.RUnlock()
+	if ok {
 		t.Fatalf("expected probe state to be removed after unregister")
 	}
 }
@@ -279,5 +285,40 @@ func TestDBHealthProbeDoesNotMarkSaturatedMetaPoolDown(t *testing.T) {
 	fullText := rec.Body.String()
 	if !strings.Contains(fullText, `drive9_db_probe_duration_seconds_bucket{result="pool_saturated",role="meta"`) {
 		t.Fatalf("expected saturated meta probe duration series, got:\n%s", fullText)
+	}
+}
+
+func TestDBHealthProbeKeepsPreviousDownStateWhenMetaPoolSaturated(t *testing.T) {
+	healthy := &atomic.Bool{}
+	healthy.Store(false)
+	db := sql.OpenDB(fakeConnector{healthy: healthy})
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() {
+		UnregisterDB(db)
+		globalDB.probeOnce(context.Background(), time.Second, nil)
+		_ = db.Close()
+	})
+
+	RegisterDB("meta", db)
+	globalDB.probeOnce(context.Background(), time.Second, nil)
+	if out := renderDB(t); !strings.Contains(out, `drive9_db_up{role="meta"} 0`) {
+		t.Fatalf("expected failed probe to mark meta down, got:\n%s", out)
+	}
+
+	healthy.Store(true)
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open held conn: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	globalDB.probeOnce(context.Background(), 10*time.Millisecond, nil)
+	out := renderDB(t)
+	if !strings.Contains(out, `drive9_db_up{role="meta"} 0`) {
+		t.Fatalf("expected saturated meta pool to preserve previous down state, got:\n%s", out)
+	}
+	if !strings.Contains(out, `drive9_db_unreachable_pools{role="meta"} 1`) {
+		t.Fatalf("expected saturated meta pool to preserve previous unreachable count, got:\n%s", out)
 	}
 }

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -17,13 +17,14 @@ import (
 // toggled at runtime so the health probe can be exercised without a real MySQL.
 type fakeConnector struct {
 	healthy *atomic.Bool
+	ping    func(context.Context) error
 }
 
 func (c fakeConnector) Connect(context.Context) (driver.Conn, error) {
 	if !c.healthy.Load() {
 		return nil, errors.New("fake db unreachable")
 	}
-	return fakeConn(c), nil
+	return fakeConn{healthy: c.healthy, ping: c.ping}, nil
 }
 
 func (c fakeConnector) Driver() driver.Driver { return fakeDriver{} }
@@ -34,13 +35,17 @@ func (fakeDriver) Open(string) (driver.Conn, error) { return nil, errors.New("no
 
 type fakeConn struct {
 	healthy *atomic.Bool
+	ping    func(context.Context) error
 }
 
 func (fakeConn) Prepare(string) (driver.Stmt, error) { return nil, errors.New("not supported") }
 func (fakeConn) Close() error                        { return nil }
 func (fakeConn) Begin() (driver.Tx, error)           { return nil, errors.New("not supported") }
 
-func (c fakeConn) Ping(context.Context) error {
+func (c fakeConn) Ping(ctx context.Context) error {
+	if c.ping != nil {
+		return c.ping(ctx)
+	}
 	if !c.healthy.Load() {
 		return driver.ErrBadConn
 	}
@@ -247,7 +252,7 @@ func TestDBHealthProbeDropsUnregisteredState(t *testing.T) {
 	}
 }
 
-func TestDBHealthProbeDoesNotMarkSaturatedMetaPoolDown(t *testing.T) {
+func TestDBHealthProbeKeepsPreviousUpStateWhenMetaPoolSaturated(t *testing.T) {
 	healthy := &atomic.Bool{}
 	healthy.Store(true)
 	db := sql.OpenDB(fakeConnector{healthy: healthy})
@@ -259,13 +264,18 @@ func TestDBHealthProbeDoesNotMarkSaturatedMetaPoolDown(t *testing.T) {
 		_ = db.Close()
 	})
 
+	RegisterDB("meta", db)
+	globalDB.probeOnce(context.Background(), time.Second, nil)
+	if out := renderDB(t); !strings.Contains(out, `drive9_db_up{role="meta"} 1`) {
+		t.Fatalf("expected initial healthy meta probe, got:\n%s", out)
+	}
+
 	conn, err := db.Conn(context.Background())
 	if err != nil {
 		t.Fatalf("open held conn: %v", err)
 	}
 	t.Cleanup(func() { _ = conn.Close() })
 
-	RegisterDB("meta", db)
 	globalDB.probeOnce(context.Background(), 10*time.Millisecond, func(role string, up bool, err error) {
 		if role == "meta" {
 			t.Fatalf("expected no down transition for saturated meta pool, got up=%v err=%v", up, err)
@@ -285,6 +295,50 @@ func TestDBHealthProbeDoesNotMarkSaturatedMetaPoolDown(t *testing.T) {
 	fullText := rec.Body.String()
 	if !strings.Contains(fullText, `drive9_db_probe_duration_seconds_bucket{result="pool_saturated",role="meta"`) {
 		t.Fatalf("expected saturated meta probe duration series, got:\n%s", fullText)
+	}
+}
+
+func TestDBHealthProbeMarksFirstSaturatedMetaPoolDown(t *testing.T) {
+	healthy := &atomic.Bool{}
+	healthy.Store(true)
+	db := sql.OpenDB(fakeConnector{healthy: healthy})
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() {
+		UnregisterDB(db)
+		globalDB.probeOnce(context.Background(), time.Second, nil)
+		_ = db.Close()
+	})
+
+	conn, err := db.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open held conn: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	var changes []struct {
+		up  bool
+		err error
+	}
+	RegisterDB("meta", db)
+	globalDB.probeOnce(context.Background(), 10*time.Millisecond, func(role string, up bool, err error) {
+		if role == "meta" {
+			changes = append(changes, struct {
+				up  bool
+				err error
+			}{up: up, err: err})
+		}
+	})
+
+	out := renderDB(t)
+	if !strings.Contains(out, `drive9_db_up{role="meta"} 0`) {
+		t.Fatalf("expected first saturated meta probe to mark role down, got:\n%s", out)
+	}
+	if !strings.Contains(out, `drive9_db_unreachable_pools{role="meta"} 1`) {
+		t.Fatalf("expected first saturated meta probe to count the unverified pool, got:\n%s", out)
+	}
+	if len(changes) != 1 || changes[0].up || changes[0].err == nil {
+		t.Fatalf("expected one down transition with saturation error, got %+v", changes)
 	}
 }
 
@@ -359,5 +413,62 @@ func TestDBHealthProbeMarksRoleDownWhenOneMetaPoolSaturatedAndAnotherUnreachable
 	}
 	if !strings.Contains(out, `drive9_db_unreachable_pools{role="meta"} 1`) {
 		t.Fatalf("expected only the unreachable meta pool to count as unreachable, got:\n%s", out)
+	}
+}
+
+func TestDBHealthProbeDoesNotResurrectUnregisteredRoleAfterInFlightProbe(t *testing.T) {
+	const role = "meta"
+
+	healthy := &atomic.Bool{}
+	healthy.Store(true)
+	pingStarted := make(chan struct{})
+	releasePing := make(chan struct{})
+	var closeStarted sync.Once
+	db := sql.OpenDB(fakeConnector{
+		healthy: healthy,
+		ping: func(ctx context.Context) error {
+			closeStarted.Do(func() { close(pingStarted) })
+			select {
+			case <-releasePing:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		},
+	})
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() {
+		UnregisterDB(db)
+		globalDB.probeOnce(context.Background(), time.Second, nil)
+		_ = db.Close()
+	})
+
+	RegisterDB(role, db)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		globalDB.probeOnce(context.Background(), time.Second, nil)
+	}()
+
+	select {
+	case <-pingStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for probe ping to start")
+	}
+
+	UnregisterDB(db)
+	close(releasePing)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for in-flight probe to finish")
+	}
+
+	globalDB.mu.RLock()
+	_, ok := globalDB.probe[role]
+	globalDB.mu.RUnlock()
+	if ok {
+		t.Fatalf("expected in-flight probe not to resurrect unregistered role")
 	}
 }

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -322,3 +322,42 @@ func TestDBHealthProbeKeepsPreviousDownStateWhenMetaPoolSaturated(t *testing.T) 
 		t.Fatalf("expected saturated meta pool to preserve previous unreachable count, got:\n%s", out)
 	}
 }
+
+func TestDBHealthProbeMarksRoleDownWhenOneMetaPoolSaturatedAndAnotherUnreachable(t *testing.T) {
+	saturatedHealthy := &atomic.Bool{}
+	saturatedHealthy.Store(true)
+	saturatedDB := sql.OpenDB(fakeConnector{healthy: saturatedHealthy})
+	saturatedDB.SetMaxOpenConns(1)
+	saturatedDB.SetMaxIdleConns(0)
+
+	unreachableHealthy := &atomic.Bool{}
+	unreachableHealthy.Store(false)
+	unreachableDB := sql.OpenDB(fakeConnector{healthy: unreachableHealthy})
+	unreachableDB.SetMaxIdleConns(0)
+
+	t.Cleanup(func() {
+		UnregisterDB(saturatedDB)
+		UnregisterDB(unreachableDB)
+		globalDB.probeOnce(context.Background(), time.Second, nil)
+		_ = saturatedDB.Close()
+		_ = unreachableDB.Close()
+	})
+
+	conn, err := saturatedDB.Conn(context.Background())
+	if err != nil {
+		t.Fatalf("open held conn: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	RegisterDB("meta", saturatedDB)
+	RegisterDB("meta", unreachableDB)
+	globalDB.probeOnce(context.Background(), 10*time.Millisecond, nil)
+
+	out := renderDB(t)
+	if !strings.Contains(out, `drive9_db_up{role="meta"} 0`) {
+		t.Fatalf("expected mixed saturated/unreachable meta pools to mark role down, got:\n%s", out)
+	}
+	if !strings.Contains(out, `drive9_db_unreachable_pools{role="meta"} 1`) {
+		t.Fatalf("expected only the unreachable meta pool to count as unreachable, got:\n%s", out)
+	}
+}

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -55,7 +55,7 @@ func renderDB(t *testing.T) string {
 }
 
 func TestDBHealthProbeFlipsDriveDBUp(t *testing.T) {
-	const role = "probe_test_role"
+	const role = "meta"
 
 	healthy := &atomic.Bool{}
 	healthy.Store(true)
@@ -72,8 +72,8 @@ func TestDBHealthProbeFlipsDriveDBUp(t *testing.T) {
 		err error
 	}
 	var changes []change
-	onChange := func(info DBPoolInfo, up bool, err error) {
-		if info.Role != role {
+	onChange := func(gotRole string, up bool, err error) {
+		if gotRole != role {
 			return
 		}
 		mu.Lock()
@@ -124,7 +124,7 @@ func TestDBHealthProbeFlipsDriveDBUp(t *testing.T) {
 	}
 }
 
-func TestDBMetricsIncludeTenantIDForTenantPools(t *testing.T) {
+func TestDBHealthProbeSkipsTenantPools(t *testing.T) {
 	const (
 		role     = "user"
 		tenantID = "tenant-db-metrics-test"
@@ -144,8 +144,11 @@ func TestDBMetricsIncludeTenantIDForTenantPools(t *testing.T) {
 	globalDB.probeOnce(context.Background(), time.Second, nil)
 	out := renderDB(t)
 
-	if !strings.Contains(out, `drive9_db_up{role="user",tenant_id="`+tenantID+`"} 1`) {
-		t.Fatalf("expected tenant db_up series, got:\n%s", out)
+	if strings.Contains(out, `drive9_db_up{role="user"`) {
+		t.Fatalf("expected user pool to have no db_up series, got:\n%s", out)
+	}
+	if strings.Contains(out, `drive9_db_unreachable_pools{role="user"`) {
+		t.Fatalf("expected user pool to have no unreachable probe series, got:\n%s", out)
 	}
 	if !strings.Contains(out, `drive9_db_pool_registered{role="user",tenant_id="`+tenantID+`"} 1`) {
 		t.Fatalf("expected tenant pool_registered series, got:\n%s", out)
@@ -156,13 +159,36 @@ func TestDBMetricsIncludeTenantIDForTenantPools(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	fullText := rec.Body.String()
-	if !strings.Contains(fullText, `drive9_db_probe_duration_seconds_bucket{result="ok",role="user",tenant_id="`+tenantID+`"`) {
-		t.Fatalf("expected tenant probe duration series, got:\n%s", fullText)
+	if strings.Contains(fullText, `drive9_db_probe_duration_seconds_bucket{result="ok",role="user"`) {
+		t.Fatalf("expected user pool to have no probe duration series, got:\n%s", fullText)
 	}
 }
 
-func TestDBHealthProbeDropsUnregisteredTenantState(t *testing.T) {
-	const tenantID = "tenant-db-unregister-test"
+func TestDBHealthProbeSkipsUserSchemaPools(t *testing.T) {
+	healthy := &atomic.Bool{}
+	healthy.Store(true)
+	db := sql.OpenDB(fakeConnector{healthy: healthy})
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() {
+		UnregisterDB(db)
+		globalDB.probeOnce(context.Background(), time.Second, nil)
+		_ = db.Close()
+	})
+
+	RegisterDB("user_schema", db)
+	globalDB.probeOnce(context.Background(), time.Second, nil)
+
+	out := renderDB(t)
+	if strings.Contains(out, `drive9_db_up{role="user_schema"`) {
+		t.Fatalf("expected user_schema to have no db_up series, got:\n%s", out)
+	}
+	if !strings.Contains(out, `drive9_db_pool_registered{role="user_schema"} 1`) {
+		t.Fatalf("expected role-only user_schema pool stats to remain visible, got:\n%s", out)
+	}
+}
+
+func TestDBHealthProbeDropsUnregisteredState(t *testing.T) {
+	const role = "meta"
 
 	healthy := &atomic.Bool{}
 	healthy.Store(false)
@@ -174,59 +200,16 @@ func TestDBHealthProbeDropsUnregisteredTenantState(t *testing.T) {
 		_ = db.Close()
 	})
 
-	RegisterTenantDB("user", tenantID, db)
+	RegisterDB(role, db)
 	globalDB.probeOnce(context.Background(), time.Second, nil)
-	if _, ok := globalDB.probe[dbMetricKey{role: "user", tenantID: tenantID}]; !ok {
-		t.Fatalf("expected tenant probe state to be recorded")
+	if _, ok := globalDB.probe[role]; !ok {
+		t.Fatalf("expected probe state to be recorded")
 	}
 
 	UnregisterDB(db)
 	globalDB.probeOnce(context.Background(), time.Second, nil)
-	if _, ok := globalDB.probe[dbMetricKey{role: "user", tenantID: tenantID}]; ok {
-		t.Fatalf("expected tenant probe state to be removed after unregister")
-	}
-}
-
-func TestDBHealthProbeDoesNotMarkSaturatedTenantPoolDown(t *testing.T) {
-	const tenantID = "tenant-db-saturated-test"
-
-	healthy := &atomic.Bool{}
-	healthy.Store(true)
-	db := sql.OpenDB(fakeConnector{healthy: healthy})
-	db.SetMaxOpenConns(1)
-	db.SetMaxIdleConns(0)
-	t.Cleanup(func() {
-		UnregisterDB(db)
-		globalDB.probeOnce(context.Background(), time.Second, nil)
-		_ = db.Close()
-	})
-
-	conn, err := db.Conn(context.Background())
-	if err != nil {
-		t.Fatalf("open held conn: %v", err)
-	}
-	t.Cleanup(func() { _ = conn.Close() })
-
-	RegisterTenantDB("user", tenantID, db)
-	globalDB.probeOnce(context.Background(), 10*time.Millisecond, func(info DBPoolInfo, up bool, err error) {
-		if info.TenantID == tenantID {
-			t.Fatalf("expected no down transition for saturated tenant pool, got up=%v err=%v", up, err)
-		}
-	})
-
-	out := renderDB(t)
-	if !strings.Contains(out, `drive9_db_up{role="user",tenant_id="`+tenantID+`"} 1`) {
-		t.Fatalf("expected saturated tenant pool to remain up, got:\n%s", out)
-	}
-	if !strings.Contains(out, `drive9_db_unreachable_pools{role="user",tenant_id="`+tenantID+`"} 0`) {
-		t.Fatalf("expected saturated tenant pool not to count as unreachable, got:\n%s", out)
-	}
-
-	rec := httptest.NewRecorder()
-	WritePrometheus(rec)
-	fullText := rec.Body.String()
-	if !strings.Contains(fullText, `drive9_db_probe_duration_seconds_bucket{result="pool_saturated",role="user",tenant_id="`+tenantID+`"`) {
-		t.Fatalf("expected saturated probe duration series, got:\n%s", fullText)
+	if _, ok := globalDB.probe[role]; ok {
+		t.Fatalf("expected probe state to be removed after unregister")
 	}
 }
 
@@ -249,8 +232,8 @@ func TestDBHealthProbeDoesNotMarkSaturatedMetaPoolDown(t *testing.T) {
 	t.Cleanup(func() { _ = conn.Close() })
 
 	RegisterDB("meta", db)
-	globalDB.probeOnce(context.Background(), 10*time.Millisecond, func(info DBPoolInfo, up bool, err error) {
-		if info.Role == "meta" {
+	globalDB.probeOnce(context.Background(), 10*time.Millisecond, func(role string, up bool, err error) {
+		if role == "meta" {
 			t.Fatalf("expected no down transition for saturated meta pool, got up=%v err=%v", up, err)
 		}
 	})
@@ -268,8 +251,5 @@ func TestDBHealthProbeDoesNotMarkSaturatedMetaPoolDown(t *testing.T) {
 	fullText := rec.Body.String()
 	if !strings.Contains(fullText, `drive9_db_probe_duration_seconds_bucket{result="pool_saturated",role="meta"`) {
 		t.Fatalf("expected saturated meta probe duration series, got:\n%s", fullText)
-	}
-	if strings.Contains(fullText, `role="meta",tenant_id=`) {
-		t.Fatalf("expected meta probe duration series to omit tenant_id, got:\n%s", fullText)
 	}
 }

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -187,6 +187,34 @@ func TestDBHealthProbeSkipsUserSchemaPools(t *testing.T) {
 	}
 }
 
+func TestStartDBHealthProbeDisabledDoesNotStart(t *testing.T) {
+	globalDB.mu.Lock()
+	origStarted := globalDB.started
+	origProbe := globalDB.probe
+	globalDB.started = false
+	globalDB.probe = map[string]dbProbeState{
+		dbRoleMeta: {up: true, known: true},
+	}
+	globalDB.mu.Unlock()
+	t.Cleanup(func() {
+		globalDB.mu.Lock()
+		globalDB.started = origStarted
+		globalDB.probe = origProbe
+		globalDB.mu.Unlock()
+	})
+
+	StartDBHealthProbeWithOptions(context.Background(), time.Millisecond, time.Millisecond, DBHealthProbeOptions{}, nil)
+
+	globalDB.mu.RLock()
+	defer globalDB.mu.RUnlock()
+	if globalDB.started {
+		t.Fatal("disabled health probe started background goroutine")
+	}
+	if len(globalDB.probe) != 0 {
+		t.Fatalf("disabled health probe kept stale probe state: %+v", globalDB.probe)
+	}
+}
+
 func TestDBHealthProbeDropsUnregisteredState(t *testing.T) {
 	const role = "meta"
 

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -24,7 +24,7 @@ func (c fakeConnector) Connect(context.Context) (driver.Conn, error) {
 	if !c.healthy.Load() {
 		return nil, errors.New("fake db unreachable")
 	}
-	return fakeConn{healthy: c.healthy, ping: c.ping}, nil
+	return fakeConn(c), nil
 }
 
 func (c fakeConnector) Driver() driver.Driver { return fakeDriver{} }

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -28,7 +28,7 @@ func OpenInstrumentedForTenant(ctx context.Context, dsn, role, tenantID string) 
 	if err != nil {
 		return nil, fmt.Errorf("open mysql connector: %w", err)
 	}
-	db := sql.OpenDB(instrumentedConnector{base: connector, role: role, tenantID: tenantID})
+	db := sql.OpenDB(instrumentedConnector{base: connector, role: role})
 	ApplyPoolDefaults(db, role)
 	metrics.RegisterTenantDB(role, tenantID, db)
 	if err := db.PingContext(ctx); err != nil {
@@ -48,21 +48,20 @@ func CloseInstrumented(db *sql.DB) error {
 }
 
 type instrumentedConnector struct {
-	base     driver.Connector
-	role     string
-	tenantID string
+	base driver.Connector
+	role string
 }
 
 func (c instrumentedConnector) Connect(ctx context.Context) (driver.Conn, error) {
 	start := time.Now()
 	conn, err := c.base.Connect(ctx)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, c.role, c.tenantID, "connect", start, err)
+		observeDBOperation(c.role, "connect", start, err)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return instrumentedConn{base: conn, role: c.role, tenantID: c.tenantID}, nil
+	return instrumentedConn{base: conn, role: c.role}, nil
 }
 
 func (c instrumentedConnector) Driver() driver.Driver {
@@ -70,21 +69,20 @@ func (c instrumentedConnector) Driver() driver.Driver {
 }
 
 type instrumentedConn struct {
-	base     driver.Conn
-	role     string
-	tenantID string
+	base driver.Conn
+	role string
 }
 
 func (c instrumentedConn) Prepare(query string) (driver.Stmt, error) {
 	start := time.Now()
 	stmt, err := c.base.Prepare(query)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(context.Background(), c.role, c.tenantID, "prepare", start, err)
+		observeDBOperation(c.role, "prepare", start, err)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return instrumentedStmt{base: stmt, role: c.role, tenantID: c.tenantID}, nil
+	return instrumentedStmt{base: stmt, role: c.role}, nil
 }
 
 func (c instrumentedConn) Close() error {
@@ -103,7 +101,7 @@ func (c instrumentedConn) Ping(ctx context.Context) error {
 	start := time.Now()
 	err := pinger.Ping(ctx)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, c.role, c.tenantID, "ping", start, err)
+		observeDBOperation(c.role, "ping", start, err)
 	}
 	return err
 }
@@ -116,12 +114,12 @@ func (c instrumentedConn) PrepareContext(ctx context.Context, query string) (dri
 	start := time.Now()
 	stmt, err := prep.PrepareContext(ctx, query)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, c.role, c.tenantID, "prepare", start, err)
+		observeDBOperation(c.role, "prepare", start, err)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return instrumentedStmt{base: stmt, role: c.role, tenantID: c.tenantID}, nil
+	return instrumentedStmt{base: stmt, role: c.role}, nil
 }
 
 func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
@@ -129,12 +127,12 @@ func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (d
 		start := time.Now()
 		tx, err := beginner.BeginTx(ctx, opts)
 		if !errors.Is(err, driver.ErrSkip) {
-			observeDBOperation(ctx, c.role, c.tenantID, "begin", start, err)
+			observeDBOperation(c.role, "begin", start, err)
 		}
 		if err != nil {
 			return nil, err
 		}
-		return instrumentedTx{base: tx, role: c.role, tenantID: c.tenantID}, nil
+		return instrumentedTx{base: tx, role: c.role}, nil
 	}
 	if opts.Isolation != driver.IsolationLevel(0) || opts.ReadOnly {
 		return nil, fmt.Errorf("driver does not support non-default transaction options")
@@ -150,7 +148,7 @@ func (c instrumentedConn) ExecContext(ctx context.Context, query string, args []
 	start := time.Now()
 	res, err := execer.ExecContext(ctx, query, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, c.role, c.tenantID, "exec", start, err)
+		observeDBOperation(c.role, "exec", start, err)
 	}
 	return res, err
 }
@@ -163,7 +161,7 @@ func (c instrumentedConn) QueryContext(ctx context.Context, query string, args [
 	start := time.Now()
 	rows, err := queryer.QueryContext(ctx, query, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, c.role, c.tenantID, "query", start, err)
+		observeDBOperation(c.role, "query", start, err)
 	}
 	return rows, err
 }
@@ -193,9 +191,8 @@ func (c instrumentedConn) CheckNamedValue(nv *driver.NamedValue) error {
 }
 
 type instrumentedStmt struct {
-	base     driver.Stmt
-	role     string
-	tenantID string
+	base driver.Stmt
+	role string
 }
 
 func (s instrumentedStmt) Close() error {
@@ -222,7 +219,7 @@ func (s instrumentedStmt) ExecContext(ctx context.Context, args []driver.NamedVa
 	start := time.Now()
 	res, err := execer.ExecContext(ctx, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, s.role, s.tenantID, "exec", start, err)
+		observeDBOperation(s.role, "exec", start, err)
 	}
 	return res, err
 }
@@ -235,7 +232,7 @@ func (s instrumentedStmt) QueryContext(ctx context.Context, args []driver.NamedV
 	start := time.Now()
 	rows, err := queryer.QueryContext(ctx, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(ctx, s.role, s.tenantID, "query", start, err)
+		observeDBOperation(s.role, "query", start, err)
 	}
 	return rows, err
 }
@@ -249,16 +246,15 @@ func (s instrumentedStmt) CheckNamedValue(nv *driver.NamedValue) error {
 }
 
 type instrumentedTx struct {
-	base     driver.Tx
-	role     string
-	tenantID string
+	base driver.Tx
+	role string
 }
 
 func (tx instrumentedTx) Commit() error {
 	start := time.Now()
 	err := tx.base.Commit()
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(context.Background(), tx.role, tx.tenantID, "commit", start, err)
+		observeDBOperation(tx.role, "commit", start, err)
 	}
 	return err
 }
@@ -267,12 +263,12 @@ func (tx instrumentedTx) Rollback() error {
 	start := time.Now()
 	err := tx.base.Rollback()
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(context.Background(), tx.role, tx.tenantID, "rollback", start, err)
+		observeDBOperation(tx.role, "rollback", start, err)
 	}
 	return err
 }
 
-func observeDBOperation(ctx context.Context, role, _ string, operation string, start time.Time, err error) {
+func observeDBOperation(role, operation string, start time.Time, err error) {
 	metrics.RecordDBOperation(role, operation, dbResult(err), time.Since(start))
 }
 


### PR DESCRIPTION
## Summary
- limit DB health probes to the long-lived metadata store only
- stop emitting user/user_schema DB availability and probe-duration series
- keep tenant_id on DB pool metrics while leaving DB operation metrics role-only
- avoid starting a no-op probe goroutine when the meta probe is disabled
- add server env parsing tests and disabled-probe behavior coverage

## Operational notes
- `drive9_db_up{role="user"}` and `drive9_db_up{role="user_schema"}` now disappear instead of emitting cold `1` series; dashboards and alerts should use tenant DB pool metrics for user/user_schema visibility.
- `DRIVE9_DB_HEALTH_PROBE_META_ENABLED=false` disables the meta probe entirely, so `drive9_db_up{role="meta"}` is absent and the documented meta DB unavailable alert will not fire in that mode.
- When the meta sql.DB pool is saturated, the health probe preserves the previous `drive9_db_up{role="meta"}` state instead of borrowing another connection. A database outage that begins while the pool is saturated is therefore surfaced through pool saturation/wait metrics until a probe can borrow a connection again.

## Tests
- `go test -count=1 ./pkg/metrics ./pkg/mysqlutil ./pkg/datastore ./pkg/tenant ./cmd/drive9-server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database health monitoring now focuses on the main metadata store by default, with a new setting to disable that check if needed.
  * Usage help now documents the available database health probe environment settings.

* **Bug Fixes**
  * Database health status reporting is now simpler and more consistent, using role-based visibility instead of tenant-specific details.
  * Database operation metrics no longer expose tenant-level labels, reducing noise in health and performance reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->