### PR TITLE
Cache TiDB Cloud RBAC and persist spending limit

### DIFF
--- a/docs/guides/quota.md
+++ b/docs/guides/quota.md
@@ -205,3 +205,13 @@ The quota API returns JSON errors through the standard server error shape.
   gaps require operational reconciliation from tenant file metadata.
 - Multipart uploads use a stricter reserve-first path before writing tenant
   upload state.
+- TiDB Cloud quota reads expose low-cardinality observability counters:
+  `drive9_tidbcloud_rbac_cache_requests_total`,
+  `drive9_tidbcloud_openapi_requests_total`,
+  `drive9_tidbcloud_spending_limit_sync_total`, and
+  `drive9_tidbcloud_spending_limit_missing_total`. These metrics intentionally
+  do not include `tenant_id`.
+- Do not alert on cache misses, spending-limit backfills, or missing local
+  spending-limit observations being greater than zero. Those are normal during
+  first access, key changes, or migration. Alert only on sustained TiDB Cloud
+  OpenAPI error rate or an unexpected OpenAPI call-rate baseline increase.

--- a/docs/guides/quota.md
+++ b/docs/guides/quota.md
@@ -1,6 +1,6 @@
 # drive9 quota guide
 
-Last verified: 2026-06-24.
+Last verified: 2026-07-10.
 
 This guide shows how to read and update Drive9 tenant quota from the CLI and
 HTTP API in TiDBCloud Mode.
@@ -14,7 +14,7 @@ Drive9 exposes these user-settable quota settings:
 | `max_storage_size` | Maximum confirmed plus reserved file storage size, in Mi. Stored in Drive9. |
 | `max_file_size` | Maximum single file size, in Mi. Stored in Drive9. Must not exceed the server `DRIVE9_MAX_UPLOAD_BYTES` limit. |
 | `max_file_count` | Maximum file count. Stored in Drive9. `0` means unlimited. |
-| `tidbcloud_spending_limit` | TiDB Cloud Cluster Spending Limit. The value is passed through to TiDB Cloud, read from and written to the TiDB Cloud cluster, and not stored in Drive9. See the [TiDB Cloud Spending Limit guide](https://docs.pingcap.com/tidbcloud/manage-serverless-spend-limit). |
+| `tidbcloud_spending_limit` | TiDB Cloud Cluster Spending Limit. Drive9 stores the latest known value locally after create/update or a TiDB Cloud authorization refresh. `0` is a valid explicit value; missing local data is treated as unknown until it is backfilled from TiDB Cloud. See the [TiDB Cloud Spending Limit guide](https://docs.pingcap.com/tidbcloud/manage-serverless-spend-limit). |
 
 Quota responses include these storage usage counters:
 
@@ -36,14 +36,18 @@ the same keys as the server defaults when passed explicitly.
 Only `tidb_cloud_native` tenants support quota update through this API. Other
 tenant providers use their configured defaults.
 
-Tenant list/get first lists TiDB Cloud managed clusters with the supplied TiDB
-Cloud API keys. Drive9 reads local tenant and quota config only after that read
-succeeds.
+Tenant list/get validates that the supplied TiDB Cloud API key can access the
+tenant's cluster. Drive9 caches successful API-key-to-cluster authorization in
+process to avoid calling the TiDB Cloud OpenAPI on every read. The quota
+response itself is assembled from Drive9's local tenant, quota config, and usage
+tables after authorization succeeds.
 
 Quota update first reads the TiDB Cloud cluster labels, then patches the Drive9
 quota update labels to confirm the API key has cluster write permission. If that
 label patch succeeds, Drive9 patches `tidbcloud_spending_limit` when present and
-then writes any Drive9-stored quota fields.
+then writes any Drive9-stored quota fields. If a TiDB Cloud read returns a
+spending limit that is missing or different locally, Drive9 updates the local
+copy before returning the quota response.
 
 ## CLI
 

--- a/docs/guides/quota.md
+++ b/docs/guides/quota.md
@@ -38,9 +38,11 @@ tenant providers use their configured defaults.
 
 Tenant list/get validates that the supplied TiDB Cloud API key can access the
 tenant's cluster. Drive9 caches successful API-key-to-cluster authorization in
-process to avoid calling the TiDB Cloud OpenAPI on every read. The quota
-response itself is assembled from Drive9's local tenant, quota config, and usage
-tables after authorization succeeds.
+process for up to one hour to avoid calling the TiDB Cloud OpenAPI on every
+read. Empty managed-cluster list results are not retained, and successful tenant
+create/delete paths invalidate the full-list cache for the submitted
+credentials. The quota response itself is assembled from Drive9's local tenant,
+quota config, and usage tables after authorization succeeds.
 
 Quota update first reads the TiDB Cloud cluster labels, then patches the Drive9
 quota update labels to confirm the API key has cluster write permission. If that

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -631,6 +631,7 @@ func metaInitSchemaStatements() []string {
 			max_file_count        BIGINT NOT NULL DEFAULT 0,
 			max_media_llm_files   BIGINT NOT NULL DEFAULT 500,
 			max_monthly_cost_mc   BIGINT NOT NULL DEFAULT 0,
+			tidbcloud_spending_limit BIGINT NULL,
 			created_at            DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at            DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
 		)`,

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -631,7 +631,9 @@ func metaInitSchemaStatements() []string {
 			max_file_count        BIGINT NOT NULL DEFAULT 0,
 			max_media_llm_files   BIGINT NOT NULL DEFAULT 500,
 			max_monthly_cost_mc   BIGINT NOT NULL DEFAULT 0,
+			quota_limits_overridden TINYINT(1) NOT NULL DEFAULT 1,
 			tidbcloud_spending_limit BIGINT NULL,
+			tidbcloud_spending_limit_checked_at DATETIME(3) NULL,
 			created_at            DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at            DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
 		)`,

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -964,6 +964,13 @@ func TestMetaSchemaSpecTracksPrimaryKeyConstraint(t *testing.T) {
 	if !pk.isPrimary {
 		t.Fatal("expected primary constraint marker")
 	}
+	spendingLimit, ok := table.columns["tidbcloud_spending_limit"]
+	if !ok {
+		t.Fatal("tenant_quota_config schema missing tidbcloud_spending_limit")
+	}
+	if spendingLimit.addSQL != "ALTER TABLE tenant_quota_config ADD COLUMN tidbcloud_spending_limit BIGINT NULL" {
+		t.Fatalf("tidbcloud_spending_limit addSQL = %q", spendingLimit.addSQL)
+	}
 }
 
 func TestMetaSchemaSpecIncludesTenantS3EncryptionColumns(t *testing.T) {
@@ -1333,14 +1340,15 @@ func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
 	meta := metaTableMeta{
 		tableName: "tenant_quota_config",
 		columns: map[string]metaColumnMeta{
-			"tenant_id":           {columnType: "varchar(64)"},
-			"max_storage_bytes":   {columnType: "bigint"},
-			"max_file_size_bytes": {columnType: "bigint"},
-			"max_file_count":      {columnType: "bigint"},
-			"max_media_llm_files": {columnType: "bigint"},
-			"max_monthly_cost_mc": {columnType: "bigint"},
-			"created_at":          {columnType: "datetime(3)"},
-			"updated_at":          {columnType: "datetime(3)"},
+			"tenant_id":                {columnType: "varchar(64)"},
+			"max_storage_bytes":        {columnType: "bigint"},
+			"max_file_size_bytes":      {columnType: "bigint"},
+			"max_file_count":           {columnType: "bigint"},
+			"max_media_llm_files":      {columnType: "bigint"},
+			"max_monthly_cost_mc":      {columnType: "bigint"},
+			"tidbcloud_spending_limit": {columnType: "bigint"},
+			"created_at":               {columnType: "datetime(3)"},
+			"updated_at":               {columnType: "datetime(3)"},
 		},
 	}
 	createStmt := `CREATE TABLE tenant_quota_config (
@@ -1350,6 +1358,7 @@ func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
 		max_file_count BIGINT NOT NULL,
 		max_media_llm_files BIGINT NOT NULL,
 		max_monthly_cost_mc BIGINT NOT NULL,
+		tidbcloud_spending_limit BIGINT NULL,
 		created_at DATETIME(3) NOT NULL,
 		updated_at DATETIME(3) NOT NULL
 	)`

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -971,6 +971,20 @@ func TestMetaSchemaSpecTracksPrimaryKeyConstraint(t *testing.T) {
 	if spendingLimit.addSQL != "ALTER TABLE tenant_quota_config ADD COLUMN tidbcloud_spending_limit BIGINT NULL" {
 		t.Fatalf("tidbcloud_spending_limit addSQL = %q", spendingLimit.addSQL)
 	}
+	quotaOverride, ok := table.columns["quota_limits_overridden"]
+	if !ok {
+		t.Fatal("tenant_quota_config schema missing quota_limits_overridden")
+	}
+	if quotaOverride.addSQL != "ALTER TABLE tenant_quota_config ADD COLUMN quota_limits_overridden TINYINT(1) NOT NULL DEFAULT 1" {
+		t.Fatalf("quota_limits_overridden addSQL = %q", quotaOverride.addSQL)
+	}
+	checkedAt, ok := table.columns["tidbcloud_spending_limit_checked_at"]
+	if !ok {
+		t.Fatal("tenant_quota_config schema missing tidbcloud_spending_limit_checked_at")
+	}
+	if checkedAt.addSQL != "ALTER TABLE tenant_quota_config ADD COLUMN tidbcloud_spending_limit_checked_at DATETIME(3) NULL" {
+		t.Fatalf("tidbcloud_spending_limit_checked_at addSQL = %q", checkedAt.addSQL)
+	}
 }
 
 func TestMetaSchemaSpecIncludesTenantS3EncryptionColumns(t *testing.T) {
@@ -1340,15 +1354,17 @@ func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
 	meta := metaTableMeta{
 		tableName: "tenant_quota_config",
 		columns: map[string]metaColumnMeta{
-			"tenant_id":                {columnType: "varchar(64)"},
-			"max_storage_bytes":        {columnType: "bigint"},
-			"max_file_size_bytes":      {columnType: "bigint"},
-			"max_file_count":           {columnType: "bigint"},
-			"max_media_llm_files":      {columnType: "bigint"},
-			"max_monthly_cost_mc":      {columnType: "bigint"},
-			"tidbcloud_spending_limit": {columnType: "bigint"},
-			"created_at":               {columnType: "datetime(3)"},
-			"updated_at":               {columnType: "datetime(3)"},
+			"tenant_id":                           {columnType: "varchar(64)"},
+			"max_storage_bytes":                   {columnType: "bigint"},
+			"max_file_size_bytes":                 {columnType: "bigint"},
+			"max_file_count":                      {columnType: "bigint"},
+			"max_media_llm_files":                 {columnType: "bigint"},
+			"max_monthly_cost_mc":                 {columnType: "bigint"},
+			"quota_limits_overridden":             {columnType: "tinyint(1)"},
+			"tidbcloud_spending_limit":            {columnType: "bigint"},
+			"tidbcloud_spending_limit_checked_at": {columnType: "datetime(3)"},
+			"created_at":                          {columnType: "datetime(3)"},
+			"updated_at":                          {columnType: "datetime(3)"},
 		},
 	}
 	createStmt := `CREATE TABLE tenant_quota_config (
@@ -1358,7 +1374,9 @@ func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
 		max_file_count BIGINT NOT NULL,
 		max_media_llm_files BIGINT NOT NULL,
 		max_monthly_cost_mc BIGINT NOT NULL,
+		quota_limits_overridden TINYINT(1) NOT NULL DEFAULT 1,
 		tidbcloud_spending_limit BIGINT NULL,
+		tidbcloud_spending_limit_checked_at DATETIME(3) NULL,
 		created_at DATETIME(3) NOT NULL,
 		updated_at DATETIME(3) NOT NULL
 	)`

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -308,6 +308,46 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 	return nil
 }
 
+// SetTiDBCloudSpendingLimitIfNotUpdatedAfter stores a TiDB Cloud spending-limit
+// observation only when the local quota row was not updated after the cloud read
+// began. It returns false when the guard skips the write.
+func (s *Store) SetTiDBCloudSpendingLimitIfNotUpdatedAfter(ctx context.Context, tenantID string, limit int64, checkedAt, observedAt time.Time) (bool, error) {
+	start := time.Now()
+	var err error
+	defer observeMeta(ctx, "set_tidbcloud_spending_limit_if_not_updated_after", start, &err)
+
+	if observedAt.IsZero() {
+		err = s.SetQuotaConfigPatch(ctx, tenantID, QuotaConfigPatch{
+			TiDBCloudSpendingLimit:          &limit,
+			TiDBCloudSpendingLimitCheckedAt: &checkedAt,
+		})
+		return err == nil, err
+	}
+
+	// tenant_quota_config timestamps use DATETIME(3). Use a strict millisecond
+	// cutoff so writes in the same DB timestamp tick as observedAt are treated as
+	// newer and cannot be overwritten by a stale cloud observation.
+	observedCutoff := observedAt.UTC().Truncate(time.Millisecond)
+	res, err := s.db.ExecContext(ctx,
+		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
+		                                  quota_limits_overridden, tidbcloud_spending_limit,
+		                                  tidbcloud_spending_limit_checked_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		 ON DUPLICATE KEY UPDATE
+		   tidbcloud_spending_limit = IF(updated_at < ?, VALUES(tidbcloud_spending_limit), tidbcloud_spending_limit),
+		   tidbcloud_spending_limit_checked_at = IF(updated_at < ?, VALUES(tidbcloud_spending_limit_checked_at), tidbcloud_spending_limit_checked_at)`,
+		tenantID, DefaultMaxStorageBytes(), int64(0), int64(0), false, sql.NullInt64{Int64: limit, Valid: true}, sql.NullTime{Time: checkedAt, Valid: true},
+		observedCutoff, observedCutoff)
+	if err != nil {
+		return false, fmt.Errorf("set tidbcloud spending limit for tenant %q: %w", tenantID, err)
+	}
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("set tidbcloud spending limit rows affected for tenant %q: %w", tenantID, err)
+	}
+	return rows > 0, nil
+}
+
 func nullInt64FromPtr(v *int64) sql.NullInt64 {
 	if v == nil {
 		return sql.NullInt64{}

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -21,11 +21,15 @@ type QuotaConfig struct {
 	MaxFileCount     int64 // 0 = unlimited
 	MaxMediaLLMFiles int64
 	MaxMonthlyCostMC int64 // millicents; 0 = disabled
+	// QuotaLimitsOverridden tracks whether storage/file quota columns should
+	// override process defaults. Spending-limit-only rows keep this false.
+	QuotaLimitsOverridden bool
 	// TiDBCloudSpendingLimit is nullable because existing tenants may not have
 	// been backfilled from TiDB Cloud yet; 0 is a valid explicit spending limit.
-	TiDBCloudSpendingLimit *int64
-	CreatedAt              time.Time
-	UpdatedAt              time.Time
+	TiDBCloudSpendingLimit          *int64
+	TiDBCloudSpendingLimitCheckedAt *time.Time
+	CreatedAt                       time.Time
+	UpdatedAt                       time.Time
 }
 
 // QuotaUsage holds pre-aggregated quota counters for a tenant.
@@ -41,17 +45,25 @@ type QuotaUsage struct {
 // QuotaConfigPatch carries externally settable quota limits. Nil fields leave
 // existing values unchanged; inserted rows inherit defaults for nil fields.
 type QuotaConfigPatch struct {
-	MaxStorageBytes        *int64
-	MaxFileSizeBytes       *int64
-	MaxFileCount           *int64
-	TiDBCloudSpendingLimit *int64
+	MaxStorageBytes                 *int64
+	MaxFileSizeBytes                *int64
+	MaxFileCount                    *int64
+	TiDBCloudSpendingLimit          *int64
+	TiDBCloudSpendingLimitCheckedAt *time.Time
 }
 
 func (p QuotaConfigPatch) AnySet() bool {
 	return p.MaxStorageBytes != nil ||
 		p.MaxFileSizeBytes != nil ||
 		p.MaxFileCount != nil ||
-		p.TiDBCloudSpendingLimit != nil
+		p.TiDBCloudSpendingLimit != nil ||
+		p.TiDBCloudSpendingLimitCheckedAt != nil
+}
+
+func (p QuotaConfigPatch) quotaLimitOverrideSet() bool {
+	return p.MaxStorageBytes != nil ||
+		p.MaxFileSizeBytes != nil ||
+		p.MaxFileCount != nil
 }
 
 // FileMeta tracks per-file quota-relevant metadata in the server DB.
@@ -122,13 +134,16 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 
 	cfg := &QuotaConfig{TenantID: tenantID}
 	var spendingLimit sql.NullInt64
+	var checkedAt sql.NullTime
 	err = s.db.QueryRowContext(ctx,
 		`SELECT max_storage_bytes, max_file_size_bytes, max_file_count,
-		        max_media_llm_files, max_monthly_cost_mc, tidbcloud_spending_limit,
+		        max_media_llm_files, max_monthly_cost_mc, quota_limits_overridden,
+		        tidbcloud_spending_limit, tidbcloud_spending_limit_checked_at,
 		        created_at, updated_at
 		 FROM tenant_quota_config WHERE tenant_id = ?`, tenantID,
 	).Scan(&cfg.MaxStorageBytes, &cfg.MaxFileSizeBytes, &cfg.MaxFileCount,
-		&cfg.MaxMediaLLMFiles, &cfg.MaxMonthlyCostMC, &spendingLimit, &cfg.CreatedAt, &cfg.UpdatedAt)
+		&cfg.MaxMediaLLMFiles, &cfg.MaxMonthlyCostMC, &cfg.QuotaLimitsOverridden,
+		&spendingLimit, &checkedAt, &cfg.CreatedAt, &cfg.UpdatedAt)
 	if err == sql.ErrNoRows {
 		// Return defaults when no per-tenant config exists.
 		cfg.MaxStorageBytes = DefaultMaxStorageBytes()
@@ -136,15 +151,23 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 		cfg.MaxFileCount = 0
 		cfg.MaxMediaLLMFiles = 500
 		cfg.MaxMonthlyCostMC = 0
+		cfg.QuotaLimitsOverridden = false
 		return cfg, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	if cfg.MaxFileSizeBytes <= 0 {
+	if !cfg.QuotaLimitsOverridden {
+		cfg.MaxStorageBytes = DefaultMaxStorageBytes()
+		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
+		cfg.MaxFileCount = 0
+		cfg.MaxMediaLLMFiles = 500
+		cfg.MaxMonthlyCostMC = 0
+	} else if cfg.MaxFileSizeBytes <= 0 {
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
 	}
 	cfg.TiDBCloudSpendingLimit = ptrFromNullInt64(spendingLimit)
+	cfg.TiDBCloudSpendingLimitCheckedAt = ptrFromNullTime(checkedAt)
 	return cfg, nil
 }
 
@@ -160,11 +183,12 @@ func (s *Store) GetQuotaConfigVersion(ctx context.Context, tenantID string) (str
 	defer observeMeta(ctx, "get_quota_config_version", start, &err)
 
 	var maxStorageBytes, maxFileSizeBytes, maxFileCount, maxMediaLLMFiles, maxMonthlyCostMC int64
+	var quotaLimitsOverridden bool
 	err = s.db.QueryRowContext(ctx,
 		`SELECT max_storage_bytes, max_file_size_bytes, max_file_count,
-		        max_media_llm_files, max_monthly_cost_mc
+		        max_media_llm_files, max_monthly_cost_mc, quota_limits_overridden
 		 FROM tenant_quota_config WHERE tenant_id = ?`, tenantID,
-	).Scan(&maxStorageBytes, &maxFileSizeBytes, &maxFileCount, &maxMediaLLMFiles, &maxMonthlyCostMC)
+	).Scan(&maxStorageBytes, &maxFileSizeBytes, &maxFileCount, &maxMediaLLMFiles, &maxMonthlyCostMC, &quotaLimitsOverridden)
 	if err == sql.ErrNoRows {
 		logger.Info(ctx, "quota_config_not_found_using_defaults",
 			zap.String("tenant_id", tenantID))
@@ -174,11 +198,7 @@ func (s *Store) GetQuotaConfigVersion(ctx context.Context, tenantID string) (str
 	if err != nil {
 		return "", fmt.Errorf("get quota config version for tenant %q: %w", tenantID, err)
 	}
-	if maxStorageBytes == DefaultMaxStorageBytes() &&
-		maxFileSizeBytes == 0 &&
-		maxFileCount == 0 &&
-		maxMediaLLMFiles == 500 &&
-		maxMonthlyCostMC == 0 {
+	if !quotaLimitsOverridden {
 		return "", nil
 	}
 	return fmt.Sprintf("v2:%d:%d:%d:%d:%d", maxStorageBytes, maxFileSizeBytes, maxFileCount, maxMediaLLMFiles, maxMonthlyCostMC), nil
@@ -192,17 +212,21 @@ func (s *Store) SetQuotaConfig(ctx context.Context, cfg *QuotaConfig) error {
 
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
-		                                  max_media_llm_files, max_monthly_cost_mc, tidbcloud_spending_limit)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		                                  max_media_llm_files, max_monthly_cost_mc, quota_limits_overridden,
+		                                  tidbcloud_spending_limit, tidbcloud_spending_limit_checked_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON DUPLICATE KEY UPDATE
 		   max_storage_bytes = VALUES(max_storage_bytes),
 		   max_file_size_bytes = VALUES(max_file_size_bytes),
 		   max_file_count = VALUES(max_file_count),
 		   max_media_llm_files = VALUES(max_media_llm_files),
 		   max_monthly_cost_mc = VALUES(max_monthly_cost_mc),
-		   tidbcloud_spending_limit = VALUES(tidbcloud_spending_limit)`,
+		   quota_limits_overridden = VALUES(quota_limits_overridden),
+		   tidbcloud_spending_limit = VALUES(tidbcloud_spending_limit),
+		   tidbcloud_spending_limit_checked_at = VALUES(tidbcloud_spending_limit_checked_at)`,
 		cfg.TenantID, cfg.MaxStorageBytes, cfg.MaxFileSizeBytes, cfg.MaxFileCount,
-		cfg.MaxMediaLLMFiles, cfg.MaxMonthlyCostMC, nullInt64FromPtr(cfg.TiDBCloudSpendingLimit))
+		cfg.MaxMediaLLMFiles, cfg.MaxMonthlyCostMC, true,
+		nullInt64FromPtr(cfg.TiDBCloudSpendingLimit), nullTimeFromPtr(cfg.TiDBCloudSpendingLimitCheckedAt))
 	return err
 }
 
@@ -246,6 +270,8 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 		insertFileCount = *patch.MaxFileCount
 	}
 	insertSpendingLimit := nullInt64FromPtr(patch.TiDBCloudSpendingLimit)
+	insertCheckedAt := nullTimeFromPtr(patch.TiDBCloudSpendingLimitCheckedAt)
+	insertOverride := patch.quotaLimitOverrideSet()
 	updateStorage := sql.NullInt64{}
 	if patch.MaxStorageBytes != nil {
 		updateStorage = sql.NullInt64{Int64: *patch.MaxStorageBytes, Valid: true}
@@ -259,16 +285,21 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 		updateFileCount = sql.NullInt64{Int64: *patch.MaxFileCount, Valid: true}
 	}
 	updateSpendingLimit := nullInt64FromPtr(patch.TiDBCloudSpendingLimit)
+	updateCheckedAt := nullTimeFromPtr(patch.TiDBCloudSpendingLimitCheckedAt)
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count, tidbcloud_spending_limit)
-		 VALUES (?, ?, ?, ?, ?)
+		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
+		                                  quota_limits_overridden, tidbcloud_spending_limit,
+		                                  tidbcloud_spending_limit_checked_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
 		 ON DUPLICATE KEY UPDATE
 		   max_storage_bytes = COALESCE(?, max_storage_bytes),
 		   max_file_size_bytes = COALESCE(?, max_file_size_bytes),
 		   max_file_count = COALESCE(?, max_file_count),
-		   tidbcloud_spending_limit = COALESCE(?, tidbcloud_spending_limit)`,
-		tenantID, insertStorage, insertFileSize, insertFileCount, insertSpendingLimit,
-		updateStorage, updateFileSize, updateFileCount, updateSpendingLimit)
+		   quota_limits_overridden = IF(?, 1, quota_limits_overridden),
+		   tidbcloud_spending_limit = COALESCE(?, tidbcloud_spending_limit),
+		   tidbcloud_spending_limit_checked_at = COALESCE(?, tidbcloud_spending_limit_checked_at)`,
+		tenantID, insertStorage, insertFileSize, insertFileCount, insertOverride, insertSpendingLimit, insertCheckedAt,
+		updateStorage, updateFileSize, updateFileCount, patch.quotaLimitOverrideSet(), updateSpendingLimit, updateCheckedAt)
 	if err != nil {
 		return fmt.Errorf("set quota config patch for tenant %q: %w", tenantID, err)
 	}
@@ -290,6 +321,21 @@ func ptrFromNullInt64(v sql.NullInt64) *int64 {
 	return &out
 }
 
+func nullTimeFromPtr(v *time.Time) sql.NullTime {
+	if v == nil {
+		return sql.NullTime{}
+	}
+	return sql.NullTime{Time: *v, Valid: true}
+}
+
+func ptrFromNullTime(v sql.NullTime) *time.Time {
+	if !v.Valid {
+		return nil
+	}
+	out := v.Time
+	return &out
+}
+
 func (s *Store) CopyQuotaConfig(ctx context.Context, sourceTenantID, destTenantID string) error {
 	start := time.Now()
 	var err error
@@ -298,6 +344,12 @@ func (s *Store) CopyQuotaConfig(ctx context.Context, sourceTenantID, destTenantI
 	cfg, err := s.GetQuotaConfig(ctx, sourceTenantID)
 	if err != nil {
 		return err
+	}
+	if !cfg.QuotaLimitsOverridden {
+		return s.SetQuotaConfigPatch(ctx, destTenantID, QuotaConfigPatch{
+			TiDBCloudSpendingLimit:          cfg.TiDBCloudSpendingLimit,
+			TiDBCloudSpendingLimitCheckedAt: cfg.TiDBCloudSpendingLimitCheckedAt,
+		})
 	}
 	cfg.TenantID = destTenantID
 	return s.SetQuotaConfig(ctx, cfg)
@@ -539,10 +591,13 @@ func (s *Store) AtomicReserveAndInsertUpload(ctx context.Context, r *UploadReser
 			     file_count = file_count + ?
 			 WHERE tenant_id = ?
 			   AND storage_bytes + reserved_bytes + ? <=
-			       COALESCE((SELECT max_storage_bytes FROM tenant_quota_config WHERE tenant_id = ?), ?)
+			       COALESCE((SELECT CASE WHEN quota_limits_overridden THEN max_storage_bytes ELSE NULL END
+			                 FROM tenant_quota_config WHERE tenant_id = ?), ?)
 			   AND (? <= 0 OR
-			        COALESCE((SELECT max_file_count FROM tenant_quota_config WHERE tenant_id = ?), 0) <= 0 OR
-			        file_count + ? <= COALESCE((SELECT max_file_count FROM tenant_quota_config WHERE tenant_id = ?), 0))`,
+			        COALESCE((SELECT CASE WHEN quota_limits_overridden THEN max_file_count ELSE NULL END
+			                  FROM tenant_quota_config WHERE tenant_id = ?), 0) <= 0 OR
+			        file_count + ? <= COALESCE((SELECT CASE WHEN quota_limits_overridden THEN max_file_count ELSE NULL END
+			                                    FROM tenant_quota_config WHERE tenant_id = ?), 0))`,
 			r.ReservedBytes, r.FileCountDelta, r.TenantID, r.ReservedBytes, r.TenantID, DefaultMaxStorageBytes(),
 			r.FileCountDelta, r.TenantID, r.FileCountDelta, r.TenantID)
 		if execErr != nil {
@@ -579,20 +634,21 @@ func (s *Store) uploadReservationQuotaErrorTx(ctx context.Context, tx *sql.Tx, r
 		return nil
 	}
 	var maxStorageBytes, maxFileCount sql.NullInt64
+	var quotaLimitsOverridden bool
 	if err := tx.QueryRowContext(ctx,
-		`SELECT max_storage_bytes, max_file_count
+		`SELECT max_storage_bytes, max_file_count, quota_limits_overridden
 		 FROM tenant_quota_config WHERE tenant_id = ?`, r.TenantID,
-	).Scan(&maxStorageBytes, &maxFileCount); err != nil && !errors.Is(err, sql.ErrNoRows) {
+	).Scan(&maxStorageBytes, &maxFileCount, &quotaLimitsOverridden); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil
 	}
 	storageLimit := DefaultMaxStorageBytes()
-	if maxStorageBytes.Valid {
+	if quotaLimitsOverridden && maxStorageBytes.Valid {
 		storageLimit = maxStorageBytes.Int64
 	}
 	if storageLimit > 0 && storageBytes+reservedBytes+r.ReservedBytes > storageLimit {
 		return ErrStorageQuotaExceeded
 	}
-	if r.FileCountDelta > 0 && maxFileCount.Valid && maxFileCount.Int64 > 0 && fileCount+r.FileCountDelta > maxFileCount.Int64 {
+	if r.FileCountDelta > 0 && quotaLimitsOverridden && maxFileCount.Valid && maxFileCount.Int64 > 0 && fileCount+r.FileCountDelta > maxFileCount.Int64 {
 		return ErrFileCountQuotaExceeded
 	}
 	return nil

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -239,10 +239,11 @@ func (s *Store) SetQuotaStorageBytes(ctx context.Context, tenantID string, maxSt
 	defer observeMeta(ctx, "set_quota_storage_bytes", start, &err)
 
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes)
-		 VALUES (?, ?)
+		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, quota_limits_overridden)
+		 VALUES (?, ?, 1)
 		 ON DUPLICATE KEY UPDATE
-		   max_storage_bytes = VALUES(max_storage_bytes)`,
+		   max_storage_bytes = VALUES(max_storage_bytes),
+		   quota_limits_overridden = 1`,
 		tenantID, maxStorageBytes)
 	if err != nil {
 		return fmt.Errorf("set quota storage bytes for tenant %q: %w", tenantID, err)

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -21,8 +21,11 @@ type QuotaConfig struct {
 	MaxFileCount     int64 // 0 = unlimited
 	MaxMediaLLMFiles int64
 	MaxMonthlyCostMC int64 // millicents; 0 = disabled
-	CreatedAt        time.Time
-	UpdatedAt        time.Time
+	// TiDBCloudSpendingLimit is nullable because existing tenants may not have
+	// been backfilled from TiDB Cloud yet; 0 is a valid explicit spending limit.
+	TiDBCloudSpendingLimit *int64
+	CreatedAt              time.Time
+	UpdatedAt              time.Time
 }
 
 // QuotaUsage holds pre-aggregated quota counters for a tenant.
@@ -38,9 +41,17 @@ type QuotaUsage struct {
 // QuotaConfigPatch carries externally settable quota limits. Nil fields leave
 // existing values unchanged; inserted rows inherit defaults for nil fields.
 type QuotaConfigPatch struct {
-	MaxStorageBytes  *int64
-	MaxFileSizeBytes *int64
-	MaxFileCount     *int64
+	MaxStorageBytes        *int64
+	MaxFileSizeBytes       *int64
+	MaxFileCount           *int64
+	TiDBCloudSpendingLimit *int64
+}
+
+func (p QuotaConfigPatch) AnySet() bool {
+	return p.MaxStorageBytes != nil ||
+		p.MaxFileSizeBytes != nil ||
+		p.MaxFileCount != nil ||
+		p.TiDBCloudSpendingLimit != nil
 }
 
 // FileMeta tracks per-file quota-relevant metadata in the server DB.
@@ -110,12 +121,14 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 	defer observeMeta(ctx, "get_quota_config", start, &err)
 
 	cfg := &QuotaConfig{TenantID: tenantID}
+	var spendingLimit sql.NullInt64
 	err = s.db.QueryRowContext(ctx,
 		`SELECT max_storage_bytes, max_file_size_bytes, max_file_count,
-		        max_media_llm_files, max_monthly_cost_mc, created_at, updated_at
+		        max_media_llm_files, max_monthly_cost_mc, tidbcloud_spending_limit,
+		        created_at, updated_at
 		 FROM tenant_quota_config WHERE tenant_id = ?`, tenantID,
 	).Scan(&cfg.MaxStorageBytes, &cfg.MaxFileSizeBytes, &cfg.MaxFileCount,
-		&cfg.MaxMediaLLMFiles, &cfg.MaxMonthlyCostMC, &cfg.CreatedAt, &cfg.UpdatedAt)
+		&cfg.MaxMediaLLMFiles, &cfg.MaxMonthlyCostMC, &spendingLimit, &cfg.CreatedAt, &cfg.UpdatedAt)
 	if err == sql.ErrNoRows {
 		// Return defaults when no per-tenant config exists.
 		cfg.MaxStorageBytes = DefaultMaxStorageBytes()
@@ -131,14 +144,16 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 	if cfg.MaxFileSizeBytes <= 0 {
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
 	}
+	cfg.TiDBCloudSpendingLimit = ptrFromNullInt64(spendingLimit)
 	return cfg, nil
 }
 
 // GetQuotaConfigVersion returns a lightweight content token for a tenant's
-// explicit quota config. An empty token means no row exists and callers should
-// use GetQuotaConfig's default config. The token is derived from the effective
-// config values instead of updated_at so updates inside the same timestamp tick
-// cannot hide a real config change from cache invalidation.
+// explicit storage quota config. An empty token means no storage-relevant row
+// exists and callers should use GetQuotaConfig's default storage config. The
+// token is derived from the effective config values instead of updated_at so
+// updates inside the same timestamp tick cannot hide a real config change from
+// cache invalidation.
 func (s *Store) GetQuotaConfigVersion(ctx context.Context, tenantID string) (string, error) {
 	start := time.Now()
 	var err error
@@ -159,6 +174,13 @@ func (s *Store) GetQuotaConfigVersion(ctx context.Context, tenantID string) (str
 	if err != nil {
 		return "", fmt.Errorf("get quota config version for tenant %q: %w", tenantID, err)
 	}
+	if maxStorageBytes == DefaultMaxStorageBytes() &&
+		maxFileSizeBytes == 0 &&
+		maxFileCount == 0 &&
+		maxMediaLLMFiles == 500 &&
+		maxMonthlyCostMC == 0 {
+		return "", nil
+	}
 	return fmt.Sprintf("v2:%d:%d:%d:%d:%d", maxStorageBytes, maxFileSizeBytes, maxFileCount, maxMediaLLMFiles, maxMonthlyCostMC), nil
 }
 
@@ -170,16 +192,17 @@ func (s *Store) SetQuotaConfig(ctx context.Context, cfg *QuotaConfig) error {
 
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
-		                                  max_media_llm_files, max_monthly_cost_mc)
-		 VALUES (?, ?, ?, ?, ?, ?)
+		                                  max_media_llm_files, max_monthly_cost_mc, tidbcloud_spending_limit)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)
 		 ON DUPLICATE KEY UPDATE
 		   max_storage_bytes = VALUES(max_storage_bytes),
 		   max_file_size_bytes = VALUES(max_file_size_bytes),
 		   max_file_count = VALUES(max_file_count),
 		   max_media_llm_files = VALUES(max_media_llm_files),
-		   max_monthly_cost_mc = VALUES(max_monthly_cost_mc)`,
+		   max_monthly_cost_mc = VALUES(max_monthly_cost_mc),
+		   tidbcloud_spending_limit = VALUES(tidbcloud_spending_limit)`,
 		cfg.TenantID, cfg.MaxStorageBytes, cfg.MaxFileSizeBytes, cfg.MaxFileCount,
-		cfg.MaxMediaLLMFiles, cfg.MaxMonthlyCostMC)
+		cfg.MaxMediaLLMFiles, cfg.MaxMonthlyCostMC, nullInt64FromPtr(cfg.TiDBCloudSpendingLimit))
 	return err
 }
 
