### PR TITLE
Fix quota reservation lock conflict handling

### DIFF
--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -21,6 +21,7 @@ var (
 	ErrMediaLLMQuotaExceeded    = errors.New("tenant media LLM file quota exceeded")
 	ErrReservationNotFound      = errors.New("upload reservation not found")
 	ErrReservationAlreadyExists = errors.New("upload reservation already exists")
+	ErrQuotaReservationBusy     = errors.New("quota reservation busy")
 )
 
 type storageQuotaCheckResult struct {

--- a/pkg/backend/round_a_review_test.go
+++ b/pkg/backend/round_a_review_test.go
@@ -144,6 +144,20 @@ func TestRoundA_Fix1_ReserveUploadOnServer_NoLeakOnInsertFailure(t *testing.T) {
 	}
 }
 
+func TestReserveUploadOnServer_BusyFailOpensWithoutLeak(t *testing.T) {
+	b, fake := newCentralQuotaBackend(t)
+	fake.insertReservationErr = ErrQuotaReservationBusy
+
+	reserved, err := b.reserveUploadOnServer(context.Background(), "u1", "/a", 100, 0)
+	if reserved || err != nil {
+		t.Fatalf("busy fail-open path: reserved=%v err=%v, want (false, nil)", reserved, err)
+	}
+	u, _ := fake.GetQuotaUsage(context.Background(), "tenant-a")
+	if u.ReservedBytes != 0 {
+		t.Fatalf("reserved_bytes = %d after busy reserve, want 0", u.ReservedBytes)
+	}
+}
+
 func TestRoundA_Fix1_ReserveUploadOnServer_DuplicateIsIdempotent(t *testing.T) {
 	b, fake := newCentralQuotaBackend(t)
 

--- a/pkg/backend/upload_reservation.go
+++ b/pkg/backend/upload_reservation.go
@@ -29,6 +29,10 @@ import (
 //     server DB is unreachable (fail-open). Callers treat this as "no
 //     server-side reservation", so the matching abort/complete paths skip
 //     counter adjustments.
+//   - (false, nil): central quota stayed lock-contended after bounded retries.
+//     This also fail-opens to avoid a user-visible upload-initiate failure, but
+//     it records a distinct busy_fail_open metric so quota-admission bypass risk
+//     is observable.
 //
 // Idempotency: a duplicate (tenant_id, upload_id) is treated as
 // (true, nil) — the original initiate already claimed the reservation;
@@ -88,6 +92,14 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 			zap.String("upload_id", uploadID))
 		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "duplicate", time.Since(start))
 		return true, nil
