### PR TITLE
fix(grep): raw content fallback when semantic text empty

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -2208,9 +2208,99 @@ func (b *Dat9Backend) Grep(ctx context.Context, query, pathPrefix string, limit 
 			err = searchErr
 			return nil, err
 		}
+		if len(rows) > 0 {
+			return rows, nil
+		}
+		// All indexed search paths returned empty. Fall back to reading raw
+		// file content and doing substring matching. This covers deployments
+		// where semantic.content_text is not populated (e.g. TiDB auto-embedding
+		// schema with the provider disabled).
+		rawRows, rawErr := b.grepRawContent(ctx, query, pathPrefix, limit)
+		if rawErr != nil {
+			logger.Warn(ctx, "backend_grep_raw_fallback_failed",
+				zap.Int("query_len", len(query)),
+				zap.String("path_prefix", pathPrefix),
+				zap.Int("limit", limit),
+				zap.Error(rawErr))
+		}
+		if len(rawRows) > 0 {
+			return rawRows, nil
+		}
 		return rows, nil
 	}
 	return rows, nil
+}
+
+// grepRawContent reads file content directly and performs substring matching.
+// This is the last-resort fallback when semantic.content_text is not populated
+// (e.g. TiDB auto-embedding schema with the provider disabled). It handles
+// both single-file paths and directory prefix paths.
+func (b *Dat9Backend) grepRawContent(ctx context.Context, query, pathPrefix string, limit int) ([]datastore.SearchResult, error) {
+	const maxFileSize = 1 << 20 // 1 MiB per file
+	const maxFiles = 100        // max files to scan
+
+	lowerQuery := strings.ToLower(query)
+
+	// Try single file first.
+	nf, statErr := b.store.Stat(ctx, pathPrefix)
+	if statErr == nil && nf != nil && !nf.Node.IsDirectory && nf.File != nil {
+		if nf.File.SizeBytes > maxFileSize {
+			return nil, nil
+		}
+		data, readErr := b.readFileDataCtx(ctx, nf.File)
+		if readErr != nil {
+			return nil, readErr
+		}
+		if !isTextContent(data) {
+			return nil, nil
+		}
+		if strings.Contains(strings.ToLower(string(data)), lowerQuery) {
+			return []datastore.SearchResult{{
+				Path:      nf.Node.Path,
+				Name:      nf.Node.Name,
+				SizeBytes: nf.File.SizeBytes,
+			}}, nil
+		}
+		return nil, nil
+	}
+
+	// Directory/prefix: list files and scan text content.
+	files, findErr := b.store.Find(ctx, &datastore.FindFilter{
+		PathPrefix: pathPrefix,
+		Limit:      maxFiles,
+	})
+	if findErr != nil {
+		return nil, findErr
+	}
+
+	var results []datastore.SearchResult
+	for _, f := range files {
+		if f.SizeBytes > maxFileSize {
+			continue
+		}
+		if len(results) >= limit {
+			break
+		}
+		filePath := f.Path
+		if filePath == "" {
+			continue
+		}
+		data, readErr := b.ReadCtx(ctx, filePath, 0, f.SizeBytes)
+		if readErr != nil {
+			continue
+		}
+		if !isTextContent(data) {
+			continue
+		}
+		if strings.Contains(strings.ToLower(string(data)), lowerQuery) {
+			results = append(results, datastore.SearchResult{
+				Path:      f.Path,
+				Name:      f.Name,
+				SizeBytes: f.SizeBytes,
+			})
+		}
+	}
+	return results, nil
 }
 
 // grepMerge takes the raw results from FTS, content-vector, and description-vector

--- a/pkg/backend/grep_test.go
+++ b/pkg/backend/grep_test.go
@@ -161,3 +161,75 @@ func TestGrepAutoEmbeddingSkipsApplicationQueryEmbedder(t *testing.T) {
 	default:
 	}
 }
