### PR TITLE
Classify expected conflicts outside error buckets

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -373,7 +373,8 @@ environment:
   DRIVE9_VAULT_MASTER_KEY 32-byte hex key for vault DEK wrapping (omit to disable vault)
   DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
-  DRIVE9_DB_TRACE_LOG_ENABLED true|false to emit DB operation trace logs with redacted SQL (default: false)
+  DRIVE9_DB_TRACE_LOG_ENABLED true|false to emit DB operation trace logs with redacted SQL (default: true)
+  DRIVE9_DB_SLOW_TRACE_MS minimum DB operation duration in ms for DB trace logs (default: 300, 0=all)
   DRIVE9_QUOTA_USAGE_CACHE_TTL soft small-write central usage cache TTL, e.g. 250ms or 1s
   DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL soft small-write in-process pending mutation cache TTL, e.g. 250ms or 1s
   DRIVE9_QUOTA_REPLAY_POLL_MS central quota mutation replay poll interval in milliseconds (default: 1000)

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -373,6 +373,7 @@ environment:
   DRIVE9_VAULT_MASTER_KEY 32-byte hex key for vault DEK wrapping (omit to disable vault)
   DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
+  DRIVE9_DB_TRACE_LOG_ENABLED true|false to emit DB operation trace logs with redacted SQL (default: false)
   DRIVE9_QUOTA_USAGE_CACHE_TTL soft small-write central usage cache TTL, e.g. 250ms or 1s
   DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL soft small-write in-process pending mutation cache TTL, e.g. 250ms or 1s
   DRIVE9_QUOTA_REPLAY_POLL_MS central quota mutation replay poll interval in milliseconds (default: 1000)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -552,6 +552,7 @@ environment:
   DRIVE9_DEFAULT_STORAGE_QUOTA_BYTES fallback per-tenant total storage limit when no explicit quota is configured (default: %d)
   DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
+  DRIVE9_DB_TRACE_LOG_ENABLED true|false to emit DB operation trace logs with redacted SQL (default: false)
   DRIVE9_QUOTA_USAGE_CACHE_TTL soft small-write central usage cache TTL, e.g. 250ms or 1s
   DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL soft small-write in-process pending mutation cache TTL, e.g. 250ms or 1s
   DRIVE9_QUOTA_REPLAY_POLL_MS central quota mutation replay poll interval in milliseconds (default: 1000)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -552,7 +552,8 @@ environment:
   DRIVE9_DEFAULT_STORAGE_QUOTA_BYTES fallback per-tenant total storage limit when no explicit quota is configured (default: %d)
   DRIVE9_LOG_LEVEL debug|info|warn|error (default: info)
   DRIVE9_BENCH_TIMING_LOG_ENABLED true|false to emit benchmark timing logs on successful server hot paths (default: false)
-  DRIVE9_DB_TRACE_LOG_ENABLED true|false to emit DB operation trace logs with redacted SQL (default: false)
+  DRIVE9_DB_TRACE_LOG_ENABLED true|false to emit DB operation trace logs with redacted SQL (default: true)
+  DRIVE9_DB_SLOW_TRACE_MS minimum DB operation duration in ms for DB trace logs (default: 300, 0=all)
   DRIVE9_QUOTA_USAGE_CACHE_TTL soft small-write central usage cache TTL, e.g. 250ms or 1s
   DRIVE9_QUOTA_PENDING_DELTAS_CACHE_TTL soft small-write in-process pending mutation cache TTL, e.g. 250ms or 1s
   DRIVE9_QUOTA_REPLAY_POLL_MS central quota mutation replay poll interval in milliseconds (default: 1000)

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -2271,13 +2271,22 @@ func (b *Dat9Backend) Find(ctx context.Context, f *datastore.FindFilter) ([]data
 }
 
 func observeBackend(ctx context.Context, tenantID, op string, err error, start time.Time) {
-	result := "ok"
-	if err != nil {
-		if errors.Is(err, datastore.ErrNotFound) {
-			result = "not_found"
-		} else {
-			result = "error"
-		}
+	metrics.RecordTenantOperation(tenantID, "backend", op, backendResultForError(err), time.Since(start))
+}
+
+func backendResultForError(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case errors.Is(err, datastore.ErrNotFound):
+		return "not_found"
+	case errors.Is(err, datastore.ErrPathConflict),
+		errors.Is(err, datastore.ErrRevisionConflict),
+		errors.Is(err, datastore.ErrUploadConflict),
+		errors.Is(err, datastore.ErrUploadNotActive),
+		errors.Is(err, datastore.ErrIdempotencyConflict):
+		return "conflict"
+	default:
+		return metrics.ResultForError(err)
 	}
-	metrics.RecordTenantOperation(tenantID, "backend", op, result, time.Since(start))
 }

--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -50,6 +51,33 @@ func newTestBackendWithOptions(t *testing.T, opts Options) *Dat9Backend {
 }
 
 var _ filesystem.FileSystem = (*Dat9Backend)(nil)