@@ -222,6 +245,7 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 	if patch.MaxFileCount != nil {
 		insertFileCount = *patch.MaxFileCount
 	}
+	insertSpendingLimit := nullInt64FromPtr(patch.TiDBCloudSpendingLimit)
 	updateStorage := sql.NullInt64{}
 	if patch.MaxStorageBytes != nil {
 		updateStorage = sql.NullInt64{Int64: *patch.MaxStorageBytes, Valid: true}
@@ -234,19 +258,36 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 	if patch.MaxFileCount != nil {
 		updateFileCount = sql.NullInt64{Int64: *patch.MaxFileCount, Valid: true}
 	}
+	updateSpendingLimit := nullInt64FromPtr(patch.TiDBCloudSpendingLimit)
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count)
-		 VALUES (?, ?, ?, ?)
+		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count, tidbcloud_spending_limit)
+		 VALUES (?, ?, ?, ?, ?)
 		 ON DUPLICATE KEY UPDATE
 		   max_storage_bytes = COALESCE(?, max_storage_bytes),
 		   max_file_size_bytes = COALESCE(?, max_file_size_bytes),
-		   max_file_count = COALESCE(?, max_file_count)`,
-		tenantID, insertStorage, insertFileSize, insertFileCount,
-		updateStorage, updateFileSize, updateFileCount)
+		   max_file_count = COALESCE(?, max_file_count),
+		   tidbcloud_spending_limit = COALESCE(?, tidbcloud_spending_limit)`,
+		tenantID, insertStorage, insertFileSize, insertFileCount, insertSpendingLimit,
+		updateStorage, updateFileSize, updateFileCount, updateSpendingLimit)
 	if err != nil {
 		return fmt.Errorf("set quota config patch for tenant %q: %w", tenantID, err)
 	}
 	return nil
