### PR TITLE
fix: clean up provisioned clusters on tenant create failure

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1415,6 +1415,13 @@ func (s *Store) GetTenantTiDBCloudOrgBinding(ctx context.Context, tenantID strin
 	return &rec, nil
 }
 
+func (s *Store) DeleteTenantTiDBCloudOrgBinding(ctx context.Context, tenantID string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_tidbcloud_org_binding", start, &err)
+	_, err = s.db.ExecContext(ctx, `DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?`, tenantID)
+	return err
+}
+
 func (s *Store) CreateTenantPool(ctx context.Context, p *TenantPool) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "create_tidbcloud_pool", start, &err)

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1415,13 +1415,6 @@ func (s *Store) GetTenantTiDBCloudOrgBinding(ctx context.Context, tenantID strin
 	return &rec, nil
 }
 
-func (s *Store) DeleteTenantTiDBCloudOrgBinding(ctx context.Context, tenantID string) (err error) {
-	start := time.Now()
-	defer observeMeta(ctx, "delete_tidbcloud_org_binding", start, &err)
-	_, err = s.db.ExecContext(ctx, `DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?`, tenantID)
-	return err
-}
-
 func (s *Store) CreateTenantPool(ctx context.Context, p *TenantPool) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "create_tidbcloud_pool", start, &err)
@@ -2464,6 +2457,52 @@ func (s *Store) UpdateTenantConnection(ctx context.Context, id string, cluster *
 		return ErrNotFound
 	}
 	return nil
