### PR TITLE
fix(ci): avoid secret masking on job outputs in prod-cd

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -42,8 +42,7 @@ jobs:
       id-token: write
       contents: read
     outputs:
-      image: ${{ steps.resolve.outputs.image }}
-      registry: ${{ steps.resolve.outputs.registry }}
+      tag: ${{ steps.resolve.outputs.tag }}
       drive9_sha: ${{ steps.resolve.outputs.drive9_sha }}
     steps:
       - name: Configure AWS credentials
@@ -117,10 +116,8 @@ jobs:
             exit 1
           fi
 
-          REGISTRY="${IMAGE%%/*}"
           {
-            echo "image=$IMAGE"
-            echo "registry=$REGISTRY"
+            echo "tag=$TAG"
             echo "drive9_sha=$SHA"
           } >> "$GITHUB_OUTPUT"
 
@@ -132,8 +129,8 @@ jobs:
       id-token: write
       contents: read
     env:
-      IMAGE: ${{ needs.resolve.outputs.image }}
-      REGISTRY: ${{ needs.resolve.outputs.registry }}
+      TAG: ${{ needs.resolve.outputs.tag }}
+      IMAGE: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.resolve.outputs.tag }}
 
     steps:
       - name: Configure AWS credentials
@@ -149,7 +146,7 @@ jobs:
           set -euo pipefail
           echo "Promoting image: $IMAGE"
           aws ecr get-login-password --region ap-southeast-1 | \
-            docker login --username AWS --password-stdin "$REGISTRY"
+            docker login --username AWS --password-stdin "$ECR_REGISTRY"
           docker pull "$IMAGE"
       - name: Deploy to aws-ap-southeast-1
         id: deploy-sg


### PR DESCRIPTION
## Problem

resolve job outputs `image` and `registry` contain the full ECR URL which matches `secrets.ECR_REGISTRY`, causing GitHub Actions to suppress both outputs:

```
##[warning]Skip output 'image' since it may contain secret.
##[warning]Skip output 'registry' since it may contain secret.
```

deploy job then receives empty `needs.resolve.outputs.image` /` .registry`, and `docker pull` fails.

## Fix

- resolve job now outputs only `tag` (safe string) instead of `image`/`registry`
- deploy job constructs the full `IMAGE` at template-expansion time from `env.ECR_REGISTRY` + `env.ECR_REPOSITORY` + `needs.resolve.outputs.tag`, bypassing job output propagation entirely
- `csi-publish` job unchanged (uses `drive9_sha`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the production deployment workflow to use a simpler image tagging flow.
  * Improved how deployment steps assemble the container image reference and authenticate to the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->