### PR TITLE
Fix S3 delete prefix fallback for compatible stores

### DIFF
--- a/pkg/s3client/aws.go
+++ b/pkg/s3client/aws.go
@@ -689,7 +689,15 @@ func (c *AWSS3Client) deleteObjectsByPrefix(ctx context.Context, fullPrefix stri
 					},
 				})
 				if err != nil {
-					return fmt.Errorf("delete objects by prefix: %w", err)
+					if !isDeleteObjectsCompatibilityError(err) {
+						return fmt.Errorf("delete objects by prefix: %w", err)
+					}
+					deleted, fallbackErr := c.deleteObjectsOneByOne(ctx, objects)
+					out.DeletedObjects += deleted
+					if fallbackErr != nil {
+						return fmt.Errorf("delete objects by prefix fallback: %w", fallbackErr)
+					}
+					continue
 				}
 				if len(del.Errors) > 0 {
 					first := del.Errors[0]
@@ -703,6 +711,34 @@ func (c *AWSS3Client) deleteObjectsByPrefix(ctx context.Context, fullPrefix stri
 		}
 		continuation = res.NextContinuationToken
 	}
+}
+
+func isDeleteObjectsCompatibilityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "MissingArgument") ||
+		strings.Contains(msg, "MalformedXML") ||
+		strings.Contains(msg, "NotImplemented")
+}
+
+func (c *AWSS3Client) deleteObjectsOneByOne(ctx context.Context, objects []types.ObjectIdentifier) (int64, error) {
+	var deleted int64
+	for _, obj := range objects {
+		key := aws.ToString(obj.Key)
+		if key == "" {
+			continue
+		}
+		if _, err := c.client.DeleteObject(ctx, &s3.DeleteObjectInput{
+			Bucket: &c.bucket,
+			Key:    aws.String(key),
+		}); err != nil {
+			return deleted, fmt.Errorf("delete object %s: %w", key, err)
+		}
+		deleted++
+	}
+	return deleted, nil
 }
 
 func (c *AWSS3Client) UploadPartCopy(ctx context.Context, destKey, uploadID string, partNumber int, sourceKey string, startByte, endByte int64) (string, error) {


### PR DESCRIPTION
## Summary
- fall back to per-object DeleteObject when batch DeleteObjects returns S3-compatible store compatibility errors
- preserve the batch DeleteObjects fast path for normal AWS S3 behavior
- keep tenant delete jobs progressing when OSS rejects DeleteObjects with MissingArgument

## Test
- go test ./pkg/s3client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved S3 prefix deletion reliability when bulk deletion isn’t supported by the service.
  * Automatically falls back to deleting objects one at a time if the batch delete request fails for compatibility reasons.
  * Keeps track of how many objects were successfully removed during the fallback flow and skips invalid empty keys.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->