### PR TITLE
feat(fuse): reexec preflight gate + state snapshot helpers

### DIFF
--- a/pkg/fuse/reexec_gate.go
+++ b/pkg/fuse/reexec_gate.go
@@ -1,0 +1,272 @@
+package fuse
+
+import (
+	"os"
+	"sync"
+	"sync/atomic"
+)
+
+// ReexecProtocolVersion is the wire protocol version for the reexec handshake.
+// Both old and new processes must advertise the same version.
+const ReexecProtocolVersion = 1
+
+// ReexecRefusal describes a single reason why reexec was refused.
+type ReexecRefusal struct {
+	Gate   string `json:"gate"`
+	Reason string `json:"reason"`
+	Count  int    `json:"count,omitempty"`
+}
+
+// ReexecPreflightResult holds the complete preflight check output.
+type ReexecPreflightResult struct {
+	OK       bool            `json:"ok"`
+	Refusals []ReexecRefusal `json:"refusals,omitempty"`
+}
+
+// reexecGuard prevents concurrent reexec attempts.
+type reexecGuard struct {
+	mu     sync.Mutex
+	active atomic.Bool
+}
+
+func (g *reexecGuard) tryAcquire() bool {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.active.Load() {
+		return false
+	}
+	g.active.Store(true)
+	return true
+}
+
+func (g *reexecGuard) release() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.active.Store(false)
+}
+
+func (g *reexecGuard) isActive() bool {
+	return g.active.Load()
+}
+
+// ReexecPreflight checks all V0 gates and returns structured refusal reasons.
+// It does NOT acquire the reexec guard or install a quiesce barrier — those
+// are the caller's responsibility during the actual handshake.
+//
+// This function is only valid for normal FUSE mounts. Vault and WebDAV mounts
+// have separate codepaths and are excluded from V0 reexec by design.
+func (fs *Dat9FS) ReexecPreflight() ReexecPreflightResult {
+	var refusals []ReexecRefusal
+	refuse := func(gate, reason string, count int) {
+		refusals = append(refusals, ReexecRefusal{Gate: gate, Reason: reason, Count: count})
+	}
+
+	// --- Static scope checks ---
+
+	if fs.localOverlay != nil {
+		refuse("local_overlay", "user/profile local overlay is enabled", 0)
+	}
+
+	if n := fs.transientOverlayEntryCount(); n > 0 {
+		refuse("transient_overlay", "transient local overlay has entries", n)
+	}
+
+	if fs.git != nil {
+		refuse("git_workspace", "git workspace layer is enabled", 0)
+	}
+
+	if fs.hasLayerOverlayState() {
+		refuse("layer_overlay", "FS layer overlay state is active", 0)
+	}
+
+	// --- Runtime clean-state checks ---
+
+	if fs.fileHandles != nil {
+		if n := fs.fileHandles.Len(); n > 0 {
+			refuse("file_handles", "open file handles exist", n)
+		}
+	}
+
+	if fs.dirHandles != nil {
+		if n := fs.dirHandles.Len(); n > 0 {
+			refuse("dir_handles", "open directory handles exist", n)
+		}
+	}
+
+	if n := fs.nonRootKernelLookupCount(); n > 0 {
+		refuse("inode_nlookup", "non-root inodes have positive kernel lookup refs", n)
+	}
+
+	if n := fs.heldLockCount(); n > 0 {
+		refuse("fuse_locks", "FUSE locks are held", n)
+	}
+
+	if n := fs.xattrCount(); n > 0 {
+		refuse("xattrs", "in-memory xattrs exist", n)
+	}
+
+	if fs.commitQueue != nil {
+		snap := fs.commitQueue.Snapshot()
+		if snap.Pending > 0 {
+			refuse("commit_queue_pending", "commit queue has pending entries", snap.Pending)
+		}
+		if snap.InFlight > 0 {
+			refuse("commit_queue_inflight", "commit queue has in-flight entries", snap.InFlight)
+		}
+		if snap.Delayed > 0 {
+			refuse("commit_queue_delayed", "commit queue has delayed entries", snap.Delayed)
+		}
+		if snap.Conflicts > 0 {
+			refuse("commit_queue_conflicts", "commit queue has conflicts", snap.Conflicts)
+		}
+	}
+
+	if fs.uploader != nil {
+		snap := fs.uploader.Snapshot()
+		if snap.Queued > 0 {
+			refuse("uploader_queued", "uploader has queued entries", snap.Queued)
+		}
+		if snap.InFlight > 0 {
+			refuse("uploader_inflight", "uploader has in-flight entries", snap.InFlight)
+		}
+		if snap.Cached > 0 {
+			refuse("uploader_cached", "uploader has cached entries", snap.Cached)
+		}
+	}
+
+	if fs.pendingIndex != nil {
+		if n := fs.pendingIndex.Count(); n > 0 {
+			refuse("pending_index", "pending index has entries", n)
+		}
+	}
+
+	if fs.shadowStore != nil {
+		if n := fs.shadowStore.PendingBytes(); n > 0 {
+			refuse("shadow_store", "shadow store has pending bytes", int(n))
+		}
+	}
+
+	if fs.journal != nil {
+		if n := journalFrameCount(fs.journal); n > 0 {
+			refuse("journal", "journal has replay-required frames", n)
+		}
+	}
+
+	return ReexecPreflightResult{
+		OK:       len(refusals) == 0,
+		Refusals: refusals,
+	}
+}
+
+// --- Count helpers for types that don't have them yet ---
+
+func (fs *Dat9FS) nonRootKernelLookupCount() int {
+	if fs.inodes == nil {
+		return 0
+	}
+	return fs.inodes.NonRootLookupCount()
+}
+
+// NonRootLookupCount returns the number of non-root inodes with positive
+// kernel lookup references (Nlookup > 0).
+func (m *InodeToPath) NonRootLookupCount() int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	count := 0
+	for ino, entry := range m.byInode {
+		if ino != 1 && entry.Nlookup > 0 {
+			count++
+		}
+	}
+	return count
+}
+
+func (fs *Dat9FS) heldLockCount() int {
+	if fs.locks == nil {
+		return 0
+	}
+	return fs.locks.totalCount()
+}
+
+// totalCount returns the total number of held locks across all inodes.
+func (t *fuseLockTable) totalCount() int {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	count := 0
+	for _, locks := range t.locks {
+		count += len(locks)
+	}
+	return count
+}
+
+func (fs *Dat9FS) xattrCount() int {
+	if fs.xattrs == nil {
+		return 0
+	}
+	return fs.xattrs.TotalCount()
+}
+
+// TotalCount returns the total number of xattr entries across all paths.
+func (s *XAttrStore) TotalCount() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	count := 0
+	for _, attrs := range s.data {
+		count += len(attrs)
+	}
+	return count
+}
+
+func (fs *Dat9FS) transientOverlayEntryCount() int {
+	if fs.transientLocalOverlay == nil {
+		return 0
+	}
+	return localOverlayEntryCount(fs.transientLocalOverlay)
+}
+
+// localOverlayEntryCount returns the number of filesystem entries under the
+// overlay root directory. Returns 0 if the root does not exist.
+func localOverlayEntryCount(o *LocalOverlay) int {
+	if o == nil || o.root == "" {
+		return 0
+	}
+	entries, err := os.ReadDir(o.root)
+	if err != nil {
+		return 0
+	}
+	return len(entries)
+}
+
+func (fs *Dat9FS) hasLayerOverlayState() bool {
+	fs.layerMu.RLock()
+	defer fs.layerMu.RUnlock()
+	return len(fs.layerWhiteouts) > 0 || len(fs.layerFiles) > 0 ||
+		len(fs.layerDirs) > 0 || len(fs.layerSymlinks) > 0
+}
+
+// journalFrameCount returns the number of uncommitted frames in the journal.
+func journalFrameCount(j *Journal) int {
+	if j == nil || j.path == "" {
+		return 0
+	}
+	data, err := os.ReadFile(j.path)
+	if err != nil || len(data) == 0 {
+		return 0
+	}
+	committed := make(map[string]bool)
+	var pending []string
+	scanJournalFrames(data, func(entry JournalEntry, _ []byte) {
+		if entry.Op == JournalCommit {
+			committed[entry.Path] = true
+		} else {
+			pending = append(pending, entry.Path)
+		}
+	})
+	count := 0
+	for _, p := range pending {
+		if !committed[p] {
+			count++
+		}
+	}
+	return count
+}

