### PR TITLE
feat(pool): add idle eviction to tenant pool

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -318,12 +318,15 @@ func main() {
 			S3EncryptionPolicy:           s3cfg.EncryptionPolicy,
 			BackendOptions:               backendOptions,
 			MaxTenants:                   envInt("DRIVE9_POOL_MAX_TENANTS", 0),
+			IdleTimeout:                  envDuration("DRIVE9_POOL_IDLE_TTL", 10*time.Minute),
+			IdleReapInterval:             envDuration("DRIVE9_POOL_IDLE_REAP_INTERVAL", 0),
 			DisableDatabaseAutoEmbedding: disableDatabaseAutoEmbedding,
 			LeaderChecker:                leaderManager,
 		}, enc)
 		defer pool.Close()
 
 		pool.SetMetaStore(store)
+		pool.Start(context.Background())
 
 		// The mutation replay and expiry sweep workers are owned by the server
 		// (started/stopped in its leader-gated startLeaderWorkers/stopLeaderWorkers),
@@ -526,6 +529,8 @@ environment:
   DRIVE9_PUBLIC_URL  externally reachable base URL for presigned URLs (required for remote clients)
   DRIVE9_META_DSN    control-plane MySQL DSN (required)
   DRIVE9_POOL_MAX_TENANTS max cached tenant user DB pools per pod (default: 1024)
+  DRIVE9_POOL_IDLE_TTL  idle duration before a cached tenant backend is evicted (default: 10m, 0=disabled)
+  DRIVE9_POOL_IDLE_REAP_INTERVAL  how often the idle reaper scans (default: 5m)
   DRIVE9_META_DB_MAX_OPEN_CONNS max open connections for the per-pod meta DB pool (default: 100)
   DRIVE9_META_DB_MAX_IDLE_CONNS max idle connections for the per-pod meta DB pool (default: 20)
   DRIVE9_USER_DB_MAX_OPEN_CONNS max open connections for each cached tenant user DB pool (default: 6)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -64,6 +64,18 @@ type PoolConfig struct {
 	// resolves to the post-transition state instead of a moment-in-time
 	// IsLeader() snapshot.
 	LeaderChecker LeaderChecker
+
+	// IdleTimeout controls how long a cached backend with no user traffic
+	// (Get/Acquire) can stay in the warm cache before the idle reaper evicts
+	// it. 0 disables idle eviction (LRU capacity eviction still applies).
+	// AcquireCached (safety-net scan etc.) does NOT refresh the idle timer —
+	// only real user traffic does, so periodic internal scans cannot keep a
+	// tenant warm forever.
+	IdleTimeout time.Duration
+
+	// IdleReapInterval is how often the idle reaper scans for idle backends.
+	// Defaults to defaultTenantPoolIdleReapInterval when IdleTimeout > 0.
+	IdleReapInterval time.Duration
 }
 
 // LeaderChecker reports whether the current process is the leader. Used by
