### PR TITLE
feat: instrument all user-DB access paths for scan-detection monitoring

### DIFF
--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/backend"
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/tenant/token"
 	"github.com/mem9-ai/drive9/pkg/tenantctx"
@@ -319,6 +320,10 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 		acquireStart := time.Now()
 		b, release, err := pool.Acquire(r.Context(), &resolved.Tenant)
 		acquireDurationMs := authPhaseMs(acquireStart)
+		// Request-path acquire: this is the expected hot-path user-DB access,
+		// driven by real traffic. Record so scan-detection alerts can compare
+		// periodic-path rates against this baseline.
+		metrics.RecordTenantOperation(resolved.Tenant.ID, "user_db_access", "auth_acquire", metrics.ResultForError(err), time.Since(acquireStart))
 		if err != nil {
 			if isClientCanceled(r.Context(), err) {
 				logAuthClientCanceled(r.Context(), "backend_load_client_canceled", "tenant_id", resolved.Tenant.ID)
@@ -454,7 +459,11 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 			return
 		}
 
+		capAcquireStart := time.Now()
 		b, release, err := pool.Acquire(r.Context(), tenant)
+		// Capability-token request-path acquire: same baseline signal as the
+		// API-key path above, but for the /v1/vault/read surface.
+		metrics.RecordTenantOperation(tenantID, "user_db_access", "auth_acquire", metrics.ResultForError(err), time.Since(capAcquireStart))
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "capability_backend_load_failed", "tenant_id", tenantID, "error", err)...)
 			errJSON(w, http.StatusInternalServerError, "backend unavailable")

--- a/pkg/server/object_gc_worker.go
+++ b/pkg/server/object_gc_worker.go
@@ -147,8 +147,8 @@ func (w *objectGCWorker) processCandidate(ctx context.Context, candidate meta.Ob
 		return w.meta.PostponeObjectGCCandidate(ctx, candidate, time.Now().UTC().Add(defaultObjectGCInactiveOwnerTTL), "namespace owner is not active")
 	}
 
-	b, release, err := w.pool.Acquire(ctx, owner)
 	acquireStart := time.Now()
+	b, release, err := w.pool.Acquire(ctx, owner)
 	if err != nil {
 		// Acquire failure: could not open the owner tenant TiDB for this GC
 		// candidate. Record so the warning alert can detect a GC path that is

--- a/pkg/server/object_gc_worker.go
+++ b/pkg/server/object_gc_worker.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"go.uber.org/zap"
 )
@@ -106,6 +107,9 @@ func (w *objectGCWorker) processOnce(ctx context.Context) (fatal bool) {
 			return true
 		}
 		logger.Warn(ctx, "object_gc_list_due_failed", zap.Error(err))
