### PR TITLE
docs(drive9-js): document downloadDir and archive APIs, bump to 0.1.3

### DIFF
--- a/clients/drive9-js/README.md
+++ b/clients/drive9-js/README.md
@@ -90,8 +90,43 @@ Environment variables `DRIVE9_SERVER` or `DRIVE9_BASE` and `DRIVE9_API_KEY` take
 | Read range stream | `client.readStreamRange(path, offset, length)` |
 | Read range bytes | `client.readAt(path, offset, length)` |
 | Download to local file | `client.downloadToFile(remotePath, localPath)` |
+| Download directory tree | `client.downloadDir(remotePath, localPath)` |
 | Stream writer | `client.newStreamWriter(path, totalSize, options?)` |
 | Append | `client.append(path, data)` |
+
+### Directory archive
+
+Download an entire remote directory tree as a `tar.gz` (or `zip`) archive. Filtering mirrors the
+Go CLI's `drive9 fs archive` (subpath, prefix, exact/glob patterns, profile-based rules).
+
+```typescript
+// Stream a tar.gz to stdout or a file
+const stream = await client.archive("/projects/app", { exclude: ["**/node_modules/**"] });
+const out = createWriteStream("app.tar.gz");
+for await (const chunk of stream) out.write(Buffer.from(chunk));
+out.end();
+
+// Or write directly to a local file (tar.gz or zip)
+await client.archiveToFile("/projects/app", "app.zip", {
+  format: "zip",
+  exclude: ["**/node_modules/**", "**/dist/**"],
+  profile: "coding-agent",
+  jobs: 16,
+  flat: false,
+});
+```
+
+`ArchiveOptions`:
+
+| Option | Description |
+|--------|-------------|
+| `format` | `"tar.gz"` (default) or `"zip"` |
+| `exclude` | Skip paths matching these patterns |
+| `include` | Keep only paths matching these patterns |
+| `profile` | Apply a named profile's rules (e.g. `"coding-agent"`) |
+| `jobs` | Concurrent file downloads (default 16) |
+| `flat` | Strip directory hierarchy; archive basenames only |
+| `signal` | `AbortSignal` to cancel the operation |
 
 `append` uses the native server append flow for existing S3-backed files. When
 native append is unavailable, the SDK only uses a bounded small-file rewrite and

--- a/clients/drive9-js/package.json
+++ b/clients/drive9-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive9",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "TypeScript SDK for drive9 — an agent-native filesystem with semantic search",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
The npm README for `drive9` did not describe the directory archive (`archive`, `archiveToFile`) or `downloadDir` APIs that were added in the directory-archive work. This PR adds a **Directory archive** section to `clients/drive9-js/README.md` with usage examples and an `ArchiveOptions` reference table, lists `downloadDir` in the streaming/multipart operations table, and bumps the package version to `0.1.3` so the updated README ships to the npm registry page.