### PR TITLE
Reduce Drive9 metrics and schema diff overhead

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -534,7 +534,7 @@ environment:
   DRIVE9_META_DB_MAX_OPEN_CONNS max open connections for the per-pod meta DB pool (default: 100)
   DRIVE9_META_DB_MAX_IDLE_CONNS max idle connections for the per-pod meta DB pool (default: 20)
   DRIVE9_USER_DB_MAX_OPEN_CONNS max open connections for each cached tenant user DB pool (default: 6)
-  DRIVE9_USER_DB_MAX_IDLE_CONNS max idle connections for each cached tenant user DB pool (default: 2)
+  DRIVE9_USER_DB_MAX_IDLE_CONNS max idle connections for each cached tenant user DB pool (default: 0)
   DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS max open connections for tenant schema-init DB pools (default: 8)
   DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS max idle connections for tenant schema-init DB pools (default: 0)
   DRIVE9_DB_HEALTH_PROBE_INTERVAL_SECONDS DB health probe interval seconds (default: 15)

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -117,25 +117,23 @@ func RecordTenantOperation(tenantID, component, operation, result string, d time
 	result = cleanMetricValue(result, "unknown")
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	RegisterModule(component)
-	counterAttrs := []Attribute{
+	baseAttrs := [4]Attribute{
 		Attr("component", component),
 		Attr("operation", operation),
 		Attr("result", result),
 	}
+	counterAttrs := baseAttrs[:3]
 	if tenantID != "unknown" {
-		counterAttrs = append(counterAttrs, Attr("tenant_id", tenantID))
+		baseAttrs[3] = Attr("tenant_id", tenantID)
+		counterAttrs = baseAttrs[:4]
 	}
 	serviceOperationsTotal.Add(1, counterAttrs...)
 	if d <= 0 {
 		return
 	}
-	durationAttrs := []Attribute{
-		Attr("component", component),
-		Attr("operation", operation),
-		Attr("result", result),
-	}
+	durationAttrs := baseAttrs[:3]
 	if tenantID != "unknown" && serviceOperationDurationIncludesTenant(component) {
-		durationAttrs = append(durationAttrs, Attr("tenant_id", tenantID))
+		durationAttrs = baseAttrs[:4]
 	}
 	serviceOperationDuration.Observe(d.Seconds(), durationAttrs...)
 }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -117,19 +117,36 @@ func RecordTenantOperation(tenantID, component, operation, result string, d time
 	result = cleanMetricValue(result, "unknown")
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	RegisterModule(component)
-	attrs := []Attribute{
+	counterAttrs := []Attribute{
 		Attr("component", component),
 		Attr("operation", operation),
 		Attr("result", result),
 	}
 	if tenantID != "unknown" {
-		attrs = append(attrs, Attr("tenant_id", tenantID))
+		counterAttrs = append(counterAttrs, Attr("tenant_id", tenantID))
 	}
-	serviceOperationsTotal.Add(1, attrs...)
+	serviceOperationsTotal.Add(1, counterAttrs...)
 	if d <= 0 {
 		return
 	}
-	serviceOperationDuration.Observe(d.Seconds(), attrs...)
+	durationAttrs := []Attribute{
+		Attr("component", component),
+		Attr("operation", operation),
+		Attr("result", result),
+	}
+	if tenantID != "unknown" && serviceOperationDurationIncludesTenant(component) {
+		durationAttrs = append(durationAttrs, Attr("tenant_id", tenantID))
+	}
+	serviceOperationDuration.Observe(d.Seconds(), durationAttrs...)
+}
+
+func serviceOperationDurationIncludesTenant(component string) bool {
+	switch component {
+	case "file_gc", "quota_config_cache", "server_quota", "user_db_access":
+		return false
+	default:
+		return true
+	}
 }
 
 func RecordTenantPoolMetadataResumeWait(poolID, organizationID, scope, result string, d time.Duration) {

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -69,6 +69,47 @@ func TestRecordTenantOperationZeroDurationDoesNotRecordDuration(t *testing.T) {
 	}
 }
 
+func TestRecordTenantOperationOmitsTenantFromSelectedDurationHistograms(t *testing.T) {
+	const operation = "duration_tenant_omit_test_operation"
+
+	for _, component := range []string{"file_gc", "quota_config_cache", "server_quota", "user_db_access"} {
+		t.Run(component, func(t *testing.T) {
+			tenantID := "tenant-duration-omit-" + component
+			RecordTenantOperation(tenantID, component, operation, "ok", time.Second)
+
+			rec := httptest.NewRecorder()
+			WritePrometheus(rec)
+			text := rec.Body.String()
+			if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="`+tenantID+`"} 1`) {
+				t.Fatalf("missing tenant-scoped operation total:\n%s", text)
+			}
+			if !strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok"} 1`) {
+				t.Fatalf("missing tenant-omitted duration histogram:\n%s", text)
+			}
+			if strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="`+tenantID+`"}`) {
+				t.Fatalf("duration histogram unexpectedly carried tenant_id:\n%s", text)
+			}
+		})
+	}
+}
+
+func TestRecordTenantOperationKeepsTenantOnBackendDurationHistogram(t *testing.T) {
+	const (
+		tenantID  = "tenant-duration-backend"
+		component = "backend"
+		operation = "duration_tenant_keep_test_operation"
+	)
+
+	RecordTenantOperation(tenantID, component, operation, "ok", time.Second)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="`+tenantID+`"} 1`) {
+		t.Fatalf("backend duration histogram should keep tenant_id:\n%s", text)
+	}
+}
+
 func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
 	const tenantID = "tenant-zero-request"
 

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -16,7 +16,7 @@ const (
 	defaultUserConnMaxLifetime       = 30 * time.Second
 	defaultUserConnMaxIdleTime       = 30 * time.Second
 	defaultUserMaxOpenConns          = 6
-	defaultUserMaxIdleConns          = 2
+	defaultUserMaxIdleConns          = 0
 	defaultUserSchemaConnMaxLifetime = 1 * time.Minute
 	defaultUserSchemaConnMaxIdleTime = 10 * time.Second
 	defaultUserSchemaMaxOpenConns    = 8

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -13,8 +13,8 @@ const (
 	defaultMetaConnMaxIdleTime       = 45 * time.Second
 	defaultMetaMaxOpenConns          = 100
 	defaultMetaMaxIdleConns          = 20
-	defaultUserConnMaxLifetime       = 30 * time.Second
-	defaultUserConnMaxIdleTime       = 30 * time.Second
+	defaultUserConnMaxLifetime       = 45 * time.Second
+	defaultUserConnMaxIdleTime       = 15 * time.Second
 	defaultUserMaxOpenConns          = 6
 	defaultUserMaxIdleConns          = 0
 	defaultUserSchemaConnMaxLifetime = 1 * time.Minute

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -13,7 +13,7 @@ const (
 	defaultMetaConnMaxIdleTime       = 45 * time.Second
 	defaultMetaMaxOpenConns          = 100
 	defaultMetaMaxIdleConns          = 20
-	defaultUserConnMaxLifetime       = 45 * time.Second
+	defaultUserConnMaxLifetime       = 30 * time.Second
 	defaultUserConnMaxIdleTime       = 15 * time.Second
 	defaultUserMaxOpenConns          = 6
 	defaultUserMaxIdleConns          = 0

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5346,6 +5346,7 @@ func (s *Server) handleLocalTenantProvision(w http.ResponseWriter, r *http.Reque
 
 func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN, provider string, schemaInit func(context.Context, string) error) {
 	ctx = ensureTrace(ctx)
+	ctx = tenantschema.WithTenantID(ctx, tenantID)
 	ctx = logger.WithContext(ctx, logger.FromContext(ctx).With(
 		zap.String("tenant_id", tenantID),
 		zap.String("provider", provider),

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -163,10 +163,11 @@ var (
 	validateTiDBSchemaForAutoEmbeddingProfile = schema.ValidateTiDBSchemaForAutoEmbeddingProfile
 	ensureTiDBSchemaForFTSOnlyProfile         = schema.EnsureTiDBSchemaForFTSOnlyProfile
 	validateTiDBSchemaForFTSOnlyProfile       = schema.ValidateTiDBSchemaForFTSOnlyProfile
-	// Validate once on the first version-matched open after process start, then
-	// periodically thereafter to catch out-of-band schema drift without putting a
-	// full schema diff on every tenant open.
-	periodicTiDBSchemaValidationEvery uint64 = 32
+	// Version-matched tenant opens trust the durable tenant schema_version by
+	// default. Set this non-zero in targeted tests or emergency builds to sample
+	// out-of-band schema drift without putting a full schema diff on every cold
+	// tenant open.
+	periodicTiDBSchemaValidationEvery uint64 = 0
 	defaultTenantPoolDrainTimeout            = 30 * time.Second
 	defaultTenantPoolMaxTenants              = 1024
 	defaultTenantPoolIdleReapInterval        = 5 * time.Minute

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -131,15 +131,14 @@ type TenantStoreEntry struct {
 }
 
 type Pool struct {
-	mu                        sync.Mutex
-	cfg                       PoolConfig
-	enc                       encrypt.Encryptor
-	metaStore                 *meta.Store // central server DB for quota operations; nil disables central quota
-	items                     map[string]*entry
-	order                     *list.List
-	maxSize                   int
-	tidbSchemaValidationOpens atomic.Uint64
-	tenantWorkNotifier        atomic.Pointer[func(tenantID string, workMask int)]
+	mu                 sync.Mutex
+	cfg                PoolConfig
+	enc                encrypt.Encryptor
+	metaStore          *meta.Store // central server DB for quota operations; nil disables central quota
+	items              map[string]*entry
+	order              *list.List
+	maxSize            int
+	tenantWorkNotifier atomic.Pointer[func(tenantID string, workMask int)]
 	// fileGCEnabled is retained for backward compatibility but no longer used:
 	// FileGC is now kick-driven through the unified tenant worker, not a
 	// per-backend goroutine.
@@ -158,19 +157,12 @@ type tenantAutoEmbeddingProfile struct {
 }
 
 var (
-	applyTiDBAutoEmbeddingProviderConfig      = schema.ApplyTiDBAutoEmbeddingProviderConfig
-	ensureTiDBSchemaForAutoEmbeddingProfile   = schema.EnsureTiDBSchemaForAutoEmbeddingProfile
-	validateTiDBSchemaForAutoEmbeddingProfile = schema.ValidateTiDBSchemaForAutoEmbeddingProfile
-	ensureTiDBSchemaForFTSOnlyProfile         = schema.EnsureTiDBSchemaForFTSOnlyProfile
-	validateTiDBSchemaForFTSOnlyProfile       = schema.ValidateTiDBSchemaForFTSOnlyProfile
-	// Version-matched tenant opens trust the durable tenant schema_version by
-	// default. Set this non-zero in targeted tests or emergency builds to sample
-	// out-of-band schema drift without putting a full schema diff on every cold
-	// tenant open.
-	periodicTiDBSchemaValidationEvery uint64 = 0
-	defaultTenantPoolDrainTimeout            = 30 * time.Second
-	defaultTenantPoolMaxTenants              = 1024
-	defaultTenantPoolIdleReapInterval        = 5 * time.Minute
+	applyTiDBAutoEmbeddingProviderConfig    = schema.ApplyTiDBAutoEmbeddingProviderConfig
+	ensureTiDBSchemaForAutoEmbeddingProfile = schema.EnsureTiDBSchemaForAutoEmbeddingProfile
+	ensureTiDBSchemaForFTSOnlyProfile       = schema.EnsureTiDBSchemaForFTSOnlyProfile
+	defaultTenantPoolDrainTimeout           = 30 * time.Second
+	defaultTenantPoolMaxTenants             = 1024
+	defaultTenantPoolIdleReapInterval       = 5 * time.Minute
 )
 
 func tenantSchemaVersionForEmbeddingMode(mode string, profile schema.TiDBAutoEmbeddingProfile) (int, error) {
@@ -193,21 +185,6 @@ func ensureTiDBSchemaForEmbeddingMode(ctx context.Context, db *sql.DB, mode stri
 		return ensureTiDBSchemaForFTSOnlyProfile(ctx, db, profile)
 	default:
 		return schema.EnsureTiDBSchemaForEmbeddingModeProfile(ctx, db, tidbMode, profile)
-	}
-}
-
-func validateTiDBSchemaForEmbeddingMode(ctx context.Context, db *sql.DB, mode string, profile schema.TiDBAutoEmbeddingProfile) error {
-	tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
-	if err != nil {
-		return err
-	}
-	switch tidbMode {
-	case schema.TiDBEmbeddingModeAuto:
-		return validateTiDBSchemaForAutoEmbeddingProfile(ctx, db, profile)
-	case schema.TiDBEmbeddingModeFTSOnly:
-		return validateTiDBSchemaForFTSOnlyProfile(ctx, db, profile)
-	default:
-		return schema.ValidateTiDBSchemaForEmbeddingModeProfile(ctx, db, tidbMode, profile)
 	}
 }
 
@@ -238,11 +215,11 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 		reapInterval = defaultTenantPoolIdleReapInterval
 	}
 	return &Pool{
-		cfg:          cfg,
-		enc:          enc,
-		items:        map[string]*entry{},
-		order:        list.New(),
-		maxSize:      max,
+		cfg:     cfg,
+		enc:     enc,
+		items:   map[string]*entry{},
+		order:   list.New(),
+		maxSize: max,
 		// No LeaderChecker means single-pod mode: FileGC runs unconditionally.
 		fileGCEnabled: cfg.LeaderChecker == nil,
 		idleTimeout:   idleTimeout,
@@ -896,13 +873,6 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 						recordTenantSchemaVersionUpdateFailure(ctx, t.ID, targetSchemaVersion, time.Since(updateSchemaVersionStart), verErr)
 					}
 				}
-			} else if p.shouldPeriodicValidateTiDBSchemaOnOpen() {
-				validateSchemaStart := time.Now()
-				if err := validateTiDBSchemaForEmbeddingMode(ctx, store.DB(), autoEmbeddingProfile.mode, autoEmbeddingProfile.schemaProfile); err != nil {
-					_ = store.Close()
-					return nil, nil, fmt.Errorf("validate tidb embedding schema: %w", err)
-				}
-				ensureSchemaDurationMs += float64(time.Since(validateSchemaStart).Microseconds()) / 1000.0
 			}
 			if autoEmbeddingProfile.modeWasNull && p.metaStore != nil {
 				if _, modeErr := p.metaStore.SetTenantAutoEmbeddingProfileModeIfNull(ctx, t.ID, autoEmbeddingProfile.mode); modeErr != nil {
@@ -1103,18 +1073,6 @@ func defaultTenantAutoEmbeddingProfile() (tenantAutoEmbeddingProfile, error) {
 			Model: schemaProfile.Model,
 		},
 	}, nil
-}
-
-func (p *Pool) shouldPeriodicValidateTiDBSchemaOnOpen() bool {
-	if p == nil {
-		return false
-	}
-	every := periodicTiDBSchemaValidationEvery
-	if every == 0 {
-		return false
-	}
-	count := p.tidbSchemaValidationOpens.Add(1)
-	return count == 1 || count%every == 0
 }
 
 func recordTenantSchemaVersionUpdateFailure(ctx context.Context, tenantID string, version int, d time.Duration, err error) {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -418,6 +418,53 @@ func TestPoolCreateBackendPeriodicallyValidatesSchemaWhenVersionMatches(t *testi
 	}
 }
 
+func TestPoolCreateBackendSkipsSchemaValidationWhenVersionMatchesByDefault(t *testing.T) {
+	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-skip-validate")
+	tenant.Provider = ProviderTiDBZero
+	tenant.SchemaVersion = schema.CurrentTiDBTenantSchemaVersion
+
+	origEnsure := ensureTiDBSchemaForAutoEmbeddingProfile
+	origValidate := validateTiDBSchemaForAutoEmbeddingProfile
+	origApply := applyTiDBAutoEmbeddingProviderConfig
+	origEvery := periodicTiDBSchemaValidationEvery
+	ensureCalls := 0
+	validateCalls := 0
+	ensureTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
+		ensureCalls++
+		return nil
+	}
+	validateTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
+		validateCalls++
+		return nil
+	}
+	applyTiDBAutoEmbeddingProviderConfig = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProviderConfig) error {
+		return nil
+	}
+	periodicTiDBSchemaValidationEvery = 0
+	t.Cleanup(func() {
+		ensureTiDBSchemaForAutoEmbeddingProfile = origEnsure
+		validateTiDBSchemaForAutoEmbeddingProfile = origValidate
+		applyTiDBAutoEmbeddingProviderConfig = origApply
+		periodicTiDBSchemaValidationEvery = origEvery
+	})
+
+	backend, store, err := pool.createBackend(context.Background(), tenant)
+	if err != nil {
+		t.Fatalf("createBackend(): %v", err)
+	}
+	backend.Close()
+	if err := store.Close(); err != nil {
+		t.Fatalf("close store: %v", err)
+	}
+
+	if ensureCalls != 0 {
+		t.Fatalf("ensureTiDBSchemaForAutoEmbeddingProfile called %d times, want 0", ensureCalls)
+	}
+	if validateCalls != 0 {
+		t.Fatalf("validateTiDBSchemaForAutoEmbeddingProfile called %d times, want 0", validateCalls)
+	}
+}
+
 func TestPoolCreateBackendEnsuresSchemaForTiDBCloudNative(t *testing.T) {
 	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-native-ensure")
 	tenant.Provider = ProviderTiDBCloudNative

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -369,83 +369,24 @@ func TestPoolAutoSemanticTaskTypes(t *testing.T) {
 	}
 }
 
-func TestPoolCreateBackendPeriodicallyValidatesSchemaWhenVersionMatches(t *testing.T) {
-	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-validate")
-	tenant.Provider = ProviderTiDBZero
-	tenant.SchemaVersion = schema.CurrentTiDBTenantSchemaVersion
-
-	origEnsure := ensureTiDBSchemaForAutoEmbeddingProfile
-	origValidate := validateTiDBSchemaForAutoEmbeddingProfile
-	origApply := applyTiDBAutoEmbeddingProviderConfig
-	origEvery := periodicTiDBSchemaValidationEvery
-	ensureCalls := 0
-	validateCalls := 0
-	ensureTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
-		ensureCalls++
-		return nil
-	}
-	validateTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
-		validateCalls++
-		return nil
-	}
-	applyTiDBAutoEmbeddingProviderConfig = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProviderConfig) error {
-		return nil
-	}
-	periodicTiDBSchemaValidationEvery = 4
-	t.Cleanup(func() {
-		ensureTiDBSchemaForAutoEmbeddingProfile = origEnsure
-		validateTiDBSchemaForAutoEmbeddingProfile = origValidate
-		applyTiDBAutoEmbeddingProviderConfig = origApply
-		periodicTiDBSchemaValidationEvery = origEvery
-	})
-
-	for i := 0; i < 4; i++ {
-		backend, store, err := pool.createBackend(context.Background(), tenant)
-		if err != nil {
-			t.Fatalf("createBackend() iteration %d: %v", i, err)
-		}
-		backend.Close()
-		if err := store.Close(); err != nil {
-			t.Fatalf("close store iteration %d: %v", i, err)
-		}
-	}
-
-	if ensureCalls != 0 {
-		t.Fatalf("ensureTiDBSchemaForAutoEmbeddingProfile called %d times, want 0", ensureCalls)
-	}
-	if validateCalls != 2 {
-		t.Fatalf("validateTiDBSchemaForAutoEmbeddingProfile called %d times, want 2", validateCalls)
-	}
-}
-
-func TestPoolCreateBackendSkipsSchemaValidationWhenVersionMatchesByDefault(t *testing.T) {
+func TestPoolCreateBackendSkipsSchemaEnsureWhenVersionMatches(t *testing.T) {
 	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-skip-validate")
 	tenant.Provider = ProviderTiDBZero
 	tenant.SchemaVersion = schema.CurrentTiDBTenantSchemaVersion
 
 	origEnsure := ensureTiDBSchemaForAutoEmbeddingProfile
-	origValidate := validateTiDBSchemaForAutoEmbeddingProfile
 	origApply := applyTiDBAutoEmbeddingProviderConfig
-	origEvery := periodicTiDBSchemaValidationEvery
 	ensureCalls := 0
-	validateCalls := 0
 	ensureTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
 		ensureCalls++
-		return nil
-	}
-	validateTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
-		validateCalls++
 		return nil
 	}
 	applyTiDBAutoEmbeddingProviderConfig = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProviderConfig) error {
 		return nil
 	}
