### PR TITLE
cd: multi-arch image build (amd64 + arm64)

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -72,8 +72,18 @@ jobs:
 
       - name: Build and push image
         run: |
-          make docker-build IMAGE_REPO=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }} IMAGE_TAG=${{ env.IMAGE_TAG }}
-          docker push ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ env.IMAGE_TAG }}
+          IMAGE_BASE=${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}
+          # amd64
+          make docker-build IMAGE_REPO=$IMAGE_BASE IMAGE_TAG=${{ env.IMAGE_TAG }}-amd64 GOARCH=amd64
+          docker push $IMAGE_BASE:${{ env.IMAGE_TAG }}-amd64
+          # arm64
+          make docker-build IMAGE_REPO=$IMAGE_BASE IMAGE_TAG=${{ env.IMAGE_TAG }}-arm64 GOARCH=arm64
+          docker push $IMAGE_BASE:${{ env.IMAGE_TAG }}-arm64
+          # manifest
+          docker manifest create $IMAGE_BASE:${{ env.IMAGE_TAG }} \
+            $IMAGE_BASE:${{ env.IMAGE_TAG }}-amd64 \
+            $IMAGE_BASE:${{ env.IMAGE_TAG }}-arm64
+          docker manifest push $IMAGE_BASE:${{ env.IMAGE_TAG }}
 
       - name: Update kubeconfig
         run: |

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -1017,6 +1017,8 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		return fmt.Errorf("complete multipart: %w", err)
 	}
 	completeMultipartDurationMs := uploadPhaseMs(completeMultipartStart)
+	finalizeCtx, cancelFinalize := postCommitQuotaMutationContext()
+	defer cancelFinalize()
 
 	var oldStorageRef string
 	var oldStorageType datastore.StorageType
@@ -1042,14 +1044,14 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	enqueueUploadSemanticTasks := func(tx *sql.Tx, mediaDelta int64) error {
 		stepStart := time.Now()
 		if b.UsesDatabaseAutoEmbedding() {
-			created, err := b.enqueueExtractSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType, mediaDelta)
+			created, err := b.enqueueExtractSemanticTasksTx(finalizeCtx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType, mediaDelta)
 			semanticTaskEnqueued = created
 			semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 			return err
 		}
 		// App-embedding mode: image/audio extract tasks are durable and
 		// independent of EMBED_TEXT, so register them in the same transaction.
-		extractCreated, err := b.enqueueExtractSemanticTasksTx(ctx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType, mediaDelta)
+		extractCreated, err := b.enqueueExtractSemanticTasksTx(finalizeCtx, tx, confirmedFileID, confirmedRevision, upload.TargetPath, contentType, mediaDelta)
 		if err != nil {
 			return err
 		}
@@ -1064,7 +1066,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		semanticEnqueueDurationMs = uploadPhaseMs(stepStart)
 		return nil
 	}