+}
+
+func (s *Store) UpdateTenantClusterReference(ctx context.Context, id string, cluster *Tenant) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_tenant_cluster_reference", start, &err)
+	if cluster == nil {
+		return fmt.Errorf("tenant cluster reference is required")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE tenants
+		SET db_host = ?, db_port = ?, db_user = ?, db_name = ?, db_tls = ?,
+			provider = ?, cluster_id = ?, branch_id = ?, claim_url = ?, claim_expires_at = ?, updated_at = ?
+		WHERE id = ?`,
+		cluster.DBHost, cluster.DBPort, cluster.DBUser, cluster.DBName, boolToInt(cluster.DBTLS),
+		cluster.Provider, nullStr(cluster.ClusterID), cluster.BranchID, nullStr(cluster.ClaimURL), cluster.ClaimExpiresAt,
+		time.Now().UTC(), id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func (s *Store) ClearTenantProvisionMetadata(ctx context.Context, tenantID string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "clear_tenant_provision_metadata", start, &err)
+	now := time.Now().UTC()
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `UPDATE tenants
+			SET db_host = '', db_port = 0, db_user = '', db_password = ?, db_name = '', db_tls = 1,
+				cluster_id = NULL, branch_id = '', claim_url = NULL, claim_expires_at = NULL, updated_at = ?
+			WHERE id = ?`,
+			[]byte{}, now, tenantID)
+		if err != nil {
+			return err
+		}
+		if err := requireAffected(res); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?`, tenantID); err != nil {
+			return err
+		}
+		return nil
+	})
 }
 
 func (s *Store) UpdateTenantDBCredentialIf(ctx context.Context, id, fromDBUser, dbUser string, dbPasswordCipher []byte) (updated bool, err error) {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -169,21 +169,21 @@ func (f *fakeProvisioner) ProvisionWithCredentialsAndQuota(_ context.Context, te
 }
 
 func (f *fakeProvisioner) Deprovision(_ context.Context, cluster *tenant.ClusterInfo) error {
-	f.deprovisionCalls.Add(1)
 	if cluster != nil {
 		out := *cluster
 		f.lastDeprovision = &out
 	}
+	f.deprovisionCalls.Add(1)
 	return f.deprovisionErr
 }
 
 func (f *fakeProvisioner) DeprovisionWithCredentials(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) error {
-	f.deprovisionCalls.Add(1)
 	f.lastCredentialReq = req
 	if cluster != nil {
 		out := *cluster
 		f.lastDeprovision = &out
 	}
+	f.deprovisionCalls.Add(1)
 	return f.deprovisionErr
 }
 
@@ -219,6 +219,35 @@ func (f *fakeProvisioner) UpdateQuota(_ context.Context, cluster *tenant.Cluster
 
 func (f *fakeProvisioner) ProvisionCallCount() int {
 	return int(f.provisionCalls.Load())
+}
+
+func waitForDeprovisionCalls(t *testing.T, prov *fakeProvisioner, want int32) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if got := prov.deprovisionCalls.Load(); got >= want {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("deprovision calls = %d, want %d", prov.deprovisionCalls.Load(), want)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func waitForTiDBCloudOrgBindingNotFound(t *testing.T, metaStore *meta.Store, tenantID string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if _, err := metaStore.GetTenantTiDBCloudOrgBinding(context.Background(), tenantID); errors.Is(err, meta.ErrNotFound) {
+			return
+		}
+		if time.Now().After(deadline) {
+			binding, err := metaStore.GetTenantTiDBCloudOrgBinding(context.Background(), tenantID)
+			t.Fatalf("tidbcloud org binding = %#v, err = %v, want ErrNotFound", binding, err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 }
 
 type credentialOnlyProvisioner struct {
@@ -860,13 +889,14 @@ func TestProvisionTiDBCloudNativeCreateTimeQuotaRequiresQuotaProvisioner(t *test
 	if !errors.As(err, &provisionErr) || provisionErr.status != http.StatusInternalServerError {
 		t.Fatalf("provision error = %#v, want 500 provisionTenantError", err)
 	}
-	var status string
-	if err := metaStore.DB().QueryRow("SELECT status FROM tenants").Scan(&status); err != nil {
+	var tenantID, status string
+	if err := metaStore.DB().QueryRow("SELECT id, status FROM tenants").Scan(&tenantID, &status); err != nil {
 		t.Fatal(err)
 	}
 	if status != string(meta.TenantFailed) {
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
+	waitForTiDBCloudOrgBindingNotFound(t, metaStore, tenantID)
 }
 
 func TestProvisionTiDBCloudNativeCreateTimeQuotaLocalPersistenceErrorIsInternal(t *testing.T) {
@@ -939,16 +969,15 @@ func TestProvisionTiDBCloudNativeCreateTimeQuotaLocalPersistenceErrorIsInternal(
 	if !errors.As(err, &provisionErr) || provisionErr.status != http.StatusInternalServerError {
 		t.Fatalf("provision error = %#v, want 500 provisionTenantError", err)
 	}
-	if got := prov.deprovisionCalls.Load(); got != 1 {
-		t.Fatalf("deprovision calls = %d, want 1", got)
-	}
-	var status string
-	if err := metaStore.DB().QueryRow("SELECT status FROM tenants").Scan(&status); err != nil {
+	waitForDeprovisionCalls(t, prov, 1)
+	var tenantID, status string
+	if err := metaStore.DB().QueryRow("SELECT id, status FROM tenants").Scan(&tenantID, &status); err != nil {
 		t.Fatal(err)
 	}
 	if status != string(meta.TenantFailed) {
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
+	waitForTiDBCloudOrgBindingNotFound(t, metaStore, tenantID)
 }
 
 func TestProvisionTiDBCloudNativeCleansClusterWhenOrgBindingMissing(t *testing.T) {
@@ -1009,9 +1038,7 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenOrgBindingMissing(t *testing.T
 	if !errors.As(err, &provisionErr) || provisionErr.status != http.StatusBadGateway {
 		t.Fatalf("provision error = %#v, want 502 provisionTenantError", err)
 	}
-	if got := prov.deprovisionCalls.Load(); got != 1 {
-		t.Fatalf("deprovision calls = %d, want 1", got)
-	}
+	waitForDeprovisionCalls(t, prov, 1)
 	if prov.lastDeprovision == nil || prov.lastDeprovision.ClusterID != "native-cluster-missing-org" {
 		t.Fatalf("deprovision cluster = %#v", prov.lastDeprovision)
 	}
@@ -1087,9 +1114,7 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenProvisionReturnsClusterAndErro
 	if err == nil {
 		t.Fatal("provisionTenant error = nil, want provision error")
 	}
-	if got := prov.deprovisionCalls.Load(); got != 1 {
-		t.Fatalf("deprovision calls = %d, want 1", got)
-	}
+	waitForDeprovisionCalls(t, prov, 1)
 	if prov.lastDeprovision == nil || prov.lastDeprovision.ClusterID != "native-cluster-provision-error" {
 		t.Fatalf("deprovision cluster = %#v", prov.lastDeprovision)
 	}
@@ -1097,13 +1122,14 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenProvisionReturnsClusterAndErro
 		t.Fatalf("cleanup credentials = %+v", prov.lastCredentialReq)
 	}
 
-	var status string
-	if err := metaStore.DB().QueryRow("SELECT status FROM tenants").Scan(&status); err != nil {
+	var tenantID, status string
+	if err := metaStore.DB().QueryRow("SELECT id, status FROM tenants").Scan(&tenantID, &status); err != nil {
 		t.Fatal(err)
 	}
 	if status != string(meta.TenantFailed) {
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
+	waitForTiDBCloudOrgBindingNotFound(t, metaStore, tenantID)
 }
 
 func TestProvisionTiDBCloudNativeCleansClusterWhenPasswordEncryptFails(t *testing.T) {
@@ -1157,9 +1183,7 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenPasswordEncryptFails(t *testin
 	if !errors.As(err, &provisionErr) || provisionErr.status != http.StatusInternalServerError {
 		t.Fatalf("provision error = %#v, want 500 provisionTenantError", err)
 	}
-	if got := prov.deprovisionCalls.Load(); got != 1 {
-		t.Fatalf("deprovision calls = %d, want 1", got)
-	}
+	waitForDeprovisionCalls(t, prov, 1)
 	if prov.lastDeprovision == nil || prov.lastDeprovision.ClusterID != "native-cluster-encrypt-error" {
 		t.Fatalf("deprovision cluster = %#v", prov.lastDeprovision)
 	}
@@ -1167,13 +1191,14 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenPasswordEncryptFails(t *testin
 		t.Fatalf("cleanup credentials = %+v", prov.lastCredentialReq)
 	}
 
-	var status string
-	if err := metaStore.DB().QueryRow("SELECT status FROM tenants").Scan(&status); err != nil {
+	var tenantID, status string
+	if err := metaStore.DB().QueryRow("SELECT id, status FROM tenants").Scan(&tenantID, &status); err != nil {
 		t.Fatal(err)
 	}
 	if status != string(meta.TenantFailed) {
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
+	waitForTiDBCloudOrgBindingNotFound(t, metaStore, tenantID)
 }
 
 func TestProvisionTiDBCloudNativeRequiresRequestCredentials(t *testing.T) {
@@ -1799,9 +1824,7 @@ func TestProvisionCleansPartialClusterBeforeMarkingFailed(t *testing.T) {
 	if clusterID != "" {
 		t.Fatalf("tenant cluster_id = %s, want empty after cleanup", clusterID)
 	}
-	if got := prov.deprovisionCalls.Load(); got != 1 {
-		t.Fatalf("deprovision calls = %d, want 1", got)
-	}
+	waitForDeprovisionCalls(t, prov, 1)
 	if prov.lastDeprovision == nil || prov.lastDeprovision.ClusterID != "cluster-after-takeover" {
 		t.Fatalf("deprovision cluster = %#v", prov.lastDeprovision)
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -53,6 +53,24 @@ type fakeProvisioner struct {
 	defaultPrivateKey      string
 }
 
+type failingEncryptor struct {
+	err error
+}
+
+func (e failingEncryptor) Encrypt(context.Context, []byte) ([]byte, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+	return nil, fmt.Errorf("encrypt failed")
+}
+
+func (e failingEncryptor) Decrypt(context.Context, []byte) ([]byte, error) {
+	if e.err != nil {
+		return nil, e.err
+	}
+	return nil, fmt.Errorf("decrypt failed")
+}
+
 func (f *fakeProvisioner) DefaultCredentials() (tenant.CredentialProvisionRequest, bool) {
 	if f.defaultPublicKey == "" || f.defaultPrivateKey == "" {
 		return tenant.CredentialProvisionRequest{}, false
@@ -1017,6 +1035,147 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenOrgBindingMissing(t *testing.T
 	}
 }
 
+func TestProvisionTiDBCloudNativeCleansClusterWhenProvisionReturnsClusterAndError(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{
+		provider:      tenant.ProviderTiDBCloudNative,
+		cloudProvider: "aws",
+		region:        "us-east-1",
+		provisionErr:  fmt.Errorf("wait metadata failed"),
+		cluster: &tenant.ClusterInfo{
+			ClusterID: "native-cluster-provision-error",
+			Password:  "db-pass",
+			DBName:    "customer_db",
+		},
+	}
+	srv := NewWithConfig(Config{
+		Meta:                         metaStore,
+		Pool:                         pool,
+		Provisioner:                  prov,
+		TokenSecret:                  tokenSecret,
+		DisableDatabaseAutoEmbedding: true,
+	})
+	defer srv.Close()
+
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}
+	_, err = srv.provisionTenant(context.Background(), provisionTenantOptions{
+		KeyName:               "default",
+		TokenVersion:          1,
+		CredentialProvisioner: &cred,
+	})
+	if err == nil {
+		t.Fatal("provisionTenant error = nil, want provision error")
+	}
+	if got := prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	if prov.lastDeprovision == nil || prov.lastDeprovision.ClusterID != "native-cluster-provision-error" {
+		t.Fatalf("deprovision cluster = %#v", prov.lastDeprovision)
+	}
+	if prov.lastCredentialReq.PublicKey != "public-1" || prov.lastCredentialReq.PrivateKey != "private-1" {
+		t.Fatalf("cleanup credentials = %+v", prov.lastCredentialReq)
+	}
+
+	var status string
+	if err := metaStore.DB().QueryRow("SELECT status FROM tenants").Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantFailed) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
+	}
+}
+
+func TestProvisionTiDBCloudNativeCleansClusterWhenPasswordEncryptFails(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, failingEncryptor{err: fmt.Errorf("kms unavailable")})
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{
+		provider:      tenant.ProviderTiDBCloudNative,
+		cloudProvider: "aws",
+		region:        "us-east-1",
+		cluster: &tenant.ClusterInfo{
+			ClusterID:      "native-cluster-encrypt-error",
+			OrganizationID: "org-1",
+			Host:           "db.example",
+			Port:           4000,
+			Username:       "u1.root",
+			Password:       "db-pass",
+			DBName:         "customer_db",
+		},
+	}
+	srv := NewWithConfig(Config{
+		Meta:                         metaStore,
+		Pool:                         pool,
+		Provisioner:                  prov,
+		TokenSecret:                  tokenSecret,
+		DisableDatabaseAutoEmbedding: true,
+	})
+	defer srv.Close()
+
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}
+	_, err = srv.provisionTenant(context.Background(), provisionTenantOptions{
+		KeyName:               "default",
+		TokenVersion:          1,
+		CredentialProvisioner: &cred,
+	})
+	if err == nil {
+		t.Fatal("provisionTenant error = nil, want encrypt error")
+	}
+	var provisionErr *provisionTenantError
+	if !errors.As(err, &provisionErr) || provisionErr.status != http.StatusInternalServerError {
+		t.Fatalf("provision error = %#v, want 500 provisionTenantError", err)
+	}
+	if got := prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	if prov.lastDeprovision == nil || prov.lastDeprovision.ClusterID != "native-cluster-encrypt-error" {
+		t.Fatalf("deprovision cluster = %#v", prov.lastDeprovision)
+	}
+	if prov.lastCredentialReq.PublicKey != "public-1" || prov.lastCredentialReq.PrivateKey != "private-1" {
+		t.Fatalf("cleanup credentials = %+v", prov.lastCredentialReq)
+	}
+
+	var status string
+	if err := metaStore.DB().QueryRow("SELECT status FROM tenants").Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantFailed) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
+	}
+}
+
 func TestProvisionTiDBCloudNativeRequiresRequestCredentials(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -1567,7 +1726,7 @@ func TestProvisionPersistsTenantBeforeProvisionFailure(t *testing.T) {
 	}
 }
 
-func TestProvisionPersistsPartialClusterBeforeMarkingFailed(t *testing.T) {
+func TestProvisionCleansPartialClusterBeforeMarkingFailed(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -1627,30 +1786,27 @@ func TestProvisionPersistsPartialClusterBeforeMarkingFailed(t *testing.T) {
 		t.Fatalf("status=%d, want %d", resp.StatusCode, http.StatusBadGateway)
 	}
 
-	var status, provider, clusterID, host, user, dbName string
-	var port int
-	var passCipher []byte
+	var status, clusterID string
 	if err := metaStore.DB().QueryRow(`
-		SELECT status, provider, cluster_id, db_host, db_port, db_user, db_password, db_name
+		SELECT status, COALESCE(cluster_id, '')
 		FROM tenants LIMIT 1`,
-	).Scan(&status, &provider, &clusterID, &host, &port, &user, &passCipher, &dbName); err != nil {
+	).Scan(&status, &clusterID); err != nil {
 		t.Fatalf("QueryRow tenant: %v", err)
 	}
 	if status != string(meta.TenantFailed) {
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
-	if provider != tenant.ProviderTiDBCloudNative || clusterID != "cluster-after-takeover" {
-		t.Fatalf("tenant provider/cluster = %s/%s, want %s/cluster-after-takeover", provider, clusterID, tenant.ProviderTiDBCloudNative)
+	if clusterID != "" {
+		t.Fatalf("tenant cluster_id = %s, want empty after cleanup", clusterID)
 	}
-	if host != "db.example" || port != 4000 || user != "u1.root" || dbName != "test" {
-		t.Fatalf("tenant connection = %s:%d %s/%s, want db.example:4000 u1.root/test", host, port, user, dbName)
+	if got := prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
 	}
-	plain, err := pool.Decrypt(context.Background(), passCipher)
-	if err != nil {
-		t.Fatalf("decrypt persisted password: %v", err)
+	if prov.lastDeprovision == nil || prov.lastDeprovision.ClusterID != "cluster-after-takeover" {
+		t.Fatalf("deprovision cluster = %#v", prov.lastDeprovision)
 	}
-	if string(plain) != "secret" {
-		t.Fatalf("persisted password = %q, want secret", plain)
+	if prov.lastCredentialReq.PublicKey != "default-public" || prov.lastCredentialReq.PrivateKey != "default-private" {
+		t.Fatalf("cleanup credentials = %+v", prov.lastCredentialReq)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -897,6 +897,13 @@ func TestProvisionTiDBCloudNativeCreateTimeQuotaRequiresQuotaProvisioner(t *test
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
 	waitForTiDBCloudOrgBindingNotFound(t, metaStore, tenantID)
+	var clusterID string
+	if err := metaStore.DB().QueryRow("SELECT COALESCE(cluster_id, '') FROM tenants WHERE id = ?", tenantID).Scan(&clusterID); err != nil {
+		t.Fatal(err)
+	}
+	if clusterID != "" {
+		t.Fatalf("tenant cluster_id = %s, want empty after cleanup", clusterID)
+	}
 }
 
 func TestProvisionTiDBCloudNativeCreateTimeQuotaLocalPersistenceErrorIsInternal(t *testing.T) {
@@ -1114,6 +1121,10 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenProvisionReturnsClusterAndErro
 	if err == nil {
 		t.Fatal("provisionTenant error = nil, want provision error")
 	}
+	var provisionErr *provisionTenantError
+	if !errors.As(err, &provisionErr) || provisionErr.status != http.StatusBadGateway {
+		t.Fatalf("provision error = %#v, want 502 provisionTenantError", err)
+	}
 	waitForDeprovisionCalls(t, prov, 1)
 	if prov.lastDeprovision == nil || prov.lastDeprovision.ClusterID != "native-cluster-provision-error" {
 		t.Fatalf("deprovision cluster = %#v", prov.lastDeprovision)
@@ -1130,6 +1141,83 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenProvisionReturnsClusterAndErro
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
 	waitForTiDBCloudOrgBindingNotFound(t, metaStore, tenantID)
+}
+
+func TestProvisionTiDBCloudNativePersistsClusterReferenceWhenCleanupFails(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{
+		provider:       tenant.ProviderTiDBCloudNative,
+		cloudProvider:  "aws",
+		region:         "us-east-1",
+		provisionErr:   fmt.Errorf("wait metadata failed"),
+		deprovisionErr: fmt.Errorf("delete unavailable"),
+		cluster: &tenant.ClusterInfo{
+			ClusterID: "native-cluster-cleanup-error",
+			Host:      "db.example",
+			Port:      4000,
+			Username:  "u1.root",
+			Password:  "db-pass",
+			DBName:    "customer_db",
+		},
+	}
+	srv := NewWithConfig(Config{
+		Meta:                         metaStore,
+		Pool:                         pool,
+		Provisioner:                  prov,
+		TokenSecret:                  tokenSecret,
+		DisableDatabaseAutoEmbedding: true,
+	})
+	defer srv.Close()
+
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}
+	_, err = srv.provisionTenant(context.Background(), provisionTenantOptions{
+		KeyName:               "default",
+		TokenVersion:          1,
+		CredentialProvisioner: &cred,
+	})
+	if err == nil {
+		t.Fatal("provisionTenant error = nil, want provision error")
+	}
+	waitForDeprovisionCalls(t, prov, 1)
+
+	var status, provider, clusterID, host, user, dbName string
+	var port int
+	if err := metaStore.DB().QueryRow(`
+		SELECT status, provider, COALESCE(cluster_id, ''), db_host, db_port, db_user, db_name
+		FROM tenants LIMIT 1`,
+	).Scan(&status, &provider, &clusterID, &host, &port, &user, &dbName); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantFailed) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
+	}
+	if provider != tenant.ProviderTiDBCloudNative || clusterID != "native-cluster-cleanup-error" {
+		t.Fatalf("tenant provider/cluster = %s/%s, want %s/native-cluster-cleanup-error", provider, clusterID, tenant.ProviderTiDBCloudNative)
+	}
+	if host != "db.example" || port != 4000 || user != "u1.root" || dbName != "customer_db" {
+		t.Fatalf("tenant reference = %s:%d %s/%s, want db.example:4000 u1.root/customer_db", host, port, user, dbName)
+	}
 }
 
 func TestProvisionTiDBCloudNativeCleansClusterWhenPasswordEncryptFails(t *testing.T) {
@@ -1199,6 +1287,13 @@ func TestProvisionTiDBCloudNativeCleansClusterWhenPasswordEncryptFails(t *testin
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
 	waitForTiDBCloudOrgBindingNotFound(t, metaStore, tenantID)
+	var clusterID string
+	if err := metaStore.DB().QueryRow("SELECT COALESCE(cluster_id, '') FROM tenants WHERE id = ?", tenantID).Scan(&clusterID); err != nil {
+		t.Fatal(err)
+	}
+	if clusterID != "" {
+		t.Fatalf("tenant cluster_id = %s, want empty after cleanup", clusterID)
+	}
 }
 
 func TestProvisionTiDBCloudNativeRequiresRequestCredentials(t *testing.T) {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -250,6 +250,28 @@ func waitForTiDBCloudOrgBindingNotFound(t *testing.T, metaStore *meta.Store, ten
 	}
 }
 
+func waitForTenantClusterReference(t *testing.T, metaStore *meta.Store, tenantID, wantClusterID string) (status, provider, clusterID, host, user, dbName string, port int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		err := metaStore.DB().QueryRow(`
+			SELECT status, provider, COALESCE(cluster_id, ''), db_host, db_port, db_user, db_name
+			FROM tenants WHERE id = ?`,
+			tenantID,
+		).Scan(&status, &provider, &clusterID, &host, &port, &user, &dbName)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if clusterID == wantClusterID {
+			return status, provider, clusterID, host, user, dbName, port
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("tenant cluster_id = %s, want %s", clusterID, wantClusterID)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 type credentialOnlyProvisioner struct {
 	provider string
 	cluster  *tenant.ClusterInfo
@@ -1201,14 +1223,11 @@ func TestProvisionTiDBCloudNativePersistsClusterReferenceWhenCleanupFails(t *tes
 	}
 	waitForDeprovisionCalls(t, prov, 1)
 
-	var status, provider, clusterID, host, user, dbName string
-	var port int
-	if err := metaStore.DB().QueryRow(`
-		SELECT status, provider, COALESCE(cluster_id, ''), db_host, db_port, db_user, db_name
-		FROM tenants LIMIT 1`,
-	).Scan(&status, &provider, &clusterID, &host, &port, &user, &dbName); err != nil {
+	var tenantID string
+	if err := metaStore.DB().QueryRow("SELECT id FROM tenants LIMIT 1").Scan(&tenantID); err != nil {
 		t.Fatal(err)
 	}
+	status, provider, clusterID, host, user, dbName, port := waitForTenantClusterReference(t, metaStore, tenantID, "native-cluster-cleanup-error")
 	if status != string(meta.TenantFailed) {
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
@@ -1906,20 +1925,18 @@ func TestProvisionCleansPartialClusterBeforeMarkingFailed(t *testing.T) {
 		t.Fatalf("status=%d, want %d", resp.StatusCode, http.StatusBadGateway)
 	}
 
-	var status, clusterID string
+	var tenantID, status string
 	if err := metaStore.DB().QueryRow(`
-		SELECT status, COALESCE(cluster_id, '')
+		SELECT id, status
 		FROM tenants LIMIT 1`,
-	).Scan(&status, &clusterID); err != nil {
+	).Scan(&tenantID, &status); err != nil {
 		t.Fatalf("QueryRow tenant: %v", err)
 	}
 	if status != string(meta.TenantFailed) {
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantFailed)
 	}
-	if clusterID != "" {
-		t.Fatalf("tenant cluster_id = %s, want empty after cleanup", clusterID)
-	}
 	waitForDeprovisionCalls(t, prov, 1)
+	waitForTenantClusterReference(t, metaStore, tenantID, "")
 	if prov.lastDeprovision == nil || prov.lastDeprovision.ClusterID != "cluster-after-takeover" {
 		t.Fatalf("deprovision cluster = %#v", prov.lastDeprovision)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4765,13 +4765,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encrypt db password", err)
 	}
 	logProvisionStage(ctx, "provision_db_password_encrypted", tenantID, provider, stageStarted)
-	dbtls := true
-	if provider == tenant.ProviderTiDBCloudNative {
-		v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
-		if v == "1" || v == "true" || v == "yes" {
-			dbtls = false
-		}
-	}
+	dbtls := dbTLSForProvisionedTenant(provider)
 	stageStarted = time.Now()
 	if err := s.meta.UpdateTenantConnection(ctx, tenantID, &meta.Tenant{
 		DBHost:           cluster.Host,
@@ -4858,13 +4852,20 @@ func (s *Server) cleanupProvisionedClusterAfterProvisionFailure(ctx context.Cont
 		return
 	}
 	t := &meta.Tenant{
-		ID:        tenantID,
-		Provider:  provider,
-		ClusterID: cluster.ClusterID,
-		DBHost:    cluster.Host,
-		DBPort:    cluster.Port,
-		DBUser:    cluster.Username,
-		DBName:    cluster.DBName,
+		ID:             tenantID,
+		Provider:       provider,
+		ClusterID:      cluster.ClusterID,
+		BranchID:       cluster.BranchID,
+		DBHost:         cluster.Host,
+		DBPort:         cluster.Port,
+		DBUser:         cluster.Username,
+		DBName:         cluster.DBName,
+		DBTLS:          dbTLSForProvisionedTenant(provider),
+		ClaimURL:       cluster.ClaimURL,
+		ClaimExpiresAt: cluster.ClaimExpiresAt,
+	}
+	if uerr := s.meta.UpdateTenantClusterReference(cleanupCtx, tenantID, t); uerr != nil {
+		logger.Error(cleanupCtx, "server_event", eventFields(cleanupCtx, "provision_cluster_cleanup_reference_persist_failed", "tenant_id", tenantID, "provider", provider, "reason", reason, "cluster_id", cluster.ClusterID, "error", uerr)...)
 	}
 	var req tenant.CredentialProvisionRequest
 	if provider == tenant.ProviderTiDBCloudNative {
@@ -4888,6 +4889,14 @@ func (s *Server) cleanupProvisionedClusterAfterProvisionFailure(ctx context.Cont
 			logger.Error(workerCtx, "server_event", eventFields(workerCtx, "provision_metadata_cleanup_failed", "tenant_id", tenantID, "provider", provider, "reason", reason, "cluster_id", cluster.ClusterID, "error", err)...)
 		}
 	})
+}
+
+func dbTLSForProvisionedTenant(provider string) bool {
+	if provider != tenant.ProviderTiDBCloudNative {
+		return true
+	}
+	v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))
+	return v != "1" && v != "true" && v != "yes"
 }
 
 func provisioningCloudRegion(provisioner tenant.Provisioner) (string, string) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4879,12 +4879,13 @@ func (s *Server) cleanupProvisionedClusterAfterProvisionFailure(ctx context.Cont
 		defer cancel()
 		if err := s.deprovisionTenantCluster(workerCtx, t, req); err != nil {
 			logger.Error(workerCtx, "server_event", eventFields(workerCtx, "provision_cluster_cleanup_failed", "tenant_id", tenantID, "provider", provider, "reason", reason, "cluster_id", cluster.ClusterID, "error", err)...)
+			if uerr := s.meta.UpdateTenantClusterReference(workerCtx, tenantID, t); uerr != nil {
+				logger.Error(workerCtx, "server_event", eventFields(workerCtx, "provision_cluster_cleanup_reference_persist_failed", "tenant_id", tenantID, "provider", provider, "reason", reason, "cluster_id", cluster.ClusterID, "error", uerr)...)
+			}
 			return
 		}
-		if provider == tenant.ProviderTiDBCloudNative {
-			if err := s.meta.DeleteTenantTiDBCloudOrgBinding(workerCtx, tenantID); err != nil {
-				logger.Error(workerCtx, "server_event", eventFields(workerCtx, "provision_tidbcloud_org_binding_cleanup_failed", "tenant_id", tenantID, "provider", provider, "reason", reason, "cluster_id", cluster.ClusterID, "error", err)...)
-			}
+		if err := s.meta.ClearTenantProvisionMetadata(workerCtx, tenantID); err != nil {
+			logger.Error(workerCtx, "server_event", eventFields(workerCtx, "provision_metadata_cleanup_failed", "tenant_id", tenantID, "provider", provider, "reason", reason, "cluster_id", cluster.ClusterID, "error", err)...)
 		}
 	})
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -276,11 +276,12 @@ type TenantStatusResponse struct {
 }
 
 const (
-	maxBatchStatPaths                     = 256
-	maxBatchReadSmallPaths                = 128
-	maxBatchReadSmallBytes                = 50_000
-	defaultBatchReadMaxBody               = 1 << 20
-	maxCredentialProvisionBodyBytes int64 = 1 << 20
+	maxBatchStatPaths                           = 256
+	maxBatchReadSmallPaths                      = 128
+	maxBatchReadSmallBytes                      = 50_000
+	defaultBatchReadMaxBody                     = 1 << 20
+	maxCredentialProvisionBodyBytes       int64 = 1 << 20
+	provisionFailureClusterCleanupTimeout       = 2 * time.Minute
 )
 
 func New(b *backend.Dat9Backend) *Server {
@@ -4714,13 +4715,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "cluster_error")
-		if cluster != nil && strings.TrimSpace(cluster.ClusterID) != "" {
-			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "cluster_provision_error")
-		} else {
-			if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
-				logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
-			}
-		}
+		s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "cluster_provision_error")
 		msg := fmt.Sprintf("provision tenant cluster failed: %v", err)
 		if strings.Contains(strings.ToLower(err.Error()), "free cluster") {
 			msg = "TiDB Cloud free cluster limit reached. Set a monthly Spending Limit to continue. See https://www.pingcap.com/tidb-cloud-starter-pricing-details/#cost-and-limitations"
@@ -4855,13 +4850,13 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 }
 
 func (s *Server) cleanupProvisionedClusterAfterProvisionFailure(ctx context.Context, tenantID, provider string, cluster *tenant.ClusterInfo, cred *tenant.CredentialProvisionRequest, reason string) {
-	if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
-		logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
+	cleanupCtx := backgroundWithTrace(ctx)
+	if uerr := s.meta.UpdateTenantStatus(cleanupCtx, tenantID, meta.TenantFailed); uerr != nil {
+		logger.Error(cleanupCtx, "server_event", eventFields(cleanupCtx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
 	}
 	if cluster == nil || strings.TrimSpace(cluster.ClusterID) == "" {
 		return
 	}
-	cleanupCtx := backgroundWithTrace(ctx)
 	t := &meta.Tenant{
 		ID:        tenantID,
 		Provider:  provider,
@@ -4879,9 +4874,19 @@ func (s *Server) cleanupProvisionedClusterAfterProvisionFailure(ctx context.Cont
 		}
 		req = *cred
 	}
-	if err := s.deprovisionTenantCluster(cleanupCtx, t, req); err != nil {
-		logger.Error(cleanupCtx, "server_event", eventFields(cleanupCtx, "provision_cluster_cleanup_failed", "tenant_id", tenantID, "provider", provider, "reason", reason, "cluster_id", cluster.ClusterID, "error", err)...)
-	}
+	s.startServerWorker(cleanupCtx, func(workerCtx context.Context) {
+		workerCtx, cancel := context.WithTimeout(workerCtx, provisionFailureClusterCleanupTimeout)
+		defer cancel()
+		if err := s.deprovisionTenantCluster(workerCtx, t, req); err != nil {
+			logger.Error(workerCtx, "server_event", eventFields(workerCtx, "provision_cluster_cleanup_failed", "tenant_id", tenantID, "provider", provider, "reason", reason, "cluster_id", cluster.ClusterID, "error", err)...)
+			return
+		}
+		if provider == tenant.ProviderTiDBCloudNative {
+			if err := s.meta.DeleteTenantTiDBCloudOrgBinding(workerCtx, tenantID); err != nil {
+				logger.Error(workerCtx, "server_event", eventFields(workerCtx, "provision_tidbcloud_org_binding_cleanup_failed", "tenant_id", tenantID, "provider", provider, "reason", reason, "cluster_id", cluster.ClusterID, "error", err)...)
+			}
+		}
+	})
 }
 
 func provisioningCloudRegion(provisioner tenant.Provisioner) (string, string) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4714,9 +4714,12 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "cluster_error")
-		s.persistFailedProvisionClusterInfo(context.Background(), tenantID, provider, cluster)
-		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
-			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
+		if cluster != nil && strings.TrimSpace(cluster.ClusterID) != "" {
+			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "cluster_provision_error")
+		} else {
+			if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
+				logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
+			}
 		}
 		msg := fmt.Sprintf("provision tenant cluster failed: %v", err)
 		if strings.Contains(strings.ToLower(err.Error()), "free cluster") {
@@ -4763,9 +4766,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	if err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_encrypt_db_password_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
-		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
-			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
-		}
+		s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "password_encrypt_error")
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to encrypt db password", err)
 	}
 	logProvisionStage(ctx, "provision_db_password_encrypted", tenantID, provider, stageStarted)
@@ -4791,9 +4792,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	}); err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_update_tenant_connection_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
-		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
-			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
-		}
+		s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "connection_persist_error")
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist tenant connection", err)
 	}
 	logProvisionStage(ctx, "provision_tenant_connection_persisted", tenantID, provider, stageStarted, "cluster_id", cluster.ClusterID, "db_tls", dbtls)
@@ -4801,9 +4800,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantProvisioning); err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_update_tenant_status_failed", "tenant_id", tenantID, "provider", provider, "status", meta.TenantProvisioning, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
-		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
-			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
-		}
+		s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "status_update_error")
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to update tenant status", err)
 	}
 	logProvisionStage(ctx, "provision_tenant_status_updated", tenantID, provider, stageStarted, "status", meta.TenantProvisioning)
@@ -4832,7 +4829,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_insert_api_key_failed", "tenant_id", tenantID, "api_key_id", apiKeyID, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
 		metricEvent(ctx, "metadb_query", "api", "insert_api_key", "result", "error")
-		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+		s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "api_key_persist_error")
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to persist api key", err)
 	}
 	logProvisionStage(ctx, "provision_api_key_issued", tenantID, provider, stageStarted, "api_key_id", apiKeyID)
@@ -4896,34 +4893,6 @@ func provisioningCloudRegion(provisioner tenant.Provisioner) (string, string) {
 		return "", ""
 	}
 	return strings.TrimSpace(regionProvider.ProvisioningCloudProvider()), strings.TrimSpace(regionProvider.ProvisioningRegion())
-}
-
-func (s *Server) persistFailedProvisionClusterInfo(ctx context.Context, tenantID, provider string, cluster *tenant.ClusterInfo) {
-	if cluster == nil || cluster.ClusterID == "" {
-		return
-	}
-	cluster.Provider = provider
-	cipherPass, err := s.pool.Encrypt(ctx, []byte(cluster.Password))
-	if err != nil {
-		logger.Error(ctx, "server_event", eventFields(ctx, "provision_failed_cluster_encrypt_password_failed", "tenant_id", tenantID, "provider", provider, "cluster_id", cluster.ClusterID, "error", err)...)
-		return
-	}
-	if err := s.meta.UpdateTenantConnection(ctx, tenantID, &meta.Tenant{
-		DBHost:           cluster.Host,
-		DBPort:           cluster.Port,
-		DBUser:           cluster.Username,
-		DBPasswordCipher: cipherPass,
-		DBName:           cluster.DBName,
-		DBTLS:            true,
-		Provider:         provider,
-		ClusterID:        cluster.ClusterID,
-		ClaimURL:         cluster.ClaimURL,
-		ClaimExpiresAt:   cluster.ClaimExpiresAt,
-	}); err != nil {
-		logger.Error(ctx, "server_event", eventFields(ctx, "provision_failed_cluster_persist_connection_failed", "tenant_id", tenantID, "provider", provider, "cluster_id", cluster.ClusterID, "error", err)...)
-		return
-	}
-	logger.Info(ctx, "server_event", eventFields(ctx, "provision_failed_cluster_persisted", "tenant_id", tenantID, "provider", provider, "cluster_id", cluster.ClusterID)...)
 }
 
 func (s *Server) startProvisionedTenantSchemaInit(ctx context.Context, res *provisionTenantResult) {


### PR DESCRIPTION
## Summary
- clean up TiDB Cloud clusters when tenant creation fails after a cluster has already been created
- route post-cluster local failures through the existing cleanup path instead of leaving failed tenants with leaked clusters
- update provision tests for partial-cluster errors and password encryption failures

## Tests
- `TESTCONTAINERS_RYUK_DISABLED=true go test ./pkg/server -run 'TestProvisionTiDBCloudNativeCleansClusterWhen(OrgBindingMissing|ProvisionReturnsClusterAndError|PasswordEncryptFails)|TestProvisionTiDBCloudNativeCreateTimeQuotaLocalPersistenceErrorIsInternal|TestProvisionCleansPartialClusterBeforeMarkingFailed' -count=1`\n- `TESTCONTAINERS_RYUK_DISABLED=true go test ./pkg/server`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of TiDB Cloud Native provisioning failures to reliably deprovision partially created clusters.
  * Ensures tenant provisioning metadata and related credentials are cleaned up consistently across multiple failure paths (including password encryption and status transition errors).
  * Clears tenant `cluster_id` and connection fields after cleanup to prevent stale provisioning data.
  * Expanded and stabilized automated tests to validate these cleanup outcomes deterministically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->