### PR TITLE
ci: publish CSI image after Drive9 CLI release

### DIFF
--- a/.github/workflows/csi-publish-trigger.yml
+++ b/.github/workflows/csi-publish-trigger.yml
@@ -1,74 +1,35 @@
 name: Publish CSI image (drive9-ai/k8s-csi)
 
-# Dispatches drive9-ai/k8s-csi's `publish-image.yml` to build the drive9-csi
-# container image pinned to a specific drive9 commit. Runs in parallel with
-# `prod-cd` (invoked as a reusable workflow) and can also be triggered
-# manually from the Actions UI.
+# Dispatches drive9-ai/k8s-csi's `publish-image.yml` after Drive9 CLI binaries
+# are released. The CSI image downloads the released CLI via install.sh, so the
+# dispatch must run after `release-cli` updates drive9.ai/releases.
 #
 # Requires repo secret `CSI_DISPATCH_TOKEN`: a PAT with `actions:write` on
 # `drive9-ai/k8s-csi` (fine-grained PAT recommended). The default
 # `GITHUB_TOKEN` cannot dispatch workflows in a different repository.
 
 on:
+  workflow_run:
+    workflows: ["Release CLI binaries"]
+    types:
+      - completed
   workflow_dispatch:
     inputs:
-      drive9_ref:
-        description: "drive9 commit SHA to bake into the CSI image (default: this workflow's commit)"
-        required: false
-        type: string
       csi_ref:
         description: "k8s-csi ref to build from (default: main)"
         required: false
         type: string
         default: main
-  workflow_call:
-    inputs:
-      drive9_ref:
-        description: "drive9 commit SHA to bake into the CSI image"
-        required: true
-        type: string
-      csi_ref:
-        description: "k8s-csi ref to build from"
-        required: false
-        type: string
-        default: main
-    secrets:
-      CSI_DISPATCH_TOKEN:
-        required: true
 
 jobs:
   dispatch:
     name: Dispatch k8s-csi publish-image workflow
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
-      - name: Resolve drive9 ref
-        id: resolve
-        env:
-          INPUT_DRIVE9_REF: ${{ inputs.drive9_ref }}
-          FALLBACK_SHA: ${{ github.sha }}
-        run: |
-          set -euo pipefail
-          REF="${INPUT_DRIVE9_REF:-$FALLBACK_SHA}"
-          # Require a hex commit SHA (7-40 chars). Earlier
-          # alnum+dot+dash validation would let branch/tag names
-          # through (e.g. `main`, `v1.2.3`), but k8s-csi bakes the
-          # value into the image tag `drive9-<ref7>-csi-<sha7>` and
-          # into the container image. A branch head can move between
-          # dispatch and build, producing a non-reproducible image
-          # under a misleading tag. Refuse anything that isn't a
-          # canonical SHA up-front so the failure mode is clear at
-          # dispatch time, not silently downstream.
-          if ! printf '%s' "$REF" | grep -Eq '^[0-9a-f]{7,40}$'; then
-            echo "Invalid drive9_ref (must be a 7-40 char hex commit SHA): $REF" >&2
-            exit 1
-          fi
-          printf 'drive9_ref=%s\n' "$REF" >> "$GITHUB_OUTPUT"
-          printf 'Dispatching k8s-csi build for drive9 ref: %s\n' "$REF"
-
       - name: Trigger drive9-ai/k8s-csi publish-image.yml
         env:
           GH_TOKEN: ${{ secrets.CSI_DISPATCH_TOKEN }}
-          DRIVE9_REF: ${{ steps.resolve.outputs.drive9_ref }}
           CSI_REF: ${{ inputs.csi_ref || 'main' }}
         run: |
           set -euo pipefail
@@ -79,7 +40,6 @@ jobs:
           fi
           gh workflow run publish-image.yml \
             --repo drive9-ai/k8s-csi \
-            --ref "$CSI_REF" \
-            -f drive9_ref="$DRIVE9_REF"
-          echo "Dispatched drive9-ai/k8s-csi publish-image.yml (csi ref: $CSI_REF, drive9_ref: $DRIVE9_REF)"
+            --ref "$CSI_REF"
+          echo "Dispatched drive9-ai/k8s-csi publish-image.yml (csi ref: $CSI_REF)"
           echo "Watch: https://github.com/drive9-ai/k8s-csi/actions/workflows/publish-image.yml"

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -25,10 +25,9 @@ env:
   K8S_DEPLOYMENT: dat9-server
 
 jobs:
