### PR TITLE
fix(ci): resolve job outputs tag instead of image to avoid secret masking

### DIFF
--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -130,9 +130,12 @@ jobs:
       contents: read
     env:
       TAG: ${{ needs.resolve.outputs.tag }}
-      IMAGE: ${{ secrets.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.resolve.outputs.tag }}
 
     steps:
+      - name: Resolve image ref
+        run: |
+          echo "IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$TAG" >> "$GITHUB_ENV"
+
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -130,7 +130,7 @@ jobs:
       contents: read
     env:
       TAG: ${{ needs.resolve.outputs.tag }}
-      IMAGE: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.resolve.outputs.tag }}
+      IMAGE: ${{ secrets.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.resolve.outputs.tag }}
 
     steps:
       - name: Configure AWS credentials

--- a/.github/workflows/prod-cd.yml
+++ b/.github/workflows/prod-cd.yml
@@ -42,8 +42,7 @@ jobs:
       id-token: write
       contents: read
     outputs:
-      image: ${{ steps.resolve.outputs.image }}
-      registry: ${{ steps.resolve.outputs.registry }}
+      tag: ${{ steps.resolve.outputs.tag }}
       drive9_sha: ${{ steps.resolve.outputs.drive9_sha }}
     steps:
       - name: Configure AWS credentials
@@ -117,10 +116,8 @@ jobs:
             exit 1
           fi
 
-          REGISTRY="${IMAGE%%/*}"
           {
-            echo "image=$IMAGE"
-            echo "registry=$REGISTRY"
+            echo "tag=$TAG"
             echo "drive9_sha=$SHA"
           } >> "$GITHUB_OUTPUT"
 
@@ -132,8 +129,8 @@ jobs:
       id-token: write
       contents: read
     env:
-      IMAGE: ${{ needs.resolve.outputs.image }}
-      REGISTRY: ${{ needs.resolve.outputs.registry }}
+      TAG: ${{ needs.resolve.outputs.tag }}
+      IMAGE: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ needs.resolve.outputs.tag }}
 
     steps:
       - name: Configure AWS credentials
@@ -149,7 +146,7 @@ jobs:
           set -euo pipefail
           echo "Promoting image: $IMAGE"
           aws ecr get-login-password --region ap-southeast-1 | \
-            docker login --username AWS --password-stdin "$REGISTRY"
+            docker login --username AWS --password-stdin "$ECR_REGISTRY"
           docker pull "$IMAGE"
       - name: Deploy to aws-ap-southeast-1
         id: deploy-sg


### PR DESCRIPTION
## Root cause

resolve job outputs `image` and `registry` contain the full ECR URL which matches `secrets.ECR_REGISTRY`, causing GitHub Actions to suppress both outputs:

```
##[warning]Skip output 'image' since it may contain secret.
##[warning]Skip output 'registry' since it may contain secret.
```

deploy job receives empty `needs.resolve.outputs.image`/`.registry`, `docker pull` fails.

## Fix

- resolve job now outputs only `tag` (safe) instead of `image`/`registry`
- deploy job constructs `IMAGE` at template time from `env.ECR_REGISTRY` + `env.ECR_REPOSITORY` + `needs.resolve.outputs.tag`
- `csi-publish` unchanged (uses `drive9_sha`)