### PR TITLE
chore: clarify Anonymous mode warning message

### DIFF
--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -148,7 +148,7 @@ func Create(args []string) error {
 	}
 
 	if mode == RegionModeAnonymous {
-		fmt.Fprintf(os.Stderr, "Note: Anonymous mode in drive9 transfers data management rights to PingCAP.\n")
+		fmt.Fprintf(os.Stderr, "Note: Anonymous mode is for evaluation and functional testing only. Please do not put production data in it.\n")
 	}
 
 	cfg := loadConfig()
@@ -290,7 +290,7 @@ examples:
   # list available regions
   drive9 region list
 
-note: Anonymous mode in drive9 transfers data management rights to PingCAP.`
+note: Anonymous mode is for evaluation and functional testing only. Please do not put production data in it.`
 }
 
 func provisionModeForCredentials(publicKey, privateKey string) string {

--- a/cmd/drive9/cli/region.go
+++ b/cmd/drive9/cli/region.go
@@ -131,7 +131,7 @@ func regionListCmd(args []string) error {
 	}
 	for _, entry := range manifest.Regions {
 		if regionModeLabel(entry.Mode) == ModeLabelAnonymous {
-			fmt.Fprintln(os.Stderr, "Note: Anonymous mode in drive9 transfers data management rights to PingCAP.")
+			fmt.Fprintln(os.Stderr, "Note: Anonymous mode is for evaluation and functional testing only. Please do not put production data in it.")
 			break
 		}
 	}


### PR DESCRIPTION
## Summary

Updates the Anonymous mode notice shown by `drive9 create` and `drive9 region list` to clearly state that Anonymous mode is for evaluation and functional testing only, and that production data should not be placed in it.

## Changes
- `cmd/drive9/cli/db.go`: update create-time warning and usage note
- `cmd/drive9/cli/region.go`: update region list warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated anonymous mode help text and warnings to clearly state it is intended for evaluation and functional testing only.
  * Clarified that production data should not be used in anonymous mode.
  * Kept the same guidance consistent in tenant creation and region listing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->