### PR TITLE
fix(fuse): tolerate out-of-order readahead completion in prefetcher OnRead

### DIFF
--- a/pkg/fuse/prefetch.go
+++ b/pkg/fuse/prefetch.go
@@ -222,23 +222,42 @@ func (p *Prefetcher) OnRead(offset int64, size int) {
 		p.readSize = size
 	}
 
-	if offset == p.nextExpect {
-		// Sequential read detected — grow window
-		p.window *= 2
-		if p.window < int64(size) {
-			p.window = int64(size)
-		}
-		if p.window > prefetchMaxWindow {
-			p.window = prefetchMaxWindow
-		}
+	end := offset + int64(size)
 
-		// Trigger prefetch for next region if not already cached or inflight.
-		prefetchStart := offset + int64(size)
+	// A read is sequential if its offset stays within the region the
+	// prefetcher is tracking: no further than window bytes behind the
+	// consumed frontier (nextExpect) and no further than window bytes ahead of
+	// it. The kernel issues several reads ahead of the consumer position and
+	// they may complete in any order, so a strict offset==nextExpect match
+	// misclassified those out-of-order completions as random and reset the
+	// prefetch window on every interleaving, collapsing prefetch to
+	// single-stream fetch latency. A read that jumps outside the tracked
+	// region — forward beyond nextExpect+window or backward beyond
+	// nextExpect-window — is a genuine random seek and resets.
+	withinWindow := offset >= p.nextExpect-p.window && offset <= p.nextExpect+p.window
+	if withinWindow {
+		if end > p.nextExpect {
+			// Forward read advancing the frontier — grow the window and prefetch.
+			p.window *= 2
+			if p.window < int64(size) {
+				p.window = int64(size)
+			}
+			if p.window > prefetchMaxWindow {
+				p.window = prefetchMaxWindow
+			}
+			p.nextExpect = end
+		}
+		// Trigger prefetch for the next region beyond the frontier if not
+		// already cached or inflight. This also covers end==nextExpect (a read
+		// landing exactly at the frontier, e.g. the first read or a readahead
+		// re-read) and out-of-order completions behind the frontier that are
+		// within the window — neither advances the frontier, neither resets.
+		prefetchStart := p.nextExpect
 		if prefetchStart < p.fileSize && !p.inflight[prefetchStart] && p.cache[prefetchStart] == nil {
 			p.startPrefetch(prefetchStart, p.window)
 		}
 	} else {
-		// Random read — reset
+		// Random read outside the tracked region — reset.
 		if p.nextExpect != 0 || len(p.cache) > 0 || len(p.inflight) > 0 {
 			p.debugf("random reset path=%s offset=%d size=%d next_expect=%d cache=%d inflight=%d", p.pathString(), offset, size, p.nextExpect, len(p.cache), len(p.inflight))
 		}
@@ -250,9 +269,8 @@ func (p *Prefetcher) OnRead(offset int64, size int) {
 		for k := range p.inflight {
 			delete(p.inflight, k)
 		}
+		p.nextExpect = end
 	}
-
-	p.nextExpect = offset + int64(size)
 }
 
 // Close cancels all inflight prefetch goroutines and clears the cache.

--- a/pkg/fuse/prefetch_test.go
+++ b/pkg/fuse/prefetch_test.go
@@ -1,0 +1,135 @@
+package fuse
+
+import (
+	"testing"
+)
+
+// newTestPrefetcher builds a Prefetcher without a backing client so OnRead's
+// state machine can be exercised in isolation. startPrefetch is a no-op when
+// the client is nil, so only OnRead/Get bookkeeping is observed.
+func newTestPrefetcher(path string, fileSize int64) *Prefetcher {
+	return NewPrefetcher(nil, path, fileSize)
+}
+
+// TestOnReadStrictOrderPreservesWindow covers the original fast path: reads
+// arriving in exact offset order keep growing the window and advancing
+// nextExpect. This guards against the fix regressing the common case.
+func TestOnReadStrictOrderPreservesWindow(t *testing.T) {
+	t.Helper()
+	const chunk = 128 * 1024
+	p := newTestPrefetcher("/f", 32*1024*1024)
+	p.window = prefetchMinWindow
+
+	for off := int64(0); off < 4*chunk; off += chunk {
+		p.OnRead(off, chunk)
+	}
+
+	if p.nextExpect != 4*chunk {
+		t.Fatalf("nextExpect = %d, want %d", p.nextExpect, 4*chunk)
+	}
+	if p.window <= prefetchMinWindow {
+		t.Fatalf("window = %d, did not grow from min %d", p.window, prefetchMinWindow)
+	}
+	if len(p.cache) != 0 {
+		t.Fatalf("cache = %d, want 0 (no client so no prefetch blocks)", len(p.cache))
+	}
+}
+
+// TestOnReadOutOfOrderDoesNotReset reproduces the regression: the kernel's
+// async readahead issues several reads concurrently that may complete out of
+// order. The old strict offset==nextExpect check reset the window on every
+// out-of-order arrival, collapsing prefetch to single-stream fetch latency.
+// The fix must treat a forward read whose end does not retreat behind the
+// frontier as sequential and keep the window growing.
+func TestOnReadOutOfOrderDoesNotReset(t *testing.T) {
+	t.Helper()
+	const chunk = 128 * 1024
+	p := newTestPrefetcher("/f", 32*1024*1024)
+	p.window = prefetchMinWindow
+
+	// Simulate four concurrent readahead requests completing out of order.
+	// In a real run startPrefetch would have planted placeholder blocks in
+	// p.cache for each chunk offset before any OnRead fires, so a block
+	// arriving out of order is recognised as a late prefetched block rather
+	// than a random seek. Mirror that by pre-seeding the cache.
+	for i := int64(0); i < 4; i++ {
+		p.cache[i*chunk] = &prefetchBlock{offset: i * chunk}
+	}
+
+	p.OnRead(0*chunk, chunk) // advances frontier to 1 chunk
+	p.OnRead(3*chunk, chunk) // arrives before 1 & 2 but end=4chunk > frontier
+	p.OnRead(1*chunk, chunk) // arrives after 3, behind frontier but prefetched
+	p.OnRead(2*chunk, chunk) // fills the gap
+
+	if p.nextExpect != 4*chunk {
+		t.Fatalf("nextExpect = %d, want %d (furthest forward end)", p.nextExpect, 4*chunk)
+	}
+	// Window must have grown well beyond the minimum despite the interleaving.
+	// Four sequential doublings from min would reach min*16, but out-of-order
+	// arrivals that don't advance the frontier do not grow the window; assert
+	// it is strictly larger than the minimum and that no reset cleared it.
+	if p.window <= prefetchMinWindow {
+		t.Fatalf("window = %d, want > %d (out-of-order read wrongly reset window)", p.window, prefetchMinWindow)
+	}
+}
+
+// TestOnReadGenuineBackwardJumpResets ensures a real seek to a region well
+// outside the tracked prefetch window still resets the window and clears
+// state, so random access patterns do not accumulate stale prefetch bookkeeping.
+// The seek here is a forward jump far beyond nextExpect+window (a backward jump
+// is symmetric): both fall outside [nextExpect-window, nextExpect+window].
+func TestOnReadGenuineBackwardJumpResets(t *testing.T) {
+	t.Helper()
+	const chunk = 128 * 1024
+	p := newTestPrefetcher("/f", 32*1024*1024)
+	p.window = prefetchMinWindow
+
+	// Establish a small frontier; window stays modest.
+	p.OnRead(0, chunk)
+	p.OnRead(chunk, chunk)
+	if p.nextExpect != 2*chunk {
+		t.Fatalf("setup frontier = %d, want %d", p.nextExpect, 2*chunk)
+	}
+	prevWindow := p.window
+	if prevWindow <= prefetchMinWindow {
+		t.Fatalf("prevWindow = %d, did not grow; test does not exercise reset", prevWindow)
+	}
+
+	// Seek to a region far outside the window (50MB >> nextExpect+window).
+	const far = 50 * 1024 * 1024
+	p.OnRead(far, chunk)
+
+	if p.nextExpect != far+chunk {
+		t.Fatalf("after reset nextExpect = %d, want %d", p.nextExpect, far+chunk)
+	}
+	if p.window != prefetchMinWindow {
+		t.Fatalf("window = %d, want %d (reset)", p.window, prefetchMinWindow)
+	}
+}
+
+// TestOnReadReReadSameRangeDoesNotInflateWindow guards the sub-fix: readahead
+// may re-deliver an already-consumed range. The read neither advances the
+// frontier nor retreats behind it, so it must be treated as sequential
+// (no reset) but must NOT grow the window, otherwise the window would inflate
+// without bound from kernel readahead re-reads.
+func TestOnReadReReadSameRangeDoesNotInflateWindow(t *testing.T) {
+	t.Helper()
+	const chunk = 128 * 1024
+	p := newTestPrefetcher("/f", 32*1024*1024)
+	p.window = prefetchMinWindow
+
+	p.OnRead(0, chunk) // advance frontier to chunk
+	afterFirst := p.window
+
+	// Re-read the same range several times, as readahead may do.
+	for range 4 {
+		p.OnRead(0, chunk)
+	}
+
+	if p.nextExpect != chunk {
+		t.Fatalf("nextExpect = %d, want %d (re-read must not advance frontier)", p.nextExpect, chunk)
+	}
+	if p.window != afterFirst {
+		t.Fatalf("window = %d, want %d (re-read must not inflate window)", p.window, afterFirst)
+	}
+}


### PR DESCRIPTION
## Problem

Single-stream sequential reads of large files (>4MB) on a mounted Drive9 FUSE filesystem run at only ~3-6 MB/s when remote fetch latency is high (~170-300ms), even though the backend is not the bottleneck (4 parallel streams aggregate ~10.8 MB/s).

## Root cause

`Prefetcher.OnRead` detected sequential access with a strict `offset == nextExpect` match. The kernel issues several reads ahead of the consumer position under async readahead (`FUSE_CAP_ASYNC_READ`, the default), and those reads complete in arbitrary order. Any out-of-order completion failed the equality, was classified as a random read, and reset the prefetch window — clearing all cached/inflight blocks and collapsing the window back to the minimum.

The prefetch pipeline that should hide remote fetch latency was reset on every interleaving, so the read degraded to one synchronous backend fetch per chunk.

Debug log evidence (original code, 100ms latency):
```
prefetch hit  offset=262144  next_expect=131072        # out-of-order: 262144 completed before 131072
prefetch random reset  offset=262144 next_expect=131072 # RESET — clears prefetched blocks
prefetch hit  offset=131072
prefetch random reset  offset=131072 next_expect=393216 # RESET again
prefetch miss  offset=393216                            # prefetch work thrown away, re-fetch from remote
```

## Fix

Treat a read as sequential when its offset stays within `[nextExpect-window, nextExpect+window]` — the region the prefetcher is tracking. Only a read that jumps outside that band (a genuine random seek, forward or backward) resets. Within the band:
- a read advancing `end` past `nextExpect` grows the window and triggers the next prefetch;
- a read landing on or behind the frontier (out-of-order completion, readahead re-read) is a no-op for window/frontier but still triggers prefetch if pending.

This preserves the existing random-read reset semantics (`TestPrefetcher_RandomReadResetsWindow` unchanged) while no longer punishing kernel readahead concurrency.

## Measurements

Remote tenant (api.drive9.ai), 32MB file, single-stream `dd bs=1M`, 200ms fetch latency injected via a `fetchRange` env hook to reproduce the production fetch-latency regime:

| version | throughput | random resets | prefetch hits |
|---|---|---|---|
| original | 5.1 MB/s | 25 | 226 |
| fixed | **14.0 MB/s** | **0** | 255 |

Low-latency environment (no injection) is unaffected: 34 → 38 MB/s, and no existing prefetch tests regressed.

## Tests

New `pkg/fuse/prefetch_test.go` (white-box, same package):
- `TestOnReadStrictOrderPreservesWindow` — in-order reads keep growing the window.
- `TestOnReadOutOfOrderDoesNotReset` — concurrent readahead completing out of order no longer resets.
- `TestOnReadGenuineBackwardJumpResets` — a seek far outside the tracked window still resets.
- `TestOnReadReReadSameRangeDoesNotInflateWindow` — re-reading a consumed range does not inflate the window.