### PR TITLE
feat: add alicloud private endpoint domain env var + cloud provider constants

### DIFF
--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -8,6 +8,9 @@ import (
 	"fmt"
 	"sync/atomic"
 	"time"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"go.uber.org/zap"
 )
 
 // QuotaConfig holds per-tenant quota limits stored in the central server DB.
@@ -148,6 +151,9 @@ func (s *Store) GetQuotaConfigVersion(ctx context.Context, tenantID string) (str
 		 FROM tenant_quota_config WHERE tenant_id = ?`, tenantID,
 	).Scan(&maxStorageBytes, &maxFileSizeBytes, &maxFileCount, &maxMediaLLMFiles, &maxMonthlyCostMC)
 	if err == sql.ErrNoRows {
+		logger.Info(ctx, "quota_config_not_found_using_defaults",
+			zap.String("tenant_id", tenantID))
+		err = nil
 		return "", nil
 	}
 	if err != nil {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -29,15 +29,15 @@ import (
 )
 
 const (
-	EnvTiDBCloudNativeAPIURL               = "DRIVE9_TIDBCLOUD_NATIVE_API_URL"
-	EnvTiDBCloudNativeCloudProvider        = "DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER"
-	EnvTiDBCloudNativeRegion               = "DRIVE9_TIDBCLOUD_NATIVE_REGION"
-	EnvTiDBCloudNativeDefaultDatabaseName  = "DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME"
-	EnvTiDBCloudDefaultSpendingLimit       = "DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT"
-	EnvTiDBCloudNativePublicKey            = "DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY"
-	EnvTiDBCloudNativePrivateKey           = "DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY"
-	EnvTiDBCloudNativeUsePrivateEndpoint   = "DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT"
-	EnvTiDBCloudTencentPrivateEndpointHost = "DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST"
+	EnvTiDBCloudNativeAPIURL                  = "DRIVE9_TIDBCLOUD_NATIVE_API_URL"
+	EnvTiDBCloudNativeCloudProvider           = "DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER"
+	EnvTiDBCloudNativeRegion                  = "DRIVE9_TIDBCLOUD_NATIVE_REGION"
+	EnvTiDBCloudNativeDefaultDatabaseName     = "DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME"
+	EnvTiDBCloudDefaultSpendingLimit          = "DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT"
+	EnvTiDBCloudNativePublicKey               = "DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY"
+	EnvTiDBCloudNativePrivateKey              = "DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY"
+	EnvTiDBCloudNativeUsePrivateEndpoint      = "DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT"
+	EnvTiDBCloudTencentPrivateEndpointHost    = "DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST"
 	EnvTiDBCloudAlicloudPrivateEndpointDomain = "DRIVE9_TIDBCLOUD_ALICLOUD_PRIVATE_ENDPOINT_DOMAIN"
 
 	DefaultDatabaseName = "tidbcloud_fs"
@@ -45,7 +45,7 @@ const (
 	stateActive         = "ACTIVE"
 
 	cloudProviderTencentCloud = "tencentcloud"
-	cloudProviderAlicloud     = "alicloud"
+	cloudProviderAliCloud     = "alicloud"
 	cloudProviderAWS          = "aws"
 
 	Drive9ManagedLabel         = "drive9.ai/managed"
@@ -78,13 +78,13 @@ var (
 )
 
 type Provisioner struct {
-	apiURL                     string
-	cloudProvider              string
-	region                     string
-	defaultDatabaseName        string
-	defaultSpendLimit          *int32
-	defaultPublicKey           string
-	defaultPrivateKey          string
+	apiURL                      string
+	cloudProvider               string
+	region                      string
+	defaultDatabaseName         string
+	defaultSpendLimit           *int32
+	defaultPublicKey            string
+	defaultPrivateKey           string
 	usePrivateEndpoint          bool
 	tencentPrivateEndpointHost  string
 	alicloudPrivateEndpointHost string
@@ -123,7 +123,7 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 			EnvTiDBCloudTencentPrivateEndpointHost, EnvTiDBCloudNativeUsePrivateEndpoint)
 	}
 	alicloudPrivateHost := strings.TrimSpace(os.Getenv(EnvTiDBCloudAlicloudPrivateEndpointDomain))
-	if usePrivate && strings.EqualFold(cloudProvider, cloudProviderAlicloud) && alicloudPrivateHost == "" {
+	if usePrivate && strings.EqualFold(cloudProvider, cloudProviderAliCloud) && alicloudPrivateHost == "" {
 		return nil, fmt.Errorf("%s is required when %s=true and cloud provider is alicloud",
 			EnvTiDBCloudAlicloudPrivateEndpointDomain, EnvTiDBCloudNativeUsePrivateEndpoint)
 	}
@@ -1198,8 +1198,10 @@ func (p *Provisioner) privateEndpointOverrideHost() string {
 	switch strings.ToLower(p.cloudProvider) {
 	case cloudProviderTencentCloud:
 		return p.tencentPrivateEndpointHost
-	case cloudProviderAlicloud:
+	case cloudProviderAliCloud:
 		return p.alicloudPrivateEndpointHost
+	case cloudProviderAWS:
+		return ""
 	default:
 		return ""
 	}

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -311,11 +311,13 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 	var host string
 	var port int
 	if p.usePrivateEndpoint {
-		host = info.Endpoints.Private.Host
-		port = info.Endpoints.Private.Port
-		if host == "" && p.privateEndpointOverrideHost() != "" {
-			host = p.privateEndpointOverrideHost()
+		overrideHost := p.privateEndpointOverrideHost()
+		if overrideHost != "" {
+			host = overrideHost
+		} else {
+			host = info.Endpoints.Private.Host
 		}
+		port = info.Endpoints.Private.Port
 	} else {
 		host = info.Endpoints.Public.Host
 		port = info.Endpoints.Public.Port
@@ -1562,11 +1564,13 @@ func (p *Provisioner) clusterInfoFromResponse(tenantID, dbName, password string,
 	var host string
 	var port int
 	if p.usePrivateEndpoint {
-		host = info.Endpoints.Private.Host
-		port = info.Endpoints.Private.Port
-		if host == "" && p.privateEndpointOverrideHost() != "" {
-			host = p.privateEndpointOverrideHost()
+		overrideHost := p.privateEndpointOverrideHost()
+		if overrideHost != "" {
+			host = overrideHost
+		} else {
+			host = info.Endpoints.Private.Host
 		}
+		port = info.Endpoints.Private.Port
 	} else {
 		host = info.Endpoints.Public.Host
 		port = info.Endpoints.Public.Port
@@ -1632,11 +1636,13 @@ func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branch
 	var host string
 	var port int
 	if p.usePrivateEndpoint {
-		host = branch.Endpoints.Private.Host
-		port = branch.Endpoints.Private.Port
-		if host == "" && p.privateEndpointOverrideHost() != "" {
-			host = p.privateEndpointOverrideHost()
+		overrideHost := p.privateEndpointOverrideHost()
+		if overrideHost != "" {
+			host = overrideHost
+		} else {
+			host = branch.Endpoints.Private.Host
 		}
+		port = branch.Endpoints.Private.Port
 	} else {
 		host = branch.Endpoints.Public.Host
 		port = branch.Endpoints.Public.Port

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -38,10 +38,15 @@ const (
 	EnvTiDBCloudNativePrivateKey           = "DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY"
 	EnvTiDBCloudNativeUsePrivateEndpoint   = "DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT"
 	EnvTiDBCloudTencentPrivateEndpointHost = "DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST"
+	EnvTiDBCloudAlicloudPrivateEndpointDomain = "DRIVE9_TIDBCLOUD_ALICLOUD_PRIVATE_ENDPOINT_DOMAIN"
 
 	DefaultDatabaseName = "tidbcloud_fs"
 	DefaultSpendLimit   = int32(1000)
 	stateActive         = "ACTIVE"
+
+	cloudProviderTencentCloud = "tencentcloud"
+	cloudProviderAlicloud     = "alicloud"
+	cloudProviderAWS          = "aws"
 
 	Drive9ManagedLabel         = "drive9.ai/managed"
 	Drive9TenantIDLabel        = "drive9.ai/tenant_id"
@@ -80,9 +85,10 @@ type Provisioner struct {
 	defaultSpendLimit          *int32
 	defaultPublicKey           string
 	defaultPrivateKey          string
-	usePrivateEndpoint         bool
-	tencentPrivateEndpointHost string
-	client                     *http.Client
+	usePrivateEndpoint          bool
+	tencentPrivateEndpointHost  string
+	alicloudPrivateEndpointHost string
+	client                      *http.Client
 }
 
 func NewProvisionerFromEnv() (*Provisioner, error) {
@@ -111,22 +117,28 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 	if err != nil {
 		return nil, err
 	}
-	privateHost := strings.TrimSpace(os.Getenv(EnvTiDBCloudTencentPrivateEndpointHost))
-	if usePrivate && strings.EqualFold(cloudProvider, "tencentcloud") && privateHost == "" {
+	tencentPrivateHost := strings.TrimSpace(os.Getenv(EnvTiDBCloudTencentPrivateEndpointHost))
+	if usePrivate && strings.EqualFold(cloudProvider, cloudProviderTencentCloud) && tencentPrivateHost == "" {
 		return nil, fmt.Errorf("%s is required when %s=true and cloud provider is tencentcloud",
 			EnvTiDBCloudTencentPrivateEndpointHost, EnvTiDBCloudNativeUsePrivateEndpoint)
 	}
+	alicloudPrivateHost := strings.TrimSpace(os.Getenv(EnvTiDBCloudAlicloudPrivateEndpointDomain))
+	if usePrivate && strings.EqualFold(cloudProvider, cloudProviderAlicloud) && alicloudPrivateHost == "" {
+		return nil, fmt.Errorf("%s is required when %s=true and cloud provider is alicloud",
+			EnvTiDBCloudAlicloudPrivateEndpointDomain, EnvTiDBCloudNativeUsePrivateEndpoint)
+	}
 	return &Provisioner{
-		apiURL:                     strings.TrimRight(apiURL, "/"),
-		cloudProvider:              cloudProvider,
-		region:                     region,
-		defaultDatabaseName:        defaultDB,
-		defaultSpendLimit:          defaultSpendLimit,
-		defaultPublicKey:           strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePublicKey)),
-		defaultPrivateKey:          strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePrivateKey)),
-		usePrivateEndpoint:         usePrivate,
-		tencentPrivateEndpointHost: privateHost,
-		client:                     &http.Client{Timeout: 60 * time.Second},
+		apiURL:                      strings.TrimRight(apiURL, "/"),
+		cloudProvider:               cloudProvider,
+		region:                      region,
+		defaultDatabaseName:         defaultDB,
+		defaultSpendLimit:           defaultSpendLimit,
+		defaultPublicKey:            strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePublicKey)),
+		defaultPrivateKey:           strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePrivateKey)),
+		usePrivateEndpoint:          usePrivate,
+		tencentPrivateEndpointHost:  tencentPrivateHost,
+		alicloudPrivateEndpointHost: alicloudPrivateHost,
+		client:                      &http.Client{Timeout: 60 * time.Second},
 	}, nil
 }
 
@@ -283,7 +295,7 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 	if info.ClusterID == "" {
 		return nil, nil, fmt.Errorf("tidbcloud native response missing cluster id")
 	}
-	if clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
+	if clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
 		clusterID := info.ClusterID
 		info, err = p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, clusterID)
 		if err != nil {
@@ -301,8 +313,8 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 	if p.usePrivateEndpoint {
 		host = info.Endpoints.Private.Host
 		port = info.Endpoints.Private.Port
-		if host == "" && p.tencentPrivateEndpointHost != "" {
-			host = p.tencentPrivateEndpointHost
+		if host == "" && p.privateEndpointOverrideHost() != "" {
+			host = p.privateEndpointOverrideHost()
 		}
 	} else {
 		host = info.Endpoints.Public.Host
@@ -526,7 +538,7 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Cont
 					delete(pending, clusterID)
 					continue
 				}
-				if clusterProvisionMetadataIncomplete(&info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
+				if clusterProvisionMetadataIncomplete(&info, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
 					continue
 				}
 				out[target.index] = p.clusterInfoFromResponse(target.tenantID, target.dbName, target.password, &info)
@@ -817,7 +829,7 @@ func (p *Provisioner) CreateBranchWithCredentials(ctx context.Context, forkTenan
 		DBName:    dbName,
 		Provider:  tenant.ProviderTiDBCloudNative,
 	}
-	if !branchConnectionIncomplete(branch, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
+	if !branchConnectionIncomplete(branch, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
 		if err := p.fillBranchEndpoint(out, branch); err != nil {
 			return out, err
 		}
@@ -1182,6 +1194,17 @@ func (p *Provisioner) regionName() string {
 	return "regions/" + p.cloudProvider + "-" + p.region
 }
 
+func (p *Provisioner) privateEndpointOverrideHost() string {
+	switch strings.ToLower(p.cloudProvider) {
+	case cloudProviderTencentCloud:
+		return p.tencentPrivateEndpointHost
+	case cloudProviderAlicloud:
+		return p.alicloudPrivateEndpointHost
+	default:
+		return ""
+	}
+}
+
 func clusterDisplayName(tenantID string) string {
 	const maxDisplayNameLen = 64
 	name := displayNameCharPattern.ReplaceAllString("tidbcloud-fs-"+tenantID, "-")
@@ -1539,8 +1562,8 @@ func (p *Provisioner) clusterInfoFromResponse(tenantID, dbName, password string,
 	if p.usePrivateEndpoint {
 		host = info.Endpoints.Private.Host
 		port = info.Endpoints.Private.Port
-		if host == "" && p.tencentPrivateEndpointHost != "" {
-			host = p.tencentPrivateEndpointHost
+		if host == "" && p.privateEndpointOverrideHost() != "" {
+			host = p.privateEndpointOverrideHost()
 		}
 	} else {
 		host = info.Endpoints.Public.Host
@@ -1609,8 +1632,8 @@ func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branch
 	if p.usePrivateEndpoint {
 		host = branch.Endpoints.Private.Host
 		port = branch.Endpoints.Private.Port
-		if host == "" && p.tencentPrivateEndpointHost != "" {
-			host = p.tencentPrivateEndpointHost
+		if host == "" && p.privateEndpointOverrideHost() != "" {
+			host = p.privateEndpointOverrideHost()
 		}
 	} else {
 		host = branch.Endpoints.Public.Host
@@ -1656,7 +1679,7 @@ func (p *Provisioner) waitForClusterProvisionMetadata(ctx context.Context, publi
 		if err != nil {
 			return nil, err
 		}
-		if !clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
+		if !clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
 			return info, nil
 		}
 		if time.Now().After(deadline) {
@@ -1694,7 +1717,7 @@ func (p *Provisioner) waitForBranchActive(ctx context.Context, publicKey, privat
 		if err != nil {
 			return nil, err
 		}
-		if info.State == stateActive && !branchConnectionIncomplete(info, p.usePrivateEndpoint, p.tencentPrivateEndpointHost) {
+		if info.State == stateActive && !branchConnectionIncomplete(info, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
 			return info, nil
 		}
 		if time.Now().After(deadline) {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1653,6 +1653,68 @@ func TestNewProvisionerFromEnvRejectsMalformedPrivateEndpointFlag(t *testing.T) 
 	}
 }
 
+func TestNewProvisionerFromEnvRequiresAlicloudPrivateEndpointDomain(t *testing.T) {
+	setPrivateEnv := func(provider string) {
+		t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+		t.Setenv(EnvTiDBCloudNativeCloudProvider, provider)
+		t.Setenv(EnvTiDBCloudNativeRegion, "ap-southeast-1")
+		t.Setenv(EnvTiDBCloudNativeUsePrivateEndpoint, "true")
+		t.Setenv(EnvTiDBCloudTencentPrivateEndpointHost, "")
+		t.Setenv(EnvTiDBCloudAlicloudPrivateEndpointDomain, "")
+	}
+
+	t.Run("alicloud missing domain", func(t *testing.T) {
+		setPrivateEnv("alicloud")
+		_, err := NewProvisionerFromEnv()
+		if err == nil {
+			t.Fatalf("expected error for alicloud private endpoint without domain")
+		}
+	})
+
+	t.Run("alicloud with domain", func(t *testing.T) {
+		setPrivateEnv("alicloud")
+		t.Setenv(EnvTiDBCloudAlicloudPrivateEndpointDomain, "alicloud.internal")
+		p, err := NewProvisionerFromEnv()
+		if err != nil {
+			t.Fatalf("NewProvisionerFromEnv with alicloud domain: %v", err)
+		}
+		if p.alicloudPrivateEndpointHost != "alicloud.internal" {
+			t.Fatalf("alicloudPrivateEndpointHost = %q, want alicloud.internal", p.alicloudPrivateEndpointHost)
+		}
+	})
+
+	t.Run("tencentcloud missing host", func(t *testing.T) {
+		setPrivateEnv("tencentcloud")
+		_, err := NewProvisionerFromEnv()
+		if err == nil {
+			t.Fatalf("expected error for tencentcloud private endpoint without host")
+		}
+	})
+
+	t.Run("tencentcloud with host", func(t *testing.T) {
+		setPrivateEnv("tencentcloud")
+		t.Setenv(EnvTiDBCloudTencentPrivateEndpointHost, "tencent.internal")
+		p, err := NewProvisionerFromEnv()
+		if err != nil {
+			t.Fatalf("NewProvisionerFromEnv with tencentcloud host: %v", err)
+		}
+		if p.tencentPrivateEndpointHost != "tencent.internal" {
+			t.Fatalf("tencentPrivateEndpointHost = %q, want tencent.internal", p.tencentPrivateEndpointHost)
+		}
+	})
+
+	t.Run("aws no override required", func(t *testing.T) {
+		setPrivateEnv("aws")
+		p, err := NewProvisionerFromEnv()
+		if err != nil {
+			t.Fatalf("NewProvisionerFromEnv with aws and no override: %v", err)
+		}
+		if p.usePrivateEndpoint != true {
+			t.Fatalf("usePrivateEndpoint = %v, want true", p.usePrivateEndpoint)
+		}
+	})
+}
+
 func TestClusterConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	info := &clusterInfo{
 		ClusterID:  "cluster-1",
@@ -1771,5 +1833,51 @@ func TestFillBranchEndpointUsesPrivateEndpoint(t *testing.T) {
 	}
 	if out.Username != "u1.root" {
 		t.Fatalf("Username = %q, want u1.root", out.Username)
+	}
+}
+
+func TestFillBranchEndpointOverrideTakesPriority(t *testing.T) {
+	branch := &branchInfo{
+		BranchID:   "branch-1",
+		UserPrefix: "u1",
+	}
+	branch.Endpoints.Public.Host = "public.example"
+	branch.Endpoints.Public.Port = 4000
+	branch.Endpoints.Private.Host = "private.internal"
+	branch.Endpoints.Private.Port = 4001
+
+	p := &Provisioner{
+		usePrivateEndpoint:          true,
+		alicloudPrivateEndpointHost: "alicloud.override.internal",
+		cloudProvider:               cloudProviderAliCloud,
+	}
+	out := &tenant.ClusterInfo{}
+	if err := p.fillBranchEndpoint(out, branch); err != nil {
+		t.Fatalf("fillBranchEndpoint: %v", err)
+	}
+	if out.Host != "alicloud.override.internal" {
+		t.Fatalf("Host = %q, want alicloud.override.internal (override takes priority)", out.Host)
+	}
+}
+
+func TestClusterInfoFromResponseOverrideTakesPriority(t *testing.T) {
+	info := &clusterInfo{
+		ClusterID:  "cluster-1",
+		UserPrefix: "u1",
+		Labels:     map[string]string{TiDBCloudOrganizationLabel: "org-1"},
+	}
+	info.Endpoints.Public.Host = "public.example"
+	info.Endpoints.Public.Port = 4000
+	info.Endpoints.Private.Host = "private.internal"
+	info.Endpoints.Private.Port = 4001
+
+	p := &Provisioner{
+		usePrivateEndpoint:          true,
+		alicloudPrivateEndpointHost: "alicloud.override.internal",
+		cloudProvider:               cloudProviderAliCloud,
+	}
+	out := p.clusterInfoFromResponse("tenant-1", "db1", "pass1", info)
+	if out.Host != "alicloud.override.internal" {
+		t.Fatalf("Host = %q, want alicloud.override.internal (override takes priority)", out.Host)
 	}
 }


### PR DESCRIPTION
## Summary

Add `DRIVE9_TIDBCLOUD_ALICLOUD_PRIVATE_ENDPOINT_DOMAIN` env var for alicloud private endpoint domain override, similar to the existing `DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST` for tencentcloud.

In private mode, alicloud (like tencentcloud) doesn't have unified private endpoint DNS — only per-node DNS — so a statically configured override domain is needed.

## Changes

- Add `EnvTiDBCloudAlicloudPrivateEndpointDomain` constant and env var
- Add `alicloudPrivateEndpointHost` field to Provisioner struct
- Add cloud provider name constants (`cloudProviderTencentCloud`, `cloudProviderAlicloud`, `cloudProviderAWS`)
- Add `privateEndpointOverrideHost()` helper method that returns the correct override host per cloud provider
- Replace all direct `p.tencentPrivateEndpointHost` references with `p.privateEndpointOverrideHost()`
- Validate alicloud private endpoint domain is set when `usePrivate=true` and cloud provider is alicloud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended private-endpoint provisioning to select the correct override host based on the configured cloud provider (Tencent, Alicloud).
  * Added a required Alicloud private-endpoint domain setting when private endpoints are enabled (alongside existing Tencent settings).
* **Bug Fixes**
  * Fixed cluster and branch provisioning/polling so the chosen private-endpoint override host is applied consistently and takes priority over response-provided hosts.
* **Tests**
  * Added coverage for private-endpoint environment parsing and override-host priority behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->