### PR TITLE
Add tenant-level FTS-only embedding mode

### DIFF
--- a/pkg/backend/grep_test.go
+++ b/pkg/backend/grep_test.go
@@ -135,6 +135,52 @@ func TestGrepFallsBackToKeywordWhenFTSIsEmptyAndVectorFails(t *testing.T) {
 	}
 }
 
+func TestGrepContentTextAlwaysWrittenToSemantic(t *testing.T) {
+	// Regression: content_text must always be written to the semantic table
+	// so FTS and LIKE searches work even when auto-embedding is disabled.
+	b := newTestBackend(t)
+	if _, err := b.Write("/notes/always.txt", []byte("content always indexed"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := b.Grep(context.Background(), "always indexed", "/notes/", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Path != "/notes/always.txt" {
+		t.Fatalf("expected grep to find /notes/always.txt via keyword, got %+v", results)
+	}
+}
+
+func TestGrepContentTextWrittenOnOverwrite(t *testing.T) {
+	// Verify content_text is updated when a file is overwritten.
+	b := newTestBackend(t)
+	if _, err := b.Write("/notes/overwrite.txt", []byte("original content alpha"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/notes/overwrite.txt", []byte("replaced content beta"), 0, filesystem.WriteFlagTruncate); err != nil {
+		t.Fatal(err)
+	}
+
+	// Old content should not match.
+	results, err := b.Grep(context.Background(), "alpha", "/notes/", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("expected old content 'alpha' to not match after overwrite, got %+v", results)
+	}
+
+	// New content should match.
+	results, err = b.Grep(context.Background(), "beta", "/notes/", 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Path != "/notes/overwrite.txt" {
+		t.Fatalf("expected grep to find /notes/overwrite.txt via keyword 'beta', got %+v", results)
+	}
+}
+
 func TestGrepAutoEmbeddingSkipsApplicationQueryEmbedder(t *testing.T) {
 	seen := make(chan string, 1)
 	b := newTestBackendWithOptions(t, Options{

--- a/pkg/datastore/file_tx.go
+++ b/pkg/datastore/file_tx.go
@@ -367,15 +367,7 @@ func (s *Store) ClearFileEmbeddingStateTx(db execer, fileID string) error {
 			return err
 		}
 	}
-	// Dual-write to split tables
-	// Skip the explicit NULL write when embedding is a GENERATED column (TiDB
-	// auto-embedding schema) — only clear the revision marker instead.
-	if s.disableAutoEmbedTextWrites {
-		if _, err := db.Exec(`UPDATE semantic SET embedding_revision = NULL WHERE inode_id = ?`, fileID); err != nil {
-			return fmt.Errorf("update semantic embedding revision: %w", err)
-		}
-		return nil
-	}
+	// Dual-write to split tables.
 	if _, err := db.Exec(`UPDATE semantic SET embedding = NULL, embedding_revision = NULL WHERE inode_id = ?`, fileID); err != nil {
 		return fmt.Errorf("update semantic embedding: %w", err)
 	}

--- a/pkg/datastore/semantic.go
+++ b/pkg/datastore/semantic.go
@@ -45,21 +45,7 @@ func (s *Store) GetSemantic(ctx context.Context, inodeID string) (*Semantic, err
 }
 
 // UpdateSemanticTx updates semantic data inside a transaction, clearing embeddings.
-// When the store has auto-embed text writes disabled (TiDB schema with GENERATED
-// embedding columns), writing NULL to those columns is forbidden (TiDB error 3105).
-// In that case only the revision markers are cleared; content_text and description
-// are left untouched to avoid triggering EMBED_TEXT() generated column evaluation.
 func (s *Store) UpdateSemanticTx(db execer, inodeID string, contentText, description string) error {
-	if s.disableAutoEmbedTextWrites {
-		// embedding and description_embedding are GENERATED ALWAYS columns on TiDB;
-		// explicit writes (even NULL) are rejected. Only clear the revision markers
-		// so stale vector state is flagged without violating the generated-column
-		// constraint.
-		_, err := db.Exec(`UPDATE semantic SET
-			embedding_revision = NULL, description_embedding_revision = NULL
-			WHERE inode_id = ?`, inodeID)
-		return err
-	}
 	_, err := db.Exec(`UPDATE semantic SET
 		content_text = ?, description = ?,
 		embedding = NULL, embedding_revision = NULL,

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -151,10 +151,6 @@ type Upload struct {
 type Store struct {
 	db             *sql.DB
 	useLegacyFiles bool // true when the legacy `files` table exists and needs dual-write
-	// disableAutoEmbedTextWrites suppresses content_text/description writes to the
-	// semantic table so TiDB does not attempt to compute EMBED_TEXT() generated
-	// columns when the cluster has no supported auto-embedding provider.
-	disableAutoEmbedTextWrites bool
 }
 
 func Open(dsn string) (*Store, error) {
@@ -187,12 +183,6 @@ func (s *Store) DB() *sql.DB  { return s.db }
 // tenant database. When false, all writes skip the `files` table entirely
 // and only target the split tables (inodes / contents / semantic).
 func (s *Store) HasLegacyFiles() bool { return s.useLegacyFiles }
-
-// DisableAutoEmbedTextWrites configures the store to omit content_text and
-// description when inserting/updating the semantic table. Use this when the
-// TiDB Cloud cluster has no supported auto-embedding provider so that
-// EMBED_TEXT() generated columns are not triggered.
-func (s *Store) DisableAutoEmbedTextWrites() { s.disableAutoEmbedTextWrites = true }
 
 func (s *Store) detectLegacyFiles(ctx context.Context) (bool, error) {
 	var n int
@@ -932,10 +922,8 @@ func (s *Store) insertSplitTablesTx(tx execer, f *File) error {
 		InodeID:                      f.FileID,
 		EmbeddingRevision:            f.EmbeddingRevision,
 		DescriptionEmbeddingRevision: f.DescriptionEmbeddingRevision,
-	}
-	if !s.disableAutoEmbedTextWrites {
-		semantic.ContentText = f.ContentText
-		semantic.Description = f.Description
+		ContentText:                  f.ContentText,
+		Description:                  f.Description,
 	}
 	if err := s.InsertSemanticTx(tx, semantic); err != nil {
 		return fmt.Errorf("insert semantic: %w", err)
@@ -1100,12 +1088,6 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 		if err != nil {
 			return nil, err
 		}
-		// Skip when auto-embed text writes are disabled: return after updating
-		// files table, skip semantic dual-write. Return the real res so
-		// RowsAffected() reflects whether the files row actually matched.
-		if s.disableAutoEmbedTextWrites {
-			return res, nil
-		}
 		if expectedRevision > 0 {
 			if _, err := db.Exec(`UPDATE semantic SET content_text = ?
 				WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`,
@@ -1122,30 +1104,6 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 		return res, nil
 	}
 	// New tenant without legacy files: write directly to semantic.
-	// Skip when auto-embed text writes are disabled: any write to content_text
-	// triggers EMBED_TEXT() recomputation on the GENERATED embedding column,
-	// which fails with error 1105 when the provider is not available on this cluster.
-	// We still gate on the revision/status check so stale tasks are correctly
-	// rejected (returning 0 rows), while current tasks return 1 so the caller
-	// can proceed to write tags (stored in file_tags, unaffected by EMBED_TEXT).
-	if s.disableAutoEmbedTextWrites {
-		var n int
-		var err error
-		if expectedRevision > 0 {
-			err = db.QueryRow(`SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?`,
-				fileID, expectedRevision).Scan(&n)
-		} else {
-			err = db.QueryRow(`SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED'`,
-				fileID).Scan(&n)
-		}
-		if err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return noopResult{0}, nil // stale or not found: report 0 rows
-			}
-			return nil, fmt.Errorf("check inode for search text skip: %w", err)
-		}
-		return noopResult{1}, nil // found: report 1 row so tags are written
-	}
 	if expectedRevision > 0 {
 		return db.Exec(`UPDATE semantic SET content_text = ?
 			WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`,
@@ -1258,14 +1216,6 @@ type execer interface {
 	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
 	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
-
-// noopResult is a sql.Result that reports a configurable number of rows
-// affected and zero last insert ID. Used when a write is intentionally skipped
-// but the caller may need to know whether the target row existed.
-type noopResult struct{ rows int64 }
-
-func (r noopResult) LastInsertId() (int64, error) { return 0, nil }
-func (r noopResult) RowsAffected() (int64, error) { return r.rows, nil }
 
 // FileStorageMeta holds the lightweight storage metadata needed by upload
 // overwrite logic, fetched with FOR UPDATE row locking.

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -89,14 +89,34 @@ type Tenant struct {
 }
 
 type TenantAutoEmbeddingProfile struct {
-	TenantID     string
-	Model        string
-	Dimensions   int
-	OptionsJSON  string
-	APIBase      string
-	APIKeyCipher []byte
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	TenantID      string
+	EmbeddingMode string
+	Model         string
+	Dimensions    int
+	OptionsJSON   string
+	APIBase       string
+	APIKeyCipher  []byte
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+}
+
+const (
+	TenantEmbeddingModeAuto    = "auto"
+	TenantEmbeddingModeFTSOnly = "fts_only"
+)
+
+func ResolveTenantEmbeddingMode(persisted string, defaultFTSOnly bool) (mode string, wasNull bool, err error) {
+	switch persisted {
+	case "":
+		if defaultFTSOnly {
+			return TenantEmbeddingModeFTSOnly, true, nil
+		}
+		return TenantEmbeddingModeAuto, true, nil
+	case TenantEmbeddingModeAuto, TenantEmbeddingModeFTSOnly:
+		return persisted, false, nil
+	default:
+		return "", false, fmt.Errorf("unsupported tenant embedding mode %q", persisted)
+	}
 }
 
 type StorageNamespaceState string
@@ -470,6 +490,7 @@ func metaInitSchemaStatements() []string {
 		)`,
 		`CREATE TABLE IF NOT EXISTS tenant_auto_embedding_profiles (
 			tenant_id      VARCHAR(64) PRIMARY KEY,
+			embedding_mode VARCHAR(32) NULL,
 			model          VARCHAR(255) NOT NULL DEFAULT 'tidbcloud_free/amazon/titan-embed-text-v2',
 			dimensions     INT UNSIGNED NOT NULL DEFAULT 1024,
 			options_json   VARCHAR(2048) NOT NULL DEFAULT '{"dimensions":1024}',
@@ -1227,16 +1248,17 @@ func (s *Store) UpsertTenantAutoEmbeddingProfile(ctx context.Context, p *TenantA
 		return fmt.Errorf("nil tenant auto-embedding profile")
 	}
 	_, err = s.db.ExecContext(ctx, `INSERT INTO tenant_auto_embedding_profiles
-		(tenant_id, model, dimensions, options_json, api_base, api_key_cipher, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		(tenant_id, embedding_mode, model, dimensions, options_json, api_base, api_key_cipher, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		ON DUPLICATE KEY UPDATE
+			embedding_mode = VALUES(embedding_mode),
 			model = VALUES(model),
 			dimensions = VALUES(dimensions),
 			options_json = VALUES(options_json),
 			api_base = VALUES(api_base),
 			api_key_cipher = VALUES(api_key_cipher),
 			updated_at = VALUES(updated_at)`,
-		p.TenantID, p.Model, p.Dimensions, p.OptionsJSON, nullStr(p.APIBase), nullableBytes(p.APIKeyCipher),
+		p.TenantID, nullStr(p.EmbeddingMode), p.Model, p.Dimensions, p.OptionsJSON, nullStr(p.APIBase), nullableBytes(p.APIKeyCipher),
 		p.CreatedAt.UTC(), p.UpdatedAt.UTC())
 	return err
 }
@@ -1244,19 +1266,23 @@ func (s *Store) UpsertTenantAutoEmbeddingProfile(ctx context.Context, p *TenantA
 func (s *Store) GetTenantAutoEmbeddingProfile(ctx context.Context, tenantID string) (out *TenantAutoEmbeddingProfile, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "get_tenant_auto_embedding_profile", start, &err)
-	row := s.db.QueryRowContext(ctx, `SELECT tenant_id, model, dimensions, options_json,
+	row := s.db.QueryRowContext(ctx, `SELECT tenant_id, embedding_mode, model, dimensions, options_json,
 			api_base, api_key_cipher, created_at, updated_at
 		FROM tenant_auto_embedding_profiles WHERE tenant_id = ?`, tenantID)
 	var rec TenantAutoEmbeddingProfile
+	var embeddingMode sql.NullString
 	var apiBase sql.NullString
 	var apiKeyCipher []byte
-	if err = row.Scan(&rec.TenantID, &rec.Model, &rec.Dimensions, &rec.OptionsJSON,
+	if err = row.Scan(&rec.TenantID, &embeddingMode, &rec.Model, &rec.Dimensions, &rec.OptionsJSON,
 		&apiBase, &apiKeyCipher, &rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
 			return nil, err
 		}
 		return nil, err
+	}
+	if embeddingMode.Valid {
+		rec.EmbeddingMode = embeddingMode.String
 	}
 	if apiBase.Valid {
 		rec.APIBase = apiBase.String
@@ -1280,6 +1306,22 @@ func (s *Store) EnsureTenantAutoEmbeddingProfile(ctx context.Context, tenantID s
 		return nil, err
 	}
 	return s.GetTenantAutoEmbeddingProfile(ctx, tenantID)
+}
+
+func (s *Store) SetTenantAutoEmbeddingProfileModeIfNull(ctx context.Context, tenantID, mode string) (updated bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "set_tenant_auto_embedding_profile_mode_if_null", start, &err)
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_auto_embedding_profiles
+		SET embedding_mode = ?, updated_at = CURRENT_TIMESTAMP(3)
+		WHERE tenant_id = ? AND embedding_mode IS NULL`, mode, tenantID)
+	if err != nil {
+		return false, err
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return n > 0, nil
 }
 
 func (s *Store) InsertAPIKey(ctx context.Context, k *APIKey) (err error) {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -662,7 +662,11 @@ func (s *Server) provisionForkTenantOnceWithCredentials(ctx context.Context, for
 	if err != nil {
 		return err
 	}
-	version, err := schema.TiDBTenantSchemaVersionForAutoEmbeddingProfile(profile)
+	tidbMode, err := tenant.TiDBEmbeddingModeForTenantMode(profile.mode)
+	if err != nil {
+		return err
+	}
+	version, err := schema.TiDBTenantSchemaVersionForEmbeddingModeProfile(tidbMode, profile.schemaProfile)
 	if err != nil {
 		return err
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -1700,15 +1700,29 @@ func TestProvisionPersistsAutoEmbeddingProfileWhenDatabaseAutoEmbeddingDisabled(
 	if profile.Model != "openai/text-embedding-3-small" || profile.Dimensions != 1536 {
 		t.Fatalf("profile = %+v", profile)
 	}
+	if profile.EmbeddingMode != meta.TenantEmbeddingModeFTSOnly {
+		t.Fatalf("embedding_mode=%q, want %q", profile.EmbeddingMode, meta.TenantEmbeddingModeFTSOnly)
+	}
 	if len(profile.APIKeyCipher) != 0 {
 		t.Fatal("disabled auto-embedding profile should not store an empty API key cipher")
 	}
 }
 
-func TestSchemaInitForTenantUsesAutoEmbeddingProfileWhenDatabaseAutoEmbeddingDisabled(t *testing.T) {
+func TestSchemaInitForTenantUsesFTSOnlyProfileWhenDatabaseAutoEmbeddingDisabled(t *testing.T) {
 	prov := &profileAwareFakeProvisioner{
 		fakeProvisioner: fakeProvisioner{provider: tenant.ProviderTiDBZero},
 	}
+	origInitFTSOnly := initTiDBTenantSchemaForFTSOnlyProfileFunc
+	var ftsOnlyInitCalls int
+	var ftsOnlyProfile tenantschema.TiDBAutoEmbeddingProfile
+	initTiDBTenantSchemaForFTSOnlyProfileFunc = func(_ context.Context, _ string, profile tenantschema.TiDBAutoEmbeddingProfile) error {
+		ftsOnlyInitCalls++
+		ftsOnlyProfile = profile
+		return nil
+	}
+	t.Cleanup(func() {
+		initTiDBTenantSchemaForFTSOnlyProfileFunc = origInitFTSOnly
+	})
 	srv := NewWithConfig(Config{
 		Provisioner:                  prov,
 		DisableDatabaseAutoEmbedding: true,
@@ -1731,11 +1745,14 @@ func TestSchemaInitForTenantUsesAutoEmbeddingProfileWhenDatabaseAutoEmbeddingDis
 	if fallbackCalled {
 		t.Fatal("fallback InitSchema was called")
 	}
-	if prov.profileInitCalls.Load() != 1 {
-		t.Fatalf("profile init calls = %d, want 1", prov.profileInitCalls.Load())
+	if prov.profileInitCalls.Load() != 0 {
+		t.Fatalf("profile init calls = %d, want 0", prov.profileInitCalls.Load())
 	}
-	if prov.lastProfile.Model != "openai/text-embedding-3-small" || prov.lastProfile.Dimensions != 1536 {
-		t.Fatalf("profile init profile = %+v", prov.lastProfile)
+	if ftsOnlyInitCalls != 1 {
+		t.Fatalf("fts-only init calls = %d, want 1", ftsOnlyInitCalls)
+	}
+	if ftsOnlyProfile.Model != "openai/text-embedding-3-small" || ftsOnlyProfile.Dimensions != 1536 {
+		t.Fatalf("fts-only init profile = %+v", ftsOnlyProfile)
 	}
 }
 
@@ -1754,14 +1771,14 @@ func TestAutoEmbeddingProfileForTenantEnsuresDefaultProfile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("autoEmbeddingProfileForTenant: %v", err)
 	}
-	if profile.Model != tenantschema.DefaultTiDBAutoEmbeddingModel {
-		t.Fatalf("profile model = %q", profile.Model)
+	if profile.schemaProfile.Model != tenantschema.DefaultTiDBAutoEmbeddingModel {
+		t.Fatalf("profile model = %q", profile.schemaProfile.Model)
 	}
-	if profile.Dimensions != tenantschema.DefaultTiDBAutoEmbeddingDimensions {
-		t.Fatalf("profile dimensions = %d", profile.Dimensions)
+	if profile.schemaProfile.Dimensions != tenantschema.DefaultTiDBAutoEmbeddingDimensions {
+		t.Fatalf("profile dimensions = %d", profile.schemaProfile.Dimensions)
 	}
-	if profile.OptionsJSON != `{"dimensions":1024}` {
-		t.Fatalf("profile options_json = %q", profile.OptionsJSON)
+	if profile.schemaProfile.OptionsJSON != `{"dimensions":1024}` {
+		t.Fatalf("profile options_json = %q", profile.schemaProfile.OptionsJSON)
 	}
 
 	stored, err := metaStore.GetTenantAutoEmbeddingProfile(context.Background(), "tenant-default-profile")
@@ -1786,11 +1803,11 @@ func TestAutoEmbeddingProfileForTenantWithoutMetaUsesConfiguredDefault(t *testin
 	if err != nil {
 		t.Fatalf("autoEmbeddingProfileForTenant: %v", err)
 	}
-	if profile.Model != "openai/text-embedding-3-small" {
-		t.Fatalf("profile model = %q", profile.Model)
+	if profile.schemaProfile.Model != "openai/text-embedding-3-small" {
+		t.Fatalf("profile model = %q", profile.schemaProfile.Model)
 	}
-	if profile.Dimensions != 1536 {
-		t.Fatalf("profile dimensions = %d", profile.Dimensions)
+	if profile.schemaProfile.Dimensions != 1536 {
+		t.Fatalf("profile dimensions = %d", profile.schemaProfile.Dimensions)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -74,8 +74,9 @@ type Config struct {
 	TiDBAutoEmbeddingConfig  tenantschema.TiDBAutoEmbeddingConfig
 	TiDBAutoEmbeddingAPIKey  string
 	TiDBAutoEmbeddingAPIBase string
-	// DisableDatabaseAutoEmbedding suppresses runtime writes that would trigger
-	// TiDB EMBED_TEXT, but TiDB tenants still use the normal auto schema.
+	// DisableDatabaseAutoEmbedding makes new or unresolved tenant embedding
+	// profiles default to fts_only mode. Resolved tenant-level embedding_mode is
+	// the runtime source of truth.
 	DisableDatabaseAutoEmbedding bool
 	// Leader, when set, gates background schedulers (semantic worker, object GC,
 	// tenant delete cleanup, pending tenant reconciler, one-time resume tasks,
@@ -242,11 +243,12 @@ type tenantAutoEmbeddingDefault struct {
 }
 
 var (
-	schemaInitRetryWindow    = 10 * time.Minute
-	schemaInitInitialBackoff = 2 * time.Second
-	schemaInitMaxBackoff     = 30 * time.Second
-	pendingTenantStaleAfter  = 10 * time.Minute
-	pendingTenantSweepEvery  = time.Minute
+	schemaInitRetryWindow                     = 10 * time.Minute
+	schemaInitInitialBackoff                  = 2 * time.Second
+	schemaInitMaxBackoff                      = 30 * time.Second
+	pendingTenantStaleAfter                   = 10 * time.Minute
+	pendingTenantSweepEvery                   = time.Minute
+	initTiDBTenantSchemaForFTSOnlyProfileFunc = tenantschema.InitTiDBTenantSchemaForFTSOnlyProfileContext
 )
 
 // DefaultMaxUploadBytes is the server-wide fallback upload size limit.
@@ -343,7 +345,7 @@ func NewWithConfig(cfg Config) *Server {
 			apiKey:  strings.TrimSpace(cfg.TiDBAutoEmbeddingAPIKey),
 			apiBase: strings.TrimSpace(cfg.TiDBAutoEmbeddingAPIBase),
 		},
-		disableDBAutoEmbed:    cfg.DisableDatabaseAutoEmbedding || (cfg.Pool != nil && cfg.Pool.IsAutoEmbeddingDisabled()),
+		disableDBAutoEmbed:    cfg.DisableDatabaseAutoEmbedding,
 		journalCursorSecret:   newJournalCursorSecret(cfg.TokenSecret),
 		forkWorkerCtx:         forkWorkerCtx,
 		forkWorkerCancel:      forkWorkerCancel,
@@ -4478,7 +4480,11 @@ func (s *Server) defaultAutoEmbeddingProfileForTenant(ctx context.Context, tenan
 	if err != nil {
 		return nil, err
 	}
-	if !s.disableDBAutoEmbed {
+	mode, _, err := s.resolveTenantEmbeddingMode("")
+	if err != nil {
+		return nil, err
+	}
+	if mode == meta.TenantEmbeddingModeAuto {
 		if err := tenantschema.ValidateTiDBAutoEmbeddingProviderConfig(tenantschema.TiDBAutoEmbeddingProviderConfig{
 			Model:   schemaProfile.Model,
 			APIKey:  s.tidbAutoEmbedding.apiKey,
@@ -4496,14 +4502,15 @@ func (s *Server) defaultAutoEmbeddingProfileForTenant(ctx context.Context, tenan
 		apiKeyCipher = cipher
 	}
 	return &meta.TenantAutoEmbeddingProfile{
-		TenantID:     tenantID,
-		Model:        schemaProfile.Model,
-		Dimensions:   schemaProfile.Dimensions,
-		OptionsJSON:  schemaProfile.OptionsJSON,
-		APIBase:      s.tidbAutoEmbedding.apiBase,
-		APIKeyCipher: apiKeyCipher,
-		CreatedAt:    now,
-		UpdatedAt:    now,
+		TenantID:      tenantID,
+		EmbeddingMode: mode,
+		Model:         schemaProfile.Model,
+		Dimensions:    schemaProfile.Dimensions,
+		OptionsJSON:   schemaProfile.OptionsJSON,
+		APIBase:       s.tidbAutoEmbedding.apiBase,
+		APIKeyCipher:  apiKeyCipher,
+		CreatedAt:     now,
+		UpdatedAt:     now,
 	}, nil
 }
 
@@ -4515,15 +4522,20 @@ func (s *Server) copyAutoEmbeddingProfileForFork(ctx context.Context, sourceTena
 	if err != nil {
 		return err
 	}
+	mode, _, err := s.resolveTenantEmbeddingMode(sourceProfile.EmbeddingMode)
+	if err != nil {
+		return err
+	}
 	return s.meta.UpsertTenantAutoEmbeddingProfile(ctx, &meta.TenantAutoEmbeddingProfile{
-		TenantID:     forkTenantID,
-		Model:        sourceProfile.Model,
-		Dimensions:   sourceProfile.Dimensions,
-		OptionsJSON:  sourceProfile.OptionsJSON,
-		APIBase:      sourceProfile.APIBase,
-		APIKeyCipher: append([]byte(nil), sourceProfile.APIKeyCipher...),
-		CreatedAt:    now,
-		UpdatedAt:    now,
+		TenantID:      forkTenantID,
+		EmbeddingMode: mode,
+		Model:         sourceProfile.Model,
+		Dimensions:    sourceProfile.Dimensions,
+		OptionsJSON:   sourceProfile.OptionsJSON,
+		APIBase:       sourceProfile.APIBase,
+		APIKeyCipher:  append([]byte(nil), sourceProfile.APIKeyCipher...),
+		CreatedAt:     now,
+		UpdatedAt:     now,
 	})
 }
 
@@ -4554,18 +4566,44 @@ func (s *Server) applyAutoEmbeddingProviderConfig(ctx context.Context, tenantID,
 	})
 }
 
-func (s *Server) autoEmbeddingProfileForTenant(ctx context.Context, tenantID string) (tenantschema.TiDBAutoEmbeddingProfile, error) {
+type serverTenantAutoEmbeddingProfile struct {
+	schemaProfile tenantschema.TiDBAutoEmbeddingProfile
+	mode          string
+	modeWasNull   bool
+}
+
+func (s *Server) resolveTenantEmbeddingMode(persisted string) (mode string, wasNull bool, err error) {
+	return meta.ResolveTenantEmbeddingMode(persisted, s.disableDBAutoEmbed)
+}
+
+func (s *Server) autoEmbeddingProfileForTenant(ctx context.Context, tenantID string) (serverTenantAutoEmbeddingProfile, error) {
 	if s.meta == nil {
-		return tenantschema.TiDBAutoEmbeddingProfileFromConfig(s.tidbAutoEmbedding.config)
+		profile, err := tenantschema.TiDBAutoEmbeddingProfileFromConfig(s.tidbAutoEmbedding.config)
+		if err != nil {
+			return serverTenantAutoEmbeddingProfile{}, err
+		}
+		mode, _, err := s.resolveTenantEmbeddingMode("")
+		if err != nil {
+			return serverTenantAutoEmbeddingProfile{}, err
+		}
+		return serverTenantAutoEmbeddingProfile{schemaProfile: profile, mode: mode}, nil
 	}
 	profile, err := s.meta.EnsureTenantAutoEmbeddingProfile(ctx, tenantID)
 	if err != nil {
-		return tenantschema.TiDBAutoEmbeddingProfile{}, err
+		return serverTenantAutoEmbeddingProfile{}, err
 	}
-	return tenantschema.TiDBAutoEmbeddingProfile{
-		Model:       profile.Model,
-		Dimensions:  profile.Dimensions,
-		OptionsJSON: profile.OptionsJSON,
+	mode, modeWasNull, err := s.resolveTenantEmbeddingMode(profile.EmbeddingMode)
+	if err != nil {
+		return serverTenantAutoEmbeddingProfile{}, err
+	}
+	return serverTenantAutoEmbeddingProfile{
+		mode:        mode,
+		modeWasNull: modeWasNull,
+		schemaProfile: tenantschema.TiDBAutoEmbeddingProfile{
+			Model:       profile.Model,
+			Dimensions:  profile.Dimensions,
+			OptionsJSON: profile.OptionsJSON,
+		},
 	}, nil
 }
 
@@ -4591,12 +4629,27 @@ func (s *Server) schemaInitForTenant(tenantID, provider string, fallback func(co
 		if err != nil {
 			return fmt.Errorf("resolve tenant auto-embedding profile: %w", err)
 		}
-		if !s.disableDBAutoEmbed {
-			if err := s.applyAutoEmbeddingProviderConfig(ctx, tenantID, dsn, profile); err != nil {
+		switch profile.mode {
+		case meta.TenantEmbeddingModeAuto:
+			if err := s.applyAutoEmbeddingProviderConfig(ctx, tenantID, dsn, profile.schemaProfile); err != nil {
 				return fmt.Errorf("apply tenant auto-embedding provider config: %w", err)
 			}
+			if err := profileAware.InitSchemaForAutoEmbeddingProfile(ctx, dsn, profile.schemaProfile); err != nil {
+				return err
+			}
+		case meta.TenantEmbeddingModeFTSOnly:
+			if err := initTiDBTenantSchemaForFTSOnlyProfileFunc(ctx, dsn, profile.schemaProfile); err != nil {
+				return err
+			}
+		default:
+			return fmt.Errorf("unsupported tenant embedding mode %q", profile.mode)
 		}
-		return profileAware.InitSchemaForAutoEmbeddingProfile(ctx, dsn, profile)
+		if profile.modeWasNull && s.meta != nil {
+			if _, err := s.meta.SetTenantAutoEmbeddingProfileModeIfNull(ctx, tenantID, profile.mode); err != nil {
+				return fmt.Errorf("persist tenant embedding mode: %w", err)
+			}
+		}
+		return nil
 	}
 }
 

--- a/pkg/server/tenant_worker.go
+++ b/pkg/server/tenant_worker.go
@@ -771,9 +771,6 @@ func (m *tenantWorkerManager) taskTypesForProvider(provider string) []semantic.T
 			return nil
 		}
 		types := m.pool.AutoSemanticTaskTypes()
-		if m.pool.IsAutoEmbeddingDisabled() {
-			return unionTaskTypes(m.appManagedTaskTypes(), types)
-		}
 		if types != nil {
 			return types
 		}

--- a/pkg/tenant/embedding_mode.go
+++ b/pkg/tenant/embedding_mode.go
@@ -1,0 +1,21 @@
+package tenant
+
+import (
+	"fmt"
+
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant/schema"
+)
+
+// TiDBEmbeddingModeForTenantMode maps the persisted tenant-level embedding
+// mode to the TiDB schema mode used by schema ensure/validation.
+func TiDBEmbeddingModeForTenantMode(mode string) (schema.TiDBEmbeddingMode, error) {
+	switch mode {
+	case meta.TenantEmbeddingModeAuto:
+		return schema.TiDBEmbeddingModeAuto, nil
+	case meta.TenantEmbeddingModeFTSOnly:
+		return schema.TiDBEmbeddingModeFTSOnly, nil
+	default:
+		return schema.TiDBEmbeddingModeUnknown, fmt.Errorf("unsupported tenant embedding mode %q", mode)
+	}
+}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -48,10 +48,9 @@ type PoolConfig struct {
 	// against plain MySQL but need a TiDB-class provider for vault.
 	SkipTiDBSchemaCheck bool
 
-	// DisableDatabaseAutoEmbedding forces runtime DatabaseAutoEmbedding=false
-	// for all tenants, even when the provider normally enables it (tidb_zero,
-	// tidb_cloud_native). It suppresses writes that would trigger DB-side
-	// EMBED_TEXT, but TiDB tenants still use the normal auto schema repair.
+	// DisableDatabaseAutoEmbedding makes newly resolved NULL tenant embedding
+	// profiles use fts_only mode. Once a tenant profile has an embedding_mode,
+	// the tenant-level mode is the source of truth.
 	DisableDatabaseAutoEmbedding bool
 
 	// LeaderChecker, when set, gates per-tenant FileGCWorker to run only on
@@ -129,12 +128,16 @@ type Pool struct {
 type tenantAutoEmbeddingProfile struct {
 	schemaProfile schema.TiDBAutoEmbeddingProfile
 	provider      schema.TiDBAutoEmbeddingProviderConfig
+	mode          string
+	modeWasNull   bool
 }
 
 var (
 	applyTiDBAutoEmbeddingProviderConfig      = schema.ApplyTiDBAutoEmbeddingProviderConfig
 	ensureTiDBSchemaForAutoEmbeddingProfile   = schema.EnsureTiDBSchemaForAutoEmbeddingProfile
 	validateTiDBSchemaForAutoEmbeddingProfile = schema.ValidateTiDBSchemaForAutoEmbeddingProfile
+	ensureTiDBSchemaForFTSOnlyProfile         = schema.EnsureTiDBSchemaForFTSOnlyProfile
+	validateTiDBSchemaForFTSOnlyProfile       = schema.ValidateTiDBSchemaForFTSOnlyProfile
 	// Validate once on the first version-matched open after process start, then
 	// periodically thereafter to catch out-of-band schema drift without putting a
 	// full schema diff on every tenant open.
@@ -142,6 +145,48 @@ var (
 	defaultTenantPoolDrainTimeout            = 30 * time.Second
 	defaultTenantPoolMaxTenants              = 1024
 )
+
+func tenantSchemaVersionForEmbeddingMode(mode string, profile schema.TiDBAutoEmbeddingProfile) (int, error) {
+	tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
+	if err != nil {
+		return 0, err
+	}
+	return schema.TiDBTenantSchemaVersionForEmbeddingModeProfile(tidbMode, profile)
+}
+
+func ensureTiDBSchemaForEmbeddingMode(ctx context.Context, db *sql.DB, mode string, profile schema.TiDBAutoEmbeddingProfile) error {
+	tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
+	if err != nil {
+		return err
+	}
+	switch tidbMode {
+	case schema.TiDBEmbeddingModeAuto:
+		return ensureTiDBSchemaForAutoEmbeddingProfile(ctx, db, profile)
+	case schema.TiDBEmbeddingModeFTSOnly:
+		return ensureTiDBSchemaForFTSOnlyProfile(ctx, db, profile)
+	default:
+		return schema.EnsureTiDBSchemaForEmbeddingModeProfile(ctx, db, tidbMode, profile)
+	}
+}
+
+func validateTiDBSchemaForEmbeddingMode(ctx context.Context, db *sql.DB, mode string, profile schema.TiDBAutoEmbeddingProfile) error {
+	tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
+	if err != nil {
+		return err
+	}
+	switch tidbMode {
+	case schema.TiDBEmbeddingModeAuto:
+		return validateTiDBSchemaForAutoEmbeddingProfile(ctx, db, profile)
+	case schema.TiDBEmbeddingModeFTSOnly:
+		return validateTiDBSchemaForFTSOnlyProfile(ctx, db, profile)
+	default:
+		return schema.ValidateTiDBSchemaForEmbeddingModeProfile(ctx, db, tidbMode, profile)
+	}
+}
+
+func (p *Pool) resolveTenantEmbeddingMode(persisted string) (mode string, wasNull bool, err error) {
+	return meta.ResolveTenantEmbeddingMode(persisted, p.cfg.DisableDatabaseAutoEmbedding)
+}
 
 type entry struct {
 	tenantID           string
@@ -646,22 +691,10 @@ func (p *Pool) AutoSemanticTaskTypes() []semantic.TaskType {
 	if backend.AsyncAudioExtractWillWireRuntime(p.cfg.BackendOptions.AsyncAudioExtract) {
 		out = append(out, semantic.TaskTypeAudioExtractText)
 	}
-	// When database auto-embedding is disabled, image/audio extract tasks are
-	// still valid (they don't depend on EMBED_TEXT). However the semantic worker
-	// routing for TiDB auto-embedding is suppressed, which is handled in
-	// taskTypesForProvider via IsAutoEmbeddingDisabled().
 	if len(out) == 0 {
 		return nil
 	}
 	return out
-}
-
-// IsAutoEmbeddingDisabled reports whether database auto-embedding has been
-// explicitly disabled for this pool via DisableDatabaseAutoEmbedding.
-// This is distinct from AutoSemanticTaskTypes returning nil because no
-// image/audio extract is configured.
-func (p *Pool) IsAutoEmbeddingDisabled() bool {
-	return p != nil && p.cfg.DisableDatabaseAutoEmbedding
 }
 
 func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantID string) (out *backend.Dat9Backend) {
@@ -703,9 +736,6 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	opts.TenantID = t.ID
 	opts.S3EncryptionPolicy = resolvedEncryptionPolicy
-	if UsesTiDBAutoEmbedding(t.Provider) && !p.cfg.DisableDatabaseAutoEmbedding {
-		opts.DatabaseAutoEmbedding = true
-	}
 	query := "parseTime=true"
 	if t.DBTLS {
 		query += "&tls=true"
@@ -718,9 +748,6 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	if err != nil {
 		return nil, nil, fmt.Errorf("open datastore: %w", err)
 	}
-	if p.cfg.DisableDatabaseAutoEmbedding && UsesTiDBAutoEmbedding(t.Provider) {
-		store.DisableAutoEmbedTextWrites()
-	}
 	openStoreDurationMs := float64(time.Since(openStoreStart).Microseconds()) / 1000.0
 	ensureSchemaDurationMs := 0.0
 	migrateDurationMs := 0.0
@@ -730,23 +757,29 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			_ = store.Close()
 			return nil, nil, fmt.Errorf("resolve tenant auto-embedding profile: %w", err)
 		}
-		if !p.cfg.DisableDatabaseAutoEmbedding {
+		if autoEmbeddingProfile.mode == meta.TenantEmbeddingModeAuto {
+			opts.DatabaseAutoEmbedding = true
 			if err := applyTiDBAutoEmbeddingProviderConfig(ctx, store.DB(), autoEmbeddingProfile.provider); err != nil {
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("apply tenant auto-embedding provider config: %w", err)
 			}
+		} else {
+			opts.DatabaseAutoEmbedding = false
+			opts.AppSemanticTasksEnabled = false
+			opts.AsyncImageExtract = backend.AsyncImageExtractOptions{}
+			opts.AsyncAudioExtract = backend.AsyncAudioExtractOptions{}
 		}
 		if !p.cfg.SkipTiDBSchemaCheck {
-			targetSchemaVersion, err := schema.TiDBTenantSchemaVersionForAutoEmbeddingProfile(autoEmbeddingProfile.schemaProfile)
+			targetSchemaVersion, err := tenantSchemaVersionForEmbeddingMode(autoEmbeddingProfile.mode, autoEmbeddingProfile.schemaProfile)
 			if err != nil {
 				_ = store.Close()
-				return nil, nil, fmt.Errorf("resolve tenant auto-embedding schema version: %w", err)
+				return nil, nil, fmt.Errorf("resolve tenant embedding schema version: %w", err)
 			}
 			if t.SchemaVersion != targetSchemaVersion {
 				ensureSchemaStart := time.Now()
-				if err := ensureTiDBSchemaForAutoEmbeddingProfile(ctx, store.DB(), autoEmbeddingProfile.schemaProfile); err != nil {
+				if err := ensureTiDBSchemaForEmbeddingMode(ctx, store.DB(), autoEmbeddingProfile.mode, autoEmbeddingProfile.schemaProfile); err != nil {
 					_ = store.Close()
-					return nil, nil, fmt.Errorf("ensure tidb auto-embedding schema: %w", err)
+					return nil, nil, fmt.Errorf("ensure tidb embedding schema: %w", err)
 				}
 				ensureSchemaDurationMs += float64(time.Since(ensureSchemaStart).Microseconds()) / 1000.0
 				if p.metaStore != nil {
@@ -762,11 +795,17 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 				}
 			} else if p.shouldPeriodicValidateTiDBSchemaOnOpen() {
 				validateSchemaStart := time.Now()
-				if err := validateTiDBSchemaForAutoEmbeddingProfile(ctx, store.DB(), autoEmbeddingProfile.schemaProfile); err != nil {
+				if err := validateTiDBSchemaForEmbeddingMode(ctx, store.DB(), autoEmbeddingProfile.mode, autoEmbeddingProfile.schemaProfile); err != nil {
 					_ = store.Close()
-					return nil, nil, fmt.Errorf("validate tidb auto-embedding schema: %w", err)
+					return nil, nil, fmt.Errorf("validate tidb embedding schema: %w", err)
 				}
 				ensureSchemaDurationMs += float64(time.Since(validateSchemaStart).Microseconds()) / 1000.0
+			}
+			if autoEmbeddingProfile.modeWasNull && p.metaStore != nil {
+				if _, modeErr := p.metaStore.SetTenantAutoEmbeddingProfileModeIfNull(ctx, t.ID, autoEmbeddingProfile.mode); modeErr != nil {
+					_ = store.Close()
+					return nil, nil, fmt.Errorf("persist tenant embedding mode: %w", modeErr)
+				}
 			}
 		}
 	}
@@ -902,9 +941,22 @@ func (p *Pool) migrateSplitTables(ctx context.Context, db *sql.DB, provider stri
 
 func (p *Pool) autoEmbeddingProfileForTenant(ctx context.Context, t *meta.Tenant) (tenantAutoEmbeddingProfile, error) {
 	if p.metaStore == nil || t == nil || t.ID == "" {
-		return defaultTenantAutoEmbeddingProfile()
+		out, err := defaultTenantAutoEmbeddingProfile()
+		if err != nil {
+			return tenantAutoEmbeddingProfile{}, err
+		}
+		mode, _, err := p.resolveTenantEmbeddingMode("")
+		if err != nil {
+			return tenantAutoEmbeddingProfile{}, err
+		}
+		out.mode = mode
+		return out, nil
 	}
 	profile, err := p.metaStore.EnsureTenantAutoEmbeddingProfile(ctx, t.ID)
+	if err != nil {
+		return tenantAutoEmbeddingProfile{}, err
+	}
+	mode, modeWasNull, err := p.resolveTenantEmbeddingMode(profile.EmbeddingMode)
 	if err != nil {
 		return tenantAutoEmbeddingProfile{}, err
 	}
@@ -923,6 +975,8 @@ func (p *Pool) autoEmbeddingProfileForTenant(ctx context.Context, t *meta.Tenant
 	}
 	return tenantAutoEmbeddingProfile{
 		schemaProfile: schemaProfile,
+		mode:          mode,
+		modeWasNull:   modeWasNull,
 		provider: schema.TiDBAutoEmbeddingProviderConfig{
 			Model:   schemaProfile.Model,
 			APIKey:  apiKey,
@@ -941,6 +995,7 @@ func defaultTenantAutoEmbeddingProfile() (tenantAutoEmbeddingProfile, error) {
 	}
 	return tenantAutoEmbeddingProfile{
 		schemaProfile: schemaProfile,
+		mode:          meta.TenantEmbeddingModeAuto,
 		provider: schema.TiDBAutoEmbeddingProviderConfig{
 			Model: schemaProfile.Model,
 		},

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -456,7 +456,7 @@ func TestPoolCreateBackendEnsuresSchemaForTiDBCloudNative(t *testing.T) {
 	}
 }
 
-func TestPoolCreateBackendRepairsAutoSchemaWhenDatabaseAutoEmbeddingDisabled(t *testing.T) {
+func TestPoolCreateBackendRepairsFTSOnlySchemaWhenDatabaseAutoEmbeddingDisabled(t *testing.T) {
 	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
 		MaxTenants:                   2,
 		DisableDatabaseAutoEmbedding: true,
@@ -466,14 +466,24 @@ func TestPoolCreateBackendRepairsAutoSchemaWhenDatabaseAutoEmbeddingDisabled(t *
 
 	origEnsure := ensureTiDBSchemaForAutoEmbeddingProfile
 	origValidate := validateTiDBSchemaForAutoEmbeddingProfile
+	origEnsureFTS := ensureTiDBSchemaForFTSOnlyProfile
+	origValidateFTS := validateTiDBSchemaForFTSOnlyProfile
 	origApply := applyTiDBAutoEmbeddingProviderConfig
-	ensureCalls := 0
+	autoEnsureCalls := 0
+	ftsEnsureCalls := 0
 	applyCalls := 0
 	ensureTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
-		ensureCalls++
+		autoEnsureCalls++
+		return nil
+	}
+	ensureTiDBSchemaForFTSOnlyProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
+		ftsEnsureCalls++
 		return nil
 	}
 	validateTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
+		return nil
+	}
+	validateTiDBSchemaForFTSOnlyProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
 		return nil
 	}
 	applyTiDBAutoEmbeddingProviderConfig = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProviderConfig) error {
@@ -483,6 +493,8 @@ func TestPoolCreateBackendRepairsAutoSchemaWhenDatabaseAutoEmbeddingDisabled(t *
 	t.Cleanup(func() {
 		ensureTiDBSchemaForAutoEmbeddingProfile = origEnsure
 		validateTiDBSchemaForAutoEmbeddingProfile = origValidate
+		ensureTiDBSchemaForFTSOnlyProfile = origEnsureFTS
+		validateTiDBSchemaForFTSOnlyProfile = origValidateFTS
 		applyTiDBAutoEmbeddingProviderConfig = origApply
 	})
 
@@ -497,8 +509,11 @@ func TestPoolCreateBackendRepairsAutoSchemaWhenDatabaseAutoEmbeddingDisabled(t *
 	if b.UsesDatabaseAutoEmbedding() {
 		t.Fatal("backend runtime auto embedding enabled with DisableDatabaseAutoEmbedding=true")
 	}
-	if ensureCalls != 1 {
-		t.Fatalf("ensureTiDBSchemaForAutoEmbeddingProfile called %d times, want 1", ensureCalls)
+	if autoEnsureCalls != 0 {
+		t.Fatalf("ensureTiDBSchemaForAutoEmbeddingProfile called %d times, want 0", autoEnsureCalls)
+	}
+	if ftsEnsureCalls != 1 {
+		t.Fatalf("ensureTiDBSchemaForFTSOnlyProfile called %d times, want 1", ftsEnsureCalls)
 	}
 	if applyCalls != 0 {
 		t.Fatalf("applyTiDBAutoEmbeddingProviderConfig called %d times, want 0", applyCalls)
@@ -533,7 +548,7 @@ func TestPoolCreateBackendReturnsValidationErrorWhenPeriodicCheckFails(t *testin
 
 	if _, _, err := pool.createBackend(context.Background(), tenant); err == nil {
 		t.Fatal("expected periodic validation failure to propagate")
-	} else if !strings.Contains(err.Error(), "validate tidb auto-embedding schema") {
+	} else if !strings.Contains(err.Error(), "validate tidb embedding schema") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }

--- a/pkg/tenant/schema/tidb.go
+++ b/pkg/tenant/schema/tidb.go
@@ -25,6 +25,9 @@ func initTiDBTenantSchemaStatementsForModeWithConfig(mode TiDBEmbeddingMode, cfg
 	switch mode {
 	case TiDBEmbeddingModeAuto:
 		return CloneStatements(tidbAutoEmbeddingSchemaStatementsForConfig(cfg)), nil
+	case TiDBEmbeddingModeFTSOnly:
+		cfg.disableGeneratedEmbedding = true
+		return CloneStatements(tidbAutoEmbeddingSchemaStatementsForConfig(cfg)), nil
 	case TiDBEmbeddingModeApp:
 		return CloneStatements(tidbAppEmbeddingSchemaStatements()), nil
 	default:
@@ -70,6 +73,8 @@ func InitTiDBTenantSchemaForModeWithOptionsContext(ctx context.Context, dsn stri
 	switch mode {
 	case TiDBEmbeddingModeAuto:
 		return initTiDBAutoEmbeddingSchema(ctx, dsn)
+	case TiDBEmbeddingModeFTSOnly:
+		return initTiDBFTSOnlySchema(ctx, dsn)
 	case TiDBEmbeddingModeApp:
 		return initTiDBAppEmbeddingSchema(ctx, dsn, opts)
 	default:
@@ -85,4 +90,8 @@ func InitTiDBTenantSchemaForAutoEmbeddingConfigContext(ctx context.Context, dsn 
 
 func InitTiDBTenantSchemaForAutoEmbeddingProfileContext(ctx context.Context, dsn string, profile TiDBAutoEmbeddingProfile) error {
 	return initTiDBAutoEmbeddingSchemaWithProfile(ctx, dsn, profile)
+}
+
+func InitTiDBTenantSchemaForFTSOnlyProfileContext(ctx context.Context, dsn string, profile TiDBAutoEmbeddingProfile) error {
+	return initTiDBFTSOnlySchemaWithProfile(ctx, dsn, profile)
 }

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -26,6 +26,7 @@ const (
 	TiDBEmbeddingModeUnknown TiDBEmbeddingMode = "unknown"
 	TiDBEmbeddingModeAuto    TiDBEmbeddingMode = "auto-embedding"
 	TiDBEmbeddingModeApp     TiDBEmbeddingMode = "app-managed"
+	TiDBEmbeddingModeFTSOnly TiDBEmbeddingMode = "fts-only"
 )
 
 // Reference of Auto Embedding in TiDB Cloud: https://docs.pingcap.com/ai/vector-search-auto-embedding-amazon-titan/
@@ -100,9 +101,10 @@ var (
 var CurrentTiDBTenantSchemaVersion = currentTiDBTenantSchemaVersion(tidbAutoEmbeddingSchemaStatements())
 
 type tidbAutoEmbeddingRenderConfig struct {
-	model       string
-	dimensions  int
-	optionsJSON string
+	model                     string
+	dimensions                int
+	optionsJSON               string
+	disableGeneratedEmbedding bool
 }
 
 type tidbAutoEmbeddingProviderSetting struct {
@@ -609,6 +611,26 @@ func TiDBTenantSchemaVersionForAutoEmbeddingProfile(profile TiDBAutoEmbeddingPro
 	return currentTiDBTenantSchemaVersion(tidbAutoEmbeddingSchemaStatementsForConfig(render)), nil
 }
 
+func TiDBTenantSchemaVersionForFTSOnlyProfile(profile TiDBAutoEmbeddingProfile) (int, error) {
+	render, err := tidbAutoEmbeddingRenderConfigForProfile(profile)
+	if err != nil {
+		return 0, err
+	}
+	render.disableGeneratedEmbedding = true
+	return currentTiDBTenantSchemaVersion(tidbAutoEmbeddingSchemaStatementsForConfig(render)), nil
+}
+
+func TiDBTenantSchemaVersionForEmbeddingModeProfile(mode TiDBEmbeddingMode, profile TiDBAutoEmbeddingProfile) (int, error) {
+	switch mode {
+	case TiDBEmbeddingModeAuto:
+		return TiDBTenantSchemaVersionForAutoEmbeddingProfile(profile)
+	case TiDBEmbeddingModeFTSOnly:
+		return TiDBTenantSchemaVersionForFTSOnlyProfile(profile)
+	default:
+		return 0, validateTiDBSchemaMode(mode)
+	}
+}
+
 func currentTiDBTenantSchemaVersion(stmts []string) int {
 	// Hash only statements that are parsed into the schema spec (CREATE TABLE,
 	// CREATE [UNIQUE] INDEX, ALTER TABLE ... ADD ... INDEX).  Statements that
@@ -723,6 +745,16 @@ func tidbAutoEmbeddingSchemaStatements() []string {
 func tidbAutoEmbeddingSchemaStatementsForConfig(cfg tidbAutoEmbeddingRenderConfig) []string {
 	modelLiteral := tidbSQLStringLiteral(cfg.model)
 	optionsLiteral := tidbSQLStringLiteral(cfg.optionsJSON)
+	// These fragments are embedded in schema-version-hashed DDL. Preserve the
+	// rendered shape unless intentionally changing the tenant schema version.
+	embeddingColumn := fmt.Sprintf("VECTOR(%d) GENERATED ALWAYS AS (EMBED_TEXT(\n\t\t\t\t%s,\n\t\t\t\tcontent_text,\n\t\t\t\t%s\n\t\t\t)) STORED",
+		cfg.dimensions, modelLiteral, optionsLiteral)
+	descriptionEmbeddingColumn := fmt.Sprintf("VECTOR(%d) GENERATED ALWAYS AS (EMBED_TEXT(\n\t\t\t\t%s,\n\t\t\t\tdescription,\n\t\t\t\t%s\n\t\t\t)) STORED",
+		cfg.dimensions, modelLiteral, optionsLiteral)
+	if cfg.disableGeneratedEmbedding {
+		embeddingColumn = fmt.Sprintf("VECTOR(%d)", cfg.dimensions)
+		descriptionEmbeddingColumn = fmt.Sprintf("VECTOR(%d)", cfg.dimensions)
+	}
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (
 			node_id      VARCHAR(64) PRIMARY KEY,
@@ -770,17 +802,9 @@ func tidbAutoEmbeddingSchemaStatementsForConfig(cfg tidbAutoEmbeddingRenderConfi
 			inode_id                           VARCHAR(64) PRIMARY KEY,
 			content_text                       LONGTEXT,
 			description                        LONGTEXT,
-			embedding                          VECTOR(` + strconv.Itoa(cfg.dimensions) + `) GENERATED ALWAYS AS (EMBED_TEXT(
-				` + modelLiteral + `,
-				content_text,
-				` + optionsLiteral + `
-			)) STORED,
+			embedding                          ` + embeddingColumn + `,
 			embedding_revision                 BIGINT,
-			description_embedding              VECTOR(` + strconv.Itoa(cfg.dimensions) + `) GENERATED ALWAYS AS (EMBED_TEXT(
-				` + modelLiteral + `,
-				description,
-				` + optionsLiteral + `
-			)) STORED,
+			description_embedding              ` + descriptionEmbeddingColumn + `,
 			description_embedding_revision     BIGINT,
 			FULLTEXT INDEX idx_semantic_fts_content (content_text) WITH PARSER MULTILINGUAL,
 			FULLTEXT INDEX idx_semantic_fts_description (description) WITH PARSER MULTILINGUAL
@@ -992,6 +1016,26 @@ func ValidateTiDBSchemaForAutoEmbeddingProfile(ctx context.Context, db *sql.DB, 
 	return validateTiDBSchemaForModeWithConfig(ctx, db, TiDBEmbeddingModeAuto, render)
 }
 
+func ValidateTiDBSchemaForFTSOnlyProfile(ctx context.Context, db *sql.DB, profile TiDBAutoEmbeddingProfile) error {
+	render, err := tidbAutoEmbeddingRenderConfigForProfile(profile)
+	if err != nil {
+		return err
+	}
+	render.disableGeneratedEmbedding = true
+	return validateTiDBSchemaForModeWithConfig(ctx, db, TiDBEmbeddingModeFTSOnly, render)
+}
+
+func ValidateTiDBSchemaForEmbeddingModeProfile(ctx context.Context, db *sql.DB, mode TiDBEmbeddingMode, profile TiDBAutoEmbeddingProfile) error {
+	switch mode {
+	case TiDBEmbeddingModeAuto:
+		return ValidateTiDBSchemaForAutoEmbeddingProfile(ctx, db, profile)
+	case TiDBEmbeddingModeFTSOnly:
+		return ValidateTiDBSchemaForFTSOnlyProfile(ctx, db, profile)
+	default:
+		return validateTiDBSchemaMode(mode)
+	}
+}
+
 func validateTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiDBEmbeddingMode, cfg tidbAutoEmbeddingRenderConfig) error {
 	start := time.Now()
 	logger.Info(ctx, "tenant_tidb_schema_validate_started",
@@ -1044,6 +1088,26 @@ func EnsureTiDBSchemaForAutoEmbeddingProfile(ctx context.Context, db *sql.DB, pr
 		return err
 	}
 	return ensureTiDBSchemaForModeWithConfig(ctx, db, TiDBEmbeddingModeAuto, render)
+}
+
+func EnsureTiDBSchemaForFTSOnlyProfile(ctx context.Context, db *sql.DB, profile TiDBAutoEmbeddingProfile) error {
+	render, err := tidbAutoEmbeddingRenderConfigForProfile(profile)
+	if err != nil {
+		return err
+	}
+	render.disableGeneratedEmbedding = true
+	return ensureTiDBSchemaForModeWithConfig(ctx, db, TiDBEmbeddingModeFTSOnly, render)
+}
+
+func EnsureTiDBSchemaForEmbeddingModeProfile(ctx context.Context, db *sql.DB, mode TiDBEmbeddingMode, profile TiDBAutoEmbeddingProfile) error {
+	switch mode {
+	case TiDBEmbeddingModeAuto:
+		return EnsureTiDBSchemaForAutoEmbeddingProfile(ctx, db, profile)
+	case TiDBEmbeddingModeFTSOnly:
+		return EnsureTiDBSchemaForFTSOnlyProfile(ctx, db, profile)
+	default:
+		return validateTiDBSchemaMode(mode)
+	}
 }
 
 func ensureTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiDBEmbeddingMode, cfg tidbAutoEmbeddingRenderConfig) error {
@@ -1129,7 +1193,7 @@ func ensureTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiD
 }
 
 func validateTiDBSchemaMode(mode TiDBEmbeddingMode) error {
-	if mode != TiDBEmbeddingModeAuto && mode != TiDBEmbeddingModeApp {
+	if mode != TiDBEmbeddingModeAuto && mode != TiDBEmbeddingModeApp && mode != TiDBEmbeddingModeFTSOnly {
 		return fmt.Errorf("unsupported TiDB embedding mode %q", mode)
 	}
 	return nil
@@ -1191,12 +1255,31 @@ func initTiDBAutoEmbeddingSchemaWithConfig(ctx context.Context, dsn string, cfg 
 }
 
 func initTiDBAutoEmbeddingSchemaWithProfile(ctx context.Context, dsn string, profile TiDBAutoEmbeddingProfile) error {
+	return initTiDBSchemaWithProfileAndMode(ctx, dsn, profile, TiDBEmbeddingModeAuto)
+}
+
+func initTiDBFTSOnlySchema(ctx context.Context, dsn string) error {
+	profile, err := TiDBAutoEmbeddingProfileFromConfig(CurrentTiDBAutoEmbeddingConfig())
+	if err != nil {
+		return err
+	}
+	return initTiDBSchemaWithProfileAndMode(ctx, dsn, profile, TiDBEmbeddingModeFTSOnly)
+}
+
+func initTiDBFTSOnlySchemaWithProfile(ctx context.Context, dsn string, profile TiDBAutoEmbeddingProfile) error {
+	return initTiDBSchemaWithProfileAndMode(ctx, dsn, profile, TiDBEmbeddingModeFTSOnly)
+}
+
+func initTiDBSchemaWithProfileAndMode(ctx context.Context, dsn string, profile TiDBAutoEmbeddingProfile, mode TiDBEmbeddingMode) error {
 	start := time.Now()
 	logger.Info(ctx, "tenant_tidb_schema_init_started",
-		zap.String("mode", string(TiDBEmbeddingModeAuto)))
+		zap.String("mode", string(mode)))
 	render, err := tidbAutoEmbeddingRenderConfigForProfile(profile)
 	if err != nil {
 		return err
+	}
+	if mode == TiDBEmbeddingModeFTSOnly {
+		render.disableGeneratedEmbedding = true
 	}
 	db, err := OpenTiDBSchemaDB(ctx, dsn)
 	if err != nil {
@@ -1212,11 +1295,20 @@ func initTiDBAutoEmbeddingSchemaWithProfile(ctx context.Context, dsn string, pro
 	if err := ExecSchemaStatementsParallelByTableContext(ctx, db, tidbAutoEmbeddingSchemaStatementsForConfig(render)); err != nil {
 		return err
 	}
-	if err := EnsureTiDBSchemaForAutoEmbeddingProfile(ctx, db, profile); err != nil {
-		return err
+	switch mode {
+	case TiDBEmbeddingModeAuto:
+		if err := EnsureTiDBSchemaForAutoEmbeddingProfile(ctx, db, profile); err != nil {
+			return err
+		}
+	case TiDBEmbeddingModeFTSOnly:
+		if err := EnsureTiDBSchemaForFTSOnlyProfile(ctx, db, profile); err != nil {
+			return err
+		}
+	default:
+		return validateTiDBSchemaMode(mode)
 	}
 	logger.Info(ctx, "tenant_tidb_schema_init_finished",
-		zap.String("mode", string(TiDBEmbeddingModeAuto)),
+		zap.String("mode", string(mode)),
 		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
 	return nil
 }
@@ -1315,6 +1407,10 @@ func detectTiDBEmbeddingModeFromMeta(meta tidbTableMeta) (TiDBEmbeddingMode, err
 	if expr != "" {
 		return TiDBEmbeddingModeUnknown, errors.New("embedding generation expression present without generated column metadata")
 	}
+	// Column metadata alone cannot distinguish app-managed from fts_only:
+	// both use writable nullable VECTOR columns. fts_only is a tenant profile
+	// contract enforced by the mode-aware schema validators, while this detector
+	// is kept for local app-vs-auto startup detection.
 	return TiDBEmbeddingModeApp, nil
 }
 
@@ -1654,6 +1750,8 @@ func tidbSchemaSpecForModeWithConfig(mode TiDBEmbeddingMode, cfg tidbAutoEmbeddi
 				return validateTiDBAutoEmbeddingDiffsWithConfig(meta, cfg)
 			case TiDBEmbeddingModeApp:
 				return validateTiDBAppEmbeddingDiffs(meta)
+			case TiDBEmbeddingModeFTSOnly:
+				return validateTiDBFTSOnlyDiffsWithConfig(meta, cfg)
 			default:
 				return []tidbSchemaDiff{{kind: tidbSchemaDiffTableContract, tableName: "semantic", detail: fmt.Sprintf("semantic schema contract: unsupported TiDB embedding mode %q", mode)}}
 			}
@@ -1686,6 +1784,8 @@ func legacyTiDBFilesTableSpecForModeWithConfig(mode TiDBEmbeddingMode, cfg tidbA
 				return validateTiDBAutoEmbeddingFilesDiffsWithConfig(meta, cfg)
 			case TiDBEmbeddingModeApp:
 				return validateTiDBAppEmbeddingFilesDiffs(meta)
+			case TiDBEmbeddingModeFTSOnly:
+				return validateTiDBFTSOnlyFilesDiffsWithConfig(meta, cfg)
 			default:
 				return []tidbSchemaDiff{{kind: tidbSchemaDiffTableContract, tableName: "files", detail: fmt.Sprintf("files legacy schema contract: unsupported TiDB embedding mode %q", mode)}}
 			}
@@ -1705,7 +1805,7 @@ func legacyTiDBFilesSchemaStatementsForModeWithConfig(mode TiDBEmbeddingMode, cf
 			cfg.dimensions, modelLiteral, optionsLiteral)
 		descriptionEmbeddingColumn = fmt.Sprintf("VECTOR(%d) GENERATED ALWAYS AS (EMBED_TEXT(%s, description, %s)) STORED",
 			cfg.dimensions, modelLiteral, optionsLiteral)
-	} else if mode != TiDBEmbeddingModeApp {
+	} else if mode != TiDBEmbeddingModeApp && mode != TiDBEmbeddingModeFTSOnly {
 		return nil, fmt.Errorf("unsupported TiDB embedding mode %q", mode)
 	}
 	stmts := []string{
@@ -1736,7 +1836,7 @@ func legacyTiDBFilesSchemaStatementsForModeWithConfig(mode TiDBEmbeddingMode, cf
 		`CREATE INDEX idx_status ON files(status, created_at)`,
 		`CREATE INDEX idx_files_storage_ref_hash ON files(storage_ref_hash)`,
 	}
-	if mode == TiDBEmbeddingModeAuto {
+	if mode == TiDBEmbeddingModeAuto || mode == TiDBEmbeddingModeFTSOnly {
 		stmts = append(stmts,
 			`ALTER TABLE files
 				ADD FULLTEXT INDEX idx_fts_content(content_text)
@@ -2664,9 +2764,21 @@ func isSafeTiDBRepairDiff(diff tidbSchemaDiff) bool {
 		return isSafeModifyColumnRepairSQL(diff)
 	case tidbSchemaDiffExtraColumn:
 		return isSafeDropLegacyUploadActiveTargetPathRepairSQL(diff)
+	case tidbSchemaDiffTableContract:
+		return isSafeFTSOnlyEmbeddingColumnRepairSQL(diff.repairSQL)
 	default:
 		return false
 	}
+}
+
+func isSafeFTSOnlyEmbeddingColumnRepairSQL(sqlText string) bool {
+	normalized := normalizeSQLFragment(sqlText)
+	if !strings.HasPrefix(normalized, "alter table ") {
+		return false
+	}
+	return (strings.Contains(normalized, " modify column embedding vector(") ||
+		strings.Contains(normalized, " modify column description_embedding vector(")) &&
+		strings.HasSuffix(normalized, " null")
 }
 
 func isSafeAddColumnRepairSQL(sqlText string) bool {
@@ -3063,6 +3175,40 @@ func validateTiDBAppEmbeddingDiffs(meta tidbTableMeta) []tidbSchemaDiff {
 
 func validateTiDBAppEmbeddingFilesDiffs(meta tidbTableMeta) []tidbSchemaDiff {
 	return validateTiDBAppEmbeddingTableDiffs(meta, "files")
+}
+
+func validateTiDBFTSOnlyDiffsWithConfig(meta tidbTableMeta, cfg tidbAutoEmbeddingRenderConfig) []tidbSchemaDiff {
+	return validateTiDBFTSOnlyTableDiffs(meta, "semantic", cfg)
+}
+
+func validateTiDBFTSOnlyFilesDiffsWithConfig(meta tidbTableMeta, cfg tidbAutoEmbeddingRenderConfig) []tidbSchemaDiff {
+	return validateTiDBFTSOnlyTableDiffs(meta, "files", cfg)
+}
+
+func validateTiDBFTSOnlyTableDiffs(meta tidbTableMeta, tableName string, cfg tidbAutoEmbeddingRenderConfig) []tidbSchemaDiff {
+	var diffs []tidbSchemaDiff
+	for _, colName := range []string{"embedding", "description_embedding"} {
+		col, err := meta.requireColumn(colName)
+		if err != nil {
+			return nil
+		}
+		extra := normalizeSQLFragment(col.extra)
+		expr := normalizeSQLFragment(col.generationExpression)
+		if strings.Contains(extra, "generated") || expr != "" {
+			// TiDB Cloud permits this one-way conversion from a stored generated
+			// EMBED_TEXT column to a writable nullable VECTOR column. The reverse
+			// ordinary VECTOR -> stored generated column conversion is not
+			// supported, so tenant embedding_mode remains immutable.
+			diffs = append(diffs, tidbSchemaDiff{
+				kind:       tidbSchemaDiffTableContract,
+				tableName:  tableName,
+				columnName: colName,
+				detail:     fmt.Sprintf("%s schema contract: %s column must be nullable writable vector in fts-only mode", tableName, colName),
+				repairSQL:  fmt.Sprintf("ALTER TABLE %s MODIFY COLUMN %s VECTOR(%d) NULL", tableName, colName, cfg.dimensions),
+			})
+		}
+	}
+	return diffs
 }
 
 func validateTiDBAppEmbeddingTableDiffs(meta tidbTableMeta, tableName string) []tidbSchemaDiff {


### PR DESCRIPTION
## Summary
- add tenant-level embedding_mode for auto vs fts_only profiles
- render/repair fts_only TiDB schemas with nullable VECTOR columns while keeping FTS and vector indexes
- make global DisableDatabaseAutoEmbedding only choose fts_only for new/unresolved tenant profiles instead of suppressing content_text/description writes
- disable DB/app embedding plus image/audio extraction runtimes for fts_only tenants

## Tests
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/datastore ./pkg/tenant/schema ./pkg/tenant ./pkg/meta ./pkg/server ./pkg/backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **FTS-only** tenant embedding mode alongside existing auto-embedding.
  * Tenant embedding mode is now persisted, resolved, and used during provisioning and schema repair.
  * Schema initialization/ensurance now selects the correct path based on the tenant’s resolved embedding mode.

* **Bug Fixes**
  * Disabled database auto-embedding now consistently applies **FTS-only** behavior (including schema handling) for newly resolved/unresolved tenants.
  * Semantic search text (`content_text`) is always written and kept up to date, including on file overwrites (validated via added grep regression tests).
  * Clearing of embedding fields is now unconditional during semantic state resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->