### PR TITLE
fix(fork): honor private endpoint TLS setting for fork tenants

### DIFF
--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -462,7 +462,7 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 		DBUser:           cluster.Username,
 		DBPasswordCipher: forkRoot.DBPasswordCipher,
 		DBName:           cluster.DBName,
-		DBTLS:            true,
+		DBTLS:            dbTLSForProvisionedTenant(cluster.Provider),
 		Provider:         cluster.Provider,
 		ClusterID:        cluster.ClusterID,
 		BranchID:         cluster.BranchID,
@@ -703,14 +703,14 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 				DBUser:           username,
 				DBPasswordCipher: forkTenant.DBPasswordCipher,
 				DBName:           forkTenant.DBName,
-				DBTLS:            true,
+				DBTLS:            dbTLSForProvisionedTenant(forkTenant.Provider),
 				Provider:         forkTenant.Provider,
 				ClusterID:        forkTenant.ClusterID,
 				BranchID:         forkTenant.BranchID,
 			}); err != nil {
 				return "", err
 			}
-			return tenantDSN(username, string(plain), host, port, forkTenant.DBName, true, forkTenant.Provider), nil
+			return tenantDSN(username, string(plain), host, port, forkTenant.DBName, dbTLSForProvisionedTenant(forkTenant.Provider), forkTenant.Provider), nil
 		}
 		cluster, err := s.waitForForkBranchActive(ctx, &tenant.ClusterInfo{
 			TenantID:  forkTenant.ID,
@@ -729,7 +729,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 			DBUser:           cluster.Username,
 			DBPasswordCipher: forkTenant.DBPasswordCipher,
 			DBName:           cluster.DBName,
-			DBTLS:            true,
+			DBTLS:            dbTLSForProvisionedTenant(cluster.Provider),
 			Provider:         cluster.Provider,
 			ClusterID:        cluster.ClusterID,
 			BranchID:         cluster.BranchID,
@@ -738,7 +738,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		}); err != nil {
 			return "", err
 		}
-		return tenantDSN(cluster.Username, string(plain), cluster.Host, cluster.Port, cluster.DBName, true, cluster.Provider), nil
+		return tenantDSN(cluster.Username, string(plain), cluster.Host, cluster.Port, cluster.DBName, dbTLSForProvisionedTenant(cluster.Provider), cluster.Provider), nil
 	}
 
 	branchPassword, err := s.pool.Decrypt(ctx, forkTenant.DBPasswordCipher)
@@ -764,7 +764,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		DBUser:           cluster.Username,
 		DBPasswordCipher: forkTenant.DBPasswordCipher,
 		DBName:           cluster.DBName,
-		DBTLS:            true,
+		DBTLS:            dbTLSForProvisionedTenant(cluster.Provider),
 		Provider:         cluster.Provider,
 		ClusterID:        cluster.ClusterID,
 		BranchID:         cluster.BranchID,
@@ -777,7 +777,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 	if cluster.Host == "" || cluster.Port == 0 || cluster.Username == "" {
 		return "", forkErr(http.StatusServiceUnavailable, "database branch is not active yet")
 	}
