### PR TITLE
Add DB operation trace logs

### DIFF
--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -6,17 +6,26 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"regexp"
+	"strings"
 	"time"
 
 	mysql "github.com/go-sql-driver/mysql"
 
+	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/metrics"
+	"go.uber.org/zap"
 )
 
 const (
 	RoleMeta       = "meta"
 	RoleUser       = "user"
 	RoleUserSchema = "user_schema"
+)
+
+const (
+	maxSQLTraceLen      = 4096
+	maxSQLTraceInputLen = maxSQLTraceLen * 2
 )
 
 func OpenInstrumented(ctx context.Context, dsn, role string) (*sql.DB, error) {
@@ -56,7 +65,7 @@ func (c instrumentedConnector) Connect(ctx context.Context) (driver.Conn, error)
 	start := time.Now()
 	conn, err := c.base.Connect(ctx)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(c.role, "connect", start, err)
+		observeDBOperation(ctx, c.role, "connect", "", start, err)
 	}
 	if err != nil {
 		return nil, err
@@ -77,12 +86,12 @@ func (c instrumentedConn) Prepare(query string) (driver.Stmt, error) {
 	start := time.Now()
 	stmt, err := c.base.Prepare(query)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(c.role, "prepare", start, err)
+		observeDBOperation(context.Background(), c.role, "prepare", query, start, err)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return instrumentedStmt{base: stmt, role: c.role}, nil
+	return instrumentedStmt{base: stmt, role: c.role, query: query}, nil
 }
 
 func (c instrumentedConn) Close() error {
@@ -101,7 +110,7 @@ func (c instrumentedConn) Ping(ctx context.Context) error {
 	start := time.Now()
 	err := pinger.Ping(ctx)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(c.role, "ping", start, err)
+		observeDBOperation(ctx, c.role, "ping", "", start, err)
 	}
 	return err
 }
@@ -114,12 +123,12 @@ func (c instrumentedConn) PrepareContext(ctx context.Context, query string) (dri
 	start := time.Now()
 	stmt, err := prep.PrepareContext(ctx, query)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(c.role, "prepare", start, err)
+		observeDBOperation(ctx, c.role, "prepare", query, start, err)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return instrumentedStmt{base: stmt, role: c.role}, nil
+	return instrumentedStmt{base: stmt, role: c.role, query: query}, nil
 }
 
 func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
@@ -127,7 +136,7 @@ func (c instrumentedConn) BeginTx(ctx context.Context, opts driver.TxOptions) (d
 		start := time.Now()
 		tx, err := beginner.BeginTx(ctx, opts)
 		if !errors.Is(err, driver.ErrSkip) {
-			observeDBOperation(c.role, "begin", start, err)
+			observeDBOperation(ctx, c.role, "begin", "", start, err)
 		}
 		if err != nil {
 			return nil, err
@@ -148,7 +157,7 @@ func (c instrumentedConn) ExecContext(ctx context.Context, query string, args []
 	start := time.Now()
 	res, err := execer.ExecContext(ctx, query, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(c.role, "exec", start, err)
+		observeDBOperation(ctx, c.role, "exec", query, start, err, res)
 	}
 	return res, err
 }
@@ -161,7 +170,7 @@ func (c instrumentedConn) QueryContext(ctx context.Context, query string, args [
 	start := time.Now()
 	rows, err := queryer.QueryContext(ctx, query, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(c.role, "query", start, err)
+		observeDBOperation(ctx, c.role, "query", query, start, err)
 	}
 	return rows, err
 }
@@ -191,8 +200,9 @@ func (c instrumentedConn) CheckNamedValue(nv *driver.NamedValue) error {
 }
 
 type instrumentedStmt struct {
-	base driver.Stmt
-	role string
+	base  driver.Stmt
+	role  string
+	query string
 }
 
 func (s instrumentedStmt) Close() error {
@@ -219,7 +229,7 @@ func (s instrumentedStmt) ExecContext(ctx context.Context, args []driver.NamedVa
 	start := time.Now()
 	res, err := execer.ExecContext(ctx, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(s.role, "exec", start, err)
+		observeDBOperation(ctx, s.role, "exec", s.query, start, err, res)
 	}
 	return res, err
 }
@@ -232,7 +242,7 @@ func (s instrumentedStmt) QueryContext(ctx context.Context, args []driver.NamedV
 	start := time.Now()
 	rows, err := queryer.QueryContext(ctx, args)
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(s.role, "query", start, err)
+		observeDBOperation(ctx, s.role, "query", s.query, start, err)
 	}
 	return rows, err
 }
@@ -254,7 +264,7 @@ func (tx instrumentedTx) Commit() error {
 	start := time.Now()
 	err := tx.base.Commit()
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(tx.role, "commit", start, err)
+		observeDBOperation(context.Background(), tx.role, "commit", "", start, err)
 	}
 	return err
 }
@@ -263,13 +273,42 @@ func (tx instrumentedTx) Rollback() error {
 	start := time.Now()
 	err := tx.base.Rollback()
 	if !errors.Is(err, driver.ErrSkip) {
-		observeDBOperation(tx.role, "rollback", start, err)
+		observeDBOperation(context.Background(), tx.role, "rollback", "", start, err)
 	}
 	return err
 }
 
-func observeDBOperation(role, operation string, start time.Time, err error) {
-	metrics.RecordDBOperation(role, operation, dbResult(err), time.Since(start))
+func observeDBOperation(ctx context.Context, role, operation, query string, start time.Time, err error, results ...driver.Result) {
+	elapsed := time.Since(start)
+	result := dbResult(err)
+	metrics.RecordDBOperation(role, operation, result, elapsed)
+
+	if !logger.BenchTimingLogEnabled() {
+		return
+	}
+
+	fields := []zap.Field{
+		zap.String("role", role),
+		zap.String("operation", operation),
+		zap.String("result", result),
+		zap.Float64("duration_ms", float64(elapsed.Microseconds())/1000.0),
+	}
+	if sqlText, truncated, sourceLen := sqlTraceText(query); sqlText != "" {
+		fields = append(fields, zap.String("sql", sqlText))
+		fields = append(fields, zap.Int("sql_len", sourceLen))
+		if truncated {
+			fields = append(fields, zap.Bool("sql_truncated", true))
+		}
+	}
+	if len(results) > 0 && results[0] != nil {
+		if affected, rowsErr := results[0].RowsAffected(); rowsErr == nil {
+			fields = append(fields, zap.Int64("rows_affected", affected))
+		}
+	}
+	if err != nil {
+		fields = append(fields, safeDBErrorFields(err)...)
+	}
+	logger.InfoBenchTiming(ctx, "db_operation_timing", fields...)
 }
 
 func dbResult(err error) string {
@@ -290,4 +329,159 @@ func toNamedValues(args []driver.Value) []driver.NamedValue {
 		})
 	}
 	return named
+}
+
+var sqlWhitespace = regexp.MustCompile(`\s+`)
+
+func sqlTraceText(query string) (string, bool, int) {
+	sourceLen := len(query)
+	if sourceLen == 0 {
+		return "", false, 0
+	}
+	truncated := false
+	if len(query) > maxSQLTraceInputLen {
+		query = query[:maxSQLTraceInputLen]
+		truncated = true
+	}
+	out := normalizeSQLForTrace(query)
+	if len(out) > maxSQLTraceLen {
+		out = out[:maxSQLTraceLen]
+		truncated = true
+	}
+	return out, truncated, sourceLen
+}
+
+func normalizeSQLForTrace(query string) string {
+	return sqlWhitespace.ReplaceAllString(strings.TrimSpace(redactSQLLiterals(query)), " ")
+}
+
+func redactSQLLiterals(query string) string {
+	var b strings.Builder
+	b.Grow(len(query))
+	for i := 0; i < len(query); {
+		switch query[i] {
+		case '\'', '"':
+			b.WriteByte('?')
+			i = skipQuotedSQLLiteral(query, i, query[i])
+		case '/':
+			if i+1 < len(query) && query[i+1] == '*' {
+				b.WriteByte(' ')
+				i = skipBlockSQLComment(query, i)
+				continue
+			}
+			b.WriteByte(query[i])
+			i++
+		case '-':
+			if i+1 < len(query) && query[i+1] == '-' {
+				b.WriteByte(' ')
+				i = skipLineSQLComment(query, i)
+				continue
+			}
+			b.WriteByte(query[i])
+			i++
+		case '#':
+			b.WriteByte(' ')
+			i = skipLineSQLComment(query, i)
+		default:
+			if isNumericSQLLiteralStart(query, i) {
+				b.WriteByte('?')
+				i = skipNumericSQLLiteral(query, i)
+				continue
+			}
+			b.WriteByte(query[i])
+			i++
+		}
+	}
+	return b.String()
+}
+
+func safeDBErrorFields(err error) []zap.Field {
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		fields := []zap.Field{
+			zap.String("db_error_type", "mysql"),
+			zap.Uint16("db_error_number", mysqlErr.Number),
+		}
+		if mysqlErr.SQLState != [5]byte{} {
+			fields = append(fields, zap.String("db_error_sql_state", string(mysqlErr.SQLState[:])))
+		}
+		return fields
+	}
+	switch {
+	case errors.Is(err, context.Canceled):
+		return []zap.Field{zap.String("db_error_type", "context_canceled")}
+	case errors.Is(err, context.DeadlineExceeded):
+		return []zap.Field{zap.String("db_error_type", "context_deadline_exceeded")}
+	case errors.Is(err, driver.ErrBadConn):
+		return []zap.Field{zap.String("db_error_type", "bad_conn")}
+	default:
+		return []zap.Field{zap.String("db_error_type", fmt.Sprintf("%T", err))}
+	}
+}
+
+func skipQuotedSQLLiteral(query string, start int, quote byte) int {
+	for i := start + 1; i < len(query); i++ {
+		switch query[i] {
+		case '\\':
+			if i+1 < len(query) {
+				i++
+			}
+		case quote:
+			if i+1 < len(query) && query[i+1] == quote {
+				i++
+				continue
+			}
+			return i + 1
+		}
+	}
+	return len(query)
+}
+
+func skipBlockSQLComment(query string, start int) int {
+	for i := start + 2; i < len(query)-1; i++ {
+		if query[i] == '*' && query[i+1] == '/' {
+			return i + 2
+		}
+	}
+	return len(query)
+}
+
+func skipLineSQLComment(query string, start int) int {
+	for i := start + 1; i < len(query); i++ {
+		if query[i] == '\n' || query[i] == '\r' {
+			return i
+		}
+	}
+	return len(query)
+}
+
+func isNumericSQLLiteralStart(query string, i int) bool {
+	if query[i] < '0' || query[i] > '9' {
+		return false
+	}
+	return i == 0 || !isSQLIdentByte(query[i-1])
+}
+
+func skipNumericSQLLiteral(query string, start int) int {
+	i := start
+	for i < len(query) {
+		c := query[i]
+		if (c >= '0' && c <= '9') ||
+			(c >= 'a' && c <= 'f') ||
+			(c >= 'A' && c <= 'F') ||
+			c == 'x' || c == 'X' || c == '.' || c == '+' || c == '-' {
+			i++
+			continue
+		}
+		break
+	}
+	return i
+}
+
+func isSQLIdentByte(c byte) bool {
+	return (c >= 'a' && c <= 'z') ||
+		(c >= 'A' && c <= 'Z') ||
+		(c >= '0' && c <= '9') ||
+		c == '_' ||
+		c == '$'
 }

--- a/pkg/mysqlutil/instrumented_test.go
+++ b/pkg/mysqlutil/instrumented_test.go
@@ -1,0 +1,195 @@
+package mysqlutil
+
+import (
+	"context"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	mysql "github.com/go-sql-driver/mysql"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestObserveDBOperationLogsSQLTraceWithoutArgs(t *testing.T) {
+	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "true")
+	logger.ResetBenchTimingLogEnabledForTest()
+	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	ctx := context.Background()
+	start := time.Now().Add(-10 * time.Millisecond)
+	observeDBOperation(ctx, RoleUser, "exec", "  INSERT INTO file_nodes\n(path, name) VALUES (?, ?)  ", start, errors.New("duplicate key"))
+
+	entries := recorded.FilterMessage("db_operation_timing").All()
+	if len(entries) != 1 {
+		t.Fatalf("db_operation_timing entries = %d, want 1", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	if fields["role"] != RoleUser {
+		t.Errorf("role field = %v, want %s", fields["role"], RoleUser)
+	}
+	if fields["operation"] != "exec" {
+		t.Errorf("operation field = %v, want exec", fields["operation"])
+	}
+	if fields["result"] != "error" {
+		t.Errorf("result field = %v, want error", fields["result"])
+	}
+	if fields["sql"] != "INSERT INTO file_nodes (path, name) VALUES (?, ?)" {
+		t.Errorf("sql field = %v", fields["sql"])
+	}
+	if _, ok := fields["args"]; ok {
+		t.Errorf("db trace log must not include args: %#v", fields)
+	}
+	if fields["duration_ms"] == nil {
+		t.Errorf("duration_ms field missing: %#v", fields)
+	}
+}
+
+func TestNormalizeSQLForTraceRedactsLiterals(t *testing.T) {
+	query := `SELECT * FROM files
+		WHERE name = 'agent secret'
+		AND path = "project literal"
+		AND size > 123
+		AND note = 'can''t leak'
+		AND raw = 'can\'t leak either'`
+	want := `SELECT * FROM files WHERE name = ? AND path = ? AND size > ? AND note = ? AND raw = ?`
+	if got := normalizeSQLForTrace(query); got != want {
+		t.Fatalf("normalizeSQLForTrace() = %q, want %q", got, want)
+	}
+}
+
+func TestNormalizeSQLForTraceStripsComments(t *testing.T) {
+	query := `SELECT '/* quoted@example.com */', "-- quoted-dash@example.com", '# quoted-hash@example.com'
+		/* block@example.com */ FROM files -- dash@example.com
+		WHERE id = 42 # hash@example.com`
+	want := `SELECT ?, ?, ? FROM files WHERE id = ?`
+	got := normalizeSQLForTrace(query)
+	if got != want {
+		t.Fatalf("normalizeSQLForTrace() = %q, want %q", got, want)
+	}
+	for _, secret := range []string{"block@example.com", "dash@example.com", "hash@example.com"} {
+		if strings.Contains(got, secret) {
+			t.Fatalf("normalizeSQLForTrace leaked comment secret %q in %q", secret, got)
+		}
+	}
+}
+
+func TestObserveDBOperationLogsSafeErrorDetails(t *testing.T) {
+	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "true")
+	logger.ResetBenchTimingLogEnabledForTest()
+	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	const secret = "CHILD_SECRET"
+	dbErr := &mysql.MySQLError{
+		Number:  1062,
+		Message: "Duplicate entry '" + secret + "' for key 'files.name'",
+	}
+	observeDBOperation(context.Background(), RoleUser, "exec", "INSERT INTO files(name) VALUES (?)", time.Now(), dbErr)
+
+	entries := recorded.FilterMessage("db_operation_timing").All()
+	if len(entries) != 1 {
+		t.Fatalf("db_operation_timing entries = %d, want 1", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	if _, ok := fields["error"]; ok {
+		t.Errorf("db trace log must not include raw error field: %#v", fields)
+	}
+	if fields["db_error_type"] != "mysql" {
+		t.Errorf("db_error_type = %v, want mysql", fields["db_error_type"])
+	}
+	if fmt.Sprint(fields["db_error_number"]) != "1062" {
+		t.Errorf("db_error_number = %v, want 1062", fields["db_error_number"])
+	}
+	assertFieldsDoNotContain(t, fields, secret)
+}
+
+func TestObserveDBOperationBoundsSQLTraceField(t *testing.T) {
+	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "true")
+	logger.ResetBenchTimingLogEnabledForTest()
+	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	query := "SELECT " + strings.Repeat("x", maxSQLTraceLen*3) + " FROM files"
+	observeDBOperation(context.Background(), RoleUser, "query", query, time.Now(), nil)
+
+	entries := recorded.FilterMessage("db_operation_timing").All()
+	if len(entries) != 1 {
+		t.Fatalf("db_operation_timing entries = %d, want 1", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	sqlText, ok := fields["sql"].(string)
+	if !ok {
+		t.Fatalf("sql field = %T, want string", fields["sql"])
+	}
+	if len(sqlText) != maxSQLTraceLen {
+		t.Fatalf("sql field len = %d, want %d", len(sqlText), maxSQLTraceLen)
+	}
+	if fields["sql_truncated"] != true {
+		t.Errorf("sql_truncated = %v, want true", fields["sql_truncated"])
+	}
+	if fmt.Sprint(fields["sql_len"]) != fmt.Sprint(len(query)) {
+		t.Errorf("sql_len = %v, want %d", fields["sql_len"], len(query))
+	}
+}
+
+func TestObserveDBOperationSkipsTraceFieldsWhenBenchTimingDisabled(t *testing.T) {
+	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "false")
+	logger.ResetBenchTimingLogEnabledForTest()
+	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	res := &recordingResult{}
+	observeDBOperation(context.Background(), RoleUser, "exec", "SELECT 'secret'", time.Now(), nil, res)
+
+	if entries := recorded.FilterMessage("db_operation_timing").All(); len(entries) != 0 {
+		t.Fatalf("db_operation_timing entries = %d, want 0", len(entries))
+	}
+	if res.rowsAffectedCalled {
+		t.Fatal("RowsAffected called while bench timing logs are disabled")
+	}
+}
+
+type recordingResult struct {
+	rowsAffectedCalled bool
+}
+
+func (r *recordingResult) LastInsertId() (int64, error) {
+	return 0, driver.ErrSkip
+}
+
+func (r *recordingResult) RowsAffected() (int64, error) {
+	r.rowsAffectedCalled = true
+	return 1, nil
+}
+
+func assertFieldsDoNotContain(t *testing.T, fields map[string]interface{}, secret string) {
+	t.Helper()
+	for key, value := range fields {
+		if strings.Contains(fmt.Sprint(value), secret) {
+			t.Fatalf("field %q leaked %q in %#v", key, secret, fields)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add bench-timing DB operation logs from the instrumented MySQL driver wrapper
- include role, operation, result, duration, normalized SQL template, and rows_affected when available
- avoid logging SQL argument values; conflict/error classification is unchanged

## Test
- go test ./pkg/mysqlutil -count=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved database operation tracing with normalized SQL statements, execution duration, operation outcomes, affected row counts, and error details.
  * Preserved request context across database connections, statements, and transactions for more accurate timing and diagnostics.
* **Bug Fixes**
  * Improved SQL trace readability by removing excess whitespace.
  * Ensured SQL details are included in error traces when available, without exposing unnecessary argument data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->