### PR TITLE
feat: fs_slow_request diagnostic log for slow list operations

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1940,11 +1940,13 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 		if errors.Is(err, datastore.ErrNotFound) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "list_not_found", "path", path)...)
 			errJSON(w, http.StatusNotFound, err.Error())
+			logSlowFSList(r.Context(), path, 0, http.StatusNotFound, time.Since(start), readDirDuration)
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "list_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "userdb_query", "api", "list", "result", "error")
 		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		logSlowFSList(r.Context(), path, 0, http.StatusInternalServerError, time.Since(start), readDirDuration)
 		return
 	}
 	metricEvent(r.Context(), "userdb_query", "api", "list", "result", "ok")
@@ -1999,7 +2001,7 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"entries": out})
 
-	logSlowFSList(r.Context(), path, len(entries), time.Since(start), readDirDuration)
+	logSlowFSList(r.Context(), path, len(entries), http.StatusOK, time.Since(start), readDirDuration)
 }
 
 func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path string) {
@@ -2364,7 +2366,7 @@ const slowWriteBodyReadThreshold = 5 * time.Second
 // follow-up PR.
 const slowFSRequestThreshold = 500 * time.Millisecond
 
-func logSlowFSList(ctx context.Context, path string, entries int, total, readDir time.Duration) {
+func logSlowFSList(ctx context.Context, path string, entries, status int, total, readDir time.Duration) {
 	if total < slowFSRequestThreshold {
 		return
 	}
@@ -2373,7 +2375,7 @@ func logSlowFSList(ctx context.Context, path string, entries int, total, readDir
 		zap.String("op", "list"),
 		zap.String("path", path),
 		zap.Int("entries", entries),
-		zap.Int("status", http.StatusOK),
+		zap.Int("status", status),
 		zap.Float64("total_ms", serverDurationMs(total)),
 		zap.Float64("read_dir_ms", serverDurationMs(readDir)),
 		zap.String("tenant_id", tenantID),

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1998,6 +1998,8 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"entries": out})
+
+	logSlowFSList(r.Context(), path, len(entries), time.Since(start), readDirDuration)
 }
 
 func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path string) {
@@ -2354,6 +2356,30 @@ func requestBodyReadMetricBytes(declared int64, observed int) int64 {
 }
 
 const slowWriteBodyReadThreshold = 5 * time.Second
+
+// slowFSRequestThreshold is the minimum handler-internal duration before a
+// slow-path diagnostic log is emitted for FS list operations. This only
+// covers the handler phase (ReadDir + serialization); auth/middleware overhead
+// is not included — that gap is a known limitation to be addressed in a
+// follow-up PR.
+const slowFSRequestThreshold = 500 * time.Millisecond
+
+func logSlowFSList(ctx context.Context, path string, entries int, total, readDir time.Duration) {
+	if total < slowFSRequestThreshold {
+		return
+	}
+	tenantID, apiKeyID, _ := requestMetricScope(ctx)
+	logger.Info(ctx, "fs_slow_request",
+		zap.String("op", "list"),
+		zap.String("path", path),
+		zap.Int("entries", entries),
+		zap.Int("status", http.StatusOK),
+		zap.Float64("total_ms", serverDurationMs(total)),
+		zap.Float64("read_dir_ms", serverDurationMs(readDir)),
+		zap.String("tenant_id", tenantID),
+		zap.String("api_key_id", apiKeyID),
+	)
+}
 
 func logSlowWriteBodyRead(ctx context.Context, r *http.Request, route string, bytes int64, d time.Duration) {
 	if d < slowWriteBodyReadThreshold {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -450,18 +450,24 @@ func TestListDirFastNoSlowLog(t *testing.T) {
 	ts := httptest.NewServer(s)
 	defer ts.Close()
 
-	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/data/x.txt", strings.NewReader("x"))
-	resp, _ := http.DefaultClient.Do(req)
+	req, err := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/data/x.txt", strings.NewReader("x"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
 	_ = resp.Body.Close()
 
-	resp, err := http.Get(ts.URL + "/v1/fs/data/?list=1")
+	resp, err = http.Get(ts.URL + "/v1/fs/data/?list=1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	_ = resp.Body.Close()
 
 	if entries := recorded.FilterMessage("fs_slow_request").AllUntimed(); len(entries) != 0 {
-		t.Fatalf("fast list should not produce fs_slow_request; got %d entries", len(entries))
+		t.Errorf("fast list should not produce fs_slow_request; got %d entries", len(entries))
 	}
 }
 
@@ -470,13 +476,13 @@ func TestLogSlowFSListThreshold(t *testing.T) {
 	ctx := logger.WithContext(context.Background(), zap.New(core))
 
 	// Below threshold: no log
-	logSlowFSList(ctx, "/data", 5, slowFSRequestThreshold-time.Millisecond, 100*time.Millisecond)
+	logSlowFSList(ctx, "/data", 5, http.StatusOK, slowFSRequestThreshold-time.Millisecond, 100*time.Millisecond)
 	if n := recorded.FilterMessage("fs_slow_request").Len(); n != 0 {
-		t.Fatalf("below threshold: expected 0 logs, got %d", n)
+		t.Errorf("below threshold: expected 0 logs, got %d", n)
 	}
 
 	// At threshold: log emitted
-	logSlowFSList(ctx, "/data/sub", 11, slowFSRequestThreshold, 200*time.Millisecond)
+	logSlowFSList(ctx, "/data/sub", 11, http.StatusOK, slowFSRequestThreshold, 200*time.Millisecond)
 	entries := recorded.FilterMessage("fs_slow_request").AllUntimed()
 	if len(entries) != 1 {
 		t.Fatalf("at threshold: expected 1 log, got %d", len(entries))
@@ -484,23 +490,37 @@ func TestLogSlowFSListThreshold(t *testing.T) {
 	fields := entries[0].ContextMap()
 	for _, key := range []string{"op", "path", "entries", "status", "total_ms", "read_dir_ms"} {
 		if _, ok := fields[key]; !ok {
-			t.Fatalf("fs_slow_request missing field %q; got %v", key, fields)
+			t.Errorf("fs_slow_request missing field %q; got %v", key, fields)
 		}
 	}
 	if fields["op"] != "list" {
-		t.Fatalf("op = %v, want list", fields["op"])
+		t.Errorf("op = %v, want list", fields["op"])
 	}
 	if fields["path"] != "/data/sub" {
-		t.Fatalf("path = %v, want /data/sub", fields["path"])
+		t.Errorf("path = %v, want /data/sub", fields["path"])
 	}
 	if fields["entries"] != int64(11) {
-		t.Fatalf("entries = %v, want 11", fields["entries"])
+		t.Errorf("entries = %v, want 11", fields["entries"])
+	}
+	if fields["status"] != int64(http.StatusOK) {
+		t.Errorf("status = %v, want %d", fields["status"], http.StatusOK)
 	}
 
 	// Above threshold: log emitted
-	logSlowFSList(ctx, "/data/big", 100, 2*time.Second, 1900*time.Millisecond)
+	logSlowFSList(ctx, "/data/big", 100, http.StatusOK, 2*time.Second, 1900*time.Millisecond)
 	if n := recorded.FilterMessage("fs_slow_request").Len(); n != 2 {
-		t.Fatalf("above threshold: expected 2 total logs, got %d", n)
+		t.Errorf("above threshold: expected 2 total logs, got %d", n)
+	}
+
+	// Slow error path: log emitted with the failure status.
+	logSlowFSList(ctx, "/data/err", 0, http.StatusInternalServerError, 3*time.Second, 2900*time.Millisecond)
+	errEntries := recorded.FilterMessage("fs_slow_request").AllUntimed()
+	if len(errEntries) != 3 {
+		t.Fatalf("slow error path: expected 3 total logs, got %d", len(errEntries))
+	}
+	errFields := errEntries[2].ContextMap()
+	if errFields["status"] != int64(http.StatusInternalServerError) {
+		t.Errorf("error path status = %v, want %d", errFields["status"], http.StatusInternalServerError)
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -444,6 +444,66 @@ func TestListDir(t *testing.T) {
 	}
 }
 
+func TestListDirFastNoSlowLog(t *testing.T) {
+	core, recorded := observer.New(zap.InfoLevel)
+	s := newTestServerWithLogger(t, zap.New(core))
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/data/x.txt", strings.NewReader("x"))
+	resp, _ := http.DefaultClient.Do(req)
+	_ = resp.Body.Close()
+
+	resp, err := http.Get(ts.URL + "/v1/fs/data/?list=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+
+	if entries := recorded.FilterMessage("fs_slow_request").AllUntimed(); len(entries) != 0 {
+		t.Fatalf("fast list should not produce fs_slow_request; got %d entries", len(entries))
+	}
+}
+
+func TestLogSlowFSListThreshold(t *testing.T) {
+	core, recorded := observer.New(zap.InfoLevel)
+	ctx := logger.WithContext(context.Background(), zap.New(core))
+
+	// Below threshold: no log
+	logSlowFSList(ctx, "/data", 5, slowFSRequestThreshold-time.Millisecond, 100*time.Millisecond)
+	if n := recorded.FilterMessage("fs_slow_request").Len(); n != 0 {
+		t.Fatalf("below threshold: expected 0 logs, got %d", n)
+	}
+
+	// At threshold: log emitted
+	logSlowFSList(ctx, "/data/sub", 11, slowFSRequestThreshold, 200*time.Millisecond)
+	entries := recorded.FilterMessage("fs_slow_request").AllUntimed()
+	if len(entries) != 1 {
+		t.Fatalf("at threshold: expected 1 log, got %d", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	for _, key := range []string{"op", "path", "entries", "status", "total_ms", "read_dir_ms"} {
+		if _, ok := fields[key]; !ok {
+			t.Fatalf("fs_slow_request missing field %q; got %v", key, fields)
+		}
+	}
+	if fields["op"] != "list" {
+		t.Fatalf("op = %v, want list", fields["op"])
+	}
+	if fields["path"] != "/data/sub" {
+		t.Fatalf("path = %v, want /data/sub", fields["path"])
+	}
+	if fields["entries"] != int64(11) {
+		t.Fatalf("entries = %v, want 11", fields["entries"])
+	}
+
+	// Above threshold: log emitted
+	logSlowFSList(ctx, "/data/big", 100, 2*time.Second, 1900*time.Millisecond)
+	if n := recorded.FilterMessage("fs_slow_request").Len(); n != 2 {
+		t.Fatalf("above threshold: expected 2 total logs, got %d", n)
+	}
+}
+
 func TestStat(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary

- Add production-visible `fs_slow_request` log when `handleList` handler takes ≥500ms
- Named constant `slowFSRequestThreshold` (500ms), follows existing `slowWriteBodyReadThreshold` pattern
- Fields: `op`, `path`, `entries`, `status`, `total_ms`, `read_dir_ms`, `tenant_id`, `api_key_id`
- Uses `logger.Info` (not `InfoBenchTiming`), so it fires in production without bench flag
- Normal fast lists produce zero additional logs

## Motivation

A production GET `/v1/fs/.../upload?list` took 1993ms for 11 entries. Existing timing logs (`server_list_timing`, `tenant_auth_timing`) are behind `BenchTimingLogEnabled()` and invisible in production. This adds a single slow-path log to diagnose where time is spent.

## Known limitation

This PR only covers handler-internal time (ReadDir + serialization). Auth/middleware overhead is **not** included — if the 2s is in `pool.Acquire()` cold-open, this log won't capture it. A follow-up PR should inject auth start time via context to cover the full request lifecycle.

## Test plan

- [x] `TestListDirFastNoSlowLog`: fast list produces no `fs_slow_request` log
- [x] `TestLogSlowFSListThreshold`: below threshold → no log; at threshold → log with correct fields; above threshold → log emitted
- [x] `go build ./pkg/server/` clean
- [x] `go vet ./pkg/server/` clean
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Observability**
  * Added conditional diagnostic logging for slow filesystem directory listing requests.
  * Logs include operation type, target path, entry count, HTTP status, and timing breakdown, along with relevant request identifiers.
* **Reliability**
  * Added tests to confirm fast listings do not emit slow diagnostics.
  * Added threshold coverage to verify logs emit exactly at/above the configured slow-request timing, including slow error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->