-	periodicTiDBSchemaValidationEvery = 0
 	t.Cleanup(func() {
 		ensureTiDBSchemaForAutoEmbeddingProfile = origEnsure
-		validateTiDBSchemaForAutoEmbeddingProfile = origValidate
 		applyTiDBAutoEmbeddingProviderConfig = origApply
-		periodicTiDBSchemaValidationEvery = origEvery
 	})
 
 	backend, store, err := pool.createBackend(context.Background(), tenant)
@@ -460,9 +401,6 @@ func TestPoolCreateBackendSkipsSchemaValidationWhenVersionMatchesByDefault(t *te
 	if ensureCalls != 0 {
 		t.Fatalf("ensureTiDBSchemaForAutoEmbeddingProfile called %d times, want 0", ensureCalls)
 	}
-	if validateCalls != 0 {
-		t.Fatalf("validateTiDBSchemaForAutoEmbeddingProfile called %d times, want 0", validateCalls)
-	}
 }
 
 func TestPoolCreateBackendEnsuresSchemaForTiDBCloudNative(t *testing.T) {
@@ -471,14 +409,10 @@ func TestPoolCreateBackendEnsuresSchemaForTiDBCloudNative(t *testing.T) {
 	tenant.SchemaVersion = 0
 
 	origEnsure := ensureTiDBSchemaForAutoEmbeddingProfile
-	origValidate := validateTiDBSchemaForAutoEmbeddingProfile
 	origApply := applyTiDBAutoEmbeddingProviderConfig
 	ensureCalls := 0
 	ensureTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
 		ensureCalls++
-		return nil
-	}
-	validateTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
 		return nil
 	}
 	applyTiDBAutoEmbeddingProviderConfig = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProviderConfig) error {
@@ -486,7 +420,6 @@ func TestPoolCreateBackendEnsuresSchemaForTiDBCloudNative(t *testing.T) {
 	}
 	t.Cleanup(func() {
 		ensureTiDBSchemaForAutoEmbeddingProfile = origEnsure
-		validateTiDBSchemaForAutoEmbeddingProfile = origValidate
 		applyTiDBAutoEmbeddingProviderConfig = origApply
 	})
 
@@ -512,9 +445,7 @@ func TestPoolCreateBackendRepairsFTSOnlySchemaWhenDatabaseAutoEmbeddingDisabled(
 	tenant.SchemaVersion = 0
 
 	origEnsure := ensureTiDBSchemaForAutoEmbeddingProfile
-	origValidate := validateTiDBSchemaForAutoEmbeddingProfile
 	origEnsureFTS := ensureTiDBSchemaForFTSOnlyProfile
-	origValidateFTS := validateTiDBSchemaForFTSOnlyProfile
 	origApply := applyTiDBAutoEmbeddingProviderConfig
 	autoEnsureCalls := 0
 	ftsEnsureCalls := 0
@@ -527,21 +458,13 @@ func TestPoolCreateBackendRepairsFTSOnlySchemaWhenDatabaseAutoEmbeddingDisabled(
 		ftsEnsureCalls++
 		return nil
 	}
-	validateTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
-		return nil
-	}
-	validateTiDBSchemaForFTSOnlyProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
-		return nil
-	}
 	applyTiDBAutoEmbeddingProviderConfig = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProviderConfig) error {
 		applyCalls++
 		return nil
 	}
 	t.Cleanup(func() {
 		ensureTiDBSchemaForAutoEmbeddingProfile = origEnsure
-		validateTiDBSchemaForAutoEmbeddingProfile = origValidate
 		ensureTiDBSchemaForFTSOnlyProfile = origEnsureFTS
-		validateTiDBSchemaForFTSOnlyProfile = origValidateFTS
 		applyTiDBAutoEmbeddingProviderConfig = origApply
 	})
 
