### PR TITLE
Add tenant pool metadata resume wait metrics

### DIFF
--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -45,6 +45,8 @@ var tenantMeter = globalMeterProvider.Meter("tenant")
 var serviceOperationsTotal = serviceMeter.Int64Counter("drive9_service_operations_total", "Service operations by component/operation/result")
 var serviceOperationDuration = serviceMeter.Float64Histogram("drive9_service_operation_duration_seconds", "Service operation duration histogram", operationDurationBounds)
 var serviceGauge = serviceMeter.Float64Gauge("drive9_service_gauge", "Service gauges by component/name")
+var tenantPoolMetadataResumeWaitTotal = serviceMeter.Int64Counter("drive9_tenant_pool_metadata_resume_wait_total", "Tenant pool metadata resume wait attempts by pool_id/organization_id/scope/result")
+var tenantPoolMetadataResumeWaitDuration = serviceMeter.Float64Histogram("drive9_tenant_pool_metadata_resume_wait_duration_seconds", "Tenant pool metadata resume wait duration by pool_id/organization_id/scope/result", operationDurationBounds)
 
 var httpRequestsTotal = httpMeter.Int64Counter("drive9_http_requests_total", "Total HTTP requests by method/route/status")
 var httpRequestDuration = httpMeter.Float64Histogram("drive9_http_request_duration_seconds", "HTTP request duration histogram by method/route", httpDurationBounds)
@@ -119,6 +121,21 @@ func RecordTenantOperation(tenantID, component, operation, result string, d time
 	}
 	serviceOperationsTotal.Add(1, attrs...)
 	serviceOperationDuration.Observe(d.Seconds(), attrs...)
+}
+
+func RecordTenantPoolMetadataResumeWait(poolID, organizationID, scope, result string, d time.Duration) {
+	poolID = cleanMetricValue(poolID, "unknown")
+	organizationID = cleanMetricValue(organizationID, "unknown")
+	scope = cleanMetricValue(scope, "unknown")
+	result = cleanMetricValue(result, "unknown")
+	attrs := []Attribute{
+		Attr("pool_id", poolID),
+		Attr("organization_id", organizationID),
+		Attr("scope", scope),
+		Attr("result", result),
+	}
+	tenantPoolMetadataResumeWaitTotal.Add(1, attrs...)
+	tenantPoolMetadataResumeWaitDuration.Observe(d.Seconds(), attrs...)
 }
 
 // ResultForError returns a stable metric result label for common infrastructure

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -47,6 +47,7 @@ var serviceOperationDuration = serviceMeter.Float64Histogram("drive9_service_ope
 var serviceGauge = serviceMeter.Float64Gauge("drive9_service_gauge", "Service gauges by component/name")
 var tenantPoolMetadataResumeWaitTotal = serviceMeter.Int64Counter("drive9_tenant_pool_metadata_resume_wait_total", "Tenant pool metadata resume wait attempts by pool_id/organization_id/scope/result")
 var tenantPoolMetadataResumeWaitDuration = serviceMeter.Float64Histogram("drive9_tenant_pool_metadata_resume_wait_duration_seconds", "Tenant pool metadata resume wait duration by pool_id/organization_id/scope/result", operationDurationBounds)
+var tenantPoolCapacity = serviceMeter.Float64Gauge("drive9_tenant_pool_capacity", "Tenant pool capacity by pool_id/organization_id/state")
 
 var httpRequestsTotal = httpMeter.Int64Counter("drive9_http_requests_total", "Total HTTP requests by method/route/status")
 var httpRequestDuration = httpMeter.Float64Histogram("drive9_http_request_duration_seconds", "HTTP request duration histogram by method/route", httpDurationBounds)
@@ -136,6 +137,15 @@ func RecordTenantPoolMetadataResumeWait(poolID, organizationID, scope, result st
 	}
 	tenantPoolMetadataResumeWaitTotal.Add(1, attrs...)
 	tenantPoolMetadataResumeWaitDuration.Observe(d.Seconds(), attrs...)
+}
+
+func RecordTenantPoolCapacity(poolID, organizationID, state string, value float64) {
+	RegisterModule("admin_tenant_pool")
+	tenantPoolCapacity.Set(value,
+		Attr("pool_id", cleanMetricValue(poolID, "unknown")),
+		Attr("organization_id", cleanMetricValue(organizationID, "unknown")),
+		Attr("state", cleanMetricValue(state, "unknown")),
+	)
 }
 
 // ResultForError returns a stable metric result label for common infrastructure

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -13,7 +13,8 @@ import (
 )
 
 var operationDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
