### PR TITLE
Reduce Drive9 metrics cardinality

### DIFF
--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -8,13 +8,13 @@ This dashboard set expects the `drive9_*` Prometheus namespace. The previous `da
 
 ## 1. Usage dashboard
 
-- `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, HTTP transport bytes, storage/media quota state, latency, and non-OK rates by tenant/surface. Use this to answer `who is using Drive9, how much, and through which workflows?`
+- `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, HTTP transport bytes, storage/media quota state, latency, and non-OK rates by tenant/surface/action. Use this to answer `who is using Drive9, how much, and through which workflows?`
 
 Tenant usage metrics intentionally allow `tenant_id` as a Prometheus label, but keep high-cardinality values out of labels: no path, file ID, upload ID, API key ID, raw URL, user agent, or trace ID.
 
 ## Tenant metric contract
 
-- `drive9_tenant_requests_total`: request count by `tenant_id`, `surface`, `result`, and `status_class`.
+- `drive9_tenant_requests_total`: request count by `tenant_id`, `surface`, `action`, `result`, and `status_class`.
 - `drive9_tenant_request_duration_seconds`: request latency histogram by `surface` and `status_class`.
 - `drive9_tenant_inflight_requests`: current in-flight request gauge by `tenant_id`, `surface`, and `action`.
 - `drive9_tenant_http_bytes_total`: HTTP transport bytes by `tenant_id`, `surface`, and `direction=request|response`.

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -8,16 +8,16 @@ This dashboard set expects the `drive9_*` Prometheus namespace. The previous `da
 
 ## 1. Usage dashboard
 
-- `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, HTTP transport bytes, storage/media quota state, latency, and non-OK rates by tenant/surface/action. Use this to answer `who is using Drive9, how much, and through which workflows?`
+- `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, HTTP transport bytes, storage/media quota state, latency, and non-OK rates by tenant/surface. Use this to answer `who is using Drive9, how much, and through which workflows?`
 
 Tenant usage metrics intentionally allow `tenant_id` as a Prometheus label, but keep high-cardinality values out of labels: no path, file ID, upload ID, API key ID, raw URL, user agent, or trace ID.
 
 ## Tenant metric contract
 
-- `drive9_tenant_requests_total`: request count by `tenant_id`, `surface`, `action`, `result`, `status`, and `status_class`.
-- `drive9_tenant_request_duration_seconds`: request latency histogram with the same labels as `drive9_tenant_requests_total`.
+- `drive9_tenant_requests_total`: request count by `tenant_id`, `surface`, `result`, and `status_class`.
+- `drive9_tenant_request_duration_seconds`: request latency histogram by `surface` and `status_class`.
 - `drive9_tenant_inflight_requests`: current in-flight request gauge by `tenant_id`, `surface`, and `action`.
-- `drive9_tenant_http_bytes_total`: HTTP transport bytes by `tenant_id`, `surface`, `action`, and `direction=request|response`.
+- `drive9_tenant_http_bytes_total`: HTTP transport bytes by `tenant_id`, `surface`, and `direction=request|response`.
 - `drive9_tenant_file_bytes_total`: logical file bytes by `tenant_id`, `surface`, `action`, and `direction=read|write`.
 - `drive9_tenant_storage_bytes`: opportunistically published quota storage gauge by `tenant_id` and `state=confirmed|reserved|limit`.
 - `drive9_tenant_media_files`: opportunistically published quota media-file gauge by `tenant_id` and `state=confirmed|limit`.

--- a/docs/grafana/drive9-tenant-usage-dashboard.json
+++ b/docs/grafana/drive9-tenant-usage-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Tenant usage dashboard: request frequency, logical file IO, transport bytes, latency, and errors by tenant/surface.",
+  "description": "Tenant usage dashboard: request frequency, logical file IO, transport bytes, latency, and errors by tenant/surface/action.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -94,7 +94,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval]) > 0))",
+          "expr": "count(count by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]) > 0))",
           "legendFormat": "active tenants",
           "refId": "A"
         }
@@ -140,7 +140,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
           "legendFormat": "requests/s",
           "refId": "A"
         }
@@ -232,7 +232,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",result!=\"ok\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval])), 0.000001)",
+          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\",result!=\"ok\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "non-ok ratio",
           "refId": "A"
         }
@@ -278,7 +278,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, sum by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval])))",
+          "expr": "topk(15, sum by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
           "legendFormat": "{{tenant_id}}",
           "refId": "A"
         }
@@ -370,12 +370,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (surface) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval]))",
-          "legendFormat": "{{surface}}",
+          "expr": "sum by (surface, action) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
+          "legendFormat": "{{surface}}/{{action}}",
           "refId": "A"
         }
       ],
-      "title": "Usage by Surface",
+      "title": "Usage by Surface and Action",
       "type": "timeseries"
     },
     {
@@ -471,7 +471,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, sum by (tenant_id, result) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",result!=\"ok\"}[$__rate_interval])))",
+          "expr": "topk(15, sum by (tenant_id, result) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\",result!=\"ok\"}[$__rate_interval])))",
           "legendFormat": "{{tenant_id}} {{result}}",
           "refId": "A"
         }
