### PR TITLE
Add TiDB Cloud private endpoint host mapping

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -577,6 +577,8 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME default tidb_cloud_native database name (default: tidbcloud_fs)
   DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY optional default TiDB Cloud API public key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY optional default TiDB Cloud API private key for tidb_cloud_native create/delete when caller omits it
+  DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT true|false to use TiDB Cloud private endpoint hosts for tidb_cloud_native
+  DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings used when private endpoint host is absent
   DRIVE9_TENANT_POOL_MAX_SIZE maximum admin tenant pool size (default: %d)
   DRIVE9_TENANT_POOL_REFILL_FREE_RATIO claim-triggered refill runs when active free tenants fall below this ratio (default: %.2f)
   DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -580,6 +580,8 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT true|false to use TiDB Cloud private endpoint hosts for tidb_cloud_native
   DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings (also accepts public_host:private_host);
                                              when set, disables legacy single-host private endpoint overrides
+  DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST legacy tencentcloud private endpoint fallback host, used only when host map is unset
+  DRIVE9_TIDBCLOUD_ALICLOUD_PRIVATE_ENDPOINT_DOMAIN legacy alicloud private endpoint fallback domain, used only when host map is unset
   DRIVE9_TENANT_POOL_MAX_SIZE maximum admin tenant pool size (default: %d)
   DRIVE9_TENANT_POOL_REFILL_FREE_RATIO claim-triggered refill runs when active free tenants fall below this ratio (default: %.2f)
   DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -578,7 +578,8 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY optional default TiDB Cloud API public key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY optional default TiDB Cloud API private key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT true|false to use TiDB Cloud private endpoint hosts for tidb_cloud_native
-  DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings used when private endpoint host is absent
+  DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings (also accepts public_host:private_host);
+                                             when set, disables legacy single-host private endpoint overrides
   DRIVE9_TENANT_POOL_MAX_SIZE maximum admin tenant pool size (default: %d)
   DRIVE9_TENANT_POOL_REFILL_FREE_RATIO claim-triggered refill runs when active free tenants fall below this ratio (default: %.2f)
   DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -3036,7 +3036,7 @@ func observeStoreOp(ctx context.Context, op string, start time.Time, errp *error
 		if shouldLogStoreOpFailure(result) {
 			logger.Error(ctx, "datastore_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
 		} else {
-			logger.Warn(ctx, "datastore_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
+			logger.Warn(ctx, "datastore_op_failed", zap.String("operation", op), zap.String("result", result), zap.String("detail", (*errp).Error()))
 		}
 	}
 	logger.InfoBenchTiming(ctx, "datastore_op_timing",

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2637,6 +2637,9 @@ func (s *Store) CountTenants(ctx context.Context) (out TenantCounts, err error) 
 			COALESCE(SUM(CASE WHEN status = ? THEN 1 ELSE 0 END), 0)
 		FROM tenants
 		WHERE status <> ?`, TenantActive, TenantDeleted).Scan(&out.TotalNonDeleted, &out.Active)
+	if err != nil {
+		err = fmt.Errorf("count tenants: %w", err)
+	}
 	return out, err
 }
 

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -3517,7 +3517,7 @@ func observeMeta(ctx context.Context, op string, start time.Time, errp *error) {
 			// Connection closed during shutdown — suppress the noisy log and
 			// only record the metric below.
 		case "not_found", "duplicate":
-			logger.Warn(ctx, "meta_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
+			logger.Warn(ctx, "meta_op_failed", zap.String("operation", op), zap.String("result", result), zap.String("detail", (*errp).Error()))
 		case "error":
 			logger.Error(ctx, "meta_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
 		}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -90,6 +90,11 @@ type Tenant struct {
 	UpdatedAt          time.Time
 }
 
+type TenantCounts struct {
+	TotalNonDeleted int64
+	Active          int64
+}
+
 type TenantAutoEmbeddingProfile struct {
 	TenantID      string
 	EmbeddingMode string
@@ -2621,6 +2626,18 @@ func (s *Store) ListTenantsByStatus(ctx context.Context, status TenantStatus, li
 	defer func() { _ = rows.Close() }()
 
 	return scanTenantRows(rows)
+}
+
+func (s *Store) CountTenants(ctx context.Context) (out TenantCounts, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "count_tenants", start, &err)
+	err = s.db.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*),
+			COALESCE(SUM(CASE WHEN status = ? THEN 1 ELSE 0 END), 0)
+		FROM tenants
+		WHERE status <> ?`, TenantActive, TenantDeleted).Scan(&out.TotalNonDeleted, &out.Active)
+	return out, err
 }
 
 // ListTenantsByStatusAfter returns one keyset page of tenants after

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -841,6 +841,48 @@ func TestListTenantsByStatus(t *testing.T) {
 	}
 }
 