-var httpDurationBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10}
+var httpDurationBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 15, 20, 30, 60}
+var tenantPoolMetadataResumeWaitDurationBounds = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 240, 480, 600, 900, 1200}
 
 // sseConnectionDurationBounds covers SSE connection lifetimes, which can
 // range from sub-second probes to long-lived mounts. Buckets extend well
@@ -46,7 +47,7 @@ var serviceOperationsTotal = serviceMeter.Int64Counter("drive9_service_operation
 var serviceOperationDuration = serviceMeter.Float64Histogram("drive9_service_operation_duration_seconds", "Service operation duration histogram", operationDurationBounds)
 var serviceGauge = serviceMeter.Float64Gauge("drive9_service_gauge", "Service gauges by component/name")
 var tenantPoolMetadataResumeWaitTotal = serviceMeter.Int64Counter("drive9_tenant_pool_metadata_resume_wait_total", "Tenant pool metadata resume wait attempts by pool_id/organization_id/scope/result")
-var tenantPoolMetadataResumeWaitDuration = serviceMeter.Float64Histogram("drive9_tenant_pool_metadata_resume_wait_duration_seconds", "Tenant pool metadata resume wait duration by pool_id/organization_id/scope/result", operationDurationBounds)
+var tenantPoolMetadataResumeWaitDuration = serviceMeter.Float64Histogram("drive9_tenant_pool_metadata_resume_wait_duration_seconds", "Tenant pool metadata resume wait duration by pool_id/organization_id/scope/result", tenantPoolMetadataResumeWaitDurationBounds)
 var tenantPoolCapacity = serviceMeter.Float64Gauge("drive9_tenant_pool_capacity", "Tenant pool capacity by pool_id/organization_id/state")
 
 var httpRequestsTotal = httpMeter.Int64Counter("drive9_http_requests_total", "Total HTTP requests by method/route/status")

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-var operationDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30}
+var operationDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600}
 var httpDurationBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 15, 20, 30, 60}
 var tenantPoolMetadataResumeWaitDurationBounds = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 240, 480, 600, 900, 1200}
 

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestResultForError(t *testing.T) {
@@ -55,7 +56,7 @@ func TestRecordTenantPoolMetadataResumeWaitIncludesPoolAndOrganizationID(t *test
 	const poolID = "pool-metadata-resume-metrics-test"
 	const organizationID = "org-metadata-resume-metrics-test"
 
-	RecordTenantPoolMetadataResumeWait(poolID, organizationID, "group", "ok", 0)
+	RecordTenantPoolMetadataResumeWait(poolID, organizationID, "group", "ok", 10*time.Minute)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
@@ -65,6 +66,28 @@ func TestRecordTenantPoolMetadataResumeWaitIncludesPoolAndOrganizationID(t *test
 	}
 	if !strings.Contains(text, `drive9_tenant_pool_metadata_resume_wait_duration_seconds_count{organization_id="`+organizationID+`",pool_id="`+poolID+`",result="ok",scope="group"} 1`) {
 		t.Fatalf("missing tenant pool metadata resume wait duration with pool_id and organization_id:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_pool_metadata_resume_wait_duration_seconds_bucket{organization_id="`+organizationID+`",pool_id="`+poolID+`",result="ok",scope="group",le="480"} 0`) {
+		t.Fatalf("missing 480s tenant pool metadata resume wait duration bucket:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_pool_metadata_resume_wait_duration_seconds_bucket{organization_id="`+organizationID+`",pool_id="`+poolID+`",result="ok",scope="group",le="600"} 1`) {
+		t.Fatalf("missing 600s tenant pool metadata resume wait duration bucket:\n%s", text)
+	}
+}
+
+func TestRecordHTTPRequestIncludesLongWriteLatencyBuckets(t *testing.T) {
+	const route = "/v1/fs/http-long-bucket-test"
+
+	RecordHTTPRequest("POST", route, 200, 25*time.Second)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_http_request_duration_seconds_bucket{method="POST",route="`+route+`",le="20"} 0`) {
+		t.Fatalf("missing 20s HTTP duration bucket:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_http_request_duration_seconds_bucket{method="POST",route="`+route+`",le="30"} 1`) {
+		t.Fatalf("missing 30s HTTP duration bucket:\n%s", text)
 	}
 }
 

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -68,6 +68,24 @@ func TestRecordTenantPoolMetadataResumeWaitIncludesPoolAndOrganizationID(t *test
 	}
 }
 
+func TestRecordTenantPoolCapacityIncludesPoolOrganizationAndState(t *testing.T) {
+	const poolID = "pool-capacity-metrics-test"
+	const organizationID = "org-capacity-metrics-test"
+
+	RecordTenantPoolCapacity(poolID, organizationID, "size", 10)
+	RecordTenantPoolCapacity(poolID, organizationID, "free", 1)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_tenant_pool_capacity{organization_id="`+organizationID+`",pool_id="`+poolID+`",state="size"} 10`) {
+		t.Fatalf("missing tenant pool size capacity gauge:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_pool_capacity{organization_id="`+organizationID+`",pool_id="`+poolID+`",state="free"} 1`) {
+		t.Fatalf("missing tenant pool free capacity gauge:\n%s", text)
+	}
+}
+
 func TestRecordDBOperationOmitsTenantID(t *testing.T) {
 	const tenantID = "tenant-db-operation-test"
 

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -91,6 +91,20 @@ func TestRecordHTTPRequestIncludesLongWriteLatencyBuckets(t *testing.T) {
 	}
 }
 
