### PR TITLE
Persist tenant schema versions and tag schema logs

### DIFF
--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -347,13 +347,14 @@ func (f *credentialOnlyProvisioner) ProvisionWithCredentials(_ context.Context, 
 
 type profileAwareFakeProvisioner struct {
 	fakeProvisioner
-	mu               sync.Mutex
-	profileInitCalls atomic.Int32
-	ensureDBCalls    atomic.Int32
-	lastProfile      tenantschema.TiDBAutoEmbeddingProfile
-	ensureDBErr      error
-	lastEnsureDSN    string
-	callOrder        []string
+	mu                  sync.Mutex
+	profileInitCalls    atomic.Int32
+	ensureDBCalls       atomic.Int32
+	lastProfile         tenantschema.TiDBAutoEmbeddingProfile
+	lastProfileTenantID string
+	ensureDBErr         error
+	lastEnsureDSN       string
+	callOrder           []string
 }
 
 func (f *profileAwareFakeProvisioner) EnsureDatabase(_ context.Context, dsn string) error {
@@ -365,11 +366,12 @@ func (f *profileAwareFakeProvisioner) EnsureDatabase(_ context.Context, dsn stri
 	return f.ensureDBErr
 }
 
-func (f *profileAwareFakeProvisioner) InitSchemaForAutoEmbeddingProfile(_ context.Context, _ string, profile tenantschema.TiDBAutoEmbeddingProfile) error {
+func (f *profileAwareFakeProvisioner) InitSchemaForAutoEmbeddingProfile(ctx context.Context, _ string, profile tenantschema.TiDBAutoEmbeddingProfile) error {
 	f.profileInitCalls.Add(1)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.lastProfile = profile
+	f.lastProfileTenantID = tenantschema.TenantIDFromContext(ctx)
 	f.callOrder = append(f.callOrder, "profile-init")
 	return nil
 }
@@ -443,6 +445,12 @@ func TestSchemaInitForTenantEnsuresDatabaseBeforeProfileInit(t *testing.T) {
 	}
 	if got, want := prov.callOrderString(), "ensure,profile-init"; got != want {
 		t.Fatalf("call order = %s, want %s", got, want)
+	}
+	prov.mu.Lock()
+	lastProfileTenantID := prov.lastProfileTenantID
+	prov.mu.Unlock()
+	if lastProfileTenantID != "tenant-native" {
+		t.Fatalf("profile init tenant id = %q, want tenant-native", lastProfileTenantID)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -1814,6 +1814,72 @@ func TestSchemaInitForTenantUsesFTSOnlyProfileWhenDatabaseAutoEmbeddingDisabled(
 	}
 }
 
+func TestInitTenantSchemaAsyncPersistsTargetSchemaVersion(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	tenantID := token.NewID()
+	now := time.Now().UTC()
+	if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantProvisioning,
+		DBPasswordCipher: []byte{},
+		Provider:         tenant.ProviderTiDBZero,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	profile := tenantschema.TiDBAutoEmbeddingProfile{
+		Model:       "openai/text-embedding-v4",
+		Dimensions:  1024,
+		OptionsJSON: `{"dimensions":1024}`,
+	}
+	targetVersion, err := tenantschema.TiDBTenantSchemaVersionForEmbeddingModeProfile(tenantschema.TiDBEmbeddingModeFTSOnly, profile)
+	if err != nil {
+		t.Fatalf("target schema version: %v", err)
+	}
+	if err := metaStore.UpsertTenantAutoEmbeddingProfile(context.Background(), &meta.TenantAutoEmbeddingProfile{
+		TenantID:      tenantID,
+		EmbeddingMode: meta.TenantEmbeddingModeFTSOnly,
+		Model:         profile.Model,
+		Dimensions:    profile.Dimensions,
+		OptionsJSON:   profile.OptionsJSON,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := NewWithConfig(Config{Meta: metaStore})
+	defer srv.Close()
+	schemaInitCalls := 0
+	srv.initTenantSchemaAsync(context.Background(), tenantID, "unused-dsn", tenant.ProviderTiDBZero, func(context.Context, string) error {
+		schemaInitCalls++
+		return nil
+	})
+
+	if schemaInitCalls != 1 {
+		t.Fatalf("schema init calls = %d, want 1", schemaInitCalls)
+	}
+	updated, err := metaStore.GetTenant(context.Background(), tenantID)
+	if err != nil {
+		t.Fatalf("GetTenant: %v", err)
+	}
+	if updated.Status != meta.TenantActive {
+		t.Fatalf("status = %q, want %q", updated.Status, meta.TenantActive)
+	}
+	if updated.SchemaVersion != targetVersion {
+		t.Fatalf("schema version = %d, want %d", updated.SchemaVersion, targetVersion)
+	}
+}
+
 func TestAutoEmbeddingProfileForTenantEnsuresDefaultProfile(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -1860,6 +1860,7 @@ func TestInitTenantSchemaAsyncPersistsTargetSchemaVersion(t *testing.T) {
 	srv := NewWithConfig(Config{Meta: metaStore})
 	defer srv.Close()
 	schemaInitCalls := 0
+	// Direct invocation is blocking; production launches this function in a worker.
 	srv.initTenantSchemaAsync(context.Background(), tenantID, "unused-dsn", tenant.ProviderTiDBZero, func(context.Context, string) error {
 		schemaInitCalls++
 		return nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4977,11 +4977,7 @@ func (s *Server) updateTenantSchemaVersionForProfile(ctx context.Context, tenant
 	if err != nil {
 		return fmt.Errorf("resolve tenant auto-embedding profile: %w", err)
 	}
-	tidbMode, err := tenant.TiDBEmbeddingModeForTenantMode(profile.mode)
-	if err != nil {
-		return err
-	}
-	version, err := tenantschema.TiDBTenantSchemaVersionForEmbeddingModeProfile(tidbMode, profile.schemaProfile)
+	version, err := tenant.TiDBTenantSchemaVersionForEmbeddingMode(profile.mode, profile.schemaProfile)
 	if err != nil {
 		return err
 	}
@@ -5401,7 +5397,13 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 			}
 			err = s.finalizeTenantSchemaInit(ctx, tenantID, tenantDSN, provider)
 			if err == nil {
-				err = s.updateTenantSchemaVersionForProfile(ctx, tenantID, provider)
+				if versionErr := s.updateTenantSchemaVersionForProfile(ctx, tenantID, provider); versionErr != nil {
+					logger.Error(ctx, "server_event", eventFields(ctx, "schema_init_version_persist_failed", "tenant_id", tenantID, "provider", provider, "attempt", attempt, "error", versionErr)...)
+					if s.metrics != nil {
+						s.metrics.recordEvent(tenantID, "tenant_schema_init", "provider", provider, "result", "error", "stage", "schema_version_persist")
+					}
+					err = versionErr
+				}
 			}
 		}
 		if err == nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4920,18 +4920,22 @@ func (s *Server) autoEmbeddingProfileForTenant(ctx context.Context, tenantID str
 }
 
 func (s *Server) schemaInitForTenant(tenantID, provider string, fallback func(context.Context, string) error) func(context.Context, string) error {
+	fallbackWithTenant := func(ctx context.Context, dsn string) error {
+		return fallback(tenantschema.WithTenantID(ctx, tenantID), dsn)
+	}
 	if !tenant.UsesTiDBAutoEmbedding(provider) {
-		return fallback
+		return fallbackWithTenant
 	}
 	provisioner := s.provisionerForTenantProvider(provider)
 	if provisioner == nil {
-		return fallback
+		return fallbackWithTenant
 	}
 	profileAware, ok := provisioner.(autoEmbeddingSchemaProvisioner)
 	if !ok {
-		return fallback
+		return fallbackWithTenant
 	}
 	return func(ctx context.Context, dsn string) error {
+		ctx = tenantschema.WithTenantID(ctx, tenantID)
 		if ensurer, ok := provisioner.(tenantDatabaseEnsurer); ok {
 			if err := ensurer.EnsureDatabase(ctx, dsn); err != nil {
 				return fmt.Errorf("ensure tenant database: %w", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4979,7 +4979,7 @@ func (s *Server) updateTenantSchemaVersionForProfile(ctx context.Context, tenant
 	}
 	version, err := tenant.TiDBTenantSchemaVersionForEmbeddingMode(profile.mode, profile.schemaProfile)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolve tenant embedding schema version: %w", err)
 	}
 	if err := s.meta.UpdateTenantSchemaVersion(ctx, tenantID, version); err != nil {
 		return fmt.Errorf("persist tenant schema version: %w", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4969,6 +4969,28 @@ func (s *Server) schemaInitForTenant(tenantID, provider string, fallback func(co
 	}
 }
 
+func (s *Server) updateTenantSchemaVersionForProfile(ctx context.Context, tenantID, provider string) error {
+	if s.meta == nil || !tenant.UsesTiDBAutoEmbedding(provider) {
+		return nil
+	}
+	profile, err := s.autoEmbeddingProfileForTenant(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("resolve tenant auto-embedding profile: %w", err)
+	}
+	tidbMode, err := tenant.TiDBEmbeddingModeForTenantMode(profile.mode)
+	if err != nil {
+		return err
+	}
+	version, err := tenantschema.TiDBTenantSchemaVersionForEmbeddingModeProfile(tidbMode, profile.schemaProfile)
+	if err != nil {
+		return err
+	}
+	if err := s.meta.UpdateTenantSchemaVersion(ctx, tenantID, version); err != nil {
+		return fmt.Errorf("persist tenant schema version: %w", err)
+	}
+	return nil
+}
+
 func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOptions) (*provisionTenantResult, error) {
 	rawProvider := s.provisioner.ProviderType()
 	provider, err := tenant.NormalizeProvider(rawProvider)
@@ -5378,6 +5400,9 @@ func (s *Server) initTenantSchemaAsync(ctx context.Context, tenantID, tenantDSN,
 				return
 			}
 			err = s.finalizeTenantSchemaInit(ctx, tenantID, tenantDSN, provider)
+			if err == nil {
+				err = s.updateTenantSchemaVersionForProfile(ctx, tenantID, provider)
+			}
 		}
 		if err == nil {
 			s.schemaInitErrors.Delete(tenantID)

--- a/pkg/tenant/embedding_mode.go
+++ b/pkg/tenant/embedding_mode.go
@@ -19,3 +19,13 @@ func TiDBEmbeddingModeForTenantMode(mode string) (schema.TiDBEmbeddingMode, erro
 		return schema.TiDBEmbeddingModeUnknown, fmt.Errorf("unsupported tenant embedding mode %q", mode)
 	}
 }
+
+// TiDBTenantSchemaVersionForEmbeddingMode derives the profile-specific TiDB
+// schema version for a persisted tenant-level embedding mode.
+func TiDBTenantSchemaVersionForEmbeddingMode(mode string, profile schema.TiDBAutoEmbeddingProfile) (int, error) {
+	tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
+	if err != nil {
+		return 0, err
+	}
+	return schema.TiDBTenantSchemaVersionForEmbeddingModeProfile(tidbMode, profile)
+}

--- a/pkg/tenant/embedding_mode.go
+++ b/pkg/tenant/embedding_mode.go
@@ -25,7 +25,11 @@ func TiDBEmbeddingModeForTenantMode(mode string) (schema.TiDBEmbeddingMode, erro
 func TiDBTenantSchemaVersionForEmbeddingMode(mode string, profile schema.TiDBAutoEmbeddingProfile) (int, error) {
 	tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
 	if err != nil {
-		return 0, err
+		return 0, fmt.Errorf("map tenant embedding mode %q: %w", mode, err)
 	}
-	return schema.TiDBTenantSchemaVersionForEmbeddingModeProfile(tidbMode, profile)
+	version, err := schema.TiDBTenantSchemaVersionForEmbeddingModeProfile(tidbMode, profile)
+	if err != nil {
+		return 0, fmt.Errorf("derive tenant schema version for mode %q: %w", mode, err)
+	}
+	return version, nil
 }

--- a/pkg/tenant/embedding_mode_test.go
+++ b/pkg/tenant/embedding_mode_test.go
@@ -1,0 +1,37 @@
+package tenant
+
+import (
+	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant/schema"
+)
+
+func TestTiDBTenantSchemaVersionForEmbeddingMode(t *testing.T) {
+	profile := schema.TiDBAutoEmbeddingProfile{
+		Model:       "openai/text-embedding-v4",
+		Dimensions:  1024,
+		OptionsJSON: `{"dimensions":1024}`,
+	}
+	for _, mode := range []string{meta.TenantEmbeddingModeAuto, meta.TenantEmbeddingModeFTSOnly} {
+		got, err := TiDBTenantSchemaVersionForEmbeddingMode(mode, profile)
+		if err != nil {
+			t.Fatalf("TiDBTenantSchemaVersionForEmbeddingMode(%q): %v", mode, err)
+		}
+		tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
+		if err != nil {
+			t.Fatalf("TiDBEmbeddingModeForTenantMode(%q): %v", mode, err)
+		}
+		want, err := schema.TiDBTenantSchemaVersionForEmbeddingModeProfile(tidbMode, profile)
+		if err != nil {
+			t.Fatalf("TiDBTenantSchemaVersionForEmbeddingModeProfile(%q): %v", mode, err)
+		}
+		if got != want {
+			t.Fatalf("version for %q = %d, want %d", mode, got, want)
+		}
+	}
+
+	if _, err := TiDBTenantSchemaVersionForEmbeddingMode("invalid", profile); err == nil {
+		t.Fatal("TiDBTenantSchemaVersionForEmbeddingMode(invalid) succeeded, want error")
+	}
+}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -868,8 +868,9 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 					// Version-matched opens trust this durable value and skip the
 					// physical diff by default; out-of-band schema drift is detected
 					// only when the target schema version changes, or through an
-					// explicit validation/repair path. SkipTiDBSchemaCheck remains
-					// the opt-out for externally managed schemas.
+					// explicit validation/repair path. SkipTiDBSchemaCheck disables
+					// the Acquire-time TiDB schema ensure/check entirely, mainly for
+					// tests that use a TiDB-class provider against plain MySQL.
 					updateSchemaVersionStart := time.Now()
 					if verErr := p.metaStore.UpdateTenantSchemaVersion(ctx, t.ID, targetSchemaVersion); verErr != nil {
 						recordTenantSchemaVersionUpdateFailure(ctx, t.ID, targetSchemaVersion, time.Since(updateSchemaVersionStart), verErr)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -857,7 +857,8 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			}
 			if t.SchemaVersion != targetSchemaVersion {
 				ensureSchemaStart := time.Now()
-				if err := ensureTiDBSchemaForEmbeddingMode(ctx, store.DB(), autoEmbeddingProfile.mode, autoEmbeddingProfile.schemaProfile); err != nil {
+				schemaCtx := schema.WithTenantID(ctx, t.ID)
+				if err := ensureTiDBSchemaForEmbeddingMode(schemaCtx, store.DB(), autoEmbeddingProfile.mode, autoEmbeddingProfile.schemaProfile); err != nil {
 					_ = store.Close()
 					return nil, nil, fmt.Errorf("ensure tidb embedding schema: %w", err)
 				}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -865,9 +865,11 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 				if p.metaStore != nil {
 					// Record the tenant-profile-specific version only after the
 					// schema has been confirmed to match that tenant's profile.
-					// Any tenant whose schema diverges between two consecutive
-					// opens will be caught on the next open because its stored
-					// version will differ from the profile-derived target.
+					// Version-matched opens trust this durable value and skip the
+					// physical diff by default; out-of-band schema drift is detected
+					// only when the target schema version changes, or through an
+					// explicit validation/repair path. SkipTiDBSchemaCheck remains
+					// the opt-out for externally managed schemas.
 					updateSchemaVersionStart := time.Now()
 					if verErr := p.metaStore.UpdateTenantSchemaVersion(ctx, t.ID, targetSchemaVersion); verErr != nil {
 						recordTenantSchemaVersionUpdateFailure(ctx, t.ID, targetSchemaVersion, time.Since(updateSchemaVersionStart), verErr)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -165,14 +165,6 @@ var (
 	defaultTenantPoolIdleReapInterval       = 5 * time.Minute
 )
 
-func tenantSchemaVersionForEmbeddingMode(mode string, profile schema.TiDBAutoEmbeddingProfile) (int, error) {
-	tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
-	if err != nil {
-		return 0, err
-	}
-	return schema.TiDBTenantSchemaVersionForEmbeddingModeProfile(tidbMode, profile)
-}
-
 func ensureTiDBSchemaForEmbeddingMode(ctx context.Context, db *sql.DB, mode string, profile schema.TiDBAutoEmbeddingProfile) error {
 	tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
 	if err != nil {
@@ -850,7 +842,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			opts.AsyncAudioExtract = backend.AsyncAudioExtractOptions{}
 		}
 		if !p.cfg.SkipTiDBSchemaCheck {
-			targetSchemaVersion, err := tenantSchemaVersionForEmbeddingMode(autoEmbeddingProfile.mode, autoEmbeddingProfile.schemaProfile)
+			targetSchemaVersion, err := TiDBTenantSchemaVersionForEmbeddingMode(autoEmbeddingProfile.mode, autoEmbeddingProfile.schemaProfile)
 			if err != nil {
 				_ = store.Close()
 				return nil, nil, fmt.Errorf("resolve tenant embedding schema version: %w", err)

--- a/pkg/tenant/schema/context.go
+++ b/pkg/tenant/schema/context.go
@@ -13,7 +13,8 @@ func WithTenantID(ctx context.Context, tenantID string) context.Context {
 	return context.WithValue(ctx, tenantIDContextKey{}, tenantID)
 }
 
-func tenantIDFromContext(ctx context.Context) string {
+// TenantIDFromContext returns the tenant attribution attached with WithTenantID.
+func TenantIDFromContext(ctx context.Context) string {
 	tenantID, _ := ctx.Value(tenantIDContextKey{}).(string)
 	return tenantID
 }

--- a/pkg/tenant/schema/context.go
+++ b/pkg/tenant/schema/context.go
@@ -7,7 +7,7 @@ type tenantIDContextKey struct{}
 // WithTenantID annotates schema-init contexts so user_schema DB pool metrics can
 // retain tenant attribution without changing public schema-init function shapes.
 func WithTenantID(ctx context.Context, tenantID string) context.Context {
-	if tenantID == "" {
+	if ctx == nil || tenantID == "" {
 		return ctx
 	}
 	return context.WithValue(ctx, tenantIDContextKey{}, tenantID)
@@ -15,6 +15,9 @@ func WithTenantID(ctx context.Context, tenantID string) context.Context {
 
 // TenantIDFromContext returns the tenant attribution attached with WithTenantID.
 func TenantIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
 	tenantID, _ := ctx.Value(tenantIDContextKey{}).(string)
 	return tenantID
 }

--- a/pkg/tenant/schema/context.go
+++ b/pkg/tenant/schema/context.go
@@ -6,6 +6,8 @@ type tenantIDContextKey struct{}
 
 // WithTenantID annotates schema-init contexts so user_schema DB pool metrics can
 // retain tenant attribution without changing public schema-init function shapes.
+// This is intentionally separate from pkg/tenantctx's request-scope tenant ID:
+// schema setup can also run outside a request and must be tagged explicitly.
 func WithTenantID(ctx context.Context, tenantID string) context.Context {
 	if ctx == nil || tenantID == "" {
 		return ctx

--- a/pkg/tenant/schema/context_test.go
+++ b/pkg/tenant/schema/context_test.go
@@ -11,10 +11,11 @@ func TestTenantIDContext(t *testing.T) {
 		t.Fatalf("tenant id = %q, want tenant-1", got)
 	}
 
-	if got := WithTenantID(nil, "tenant-1"); got != nil {
+	var nilCtx context.Context
+	if got := WithTenantID(nilCtx, "tenant-1"); got != nil {
 		t.Fatalf("nil context = %#v, want nil", got)
 	}
-	if got := TenantIDFromContext(nil); got != "" {
+	if got := TenantIDFromContext(nilCtx); got != "" {
 		t.Fatalf("nil context tenant id = %q, want empty", got)
 	}
 	if got := TenantIDFromContext(WithTenantID(context.Background(), "")); got != "" {

--- a/pkg/tenant/schema/context_test.go
+++ b/pkg/tenant/schema/context_test.go
@@ -1,0 +1,23 @@
+package schema
+
+import (
+	"context"
+	"testing"
+)
+
+func TestTenantIDContext(t *testing.T) {
+	ctx := WithTenantID(context.Background(), "tenant-1")
+	if got := TenantIDFromContext(ctx); got != "tenant-1" {
+		t.Fatalf("tenant id = %q, want tenant-1", got)
+	}
+
+	if got := WithTenantID(nil, "tenant-1"); got != nil {
+		t.Fatalf("nil context = %#v, want nil", got)
+	}
+	if got := TenantIDFromContext(nil); got != "" {
+		t.Fatalf("nil context tenant id = %q, want empty", got)
+	}
+	if got := TenantIDFromContext(WithTenantID(context.Background(), "")); got != "" {
+		t.Fatalf("empty tenant id = %q, want empty", got)
+	}
+}

--- a/pkg/tenant/schema/context_test.go
+++ b/pkg/tenant/schema/context_test.go
@@ -3,6 +3,8 @@ package schema
 import (
 	"context"
 	"testing"
+
+	"go.uber.org/zap"
 )
 
 func TestTenantIDContext(t *testing.T) {
@@ -20,5 +22,26 @@ func TestTenantIDContext(t *testing.T) {
 	}
 	if got := TenantIDFromContext(WithTenantID(context.Background(), "")); got != "" {
 		t.Fatalf("empty tenant id = %q, want empty", got)
+	}
+}
+
+func TestTenantSchemaLogFieldsIncludesTenantID(t *testing.T) {
+	fields := tenantSchemaLogFields(WithTenantID(context.Background(), "tenant-1"), zap.String("mode", "fts-only"))
+	if len(fields) != 2 {
+		t.Fatalf("field count = %d, want 2", len(fields))
+	}
+	if fields[0].Key != "tenant_id" || fields[0].String != "tenant-1" {
+		t.Fatalf("first field = %+v, want tenant_id=tenant-1", fields[0])
+	}
+	if fields[1].Key != "mode" || fields[1].String != "fts-only" {
+		t.Fatalf("second field = %+v, want mode=fts-only", fields[1])
+	}
+
+	fields = tenantSchemaLogFields(context.Background(), zap.String("mode", "fts-only"))
+	if len(fields) != 1 {
+		t.Fatalf("field count without tenant id = %d, want 1", len(fields))
+	}
+	if fields[0].Key != "mode" || fields[0].String != "fts-only" {
+		t.Fatalf("field without tenant id = %+v, want mode=fts-only", fields[0])
 	}
 }

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -1377,7 +1377,7 @@ func OpenTiDBSchemaDB(ctx context.Context, dsn string) (*sql.DB, error) {
 	if HasMultiStatements(dsn) {
 		return nil, fmt.Errorf("multiStatements is not allowed")
 	}
-	db, err := mysqlutil.OpenInstrumentedForTenant(ctx, dsn, mysqlutil.RoleUserSchema, tenantIDFromContext(ctx))
+	db, err := mysqlutil.OpenInstrumentedForTenant(ctx, dsn, mysqlutil.RoleUserSchema, TenantIDFromContext(ctx))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -654,6 +654,13 @@ func currentTiDBTenantSchemaVersion(stmts []string) int {
 	return schemaspec.CRC32Version(specStmts)
 }
 
+func tenantSchemaLogFields(ctx context.Context, fields ...zap.Field) []zap.Field {
+	if tenantID := TenantIDFromContext(ctx); tenantID != "" {
+		fields = append([]zap.Field{zap.String("tenant_id", tenantID)}, fields...)
+	}
+	return fields
+}
+
 type tidbColumnMeta struct {
 	columnType           string
 	extra                string
@@ -1041,8 +1048,8 @@ func ValidateTiDBSchemaForEmbeddingModeProfile(ctx context.Context, db *sql.DB, 
 
 func validateTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiDBEmbeddingMode, cfg tidbAutoEmbeddingRenderConfig) error {
 	start := time.Now()
-	logger.Info(ctx, "tenant_tidb_schema_validate_started",
-		zap.String("mode", string(mode)))
+	logger.Info(ctx, "tenant_tidb_schema_validate_started", tenantSchemaLogFields(ctx,
+		zap.String("mode", string(mode)))...)
 	if db == nil {
 		return fmt.Errorf("nil db")
 	}
@@ -1057,17 +1064,17 @@ func validateTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode T
 		return err
 	}
 	if len(diffs) > 0 {
-		logger.Warn(ctx, "tenant_tidb_schema_validate_failed",
+		logger.Warn(ctx, "tenant_tidb_schema_validate_failed", tenantSchemaLogFields(ctx,
 			zap.String("mode", string(mode)),
 			zap.Int("diff_count", len(diffs)),
 			zap.Strings("diffs", summarizeTiDBSchemaDiffs(diffs)),
-			zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+			zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 		return &tidbSchemaDiffError{mode: mode, diffs: diffs}
 	}
-	logger.Info(ctx, "tenant_tidb_schema_validate_finished",
+	logger.Info(ctx, "tenant_tidb_schema_validate_finished", tenantSchemaLogFields(ctx,
 		zap.String("mode", string(mode)),
 		zap.Int("diff_count", 0),
-		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 	return nil
 }
 
@@ -1116,8 +1123,8 @@ func EnsureTiDBSchemaForEmbeddingModeProfile(ctx context.Context, db *sql.DB, mo
 func ensureTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiDBEmbeddingMode, cfg tidbAutoEmbeddingRenderConfig) error {
 	start := time.Now()
 	attemptedPasses := 0
-	logger.Info(ctx, "tenant_tidb_schema_ensure_started",
-		zap.String("mode", string(mode)))
+	logger.Info(ctx, "tenant_tidb_schema_ensure_started", tenantSchemaLogFields(ctx,
+		zap.String("mode", string(mode)))...)
 	if db == nil {
 		return fmt.Errorf("nil db")
 	}
@@ -1138,13 +1145,13 @@ func ensureTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiD
 		if err != nil {
 			return err
 		}
-		logger.Info(ctx, "tenant_tidb_schema_ensure_diff_pass_finished",
+		logger.Info(ctx, "tenant_tidb_schema_ensure_diff_pass_finished", tenantSchemaLogFields(ctx,
 			zap.String("mode", string(mode)),
 			zap.Int("repair_pass", i+1),
 			zap.Int("max_repair_passes", maxRepairPasses),
 			zap.Int("diff_count", len(diffs)),
 			zap.Strings("diffs", summarizeTiDBSchemaDiffs(diffs)),
-			zap.Float64("duration_ms", float64(time.Since(passStart).Microseconds())/1000.0))
+			zap.Float64("duration_ms", float64(time.Since(passStart).Microseconds())/1000.0))...)
 		if err := BackfillPathHashes(ctx, db); err != nil {
 			return fmt.Errorf("backfill path hashes before repair: %w", err)
 		}
@@ -1152,26 +1159,26 @@ func ensureTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiD
 			if err := BackfillStorageRefHashes(ctx, db); err != nil {
 				return fmt.Errorf("backfill storage_ref_hash: %w", err)
 			}
-			logger.Info(ctx, "tenant_tidb_schema_ensure_finished",
+			logger.Info(ctx, "tenant_tidb_schema_ensure_finished", tenantSchemaLogFields(ctx,
 				zap.String("mode", string(mode)),
 				zap.Int("repair_passes", attemptedPasses),
-				zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+				zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 			return nil
 		}
 		repairs := plannedTiDBSchemaRepairs(diffs)
 		if len(repairs) == 0 {
-			logger.Warn(ctx, "tenant_tidb_schema_ensure_no_safe_repairs",
+			logger.Warn(ctx, "tenant_tidb_schema_ensure_no_safe_repairs", tenantSchemaLogFields(ctx,
 				zap.String("mode", string(mode)),
 				zap.Int("repair_pass", i+1),
-				zap.Strings("diffs", summarizeTiDBSchemaDiffs(diffs)))
+				zap.Strings("diffs", summarizeTiDBSchemaDiffs(diffs)))...)
 			// Drift remains but nothing in it is safe to repair automatically.
 			break
 		}
-		logger.Info(ctx, "tenant_tidb_schema_ensure_repair_pass_started",
+		logger.Info(ctx, "tenant_tidb_schema_ensure_repair_pass_started", tenantSchemaLogFields(ctx,
 			zap.String("mode", string(mode)),
 			zap.Int("repair_pass", i+1),
 			zap.Int("repair_count", len(repairs)),
-			zap.Strings("repairs", summarizeSchemaStatements(repairs)))
+			zap.Strings("repairs", summarizeSchemaStatements(repairs)))...)
 		if err := applyTiDBSchemaRepairs(ctx, db, repairs); err != nil {
 			return err
 		}
@@ -1188,10 +1195,10 @@ func ensureTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiD
 	if err := BackfillPathHashes(ctx, db); err != nil {
 		return fmt.Errorf("backfill path hashes: %w", err)
 	}
-	logger.Info(ctx, "tenant_tidb_schema_ensure_finished",
+	logger.Info(ctx, "tenant_tidb_schema_ensure_finished", tenantSchemaLogFields(ctx,
 		zap.String("mode", string(mode)),
 		zap.Int("repair_passes", attemptedPasses),
-		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 	return nil
 }
 
@@ -1275,8 +1282,8 @@ func initTiDBFTSOnlySchemaWithProfile(ctx context.Context, dsn string, profile T
 
 func initTiDBSchemaWithProfileAndMode(ctx context.Context, dsn string, profile TiDBAutoEmbeddingProfile, mode TiDBEmbeddingMode) error {
 	start := time.Now()
-	logger.Info(ctx, "tenant_tidb_schema_init_started",
-		zap.String("mode", string(mode)))
+	logger.Info(ctx, "tenant_tidb_schema_init_started", tenantSchemaLogFields(ctx,
+		zap.String("mode", string(mode)))...)
 	render, err := tidbAutoEmbeddingRenderConfigForProfile(profile)
 	if err != nil {
 		return err
@@ -1310,9 +1317,9 @@ func initTiDBSchemaWithProfileAndMode(ctx context.Context, dsn string, profile T
 	default:
 		return validateTiDBSchemaMode(mode)
 	}
-	logger.Info(ctx, "tenant_tidb_schema_init_finished",
+	logger.Info(ctx, "tenant_tidb_schema_init_finished", tenantSchemaLogFields(ctx,
 		zap.String("mode", string(mode)),
-		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 	return nil
 }
 
@@ -1596,12 +1603,12 @@ func diffTiDBSchemaForModeWithConfig(ctx context.Context, db *sql.DB, mode TiDBE
 		return nil, err
 	}
 	diffs = append(diffs, legacyFilesDiffs...)
-	logger.Info(ctx, "tenant_tidb_schema_diff_finished",
+	logger.Info(ctx, "tenant_tidb_schema_diff_finished", tenantSchemaLogFields(ctx,
 		zap.String("mode", string(mode)),
 		zap.Int("table_count", len(spec.tables)),
 		zap.Int("table_parallelism", tableParallelism),
 		zap.Int("diff_count", len(diffs)),
-		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 	return diffs, nil
 }
 
@@ -1703,7 +1710,7 @@ func diffTiDBTable(ctx context.Context, db *sql.DB, table tidbTableSpec) ([]tidb
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			diffs := missingTableAndIndexDiffs(table)
-			logger.Info(ctx, "tenant_tidb_schema_diff_table_finished",
+			logger.Info(ctx, "tenant_tidb_schema_diff_table_finished", tenantSchemaLogFields(ctx,
 				zap.String("table", table.name),
 				zap.Bool("table_missing", true),
 				zap.Float64("load_columns_ms", loadColumnsDurationMs),
@@ -1711,7 +1718,7 @@ func diffTiDBTable(ctx context.Context, db *sql.DB, table tidbTableSpec) ([]tidb
 				zap.Float64("load_indexes_ms", 0),
 				zap.Int("diff_count", len(diffs)),
 				zap.Strings("diffs", summarizeTiDBSchemaDiffs(diffs)),
-				zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+				zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 			return diffs, nil
 		}
 		return nil, fmt.Errorf("load %s table metadata: %w", table.name, err)
@@ -1726,7 +1733,7 @@ func diffTiDBTable(ctx context.Context, db *sql.DB, table tidbTableSpec) ([]tidb
 	observedIndexes, indexesObserved := loadObservedTiDBIndexes(ctx, db, table.name, createStmt)
 	loadIndexesDurationMs := float64(time.Since(loadIndexesStart).Microseconds()) / 1000.0
 	diffs := diffTiDBTableMetaWithObservedIndexes(table, meta, createStmt, observedIndexes, indexesObserved)
-	logger.Info(ctx, "tenant_tidb_schema_diff_table_finished",
+	logger.Info(ctx, "tenant_tidb_schema_diff_table_finished", tenantSchemaLogFields(ctx,
 		zap.String("table", table.name),
 		zap.Bool("table_missing", false),
 		zap.Bool("indexes_observed", indexesObserved),
@@ -1736,16 +1743,16 @@ func diffTiDBTable(ctx context.Context, db *sql.DB, table tidbTableSpec) ([]tidb
 		zap.Int("column_count", len(meta.columns)),
 		zap.Int("diff_count", len(diffs)),
 		zap.Strings("diffs", summarizeTiDBSchemaDiffs(diffs)),
-		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 	return diffs, nil
 }
 
 func loadObservedTiDBIndexes(ctx context.Context, db *sql.DB, tableName, createStmt string) (map[string]struct{}, bool) {
 	indexNames, statErr := loadTiDBIndexNames(ctx, db, tableName)
 	if statErr != nil {
-		logger.Warn(ctx, "tenant_tidb_schema_load_index_metadata_failed",
+		logger.Warn(ctx, "tenant_tidb_schema_load_index_metadata_failed", tenantSchemaLogFields(ctx,
 			zap.String("table", tableName),
-			zap.Error(statErr))
+			zap.Error(statErr))...)
 	}
 
 	merged := make(map[string]struct{})
@@ -1762,8 +1769,8 @@ func loadObservedTiDBIndexes(ctx context.Context, db *sql.DB, tableName, createS
 			}
 		}
 	} else if statErr != nil {
-		logger.Warn(ctx, "tenant_tidb_schema_parse_show_create_indexes_failed",
-			zap.String("table", tableName))
+		logger.Warn(ctx, "tenant_tidb_schema_parse_show_create_indexes_failed", tenantSchemaLogFields(ctx,
+			zap.String("table", tableName))...)
 	}
 
 	if len(merged) == 0 && statErr != nil {
@@ -2946,10 +2953,10 @@ func applyTiDBSchemaRepairs(ctx context.Context, db *sql.DB, statements []string
 	for i, stmt := range statements {
 		start := time.Now()
 		snippet := schemaStatementSnippet(stmt)
-		logger.Info(ctx, "tenant_tidb_schema_repair_statement_started",
+		logger.Info(ctx, "tenant_tidb_schema_repair_statement_started", tenantSchemaLogFields(ctx,
 			zap.Int("statement_index", i+1),
 			zap.Int("statement_count", len(statements)),
-			zap.String("statement", snippet))
+			zap.String("statement", snippet))...)
 		if isUniqueIndexRepairSQL(stmt) {
 			repair, ok := parseUniqueIndexRepairStatement(stmt)
 			if !ok {
@@ -2965,12 +2972,12 @@ func applyTiDBSchemaRepairs(ctx context.Context, db *sql.DB, statements []string
 		}
 		if _, err := db.ExecContext(ctx, stmt); err != nil {
 			if isIgnorableTiDBSchemaError(err) {
-				logger.Info(ctx, "tenant_tidb_schema_repair_statement_skipped_existing",
+				logger.Info(ctx, "tenant_tidb_schema_repair_statement_skipped_existing", tenantSchemaLogFields(ctx,
 					zap.Int("statement_index", i+1),
 					zap.Int("statement_count", len(statements)),
 					zap.String("statement", snippet),
 					zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0),
-					zap.Error(err))
+					zap.Error(err))...)
 				continue
 			}
 			// FULLTEXT and VECTOR index repairs may fail with optional-feature
@@ -2979,27 +2986,27 @@ func applyTiDBSchemaRepairs(ctx context.Context, db *sql.DB, statements []string
 			// 1105: FULLTEXT index is not supported). Treat these the same as
 			// when the statement was skipped during initial provisioning.
 			if isFulltextOrVectorIndexRepairSQL(stmt) && isIgnorableOptionalSchemaError(err) {
-				logger.Warn(ctx, "tenant_tidb_schema_repair_optional_index_skipped",
+				logger.Warn(ctx, "tenant_tidb_schema_repair_optional_index_skipped", tenantSchemaLogFields(ctx,
 					zap.Int("statement_index", i+1),
 					zap.Int("statement_count", len(statements)),
 					zap.String("statement", snippet),
 					zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0),
-					zap.Error(err))
+					zap.Error(err))...)
 				continue
 			}
-			logger.Error(ctx, "tenant_tidb_schema_repair_statement_failed",
+			logger.Error(ctx, "tenant_tidb_schema_repair_statement_failed", tenantSchemaLogFields(ctx,
 				zap.Int("statement_index", i+1),
 				zap.Int("statement_count", len(statements)),
 				zap.String("statement", snippet),
 				zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0),
-				zap.Error(err))
+				zap.Error(err))...)
 			return fmt.Errorf("apply tidb schema repair %q: %w", snippet, err)
 		}
-		logger.Info(ctx, "tenant_tidb_schema_repair_statement_finished",
+		logger.Info(ctx, "tenant_tidb_schema_repair_statement_finished", tenantSchemaLogFields(ctx,
 			zap.Int("statement_index", i+1),
 			zap.Int("statement_count", len(statements)),
 			zap.String("statement", snippet),
-			zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+			zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 	}
 	return nil
 }
@@ -3093,28 +3100,28 @@ func parseAlterTableAddUniqueIndexRepairStatement(stmt string) (tableName, index
 
 func ensureUniqueIndexRepairSafe(ctx context.Context, db *sql.DB, repair tidbUniqueIndexRepair) error {
 	start := time.Now()
-	logger.Info(ctx, "tenant_tidb_schema_unique_index_preflight_started",
+	logger.Info(ctx, "tenant_tidb_schema_unique_index_preflight_started", tenantSchemaLogFields(ctx,
 		zap.String("table", repair.tableName),
 		zap.String("index", repair.indexName),
-		zap.Strings("columns", repair.columns))
+		zap.Strings("columns", repair.columns))...)
 	var exists int
 	err := db.QueryRowContext(ctx, buildUniqueIndexDuplicateCheckSQL(repair)).Scan(&exists)
 	if errors.Is(err, sql.ErrNoRows) {
-		logger.Info(ctx, "tenant_tidb_schema_unique_index_preflight_finished",
+		logger.Info(ctx, "tenant_tidb_schema_unique_index_preflight_finished", tenantSchemaLogFields(ctx,
 			zap.String("table", repair.tableName),
 			zap.String("index", repair.indexName),
 			zap.Bool("duplicates_found", false),
-			zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+			zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 		return nil
 	}
 	if err != nil {
 		return fmt.Errorf("preflight unique index repair %s on %s: %w", repair.indexName, repair.tableName, err)
 	}
-	logger.Warn(ctx, "tenant_tidb_schema_unique_index_preflight_finished",
+	logger.Warn(ctx, "tenant_tidb_schema_unique_index_preflight_finished", tenantSchemaLogFields(ctx,
 		zap.String("table", repair.tableName),
 		zap.String("index", repair.indexName),
 		zap.Bool("duplicates_found", true),
-		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))
+		zap.Float64("duration_ms", float64(time.Since(start).Microseconds())/1000.0))...)
 	return fmt.Errorf("cannot auto-repair unique index %s on %s: duplicate rows exist for columns (%s)", repair.indexName, repair.tableName, strings.Join(repair.columns, ", "))
 }
 


### PR DESCRIPTION
## Summary
- Persist the profile-derived tenant `schema_version` after async schema initialization succeeds, so newly initialized TiDB tenants do not run a first-request physical diff when the stored version is already aligned.
- Propagate tenant ID into request cold-open schema ensure contexts and add `tenant_id` to `tenant_tidb_schema_*` init, validate, diff, repair, and preflight logs.
- Share tenant embedding-mode schema-version derivation between the server and pool paths, add review-requested comments/logging around schema init attribution and version persistence failures, and wrap schema-version derivation errors with context.
- Add regression coverage for async schema-version persistence, schema log field attribution, and shared schema-version derivation.

## Validation
- `go test ./pkg/tenant -run 'TestTiDBTenantSchemaVersionForEmbeddingMode|TestPoolCreateBackend|TestRecordTenantSchemaVersionUpdateFailureRecordsMetric' -count=1`
- `make test TEST_PKGS='./pkg/server' TEST_RUN='TestInitTenantSchemaAsyncPersistsTargetSchemaVersion|TestSchemaInitForTenantUsesFTSOnlyProfileWhenDatabaseAutoEmbeddingDisabled|TestAutoEmbeddingProfileForTenantEnsuresDefaultProfile'`
- `go test ./pkg/tenant/schema -run 'TestTenantIDContext|TestTenantSchemaLogFieldsIncludesTenantID' -count=1`
- `make test TEST_PKGS='./pkg/server' TEST_RUN='TestInitTenantSchemaAsyncPersistsTargetSchemaVersion'`
- `make lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tenant-specific schema initialization and persistence of embedding schema versions.
  * Ensured schema operations consistently use the correct tenant context.
  * Enhanced tenant schema logs with tenant identifiers for clearer diagnostics.
  * Improved handling of invalid embedding modes and schema version updates.

* **Tests**
  * Added coverage for tenant context propagation, schema initialization order, version persistence, and embedding-mode validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->