@@ -123,6 +135,10 @@ type Pool struct {
 	// FileGC is now kick-driven through the unified tenant worker, not a
 	// per-backend goroutine.
 	fileGCEnabled bool
+	idleTimeout   time.Duration
+	reapInterval  time.Duration
+	reapStop      context.CancelFunc
+	reapWG        sync.WaitGroup
 }
 
 type tenantAutoEmbeddingProfile struct {
@@ -144,6 +160,7 @@ var (
 	periodicTiDBSchemaValidationEvery uint64 = 32
 	defaultTenantPoolDrainTimeout            = 30 * time.Second
 	defaultTenantPoolMaxTenants              = 1024
+	defaultTenantPoolIdleReapInterval        = 5 * time.Minute
 )
 
 func tenantSchemaVersionForEmbeddingMode(mode string, profile schema.TiDBAutoEmbeddingProfile) (int, error) {
@@ -197,6 +214,7 @@ type entry struct {
 	elem               *list.Element
 	refs               int
 	retired            bool
+	lastUsed           time.Time // updated only on Get/Acquire (user traffic), not AcquireCached
 }
 
 func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
@@ -204,14 +222,21 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 	if max <= 0 {
 		max = defaultTenantPoolMaxTenants
 	}
+	idleTimeout := cfg.IdleTimeout
+	reapInterval := cfg.IdleReapInterval
+	if reapInterval <= 0 && idleTimeout > 0 {
+		reapInterval = defaultTenantPoolIdleReapInterval
+	}
 	return &Pool{
-		cfg:     cfg,
-		enc:     enc,
-		items:   map[string]*entry{},
-		order:   list.New(),
-		maxSize: max,
+		cfg:          cfg,
+		enc:          enc,
+		items:        map[string]*entry{},
+		order:        list.New(),
+		maxSize:      max,
 		// No LeaderChecker means single-pod mode: FileGC runs unconditionally.
 		fileGCEnabled: cfg.LeaderChecker == nil,
+		idleTimeout:   idleTimeout,
+		reapInterval:  reapInterval,
 	}
 }
 
@@ -264,6 +289,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 	if e, ok := p.items[t.ID]; ok {
 		if e.s3EncryptionPolicy == s3EncryptionPolicy && (storageNamespaceID == "" || e.storageNamespaceID == storageNamespaceID) {
 			p.order.MoveToFront(e.elem)
+			e.lastUsed = time.Now()
 			b := e.backend
 			p.mu.Unlock()
 			return b, nil
@@ -291,6 +317,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 			b.Close()
 			_ = st.Close()
 			p.order.MoveToFront(e.elem)
+			e.lastUsed = time.Now()
 			p.mu.Unlock()
 			return e.backend, nil
 		}
@@ -298,7 +325,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 			toClose = append(toClose, removed)
 		}
 	}
