### PR TITLE
Surface TiDB Cloud client errors

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -187,7 +187,8 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 				"error", err)...)
 			s.deleteTenantPoolMetadata(ctx, poolID, "create_free_tenants_error")
 			metricResult = "cluster_error"
-			errJSON(w, http.StatusBadGateway, fmt.Sprintf("create tenant pool failed: %v", err))
+			status, msg := clientFacingErrorResponse(http.StatusBadGateway, "create tenant pool failed", err)
+			errJSON(w, status, msg)
 			return nil
 		}
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_create_free_tenants_done",
@@ -370,7 +371,8 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 					"grow_count", growCount,
 					"duration_ms", durationMillis(stageStarted),
 					"error", err)...)
-				return adminTenantPoolError(http.StatusBadGateway, fmt.Sprintf("grow tenant pool failed: %v", err))
+				status, msg := clientFacingErrorResponse(http.StatusBadGateway, "grow tenant pool failed", err)
+				return adminTenantPoolError(status, msg)
 			}
 			for _, res := range results {
 				s.startProvisionedTenantSchemaInit(ctx, res)
@@ -413,7 +415,8 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 					"deleted_count", deleted,
 					"duration_ms", durationMillis(stageStarted),
 					"error", err)...)
-				return adminTenantPoolError(http.StatusBadGateway, fmt.Sprintf("shrink tenant pool failed: %v", err))
+				status, msg := clientFacingErrorResponse(http.StatusBadGateway, "shrink tenant pool failed", err)
+				return adminTenantPoolError(status, msg)
 			}
 			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_shrink_done",
 				"provider", tenant.ProviderTiDBCloudNative,
@@ -562,7 +565,8 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 			"organization_id", pool.OrganizationID)...)
 		deleted, err := s.deleteNewestFreePoolTenants(ctx, pool.PoolID, pool.OrganizationID, 0, cred, true)
 		if err != nil {
-			return adminTenantPoolError(http.StatusBadGateway, fmt.Sprintf("delete tenant pool failed: %v", err))
+			status, msg := clientFacingErrorResponse(http.StatusBadGateway, "delete tenant pool failed", err)
+			return adminTenantPoolError(status, msg)
 		}
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_delete_free_tenants_done",
 			"provider", tenant.ProviderTiDBCloudNative,

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -172,7 +172,8 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_started", "provider", tenant.ProviderTiDBCloudNative, "quota_requested", quotaOpt != nil)...)
 	if res, pool, claimed, err := s.claimAdminTenantFromPool(r.Context(), cred, quotaOpt); err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_failed", "provider", tenant.ProviderTiDBCloudNative, "duration_ms", durationMillis(poolClaimStarted), "error", err)...)
-		errJSON(w, http.StatusBadGateway, fmt.Sprintf("claim tenant pool tenant failed: %v", err))
+		status, msg := clientFacingErrorResponse(http.StatusBadGateway, "claim tenant pool tenant failed", err)
+		errJSON(w, status, msg)
 		return
 	} else if claimed {
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
@@ -409,7 +410,8 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 		if t.Status != meta.TenantDeleting {
 			_, _ = s.meta.UpdateTenantStatusIf(r.Context(), t.ID, meta.TenantDeleting, t.Status)
 		}
-		errJSON(w, http.StatusBadGateway, fmt.Sprintf("delete tenant cluster failed: %v", err))
+		status, msg := clientFacingErrorResponse(http.StatusBadGateway, "delete tenant cluster failed", err)
+		errJSON(w, status, msg)
 		return
 	}
 	_ = s.meta.AbortActiveUploadReservations(r.Context(), t.ID)