--- a/pkg/fuse/reexec_gate.go
+++ b/pkg/fuse/reexec_gate.go
@@ -255,12 +255,15 @@ func (fs *Dat9FS) hasLayerOverlayState() bool {
 		len(fs.layerDirs) > 0 || len(fs.layerSymlinks) > 0
 }
 
-// UncommittedFrameCount returns the number of uncommitted frames in the
-// journal. It acquires j.mu to prevent races with concurrent Append calls.
+// UncommittedFrameCount returns the number of paths that have replay-required
+// journal state: a JournalFsync entry not superseded by a later
+// JournalCommit/JournalUnlink. This mirrors the classification logic of
+// replayJournalIntoPending so that preflight and crash recovery agree on
+// what constitutes dirty journal state.
 //
-// This assumes the caller has already drained (Drain + Fsync) before
-// preflight, so all buffered writes are on disk. If called without a prior
-// drain, buffered writes not yet flushed could be missed.
+// It acquires j.mu to prevent races with concurrent Append calls.
+// The caller should drain (Drain + Fsync) before calling so all buffered
+// writes are on disk.
 func (j *Journal) UncommittedFrameCount() int {
 	j.mu.Lock()
 	defer j.mu.Unlock()
@@ -272,20 +275,28 @@ func (j *Journal) UncommittedFrameCount() int {
 	if err != nil || len(data) == 0 {
 		return 0
 	}
-	committed := make(map[string]bool)
-	var pending []string
+
+	latestData := make(map[string]uint64) // path → latest JournalFsync seq
+	latestDone := make(map[string]uint64) // path → latest JournalCommit/Unlink seq
 	scanJournalFrames(data, func(entry JournalEntry, _ []byte) {
-		if entry.Op == JournalCommit {
-			committed[entry.Path] = true
-		} else {
-			pending = append(pending, entry.Path)
+		switch entry.Op {
+		case JournalCommit, JournalUnlink:
+			if entry.Seq > latestDone[entry.Path] {
+				latestDone[entry.Path] = entry.Seq
+			}
+		case JournalFsync:
+			if entry.Seq > latestData[entry.Path] {
+				latestData[entry.Path] = entry.Seq
+			}
 		}
 	})
+
 	count := 0
-	for _, p := range pending {
-		if !committed[p] {
-			count++
+	for path, dataSeq := range latestData {
+		if doneSeq, ok := latestDone[path]; ok && doneSeq > dataSeq {
+			continue
 		}
+		count++
 	}
 	return count
 }

--- a/pkg/fuse/reexec_gate.go
+++ b/pkg/fuse/reexec_gate.go
@@ -7,6 +7,7 @@ import (
 
 // ReexecProtocolVersion is the wire protocol version for the reexec handshake.
 // Both old and new processes must advertise the same version.
+// Consumed by the fd handoff protocol in Phase 3.
 const ReexecProtocolVersion = 1
 
 // ReexecRefusal describes a single reason why reexec was refused.
@@ -68,8 +69,12 @@ func (fs *Dat9FS) ReexecPreflight() ReexecPreflightResult {
 		refuse("local_overlay", "user/profile local overlay is enabled", 0)
 	}
 
-	if n := fs.transientOverlayEntryCount(); n > 0 {
-		refuse("transient_overlay", "transient local overlay has entries", n)
+	if n := fs.transientOverlayEntryCount(); n != 0 {
+		if n < 0 {
+			refuse("transient_overlay", "transient local overlay root cannot be read", 0)
+		} else {
+			refuse("transient_overlay", "transient local overlay has entries", n)
+		}
 	}
 
 	if fs.git != nil {
@@ -148,7 +153,7 @@ func (fs *Dat9FS) ReexecPreflight() ReexecPreflightResult {
 	}
 
 	if fs.journal != nil {
-		if n := journalFrameCount(fs.journal); n > 0 {
+		if n := fs.journal.UncommittedFrameCount(); n > 0 {
 			refuse("journal", "journal has replay-required frames", n)
 		}
 	}
@@ -165,12 +170,12 @@ func (fs *Dat9FS) nonRootKernelLookupCount() int {
 	if fs.inodes == nil {
 		return 0
 	}
-	return fs.inodes.NonRootLookupCount()
+	return fs.inodes.nonRootLookupCount()
 }
 
-// NonRootLookupCount returns the number of non-root inodes with positive
+// nonRootLookupCount returns the number of non-root inodes with positive
 // kernel lookup references (Nlookup > 0).
-func (m *InodeToPath) NonRootLookupCount() int {
+func (m *InodeToPath) nonRootLookupCount() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 	count := 0
@@ -204,11 +209,11 @@ func (fs *Dat9FS) xattrCount() int {
 	if fs.xattrs == nil {
 		return 0
 	}
-	return fs.xattrs.TotalCount()
+	return fs.xattrs.totalCount()
 }
 
-// TotalCount returns the total number of xattr entries across all paths.
-func (s *XAttrStore) TotalCount() int {
+// totalCount returns the total number of xattr entries across all paths.
+func (s *XAttrStore) totalCount() int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	count := 0
@@ -226,14 +231,19 @@ func (fs *Dat9FS) transientOverlayEntryCount() int {
 }
 
 // localOverlayEntryCount returns the number of filesystem entries under the
-// overlay root directory. Returns 0 if the root does not exist.
+// overlay root directory. Returns 0 if the overlay is nil, empty, or the root
+// does not exist. Returns -1 if the root exists but cannot be read (permission
+// error, etc.) — the caller must treat -1 as a refusal, not a clean pass.
 func localOverlayEntryCount(o *LocalOverlay) int {
 	if o == nil || o.root == "" {
 		return 0
 	}
 	entries, err := os.ReadDir(o.root)
 	if err != nil {
-		return 0
+		if os.IsNotExist(err) {
+			return 0
+		}
+		return -1
 	}
 	return len(entries)
 }
@@ -245,13 +255,17 @@ func (fs *Dat9FS) hasLayerOverlayState() bool {
 		len(fs.layerDirs) > 0 || len(fs.layerSymlinks) > 0
 }
 
-// journalFrameCount returns the number of uncommitted frames in the journal.
-// It reads the journal file directly via os.ReadFile. This assumes the caller
-// has already drained (Drain + journal Fsync) before preflight, so all
-// buffered writes are on disk. If called without a prior drain, buffered
-// writes not yet flushed could be missed.
-func journalFrameCount(j *Journal) int {
-	if j == nil || j.path == "" {
+// UncommittedFrameCount returns the number of uncommitted frames in the
+// journal. It acquires j.mu to prevent races with concurrent Append calls.
+//
+// This assumes the caller has already drained (Drain + Fsync) before
+// preflight, so all buffered writes are on disk. If called without a prior
+// drain, buffered writes not yet flushed could be missed.
+func (j *Journal) UncommittedFrameCount() int {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+
+	if j.path == "" {
 		return 0
 	}
 	data, err := os.ReadFile(j.path)

--- a/pkg/fuse/reexec_gate.go
+++ b/pkg/fuse/reexec_gate.go
@@ -3,7 +3,6 @@ package fuse
 import (
 	"os"
 	"sync"
-	"sync/atomic"
 )
 
 // ReexecProtocolVersion is the wire protocol version for the reexec handshake.
@@ -26,27 +25,29 @@ type ReexecPreflightResult struct {
 // reexecGuard prevents concurrent reexec attempts.
 type reexecGuard struct {
 	mu     sync.Mutex
-	active atomic.Bool
+	active bool
 }
 
 func (g *reexecGuard) tryAcquire() bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if g.active.Load() {
+	if g.active {
 		return false
 	}
-	g.active.Store(true)
+	g.active = true
 	return true
 }
 
 func (g *reexecGuard) release() {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	g.active.Store(false)
+	g.active = false
 }
 
 func (g *reexecGuard) isActive() bool {
-	return g.active.Load()
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	return g.active
 }
 
 // ReexecPreflight checks all V0 gates and returns structured refusal reasons.
@@ -245,6 +246,10 @@ func (fs *Dat9FS) hasLayerOverlayState() bool {
 }
 
 // journalFrameCount returns the number of uncommitted frames in the journal.
+// It reads the journal file directly via os.ReadFile. This assumes the caller
+// has already drained (Drain + journal Fsync) before preflight, so all
+// buffered writes are on disk. If called without a prior drain, buffered
+// writes not yet flushed could be missed.
 func journalFrameCount(j *Journal) int {
 	if j == nil || j.path == "" {
 		return 0

--- a/pkg/fuse/reexec_gate_test.go
+++ b/pkg/fuse/reexec_gate_test.go
@@ -214,6 +214,65 @@ func TestReexecPreflightJournalPassesAfterCommit(t *testing.T) {
 	require.False(t, hasJournalRefusal, "journal with committed frames should not refuse")
 }
 
+func TestReexecPreflightRefusesShadowStorePendingBytes(t *testing.T) {
+	dir := t.TempDir()
+	shadowDir := filepath.Join(dir, "shadow")
+	ss, err := NewShadowStore(shadowDir)
+	require.NoError(t, err)
+
+	// Write a shadow file to create pending bytes.
+	shadowPath := filepath.Join(shadowDir, "test.shadow")
+	require.NoError(t, os.WriteFile(shadowPath, []byte("dirty data"), 0o644))
+	ss.RecoverPendingBytes()
+	require.Greater(t, ss.PendingBytes(), int64(0), "shadow store should have pending bytes")
+
+	fs := newTestReexecFS()
+	fs.shadowStore = ss
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "shadow_store" {
+			hasGate = true
+		}
+	}
+	require.True(t, hasGate, "should refuse when shadow store has pending bytes")
+}
+
+func TestReexecPreflightRefusesCommitQueuePendingWork(t *testing.T) {
+	// CommitQueue requires a full client + shadow + pending setup.
+	// Create a minimal CommitQueue with a pending entry via the public API.
+	dir := t.TempDir()
+	shadowDir := filepath.Join(dir, "shadow")
+	ss, err := NewShadowStore(shadowDir)
+	require.NoError(t, err)
+	idx, err := NewPendingIndex(filepath.Join(dir, "pending"))
+	require.NoError(t, err)
+	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
+	require.NoError(t, err)
+
+	cq := NewCommitQueue(nil, ss, idx, j, 1, 100)
+	// Enqueue work — this will fail to commit (nil client) but the entry
+	// stays pending, which is what we need for the snapshot check.
+	seq, err := idx.Put("/test.txt", 10, PendingNew)
+	require.NoError(t, err)
+	_ = seq
+
+	fs := newTestReexecFS()
+	fs.commitQueue = cq
+	fs.pendingIndex = idx
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	// Should have pending_index refusal at minimum
+	hasIndex := false
+	for _, r := range result.Refusals {
+		if r.Gate == "pending_index" {
+			hasIndex = true
+		}
+	}
+	require.True(t, hasIndex, "should refuse when pending index has entries (commit queue scenario)")
+}
+
 func TestReexecPreflightCollectsMultipleRefusals(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.fileHandles.Allocate(&FileHandle{Path: "/a.txt"})

--- a/pkg/fuse/reexec_gate_test.go
+++ b/pkg/fuse/reexec_gate_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
-	"github.com/stretchr/testify/require"
 )
 
 func newTestReexecFS() *Dat9FS {
@@ -24,42 +23,55 @@ func newTestReexecFS() *Dat9FS {
 func TestReexecPreflightIdleMount(t *testing.T) {
 	fs := newTestReexecFS()
 	result := fs.ReexecPreflight()
-	require.True(t, result.OK, "idle mount should pass preflight")
-	require.Empty(t, result.Refusals)
+	if !result.OK {
+		t.Fatalf("idle mount should pass preflight, got refusals: %+v", result.Refusals)
+	}
+	if len(result.Refusals) != 0 {
+		t.Fatalf("expected no refusals, got %d", len(result.Refusals))
+	}
 }
 
 func TestReexecPreflightRefusesOpenFileHandle(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.fileHandles.Allocate(&FileHandle{Path: "/test.txt"})
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	require.Len(t, result.Refusals, 1)
-	require.Equal(t, "file_handles", result.Refusals[0].Gate)
-	require.Equal(t, 1, result.Refusals[0].Count)
+	if result.OK {
+		t.Fatal("expected preflight to fail with open file handle")
+	}
+	if len(result.Refusals) != 1 {
+		t.Fatalf("expected 1 refusal, got %d", len(result.Refusals))
+	}
+	if result.Refusals[0].Gate != "file_handles" {
+		t.Fatalf("expected gate file_handles, got %s", result.Refusals[0].Gate)
+	}
+	if result.Refusals[0].Count != 1 {
+		t.Fatalf("expected count 1, got %d", result.Refusals[0].Count)
+	}
 }
 
 func TestReexecPreflightRefusesOpenDirHandle(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.dirHandles.Allocate(&DirHandle{Path: "/"})
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	require.Len(t, result.Refusals, 1)
-	require.Equal(t, "dir_handles", result.Refusals[0].Gate)
+	if result.OK {
+		t.Fatal("expected preflight to fail with open dir handle")
+	}
+	if len(result.Refusals) != 1 {
+		t.Fatalf("expected 1 refusal, got %d", len(result.Refusals))
+	}
+	if result.Refusals[0].Gate != "dir_handles" {
+		t.Fatalf("expected gate dir_handles, got %s", result.Refusals[0].Gate)
+	}
 }
 
 func TestReexecPreflightRefusesNonRootNlookup(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.inodes.Lookup("/foo", false, 0, time.Time{})
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "inode_nlookup" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with non-root nlookup")
 	}
-	require.True(t, hasGate, "should refuse on non-root inode with Nlookup > 0")
+	assertHasGate(t, result.Refusals, "inode_nlookup", 1)
 }
 
 func TestReexecPreflightRefusesFuseLock(t *testing.T) {
@@ -70,263 +82,201 @@ func TestReexecPreflightRefusesFuseLock(t *testing.T) {
 		Typ:   uint32(syscall.F_WRLCK),
 	}, false)
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "fuse_locks" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with held FUSE lock")
 	}
-	require.True(t, hasGate, "should refuse when FUSE lock is held")
+	assertHasGate(t, result.Refusals, "fuse_locks", 1)
 }
 
 func TestReexecPreflightRefusesXattr(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.xattrs.Set("/test.txt", "user.test", []byte("value"))
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "xattrs" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with xattrs")
 	}
-	require.True(t, hasGate, "should refuse when xattrs exist")
+	assertHasGate(t, result.Refusals, "xattrs", 1)
 }
 
 func TestReexecPreflightRefusesLocalOverlay(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.localOverlay = &LocalOverlay{root: "/tmp/overlay"}
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "local_overlay" {
-			hasGate = true
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with local overlay enabled")
 	}
-	require.True(t, hasGate, "should refuse when local overlay is enabled")
+	assertHasGate(t, result.Refusals, "local_overlay", -1)
 }
 
 func TestReexecPreflightRefusesGitWorkspace(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.git = &gitWorkspaceLayer{}
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "git_workspace" {
-			hasGate = true
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with git workspace enabled")
 	}
-	require.True(t, hasGate, "should refuse when git workspace is enabled")
+	assertHasGate(t, result.Refusals, "git_workspace", -1)
 }
 
 func TestReexecPreflightRefusesNonEmptyTransientOverlay(t *testing.T) {
 	dir := t.TempDir()
 	overlayRoot := filepath.Join(dir, "overlay")
-	require.NoError(t, os.MkdirAll(overlayRoot, 0o755))
-	require.NoError(t, os.WriteFile(filepath.Join(overlayRoot, "file.txt"), []byte("data"), 0o644))
+	if err := os.MkdirAll(overlayRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(overlayRoot, "file.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 
 	fs := newTestReexecFS()
 	fs.transientLocalOverlay = &LocalOverlay{root: overlayRoot}
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "transient_overlay" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with non-empty transient overlay")
 	}
-	require.True(t, hasGate, "should refuse when transient overlay has entries")
+	assertHasGate(t, result.Refusals, "transient_overlay", 1)
 }
 
 func TestReexecPreflightAllowsEmptyTransientOverlay(t *testing.T) {
 	dir := t.TempDir()
 	overlayRoot := filepath.Join(dir, "overlay")
-	require.NoError(t, os.MkdirAll(overlayRoot, 0o755))
+	if err := os.MkdirAll(overlayRoot, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
 
 	fs := newTestReexecFS()
 	fs.transientLocalOverlay = &LocalOverlay{root: overlayRoot}
 	result := fs.ReexecPreflight()
-	require.True(t, result.OK, "empty transient overlay should pass preflight")
+	if !result.OK {
+		t.Fatalf("empty transient overlay should pass preflight, got refusals: %+v", result.Refusals)
+	}
 }
 
 func TestReexecPreflightRefusesPendingIndex(t *testing.T) {
 	dir := t.TempDir()
 	idx, err := NewPendingIndex(dir)
-	require.NoError(t, err)
-	_, err = idx.Put("/test.txt", 100, PendingNew)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewPendingIndex: %v", err)
+	}
+	if _, err := idx.Put("/test.txt", 100, PendingNew); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
 
 	fs := newTestReexecFS()
 	fs.pendingIndex = idx
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "pending_index" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with pending index entries")
 	}
-	require.True(t, hasGate, "should refuse when pending index has entries")
+	assertHasGate(t, result.Refusals, "pending_index", 1)
 }
 
 func TestReexecPreflightRefusesJournal(t *testing.T) {
 	dir := t.TempDir()
 	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
-	require.NoError(t, err)
-	require.NoError(t, j.Append(JournalEntry{Op: JournalWrite, Path: "/test.txt"}))
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
+	if err := j.Append(JournalEntry{Op: JournalWrite, Path: "/test.txt"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
 
 	fs := newTestReexecFS()
 	fs.journal = j
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "journal" {
-			hasGate = true
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with uncommitted journal frames")
 	}
-	require.True(t, hasGate, "should refuse when journal has uncommitted frames")
+	assertHasGate(t, result.Refusals, "journal", -1)
 }
 
 func TestReexecPreflightJournalPassesAfterCommit(t *testing.T) {
 	dir := t.TempDir()
 	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
-	require.NoError(t, err)
-	require.NoError(t, j.Append(JournalEntry{Op: JournalWrite, Path: "/test.txt"}))
-	require.NoError(t, j.Append(JournalEntry{Op: JournalCommit, Path: "/test.txt"}))
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
+	if err := j.Append(JournalEntry{Op: JournalWrite, Path: "/test.txt"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := j.Append(JournalEntry{Op: JournalCommit, Path: "/test.txt"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
 
 	fs := newTestReexecFS()
 	fs.journal = j
 	result := fs.ReexecPreflight()
-	hasJournalRefusal := false
 	for _, r := range result.Refusals {
 		if r.Gate == "journal" {
-			hasJournalRefusal = true
+			t.Fatal("journal with committed frames should not refuse")
 		}
 	}
-	require.False(t, hasJournalRefusal, "journal with committed frames should not refuse")
 }
 
 func TestReexecPreflightRefusesShadowStorePendingBytes(t *testing.T) {
 	dir := t.TempDir()
 	shadowDir := filepath.Join(dir, "shadow")
 	ss, err := NewShadowStore(shadowDir)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewShadowStore: %v", err)
+	}
 
-	// Write a shadow file to create pending bytes.
 	shadowPath := filepath.Join(shadowDir, "test.shadow")
-	require.NoError(t, os.WriteFile(shadowPath, []byte("dirty data"), 0o644))
+	if err := os.WriteFile(shadowPath, []byte("dirty data"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 	ss.RecoverPendingBytes()
-	require.Greater(t, ss.PendingBytes(), int64(0), "shadow store should have pending bytes")
+	if ss.PendingBytes() <= 0 {
+		t.Fatal("shadow store should have pending bytes after recovery")
+	}
 
 	fs := newTestReexecFS()
 	fs.shadowStore = ss
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "shadow_store" {
-			hasGate = true
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with shadow store pending bytes")
 	}
-	require.True(t, hasGate, "should refuse when shadow store has pending bytes")
-}
-
-func TestReexecPreflightRefusesCommitQueuePendingWork(t *testing.T) {
-	// CommitQueue requires a full client + shadow + pending setup.
-	// Create a minimal CommitQueue with a pending entry via the public API.
-	dir := t.TempDir()
-	shadowDir := filepath.Join(dir, "shadow")
-	ss, err := NewShadowStore(shadowDir)
-	require.NoError(t, err)
-	idx, err := NewPendingIndex(filepath.Join(dir, "pending"))
-	require.NoError(t, err)
-	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
-	require.NoError(t, err)
-
-	cq := NewCommitQueue(nil, ss, idx, j, 1, 100)
-	// Enqueue work — this will fail to commit (nil client) but the entry
-	// stays pending, which is what we need for the snapshot check.
-	seq, err := idx.Put("/test.txt", 10, PendingNew)
-	require.NoError(t, err)
-	_ = seq
-
-	fs := newTestReexecFS()
-	fs.commitQueue = cq
-	fs.pendingIndex = idx
-	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	// Should have pending_index refusal at minimum
-	hasIndex := false
-	for _, r := range result.Refusals {
-		if r.Gate == "pending_index" {
-			hasIndex = true
-		}
-	}
-	require.True(t, hasIndex, "should refuse when pending index has entries (commit queue scenario)")
+	assertHasGate(t, result.Refusals, "shadow_store", -1)
 }
 
 func TestReexecPreflightRefusesLayerOverlayWhiteouts(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.layerWhiteouts = map[string]struct{}{"/deleted": {}}
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "layer_overlay" {
-			hasGate = true
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with layer whiteouts")
 	}
-	require.True(t, hasGate, "should refuse when layerWhiteouts is non-empty")
+	assertHasGate(t, result.Refusals, "layer_overlay", -1)
 }
 
 func TestReexecPreflightRefusesLayerOverlayFiles(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.layerFiles = map[string]uint32{"/new.txt": 0o644}
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "layer_overlay" {
-			hasGate = true
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with layer files")
 	}
-	require.True(t, hasGate, "should refuse when layerFiles is non-empty")
+	assertHasGate(t, result.Refusals, "layer_overlay", -1)
 }
 
 func TestReexecPreflightRefusesLayerOverlayDirs(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.layerDirs = map[string]uint32{"/newdir": 0o755}
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "layer_overlay" {
-			hasGate = true
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with layer dirs")
 	}
-	require.True(t, hasGate, "should refuse when layerDirs is non-empty")
+	assertHasGate(t, result.Refusals, "layer_overlay", -1)
 }
 
 func TestReexecPreflightRefusesLayerOverlaySymlinks(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.layerSymlinks = map[string]layerSymlinkState{"/link": {Target: "/target", Mode: 0o777}}
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "layer_overlay" {
-			hasGate = true
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with layer symlinks")
 	}
-	require.True(t, hasGate, "should refuse when layerSymlinks is non-empty")
+	assertHasGate(t, result.Refusals, "layer_overlay", -1)
 }
 
 func TestReexecPreflightRefusesUploaderQueued(t *testing.T) {
@@ -339,15 +289,10 @@ func TestReexecPreflightRefusesUploaderQueued(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.uploader = u
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "uploader_queued" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with uploader queued entries")
 	}
-	require.True(t, hasGate, "should refuse when uploader has queued entries")
+	assertHasGate(t, result.Refusals, "uploader_queued", 1)
 }
 
 func TestReexecPreflightRefusesUploaderInFlight(t *testing.T) {
@@ -358,21 +303,18 @@ func TestReexecPreflightRefusesUploaderInFlight(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.uploader = u
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "uploader_inflight" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with uploader in-flight entries")
 	}
-	require.True(t, hasGate, "should refuse when uploader has in-flight entries")
+	assertHasGate(t, result.Refusals, "uploader_inflight", 1)
 }
 
 func TestReexecPreflightRefusesUploaderCached(t *testing.T) {
 	dir := t.TempDir()
 	cache, err := NewWriteBackCache(dir)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewWriteBackCache: %v", err)
+	}
 	cache.mu.Lock()
 	cache.metas["/cached.txt"] = &WriteBackMeta{Path: "/cached.txt", Size: 42}
 	cache.mu.Unlock()
@@ -385,25 +327,26 @@ func TestReexecPreflightRefusesUploaderCached(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.uploader = u
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "uploader_cached" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with uploader cached entries")
 	}
-	require.True(t, hasGate, "should refuse when uploader has cached entries")
+	assertHasGate(t, result.Refusals, "uploader_cached", 1)
 }
 
 func TestReexecPreflightRefusesCommitQueuePending(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStore(filepath.Join(dir, "shadow"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewShadowStore: %v", err)
+	}
 	idx, err := NewPendingIndex(filepath.Join(dir, "pending"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewPendingIndex: %v", err)
+	}
 	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
 
 	cq := NewCommitQueue(nil, ss, idx, j, 1, 100)
 	cq.mu.Lock()
@@ -413,25 +356,26 @@ func TestReexecPreflightRefusesCommitQueuePending(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.commitQueue = cq
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "commit_queue_pending" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with commit queue pending entries")
 	}
-	require.True(t, hasGate, "should refuse when commit queue has pending entries")
+	assertHasGate(t, result.Refusals, "commit_queue_pending", 1)
 }
 
 func TestReexecPreflightRefusesCommitQueueInFlight(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStore(filepath.Join(dir, "shadow"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewShadowStore: %v", err)
+	}
 	idx, err := NewPendingIndex(filepath.Join(dir, "pending"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewPendingIndex: %v", err)
+	}
 	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
 
 	cq := NewCommitQueue(nil, ss, idx, j, 1, 100)
 	cq.mu.Lock()
@@ -441,73 +385,72 @@ func TestReexecPreflightRefusesCommitQueueInFlight(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.commitQueue = cq
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "commit_queue_inflight" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with commit queue in-flight entries")
 	}
-	require.True(t, hasGate, "should refuse when commit queue has in-flight entries")
+	assertHasGate(t, result.Refusals, "commit_queue_inflight", 1)
 }
 
 func TestReexecPreflightRefusesCommitQueueDelayed(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStore(filepath.Join(dir, "shadow"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewShadowStore: %v", err)
+	}
 	idx, err := NewPendingIndex(filepath.Join(dir, "pending"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewPendingIndex: %v", err)
+	}
 	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
 
 	cq := NewCommitQueue(nil, ss, idx, j, 1, 100)
 	entry := &CommitEntry{Path: "/delayed.txt", Size: 10}
+	timer := time.NewTimer(time.Hour)
+	t.Cleanup(func() { timer.Stop() })
 	cq.mu.Lock()
-	cq.delayed[entry] = time.NewTimer(time.Hour)
+	cq.delayed[entry] = timer
 	cq.mu.Unlock()
 
 	fs := newTestReexecFS()
 	fs.commitQueue = cq
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "commit_queue_delayed" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with commit queue delayed entries")
 	}
-	require.True(t, hasGate, "should refuse when commit queue has delayed entries")
+	assertHasGate(t, result.Refusals, "commit_queue_delayed", 1)
 }
 
 func TestReexecPreflightRefusesCommitQueueConflicts(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStore(filepath.Join(dir, "shadow"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewShadowStore: %v", err)
+	}
 	idx, err := NewPendingIndex(filepath.Join(dir, "pending"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewPendingIndex: %v", err)
+	}
 	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
 
-	// Add a conflict entry via the pending index.
-	_, err = idx.Put("/conflict.txt", 100, PendingConflict)
-	require.NoError(t, err)
+	if _, err := idx.Put("/conflict.txt", 100, PendingConflict); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
 
 	cq := NewCommitQueue(nil, ss, idx, j, 1, 100)
 
 	fs := newTestReexecFS()
 	fs.commitQueue = cq
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	hasGate := false
-	for _, r := range result.Refusals {
-		if r.Gate == "commit_queue_conflicts" {
-			hasGate = true
-			require.Equal(t, 1, r.Count)
-		}
+	if result.OK {
+		t.Fatal("expected preflight to fail with commit queue conflicts")
 	}
-	require.True(t, hasGate, "should refuse when commit queue has conflicts")
+	assertHasGate(t, result.Refusals, "commit_queue_conflicts", 1)
 }
 
 func TestReexecPreflightCollectsMultipleRefusals(t *testing.T) {
@@ -516,18 +459,32 @@ func TestReexecPreflightCollectsMultipleRefusals(t *testing.T) {
 	fs.dirHandles.Allocate(&DirHandle{Path: "/"})
 	fs.xattrs.Set("/b.txt", "user.test", []byte("val"))
 	result := fs.ReexecPreflight()
-	require.False(t, result.OK)
-	require.GreaterOrEqual(t, len(result.Refusals), 3, "should collect all refusals, not stop at first")
+	if result.OK {
+		t.Fatal("expected preflight to fail with multiple dirty states")
+	}
+	if len(result.Refusals) < 3 {
+		t.Fatalf("expected at least 3 refusals, got %d", len(result.Refusals))
+	}
 }
 
 func TestReexecGuardPreventsConcurrent(t *testing.T) {
 	g := &reexecGuard{}
-	require.True(t, g.tryAcquire(), "first acquire should succeed")
-	require.True(t, g.isActive())
-	require.False(t, g.tryAcquire(), "second acquire should fail")
+	if !g.tryAcquire() {
+		t.Fatal("first acquire should succeed")
+	}
+	if !g.isActive() {
+		t.Fatal("guard should be active after acquire")
+	}
+	if g.tryAcquire() {
+		t.Fatal("second acquire should fail")
+	}
 	g.release()
-	require.False(t, g.isActive())
-	require.True(t, g.tryAcquire(), "acquire after release should succeed")
+	if g.isActive() {
+		t.Fatal("guard should not be active after release")
+	}
+	if !g.tryAcquire() {
+		t.Fatal("acquire after release should succeed")
+	}
 	g.release()
 }
 
@@ -535,74 +492,152 @@ func TestReexecGuardPreventsConcurrent(t *testing.T) {
 
 func TestNonRootLookupCount(t *testing.T) {
 	m := NewInodeToPath()
-	require.Equal(t, 0, m.NonRootLookupCount(), "empty inode table has no non-root lookups")
+	if got := m.nonRootLookupCount(); got != 0 {
+		t.Fatalf("empty inode table: want 0, got %d", got)
+	}
 
 	m.Lookup("/foo", false, 0, time.Time{})
-	require.Equal(t, 1, m.NonRootLookupCount())
+	if got := m.nonRootLookupCount(); got != 1 {
+		t.Fatalf("after one lookup: want 1, got %d", got)
+	}
 
 	m.Lookup("/bar", false, 0, time.Time{})
-	require.Equal(t, 2, m.NonRootLookupCount())
+	if got := m.nonRootLookupCount(); got != 2 {
+		t.Fatalf("after two lookups: want 2, got %d", got)
+	}
 }
 
 func TestFuseLockTableTotalCount(t *testing.T) {
 	lt := newFuseLockTable()
-	require.Equal(t, 0, lt.totalCount())
+	if got := lt.totalCount(); got != 0 {
+		t.Fatalf("empty lock table: want 0, got %d", got)
+	}
 
 	lt.set(nil, 1, 100, 1, gofuse.FileLock{Start: 0, End: 10, Typ: uint32(syscall.F_RDLCK)}, false)
-	require.Equal(t, 1, lt.totalCount())
+	if got := lt.totalCount(); got != 1 {
+		t.Fatalf("after one lock: want 1, got %d", got)
+	}
 
 	lt.set(nil, 2, 200, 2, gofuse.FileLock{Start: 0, End: 10, Typ: uint32(syscall.F_WRLCK)}, false)
-	require.Equal(t, 2, lt.totalCount())
+	if got := lt.totalCount(); got != 2 {
+		t.Fatalf("after two locks: want 2, got %d", got)
+	}
 
 	lt.release(1, 100)
-	require.Equal(t, 1, lt.totalCount())
+	if got := lt.totalCount(); got != 1 {
+		t.Fatalf("after release: want 1, got %d", got)
+	}
 }
 
 func TestXAttrStoreTotalCount(t *testing.T) {
 	s := NewXAttrStore()
-	require.Equal(t, 0, s.TotalCount())
+	if got := s.totalCount(); got != 0 {
+		t.Fatalf("empty store: want 0, got %d", got)
+	}
 
 	s.Set("/a", "user.x", []byte("1"))
-	require.Equal(t, 1, s.TotalCount())
+	if got := s.totalCount(); got != 1 {
+		t.Fatalf("after one set: want 1, got %d", got)
+	}
 
 	s.Set("/a", "user.y", []byte("2"))
-	require.Equal(t, 2, s.TotalCount())
+	if got := s.totalCount(); got != 2 {
+		t.Fatalf("after two sets: want 2, got %d", got)
+	}
 
 	s.Set("/b", "user.x", []byte("3"))
-	require.Equal(t, 3, s.TotalCount())
+	if got := s.totalCount(); got != 3 {
+		t.Fatalf("after three sets: want 3, got %d", got)
+	}
 
 	s.Remove("/a", "user.x")
-	require.Equal(t, 2, s.TotalCount())
+	if got := s.totalCount(); got != 2 {
+		t.Fatalf("after remove: want 2, got %d", got)
+	}
 }
 
 func TestLocalOverlayEntryCount(t *testing.T) {
-	require.Equal(t, 0, localOverlayEntryCount(nil))
+	if got := localOverlayEntryCount(nil); got != 0 {
+		t.Fatalf("nil overlay: want 0, got %d", got)
+	}
 
 	dir := t.TempDir()
 	o := &LocalOverlay{root: dir}
-	require.Equal(t, 0, localOverlayEntryCount(o))
+	if got := localOverlayEntryCount(o); got != 0 {
+		t.Fatalf("empty dir: want 0, got %d", got)
+	}
 
-	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), nil, 0o644))
-	require.Equal(t, 1, localOverlayEntryCount(o))
+	if err := os.WriteFile(filepath.Join(dir, "a.txt"), nil, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if got := localOverlayEntryCount(o); got != 1 {
+		t.Fatalf("one file: want 1, got %d", got)
+	}
 
-	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
-	require.Equal(t, 2, localOverlayEntryCount(o))
+	if err := os.Mkdir(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatalf("Mkdir: %v", err)
+	}
+	if got := localOverlayEntryCount(o); got != 2 {
+		t.Fatalf("file + dir: want 2, got %d", got)
+	}
 }
 
-func TestJournalFrameCount(t *testing.T) {
-	require.Equal(t, 0, journalFrameCount(nil))
+func TestLocalOverlayEntryCountReturnsNegativeOnReadError(t *testing.T) {
+	// A root that exists as a file (not directory) should cause ReadDir to fail.
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(filePath, []byte("x"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	o := &LocalOverlay{root: filePath}
+	if got := localOverlayEntryCount(o); got != -1 {
+		t.Fatalf("read error: want -1, got %d", got)
+	}
+}
 
+func TestJournalUncommittedFrameCount(t *testing.T) {
 	dir := t.TempDir()
 	j, err := NewJournal(filepath.Join(dir, "test.wal"))
-	require.NoError(t, err)
-	require.Equal(t, 0, journalFrameCount(j))
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
+	if got := j.UncommittedFrameCount(); got != 0 {
+		t.Fatalf("empty journal: want 0, got %d", got)
+	}
 
-	require.NoError(t, j.Append(JournalEntry{Op: JournalWrite, Path: "/a"}))
-	require.Equal(t, 1, journalFrameCount(j))
+	if err := j.Append(JournalEntry{Op: JournalWrite, Path: "/a"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if got := j.UncommittedFrameCount(); got != 1 {
+		t.Fatalf("one write: want 1, got %d", got)
+	}
 
-	require.NoError(t, j.Append(JournalEntry{Op: JournalWrite, Path: "/b"}))
-	require.Equal(t, 2, journalFrameCount(j))
+	if err := j.Append(JournalEntry{Op: JournalWrite, Path: "/b"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if got := j.UncommittedFrameCount(); got != 2 {
+		t.Fatalf("two writes: want 2, got %d", got)
+	}
 
-	require.NoError(t, j.Append(JournalEntry{Op: JournalCommit, Path: "/a"}))
-	require.Equal(t, 1, journalFrameCount(j), "committed path should not count")
+	if err := j.Append(JournalEntry{Op: JournalCommit, Path: "/a"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if got := j.UncommittedFrameCount(); got != 1 {
+		t.Fatalf("after commit of /a: want 1, got %d", got)
+	}
+}
+
+// assertHasGate checks that at least one refusal has the given gate name.
+// If wantCount >= 0, it also asserts the count matches.
+func assertHasGate(t *testing.T, refusals []ReexecRefusal, gate string, wantCount int) {
+	t.Helper()
+	for _, r := range refusals {
+		if r.Gate == gate {
+			if wantCount >= 0 && r.Count != wantCount {
+				t.Fatalf("gate %s: want count %d, got %d", gate, wantCount, r.Count)
+			}
+			return
+		}
+	}
+	t.Fatalf("gate %q not found in refusals: %+v", gate, refusals)
 }

--- a/pkg/fuse/reexec_gate_test.go
+++ b/pkg/fuse/reexec_gate_test.go
@@ -177,7 +177,7 @@ func TestReexecPreflightRefusesJournal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJournal: %v", err)
 	}
-	if err := j.Append(JournalEntry{Op: JournalWrite, Path: "/test.txt"}); err != nil {
+	if err := j.Append(JournalEntry{Op: JournalFsync, Path: "/test.txt"}); err != nil {
 		t.Fatalf("Append: %v", err)
 	}
 
@@ -196,7 +196,7 @@ func TestReexecPreflightJournalPassesAfterCommit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewJournal: %v", err)
 	}
-	if err := j.Append(JournalEntry{Op: JournalWrite, Path: "/test.txt"}); err != nil {
+	if err := j.Append(JournalEntry{Op: JournalFsync, Path: "/test.txt"}); err != nil {
 		t.Fatalf("Append: %v", err)
 	}
 	if err := j.Append(JournalEntry{Op: JournalCommit, Path: "/test.txt"}); err != nil {
@@ -211,6 +211,34 @@ func TestReexecPreflightJournalPassesAfterCommit(t *testing.T) {
 			t.Fatal("journal with committed frames should not refuse")
 		}
 	}
+}
+
+func TestReexecPreflightRefusesJournalFsyncAfterCommit(t *testing.T) {
+	// Regression: Fsync → Commit → Fsync on the same path must refuse.
+	// The second Fsync has a higher Seq than the Commit, so the path
+	// is still replay-required.
+	dir := t.TempDir()
+	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
+	if err != nil {
+		t.Fatalf("NewJournal: %v", err)
+	}
+	if err := j.Append(JournalEntry{Op: JournalFsync, Path: "/same.txt"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := j.Append(JournalEntry{Op: JournalCommit, Path: "/same.txt"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := j.Append(JournalEntry{Op: JournalFsync, Path: "/same.txt"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	fs := newTestReexecFS()
+	fs.journal = j
+	result := fs.ReexecPreflight()
+	if result.OK {
+		t.Fatal("expected preflight to fail: Fsync after Commit on same path is replay-required")
+	}
+	assertHasGate(t, result.Refusals, "journal", -1)
 }
 
 func TestReexecPreflightRefusesShadowStorePendingBytes(t *testing.T) {
@@ -605,18 +633,18 @@ func TestJournalUncommittedFrameCount(t *testing.T) {
 		t.Fatalf("empty journal: want 0, got %d", got)
 	}
 
-	if err := j.Append(JournalEntry{Op: JournalWrite, Path: "/a"}); err != nil {
+	if err := j.Append(JournalEntry{Op: JournalFsync, Path: "/a"}); err != nil {
 		t.Fatalf("Append: %v", err)
 	}
 	if got := j.UncommittedFrameCount(); got != 1 {
-		t.Fatalf("one write: want 1, got %d", got)
+		t.Fatalf("one fsync: want 1, got %d", got)
 	}
 
-	if err := j.Append(JournalEntry{Op: JournalWrite, Path: "/b"}); err != nil {
+	if err := j.Append(JournalEntry{Op: JournalFsync, Path: "/b"}); err != nil {
 		t.Fatalf("Append: %v", err)
 	}
 	if got := j.UncommittedFrameCount(); got != 2 {
-		t.Fatalf("two writes: want 2, got %d", got)
+		t.Fatalf("two fsyncs: want 2, got %d", got)
 	}
 
 	if err := j.Append(JournalEntry{Op: JournalCommit, Path: "/a"}); err != nil {
@@ -624,6 +652,14 @@ func TestJournalUncommittedFrameCount(t *testing.T) {
 	}
 	if got := j.UncommittedFrameCount(); got != 1 {
 		t.Fatalf("after commit of /a: want 1, got %d", got)
+	}
+
+	// Fsync after Commit on same path: must count as uncommitted again.
+	if err := j.Append(JournalEntry{Op: JournalFsync, Path: "/a"}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if got := j.UncommittedFrameCount(); got != 2 {
+		t.Fatalf("fsync after commit on /a: want 2, got %d", got)
 	}
 }
 

--- a/pkg/fuse/reexec_gate_test.go
+++ b/pkg/fuse/reexec_gate_test.go
@@ -273,6 +273,215 @@ func TestReexecPreflightRefusesCommitQueuePendingWork(t *testing.T) {
 	require.True(t, hasIndex, "should refuse when pending index has entries (commit queue scenario)")
 }
 
+func TestReexecPreflightRefusesLayerOverlayWhiteouts(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.layerWhiteouts = map[string]struct{}{"/deleted": {}}
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "layer_overlay" {
+			hasGate = true
+		}
+	}
+	require.True(t, hasGate, "should refuse when layerWhiteouts is non-empty")
+}
+
+func TestReexecPreflightRefusesLayerOverlayFiles(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.layerFiles = map[string]uint32{"/new.txt": 0o644}
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "layer_overlay" {
+			hasGate = true
+		}
+	}
+	require.True(t, hasGate, "should refuse when layerFiles is non-empty")
+}
+
+func TestReexecPreflightRefusesLayerOverlayDirs(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.layerDirs = map[string]uint32{"/newdir": 0o755}
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "layer_overlay" {
+			hasGate = true
+		}
+	}
+	require.True(t, hasGate, "should refuse when layerDirs is non-empty")
+}
+
+func TestReexecPreflightRefusesLayerOverlaySymlinks(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.layerSymlinks = map[string]layerSymlinkState{"/link": {Target: "/target", Mode: 0o777}}
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "layer_overlay" {
+			hasGate = true
+		}
+	}
+	require.True(t, hasGate, "should refuse when layerSymlinks is non-empty")
+}
+
+func TestReexecPreflightRefusesUploaderQueued(t *testing.T) {
+	ch := make(chan string, 10)
+	ch <- "/queued.txt"
+	u := &WriteBackUploader{
+		uploadCh: ch,
+		inflight: make(map[string]*pathState),
+	}
+	fs := newTestReexecFS()
+	fs.uploader = u
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "uploader_queued" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when uploader has queued entries")
+}
+
+func TestReexecPreflightRefusesUploaderInFlight(t *testing.T) {
+	u := &WriteBackUploader{
+		uploadCh: make(chan string, 10),
+		inflight: map[string]*pathState{"/uploading.txt": {done: make(chan struct{})}},
+	}
+	fs := newTestReexecFS()
+	fs.uploader = u
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "uploader_inflight" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when uploader has in-flight entries")
+}
+
+func TestReexecPreflightRefusesUploaderCached(t *testing.T) {
+	dir := t.TempDir()
+	cache, err := NewWriteBackCache(dir)
+	require.NoError(t, err)
+	cache.mu.Lock()
+	cache.metas["/cached.txt"] = &WriteBackMeta{Path: "/cached.txt", Size: 42}
+	cache.mu.Unlock()
+
+	u := &WriteBackUploader{
+		uploadCh: make(chan string, 10),
+		inflight: make(map[string]*pathState),
+		cache:    cache,
+	}
+	fs := newTestReexecFS()
+	fs.uploader = u
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "uploader_cached" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when uploader has cached entries")
+}
+
+func TestReexecPreflightRefusesCommitQueueInFlight(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStore(filepath.Join(dir, "shadow"))
+	require.NoError(t, err)
+	idx, err := NewPendingIndex(filepath.Join(dir, "pending"))
+	require.NoError(t, err)
+	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
+	require.NoError(t, err)
+
+	cq := NewCommitQueue(nil, ss, idx, j, 1, 100)
+	cq.mu.Lock()
+	cq.inFlight["/inflight.txt"] = &CommitEntry{Path: "/inflight.txt", Size: 10}
+	cq.mu.Unlock()
+
+	fs := newTestReexecFS()
+	fs.commitQueue = cq
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "commit_queue_inflight" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when commit queue has in-flight entries")
+}
+
+func TestReexecPreflightRefusesCommitQueueDelayed(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStore(filepath.Join(dir, "shadow"))
+	require.NoError(t, err)
+	idx, err := NewPendingIndex(filepath.Join(dir, "pending"))
+	require.NoError(t, err)
+	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
+	require.NoError(t, err)
+
+	cq := NewCommitQueue(nil, ss, idx, j, 1, 100)
+	entry := &CommitEntry{Path: "/delayed.txt", Size: 10}
+	cq.mu.Lock()
+	cq.delayed[entry] = time.NewTimer(time.Hour)
+	cq.mu.Unlock()
+
+	fs := newTestReexecFS()
+	fs.commitQueue = cq
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "commit_queue_delayed" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when commit queue has delayed entries")
+}
+
+func TestReexecPreflightRefusesCommitQueueConflicts(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStore(filepath.Join(dir, "shadow"))
+	require.NoError(t, err)
+	idx, err := NewPendingIndex(filepath.Join(dir, "pending"))
+	require.NoError(t, err)
+	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
+	require.NoError(t, err)
+
+	// Add a conflict entry via the pending index.
+	_, err = idx.Put("/conflict.txt", 100, PendingConflict)
+	require.NoError(t, err)
+
+	cq := NewCommitQueue(nil, ss, idx, j, 1, 100)
+
+	fs := newTestReexecFS()
+	fs.commitQueue = cq
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "commit_queue_conflicts" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when commit queue has conflicts")
+}
+
 func TestReexecPreflightCollectsMultipleRefusals(t *testing.T) {
 	fs := newTestReexecFS()
 	fs.fileHandles.Allocate(&FileHandle{Path: "/a.txt"})

--- a/pkg/fuse/reexec_gate_test.go
+++ b/pkg/fuse/reexec_gate_test.go
@@ -1,0 +1,312 @@
+package fuse
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestReexecFS() *Dat9FS {
+	return &Dat9FS{
+		inodes:      NewInodeToPath(),
+		fileHandles: NewHandleTable[*FileHandle](),
+		dirHandles:  NewHandleTable[*DirHandle](),
+		locks:       newFuseLockTable(),
+		xattrs:      NewXAttrStore(),
+	}
+}
+
+func TestReexecPreflightIdleMount(t *testing.T) {
+	fs := newTestReexecFS()
+	result := fs.ReexecPreflight()
+	require.True(t, result.OK, "idle mount should pass preflight")
+	require.Empty(t, result.Refusals)
+}
+
+func TestReexecPreflightRefusesOpenFileHandle(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.fileHandles.Allocate(&FileHandle{Path: "/test.txt"})
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	require.Len(t, result.Refusals, 1)
+	require.Equal(t, "file_handles", result.Refusals[0].Gate)
+	require.Equal(t, 1, result.Refusals[0].Count)
+}
+
+func TestReexecPreflightRefusesOpenDirHandle(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.dirHandles.Allocate(&DirHandle{Path: "/"})
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	require.Len(t, result.Refusals, 1)
+	require.Equal(t, "dir_handles", result.Refusals[0].Gate)
+}
+
+func TestReexecPreflightRefusesNonRootNlookup(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.inodes.Lookup("/foo", false, 0, time.Time{})
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "inode_nlookup" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse on non-root inode with Nlookup > 0")
+}
+
+func TestReexecPreflightRefusesFuseLock(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.locks.set(nil, 42, 1, 100, gofuse.FileLock{
+		Start: 0,
+		End:   100,
+		Typ:   uint32(syscall.F_WRLCK),
+	}, false)
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "fuse_locks" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when FUSE lock is held")
+}
+
+func TestReexecPreflightRefusesXattr(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.xattrs.Set("/test.txt", "user.test", []byte("value"))
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "xattrs" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when xattrs exist")
+}
+
+func TestReexecPreflightRefusesLocalOverlay(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.localOverlay = &LocalOverlay{root: "/tmp/overlay"}
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "local_overlay" {
+			hasGate = true
+		}
+	}
+	require.True(t, hasGate, "should refuse when local overlay is enabled")
+}
+
+func TestReexecPreflightRefusesGitWorkspace(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.git = &gitWorkspaceLayer{}
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "git_workspace" {
+			hasGate = true
+		}
+	}
+	require.True(t, hasGate, "should refuse when git workspace is enabled")
+}
+
+func TestReexecPreflightRefusesNonEmptyTransientOverlay(t *testing.T) {
+	dir := t.TempDir()
+	overlayRoot := filepath.Join(dir, "overlay")
+	require.NoError(t, os.MkdirAll(overlayRoot, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(overlayRoot, "file.txt"), []byte("data"), 0o644))
+
+	fs := newTestReexecFS()
+	fs.transientLocalOverlay = &LocalOverlay{root: overlayRoot}
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "transient_overlay" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when transient overlay has entries")
+}
+
+func TestReexecPreflightAllowsEmptyTransientOverlay(t *testing.T) {
+	dir := t.TempDir()
+	overlayRoot := filepath.Join(dir, "overlay")
+	require.NoError(t, os.MkdirAll(overlayRoot, 0o755))
+
+	fs := newTestReexecFS()
+	fs.transientLocalOverlay = &LocalOverlay{root: overlayRoot}
+	result := fs.ReexecPreflight()
+	require.True(t, result.OK, "empty transient overlay should pass preflight")
+}
+
+func TestReexecPreflightRefusesPendingIndex(t *testing.T) {
+	dir := t.TempDir()
+	idx, err := NewPendingIndex(dir)
+	require.NoError(t, err)
+	_, err = idx.Put("/test.txt", 100, PendingNew)
+	require.NoError(t, err)
+
+	fs := newTestReexecFS()
+	fs.pendingIndex = idx
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "pending_index" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when pending index has entries")
+}
+
+func TestReexecPreflightRefusesJournal(t *testing.T) {
+	dir := t.TempDir()
+	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
+	require.NoError(t, err)
+	require.NoError(t, j.Append(JournalEntry{Op: JournalWrite, Path: "/test.txt"}))
+
+	fs := newTestReexecFS()
+	fs.journal = j
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "journal" {
+			hasGate = true
+		}
+	}
+	require.True(t, hasGate, "should refuse when journal has uncommitted frames")
+}
+
+func TestReexecPreflightJournalPassesAfterCommit(t *testing.T) {
+	dir := t.TempDir()
+	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
+	require.NoError(t, err)
+	require.NoError(t, j.Append(JournalEntry{Op: JournalWrite, Path: "/test.txt"}))
+	require.NoError(t, j.Append(JournalEntry{Op: JournalCommit, Path: "/test.txt"}))
+
+	fs := newTestReexecFS()
+	fs.journal = j
+	result := fs.ReexecPreflight()
+	hasJournalRefusal := false
+	for _, r := range result.Refusals {
+		if r.Gate == "journal" {
+			hasJournalRefusal = true
+		}
+	}
+	require.False(t, hasJournalRefusal, "journal with committed frames should not refuse")
+}
+
+func TestReexecPreflightCollectsMultipleRefusals(t *testing.T) {
+	fs := newTestReexecFS()
+	fs.fileHandles.Allocate(&FileHandle{Path: "/a.txt"})
+	fs.dirHandles.Allocate(&DirHandle{Path: "/"})
+	fs.xattrs.Set("/b.txt", "user.test", []byte("val"))
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	require.GreaterOrEqual(t, len(result.Refusals), 3, "should collect all refusals, not stop at first")
+}
+
+func TestReexecGuardPreventsConcurrent(t *testing.T) {
+	g := &reexecGuard{}
+	require.True(t, g.tryAcquire(), "first acquire should succeed")
+	require.True(t, g.isActive())
+	require.False(t, g.tryAcquire(), "second acquire should fail")
+	g.release()
+	require.False(t, g.isActive())
+	require.True(t, g.tryAcquire(), "acquire after release should succeed")
+	g.release()
+}
+
+// --- Count helper tests ---
+
+func TestNonRootLookupCount(t *testing.T) {
+	m := NewInodeToPath()
+	require.Equal(t, 0, m.NonRootLookupCount(), "empty inode table has no non-root lookups")
+
+	m.Lookup("/foo", false, 0, time.Time{})
+	require.Equal(t, 1, m.NonRootLookupCount())
+
+	m.Lookup("/bar", false, 0, time.Time{})
+	require.Equal(t, 2, m.NonRootLookupCount())
+}
+
+func TestFuseLockTableTotalCount(t *testing.T) {
+	lt := newFuseLockTable()
+	require.Equal(t, 0, lt.totalCount())
+
+	lt.set(nil, 1, 100, 1, gofuse.FileLock{Start: 0, End: 10, Typ: uint32(syscall.F_RDLCK)}, false)
+	require.Equal(t, 1, lt.totalCount())
+
+	lt.set(nil, 2, 200, 2, gofuse.FileLock{Start: 0, End: 10, Typ: uint32(syscall.F_WRLCK)}, false)
+	require.Equal(t, 2, lt.totalCount())
+
+	lt.release(1, 100)
+	require.Equal(t, 1, lt.totalCount())
+}
+
+func TestXAttrStoreTotalCount(t *testing.T) {
+	s := NewXAttrStore()
+	require.Equal(t, 0, s.TotalCount())
+
+	s.Set("/a", "user.x", []byte("1"))
+	require.Equal(t, 1, s.TotalCount())
+
+	s.Set("/a", "user.y", []byte("2"))
+	require.Equal(t, 2, s.TotalCount())
+
+	s.Set("/b", "user.x", []byte("3"))
+	require.Equal(t, 3, s.TotalCount())
+
+	s.Remove("/a", "user.x")
+	require.Equal(t, 2, s.TotalCount())
+}
+
+func TestLocalOverlayEntryCount(t *testing.T) {
+	require.Equal(t, 0, localOverlayEntryCount(nil))
+
+	dir := t.TempDir()
+	o := &LocalOverlay{root: dir}
+	require.Equal(t, 0, localOverlayEntryCount(o))
+
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.txt"), nil, 0o644))
+	require.Equal(t, 1, localOverlayEntryCount(o))
+
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "subdir"), 0o755))
+	require.Equal(t, 2, localOverlayEntryCount(o))
+}
+
+func TestJournalFrameCount(t *testing.T) {
+	require.Equal(t, 0, journalFrameCount(nil))
+
+	dir := t.TempDir()
+	j, err := NewJournal(filepath.Join(dir, "test.wal"))
+	require.NoError(t, err)
+	require.Equal(t, 0, journalFrameCount(j))
+
+	require.NoError(t, j.Append(JournalEntry{Op: JournalWrite, Path: "/a"}))
+	require.Equal(t, 1, journalFrameCount(j))
+
+	require.NoError(t, j.Append(JournalEntry{Op: JournalWrite, Path: "/b"}))
+	require.Equal(t, 2, journalFrameCount(j))
+
+	require.NoError(t, j.Append(JournalEntry{Op: JournalCommit, Path: "/a"}))
+	require.Equal(t, 1, journalFrameCount(j), "committed path should not count")
+}

--- a/pkg/fuse/reexec_gate_test.go
+++ b/pkg/fuse/reexec_gate_test.go
@@ -396,6 +396,34 @@ func TestReexecPreflightRefusesUploaderCached(t *testing.T) {
 	require.True(t, hasGate, "should refuse when uploader has cached entries")
 }
 
+func TestReexecPreflightRefusesCommitQueuePending(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStore(filepath.Join(dir, "shadow"))
+	require.NoError(t, err)
+	idx, err := NewPendingIndex(filepath.Join(dir, "pending"))
+	require.NoError(t, err)
+	j, err := NewJournal(filepath.Join(dir, "journal.wal"))
+	require.NoError(t, err)
+
+	cq := NewCommitQueue(nil, ss, idx, j, 1, 100)
+	cq.mu.Lock()
+	cq.queue = append(cq.queue, &CommitEntry{Path: "/pending.txt", Size: 10})
+	cq.mu.Unlock()
+
+	fs := newTestReexecFS()
+	fs.commitQueue = cq
+	result := fs.ReexecPreflight()
+	require.False(t, result.OK)
+	hasGate := false
+	for _, r := range result.Refusals {
+		if r.Gate == "commit_queue_pending" {
+			hasGate = true
+			require.Equal(t, 1, r.Count)
+		}
+	}
+	require.True(t, hasGate, "should refuse when commit queue has pending entries")
+}
+
 func TestReexecPreflightRefusesCommitQueueInFlight(t *testing.T) {
 	dir := t.TempDir()
 	ss, err := NewShadowStore(filepath.Join(dir, "shadow"))


### PR DESCRIPTION
## Summary
- Phase 2 of V0 clean-state binary reexec (per PR #718 audit doc, tasks #9-12 in #csi)
- `ReexecPreflight()` checks all V0 gates from the audit doc and returns structured refusal reasons
- `reexecGuard` prevents concurrent reexec attempts (`already_in_progress`)
- New count helpers for types that lacked them: `InodeToPath.NonRootLookupCount`, `fuseLockTable.totalCount`, `XAttrStore.TotalCount`, `localOverlayEntryCount`, `journalFrameCount`

## Gates checked
- Static: local overlay, transient overlay entries, git workspace, layer overlay state
- Runtime: file handles, dir handles, non-root inode Nlookup, FUSE locks, xattrs, commit queue (pending/inflight/delayed/conflicts), uploader (queued/inflight/cached), pending index, shadow store pending bytes, journal uncommitted frames

## Test plan
- [x] 20 tests covering idle pass, each refusal gate, multiple refusals collected, guard concurrency, and count helper correctness
- [x] `go build ./pkg/fuse/` passes
- [x] All tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reexec preflight gate that determines whether a mount is safe to proceed.
  * Added structured refusal details describing what is preventing reexec, across configuration and live runtime state.
  * Added journal analysis to detect uncommitted changes that block reexec.

* **Bug Fixes**
  * Improved detection of dirty state, including open handles, locks, xattrs, overlays, indexing backlog, shadow-store pending bytes, and layer overlay contents.

* **Tests**
  * Added comprehensive unit and integration-style coverage for allowed/refused cases, multi-refusal collection, journal sequencing edge cases, and concurrency/guard behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->