+func TestRecordOperationIncludesLongAdminTenantPoolUpdateBuckets(t *testing.T) {
+	RecordOperation("admin_tenant_pool", "update", "ok", 5*time.Minute)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_service_operation_duration_seconds_bucket{component="admin_tenant_pool",operation="update",result="ok",le="300"} 1`) {
+		t.Fatalf("missing 300s service operation duration bucket:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_service_operation_duration_seconds_bucket{component="admin_tenant_pool",operation="update",result="ok",le="600"} 1`) {
+		t.Fatalf("missing 600s service operation duration bucket:\n%s", text)
+	}
+}
+
 func TestRecordTenantPoolCapacityIncludesPoolOrganizationAndState(t *testing.T) {
 	const poolID = "pool-capacity-metrics-test"
 	const organizationID = "org-capacity-metrics-test"

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -51,6 +51,23 @@ func TestRecordTenantOperationCountDoesNotRecordDuration(t *testing.T) {
 	}
 }
 
+func TestRecordTenantPoolMetadataResumeWaitIncludesPoolAndOrganizationID(t *testing.T) {
+	const poolID = "pool-metadata-resume-metrics-test"
+	const organizationID = "org-metadata-resume-metrics-test"
+
+	RecordTenantPoolMetadataResumeWait(poolID, organizationID, "group", "ok", 0)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_tenant_pool_metadata_resume_wait_total{organization_id="`+organizationID+`",pool_id="`+poolID+`",result="ok",scope="group"} 1`) {
+		t.Fatalf("missing tenant pool metadata resume wait total with pool_id and organization_id:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_pool_metadata_resume_wait_duration_seconds_count{organization_id="`+organizationID+`",pool_id="`+poolID+`",result="ok",scope="group"} 1`) {
+		t.Fatalf("missing tenant pool metadata resume wait duration with pool_id and organization_id:\n%s", text)
+	}
+}
+
 func TestRecordDBOperationOmitsTenantID(t *testing.T) {
 	const tenantID = "tenant-db-operation-test"
 

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1005,7 +1005,9 @@ func (s *Server) resumePoolClustersMetadataGroups(ctx context.Context, started t
 			groupStarted := time.Now()
 			updated, err := s.waitForPoolClustersMetadata(ctx, group, cred)
 			groupResult := metrics.ResultForError(err)
-			metrics.RecordOperation(adminTenantPoolMetricsComponent, "metadata_resume_group_wait", groupResult, time.Since(groupStarted))
+			groupDuration := time.Since(groupStarted)
+			metrics.RecordOperation(adminTenantPoolMetricsComponent, "metadata_resume_group_wait", groupResult, groupDuration)
+			metrics.RecordTenantPoolMetadataResumeWait(poolID, poolResumeOrganizationID(group), "group", groupResult, groupDuration)
 			recordGroupResult(groupResult)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_metadata_resume_batch_failed",
@@ -1023,7 +1025,9 @@ func (s *Server) resumePoolClustersMetadataGroups(ctx context.Context, started t
 		}()
 	}
 	wg.Wait()
-	metrics.RecordOperation(adminTenantPoolMetricsComponent, "metadata_resume_wait", overallResult, time.Since(waitStarted))
+	waitDuration := time.Since(waitStarted)
+	metrics.RecordOperation(adminTenantPoolMetricsComponent, "metadata_resume_wait", overallResult, waitDuration)
+	metrics.RecordTenantPoolMetadataResumeWait(poolID, poolResumeOrganizationID(clusters), "batch", overallResult, waitDuration)
 }
 
 func poolMetadataResumeGroups(clusters []*tenant.ClusterInfo, groupSize int) [][]*tenant.ClusterInfo {
@@ -1061,6 +1065,18 @@ func poolResumeClusterIDs(clusters []*tenant.ClusterInfo) []string {
 		out = append(out, strings.TrimSpace(cluster.ClusterID))
 	}
 	return out
+}
+
+func poolResumeOrganizationID(clusters []*tenant.ClusterInfo) string {
+	for _, cluster := range clusters {
+		if cluster == nil {
+			continue
+		}
+		if orgID := strings.TrimSpace(cluster.OrganizationID); orgID != "" {
+			return orgID
+		}
+	}
+	return ""
 }
 
 func compactPoolResumeClusters(clusters []*tenant.ClusterInfo) []*tenant.ClusterInfo {
@@ -1484,6 +1500,7 @@ func (s *Server) pendingTenantPoolResumeClusters(ctx context.Context, poolID str
 			continue
 		}
 		cluster := clusterInfoFromTenant(&row.Tenant)
+		cluster.OrganizationID = row.Binding.OrganizationID
 		cluster.Password = string(plainPass)
 		clusters = append(clusters, cluster)
 	}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1024,7 +1024,7 @@ func (s *Server) resumePoolClustersMetadataGroups(ctx context.Context, started t
 	recordGroupResult := func(result string) {
 		overallMu.Lock()
 		defer overallMu.Unlock()
-		if overallResult == "ok" || result == "deadline_exceeded" || result == "canceled" {
+		if adminTenantPoolMetadataResumeResultRank(result) > adminTenantPoolMetadataResumeResultRank(overallResult) {
 			overallResult = result
 		}
 	}
@@ -1061,6 +1061,23 @@ func (s *Server) resumePoolClustersMetadataGroups(ctx context.Context, started t
 	waitDuration := time.Since(waitStarted)
 	metrics.RecordOperation(adminTenantPoolMetricsComponent, "metadata_resume_wait", overallResult, waitDuration)
 	metrics.RecordTenantPoolMetadataResumeWait(poolID, poolResumeOrganizationID(clusters), "batch", overallResult, waitDuration)
+}
+
+func adminTenantPoolMetadataResumeResultRank(result string) int {
+	switch result {
+	case "ok":
+		return 0
+	case "canceled":
+		return 1
+	case "deadline_exceeded":
+		return 2
+	case "bad_conn":
+		return 3
+	case "error":
+		return 4
+	default:
+		return 4
+	}
 }
 
 func poolMetadataResumeGroups(clusters []*tenant.ClusterInfo, groupSize int) [][]*tenant.ClusterInfo {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -235,6 +235,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 					zap.Error(err))
 			}
 		}
