### PR TITLE
feat: increase commit queue max pending default to 500

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -156,7 +156,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	dirCacheMaxEntries := fs.Int("dir-cache-max-entries", 200000, "maximum entries per directory in namespace cache before complete marking is disabled")
 	writeCacheFreeRatio := fs.Float64("write-cache-free-ratio", 0.10, "minimum filesystem free-space ratio before write-back refuses writes with ENOSPC (0 disables)")
 	writeCacheSizeMB := fs.Int64("write-cache-size-mb", 1024, "shadow cache byte quota in MB (default 1024; 0 disables); shadow writes exceeding this return ENOSPC")
-	commitQueueMaxPending := fs.Int("commit-queue-max-pending", 100, "maximum pending entries in CommitQueue before backpressure")
+	commitQueueMaxPending := fs.Int("commit-queue-max-pending", 500, "maximum pending entries in CommitQueue before backpressure")
 	allowOther := fs.Bool("allow-other", false, "allow other users to access mount")
 	readOnly := fs.Bool("read-only", false, "mount as read-only")
 	debug := fs.Bool("debug", false, "enable FUSE debug logging")

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -7638,16 +7638,16 @@ func TestCommitQueueMaxPendingResolution(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Zero maxPending → NewCommitQueue uses internal default (maxCommitQueuePending=100).
+	// Zero maxPending → NewCommitQueue uses internal default (maxCommitQueuePending=500).
 	cq0 := NewCommitQueue(nil, shadow, pending, nil, 1, 0)
 	if cq0.maxPending != maxCommitQueuePending {
 		t.Fatalf("NewCommitQueue(maxPending=0).maxPending = %d, want %d", cq0.maxPending, maxCommitQueuePending)
 	}
 
 	// Explicit positive value is honored.
-	cq500 := NewCommitQueue(nil, shadow, pending, nil, 1, 500)
-	if cq500.maxPending != 500 {
-		t.Fatalf("NewCommitQueue(maxPending=500).maxPending = %d, want 500", cq500.maxPending)
+	cq200 := NewCommitQueue(nil, shadow, pending, nil, 1, 200)
+	if cq200.maxPending != 200 {
+		t.Fatalf("NewCommitQueue(maxPending=200).maxPending = %d, want 200", cq200.maxPending)
 	}
 }
 

--- a/pkg/fuse/mount_profile.go
+++ b/pkg/fuse/mount_profile.go
@@ -95,7 +95,7 @@ func ParseSyncMode(s string) (SyncMode, error) {
 const rttThreshold = 10 * time.Millisecond
 
 // maxCommitQueuePending is the backpressure limit for the commit queue.
-const maxCommitQueuePending = 100
+const maxCommitQueuePending = 500
 
 // MeasureRTT measures the round-trip time to the server by issuing a HEAD
 // request to the root path. Returns the measured duration.


### PR DESCRIPTION
## Summary
- Increase `maxCommitQueuePending` default from 100 to 500
- Updates constant in `pkg/fuse/mount_profile.go`, CLI default in `cmd/drive9/cli/mount.go`, and test comment

## Motivation
Higher default allows more files to queue for async upload before backpressure kicks in, improving throughput for burst writes.

## Test plan
- [x] `go build` passes
- [x] Existing test `TestNewCommitQueueMaxPending` updated to match new default
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the default pending-entry limit for mount commit queues, allowing more operations before backpressure kicks in.
  * Updated the CLI default for the mount command to match the new higher limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->