### PR TITLE
fix(cli): make `drive9 fs grep --json` actually work

### DIFF
--- a/cmd/drive9/cli/grep.go
+++ b/cmd/drive9/cli/grep.go
@@ -10,12 +10,12 @@ import (
 )
 
 func Grep(c *client.Client, args []string) error {
-	layerRef, args, err := parseLayerFlag(args)
+	layerRef, jsonMode, args, err := parseGrepFlags(args)
 	if err != nil {
 		return err
 	}
 	if len(args) < 1 {
-		return fmt.Errorf("usage: drive9 fs grep [--layer <ref>] <pattern> [path]")
+		return fmt.Errorf("usage: drive9 fs grep [--layer <ref>] [--json] <pattern> [path]")
 	}
 	query := args[0]
 	path := "/"
@@ -31,6 +31,14 @@ func Grep(c *client.Client, args []string) error {
 	results, err := c.GrepWithLayer(query, path, 20, layerRef)
 	if err != nil {
 		return err
+	}
+	if jsonMode {
+		if results == nil {
+			results = []client.SearchResult{}
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(results)
 	}
 	if len(results) == 0 {
 		return nil
@@ -45,32 +53,24 @@ func Grep(c *client.Client, args []string) error {
 	return nil
 }
 
-func GrepJSON(c *client.Client, args []string) error {
-	layerRef, args, err := parseLayerFlag(args)
+// parseGrepFlags strips --layer <ref> and --json from args, returning the
+// layer reference, whether JSON output mode is requested, and the remaining
+// positional args. It extends parseLayerFlag with grep-specific --json.
+func parseGrepFlags(args []string) (string, bool, []string, error) {
+	layerRef, filtered, err := parseLayerFlag(args)
 	if err != nil {
-		return err
+		return "", false, nil, err
 	}
-	if len(args) < 1 {
-		return fmt.Errorf("usage: drive9 fs grep [--layer <ref>] <pattern> [path]")
+	jsonMode := false
+	remaining := make([]string, 0, len(filtered))
+	for _, arg := range filtered {
+		if arg == "--json" {
+			jsonMode = true
+		} else {
+			remaining = append(remaining, arg)
+		}
 	}
-	query := args[0]
-	path := "/"
-	if len(args) > 1 {
-		path = args[1]
-	}
-
-	c, path, _, _, err = fsClientForRemoteArg(c, path)
-	if err != nil {
-		return err
-	}
-
-	results, err := c.GrepWithLayer(query, path, 20, layerRef)
-	if err != nil {
-		return err
-	}
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	return enc.Encode(results)
+	return layerRef, jsonMode, remaining, nil
 }
 
 func parseLayerFlag(args []string) (string, []string, error) {

--- a/cmd/drive9/cli/grep_test.go
+++ b/cmd/drive9/cli/grep_test.go
@@ -1,0 +1,112 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/client"
+)
+
+// newGrepTestServer returns an httptest.Server that responds to grep
+// requests with the given JSON body. It also captures the layer query param
+// via the provided pointer (left untouched if nil).
+func newGrepTestServer(t *testing.T, responseBody string, layerPtr *string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Has("grep") {
+			if layerPtr != nil {
+				*layerPtr = r.URL.Query().Get("layer")
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = io.WriteString(w, responseBody)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+}
+
+func TestGrepJSONEmptyResultsOutputsArray(t *testing.T) {
+	srv := newGrepTestServer(t, `[]`, nil)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	out, err := captureStdoutE(t, func() error {
+		return Grep(c, []string{"--json", "needle", ":/repo/"})
+	})
+	if err != nil {
+		t.Fatalf("Grep --json: %v", err)
+	}
+
+	if got := strings.TrimSpace(out); got != "[]" {
+		t.Fatalf("got %q, want []", got)
+	}
+}
+
+func TestGrepJSONOutputsResults(t *testing.T) {
+	srv := newGrepTestServer(t, `[{"path":"/repo/a.txt","name":"a.txt","size_bytes":31,"score":0.03}]`, nil)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	out, err := captureStdoutE(t, func() error {
+		return Grep(c, []string{"--json", "needle", ":/repo/"})
+	})
+	if err != nil {
+		t.Fatalf("Grep --json: %v", err)
+	}
+
+	var results []client.SearchResult
+	if err := json.Unmarshal([]byte(strings.TrimSpace(out)), &results); err != nil {
+		t.Fatalf("decode JSON output: %v\nraw: %s", err, out)
+	}
+	if len(results) != 1 {
+		t.Fatalf("got %d results, want 1", len(results))
+	}
+	if results[0].Path != "/repo/a.txt" {
+		t.Fatalf("got path %q, want /repo/a.txt", results[0].Path)
+	}
+	if results[0].Score == nil || *results[0].Score != 0.03 {
+		t.Fatalf("got score %v, want 0.03", results[0].Score)
+	}
+}
+
+func TestGrepTextOutputWithoutJSON(t *testing.T) {
+	srv := newGrepTestServer(t, `[{"path":"/repo/a.txt","name":"a.txt","size_bytes":31,"score":0.03}]`, nil)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	out, err := captureStdoutE(t, func() error {
+		return Grep(c, []string{"needle", ":/repo/"})
+	})
+	if err != nil {
+		t.Fatalf("Grep: %v", err)
+	}
+
+	if got := strings.TrimSpace(out); got != "/repo/a.txt\t0.03" {
+		t.Fatalf("got %q, want /repo/a.txt\\t0.03", got)
+	}
+}
+
+func TestGrepJSONWithLayer(t *testing.T) {
+	var capturedLayer string
+	srv := newGrepTestServer(t, `[]`, &capturedLayer)
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	out, err := captureStdoutE(t, func() error {
+		return Grep(c, []string{"--json", "--layer", "task=search", "needle", ":/repo/"})
+	})
+	if err != nil {
+		t.Fatalf("Grep --json --layer: %v", err)
+	}
+
+	if capturedLayer != "task=search" {
+		t.Fatalf("layer param = %q, want task=search", capturedLayer)
+	}
+	if got := strings.TrimSpace(out); got != "[]" {
+		t.Fatalf("got %q, want []", got)
+	}
+}

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -496,7 +496,8 @@ commands:
   rm [-r|--recursive] <path>
                        remove file or directory tree
   sh                  interactive shell
-  grep <pattern> [dir] search file contents
+  grep [--json] <pattern> [dir]
+                       search file contents
   find [dir] [flags]   find files by attributes
     -name <glob>         match filename
     -tag <key=value>     exact match tag key/value

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -789,6 +789,17 @@ PY
 )
 check_eq "cli grep finds batch file" "$grep_has_batch" "true"
 
+echo "[6.0] cli grep --json checks"
+grep_json_out="$(drive9_retry fs grep --json "cli-batch-$TS" "/")"
+check_cmd "grep --json emits a JSON array" \
+  bash -c 'jq -e "type == \"array\"" >/dev/null <<<"$1"' -- "$grep_json_out"
+grep_json_has_batch=$(jq -r --arg target "$BATCH_REMOTE_DIR/file-1.txt" \
+  '([ .[] | select(.path == $target) ] | length > 0)' <<<"$grep_json_out")
+check_eq "grep --json finds batch file in array" "$grep_json_has_batch" "true"
+
+grep_json_empty="$(drive9_retry fs grep --json "zzz_nonexistent_marker_xyz" "/")"
+check_eq "grep --json empty result is []" "$(jq -c <<<"$grep_json_empty")" "[]"
+
 find_out="$(drive9_retry fs find / -name "*.txt")"
 find_has_txt=$(python3 - "$find_out" <<'PY'
 import sys


### PR DESCRIPTION
## Problem

`drive9 fs grep --json` silently produces no output instead of JSON. The `GrepJSON` function in `cmd/drive9/cli/grep.go` was defined but never dispatched from `runFS` in `main.go` — the `case "grep"` only calls `cli.Grep`. Since `parseLayerFlag` does not recognize `--json`, the flag is left in the positional args and treated as the path, causing the server request to target a non-existent path and return empty results.

```text
$ drive9 fs grep "payment" --json
# empty output (should be JSON)
```

## Fix

- **`cmd/drive9/cli/grep.go`**: Add `parseGrepFlags` that extends `parseLayerFlag` with `--json` detection. Route JSON vs text output inside `Grep` based on the flag. Normalize nil result slice to `[]SearchResult{}` so empty results emit `[]` instead of `null`. Remove the dead `GrepJSON` function.
- **`cmd/drive9/main.go`**: Document `--json` in the `fs grep` usage line.
- **`cmd/drive9/cli/grep_test.go`** (new): 4 tests covering empty `[]` output, results JSON output, text fallback without `--json`, and `--json` + `--layer` combination.

## Verification

```text
$ drive9 fs grep "payment" --json
[
  {
    "path": "/test.txt",
    "name": "test.txt",
    "size_bytes": 91,
    "score": 0.01639344262295082
  }
]

$ drive9 fs grep "zzz_nonexistent" --json
[]
```

- `go build ./cmd/...` ✅
- `go test ./cmd/drive9/cli/...` all pass ✅
- `make lint` 0 issues ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional JSON output mode for file-content search, alongside the existing text output.
  * Search help now documents the new JSON flag.

* **Bug Fixes**
  * Empty search results in JSON mode now return a valid empty array instead of an empty response.
  * Search output remains consistent when a layer is specified.

* **Tests**
  * Added coverage for JSON output, text output, empty results, and layer handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->