-	return tenantDSN(cluster.Username, string(branchPassword), cluster.Host, cluster.Port, cluster.DBName, true, cluster.Provider), nil
+	return tenantDSN(cluster.Username, string(branchPassword), cluster.Host, cluster.Port, cluster.DBName, dbTLSForProvisionedTenant(cluster.Provider), cluster.Provider), nil
 }
 
 func generateForkDBPassword(length int) (string, error) {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -697,20 +697,21 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 			if port == 0 {
 				port = source.DBPort
 			}
+			dbTLS := dbTLSForProvisionedTenant(forkTenant.Provider)
 			if err := s.meta.UpdateTenantConnection(ctx, forkTenant.ID, &meta.Tenant{
 				DBHost:           host,
 				DBPort:           port,
 				DBUser:           username,
 				DBPasswordCipher: forkTenant.DBPasswordCipher,
 				DBName:           forkTenant.DBName,
-				DBTLS:            dbTLSForProvisionedTenant(forkTenant.Provider),
+				DBTLS:            dbTLS,
 				Provider:         forkTenant.Provider,
 				ClusterID:        forkTenant.ClusterID,
 				BranchID:         forkTenant.BranchID,
 			}); err != nil {
 				return "", err
 			}
-			return tenantDSN(username, string(plain), host, port, forkTenant.DBName, dbTLSForProvisionedTenant(forkTenant.Provider), forkTenant.Provider), nil
+			return tenantDSN(username, string(plain), host, port, forkTenant.DBName, dbTLS, forkTenant.Provider), nil
 		}
 		cluster, err := s.waitForForkBranchActive(ctx, &tenant.ClusterInfo{
 			TenantID:  forkTenant.ID,
@@ -723,13 +724,14 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		if err != nil {
 			return "", err
 		}
+		dbTLS := dbTLSForProvisionedTenant(cluster.Provider)
 		if err := s.meta.UpdateTenantConnection(ctx, forkTenant.ID, &meta.Tenant{
 			DBHost:           cluster.Host,
 			DBPort:           cluster.Port,
 			DBUser:           cluster.Username,
 			DBPasswordCipher: forkTenant.DBPasswordCipher,
 			DBName:           cluster.DBName,
-			DBTLS:            dbTLSForProvisionedTenant(cluster.Provider),
+			DBTLS:            dbTLS,
 			Provider:         cluster.Provider,
 			ClusterID:        cluster.ClusterID,
 			BranchID:         cluster.BranchID,
@@ -738,7 +740,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 		}); err != nil {
 			return "", err
 		}
-		return tenantDSN(cluster.Username, string(plain), cluster.Host, cluster.Port, cluster.DBName, dbTLSForProvisionedTenant(cluster.Provider), cluster.Provider), nil
+		return tenantDSN(cluster.Username, string(plain), cluster.Host, cluster.Port, cluster.DBName, dbTLS, cluster.Provider), nil
 	}
 
 	branchPassword, err := s.pool.Decrypt(ctx, forkTenant.DBPasswordCipher)
@@ -758,13 +760,14 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 	if cluster == nil || cluster.ClusterID == "" || cluster.BranchID == "" {
 		return "", forkErr(http.StatusBadGateway, "database branch response missing required metadata")
 	}
+	dbTLS := dbTLSForProvisionedTenant(cluster.Provider)
 	if err := s.meta.UpdateTenantConnection(ctx, forkTenant.ID, &meta.Tenant{
 		DBHost:           cluster.Host,
 		DBPort:           cluster.Port,
 		DBUser:           cluster.Username,
 		DBPasswordCipher: forkTenant.DBPasswordCipher,
 		DBName:           cluster.DBName,
-		DBTLS:            dbTLSForProvisionedTenant(cluster.Provider),
+		DBTLS:            dbTLS,
 		Provider:         cluster.Provider,
 		ClusterID:        cluster.ClusterID,
 		BranchID:         cluster.BranchID,
@@ -777,7 +780,7 @@ func (s *Server) ensureForkBranchConnection(ctx context.Context, forkTenant, sou
 	if cluster.Host == "" || cluster.Port == 0 || cluster.Username == "" {
 		return "", forkErr(http.StatusServiceUnavailable, "database branch is not active yet")
 	}
-	return tenantDSN(cluster.Username, string(branchPassword), cluster.Host, cluster.Port, cluster.DBName, dbTLSForProvisionedTenant(cluster.Provider), cluster.Provider), nil
+	return tenantDSN(cluster.Username, string(branchPassword), cluster.Host, cluster.Port, cluster.DBName, dbTLS, cluster.Provider), nil
 }
 
 func generateForkDBPassword(length int) (string, error) {

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -1045,6 +1045,61 @@ func TestProvisionForkTenantWithCredentialsUsesRequestKeyForWait(t *testing.T) {
 	}
 }
 
+func TestCreateForkTenantPersistsPrivateEndpointDBTLS(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		envValue   string
+		wantDBTLS  bool
+		wantDSNTLS string
+	}{
+		{name: "public_endpoint_uses_tls", envValue: "", wantDBTLS: true, wantDSNTLS: "tls=true"},
+		{name: "private_endpoint_skips_verify", envValue: "1", wantDBTLS: false, wantDSNTLS: "tls=skip-verify"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT", tc.envValue)
+
+			rt := newForkCleanupTestRuntime(t)
+			rt.prov.provider = tenant.ProviderTiDBCloudNative
+			rt.insertLiveTenantWithProvider(t, "source", tenant.ProviderTiDBCloudNative)
+			rt.prov.cluster = &tenant.ClusterInfo{
+				ClusterID: "cluster-a",
+				BranchID:  "branch-created",
+				Host:      rt.dbHost,
+				Port:      rt.dbPort,
+				Username:  rt.dbUser,
+				DBName:    rt.dbName,
+				Provider:  tenant.ProviderTiDBCloudNative,
+			}
+			rt.prov.provisionErr = context.Canceled
+
+			resp, err := rt.server.createForkTenant(context.Background(), "source", "fork", &tenant.CredentialProvisionRequest{
+				PublicKey:  "public-1",
+				PrivateKey: "private-1",
+			})
+			if err != nil {
+				t.Fatalf("createForkTenant error = %v, want nil (provision is async)", err)
+			}
+
+			forkTenant, err := rt.meta.GetTenant(context.Background(), resp.TenantID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if forkTenant.DBTLS != tc.wantDBTLS {
+				t.Fatalf("fork DBTLS = %v, want %v", forkTenant.DBTLS, tc.wantDBTLS)
+			}
+
+			plain, err := rt.pool.Decrypt(context.Background(), forkTenant.DBPasswordCipher)
+			if err != nil {
+				t.Fatalf("decrypt fork password: %v", err)
+			}
+			dsn := tenantDSN(forkTenant.DBUser, string(plain), forkTenant.DBHost, forkTenant.DBPort, forkTenant.DBName, forkTenant.DBTLS, forkTenant.Provider)
+			if !strings.Contains(dsn, tc.wantDSNTLS) {
+				t.Fatalf("fork DSN = %q, want it to contain %q", dsn, tc.wantDSNTLS)
+			}
+		})
+	}
+}
+
 func TestProvisionForkTenantAsyncWithProvisionCallsProvisionClosure(t *testing.T) {
 	var called bool
 	rt := newForkCleanupTestRuntime(t)


### PR DESCRIPTION
## Summary

Fork tenant connections hardcoded `DBTLS: true`, diverging from normal tenants which derive TLS from `dbTLSForProvisionedTenant(provider)`.

When `DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT` is enabled:
- Normal `TiDBCloudNative` tenants use `tls=skip-verify` (`DBTLS=false`)
- Forks used `tls=true` (full cert verification)

This inconsistency caused fork DB connections to fail certificate verification under private endpoints.

## Changes

`pkg/server/fork.go` — replace hardcoded `DBTLS: true` / `tenantDSN(..., true, ...)` with `dbTLSForProvisionedTenant(provider)` across all fork connection persist and DSN build paths:
- `createForkTenant` connection persist
- `ensureForkBranchConnection` branch-user path (persist + DSN)
- `ensureForkBranchConnection` `waitForForkBranchActive` path (persist + DSN)
- `ensureForkBranchConnection` `createForkBranch` path (persist + DSN)

Cleanup paths already read the persisted `DBTLS`, so they inherit the corrected value.

## Test plan
- [x] `go build ./pkg/server/...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database connection handling for forked tenants so TLS is set based on the provider instead of being forced on.
  * Updated fork branch connection setup to use the correct TLS setting when creating, resolving, or refreshing connection details.
  * This helps forked environments connect more reliably across different database providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->