### PR TITLE
Propagate request context to tenant datastore open

### DIFF
--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -154,20 +154,20 @@ type Store struct {
 }
 
 func Open(dsn string) (*Store, error) {
-	return OpenForTenant(dsn, "")
+	return OpenForTenant(context.Background(), dsn, "")
 }
 
-func OpenForTenant(dsn, tenantID string) (*Store, error) {
+func OpenForTenant(ctx context.Context, dsn, tenantID string) (*Store, error) {
 	lower := strings.ToLower(dsn)
 	if strings.Contains(lower, "multistatements=true") || strings.Contains(lower, "multistatements=1") {
 		return nil, fmt.Errorf("multiStatements is not allowed in production DSN")
 	}
-	db, err := mysqlutil.OpenInstrumentedForTenant(context.Background(), dsn, mysqlutil.RoleUser, tenantID)
+	db, err := mysqlutil.OpenInstrumentedForTenant(ctx, dsn, mysqlutil.RoleUser, tenantID)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
 	s := &Store{db: db}
-	hasLegacy, err := s.detectLegacyFiles(context.Background())
+	hasLegacy, err := s.detectLegacyFiles(ctx)
 	if err != nil {
 		_ = mysqlutil.CloseInstrumented(db)
 		return nil, fmt.Errorf("detect legacy files table: %w", err)

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mem9-ai/drive9/internal/testmysql"
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/traceid"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -101,6 +102,39 @@ func TestObserveStoreOpConflictLogsWarnDetail(t *testing.T) {
 	if fields["detail"] != ErrPathConflict.Error() {
 		t.Fatalf("detail field = %v, want %q", fields["detail"], ErrPathConflict.Error())
 	}
+}
+
+func TestOpenForTenantPropagatesTraceToDBTiming(t *testing.T) {
+	initDatastoreSchema(t, testDSN)
+	t.Setenv("DRIVE9_DB_TRACE_LOG_ENABLED", "true")
+	t.Setenv("DRIVE9_DB_SLOW_TRACE_MS", "0")
+	logger.ResetDBTraceLogEnabledForTest()
+	logger.ResetDBSlowTraceThresholdForTest()
+	t.Cleanup(logger.ResetDBTraceLogEnabledForTest)
+	t.Cleanup(logger.ResetDBSlowTraceThresholdForTest)
+
+	core, recorded := observer.New(zap.InfoLevel)
+	prevLogger := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prevLogger) })
+
+	const wantTraceID = "trace-open-store"
+	store, err := OpenForTenant(traceid.With(context.Background(), wantTraceID), testDSN, "tenant-trace")
+	if err != nil {
+		t.Fatalf("OpenForTenant: %v", err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+
+	entries := recorded.FilterMessage("db_operation_timing").All()
+	if len(entries) == 0 {
+		t.Fatal("db_operation_timing entries = 0, want at least 1")
+	}
+	for _, entry := range entries {
+		if entry.ContextMap()["trace_id"] == wantTraceID {
+			return
+		}
+	}
+	t.Fatalf("no db_operation_timing entry carried trace_id %q; entries=%#v", wantTraceID, entries)
 }
 
 func genID() string {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -184,6 +184,18 @@ func durationMs(d time.Duration) float64 {
 	return float64(d.Microseconds()) / 1000.0
 }
 
+func poolAcquireTimingFields(tenantID string, coldOpen bool, createBackendDurationMs float64, totalDuration time.Duration) []zap.Field {
+	fields := []zap.Field{
+		zap.String("tenant_id", tenantID),
+		zap.Bool("cold_open", coldOpen),
+	}
+	if coldOpen {
+		fields = append(fields, zap.Float64("create_backend_ms", createBackendDurationMs))
+	}
+	fields = append(fields, zap.Float64("total_ms", durationMs(totalDuration)))
+	return fields
+}
+
 func (p *Pool) resolveTenantEmbeddingMode(persisted string) (mode string, wasNull bool, err error) {
 	return meta.ResolveTenantEmbeddingMode(persisted, p.cfg.DisableDatabaseAutoEmbedding)
 }
@@ -356,9 +368,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 			metrics.RecordOperation("tenant_pool", "cache_lookup", "hit", 0)
 			totalDuration := time.Since(start)
 			logger.InfoOpenPoolTiming(ctx, "tenant_pool_acquire_timing", totalDuration,
-				zap.String("tenant_id", t.ID),
-				zap.Bool("cache_hit", true),
-				zap.Float64("total_ms", durationMs(totalDuration)))
+				poolAcquireTimingFields(t.ID, false, 0, totalDuration)...)
 			return e.backend, p.makeRelease(e), nil
 		}
 		if removed := p.removeLocked(e.elem, "replace"); removed != nil {
@@ -400,10 +410,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 			metrics.RecordOperation("tenant_pool", "cache_lookup", "hit", 0)
 			totalDuration := time.Since(start)
 			logger.InfoOpenPoolTiming(ctx, "tenant_pool_acquire_timing", totalDuration,
-				zap.String("tenant_id", t.ID),
-				zap.Bool("cache_hit", true),
-				zap.Float64("create_backend_ms", createBackendDurationMs),
-				zap.Float64("total_ms", durationMs(totalDuration)))
+				poolAcquireTimingFields(t.ID, true, createBackendDurationMs, totalDuration)...)
 			return e.backend, p.makeRelease(e), nil
 		}
 		if removed := p.removeLocked(e.elem, "replace"); removed != nil {
@@ -432,10 +439,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	metrics.RecordOperation("tenant_pool", "cache_lookup", "miss", 0)
 	totalDuration := time.Since(start)
 	logger.InfoOpenPoolTiming(ctx, "tenant_pool_acquire_timing", totalDuration,
-		zap.String("tenant_id", t.ID),
-		zap.Bool("cache_hit", false),
-		zap.Float64("create_backend_ms", createBackendDurationMs),
-		zap.Float64("total_ms", durationMs(totalDuration)))
+		poolAcquireTimingFields(t.ID, true, createBackendDurationMs, totalDuration)...)
 	return b, p.makeRelease(e), nil
 }
 

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -823,7 +823,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
 	openStoreStart := time.Now()
