### PR TITLE
Optimize workspace root mount validation

### DIFF
--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -203,6 +204,26 @@ func (o *MountOptions) setDefaults() {
 	}
 }
 
+func validateWorkspaceRoot(c *client.Client) error {
+	stat, err := c.Stat("/")
+	if err == nil {
+		if !stat.IsDir {
+			return fmt.Errorf("remote root %q is not a directory", "/")
+		}
+		return nil
+	}
+
+	var statusErr *client.StatusError
+	if !errors.As(err, &statusErr) ||
+		(statusErr.StatusCode != http.StatusNotFound && statusErr.StatusCode != http.StatusMethodNotAllowed) {
+		return fmt.Errorf("cannot reach drive9 server: %w", err)
+	}
+	if _, listErr := c.List("/"); listErr != nil {
+		return fmt.Errorf("cannot reach drive9 server: %w", listErr)
+	}
+	return nil
+}
+
 // Mount creates and serves a FUSE mount. It blocks until the filesystem
 // is unmounted or a signal (SIGINT, SIGTERM) is received.
 func Mount(opts *MountOptions) error {
@@ -261,8 +282,8 @@ func Mount(opts *MountOptions) error {
 	}
 	opts.RemoteRoot = remoteRoot
 	if remoteRoot == "/" {
-		if _, err := c.List("/"); err != nil {
-			return fmt.Errorf("cannot reach drive9 server: %w", err)
+		if err := validateWorkspaceRoot(c); err != nil {
+			return err
 		}
 	} else {
 		stat, err := c.Stat(remoteRoot)

--- a/pkg/fuse/mount_remote_root_test.go
+++ b/pkg/fuse/mount_remote_root_test.go
@@ -1,0 +1,123 @@
+package fuse
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/client"
+)
+
+func TestValidateWorkspaceRootRequestBehavior(t *testing.T) {
+	tests := []struct {
+		name         string
+		headStatus   int
+		headIsDir    bool
+		listStatus   int
+		wantRequests []string
+		wantErr      string
+	}{
+		{
+			name:         "stat succeeds",
+			headStatus:   http.StatusOK,
+			headIsDir:    true,
+			wantRequests: []string{"HEAD /v1/fs/"},
+		},
+		{
+			name:         "not found falls back once",
+			headStatus:   http.StatusNotFound,
+			listStatus:   http.StatusOK,
+			wantRequests: []string{"HEAD /v1/fs/", "GET /v1/fs/?list=1"},
+		},
+		{
+			name:         "method not allowed falls back once",
+			headStatus:   http.StatusMethodNotAllowed,
+			listStatus:   http.StatusOK,
+			wantRequests: []string{"HEAD /v1/fs/", "GET /v1/fs/?list=1"},
+		},
+		{
+			name:         "authentication failure does not fall back",
+			headStatus:   http.StatusUnauthorized,
+			wantRequests: []string{"HEAD /v1/fs/"},
+			wantErr:      "HTTP 401",
+		},
+		{
+			name:         "server failure does not fall back",
+			headStatus:   http.StatusInternalServerError,
+			wantRequests: []string{"HEAD /v1/fs/"},
+			wantErr:      "HTTP 500",
+		},
+		{
+			name:         "root must be a directory",
+			headStatus:   http.StatusOK,
+			wantRequests: []string{"HEAD /v1/fs/"},
+			wantErr:      `remote root "/" is not a directory`,
+		},
+		{
+			name:         "fallback list failure is returned",
+			headStatus:   http.StatusNotFound,
+			listStatus:   http.StatusInternalServerError,
+			wantRequests: []string{"HEAD /v1/fs/", "GET /v1/fs/?list=1"},
+			wantErr:      "HTTP 500",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var mu sync.Mutex
+			var requests []string
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				mu.Lock()
+				requests = append(requests, r.Method+" "+r.URL.RequestURI())
+				mu.Unlock()
+
+				switch r.Method {
+				case http.MethodHead:
+					if tt.headIsDir {
+						w.Header().Set("X-Dat9-IsDir", "true")
+					} else {
+						w.Header().Set("X-Dat9-IsDir", "false")
+					}
+					w.WriteHeader(tt.headStatus)
+				case http.MethodGet:
+					if r.URL.Query().Get("list") != "1" {
+						t.Errorf("list query = %q, want 1", r.URL.Query().Get("list"))
+					}
+					listStatus := tt.listStatus
+					if listStatus == 0 {
+						listStatus = http.StatusOK
+					}
+					w.WriteHeader(listStatus)
+					if listStatus < http.StatusMultipleChoices {
+						_, _ = w.Write([]byte(`{"entries":[]}`))
+					}
+				default:
+					t.Errorf("request method = %s, want HEAD or GET", r.Method)
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			}))
+			t.Cleanup(server.Close)
+
+			err := validateWorkspaceRoot(client.New(server.URL, ""))
+			if tt.wantErr == "" && err != nil {
+				t.Fatalf("validateWorkspaceRoot() error = %v, want nil", err)
+			}
+			if tt.wantErr != "" && (err == nil || !strings.Contains(err.Error(), tt.wantErr)) {
+				t.Fatalf("validateWorkspaceRoot() error = %v, want containing %q", err, tt.wantErr)
+			}
+
+			mu.Lock()
+			defer mu.Unlock()
+			if len(requests) != len(tt.wantRequests) {
+				t.Fatalf("requests = %v, want %v", requests, tt.wantRequests)
+			}
+			for i := range tt.wantRequests {
+				if requests[i] != tt.wantRequests[i] {
+					t.Fatalf("requests[%d] = %q, want %q", i, requests[i], tt.wantRequests[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- validate workspace-root mounts with Stat/HEAD instead of listing every root entry
- fall back to one List request only when HEAD returns 404 or 405 for legacy server compatibility
- cover the fast path, bounded fallback, authentication/server failures, non-directory roots, and fallback failures

## Why

CSI workspace-root mounts only need to verify that the remote root is a directory. Listing and decoding every root entry makes startup work grow with root size, while the server already provides a constant-size root HEAD response.

## Testing

- go test -race ./pkg/fuse -run ^TestValidateWorkspaceRootRequestBehavior$ -count=1

## Compatibility

- no CLI flag or API contract changes
- supported servers use HEAD only
- legacy servers without root HEAD support retain a single List fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation when mounting a workspace configured at the remote root.
  * Mounting now distinguishes between missing or unsupported root checks and genuine authentication or server errors.
  * Added clearer error reporting when the remote root is unavailable or is not a directory.
  * Improved fallback connectivity checks for servers that do not support direct root inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->