### PR TITLE
Fix admin pool private endpoint TLS handling

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -807,11 +807,13 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 				return nil, err
 			}
 			res.Status = meta.TenantProvisioning
-			res.TenantDSN = tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, true, provider)
+			dbtls := dbTLSForProvisionedTenant(provider)
+			res.TenantDSN = tenantDSN(cluster.Username, cluster.Password, cluster.Host, cluster.Port, cluster.DBName, dbtls, provider)
 			logProvisionStage(ctx, "admin_tenant_pool_free_tenant_connection_persisted", tenantID, provider, stageStarted,
 				"pool_id", poolID,
 				"organization_id", orgID,
 				"cluster_id", cluster.ClusterID,
+				"db_tls", dbtls,
 				"status", meta.TenantProvisioning)
 		} else {
 			stageStarted = time.Now()
@@ -882,7 +884,7 @@ func (s *Server) persistPoolTenantProvisionSeed(ctx context.Context, cluster *te
 	return s.meta.UpdateTenantConnection(ctx, cluster.TenantID, &meta.Tenant{
 		DBPasswordCipher: cipherPass,
 		DBName:           cluster.DBName,
-		DBTLS:            true,
+		DBTLS:            dbTLSForProvisionedTenant(provider),
 		Provider:         provider,
 		ClusterID:        cluster.ClusterID,
 	})
@@ -908,7 +910,7 @@ func (s *Server) persistPoolTenantConnection(ctx context.Context, cluster *tenan
 		DBUser:           cluster.Username,
 		DBPasswordCipher: cipherPass,
 		DBName:           cluster.DBName,
-		DBTLS:            true,
+		DBTLS:            dbTLSForProvisionedTenant(provider),
 		Provider:         provider,
 		ClusterID:        cluster.ClusterID,
 	})
@@ -1051,12 +1053,13 @@ func (s *Server) completePoolClusterMetadataResume(ctx context.Context, started 
 		return
 	}
 	cloudProvider, region := provisioningCloudRegion(s.provisioner)
+	dbtls := dbTLSForProvisionedTenant(tenant.ProviderTiDBCloudNative)
 	logProvisionStage(ctx, "admin_tenant_pool_metadata_resume_done", updated.TenantID, tenant.ProviderTiDBCloudNative, started, "cluster_id", updated.ClusterID, "organization_id", updated.OrganizationID)
 	s.startProvisionedTenantSchemaInit(ctx, &provisionTenantResult{
 		TenantID:       updated.TenantID,
 		Status:         meta.TenantProvisioning,
 		Provider:       tenant.ProviderTiDBCloudNative,
-		TenantDSN:      tenantDSN(updated.Username, updated.Password, updated.Host, updated.Port, updated.DBName, true, tenant.ProviderTiDBCloudNative),
+		TenantDSN:      tenantDSN(updated.Username, updated.Password, updated.Host, updated.Port, updated.DBName, dbtls, tenant.ProviderTiDBCloudNative),
 		CloudProvider:  cloudProvider,
 		Region:         region,
 		OrganizationID: strings.TrimSpace(updated.OrganizationID),

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1,0 +1,192 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+)
+
+func TestAdminTenantPoolCreateUsesPrivateEndpointDBTLS(t *testing.T) {
+	t.Setenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT", "1")
+	rt, schemaInitRecorder := newAdminTenantPoolRuntime(t)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{
+		{},
+		{Clusters: []tenant.CloudClusterInfo{{OrganizationID: "org-1"}}},
+	}
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+
+	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+		"pool_size":   1,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d body=%s", resp.StatusCode, body)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	var rows []meta.TenantWithTiDBCloudOrgBinding
+	for {
+		var err error
+		rows, err = rt.meta.ListTenantPoolFreeSlotsForDelete(context.Background(), "org-1", false, 10)
+		if err != nil {
+			t.Fatalf("list free slots: %v", err)
+		}
+		if len(rows) == 1 && rows[0].Tenant.DBHost == "db.example.com" && schemaInitRecorder.schemaInitCalls.Load() >= 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("free slots = %d, schema init calls=%d", len(rows), schemaInitRecorder.schemaInitCalls.Load())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if rows[0].Tenant.DBTLS {
+		t.Fatalf("pool tenant DBTLS = true, want false for private endpoint")
+	}
+	assertTenantUsesPrivateEndpointTLS(t, rows[0].Tenant)
+	assertSchemaInitUsesPrivateEndpointTLS(t, schemaInitRecorder.lastSchemaInitDSNSnapshot())
+}
+
+func TestTenantPoolMetadataResumeUsesPrivateEndpointDBTLS(t *testing.T) {
+	t.Setenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT", "1")
+	rt, schemaInitRecorder := newAdminTenantPoolRuntime(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           1,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	passCipher, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
+	if err != nil {
+		t.Fatalf("encrypt password: %v", err)
+	}
+	tenantID := "pool-private-resume-1"
+	clusterID := "cluster-private-resume-1"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantPending,
+		DBPasswordCipher: passCipher,
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        clusterID,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       tenantID,
+		OrganizationID: "org-1",
+		ClusterID:      clusterID,
+		PoolID:         "pool-1",
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+
+	rt.server.startPoolClustersMetadataResume(ctx, "pool-1", []*tenant.ClusterInfo{{
+		TenantID:       tenantID,
+		ClusterID:      clusterID,
+		OrganizationID: "org-1",
+		Password:       "pool-pass",
+		DBName:         "tidbcloud_fs",
+		Provider:       tenant.ProviderTiDBCloudNative,
+	}}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+
+	deadline := time.Now().Add(5 * time.Second)
+	var got *meta.Tenant
+	for {
+		got, err = rt.meta.GetTenant(ctx, tenantID)
+		if err != nil {
+			t.Fatalf("get tenant: %v", err)
+		}
+		if rt.prov.metadataBatchWaitCalls.Load() >= 1 && schemaInitRecorder.schemaInitCalls.Load() >= 1 && got.DBHost == "db.example.com" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("tenant after resume = status %s host %q, metadata waits=%d, schema init calls=%d", got.Status, got.DBHost, rt.prov.metadataBatchWaitCalls.Load(), schemaInitRecorder.schemaInitCalls.Load())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got.DBTLS {
+		t.Fatalf("resumed pool tenant DBTLS = true, want false for private endpoint")
+	}
+	assertTenantUsesPrivateEndpointTLS(t, *got)
+	assertSchemaInitUsesPrivateEndpointTLS(t, schemaInitRecorder.lastSchemaInitDSNSnapshot())
+}
+
+type adminTenantPoolSchemaInitRecorder struct {
+	*quotaTestProvisioner
+
+	schemaInitCalls   atomic.Int32
+	mu                sync.Mutex
+	lastSchemaInitDSN string
+}
+
+func newAdminTenantPoolRuntime(t *testing.T) (*quotaRuntime, *adminTenantPoolSchemaInitRecorder) {
+	t.Helper()
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	recorder := &adminTenantPoolSchemaInitRecorder{quotaTestProvisioner: rt.prov}
+	rt.server.provisioner = recorder
+	return rt, recorder
+}
+
+func (p *adminTenantPoolSchemaInitRecorder) InitSchema(_ context.Context, dsn string) error {
+	p.mu.Lock()
+	p.lastSchemaInitDSN = dsn
+	p.mu.Unlock()
+	p.schemaInitCalls.Add(1)
+	return nil
+}
+
+func (p *adminTenantPoolSchemaInitRecorder) lastSchemaInitDSNSnapshot() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastSchemaInitDSN
+}
+
+func assertTenantUsesPrivateEndpointTLS(t *testing.T, got meta.Tenant) {
+	t.Helper()
+	dsn := tenantDSN("u.root", "pass", got.DBHost, got.DBPort, got.DBName, got.DBTLS, got.Provider)
+	if !strings.Contains(dsn, "tls=skip-verify") {
+		t.Fatalf("tenant DSN = %q, want tls=skip-verify", dsn)
+	}
+	if strings.Contains(dsn, "tls=true") {
+		t.Fatalf("tenant DSN = %q, should not use tls=true for private endpoint", dsn)
+	}
+}
+
+func assertSchemaInitUsesPrivateEndpointTLS(t *testing.T, dsn string) {
+	t.Helper()
+	if !strings.Contains(dsn, "tls=skip-verify") {
+		t.Fatalf("schema init DSN = %q, want tls=skip-verify", dsn)
+	}
+	if strings.Contains(dsn, "tls=true") {
+		t.Fatalf("schema init DSN = %q, should not use tls=true for private endpoint", dsn)
+	}
+}


### PR DESCRIPTION
## Summary
- use the provisioned tenant DBTLS policy for admin tenant pool connection persistence and schema init DSNs
- preserve private endpoint behavior by using tls=skip-verify instead of tls=true for TiDB Cloud Native pool tenants
- add admin pool regression tests for create and metadata resume paths

## Tests
- go test ./pkg/server -run 'TestAdminTenantPoolCreateUsesPrivateEndpointDBTLS|TestTenantPoolMetadataResumeUsesPrivateEndpointDBTLS'
- go test ./pkg/server -run 'TestAdminTenantPool|TestTenantPoolClaimMissTriggersPendingMetadataResume|TestTenantPoolMetadataResumeRerunsWhenTriggeredWhileActive'
- go test ./pkg/server
- git diff --check -- pkg/server/admin_tenant_pool.go pkg/server/admin_tenant_pool_test.go