### PR TITLE
fix: clarify Anonymous mode messaging to build trust

### DIFF
--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -148,7 +148,7 @@ func Create(args []string) error {
 	}
 
 	if mode == RegionModeAnonymous {
-		fmt.Fprintf(os.Stderr, "Note: Anonymous mode is for evaluation and functional testing only. Please do not put production data in it.\n")
+		fmt.Fprintf(os.Stderr, "Anonymous mode: a quick-start workspace hosted by TiDB. Your files are tenant-isolated and encrypted in transit. For a workspace tied to your own account (recommended for important data), sign up at drive9.ai. Details: drive9.ai/security\n")
 	}
 
 	cfg := loadConfig()
@@ -290,7 +290,7 @@ examples:
   # list available regions
   drive9 region list
 
-note: Anonymous mode is for evaluation and functional testing only. Please do not put production data in it.`
+note: Anonymous mode is a quick-start workspace hosted by TiDB — tenant-isolated, encrypted in transit. Sign up at drive9.ai for your own account workspace. Details: drive9.ai/security`
 }
 
 func provisionModeForCredentials(publicKey, privateKey string) string {

--- a/cmd/drive9/cli/db.go
+++ b/cmd/drive9/cli/db.go
@@ -148,7 +148,7 @@ func Create(args []string) error {
 	}
 
 	if mode == RegionModeAnonymous {
-		fmt.Fprintf(os.Stderr, "Anonymous mode: a quick-start workspace hosted by TiDB. Your files are tenant-isolated and encrypted in transit. For a workspace tied to your own account (recommended for important data), sign up at drive9.ai. Details: drive9.ai/security\n")
+		fmt.Fprintf(os.Stderr, "Anonymous mode: a quick-start workspace hosted by TiDB. Your files are tenant-isolated and encrypted in transit. For a workspace tied to your own TiDB Cloud account, re-run drive9 create with --tidbcloud-public-key and --tidbcloud-private-key. Details: drive9.ai/security\n")
 	}
 
 	cfg := loadConfig()
@@ -290,7 +290,7 @@ examples:
   # list available regions
   drive9 region list
 
-note: Anonymous mode is a quick-start workspace hosted by TiDB — tenant-isolated, encrypted in transit. Sign up at drive9.ai for your own account workspace. Details: drive9.ai/security`
+note: Anonymous mode is a quick-start workspace hosted by TiDB — tenant-isolated, encrypted in transit. For an account-bound workspace, pass your TiDB Cloud keys to drive9 create (TiDBCloud Mode). Details: drive9.ai/security`
 }
 
 func provisionModeForCredentials(publicKey, privateKey string) string {

--- a/cmd/drive9/cli/region.go
+++ b/cmd/drive9/cli/region.go
@@ -131,7 +131,7 @@ func regionListCmd(args []string) error {
 	}
 	for _, entry := range manifest.Regions {
 		if regionModeLabel(entry.Mode) == ModeLabelAnonymous {
-			fmt.Fprintln(os.Stderr, "Note: Anonymous mode is for evaluation and functional testing only. Please do not put production data in it.")
+			fmt.Fprintln(os.Stderr, "Note: Anonymous mode is a quick-start workspace hosted by TiDB — tenant-isolated, encrypted in transit. Sign up at drive9.ai for your own account workspace. Details: drive9.ai/security")
 			break
 		}
 	}

--- a/cmd/drive9/cli/region.go
+++ b/cmd/drive9/cli/region.go
@@ -131,7 +131,7 @@ func regionListCmd(args []string) error {
 	}
 	for _, entry := range manifest.Regions {
 		if regionModeLabel(entry.Mode) == ModeLabelAnonymous {
-			fmt.Fprintln(os.Stderr, "Note: Anonymous mode is a quick-start workspace hosted by TiDB — tenant-isolated, encrypted in transit. Sign up at drive9.ai for your own account workspace. Details: drive9.ai/security")
+			fmt.Fprintln(os.Stderr, "Note: Anonymous mode is a quick-start workspace hosted by TiDB — tenant-isolated, encrypted in transit. For an account-bound workspace, pass your TiDB Cloud keys to drive9 create (TiDBCloud Mode). Details: drive9.ai/security")
 			break
 		}
 	}

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -161,7 +161,7 @@ func TestDispatchHelpCommandShowsVisualTreeHelp(t *testing.T) {
 		"drive9 <command> [args] [flags]",
 		"drive9 fs <command> [arguments]",
 		"drive9 git <clone|worktree|hydrate>",
-		"Anonymous mode transfers data management rights to PingCAP",
+		"Anonymous mode is a quick-start workspace hosted by TiDB",
 		"--tidbcloud-public-key KEY",
 		"--tidbcloud-private-key KEY",
 		"drive9 region list [--json] [--manifest-url URL]",

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -431,7 +431,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 			Summary: "provision a new tenant and save an owner context",
 			Details: []string{
 				"no TiDB Cloud keys -> Anonymous mode; TiDB Cloud keys -> TiDBCloud Mode",
-				"Anonymous mode transfers data management rights to PingCAP",
+				"Anonymous mode is a quick-start workspace hosted by TiDB so you can try drive9 without an account; files are tenant-isolated and encrypted in transit. Sign up at drive9.ai for a workspace tied to your own account. Details: drive9.ai/security",
 			},
 			Flags: []visualHelpFlag{
 				{Name: "--name NAME", Desc: "context name; defaults to an auto-generated 7-character name"},
@@ -665,7 +665,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 			},
 			Details: []string{
 				"text output columns: REGION CODE, CLOUD PROVIDER, REGION, MODE, SERVER",
-				"Anonymous regions print a data-management rights note on stderr",
+				"Anonymous regions print a tenant-isolation and encryption note on stderr",
 			},
 			Examples: []visualHelpExample{
 				{Command: "drive9 region list", Desc: "human-readable regions"},

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -431,7 +431,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 			Summary: "provision a new tenant and save an owner context",
 			Details: []string{
 				"no TiDB Cloud keys -> Anonymous mode; TiDB Cloud keys -> TiDBCloud Mode",
-				"Anonymous mode is a quick-start workspace hosted by TiDB so you can try drive9 without an account; files are tenant-isolated and encrypted in transit. Sign up at drive9.ai for a workspace tied to your own account. Details: drive9.ai/security",
+				"Anonymous mode is a quick-start workspace hosted by TiDB so you can try drive9 without TiDB Cloud credentials; files are tenant-isolated and encrypted in transit. For a workspace tied to your own TiDB Cloud account, run drive9 create with your TiDB Cloud keys. Details: drive9.ai/security",
 			},
 			Flags: []visualHelpFlag{
 				{Name: "--name NAME", Desc: "context name; defaults to an auto-generated 7-character name"},


### PR DESCRIPTION
## Summary

Fixes the P0 trust-copy issue for Anonymous mode. The previous wording
("Anonymous mode transfers data management rights to PingCAP") was vague
and read like the user gives up data ownership. Developers react worse to
ambiguous data terms than to strict ones, so this replaces it with a clear,
factual explanation.

## Changes

- `cmd/drive9/visual_help.go` — `create` command detail now explains Anonymous
  mode is a TiDB-hosted quick-start workspace (tenant-isolated, encrypted in
  transit) and points to `drive9.ai` / `drive9.ai/security`.
- `cmd/drive9/visual_help.go` — region-list detail note updated ("data-management
  rights note" -> "tenant-isolation and encryption note").
- `cmd/drive9/cli/db.go` — provision (`create`) stderr note and help text updated.
- `cmd/drive9/cli/region.go` — `region list` stderr note updated.
- `cmd/drive9/main_test.go` — updated the help-output assertion to match.

## Test

`go test ./cmd/drive9/ ./cmd/drive9/cli/` passes.

## Note

The companion `skill.md` Setup wording (1.2) and the security-page FAQ live in
`mem9-ai/drive9-fe`; a separate PR covers `skill.md` there.