-	e := &entry{tenantID: t.ID, storageNamespaceID: t.StorageNamespaceID, s3EncryptionPolicy: s3EncryptionPolicy, backend: b, store: st}
+	e := &entry{tenantID: t.ID, storageNamespaceID: t.StorageNamespaceID, s3EncryptionPolicy: s3EncryptionPolicy, backend: b, store: st, lastUsed: time.Now()}
 	e.elem = p.order.PushFront(e)
 	p.items[t.ID] = e
 	for p.order.Len() > p.maxSize {
@@ -341,6 +368,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 		if e.s3EncryptionPolicy == s3EncryptionPolicy && (storageNamespaceID == "" || e.storageNamespaceID == storageNamespaceID) {
 			e.refs++
 			p.order.MoveToFront(e.elem)
+			e.lastUsed = time.Now()
 			p.mu.Unlock()
 			metrics.RecordOperation("tenant_pool", "cache_lookup", "hit", 0)
 			logger.InfoBenchTiming(ctx, "tenant_pool_acquire_timing",
@@ -381,6 +409,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 		if e.s3EncryptionPolicy == s3EncryptionPolicy && (t.StorageNamespaceID == "" || e.storageNamespaceID == t.StorageNamespaceID) {
 			e.refs++
 			p.order.MoveToFront(e.elem)
+			e.lastUsed = time.Now()
 			p.mu.Unlock()
 			b.Close()
 			_ = st.Close()
@@ -396,7 +425,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 			toClose = append(toClose, removed)
 		}
 	}
-	e := &entry{tenantID: t.ID, storageNamespaceID: t.StorageNamespaceID, s3EncryptionPolicy: s3EncryptionPolicy, backend: b, store: st, refs: 1}
+	e := &entry{tenantID: t.ID, storageNamespaceID: t.StorageNamespaceID, s3EncryptionPolicy: s3EncryptionPolicy, backend: b, store: st, refs: 1, lastUsed: time.Now()}
 	e.elem = p.order.PushFront(e)
 	p.items[t.ID] = e
 	for p.order.Len() > p.maxSize {
@@ -632,7 +661,67 @@ func withTenantPoolDrainTimeout(ctx context.Context) (context.Context, context.C
 	return context.WithTimeout(ctx, defaultTenantPoolDrainTimeout)
 }
 
+// Start launches the idle reaper goroutine if IdleTimeout is configured.
+// Safe to call on a pool with IdleTimeout=0 (no-op). The reaper is stopped
+// by Close.
+func (p *Pool) Start(ctx context.Context) {
+	if p == nil || p.idleTimeout <= 0 {
+		return
+	}
+	workerCtx, cancel := context.WithCancel(ctx)
+	p.reapStop = cancel
+	p.reapWG.Add(1)
+	go func() {
+		defer p.reapWG.Done()
+		p.reapLoop(workerCtx)
+	}()
+}
+
+func (p *Pool) reapLoop(ctx context.Context) {
+	ticker := time.NewTicker(p.reapInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			p.reapOnce(ctx)
+		}
+	}
+}
+
+func (p *Pool) reapOnce(ctx context.Context) {
+	if p.idleTimeout <= 0 {
+		return
+	}
+	now := time.Now()
+	var toClose []*entry
+	p.mu.Lock()
+	for _, e := range p.items {
+		if e.retired || e.refs > 0 {
+			continue
+		}
+		if now.Sub(e.lastUsed) > p.idleTimeout {
+			if removed := p.removeLocked(e.elem, "idle"); removed != nil {
+				toClose = append(toClose, removed)
+			}
+		}
+	}
+	cachedCount := len(p.items)
+	p.mu.Unlock()
+	for _, retired := range toClose {
+		closeEntry(retired)
+	}
+	metrics.RecordGauge("tenant_pool", "cached_backends", float64(cachedCount))
+}
+
 func (p *Pool) Close() {
+	// Stop the idle reaper first so it doesn't race with shutdown eviction.
+	if p.reapStop != nil {
+		p.reapStop()
+		p.reapWG.Wait()
+		p.reapStop = nil
+	}
 	toClose := make([]*entry, 0, p.order.Len())
 	p.mu.Lock()
 	for p.order.Len() > 0 {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -541,7 +541,7 @@ func (p *Pool) AcquireCached(t *meta.Tenant) (b *backend.Dat9Backend, release fu
 	p.mu.Unlock()
 	metrics.RecordOperation("tenant_pool", "cache_lookup", "hit", 0)
 	metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cached", "hit", 0)
-	return e.backend, p.makeRelease(e), true
+	return e.backend, p.makeReleaseNoRefresh(e), true
 }
 
 func (p *Pool) InvalidateAndWait(ctx context.Context, tenantID string) error {
@@ -678,6 +678,9 @@ func (p *Pool) Start(ctx context.Context) {
 }
 
 func (p *Pool) reapLoop(ctx context.Context) {
+	if p.reapInterval <= 0 {
+		return
+	}
 	ticker := time.NewTicker(p.reapInterval)
 	defer ticker.Stop()
 	for {
@@ -739,6 +742,7 @@ func (p *Pool) S3Backend(tenantID string) *backend.Dat9Backend {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if e, ok := p.items[tenantID]; ok {
+		e.lastUsed = time.Now()
 		return e.backend
 	}
 	return nil
@@ -1175,12 +1179,24 @@ func (p *Pool) makeRelease(e *entry) func() {
 	var once sync.Once
 	return func() {
 		once.Do(func() {
-			p.releaseEntry(e)
+			p.releaseEntry(e, true)
 		})
 	}
 }
 
-func (p *Pool) releaseEntry(e *entry) {
+// makeReleaseNoRefresh is like makeRelease but does not refresh lastUsed on
+// release. Used by AcquireCached so internal scans (safety-net) do not reset
+// the idle timer.
+func (p *Pool) makeReleaseNoRefresh(e *entry) func() {
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			p.releaseEntry(e, false)
+		})
+	}
+}
+
+func (p *Pool) releaseEntry(e *entry, refreshLastUsed bool) {
 	if e == nil {
 		return
 	}
@@ -1188,6 +1204,9 @@ func (p *Pool) releaseEntry(e *entry) {
 	p.mu.Lock()
 	if e.refs > 0 {
 		e.refs--
+	}
+	if e.refs == 0 && !e.retired && refreshLastUsed {
+		e.lastUsed = time.Now()
 	}
 	if e.refs == 0 && e.retired {
 		toClose = e

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -65,12 +65,21 @@ type PoolConfig struct {
 	// IsLeader() snapshot.
 	LeaderChecker LeaderChecker
 
-	// IdleTimeout controls how long a cached backend with no user traffic
-	// (Get/Acquire) can stay in the warm cache before the idle reaper evicts
-	// it. 0 disables idle eviction (LRU capacity eviction still applies).
-	// AcquireCached (safety-net scan etc.) does NOT refresh the idle timer —
-	// only real user traffic does, so periodic internal scans cannot keep a
-	// tenant warm forever.
+	// IdleTimeout controls how long a cached backend can stay in the warm
+	// cache without any activity before the idle reaper evicts it. 0
+	// disables idle eviction (LRU capacity eviction still applies).
+	//
+	// "Activity" means any access through Get, Acquire, or S3Backend —
+	// including foreground user requests (HTTP/FUSE), tenant-specific
+	// durable work driven by kicks (semantic/file_gc task processing), and
+	// object-GC candidate processing. These are all legitimate uses that
+	// should keep a tenant warm.
+	//
+	// AcquireCached (safety-net scan) does NOT refresh the idle timer on
+	// acquire or release, so warm-only periodic observation cannot keep an
+	// idle tenant warm forever. Object-GC may cold-open a tenant for a due
+	// candidate and intentionally keeps it warm for one idle-TTL window
+	// per due attempt.
 	IdleTimeout time.Duration
 
 	// IdleReapInterval is how often the idle reaper scans for idle backends.
@@ -214,7 +223,7 @@ type entry struct {
 	elem               *list.Element
 	refs               int
 	retired            bool
-	lastUsed           time.Time // updated only on Get/Acquire (user traffic), not AcquireCached
+	lastUsed           time.Time // refreshed by Get/Acquire/S3Backend (foreground + durable work) and on Acquire release; never by AcquireCached
 }
 
 func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -758,8 +758,14 @@ func TestIdleEvictionRespectsRefs(t *testing.T) {
 		t.Fatal("expected pinned entry to remain in pool")
 	}
 
-	// Now release and reap — should evict.
+	// Release refreshes lastUsed (user release), so entry stays warm
+	// for another IdleTimeout window.
 	release()
+	pool.reapOnce(ctx)
+	assertStoreOpen(t, store)
+
+	// Now wait for idle timeout to lapse after release, then reap.
+	time.Sleep(60 * time.Millisecond)
 	pool.reapOnce(ctx)
 	assertStoreClosed(t, store)
 }
@@ -799,4 +805,116 @@ func TestIdleEvictionStartNoOpWhenDisabled(t *testing.T) {
 	if pool.reapStop != nil {
 		t.Fatal("expected reapStop to be nil when IdleTimeout=0")
 	}
+}
+
+// TestIdleEvictionReleaseRefreshesLastUsed verifies that a long-running user
+// request (held longer than IdleTimeout) is not immediately evicted on
+// release. The release path must refresh lastUsed so the idle timer starts
+// counting from "user finished", not "user started".
+func TestIdleEvictionReleaseRefreshesLastUsed(t *testing.T) {
+	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants:       2,
+		IdleTimeout:      50 * time.Millisecond,
+		IdleReapInterval: 10 * time.Millisecond,
+	}, "tenant-long")
+	ctx := context.Background()
+
+	b, release, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := b.Store()
+
+	// Hold the backend longer than IdleTimeout. The reaper must skip it
+	// because refs > 0.
+	time.Sleep(80 * time.Millisecond)
+	pool.reapOnce(ctx)
+	assertStoreOpen(t, store)
+
+	// Release now — lastUsed is refreshed. Immediate reap must NOT evict.
+	release()
+	pool.reapOnce(ctx)
+	assertStoreOpen(t, store)
+	if _, ok := pool.items[tenant.ID]; !ok {
+		t.Fatal("expected entry to remain after release refreshed lastUsed")
+	}
+
+	// Wait for idle timeout to lapse after release, then reap.
+	time.Sleep(60 * time.Millisecond)
+	pool.reapOnce(ctx)
+	assertStoreClosed(t, store)
+}
+
+// TestIdleEvictionAcquireCachedReleaseDoesNotRefresh verifies that
+// AcquireCached's release does not refresh lastUsed. A safety-net scan
+// touch must not reset the idle timer even on release.
+func TestIdleEvictionAcquireCachedReleaseDoesNotRefresh(t *testing.T) {
+	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants:       2,
+		IdleTimeout:      50 * time.Millisecond,
+		IdleReapInterval: 10 * time.Millisecond,
+	}, "tenant-cached-release")
+	ctx := context.Background()
+
+	b, release, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := b.Store()
+	release()
+
+	// Wait until lastUsed is stale.
+	time.Sleep(60 * time.Millisecond)
+
+	// AcquireCached + release should not refresh lastUsed.
+	_, release2, ok := pool.AcquireCached(tenant)
+	if !ok {
+		t.Fatal("expected AcquireCached to hit warm cache")
+	}
+	release2()
+
+	// Reap — should evict because neither AcquireCached nor its release
+	// refreshed lastUsed.
+	pool.reapOnce(ctx)
+	assertStoreClosed(t, store)
+	if _, ok := pool.items[tenant.ID]; ok {
+		t.Fatal("expected entry to be evicted — AcquireCached release must not refresh lastUsed")
+	}
+}
+
+// TestIdleEvictionStartAutoEvictsAndCloseStops verifies the end-to-end
+// lifecycle: Start launches the reaper, the ticker automatically evicts an
+// idle entry, and Close stops the reaper cleanly.
+func TestIdleEvictionStartAutoEvictsAndCloseStops(t *testing.T) {
+	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants:       2,
+		IdleTimeout:      50 * time.Millisecond,
+		IdleReapInterval: 10 * time.Millisecond,
+	}, "tenant-e2e")
+	ctx := context.Background()
+	pool.Start(ctx)
+	defer pool.Close()
+
+	b, release, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := b.Store()
+	release()
+
+	// Wait for the ticker-driven reaper to auto-evict (within ~2s).
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		pool.mu.Lock()
+		_, ok := pool.items[tenant.ID]
+		pool.mu.Unlock()
+		if !ok {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if _, ok := pool.items[tenant.ID]; ok {
+		t.Fatal("expected auto-eviction by ticker")
+	}
+	assertStoreClosed(t, store)
 }

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -638,3 +638,165 @@ type poolDummyAudioExtractor struct{}
 func (poolDummyAudioExtractor) ExtractAudioText(context.Context, backend.AudioExtractRequest) (string, backend.AudioExtractUsage, error) {
 	return "", backend.AudioExtractUsage{}, nil
 }
+
+func TestIdleEviction(t *testing.T) {
+	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants:       2,
+		IdleTimeout:      50 * time.Millisecond,
+		IdleReapInterval: 10 * time.Millisecond,
+	}, "tenant-idle")
+	ctx := context.Background()
+
+	b, release, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := b.Store()
+	assertStoreOpen(t, store)
+	release()
+
+	// Wait for idle timeout to lapse, then reap manually.
+	time.Sleep(60 * time.Millisecond)
+	pool.reapOnce(ctx)
+
+	assertStoreClosed(t, store)
+	if _, ok := pool.items[tenant.ID]; ok {
+		t.Fatal("expected entry to be evicted from pool")
+	}
+}
+
+func TestIdleEvictionSkippedByRecentAcquire(t *testing.T) {
+	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants:       2,
+		IdleTimeout:      50 * time.Millisecond,
+		IdleReapInterval: 10 * time.Millisecond,
+	}, "tenant-recent")
+	ctx := context.Background()
+
+	b, release, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := b.Store()
+	release()
+
+	// Re-acquire immediately — lastUsed is refreshed to now.
+	b2, release2, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b2 != b {
+		t.Fatal("expected same backend on cache hit")
+	}
+	release2()
+
+	// Reap immediately — lastUsed is recent, should not evict.
+	pool.reapOnce(ctx)
+	assertStoreOpen(t, store)
+	if _, ok := pool.items[tenant.ID]; !ok {
+		t.Fatal("expected entry to remain in pool after recent acquire")
+	}
+}
+
+func TestIdleEvictionNotRefreshedByAcquireCached(t *testing.T) {
+	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants:       2,
+		IdleTimeout:      50 * time.Millisecond,
+		IdleReapInterval: 10 * time.Millisecond,
+	}, "tenant-cached")
+	ctx := context.Background()
+
+	// Cold-open via Acquire so the backend enters the pool.
+	b, release, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := b.Store()
+	release()
+
+	// Wait long enough that lastUsed is stale, but use AcquireCached
+	// before reaping — AcquireCached must NOT refresh lastUsed.
+	time.Sleep(60 * time.Millisecond)
+	b2, release2, ok := pool.AcquireCached(tenant)
+	if !ok {
+		t.Fatal("expected AcquireCached to hit warm cache")
+	}
+	if b2 != b {
+		t.Fatal("expected same backend from AcquireCached")
+	}
+	release2()
+
+	// Reap — entry should be evicted because AcquireCached did not
+	// refresh lastUsed.
+	pool.reapOnce(ctx)
+	assertStoreClosed(t, store)
+	if _, ok := pool.items[tenant.ID]; ok {
+		t.Fatal("expected entry to be evicted despite AcquireCached touch")
+	}
+}
+
+func TestIdleEvictionRespectsRefs(t *testing.T) {
+	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants:       2,
+		IdleTimeout:      50 * time.Millisecond,
+		IdleReapInterval: 10 * time.Millisecond,
+	}, "tenant-pinned")
+	ctx := context.Background()
+
+	b, release, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := b.Store()
+
+	// Wait for idle timeout, but don't release — refs > 0 must prevent
+	// eviction.
+	time.Sleep(60 * time.Millisecond)
+	pool.reapOnce(ctx)
+	assertStoreOpen(t, store)
+	if _, ok := pool.items[tenant.ID]; !ok {
+		t.Fatal("expected pinned entry to remain in pool")
+	}
+
+	// Now release and reap — should evict.
+	release()
+	pool.reapOnce(ctx)
+	assertStoreClosed(t, store)
+}
+
+func TestIdleEvictionDisabled(t *testing.T) {
+	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
+		MaxTenants:    2,
+		IdleTimeout:   0, // disabled
+	}, "tenant-disabled")
+	ctx := context.Background()
+
+	b, release, err := pool.Acquire(ctx, tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	store := b.Store()
+	release()
+
+	// Wait well beyond any idle timeout, but since IdleTimeout=0 the
+	// reaper is disabled and reapOnce is a no-op (idleTimeout is 0 so
+	// now.Sub(lastUsed) > 0 is always true — but Start won't have been
+	// called). Call reapOnce directly to confirm it's a no-op.
+	time.Sleep(20 * time.Millisecond)
+	pool.reapOnce(ctx)
+	assertStoreOpen(t, store)
+	if _, ok := pool.items[tenant.ID]; !ok {
+		t.Fatal("expected entry to remain when idle eviction is disabled")
+	}
+}
+
+func TestIdleEvictionStartNoOpWhenDisabled(t *testing.T) {
+	pool := NewPool(PoolConfig{
+		MaxTenants:  2,
+		IdleTimeout: 0,
+	}, nil)
+	pool.Start(context.Background())
+	if pool.reapStop != nil {
+		t.Fatal("expected reapStop to be nil when IdleTimeout=0")
+	}
+}

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -904,16 +904,18 @@ func TestIdleEvictionStartAutoEvictsAndCloseStops(t *testing.T) {
 
 	// Wait for the ticker-driven reaper to auto-evict (within ~2s).
 	deadline := time.Now().Add(2 * time.Second)
+	evicted := false
 	for time.Now().Before(deadline) {
 		pool.mu.Lock()
 		_, ok := pool.items[tenant.ID]
 		pool.mu.Unlock()
 		if !ok {
+			evicted = true
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if _, ok := pool.items[tenant.ID]; ok {
+	if !evicted {
 		t.Fatal("expected auto-eviction by ticker")
 	}
 	assertStoreClosed(t, store)


### PR DESCRIPTION
## Summary

The tenant Pool is an LRU cache of per-tenant backends (`*backend.Dat9Backend` + `*datastore.Store` holding a `*sql.DB`). Until now, the only eviction path was **capacity-based** (`MaxTenants=1024`). A backend that entered the cache stayed warm forever — even with zero activity.

This causes a problem with the safety-net scan (`safetyNetScan`, PR #660). The scan runs every 5 minutes on every pod and uses `pool.AcquireCached` (warm-only) to recover expired leases and discover unclaimed queued tasks. Because warm tenants are never transitioned back to cold, `AcquireCached` keeps hitting them every 5 minutes, executing 4 SQL queries against each warm tenant's user DB. This creates a periodic connection pulse that prevents idle tenant TiDBs from reaching zero connections and scaling to zero.

PR #660 correctly established the invariant *"no periodic goroutine ever touches idle tenant TiDBs"* via the warm-only `AcquireCached`. But the missing piece was: **nothing ever moves a warm tenant back to cold.** This PR fills that gap.

## Approach

Add a background **idle reaper** to the Pool itself. On each tick (default every 5 minutes), it scans cached entries and evicts any with `refs == 0` and `lastUsed` older than `IdleTimeout` (default 10 minutes). Evicted backends are closed (backend workers stopped + `*sql.DB` closed), making the tenant cold. Subsequent `AcquireCached` calls return `cold_skipped`, leaving the tenant TiDB untouched until the next activity cold-opens it.

### Activity contract

`lastUsed` is refreshed by **any access through `Get`, `Acquire`, or `S3Backend`** — including:

- **Foreground user requests** (HTTP/FUSE/CLI via `auth.go`)
- **Tenant-specific durable work driven by kicks** (semantic/file_gc task processing via `tenant_worker.go`). Kicks are produced by writes — a user write enqueues a task and fires a kick, so the worker only touches tenants with recent write activity.
- **Object-GC candidate processing** (`object_gc_worker.go`). The worker is candidate-driven (not a full scan); it opens only the owner of a due GC candidate. A candidate is either deleted or postponed (24h for reachable refs, 1h for retries), so it does not continuously refresh `lastUsed`.

`lastUsed` is also refreshed on `Acquire` **release** (when `refs` drops to 0), so a long-running request is not immediately evictable after it finishes.

### What does NOT refresh `lastUsed`

**`AcquireCached` (safety-net scan)** does NOT refresh `lastUsed` on acquire or release. This is the critical distinction: warm-only periodic observation cannot keep an idle tenant warm forever. Once all foreground/durable activity stops, `lastUsed` goes stale and the idle reaper evicts the entry. Subsequent `AcquireCached` calls return `cold_skipped`, leaving the tenant TiDB untouched.

| Path | Used by | Refreshes `lastUsed`? |
|------|---------|----------------------|
| `Get` / `Acquire` | HTTP requests, kick-driven worker, object-GC | ✅ on acquire and release |
| `S3Backend` | local `/s3/` downloads | ✅ |
| `AcquireCached` | safety-net scan (periodic, warm-only) | ❌ never |

## Changes

### `pkg/tenant/pool.go`

- **`PoolConfig`**: new `IdleTimeout` and `IdleReapInterval` fields (`time.Duration`, 0 = disabled)
- **`entry` struct**: new `lastUsed time.Time` field, refreshed on `Get`/`Acquire`/`S3Backend` cache hits and on `Acquire` release; never by `AcquireCached`
- **`Pool` struct**: new `idleTimeout`, `reapInterval`, `reapStop`, `reapWG` fields for reaper lifecycle
- **`NewPool`**: reads `IdleTimeout`/`IdleReapInterval` from config; defaults `reapInterval` to 5min when `IdleTimeout > 0`
- **`Start(ctx)`**: launches the reaper goroutine if `IdleTimeout > 0`; no-op otherwise
- **`reapLoop`**: ticker-driven loop calling `reapOnce` on each interval; guards against non-positive interval
- **`reapOnce`**: iterates `p.items` under `p.mu`; for entries with `refs == 0 && !retired && time.Since(lastUsed) > idleTimeout`, calls `removeLocked(e.elem, "idle")` and collects for `closeEntry` outside the lock; no-op when `idleTimeout <= 0`
- **`releaseEntry`**: now takes `refreshLastUsed bool` — `makeRelease` (Acquire) passes true; `makeReleaseNoRefresh` (AcquireCached) passes false. When refs drop to 0 and not retired, `lastUsed` is refreshed so the idle timer starts from "activity finished"
- **`S3Backend`**: refreshes `lastUsed` on cache hit (local `/s3/` download path)
- **`Close`**: stops the reaper (`reapStop` + `reapWG.Wait()`) before draining entries, preventing shutdown races
- Existing `removeLocked` reason metric now records `"idle"` automatically; `reapOnce` refreshes the `cached_backends` gauge

### `cmd/drive9-server/main.go`

- `DRIVE9_POOL_IDLE_TTL` env var (default `10m`, `0` = disabled)
- `DRIVE9_POOL_IDLE_REAP_INTERVAL` env var (default `5m`)
- `pool.Start(context.Background())` after `SetMetaStore`
- Help text for both env vars

### `pkg/tenant/pool_test.go`

9 tests:

1. `TestIdleEviction` — backend is evicted and store closed after idle timeout lapses
2. `TestIdleEvictionSkippedByRecentAcquire` — recent `Acquire` refreshes `lastUsed`, no eviction
3. `TestIdleEvictionNotRefreshedByAcquireCached` — `AcquireCached` does **not** refresh `lastUsed`; entry is evicted despite a recent cached touch
4. `TestIdleEvictionRespectsRefs` — pinned entry (`refs > 0`) is not evicted; after release + timeout it is evicted
5. `TestIdleEvictionDisabled` — `IdleTimeout=0` → `reapOnce` is a no-op, entry stays
6. `TestIdleEvictionStartNoOpWhenDisabled` — `Start` does not launch a goroutine when `IdleTimeout=0`
7. `TestIdleEvictionReleaseRefreshesLastUsed` — long-running request held beyond TTL is not immediately evicted on release; `lastUsed` is refreshed
8. `TestIdleEvictionAcquireCachedReleaseDoesNotRefresh` — `AcquireCached` release does not refresh `lastUsed`
9. `TestIdleEvictionStartAutoEvictsAndCloseStops` — end-to-end: `Start` → ticker auto-evicts → `Close` lifecycle

## Safety guarantees

1. **Pinned entries are safe**: `reapOnce` skips `refs > 0`; `removeLocked` returns nil for pinned entries (deferred close via `releaseEntry` when refs drop to 0) — reuses the existing mechanism
2. **Close happens outside the lock**: `reapOnce` collects `toClose` under `p.mu`, then `closeEntry` after `Unlock`
3. **Shutdown is clean**: `Close()` stops the reaper and waits for it before draining
4. **Backward compatible**: `DRIVE9_POOL_IDLE_TTL=0` fully disables the feature, restoring current behavior
5. **No changes to safetyNetScan or other callers**: the warm-only `AcquireCached` contract is preserved; idle eviction just ensures warm tenants eventually become cold

## Metric impact

- Existing `drive9_service_operations_total{component="tenant_pool",operation="remove",result="idle"}` records each eviction
- `drive9_tenant_pool_cached_backends` gauge is refreshed after each reap cycle
- No new metric definitions needed

## Defaults

| Env var | Default | Rationale |
|---------|---------|-----------|
| `DRIVE9_POOL_IDLE_TTL` | 10m | 2× the safety-net scan interval (5m); only truly idle tenants (no activity for 10 min) are evicted |
| `DRIVE9_POOL_IDLE_REAP_INTERVAL` | 5m | Guarantees eviction within at most one interval after the timeout lapses |