### PR TITLE
chore(drive9-js): bump version to 0.1.2

### DIFF
--- a/clients/drive9-js/package.json
+++ b/clients/drive9-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive9",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "TypeScript SDK for drive9 — an agent-native filesystem with semantic search",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
Bump drive9-js (TypeScript SDK) version from 0.1.1 to 0.1.2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the `drive9` package version to `0.1.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->