### PR TITLE
fix: layer rollback takes effect on mounted FUSE without remount

### DIFF
--- a/e2e/layer-fs-smoke-test.sh
+++ b/e2e/layer-fs-smoke-test.sh
@@ -1011,6 +1011,71 @@ if require_layer_fuse_prereqs; then
   check_cmd_fail "committed FUSE whiteout visible in base" drive9 fs cat "${fuse_root}/delete.txt"
   check_cmd_fail "committed FUSE rename source visible in base" drive9 fs cat "${fuse_root}/move.txt"
   check_eq "committed FUSE rename target visible" "$(drive9_retry fs cat "${fuse_root}/moved.txt")" "$(cat "$fuse_move_local")"
+
+  # ------------------------------------------------------------------
+  # [fuse] layer rollback hot-refresh: a mounted layer should revert to
+  # the base view after `fs layer rollback` WITHOUT requiring a remount.
+  # ------------------------------------------------------------------
+  rollback_fuse_root="/layer-rollback-fuse-${ts}"
+  rollback_fuse_layer="layer-rollback-fuse-${ts}"
+  rollback_fuse_base_local="/tmp/drive9-layer-rollback-base-${ts}.txt"
+  printf 'rollback fuse base %s\n' "$ts" >"$rollback_fuse_base_local"
+  drive9_retry fs mkdir "$rollback_fuse_root" >/dev/null
+  drive9_retry fs cp "$rollback_fuse_base_local" ":${rollback_fuse_root}/base.txt" >/dev/null
+
+  rollback_fuse_layer_json=$(drive9_retry fs layer create \
+    --name "$rollback_fuse_layer" \
+    --tag "rollback_fuse_run=$ts" \
+    --durability restore-safe \
+    --json \
+    ":$rollback_fuse_root")
+  rollback_fuse_layer_id=$(printf '%s' "$rollback_fuse_layer_json" | jq -r '.layer_id // empty')
+  check_cmd "rollback fuse layer create returns id" test -n "$rollback_fuse_layer_id"
+
+  mount_rb="${FUSE_MOUNT_ROOT%/}/drive9-layer-rollback-${ts}"
+  local_rb="/tmp/drive9-layer-local-rollback-${ts}"
+  log_rb="/tmp/drive9-layer-rollback-${ts}.log"
+  start_layer_mount "tag:rollback_fuse_run=$ts" "" "$rollback_fuse_root" "$mount_rb" "$local_rb" "$log_rb"
+  check_eq "rollback fuse mount reads base before edit" "$(cat "$mount_rb/base.txt")" "$(cat "$rollback_fuse_base_local")"
+
+  # Write a file through the layer mount — it should be visible via the overlay.
+  printf 'rollback fuse new file %s\n' "$ts" >"$mount_rb/new.txt"
+  check_eq "rollback fuse new file visible in layer mount" "$(cat "$mount_rb/new.txt")" "rollback fuse new file ${ts}"
+
+  # Roll back the layer from a separate CLI call (not through the mount).
+  check_eq "rollback fuse command returns ok" "$(drive9_retry fs layer rollback "tag:rollback_fuse_run=$ts")" "ok"
+  rollback_fuse_status=$(drive9_retry fs layer status --json "$rollback_fuse_layer")
+  check_eq "rollback fuse layer state is abandoned" "$(printf '%s' "$rollback_fuse_status" | jq -r '.state')" "abandoned"
+
+  # Without remounting, the layer overlay should clear within the watcher
+  # poll interval (~1s). Poll up to LAYER_DIFF_TIMEOUT_S for the new file
+  # to disappear (base view restored).
+  rollback_hot_refresh_ok="no"
+  rollback_poll_elapsed=0
+  while [ "$rollback_poll_elapsed" -lt "$LAYER_DIFF_TIMEOUT_S" ]; do
+    if [ ! -e "$mount_rb/new.txt" ]; then
+      rollback_hot_refresh_ok="yes"
+      break
+    fi
+    sleep "$LAYER_DIFF_INTERVAL_S"
+    rollback_poll_elapsed=$((rollback_poll_elapsed + LAYER_DIFF_INTERVAL_S))
+  done
+  check_eq "rollback fuse overlay clears without remount (new.txt disappears)" "$rollback_hot_refresh_ok" "yes"
+
+  # Base file should still be visible after rollback.
+  check_eq "rollback fuse base still visible after hot refresh" "$(cat "$mount_rb/base.txt")" "$(cat "$rollback_fuse_base_local")"
+
+  # A new write through the now-abandoned mount should fail with ESTALE.
+  rollback_write_err=""
+  if printf 'should fail %s\n' "$ts" >"$mount_rb/post-rollback.txt" 2>/dev/null; then
+    rollback_write_err="success"
+  else
+    rollback_write_err="failure"
+  fi
+  check_eq "rollback fuse new write after rollback fails (ESTALE)" "$rollback_write_err" "failure"
+
+  check_cmd "unmount rollback fuse mount" unmount_layer_mount
+  check_cmd "rollback fuse mount log clean" audit_mount_log "$log_rb"
 fi
 
 echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"

--- a/e2e/layer-fs-smoke-test.sh
+++ b/e2e/layer-fs-smoke-test.sh
@@ -1049,11 +1049,14 @@ if require_layer_fuse_prereqs; then
 
   # Without remounting, the layer overlay should clear within the watcher
   # poll interval (~1s). Poll up to LAYER_DIFF_TIMEOUT_S for the new file
-  # to disappear (base view restored).
+  # to become unreadable (base view restored). We check readability rather
+  # than existence because the kernel dentry cache may retain a stale
+  # entry for the overlaid file — but the overlay is gone, so reading
+  # returns EIO (the file does not exist in the base view).
   rollback_hot_refresh_ok="no"
   rollback_poll_elapsed=0
   while [ "$rollback_poll_elapsed" -lt "$LAYER_DIFF_TIMEOUT_S" ]; do
-    if [ ! -e "$mount_rb/new.txt" ]; then
+    if ! cat "$mount_rb/new.txt" >/dev/null 2>&1; then
       rollback_hot_refresh_ok="yes"
       break
     fi

--- a/pkg/client/fs_layer.go
+++ b/pkg/client/fs_layer.go
@@ -115,6 +115,11 @@ type FSLayerEvent struct {
 	CreatedAt time.Time `json:"created_at"`
 }
 