+func TestCountTenants(t *testing.T) {
+	s := newControlStore(t)
+	now := time.Now().UTC()
+	for _, tc := range []struct {
+		id     string
+		status TenantStatus
+	}{
+		{id: "count-active", status: TenantActive},
+		{id: "count-provisioning", status: TenantProvisioning},
+		{id: "count-failed", status: TenantFailed},
+		{id: "count-deleted", status: TenantDeleted},
+	} {
+		if err := s.InsertTenant(context.Background(), &Tenant{
+			ID:               tc.id,
+			Status:           tc.status,
+			DBHost:           "127.0.0.1",
+			DBPort:           4000,
+			DBUser:           "root",
+			DBPasswordCipher: []byte("cipher"),
+			DBName:           "tenant_db",
+			DBTLS:            true,
+			Provider:         "tidb_zero",
+			SchemaVersion:    1,
+			CreatedAt:        now,
+			UpdatedAt:        now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got, err := s.CountTenants(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TotalNonDeleted != 3 {
+		t.Fatalf("TotalNonDeleted = %d, want 3", got.TotalNonDeleted)
+	}
+	if got.Active != 1 {
+		t.Fatalf("Active = %d, want 1", got.Active)
+	}
+}
+
 func TestListTenantsByStatusAfterKeyset(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC().Truncate(time.Millisecond)

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -876,10 +876,10 @@ func TestCountTenants(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got.TotalNonDeleted != 3 {
-		t.Fatalf("TotalNonDeleted = %d, want 3", got.TotalNonDeleted)
+		t.Errorf("TotalNonDeleted = %d, want 3", got.TotalNonDeleted)
 	}
 	if got.Active != 1 {
-		t.Fatalf("Active = %d, want 1", got.Active)
+		t.Errorf("Active = %d, want 1", got.Active)
 	}
 }
 

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -73,6 +73,7 @@ var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_
 var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/surface/action")
 var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/surface/direction")
 var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/surface/action/direction")
+var tenantCount = tenantMeter.Float64Gauge("drive9_tenant_count", "Tenant count by state")
 var tenantStorageBytes = tenantMeter.Float64Gauge("drive9_tenant_storage_bytes", "Tenant storage bytes by state")
 var tenantMediaFiles = tenantMeter.Float64Gauge("drive9_tenant_media_files", "Tenant media file count by state")
 
@@ -374,6 +375,16 @@ func RecordTenantInFlight(tenantID, surface, action string, value float64) {
 		return
 	}
 	tenantInflight.Set(value, attrs...)
+}
+
+func RecordTenantCount(state string, count int64) {
+	if count < 0 {
+		return
+	}
+	RegisterModule("tenant_usage")
+	tenantCount.Set(float64(count),
+		Attr("state", cleanMetricValue(state, "unknown")),
+	)
 }
 
 func RecordTenantStorageBytes(tenantID, state string, bytes int64) {

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -227,7 +227,7 @@ func TestRecordTenantCountIncludesState(t *testing.T) {
 		`drive9_tenant_count{state="active_test"} 3.000000`,
 	} {
 		if !strings.Contains(text, want) {
-			t.Fatalf("missing tenant count metric %q:\n%s", want, text)
+			t.Errorf("missing tenant count metric %q:\n%s", want, text)
 		}
 	}
 }

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -215,6 +215,23 @@ func TestRecordTenantInFlightDeletesZeroValue(t *testing.T) {
 	}
 }
 
+func TestRecordTenantCountIncludesState(t *testing.T) {
+	RecordTenantCount("total_non_deleted_test", 7)
+	RecordTenantCount("active_test", 3)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	for _, want := range []string{
+		`drive9_tenant_count{state="total_non_deleted_test"} 7.000000`,
+		`drive9_tenant_count{state="active_test"} 3.000000`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing tenant count metric %q:\n%s", want, text)
+		}
+	}
+}
+
 func TestRecordTenantPoolMetadataResumeWaitIncludesPoolAndOrganizationID(t *testing.T) {
 	const poolID = "pool-metadata-resume-metrics-test"
 	const organizationID = "org-metadata-resume-metrics-test"

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -259,6 +259,7 @@ var (
 	tenantPoolMetadataResumeGroupSize         = 10
 	pendingTenantStaleAfter                   = 10 * time.Minute
 	pendingTenantSweepEvery                   = time.Minute
+	tenantCountMetricsInterval                = time.Minute
 	initTiDBTenantSchemaForFTSOnlyProfileFunc = tenantschema.InitTiDBTenantSchemaForFTSOnlyProfileContext
 )
 
@@ -798,6 +799,19 @@ func (s *Server) startLeaderWorkers() {
 	if s.meta != nil {
 		s.replayWorker = backend.StartMutationReplayWorker(tenant.NewMetaQuotaAdapter(s.meta))
 		s.expirySweepWorker = backend.StartExpirySweepWorker(s.meta)
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			ticker := time.NewTicker(tenantCountMetricsInterval)
+			defer ticker.Stop()
+			s.observeTenantCounts(workerCtx)
+			for {
+				select {
+				case <-workerCtx.Done():
+					return
+				case <-ticker.C:
+					s.observeTenantCounts(workerCtx)
+				}
+			}
+		})
 	}
 	// Per-tenant FileGC and quota outbox workers are no longer per-backend
 	// goroutines — they are driven by kicks through the unified tenant worker.

--- a/pkg/server/tenant_metrics.go
+++ b/pkg/server/tenant_metrics.go
@@ -20,7 +20,7 @@ func (s *Server) observeTenantCounts(ctx context.Context) {
 	metrics.RecordOperation("tenant_usage", "count_tenants", result, time.Since(start))
 	if err != nil {
 		if ctx.Err() == nil {
-			logger.Warn(ctx, "tenant_count_metrics_failed", zap.Error(err))
+			logger.Warn(ctx, "tenant_count_metrics_failed", zap.String("detail", err.Error()))
 		}
 		return
 	}

--- a/pkg/server/tenant_metrics.go
+++ b/pkg/server/tenant_metrics.go
@@ -1,0 +1,29 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
+)
+
+func (s *Server) observeTenantCounts(ctx context.Context) {
+	if s.meta == nil {
+		return
+	}
+	start := time.Now()
+	counts, err := s.meta.CountTenants(ctx)
+	result := metrics.ResultForError(err)
+	metrics.RecordOperation("tenant_usage", "count_tenants", result, time.Since(start))
+	if err != nil {
+		if ctx.Err() == nil {
+			logger.Warn(ctx, "tenant_count_metrics_failed", zap.Error(err))
+		}
+		return
+	}
+	metrics.RecordTenantCount("total_non_deleted", counts.TotalNonDeleted)
+	metrics.RecordTenantCount("active", counts.Active)
+}

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1868,19 +1868,6 @@ func parseBranchInfo(raw []byte) (*branchInfo, error) {
 	return &out, nil
 }
 
-func clusterConnectionIncomplete(info *clusterInfo, usePrivate bool, overridePrivateHost string) bool {
-	if info == nil {
-		return true
-	}
-	if usePrivate {
-		if overridePrivateHost != "" {
-			return info.Endpoints.Private.Port == 0 || info.UserPrefix == ""
-		}
-		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || info.UserPrefix == ""
-	}
-	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
-}
-
 func (p *Provisioner) clusterConnectionIncomplete(info *clusterInfo) bool {
 	if info == nil {
 		return true
@@ -1899,19 +1886,6 @@ func (p *Provisioner) clusterProvisionMetadataIncomplete(info *clusterInfo) bool
 		return true
 	}
 	return strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]) == ""
-}
-
-func branchConnectionIncomplete(info *branchInfo, usePrivate bool, overridePrivateHost string) bool {
-	if info == nil {
-		return true
-	}
-	if usePrivate {
-		if overridePrivateHost != "" {
-			return info.Endpoints.Private.Port == 0 || info.UserPrefix == ""
-		}
-		return info.Endpoints.Private.Host == "" || info.Endpoints.Private.Port == 0 || info.UserPrefix == ""
-	}
-	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
 }
 
 func (p *Provisioner) branchConnectionIncomplete(info *branchInfo) bool {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1943,13 +1943,10 @@ func (p *Provisioner) endpointConnectionIncomplete(publicHost, privateHost strin
 	if publicHost == "" {
 		return true
 	}
-	if len(p.privateEndpointHostMap) > 0 {
-		return false
-	}
-	if p.privateEndpointOverrideHost() != "" {
-		return false
-	}
-	return true
+	// TiDB Cloud exposes public/private endpoint host readiness together. Once
+	// public host is visible, an empty private host is a resolution problem:
+	// use the public->private map or fail fast instead of polling indefinitely.
+	return false
 }
 
 func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branchInfo) error {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -26,6 +26,7 @@ import (
 
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/tenant/schema"
 	"go.uber.org/zap"
@@ -40,6 +41,7 @@ const (
 	EnvTiDBCloudNativePublicKey               = "DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY"
 	EnvTiDBCloudNativePrivateKey              = "DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY"
 	EnvTiDBCloudNativeUsePrivateEndpoint      = "DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT"
+	EnvTiDBCloudPrivateEndpointHostMap        = "DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP"
 	EnvTiDBCloudTencentPrivateEndpointHost    = "DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST"
 	EnvTiDBCloudAlicloudPrivateEndpointDomain = "DRIVE9_TIDBCLOUD_ALICLOUD_PRIVATE_ENDPOINT_DOMAIN"
 
@@ -74,10 +76,11 @@ var databaseNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)
 var displayNameCharPattern = regexp.MustCompile(`[^A-Za-z0-9-]`)
 
 var (
-	ensureDatabaseFunc                       = ensureDatabase
-	tidbCloudNativePollInterval              = 5 * time.Second
-	tidbCloudNativeBatchMetadataGroupSize    = 10
-	tidbCloudNativeBatchMetadataPollInterval = 15 * time.Second
+	ensureDatabaseFunc                        = ensureDatabase
+	tidbCloudNativePollInterval               = 5 * time.Second
+	tidbCloudNativeBatchMetadataGroupSize     = 10
+	tidbCloudNativeBatchMetadataPollInterval  = 15 * time.Second
+	tidbCloudNativeMetadataNotReadyAlertAfter = 5 * time.Minute
 )
 
 type Provisioner struct {
@@ -89,6 +92,7 @@ type Provisioner struct {
 	defaultPublicKey            string
 	defaultPrivateKey           string
 	usePrivateEndpoint          bool
+	privateEndpointHostMap      map[string]string
 	tencentPrivateEndpointHost  string
 	alicloudPrivateEndpointHost string
 	client                      *http.Client
@@ -121,14 +125,10 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 		return nil, err
 	}
 	tencentPrivateHost := strings.TrimSpace(os.Getenv(EnvTiDBCloudTencentPrivateEndpointHost))
-	if usePrivate && strings.EqualFold(cloudProvider, cloudProviderTencentCloud) && tencentPrivateHost == "" {
-		return nil, fmt.Errorf("%s is required when %s=true and cloud provider is tencentcloud",
-			EnvTiDBCloudTencentPrivateEndpointHost, EnvTiDBCloudNativeUsePrivateEndpoint)
-	}
 	alicloudPrivateHost := strings.TrimSpace(os.Getenv(EnvTiDBCloudAlicloudPrivateEndpointDomain))
-	if usePrivate && strings.EqualFold(cloudProvider, cloudProviderAliCloud) && alicloudPrivateHost == "" {
-		return nil, fmt.Errorf("%s is required when %s=true and cloud provider is alicloud",
-			EnvTiDBCloudAlicloudPrivateEndpointDomain, EnvTiDBCloudNativeUsePrivateEndpoint)
+	hostMap, err := parsePrivateEndpointHostMap(os.Getenv(EnvTiDBCloudPrivateEndpointHostMap))
+	if err != nil {
+		return nil, err
 	}
 	return &Provisioner{
 		apiURL:                      strings.TrimRight(apiURL, "/"),
@@ -139,6 +139,7 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 		defaultPublicKey:            strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePublicKey)),
 		defaultPrivateKey:           strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePrivateKey)),
 		usePrivateEndpoint:          usePrivate,
+		privateEndpointHostMap:      hostMap,
 		tencentPrivateEndpointHost:  tencentPrivateHost,
 		alicloudPrivateEndpointHost: alicloudPrivateHost,
 		client:                      &http.Client{Timeout: 60 * time.Second},
@@ -298,7 +299,7 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 	if info.ClusterID == "" {
 		return nil, nil, fmt.Errorf("tidbcloud native response missing cluster id")
 	}
-	if clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
+	if p.clusterProvisionMetadataIncomplete(info) {
 		clusterID := info.ClusterID
 		info, err = p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, clusterID)
 		if err != nil {
@@ -311,32 +312,16 @@ func (p *Provisioner) ProvisionWithCredentialsAndQuota(ctx context.Context, tena
 			}, nil, err
 		}
 	}