+
+func TestBackendResultForErrorClassifiesExpectedConflicts(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: "ok"},
+		{name: "not found", err: datastore.ErrNotFound, want: "not_found"},
+		{name: "path conflict", err: datastore.ErrPathConflict, want: "conflict"},
+		{name: "revision conflict", err: datastore.ErrRevisionConflict, want: "conflict"},
+		{name: "upload conflict", err: datastore.ErrUploadConflict, want: "conflict"},
+		{name: "upload not active", err: datastore.ErrUploadNotActive, want: "conflict"},
+		{name: "idempotency conflict", err: datastore.ErrIdempotencyConflict, want: "conflict"},
+		{name: "wrapped conflict", err: fmt.Errorf("create node: %w", datastore.ErrPathConflict), want: "conflict"},
+		{name: "canceled", err: context.Canceled, want: "canceled"},
+		{name: "deadline", err: context.DeadlineExceeded, want: "deadline_exceeded"},
+		{name: "generic", err: errors.New("boom"), want: "error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := backendResultForError(tt.err); got != tt.want {
+				t.Errorf("backendResultForError(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestCreateAndStat(t *testing.T) {
 	b := newTestBackend(t)

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -3014,25 +3014,7 @@ func observeStoreOp(ctx context.Context, op string, start time.Time, errp *error
 	elapsed := time.Since(start)
 	result := "ok"
 	if errp != nil && *errp != nil {
-		switch {
-		case errors.Is(*errp, ErrNotFound):
-			result = "not_found"
-		case errors.Is(*errp, ErrPathConflict), errors.Is(*errp, ErrUploadConflict), errors.Is(*errp, ErrIdempotencyConflict):
-			result = "conflict"
-		case errors.Is(*errp, context.Canceled):
-			result = "canceled"
-		case errors.Is(*errp, context.DeadlineExceeded):
-			result = "deadline_exceeded"
-		case errors.Is(*errp, sql.ErrConnDone):
-			// Connection closed during shutdown — not an unexpected failure.
-			result = "conn_closed"
-		default:
-			if strings.Contains((*errp).Error(), "database is closed") {
-				result = "conn_closed"
-			} else {
-				result = "error"
-			}
-		}
+		result = storeOpResultForError(*errp)
 		if shouldLogStoreOpFailure(result) {
 			logger.Error(ctx, "datastore_op_failed", zap.String("operation", op), zap.String("result", result), zap.Error(*errp))
 		} else {
@@ -3046,9 +3028,36 @@ func observeStoreOp(ctx context.Context, op string, start time.Time, errp *error
 	metrics.RecordOperation("datastore", op, result, elapsed)
 }
 
+func storeOpResultForError(err error) string {
+	switch {
+	case err == nil:
+		return "ok"
+	case errors.Is(err, ErrNotFound):
+		return "not_found"
+	case errors.Is(err, ErrPathConflict),
+		errors.Is(err, ErrRevisionConflict),
+		errors.Is(err, ErrUploadConflict),
+		errors.Is(err, ErrUploadNotActive),
+		errors.Is(err, ErrIdempotencyConflict),
+		errors.Is(err, ErrJournalConflict):
+		return "conflict"
+	case errors.Is(err, context.Canceled):
+		return "canceled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "deadline_exceeded"
+	case errors.Is(err, sql.ErrConnDone):
+		return "conn_closed"
+	default:
+		if strings.Contains(err.Error(), "database is closed") {
+			return "conn_closed"
+		}
+		return "error"
+	}
+}
+
 func shouldLogStoreOpFailure(result string) bool {
 	switch result {
-	case "not_found", "canceled", "deadline_exceeded", "conn_closed":
+	case "not_found", "conflict", "canceled", "deadline_exceeded", "conn_closed":
 		return false
 	default:
 		return true

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -11,6 +11,9 @@ import (
 	"time"
 
 	"github.com/mem9-ai/drive9/internal/testmysql"
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func newTestStore(t *testing.T) *Store {
@@ -36,7 +39,7 @@ func TestShouldLogStoreOpFailure(t *testing.T) {
 		{result: "canceled", want: false},
 		{result: "deadline_exceeded", want: false},
 		{result: "conn_closed", want: false},
-		{result: "conflict", want: true},
+		{result: "conflict", want: false},
 		{result: "error", want: true},
 	}
 	for _, tt := range tests {
@@ -45,6 +48,58 @@ func TestShouldLogStoreOpFailure(t *testing.T) {
 				t.Fatalf("shouldLogStoreOpFailure(%q) = %v, want %v", tt.result, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestStoreOpResultForErrorClassifiesExpectedConflicts(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "nil", err: nil, want: "ok"},
+		{name: "not found", err: ErrNotFound, want: "not_found"},
+		{name: "path conflict", err: ErrPathConflict, want: "conflict"},
+		{name: "revision conflict", err: ErrRevisionConflict, want: "conflict"},
+		{name: "upload conflict", err: ErrUploadConflict, want: "conflict"},
+		{name: "upload not active", err: ErrUploadNotActive, want: "conflict"},
+		{name: "idempotency conflict", err: ErrIdempotencyConflict, want: "conflict"},
+		{name: "journal conflict", err: ErrJournalConflict, want: "conflict"},
+		{name: "canceled", err: context.Canceled, want: "canceled"},
+		{name: "deadline", err: context.DeadlineExceeded, want: "deadline_exceeded"},
+		{name: "generic", err: errors.New("boom"), want: "error"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := storeOpResultForError(tt.err); got != tt.want {
+				t.Errorf("storeOpResultForError(%v) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestObserveStoreOpConflictLogsWarnDetail(t *testing.T) {
+	core, recorded := observer.New(zap.WarnLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	err := ErrPathConflict
+	observeStoreOp(context.Background(), "in_tx", time.Now(), &err)
+
+	entries := recorded.FilterMessage("datastore_op_failed").All()
+	if len(entries) != 1 {
+		t.Fatalf("datastore_op_failed entries = %d, want 1", len(entries))
+	}
+	if entries[0].Level != zap.WarnLevel {
+		t.Fatalf("datastore_op_failed level = %s, want warn", entries[0].Level)
+	}
+	fields := entries[0].ContextMap()
+	if _, ok := fields["error"]; ok {
+		t.Fatalf("conflict log must not include error field: %#v", fields)
+	}
+	if fields["detail"] != ErrPathConflict.Error() {
+		t.Fatalf("detail field = %v, want %q", fields["detail"], ErrPathConflict.Error())
 	}
 }
 

--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -16,8 +17,11 @@ import (
 const (
 	envBenchTimingLogEnabled = "DRIVE9_BENCH_TIMING_LOG_ENABLED"
 	envDBTraceLogEnabled     = "DRIVE9_DB_TRACE_LOG_ENABLED"
+	envDBSlowTraceMS         = "DRIVE9_DB_SLOW_TRACE_MS"
 	envLogLevel              = "DRIVE9_LOG_LEVEL"
 )
+
+const defaultDBSlowTraceThreshold = 300 * time.Millisecond
 
 const (
 	benchTimingLogUnknown uint32 = iota
@@ -33,6 +37,7 @@ const (
 
 var benchTimingLogState atomic.Uint32
 var dbTraceLogState atomic.Uint32
+var dbSlowTraceThresholdNS atomic.Int64
 
 func NewServerLogger() (*zap.Logger, error) {
 	cfg := zap.NewProductionConfig()
@@ -75,13 +80,23 @@ func DBTraceLogEnabled() bool {
 		return true
 	}
 
-	enabled := envBool(envDBTraceLogEnabled, false)
+	enabled := envBool(envDBTraceLogEnabled, true)
 	if enabled {
 		dbTraceLogState.Store(dbTraceLogEnabled)
 		return true
 	}
 	dbTraceLogState.Store(dbTraceLogDisabled)
 	return false
+}
+
+func DBSlowTraceThreshold() time.Duration {
+	if value := dbSlowTraceThresholdNS.Load(); value >= 0 {
+		return time.Duration(value)
+	}
+
+	threshold := envDurationMS(envDBSlowTraceMS, defaultDBSlowTraceThreshold)
+	dbSlowTraceThresholdNS.Store(int64(threshold))
+	return threshold
 }
 
 func CLIEnabled() bool {
@@ -163,12 +178,28 @@ func envBool(key string, fallback bool) bool {
 	return v
 }
 
+func envDurationMS(key string, fallback time.Duration) time.Duration {
+	raw := os.Getenv(key)
+	if raw == "" {
+		return fallback
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v < 0 {
+		return fallback
+	}
+	return time.Duration(v) * time.Millisecond
+}
+
 func resetBenchTimingLogEnabledForTest() {
 	benchTimingLogState.Store(benchTimingLogUnknown)
 }
 
 func resetDBTraceLogEnabledForTest() {
 	dbTraceLogState.Store(dbTraceLogUnknown)
+}
+
+func resetDBSlowTraceThresholdForTest() {
+	dbSlowTraceThresholdNS.Store(-1)
 }
 
 // ResetBenchTimingLogEnabledForTest clears the cached benchmark timing flag.
@@ -183,4 +214,15 @@ func ResetBenchTimingLogEnabledForTest() {
 // DRIVE9_DB_TRACE_LOG_ENABLED deterministically.
 func ResetDBTraceLogEnabledForTest() {
 	resetDBTraceLogEnabledForTest()
+}
+
+// ResetDBSlowTraceThresholdForTest clears the cached DB slow trace threshold.
+// It is intended for tests in packages outside logger that need to toggle
+// DRIVE9_DB_SLOW_TRACE_MS deterministically.
+func ResetDBSlowTraceThresholdForTest() {
+	resetDBSlowTraceThresholdForTest()
+}
+
+func init() {
+	resetDBSlowTraceThresholdForTest()
 }

--- a/pkg/logger/factory.go
+++ b/pkg/logger/factory.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	envBenchTimingLogEnabled = "DRIVE9_BENCH_TIMING_LOG_ENABLED"
+	envDBTraceLogEnabled     = "DRIVE9_DB_TRACE_LOG_ENABLED"
 	envLogLevel              = "DRIVE9_LOG_LEVEL"
 )
 
@@ -24,7 +25,14 @@ const (
 	benchTimingLogEnabled
 )
 
+const (
+	dbTraceLogUnknown uint32 = iota
+	dbTraceLogDisabled
+	dbTraceLogEnabled
+)
+
 var benchTimingLogState atomic.Uint32
+var dbTraceLogState atomic.Uint32
 
 func NewServerLogger() (*zap.Logger, error) {
 	cfg := zap.NewProductionConfig()
@@ -56,6 +64,23 @@ func BenchTimingLogEnabled() bool {
 		return true
 	}
 	benchTimingLogState.Store(benchTimingLogDisabled)
+	return false
+}
+
+func DBTraceLogEnabled() bool {
+	switch dbTraceLogState.Load() {
+	case dbTraceLogDisabled:
+		return false
+	case dbTraceLogEnabled:
+		return true
+	}
+
+	enabled := envBool(envDBTraceLogEnabled, false)
+	if enabled {
+		dbTraceLogState.Store(dbTraceLogEnabled)
+		return true
+	}
+	dbTraceLogState.Store(dbTraceLogDisabled)
 	return false
 }
 
@@ -142,9 +167,20 @@ func resetBenchTimingLogEnabledForTest() {
 	benchTimingLogState.Store(benchTimingLogUnknown)
 }
 
+func resetDBTraceLogEnabledForTest() {
+	dbTraceLogState.Store(dbTraceLogUnknown)
+}
+
 // ResetBenchTimingLogEnabledForTest clears the cached benchmark timing flag.
 // It is intended for tests in packages outside logger that need to toggle
 // DRIVE9_BENCH_TIMING_LOG_ENABLED deterministically.
 func ResetBenchTimingLogEnabledForTest() {
 	resetBenchTimingLogEnabledForTest()
+}
+
+// ResetDBTraceLogEnabledForTest clears the cached DB trace flag.
+// It is intended for tests in packages outside logger that need to toggle
+// DRIVE9_DB_TRACE_LOG_ENABLED deterministically.
+func ResetDBTraceLogEnabledForTest() {
+	resetDBTraceLogEnabledForTest()
 }

--- a/pkg/logger/factory_test.go
+++ b/pkg/logger/factory_test.go
@@ -106,6 +106,26 @@ func TestBenchTimingLogEnabledCachesUntilReset(t *testing.T) {
 	}
 }
 
+func TestDBTraceLogEnabledCachesUntilReset(t *testing.T) {
+	resetDBTraceLogEnabledForTest()
+	t.Cleanup(resetDBTraceLogEnabledForTest)
+
+	t.Setenv(envDBTraceLogEnabled, "true")
+	if !DBTraceLogEnabled() {
+		t.Fatal("expected DB trace log to be enabled")
+	}
+
+	t.Setenv(envDBTraceLogEnabled, "false")
+	if !DBTraceLogEnabled() {
+		t.Fatal("expected cached enabled value to remain true before reset")
+	}
+
+	resetDBTraceLogEnabledForTest()
+	if DBTraceLogEnabled() {
+		t.Fatal("expected DB trace log to be disabled after reset")
+	}
+}
+
 func TestInfoBenchTimingHonorsEnabledFlag(t *testing.T) {
 	resetBenchTimingLogEnabledForTest()
 	t.Cleanup(resetBenchTimingLogEnabledForTest)

--- a/pkg/logger/factory_test.go
+++ b/pkg/logger/factory_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
@@ -110,9 +111,8 @@ func TestDBTraceLogEnabledCachesUntilReset(t *testing.T) {
 	resetDBTraceLogEnabledForTest()
 	t.Cleanup(resetDBTraceLogEnabledForTest)
 
-	t.Setenv(envDBTraceLogEnabled, "true")
 	if !DBTraceLogEnabled() {
-		t.Fatal("expected DB trace log to be enabled")
+		t.Fatal("expected DB trace log to be enabled by default")
 	}
 
 	t.Setenv(envDBTraceLogEnabled, "false")
@@ -123,6 +123,51 @@ func TestDBTraceLogEnabledCachesUntilReset(t *testing.T) {
 	resetDBTraceLogEnabledForTest()
 	if DBTraceLogEnabled() {
 		t.Fatal("expected DB trace log to be disabled after reset")
+	}
+
+	t.Setenv(envDBTraceLogEnabled, "true")
+	resetDBTraceLogEnabledForTest()
+	if !DBTraceLogEnabled() {
+		t.Fatal("expected DB trace log to be enabled")
+	}
+}
+
+func TestDBSlowTraceThresholdDefaultsTo300MS(t *testing.T) {
+	resetDBSlowTraceThresholdForTest()
+	t.Cleanup(resetDBSlowTraceThresholdForTest)
+
+	if got := DBSlowTraceThreshold(); got != 300*time.Millisecond {
+		t.Fatalf("DBSlowTraceThreshold() = %s, want 300ms", got)
+	}
+}
+
+func TestDBSlowTraceThresholdAcceptsZeroForAllOperations(t *testing.T) {
+	resetDBSlowTraceThresholdForTest()
+	t.Cleanup(resetDBSlowTraceThresholdForTest)
+
+	t.Setenv(envDBSlowTraceMS, "0")
+	if got := DBSlowTraceThreshold(); got != 0 {
+		t.Fatalf("DBSlowTraceThreshold() = %s, want 0", got)
+	}
+}
+
+func TestDBSlowTraceThresholdCachesUntilReset(t *testing.T) {
+	resetDBSlowTraceThresholdForTest()
+	t.Cleanup(resetDBSlowTraceThresholdForTest)
+
+	t.Setenv(envDBSlowTraceMS, "250")
+	if got := DBSlowTraceThreshold(); got != 250*time.Millisecond {
+		t.Fatalf("DBSlowTraceThreshold() = %s, want 250ms", got)
+	}
+
+	t.Setenv(envDBSlowTraceMS, "500")
+	if got := DBSlowTraceThreshold(); got != 250*time.Millisecond {
+		t.Fatalf("DBSlowTraceThreshold() = %s, want cached 250ms before reset", got)
+	}
+
+	resetDBSlowTraceThresholdForTest()
+	if got := DBSlowTraceThreshold(); got != 500*time.Millisecond {
+		t.Fatalf("DBSlowTraceThreshold() after reset = %s, want 500ms", got)
 	}
 }
 

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -283,7 +283,7 @@ func observeDBOperation(ctx context.Context, role, operation, query string, star
 	result := dbResult(err)
 	metrics.RecordDBOperation(role, operation, result, elapsed)
 
-	if !logger.BenchTimingLogEnabled() {
+	if !logger.BenchTimingLogEnabled() && !logger.DBTraceLogEnabled() {
 		return
 	}
 
@@ -308,7 +308,7 @@ func observeDBOperation(ctx context.Context, role, operation, query string, star
 	if err != nil {
 		fields = append(fields, safeDBErrorFields(err)...)
 	}
-	logger.InfoBenchTiming(ctx, "db_operation_timing", fields...)
+	logger.Info(ctx, "db_operation_timing", fields...)
 }
 
 func dbResult(err error) string {

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -283,7 +283,7 @@ func observeDBOperation(ctx context.Context, role, operation, query string, star
 	result := dbResult(err)
 	metrics.RecordDBOperation(role, operation, result, elapsed)
 
-	if !logger.BenchTimingLogEnabled() && !logger.DBTraceLogEnabled() {
+	if !logger.DBTraceLogEnabled() {
 		return
 	}
 

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -286,6 +286,9 @@ func observeDBOperation(ctx context.Context, role, operation, query string, star
 	if !logger.DBTraceLogEnabled() {
 		return
 	}
+	if threshold := logger.DBSlowTraceThreshold(); threshold > 0 && elapsed < threshold {
+		return
+	}
 
 	fields := []zap.Field{
 		zap.String("role", role),

--- a/pkg/mysqlutil/instrumented_test.go
+++ b/pkg/mysqlutil/instrumented_test.go
@@ -29,7 +29,7 @@ func TestObserveDBOperationLogsSQLTraceWithoutArgs(t *testing.T) {
 	t.Cleanup(func() { logger.Set(prevLogger) })
 
 	ctx := context.Background()
-	start := time.Now().Add(-10 * time.Millisecond)
+	start := time.Now().Add(-350 * time.Millisecond)
 	observeDBOperation(ctx, RoleUser, "exec", "  INSERT INTO file_nodes\n(path, name) VALUES (?, ?)  ", start, errors.New("duplicate key"))
 
 	entries := recorded.FilterMessage("db_operation_timing").All()
@@ -70,7 +70,7 @@ func TestObserveDBOperationLogsSQLTraceWhenDBTraceEnabled(t *testing.T) {
 	logger.Set(zap.New(core))
 	t.Cleanup(func() { logger.Set(prevLogger) })
 
-	observeDBOperation(context.Background(), RoleUser, "query", "SELECT * FROM file_nodes WHERE path = ?", time.Now(), nil)
+	observeDBOperation(context.Background(), RoleUser, "query", "SELECT * FROM file_nodes WHERE path = ?", time.Now().Add(-350*time.Millisecond), nil)
 
 	entries := recorded.FilterMessage("db_operation_timing").All()
 	if len(entries) != 1 {
@@ -128,7 +128,7 @@ func TestObserveDBOperationLogsSafeErrorDetails(t *testing.T) {
 		Number:  1062,
 		Message: "Duplicate entry '" + secret + "' for key 'files.name'",
 	}
-	observeDBOperation(context.Background(), RoleUser, "exec", "INSERT INTO files(name) VALUES (?)", time.Now(), dbErr)
+	observeDBOperation(context.Background(), RoleUser, "exec", "INSERT INTO files(name) VALUES (?)", time.Now().Add(-350*time.Millisecond), dbErr)
 
 	entries := recorded.FilterMessage("db_operation_timing").All()
 	if len(entries) != 1 {
@@ -160,7 +160,7 @@ func TestObserveDBOperationBoundsSQLTraceField(t *testing.T) {
 	t.Cleanup(func() { logger.Set(prevLogger) })
 
 	query := "SELECT " + strings.Repeat("x", maxSQLTraceLen*3) + " FROM files"
-	observeDBOperation(context.Background(), RoleUser, "query", query, time.Now(), nil)
+	observeDBOperation(context.Background(), RoleUser, "query", query, time.Now().Add(-350*time.Millisecond), nil)
 
 	entries := recorded.FilterMessage("db_operation_timing").All()
 	if len(entries) != 1 {
@@ -223,6 +223,63 @@ func TestObserveDBOperationSkipsTraceWhenOnlyBenchTimingEnabled(t *testing.T) {
 
 	if entries := recorded.FilterMessage("db_operation_timing").All(); len(entries) != 0 {
 		t.Fatalf("db_operation_timing entries = %d, want 0", len(entries))
+	}
+}
+
+func TestObserveDBOperationSkipsTraceBelowDefaultSlowThreshold(t *testing.T) {
+	t.Setenv("DRIVE9_DB_TRACE_LOG_ENABLED", "true")
+	logger.ResetDBTraceLogEnabledForTest()
+	logger.ResetDBSlowTraceThresholdForTest()
+	t.Cleanup(logger.ResetDBTraceLogEnabledForTest)
+	t.Cleanup(logger.ResetDBSlowTraceThresholdForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	observeDBOperation(context.Background(), RoleUser, "query", "SELECT * FROM file_nodes", time.Now().Add(-50*time.Millisecond), nil)
+
+	if entries := recorded.FilterMessage("db_operation_timing").All(); len(entries) != 0 {
+		t.Fatalf("db_operation_timing entries = %d, want 0", len(entries))
+	}
+}
+
+func TestObserveDBOperationLogsTraceAboveDefaultSlowThreshold(t *testing.T) {
+	logger.ResetDBTraceLogEnabledForTest()
+	logger.ResetDBSlowTraceThresholdForTest()
+	t.Cleanup(logger.ResetDBTraceLogEnabledForTest)
+	t.Cleanup(logger.ResetDBSlowTraceThresholdForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	observeDBOperation(context.Background(), RoleUser, "query", "SELECT * FROM file_nodes", time.Now().Add(-350*time.Millisecond), nil)
+
+	if entries := recorded.FilterMessage("db_operation_timing").All(); len(entries) != 1 {
+		t.Fatalf("db_operation_timing entries = %d, want 1", len(entries))
+	}
+}
+
+func TestObserveDBOperationLogsTraceWhenSlowThresholdIsZero(t *testing.T) {
+	t.Setenv("DRIVE9_DB_TRACE_LOG_ENABLED", "true")
+	t.Setenv("DRIVE9_DB_SLOW_TRACE_MS", "0")
+	logger.ResetDBTraceLogEnabledForTest()
+	logger.ResetDBSlowTraceThresholdForTest()
+	t.Cleanup(logger.ResetDBTraceLogEnabledForTest)
+	t.Cleanup(logger.ResetDBSlowTraceThresholdForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	observeDBOperation(context.Background(), RoleUser, "query", "SELECT * FROM file_nodes", time.Now(), nil)
+
+	if entries := recorded.FilterMessage("db_operation_timing").All(); len(entries) != 1 {
+		t.Fatalf("db_operation_timing entries = %d, want 1", len(entries))
 	}
 }
 

--- a/pkg/mysqlutil/instrumented_test.go
+++ b/pkg/mysqlutil/instrumented_test.go
@@ -17,9 +17,11 @@ import (
 )
 
 func TestObserveDBOperationLogsSQLTraceWithoutArgs(t *testing.T) {
-	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "true")
+	t.Setenv("DRIVE9_DB_TRACE_LOG_ENABLED", "true")
 	logger.ResetBenchTimingLogEnabledForTest()
+	logger.ResetDBTraceLogEnabledForTest()
 	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+	t.Cleanup(logger.ResetDBTraceLogEnabledForTest)
 
 	core, recorded := observer.New(zap.InfoLevel)
 	prevLogger := logger.L()
@@ -110,9 +112,11 @@ func TestNormalizeSQLForTraceStripsComments(t *testing.T) {
 }
 
 func TestObserveDBOperationLogsSafeErrorDetails(t *testing.T) {
-	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "true")
+	t.Setenv("DRIVE9_DB_TRACE_LOG_ENABLED", "true")
 	logger.ResetBenchTimingLogEnabledForTest()
+	logger.ResetDBTraceLogEnabledForTest()
 	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+	t.Cleanup(logger.ResetDBTraceLogEnabledForTest)
 
 	core, recorded := observer.New(zap.InfoLevel)
 	prevLogger := logger.L()
@@ -144,9 +148,11 @@ func TestObserveDBOperationLogsSafeErrorDetails(t *testing.T) {
 }
 
 func TestObserveDBOperationBoundsSQLTraceField(t *testing.T) {
-	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "true")
+	t.Setenv("DRIVE9_DB_TRACE_LOG_ENABLED", "true")
 	logger.ResetBenchTimingLogEnabledForTest()
+	logger.ResetDBTraceLogEnabledForTest()
 	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+	t.Cleanup(logger.ResetDBTraceLogEnabledForTest)
 
 	core, recorded := observer.New(zap.InfoLevel)
 	prevLogger := logger.L()
@@ -196,7 +202,27 @@ func TestObserveDBOperationSkipsTraceFieldsWhenBenchTimingDisabled(t *testing.T)
 		t.Fatalf("db_operation_timing entries = %d, want 0", len(entries))
 	}
 	if res.rowsAffectedCalled {
-		t.Fatal("RowsAffected called while bench timing logs are disabled")
+		t.Fatal("RowsAffected called while DB trace logs are disabled")
+	}
+}
+
+func TestObserveDBOperationSkipsTraceWhenOnlyBenchTimingEnabled(t *testing.T) {
+	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "true")
+	t.Setenv("DRIVE9_DB_TRACE_LOG_ENABLED", "false")
+	logger.ResetBenchTimingLogEnabledForTest()
+	logger.ResetDBTraceLogEnabledForTest()
+	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+	t.Cleanup(logger.ResetDBTraceLogEnabledForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	observeDBOperation(context.Background(), RoleUser, "query", "SELECT * FROM file_nodes", time.Now(), nil)
+
+	if entries := recorded.FilterMessage("db_operation_timing").All(); len(entries) != 0 {
+		t.Fatalf("db_operation_timing entries = %d, want 0", len(entries))
 	}
 }
 

--- a/pkg/mysqlutil/instrumented_test.go
+++ b/pkg/mysqlutil/instrumented_test.go
@@ -55,6 +55,31 @@ func TestObserveDBOperationLogsSQLTraceWithoutArgs(t *testing.T) {
 	}
 }
 
+func TestObserveDBOperationLogsSQLTraceWhenDBTraceEnabled(t *testing.T) {
+	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "false")
+	t.Setenv("DRIVE9_DB_TRACE_LOG_ENABLED", "true")
+	logger.ResetBenchTimingLogEnabledForTest()
+	logger.ResetDBTraceLogEnabledForTest()
+	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+	t.Cleanup(logger.ResetDBTraceLogEnabledForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	observeDBOperation(context.Background(), RoleUser, "query", "SELECT * FROM file_nodes WHERE path = ?", time.Now(), nil)
+
+	entries := recorded.FilterMessage("db_operation_timing").All()
+	if len(entries) != 1 {
+		t.Fatalf("db_operation_timing entries = %d, want 1", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	if fields["sql"] != "SELECT * FROM file_nodes WHERE path = ?" {
+		t.Errorf("sql field = %v", fields["sql"])
+	}
+}
+
 func TestNormalizeSQLForTraceRedactsLiterals(t *testing.T) {
 	query := `SELECT * FROM files
 		WHERE name = 'agent secret'
@@ -153,8 +178,11 @@ func TestObserveDBOperationBoundsSQLTraceField(t *testing.T) {
 
 func TestObserveDBOperationSkipsTraceFieldsWhenBenchTimingDisabled(t *testing.T) {
 	t.Setenv("DRIVE9_BENCH_TIMING_LOG_ENABLED", "false")
+	t.Setenv("DRIVE9_DB_TRACE_LOG_ENABLED", "false")
 	logger.ResetBenchTimingLogEnabledForTest()
+	logger.ResetDBTraceLogEnabledForTest()
 	t.Cleanup(logger.ResetBenchTimingLogEnabledForTest)
+	t.Cleanup(logger.ResetDBTraceLogEnabledForTest)
 
 	core, recorded := observer.New(zap.InfoLevel)
 	prevLogger := logger.L()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2212,13 +2212,13 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 				return
 			}
 			if errors.Is(err, datastore.ErrUploadConflict) {
-				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_upload_conflict", "path", path, "error", err)...)
+				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_upload_conflict", "path", path, "detail", err.Error())...)
 				metricEvent(r.Context(), "fs_write", "result", "conflict")
 				errJSON(w, http.StatusConflict, err.Error())
 				return
 			}
 			if errors.Is(err, datastore.ErrRevisionConflict) {
-				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_upload_revision_conflict", "path", path, "error", err)...)
+				logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_upload_revision_conflict", "path", path, "detail", err.Error())...)
 				metricEvent(r.Context(), "fs_write", "result", "conflict")
 				errJSON(w, http.StatusConflict, err.Error())
 				return
@@ -2295,7 +2295,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 			return
 		}
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_conflict", "path", path, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_conflict", "path", path, "detail", err.Error())...)
 			metricEvent(r.Context(), "fs_write", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
@@ -2462,7 +2462,7 @@ func (s *Server) handlePatch(w http.ResponseWriter, r *http.Request, path string
 			return
 		}
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "patch_revision_conflict", "path", path, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "patch_revision_conflict", "path", path, "detail", err.Error())...)
 			metricEvent(r.Context(), "fs_patch", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
@@ -2560,7 +2560,7 @@ func (s *Server) handleAppend(w http.ResponseWriter, r *http.Request, path strin
 			return
 		}
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "append_revision_conflict", "path", path, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "append_revision_conflict", "path", path, "detail", err.Error())...)
 			metricEvent(r.Context(), "fs_append", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
@@ -3322,7 +3322,7 @@ func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string
 	}
 	if err := b.MkdirCtx(r.Context(), path, mode); err != nil {
 		if errors.Is(err, datastore.ErrPathConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "mkdir_conflict", "path", path, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "mkdir_conflict", "path", path, "detail", err.Error())...)
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
@@ -3391,7 +3391,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request, path strin
 	}
 	if err := b.CreateCtx(r.Context(), path); err != nil {
 		if errors.Is(err, datastore.ErrPathConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "create_conflict", "path", path, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "create_conflict", "path", path, "detail", err.Error())...)
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
@@ -3453,7 +3453,7 @@ func (s *Server) handleSymlink(w http.ResponseWriter, r *http.Request, path stri
 			return
 		}
 		if errors.Is(err, datastore.ErrPathConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_conflict", "path", path, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "symlink_conflict", "path", path, "detail", err.Error())...)
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
@@ -3629,13 +3629,13 @@ func (s *Server) handleUploadInitiate(w http.ResponseWriter, r *http.Request, b 
 			return
 		}
 		if errors.Is(err, datastore.ErrUploadConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_conflict", "path", req.Path, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_conflict", "path", req.Path, "detail", err.Error())...)
 			metricEvent(r.Context(), "fs_write", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_revision_conflict", "path", req.Path, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_revision_conflict", "path", req.Path, "detail", err.Error())...)
 			metricEvent(r.Context(), "fs_write", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
@@ -3738,7 +3738,7 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 			return
 		}
 		if errors.Is(err, datastore.ErrUploadNotActive) || errors.Is(err, datastore.ErrPathConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_conflict", "upload_id", uploadID, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_conflict", "upload_id", uploadID, "detail", err.Error())...)
 			metricEvent(r.Context(), "upload_complete", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
@@ -3750,7 +3750,7 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 			return
 		}
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_revision_conflict", "upload_id", uploadID, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_revision_conflict", "upload_id", uploadID, "detail", err.Error())...)
 			metricEvent(r.Context(), "upload_complete", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
@@ -4095,13 +4095,13 @@ func (s *Server) handleV2UploadInitiate(w http.ResponseWriter, r *http.Request) 
 			return
 		}
 		if errors.Is(err, datastore.ErrUploadConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_conflict", "path", req.Path, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_conflict", "path", req.Path, "detail", err.Error())...)
 			metricEvent(r.Context(), "v2_upload_initiate", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_revision_conflict", "path", req.Path, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_revision_conflict", "path", req.Path, "detail", err.Error())...)
 			metricEvent(r.Context(), "v2_upload_initiate", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
@@ -4303,13 +4303,13 @@ func (s *Server) handleV2UploadComplete(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 		if errors.Is(err, datastore.ErrPathConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_conflict", "upload_id", uploadID, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_conflict", "upload_id", uploadID, "detail", err.Error())...)
 			metricEvent(r.Context(), "v2_upload_complete", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return
 		}
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_revision_conflict", "upload_id", uploadID, "error", err)...)
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_revision_conflict", "upload_id", uploadID, "detail", err.Error())...)
 			metricEvent(r.Context(), "v2_upload_complete", "result", "conflict")
 			errJSON(w, http.StatusConflict, err.Error())
 			return


### PR DESCRIPTION
## Summary
- classify backend path/upload/revision/idempotency conflicts as result=conflict instead of result=error
- keep datastore conflict observations visible at warn level with detail instead of error fields
- remove error fields from expected conflict server_event logs; HTTP behavior is unchanged

## Test
- go test ./pkg/datastore -run TestShouldLogStoreOpFailure -count=1
- go test ./pkg/backend -run TestBackendResultForErrorClassifiesExpectedConflicts -count=1
- go test ./pkg/server -run '^$' -count=1
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Monitoring**
  - Refined backend and datastore operation result tracking, including clearer mapping for conflicts, cancellations, deadlines, missing resources, and other errors.

- **Logging**
  - Conflict outcomes are no longer treated as unexpected failures for datastore operation logging.
  - Server-side conflict logging now surfaces the conflict information under a clearer log field (without changing HTTP responses).

- **Configuration / Documentation**
  - Added `DRIVE9_DB_TRACE_LOG_ENABLED` to enable DB SQL trace logs (default: `false`).

- **Tests**
  - Added/updated coverage for conflict classification, logging behavior, and DB trace flag caching.  

- **Compatibility**
  - HTTP status codes, response bodies, and endpoint behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->