@@ -761,14 +761,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(drive9_tenant_file_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
+        "definition": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
         "hide": 0,
         "includeAll": true,
         "label": "Action",
         "multi": true,
         "name": "action",
         "options": [],
-        "query": "label_values(drive9_tenant_file_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
+        "query": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/docs/grafana/drive9-tenant-usage-dashboard.json
+++ b/docs/grafana/drive9-tenant-usage-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Tenant usage dashboard: request frequency, logical file IO, transport bytes, latency, and errors by tenant/surface/action.",
+  "description": "Tenant usage dashboard: request frequency, logical file IO, transport bytes, latency, and errors by tenant/surface.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -94,7 +94,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]) > 0))",
+          "expr": "count(count by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval]) > 0))",
           "legendFormat": "active tenants",
           "refId": "A"
         }
@@ -140,7 +140,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval]))",
           "legendFormat": "requests/s",
           "refId": "A"
         }
@@ -232,7 +232,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\",result!=\"ok\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])), 0.000001)",
+          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",result!=\"ok\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "non-ok ratio",
           "refId": "A"
         }
@@ -278,7 +278,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, sum by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
+          "expr": "topk(15, sum by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval])))",
           "legendFormat": "{{tenant_id}}",
           "refId": "A"
         }
@@ -370,12 +370,12 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (surface, action) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
-          "legendFormat": "{{surface}}/{{action}}",
+          "expr": "sum by (surface) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval]))",
+          "legendFormat": "{{surface}}",
           "refId": "A"
         }
       ],
-      "title": "Usage by Surface and Action",
+      "title": "Usage by Surface",
       "type": "timeseries"
     },
     {
@@ -416,8 +416,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.95, sum by (le, tenant_id, surface, action) (rate(drive9_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} {{surface}}/{{action}} p95",
+          "expr": "histogram_quantile(0.95, sum by (le, surface) (rate(drive9_tenant_request_duration_seconds_bucket{surface=~\"$surface\"}[$__rate_interval])))",
+          "legendFormat": "{{surface}} p95",
           "refId": "A"
         },
         {
@@ -425,8 +425,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "histogram_quantile(0.99, sum by (le, tenant_id, surface, action) (rate(drive9_tenant_request_duration_seconds_bucket{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} {{surface}}/{{action}} p99",
+          "expr": "histogram_quantile(0.99, sum by (le, surface) (rate(drive9_tenant_request_duration_seconds_bucket{surface=~\"$surface\"}[$__rate_interval])))",
+          "legendFormat": "{{surface}} p99",
           "refId": "B"
         }
       ],
@@ -471,7 +471,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, sum by (tenant_id, result) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\",result!=\"ok\"}[$__rate_interval])))",
+          "expr": "topk(15, sum by (tenant_id, result) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",result!=\"ok\"}[$__rate_interval])))",
           "legendFormat": "{{tenant_id}} {{result}}",
           "refId": "A"
         }
@@ -517,8 +517,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (surface, action, direction) (rate(drive9_tenant_http_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
-          "legendFormat": "{{surface}}/{{action}} {{direction}}",
+          "expr": "sum by (surface, direction) (rate(drive9_tenant_http_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval]))",
+          "legendFormat": "{{surface}} {{direction}}",
           "refId": "A"
         }
       ],
@@ -761,14 +761,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
+        "definition": "label_values(drive9_tenant_file_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
         "hide": 0,
         "includeAll": true,
         "label": "Action",
         "multi": true,
         "name": "action",
         "options": [],
-        "query": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
+        "query": "label_values(drive9_tenant_file_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -350,7 +350,7 @@ func RecordTenantRequest(tenantID, surface, action, result string, status int, d
 	)
 }
 
