### PR TITLE
fix(fuse): implement directory fsync

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -8467,6 +8467,38 @@ func (fs *Dat9FS) ReleaseDir(input *gofuse.ReleaseIn) {
 	fs.dirHandles.Delete(input.Fh)
 }
 
+func (fs *Dat9FS) FsyncDir(cancel <-chan struct{}, input *gofuse.FsyncIn) (status gofuse.Status) {
+	perfStart := fs.perfStart()
+	defer func() { fs.perfRecordFuse(perfFuseFsyncDir, perfStart, status, 0) }()
+
+	dh, ok := fs.dirHandles.Get(input.Fh)
+	if !ok {
+		return gofuse.OK
+	}
+	ctx, cf := fuseCtx(cancel)
+	defer cf()
+
+	if overlay, local, st := fs.localOverlayForDirPath(ctx, dh.Path); local {
+		if st != gofuse.OK {
+			return st
+		}
+		abs, err := overlay.abs(dh.Path)
+		if err != nil {
+			return localErrToFuseStatus(err)
+		}
+		dir, err := os.Open(abs)
+		if err != nil {
+			return localErrToFuseStatus(err)
+		}
+		defer dir.Close()
+		if err := syncOpenLocalFile(dir); err != nil {
+			return localErrToFuseStatus(err)
+		}
+	}
+
+	return gofuse.OK
+}
+
 func (fs *Dat9FS) listDir(ctx context.Context, dirPath string) ([]DirEntry, error) {
 	if overlay, local, st := fs.localOverlayForPath(ctx, dirPath); local {
 		if st != gofuse.OK {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -8490,7 +8490,7 @@ func (fs *Dat9FS) FsyncDir(cancel <-chan struct{}, input *gofuse.FsyncIn) (statu
 		if err != nil {
 			return localErrToFuseStatus(err)
 		}
-		defer dir.Close()
+		defer func() { _ = dir.Close() }()
 		if err := syncOpenLocalFile(dir); err != nil {
 			return localErrToFuseStatus(err)
 		}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -7815,6 +7815,64 @@ func TestCodingAgentLocalOverlayCreateReadWriteDoesNotUseRemote(t *testing.T) {
 	}
 }
 
+func TestFsyncDirRemotePathReturnsOK(t *testing.T) {
+	var remoteCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "remote should not be used for directory fsync", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	dirIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+	fh := fs.dirHandles.Allocate(&DirHandle{Ino: dirIno, Path: "/repo"})
+
+	if st := fs.FsyncDir(nil, &gofuse.FsyncIn{Fh: fh}); st != gofuse.OK {
+		t.Fatalf("FsyncDir remote path status = %v, want OK", st)
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote calls = %d, want 0", got)
+	}
+}
+
+func TestFsyncDirLocalOverlaySyncsDirectory(t *testing.T) {
+	var syncCalls atomic.Int32
+	previousSync := syncOpenLocalFile
+	syncOpenLocalFile = func(file *os.File) error {
+		syncCalls.Add(1)
+		return nil
+	}
+	t.Cleanup(func() {
+		syncOpenLocalFile = previousSync
+	})
+
+	opts := &MountOptions{
+		Profile:   MountProfileCodingAgent,
+		LocalRoot: t.TempDir(),
+	}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+	var gitOut gofuse.EntryOut
+	if st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Mode:     0o755,
+	}, ".git", &gitOut); st != gofuse.OK {
+		t.Fatalf("Mkdir .git: %v", st)
+	}
+	fh := fs.dirHandles.Allocate(&DirHandle{Ino: gitOut.NodeId, Path: "/repo/.git"})
+
+	if st := fs.FsyncDir(nil, &gofuse.FsyncIn{Fh: fh}); st != gofuse.OK {
+		t.Fatalf("FsyncDir local overlay status = %v, want OK", st)
+	}
+	if got := syncCalls.Load(); got != 1 {
+		t.Fatalf("FsyncDir sync calls = %d, want 1", got)
+	}
+}
+
 func TestSQLiteWALIndexSidecarUsesTransientLocalOverlay(t *testing.T) {
 	var remoteCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -7847,10 +7905,13 @@ func TestSQLiteWALIndexSidecarUsesTransientLocalOverlay(t *testing.T) {
 	var createOut gofuse.CreateOut
 	if st := fs.Create(nil, &gofuse.CreateIn{
 		InHeader: gofuse.InHeader{NodeId: repoIno},
-		Flags:    uint32(syscall.O_RDWR),
+		Flags:    uint32(syscall.O_RDWR | syscall.O_TRUNC),
 		Mode:     0o644,
 	}, "workload.db-shm", &createOut); st != gofuse.OK {
 		t.Fatalf("Create workload.db-shm: %v", st)
+	}
+	if createOut.OpenFlags != gofuse.FOPEN_KEEP_CACHE {
+		t.Fatalf("Create workload.db-shm open flags = %d, want FOPEN_KEEP_CACHE for local mmap", createOut.OpenFlags)
 	}
 
 	content := []byte("sqlite wal-index bytes")
@@ -7897,6 +7958,9 @@ func TestSQLiteWALIndexSidecarUsesTransientLocalOverlay(t *testing.T) {
 		Flags:    uint32(syscall.O_RDONLY),
 	}, &openOut); st != gofuse.OK {
 		t.Fatalf("Open workload.db-shm: %v", st)
+	}
+	if openOut.OpenFlags != gofuse.FOPEN_KEEP_CACHE {
+		t.Fatalf("Open workload.db-shm open flags = %d, want FOPEN_KEEP_CACHE for local mmap", openOut.OpenFlags)
 	}
 	buf := make([]byte, len(content)+8)
 	result, st := fs.Read(nil, &gofuse.ReadIn{

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -24,6 +24,7 @@ const (
 	perfFuseWrite
 	perfFuseFlush
 	perfFuseFsync
+	perfFuseFsyncDir
 	perfFuseSyncFs
 	perfFuseRelease
 	perfFuseCreate
@@ -51,6 +52,7 @@ var perfFuseOpNames = [...]string{
 	perfFuseWrite:       "write",
 	perfFuseFlush:       "flush",
 	perfFuseFsync:       "fsync",
+	perfFuseFsyncDir:    "fsyncdir",
 	perfFuseSyncFs:      "syncfs",
 	perfFuseRelease:     "release",
 	perfFuseCreate:      "create",


### PR DESCRIPTION
## Summary
- Implement FUSE FsyncDir so directory fsync no longer falls through to go-fuse default ENOSYS.
- Sync local-overlay directories through the existing local sync hook and return OK for remote-persistent directories where Drive9 has no local directory metadata to flush.
- Add perf accounting for fsyncdir and regressions for remote path OK, local overlay sync, and SQLite -shm local-overlay mmap-safe open flags.

## SQLite/WAL/mmap findings
- On 81.70.84.180 with latest released CLI d8a7f2c, sqlite3 CLI with PRAGMA mmap_size=0 + WAL + synchronous=FULL + wal_checkpoint(FULL) passed on Drive9 mount.
- Python sqlite3 with mmap_size=0 + WAL passed on Drive9 mount: 100 inserts committed and read back.
- Direct C mmap probe showed current main-DB mmap gap is the FOPEN_DIRECT_IO path; PR #685 is the right fix for that path via CAP_DIRECT_IO_ALLOW_MMAP on Linux 6.6+.
- This PR intentionally does not switch SQLite main DB away from direct-io, to avoid reintroducing stale page-cache races and to stay compatible with PR #685.

## Validation
- git diff --check
- /usr/local/go/bin/go test ./pkg/fuse -run 'Test(SQLiteDirectIOPathMatching|OpenReadOnlySQLiteUsesDirectIO|OpenWritableSQLiteUsesDirectIO|SQLiteWALIndexSidecar|FsyncDir)' -count=1

Note: full ./pkg/fuse currently also hits unrelated existing mount_wait_test failures on this macOS environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added directory syncing via FUSE, including proper handling for directories served through the local overlay.
  * Extended FUSE performance reporting with a new `fsyncdir` operation.

* **Bug Fixes**
  * Improved SQLite WAL sidecar handling for `-shm` by ensuring the `Create` request uses `O_TRUNC`, and by validating consistent cache-friendly open behavior.

* **Tests**
  * Added coverage confirming directory sync avoids remote calls and performs the expected single local sync for local-overlay paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->