+		s.recordTenantPoolCapacity(poolID, orgID, *req.PoolSize, freeSize)
 		writeJSON(w, http.StatusAccepted, adminTenantPoolResponse{
 			PoolID:         poolID,
 			OrganizationID: orgID,
@@ -279,6 +280,7 @@ func (s *Server) handleAdminTenantPoolGet(w http.ResponseWriter, r *http.Request
 		errJSON(w, http.StatusInternalServerError, err.Error())
 		return
 	}
+	s.recordTenantPoolCapacity(pool.PoolID, pool.OrganizationID, pool.Size, freeSize)
 	writeJSON(w, http.StatusOK, adminTenantPoolResponse{
 		PoolID:         pool.PoolID,
 		OrganizationID: pool.OrganizationID,
@@ -456,6 +458,7 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 			FreeSize:       freeSize,
 			Status:         adminTenantPoolDisplayStatus(pool.Status, freeSize, slotSize),
 		}
+		s.recordTenantPoolCapacity(pool.PoolID, pool.OrganizationID, targetSize, freeSize)
 		return nil
 	}); err != nil {
 		metricResult = adminTenantPoolMetricResult(err)
@@ -606,6 +609,7 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 		"free_size", 0,
 		"status", meta.TenantPoolDeleting,
 		"duration_ms", durationMillis(deleteStarted))...)