+}
+
+func nullInt64FromPtr(v *int64) sql.NullInt64 {
+	if v == nil {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: *v, Valid: true}
+}
+
+func ptrFromNullInt64(v sql.NullInt64) *int64 {
+	if !v.Valid {
+		return nil
+	}
+	out := v.Int64
+	return &out
 }
 
 func (s *Store) CopyQuotaConfig(ctx context.Context, sourceTenantID, destTenantID string) error {

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -257,6 +257,7 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 	var err error
 	defer observeMeta(ctx, "set_quota_config_patch", start, &err)
 
+	quotaLimitOverrideSet := patch.quotaLimitOverrideSet()
 	insertStorage := DefaultMaxStorageBytes()
 	if patch.MaxStorageBytes != nil {
 		insertStorage = *patch.MaxStorageBytes
@@ -271,7 +272,6 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 	}
 	insertSpendingLimit := nullInt64FromPtr(patch.TiDBCloudSpendingLimit)
 	insertCheckedAt := nullTimeFromPtr(patch.TiDBCloudSpendingLimitCheckedAt)
-	insertOverride := patch.quotaLimitOverrideSet()
 	updateStorage := sql.NullInt64{}
 	if patch.MaxStorageBytes != nil {
 		updateStorage = sql.NullInt64{Int64: *patch.MaxStorageBytes, Valid: true}
@@ -291,15 +291,16 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 		                                  quota_limits_overridden, tidbcloud_spending_limit,
 		                                  tidbcloud_spending_limit_checked_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?)
-		 ON DUPLICATE KEY UPDATE
-		   max_storage_bytes = COALESCE(?, max_storage_bytes),
-		   max_file_size_bytes = COALESCE(?, max_file_size_bytes),
-		   max_file_count = COALESCE(?, max_file_count),
-		   quota_limits_overridden = IF(?, 1, quota_limits_overridden),
-		   tidbcloud_spending_limit = COALESCE(?, tidbcloud_spending_limit),
-		   tidbcloud_spending_limit_checked_at = COALESCE(?, tidbcloud_spending_limit_checked_at)`,
-		tenantID, insertStorage, insertFileSize, insertFileCount, insertOverride, insertSpendingLimit, insertCheckedAt,
-		updateStorage, updateFileSize, updateFileCount, patch.quotaLimitOverrideSet(), updateSpendingLimit, updateCheckedAt)
+			 ON DUPLICATE KEY UPDATE
+			   max_storage_bytes = COALESCE(?, max_storage_bytes),
+			   max_file_size_bytes = COALESCE(?, max_file_size_bytes),
+			   max_file_count = COALESCE(?, max_file_count),
+			   /* Storage quota overrides are sticky once any storage/file limit is explicitly set. */
+			   quota_limits_overridden = IF(?, 1, quota_limits_overridden),
+			   tidbcloud_spending_limit = COALESCE(?, tidbcloud_spending_limit),
+			   tidbcloud_spending_limit_checked_at = COALESCE(?, tidbcloud_spending_limit_checked_at)`,
+		tenantID, insertStorage, insertFileSize, insertFileCount, quotaLimitOverrideSet, insertSpendingLimit, insertCheckedAt,
+		updateStorage, updateFileSize, updateFileCount, quotaLimitOverrideSet, updateSpendingLimit, updateCheckedAt)
 	if err != nil {
 		return fmt.Errorf("set quota config patch for tenant %q: %w", tenantID, err)
 	}

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -288,6 +288,50 @@ func TestSetQuotaConfigPatchUpdatesExternalFieldsOnly(t *testing.T) {
 	}
 }
 
