### PR TITLE
Avoid waking cold tenant DBs in semantic worker

### DIFF
--- a/cmd/drive9-server-local/main_test.go
+++ b/cmd/drive9-server-local/main_test.go
@@ -248,6 +248,7 @@ func TestBuildSemanticWorkerConfigFromEnvReadsWorkerOptionsWithoutEmbedder(t *te
 	for _, key := range keys {
 		_ = os.Unsetenv(key)
 	}
+
 	if err := os.Setenv("DRIVE9_SEMANTIC_WORKERS", "8"); err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -183,6 +183,7 @@ func TestBuildSemanticWorkerConfigFromEnvReadsWorkerOptionsWithoutEmbedder(t *te
 	restore := snapshotEnv(t, keys)
 	t.Cleanup(func() { restoreEnv(t, restore) })
 	unsetEnv(t, keys)
+
 	setEnv(t, "DRIVE9_SEMANTIC_WORKERS", "8")
 	setEnv(t, "DRIVE9_SEMANTIC_TENANT_LIMIT", "512")
 

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -13,9 +13,9 @@ const (
 	defaultMetaConnMaxIdleTime       = 45 * time.Second
 	defaultMetaMaxOpenConns          = 100
 	defaultMetaMaxIdleConns          = 20
-	defaultUserConnMaxLifetime       = 30 * time.Second
+	defaultUserConnMaxLifetime       = 45 * time.Second
 	defaultUserConnMaxIdleTime       = 30 * time.Second
-	defaultUserMaxOpenConns          = 4
+	defaultUserMaxOpenConns          = 6
 	defaultUserMaxIdleConns          = 1
 	defaultUserSchemaConnMaxLifetime = 1 * time.Minute
 	defaultUserSchemaConnMaxIdleTime = 10 * time.Second
@@ -46,6 +46,12 @@ func ApplyPoolDefaults(db *sql.DB, role string) {
 	if v := poolEnvInt(role, "MAX_IDLE_CONNS", maxIdle); v >= 0 {
 		db.SetMaxIdleConns(v)
 	}
+}
+
+// DefaultUserConnMaxLifetime returns the default maximum lifetime for tenant
+// user DB connections.
+func DefaultUserConnMaxLifetime() time.Duration {
+	return defaultUserConnMaxLifetime
 }
 
 func defaultPoolLifetime(role string) (time.Duration, time.Duration) {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
+	"github.com/mem9-ai/drive9/pkg/mysqlutil"
 	"github.com/mem9-ai/drive9/pkg/semantic"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
@@ -30,12 +31,13 @@ const (
 	defaultSemanticRecoverInterval      = 5 * time.Second
 	defaultSemanticRetryBaseDelay       = 200 * time.Millisecond
 	defaultSemanticRetryMaxDelay        = 30 * time.Second
+	defaultSemanticWarmPollMargin       = 15 * time.Second
 	defaultSemanticTenantScanLimit      = 128
 	defaultSemanticPerTenantConcurrency = 1
 	semanticLocalTenantID               = "local"
 	// semanticKickQueueCapacity bounds buffered upload-commit kicks; overflow
-	// kicks are dropped because the periodic tenant scan remains the durable
-	// fallback for claiming queued tasks.
+	// kicks are dropped. Periodic polling only checks cached tenant backends, so
+	// a later tenant request or kick is the fallback for dormant tenants.
 	semanticKickQueueCapacity = 256
 	// semanticKickDrainLimit caps tasks drained per kick so one busy tenant
 	// cannot monopolize a worker; the tenant is re-kicked to continue after
@@ -60,6 +62,11 @@ type SemanticWorkerOptions struct {
 	Workers int
 	// PollInterval is the idle wait between claim attempts.
 	PollInterval time.Duration
+	// WarmTenantPollInterval limits best-effort multi-tenant polling over
+	// cached tenants that still have open DB connections. It should stay above
+	// the user DB connection lifetime so the worker does not keep tenant
+	// connections warm by itself.
+	WarmTenantPollInterval time.Duration
 	// LeaseDuration is the base task lease window used by claim and renew.
 	LeaseDuration time.Duration
 	// RecoverInterval controls how often expired leases are swept back to queue.
@@ -80,6 +87,12 @@ func (o *SemanticWorkerOptions) normalize() {
 	}
 	if o.PollInterval <= 0 {
 		o.PollInterval = defaultSemanticPollInterval
+	}
+	if o.WarmTenantPollInterval <= 0 {
+		o.WarmTenantPollInterval = DefaultSemanticWarmTenantPollInterval()
+	}
+	if minWarm := mysqlutil.DefaultUserConnMaxLifetime(); o.WarmTenantPollInterval < minWarm {
+		o.WarmTenantPollInterval = minWarm
 	}
 	if o.LeaseDuration <= 0 {
 		o.LeaseDuration = defaultSemanticLeaseDuration
@@ -102,6 +115,12 @@ func (o *SemanticWorkerOptions) normalize() {
 	if o.PerTenantConcurrency <= 0 {
 		o.PerTenantConcurrency = defaultSemanticPerTenantConcurrency
 	}
+}
+
+// DefaultSemanticWarmTenantPollInterval returns the default warm cached tenant
+// polling interval derived from tenant user DB pool defaults.
+func DefaultSemanticWarmTenantPollInterval() time.Duration {
+	return mysqlutil.DefaultUserConnMaxLifetime() + defaultSemanticWarmPollMargin
 }
 
 // SemanticWorkerWillRun reports whether NewWithConfig would construct a non-nil
@@ -152,13 +171,7 @@ type semanticWorkerManager struct {
 
 	kicks chan string
 
-	tenantScanCursorSet       bool
-	tenantScanCursorCreatedAt time.Time
-	tenantScanCursorID        string
-	tenantScanRoundRawTenants int
-	tenantScanRoundIncluded   int
-	lastTenantScan            semanticTenantScanSnapshot
-	tenantScanMu              sync.Mutex
+	lastTenantScan semanticTenantScanSnapshot
 
 	priorObservedTenants map[string]struct{}
 
@@ -169,6 +182,7 @@ type semanticWorkerManager struct {
 type semanticTenantRef struct {
 	id     string
 	tenant *meta.Tenant
+	cached bool
 }
 
 type semanticTarget struct {
@@ -293,10 +307,10 @@ func newSemanticWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Sto
 }
 
 // Kick prompts a worker to attempt claiming tasks for tenantID as soon as one
-// is idle, instead of waiting for the round-robin tenant scan to reach the
-// tenant. Kicks are best-effort: duplicates collapse while one is pending, and
-// the kick is dropped when the buffer is full — the periodic scan remains the
-// durable path that eventually claims every queued task.
+// is idle. Kicks are best-effort: duplicates collapse while one is pending, and
+// the kick is dropped when the buffer is full. In multi-tenant mode this is the
+// only path that may acquire a dormant tenant backend; periodic polling only
+// processes warm cached backends.
 func (m *semanticWorkerManager) Kick(tenantID string) {
 	if m == nil || tenantID == "" {
 		return
@@ -345,8 +359,11 @@ func (m *semanticWorkerManager) Start(ctx context.Context) {
 	fields := []zap.Field{
 		zap.Int("workers", m.opts.Workers),
 		zap.Duration("poll_interval", m.opts.PollInterval),
+		zap.Duration("warm_tenant_poll_interval", m.opts.WarmTenantPollInterval),
+		zap.Duration("effective_poll_interval", m.effectivePollInterval()),
 		zap.Duration("lease_duration", m.opts.LeaseDuration),
 		zap.Duration("recover_interval", m.opts.RecoverInterval),
+		zap.Duration("effective_recover_interval", m.effectiveRecoverInterval()),
 	}
 	fields = append(fields, m.tenantScanLogFields()...)
 	logger.Info(workerCtx, "semantic_worker_manager_started", fields...)
@@ -369,11 +386,11 @@ func (m *semanticWorkerManager) Stop() {
 
 func (m *semanticWorkerManager) workerLoop(ctx context.Context, workerID int) {
 	defer m.wg.Done()
-	ticker := time.NewTicker(m.opts.PollInterval)
+	ticker := time.NewTicker(m.effectivePollInterval())
 	defer ticker.Stop()
 	for {
 		processed := m.processNext(ctx)
-		if processed {
+		if processed && !m.isMultiTenant() {
 			continue
 		}
 		select {
@@ -389,7 +406,7 @@ func (m *semanticWorkerManager) workerLoop(ctx context.Context, workerID int) {
 
 func (m *semanticWorkerManager) recoverLoop(ctx context.Context) {
 	defer m.wg.Done()
-	ticker := time.NewTicker(m.opts.RecoverInterval)
+	ticker := time.NewTicker(m.effectiveRecoverInterval())
 	defer ticker.Stop()
 	for {
 		select {
@@ -400,6 +417,38 @@ func (m *semanticWorkerManager) recoverLoop(ctx context.Context) {
 			m.observeOnce(ctx, time.Now().UTC())
 		}
 	}
+}
+
+func (m *semanticWorkerManager) isMultiTenant() bool {
+	return m != nil && m.meta != nil && m.pool != nil
+}
+
+func (m *semanticWorkerManager) effectivePollInterval() time.Duration {
+	if m == nil {
+		return defaultSemanticPollInterval
+	}
+	interval := m.opts.PollInterval
+	if interval <= 0 {
+		interval = defaultSemanticPollInterval
+	}
+	if m.isMultiTenant() && interval < m.opts.WarmTenantPollInterval {
+		return m.opts.WarmTenantPollInterval
+	}
+	return interval
+}
+
+func (m *semanticWorkerManager) effectiveRecoverInterval() time.Duration {
+	if m == nil {
+		return defaultSemanticRecoverInterval
+	}
+	interval := m.opts.RecoverInterval
+	if interval <= 0 {
+		interval = defaultSemanticRecoverInterval
+	}
+	if m.isMultiTenant() && interval < m.opts.WarmTenantPollInterval {
+		return m.opts.WarmTenantPollInterval
+	}
+	return interval
 }
 
 func (m *semanticWorkerManager) processNext(ctx context.Context) bool {
@@ -416,8 +465,9 @@ func (m *semanticWorkerManager) processNext(ctx context.Context) bool {
 }
 
 // processKicked attempts to claim tasks for one kicked tenant immediately. It
-// is best-effort by design: every early return leaves the committed task to
-// the periodic tenant scan, which stays the durable claiming path.
+// is best-effort by design: every early return leaves the committed task
+// durable in the tenant DB until the tenant is kicked again or becomes active
+// enough to be present in the pool cache with an open DB connection.
 func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID string) {
 	// Clear the pending mark before claiming: a task committed after this
 	// point triggers a fresh kick, and a task committed before it is already
@@ -457,7 +507,7 @@ func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID stri
 }
 
 // kickRef resolves a kicked tenant ID to a schedulable ref, applying the same
-// status and provider/task-type filters as the scan path (listTenantRefs).
+// status and provider/task-type filters as cached polling.
 func (m *semanticWorkerManager) kickRef(ctx context.Context, tenantID string) (semanticTenantRef, bool) {
 	if tenantID == semanticLocalTenantID {
 		// Match scan behavior: the local fallback is only schedulable outside
@@ -773,27 +823,17 @@ func (m *semanticWorkerManager) releaseTenantSlot(tenantID string) {
 
 func (m *semanticWorkerManager) listTenantRefs(ctx context.Context) ([]semanticTenantRef, error) {
 	if m.meta != nil && m.pool != nil {
-		// Multi-tenant workers scan active tenants with a keyset cursor rather than
-		// repeatedly reading the oldest TenantScanLimit rows. The cursor advances to
-		// the last raw active tenant in each page, even when provider filtering drops
-		// every tenant from that page, so unsupported providers cannot pin the scan.
-		// When the page after the cursor is empty, the next scan wraps to the start
-		// of the active-tenant order and continues round-robin pagination.
-		m.tenantScanMu.Lock()
-		defer m.tenantScanMu.Unlock()
-		tenants, wrapped, err := m.nextTenantScanPage(ctx)
-		if err != nil {
-			return nil, err
+		// Multi-tenant periodic work must not wake dormant tenant databases. It
+		// therefore polls only cached tenant backends whose DB pools still have
+		// open connections, and at a cadence longer than the user DB connection
+		// lifetime. Fresh work for a dormant tenant is handled by Kick, which is
+		// emitted after the write/upload transaction that created the semantic task.
+		tenantIDs := m.pool.WarmTenantIDs()
+		refs := make([]semanticTenantRef, 0, len(tenantIDs))
+		for _, tenantID := range tenantIDs {
+			refs = append(refs, semanticTenantRef{id: tenantID, cached: true})
 		}
-		refs := make([]semanticTenantRef, 0, len(tenants))
-		for i := range tenants {
-			t := tenants[i]
-			if !hasAnyTaskTypes(m.taskTypesForProvider(t.Provider)) {
-				continue
-			}
-			refs = append(refs, semanticTenantRef{id: t.ID, tenant: &t})
-		}
-		m.recordTenantScan(ctx, tenants, len(refs), wrapped)
+		m.recordCachedTenantScan(len(tenantIDs), len(refs))
 		return refs, nil
 	}
 	if m.shouldIncludeFallback() {
@@ -802,77 +842,13 @@ func (m *semanticWorkerManager) listTenantRefs(ctx context.Context) ([]semanticT
 	return nil, nil
 }
 
-// nextTenantScanPage returns the next raw page of active tenants for round-robin
-// scheduling. It reads the current scan cursor, fetches up to TenantScanLimit rows
-// after that cursor in (created_at, id) order, and wraps to the first page when the
-// cursor is already at the end of the active-tenant sequence.
-//
-// Outward behavior for callers (typically listTenantRefs under tenantScanMu):
-//   - Returns DB rows only; provider/task-type filtering happens after this call.
-//   - Does not advance the scan cursor; the caller must call recordTenantScan with
-//     the returned page and wrapped flag.
-//   - wrapped is true only when the first query after the cursor returned no rows
-//     and a second query restarted from the beginning of the active-tenant order.
-//   - On the first scan (no cursor yet), an empty page means there are no active
-//     tenants; wrapped stays false.
-func (m *semanticWorkerManager) nextTenantScanPage(ctx context.Context) ([]meta.Tenant, bool, error) {
-	createdAt, id, ok := m.tenantScanCursor()
-	tenants, err := m.meta.ListTenantsByStatusAfter(ctx, meta.TenantActive, createdAt, id, m.opts.TenantScanLimit)
-	if err != nil {
-		return nil, false, err
-	}
-	// Non-empty page, or the initial scan before any cursor exists: return as-is.
-	if len(tenants) > 0 || !ok {
-		return tenants, false, nil
-	}
-	// Cursor was set but nothing remains after it; wrap to the head of the order.
-	tenants, err = m.meta.ListTenantsByStatusAfter(ctx, meta.TenantActive, time.Time{}, "", m.opts.TenantScanLimit)
-	if err != nil {
-		return nil, true, err
-	}
-	return tenants, true, nil
-}
-
-func (m *semanticWorkerManager) tenantScanCursor() (time.Time, string, bool) {
+func (m *semanticWorkerManager) recordCachedTenantScan(raw, included int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if !m.tenantScanCursorSet {
-		return time.Time{}, "", false
-	}
-	return m.tenantScanCursorCreatedAt, m.tenantScanCursorID, true
-}
-
-func (m *semanticWorkerManager) recordTenantScan(ctx context.Context, tenants []meta.Tenant, included int, wrapped bool) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	if wrapped {
-		logger.Info(ctx, "semantic_worker_tenant_scan_wrapped",
-			zap.Int("tenant_scan_round_raw_tenants", m.tenantScanRoundRawTenants),
-			zap.Int("tenant_scan_round_included_tenants", m.tenantScanRoundIncluded),
-		)
-		m.tenantScanRoundRawTenants = 0
-		m.tenantScanRoundIncluded = 0
-	}
-	m.tenantScanRoundRawTenants += len(tenants)
-	m.tenantScanRoundIncluded += included
-	if len(tenants) > 0 {
-		last := tenants[len(tenants)-1]
-		m.tenantScanCursorSet = true
-		m.tenantScanCursorCreatedAt = last.CreatedAt.UTC()
-		m.tenantScanCursorID = last.ID
-	} else if wrapped || !m.tenantScanCursorSet {
-		m.tenantScanCursorSet = false
-		m.tenantScanCursorCreatedAt = time.Time{}
-		m.tenantScanCursorID = ""
-	}
 	m.lastTenantScan = semanticTenantScanSnapshot{
 		limit:           m.opts.TenantScanLimit,
-		cursorSet:       m.tenantScanCursorSet,
-		cursorCreatedAt: m.tenantScanCursorCreatedAt,
-		cursorID:        m.tenantScanCursorID,
-		rawTenants:      len(tenants),
+		rawTenants:      raw,
 		includedTenants: included,
-		wrapped:         wrapped,
 	}
 }
 
@@ -891,6 +867,23 @@ func (m *semanticWorkerManager) targetForRef(ctx context.Context, ref semanticTe
 			store:            m.fallback.Store(),
 			allowedTaskTypes: m.taskTypesForTarget(m.fallback),
 			release:          func() {},
+		}, nil
+	}
+	if ref.cached {
+		b, release, ok := m.pool.AcquireCached(ref.id)
+		if !ok {
+			return nil, fmt.Errorf("cached backend missing for %s", ref.id)
+		}
+		if b.Store().DB().Stats().OpenConnections == 0 {
+			release()
+			return nil, fmt.Errorf("cached backend cold for %s", ref.id)
+		}
+		return &semanticTarget{
+			tenantID:         ref.id,
+			backend:          b,
+			store:            b.Store(),
+			allowedTaskTypes: m.taskTypesForTarget(b),
+			release:          release,
 		}, nil
 	}
 	if ref.tenant == nil {
@@ -1306,9 +1299,6 @@ func (m *semanticWorkerManager) tenantScanSnapshot() semanticTenantScanSnapshot 
 	s := m.lastTenantScan
 	if s.limit == 0 {
 		s.limit = m.opts.TenantScanLimit
-		s.cursorSet = m.tenantScanCursorSet
-		s.cursorCreatedAt = m.tenantScanCursorCreatedAt
-		s.cursorID = m.tenantScanCursorID
 	}
 	return s
 }

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -168,6 +168,7 @@ type semanticWorkerManager struct {
 	processing  int
 	kickPending map[string]struct{}
 	kickQueued  map[string]struct{}
+	kickRetryAt map[string]time.Time
 
 	kicks chan string
 
@@ -305,6 +306,7 @@ func newSemanticWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Sto
 	m.inflight = make(map[string]int)
 	m.kickPending = make(map[string]struct{})
 	m.kickQueued = make(map[string]struct{})
+	m.kickRetryAt = make(map[string]time.Time)
 	m.kicks = make(chan string, semanticKickQueueCapacity)
 	return m
 }
@@ -338,6 +340,11 @@ func (m *semanticWorkerManager) queuePendingKick(tenantID string) bool {
 		m.mu.Unlock()
 		return true
 	}
+	if retryAt, delayed := m.kickRetryAt[tenantID]; delayed && time.Now().Before(retryAt) {
+		m.mu.Unlock()
+		return true
+	}
+	delete(m.kickRetryAt, tenantID)
 	m.kickQueued[tenantID] = struct{}{}
 	m.mu.Unlock()
 
@@ -365,6 +372,9 @@ func (m *semanticWorkerManager) queueNextPendingKick() {
 			if _, queued := m.kickQueued[id]; queued {
 				continue
 			}
+			if retryAt, delayed := m.kickRetryAt[id]; delayed && time.Now().Before(retryAt) {
+				continue
+			}
 			tenantID = id
 			break
 		}
@@ -379,6 +389,7 @@ func (m *semanticWorkerManager) clearKickPending(tenantID string) {
 	m.mu.Lock()
 	delete(m.kickPending, tenantID)
 	delete(m.kickQueued, tenantID)
+	delete(m.kickRetryAt, tenantID)
 	m.mu.Unlock()
 }
 
@@ -386,6 +397,49 @@ func (m *semanticWorkerManager) markKickDequeued(tenantID string) {
 	m.mu.Lock()
 	delete(m.kickQueued, tenantID)
 	m.mu.Unlock()
+}
+
+func (m *semanticWorkerManager) delayPendingKick(ctx context.Context, tenantID string) {
+	delay := m.opts.RetryBaseDelay
+	if delay <= 0 {
+		delay = defaultSemanticRetryBaseDelay
+	}
+	retryAt := time.Now().Add(delay)
+	m.mu.Lock()
+	if _, pending := m.kickPending[tenantID]; !pending {
+		m.mu.Unlock()
+		return
+	}
+	if existing, delayed := m.kickRetryAt[tenantID]; delayed && time.Now().Before(existing) {
+		m.mu.Unlock()
+		return
+	}
+	delete(m.kickQueued, tenantID)
+	m.kickRetryAt[tenantID] = retryAt
+	m.mu.Unlock()
+	metrics.RecordTenantOperation(tenantID, "semantic_worker", "kick", "retry_delayed", 0)
+
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		m.mu.Lock()
+		if _, pending := m.kickPending[tenantID]; !pending {
+			m.mu.Unlock()
+			return
+		}
+		if current, delayed := m.kickRetryAt[tenantID]; delayed && time.Now().Before(current) {
+			m.mu.Unlock()
+			return
+		}
+		delete(m.kickRetryAt, tenantID)
+		m.mu.Unlock()
+		m.queuePendingKick(tenantID)
+	}()
 }
 
 func (m *semanticWorkerManager) Start(ctx context.Context) {
@@ -440,6 +494,15 @@ func (m *semanticWorkerManager) workerLoop(ctx context.Context, workerID int) {
 	ticker := time.NewTicker(m.effectivePollInterval())
 	defer ticker.Stop()
 	for {
+		select {
+		case <-ctx.Done():
+			logger.Info(ctx, "semantic_worker_stopped", zap.Int("worker_id", workerID))
+			return
+		default:
+		}
+		if m.processQueuedKick(ctx) {
+			continue
+		}
 		processed := m.processNext(ctx)
 		// If a task was processed, immediately look for more work. Multi-tenant
 		// scans are warm-cache only, so this drains real backlog without opening
@@ -455,6 +518,16 @@ func (m *semanticWorkerManager) workerLoop(ctx context.Context, workerID int) {
 			m.processKicked(ctx, tenantID)
 		case <-ticker.C:
 		}
+	}
+}
+
+func (m *semanticWorkerManager) processQueuedKick(ctx context.Context) bool {
+	select {
+	case tenantID := <-m.kicks:
+		m.processKicked(ctx, tenantID)
+		return true
+	default:
+		return false
 	}
 }
 
@@ -521,6 +594,7 @@ func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID stri
 	m.markKickDequeued(tenantID)
 	ref, ok, err := m.kickRef(ctx, tenantID)
 	if err != nil {
+		m.delayPendingKick(ctx, tenantID)
 		return
 	}
 	if !ok {
@@ -539,10 +613,12 @@ func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID stri
 			zap.String("tenant_id", ref.id),
 			zap.Error(err))
 		m.releaseTenantSlot(ref.id)
+		m.delayPendingKick(ctx, tenantID)
 		return
 	}
 	if target == nil {
 		m.releaseTenantSlot(ref.id)
+		m.delayPendingKick(ctx, tenantID)
 		return
 	}
 	// Clear the pending mark only after the backend is acquired: a task

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -35,9 +35,8 @@ const (
 	defaultSemanticTenantScanLimit      = 128
 	defaultSemanticPerTenantConcurrency = 1
 	semanticLocalTenantID               = "local"
-	// semanticKickQueueCapacity bounds buffered upload-commit kicks; overflow
-	// kicks are dropped. Periodic polling only checks cached tenant backends, so
-	// a later tenant request or kick is the fallback for dormant tenants.
+	// semanticKickQueueCapacity bounds buffered upload-commit kicks. Overflow
+	// kicks stay pending and are retried as workers drain the queue.
 	semanticKickQueueCapacity = 256
 	// semanticKickDrainLimit caps tasks drained per kick so one busy tenant
 	// cannot monopolize a worker; the tenant is re-kicked to continue after
@@ -91,8 +90,8 @@ func (o *SemanticWorkerOptions) normalize() {
 	if o.WarmTenantPollInterval <= 0 {
 		o.WarmTenantPollInterval = DefaultSemanticWarmTenantPollInterval()
 	}
-	if minWarm := mysqlutil.DefaultUserConnMaxLifetime(); o.WarmTenantPollInterval < minWarm {
-		o.WarmTenantPollInterval = minWarm
+	if minWarm := mysqlutil.DefaultUserConnMaxLifetime(); o.WarmTenantPollInterval <= minWarm {
+		o.WarmTenantPollInterval = minWarm + defaultSemanticWarmPollMargin
 	}
 	if o.LeaseDuration <= 0 {
 		o.LeaseDuration = defaultSemanticLeaseDuration
@@ -168,10 +167,12 @@ type semanticWorkerManager struct {
 	inflight    map[string]int
 	processing  int
 	kickPending map[string]struct{}
+	kickQueued  map[string]struct{}
 
 	kicks chan string
 
 	lastTenantScan semanticTenantScanSnapshot
+	recoveryScan   semanticTenantScanSnapshot
 
 	priorObservedTenants map[string]struct{}
 
@@ -302,15 +303,16 @@ func newSemanticWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Sto
 	m.opts = opts
 	m.inflight = make(map[string]int)
 	m.kickPending = make(map[string]struct{})
+	m.kickQueued = make(map[string]struct{})
 	m.kicks = make(chan string, semanticKickQueueCapacity)
 	return m
 }
 
 // Kick prompts a worker to attempt claiming tasks for tenantID as soon as one
-// is idle. Kicks are best-effort: duplicates collapse while one is pending, and
-// the kick is dropped when the buffer is full. In multi-tenant mode this is the
-// only path that may acquire a dormant tenant backend; periodic polling only
-// processes warm cached backends.
+// is idle. Duplicates collapse while one is pending; if the channel buffer is
+// full, the tenant stays pending and is retried as workers drain queued kicks.
+// In multi-tenant mode this is the only normal claim path that may acquire a
+// dormant tenant backend; periodic polling only processes warm cached backends.
 func (m *semanticWorkerManager) Kick(tenantID string) {
 	if m == nil || tenantID == "" {
 		return
@@ -322,18 +324,57 @@ func (m *semanticWorkerManager) Kick(tenantID string) {
 	}
 	m.kickPending[tenantID] = struct{}{}
 	m.mu.Unlock()
+	m.queuePendingKick(tenantID)
+}
+
+func (m *semanticWorkerManager) queuePendingKick(tenantID string) bool {
+	m.mu.Lock()
+	if _, pending := m.kickPending[tenantID]; !pending {
+		m.mu.Unlock()
+		return false
+	}
+	if _, queued := m.kickQueued[tenantID]; queued {
+		m.mu.Unlock()
+		return true
+	}
+	m.kickQueued[tenantID] = struct{}{}
+	m.mu.Unlock()
+
 	select {
 	case m.kicks <- tenantID:
 		metrics.RecordTenantOperation(tenantID, "semantic_worker", "kick", "queued", 0)
+		return true
 	default:
-		m.clearKickPending(tenantID)
-		metrics.RecordTenantOperation(tenantID, "semantic_worker", "kick", "dropped", 0)
+		m.mu.Lock()
+		delete(m.kickQueued, tenantID)
+		m.mu.Unlock()
+		metrics.RecordTenantOperation(tenantID, "semantic_worker", "kick", "delayed", 0)
+		return false
+	}
+}
+
+func (m *semanticWorkerManager) queueNextPendingKick() {
+	for {
+		m.mu.Lock()
+		tenantID := ""
+		for id := range m.kickPending {
+			if _, queued := m.kickQueued[id]; queued {
+				continue
+			}
+			tenantID = id
+			break
+		}
+		m.mu.Unlock()
+		if tenantID == "" || !m.queuePendingKick(tenantID) {
+			return
+		}
 	}
 }
 
 func (m *semanticWorkerManager) clearKickPending(tenantID string) {
 	m.mu.Lock()
 	delete(m.kickPending, tenantID)
+	delete(m.kickQueued, tenantID)
 	m.mu.Unlock()
 }
 
@@ -390,6 +431,9 @@ func (m *semanticWorkerManager) workerLoop(ctx context.Context, workerID int) {
 	defer ticker.Stop()
 	for {
 		processed := m.processNext(ctx)
+		// Multi-tenant periodic polling waits for the warm-tenant cadence after
+		// each claim so the poll loop itself does not keep user DB pools warm.
+		// New writes still drain promptly through Kick/processKicked.
 		if processed && !m.isMultiTenant() {
 			continue
 		}
@@ -464,11 +508,9 @@ func (m *semanticWorkerManager) processNext(ctx context.Context) bool {
 	return m.claimAndProcessOne(ctx, target)
 }
 
-// processKicked attempts to claim tasks for one kicked tenant immediately. It
-// is best-effort by design: every early return leaves the committed task
-// durable in the tenant DB until the tenant is kicked again or becomes active
-// enough to be present in the pool cache with an open DB connection.
+// processKicked attempts to claim tasks for one kicked tenant immediately.
 func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID string) {
+	defer m.queueNextPendingKick()
 	// Clear the pending mark before claiming: a task committed after this
 	// point triggers a fresh kick, and a task committed before it is already
 	// visible to the claim below, so no enqueue can slip through unnoticed.
@@ -709,12 +751,24 @@ func (m *semanticWorkerManager) retryDelay(attemptCount int) time.Duration {
 }
 
 func (m *semanticWorkerManager) recoverExpired(ctx context.Context) {
+	// Expired lease recovery is the only periodic path allowed to open cold
+	// tenant DBs. Normal polling still uses cached warm tenants only.
+	visited := make(map[string]struct{})
+	m.recoverExpiredRefs(ctx, m.recoveryTenantRefs(ctx), visited)
 	refs, err := m.listTenantRefs(ctx)
 	if err != nil {
 		logger.Warn(ctx, "semantic_worker_list_tenants_for_recovery_failed", zap.Error(err))
 		return
 	}
+	m.recoverExpiredRefs(ctx, refs, visited)
+}
+
+func (m *semanticWorkerManager) recoverExpiredRefs(ctx context.Context, refs []semanticTenantRef, visited map[string]struct{}) {
 	for _, ref := range refs {
+		if _, ok := visited[ref.id]; ok {
+			continue
+		}
+		visited[ref.id] = struct{}{}
 		target, err := m.targetForRef(ctx, ref)
 		if err != nil {
 			logger.Warn(ctx, "semantic_worker_open_store_for_recovery_failed",
@@ -829,11 +883,23 @@ func (m *semanticWorkerManager) listTenantRefs(ctx context.Context) ([]semanticT
 		// lifetime. Fresh work for a dormant tenant is handled by Kick, which is
 		// emitted after the write/upload transaction that created the semantic task.
 		tenantIDs := m.pool.WarmTenantIDs()
+		raw := len(tenantIDs)
+		tenantIDs = limitTenantIDsForPass(tenantIDs, m.opts.TenantScanLimit)
 		refs := make([]semanticTenantRef, 0, len(tenantIDs))
 		for _, tenantID := range tenantIDs {
-			refs = append(refs, semanticTenantRef{id: tenantID, cached: true})
+			t, err := m.meta.GetTenant(ctx, tenantID)
+			if err != nil {
+				logger.Warn(ctx, "semantic_worker_cached_tenant_lookup_failed",
+					zap.String("tenant_id", tenantID),
+					zap.Error(err))
+				continue
+			}
+			if t.Status != meta.TenantActive {
+				continue
+			}
+			refs = append(refs, semanticTenantRef{id: tenantID, tenant: t, cached: true})
 		}
-		m.recordCachedTenantScan(len(tenantIDs), len(refs))
+		m.recordCachedTenantScan(raw, len(refs), raw > len(tenantIDs))
 		return refs, nil
 	}
 	if m.shouldIncludeFallback() {
@@ -842,14 +908,82 @@ func (m *semanticWorkerManager) listTenantRefs(ctx context.Context) ([]semanticT
 	return nil, nil
 }
 
-func (m *semanticWorkerManager) recordCachedTenantScan(raw, included int) {
+func (m *semanticWorkerManager) recoveryTenantRefs(ctx context.Context) []semanticTenantRef {
+	if m.meta == nil || m.pool == nil {
+		return nil
+	}
+
+	m.mu.Lock()
+	afterCreatedAt := m.recoveryScan.cursorCreatedAt
+	afterID := m.recoveryScan.cursorID
+	m.mu.Unlock()
+
+	tenants, err := m.meta.ListTenantsByStatusAfter(ctx, meta.TenantActive, afterCreatedAt, afterID, m.opts.TenantScanLimit)
+	if err != nil {
+		logger.Warn(ctx, "semantic_worker_list_tenants_for_recovery_scan_failed", zap.Error(err))
+		return nil
+	}
+	wrapped := false
+	if len(tenants) == 0 && (!afterCreatedAt.IsZero() || afterID != "") {
+		wrapped = true
+		tenants, err = m.meta.ListTenantsByStatusAfter(ctx, meta.TenantActive, time.Time{}, "", m.opts.TenantScanLimit)
+		if err != nil {
+			logger.Warn(ctx, "semantic_worker_list_tenants_for_recovery_scan_failed", zap.Error(err))
+			return nil
+		}
+	}
+
+	refs := make([]semanticTenantRef, 0, len(tenants))
+	for i := range tenants {
+		tenantMeta := tenants[i]
+		if !hasAnyTaskTypes(m.taskTypesForProvider(tenantMeta.Provider)) {
+			continue
+		}
+		refs = append(refs, semanticTenantRef{id: tenantMeta.ID, tenant: &tenantMeta})
+	}
+	m.recordRecoveryTenantScan(tenants, len(refs), wrapped)
+	return refs
+}
+
+func (m *semanticWorkerManager) recordCachedTenantScan(raw, included int, limited bool) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.lastTenantScan = semanticTenantScanSnapshot{
 		limit:           m.opts.TenantScanLimit,
 		rawTenants:      raw,
 		includedTenants: included,
+		wrapped:         limited,
 	}
+}
+
+func (m *semanticWorkerManager) recordRecoveryTenantScan(tenants []meta.Tenant, included int, wrapped bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := semanticTenantScanSnapshot{
+		limit:           m.opts.TenantScanLimit,
+		rawTenants:      len(tenants),
+		includedTenants: included,
+		wrapped:         wrapped,
+	}
+	if len(tenants) > 0 {
+		last := tenants[len(tenants)-1]
+		s.cursorSet = true
+		s.cursorCreatedAt = last.CreatedAt.UTC()
+		s.cursorID = last.ID
+	}
+	m.recoveryScan = s
+}
+
+func limitTenantIDsForPass(ids []string, limit int) []string {
+	if limit <= 0 || len(ids) <= limit {
+		return ids
+	}
+	order := pageWalkOrder(len(ids))
+	out := make([]string, 0, limit)
+	for _, idx := range order[:limit] {
+		out = append(out, ids[idx])
+	}
+	return out
 }
 
 // TODO(JaySon-Huang): DB9/Postgres tenants are not yet supported in the semantic
@@ -874,6 +1008,8 @@ func (m *semanticWorkerManager) targetForRef(ctx context.Context, ref semanticTe
 		if !ok {
 			return nil, fmt.Errorf("cached backend missing for %s", ref.id)
 		}
+		// WarmTenantIDs is only a snapshot; the pool can go cold before this
+		// cached acquire pins the backend, so re-check without opening a conn.
 		if b.Store().DB().Stats().OpenConnections == 0 {
 			release()
 			return nil, fmt.Errorf("cached backend cold for %s", ref.id)

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -358,6 +358,9 @@ func (m *semanticWorkerManager) queueNextPendingKick() {
 	for {
 		m.mu.Lock()
 		tenantID := ""
+		// The pending set is bounded by tenant count. Re-scanning after each
+		// successful enqueue keeps the common path simple and preserves fairness
+		// well enough for the small delayed-kick backlog this queue is meant for.
 		for id := range m.kickPending {
 			if _, queued := m.kickQueued[id]; queued {
 				continue
@@ -375,6 +378,12 @@ func (m *semanticWorkerManager) queueNextPendingKick() {
 func (m *semanticWorkerManager) clearKickPending(tenantID string) {
 	m.mu.Lock()
 	delete(m.kickPending, tenantID)
+	delete(m.kickQueued, tenantID)
+	m.mu.Unlock()
+}
+
+func (m *semanticWorkerManager) markKickDequeued(tenantID string) {
+	m.mu.Lock()
 	delete(m.kickQueued, tenantID)
 	m.mu.Unlock()
 }
@@ -432,10 +441,10 @@ func (m *semanticWorkerManager) workerLoop(ctx context.Context, workerID int) {
 	defer ticker.Stop()
 	for {
 		processed := m.processNext(ctx)
-		// Multi-tenant periodic polling waits for the warm-tenant cadence after
-		// each claim so the poll loop itself does not keep user DB pools warm.
-		// New writes still drain promptly through Kick/processKicked.
-		if processed && !m.isMultiTenant() {
+		// If a task was processed, immediately look for more work. Multi-tenant
+		// scans are warm-cache only, so this drains real backlog without opening
+		// dormant tenant DBs.
+		if processed {
 			continue
 		}
 		select {
@@ -490,9 +499,6 @@ func (m *semanticWorkerManager) effectiveRecoverInterval() time.Duration {
 	if interval <= 0 {
 		interval = defaultSemanticRecoverInterval
 	}
-	if m.isMultiTenant() && interval < m.opts.WarmTenantPollInterval {
-		return m.opts.WarmTenantPollInterval
-	}
 	return interval
 }
 
@@ -512,17 +518,16 @@ func (m *semanticWorkerManager) processNext(ctx context.Context) bool {
 // processKicked attempts to claim tasks for one kicked tenant immediately.
 func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID string) {
 	defer m.queueNextPendingKick()
-	// Clear the pending mark before claiming: a task committed after this
-	// point triggers a fresh kick, and a task committed before it is already
-	// visible to the claim below, so no enqueue can slip through unnoticed.
-	m.clearKickPending(tenantID)
+	m.markKickDequeued(tenantID)
 	ref, ok := m.kickRef(ctx, tenantID)
 	if !ok {
+		m.clearKickPending(tenantID)
 		return
 	}
 	if !m.tryClaimTenantSlot(ref.id) {
 		// Another worker already holds this tenant's slot and its claim will
 		// observe any task committed before the kick was sent.
+		m.clearKickPending(tenantID)
 		return
 	}
 	target, err := m.targetForRef(ctx, ref)
@@ -533,6 +538,15 @@ func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID stri
 		m.releaseTenantSlot(ref.id)
 		return
 	}
+	if target == nil {
+		m.releaseTenantSlot(ref.id)
+		return
+	}
+	// Clear the pending mark only after the backend is acquired: a task
+	// committed after this point triggers a fresh kick, and a task committed
+	// before it is already visible to the claim below. If acquire failed above,
+	// the pending mark is left in place and queueNextPendingKick retries it.
+	m.clearKickPending(tenantID)
 	target.release = chainReleases(target.release, func() { m.releaseTenantSlot(ref.id) })
 	defer target.release()
 	if len(target.allowedTaskTypes) == 0 {
@@ -778,6 +792,9 @@ func (m *semanticWorkerManager) recoverExpiredRefs(ctx context.Context, refs []s
 				zap.Error(err))
 			continue
 		}
+		if target == nil {
+			continue
+		}
 		func() {
 			defer target.release()
 			start := time.Now()
@@ -820,6 +837,10 @@ func (m *semanticWorkerManager) nextTarget(ctx context.Context) (*semanticTarget
 			logger.Warn(ctx, "semantic_worker_open_store_failed",
 				zap.String("tenant_id", ref.id),
 				zap.Error(err))
+			m.releaseTenantSlot(ref.id)
+			continue
+		}
+		if target == nil {
 			m.releaseTenantSlot(ref.id)
 			continue
 		}
@@ -1008,13 +1029,13 @@ func (m *semanticWorkerManager) targetForRef(ctx context.Context, ref semanticTe
 	if ref.cached {
 		b, release, ok := m.pool.AcquireCached(ref.id)
 		if !ok {
-			return nil, fmt.Errorf("cached backend missing for %s", ref.id)
+			return nil, nil
 		}
 		// WarmTenantIDs is only a snapshot; the pool can go cold before this
 		// cached acquire pins the backend, so re-check without opening a conn.
 		if b.Store().DB().Stats().OpenConnections == 0 {
 			release()
-			return nil, fmt.Errorf("cached backend cold for %s", ref.id)
+			return nil, nil
 		}
 		return &semanticTarget{
 			tenantID:         ref.id,
@@ -1503,6 +1524,9 @@ func (m *semanticWorkerManager) collectObservation(ctx context.Context, now time
 			logger.Warn(ctx, "semantic_worker_open_store_for_observation_failed",
 				zap.String("tenant_id", ref.id),
 				zap.Error(err))
+			continue
+		}
+		if target == nil {
 			continue
 		}
 		func() {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -215,6 +215,7 @@ type semanticTenantScanSnapshot struct {
 	cursorID        string
 	rawTenants      int
 	includedTenants int
+	limited         bool
 	wrapped         bool
 }
 
@@ -548,8 +549,9 @@ func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID stri
 	m.Kick(tenantID)
 }
 
-// kickRef resolves a kicked tenant ID to a schedulable ref, applying the same
-// status and provider/task-type filters as cached polling.
+// kickRef resolves a kicked tenant ID to a schedulable ref. Unlike cached
+// polling, a kick can wake a dormant tenant, so it applies provider/task-type
+// filters before acquiring the backend.
 func (m *semanticWorkerManager) kickRef(ctx context.Context, tenantID string) (semanticTenantRef, bool) {
 	if tenantID == semanticLocalTenantID {
 		// Match scan behavior: the local fallback is only schedulable outside
@@ -952,7 +954,7 @@ func (m *semanticWorkerManager) recordCachedTenantScan(raw, included int, limite
 		limit:           m.opts.TenantScanLimit,
 		rawTenants:      raw,
 		includedTenants: included,
-		wrapped:         limited,
+		limited:         limited,
 	}
 }
 
@@ -1450,6 +1452,7 @@ func semanticTenantScanLogFields(s semanticTenantScanSnapshot) []zap.Field {
 		zap.String("tenant_scan_cursor_id", s.cursorID),
 		zap.Int("tenant_scan_raw_tenants", s.rawTenants),
 		zap.Int("tenant_scan_included_tenants", s.includedTenants),
+		zap.Bool("tenant_scan_limited", s.limited),
 		zap.Bool("tenant_scan_wrapped", s.wrapped),
 	}
 	if s.cursorSet {

--- a/pkg/server/semantic_worker.go
+++ b/pkg/server/semantic_worker.go
@@ -519,7 +519,10 @@ func (m *semanticWorkerManager) processNext(ctx context.Context) bool {
 func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID string) {
 	defer m.queueNextPendingKick()
 	m.markKickDequeued(tenantID)
-	ref, ok := m.kickRef(ctx, tenantID)
+	ref, ok, err := m.kickRef(ctx, tenantID)
+	if err != nil {
+		return
+	}
 	if !ok {
 		m.clearKickPending(tenantID)
 		return
@@ -566,34 +569,37 @@ func (m *semanticWorkerManager) processKicked(ctx context.Context, tenantID stri
 // kickRef resolves a kicked tenant ID to a schedulable ref. Unlike cached
 // polling, a kick can wake a dormant tenant, so it applies provider/task-type
 // filters before acquiring the backend.
-func (m *semanticWorkerManager) kickRef(ctx context.Context, tenantID string) (semanticTenantRef, bool) {
+func (m *semanticWorkerManager) kickRef(ctx context.Context, tenantID string) (semanticTenantRef, bool, error) {
 	if tenantID == semanticLocalTenantID {
 		// Match scan behavior: the local fallback is only schedulable outside
 		// multi-tenant mode (listTenantRefs never enumerates it otherwise).
 		if m.meta == nil || m.pool == nil {
 			if m.shouldIncludeFallback() {
-				return semanticTenantRef{id: semanticLocalTenantID}, true
+				return semanticTenantRef{id: semanticLocalTenantID}, true, nil
 			}
 		}
-		return semanticTenantRef{}, false
+		return semanticTenantRef{}, false, nil
 	}
 	if m.meta == nil || m.pool == nil {
-		return semanticTenantRef{}, false
+		return semanticTenantRef{}, false, nil
 	}
 	t, err := m.meta.GetTenant(ctx, tenantID)
 	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			return semanticTenantRef{}, false, nil
+		}
 		logger.Warn(ctx, "semantic_worker_kick_tenant_lookup_failed",
 			zap.String("tenant_id", tenantID),
 			zap.Error(err))
-		return semanticTenantRef{}, false
+		return semanticTenantRef{}, false, err
 	}
 	if t.Status != meta.TenantActive {
-		return semanticTenantRef{}, false
+		return semanticTenantRef{}, false, nil
 	}
 	if !hasAnyTaskTypes(m.taskTypesForProvider(t.Provider)) {
-		return semanticTenantRef{}, false
+		return semanticTenantRef{}, false, nil
 	}
-	return semanticTenantRef{id: t.ID, tenant: t}, true
+	return semanticTenantRef{id: t.ID, tenant: t}, true, nil
 }
 
 func (m *semanticWorkerManager) claimAndProcessOne(ctx context.Context, target *semanticTarget) bool {

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -1299,7 +1299,7 @@ func TestSemanticWorkerListTenantRefsIncludesOnlyWarmCachedTenants(t *testing.T)
 		t.Fatalf("refs = %v, want one cached tenant and no dormant tenant", got)
 	}
 	scan := m.tenantScanSnapshot()
-	if scan.rawTenants != 2 || scan.includedTenants != 1 || !scan.wrapped || scan.cursorSet {
+	if scan.rawTenants != 2 || scan.includedTenants != 1 || !scan.limited || scan.wrapped || scan.cursorSet {
 		t.Fatalf("tenant scan snapshot = %+v, want limited warm scan", scan)
 	}
 }

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -483,8 +483,7 @@ func TestSemanticWorkerKeepsBorrowedTenantBackendAliveDuringInvalidate(t *testin
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPool(t)
 	parsed, err := mysql.ParseDSN(testDSN)
@@ -524,14 +523,7 @@ func TestSemanticWorkerKeepsBorrowedTenantBackendAliveDuringInvalidate(t *testin
 	if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
 		t.Fatal(err)
 	}
-	b, err := pool.Get(context.Background(), tenantMeta)
-	if err != nil {
-		t.Fatal(err)
-	}
-	b.Store().DB().SetMaxIdleConns(1)
-	if err := b.Store().DB().PingContext(context.Background()); err != nil {
-		t.Fatal(err)
-	}
+	b := warmTestTenantBackend(t, pool, tenantMeta)
 	if _, err := b.Write("/docs/pinned-worker.txt", []byte("hello borrowed backend"), 0, filesystem.WriteFlagCreate); err != nil {
 		t.Fatal(err)
 	}
@@ -743,8 +735,7 @@ func TestSemanticWorkerManagerStartsForMultiTenantImageOnlyMode(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPoolWithBackendOptions(t, backend.Options{
 		AsyncImageExtract: backend.AsyncImageExtractOptions{Enabled: true},
@@ -785,8 +776,7 @@ func TestSemanticWorkerManagerStartsForMultiTenantAudioOnlyMode(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPoolWithBackendOptions(t, backend.Options{
 		AsyncAudioExtract: backend.AsyncAudioExtractOptions{Enabled: true, Extractor: staticServerAudioExtractor{text: "x"}},
@@ -828,8 +818,7 @@ func TestSemanticWorkerManagerNilWhenMultiTenantOnlyFallbackHasAutoTasks(t *test
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPool(t)
 	fallback := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{
@@ -929,6 +918,104 @@ func TestSemanticWorkerRecoversExpiredClaim(t *testing.T) {
 	waitForTaskStatus(t, b, nf.File.FileID, 1, string(semantic.TaskSucceeded), 3*time.Second)
 	if claimed.TaskID == "" {
 		t.Fatal("expected claimed task id")
+	}
+}
+
+func TestSemanticWorkerRecoversExpiredClaimForColdPoolTenant(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	appStore, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetDB(t, appStore.DB())
+	defer func() { _ = appStore.Close() }()
+
+	pool := newTestTenantPool(t)
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	tenantMeta := &meta.Tenant{
+		ID:               token.NewID(),
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
+		t.Fatal(err)
+	}
+	if warm := pool.WarmTenantIDs(); len(warm) != 0 {
+		t.Fatalf("warm tenant ids before recovery = %v, want none", warm)
+	}
+
+	ctx := context.Background()
+	taskTime := time.Now().UTC().Add(-time.Minute)
+	if _, err := appStore.EnqueueSemanticTask(ctx, &semantic.Task{
+		TaskID:          "cold-expired-task",
+		TaskType:        semantic.TaskTypeEmbed,
+		ResourceID:      "file-cold-expired",
+		ResourceVersion: 1,
+		Status:          semantic.TaskQueued,
+		MaxAttempts:     3,
+		AvailableAt:     taskTime,
+		CreatedAt:       taskTime,
+		UpdatedAt:       taskTime,
+		PayloadJSON:     []byte(`{"path":"/docs/cold.txt"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	claimed, found, err := appStore.ClaimSemanticTask(ctx, taskTime.Add(time.Second), 10*time.Millisecond, semantic.TaskTypeEmbed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected claim to find cold tenant task")
+	}
+
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{
+		TenantScanLimit: 1,
+	})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	m.recoverExpired(context.Background())
+
+	var status string
+	if err := appStore.DB().QueryRow(`SELECT status FROM semantic_tasks WHERE task_id = ?`, claimed.TaskID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(semantic.TaskQueued) {
+		t.Fatalf("cold tenant task status=%q, want %q", status, semantic.TaskQueued)
 	}
 }
 
@@ -1041,8 +1128,7 @@ func TestSemanticWorkerListTenantRefsUsesWarmCachedBackendsOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPool(t)
 	parsed, err := mysql.ParseDSN(testDSN)
@@ -1206,13 +1292,15 @@ func TestSemanticWorkerListTenantRefsIncludesOnlyWarmCachedTenants(t *testing.T)
 		got = append(got, ref.id)
 	}
 	slices.Sort(got)
-	want := []string{"tenant-cached-1", "tenant-cached-2"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("refs = %v, want %v", got, want)
+	if len(got) != 1 {
+		t.Fatalf("refs = %v, want one cached tenant due to scan limit", got)
+	}
+	if !slices.Contains([]string{"tenant-cached-1", "tenant-cached-2"}, got[0]) {
+		t.Fatalf("refs = %v, want one cached tenant and no dormant tenant", got)
 	}
 	scan := m.tenantScanSnapshot()
-	if scan.rawTenants != 2 || scan.includedTenants != 2 || scan.cursorSet {
-		t.Fatalf("tenant scan snapshot = %+v, want two cached tenants and no cursor", scan)
+	if scan.rawTenants != 2 || scan.includedTenants != 1 || !scan.wrapped || scan.cursorSet {
+		t.Fatalf("tenant scan snapshot = %+v, want limited warm scan", scan)
 	}
 }
 
@@ -1223,8 +1311,7 @@ func TestSemanticWorkerListTenantRefsDoesNotFilterWarmCachedProviders(t *testing
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPool(t)
 	parsed, err := mysql.ParseDSN(testDSN)
@@ -1312,14 +1399,100 @@ func TestSemanticWorkerListTenantRefsDoesNotFilterWarmCachedProviders(t *testing
 	}
 }
 
+func TestSemanticWorkerListTenantRefsSkipsInactiveWarmCachedTenant(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	pool := newTestTenantPool(t)
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	activeTenant := &meta.Tenant{
+		ID:               "tenant-active-warm",
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	deletingTenant := &meta.Tenant{
+		ID:               "tenant-deleting-warm",
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now.Add(time.Millisecond),
+		UpdatedAt:        now.Add(time.Millisecond),
+	}
+	if err := metaStore.InsertTenant(context.Background(), activeTenant); err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.InsertTenant(context.Background(), deletingTenant); err != nil {
+		t.Fatal(err)
+	}
+	warmTestTenantBackend(t, pool, activeTenant)
+	warmTestTenantBackend(t, pool, deletingTenant)
+	if err := metaStore.UpdateTenantStatus(context.Background(), deletingTenant.ID, meta.TenantDeleting); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	refs, err := m.listTenantRefs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		got = append(got, ref.id)
+	}
+	slices.Sort(got)
+	if !slices.Equal(got, []string{activeTenant.ID}) {
+		t.Fatalf("tenant refs=%v, want only active warm tenant %q", got, activeTenant.ID)
+	}
+}
+
 func TestSemanticWorkerLegacyProviderFilterStillAppliesToKicks(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPool(t)
 	passCipher, err := pool.Encrypt(context.Background(), []byte("pw"))
@@ -1392,8 +1565,7 @@ func TestSemanticWorkerHTTPMultiTenantImageOnlySkipsAppTenantEmbedTasks(t *testi
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPoolWithBackendOptions(t, backend.Options{
 		AppSemanticTasksEnabled: true,
@@ -1550,8 +1722,7 @@ func TestSemanticWorkerListTenantRefsDoesNotUseFallbackImageCapabilityForPoolTen
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPool(t)
 	passCipher, err := pool.Encrypt(context.Background(), []byte("pw"))
@@ -2167,8 +2338,7 @@ func TestSemanticWorkerNextTargetUsesWarmCachedBackendOnly(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPool(t)
 	parsed, err := mysql.ParseDSN(testDSN)
@@ -2275,14 +2445,13 @@ func TestSemanticWorkerKickDedupAndOverflow(t *testing.T) {
 	if len(m.kicks) != semanticKickQueueCapacity {
 		t.Fatalf("kicks=%d after overflow, want %d", len(m.kicks), semanticKickQueueCapacity)
 	}
-	// A dropped kick must not stay marked pending, or later kicks for that
-	// tenant would be deduped away forever.
-	droppedID := fmt.Sprintf("tenant-fill-%d", semanticKickQueueCapacity-1)
+	delayedID := fmt.Sprintf("tenant-fill-%d", semanticKickQueueCapacity-1)
 	m.mu.Lock()
-	_, pending := m.kickPending[droppedID]
+	_, pending := m.kickPending[delayedID]
+	_, queued := m.kickQueued[delayedID]
 	m.mu.Unlock()
-	if pending {
-		t.Fatalf("tenant %s still pending after dropped kick", droppedID)
+	if !pending || queued {
+		t.Fatalf("tenant %s pending=%v queued=%v, want pending delayed kick", delayedID, pending, queued)
 	}
 
 	got := <-m.kicks
@@ -2290,9 +2459,16 @@ func TestSemanticWorkerKickDedupAndOverflow(t *testing.T) {
 		t.Fatalf("first queued kick=%q, want tenant-a", got)
 	}
 	m.clearKickPending(got)
-	m.Kick("tenant-a")
+	m.queueNextPendingKick()
 	if len(m.kicks) != semanticKickQueueCapacity {
-		t.Fatalf("kicks=%d after re-kick, want %d", len(m.kicks), semanticKickQueueCapacity)
+		t.Fatalf("kicks=%d after delayed kick retry, want %d", len(m.kicks), semanticKickQueueCapacity)
+	}
+	m.mu.Lock()
+	_, pending = m.kickPending[delayedID]
+	_, queued = m.kickQueued[delayedID]
+	m.mu.Unlock()
+	if !pending || !queued {
+		t.Fatalf("tenant %s pending=%v queued=%v, want delayed kick requeued", delayedID, pending, queued)
 	}
 }
 
@@ -2322,8 +2498,7 @@ func TestSemanticWorkerKickClaimsPoolTenantTaskWithoutScan(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = metaStore.Close() }()
-	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
-	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPool(t)
 

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -1563,10 +1563,16 @@ func TestSemanticWorkerLegacyProviderFilterStillAppliesToKicks(t *testing.T) {
 	if m == nil {
 		t.Fatal("expected semantic worker manager")
 	}
-	if ref, ok := m.kickRef(context.Background(), autoTenantID); ok {
+	if ref, ok, err := m.kickRef(context.Background(), autoTenantID); err != nil || ok {
+		if err != nil {
+			t.Fatal(err)
+		}
 		t.Fatalf("auto tenant kick ref = %+v, want skipped without pool extract types", ref)
 	}
-	ref, ok := m.kickRef(context.Background(), keepTenantID)
+	ref, ok, err := m.kickRef(context.Background(), keepTenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if !ok {
 		t.Fatal("expected non-auto tenant kick ref")
 	}
@@ -2544,6 +2550,41 @@ func TestSemanticWorkerKickedAcquireFailureKeepsKickPending(t *testing.T) {
 	m.mu.Unlock()
 	if !pending || !queued {
 		t.Fatalf("tenant %s pending=%v queued=%v, want acquire failure to keep kick retryable", tenantID, pending, queued)
+	}
+	if len(m.kicks) != 1 {
+		t.Fatalf("kicks=%d, want requeued failed kick", len(m.kicks))
+	}
+}
+
+func TestSemanticWorkerKickedLookupFailureKeepsKickPending(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	pool := newTestTenantPool(t)
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	tenantID := token.NewID()
+	m.Kick(tenantID)
+	got := <-m.kicks
+	if got != tenantID {
+		t.Fatalf("queued kick=%q, want %q", got, tenantID)
+	}
+	if err := metaStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+	m.processKicked(context.Background(), got)
+
+	m.mu.Lock()
+	_, pending := m.kickPending[tenantID]
+	_, queued := m.kickQueued[tenantID]
+	m.mu.Unlock()
+	if !pending || !queued {
+		t.Fatalf("tenant %s pending=%v queued=%v, want lookup failure to keep kick retryable", tenantID, pending, queued)
 	}
 	if len(m.kicks) != 1 {
 		t.Fatalf("kicks=%d, want requeued failed kick", len(m.kicks))

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -107,6 +107,37 @@ func newTestTenantPoolWithBackendOptions(t *testing.T, opts backend.Options) *te
 	return pool
 }
 
+func warmTestTenantBackend(t *testing.T, pool *tenant.Pool, tenantMeta *meta.Tenant) *backend.Dat9Backend {
+	t.Helper()
+	b, err := pool.Get(context.Background(), tenantMeta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db := b.Store().DB()
+	db.SetMaxIdleConns(1)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := db.PingContext(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if stats := db.Stats(); stats.OpenConnections == 0 {
+		t.Fatalf("tenant backend open connections = 0, want warm backend")
+	}
+	return b
+}
+
+func waitForTenantDBOpenConnections(t *testing.T, db *sql.DB, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if got := db.Stats().OpenConnections; got == want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("tenant backend open connections = %d, want %d", db.Stats().OpenConnections, want)
+}
+
 func newTestBackendForSemanticWorkerWithOptions(t *testing.T, opts backend.Options) *backend.Dat9Backend {
 	t.Helper()
 	s3Dir, err := os.MkdirTemp("", "dat9-semantic-worker-s3-*")
@@ -497,6 +528,10 @@ func TestSemanticWorkerKeepsBorrowedTenantBackendAliveDuringInvalidate(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
+	b.Store().DB().SetMaxIdleConns(1)
+	if err := b.Store().DB().PingContext(context.Background()); err != nil {
+		t.Fatal(err)
+	}
 	if _, err := b.Write("/docs/pinned-worker.txt", []byte("hello borrowed backend"), 0, filesystem.WriteFlagCreate); err != nil {
 		t.Fatal(err)
 	}
@@ -508,10 +543,11 @@ func TestSemanticWorkerKeepsBorrowedTenantBackendAliveDuringInvalidate(t *testin
 	}
 
 	s := NewWithConfig(Config{Meta: metaStore, Pool: pool, SemanticEmbedder: embedder, SemanticWorkers: SemanticWorkerOptions{
-		Workers:         1,
-		PollInterval:    10 * time.Millisecond,
-		RecoverInterval: 50 * time.Millisecond,
-		LeaseDuration:   200 * time.Millisecond,
+		Workers:                1,
+		PollInterval:           10 * time.Millisecond,
+		WarmTenantPollInterval: 10 * time.Millisecond,
+		RecoverInterval:        50 * time.Millisecond,
+		LeaseDuration:          200 * time.Millisecond,
 	}})
 	t.Cleanup(func() { s.Close() })
 
@@ -998,7 +1034,8 @@ func TestSemanticWorkerCollectObservationLocalFallback(t *testing.T) {
 	waitForNamedTaskStatus(t, b, claimed.TaskID, string(semantic.TaskProcessing), time.Second)
 }
 
-func TestSemanticWorkerListTenantRefsImageOnlyIncludesAutoProviders(t *testing.T) {
+func TestSemanticWorkerListTenantRefsUsesWarmCachedBackendsOnly(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -1007,40 +1044,51 @@ func TestSemanticWorkerListTenantRefsImageOnlyIncludesAutoProviders(t *testing.T
 	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
 	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
 
-	pool := newTestTenantPoolWithBackendOptions(t, backend.Options{
-		AsyncImageExtract: backend.AsyncImageExtractOptions{Enabled: true},
-	})
-	passCipher, err := pool.Encrypt(context.Background(), []byte("pw"))
+	pool := newTestTenantPool(t)
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
 	if err != nil {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
-	autoTenantID := token.NewID()
-	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
-		ID:               autoTenantID,
+	cachedTenant := &meta.Tenant{
+		ID:               token.NewID(),
 		Status:           meta.TenantActive,
-		DBHost:           "127.0.0.1",
-		DBPort:           4000,
-		DBUser:           "root",
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
 		DBPasswordCipher: passCipher,
-		DBName:           "app",
+		DBName:           parsed.DBName,
 		DBTLS:            false,
-		Provider:         tenant.ProviderTiDBZero,
+		Provider:         tenant.ProviderDB9,
 		SchemaVersion:    1,
 		CreatedAt:        now,
 		UpdatedAt:        now,
-	}); err != nil {
+	}
+	if err := metaStore.InsertTenant(context.Background(), cachedTenant); err != nil {
 		t.Fatal(err)
 	}
-	keepTenantID := token.NewID()
 	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
-		ID:               keepTenantID,
+		ID:               token.NewID(),
 		Status:           meta.TenantActive,
-		DBHost:           "127.0.0.1",
-		DBPort:           4000,
-		DBUser:           "root",
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
 		DBPasswordCipher: passCipher,
-		DBName:           "app",
+		DBName:           parsed.DBName,
 		DBTLS:            false,
 		Provider:         tenant.ProviderDB9,
 		SchemaVersion:    1,
@@ -1058,7 +1106,7 @@ func TestSemanticWorkerListTenantRefsImageOnlyIncludesAutoProviders(t *testing.T
 		semanticWorkerUsesTiDBAutoEmbedding = orig
 	}()
 
-	m := newSemanticWorkerManager(nil, metaStore, pool, nil, SemanticWorkerOptions{})
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
 	if m == nil {
 		t.Fatal("expected semantic worker manager")
 	}
@@ -1066,16 +1114,24 @@ func TestSemanticWorkerListTenantRefsImageOnlyIncludesAutoProviders(t *testing.T
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Both the TiDB-auto tenant and the DB9 tenant are included: the pool
-	// configures async image extract, and extract task types are independent
-	// of EMBED_TEXT. taskTypesForTarget filters at the per-backend level, so
-	// only backends that actually support extract will claim tasks.
-	if len(refs) != 2 {
-		t.Fatalf("tenant ref count=%d, want 2 (auto + db9)", len(refs))
+	if len(refs) != 0 {
+		t.Fatalf("tenant ref count before cache=%d, want 0", len(refs))
+	}
+	warmTestTenantBackend(t, pool, cachedTenant)
+	refs, err = m.listTenantRefs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 {
+		t.Fatalf("tenant ref count after cache=%d, want 1", len(refs))
+	}
+	if refs[0].id != cachedTenant.ID || !refs[0].cached {
+		t.Fatalf("tenant ref = %+v, want cached tenant %q", refs[0], cachedTenant.ID)
 	}
 }
 
-func TestSemanticWorkerListTenantRefsRotatesAcrossActiveTenantPages(t *testing.T) {
+func TestSemanticWorkerListTenantRefsIncludesOnlyWarmCachedTenants(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -1083,40 +1139,150 @@ func TestSemanticWorkerListTenantRefsRotatesAcrossActiveTenantPages(t *testing.T
 	defer func() { _ = metaStore.Close() }()
 	testmysql.ResetMetaDB(t, metaStore.DB())
 
-	pool := newTestTenantPoolWithBackendOptions(t, backend.Options{
-		AsyncImageExtract: backend.AsyncImageExtractOptions{Enabled: true},
-	})
-	passCipher, err := pool.Encrypt(context.Background(), []byte("pw"))
+	pool := newTestTenantPool(t)
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
 	if err != nil {
 		t.Fatal(err)
 	}
 	base := time.Now().UTC().Truncate(time.Millisecond)
+	var cached []*meta.Tenant
 	for _, tc := range []struct {
-		id        string
-		provider  string
-		createdAt time.Time
+		id     string
+		cached bool
 	}{
-		{id: "tenant-db9", provider: tenant.ProviderDB9, createdAt: base},
-		{id: "tenant-auto-1", provider: tenant.ProviderTiDBZero, createdAt: base.Add(time.Second)},
-		{id: "tenant-auto-2", provider: tenant.ProviderTiDBZero, createdAt: base.Add(2 * time.Second)},
+		{id: "tenant-cached-1", cached: true},
+		{id: "tenant-dormant", cached: false},
+		{id: "tenant-cached-2", cached: true},
 	} {
-		if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		tnt := &meta.Tenant{
 			ID:               tc.id,
 			Status:           meta.TenantActive,
-			DBHost:           "127.0.0.1",
-			DBPort:           4000,
-			DBUser:           "root",
+			DBHost:           host,
+			DBPort:           port,
+			DBUser:           parsed.User,
 			DBPasswordCipher: passCipher,
-			DBName:           "app",
+			DBName:           parsed.DBName,
 			DBTLS:            false,
-			Provider:         tc.provider,
+			Provider:         tenant.ProviderDB9,
 			SchemaVersion:    1,
-			CreatedAt:        tc.createdAt,
-			UpdatedAt:        tc.createdAt,
-		}); err != nil {
+			CreatedAt:        base,
+			UpdatedAt:        base,
+		}
+		if err := metaStore.InsertTenant(context.Background(), tnt); err != nil {
 			t.Fatal(err)
 		}
+		if tc.cached {
+			cached = append(cached, tnt)
+		}
 	}
+	for _, tnt := range cached {
+		warmTestTenantBackend(t, pool, tnt)
+	}
+
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{TenantScanLimit: 1})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	refs, err := m.listTenantRefs(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		got = append(got, ref.id)
+	}
+	slices.Sort(got)
+	want := []string{"tenant-cached-1", "tenant-cached-2"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("refs = %v, want %v", got, want)
+	}
+	scan := m.tenantScanSnapshot()
+	if scan.rawTenants != 2 || scan.includedTenants != 2 || scan.cursorSet {
+		t.Fatalf("tenant scan snapshot = %+v, want two cached tenants and no cursor", scan)
+	}
+}
+
+func TestSemanticWorkerListTenantRefsDoesNotFilterWarmCachedProviders(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	_, _ = metaStore.DB().Exec("DELETE FROM tenant_api_keys")
+	_, _ = metaStore.DB().Exec("DELETE FROM tenants")
+
+	pool := newTestTenantPool(t)
+	parsed, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	customTenant := &meta.Tenant{
+		ID:               token.NewID(),
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         "custom-semantic-provider",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := metaStore.InsertTenant(context.Background(), customTenant); err != nil {
+		t.Fatal(err)
+	}
+	keepTenantID := token.NewID()
+	keepTenant := &meta.Tenant{
+		ID:               keepTenantID,
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+	if err := metaStore.InsertTenant(context.Background(), keepTenant); err != nil {
+		t.Fatal(err)
+	}
+	warmTestTenantBackend(t, pool, customTenant)
+	warmTestTenantBackend(t, pool, keepTenant)
 
 	orig := semanticWorkerUsesTiDBAutoEmbedding
 	semanticWorkerUsesTiDBAutoEmbedding = func(provider string) bool {
@@ -1126,47 +1292,27 @@ func TestSemanticWorkerListTenantRefsRotatesAcrossActiveTenantPages(t *testing.T
 		semanticWorkerUsesTiDBAutoEmbedding = orig
 	}()
 
-	m := newSemanticWorkerManager(nil, metaStore, pool, nil, SemanticWorkerOptions{TenantScanLimit: 1})
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
 	if m == nil {
 		t.Fatal("expected semantic worker manager")
 	}
-	assertRefs := func(want ...string) {
-		t.Helper()
-		refs, err := m.listTenantRefs(context.Background())
-		if err != nil {
-			t.Fatal(err)
-		}
-		got := make([]string, 0, len(refs))
-		for _, ref := range refs {
-			got = append(got, ref.id)
-		}
-		if !slices.Equal(got, want) {
-			t.Fatalf("refs = %v, want %v", got, want)
-		}
+	refs, err := m.listTenantRefs(context.Background())
+	if err != nil {
+		t.Fatal(err)
 	}
-
-	// All three tenants are scanned: db9 is included because the pool configures
-	// async image extract, and extract task types are independent of EMBED_TEXT.
-	// With TenantScanLimit=1, each scan page returns one tenant in created-at order.
-	assertRefs("tenant-db9")
-	assertRefs("tenant-auto-1")
-	assertRefs("tenant-auto-2")
-	assertRefs("tenant-db9")
-	assertRefs("tenant-auto-1")
-
-	scan := m.tenantScanSnapshot()
-	if scan.limit != 1 {
-		t.Fatalf("tenant scan limit = %d, want 1", scan.limit)
+	got := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		got = append(got, ref.id)
 	}
-	if scan.rawTenants != 1 || scan.includedTenants != 1 {
-		t.Fatalf("tenant scan raw/included = %d/%d, want 1/1", scan.rawTenants, scan.includedTenants)
-	}
-	if !scan.cursorSet || scan.cursorID != "tenant-auto-1" {
-		t.Fatalf("tenant scan cursor = set:%v id:%q, want tenant-auto-1", scan.cursorSet, scan.cursorID)
+	slices.Sort(got)
+	want := []string{customTenant.ID, keepTenantID}
+	slices.Sort(want)
+	if !slices.Equal(got, want) {
+		t.Fatalf("tenant refs=%v, want cached tenants %v", got, want)
 	}
 }
 
-func TestSemanticWorkerListTenantRefsEmbedOnlySkipsAutoProviders(t *testing.T) {
+func TestSemanticWorkerLegacyProviderFilterStillAppliesToKicks(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -1228,15 +1374,15 @@ func TestSemanticWorkerListTenantRefsEmbedOnlySkipsAutoProviders(t *testing.T) {
 	if m == nil {
 		t.Fatal("expected semantic worker manager")
 	}
-	refs, err := m.listTenantRefs(context.Background())
-	if err != nil {
-		t.Fatal(err)
+	if ref, ok := m.kickRef(context.Background(), autoTenantID); ok {
+		t.Fatalf("auto tenant kick ref = %+v, want skipped without pool extract types", ref)
 	}
-	if len(refs) != 1 {
-		t.Fatalf("tenant ref count=%d, want 1", len(refs))
+	ref, ok := m.kickRef(context.Background(), keepTenantID)
+	if !ok {
+		t.Fatal("expected non-auto tenant kick ref")
 	}
-	if refs[0].id != keepTenantID {
-		t.Fatalf("tenant ref id=%q, want %q", refs[0].id, keepTenantID)
+	if ref.id != keepTenantID || ref.tenant == nil {
+		t.Fatalf("kick ref = %+v, want tenant %q with metadata", ref, keepTenantID)
 	}
 }
 
@@ -1648,6 +1794,49 @@ func TestSemanticWorkerNormalizeRetryMaxDelayAtLeastBase(t *testing.T) {
 	}
 }
 
+func TestSemanticWorkerMultiTenantEffectiveIntervalsUseWarmTenantMinimum(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	pool := newTestTenantPool(t)
+	warmInterval := 90 * time.Second
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{
+		PollInterval:           200 * time.Millisecond,
+		RecoverInterval:        5 * time.Second,
+		WarmTenantPollInterval: warmInterval,
+	})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	if got := m.effectivePollInterval(); got != warmInterval {
+		t.Fatalf("effective poll interval=%v, want %v", got, warmInterval)
+	}
+	if got := m.effectiveRecoverInterval(); got != warmInterval {
+		t.Fatalf("effective recover interval=%v, want %v", got, warmInterval)
+	}
+}
+
+func TestSemanticWorkerSingleTenantEffectiveIntervalsKeepConfiguredPoll(t *testing.T) {
+	pollInterval := 200 * time.Millisecond
+	recoverInterval := 5 * time.Second
+	m := newSemanticWorkerManager(newTestBackendForSemanticWorker(t), nil, nil, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{
+		PollInterval:           pollInterval,
+		RecoverInterval:        recoverInterval,
+		WarmTenantPollInterval: 90 * time.Second,
+	})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	if got := m.effectivePollInterval(); got != pollInterval {
+		t.Fatalf("effective poll interval=%v, want %v", got, pollInterval)
+	}
+	if got := m.effectiveRecoverInterval(); got != recoverInterval {
+		t.Fatalf("effective recover interval=%v, want %v", got, recoverInterval)
+	}
+}
+
 type serverSemanticTaskRow struct {
 	TaskType string
 	Status   string
@@ -1971,7 +2160,7 @@ func TestPageWalkOrderCoversAllTenantsAcrossUnevenRotatingPages(t *testing.T) {
 	}
 }
 
-func TestSemanticWorkerNextTargetSkipsFailingTenantWithinPage(t *testing.T) {
+func TestSemanticWorkerNextTargetUsesWarmCachedBackendOnly(t *testing.T) {
 	initServerTenantSchema(t, testDSN)
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -2000,29 +2189,8 @@ func TestSemanticWorkerNextTargetSkipsFailingTenantWithinPage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	now := time.Now().UTC()
-	// The failing tenant sorts first in the keyset page (older created_at):
-	// its backend can never be acquired because port 1 refuses connections.
-	failingTenantID := token.NewID()
-	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
-		ID:               failingTenantID,
-		Status:           meta.TenantActive,
-		DBHost:           "127.0.0.1",
-		DBPort:           1,
-		DBUser:           parsed.User,
-		DBPasswordCipher: passCipher,
-		DBName:           parsed.DBName,
-		DBTLS:            false,
-		Provider:         tenant.ProviderDB9,
-		SchemaVersion:    1,
-		CreatedAt:        now.Add(-time.Hour),
-		UpdatedAt:        now.Add(-time.Hour),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	healthyTenantID := token.NewID()
-	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
-		ID:               healthyTenantID,
+	tenantMeta := &meta.Tenant{
+		ID:               token.NewID(),
 		Status:           meta.TenantActive,
 		DBHost:           host,
 		DBPort:           port,
@@ -2032,33 +2200,52 @@ func TestSemanticWorkerNextTargetSkipsFailingTenantWithinPage(t *testing.T) {
 		DBTLS:            false,
 		Provider:         tenant.ProviderDB9,
 		SchemaVersion:    1,
-		CreatedAt:        now,
-		UpdatedAt:        now,
-	}); err != nil {
+		CreatedAt:        time.Now().UTC(),
+		UpdatedAt:        time.Now().UTC(),
+	}
+	if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
 		t.Fatal(err)
 	}
 
 	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
-
-	// Every pass over the page must reach the healthy tenant: the wrap-around
-	// walk attempts each tenant at most once, so the failing tenant cannot
-	// absorb retries meant for its neighbors. Under a per-claim random picker
-	// each pass had a 25% chance of claiming the failing tenant twice and
-	// returning nil, so 30 iterations expose that regression with probability
-	// 1 - 0.75^30 ≈ 99.98%.
-	for i := range 30 {
-		target, err := m.nextTarget(context.Background())
-		if err != nil {
-			t.Fatalf("nextTarget error at iteration %d: %v", i, err)
-		}
-		if target == nil {
-			t.Fatalf("nextTarget returned nil at iteration %d; failing tenant absorbed the page walk", i)
-		}
-		tenantID := target.tenantID
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	target, err := m.nextTarget(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != nil {
 		target.release()
-		if tenantID != healthyTenantID {
-			t.Fatalf("nextTarget picked tenant %q at iteration %d, want healthy tenant %q", tenantID, i, healthyTenantID)
-		}
+		t.Fatalf("nextTarget before cache = %+v, want nil", target)
+	}
+	coldBackend, err := pool.Get(context.Background(), tenantMeta)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool.StopAllFileGC()
+	coldBackend.Store().DB().SetMaxIdleConns(0)
+	waitForTenantDBOpenConnections(t, coldBackend.Store().DB(), 0)
+	target, err = m.nextTarget(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != nil {
+		target.release()
+		t.Fatalf("nextTarget after cold cache = %+v, want nil", target)
+	}
+	warmTestTenantBackend(t, pool, tenantMeta)
+	target, err = m.nextTarget(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target == nil {
+		t.Fatal("nextTarget after warm cache = nil, want target")
+	}
+	tenantID := target.tenantID
+	target.release()
+	if tenantID != tenantMeta.ID {
+		t.Fatalf("nextTarget tenant=%q, want %q", tenantID, tenantMeta.ID)
 	}
 }
 

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -2501,6 +2501,27 @@ func TestSemanticWorkerKickDedupAndOverflow(t *testing.T) {
 	}
 }
 
+func TestSemanticWorkerProcessQueuedKickDrainsBeforePoll(t *testing.T) {
+	m := newSemanticWorkerManager(newTestBackendForSemanticWorker(t), nil, nil, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	m.Kick(semanticLocalTenantID)
+	if !m.processQueuedKick(context.Background()) {
+		t.Fatal("processQueuedKick=false, want queued kick drained")
+	}
+	if len(m.kicks) != 0 {
+		t.Fatalf("kicks=%d, want drained queue", len(m.kicks))
+	}
+	m.mu.Lock()
+	_, pending := m.kickPending[semanticLocalTenantID]
+	_, queued := m.kickQueued[semanticLocalTenantID]
+	m.mu.Unlock()
+	if pending || queued {
+		t.Fatalf("local kick pending=%v queued=%v, want cleared after processing", pending, queued)
+	}
+}
+
 func TestSemanticWorkerKickedAcquireFailureKeepsKickPending(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -2533,7 +2554,11 @@ func TestSemanticWorkerKickedAcquireFailureKeepsKickPending(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
+	retryDelay := 50 * time.Millisecond
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{
+		RetryBaseDelay: retryDelay,
+		RetryMaxDelay:  retryDelay,
+	})
 	if m == nil {
 		t.Fatal("expected semantic worker manager")
 	}
@@ -2548,11 +2573,19 @@ func TestSemanticWorkerKickedAcquireFailureKeepsKickPending(t *testing.T) {
 	_, pending := m.kickPending[tenantID]
 	_, queued := m.kickQueued[tenantID]
 	m.mu.Unlock()
-	if !pending || !queued {
-		t.Fatalf("tenant %s pending=%v queued=%v, want acquire failure to keep kick retryable", tenantID, pending, queued)
+	if !pending || queued {
+		t.Fatalf("tenant %s pending=%v queued=%v, want delayed retryable kick", tenantID, pending, queued)
 	}
-	if len(m.kicks) != 1 {
-		t.Fatalf("kicks=%d, want requeued failed kick", len(m.kicks))
+	if len(m.kicks) != 0 {
+		t.Fatalf("kicks=%d, want no immediate requeue after acquire failure", len(m.kicks))
+	}
+	select {
+	case got := <-m.kicks:
+		if got != tenantID {
+			t.Fatalf("delayed queued kick=%q, want %q", got, tenantID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for delayed kick retry")
 	}
 }
 
@@ -2564,7 +2597,11 @@ func TestSemanticWorkerKickedLookupFailureKeepsKickPending(t *testing.T) {
 	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPool(t)
-	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
+	retryDelay := 50 * time.Millisecond
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{
+		RetryBaseDelay: retryDelay,
+		RetryMaxDelay:  retryDelay,
+	})
 	if m == nil {
 		t.Fatal("expected semantic worker manager")
 	}
@@ -2583,11 +2620,19 @@ func TestSemanticWorkerKickedLookupFailureKeepsKickPending(t *testing.T) {
 	_, pending := m.kickPending[tenantID]
 	_, queued := m.kickQueued[tenantID]
 	m.mu.Unlock()
-	if !pending || !queued {
-		t.Fatalf("tenant %s pending=%v queued=%v, want lookup failure to keep kick retryable", tenantID, pending, queued)
+	if !pending || queued {
+		t.Fatalf("tenant %s pending=%v queued=%v, want delayed retryable kick", tenantID, pending, queued)
 	}
-	if len(m.kicks) != 1 {
-		t.Fatalf("kicks=%d, want requeued failed kick", len(m.kicks))
+	if len(m.kicks) != 0 {
+		t.Fatalf("kicks=%d, want no immediate requeue after lookup failure", len(m.kicks))
+	}
+	select {
+	case got := <-m.kicks:
+		if got != tenantID {
+			t.Fatalf("delayed queued kick=%q, want %q", got, tenantID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for delayed kick retry")
 	}
 }
 

--- a/pkg/server/semantic_worker_test.go
+++ b/pkg/server/semantic_worker_test.go
@@ -126,6 +126,46 @@ func warmTestTenantBackend(t *testing.T, pool *tenant.Pool, tenantMeta *meta.Ten
 	return b
 }
 
+func newWarmableTenantMeta(t *testing.T, pool *tenant.Pool, dsn, id, provider string) *meta.Tenant {
+	t.Helper()
+	parsed, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, port := "127.0.0.1", 3306
+	if parsed.Addr != "" {
+		h, p, _ := strings.Cut(parsed.Addr, ":")
+		if h != "" {
+			host = h
+		}
+		if p != "" {
+			_, _ = fmt.Sscanf(p, "%d", &port)
+		}
+	}
+	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if id == "" {
+		id = token.NewID()
+	}
+	now := time.Now().UTC()
+	return &meta.Tenant{
+		ID:               id,
+		Status:           meta.TenantActive,
+		DBHost:           host,
+		DBPort:           port,
+		DBUser:           parsed.User,
+		DBPasswordCipher: passCipher,
+		DBName:           parsed.DBName,
+		DBTLS:            false,
+		Provider:         provider,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}
+}
+
 func waitForTenantDBOpenConnections(t *testing.T, db *sql.DB, want int) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)
@@ -485,41 +525,18 @@ func TestSemanticWorkerKeepsBorrowedTenantBackendAliveDuringInvalidate(t *testin
 	defer func() { _ = metaStore.Close() }()
 	testmysql.ResetMetaDB(t, metaStore.DB())
 
+	appStore, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testmysql.ResetDB(t, appStore.DB())
+	if err := appStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+
 	pool := newTestTenantPool(t)
-	parsed, err := mysql.ParseDSN(testDSN)
-	if err != nil {
-		t.Fatal(err)
-	}
-	host, port := "127.0.0.1", 3306
-	if parsed.Addr != "" {
-		h, p, _ := strings.Cut(parsed.Addr, ":")
-		if h != "" {
-			host = h
-		}
-		if p != "" {
-			_, _ = fmt.Sscanf(p, "%d", &port)
-		}
-	}
-	passCipher, err := pool.Encrypt(context.Background(), []byte(parsed.Passwd))
-	if err != nil {
-		t.Fatal(err)
-	}
-	now := time.Now().UTC()
 	tenantID := token.NewID()
-	tenantMeta := &meta.Tenant{
-		ID:               tenantID,
-		Status:           meta.TenantActive,
-		DBHost:           host,
-		DBPort:           port,
-		DBUser:           parsed.User,
-		DBPasswordCipher: passCipher,
-		DBName:           parsed.DBName,
-		DBTLS:            false,
-		Provider:         tenant.ProviderDB9,
-		SchemaVersion:    1,
-		CreatedAt:        now,
-		UpdatedAt:        now,
-	}
+	tenantMeta := newWarmableTenantMeta(t, pool, testDSN, tenantID, tenant.ProviderDB9)
 	if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
 		t.Fatal(err)
 	}
@@ -535,11 +552,10 @@ func TestSemanticWorkerKeepsBorrowedTenantBackendAliveDuringInvalidate(t *testin
 	}
 
 	s := NewWithConfig(Config{Meta: metaStore, Pool: pool, SemanticEmbedder: embedder, SemanticWorkers: SemanticWorkerOptions{
-		Workers:                1,
-		PollInterval:           10 * time.Millisecond,
-		WarmTenantPollInterval: 10 * time.Millisecond,
-		RecoverInterval:        50 * time.Millisecond,
-		LeaseDuration:          200 * time.Millisecond,
+		Workers:         1,
+		PollInterval:    10 * time.Millisecond,
+		RecoverInterval: 50 * time.Millisecond,
+		LeaseDuration:   200 * time.Millisecond,
 	}})
 	t.Cleanup(func() { s.Close() })
 
@@ -1717,6 +1733,7 @@ func TestSemanticWorkerHTTPMultiTenantImageOnlySkipsAppTenantEmbedTasks(t *testi
 }
 
 func TestSemanticWorkerListTenantRefsDoesNotUseFallbackImageCapabilityForPoolTenants(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -1725,28 +1742,11 @@ func TestSemanticWorkerListTenantRefsDoesNotUseFallbackImageCapabilityForPoolTen
 	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	pool := newTestTenantPool(t)
-	passCipher, err := pool.Encrypt(context.Background(), []byte("pw"))
-	if err != nil {
+	tenantMeta := newWarmableTenantMeta(t, pool, testDSN, token.NewID(), tenant.ProviderDB9)
+	if err := metaStore.InsertTenant(context.Background(), tenantMeta); err != nil {
 		t.Fatal(err)
 	}
-	now := time.Now().UTC()
-	autoTenantID := token.NewID()
-	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
-		ID:               autoTenantID,
-		Status:           meta.TenantActive,
-		DBHost:           "127.0.0.1",
-		DBPort:           4000,
-		DBUser:           "root",
-		DBPasswordCipher: passCipher,
-		DBName:           "app",
-		DBTLS:            false,
-		Provider:         tenant.ProviderTiDBZero,
-		SchemaVersion:    1,
-		CreatedAt:        now,
-		UpdatedAt:        now,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	warmTestTenantBackend(t, pool, tenantMeta)
 	fallback := newTestBackendForSemanticWorkerWithOptions(t, backend.Options{
 		DatabaseAutoEmbedding: true,
 		AsyncImageExtract: backend.AsyncImageExtractOptions{
@@ -1757,17 +1757,8 @@ func TestSemanticWorkerListTenantRefsDoesNotUseFallbackImageCapabilityForPoolTen
 		},
 	})
 
-	orig := semanticWorkerUsesTiDBAutoEmbedding
-	semanticWorkerUsesTiDBAutoEmbedding = func(provider string) bool {
-		return provider == tenant.ProviderTiDBZero
-	}
-	defer func() {
-		semanticWorkerUsesTiDBAutoEmbedding = orig
-	}()
-
-	// Pool has no async image extract, so TiDB-auto tenants get no task types from
-	// the pool; embedder is only to satisfy worker viability (multi-tenant path does
-	// not count fallback-only fbAuto — see newSemanticWorkerManager).
+	// Pool has no async image extract, so fallback-only image capability must not
+	// leak into pool tenants; embedder is only to satisfy worker viability.
 	m := newSemanticWorkerManager(fallback, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
 	if m == nil {
 		t.Fatal("expected semantic worker manager")
@@ -1776,8 +1767,22 @@ func TestSemanticWorkerListTenantRefsDoesNotUseFallbackImageCapabilityForPoolTen
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(refs) != 0 {
-		t.Fatalf("tenant ref count=%d, want 0", len(refs))
+	if len(refs) != 1 {
+		t.Fatalf("tenant ref count=%d, want warm pool tenant", len(refs))
+	}
+	target, err := m.targetForRef(context.Background(), refs[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target == nil {
+		t.Fatal("target is nil, want warm pool target")
+	}
+	defer target.release()
+	if slices.Contains(target.allowedTaskTypes, semantic.TaskTypeImgExtractText) {
+		t.Fatalf("allowed task types=%v, want no fallback image extract type for pool tenant", target.allowedTaskTypes)
+	}
+	if !slices.Contains(target.allowedTaskTypes, semantic.TaskTypeEmbed) {
+		t.Fatalf("allowed task types=%v, want app-managed embed type", target.allowedTaskTypes)
 	}
 }
 
@@ -1965,7 +1970,7 @@ func TestSemanticWorkerNormalizeRetryMaxDelayAtLeastBase(t *testing.T) {
 	}
 }
 
-func TestSemanticWorkerMultiTenantEffectiveIntervalsUseWarmTenantMinimum(t *testing.T) {
+func TestSemanticWorkerMultiTenantEffectiveIntervalsKeepRecoverIndependent(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -1973,9 +1978,10 @@ func TestSemanticWorkerMultiTenantEffectiveIntervalsUseWarmTenantMinimum(t *test
 	defer func() { _ = metaStore.Close() }()
 	pool := newTestTenantPool(t)
 	warmInterval := 90 * time.Second
+	recoverInterval := 5 * time.Second
 	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{
 		PollInterval:           200 * time.Millisecond,
-		RecoverInterval:        5 * time.Second,
+		RecoverInterval:        recoverInterval,
 		WarmTenantPollInterval: warmInterval,
 	})
 	if m == nil {
@@ -1984,8 +1990,8 @@ func TestSemanticWorkerMultiTenantEffectiveIntervalsUseWarmTenantMinimum(t *test
 	if got := m.effectivePollInterval(); got != warmInterval {
 		t.Fatalf("effective poll interval=%v, want %v", got, warmInterval)
 	}
-	if got := m.effectiveRecoverInterval(); got != warmInterval {
-		t.Fatalf("effective recover interval=%v, want %v", got, warmInterval)
+	if got := m.effectiveRecoverInterval(); got != recoverInterval {
+		t.Fatalf("effective recover interval=%v, want %v", got, recoverInterval)
 	}
 }
 
@@ -2419,6 +2425,23 @@ func TestSemanticWorkerNextTargetUsesWarmCachedBackendOnly(t *testing.T) {
 	}
 }
 
+func TestSemanticWorkerTargetForCachedRefMissingSkipsSilently(t *testing.T) {
+	pool := newTestTenantPool(t)
+	m := &semanticWorkerManager{pool: pool}
+	var opts SemanticWorkerOptions
+	opts.normalize()
+	m.opts = opts
+
+	target, err := m.targetForRef(context.Background(), semanticTenantRef{id: "tenant-cold", cached: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if target != nil {
+		target.release()
+		t.Fatalf("target=%+v, want nil for missing cached backend", target)
+	}
+}
+
 func TestSemanticWorkerKickDedupAndOverflow(t *testing.T) {
 	m := newSemanticWorkerManager(newTestBackendForSemanticWorker(t), nil, nil, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
 	if m == nil {
@@ -2469,6 +2492,61 @@ func TestSemanticWorkerKickDedupAndOverflow(t *testing.T) {
 	m.mu.Unlock()
 	if !pending || !queued {
 		t.Fatalf("tenant %s pending=%v queued=%v, want delayed kick requeued", delayedID, pending, queued)
+	}
+}
+
+func TestSemanticWorkerKickedAcquireFailureKeepsKickPending(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	pool := newTestTenantPool(t)
+	passCipher, err := pool.Encrypt(context.Background(), []byte("pw"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID := token.NewID()
+	now := time.Now().UTC()
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           1,
+		DBUser:           "root",
+		DBPasswordCipher: passCipher,
+		DBName:           "drive9_missing",
+		DBTLS:            false,
+		Provider:         tenant.ProviderDB9,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newSemanticWorkerManager(nil, metaStore, pool, staticSemanticEmbedder{vec: []float32{0.1}}, SemanticWorkerOptions{})
+	if m == nil {
+		t.Fatal("expected semantic worker manager")
+	}
+	m.Kick(tenantID)
+	got := <-m.kicks
+	if got != tenantID {
+		t.Fatalf("queued kick=%q, want %q", got, tenantID)
+	}
+	m.processKicked(context.Background(), got)
+
+	m.mu.Lock()
+	_, pending := m.kickPending[tenantID]
+	_, queued := m.kickQueued[tenantID]
+	m.mu.Unlock()
+	if !pending || !queued {
+		t.Fatalf("tenant %s pending=%v queued=%v, want acquire failure to keep kick retryable", tenantID, pending, queued)
+	}
+	if len(m.kicks) != 1 {
+		t.Fatalf("kicks=%d, want requeued failed kick", len(m.kicks))
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -100,10 +100,10 @@ type Config struct {
 	// authentication. When set, the pod-to-pod push path is enabled; when nil,
 	// only the 200ms poller fallback is used (no push).
 	SSENotifyPollInterval time.Duration
-	SSENotifyRetention     time.Duration
-	PodID                  string
-	PodAddr                string
-	PodNotifySecret        []byte
+	SSENotifyRetention    time.Duration
+	PodID                 string
+	PodAddr               string
+	PodNotifySecret       []byte
 }
 
 type SlockOAuthClient interface {
@@ -319,7 +319,7 @@ func NewWithConfig(cfg Config) *Server {
 		leader:              cfg.Leader,
 		podNotifySecret:     cfg.PodNotifySecret,
 		sseNotifyRetention:  cfg.SSENotifyRetention,
-		}
+	}
 	// Default SSE notify retention.
 	if s.sseNotifyRetention <= 0 {
 		s.sseNotifyRetention = defaultSSENotifyRetention
@@ -1006,8 +1006,11 @@ func (s *Server) logSemanticWorkerStatus(cfg Config, appManagedTaskTypes, fallba
 		fields := []zap.Field{
 			zap.Int("workers", s.semanticWorker.opts.Workers),
 			zap.Duration("poll_interval", s.semanticWorker.opts.PollInterval),
+			zap.Duration("warm_tenant_poll_interval", s.semanticWorker.opts.WarmTenantPollInterval),
+			zap.Duration("effective_poll_interval", s.semanticWorker.effectivePollInterval()),
 			zap.Duration("lease_duration", s.semanticWorker.opts.LeaseDuration),
 			zap.Duration("recover_interval", s.semanticWorker.opts.RecoverInterval),
+			zap.Duration("effective_recover_interval", s.semanticWorker.effectiveRecoverInterval()),
 			zap.Bool("embedder_configured", cfg.SemanticEmbedder != nil),
 			zap.Strings("app_managed_task_types", appManagedTaskTypes),
 			zap.Strings("fallback_task_types", fallbackTaskTypes),

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -152,6 +152,28 @@ type TenantStoreEntry struct {
 	Store    *datastore.Store
 }
 
+// WarmTenantIDs snapshots tenant IDs whose backends are cached and whose DB
+// pool currently has at least one open connection. It is a best-effort signal
+// for background work that should avoid waking cold tenant databases.
+func (p *Pool) WarmTenantIDs() []string {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	out := make([]string, 0, len(p.items))
+	for _, e := range p.items {
+		if e.backend == nil || e.store == nil || e.retired {
+			continue
+		}
+		if e.store.DB().Stats().OpenConnections == 0 {
+			continue
+		}
+		out = append(out, e.tenantID)
+	}
+	p.mu.Unlock()
+	return out
+}
+
 type Pool struct {
 	mu                        sync.Mutex
 	cfg                       PoolConfig
@@ -425,6 +447,27 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 		zap.Float64("create_backend_ms", createBackendDurationMs),
 		zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0))
 	return b, p.makeRelease(e), nil
+}
+
+// AcquireCached pins a cached backend without creating one on cache miss. It is
+// intended for background maintenance that may process already-active tenants
+// but must not wake dormant tenant databases.
+func (p *Pool) AcquireCached(tenantID string) (*backend.Dat9Backend, func(), bool) {
+	if p == nil || tenantID == "" {
+		return nil, nil, false
+	}
+	p.mu.Lock()
+	e, ok := p.items[tenantID]
+	if !ok || e.retired || e.backend == nil {
+		p.mu.Unlock()
+		return nil, nil, false
+	}
+	e.refs++
+	p.order.MoveToFront(e.elem)
+	b := e.backend
+	release := p.makeRelease(e)
+	p.mu.Unlock()
+	return b, release, true
 }
 
 func (p *Pool) Invalidate(tenantID string) {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -159,18 +159,27 @@ func (p *Pool) WarmTenantIDs() []string {
 	if p == nil {
 		return nil
 	}
+	type warmCandidate struct {
+		tenantID string
+		db       *sql.DB
+	}
 	p.mu.Lock()
-	out := make([]string, 0, len(p.items))
+	candidates := make([]warmCandidate, 0, len(p.items))
 	for _, e := range p.items {
 		if e.backend == nil || e.store == nil || e.retired {
 			continue
 		}
-		if e.store.DB().Stats().OpenConnections == 0 {
-			continue
-		}
-		out = append(out, e.tenantID)
+		candidates = append(candidates, warmCandidate{tenantID: e.tenantID, db: e.store.DB()})
 	}
 	p.mu.Unlock()
+
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		if c.db.Stats().OpenConnections == 0 {
+			continue
+		}
+		out = append(out, c.tenantID)
+	}
 	return out
 }
 


### PR DESCRIPTION
## Summary
- Limit multi-tenant Semantic Worker periodic polling/observation to warm cached tenant backends with open DB connections.
- Keep explicit kick processing able to acquire the tenant backend for fresh foreground-created work.
- Derive the warm tenant poll cadence from the user DB connection lifetime and remove the extra public warm-poll env knob.
- Add cached-acquire/warm-tenant pool helpers and focused worker tests for warm vs cold tenants.

## Notes
- The related runbooks alert wording was committed separately in the runbooks repo as `e8cf0e17 Clarify semantic worker tenant alert scope`; no runbooks PR was created.

## Tests
- `go test ./pkg/server ./pkg/tenant ./pkg/mysqlutil ./cmd/drive9-server ./cmd/drive9-server-local`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background semantic processing now prioritizes warmed, cached tenant backends and surfaces warm-tenant poll timing in runtime status logs.

* **Bug Fixes**
  * Multi-tenant polling/recovery scheduling now respects a warm-tenant-aware poll cadence, improving scan and retry behavior.
  * Cold cached tenants are no longer treated as ready until warmed; expired-claim recovery for cold tenants is improved.
  * Kick wake-up handling was hardened to better track queued vs pending work and preserve pending state on acquisition failures.
  * Increased default MySQL pool lifetime and max open connections for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->