### PR TITLE
cd: remove dat9 deploy for us-west-2, keep only drive9-tidbcloud

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -146,49 +146,18 @@ jobs:
           kubectl --context us -n drive9-tidbcloud \
             rollout undo deployment/drive9-server
 
-      - name: Deploy to aws-us-west-2
-        id: deploy-uw2
-        if: inputs.region == 'all' || inputs.region == 'aws-us-west-2'
-        run: |
-          aws eks update-kubeconfig \
-            --name prod-drive9-usw2 \
-            --region us-west-2 \
-            --alias uw2
-          kubectl --context uw2 -n "${{ env.DEPLOY_NAMESPACE }}" \
-            set image "deployment/${{ env.K8S_DEPLOYMENT }}" \
-            "${{ env.K8S_DEPLOYMENT }}=$IMAGE"
-          REPLICAS=$(kubectl --context uw2 -n "${{ env.DEPLOY_NAMESPACE }}" \
-            get "deployment/${{ env.K8S_DEPLOYMENT }}" \
-            -o 'jsonpath={.spec.replicas}')
-          if [ "$REPLICAS" != "0" ]; then
-            kubectl --context uw2 -n "${{ env.DEPLOY_NAMESPACE }}" \
-              rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
-              --timeout=300s
-          fi
-
-      - name: Rollback aws-us-west-2 dat9 on failure
-        if: failure() && steps.deploy-uw2.outcome == 'failure'
-        run: |
-          kubectl --context uw2 -n "${{ env.DEPLOY_NAMESPACE }}" \
-            rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
-
       - name: Deploy drive9-tidbcloud to aws-us-west-2
-        id: deploy-uw2-native
+        id: deploy-uw2
         if: inputs.region == 'all' || inputs.region == 'aws-us-west-2'
         run: |
           kubectl --context uw2 -n drive9-tidbcloud \
             set image deployment/drive9-server \
             drive9-server=$IMAGE
-          REPLICAS=$(kubectl --context uw2 -n drive9-tidbcloud \
-            get deployment/drive9-server \
-            -o 'jsonpath={.spec.replicas}')
-          if [ "$REPLICAS" != "0" ]; then
-            kubectl --context uw2 -n drive9-tidbcloud \
-              rollout status deployment/drive9-server --timeout=300s
-          fi
+          kubectl --context uw2 -n drive9-tidbcloud \
+            rollout status deployment/drive9-server --timeout=300s
 
       - name: Rollback drive9-tidbcloud aws-us-west-2 on failure
-        if: failure() && steps.deploy-uw2-native.outcome == 'failure'
+        if: failure() && steps.deploy-uw2.outcome == 'failure'
         run: |
           kubectl --context uw2 -n drive9-tidbcloud \
             rollout undo deployment/drive9-server

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -147,23 +147,23 @@ jobs:
             rollout undo deployment/drive9-server
 
       - name: Deploy drive9-tidbcloud to aws-us-west-2
-        id: deploy-us-west-2
+        id: deploy-aws-us-west-2
         if: inputs.region == 'all' || inputs.region == 'aws-us-west-2'
         run: |
           aws eks update-kubeconfig \
             --name prod-drive9-usw2 \
             --region us-west-2 \
-            --alias us-west-2
-          kubectl --context us-west-2 -n drive9-tidbcloud \
+            --alias aws-us-west-2
+          kubectl --context aws-us-west-2 -n drive9-tidbcloud \
             set image deployment/drive9-server \
             drive9-server=$IMAGE
-          kubectl --context us-west-2 -n drive9-tidbcloud \
+          kubectl --context aws-us-west-2 -n drive9-tidbcloud \
             rollout status deployment/drive9-server --timeout=300s
 
       - name: Rollback drive9-tidbcloud aws-us-west-2 on failure
-        if: failure() && steps.deploy-us-west-2.outcome == 'failure'
+        if: failure() && steps.deploy-aws-us-west-2.outcome == 'failure'
         run: |
-          kubectl --context us-west-2 -n drive9-tidbcloud \
+          kubectl --context aws-us-west-2 -n drive9-tidbcloud \
             rollout undo deployment/drive9-server
 
       - name: Configure Alibaba Cloud credentials

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -147,19 +147,23 @@ jobs:
             rollout undo deployment/drive9-server
 
       - name: Deploy drive9-tidbcloud to aws-us-west-2
-        id: deploy-uw2
+        id: deploy-us-west-2
         if: inputs.region == 'all' || inputs.region == 'aws-us-west-2'
         run: |
-          kubectl --context uw2 -n drive9-tidbcloud \
+          aws eks update-kubeconfig \
+            --name prod-drive9-usw2 \
+            --region us-west-2 \
+            --alias us-west-2
+          kubectl --context us-west-2 -n drive9-tidbcloud \
             set image deployment/drive9-server \
             drive9-server=$IMAGE
-          kubectl --context uw2 -n drive9-tidbcloud \
+          kubectl --context us-west-2 -n drive9-tidbcloud \
             rollout status deployment/drive9-server --timeout=300s
 
       - name: Rollback drive9-tidbcloud aws-us-west-2 on failure
-        if: failure() && steps.deploy-uw2.outcome == 'failure'
+        if: failure() && steps.deploy-us-west-2.outcome == 'failure'
         run: |
-          kubectl --context uw2 -n drive9-tidbcloud \
+          kubectl --context us-west-2 -n drive9-tidbcloud \
             rollout undo deployment/drive9-server
 
       - name: Configure Alibaba Cloud credentials


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production deployment workflow for the `aws-us-west-2` region.
  * Changed which service is deployed in that region and simplified rollout handling to wait for completion consistently.
  * Improved rollback triggering so failures are handled against the updated deployment step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->