+
+func TestGrepRawContentFallbackWhenSemanticTextEmpty(t *testing.T) {
+	// Simulate the TiDB auto-embedding case where content_text is not written
+	// to the semantic table. The raw-content fallback should read the file
+	// directly and find the match.
+	b := newTestBackend(t)
+	b.store.DisableAutoEmbedTextWrites()
+
+	if _, err := b.Write("/notes/raw.txt", []byte("secret payment info"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := b.Grep(context.Background(), "payment", "/notes/", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Path != "/notes/raw.txt" {
+		t.Fatalf("expected raw fallback to find /notes/raw.txt, got %+v", results)
+	}
+}
+
+func TestGrepRawContentFallbackSingleFile(t *testing.T) {
+	b := newTestBackend(t)
+	b.store.DisableAutoEmbedTextWrites()
+
+	if _, err := b.Write("/data.txt", []byte("hello world grep test"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := b.Grep(context.Background(), "hello", "/data.txt", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Path != "/data.txt" {
+		t.Fatalf("expected raw fallback to find /data.txt, got %+v", results)
+	}
+}
+
+func TestGrepRawContentFallbackNoMatchReturnsEmpty(t *testing.T) {
+	b := newTestBackend(t)
+	b.store.DisableAutoEmbedTextWrites()
+
+	if _, err := b.Write("/notes/no.txt", []byte("nothing relevant here"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := b.Grep(context.Background(), "payment", "/notes/", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected empty results, got %+v", results)
+	}
+}
+
+func TestGrepRawContentFallbackSkipsBinaryFiles(t *testing.T) {
+	b := newTestBackend(t)
+	b.store.DisableAutoEmbedTextWrites()
+
+	// Write a binary file (contains null byte)
+	if _, err := b.Write("/notes/bin.dat", []byte("payment\x00binary"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := b.Grep(context.Background(), "payment", "/notes/", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected binary file to be skipped, got %+v", results)
+	}
+}


### PR DESCRIPTION
## Summary
- When `DisableAutoEmbedTextWrites` is active (TiDB auto-embedding schema with provider disabled), `semantic.content_text` is NULL
- All three grep search paths (FTS, vector, LIKE) return empty results, even though `drive9 fs cat` works
- Added `grepRawContent` as last-resort fallback: reads actual file content and does case-insensitive substring matching
- Handles both single-file paths and directory prefix scans
- Guards: skips binary files, caps at 1MiB per file, max 100 files scanned

## Root cause
`pool.go:721` calls `store.DisableAutoEmbedTextWrites()` when `DisableDatabaseAutoEmbedding=true && UsesTiDBAutoEmbedding(provider)=true`. This is necessary because writing to `semantic.content_text` triggers `EMBED_TEXT()` recomputation on GENERATED columns, which fails with error 1105 when the embedding provider is unavailable.

However, this leaves `semantic.content_text` as NULL, making all search paths (FTS `fts_match_word`, vector search, LIKE fallback) return empty.

## Reproduced
Created workspace on `drive9.pingkai.cn`, uploaded text file, `cat` works, `grep` returns `null`.

## Test plan
- [x] `go vet ./pkg/backend/` passes
- [x] `go build ./pkg/backend/` passes
- [ ] CI: `TestGrepRawContentFallbackWhenSemanticTextEmpty` — writes file with `DisableAutoEmbedTextWrites`, verifies grep finds it
- [ ] CI: `TestGrepRawContentFallbackSingleFile` — single file path grep
- [ ] CI: `TestGrepRawContentFallbackNoMatchReturnsEmpty` — no false positives
- [ ] CI: `TestGrepRawContentFallbackSkipsBinaryFiles` — binary files excluded

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search fallback so matches can still be found by scanning raw file contents when ranked and keyword-based search return nothing.
  * Search now handles both single-file and directory-based queries more reliably, while skipping large or non-text files.
  * Binary files are ignored during this fallback to avoid false matches.

* **Tests**
  * Added coverage for raw-content fallback behavior, including empty semantic results, single-file searches, no-match cases, and binary file skipping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->