+func TestSetTiDBCloudSpendingLimitIfNotUpdatedAfterSkipsNewerLocal(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	newLimit := int64(200)
+	if err := s.SetQuotaConfigPatch(ctx, "tenant-spending-cas", QuotaConfigPatch{TiDBCloudSpendingLimit: &newLimit}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := s.GetQuotaConfig(ctx, "tenant-spending-cas")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	applied, err := s.SetTiDBCloudSpendingLimitIfNotUpdatedAfter(ctx, "tenant-spending-cas", 100, time.Now().UTC(), cfg.UpdatedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if applied {
+		t.Fatal("stale spending limit sync applied, want skipped")
+	}
+	cfg, err = s.GetQuotaConfig(ctx, "tenant-spending-cas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != newLimit {
+		t.Fatalf("spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, newLimit)
+	}
+
+	applied, err = s.SetTiDBCloudSpendingLimitIfNotUpdatedAfter(ctx, "tenant-spending-cas", 300, time.Now().UTC(), cfg.UpdatedAt.Add(2*time.Millisecond))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !applied {
+		t.Fatal("fresh spending limit sync skipped, want applied")
+	}
+	cfg, err = s.GetQuotaConfig(ctx, "tenant-spending-cas")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != 300 {
+		t.Fatalf("spending limit after fresh sync = %#v, want 300", cfg.TiDBCloudSpendingLimit)
+	}
+}
+
 func TestAtomicReserveAndInsertUploadBootstrapsUsageRow(t *testing.T) {
 	orig := DefaultMaxStorageBytes()
 	defer func() { SetDefaultMaxStorageBytes(orig) }()

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -76,6 +76,53 @@ func TestGetQuotaConfigUsesConfiguredDefaultStorageBytes(t *testing.T) {
 	}
 }
 
+func TestQuotaConfigStoresTiDBCloudSpendingLimitWithoutStorageVersion(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	cfg, err := s.GetQuotaConfig(ctx, "tenant-spending-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit != nil {
+		t.Fatalf("default spending limit = %#v, want nil", cfg.TiDBCloudSpendingLimit)
+	}
+
+	zero := int64(0)
+	if err := s.SetQuotaConfigPatch(ctx, "tenant-spending-only", QuotaConfigPatch{TiDBCloudSpendingLimit: &zero}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = s.GetQuotaConfig(ctx, "tenant-spending-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != 0 {
+		t.Fatalf("spending limit = %#v, want 0", cfg.TiDBCloudSpendingLimit)
+	}
+	if cfg.MaxStorageBytes != DefaultMaxStorageBytes() || cfg.MaxFileSizeBytes != DefaultMaxFileSizeBytes() || cfg.MaxFileCount != 0 {
+		t.Fatalf("storage quota fields = %#v, want defaults", cfg)
+	}
+	version, err := s.GetQuotaConfigVersion(ctx, "tenant-spending-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if version != "" {
+		t.Fatalf("storage quota version = %q, want empty", version)
+	}
+
+	updated := int64(123)
+	if err := s.SetQuotaConfigPatch(ctx, "tenant-spending-only", QuotaConfigPatch{TiDBCloudSpendingLimit: &updated}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = s.GetQuotaConfig(ctx, "tenant-spending-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != updated {
+		t.Fatalf("updated spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, updated)
+	}
+}
+
 func TestGetQuotaConfigVersion(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -223,6 +223,40 @@ func TestSetQuotaStorageBytesInsertsInternalDefaults(t *testing.T) {
 	}
 }
 
+func TestSetQuotaStorageBytesOverridesSpendingOnlyRow(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	spendingLimit := int64(100)
+	if err := s.SetQuotaConfigPatch(ctx, "tenant-spending-then-storage", QuotaConfigPatch{TiDBCloudSpendingLimit: &spendingLimit}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := s.GetQuotaConfig(ctx, "tenant-spending-then-storage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.QuotaLimitsOverridden {
+		t.Fatal("QuotaLimitsOverridden after spending-only patch = true, want false")
+	}
+
+	if err := s.SetQuotaStorageBytes(ctx, "tenant-spending-then-storage", 12345); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = s.GetQuotaConfig(ctx, "tenant-spending-then-storage")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MaxStorageBytes != 12345 {
+		t.Fatalf("MaxStorageBytes = %d, want 12345", cfg.MaxStorageBytes)
+	}
+	if !cfg.QuotaLimitsOverridden {
+		t.Fatal("QuotaLimitsOverridden = false, want true after storage override")
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
+		t.Fatalf("TiDBCloudSpendingLimit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)
+	}
+}
+
 func TestSetQuotaConfigPatchUpdatesExternalFieldsOnly(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -102,6 +102,9 @@ func TestQuotaConfigStoresTiDBCloudSpendingLimitWithoutStorageVersion(t *testing
 	if cfg.MaxStorageBytes != DefaultMaxStorageBytes() || cfg.MaxFileSizeBytes != DefaultMaxFileSizeBytes() || cfg.MaxFileCount != 0 {
 		t.Fatalf("storage quota fields = %#v, want defaults", cfg)
 	}
+	if cfg.QuotaLimitsOverridden {
+		t.Fatalf("QuotaLimitsOverridden = true, want false for spending-only row")
+	}
 	version, err := s.GetQuotaConfigVersion(ctx, "tenant-spending-only")
 	if err != nil {
 		t.Fatal(err)
@@ -120,6 +123,20 @@ func TestQuotaConfigStoresTiDBCloudSpendingLimitWithoutStorageVersion(t *testing
 	}
 	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != updated {
 		t.Fatalf("updated spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, updated)
+	}
+	checkedAt := time.Now().UTC()
+	if err := s.SetQuotaConfigPatch(ctx, "tenant-spending-only", QuotaConfigPatch{TiDBCloudSpendingLimitCheckedAt: &checkedAt}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = s.GetQuotaConfig(ctx, "tenant-spending-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimitCheckedAt == nil {
+		t.Fatal("spending limit checked_at = nil, want timestamp")
+	}
+	if cfg.QuotaLimitsOverridden {
+		t.Fatalf("QuotaLimitsOverridden after checked_at = true, want false")
 	}
 }
 

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -49,6 +49,10 @@ var serviceGauge = serviceMeter.Float64Gauge("drive9_service_gauge", "Service ga
 var tenantPoolMetadataResumeWaitTotal = serviceMeter.Int64Counter("drive9_tenant_pool_metadata_resume_wait_total", "Tenant pool metadata resume wait attempts by pool_id/organization_id/scope/result")
 var tenantPoolMetadataResumeWaitDuration = serviceMeter.Float64Histogram("drive9_tenant_pool_metadata_resume_wait_duration_seconds", "Tenant pool metadata resume wait duration by pool_id/organization_id/scope/result", tenantPoolMetadataResumeWaitDurationBounds)
 var tenantPoolCapacity = serviceMeter.Float64Gauge("drive9_tenant_pool_capacity", "Tenant pool capacity by pool_id/organization_id/state")
+var tidbCloudRBACCacheRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_rbac_cache_requests_total", "TiDB Cloud API key to cluster RBAC cache requests by path/scope/result")
+var tidbCloudOpenAPIRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_openapi_requests_total", "TiDB Cloud OpenAPI requests by path/operation/result")
+var tidbCloudSpendingLimitSyncTotal = serviceMeter.Int64Counter("drive9_tidbcloud_spending_limit_sync_total", "TiDB Cloud spending limit local sync outcomes by source/result")
+var tidbCloudSpendingLimitMissingTotal = serviceMeter.Int64Counter("drive9_tidbcloud_spending_limit_missing_total", "TiDB Cloud spending limit missing local config observations by path")
 
 var httpRequestsTotal = httpMeter.Int64Counter("drive9_http_requests_total", "Total HTTP requests by method/route/status")
 var httpRequestDuration = httpMeter.Float64Histogram("drive9_http_request_duration_seconds", "HTTP request duration histogram by method/route", httpDurationBounds)
@@ -146,6 +150,39 @@ func RecordTenantPoolCapacity(poolID, organizationID, state string, value float6
 		Attr("pool_id", cleanMetricValue(poolID, "unknown")),
 		Attr("organization_id", cleanMetricValue(organizationID, "unknown")),
 		Attr("state", cleanMetricValue(state, "unknown")),
+	)
+}
+
+func RecordTiDBCloudRBACCacheRequest(path, scope, result string) {
+	RegisterModule("tidbcloud_quota")
+	tidbCloudRBACCacheRequestsTotal.Add(1,
+		Attr("path", cleanMetricValue(path, "unknown")),
+		Attr("scope", cleanMetricValue(scope, "unknown")),
+		Attr("result", cleanMetricValue(result, "unknown")),
+	)
+}
+
+func RecordTiDBCloudOpenAPIRequest(path, operation, result string) {
+	RegisterModule("tidbcloud_quota")
+	tidbCloudOpenAPIRequestsTotal.Add(1,
+		Attr("path", cleanMetricValue(path, "unknown")),
+		Attr("operation", cleanMetricValue(operation, "unknown")),
+		Attr("result", cleanMetricValue(result, "unknown")),
+	)
+}
+
+func RecordTiDBCloudSpendingLimitSync(source, result string) {
+	RegisterModule("tidbcloud_quota")
+	tidbCloudSpendingLimitSyncTotal.Add(1,
+		Attr("source", cleanMetricValue(source, "unknown")),
+		Attr("result", cleanMetricValue(result, "unknown")),
+	)
+}
+
+func RecordTiDBCloudSpendingLimitMissing(path string) {
+	RegisterModule("tidbcloud_quota")
+	tidbCloudSpendingLimitMissingTotal.Add(1,
+		Attr("path", cleanMetricValue(path, "unknown")),
 	)
 }
 

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -123,6 +123,32 @@ func TestRecordTenantPoolCapacityIncludesPoolOrganizationAndState(t *testing.T) 
 	}
 }
 
+func TestTiDBCloudQuotaMetricsOmitTenantID(t *testing.T) {
+	RecordTiDBCloudRBACCacheRequest("quota_get", "cluster", "hit")
+	RecordTiDBCloudOpenAPIRequest("admin_tenant_get", "list_managed_clusters", "ok")
+	RecordTiDBCloudSpendingLimitSync("quota_get", "updated")
+	RecordTiDBCloudSpendingLimitMissing("admin_tenant_list")
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	for _, want := range []string{
+		`drive9_tidbcloud_rbac_cache_requests_total{path="quota_get",result="hit",scope="cluster"} 1`,
+		`drive9_tidbcloud_openapi_requests_total{operation="list_managed_clusters",path="admin_tenant_get",result="ok"} 1`,
+		`drive9_tidbcloud_spending_limit_sync_total{result="updated",source="quota_get"} 1`,
+		`drive9_tidbcloud_spending_limit_missing_total{path="admin_tenant_list"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing TiDB Cloud quota metric %q:\n%s", want, text)
+		}
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "drive9_tidbcloud_") && strings.Contains(line, `tenant_id=`) {
+			t.Fatalf("TiDB Cloud quota metrics must not carry tenant_id:\n%s", text)
+		}
+	}
+}
+
 func TestRecordDBOperationOmitsTenantID(t *testing.T) {
 	const tenantID = "tenant-db-operation-test"
 

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -873,9 +873,13 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 				cleanupOnError = true
 				return nil, err
 			}
-			if err := s.syncTiDBCloudSpendingLimit(ctx, "pool_create", tenantID, batchCloudCfg); err != nil {
-				cleanupOnError = true
-				return nil, err
+			if err := s.syncTiDBCloudSpendingLimit(ctx, "pool_create", tenantID, batchCloudCfg, time.Time{}); err != nil {
+				logger.Warn(ctx, "admin_tenant_pool_spending_limit_sync_failed",
+					zap.String("tenant_id", tenantID),
+					zap.String("pool_id", poolID),
+					zap.String("organization_id", orgID),
+					zap.String("cluster_id", cluster.ClusterID),
+					zap.Error(err))
 			}
 			logProvisionStage(ctx, "admin_tenant_pool_free_tenant_quota_local_config_applied", tenantID, provider, stageStarted,
 				"pool_id", poolID,
@@ -1677,7 +1681,7 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		if err := s.applyQuotaLocalConfig(ctx, "pool_claim", row.Tenant.ID, quotaReq); err != nil {
 			return nil, nil, false, err
 		}
-		if err := s.syncTiDBCloudSpendingLimit(ctx, "pool_claim", row.Tenant.ID, cloudCfg); err != nil {
+		if err := s.syncTiDBCloudSpendingLimit(ctx, "pool_claim", row.Tenant.ID, cloudCfg, time.Time{}); err != nil {
 			return nil, nil, false, err
 		}
 		logProvisionStage(ctx, "admin_tenant_pool_claim_quota_local_config_applied", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "create_time_spending_limit", cloudCfg != nil && cloudCfg.TiDBCloudSpendingLimitMonthly != nil)

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -732,7 +732,7 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 		"pool_id", poolID,
 		"count", len(tenantIDs),
 		"quota_requested", quotaOpt != nil)...)
-	clusters, _, err := manager.BatchProvisionFreeClustersWithCredentialsAndQuota(ctx, tenantIDs, cred, opts)
+	clusters, batchCloudCfg, err := manager.BatchProvisionFreeClustersWithCredentialsAndQuota(ctx, tenantIDs, cred, opts)
 	if err != nil && len(clusters) == 0 {
 		logger.Error(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_batch_create_failed",
 			"provider", provider,
@@ -864,6 +864,24 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 				"organization_id", orgID,
 				"cluster_id", cluster.ClusterID,
 				"status", meta.TenantPending)
+		}
+		if quotaOpt != nil {
+			stageStarted = time.Now()
+			quotaReq := *quotaOpt
+			quotaReq.TenantID = tenantID
+			if err := s.applyQuotaLocalConfig(ctx, tenantID, quotaReq); err != nil {
+				cleanupOnError = true
+				return nil, err
+			}
+			if err := s.syncTiDBCloudSpendingLimit(ctx, tenantID, batchCloudCfg); err != nil {
+				cleanupOnError = true
+				return nil, err
+			}
+			logProvisionStage(ctx, "admin_tenant_pool_free_tenant_quota_local_config_applied", tenantID, provider, stageStarted,
+				"pool_id", poolID,
+				"organization_id", orgID,
+				"cluster_id", cluster.ClusterID,
+				"create_time_spending_limit", batchCloudCfg != nil && batchCloudCfg.TiDBCloudSpendingLimitMonthly != nil)
 		}
 		results = append(results, res)
 	}
@@ -1640,7 +1658,8 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 	}
 	cluster := clusterInfoFromTenant(&row.Tenant)
 	stageStarted = time.Now()
-	if _, err := manager.MarkClusterPoolUsed(ctx, cluster, cred, usedAt, opts); err != nil {
+	cloudCfg, err := manager.MarkClusterPoolUsed(ctx, cluster, cred, usedAt, opts)
+	if err != nil {
 		s.releaseClaimedPoolTenant(ctx, manager, cluster, cred, row.Tenant.ID, "mark_used_error")
 		return nil, nil, false, err
 	}
@@ -1658,7 +1677,10 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		if err := s.applyQuotaLocalConfig(ctx, row.Tenant.ID, quotaReq); err != nil {
 			return nil, nil, false, err
 		}
-		logProvisionStage(ctx, "admin_tenant_pool_claim_quota_local_config_applied", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID)
+		if err := s.syncTiDBCloudSpendingLimit(ctx, row.Tenant.ID, cloudCfg); err != nil {
+			return nil, nil, false, err
+		}
+		logProvisionStage(ctx, "admin_tenant_pool_claim_quota_local_config_applied", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "create_time_spending_limit", cloudCfg != nil && cloudCfg.TiDBCloudSpendingLimitMonthly != nil)
 	}
 	stageStarted = time.Now()
 	plainPass, err := s.pool.Decrypt(ctx, row.Tenant.DBPasswordCipher)

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -869,11 +869,11 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			stageStarted = time.Now()
 			quotaReq := *quotaOpt
 			quotaReq.TenantID = tenantID
-			if err := s.applyQuotaLocalConfig(ctx, tenantID, quotaReq); err != nil {
+			if err := s.applyQuotaLocalConfig(ctx, "pool_create", tenantID, quotaReq); err != nil {
 				cleanupOnError = true
 				return nil, err
 			}
-			if err := s.syncTiDBCloudSpendingLimit(ctx, tenantID, batchCloudCfg); err != nil {
+			if err := s.syncTiDBCloudSpendingLimit(ctx, "pool_create", tenantID, batchCloudCfg); err != nil {
 				cleanupOnError = true
 				return nil, err
 			}
@@ -1674,10 +1674,10 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		stageStarted = time.Now()
 		quotaReq := *quotaOpt
 		quotaReq.TenantID = row.Tenant.ID
-		if err := s.applyQuotaLocalConfig(ctx, row.Tenant.ID, quotaReq); err != nil {
+		if err := s.applyQuotaLocalConfig(ctx, "pool_claim", row.Tenant.ID, quotaReq); err != nil {
 			return nil, nil, false, err
 		}
-		if err := s.syncTiDBCloudSpendingLimit(ctx, row.Tenant.ID, cloudCfg); err != nil {
+		if err := s.syncTiDBCloudSpendingLimit(ctx, "pool_claim", row.Tenant.ID, cloudCfg); err != nil {
 			return nil, nil, false, err
 		}
 		logProvisionStage(ctx, "admin_tenant_pool_claim_quota_local_config_applied", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "create_time_spending_limit", cloudCfg != nil && cloudCfg.TiDBCloudSpendingLimitMonthly != nil)

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
@@ -229,7 +230,7 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	clusters, err := s.listAllManagedClusters(r.Context(), cred, "")
+	clusters, err := s.listAllManagedClusters(r.Context(), cred, "", "admin_tenant_list")
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "list tenants")
 		return
@@ -267,8 +268,8 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 			errJSON(w, http.StatusInternalServerError, "quota lookup failed")
 			return
 		}
-		if s.adminTenantRowsNeedSpendingLimitBackfill(r.Context(), rows) {
-			clusters, err = s.listAllManagedClustersFresh(r.Context(), cred, "")
+		if s.adminTenantRowsNeedSpendingLimitBackfill(r.Context(), "admin_tenant_list", rows) {
+			clusters, err = s.listAllManagedClustersFresh(r.Context(), cred, "", "admin_tenant_list")
 			if err != nil {
 				writeAdminTiDBCloudError(w, r.Context(), err, "list tenants")
 				return
@@ -338,7 +339,7 @@ func (s *Server) handleAdminTenantQuotaSet(w http.ResponseWriter, r *http.Reques
 		errJSON(w, http.StatusConflict, err.Error())
 		return
 	}
-	if err := s.applyQuotaSet(r.Context(), t, cred, quotaReq); err != nil {
+	if err := s.applyQuotaSet(r.Context(), "admin_tenant_quota_set", t, cred, quotaReq); err != nil {
 		writeQuotaSetError(w, r.Context(), err, "update")
 		return
 	}
@@ -479,13 +480,13 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 		}
 		allowCache = cfg.TiDBCloudSpendingLimit != nil
 	}
-	clusters, err := s.listAllManagedClustersCached(r.Context(), cred, binding.ClusterID, allowCache)
+	clusters, err := s.listAllManagedClustersCached(r.Context(), cred, binding.ClusterID, allowCache, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
 		return nil, nil, false
 	}
 	if len(clusters) == 0 && allowDeletingMissingCluster && t.Status == meta.TenantDeleting {
-		clusters, err = s.listAllManagedClusters(r.Context(), cred, "")
+		clusters, err = s.listAllManagedClusters(r.Context(), cred, "", adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
 		if err != nil {
 			writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
 			return nil, nil, false
@@ -515,7 +516,7 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 	}
 	if loadQuota {
 		cloudCfg := &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: authorizedCluster.TiDBCloudSpendingLimitMonthly}
-		if err := s.syncTiDBCloudSpendingLimit(r.Context(), t.ID, cloudCfg); err != nil {
+		if err := s.syncTiDBCloudSpendingLimit(r.Context(), "admin_tenant_get", t.ID, cloudCfg); err != nil {
 			logger.Warn(r.Context(), "admin_tenant_spending_limit_sync_failed", zap.String("tenant_id", t.ID), zap.Error(err))
 			errJSON(w, http.StatusInternalServerError, "quota lookup failed")
 			return nil, nil, false
@@ -524,26 +525,46 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 	return t, binding, true
 }
 
-func (s *Server) listAllManagedClusters(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string) ([]tenant.CloudClusterInfo, error) {
-	return s.listAllManagedClustersCached(ctx, cred, clusterID, true)
+func adminTenantMetricPath(loadQuota bool, allowDeletingMissingCluster bool) string {
+	switch {
+	case loadQuota:
+		return "admin_tenant_get"
+	case allowDeletingMissingCluster:
+		return "admin_tenant_delete"
+	default:
+		return "admin_tenant_quota_set"
+	}
 }
 
-func (s *Server) listAllManagedClustersFresh(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string) ([]tenant.CloudClusterInfo, error) {
-	return s.listAllManagedClustersCached(ctx, cred, clusterID, false)
+func (s *Server) listAllManagedClusters(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, error) {
+	return s.listAllManagedClustersCached(ctx, cred, clusterID, true, metricPath)
 }
 
-func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string, allowCache bool) ([]tenant.CloudClusterInfo, error) {
+func (s *Server) listAllManagedClustersFresh(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, error) {
+	return s.listAllManagedClustersCached(ctx, cred, clusterID, false, metricPath)
+}
+
+func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string, allowCache bool, metricPath string) ([]tenant.CloudClusterInfo, error) {
 	clusterID = strings.TrimSpace(clusterID)
+	scope := "list"
+	if clusterID != "" {
+		scope = "cluster"
+	}
 	if allowCache {
 		if clusterID != "" {
 			if cluster, ok := s.tidbCloudRBACCache.getCluster(cred, clusterID); ok {
 				if cluster.OrganizationID != "" {
+					metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "hit")
 					return []tenant.CloudClusterInfo{cluster}, nil
 				}
 			}
 		} else if clusters, ok := s.tidbCloudRBACCache.getClusterList(cred); ok {
+			metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "hit")
 			return clusters, nil
 		}
+		metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "miss")
+	} else {
+		metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "bypass")
 	}
 	lister, ok := s.provisioner.(tenant.ManagedClusterLister)
 	if !ok {
@@ -558,8 +579,10 @@ func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.C
 			ClusterID: clusterID,
 		})
 		if err != nil {
+			metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "list_managed_clusters", "error")
 			return nil, err
 		}
+		metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "list_managed_clusters", "ok")
 		if page == nil {
 			if clusterID == "" {
 				s.tidbCloudRBACCache.rememberClusterList(cred, out)
@@ -673,7 +696,7 @@ func (s *Server) syncAdminTenantSpendingLimits(ctx context.Context, rows []meta.
 		if !ok || cluster.OrganizationID != row.Binding.OrganizationID || cluster.TiDBCloudSpendingLimitMonthly == nil {
 			continue
 		}
-		if err := s.syncTiDBCloudSpendingLimit(ctx, row.Tenant.ID, &tenant.QuotaCloudConfig{
+		if err := s.syncTiDBCloudSpendingLimit(ctx, "admin_tenant_list", row.Tenant.ID, &tenant.QuotaCloudConfig{
 			TiDBCloudSpendingLimitMonthly: cluster.TiDBCloudSpendingLimitMonthly,
 		}); err != nil {
 			return err
@@ -682,13 +705,14 @@ func (s *Server) syncAdminTenantSpendingLimits(ctx context.Context, rows []meta.
 	return nil
 }
 
-func (s *Server) adminTenantRowsNeedSpendingLimitBackfill(ctx context.Context, rows []meta.TenantWithTiDBCloudOrgBinding) bool {
+func (s *Server) adminTenantRowsNeedSpendingLimitBackfill(ctx context.Context, metricPath string, rows []meta.TenantWithTiDBCloudOrgBinding) bool {
 	for _, row := range rows {
 		cfg, err := s.meta.GetQuotaConfig(ctx, row.Tenant.ID)
 		if err != nil {
 			return false
 		}
 		if cfg.TiDBCloudSpendingLimit == nil {
+			metrics.RecordTiDBCloudSpendingLimitMissing(metricPath)
 			return true
 		}
 	}

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -179,6 +179,7 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 	} else if claimed {
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
 		setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+		s.forgetTiDBCloudRBACList(cred)
 		if res.Status == meta.TenantProvisioning {
 			s.startProvisionedTenantSchemaInit(r.Context(), res)
 		}
@@ -212,6 +213,7 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+	s.forgetTiDBCloudRBACList(cred)
 	s.startProvisionedTenantSchemaInit(r.Context(), res)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
@@ -230,7 +232,8 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	clusters, err := s.listAllManagedClusters(r.Context(), cred, "", "admin_tenant_list")
+	listStarted := time.Now().UTC()
+	clusters, clustersFromCache, err := s.listAllManagedClusters(r.Context(), cred, "", "admin_tenant_list")
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "list tenants")
 		return
@@ -263,19 +266,20 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 	}
 	clusterMap := cloudClusterMap(clusters)
 	if includeQuota {
-		if err := s.syncAdminTenantSpendingLimits(r.Context(), rows, clusterMap); err != nil {
+		if err := s.syncAdminTenantSpendingLimits(r.Context(), rows, clusterMap, listStarted); err != nil {
 			logger.Warn(r.Context(), "admin_tenant_spending_limit_sync_failed", zap.Error(err))
 			errJSON(w, http.StatusInternalServerError, "quota lookup failed")
 			return
 		}
-		if s.adminTenantRowsNeedSpendingLimitBackfill(r.Context(), "admin_tenant_list", rows) {
-			clusters, err = s.listAllManagedClustersFresh(r.Context(), cred, "", "admin_tenant_list")
+		if clustersFromCache && s.adminTenantRowsNeedSpendingLimitBackfill(r.Context(), "admin_tenant_list", rows) {
+			listStarted = time.Now().UTC()
+			clusters, _, err = s.listAllManagedClustersFresh(r.Context(), cred, "", "admin_tenant_list")
 			if err != nil {
 				writeAdminTiDBCloudError(w, r.Context(), err, "list tenants")
 				return
 			}
 			clusterMap = cloudClusterMap(clusters)
-			if err := s.syncAdminTenantSpendingLimits(r.Context(), rows, clusterMap); err != nil {
+			if err := s.syncAdminTenantSpendingLimits(r.Context(), rows, clusterMap, listStarted); err != nil {
 				logger.Warn(r.Context(), "admin_tenant_spending_limit_sync_failed", zap.Error(err))
 				errJSON(w, http.StatusInternalServerError, "quota lookup failed")
 				return
@@ -437,6 +441,7 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
+	s.forgetTiDBCloudRBACList(cred)
 	writeJSON(w, http.StatusAccepted, adminTenantDeleteResponse{TenantID: t.ID, Status: string(status)})
 }
 
@@ -480,13 +485,14 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 		}
 		allowCache = cfg.TiDBCloudSpendingLimit != nil
 	}
-	clusters, err := s.listAllManagedClustersCached(r.Context(), cred, binding.ClusterID, allowCache, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
+	listStarted := time.Now().UTC()
+	clusters, _, err := s.listAllManagedClustersCached(r.Context(), cred, binding.ClusterID, allowCache, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
 		return nil, nil, false
 	}
 	if len(clusters) == 0 && allowDeletingMissingCluster && t.Status == meta.TenantDeleting {
-		clusters, err = s.listAllManagedClusters(r.Context(), cred, "", adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
+		clusters, _, err = s.listAllManagedClusters(r.Context(), cred, "", adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
 		if err != nil {
 			writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
 			return nil, nil, false
@@ -516,7 +522,7 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 	}
 	if loadQuota {
 		cloudCfg := &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: authorizedCluster.TiDBCloudSpendingLimitMonthly}
-		if err := s.syncTiDBCloudSpendingLimit(r.Context(), "admin_tenant_get", t.ID, cloudCfg); err != nil {
+		if err := s.syncTiDBCloudSpendingLimit(r.Context(), "admin_tenant_get", t.ID, cloudCfg, listStarted); err != nil {
 			logger.Warn(r.Context(), "admin_tenant_spending_limit_sync_failed", zap.String("tenant_id", t.ID), zap.Error(err))
 			errJSON(w, http.StatusInternalServerError, "quota lookup failed")
 			return nil, nil, false
@@ -536,15 +542,15 @@ func adminTenantMetricPath(loadQuota bool, allowDeletingMissingCluster bool) str
 	}
 }
 
-func (s *Server) listAllManagedClusters(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, error) {
+func (s *Server) listAllManagedClusters(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, bool, error) {
 	return s.listAllManagedClustersCached(ctx, cred, clusterID, true, metricPath)
 }
 
-func (s *Server) listAllManagedClustersFresh(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, error) {
+func (s *Server) listAllManagedClustersFresh(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, bool, error) {
 	return s.listAllManagedClustersCached(ctx, cred, clusterID, false, metricPath)
 }
 
-func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string, allowCache bool, metricPath string) ([]tenant.CloudClusterInfo, error) {
+func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string, allowCache bool, metricPath string) ([]tenant.CloudClusterInfo, bool, error) {
 	clusterID = strings.TrimSpace(clusterID)
 	scope := "list"
 	if clusterID != "" {
@@ -555,12 +561,12 @@ func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.C
 			if cluster, ok := s.tidbCloudRBACCache.getCluster(cred, clusterID); ok {
 				if cluster.OrganizationID != "" {
 					metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "hit")
-					return []tenant.CloudClusterInfo{cluster}, nil
+					return []tenant.CloudClusterInfo{cluster}, true, nil
 				}
 			}
 		} else if clusters, ok := s.tidbCloudRBACCache.getClusterList(cred); ok {
 			metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "hit")
-			return clusters, nil
+			return clusters, true, nil
 		}
 		metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "miss")
 	} else {
@@ -568,7 +574,7 @@ func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.C
 	}
 	lister, ok := s.provisioner.(tenant.ManagedClusterLister)
 	if !ok {
-		return nil, fmt.Errorf("managed cluster list not enabled")
+		return nil, false, fmt.Errorf("managed cluster list not enabled")
 	}
 	var out []tenant.CloudClusterInfo
 	pageToken := ""
@@ -580,14 +586,14 @@ func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.C
 		})
 		if err != nil {
 			metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "list_managed_clusters", "error")
-			return nil, err
+			return nil, false, err
 		}
 		metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "list_managed_clusters", "ok")
 		if page == nil {
 			if clusterID == "" {
 				s.tidbCloudRBACCache.rememberClusterList(cred, out)
 			}
-			return out, nil
+			return out, false, nil
 		}
 		out = append(out, page.Clusters...)
 		pageToken = strings.TrimSpace(page.NextPageToken)
@@ -599,7 +605,7 @@ func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.C
 					s.rememberTiDBCloudRBAC(cred, cluster)
 				}
 			}
-			return out, nil
+			return out, false, nil
 		}
 	}
 }
@@ -690,15 +696,15 @@ func cloudClusterMap(clusters []tenant.CloudClusterInfo) map[string]tenant.Cloud
 	return out
 }
 
-func (s *Server) syncAdminTenantSpendingLimits(ctx context.Context, rows []meta.TenantWithTiDBCloudOrgBinding, clusters map[string]tenant.CloudClusterInfo) error {
+func (s *Server) syncAdminTenantSpendingLimits(ctx context.Context, rows []meta.TenantWithTiDBCloudOrgBinding, clusters map[string]tenant.CloudClusterInfo, observedAt time.Time) error {
 	for _, row := range rows {
 		cluster, ok := clusters[row.Binding.ClusterID]
-		if !ok || cluster.OrganizationID != row.Binding.OrganizationID || cluster.TiDBCloudSpendingLimitMonthly == nil {
+		if !ok || cluster.OrganizationID != row.Binding.OrganizationID {
 			continue
 		}
 		if err := s.syncTiDBCloudSpendingLimit(ctx, "admin_tenant_list", row.Tenant.ID, &tenant.QuotaCloudConfig{
 			TiDBCloudSpendingLimitMonthly: cluster.TiDBCloudSpendingLimitMonthly,
-		}); err != nil {
+		}, observedAt); err != nil {
 			return err
 		}
 	}
@@ -711,7 +717,7 @@ func (s *Server) adminTenantRowsNeedSpendingLimitBackfill(ctx context.Context, m
 		if err != nil {
 			return false
 		}
-		if cfg.TiDBCloudSpendingLimit == nil {
+		if cfg.TiDBCloudSpendingLimit == nil && cfg.TiDBCloudSpendingLimitCheckedAt == nil {
 			metrics.RecordTiDBCloudSpendingLimitMissing(metricPath)
 			return true
 		}

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -261,15 +261,31 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 		nextPage = page + 1
 	}
 	clusterMap := cloudClusterMap(clusters)
+	if includeQuota {
+		if err := s.syncAdminTenantSpendingLimits(r.Context(), rows, clusterMap); err != nil {
+			logger.Warn(r.Context(), "admin_tenant_spending_limit_sync_failed", zap.Error(err))
+			errJSON(w, http.StatusInternalServerError, "quota lookup failed")
+			return
+		}
+		if s.adminTenantRowsNeedSpendingLimitBackfill(r.Context(), rows) {
+			clusters, err = s.listAllManagedClustersFresh(r.Context(), cred, "")
+			if err != nil {
+				writeAdminTiDBCloudError(w, r.Context(), err, "list tenants")
+				return
+			}
+			clusterMap = cloudClusterMap(clusters)
+			if err := s.syncAdminTenantSpendingLimits(r.Context(), rows, clusterMap); err != nil {
+				logger.Warn(r.Context(), "admin_tenant_spending_limit_sync_failed", zap.Error(err))
+				errJSON(w, http.StatusInternalServerError, "quota lookup failed")
+				return
+			}
+		}
+	}
 	out := make([]adminTenantResponse, 0, len(rows))
 	for _, row := range rows {
 		var quota *adminTenantQuotaSummary
 		if includeQuota {
-			cloudCfg := &tenant.QuotaCloudConfig{}
-			if cloud, ok := clusterMap[row.Binding.ClusterID]; ok {
-				cloudCfg.TiDBCloudSpendingLimitMonthly = cloud.TiDBCloudSpendingLimitMonthly
-			}
-			quota = s.adminTenantQuotaSummary(r.Context(), &row.Tenant, cloudCfg)
+			quota = s.adminTenantQuotaSummary(r.Context(), &row.Tenant)
 		}
 		out = append(out, s.adminTenantResponse(&row.Tenant, &row.Binding, quota))
 	}
@@ -282,11 +298,11 @@ func (s *Server) handleAdminTenantGet(w http.ResponseWriter, r *http.Request, te
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	t, binding, cloudCfg, ok := s.authorizedAdminTenant(w, r, tenantID, cred, true, false)
+	t, binding, ok := s.authorizedAdminTenant(w, r, tenantID, cred, true, false)
 	if !ok {
 		return
 	}
-	quota, err := s.loadAdminTenantQuotaSummary(r.Context(), t, cloudCfg)
+	quota, err := s.loadAdminTenantQuotaSummary(r.Context(), t)
 	if err != nil {
 		logger.Warn(r.Context(), "admin_tenant_quota_lookup_failed", zap.String("tenant_id", t.ID), zap.Error(err))
 		errJSON(w, http.StatusInternalServerError, "quota lookup failed")
@@ -314,7 +330,7 @@ func (s *Server) handleAdminTenantQuotaSet(w http.ResponseWriter, r *http.Reques
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	t, _, _, ok := s.authorizedAdminTenant(w, r, tenantID, cred, false, false)
+	t, _, ok := s.authorizedAdminTenant(w, r, tenantID, cred, false, false)
 	if !ok {
 		return
 	}
@@ -322,12 +338,11 @@ func (s *Server) handleAdminTenantQuotaSet(w http.ResponseWriter, r *http.Reques
 		errJSON(w, http.StatusConflict, err.Error())
 		return
 	}
-	cloudCfg, err := s.applyQuotaSet(r.Context(), t, cred, quotaReq)
-	if err != nil {
+	if err := s.applyQuotaSet(r.Context(), t, cred, quotaReq); err != nil {
 		writeQuotaSetError(w, r.Context(), err, "update")
 		return
 	}
-	s.writeAdminQuotaResponse(w, r, t, cloudCfg)
+	s.writeAdminQuotaResponse(w, r, t)
 }
 
 func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request, tenantID string) {
@@ -344,7 +359,7 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	t, _, _, ok := s.authorizedAdminTenant(w, r, tenantID, cred, false, true)
+	t, _, ok := s.authorizedAdminTenant(w, r, tenantID, cred, false, true)
 	if !ok {
 		return
 	}
@@ -424,77 +439,112 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 	writeJSON(w, http.StatusAccepted, adminTenantDeleteResponse{TenantID: t.ID, Status: string(status)})
 }
 
-func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, tenantID string, cred tenant.CredentialProvisionRequest, loadQuota bool, allowDeletingMissingCluster bool) (*meta.Tenant, *meta.TenantTiDBCloudOrgBinding, *tenant.QuotaCloudConfig, bool) {
+func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, tenantID string, cred tenant.CredentialProvisionRequest, loadQuota bool, allowDeletingMissingCluster bool) (*meta.Tenant, *meta.TenantTiDBCloudOrgBinding, bool) {
 	t, err := s.meta.GetTenant(r.Context(), tenantID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "tenant not found")
-			return nil, nil, nil, false
+			return nil, nil, false
 		}
 		errJSON(w, http.StatusInternalServerError, "tenant lookup failed")
-		return nil, nil, nil, false
+		return nil, nil, false
 	}
 	if t.Provider != tenant.ProviderTiDBCloudNative {
 		errJSON(w, http.StatusConflict, "admin tenant API is only supported for tidb_cloud_native tenants")
-		return nil, nil, nil, false
+		return nil, nil, false
 	}
 	if t.Status == meta.TenantDeleted {
 		errJSON(w, http.StatusNotFound, "tenant not found")
-		return nil, nil, nil, false
+		return nil, nil, false
 	}
 	binding, err := s.meta.GetTenantTiDBCloudOrgBinding(r.Context(), tenantID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			errJSON(w, http.StatusNotFound, "tenant tidbcloud organization binding not found")
-			return nil, nil, nil, false
+			return nil, nil, false
 		}
 		errJSON(w, http.StatusInternalServerError, "tenant organization binding lookup failed")
-		return nil, nil, nil, false
+		return nil, nil, false
 	}
 	if binding.PoolStatus == meta.TenantPoolBindingFree {
 		errJSON(w, http.StatusNotFound, "tenant not found")
-		return nil, nil, nil, false
+		return nil, nil, false
 	}
-	clusters, err := s.listAllManagedClusters(r.Context(), cred, binding.ClusterID)
+	allowCache := true
+	if loadQuota {
+		cfg, err := s.meta.GetQuotaConfig(r.Context(), tenantID)
+		if err != nil {
+			errJSON(w, http.StatusInternalServerError, "quota config lookup failed")
+			return nil, nil, false
+		}
+		allowCache = cfg.TiDBCloudSpendingLimit != nil
+	}
+	clusters, err := s.listAllManagedClustersCached(r.Context(), cred, binding.ClusterID, allowCache)
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
-		return nil, nil, nil, false
+		return nil, nil, false
 	}
 	if len(clusters) == 0 && allowDeletingMissingCluster && t.Status == meta.TenantDeleting {
 		clusters, err = s.listAllManagedClusters(r.Context(), cred, "")
 		if err != nil {
 			writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
-			return nil, nil, nil, false
+			return nil, nil, false
 		}
 		for _, cluster := range clusters {
 			if cluster.OrganizationID == binding.OrganizationID {
-				return t, binding, nil, true
+				return t, binding, true
 			}
 		}
 	}
 	if len(clusters) == 0 {
 		errJSON(w, http.StatusForbidden, "no permission to access tenant with TiDB Cloud API key")
-		return nil, nil, nil, false
+		return nil, nil, false
 	}
-	var cloudCfg *tenant.QuotaCloudConfig
+	var authorizedCluster tenant.CloudClusterInfo
 	authorized := false
 	for _, cluster := range clusters {
 		if cluster.ClusterID == binding.ClusterID && cluster.OrganizationID == binding.OrganizationID {
 			authorized = true
-			if loadQuota {
-				cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: cluster.TiDBCloudSpendingLimitMonthly}
-			}
+			authorizedCluster = cluster
 			break
 		}
 	}
 	if !authorized {
 		errJSON(w, http.StatusForbidden, "no permission to access tenant with TiDB Cloud API key")
-		return nil, nil, nil, false
+		return nil, nil, false
 	}
-	return t, binding, cloudCfg, true
+	if loadQuota {
+		cloudCfg := &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: authorizedCluster.TiDBCloudSpendingLimitMonthly}
+		if err := s.syncTiDBCloudSpendingLimit(r.Context(), t.ID, cloudCfg); err != nil {
+			logger.Warn(r.Context(), "admin_tenant_spending_limit_sync_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+			errJSON(w, http.StatusInternalServerError, "quota lookup failed")
+			return nil, nil, false
+		}
+	}
+	return t, binding, true
 }
 
 func (s *Server) listAllManagedClusters(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string) ([]tenant.CloudClusterInfo, error) {
+	return s.listAllManagedClustersCached(ctx, cred, clusterID, true)
+}
+
+func (s *Server) listAllManagedClustersFresh(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string) ([]tenant.CloudClusterInfo, error) {
+	return s.listAllManagedClustersCached(ctx, cred, clusterID, false)
+}
+
+func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string, allowCache bool) ([]tenant.CloudClusterInfo, error) {
+	clusterID = strings.TrimSpace(clusterID)
+	if allowCache {
+		if clusterID != "" {
+			if cluster, ok := s.tidbCloudRBACCache.getCluster(cred, clusterID); ok {
+				if cluster.OrganizationID != "" {
+					return []tenant.CloudClusterInfo{cluster}, nil
+				}
+			}
+		} else if clusters, ok := s.tidbCloudRBACCache.getClusterList(cred); ok {
+			return clusters, nil
+		}
+	}
 	lister, ok := s.provisioner.(tenant.ManagedClusterLister)
 	if !ok {
 		return nil, fmt.Errorf("managed cluster list not enabled")
@@ -511,11 +561,21 @@ func (s *Server) listAllManagedClusters(ctx context.Context, cred tenant.Credent
 			return nil, err
 		}
 		if page == nil {
+			if clusterID == "" {
+				s.tidbCloudRBACCache.rememberClusterList(cred, out)
+			}
 			return out, nil
 		}
 		out = append(out, page.Clusters...)
 		pageToken = strings.TrimSpace(page.NextPageToken)
 		if pageToken == "" || clusterID != "" {
+			if clusterID == "" {
+				s.tidbCloudRBACCache.rememberClusterList(cred, out)
+			} else {
+				for _, cluster := range out {
+					s.rememberTiDBCloudRBAC(cred, cluster)
+				}
+			}
 			return out, nil
 		}
 	}
@@ -530,8 +590,8 @@ func (s *Server) adminTenantResponse(t *meta.Tenant, _ *meta.TenantTiDBCloudOrgB
 	}
 }
 
-func (s *Server) adminTenantQuotaSummary(ctx context.Context, t *meta.Tenant, cloudCfg *tenant.QuotaCloudConfig) *adminTenantQuotaSummary {
-	out, err := s.loadAdminTenantQuotaSummary(ctx, t, cloudCfg)
+func (s *Server) adminTenantQuotaSummary(ctx context.Context, t *meta.Tenant) *adminTenantQuotaSummary {
+	out, err := s.loadAdminTenantQuotaSummary(ctx, t)
 	if err != nil {
 		logger.Warn(ctx, "admin_tenant_quota_lookup_failed", zap.String("tenant_id", t.ID), zap.Error(err))
 		return nil
@@ -539,7 +599,7 @@ func (s *Server) adminTenantQuotaSummary(ctx context.Context, t *meta.Tenant, cl
 	return out
 }
 
-func (s *Server) loadAdminTenantQuotaSummary(ctx context.Context, t *meta.Tenant, cloudCfg *tenant.QuotaCloudConfig) (*adminTenantQuotaSummary, error) {
+func (s *Server) loadAdminTenantQuotaSummary(ctx context.Context, t *meta.Tenant) (*adminTenantQuotaSummary, error) {
 	cfg, err := s.meta.GetQuotaConfig(ctx, t.ID)
 	if err != nil {
 		return nil, fmt.Errorf("quota config lookup failed: %w", err)
@@ -548,16 +608,12 @@ func (s *Server) loadAdminTenantQuotaSummary(ctx context.Context, t *meta.Tenant
 	if err != nil {
 		return nil, fmt.Errorf("quota usage lookup failed: %w", err)
 	}
-	var spendingLimit *int64
-	if cloudCfg != nil {
-		spendingLimit = cloudCfg.TiDBCloudSpendingLimitMonthly
-	}
 	return &adminTenantQuotaSummary{
 		Config: quotaConfigResponse{
 			MaxStorageSize:         quotaStorageBytesToSize(cfg.MaxStorageBytes),
 			MaxFileSize:            quotaStorageBytesToSize(cfg.MaxFileSizeBytes),
 			MaxFileCount:           cfg.MaxFileCount,
-			TiDBCloudSpendingLimit: spendingLimit,
+			TiDBCloudSpendingLimit: cfg.TiDBCloudSpendingLimit,
 		},
 		Usage: quotaUsageResponse{
 			StorageBytes:  usage.StorageBytes,
@@ -567,8 +623,8 @@ func (s *Server) loadAdminTenantQuotaSummary(ctx context.Context, t *meta.Tenant
 	}, nil
 }
 
-func (s *Server) writeAdminQuotaResponse(w http.ResponseWriter, r *http.Request, t *meta.Tenant, cloudCfg *tenant.QuotaCloudConfig) {
-	quota, err := s.loadAdminTenantQuotaSummary(r.Context(), t, cloudCfg)
+func (s *Server) writeAdminQuotaResponse(w http.ResponseWriter, r *http.Request, t *meta.Tenant) {
+	quota, err := s.loadAdminTenantQuotaSummary(r.Context(), t)
 	if err != nil {
 		logger.Warn(r.Context(), "admin_tenant_quota_lookup_failed", zap.String("tenant_id", t.ID), zap.Error(err))
 		errJSON(w, http.StatusInternalServerError, "quota lookup failed")
@@ -609,6 +665,34 @@ func cloudClusterMap(clusters []tenant.CloudClusterInfo) map[string]tenant.Cloud
 		}
 	}
 	return out
+}
+
+func (s *Server) syncAdminTenantSpendingLimits(ctx context.Context, rows []meta.TenantWithTiDBCloudOrgBinding, clusters map[string]tenant.CloudClusterInfo) error {
+	for _, row := range rows {
+		cluster, ok := clusters[row.Binding.ClusterID]
+		if !ok || cluster.OrganizationID != row.Binding.OrganizationID || cluster.TiDBCloudSpendingLimitMonthly == nil {
+			continue
+		}
+		if err := s.syncTiDBCloudSpendingLimit(ctx, row.Tenant.ID, &tenant.QuotaCloudConfig{
+			TiDBCloudSpendingLimitMonthly: cluster.TiDBCloudSpendingLimitMonthly,
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Server) adminTenantRowsNeedSpendingLimitBackfill(ctx context.Context, rows []meta.TenantWithTiDBCloudOrgBinding) bool {
+	for _, row := range rows {
+		cfg, err := s.meta.GetQuotaConfig(ctx, row.Tenant.ID)
+		if err != nil {
+			return false
+		}
+		if cfg.TiDBCloudSpendingLimit == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func adminCredentialsFromHeaders(r *http.Request) (tenant.CredentialProvisionRequest, error) {

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
+	"github.com/mem9-ai/drive9/pkg/tenant/token"
 )
 
 type quotaRequest struct {
@@ -87,10 +89,16 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req := decodeQuotaGetRequest(r)
-	cred, err := quotaCredentials(req)
-	if err != nil {
-		errJSON(w, http.StatusBadRequest, err.Error())
-		return
+	hasTiDBCloudCreds := req.PublicKey != "" || req.PrivateKey != ""
+	var apiKeyTenant *meta.TenantWithAPIKey
+	var apiKeyErr error
+	if req.TenantID == "" && bearerToken(r) != "" {
+		apiKeyTenant, apiKeyErr = s.resolveQuotaAPIKey(r.Context(), r)
+		if apiKeyErr != nil {
+			writeQuotaAPIKeyError(w, r.Context(), apiKeyErr)
+			return
+		}
+		req.TenantID = apiKeyTenant.Tenant.ID
 	}
 	t, ok := s.quotaTenant(w, r.Context(), req.TenantID)
 	if !ok {
@@ -112,6 +120,29 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 	cfg, err := s.meta.GetQuotaConfig(r.Context(), t.ID)
 	if err != nil {
 		errJSON(w, http.StatusInternalServerError, "quota config lookup failed")
+		return
+	}
+	if cfg.TiDBCloudSpendingLimit != nil && bearerToken(r) != "" {
+		if apiKeyTenant == nil && apiKeyErr == nil {
+			apiKeyTenant, apiKeyErr = s.resolveQuotaAPIKey(r.Context(), r)
+		}
+		if apiKeyErr == nil && apiKeyTenant != nil && apiKeyTenant.Tenant.ID == t.ID {
+			setRequestMetricTenant(r.Context(), t.ID, apiKeyTenant.APIKey.ID, t.Provider, classifyTenantRequest(r))
+			s.writeQuotaResponse(w, r, t)
+			return
+		}
+		if !hasTiDBCloudCreds {
+			if apiKeyErr != nil {
+				writeQuotaAPIKeyError(w, r.Context(), apiKeyErr)
+				return
+			}
+			errJSON(w, http.StatusForbidden, "API key tenant does not match requested tenant")
+			return
+		}
+	}
+	cred, err := quotaCredentials(req)
+	if err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	needRefresh := false
@@ -140,6 +171,63 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 	}
 	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, classifyTenantRequest(r))
 	s.writeQuotaResponse(w, r, t)
+}
+
+var (
+	errQuotaAPIKeyAuthNotEnabled = errors.New("API key quota auth not enabled")
+	errQuotaAPIKeyMissing        = errors.New("missing or malformed Authorization header")
+	errQuotaAPIKeyInvalid        = errors.New("invalid API key")
+)
+
+func (s *Server) resolveQuotaAPIKey(ctx context.Context, r *http.Request) (*meta.TenantWithAPIKey, error) {
+	if s.meta == nil || s.pool == nil || len(s.tokenSecret) == 0 {
+		return nil, errQuotaAPIKeyAuthNotEnabled
+	}
+	tok := bearerToken(r)
+	if tok == "" {
+		return nil, errQuotaAPIKeyMissing
+	}
+	hash := token.HashToken(tok)
+	resolved, err := s.meta.ResolveByAPIKeyHash(ctx, hash)
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			return nil, errQuotaAPIKeyInvalid
+		}
+		return nil, fmt.Errorf("resolve API key: %w", err)
+	}
+	if subtle.ConstantTimeCompare([]byte(hash), []byte(resolved.APIKey.JWTHash)) != 1 {
+		return nil, errQuotaAPIKeyInvalid
+	}
+	if resolved.APIKey.Status != meta.APIKeyActive {
+		return nil, errQuotaAPIKeyInvalid
+	}
+	plain, err := poolDecryptToken(ctx, s.pool, resolved.APIKey.JWTCiphertext)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt API key: %w", err)
+	}
+	if subtle.ConstantTimeCompare([]byte(tok), plain) != 1 {
+		return nil, errQuotaAPIKeyInvalid
+	}
+	claims, err := token.ParseAndVerifyToken(s.tokenSecret, tok)
+	if err != nil {
+		return nil, errQuotaAPIKeyInvalid
+	}
+	if claims.TenantID != resolved.Tenant.ID || claims.TokenVersion != resolved.APIKey.TokenVersion {
+		return nil, errQuotaAPIKeyInvalid
+	}
+	return resolved, nil
+}
+
+func writeQuotaAPIKeyError(w http.ResponseWriter, ctx context.Context, err error) {
+	switch {
+	case errors.Is(err, errQuotaAPIKeyMissing), errors.Is(err, errQuotaAPIKeyInvalid):
+		errJSON(w, http.StatusUnauthorized, errQuotaAPIKeyInvalid.Error())
+	case errors.Is(err, errQuotaAPIKeyAuthNotEnabled):
+		errJSON(w, http.StatusNotFound, "quota query not enabled")
+	default:
+		logger.Warn(ctx, "quota_api_key_auth_failed", zap.Error(err))
+		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
+	}
 }
 
 func decodeQuotaGetRequest(r *http.Request) quotaRequest {

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"go.uber.org/zap"
 
@@ -122,6 +123,7 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		needRefresh = true
 	}
 	if needRefresh {
+		observedAt := time.Now().UTC()
 		cloudCfg, err := getter.GetQuota(r.Context(), clusterInfoFromTenant(t), cred)
 		if err != nil {
 			metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "error")
@@ -130,7 +132,7 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		}
 		metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "ok")
 		s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
-		if err := s.syncTiDBCloudSpendingLimit(r.Context(), "quota_get", t.ID, cloudCfg); err != nil {
+		if err := s.syncTiDBCloudSpendingLimit(r.Context(), "quota_get", t.ID, cloudCfg, observedAt); err != nil {
 			logger.Warn(r.Context(), "tidbcloud_spending_limit_sync_failed", zap.String("tenant_id", t.ID), zap.Error(err))
 			errJSON(w, http.StatusInternalServerError, "quota config update failed")
 			return
@@ -532,6 +534,10 @@ func (s *Server) rememberTiDBCloudRBAC(cred tenant.CredentialProvisionRequest, c
 	s.tidbCloudRBACCache.rememberCluster(cred, cluster)
 }
 
+func (s *Server) forgetTiDBCloudRBACList(cred tenant.CredentialProvisionRequest) {
+	s.tidbCloudRBACCache.forgetClusterList(cred)
+}
+
 func tidbCloudSpendingLimitFromCloud(cloudCfg *tenant.QuotaCloudConfig) *int64 {
 	if cloudCfg == nil || cloudCfg.TiDBCloudSpendingLimitMonthly == nil {
 		return nil
@@ -540,9 +546,14 @@ func tidbCloudSpendingLimitFromCloud(cloudCfg *tenant.QuotaCloudConfig) *int64 {
 	return &limit
 }
 
-func (s *Server) syncTiDBCloudSpendingLimit(ctx context.Context, source, tenantID string, cloudCfg *tenant.QuotaCloudConfig) error {
+func (s *Server) syncTiDBCloudSpendingLimit(ctx context.Context, source, tenantID string, cloudCfg *tenant.QuotaCloudConfig, observedAt time.Time) error {
+	checkedAt := time.Now().UTC()
 	limit := tidbCloudSpendingLimitFromCloud(cloudCfg)
 	if limit == nil {
+		if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimitCheckedAt: &checkedAt}); err != nil {
+			metrics.RecordTiDBCloudSpendingLimitSync(source, "error")
+			return err
+		}
 		metrics.RecordTiDBCloudSpendingLimitSync(source, "missing_cloud_value")
 		return nil
 	}
@@ -552,10 +563,28 @@ func (s *Server) syncTiDBCloudSpendingLimit(ctx context.Context, source, tenantI
 		return err
 	}
 	if result == "unchanged" {
+		if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimitCheckedAt: &checkedAt}); err != nil {
+			metrics.RecordTiDBCloudSpendingLimitSync(source, "error")
+			return err
+		}
 		metrics.RecordTiDBCloudSpendingLimitSync(source, result)
 		return nil
 	}
-	if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: limit}); err != nil {
+	if !observedAt.IsZero() {
+		cfg, err := s.meta.GetQuotaConfig(ctx, tenantID)
+		if err != nil {
+			metrics.RecordTiDBCloudSpendingLimitSync(source, "error")
+			return err
+		}
+		if cfg.TiDBCloudSpendingLimit != nil && cfg.UpdatedAt.After(observedAt) {
+			metrics.RecordTiDBCloudSpendingLimitSync(source, "skipped_newer_local")
+			return nil
+		}
+	}
+	if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, meta.QuotaConfigPatch{
+		TiDBCloudSpendingLimit:          limit,
+		TiDBCloudSpendingLimitCheckedAt: &checkedAt,
+	}); err != nil {
 		metrics.RecordTiDBCloudSpendingLimitSync(source, "error")
 		return err
 	}

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -646,23 +646,14 @@ func (s *Server) syncTiDBCloudSpendingLimit(ctx context.Context, source, tenantI
 		metrics.RecordTiDBCloudSpendingLimitSync(source, result)
 		return nil
 	}
-	if !observedAt.IsZero() {
-		cfg, err := s.meta.GetQuotaConfig(ctx, tenantID)
-		if err != nil {
-			metrics.RecordTiDBCloudSpendingLimitSync(source, "error")
-			return err
-		}
-		if cfg.TiDBCloudSpendingLimit != nil && cfg.UpdatedAt.After(observedAt) {
-			metrics.RecordTiDBCloudSpendingLimitSync(source, "skipped_newer_local")
-			return nil
-		}
-	}
-	if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, meta.QuotaConfigPatch{
-		TiDBCloudSpendingLimit:          limit,
-		TiDBCloudSpendingLimitCheckedAt: &checkedAt,
-	}); err != nil {
+	applied, err := s.meta.SetTiDBCloudSpendingLimitIfNotUpdatedAfter(ctx, tenantID, *limit, checkedAt, observedAt)
+	if err != nil {
 		metrics.RecordTiDBCloudSpendingLimitSync(source, "error")
 		return err
+	}
+	if !applied {
+		metrics.RecordTiDBCloudSpendingLimitSync(source, "skipped_newer_local")
+		return nil
 	}
 	metrics.RecordTiDBCloudSpendingLimitSync(source, result)
 	return nil

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -16,6 +17,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
+	"github.com/mem9-ai/drive9/pkg/tenant/token"
 )
 
 type quotaRequest struct {
@@ -87,11 +89,7 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req := decodeQuotaGetRequest(r)
-	cred, err := quotaCredentials(req)
-	if err != nil {
-		errJSON(w, http.StatusBadRequest, err.Error())
-		return
-	}
+	hasTiDBCloudCreds := req.PublicKey != "" || req.PrivateKey != ""
 	t, ok := s.quotaTenant(w, r.Context(), req.TenantID)
 	if !ok {
 		return
@@ -112,6 +110,27 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 	cfg, err := s.meta.GetQuotaConfig(r.Context(), t.ID)
 	if err != nil {
 		errJSON(w, http.StatusInternalServerError, "quota config lookup failed")
+		return
+	}
+	if cfg.TiDBCloudSpendingLimit != nil && bearerToken(r) != "" {
+		apiKeyTenant, apiKeyErr := s.resolveQuotaAPIKey(r.Context(), r)
+		if apiKeyErr == nil && apiKeyTenant != nil && apiKeyTenant.Tenant.ID == t.ID {
+			setRequestMetricTenant(r.Context(), t.ID, apiKeyTenant.APIKey.ID, t.Provider, classifyTenantRequest(r))
+			s.writeQuotaResponse(w, r, t)
+			return
+		}
+		if !hasTiDBCloudCreds {
+			if apiKeyErr != nil {
+				writeQuotaAPIKeyError(w, r.Context(), apiKeyErr)
+				return
+			}
+			errJSON(w, http.StatusForbidden, "API key tenant does not match requested tenant")
+			return
+		}
+	}
+	cred, err := quotaCredentials(req)
+	if err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	needRefresh := false
@@ -140,6 +159,63 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 	}
 	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, classifyTenantRequest(r))
 	s.writeQuotaResponse(w, r, t)
+}
+
+var (
+	errQuotaAPIKeyAuthNotEnabled = errors.New("API key quota auth not enabled")
+	errQuotaAPIKeyMissing        = errors.New("missing or malformed Authorization header")
+	errQuotaAPIKeyInvalid        = errors.New("invalid API key")
+)
+
+func (s *Server) resolveQuotaAPIKey(ctx context.Context, r *http.Request) (*meta.TenantWithAPIKey, error) {
+	if s.meta == nil || s.pool == nil || len(s.tokenSecret) == 0 {
+		return nil, errQuotaAPIKeyAuthNotEnabled
+	}
+	tok := bearerToken(r)
+	if tok == "" {
+		return nil, errQuotaAPIKeyMissing
+	}
+	hash := token.HashToken(tok)
+	resolved, err := s.meta.ResolveByAPIKeyHash(ctx, hash)
+	if err != nil {
+		if errors.Is(err, meta.ErrNotFound) {
+			return nil, errQuotaAPIKeyInvalid
+		}
+		return nil, fmt.Errorf("resolve API key: %w", err)
+	}
+	if subtle.ConstantTimeCompare([]byte(hash), []byte(resolved.APIKey.JWTHash)) != 1 {
+		return nil, errQuotaAPIKeyInvalid
+	}
+	if resolved.APIKey.Status != meta.APIKeyActive {
+		return nil, errQuotaAPIKeyInvalid
+	}
+	plain, err := poolDecryptToken(ctx, s.pool, resolved.APIKey.JWTCiphertext)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt API key: %w", err)
+	}
+	if subtle.ConstantTimeCompare([]byte(tok), plain) != 1 {
+		return nil, errQuotaAPIKeyInvalid
+	}
+	claims, err := token.ParseAndVerifyToken(s.tokenSecret, tok)
+	if err != nil {
+		return nil, errQuotaAPIKeyInvalid
+	}
+	if claims.TenantID != resolved.Tenant.ID || claims.TokenVersion != resolved.APIKey.TokenVersion {
+		return nil, errQuotaAPIKeyInvalid
+	}
+	return resolved, nil
+}
+
+func writeQuotaAPIKeyError(w http.ResponseWriter, ctx context.Context, err error) {
+	switch {
+	case errors.Is(err, errQuotaAPIKeyMissing), errors.Is(err, errQuotaAPIKeyInvalid):
+		errJSON(w, http.StatusUnauthorized, errQuotaAPIKeyInvalid.Error())
+	case errors.Is(err, errQuotaAPIKeyAuthNotEnabled):
+		errJSON(w, http.StatusNotFound, "quota query not enabled")
+	default:
+		logger.Warn(ctx, "quota_api_key_auth_failed", zap.Error(err))
+		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
+	}
 }
 
 func decodeQuotaGetRequest(r *http.Request) quotaRequest {

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
@@ -112,14 +113,24 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusInternalServerError, "quota config lookup failed")
 		return
 	}
-	if cfg.TiDBCloudSpendingLimit == nil || !s.tidbCloudRBACAllowed(cred, t.ClusterID) {
+	needRefresh := false
+	if cfg.TiDBCloudSpendingLimit == nil {
+		metrics.RecordTiDBCloudSpendingLimitMissing("quota_get")
+		metrics.RecordTiDBCloudRBACCacheRequest("quota_get", "cluster", "bypass")
+		needRefresh = true
+	} else if !s.tidbCloudRBACAllowed(cred, t.ClusterID, "quota_get") {
+		needRefresh = true
+	}
+	if needRefresh {
 		cloudCfg, err := getter.GetQuota(r.Context(), clusterInfoFromTenant(t), cred)
 		if err != nil {
+			metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "error")
 			writeQuotaCredentialError(w, r.Context(), err, "query")
 			return
 		}
+		metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "ok")
 		s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
-		if err := s.syncTiDBCloudSpendingLimit(r.Context(), t.ID, cloudCfg); err != nil {
+		if err := s.syncTiDBCloudSpendingLimit(r.Context(), "quota_get", t.ID, cloudCfg); err != nil {
 			logger.Warn(r.Context(), "tidbcloud_spending_limit_sync_failed", zap.String("tenant_id", t.ID), zap.Error(err))
 			errJSON(w, http.StatusInternalServerError, "quota config update failed")
 			return
@@ -178,7 +189,7 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusConflict, err.Error())
 		return
 	}
-	if err := s.applyQuotaSet(r.Context(), t, cred, req); err != nil {
+	if err := s.applyQuotaSet(r.Context(), "quota_set", t, cred, req); err != nil {
 		writeQuotaSetError(w, r.Context(), err, "update")
 		return
 	}
@@ -276,7 +287,7 @@ func (s *Server) rejectQuotaSetForTenantStatus(t *meta.Tenant) error {
 	}
 }
 
-func (s *Server) applyQuotaSet(ctx context.Context, t *meta.Tenant, cred tenant.CredentialProvisionRequest, req quotaRequest) error {
+func (s *Server) applyQuotaSet(ctx context.Context, metricPath string, t *meta.Tenant, cred tenant.CredentialProvisionRequest, req quotaRequest) error {
 	if t == nil {
 		return fmt.Errorf("tenant is required")
 	}
@@ -289,16 +300,20 @@ func (s *Server) applyQuotaSet(ctx context.Context, t *meta.Tenant, cred tenant.
 	}
 	cloudCfg, err := updater.MarkQuotaUpdateStarted(ctx, clusterInfoFromTenant(t), cred)
 	if err != nil {
+		metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "mark_quota_update_started", "error")
 		return err
 	}
+	metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "mark_quota_update_started", "ok")
 	s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
 	if req.TiDBCloudSpendingLimit != nil {
 		updatedCloudCfg, err := updater.UpdateQuota(ctx, clusterInfoFromTenant(t), cred, tenant.QuotaUpdateOptions{
 			TiDBCloudSpendingLimitMonthly: req.TiDBCloudSpendingLimit,
 		})
 		if err != nil {
+			metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "update_quota", "error")
 			return err
 		}
+		metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "update_quota", "ok")
 		if cloudCfg == nil {
 			cloudCfg = updatedCloudCfg
 		} else if updatedCloudCfg != nil && updatedCloudCfg.TiDBCloudSpendingLimitMonthly != nil {
@@ -313,8 +328,21 @@ func (s *Server) applyQuotaSet(ctx context.Context, t *meta.Tenant, cred tenant.
 		quotaPatch.TiDBCloudSpendingLimit = cloudLimit
 	}
 	if quotaPatch.AnySet() {
+		hasSpendingLimitPatch := quotaPatch.TiDBCloudSpendingLimit != nil
+		spendingSyncResult := ""
+		if hasSpendingLimitPatch {
+			if result, resultErr := s.tidbCloudSpendingLimitSyncResult(ctx, t.ID, quotaPatch.TiDBCloudSpendingLimit); resultErr == nil {
+				spendingSyncResult = result
+			}
+		}
 		if err := s.meta.SetQuotaConfigPatch(ctx, t.ID, quotaPatch); err != nil {
+			if hasSpendingLimitPatch {
+				metrics.RecordTiDBCloudSpendingLimitSync(metricPath, "error")
+			}
 			return fmt.Errorf("%w: quota config update failed: %w", errQuotaLocalUpdateFailed, err)
+		}
+		if spendingSyncResult != "" {
+			metrics.RecordTiDBCloudSpendingLimitSync(metricPath, spendingSyncResult)
 		}
 		if err := s.meta.EnsureQuotaUsageRow(ctx, t.ID); err != nil {
 			return fmt.Errorf("%w: quota usage initialization failed: %w", errQuotaLocalUpdateFailed, err)
@@ -323,7 +351,7 @@ func (s *Server) applyQuotaSet(ctx context.Context, t *meta.Tenant, cred tenant.
 	return nil
 }
 
-func (s *Server) applyQuotaLocalConfig(ctx context.Context, tenantID string, req quotaRequest) error {
+func (s *Server) applyQuotaLocalConfig(ctx context.Context, source, tenantID string, req quotaRequest) error {
 	quotaPatch, err := quotaConfigPatchFromRequest(req)
 	if err != nil {
 		return err
@@ -331,8 +359,21 @@ func (s *Server) applyQuotaLocalConfig(ctx context.Context, tenantID string, req
 	if !quotaPatch.AnySet() {
 		return nil
 	}
+	hasSpendingLimitPatch := quotaPatch.TiDBCloudSpendingLimit != nil
+	spendingSyncResult := ""
+	if hasSpendingLimitPatch {
+		if result, resultErr := s.tidbCloudSpendingLimitSyncResult(ctx, tenantID, quotaPatch.TiDBCloudSpendingLimit); resultErr == nil {
+			spendingSyncResult = result
+		}
+	}
 	if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, quotaPatch); err != nil {
+		if hasSpendingLimitPatch {
+			metrics.RecordTiDBCloudSpendingLimitSync(source, "error")
+		}
 		return fmt.Errorf("%w: quota config update failed: %w", errQuotaLocalUpdateFailed, err)
+	}
+	if spendingSyncResult != "" {
+		metrics.RecordTiDBCloudSpendingLimitSync(source, spendingSyncResult)
 	}
 	if err := s.meta.EnsureQuotaUsageRow(ctx, tenantID); err != nil {
 		return fmt.Errorf("%w: quota usage initialization failed: %w", errQuotaLocalUpdateFailed, err)
@@ -477,8 +518,13 @@ func quotaSetErrorStatusMessage(err error, action string) (int, string, bool) {
 	}
 }
 
-func (s *Server) tidbCloudRBACAllowed(cred tenant.CredentialProvisionRequest, clusterID string) bool {
+func (s *Server) tidbCloudRBACAllowed(cred tenant.CredentialProvisionRequest, clusterID, metricPath string) bool {
 	_, ok := s.tidbCloudRBACCache.getCluster(cred, clusterID)
+	result := "miss"
+	if ok {
+		result = "hit"
+	}
+	metrics.RecordTiDBCloudRBACCacheRequest(metricPath, "cluster", result)
 	return ok
 }
 
@@ -494,17 +540,42 @@ func tidbCloudSpendingLimitFromCloud(cloudCfg *tenant.QuotaCloudConfig) *int64 {
 	return &limit
 }
 
-func (s *Server) syncTiDBCloudSpendingLimit(ctx context.Context, tenantID string, cloudCfg *tenant.QuotaCloudConfig) error {
+func (s *Server) syncTiDBCloudSpendingLimit(ctx context.Context, source, tenantID string, cloudCfg *tenant.QuotaCloudConfig) error {
 	limit := tidbCloudSpendingLimitFromCloud(cloudCfg)
 	if limit == nil {
+		metrics.RecordTiDBCloudSpendingLimitSync(source, "missing_cloud_value")
 		return nil
+	}
+	result, err := s.tidbCloudSpendingLimitSyncResult(ctx, tenantID, limit)
+	if err != nil {
+		metrics.RecordTiDBCloudSpendingLimitSync(source, "error")
+		return err
+	}
+	if result == "unchanged" {
+		metrics.RecordTiDBCloudSpendingLimitSync(source, result)
+		return nil
+	}
+	if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: limit}); err != nil {
+		metrics.RecordTiDBCloudSpendingLimitSync(source, "error")
+		return err
+	}
+	metrics.RecordTiDBCloudSpendingLimitSync(source, result)
+	return nil
+}
+
+func (s *Server) tidbCloudSpendingLimitSyncResult(ctx context.Context, tenantID string, limit *int64) (string, error) {
+	if limit == nil {
+		return "", nil
 	}
 	cfg, err := s.meta.GetQuotaConfig(ctx, tenantID)
 	if err != nil {
-		return err
+		return "error", err
 	}
-	if cfg.TiDBCloudSpendingLimit != nil && *cfg.TiDBCloudSpendingLimit == *limit {
-		return nil
+	if cfg.TiDBCloudSpendingLimit == nil {
+		return "inserted", nil
 	}
-	return s.meta.SetQuotaConfigPatch(ctx, tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: limit})
+	if *cfg.TiDBCloudSpendingLimit == *limit {
+		return "unchanged", nil
+	}
+	return "updated", nil
 }

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"crypto/subtle"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -17,7 +16,6 @@ import (
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
-	"github.com/mem9-ai/drive9/pkg/tenant/token"
 )
 
 type quotaRequest struct {
@@ -89,16 +87,10 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req := decodeQuotaGetRequest(r)
-	hasTiDBCloudCreds := req.PublicKey != "" || req.PrivateKey != ""
-	var apiKeyTenant *meta.TenantWithAPIKey
-	var apiKeyErr error
-	if req.TenantID == "" && bearerToken(r) != "" {
-		apiKeyTenant, apiKeyErr = s.resolveQuotaAPIKey(r.Context(), r)
-		if apiKeyErr != nil {
-			writeQuotaAPIKeyError(w, r.Context(), apiKeyErr)
-			return
-		}
-		req.TenantID = apiKeyTenant.Tenant.ID
+	cred, err := quotaCredentials(req)
+	if err != nil {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
 	}
 	t, ok := s.quotaTenant(w, r.Context(), req.TenantID)
 	if !ok {
@@ -120,29 +112,6 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 	cfg, err := s.meta.GetQuotaConfig(r.Context(), t.ID)
 	if err != nil {
 		errJSON(w, http.StatusInternalServerError, "quota config lookup failed")
-		return
-	}
-	if cfg.TiDBCloudSpendingLimit != nil && bearerToken(r) != "" {
-		if apiKeyTenant == nil && apiKeyErr == nil {
-			apiKeyTenant, apiKeyErr = s.resolveQuotaAPIKey(r.Context(), r)
-		}
-		if apiKeyErr == nil && apiKeyTenant != nil && apiKeyTenant.Tenant.ID == t.ID {
-			setRequestMetricTenant(r.Context(), t.ID, apiKeyTenant.APIKey.ID, t.Provider, classifyTenantRequest(r))
-			s.writeQuotaResponse(w, r, t)
-			return
-		}
-		if !hasTiDBCloudCreds {
-			if apiKeyErr != nil {
-				writeQuotaAPIKeyError(w, r.Context(), apiKeyErr)
-				return
-			}
-			errJSON(w, http.StatusForbidden, "API key tenant does not match requested tenant")
-			return
-		}
-	}
-	cred, err := quotaCredentials(req)
-	if err != nil {
-		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
 	needRefresh := false
@@ -171,63 +140,6 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 	}
 	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, classifyTenantRequest(r))
 	s.writeQuotaResponse(w, r, t)
-}
-
-var (
-	errQuotaAPIKeyAuthNotEnabled = errors.New("API key quota auth not enabled")
-	errQuotaAPIKeyMissing        = errors.New("missing or malformed Authorization header")
-	errQuotaAPIKeyInvalid        = errors.New("invalid API key")
-)
-
-func (s *Server) resolveQuotaAPIKey(ctx context.Context, r *http.Request) (*meta.TenantWithAPIKey, error) {
-	if s.meta == nil || s.pool == nil || len(s.tokenSecret) == 0 {
-		return nil, errQuotaAPIKeyAuthNotEnabled
-	}
-	tok := bearerToken(r)
-	if tok == "" {
-		return nil, errQuotaAPIKeyMissing
-	}
-	hash := token.HashToken(tok)
-	resolved, err := s.meta.ResolveByAPIKeyHash(ctx, hash)
-	if err != nil {
-		if errors.Is(err, meta.ErrNotFound) {
-			return nil, errQuotaAPIKeyInvalid
-		}
-		return nil, fmt.Errorf("resolve API key: %w", err)
-	}
-	if subtle.ConstantTimeCompare([]byte(hash), []byte(resolved.APIKey.JWTHash)) != 1 {
-		return nil, errQuotaAPIKeyInvalid
-	}
-	if resolved.APIKey.Status != meta.APIKeyActive {
-		return nil, errQuotaAPIKeyInvalid
-	}
-	plain, err := poolDecryptToken(ctx, s.pool, resolved.APIKey.JWTCiphertext)
-	if err != nil {
-		return nil, fmt.Errorf("decrypt API key: %w", err)
-	}
-	if subtle.ConstantTimeCompare([]byte(tok), plain) != 1 {
-		return nil, errQuotaAPIKeyInvalid
-	}
-	claims, err := token.ParseAndVerifyToken(s.tokenSecret, tok)
-	if err != nil {
-		return nil, errQuotaAPIKeyInvalid
-	}
-	if claims.TenantID != resolved.Tenant.ID || claims.TokenVersion != resolved.APIKey.TokenVersion {
-		return nil, errQuotaAPIKeyInvalid
-	}
-	return resolved, nil
-}
-
-func writeQuotaAPIKeyError(w http.ResponseWriter, ctx context.Context, err error) {
-	switch {
-	case errors.Is(err, errQuotaAPIKeyMissing), errors.Is(err, errQuotaAPIKeyInvalid):
-		errJSON(w, http.StatusUnauthorized, errQuotaAPIKeyInvalid.Error())
-	case errors.Is(err, errQuotaAPIKeyAuthNotEnabled):
-		errJSON(w, http.StatusNotFound, "quota query not enabled")
-	default:
-		logger.Warn(ctx, "quota_api_key_auth_failed", zap.Error(err))
-		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
-	}
 }
 
 func decodeQuotaGetRequest(r *http.Request) quotaRequest {

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -107,13 +107,26 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusNotFound, "quota query not enabled")
 		return
 	}
-	cloudCfg, err := getter.GetQuota(r.Context(), clusterInfoFromTenant(t), cred)
+	cfg, err := s.meta.GetQuotaConfig(r.Context(), t.ID)
 	if err != nil {
-		writeQuotaCredentialError(w, r.Context(), err, "query")
+		errJSON(w, http.StatusInternalServerError, "quota config lookup failed")
 		return
 	}
+	if cfg.TiDBCloudSpendingLimit == nil || !s.tidbCloudRBACAllowed(cred, t.ClusterID) {
+		cloudCfg, err := getter.GetQuota(r.Context(), clusterInfoFromTenant(t), cred)
+		if err != nil {
+			writeQuotaCredentialError(w, r.Context(), err, "query")
+			return
+		}
+		s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
+		if err := s.syncTiDBCloudSpendingLimit(r.Context(), t.ID, cloudCfg); err != nil {
+			logger.Warn(r.Context(), "tidbcloud_spending_limit_sync_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+			errJSON(w, http.StatusInternalServerError, "quota config update failed")
+			return
+		}
+	}
 	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, classifyTenantRequest(r))
-	s.writeQuotaResponse(w, r, t, cloudCfg)
+	s.writeQuotaResponse(w, r, t)
 }
 
 func decodeQuotaGetRequest(r *http.Request) quotaRequest {
@@ -165,13 +178,12 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusConflict, err.Error())
 		return
 	}
-	cloudCfg, err := s.applyQuotaSet(r.Context(), t, cred, req)
-	if err != nil {
+	if err := s.applyQuotaSet(r.Context(), t, cred, req); err != nil {
 		writeQuotaSetError(w, r.Context(), err, "update")
 		return
 	}
 	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, classifyTenantRequest(r))
-	s.writeQuotaResponse(w, r, t, cloudCfg)
+	s.writeQuotaResponse(w, r, t)
 }
 
 func decodeQuotaRequest(w http.ResponseWriter, r *http.Request) (quotaRequest, error) {
@@ -264,27 +276,28 @@ func (s *Server) rejectQuotaSetForTenantStatus(t *meta.Tenant) error {
 	}
 }
 
-func (s *Server) applyQuotaSet(ctx context.Context, t *meta.Tenant, cred tenant.CredentialProvisionRequest, req quotaRequest) (*tenant.QuotaCloudConfig, error) {
+func (s *Server) applyQuotaSet(ctx context.Context, t *meta.Tenant, cred tenant.CredentialProvisionRequest, req quotaRequest) error {
 	if t == nil {
-		return nil, fmt.Errorf("tenant is required")
+		return fmt.Errorf("tenant is required")
 	}
 	if strings.TrimSpace(t.ClusterID) == "" {
-		return nil, tenant.ErrQuotaBackendNotFound
+		return tenant.ErrQuotaBackendNotFound
 	}
 	updater, ok := s.provisioner.(tenant.QuotaUpdater)
 	if !ok {
-		return nil, errQuotaSettingNotEnabled
+		return errQuotaSettingNotEnabled
 	}
 	cloudCfg, err := updater.MarkQuotaUpdateStarted(ctx, clusterInfoFromTenant(t), cred)
 	if err != nil {
-		return nil, err
+		return err
 	}
+	s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
 	if req.TiDBCloudSpendingLimit != nil {
 		updatedCloudCfg, err := updater.UpdateQuota(ctx, clusterInfoFromTenant(t), cred, tenant.QuotaUpdateOptions{
 			TiDBCloudSpendingLimitMonthly: req.TiDBCloudSpendingLimit,
 		})
 		if err != nil {
-			return nil, err
+			return err
 		}
 		if cloudCfg == nil {
 			cloudCfg = updatedCloudCfg
@@ -294,17 +307,20 @@ func (s *Server) applyQuotaSet(ctx context.Context, t *meta.Tenant, cred tenant.
 	}
 	quotaPatch, err := quotaConfigPatchFromRequest(req)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	if quotaPatch.MaxStorageBytes != nil || quotaPatch.MaxFileSizeBytes != nil || quotaPatch.MaxFileCount != nil {
+	if cloudLimit := tidbCloudSpendingLimitFromCloud(cloudCfg); cloudLimit != nil {
+		quotaPatch.TiDBCloudSpendingLimit = cloudLimit
+	}
+	if quotaPatch.AnySet() {
 		if err := s.meta.SetQuotaConfigPatch(ctx, t.ID, quotaPatch); err != nil {
-			return nil, fmt.Errorf("%w: quota config update failed: %w", errQuotaLocalUpdateFailed, err)
+			return fmt.Errorf("%w: quota config update failed: %w", errQuotaLocalUpdateFailed, err)
 		}
 		if err := s.meta.EnsureQuotaUsageRow(ctx, t.ID); err != nil {
-			return nil, fmt.Errorf("%w: quota usage initialization failed: %w", errQuotaLocalUpdateFailed, err)
+			return fmt.Errorf("%w: quota usage initialization failed: %w", errQuotaLocalUpdateFailed, err)
 		}
 	}
-	return cloudCfg, nil
+	return nil
 }
 
 func (s *Server) applyQuotaLocalConfig(ctx context.Context, tenantID string, req quotaRequest) error {
@@ -312,7 +328,7 @@ func (s *Server) applyQuotaLocalConfig(ctx context.Context, tenantID string, req
 	if err != nil {
 		return err
 	}
-	if quotaPatch.MaxStorageBytes == nil && quotaPatch.MaxFileSizeBytes == nil && quotaPatch.MaxFileCount == nil {
+	if !quotaPatch.AnySet() {
 		return nil
 	}
 	if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, quotaPatch); err != nil {
@@ -343,6 +359,9 @@ func quotaConfigPatchFromRequest(req quotaRequest) (meta.QuotaConfigPatch, error
 	if req.MaxFileCount != nil {
 		patch.MaxFileCount = req.MaxFileCount
 	}
+	if req.TiDBCloudSpendingLimit != nil {
+		patch.TiDBCloudSpendingLimit = req.TiDBCloudSpendingLimit
+	}
 	return patch, nil
 }
 
@@ -368,7 +387,7 @@ func (s *Server) quotaTenant(w http.ResponseWriter, ctx context.Context, tenantI
 	return t, true
 }
 
-func (s *Server) writeQuotaResponse(w http.ResponseWriter, r *http.Request, t *meta.Tenant, cloudCfg *tenant.QuotaCloudConfig) {
+func (s *Server) writeQuotaResponse(w http.ResponseWriter, r *http.Request, t *meta.Tenant) {
 	cfg, err := s.meta.GetQuotaConfig(r.Context(), t.ID)
 	if err != nil {
 		errJSON(w, http.StatusInternalServerError, "quota config lookup failed")
@@ -378,10 +397,6 @@ func (s *Server) writeQuotaResponse(w http.ResponseWriter, r *http.Request, t *m
 	if err != nil {
 		errJSON(w, http.StatusInternalServerError, "quota usage lookup failed")
 		return
-	}
-	var spendingLimit *int64
-	if cloudCfg != nil {
-		spendingLimit = cloudCfg.TiDBCloudSpendingLimitMonthly
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(quotaResponse{
@@ -393,7 +408,7 @@ func (s *Server) writeQuotaResponse(w http.ResponseWriter, r *http.Request, t *m
 			MaxStorageSize:         quotaStorageBytesToSize(cfg.MaxStorageBytes),
 			MaxFileSize:            quotaStorageBytesToSize(cfg.MaxFileSizeBytes),
 			MaxFileCount:           cfg.MaxFileCount,
-			TiDBCloudSpendingLimit: spendingLimit,
+			TiDBCloudSpendingLimit: cfg.TiDBCloudSpendingLimit,
 		},
 		Usage: quotaUsageResponse{
 			StorageBytes:  usage.StorageBytes,
@@ -460,4 +475,36 @@ func quotaSetErrorStatusMessage(err error, action string) (int, string, bool) {
 	default:
 		return 0, "", false
 	}
+}
+
+func (s *Server) tidbCloudRBACAllowed(cred tenant.CredentialProvisionRequest, clusterID string) bool {
+	_, ok := s.tidbCloudRBACCache.getCluster(cred, clusterID)
+	return ok
+}
+
+func (s *Server) rememberTiDBCloudRBAC(cred tenant.CredentialProvisionRequest, cluster tenant.CloudClusterInfo) {
+	s.tidbCloudRBACCache.rememberCluster(cred, cluster)
+}
+
+func tidbCloudSpendingLimitFromCloud(cloudCfg *tenant.QuotaCloudConfig) *int64 {
+	if cloudCfg == nil || cloudCfg.TiDBCloudSpendingLimitMonthly == nil {
+		return nil
+	}
+	limit := *cloudCfg.TiDBCloudSpendingLimitMonthly
+	return &limit
+}
+
+func (s *Server) syncTiDBCloudSpendingLimit(ctx context.Context, tenantID string, cloudCfg *tenant.QuotaCloudConfig) error {
+	limit := tidbCloudSpendingLimitFromCloud(cloudCfg)
+	if limit == nil {
+		return nil
+	}
+	cfg, err := s.meta.GetQuotaConfig(ctx, tenantID)
+	if err != nil {
+		return err
+	}
+	if cfg.TiDBCloudSpendingLimit != nil && *cfg.TiDBCloudSpendingLimit == *limit {
+		return nil
+	}
+	return s.meta.SetQuotaConfigPatch(ctx, tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: limit})
 }

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -548,6 +548,47 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	}
 }
 
+func TestQuotaGetUsesDrive9APIKeyWhenLocalSpendingLimitExists(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	spendingLimit := int64(10000)
+	ctx := context.Background()
+	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &spendingLimit}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.EnsureQuotaUsageRow(ctx, rt.tenantID); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.SetQuotaCounters(ctx, rt.tenantID, 321, 7, 9); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.IncrReservedBytes(ctx, rt.tenantID, 7); err != nil {
+		t.Fatal(err)
+	}
+	rt.prov.getErr = errors.New("should not call TiDB Cloud when Drive9 API key and local spending limit are present")
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+
+	resp := getQuota(t, ts.URL, rt.tenantID, "", "", rt.apiKey)
+	defer func(body io.Closer) { _ = body.Close() }(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var out quotaResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
+		t.Fatalf("spending limit = %#v, want %d", out.Config.TiDBCloudSpendingLimit, spendingLimit)
+	}
+	if out.Usage.StorageBytes != 321 || out.Usage.ReservedBytes != 7 || out.Usage.FileCount != 9 {
+		t.Fatalf("usage = %#v", out.Usage)
+	}
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("get calls = %d, want 0", got)
+	}
+}
+
 func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ts := httptest.NewServer(rt.server)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -589,6 +589,34 @@ func TestQuotaGetUsesDrive9APIKeyWhenLocalSpendingLimitExists(t *testing.T) {
 	}
 }
 
+func TestSyncTiDBCloudSpendingLimitSkipsNewerLocalAtSameTimestampTick(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+
+	newLimit := int64(200)
+	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &newLimit}); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	staleLimit := int64(100)
+	if err := rt.server.syncTiDBCloudSpendingLimit(ctx, "quota_get", rt.tenantID, &tenant.QuotaCloudConfig{
+		TiDBCloudSpendingLimitMonthly: &staleLimit,
+	}, cfg.UpdatedAt); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err = rt.meta.GetQuotaConfig(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != newLimit {
+		t.Fatalf("spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, newLimit)
+	}
+}
+
 func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ts := httptest.NewServer(rt.server)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -422,7 +422,7 @@ func TestQuotaGetRejectsDrive9Key(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.Closer) { _ = body.Close() }(resp.Body)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", resp.StatusCode)
 	}
@@ -445,7 +445,7 @@ func TestQuotaGetDoesNotFallbackToDefaultTiDBCloudCredentials(t *testing.T) {
 	defer ts.Close()
 
 	resp := getQuota(t, ts.URL, rt.tenantID, "", "", "")
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.Closer) { _ = body.Close() }(resp.Body)
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("status = %d, want 400", resp.StatusCode)
 	}
@@ -473,7 +473,7 @@ func TestQuotaGetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	defer ts.Close()
 
 	resp := getQuota(t, ts.URL, rt.tenantID, "default-pk", "default-sk", "")
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.Closer) { _ = body.Close() }(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
@@ -515,7 +515,7 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	defer ts.Close()
 
 	resp := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.Closer) { _ = body.Close() }(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d", resp.StatusCode)
 	}
@@ -532,6 +532,13 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	}
 	if out.Config.MaxStorageSize != 123 || out.Config.MaxFileSize != 12 || out.Config.MaxFileCount != 34 || out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
 		t.Fatalf("config = %#v", out.Config)
+	}
+	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
+		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)
 	}
 	if out.Usage.StorageBytes != 321 || out.Usage.ReservedBytes != 11 || out.Usage.FileCount != 9 {
 		t.Fatalf("usage = %#v", out.Usage)
@@ -564,6 +571,70 @@ func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	lastCredentials := rt.prov.lastCredentialsSnapshot()
 	if lastCredentials.PublicKey != "public-1" || lastCredentials.PrivateKey != "private-1" {
 		t.Fatalf("last credentials = %#v", lastCredentials)
+	}
+}
+
+func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	spendingLimit := int64(222)
+	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+
+	resp := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		t.Fatalf("first status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	_ = resp.Body.Close()
+	if got := rt.prov.getCalls.Load(); got != 1 {
+		t.Fatalf("get calls after first request = %d, want 1", got)
+	}
+	cfg, err := rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
+		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)
+	}
+
+	rt.prov.getErr = errors.New("should not call TiDB Cloud while RBAC cache and local spending limit are present")
+	resp2 := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("second status = %d, want 200: %s", resp2.StatusCode, body)
+	}
+	var out quotaResponse
+	if err := json.NewDecoder(resp2.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
+		t.Fatalf("response spending limit = %#v, want %d", out.Config.TiDBCloudSpendingLimit, spendingLimit)
+	}
+	if got := rt.prov.getCalls.Load(); got != 1 {
+		t.Fatalf("get calls after cached request = %d, want 1", got)
+	}
+
+	rt.prov.getErr = nil
+	updatedLimit := int64(333)
+	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &updatedLimit}
+	resp3 := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-2", "")
+	defer func() { _ = resp3.Body.Close() }()
+	if resp3.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp3.Body)
+		t.Fatalf("third status = %d, want 200: %s", resp3.StatusCode, body)
+	}
+	if got := rt.prov.getCalls.Load(); got != 2 {
+		t.Fatalf("get calls after new credential = %d, want 2", got)
+	}
+	cfg, err = rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != updatedLimit {
+		t.Fatalf("updated spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, updatedLimit)
 	}
 }
 
@@ -748,7 +819,7 @@ func TestQuotaSetChecksClusterWritePermissionBeforeFileLimitUpdate(t *testing.T)
 	}
 }
 
-func TestQuotaSetSpendingLimitOnlyDoesNotWriteStorageConfig(t *testing.T) {
+func TestQuotaSetSpendingLimitOnlyPersistsSpendingLimitConfig(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	spendingLimit := int64(0)
 	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
@@ -779,12 +850,22 @@ func TestQuotaSetSpendingLimitOnlyDoesNotWriteStorageConfig(t *testing.T) {
 	if lastOptions.TiDBCloudSpendingLimitMonthly == nil || *lastOptions.TiDBCloudSpendingLimitMonthly != spendingLimit {
 		t.Fatalf("spending limit option = %#v, want %d", lastOptions.TiDBCloudSpendingLimitMonthly, spendingLimit)
 	}
+	cfg, err := rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
+		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)
+	}
+	if cfg.MaxStorageBytes != meta.DefaultMaxStorageBytes() || cfg.MaxFileSizeBytes != meta.DefaultMaxFileSizeBytes() || cfg.MaxFileCount != 0 {
+		t.Fatalf("storage quota fields = %#v, want defaults", cfg)
+	}
 	version, err := rt.meta.GetQuotaConfigVersion(context.Background(), rt.tenantID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if version != "" {
-		t.Fatalf("quota config version = %q, want empty", version)
+		t.Fatalf("storage quota config version = %q, want empty", version)
 	}
 	var out quotaResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
@@ -1398,7 +1479,7 @@ func TestAdminTenantGetUsesListClusterAuthorizationAndReturnsQuota(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() { _ = resp.Body.Close() }()
+	defer func(body io.Closer) { _ = body.Close() }(resp.Body)
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
@@ -1438,6 +1519,32 @@ func TestAdminTenantGetUsesListClusterAuthorizationAndReturnsQuota(t *testing.T)
 	}
 	if got := rt.prov.markCalls.Load(); got != 0 {
 		t.Fatalf("mark calls = %d, want 0", got)
+	}
+
+	rt.prov.listErr = errors.New("should not call TiDB Cloud while admin RBAC cache and local spending limit are present")
+	req, err = http.NewRequest(http.MethodGet, ts.URL+"/v1/admin/tenants/"+rt.tenantID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set(quotaPublicKeyHeader, "public-1")
+	req.Header.Set(quotaPrivateKeyHeader, "private-1")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func(body io.Closer) { _ = body.Close() }(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("cached status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	if got := rt.prov.listCalls.Load(); got != 1 {
+		t.Fatalf("list calls after cached request = %d, want 1", got)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out.Quota == nil || out.Quota.Config.TiDBCloudSpendingLimit == nil || *out.Quota.Config.TiDBCloudSpendingLimit != spendingLimit {
+		t.Fatalf("cached spending limit = %#v, want %d", out.Quota, spendingLimit)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -548,47 +548,6 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	}
 }
 
-func TestQuotaGetUsesDrive9APIKeyWhenLocalSpendingLimitExists(t *testing.T) {
-	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	spendingLimit := int64(10000)
-	ctx := context.Background()
-	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &spendingLimit}); err != nil {
-		t.Fatal(err)
-	}
-	if err := rt.meta.EnsureQuotaUsageRow(ctx, rt.tenantID); err != nil {
-		t.Fatal(err)
-	}
-	if err := rt.meta.SetQuotaCounters(ctx, rt.tenantID, 321, 7, 9); err != nil {
-		t.Fatal(err)
-	}
-	if err := rt.meta.IncrReservedBytes(ctx, rt.tenantID, 7); err != nil {
-		t.Fatal(err)
-	}
-	rt.prov.getErr = errors.New("should not call TiDB Cloud when Drive9 API key and local spending limit are present")
-	ts := httptest.NewServer(rt.server)
-	defer ts.Close()
-
-	resp := getQuota(t, ts.URL, rt.tenantID, "", "", rt.apiKey)
-	defer func(body io.Closer) { _ = body.Close() }(resp.Body)
-	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
-	}
-	var out quotaResponse
-	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
-		t.Fatal(err)
-	}
-	if out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
-		t.Fatalf("spending limit = %#v, want %d", out.Config.TiDBCloudSpendingLimit, spendingLimit)
-	}
-	if out.Usage.StorageBytes != 321 || out.Usage.ReservedBytes != 7 || out.Usage.FileCount != 9 {
-		t.Fatalf("usage = %#v", out.Usage)
-	}
-	if got := rt.prov.getCalls.Load(); got != 0 {
-		t.Fatalf("get calls = %d, want 0", got)
-	}
-}
-
 func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ts := httptest.NewServer(rt.server)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5140,13 +5140,13 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		stageStarted = time.Now()
 		quotaReq := *opts.Quota
 		quotaReq.TenantID = tenantID
-		if err := s.applyQuotaLocalConfig(ctx, tenantID, quotaReq); err != nil {
+		if err := s.applyQuotaLocalConfig(ctx, "provision", tenantID, quotaReq); err != nil {
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 			metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
 			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to set tenant quota", err)
 		}
-		if err := s.syncTiDBCloudSpendingLimit(ctx, tenantID, provisionCloudCfg); err != nil {
+		if err := s.syncTiDBCloudSpendingLimit(ctx, "provision", tenantID, provisionCloudCfg); err != nil {
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 			metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -200,6 +200,7 @@ type Server struct {
 	tenantPoolLocks          sync.Map
 	tenantPoolCreateLocks    sync.Map
 	tenantPoolResumeJobs     sync.Map
+	tidbCloudRBACCache       *tidbCloudRBACCache
 	schemaInitErrors         sync.Map
 	leader                   *leader.Manager
 	// leaderWorkerCtx gates leader-only background schedulers. When leadership
@@ -356,6 +357,7 @@ func NewWithConfig(cfg Config) *Server {
 		journalCursorSecret:   newJournalCursorSecret(cfg.TokenSecret),
 		forkWorkerCtx:         forkWorkerCtx,
 		forkWorkerCancel:      forkWorkerCancel,
+		tidbCloudRBACCache:    newTiDBCloudRBACCache(tidbCloudRBACCacheTTL),
 		leader:                cfg.Leader,
 		podNotifySecret:       cfg.PodNotifySecret,
 		sseNotifyRetention:    cfg.SSENotifyRetention,
@@ -5144,8 +5146,12 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
 			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to set tenant quota", err)
 		}
-		// The TiDB Cloud spending limit is applied in the create-cluster request and
-		// remains cloud-side; list/get quota reads it back from TiDB Cloud.
+		if err := s.syncTiDBCloudSpendingLimit(ctx, tenantID, provisionCloudCfg); err != nil {
+			logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+			metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
+			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
+			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to set tenant quota", err)
+		}
 		if provisionCloudCfg != nil && provisionCloudCfg.TiDBCloudSpendingLimitMonthly != nil {
 			metricEvent(ctx, "tenant_provision", "provider", provider, "quota", "create_time_spending_limit")
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4420,6 +4420,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		} else if claimed {
 			logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
 			setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+			s.forgetTiDBCloudRBACList(*credentialReq)
 			if res.Status == meta.TenantProvisioning {
 				s.startProvisionedTenantSchemaInit(r.Context(), res)
 			}
@@ -4450,6 +4451,9 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+	if credentialReq != nil {
+		s.forgetTiDBCloudRBACList(*credentialReq)
+	}
 	s.startProvisionedTenantSchemaInit(r.Context(), res)
 	writeProvisionTenantAccepted(w, res)
 }
@@ -5146,7 +5150,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
 			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to set tenant quota", err)
 		}
-		if err := s.syncTiDBCloudSpendingLimit(ctx, "provision", tenantID, provisionCloudCfg); err != nil {
+		if err := s.syncTiDBCloudSpendingLimit(ctx, "provision", tenantID, provisionCloudCfg, time.Time{}); err != nil {
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 			metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")

--- a/pkg/server/tidbcloud_rbac_cache.go
+++ b/pkg/server/tidbcloud_rbac_cache.go
@@ -10,10 +10,14 @@ import (
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
-const tidbCloudRBACCacheTTL = 6 * time.Hour
+const (
+	tidbCloudRBACCacheTTL        = time.Hour
+	tidbCloudRBACCacheMaxEntries = 10000
+	tidbCloudRBACCacheMaxLists   = 1000
+)
 
 type tidbCloudRBACCache struct {
-	mu      sync.Mutex
+	mu      sync.RWMutex
 	ttl     time.Duration
 	entries map[string]tidbCloudRBACEntry
 	lists   map[string]tidbCloudRBACListEntry
@@ -49,13 +53,20 @@ func (c *tidbCloudRBACCache) getCluster(cred tenant.CredentialProvisionRequest, 
 	if clusterID == "" {
 		return tenant.CloudClusterInfo{}, false
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	entry, ok := c.entries[c.entryKey(cred, clusterID)]
-	if !ok || time.Now().After(entry.expiresAt) {
-		if ok {
-			delete(c.entries, c.entryKey(cred, clusterID))
+	key := c.entryKey(cred, clusterID)
+	now := time.Now()
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	if !ok {
+		return tenant.CloudClusterInfo{}, false
+	}
+	if now.After(entry.expiresAt) {
+		c.mu.Lock()
+		if current, currentOK := c.entries[key]; currentOK && now.After(current.expiresAt) {
+			delete(c.entries, key)
 		}
+		c.mu.Unlock()
 		return tenant.CloudClusterInfo{}, false
 	}
 	return tenant.CloudClusterInfo{ClusterID: entry.clusterID, OrganizationID: entry.organizationID}, true
@@ -65,14 +76,20 @@ func (c *tidbCloudRBACCache) getClusterList(cred tenant.CredentialProvisionReque
 	if c == nil {
 		return nil, false
 	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
 	key := c.credentialKey(cred)
+	now := time.Now()
+	c.mu.RLock()
 	entry, ok := c.lists[key]
-	if !ok || time.Now().After(entry.expiresAt) {
-		if ok {
+	c.mu.RUnlock()
+	if !ok {
+		return nil, false
+	}
+	if now.After(entry.expiresAt) {
+		c.mu.Lock()
+		if current, currentOK := c.lists[key]; currentOK && now.After(current.expiresAt) {
 			delete(c.lists, key)
 		}
+		c.mu.Unlock()
 		return nil, false
 	}
 	out := make([]tenant.CloudClusterInfo, len(entry.clusters))
@@ -89,13 +106,16 @@ func (c *tidbCloudRBACCache) rememberCluster(cred tenant.CredentialProvisionRequ
 		return
 	}
 	cluster.OrganizationID = strings.TrimSpace(cluster.OrganizationID)
+	key := c.entryKey(cred, cluster.ClusterID)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.entries[c.entryKey(cred, cluster.ClusterID)] = tidbCloudRBACEntry{
+	c.pruneLocked(time.Now())
+	c.entries[key] = tidbCloudRBACEntry{
 		clusterID:      cluster.ClusterID,
 		organizationID: cluster.OrganizationID,
 		expiresAt:      time.Now().Add(c.ttl),
 	}
+	c.enforceSizeLocked()
 }
 
 func (c *tidbCloudRBACCache) rememberClusterList(cred tenant.CredentialProvisionRequest, clusters []tenant.CloudClusterInfo) {
@@ -108,6 +128,7 @@ func (c *tidbCloudRBACCache) rememberClusterList(cred tenant.CredentialProvision
 	out := make([]tenant.CloudClusterInfo, 0, len(clusters))
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.pruneLocked(now)
 	for _, cluster := range clusters {
 		cluster.ClusterID = strings.TrimSpace(cluster.ClusterID)
 		if cluster.ClusterID == "" || seen[cluster.ClusterID] {
@@ -122,7 +143,50 @@ func (c *tidbCloudRBACCache) rememberClusterList(cred tenant.CredentialProvision
 		}
 		out = append(out, tenant.CloudClusterInfo{ClusterID: cluster.ClusterID, OrganizationID: cluster.OrganizationID})
 	}
-	c.lists[c.credentialKey(cred)] = tidbCloudRBACListEntry{clusters: out, expiresAt: expiresAt}
+	key := c.credentialKey(cred)
+	if len(out) == 0 {
+		delete(c.lists, key)
+		return
+	}
+	c.lists[key] = tidbCloudRBACListEntry{clusters: out, expiresAt: expiresAt}
+	c.enforceSizeLocked()
+}
+
+func (c *tidbCloudRBACCache) forgetClusterList(cred tenant.CredentialProvisionRequest) {
+	if c == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.lists, c.credentialKey(cred))
+}
+
+func (c *tidbCloudRBACCache) pruneLocked(now time.Time) {
+	for key, entry := range c.entries {
+		if now.After(entry.expiresAt) {
+			delete(c.entries, key)
+		}
+	}
+	for key, entry := range c.lists {
+		if now.After(entry.expiresAt) {
+			delete(c.lists, key)
+		}
+	}
+}
+
+func (c *tidbCloudRBACCache) enforceSizeLocked() {
+	for len(c.entries) > tidbCloudRBACCacheMaxEntries {
+		for key := range c.entries {
+			delete(c.entries, key)
+			break
+		}
+	}
+	for len(c.lists) > tidbCloudRBACCacheMaxLists {
+		for key := range c.lists {
+			delete(c.lists, key)
+			break
+		}
+	}
 }
 
 func (c *tidbCloudRBACCache) credentialKey(cred tenant.CredentialProvisionRequest) string {

--- a/pkg/server/tidbcloud_rbac_cache.go
+++ b/pkg/server/tidbcloud_rbac_cache.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/tenant"
+)
+
+const tidbCloudRBACCacheTTL = 6 * time.Hour
+
+type tidbCloudRBACCache struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	entries map[string]tidbCloudRBACEntry
+	lists   map[string]tidbCloudRBACListEntry
+}
+
+type tidbCloudRBACEntry struct {
+	clusterID      string
+	organizationID string
+	expiresAt      time.Time
+}
+
+type tidbCloudRBACListEntry struct {
+	clusters  []tenant.CloudClusterInfo
+	expiresAt time.Time
+}
+
+func newTiDBCloudRBACCache(ttl time.Duration) *tidbCloudRBACCache {
+	if ttl <= 0 {
+		ttl = tidbCloudRBACCacheTTL
+	}
+	return &tidbCloudRBACCache{
+		ttl:     ttl,
+		entries: make(map[string]tidbCloudRBACEntry),
+		lists:   make(map[string]tidbCloudRBACListEntry),
+	}
+}
+
+func (c *tidbCloudRBACCache) getCluster(cred tenant.CredentialProvisionRequest, clusterID string) (tenant.CloudClusterInfo, bool) {
+	if c == nil {
+		return tenant.CloudClusterInfo{}, false
+	}
+	clusterID = strings.TrimSpace(clusterID)
+	if clusterID == "" {
+		return tenant.CloudClusterInfo{}, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	entry, ok := c.entries[c.entryKey(cred, clusterID)]
+	if !ok || time.Now().After(entry.expiresAt) {
+		if ok {
+			delete(c.entries, c.entryKey(cred, clusterID))
+		}
+		return tenant.CloudClusterInfo{}, false
+	}
+	return tenant.CloudClusterInfo{ClusterID: entry.clusterID, OrganizationID: entry.organizationID}, true
+}
+
+func (c *tidbCloudRBACCache) getClusterList(cred tenant.CredentialProvisionRequest) ([]tenant.CloudClusterInfo, bool) {
+	if c == nil {
+		return nil, false
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	key := c.credentialKey(cred)
+	entry, ok := c.lists[key]
+	if !ok || time.Now().After(entry.expiresAt) {
+		if ok {
+			delete(c.lists, key)
+		}
+		return nil, false
+	}
+	out := make([]tenant.CloudClusterInfo, len(entry.clusters))
+	copy(out, entry.clusters)
+	return out, true
+}
+
+func (c *tidbCloudRBACCache) rememberCluster(cred tenant.CredentialProvisionRequest, cluster tenant.CloudClusterInfo) {
+	if c == nil {
+		return
+	}
+	cluster.ClusterID = strings.TrimSpace(cluster.ClusterID)
+	if cluster.ClusterID == "" {
+		return
+	}
+	cluster.OrganizationID = strings.TrimSpace(cluster.OrganizationID)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[c.entryKey(cred, cluster.ClusterID)] = tidbCloudRBACEntry{
+		clusterID:      cluster.ClusterID,
+		organizationID: cluster.OrganizationID,
+		expiresAt:      time.Now().Add(c.ttl),
+	}
+}
+
+func (c *tidbCloudRBACCache) rememberClusterList(cred tenant.CredentialProvisionRequest, clusters []tenant.CloudClusterInfo) {
+	if c == nil {
+		return
+	}
+	now := time.Now()
+	expiresAt := now.Add(c.ttl)
+	seen := make(map[string]bool, len(clusters))
+	out := make([]tenant.CloudClusterInfo, 0, len(clusters))
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, cluster := range clusters {
+		cluster.ClusterID = strings.TrimSpace(cluster.ClusterID)
+		if cluster.ClusterID == "" || seen[cluster.ClusterID] {
+			continue
+		}
+		cluster.OrganizationID = strings.TrimSpace(cluster.OrganizationID)
+		seen[cluster.ClusterID] = true
+		c.entries[c.entryKey(cred, cluster.ClusterID)] = tidbCloudRBACEntry{
+			clusterID:      cluster.ClusterID,
+			organizationID: cluster.OrganizationID,
+			expiresAt:      expiresAt,
+		}
+		out = append(out, tenant.CloudClusterInfo{ClusterID: cluster.ClusterID, OrganizationID: cluster.OrganizationID})
+	}
+	c.lists[c.credentialKey(cred)] = tidbCloudRBACListEntry{clusters: out, expiresAt: expiresAt}
+}
+
+func (c *tidbCloudRBACCache) credentialKey(cred tenant.CredentialProvisionRequest) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(cred.PublicKey) + "\x00" + strings.TrimSpace(cred.PrivateKey)))
+	return hex.EncodeToString(sum[:])
+}
+
+func (c *tidbCloudRBACCache) entryKey(cred tenant.CredentialProvisionRequest, clusterID string) string {
+	return c.credentialKey(cred) + "\x00" + strings.TrimSpace(clusterID)
+}

--- a/pkg/server/tidbcloud_rbac_cache_test.go
+++ b/pkg/server/tidbcloud_rbac_cache_test.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/tenant"
+)
+
+func TestTiDBCloudRBACCacheDoesNotRetainEmptyListAndSupportsInvalidation(t *testing.T) {
+	cache := newTiDBCloudRBACCache(time.Hour)
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}
+
+	cache.rememberClusterList(cred, nil)
+	if clusters, ok := cache.getClusterList(cred); ok {
+		t.Fatalf("empty list cache hit = %#v, want miss", clusters)
+	}
+
+	cache.rememberClusterList(cred, []tenant.CloudClusterInfo{{
+		ClusterID:      "cluster-1",
+		OrganizationID: "org-1",
+	}})
+	clusters, ok := cache.getClusterList(cred)
+	if !ok {
+		t.Fatal("list cache miss, want hit")
+	}
+	if len(clusters) != 1 || clusters[0].ClusterID != "cluster-1" || clusters[0].OrganizationID != "org-1" {
+		t.Fatalf("clusters = %#v", clusters)
+	}
+
+	cache.forgetClusterList(cred)
+	if clusters, ok := cache.getClusterList(cred); ok {
+		t.Fatalf("list cache hit after invalidation = %#v, want miss", clusters)
+	}
+	if cluster, ok := cache.getCluster(cred, "cluster-1"); !ok || cluster.OrganizationID != "org-1" {
+		t.Fatalf("cluster cache after list invalidation = %#v, %v; want cluster auth retained", cluster, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- persist TiDB Cloud spending limit in tenant quota config and return quota/admin responses from local DB
- add positive TiDB Cloud API-key-to-cluster RBAC cache so quota/admin reads avoid repeated OpenAPI calls
- backfill or reconcile local spending limit from TiDB Cloud when authorization refreshes, including create-time quota and pool claim flows

## Tests
- go test ./pkg/meta ./pkg/server -run 'TestQuota|TestAdminTenant|TestGetQuotaConfig|TestMetaSchema|TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint' -count=1
- go test ./pkg/meta ./pkg/server -count=1
- go test ./pkg/client -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TiDB Cloud spending-limit fields to tenant quota settings (including explicit `0`) with local persistence and checked timestamps.
  * Improved sync/backfill and admin quota handling so stored values are preferred, with targeted refresh when needed.
  * Added TiDB Cloud RBAC caching and new quota observability metrics (including no `tenant_id` label).
* **Bug Fixes**
  * Updated upload quota enforcement to apply storage/file limits only when quota overrides are enabled.
* **Documentation**
  * Revised the quota guide for updated semantics and expanded operator alerting guidance.
* **Tests**
  * Expanded quota and metrics coverage for spending-only and caching/backfill scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->