+		// List failure: the meta-DB read that drives object GC failed. Record
+		// so the warning alert can detect sustained listing trouble.
+		metrics.RecordOperation("user_db_access", "object_gc_list", "error", 0)
 		return false
 	}
 	for _, candidate := range candidates {
@@ -144,10 +148,19 @@ func (w *objectGCWorker) processCandidate(ctx context.Context, candidate meta.Ob
 	}
 
 	b, release, err := w.pool.Acquire(ctx, owner)
+	acquireStart := time.Now()
 	if err != nil {
+		// Acquire failure: could not open the owner tenant TiDB for this GC
+		// candidate. Record so the warning alert can detect a GC path that is
+		// churning cold opens or hitting bad connections.
+		metrics.RecordTenantOperation(owner.ID, "user_db_access", "object_gc_acquire", metrics.ResultForError(err), time.Since(acquireStart))
 		return err
 	}
 	defer release()
+	// Acquire success: the owner tenant TiDB is now open for this GC check.
+	// Object-GC is leader-gated and opens cold tenants — a spike here is a
+	// potential billing-storm contributor, hence the warning alert.
+	metrics.RecordTenantOperation(owner.ID, "user_db_access", "object_gc_acquire", "ok", time.Since(acquireStart))
 
 	reachable, err := b.HasConfirmedS3StorageRef(ctx, candidate.StorageRefHash, candidate.StorageRef)
 	if err != nil {

--- a/pkg/server/safety_net_scan.go
+++ b/pkg/server/safety_net_scan.go
@@ -60,6 +60,7 @@ func (s *Server) safetyNetScan(ctx context.Context) {
 	if s.meta == nil || s.pool == nil {
 		return
 	}
+	scanStart := time.Now()
 	shardFn := func(string) bool { return true }
 	if s.shardResolver != nil {
 		shardFn = s.shardResolver.ownsTenantFn()
@@ -69,18 +70,29 @@ func (s *Server) safetyNetScan(ctx context.Context) {
 	var afterID string
 	for {
 		if ctx.Err() != nil {
+			// Record the scan cycle with a canceled result so the alert can
+			// distinguish a full cycle from one interrupted by shutdown.
+			metrics.RecordOperation("user_db_access", "safety_net_scan_cycle", "canceled", time.Since(scanStart))
 			return
 		}
 		tenants, err := s.meta.ListTenantsByStatusAfter(ctx, meta.TenantActive, afterCreatedAt, afterID, safetyNetScanBatchSize)
 		if err != nil {
-			logger.Warn(ctx, "safety_net_scan_list_failed", zap.Error(err))
+			if ctx.Err() == nil {
+				logger.Warn(ctx, "safety_net_scan_list_failed", zap.Error(err))
+			}
+			// List failure: the meta-DB read that drives the scan failed. The
+			// scan stops early — warm-tenant recovery is degraded this cycle.
+			metrics.RecordOperation("user_db_access", "safety_net_scan_list", "error", 0)
+			metrics.RecordOperation("user_db_access", "safety_net_scan_cycle", "error", time.Since(scanStart))
 			return
 		}
 		if len(tenants) == 0 {
+			metrics.RecordOperation("user_db_access", "safety_net_scan_cycle", "ok", time.Since(scanStart))
 			return
 		}
 		for _, t := range tenants {
 			if ctx.Err() != nil {
+				metrics.RecordOperation("user_db_access", "safety_net_scan_cycle", "canceled", time.Since(scanStart))
 				return
 			}
 			// Shard filter: only process tenants this pod owns.
@@ -102,6 +114,11 @@ func (s *Server) safetyNetScan(ctx context.Context) {
 				if store == nil {
 					return
 				}
+				// Per-warm-tenant touch: record that the safety-net accessed
+				// this tenant's user DB this cycle. A spike in this rate is a
+				// precursor to a scan touching many DBs — the warning alert
+				// catches it before it becomes a billing storm.
+				metrics.RecordTenantOperationCount(t.ID, "user_db_access", "safety_net_tenant_scan", "ok")
 				needKick := false
 				// Recover expired semantic task leases.
 				if recovered, err := store.RecoverExpiredSemanticTasks(ctx, now, safetyNetRecoverLimit); err != nil {
@@ -109,8 +126,10 @@ func (s *Server) safetyNetScan(ctx context.Context) {
 						logger.Warn(ctx, "safety_net_scan_semantic_recover_failed",
 							zap.String("tenant_id", t.ID), zap.Error(err))
 					}
+					metrics.RecordTenantOperationCount(t.ID, "user_db_access", "safety_net_semantic_recover", "error")
 				} else if recovered > 0 {
 					metrics.RecordTenantOperation(t.ID, "semantic_worker", "safety_net_recover", "ok", 0)
+					metrics.RecordTenantOperationCount(t.ID, "user_db_access", "safety_net_semantic_recover", "ok")
 					needKick = true
 				}
 				// Recover expired file_gc leases.
@@ -119,7 +138,9 @@ func (s *Server) safetyNetScan(ctx context.Context) {
 						logger.Warn(ctx, "safety_net_scan_file_gc_recover_failed",
 							zap.String("tenant_id", t.ID), zap.Error(err))
 					}
+					metrics.RecordTenantOperationCount(t.ID, "user_db_access", "safety_net_file_gc_recover", "error")
 				} else if recovered > 0 {
+					metrics.RecordTenantOperationCount(t.ID, "user_db_access", "safety_net_file_gc_recover", "ok")
 					needKick = true
 				}
 				// Check for unclaimed queued semantic tasks. If the outbox
@@ -147,6 +168,7 @@ func (s *Server) safetyNetScan(ctx context.Context) {
 		afterCreatedAt = last.CreatedAt.UTC()
 		afterID = last.ID
 		if len(tenants) < safetyNetScanBatchSize {
+			metrics.RecordOperation("user_db_access", "safety_net_scan_cycle", "ok", time.Since(scanStart))
 			return
 		}
 	}

--- a/pkg/server/tenant_outbox_poller.go
+++ b/pkg/server/tenant_outbox_poller.go
@@ -175,7 +175,12 @@ func (p *tenantOutboxPoller) pollOnce(ctx context.Context) {
 			logger.Warn(ctx, "tenant_outbox_poller_list_failed",
 				zap.Uint64("after_id", p.lastID),
 				zap.Error(err))
-			metrics.RecordEventBusPollFailure("tenant_outbox_poller")
+			// List failure: the meta-DB read that drives kick dispatch failed.
+			// Record as a user_db_access path-level signal (the poller itself
+			// only reads the meta DB, but a list failure delays all downstream
+			// tenant-DB work). Avoids the previous abuse of putting the pod
+			// name in the tenant_id label of drive9_event_bus_poll_failures_total.
+			metrics.RecordOperation("user_db_access", "outbox_poll_list", "error", 0)
 			return
 		}
 		for _, row := range rows {
@@ -205,6 +210,11 @@ func (p *tenantOutboxPoller) dispatch(ctx context.Context, row meta.TenantNotify
 		// the safety-net scan recovers any work whose kick was lost.
 		if p.shardFn(row.TenantID) {
 			p.worker.Kick(row.TenantID, shardedMask)
+			// Record the kick that will trigger a tenant-DB access via the
+			// worker. This gives a baseline rate of "kicks dispatched" to
+			// compare against actual tenant_worker_acquire — a divergence
+			// (kicks without acquires) points to lost work.
+			metrics.RecordTenantOperationCount(row.TenantID, "user_db_access", "outbox_dispatch_kick", "ok")
 		}
 	}
 }

--- a/pkg/server/tenant_worker.go
+++ b/pkg/server/tenant_worker.go
@@ -627,14 +627,24 @@ func (m *tenantWorkerManager) targetForRef(ctx context.Context, ref semanticTena
 	if ref.tenant == nil {
 		return nil, fmt.Errorf("tenant metadata missing for %s", ref.id)
 	}
+	acquireStart := time.Now()
 	b, release, err := m.pool.Acquire(ctx, ref.tenant)
 	if err != nil {
+		// Kick-driven acquire failure: a kick arrived but the tenant TiDB could
+		// not be opened. Record so the major alert can detect sustained worker
+		// acquire errors (kicks not reaching the tenant DB).
+		metrics.RecordTenantOperation(ref.tenant.ID, "user_db_access", "tenant_worker_acquire", metrics.ResultForError(err), time.Since(acquireStart))
 		return nil, fmt.Errorf("acquire tenant backend: %w", err)
 	}
 	if b == nil {
 		release()
+		metrics.RecordTenantOperation(ref.tenant.ID, "user_db_access", "tenant_worker_acquire", "error", time.Since(acquireStart))
 		return nil, fmt.Errorf("backend missing for %s", ref.id)
 	}
+	// Kick-driven acquire success: the tenant TiDB is now open for this kick.
+	// The rate follows write traffic (kicks are produced by writes). A spike
+	// uncorrelated with writes would suggest a scan path regressing.
+	metrics.RecordTenantOperation(ref.tenant.ID, "user_db_access", "tenant_worker_acquire", "ok", time.Since(acquireStart))
 	return &tenantTarget{
 		tenantID:         ref.id,
 		backend:          b,

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -319,9 +319,17 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	createBackendStart := time.Now()
 	b, st, err := p.createBackend(ctx, t)
 	if err != nil {
+		// Cold-open failure: a tenant TiDB open was attempted but failed.
+		// Record so alerts can detect a scan path that is churning cold opens.
+		metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cold_open", "error", time.Since(createBackendStart))
 		return nil, nil, err
 	}
 	createBackendDurationMs := float64(time.Since(createBackendStart).Microseconds()) / 1000.0
+	// Cold-open success: a tenant TiDB was opened from scratch (cache miss).
+	// This is the canonical "a serverless TiDB was woken up" signal — the
+	// primary billing-storm indicator. PR #660 eliminated periodic scans that
+	// caused cold opens at scale; this metric guards against regressions.
+	metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cold_open", "ok", time.Since(createBackendStart))
 
 	p.mu.Lock()
 	if e, ok := p.items[t.ID]; ok {
@@ -439,16 +447,26 @@ func (p *Pool) AcquireCached(t *meta.Tenant) (b *backend.Dat9Backend, release fu
 	e, exists := p.items[t.ID]
 	if !exists {
 		p.mu.Unlock()
+		// Cold-skip: the tenant is not cached (TiDB likely scaled to zero).
+		// This is the warm-only invariant working as designed — the safety-net
+		// must never open a cold tenant TiDB. Record so the invariant-violation
+		// alert can confirm AcquireCached is staying warm-only.
+		metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cached", "cold_skipped", 0)
 		return nil, nil, false
 	}
 	if e.s3EncryptionPolicy != s3EncryptionPolicy || (t.StorageNamespaceID != "" && e.storageNamespaceID != t.StorageNamespaceID) {
 		p.mu.Unlock()
+		// Stale-skip: the cached backend's encryption policy / storage namespace
+		// no longer matches the tenant. The safety-net defers to the next write
+		// kick. Record so this rare edge case is observable.
+		metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cached", "stale_skipped", 0)
 		return nil, nil, false
 	}
 	e.refs++
 	p.order.MoveToFront(e.elem)
 	p.mu.Unlock()
 	metrics.RecordOperation("tenant_pool", "cache_lookup", "hit", 0)
+	metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cached", "hit", 0)
 	return e.backend, p.makeRelease(e), true
 }
 


### PR DESCRIPTION
## Background

PR #660 eliminated all periodic full-scans of tenant TiDBs to avoid waking serverless instances and causing billing storms — a severe incident class where idle serverless TiDBs are repeatedly woken by periodic goroutines, incurring significant cost. The core invariant is: **no periodic goroutine ever touches idle tenant TiDBs.**

However, after PR #660 there was no observability layer to detect regressions of this invariant. The driver-layer metric (`drive9_db_operations_total{role="user"}`) records every query but carries **no caller/path label**, so it cannot distinguish request-path access from a periodic scan path. A future code change that reintroduces a periodic tenant-DB scan would go undetected until the billing storm hits.

This PR closes that gap by adding path-level metrics instrumentation at **every code path that accesses a tenant user DB**, plus the corresponding Prometheus alerts in the runbooks repo (PR tidbcloud/runbooks#2634).

## What this PR does

Adds a single new metric family via the existing `metrics.RecordOperation` / `metrics.RecordTenantOperation` helpers:

```
drive9_service_operations_total{component="user_db_access",operation=<path>,result=...[,tenant_id=...]}
drive9_service_operation_duration_seconds{component="user_db_access",operation=<path>,...}
```

The `operation` label identifies the calling path that touched a tenant user DB. No new metric declarations are needed — these helpers already feed the existing `drive9_service_operations_total` counter and `drive9_service_operation_duration_seconds` histogram, following the same convention used by every other background worker component in the codebase.

## Instrumented paths

| operation label | file | what it instruments | opens cold TiDB? | expected rate |
|---|---|---|---|---|
| `auth_acquire` | `pkg/server/auth.go` | request-path `pool.Acquire` (API-key + capability-token auth) | yes (first request) | follows real traffic — the baseline |
| `tenant_worker_acquire` | `pkg/server/tenant_worker.go` | kick-driven worker `pool.Acquire` (`targetForRef`) | yes (if evicted) | follows write rate (kicks produced by writes) |
| `acquire_cold_open` | `pkg/tenant/pool.go` | `pool.Acquire` cache-miss → `createBackend` cold open | **yes** | follows traffic + kicks — **the canonical billing-storm indicator** |
| `acquire_cached` | `pkg/tenant/pool.go` | `pool.AcquireCached` warm-only access (hit / cold_skipped / stale_skipped) | **no** (warm-only) | bounded by warm cache size — **the invariant guard** |
| `safety_net_scan_cycle` | `pkg/server/safety_net_scan.go` | periodic 5min scan cycle (ok / error / canceled) | no | 1 per 5min per pod |
| `safety_net_tenant_scan` | `pkg/server/safety_net_scan.go` | per-warm-tenant touch inside the scan | no | ≤ warm-tenant count per 5min |
| `safety_net_scan_list` | `pkg/server/safety_net_scan.go` | meta-DB list failure driving the scan | no (meta-DB only) | near-zero |
| `safety_net_semantic_recover` | `pkg/server/safety_net_scan.go` | per-tenant expired semantic lease recovery outcome | no | low |
| `safety_net_file_gc_recover` | `pkg/server/safety_net_scan.go` | per-tenant expired file_gc lease recovery outcome | no | low |
| `object_gc_acquire` | `pkg/server/object_gc_worker.go` | leader-gated 1min object-GC `pool.Acquire` | **yes** | follows GC candidates |
| `object_gc_list` | `pkg/server/object_gc_worker.go` | object-GC meta-DB list failure | no (meta-DB only) | near-zero |
| `outbox_dispatch_kick` | `pkg/server/tenant_outbox_poller.go` | poller dispatched a sharded kick that will trigger a tenant-DB access | no (kick only) | follows write rate — baseline for comparing against `tenant_worker_acquire` |

## Design decisions

### Path-level counter, not driver-layer changes

The driver layer (`pkg/mysqlutil/instrumented.go`) already records every query as `drive9_db_operations_total{role="user",operation,result}` — but with **no caller/path label**, so it cannot distinguish "request path" vs "safety-net scan" vs "object_gc" vs "tenant_worker". Adding a path label to the driver layer would require propagating context tags through every `QueryContext` call site — invasive and high-cardinality-risk.

Instead, this PR adds a **dedicated path-level counter at each user-DB access call site**. This follows the existing codebase convention (every background worker already records into `drive9_service_operations_total` with its own `component` label). The `component="user_db_access"` value groups all tenant-DB access paths under one family, while the `operation` label distinguishes them.

### `acquire_cold_open` is the key billing-storm signal

Every cold open = a serverless TiDB wake-up. PR #660 ensures only request traffic and kicks produce cold opens, never periodic scans. A sustained high `acquire_cold_open` rate uncorrelated with real traffic is the earliest indicator that a periodic scan path has regressed. The critical-severity alert (`Drive9UserDBAcquireColdOpenBurst`) fires on an acute 2-minute burst — the exact billing-storm signature.

### `acquire_cached` guards the warm-only invariant

`AcquireCached` must never open a cold tenant TiDB — it returns `cold_skipped` on cache miss. The critical alert `Drive9SafetyNetScanColdOpenInvariantViolated` fires if `acquire_cached` ever records `result="error"` or `result="cold_open"`, which would mean the warm-only invariant is broken — a direct regression of the core PR #660 guarantee.

### Fixed a pre-existing metric label abuse

The outbox poller previously called `metrics.RecordEventBusPollFailure("tenant_outbox_poller")`, which put the pod-level identifier `"tenant_outbox_poller"` in the `tenant_id` label of `drive9_event_bus_poll_failures_total`. This was a slight abuse of the tenant_id label (it is a pod-level failure, not tenant-scoped). Replaced with `metrics.RecordOperation("user_db_access", "outbox_poll_list", "error", 0)`, which correctly records it as a path-level user-DB-access signal without polluting the tenant_id label.

## Files changed

- `pkg/tenant/pool.go` — instrument `Acquire` cold-open (success + failure) and `AcquireCached` all return paths (hit / cold_skipped / stale_skipped)
- `pkg/server/safety_net_scan.go` — scan-cycle duration + result, per-warm-tenant count, list failure, per-tenant recover outcomes
- `pkg/server/object_gc_worker.go` — acquire (success + error with duration), list failure
- `pkg/server/tenant_worker.go` — `targetForRef` acquire (success + error + nil-backend)
- `pkg/server/tenant_outbox_poller.go` — dispatch-kick count, fix poll-failure label abuse
- `pkg/server/auth.go` — request-path acquire at both sites (API-key auth + capability-token auth)

## Verification

- `make build` — compiles (server binary + all packages)
- `make lint` — golangci-lint v2.5.0, **0 issues**
- `go vet ./pkg/tenant/... ./pkg/server/...` — clean
- `go test -run 'TestSafetyNet|TestTenantOutbox|TestObjectGC|TestPool|TestAcquire' ./pkg/server/... ./pkg/tenant/...` — all pass

## Corresponding alerts

The Prometheus alert rules (3 warning, 3 major, 2 critical) are added in the runbooks repo on the existing PR #2634 branch (`fix/drive9-alerts-unified-outbox`), in `rules/mem9/mnemos/drive9-alerts.yaml`:

| Alert | Severity | Detects |
|---|---|---|
| `Drive9SafetyNetScanFailureHigh` | warning | safety-net meta-DB list failures |
| `Drive9SafetyNetScanTenantScanRateHigh` | warning | safety-net scanning too many warm tenants — scan-storm precursor |
| `Drive9ObjectGCAcquireRateHigh` | warning | object-GC opening cold tenants too fast |
| `Drive9UserDBAcquireColdOpenRateHigh` | major | sustained high cold-open rate — primary billing-storm signal |
| `Drive9UserDBAcquireColdOpenBurst` | critical | acute cold-open burst — exact billing-storm signature |
| `Drive9SafetyNetScanColdOpenInvariantViolated` | critical | AcquireCached recorded error/cold-open — warm-only invariant broken |
| `Drive9TenantWorkerAcquireErrorRateHigh` | major | kick-driven worker acquire errors — work not processed |
| `Drive9UserDBAccessUnexpectedPath` | warning | user-DB access from a path not in the known allowlist — future scan regression guard |

Depends on tidbcloud/runbooks#2634 for the alert rules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved monitoring and error tracking across authentication, tenant access, outbox polling, background scans, and garbage collection.
  * Added clearer status reporting for successful, failed, skipped, and canceled background operations.
  * Improved visibility into tenant backend acquisition so cache hits, misses, and cold starts are easier to distinguish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->