@@ -564,39 +487,6 @@ func TestPoolCreateBackendRepairsFTSOnlySchemaWhenDatabaseAutoEmbeddingDisabled(
 	}
 	if applyCalls != 0 {
 		t.Fatalf("applyTiDBAutoEmbeddingProviderConfig called %d times, want 0", applyCalls)
-	}
-}
-
-func TestPoolCreateBackendReturnsValidationErrorWhenPeriodicCheckFails(t *testing.T) {
-	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-validate-fail")
-	tenant.Provider = ProviderTiDBZero
-	tenant.SchemaVersion = schema.CurrentTiDBTenantSchemaVersion
-
-	origEnsure := ensureTiDBSchemaForAutoEmbeddingProfile
-	origValidate := validateTiDBSchemaForAutoEmbeddingProfile
-	origApply := applyTiDBAutoEmbeddingProviderConfig
-	origEvery := periodicTiDBSchemaValidationEvery
-	ensureTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
-		return nil
-	}
-	validateTiDBSchemaForAutoEmbeddingProfile = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProfile) error {
-		return fmt.Errorf("schema drift")
-	}
-	applyTiDBAutoEmbeddingProviderConfig = func(context.Context, *sql.DB, schema.TiDBAutoEmbeddingProviderConfig) error {
-		return nil
-	}
-	periodicTiDBSchemaValidationEvery = 1
-	t.Cleanup(func() {
-		ensureTiDBSchemaForAutoEmbeddingProfile = origEnsure
-		validateTiDBSchemaForAutoEmbeddingProfile = origValidate
-		applyTiDBAutoEmbeddingProviderConfig = origApply
-		periodicTiDBSchemaValidationEvery = origEvery
-	})
-
-	if _, _, err := pool.createBackend(context.Background(), tenant); err == nil {
-		t.Fatal("expected periodic validation failure to propagate")
-	} else if !strings.Contains(err.Error(), "validate tidb embedding schema") {
-		t.Fatalf("unexpected error: %v", err)
 	}
 }
 