-	if err := b.store.InTx(ctx, func(tx *sql.Tx) error {
+	if err := b.store.InTx(finalizeCtx, func(tx *sql.Tx) error {
 		semanticTaskEnqueued = false
 		oldStorageRef = ""
 		oldStorageType = ""
@@ -1218,9 +1220,9 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		return nil
 	}); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_tx_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		b.cleanupFailedFinalizeUpload(ctx, upload)
-		// Abort the server-side reservation since the tenant DB tx failed.
 		cleanupCtx, cancelCleanup := postCommitQuotaMutationContext()
+		b.cleanupFailedFinalizeUpload(cleanupCtx, upload)
+		// Abort the server-side reservation since the tenant DB tx failed.
 		b.abortUploadReservation(cleanupCtx, uploadID, upload.TotalSize)
 		cancelCleanup()
 		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
@@ -1238,7 +1240,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	}
 
 	if isOverwrite {
-		b.deleteBlobIfS3Ctx(ctx, oldStorageType, oldStorageRef, upload.S3Key)
+		b.deleteBlobIfS3Ctx(finalizeCtx, oldStorageType, oldStorageRef, upload.S3Key)
 	}
 	logger.InfoBenchTiming(ctx, "backend_finalize_upload_timing",
 		zap.String("upload_id", uploadID),

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -17,6 +17,12 @@ import (
 	"go.uber.org/zap"
 )
 
+const postS3UploadFinalizeTimeout = 2 * time.Minute
+
+func postS3UploadFinalizeContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), postS3UploadFinalizeTimeout)
+}
+
 // UploadPlan is returned by InitiateUpload for the 202 response.
 type UploadPlan struct {
 	UploadID string                    `json:"upload_id"`
@@ -1001,7 +1007,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	if err := b.s3.CompleteMultipartUpload(ctx, upload.S3Key, upload.S3UploadID, parts); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_complete_multipart_failed", zap.String("upload_id", uploadID), zap.Error(err))
 		if b.UseServerQuota() {
-			cleanupCtx, cancelCleanup := postCommitQuotaMutationContext()
+			cleanupCtx, cancelCleanup := postS3UploadFinalizeContext(ctx)
 			if resetErr := b.metaStore.UpdateUploadReservationStatus(cleanupCtx, b.tenantID, uploadID, "active"); resetErr != nil {
 				logger.Warn(cleanupCtx, "central_quota_upload_reset_active_failed",
 					zap.String("tenant_id", b.tenantID),
@@ -1017,7 +1023,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		return fmt.Errorf("complete multipart: %w", err)
 	}
 	completeMultipartDurationMs := uploadPhaseMs(completeMultipartStart)
-	finalizeCtx, cancelFinalize := postCommitQuotaMutationContext()
+	finalizeCtx, cancelFinalize := postS3UploadFinalizeContext(ctx)
 	defer cancelFinalize()
 
 	var oldStorageRef string
@@ -1220,11 +1226,14 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		return nil
 	}); err != nil {
 		logger.Error(ctx, "backend_finalize_upload_tx_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		cleanupCtx, cancelCleanup := postCommitQuotaMutationContext()
+		cleanupCtx, cancelCleanup := postS3UploadFinalizeContext(ctx)
 		b.cleanupFailedFinalizeUpload(cleanupCtx, upload)
-		// Abort the server-side reservation since the tenant DB tx failed.
-		b.abortUploadReservation(cleanupCtx, uploadID, upload.TotalSize)
 		cancelCleanup()
+
+		// Abort the server-side reservation since the tenant DB tx failed.
+		quotaCleanupCtx, cancelQuotaCleanup := postS3UploadFinalizeContext(ctx)
+		b.abortUploadReservation(quotaCleanupCtx, uploadID, upload.TotalSize)
+		cancelQuotaCleanup()
 		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
 		return err
 	}
@@ -1232,7 +1241,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	if semanticTaskEnqueued {
 		b.notifyWorkEnqueued(BackendWorkSemantic)
 	}
-	quotaCtx, cancelQuota := postCommitQuotaMutationContext()
+	quotaCtx, cancelQuota := postS3UploadFinalizeContext(ctx)
 	defer cancelQuota()
 	if err := b.completeUploadReservation(quotaCtx, uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia); err != nil {
 		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
@@ -1240,7 +1249,9 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	}
 
 	if isOverwrite {
-		b.deleteBlobIfS3Ctx(finalizeCtx, oldStorageType, oldStorageRef, upload.S3Key)
+		gcCtx, cancelGC := postS3UploadFinalizeContext(ctx)
+		b.deleteBlobIfS3Ctx(gcCtx, oldStorageType, oldStorageRef, upload.S3Key)
+		cancelGC()
 	}
 	logger.InfoBenchTiming(ctx, "backend_finalize_upload_timing",
 		zap.String("upload_id", uploadID),

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -68,6 +68,19 @@ func (c *completeRecordingS3Client) CompleteMultipartUpload(ctx context.Context,
 	return c.S3Client.CompleteMultipartUpload(ctx, key, uploadID, parts)
 }
 
+type cancelAfterCompleteS3Client struct {
+	s3client.S3Client
+	cancel context.CancelFunc
+}
+
+func (c *cancelAfterCompleteS3Client) CompleteMultipartUpload(ctx context.Context, key, uploadID string, parts []s3client.Part) error {
+	err := c.S3Client.CompleteMultipartUpload(ctx, key, uploadID, parts)
+	if err == nil && c.cancel != nil {
+		c.cancel()
+	}
+	return err
+}
+
 func newTestBackendNoS3(t *testing.T) *Dat9Backend {
 	t.Helper()
 	initBackendSchema(t, testDSN)
@@ -229,6 +242,54 @@ func TestInitiateAndConfirmUpload(t *testing.T) {
 	}
 	if url == "" {
 		t.Error("expected non-empty presigned URL")
+	}
+}
+
+func TestConfirmUploadFinalizesAfterRequestContextCanceledPostS3Complete(t *testing.T) {
+	b := newTestBackendWithS3(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	totalSize := int64(2 << 20)
+	plan, err := b.InitiateUpload(ctx, "/complete-after-cancel.bin", totalSize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	upload, err := b.GetUpload(ctx, plan.UploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	partData := bytes.Repeat([]byte("x"), int(totalSize))
+	for _, p := range plan.Parts {
+		start := int64(p.Number-1) * plan.PartSize
+		end := start + p.Size
+		if end > totalSize {
+			end = totalSize
+		}
+		if _, err := b.S3().(*s3client.LocalS3Client).UploadPart(ctx, upload.S3UploadID, p.Number, bytes.NewReader(partData[start:end])); err != nil {
+			t.Fatalf("upload part %d: %v", p.Number, err)
+		}
+	}
+
+	b.s3 = &cancelAfterCompleteS3Client{S3Client: b.s3, cancel: cancel}
+	if err := b.ConfirmUpload(ctx, plan.UploadID); err != nil {
+		t.Fatalf("ConfirmUpload after post-S3 context cancel: %v", err)
+	}
+
+	verifyCtx := context.Background()
+	upload, err = b.GetUpload(verifyCtx, plan.UploadID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if upload.Status != datastore.UploadCompleted {
+		t.Fatalf("upload status = %s, want %s", upload.Status, datastore.UploadCompleted)
+	}
+	info, err := b.store.Stat(verifyCtx, "/complete-after-cancel.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.File == nil || info.File.SizeBytes != totalSize {
+		t.Fatalf("file size = %v, want %d", info.File, totalSize)
 	}
 }
 

--- a/pkg/backend/upload_test.go
+++ b/pkg/backend/upload_test.go
@@ -282,14 +282,14 @@ func TestConfirmUploadFinalizesAfterRequestContextCanceledPostS3Complete(t *test
 		t.Fatal(err)
 	}
 	if upload.Status != datastore.UploadCompleted {
-		t.Fatalf("upload status = %s, want %s", upload.Status, datastore.UploadCompleted)
+		t.Errorf("upload status = %s, want %s", upload.Status, datastore.UploadCompleted)
 	}
 	info, err := b.store.Stat(verifyCtx, "/complete-after-cancel.bin")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if info.File == nil || info.File.SizeBytes != totalSize {
-		t.Fatalf("file size = %v, want %d", info.File, totalSize)
+		t.Errorf("file size = %v, want %d", info.File, totalSize)
 	}
 }
 


### PR DESCRIPTION
Build both amd64 and arm64 images in dev-cd, create a multi-arch manifest for dev cluster's ARM64 nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Release images are now published for both `amd64` and `arm64`, with a combined image tag for broader deployment support.

* **Bug Fixes**
  * Upload completion is now more resilient if the request context ends immediately after storage upload finishes.
  * Finalization steps now continue safely after S3 upload completion, helping prevent failed or incomplete uploads in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->