+	s.recordTenantPoolCapacity(pool.PoolID, pool.OrganizationID, 0, 0)
 	writeJSON(w, http.StatusAccepted, out)
 }
 
@@ -641,6 +645,35 @@ func (s *Server) tenantPoolSizes(ctx context.Context, organizationID string) (in
 		return 0, 0, fmt.Errorf("tenant pool slot size lookup failed")
 	}
 	return freeSize, slotSize, nil
+}
+
+func (s *Server) recordTenantPoolCapacity(poolID, organizationID string, size, freeSize int) {
+	if poolID == "" || organizationID == "" {
+		return
+	}
+	if size < 0 {
+		size = 0
+	}
+	if freeSize < 0 {
+		freeSize = 0
+	}
+	metrics.RecordTenantPoolCapacity(poolID, organizationID, "size", float64(size))
+	metrics.RecordTenantPoolCapacity(poolID, organizationID, "free", float64(freeSize))
+}
+
+func (s *Server) refreshTenantPoolCapacity(ctx context.Context, pool *meta.TenantPool) {
+	if s == nil || s.meta == nil || pool == nil || pool.OrganizationID == "" {
+		return
+	}
+	freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID)
+	if err != nil {
+		logger.Warn(ctx, "admin_tenant_pool_capacity_refresh_failed",
+			zap.String("pool_id", pool.PoolID),
+			zap.String("organization_id", pool.OrganizationID),
+			zap.Error(err))
+		return
+	}
+	s.recordTenantPoolCapacity(pool.PoolID, pool.OrganizationID, pool.Size, freeSize)
 }
 
 func (s *Server) firstManagedOrganization(ctx context.Context, cred tenant.CredentialProvisionRequest) (string, error) {
@@ -1431,6 +1464,7 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				metricResult = "skipped"
 				return nil
 			}
+			defer s.refreshTenantPoolCapacity(ctx, current)
 			slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
@@ -1566,6 +1600,7 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "reason", "pool_inactive", "pool_status", pool.Status, "duration_ms", durationMillis(claimStarted))...)
 		return nil, nil, false, nil
 	}
