### PR TITLE
fix: deploy ACK prod to native namespace

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -275,19 +275,19 @@ jobs:
         run: |
           mkdir -p ~/.kube
           aliyun --profile github-actions cs GET "/k8s/c4dad0ecde1e94472a36fec0498e181ed/user_config" --region ap-southeast-1 | jq -r '.config' > ~/.kube/alicloud-config
-          kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
-            set image "deployment/${{ env.K8S_DEPLOYMENT }}" \
-            "${{ env.K8S_DEPLOYMENT }}=$ACR_IMAGE"
-          kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
-            rollout status "deployment/${{ env.K8S_DEPLOYMENT }}" \
+          kubectl --kubeconfig ~/.kube/alicloud-config -n drive9-tidbcloud \
+            set image deployment/drive9-server \
+            drive9-server=$ACR_IMAGE
+          kubectl --kubeconfig ~/.kube/alicloud-config -n drive9-tidbcloud \
+            rollout status deployment/drive9-server \
             --timeout=300s
 
       - name: Rollback alicloud-ap-southeast-1 on failure
         if: failure() && steps.deploy-alicloud.outcome == 'failure'
         run: |
           if [ -f ~/.kube/alicloud-config ]; then
-            kubectl --kubeconfig ~/.kube/alicloud-config -n "${{ env.DEPLOY_NAMESPACE }}" \
-              rollout undo "deployment/${{ env.K8S_DEPLOYMENT }}"
+            kubectl --kubeconfig ~/.kube/alicloud-config -n drive9-tidbcloud \
+              rollout undo deployment/drive9-server
           fi
 
       - name: Configure Tencent Cloud credentials


### PR DESCRIPTION
## Summary
- update the Alibaba Cloud prod deploy step to roll out `drive9-tidbcloud/drive9-server`
- update the matching rollback step to target the same namespace/deployment

## Why
The ACK production cluster currently runs the TiDBCloud native server in `drive9-tidbcloud/drive9-server`, but prod-cd was updating the legacy `dat9/dat9-server` target. That left ACK on an older image even after prod promotion.

## Validation
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production deployment reliability for one region by ensuring updates target the correct live service.
  * Rollbacks now use the same specific deployment target, helping failures recover more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->