-  # Resolves the drive9 image + short SHA ONCE from either the
-  # `image_tag` override or the dev deployment. Downstream jobs
-  # (deploy + csi-publish) consume the outputs, so prod promotion
-  # and the paired CSI image build agree on the same drive9 commit.
+  # Resolves the drive9 image ONCE from either the `image_tag` override or
+  # the dev deployment. Downstream deploy jobs consume the same output so all
+  # prod regions promote the same image.
   #
   # Prior versions had `deploy` and `resolve-drive9-sha` each read
   # dev independently. If a dev-cd retag landed between the two
@@ -44,7 +43,6 @@ jobs:
     outputs:
       image: ${{ steps.resolve.outputs.image }}
       registry: ${{ steps.resolve.outputs.registry }}
-      drive9_sha: ${{ steps.resolve.outputs.drive9_sha }}
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
@@ -100,28 +98,10 @@ jobs:
           fi
           echo "Resolved image: $IMAGE (tag: $TAG)"
 
-          # dev-cd tags images as `<branch>-<sha7>` where sha7 is
-          # exactly 7 hex chars from `git rev-parse --short=7 HEAD`.
-          # Extract the trailing token and REQUIRE it to be 7-40
-          # hex chars — the earlier check accepted any alphanumeric
-          # of length >= 7, so `prod-release1` or `v1.2.3` sneaked
-          # through and got baked into the CSI image as if it were
-          # a commit SHA. A branch or tag name that ends in a
-          # non-hex token now fails fast at prod-cd time rather
-          # than producing a misleading `drive9-<not-a-sha>-csi-*`
-          # image downstream.
-          SHA="${TAG##*-}"
-          if ! printf '%s' "$SHA" | grep -Eq '^[0-9a-f]{7,40}$'; then
-            echo "Could not extract hex drive9 SHA from tag: $TAG (extracted: $SHA)" >&2
-            echo "Expected pattern: <ref-name>-<7-40 hex chars>" >&2
-            exit 1
-          fi
-
           REGISTRY="${IMAGE%%/*}"
           {
             echo "image=$IMAGE"
             echo "registry=$REGISTRY"
-            echo "drive9_sha=$SHA"
           } >> "$GITHUB_OUTPUT"
 
   deploy:
@@ -343,20 +323,3 @@ jobs:
             kubectl --kubeconfig ~/.kube/tencent-config -n drive9-tidbcloud \
               rollout undo deployment/drive9-server
           fi
-
-  csi-publish:
-    # Dispatches drive9-ai/k8s-csi's publish-image.yml to build a drive9-csi
-    # image pinned to the drive9 commit currently being promoted to prod.
-    # Consumes the same `resolve` output as `deploy`, so the CSI image is
-    # guaranteed to be baked for the exact drive9 build going to prod
-    # (no dev-cd retag can slip between the two reads any more).
-    # Still runs in parallel with `deploy` — a failed prod rollout does
-    # not cancel the CSI build and vice versa; only the shared resolve
-    # is sequenced first.
-    name: Publish drive9-csi image
-    needs: resolve
-    uses: ./.github/workflows/csi-publish-trigger.yml
-    with:
-      drive9_ref: ${{ needs.resolve.outputs.drive9_sha }}
-    secrets:
-      CSI_DISPATCH_TOKEN: ${{ secrets.CSI_DISPATCH_TOKEN }}


### PR DESCRIPTION
## Summary\n- Trigger drive9-ai/k8s-csi publish-image.yml after the Drive9 CLI release workflow succeeds\n- Remove the old prod-cd reusable dispatch that passed drive9_ref\n- Dispatch without drive9_ref because k8s-csi PR #15 downloads the released CLI from drive9.ai/install.sh\n\n## Why\nCSI images should be rebuilt only after drive9.ai/releases has the new CLI binary. Triggering from prod-cd/main before release-cli finishes can rebuild CSI with the previous released CLI.\n\n## Validation\n- git diff --check\n- ruby YAML parse for .github/workflows/csi-publish-trigger.yml and .github/workflows/prod-cd.yml