-	var host string
-	var port int
-	if p.usePrivateEndpoint {
-		overrideHost := p.privateEndpointOverrideHost()
-		if overrideHost != "" {
-			host = overrideHost
-		} else {
-			host = info.Endpoints.Private.Host
-		}
-		port = info.Endpoints.Private.Port
-	} else {
-		host = info.Endpoints.Public.Host
-		port = info.Endpoints.Public.Port
-	}
-	out := &tenant.ClusterInfo{
-		TenantID:       tenantID,
-		ClusterID:      info.ClusterID,
-		OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
-		Host:           host,
-		Port:           port,
-		Password:       password,
-		DBName:         dbName,
-		Provider:       tenant.ProviderTiDBCloudNative,
-	}
-	if info.UserPrefix != "" {
-		out.Username = info.UserPrefix + ".root"
+	out, err := p.clusterInfoFromResponse(tenantID, dbName, password, info)
+	if err != nil {
+		return &tenant.ClusterInfo{
+			TenantID:       tenantID,
+			ClusterID:      info.ClusterID,
+			OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
+			Password:       password,
+			DBName:         dbName,
+			Provider:       tenant.ProviderTiDBCloudNative,
+		}, nil, err
 	}
 	cloudCfg := &tenant.QuotaCloudConfig{
 		Labels: map[string]string{
@@ -454,7 +439,7 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 			errs[i] = fmt.Errorf("tidbcloud native batch response missing cluster id for tenant %q", tenantID)
 			continue
 		}
-		out[i] = p.clusterInfoFromResponse(tenantID, dbName, password, &info)
+		out[i], errs[i] = p.clusterInfoFromResponse(tenantID, dbName, password, &info)
 	}
 	for _, err := range errs {
 		if err != nil {
@@ -524,11 +509,13 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Cont
 		zap.Strings("cluster_ids", sortedClusterIDs(pending)),
 		zap.Strings("tenant_ids", sortedTenantIDs(pending)))
 	pollCount := 0
+	notReadyAlertRecorded := false
 	for len(pending) > 0 {
 		pollCount++
 		seenCount := 0
 		readyCount := 0
 		incompleteClusterIDs := make([]string, 0, len(pending))
+		incompleteReasons := make(map[string]struct{})
 		infos, err := p.listClusterInfosWithCredentials(ctx, publicKey, privateKey, clusterIDs, len(clusterIDs))
 		if err != nil {
 			if !isTiDBCloudStatus(err, http.StatusTooManyRequests) || time.Now().After(deadline) {
@@ -564,11 +551,18 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Cont
 					delete(pending, clusterID)
 					continue
 				}
-				if clusterProvisionMetadataIncomplete(&info, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
+				if p.clusterProvisionMetadataIncomplete(&info) {
 					incompleteClusterIDs = append(incompleteClusterIDs, clusterID)
+					incompleteReasons[p.metadataIncompleteReasonForCluster(&info)] = struct{}{}
 					continue
 				}
-				out[target.index] = p.clusterInfoFromResponse(target.tenantID, target.dbName, target.password, &info)
+				updated, err := p.clusterInfoFromResponse(target.tenantID, target.dbName, target.password, &info)
+				if err != nil {
+					errs[target.index] = err
+					delete(pending, clusterID)
+					continue
+				}
+				out[target.index] = updated
 				delete(pending, clusterID)
 				readyCount++
 			}
@@ -592,6 +586,7 @@ func (p *Provisioner) waitForBatchClusterProvisionMetadataGroup(ctx context.Cont
 			zap.Strings("pending_tenant_ids", sortedTenantIDs(pending)),
 			zap.Strings("incomplete_cluster_ids", incompleteClusterIDs),
 			zap.Duration("elapsed", time.Since(started)))
+		p.recordMetadataNotReadyAlert(ctx, "cluster_batch", "", "", batchMetadataIncompleteReason(seenCount, incompleteReasons), started, &notReadyAlertRecorded)
 		if time.Now().After(deadline) {
 			for clusterID, target := range pending {
 				errs[target.index] = fmt.Errorf("tidbcloud native cluster %s missing connection metadata or organization label before timeout", clusterID)
@@ -687,7 +682,7 @@ func (p *Provisioner) WaitForPoolClusterMetadata(ctx context.Context, cluster *t
 	if err != nil {
 		return nil, err
 	}
-	return p.clusterInfoFromResponse(strings.TrimSpace(cluster.TenantID), dbName, cluster.Password, info), nil
+	return p.clusterInfoFromResponse(strings.TrimSpace(cluster.TenantID), dbName, cluster.Password, info)
 }
 
 func (p *Provisioner) WaitForPoolClustersMetadata(ctx context.Context, clusters []*tenant.ClusterInfo, req tenant.CredentialProvisionRequest) ([]*tenant.ClusterInfo, error) {
@@ -906,7 +901,7 @@ func (p *Provisioner) CreateBranchWithCredentials(ctx context.Context, forkTenan
 		DBName:    dbName,
 		Provider:  tenant.ProviderTiDBCloudNative,
 	}
-	if !branchConnectionIncomplete(branch, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
+	if !p.branchConnectionIncomplete(branch) {
 		if err := p.fillBranchEndpoint(out, branch); err != nil {
 			return out, err
 		}
@@ -1275,6 +1270,9 @@ func (p *Provisioner) regionName() string {
 }
 
 func (p *Provisioner) privateEndpointOverrideHost() string {
+	if len(p.privateEndpointHostMap) > 0 {
+		return ""
+	}
 	switch strings.ToLower(p.cloudProvider) {
 	case cloudProviderTencentCloud:
 		return p.tencentPrivateEndpointHost
@@ -1285,6 +1283,67 @@ func (p *Provisioner) privateEndpointOverrideHost() string {
 	default:
 		return ""
 	}
+}
+
+func (p *Provisioner) mappedPrivateEndpointHost(publicHost string) (string, bool) {
+	if len(p.privateEndpointHostMap) == 0 {
+		return "", false
+	}
+	host, ok := p.privateEndpointHostMap[privateEndpointHostMapKey(publicHost)]
+	if !ok || strings.TrimSpace(host) == "" {
+		return "", false
+	}
+	return host, true
+}
+
+func (p *Provisioner) resolveClusterEndpoint(info *clusterInfo) (string, int, error) {
+	if info == nil {
+		return "", 0, fmt.Errorf("tidbcloud native response missing cluster connection metadata")
+	}
+	if !p.usePrivateEndpoint {
+		return strings.TrimSpace(info.Endpoints.Public.Host), info.Endpoints.Public.Port, nil
+	}
+	host, err := p.resolvePrivateEndpointHost("cluster", info.Endpoints.Public.Host, info.Endpoints.Private.Host)
+	if err != nil {
+		return "", 0, err
+	}
+	return host, info.Endpoints.Private.Port, nil
+}
+
+func (p *Provisioner) resolveBranchEndpoint(branch *branchInfo) (string, int, error) {
+	if branch == nil {
+		return "", 0, fmt.Errorf("tidbcloud native response missing branch connection metadata")
+	}
+	if !p.usePrivateEndpoint {
+		return strings.TrimSpace(branch.Endpoints.Public.Host), branch.Endpoints.Public.Port, nil
+	}
+	host, err := p.resolvePrivateEndpointHost("branch", branch.Endpoints.Public.Host, branch.Endpoints.Private.Host)
+	if err != nil {
+		return "", 0, err
+	}
+	return host, branch.Endpoints.Private.Port, nil
+}
+
+func (p *Provisioner) resolvePrivateEndpointHost(resource, publicHost, privateHost string) (string, error) {
+	if host := strings.TrimSpace(privateHost); host != "" {
+		return host, nil
+	}
+	publicHost = strings.TrimSpace(publicHost)
+	if publicHost != "" {
+		if host, ok := p.mappedPrivateEndpointHost(publicHost); ok {
+			return host, nil
+		}
+	}
+	if len(p.privateEndpointHostMap) == 0 {
+		if host := p.privateEndpointOverrideHost(); host != "" {
+			return host, nil
+		}
+	}
+	metrics.RecordOperation("tidbcloud_native", "private_endpoint_host_lookup", "mapping_missing", 0)
+	if publicHost == "" {
+		return "", fmt.Errorf("tidbcloud native %s private endpoint host is empty and public host is unavailable for %s lookup", resource, EnvTiDBCloudPrivateEndpointHostMap)
+	}
+	return "", fmt.Errorf("tidbcloud native %s private endpoint host is empty and public host %q has no private host mapping in %s", resource, publicHost, EnvTiDBCloudPrivateEndpointHostMap)
 }
 
 func clusterDisplayName(tenantID string) string {
@@ -1385,6 +1444,142 @@ func parseBoolEnv(name string) (bool, error) {
 		return false, nil
 	}
 	return false, fmt.Errorf("%s must be 1/true/yes or 0/false/no, got %q", name, os.Getenv(name))
+}
+
+func parsePrivateEndpointHostMap(raw string) (map[string]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	entries := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ';' || r == '\n'
+	})
+	out := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		key, value, ok := strings.Cut(entry, "=")
+		if !ok {
+			key, value, ok = strings.Cut(entry, ":")
+		}
+		if !ok {
+			return nil, fmt.Errorf("%s entry %q must use public_host=private_host", EnvTiDBCloudPrivateEndpointHostMap, entry)
+		}
+		key = privateEndpointHostMapKey(strings.Trim(strings.TrimSpace(key), `"'`))
+		value = strings.Trim(strings.TrimSpace(value), `"'`)
+		if key == "" || value == "" {
+			return nil, fmt.Errorf("%s entry %q must include both public and private hosts", EnvTiDBCloudPrivateEndpointHostMap, entry)
+		}
+		if prev, exists := out[key]; exists && prev != value {
+			return nil, fmt.Errorf("%s has duplicate public host %q", EnvTiDBCloudPrivateEndpointHostMap, key)
+		}
+		out[key] = value
+	}
+	if len(out) == 0 {
+		return nil, nil
+	}
+	return out, nil
+}
+
+func privateEndpointHostMapKey(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	host = strings.TrimSuffix(host, ".")
+	return host
+}
+
+func (p *Provisioner) metadataIncompleteReasonForCluster(info *clusterInfo) string {
+	if info == nil {
+		return "response_missing"
+	}
+	if strings.TrimSpace(info.UserPrefix) == "" {
+		return "user_prefix_missing"
+	}
+	if !p.usePrivateEndpoint {
+		if strings.TrimSpace(info.Endpoints.Public.Host) == "" {
+			return "public_host_missing"
+		}
+		if info.Endpoints.Public.Port == 0 {
+			return "public_port_missing"
+		}
+		if strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]) == "" {
+			return "organization_label_missing"
+		}
+		return "connection_metadata_missing"
+	}
+	if info.Endpoints.Private.Port == 0 {
+		return "private_port_missing"
+	}
+	if strings.TrimSpace(info.Endpoints.Private.Host) == "" && strings.TrimSpace(info.Endpoints.Public.Host) == "" {
+		return "public_host_missing"
+	}
+	if strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]) == "" {
+		return "organization_label_missing"
+	}
+	return "connection_metadata_missing"
+}
+
+func (p *Provisioner) metadataIncompleteReasonForBranch(info *branchInfo) string {
+	if info == nil {
+		return "response_missing"
+	}
+	if strings.TrimSpace(info.UserPrefix) == "" {
+		return "user_prefix_missing"
+	}
+	if !p.usePrivateEndpoint {
+		if strings.TrimSpace(info.Endpoints.Public.Host) == "" {
+			return "public_host_missing"
+		}
+		if info.Endpoints.Public.Port == 0 {
+			return "public_port_missing"
+		}
+		return "connection_metadata_missing"
+	}
+	if info.Endpoints.Private.Port == 0 {
+		return "private_port_missing"
+	}
+	if strings.TrimSpace(info.Endpoints.Private.Host) == "" && strings.TrimSpace(info.Endpoints.Public.Host) == "" {
+		return "public_host_missing"
+	}
+	return "connection_metadata_missing"
+}
+
+func batchMetadataIncompleteReason(seenCount int, reasons map[string]struct{}) string {
+	if seenCount == 0 {
+		return "cluster_not_seen"
+	}
+	if len(reasons) == 1 {
+		for reason := range reasons {
+			return reason
+		}
+	}
+	if len(reasons) > 1 {
+		return "multiple_missing_fields"
+	}
+	return "metadata_pending"
+}
+
+func (p *Provisioner) recordMetadataNotReadyAlert(ctx context.Context, resource, clusterID, branchID, reason string, started time.Time, recorded *bool) {
+	if recorded == nil || *recorded {
+		return
+	}
+	threshold := tidbCloudNativeMetadataNotReadyAlertAfter
+	if threshold <= 0 || time.Since(started) < threshold {
+		return
+	}
+	*recorded = true
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = "not_ready"
+	}
+	metrics.RecordOperation("tidbcloud_native", "metadata_not_ready_5m", reason, time.Since(started))
+	logger.Warn(ctx, "tidbcloud_native_metadata_not_ready_5m",
+		zap.String("resource", resource),
+		zap.String("cluster_id", strings.TrimSpace(clusterID)),
+		zap.String("branch_id", strings.TrimSpace(branchID)),
+		zap.String("reason", reason),
+		zap.Duration("elapsed", time.Since(started)))
 }
 
 func normalizeDatabaseName(name string) (string, error) {
@@ -1633,28 +1828,18 @@ func compactNonEmptyStrings(values []string) []string {
 	return out
 }
 
-func (p *Provisioner) clusterInfoFromResponse(tenantID, dbName, password string, info *clusterInfo) *tenant.ClusterInfo {
+func (p *Provisioner) clusterInfoFromResponse(tenantID, dbName, password string, info *clusterInfo) (*tenant.ClusterInfo, error) {
 	if info == nil {
 		return &tenant.ClusterInfo{
 			TenantID: tenantID,
 			Password: password,
 			DBName:   dbName,
 			Provider: tenant.ProviderTiDBCloudNative,
-		}
+		}, nil
 	}
-	var host string
-	var port int
-	if p.usePrivateEndpoint {
-		overrideHost := p.privateEndpointOverrideHost()
-		if overrideHost != "" {
-			host = overrideHost
-		} else {
-			host = info.Endpoints.Private.Host
-		}
-		port = info.Endpoints.Private.Port
-	} else {
-		host = info.Endpoints.Public.Host
-		port = info.Endpoints.Public.Port
+	host, port, err := p.resolveClusterEndpoint(info)
+	if err != nil {
+		return nil, err
 	}
 	out := &tenant.ClusterInfo{
 		TenantID:       tenantID,
@@ -1669,7 +1854,7 @@ func (p *Provisioner) clusterInfoFromResponse(tenantID, dbName, password string,
 	if info.UserPrefix != "" {
 		out.Username = info.UserPrefix + ".root"
 	}
-	return out
+	return out, nil
 }
 
 func parseBranchInfo(raw []byte) (*branchInfo, error) {
@@ -1693,8 +1878,33 @@ func clusterConnectionIncomplete(info *clusterInfo, usePrivate bool, overridePri
 	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
 }
 
-func clusterProvisionMetadataIncomplete(info *clusterInfo, usePrivate bool, overridePrivateHost string) bool {
-	if clusterConnectionIncomplete(info, usePrivate, overridePrivateHost) {
+func (p *Provisioner) clusterConnectionIncomplete(info *clusterInfo) bool {
+	if info == nil {
+		return true
+	}
+	if !p.usePrivateEndpoint {
+		return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
+	}
+	if info.Endpoints.Private.Port == 0 || info.UserPrefix == "" {
+		return true
+	}
+	if strings.TrimSpace(info.Endpoints.Private.Host) != "" {
+		return false
+	}
+	if strings.TrimSpace(info.Endpoints.Public.Host) == "" {
+		return true
+	}
+	if _, ok := p.mappedPrivateEndpointHost(info.Endpoints.Public.Host); ok {
+		return false
+	}
+	if len(p.privateEndpointHostMap) == 0 && p.privateEndpointOverrideHost() != "" {
+		return false
+	}
+	return false
+}
+
+func (p *Provisioner) clusterProvisionMetadataIncomplete(info *clusterInfo) bool {
+	if p.clusterConnectionIncomplete(info) {
 		return true
 	}
 	return strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]) == ""
@@ -1713,20 +1923,35 @@ func branchConnectionIncomplete(info *branchInfo, usePrivate bool, overridePriva
 	return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
 }
 
+func (p *Provisioner) branchConnectionIncomplete(info *branchInfo) bool {
+	if info == nil {
+		return true
+	}
+	if !p.usePrivateEndpoint {
+		return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
+	}
+	if info.Endpoints.Private.Port == 0 || info.UserPrefix == "" {
+		return true
+	}
+	if strings.TrimSpace(info.Endpoints.Private.Host) != "" {
+		return false
+	}
+	if strings.TrimSpace(info.Endpoints.Public.Host) == "" {
+		return true
+	}
+	if _, ok := p.mappedPrivateEndpointHost(info.Endpoints.Public.Host); ok {
+		return false
+	}
+	if len(p.privateEndpointHostMap) == 0 && p.privateEndpointOverrideHost() != "" {
+		return false
+	}
+	return false
+}
+
 func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branchInfo) error {
-	var host string
-	var port int
-	if p.usePrivateEndpoint {
-		overrideHost := p.privateEndpointOverrideHost()
-		if overrideHost != "" {
-			host = overrideHost
-		} else {
-			host = branch.Endpoints.Private.Host
-		}
-		port = branch.Endpoints.Private.Port
-	} else {
-		host = branch.Endpoints.Public.Host
-		port = branch.Endpoints.Public.Port
+	host, port, err := p.resolveBranchEndpoint(branch)
+	if err != nil {
+		return err
 	}
 	if branch.UserPrefix != "" {
 		out.Username = branch.UserPrefix + ".root"
@@ -1737,7 +1962,9 @@ func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branch
 }
 
 func (p *Provisioner) waitForClusterProvisionMetadata(ctx context.Context, publicKey, privateKey, clusterID string) (*clusterInfo, error) {
+	started := time.Now()
 	deadline := time.Now().Add(10 * time.Minute)
+	notReadyAlertRecorded := false
 	for {
 		endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s?view=BASIC", p.apiURL, clusterID)
 		resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
@@ -1768,9 +1995,10 @@ func (p *Provisioner) waitForClusterProvisionMetadata(ctx context.Context, publi
 		if err != nil {
 			return nil, err
 		}
-		if !clusterProvisionMetadataIncomplete(info, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
+		if !p.clusterProvisionMetadataIncomplete(info) {
 			return info, nil
 		}
+		p.recordMetadataNotReadyAlert(ctx, "cluster", clusterID, "", p.metadataIncompleteReasonForCluster(info), started, &notReadyAlertRecorded)
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("tidbcloud native cluster %s missing connection metadata or organization label before timeout: %s", clusterID, info.State)
 		}
@@ -1783,7 +2011,9 @@ func (p *Provisioner) waitForClusterProvisionMetadata(ctx context.Context, publi
 }
 
 func (p *Provisioner) waitForBranchActive(ctx context.Context, publicKey, privateKey, clusterID, branchID string) (*branchInfo, error) {
+	started := time.Now()
 	deadline := time.Now().Add(10 * time.Minute)
+	notReadyAlertRecorded := false
 	for {
 		endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s/branches/%s?view=BASIC", p.apiURL, url.PathEscape(clusterID), url.PathEscape(branchID))
 		resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
@@ -1806,9 +2036,14 @@ func (p *Provisioner) waitForBranchActive(ctx context.Context, publicKey, privat
 		if err != nil {
 			return nil, err
 		}
-		if info.State == stateActive && !branchConnectionIncomplete(info, p.usePrivateEndpoint, p.privateEndpointOverrideHost()) {
+		if info.State == stateActive && !p.branchConnectionIncomplete(info) {
 			return info, nil
 		}
+		reason := p.metadataIncompleteReasonForBranch(info)
+		if info.State != stateActive {
+			reason = "state_not_active"
+		}
+		p.recordMetadataNotReadyAlert(ctx, "branch", clusterID, branchID, reason, started, &notReadyAlertRecorded)
 		if time.Now().After(deadline) {
 			return nil, fmt.Errorf("tidbcloud native branch %s not active before timeout: %s", branchID, info.State)
 		}
@@ -1826,7 +2061,9 @@ func (p *Provisioner) WaitForBranchUserWithCredentials(ctx context.Context, clus
 	if publicKey == "" || privateKey == "" {
 		return "", tenant.ErrCredentialsRequired
 	}
+	started := time.Now()
 	deadline := time.Now().Add(10 * time.Minute)
+	notReadyAlertRecorded := false
 	for {
 		endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s/branches/%s?view=BASIC", p.apiURL, url.PathEscape(clusterID), url.PathEscape(branchID))
 		resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
@@ -1852,6 +2089,7 @@ func (p *Provisioner) WaitForBranchUserWithCredentials(ctx context.Context, clus
 		if info.UserPrefix != "" {
 			return info.UserPrefix + ".root", nil
 		}
+		p.recordMetadataNotReadyAlert(ctx, "branch_user", clusterID, branchID, "user_prefix_missing", started, &notReadyAlertRecorded)
 		if time.Now().After(deadline) {
 			return "", fmt.Errorf("tidbcloud native branch %s user prefix not available before timeout", branchID)
 		}

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1270,6 +1270,9 @@ func (p *Provisioner) regionName() string {
 }
 
 func (p *Provisioner) privateEndpointOverrideHost() string {
+	// A non-empty host map is authoritative. Falling back to the legacy
+	// provider-wide host for unmapped public hosts can route clusters from a
+	// different VPC to the wrong private endpoint.
 	if len(p.privateEndpointHostMap) > 0 {
 		return ""
 	}
@@ -1882,25 +1885,13 @@ func (p *Provisioner) clusterConnectionIncomplete(info *clusterInfo) bool {
 	if info == nil {
 		return true
 	}
-	if !p.usePrivateEndpoint {
-		return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
-	}
-	if info.Endpoints.Private.Port == 0 || info.UserPrefix == "" {
-		return true
-	}
-	if strings.TrimSpace(info.Endpoints.Private.Host) != "" {
-		return false
-	}
-	if strings.TrimSpace(info.Endpoints.Public.Host) == "" {
-		return true
-	}
-	if _, ok := p.mappedPrivateEndpointHost(info.Endpoints.Public.Host); ok {
-		return false
-	}
-	if len(p.privateEndpointHostMap) == 0 && p.privateEndpointOverrideHost() != "" {
-		return false
-	}
-	return false
+	return p.endpointConnectionIncomplete(
+		info.Endpoints.Public.Host,
+		info.Endpoints.Private.Host,
+		info.Endpoints.Public.Port,
+		info.Endpoints.Private.Port,
+		info.UserPrefix,
+	)
 }
 
 func (p *Provisioner) clusterProvisionMetadataIncomplete(info *clusterInfo) bool {
@@ -1927,25 +1918,38 @@ func (p *Provisioner) branchConnectionIncomplete(info *branchInfo) bool {
 	if info == nil {
 		return true
 	}
+	return p.endpointConnectionIncomplete(
+		info.Endpoints.Public.Host,
+		info.Endpoints.Private.Host,
+		info.Endpoints.Public.Port,
+		info.Endpoints.Private.Port,
+		info.UserPrefix,
+	)
+}
+
+func (p *Provisioner) endpointConnectionIncomplete(publicHost, privateHost string, publicPort, privatePort int, userPrefix string) bool {
+	publicHost = strings.TrimSpace(publicHost)
+	privateHost = strings.TrimSpace(privateHost)
+	userPrefix = strings.TrimSpace(userPrefix)
 	if !p.usePrivateEndpoint {
-		return info.Endpoints.Public.Host == "" || info.Endpoints.Public.Port == 0 || info.UserPrefix == ""
+		return publicHost == "" || publicPort == 0 || userPrefix == ""
 	}
-	if info.Endpoints.Private.Port == 0 || info.UserPrefix == "" {
+	if privatePort == 0 || userPrefix == "" {
 		return true
 	}
-	if strings.TrimSpace(info.Endpoints.Private.Host) != "" {
+	if privateHost != "" {
 		return false
 	}
-	if strings.TrimSpace(info.Endpoints.Public.Host) == "" {
+	if publicHost == "" {
 		return true
 	}
-	if _, ok := p.mappedPrivateEndpointHost(info.Endpoints.Public.Host); ok {
+	if len(p.privateEndpointHostMap) > 0 {
 		return false
 	}
-	if len(p.privateEndpointHostMap) == 0 && p.privateEndpointOverrideHost() != "" {
+	if p.privateEndpointOverrideHost() != "" {
 		return false
 	}
-	return false
+	return true
 }
 
 func (p *Provisioner) fillBranchEndpoint(out *tenant.ClusterInfo, branch *branchInfo) error {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1672,7 +1672,8 @@ func TestNewProvisionerFromEnvRejectsMalformedPrivateEndpointFlag(t *testing.T) 
 }
 
 func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
-	setPrivateEnv := func(provider string) {
+	setPrivateEnv := func(t *testing.T, provider string) {
+		t.Helper()
 		t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 		t.Setenv(EnvTiDBCloudNativeCloudProvider, provider)
 		t.Setenv(EnvTiDBCloudNativeRegion, "ap-southeast-1")
@@ -1683,7 +1684,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	}
 
 	t.Run("alicloud no startup override required", func(t *testing.T) {
-		setPrivateEnv("alicloud")
+		setPrivateEnv(t, "alicloud")
 		p, err := NewProvisionerFromEnv()
 		if err != nil {
 			t.Fatalf("NewProvisionerFromEnv without alicloud host override: %v", err)
@@ -1694,7 +1695,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	})
 
 	t.Run("alicloud legacy domain fallback", func(t *testing.T) {
-		setPrivateEnv("alicloud")
+		setPrivateEnv(t, "alicloud")
 		t.Setenv(EnvTiDBCloudAlicloudPrivateEndpointDomain, "alicloud.internal")
 		p, err := NewProvisionerFromEnv()
 		if err != nil {
@@ -1706,7 +1707,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	})
 
 	t.Run("tencentcloud no startup override required", func(t *testing.T) {
-		setPrivateEnv("tencentcloud")
+		setPrivateEnv(t, "tencentcloud")
 		p, err := NewProvisionerFromEnv()
 		if err != nil {
 			t.Fatalf("NewProvisionerFromEnv without tencentcloud host override: %v", err)
@@ -1717,7 +1718,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	})
 
 	t.Run("tencentcloud legacy host fallback", func(t *testing.T) {
-		setPrivateEnv("tencentcloud")
+		setPrivateEnv(t, "tencentcloud")
 		t.Setenv(EnvTiDBCloudTencentPrivateEndpointHost, "tencent.internal")
 		p, err := NewProvisionerFromEnv()
 		if err != nil {
@@ -1729,7 +1730,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	})
 
 	t.Run("aws no override required", func(t *testing.T) {
-		setPrivateEnv("aws")
+		setPrivateEnv(t, "aws")
 		p, err := NewProvisionerFromEnv()
 		if err != nil {
 			t.Fatalf("NewProvisionerFromEnv with aws and no override: %v", err)
@@ -1740,7 +1741,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	})
 
 	t.Run("host map", func(t *testing.T) {
-		setPrivateEnv("tencentcloud")
+		setPrivateEnv(t, "tencentcloud")
 		t.Setenv(EnvTiDBCloudPrivateEndpointHostMap, "public-a.example=private-a.internal, public-b.example:private-b.internal")
 		p, err := NewProvisionerFromEnv()
 		if err != nil {
@@ -1774,6 +1775,15 @@ func TestClusterConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	// With tencent override host set, API private host empty is OK
 	if clusterConnectionIncomplete(info, true, "tencent.internal") {
 		t.Fatalf("private mode with override host should report complete even if API private host is empty")
+	}
+
+	p := &Provisioner{usePrivateEndpoint: true}
+	if !p.clusterConnectionIncomplete(info) {
+		t.Fatalf("private mode without host map or legacy override should keep waiting for API private host")
+	}
+	p.privateEndpointHostMap = map[string]string{"other-public.example": "private.internal"}
+	if p.clusterConnectionIncomplete(info) {
+		t.Fatalf("private mode with host map should stop waiting and let endpoint resolution fail fast on an unmapped public host")
 	}
 }
 
@@ -1859,11 +1869,13 @@ func TestProvisionWithCredentialsMapsPublicHostToPrivateEndpoint(t *testing.T) {
 	defer ts.Close()
 
 	p := &Provisioner{
-		apiURL:                 ts.URL,
-		defaultDatabaseName:    DefaultDatabaseName,
-		usePrivateEndpoint:     true,
-		privateEndpointHostMap: map[string]string{"public-a.example": "private-a.internal"},
-		client:                 ts.Client(),
+		apiURL:                      ts.URL,
+		defaultDatabaseName:         DefaultDatabaseName,
+		usePrivateEndpoint:          true,
+		cloudProvider:               cloudProviderAliCloud,
+		alicloudPrivateEndpointHost: "legacy-alicloud.internal",
+		privateEndpointHostMap:      map[string]string{"public-a.example": "private-a.internal"},
+		client:                      ts.Client(),
 	}
 	res, _, err := p.ProvisionWithCredentialsAndQuota(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
 		PublicKey: "public-1", PrivateKey: "private-1",
@@ -1900,11 +1912,13 @@ func TestProvisionWithCredentialsErrorsWhenPrivateHostMappingMissing(t *testing.
 	defer ts.Close()
 
 	p := &Provisioner{
-		apiURL:                 ts.URL,
-		defaultDatabaseName:    DefaultDatabaseName,
-		usePrivateEndpoint:     true,
-		privateEndpointHostMap: map[string]string{"public-a.example": "private-a.internal"},
-		client:                 ts.Client(),
+		apiURL:                      ts.URL,
+		defaultDatabaseName:         DefaultDatabaseName,
+		usePrivateEndpoint:          true,
+		cloudProvider:               cloudProviderAliCloud,
+		alicloudPrivateEndpointHost: "legacy-alicloud.internal",
+		privateEndpointHostMap:      map[string]string{"public-a.example": "private-a.internal"},
+		client:                      ts.Client(),
 	}
 	res, _, err := p.ProvisionWithCredentialsAndQuota(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
 		PublicKey: "public-1", PrivateKey: "private-1",
@@ -1935,6 +1949,15 @@ func TestBranchConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	}
 	if !branchConnectionIncomplete(branch, true, "") {
 		t.Fatalf("private mode should report incomplete when private host is empty")
+	}
+
+	p := &Provisioner{usePrivateEndpoint: true}
+	if !p.branchConnectionIncomplete(branch) {
+		t.Fatalf("private mode without host map or legacy override should keep waiting for API private host")
+	}
+	p.privateEndpointHostMap = map[string]string{"other-public.example": "private.internal"}
+	if p.branchConnectionIncomplete(branch) {
+		t.Fatalf("private mode with host map should stop waiting and let endpoint resolution fail fast on an unmapped public host")
 	}
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1778,12 +1778,8 @@ func TestClusterConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	}
 
 	p := &Provisioner{usePrivateEndpoint: true}
-	if !p.clusterConnectionIncomplete(info) {
-		t.Fatalf("private mode without host map or legacy override should keep waiting for API private host")
-	}
-	p.privateEndpointHostMap = map[string]string{"other-public.example": "private.internal"}
 	if p.clusterConnectionIncomplete(info) {
-		t.Fatalf("private mode with host map should stop waiting and let endpoint resolution fail fast on an unmapped public host")
+		t.Fatalf("private mode should stop waiting once public host, private port, and user prefix are ready")
 	}
 }
 
@@ -1952,12 +1948,8 @@ func TestBranchConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	}
 
 	p := &Provisioner{usePrivateEndpoint: true}
-	if !p.branchConnectionIncomplete(branch) {
-		t.Fatalf("private mode without host map or legacy override should keep waiting for API private host")
-	}
-	p.privateEndpointHostMap = map[string]string{"other-public.example": "private.internal"}
 	if p.branchConnectionIncomplete(branch) {
-		t.Fatalf("private mode with host map should stop waiting and let endpoint resolution fail fast on an unmapped public host")
+		t.Fatalf("private mode should stop waiting once public host, private port, and user prefix are ready")
 	}
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1766,20 +1766,17 @@ func TestClusterConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	info.Endpoints.Private.Host = ""
 	info.Endpoints.Private.Port = 4000
 
-	if clusterConnectionIncomplete(info, false, "") {
+	p := &Provisioner{}
+	if p.clusterConnectionIncomplete(info) {
 		t.Fatalf("public mode should report complete")
 	}
-	if !clusterConnectionIncomplete(info, true, "") {
-		t.Fatalf("private mode should report incomplete when private host is empty")
-	}
-	// With tencent override host set, API private host empty is OK
-	if clusterConnectionIncomplete(info, true, "tencent.internal") {
-		t.Fatalf("private mode with override host should report complete even if API private host is empty")
-	}
-
-	p := &Provisioner{usePrivateEndpoint: true}
+	p.usePrivateEndpoint = true
 	if p.clusterConnectionIncomplete(info) {
 		t.Fatalf("private mode should stop waiting once public host, private port, and user prefix are ready")
+	}
+	info.Endpoints.Public.Host = ""
+	if !p.clusterConnectionIncomplete(info) {
+		t.Fatalf("private mode should keep waiting while public host is empty")
 	}
 }
 
@@ -1940,16 +1937,17 @@ func TestBranchConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	branch.Endpoints.Private.Host = ""
 	branch.Endpoints.Private.Port = 4000
 
-	if branchConnectionIncomplete(branch, false, "") {
+	p := &Provisioner{}
+	if p.branchConnectionIncomplete(branch) {
 		t.Fatalf("public mode should report complete")
 	}
-	if !branchConnectionIncomplete(branch, true, "") {
-		t.Fatalf("private mode should report incomplete when private host is empty")
-	}
-
-	p := &Provisioner{usePrivateEndpoint: true}
+	p.usePrivateEndpoint = true
 	if p.branchConnectionIncomplete(branch) {
 		t.Fatalf("private mode should stop waiting once public host, private port, and user prefix are ready")
+	}
+	branch.Endpoints.Public.Host = ""
+	if !p.branchConnectionIncomplete(branch) {
+		t.Fatalf("private mode should keep waiting while public host is empty")
 	}
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1671,7 +1671,7 @@ func TestNewProvisionerFromEnvRejectsMalformedPrivateEndpointFlag(t *testing.T) 
 	}
 }
 
-func TestNewProvisionerFromEnvRequiresAlicloudPrivateEndpointDomain(t *testing.T) {
+func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	setPrivateEnv := func(provider string) {
 		t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 		t.Setenv(EnvTiDBCloudNativeCloudProvider, provider)
@@ -1679,17 +1679,21 @@ func TestNewProvisionerFromEnvRequiresAlicloudPrivateEndpointDomain(t *testing.T
 		t.Setenv(EnvTiDBCloudNativeUsePrivateEndpoint, "true")
 		t.Setenv(EnvTiDBCloudTencentPrivateEndpointHost, "")
 		t.Setenv(EnvTiDBCloudAlicloudPrivateEndpointDomain, "")
+		t.Setenv(EnvTiDBCloudPrivateEndpointHostMap, "")
 	}
 
-	t.Run("alicloud missing domain", func(t *testing.T) {
+	t.Run("alicloud no startup override required", func(t *testing.T) {
 		setPrivateEnv("alicloud")
-		_, err := NewProvisionerFromEnv()
-		if err == nil {
-			t.Fatalf("expected error for alicloud private endpoint without domain")
+		p, err := NewProvisionerFromEnv()
+		if err != nil {
+			t.Fatalf("NewProvisionerFromEnv without alicloud host override: %v", err)
+		}
+		if !p.usePrivateEndpoint {
+			t.Fatalf("usePrivateEndpoint = false, want true")
 		}
 	})
 
-	t.Run("alicloud with domain", func(t *testing.T) {
+	t.Run("alicloud legacy domain fallback", func(t *testing.T) {
 		setPrivateEnv("alicloud")
 		t.Setenv(EnvTiDBCloudAlicloudPrivateEndpointDomain, "alicloud.internal")
 		p, err := NewProvisionerFromEnv()
@@ -1701,15 +1705,18 @@ func TestNewProvisionerFromEnvRequiresAlicloudPrivateEndpointDomain(t *testing.T
 		}
 	})
 
-	t.Run("tencentcloud missing host", func(t *testing.T) {
+	t.Run("tencentcloud no startup override required", func(t *testing.T) {
 		setPrivateEnv("tencentcloud")
-		_, err := NewProvisionerFromEnv()
-		if err == nil {
-			t.Fatalf("expected error for tencentcloud private endpoint without host")
+		p, err := NewProvisionerFromEnv()
+		if err != nil {
+			t.Fatalf("NewProvisionerFromEnv without tencentcloud host override: %v", err)
+		}
+		if !p.usePrivateEndpoint {
+			t.Fatalf("usePrivateEndpoint = false, want true")
 		}
 	})
 
-	t.Run("tencentcloud with host", func(t *testing.T) {
+	t.Run("tencentcloud legacy host fallback", func(t *testing.T) {
 		setPrivateEnv("tencentcloud")
 		t.Setenv(EnvTiDBCloudTencentPrivateEndpointHost, "tencent.internal")
 		p, err := NewProvisionerFromEnv()
@@ -1729,6 +1736,21 @@ func TestNewProvisionerFromEnvRequiresAlicloudPrivateEndpointDomain(t *testing.T
 		}
 		if p.usePrivateEndpoint != true {
 			t.Fatalf("usePrivateEndpoint = %v, want true", p.usePrivateEndpoint)
+		}
+	})
+
+	t.Run("host map", func(t *testing.T) {
+		setPrivateEnv("tencentcloud")
+		t.Setenv(EnvTiDBCloudPrivateEndpointHostMap, "public-a.example=private-a.internal, public-b.example:private-b.internal")
+		p, err := NewProvisionerFromEnv()
+		if err != nil {
+			t.Fatalf("NewProvisionerFromEnv with host map: %v", err)
+		}
+		if got := p.privateEndpointHostMap["public-a.example"]; got != "private-a.internal" {
+			t.Fatalf("host map public-a = %q, want private-a.internal", got)
+		}
+		if got := p.privateEndpointHostMap["public-b.example"]; got != "private-b.internal" {
+			t.Fatalf("host map public-b = %q, want private-b.internal", got)
 		}
 	})
 }
@@ -1810,6 +1832,94 @@ func TestProvisionWithCredentialsUsesPrivateEndpoint(t *testing.T) {
 	}
 }
 
+func TestProvisionWithCredentialsMapsPublicHostToPrivateEndpoint(t *testing.T) {
+	origEnsureDatabase := ensureDatabaseFunc
+	ensureDatabaseFunc = func(context.Context, string, string, string, int, string) error {
+		return nil
+	}
+	t.Cleanup(func() { ensureDatabaseFunc = origEnsureDatabase })
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"clusterId":  "cluster-1",
+			"state":      "ACTIVE",
+			"userPrefix": "u1",
+			"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1"},
+			"endpoints": map[string]any{
+				"public":  map[string]any{"host": "public-a.example", "port": 4000},
+				"private": map[string]any{"host": "", "port": 4001},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:                 ts.URL,
+		defaultDatabaseName:    DefaultDatabaseName,
+		usePrivateEndpoint:     true,
+		privateEndpointHostMap: map[string]string{"public-a.example": "private-a.internal"},
+		client:                 ts.Client(),
+	}
+	res, _, err := p.ProvisionWithCredentialsAndQuota(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
+		PublicKey: "public-1", PrivateKey: "private-1",
+	}, tenant.QuotaUpdateOptions{})
+	if err != nil {
+		t.Fatalf("ProvisionWithCredentialsAndQuota: %v", err)
+	}
+	if res.Host != "private-a.internal" {
+		t.Fatalf("Host = %q, want private-a.internal", res.Host)
+	}
+	if res.Port != 4001 {
+		t.Fatalf("Port = %d, want 4001", res.Port)
+	}
+}
+
+func TestProvisionWithCredentialsErrorsWhenPrivateHostMappingMissing(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"clusterId":  "cluster-1",
+			"state":      "ACTIVE",
+			"userPrefix": "u1",
+			"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1"},
+			"endpoints": map[string]any{
+				"public":  map[string]any{"host": "unmapped.example", "port": 4000},
+				"private": map[string]any{"host": "", "port": 4001},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:                 ts.URL,
+		defaultDatabaseName:    DefaultDatabaseName,
+		usePrivateEndpoint:     true,
+		privateEndpointHostMap: map[string]string{"public-a.example": "private-a.internal"},
+		client:                 ts.Client(),
+	}
+	res, _, err := p.ProvisionWithCredentialsAndQuota(context.Background(), "tenant-1", tenant.CredentialProvisionRequest{
+		PublicKey: "public-1", PrivateKey: "private-1",
+	}, tenant.QuotaUpdateOptions{})
+	if err == nil {
+		t.Fatalf("ProvisionWithCredentialsAndQuota error = nil, want missing mapping error")
+	}
+	if !strings.Contains(err.Error(), EnvTiDBCloudPrivateEndpointHostMap) || !strings.Contains(err.Error(), "unmapped.example") {
+		t.Fatalf("error = %v, want mapping miss with public host", err)
+	}
+	if res == nil || res.ClusterID != "cluster-1" {
+		t.Fatalf("partial cluster = %#v, want cluster id preserved", res)
+	}
+}
+
 func TestBranchConnectionIncompleteWhenPrivateEndpointMissing(t *testing.T) {
 	branch := &branchInfo{
 		BranchID:   "branch-1",
@@ -1854,7 +1964,7 @@ func TestFillBranchEndpointUsesPrivateEndpoint(t *testing.T) {
 	}
 }
 
-func TestFillBranchEndpointOverrideTakesPriority(t *testing.T) {
+func TestFillBranchEndpointUsesClusterPrivateHostBeforeLegacyOverride(t *testing.T) {
 	branch := &branchInfo{
 		BranchID:   "branch-1",
 		UserPrefix: "u1",
@@ -1873,12 +1983,21 @@ func TestFillBranchEndpointOverrideTakesPriority(t *testing.T) {
 	if err := p.fillBranchEndpoint(out, branch); err != nil {
 		t.Fatalf("fillBranchEndpoint: %v", err)
 	}
+	if out.Host != "private.internal" {
+		t.Fatalf("Host = %q, want private.internal", out.Host)
+	}
+
+	branch.Endpoints.Private.Host = ""
+	out = &tenant.ClusterInfo{}
+	if err := p.fillBranchEndpoint(out, branch); err != nil {
+		t.Fatalf("fillBranchEndpoint with empty private host: %v", err)
+	}
 	if out.Host != "alicloud.override.internal" {
-		t.Fatalf("Host = %q, want alicloud.override.internal (override takes priority)", out.Host)
+		t.Fatalf("Host with empty private host = %q, want alicloud.override.internal", out.Host)
 	}
 }
 
-func TestClusterInfoFromResponseOverrideTakesPriority(t *testing.T) {
+func TestClusterInfoFromResponseUsesClusterPrivateHostBeforeLegacyOverride(t *testing.T) {
 	info := &clusterInfo{
 		ClusterID:  "cluster-1",
 		UserPrefix: "u1",
@@ -1894,8 +2013,20 @@ func TestClusterInfoFromResponseOverrideTakesPriority(t *testing.T) {
 		alicloudPrivateEndpointHost: "alicloud.override.internal",
 		cloudProvider:               cloudProviderAliCloud,
 	}
-	out := p.clusterInfoFromResponse("tenant-1", "db1", "pass1", info)
+	out, err := p.clusterInfoFromResponse("tenant-1", "db1", "pass1", info)
+	if err != nil {
+		t.Fatalf("clusterInfoFromResponse: %v", err)
+	}
+	if out.Host != "private.internal" {
+		t.Fatalf("Host = %q, want private.internal", out.Host)
+	}
+
+	info.Endpoints.Private.Host = ""
+	out, err = p.clusterInfoFromResponse("tenant-1", "db1", "pass1", info)
+	if err != nil {
+		t.Fatalf("clusterInfoFromResponse with empty private host: %v", err)
+	}
 	if out.Host != "alicloud.override.internal" {
-		t.Fatalf("Host = %q, want alicloud.override.internal (override takes priority)", out.Host)
+		t.Fatalf("Host with empty private host = %q, want alicloud.override.internal", out.Host)
 	}
 }


### PR DESCRIPTION
## Summary
- add `DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP` for public host to private host resolution when TiDB Cloud private endpoint host is absent
- prefer cluster-provided private hosts, fall back to host map, then legacy single-host provider overrides only when no map is configured
- emit metrics/logs for missing private endpoint mapping and TiDB Cloud metadata still not ready after 5 minutes

## Tests
- `go test ./pkg/tenant/tidbcloudnative -count=1`
- `go test ./pkg/server -run 'TestAdminTenantPoolCreateUsesPrivateEndpointDBTLS|TestTenantPoolMetadataResumeUsesPrivateEndpointDBTLS|TestTenantPoolMetadataResumeRerunsWhenTriggeredWhileActive' -count=1`\n- `go test ./pkg/server -count=1`\n- `git diff --check -- cmd/drive9-server/main.go pkg/tenant/tidbcloudnative/provisioner.go pkg/tenant/tidbcloudnative/provisioner_test.go`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TiDB Cloud private-endpoint host mapping via environment variables, supporting both `public_host=private_host` and `public_host:private_host`.
  * Added tenant count metrics, including periodic leader-only observation and a labeled `drive9_tenant_count` gauge for total non-deleted and active tenants.
* **Bug Fixes**
  * Improved private-endpoint host resolution and propagated per-cluster/branch readiness failures for clearer error reporting.
  * Enhanced “metadata not ready” alerting and improved warning log detail for connection and datastore operation events.
* **Documentation**
  * Updated server usage output to describe the new mapping variables and their precedence over legacy private-endpoint settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->