+	case errors.Is(err, ErrQuotaReservationBusy):
+		logger.Warn(ctx, "central_quota_reserve_upload_busy_fail_open",
+			zap.String("tenant_id", b.tenantID),
+			zap.String("upload_id", uploadID),
+			zap.Int64("size", totalSize),
+			zap.Error(err))
+		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "busy_fail_open", time.Since(start))
+		return false, nil
 	default:
 		logger.Warn(ctx, "central_quota_reserve_upload_failed",
 			zap.String("tenant_id", b.tenantID),

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -26,6 +26,7 @@ var (
 	ErrStorageQuotaExceeded     = errors.New("tenant storage quota exceeded")
 	ErrFileCountQuotaExceeded   = errors.New("tenant file count quota exceeded")
 	ErrReservationAlreadyExists = errors.New("upload reservation already exists")
+	ErrQuotaReservationBusy     = errors.New("quota reservation busy")
 )
 
 type TenantStatus string

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -10,6 +10,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	mysql "github.com/go-sql-driver/mysql"
+
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 	"go.uber.org/zap"
@@ -571,14 +573,28 @@ func isMetaLockConflictError(err error) bool {
 	if err == nil {
 		return false
 	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		if string(mysqlErr.SQLState[:]) == "40001" {
+			return true
+		}
+		switch mysqlErr.Number {
+		case 1213, 1205:
+			return true
+		case 9007:
+			return strings.Contains(strings.ToLower(mysqlErr.Message), "write conflict")
+		}
+		return false
+	}
 	msg := err.Error()
 	lower := strings.ToLower(msg)
-	return strings.Contains(msg, "Deadlock found") ||
-		strings.Contains(msg, "Error 1213") ||
-		strings.Contains(msg, "40001") ||
-		strings.Contains(msg, "Lock wait timeout exceeded") ||
-		strings.Contains(msg, "Error 1205") ||
-		strings.Contains(lower, "write conflict")
+	return (strings.Contains(msg, "Error 1213") && strings.Contains(msg, "Deadlock found")) ||
+		(strings.Contains(msg, "ERROR 1213") && strings.Contains(msg, "Deadlock found")) ||
+		(strings.Contains(msg, "Error 1205") && strings.Contains(msg, "Lock wait timeout exceeded")) ||
+		(strings.Contains(msg, "ERROR 1205") && strings.Contains(msg, "Lock wait timeout exceeded")) ||
+		strings.Contains(msg, "SQLSTATE 40001") ||
+		((strings.Contains(msg, "Error 9007 (") || strings.Contains(msg, "ERROR 9007 (")) &&
+			strings.Contains(lower, "write conflict"))
 }
 
 func (s *Store) uploadReservationQuotaErrorTx(ctx context.Context, tx *sql.Tx, r *UploadReservation) error {

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -564,7 +564,7 @@ func retryMetaLockConflict(ctx context.Context, tenantID, metricOperation, logOp
 		case <-time.After(time.Duration(attempt) * metaLockConflictRetryBase):
 		}
 	}
-	return fmt.Errorf("%w: %v", ErrQuotaReservationBusy, lastErr)
+	return fmt.Errorf("%w: %w", ErrQuotaReservationBusy, lastErr)
 }
 
 func isMetaLockConflictError(err error) bool {
@@ -572,11 +572,14 @@ func isMetaLockConflictError(err error) bool {
 		return false
 	}
 	msg := err.Error()
+	lower := strings.ToLower(msg)
 	return strings.Contains(msg, "Deadlock found") ||
 		strings.Contains(msg, "Error 1213") ||
 		strings.Contains(msg, "40001") ||
 		strings.Contains(msg, "Lock wait timeout exceeded") ||
-		strings.Contains(msg, "Error 1205")
+		strings.Contains(msg, "Error 1205") ||
+		(strings.Contains(msg, "9007") && strings.Contains(lower, "write conflict")) ||
+		strings.Contains(lower, "write conflict")
 }
 
 func (s *Store) uploadReservationQuotaErrorTx(ctx context.Context, tx *sql.Tx, r *UploadReservation) error {

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -578,7 +578,6 @@ func isMetaLockConflictError(err error) bool {
 		strings.Contains(msg, "40001") ||
 		strings.Contains(msg, "Lock wait timeout exceeded") ||
 		strings.Contains(msg, "Error 1205") ||
-		(strings.Contains(msg, "9007") && strings.Contains(lower, "write conflict")) ||
 		strings.Contains(lower, "write conflict")
 }
 

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"go.uber.org/zap"
 )
 