+	defer s.refreshTenantPoolCapacity(ctx, pool)
 	s.resumePendingTenantPoolAsync(ctx, pool, cred)
 	stageStarted = time.Now()
 	row, err := s.meta.ClaimOldestFreeTenantPoolBinding(ctx, orgID)

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -981,9 +981,19 @@ func (s *Server) startPoolClustersMetadataResume(ctx context.Context, poolID str
 }
 
 func (s *Server) resumePoolClustersMetadataGroups(ctx context.Context, started time.Time, poolID string, clusters []*tenant.ClusterInfo, cred tenant.CredentialProvisionRequest) {
+	waitStarted := time.Now()
 	groups := poolMetadataResumeGroups(clusters, tenantPoolMetadataResumeGroupSize)
 	if len(groups) == 0 {
 		return
+	}
+	overallResult := "ok"
+	var overallMu sync.Mutex
+	recordGroupResult := func(result string) {
+		overallMu.Lock()
+		defer overallMu.Unlock()
+		if overallResult == "ok" || result == "deadline_exceeded" || result == "canceled" {
+			overallResult = result
+		}
 	}
 	var wg sync.WaitGroup
 	for i, group := range groups {
@@ -992,7 +1002,11 @@ func (s *Server) resumePoolClustersMetadataGroups(ctx context.Context, started t
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			groupStarted := time.Now()
 			updated, err := s.waitForPoolClustersMetadata(ctx, group, cred)
+			groupResult := metrics.ResultForError(err)
+			metrics.RecordOperation(adminTenantPoolMetricsComponent, "metadata_resume_group_wait", groupResult, time.Since(groupStarted))
+			recordGroupResult(groupResult)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_metadata_resume_batch_failed",
 					zap.String("pool_id", poolID),
@@ -1009,6 +1023,7 @@ func (s *Server) resumePoolClustersMetadataGroups(ctx context.Context, started t
 		}()
 	}
 	wg.Wait()
+	metrics.RecordOperation(adminTenantPoolMetricsComponent, "metadata_resume_wait", overallResult, time.Since(waitStarted))
 }
 
 func poolMetadataResumeGroups(clusters []*tenant.ClusterInfo, groupSize int) [][]*tenant.ClusterInfo {

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -15,6 +15,17 @@ import (
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
+func TestAdminTenantPoolMetadataResumeResultRank(t *testing.T) {
+	ordered := []string{"ok", "canceled", "deadline_exceeded", "bad_conn", "error", "unknown"}
+	for i := 1; i < len(ordered); i++ {
+		prev := ordered[i-1]
+		next := ordered[i]
+		if adminTenantPoolMetadataResumeResultRank(next) < adminTenantPoolMetadataResumeResultRank(prev) {
+			t.Fatalf("rank(%q) < rank(%q)", next, prev)
+		}
+	}
+}
+
 func TestAdminTenantPoolCreateUsesPrivateEndpointDBTLS(t *testing.T) {
 	t.Setenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT", "1")
 	rt, schemaInitRecorder := newAdminTenantPoolRuntime(t)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5260,8 +5260,11 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 				return
 			}
 			s.schemaInitErrors.Store(tenantID, schemaInitStatusErrorMessage(err))
-			logger.Error(ctx, "server_event", eventFields(ctx, "schema_init_failed", "tenant_id", tenantID, "provider", provider, "attempt", attempt, "error", err)...)
-			if s.metrics != nil {
+			expectedRetryErr := tenantschema.IsExpectedSchemaInitRetryError(err)
+			if !expectedRetryErr {
+				logger.Error(ctx, "server_event", eventFields(ctx, "schema_init_failed", "tenant_id", tenantID, "provider", provider, "attempt", attempt, "error", err)...)
+			}
+			if s.metrics != nil && !expectedRetryErr {
 				s.metrics.recordEvent(tenantID, "tenant_schema_init", "provider", provider, "result", "error")
 			}
 			remaining := time.Until(deadline)
@@ -5274,7 +5277,15 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 						zap.String("provider", provider),
 						zap.String("reason", "status_changed"))
 				}
-				logger.Error(ctx, "schema_init_retry_exhausted", zap.String("tenant_id", tenantID), zap.Error(err))
+				if expectedRetryErr {
+					logger.Warn(ctx, "schema_init_retry_exhausted",
+						zap.String("tenant_id", tenantID),
+						zap.String("provider", provider),
+						zap.Int("attempt", attempt),
+						zap.Error(err))
+				} else {
+					logger.Error(ctx, "schema_init_retry_exhausted", zap.String("tenant_id", tenantID), zap.Error(err))
+				}
 				return
 			}
 			logger.Warn(ctx, "schema_init_attempt_failed",
@@ -5282,6 +5293,7 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 				zap.String("provider", provider),
 				zap.Int("attempt", attempt),
 				zap.String("remaining", remaining.Round(time.Second).String()),
+				zap.Bool("business_event_recorded", !expectedRetryErr),
 				zap.Error(err),
 			)
 		}

--- a/pkg/tenant/schema/common.go
+++ b/pkg/tenant/schema/common.go
@@ -181,6 +181,15 @@ func execSchemaStatement(ctx context.Context, db *sql.DB, stmt string, index, co
 				zap.Error(err))
 			return nil
 		}
+		if IsTransientSchemaError(err) {
+			logger.Warn(ctx, "schema_statement_exec_retryable_failed",
+				zap.Int("statement_index", index),
+				zap.Int("statement_count", count),
+				zap.String("statement", snippet),
+				zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0),
+				zap.Error(err))
+			return fmt.Errorf("exec %q: %w", snippet, err)
+		}
 		logger.Error(ctx, "schema_statement_exec_failed",
 			zap.Int("statement_index", index),
 			zap.Int("statement_count", count),
@@ -230,6 +239,15 @@ func ExecOptionalSchemaStatements(ctx context.Context, db *sql.DB, stmts []strin
 					zap.Error(err))
 				continue
 			}
