### PR TITLE
Throttle admin tenant pool replenishment

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -181,6 +181,10 @@ func main() {
 	if err != nil {
 		die(err)
 	}
+	tenantPoolRefillFreeRatio, err := tenantPoolRefillFreeRatioFromEnv()
+	if err != nil {
+		die(err)
+	}
 	maxUploadBytes := server.DefaultMaxUploadBytes
 	if raw := os.Getenv("DRIVE9_MAX_UPLOAD_BYTES"); raw != "" {
 		maxUploadBytes, err = strconv.ParseInt(raw, 10, 64)
@@ -405,6 +409,7 @@ func main() {
 		S3Dir:                           s3cfg.Dir,
 		MaxUploadBytes:                  maxUploadBytes,
 		TenantPoolMaxSize:               tenantPoolMaxSize,
+		TenantPoolRefillFreeRatio:       tenantPoolRefillFreeRatio,
 		InlineThreshold:                 backendOptions.InlineThreshold,
 		Logger:                          srvLogger,
 		SemanticEmbedder:                semanticEmbedder,
@@ -568,6 +573,7 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY optional default TiDB Cloud API public key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY optional default TiDB Cloud API private key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TENANT_POOL_MAX_SIZE maximum admin tenant pool size (default: %d)
+  DRIVE9_TENANT_POOL_REFILL_FREE_RATIO claim-triggered refill runs when active free tenants fall below this ratio (default: %.2f)
   DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*
   DRIVE9_SLOCK_API_ORIGIN Slock API origin (required when DRIVE9_SLOCK_ORIGIN is set)
   DRIVE9_SLOCK_CLIENT_ID Slock connected-app client id (required when DRIVE9_SLOCK_ORIGIN is set)
@@ -659,7 +665,7 @@ environment:
 schema tooling:
   dump-init-sql writes the exact init schema SQL to stdout so external systems
   can stay in sync with drive9's schema source of truth.
-`, server.DefaultMaxUploadBytes, meta.DefaultMaxStorageBytes(), server.DefaultTenantPoolMaxSize)
+`, server.DefaultMaxUploadBytes, meta.DefaultMaxStorageBytes(), server.DefaultTenantPoolMaxSize, server.DefaultTenantPoolRefillFreeRatio)
 	os.Exit(exitCode)
 }
 
@@ -971,6 +977,18 @@ func tenantPoolMaxSizeFromEnv() (int, error) {
 	v, err := strconv.Atoi(raw)
 	if err != nil || v <= 0 {
 		return 0, fmt.Errorf("invalid DRIVE9_TENANT_POOL_MAX_SIZE=%q: must be a positive integer", raw)
+	}
+	return v, nil
+}
+
+func tenantPoolRefillFreeRatioFromEnv() (float64, error) {
+	raw := strings.TrimSpace(os.Getenv("DRIVE9_TENANT_POOL_REFILL_FREE_RATIO"))
+	if raw == "" {
+		return server.DefaultTenantPoolRefillFreeRatio, nil
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v <= 0 || v > 1 {
+		return 0, fmt.Errorf("invalid DRIVE9_TENANT_POOL_REFILL_FREE_RATIO=%q: must be a number in (0,1]", raw)
 	}
 	return v, nil
 }

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -987,7 +987,7 @@ func tenantPoolRefillFreeRatioFromEnv() (float64, error) {
 		return server.DefaultTenantPoolRefillFreeRatio, nil
 	}
 	v, err := strconv.ParseFloat(raw, 64)
-	if err != nil || v <= 0 || v > 1 {
+	if err != nil || v <= 0 || v > 1 || v != v {
 		return 0, fmt.Errorf("invalid DRIVE9_TENANT_POOL_REFILL_FREE_RATIO=%q: must be a number in (0,1]", raw)
 	}
 	return v, nil

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -136,7 +136,7 @@ func TestTenantPoolRefillFreeRatioFromEnv(t *testing.T) {
 		t.Fatalf("refill ratio = %f, want 0.75", got)
 	}
 
-	for _, raw := range []string{"0", "-0.1", "1.1", "bad"} {
+	for _, raw := range []string{"0", "-0.1", "1.1", "NaN", "bad"} {
 		setEnv(t, key, raw)
 		if _, err := tenantPoolRefillFreeRatioFromEnv(); err == nil {
 			t.Fatalf("tenantPoolRefillFreeRatioFromEnv(%q) error = nil, want error", raw)

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -113,6 +113,37 @@ func TestTenantPoolMaxSizeFromEnv(t *testing.T) {
 	}
 }
 
+func TestTenantPoolRefillFreeRatioFromEnv(t *testing.T) {
+	const key = "DRIVE9_TENANT_POOL_REFILL_FREE_RATIO"
+	restore := snapshotEnv(t, []string{key})
+	t.Cleanup(func() { restoreEnv(t, restore) })
+
+	unsetEnv(t, []string{key})
+	got, err := tenantPoolRefillFreeRatioFromEnv()
+	if err != nil {
+		t.Fatalf("tenantPoolRefillFreeRatioFromEnv empty: %v", err)
+	}
+	if got != server.DefaultTenantPoolRefillFreeRatio {
+		t.Fatalf("empty refill ratio = %f, want %f", got, server.DefaultTenantPoolRefillFreeRatio)
+	}
+
+	setEnv(t, key, "0.75")
+	got, err = tenantPoolRefillFreeRatioFromEnv()
+	if err != nil {
+		t.Fatalf("tenantPoolRefillFreeRatioFromEnv valid: %v", err)
+	}
+	if got != 0.75 {
+		t.Fatalf("refill ratio = %f, want 0.75", got)
+	}
+
+	for _, raw := range []string{"0", "-0.1", "1.1", "bad"} {
+		setEnv(t, key, raw)
+		if _, err := tenantPoolRefillFreeRatioFromEnv(); err == nil {
+			t.Fatalf("tenantPoolRefillFreeRatioFromEnv(%q) error = nil, want error", raw)
+		}
+	}
+}
+
 func TestDBHealthProbeOptionsFromEnvDefaults(t *testing.T) {
 	keys := []string{
 		"DRIVE9_DB_HEALTH_PROBE_META_ENABLED",

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1524,6 +1524,9 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				metricResult = "noop"
 				return nil
 			}
+			// Trigger on active free tenants, but size refill against all free
+			// slots, including in-flight pending/provisioning tenants, so
+			// concurrent replenishment does not double-provision.
 			slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
@@ -1563,10 +1566,10 @@ func (s *Server) tenantPoolBelowRefillWatermark(freeSize, poolSize int) bool {
 }
 
 func (s *Server) effectiveTenantPoolRefillFreeRatio() float64 {
-	if s == nil || s.tenantPoolRefillFreeRatio <= 0 || s.tenantPoolRefillFreeRatio > 1 {
+	if s == nil {
 		return DefaultTenantPoolRefillFreeRatio
 	}
-	return s.tenantPoolRefillFreeRatio
+	return normalizeTenantPoolRefillFreeRatio(s.tenantPoolRefillFreeRatio)
 }
 
 func (s *Server) resumePendingTenantPoolAsync(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1508,6 +1508,22 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				return nil
 			}
 			defer s.refreshTenantPoolCapacity(ctx, current)
+			freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
+			if err != nil {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+				metricResult = "error"
+				return nil
+			}
+			if !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
+				logger.Info(ctx, "admin_tenant_pool_replenish_skipped",
+					zap.String("pool_id", current.PoolID),
+					zap.String("organization_id", current.OrganizationID),
+					zap.Int("pool_size", current.Size),
+					zap.Int("free_size", freeSize),
+					zap.Float64("refill_free_ratio", s.effectiveTenantPoolRefillFreeRatio()))
+				metricResult = "noop"
+				return nil
+			}
 			slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
@@ -1534,6 +1550,23 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			metricResult = adminTenantPoolMetricResult(err)
 		}
 	})
+}
+
+func (s *Server) tenantPoolBelowRefillWatermark(freeSize, poolSize int) bool {
+	if poolSize <= 0 {
+		return false
+	}
+	if freeSize < 0 {
+		freeSize = 0
+	}
+	return float64(freeSize)/float64(poolSize) < s.effectiveTenantPoolRefillFreeRatio()
+}
+
+func (s *Server) effectiveTenantPoolRefillFreeRatio() float64 {
+	if s == nil || s.tenantPoolRefillFreeRatio <= 0 || s.tenantPoolRefillFreeRatio > 1 {
+		return DefaultTenantPoolRefillFreeRatio
+	}
+	return s.tenantPoolRefillFreeRatio
 }
 
 func (s *Server) resumePendingTenantPoolAsync(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -382,6 +383,87 @@ func TestTenantPoolMetadataResumePersistContextPreservesServerCancellation(t *te
 	}
 }
 
+func TestAdminTenantPoolReplenishSkipsAtFreeWatermark(t *testing.T) {
+	rt, _ := newAdminTenantPoolRuntime(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID:         "pool-watermark-skip",
+		OrganizationID: "org-1",
+		Size:           10,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	for i := 1; i <= 8; i++ {
+		insertAdminPoolFreeTenant(t, rt, pool.PoolID, pool.OrganizationID, i)
+	}
+
+	rt.server.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	rt.server.forkWorkerWG.Wait()
+
+	if got := rt.prov.batchPoolCalls.Load(); got != 0 {
+		t.Fatalf("batch pool calls = %d, want 0", got)
+	}
+	free, err := rt.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID)
+	if err != nil {
+		t.Fatalf("count free: %v", err)
+	}
+	if free != 8 {
+		t.Fatalf("free size = %d, want 8", free)
+	}
+}
+
+func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
+	rt, _ := newAdminTenantPoolRuntime(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID:         "pool-watermark-refill",
+		OrganizationID: "org-1",
+		Size:           10,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	for i := 1; i <= 7; i++ {
+		insertAdminPoolFreeTenant(t, rt, pool.PoolID, pool.OrganizationID, i)
+	}
+
+	rt.server.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	rt.server.forkWorkerWG.Wait()
+
+	if got := rt.prov.batchPoolCalls.Load(); got != 1 {
+		t.Fatalf("batch pool calls = %d, want 1", got)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		free, err := rt.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID)
+		if err != nil {
+			t.Fatalf("count free: %v", err)
+		}
+		if free == 10 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("free size = %d, want 10 after refill", free)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 type adminTenantPoolSchemaInitRecorder struct {
 	*quotaTestProvisioner
 
@@ -396,6 +478,47 @@ func newAdminTenantPoolRuntime(t *testing.T) (*quotaRuntime, *adminTenantPoolSch
 	recorder := &adminTenantPoolSchemaInitRecorder{quotaTestProvisioner: rt.prov}
 	rt.server.provisioner = recorder
 	return rt, recorder
+}
+
+func insertAdminPoolFreeTenant(t *testing.T, rt *quotaRuntime, poolID, organizationID string, index int) string {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC().Add(time.Duration(index) * time.Second)
+	tenantID := fmt.Sprintf("%s-free-%d", poolID, index)
+	clusterID := fmt.Sprintf("%s-cluster-%d", poolID, index)
+	passCipher, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
+	if err != nil {
+		t.Fatalf("encrypt password: %v", err)
+	}
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           "db.example.com",
+		DBPort:           4000,
+		DBUser:           "u.root",
+		DBPasswordCipher: passCipher,
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        clusterID,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant %s: %v", tenantID, err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       tenantID,
+		OrganizationID: organizationID,
+		ClusterID:      clusterID,
+		PoolID:         poolID,
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert binding %s: %v", tenantID, err)
+	}
+	return tenantID
 }
 
 type deadlineMetadataResumeProvisioner struct {

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -461,6 +462,13 @@ func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
 			t.Fatalf("free size = %d, want 10 after refill", free)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestTenantPoolEffectiveRefillRatioRejectsNaN(t *testing.T) {
+	s := &Server{tenantPoolRefillFreeRatio: math.NaN()}
+	if got := s.effectiveTenantPoolRefillFreeRatio(); got != DefaultTenantPoolRefillFreeRatio {
+		t.Fatalf("effective refill ratio = %f, want %f", got, DefaultTenantPoolRefillFreeRatio)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -63,6 +63,11 @@ type Config struct {
 	// <= 0 are normalized to DefaultTenantPoolMaxSize; the pool is never
 	// intentionally uncapped.
 	TenantPoolMaxSize int
+	// TenantPoolRefillFreeRatio controls when claim-triggered asynchronous pool
+	// refill creates replacement tenants. Refill runs only when active free
+	// tenants fall below this ratio of the configured pool size. Values <= 0 are
+	// normalized to DefaultTenantPoolRefillFreeRatio.
+	TenantPoolRefillFreeRatio float64
 	// InlineThreshold is the server-wide DB-inline vs S3 cutoff surfaced to
 	// clients via /v1/status. When 0, the value is inferred from
 	// cfg.Backend.InlineThreshold() (or omitted in responses if no backend).
@@ -168,41 +173,42 @@ func (s *Server) provisionerForTenantProvider(provider string) tenant.Provisione
 }
 
 type Server struct {
-	fallback                 *backend.Dat9Backend
-	meta                     *meta.Store
-	pool                     *tenant.Pool
-	provisioner              tenant.Provisioner
-	legacyStarterProvisioner tenant.Provisioner
-	tokenSecret              []byte
-	localTenantAPIKey        string
-	vaultMK                  *vault.MasterKey
-	vaultIssuerURL           string
-	publicURL                string
-	maxUploadBytes           int64
-	tenantPoolMaxSize        int
-	inlineThreshold          int64
-	metrics                  *serverMetrics
-	logger                   *zap.Logger
-	mux                      *http.ServeMux
-	events                   *eventBuses
-	tenantWorker             *tenantWorkerManager
-	shardResolver            *semanticShardResolver
-	journalCursorSecret      []byte
-	objectGCWorker           *objectGCWorker
-	slockOAuth               SlockOAuthClient
-	tidbAutoEmbedding        tenantAutoEmbeddingDefault
-	disableDBAutoEmbed       bool
-	forkWorkerCtx            context.Context
-	forkWorkerCancel         context.CancelFunc
-	forkWorkerWG             sync.WaitGroup
-	forkWorkerMu             sync.Mutex
-	forkWorkerClosed         bool
-	tenantPoolLocks          sync.Map
-	tenantPoolCreateLocks    sync.Map
-	tenantPoolResumeJobs     sync.Map
-	tidbCloudRBACCache       *tidbCloudRBACCache
-	schemaInitErrors         sync.Map
-	leader                   *leader.Manager
+	fallback                  *backend.Dat9Backend
+	meta                      *meta.Store
+	pool                      *tenant.Pool
+	provisioner               tenant.Provisioner
+	legacyStarterProvisioner  tenant.Provisioner
+	tokenSecret               []byte
+	localTenantAPIKey         string
+	vaultMK                   *vault.MasterKey
+	vaultIssuerURL            string
+	publicURL                 string
+	maxUploadBytes            int64
+	tenantPoolMaxSize         int
+	tenantPoolRefillFreeRatio float64
+	inlineThreshold           int64
+	metrics                   *serverMetrics
+	logger                    *zap.Logger
+	mux                       *http.ServeMux
+	events                    *eventBuses
+	tenantWorker              *tenantWorkerManager
+	shardResolver             *semanticShardResolver
+	journalCursorSecret       []byte
+	objectGCWorker            *objectGCWorker
+	slockOAuth                SlockOAuthClient
+	tidbAutoEmbedding         tenantAutoEmbeddingDefault
+	disableDBAutoEmbed        bool
+	forkWorkerCtx             context.Context
+	forkWorkerCancel          context.CancelFunc
+	forkWorkerWG              sync.WaitGroup
+	forkWorkerMu              sync.Mutex
+	forkWorkerClosed          bool
+	tenantPoolLocks           sync.Map
+	tenantPoolCreateLocks     sync.Map
+	tenantPoolResumeJobs      sync.Map
+	tidbCloudRBACCache        *tidbCloudRBACCache
+	schemaInitErrors          sync.Map
+	leader                    *leader.Manager
 	// leaderWorkerCtx gates leader-only background schedulers. When leadership
 	// changes, this context is cancelled and recreated. Workers that use it
 	// (pending tenant reconciler, tenant delete cleanup, one-time resume tasks)
@@ -263,6 +269,10 @@ const DefaultMaxUploadBytes int64 = 10 * (1 << 30) // 10 GiB
 // DefaultTenantPoolMaxSize caps admin tenant pools unless overridden by server
 // configuration with a positive value.
 const DefaultTenantPoolMaxSize = 200
+
+// DefaultTenantPoolRefillFreeRatio delays claim-triggered pool refill until the
+// active free tenant count falls below 80% of the configured pool size.
+const DefaultTenantPoolRefillFreeRatio = 0.8
 
 // TenantStatusResponse is the JSON body of GET /v1/status. Fields are filled
 // per authenticated tenant so callers can discover their effective limits
@@ -329,25 +339,30 @@ func NewWithConfig(cfg Config) *Server {
 	if tenantPoolMaxSize <= 0 {
 		tenantPoolMaxSize = DefaultTenantPoolMaxSize
 	}
+	tenantPoolRefillFreeRatio := cfg.TenantPoolRefillFreeRatio
+	if tenantPoolRefillFreeRatio <= 0 || tenantPoolRefillFreeRatio > 1 {
+		tenantPoolRefillFreeRatio = DefaultTenantPoolRefillFreeRatio
+	}
 	forkWorkerCtx, forkWorkerCancel := context.WithCancel(context.Background())
 	s := &Server{
-		fallback:                 cfg.Backend,
-		meta:                     cfg.Meta,
-		pool:                     cfg.Pool,
-		tokenSecret:              cfg.TokenSecret,
-		localTenantAPIKey:        strings.TrimSpace(cfg.LocalTenantAPIKey),
-		vaultMK:                  vaultMK,
-		vaultIssuerURL:           strings.TrimSpace(cfg.VaultIssuerURL),
-		publicURL:                strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
-		provisioner:              cfg.Provisioner,
-		legacyStarterProvisioner: cfg.LegacyStarterProvisioner,
-		maxUploadBytes:           maxUpload,
-		tenantPoolMaxSize:        tenantPoolMaxSize,
-		inlineThreshold:          inlineThreshold,
-		metrics:                  newServerMetrics(),
-		logger:                   logger,
-		events:                   newEventBuses(),
-		slockOAuth:               cfg.SlockOAuth,
+		fallback:                  cfg.Backend,
+		meta:                      cfg.Meta,
+		pool:                      cfg.Pool,
+		tokenSecret:               cfg.TokenSecret,
+		localTenantAPIKey:         strings.TrimSpace(cfg.LocalTenantAPIKey),
+		vaultMK:                   vaultMK,
+		vaultIssuerURL:            strings.TrimSpace(cfg.VaultIssuerURL),
+		publicURL:                 strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
+		provisioner:               cfg.Provisioner,
+		legacyStarterProvisioner:  cfg.LegacyStarterProvisioner,
+		maxUploadBytes:            maxUpload,
+		tenantPoolMaxSize:         tenantPoolMaxSize,
+		tenantPoolRefillFreeRatio: tenantPoolRefillFreeRatio,
+		inlineThreshold:           inlineThreshold,
+		metrics:                   newServerMetrics(),
+		logger:                    logger,
+		events:                    newEventBuses(),
+		slockOAuth:                cfg.SlockOAuth,
 		tidbAutoEmbedding: tenantAutoEmbeddingDefault{
 			config:  defaultTiDBAutoEmbeddingConfig(cfg.TiDBAutoEmbeddingConfig),
 			apiKey:  strings.TrimSpace(cfg.TiDBAutoEmbeddingAPIKey),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -65,8 +65,8 @@ type Config struct {
 	TenantPoolMaxSize int
 	// TenantPoolRefillFreeRatio controls when claim-triggered asynchronous pool
 	// refill creates replacement tenants. Refill runs only when active free
-	// tenants fall below this ratio of the configured pool size. Values <= 0 are
-	// normalized to DefaultTenantPoolRefillFreeRatio.
+	// tenants fall below this ratio of the configured pool size. Values outside
+	// (0,1] are normalized to DefaultTenantPoolRefillFreeRatio.
 	TenantPoolRefillFreeRatio float64
 	// InlineThreshold is the server-wide DB-inline vs S3 cutoff surfaced to
 	// clients via /v1/status. When 0, the value is inferred from
@@ -339,10 +339,7 @@ func NewWithConfig(cfg Config) *Server {
 	if tenantPoolMaxSize <= 0 {
 		tenantPoolMaxSize = DefaultTenantPoolMaxSize
 	}
-	tenantPoolRefillFreeRatio := cfg.TenantPoolRefillFreeRatio
-	if tenantPoolRefillFreeRatio <= 0 || tenantPoolRefillFreeRatio > 1 {
-		tenantPoolRefillFreeRatio = DefaultTenantPoolRefillFreeRatio
-	}
+	tenantPoolRefillFreeRatio := normalizeTenantPoolRefillFreeRatio(cfg.TenantPoolRefillFreeRatio)
 	forkWorkerCtx, forkWorkerCancel := context.WithCancel(context.Background())
 	s := &Server{
 		fallback:                  cfg.Backend,
@@ -550,6 +547,13 @@ func NewWithConfig(cfg Config) *Server {
 		s.logTenantWorkerStatus(cfg, appManagedTaskTypes, fallbackTaskTypes, poolAutoTaskTypes)
 	}
 	return s
+}
+
+func normalizeTenantPoolRefillFreeRatio(ratio float64) float64 {
+	if ratio <= 0 || ratio > 1 || ratio != ratio {
+		return DefaultTenantPoolRefillFreeRatio
+	}
+	return ratio
 }
 
 // insertTenantNotify writes a best-effort unified outbox row so other pods

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1396,6 +1397,13 @@ func TestNewWithConfigUsesDefaultTenantPoolRefillFreeRatio(t *testing.T) {
 	s := NewWithConfig(Config{})
 	if s.tenantPoolRefillFreeRatio != DefaultTenantPoolRefillFreeRatio {
 		t.Fatalf("default tenantPoolRefillFreeRatio = %f, want %f", s.tenantPoolRefillFreeRatio, DefaultTenantPoolRefillFreeRatio)
+	}
+}
+
+func TestNewWithConfigRejectsNaNTenantPoolRefillFreeRatio(t *testing.T) {
+	s := NewWithConfig(Config{TenantPoolRefillFreeRatio: math.NaN()})
+	if s.tenantPoolRefillFreeRatio != DefaultTenantPoolRefillFreeRatio {
+		t.Fatalf("NaN tenantPoolRefillFreeRatio = %f, want %f", s.tenantPoolRefillFreeRatio, DefaultTenantPoolRefillFreeRatio)
 	}
 }
 

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -1392,6 +1392,13 @@ func TestNewWithConfigUsesDefaultTenantPoolMaxSize(t *testing.T) {
 	}
 }
 
+func TestNewWithConfigUsesDefaultTenantPoolRefillFreeRatio(t *testing.T) {
+	s := NewWithConfig(Config{})
+	if s.tenantPoolRefillFreeRatio != DefaultTenantPoolRefillFreeRatio {
+		t.Fatalf("default tenantPoolRefillFreeRatio = %f, want %f", s.tenantPoolRefillFreeRatio, DefaultTenantPoolRefillFreeRatio)
+	}
+}
+
 func TestDeclaredContentLengthOverMaxRejected(t *testing.T) {
 	base, _ := newTestServerWithS3(t)
 	s := NewWithConfig(Config{Backend: base.fallback, MaxUploadBytes: 10})


### PR DESCRIPTION
## Summary
- add a configurable admin tenant pool refill free-ratio watermark, defaulting to 0.8
- skip claim-triggered replenishment while active free tenants remain at or above the watermark
- batch refill back to the configured pool size once active free capacity drops below the watermark

## Tests
- go test ./pkg/server -run 'TestAdminTenantPoolReplenish|TestNewWithConfigUsesDefaultTenantPool|TestAdminTenantPoolCreateUsesPrivateEndpointDBTLS|TestTenantPoolMetadataResumeUsesPrivateEndpointDBTLS'
- go test ./cmd/drive9-server -run 'TestTenantPoolMaxSizeFromEnv|TestTenantPoolRefillFreeRatioFromEnv'
- go test ./pkg/server
- go test ./cmd/drive9-server
- git diff --check