@@ -690,13 +692,11 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 }
 
 func writeAdminTiDBCloudError(w http.ResponseWriter, ctx context.Context, err error, action string) {
-	switch {
-	case errors.Is(err, tenant.ErrQuotaPermissionDenied):
-		errJSON(w, http.StatusForbidden, "no permission to "+action+" with TiDB Cloud API key")
-	case errors.Is(err, tenant.ErrQuotaBackendNotFound):
+	if errors.Is(err, tenant.ErrQuotaBackendNotFound) {
 		errJSON(w, http.StatusNotFound, quotaBackendNotFoundMessage)
-	default:
-		logger.Warn(ctx, "tidbcloud_admin_failed", zap.String("action", action), zap.Error(err))
-		errJSON(w, http.StatusBadGateway, "tidbcloud admin "+action+" failed")
+		return
 	}
+	logger.Warn(ctx, "tidbcloud_admin_failed", zap.String("action", action), zap.Error(err))
+	status, msg := clientFacingErrorResponse(http.StatusBadGateway, "tidbcloud admin "+action+" failed", err)
+	errJSON(w, status, msg)
 }

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -240,6 +240,12 @@ func TestClientFacingErrorResponseMapsTiDBCloudClientErrors(t *testing.T) {
 			wantStatus: http.StatusUnauthorized,
 			wantBody:   "invalid TiDB Cloud API key",
 		},
+		{
+			name:       "generic error hides detail",
+			err:        errors.New("internal upstream detail"),
+			wantStatus: http.StatusBadGateway,
+			wantBody:   "claim tenant pool tenant failed",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			gotStatus, gotMsg := clientFacingErrorResponse(http.StatusBadGateway, "claim tenant pool tenant failed", tc.err)
@@ -251,6 +257,9 @@ func TestClientFacingErrorResponseMapsTiDBCloudClientErrors(t *testing.T) {
 			}
 			if strings.Contains(gotMsg, "requestId") || strings.Contains(gotMsg, "details") {
 				t.Fatalf("msg = %q, should not expose raw TiDB Cloud details", gotMsg)
+			}
+			if strings.Contains(gotMsg, "internal upstream detail") {
+				t.Fatalf("msg = %q, should not expose generic upstream details", gotMsg)
 			}
 		})
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -230,7 +230,7 @@ func TestClientFacingErrorResponseMapsTiDBCloudClientErrors(t *testing.T) {
 	}{
 		{
 			name:       "invalid request",
-			err:        errors.New(`update cluster spending limit: tidbcloud native cluster spending limit update status 400: {"code":400,"message":"Scalable cluster can not set spending limit to 0."}`),
+			err:        errors.New(`update cluster spending limit: tidbcloud native cluster spending limit update status 400: {"code":400,"message":"Scalable cluster can not set spending limit to 0.","details":[{"requestId":"202607090625337c3caba58b2eb378ca"}]}`),
 			wantStatus: http.StatusBadRequest,
 			wantBody:   "Scalable cluster can not set spending limit to 0",
 		},
@@ -248,6 +248,9 @@ func TestClientFacingErrorResponseMapsTiDBCloudClientErrors(t *testing.T) {
 			}
 			if !strings.Contains(gotMsg, tc.wantBody) {
 				t.Fatalf("msg = %q, want containing %q", gotMsg, tc.wantBody)
+			}
+			if strings.Contains(gotMsg, "requestId") || strings.Contains(gotMsg, "details") {
+				t.Fatalf("msg = %q, should not expose raw TiDB Cloud details", gotMsg)
 			}
 		})
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -221,6 +221,38 @@ func (f *fakeProvisioner) ProvisionCallCount() int {
 	return int(f.provisionCalls.Load())
 }
 
