### PR TITLE
feat(cli): add strict direct mount option

### DIFF
--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -71,6 +71,7 @@ type mountFuseOptions struct {
 	ParallelReadConcurrency int
 	ParallelReadBlockSize   int64
 	SyncRead                bool
+	DirectMountStrict       bool
 	AllowOther              bool
 	ReadOnly                bool
 	Debug                   bool

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -64,6 +64,7 @@ func mountFuseImpl(opts *mountFuseOptions) error {
 		ParallelReadConcurrency: opts.ParallelReadConcurrency,
 		ParallelReadBlockSize:   opts.ParallelReadBlockSize,
 		SyncRead:                opts.SyncRead,
+		DirectMountStrict:       opts.DirectMountStrict,
 		AllowOther:              opts.AllowOther,
 		ReadOnly:                opts.ReadOnly,
 		Debug:                   opts.Debug,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -133,6 +133,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	parallelReadConcurrency := fs.Int("parallel-read-concurrency", defaultFuseParallelReadConcurrency, "maximum concurrent block reads for one large FUSE read")
 	parallelReadBlockSize := fs.Int64("parallel-read-block-size-mb", defaultFuseParallelReadBlockSizeMB, "block size in MB for parallel large-file reads")
 	syncRead := fs.Bool("fuse-sync-read", false, "disable kernel async read dispatch; at most one read in flight per file handle")
+	directMountStrict := fs.Bool("direct-mount-strict", false, "Linux only: mount directly with mount(2) and do not fall back to fusermount")
 	legacyDirStatFallback := fs.Bool("legacy-dir-stat-fallback", false, "on Lookup stat 404, list parent to support legacy servers without directory stat")
 	readDirPrefetch := fs.Bool("readdir-prefetch", false, "prefetch small files after directory reads into the read cache")
 	prefetchMaxFiles := fs.Int("readdir-prefetch-max-files", 32, "maximum small files prefetched per directory read")
@@ -305,6 +306,12 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	profileGiven := flagProvided(fs, "profile")
 	resolved := ResolveMountMode(mountMode, runtime.GOOS, exec.LookPath)
 	fmt.Fprintf(os.Stderr, "drive9: mount mode: %s\n", resolved)
+	if *directMountStrict && resolved == MountModeWebDAV {
+		return fmt.Errorf("drive9 mount: --direct-mount-strict is not supported with WebDAV mode")
+	}
+	if *directMountStrict && runtime.GOOS != "linux" {
+		return fmt.Errorf("drive9 mount: --direct-mount-strict is only supported on Linux")
+	}
 	var profileCfg profileConfig
 	if !profileGiven && resolved == MountModeWebDAV {
 		profileCfg = builtinNoneProfile()
@@ -567,6 +574,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 		ParallelReadConcurrency: *parallelReadConcurrency,
 		ParallelReadBlockSize:   *parallelReadBlockSize << 20,
 		SyncRead:                *syncRead,
+		DirectMountStrict:       *directMountStrict,
 		AllowOther:              *allowOther,
 		ReadOnly:                *readOnly,
 		Debug:                   *debug,

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -924,6 +924,11 @@ func TestForegroundMountCommandArgs(t *testing.T) {
 			want: []string{"mount", "--foreground", "--mode", "fuse", "/mnt/drive9"},
 		},
 		{
+			name: "fs preserve direct mount strict",
+			in:   []string{"--direct-mount-strict", "/mnt/drive9"},
+			want: []string{"mount", "--foreground", "--direct-mount-strict", "/mnt/drive9"},
+		},
+		{
 			name: "vault",
 			in:   []string{"vault", "--dir-ttl", "1s", "/mnt/vault"},
 			want: []string{"mount", "vault", "--foreground", "--dir-ttl", "1s", "/mnt/vault"},
@@ -1638,6 +1643,86 @@ func TestMountCmdPassesFuseSyncReadOption(t *testing.T) {
 	}
 	if !got.SyncRead {
 		t.Fatal("SyncRead = false, want true")
+	}
+}
+
+func TestMountCmdMapsDirectMountStrictOption(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "default"},
+		{name: "enabled", args: []string{"--direct-mount-strict"}, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.want && runtime.GOOS != "linux" {
+				t.Skip("direct mount is only supported on Linux")
+			}
+
+			var got *mountFuseOptions
+			mountFuse = func(opts *mountFuseOptions) error {
+				copied := *opts
+				got = &copied
+				return nil
+			}
+
+			args := []string{
+				"--foreground",
+				"--mode", "fuse",
+				"--server", "https://drive9.example",
+				"--api-key", "sk-test",
+			}
+			args = append(args, tt.args...)
+			args = append(args, t.TempDir())
+
+			if err := MountCmd(args); err != nil {
+				t.Fatalf("MountCmd: %v", err)
+			}
+			if got == nil {
+				t.Fatal("mountFuse was not called")
+			}
+			if got.DirectMountStrict != tt.want {
+				t.Fatalf("DirectMountStrict = %t, want %t", got.DirectMountStrict, tt.want)
+			}
+		})
+	}
+}
+
+func TestMountCmdRejectsDirectMountStrictWithWebDAV(t *testing.T) {
+	err := MountCmd([]string{
+		"--foreground",
+		"--mode", "webdav",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--direct-mount-strict",
+		t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "--direct-mount-strict is not supported with WebDAV mode") {
+		t.Fatalf("MountCmd error = %v, want direct-mount-strict WebDAV validation error", err)
+	}
+}
+
+func TestMountCmdRejectsDirectMountStrictOutsideLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("non-Linux validation")
+	}
+
+	err := MountCmd([]string{
+		"--foreground",
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--direct-mount-strict",
+		t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "--direct-mount-strict is only supported on Linux") {
+		t.Fatalf("MountCmd error = %v, want direct-mount-strict platform validation error", err)
 	}
 }
 