@@ -467,6 +469,11 @@ func SetDefaultMaxFileSizeBytes(bytes int64) {
 // DefaultMaxFileSizeBytes returns the configured per-tenant fallback file size quota.
 func DefaultMaxFileSizeBytes() int64 { return defaultMaxFileSizeBytes.Load() }
 
+const (
+	metaLockConflictRetryAttempts = 4
+	metaLockConflictRetryBase     = 20 * time.Millisecond
+)
+
 // AtomicReserveAndInsertUpload claims reserved_bytes and inserts the reservation
 // tracking row inside a single server DB transaction. This is the correct API
 // for the upload-initiate path: either both rows are written, or neither is.
@@ -486,7 +493,14 @@ func (s *Store) AtomicReserveAndInsertUpload(ctx context.Context, r *UploadReser
 	var err error
 	defer observeMeta(ctx, "atomic_reserve_and_insert_upload", start, &err)
 
-	err = s.InTx(ctx, func(tx *sql.Tx) error {
+	err = retryMetaLockConflict(ctx, r.TenantID, "reserve_upload", "atomic_reserve_and_insert_upload", func() error {
+		return s.atomicReserveAndInsertUploadOnce(ctx, r)
+	})
+	return err
+}
+
+func (s *Store) atomicReserveAndInsertUploadOnce(ctx context.Context, r *UploadReservation) error {
+	return s.InTx(ctx, func(tx *sql.Tx) error {
 		if _, execErr := tx.ExecContext(ctx,
 			`INSERT IGNORE INTO tenant_quota_usage (tenant_id) VALUES (?)`,
 			r.TenantID); execErr != nil {
@@ -526,7 +540,43 @@ func (s *Store) AtomicReserveAndInsertUpload(ctx context.Context, r *UploadReser
 		}
 		return nil
 	})
-	return err
+}
+
+func retryMetaLockConflict(ctx context.Context, tenantID, metricOperation, logOperation string, fn func() error) error {
+	var lastErr error
+	for attempt := 1; attempt <= metaLockConflictRetryAttempts; attempt++ {
+		err := fn()
+		if err == nil || !isMetaLockConflictError(err) {
+			return err
+		}
+		lastErr = err
+		if attempt == metaLockConflictRetryAttempts {
+			break
+		}
+		logger.Warn(ctx, "meta_lock_conflict_retry",
+			zap.String("operation", logOperation),
+			zap.Int("attempt", attempt),
+			zap.Error(err))
+		metrics.RecordTenantOperationCount(tenantID, "central_quota", metricOperation, "lock_conflict_retry")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(attempt) * metaLockConflictRetryBase):
+		}
+	}
+	return fmt.Errorf("%w: %v", ErrQuotaReservationBusy, lastErr)
+}
+
+func isMetaLockConflictError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Deadlock found") ||
+		strings.Contains(msg, "Error 1213") ||
+		strings.Contains(msg, "40001") ||
+		strings.Contains(msg, "Lock wait timeout exceeded") ||
+		strings.Contains(msg, "Error 1205")
 }
 
 func (s *Store) uploadReservationQuotaErrorTx(ctx context.Context, tx *sql.Tx, r *UploadReservation) error {

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -270,15 +270,50 @@ func TestRetryMetaLockConflictDoesNotRetryBusinessError(t *testing.T) {
 
 func TestRetryMetaLockConflictExhaustedReturnsBusy(t *testing.T) {
 	var calls int
+	lockErr := errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction")
 	err := retryMetaLockConflict(context.Background(), "tenant-busy", "reserve_upload", "test_op", func() error {
 		calls++
-		return errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction")
+		return lockErr
 	})
 	if !errors.Is(err, ErrQuotaReservationBusy) {
 		t.Fatalf("err = %v, want ErrQuotaReservationBusy", err)
 	}
+	if !errors.Is(err, lockErr) {
+		t.Fatalf("err = %v, want wrapped lock conflict error", err)
+	}
 	if calls != metaLockConflictRetryAttempts {
 		t.Fatalf("calls = %d, want %d", calls, metaLockConflictRetryAttempts)
+	}
+}
+
+func TestIsMetaLockConflictErrorIncludesTiDBWriteConflict(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "tidb write conflict code",
+			err:  errors.New("ERROR 9007 (HY000): Write conflict, txnStartTS=123, conflictStartTS=456"),
+			want: true,
+		},
+		{
+			name: "tidb write conflict message",
+			err:  errors.New("write conflict, retry txn"),
+			want: true,
+		},
+		{
+			name: "unrelated 9007",
+			err:  errors.New("ERROR 9007 quota unavailable"),
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMetaLockConflictError(tt.err); got != tt.want {
+				t.Fatalf("isMetaLockConflictError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -2,8 +2,13 @@ package meta
 
 import (
 	"context"
+	"errors"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 func TestDefaultMaxStorageBytesDefault(t *testing.T) {
@@ -223,5 +228,72 @@ func TestAtomicReserveAndInsertUploadBootstrapsUsageRow(t *testing.T) {
 	}
 	if reservation.Status != "active" || reservation.ReservedBytes != 40 || reservation.FileCountDelta != 1 {
 		t.Fatalf("reservation = %+v, want active reserved=40", reservation)
+	}
+}
+
+func TestRetryMetaLockConflictRetriesDeadlock(t *testing.T) {
+	var calls int
+	err := retryMetaLockConflict(context.Background(), "tenant-retry-metric", "reserve_upload", "test_op", func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retryMetaLockConflict returned error: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("calls = %d, want 3", calls)
+	}
+
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	if !strings.Contains(rec.Body.String(), `drive9_service_operations_total{component="central_quota",operation="reserve_upload",result="lock_conflict_retry",tenant_id="tenant-retry-metric"} 2`) {
+		t.Fatalf("missing lock conflict retry metric:\n%s", rec.Body.String())
+	}
+}
+
+func TestRetryMetaLockConflictDoesNotRetryBusinessError(t *testing.T) {
+	var calls int
+	err := retryMetaLockConflict(context.Background(), "tenant-business-error", "reserve_upload", "test_op", func() error {
+		calls++
+		return ErrStorageQuotaExceeded
+	})
+	if !errors.Is(err, ErrStorageQuotaExceeded) {
+		t.Fatalf("err = %v, want ErrStorageQuotaExceeded", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
+	}
+}
+
+func TestRetryMetaLockConflictExhaustedReturnsBusy(t *testing.T) {
+	var calls int
+	err := retryMetaLockConflict(context.Background(), "tenant-busy", "reserve_upload", "test_op", func() error {
+		calls++
+		return errors.New("Error 1213 (40001): Deadlock found when trying to get lock; try restarting transaction")
+	})
+	if !errors.Is(err, ErrQuotaReservationBusy) {
+		t.Fatalf("err = %v, want ErrQuotaReservationBusy", err)
+	}
+	if calls != metaLockConflictRetryAttempts {
+		t.Fatalf("calls = %d, want %d", calls, metaLockConflictRetryAttempts)
+	}
+}
+
+func TestRetryMetaLockConflictHonorsContextDuringBackoff(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	var calls int
+	err := retryMetaLockConflict(ctx, "tenant-canceled", "reserve_upload", "test_op", func() error {
+		calls++
+		cancel()
+		return errors.New("SQLSTATE 40001 serialization failure")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if calls != 1 {
+		t.Fatalf("calls = %d, want 1", calls)
 	}
 }

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -3,10 +3,13 @@ package meta
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
 
 	"github.com/mem9-ai/drive9/pkg/metrics"
 )
@@ -293,13 +296,28 @@ func TestIsMetaLockConflictErrorIncludesTiDBWriteConflict(t *testing.T) {
 		want bool
 	}{
 		{
-			name: "tidb write conflict code",
-			err:  errors.New("ERROR 9007 (HY000): Write conflict, txnStartTS=123, conflictStartTS=456"),
+			name: "tidb write conflict mysql error",
+			err:  &mysql.MySQLError{Number: 9007, SQLState: [5]byte{'H', 'Y', '0', '0', '0'}, Message: "Write conflict, txnStartTS=123, conflictStartTS=456"},
 			want: true,
 		},
 		{
-			name: "tidb write conflict message",
-			err:  errors.New("write conflict, retry txn"),
+			name: "mysql deadlock",
+			err:  &mysql.MySQLError{Number: 1213, SQLState: [5]byte{'4', '0', '0', '0', '1'}, Message: "Deadlock found when trying to get lock; try restarting transaction"},
+			want: true,
+		},
+		{
+			name: "mysql lock wait timeout",
+			err:  &mysql.MySQLError{Number: 1205, SQLState: [5]byte{'H', 'Y', '0', '0', '0'}, Message: "Lock wait timeout exceeded; try restarting transaction"},
+			want: true,
+		},
+		{
+			name: "sqlstate serialization failure",
+			err:  &mysql.MySQLError{Number: 1105, SQLState: [5]byte{'4', '0', '0', '0', '1'}, Message: "transaction aborted"},
+			want: true,
+		},
+		{
+			name: "tidb write conflict db-shaped fallback",
+			err:  errors.New("ERROR 9007 (HY000): Write conflict, txnStartTS=123, conflictStartTS=456"),
 			want: true,
 		},
 		{
@@ -307,11 +325,78 @@ func TestIsMetaLockConflictErrorIncludesTiDBWriteConflict(t *testing.T) {
 			err:  errors.New("ERROR 9007 quota unavailable"),
 			want: false,
 		},
+		{
+			name: "tidb mysql error without write conflict",
+			err:  &mysql.MySQLError{Number: 9007, SQLState: [5]byte{'H', 'Y', '0', '0', '0'}, Message: "quota unavailable"},
+			want: false,
+		},
+		{
+			name: "unrelated 40001 string",
+			err:  errors.New("quota request 40001 rejected by policy"),
+			want: false,
+		},
+		{
+			name: "unrelated write conflict string",
+			err:  errors.New("application write conflict in cache layer"),
+			want: false,
+		},
+		{
+			name: "wrapped non-db context with 40001",
+			err:  fmt.Errorf("quota admission 40001: %w", errors.New("application rejected write")),
+			want: false,
+		},
+		{
+			name: "wrapped non-db context with write conflict",
+			err:  fmt.Errorf("quota admission write conflict: %w", errors.New("application rejected write")),
+			want: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isMetaLockConflictError(tt.err); got != tt.want {
 				t.Fatalf("isMetaLockConflictError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRetryMetaLockConflictDoesNotRetryFalsePositiveLockText(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "unrelated 40001 string",
+			err:  errors.New("quota request 40001 rejected by policy"),
+		},
+		{
+			name: "unrelated write conflict string",
+			err:  errors.New("application write conflict in cache layer"),
+		},
+		{
+			name: "wrapped non-db context with 40001",
+			err:  fmt.Errorf("quota admission 40001: %w", errors.New("application rejected write")),
+		},
+		{
+			name: "wrapped non-db context with write conflict",
+			err:  fmt.Errorf("quota admission write conflict: %w", errors.New("application rejected write")),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var calls int
+			err := retryMetaLockConflict(context.Background(), "tenant-false-positive", "reserve_upload", "test_op", func() error {
+				calls++
+				return tt.err
+			})
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("err = %v, want original error %v", err, tt.err)
+			}
+			if errors.Is(err, ErrQuotaReservationBusy) {
+				t.Fatalf("err = %v, want no busy fail-open sentinel", err)
+			}
+			if calls != 1 {
+				t.Fatalf("calls = %d, want 1", calls)
 			}
 		})
 	}

--- a/pkg/tenant/quota_adapter.go
+++ b/pkg/tenant/quota_adapter.go
@@ -135,6 +135,8 @@ func (a *metaQuotaAdapter) AtomicReserveAndInsertUpload(ctx context.Context, r *
 		return backend.ErrFileCountQuotaExceeded
 	case errors.Is(err, meta.ErrReservationAlreadyExists):
 		return backend.ErrReservationAlreadyExists
+	case errors.Is(err, meta.ErrQuotaReservationBusy):
+		return backend.ErrQuotaReservationBusy
 	}
 	return err
 }


### PR DESCRIPTION
## Summary
- retry transient lock conflicts around meta upload reservation transactions
- fail open after retry exhaustion to preserve upload availability while recording busy_fail_open metrics
- add regression coverage for retry, business-error bypass, context cancellation, and backend fail-open semantics

## Tests
- go test ./pkg/meta ./pkg/backend ./pkg/server ./pkg/client

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a distinct “quota reservation busy” error signal and corresponding fail-open handling during upload reservations.
  * Emit a dedicated metric for busy fail-open outcomes.

* **Bug Fixes**
  * Central upload quota reservation now retries on temporary metadata lock conflicts with backoff, and returns the busy signal after retries are exhausted.
  * Prevents reserved quota bytes from leaking when the reservation is handled as fail-open.

* **Tests**
  * Added/extended coverage for busy fail-open behavior, lock-conflict retry, retry exhaustion, context cancellation, and lock-conflict detection patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->