### PR TITLE
e2e: relax provision status check to accept active for pool tenants

### DIFF
--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -243,7 +243,7 @@ TENANT_ID=$(printf '%s' "$body" | jq -r '.tenant_id // empty')
 INIT_STATUS=$(printf '%s' "$body" | jq -r '.status // empty')
 check_cmd "response contains tenant_id" test -n "$TENANT_ID"
 check_cmd "response contains api_key" test -n "$API_KEY"
-check_cmd "provision response status is provisioning or active" bash -c 'case "$1" in provisioning|active) exit 0;; *) exit 1;; esac' _ "$INIT_STATUS"
+check_cmd "provision response status is provisioning or active (got=$INIT_STATUS)" bash -c 'case "$1" in provisioning|active) exit 0;; *) exit 1;; esac' _ "$INIT_STATUS"
 check_cmd "provision response contains api_key, status, tenant_id" bash -c "echo \"\$1\" | jq -e '.api_key and .status and .tenant_id' >/dev/null" _ "$body"
 
 step "2" "Poll tenant status via /v1/status"

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -243,7 +243,7 @@ TENANT_ID=$(printf '%s' "$body" | jq -r '.tenant_id // empty')
 INIT_STATUS=$(printf '%s' "$body" | jq -r '.status // empty')
 check_cmd "response contains tenant_id" test -n "$TENANT_ID"
 check_cmd "response contains api_key" test -n "$API_KEY"
-check_eq "provision response status is provisioning" "$INIT_STATUS" "provisioning"
+check_cmd "provision response status is provisioning or active" bash -c 'case "$1" in provisioning|active) exit 0;; *) exit 1;; esac' _ "$INIT_STATUS"
 check_cmd "provision response contains api_key, status, tenant_id" bash -c "echo \"\$1\" | jq -e '.api_key and .status and .tenant_id' >/dev/null" _ "$body"
 
 step "2" "Poll tenant status via /v1/status"

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -206,7 +206,7 @@ CREATE_STATUS="$(printf '%s' "$create_out" | jq -r '.status // empty')"
 
 check_cmd "response contains tenant_id" test -n "$TENANT_ID"
 check_cmd "response contains api_key" test -n "$API_KEY"
-check_eq "provision status is provisioning" "$CREATE_STATUS" "provisioning"
+check_cmd "provision status is provisioning or active" bash -c 'case "$1" in provisioning|active) exit 0;; *) exit 1;; esac' _ "$CREATE_STATUS"
 CREATED=1
 
 # ── [2] wait tenant active ──────────────────────────────────────────────────

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -206,7 +206,7 @@ CREATE_STATUS="$(printf '%s' "$create_out" | jq -r '.status // empty')"
 
 check_cmd "response contains tenant_id" test -n "$TENANT_ID"
 check_cmd "response contains api_key" test -n "$API_KEY"
-check_cmd "provision status is provisioning or active" bash -c 'case "$1" in provisioning|active) exit 0;; *) exit 1;; esac' _ "$CREATE_STATUS"
+check_cmd "provision status is provisioning or active (got=$CREATE_STATUS)" bash -c 'case "$1" in provisioning|active) exit 0;; *) exit 1;; esac' _ "$CREATE_STATUS"
 CREATED=1
 
 # ── [2] wait tenant active ──────────────────────────────────────────────────


### PR DESCRIPTION
When /v1/provision claims a pre-provisioned pool tenant that is already active (schema init completed), the API returns status=active instead of provisioning. This PR updates the e2e smoke tests to accept both statuses.

- `e2e/api-smoke-test.sh`: relax check from strict `provisioning` to `provisioning|active`
- `e2e/native-smoke-test.sh`: same

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated provisioning smoke tests to accept tenants entering either `provisioning` or `active` status after creation.
  * Preserved validation of all other provisioning response fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->