### PR TITLE
Reduce zero-duration tenant metric histograms

### DIFF
--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -3033,8 +3033,10 @@ func observeStoreOp(ctx context.Context, op string, start time.Time, errp *error
 				result = "error"
 			}
 		}
-		if result != "canceled" && result != "deadline_exceeded" && result != "conn_closed" {
+		if shouldLogStoreOpFailure(result) {
 			logger.Error(ctx, "datastore_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
+		} else {
+			logger.Warn(ctx, "datastore_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
 		}
 	}
 	logger.InfoBenchTiming(ctx, "datastore_op_timing",
@@ -3042,6 +3044,15 @@ func observeStoreOp(ctx context.Context, op string, start time.Time, errp *error
 		zap.String("result", result),
 		zap.Float64("duration_ms", float64(elapsed.Microseconds())/1000.0))
 	metrics.RecordOperation("datastore", op, result, elapsed)
+}
+
+func shouldLogStoreOpFailure(result string) bool {
+	switch result {
+	case "not_found", "canceled", "deadline_exceeded", "conn_closed":
+		return false
+	default:
+		return true
+	}
 }
 
 func (s *Store) ExecSQL(ctx context.Context, query string) (out []map[string]interface{}, err error) {

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -27,6 +27,27 @@ func newTestStore(t *testing.T) *Store {
 
 var seq int
 
+func TestShouldLogStoreOpFailure(t *testing.T) {
+	tests := []struct {
+		result string
+		want   bool
+	}{
+		{result: "not_found", want: false},
+		{result: "canceled", want: false},
+		{result: "deadline_exceeded", want: false},
+		{result: "conn_closed", want: false},
+		{result: "conflict", want: true},
+		{result: "error", want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.result, func(t *testing.T) {
+			if got := shouldLogStoreOpFailure(tt.result); got != tt.want {
+				t.Fatalf("shouldLogStoreOpFailure(%q) = %v, want %v", tt.result, got, tt.want)
+			}
+		})
+	}
+}
+
 func genID() string {
 	seq++
 	return fmt.Sprintf("id-%04d", seq)

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -126,6 +126,9 @@ func RecordTenantOperation(tenantID, component, operation, result string, d time
 		attrs = append(attrs, Attr("tenant_id", tenantID))
 	}
 	serviceOperationsTotal.Add(1, attrs...)
+	if d <= 0 {
+		return
+	}
 	serviceOperationDuration.Observe(d.Seconds(), attrs...)
 }
 
@@ -347,6 +350,9 @@ func RecordTenantRequest(tenantID, surface, action, result string, status int, d
 		Attr("status_class", statusClass),
 	}
 	tenantRequestsTotal.Add(1, attrs...)
+	if d <= 0 {
+		return
+	}
 	tenantRequestDuration.Observe(d.Seconds(), attrs...)
 }
 
@@ -438,6 +444,9 @@ func RecordSSEConnection(tenantID, reason string, d time.Duration) {
 	RegisterModule("sse")
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	sseConnectionsTotal.Add(1, Attr("tenant_id", tenantID), Attr("reason", cleanMetricValue(reason, "unknown")))
+	if d <= 0 {
+		return
+	}
 	sseConnectionDuration.Observe(d.Seconds(), Attr("tenant_id", tenantID))
 }
 
@@ -455,6 +464,9 @@ func RecordSSEInFlight(tenantID string, count float64) {
 
 // RecordSSEPhase1 records the duration of the SSE Phase-1 replay/reset stage.
 func RecordSSEPhase1(tenantID string, d time.Duration) {
+	if d <= 0 {
+		return
+	}
 	RegisterModule("sse")
 	ssePhase1Duration.Observe(d.Seconds(), Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
 }
@@ -487,6 +499,9 @@ func RecordSSEHeartbeatSent(tenantID string) {
 // the error-only counters, this records every query (ok and error) so DB
 // pressure and table growth on the events path are observable.
 func RecordEventBusQuery(tenantID, operation, result string, d time.Duration) {
+	if d <= 0 {
+		return
+	}
 	RegisterModule("sse")
 	eventBusQueryDuration.Observe(d.Seconds(),
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -52,6 +52,75 @@ func TestRecordTenantOperationCountDoesNotRecordDuration(t *testing.T) {
 	}
 }
 
+func TestRecordTenantOperationZeroDurationDoesNotRecordDuration(t *testing.T) {
+	const component = "zero_duration_test_component"
+	const operation = "zero_duration_test_operation"
+
+	RecordTenantOperation("tenant-zero", component, operation, "ok", 0)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-zero"} 1`) {
+		t.Fatalf("missing zero-duration operation total:\n%s", text)
+	}
+	if strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-zero"}`) {
+		t.Fatalf("zero-duration operation unexpectedly recorded a duration:\n%s", text)
+	}
+}
+
+func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
+	const tenantID = "tenant-zero-request"
+
+	RecordTenantRequest(tenantID, "zero_surface", "zero_action", "ok", 200, 0)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="zero_action",result="ok",status="200",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`"} 1`) {
+		t.Fatalf("missing zero-duration tenant request total:\n%s", text)
+	}
+	if strings.Contains(text, `drive9_tenant_request_duration_seconds_count{action="zero_action",result="ok",status="200",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`"}`) {
+		t.Fatalf("zero-duration tenant request unexpectedly recorded a duration:\n%s", text)
+	}
+}
+
+func TestRecordSSEConnectionZeroDurationDoesNotRecordDuration(t *testing.T) {
+	const tenantID = "tenant-zero-sse-connection"
+
+	RecordSSEConnection(tenantID, "closed", 0)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_sse_connections_total{reason="closed",tenant_id="`+tenantID+`"} 1`) {
+		t.Fatalf("missing zero-duration SSE connection total:\n%s", text)
+	}
+	if strings.Contains(text, `drive9_sse_connection_duration_seconds_count{tenant_id="`+tenantID+`"}`) {
+		t.Fatalf("zero-duration SSE connection unexpectedly recorded a duration:\n%s", text)
+	}
+}
+
+func TestRecordTenantDurationMetricsSkipZeroDuration(t *testing.T) {
+	const (
+		phaseTenant    = "tenant-zero-sse-phase1"
+		eventBusTenant = "tenant-zero-event-bus"
+	)
+
+	RecordSSEPhase1(phaseTenant, 0)
+	RecordEventBusQuery(eventBusTenant, "events_since", "ok", 0)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if strings.Contains(text, `drive9_sse_phase1_duration_seconds_count{tenant_id="`+phaseTenant+`"}`) {
+		t.Fatalf("zero-duration SSE phase1 unexpectedly recorded a duration:\n%s", text)
+	}
+	if strings.Contains(text, `drive9_event_bus_query_duration_seconds_count{operation="events_since",result="ok",tenant_id="`+eventBusTenant+`"}`) {
+		t.Fatalf("zero-duration event bus query unexpectedly recorded a duration:\n%s", text)
+	}
+}
+
 func TestRecordTenantPoolMetadataResumeWaitIncludesPoolAndOrganizationID(t *testing.T) {
 	const poolID = "pool-metadata-resume-metrics-test"
 	const organizationID = "org-metadata-resume-metrics-test"


### PR DESCRIPTION
## Summary
- skip zero-duration samples for tenant-scoped duration histograms while keeping tenant-scoped counters intact
- keep `tenant_id` on counters/gauges and positive-duration histogram samples
- downgrade expected datastore non-error outcomes from error logs to warn logs while preserving datastore timing and metrics

## Details
- `RecordTenantOperation`, `RecordTenantRequest`, `RecordSSEConnection`, `RecordSSEPhase1`, and `RecordEventBusQuery` now avoid creating duration histogram buckets for `d <= 0`.
- `datastore_op_failed` still logs for non-ok datastore results, but `not_found`, `canceled`, `deadline_exceeded`, and `conn_closed` are warn-level rather than error-level.

## Tests
- `go test ./pkg/metrics ./pkg/datastore ./pkg/tenant ./pkg/server -run 'TestShouldLogStoreOpFailure|TestRecordTenantOperation|TestRecordTenantRequest|TestRecordSSEConnection|TestRecordTenantDurationMetricsSkipZeroDuration|TestRecordOperationIncludesLongAdminTenantPoolUpdateBuckets|TestRecordTenantPoolMetadataResumeWaitIncludesPoolAndOrganizationID|TestVaultMetricsExposed|TestServerMetrics|TestTenantPool'`
- `git diff --check -- pkg/metrics/operations.go pkg/metrics/operations_test.go pkg/datastore/store.go pkg/datastore/store_test.go`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced metric accuracy by filtering out invalid duration samples in operation and event tracking.

* **Tests**
  * Added test coverage for store operation logging behavior and metric recording with zero-duration edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->