### PR TITLE
provisioner: grant SYSTEM_VARIABLES_ADMIN to tdc_fs_admin role

### DIFF
--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1214,6 +1214,7 @@ func systemUserStatements(dbName, username, password string) []string {
 	return []string{
 		fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", quoteIdent(dbName)),
 		fmt.Sprintf("CREATE ROLE IF NOT EXISTS %s", quoteString(roleName)),
+		fmt.Sprintf("GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO %s", quoteString(roleName)),
 		fmt.Sprintf("GRANT CREATE, ALTER, DROP, INDEX, SELECT, INSERT, UPDATE, DELETE ON %s.* TO %s", quoteIdent(dbName), quoteString(roleName)),
 		fmt.Sprintf("CREATE USER IF NOT EXISTS %s IDENTIFIED BY %s", quoteString(username), quoteString(password)),
 		fmt.Sprintf("ALTER USER %s IDENTIFIED BY %s", quoteString(username), quoteString(password)),

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1497,6 +1497,7 @@ func TestSystemUserStatements(t *testing.T) {
 	want := []string{
 		"CREATE DATABASE IF NOT EXISTS `tidbcloud_fs`",
 		"CREATE ROLE IF NOT EXISTS 'tdc_fs_admin'",
+		"GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO 'tdc_fs_admin'",
 		"GRANT CREATE, ALTER, DROP, INDEX, SELECT, INSERT, UPDATE, DELETE ON `tidbcloud_fs`.* TO 'tdc_fs_admin'",
 		"CREATE USER IF NOT EXISTS '22ipQWBXXq2wN2S.tdc_fs_sys' IDENTIFIED BY 'pass123'",
 		"ALTER USER '22ipQWBXXq2wN2S.tdc_fs_sys' IDENTIFIED BY 'pass123'",


### PR DESCRIPTION
The system user created by `EnsureSystemUser` lacked `SYSTEM_VARIABLES_ADMIN`, causing `SET @@GLOBAL.TIDB_EXP_EMBED_OPENAI_API_KEY` to fail with Error 1227 during init schema on TiDB Serverless.

This adds `GRANT SYSTEM_VARIABLES_ADMIN ON *.* TO 'tdc_fs_admin'` so the system user can set TiDB global embedding variables.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database provisioning so the `tdc_fs_admin` role now receives the necessary permission to administer system variables.
  * This helps avoid privilege-related issues during setup and administration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->