### PR TITLE
fix: relax provision response field check in api smoke test

### DIFF
--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -244,8 +244,7 @@ INIT_STATUS=$(printf '%s' "$body" | jq -r '.status // empty')
 check_cmd "response contains tenant_id" test -n "$TENANT_ID"
 check_cmd "response contains api_key" test -n "$API_KEY"
 check_eq "provision response status is provisioning" "$INIT_STATUS" "provisioning"
-keys=$(printf '%s' "$body" | jq -r 'keys_unsorted | sort | join(",")')
-check_eq "provision response only has api_key+status+tenant_id" "$keys" "api_key,status,tenant_id"
+check_cmd "provision response contains api_key, status, tenant_id" bash -c "echo \"\$1\" | jq -e '.api_key and .status and .tenant_id' >/dev/null" _ "$body"
 
 step "2" "Poll tenant status via /v1/status"
 deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))


### PR DESCRIPTION
Some server versions return `cloud_provider` and `region` in provision responses. Change the strict key-set assertion to a presence check for `api_key`, `status`, `tenant_id`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API smoke test validation for tenant provisioning responses.
  * The check now confirms required fields are present without failing when extra response data is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->