### PR TITLE
Add unique TiDB Cloud binding index

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -42,6 +42,7 @@ const (
 )
 
 const tidbCloudNativeProvider = "tidb_cloud_native"
+const maxTiDBCloudOrgBindingDuplicateTuples = 20
 
 type TenantKind string
 
@@ -350,6 +351,12 @@ func (s *Store) migrate() (err error) {
 	if err := backfillTiDBCloudOrgBindingBranchIDs(ctx, s.db); err != nil {
 		return err
 	}
+	if err := deleteStaleTiDBCloudOrgBindings(ctx, s.db); err != nil {
+		return err
+	}
+	if err := ensureTiDBCloudOrgBindingUniqueIndex(ctx, s.db); err != nil {
+		return err
+	}
 	diffs, err = diffMetaSchema(ctx, s.db, spec)
 	if err != nil {
 		return fmt.Errorf("re-diff meta schema: %w", err)
@@ -599,6 +606,7 @@ func metaInitSchemaStatements() []string {
 				used_at         DATETIME(3) NULL,
 				created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 				updated_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+				UNIQUE INDEX uk_tidbcloud_org_cluster_branch (organization_id, cluster_id, branch_id),
 				INDEX idx_tidbcloud_org_cluster (organization_id, cluster_id, branch_id, created_at, tenant_id),
 				INDEX idx_tidbcloud_org_created (organization_id, created_at, tenant_id),
 				INDEX idx_tidbcloud_pool_free (organization_id, pool_status, created_at, tenant_id)
@@ -1105,6 +1113,93 @@ func backfillTiDBCloudOrgBindingBranchIDs(ctx context.Context, db *sql.DB) error
 	return nil
 }
 
+func deleteStaleTiDBCloudOrgBindings(ctx context.Context, db metaQueryExecer) error {
+	_, err := db.ExecContext(ctx, `DELETE b
+		FROM tenant_tidbcloud_org_bindings b
+		LEFT JOIN tenants t ON t.id = b.tenant_id
+		WHERE t.id IS NULL OR t.status = ?`, TenantDeleted)
+	if err != nil {
+		return fmt.Errorf("delete stale tidbcloud org bindings: %w", err)
+	}
+	return nil
+}
+
+func ensureTiDBCloudOrgBindingUniqueIndex(ctx context.Context, db *sql.DB) error {
+	exists, err := metaIndexExists(ctx, db, "tenant_tidbcloud_org_bindings", "uk_tidbcloud_org_cluster_branch")
+	if err != nil {
+		return fmt.Errorf("check tidbcloud org binding unique index: %w", err)
+	}
+	if exists {
+		return nil
+	}
+	if err := ensureNoDuplicateTiDBCloudOrgBindingTuples(ctx, db); err != nil {
+		return fmt.Errorf("preflight tidbcloud org binding unique index: %w", err)
+	}
+	_, err = db.ExecContext(ctx, `CREATE UNIQUE INDEX uk_tidbcloud_org_cluster_branch
+		ON tenant_tidbcloud_org_bindings(organization_id, cluster_id, branch_id)`)
+	if err != nil {
+		if isIgnorableMetaSchemaError(err) {
+			return nil
+		}
+		return fmt.Errorf("create tidbcloud org binding unique index: %w", err)
+	}
+	return nil
+}
+
+func metaIndexExists(ctx context.Context, db *sql.DB, tableName, indexName string) (bool, error) {
+	var count int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM information_schema.statistics
+		WHERE table_schema = DATABASE() AND table_name = ? AND index_name = ?`,
+		tableName, indexName).Scan(&count); err != nil {
+		return false, fmt.Errorf("check meta index %s.%s exists: %w", tableName, indexName, err)
+	}
+	return count > 0, nil
+}
+
+func ensureNoDuplicateTiDBCloudOrgBindingTuples(ctx context.Context, db *sql.DB) error {
+	var total int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM (
+		SELECT organization_id, cluster_id, branch_id
+		FROM tenant_tidbcloud_org_bindings
+		GROUP BY organization_id, cluster_id, branch_id
+		HAVING COUNT(*) > 1
+	) duplicates`).Scan(&total); err != nil {
+		return fmt.Errorf("count duplicate tidbcloud org binding tuples: %w", err)
+	}
+	if total == 0 {
+		return nil
+	}
+
+	rows, err := db.QueryContext(ctx, `SELECT organization_id, cluster_id, branch_id, COUNT(*) AS n, GROUP_CONCAT(tenant_id ORDER BY tenant_id)
+		FROM tenant_tidbcloud_org_bindings
+		GROUP BY organization_id, cluster_id, branch_id
+		HAVING COUNT(*) > 1
+		ORDER BY n DESC, organization_id, cluster_id, branch_id
+		LIMIT ?`, maxTiDBCloudOrgBindingDuplicateTuples)
+	if err != nil {
+		return fmt.Errorf("list duplicate tidbcloud org binding tuples: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	conflicts := make([]string, 0, min(total, maxTiDBCloudOrgBindingDuplicateTuples))
+	for rows.Next() {
+		var organizationID, clusterID, branchID, tenantIDs string
+		var count int
+		if err := rows.Scan(&organizationID, &clusterID, &branchID, &count, &tenantIDs); err != nil {
+			return fmt.Errorf("scan duplicate tidbcloud org binding tuple: %w", err)
+		}
+		conflicts = append(conflicts, fmt.Sprintf("organization_id=%q cluster_id=%q branch_id=%q count=%d tenant_ids=%s", organizationID, clusterID, branchID, count, tenantIDs))
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("iterate duplicate tidbcloud org binding tuples: %w", err)
+	}
+	if total > len(conflicts) {
+		conflicts = append(conflicts, fmt.Sprintf("... %d more duplicate tuple(s) omitted", total-len(conflicts)))
+	}
+	return fmt.Errorf("cannot create tidbcloud org binding unique index: found %d duplicate tuple(s): %s", total, strings.Join(conflicts, "; "))
+}
+
 func parseMetaCreateTableStatement(stmt string) (tableName string, definitions string, ok bool, err error) {
 	return schemaspec.ParseCreateTableStatement(stmt)
 }
@@ -1533,6 +1628,9 @@ func (s *Store) UpsertTenantTiDBCloudOrgBinding(ctx context.Context, b *TenantTi
 		updatedAt = now
 	}
 	return s.withTiDBCloudOrgBindingLock(ctx, organizationID, clusterID, branchID, func(ctx context.Context, conn metaQueryExecer) error {
+		if err := deleteStaleTiDBCloudOrgBindingConflicts(ctx, conn, tenantID, organizationID, clusterID, branchID); err != nil {
+			return err
+		}
 		if err := ensureTiDBCloudOrgBindingAvailable(ctx, conn, tenantID, organizationID, clusterID, branchID); err != nil {
 			return err
 		}
@@ -1551,6 +1649,19 @@ func (s *Store) UpsertTenantTiDBCloudOrgBinding(ctx context.Context, b *TenantTi
 			createdAt.UTC(), updatedAt.UTC())
 		return execErr
 	})
+}
+
+func deleteStaleTiDBCloudOrgBindingConflicts(ctx context.Context, q metaQueryExecer, tenantID, organizationID, clusterID, branchID string) error {
+	_, err := q.ExecContext(ctx, `DELETE b
+		FROM tenant_tidbcloud_org_bindings b
+		LEFT JOIN tenants t ON t.id = b.tenant_id
+		WHERE b.organization_id = ? AND b.cluster_id = ? AND b.branch_id = ?
+			AND b.tenant_id <> ? AND (t.id IS NULL OR t.status = ?)`,
+		organizationID, clusterID, branchID, tenantID, TenantDeleted)
+	if err != nil {
+		return fmt.Errorf("delete stale tidbcloud org binding conflicts: %w", err)
+	}
+	return nil
 }
 
 func (s *Store) lookupTenantBranchID(ctx context.Context, tenantID string) (string, bool, error) {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1236,7 +1236,7 @@ func TestMetaSchemaSpecIncludesTiDBCloudOrgBindings(t *testing.T) {
 			t.Fatalf("tenant_tidbcloud_org_bindings schema missing %s", column)
 		}
 	}
-	for _, index := range []string{"primary", "idx_tidbcloud_org_cluster", "idx_tidbcloud_org_created"} {
+	for _, index := range []string{"primary", "uk_tidbcloud_org_cluster_branch", "idx_tidbcloud_org_cluster", "idx_tidbcloud_org_created"} {
 		if _, ok := table.indexes[index]; !ok {
 			t.Fatalf("tenant_tidbcloud_org_bindings schema missing index %s", index)
 		}
@@ -1319,6 +1319,53 @@ func TestUpsertTenantTiDBCloudOrgBindingIgnoresDeletedClusterBranch(t *testing.T
 		UpdatedAt:      now,
 	}); err != nil {
 		t.Fatalf("upsert new binding after deleted tenant: %v", err)
+	}
+}
+
+func TestEnsureNoDuplicateTiDBCloudOrgBindingTuplesReportsConflict(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	tenantIDs := []string{"binding-dup-1", "binding-dup-2", "binding-dup-3", "binding-dup-4"}
+	if _, err := s.DB().ExecContext(ctx, `DROP INDEX uk_tidbcloud_org_cluster_branch ON tenant_tidbcloud_org_bindings`); err != nil {
+		t.Fatalf("drop unique index: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = s.DB().ExecContext(context.Background(), `DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id IN (?, ?, ?, ?)`, tenantIDs[0], tenantIDs[1], tenantIDs[2], tenantIDs[3])
+		_, _ = s.DB().ExecContext(context.Background(), `DELETE FROM tenants WHERE id IN (?, ?, ?, ?)`, tenantIDs[0], tenantIDs[1], tenantIDs[2], tenantIDs[3])
+		if err := ensureTiDBCloudOrgBindingUniqueIndex(context.Background(), s.DB()); err != nil {
+			t.Fatalf("restore unique index: %v", err)
+		}
+	})
+	insertTiDBCloudBindingTenant(t, s, "binding-dup-1", TenantKindLive, TenantActive, "cluster-dup-a", "", now)
+	insertTiDBCloudBindingTenant(t, s, "binding-dup-2", TenantKindLive, TenantActive, "cluster-dup-a", "", now)
+	insertTiDBCloudBindingTenant(t, s, "binding-dup-3", TenantKindLive, TenantActive, "cluster-dup-b", "branch-dup", now)
+	insertTiDBCloudBindingTenant(t, s, "binding-dup-4", TenantKindLive, TenantActive, "cluster-dup-b", "branch-dup", now)
+	for _, binding := range []struct {
+		tenantID  string
+		clusterID string
+		branchID  string
+	}{
+		{tenantID: "binding-dup-1", clusterID: "cluster-dup-a"},
+		{tenantID: "binding-dup-2", clusterID: "cluster-dup-a"},
+		{tenantID: "binding-dup-3", clusterID: "cluster-dup-b", branchID: "branch-dup"},
+		{tenantID: "binding-dup-4", clusterID: "cluster-dup-b", branchID: "branch-dup"},
+	} {
+		if _, err := s.DB().ExecContext(ctx, `INSERT INTO tenant_tidbcloud_org_bindings
+			(tenant_id, organization_id, cluster_id, branch_id, pool_id, pool_status, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+			binding.tenantID, "org-1", binding.clusterID, binding.branchID, "", TenantPoolBindingUsed, now, now); err != nil {
+			t.Fatalf("insert duplicate binding %s: %v", binding.tenantID, err)
+		}
+	}
+	err := ensureNoDuplicateTiDBCloudOrgBindingTuples(ctx, s.DB())
+	if err == nil {
+		t.Fatal("ensureNoDuplicateTiDBCloudOrgBindingTuples error = nil, want duplicate error")
+	}
+	for _, want := range []string{"found 2 duplicate tuple(s)", "org-1", "cluster-dup-a", "cluster-dup-b", "branch-dup", "binding-dup-1", "binding-dup-2", "binding-dup-3", "binding-dup-4"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("duplicate error %q does not contain %q", err, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- add uk_tidbcloud_org_cluster_branch on organization_id, cluster_id, branch_id for TiDB Cloud org bindings
- create the unique index through an explicit migration step after branch_id backfill, stale deleted/orphan binding cleanup, and duplicate preflight
- make duplicate preflight diagnostics report the total duplicate tuple count and the first 20 conflicting tuples instead of only the first conflict
- clean same-tuple deleted/orphan conflicts inside the upsert lock before enforcing the non-deleted duplicate guard
- keep the existing non-unique org/cluster/created/tenant index for ordered listing coverage; it is not redundant with the new unique tuple index

## Branch ID behavior
branch_id remains NOT NULL DEFAULT empty string. Missing branch IDs are stored as the root branch dimension, so inserts do not fail just because branch_id is absent. They will conflict only when another binding already owns the same organization_id, cluster_id, branch_id tuple, which is the intended invariant.

## Deployment note
Before rolling this migration to production, run a duplicate check for active TiDB Cloud org bindings. If historical data contains more than one non-deleted tenant for the same organization_id, cluster_id, branch_id tuple, the migration preflight will fail and block service startup until the data is manually cleaned up. This is intentional safe-fail behavior so the unique index is not created over ambiguous ownership.

```sql
SELECT
  b.organization_id,
  b.cluster_id,
  b.branch_id,
  COUNT(*) AS tenant_count,
  GROUP_CONCAT(b.tenant_id ORDER BY b.tenant_id) AS tenant_ids
FROM tenant_tidbcloud_org_bindings b
JOIN tenants t ON t.id = b.tenant_id
WHERE t.status <> 'deleted'
GROUP BY b.organization_id, b.cluster_id, b.branch_id
HAVING COUNT(*) > 1
ORDER BY tenant_count DESC, b.organization_id, b.cluster_id, b.branch_id;
```

## Tests
- go test ./pkg/meta -count=1
- go test ./pkg/server -run "TestAdminTenantPool|TestAdminTenantCreateClaimsFreePoolTenant|TestAdminTenantGet|TestAdminTenantList|TestFork|TestTenantDeleteRejectsNonDeletedFork" -count=1
- git diff --check -- pkg/meta/meta.go pkg/meta/meta_test.go

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate TiDB Cloud organization bindings for the same cluster and branch.
  * Automatically cleans up stale bindings associated with deleted or unavailable tenants.
  * Improved handling of conflicting bindings during updates to preserve data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