+func TestClientFacingErrorResponseMapsTiDBCloudClientErrors(t *testing.T) {
+	for _, tc := range []struct {
+		name       string
+		err        error
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:       "invalid request",
+			err:        errors.New(`update cluster spending limit: tidbcloud native cluster spending limit update status 400: {"code":400,"message":"Scalable cluster can not set spending limit to 0."}`),
+			wantStatus: http.StatusBadRequest,
+			wantBody:   "Scalable cluster can not set spending limit to 0",
+		},
+		{
+			name:       "invalid api key",
+			err:        errors.New("list managed clusters: tidbcloud native cluster list status 401: invalid TiDB Cloud API key"),
+			wantStatus: http.StatusUnauthorized,
+			wantBody:   "invalid TiDB Cloud API key",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotStatus, gotMsg := clientFacingErrorResponse(http.StatusBadGateway, "claim tenant pool tenant failed", tc.err)
+			if gotStatus != tc.wantStatus {
+				t.Fatalf("status = %d, want %d; msg=%s", gotStatus, tc.wantStatus, gotMsg)
+			}
+			if !strings.Contains(gotMsg, tc.wantBody) {
+				t.Fatalf("msg = %q, want containing %q", gotMsg, tc.wantBody)
+			}
+		})
+	}
+}
+
 func waitForDeprovisionCalls(t *testing.T, prov *fakeProvisioner, want int32) {
 	t.Helper()
 	deadline := time.Now().Add(2 * time.Second)

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -241,6 +241,12 @@ func TestClientFacingErrorResponseMapsTiDBCloudClientErrors(t *testing.T) {
 			wantBody:   "invalid TiDB Cloud API key",
 		},
 		{
+			name:       "forbidden",
+			err:        errors.New("update quota: tidbcloud native cluster spending limit update status 403: access denied"),
+			wantStatus: http.StatusForbidden,
+			wantBody:   "access denied",
+		},
+		{
 			name:       "generic error hides detail",
 			err:        errors.New("internal upstream detail"),
 			wantStatus: http.StatusBadGateway,

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -234,6 +234,9 @@ func (s *Server) validateQuotaSetRequest(req quotaRequest) error {
 	if req.TiDBCloudSpendingLimit != nil && *req.TiDBCloudSpendingLimit < 0 {
 		return fmt.Errorf("tidbcloud_spending_limit must be non-negative")
 	}
+	if req.TiDBCloudSpendingLimit != nil && *req.TiDBCloudSpendingLimit > 0 && *req.TiDBCloudSpendingLimit < 10 {
+		return fmt.Errorf("tidbcloud_spending_limit must be 0 or at least 10 RMB")
+	}
 	if req.TiDBCloudSpendingLimit != nil && *req.TiDBCloudSpendingLimit > maxInt32 {
 		return fmt.Errorf("tidbcloud_spending_limit is too large")
 	}
@@ -428,15 +431,13 @@ func quotaStorageBytesToSize(sizeBytes int64) int64 {
 const quotaBackendNotFoundMessage = "backend service exception; please check TiDB Cloud starter/native cluster status"
 
 func writeQuotaCredentialError(w http.ResponseWriter, ctx context.Context, err error, action string) {
-	switch {
-	case errors.Is(err, tenant.ErrQuotaPermissionDenied):
-		errJSON(w, http.StatusForbidden, "no permission to "+action+" quota with TiDB Cloud API key")
-	case errors.Is(err, tenant.ErrQuotaBackendNotFound):
+	if errors.Is(err, tenant.ErrQuotaBackendNotFound) {
 		errJSON(w, http.StatusNotFound, quotaBackendNotFoundMessage)
-	default:
-		logger.Warn(ctx, "tidbcloud_quota_failed", zap.String("action", action), zap.Error(err))
-		errJSON(w, http.StatusBadGateway, "tidbcloud quota "+action+" failed")
+		return
 	}
+	logger.Warn(ctx, "tidbcloud_quota_failed", zap.String("action", action), zap.Error(err))
+	status, msg := clientFacingErrorResponse(http.StatusBadGateway, "tidbcloud quota "+action+" failed", err)
+	errJSON(w, status, msg)
 }
 
 func writeQuotaSetError(w http.ResponseWriter, ctx context.Context, err error, action string) {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -926,6 +926,7 @@ func TestQuotaSetRejectsInvalidQuotaValues(t *testing.T) {
 		{name: "file_size_above_server_max", field: "max_file_size", value: 10241, wantErr: "max_file_size must be less than or equal to server max upload size"},
 		{name: "negative_file_count", field: "max_file_count", value: -1, wantErr: "max_file_count must be non-negative"},
 		{name: "negative_spending_limit", field: "tidbcloud_spending_limit", value: -1, wantErr: "tidbcloud_spending_limit must be non-negative"},
+		{name: "small_spending_limit", field: "tidbcloud_spending_limit", value: 9, wantErr: "tidbcloud_spending_limit must be 0 or at least 10 RMB"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4509,7 +4509,18 @@ func clientFacingErrorDetail(err error) string {
 	if err == nil {
 		return ""
 	}
-	return strings.TrimSpace(err.Error())
+	switch {
+	case errors.Is(err, tenant.ErrCredentialsRequired):
+		return tenant.ErrCredentialsRequired.Error()
+	case errors.Is(err, tenant.ErrPartialCredentials):
+		return tenant.ErrPartialCredentials.Error()
+	case errors.Is(err, tenant.ErrQuotaPermissionDenied):
+		return tenant.ErrQuotaPermissionDenied.Error()
+	case errors.Is(err, tenant.ErrQuotaBackendNotFound):
+		return tenant.ErrQuotaBackendNotFound.Error()
+	default:
+		return ""
+	}
 }
 
 func parseTiDBCloudStatusError(err error) (operation string, code int, ok bool) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	pathpkg "path"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -4458,10 +4459,12 @@ func provisionTenantPoolClaimMetricResult(err error) string {
 	return "error"
 }
 
+var tidbCloudStatusErrorPattern = regexp.MustCompile(`tidbcloud native ([A-Za-z0-9 _-]+) status ([0-9]{3})(?:: (.*))?`)
+
 func clientFacingErrorResponse(defaultStatus int, defaultMessage string, err error) (int, string) {
 	msg := strings.TrimSpace(defaultMessage)
 	if err != nil {
-		detail := strings.TrimSpace(err.Error())
+		detail := clientFacingErrorDetail(err)
 		if detail != "" {
 			if msg != "" {
 				msg += ": " + detail
@@ -4488,11 +4491,65 @@ func clientFacingErrorResponse(defaultStatus int, defaultMessage string, err err
 }
 
 func isTiDBCloudStatusError(err error, code int) bool {
-	if err == nil {
-		return false
+	_, got, ok := parseTiDBCloudStatusError(err)
+	return ok && got == code
+}
+
+func clientFacingErrorDetail(err error) string {
+	if operation, code, ok := parseTiDBCloudStatusError(err); ok {
+		body := strings.TrimSpace(tidbCloudStatusBody(err))
+		if msg := tidbCloudStatusMessage(body); msg != "" {
+			return msg
+		}
+		if body != "" {
+			return fmt.Sprintf("TiDB Cloud %s failed with status %d: %s", operation, code, body)
+		}
+		return fmt.Sprintf("TiDB Cloud %s failed with status %d", operation, code)
 	}
-	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "tidbcloud native ") && strings.Contains(msg, fmt.Sprintf(" status %d", code))
+	if err == nil {
+		return ""
+	}
+	return strings.TrimSpace(err.Error())
+}
+
+func parseTiDBCloudStatusError(err error) (operation string, code int, ok bool) {
+	if err == nil {
+		return "", 0, false
+	}
+	matches := tidbCloudStatusErrorPattern.FindStringSubmatch(err.Error())
+	if len(matches) == 0 {
+		return "", 0, false
+	}
+	code, convErr := strconv.Atoi(matches[2])
+	if convErr != nil {
+		return "", 0, false
+	}
+	return strings.TrimSpace(matches[1]), code, true
+}
+
+func tidbCloudStatusBody(err error) string {
+	if err == nil {
+		return ""
+	}
+	matches := tidbCloudStatusErrorPattern.FindStringSubmatch(err.Error())
+	if len(matches) < 4 {
+		return ""
+	}
+	return strings.TrimSpace(matches[3])
+}
+
+func tidbCloudStatusMessage(body string) string {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return ""
+	}
+	var decoded struct {
+		Message string `json:"message"`
+	}
+	if strings.HasPrefix(body, "{") && json.Unmarshal([]byte(body), &decoded) == nil && strings.TrimSpace(decoded.Message) != "" {
+		return strings.TrimSpace(decoded.Message)
+	}
+	return body
 }
 
 func writeProvisionTenantAccepted(w http.ResponseWriter, res *provisionTenantResult) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4411,7 +4411,8 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		if res, pool, claimed, err := s.claimAdminTenantFromPool(r.Context(), *credentialReq, quotaReq); err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_failed", "provider", provider, "duration_ms", durationMillis(poolClaimStarted), "error", err)...)
 			metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", provisionTenantPoolClaimMetricResult(err))
-			errJSON(w, http.StatusBadGateway, "claim tenant pool tenant failed")
+			status, msg := clientFacingErrorResponse(http.StatusBadGateway, "claim tenant pool tenant failed", err)
+			errJSON(w, status, msg)
 			return
 		} else if claimed {
 			logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
@@ -4455,6 +4456,43 @@ func provisionTenantPoolClaimMetricResult(err error) string {
 		return "cluster_error"
 	}
 	return "error"
+}
+
+func clientFacingErrorResponse(defaultStatus int, defaultMessage string, err error) (int, string) {
+	msg := strings.TrimSpace(defaultMessage)
+	if err != nil {
+		detail := strings.TrimSpace(err.Error())
+		if detail != "" {
+			if msg != "" {
+				msg += ": " + detail
+			} else {
+				msg = detail
+			}
+		}
+	}
+	if msg == "" {
+		msg = http.StatusText(defaultStatus)
+	}
+	switch {
+	case errors.Is(err, tenant.ErrCredentialsRequired), errors.Is(err, tenant.ErrPartialCredentials):
+		return http.StatusBadRequest, msg
+	case isTiDBCloudStatusError(err, http.StatusBadRequest):
+		return http.StatusBadRequest, msg
+	case isTiDBCloudStatusError(err, http.StatusUnauthorized):
+		return http.StatusUnauthorized, msg
+	case errors.Is(err, tenant.ErrQuotaPermissionDenied), isTiDBCloudStatusError(err, http.StatusForbidden):
+		return http.StatusForbidden, msg
+	default:
+		return defaultStatus, msg
+	}
+}
+
+func isTiDBCloudStatusError(err error, code int) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "tidbcloud native ") && strings.Contains(msg, fmt.Sprintf(" status %d", code))
 }
 
 func writeProvisionTenantAccepted(w http.ResponseWriter, res *provisionTenantResult) {
@@ -4950,19 +4988,19 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_cluster_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "cluster_error")
 		s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "cluster_provision_error")
-		msg := fmt.Sprintf("provision tenant cluster failed: %v", err)
-		if strings.Contains(strings.ToLower(err.Error()), "free cluster") {
-			msg = "TiDB Cloud free cluster limit reached. Set a monthly Spending Limit to continue. See https://www.pingcap.com/tidb-cloud-starter-pricing-details/#cost-and-limitations"
-		} else if strings.Contains(strings.ToLower(err.Error()), "credits") || strings.Contains(strings.ToLower(err.Error()), "payment") {
-			msg = "TiDB Cloud payment required. Add a payment method at https://tidbcloud.com/org-settings/billing/payments"
-		} else if strings.Contains(strings.ToLower(err.Error()), "instance capacity limit") || strings.Contains(strings.ToLower(err.Error()), "capacity limit") {
-			msg = "TiDB Cloud cluster capacity limit reached"
-		} else if strings.Contains(strings.ToLower(err.Error()), "status 401") || strings.Contains(strings.ToLower(err.Error()), "invalid tidb cloud") || strings.Contains(strings.ToLower(err.Error()), "unauthorized") {
-			msg = "invalid TiDB Cloud API key"
-		} else if strings.Contains(strings.ToLower(err.Error()), "cluster limit") {
-			msg = "TiDB Cloud cluster limit reached (100 clusters per organization). Contact PingCAP support for assistance."
+		status, msg := clientFacingErrorResponse(http.StatusBadGateway, "provision tenant cluster failed", err)
+		if status == http.StatusBadGateway {
+			if strings.Contains(strings.ToLower(err.Error()), "free cluster") {
+				msg = "TiDB Cloud free cluster limit reached. Set a monthly Spending Limit to continue. See https://www.pingcap.com/tidb-cloud-starter-pricing-details/#cost-and-limitations"
+			} else if strings.Contains(strings.ToLower(err.Error()), "credits") || strings.Contains(strings.ToLower(err.Error()), "payment") {
+				msg = "TiDB Cloud payment required. Add a payment method at https://tidbcloud.com/org-settings/billing/payments"
+			} else if strings.Contains(strings.ToLower(err.Error()), "instance capacity limit") || strings.Contains(strings.ToLower(err.Error()), "capacity limit") {
+				msg = "TiDB Cloud cluster capacity limit reached"
+			} else if strings.Contains(strings.ToLower(err.Error()), "cluster limit") {
+				msg = "TiDB Cloud cluster limit reached (100 clusters per organization). Contact PingCAP support for assistance."
+			}
 		}
-		return nil, newProvisionTenantError(http.StatusBadGateway, msg, err)
+		return nil, newProvisionTenantError(status, msg, err)
 	}
 	logProvisionStage(ctx, "provision_cluster_provisioned", tenantID, provider, stageStarted, "mode", provisionMode, "cluster_id", cluster.ClusterID, "organization_id", cluster.OrganizationID)
 	cluster.Provider = provider

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -130,7 +130,8 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 		if t.Status != meta.TenantDeleting {
 			_, _ = s.meta.UpdateTenantStatusIf(r.Context(), t.ID, meta.TenantDeleting, t.Status)
 		}
-		errJSON(w, http.StatusBadGateway, fmt.Sprintf("delete tenant cluster failed: %v", err))
+		status, msg := clientFacingErrorResponse(http.StatusBadGateway, "delete tenant cluster failed", err)
+		errJSON(w, status, msg)
 		return
 	}
 

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1254,6 +1254,9 @@ func validateTiDBCloudSpendingLimit(monthly int64) error {
 	if monthly < 0 {
 		return fmt.Errorf("tidbcloud_spending_limit must be non-negative")
 	}
+	if monthly > 0 && monthly < 10 {
+		return fmt.Errorf("tidbcloud_spending_limit must be 0 or at least 10 RMB")
+	}
 	if monthly > maxInt32 {
 		return fmt.Errorf("tidbcloud_spending_limit is too large")
 	}

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1366,6 +1366,9 @@ func parseDefaultSpendLimit(raw string) (*int32, error) {
 	if err != nil || monthly < 0 {
 		return nil, fmt.Errorf("invalid %s value %q: must be a non-negative integer", EnvTiDBCloudDefaultSpendingLimit, raw)
 	}
+	if err := validateTiDBCloudSpendingLimit(monthly); err != nil {
+		return nil, fmt.Errorf("invalid %s value %q: %w", EnvTiDBCloudDefaultSpendingLimit, raw, err)
+	}
 	out := int32(monthly)
 	return &out, nil
 }

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -59,6 +59,24 @@ func TestNewProvisionerFromEnvUsesBuiltinDefaultSpendingLimit(t *testing.T) {
 	}
 }
 
+func TestNewProvisionerFromEnvRejectsTooSmallDefaultSpendingLimit(t *testing.T) {
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+	t.Setenv(EnvTiDBCloudDefaultSpendingLimit, "5")
+
+	_, err := NewProvisionerFromEnv()
+	if err == nil {
+		t.Fatal("expected invalid default spending limit error")
+	}
+	if !strings.Contains(err.Error(), EnvTiDBCloudDefaultSpendingLimit) {
+		t.Fatalf("error = %v, want env name", err)
+	}
+	if !strings.Contains(err.Error(), "must be 0 or at least 10 RMB") {
+		t.Fatalf("error = %v, want spending-limit floor", err)
+	}
+}
+
 func TestNewProvisionerFromEnvRequiresCloudProviderAndRegion(t *testing.T) {
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "")


### PR DESCRIPTION
## Summary
- return client-facing TiDB Cloud 400/401/403 errors instead of hiding them behind generic 502 responses
- apply the shared mapping across provision, admin tenant pool, quota, TiDB Cloud admin, and tenant delete cluster paths
- reject tidbcloud_spending_limit values between 1 and 9 RMB locally before calling TiDB Cloud

## Behavior
- TiDB Cloud status 400 -> HTTP 400 with upstream detail
- TiDB Cloud status 401 -> HTTP 401 with upstream detail
- TiDB Cloud status 403 / quota permission denied -> HTTP 403 with detail
- server/internal failures still keep their default generic status/message

## Tests
- go test ./pkg/server -run 'TestClientFacingErrorResponseMapsTiDBCloudClientErrors|TestQuotaSetRejectsInvalidQuotaValues|TestTenantPool|TestAdminTenantPool|TestProvision'
- go test ./pkg/tenant/tidbcloudnative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved error messages for tenant pool, tenant creation, deletion, and quota-related failures so clients receive clearer, safer responses.

* **Bug Fixes**
  * Updated TiDB Cloud error handling to return more accurate HTTP statuses in common failure cases.
  * Tightened spending limit validation: positive values must now be at least 10 RMB, or set to 0.
  * Prevented sensitive upstream error details from being exposed to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->