### PR TITLE
Fix tenant pool metadata resume persistence context

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -956,7 +956,7 @@ func (s *Server) startPoolClustersMetadataResume(ctx context.Context, poolID str
 		if poolID != "" {
 			defer s.tenantPoolResumeJobs.Delete(poolID)
 		}
-		workerCtx, cancel := context.WithTimeout(workerCtx, 10*time.Minute)
+		workerCtx, cancel := context.WithTimeout(workerCtx, tenantPoolMetadataResumeWaitTimeout)
 		defer cancel()
 
 		for {
@@ -1022,6 +1022,9 @@ func (s *Server) waitForPoolClustersMetadata(ctx context.Context, clusters []*te
 }
 
 func (s *Server) completePoolClusterMetadataResume(ctx context.Context, started time.Time, updated *tenant.ClusterInfo) {
+	ctx, cancel := context.WithTimeout(backgroundWithTrace(ctx), tenantPoolMetadataResumePersistTimeout)
+	defer cancel()
+
 	if !poolClusterConnectionReady(updated) {
 		if updated != nil {
 			logger.Warn(ctx, "admin_tenant_pool_metadata_resume_incomplete",

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -961,16 +961,7 @@ func (s *Server) startPoolClustersMetadataResume(ctx context.Context, poolID str
 
 		for {
 			started := time.Now()
-			updated, err := s.waitForPoolClustersMetadata(workerCtx, clusterCopies, cred)
-			if err != nil {
-				logger.Warn(workerCtx, "admin_tenant_pool_metadata_resume_batch_failed",
-					zap.String("pool_id", poolID),
-					zap.Int("cluster_count", len(clusterCopies)),
-					zap.Error(err))
-			}
-			for _, cluster := range updated {
-				s.completePoolClusterMetadataResume(workerCtx, started, cluster)
-			}
+			s.resumePoolClustersMetadataGroups(workerCtx, started, poolID, clusterCopies, cred)
 			if poolID == "" || !job.rerun.Swap(false) {
 				return
 			}
@@ -987,6 +978,74 @@ func (s *Server) startPoolClustersMetadataResume(ctx context.Context, poolID str
 			}
 		}
 	})
+}
+
+func (s *Server) resumePoolClustersMetadataGroups(ctx context.Context, started time.Time, poolID string, clusters []*tenant.ClusterInfo, cred tenant.CredentialProvisionRequest) {
+	groups := poolMetadataResumeGroups(clusters, tenantPoolMetadataResumeGroupSize)
+	if len(groups) == 0 {
+		return
+	}
+	var wg sync.WaitGroup
+	for i, group := range groups {
+		groupIndex := i
+		group := group
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			updated, err := s.waitForPoolClustersMetadata(ctx, group, cred)
+			if err != nil {
+				logger.Warn(ctx, "admin_tenant_pool_metadata_resume_batch_failed",
+					zap.String("pool_id", poolID),
+					zap.Int("group_index", groupIndex),
+					zap.Int("group_count", len(groups)),
+					zap.Int("cluster_count", len(group)),
+					zap.Strings("tenant_ids", poolResumeTenantIDs(group)),
+					zap.Strings("cluster_ids", poolResumeClusterIDs(group)),
+					zap.Error(err))
+			}
+			for _, cluster := range updated {
+				s.completePoolClusterMetadataResume(ctx, started, cluster)
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+func poolMetadataResumeGroups(clusters []*tenant.ClusterInfo, groupSize int) [][]*tenant.ClusterInfo {
+	if groupSize <= 0 {
+		groupSize = 10
+	}
+	groups := make([][]*tenant.ClusterInfo, 0, (len(clusters)+groupSize-1)/groupSize)
+	for start := 0; start < len(clusters); start += groupSize {
+		end := start + groupSize
+		if end > len(clusters) {
+			end = len(clusters)
+		}
+		groups = append(groups, clusters[start:end])
+	}
+	return groups
+}
+
+func poolResumeTenantIDs(clusters []*tenant.ClusterInfo) []string {
+	out := make([]string, 0, len(clusters))
+	for _, cluster := range clusters {
+		if cluster == nil {
+			continue
+		}
+		out = append(out, strings.TrimSpace(cluster.TenantID))
+	}
+	return out
+}
+
+func poolResumeClusterIDs(clusters []*tenant.ClusterInfo) []string {
+	out := make([]string, 0, len(clusters))
+	for _, cluster := range clusters {
+		if cluster == nil {
+			continue
+		}
+		out = append(out, strings.TrimSpace(cluster.ClusterID))
+	}
+	return out
 }
 
 func compactPoolResumeClusters(clusters []*tenant.ClusterInfo) []*tenant.ClusterInfo {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1022,7 +1022,7 @@ func (s *Server) waitForPoolClustersMetadata(ctx context.Context, clusters []*te
 }
 
 func (s *Server) completePoolClusterMetadataResume(ctx context.Context, started time.Time, updated *tenant.ClusterInfo) {
-	ctx, cancel := context.WithTimeout(backgroundWithTrace(ctx), tenantPoolMetadataResumePersistTimeout)
+	ctx, cancel := s.tenantPoolMetadataResumePersistContext(ctx)
 	defer cancel()
 
 	if !poolClusterConnectionReady(updated) {
@@ -1067,6 +1067,14 @@ func (s *Server) completePoolClusterMetadataResume(ctx context.Context, started 
 		Region:         region,
 		OrganizationID: strings.TrimSpace(updated.OrganizationID),
 	})
+}
+
+func (s *Server) tenantPoolMetadataResumePersistContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	parent := backgroundWithTrace(ctx)
+	if s.forkWorkerCtx != nil {
+		parent = contextWithTrace(s.forkWorkerCtx, ctx)
+	}
+	return context.WithTimeout(parent, tenantPoolMetadataResumePersistTimeout)
 }
 
 func (s *Server) cleanupPoolProvisionedClusters(ctx context.Context, clusters []*tenant.ClusterInfo, cred tenant.CredentialProvisionRequest, tenantIDs []string, reason string) {

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -232,6 +232,131 @@ func TestTenantPoolMetadataResumePersistsAfterWaitDeadline(t *testing.T) {
 	}
 }
 
+func TestTenantPoolMetadataResumePersistsReadyGroupBeforeSlowGroup(t *testing.T) {
+	oldGroupSize := tenantPoolMetadataResumeGroupSize
+	tenantPoolMetadataResumeGroupSize = 1
+	t.Cleanup(func() {
+		tenantPoolMetadataResumeGroupSize = oldGroupSize
+	})
+
+	rt, schemaInitRecorder := newAdminTenantPoolRuntime(t)
+	waiter := &groupStreamingMetadataResumeProvisioner{
+		adminTenantPoolSchemaInitRecorder: schemaInitRecorder,
+		slowTenantID:                      "pool-stream-resume-slow",
+		slowStarted:                       make(chan struct{}),
+		releaseSlow:                       make(chan struct{}),
+	}
+	var releaseSlowOnce sync.Once
+	t.Cleanup(func() {
+		releaseSlowOnce.Do(func() { close(waiter.releaseSlow) })
+	})
+	rt.server.provisioner = waiter
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           2,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	makePending := func(tenantID, clusterID string) *tenant.ClusterInfo {
+		t.Helper()
+		passCipher, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
+		if err != nil {
+			t.Fatalf("encrypt password: %v", err)
+		}
+		if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+			ID:               tenantID,
+			Status:           meta.TenantPending,
+			DBPasswordCipher: passCipher,
+			DBName:           "tidbcloud_fs",
+			DBTLS:            true,
+			Provider:         tenant.ProviderTiDBCloudNative,
+			ClusterID:        clusterID,
+			SchemaVersion:    1,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}); err != nil {
+			t.Fatalf("insert tenant %s: %v", tenantID, err)
+		}
+		if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+			TenantID:       tenantID,
+			OrganizationID: "org-1",
+			ClusterID:      clusterID,
+			PoolID:         "pool-1",
+			PoolStatus:     meta.TenantPoolBindingFree,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}); err != nil {
+			t.Fatalf("upsert binding %s: %v", tenantID, err)
+		}
+		return &tenant.ClusterInfo{
+			TenantID:       tenantID,
+			ClusterID:      clusterID,
+			OrganizationID: "org-1",
+			Password:       "pool-pass",
+			DBName:         "tidbcloud_fs",
+			Provider:       tenant.ProviderTiDBCloudNative,
+		}
+	}
+	slow := makePending(waiter.slowTenantID, "cluster-stream-resume-slow")
+	fast := makePending("pool-stream-resume-fast", "cluster-stream-resume-fast")
+
+	rt.server.startPoolClustersMetadataResume(ctx, "pool-1", []*tenant.ClusterInfo{slow, fast}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+
+	select {
+	case <-waiter.slowStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("slow metadata resume group did not start")
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		got, err := rt.meta.GetTenant(ctx, fast.TenantID)
+		if err != nil {
+			t.Fatalf("get fast tenant: %v", err)
+		}
+		if got.DBHost == "db.example.com" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("fast tenant was not persisted while slow group was blocked: status %s host %q", got.Status, got.DBHost)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	slowTenant, err := rt.meta.GetTenant(ctx, slow.TenantID)
+	if err != nil {
+		t.Fatalf("get slow tenant: %v", err)
+	}
+	if slowTenant.DBHost != "" {
+		t.Fatalf("slow tenant host = %q before slow group release, want empty", slowTenant.DBHost)
+	}
+
+	releaseSlowOnce.Do(func() { close(waiter.releaseSlow) })
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		got, err := rt.meta.GetTenant(ctx, slow.TenantID)
+		if err != nil {
+			t.Fatalf("get slow tenant: %v", err)
+		}
+		if got.DBHost == "db.example.com" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("slow tenant was not persisted after release: status %s host %q", got.Status, got.DBHost)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestTenantPoolMetadataResumePersistContextPreservesServerCancellation(t *testing.T) {
 	srv := NewWithConfig(Config{})
 	ctx, cancel := srv.tenantPoolMetadataResumePersistContext(context.Background())
@@ -273,6 +398,30 @@ func (p *deadlineMetadataResumeProvisioner) WaitForPoolClustersMetadata(ctx cont
 	p.waitStartedOnce.Do(func() { close(p.waitStarted) })
 	<-ctx.Done()
 	return p.quotaTestProvisioner.WaitForPoolClustersMetadata(context.Background(), clusters, req)
+}
+
+type groupStreamingMetadataResumeProvisioner struct {
+	*adminTenantPoolSchemaInitRecorder
+
+	slowTenantID string
+	slowStarted  chan struct{}
+	releaseSlow  chan struct{}
+	slowOnce     sync.Once
+}
+
+func (p *groupStreamingMetadataResumeProvisioner) WaitForPoolClustersMetadata(ctx context.Context, clusters []*tenant.ClusterInfo, req tenant.CredentialProvisionRequest) ([]*tenant.ClusterInfo, error) {
+	for _, cluster := range clusters {
+		if cluster != nil && cluster.TenantID == p.slowTenantID {
+			p.slowOnce.Do(func() { close(p.slowStarted) })
+			select {
+			case <-p.releaseSlow:
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+			break
+		}
+	}
+	return p.quotaTestProvisioner.WaitForPoolClustersMetadata(ctx, clusters, req)
 }
 
 func (p *adminTenantPoolSchemaInitRecorder) InitSchema(_ context.Context, dsn string) error {

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -232,6 +232,20 @@ func TestTenantPoolMetadataResumePersistsAfterWaitDeadline(t *testing.T) {
 	}
 }
 
+func TestTenantPoolMetadataResumePersistContextPreservesServerCancellation(t *testing.T) {
+	srv := NewWithConfig(Config{})
+	ctx, cancel := srv.tenantPoolMetadataResumePersistContext(context.Background())
+	defer cancel()
+
+	srv.Close()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("persist context was not canceled by server close")
+	}
+}
+
 type adminTenantPoolSchemaInitRecorder struct {
 	*quotaTestProvisioner
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -140,6 +140,98 @@ func TestTenantPoolMetadataResumeUsesPrivateEndpointDBTLS(t *testing.T) {
 	assertSchemaInitUsesPrivateEndpointTLS(t, schemaInitRecorder.lastSchemaInitDSNSnapshot())
 }
 
+func TestTenantPoolMetadataResumePersistsAfterWaitDeadline(t *testing.T) {
+	oldWaitTimeout := tenantPoolMetadataResumeWaitTimeout
+	tenantPoolMetadataResumeWaitTimeout = 20 * time.Millisecond
+	t.Cleanup(func() {
+		tenantPoolMetadataResumeWaitTimeout = oldWaitTimeout
+	})
+
+	rt, schemaInitRecorder := newAdminTenantPoolRuntime(t)
+	waiter := &deadlineMetadataResumeProvisioner{
+		adminTenantPoolSchemaInitRecorder: schemaInitRecorder,
+		waitStarted:                       make(chan struct{}),
+	}
+	rt.server.provisioner = waiter
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           1,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	passCipher, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
+	if err != nil {
+		t.Fatalf("encrypt password: %v", err)
+	}
+	tenantID := "pool-deadline-resume-1"
+	clusterID := "cluster-deadline-resume-1"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantPending,
+		DBPasswordCipher: passCipher,
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        clusterID,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       tenantID,
+		OrganizationID: "org-1",
+		ClusterID:      clusterID,
+		PoolID:         "pool-1",
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+
+	rt.server.startPoolClustersMetadataResume(ctx, "pool-1", []*tenant.ClusterInfo{{
+		TenantID:       tenantID,
+		ClusterID:      clusterID,
+		OrganizationID: "org-1",
+		Password:       "pool-pass",
+		DBName:         "tidbcloud_fs",
+		Provider:       tenant.ProviderTiDBCloudNative,
+	}}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+
+	select {
+	case <-waiter.waitStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("metadata resume did not start")
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		got, err := rt.meta.GetTenant(ctx, tenantID)
+		if err != nil {
+			t.Fatalf("get tenant: %v", err)
+		}
+		if rt.prov.metadataBatchWaitCalls.Load() >= 1 && schemaInitRecorder.schemaInitCalls.Load() >= 1 && got.DBHost == "db.example.com" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("tenant after deadline resume = status %s host %q, metadata waits=%d, schema init calls=%d", got.Status, got.DBHost, rt.prov.metadataBatchWaitCalls.Load(), schemaInitRecorder.schemaInitCalls.Load())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 type adminTenantPoolSchemaInitRecorder struct {
 	*quotaTestProvisioner
 
@@ -154,6 +246,19 @@ func newAdminTenantPoolRuntime(t *testing.T) (*quotaRuntime, *adminTenantPoolSch
 	recorder := &adminTenantPoolSchemaInitRecorder{quotaTestProvisioner: rt.prov}
 	rt.server.provisioner = recorder
 	return rt, recorder
+}
+
+type deadlineMetadataResumeProvisioner struct {
+	*adminTenantPoolSchemaInitRecorder
+
+	waitStarted     chan struct{}
+	waitStartedOnce sync.Once
+}
+
+func (p *deadlineMetadataResumeProvisioner) WaitForPoolClustersMetadata(ctx context.Context, clusters []*tenant.ClusterInfo, req tenant.CredentialProvisionRequest) ([]*tenant.ClusterInfo, error) {
+	p.waitStartedOnce.Do(func() { close(p.waitStarted) })
+	<-ctx.Done()
+	return p.quotaTestProvisioner.WaitForPoolClustersMetadata(context.Background(), clusters, req)
 }
 
 func (p *adminTenantPoolSchemaInitRecorder) InitSchema(_ context.Context, dsn string) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -246,6 +246,8 @@ var (
 	schemaInitRetryWindow                     = 10 * time.Minute
 	schemaInitInitialBackoff                  = 2 * time.Second
 	schemaInitMaxBackoff                      = 30 * time.Second
+	tenantPoolMetadataResumeWaitTimeout       = 10 * time.Minute
+	tenantPoolMetadataResumePersistTimeout    = 2 * time.Minute
 	pendingTenantStaleAfter                   = 10 * time.Minute
 	pendingTenantSweepEvery                   = time.Minute
 	initTiDBTenantSchemaForFTSOnlyProfileFunc = tenantschema.InitTiDBTenantSchemaForFTSOnlyProfileContext

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -248,6 +248,7 @@ var (
 	schemaInitMaxBackoff                      = 30 * time.Second
 	tenantPoolMetadataResumeWaitTimeout       = 10 * time.Minute
 	tenantPoolMetadataResumePersistTimeout    = 2 * time.Minute
+	tenantPoolMetadataResumeGroupSize         = 10
 	pendingTenantStaleAfter                   = 10 * time.Minute
 	pendingTenantSweepEvery                   = time.Minute
 	initTiDBTenantSchemaForFTSOnlyProfileFunc = tenantschema.InitTiDBTenantSchemaForFTSOnlyProfileContext

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -18,14 +18,17 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
 
 	mysql "github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/tenant/schema"
+	"go.uber.org/zap"
 )
 
 const (
@@ -501,6 +504,7 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadata(ctx context.Context, 
 }
 
 func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Context, publicKey, privateKey, poolID string, group []batchClusterMetadataTarget, out []*tenant.ClusterInfo, errs []error) {
+	started := time.Now()
 	deadline := time.Now().Add(10 * time.Minute)
 	pending := make(map[string]batchClusterMetadataTarget, len(group))
 	clusterIDs := make([]string, 0, len(group))
@@ -513,13 +517,32 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Cont
 		pending[clusterID] = target
 		clusterIDs = append(clusterIDs, clusterID)
 	}
+	logger.Info(ctx, "tidbcloud_native_batch_metadata_wait_started",
+		zap.Int("group_size", len(group)),
+		zap.Int("pending_count", len(pending)),
+		zap.String("pool_id", strings.TrimSpace(poolID)),
+		zap.Strings("cluster_ids", sortedClusterIDs(pending)),
+		zap.Strings("tenant_ids", sortedTenantIDs(pending)))
+	pollCount := 0
 	for len(pending) > 0 {
+		pollCount++
+		seenCount := 0
+		readyCount := 0
+		incompleteClusterIDs := make([]string, 0, len(pending))
 		infos, err := p.listClusterInfosWithCredentials(ctx, publicKey, privateKey, clusterIDs, len(clusterIDs))
 		if err != nil {
 			if !isTiDBCloudStatus(err, http.StatusTooManyRequests) || time.Now().After(deadline) {
 				for _, target := range pending {
 					errs[target.index] = err
 				}
+				logger.Warn(ctx, "tidbcloud_native_batch_metadata_wait_failed",
+					zap.Int("poll_count", pollCount),
+					zap.Int("pending_count", len(pending)),
+					zap.String("pool_id", strings.TrimSpace(poolID)),
+					zap.Strings("cluster_ids", sortedClusterIDs(pending)),
+					zap.Strings("tenant_ids", sortedTenantIDs(pending)),
+					zap.Duration("elapsed", time.Since(started)),
+					zap.Error(err))
 				return
 			}
 		} else {
@@ -530,6 +553,7 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Cont
 				if !ok {
 					continue
 				}
+				seenCount++
 				if tenantID := strings.TrimSpace(info.Labels[Drive9TenantIDLabel]); tenantID != target.tenantID {
 					errs[target.index] = fmt.Errorf("tidbcloud native batch metadata tenant label mismatch for cluster %q: got %q, want %q", clusterID, tenantID, target.tenantID)
 					delete(pending, clusterID)
@@ -541,19 +565,44 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Cont
 					continue
 				}
 				if clusterProvisionMetadataIncomplete(&info, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
+					incompleteClusterIDs = append(incompleteClusterIDs, clusterID)
 					continue
 				}
 				out[target.index] = p.clusterInfoFromResponse(target.tenantID, target.dbName, target.password, &info)
 				delete(pending, clusterID)
+				readyCount++
 			}
 		}
 		if len(pending) == 0 {
+			logger.Info(ctx, "tidbcloud_native_batch_metadata_wait_finished",
+				zap.Int("poll_count", pollCount),
+				zap.Int("ready_count", readyCount),
+				zap.String("pool_id", strings.TrimSpace(poolID)),
+				zap.Duration("elapsed", time.Since(started)))
 			return
 		}
+		sort.Strings(incompleteClusterIDs)
+		logger.Info(ctx, "tidbcloud_native_batch_metadata_wait_pending",
+			zap.Int("poll_count", pollCount),
+			zap.Int("pending_count", len(pending)),
+			zap.Int("seen_count", seenCount),
+			zap.Int("ready_count", readyCount),
+			zap.String("pool_id", strings.TrimSpace(poolID)),
+			zap.Strings("pending_cluster_ids", sortedClusterIDs(pending)),
+			zap.Strings("pending_tenant_ids", sortedTenantIDs(pending)),
+			zap.Strings("incomplete_cluster_ids", incompleteClusterIDs),
+			zap.Duration("elapsed", time.Since(started)))
 		if time.Now().After(deadline) {
 			for clusterID, target := range pending {
 				errs[target.index] = fmt.Errorf("tidbcloud native cluster %s missing connection metadata or organization label before timeout", clusterID)
 			}
+			logger.Warn(ctx, "tidbcloud_native_batch_metadata_wait_timeout",
+				zap.Int("poll_count", pollCount),
+				zap.Int("pending_count", len(pending)),
+				zap.String("pool_id", strings.TrimSpace(poolID)),
+				zap.Strings("cluster_ids", sortedClusterIDs(pending)),
+				zap.Strings("tenant_ids", sortedTenantIDs(pending)),
+				zap.Duration("elapsed", time.Since(started)))
 			return
 		}
 		select {
@@ -561,10 +610,36 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Cont
 			for _, target := range pending {
 				errs[target.index] = ctx.Err()
 			}
+			logger.Warn(ctx, "tidbcloud_native_batch_metadata_wait_canceled",
+				zap.Int("poll_count", pollCount),
+				zap.Int("pending_count", len(pending)),
+				zap.String("pool_id", strings.TrimSpace(poolID)),
+				zap.Strings("cluster_ids", sortedClusterIDs(pending)),
+				zap.Strings("tenant_ids", sortedTenantIDs(pending)),
+				zap.Duration("elapsed", time.Since(started)),
+				zap.Error(ctx.Err()))
 			return
 		case <-time.After(batchMetadataPollInterval()):
 		}
 	}
+}
+
+func sortedClusterIDs(pending map[string]batchClusterMetadataTarget) []string {
+	out := make([]string, 0, len(pending))
+	for clusterID := range pending {
+		out = append(out, clusterID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func sortedTenantIDs(pending map[string]batchClusterMetadataTarget) []string {
+	out := make([]string, 0, len(pending))
+	for _, target := range pending {
+		out = append(out, target.tenantID)
+	}
+	sort.Strings(out)
+	return out
 }
 
 func batchMetadataPollInterval() time.Duration {


### PR DESCRIPTION
## Summary
- keep tenant pool metadata waiting under the existing resume timeout while giving metadata persistence its own background trace context and deadline
- make the resume wait timeout testable
- add a regression test for persisting tenant pool metadata after the wait context deadline has fired

## Tests
- go test ./pkg/server -run 'TestTenantPoolMetadataResume(PersistsAfterWaitDeadline|UsesPrivateEndpointDBTLS)'
- go test ./pkg/server -run 'TestTenantPool|TestAdminTenantPool'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant pool metadata resume handling by separating the wait phase from the persistence phase, helping resumptions complete more reliably.
  * Added configurable time limits for metadata resume operations, replacing fixed timing behavior.
  * Ensured resume persistence respects server shutdown/cancellation so work stops cleanly when the server closes.

* **Tests**
  * Added coverage for metadata resume behavior when the wait deadline is reached.
  * Added coverage to verify the resume persistence context is cancelled during server shutdown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->