@@ -819,8 +709,8 @@ func TestIdleEvictionRespectsRefs(t *testing.T) {
 
 func TestIdleEvictionDisabled(t *testing.T) {
 	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
-		MaxTenants:    2,
-		IdleTimeout:   0, // disabled
+		MaxTenants:  2,
+		IdleTimeout: 0, // disabled
 	}, "tenant-disabled")
 	ctx := context.Background()
 

--- a/pkg/tenant/schema/context.go
+++ b/pkg/tenant/schema/context.go
@@ -1,0 +1,19 @@
+package schema
+
+import "context"
+
+type tenantIDContextKey struct{}
+
+// WithTenantID annotates schema-init contexts so user_schema DB pool metrics can
+// retain tenant attribution without changing public schema-init function shapes.
+func WithTenantID(ctx context.Context, tenantID string) context.Context {
+	if tenantID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, tenantIDContextKey{}, tenantID)
+}
+
+func tenantIDFromContext(ctx context.Context) string {
+	tenantID, _ := ctx.Value(tenantIDContextKey{}).(string)
+	return tenantID
+}

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -1377,7 +1377,7 @@ func OpenTiDBSchemaDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	if HasMultiStatements(dsn) {
 		return nil, fmt.Errorf("multiStatements is not allowed")
 	}