-func RecordTenantHTTPBytes(tenantID, surface, action, direction string, bytes int64) {
+func RecordTenantHTTPBytes(tenantID, surface, _, direction string, bytes int64) {
 	recordTenantHTTPBytes(tenantID, surface, direction, bytes)
 }
 

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -68,10 +68,10 @@ var fuseRemoteOperationsTotal = fuseMeter.Int64Counter("drive9_fuse_remote_opera
 var fuseRemoteOperationDuration = fuseMeter.Float64Histogram("drive9_fuse_remote_operation_duration_seconds", "Remote FUSE operation duration histogram", operationDurationBounds)
 var fuseRemoteOperationBytes = fuseMeter.Int64Counter("drive9_fuse_remote_operation_bytes_total", "Bytes processed by remote FUSE operation/result")
 
-var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/surface/action/result/status/status_class")
-var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_duration_seconds", "Tenant request duration histogram by surface/action/result/status_class", httpDurationBounds)
+var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/surface/result/status_class")
+var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_duration_seconds", "Tenant request duration histogram by surface/status_class", httpDurationBounds)
 var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/surface/action")
-var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/surface/action/direction")
+var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/surface/direction")
 var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/surface/action/direction")
 var tenantStorageBytes = tenantMeter.Float64Gauge("drive9_tenant_storage_bytes", "Tenant storage bytes by state")
 var tenantMediaFiles = tenantMeter.Float64Gauge("drive9_tenant_media_files", "Tenant media file count by state")
@@ -286,19 +286,12 @@ func RecordHTTPRequestCount(method, route string, status int) {
 func RecordTenantRequestCount(tenantID, surface, action, result string, status int) {
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	surface = cleanMetricValue(surface, "other")
-	action = cleanMetricValue(action, "other")
 	result = cleanMetricValue(result, "unknown")
-	statusValue := "unknown"
-	if status > 0 {
-		statusValue = strconv.Itoa(status)
-	}
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
 		Attr("tenant_id", tenantID),
 		Attr("surface", surface),
-		Attr("action", action),
 		Attr("result", result),
-		Attr("status", statusValue),
 		Attr("status_class", statusClass(status)),
 	}
 	tenantRequestsTotal.Add(1, attrs...)
@@ -335,21 +328,16 @@ func RecordTenantEvent(tenantID, event string, labels ...string) {
 func RecordTenantRequest(tenantID, surface, action, result string, status int, d time.Duration) {
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	surface = cleanMetricValue(surface, "other")
-	action = cleanMetricValue(action, "other")
 	result = cleanMetricValue(result, "unknown")
-	statusValue := "unknown"
 	statusClass := "unknown"
 	if status > 0 {
-		statusValue = strconv.Itoa(status)
 		statusClass = strconv.Itoa(status/100) + "xx"
 	}
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
 		Attr("tenant_id", tenantID),
 		Attr("surface", surface),
-		Attr("action", action),
 		Attr("result", result),
-		Attr("status", statusValue),
 		Attr("status_class", statusClass),
 	}
 	tenantRequestsTotal.Add(1, attrs...)
@@ -358,14 +346,12 @@ func RecordTenantRequest(tenantID, surface, action, result string, status int, d
 	}
 	tenantRequestDuration.Observe(d.Seconds(),
 		Attr("surface", surface),
-		Attr("action", action),
-		Attr("result", result),
 		Attr("status_class", statusClass),
 	)
 }
 
 func RecordTenantHTTPBytes(tenantID, surface, action, direction string, bytes int64) {
-	recordTenantBytes(tenantHTTPBytes, tenantID, surface, action, direction, bytes)
+	recordTenantHTTPBytes(tenantID, surface, direction, bytes)
 }
 
 func RecordTenantFileBytes(tenantID, surface, action, direction string, bytes int64) {
@@ -417,6 +403,18 @@ func recordTenantBytes(counter *Int64Counter, tenantID, surface, action, directi
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
 		Attr("surface", cleanMetricValue(surface, "other")),
 		Attr("action", cleanMetricValue(action, "other")),
+		Attr("direction", cleanMetricValue(direction, "unknown")),
+	)
+}
+
+func recordTenantHTTPBytes(tenantID, surface, direction string, bytes int64) {
+	if bytes <= 0 {
+		return
+	}
+	RegisterModule("tenant_usage")
+	tenantHTTPBytes.Add(bytes,
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("surface", cleanMetricValue(surface, "other")),
 		Attr("direction", cleanMetricValue(direction, "unknown")),
 	)
 }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -68,7 +68,7 @@ var fuseRemoteOperationsTotal = fuseMeter.Int64Counter("drive9_fuse_remote_opera
 var fuseRemoteOperationDuration = fuseMeter.Float64Histogram("drive9_fuse_remote_operation_duration_seconds", "Remote FUSE operation duration histogram", operationDurationBounds)
 var fuseRemoteOperationBytes = fuseMeter.Int64Counter("drive9_fuse_remote_operation_bytes_total", "Bytes processed by remote FUSE operation/result")
 
-var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/surface/result/status_class")
+var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/surface/action/result/status_class")
 var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_duration_seconds", "Tenant request duration histogram by surface/status_class", httpDurationBounds)
 var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/surface/action")
 var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/surface/direction")
@@ -286,11 +286,13 @@ func RecordHTTPRequestCount(method, route string, status int) {
 func RecordTenantRequestCount(tenantID, surface, action, result string, status int) {
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	surface = cleanMetricValue(surface, "other")
+	action = cleanMetricValue(action, "other")
 	result = cleanMetricValue(result, "unknown")
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
 		Attr("tenant_id", tenantID),
 		Attr("surface", surface),
+		Attr("action", action),
 		Attr("result", result),
 		Attr("status_class", statusClass(status)),
 	}
@@ -328,6 +330,7 @@ func RecordTenantEvent(tenantID, event string, labels ...string) {
 func RecordTenantRequest(tenantID, surface, action, result string, status int, d time.Duration) {
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	surface = cleanMetricValue(surface, "other")
+	action = cleanMetricValue(action, "other")
 	result = cleanMetricValue(result, "unknown")
 	statusClass := "unknown"
 	if status > 0 {
@@ -337,6 +340,7 @@ func RecordTenantRequest(tenantID, surface, action, result string, status int, d
 	attrs := []Attribute{
 		Attr("tenant_id", tenantID),
 		Attr("surface", surface),
+		Attr("action", action),
 		Attr("result", result),
 		Attr("status_class", statusClass),
 	}

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -44,7 +44,7 @@ var sseMeter = globalMeterProvider.Meter("sse")
 var tenantMeter = globalMeterProvider.Meter("tenant")
 
 var serviceOperationsTotal = serviceMeter.Int64Counter("drive9_service_operations_total", "Service operations by component/operation/result")
-var serviceOperationDuration = serviceMeter.Float64Histogram("drive9_service_operation_duration_seconds", "Service operation duration histogram", operationDurationBounds)
+var serviceOperationDuration = serviceMeter.Float64Histogram("drive9_service_operation_duration_seconds", "Service operation duration histogram by component/operation/result", operationDurationBounds)
 var serviceGauge = serviceMeter.Float64Gauge("drive9_service_gauge", "Service gauges by component/name")
 var tenantPoolMetadataResumeWaitTotal = serviceMeter.Int64Counter("drive9_tenant_pool_metadata_resume_wait_total", "Tenant pool metadata resume wait attempts by pool_id/organization_id/scope/result")
 var tenantPoolMetadataResumeWaitDuration = serviceMeter.Float64Histogram("drive9_tenant_pool_metadata_resume_wait_duration_seconds", "Tenant pool metadata resume wait duration by pool_id/organization_id/scope/result", tenantPoolMetadataResumeWaitDurationBounds)
@@ -69,7 +69,7 @@ var fuseRemoteOperationDuration = fuseMeter.Float64Histogram("drive9_fuse_remote
 var fuseRemoteOperationBytes = fuseMeter.Int64Counter("drive9_fuse_remote_operation_bytes_total", "Bytes processed by remote FUSE operation/result")
 
 var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/surface/action/result/status/status_class")
-var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_duration_seconds", "Tenant-scoped request duration histogram", httpDurationBounds)
+var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_duration_seconds", "Tenant request duration histogram by surface/action/result/status_class", httpDurationBounds)
 var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/surface/action")
 var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/surface/action/direction")
 var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/surface/action/direction")
@@ -90,7 +90,7 @@ var sseHeartbeatsSentTotal = sseMeter.Int64Counter("drive9_sse_heartbeats_sent_t
 // Event-bus query instruments. Covers all fs_events DB reads (events_since,
 // poll, latest, oldest) so DB pressure and table growth on the events path
 // are observable without direct DB access.
-var eventBusQueryDuration = serviceMeter.Float64Histogram("drive9_event_bus_query_duration_seconds", "Event-bus fs_events query duration by operation/result/tenant_id", eventBusQueryDurationBounds)
+var eventBusQueryDuration = serviceMeter.Float64Histogram("drive9_event_bus_query_duration_seconds", "Event-bus fs_events query duration by operation/result", eventBusQueryDurationBounds)
 var eventBusPollFailuresTotal = sseMeter.Int64Counter("drive9_event_bus_poll_failures_total", "Event-bus cross-pod poll query failures by tenant_id")
 var eventBusPublishErrorsTotal = sseMeter.Int64Counter("drive9_event_bus_publish_errors_total", "Event-bus fs_events INSERT failures by tenant_id")
 
@@ -132,19 +132,7 @@ func RecordTenantOperation(tenantID, component, operation, result string, d time
 		return
 	}
 	durationAttrs := baseAttrs[:3]
-	if tenantID != "unknown" && serviceOperationDurationIncludesTenant(component) {
-		durationAttrs = baseAttrs[:4]
-	}
 	serviceOperationDuration.Observe(d.Seconds(), durationAttrs...)
-}
-
-func serviceOperationDurationIncludesTenant(component string) bool {
-	switch component {
-	case "file_gc", "quota_config_cache", "server_quota", "user_db_access":
-		return false
-	default:
-		return true
-	}
 }
 
 func RecordTenantPoolMetadataResumeWait(poolID, organizationID, scope, result string, d time.Duration) {
@@ -368,7 +356,12 @@ func RecordTenantRequest(tenantID, surface, action, result string, status int, d
 	if d <= 0 {
 		return
 	}
-	tenantRequestDuration.Observe(d.Seconds(), attrs...)
+	tenantRequestDuration.Observe(d.Seconds(),
+		Attr("surface", surface),
+		Attr("action", action),
+		Attr("result", result),
+		Attr("status_class", statusClass),
+	)
 }
 
 func RecordTenantHTTPBytes(tenantID, surface, action, direction string, bytes int64) {
@@ -381,11 +374,16 @@ func RecordTenantFileBytes(tenantID, surface, action, direction string, bytes in
 
 func RecordTenantInFlight(tenantID, surface, action string, value float64) {
 	RegisterModule("tenant_usage")
-	tenantInflight.Set(value,
+	attrs := []Attribute{
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
 		Attr("surface", cleanMetricValue(surface, "other")),
 		Attr("action", cleanMetricValue(action, "other")),
-	)
+	}
+	if value <= 0 {
+		tenantInflight.Delete(attrs...)
+		return
+	}
+	tenantInflight.Set(value, attrs...)
 }
 
 func RecordTenantStorageBytes(tenantID, state string, bytes int64) {
@@ -519,7 +517,6 @@ func RecordEventBusQuery(tenantID, operation, result string, d time.Duration) {
 	}
 	RegisterModule("sse")
 	eventBusQueryDuration.Observe(d.Seconds(),
-		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
 		Attr("operation", cleanMetricValue(operation, "unknown")),
 		Attr("result", cleanMetricValue(result, "unknown")),
 	)

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -69,10 +69,10 @@ func TestRecordTenantOperationZeroDurationDoesNotRecordDuration(t *testing.T) {
 	}
 }
 
-func TestRecordTenantOperationOmitsTenantFromSelectedDurationHistograms(t *testing.T) {
+func TestRecordTenantOperationOmitsTenantFromDurationHistograms(t *testing.T) {
 	const operation = "duration_tenant_omit_test_operation"
 
-	for _, component := range []string{"file_gc", "quota_config_cache", "server_quota", "user_db_access"} {
+	for _, component := range []string{"backend", "central_quota", "file_gc", "quota_config_cache", "server_quota", "user_db_access", "vault"} {
 		t.Run(component, func(t *testing.T) {
 			tenantID := "tenant-duration-omit-" + component
 			RecordTenantOperation(tenantID, component, operation, "ok", time.Second)
@@ -93,20 +93,27 @@ func TestRecordTenantOperationOmitsTenantFromSelectedDurationHistograms(t *testi
 	}
 }
 
-func TestRecordTenantOperationKeepsTenantOnBackendDurationHistogram(t *testing.T) {
+func TestRecordTenantRequestDurationOmitsTenantAndStatus(t *testing.T) {
 	const (
-		tenantID  = "tenant-duration-backend"
-		component = "backend"
-		operation = "duration_tenant_keep_test_operation"
+		tenantID = "tenant-request-duration-omit"
+		surface  = "request_duration_surface"
+		action   = "request_duration_action"
 	)
 
-	RecordTenantOperation(tenantID, component, operation, "ok", time.Second)
+	RecordTenantRequest(tenantID, surface, action, "ok", 201, time.Second)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="`+tenantID+`"} 1`) {
-		t.Fatalf("backend duration histogram should keep tenant_id:\n%s", text)
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="`+action+`",result="ok",status="201",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`"} 1`) {
+		t.Fatalf("missing tenant-scoped request total:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_count{action="`+action+`",result="ok",status_class="2xx",surface="`+surface+`"} 1`) {
+		t.Fatalf("missing tenant-omitted request duration histogram:\n%s", text)
+	}
+	if strings.Contains(text, `drive9_tenant_request_duration_seconds_count{action="`+action+`",result="ok",status="201"`) ||
+		strings.Contains(text, `drive9_tenant_request_duration_seconds_count{action="`+action+`",result="ok",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`"}`) {
+		t.Fatalf("request duration histogram unexpectedly carried status or tenant_id:\n%s", text)
 	}
 }
 
@@ -159,6 +166,46 @@ func TestRecordTenantDurationMetricsSkipZeroDuration(t *testing.T) {
 	}
 	if strings.Contains(text, `drive9_event_bus_query_duration_seconds_count{operation="events_since",result="ok",tenant_id="`+eventBusTenant+`"}`) {
 		t.Fatalf("zero-duration event bus query unexpectedly recorded a duration:\n%s", text)
+	}
+}
+
+func TestRecordEventBusQueryDurationOmitsTenant(t *testing.T) {
+	const tenantID = "tenant-event-bus-duration-omit"
+
+	RecordEventBusQuery(tenantID, "event_bus_duration_omit", "ok", time.Second)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_event_bus_query_duration_seconds_count{operation="event_bus_duration_omit",result="ok"} 1`) {
+		t.Fatalf("missing tenant-omitted event bus duration:\n%s", text)
+	}
+	if strings.Contains(text, `drive9_event_bus_query_duration_seconds_count{operation="event_bus_duration_omit",result="ok",tenant_id="`+tenantID+`"}`) {
+		t.Fatalf("event bus duration unexpectedly carried tenant_id:\n%s", text)
+	}
+}
+
+func TestRecordTenantInFlightDeletesZeroValue(t *testing.T) {
+	const (
+		tenantID = "tenant-inflight-delete"
+		surface  = "inflight_delete_surface"
+		action   = "inflight_delete_action"
+	)
+
+	RecordTenantInFlight(tenantID, surface, action, 1)
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_tenant_inflight_requests{action="`+action+`",surface="`+surface+`",tenant_id="`+tenantID+`"} 1.000000`) {
+		t.Fatalf("missing tenant in-flight gauge:\n%s", text)
+	}
+
+	RecordTenantInFlight(tenantID, surface, action, 0)
+	rec = httptest.NewRecorder()
+	WritePrometheus(rec)
+	text = rec.Body.String()
+	if strings.Contains(text, `drive9_tenant_inflight_requests{action="`+action+`",surface="`+surface+`",tenant_id="`+tenantID+`"}`) {
+		t.Fatalf("tenant in-flight gauge should be deleted at zero:\n%s", text)
 	}
 }
 

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -105,14 +105,13 @@ func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_requests_total{result="ok",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`"} 1`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="`+action+`",result="ok",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`"} 1`) {
 		t.Errorf("missing tenant-scoped request total:\n%s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_count{status_class="2xx",surface="`+surface+`"} 1`) {
 		t.Errorf("missing reduced request duration histogram:\n%s", text)
 	}
 	for _, unexpected := range []string{
-		`drive9_tenant_requests_total{action="` + action + `"`,
 		`drive9_tenant_requests_total{result="ok",status="201"`,
 		`drive9_tenant_request_duration_seconds_count{action="` + action + `"`,
 		`drive9_tenant_request_duration_seconds_count{result="ok"`,
@@ -132,7 +131,7 @@ func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_requests_total{result="ok",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`"} 1`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="zero_action",result="ok",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`"} 1`) {
 		t.Errorf("missing zero-duration tenant request total:\n%s", text)
 	}
 	if strings.Contains(text, `drive9_tenant_request_duration_seconds_count{surface="zero_surface"`) {

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -93,7 +93,7 @@ func TestRecordTenantOperationOmitsTenantFromDurationHistograms(t *testing.T) {
 	}
 }
 
-func TestRecordTenantRequestDurationOmitsTenantAndStatus(t *testing.T) {
+func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 	const (
 		tenantID = "tenant-request-duration-omit"
 		surface  = "request_duration_surface"
@@ -105,15 +105,22 @@ func TestRecordTenantRequestDurationOmitsTenantAndStatus(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_requests_total{action="`+action+`",result="ok",status="201",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`"} 1`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{result="ok",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`"} 1`) {
 		t.Fatalf("missing tenant-scoped request total:\n%s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_count{action="`+action+`",result="ok",status_class="2xx",surface="`+surface+`"} 1`) {
-		t.Fatalf("missing tenant-omitted request duration histogram:\n%s", text)
+	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_count{status_class="2xx",surface="`+surface+`"} 1`) {
+		t.Fatalf("missing reduced request duration histogram:\n%s", text)
 	}
-	if strings.Contains(text, `drive9_tenant_request_duration_seconds_count{action="`+action+`",result="ok",status="201"`) ||
-		strings.Contains(text, `drive9_tenant_request_duration_seconds_count{action="`+action+`",result="ok",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`"}`) {
-		t.Fatalf("request duration histogram unexpectedly carried status or tenant_id:\n%s", text)
+	for _, unexpected := range []string{
+		`drive9_tenant_requests_total{action="` + action + `"`,
+		`drive9_tenant_requests_total{result="ok",status="201"`,
+		`drive9_tenant_request_duration_seconds_count{action="` + action + `"`,
+		`drive9_tenant_request_duration_seconds_count{result="ok"`,
+		`drive9_tenant_request_duration_seconds_count{status_class="2xx",surface="` + surface + `",tenant_id="` + tenantID + `"`,
+	} {
+		if strings.Contains(text, unexpected) {
+			t.Fatalf("tenant request metric unexpectedly carried high-cardinality label %q:\n%s", unexpected, text)
+		}
 	}
 }
 
@@ -125,10 +132,10 @@ func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_requests_total{action="zero_action",result="ok",status="200",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`"} 1`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{result="ok",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`"} 1`) {
 		t.Fatalf("missing zero-duration tenant request total:\n%s", text)
 	}
-	if strings.Contains(text, `drive9_tenant_request_duration_seconds_count{action="zero_action",result="ok",status="200",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`"}`) {
+	if strings.Contains(text, `drive9_tenant_request_duration_seconds_count{surface="zero_surface"`) {
 		t.Fatalf("zero-duration tenant request unexpectedly recorded a duration:\n%s", text)
 	}
 }

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -106,10 +106,10 @@ func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 	WritePrometheus(rec)
 	text := rec.Body.String()
 	if !strings.Contains(text, `drive9_tenant_requests_total{result="ok",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`"} 1`) {
-		t.Fatalf("missing tenant-scoped request total:\n%s", text)
+		t.Errorf("missing tenant-scoped request total:\n%s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_count{status_class="2xx",surface="`+surface+`"} 1`) {
-		t.Fatalf("missing reduced request duration histogram:\n%s", text)
+		t.Errorf("missing reduced request duration histogram:\n%s", text)
 	}
 	for _, unexpected := range []string{
 		`drive9_tenant_requests_total{action="` + action + `"`,
@@ -119,7 +119,7 @@ func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 		`drive9_tenant_request_duration_seconds_count{status_class="2xx",surface="` + surface + `",tenant_id="` + tenantID + `"`,
 	} {
 		if strings.Contains(text, unexpected) {
-			t.Fatalf("tenant request metric unexpectedly carried high-cardinality label %q:\n%s", unexpected, text)
+			t.Errorf("tenant request metric unexpectedly carried high-cardinality label %q:\n%s", unexpected, text)
 		}
 	}
 }
@@ -133,10 +133,10 @@ func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
 	WritePrometheus(rec)
 	text := rec.Body.String()
 	if !strings.Contains(text, `drive9_tenant_requests_total{result="ok",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`"} 1`) {
-		t.Fatalf("missing zero-duration tenant request total:\n%s", text)
+		t.Errorf("missing zero-duration tenant request total:\n%s", text)
 	}
 	if strings.Contains(text, `drive9_tenant_request_duration_seconds_count{surface="zero_surface"`) {
-		t.Fatalf("zero-duration tenant request unexpectedly recorded a duration:\n%s", text)
+		t.Errorf("zero-duration tenant request unexpectedly recorded a duration:\n%s", text)
 	}
 }
 
@@ -185,10 +185,10 @@ func TestRecordEventBusQueryDurationOmitsTenant(t *testing.T) {
 	WritePrometheus(rec)
 	text := rec.Body.String()
 	if !strings.Contains(text, `drive9_event_bus_query_duration_seconds_count{operation="event_bus_duration_omit",result="ok"} 1`) {
-		t.Fatalf("missing tenant-omitted event bus duration:\n%s", text)
+		t.Errorf("missing tenant-omitted event bus duration:\n%s", text)
 	}
 	if strings.Contains(text, `drive9_event_bus_query_duration_seconds_count{operation="event_bus_duration_omit",result="ok",tenant_id="`+tenantID+`"}`) {
-		t.Fatalf("event bus duration unexpectedly carried tenant_id:\n%s", text)
+		t.Errorf("event bus duration unexpectedly carried tenant_id:\n%s", text)
 	}
 }
 
@@ -204,7 +204,7 @@ func TestRecordTenantInFlightDeletesZeroValue(t *testing.T) {
 	WritePrometheus(rec)
 	text := rec.Body.String()
 	if !strings.Contains(text, `drive9_tenant_inflight_requests{action="`+action+`",surface="`+surface+`",tenant_id="`+tenantID+`"} 1.000000`) {
-		t.Fatalf("missing tenant in-flight gauge:\n%s", text)
+		t.Errorf("missing tenant in-flight gauge:\n%s", text)
 	}
 
 	RecordTenantInFlight(tenantID, surface, action, 0)
@@ -212,7 +212,7 @@ func TestRecordTenantInFlightDeletesZeroValue(t *testing.T) {
 	WritePrometheus(rec)
 	text = rec.Body.String()
 	if strings.Contains(text, `drive9_tenant_inflight_requests{action="`+action+`",surface="`+surface+`",tenant_id="`+tenantID+`"}`) {
-		t.Fatalf("tenant in-flight gauge should be deleted at zero:\n%s", text)
+		t.Errorf("tenant in-flight gauge should be deleted at zero:\n%s", text)
 	}
 }
 

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -163,6 +163,13 @@ func (g *Float64Gauge) Set(value float64, attrs ...Attribute) {
 	g.registry.setGauge(g.name, labelsKey(attrs), value)
 }
 
+func (g *Float64Gauge) Delete(attrs ...Attribute) {
+	if g == nil || g.registry == nil {
+		return
+	}
+	g.registry.deleteGauge(g.name, labelsKey(attrs))
+}
+
 func (h *Float64Histogram) Observe(value float64, attrs ...Attribute) {
 	if h == nil || h.registry == nil {
 		return
@@ -274,6 +281,16 @@ func (r *Registry) setGauge(name, labels string, value float64) {
 		panic(fmt.Sprintf("metrics: gauge %s not registered", name))
 	}
 	inst.values[labels] = value
+}
+
+func (r *Registry) deleteGauge(name, labels string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inst := r.gauges[name]
+	if inst == nil {
+		panic(fmt.Sprintf("metrics: gauge %s not registered", name))
+	}
+	delete(inst.values, labels)
 }
 
 func (r *Registry) observeHistogram(name, labels string, value float64) {

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -288,7 +288,7 @@ func (r *Registry) deleteGauge(name, labels string) {
 	defer r.mu.Unlock()
 	inst := r.gauges[name]
 	if inst == nil {
-		panic(fmt.Sprintf("metrics: gauge %s not registered", name))
+		return
 	}
 	delete(inst.values, labels)
 }

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2236,7 +2236,7 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `drive9_db_pool_registered{role="user"`) {
 		t.Fatalf("expected user db pool metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_requests_total{result="ok",status_class="2xx",surface="fs",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="write",result="ok",status_class="2xx",surface="fs",tenant_id="local"}`) {
 		t.Errorf("expected tenant request usage metric in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_bucket{status_class="2xx",surface="fs",le="0.1"}`) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2239,11 +2239,11 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `drive9_tenant_requests_total{action="write",result="ok",status="200",status_class="2xx",surface="fs",tenant_id="local"}`) {
 		t.Fatalf("expected tenant request usage metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_bucket{action="read",result="ok",status="200",status_class="2xx",surface="fs",tenant_id="local",le="0.1"}`) {
+	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_bucket{action="read",result="ok",status_class="2xx",surface="fs",le="0.1"}`) {
 		t.Fatalf("expected tenant request duration usage metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_inflight_requests{action="read",surface="fs",tenant_id="local"} 0.000000`) {
-		t.Fatalf("expected tenant in-flight usage metric in response: %s", text)
+	if strings.Contains(text, `drive9_tenant_inflight_requests{action="read",surface="fs",tenant_id="local"}`) {
+		t.Fatalf("completed tenant in-flight usage metric should be removed: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_http_bytes_total{action="write",direction="request",surface="fs",tenant_id="local"}`) {
 		t.Fatalf("expected tenant HTTP byte metric in response: %s", text)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2236,17 +2236,20 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `drive9_db_pool_registered{role="user"`) {
 		t.Fatalf("expected user db pool metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_requests_total{action="write",result="ok",status="200",status_class="2xx",surface="fs",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{result="ok",status_class="2xx",surface="fs",tenant_id="local"}`) {
 		t.Fatalf("expected tenant request usage metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_bucket{action="read",result="ok",status_class="2xx",surface="fs",le="0.1"}`) {
+	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_bucket{status_class="2xx",surface="fs",le="0.1"}`) {
 		t.Fatalf("expected tenant request duration usage metric in response: %s", text)
 	}
 	if strings.Contains(text, `drive9_tenant_inflight_requests{action="read",surface="fs",tenant_id="local"}`) {
 		t.Fatalf("completed tenant in-flight usage metric should be removed: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_http_bytes_total{action="write",direction="request",surface="fs",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_tenant_http_bytes_total{direction="request",surface="fs",tenant_id="local"}`) {
 		t.Fatalf("expected tenant HTTP byte metric in response: %s", text)
+	}
+	if strings.Contains(text, `drive9_tenant_http_bytes_total{action="`) {
+		t.Fatalf("tenant HTTP byte metric should not carry action: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="write",direction="write",surface="fs",tenant_id="local"}`) {
 		t.Fatalf("expected tenant file write byte metric in response: %s", text)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2237,19 +2237,19 @@ func TestMetricsEndpoint(t *testing.T) {
 		t.Fatalf("expected user db pool metric in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_requests_total{result="ok",status_class="2xx",surface="fs",tenant_id="local"}`) {
-		t.Fatalf("expected tenant request usage metric in response: %s", text)
+		t.Errorf("expected tenant request usage metric in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_bucket{status_class="2xx",surface="fs",le="0.1"}`) {
-		t.Fatalf("expected tenant request duration usage metric in response: %s", text)
+		t.Errorf("expected tenant request duration usage metric in response: %s", text)
 	}
 	if strings.Contains(text, `drive9_tenant_inflight_requests{action="read",surface="fs",tenant_id="local"}`) {
-		t.Fatalf("completed tenant in-flight usage metric should be removed: %s", text)
+		t.Errorf("completed tenant in-flight usage metric should be removed: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_http_bytes_total{direction="request",surface="fs",tenant_id="local"}`) {
-		t.Fatalf("expected tenant HTTP byte metric in response: %s", text)
+		t.Errorf("expected tenant HTTP byte metric in response: %s", text)
 	}
 	if strings.Contains(text, `drive9_tenant_http_bytes_total{action="`) {
-		t.Fatalf("tenant HTTP byte metric should not carry action: %s", text)
+		t.Errorf("tenant HTTP byte metric should not carry action: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="write",direction="write",surface="fs",tenant_id="local"}`) {
 		t.Fatalf("expected tenant file write byte metric in response: %s", text)

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -367,7 +367,10 @@ func TestVaultMetricsExposed(t *testing.T) {
 	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"vault\",operation=\"read_secret\",result=\"ok\",tenant_id=\"") {
 		t.Fatalf("metrics missing vault service operation counter: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\",tenant_id=\"") {
+	if !strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
 		t.Fatalf("metrics missing vault service duration histogram: %s", metricsText)
+	}
+	if strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\",tenant_id=\"") {
+		t.Fatalf("vault service duration histogram should not carry tenant_id: %s", metricsText)
 	}
 }

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -365,12 +365,12 @@ func TestVaultMetricsExposed(t *testing.T) {
 		t.Fatalf("metrics missing vault module availability: %s", metricsText)
 	}
 	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"vault\",operation=\"read_secret\",result=\"ok\",tenant_id=\"") {
-		t.Fatalf("metrics missing vault service operation counter: %s", metricsText)
+		t.Errorf("metrics missing vault service operation counter: %s", metricsText)
 	}
 	if !strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
-		t.Fatalf("metrics missing vault service duration histogram: %s", metricsText)
+		t.Errorf("metrics missing vault service duration histogram: %s", metricsText)
 	}
 	if strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\",tenant_id=\"") {
-		t.Fatalf("vault service duration histogram should not carry tenant_id: %s", metricsText)
+		t.Errorf("vault service duration histogram should not carry tenant_id: %s", metricsText)
 	}
 }


### PR DESCRIPTION
## Summary
- Remove tenant fanout from high-cardinality duration histograms while keeping tenant attribution on counters that alerts use:
  - `drive9_tenant_request_duration_seconds` now uses only `surface/status_class`.
  - `drive9_service_operation_duration_seconds` now uses `component/operation/result` only.
  - `drive9_event_bus_query_duration_seconds` now uses `operation/result` only.
- Reduce tenant usage counter fanout without losing request action breakdown:
  - `drive9_tenant_requests_total` now uses `tenant_id/surface/action/result/status_class` and drops only raw `status`.
  - `drive9_tenant_http_bytes_total` now uses `tenant_id/surface/direction` and drops `action`.
- Keep tenant attribution on alert-sensitive counters such as `drive9_tenant_requests_total` and `drive9_service_operations_total`.
- Add gauge deletion support and remove `drive9_tenant_inflight_requests` labelsets when their value returns to zero, so completed tenant/action combinations no longer remain exported as zero-valued series.
- Update the tenant usage Grafana dashboard and metric contract docs for the reduced labels.

## Expected impact
- `drive9_tenant_request_duration_seconds_bucket` should no longer scale with tenant count or action/result/raw-status fanout. The observed `73283 / 3857 = 19` bucket fanout collapses to `surface/status_class` labelsets.
- `drive9_tenant_request_duration_seconds_count` and `_sum` collapse to the same reduced `surface/status_class` labelsets.
- `drive9_tenant_requests_total` should shrink by removing raw `status` while preserving `tenant_id/surface/action/result/status_class` request analysis and tenant/surface/action error alerts.
- `drive9_tenant_http_bytes_total` should shrink by removing action fanout.
- `drive9_service_operation_duration_seconds_bucket` and `drive9_event_bus_query_duration_seconds_bucket` stop multiplying by tenant IDs.
- `drive9_tenant_inflight_requests` should only expose currently active tenant request combinations, not historical zero values.

## Alert compatibility
- Existing Drive9 alerts keep working for tenant error rate and quota/service operation counters because `tenant_id`, `surface`, `action`, `result`, and `status_class` remain where those alerts need them.
- `Drive9BackendUploadLatencyP95High` must be updated in runbooks because it used `tenant_id` on `drive9_service_operation_duration_seconds_bucket`; this is handled in a separate runbooks PR.

## Validation
- `go test ./pkg/metrics -run 'TestRecordTenantOperation|TestRecordTenantRequest|TestRecordEventBusQuery|TestRecordTenantInFlight|TestRecordTenantDurationMetricsSkipZeroDuration|TestRecordOperationIncludesLongAdminTenantPoolUpdateBuckets' -count=1`
- `make test TEST_PKGS='./pkg/server' TEST_RUN='TestMetricsEndpoint|TestVaultMetricsExposed|TestUploadActionMetrics|TestTenantInFlight'`
- `go test ./pkg/metrics -count=1`
- `jq empty docs/grafana/drive9-tenant-usage-dashboard.json`
- `make lint`
- `git diff --check`