-	store, err := datastore.OpenForTenant(dsn, t.ID)
+	store, err := datastore.OpenForTenant(ctx, dsn, t.ID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("open datastore: %w", err)
 	}

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -21,6 +21,8 @@ import (
 	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/semantic"
 	"github.com/mem9-ai/drive9/pkg/tenant/schema"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestNewPoolUsesDefaultMaxTenants(t *testing.T) {
@@ -34,6 +36,44 @@ func TestNewPoolUsesDocumentedDefaultIdleReapInterval(t *testing.T) {
 	pool := NewPool(PoolConfig{IdleTimeout: time.Minute}, nil)
 	if pool.reapInterval != 2*time.Minute {
 		t.Fatalf("reap interval = %s, want 2m", pool.reapInterval)
+	}
+}
+
+func TestPoolAcquireTimingFieldsClassifyColdOpen(t *testing.T) {
+	tests := []struct {
+		name              string
+		coldOpen          bool
+		createBackendMs   float64
+		wantCreateBackend bool
+	}{
+		{name: "hot cache hit", coldOpen: false},
+		{name: "cold open inserted", coldOpen: true, createBackendMs: 12.5, wantCreateBackend: true},
+		{name: "cold open discarded by cache race", coldOpen: true, createBackendMs: 15.25, wantCreateBackend: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			core, recorded := observer.New(zap.InfoLevel)
+			zap.New(core).Info("timing", poolAcquireTimingFields("tenant-a", tt.coldOpen, tt.createBackendMs, 20*time.Millisecond)...)
+
+			entries := recorded.FilterMessage("timing").All()
+			if len(entries) != 1 {
+				t.Fatalf("entries = %d, want 1", len(entries))
+			}
+			fields := entries[0].ContextMap()
+			if fields["tenant_id"] != "tenant-a" {
+				t.Errorf("tenant_id = %v, want tenant-a", fields["tenant_id"])
+			}
+			if _, ok := fields["cache_hit"]; ok {
+				t.Errorf("cache_hit field should be omitted: %#v", fields)
+			}
+			if fields["cold_open"] != tt.coldOpen {
+				t.Errorf("cold_open = %v, want %v", fields["cold_open"], tt.coldOpen)
+			}
+			if _, ok := fields["create_backend_ms"]; ok != tt.wantCreateBackend {
+				t.Errorf("create_backend_ms present = %v, want %v", ok, tt.wantCreateBackend)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- pass request context through tenant datastore open so DB trace logs from connect/ping/detectLegacyFiles carry the request trace_id
- keep `Open` as the background-context convenience wrapper while making `OpenForTenant` require an explicit context
- add a regression test that verifies `db_operation_timing` emitted during tenant store open carries the provided trace_id

## Tests

- `go test ./pkg/datastore -run TestOpenForTenantPropagatesTraceToDBTiming -count=1`
- `go test ./pkg/tenant -run 'TestNewPoolUsesDocumentedDefaultIdleReapInterval|TestNewPoolUsesDefaultMaxTenants' -count=1`
- `go test ./pkg/datastore ./pkg/tenant -count=1`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tenant datastore operations now honor the active request context, improving cancellation and timeout handling.
  * Diagnostic database timing records now retain request trace information, making troubleshooting easier.

* **Observability**
  * Improved correlation between datastore activity and application requests through consistent trace propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->