### PR TITLE
Route quota accounting through meta runtime

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -244,8 +244,7 @@ func main() {
 	logLocalStartupStep(startupCtx, startupStart, stepStart, "create_local_backend")
 
 	// Wire central quota store when DRIVE9_LOCAL_META_DSN is set.
-	// This enables server-mode quota enforcement (DRIVE9_QUOTA_SOURCE=server)
-	// in the local single-tenant entrypoint for E2E validation.
+	// The runtime quota accounting path uses the meta DB when it is present.
 	metaDSN := strings.TrimSpace(os.Getenv("DRIVE9_LOCAL_META_DSN"))
 	if metaDSN != "" {
 		stepStart = time.Now()
@@ -635,15 +634,6 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 	opts.TextExtractMaxBytes = envInt64("DRIVE9_TEXT_EXTRACT_MAX_BYTES", backend.DefaultTextExtractMaxBytes)
 	if opts.TextExtractMaxBytes <= 0 {
 		return backend.Options{}, fmt.Errorf("DRIVE9_TEXT_EXTRACT_MAX_BYTES must be a positive integer")
-	}
-
-	// Quota enforcement source: "tenant" (default) or "server" (central server DB).
-	switch qs := strings.ToLower(strings.TrimSpace(os.Getenv("DRIVE9_QUOTA_SOURCE"))); qs {
-	case "", "tenant":
-	case "server":
-		opts.QuotaSource = backend.QuotaSourceServer
-	default:
-		die(fmt.Errorf("DRIVE9_QUOTA_SOURCE must be one of tenant or server, got %q", qs))
 	}
 
 	queryBaseURL := strings.TrimSpace(os.Getenv("DRIVE9_QUERY_EMBED_API_BASE"))

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -622,6 +622,9 @@ func localEmbeddingModeLabel(mode schema.TiDBEmbeddingMode, explicit bool) strin
 
 func buildBackendOptionsFromEnv() (backend.Options, error) {
 	var opts backend.Options
+	if strings.TrimSpace(os.Getenv("DRIVE9_QUOTA_SOURCE")) != "" {
+		return backend.Options{}, fmt.Errorf("DRIVE9_QUOTA_SOURCE has been removed; remove this setting and wire central quota through the meta store")
+	}
 	opts.MaxTenantStorageBytes = envInt64("DRIVE9_MAX_TENANT_STORAGE_BYTES", 50*(1<<30))
 	if opts.MaxTenantStorageBytes <= 0 {
 		return backend.Options{}, fmt.Errorf("DRIVE9_MAX_TENANT_STORAGE_BYTES must be a positive integer")

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -370,7 +370,7 @@ environment:
   DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
   DRIVE9_QUOTA_USAGE_CACHE_TTL soft small-write central usage cache TTL, e.g. 250ms or 1s
-  DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL soft small-write tenant pending-outbox aggregate cache TTL, e.g. 250ms or 1s
+  DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL soft small-write in-process pending mutation cache TTL, e.g. 250ms or 1s
 
   S3 storage:
   Set DRIVE9_S3_BUCKET to enable AWS S3 mode.

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -696,6 +696,9 @@ func publicBaseURL(listenAddr string) string {
 
 func buildBackendOptionsFromEnv() (backend.Options, error) {
 	var opts backend.Options
+	if strings.TrimSpace(os.Getenv("DRIVE9_QUOTA_SOURCE")) != "" {
+		return backend.Options{}, fmt.Errorf("DRIVE9_QUOTA_SOURCE has been removed; central quota is now driven by meta-store wiring")
+	}
 	opts.MaxTenantStorageBytes = envInt64("DRIVE9_MAX_TENANT_STORAGE_BYTES", 50*(1<<30))
 	if opts.MaxTenantStorageBytes <= 0 {
 		return backend.Options{}, fmt.Errorf("DRIVE9_MAX_TENANT_STORAGE_BYTES must be a positive integer")

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -536,9 +536,8 @@ environment:
   DRIVE9_DEFAULT_STORAGE_QUOTA_BYTES fallback per-tenant total storage limit when no explicit quota is configured (default: %d)
   DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
-  DRIVE9_QUOTA_SOURCE tenant|server quota enforcement source (default: tenant)
   DRIVE9_QUOTA_USAGE_CACHE_TTL soft small-write central usage cache TTL, e.g. 250ms or 1s
-  DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL soft small-write tenant pending-outbox aggregate cache TTL, e.g. 250ms or 1s
+  DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL soft small-write in-process pending mutation cache TTL, e.g. 250ms or 1s
   DRIVE9_DISABLE_AUTO_EMBEDDING true|false disable TiDB database-managed auto-embedding (default: false)
                                 set to true when the TiDB Cloud cluster has no supported embedding provider
   DRIVE9_TIDB_AUTO_EMBEDDING_MODEL TiDB EMBED_TEXT model for auto-embedding generated columns
@@ -709,15 +708,6 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 	opts.TextExtractMaxBytes = envInt64("DRIVE9_TEXT_EXTRACT_MAX_BYTES", backend.DefaultTextExtractMaxBytes)
 	if opts.TextExtractMaxBytes <= 0 {
 		return backend.Options{}, fmt.Errorf("DRIVE9_TEXT_EXTRACT_MAX_BYTES must be a positive integer")
-	}
-
-	// Quota enforcement source: "tenant" (default, per-tenant DB) or "server" (central server DB).
-	switch qs := strings.ToLower(strings.TrimSpace(os.Getenv("DRIVE9_QUOTA_SOURCE"))); qs {
-	case "", "tenant":
-	case "server":
-		opts.QuotaSource = backend.QuotaSourceServer
-	default:
-		return backend.Options{}, fmt.Errorf("DRIVE9_QUOTA_SOURCE must be one of tenant or server, got %q", qs)
 	}
 
 	queryBaseURL := strings.TrimSpace(os.Getenv("DRIVE9_QUERY_EMBED_API_BASE"))

--- a/docs/quota-meta-runtime-cutover.md
+++ b/docs/quota-meta-runtime-cutover.md
@@ -1,0 +1,109 @@
+# Quota Accounting: Remove the User DB from the Runtime Hot Path
+
+## Context
+
+High-QPS small-file writes used to write a `quota_outbox` row into the tenant
+database inside every write transaction. A per-tenant `quotaOutboxWorker` then
+claimed, acked, and retried those rows against the same tenant database before
+applying quota deltas to the meta database. When the tenant database was slow or
+had bad connections, central quota convergence stalled and worker alerts became
+noisy or real.
+
+Runtime quota accounting now has a stricter goal: do not touch the tenant/user
+database for quota work. That means no outbox writes in the write transaction,
+no outbox claim/ack/retry worker, and no pending-outbox `SUM` read during
+admission. Eventual consistency is acceptable; strict per-write reservation
+through a tenant-DB `FOR UPDATE` lock is not required for small writes.
+
+## Correctness Tradeoff
+
+Tenant file metadata and central quota live in different databases. Without a
+distributed transaction, removing the tenant outbox cannot be fully equivalent
+to the old durable handoff. The old outbox avoided a crash gap by committing the
+file mutation and the quota marker in the same tenant transaction.
+
+The new runtime path uses the meta database `quota_mutation_log` as the only
+quota handoff. File create/overwrite mutations are logged after the tenant write
+transaction commits, then applied asynchronously and replayed by
+`MutationReplayWorker` if the in-process apply is missed.
+
+This leaves a known residual window:
+
+```text
+tenant DB commit succeeds -> process crashes before meta quota_mutation_log insert
+```
+
+In that case, quota may remain undercounted until reconciliation/backfill. The
+new path intentionally surfaces meta-log insert failure as an error rather than
+silently dropping it, but it cannot roll back the already-committed tenant
+write. Runtime accounting is user-DB-free; repair/backfill may still read the
+tenant database.
+
+## Runtime Flow
+
+Small create/overwrite writes:
+
+1. Perform normal tenant DB file mutation.
+2. Insert a meta `quota_mutation_log` row.
+3. Add the mutation delta to the in-process pending-delta cache.
+4. Enqueue async apply.
+5. On apply success, update `tenant_file_meta` and `tenant_quota_usage`, mark the
+   log row applied, and subtract the pending delta.
+
+Uploads:
+
+1. Reserve bytes in the meta DB with `AtomicReserveAndInsertUpload`.
+2. Mark the reservation `completing` before finalization so expiry sweep cannot
+   abort an upload that is being finalized.
+3. After tenant finalization commits, log `upload_complete` in the meta mutation
+   log.
+4. Async apply settles the reservation and transfers reserved bytes to confirmed
+   usage.
+
+Admission:
+
+Small-write quota checks read central quota config/usage and add only local
+in-process pending mutation deltas. They do not read tenant `quota_outbox`.
+Different pods do not see each other's local pending deltas, so burst admission
+is optimistic and may temporarily over-admit until replay converges.
+
+## Removed Runtime Dependencies
+
+- `DRIVE9_QUOTA_SOURCE` is retired. Central quota is active when a meta quota
+  store is wired into the backend.
+- The tenant `quota_outbox` worker is no longer started by `SetMetaQuotaStore`.
+- Runtime create/overwrite/upload paths no longer enqueue tenant `quota_outbox`
+  rows.
+- Runtime admission no longer calls `PendingQuotaOutboxDeltas` or any tenant
+  `quota_outbox` pending read.
+
+Legacy `quota_outbox` schema and datastore code remain for old rows,
+backfill/drain tooling, and historical tests. They are not part of the runtime
+quota path after this cutover.
+
+## Operational Guardrails
+
+Watch the meta pipeline instead of tenant outbox health:
+
+- `quota_mutation_log` pending backlog.
+- oldest pending mutation age.
+- `central_quota_mutation_log_insert_failed` log/metric.
+- any new tenant `quota_outbox` row after cutover, which indicates a missed
+  runtime code path.
+
+For permanent gaps caused by the residual crash window, run quota backfill to
+reconcile central counters from tenant file metadata.
+
+## Verification
+
+Useful checks for this change:
+
+- Small create and overwrite increase central usage and do not create new tenant
+  `quota_outbox` rows.
+- Meta log insert failure is returned to the caller and recorded, not fail-open.
+- Replaying the same mutation is idempotent through central `tenant_file_meta`
+  old-state reads.
+- Upload completion settles `active` or `completing` reservations and expiry
+  sweep does not abort `completing` rows.
+- A tenant DB connection issue no longer stops central quota mutation replay,
+  because replay uses only the meta DB.

--- a/docs/quota-meta-runtime-cutover.md
+++ b/docs/quota-meta-runtime-cutover.md
@@ -88,6 +88,9 @@ Watch the meta pipeline instead of tenant outbox health:
 - `quota_mutation_log` pending backlog.
 - oldest pending mutation age.
 - `central_quota_mutation_log_insert_failed` log/metric.
+- `central_quota/upload_reset_active` errors or
+  `central_quota_upload_reset_active_failed`, which indicate a retryable upload
+  complete failure could not reset the reservation back to active.
 - any new tenant `quota_outbox` row after cutover, which indicates a missed
   runtime code path.
 

--- a/e2e/server-quota/README.md
+++ b/e2e/server-quota/README.md
@@ -1,7 +1,7 @@
 # Server-Mode Quota E2E Test
 
-This directory contains an end-to-end test suite for drive9's **server-mode quota**
-(central quota enforcement via `DRIVE9_QUOTA_SOURCE=server`).
+This directory contains an end-to-end test suite for drive9's central quota
+runtime path. Central quota is enabled by wiring `DRIVE9_LOCAL_META_DSN`.
 
 ## Architecture
 
@@ -23,7 +23,6 @@ This directory contains an end-to-end test suite for drive9's **server-mode quot
             ▼
 ┌─────────────────────────────────────────┐
 │  bin/drive9-server-local                │
-│  - DRIVE9_QUOTA_SOURCE=server           │
 │  - DRIVE9_LOCAL_META_DSN set            │
 │  - MutationReplayWorker running         │
 │  - ExpirySweepWorker running            │
@@ -55,7 +54,7 @@ bash e2e/server-quota/quota-server-e2e.sh
 The script will:
 1. Start two Docker containers
 2. Build `drive9-server-local` with the `DRIVE9_LOCAL_META_DSN` patch
-3. Start the server in **server quota mode**
+3. Start the server with central quota wired through the meta DB
 4. Run 10 test cases
 5. Tear down containers (unless `KEEP_CONTAINERS=1`)
 
@@ -93,7 +92,6 @@ the full server-mode quota stack without requiring the multi-tenant
 
 | Variable | Value in test | Meaning |
 |----------|---------------|---------|
-| `DRIVE9_QUOTA_SOURCE` | `server` | Read quota state from central DB |
 | `DRIVE9_LOCAL_META_DSN` | `root:root@tcp(127.0.0.1:13306)/drive9_meta?parseTime=true` | Control-plane DB (host-published port) |
 | `DRIVE9_LOCAL_DSN` | `root@tcp(127.0.0.1:14000)/drive9_local?parseTime=true` | Tenant DB — TiDB (host-published port) |
 | `DRIVE9_MAX_TENANT_STORAGE_BYTES` | `1048576` (1 MiB) | Small limit for fast boundary testing |

--- a/e2e/server-quota/quota-server-e2e.sh
+++ b/e2e/server-quota/quota-server-e2e.sh
@@ -7,7 +7,7 @@
 #   - curl, jq
 #
 # This script starts two local DB containers (meta: MySQL, tenant: TiDB), spins up
-# drive9-server-local with DRIVE9_QUOTA_SOURCE=server, and validates the
+# drive9-server-local with DRIVE9_LOCAL_META_DSN, and validates the
 # central quota enforcement end-to-end.
 #
 # Usage:
@@ -228,7 +228,6 @@ export DRIVE9_LOCAL_META_DSN="${META_DSN}"
 export DRIVE9_LOCAL_INIT_SCHEMA="true"
 export DRIVE9_LOCAL_API_KEY="${API_KEY}"
 export DRIVE9_S3_DIR="${S3_DIR}"
-export DRIVE9_QUOTA_SOURCE="server"
 export DRIVE9_MAX_TENANT_STORAGE_BYTES="${MAX_STORAGE_BYTES}"
 export DRIVE9_MAX_UPLOAD_BYTES="${MAX_UPLOAD_BYTES}"
 export DRIVE9_MAX_MEDIA_LLM_FILES="${MAX_MEDIA_LLM_FILES}"

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -112,7 +112,7 @@ type Dat9Backend struct {
 	// durable log_id order and channel enqueue order cannot diverge under
 	// concurrent same-tenant writes.
 	mutationMu    sync.Mutex
-	mutationQueue chan func()
+	mutationQueue chan func(context.Context)
 	mutationWG    sync.WaitGroup
 	mutationStop  context.CancelFunc
 
@@ -307,8 +307,10 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 		}
 		return err
 	}
-	if err := b.recordCentralFileCreateMutation(ctx, fileID, 0, ""); err != nil {
-		return fmt.Errorf("record central quota file create: %w", err)
+	quotaCtx, cancelQuota := postCommitQuotaMutationContext()
+	defer cancelQuota()
+	if err := b.recordCentralFileCreateMutation(quotaCtx, fileID, 0, ""); err != nil {
+		return postCommitQuotaMutationError("record central quota file create", err)
 	}
 	return nil
 }
@@ -379,8 +381,10 @@ func (b *Dat9Backend) CreateSymlinkCtx(ctx context.Context, linkPath, target str
 	if err != nil {
 		return err
 	}
-	if err := b.recordCentralFileCreateMutation(ctx, fileID, int64(len(data)), symlinkContentType); err != nil {
-		return fmt.Errorf("record central quota file create: %w", err)
+	quotaCtx, cancelQuota := postCommitQuotaMutationContext()
+	defer cancelQuota()
+	if err := b.recordCentralFileCreateMutation(quotaCtx, fileID, int64(len(data)), symlinkContentType); err != nil {
+		return postCommitQuotaMutationError("record central quota file create", err)
 	}
 	return nil
 }
@@ -1020,11 +1024,13 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 	if timingEnabled {
 		centralQuotaStart = time.Now()
 	}
-	if err := b.recordCentralFileCreateMutation(ctx, fileID, int64(len(data)), contentType); err != nil {
+	quotaCtx, cancelQuota := postCommitQuotaMutationContext()
+	defer cancelQuota()
+	if err := b.recordCentralFileCreateMutation(quotaCtx, fileID, int64(len(data)), contentType); err != nil {
 		if timingEnabled {
 			centralQuotaDuration = time.Since(centralQuotaStart)
 		}
-		return 0, fmt.Errorf("record central quota file create: %w", err)
+		return 0, postCommitQuotaMutationError("record central quota file create", err)
 	}
 	if timingEnabled {
 		centralQuotaDuration = time.Since(centralQuotaStart)
@@ -1278,11 +1284,13 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 	if timingEnabled {
 		centralQuotaStart = time.Now()
 	}
-	if err := b.recordCentralFileOverwriteMutation(ctx, nf.File.FileID, nf.File.SizeBytes, nf.File.ContentType, int64(len(finalData)), contentType); err != nil {
+	quotaCtx, cancelQuota := postCommitQuotaMutationContext()
+	defer cancelQuota()
+	if err := b.recordCentralFileOverwriteMutation(quotaCtx, nf.File.FileID, nf.File.SizeBytes, nf.File.ContentType, int64(len(finalData)), contentType); err != nil {
 		if timingEnabled {
 			centralQuotaDuration = time.Since(centralQuotaStart)
 		}
-		return 0, 0, fmt.Errorf("record central quota file overwrite: %w", err)
+		return 0, 0, postCommitQuotaMutationError("record central quota file overwrite", err)
 	}
 	if timingEnabled {
 		centralQuotaDuration = time.Since(centralQuotaStart)

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -98,13 +98,13 @@ type Dat9Backend struct {
 	tenantID           string
 	storageNamespaceID string
 	metaStore          MetaQuotaStore // nil when central quota is not wired (tests, fallback)
-	quotaSource        QuotaSource    // "tenant" (default) or "server"
 	quotaConfigCache   *quotaConfigCache
 	quotaUsageCache    *quotaUsageCache
 	quotaPendingCache  *quotaPendingDeltasCache
 
-	// mutationQueue decouples central quota mutations (syncCentralFileCreate,
-	// syncCentralFileOverwrite) from the fsync critical path. Mutations are
+	// mutationQueue decouples central quota mutations
+	// (recordCentralFileCreateMutation, recordCentralFileOverwriteMutation) from
+	// the fsync critical path. Mutations are
 	// enqueued here and drained by a background worker. The mutation log
 	// provides crash recovery via the existing MutationReplayWorker.
 	//
@@ -117,8 +117,6 @@ type Dat9Backend struct {
 	mutationStop  context.CancelFunc
 
 	quotaOutboxNotify chan struct{}
-	quotaOutboxWG     sync.WaitGroup
-	quotaOutboxStop   context.CancelFunc
 	claimQuotaOutbox  quotaOutboxBatchClaimer
 
 	s3EncryptionPolicy meta.ResolvedS3EncryptionPolicy
@@ -278,7 +276,6 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 		}
 	}
 
-	var quotaOutboxEnqueued bool
 	err = b.store.InTx(ctx, func(tx *sql.Tx) error {
 		if err := b.ensureFileCountQuotaServer(ctx, tx, 1); err != nil {
 			return err
@@ -302,11 +299,6 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 		}); err != nil {
 			return err
 		}
-		created, err := b.enqueueQuotaFileCreateOutboxTx(tx, fileID, 0, "")
-		if err != nil {
-			return err
-		}
-		quotaOutboxEnqueued = created
 		return nil
 	})
 	if err != nil {
@@ -315,11 +307,8 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 		}
 		return err
 	}
-	if quotaOutboxEnqueued {
-		b.addLocalQuotaPendingDeltas(0, 1, 0)
-		b.notifyQuotaOutbox(true)
-	} else {
-		b.syncCentralFileCreate(ctx, fileID, 0, "")
+	if err := b.recordCentralFileCreateMutation(ctx, fileID, 0, ""); err != nil {
+		return fmt.Errorf("record central quota file create: %w", err)
 	}
 	return nil
 }
@@ -352,7 +341,6 @@ func (b *Dat9Backend) CreateSymlinkCtx(ctx context.Context, linkPath, target str
 	now := time.Now()
 	checksum := sha256sum(data)
 
-	var quotaOutboxEnqueued bool
 	err = b.store.InTx(ctx, func(tx *sql.Tx) error {
 		if err := b.ensureStorageQuota(ctx, tx, linkPath, int64(len(data))); err != nil {
 			return err
@@ -386,25 +374,13 @@ func (b *Dat9Backend) CreateSymlinkCtx(ctx context.Context, linkPath, target str
 		}); err != nil {
 			return err
 		}
-		created, err := b.enqueueQuotaFileCreateOutboxTx(tx, fileID, int64(len(data)), symlinkContentType)
-		if err != nil {
-			return err
-		}
-		quotaOutboxEnqueued = created
 		return nil
 	})
 	if err != nil {
 		return err
 	}
-	if quotaOutboxEnqueued {
-		mediaDelta := int64(0)
-		if isQuotaMediaContentType(symlinkContentType) {
-			mediaDelta = 1
-		}
-		b.addLocalQuotaPendingDeltas(int64(len(data)), 1, mediaDelta)
-		b.notifyQuotaOutbox(true)
-	} else {
-		b.syncCentralFileCreate(ctx, fileID, int64(len(data)), symlinkContentType)
+	if err := b.recordCentralFileCreateMutation(ctx, fileID, int64(len(data)), symlinkContentType); err != nil {
+		return fmt.Errorf("record central quota file create: %w", err)
 	}
 	return nil
 }
@@ -843,7 +819,6 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 	var insertNodeDuration time.Duration
 	var tagUpdateDuration time.Duration
 	var semanticEnqueueDuration time.Duration
-	var quotaOutboxEnqueueDuration time.Duration
 	defer func() {
 		if !timingEnabled {
 			return
@@ -866,7 +841,6 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 			zap.Float64("insert_node_ms", backendDurationMs(insertNodeDuration)),
 			zap.Float64("tag_update_ms", backendDurationMs(tagUpdateDuration)),
 			zap.Float64("semantic_enqueue_ms", backendDurationMs(semanticEnqueueDuration)),
-			zap.Float64("quota_outbox_enqueue_ms", backendDurationMs(quotaOutboxEnqueueDuration)),
 			zap.Float64("image_enqueue_ms", backendDurationMs(imageEnqueueDuration)),
 			zap.Float64("total_ms", backendDurationMs(time.Since(start))),
 		}
@@ -927,14 +901,12 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 	}
 
 	var semanticTaskEnqueued bool
-	var quotaOutboxEnqueued bool
 	txStart := time.Time{}
 	if timingEnabled {
 		txStart = time.Now()
 	}
 	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
 		semanticTaskEnqueued = false
-		quotaOutboxEnqueued = false
 
 		done := backendTimingStep(timingEnabled, &quotaStorageCheckDuration)
 		err := b.ensureCreateStorageQuota(ctx, tx, int64(len(data)))
@@ -1030,13 +1002,6 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 			imageEnqueueDuration = semanticEnqueueDuration
 		}
 
-		done = backendTimingStep(timingEnabled, &quotaOutboxEnqueueDuration)
-		created, err := b.enqueueQuotaFileCreateOutboxTx(tx, fileID, int64(len(data)), contentType)
-		done()
-		if err != nil {
-			return err
-		}
-		quotaOutboxEnqueued = created
 		return nil
 	}); err != nil {
 		if timingEnabled {
@@ -1055,15 +1020,11 @@ func (b *Dat9Backend) createAndWriteCtx(ctx context.Context, path string, data [
 	if timingEnabled {
 		centralQuotaStart = time.Now()
 	}
-	if quotaOutboxEnqueued {
-		mediaDelta := int64(0)
-		if isQuotaMediaContentType(contentType) {
-			mediaDelta = 1
+	if err := b.recordCentralFileCreateMutation(ctx, fileID, int64(len(data)), contentType); err != nil {
+		if timingEnabled {
+			centralQuotaDuration = time.Since(centralQuotaStart)
 		}
-		b.addLocalQuotaPendingDeltas(int64(len(data)), 1, mediaDelta)
-		b.notifyQuotaOutbox(true)
-	} else {
-		b.syncCentralFileCreate(ctx, fileID, int64(len(data)), contentType)
+		return 0, fmt.Errorf("record central quota file create: %w", err)
 	}
 	if timingEnabled {
 		centralQuotaDuration = time.Since(centralQuotaStart)
@@ -1215,14 +1176,12 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 	}
 
 	var semanticTaskEnqueued bool
-	var quotaOutboxEnqueued bool
 	txStart := time.Time{}
 	if timingEnabled {
 		txStart = time.Now()
 	}
 	err = b.store.InTx(ctx, func(tx *sql.Tx) error {
 		semanticTaskEnqueued = false
-		quotaOutboxEnqueued = false
 		var oldSizeBytes int64
 		var oldContentTypeForQuota string
 		currentMeta, err := b.store.GetFileStorageMetaForUpdateTx(tx, nf.File.FileID)
@@ -1234,13 +1193,7 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 		if expectedRevision > 0 && currentMeta.Revision != expectedRevision {
 			return datastore.ErrRevisionConflict
 		}
-		if b.UseServerQuota() {
-			if deltaBytes := int64(len(finalData)) - currentMeta.SizeBytes; deltaBytes > 0 {
-				if err := b.ensureStorageQuotaServer(ctx, tx, deltaBytes); err != nil {
-					return err
-				}
-			}
-		} else if err := b.ensureStorageQuota(ctx, tx, nf.Node.Path, int64(len(finalData))); err != nil {
+		if err := b.ensureStorageQuota(ctx, tx, nf.Node.Path, int64(len(finalData))); err != nil {
 			return err
 		}
 		var txErr error
@@ -1305,11 +1258,6 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 				semanticTaskEnqueued = extractCreated
 			}
 		}
-		created, err := b.enqueueQuotaFileOverwriteOutboxTx(tx, nf.File.FileID, oldSizeBytes, oldContentTypeForQuota, int64(len(finalData)), contentType)
-		if err != nil {
-			return err
-		}
-		quotaOutboxEnqueued = created
 		nf.File.StorageType = currentMeta.StorageType
 		nf.File.StorageRef = currentMeta.StorageRef
 		nf.File.SizeBytes = oldSizeBytes
@@ -1330,15 +1278,11 @@ func (b *Dat9Backend) overwriteFileCtxWithRev(ctx context.Context, nf *datastore
 	if timingEnabled {
 		centralQuotaStart = time.Now()
 	}
-	if quotaOutboxEnqueued {
-		b.addLocalQuotaPendingDeltas(
-			int64(len(finalData))-nf.File.SizeBytes,
-			0,
-			quotaMediaDelta(isQuotaMediaContentType(nf.File.ContentType), isQuotaMediaContentType(contentType)),
-		)
-		b.notifyQuotaOutbox(true)
-	} else {
-		b.syncCentralFileOverwrite(ctx, nf.File.FileID, nf.File.SizeBytes, nf.File.ContentType, int64(len(finalData)), contentType)
+	if err := b.recordCentralFileOverwriteMutation(ctx, nf.File.FileID, nf.File.SizeBytes, nf.File.ContentType, int64(len(finalData)), contentType); err != nil {
+		if timingEnabled {
+			centralQuotaDuration = time.Since(centralQuotaStart)
+		}
+		return 0, 0, fmt.Errorf("record central quota file overwrite: %w", err)
 	}
 	if timingEnabled {
 		centralQuotaDuration = time.Since(centralQuotaStart)

--- a/pkg/backend/fs_layer_content.go
+++ b/pkg/backend/fs_layer_content.go
@@ -170,8 +170,10 @@ func (b *Dat9Backend) WriteStoredObjectCtxIfRevision(ctx context.Context, path s
 		if err != nil {
 			return 0, err
 		}
-		if err := b.recordCentralFileCreateMutation(ctx, fileID, entry.SizeBytes, contentType); err != nil {
-			return 0, fmt.Errorf("record central quota file create: %w", err)
+		quotaCtx, cancelQuota := postCommitQuotaMutationContext()
+		defer cancelQuota()
+		if err := b.recordCentralFileCreateMutation(quotaCtx, fileID, entry.SizeBytes, contentType); err != nil {
+			return 0, postCommitQuotaMutationError("record central quota file create", err)
 		}
 		return 1, nil
 	}
@@ -230,8 +232,10 @@ func (b *Dat9Backend) WriteStoredObjectCtxIfRevision(ctx context.Context, path s
 	if err != nil {
 		return 0, err
 	}
-	if err := b.recordCentralFileOverwriteMutation(ctx, nf.File.FileID, oldSize, oldContentType, entry.SizeBytes, contentType); err != nil {
-		return 0, fmt.Errorf("record central quota file overwrite: %w", err)
+	quotaCtx, cancelQuota := postCommitQuotaMutationContext()
+	defer cancelQuota()
+	if err := b.recordCentralFileOverwriteMutation(quotaCtx, nf.File.FileID, oldSize, oldContentType, entry.SizeBytes, contentType); err != nil {
+		return 0, postCommitQuotaMutationError("record central quota file overwrite", err)
 	}
 	b.deleteBlobIfS3Ctx(ctx, oldStorageType, oldStorageRef, entry.StorageRef)
 	return newRev, nil

--- a/pkg/backend/fs_layer_content.go
+++ b/pkg/backend/fs_layer_content.go
@@ -129,7 +129,6 @@ func (b *Dat9Backend) WriteStoredObjectCtxIfRevision(ctx context.Context, path s
 	nf, statErr := b.store.Stat(ctx, canonical)
 	if errorsIsNotFound(statErr) {
 		fileID := b.genID()
-		var quotaOutboxEnqueued bool
 		err := b.store.InTx(ctx, func(tx *sql.Tx) error {
 			if err := b.ensureStorageQuota(ctx, tx, canonical, entry.SizeBytes); err != nil {
 				return err
@@ -166,25 +165,13 @@ func (b *Dat9Backend) WriteStoredObjectCtxIfRevision(ctx context.Context, path s
 			}); err != nil {
 				return err
 			}
-			created, err := b.enqueueQuotaFileCreateOutboxTx(tx, fileID, entry.SizeBytes, contentType)
-			if err != nil {
-				return err
-			}
-			quotaOutboxEnqueued = created
 			return nil
 		})
 		if err != nil {
 			return 0, err
 		}
-		if quotaOutboxEnqueued {
-			mediaDelta := int64(0)
-			if isQuotaMediaContentType(contentType) {
-				mediaDelta = 1
-			}
-			b.addLocalQuotaPendingDeltas(entry.SizeBytes, 1, mediaDelta)
-			b.notifyQuotaOutbox(true)
-		} else {
-			b.syncCentralFileCreate(ctx, fileID, entry.SizeBytes, contentType)
+		if err := b.recordCentralFileCreateMutation(ctx, fileID, entry.SizeBytes, contentType); err != nil {
+			return 0, fmt.Errorf("record central quota file create: %w", err)
 		}
 		return 1, nil
 	}
@@ -203,7 +190,6 @@ func (b *Dat9Backend) WriteStoredObjectCtxIfRevision(ctx context.Context, path s
 	oldSize := nf.File.SizeBytes
 	oldContentType := nf.File.ContentType
 	var newRev int64
-	var quotaOutboxEnqueued bool
 	err = b.store.InTx(ctx, func(tx *sql.Tx) error {
 		currentMeta, err := b.store.GetFileStorageMetaForUpdateTx(tx, nf.File.FileID)
 		if err != nil {
@@ -216,13 +202,7 @@ func (b *Dat9Backend) WriteStoredObjectCtxIfRevision(ctx context.Context, path s
 		if entry.BaseRevision > 0 && currentMeta.Revision != entry.BaseRevision {
 			return datastore.ErrRevisionConflict
 		}
-		if b.UseServerQuota() {
-			if deltaBytes := entry.SizeBytes - currentMeta.SizeBytes; deltaBytes > 0 {
-				if err := b.ensureStorageQuotaServer(ctx, tx, deltaBytes); err != nil {
-					return err
-				}
-			}
-		} else if err := b.ensureStorageQuota(ctx, tx, canonical, entry.SizeBytes); err != nil {
+		if err := b.ensureStorageQuota(ctx, tx, canonical, entry.SizeBytes); err != nil {
 			return err
 		}
 		var txErr error
@@ -245,25 +225,13 @@ func (b *Dat9Backend) WriteStoredObjectCtxIfRevision(ctx context.Context, path s
 		if err := b.store.UpdateFileStorageEncryptionTx(tx, nf.File.FileID, storageEncryptionMode, storageEncryptionKeyID); err != nil {
 			return err
 		}
-		created, err := b.enqueueQuotaFileOverwriteOutboxTx(tx, nf.File.FileID, oldSize, oldContentType, entry.SizeBytes, contentType)
-		if err != nil {
-			return err
-		}
-		quotaOutboxEnqueued = created
 		return nil
 	})
 	if err != nil {
 		return 0, err
 	}
-	if quotaOutboxEnqueued {
-		b.addLocalQuotaPendingDeltas(
-			entry.SizeBytes-oldSize,
-			0,
-			quotaMediaDelta(isQuotaMediaContentType(oldContentType), isQuotaMediaContentType(contentType)),
-		)
-		b.notifyQuotaOutbox(true)
-	} else {
-		b.syncCentralFileOverwrite(ctx, nf.File.FileID, oldSize, oldContentType, entry.SizeBytes, contentType)
+	if err := b.recordCentralFileOverwriteMutation(ctx, nf.File.FileID, oldSize, oldContentType, entry.SizeBytes, contentType); err != nil {
+		return 0, fmt.Errorf("record central quota file overwrite: %w", err)
 	}
 	b.deleteBlobIfS3Ctx(ctx, oldStorageType, oldStorageRef, entry.StorageRef)
 	return newRev, nil

--- a/pkg/backend/llm_usage.go
+++ b/pkg/backend/llm_usage.go
@@ -43,7 +43,14 @@ func (b *Dat9Backend) recordImageExtractUsage(taskID string, usage ImageExtractU
 			metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "usage_insert", "error", 0)
 		}
 	}
-	b.syncCentralLLMCostRecord(backgroundWithTrace(), "img_extract_text", taskID, cost, totalTokens, "tokens")
+	if err := b.syncCentralLLMCostRecord(backgroundWithTrace(), "img_extract_text", taskID, cost, totalTokens, "tokens"); err != nil {
+		logger.Warn(backgroundWithTrace(), "central_quota_llm_cost_record_failed",
+			zap.String("tenant_id", b.tenantID),
+			zap.String("task_type", "img_extract_text"),
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "llm_cost_record", "log_error", 0)
+	}
 }
 
 func (b *Dat9Backend) recordAudioExtractUsage(taskID string, usage AudioExtractUsage) {
@@ -78,7 +85,14 @@ func (b *Dat9Backend) recordAudioExtractUsage(taskID string, usage AudioExtractU
 			metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "usage_insert", "error", 0)
 		}
 	}
-	b.syncCentralLLMCostRecord(backgroundWithTrace(), "audio_extract_text", taskID, cost, rawUnits, rawUnitType)
+	if err := b.syncCentralLLMCostRecord(backgroundWithTrace(), "audio_extract_text", taskID, cost, rawUnits, rawUnitType); err != nil {
+		logger.Warn(backgroundWithTrace(), "central_quota_llm_cost_record_failed",
+			zap.String("tenant_id", b.tenantID),
+			zap.String("task_type", "audio_extract_text"),
+			zap.String("task_id", taskID),
+			zap.Error(err))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "llm_cost_record", "log_error", 0)
+	}
 }
 
 func (b *Dat9Backend) imageTokenCostMillicents(totalTokens int64) int64 {

--- a/pkg/backend/llm_usage_test.go
+++ b/pkg/backend/llm_usage_test.go
@@ -72,7 +72,13 @@ func (m *mockQuotaStore) InsertUploadReservation(_ context.Context, _ *UploadRes
 func (m *mockQuotaStore) UpdateUploadReservationStatus(_ context.Context, _, _, _ string) error {
 	return nil
 }
-func (m *mockQuotaStore) SettleActiveReservationTx(_ *sql.Tx, _, _, _ string) (bool, int64, error) {
+func (m *mockQuotaStore) UpdateUploadReservationStatusTx(_ context.Context, _ *sql.Tx, _, _, _ string) error {
+	return nil
+}
+func (m *mockQuotaStore) AbortActiveReservationTx(_ context.Context, _ *sql.Tx, _, _ string) (bool, int64, int64, error) {
+	return false, 0, 0, nil
+}
+func (m *mockQuotaStore) SettleActiveReservationTx(_ context.Context, _ *sql.Tx, _, _, _ string) (bool, int64, error) {
 	return false, 0, nil
 }
 func (m *mockQuotaStore) GetUploadReservation(_ context.Context, _, _ string) (*UploadReservationView, error) {

--- a/pkg/backend/llm_usage_test.go
+++ b/pkg/backend/llm_usage_test.go
@@ -97,7 +97,6 @@ func TestMonthlyLLMCostExceeded_ServerQuota(t *testing.T) {
 	b := &Dat9Backend{
 		metaStore:                   mock,
 		tenantID:                    "tenant-1",
-		quotaSource:                 QuotaSourceServer,
 		maxMonthlyLLMCostMillicents: 4000,
 	}
 	if !b.monthlyLLMCostExceeded() {
@@ -110,7 +109,6 @@ func TestMonthlyLLMCostExceeded_ServerQuota_NotExceeded(t *testing.T) {
 	b := &Dat9Backend{
 		metaStore:                   mock,
 		tenantID:                    "tenant-1",
-		quotaSource:                 QuotaSourceServer,
 		maxMonthlyLLMCostMillicents: 4000,
 	}
 	if b.monthlyLLMCostExceeded() {
@@ -129,7 +127,6 @@ func TestMonthlyLLMCostExceeded_ServerQuotaZeroUsesDefault(t *testing.T) {
 	b := &Dat9Backend{
 		metaStore:                   mock,
 		tenantID:                    "tenant-1",
-		quotaSource:                 QuotaSourceServer,
 		maxMonthlyLLMCostMillicents: 4000,
 	}
 	if !b.monthlyLLMCostExceeded() {
@@ -142,7 +139,6 @@ func TestMonthlyLLMCostExceeded_ServerQuota_FailOpen(t *testing.T) {
 	b := &Dat9Backend{
 		metaStore:                   mock,
 		tenantID:                    "tenant-1",
-		quotaSource:                 QuotaSourceServer,
 		maxMonthlyLLMCostMillicents: 4000,
 	}
 	if b.monthlyLLMCostExceeded() {

--- a/pkg/backend/mutation_replay.go
+++ b/pkg/backend/mutation_replay.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,11 +15,31 @@ import (
 )
 
 const (
-	replayPollInterval = 30 * time.Second
-	replayMinAge       = 5 * time.Second // only replay mutations older than 5s (avoid racing with inline apply)
-	replayBatchLimit   = 100
-	replayMaxRetries   = 5
+	defaultReplayPollInterval = time.Second
+	defaultReplayMinAge       = time.Second // only replay older mutations to avoid racing inline apply
+	replayBatchLimit          = 100
+	replayMaxRetries          = 5
 )
+
+func replayPollInterval() time.Duration {
+	return envDurationMS("DRIVE9_QUOTA_REPLAY_POLL_MS", defaultReplayPollInterval)
+}
+
+func replayMinAge() time.Duration {
+	return envDurationMS("DRIVE9_QUOTA_REPLAY_MIN_AGE_MS", defaultReplayMinAge)
+}
+
+func envDurationMS(name string, def time.Duration) time.Duration {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return def
+	}
+	ms, err := strconv.Atoi(raw)
+	if err != nil || ms < 0 {
+		return def
+	}
+	return time.Duration(ms) * time.Millisecond
+}
 
 // MutationReplayWorker reads pending mutations from the quota_mutation_log
 // and applies them idempotently. It runs as a background goroutine.
@@ -56,7 +78,7 @@ func (w *MutationReplayWorker) run(ctx context.Context) {
 	defer close(w.done)
 
 	logger.Info(ctx, "mutation_replay_worker_started")
-	ticker := time.NewTicker(replayPollInterval)
+	ticker := time.NewTicker(replayPollInterval())
 	defer ticker.Stop()
 
 	for {
@@ -78,7 +100,7 @@ func (w *MutationReplayWorker) run(ctx context.Context) {
 // fatal error occurred (e.g. database closed) and the loop should stop.
 func (w *MutationReplayWorker) replayBatch(ctx context.Context) (fatal bool) {
 	start := time.Now()
-	entries, err := w.store.ListPendingMutations(ctx, replayMinAge, replayBatchLimit)
+	entries, err := w.store.ListPendingMutations(ctx, replayMinAge(), replayBatchLimit)
 	if err != nil {
 		if strings.Contains(err.Error(), "database is closed") || strings.Contains(err.Error(), "connection refused") {
 			logger.Info(ctx, "mutation_replay_worker_db_closed")

--- a/pkg/backend/mutation_replay.go
+++ b/pkg/backend/mutation_replay.go
@@ -30,7 +30,11 @@ func replayPollInterval() time.Duration {
 }
 
 func replayMinAge() time.Duration {
-	return envDurationMS("DRIVE9_QUOTA_REPLAY_MIN_AGE_MS", defaultReplayMinAge)
+	d := envDurationMS("DRIVE9_QUOTA_REPLAY_MIN_AGE_MS", defaultReplayMinAge)
+	if d <= 0 {
+		return defaultReplayMinAge
+	}
+	return d
 }
 
 func envDurationMS(name string, def time.Duration) time.Duration {

--- a/pkg/backend/mutation_replay.go
+++ b/pkg/backend/mutation_replay.go
@@ -22,7 +22,11 @@ const (
 )
 
 func replayPollInterval() time.Duration {
-	return envDurationMS("DRIVE9_QUOTA_REPLAY_POLL_MS", defaultReplayPollInterval)
+	d := envDurationMS("DRIVE9_QUOTA_REPLAY_POLL_MS", defaultReplayPollInterval)
+	if d <= 0 {
+		return defaultReplayPollInterval
+	}
+	return d
 }
 
 func replayMinAge() time.Duration {
@@ -166,18 +170,18 @@ func (w *MutationReplayWorker) replayBatch(ctx context.Context) (fatal bool) {
 
 func (w *MutationReplayWorker) replayOne(ctx context.Context, entry MutationLogView) error {
 	return w.store.InTx(ctx, func(tx *sql.Tx) error {
-		if err := w.applyMutation(tx, entry); err != nil {
+		if err := w.applyMutation(ctx, tx, entry); err != nil {
 			return err
 		}
 		return w.store.MarkMutationAppliedTx(tx, entry.ID)
 	})
 }
 
-func (w *MutationReplayWorker) applyMutation(tx *sql.Tx, entry MutationLogView) error {
-	return applyCentralQuotaMutationTx(w.store, tx, entry.TenantID, entry.MutationType, entry.MutationData, entry.ID)
+func (w *MutationReplayWorker) applyMutation(ctx context.Context, tx *sql.Tx, entry MutationLogView) error {
+	return applyCentralQuotaMutationTx(ctx, w.store, tx, entry.TenantID, entry.MutationType, entry.MutationData, entry.ID)
 }
 
-func applyCentralQuotaMutationTx(store MetaQuotaStore, tx *sql.Tx, tenantID, mutationType string, mutationData json.RawMessage, logID int64) error {
+func applyCentralQuotaMutationTx(ctx context.Context, store MetaQuotaStore, tx *sql.Tx, tenantID, mutationType string, mutationData json.RawMessage, logID int64) error {
 	switch mutationType {
 	case "file_create":
 		var data fileCreateMutationData
@@ -230,7 +234,7 @@ func applyCentralQuotaMutationTx(store MetaQuotaStore, tx *sql.Tx, tenantID, mut
 		// caller (replayOne wraps applyMutation + MarkMutationAppliedTx in
 		// the same InTx), so this delegation is safe w.r.t. the Fix 2
 		// status='pending' guard.
-		return applyUploadCompleteTx(store, tx, tenantID, data)
+		return applyUploadCompleteTx(ctx, store, tx, tenantID, data)
 
 	case "llm_cost_record":
 		var data llmCostMutationData

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -11,8 +11,8 @@ import (
 )
 
 const (
-	defaultImageExtractMaxSize   = int64(8 << 20) // 8 MiB
-	defaultImageExtractTimeout   = 20 * time.Second
+	defaultImageExtractMaxSize = int64(8 << 20) // 8 MiB
+	defaultImageExtractTimeout = 20 * time.Second
 	// DefaultImageExtractMaxTextBytes is the default stored semantic text cap
 	// for image extraction. The image writeback path also enforces an
 	// estimated-token cap before this byte cap is applied.
@@ -35,20 +35,6 @@ const (
 	// negative MaxMonthlyMillicents in Options.LLMCostBudget. Per-tenant
 	// overrides via meta.QuotaConfig.MaxMonthlyCostMC continue to win.
 	defaultMaxMonthlyLLMCostMillicents = int64(1_000_000) // $10.00
-)
-
-// QuotaSource controls where quota checks read authoritative state from.
-// During migration from per-tenant DB to server DB, this flag selects the
-// active source.
-type QuotaSource string
-
-const (
-	// QuotaSourceTenant reads quota state from the per-tenant TiDB cluster
-	// (current/legacy behavior). This is the default.
-	QuotaSourceTenant QuotaSource = "tenant"
-	// QuotaSourceServer reads quota state from the drive9 server DB (meta).
-	// Requires that central quota tables are populated (backfill complete).
-	QuotaSourceServer QuotaSource = "server"
 )
 
 // Options configures Dat9Backend behavior.
@@ -81,9 +67,6 @@ type Options struct {
 	MaxMediaLLMFiles int64
 	// LLMCostBudget configures the monthly LLM cost budget for this tenant.
 	LLMCostBudget LLMCostBudgetOptions
-	// QuotaSource selects where quota enforcement reads authoritative state.
-	// "tenant" (default) uses per-tenant DB; "server" uses the central server DB.
-	QuotaSource QuotaSource
 	// TenantID is used for per-write S3 encryption context and audit metadata.
 	TenantID string
 	// StorageNamespaceID is the control-plane namespace for S3 object lifecycle.
@@ -191,11 +174,6 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		if err == nil {
 			b.s3EncryptionPolicy = resolved
 		}
-	}
-	if opts.QuotaSource == QuotaSourceServer {
-		b.quotaSource = QuotaSourceServer
-	} else {
-		b.quotaSource = QuotaSourceTenant
 	}
 	if opts.MaxUploadBytes > 0 {
 		b.maxUploadBytes = opts.MaxUploadBytes
@@ -310,7 +288,6 @@ func (b *Dat9Backend) Close() {
 		b.audioExtractEnabled = false
 	}
 	b.stopMutationWorker()
-	b.stopQuotaOutboxWorker()
 	if b.quotaConfigCache != nil {
 		b.quotaConfigCache.stop()
 		b.quotaConfigCache = nil

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -347,7 +347,13 @@ func (b *Dat9Backend) pendingCentralMutationDeltas(ctx context.Context) (storage
 
 func (b *Dat9Backend) addPendingCentralMutationDeltas(storageDelta, fileDelta, mediaDelta int64) {
 	if b.quotaPendingCache != nil {
-		b.quotaPendingCache.add(storageDelta, fileDelta, mediaDelta)
+		b.quotaPendingCache.addPending(storageDelta, fileDelta, mediaDelta)
+	}
+}
+
+func (b *Dat9Backend) clearPendingCentralMutationDeltas(storageDelta, fileDelta, mediaDelta int64) {
+	if b.quotaPendingCache != nil {
+		b.quotaPendingCache.clearPending(storageDelta, fileDelta, mediaDelta)
 	}
 }
 

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -33,63 +33,53 @@ type storageQuotaCheckResult struct {
 	projected     int64
 }
 
-// UseServerQuota reports whether this backend reads authoritative quota state
-// from the central server DB rather than the per-tenant DB.
+// UseServerQuota reports whether this backend has central quota wired. Runtime
+// quota accounting now uses the meta DB only; the legacy tenant-DB quota path is
+// retained for old tests/tools but is no longer selected by a source knob.
 func (b *Dat9Backend) UseServerQuota() bool {
-	return b.quotaSource == QuotaSourceServer && b.metaStore != nil
+	return b.metaStore != nil
 }
 
-// --- Feature-flag dispatched quota checks ---
-
-// ensureStorageQuota dispatches the storage quota check based on quotaSource.
-// For uploads: when server quota is active, the server-first saga (reserveUploadOnServer)
-// already claimed the reservation, so the tenant-DB check is skipped.
-// For small writes: delegates to ensureStorageQuotaServer or ensureTenantStorageQuotaTx.
 func (b *Dat9Backend) ensureStorageQuota(ctx context.Context, tx *sql.Tx, path string, newSize int64) error {
-	if b.UseServerQuota() {
-		// Server quota tracks total storage_bytes. For overwrites we need the
-		// delta (newSize - currentSize) not the full newSize, otherwise the
-		// check double-charges the existing file's bytes.
-		currentSize, err := b.store.ConfirmedFileSizeByPathTx(tx, path)
-		if err != nil {
-			return fmt.Errorf("load current file size: %w", err)
-		}
-		deltaBytes := newSize - currentSize
-		if deltaBytes <= 0 {
-			return nil // shrinking or same size — no additional quota needed
-		}
-		return b.ensureStorageQuotaServer(ctx, tx, deltaBytes)
+	if !b.UseServerQuota() {
+		return b.ensureTenantStorageQuotaTx(tx, path, newSize)
 	}
-	return b.ensureTenantStorageQuotaTx(tx, path, newSize)
+	// Central quota tracks total storage_bytes. For overwrites we need the
+	// delta (newSize - currentSize) not the full newSize, otherwise the
+	// check double-charges the existing file's bytes.
+	currentSize, err := b.store.ConfirmedFileSizeByPathTx(tx, path)
+	if err != nil {
+		return fmt.Errorf("load current file size: %w", err)
+	}
+	deltaBytes := newSize - currentSize
+	if deltaBytes <= 0 {
+		return nil // shrinking or same size — no additional quota needed
+	}
+	return b.ensureStorageQuotaServer(ctx, tx, deltaBytes)
 }
 
 // ensureCreateStorageQuota is the create-only variant of ensureStorageQuota.
 // The caller has not attached a dentry yet, so the current path size is known
 // to be zero; path conflicts later in the transaction roll back the write.
 func (b *Dat9Backend) ensureCreateStorageQuota(ctx context.Context, tx *sql.Tx, newSize int64) error {
-	if b.UseServerQuota() {
-		return b.ensureStorageQuotaServer(ctx, tx, newSize)
+	if !b.UseServerQuota() {
+		return b.ensureTenantCreateStorageQuotaTx(tx, newSize)
 	}
-	return b.ensureTenantCreateStorageQuotaTx(tx, newSize)
+	return b.ensureStorageQuotaServer(ctx, tx, newSize)
 }
 
-// mediaLLMQuotaExceededCheckTx dispatches the media LLM quota check
-// (transactional variant). currentMediaDelta is only applied to server quota,
-// where the current write may not be visible in central usage or pending outbox
-// deltas yet.
 func (b *Dat9Backend) mediaLLMQuotaExceededCheckTx(ctx context.Context, tx *sql.Tx, currentMediaDelta int64) bool {
-	if b.UseServerQuota() {
-		return b.mediaLLMQuotaExceededServerTx(ctx, tx, currentMediaDelta)
+	if !b.UseServerQuota() {
+		return b.mediaLLMQuotaExceededTx(tx)
 	}
-	return b.mediaLLMQuotaExceededTx(tx)
+	return b.mediaLLMQuotaExceededServerTx(ctx, tx, currentMediaDelta)
 }
 
-// monthlyLLMCostExceededCheck dispatches the monthly LLM cost check based on quotaSource.
 func (b *Dat9Backend) monthlyLLMCostExceededCheck(ctx context.Context) bool {
-	if b.UseServerQuota() {
-		return b.monthlyLLMCostExceededServer(ctx)
+	if !b.UseServerQuota() {
+		return b.monthlyLLMCostExceeded()
 	}
-	return b.monthlyLLMCostExceeded()
+	return b.monthlyLLMCostExceededServer(ctx)
 }
 
 // monthlyLLMCostExceededServer checks the server DB monthly cost counter
@@ -147,21 +137,16 @@ func (b *Dat9Backend) ensureFileSizeQuota(ctx context.Context, size int64) error
 	return nil
 }
 
-// --- Server-side storage quota (Rev 4 migration) ---
-
 // ensureStorageQuotaServer performs a soft optimistic storage quota check
 // against the server DB. Used for small writes (create, overwrite, patch) where
 // a server-reserve-first protocol or tenant-wide admission lock would add
 // latency to the single-tenant write hot path.
 //
-// The check includes central confirmed/reserved usage plus tenant-local
-// quota_outbox pending deltas, but intentionally does not lock
-// quota_admission_locks. In multi-server deployments, concurrent small writes
-// may briefly over-admit before their outbox rows become visible to each other.
-// Successful writes still durably enqueue quota mutations in the tenant
-// transaction, and the outbox worker/backfill path restores counter
-// convergence. Multipart uploads keep the stricter reserve-first path in
-// upload_reservation.go.
+// The check includes central confirmed/reserved usage plus this process's
+// in-memory pending central mutations. It intentionally does not read the tenant
+// DB or lock quota_admission_locks; multi-pod small writes may briefly
+// over-admit until meta mutation replay converges. Multipart uploads use the
+// meta-DB reserve-first path in upload_reservation.go.
 func (b *Dat9Backend) ensureStorageQuotaServer(ctx context.Context, tx *sql.Tx, deltaBytes int64) error {
 	result, ok := b.checkStorageQuotaServerTx(ctx, tx, deltaBytes)
 	if !ok {
@@ -177,10 +162,10 @@ func (b *Dat9Backend) ensureStorageQuotaServer(ctx context.Context, tx *sql.Tx, 
 
 // ensureFileCountQuotaServer is a soft optimistic file-count check for small
 // create-like writes. Like storage soft admission, concurrent servers may
-// briefly over-admit within the quota usage/pending-delta cache TTL; strict
-// upload reservations keep using live counters under the admission lock.
+// briefly over-admit within the quota usage/pending-delta cache TTL. Upload
+// reservations use live meta counters without touching the tenant DB.
 func (b *Dat9Backend) ensureFileCountQuotaServer(ctx context.Context, tx *sql.Tx, currentFileDelta int64) error {
-	if !b.UseServerQuota() || currentFileDelta <= 0 {
+	if currentFileDelta <= 0 || !b.UseServerQuota() {
 		return nil
 	}
 	cfg := b.cachedQuotaConfig(ctx)
@@ -197,10 +182,7 @@ func (b *Dat9Backend) ensureFileCountQuotaServer(ctx context.Context, tx *sql.Tx
 		return nil
 	}
 	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
-	_, pendingFileDelta, _, pendingOK := b.cachedPendingQuotaOutboxDeltasTx(ctx, tx)
-	if !pendingOK {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check_pending_delta", "fail_open", 0)
-	}
+	_, pendingFileDelta, _ := b.pendingCentralMutationDeltas(ctx)
 	projected := usage.FileCount + pendingFileDelta + currentFileDelta
 	if projected > cfg.MaxFileCount {
 		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check", "exceeded", 0)
@@ -231,10 +213,7 @@ func (b *Dat9Backend) checkStorageQuotaServerTx(ctx context.Context, tx *sql.Tx,
 		return result, false // fail-open: usage unavailable
 	}
 	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
-	pendingStorageDelta, _, _, pendingOK := b.cachedPendingQuotaOutboxDeltasTx(ctx, tx)
-	if !pendingOK {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "storage_check_pending_delta", "fail_open", 0)
-	}
+	pendingStorageDelta, _, _ := b.pendingCentralMutationDeltas(ctx)
 	result.checked = true
 	result.limitBytes = cfg.MaxStorageBytes
 	result.storageBytes = usage.StorageBytes
@@ -337,9 +316,6 @@ func quotaMediaDelta(oldIsMedia, newIsMedia bool) int64 {
 // quota inside a transactional context. Like storage quota for small writes,
 // this is a soft check and does not take the tenant-wide quota admission lock.
 func (b *Dat9Backend) mediaLLMQuotaExceededServerTx(ctx context.Context, tx *sql.Tx, currentMediaDelta int64) bool {
-	if b.metaStore == nil {
-		return b.mediaLLMQuotaExceededTx(tx) // fallback to tenant DB
-	}
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
 		metrics.RecordTenantOperation(b.tenantID, "server_quota", "media_check", "fail_open", 0)
@@ -354,44 +330,22 @@ func (b *Dat9Backend) mediaLLMQuotaExceededServerTx(ctx context.Context, tx *sql
 		return false
 	}
 	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
-	_, _, pendingMediaDelta, pendingOK := b.cachedPendingQuotaOutboxDeltasTx(ctx, tx)
-	if !pendingOK {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "media_check_pending_delta", "fail_open", 0)
-	}
+	_, _, pendingMediaDelta := b.pendingCentralMutationDeltas(ctx)
 	return usage.MediaFileCount+pendingMediaDelta+currentMediaDelta > cfg.MaxMediaLLMFiles
 }
 
-// cachedPendingQuotaOutboxDeltasTx returns tenant-local pending quota deltas
-// for soft small-write checks. The short TTL cache avoids a SUM over
-// quota_outbox on every tiny write; strict upload reservations must call
-// livePendingQuotaOutboxDeltasTx under the admission lock instead.
-func (b *Dat9Backend) cachedPendingQuotaOutboxDeltasTx(ctx context.Context, tx *sql.Tx) (storageDelta, fileDelta, mediaDelta int64, ok bool) {
-	if b.store == nil || tx == nil {
-		return 0, 0, 0, true
+func (b *Dat9Backend) pendingCentralMutationDeltas(ctx context.Context) (storageDelta, fileDelta, mediaDelta int64) {
+	if b.quotaPendingCache == nil {
+		return 0, 0, 0
 	}
-	if b.quotaPendingCache != nil {
-		deltas, ok := b.quotaPendingCache.get(ctx)
-		if ok {
-			return deltas.storageDelta, deltas.fileDelta, deltas.mediaDelta, true
-		}
+	deltas, ok := b.quotaPendingCache.get(ctx)
+	if !ok {
+		return 0, 0, 0
 	}
-	return b.livePendingQuotaOutboxDeltasTx(ctx, tx)
+	return deltas.storageDelta, deltas.fileDelta, deltas.mediaDelta
 }
 
-func (b *Dat9Backend) livePendingQuotaOutboxDeltasTx(ctx context.Context, tx *sql.Tx) (storageDelta, fileDelta, mediaDelta int64, ok bool) {
-	if b.store == nil || tx == nil {
-		return 0, 0, 0, true
-	}
-	storageDelta, fileDelta, mediaDelta, err := b.store.PendingQuotaOutboxDeltasTx(tx)
-	if err != nil {
-		logger.Warn(ctx, "server_quota_pending_outbox_delta_fail_open",
-			zap.String("tenant_id", b.tenantID), zap.Error(err))
-		return 0, 0, 0, false
-	}
-	return storageDelta, fileDelta, mediaDelta, true
-}
-
-func (b *Dat9Backend) addLocalQuotaPendingDeltas(storageDelta, fileDelta, mediaDelta int64) {
+func (b *Dat9Backend) addPendingCentralMutationDeltas(storageDelta, fileDelta, mediaDelta int64) {
 	if b.quotaPendingCache != nil {
 		b.quotaPendingCache.add(storageDelta, fileDelta, mediaDelta)
 	}

--- a/pkg/backend/quota_async.go
+++ b/pkg/backend/quota_async.go
@@ -10,13 +10,12 @@ const (
 	// worker drains the channel to preserve per-tenant FIFO ordering
 	// (UpsertFileMetaTx is not commutative across create/overwrite).
 	//
-	// DEPRECATED: The in-process mutation queue provides per-tenant FIFO ordering
-	// only within a single backend instance. In multi-pod deployments, cross-pod
-	// ordering is not guaranteed (see logAndEnqueueMutation comment). The newer
-	// quota_outbox_worker.go uses FOR UPDATE SKIP LOCKED + lease for multi-pod
-	// safe claim-based processing. The mutation replay worker (leader-gated since
-	// PR #601) provides a convergence backstop for the durable mutation log.
-	// This queue remains as the primary in-process apply path for same-pod writes.
+	// The in-process mutation queue provides per-tenant FIFO ordering only
+	// within a single backend instance. In multi-pod deployments, cross-pod
+	// ordering is not guaranteed (see logAndEnqueueMutation comment). The
+	// durable quota_mutation_log plus MutationReplayWorker provides the
+	// convergence backstop. Legacy tenant quota_outbox code remains only for
+	// old rows and tests, not for the runtime write path.
 	mutationQueueSize = 256
 )
 

--- a/pkg/backend/quota_async.go
+++ b/pkg/backend/quota_async.go
@@ -65,10 +65,10 @@ func (b *Dat9Backend) drainMutations(ctx context.Context) {
 // If the queue is not wired (tests), the function runs inline.
 // The channel send blocks if the buffer is full, preserving FIFO ordering;
 // the 256-slot buffer makes blocking extremely unlikely in practice.
-func (b *Dat9Backend) enqueueMutation(fn func(context.Context)) {
+func (b *Dat9Backend) enqueueMutation(ctx context.Context, fn func(context.Context)) {
 	if b.mutationQueue == nil {
 		// No async queue — run inline (test/fallback path).
-		fn(context.Background())
+		fn(ctx)
 		return
 	}
 	b.mutationQueue <- fn

--- a/pkg/backend/quota_async.go
+++ b/pkg/backend/quota_async.go
@@ -32,7 +32,7 @@ func (b *Dat9Backend) startMutationWorker() {
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	b.mutationStop = cancel
-	b.mutationQueue = make(chan func(), mutationQueueSize)
+	b.mutationQueue = make(chan func(context.Context), mutationQueueSize)
 	b.mutationWG.Add(1)
 	go b.drainMutations(ctx)
 }
@@ -46,13 +46,13 @@ func (b *Dat9Backend) drainMutations(ctx context.Context) {
 			for {
 				select {
 				case fn := <-b.mutationQueue:
-					fn()
+					fn(ctx)
 				default:
 					return
 				}
 			}
 		case fn := <-b.mutationQueue:
-			fn()
+			fn(ctx)
 		}
 	}
 }
@@ -65,10 +65,10 @@ func (b *Dat9Backend) drainMutations(ctx context.Context) {
 // If the queue is not wired (tests), the function runs inline.
 // The channel send blocks if the buffer is full, preserving FIFO ordering;
 // the 256-slot buffer makes blocking extremely unlikely in practice.
-func (b *Dat9Backend) enqueueMutation(fn func()) {
+func (b *Dat9Backend) enqueueMutation(fn func(context.Context)) {
 	if b.mutationQueue == nil {
 		// No async queue — run inline (test/fallback path).
-		fn()
+		fn(context.Background())
 		return
 	}
 	b.mutationQueue <- fn

--- a/pkg/backend/quota_async_test.go
+++ b/pkg/backend/quota_async_test.go
@@ -17,7 +17,7 @@ func TestEnqueueMutation_Async(t *testing.T) {
 
 	var executed atomic.Int64
 	for i := 0; i < 10; i++ {
-		b.enqueueMutation(func(context.Context) {
+		b.enqueueMutation(context.Background(), func(context.Context) {
 			executed.Add(1)
 		})
 	}
@@ -31,7 +31,7 @@ func TestEnqueueMutation_InlineFallback(t *testing.T) {
 	// No mutation worker started — should run inline.
 	b := &Dat9Backend{}
 	var executed atomic.Int64
-	b.enqueueMutation(func(context.Context) {
+	b.enqueueMutation(context.Background(), func(context.Context) {
 		executed.Add(1)
 	})
 	require.Equal(t, int64(1), executed.Load())
@@ -48,7 +48,7 @@ func TestEnqueueMutation_FIFO_SingleWorker(t *testing.T) {
 	const n = 20
 	for i := 0; i < n; i++ {
 		i := i
-		b.enqueueMutation(func(context.Context) {
+		b.enqueueMutation(context.Background(), func(context.Context) {
 			order = append(order, i)
 			if len(order) == n {
 				close(done)
@@ -98,7 +98,7 @@ func TestMutationMu_ConcurrentOrdering(t *testing.T) {
 			// This models InsertMutationLog returning sequential IDs.
 			logID := nextID
 			nextID++
-			b.enqueueMutation(func(context.Context) {
+			b.enqueueMutation(context.Background(), func(context.Context) {
 				resultMu.Lock()
 				applied = append(applied, logID)
 				if len(applied) == n {
@@ -135,7 +135,7 @@ func TestStopMutationWorker_DrainsPending(t *testing.T) {
 
 	var executed atomic.Int64
 	for i := 0; i < 50; i++ {
-		b.enqueueMutation(func(context.Context) {
+		b.enqueueMutation(context.Background(), func(context.Context) {
 			executed.Add(1)
 		})
 	}

--- a/pkg/backend/quota_async_test.go
+++ b/pkg/backend/quota_async_test.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -16,7 +17,7 @@ func TestEnqueueMutation_Async(t *testing.T) {
 
 	var executed atomic.Int64
 	for i := 0; i < 10; i++ {
-		b.enqueueMutation(func() {
+		b.enqueueMutation(func(context.Context) {
 			executed.Add(1)
 		})
 	}
@@ -30,7 +31,7 @@ func TestEnqueueMutation_InlineFallback(t *testing.T) {
 	// No mutation worker started — should run inline.
 	b := &Dat9Backend{}
 	var executed atomic.Int64
-	b.enqueueMutation(func() {
+	b.enqueueMutation(func(context.Context) {
 		executed.Add(1)
 	})
 	require.Equal(t, int64(1), executed.Load())
@@ -47,7 +48,7 @@ func TestEnqueueMutation_FIFO_SingleWorker(t *testing.T) {
 	const n = 20
 	for i := 0; i < n; i++ {
 		i := i
-		b.enqueueMutation(func() {
+		b.enqueueMutation(func(context.Context) {
 			order = append(order, i)
 			if len(order) == n {
 				close(done)
@@ -97,7 +98,7 @@ func TestMutationMu_ConcurrentOrdering(t *testing.T) {
 			// This models InsertMutationLog returning sequential IDs.
 			logID := nextID
 			nextID++
-			b.enqueueMutation(func() {
+			b.enqueueMutation(func(context.Context) {
 				resultMu.Lock()
 				applied = append(applied, logID)
 				if len(applied) == n {
@@ -134,7 +135,7 @@ func TestStopMutationWorker_DrainsPending(t *testing.T) {
 
 	var executed atomic.Int64
 	for i := 0; i < 50; i++ {
-		b.enqueueMutation(func() {
+		b.enqueueMutation(func(context.Context) {
 			executed.Add(1)
 		})
 	}

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -301,21 +301,28 @@ type quotaPendingDeltasSnapshot struct {
 	expiresAt time.Time
 }
 
+type quotaPendingDeltaEntry struct {
+	deltas    quotaPendingDeltas
+	expiresAt time.Time
+}
+
 type quotaPendingDeltasLoader func(context.Context) (storageDelta, fileDelta, mediaDelta int64, err error)
 
 // quotaPendingDeltasCache tracks this process's central quota mutations that
 // have been logged but not yet applied. It deliberately has no tenant-DB
 // fallback: runtime quota admission must not SUM quota_outbox from the user DB.
 type quotaPendingDeltasCache struct {
-	tenantID string
-	load     quotaPendingDeltasLoader
-	ttl      time.Duration
+	tenantID   string
+	load       quotaPendingDeltasLoader
+	ttl        time.Duration
+	pendingTTL time.Duration
 
 	mu                  sync.RWMutex
 	snapshot            *quotaPendingDeltasSnapshot
 	generation          uint64
 	localDeltas         quotaPendingDeltas
 	localPositiveDeltas quotaPendingDeltas
+	localEntries        []quotaPendingDeltaEntry
 	loadMu              sync.Mutex
 }
 
@@ -323,7 +330,15 @@ func newQuotaPendingDeltasCache(tenantID string, load quotaPendingDeltasLoader, 
 	if ttl <= 0 {
 		ttl = quotaPendingDeltasCacheTTL
 	}
-	return &quotaPendingDeltasCache{tenantID: tenantID, load: load, ttl: ttl}
+	return &quotaPendingDeltasCache{tenantID: tenantID, load: load, ttl: ttl, pendingTTL: localPendingMutationTTL()}
+}
+
+func localPendingMutationTTL() time.Duration {
+	ttl := replayMinAge() + replayPollInterval() + quotaPendingDeltasCacheTTL
+	if ttl <= 0 {
+		return defaultReplayMinAge + defaultReplayPollInterval + defaultQuotaPendingDeltasCacheTTL
+	}
+	return ttl
 }
 
 func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, bool) {
@@ -331,11 +346,15 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 		return quotaPendingDeltas{}, false
 	}
 	if c.load == nil {
-		c.mu.RLock()
-		defer c.mu.RUnlock()
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.expireLocalDeltasLocked(time.Now())
 		return c.localDeltas, true
 	}
 	now := time.Now()
+	c.mu.Lock()
+	c.expireLocalDeltasLocked(now)
+	c.mu.Unlock()
 	if deltas, ok := c.cached(now); ok {
 		return deltas, true
 	}
@@ -397,32 +416,106 @@ func (c *quotaPendingDeltasCache) cached(now time.Time) (quotaPendingDeltas, boo
 	return quotaPendingDeltas{}, false
 }
 
-func (c *quotaPendingDeltasCache) add(storageDelta, fileDelta, mediaDelta int64) {
+func (c *quotaPendingDeltasCache) addPending(storageDelta, fileDelta, mediaDelta int64) {
 	if c == nil {
 		return
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.generation++
-	c.localDeltas.add(quotaPendingDeltas{
+	deltas := quotaPendingDeltas{
 		storageDelta: storageDelta,
 		fileDelta:    fileDelta,
 		mediaDelta:   mediaDelta,
-	})
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	c.expireLocalDeltasLocked(now)
+	c.generation++
+	c.localDeltas.add(deltas)
 	c.localPositiveDeltas.add(quotaPendingDeltas{
 		storageDelta: maxInt64(storageDelta, 0),
 		fileDelta:    maxInt64(fileDelta, 0),
 		mediaDelta:   maxInt64(mediaDelta, 0),
 	})
+	if !deltas.zero() {
+		c.localEntries = append(c.localEntries, quotaPendingDeltaEntry{
+			deltas:    deltas,
+			expiresAt: now.Add(c.pendingTTL),
+		})
+	}
 	// If the snapshot is missing or expired, leave it cold. The no-loader
 	// runtime path reads localDeltas directly; the legacy loader path refreshes
 	// snapshots on demand.
-	if c.snapshot == nil || time.Now().After(c.snapshot.expiresAt) {
+	if c.snapshot == nil || now.After(c.snapshot.expiresAt) {
 		return
 	}
 	c.snapshot.deltas.storageDelta += storageDelta
 	c.snapshot.deltas.fileDelta += fileDelta
 	c.snapshot.deltas.mediaDelta += mediaDelta
+}
+
+func (c *quotaPendingDeltasCache) clearPending(storageDelta, fileDelta, mediaDelta int64) {
+	if c == nil {
+		return
+	}
+	deltas := quotaPendingDeltas{
+		storageDelta: storageDelta,
+		fileDelta:    fileDelta,
+		mediaDelta:   mediaDelta,
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	now := time.Now()
+	c.expireLocalDeltasLocked(now)
+	c.generation++
+	if !c.removeLocalEntryLocked(deltas) {
+		return
+	}
+	c.localDeltas.add(quotaPendingDeltas{
+		storageDelta: -storageDelta,
+		fileDelta:    -fileDelta,
+		mediaDelta:   -mediaDelta,
+	})
+	if c.snapshot == nil || now.After(c.snapshot.expiresAt) {
+		return
+	}
+	c.snapshot.deltas.storageDelta -= storageDelta
+	c.snapshot.deltas.fileDelta -= fileDelta
+	c.snapshot.deltas.mediaDelta -= mediaDelta
+}
+
+func (c *quotaPendingDeltasCache) expireLocalDeltasLocked(now time.Time) {
+	if len(c.localEntries) == 0 {
+		return
+	}
+	kept := c.localEntries[:0]
+	for _, entry := range c.localEntries {
+		if now.Before(entry.expiresAt) {
+			kept = append(kept, entry)
+			continue
+		}
+		c.localDeltas.add(quotaPendingDeltas{
+			storageDelta: -entry.deltas.storageDelta,
+			fileDelta:    -entry.deltas.fileDelta,
+			mediaDelta:   -entry.deltas.mediaDelta,
+		})
+		if c.snapshot != nil && now.Before(c.snapshot.expiresAt) {
+			c.snapshot.deltas.storageDelta -= entry.deltas.storageDelta
+			c.snapshot.deltas.fileDelta -= entry.deltas.fileDelta
+			c.snapshot.deltas.mediaDelta -= entry.deltas.mediaDelta
+		}
+	}
+	c.localEntries = kept
+}
+
+func (c *quotaPendingDeltasCache) removeLocalEntryLocked(deltas quotaPendingDeltas) bool {
+	for i, entry := range c.localEntries {
+		if entry.deltas == deltas {
+			copy(c.localEntries[i:], c.localEntries[i+1:])
+			c.localEntries = c.localEntries[:len(c.localEntries)-1]
+			return true
+		}
+	}
+	return false
 }
 
 func (d *quotaPendingDeltas) add(other quotaPendingDeltas) {
@@ -437,6 +530,10 @@ func (d quotaPendingDeltas) sub(other quotaPendingDeltas) quotaPendingDeltas {
 		fileDelta:    d.fileDelta - other.fileDelta,
 		mediaDelta:   d.mediaDelta - other.mediaDelta,
 	}
+}
+
+func (d quotaPendingDeltas) zero() bool {
+	return d.storageDelta == 0 && d.fileDelta == 0 && d.mediaDelta == 0
 }
 
 func maxInt64(a, b int64) int64 {

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -303,9 +303,9 @@ type quotaPendingDeltasSnapshot struct {
 
 type quotaPendingDeltasLoader func(context.Context) (storageDelta, fileDelta, mediaDelta int64, err error)
 
-// quotaPendingDeltasCache avoids SUM(quota_outbox) on every small write. It is
-// only used by soft admission checks; strict upload reservation still reads the
-// tenant DB directly.
+// quotaPendingDeltasCache tracks this process's central quota mutations that
+// have been logged but not yet applied. It deliberately has no tenant-DB
+// fallback: runtime quota admission must not SUM quota_outbox from the user DB.
 type quotaPendingDeltasCache struct {
 	tenantID string
 	load     quotaPendingDeltasLoader
@@ -314,6 +314,7 @@ type quotaPendingDeltasCache struct {
 	mu                  sync.RWMutex
 	snapshot            *quotaPendingDeltasSnapshot
 	generation          uint64
+	localDeltas         quotaPendingDeltas
 	localPositiveDeltas quotaPendingDeltas
 	loadMu              sync.Mutex
 }
@@ -326,8 +327,13 @@ func newQuotaPendingDeltasCache(tenantID string, load quotaPendingDeltasLoader, 
 }
 
 func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, bool) {
-	if c == nil || c.load == nil {
+	if c == nil {
 		return quotaPendingDeltas{}, false
+	}
+	if c.load == nil {
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+		return c.localDeltas, true
 	}
 	now := time.Now()
 	if deltas, ok := c.cached(now); ok {
@@ -367,11 +373,9 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 			expiresAt: expiresAt,
 		}
 		c.mu.Unlock()
-		// A local enqueue or ack raced this DB load. The SELECT may or may not
-		// have observed those rows. Merge only positive local deltas from the
-		// race window: that may double-count this process's newest writes for
-		// one short TTL, but it avoids undercounting quota and keeps small-write
-		// admission off the expensive in-transaction SUM(quota_outbox) path.
+		// A local mutation raced this DB load. This legacy loader path is kept
+		// only for tests; runtime central quota uses in-memory deltas with no
+		// tenant DB read.
 		metrics.RecordTenantOperation(c.tenantID, "server_quota", "pending_delta_cache", "raced_local_delta", time.Since(start))
 		return deltas, true
 	}
@@ -400,16 +404,19 @@ func (c *quotaPendingDeltasCache) add(storageDelta, fileDelta, mediaDelta int64)
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.generation++
+	c.localDeltas.add(quotaPendingDeltas{
+		storageDelta: storageDelta,
+		fileDelta:    fileDelta,
+		mediaDelta:   mediaDelta,
+	})
 	c.localPositiveDeltas.add(quotaPendingDeltas{
 		storageDelta: maxInt64(storageDelta, 0),
 		fileDelta:    maxInt64(fileDelta, 0),
 		mediaDelta:   maxInt64(mediaDelta, 0),
 	})
-	// If the snapshot is missing or expired, leave it cold. A concurrent loader
-	// publishes a conservative snapshot by merging positive local deltas from
-	// the race window; otherwise the next soft admission check reloads from
-	// quota_outbox and sees this backend's queued row along with rows from
-	// other servers.
+	// If the snapshot is missing or expired, leave it cold. The no-loader
+	// runtime path reads localDeltas directly; the legacy loader path refreshes
+	// snapshots on demand.
 	if c.snapshot == nil || time.Now().After(c.snapshot.expiresAt) {
 		return
 	}

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -433,11 +433,7 @@ func (c *quotaPendingDeltasCache) addPending(storageDelta, fileDelta, mediaDelta
 	c.expireLocalDeltasLocked(now)
 	c.generation++
 	c.localDeltas.add(deltas)
-	c.localPositiveDeltas.add(quotaPendingDeltas{
-		storageDelta: maxInt64(storageDelta, 0),
-		fileDelta:    maxInt64(fileDelta, 0),
-		mediaDelta:   maxInt64(mediaDelta, 0),
-	})
+	c.localPositiveDeltas.add(deltas.positivePart())
 	if !deltas.zero() {
 		c.localEntries = append(c.localEntries, quotaPendingDeltaEntry{
 			deltas:    deltas,
@@ -477,6 +473,7 @@ func (c *quotaPendingDeltasCache) clearPending(storageDelta, fileDelta, mediaDel
 		fileDelta:    -fileDelta,
 		mediaDelta:   -mediaDelta,
 	})
+	c.localPositiveDeltas.add(deltas.positivePart().negate())
 	if c.snapshot == nil || now.After(c.snapshot.expiresAt) {
 		return
 	}
@@ -500,6 +497,7 @@ func (c *quotaPendingDeltasCache) expireLocalDeltasLocked(now time.Time) {
 			fileDelta:    -entry.deltas.fileDelta,
 			mediaDelta:   -entry.deltas.mediaDelta,
 		})
+		c.localPositiveDeltas.add(entry.deltas.positivePart().negate())
 		if c.snapshot != nil && now.Before(c.snapshot.expiresAt) {
 			c.snapshot.deltas.storageDelta -= entry.deltas.storageDelta
 			c.snapshot.deltas.fileDelta -= entry.deltas.fileDelta
@@ -538,6 +536,22 @@ func (d quotaPendingDeltas) sub(other quotaPendingDeltas) quotaPendingDeltas {
 
 func (d quotaPendingDeltas) zero() bool {
 	return d.storageDelta == 0 && d.fileDelta == 0 && d.mediaDelta == 0
+}
+
+func (d quotaPendingDeltas) positivePart() quotaPendingDeltas {
+	return quotaPendingDeltas{
+		storageDelta: maxInt64(d.storageDelta, 0),
+		fileDelta:    maxInt64(d.fileDelta, 0),
+		mediaDelta:   maxInt64(d.mediaDelta, 0),
+	}
+}
+
+func (d quotaPendingDeltas) negate() quotaPendingDeltas {
+	return quotaPendingDeltas{
+		storageDelta: -d.storageDelta,
+		fileDelta:    -d.fileDelta,
+		mediaDelta:   -d.mediaDelta,
+	}
 }
 
 func maxInt64(a, b int64) int64 {

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -346,6 +346,8 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 		return quotaPendingDeltas{}, false
 	}
 	if c.load == nil {
+		// Expiry mutates localDeltas/localEntries, so the hot no-loader path
+		// needs the write lock even though callers are logically reading.
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		c.expireLocalDeltasLocked(time.Now())
@@ -508,6 +510,8 @@ func (c *quotaPendingDeltasCache) expireLocalDeltasLocked(now time.Time) {
 }
 
 func (c *quotaPendingDeltasCache) removeLocalEntryLocked(deltas quotaPendingDeltas) bool {
+	// Match by aggregate delta rather than log ID: admission only reads the
+	// aggregate total, so same-delta pending entries are interchangeable.
 	for i, entry := range c.localEntries {
 		if entry.deltas == deltas {
 			copy(c.localEntries[i:], c.localEntries[i+1:])

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -475,6 +475,26 @@ func TestQuotaPendingDeltasCacheClearAfterExpiryDoesNotGoNegative(t *testing.T) 
 	}
 }
 
+func TestQuotaPendingDeltasCacheRemovesPositiveRaceDeltasOnClearAndExpire(t *testing.T) {
+	c := newQuotaPendingDeltasCache("test-tenant", nil, time.Hour)
+	c.pendingTTL = 10 * time.Millisecond
+
+	c.addPending(8, 1, -1)
+	c.clearPending(8, 1, -1)
+	if got := c.localPositiveDeltas; got.storageDelta != 0 || got.fileDelta != 0 || got.mediaDelta != 0 {
+		t.Fatalf("positive deltas after clear = %+v, want zero", got)
+	}
+
+	c.addPending(5, 2, 1)
+	time.Sleep(20 * time.Millisecond)
+	if _, ok := c.get(context.Background()); !ok {
+		t.Fatal("expired get failed")
+	}
+	if got := c.localPositiveDeltas; got.storageDelta != 0 || got.fileDelta != 0 || got.mediaDelta != 0 {
+		t.Fatalf("positive deltas after expire = %+v, want zero", got)
+	}
+}
+
 func TestQuotaConfigCacheStop(t *testing.T) {
 	store := newCacheTestStore()
 	c := newQuotaConfigCache("t1", store)

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -301,7 +301,7 @@ func TestQuotaPendingDeltasCacheUsesTTLAndLocalAdjustments(t *testing.T) {
 
 	storage = 99
 	file = 9
-	c.add(5, 2, 1)
+	c.addPending(5, 2, 1)
 	second, ok := c.get(context.Background())
 	if !ok {
 		t.Fatal("second get failed")
@@ -337,7 +337,7 @@ func TestQuotaPendingDeltasCachePublishesConservativeSnapshotWhenLocalDeltaRaces
 	}()
 
 	<-started
-	c.add(5, 1, 0)
+	c.addPending(5, 1, 0)
 	close(release)
 
 	got := <-done
@@ -382,7 +382,7 @@ func TestQuotaPendingDeltasCacheIgnoresNegativeRaceDeltasWhenPublishing(t *testi
 	}()
 
 	<-started
-	c.add(-5, -1, -1)
+	c.addPending(-5, -1, -1)
 	close(release)
 
 	got := <-done
@@ -401,6 +401,77 @@ func TestQuotaPendingDeltasCacheIgnoresNegativeRaceDeltasWhenPublishing(t *testi
 	}
 	if got := calls.Load(); got != 1 {
 		t.Fatalf("loader calls = %d, want 1", got)
+	}
+}
+
+func TestQuotaPendingDeltasCacheExpiresNoLoaderPending(t *testing.T) {
+	c := newQuotaPendingDeltasCache("test-tenant", nil, time.Hour)
+	c.pendingTTL = 10 * time.Millisecond
+
+	c.addPending(8, 1, -1)
+	first, ok := c.get(context.Background())
+	if !ok {
+		t.Fatal("first get failed")
+	}
+	if first.storageDelta != 8 || first.fileDelta != 1 || first.mediaDelta != -1 {
+		t.Fatalf("first deltas = %+v, want 8/1/-1", first)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	expired, ok := c.get(context.Background())
+	if !ok {
+		t.Fatal("expired get failed")
+	}
+	if expired.storageDelta != 0 || expired.fileDelta != 0 || expired.mediaDelta != 0 {
+		t.Fatalf("expired deltas = %+v, want zero", expired)
+	}
+}
+
+func TestQuotaPendingDeltasCacheClearPreventsExpiryDoubleSubtract(t *testing.T) {
+	c := newQuotaPendingDeltasCache("test-tenant", nil, time.Hour)
+	c.pendingTTL = 10 * time.Millisecond
+
+	c.addPending(8, 1, 0)
+	c.clearPending(8, 1, 0)
+	cleared, ok := c.get(context.Background())
+	if !ok {
+		t.Fatal("cleared get failed")
+	}
+	if cleared.storageDelta != 0 || cleared.fileDelta != 0 || cleared.mediaDelta != 0 {
+		t.Fatalf("cleared deltas = %+v, want zero", cleared)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	expired, ok := c.get(context.Background())
+	if !ok {
+		t.Fatal("expired get failed")
+	}
+	if expired.storageDelta != 0 || expired.fileDelta != 0 || expired.mediaDelta != 0 {
+		t.Fatalf("expired deltas = %+v, want zero", expired)
+	}
+}
+
+func TestQuotaPendingDeltasCacheClearAfterExpiryDoesNotGoNegative(t *testing.T) {
+	c := newQuotaPendingDeltasCache("test-tenant", nil, time.Hour)
+	c.pendingTTL = 10 * time.Millisecond
+
+	c.addPending(8, 1, 0)
+	time.Sleep(20 * time.Millisecond)
+	expired, ok := c.get(context.Background())
+	if !ok {
+		t.Fatal("expired get failed")
+	}
+	if expired.storageDelta != 0 || expired.fileDelta != 0 || expired.mediaDelta != 0 {
+		t.Fatalf("expired deltas = %+v, want zero", expired)
+	}
+
+	c.clearPending(8, 1, 0)
+	cleared, ok := c.get(context.Background())
+	if !ok {
+		t.Fatal("cleared get failed")
+	}
+	if cleared.storageDelta != 0 || cleared.fileDelta != 0 || cleared.mediaDelta != 0 {
+		t.Fatalf("cleared deltas = %+v, want zero after late clear", cleared)
 	}
 }
 

--- a/pkg/backend/quota_integration_test.go
+++ b/pkg/backend/quota_integration_test.go
@@ -15,7 +15,6 @@ import (
 
 func newServerQuotaBackend(t *testing.T, opts Options) (*Dat9Backend, *fakeMetaQuotaStore) {
 	t.Helper()
-	opts.QuotaSource = QuotaSourceServer
 	b := newTestBackendWithOptions(t, opts)
 	fake := newFakeMetaQuotaStore()
 	fake.config["tenant-a"] = &QuotaConfigView{
@@ -51,7 +50,6 @@ func waitForFakeCentralLLMUsage(t *testing.T, fake *fakeMetaQuotaStore, tenantID
 
 func TestServerQuotaFeatureFlagRejectsOverLimitWrite(t *testing.T) {
 	opts := Options{}
-	opts.QuotaSource = QuotaSourceServer
 	b := newTestBackendWithOptions(t, opts)
 	fake := newFakeMetaQuotaStore()
 	fake.config["tenant-a"] = &QuotaConfigView{
@@ -85,7 +83,6 @@ func TestServerQuotaFeatureFlagRejectsOverLimitWrite(t *testing.T) {
 
 func TestCreateIfAbsentExistingPathReturnsConflictBeforeStorageQuota(t *testing.T) {
 	opts := Options{}
-	opts.QuotaSource = QuotaSourceServer
 	b := newTestBackendWithOptions(t, opts)
 	fake := newFakeMetaQuotaStore()
 	fake.config["tenant-a"] = &QuotaConfigView{
@@ -152,6 +149,7 @@ func TestCreateIfAbsentExistingPathReturnsConflictBeforeFileSizeQuota(t *testing
 }
 
 func TestServerQuotaPendingOutboxFileDeltaRejectsOverFileCount(t *testing.T) {
+	t.Skip("runtime quota admission no longer reads tenant quota_outbox pending deltas")
 	b, fake := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -287,14 +287,13 @@ func (f *fakeMetaQuotaStore) UpdateUploadReservationStatusTx(tx *sql.Tx, tenantI
 	return f.UpdateUploadReservationStatus(context.Background(), tenantID, uploadID, status)
 }
 
-// SettleActiveReservationTx models the atomic "active → status" transition
-// and reports whether an active row was actually settled. Mirrors the real
-// Store contract used by Round A / fix 4.
+// SettleActiveReservationTx models the atomic "active/completing → status"
+// transition and reports whether a releasable row was actually settled.
 func (f *fakeMetaQuotaStore) SettleActiveReservationTx(tx *sql.Tx, tenantID, uploadID, status string) (bool, int64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	r, ok := f.reservations[metaKey(tenantID, uploadID)]
-	if !ok || r.Status != "active" {
+	if !ok || (r.Status != "active" && r.Status != "completing") {
 		return false, 0, nil
 	}
 	r.Status = status
@@ -514,12 +513,38 @@ func newCentralQuotaBackend(t *testing.T) (*Dat9Backend, *fakeMetaQuotaStore) {
 	return b, fake
 }
 
+func drainCentralQuotaMutations(t *testing.T, b *Dat9Backend) {
+	t.Helper()
+	done := make(chan struct{})
+	b.enqueueMutation(func() {
+		close(done)
+	})
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for central quota mutations")
+	}
+}
+
+func assertNoTenantQuotaOutboxRows(t *testing.T, b *Dat9Backend) {
+	t.Helper()
+	var count int
+	if err := b.Store().DB().QueryRowContext(context.Background(), `SELECT COUNT(*) FROM quota_outbox`).Scan(&count); err != nil {
+		t.Fatalf("count tenant quota_outbox rows: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("tenant quota_outbox rows = %d, want 0", count)
+	}
+}
+
 func TestCentralQuotaFileMutationLifecycle(t *testing.T) {
 	b, fake := newCentralQuotaBackend(t)
 
 	if _, err := b.Write("/img.png", []byte("png-data"), 0, filesystem.WriteFlagCreate); err != nil {
 		t.Fatalf("create image: %v", err)
 	}
+	drainCentralQuotaMutations(t, b)
+	assertNoTenantQuotaOutboxRows(t, b)
 	nf, err := b.Store().Stat(context.Background(), "/img.png")
 	if err != nil {
 		t.Fatalf("stat create: %v", err)
@@ -539,6 +564,8 @@ func TestCentralQuotaFileMutationLifecycle(t *testing.T) {
 	if _, err := b.Write("/img.png", []byte("much-longer-png-data"), 0, filesystem.WriteFlagTruncate); err != nil {
 		t.Fatalf("overwrite image: %v", err)
 	}
+	drainCentralQuotaMutations(t, b)
+	assertNoTenantQuotaOutboxRows(t, b)
 	usage, _ = fake.GetQuotaUsage(context.Background(), "tenant-a")
 	if usage.StorageBytes != int64(len("much-longer-png-data")) || usage.FileCount != 1 || usage.MediaFileCount != 1 {
 		t.Fatalf("usage after overwrite = %+v", usage)
@@ -603,6 +630,8 @@ func TestCentralQuotaUploadCompleteUpdatesShadowState(t *testing.T) {
 	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
 		t.Fatalf("confirm upload: %v", err)
 	}
+	drainCentralQuotaMutations(t, b)
+	assertNoTenantQuotaOutboxRows(t, b)
 
 	nf, err := b.Store().Stat(ctx, "/clip.wav")
 	if err != nil {
@@ -632,9 +661,21 @@ func TestCentralQuotaUploadCompleteUpdatesShadowState(t *testing.T) {
 	}
 }
 
+func TestCentralQuotaMutationLogInsertFailureSurfaces(t *testing.T) {
+	b, fake := newCentralQuotaBackend(t)
+	fake.insertMutationErr = errors.New("meta log unavailable")
+
+	if _, err := b.Write("/lost.png", []byte("png-data"), 0, filesystem.WriteFlagCreate); err == nil {
+		t.Fatal("create error = nil, want central quota mutation log error")
+	}
+	assertNoTenantQuotaOutboxRows(t, b)
+	if len(fake.mutations) != 0 {
+		t.Fatalf("mutation log rows = %d, want 0", len(fake.mutations))
+	}
+}
+
 func TestMonthlyLLMCostExceededUsesCentralCounter(t *testing.T) {
 	b, fake := newCentralQuotaBackend(t)
-	b.quotaSource = QuotaSourceServer // enable server-side cost check
 	b.maxMonthlyLLMCostMillicents = 100
 	fake.config["tenant-a"].MaxMonthlyCostMC = 100
 	fake.monthly["tenant-a"] = 101
@@ -647,7 +688,7 @@ func TestMonthlyLLMCostExceededUsesCentralCounter(t *testing.T) {
 	}
 }
 
-func TestRecordImageExtractUsageWritesCentralLedgerAndLegacyStore(t *testing.T) {
+func TestRecordImageExtractUsageWritesCentralLedgerOnlyWhenServerQuotaActive(t *testing.T) {
 	b, fake := newCentralQuotaBackend(t)
 	b.visionCostPerKTokenMillicents = 1000
 
@@ -655,13 +696,14 @@ func TestRecordImageExtractUsageWritesCentralLedgerAndLegacyStore(t *testing.T) 
 		PromptTokens:     120,
 		CompletionTokens: 80,
 	})
+	drainCentralQuotaMutations(t, b)
 
 	total, err := b.store.MonthlyLLMCostMillicents()
 	if err != nil {
 		t.Fatalf("tenant monthly llm cost: %v", err)
 	}
-	if total != 200 {
-		t.Fatalf("tenant monthly llm cost = %d, want 200", total)
+	if total != 0 {
+		t.Fatalf("tenant monthly llm cost = %d, want 0 when server quota is active", total)
 	}
 	if fake.monthly["tenant-a"] != 200 {
 		t.Fatalf("central monthly llm cost = %d, want 200", fake.monthly["tenant-a"])

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -690,9 +690,10 @@ func TestCentralQuotaMutationLogInsertFailureSurfaces(t *testing.T) {
 	}
 }
 
-func TestCentralQuotaPendingDeltaRetainedAfterInlineApplyFailure(t *testing.T) {
+func TestCentralQuotaPendingDeltaRetainedThenExpiresAfterInlineApplyFailure(t *testing.T) {
 	b, fake := newCentralQuotaBackend(t)
 	applyErr := errors.New("meta apply unavailable")
+	b.quotaPendingCache.pendingTTL = 10 * time.Millisecond
 
 	if err := b.logAndEnqueueMutation(context.Background(), "file_create", fileCreateMutationData{
 		FileID:    "file-pending",
@@ -714,6 +715,12 @@ func TestCentralQuotaPendingDeltaRetainedAfterInlineApplyFailure(t *testing.T) {
 	}
 	if got := fake.mutations[len(fake.mutations)-1].status; got != "pending" {
 		t.Fatalf("mutation status = %q, want pending for replay", got)
+	}
+
+	time.Sleep(20 * time.Millisecond)
+	storageDelta, fileDelta, mediaDelta = b.pendingCentralMutationDeltas(context.Background())
+	if storageDelta != 0 || fileDelta != 0 || mediaDelta != 0 {
+		t.Fatalf("expired pending deltas = (%d,%d,%d), want zero after local TTL", storageDelta, fileDelta, mediaDelta)
 	}
 }
 

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -283,13 +283,24 @@ func (f *fakeMetaQuotaStore) UpdateUploadReservationStatus(ctx context.Context, 
 	return nil
 }
 
-func (f *fakeMetaQuotaStore) UpdateUploadReservationStatusTx(tx *sql.Tx, tenantID, uploadID, status string) error {
-	return f.UpdateUploadReservationStatus(context.Background(), tenantID, uploadID, status)
+func (f *fakeMetaQuotaStore) UpdateUploadReservationStatusTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID, status string) error {
+	return f.UpdateUploadReservationStatus(ctx, tenantID, uploadID, status)
+}
+
+func (f *fakeMetaQuotaStore) AbortActiveReservationTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID string) (bool, int64, int64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	r, ok := f.reservations[metaKey(tenantID, uploadID)]
+	if !ok || (r.Status != "active" && r.Status != "completing") {
+		return false, 0, 0, nil
+	}
+	r.Status = "aborted"
+	return true, r.ReservedBytes, r.FileCountDelta, nil
 }
 
 // SettleActiveReservationTx models the atomic "active/completing → status"
 // transition and reports whether a releasable row was actually settled.
-func (f *fakeMetaQuotaStore) SettleActiveReservationTx(tx *sql.Tx, tenantID, uploadID, status string) (bool, int64, error) {
+func (f *fakeMetaQuotaStore) SettleActiveReservationTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID, status string) (bool, int64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	r, ok := f.reservations[metaKey(tenantID, uploadID)]
@@ -485,7 +496,7 @@ func (f *fakeMetaQuotaStore) ExpireActiveReservations(ctx context.Context) (int6
 	now := time.Now()
 	var released int64
 	for _, r := range f.reservations {
-		if r.Status != "active" || !r.ExpiresAt.Before(now) {
+		if (r.Status != "active" && r.Status != "completing") || !r.ExpiresAt.Before(now) {
 			continue
 		}
 		r.Status = "aborted"
@@ -516,7 +527,7 @@ func newCentralQuotaBackend(t *testing.T) (*Dat9Backend, *fakeMetaQuotaStore) {
 func drainCentralQuotaMutations(t *testing.T, b *Dat9Backend) {
 	t.Helper()
 	done := make(chan struct{})
-	b.enqueueMutation(func() {
+	b.enqueueMutation(func(context.Context) {
 		close(done)
 	})
 	select {
@@ -671,6 +682,72 @@ func TestCentralQuotaMutationLogInsertFailureSurfaces(t *testing.T) {
 	assertNoTenantQuotaOutboxRows(t, b)
 	if len(fake.mutations) != 0 {
 		t.Fatalf("mutation log rows = %d, want 0", len(fake.mutations))
+	}
+}
+
+func TestCentralQuotaPendingDeltaClearsAfterInlineApplyFailure(t *testing.T) {
+	b, fake := newCentralQuotaBackend(t)
+	applyErr := errors.New("meta apply unavailable")
+
+	if err := b.logAndEnqueueMutation(context.Background(), "file_create", fileCreateMutationData{
+		FileID:    "file-pending",
+		SizeBytes: 128,
+		IsMedia:   false,
+	}, quotaPendingDeltas{
+		storageDelta: 128,
+		fileDelta:    1,
+	}, func(context.Context, *sql.Tx) error {
+		return applyErr
+	}); err != nil {
+		t.Fatalf("log and enqueue mutation: %v", err)
+	}
+	drainCentralQuotaMutations(t, b)
+
+	storageDelta, fileDelta, mediaDelta := b.pendingCentralMutationDeltas(context.Background())
+	if storageDelta != 0 || fileDelta != 0 || mediaDelta != 0 {
+		t.Fatalf("pending deltas = (%d,%d,%d), want zero after apply attempt", storageDelta, fileDelta, mediaDelta)
+	}
+	if got := fake.mutations[len(fake.mutations)-1].status; got != "pending" {
+		t.Fatalf("mutation status = %q, want pending for replay", got)
+	}
+}
+
+func TestCentralQuotaExpireReclaimsCompletingReservations(t *testing.T) {
+	_, fake := newCentralQuotaBackend(t)
+	ctx := context.Background()
+	reservation := &UploadReservationView{
+		TenantID:       "tenant-a",
+		UploadID:       "upload-completing",
+		ReservedBytes:  512,
+		FileCountDelta: 1,
+		TargetPath:     "/upload.bin",
+		Status:         "active",
+		ExpiresAt:      time.Now().Add(-time.Minute),
+	}
+	if err := fake.AtomicReserveAndInsertUpload(ctx, reservation); err != nil {
+		t.Fatalf("reserve upload: %v", err)
+	}
+	if err := fake.UpdateUploadReservationStatus(ctx, "tenant-a", "upload-completing", "completing"); err != nil {
+		t.Fatalf("mark completing: %v", err)
+	}
+
+	released, err := fake.ExpireActiveReservations(ctx)
+	if err != nil {
+		t.Fatalf("expire reservations: %v", err)
+	}
+	if released != 512 {
+		t.Fatalf("released bytes = %d, want 512", released)
+	}
+	usage := fake.usage["tenant-a"]
+	if usage.ReservedBytes != 0 || usage.FileCount != 0 {
+		t.Fatalf("usage after expiry = %+v, want reserved/file count released", usage)
+	}
+	r, err := fake.GetUploadReservation(ctx, "tenant-a", "upload-completing")
+	if err != nil {
+		t.Fatalf("get reservation: %v", err)
+	}
+	if r.Status != "aborted" {
+		t.Fatalf("reservation status = %q, want aborted", r.Status)
 	}
 }
 

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -284,7 +284,12 @@ func (f *fakeMetaQuotaStore) UpdateUploadReservationStatus(ctx context.Context, 
 }
 
 func (f *fakeMetaQuotaStore) UpdateUploadReservationStatusTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID, status string) error {
-	return f.UpdateUploadReservationStatus(ctx, tenantID, uploadID, status)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if r, ok := f.reservations[metaKey(tenantID, uploadID)]; ok && (r.Status == "active" || r.Status == "completing") {
+		r.Status = status
+	}
+	return nil
 }
 
 func (f *fakeMetaQuotaStore) AbortActiveReservationTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID string) (bool, int64, int64, error) {
@@ -527,7 +532,7 @@ func newCentralQuotaBackend(t *testing.T) (*Dat9Backend, *fakeMetaQuotaStore) {
 func drainCentralQuotaMutations(t *testing.T, b *Dat9Backend) {
 	t.Helper()
 	done := make(chan struct{})
-	b.enqueueMutation(func(context.Context) {
+	b.enqueueMutation(context.Background(), func(context.Context) {
 		close(done)
 	})
 	select {
@@ -685,7 +690,7 @@ func TestCentralQuotaMutationLogInsertFailureSurfaces(t *testing.T) {
 	}
 }
 
-func TestCentralQuotaPendingDeltaClearsAfterInlineApplyFailure(t *testing.T) {
+func TestCentralQuotaPendingDeltaRetainedAfterInlineApplyFailure(t *testing.T) {
 	b, fake := newCentralQuotaBackend(t)
 	applyErr := errors.New("meta apply unavailable")
 
@@ -704,8 +709,8 @@ func TestCentralQuotaPendingDeltaClearsAfterInlineApplyFailure(t *testing.T) {
 	drainCentralQuotaMutations(t, b)
 
 	storageDelta, fileDelta, mediaDelta := b.pendingCentralMutationDeltas(context.Background())
-	if storageDelta != 0 || fileDelta != 0 || mediaDelta != 0 {
-		t.Fatalf("pending deltas = (%d,%d,%d), want zero after apply attempt", storageDelta, fileDelta, mediaDelta)
+	if storageDelta != 128 || fileDelta != 1 || mediaDelta != 0 {
+		t.Fatalf("pending deltas = (%d,%d,%d), want retained pending mutation", storageDelta, fileDelta, mediaDelta)
 	}
 	if got := fake.mutations[len(fake.mutations)-1].status; got != "pending" {
 		t.Fatalf("mutation status = %q, want pending for replay", got)

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -277,7 +277,7 @@ func (f *fakeMetaQuotaStore) InsertUploadReservation(ctx context.Context, r *Upl
 func (f *fakeMetaQuotaStore) UpdateUploadReservationStatus(ctx context.Context, tenantID, uploadID, status string) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if r, ok := f.reservations[metaKey(tenantID, uploadID)]; ok {
+	if r, ok := f.reservations[metaKey(tenantID, uploadID)]; ok && (r.Status == "active" || r.Status == "completing") {
 		r.Status = status
 	}
 	return nil

--- a/pkg/backend/quota_mutation.go
+++ b/pkg/backend/quota_mutation.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -42,6 +43,32 @@ type llmCostMutationData struct {
 	CostMillicents int64  `json:"cost_millicents"`
 	RawUnits       int64  `json:"raw_units"`
 	RawUnitType    string `json:"raw_unit_type"`
+}
+
+const postCommitQuotaMutationTimeout = 30 * time.Second
+
+// PostCommitQuotaMutationError reports that the user-visible file mutation has
+// already committed, but the central quota handoff failed afterward.
+type PostCommitQuotaMutationError struct {
+	Op  string
+	Err error
+}
+
+func (e *PostCommitQuotaMutationError) Error() string {
+	return fmt.Sprintf("%s after commit: %v", e.Op, e.Err)
+}
+
+func (e *PostCommitQuotaMutationError) Unwrap() error { return e.Err }
+
+func postCommitQuotaMutationContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(backgroundWithTrace(), postCommitQuotaMutationTimeout)
+}
+
+func postCommitQuotaMutationError(op string, err error) error {
+	if err == nil {
+		return nil
+	}
+	return &PostCommitQuotaMutationError{Op: op, Err: err}
 }
 
 func isQuotaMediaContentType(contentType string) bool {
@@ -85,9 +112,15 @@ func (b *Dat9Backend) logQuotaMutation(ctx context.Context, mutationType string,
 // applyQuotaMutation applies a previously-logged mutation and marks it as
 // applied. This is the async-safe half of the split mutation path — if it
 // fails or never runs, MutationReplayWorker picks up the pending log entry.
-func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType string, logID int64, pending quotaPendingDeltas, apply func(tx *sql.Tx) error) {
+func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType string, logID int64, pending quotaPendingDeltas, apply func(context.Context, *sql.Tx) error) {
+	defer func() {
+		if b.quotaUsageCache != nil {
+			b.quotaUsageCache.invalidate()
+		}
+		b.addPendingCentralMutationDeltas(-pending.storageDelta, -pending.fileDelta, -pending.mediaDelta)
+	}()
 	if err := b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
-		if err := apply(tx); err != nil {
+		if err := apply(ctx, tx); err != nil {
 			return err
 		}
 		return b.metaStore.MarkMutationAppliedTx(tx, logID)
@@ -100,7 +133,6 @@ func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType strin
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "pending", time.Duration(0))
 		return
 	}
-	b.addPendingCentralMutationDeltas(-pending.storageDelta, -pending.fileDelta, -pending.mediaDelta)
 	metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "ok", time.Duration(0))
 }
 
@@ -119,7 +151,7 @@ func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType strin
 // pending (unapplied) entries in (tenant_id, id) order, which handles
 // crash recovery. For cross-pod last-writer divergence on file_meta,
 // the backfill-quota tool can be run manually to reconcile.
-func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType string, payload any, pending quotaPendingDeltas, apply func(tx *sql.Tx) error) error {
+func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType string, payload any, pending quotaPendingDeltas, apply func(context.Context, *sql.Tx) error) error {
 	if b.metaStore == nil || b.tenantID == "" {
 		return nil
 	}
@@ -132,8 +164,8 @@ func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType st
 		return err
 	}
 	b.addPendingCentralMutationDeltas(pending.storageDelta, pending.fileDelta, pending.mediaDelta)
-	b.enqueueMutation(func() {
-		b.applyQuotaMutation(context.Background(), mutationType, logID, pending, apply)
+	b.enqueueMutation(func(applyCtx context.Context) {
+		b.applyQuotaMutation(applyCtx, mutationType, logID, pending, apply)
 	})
 	b.mutationMu.Unlock()
 
@@ -210,7 +242,7 @@ func (b *Dat9Backend) recordCentralFileCreateMutation(ctx context.Context, fileI
 		storageDelta: sizeBytes,
 		fileDelta:    1,
 		mediaDelta:   mediaDelta,
-	}, func(tx *sql.Tx) error {
+	}, func(applyCtx context.Context, tx *sql.Tx) error {
 		return applyCentralFileCreateTx(b.metaStore, tx, b.tenantID, data)
 	})
 }
@@ -228,19 +260,19 @@ func (b *Dat9Backend) recordCentralFileOverwriteMutation(ctx context.Context, fi
 	return b.logAndEnqueueMutation(ctx, "file_overwrite", data, quotaPendingDeltas{
 		storageDelta: newSize - oldSize,
 		mediaDelta:   quotaMediaDelta(oldIsMedia, newIsMedia),
-	}, func(tx *sql.Tx) error {
+	}, func(applyCtx context.Context, tx *sql.Tx) error {
 		return applyCentralFileOverwriteTx(b.metaStore, tx, b.tenantID, data)
 	})
 }
 
-func (b *Dat9Backend) syncCentralLLMCostRecord(ctx context.Context, taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) {
-	_ = b.logAndEnqueueMutation(ctx, "llm_cost_record", llmCostMutationData{
+func (b *Dat9Backend) syncCentralLLMCostRecord(ctx context.Context, taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) error {
+	return b.logAndEnqueueMutation(ctx, "llm_cost_record", llmCostMutationData{
 		TaskType:       taskType,
 		TaskID:         taskID,
 		CostMillicents: costMillicents,
 		RawUnits:       rawUnits,
 		RawUnitType:    rawUnitType,
-	}, quotaPendingDeltas{}, func(tx *sql.Tx) error {
+	}, quotaPendingDeltas{}, func(applyCtx context.Context, tx *sql.Tx) error {
 		if err := b.metaStore.InsertCentralLLMUsageTx(tx, &LLMUsageView{
 			TenantID:       b.tenantID,
 			TaskType:       taskType,

--- a/pkg/backend/quota_mutation.go
+++ b/pkg/backend/quota_mutation.go
@@ -113,12 +113,6 @@ func (b *Dat9Backend) logQuotaMutation(ctx context.Context, mutationType string,
 // applied. This is the async-safe half of the split mutation path — if it
 // fails or never runs, MutationReplayWorker picks up the pending log entry.
 func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType string, logID int64, pending quotaPendingDeltas, apply func(context.Context, *sql.Tx) error) {
-	defer func() {
-		if b.quotaUsageCache != nil {
-			b.quotaUsageCache.invalidate()
-		}
-		b.addPendingCentralMutationDeltas(-pending.storageDelta, -pending.fileDelta, -pending.mediaDelta)
-	}()
 	if err := b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
 		if err := apply(ctx, tx); err != nil {
 			return err
@@ -133,6 +127,10 @@ func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType strin
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "pending", time.Duration(0))
 		return
 	}
+	if b.quotaUsageCache != nil {
+		b.quotaUsageCache.invalidate()
+	}
+	b.addPendingCentralMutationDeltas(-pending.storageDelta, -pending.fileDelta, -pending.mediaDelta)
 	metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "ok", time.Duration(0))
 }
 
@@ -164,7 +162,7 @@ func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType st
 		return err
 	}
 	b.addPendingCentralMutationDeltas(pending.storageDelta, pending.fileDelta, pending.mediaDelta)
-	b.enqueueMutation(func(applyCtx context.Context) {
+	b.enqueueMutation(ctx, func(applyCtx context.Context) {
 		b.applyQuotaMutation(applyCtx, mutationType, logID, pending, apply)
 	})
 	b.mutationMu.Unlock()

--- a/pkg/backend/quota_mutation.go
+++ b/pkg/backend/quota_mutation.go
@@ -130,7 +130,7 @@ func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType strin
 	if b.quotaUsageCache != nil {
 		b.quotaUsageCache.invalidate()
 	}
-	b.addPendingCentralMutationDeltas(-pending.storageDelta, -pending.fileDelta, -pending.mediaDelta)
+	b.clearPendingCentralMutationDeltas(pending.storageDelta, pending.fileDelta, pending.mediaDelta)
 	metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "ok", time.Duration(0))
 }
 

--- a/pkg/backend/quota_mutation.go
+++ b/pkg/backend/quota_mutation.go
@@ -49,14 +49,14 @@ func isQuotaMediaContentType(contentType string) bool {
 }
 
 // logQuotaMutation durably records a mutation in the central quota_mutation_log.
-// Returns the log ID and true on success, or (0, false) if the mutation could
-// not be logged (caller should treat as fail-open). This is the synchronous
-// half of the split mutation path — it MUST complete before the write/fsync
-// returns success so that MutationReplayWorker can recover the mutation after
-// a crash.
-func (b *Dat9Backend) logQuotaMutation(ctx context.Context, mutationType string, payload any) (int64, bool) {
+// This is the only runtime quota accounting handoff after tenant quota_outbox
+// removal. Callers must surface an error instead of silently dropping the
+// mutation. The current write paths still call this after the tenant DB commit,
+// so a process crash between tenant commit and this insert remains a known
+// reconciliation/backfill window.
+func (b *Dat9Backend) logQuotaMutation(ctx context.Context, mutationType string, payload any) (int64, error) {
 	if b.metaStore == nil || b.tenantID == "" {
-		return 0, false
+		return 0, nil
 	}
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -64,7 +64,7 @@ func (b *Dat9Backend) logQuotaMutation(ctx context.Context, mutationType string,
 			zap.String("tenant_id", b.tenantID),
 			zap.String("mutation_type", mutationType),
 			zap.Error(err))
-		return 0, false
+		return 0, err
 	}
 	logID, err := b.metaStore.InsertMutationLog(ctx, &MutationLogView{
 		TenantID:     b.tenantID,
@@ -76,16 +76,16 @@ func (b *Dat9Backend) logQuotaMutation(ctx context.Context, mutationType string,
 			zap.String("tenant_id", b.tenantID),
 			zap.String("mutation_type", mutationType),
 			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "fail_open", time.Duration(0))
-		return 0, false
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "log_error", time.Duration(0))
+		return 0, err
 	}
-	return logID, true
+	return logID, nil
 }
 
 // applyQuotaMutation applies a previously-logged mutation and marks it as
 // applied. This is the async-safe half of the split mutation path — if it
 // fails or never runs, MutationReplayWorker picks up the pending log entry.
-func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType string, logID int64, apply func(tx *sql.Tx) error) {
+func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType string, logID int64, pending quotaPendingDeltas, apply func(tx *sql.Tx) error) {
 	if err := b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
 		if err := apply(tx); err != nil {
 			return err
@@ -100,6 +100,7 @@ func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType strin
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "pending", time.Duration(0))
 		return
 	}
+	b.addPendingCentralMutationDeltas(-pending.storageDelta, -pending.fileDelta, -pending.mediaDelta)
 	metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "ok", time.Duration(0))
 }
 
@@ -118,17 +119,21 @@ func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType strin
 // pending (unapplied) entries in (tenant_id, id) order, which handles
 // crash recovery. For cross-pod last-writer divergence on file_meta,
 // the backfill-quota tool can be run manually to reconcile.
-func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType string, payload any, apply func(tx *sql.Tx) error) {
+func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType string, payload any, pending quotaPendingDeltas, apply func(tx *sql.Tx) error) error {
+	if b.metaStore == nil || b.tenantID == "" {
+		return nil
+	}
 	start := time.Now()
 
 	b.mutationMu.Lock()
-	logID, ok := b.logQuotaMutation(ctx, mutationType, payload)
-	if !ok {
+	logID, err := b.logQuotaMutation(ctx, mutationType, payload)
+	if err != nil {
 		b.mutationMu.Unlock()
-		return
+		return err
 	}
+	b.addPendingCentralMutationDeltas(pending.storageDelta, pending.fileDelta, pending.mediaDelta)
 	b.enqueueMutation(func() {
-		b.applyQuotaMutation(context.Background(), mutationType, logID, apply)
+		b.applyQuotaMutation(context.Background(), mutationType, logID, pending, apply)
 	})
 	b.mutationMu.Unlock()
 
@@ -137,6 +142,7 @@ func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType st
 		zap.String("mutation_type", mutationType),
 		zap.Int64("log_id", logID),
 		zap.Float64("total_ms", backendDurationMs(time.Since(start))))
+	return nil
 }
 
 func applyCentralFileStateTx(store MetaQuotaStore, tx *sql.Tx, tenantID, fileID string, sizeBytes int64, isMedia bool) error {
@@ -189,19 +195,27 @@ func applyCentralFileOverwriteTx(store MetaQuotaStore, tx *sql.Tx, tenantID stri
 	return applyCentralFileStateTx(store, tx, tenantID, data.FileID, data.NewSizeBytes, data.NewIsMedia)
 }
 
-func (b *Dat9Backend) syncCentralFileCreate(ctx context.Context, fileID string, sizeBytes int64, contentType string) {
+func (b *Dat9Backend) recordCentralFileCreateMutation(ctx context.Context, fileID string, sizeBytes int64, contentType string) error {
 	isMedia := isQuotaMediaContentType(contentType)
 	data := fileCreateMutationData{
 		FileID:    fileID,
 		SizeBytes: sizeBytes,
 		IsMedia:   isMedia,
 	}
-	b.logAndEnqueueMutation(ctx, "file_create", data, func(tx *sql.Tx) error {
+	mediaDelta := int64(0)
+	if isMedia {
+		mediaDelta = 1
+	}
+	return b.logAndEnqueueMutation(ctx, "file_create", data, quotaPendingDeltas{
+		storageDelta: sizeBytes,
+		fileDelta:    1,
+		mediaDelta:   mediaDelta,
+	}, func(tx *sql.Tx) error {
 		return applyCentralFileCreateTx(b.metaStore, tx, b.tenantID, data)
 	})
 }
 
-func (b *Dat9Backend) syncCentralFileOverwrite(ctx context.Context, fileID string, oldSize int64, oldContentType string, newSize int64, newContentType string) {
+func (b *Dat9Backend) recordCentralFileOverwriteMutation(ctx context.Context, fileID string, oldSize int64, oldContentType string, newSize int64, newContentType string) error {
 	oldIsMedia := isQuotaMediaContentType(oldContentType)
 	newIsMedia := isQuotaMediaContentType(newContentType)
 	data := fileOverwriteMutationData{
@@ -211,19 +225,22 @@ func (b *Dat9Backend) syncCentralFileOverwrite(ctx context.Context, fileID strin
 		NewSizeBytes: newSize,
 		NewIsMedia:   newIsMedia,
 	}
-	b.logAndEnqueueMutation(ctx, "file_overwrite", data, func(tx *sql.Tx) error {
+	return b.logAndEnqueueMutation(ctx, "file_overwrite", data, quotaPendingDeltas{
+		storageDelta: newSize - oldSize,
+		mediaDelta:   quotaMediaDelta(oldIsMedia, newIsMedia),
+	}, func(tx *sql.Tx) error {
 		return applyCentralFileOverwriteTx(b.metaStore, tx, b.tenantID, data)
 	})
 }
 
 func (b *Dat9Backend) syncCentralLLMCostRecord(ctx context.Context, taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) {
-	b.logAndEnqueueMutation(ctx, "llm_cost_record", llmCostMutationData{
+	_ = b.logAndEnqueueMutation(ctx, "llm_cost_record", llmCostMutationData{
 		TaskType:       taskType,
 		TaskID:         taskID,
 		CostMillicents: costMillicents,
 		RawUnits:       rawUnits,
 		RawUnitType:    rawUnitType,
-	}, func(tx *sql.Tx) error {
+	}, quotaPendingDeltas{}, func(tx *sql.Tx) error {
 		if err := b.metaStore.InsertCentralLLMUsageTx(tx, &LLMUsageView{
 			TenantID:       b.tenantID,
 			TaskType:       taskType,

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -18,6 +18,7 @@ import (
 )
 
 func TestServerQuotaSmallWriteUsesTenantOutbox(t *testing.T) {
+	t.Skip("runtime quota accounting now uses meta quota_mutation_log, not tenant quota_outbox")
 	b, fake := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()
@@ -69,6 +70,7 @@ func TestServerQuotaSmallWriteUsesTenantOutbox(t *testing.T) {
 }
 
 func TestServerQuotaOutboxBatchProcessesDifferentFiles(t *testing.T) {
+	t.Skip("runtime quota accounting now uses meta quota_mutation_log, not tenant quota_outbox")
 	b, fake := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()
@@ -318,6 +320,7 @@ func TestServerQuotaSmallWriteDoesNotWaitForAdmissionLock(t *testing.T) {
 }
 
 func TestQuotaOutboxWorkerHoldsAdmissionLockAcrossApplyAndAck(t *testing.T) {
+	t.Skip("runtime quota accounting no longer runs tenant quota_outbox worker")
 	b, fake := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()
@@ -456,6 +459,7 @@ func TestQuotaOutboxNotifyQuietReturnsAfterQuietPeriod(t *testing.T) {
 }
 
 func TestDrainQuotaOutboxForFileErrorsWhenPendingRowIsNotClaimable(t *testing.T) {
+	t.Skip("legacy tenant quota_outbox path is no longer used by runtime quota accounting")
 	b, _ := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()
@@ -484,7 +488,8 @@ func TestDrainQuotaOutboxForFileErrorsWhenPendingRowIsNotClaimable(t *testing.T)
 }
 
 func TestUploadOverwriteQueuesCompleteBehindPendingFileMutation(t *testing.T) {
-	b := newTestBackendWithS3AndOptions(t, Options{QuotaSource: QuotaSourceServer})
+	t.Skip("legacy tenant quota_outbox path is no longer used by runtime quota accounting")
+	b := newTestBackendWithS3AndOptions(t, Options{})
 	fake := newFakeMetaQuotaStore()
 	fake.config["tenant-a"] = &QuotaConfigView{
 		TenantID:         "tenant-a",
@@ -708,6 +713,7 @@ func TestDrainQuotaOutboxForFileContinuesAfterUnrelatedBatchError(t *testing.T) 
 }
 
 func TestServerQuotaPendingOutboxDeltaRejectsOverLimitWrite(t *testing.T) {
+	t.Skip("runtime quota admission no longer reads tenant quota_outbox pending deltas")
 	b, fake := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()
@@ -742,6 +748,7 @@ func TestServerQuotaPendingOutboxDeltaRejectsOverLimitWrite(t *testing.T) {
 }
 
 func TestServerQuotaPendingOutboxDeltaRejectsUploadReserve(t *testing.T) {
+	t.Skip("runtime quota admission no longer reads tenant quota_outbox pending deltas")
 	b, fake := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()
@@ -779,6 +786,7 @@ func TestServerQuotaPendingOutboxDeltaRejectsUploadReserve(t *testing.T) {
 }
 
 func TestServerQuotaUploadReserveUsesLivePendingOutboxDeltas(t *testing.T) {
+	t.Skip("runtime quota admission no longer reads tenant quota_outbox pending deltas")
 	b, fake := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()
@@ -859,6 +867,7 @@ func TestServerQuotaReserveUploadRetrySkipsPendingPrecheck(t *testing.T) {
 }
 
 func TestServerQuotaOverwriteOutboxUsesLockedCurrentMeta(t *testing.T) {
+	t.Skip("legacy tenant quota_outbox path is no longer used by runtime quota accounting")
 	b, _ := newServerQuotaBackend(t, Options{})
 	b.stopQuotaOutboxWorker()
 	ctx := context.Background()

--- a/pkg/backend/quota_outbox_test.go
+++ b/pkg/backend/quota_outbox_test.go
@@ -941,7 +941,7 @@ func TestApplyCentralFileMutationIsIdempotent(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		if err := fake.InTx(context.Background(), func(tx *sql.Tx) error {
-			return applyCentralQuotaMutationTx(fake, tx, "tenant-a", quotaMutationTypeFileCreate, raw, int64(i+1))
+			return applyCentralQuotaMutationTx(context.Background(), fake, tx, "tenant-a", quotaMutationTypeFileCreate, raw, int64(i+1))
 		}); err != nil {
 			t.Fatalf("apply central mutation %d: %v", i+1, err)
 		}

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -333,7 +333,7 @@ func (b *Dat9Backend) recordAppliedQuotaOutboxEntries(entries []datastore.QuotaO
 		b.quotaUsageCache.invalidate()
 	}
 	for _, entry := range entries {
-		b.addPendingCentralMutationDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
+		b.clearPendingCentralMutationDeltas(entry.StorageDelta, entry.FileDelta, entry.MediaDelta)
 		metrics.RecordTenantOperationCount(b.tenantID, "quota_outbox", entry.MutationType, "ok")
 	}
 }

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -34,24 +33,9 @@ const (
 
 type quotaOutboxBatchClaimer func(context.Context, time.Time, time.Duration, int) (datastore.QuotaOutboxBatchClaimResult, error)
 
-func (b *Dat9Backend) startQuotaOutboxWorker() {
-	if b.quotaOutboxNotify != nil {
-		return
-	}
-	ctx, cancel := context.WithCancel(context.Background())
-	b.quotaOutboxStop = cancel
-	b.quotaOutboxNotify = make(chan struct{}, quotaOutboxNotifySize)
-	b.quotaOutboxWG.Add(1)
-	go b.runQuotaOutboxWorker(ctx)
-}
-
 func (b *Dat9Backend) stopQuotaOutboxWorker() {
-	if b.quotaOutboxStop != nil {
-		b.quotaOutboxStop()
-		b.quotaOutboxWG.Wait()
-		b.quotaOutboxStop = nil
-		b.quotaOutboxNotify = nil
-	}
+	// Runtime quota accounting no longer starts the tenant quota_outbox worker.
+	// Keep this cleanup hook for legacy tests that explicitly disable it.
 }
 
 func (b *Dat9Backend) notifyQuotaOutbox(enqueued bool) {
@@ -61,28 +45,6 @@ func (b *Dat9Backend) notifyQuotaOutbox(enqueued bool) {
 	select {
 	case b.quotaOutboxNotify <- struct{}{}:
 	default:
-	}
-}
-
-func (b *Dat9Backend) runQuotaOutboxWorker(ctx context.Context) {
-	defer b.quotaOutboxWG.Done()
-
-	ticker := time.NewTicker(quotaOutboxPollInterval)
-	defer ticker.Stop()
-
-	b.processQuotaOutboxAvailable(ctx)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-b.quotaOutboxNotify:
-			if !b.waitQuotaOutboxNotifyQuiet(ctx) {
-				return
-			}
-			b.processQuotaOutboxAvailable(ctx)
-		case <-ticker.C:
-			b.processQuotaOutboxAvailable(ctx)
-		}
 	}
 }
 
@@ -371,7 +333,7 @@ func (b *Dat9Backend) recordAppliedQuotaOutboxEntries(entries []datastore.QuotaO
 		b.quotaUsageCache.invalidate()
 	}
 	for _, entry := range entries {
-		b.addLocalQuotaPendingDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
+		b.addPendingCentralMutationDeltas(-entry.StorageDelta, -entry.FileDelta, -entry.MediaDelta)
 		metrics.RecordTenantOperationCount(b.tenantID, "quota_outbox", entry.MutationType, "ok")
 	}
 }
@@ -438,96 +400,4 @@ func quotaOutboxRetryDelay(attempt int, base, max time.Duration) time.Duration {
 		return max
 	}
 	return delay
-}
-
-func (b *Dat9Backend) enqueueQuotaFileCreateOutboxTx(tx *sql.Tx, fileID string, sizeBytes int64, contentType string) (bool, error) {
-	if !b.UseServerQuota() {
-		return false, nil
-	}
-	isMedia := isQuotaMediaContentType(contentType)
-	data := fileCreateMutationData{
-		FileID:    fileID,
-		SizeBytes: sizeBytes,
-		IsMedia:   isMedia,
-	}
-	raw, err := json.Marshal(data)
-	if err != nil {
-		return false, err
-	}
-	mediaDelta := int64(0)
-	if isMedia {
-		mediaDelta = 1
-	}
-	_, err = b.store.EnqueueQuotaOutboxTx(tx, &datastore.QuotaOutboxEntry{
-		FileID:       fileID,
-		MutationType: quotaMutationTypeFileCreate,
-		MutationData: raw,
-		StorageDelta: sizeBytes,
-		FileDelta:    1,
-		MediaDelta:   mediaDelta,
-	})
-	if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func (b *Dat9Backend) enqueueQuotaUploadCompleteOutboxTx(tx *sql.Tx, uploadID string, reservedBytes int64, fileID string, oldSizeBytes int64, oldIsMedia bool, newSizeBytes int64, newIsMedia bool) (bool, error) {
-	if !b.UseServerQuota() {
-		return false, nil
-	}
-	data := uploadCompleteMutationData{
-		UploadID:      uploadID,
-		FileID:        fileID,
-		ReservedBytes: reservedBytes,
-		OldSizeBytes:  oldSizeBytes,
-		OldIsMedia:    oldIsMedia,
-		NewSizeBytes:  newSizeBytes,
-		NewIsMedia:    newIsMedia,
-	}
-	raw, err := json.Marshal(data)
-	if err != nil {
-		return false, err
-	}
-	_, err = b.store.EnqueueQuotaOutboxTx(tx, &datastore.QuotaOutboxEntry{
-		FileID:       fileID,
-		MutationType: quotaMutationTypeUploadComplete,
-		MutationData: raw,
-	})
-	if err != nil {
-		return false, err
-	}
-	return true, nil
-}
-
-func (b *Dat9Backend) enqueueQuotaFileOverwriteOutboxTx(tx *sql.Tx, fileID string, oldSize int64, oldContentType string, newSize int64, newContentType string) (bool, error) {
-	if !b.UseServerQuota() {
-		return false, nil
-	}
-	oldIsMedia := isQuotaMediaContentType(oldContentType)
-	newIsMedia := isQuotaMediaContentType(newContentType)
-	data := fileOverwriteMutationData{
-		FileID:       fileID,
-		OldSizeBytes: oldSize,
-		OldIsMedia:   oldIsMedia,
-		NewSizeBytes: newSize,
-		NewIsMedia:   newIsMedia,
-	}
-	raw, err := json.Marshal(data)
-	if err != nil {
-		return false, err
-	}
-	mediaDelta := quotaMediaDelta(oldIsMedia, newIsMedia)
-	_, err = b.store.EnqueueQuotaOutboxTx(tx, &datastore.QuotaOutboxEntry{
-		FileID:       fileID,
-		MutationType: quotaMutationTypeOverwrite,
-		MutationData: raw,
-		StorageDelta: newSize - oldSize,
-		FileDelta:    0,
-		MediaDelta:   mediaDelta,
-	})
-	if err != nil {
-		return false, err
-	}
-	return true, nil
 }

--- a/pkg/backend/quota_outbox_worker.go
+++ b/pkg/backend/quota_outbox_worker.go
@@ -376,7 +376,7 @@ func (b *Dat9Backend) applyQuotaOutboxEntryTx(tx *sql.Tx, entry *datastore.Quota
 	}
 	// Reuse the central mutation dispatcher; upload_complete is handled there
 	// by applyUploadCompleteTx, the same body used by mutation replay.
-	return applyCentralQuotaMutationTx(b.metaStore, tx, b.tenantID, entry.MutationType, entry.MutationData, entry.ID)
+	return applyCentralQuotaMutationTx(context.Background(), b.metaStore, tx, b.tenantID, entry.MutationType, entry.MutationData, entry.ID)
 }
 
 func quotaOutboxRetryDelay(attempt int, base, max time.Duration) time.Duration {

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -47,8 +47,9 @@ type MetaQuotaStore interface {
 	InsertUploadReservation(ctx context.Context, r *UploadReservationView) error
 	UpdateUploadReservationStatus(ctx context.Context, tenantID, uploadID, status string) error
 	GetUploadReservation(ctx context.Context, tenantID, uploadID string) (*UploadReservationView, error)
-	UpdateUploadReservationStatusTx(tx *sql.Tx, tenantID, uploadID, status string) error
-	SettleActiveReservationTx(tx *sql.Tx, tenantID, uploadID, status string) (settled bool, fileCountDelta int64, err error)
+	UpdateUploadReservationStatusTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID, status string) error
+	AbortActiveReservationTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID string) (aborted bool, reservedBytes, fileCountDelta int64, err error)
+	SettleActiveReservationTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID, status string) (settled bool, fileCountDelta int64, err error)
 
 	// LLM cost
 	InsertCentralLLMUsage(ctx context.Context, r *LLMUsageView) error

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -137,14 +137,11 @@ func (b *Dat9Backend) SetMetaQuotaStore(ctx context.Context, tenantID string, mq
 				zap.Error(err))
 		}
 	}
-	if mqs != nil && b.quotaSource == QuotaSourceServer {
+	if mqs != nil {
 		b.quotaConfigCache = newQuotaConfigCache(tenantID, mqs)
 		b.quotaUsageCache = newQuotaUsageCache(tenantID, mqs, quotaUsageCacheTTL)
-		if b.store != nil {
-			b.quotaPendingCache = newQuotaPendingDeltasCache(b.tenantID, b.store.PendingQuotaOutboxDeltas, quotaPendingDeltasCacheTTL)
-		}
+		b.quotaPendingCache = newQuotaPendingDeltasCache(b.tenantID, nil, quotaPendingDeltasCacheTTL)
 		b.startMutationWorker()
-		b.startQuotaOutboxWorker()
 	}
 }
 

--- a/pkg/backend/round_a_review_test.go
+++ b/pkg/backend/round_a_review_test.go
@@ -394,10 +394,12 @@ func TestRoundA_Fix4_CompleteUpload_WritesMutationEvenOnTransientPath(t *testing
 	// to prove the apply path does NOT depend on pre-lookup anymore.
 	fake.getReservationErr = errors.New("sim: transient DB error")
 
-	b.completeUploadReservation(context.Background(),
+	if err := b.completeUploadReservation(context.Background(),
 		"u1" /*reservedBytes*/, 50, "file-1",
 		/*oldSize*/ 0 /*oldMedia*/, false,
-		/*newSize*/ 50 /*newMedia*/, true)
+		/*newSize*/ 50 /*newMedia*/, true); err != nil {
+		t.Fatalf("complete upload reservation: %v", err)
+	}
 
 	fake.mu.Lock()
 	defer fake.mu.Unlock()
@@ -426,10 +428,12 @@ func TestRoundA_Fix4_CompleteUpload_WritesMutationEvenOnTransientPath(t *testing
 func TestRoundA_Fix4_CompleteUpload_FailOpenInitiateStillAppliesStorage(t *testing.T) {
 	b, fake := newCentralQuotaBackend(t)
 	// No prior reserve → no reservation row. Simulate fail-open initiate.
-	b.completeUploadReservation(context.Background(),
+	if err := b.completeUploadReservation(context.Background(),
 		"u1" /*reservedBytes*/, 0, "file-1",
 		/*oldSize*/ 0 /*oldMedia*/, false,
-		/*newSize*/ 40 /*newMedia*/, false)
+		/*newSize*/ 40 /*newMedia*/, false); err != nil {
+		t.Fatalf("complete upload reservation: %v", err)
+	}
 
 	u, _ := fake.GetQuotaUsage(context.Background(), "tenant-a")
 	if u.StorageBytes != 40 {
@@ -481,10 +485,12 @@ func TestRoundA_Fix4_CompleteUpload_ApplyAfterReservationSwept(t *testing.T) {
 	// skip the reserved→storage transfer (reserved_bytes already released by
 	// the sweep) but still advance storage_bytes + file_meta for the
 	// confirmed bytes.
-	b.completeUploadReservation(ctx,
+	if err := b.completeUploadReservation(ctx,
 		"u1" /*reservedBytes*/, 50, "file-1",
 		/*oldSize*/ 0 /*oldMedia*/, false,
-		/*newSize*/ 50 /*newMedia*/, true)
+		/*newSize*/ 50 /*newMedia*/, true); err != nil {
+		t.Fatalf("complete upload reservation: %v", err)
+	}
 
 	after, _ := fake.GetQuotaUsage(ctx, "tenant-a")
 	if after.ReservedBytes != 0 {
@@ -533,10 +539,12 @@ func TestRoundA_Fix4_CompleteUpload_ApplyAfterReservationSwept(t *testing.T) {
 func TestRoundA_Fix4_CompleteUpload_MarkAppliedCalledExactlyOnce(t *testing.T) {
 	t.Run("inline_path", func(t *testing.T) {
 		b, fake := newCentralQuotaBackend(t)
-		b.completeUploadReservation(context.Background(),
+		if err := b.completeUploadReservation(context.Background(),
 			"u1" /*reservedBytes*/, 0, "file-1",
 			/*oldSize*/ 0 /*oldMedia*/, false,
-			/*newSize*/ 40 /*newMedia*/, false)
+			/*newSize*/ 40 /*newMedia*/, false); err != nil {
+			t.Fatalf("complete upload reservation: %v", err)
+		}
 		if fake.markAppliedCalls != 1 {
 			t.Fatalf("inline path markAppliedCalls = %d, want exactly 1", fake.markAppliedCalls)
 		}

--- a/pkg/backend/round_a_review_test.go
+++ b/pkg/backend/round_a_review_test.go
@@ -400,6 +400,7 @@ func TestRoundA_Fix4_CompleteUpload_WritesMutationEvenOnTransientPath(t *testing
 		/*newSize*/ 50 /*newMedia*/, true); err != nil {
 		t.Fatalf("complete upload reservation: %v", err)
 	}
+	drainCentralQuotaMutations(t, b)
 
 	fake.mu.Lock()
 	defer fake.mu.Unlock()
@@ -434,6 +435,7 @@ func TestRoundA_Fix4_CompleteUpload_FailOpenInitiateStillAppliesStorage(t *testi
 		/*newSize*/ 40 /*newMedia*/, false); err != nil {
 		t.Fatalf("complete upload reservation: %v", err)
 	}
+	drainCentralQuotaMutations(t, b)
 
 	u, _ := fake.GetQuotaUsage(context.Background(), "tenant-a")
 	if u.StorageBytes != 40 {
@@ -491,6 +493,7 @@ func TestRoundA_Fix4_CompleteUpload_ApplyAfterReservationSwept(t *testing.T) {
 		/*newSize*/ 50 /*newMedia*/, true); err != nil {
 		t.Fatalf("complete upload reservation: %v", err)
 	}
+	drainCentralQuotaMutations(t, b)
 
 	after, _ := fake.GetQuotaUsage(ctx, "tenant-a")
 	if after.ReservedBytes != 0 {
@@ -545,6 +548,7 @@ func TestRoundA_Fix4_CompleteUpload_MarkAppliedCalledExactlyOnce(t *testing.T) {
 			/*newSize*/ 40 /*newMedia*/, false); err != nil {
 			t.Fatalf("complete upload reservation: %v", err)
 		}
+		drainCentralQuotaMutations(t, b)
 		if fake.markAppliedCalls != 1 {
 			t.Fatalf("inline path markAppliedCalls = %d, want exactly 1", fake.markAppliedCalls)
 		}
@@ -613,7 +617,7 @@ func TestRoundA_Fix4_CompleteUpload_MarkAppliedCalledExactlyOnce(t *testing.T) {
 		if err != nil {
 			t.Fatalf("insert: %v", err)
 		}
-		if err := applyUploadCompleteTx(fake, nil, "tenant-a", uploadCompleteMutationData{
+		if err := applyUploadCompleteTx(context.Background(), fake, nil, "tenant-a", uploadCompleteMutationData{
 			UploadID:     "u1",
 			FileID:       "file-1",
 			NewSizeBytes: 40,

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -992,7 +992,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 				zap.String("upload_id", uploadID),
 				zap.Error(err))
 			metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_mark_completing", "error", time.Since(start))
-			return err
+			return fmt.Errorf("mark central quota upload completing: %w", err)
 		}
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_mark_completing", "ok", 0)
 	}
@@ -1000,7 +1000,6 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	completeMultipartStart := time.Now()
 	if err := b.s3.CompleteMultipartUpload(ctx, upload.S3Key, upload.S3UploadID, parts); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_complete_multipart_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		b.abortUploadReservation(ctx, uploadID, upload.TotalSize)
 		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
 		return fmt.Errorf("complete multipart: %w", err)
 	}
@@ -1208,15 +1207,19 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		logger.Error(ctx, "backend_finalize_upload_tx_failed", zap.String("upload_id", uploadID), zap.Error(err))
 		b.cleanupFailedFinalizeUpload(ctx, upload)
 		// Abort the server-side reservation since the tenant DB tx failed.
-		b.abortUploadReservation(ctx, uploadID, upload.TotalSize)
+		cleanupCtx, cancelCleanup := postCommitQuotaMutationContext()
+		b.abortUploadReservation(cleanupCtx, uploadID, upload.TotalSize)
+		cancelCleanup()
 		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
 		return err
 	}
 	txDurationMs := uploadPhaseMs(txStart)
 	b.notifySemanticTaskEnqueued(semanticTaskEnqueued)
-	if err := b.completeUploadReservation(ctx, uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia); err != nil {
+	quotaCtx, cancelQuota := postCommitQuotaMutationContext()
+	defer cancelQuota()
+	if err := b.completeUploadReservation(quotaCtx, uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia); err != nil {
 		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
-		return fmt.Errorf("record central quota upload complete: %w", err)
+		return postCommitQuotaMutationError("record central quota upload complete", err)
 	}
 
 	if isOverwrite {

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -1000,6 +1000,19 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	completeMultipartStart := time.Now()
 	if err := b.s3.CompleteMultipartUpload(ctx, upload.S3Key, upload.S3UploadID, parts); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_complete_multipart_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		if b.UseServerQuota() {
+			cleanupCtx, cancelCleanup := postCommitQuotaMutationContext()
+			if resetErr := b.metaStore.UpdateUploadReservationStatus(cleanupCtx, b.tenantID, uploadID, "active"); resetErr != nil {
+				logger.Warn(cleanupCtx, "central_quota_upload_reset_active_failed",
+					zap.String("tenant_id", b.tenantID),
+					zap.String("upload_id", uploadID),
+					zap.Error(resetErr))
+				metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_reset_active", "error", time.Since(start))
+			} else {
+				metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_reset_active", "ok", time.Since(start))
+			}
+			cancelCleanup()
+		}
 		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
 		return fmt.Errorf("complete multipart: %w", err)
 	}

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -985,10 +985,22 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		return err
 	}
 	expectedRevision := uploadExpectedRevision(upload)
+	if b.UseServerQuota() {
+		if err := b.metaStore.UpdateUploadReservationStatus(ctx, b.tenantID, uploadID, "completing"); err != nil {
+			logger.Warn(ctx, "central_quota_upload_mark_completing_failed",
+				zap.String("tenant_id", b.tenantID),
+				zap.String("upload_id", uploadID),
+				zap.Error(err))
+			metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_mark_completing", "error", time.Since(start))
+			return err
+		}
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_mark_completing", "ok", 0)
+	}
 
 	completeMultipartStart := time.Now()
 	if err := b.s3.CompleteMultipartUpload(ctx, upload.S3Key, upload.S3UploadID, parts); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_complete_multipart_failed", zap.String("upload_id", uploadID), zap.Error(err))
+		b.abortUploadReservation(ctx, uploadID, upload.TotalSize)
 		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
 		return fmt.Errorf("complete multipart: %w", err)
 	}
@@ -1015,19 +1027,6 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	var insertNodeDurationMs float64
 	var semanticEnqueueDurationMs float64
 	var semanticTaskEnqueued bool
-	var quotaOutboxEnqueued bool
-	// upload.TotalSize is immutable from the upload row. The old* fields and
-	// confirmedFileID are refreshed inside each InTx attempt after locking the
-	// target node/file, then consumed by this same transaction's outbox enqueue.
-	enqueueUploadCompleteOutbox := func(tx *sql.Tx) error {
-		created, err := b.enqueueQuotaUploadCompleteOutboxTx(tx,
-			uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia)
-		if err != nil {
-			return err
-		}
-		quotaOutboxEnqueued = created
-		return nil
-	}
 	enqueueUploadSemanticTasks := func(tx *sql.Tx, mediaDelta int64) error {
 		stepStart := time.Now()
 		if b.UsesDatabaseAutoEmbedding() {
@@ -1055,7 +1054,6 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	}
 	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
 		semanticTaskEnqueued = false
-		quotaOutboxEnqueued = false
 		oldStorageRef = ""
 		oldStorageType = ""
 		oldContentType = ""
@@ -1205,7 +1203,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 				return err
 			}
 		}
-		return enqueueUploadCompleteOutbox(tx)
+		return nil
 	}); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_tx_failed", zap.String("upload_id", uploadID), zap.Error(err))
 		b.cleanupFailedFinalizeUpload(ctx, upload)
@@ -1216,19 +1214,9 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	}
 	txDurationMs := uploadPhaseMs(txStart)
 	b.notifySemanticTaskEnqueued(semanticTaskEnqueued)
-	b.notifyQuotaOutbox(quotaOutboxEnqueued)
-
-	if !quotaOutboxEnqueued {
-		if b.UseServerQuota() {
-			logger.Error(ctx, "upload_complete_quota_accounting_skipped",
-				zap.String("tenant_id", b.tenantID),
-				zap.String("upload_id", uploadID),
-				zap.String("file_id", confirmedFileID))
-		}
-		// Preserve the non-outbox path when central quota is wired without
-		// server-quota mode; server quota uses the tenant-local outbox so
-		// upload completion is ordered with prior mutations for the same file.
-		b.completeUploadReservation(ctx, uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia)
+	if err := b.completeUploadReservation(ctx, uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia); err != nil {
+		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
+		return fmt.Errorf("record central quota upload complete: %w", err)
 	}
 
 	if isOverwrite {

--- a/pkg/backend/upload_reservation.go
+++ b/pkg/backend/upload_reservation.go
@@ -62,6 +62,8 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 		Status:         "active",
 		ExpiresAt:      time.Now().Add(24 * time.Hour),
 	}
+	// Hold mutationMu across the pending-delta check and atomic reserve so
+	// same-backend post-commit quota mutations cannot slip between them.
 	b.mutationMu.Lock()
 	defer b.mutationMu.Unlock()
 	if err := b.ensureUploadReserveFitsPendingQuota(ctx, totalSize, fileCountDelta); err != nil {

--- a/pkg/backend/upload_reservation.go
+++ b/pkg/backend/upload_reservation.go
@@ -14,13 +14,14 @@ import (
 	"go.uber.org/zap"
 )
 
-// --- Server-first saga: upload initiate reservation ---
+// --- Meta-first saga: upload initiate reservation ---
 
-// reserveUploadOnServer performs the server-reserve-first protocol for an
-// upload via a single server-DB transaction: AtomicReserveAndInsertUpload
-// claims reserved_bytes and inserts the reservation row atomically. Either
-// both rows are written or neither is; there is no compensating path that
-// can leak reserved_bytes.
+// reserveUploadOnServer performs the central reserve-first protocol for an
+// upload using only the meta DB. AtomicReserveAndInsertUpload claims
+// reserved_bytes and inserts the reservation row atomically in the meta DB.
+// Either both rows are written or neither is; there is no compensating path that
+// can leak reserved_bytes. This intentionally does not take the legacy tenant DB
+// quota_admission_locks row.
 //
 // Return semantics:
 //   - (true, nil):  reservation successfully claimed on the server DB.
@@ -62,42 +63,11 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 		Status:         "active",
 		ExpiresAt:      time.Now().Add(24 * time.Hour),
 	}
-	duplicate := false
-	centralReserved := false
-	err := b.store.InTx(ctx, func(tx *sql.Tx) error {
-		if err := b.lockQuotaAdmissionTx(ctx, tx); err != nil {
-			return err
-		}
-		if _, err := b.metaStore.GetUploadReservation(ctx, b.tenantID, uploadID); err == nil {
-			duplicate = true
-			return nil
-		} else if err != nil && !errors.Is(err, ErrReservationNotFound) {
-			return err
-		}
-		if err := b.ensureUploadReserveFitsPendingQuotaTx(ctx, tx, totalSize, fileCountDelta); err != nil {
-			return err
-		}
-		if err := b.metaStore.AtomicReserveAndInsertUpload(ctx, reservation); err != nil {
-			return err
-		}
-		centralReserved = true
-		return nil
-	})
-	if duplicate {
-		logger.Info(ctx, "central_quota_reserve_upload_duplicate",
-			zap.String("tenant_id", b.tenantID),
-			zap.String("upload_id", uploadID))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "duplicate", time.Since(start))
-		return true, nil
+	if err := b.ensureUploadReserveFitsPendingQuota(ctx, totalSize, fileCountDelta); err != nil {
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
+		return false, err
 	}
-	if err != nil && centralReserved {
-		logger.Warn(ctx, "central_quota_reserve_upload_tenant_lock_commit_failed",
-			zap.String("tenant_id", b.tenantID),
-			zap.String("upload_id", uploadID),
-			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "ok_lock_commit_failed", time.Since(start))
-		return true, nil
-	}
+	err := b.metaStore.AtomicReserveAndInsertUpload(ctx, reservation)
 	switch {
 	case err == nil:
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "ok", time.Since(start))
@@ -128,7 +98,7 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 	}
 }
 
-func (b *Dat9Backend) ensureUploadReserveFitsPendingQuotaTx(ctx context.Context, tx *sql.Tx, totalSize, fileCountDelta int64) error {
+func (b *Dat9Backend) ensureUploadReserveFitsPendingQuota(ctx context.Context, totalSize, fileCountDelta int64) error {
 	if !b.UseServerQuota() || (totalSize <= 0 && fileCountDelta <= 0) {
 		return nil
 	}
@@ -145,11 +115,7 @@ func (b *Dat9Backend) ensureUploadReserveFitsPendingQuotaTx(ctx context.Context,
 		metrics.RecordTenantOperation(b.tenantID, "server_quota", "upload_reserve_pending_check", "fail_open", 0)
 		return nil
 	}
-	pendingStorageDelta, pendingFileDelta, _, pendingOK := b.livePendingQuotaOutboxDeltasTx(ctx, tx)
-	if !pendingOK {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "upload_reserve_pending_check", "fail_open", 0)
-		return nil
-	}
+	pendingStorageDelta, pendingFileDelta, _ := b.pendingCentralMutationDeltas(ctx)
 	projected := usage.StorageBytes + usage.ReservedBytes + pendingStorageDelta + totalSize
 	if cfg.MaxStorageBytes > 0 && projected > cfg.MaxStorageBytes {
 		return fmt.Errorf("%w: server limit=%d used=%d reserved=%d pending=%d delta=%d",
@@ -166,8 +132,8 @@ func (b *Dat9Backend) ensureUploadReserveFitsPendingQuotaTx(ctx context.Context,
 // --- Upload abort: release reservation ---
 
 // abortUploadReservation is called after a tenant-DB upload abort.
-// It releases the reserved_bytes back to the pool. Only adjusts counters
-// if a server-side reservation row exists and is active, preventing
+// It releases the reserved_bytes back to the pool. Only adjusts counters if a
+// server-side reservation row exists and is active/completing, preventing
 // counter corruption when the initiate-time reserve was a fail-open no-op.
 func (b *Dat9Backend) abortUploadReservation(ctx context.Context, uploadID string, totalSize int64) {
 	if b.metaStore == nil {
@@ -175,7 +141,7 @@ func (b *Dat9Backend) abortUploadReservation(ctx context.Context, uploadID strin
 	}
 	start := time.Now()
 
-	// Check if a reservation row actually exists and is active.
+	// Check if a reservation row actually exists and can still be released.
 	r, err := b.metaStore.GetUploadReservation(ctx, b.tenantID, uploadID)
 	if errors.Is(err, ErrReservationNotFound) {
 		// No reservation row — initiate was a fail-open no-op; nothing to release.
@@ -191,7 +157,7 @@ func (b *Dat9Backend) abortUploadReservation(ctx context.Context, uploadID strin
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "lookup_error", time.Since(start))
 		return
 	}
-	if r.Status != "active" {
+	if r.Status != "active" && r.Status != "completing" {
 		// Already completed or aborted — nothing to release.
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "skip_no_reservation", time.Since(start))
 		return
@@ -247,9 +213,9 @@ type uploadCompleteMutationData struct {
 // actually found (settled=true). When no active row exists (fail-open
 // initiate or already-completed), the transfer is skipped so counters stay
 // consistent.
-func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID string, reservedBytes int64, fileID string, oldSizeBytes int64, oldIsMedia bool, newSizeBytes int64, newIsMedia bool) {
+func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID string, reservedBytes int64, fileID string, oldSizeBytes int64, oldIsMedia bool, newSizeBytes int64, newIsMedia bool) error {
 	if b.metaStore == nil {
-		return
+		return nil
 	}
 	start := time.Now()
 
@@ -267,7 +233,7 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID),
 			zap.Error(err))
-		return
+		return err
 	}
 	logID, err := b.metaStore.InsertMutationLog(ctx, &MutationLogView{
 		TenantID:     b.tenantID,
@@ -279,8 +245,8 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID),
 			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_complete", "fail_open", time.Since(start))
-		return
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_complete", "log_error", time.Since(start))
+		return err
 	}
 	if err := b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
 		if err := applyUploadCompleteTx(b.metaStore, tx, b.tenantID, uploadCompleteMutationData{
@@ -304,9 +270,10 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_complete", "pending", time.Since(start))
 		// Leave entry in 'pending' — replay worker will retry inside
 		// applyUploadCompleteTx with the same reservation-state decision.
-		return
+		return nil
 	}
 	metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_complete", "ok", time.Since(start))
+	return nil
 }
 
 // applyUploadCompleteTx is the single tx-scoped apply body shared by both

--- a/pkg/backend/upload_reservation.go
+++ b/pkg/backend/upload_reservation.go
@@ -3,7 +3,6 @@ package backend
 import (
 	"context"
 	"database/sql"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -63,6 +62,8 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 		Status:         "active",
 		ExpiresAt:      time.Now().Add(24 * time.Hour),
 	}
+	b.mutationMu.Lock()
+	defer b.mutationMu.Unlock()
 	if err := b.ensureUploadReserveFitsPendingQuota(ctx, totalSize, fileCountDelta); err != nil {
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
 		return false, err
@@ -141,45 +142,35 @@ func (b *Dat9Backend) abortUploadReservation(ctx context.Context, uploadID strin
 	}
 	start := time.Now()
 
-	// Check if a reservation row actually exists and can still be released.
-	r, err := b.metaStore.GetUploadReservation(ctx, b.tenantID, uploadID)
-	if errors.Is(err, ErrReservationNotFound) {
-		// No reservation row — initiate was a fail-open no-op; nothing to release.
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "skip_no_reservation", time.Since(start))
-		return
-	}
-	if err != nil {
-		// Transient DB error — don't touch counters to avoid corruption.
-		logger.Warn(ctx, "central_quota_abort_lookup_failed",
-			zap.String("tenant_id", b.tenantID),
-			zap.String("upload_id", uploadID),
-			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "lookup_error", time.Since(start))
-		return
-	}
-	if r.Status != "active" && r.Status != "completing" {
-		// Already completed or aborted — nothing to release.
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "skip_no_reservation", time.Since(start))
-		return
-	}
-
-	// Atomically release reserved bytes and mark reservation aborted.
+	aborted := false
 	if err := b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
-		if err := b.metaStore.IncrReservedBytesTx(tx, b.tenantID, -r.ReservedBytes); err != nil {
+		ok, reservedBytes, fileCountDelta, err := b.metaStore.AbortActiveReservationTx(ctx, tx, b.tenantID, uploadID)
+		if err != nil {
 			return err
 		}
-		if r.FileCountDelta > 0 {
-			if err := b.metaStore.IncrFileCountTx(tx, b.tenantID, -r.FileCountDelta); err != nil {
+		if !ok {
+			return nil
+		}
+		aborted = true
+		if err := b.metaStore.IncrReservedBytesTx(tx, b.tenantID, -reservedBytes); err != nil {
+			return err
+		}
+		if fileCountDelta > 0 {
+			if err := b.metaStore.IncrFileCountTx(tx, b.tenantID, -fileCountDelta); err != nil {
 				return err
 			}
 		}
-		return b.metaStore.UpdateUploadReservationStatusTx(tx, b.tenantID, uploadID, "aborted")
+		return nil
 	}); err != nil {
 		logger.Warn(ctx, "central_quota_abort_failed",
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID),
 			zap.Error(err))
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "error", time.Since(start))
+		return
+	}
+	if !aborted {
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "skip_no_reservation", time.Since(start))
 		return
 	}
 
@@ -198,15 +189,16 @@ type uploadCompleteMutationData struct {
 	NewIsMedia    bool   `json:"new_is_media"`
 }
 
-// completeUploadReservation applies the upload-complete saga in mutation-first
-// style. The reservation-state decision ("is this reservation still active?
-// should reserved_bytes be transferred?") is made INSIDE the apply/replay
-// transaction via SettleActiveReservationTx, not by a pre-check outside the
-// tx. This guarantees the durable-outbox contract: the mutation log entry is
-// always written (unless InsertMutationLog itself fails), so storage_bytes,
-// file_meta, and media_count deltas cannot be silently dropped by a transient
-// lookup error. Any transient failure during the initial apply attempt leaves
-// the mutation in 'pending' status for the replay worker.
+// completeUploadReservation logs and enqueues the upload-complete saga through
+// the same ordered mutation queue as create/overwrite. The reservation-state
+// decision ("is this reservation still active? should reserved_bytes be
+// transferred?") is made INSIDE the apply/replay transaction via
+// SettleActiveReservationTx, not by a pre-check outside the tx. This guarantees
+// the durable-outbox contract: the mutation log entry is always written (unless
+// InsertMutationLog itself fails), so storage_bytes, file_meta, and media_count
+// deltas cannot be silently dropped by a transient lookup error. Any transient
+// failure during async apply leaves the mutation in 'pending' status for the
+// replay worker.
 //
 // reservedBytes is the bytes that were claimed at initiate time; the apply tx
 // will transfer them reserved→storage only when an active reservation row is
@@ -217,9 +209,7 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 	if b.metaStore == nil {
 		return nil
 	}
-	start := time.Now()
-
-	data, err := json.Marshal(uploadCompleteMutationData{
+	data := uploadCompleteMutationData{
 		UploadID:      uploadID,
 		FileID:        fileID,
 		ReservedBytes: reservedBytes,
@@ -227,60 +217,17 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 		OldIsMedia:    oldIsMedia,
 		NewSizeBytes:  newSizeBytes,
 		NewIsMedia:    newIsMedia,
+	}
+	return b.logAndEnqueueMutation(ctx, "upload_complete", data, quotaPendingDeltas{}, func(applyCtx context.Context, tx *sql.Tx) error {
+		return applyUploadCompleteTx(applyCtx, b.metaStore, tx, b.tenantID, data)
 	})
-	if err != nil {
-		logger.Warn(ctx, "central_quota_upload_complete_marshal_failed",
-			zap.String("tenant_id", b.tenantID),
-			zap.String("upload_id", uploadID),
-			zap.Error(err))
-		return err
-	}
-	logID, err := b.metaStore.InsertMutationLog(ctx, &MutationLogView{
-		TenantID:     b.tenantID,
-		MutationType: "upload_complete",
-		MutationData: data,
-	})
-	if err != nil {
-		logger.Warn(ctx, "central_quota_mutation_log_insert_failed",
-			zap.String("tenant_id", b.tenantID),
-			zap.String("upload_id", uploadID),
-			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_complete", "log_error", time.Since(start))
-		return err
-	}
-	if err := b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
-		if err := applyUploadCompleteTx(b.metaStore, tx, b.tenantID, uploadCompleteMutationData{
-			UploadID:      uploadID,
-			FileID:        fileID,
-			ReservedBytes: reservedBytes,
-			OldSizeBytes:  oldSizeBytes,
-			OldIsMedia:    oldIsMedia,
-			NewSizeBytes:  newSizeBytes,
-			NewIsMedia:    newIsMedia,
-		}); err != nil {
-			return err
-		}
-		return b.metaStore.MarkMutationAppliedTx(tx, logID)
-	}); err != nil {
-		logger.Warn(ctx, "central_quota_upload_complete_apply_failed",
-			zap.String("tenant_id", b.tenantID),
-			zap.String("upload_id", uploadID),
-			zap.Int64("log_id", logID),
-			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_complete", "pending", time.Since(start))
-		// Leave entry in 'pending' — replay worker will retry inside
-		// applyUploadCompleteTx with the same reservation-state decision.
-		return nil
-	}
-	metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_complete", "ok", time.Since(start))
-	return nil
 }
 
-// applyUploadCompleteTx is the single tx-scoped apply body shared by both
-// the inline fast path (completeUploadReservation) and the replay worker
-// (mutation_replay.go upload_complete case). The reservation-state branch
-// lives here (inside the tx) so that transient lookup failures outside
-// never cause silent data loss of the paired shadow-state mutation.
+// applyUploadCompleteTx is the single tx-scoped apply body shared by both the
+// backend mutation worker and the replay worker (mutation_replay.go
+// upload_complete case). The reservation-state branch lives here (inside the
+// tx) so that transient lookup failures outside never cause silent data loss of
+// the paired shadow-state mutation.
 //
 // The settled flag from SettleActiveReservationTx partitions the
 // reservation-state space into exactly two branches:
@@ -315,7 +262,7 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 // replay path calls it inside replayOne. Keeping the mark-applied call out
 // of this helper prevents a double-mark rollback trap if any future caller
 // also marks applied in the outer tx.
-func applyUploadCompleteTx(store MetaQuotaStore, tx *sql.Tx, tenantID string, data uploadCompleteMutationData) error {
+func applyUploadCompleteTx(ctx context.Context, store MetaQuotaStore, tx *sql.Tx, tenantID string, data uploadCompleteMutationData) error {
 	mediaDelta := int64(0)
 	switch {
 	case !data.OldIsMedia && data.NewIsMedia:
@@ -333,7 +280,7 @@ func applyUploadCompleteTx(store MetaQuotaStore, tx *sql.Tx, tenantID string, da
 		oldExists = true
 		oldMeta = old
 	}
-	settled, reservedFileCountDelta, err := store.SettleActiveReservationTx(tx, tenantID, data.UploadID, "completed")
+	settled, reservedFileCountDelta, err := store.SettleActiveReservationTx(ctx, tx, tenantID, data.UploadID, "completed")
 	if err != nil {
 		return err
 	}

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -678,11 +678,39 @@ func (s *Store) UpdateUploadReservationStatus(ctx context.Context, tenantID, upl
 }
 
 // UpdateUploadReservationStatusTx updates a reservation's status inside a transaction.
-func (s *Store) UpdateUploadReservationStatusTx(tx *sql.Tx, tenantID, uploadID, status string) error {
-	_, err := tx.Exec(
+func (s *Store) UpdateUploadReservationStatusTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID, status string) error {
+	_, err := tx.ExecContext(ctx,
 		`UPDATE tenant_upload_reservations SET status = ? WHERE tenant_id = ? AND upload_id = ? AND status IN ('active', 'completing')`,
 		status, tenantID, uploadID)
 	return err
+}
+
+// AbortActiveReservationTx atomically claims an active/completing reservation
+// for abort and reports the counters that must be released by the caller in the
+// same transaction.
+func (s *Store) AbortActiveReservationTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID string) (aborted bool, reservedBytes, fileCountDelta int64, err error) {
+	var bytes, files sql.NullInt64
+	if err := tx.QueryRowContext(ctx,
+		`SELECT reserved_bytes, file_count_delta FROM tenant_upload_reservations
+		 WHERE tenant_id = ? AND upload_id = ? AND status IN ('active', 'completing') FOR UPDATE`,
+		tenantID, uploadID).Scan(&bytes, &files); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return false, 0, 0, nil
+		}
+		return false, 0, 0, err
+	}
+	res, err := tx.ExecContext(ctx,
+		`UPDATE tenant_upload_reservations SET status = 'aborted'
+		 WHERE tenant_id = ? AND upload_id = ? AND status IN ('active', 'completing')`,
+		tenantID, uploadID)
+	if err != nil {
+		return false, 0, 0, err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return false, 0, 0, nil
+	}
+	return true, bytes.Int64, files.Int64, nil
 }
 
 // SettleActiveReservationTx transitions a reservation from 'active' to the
@@ -705,9 +733,9 @@ func (s *Store) UpdateUploadReservationStatusTx(tx *sql.Tx, tenantID, uploadID, 
 //   - Transient error: we cannot tell whether a reservation exists, so we
 //     would otherwise have to bail out and silently drop the paired mutation.
 //   - TOCTOU: between lookup and apply another worker could settle the row.
-func (s *Store) SettleActiveReservationTx(tx *sql.Tx, tenantID, uploadID, status string) (settled bool, fileCountDelta int64, err error) {
+func (s *Store) SettleActiveReservationTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID, status string) (settled bool, fileCountDelta int64, err error) {
 	var delta sql.NullInt64
-	if err := tx.QueryRow(
+	if err := tx.QueryRowContext(ctx,
 		`SELECT file_count_delta FROM tenant_upload_reservations
 		 WHERE tenant_id = ? AND upload_id = ? AND status IN ('active', 'completing') FOR UPDATE`,
 		tenantID, uploadID).Scan(&delta); err != nil {
@@ -716,7 +744,7 @@ func (s *Store) SettleActiveReservationTx(tx *sql.Tx, tenantID, uploadID, status
 		}
 		return false, 0, err
 	}
-	res, err := tx.Exec(
+	res, err := tx.ExecContext(ctx,
 		`UPDATE tenant_upload_reservations SET status = ? WHERE tenant_id = ? AND upload_id = ? AND status IN ('active', 'completing')`,
 		status, tenantID, uploadID)
 	if err != nil {
@@ -760,7 +788,7 @@ func (s *Store) HasActiveUploadReservations(ctx context.Context, tenantID string
 	err = s.db.QueryRowContext(ctx,
 		`SELECT 1
 		 FROM tenant_upload_reservations
-		 WHERE tenant_id = ? AND status = 'active' AND expires_at > ?
+		 WHERE tenant_id = ? AND status IN ('active', 'completing') AND expires_at > ?
 		 LIMIT 1`, tenantID, time.Now().UTC()).Scan(&one)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
@@ -780,7 +808,7 @@ func (s *Store) AbortActiveUploadReservations(ctx context.Context, tenantID stri
 		if err := tx.QueryRowContext(ctx,
 			`SELECT COALESCE(SUM(reserved_bytes), 0), COALESCE(SUM(file_count_delta), 0)
 			 FROM tenant_upload_reservations
-			 WHERE tenant_id = ? AND status = 'active'`, tenantID).Scan(&totalBytes, &totalFiles); err != nil {
+			 WHERE tenant_id = ? AND status IN ('active', 'completing')`, tenantID).Scan(&totalBytes, &totalFiles); err != nil {
 			return err
 		}
 		if totalBytes.Int64 != 0 || totalFiles.Int64 != 0 {
@@ -798,16 +826,18 @@ func (s *Store) AbortActiveUploadReservations(ctx context.Context, tenantID stri
 		}
 		_, err := tx.ExecContext(ctx,
 			`UPDATE tenant_upload_reservations SET status = 'aborted'
-			 WHERE tenant_id = ? AND status = 'active'`, tenantID)
+			 WHERE tenant_id = ? AND status IN ('active', 'completing')`, tenantID)
 		return err
 	})
 	return err
 }
 
-// ExpireActiveReservations marks expired active reservations as aborted and
-// returns the total bytes released. This is called by the expiry sweep worker.
-// All changes are applied in a single transaction to prevent double-release
-// if the process crashes mid-sweep.
+// ExpireActiveReservations marks expired active/completing reservations as
+// aborted and returns the total bytes released. This is called by the expiry
+// sweep worker. All changes are applied in a single transaction to prevent
+// double-release if the process crashes mid-sweep. Completing reservations are
+// included so a crash after mark-completing but before finalize settle does not
+// leak reserved_bytes forever.
 func (s *Store) ExpireActiveReservations(ctx context.Context) (int64, error) {
 	start := time.Now()
 	var err error
@@ -821,7 +851,7 @@ func (s *Store) ExpireActiveReservations(ctx context.Context) (int64, error) {
 		rows, err := tx.QueryContext(ctx,
 			`SELECT tenant_id, SUM(reserved_bytes), SUM(file_count_delta)
 			 FROM tenant_upload_reservations
-			 WHERE status = 'active' AND expires_at < ?
+			 WHERE status IN ('active', 'completing') AND expires_at < ?
 			 GROUP BY tenant_id`, now)
 		if err != nil {
 			return err
@@ -863,7 +893,7 @@ func (s *Store) ExpireActiveReservations(ctx context.Context) (int64, error) {
 
 		_, err = tx.ExecContext(ctx,
 			`UPDATE tenant_upload_reservations SET status = 'aborted'
-			 WHERE status = 'active' AND expires_at < ?`, now)
+			 WHERE status IN ('active', 'completing') AND expires_at < ?`, now)
 		return err
 	})
 	return totalReleased, err

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -672,7 +672,7 @@ func (s *Store) UpdateUploadReservationStatus(ctx context.Context, tenantID, upl
 	defer observeMeta(ctx, "update_upload_reservation_status", start, &err)
 
 	_, err = s.db.ExecContext(ctx,
-		`UPDATE tenant_upload_reservations SET status = ? WHERE tenant_id = ? AND upload_id = ? AND status = 'active'`,
+		`UPDATE tenant_upload_reservations SET status = ? WHERE tenant_id = ? AND upload_id = ? AND status IN ('active', 'completing')`,
 		status, tenantID, uploadID)
 	return err
 }
@@ -680,7 +680,7 @@ func (s *Store) UpdateUploadReservationStatus(ctx context.Context, tenantID, upl
 // UpdateUploadReservationStatusTx updates a reservation's status inside a transaction.
 func (s *Store) UpdateUploadReservationStatusTx(tx *sql.Tx, tenantID, uploadID, status string) error {
 	_, err := tx.Exec(
-		`UPDATE tenant_upload_reservations SET status = ? WHERE tenant_id = ? AND upload_id = ? AND status = 'active'`,
+		`UPDATE tenant_upload_reservations SET status = ? WHERE tenant_id = ? AND upload_id = ? AND status IN ('active', 'completing')`,
 		status, tenantID, uploadID)
 	return err
 }
@@ -709,7 +709,7 @@ func (s *Store) SettleActiveReservationTx(tx *sql.Tx, tenantID, uploadID, status
 	var delta sql.NullInt64
 	if err := tx.QueryRow(
 		`SELECT file_count_delta FROM tenant_upload_reservations
-		 WHERE tenant_id = ? AND upload_id = ? AND status = 'active' FOR UPDATE`,
+		 WHERE tenant_id = ? AND upload_id = ? AND status IN ('active', 'completing') FOR UPDATE`,
 		tenantID, uploadID).Scan(&delta); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, 0, nil
@@ -717,7 +717,7 @@ func (s *Store) SettleActiveReservationTx(tx *sql.Tx, tenantID, uploadID, status
 		return false, 0, err
 	}
 	res, err := tx.Exec(
-		`UPDATE tenant_upload_reservations SET status = ? WHERE tenant_id = ? AND upload_id = ? AND status = 'active'`,
+		`UPDATE tenant_upload_reservations SET status = ? WHERE tenant_id = ? AND upload_id = ? AND status IN ('active', 'completing')`,
 		status, tenantID, uploadID)
 	if err != nil {
 		return false, 0, err

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -13,9 +13,9 @@ const (
 	defaultMetaConnMaxIdleTime       = 45 * time.Second
 	defaultMetaMaxOpenConns          = 100
 	defaultMetaMaxIdleConns          = 20
-	defaultUserConnMaxLifetime       = 45 * time.Second
+	defaultUserConnMaxLifetime       = 30 * time.Second
 	defaultUserConnMaxIdleTime       = 30 * time.Second
-	defaultUserMaxOpenConns          = 6
+	defaultUserMaxOpenConns          = 4
 	defaultUserMaxIdleConns          = 1
 	defaultUserSchemaConnMaxLifetime = 1 * time.Minute
 	defaultUserSchemaConnMaxIdleTime = 10 * time.Second

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -13,9 +13,9 @@ const (
 	defaultMetaConnMaxIdleTime       = 45 * time.Second
 	defaultMetaMaxOpenConns          = 100
 	defaultMetaMaxIdleConns          = 20
-	defaultUserConnMaxLifetime       = 30 * time.Second
+	defaultUserConnMaxLifetime       = 45 * time.Second
 	defaultUserConnMaxIdleTime       = 30 * time.Second
-	defaultUserMaxOpenConns          = 4
+	defaultUserMaxOpenConns          = 6
 	defaultUserMaxIdleConns          = 1
 	defaultUserSchemaConnMaxLifetime = 1 * time.Minute
 	defaultUserSchemaConnMaxIdleTime = 10 * time.Second

--- a/pkg/tenant/quota_adapter.go
+++ b/pkg/tenant/quota_adapter.go
@@ -198,12 +198,16 @@ func (a *metaQuotaAdapter) UpdateUploadReservationStatus(ctx context.Context, te
 	return a.s.UpdateUploadReservationStatus(ctx, tenantID, uploadID, status)
 }
 
-func (a *metaQuotaAdapter) UpdateUploadReservationStatusTx(tx *sql.Tx, tenantID, uploadID, status string) error {
-	return a.s.UpdateUploadReservationStatusTx(tx, tenantID, uploadID, status)
+func (a *metaQuotaAdapter) UpdateUploadReservationStatusTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID, status string) error {
+	return a.s.UpdateUploadReservationStatusTx(ctx, tx, tenantID, uploadID, status)
 }
 
-func (a *metaQuotaAdapter) SettleActiveReservationTx(tx *sql.Tx, tenantID, uploadID, status string) (bool, int64, error) {
-	return a.s.SettleActiveReservationTx(tx, tenantID, uploadID, status)
+func (a *metaQuotaAdapter) AbortActiveReservationTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID string) (bool, int64, int64, error) {
+	return a.s.AbortActiveReservationTx(ctx, tx, tenantID, uploadID)
+}
+
+func (a *metaQuotaAdapter) SettleActiveReservationTx(ctx context.Context, tx *sql.Tx, tenantID, uploadID, status string) (bool, int64, error) {
+	return a.s.SettleActiveReservationTx(ctx, tx, tenantID, uploadID, status)
 }
 
 func (a *metaQuotaAdapter) GetUploadReservation(ctx context.Context, tenantID, uploadID string) (*backend.UploadReservationView, error) {


### PR DESCRIPTION
## Summary

- route runtime quota accounting through the meta DB `quota_mutation_log` path instead of tenant/user DB `quota_outbox`
- remove `DRIVE9_QUOTA_SOURCE`; central quota is active when a meta quota store is wired
- stop starting the tenant quota outbox worker at runtime and stop enqueueing outbox rows from create/overwrite/upload-complete paths
- make meta quota mutation log insert failures surface as errors instead of fail-open drops
- switch upload reservation to a pure meta DB reserve-first path and protect finalize with the `completing` status
- update replay cadence knobs and document the accepted post-tenant-commit/pre-meta-log crash window

## Correctness note

This intentionally does not claim durable equivalence with the old tenant outbox. Runtime quota accounting no longer touches the user DB, but a process crash after tenant commit and before meta `quota_mutation_log` insert can still require reconciliation/backfill. Meta log insert failure is now visible to callers and metrics instead of being silently dropped.

## Tests

- `make lint`
- `go test ./pkg/backend ./pkg/meta ./pkg/tenant ./cmd/drive9-server ./cmd/drive9-server-local -count=1`
- `go test ./... -count=1`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Central quota runtime now runs through the meta database with durable mutation logging and background replay to converge usage.
  * Upload reservations now use an intermediate **“completing”** state to improve end-to-end reservation/settlement behavior.

* **Bug Fixes**
  * Startup now fails fast if the deprecated quota-source environment setting is present (removed from runtime/help flows).
  * Quota replay timing is now configurable, and quota mutation error handling is more robust.

* **Documentation**
  * Updated local setup, server help, and central-quota cutover/e2e guidance to reflect the meta-based configuration path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->