+			if IsTransientSchemaError(err) {
+				logger.Warn(ctx, "optional_schema_statement_exec_retryable_failed",
+					zap.Int("statement_index", i+1),
+					zap.Int("statement_count", len(stmts)),
+					zap.String("statement", snippet),
+					zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0),
+					zap.Error(err))
+				return skipped, fmt.Errorf("exec optional %q: %w", snippet, err)
+			}
 			logger.Error(ctx, "optional_schema_statement_exec_failed",
 				zap.Int("statement_index", i+1),
 				zap.Int("statement_count", len(stmts)),
@@ -250,6 +268,32 @@ func ExecOptionalSchemaStatements(ctx context.Context, db *sql.DB, stmts []strin
 func HasMultiStatements(dsn string) bool {
 	lower := strings.ToLower(dsn)
 	return strings.Contains(lower, "multistatements=true") || strings.Contains(lower, "multistatements=1")
+}
+
+// IsBenignSchemaError reports idempotent DDL errors that can arise when two
+// schema initializers race and one has already applied the same change.
+func IsBenignSchemaError(err error) bool {
+	return isIgnorableSchemaError(err)
+}
+
+// IsTransientSchemaError reports retryable TiDB DDL metadata races.
+func IsTransientSchemaError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 8028 {
+		return true
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "information schema is changed during the execution of the statement") ||
+		strings.Contains(msg, "[try again later]")
+}
+
+// IsExpectedSchemaInitRetryError reports schema init failures that are noisy
+// but expected during concurrent or eventually consistent DDL setup.
+func IsExpectedSchemaInitRetryError(err error) bool {
+	return IsBenignSchemaError(err) || IsTransientSchemaError(err)
 }
 
 func isIgnorableSchemaError(err error) bool {

--- a/pkg/tenant/schema/common_test.go
+++ b/pkg/tenant/schema/common_test.go
@@ -1,0 +1,59 @@
+package schema
+
+import (
+	"fmt"
+	"testing"
+
+	mysql "github.com/go-sql-driver/mysql"
+)
+
+func TestIsExpectedSchemaInitRetryError(t *testing.T) {
+	tests := []struct {
+		name          string
+		err           error
+		wantTransient bool
+		wantExpected  bool
+	}{
+		{
+			name:          "tidb information schema changed code",
+			err:           &mysql.MySQLError{Number: 8028, Message: "Information schema is changed during the execution of the statement [try again later]"},
+			wantTransient: true,
+			wantExpected:  true,
+		},
+		{
+			name:          "wrapped tidb retry message",
+			err:           fmt.Errorf("exec ddl: %w", &mysql.MySQLError{Number: 1105, Message: "Information schema is changed during the execution of the statement [try again later]"}),
+			wantTransient: true,
+			wantExpected:  true,
+		},
+		{
+			name:          "duplicate column",
+			err:           &mysql.MySQLError{Number: 1060, Message: "Duplicate column name 'worktree_name'"},
+			wantTransient: false,
+			wantExpected:  true,
+		},
+		{
+			name:          "table already exists",
+			err:           &mysql.MySQLError{Number: 1050, Message: "Table 'fs_nodes' already exists"},
+			wantTransient: false,
+			wantExpected:  true,
+		},
+		{
+			name:          "ordinary ddl error",
+			err:           &mysql.MySQLError{Number: 1146, Message: "Table 'missing' doesn't exist"},
+			wantTransient: false,
+			wantExpected:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsTransientSchemaError(tt.err); got != tt.wantTransient {
+				t.Fatalf("IsTransientSchemaError() = %v, want %v", got, tt.wantTransient)
+			}
+			if got := IsExpectedSchemaInitRetryError(tt.err); got != tt.wantExpected {
+				t.Fatalf("IsExpectedSchemaInitRetryError() = %v, want %v", got, tt.wantExpected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- record admin tenant pool metadata resume wait duration across all groups
- record per-group metadata wait duration with deterministic result labels
- add pool-scoped metadata resume wait metrics with pool_id and TiDB Cloud organization_id labels
- add tenant pool capacity gauge with pool_id and organization_id labels
- suppress noisy schema-init business error events for expected transient TiDB DDL races / already-exists cases
- extend histogram buckets so minute-scale metadata resume waits, relaxed HTTP write latency alerts, and admin tenant pool update latency alerts are reachable

## Metrics
- drive9_service_operations_total / drive9_service_operation_duration_seconds with component="admin_tenant_pool", operation="metadata_resume_wait"
- drive9_service_operations_total / drive9_service_operation_duration_seconds with component="admin_tenant_pool", operation="metadata_resume_group_wait"
- drive9_tenant_pool_metadata_resume_wait_total{pool_id,organization_id,scope,result}
- drive9_tenant_pool_metadata_resume_wait_duration_seconds{pool_id,organization_id,scope,result}
- drive9_tenant_pool_capacity{pool_id,organization_id,state}

## Tests
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/metrics -count=1
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -run 'TestAdminTenantPoolMetadataResumeResultRank|TestTenantPoolMetadataResume|TestAdminTenantPool' -count=1