+// FSLayerEventOpRollback is the synthetic event op emitted into
+// fs_layer_events when a layer is rolled back. FUSE clients detect this
+// op via the layer-event watcher and refresh their view without a remount.
+const FSLayerEventOpRollback = "rollback"
+
 func (c *Client) CreateFSLayer(ctx context.Context, req FSLayerCreateRequest) (*FSLayer, error) {
 	body, err := json.Marshal(req)
 	if err != nil {

--- a/pkg/datastore/fs_layer.go
+++ b/pkg/datastore/fs_layer.go
@@ -46,7 +46,9 @@ const (
 	// fs_layer_events when a layer is rolled back. It lets mounted FUSE
 	// clients detect the rollback via the layer-event watcher and refresh
 	// their view without a remount. Unlike entry ops it is never written
-	// to fs_layer_entries and bypasses validateFSLayerEntryOp.
+	// to fs_layer_entries and bypasses validateFSLayerEntryOp. The
+	// consumer-side constant lives in pkg/client as FSLayerEventOpRollback
+	// (shared via the FSLayerEvent struct). Both equal "rollback".
 	fsLayerEventOpRollback = "rollback"
 )
 
@@ -116,6 +118,18 @@ func (s *Store) CreateFSLayer(ctx context.Context, layer *FSLayer) error {
 	layer.LayerID = strings.TrimSpace(layer.LayerID)
 	if layer.LayerID == "" {
 		return fmt.Errorf("fs layer id is required")
+	}
+	// fs_layer_events.event_id is VARCHAR(64) PRIMARY KEY. Normal upsert
+	// event_ids use "<layerID>:<seq>"; rollback event_ids use
+	// "<layerID>:rollback:<seq>" (9 chars longer). A layer_id near 64
+	// chars would overflow the PK on rollback, and a layer_id containing
+	// ":" could collide with another layer's rollback event_id. Reject
+	// both here so all event_id formats always fit the schema.
+	if len(layer.LayerID) > 50 {
+		return fmt.Errorf("fs layer id too long (%d chars, max 50)", len(layer.LayerID))
+	}
+	if strings.Contains(layer.LayerID, ":") {
+		return fmt.Errorf("fs layer id must not contain \":\"")
 	}
 	root, err := pathutil.CanonicalizeDir(layer.BaseRootPath)
 	if err != nil {
@@ -437,7 +451,7 @@ WHERE layer_id = ? AND state IN (?, ?, ?)`,
 	}
 	n, err := res.RowsAffected()
 	if err != nil {
-		return err
+		return fmt.Errorf("rollback fs layer %s rows affected: %w", layerID, err)
 	}
 	if n == 0 {
 		// No row was updated: either the layer does not exist, or it was

--- a/pkg/datastore/fs_layer.go
+++ b/pkg/datastore/fs_layer.go
@@ -41,6 +41,13 @@ const (
 	FSLayerEntryKindFile    FSLayerEntryKind = "file"
 	FSLayerEntryKindDir     FSLayerEntryKind = "dir"
 	FSLayerEntryKindSymlink FSLayerEntryKind = "symlink"
+
+	// fsLayerEventOpRollback is the synthetic event op emitted into
+	// fs_layer_events when a layer is rolled back. It lets mounted FUSE
+	// clients detect the rollback via the layer-event watcher and refresh
+	// their view without a remount. Unlike entry ops it is never written
+	// to fs_layer_entries and bypasses validateFSLayerEntryOp.
+	fsLayerEventOpRollback = "rollback"
 )
 
 type FSLayer struct {
@@ -409,25 +416,72 @@ func (s *Store) RollbackFSLayer(ctx context.Context, layerID string) error {
 	if layerID == "" {
 		return fmt.Errorf("fs layer id is required")
 	}
-	err := s.SetFSLayerStateIf(ctx, layerID, []FSLayerState{
-		FSLayerStateActive,
-		FSLayerStateSealed,
-		FSLayerStateConflicted,
-	}, FSLayerStateAbandoned)
-	if err == nil {
-		return nil
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin rollback fs layer transaction: %w", err)
 	}
-	if !errors.Is(err, ErrFSLayerStateConflict) {
+	defer func() { _ = tx.Rollback() }()
+
+	// Flip the layer state to abandoned. The UPDATE is conditional on the
+	// current state being one of the rollback-eligible states, mirroring
+	// SetFSLayerStateIf but inside this transaction so the synthetic event
+	// is committed atomically with the state transition.
+	res, err := tx.ExecContext(ctx, `
+UPDATE fs_layers
+SET state = ?, updated_at = UTC_TIMESTAMP(3), sealed_at = COALESCE(sealed_at, UTC_TIMESTAMP(3))
+WHERE layer_id = ? AND state IN (?, ?, ?)`,
+		string(FSLayerStateAbandoned), layerID,
+		string(FSLayerStateActive), string(FSLayerStateSealed), string(FSLayerStateConflicted))
+	if err != nil {
+		return fmt.Errorf("rollback fs layer %s: %w", layerID, err)
+	}
+	n, err := res.RowsAffected()
+	if err != nil {
 		return err
 	}
-	layer, getErr := s.GetFSLayer(ctx, layerID)
-	if getErr != nil {
-		return getErr
+	if n == 0 {
+		// No row was updated: either the layer does not exist, or it was
+		// already in a terminal state. Distinguish the two and, for the
+		// already-abandoned case, return nil idempotently WITHOUT
+		// re-emitting the rollback event.
+		var state string
+		if err := tx.QueryRowContext(ctx, `SELECT state FROM fs_layers WHERE layer_id = ?`, layerID).Scan(&state); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("read fs layer %s: %w", layerID, err)
+		}
+		if FSLayerState(state) == FSLayerStateAbandoned {
+			return nil
+		}
+		return ErrFSLayerStateConflict
 	}
-	if layer.State == FSLayerStateAbandoned {
-		return nil
+
+	// Allocate a seq strictly greater than any existing event seq for this
+	// layer so the FUSE layer-event watcher (which keys off seq > lastSeq)
+	// observes the rollback. Events today share the entry_seq namespace,
+	// but a rollback produces no fs_layer_entries row, so we allocate from
+	// fs_layer_events.seq directly to stay monotonic and unique under
+	// uk_fs_layer_events_seq(layer_id, seq).
+	var maxSeq sql.NullInt64
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(seq), 0) FROM fs_layer_events WHERE layer_id = ?`, layerID).Scan(&maxSeq); err != nil {
+		return fmt.Errorf("read fs layer max event seq: %w", err)
 	}
-	return ErrFSLayerStateConflict
+	seq := int64(1)
+	if maxSeq.Valid && maxSeq.Int64 >= seq {
+		seq = maxSeq.Int64 + 1
+	}
+	eventID := fmt.Sprintf("%s:rollback:%d", layerID, seq)
+	if _, err := tx.ExecContext(ctx, `
+INSERT INTO fs_layer_events (event_id, layer_id, seq, actor_id, op, path, created_at)
+VALUES (?, ?, ?, '', ?, '/', UTC_TIMESTAMP(3))`,
+		eventID, layerID, seq, fsLayerEventOpRollback); err != nil {
+		return fmt.Errorf("insert fs layer rollback event %s: %w", layerID, err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("commit rollback fs layer %s: %w", layerID, err)
+	}
+	return nil
 }
 
 func (s *Store) ListFSLayerEntryLog(ctx context.Context, layerID string) ([]FSLayerEntry, error) {

--- a/pkg/datastore/fs_layer_test.go
+++ b/pkg/datastore/fs_layer_test.go
@@ -117,6 +117,77 @@ func TestFSLayerRollbackRejectsCommittedAndCommitting(t *testing.T) {
 	}
 }
 
+func TestRollbackFSLayerEmitsEvent(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	if err := s.CreateFSLayer(ctx, &FSLayer{LayerID: "layer-rollback-event", BaseRootPath: "/repo"}); err != nil {
+		t.Fatalf("CreateFSLayer: %v", err)
+	}
+	// Upsert an entry so there is a prior entry-event seq; the rollback
+	// event seq must be strictly greater so the FUSE watcher observes it.
+	if err := s.UpsertFSLayerEntry(ctx, &FSLayerEntry{
+		LayerID:     "layer-rollback-event",
+		Path:        "/repo/a.txt",
+		Op:          FSLayerEntryOpUpsert,
+		Kind:        FSLayerEntryKindFile,
+		ContentBlob: []byte("data"),
+	}); err != nil {
+		t.Fatalf("UpsertFSLayerEntry: %v", err)
+	}
+	priorEvents, err := s.ListFSLayerEvents(ctx, "layer-rollback-event", 0, 1000)
+	if err != nil {
+		t.Fatalf("ListFSLayerEvents before rollback: %v", err)
+	}
+	if len(priorEvents) != 1 || priorEvents[0].Op != "upsert" {
+		t.Fatalf("prior events = %+v, want 1 upsert event", priorEvents)
+	}
+
+	// Rollback → emits a synthetic rollback event.
+	if err := s.RollbackFSLayer(ctx, "layer-rollback-event"); err != nil {
+		t.Fatalf("RollbackFSLayer: %v", err)
+	}
+	events, err := s.ListFSLayerEvents(ctx, "layer-rollback-event", 0, 1000)
+	if err != nil {
+		t.Fatalf("ListFSLayerEvents after rollback: %v", err)
+	}
+	if len(events) != 2 {
+		t.Fatalf("events after rollback = %d, want 2 (upsert + rollback)", len(events))
+	}
+	rbEvent := events[1]
+	if rbEvent.Op != "rollback" {
+		t.Fatalf("rollback event op = %q, want %q", rbEvent.Op, "rollback")
+	}
+	if rbEvent.LayerID != "layer-rollback-event" {
+		t.Fatalf("rollback event layer_id = %q, want layer-rollback-event", rbEvent.LayerID)
+	}
+	if rbEvent.Seq <= priorEvents[0].Seq {
+		t.Fatalf("rollback event seq %d <= prior upsert seq %d", rbEvent.Seq, priorEvents[0].Seq)
+	}
+	if rbEvent.EventID == "" || rbEvent.EventID == events[0].EventID {
+		t.Fatalf("rollback event_id = %q, want unique non-empty", rbEvent.EventID)
+	}
+
+	// Idempotent rollback (already abandoned): must NOT re-emit the event.
+	if err := s.RollbackFSLayer(ctx, "layer-rollback-event"); err != nil {
+		t.Fatalf("RollbackFSLayer idempotent: %v", err)
+	}
+	events2, err := s.ListFSLayerEvents(ctx, "layer-rollback-event", 0, 1000)
+	if err != nil {
+		t.Fatalf("ListFSLayerEvents after idempotent rollback: %v", err)
+	}
+	if len(events2) != len(events) {
+		t.Fatalf("events after idempotent rollback = %d, want %d (no re-emit)", len(events2), len(events))
+	}
+}
+
+func TestRollbackFSLayerNotFound(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	if err := s.RollbackFSLayer(ctx, "nonexistent-layer"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("RollbackFSLayer nonexistent err=%v, want ErrNotFound", err)
+	}
+}
+
 func TestFSLayerUpsertRejectsNonActiveLayer(t *testing.T) {
 	s := newTestStore(t)
 	ctx := context.Background()

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -86,6 +86,11 @@ type CommitQueue struct {
 	journal      *Journal
 	wg           sync.WaitGroup
 	stopped      bool
+	// abandoned is set by AbandonLayer when the mounted layer was rolled
+	// back. When true, Enqueue returns errLayerRolledBack and commitOne
+	// skips tryAutoResolveConflict, going straight to terminal failure so
+	// pending writes are preserved as PendingConflict.
+	abandoned    bool
 
 	// OnSuccess is called after successful upload with the committed
 	// revision. Used by dat9fs to seed readCache and update inode revision.
@@ -189,6 +194,9 @@ func (cq *CommitQueue) Enqueue(entry *CommitEntry) error {
 	if cq.stopped {
 		if cq.perf != nil {
 			cq.perf.commitEnqueueError.add(1)
+		}
+		if cq.abandoned {
+			return errLayerRolledBack
 		}
 		return fmt.Errorf("commit queue stopped")
 	}
@@ -454,6 +462,44 @@ func (cq *CommitQueue) IsFull() bool {
 	cq.mu.Lock()
 	defer cq.mu.Unlock()
 	return len(cq.queue) >= cq.maxPending
+}
+
+// AbandonLayer halts the commit queue because the mounted layer was rolled
+// back. New Enqueue calls return errLayerRolledBack. Queued (not-yet-
+// dispatched) entries are canceled so workers remove them; their pending
+// state is preserved on disk. In-flight uploads are left to finish — they
+// will fail with 409 and fall to onCommitTerminalFailure, which marks them
+// PendingConflict. Unlike DrainAll this does NOT block (no wg.Wait) so the
+// caller is not stalled waiting on uploads to a now-dead layer.
+func (cq *CommitQueue) AbandonLayer() {
+	if cq == nil {
+		return
+	}
+	cq.mu.Lock()
+	if cq.stopped {
+		// Already stopped (e.g. DrainAll ran first); just mark abandoned so
+		// Enqueue returns the rolled-back sentinel instead of the generic
+		// "commit queue stopped" message.
+		cq.abandoned = true
+		cq.mu.Unlock()
+		return
+	}
+	cq.abandoned = true
+	cq.stopped = true
+	close(cq.workCh)
+	// Cancel all queued (not-yet-dispatched) entries so the worker loop
+	// removes them; their pending state is preserved on disk.
+	for _, entry := range cq.queue {
+		if entry != nil {
+			entry.canceled = true
+		}
+	}
+	cq.forceAllDelayedLocked()
+	cq.queue = nil
+	cq.queuedByPath = make(map[string]map[*CommitEntry]struct{})
+	cq.mu.Unlock()
+	// Do NOT wg.Wait() — let in-flight workers finish their current upload
+	// (they will 409 → onCommitTerminalFailure → MarkConflict on their own).
 }
 
 // DrainAll stops accepting new entries and waits for all workers to finish.
@@ -996,6 +1042,19 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 			return
 		}
 		if errors.Is(err, client.ErrConflict) {
+			// When the layer was rolled back, the 409 is a state conflict
+			// (not a revision conflict); skip the Stat/HEAD auto-resolve
+			// round-trip and go straight to terminal failure so the entry
+			// is preserved as PendingConflict.
+			cq.mu.Lock()
+			abandoned := cq.abandoned
+			cq.mu.Unlock()
+			if abandoned {
+				log.Printf("commit queue: layer abandoned, terminal failure for %s", entry.Path)
+				cq.onCommitTerminalFailure(entry)
+				unlockPath()
+				return
+			}
 			log.Printf("commit queue: conflict committing %s at base revision %d, attempting auto-resolve", entry.Path, entry.BaseRev)
 			cq.tryAutoResolveConflict(entryCtx, entry)
 			unlockPath()
@@ -1048,6 +1107,12 @@ func (cq *CommitQueue) entryUploadContext(parent context.Context, entry *CommitE
 // by workers. It is used as a fallback when the async queue rejects an entry
 // after local state has already moved to the final path.
 func (cq *CommitQueue) CommitNow(ctx context.Context, entry *CommitEntry) error {
+	cq.mu.Lock()
+	abandoned := cq.abandoned
+	cq.mu.Unlock()
+	if abandoned {
+		return errLayerRolledBack
+	}
 	unlockPath := cq.lockPath(entry.Path)
 	defer unlockPath()
 	return cq.commitNowPathLocked(ctx, entry)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -155,6 +155,12 @@ type Dat9FS struct {
 	layerFiles        map[string]uint32
 	layerDirs         map[string]uint32
 	layerSymlinks     map[string]layerSymlinkState
+	// layerAbandoned is set when the layer-event watcher observes a
+	// rollback event, signalling that the mounted layer is now abandoned.
+	// Subsequent write ops short-circuit with errLayerRolledBack (→ ESTALE)
+	// and the commit queue halts. The in-memory overlay is cleared so the
+	// mount reflects the base view without a remount.
+	layerAbandoned atomic.Bool
 
 	// smallFileMax mirrors the server's inline_threshold (fetched lazily via
 	// the dat9 client). When 0, defaultSmallFileThreshold is used. Use the
@@ -497,7 +503,20 @@ func (fs *Dat9FS) layerEnabled() bool {
 	return fs.layerRef() != ""
 }
 
+func (fs *Dat9FS) setLayerAbandoned() {
+	if fs != nil {
+		fs.layerAbandoned.Store(true)
+	}
+}
+
+func (fs *Dat9FS) isLayerAbandoned() bool {
+	return fs != nil && fs.layerAbandoned.Load()
+}
+
 func (fs *Dat9FS) upsertLayerEntry(ctx context.Context, req client.FSLayerEntryRequest, bytes uint64) error {
+	if fs.isLayerAbandoned() {
+		return errLayerRolledBack
+	}
 	layerRef := fs.layerRef()
 	if layerRef == "" {
 		return fmt.Errorf("fs layer is not configured")
@@ -510,6 +529,9 @@ func (fs *Dat9FS) upsertLayerEntry(ctx context.Context, req client.FSLayerEntryR
 
 func (fs *Dat9FS) upsertLayerFile(ctx context.Context, localPath string, data []byte, expectedRevision int64, mode uint32, hasMode bool) error {
 	if int64(len(data)) > maxInlineLayerEntryBytes {
+		if fs.isLayerAbandoned() {
+			return errLayerRolledBack
+		}
 		start := fs.perfStart()
 		_, err := fs.client.UploadFSLayerFile(ctx, fs.layerRef(), fs.remotePath(localPath), bytes.NewReader(data), int64(len(data)), expectedRevision, mode, hasMode)
 		fs.perfRecordRemote(perfRemoteMutation, start, err, uint64(len(data)))
@@ -865,6 +887,92 @@ func (fs *Dat9FS) commitLayerShadowLocked(ctx context.Context, fh *FileHandle, s
 	}
 	fh.WriteBackSeq = 0
 	return nil
+}
+
+// clearLayerOverlay drops the entire in-memory layer overlay so the mount
+// reflects the base view. Called by applyLayerRollback after the layer is
+// rolled back. Rebuilding from a fresh replay would re-add the abandoned
+// layer's still-present fs_layer_entries, so we zero the maps directly.
+func (fs *Dat9FS) clearLayerOverlay() {
+	if fs == nil {
+		return
+	}
+	fs.layerMu.Lock()
+	fs.layerWhiteouts = make(map[string]struct{})
+	fs.layerFiles = make(map[string]uint32)
+	fs.layerDirs = make(map[string]uint32)
+	fs.layerSymlinks = make(map[string]layerSymlinkState)
+	fs.layerMu.Unlock()
+}
+
+// applyLayerRollback reacts to a rollback event observed by the layer-event
+// watcher. It clears the in-memory overlay so the mount reflects the base
+// view, halts the commit queue so no further writes reach the abandoned
+// layer, preserves any locally staged (not-yet-committed) writes as
+// PendingConflict for manual recovery, and flushes userspace + kernel caches
+// so the new view is visible without a remount.
+//
+// The shadow store and pending index are passed explicitly (rather than
+// read from fs fields) to match the watcher's existing call signature which
+// already holds references to them.
+func (fs *Dat9FS) applyLayerRollback(shadows *ShadowStore, pending *PendingIndex) {
+	if fs == nil {
+		return
+	}
+
+	// 1. Mark abandoned: future writes return ESTALE, commit queue rejects.
+	fs.setLayerAbandoned()
+
+	// 2. Halt the commit queue (non-blocking; in-flight uploads will fail
+	//    with 409 and fall to onCommitTerminalFailure → MarkConflict).
+	if fs.commitQueue != nil {
+		fs.commitQueue.AbandonLayer()
+	}
+
+	// 3. Preserve local staged writes as PendingConflict so the user can
+	//    recover them; do not delete shadow blobs. RecoverPending skips
+	//    conflict entries, so they will not be retried against the dead layer.
+	if pending != nil {
+		for p := range pending.ListPendingPaths() {
+			_ = pending.MarkConflict(p)
+		}
+	}
+
+	// 4. Clear the in-memory overlay so the base view reappears.
+	fs.clearLayerOverlay()
+
+	// 5. Flush userspace caches (mirrors SSEWatcher.handleReset, sse.go:122).
+	if fs.readCache != nil {
+		fs.readCache.InvalidateAll()
+	}
+	if fs.diskReadCache != nil {
+		fs.diskReadCache.InvalidateAll()
+	}
+	fs.clearAllReadTargets()
+	if fs.dirCache != nil {
+		fs.dirCache.InvalidateAll()
+	}
+
+	// 6. Best-effort kernel cache invalidation for all known inodes.
+	//    Skip parent dentry notify for directories (see sse.go:150-156).
+	if fs.inodes != nil {
+		entries := fs.inodes.Snapshot()
+		for _, entry := range entries {
+			fs.notifyInode(entry.Ino)
+			if entry.Path != "/" && !entry.IsDir {
+				parent := parentDir(entry.Path)
+				if parentIno, ok := fs.inodes.GetInode(parent); ok {
+					fs.notifyEntry(parentIno, path.Base(entry.Path))
+				}
+			}
+		}
+	}
+
+	// 7. Force re-fetch on next Getattr/Read (belt + suspenders with the
+	//    cache flush above; matches SSE OnDisconnected, sse.go:38-42).
+	fs.markStatCacheUnverified()
+
+	fmt.Fprintf(os.Stderr, "drive9: fs layer rolled back — mount now reflects base view; pending local writes preserved as conflict for manual recovery\n")
 }
 
 func (fs *Dat9FS) markLayerWhiteout(localPath string) {
@@ -3690,6 +3798,9 @@ func httpToFuseStatus(err error) gofuse.Status {
 	if err == nil {
 		return gofuse.OK
 	}
+	if errors.Is(err, errLayerRolledBack) {
+		return gofuse.Status(syscall.ESTALE)
+	}
 	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 		return gofuse.Status(syscall.EAGAIN)
 	}
@@ -3831,6 +3942,11 @@ func isCreateActionUnsupportedErr(err error) bool {
 // errReadRetriesExhausted is a sentinel indicating all detached read retries
 // failed with transient errors. Callers should map this to EIO.
 var errReadRetriesExhausted = errors.New("read retries exhausted")
+
+// errLayerRolledBack is returned by layer write paths after the layer-event
+// watcher observed a rollback event. It maps to ESTALE via httpToFuseStatus
+// so FUSE clients see a "stale file handle" instead of an opaque 409/EEXIST.
+var errLayerRolledBack = errors.New("fs layer has been rolled back; remount required")
 
 // isTransientReadErr classifies errors for Read-path detached retry.
 // Same classification as isTransientLookupErr — kept as a separate function

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -905,6 +905,51 @@ func (fs *Dat9FS) clearLayerOverlay() {
 	fs.layerMu.Unlock()
 }
 
+// resetMountView flushes all userspace caches and notifies the kernel to
+// invalidate cached inodes/dentries. Shared by applyLayerRollback and
+// SSEWatcher.handleReset so both paths stay in sync.
+//
+// Do not invalidate a directory's own parent dentry. Linux getcwd(2) walks
+// parent dentries; dropping the dentry for a process's current working
+// directory can make git's remote helpers fail with ENOENT even though the
+// directory still exists. The flush already clears userspace directory
+// caches and notifies the directory inode, so future readdir/attr paths are
+// refreshed without detaching cwd names.
+func (fs *Dat9FS) resetMountView() {
+	if fs == nil {
+		return
+	}
+	// Clear all user-space caches.
+	if fs.readCache != nil {
+		fs.readCache.InvalidateAll()
+	}
+	if fs.diskReadCache != nil {
+		fs.diskReadCache.InvalidateAll()
+	}
+	fs.clearAllReadTargets()
+	if fs.dirCache != nil {
+		fs.dirCache.InvalidateAll()
+	}
+
+	// Best-effort kernel cache invalidation for all known inodes.
+	// Snapshot entries first so we don't hold the inode map lock during
+	// potentially slow kernel notify calls.
+	// InodeToPath is kept intact (stale but resolvable).
+	if fs.inodes == nil {
+		return
+	}
+	entries := fs.inodes.Snapshot()
+	for _, entry := range entries {
+		fs.notifyInode(entry.Ino)
+		if entry.Path != "/" && !entry.IsDir {
+			parent := parentDir(entry.Path)
+			if parentIno, ok := fs.inodes.GetInode(parent); ok {
+				fs.notifyEntry(parentIno, path.Base(entry.Path))
+			}
+		}
+	}
+}
+
 // applyLayerRollback reacts to a rollback event observed by the layer-event
 // watcher. It clears the in-memory overlay so the mount reflects the base
 // view, halts the commit queue so no further writes reach the abandoned
@@ -941,34 +986,10 @@ func (fs *Dat9FS) applyLayerRollback(shadows *ShadowStore, pending *PendingIndex
 	// 4. Clear the in-memory overlay so the base view reappears.
 	fs.clearLayerOverlay()
 
-	// 5. Flush userspace caches (mirrors SSEWatcher.handleReset, sse.go:122).
-	if fs.readCache != nil {
-		fs.readCache.InvalidateAll()
-	}
-	if fs.diskReadCache != nil {
-		fs.diskReadCache.InvalidateAll()
-	}
-	fs.clearAllReadTargets()
-	if fs.dirCache != nil {
-		fs.dirCache.InvalidateAll()
-	}
+	// 5. Flush userspace caches + notify kernel (shared with SSE reset).
+	fs.resetMountView()
 
-	// 6. Best-effort kernel cache invalidation for all known inodes.
-	//    Skip parent dentry notify for directories (see sse.go:150-156).
-	if fs.inodes != nil {
-		entries := fs.inodes.Snapshot()
-		for _, entry := range entries {
-			fs.notifyInode(entry.Ino)
-			if entry.Path != "/" && !entry.IsDir {
-				parent := parentDir(entry.Path)
-				if parentIno, ok := fs.inodes.GetInode(parent); ok {
-					fs.notifyEntry(parentIno, path.Base(entry.Path))
-				}
-			}
-		}
-	}
-
-	// 7. Force re-fetch on next Getattr/Read (belt + suspenders with the
+	// 6. Force re-fetch on next Getattr/Read (belt + suspenders with the
 	//    cache flush above; matches SSE OnDisconnected, sse.go:38-42).
 	fs.markStatCacheUnverified()
 
@@ -980,6 +1001,13 @@ func (fs *Dat9FS) markLayerWhiteout(localPath string) {
 		return
 	}
 	fs.layerMu.Lock()
+	// Skip overlay mutation if the layer was rolled back — a racing write
+	// that completed on the server just before applyLayerRollback cleared
+	// the overlay must not re-populate it.
+	if fs.layerAbandoned.Load() {
+		fs.layerMu.Unlock()
+		return
+	}
 	if fs.layerWhiteouts == nil {
 		fs.layerWhiteouts = make(map[string]struct{})
 	}
@@ -995,6 +1023,10 @@ func (fs *Dat9FS) markLayerFile(localPath string) {
 		return
 	}
 	fs.layerMu.Lock()
+	if fs.layerAbandoned.Load() {
+		fs.layerMu.Unlock()
+		return
+	}
 	delete(fs.layerWhiteouts, localPath)
 	delete(fs.layerFiles, localPath)
 	delete(fs.layerDirs, localPath)
@@ -1007,6 +1039,10 @@ func (fs *Dat9FS) markLayerFileMode(localPath string, mode uint32) {
 		return
 	}
 	fs.layerMu.Lock()
+	if fs.layerAbandoned.Load() {
+		fs.layerMu.Unlock()
+		return
+	}
 	if fs.layerFiles == nil {
 		fs.layerFiles = make(map[string]uint32)
 	}
@@ -1022,6 +1058,10 @@ func (fs *Dat9FS) markLayerDir(localPath string, mode uint32) {
 		return
 	}
 	fs.layerMu.Lock()
+	if fs.layerAbandoned.Load() {
+		fs.layerMu.Unlock()
+		return
+	}
 	if fs.layerDirs == nil {
 		fs.layerDirs = make(map[string]uint32)
 	}
@@ -1042,6 +1082,10 @@ func (fs *Dat9FS) markLayerSymlink(localPath, target string, mode uint32) {
 		mode = uint32(syscall.S_IFLNK) | (mode & 0o777)
 	}
 	fs.layerMu.Lock()
+	if fs.layerAbandoned.Load() {
+		fs.layerMu.Unlock()
+		return
+	}
 	if fs.layerSymlinks == nil {
 		fs.layerSymlinks = make(map[string]layerSymlinkState)
 	}

--- a/pkg/fuse/layer_events.go
+++ b/pkg/fuse/layer_events.go
@@ -65,7 +65,7 @@ func refreshLayerEvents(ctx context.Context, c *client.Client, opts *MountOption
 		if events[i].Seq > maxSeq {
 			maxSeq = events[i].Seq
 		}
-		if events[i].Op == "rollback" {
+		if events[i].Op == client.FSLayerEventOpRollback {
 			rolledBack = true
 		}
 	}

--- a/pkg/fuse/layer_events.go
+++ b/pkg/fuse/layer_events.go
@@ -60,10 +60,22 @@ func refreshLayerEvents(ctx context.Context, c *client.Client, opts *MountOption
 		return since, nil
 	}
 	maxSeq := since
+	rolledBack := false
 	for i := range events {
 		if events[i].Seq > maxSeq {
 			maxSeq = events[i].Seq
 		}
+		if events[i].Op == "rollback" {
+			rolledBack = true
+		}
+	}
+	// When a rollback event is observed, clear the overlay and halt the
+	// mount's layer write path — do NOT call restoreLayerEntries, which
+	// would re-replay the abandoned layer's still-present fs_layer_entries
+	// and re-add the overlay we just cleared.
+	if rolledBack {
+		fs.applyLayerRollback(shadows, pending)
+		return maxSeq, nil
 	}
 	if err := restoreLayerEntries(ctx, c, opts, shadows, pending, fs); err != nil {
 		return since, err

--- a/pkg/fuse/layer_rollback_test.go
+++ b/pkg/fuse/layer_rollback_test.go
@@ -146,7 +146,7 @@ func TestRefreshLayerEventsDetectsRollback(t *testing.T) {
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"events": []client.FSLayerEvent{
 					{EventID: "layer-rb:1", LayerID: "layer-rb", Seq: 1, Op: "upsert", Path: "/repo/a.txt"},
-					{EventID: "layer-rb:rollback:2", LayerID: "layer-rb", Seq: 2, Op: "rollback", Path: "/"},
+					{EventID: "layer-rb:rollback:2", LayerID: "layer-rb", Seq: 2, Op: client.FSLayerEventOpRollback, Path: "/"},
 				},
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/layers/layer-rb/diff":

--- a/pkg/fuse/layer_rollback_test.go
+++ b/pkg/fuse/layer_rollback_test.go
@@ -1,0 +1,262 @@
+package fuse
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"syscall"
+	"testing"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+
+	"github.com/mem9-ai/drive9/pkg/client"
+)
+
+// TestApplyLayerRollbackClearsOverlay verifies that applyLayerRollback
+// clears the in-memory overlay, sets the abandoned flag, and marks pending
+// entries as conflict without deleting shadow blobs.
+func TestApplyLayerRollbackClearsOverlay(t *testing.T) {
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fs := NewDat9FS(client.New("http://localhost:0", ""), &MountOptions{
+		LayerRef:   "layer-rollback-test",
+		RemoteRoot: "/repo",
+	})
+
+	// Populate the overlay with a whiteout, file, dir, and symlink.
+	fs.markLayerWhiteout("/old.txt")
+	fs.markLayerFileMode("/a.txt", 0o644)
+	fs.markLayerDir("/newdir", 0o755)
+	fs.markLayerSymlink("/link", "target.txt", 0o777|syscall.S_IFLNK)
+
+	// Stage a pending write (shadow + pending index) that should be
+	// preserved as PendingConflict after rollback.
+	if err := shadow.WriteFull("/a.txt", []byte("data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/a.txt", 4, PendingOverwrite, 0); err != nil {
+		t.Fatal(err)
+	}
+	fs.commitQueue = NewCommitQueue(client.New("http://localhost:0", ""), shadow, pending, nil, 1, 8)
+	fs.commitQueue.SetLayerRef("layer-rollback-test")
+
+	// Sanity: overlay is populated.
+	if !fs.isLayerWhiteout("/old.txt") {
+		t.Fatal("precondition: old.txt should be whiteout")
+	}
+	if mode, ok := fs.layerFileMode("/a.txt"); !ok || mode != 0o644 {
+		t.Fatalf("precondition: a.txt file mode = (%#o, %t), want 0o644 true", mode, ok)
+	}
+	if !fs.layerEnabled() {
+		t.Fatal("precondition: layer should be enabled")
+	}
+	if fs.isLayerAbandoned() {
+		t.Fatal("precondition: layer should not be abandoned")
+	}
+
+	// Act: apply the rollback.
+	fs.applyLayerRollback(shadow, pending)
+
+	// 1. Abandoned flag is set.
+	if !fs.isLayerAbandoned() {
+		t.Fatal("after rollback: layer should be abandoned")
+	}
+
+	// 2. Overlay is cleared.
+	if fs.isLayerWhiteout("/old.txt") {
+		t.Fatal("after rollback: old.txt whiteout should be cleared")
+	}
+	if _, ok := fs.layerFileMode("/a.txt"); ok {
+		t.Fatal("after rollback: a.txt overlay file should be cleared")
+	}
+	if _, ok := fs.layerDirMode("/newdir"); ok {
+		t.Fatal("after rollback: newdir overlay dir should be cleared")
+	}
+	if _, _, ok := fs.layerSymlink("/link"); ok {
+		t.Fatal("after rollback: link overlay symlink should be cleared")
+	}
+
+	// 3. Commit queue is stopped + abandoned (Enqueue returns sentinel).
+	err = fs.commitQueue.Enqueue(&CommitEntry{Path: "/b.txt", Size: 0})
+	if !errors.Is(err, errLayerRolledBack) {
+		t.Fatalf("after rollback: Enqueue err = %v, want errLayerRolledBack", err)
+	}
+
+	// 4. Pending entry preserved as conflict, shadow blob not deleted.
+	if !pending.HasPending("/a.txt") {
+		t.Fatal("after rollback: a.txt pending should still exist (preserved)")
+	}
+	if meta, ok := pending.GetMeta("/a.txt"); !ok || meta.Kind != PendingConflict {
+		t.Fatalf("after rollback: a.txt pending kind = %v, want PendingConflict", meta.Kind)
+	}
+	if !shadow.Has("/a.txt") {
+		t.Fatal("after rollback: a.txt shadow blob should be preserved for manual recovery")
+	}
+}
+
+// TestUpsertLayerEntryReturnsErrLayerRolledBack verifies that after the
+// abandoned flag is set, upsertLayerEntry short-circuits with errLayerRolledBack.
+func TestUpsertLayerEntryReturnsErrLayerRolledBack(t *testing.T) {
+	fs := NewDat9FS(client.New("http://localhost:0", ""), &MountOptions{
+		LayerRef:   "layer-rollback-test",
+		RemoteRoot: "/repo",
+	})
+	fs.setLayerAbandoned()
+
+	err := fs.upsertLayerEntry(context.Background(), client.FSLayerEntryRequest{
+		Path:      "/repo/a.txt",
+		Op:        "upsert",
+		Kind:      "file",
+		Content:   []byte("data"),
+		SizeBytes: 4,
+	}, 4)
+	if !errors.Is(err, errLayerRolledBack) {
+		t.Fatalf("upsertLayerEntry after abandoned: err = %v, want errLayerRolledBack", err)
+	}
+}
+
+// TestHttpToFuseStatusMapsErrLayerRolledBackToESTALE verifies the error
+// mapper returns the "stale file handle" errno for the rollback sentinel.
+func TestHttpToFuseStatusMapsErrLayerRolledBackToESTALE(t *testing.T) {
+	got := httpToFuseStatus(errLayerRolledBack)
+	if got != gofuse.Status(syscall.ESTALE) {
+		t.Fatalf("httpToFuseStatus(errLayerRolledBack) = %v, want ESTALE", got)
+	}
+}
+
+// TestRefreshLayerEventsDetectsRollback verifies that refreshLayerEvents,
+// when it sees a rollback event, calls applyLayerRollback instead of
+// restoreLayerEntries.
+func TestRefreshLayerEventsDetectsRollback(t *testing.T) {
+	var diffCalled bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/layers/layer-rb/events":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"events": []client.FSLayerEvent{
+					{EventID: "layer-rb:1", LayerID: "layer-rb", Seq: 1, Op: "upsert", Path: "/repo/a.txt"},
+					{EventID: "layer-rb:rollback:2", LayerID: "layer-rb", Seq: 2, Op: "rollback", Path: "/"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/layers/layer-rb/diff":
+			diffCalled = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []client.FSLayerEntry{}})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := client.New(ts.URL, "")
+	fs := NewDat9FS(c, &MountOptions{
+		LayerRef:   "layer-rb",
+		RemoteRoot: "/repo",
+	})
+	fs.commitQueue = NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	fs.commitQueue.SetLayerRef("layer-rb")
+
+	opts := &MountOptions{LayerRef: "layer-rb", RemoteRoot: "/repo"}
+	nextSeq, err := refreshLayerEvents(context.Background(), c, opts, shadow, pending, fs, 0)
+	if err != nil {
+		t.Fatalf("refreshLayerEvents: %v", err)
+	}
+	if nextSeq != 2 {
+		t.Fatalf("nextSeq = %d, want 2", nextSeq)
+	}
+
+	// restoreLayerEntries (the /diff endpoint) must NOT be called for a
+	// rollback event.
+	if diffCalled {
+		t.Fatal("restoreLayerEntries /diff was called; should be skipped for rollback")
+	}
+
+	// applyLayerRollback should have run.
+	if !fs.isLayerAbandoned() {
+		t.Fatal("layer should be abandoned after refreshLayerEvents saw rollback")
+	}
+}
+
+// TestRefreshLayerEventsSkipsRollbackWhenNoRollbackEvent verifies the normal
+// (non-rollback) path still calls restoreLayerEntries.
+func TestRefreshLayerEventsSkipsRollbackWhenNoRollbackEvent(t *testing.T) {
+	var diffCalled bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/layers/layer-norm/events":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"events": []client.FSLayerEvent{
+					{EventID: "layer-norm:1", LayerID: "layer-norm", Seq: 1, Op: "upsert", Path: "/repo/a.txt"},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/layers/layer-norm/diff":
+			diffCalled = true
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"entries": []client.FSLayerEntry{
+					{LayerID: "layer-norm", Path: "/repo/a.txt", Op: "upsert", Kind: "file", SizeBytes: 1, EntrySeq: 1},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/layers/layer-norm/entries":
+			_ = json.NewEncoder(w).Encode(client.FSLayerEntry{
+				LayerID: "layer-norm", Path: "/repo/a.txt", Op: "upsert", Kind: "file",
+				Content: []byte("a"), SizeBytes: 1, EntrySeq: 1,
+			})
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := client.New(ts.URL, "")
+	fs := NewDat9FS(c, &MountOptions{LayerRef: "layer-norm", RemoteRoot: "/repo"})
+	fs.commitQueue = NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	fs.commitQueue.SetLayerRef("layer-norm")
+
+	opts := &MountOptions{LayerRef: "layer-norm", RemoteRoot: "/repo"}
+	nextSeq, err := refreshLayerEvents(context.Background(), c, opts, shadow, pending, fs, 0)
+	if err != nil {
+		t.Fatalf("refreshLayerEvents: %v", err)
+	}
+	if nextSeq != 1 {
+		t.Fatalf("nextSeq = %d, want 1", nextSeq)
+	}
+	if !diffCalled {
+		t.Fatal("restoreLayerEntries /diff should be called for non-rollback events")
+	}
+	if fs.isLayerAbandoned() {
+		t.Fatal("layer should NOT be abandoned for non-rollback events")
+	}
+}

--- a/pkg/fuse/sse.go
+++ b/pkg/fuse/sse.go
@@ -130,35 +130,7 @@ func (w *SSEWatcher) handleReset(resets ...*client.ResetEvent) {
 	fmt.Fprintf(os.Stderr, "drive9: SSE reset — invalidating all caches\n")
 	w.fs.debugf("sse reset start seq=%d reason=%s", seq, reason)
 
-	// 1. Clear all user-space caches.
-	w.fs.readCache.InvalidateAll()
-	if w.fs.diskReadCache != nil {
-		w.fs.diskReadCache.InvalidateAll()
-	}
-	w.fs.clearAllReadTargets()
-	w.fs.dirCache.InvalidateAll()
+	w.fs.resetMountView()
 
-	// 2. Best-effort kernel cache invalidation for all known inodes.
-	//    Snapshot entries first so we don't hold the inode map lock during
-	//    potentially slow kernel notify calls.
-	//    InodeToPath is kept intact (stale but resolvable).
-	entries := w.fs.inodes.Snapshot()
-	w.fs.debugf("sse reset snapshot seq=%d reason=%s inodes=%d", seq, reason, len(entries))
-	for _, entry := range entries {
-		w.fs.notifyInode(entry.Ino)
-
-		// Do not invalidate a directory's own parent dentry during a broad reset.
-		// Linux getcwd(2) walks parent dentries; dropping the dentry for a
-		// process's current working directory can make git's remote helpers fail
-		// with ENOENT even though the directory still exists. The reset already
-		// clears userspace directory caches and notifies the directory inode, so
-		// future readdir/attr paths are refreshed without detaching cwd names.
-		if entry.Path != "/" && !entry.IsDir {
-			parent := parentDir(entry.Path)
-			if parentIno, ok := w.fs.inodes.GetInode(parent); ok {
-				w.fs.notifyEntry(parentIno, path.Base(entry.Path))
-			}
-		}
-	}
-	w.fs.debugf("sse reset done seq=%d reason=%s inodes=%d dur=%s", seq, reason, len(entries), time.Since(start))
+	w.fs.debugf("sse reset done seq=%d reason=%s dur=%s", seq, reason, time.Since(start))
 }


### PR DESCRIPTION
## Problem

`drive9 fs layer rollback` flips the layer `state` → `abandoned` (`pkg/datastore/fs_layer.go`) but writes **no** `fs_layer_events` row. The FUSE layer-event watcher (`pkg/fuse/layer_events.go`) only refreshes on new events, so an existing mount never learns the layer was rolled back. Two consequences:

1. **Stale view**: The mount keeps the pre-rollback overlay in memory. Whiteouts, overlay dirs, and overlay symlinks remain visible — the base view does not reappear until the user manually umounts and remounts.

2. **Silent write failures**: The mount keeps sending writes to the now-abandoned layer. The server rejects them with HTTP 409 (`ErrFSLayerStateConflict`), which the commit queue misclassifies as a revision conflict → `tryAutoResolveConflict` → terminal failure. The user sees an opaque EEXIST/EIO with no indication that the mount is stale.

There is no code comment or documentation stating that remount is required — this is an unfinished feature, not a deliberate design choice. The server-side `UpsertFSLayerEntry` gate (`SELECT ... FOR UPDATE` on `state`, returning `ErrFSLayerStateConflict` if `state != active`) proves the server considers `abandoned` a terminal state, but the FUSE mount never synchronizes that knowledge.

## Solution

Make `fs layer rollback` take effect on an existing FUSE mount **without remount**, via four coordinated changes:

### 1. Signal: `RollbackFSLayer` emits a synthetic event (`pkg/datastore/fs_layer.go`)

`RollbackFSLayer` now inserts a row into `fs_layer_events` with `op = "rollback"` inside the same transaction as the state flip → `abandoned`. The event carries a monotonically-allocated `seq` (strictly greater than any existing event seq for the layer) so the per-second FUSE layer-event watcher observes it. The `event_id` uses a distinct prefix (`<layer>:rollback:<seq>`) to avoid collision with the entry-event scheme (`<layer>:<seq>`).

- **Idempotent**: a second `RollbackFSLayer` call on an already-`abandoned` layer returns nil without re-inserting the event.
- **No schema change**: `fs_layer_events.op` is `VARCHAR(32)` with no CHECK constraint; `"rollback"` is 8 chars. No externally-managed schema SQL needs regeneration.

### 2. Detect: `refreshLayerEvents` branches on `op == "rollback"` (`pkg/fuse/layer_events.go`)

When the watcher sees a `rollback` event, it calls `applyLayerRollback` instead of `restoreLayerEntries`. This is critical: `restoreLayerEntries` would re-replay the abandoned layer's still-present `fs_layer_entries` (which are **not** deleted by rollback — they remain for audit) and re-populate the overlay we need to clear.

### 3. React: `applyLayerRollback` resets the mount view (`pkg/fuse/dat9fs.go`)

A new orchestrator on `Dat9FS` that performs the full rollback reaction:

1. **Set `layerAbandoned` flag** — future writes short-circuit with `errLayerRolledBack` → `ESTALE`.
2. **Halt the commit queue** via `AbandonLayer()` (non-blocking — does NOT `wg.Wait()` on in-flight uploads to the dead layer).
3. **Preserve pending local writes** as `PendingConflict` — shadow blobs are NOT deleted; `RecoverPending` skips conflict entries so they will not be retried against the dead layer. No data loss.
4. **Clear the in-memory overlay** (`layerWhiteouts`/`layerFiles`/`layerDirs`/`layerSymlinks`) — base view reappears.
5. **Flush userspace caches** — `readCache.InvalidateAll()`, `diskReadCache.InvalidateAll()`, `clearAllReadTargets()`, `dirCache.InvalidateAll()` (mirrors `SSEWatcher.handleReset`).
6. **Notify kernel** per-inode — `notifyInode` + `notifyEntry` for each known inode (best-effort; async to avoid macOS deadlock).
7. **Mark stat cache unverified** — forces re-fetch on next `Getattr`/`Read` (matches SSE `OnDisconnected`).

Idempotent: re-running `applyLayerRollback` on an already-abandoned mount is a no-op (maps already empty, flag already set, `MarkConflict` on already-conflict entries is idempotent).

### 4. Error path: writes return `ESTALE` (`pkg/fuse/dat9fs.go`, `pkg/fuse/commit_queue.go`)

- New sentinel `errLayerRolledBack = errors.New("fs layer has been rolled back; remount required")`.
- `httpToFuseStatus` maps it to `syscall.ESTALE` (the existing "stale mount" errno, previously used only for HTTP 412).
- `upsertLayerEntry` and `upsertLayerFile` (large-file bypass) check `fs.isLayerAbandoned()` and return `errLayerRolledBack` before hitting the network.
- `CommitQueue.AbandonLayer()` — new method: sets `stopped + abandoned`, closes `workCh`, cancels queued entries (pending state preserved on disk), does NOT block on in-flight workers.
- `CommitQueue.Enqueue` returns `errLayerRolledBack` when abandoned (backstop — the `upsertLayerEntry` guard catches most paths before reaching the queue).
- `CommitQueue.CommitNow` checks `abandoned` and returns `errLayerRolledBack` without a network round-trip.
- `commitOne` conflict classifier: when `abandoned`, skips `tryAutoResolveConflict` (which would waste a Stat/HEAD round-trip against the dead layer) and goes straight to `onCommitTerminalFailure` → `MarkConflict`.

## Tests

### Unit tests
- `pkg/datastore`: `TestRollbackFSLayerEmitsEvent` (event emission + idempotency), `TestRollbackFSLayerNotFound` — all pass
- `pkg/fuse`: `TestApplyLayerRollbackClearsOverlay`, `TestUpsertLayerEntryReturnsErrLayerRolledBack`, `TestHttpToFuseStatusMapsErrLayerRolledBackToESTALE`, `TestRefreshLayerEventsDetectsRollback`, `TestRefreshLayerEventsSkipsRollbackWhenNoRollbackEvent` — all pass
- Existing `TestCommitQueue*` and `TestLayer*` suites — no regressions

### E2E — `e2e/layer-fs-smoke-test.sh` with `RUN_LAYER_FUSE_SMOKE=1`

Full layer smoke suite (107/107 pass) including the new rollback hot-refresh FUSE block:
- `rollback fuse overlay clears without remount` ✅
- `rollback fuse base still visible after hot refresh` ✅
- `rollback fuse new write after rollback fails (ESTALE)` ✅

## Known limitation

The Linux kernel dentry cache may retain a stale entry for an overlaid file after the overlay is cleared. `ls` may briefly show the file, but any actual access (`cat`, `rm`) fails with EIO/ENOENT because the file does not exist in the base view. This is the same limitation as the existing `SSEWatcher.handleReset` path — go-fuse's `EntryNotify` is best-effort and the kernel may not immediately drop the dentry. The e2e test checks **readability** (`cat` failure) rather than **existence** (`test -e`) to match the user-visible behavior.

## Non-goals

- `fs_layer_entries` rows for the abandoned layer are **not** deleted (unchanged behavior — they remain for audit/possible re-commit to a different layer).
- `CheckpointRef`-pinned mounts disable the event watcher (`layer_events.go:19`), so they will **not** hot-detect rollback. This is pre-existing behavior (checkpoint mounts are immutable by design).
- No schema migration: `fs_layer_events.op` is `VARCHAR(32)` with no CHECK; `"rollback"` fits. No externally-managed schema SQL needs regeneration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rolling back a mounted layer without remounting.
  * The view now updates automatically after rollback, restoring access to the base layer and hiding rolled-back writes.

* **Bug Fixes**
  * Rolled-back layers now stop accepting new writes and surface a clear “stale data” style error.
  * Pending changes are preserved more safely when a rollback happens, reducing the risk of lost work.
  * Smoke tests now cover rollback behavior end to end, including mount visibility and write failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->