### PR TITLE
demo: add video voice semantic search smoke

### DIFF
--- a/docs/design/video-voice-semantic-search-demo.md
+++ b/docs/design/video-voice-semantic-search-demo.md
@@ -1,0 +1,94 @@
+# Video Voice Semantic Search Demo
+
+## Scope
+
+This demo validates the fastest useful video semantic-search path for Drive9:
+voice in supported media files becomes `files.content_text` through the existing
+durable `audio_extract_text` worker, and search reuses the current grep, FTS, and
+auto-embedding pipeline. It is a video voice-search demo, not visual scene
+retrieval.
+
+The integration deliberately avoids a sidecar media stack for the first PR:
+
+- video/audio bytes remain ordinary Drive9 files
+- `.mp4`, `.m4a`, `.mp3`, and `.wav` use the current audio extraction closed set
+- transcripts are written into `files.content_text`
+- search stays on existing Drive9 APIs
+- no code is copied from external repositories
+
+## GitHub Survey
+
+| Repo | License | Fit | Notes |
+| --- | --- | --- | --- |
+| [backblaze-b2-samples/video-semantic-search](https://github.com/backblaze-b2-samples/video-semantic-search) | MIT | Best architecture reference | Full-stack TypeScript/Python sample: upload video, extract audio with ffmpeg, transcribe with Whisper, chunk transcript, embed chunks, search timestamped results. Good shape, but it is B2/Next/FastAPI-specific and heavier than a Drive9 demo needs. |
+| [WxExLGHTZ/Multimodal-Video-Retrieval](https://github.com/WxExLGHTZ/Multimodal-Video-Retrieval) | MIT | Useful V2 reference | Combines OpenCLIP visual embeddings, Whisper transcription, and metadata with late fusion. Better for visual-scene retrieval, but requires Python model stack/GPU-style dependencies and is too heavy for a quick Drive9 PR. |
+| [aihpi/workshop-video-search](https://github.com/aihpi/workshop-video-search) | No license found | Idea only | Demonstrates transcribe-and-search workflow, but no license means no code reuse. |
+| [ashrielbrian/video_search](https://github.com/ashrielbrian/video_search) | No license found | Idea only | YouTube download, Whisper transcript segments, embeddings, and Supabase. No license and not aligned with Drive9 storage/search internals. |
+
+The practical choice is to adopt the transcript-first architecture pattern, not
+the implementation. Drive9 already has the key backend primitive on `main`:
+`audio_extract_text` writes searchable transcript text into the same
+`content_text` field used by existing retrieval.
+
+## Demo Flow
+
+1. Start `drive9-server-local` with TiDB auto-embedding mode and audio extraction
+   enabled.
+2. Upload a supported media object under `/video-voice-demo/`.
+3. Wait for the durable `audio_extract_text` task to succeed for that file
+   revision.
+4. Assert `files.content_text` is populated.
+5. Run grep under `/video-voice-demo/` for a spoken phrase and verify the uploaded
+   path is returned.
+
+Local deterministic smoke:
+
+```bash
+source ./scripts/drive9-server-local-env.sh
+export DRIVE9_LOCAL_EMBEDDING_MODE=auto
+export DRIVE9_AUDIO_EXTRACT_ENABLED=true
+export DRIVE9_AUDIO_EXTRACT_MODE=stub
+make run-server-local
+python3 scripts/verify_local_video_voice_search_demo.py --mode stub
+```
+
+Provider smoke with a real video file:
+
+```bash
+source ./scripts/drive9-server-local-env.sh
+export DRIVE9_LOCAL_EMBEDDING_MODE=auto
+export DRIVE9_AUDIO_EXTRACT_ENABLED=true
+export DRIVE9_AUDIO_EXTRACT_MODE=openai
+export DRIVE9_AUDIO_EXTRACT_API_BASE=...
+export DRIVE9_AUDIO_EXTRACT_API_KEY=...
+export DRIVE9_AUDIO_EXTRACT_MODEL=whisper-1
+make run-server-local
+python3 scripts/verify_local_video_voice_search_demo.py --mode provider --video-file ./demo.mp4 --query "spoken phrase"
+```
+
+`qwen-asr` can be used the same way by setting
+`DRIVE9_AUDIO_EXTRACT_MODE=qwen-asr` and the provider-specific API settings.
+
+## Current Boundaries
+
+- This is transcript search over media voice tracks. It does not index frames,
+  objects, OCR, faces, or visual scenes.
+- Results are file-level because Drive9 currently stores searchable text at
+  `files.content_text`; there are no timestamped transcript segments yet.
+- The current extraction closed set is `.mp4`, `.m4a`, `.mp3`, and `.wav`.
+  WebM, OGG, FLAC, AAC, MOV, and MKV need explicit follow-up support.
+- The extraction task is bounded by `DRIVE9_AUDIO_EXTRACT_MAX_BYTES`,
+  `DRIVE9_AUDIO_EXTRACT_TIMEOUT_SECONDS`, and
+  `DRIVE9_AUDIO_EXTRACT_MAX_TEXT_BYTES`; long videos can be truncated or skipped.
+- Provider mode depends on the configured ASR accepting the uploaded container.
+  If a provider rejects direct MP4 input, the next step is an ffmpeg/remux stage
+  before calling ASR.
+
+## Follow-Up PRs
+
+- Add segment-level transcript storage with timestamps so search can return exact
+  moments inside a video.
+- Add optional ffmpeg extraction/remuxing for provider compatibility.
+- Add visual retrieval as a separate representation using frame sampling plus
+  CLIP-style embeddings; do not overload `content_text` with visual vectors.
+- Surface this in UI/SDK flows once the backend demo is validated.

--- a/scripts/drive9-server-local-env.sh
+++ b/scripts/drive9-server-local-env.sh
@@ -149,3 +149,8 @@ echo "  export DRIVE9_LOCAL_EMBEDDING_MODE=auto DRIVE9_AUDIO_EXTRACT_ENABLED=tru
 echo "  export DRIVE9_AUDIO_EXTRACT_API_BASE=... DRIVE9_AUDIO_EXTRACT_API_KEY=... DRIVE9_AUDIO_EXTRACT_MODEL=..."
 echo "  make run-server-local"
 echo "  python3 scripts/verify_local_audio_extract.py --mode openai --audio-file /path/to/sample.wav"
+echo ""
+echo "Video voice search smoke (optional):"
+echo "  export DRIVE9_LOCAL_EMBEDDING_MODE=auto DRIVE9_AUDIO_EXTRACT_ENABLED=true DRIVE9_AUDIO_EXTRACT_MODE=stub"
+echo "  make run-server-local"
+echo "  python3 scripts/verify_local_video_voice_search_demo.py --mode stub"

--- a/scripts/verify_local_video_voice_search_demo.py
+++ b/scripts/verify_local_video_voice_search_demo.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+
+"""Verify a minimal Drive9 video voice semantic-search demo.
+
+This is intentionally a Drive9-native smoke instead of a separate video-search
+stack. It uploads a video/audio container that Drive9 can route through the
+existing durable `audio_extract_text` path, waits for `files.content_text`, and
+optionally verifies search via the existing grep endpoint.
+
+Modes:
+
+- `stub` (default): use a tiny synthetic `.mp4` payload against
+  `DRIVE9_AUDIO_EXTRACT_MODE=stub`; asserts the deterministic stub transcript
+  and grep for `transcript`.
+- `provider`: upload a real media file (`.mp4`, `.m4a`, `.mp3`, `.wav`) against a
+  server configured with an ASR provider such as `openai` or `qwen-asr`; asserts
+  non-empty transcript text and verifies grep only when `--query` is supplied.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from pathlib import Path
+from typing import Any, Sequence
+
+from verify_local_audio_extract import (
+    DEFAULT_BASE_URL,
+    Verifier,
+    VerificationResult,
+    expected_stub_transcript,
+)
+
+
+DEFAULT_REMOTE_PREFIX = "/video-voice-demo/"
+SUPPORTED_MEDIA_EXTENSIONS = frozenset((".mp4", ".m4a", ".mp3", ".wav"))
+
+# Enough MP4 container-looking bytes for a local smoke. The stub extractor does
+# not decode media; Drive9 routes this by path/container type and verifies the
+# durable task/search plumbing.
+STUB_MP4_PAYLOAD = (
+    b"\x00\x00\x00\x18ftypmp42\x00\x00\x00\x00mp42isom"
+    + b"\x00" * 256
+)
+
+
+def normalize_remote_prefix(prefix: str) -> str:
+    prefix = prefix.strip()
+    if not prefix:
+        raise ValueError("remote prefix must not be empty")
+    if not prefix.startswith("/"):
+        prefix = "/" + prefix
+    if not prefix.endswith("/"):
+        prefix = prefix + "/"
+    return prefix
+
+
+def supported_media_extension(path: str) -> str:
+    ext = Path(path).suffix.lower()
+    if ext not in SUPPORTED_MEDIA_EXTENSIONS:
+        allowed = ", ".join(sorted(SUPPORTED_MEDIA_EXTENSIONS))
+        raise ValueError(f"unsupported media extension {ext or '<none>'}; allowed: {allowed}")
+    return ext
+
+
+def make_demo_path(prefix: str, ext: str) -> str:
+    if not ext.startswith("."):
+        ext = "." + ext
+    if ext not in SUPPORTED_MEDIA_EXTENSIONS:
+        allowed = ", ".join(sorted(SUPPORTED_MEDIA_EXTENSIONS))
+        raise ValueError(f"unsupported media extension {ext}; allowed: {allowed}")
+    suffix = uuid.uuid4().hex[:10]
+    return f"{normalize_remote_prefix(prefix)}voice-{suffix}{ext}"
+
+
+def load_provider_media(path: str) -> tuple[bytes, str]:
+    ext = supported_media_extension(path)
+    p = Path(path).expanduser()
+    if not p.is_file():
+        raise RuntimeError(f"media file not found or not a file: {path}")
+    data = p.read_bytes()
+    if not data:
+        raise RuntimeError(f"media file is empty: {path}")
+    return data, ext
+
+
+def result_payload(result: VerificationResult) -> dict[str, Any]:
+    return {
+        "flow": result.flow,
+        "path": result.path,
+        "file_id": result.file_id,
+        "revision": result.revision,
+        "task_id": result.task_id,
+        "task_type": result.task_type,
+        "status": result.status,
+        "attempt_count": result.attempt_count,
+        "content_text": result.content_text,
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        choices=("stub", "provider"),
+        default="stub",
+        help="stub: synthetic MP4 + deterministic transcript; provider: real media + ASR runtime",
+    )
+    parser.add_argument(
+        "--video-file",
+        metavar="PATH",
+        help="real media file for --mode=provider; supported extensions: .mp4, .m4a, .mp3, .wav",
+    )
+    parser.add_argument(
+        "--query",
+        help="spoken phrase to verify with grep. In stub mode, defaults to 'transcript'.",
+    )
+    parser.add_argument(
+        "--remote-prefix",
+        default=DEFAULT_REMOTE_PREFIX,
+        help=f"Drive9 directory used for uploaded demo objects (default: {DEFAULT_REMOTE_PREFIX})",
+    )
+    parser.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help="drive9-server-local base URL",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=90.0,
+        help="wait timeout for upload/task/search verification",
+    )
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=float,
+        default=1.0,
+        help="poll interval while waiting for the semantic worker",
+    )
+
+    args = parser.parse_args(argv)
+    if args.mode == "provider" and not args.video_file:
+        parser.error("--video-file is required when --mode=provider")
+    if args.mode == "stub" and args.video_file:
+        parser.error("--video-file is only valid when --mode=provider")
+    return args
+
+
+def run_demo(args: argparse.Namespace) -> dict[str, Any]:
+    remote_prefix = normalize_remote_prefix(args.remote_prefix)
+    verifier = Verifier(args.base_url, args.timeout_seconds, args.poll_interval_seconds)
+
+    if args.mode == "provider":
+        payload, ext = load_provider_media(args.video_file)
+    else:
+        payload, ext = STUB_MP4_PAYLOAD, ".mp4"
+
+    remote_path = make_demo_path(remote_prefix, ext)
+    result = verifier.verify_direct_put_bytes(remote_path, payload)
+
+    if args.mode == "stub":
+        want = expected_stub_transcript(remote_path)
+        if result.content_text != want:
+            raise RuntimeError(
+                f"stub content_text={result.content_text!r}, want {want!r}"
+            )
+    elif not (result.content_text or "").strip():
+        raise RuntimeError("provider mode produced empty content_text")
+
+    grep_query = args.query
+    if args.mode == "stub" and not grep_query:
+        grep_query = "transcript"
+    if grep_query:
+        verifier.verify_grep_under_prefix(remote_prefix, grep_query, remote_path)
+
+    return {
+        "ok": True,
+        "mode": args.mode,
+        "remote_prefix": remote_prefix,
+        "grep_checked": bool(grep_query),
+        "grep_query": grep_query or "",
+        "result": result_payload(result),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    print(json.dumps(run_demo(args), ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover - CLI failure path
+        print(json.dumps({"error": str(exc)}, ensure_ascii=False), file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/verify_local_video_voice_search_demo_test.py
+++ b/scripts/verify_local_video_voice_search_demo_test.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+import unittest
+from contextlib import redirect_stderr
+from io import StringIO
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import verify_local_video_voice_search_demo as demo
+
+
+class VideoVoiceDemoHelpersTest(unittest.TestCase):
+    def test_normalize_remote_prefix(self) -> None:
+        self.assertEqual(demo.normalize_remote_prefix("video-demo"), "/video-demo/")
+        self.assertEqual(demo.normalize_remote_prefix("/video-demo"), "/video-demo/")
+        self.assertEqual(demo.normalize_remote_prefix("/video-demo/"), "/video-demo/")
+
+    def test_supported_media_extension_accepts_current_closed_set(self) -> None:
+        self.assertEqual(demo.supported_media_extension("clip.MP4"), ".mp4")
+        self.assertEqual(demo.supported_media_extension("voice.m4a"), ".m4a")
+        self.assertEqual(demo.supported_media_extension("speech.mp3"), ".mp3")
+        self.assertEqual(demo.supported_media_extension("sample.wav"), ".wav")
+
+    def test_supported_media_extension_rejects_webm(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported media extension"):
+            demo.supported_media_extension("clip.webm")
+
+    def test_make_demo_path_uses_prefix_and_extension(self) -> None:
+        path = demo.make_demo_path("/video-voice-demo", ".mp4")
+        self.assertTrue(path.startswith("/video-voice-demo/voice-"))
+        self.assertTrue(path.endswith(".mp4"))
+
+    def test_parse_args_requires_provider_media(self) -> None:
+        with redirect_stderr(StringIO()):
+            with self.assertRaises(SystemExit):
+                demo.parse_args(["--mode", "provider"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a minimal Drive9-native video voice semantic-search demo:

- documents the GitHub repo survey and why transcript-first is the fastest safe path
- adds `scripts/verify_local_video_voice_search_demo.py` for local stub and provider smoke tests
- adds helper unit tests for supported media/path validation
- advertises the new video voice smoke in `scripts/drive9-server-local-env.sh`

This PR is intentionally a draft and should not be merged until qiffang reviews the direction. It proves voice-in-video search through the existing `audio_extract_text -> files.content_text -> grep/FTS/vector` path, not visual scene retrieval or timestamped segment search.

## Validation

- `python3 -m py_compile scripts/verify_local_video_voice_search_demo.py scripts/verify_local_video_voice_search_demo_test.py scripts/verify_local_audio_extract.py`
- `python3 -m unittest scripts/verify_local_video_voice_search_demo_test.py`
- `bash -n scripts/drive9-server-local-env.sh`
- `python3 scripts/verify_local_video_voice_search_demo.py --help`
- `git diff --cached --check`
- `go test ./cmd/drive9-server -run Audio -count=1`
- `go test ./cmd/drive9-server-local -run Audio -count=1`

## Notes

I did not run the live `drive9-server-local` stub demo because it requires local TiDB/server runtime setup. The script is wired to use the existing local audio verifier helpers once that runtime is started.