--- a/cmd/drive9/main_test.go
+++ b/cmd/drive9/main_test.go
@@ -291,7 +291,7 @@ func TestRenderDrive9VisualHelpColor(t *testing.T) {
 	if !strings.Contains(out, "\x1b[") {
 		t.Fatalf("renderDrive9VisualHelp(true) missing ANSI color escapes")
 	}
-	for _, want := range []string{"drive9", "create", "fs", "git", "less", "-R", "-S"} {
+	for _, want := range []string{"drive9", "create", "fs", "git", "--direct-mount-strict", "less", "-R", "-S"} {
 		if !strings.Contains(out, want) {
 			t.Fatalf("rendered help missing %q:\n%s", want, out)
 		}

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -724,6 +724,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 					{Name: "--api-key KEY", Desc: "owner API key; overrides DRIVE9_API_KEY and config"},
 					{Name: "--mode auto|fuse|webdav", Desc: "mount mode; auto selects the best supported mode"},
 					{Name: "--foreground", Desc: "run in foreground and block until unmounted"},
+					{Name: "--direct-mount-strict", Desc: "Linux only; use mount(2) without fallback to fusermount"},
 				}},
 				{Title: "Read cache", Flags: []visualHelpFlag{
 					{Name: "--cache-dir DIR", Desc: "write-back cache directory; default ~/.cache/drive9"},

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -8690,6 +8690,18 @@ func TestGoFuseMountOptionsMapsSyncRead(t *testing.T) {
 	}
 }
 
+func TestGoFuseMountOptionsMapsDirectMountStrict(t *testing.T) {
+	defaults := newGoFuseMountOptions(&MountOptions{})
+	if defaults.DirectMountStrict {
+		t.Fatal("default go-fuse DirectMountStrict = true, want false")
+	}
+
+	explicit := newGoFuseMountOptions(&MountOptions{DirectMountStrict: true})
+	if !explicit.DirectMountStrict {
+		t.Fatal("explicit go-fuse DirectMountStrict = false, want true")
+	}
+}
+
 func TestGoFuseMountOptionsAllowOtherUsesDefaultPermissionsOnLinux(t *testing.T) {
 	opts := newGoFuseMountOptions(&MountOptions{AllowOther: true})
 	hasDefaultPermissions := false

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -68,6 +68,7 @@ type MountOptions struct {
 	ParallelReadConcurrency int           // maximum concurrent block reads for one large FUSE read (default 4)
 	ParallelReadBlockSize   int64         // block size for parallel large-file reads in bytes (default 1MiB)
 	SyncRead                bool          // disable kernel async read dispatch; at most one read in flight per file handle
+	DirectMountStrict       bool          // Linux only: mount with mount(2) and do not fall back to fusermount
 	LookupRetryCount        int           // detached retries after transient Lookup/GetAttr stat failures (default 2)
 	LookupRetryTimeout      time.Duration // timeout per detached stat retry after interrupt/transient errors (default 250ms)
 	LegacyDirStatFallback   bool          // on Lookup stat 404, list parent to support legacy servers without directory stat
@@ -1218,6 +1219,7 @@ func newGoFuseMountOptions(opts *MountOptions) *gofuse.MountOptions {
 		MaxWrite:           128 * 1024,      // 128KB per write request (default 64KB)
 		MaxBackground:      32,              // concurrent background FUSE requests (default 12)
 		SyncRead:           opts.SyncRead,   // disables FUSE_CAP_ASYNC_READ; one read in flight per file handle
+		DirectMountStrict:  opts.DirectMountStrict,
 		EnableLocks:        true,
 		Debug:              opts.Debug,
 		AllowOther:         opts.AllowOther,


### PR DESCRIPTION
## Summary

- add an opt-in `--direct-mount-strict` flag for Linux FUSE mounts
- pass the setting through the CLI bridge to go-fuse's `DirectMountStrict`
- preserve the existing fusermount-based default behavior
- reject the flag for WebDAV and non-Linux mounts, and expose it in CLI help

## Motivation

Kubernetes CSI deployments can execute drive9 inside the host mount namespace with `/dev/fuse` and `CAP_SYS_ADMIN`. Strict direct mounting uses `mount(2)` without requiring `fusermount3` in the image.

## Behavior

- without the flag: unchanged; go-fuse uses the fusermount helper path
- with the flag: go-fuse uses direct `mount(2)` and returns an error without helper fallback

## Validation

- `go test ./cmd/drive9 ./cmd/drive9/cli`
- `go test ./pkg/fuse -run '^TestGoFuseMountOptionsMapsDirectMountStrict$' -count=1`
- changed-scope golangci-lint: 0 issues
- two independent read-only diff reviews: no findings

Full `pkg/fuse` tests were attempted, but the local host's low free disk space triggered unrelated existing ENOSPC quota-test failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Linux-only `--direct-mount-strict` option to `drive9 mount`.
  * Enables strict direct FUSE mounting without fallback behavior.
  * The option is displayed in visual help and preserved in foreground mount commands.

* **Bug Fixes**
  * Clear validation errors are now shown when using the option with WebDAV or on non-Linux systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->