### PR TITLE
fix(grep): drop generated embedding columns when auto-embedding disabled

### DIFF
--- a/pkg/backend/grep_test.go
+++ b/pkg/backend/grep_test.go
@@ -135,6 +135,56 @@ func TestGrepFallsBackToKeywordWhenFTSIsEmptyAndVectorFails(t *testing.T) {
 	}
 }
 
+func TestGrepContentTextAlwaysWrittenToSemantic(t *testing.T) {
+	// Regression: content_text must always be written to the semantic table
+	// so FTS and LIKE searches work even when auto-embedding is disabled.
+	// Previously DisableAutoEmbedTextWrites skipped writing content_text,
+	// causing all search paths to return empty.
+	b := newTestBackend(t)
+	if _, err := b.Write("/notes/always.txt", []byte("content always indexed"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify grep finds the file via keyword search (LIKE on content_text).
+	// This proves content_text was written to the semantic table.
+	results, err := b.Grep(context.Background(), "always indexed", "/notes/", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Path != "/notes/always.txt" {
+		t.Fatalf("expected grep to find /notes/always.txt via keyword, got %+v", results)
+	}
+}
+
+func TestGrepContentTextWrittenOnOverwrite(t *testing.T) {
+	// Verify content_text is updated when a file is overwritten.
+	b := newTestBackend(t)
+	if _, err := b.Write("/notes/overwrite.txt", []byte("original content alpha"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/notes/overwrite.txt", []byte("replaced content beta"), 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatal(err)
+	}
+
+	// Old content should not match.
+	results, err := b.Grep(context.Background(), "alpha", "/notes/", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected old content 'alpha' to not match after overwrite, got %+v", results)
+	}
+
+	// New content should match.
+	results, err = b.Grep(context.Background(), "beta", "/notes/", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Path != "/notes/overwrite.txt" {
+		t.Fatalf("expected grep to find /notes/overwrite.txt via keyword 'beta', got %+v", results)
+	}
+}
+
 func TestGrepAutoEmbeddingSkipsApplicationQueryEmbedder(t *testing.T) {
 	seen := make(chan string, 1)
 	b := newTestBackendWithOptions(t, Options{

--- a/pkg/datastore/file_tx.go
+++ b/pkg/datastore/file_tx.go
@@ -367,17 +367,12 @@ func (s *Store) ClearFileEmbeddingStateTx(db execer, fileID string) error {
 			return err
 		}
 	}
-	// Dual-write to split tables
-	// Skip the explicit NULL write when embedding is a GENERATED column (TiDB
-	// auto-embedding schema) — only clear the revision marker instead.
-	if s.disableAutoEmbedTextWrites {
-		if _, err := db.Exec(`UPDATE semantic SET embedding_revision = NULL WHERE inode_id = ?`, fileID); err != nil {
-			return fmt.Errorf("update semantic embedding revision: %w", err)
-		}
-		return nil
-	}
-	if _, err := db.Exec(`UPDATE semantic SET embedding = NULL, embedding_revision = NULL WHERE inode_id = ?`, fileID); err != nil {
-		return fmt.Errorf("update semantic embedding: %w", err)
+	// Clear embedding revision marker on the split semantic table.
+	// The embedding/description_embedding vector columns may not exist
+	// (dropped when auto-embedding is disabled), so only clear the
+	// revision marker which is always present.
+	if _, err := db.Exec(`UPDATE semantic SET embedding_revision = NULL WHERE inode_id = ?`, fileID); err != nil {
+		return fmt.Errorf("update semantic embedding revision: %w", err)
 	}
 	return nil
 }

--- a/pkg/datastore/semantic.go
+++ b/pkg/datastore/semantic.go
@@ -44,26 +44,15 @@ func (s *Store) GetSemantic(ctx context.Context, inodeID string) (*Semantic, err
 	return scanSemantic(row)
 }
 
-// UpdateSemanticTx updates semantic data inside a transaction, clearing embeddings.
-// When the store has auto-embed text writes disabled (TiDB schema with GENERATED
-// embedding columns), writing NULL to those columns is forbidden (TiDB error 3105).
-// In that case only the revision markers are cleared; content_text and description
-// are left untouched to avoid triggering EMBED_TEXT() generated column evaluation.
+// UpdateSemanticTx updates semantic text data and clears embedding revision
+// markers inside a transaction. The embedding and description_embedding
+// vector columns may not exist (they are dropped when auto-embedding is
+// disabled), so this method only touches content_text, description, and
+// the revision markers.
 func (s *Store) UpdateSemanticTx(db execer, inodeID string, contentText, description string) error {
-	if s.disableAutoEmbedTextWrites {
-		// embedding and description_embedding are GENERATED ALWAYS columns on TiDB;
-		// explicit writes (even NULL) are rejected. Only clear the revision markers
-		// so stale vector state is flagged without violating the generated-column
-		// constraint.
-		_, err := db.Exec(`UPDATE semantic SET
-			embedding_revision = NULL, description_embedding_revision = NULL
-			WHERE inode_id = ?`, inodeID)
-		return err
-	}
 	_, err := db.Exec(`UPDATE semantic SET
 		content_text = ?, description = ?,
-		embedding = NULL, embedding_revision = NULL,
-		description_embedding = NULL, description_embedding_revision = NULL
+		embedding_revision = NULL, description_embedding_revision = NULL
 		WHERE inode_id = ?`,
 		nullStr(contentText), nullStr(description), inodeID)
 	return err

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -151,10 +151,6 @@ type Upload struct {
 type Store struct {
 	db             *sql.DB
 	useLegacyFiles bool // true when the legacy `files` table exists and needs dual-write
-	// disableAutoEmbedTextWrites suppresses content_text/description writes to the
-	// semantic table so TiDB does not attempt to compute EMBED_TEXT() generated
-	// columns when the cluster has no supported auto-embedding provider.
-	disableAutoEmbedTextWrites bool
 }
 
 func Open(dsn string) (*Store, error) {
@@ -187,12 +183,6 @@ func (s *Store) DB() *sql.DB  { return s.db }
 // tenant database. When false, all writes skip the `files` table entirely
 // and only target the split tables (inodes / contents / semantic).
 func (s *Store) HasLegacyFiles() bool { return s.useLegacyFiles }
-
-// DisableAutoEmbedTextWrites configures the store to omit content_text and
-// description when inserting/updating the semantic table. Use this when the
-// TiDB Cloud cluster has no supported auto-embedding provider so that
-// EMBED_TEXT() generated columns are not triggered.
-func (s *Store) DisableAutoEmbedTextWrites() { s.disableAutoEmbedTextWrites = true }
 
 func (s *Store) detectLegacyFiles(ctx context.Context) (bool, error) {
 	var n int
@@ -930,12 +920,10 @@ func (s *Store) insertSplitTablesTx(tx execer, f *File) error {
 	}
 	semantic := &Semantic{
 		InodeID:                      f.FileID,
+		ContentText:                  f.ContentText,
+		Description:                  f.Description,
 		EmbeddingRevision:            f.EmbeddingRevision,
 		DescriptionEmbeddingRevision: f.DescriptionEmbeddingRevision,
-	}
-	if !s.disableAutoEmbedTextWrites {
-		semantic.ContentText = f.ContentText
-		semantic.Description = f.Description
 	}
 	if err := s.InsertSemanticTx(tx, semantic); err != nil {
 		return fmt.Errorf("insert semantic: %w", err)
@@ -1100,12 +1088,6 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 		if err != nil {
 			return nil, err
 		}
-		// Skip when auto-embed text writes are disabled: return after updating
-		// files table, skip semantic dual-write. Return the real res so
-		// RowsAffected() reflects whether the files row actually matched.
-		if s.disableAutoEmbedTextWrites {
-			return res, nil
-		}
 		if expectedRevision > 0 {
 			if _, err := db.Exec(`UPDATE semantic SET content_text = ?
 				WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`,
@@ -1122,30 +1104,6 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 		return res, nil
 	}
 	// New tenant without legacy files: write directly to semantic.
-	// Skip when auto-embed text writes are disabled: any write to content_text
-	// triggers EMBED_TEXT() recomputation on the GENERATED embedding column,
-	// which fails with error 1105 when the provider is not available on this cluster.
-	// We still gate on the revision/status check so stale tasks are correctly
-	// rejected (returning 0 rows), while current tasks return 1 so the caller
-	// can proceed to write tags (stored in file_tags, unaffected by EMBED_TEXT).
-	if s.disableAutoEmbedTextWrites {
-		var n int
-		var err error
-		if expectedRevision > 0 {
-			err = db.QueryRow(`SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?`,
-				fileID, expectedRevision).Scan(&n)
-		} else {
-			err = db.QueryRow(`SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED'`,
-				fileID).Scan(&n)
-		}
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return noopResult{0}, nil // stale or not found: report 0 rows
-			}
-			return nil, fmt.Errorf("check inode for search text skip: %w", err)
-		}
-		return noopResult{1}, nil // found: report 1 row so tags are written
-	}
 	if expectedRevision > 0 {
 		return db.Exec(`UPDATE semantic SET content_text = ?
 			WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`,
@@ -1258,14 +1216,6 @@ type execer interface {
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
-
-// noopResult is a sql.Result that reports a configurable number of rows
-// affected and zero last insert ID. Used when a write is intentionally skipped
-// but the caller may need to know whether the target row existed.
-type noopResult struct{ rows int64 }
-
-func (r noopResult) LastInsertId() (int64, error) { return 0, nil }
-func (r noopResult) RowsAffected() (int64, error) { return r.rows, nil }
 
 // FileStorageMeta holds the lightweight storage metadata needed by upload
 // overwrite logic, fetched with FOR UPDATE row locking.

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -757,7 +757,10 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 						recordTenantSchemaVersionUpdateFailure(ctx, t.ID, targetSchemaVersion, time.Since(updateSchemaVersionStart), verErr)
 					}
 				}
-			} else if p.shouldPeriodicValidateTiDBSchemaOnOpen() {
+			} else if p.shouldPeriodicValidateTiDBSchemaOnOpen() && !p.cfg.DisableDatabaseAutoEmbedding {
+				// Skip auto-embedding schema validation when embedding is
+				// disabled: the generated embedding columns are intentionally
+				// dropped and validation would fail on their absence.
 				validateSchemaStart := time.Now()
 				if err := validateTiDBSchemaForAutoEmbeddingProfile(ctx, store.DB(), autoEmbeddingProfile.schemaProfile); err != nil {
 					_ = store.Close()

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -718,9 +718,6 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	if err != nil {
 		return nil, nil, fmt.Errorf("open datastore: %w", err)
 	}
-	if p.cfg.DisableDatabaseAutoEmbedding && UsesTiDBAutoEmbedding(t.Provider) {
-		store.DisableAutoEmbedTextWrites()
-	}
 	openStoreDurationMs := float64(time.Since(openStoreStart).Microseconds()) / 1000.0
 	ensureSchemaDurationMs := 0.0
 	migrateDurationMs := 0.0
@@ -767,6 +764,17 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 					return nil, nil, fmt.Errorf("validate tidb auto-embedding schema: %w", err)
 				}
 				ensureSchemaDurationMs += float64(time.Since(validateSchemaStart).Microseconds()) / 1000.0
+			}
+		}
+		// When auto-embedding is disabled at runtime, drop the GENERATED
+		// STORED embedding columns so that content_text can be written
+		// without triggering EMBED_TEXT() (which fails with error 1105
+		// when the provider is not configured). The function is idempotent
+		// and checks information_schema before each DROP.
+		if p.cfg.DisableDatabaseAutoEmbedding {
+			if err := schema.DropGeneratedEmbeddingColumns(ctx, store.DB()); err != nil {
+				_ = store.Close()
+				return nil, nil, fmt.Errorf("drop generated embedding columns: %w", err)
 			}
 		}
 	}

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -3148,3 +3148,74 @@ func isMissingColumnError(err error) bool {
 		strings.Contains(msg, "unknown column") ||
 		(strings.Contains(msg, "column") && strings.Contains(msg, "does not exist"))
 }
+
+// DropGeneratedEmbeddingColumns removes the GENERATED STORED embedding and
+// description_embedding columns (and their VECTOR indexes) from the semantic
+// table. This allows content_text to be written without triggering EMBED_TEXT()
+// computation, which fails when the embedding provider is not configured.
+//
+// The function is idempotent: it checks information_schema before each DROP
+// and silently succeeds when the target column or index does not exist.
+func DropGeneratedEmbeddingColumns(ctx context.Context, db *sql.DB) error {
+	start := time.Now()
+
+	// Drop vector indexes first (must happen before dropping the columns they reference).
+	for _, idx := range []string{"idx_semantic_cosine", "idx_semantic_desc_cosine"} {
+		exists, err := indexExistsOnTable(ctx, db, "semantic", idx)
+		if err != nil {
+			return fmt.Errorf("check index %s: %w", idx, err)
+		}
+		if !exists {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, "ALTER TABLE semantic DROP INDEX "+idx); err != nil {
+			return fmt.Errorf("drop index %s: %w", idx, err)
+		}
+		logger.Info(ctx, "tenant_drop_generated_embedding_index",
+			zap.String("index", idx))
+	}
+
+	// Drop generated columns.
+	for _, col := range []string{"embedding", "description_embedding"} {
+		exists, err := columnExistsOnTable(ctx, db, "semantic", col)
+		if err != nil {
+			return fmt.Errorf("check column %s: %w", col, err)
+		}
+		if !exists {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, "ALTER TABLE semantic DROP COLUMN "+col); err != nil {
+			return fmt.Errorf("drop column %s: %w", col, err)
+		}
+		logger.Info(ctx, "tenant_drop_generated_embedding_column",
+			zap.String("column", col))
+	}
+
+	logger.Info(ctx, "tenant_drop_generated_embedding_columns_finished",
+		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+	return nil
+}
+
+func indexExistsOnTable(ctx context.Context, db *sql.DB, table, indexName string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM information_schema.statistics
+		 WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?`,
+		table, indexName).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func columnExistsOnTable(ctx context.Context, db *sql.DB, table, column string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM information_schema.columns
+		 WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?`,
+		table, column).Scan(&count)
+	if err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -3159,6 +3159,21 @@ func isMissingColumnError(err error) bool {
 func DropGeneratedEmbeddingColumns(ctx context.Context, db *sql.DB) error {
 	start := time.Now()
 
+	// Fast path: if neither generated column exists, skip entirely.
+	// This avoids 4 information_schema queries on every tenant init
+	// in the steady-state case where columns are already dropped.
+	hasEmbedding, err := columnExistsOnTable(ctx, db, "semantic", "embedding")
+	if err != nil {
+		return fmt.Errorf("check embedding column: %w", err)
+	}
+	hasDescEmbedding, err := columnExistsOnTable(ctx, db, "semantic", "description_embedding")
+	if err != nil {
+		return fmt.Errorf("check description_embedding column: %w", err)
+	}
+	if !hasEmbedding && !hasDescEmbedding {
+		return nil
+	}
+
 	// Drop vector indexes first (must happen before dropping the columns they reference).
 	for _, idx := range []string{"idx_semantic_cosine", "idx_semantic_desc_cosine"} {
 		exists, err := indexExistsOnTable(ctx, db, "semantic", idx)


### PR DESCRIPTION
## Summary

- **Root cause**: on TiDB auto-embedding clusters, `semantic.content_text` was NULL because writing it triggers `EMBED_TEXT()` → error 1105 (no provider). All search paths (FTS, LIKE, vector) returned empty.
- **Fix**: when `DisableDatabaseAutoEmbedding=true`, DROP the `embedding` and `description_embedding` GENERATED STORED columns (and their VECTOR indexes). This allows `content_text` to be written normally → FTS and keyword search work independently of embedding state.
- Removes `DisableAutoEmbedTextWrites` flag and all its branches — `content_text` is now always written
- `DropGeneratedEmbeddingColumns()` is idempotent (checks `information_schema` before each DROP)
- When embedding is re-enabled, existing schema repair logic ADDs the columns back

## Changes

| File | Change |
|------|--------|
| `pkg/tenant/schema/tidb_auto.go` | Add `DropGeneratedEmbeddingColumns()` + helpers |
| `pkg/tenant/pool.go` | Call DROP after schema ensure when embedding disabled |
| `pkg/datastore/store.go` | Remove `disableAutoEmbedTextWrites` field and all branches |
| `pkg/datastore/semantic.go` | `UpdateSemanticTx` no longer references vector columns |
| `pkg/datastore/file_tx.go` | `ClearFileEmbeddingStateTx` only clears revision marker |
| `pkg/backend/grep_test.go` | Regression tests for content_text write + grep after overwrite |

## Test plan

- [ ] CI passes (build + vet + existing tests)
- [ ] `TestGrepContentTextAlwaysWrittenToSemantic` — verifies content_text is written and keyword grep works
- [ ] `TestGrepContentTextWrittenOnOverwrite` — verifies content_text is updated on file overwrite
- [ ] Manual: deploy to `drive9.pingkai.cn`, `drive9 fs grep "payment" :/test.txt` returns results

🤖 Generated with [Claude Code](https://claude.com/claude-code)