### PR TITLE
feat: add paginated fs listing

### DIFF
--- a/examples/go-sdk-cookbook/cookbook_test.go
+++ b/examples/go-sdk-cookbook/cookbook_test.go
@@ -73,6 +73,10 @@ func ExampleClient_filesystemCRUDAndMetadata() {
 
 	_, _ = c.List("/workspace/")
 	_, _ = c.ListCtx(ctx, "/workspace/")
+	page, err := c.ListPage("/workspace/", 100, "")
+	if err == nil && page.NextCursor != "" {
+		_, _ = c.ListPageCtx(ctx, "/workspace/", 100, page.NextCursor)
+	}
 	_, _ = c.BatchStatCtx(ctx, []string{"/workspace/a.txt", "/workspace/b.txt"})
 	_, _ = c.BatchReadSmallCtx(ctx, []string{"/workspace/a.txt"}, 1<<20)
 
@@ -497,6 +501,8 @@ var coveredClientMethods = map[string]bool{
 	"IssueVaultToken":                      true,
 	"List":                                 true,
 	"ListCtx":                              true,
+	"ListPage":                             true,
+	"ListPageCtx":                          true,
 	"ListFSLayerEvents":                    true,
 	"ListFSLayers":                         true,
 	"ListGitObjectPacks":                   true,

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -1310,6 +1310,17 @@ func (b *Dat9Backend) ReadDir(path string) ([]filesystem.FileInfo, error) {
 }
 
 func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []filesystem.FileInfo, err error) {
+	return b.readDirCtx(ctx, path, "", 0)
+}
+
+func (b *Dat9Backend) ReadDirPageCtx(ctx context.Context, path, afterName string, limit int) (infos []filesystem.FileInfo, err error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("read dir page limit must be positive")
+	}
+	return b.readDirCtx(ctx, path, afterName, limit)
+}
+
+func (b *Dat9Backend) readDirCtx(ctx context.Context, path, afterName string, limit int) (infos []filesystem.FileInfo, err error) {
 	start := time.Now()
 	var canonicalPath string
 	var listDuration time.Duration
@@ -1318,6 +1329,8 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 		fields := []zap.Field{
 			zap.String("path", path),
 			zap.String("canonical_path", canonicalPath),
+			zap.String("after_name", afterName),
+			zap.Int("limit", limit),
 			zap.Int("entries", len(infos)),
 			zap.Float64("list_dir_ms", float64(listDuration.Microseconds())/1000.0),
 			zap.Float64("total_ms", float64(time.Since(start).Microseconds())/1000.0),
@@ -1337,7 +1350,12 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 		zap.String("path", path),
 		zap.String("canonical_path", dirPath))
 	listStart := time.Now()
-	entries, err := b.store.ListDir(ctx, dirPath)
+	var entries []*datastore.NodeWithFile
+	if limit > 0 {
+		entries, err = b.store.ListDirPage(ctx, dirPath, afterName, limit)
+	} else {
+		entries, err = b.store.ListDir(ctx, dirPath)
+	}
 	listDuration = time.Since(listStart)
 	if err != nil {
 		return nil, err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -196,6 +196,11 @@ type FileInfo struct {
 	Nlink      uint32 `json:"nlink,omitempty"`
 }
 
+type ListPageResult struct {
+	Entries    []FileInfo `json:"entries"`
+	NextCursor string     `json:"next_cursor,omitempty"`
+}
+
 // StatResult represents file metadata from HEAD.
 type StatResult struct {
 	Size       int64
@@ -681,6 +686,38 @@ func (c *Client) ListCtx(ctx context.Context, path string) ([]FileInfo, error) {
 		return nil, fmt.Errorf("decode: %w", err)
 	}
 	return result.Entries, nil
+}
+
+// ListPage returns a single explicit page of directory entries.
+func (c *Client) ListPage(path string, limit int, cursor string) (*ListPageResult, error) {
+	return c.ListPageCtx(context.Background(), path, limit, cursor)
+}
+
+// ListPageCtx returns a single explicit page of directory entries with context support.
+func (c *Client) ListPageCtx(ctx context.Context, path string, limit int, cursor string) (*ListPageResult, error) {
+	q := url.Values{}
+	q.Set("list", "1")
+	q.Set("limit", strconv.Itoa(limit))
+	if cursor != "" {
+		q.Set("cursor", cursor)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(path)+"?"+q.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var result ListPageResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("decode: %w", err)
+	}
+	return &result, nil
 }
 
 // BatchStatCtx returns lightweight metadata for up to MaxBatchStatPaths paths.

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -260,6 +260,35 @@ func TestBatchReadSmallCtxRejectsPathMismatch(t *testing.T) {
 	}
 }
 
+func TestListPageSendsExplicitPagination(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		if r.URL.Path != "/v1/fs/data/" {
+			t.Errorf("path = %s, want /v1/fs/data/", r.URL.Path)
+		}
+		q := r.URL.Query()
+		if q.Get("list") != "1" || q.Get("limit") != "2" || q.Get("cursor") != "cursor-1" {
+			t.Errorf("query = %q", r.URL.RawQuery)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"entries":[{"name":"a.txt","size":1}],"next_cursor":"cursor-2"}`)
+	}))
+	defer ts.Close()
+
+	result, err := New(ts.URL, "key").ListPage("/data/", 2, "cursor-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.NextCursor != "cursor-2" {
+		t.Fatalf("next cursor = %q", result.NextCursor)
+	}
+	if len(result.Entries) != 1 || result.Entries[0].Name != "a.txt" || result.Entries[0].Size != 1 {
+		t.Fatalf("entries = %+v", result.Entries)
+	}
+}
+
 func TestStat(t *testing.T) {
 	c, cleanup := newTestClient(t)
 	defer cleanup()

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1832,8 +1832,19 @@ func (s *Store) StatPathFallbackForRead(ctx context.Context, primaryPath, fallba
 }
 
 func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWithFile, err error) {
+	return s.listDir(ctx, parentPath, "", 0, "list_dir")
+}
+
+func (s *Store) ListDirPage(ctx context.Context, parentPath, afterName string, limit int) (out []*NodeWithFile, err error) {
+	if limit <= 0 {
+		return nil, fmt.Errorf("list dir page limit must be positive")
+	}
+	return s.listDir(ctx, parentPath, afterName, limit, "list_dir_page")
+}
+
+func (s *Store) listDir(ctx context.Context, parentPath, afterName string, limit int, op string) (out []*NodeWithFile, err error) {
 	start := time.Now()
-	defer observeStoreOp(ctx, "list_dir", start, &err)
+	defer observeStoreOp(ctx, op, start, &err)
 
 	// TODO(#110): ReadDir only needs lightweight file metadata. Split this into a
 	// metadata-only listing path so directory scans do not fetch or copy content_blob.
@@ -1843,9 +1854,18 @@ func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWith
 		FROM file_nodes fn
 		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
 		LEFT JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE fn.parent_path_hash = ? AND fn.parent_path = ?
-		ORDER BY fn.name`
-	rows, err := s.db.QueryContext(ctx, q, fileNodePathHash(parentPath), parentPath)
+		WHERE fn.parent_path_hash = ? AND fn.parent_path = ?`
+	args := []any{fileNodePathHash(parentPath), parentPath}
+	if afterName != "" {
+		q += ` AND fn.name > ?`
+		args = append(args, afterName)
+	}
+	q += ` ORDER BY fn.name`
+	if limit > 0 {
+		q += ` LIMIT ?`
+		args = append(args, limit)
+	}
+	rows, err := s.db.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -297,6 +297,130 @@ func TestListDir(t *testing.T) {
 	requireEmbeddingRevision(t, entries[0].File.EmbeddingRevision, 13)
 }
 
+func TestListDirPageKeyset(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now()
+	empty, err := s.ListDirPage(context.Background(), "/empty/", "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("empty page len = %d, want 0", len(empty))
+	}
+
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "single-dir", Path: "/single/", ParentPath: "/", Name: "single", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(context.Background(), &FileNode{
+		NodeID:      "single-only",
+		Path:        "/single/only/",
+		ParentPath:  "/single/",
+		Name:        "only",
+		IsDirectory: true,
+		CreatedAt:   now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	single, err := s.ListDirPage(context.Background(), "/single/", "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeNames(single); !reflect.DeepEqual(got, []string{"only"}) {
+		t.Fatalf("single page names = %v", got)
+	}
+
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "page-dir", Path: "/data/", ParentPath: "/", Name: "data", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"c", "a", "d", "b"} {
+		if err := s.InsertNode(context.Background(), &FileNode{
+			NodeID:      "page-" + name,
+			Path:        "/data/" + name + "/",
+			ParentPath:  "/data/",
+			Name:        name,
+			IsDirectory: true,
+			CreatedAt:   now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	all, err := s.ListDir(context.Background(), "/data/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeNames(all); !reflect.DeepEqual(got, []string{"a", "b", "c", "d"}) {
+		t.Fatalf("ListDir names = %v", got)
+	}
+
+	page, err := s.ListDirPage(context.Background(), "/data/", "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeNames(page); !reflect.DeepEqual(got, []string{"a", "b"}) {
+		t.Fatalf("first page names = %v", got)
+	}
+
+	page, err = s.ListDirPage(context.Background(), "/data/", "b", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeNames(page); !reflect.DeepEqual(got, []string{"c", "d"}) {
+		t.Fatalf("second page names = %v", got)
+	}
+
+	page, err = s.ListDirPage(context.Background(), "/data/", "d", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(page) != 0 {
+		t.Fatalf("after last page len = %d, want 0", len(page))
+	}
+
+	if err := s.InsertNode(context.Background(), &FileNode{NodeID: "special-dir", Path: "/special/", ParentPath: "/", Name: "special", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	specialNames := []string{"01 space name", "02 hash#name", "03 percent%name", "04 中文"}
+	for _, name := range specialNames {
+		if err := s.InsertNode(context.Background(), &FileNode{
+			NodeID:      "special-" + name,
+			Path:        "/special/" + name + "/",
+			ParentPath:  "/special/",
+			Name:        name,
+			IsDirectory: true,
+			CreatedAt:   now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	special, err := s.ListDirPage(context.Background(), "/special/", "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeNames(special); !reflect.DeepEqual(got, specialNames[:2]) {
+		t.Fatalf("special first page names = %v", got)
+	}
+	special, err = s.ListDirPage(context.Background(), "/special/", specialNames[1], 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := nodeNames(special); !reflect.DeepEqual(got, specialNames[2:]) {
+		t.Fatalf("special second page names = %v", got)
+	}
+
+	if _, err := s.ListDirPage(context.Background(), "/data/", "", 0); err == nil {
+		t.Fatal("ListDirPage limit=0 succeeded, want error")
+	}
+}
+
+func nodeNames(entries []*NodeWithFile) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Node.Name)
+	}
+	return names
+}
+
 func TestInsertNodeRejectsRootDentry(t *testing.T) {
 	s := newTestStore(t)
 	for _, name := range []string{"/", "root-alias"} {

--- a/pkg/server/fs_authorization_test.go
+++ b/pkg/server/fs_authorization_test.go
@@ -155,6 +155,8 @@ func TestIsScopedBusinessRequestAllowed(t *testing.T) {
 		}{
 			{http.MethodGet, "/v1/fs/main.txt", ""},
 			{http.MethodGet, "/v1/fs/dir/", "list=1"},
+			{http.MethodGet, "/v1/fs/dir/", "list=1&limit=100"},
+			{http.MethodGet, "/v1/fs/dir/", "list=1&limit=100&cursor=opaque"},
 			{http.MethodGet, "/v1/fs/dir/file.txt", "stat=1"},
 			{http.MethodGet, "/v1/fs/dir/", "grep=hello"},
 			// Regression for @adversary-1 msg 00efe734: grep + limit must

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3,6 +3,8 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/subtle"
 	"database/sql"
 	"encoding/base64"
@@ -100,10 +102,10 @@ type Config struct {
 	// authentication. When set, the pod-to-pod push path is enabled; when nil,
 	// only the 200ms poller fallback is used (no push).
 	SSENotifyPollInterval time.Duration
-	SSENotifyRetention     time.Duration
-	PodID                  string
-	PodAddr                string
-	PodNotifySecret        []byte
+	SSENotifyRetention    time.Duration
+	PodID                 string
+	PodAddr               string
+	PodNotifySecret       []byte
 }
 
 type SlockOAuthClient interface {
@@ -319,7 +321,7 @@ func NewWithConfig(cfg Config) *Server {
 		leader:              cfg.Leader,
 		podNotifySecret:     cfg.PodNotifySecret,
 		sseNotifyRetention:  cfg.SSENotifyRetention,
-		}
+	}
 	// Default SSE notify retention.
 	if s.sseNotifyRetention <= 0 {
 		s.sseNotifyRetention = defaultSSENotifyRetention
@@ -1540,8 +1542,8 @@ func isScopedFSGetQueryAllowed(q url.Values) bool {
 			"minsize", "maxsize", "limit", "layer",
 		})
 	case q.Has("list"):
-		// handleList reads only ?list. (No filter params today.)
-		return queryKeysSubsetOf(q, []string{"list"})
+		// handleList reads ?list plus optional explicit pagination params.
+		return queryKeysSubsetOf(q, []string{"list", "limit", "cursor"})
 	default:
 		// No action selector → handleRead, which does not consume query
 		// params. Any unknown key on a read request is rejected to prevent
@@ -1729,6 +1731,140 @@ func (s *Server) handleLocalTenantStatus(w http.ResponseWriter, r *http.Request)
 	})
 }
 
+const (
+	fsListCursorVersion     = 1
+	fsListMaxLimit          = 10000
+	fsListCursorFallbackKey = "drive9-fs-list-cursor-v1"
+)
+
+type fsListCursor struct {
+	Version   int    `json:"v"`
+	Dir       string `json:"dir"`
+	AfterName string `json:"after_name"`
+	Sig       string `json:"sig"`
+}
+
+type fsListPageParams struct {
+	Enabled      bool
+	Limit        int
+	AfterName    string
+	CanonicalDir string
+}
+
+func (s *Server) parseFSListPageParams(q url.Values, path string) (fsListPageParams, error) {
+	limitRaw, hasLimit, err := singleQueryValue(q, "limit")
+	if err != nil {
+		return fsListPageParams{}, err
+	}
+	cursorRaw, hasCursor, err := singleQueryValue(q, "cursor")
+	if err != nil {
+		return fsListPageParams{}, err
+	}
+	if !hasLimit {
+		if hasCursor {
+			return fsListPageParams{}, errors.New("cursor requires limit")
+		}
+		return fsListPageParams{}, nil
+	}
+	limit, err := strconv.Atoi(limitRaw)
+	if err != nil || limit < 1 || limit > fsListMaxLimit {
+		return fsListPageParams{}, fmt.Errorf("limit must be between 1 and %d", fsListMaxLimit)
+	}
+	canonicalDir, err := pathutil.CanonicalizeDir(path)
+	if err != nil {
+		return fsListPageParams{}, fmt.Errorf("invalid list path: %w", err)
+	}
+	params := fsListPageParams{
+		Enabled:      true,
+		Limit:        limit,
+		CanonicalDir: canonicalDir,
+	}
+	if hasCursor {
+		afterName, err := s.decodeFSListCursor(cursorRaw, canonicalDir)
+		if err != nil {
+			return fsListPageParams{}, err
+		}
+		params.AfterName = afterName
+	}
+	return params, nil
+}
+
+func singleQueryValue(q url.Values, key string) (string, bool, error) {
+	values, ok := q[key]
+	if !ok {
+		return "", false, nil
+	}
+	if len(values) != 1 {
+		return "", false, fmt.Errorf("%s must be provided once", key)
+	}
+	return values[0], true, nil
+}
+
+func (s *Server) encodeFSListCursor(dir, afterName string) (string, error) {
+	cursor := fsListCursor{
+		Version:   fsListCursorVersion,
+		Dir:       dir,
+		AfterName: afterName,
+	}
+	cursor.Sig = s.signFSListCursor(cursor)
+	payload, err := json.Marshal(cursor)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(payload), nil
+}
+
+func (s *Server) decodeFSListCursor(raw, dir string) (string, error) {
+	payload, err := base64.RawURLEncoding.DecodeString(raw)
+	if err != nil {
+		return "", errors.New("invalid cursor")
+	}
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.DisallowUnknownFields()
+	var cursor fsListCursor
+	if err := dec.Decode(&cursor); err != nil {
+		return "", errors.New("invalid cursor")
+	}
+	var extra struct{}
+	if err := dec.Decode(&extra); err != io.EOF {
+		return "", errors.New("invalid cursor")
+	}
+	if cursor.Version != fsListCursorVersion || cursor.Dir != dir || !validFSListCursorName(cursor.AfterName) {
+		return "", errors.New("invalid cursor")
+	}
+	expected := s.signFSListCursor(fsListCursor{
+		Version:   cursor.Version,
+		Dir:       cursor.Dir,
+		AfterName: cursor.AfterName,
+	})
+	if subtle.ConstantTimeCompare([]byte(cursor.Sig), []byte(expected)) != 1 {
+		return "", errors.New("invalid cursor")
+	}
+	return cursor.AfterName, nil
+}
+
+func (s *Server) signFSListCursor(cursor fsListCursor) string {
+	key := s.tokenSecret
+	if len(key) == 0 {
+		key = []byte(fsListCursorFallbackKey)
+	}
+	mac := hmac.New(sha256.New, key)
+	_, _ = fmt.Fprintf(mac, "%d\x00%s\x00%s", cursor.Version, cursor.Dir, cursor.AfterName)
+	return fmt.Sprintf("%x", mac.Sum(nil))
+}
+
+func validFSListCursorName(name string) bool {
+	if name == "" || name == "." || name == ".." || !utf8.ValidString(name) {
+		return false
+	}
+	for _, r := range name {
+		if r == '/' || r == '\\' || r == 0 || r < 0x20 {
+			return false
+		}
+	}
+	return true
+}
+
 func (s *Server) handleFS(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, "/v1/fs")
 	if path == "" {
@@ -1865,9 +2001,20 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
 		return
 	}
+	page, err := s.parseFSListPageParams(r.URL.Query(), path)
+	if err != nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "list_bad_pagination", "path", path, "error", err)...)
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	logger.InfoBenchTiming(r.Context(), "server_list_start", zap.String("path", path))
 	readDirStart := time.Now()
-	entries, err := b.ReadDirCtx(r.Context(), path)
+	var entries []filesystem.FileInfo
+	if page.Enabled {
+		entries, err = b.ReadDirPageCtx(r.Context(), path, page.AfterName, page.Limit+1)
+	} else {
+		entries, err = b.ReadDirCtx(r.Context(), path)
+	}
 	readDirDuration := time.Since(readDirStart)
 	if err != nil {
 		logger.InfoBenchTiming(r.Context(), "server_list_timing",
@@ -1884,6 +2031,16 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 		metricEvent(r.Context(), "userdb_query", "api", "list", "result", "error")
 		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
 		return
+	}
+	nextCursor := ""
+	if page.Enabled && len(entries) > page.Limit {
+		entries = entries[:page.Limit]
+		nextCursor, err = s.encodeFSListCursor(page.CanonicalDir, entries[len(entries)-1].Name)
+		if err != nil {
+			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "list_cursor_encode_failed", "path", path, "error", err)...)
+			errJSON(w, http.StatusInternalServerError, "encode cursor")
+			return
+		}
 	}
 	metricEvent(r.Context(), "userdb_query", "api", "list", "result", "ok")
 	logger.InfoBenchTiming(r.Context(), "server_list_timing",
@@ -1935,7 +2092,11 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 		})
 	}
 	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]any{"entries": out})
+	resp := map[string]any{"entries": out}
+	if nextCursor != "" {
+		resp["next_cursor"] = nextCursor
+	}
+	_ = json.NewEncoder(w).Encode(resp)
 }
 
 func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path string) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -3,12 +3,15 @@ package server
 import (
 	"context"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
+	"reflect"
 	"strconv"
 	"strings"
 	"syscall"
@@ -439,6 +442,186 @@ func TestListDir(t *testing.T) {
 	if result.Entries[0].Revision <= 0 {
 		t.Fatalf("list entry revision = %d, want > 0", result.Entries[0].Revision)
 	}
+}
+
+func TestListDirPagination(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	empty := getListPage(t, ts.URL+"/v1/fs/empty/?list=1&limit=10")
+	if len(empty.Entries) != 0 {
+		t.Fatalf("empty directory entries = %v, want empty", listEntryNames(empty.Entries))
+	}
+	if empty.NextCursor != "" {
+		t.Fatalf("empty directory next_cursor = %q, want empty", empty.NextCursor)
+	}
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/single/only.txt", strings.NewReader("only"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		t.Fatalf("write single entry status = %d", resp.StatusCode)
+	}
+
+	single := getListPage(t, ts.URL+"/v1/fs/single/?list=1&limit=1")
+	if got := listEntryNames(single.Entries); !reflect.DeepEqual(got, []string{"only.txt"}) {
+		t.Fatalf("single entry names = %v", got)
+	}
+	if single.NextCursor != "" {
+		t.Fatalf("single entry next_cursor = %q, want empty", single.NextCursor)
+	}
+
+	for _, name := range []string{"c.txt", "a.txt", "b.txt"} {
+		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/data/"+name, strings.NewReader(name))
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode >= 300 {
+			t.Fatalf("write %s status = %d", name, resp.StatusCode)
+		}
+	}
+
+	full := getListPage(t, ts.URL+"/v1/fs/data/?list=1")
+	if got := listEntryNames(full.Entries); !reflect.DeepEqual(got, []string{"a.txt", "b.txt", "c.txt"}) {
+		t.Fatalf("compat list names = %v", got)
+	}
+	if full.NextCursor != "" {
+		t.Fatalf("compat list next_cursor = %q, want empty", full.NextCursor)
+	}
+
+	first := getListPage(t, ts.URL+"/v1/fs/data/?list=1&limit=2")
+	if got := listEntryNames(first.Entries); !reflect.DeepEqual(got, []string{"a.txt", "b.txt"}) {
+		t.Fatalf("first page names = %v", got)
+	}
+	if first.NextCursor == "" {
+		t.Fatal("first page next_cursor is empty")
+	}
+
+	second := getListPage(t, ts.URL+"/v1/fs/data/?list=1&limit=2&cursor="+url.QueryEscape(first.NextCursor))
+	if got := listEntryNames(second.Entries); !reflect.DeepEqual(got, []string{"c.txt"}) {
+		t.Fatalf("second page names = %v", got)
+	}
+	if second.NextCursor != "" {
+		t.Fatalf("last page next_cursor = %q, want empty", second.NextCursor)
+	}
+
+	exact := getListPage(t, ts.URL+"/v1/fs/data/?list=1&limit=3")
+	if got := listEntryNames(exact.Entries); !reflect.DeepEqual(got, []string{"a.txt", "b.txt", "c.txt"}) {
+		t.Fatalf("exact page names = %v", got)
+	}
+	if exact.NextCursor != "" {
+		t.Fatalf("exact page next_cursor = %q, want empty", exact.NextCursor)
+	}
+
+	specialNames := []string{"01 space name.txt", "02 hash#name.txt", "03 percent%name.txt", "04 中文.txt"}
+	for _, name := range specialNames {
+		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/special/"+url.PathEscape(name), strings.NewReader(name))
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode >= 300 {
+			t.Fatalf("write special entry %q status = %d", name, resp.StatusCode)
+		}
+	}
+
+	firstSpecial := getListPage(t, ts.URL+"/v1/fs/special/?list=1&limit=2")
+	if got := listEntryNames(firstSpecial.Entries); !reflect.DeepEqual(got, specialNames[:2]) {
+		t.Fatalf("first special page names = %v", got)
+	}
+	if firstSpecial.NextCursor == "" {
+		t.Fatal("first special page next_cursor is empty")
+	}
+	secondSpecial := getListPage(t, ts.URL+"/v1/fs/special/?list=1&limit=2&cursor="+url.QueryEscape(firstSpecial.NextCursor))
+	if got := listEntryNames(secondSpecial.Entries); !reflect.DeepEqual(got, specialNames[2:]) {
+		t.Fatalf("second special page names = %v", got)
+	}
+	if secondSpecial.NextCursor != "" {
+		t.Fatalf("second special page next_cursor = %q, want empty", secondSpecial.NextCursor)
+	}
+
+	for _, rawQuery := range []string{
+		"list=1&cursor=" + url.QueryEscape(first.NextCursor),
+		"list=1&limit=0",
+		"list=1&limit=10001",
+		"list=1&limit=abc",
+		"list=1&limit=1&limit=2",
+		"list=1&limit=1&cursor=not-base64",
+		"list=1&limit=1&cursor=" + url.QueryEscape(tamperedFSListCursor(t, "/data/", "b.txt")),
+	} {
+		resp, err := http.Get(ts.URL + "/v1/fs/data/?" + rawQuery)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusBadRequest {
+			t.Fatalf("GET ?%s status = %d, want 400", rawQuery, resp.StatusCode)
+		}
+	}
+
+	resp, err = http.Get(ts.URL + "/v1/fs/other/?list=1&limit=1&cursor=" + url.QueryEscape(first.NextCursor))
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("cross-dir cursor status = %d, want 400", resp.StatusCode)
+	}
+}
+
+type listPageResponse struct {
+	Entries []struct {
+		Name string `json:"name"`
+	} `json:"entries"`
+	NextCursor string `json:"next_cursor"`
+}
+
+func getListPage(t *testing.T, rawURL string) listPageResponse {
+	t.Helper()
+	resp, err := http.Get(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s status = %d", rawURL, resp.StatusCode)
+	}
+	var result listPageResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func listEntryNames(entries []struct {
+	Name string `json:"name"`
+}) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name)
+	}
+	return names
+}
+
+func tamperedFSListCursor(t *testing.T, dir, afterName string) string {
+	t.Helper()
+	payload, err := json.Marshal(fsListCursor{
+		Version:   fsListCursorVersion,
+		Dir:       dir,
+		AfterName: afterName,
+		Sig:       "bad",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(payload)
 }
 
 func TestStat(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add explicit `limit`/`cursor` pagination for `GET /v1/fs/<path>?list=1` while preserving the legacy full-list response when `limit` is absent.
- Use keyset pagination over `fn.name`, directory-bound opaque cursors, and `limit` validation in `1..10000`.
- Allow scoped tokens to pass `list+limit+cursor` and add SDK `ListPage` / `ListPageCtx`.

## Tests
- `/usr/local/go/bin/go test -c ./pkg/client ./pkg/server ./pkg/datastore ./pkg/backend`
- `/usr/local/go/bin/go vet ./pkg/client ./pkg/server ./pkg/datastore ./pkg/backend`
- `git diff --check`

Runtime package tests on this machine are blocked by local testcontainers startup: `rootless Docker not found`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added cookbook examples demonstrating paginated filesystem directory listings, including cursor-based continuation.

* **Tests**
  * Expanded coverage for paginated directory listings across empty, single-page, multi-page, and exact-limit results.
  * Added validation for sorting, continuation behavior, exhausted listings, special-character and Unicode filenames, invalid limits and cursors, and cross-directory cursor handling.
  * Added end-to-end coverage for compatibility scenarios and encoded pagination responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->