-	db, err := mysqlutil.OpenInstrumented(ctx, dsn, mysqlutil.RoleUserSchema)
+	db, err := mysqlutil.OpenInstrumentedForTenant(ctx, dsn, mysqlutil.RoleUserSchema, tenantIDFromContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	mysql "github.com/go-sql-driver/mysql"
@@ -28,6 +29,8 @@ const (
 	TiDBEmbeddingModeApp     TiDBEmbeddingMode = "app-managed"
 	TiDBEmbeddingModeFTSOnly TiDBEmbeddingMode = "fts-only"
 )
+
+const maxConcurrentTiDBSchemaDiffTables = 4
 
 // Reference of Auto Embedding in TiDB Cloud: https://docs.pingcap.com/ai/vector-search-auto-embedding-amazon-titan/
 const (
@@ -1583,14 +1586,11 @@ func diffTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiDBE
 	if err != nil {
 		return nil, err
 	}
-	var diffs []tidbSchemaDiff
-	for _, table := range spec.tables {
-		tableDiffs, err := diffTiDBTable(ctx, db, table)
-		if err != nil {
-			return nil, err
-		}
-		diffs = append(diffs, tableDiffs...)
+	tableDiffs, tableParallelism, err := diffTiDBTables(ctx, db, spec.tables)
+	if err != nil {
+		return nil, err
 	}
+	diffs := append([]tidbSchemaDiff(nil), tableDiffs...)
 	legacyFilesDiffs, err := diffLegacyTiDBFilesTableIfExistsWithConfig(ctx, db, mode, cfg)
 	if err != nil {
 		return nil, err
@@ -1599,9 +1599,73 @@ func diffTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiDBE
 	logger.Info(ctx, "tenant_tidb_schema_diff_finished",
 		zap.String("mode", string(mode)),
 		zap.Int("table_count", len(spec.tables)),
+		zap.Int("table_parallelism", tableParallelism),
 		zap.Int("diff_count", len(diffs)),
 		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
 	return diffs, nil
+}
+
+func diffTiDBTables(ctx context.Context, db *sql.DB, tables []tidbTableSpec) ([]tidbSchemaDiff, int, error) {
+	if len(tables) == 0 {
+		return nil, 0, nil
+	}
+	workerCount := maxConcurrentTiDBSchemaDiffTables
+	if len(tables) < workerCount {
+		workerCount = len(tables)
+	}
+
+	diffCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	jobs := make(chan int)
+	errCh := make(chan error, 1)
+	results := make([][]tidbSchemaDiff, len(tables))
+
+	var wg sync.WaitGroup
+	for i := 0; i < workerCount; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for tableIndex := range jobs {
+				tableDiffs, err := diffTiDBTable(diffCtx, db, tables[tableIndex])
+				if err != nil {
+					select {
+					case errCh <- err:
+						cancel()
+					default:
+					}
+					return
+				}
+				results[tableIndex] = tableDiffs
+			}
+		}()
+	}
+
+sendJobs:
+	for tableIndex := range tables {
+		select {
+		case <-diffCtx.Done():
+			break sendJobs
+		case jobs <- tableIndex:
+		}
+	}
+	close(jobs)
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		return nil, workerCount, err
+	default:
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, workerCount, err
+	}
+
+	var diffs []tidbSchemaDiff
+	for _, tableDiffs := range results {
+		diffs = append(diffs, tableDiffs...)
+	}
+	return diffs, workerCount, nil
 }
 
 func diffLegacyTiDBFilesTableIfExists(ctx context.Context, db *sql.DB, mode TiDBEmbeddingMode) ([]tidbSchemaDiff, error) {

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -852,6 +852,94 @@ func TestDiffTiDBTableUsesInformationSchemaIndexesForUploads(t *testing.T) {
 	}
 }
 
+func TestDiffTiDBTablesRunsIndependentTablesConcurrently(t *testing.T) {
+	tables := []tidbTableSpec{
+		{
+			name:            "diff_parallel_t1",
+			createStatement: "CREATE TABLE diff_parallel_t1 (id VARCHAR(64))",
+			columns: map[string]tidbColumnSpec{
+				"id": {columnType: "varchar(64)"},
+			},
+		},
+		{
+			name:            "diff_parallel_t2",
+			createStatement: "CREATE TABLE diff_parallel_t2 (id VARCHAR(64))",
+			columns: map[string]tidbColumnSpec{
+				"id": {columnType: "varchar(64)"},
+			},
+		},
+	}
+
+	started := make(chan string, len(tables))
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	defer releaseOnce.Do(func() { close(release) })
+
+	db := newTestRepairDBWithArgs(t, func(query string, args []driver.NamedValue) testRepairQueryResult {
+		normalized := normalizeSQLFragment(query)
+		switch {
+		case strings.Contains(normalized, "from information_schema.columns"):
+			tableName := fmt.Sprint(args[0].Value)
+			select {
+			case started <- tableName:
+			default:
+			}
+			<-release
+			return testRepairQueryResult{
+				columns: []string{"column_name", "column_type", "extra", "generation_expression"},
+				rows: [][]driver.Value{
+					{"id", "varchar(64)", "", ""},
+				},
+			}
+		case strings.HasPrefix(normalized, "show create table"):
+			tableName := strings.TrimSpace(strings.TrimPrefix(query, "SHOW CREATE TABLE "))
+			return testRepairQueryResult{
+				columns: []string{"Table", "Create Table"},
+				rows: [][]driver.Value{
+					{tableName, fmt.Sprintf("CREATE TABLE %s (id VARCHAR(64))", tableName)},
+				},
+			}
+		case strings.Contains(normalized, "from information_schema.statistics"):
+			return testRepairQueryResult{columns: []string{"index_name"}}
+		default:
+			return testRepairQueryResult{err: fmt.Errorf("unexpected query: %s", query)}
+		}
+	}, nil)
+	db.SetMaxOpenConns(2)
+
+	errCh := make(chan error, 1)
+	go func() {
+		diffs, parallelism, err := diffTiDBTables(context.Background(), db, tables)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if parallelism != 2 {
+			errCh <- fmt.Errorf("parallelism = %d, want 2", parallelism)
+			return
+		}
+		if len(diffs) != 0 {
+			errCh <- fmt.Errorf("diff count = %d, want 0: %#v", len(diffs), diffs)
+			return
+		}
+		errCh <- nil
+	}()
+
+	got := map[string]bool{}
+	for len(got) < len(tables) {
+		select {
+		case tableName := <-started:
+			got[tableName] = true
+		case <-time.After(2 * time.Second):
+			t.Fatalf("timed out waiting for concurrent table metadata queries; got %v", got)
+		}
+	}
+	releaseOnce.Do(func() { close(release) })
+	if err := <-errCh; err != nil {
+		t.Fatalf("diffTiDBTables: %v", err)
+	}
+}
+
 func TestRepairMySQLPathHashSchemaUpgradesLegacyPathIndexes(t *testing.T) {
 	if testDSN == "" {
 		t.Skip("mysql test DSN not configured")


### PR DESCRIPTION
## Summary
- keep tenant-scoped service operation counters while omitting tenant_id from high-fanout internal service duration histograms
- trust durable tenant schema_version by default for version-matched cold opens instead of periodic schema validation diffs
- parallelize TiDB schema table diff checks with bounded table-level concurrency

## Tests
- make test TEST_PKGS='./pkg/metrics'
- make test TEST_PKGS='./pkg/tenant/schema ./pkg/tenant'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved TiDB schema diffing by processing independent tables concurrently to reduce overall validation time.
- **Bug Fixes**
  - Refined operation metrics labeling so tenant identifiers are included only in the appropriate duration metrics.
  - Avoided redundant TiDB auto-embedding schema work when the tenant schema version already matches the target.
- **Configuration**
  - Disabled periodic TiDB auto-embedding schema validation in favor of version-driven checks.
  - Updated the documented default for `DRIVE9_USER_DB_MAX_IDLE_CONNS` to `0`, and adjusted the default accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->