### PR TITLE
Add shared-schema (fs_id) foundation and minimal shared-DB mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,11 +276,12 @@ Obtain a logger from `pkg/logger` or accept `*zap.Logger` via `Config`.
 drive9-server schema dump-init-sql --provider tidb_zero
 drive9-server schema dump-init-sql --provider tidb_cloud_native
 drive9-server schema dump-init-sql --provider db9
-drive9-server schema dump-init-sql --provider shared
+drive9-server schema dump-init-sql --provider tidb_cloud_native_shared
 ```
 
-- The `shared` provider dumps the new shared (multi-tenant) schema shape: all 31 tenant tables in
-  one physical database, each carrying an `fs_id BIGINT NOT NULL` discriminator column.
+- The `tidb_cloud_native_shared` provider dumps the new shared (multi-tenant) schema shape: all
+  31 tenant tables in one physical database, each carrying an `fs_id BIGINT NOT NULL`
+  discriminator column.
 
 - Do not maintain a second handwritten copy of those init SQL statements when a command can
   export the exact runtime source of truth.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,7 +276,11 @@ Obtain a logger from `pkg/logger` or accept `*zap.Logger` via `Config`.
 drive9-server schema dump-init-sql --provider tidb_zero
 drive9-server schema dump-init-sql --provider tidb_cloud_native
 drive9-server schema dump-init-sql --provider db9
+drive9-server schema dump-init-sql --provider shared
 ```
+
+- The `shared` provider dumps the new shared (multi-tenant) schema shape: all 31 tenant tables in
+  one physical database, each carrying an `fs_id BIGINT NOT NULL` discriminator column.
 
 - Do not maintain a second handwritten copy of those init SQL statements when a command can
   export the exact runtime source of truth.

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -332,14 +332,24 @@ func main() {
 
 		// Optional shared-schema pool: when DRIVE9_SHARED_POOL_DSN is set,
 		// initialize the shared schema on that database and register it in
-		// db_pool so tenants in the matching org (default: wildcard) are
-		// provisioned onto it instead of getting a dedicated cluster.
+		// db_pool so tenants in the matching org are provisioned onto it
+		// instead of getting a dedicated cluster. The org binding is always
+		// explicit — DRIVE9_SHARED_POOL_ORG has no default, and the '*' wildcard
+		// (which places ALL new tenants on the shared pool) is opt-in and loud.
 		if sharedDSN := strings.TrimSpace(os.Getenv("DRIVE9_SHARED_POOL_DSN")); sharedDSN != "" {
-			if err := registerSharedPoolFromEnv(context.Background(), store, pool, sharedDSN, envOr("DRIVE9_SHARED_POOL_ORG", meta.SharedDBOrgWildcard)); err != nil {
+			sharedOrg := strings.TrimSpace(os.Getenv("DRIVE9_SHARED_POOL_ORG"))
+			if sharedOrg == "" {
+				die(fmt.Errorf("DRIVE9_SHARED_POOL_ORG is required when DRIVE9_SHARED_POOL_DSN is set (set an explicit org id; use '*' only to intentionally place ALL new tenants on the shared pool)"))
+			}
+			if err := registerSharedPoolFromEnv(context.Background(), store, pool, sharedDSN, sharedOrg); err != nil {
 				die(fmt.Errorf("register shared pool: %w", err))
 			}
+			if sharedOrg == meta.SharedDBOrgWildcard {
+				logger.Warn(context.Background(), "shared_pool_wildcard_all_new_tenants",
+					zap.String("warning", "ALL new tenants will be provisioned onto the shared pool"))
+			}
 			logger.Info(context.Background(), "shared_pool_registered",
-				zap.String("org", envOr("DRIVE9_SHARED_POOL_ORG", meta.SharedDBOrgWildcard)))
+				zap.String("org", sharedOrg))
 		}
 
 		// The mutation replay and expiry sweep workers are owned by the server
@@ -590,7 +600,7 @@ environment:
   DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS max open connections for tenant schema-init DB pools (default: 8)
   DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS max idle connections for tenant schema-init DB pools (default: 2)
   DRIVE9_SHARED_POOL_DSN register a shared-schema DB at startup and place matching tenants on it (empty = disabled)
-  DRIVE9_SHARED_POOL_ORG TiDB Cloud org the shared pool serves (default: * = any org)
+  DRIVE9_SHARED_POOL_ORG TiDB Cloud org the shared pool serves (required when DSN is set; '*' = all orgs, loud warn)
   DRIVE9_SHARED_DB_MAX_OPEN_CONNS max open connections for each shared-schema DB handle (default: 50)
   DRIVE9_SHARED_DB_MAX_IDLE_CONNS max idle connections for each shared-schema DB handle (default: 10)
   DRIVE9_DB_HEALTH_PROBE_INTERVAL_SECONDS DB health probe interval seconds (default: 15)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -490,7 +490,13 @@ func registerSharedPoolFromEnv(ctx context.Context, metaStore *meta.Store, pool 
 	if err != nil {
 		return fmt.Errorf("parse DRIVE9_SHARED_POOL_DSN port %q: %w", portStr, err)
 	}
-	tls := cfg.TLSConfig != "" && cfg.TLSConfig != "false"
+	// Persist the driver TLS mode verbatim ("true", "skip-verify", a custom
+	// registered config name; "" for plaintext) so the runtime handle reopens
+	// the DB with exactly the mode the schema init DSN used.
+	tlsMode := cfg.TLSConfig
+	if tlsMode == "false" {
+		tlsMode = ""
+	}
 	_, err = metaStore.RegisterSharedDB(ctx, &meta.SharedDB{
 		OrgID:          orgID,
 		Role:           meta.SharedDBRoleShared,
@@ -499,7 +505,7 @@ func registerSharedPoolFromEnv(ctx context.Context, metaStore *meta.Store, pool 
 		User:           cfg.User,
 		PasswordCipher: passCipher,
 		Name:           cfg.DBName,
-		TLS:            tls,
+		TLSMode:        tlsMode,
 	})
 	return err
 }

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	mysql "github.com/go-sql-driver/mysql"
 	"go.uber.org/zap"
 
 	"github.com/mem9-ai/drive9/pkg/backend"
@@ -329,6 +330,18 @@ func main() {
 		pool.SetMetaStore(store)
 		pool.Start(context.Background())
 
+		// Optional shared-schema pool: when DRIVE9_SHARED_POOL_DSN is set,
+		// initialize the shared schema on that database and register it in
+		// db_pool so tenants in the matching org (default: wildcard) are
+		// provisioned onto it instead of getting a dedicated cluster.
+		if sharedDSN := strings.TrimSpace(os.Getenv("DRIVE9_SHARED_POOL_DSN")); sharedDSN != "" {
+			if err := registerSharedPoolFromEnv(context.Background(), store, pool, sharedDSN, envOr("DRIVE9_SHARED_POOL_ORG", meta.SharedDBOrgWildcard)); err != nil {
+				die(fmt.Errorf("register shared pool: %w", err))
+			}
+			logger.Info(context.Background(), "shared_pool_registered",
+				zap.String("org", envOr("DRIVE9_SHARED_POOL_ORG", meta.SharedDBOrgWildcard)))
+		}
+
 		// The mutation replay and expiry sweep workers are owned by the server
 		// (started/stopped in its leader-gated startLeaderWorkers/stopLeaderWorkers),
 		// so they follow leadership transitions alongside the other leader-gated
@@ -443,6 +456,44 @@ func envOr(key, fallback string) string {
 	return fallback
 }
 
+// registerSharedPoolFromEnv initializes the shared schema on the database at
+// dsn and upserts it into db_pool with the given org binding. The DSN carries
+// a plaintext password (local/dev convenience); it is encrypted with the
+// pool's encryptor before persistence, like tenant DB passwords.
+func registerSharedPoolFromEnv(ctx context.Context, metaStore *meta.Store, pool *tenant.Pool, dsn, orgID string) error {
+	cfg, err := mysql.ParseDSN(dsn)
+	if err != nil {
+		return fmt.Errorf("parse DRIVE9_SHARED_POOL_DSN: %w", err)
+	}
+	if err := schema.InitSharedSchema(ctx, dsn); err != nil {
+		return fmt.Errorf("init shared schema: %w", err)
+	}
+	passCipher, err := pool.Encrypt(ctx, []byte(cfg.Passwd))
+	if err != nil {
+		return fmt.Errorf("encrypt shared db password: %w", err)
+	}
+	host, portStr, err := net.SplitHostPort(cfg.Addr)
+	if err != nil {
+		return fmt.Errorf("parse DRIVE9_SHARED_POOL_DSN address %q: %w", cfg.Addr, err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		return fmt.Errorf("parse DRIVE9_SHARED_POOL_DSN port %q: %w", portStr, err)
+	}
+	tls := cfg.TLSConfig != "" && cfg.TLSConfig != "false"
+	_, err = metaStore.RegisterSharedDB(ctx, &meta.SharedDB{
+		OrgID:          orgID,
+		Role:           meta.SharedDBRoleShared,
+		Host:           host,
+		Port:           port,
+		User:           cfg.User,
+		PasswordCipher: passCipher,
+		Name:           cfg.DBName,
+		TLS:            tls,
+	})
+	return err
+}
+
 func slockOAuthFromEnv() (*slockoauth.Client, error) {
 	origin := strings.TrimSpace(os.Getenv("DRIVE9_SLOCK_ORIGIN"))
 	if origin == "" {
@@ -538,6 +589,10 @@ environment:
   DRIVE9_USER_DB_MAX_IDLE_CONNS max idle connections for each cached tenant user DB pool (default: 2)
   DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS max open connections for tenant schema-init DB pools (default: 8)
   DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS max idle connections for tenant schema-init DB pools (default: 2)
+  DRIVE9_SHARED_POOL_DSN register a shared-schema DB at startup and place matching tenants on it (empty = disabled)
+  DRIVE9_SHARED_POOL_ORG TiDB Cloud org the shared pool serves (default: * = any org)
+  DRIVE9_SHARED_DB_MAX_OPEN_CONNS max open connections for each shared-schema DB handle (default: 50)
+  DRIVE9_SHARED_DB_MAX_IDLE_CONNS max idle connections for each shared-schema DB handle (default: 10)
   DRIVE9_DB_HEALTH_PROBE_INTERVAL_SECONDS DB health probe interval seconds (default: 15)
   DRIVE9_DB_HEALTH_PROBE_TIMEOUT_SECONDS DB health probe timeout seconds (default: 3)
   DRIVE9_DB_HEALTH_PROBE_META_ENABLED true|false to probe the control-plane DB (default: true)

--- a/docs/TENANT_DB_REDESIGN.md
+++ b/docs/TENANT_DB_REDESIGN.md
@@ -1,0 +1,991 @@
+# Drive9 Tenant DB Architecture Redesign
+
+> Core design decisions:
+> 1. **Identity model**: keep the existing external `tenant_id` (VARCHAR(64) UUID); add a new internal `fs_id BIGINT` to shared tables as the row sharding key — no external compatibility breakage, while gaining the index performance of a numeric key.
+> 2. **Fork**: the current fork is based on TiDB Cloud Branch and is tightly bound to the cluster==tenant model; under shared tables it must be redesigned (see §7).
+> 3. **Embedding**: shared tables keep only the app-managed mode; auto mode (`EMBED_TEXT` generated columns) no longer applies (see 5.3).
+
+---
+
+## 1. Background and Current State
+
+### 1.1 Current architecture
+
+Each fs (tenant) maps to a dedicated TiDB Cloud Starter (Serverless) cluster (the current provisioner is `tidb_cloud_native`, which creates Starter clusters).
+
+- Each tenant DB contains **32 tables** (Core FS 10 + Git Workspace 5 + FS Layers 5 + Journal 5 + Vault 7)
+  - ⚠️ Existing DBs may have a 33rd: the legacy `files` table (`SplitTablesMigrator` does not DROP it; it carries vector/FTS indexes)
+  - ⚠️ The Journal 5 tables and Vault 7 tables **already have a `tenant_id VARCHAR(64)` column** — the only part of the 32 tables with a pre-existing row-level multi-tenant shape
+  - ⚠️ The db9 provider (PostgreSQL + pgvector) schema has **24 tables** and is out of scope for this redesign (see 5.2.6)
+- The provisioner calls the TiDB Cloud OpenAPI to create a dedicated cluster
+- `pool.go` builds a dedicated DSN and connection pool per tenant
+- Clusters are created under the user's own TiDB Cloud org (using the user's own API credentials)
+
+### 1.2 Proven engineering foundations
+
+| Foundation | Location | Notes |
+|---|---|---|
+| Provisioning abstraction | `pkg/tenant/provisioner.go` | Provider interface; already supports `db9` / `tidb_zero` / `tidb_cloud_native` |
+| Per-tenant schema version management | `pkg/tenant/schema/` | `schema_version` + `InitSchema` + diff/repair |
+| LRU connection pool + idle eviction | `pkg/tenant/pool.go` | max 1024 warm backends, keyed by tenant ID string |
+| Dynamic DSN construction + KMS password encrypt/decrypt | `pkg/tenant/pool.go` + `pkg/encrypt/` | Supports Aliyun / Tencent / local AES |
+| Quota / spending limit management | `pkg/meta/` + `pkg/backend/quota.go` | All enforced at the application layer via the central meta DB |
+| **Online migration framework** | `pkg/migrate/split_tables.go` | `SplitTablesMigrator`: idempotent, resumable, auto-triggered on `Acquire` — the direct precedent for this plan's migration layer |
+| **Outbox + replay worker** | `pkg/meta/quota.go` + `pkg/backend/mutation_replay.go` | `quota_mutation_log` + `MutationReplayWorker` (atomic claim, batches of 100, max 5 retries) — a ready-made template for the retry log mechanism |
+| **Sharded task framework** | `tenant_notify_outbox` + `pkg/server/tenant_worker.go` | 200ms polling + sharded lease — a reusable base for migration orchestration |
+| **Pre-warmed cluster pool** | `tenant_tidbcloud_pools` | Existing per-org idle cluster pool; a reference for shared-pool provisioning |
+| **Existing dual-write implementation** | `useLegacyFiles` (`store.go`) | legacy files ↔ split tables dual-write already running in production |
+
+### 1.3 Key facts clarification
+
+| Fact | Current state | Impact on this plan |
+|---|---|---|
+| Tenant identifier | `tenants.id` is a `VARCHAR(64)` UUID v4 string; no numeric tenant key exists anywhere in the DB | Shared tables cannot use `tenant_id BIGINT` directly; an internal `fs_id` must be introduced (see 4.1) |
+| fs and tenant | 1:1, no independent fs id | `fs_id` is a new concept introduced by this redesign |
+| Fork | `POST /v1/fork` creates a **TiDB Cloud Branch** of the source tenant's cluster | The branch mechanism breaks under shared tables and must be redesigned (§7) |
+| Embedding | The `semantic` table has two modes: auto (`VECTOR GENERATED ALWAYS AS EMBED_TEXT(...)` STORED, with model/dimensions burned into the DDL) and app-managed (plain `VECTOR(n)` column); model/dimensions configured per tenant (`tenant_auto_embedding_profiles`) | A single shared table cannot express per-tenant generated columns; must converge to app-managed (see 5.3) |
+| Foreign keys / triggers / stored procedures | Zero across the entire DB; referential integrity lives entirely in the application layer | Dual-write does not need to handle DB-level constraints |
+| Multi-table transactions | A file write is a single transaction spanning 5~7 tables (`inodes`+`contents`+`semantic`+`file_nodes`+`file_tags`+`semantic_tasks` enqueue) | Dual-write must be in units of **transactions**, not statements (see 8.2) |
+| AUTO_INCREMENT | Only `llm_usage.id` and `fs_events.seq` in tenant DBs; `seq` is consumed by the SSE cursor | Shared tables and migration need special handling (see 5.4) |
+
+---
+
+## 2. The Cost Problem
+
+### 2.1 Quantifying the problem
+
+Every Starter cluster has its own baseline cost (storage fees + a small RU floor):
+
+- Cost grows **linearly** with tenant count and cannot be compressed
+- `tenant count × baseline = total cost`; sharing cannot amortize it
+- (To be filled in: actual baseline cost figures, current monthly bill, growth trend)
+
+### 2.2 Root cause of unsustainable cost
+
+- **The "one fs, one cluster" model**: every tenant bears a dedicated cluster baseline
+- Starter clusters do not support sharing or multi-database consolidated billing
+- tenant count growth → linear cluster count growth → linear cost growth
+
+---
+
+## 3. Options Considered
+
+### 3.1 Rejected options
+
+| Option | Why rejected |
+|---|---|
+| Self-hosted Neon | Complex architecture (page server + safekeeper + compute + control plane), needs S3 alongside, few community production cases, unacceptable operational risk |
+| Managed RDS (Aurora / Cloud SQL / Supabase) | MySQL/TiDB → PostgreSQL dialect migration, rewriting 32-table DDL + all datastore SQL; unclear short-term payoff |
+| CockroachDB | Dialect migration + no vector/FTS |
+| Self-hosted TiDB | Operational burden + some Cloud-only features missing |
+| Postgres + pgvector | Same dialect migration as above |
+
+**Conclusion: keep TiDB Cloud Starter as the underlying DB; change the multi-tenant isolation model.**
+
+### 3.2 share-cluster (DB-per-tenant) vs share-table
+
+**share-cluster**: one database per tenant inside a single Starter cluster; table structures unchanged.
+
+- Pros: good isolation, small code changes
+- Bottleneck: **TiDB Cloud Starter per-cluster table-count limit** (PingCAP's official feedback: "the limit is roughly a few thousand")
+
+| Assumed limit | Tables per tenant | Max tenants per cluster | Enough to amortize cost? |
+|---|---|---|---|
+| 7,000 | 35 (32 + 3 reserved) | 200 | ❌ still needs many clusters |
+| 20,000 | 35 | 571 | ❌ still too high |
+| 50,000 | 35 | 1,428 | ⚠️ marginal |
+
+**share-table (the decision)**: all tenants share one set of tables (32), with an `fs_id` column distinguishing rows:
+
+- Per-cluster table count is **fixed at 32**, independent of tenant count
+- One Starter cluster can host hundreds to thousands of tenants
+- Cost: add the `fs_id` column, rebuild indexes/constraints, change datastore-layer SQL (one-time change)
+- Benefit: cost goes from linear growth to **stepwise growth** (a new cluster is opened only when the current one fills up)
+
+---
+
+## 4. Overall Architecture
+
+### 4.1 Identity model: `tenant_id` ↔ `fs_id`
+
+Shared tables need a stable numeric row key, but the existing tenant identifier is a `VARCHAR(64)` UUID that has already permeated every external interface — API keys, quota tables, journal/vault tables, the S3 namespace. **Do not change the external identifier; add an internal mapping**:
+
+```sql
+-- meta DB: registry mapping tenant UUID → internal fs_id (assigned at tenant creation, immutable for life)
+CREATE TABLE fs_registry (
+    fs_id      BIGINT AUTO_INCREMENT PRIMARY KEY,
+    tenant_id  VARCHAR(64) NOT NULL UNIQUE,   -- existing tenants.id (UUID)
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+| Layer | Identifier used | Notes |
+|---|---|---|
+| External interfaces (API, quota, existing journal/vault columns, S3 namespace) | `tenant_id` VARCHAR(64) UUID | **Completely unchanged**; zero compatibility breakage |
+| meta DB internals (`fs_registry`, `tenant_placements`, `db_pool`, `migration_retry_log`) | `fs_id` BIGINT | Internal key for routing and migration |
+| The 32 shared tables | `fs_id BIGINT NOT NULL` | Row sharding key; prefix of every index |
+| datastore at runtime | UUID → fs_id resolved on Acquire, cached in-process | All SQL predicates use fs_id |
+
+Existing data handling: the existing `tenant_id VARCHAR(64)` columns in journal/vault tables are uniformly replaced by `fs_id BIGINT` in the shared schema; backfill converts via `fs_registry`. Application-layer interface signatures are unchanged.
+
+### 4.2 Layered architecture overview
+
+```mermaid
+graph TB
+    subgraph BIZ["Access layer · datastore"]
+        B1["All SQL predicates on fs_id"]
+        B2["Unaware of shared / dedicated / engine / migration state"]
+    end
+    subgraph ROUTE["Routing layer · pool.go rework"]
+        R1["tenant UUID → fs_id → placement"]
+        R2["placement cache + epoch fencing"]
+        R3["Transaction-mirrored dual-write during migration"]
+    end
+    subgraph SCHED["Scheduler layer"]
+        S1["Global RU / storage / QPS monitoring"]
+        S2["Hotspot detection → migration trigger (automatic + human confirmation)"]
+    end
+    subgraph MIG["Migration layer"]
+        M1["Transaction-mirrored dual-write + backfill"]
+        M2["verify → cutover → deferred cleanup"]
+    end
+    subgraph PROV["Provisioning layer"]
+        P1["New tenants assigned to the shared pool"]
+        P2["Dedicated DB created for hot tenants"]
+        P3["fork lands on dedicated / shared (§7)"]
+    end
+    subgraph DBS["Physical DB layer"]
+        D1[("Shared DB-A<br/>N tenants · shared table")]
+        D2[("Shared DB-B<br/>N tenants · shared table")]
+        D3[("Dedicated DB<br/>1 tenant · shared table")]
+    end
+
+    BIZ --> ROUTE
+    ROUTE --> DBS
+    SCHED --> MIG
+    MIG --> ROUTE
+    SCHED --> PROV
+    PROV --> DBS
+
+    classDef layer fill:#F8FAFC,stroke:#94A3B8,color:#334155
+    classDef db fill:#EFF6FF,stroke:#2563EB,color:#1E40AF
+    class BIZ,ROUTE,SCHED,MIG,PROV layer
+    class D1,D2,D3 db
+```
+
+### 4.3 Layer responsibilities
+
+**Access layer (business layer / datastore)**
+
+| Dimension | Description |
+|---|---|
+| Responsibility | Execute business SQL predicated on fs_id |
+| Unaware of | Which physical DB instance is underneath; whether the tenant is shared or dedicated; engine type; whether a migration is in flight |
+| Interface | Obtains fs_id from context / backend, returns results |
+| Changes | Add fs_id predicates to all queries on the 32 tables, prefix indexes with fs_id, change unique constraints to composite (fs_id, ...) |
+
+**Routing layer (pool.go rework)**
+
+| Dimension | Description |
+|---|---|
+| Responsibility | tenant UUID → fs_id → physical DB connection |
+| Core mechanism | Queries meta DB `tenant_placements` (in-process cache + epoch invalidation, see 6.4) |
+| Shared DB | Multiple tenants share one `*sql.DB` |
+| Dedicated DB | One connection pool per tenant |
+| During migration | Transaction-mirrored dual-write, holding source/target connections simultaneously (see 8.2) |
+| Routing hot update | meta bumps the epoch; pools refresh on noticing it, without restarting the service |
+| Existing-tenant compatibility | Existing per-tenant DBs are marked `placement=dedicated` and handled by routing normally |
+
+**Scheduler layer**
+
+| Dimension | Description |
+|---|---|
+| Responsibility | Global monitoring + hotspot detection + migration triggering |
+| Monitoring | RU / storage / QPS of all DBs; per-tenant RU / storage / QPS (application-layer metrics) |
+| Upgrade trigger | tenant RU > threshold_upgrade, sustained for T minutes → shared → dedicated |
+| Downgrade trigger | tenant RU < threshold_downgrade, idle for N consecutive days → dedicated → shared |
+
+**Migration layer**: see §8. **Provisioning layer**: DB instance lifecycle + tenant assignment, all unified under the drive9-internal org (§10), compatible with the existing Provider interface.
+
+---
+
+## 5. Schema Changes
+
+### 5.1 General principles
+
+- Add `fs_id BIGINT NOT NULL` to all 32 tables
+- Rebuild primary keys as composite `(fs_id, <original PK>)`, using TiDB's clustered index to physically cluster rows by fs_id
+- Prefix all secondary indexes with `fs_id`
+- Change all unique constraints to composite `(fs_id, ...)`
+- Inject the `fs_id` predicate into all queries
+
+### 5.2 Per-table change list
+
+#### 5.2.1 Core FS (10 tables)
+
+| Table | Current PK / unique constraints (actual) | Shared-table change |
+|---|---|---|
+| `file_nodes` | `UNIQUE idx_path (path_hash)`; `KEY idx_parent (parent_path_hash, name)` | `UNIQUE(fs_id, path_hash)`; `KEY(fs_id, parent_path_hash, name)` |
+| `inodes` | `PK (id)` (ULID string) | Composite primary key `(fs_id, id)` |
+| `contents` | `UNIQUE (inode_id)` | `UNIQUE(fs_id, inode_id)` |
+| `semantic` | `PK (inode_id)` | Composite primary key `(fs_id, inode_id)`; vector/FTS index changes in 5.3 |
+| `file_tags` | `UNIQUE (file_id, key)` | `UNIQUE(fs_id, file_id, key)` |
+| `uploads` | `UNIQUE (upload_id)`; generated column `active_target_path_hash VIRTUAL` + unique index | `UNIQUE(fs_id, upload_id)`; `UNIQUE(fs_id, active_target_path_hash)` |
+| `semantic_tasks` | `UNIQUE (task_id)`; `UNIQUE (task_type, resource_id, resource_version)` | Add `fs_id` prefix to both unique constraints |
+| `file_gc_tasks` | `UNIQUE (task_id)`; `uk_file_gc_file_id`; `uk_file_gc_inode_id` | Add `fs_id` prefix to all three unique constraints |
+| `llm_usage` | `id AUTO_INCREMENT PK` | `id` stays a purely physical primary key (cluster-global auto-increment); add `KEY(fs_id, ...)`; see 5.4 |
+| `fs_events` | `seq AUTO_INCREMENT PK` | Same as above; add `KEY(fs_id, seq)`; SSE cursor handling in 5.4 |
+
+#### 5.2.2 Git Workspace (5 tables)
+
+`git_workspaces` / `git_workspace_tree_nodes` / `git_workspace_git_state` / `git_workspace_object_packs` / `git_workspace_overlay`: add the `fs_id` column + index prefixes + composite unique constraints (`workspace_id` is a UUID string; same pattern as above).
+
+#### 5.2.3 FS Layers (5 tables)
+
+`fs_layers` / `fs_layer_tags` / `fs_layer_entries` / `fs_layer_events` / `fs_layer_checkpoints`: same as above.
+
+#### 5.2.4 Journal (5 tables) and Vault (7 tables)
+
+`journals` / `journal_labels` / `journal_append_requests` / `journal_entries` / `journal_entry_subjects`;
+`vault_deks` / `vault_secrets` / `vault_secret_fields` / `vault_tokens` / `vault_grants` / `vault_policies` / `vault_audit_log`.
+
+These 12 tables **already have a `tenant_id VARCHAR(64)` column and tenant-prefixed keys**. The shared schema replaces that column with `fs_id BIGINT` (narrower indexes, faster joins); existing data is converted via `fs_registry` during backfill. Application-layer method signatures (which take the tenant UUID string) are unchanged.
+
+#### 5.2.5 Handling the legacy `files` table
+
+- The legacy `files` table **does not enter** the shared schema
+- Prerequisite for existing-tenant migration: the tenant has completed `SplitTablesMigrator` (data already in the new tables)
+- If a tenant has not finished the split: the migration pipeline first triggers/waits for the split to complete, then starts fs-level migration (order: intra-DB table split first, cross-DB migration second)
+- Phase 0 must inventory the distribution and data volume of legacy `files` tables across existing DBs
+
+#### 5.2.6 db9 provider (out-of-scope statement)
+
+db9 (PostgreSQL + pgvector, 24 tables) is **not in scope** for this shared-table redesign and keeps its per-tenant instances as-is. All schema / SQL changes in this plan target only the TiDB/MySQL providers. db9's long-term positioning (whether to also adopt sharing, whether to retire it) is a separate decision.
+
+### 5.3 The `semantic` table and embedding-mode convergence
+
+**Problem**: in auto mode, `semantic.embedding` / `description_embedding` are `VECTOR(n) GENERATED ALWAYS AS (EMBED_TEXT(model, content, options)) STORED` generated columns — **model and dimensions are burned into the DDL**, and each tenant has its own embedding profile. A single shared table can have only one generated-column expression, which fundamentally conflicts with per-tenant model/dimensions.
+
+**Decision: shared tables keep only the app-managed mode.**
+
+| Dimension | Decision |
+|---|---|
+| Shared-table schema | `embedding` / `description_embedding` are plain `VECTOR(n)` columns, **no generated columns**; embeddings are computed by the application layer and written in (app-managed) |
+| auto mode | No longer applies to shared tables. When an existing auto-mode tenant migrates, the migration pipeline recomputes embeddings at the application layer and writes them to the target; after migration it runs as app-managed |
+| Model / dimensions | Shared tables use one standard model and dimension (Phase 0 completes the selection and the re-embedding cost estimate for existing tenants); mixing vectors from multiple models in one column corrupts distance metrics — **not allowed** |
+| Custom models | Kept as a **differentiating capability of dedicated DBs**: tenants needing custom embedding models are scheduled to dedicated DBs (schema likewise has no generated columns, but column dimensions/model can vary as needed) |
+| Retrieval compatibility | Query vectors are computed by the application layer with the same standard model; `VEC_EMBED_COSINE_DISTANCE` computation is unchanged |
+
+**To be verified (already in Phase 0)**: the current DDL builds indexes with `VEC_COSINE_DISTANCE` while queries use `VEC_EMBED_COSINE_DISTANCE`; first verify whether the vector index is actually hit under current queries, then design the fs_id-prefixed index shape.
+
+### 5.4 Special handling for AUTO_INCREMENT tables
+
+| Table | Current state | Shared-table handling |
+|---|---|---|
+| `llm_usage` | `id AUTO_INCREMENT` | Keep the auto-increment id as a cluster-global physical primary key (physical ordering only); all queries go through `(fs_id, ...)` indexes; no external references, so values need not be preserved during migration |
+| `fs_events` | `seq AUTO_INCREMENT`, consumed by the SSE cursor (`WHERE seq > cursor`) | In shared tables seq is globally monotonic with per-tenant gaps — `WHERE fs_id=? AND seq>cursor` semantics stay correct; **seq values cannot be preserved during migration**. On cutover, write a migration checkpoint event into the target DB; the SSE layer detects it and tells clients to re-sync their cursor |
+
+### 5.5 Partitioning strategy
+
+Optional: HASH partition by `fs_id` (`PARTITION BY HASH(fs_id) PARTITIONS N`).
+
+| Dimension | Notes |
+|---|---|
+| Effect | Automatic partition pruning when queries carry fs_id |
+| Partition count | Evaluate based on tenant density and per-partition data volume |
+| Caveat | Compatibility of vector / FTS indexes on partitioned tables must be verified (Phase 0) |
+| Initial strategy | Can skip partitioning (rely on composite PK + index-prefix pruning); introduce it later as data volume grows |
+
+### 5.6 Dual-shape window of old and new schemas
+
+- **Dedicated DBs always use the shared schema** (shared tables with 1 tenant) — ensuring "shared ⇄ dedicated" migration is pure data movement between isomorphic schemas
+- **The old schema (no fs_id column) exists only in existing per-tenant DBs awaiting migration**
+- During the whole existing-tenant migration window, datastore must support both schema shapes simultaneously, plus shape translation during dual-write (there is precedent and hard-won lessons from the `useLegacyFiles` dual-shape maintenance)
+- datastore picks the SQL shape from the placement's schema flag; the goal is to delete the old-shape code paths wholesale once existing-tenant migration completes
+
+### 5.7 Schema version management
+
+| Dimension | Notes |
+|---|---|
+| Version registration | Reuse the existing `schema_version` + `InitSchema` + diff/repair mechanism; the shared schema registers as a new version |
+| Granularity change | schema_version goes from per-tenant-DB to **per-physical-DB** (a shared DB has one version serving all its tenants) |
+| New shared / dedicated DBs | Apply the shared schema directly |
+| Existing per-tenant DBs | Keep the current schema until migration completes |
+
+### 5.8 Datastore-layer changes
+
+| Dimension | Notes |
+|---|---|
+| fs_id resolution | On Acquire, tenant UUID → fs_id (`fs_registry`), cached in-process; SQL predicates use fs_id |
+| SQL injection | All queries get the fs_id predicate injected |
+| Connection acquisition | From per-tenant DSNs to DB connections returned by the routing layer |
+| Dual-write support | Writes support transaction-mirrored dual-write during migration (see 8.2) |
+| Change surface | 32 tables × all CRUD methods, with a uniform change pattern |
+
+---
+
+## 6. Shared Pool and Routing
+
+### 6.1 Sharing density
+
+By default every N tenants share one Starter instance:
+
+- **N's initial value is based on**: the capacity ceiling of a single Starter cluster (RU/s, storage cap); expected activity rate (most tenants low-activity, a few hot); preliminary estimate **N = 100 ~ 1000**
+- **How N is determined**: theoretical estimate `average per-tenant RU consumption × N < cluster RU ceiling × safety factor`; validation through gradual rollout (start at N=100 and raise stepwise); dynamic adjustment from runtime data
+
+### 6.2 Shared-pool assignment strategy
+
+- New tenants are assigned to the **least-loaded** DB in the shared pool at creation time
+- When the shared pool is full (tenant count reaches N or RU nears the ceiling), create a new Starter cluster into the pool
+- Best-effort avoidance of high-load DBs (reduces noisy neighbor)
+- Can reuse the existing `tenant_tidbcloud_pools` pre-warmed pool idea to shorten the wait for a new cluster to join the pool
+
+### 6.3 New meta DB tables
+
+> Naming note: `db_pool` and the existing `tenant_tidbcloud_pools` (pre-warmed idle cluster pool) are different concepts; the former is the shared-pool physical DB registry. Keep them distinct in DDL and docs.
+
+```sql
+CREATE TABLE db_pool (
+    db_id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    dsn            VARCHAR(500) NOT NULL,   -- KMS-encrypted password stored in a separate column
+    tier           VARCHAR(20) NOT NULL,    -- 'cold' | 'warm' | 'hot'
+    role           VARCHAR(20) NOT NULL,    -- 'shared' | 'dedicated'
+    spending_limit BIGINT,                  -- cluster-level spending limit (see §11)
+    tenant_count   INT DEFAULT 0,
+    max_tenants    INT NOT NULL,
+    created_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE tenant_placements (
+    fs_id        BIGINT PRIMARY KEY,        -- internal key, linked to tenant UUID via fs_registry
+    db_id        BIGINT NOT NULL,
+    placement    VARCHAR(20) NOT NULL,      -- 'shared' | 'dedicated'
+    status       VARCHAR(20) NOT NULL,      -- 'active' | 'migrating'
+    target_db_id BIGINT,                    -- non-null while migrating
+    epoch        BIGINT NOT NULL DEFAULT 1, -- routing fencing: +1 on every routing change
+    updated_at   TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+```
+
+### 6.4 Routing cache and epoch fencing
+
+`tenant_placements` lookups must not enter the per-request hot path (the meta DB would immediately become a bottleneck and a single point of failure). Design:
+
+| Mechanism | Notes |
+|---|---|
+| In-process cache | pool caches `fs_id → (db_id, epoch, status)`; a hit connects directly |
+| Invalidation | Short TTL (seconds) + active invalidation (reuse `tenant_notify_outbox` to broadcast placement changes) |
+| epoch fencing | epoch+1 on every routing change; the cutover flow uses epoch to confirm all instances have refreshed (see 8.5) |
+| meta DB failure | Cache fallback + fail-open, following the existing quota-cache precedent; migration-type operations (changing placement) must hit meta directly |
+
+---
+
+## 7. Fork Redesign
+
+### 7.1 Current state: fork = TiDB Cloud Branch
+
+Current implementation of `POST /v1/fork`: create a **TiDB Cloud Branch** based on the source tenant's cluster as the new tenant's DB (`pkg/server/fork.go`; `tenants.parent_tenant_id`; `TenantKindFork`).
+
+- Advantage: **zero-copy, minute-level**; the branch is implemented via CoW in the TiDB Cloud storage layer
+- Binding: this mechanism fundamentally assumes **cluster == tenant**
+
+### 7.2 Problem: branch breaks under the shared-table model
+
+With shared tables, the rows of N tenants are mixed in one cluster; **there is no way to do a cluster-level branch of a single tenant's data**. fork is a core drive9 feature (parallel attempts, experiment isolation), so a replacement must be provided.
+
+### 7.3 Candidate options
+
+```mermaid
+graph TB
+    F["fork request"] --> A["Option A: logical copy → dedicated DB<br/>fork artifact = 1-tenant shared schema"]
+    F --> B["Option B: logical copy → shared DB<br/>fork artifact enters the shared pool"]
+    F --> C["Option C (mid-term): application-layer CoW<br/>layer references the source fs + overlay"]
+
+    classDef opt fill:#F8FAFC,stroke:#94A3B8,color:#334155
+    class A,B,C opt
+```
+
+| Dimension | A: copy → dedicated | B: copy → shared | C: application-layer CoW (mid-term) |
+|---|---|---|---|
+| Mechanism | SELECT all rows of the source fs_id → write into a new dedicated DB | Same source SELECT → write into a shared-pool target DB (new fs_id) | The new fs records only layer references to the source fs; reads pass through, writes go to an overlay |
+| fork latency | Proportional to data volume (minutes~hours) | Same as left | **Seconds, zero-copy** |
+| Extra cost | One cluster baseline per fork | No extra cluster | None |
+| fork-of-fork | Can keep branching between dedicated clusters | Still needs logical copy | Natively supported (layer chain) |
+| Implementation | **Fully reuses the migration pipeline** (isomorphic schema, source-side read-only snapshot + target writes + verification) | Same as left | Read path must support cross-fs references + reference counting to prevent source deletion; large change |
+| Source fs constraint | None | None | The source fs cannot be deleted/cleaned up while referenced |
+| Consistency | Writes continuing on the source during copy must be caught up (reuse dual-write) or a short read-only window | Same as left | Natively consistent (same physical data) |
+
+### 7.4 Decision
+
+| Stage | Decision |
+|---|---|
+| Short term (lands with this plan) | **A is the default** (fork artifacts land on dedicated DBs, preserving the "a fork can independently go hot at any time" semantics, and fork-of-fork can fall back to branch); small-data tenants may choose B to save cost. Both share the same logical-copy pipeline — a read-only variant of the §8 migration mechanism (catch-up via transaction-mirrored dual-write while the source keeps writing) |
+| Mid term | Evaluate **C: application-layer CoW fork based on fs_layers**. drive9 already has a layer/overlay mechanism (the 5 `fs_layers` tables); once fork is promoted to an FS-layer primitive, it can be second-level and zero-copy, no longer depending on any DB feature — also the long-term direction for breaking the TiDB Branch binding |
+| Existing tenants | During the window, branch fork between not-yet-migrated dedicated clusters remains usable; logical copy takes over after migration completes |
+
+**Semantic-change disclosure**: logical-copy fork latency changes from "minute-level (data-volume independent)" to "proportional to data volume". The API/docs must disclose fork as an asynchronous operation (state machine: copying → catching-up → ready); the fork experience for large filesystems needs product-side confirmation.
+
+---
+
+## 8. Migration Mechanism: Transaction-Mirrored Dual-Write + Backfill
+
+### 8.1 Five-phase overview
+
+```mermaid
+graph LR
+    P1["<b>Phase 1 Prepare</b><br/>Build shared schema on target<br/>status=migrating<br/>invisible to users"]
+    P2["<b>Phase 2 Dual-write + backfill</b><br/>Transaction-mirrored dual-write<br/>Batched idempotent backfill<br/>write latency rises"]
+    P3["<b>Phase 3 Verify</b><br/>retry log drained<br/>row counts / chunked checksum<br/>dark read"]
+    P4["<b>Phase 4 Cutover</b><br/>meta atomic update epoch+1<br/>instances refresh routing<br/>millisecond-level"]
+    P5["<b>Phase 5 Deferred cleanup</b><br/>Rollback window (default 72h)<br/>Batched source-data deletion"]
+
+    P1 --> P2 --> P3 --> P4 --> P5
+
+    classDef phase fill:#EFF6FF,stroke:#2563EB,color:#1E40AF
+    classDef cleanup fill:#F8FAFC,stroke:#94A3B8,color:#334155
+    class P1,P2,P3,P4 phase
+    class P5 cleanup
+```
+
+| Phase | Key actions | User perception |
+|---|---|---|
+| 1 Prepare | Build shared schema on the target DB; meta updates `status=migrating, target_db_id` | None |
+| 2 Dual-write + backfill | **Turn on dual-write first, then backfill**; reads always go to the source; write latency rises | Write latency rises |
+| 3 Verify | retry log drained → row-count comparison → chunked checksum / dark read | None |
+| 4 Cutover | Dual-write caught up → meta atomic update (epoch+1) → instances refresh | Millisecond-level |
+| 5 Deferred cleanup | Source data retained during the rollback window; batched DELETE afterwards | None |
+
+> **Why turn on dual-write before backfilling?** Backfill first and dual-write second would lose new writes made during the backfill. With dual-write first, new writes are not lost, and the backfill overwrites idempotently with `ON DUPLICATE KEY UPDATE` (see 8.3).
+
+### 8.2 Transaction boundaries of dual-write
+
+A drive9 write is **a single transaction spanning 5~7 tables** (file write: `inodes`+`contents`+`semantic`+`file_nodes`+`file_tags`+`semantic_tasks` enqueue). Dual-write cannot be in units of individual SQL statements — statement-level dual-write leaves half a transaction behind when the target DB fails. Therefore:
+
+**Dual-write unit = the mirror of an application transaction.**
+
+| Design point | Notes |
+|---|---|
+| Where implemented | A migration proxy wrapping the datastore Store interface: after side A's transaction commits successfully, replay the whole group of changes in one transaction on side B using **the same method calls and arguments** |
+| Why function-level replay | All writes go through datastore methods; function-level replay naturally preserves transaction boundaries and write order, with no need for SQL row-level change capture |
+| B succeeds | Return success to the user |
+| B fails | Record the whole group of changes (tx_id + method + arguments) into the retry log and return error to the user; replay in the background **per transaction** atomically |
+| Ordering guarantee | Writes of the same fs are serialized through the routing layer (or ordered by tx sequence), ensuring B's replay order matches A's |
+| Cost | Higher write latency during migration (A commit + B replay serialized) |
+
+### 8.3 Backfill
+
+| Point | Approach | Reason |
+|---|---|---|
+| Batching | 1000 rows per batch, sleep between batches, configurable rate | Avoid big queries impacting other tenants on the shared DB |
+| Idempotency | `ON DUPLICATE KEY UPDATE` (**do not use** `INSERT IGNORE` / `REPLACE INTO`) | INSERT IGNORE skips rows with older versions causing inconsistency; REPLACE INTO's delete-then-insert semantics has side effects |
+| Table by table | Backfill only one table at a time | Control pressure on the source DB |
+| DELETE synchronization | Backfill SELECT cannot see already-deleted rows; deletions are guaranteed entirely by dual-write + retry log | Separation of concerns |
+| AUTO_INCREMENT tables | `llm_usage.id` / `fs_events.seq` values are not preserved; the target side auto-increments anew (see 5.4) | Shared-table auto-increment cannot preserve values |
+
+### 8.4 Dual-write failure handling
+
+#### 8.4.1 Write ordering and failure matrix
+
+```mermaid
+graph TB
+    W["Write transaction arrives"] --> A["Source A commits transaction"]
+    A -->|"❌ fails"| E1["Return error<br/>B not written; user can just retry"]
+    A -->|"✅ succeeds"| B["Target B replays same transaction"]
+    B -->|"✅ succeeds"| OK["Return success"]
+    B -->|"❌ fails"| L["Record retry log (grouped by tx)<br/>Return error"]
+    L --> RW["replay worker replays atomically per tx"]
+    RW -->|"succeeds"| M["Mark replayed"]
+    RW -->|"keeps failing"| AL["Alert → human intervention<br/>consider pausing migration / rollback"]
+
+    classDef ok fill:#ECFDF5,stroke:#059669,color:#065F46
+    classDef err fill:#FEF2F2,stroke:#DC2626,color:#991B1B
+    classDef bg fill:#FFFBEB,stroke:#D97706,color:#92400E
+    class OK,M ok
+    class E1,AL err
+    class L,RW bg
+```
+
+Choose **A first, B second**: A is the read source during migration, so A's consistency takes priority; a B failure only means the target temporarily lags, covered by the retry log.
+
+| Scenario | A | B | User perception | Handling |
+|---|---|---|---|---|
+| Normal | ✅ | ✅ | success | — |
+| A fails | ❌ | not written | error | User retries |
+| B fails | ✅ | ❌ | error | Record retry log for background replay; on user retry A is idempotent (ODKU / business idempotency keys) |
+| A fails, B succeeds | ❌ | ✅ | error | Should not happen (A first, B second); if a bug causes it, verification finds B row count > A — roll back and re-sync |
+| Both fail | ❌ | ❌ | error | User retries |
+
+**User-retry semantics when A succeeds and B fails**: the user gets an error but A has already taken effect. Writes on side A must be idempotent (INSERT uses ODKU; business operations like `cp /a /b` treat a unique-constraint conflict as already-exists), so user retries do not error; B is caught up by the retry log.
+
+#### 8.4.2 retry log (reusing the quota outbox pattern)
+
+`migration_retry_log` is semantically isomorphic to the production `quota_mutation_log` + `MutationReplayWorker` (atomic claim, batched replay, max retries, alerting), and directly reuses that implementation pattern:
+
+```sql
+CREATE TABLE migration_retry_log (
+    id          BIGINT AUTO_INCREMENT PRIMARY KEY,
+    fs_id       BIGINT NOT NULL,
+    db_id       BIGINT NOT NULL,        -- target DB
+    tx_id       VARCHAR(64) NOT NULL,   -- one group per application transaction
+    tx_seq      INT NOT NULL,           -- order within the transaction
+    table_name  VARCHAR(100) NOT NULL,
+    row_key     VARCHAR(200) NOT NULL,
+    op_type     VARCHAR(20) NOT NULL,   -- 'insert' | 'update' | 'delete'
+    payload     JSON NOT NULL,          -- method + arguments (needed for function-level replay)
+    created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    retry_count INT DEFAULT 0,
+    status      VARCHAR(20) DEFAULT 'pending', -- 'pending' | 'replayed' | 'failed'
+    KEY idx_claim (status, id)
+);
+```
+
+Replay rules: entries with the same `tx_id` are replayed in `tx_seq` order within **a single transaction**; replay is idempotent (ODKU); `retry_count >= max` sets `failed` and alerts for human intervention.
+
+#### 8.4.3 retry log and cutover
+
+| Checkpoint | Condition | If not met |
+|---|---|---|
+| Enter verification (Phase 3) | retry log has no pending entries | Wait for catch-up; pause migration on timeout |
+| Execute cutover (Phase 4) | retry log still empty | Cutover not allowed |
+| Sustained backlog | Growth exceeds threshold | Pause migration, human intervention; consider rollback |
+
+### 8.5 Cutover and fencing
+
+Routing cutover needs an explicit awareness mechanism and multi-instance safety guarantees, otherwise "the pool layer refreshes once it notices" is just a slogan. This plan adopts **epoch fencing**:
+
+```mermaid
+graph TB
+    S1["<b>1.</b> Confirm dual-write caught up<br/>retry log empty, no in-flight transactions on source"] --> S2["<b>2.</b> meta atomic update<br/>db_id=target, status=active, epoch+1"]
+    S2 --> S3["<b>3.</b> Instances notice new epoch<br/>(notify_outbox broadcast + TTL fallback)<br/>refresh caches; new requests routed to target"]
+    S3 --> S4["<b>4.</b> Confirm all-instance ack / max TTL exceeded<br/>in-flight old connections finish naturally"]
+    S4 --> S5["<b>5.</b> Enter deferred-cleanup window (Phase 5)"]
+
+    classDef step fill:#EFF6FF,stroke:#2563EB,color:#1E40AF
+    class S1,S2,S3,S4,S5 step
+```
+
+| Guarantee | Mechanism |
+|---|---|
+| No data loss | Return only after dual-write sync succeeds; cut over only when the retry log is drained |
+| Cutover atomicity | One-row meta update (db_id + epoch); pools refresh by epoch |
+| Multi-instance safety | Un-refreshed instances keep reading/writing the source (dual-write still on, no data loss); **cleanup must wait for all-instance ack or max TTL** |
+| Cleanup safety | Before Phase 5 deletes source data, confirm all active instances have epoch ≥ cutover epoch |
+
+### 8.6 Rollback and deferred cleanup
+
+| Window | Rollback capability |
+|---|---|
+| Before cutover (Phase 1~3) | Roll back anytime: stop dual-write, delete target data, keep the source |
+| After cutover, before cleanup (rollback window, default 72h) | Source data fully retained; rollback = meta switched back to source + new writes during the window reverse-synced (reuse the dual-write mechanism in reverse) |
+| After cleanup | No rollback |
+
+Deferred cleanup also covers the escape need of "the target DB turns out to be broken right after cutover". Window length is configured per fs data volume and business tolerance.
+
+### 8.7 Consistency verification
+
+| Method | Notes |
+|---|---|
+| Row-count comparison | Per-table `COUNT(*) WHERE fs_id=?` compared on both sides |
+| Chunked checksum | Chunk by primary-key range, aggregate-compare `BIT_XOR(CRC32(CONCAT_WS(...)))`; **do not use** `CRC32(GROUP_CONCAT(id))` (limited by `group_concat_max_len`, overflows on large tables) |
+| Dark read | Run the same query against source/target and compare (sampling) |
+
+### 8.8 Reusing existing mechanisms
+
+| Existing mechanism | Location | Role in this plan |
+|---|---|---|
+| `SplitTablesMigrator` | `pkg/migrate/` | Execution template for online, idempotent, resumable migration; precedent for triggering existing-tenant migration on `Acquire` |
+| `quota_mutation_log` + `MutationReplayWorker` | `pkg/meta/quota.go`, `pkg/backend/mutation_replay.go` | Direct implementation template for `migration_retry_log` + replay worker |
+| `tenant_notify_outbox` + sharded lease | `pkg/server/tenant_worker.go` | Base for the migration orchestrator (state machine) and epoch broadcast |
+| `semantic_tasks` / `file_gc_tasks` lease tasks | `pkg/datastore/` | Reference for claim/lease/receipt semantics of migration tasks |
+| `tenant_tidbcloud_pools` | `pkg/meta/meta.go` | Pre-warming reference for shared-pool provisioning |
+
+### 8.9 Generality and scenarios
+
+| Scenario | Source | Target | Trigger |
+|---|---|---|---|
+| Hot upgrade | Shared DB | Dedicated DB | tenant RU exceeds threshold |
+| Cold downgrade | Dedicated DB | Shared DB | Low activity for N consecutive days |
+| Rebalance | Shared DB-A | Shared DB-B | DB-A overloaded |
+| Existing-tenant migration | User-org per-tenant DB | drive9-internal-org shared DB | Phase 6 batch |
+| **fork copy** | Any DB | Dedicated / shared DB | fork request (§7, read-only variant of the isomorphic pipeline) |
+
+Source and target DBs can be under different TiDB Cloud orgs. dual-write + backfill is an application-layer approach: **the application layer connects to both DBs separately; no direct DB-to-DB connection is needed** — cross-org connectivity only requires the application → each of the two DBs to be reachable (the application already connects to them separately); Phase 0 connectivity verification is based on this.
+
+### 8.10 Industry benchmarks
+
+| Company | Migration scenario | Correspondence to this plan |
+|---|---|---|
+| **Stripe** | Splitting hundreds of millions of Subscription rows | Dual-write + Hadoop batch backfill; Scientist dark read; phased cutover (stripe.com/blog/online-migrations) |
+| **Stripe** | Petabyte-scale DocDB cross-shard (5M QPS) | Bulk import + bidirectional async replication (full rollback); consistency check before cutover (stripe.dev/blog/how-stripes-document-databases-supported-99.999-uptime) |
+| **Notion** | Monolithic Postgres → 480 logical shards | Audit log + catch-up incremental sync; backfill ~3 days; version-number comparison to skip stale updates; dark read (notion.com/blog/sharding-postgres-at-notion) |
+| **Slack** | legacy MySQL → Vitess re-sharding | Generic backfill system cloning existing tables during dual-write; double-read diff verification (slack.engineering/scaling-datastores-at-slack-with-vitess) |
+| **Gusto** | Overloaded-table split | Single-transaction dual-write; backfill runs only after dual-write is enabled; differ job continuously verifies and alerts (engineering.gusto.com/zero-downtime-table-migrations) |
+| **AWS** | High-traffic NoSQL → DynamoDB | Dual-Write Single-Read → Dual-Write Dual-Read comparison → Single-Write Single-Read irreversible cutover (aws.amazon.com/blogs/architecture/middleware-assisted-zero-downtime-live-database-migration) |
+| **Mercari** | Spanner balance service v1→v2 | Chose single-transaction dual-write over CDC; batched idempotent backfill; lock-free consistency check (engineering.mercari.com/en/blog/entry/20241113-designing-a-zero-downtime-migration-solution-part-iv) |
+
+| Stage | Industry commonality | This plan |
+|---|---|---|
+| Dual-write | Synchronous write to both sides (Stripe / Gusto / AWS / Mercari) | ✅ Transaction-mirrored dual-write (8.2) |
+| Backfill | Batch backfill after dual-write is enabled | ✅ 8.3 |
+| Idempotency | Version comparison / ODKU skip | ✅ ODKU (8.3) |
+| Verification | dark read / differ | ✅ 8.7 |
+| Cutover | Phased cutover / atomic routing | ✅ epoch fencing (8.5) |
+| Rollback | Reverse sync / bidirectional replication | ✅ Rollback possible within the deferred-cleanup window (8.6) |
+
+> **Contrast with Figma**: Figma explicitly avoided dual-write + backfill in its sharding migration, using logical replication + physical failover instead (figma.com/blog/how-figmas-databases-team-lived-to-tell-the-scale). dual-write + backfill is not the only choice, but given drive9's scale and existing outbox infrastructure, application-layer dual-write is the path with the best cost-benefit ratio.
+
+---
+
+## 9. Existing-Tenant Migration
+
+### 9.1 Existing per-tenant DBs → shared DBs
+
+The same transaction-mirrored dual-write + backfill, with two extra handling points:
+
+| Difference | Handling |
+|---|---|
+| Source is the old schema (no fs_id column) | The dual-write proxy does shape translation: read the source per the old schema, write the target per the shared schema (injecting fs_id); see 5.6 |
+| Source may have a legacy `files` table with unfinished split | Prerequisite: run `SplitTablesMigrator` to completion first, then start fs-level migration (see 5.2.5) |
+
+### 9.2 Migration pacing
+
+| Stage | Notes |
+|---|---|
+| Batching | Batch by user/customer; avoid the risk of a one-shot full migration |
+| Priority | Low-activity tenants first (small backfill, short dual-write window); high-activity tenants last or evaluated separately |
+| Verification | After each batch completes, verify the cost-reduction effect |
+
+### 9.3 Onboarding existing per-tenant DBs
+
+| Step | Notes |
+|---|---|
+| Registration | `fs_registry` assigns an fs_id; `tenant_placements` marks `placement=dedicated, status=active` |
+| Routing | The routing layer handles them normally (DSN points at the existing cluster); the business layer is unaware |
+| Afterwards | Migrate transparently to shared DBs through the migration pipeline per the 9.2 pacing |
+
+---
+
+## 10. DB Instance Ownership Change
+
+### 10.1 Current state
+
+Existing per-tenant DBs are created under the user's TiDB Cloud org (the user's own API credentials). Users must manage their own TiDB Cloud account, billing, and cluster lifecycle.
+
+### 10.2 New architecture
+
+| Dimension | Notes |
+|---|---|
+| Unified ownership | All DB instances are created and managed under the drive9-internal TiDB Cloud org |
+| Unified management | Cluster create/delete/scale, billing, monitoring and alerting, schema version management |
+| Transparent to users | Users perceive only fs functionality, not the underlying DB management |
+
+---
+
+## 11. Quota-Related Changes
+
+### 11.1 Current state
+
+The quota system is enforced entirely **at the application layer via the central meta DB**, independent of the underlying physical DB:
+
+| Quota table (meta DB) | Purpose |
+|---|---|
+| `tenant_quota_config` | Storage / file count / file size / LLM monthly cost caps, `tidbcloud_spending_limit` |
+| `tenant_quota_usage` | Real-time storage bytes and file count usage |
+| `tenant_file_meta` | Per-file size records |
+| `tenant_upload_reservations` | Upload reservations (`AtomicReserveAndInsertUpload` atomic reservation + rollback on over-limit) |
+| `tenant_llm_usage` / `tenant_monthly_llm_cost` | LLM billing |
+| `quota_mutation_log` | Async quota-change outbox + `MutationReplayWorker` replay |
+
+| Dimension | Field | Enforced at |
+|---|---|---|
+| Storage cap | `max_storage_bytes` (default 50 GiB) | Application layer `ensureStorageQuota` |
+| File-count cap | `max_file_count` (0 = unlimited) | Application layer `ensureFileCountQuotaServer` |
+| Per-file size cap | `max_file_size_bytes` (default **0 = unlimited**) | Application layer `ensureFileSizeQuota` |
+| Media LLM file count | `max_media_llm_files` (default 500) | Application layer `mediaLLMQuotaExceeded` |
+| LLM monthly cost | `max_monthly_cost_mc` (0 = disabled) | Application layer `monthlyLLMCostExceeded` |
+| TiDB Cloud spending limit | `tidbcloud_spending_limit` | TiDB Cloud API (per-cluster) |
+
+All quota checks are keyed by tenant UUID in the central meta DB, **regardless of which physical DB the tenant's data lives on**.
+
+### 11.2 What does not change
+
+`tenant_quota_config` / `tenant_quota_usage` / `tenant_file_meta` / `tenant_upload_reservations` / `tenant_llm_usage` / `tenant_monthly_llm_cost` / `quota_mutation_log`, plus the check logic for storage / file count / file size / Media LLM / LLM monthly cost — all keyed by tenant_id and independent of the physical DB — **keep working as-is** after the shared-table migration.
+
+### 11.3 What must change: TiDB Cloud spending limit semantics
+
+```mermaid
+graph LR
+    subgraph NOW["Current · per-cluster = per-tenant"]
+        U1["tenant A"] --> C1["cluster A<br/>limit ¥100/mo"]
+        U2["tenant B"] --> C2["cluster B<br/>limit ¥200/mo"]
+        U3["tenant C"] --> C3["cluster C<br/>limit ¥50/mo"]
+    end
+    subgraph NEW["New architecture · shared pool"]
+        V1["tenant A"] --> SH["shared cluster<br/>pool limit ¥2000/mo"]
+        V2["tenant B"] --> SH
+        V3["tenant C"] --> SH
+        V4["tenant X (dedicated)"] --> DX["dedicated cluster<br/>limit ¥500/mo"]
+    end
+
+    classDef shared fill:#FFFBEB,stroke:#D97706,color:#92400E
+    classDef dedi fill:#ECFDF5,stroke:#059669,color:#065F46
+    class SH shared
+    class DX dedi
+```
+
+| Dimension | Current | New architecture |
+|---|---|---|
+| Granularity | per-tenant (one cluster per tenant) | per-cluster (N tenants share the limit) |
+| Who sets it | User `SET /quota` | drive9 manages centrally (recorded in `db_pool.spending_limit`) |
+| Independent per-tenant limit | ✅ | ❌ not for shared tenants; dedicated tenants regain per-tenant semantics |
+| `tidbcloud_spending_limit` field | User read/write | Shared tenants: read-only/deprecated; dedicated tenants: drive9 sets it per paid tier |
+
+Code changes: `applyQuotaSet` removes the `MarkQuotaUpdateStarted` / `UpdateQuota` TiDB Cloud API calls for shared tenants, keeping only `SetQuotaConfigPatch` (storage/file/LLM dimensions); `handleQuotaGet` returns the total limit of the hosting cluster, or nothing, for shared tenants.
+
+### 11.4 What must be added: per-tenant RU control
+
+Under the shared model one tenant can eat an entire cluster's RU (noisy neighbor). There is currently no per-tenant QPS/RU throttling (under the per-cluster model it was naturally constrained by the spending limit).
+
+```mermaid
+graph TB
+    subgraph NOW2["Initial (recommended option D: soft throttling + scheduling)"]
+        M1["Application-layer per-tenant RU collection"] --> M2["Scheduler-layer monitoring<br/>over-threshold alerts"] --> M3["Auto-trigger migration<br/>hot tenant → dedicated DB"]
+    end
+    subgraph LATER["Later (when noisy neighbor gets severe)"]
+        M4["Application-layer RU hard throttling<br/>token bucket / RU estimation"] --> M5["Queue / reject over-limit"]
+        M5 --> M6["Scheduled migration as backstop"]
+    end
+    M3 -.->|"upgrade on demand"| M4
+
+    classDef now fill:#EFF6FF,stroke:#2563EB,color:#1E40AF
+    classDef later fill:#F8FAFC,stroke:#94A3B8,color:#334155
+    class M1,M2,M3 now
+    class M4,M5,M6 later
+```
+
+| Candidate | Mechanism | Assessment |
+|---|---|---|
+| A Application-layer RU-estimation throttling | Estimate each SQL per TiDB RU rules; reject when the per-tenant total exceeds the limit | Engine-agnostic but imprecise estimation |
+| B TiDB Resource Control | Resource group caps RU/s per tenant | Precise at engine level; must confirm Serverless support; engine-bound |
+| C Pure scheduling backstop | Detect + migrate only | Reactive, cannot prevent in advance |
+| **D Soft throttling + scheduling (recommended)** | Application-layer collection + alerting + scheduled migration; add hard throttling later on demand | Moves forward together with Phase 5 monitoring/scheduling |
+
+### 11.5 Quota during migration
+
+| Question | Handling |
+|---|---|
+| Does backfill write count toward quota? | No. Quota checks sit at the user write entry; backfill goes through a separate channel |
+| Where do quota checks happen during dual-write? | Once at the application-layer entry; `tenant_quota_usage` is in the meta DB and does not change with the physical DB |
+| Recompute quota usage after migration? | Not needed |
+| Spending limit during migration | Shared tenants unaffected; for a dedicated tenant's migration, provisioning sets the new cluster's limit |
+
+### 11.6 User API changes
+
+| API | Change |
+|---|---|
+| `GET /quota` | storage / file_count unchanged; spending_limit for shared tenants returns the cluster's total limit or nothing |
+| `SET /quota` | storage / file_count unchanged; spending_limit cannot be set by shared tenants; optionally add `max_ru_per_minute` |
+| Dedicated tenants | spending_limit regains per-tenant settability |
+
+---
+
+## 12. Backup and Recovery
+
+With shared tables, **TiDB Cloud PITR/backup is cluster-granular** — if a single tenant's data is corrupted or accidentally deleted, cluster-level recovery affects all tenants on that cluster.
+
+| Level | Mechanism | Purpose |
+|---|---|---|
+| Cluster level | TiDB Cloud PITR / snapshots | Only for **disaster recovery** (whole-cluster failure) |
+| Tenant level | **Per-tenant logical export**: batch-export the 32 tables by fs_id → S3 (manifest + data files, versioned) | Recovery from single-tenant accidental deletion/corruption; also the basis for cross-region DR and compliance export |
+| Restore | Import with a new fs_id (or overwrite-import the original fs_id), remapped via `fs_registry` | The restored artifact is an independent fs; cut over after verification |
+
+Export frequency is configured per paid tier (RPO disclosure); export jobs reuse the backfill pipeline's batched-read capability.
+
+---
+
+## 13. Risks and Mitigations
+
+| # | Risk | Mitigation |
+|---|---|---|
+| 13.1 | Shared-table noisy neighbor | N starts at 100 and rises through gradual rollout; per-tenant RU monitoring + over-threshold migration to dedicated; long-term RU throttling (11.4) |
+| 13.2 | Dual-write failure | retry log replays per tx; cut over only when drained; sustained failure pauses migration for human intervention (8.4) |
+| 13.3 | Backfill hurting source DB performance | Batching + sleep + rate limiting; run at off-peak; pause backfill if other tenants' latency exceeds threshold |
+| 13.4 | In-flight requests at the cutover instant | Dual-write keeps both sides consistent; old connections finish naturally; epoch fencing guards un-refreshed instances (8.5) |
+| 13.5 | Large-tenant DELETE across 32 tables | Batched `LIMIT 10000` + pauses; async in background; executed within the deferred-cleanup window |
+| 13.6 | Fuzzy Starter table-count limit | share-table keeps a fixed 32 tables per cluster and does not depend on that limit; Phase 0 confirmation is only a reference for share-cluster |
+| 13.7 | Cross-org connectivity | Application-layer dual-write needs no direct DB-to-DB connection, only application → each DB reachable; Phase 0 verification (8.9) |
+| 13.8 | Schema version drift | Dedicated DBs also use the shared schema; the old schema exists only in existing DBs awaiting migration; datastore dual-shape during the window (5.6) |
+| 13.9 | Shared-DB single point of failure | Serverless multi-AZ; the N cap bounds the blast radius; batch migration on failure; cluster PITR + per-tenant export (§12) |
+| 13.10 | **fork latency regression** (branch → logical copy) | fork becomes an async state machine with disclosure; small filesystems barely affected; mid-term application-layer CoW fork fixes it for good (§7) |
+| 13.11 | **Vector/FTS + fs_id filtering execution plan** below expectations (post-filter recall dilution) | Phase 0 empirical verification; fallbacks: top-k over-fetch + rerank, HASH partition pruning, two-phase query (5.3, 14.1) |
+| 13.12 | **meta DB becoming a hot-path bottleneck and single point of failure** | In-process placement cache + epoch invalidation; quota already has a fail-open precedent; only migration operations hit meta directly (6.4) |
+| 13.13 | **AUTO_INCREMENT semantic change** (SSE cursor, llm_usage id) | fs_events writes a migration checkpoint event; SSE triggers client re-sync (5.4) |
+| 13.14 | **Shared connection-pool capacity** (aggregated QPS of N tenants on one `*sql.DB`) | Configure `MaxOpenConns` per cluster capacity; monitor connection-wait queues; migrate hot tenants out promptly |
+
+---
+
+## 14. Implementation Plan
+
+### 14.1 Phase overview
+
+| Phase | Tasks |
+|---|---|
+| **Phase 0 Verification** | ① Table-count limit confirmation ② Single-cluster RU stress test (N tenants sharing) ③ Cross-org connectivity (application → two DBs) ④ scale-to-zero cold start ⑤ **Vector top-k + fs_id filtering execution plan and recall rate** ⑥ **FTS + fs_id filtering execution plan** ⑦ **Verify index hit for `VEC_COSINE_DISTANCE` vs `VEC_EMBED_COSINE_DISTANCE`** ⑧ **Inventory of legacy `files` table distribution** ⑨ **Unified embedding model selection + re-embedding cost estimate for existing tenants** |
+| **Phase 1 Schema** | 32-table shared schema (fs_id + indexes + constraints); `semantic` app-managed conversion; `fs_registry`; schema version registration; datastore dual-shape rework |
+| **Phase 2 Routing layer** | pool.go routing rework (UUID→fs_id→placement); `tenant_placements` + `db_pool`; cache + epoch fencing; routing hot update |
+| **Phase 3 Shared pool** | Shared-pool instance management; new-tenant assignment; provisioning integration (including dedicated-as-shared-schema) |
+| **Phase 4 Migration mechanism** | Transaction-mirrored dual-write + backfill; retry log (reusing the MutationReplayWorker pattern); verification + epoch cutover + deferred cleanup; migration orchestration state machine (reusing the notify_outbox base) |
+| **Phase 5 Monitoring & scheduling** | Global + per-tenant metrics; hotspot detection + migration triggering |
+| **Phase 6 Existing-tenant migration** | Batched migration (each tenant's split migration completes first); verify cost per batch |
+| **Phase 7 fork rework + ownership unification** | fork logical-copy pipeline (reusing Phase 4) + async state machine; user-org DB cleanup |
+
+```mermaid
+graph LR
+    P0["Phase 0<br/>Verification"] --> P1["Phase 1<br/>Schema"]
+    P1 --> P2["Phase 2<br/>Routing layer"]
+    P2 --> P3["Phase 3<br/>Shared pool"]
+    P3 --> P4["Phase 4<br/>Migration mechanism"]
+    P4 --> P5["Phase 5<br/>Monitoring & scheduling"]
+    P5 --> P6["Phase 6<br/>Existing-tenant migration"]
+    P6 --> P7["Phase 7<br/>fork + ownership unification"]
+
+    classDef phase fill:#EFF6FF,stroke:#2563EB,color:#1E40AF
+    class P0,P1,P2,P3,P4,P5,P6,P7 phase
+```
+
+---
+
+## 15. Rollout Plan
+
+### 15.1 General principle: existing tenants untouched, new tenants first
+
+| Principle | Notes |
+|---|---|
+| **No existing-tenant migration** | Existing per-tenant DBs keep the current schema (no fs_id column); no DDL changes or data migration |
+| **Full compatibility** | All existing-tenant functionality (fork, quota, spending limit setting, existing SQL behavior) is exactly the same as today |
+| **New tenants first** | The shared pool takes only new tenants; not a single existing tenant enters |
+| **Shapes coexist rather than being retired** | Dedicated deployment (one fs, one cluster) **remains a long-term product shape** — e.g. enterprise-tier customers explicitly requesting a dedicated org + a dedicated DB per fs as a paid-isolation scenario; the existing schema is a formally supported long-term shape, not legacy |
+| **Every step reversible** | Stepwise rollout; every step has explicit entry conditions and a rollback action |
+
+### 15.2 Shape vocabulary and tenant tiers
+
+Separating two often-conflated dimensions is the key to eliminating the "legacy narrative":
+
+| Dimension | Values | Notes |
+|---|---|---|
+| Placement | `shared-pool` / `dedicated` | A business and isolation decision: the shared pool amortizes cost; dedicated clusters provide strong isolation and custom ownership |
+| Schema shape | `standalone` / `shared` | A purely technical decision: whether tables have the fs_id column |
+
+| Tenant type | Placement | Schema shape | DB ownership | Notes |
+|---|---|---|---|---|
+| Existing tenants | dedicated | standalone | user's org | Status quo frozen, long-term full compatibility |
+| Standard new tenants | shared-pool | shared | drive9 org | Default shape |
+| Enterprise dedicated deployment | dedicated | shared | drive9 org or user's org | Paid-isolation shape, retained long-term; enjoys the full capabilities of its own cluster (spending limit settable, etc.) |
+
+Two things behave identically under all shapes and **do not constitute shape differences**:
+
+- **embedding**: unified application-layer writes (5.3); the write path is the same for standalone and shared
+- **fork**: unified in-house logical copy (§7), independent of Cloud Branch and of placement
+
+### 15.3 Abstraction-layer design: one set of SQL, shape injected
+
+Goal: **no parallel pair of datastore methods may appear**. Shape differences converge to a single injection point:
+
+```go
+// pkg/datastore/scope.go (the only shape branch point)
+type Scope struct {
+    fsID   int64 // assigned by fs_registry; every tenant (including existing ones) has one
+    shared bool  // false = standalone shape (tables have no fs_id column)
+}
+
+func (s Scope) And(pred string) string   // shared: "fs_id = ? AND " + pred; standalone: pred
+func (s Scope) Args(a ...any) []any      // shared: prepend fsID; standalone: unchanged
+func (s Scope) InsCols(c string) string  // shared: "fs_id, " + c; standalone: c
+func (s Scope) InsVals(v string) string  // shared: "?, " + v; standalone: v
+```
+
+| Layer | Redundancy | Notes |
+|---|---|---|
+| SQL code paths | **One set** | Each datastore method is written once; SQL is assembled via Scope; in standalone the fs_id predicates and columns disappear automatically. Standalone "compatibility" = the behavior of the same code under `Scope{shared:false}`, not separately maintained legacy code |
+| journal / vault | **One set** | These two table groups already take a tenant predicate parameter; Scope only switches the column name and value (standalone uses the `tenant_id` string, shared uses `fs_id`) |
+| DDL | Generated | Schema is generated from a per-DB descriptor `{shape}`, reusing the existing schema_version + InitSchema + diff/repair mechanism; no two handwritten copies |
+| Routing | One set | placement decides DSN and connection-pool ownership; schema shape is read from placement (`tenant_placements` needs a new `schema` flag column: `'standalone' \| 'shared'`) |
+| Explicitly excluded | — | legacy `files` table dual-write (useLegacyFiles) is an earlier-generation intra-table shape problem, isolated in `pkg/migrate`, and does not enter the Scope abstraction; AUTO_INCREMENT semantic differences (5.4) are documented only and produce no code branches |
+
+Test matrix: full regression under both schema shapes `{standalone, shared}` (CRUD / search / vector / FTS / fork / quota); CI must pass both.
+
+### 15.4 Existing-shape (standalone) compatibility guarantees
+
+| Dimension | Design |
+|---|---|
+| placement registration | All existing tenants registered in `tenant_placements`: `placement=dedicated`, `schema=standalone`, `status=active` |
+| Routing | Connect directly to the original cluster DSN; behavior matches the existing `pool.go` point for point |
+| datastore | `Scope{shared:false}`: SQL emits no fs_id predicates or columns, verbatim identical to before rollout |
+| journal / vault | Keep using the existing `tenant_id VARCHAR(64)` column; no changes at all |
+| quota / spending limit | Remains per-cluster user-settable; the 11.3 semantic change **applies only to shared-pool** |
+| embedding writes | Switch to application-layer writes together with everyone (5.3); only the write path changes, existing DBs' DDL untouched |
+| fs_id pre-assignment | At rollout, batch-pre-assign fs_ids for existing tenants in `fs_registry` (pure meta data, no business data touched), for unified monitoring, Scope simplification, and future optional migration |
+
+### 15.5 Rollout steps
+
+```mermaid
+graph LR
+    S0["<b>Step 0</b><br/>Routing layer ships silently<br/>all dedicated, no change"]
+    S1["<b>Step 1</b><br/>Internal tenants<br/>enter the shared pool"]
+    S2["<b>Step 2</b><br/>Newly registered tenants<br/>gradual rollout by ratio"]
+    S3["<b>Step 3</b><br/>Monitoring & scheduling ships<br/>hotspot migration triggers"]
+
+    S0 --> S1 --> S2 --> S3
+
+    classDef step fill:#EFF6FF,stroke:#2563EB,color:#1E40AF
+    class S0,S1,S2,S3 step
+```
+
+| Step | Actions | Entry conditions | Rollback action |
+|---|---|---|---|
+| **Step 0: routing layer ships silently** | Deploy new code (routing layer + Scope-ified datastore); register placement for all existing tenants; production behavior has zero diff vs before rollout | Dual-shape full regression passes (standalone-shape CRUD / search / vector / FTS / fork / quota) | Roll back the deployment; the new meta tables have no side effects |
+| **Step 1: internal tenants enter the shared pool** | Create the first shared-pool cluster; provision internal / test tenants in the shared shape | Step 0 stable in production; shared-shape functional regression passes | Delete test tenants; scale down or delete the shared cluster |
+| **Step 2: gradual rollout for newly registered tenants** | A provisioning switch assigns new tenants to the shared pool by ratio (e.g. 10% → 50% → 100%); **new tenants outside the ratio go to dedicated DBs (shared schema)** — no new standalone-shape DBs are created | Step 1's RU / latency baseline within budget; vector + fs_id query quality spot-checks pass | Turn the ratio back to 0%; all new tenants go dedicated (shared schema); tenants already in the shared pool keep being served |
+| **Step 3: monitoring & scheduling ships** | per-tenant RU / QPS / storage collection (**including existing tenants**); hotspot detection; shared → dedicated migration trigger (human-confirmed first, automated after validation) | Stable after Step 2 reaches 100% | Turn off migration triggers, keep monitoring |
+
+### 15.6 Rollback plan summary
+
+| Anomaly | Rollback action |
+|---|---|
+| Routing-layer bug | Roll back the deployment; the standalone path is exactly as before rollout, inherently zero-risk |
+| Shared-cluster failure | Affected tenants migrate to dedicated DBs via the migration pipeline (isomorphic schema, low risk); new-tenant assignment switches back to dedicated |
+| Shared-shape functional defect | Affected tenants migrate to dedicated; the shared pool stops taking new tenants |
+| Cost below expectations | Freeze the shared-pool / dedicated ratio, keep running as-is, re-evaluate the sharing density N |
+
+### 15.7 Shape maintenance and new-feature rules
+
+| Dimension | Notes |
+|---|---|
+| New features | Default to one implementation + Scope adapting to both shapes; standalone gets no separate features and no deliberate omissions |
+| standalone retirement | **No preset retirement date**; the standalone branch is deleted only when all existing tenants have migrated out or an EOL is officially announced; the decision is driven by cost data and shared stability |
+| Long-term value of the dedicated shape | Enterprise paid isolation + upgrade target for hot tenants + default fork destination; coexists with the shared pool long-term |
+
+### 15.8 Relationship to existing-tenant migration (§9) and the implementation plan (§14)
+
+| Item | Positioning change |
+|---|---|
+| §9 existing-tenant migration, §14 Phase 6 / Phase 7 | Demoted to **optional follow-up phases**: the rollout plan does not include existing-tenant migration; entry conditions = shared pool running stably + sufficient cost-comparison data + the migration pipeline already production-proven in the fork-copy scenario |
+| §14 Phase 0 ~ Phase 5 | Required for rollout; order unchanged |
+| Migration mechanism (§8) | Right after rollout it has two production uses as backstop validation: hot-tenant shared → dedicated scheduling, and fork logical copy; get these two scenarios running smoothly first, then discuss whether to use it for existing-tenant migration |
+
+### 15.9 Post-rollout cost shape
+
+| Part | Cost curve |
+|---|---|
+| Existing tenants | Frozen at current levels (cluster count neither grows nor shrinks) |
+| New tenants | Enter the shared pool; stepwise growth (a new cluster only when one fills up) |
+| Total cost | From "linear growth" to "existing frozen + incremental steps"; break-even depends on new-tenant growth rate |
+
+### 15.10 User-visible differences across tenant shapes (to be disclosed in API / docs)
+
+| Dimension | Existing (dedicated + standalone) | Standard (shared-pool) | Enterprise (dedicated + shared) |
+|---|---|---|---|
+| spending limit | User-settable (per-cluster) | Not settable (shared-cluster unified limit) | User-settable (per-cluster) |
+| embedding | Unified application-layer writes; behavior identical | Same as left | Same as left |
+| fork | Logical copy (in-house, async) | Same as left | Same as left |
+| Underlying ownership | Independent cluster in the user's org | Shared cluster in the drive9 org | Independent cluster in the user's org or drive9 org |

--- a/docs/TENANT_DB_REDESIGN.md
+++ b/docs/TENANT_DB_REDESIGN.md
@@ -233,8 +233,8 @@ graph TB
 | `uploads` | `UNIQUE (upload_id)`; generated column `active_target_path_hash VIRTUAL` + unique index | `UNIQUE(fs_id, upload_id)`; `UNIQUE(fs_id, active_target_path_hash)` |
 | `semantic_tasks` | `UNIQUE (task_id)`; `UNIQUE (task_type, resource_id, resource_version)` | Add `fs_id` prefix to both unique constraints |
 | `file_gc_tasks` | `UNIQUE (task_id)`; `uk_file_gc_file_id`; `uk_file_gc_inode_id` | Add `fs_id` prefix to all three unique constraints |
-| `llm_usage` | `id AUTO_INCREMENT PK` | `id` stays a purely physical primary key (cluster-global auto-increment); add `KEY(fs_id, ...)`; see 5.4 |
-| `fs_events` | `seq AUTO_INCREMENT PK` | Same as above; add `KEY(fs_id, seq)`; SSE cursor handling in 5.4 |
+| `llm_usage` | `id AUTO_INCREMENT PK` | **Dropped from the shared schema** — the backend only writes the tenant-DB `llm_usage` when server quota is inactive (single-tenant/local mode), which shared-schema databases never run; the central `tenant_llm_usage` ledger is authoritative in multi-tenant deployments, so the duplicate table is not carried over |
+| `fs_events` | `seq AUTO_INCREMENT PK` | `seq` stays a purely physical primary key (cluster-global auto-increment); add `KEY(fs_id, seq)`; SSE cursor handling in 5.4 |
 
 #### 5.2.2 Git Workspace (5 tables)
 
@@ -282,8 +282,8 @@ db9 (PostgreSQL + pgvector, 24 tables) is **not in scope** for this shared-table
 
 | Table | Current state | Shared-table handling |
 |---|---|---|
-| `llm_usage` | `id AUTO_INCREMENT` | Keep the auto-increment id as a cluster-global physical primary key (physical ordering only); all queries go through `(fs_id, ...)` indexes; no external references, so values need not be preserved during migration |
-| `fs_events` | `seq AUTO_INCREMENT`, consumed by the SSE cursor (`WHERE seq > cursor`) | In shared tables seq is globally monotonic with per-tenant gaps — `WHERE fs_id=? AND seq>cursor` semantics stay correct; **seq values cannot be preserved during migration**. On cutover, write a migration checkpoint event into the target DB; the SSE layer detects it and tells clients to re-sync their cursor |
+| `llm_usage` | `id AUTO_INCREMENT` | **Dropped from the shared schema** (see 5.2.1) — no AUTO_INCREMENT handling needed |
+| `fs_events` | `seq AUTO_INCREMENT`, consumed by the SSE cursor (`WHERE seq > cursor`) | In shared tables seq is globally monotonic with per-tenant gaps. Gap detection in the SSE layer previously treated any hole as pruning (reset storm under interleaved tenants); it now resets only when the cursor falls behind the oldest retained seq (shipped in #754), so `WHERE fs_id=? AND seq>cursor` delivers correctly through interior gaps. **seq values cannot be preserved during migration**: on cutover, write a migration checkpoint event into the target DB; the SSE layer detects it and tells clients to re-sync their cursor |
 
 ### 5.5 Partitioning strategy
 
@@ -480,7 +480,7 @@ A drive9 write is **a single transaction spanning 5~7 tables** (file write: `ino
 | Idempotency | `ON DUPLICATE KEY UPDATE` (**do not use** `INSERT IGNORE` / `REPLACE INTO`) | INSERT IGNORE skips rows with older versions causing inconsistency; REPLACE INTO's delete-then-insert semantics has side effects |
 | Table by table | Backfill only one table at a time | Control pressure on the source DB |
 | DELETE synchronization | Backfill SELECT cannot see already-deleted rows; deletions are guaranteed entirely by dual-write + retry log | Separation of concerns |
-| AUTO_INCREMENT tables | `llm_usage.id` / `fs_events.seq` values are not preserved; the target side auto-increments anew (see 5.4) | Shared-table auto-increment cannot preserve values |
+| AUTO_INCREMENT tables | `fs_events.seq` values are not preserved; the target side auto-increments anew (see 5.4) | Shared-table auto-increment cannot preserve values |
 
 ### 8.4 Dual-write failure handling
 
@@ -819,8 +819,10 @@ Export frequency is configured per paid tier (RPO disclosure); export jobs reuse
 | 13.10 | **fork latency regression** (branch → logical copy) | fork becomes an async state machine with disclosure; small filesystems barely affected; mid-term application-layer CoW fork fixes it for good (§7) |
 | 13.11 | **Vector/FTS + fs_id filtering execution plan** below expectations (post-filter recall dilution) | Phase 0 empirical verification; fallbacks: top-k over-fetch + rerank, HASH partition pruning, two-phase query (5.3, 14.1) |
 | 13.12 | **meta DB becoming a hot-path bottleneck and single point of failure** | In-process placement cache + epoch invalidation; quota already has a fail-open precedent; only migration operations hit meta directly (6.4) |
-| 13.13 | **AUTO_INCREMENT semantic change** (SSE cursor, llm_usage id) | fs_events writes a migration checkpoint event; SSE triggers client re-sync (5.4) |
+| 13.13 | **AUTO_INCREMENT semantic change** (SSE cursor) | fs_events writes a migration checkpoint event; SSE triggers client re-sync (5.4); SSE gap detection already tolerates interior seq holes (merged in #754) |
 | 13.14 | **Shared connection-pool capacity** (aggregated QPS of N tenants on one `*sql.DB`) | Configure `MaxOpenConns` per cluster capacity; monitor connection-wait queues; migrate hot tenants out promptly |
+| 13.15 | **Tenant deletion on a shared DB** (the current delete flow assumes cluster==tenant and deprovisions the cluster) | Shared-tenant deletion must instead batch-DELETE all rows `WHERE fs_id = ?` across the shared tables (batched + pauses, as in 13.5), clean the S3 namespace and meta-side state, and **never deprovision the shared cluster**; fork deletion follows the same rule (S3 is a shared namespace with refcount GC). Owned by Phase 3 (§14) |
+| 13.16 | **Unbounded row growth on shared tables** (`fs_events` retention today is driven by per-tenant worker activity, so idle tenants' rows accumulate forever — on a shared table this is a cluster-wide growth problem) | Cluster-level batched retention sweep (`DELETE WHERE created_at < cutoff`, no fs_id filter, off-peak, rate-limited) owned by Phase 3 (§14); completed/dead `semantic_tasks`/`file_gc_tasks` rows get the same treatment later (pre-existing issue, amplified by sharing) |
 
 ---
 
@@ -833,7 +835,7 @@ Export frequency is configured per paid tier (RPO disclosure); export jobs reuse
 | **Phase 0 Verification** | ① Table-count limit confirmation ② Single-cluster RU stress test (N tenants sharing) ③ Cross-org connectivity (application → two DBs) ④ scale-to-zero cold start ⑤ **Vector top-k + fs_id filtering execution plan and recall rate** ⑥ **FTS + fs_id filtering execution plan** ⑦ **Verify index hit for `VEC_COSINE_DISTANCE` vs `VEC_EMBED_COSINE_DISTANCE`** ⑧ **Inventory of legacy `files` table distribution** ⑨ **Unified embedding model selection + re-embedding cost estimate for existing tenants** |
 | **Phase 1 Schema** | 32-table shared schema (fs_id + indexes + constraints); `semantic` app-managed conversion; `fs_registry`; schema version registration; datastore dual-shape rework |
 | **Phase 2 Routing layer** | pool.go routing rework (UUID→fs_id→placement); `tenant_placements` + `db_pool`; cache + epoch fencing; routing hot update |
-| **Phase 3 Shared pool** | Shared-pool instance management; new-tenant assignment; provisioning integration (including dedicated-as-shared-schema) |
+| **Phase 3 Shared pool** | Shared-pool instance management; new-tenant assignment; provisioning integration (including dedicated-as-shared-schema); **shared-tenant deletion flow** (batched `WHERE fs_id = ?` deletes, no cluster deprovisioning; 13.15); **cluster-level retention sweep for shared tables** (13.16) |
 | **Phase 4 Migration mechanism** | Transaction-mirrored dual-write + backfill; retry log (reusing the MutationReplayWorker pattern); verification + epoch cutover + deferred cleanup; migration orchestration state machine (reusing the notify_outbox base) |
 | **Phase 5 Monitoring & scheduling** | Global + per-tenant metrics; hotspot detection + migration triggering |
 | **Phase 6 Existing-tenant migration** | Batched migration (each tenant's split migration completes first); verify cost per batch |

--- a/docs/TENANT_DB_REDESIGN.md
+++ b/docs/TENANT_DB_REDESIGN.md
@@ -128,6 +128,8 @@ CREATE TABLE fs_registry (
 
 Existing data handling: the existing `tenant_id VARCHAR(64)` columns in journal/vault tables are uniformly replaced by `fs_id BIGINT` in the shared schema; backfill converts via `fs_registry`. Application-layer interface signatures are unchanged.
 
+**Persisted provider for shared tenants**: a tenant placed on a shared DB is persisted with provider `tidb_cloud_native_shared` (a first-class provider in `pkg/tenant/provider.go`), not the request's original provider. This gives every lifecycle surface a durable, placement-row-independent routing signal: capability helpers classify it as TiDB-backed but with **no database auto-embedding** (shared tables have no generated columns) and **no per-tenant cluster to delete or fork** (`SupportsClusterDelete` = false). The admin tenant API is cluster-centric and explicitly rejects shared tenants (409); shared tenants are managed through the owner API. Placement lookup errors fail closed everywhere — a meta read failure never silently falls back to dedicated-cluster provisioning.
+
 ### 4.2 Layered architecture overview
 
 ```mermaid

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -529,6 +529,23 @@ Manual-only: requires TiDB Cloud API credentials. Not wired into CI.
 17. Delete main tenant via `drive9 delete` and verify removal (401/403/404 on `GET /v1/status`)
 18. Trap-based cleanup: attempts to delete both admin and main tenants on script failure unless `SKIP_CLEANUP=1`
 
+### `shared-mode-smoke-test.sh`
+
+Shared-schema (fs_id) mode end-to-end smoke: starts a throwaway MySQL
+container (or uses `META_DSN`/`SHARED_DSN` you provide, e.g. a TiDB endpoint),
+then boots `drive9-server` with `DRIVE9_SHARED_POOL_DSN` registered as a
+wildcard shared pool.
+
+1. Two tenants provision — both placed on the shared DB and `active` immediately (no cluster creation)
+2. File CRUD + mkdir + directory listing on tenant A
+3. Cross-tenant isolation: same path under tenant B holds different content; B cannot read A's nested file
+4. Raw SQL on the shared DB: both tenants' rows share tables with distinct `fs_id`s
+5. `DELETE /v1/tenant` on A: shared rows purged (`file_nodes`/`inodes` empty for A's fs_id), A's key revoked (401/403), B fully intact
+
+Knobs: `META_DSN` / `SHARED_DSN` (skip the container), `KEEP_DB=1`,
+`DRIVE9_SHARED_E2E_DB_RUNTIME`, `DRIVE9_SHARED_E2E_DB_IMAGE`,
+`DRIVE9_SHARED_E2E_DB_PASSWORD`.
+
 ## Environment variables
 
 | Variable | Default | Used by |

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -531,20 +531,33 @@ Manual-only: requires TiDB Cloud API credentials. Not wired into CI.
 
 ### `shared-mode-smoke-test.sh`
 
-Shared-schema (fs_id) mode end-to-end smoke: starts a throwaway MySQL
-container (or uses `META_DSN`/`SHARED_DSN` you provide, e.g. a TiDB endpoint),
-then boots `drive9-server` with `DRIVE9_SHARED_POOL_DSN` registered as a
-wildcard shared pool.
+Shared-schema (fs_id) mode end-to-end smoke against real engines: a MySQL
+container for the meta DB and a TiDB (`pingcap/tidb:v8.5.6`) container holding
+both the shared DB and a standalone tenant DB, then boots `drive9-server`
+with `DRIVE9_SHARED_POOL_DSN` registered as a wildcard shared pool.
 
 1. Two tenants provision — both placed on the shared DB and `active` immediately (no cluster creation)
 2. File CRUD + mkdir + directory listing on tenant A
 3. Cross-tenant isolation: same path under tenant B holds different content; B cannot read A's nested file
-4. Raw SQL on the shared DB: both tenants' rows share tables with distinct `fs_id`s
-5. `DELETE /v1/tenant` on A: shared rows purged (`file_nodes`/`inodes` empty for A's fs_id), A's key revoked (401/403), B fully intact
+4. Raw SQL on TiDB: rows share tables with distinct `fs_id`s; `file_nodes` is `TIDB_PK_TYPE=CLUSTERED`; no `llm_usage` table
+5. SSE `/v1/events` stream delivers initial reset + file event on a shared tenant
+6. Multipart upload (v2 initiate/parts/complete) on a shared tenant, served via redirect
+7. `POST /v1/fork` on a shared tenant is rejected (409)
+8. Standalone tenant coexistence (registered directly via `e2e/harness/standalone-tenant` with `-skip-ensure`): standalone CRUD, no `fs_id` column in its tables, no row leakage either direction
+9. Server restart persistence: both shared and standalone backends keep working
+10. `DELETE /v1/tenant` on A: shared rows purged (`file_nodes`/`inodes` empty for A's fs_id), A's key revoked (401/403), B and standalone fully intact
 
-Knobs: `META_DSN` / `SHARED_DSN` (skip the container), `KEEP_DB=1`,
-`DRIVE9_SHARED_E2E_DB_RUNTIME`, `DRIVE9_SHARED_E2E_DB_IMAGE`,
-`DRIVE9_SHARED_E2E_DB_PASSWORD`.
+Knobs: `META_DSN` / `SHARED_DSN` / `STANDALONE_DSN` (skip the containers),
+`KEEP_DB=1`, `DRIVE9_SHARED_E2E_DB_RUNTIME`, `DRIVE9_SHARED_E2E_MYSQL_IMAGE`,
+`DRIVE9_SHARED_E2E_TIDB_IMAGE`, `DRIVE9_SHARED_E2E_DB_PASSWORD`.
+
+### `harness/standalone-tenant`
+
+Go helper that registers a pre-existing standalone tenant directly in the meta
+DB (tenant row + owner API key), bypassing cluster provisioning. `-skip-ensure`
+initializes the standalone DB with the base (no FTS/vector) schema and stamps
+`tenants.schema_version` so the Acquire-time ensure is skipped — required for
+engines without FTS/vector support such as self-hosted TiDB.
 
 ## Environment variables
 

--- a/e2e/harness/standalone-tenant/main.go
+++ b/e2e/harness/standalone-tenant/main.go
@@ -1,0 +1,177 @@
+// Command standalone-tenant registers an existing (standalone) tenant directly
+// in the meta DB and issues an owner API key for it, bypassing cluster
+// provisioning. It exists so e2e scripts can simulate a pre-existing
+// standalone tenant coexisting with shared-pool tenants.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/encrypt"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant/schema"
+	"github.com/mem9-ai/drive9/pkg/tenant/token"
+)
+
+func main() {
+	var (
+		metaDSN    = flag.String("meta-dsn", "", "control-plane meta DSN (required)")
+		masterHex  = flag.String("master-key", "", "hex master key for local_aes encryption (required)")
+		tokenHex   = flag.String("token-secret", "", "hex token signing key (required)")
+		tenantID   = flag.String("tenant-id", "", "tenant UUID to register (required)")
+		dbHost     = flag.String("db-host", "127.0.0.1", "standalone tenant DB host")
+		dbPort     = flag.Int("db-port", 4000, "standalone tenant DB port")
+		dbUser     = flag.String("db-user", "root", "standalone tenant DB user")
+		dbPassword = flag.String("db-password", "", "standalone tenant DB password (plaintext, encrypted before persist)")
+		dbName     = flag.String("db-name", "", "standalone tenant DB name (required)")
+		dbTLS      = flag.Bool("db-tls", false, "standalone tenant DB TLS")
+		provider   = flag.String("provider", "tidb_zero", "provider string recorded on the tenant row")
+		clusterID  = flag.String("cluster-id", "", "cluster id recorded on the tenant row (optional)")
+		keyName    = flag.String("key-name", "default", "API key name")
+		skipEnsure = flag.Bool("skip-ensure", false, "init the standalone DB with the base (no FTS/vector) schema and stamp the tenant schema_version so Acquire-time ensure is skipped; for engines without FTS/vector support such as self-hosted TiDB")
+	)
+	flag.Parse()
+	if *metaDSN == "" || *masterHex == "" || *tokenHex == "" || *tenantID == "" || *dbName == "" {
+		fmt.Fprintln(os.Stderr, "required: -meta-dsn -master-key -token-secret -tenant-id -db-name")
+		os.Exit(2)
+	}
+	ctx := context.Background()
+
+	store, err := meta.OpenContext(ctx, *metaDSN)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "open meta store:", err)
+		os.Exit(1)
+	}
+	defer func() { _ = store.Close() }()
+
+	masterKey, err := hex.DecodeString(*masterHex)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "decode master key:", err)
+		os.Exit(1)
+	}
+	enc, err := encrypt.New(ctx, encrypt.Config{Type: encrypt.TypeLocalAES, Key: hex.EncodeToString(masterKey)})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "create encryptor:", err)
+		os.Exit(1)
+	}
+	passCipher, err := enc.Encrypt(ctx, []byte(*dbPassword))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "encrypt db password:", err)
+		os.Exit(1)
+	}
+
+	now := time.Now().UTC()
+	if err := store.InsertTenant(ctx, &meta.Tenant{
+		ID:               *tenantID,
+		Status:           meta.TenantActive,
+		Kind:             meta.TenantKindLive,
+		DBHost:           *dbHost,
+		DBPort:           *dbPort,
+		DBUser:           *dbUser,
+		DBPasswordCipher: passCipher,
+		DBName:           *dbName,
+		DBTLS:            *dbTLS,
+		Provider:         *provider,
+		ClusterID:        *clusterID,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "insert tenant:", err)
+		os.Exit(1)
+	}
+
+	if *skipEnsure {
+		if err := initStandaloneBaseSchema(ctx, store, *tenantID, *dbUser, *dbPassword, *dbHost, *dbPort, *dbName, *dbTLS); err != nil {
+			fmt.Fprintln(os.Stderr, "init standalone base schema:", err)
+			os.Exit(1)
+		}
+	}
+
+	tokenSecret, err := hex.DecodeString(*tokenHex)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "decode token secret:", err)
+		os.Exit(1)
+	}
+	rawToken, err := token.IssueTokenWithJournalPermissions(tokenSecret, *tenantID, 1, time.Time{}, nil)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "issue token:", err)
+		os.Exit(1)
+	}
+	cipherToken, err := enc.Encrypt(ctx, []byte(rawToken))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "encrypt token:", err)
+		os.Exit(1)
+	}
+	if err := store.InsertAPIKey(ctx, &meta.APIKey{
+		ID:            token.NewID(),
+		TenantID:      *tenantID,
+		KeyName:       *keyName,
+		JWTCiphertext: cipherToken,
+		JWTHash:       token.HashToken(rawToken),
+		TokenVersion:  1,
+		Status:        meta.APIKeyActive,
+		ScopeKind:     meta.APIKeyScopeKindOwner,
+		IssuedAt:      now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		fmt.Fprintln(os.Stderr, "insert api key:", err)
+		os.Exit(1)
+	}
+	// stdout carries only the raw API key; everything else goes to stderr.
+	fmt.Println(rawToken)
+}
+
+// initStandaloneBaseSchema applies the base (no FTS/vector) tenant schema to
+// the standalone DB and stamps the tenant's schema_version with the fts_only
+// target version, so the pool's Acquire-time ensure — which would require
+// FTS/vector indexes this engine cannot build — is skipped entirely.
+func initStandaloneBaseSchema(ctx context.Context, store *meta.Store, tenantID, user, pass, host string, port int, dbName string, tls bool) error {
+	query := "parseTime=true"
+	if tls {
+		query += "&tls=true"
+	}
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", user, pass, host, port, dbName, query)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = db.Close() }()
+	for _, stmt := range schema.MySQLNoEmbeddingTenantSchemaStatements() {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			msg := err.Error()
+			if strings.Contains(msg, "Duplicate key name") || strings.Contains(msg, "already exists") || strings.Contains(msg, "Duplicate column") {
+				continue
+			}
+			return fmt.Errorf("apply base schema: %w", err)
+		}
+	}
+	if _, err := store.DB().ExecContext(ctx,
+		`INSERT INTO tenant_auto_embedding_profiles (tenant_id) VALUES (?) ON DUPLICATE KEY UPDATE tenant_id = tenant_id`, tenantID); err != nil {
+		return fmt.Errorf("ensure embedding profile: %w", err)
+	}
+	profile, err := store.GetTenantAutoEmbeddingProfile(ctx, tenantID)
+	if err != nil {
+		return fmt.Errorf("load embedding profile: %w", err)
+	}
+	version, err := schema.TiDBTenantSchemaVersionForFTSOnlyProfile(schema.TiDBAutoEmbeddingProfile{
+		Model:       profile.Model,
+		Dimensions:  profile.Dimensions,
+		OptionsJSON: profile.OptionsJSON,
+	})
+	if err != nil {
+		return fmt.Errorf("compute fts_only schema version: %w", err)
+	}
+	if err := store.UpdateTenantSchemaVersion(ctx, tenantID, version); err != nil {
+		return fmt.Errorf("stamp schema version: %w", err)
+	}
+	return nil
+}

--- a/e2e/shared-mode-smoke-test.sh
+++ b/e2e/shared-mode-smoke-test.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
-# End-to-end smoke test for shared-schema (fs_id) mode:
-#   1 meta DB + 1 shared DB, two tenants provisioned onto the shared DB,
-#   CRUD + cross-tenant isolation + delete/purge verification.
+# End-to-end smoke test for shared-schema (fs_id) mode against real engines:
+#   - MySQL container      → control-plane meta DB
+#   - TiDB container       → shared-schema DB (validates CLUSTERED DDL) AND a
+#                            second database simulating a pre-existing
+#                            standalone tenant DB (coexistence)
 #
-# Defaults start a throwaway MySQL container. To run against a TiDB endpoint
-# instead, set META_DSN / SHARED_DSN (and TLS=true in the DSN if needed):
-#   META_DSN='root:pass@tcp(host:4000)/meta?parseTime=true' \
-#   SHARED_DSN='root:pass@tcp(host:4000)/shared?parseTime=true' \
-#     bash e2e/shared-mode-smoke-test.sh
+# Covers: provision onto shared pool (instant active), CRUD, cross-tenant
+# isolation, SSE events, multipart upload, fork rejection, shared delete +
+# purge, server restart persistence, and standalone↔shared coexistence.
+#
+# Override endpoints to skip containers:
+#   META_DSN=... SHARED_DSN=... STANDALONE_DSN=... bash e2e/shared-mode-smoke-test.sh
 
 set -euo pipefail
 
@@ -15,18 +18,22 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 DB_RUNTIME="${DRIVE9_SHARED_E2E_DB_RUNTIME:-}"
-DB_IMAGE="${DRIVE9_SHARED_E2E_DB_IMAGE:-mysql:8.4}"
+MYSQL_IMAGE="${DRIVE9_SHARED_E2E_MYSQL_IMAGE:-mysql:8.4}"
+TIDB_IMAGE="${DRIVE9_SHARED_E2E_TIDB_IMAGE:-pingcap/tidb:v8.5.6}"
 DB_PASSWORD="${DRIVE9_SHARED_E2E_DB_PASSWORD:-drive9pass}"
 META_DB="${DRIVE9_SHARED_E2E_META_DB:-drive9_meta}"
 SHARED_DB="${DRIVE9_SHARED_E2E_SHARED_DB:-drive9_shared}"
+STANDALONE_DB="${DRIVE9_SHARED_E2E_STANDALONE_DB:-drive9_standalone}"
 META_DSN="${META_DSN:-}"
 SHARED_DSN="${SHARED_DSN:-}"
+STANDALONE_DSN="${STANDALONE_DSN:-}"
 KEEP_DB="${KEEP_DB:-0}"
-POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-90}"
-POLL_INTERVAL_S="${POLL_INTERVAL_S:-1}"
-LISTEN_ADDR="${LISTEN_ADDR:-}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-180}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-2}"
 
-DB_CONTAINER=""
+MYSQL_CONTAINER=""
+TIDB_CONTAINER=""
+NETWORK=""
 SERVER_PID=""
 TMP_DIR="$(mktemp -d)"
 PASS_COUNT=0
@@ -35,24 +42,20 @@ FAIL_COUNT=0
 log() { echo "[shared-e2e] $*"; }
 pass() { PASS_COUNT=$((PASS_COUNT + 1)); log "PASS: $1"; }
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); log "FAIL: $1" >&2; }
-check_eq() { # name want got
-  if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (want=$2 got=$3)"; fi
-}
+check_eq() { if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (want=$2 got=$3)"; fi }
 
 cleanup() {
   local rc=$?
-  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+  [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1 && {
     kill "$SERVER_PID" >/dev/null 2>&1 || true
     wait "$SERVER_PID" 2>/dev/null || true
+  }
+  if [ "$KEEP_DB" != "1" ]; then
+    [ -n "$MYSQL_CONTAINER" ] && "$DB_RUNTIME" rm -f "$MYSQL_CONTAINER" >/dev/null 2>&1 || true
+    [ -n "$TIDB_CONTAINER" ] && "$DB_RUNTIME" rm -f "$TIDB_CONTAINER" >/dev/null 2>&1 || true
+    [ -n "$NETWORK" ] && "$DB_RUNTIME" network rm "$NETWORK" >/dev/null 2>&1 || true
   fi
-  if [ -n "$DB_CONTAINER" ] && [ "$KEEP_DB" != "1" ]; then
-    "$DB_RUNTIME" rm -f "$DB_CONTAINER" >/dev/null 2>&1 || true
-  fi
-  if [ "$rc" -eq 0 ]; then
-    rm -rf "$TMP_DIR"
-  else
-    log "failed; artifacts kept at $TMP_DIR"
-  fi
+  [ "$rc" -eq 0 ] && rm -rf "$TMP_DIR" || log "failed; artifacts kept at $TMP_DIR"
   log "passed=$PASS_COUNT failed=$FAIL_COUNT"
   [ "$FAIL_COUNT" -eq 0 ]
   exit $?
@@ -75,44 +78,63 @@ detect_runtime() {
   if [ -n "$DB_RUNTIME" ]; then return; fi
   if command -v docker >/dev/null 2>&1; then DB_RUNTIME="docker"; return; fi
   if command -v podman >/dev/null 2>&1; then DB_RUNTIME="podman"; return; fi
-  echo "docker or podman is required when META_DSN/SHARED_DSN are not set" >&2
+  echo "docker or podman is required when DSNs are not set" >&2
   exit 1
 }
 
-start_mysql_container() {
-  detect_runtime
-  DB_CONTAINER="drive9-shared-e2e-$(date +%s)-$$"
-  log "starting $DB_RUNTIME container $DB_CONTAINER from $DB_IMAGE"
-  "$DB_RUNTIME" run -d \
-    --name "$DB_CONTAINER" \
-    -e MYSQL_ROOT_PASSWORD="$DB_PASSWORD" \
-    -p 127.0.0.1::3306 \
-    "$DB_IMAGE" >/dev/null
+meta_exec() { "$DB_RUNTIME" exec "$MYSQL_CONTAINER" mysql -uroot -p"$DB_PASSWORD" -N -e "$1"; }
+tidb_exec() { "$DB_RUNTIME" exec "$MYSQL_CONTAINER" mysql -h tidb-e2e -P 4000 -uroot -N -e "$1" 2>/dev/null; }
 
+start_mysql_container() {
+  MYSQL_CONTAINER="drive9-shared-e2e-mysql-$(date +%s)-$$"
+  log "starting MySQL container $MYSQL_CONTAINER ($MYSQL_IMAGE)"
+  "$DB_RUNTIME" run -d --name "$MYSQL_CONTAINER" --network "$NETWORK" \
+    -e MYSQL_ROOT_PASSWORD="$DB_PASSWORD" -p 127.0.0.1::3306 "$MYSQL_IMAGE" >/dev/null
   local deadline port
   deadline=$(($(date +%s) + POLL_TIMEOUT_S))
   while :; do
-    port=$("$DB_RUNTIME" port "$DB_CONTAINER" 3306/tcp 2>/dev/null | awk -F: 'END{print $NF}')
+    port=$("$DB_RUNTIME" port "$MYSQL_CONTAINER" 3306/tcp 2>/dev/null | awk -F: 'END{print $NF}')
     [ -n "$port" ] && break
-    [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for port mapping" >&2; exit 1; }
+    [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for mysql port" >&2; exit 1; }
     sleep "$POLL_INTERVAL_S"
   done
   while :; do
-    # mysqladmin ping succeeds before the entrypoint finishes setting the
-    # root password, so use a real authenticated query as the readiness gate.
-    "$DB_RUNTIME" exec "$DB_CONTAINER" mysql -uroot -p"$DB_PASSWORD" -N -e "SELECT 1" >/dev/null 2>&1 && break
-    [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for MySQL readiness" >&2; exit 1; }
+    meta_exec "SELECT 1" >/dev/null 2>&1 && break
+    [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for MySQL auth readiness" >&2; exit 1; }
     sleep "$POLL_INTERVAL_S"
   done
-  DB_PORT_HOST="$port"
-  mysql_exec() { "$DB_RUNTIME" exec "$DB_CONTAINER" mysql -uroot -p"$DB_PASSWORD" -N -e "$1"; }
-  mysql_exec "CREATE DATABASE IF NOT EXISTS $META_DB; CREATE DATABASE IF NOT EXISTS $SHARED_DB;"
+  meta_exec "CREATE DATABASE IF NOT EXISTS $META_DB;"
   META_DSN="root:${DB_PASSWORD}@tcp(127.0.0.1:${port})/${META_DB}?parseTime=true"
-  SHARED_DSN="root:${DB_PASSWORD}@tcp(127.0.0.1:${port})/${SHARED_DB}?parseTime=true"
-  log "meta db: $META_DB, shared db: $SHARED_DB (127.0.0.1:$port)"
+  log "meta db: $META_DB (mysql 127.0.0.1:$port)"
 }
 
-http() { # method path [api_key] [body] -> "code|body"
+start_tidb_container() {
+  TIDB_CONTAINER="tidb-e2e"
+  log "starting TiDB container $TIDB_CONTAINER ($TIDB_IMAGE) — this takes ~1 min"
+  "$DB_RUNTIME" rm -f "$TIDB_CONTAINER" >/dev/null 2>&1 || true
+  "$DB_RUNTIME" run -d --name "$TIDB_CONTAINER" --network "$NETWORK" --network-alias tidb-e2e \
+    -p 127.0.0.1::4000 "$TIDB_IMAGE" >/dev/null
+  local deadline port
+  deadline=$(($(date +%s) + POLL_TIMEOUT_S))
+  while :; do
+    port=$("$DB_RUNTIME" port "$TIDB_CONTAINER" 4000/tcp 2>/dev/null | awk -F: 'END{print $NF}')
+    [ -n "$port" ] && break
+    [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for tidb port" >&2; exit 1; }
+    sleep "$POLL_INTERVAL_S"
+  done
+  while :; do
+    tidb_exec "SELECT 1" >/dev/null 2>&1 && break
+    [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for TiDB readiness" >&2; "$DB_RUNTIME" logs "$TIDB_CONTAINER" 2>&1 | tail -20 >&2; exit 1; }
+    sleep "$POLL_INTERVAL_S"
+  done
+  tidb_exec "CREATE DATABASE IF NOT EXISTS $SHARED_DB; CREATE DATABASE IF NOT EXISTS $STANDALONE_DB;"
+  SHARED_DSN="root:@tcp(127.0.0.1:${port})/${SHARED_DB}?parseTime=true"
+  STANDALONE_DSN="root:@tcp(127.0.0.1:${port})/${STANDALONE_DB}?parseTime=true"
+  TIDB_PORT="$port"
+  log "tidb up: shared=$SHARED_DB standalone=$STANDALONE_DB (127.0.0.1:$port)"
+}
+
+http() { # method path [api_key] [body]
   local method="$1" path="$2" key="${3:-}" body="${4:-}"
   local args=(-sS -o "$TMP_DIR/resp.json" -w "%{http_code}" -X "$method")
   [ -n "$key" ] && args+=(-H "Authorization: Bearer $key")
@@ -121,77 +143,89 @@ http() { # method path [api_key] [body] -> "code|body"
   code=$(curl "${args[@]}" "http://127.0.0.1:${SERVER_PORT}${path}" 2>/dev/null) || code="000"
   printf '%s|%s' "$code" "$(cat "$TMP_DIR/resp.json" 2>/dev/null || true)"
 }
-
 field() { printf '%s' "$2" | python3 -c "import sys,json;print(json.load(sys.stdin).get('$1',''))" 2>/dev/null || true; }
 
-need_cmd curl
-need_cmd python3
-need_cmd jq
+start_server() {
+  env \
+    DRIVE9_LISTEN_ADDR="127.0.0.1:$SERVER_PORT" \
+    DRIVE9_PUBLIC_URL="http://127.0.0.1:$SERVER_PORT" \
+    DRIVE9_META_DSN="$META_DSN" \
+    DRIVE9_SHARED_POOL_DSN="$SHARED_DSN" \
+    DRIVE9_SHARED_POOL_ORG="*" \
+    DRIVE9_TOKEN_SIGNING_KEY="$TOKEN_KEY" \
+    DRIVE9_MASTER_KEY="$MASTER_KEY" \
+    DRIVE9_TENANT_PROVIDER=tidb_zero \
+    DRIVE9_ZERO_API_URL="http://127.0.0.1:1/unused" \
+    DRIVE9_DISABLE_AUTO_EMBEDDING=true \
+    DRIVE9_LEADER_DISABLED=1 \
+    DRIVE9_S3_DIR="$TMP_DIR/s3" \
+    "$TMP_DIR/drive9-server" >"$SERVER_LOG" 2>&1 &
+  SERVER_PID=$!
+  local deadline
+  deadline=$(($(date +%s) + POLL_TIMEOUT_S))
+  while :; do
+    curl -sf "http://127.0.0.1:$SERVER_PORT/healthz" >/dev/null 2>&1 && break
+    kill -0 "$SERVER_PID" 2>/dev/null || { echo "server died; log:" >&2; tail -30 "$SERVER_LOG" >&2; exit 1; }
+    [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for /healthz" >&2; tail -30 "$SERVER_LOG" >&2; exit 1; }
+    sleep "$POLL_INTERVAL_S"
+  done
+  log "server is up on :$SERVER_PORT"
+}
 
-if [ -z "$META_DSN" ] || [ -z "$SHARED_DSN" ]; then
-  start_mysql_container
+stop_server() {
+  [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1 && {
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  }
+  SERVER_PID=""
+}
+
+need_cmd curl; need_cmd python3; need_cmd jq; need_cmd go
+
+detect_runtime
+if [ -z "$META_DSN" ] || [ -z "$SHARED_DSN" ] || [ -z "$STANDALONE_DSN" ]; then
+  NETWORK="drive9-shared-e2e-net-$$"
+  "$DB_RUNTIME" network create "$NETWORK" >/dev/null
+fi
+[ -z "$META_DSN" ] && start_mysql_container
+if [ -z "$SHARED_DSN" ] || [ -z "$STANDALONE_DSN" ]; then
+  start_tidb_container
 fi
 
-SERVER_PORT="${LISTEN_ADDR##*:}"
-[ -n "$LISTEN_ADDR" ] || SERVER_PORT="$(pick_port)"
+SERVER_PORT="$(pick_port)"
 SERVER_LOG="$TMP_DIR/server.log"
+TOKEN_KEY="$(python3 -c 'import secrets;print(secrets.token_hex(32))')"
+MASTER_KEY="$(python3 -c 'import secrets;print(secrets.token_hex(32))')"
 
-log "building drive9-server"
+log "building drive9-server + harness"
 go build -o "$TMP_DIR/drive9-server" ./cmd/drive9-server
+go build -o "$TMP_DIR/standalone-tenant" ./e2e/harness/standalone-tenant
 
-log "starting drive9-server on :$SERVER_PORT (shared pool mode)"
-env \
-  DRIVE9_LISTEN_ADDR="127.0.0.1:$SERVER_PORT" \
-  DRIVE9_PUBLIC_URL="http://127.0.0.1:$SERVER_PORT" \
-  DRIVE9_META_DSN="$META_DSN" \
-  DRIVE9_SHARED_POOL_DSN="$SHARED_DSN" \
-  DRIVE9_SHARED_POOL_ORG="*" \
-  DRIVE9_TOKEN_SIGNING_KEY="$(python3 -c 'import secrets;print(secrets.token_hex(32))')" \
-  DRIVE9_MASTER_KEY="$(python3 -c 'import secrets;print(secrets.token_hex(32))')" \
-  DRIVE9_TENANT_PROVIDER=tidb_zero \
-  DRIVE9_ZERO_API_URL="http://127.0.0.1:1/unused" \
-  DRIVE9_DISABLE_AUTO_EMBEDDING=true \
-  DRIVE9_LEADER_DISABLED=1 \
-  DRIVE9_S3_DIR="$TMP_DIR/s3" \
-  "$TMP_DIR/drive9-server" >"$SERVER_LOG" 2>&1 &
-SERVER_PID=$!
+start_server
 
-deadline=$(($(date +%s) + POLL_TIMEOUT_S))
-while :; do
-  if curl -sf "http://127.0.0.1:$SERVER_PORT/healthz" >/dev/null 2>&1; then break; fi
-  kill -0 "$SERVER_PID" 2>/dev/null || { echo "server died; log:" >&2; tail -30 "$SERVER_LOG" >&2; exit 1; }
-  [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for /healthz" >&2; tail -30 "$SERVER_LOG" >&2; exit 1; }
-  sleep "$POLL_INTERVAL_S"
-done
-log "server is up"
-
-# --- 1. Provision two tenants; both should land on the shared DB and be active immediately
-resp=$(http POST /v1/provision)
-code="${resp%%|*}"; body="${resp#*|}"
+# ============ 1. Provision two shared tenants (instant active) ============
+resp=$(http POST /v1/provision); code="${resp%%|*}"; body="${resp#*|}"
 check_eq "provision A returns 202" "202" "$code"
 A_KEY="$(field api_key "$body")"; A_TENANT="$(field tenant_id "$body")"
 check_eq "provision A status is active (shared path is instant)" "active" "$(field status "$body")"
 
-resp=$(http POST /v1/provision)
-code="${resp%%|*}"; body="${resp#*|}"
+resp=$(http POST /v1/provision); code="${resp%%|*}"; body="${resp#*|}"
 check_eq "provision B returns 202" "202" "$code"
 B_KEY="$(field api_key "$body")"; B_TENANT="$(field tenant_id "$body")"
 check_eq "provision B status is active" "active" "$(field status "$body")"
 
-# --- 2. Basic CRUD on A
+# ============ 2. CRUD + isolation on shared tenants ============
 resp=$(http PUT /v1/fs/a.txt "$A_KEY" "hello from A")
 check_eq "A write /a.txt returns 200" "200" "${resp%%|*}"
 resp=$(http GET /v1/fs/a.txt "$A_KEY")
-check_eq "A read /a.txt returns 200" "200" "${resp%%|*}"
 check_eq "A read /a.txt content" "hello from A" "${resp#*|}"
 resp=$(http POST "/v1/fs/docs?mkdir" "$A_KEY")
 check_eq "A mkdir /docs returns 200" "200" "${resp%%|*}"
 resp=$(http PUT /v1/fs/docs/note.txt "$A_KEY" "nested note")
 check_eq "A write /docs/note.txt returns 200" "200" "${resp%%|*}"
 resp=$(http GET "/v1/fs/docs/?list" "$A_KEY")
-case "${resp#*|}" in *note.txt*) pass "A list /docs contains note.txt" ;; *) fail "A list /docs missing note.txt: ${resp#*|}" ;; esac
+case "${resp#*|}" in *note.txt*) pass "A list /docs contains note.txt" ;; *) fail "A list /docs: ${resp#*|}" ;; esac
 
-# --- 3. Cross-tenant isolation: same path under B holds different content
 resp=$(http PUT /v1/fs/a.txt "$B_KEY" "hello from B")
 check_eq "B write same path /a.txt returns 200" "200" "${resp%%|*}"
 resp=$(http GET /v1/fs/a.txt "$B_KEY")
@@ -201,34 +235,163 @@ check_eq "A still reads its own /a.txt content" "hello from A" "${resp#*|}"
 resp=$(http GET /v1/fs/docs/note.txt "$B_KEY")
 check_eq "B cannot read A's /docs/note.txt" "404" "${resp%%|*}"
 
-# --- 4. Raw SQL: both tenants' rows share the tables with distinct fs_ids
-if [ -n "$DB_CONTAINER" ]; then
-  A_FS_ID=$(mysql_exec "SELECT fs_id FROM $META_DB.fs_registry WHERE tenant_id='$A_TENANT';")
-  B_FS_ID=$(mysql_exec "SELECT fs_id FROM $META_DB.fs_registry WHERE tenant_id='$B_TENANT';")
+# ============ 3. Raw SQL on TiDB: fs_id isolation + CLUSTERED ============
+if [ -n "$TIDB_CONTAINER" ]; then
+  A_FS_ID=$(meta_exec "SELECT fs_id FROM $META_DB.fs_registry WHERE tenant_id='$A_TENANT';")
+  B_FS_ID=$(meta_exec "SELECT fs_id FROM $META_DB.fs_registry WHERE tenant_id='$B_TENANT';")
   [ -n "$A_FS_ID" ] && [ -n "$B_FS_ID" ] && [ "$A_FS_ID" != "$B_FS_ID" ] \
     && pass "fs_registry assigns distinct fs_ids ($A_FS_ID vs $B_FS_ID)" \
     || fail "fs_registry fs_id assignment (A=$A_FS_ID B=$B_FS_ID)"
-  N=$(mysql_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$A_FS_ID;")
+  N=$(tidb_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$A_FS_ID;")
   [ "${N:-0}" -ge 2 ] && pass "shared file_nodes has A's rows ($N)" || fail "shared file_nodes A rows=$N"
-  N=$(mysql_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$B_FS_ID;")
+  N=$(tidb_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$B_FS_ID;")
   [ "${N:-0}" -ge 1 ] && pass "shared file_nodes has B's rows ($N)" || fail "shared file_nodes B rows=$N"
+  CLUSTERED=$(tidb_exec "SELECT TIDB_PK_TYPE FROM information_schema.tables WHERE table_schema='$SHARED_DB' AND table_name='file_nodes';")
+  check_eq "shared file_nodes is CLUSTERED on TiDB" "CLUSTERED" "${CLUSTERED:-}"
+  N=$(tidb_exec "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='$SHARED_DB' AND table_name='llm_usage';")
+  check_eq "shared DB has no llm_usage table" "0" "${N:-?}"
 fi
 
-# --- 5. Delete tenant A: purges its shared rows; B unaffected
+# ============ 4. SSE events on shared tenant ============
+SSE_OUT="$TMP_DIR/sse.log"
+curl -sS -N --max-time 12 -H "Authorization: Bearer $B_KEY" \
+  "http://127.0.0.1:$SERVER_PORT/v1/events?since=0" >"$SSE_OUT" 2>/dev/null &
+SSE_PID=$!
+sleep 2
+resp=$(http PUT /v1/fs/sse-target.txt "$B_KEY" "sse payload")
+check_eq "B write for SSE returns 200" "200" "${resp%%|*}"
+sleep 4
+kill "$SSE_PID" >/dev/null 2>&1 || true
+wait "$SSE_PID" 2>/dev/null || true
+if grep -q "initial_sync\|server_restart" "$SSE_OUT" && grep -q "sse-target.txt" "$SSE_OUT"; then
+  pass "SSE stream delivered reset + file event for shared tenant"
+else
+  fail "SSE stream missing events: $(head -c 400 "$SSE_OUT")"
+fi
+
+# ============ 5. Multipart upload (v2) on shared tenant ============
+BIG_FILE="$TMP_DIR/big.bin"
+python3 -c "import os;open('$BIG_FILE','wb').write(os.urandom(10*1024*1024))"
+CHECKSUMS=$(python3 - "$BIG_FILE" <<'PY'
+import base64, struct, sys
+_TABLE = []
+for i in range(256):
+    c = i
+    for _ in range(8):
+        c = (c >> 1) ^ (0x82F63B78 if c & 1 else 0)
+    _TABLE.append(c)
+def crc32c(data):
+    crc = 0xFFFFFFFF
+    for b in data:
+        crc = _TABLE[(crc ^ b) & 0xFF] ^ (crc >> 8)
+    return crc ^ 0xFFFFFFFF
+part_size = 8 * 1024 * 1024
+out = []
+with open(sys.argv[1], "rb") as f:
+    while True:
+        chunk = f.read(part_size)
+        if not chunk:
+            break
+        out.append(base64.b64encode(struct.pack(">I", crc32c(chunk))).decode())
+print(",".join(out))
+PY
+)
+INIT_PAYLOAD="$TMP_DIR/init.json"
+jq -n --arg path "/big.bin" --argjson total_size 10485760 --arg checksums "$CHECKSUMS" \
+  '{path:$path,total_size:$total_size,part_checksums:($checksums|split(","))}' > "$INIT_PAYLOAD"
+code=$(curl -sS -o "$TMP_DIR/plan.json" -w "%{http_code}" -X POST \
+  -H "Authorization: Bearer $B_KEY" -H "Content-Type: application/json" \
+  --data-binary "@$INIT_PAYLOAD" "http://127.0.0.1:$SERVER_PORT/v1/uploads/initiate")
+check_eq "multipart initiate returns 202" "202" "$code"
+UPLOAD_ID=$(jq -r '.upload_id // empty' "$TMP_DIR/plan.json")
+python3 - "$TMP_DIR/plan.json" "$BIG_FILE" <<'PY'
+import json, sys, urllib.request
+plan_path, file_path = sys.argv[1], sys.argv[2]
+plan = json.load(open(plan_path))
+with open(file_path, "rb") as data_file:
+    for idx, p in enumerate(plan.get("parts", []), 1):
+        size = int(p["size"])
+        data = data_file.read(size)
+        if len(data) != size:
+            raise SystemExit(f"short read part {idx}")
+        req = urllib.request.Request(p["url"], data=data, method="PUT")
+        req.add_header("Content-Length", str(size))
+        for hk, hv in (p.get("headers") or {}).items():
+            req.add_header(hk, hv)
+        if p.get("checksum_crc32c"):
+            req.add_header("x-amz-checksum-crc32c", p["checksum_crc32c"])
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            if getattr(resp, "status", 200) >= 300:
+                raise SystemExit(f"part {idx} HTTP {resp.status}")
+PY
+check_eq "multipart parts uploaded" "0" "$?"
+resp=$(http POST "/v1/uploads/$UPLOAD_ID/complete" "$B_KEY")
+check_eq "multipart complete returns 200" "200" "${resp%%|*}"
+check_eq "multipart complete status ok" "ok" "$(field status "${resp#*|}")"
+# Large files are served via a redirect to the object store; follow it.
+BIG_URL=$(curl -sS -o /dev/null -w "%{redirect_url}" -H "Authorization: Bearer $B_KEY" "http://127.0.0.1:$SERVER_PORT/v1/fs/big.bin")
+if [ -n "$BIG_URL" ]; then
+  BIG_SIZE=$(curl -sS "$BIG_URL" | wc -c | tr -d ' ')
+  check_eq "multipart file served via redirect, size matches" "10485760" "$BIG_SIZE"
+else
+  resp=$(http GET /v1/fs/big.bin "$B_KEY")
+  check_eq "multipart file readable inline" "200" "${resp%%|*}"
+fi
+
+# ============ 6. Fork rejected on shared tenant ============
+resp=$(http POST /v1/fork "$B_KEY")
+check_eq "fork on shared tenant is rejected (409)" "409" "${resp%%|*}"
+
+# ============ 7. Standalone tenant coexistence ============
+S_TENANT="standalone-$(python3 -c 'import uuid;print(uuid.uuid4())')"
+S_KEY=$("$TMP_DIR/standalone-tenant" \
+  -meta-dsn "$META_DSN" -master-key "$MASTER_KEY" -token-secret "$TOKEN_KEY" \
+  -tenant-id "$S_TENANT" -db-host 127.0.0.1 -db-port "${TIDB_PORT:-4000}" \
+  -db-user root -db-password "" -db-name "$STANDALONE_DB" -db-tls=false \
+  -provider tidb_zero -cluster-id standalone-e2e -skip-ensure 2>"$TMP_DIR/harness.log")
+[ -n "$S_KEY" ] && pass "standalone tenant registered via harness" || { cat "$TMP_DIR/harness.log" >&2; fail "harness returned no key"; }
+
+resp=$(http PUT /v1/fs/a.txt "$S_KEY" "hello from standalone")
+check_eq "standalone write /a.txt returns 200" "200" "${resp%%|*}"
+resp=$(http GET /v1/fs/a.txt "$S_KEY")
+check_eq "standalone reads its own content" "hello from standalone" "${resp#*|}"
+resp=$(http GET /v1/fs/a.txt "$B_KEY")
+check_eq "shared B unaffected by standalone writes" "hello from B" "${resp#*|}"
+resp=$(http GET /v1/fs/docs/note.txt "$S_KEY")
+check_eq "standalone cannot read shared A's nested file" "404" "${resp%%|*}"
+if [ -n "$TIDB_CONTAINER" ]; then
+  N=$(tidb_exec "SELECT COUNT(*) FROM information_schema.columns WHERE table_schema='$STANDALONE_DB' AND table_name='file_nodes' AND column_name='fs_id';")
+  check_eq "standalone file_nodes has NO fs_id column" "0" "${N:-?}"
+  N=$(tidb_exec "SELECT COUNT(*) FROM $STANDALONE_DB.file_nodes WHERE path='/a.txt';")
+  check_eq "standalone DB holds its own file" "1" "${N:-?}"
+  N=$(tidb_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE path='/a.txt' AND fs_id NOT IN ($A_FS_ID,$B_FS_ID);")
+  check_eq "no foreign rows leaked into shared DB" "0" "${N:-?}"
+fi
+
+# ============ 8. Server restart persistence ============
+log "restarting server to verify persistence"
+stop_server
+start_server
+resp=$(http GET /v1/fs/a.txt "$B_KEY")
+check_eq "B reads /a.txt after server restart" "hello from B" "${resp#*|}"
+resp=$(http GET /v1/fs/a.txt "$S_KEY")
+check_eq "standalone reads /a.txt after restart" "hello from standalone" "${resp#*|}"
+
+# ============ 9. Delete tenant A: purge; others intact ============
 resp=$(http DELETE /v1/tenant "$A_KEY")
 check_eq "DELETE /v1/tenant A returns 202" "202" "${resp%%|*}"
 resp=$(http GET /v1/fs/a.txt "$A_KEY")
-# Delete revokes the API key, so auth fails at the key-status check (401)
-# before ever reaching the tenant-status gate (403) — accept either.
-[ "${resp%%|*}" = "401" ] || [ "${resp%%|*}" = "403" ] && pass "A key rejected after delete (got ${resp%%|*})" || fail "A key rejected after delete (want 401|403, got ${resp%%|*})"
+[ "${resp%%|*}" = "401" ] || [ "${resp%%|*}" = "403" ] && pass "A key rejected after delete (got ${resp%%|*})" || fail "A key after delete (got ${resp%%|*})"
 resp=$(http GET /v1/fs/a.txt "$B_KEY")
 check_eq "B unaffected after A delete" "hello from B" "${resp#*|}"
-if [ -n "$DB_CONTAINER" ]; then
-  N=$(mysql_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$A_FS_ID;")
+resp=$(http GET /v1/fs/a.txt "$S_KEY")
+check_eq "standalone unaffected after A delete" "hello from standalone" "${resp#*|}"
+if [ -n "$TIDB_CONTAINER" ]; then
+  N=$(tidb_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$A_FS_ID;")
   check_eq "A's file_nodes purged from shared DB" "0" "${N:-?}"
-  N=$(mysql_exec "SELECT COUNT(*) FROM $SHARED_DB.inodes WHERE fs_id=$A_FS_ID;")
+  N=$(tidb_exec "SELECT COUNT(*) FROM $SHARED_DB.inodes WHERE fs_id=$A_FS_ID;")
   check_eq "A's inodes purged from shared DB" "0" "${N:-?}"
-  N=$(mysql_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$B_FS_ID;")
+  N=$(tidb_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$B_FS_ID;")
   [ "${N:-0}" -ge 1 ] && pass "B's rows still in shared DB" || fail "B's rows missing after A purge"
 fi
 

--- a/e2e/shared-mode-smoke-test.sh
+++ b/e2e/shared-mode-smoke-test.sh
@@ -31,6 +31,12 @@ KEEP_DB="${KEEP_DB:-0}"
 POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-180}"
 POLL_INTERVAL_S="${POLL_INTERVAL_S:-2}"
 
+# Remember which endpoints were supplied externally: the container startup
+# paths assign these variables too, and only externally supplied endpoints
+# should bypass container execs.
+META_DSN_EXTERNAL=0; [ -n "$META_DSN" ] && META_DSN_EXTERNAL=1
+SHARED_DSN_EXTERNAL=0; [ -n "$SHARED_DSN" ] && SHARED_DSN_EXTERNAL=1
+
 MYSQL_CONTAINER=""
 TIDB_CONTAINER=""
 NETWORK=""
@@ -57,7 +63,10 @@ cleanup() {
   fi
   [ "$rc" -eq 0 ] && rm -rf "$TMP_DIR" || log "failed; artifacts kept at $TMP_DIR"
   log "passed=$PASS_COUNT failed=$FAIL_COUNT"
-  [ "$FAIL_COUNT" -eq 0 ]
+  # Fold the trapped exit code into the final status: a hard abort under
+  # set -e (build failure, container startup, ...) must not report success
+  # just because no check_eq ran yet.
+  [ "$rc" -eq 0 ] && [ "$FAIL_COUNT" -eq 0 ]
   exit $?
 }
 trap cleanup EXIT
@@ -82,8 +91,36 @@ detect_runtime() {
   exit 1
 }
 
-meta_exec() { "$DB_RUNTIME" exec "$MYSQL_CONTAINER" mysql -uroot -p"$DB_PASSWORD" -N -e "$1"; }
-tidb_exec() { "$DB_RUNTIME" exec "$MYSQL_CONTAINER" mysql -h tidb-e2e -P 4000 -uroot -N -e "$1" 2>/dev/null; }
+# run_mysql_dsn runs the mysql client against a DSN of the form
+# user:pass@tcp(host:port)/dbname?params. Used instead of container execs
+# when an endpoint is supplied externally.
+run_mysql_dsn() {
+  python3 - "$1" "$2" <<'PY'
+import re, subprocess, sys
+dsn, sql = sys.argv[1], sys.argv[2]
+m = re.match(r'([^:]+):([^@]*)@tcp\(([^:]+):(\d+)\)/([^?]+)', dsn)
+if not m:
+    sys.exit(f"cannot parse DSN for mysql client: {dsn!r}")
+user, pw, host, port, _db = m.groups()
+cmd = ["mysql", "-N", "-h", host, "-P", port, "-u", user, f"-p{pw}", "-e", sql]
+sys.exit(subprocess.run(cmd).returncode)
+PY
+}
+
+meta_exec() {
+  if [ "$META_DSN_EXTERNAL" = "1" ]; then
+    run_mysql_dsn "$META_DSN" "$1"
+  else
+    "$DB_RUNTIME" exec "$MYSQL_CONTAINER" mysql -uroot -p"$DB_PASSWORD" -N -e "$1"
+  fi
+}
+tidb_exec() {
+  if [ "$SHARED_DSN_EXTERNAL" = "1" ]; then
+    run_mysql_dsn "$SHARED_DSN" "$1" 2>/dev/null
+  else
+    "$DB_RUNTIME" exec "$MYSQL_CONTAINER" mysql -h tidb-e2e -P 4000 -uroot -N -e "$1" 2>/dev/null
+  fi
+}
 
 start_mysql_container() {
   MYSQL_CONTAINER="drive9-shared-e2e-mysql-$(date +%s)-$$"
@@ -181,9 +218,16 @@ stop_server() {
 }
 
 need_cmd curl; need_cmd python3; need_cmd jq; need_cmd go
+if [ "$META_DSN_EXTERNAL" = "1" ] || [ "$SHARED_DSN_EXTERNAL" = "1" ]; then
+  # External endpoints are probed with the local mysql client instead of
+  # container execs.
+  need_cmd mysql
+fi
 
-detect_runtime
 if [ -z "$META_DSN" ] || [ -z "$SHARED_DSN" ] || [ -z "$STANDALONE_DSN" ]; then
+  # A container runtime is only needed when one of the DSNs is not supplied
+  # externally; with all three set, no container is started at all.
+  detect_runtime
   NETWORK="drive9-shared-e2e-net-$$"
   "$DB_RUNTIME" network create "$NETWORK" >/dev/null
 fi

--- a/e2e/shared-mode-smoke-test.sh
+++ b/e2e/shared-mode-smoke-test.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# End-to-end smoke test for shared-schema (fs_id) mode:
+#   1 meta DB + 1 shared DB, two tenants provisioned onto the shared DB,
+#   CRUD + cross-tenant isolation + delete/purge verification.
+#
+# Defaults start a throwaway MySQL container. To run against a TiDB endpoint
+# instead, set META_DSN / SHARED_DSN (and TLS=true in the DSN if needed):
+#   META_DSN='root:pass@tcp(host:4000)/meta?parseTime=true' \
+#   SHARED_DSN='root:pass@tcp(host:4000)/shared?parseTime=true' \
+#     bash e2e/shared-mode-smoke-test.sh
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+DB_RUNTIME="${DRIVE9_SHARED_E2E_DB_RUNTIME:-}"
+DB_IMAGE="${DRIVE9_SHARED_E2E_DB_IMAGE:-mysql:8.4}"
+DB_PASSWORD="${DRIVE9_SHARED_E2E_DB_PASSWORD:-drive9pass}"
+META_DB="${DRIVE9_SHARED_E2E_META_DB:-drive9_meta}"
+SHARED_DB="${DRIVE9_SHARED_E2E_SHARED_DB:-drive9_shared}"
+META_DSN="${META_DSN:-}"
+SHARED_DSN="${SHARED_DSN:-}"
+KEEP_DB="${KEEP_DB:-0}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-90}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-1}"
+LISTEN_ADDR="${LISTEN_ADDR:-}"
+
+DB_CONTAINER=""
+SERVER_PID=""
+TMP_DIR="$(mktemp -d)"
+PASS_COUNT=0
+FAIL_COUNT=0
+
+log() { echo "[shared-e2e] $*"; }
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); log "PASS: $1"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); log "FAIL: $1" >&2; }
+check_eq() { # name want got
+  if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (want=$2 got=$3)"; fi
+}
+
+cleanup() {
+  local rc=$?
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  if [ -n "$DB_CONTAINER" ] && [ "$KEEP_DB" != "1" ]; then
+    "$DB_RUNTIME" rm -f "$DB_CONTAINER" >/dev/null 2>&1 || true
+  fi
+  if [ "$rc" -eq 0 ]; then
+    rm -rf "$TMP_DIR"
+  else
+    log "failed; artifacts kept at $TMP_DIR"
+  fi
+  log "passed=$PASS_COUNT failed=$FAIL_COUNT"
+  [ "$FAIL_COUNT" -eq 0 ]
+  exit $?
+}
+trap cleanup EXIT
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "missing required command: $1" >&2; exit 1; }; }
+
+pick_port() {
+  python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+detect_runtime() {
+  if [ -n "$DB_RUNTIME" ]; then return; fi
+  if command -v docker >/dev/null 2>&1; then DB_RUNTIME="docker"; return; fi
+  if command -v podman >/dev/null 2>&1; then DB_RUNTIME="podman"; return; fi
+  echo "docker or podman is required when META_DSN/SHARED_DSN are not set" >&2
+  exit 1
+}
+
+start_mysql_container() {
+  detect_runtime
+  DB_CONTAINER="drive9-shared-e2e-$(date +%s)-$$"
+  log "starting $DB_RUNTIME container $DB_CONTAINER from $DB_IMAGE"
+  "$DB_RUNTIME" run -d \
+    --name "$DB_CONTAINER" \
+    -e MYSQL_ROOT_PASSWORD="$DB_PASSWORD" \
+    -p 127.0.0.1::3306 \
+    "$DB_IMAGE" >/dev/null
+
+  local deadline port
+  deadline=$(($(date +%s) + POLL_TIMEOUT_S))
+  while :; do
+    port=$("$DB_RUNTIME" port "$DB_CONTAINER" 3306/tcp 2>/dev/null | awk -F: 'END{print $NF}')
+    [ -n "$port" ] && break
+    [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for port mapping" >&2; exit 1; }
+    sleep "$POLL_INTERVAL_S"
+  done
+  while :; do
+    # mysqladmin ping succeeds before the entrypoint finishes setting the
+    # root password, so use a real authenticated query as the readiness gate.
+    "$DB_RUNTIME" exec "$DB_CONTAINER" mysql -uroot -p"$DB_PASSWORD" -N -e "SELECT 1" >/dev/null 2>&1 && break
+    [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for MySQL readiness" >&2; exit 1; }
+    sleep "$POLL_INTERVAL_S"
+  done
+  DB_PORT_HOST="$port"
+  mysql_exec() { "$DB_RUNTIME" exec "$DB_CONTAINER" mysql -uroot -p"$DB_PASSWORD" -N -e "$1"; }
+  mysql_exec "CREATE DATABASE IF NOT EXISTS $META_DB; CREATE DATABASE IF NOT EXISTS $SHARED_DB;"
+  META_DSN="root:${DB_PASSWORD}@tcp(127.0.0.1:${port})/${META_DB}?parseTime=true"
+  SHARED_DSN="root:${DB_PASSWORD}@tcp(127.0.0.1:${port})/${SHARED_DB}?parseTime=true"
+  log "meta db: $META_DB, shared db: $SHARED_DB (127.0.0.1:$port)"
+}
+
+http() { # method path [api_key] [body] -> "code|body"
+  local method="$1" path="$2" key="${3:-}" body="${4:-}"
+  local args=(-sS -o "$TMP_DIR/resp.json" -w "%{http_code}" -X "$method")
+  [ -n "$key" ] && args+=(-H "Authorization: Bearer $key")
+  [ -n "$body" ] && args+=(-H "Content-Type: application/octet-stream" --data-binary "$body")
+  local code
+  code=$(curl "${args[@]}" "http://127.0.0.1:${SERVER_PORT}${path}" 2>/dev/null) || code="000"
+  printf '%s|%s' "$code" "$(cat "$TMP_DIR/resp.json" 2>/dev/null || true)"
+}
+
+field() { printf '%s' "$2" | python3 -c "import sys,json;print(json.load(sys.stdin).get('$1',''))" 2>/dev/null || true; }
+
+need_cmd curl
+need_cmd python3
+need_cmd jq
+
+if [ -z "$META_DSN" ] || [ -z "$SHARED_DSN" ]; then
+  start_mysql_container
+fi
+
+SERVER_PORT="${LISTEN_ADDR##*:}"
+[ -n "$LISTEN_ADDR" ] || SERVER_PORT="$(pick_port)"
+SERVER_LOG="$TMP_DIR/server.log"
+
+log "building drive9-server"
+go build -o "$TMP_DIR/drive9-server" ./cmd/drive9-server
+
+log "starting drive9-server on :$SERVER_PORT (shared pool mode)"
+env \
+  DRIVE9_LISTEN_ADDR="127.0.0.1:$SERVER_PORT" \
+  DRIVE9_PUBLIC_URL="http://127.0.0.1:$SERVER_PORT" \
+  DRIVE9_META_DSN="$META_DSN" \
+  DRIVE9_SHARED_POOL_DSN="$SHARED_DSN" \
+  DRIVE9_SHARED_POOL_ORG="*" \
+  DRIVE9_TOKEN_SIGNING_KEY="$(python3 -c 'import secrets;print(secrets.token_hex(32))')" \
+  DRIVE9_MASTER_KEY="$(python3 -c 'import secrets;print(secrets.token_hex(32))')" \
+  DRIVE9_TENANT_PROVIDER=tidb_zero \
+  DRIVE9_ZERO_API_URL="http://127.0.0.1:1/unused" \
+  DRIVE9_DISABLE_AUTO_EMBEDDING=true \
+  DRIVE9_LEADER_DISABLED=1 \
+  DRIVE9_S3_DIR="$TMP_DIR/s3" \
+  "$TMP_DIR/drive9-server" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+
+deadline=$(($(date +%s) + POLL_TIMEOUT_S))
+while :; do
+  if curl -sf "http://127.0.0.1:$SERVER_PORT/healthz" >/dev/null 2>&1; then break; fi
+  kill -0 "$SERVER_PID" 2>/dev/null || { echo "server died; log:" >&2; tail -30 "$SERVER_LOG" >&2; exit 1; }
+  [ "$(date +%s)" -lt "$deadline" ] || { echo "timed out waiting for /healthz" >&2; tail -30 "$SERVER_LOG" >&2; exit 1; }
+  sleep "$POLL_INTERVAL_S"
+done
+log "server is up"
+
+# --- 1. Provision two tenants; both should land on the shared DB and be active immediately
+resp=$(http POST /v1/provision)
+code="${resp%%|*}"; body="${resp#*|}"
+check_eq "provision A returns 202" "202" "$code"
+A_KEY="$(field api_key "$body")"; A_TENANT="$(field tenant_id "$body")"
+check_eq "provision A status is active (shared path is instant)" "active" "$(field status "$body")"
+
+resp=$(http POST /v1/provision)
+code="${resp%%|*}"; body="${resp#*|}"
+check_eq "provision B returns 202" "202" "$code"
+B_KEY="$(field api_key "$body")"; B_TENANT="$(field tenant_id "$body")"
+check_eq "provision B status is active" "active" "$(field status "$body")"
+
+# --- 2. Basic CRUD on A
+resp=$(http PUT /v1/fs/a.txt "$A_KEY" "hello from A")
+check_eq "A write /a.txt returns 200" "200" "${resp%%|*}"
+resp=$(http GET /v1/fs/a.txt "$A_KEY")
+check_eq "A read /a.txt returns 200" "200" "${resp%%|*}"
+check_eq "A read /a.txt content" "hello from A" "${resp#*|}"
+resp=$(http POST "/v1/fs/docs?mkdir" "$A_KEY")
+check_eq "A mkdir /docs returns 200" "200" "${resp%%|*}"
+resp=$(http PUT /v1/fs/docs/note.txt "$A_KEY" "nested note")
+check_eq "A write /docs/note.txt returns 200" "200" "${resp%%|*}"
+resp=$(http GET "/v1/fs/docs/?list" "$A_KEY")
+case "${resp#*|}" in *note.txt*) pass "A list /docs contains note.txt" ;; *) fail "A list /docs missing note.txt: ${resp#*|}" ;; esac
+
+# --- 3. Cross-tenant isolation: same path under B holds different content
+resp=$(http PUT /v1/fs/a.txt "$B_KEY" "hello from B")
+check_eq "B write same path /a.txt returns 200" "200" "${resp%%|*}"
+resp=$(http GET /v1/fs/a.txt "$B_KEY")
+check_eq "B reads its own /a.txt content" "hello from B" "${resp#*|}"
+resp=$(http GET /v1/fs/a.txt "$A_KEY")
+check_eq "A still reads its own /a.txt content" "hello from A" "${resp#*|}"
+resp=$(http GET /v1/fs/docs/note.txt "$B_KEY")
+check_eq "B cannot read A's /docs/note.txt" "404" "${resp%%|*}"
+
+# --- 4. Raw SQL: both tenants' rows share the tables with distinct fs_ids
+if [ -n "$DB_CONTAINER" ]; then
+  A_FS_ID=$(mysql_exec "SELECT fs_id FROM $META_DB.fs_registry WHERE tenant_id='$A_TENANT';")
+  B_FS_ID=$(mysql_exec "SELECT fs_id FROM $META_DB.fs_registry WHERE tenant_id='$B_TENANT';")
+  [ -n "$A_FS_ID" ] && [ -n "$B_FS_ID" ] && [ "$A_FS_ID" != "$B_FS_ID" ] \
+    && pass "fs_registry assigns distinct fs_ids ($A_FS_ID vs $B_FS_ID)" \
+    || fail "fs_registry fs_id assignment (A=$A_FS_ID B=$B_FS_ID)"
+  N=$(mysql_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$A_FS_ID;")
+  [ "${N:-0}" -ge 2 ] && pass "shared file_nodes has A's rows ($N)" || fail "shared file_nodes A rows=$N"
+  N=$(mysql_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$B_FS_ID;")
+  [ "${N:-0}" -ge 1 ] && pass "shared file_nodes has B's rows ($N)" || fail "shared file_nodes B rows=$N"
+fi
+
+# --- 5. Delete tenant A: purges its shared rows; B unaffected
+resp=$(http DELETE /v1/tenant "$A_KEY")
+check_eq "DELETE /v1/tenant A returns 202" "202" "${resp%%|*}"
+resp=$(http GET /v1/fs/a.txt "$A_KEY")
+# Delete revokes the API key, so auth fails at the key-status check (401)
+# before ever reaching the tenant-status gate (403) — accept either.
+[ "${resp%%|*}" = "401" ] || [ "${resp%%|*}" = "403" ] && pass "A key rejected after delete (got ${resp%%|*})" || fail "A key rejected after delete (want 401|403, got ${resp%%|*})"
+resp=$(http GET /v1/fs/a.txt "$B_KEY")
+check_eq "B unaffected after A delete" "hello from B" "${resp#*|}"
+if [ -n "$DB_CONTAINER" ]; then
+  N=$(mysql_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$A_FS_ID;")
+  check_eq "A's file_nodes purged from shared DB" "0" "${N:-?}"
+  N=$(mysql_exec "SELECT COUNT(*) FROM $SHARED_DB.inodes WHERE fs_id=$A_FS_ID;")
+  check_eq "A's inodes purged from shared DB" "0" "${N:-?}"
+  N=$(mysql_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$B_FS_ID;")
+  [ "${N:-0}" -ge 1 ] && pass "B's rows still in shared DB" || fail "B's rows missing after A purge"
+fi
+
+log "all shared-mode e2e checks done"

--- a/internal/testmysql/testmysql.go
+++ b/internal/testmysql/testmysql.go
@@ -114,6 +114,8 @@ func ResetMetaDB(t *testing.T, db *sql.DB) {
 		"DELETE FROM tenant_external_bindings",
 		"DELETE FROM tenant_tidbcloud_org_bindings",
 		"DELETE FROM tenant_tidbcloud_pools",
+		"DELETE FROM tenant_placements",
+		"DELETE FROM db_pool",
 		"DELETE FROM fs_registry",
 		"DELETE FROM tenants",
 	}

--- a/internal/testmysql/testmysql.go
+++ b/internal/testmysql/testmysql.go
@@ -114,6 +114,7 @@ func ResetMetaDB(t *testing.T, db *sql.DB) {
 		"DELETE FROM tenant_external_bindings",
 		"DELETE FROM tenant_tidbcloud_org_bindings",
 		"DELETE FROM tenant_tidbcloud_pools",
+		"DELETE FROM fs_registry",
 		"DELETE FROM tenants",
 	}
 	for _, q := range queries {

--- a/pkg/datastore/content.go
+++ b/pkg/datastore/content.go
@@ -25,13 +25,13 @@ type Content struct {
 func (s *Store) InsertContent(ctx context.Context, content *Content) error {
 	mode := fileStorageEncryptionModeForWrite(content.StorageEncryptionMode)
 	_, err := s.db.ExecContext(ctx, `INSERT INTO contents
-		(inode_id, storage_type, storage_ref, storage_ref_hash, storage_encryption_mode, storage_encryption_key_id,
-		 content_blob, content_type, checksum_sha256, source_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		content.InodeID, content.StorageType, content.StorageRef, StorageRefHash(content.StorageRef), mode,
-		storageEncryptionKeyIDForWrite(mode, content.StorageEncryptionKeyID),
-		nilBytes(content.ContentBlob), nullStr(content.ContentType),
-		nullStr(content.ChecksumSHA256), nullStr(content.SourceID))
+		(`+s.scope.InsCols(`inode_id, storage_type, storage_ref, storage_ref_hash, storage_encryption_mode, storage_encryption_key_id,
+		 content_blob, content_type, checksum_sha256, source_id`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(content.InodeID, content.StorageType, content.StorageRef, StorageRefHash(content.StorageRef), mode,
+			storageEncryptionKeyIDForWrite(mode, content.StorageEncryptionKeyID),
+			nilBytes(content.ContentBlob), nullStr(content.ContentType),
+			nullStr(content.ChecksumSHA256), nullStr(content.SourceID))...)
 	return err
 }
 
@@ -39,13 +39,13 @@ func (s *Store) InsertContent(ctx context.Context, content *Content) error {
 func (s *Store) InsertContentTx(db execer, content *Content) error {
 	mode := fileStorageEncryptionModeForWrite(content.StorageEncryptionMode)
 	_, err := db.Exec(`INSERT INTO contents
-		(inode_id, storage_type, storage_ref, storage_ref_hash, storage_encryption_mode, storage_encryption_key_id,
-		 content_blob, content_type, checksum_sha256, source_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		content.InodeID, content.StorageType, content.StorageRef, StorageRefHash(content.StorageRef), mode,
-		storageEncryptionKeyIDForWrite(mode, content.StorageEncryptionKeyID),
-		nilBytes(content.ContentBlob), nullStr(content.ContentType),
-		nullStr(content.ChecksumSHA256), nullStr(content.SourceID))
+		(`+s.scope.InsCols(`inode_id, storage_type, storage_ref, storage_ref_hash, storage_encryption_mode, storage_encryption_key_id,
+		 content_blob, content_type, checksum_sha256, source_id`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(content.InodeID, content.StorageType, content.StorageRef, StorageRefHash(content.StorageRef), mode,
+			storageEncryptionKeyIDForWrite(mode, content.StorageEncryptionKeyID),
+			nilBytes(content.ContentBlob), nullStr(content.ContentType),
+			nullStr(content.ChecksumSHA256), nullStr(content.SourceID))...)
 	return err
 }
 
@@ -54,7 +54,7 @@ func (s *Store) GetContent(ctx context.Context, inodeID string) (*Content, error
 	row := s.db.QueryRowContext(ctx, `SELECT inode_id, storage_type, storage_ref,
 		storage_ref_hash, storage_encryption_mode, storage_encryption_key_id,
 		content_blob, content_type, checksum_sha256, source_id
-		FROM contents WHERE inode_id = ?`, inodeID)
+		FROM contents WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(inodeID)...)
 	return scanContent(row)
 }
 
@@ -64,9 +64,9 @@ func (s *Store) UpdateContentTx(db execer, inodeID string, storageType StorageTy
 	_, err := db.Exec(`UPDATE contents SET
 		storage_type = ?, storage_ref = ?, storage_ref_hash = ?, storage_encryption_mode = ?,
 		content_blob = ?, content_type = ?, checksum_sha256 = ?
-		WHERE inode_id = ?`,
-		storageType, storageRef, StorageRefHash(storageRef), mode,
-		nilBytes(contentBlob), nullStr(contentType), nullStr(checksum), inodeID)
+		WHERE `+s.scope.And(`inode_id = ?`),
+		append([]any{storageType, storageRef, StorageRefHash(storageRef), mode,
+			nilBytes(contentBlob), nullStr(contentType), nullStr(checksum)}, s.scope.Args(inodeID)...)...)
 	return err
 }
 

--- a/pkg/datastore/embedding_writeback.go
+++ b/pkg/datastore/embedding_writeback.go
@@ -27,16 +27,16 @@ func (s *Store) UpdateFileEmbedding(ctx context.Context, fileID string, revision
 		// Always attempt semantic update regardless of legacy rowsAffected,
 		// so a retry after transient semantic failure is not skipped.
 		if _, err := s.db.ExecContext(ctx, `UPDATE semantic SET embedding = ?, embedding_revision = ?
-			WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`,
-			embedding.FormatVector(vector), revision, fileID, fileID, revision); err != nil {
+			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`),
+			append([]any{embedding.FormatVector(vector), revision}, s.scope.Args(fileID, fileID, revision)...)...); err != nil {
 			return false, fmt.Errorf("update semantic embedding: %w", err)
 		}
 		return rowsAffected > 0, nil
 	}
 	// New tenant without legacy files: write directly to semantic.
 	res, err := s.db.ExecContext(ctx, `UPDATE semantic SET embedding = ?, embedding_revision = ?
-		WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`,
-		embedding.FormatVector(vector), revision, fileID, fileID, revision)
+		WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`),
+		append([]any{embedding.FormatVector(vector), revision}, s.scope.Args(fileID, fileID, revision)...)...)
 	if err != nil {
 		return false, fmt.Errorf("update semantic embedding: %w", err)
 	}
@@ -62,16 +62,16 @@ func (s *Store) UpdateFileDescriptionEmbedding(ctx context.Context, fileID strin
 		rowsAffected, _ := res.RowsAffected()
 		// Always attempt semantic update regardless of legacy rowsAffected.
 		if _, err := s.db.ExecContext(ctx, `UPDATE semantic SET description_embedding = ?, description_embedding_revision = ?
-			WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`,
-			embedding.FormatVector(vector), revision, fileID, fileID, revision); err != nil {
+			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`),
+			append([]any{embedding.FormatVector(vector), revision}, s.scope.Args(fileID, fileID, revision)...)...); err != nil {
 			return false, fmt.Errorf("update semantic description_embedding: %w", err)
 		}
 		return rowsAffected > 0, nil
 	}
 	// New tenant without legacy files: write directly to semantic.
 	res, err := s.db.ExecContext(ctx, `UPDATE semantic SET description_embedding = ?, description_embedding_revision = ?
-		WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`,
-		embedding.FormatVector(vector), revision, fileID, fileID, revision)
+		WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`),
+		append([]any{embedding.FormatVector(vector), revision}, s.scope.Args(fileID, fileID, revision)...)...)
 	if err != nil {
 		return false, fmt.Errorf("update semantic description_embedding: %w", err)
 	}

--- a/pkg/datastore/embedding_writeback.go
+++ b/pkg/datastore/embedding_writeback.go
@@ -27,16 +27,16 @@ func (s *Store) UpdateFileEmbedding(ctx context.Context, fileID string, revision
 		// Always attempt semantic update regardless of legacy rowsAffected,
 		// so a retry after transient semantic failure is not skipped.
 		if _, err := s.db.ExecContext(ctx, `UPDATE semantic SET embedding = ?, embedding_revision = ?
-			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`),
-			append([]any{embedding.FormatVector(vector), revision}, s.scope.Args(fileID, fileID, revision)...)...); err != nil {
+			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND revision = ? AND status = 'CONFIRMED'`)+`)`),
+			append([]any{embedding.FormatVector(vector), revision}, append(s.scope.Args(fileID), s.scope.Args(fileID, revision)...)...)...); err != nil {
 			return false, fmt.Errorf("update semantic embedding: %w", err)
 		}
 		return rowsAffected > 0, nil
 	}
 	// New tenant without legacy files: write directly to semantic.
 	res, err := s.db.ExecContext(ctx, `UPDATE semantic SET embedding = ?, embedding_revision = ?
-		WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`),
-		append([]any{embedding.FormatVector(vector), revision}, s.scope.Args(fileID, fileID, revision)...)...)
+		WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND revision = ? AND status = 'CONFIRMED'`)+`)`),
+		append([]any{embedding.FormatVector(vector), revision}, append(s.scope.Args(fileID), s.scope.Args(fileID, revision)...)...)...)
 	if err != nil {
 		return false, fmt.Errorf("update semantic embedding: %w", err)
 	}
@@ -62,16 +62,16 @@ func (s *Store) UpdateFileDescriptionEmbedding(ctx context.Context, fileID strin
 		rowsAffected, _ := res.RowsAffected()
 		// Always attempt semantic update regardless of legacy rowsAffected.
 		if _, err := s.db.ExecContext(ctx, `UPDATE semantic SET description_embedding = ?, description_embedding_revision = ?
-			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`),
-			append([]any{embedding.FormatVector(vector), revision}, s.scope.Args(fileID, fileID, revision)...)...); err != nil {
+			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND revision = ? AND status = 'CONFIRMED'`)+`)`),
+			append([]any{embedding.FormatVector(vector), revision}, append(s.scope.Args(fileID), s.scope.Args(fileID, revision)...)...)...); err != nil {
 			return false, fmt.Errorf("update semantic description_embedding: %w", err)
 		}
 		return rowsAffected > 0, nil
 	}
 	// New tenant without legacy files: write directly to semantic.
 	res, err := s.db.ExecContext(ctx, `UPDATE semantic SET description_embedding = ?, description_embedding_revision = ?
-		WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND revision = ? AND status = 'CONFIRMED')`),
-		append([]any{embedding.FormatVector(vector), revision}, s.scope.Args(fileID, fileID, revision)...)...)
+		WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND revision = ? AND status = 'CONFIRMED'`)+`)`),
+		append([]any{embedding.FormatVector(vector), revision}, append(s.scope.Args(fileID), s.scope.Args(fileID, revision)...)...)...)
 	if err != nil {
 		return false, fmt.Errorf("update semantic description_embedding: %w", err)
 	}

--- a/pkg/datastore/execsql.go
+++ b/pkg/datastore/execsql.go
@@ -1,0 +1,159 @@
+package datastore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
+)
+
+// ErrExecSQLNotSupportedShared is returned by ExecSQL when the Store
+// addresses a shared-schema (fs_id) database. Raw agent SQL carries no fs_id
+// predicates and cannot be rewritten to be tenant-safe, so it is rejected
+// outright in shared shape.
+var ErrExecSQLNotSupportedShared = errors.New("exec SQL is not supported on shared-schema stores")
+
+var wsNorm = regexp.MustCompile(`\s+`)
+
+func normalizeSQL(s string) string {
+	return wsNorm.ReplaceAllString(strings.TrimSpace(s), " ")
+}
+
+func (s *Store) ExecSQL(ctx context.Context, query string) (out []map[string]interface{}, err error) {
+	start := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+		}
+		metrics.RecordOperation("datastore", "exec_sql", result, time.Since(start))
+	}()
+
+	// Shared shape: raw agent SQL cannot be made tenant-safe, so reject it
+	// before anything executes.
+	if s != nil && s.scope.Shared() {
+		err = ErrExecSQLNotSupportedShared
+		return nil, err
+	}
+
+	q := strings.TrimSpace(query)
+	norm := strings.ToUpper(normalizeSQL(q))
+
+	isSelect := strings.HasPrefix(norm, "SELECT")
+	if strings.HasPrefix(norm, "WITH") {
+		hasDML := strings.Contains(norm, "INSERT") ||
+			strings.Contains(norm, "UPDATE") ||
+			strings.Contains(norm, "DELETE") ||
+			strings.Contains(norm, "DROP") ||
+			strings.Contains(norm, "ALTER") ||
+			strings.Contains(norm, "TRUNCATE")
+		if !hasDML {
+			isSelect = true
+		}
+	}
+	isTagWrite := strings.HasPrefix(norm, "INSERT INTO FILE_TAGS") ||
+		strings.HasPrefix(norm, "UPDATE FILE_TAGS") ||
+		strings.HasPrefix(norm, "DELETE FROM FILE_TAGS")
+
+	if isTagWrite {
+		if strings.HasPrefix(norm, "UPDATE") || strings.HasPrefix(norm, "DELETE") {
+			if strings.Contains(norm, " JOIN ") || strings.Contains(norm, " USING ") {
+				return nil, fmt.Errorf("multi-table DML not allowed; single-table statements on file_tags only")
+			}
+			if strings.HasPrefix(norm, "UPDATE") {
+				setIdx := strings.Index(norm, " SET ")
+				if setIdx > 0 && strings.Contains(norm[:setIdx], ",") {
+					return nil, fmt.Errorf("multi-table DML not allowed; single-table statements on file_tags only")
+				}
+			}
+			if strings.HasPrefix(norm, "DELETE") {
+				fromIdx := strings.Index(norm, " FROM ")
+				if fromIdx > 0 {
+					rest := norm[fromIdx+6:]
+					endIdx := strings.IndexAny(rest, " ;")
+					if endIdx < 0 {
+						endIdx = len(rest)
+					}
+					tablePart := rest[:endIdx]
+					if strings.Contains(tablePart, ",") {
+						return nil, fmt.Errorf("multi-table DML not allowed; single-table statements on file_tags only")
+					}
+				}
+			}
+		}
+	}
+
+	if !isSelect && !isTagWrite {
+		err = fmt.Errorf("only SELECT queries and INSERT/UPDATE/DELETE on file_tags are allowed")
+		logger.Warn(ctx, "datastore_exec_sql_rejected", zap.Int("query_len", len(q)), zap.Error(err))
+		return nil, err
+	}
+	if s == nil || s.db == nil {
+		err = fmt.Errorf("database is closed")
+		logger.Error(ctx, "datastore_exec_sql_closed", zap.Error(err))
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	if isTagWrite {
+		res, err := s.db.ExecContext(ctx, q)
+		if err != nil {
+			logger.Error(ctx, "datastore_exec_sql_tag_write_failed", zap.Int("query_len", len(q)), zap.Error(err))
+			return nil, err
+		}
+		affected, _ := res.RowsAffected()
+		return []map[string]interface{}{{"rows_affected": affected}}, nil
+	}
+
+	rows, err := s.db.QueryContext(ctx, q)
+	if err != nil {
+		logger.Error(ctx, "datastore_exec_sql_query_failed", zap.Int("query_len", len(q)), zap.Error(err))
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols, err := rows.Columns()
+	if err != nil {
+		return nil, err
+	}
+
+	const maxRows = 1000
+	result := make([]map[string]interface{}, 0)
+	for rows.Next() {
+		if len(result) >= maxRows {
+			break
+		}
+		vals := make([]interface{}, len(cols))
+		ptrs := make([]interface{}, len(cols))
+		for i := range vals {
+			ptrs[i] = &vals[i]
+		}
+		if err := rows.Scan(ptrs...); err != nil {
+			return nil, err
+		}
+		row := make(map[string]interface{}, len(cols))
+		for i, col := range cols {
+			v := vals[i]
+			if b, ok := v.([]byte); ok {
+				row[col] = string(b)
+			} else {
+				row[col] = v
+			}
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		logger.Error(ctx, "datastore_exec_sql_scan_failed", zap.Int("query_len", len(q)), zap.Error(err))
+		return nil, err
+	}
+	return result, nil
+}

--- a/pkg/datastore/execsql_shared_test.go
+++ b/pkg/datastore/execsql_shared_test.go
@@ -1,0 +1,27 @@
+package datastore
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// TestExecSQLSharedShapeRejected asserts the raw-SQL channel is closed in
+// shared shape: both reads and file_tags writes fail with the sentinel before
+// anything executes. No shared schema install is needed — the check fires
+// before any table access.
+func TestExecSQLSharedShapeRejected(t *testing.T) {
+	store := newSharedStore(t, 4400020)
+	ctx := context.Background()
+	for _, q := range []string{
+		"SELECT 1",
+		"SELECT path FROM file_nodes",
+		"INSERT INTO file_tags (file_id, tag_key, tag_value) VALUES ('a', 'b', 'c')",
+		"UPDATE file_tags SET tag_value = 'x' WHERE tag_key = 'y'",
+		"DELETE FROM file_tags WHERE file_id = 'a'",
+	} {
+		if _, err := store.ExecSQL(ctx, q); !errors.Is(err, ErrExecSQLNotSupportedShared) {
+			t.Fatalf("ExecSQL(%q) err = %v, want ErrExecSQLNotSupportedShared", q, err)
+		}
+	}
+}

--- a/pkg/datastore/file_gc_tasks.go
+++ b/pkg/datastore/file_gc_tasks.go
@@ -65,7 +65,7 @@ func (s *Store) GetFileGCTaskByFileID(ctx context.Context, fileID string) (out *
 	row := s.db.QueryRowContext(ctx, `SELECT task_id, file_id, storage_type, storage_ref,
 		size_bytes, content_type, status, attempt_count, max_attempts, receipt,
 		leased_at, lease_until, available_at, last_error, created_at, updated_at, completed_at
-		FROM file_gc_tasks WHERE file_id = ?`, fileID)
+		FROM file_gc_tasks WHERE `+s.scope.And(`file_id = ?`), s.scope.Args(fileID)...)
 	return scanFileGCTask(row)
 }
 
@@ -79,14 +79,14 @@ func (s *Store) ListFileGCTaskS3Refs(ctx context.Context, cursor string, limit i
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT DISTINCT storage_ref
 			 FROM file_gc_tasks
-			 WHERE storage_type = 's3' AND storage_ref <> ''
-			 ORDER BY storage_ref ASC LIMIT ?`, limit)
+			 WHERE `+s.scope.And(`storage_type = 's3' AND storage_ref <> ''`)+`
+			 ORDER BY storage_ref ASC LIMIT ?`, s.scope.Args(limit)...)
 	} else {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT DISTINCT storage_ref
 			 FROM file_gc_tasks
-			 WHERE storage_type = 's3' AND storage_ref <> '' AND storage_ref > ?
-			 ORDER BY storage_ref ASC LIMIT ?`, cursor, limit)
+			 WHERE `+s.scope.And(`storage_type = 's3' AND storage_ref <> '' AND storage_ref > ?`)+`
+			 ORDER BY storage_ref ASC LIMIT ?`, s.scope.Args(cursor, limit)...)
 	}
 	if err != nil {
 		return nil, "", fmt.Errorf("query file gc s3 refs: %w", err)
@@ -119,8 +119,8 @@ func (s *Store) CountQueuedFileGCTasks(ctx context.Context) (count int64, err er
 	start := time.Now()
 	defer observeStoreOp(ctx, "count_queued_file_gc_tasks", start, &err)
 	err = s.db.QueryRowContext(ctx,
-		`SELECT COUNT(*) FROM file_gc_tasks WHERE status = ?`,
-		"queued").Scan(&count)
+		`SELECT COUNT(*) FROM file_gc_tasks WHERE `+s.scope.And(`status = ?`),
+		s.scope.Args("queued")...).Scan(&count)
 	return count, err
 }
 
@@ -148,10 +148,10 @@ func (s *Store) ClaimFileGCTask(ctx context.Context, now time.Time, leaseDuratio
 		size_bytes, content_type, status, attempt_count, max_attempts, receipt,
 		leased_at, lease_until, available_at, last_error, created_at, updated_at, completed_at
 		FROM file_gc_tasks
-		WHERE status = ? AND available_at <= ?
+		WHERE `+s.scope.And(`status = ? AND available_at <= ?`)+`
 		ORDER BY available_at, created_at, task_id
 		LIMIT 1
-		FOR UPDATE SKIP LOCKED`, FileGCTaskQueued, now)
+		FOR UPDATE SKIP LOCKED`, s.scope.Args(FileGCTaskQueued, now)...)
 	task, err := scanFileGCTask(row)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
@@ -166,9 +166,9 @@ func (s *Store) ClaimFileGCTask(ctx context.Context, now time.Time, leaseDuratio
 	res, err := tx.ExecContext(ctx, `UPDATE file_gc_tasks SET status = ?,
 		attempt_count = attempt_count + 1, receipt = ?, leased_at = ?,
 		lease_until = ?, updated_at = ?
-		WHERE task_id = ? AND status = ? AND available_at <= ?`,
-		FileGCTaskProcessing, receipt, leasedAt, leaseUntil, now,
-		task.TaskID, FileGCTaskQueued, now)
+		WHERE `+s.scope.And(`task_id = ? AND status = ? AND available_at <= ?`),
+		append([]any{FileGCTaskProcessing, receipt, leasedAt, leaseUntil, now},
+			s.scope.Args(task.TaskID, FileGCTaskQueued, now)...)...)
 	if err != nil {
 		return nil, false, err
 	}
@@ -201,8 +201,9 @@ func (s *Store) AckFileGCTask(ctx context.Context, taskID, receipt string) (err 
 	now := time.Now().UTC()
 	res, err := s.db.ExecContext(ctx, `UPDATE file_gc_tasks SET status = ?, receipt = NULL,
 		leased_at = NULL, lease_until = NULL, completed_at = ?, updated_at = ?
-		WHERE task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`,
-		FileGCTaskSucceeded, now, now, taskID, FileGCTaskProcessing, receipt, now)
+		WHERE `+s.scope.And(`task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`),
+		append([]any{FileGCTaskSucceeded, now, now},
+			s.scope.Args(taskID, FileGCTaskProcessing, receipt, now)...)...)
 	if err != nil {
 		return err
 	}
@@ -237,7 +238,7 @@ func (s *Store) RetryFileGCTask(ctx context.Context, taskID, receipt string, ret
 	row := tx.QueryRowContext(ctx, `SELECT task_id, file_id, storage_type, storage_ref,
 		size_bytes, content_type, status, attempt_count, max_attempts, receipt,
 		leased_at, lease_until, available_at, last_error, created_at, updated_at, completed_at
-		FROM file_gc_tasks WHERE task_id = ? FOR UPDATE`, taskID)
+		FROM file_gc_tasks WHERE `+s.scope.And(`task_id = ?`)+` FOR UPDATE`, s.scope.Args(taskID)...)
 	task, err := scanFileGCTask(row)
 	if err != nil {
 		return err
@@ -249,12 +250,14 @@ func (s *Store) RetryFileGCTask(ctx context.Context, taskID, receipt string, ret
 	if task.MaxAttempts > 0 && task.AttemptCount >= task.MaxAttempts {
 		_, err = tx.ExecContext(ctx, `UPDATE file_gc_tasks SET status = ?, receipt = NULL,
 			leased_at = NULL, lease_until = NULL, last_error = ?, completed_at = ?, updated_at = ?
-			WHERE task_id = ?`, FileGCTaskDeadLettered, nullStr(lastErr), now, now, taskID)
+			WHERE `+s.scope.And(`task_id = ?`),
+			append([]any{FileGCTaskDeadLettered, nullStr(lastErr), now, now}, s.scope.Args(taskID)...)...)
 	} else {
 		_, err = tx.ExecContext(ctx, `UPDATE file_gc_tasks SET status = ?, receipt = NULL,
 			leased_at = NULL, lease_until = NULL, available_at = ?, last_error = ?,
 			completed_at = NULL, updated_at = ?
-			WHERE task_id = ?`, FileGCTaskQueued, retryAt, nullStr(lastErr), now, taskID)
+			WHERE `+s.scope.And(`task_id = ?`),
+			append([]any{FileGCTaskQueued, retryAt, nullStr(lastErr), now}, s.scope.Args(taskID)...)...)
 	}
 	if err != nil {
 		return err
@@ -280,9 +283,9 @@ func (s *Store) RecoverExpiredFileGCTasks(ctx context.Context, now time.Time, li
 	defer func() { _ = tx.Rollback() }()
 
 	query := `SELECT task_id FROM file_gc_tasks
-		WHERE status = ? AND lease_until IS NOT NULL AND lease_until < ?
+		WHERE ` + s.scope.And(`status = ? AND lease_until IS NOT NULL AND lease_until < ?`) + `
 		ORDER BY lease_until, created_at, task_id`
-	args := []any{FileGCTaskProcessing, now}
+	args := s.scope.Args(FileGCTaskProcessing, now)
 	if limit > 0 {
 		query += ` LIMIT ?`
 		args = append(args, limit)
@@ -309,8 +312,9 @@ func (s *Store) RecoverExpiredFileGCTasks(ctx context.Context, now time.Time, li
 	for _, taskID := range taskIDs {
 		res, err := tx.ExecContext(ctx, `UPDATE file_gc_tasks SET status = ?, receipt = NULL,
 			leased_at = NULL, lease_until = NULL, available_at = ?, updated_at = ?
-			WHERE task_id = ? AND status = ? AND lease_until IS NOT NULL AND lease_until < ?`,
-			FileGCTaskQueued, now, now, taskID, FileGCTaskProcessing, now)
+			WHERE `+s.scope.And(`task_id = ? AND status = ? AND lease_until IS NOT NULL AND lease_until < ?`),
+			append([]any{FileGCTaskQueued, now, now},
+				s.scope.Args(taskID, FileGCTaskProcessing, now)...)...)
 		if err != nil {
 			return 0, err
 		}
@@ -387,15 +391,15 @@ func (s *Store) enqueueFileGCTask(db execer, task *FileGCTask) (bool, error) {
 	}
 
 	_, err := db.Exec(`INSERT INTO file_gc_tasks
-		(task_id, file_id, storage_type, storage_ref, size_bytes, content_type,
+		(`+s.scope.InsCols(`task_id, file_id, storage_type, storage_ref, size_bytes, content_type,
 		 status, attempt_count, max_attempts, receipt, leased_at, lease_until,
-		 available_at, last_error, created_at, updated_at, completed_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		task.TaskID, task.FileID, task.StorageType, task.StorageRef, task.SizeBytes,
-		nullStr(task.ContentType), status, task.AttemptCount, maxAttempts,
-		nullStr(task.Receipt), nilTime(task.LeasedAt), nilTime(task.LeaseUntil),
-		availableAt.UTC(), nullStr(task.LastError), createdAt.UTC(),
-		updatedAt.UTC(), nilTime(task.CompletedAt))
+		 available_at, last_error, created_at, updated_at, completed_at`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(task.TaskID, task.FileID, task.StorageType, task.StorageRef, task.SizeBytes,
+			nullStr(task.ContentType), status, task.AttemptCount, maxAttempts,
+			nullStr(task.Receipt), nilTime(task.LeasedAt), nilTime(task.LeaseUntil),
+			availableAt.UTC(), nullStr(task.LastError), createdAt.UTC(),
+			updatedAt.UTC(), nilTime(task.CompletedAt))...)
 	if err == nil {
 		return true, nil
 	}
@@ -407,7 +411,7 @@ func (s *Store) enqueueFileGCTask(db execer, task *FileGCTask) (bool, error) {
 
 func (s *Store) fileGCTaskLeaseError(ctx context.Context, taskID string) error {
 	var count int
-	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM file_gc_tasks WHERE task_id = ?`, taskID).Scan(&count)
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM file_gc_tasks WHERE `+s.scope.And(`task_id = ?`), s.scope.Args(taskID)...).Scan(&count)
 	if err != nil {
 		return err
 	}

--- a/pkg/datastore/file_tx.go
+++ b/pkg/datastore/file_tx.go
@@ -56,7 +56,7 @@ func (s *Store) updateFileContentTx(db execer, fileID string, expectedRevision i
 		}
 		if description != "" {
 			var currentDesc sql.NullString
-			if err := db.QueryRow(`SELECT description FROM semantic WHERE inode_id = ?`, fileID).Scan(&currentDesc); err != nil {
+			if err := db.QueryRow(`SELECT description FROM semantic WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(fileID)...).Scan(&currentDesc); err != nil {
 				return 0, fmt.Errorf("read current description: %w", err)
 			}
 			query += ` description = ?,`
@@ -107,7 +107,7 @@ func (s *Store) updateFileContentTx(db execer, fileID string, expectedRevision i
 		}
 	} else {
 		var currentRev int64
-		if err := db.QueryRow(`SELECT revision FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' FOR UPDATE`, fileID).Scan(&currentRev); err != nil {
+		if err := db.QueryRow(`SELECT revision FROM inodes WHERE `+s.scope.And(`inode_id = ? AND status = 'CONFIRMED'`)+` FOR UPDATE`, s.scope.Args(fileID)...).Scan(&currentRev); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				if expectedRevision > 0 {
 					return 0, ErrRevisionConflict
@@ -127,7 +127,7 @@ func (s *Store) updateFileContentTx(db execer, fileID string, expectedRevision i
 		return 0, fmt.Errorf("update inode: %w", err)
 	}
 	var encryptionMode StorageEncryptionMode
-	if err := db.QueryRow(`SELECT storage_encryption_mode FROM contents WHERE inode_id = ?`, fileID).Scan(&encryptionMode); err != nil {
+	if err := db.QueryRow(`SELECT storage_encryption_mode FROM contents WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(fileID)...).Scan(&encryptionMode); err != nil {
 		return 0, fmt.Errorf("read encryption mode: %w", err)
 	}
 	if err := s.UpdateContentTx(db, fileID, storageType, storageRef, contentType, checksum, contentBlob, encryptionMode); err != nil {
@@ -161,7 +161,7 @@ func (s *Store) UpdateFileStorageEncryptionTx(db execer, fileID string, mode Sto
 		}
 		if rowsAffected == 0 {
 			var exists int
-			if err := db.QueryRow(`SELECT 1 FROM inodes WHERE inode_id = ?`, fileID).Scan(&exists); err != nil {
+			if err := db.QueryRow(`SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(fileID)...).Scan(&exists); err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
 					return ErrNotFound
 				}
@@ -170,7 +170,7 @@ func (s *Store) UpdateFileStorageEncryptionTx(db execer, fileID string, mode Sto
 		}
 	} else {
 		var exists int
-		if err := db.QueryRow(`SELECT 1 FROM inodes WHERE inode_id = ?`, fileID).Scan(&exists); err != nil {
+		if err := db.QueryRow(`SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(fileID)...).Scan(&exists); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrNotFound
 			}
@@ -178,8 +178,8 @@ func (s *Store) UpdateFileStorageEncryptionTx(db execer, fileID string, mode Sto
 		}
 	}
 	// Dual-write to split tables
-	if _, err := db.Exec(`UPDATE contents SET storage_encryption_mode = ?, storage_encryption_key_id = ? WHERE inode_id = ?`,
-		mode, storageEncryptionKeyIDForWrite(mode, keyID), fileID); err != nil {
+	if _, err := db.Exec(`UPDATE contents SET storage_encryption_mode = ?, storage_encryption_key_id = ? WHERE `+s.scope.And(`inode_id = ?`),
+		append([]any{mode, storageEncryptionKeyIDForWrite(mode, keyID)}, s.scope.Args(fileID)...)...); err != nil {
 		return fmt.Errorf("update contents encryption: %w", err)
 	}
 	return nil
@@ -227,7 +227,7 @@ func (s *Store) ConfirmPendingFileTx(db execer, fileID string, storageType Stora
 		}
 	} else {
 		var status string
-		if err := db.QueryRow(`SELECT status FROM inodes WHERE inode_id = ? FOR UPDATE`, fileID).Scan(&status); err != nil {
+		if err := db.QueryRow(`SELECT status FROM inodes WHERE `+s.scope.And(`inode_id = ?`)+` FOR UPDATE`, s.scope.Args(fileID)...).Scan(&status); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrNotFound
 			}
@@ -242,7 +242,7 @@ func (s *Store) ConfirmPendingFileTx(db execer, fileID string, storageType Stora
 		return fmt.Errorf("update inode: %w", err)
 	}
 	var encMode StorageEncryptionMode
-	if err := db.QueryRow(`SELECT storage_encryption_mode FROM contents WHERE inode_id = ?`, fileID).Scan(&encMode); err != nil {
+	if err := db.QueryRow(`SELECT storage_encryption_mode FROM contents WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(fileID)...).Scan(&encMode); err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("read content encryption: %w", err)
 		}
@@ -285,7 +285,7 @@ func (s *Store) ConfirmPendingFileAutoEmbeddingTx(db execer, fileID string, stor
 		}
 	} else {
 		var status string
-		if err := db.QueryRow(`SELECT status FROM inodes WHERE inode_id = ? FOR UPDATE`, fileID).Scan(&status); err != nil {
+		if err := db.QueryRow(`SELECT status FROM inodes WHERE `+s.scope.And(`inode_id = ?`)+` FOR UPDATE`, s.scope.Args(fileID)...).Scan(&status); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrNotFound
 			}
@@ -300,7 +300,7 @@ func (s *Store) ConfirmPendingFileAutoEmbeddingTx(db execer, fileID string, stor
 		return fmt.Errorf("update inode: %w", err)
 	}
 	var encMode StorageEncryptionMode
-	if err := db.QueryRow(`SELECT storage_encryption_mode FROM contents WHERE inode_id = ?`, fileID).Scan(&encMode); err != nil {
+	if err := db.QueryRow(`SELECT storage_encryption_mode FROM contents WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(fileID)...).Scan(&encMode); err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			return fmt.Errorf("read content encryption: %w", err)
 		}
@@ -331,14 +331,16 @@ func (s *Store) DeletePendingFileTx(db execer, fileID string) error {
 			return ErrNotFound
 		}
 	}
-	res, err := db.Exec(`UPDATE inodes SET status = 'DELETED', mtime = ? WHERE inode_id = ? AND status = 'PENDING'`, now, fileID)
+	res, err := db.Exec(`UPDATE inodes SET status = 'DELETED', mtime = ? WHERE `+s.scope.And(`inode_id = ? AND status = 'PENDING'`),
+		append([]any{now}, s.scope.Args(fileID)...)...)
 	if err != nil {
 		return err
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
 		return ErrNotFound
 	}
-	if _, err := db.Exec(`UPDATE contents SET storage_ref = '', storage_ref_hash = '' WHERE inode_id = ?`, fileID); err != nil {
+	if _, err := db.Exec(`UPDATE contents SET storage_ref = '', storage_ref_hash = '' WHERE `+s.scope.And(`inode_id = ?`),
+		s.scope.Args(fileID)...); err != nil {
 		return err
 	}
 	return nil
@@ -360,7 +362,7 @@ func (s *Store) ClearFileEmbeddingStateTx(db execer, fileID string) error {
 		}
 	} else {
 		var exists int
-		if err := db.QueryRow(`SELECT 1 FROM inodes WHERE inode_id = ?`, fileID).Scan(&exists); err != nil {
+		if err := db.QueryRow(`SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(fileID)...).Scan(&exists); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrNotFound
 			}
@@ -368,7 +370,8 @@ func (s *Store) ClearFileEmbeddingStateTx(db execer, fileID string) error {
 		}
 	}
 	// Dual-write to split tables.
-	if _, err := db.Exec(`UPDATE semantic SET embedding = NULL, embedding_revision = NULL WHERE inode_id = ?`, fileID); err != nil {
+	if _, err := db.Exec(`UPDATE semantic SET embedding = NULL, embedding_revision = NULL WHERE `+s.scope.And(`inode_id = ?`),
+		s.scope.Args(fileID)...); err != nil {
 		return fmt.Errorf("update semantic embedding: %w", err)
 	}
 	return nil

--- a/pkg/datastore/fs_events.go
+++ b/pkg/datastore/fs_events.go
@@ -21,8 +21,8 @@ type FSEventRow struct {
 // INSERT — wrapping it in BEGIN/COMMIT adds 2 unnecessary RTTs per event.
 func (s *Store) InsertFSEvent(ctx context.Context, path, op, actor string, ts int64) (int64, error) {
 	res, err := s.db.ExecContext(ctx,
-		`INSERT INTO fs_events (path, op, actor, ts) VALUES (?, ?, ?, ?)`,
-		path, op, actor, ts)
+		`INSERT INTO fs_events (`+s.scope.InsCols(`path, op, actor, ts`)+`) VALUES (`+s.scope.InsVals(`?, ?, ?, ?`)+`)`,
+		s.scope.Args(path, op, actor, ts)...)
 	if err != nil {
 		return 0, fmt.Errorf("insert fs_event: %w", err)
 	}
@@ -34,13 +34,18 @@ func (s *Store) InsertFSEvent(ctx context.Context, path, op, actor string, ts in
 }
 
 // ListFSEventsSince returns events with seq > since, ordered by seq, up to limit.
+//
+// In shared shape seq stays a table-global AUTO_INCREMENT, so interleaved
+// tenants produce holes in each tenant's per-fs_id seq stream. Consumers must
+// tolerate the gaps; the SSE gap/reset handling for that lives in pkg/server
+// eventbus and is a separate change.
 func (s *Store) ListFSEventsSince(ctx context.Context, since int64, limit int) ([]FSEventRow, error) {
 	if limit <= 0 {
 		limit = 1000
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT seq, path, op, actor, ts FROM fs_events WHERE seq > ? ORDER BY seq LIMIT ?`,
-		since, limit)
+		`SELECT seq, path, op, actor, ts FROM fs_events WHERE `+s.scope.And(`seq > ?`)+` ORDER BY seq LIMIT ?`,
+		s.scope.Args(since, limit)...)
 	if err != nil {
 		return nil, fmt.Errorf("list fs_events since %d: %w", since, err)
 	}
@@ -60,8 +65,14 @@ func (s *Store) ListFSEventsSince(ctx context.Context, since int64, limit int) (
 
 // LatestFSEventSeq returns the current max seq in fs_events, or 0 if empty.
 func (s *Store) LatestFSEventSeq(ctx context.Context) (int64, error) {
+	q := `SELECT MAX(seq) FROM fs_events`
+	var args []any
+	if s.scope.Shared() {
+		q += ` WHERE fs_id = ?`
+		args = s.scope.Args()
+	}
 	var seq sql.NullInt64
-	if err := s.db.QueryRowContext(ctx, `SELECT MAX(seq) FROM fs_events`).Scan(&seq); err != nil {
+	if err := s.db.QueryRowContext(ctx, q, args...).Scan(&seq); err != nil {
 		return 0, fmt.Errorf("latest fs_event seq: %w", err)
 	}
 	if !seq.Valid {
@@ -72,8 +83,14 @@ func (s *Store) LatestFSEventSeq(ctx context.Context) (int64, error) {
 
 // OldestFSEventSeq returns the current min seq in fs_events, or 0 if empty.
 func (s *Store) OldestFSEventSeq(ctx context.Context) (int64, error) {
+	q := `SELECT MIN(seq) FROM fs_events`
+	var args []any
+	if s.scope.Shared() {
+		q += ` WHERE fs_id = ?`
+		args = s.scope.Args()
+	}
 	var seq sql.NullInt64
-	if err := s.db.QueryRowContext(ctx, `SELECT MIN(seq) FROM fs_events`).Scan(&seq); err != nil {
+	if err := s.db.QueryRowContext(ctx, q, args...).Scan(&seq); err != nil {
 		return 0, fmt.Errorf("oldest fs_event seq: %w", err)
 	}
 	if !seq.Valid {
@@ -94,8 +111,14 @@ func (s *Store) OldestFSEventSeq(ctx context.Context) (int64, error) {
 // `WHERE created_at > NOW() - INTERVAL 2 HOUR`) or an approximate count from
 // information_schema.TABLES.
 func (s *Store) CountFSEvents(ctx context.Context) (int64, error) {
+	q := `SELECT COUNT(*) FROM fs_events`
+	var args []any
+	if s.scope.Shared() {
+		q += ` WHERE fs_id = ?`
+		args = s.scope.Args()
+	}
 	var count int64
-	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM fs_events`).Scan(&count); err != nil {
+	if err := s.db.QueryRowContext(ctx, q, args...).Scan(&count); err != nil {
 		return 0, fmt.Errorf("count fs_events: %w", err)
 	}
 	return count, nil
@@ -109,7 +132,7 @@ func (s *Store) CountFSEvents(ctx context.Context) (int64, error) {
 // ts-based deletion path would be needed. For now, created_at is indexed and
 // sufficient because the SSE protocol uses seq (not ts) for cursor management.
 func (s *Store) DeleteFSEventsBefore(ctx context.Context, before time.Time) (int64, error) {
-	res, err := s.db.ExecContext(ctx, `DELETE FROM fs_events WHERE created_at < ?`, before)
+	res, err := s.db.ExecContext(ctx, `DELETE FROM fs_events WHERE `+s.scope.And(`created_at < ?`), s.scope.Args(before)...)
 	if err != nil {
 		return 0, fmt.Errorf("delete fs_events before %s: %w", before, err)
 	}

--- a/pkg/datastore/fs_events_shared_test.go
+++ b/pkg/datastore/fs_events_shared_test.go
@@ -1,0 +1,169 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestFSEventsSharedShapeParity exercises insert / list-since / seq helpers /
+// retention against the shared (fs_id) schema shape.
+func TestFSEventsSharedShapeParity(t *testing.T) {
+	installSharedCoreFSSchema(t)
+	const fsID int64 = 4400010
+	store := newSharedStore(t, fsID)
+	ctx := context.Background()
+
+	seq1, err := store.InsertFSEvent(ctx, "/a.txt", "create", "tester", 100)
+	if err != nil {
+		t.Fatalf("InsertFSEvent 1: %v", err)
+	}
+	seq2, err := store.InsertFSEvent(ctx, "/b.txt", "delete", "", 101)
+	if err != nil {
+		t.Fatalf("InsertFSEvent 2: %v", err)
+	}
+	if seq2 <= seq1 {
+		t.Fatalf("seq2 = %d, want > seq1 = %d", seq2, seq1)
+	}
+
+	events, err := store.ListFSEventsSince(ctx, 0, 10)
+	if err != nil {
+		t.Fatalf("ListFSEventsSince: %v", err)
+	}
+	if len(events) != 2 || events[0].Path != "/a.txt" || events[1].Path != "/b.txt" {
+		t.Fatalf("events = %#v, want /a.txt then /b.txt", events)
+	}
+	if events[0].Actor != "tester" || events[1].Actor != "" {
+		t.Fatalf("actors = %q, %q; want tester, \"\"", events[0].Actor, events[1].Actor)
+	}
+	events, err = store.ListFSEventsSince(ctx, seq1, 10)
+	if err != nil {
+		t.Fatalf("ListFSEventsSince seq1: %v", err)
+	}
+	if len(events) != 1 || events[0].Seq != uint64(seq2) {
+		t.Fatalf("events since seq1 = %#v, want only seq %d", events, seq2)
+	}
+
+	latest, err := store.LatestFSEventSeq(ctx)
+	if err != nil {
+		t.Fatalf("LatestFSEventSeq: %v", err)
+	}
+	if latest != seq2 {
+		t.Fatalf("latest = %d, want %d", latest, seq2)
+	}
+	oldest, err := store.OldestFSEventSeq(ctx)
+	if err != nil {
+		t.Fatalf("OldestFSEventSeq: %v", err)
+	}
+	if oldest != seq1 {
+		t.Fatalf("oldest = %d, want %d", oldest, seq1)
+	}
+	count, err := store.CountFSEvents(ctx)
+	if err != nil {
+		t.Fatalf("CountFSEvents: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("count = %d, want 2", count)
+	}
+
+	// Retention: age the first row, sweep, and only that row is deleted.
+	old := time.Now().Add(-2 * time.Hour)
+	if _, err := store.DB().Exec(`UPDATE fs_events SET created_at = ? WHERE seq = ?`, old, seq1); err != nil {
+		t.Fatalf("age row: %v", err)
+	}
+	deleted, err := store.DeleteFSEventsBefore(ctx, time.Now().Add(-time.Hour))
+	if err != nil {
+		t.Fatalf("DeleteFSEventsBefore: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	events, err = store.ListFSEventsSince(ctx, 0, 10)
+	if err != nil {
+		t.Fatalf("ListFSEventsSince after sweep: %v", err)
+	}
+	if len(events) != 1 || events[0].Seq != uint64(seq2) {
+		t.Fatalf("events after sweep = %#v, want only seq %d", events, seq2)
+	}
+}
+
+// TestFSEventsSharedShapeInterleaving appends events from two tenants
+// alternately and asserts each store sees only its own events in seq order.
+// Because seq is a table-global AUTO_INCREMENT in shared shape, each tenant's
+// seq stream has holes where the other tenant's events landed — per-tenant
+// gaps are expected; the SSE gap/reset handling for them lives in pkg/server
+// eventbus (separate change).
+func TestFSEventsSharedShapeInterleaving(t *testing.T) {
+	installSharedCoreFSSchema(t)
+	const fsA, fsB int64 = 4400011, 4400012
+	storeA := newSharedStore(t, fsA)
+	storeB := newSharedStore(t, fsB)
+	ctx := context.Background()
+
+	var seqsA []int64
+	for i, tc := range []struct {
+		store *Store
+		path  string
+	}{
+		{storeA, "/a/1"}, {storeB, "/b/1"},
+		{storeA, "/a/2"}, {storeB, "/b/2"},
+		{storeA, "/a/3"},
+	} {
+		seq, err := tc.store.InsertFSEvent(ctx, tc.path, "write", "tester", int64(200+i))
+		if err != nil {
+			t.Fatalf("InsertFSEvent %s: %v", tc.path, err)
+		}
+		if tc.store == storeA {
+			seqsA = append(seqsA, seq)
+		}
+	}
+
+	events, err := storeA.ListFSEventsSince(ctx, 0, 10)
+	if err != nil {
+		t.Fatalf("ListFSEventsSince A: %v", err)
+	}
+	if len(events) != 3 {
+		t.Fatalf("A sees %d events, want 3 (cross-tenant leak): %#v", len(events), events)
+	}
+	for i, ev := range events {
+		wantPath := []string{"/a/1", "/a/2", "/a/3"}[i]
+		if ev.Path != wantPath || ev.Seq != uint64(seqsA[i]) {
+			t.Fatalf("A event %d = (%d, %s), want (%d, %s)", i, ev.Seq, ev.Path, seqsA[i], wantPath)
+		}
+	}
+	// B's interleaved seqs must leave holes in A's stream.
+	if events[2].Seq-events[0].Seq == 2 {
+		t.Fatalf("expected seq holes from interleaved tenant, got contiguous: %#v", events)
+	}
+
+	countB, err := storeB.CountFSEvents(ctx)
+	if err != nil {
+		t.Fatalf("CountFSEvents B: %v", err)
+	}
+	if countB != 2 {
+		t.Fatalf("B count = %d, want 2", countB)
+	}
+
+	// A's retention sweep must delete only A's rows.
+	deleted, err := storeA.DeleteFSEventsBefore(ctx, time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("DeleteFSEventsBefore A: %v", err)
+	}
+	if deleted != 3 {
+		t.Fatalf("A deleted = %d, want 3", deleted)
+	}
+	eventsB, err := storeB.ListFSEventsSince(ctx, 0, 10)
+	if err != nil {
+		t.Fatalf("ListFSEventsSince B: %v", err)
+	}
+	if len(eventsB) != 2 || eventsB[0].Path != "/b/1" || eventsB[1].Path != "/b/2" {
+		t.Fatalf("B events after A's sweep = %#v, want /b/1 and /b/2", eventsB)
+	}
+	var total int64
+	if err := storeA.DB().QueryRow(`SELECT COUNT(*) FROM fs_events`).Scan(&total); err != nil {
+		t.Fatalf("count all fs_events: %v", err)
+	}
+	if total != 2 {
+		t.Fatalf("total fs_events rows = %d, want 2 (only B's rows survive)", total)
+	}
+}

--- a/pkg/datastore/fs_layer.go
+++ b/pkg/datastore/fs_layer.go
@@ -161,10 +161,10 @@ func (s *Store) CreateFSLayer(ctx context.Context, layer *FSLayer) error {
 	defer func() { _ = tx.Rollback() }()
 	_, err = tx.ExecContext(ctx, `
 INSERT INTO fs_layers (
-	layer_id, base_root_path, name, state, durability_mode, actor_id, durable_seq, created_at, updated_at, sealed_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3), ?)`,
-		layer.LayerID, layer.BaseRootPath, layer.Name, string(layer.State), string(layer.DurabilityMode), layer.ActorID,
-		layer.DurableSeq, nilTime(layer.SealedAt))
+	`+s.scope.InsCols(`layer_id, base_root_path, name, state, durability_mode, actor_id, durable_seq, created_at, updated_at, sealed_at`)+`
+) VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3), ?`)+`)`,
+		s.scope.Args(layer.LayerID, layer.BaseRootPath, layer.Name, string(layer.State), string(layer.DurabilityMode), layer.ActorID,
+			layer.DurableSeq, nilTime(layer.SealedAt))...)
 	if err != nil {
 		return fmt.Errorf("create fs layer %s: %w", layer.LayerID, err)
 	}
@@ -186,7 +186,7 @@ func (s *Store) GetFSLayer(ctx context.Context, layerID string) (*FSLayer, error
 	row := s.db.QueryRowContext(ctx, `
 SELECT layer_id, base_root_path, name, state, durability_mode, actor_id, durable_seq, created_at, updated_at, sealed_at
 	FROM fs_layers
-	WHERE layer_id = ?`, layerID)
+	WHERE `+s.scope.And(`layer_id = ?`), s.scope.Args(layerID)...)
 	layer, err := scanFSLayer(row)
 	if err != nil {
 		return nil, err
@@ -198,10 +198,20 @@ SELECT layer_id, base_root_path, name, state, durability_mode, actor_id, durable
 }
 
 func (s *Store) ListFSLayers(ctx context.Context) ([]FSLayer, error) {
-	rows, err := s.db.QueryContext(ctx, `
+	// A full layer list has no natural WHERE clause; in shared shape still
+	// restrict the scan to this tenant's fs_id.
+	query := `
 SELECT layer_id, base_root_path, name, state, durability_mode, actor_id, durable_seq, created_at, updated_at, sealed_at
-FROM fs_layers
-ORDER BY updated_at DESC, layer_id`)
+FROM fs_layers`
+	var args []any
+	if s.scope.Shared() {
+		query += `
+WHERE fs_id = ?`
+		args = append(args, s.scope.FsID())
+	}
+	query += `
+ORDER BY updated_at DESC, layer_id`
+	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list fs layers: %w", err)
 	}
@@ -279,7 +289,7 @@ func (s *Store) SetFSLayerTags(ctx context.Context, layerID string, tags map[str
 	}
 	defer func() { _ = tx.Rollback() }()
 	var existing string
-	if err := tx.QueryRowContext(ctx, `SELECT layer_id FROM fs_layers WHERE layer_id = ?`, layerID).Scan(&existing); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT layer_id FROM fs_layers WHERE `+s.scope.And(`layer_id = ?`), s.scope.Args(layerID)...).Scan(&existing); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
 		}
@@ -302,8 +312,8 @@ func (s *Store) GetFSLayerTags(ctx context.Context, layerID string) (map[string]
 	rows, err := s.db.QueryContext(ctx, `
 SELECT tag_key, tag_value
 FROM fs_layer_tags
-WHERE layer_id = ?
-ORDER BY tag_key`, layerID)
+WHERE `+s.scope.And(`layer_id = ?`)+`
+ORDER BY tag_key`, s.scope.Args(layerID)...)
 	if err != nil {
 		return nil, fmt.Errorf("list fs layer tags: %w", err)
 	}
@@ -330,12 +340,12 @@ func (s *Store) SetFSLayerState(ctx context.Context, layerID string, state FSLay
 		return err
 	}
 	query := `UPDATE fs_layers SET state = ?, updated_at = UTC_TIMESTAMP(3)`
-	args := []any{string(state)}
+	setArgs := []any{string(state)}
 	if state == FSLayerStateSealed || state == FSLayerStateCommitting || state == FSLayerStateCommitted || state == FSLayerStateAbandoned || state == FSLayerStateConflicted {
 		query += `, sealed_at = COALESCE(sealed_at, UTC_TIMESTAMP(3))`
 	}
-	query += ` WHERE layer_id = ?`
-	args = append(args, layerID)
+	query += ` WHERE ` + s.scope.And(`layer_id = ?`)
+	args := append(setArgs, s.scope.Args(layerID)...)
 	res, err := s.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("set fs layer state %s: %w", layerID, err)
@@ -363,14 +373,13 @@ func (s *Store) SetFSLayerStateIf(ctx context.Context, layerID string, from []FS
 	if err := validateFSLayerState(to); err != nil {
 		return err
 	}
-	args := make([]any, 0, 2+len(from))
+	setArgs := []any{string(to)}
 	query := `UPDATE fs_layers SET state = ?, updated_at = UTC_TIMESTAMP(3)`
-	args = append(args, string(to))
 	if to == FSLayerStateSealed || to == FSLayerStateCommitting || to == FSLayerStateCommitted || to == FSLayerStateAbandoned || to == FSLayerStateConflicted {
 		query += `, sealed_at = COALESCE(sealed_at, UTC_TIMESTAMP(3))`
 	}
-	query += ` WHERE layer_id = ? AND state IN (`
-	args = append(args, layerID)
+	query += ` WHERE ` + s.scope.And(`layer_id = ? AND state IN (`)
+	whereArgs := []any{layerID}
 	for i, state := range from {
 		if err := validateFSLayerState(state); err != nil {
 			return err
@@ -379,9 +388,10 @@ func (s *Store) SetFSLayerStateIf(ctx context.Context, layerID string, from []FS
 			query += `, `
 		}
 		query += `?`
-		args = append(args, string(state))
+		whereArgs = append(whereArgs, string(state))
 	}
 	query += `)`
+	args := append(setArgs, s.scope.Args(whereArgs...)...)
 	res, err := s.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return fmt.Errorf("set fs layer state %s: %w", layerID, err)
@@ -407,8 +417,9 @@ func (s *Store) BeginFSLayerCommit(ctx context.Context, layerID string) error {
 	res, err := s.db.ExecContext(ctx, `
 UPDATE fs_layers
 SET state = ?, sealed_at = COALESCE(sealed_at, UTC_TIMESTAMP(3)), updated_at = UTC_TIMESTAMP(3)
-WHERE layer_id = ? AND state IN (?, ?)`,
-		string(FSLayerStateCommitting), layerID, string(FSLayerStateActive), string(FSLayerStateSealed))
+WHERE `+s.scope.And(`layer_id = ? AND state IN (?, ?)`),
+		append([]any{string(FSLayerStateCommitting)},
+			s.scope.Args(layerID, string(FSLayerStateActive), string(FSLayerStateSealed))...)...)
 	if err != nil {
 		return fmt.Errorf("begin fs layer commit %s: %w", layerID, err)
 	}
@@ -443,9 +454,9 @@ func (s *Store) RollbackFSLayer(ctx context.Context, layerID string) error {
 	res, err := tx.ExecContext(ctx, `
 UPDATE fs_layers
 SET state = ?, updated_at = UTC_TIMESTAMP(3), sealed_at = COALESCE(sealed_at, UTC_TIMESTAMP(3))
-WHERE layer_id = ? AND state IN (?, ?, ?)`,
-		string(FSLayerStateAbandoned), layerID,
-		string(FSLayerStateActive), string(FSLayerStateSealed), string(FSLayerStateConflicted))
+WHERE `+s.scope.And(`layer_id = ? AND state IN (?, ?, ?)`),
+		append([]any{string(FSLayerStateAbandoned)},
+			s.scope.Args(layerID, string(FSLayerStateActive), string(FSLayerStateSealed), string(FSLayerStateConflicted))...)...)
 	if err != nil {
 		return fmt.Errorf("rollback fs layer %s: %w", layerID, err)
 	}
@@ -459,7 +470,7 @@ WHERE layer_id = ? AND state IN (?, ?, ?)`,
 		// already-abandoned case, return nil idempotently WITHOUT
 		// re-emitting the rollback event.
 		var state string
-		if err := tx.QueryRowContext(ctx, `SELECT state FROM fs_layers WHERE layer_id = ?`, layerID).Scan(&state); err != nil {
+		if err := tx.QueryRowContext(ctx, `SELECT state FROM fs_layers WHERE `+s.scope.And(`layer_id = ?`), s.scope.Args(layerID)...).Scan(&state); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrNotFound
 			}
@@ -478,7 +489,7 @@ WHERE layer_id = ? AND state IN (?, ?, ?)`,
 	// fs_layer_events.seq directly to stay monotonic and unique under
 	// uk_fs_layer_events_seq(layer_id, seq).
 	var maxSeq sql.NullInt64
-	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(seq), 0) FROM fs_layer_events WHERE layer_id = ?`, layerID).Scan(&maxSeq); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT COALESCE(MAX(seq), 0) FROM fs_layer_events WHERE `+s.scope.And(`layer_id = ?`), s.scope.Args(layerID)...).Scan(&maxSeq); err != nil {
 		return fmt.Errorf("read fs layer max event seq: %w", err)
 	}
 	seq := int64(1)
@@ -487,9 +498,9 @@ WHERE layer_id = ? AND state IN (?, ?, ?)`,
 	}
 	eventID := fmt.Sprintf("%s:rollback:%d", layerID, seq)
 	if _, err := tx.ExecContext(ctx, `
-INSERT INTO fs_layer_events (event_id, layer_id, seq, actor_id, op, path, created_at)
-VALUES (?, ?, ?, '', ?, '/', UTC_TIMESTAMP(3))`,
-		eventID, layerID, seq, fsLayerEventOpRollback); err != nil {
+INSERT INTO fs_layer_events (`+s.scope.InsCols(`event_id, layer_id, seq, actor_id, op, path, created_at`)+`)
+VALUES (`+s.scope.InsVals(`?, ?, ?, '', ?, '/', UTC_TIMESTAMP(3)`)+`)`,
+		s.scope.Args(eventID, layerID, seq, fsLayerEventOpRollback)...); err != nil {
 		return fmt.Errorf("insert fs layer rollback event %s: %w", layerID, err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -518,8 +529,8 @@ func (s *Store) ListFSLayerEntryLogAtSeq(ctx context.Context, layerID string, ma
 }
 
 func (s *Store) listFSLayerEntryLog(ctx context.Context, layerID string, maxSeq *int64) ([]FSLayerEntry, error) {
-	where := "WHERE layer_id = ?"
-	args := []any{layerID}
+	where := "WHERE " + s.scope.And("layer_id = ?")
+	args := s.scope.Args(layerID)
 	if maxSeq != nil {
 		where += " AND entry_seq <= ?"
 		args = append(args, *maxSeq)
@@ -565,7 +576,7 @@ func (s *Store) UpsertFSLayerEntry(ctx context.Context, entry *FSLayerEntry) err
 		baseRoot string
 		state    string
 	)
-	if err := tx.QueryRowContext(ctx, `SELECT base_root_path, state FROM fs_layers WHERE layer_id = ? FOR UPDATE`, entry.LayerID).Scan(&baseRoot, &state); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT base_root_path, state FROM fs_layers WHERE `+s.scope.And(`layer_id = ?`)+` FOR UPDATE`, s.scope.Args(entry.LayerID)...).Scan(&baseRoot, &state); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
 		}
@@ -579,7 +590,7 @@ func (s *Store) UpsertFSLayerEntry(ctx context.Context, entry *FSLayerEntry) err
 	}
 	if entry.EntrySeq <= 0 {
 		var seq sql.NullInt64
-		if err := tx.QueryRowContext(ctx, `SELECT MAX(entry_seq) FROM fs_layer_entries WHERE layer_id = ?`, entry.LayerID).Scan(&seq); err != nil {
+		if err := tx.QueryRowContext(ctx, `SELECT MAX(entry_seq) FROM fs_layer_entries WHERE `+s.scope.And(`layer_id = ?`), s.scope.Args(entry.LayerID)...).Scan(&seq); err != nil {
 			return fmt.Errorf("read fs layer max seq: %w", err)
 		}
 		entry.EntrySeq = 1
@@ -589,24 +600,24 @@ func (s *Store) UpsertFSLayerEntry(ctx context.Context, entry *FSLayerEntry) err
 	}
 	_, err = tx.ExecContext(ctx, `
 INSERT INTO fs_layer_entries (
-	layer_id, path, path_hash, parent_path, parent_path_hash, name, op, kind, base_inode_id, base_revision,
+	`+s.scope.InsCols(`layer_id, path, path_hash, parent_path, parent_path_hash, name, op, kind, base_inode_id, base_revision,
 	storage_type, storage_ref, storage_ref_hash, storage_encryption_mode, storage_encryption_key_id,
-	content_blob, content_type, content_text, checksum_sha256, size_bytes, mode, entry_seq, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3))`,
-		entry.LayerID, entry.Path, entry.PathHash, entry.ParentPath, entry.ParentPathHash, entry.Name,
-		string(entry.Op), string(entry.Kind), entry.BaseInodeID, entry.BaseRevision, entry.StorageType,
-		entry.StorageRef, entry.StorageRefHash, fileStorageEncryptionModeForWrite(entry.StorageEncryptionMode),
-		storageEncryptionKeyIDForWrite(entry.StorageEncryptionMode, entry.StorageEncryptionKeyID),
-		nilBytes(entry.ContentBlob), nullStr(entry.ContentType),
-		nullStr(entry.ContentText), entry.ChecksumSHA256, entry.SizeBytes, entry.Mode, entry.EntrySeq)
+	content_blob, content_type, content_text, checksum_sha256, size_bytes, mode, entry_seq, created_at, updated_at`)+`
+) VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3)`)+`)`,
+		s.scope.Args(entry.LayerID, entry.Path, entry.PathHash, entry.ParentPath, entry.ParentPathHash, entry.Name,
+			string(entry.Op), string(entry.Kind), entry.BaseInodeID, entry.BaseRevision, entry.StorageType,
+			entry.StorageRef, entry.StorageRefHash, fileStorageEncryptionModeForWrite(entry.StorageEncryptionMode),
+			storageEncryptionKeyIDForWrite(entry.StorageEncryptionMode, entry.StorageEncryptionKeyID),
+			nilBytes(entry.ContentBlob), nullStr(entry.ContentType),
+			nullStr(entry.ContentText), entry.ChecksumSHA256, entry.SizeBytes, entry.Mode, entry.EntrySeq)...)
 	if err != nil {
 		return fmt.Errorf("upsert fs layer entry %s:%s: %w", entry.LayerID, entry.Path, err)
 	}
 	eventID := fmt.Sprintf("%s:%d", entry.LayerID, entry.EntrySeq)
 	if _, err := tx.ExecContext(ctx, `
-INSERT INTO fs_layer_events (event_id, layer_id, seq, actor_id, op, path, created_at)
-VALUES (?, ?, ?, '', ?, ?, UTC_TIMESTAMP(3))`,
-		eventID, entry.LayerID, entry.EntrySeq, string(entry.Op), entry.Path); err != nil {
+INSERT INTO fs_layer_events (`+s.scope.InsCols(`event_id, layer_id, seq, actor_id, op, path, created_at`)+`)
+VALUES (`+s.scope.InsVals(`?, ?, ?, '', ?, ?, UTC_TIMESTAMP(3)`)+`)`,
+		s.scope.Args(eventID, entry.LayerID, entry.EntrySeq, string(entry.Op), entry.Path)...); err != nil {
 		return fmt.Errorf("insert fs layer event %s:%s: %w", entry.LayerID, entry.Path, err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -629,9 +640,9 @@ SELECT layer_id, path, path_hash, parent_path, parent_path_hash, name, op, kind,
 	storage_type, storage_ref, storage_ref_hash, storage_encryption_mode, storage_encryption_key_id,
 	content_blob, content_type, content_text, checksum_sha256, size_bytes, mode, entry_seq, created_at, updated_at
 FROM fs_layer_entries
-WHERE layer_id = ? AND path_hash = ? AND path = ?
+WHERE `+s.scope.And(`layer_id = ? AND path_hash = ? AND path = ?`)+`
 ORDER BY entry_seq DESC
-LIMIT 1`, layerID, fsLayerPathHash(canonical), canonical)
+LIMIT 1`, s.scope.Args(layerID, fsLayerPathHash(canonical), canonical)...)
 	return scanFSLayerEntry(row)
 }
 
@@ -652,9 +663,9 @@ SELECT layer_id, path, path_hash, parent_path, parent_path_hash, name, op, kind,
 	storage_type, storage_ref, storage_ref_hash, storage_encryption_mode, storage_encryption_key_id,
 	content_blob, content_type, content_text, checksum_sha256, size_bytes, mode, entry_seq, created_at, updated_at
 FROM fs_layer_entries
-WHERE layer_id = ? AND path_hash = ? AND path = ? AND entry_seq <= ?
+WHERE `+s.scope.And(`layer_id = ? AND path_hash = ? AND path = ? AND entry_seq <= ?`)+`
 ORDER BY entry_seq DESC
-LIMIT 1`, layerID, fsLayerPathHash(canonical), canonical, maxSeq)
+LIMIT 1`, s.scope.Args(layerID, fsLayerPathHash(canonical), canonical, maxSeq)...)
 	return scanFSLayerEntry(row)
 }
 
@@ -678,12 +689,16 @@ func (s *Store) listFSLayerEntriesLatest(ctx context.Context, layerID string, ma
 	if layerID == "" {
 		return nil, fmt.Errorf("fs layer id is required")
 	}
-	where := "WHERE layer_id = ?"
-	args := []any{layerID}
+	where := "WHERE " + s.scope.And("layer_id = ?")
+	args := s.scope.Args(layerID)
 	if maxSeq != nil {
 		where += " AND entry_seq <= ?"
 		args = append(args, *maxSeq)
 	}
+	// Both the derived latest table and the outer fs_layer_entries alias get
+	// an fs_id predicate in shared shape: the same (layer_id, path) pair can
+	// exist under another fs_id, and an unfiltered MAX(entry_seq) could then
+	// hide this tenant's newest entry.
 	query := `
 SELECT e.layer_id, e.path, e.path_hash, e.parent_path, e.parent_path_hash, e.name, e.op, e.kind, e.base_inode_id, e.base_revision,
 	e.storage_type, e.storage_ref, e.storage_ref_hash, e.storage_encryption_mode, e.storage_encryption_key_id,
@@ -695,9 +710,9 @@ JOIN (
 		` + where + `
 		GROUP BY layer_id, path_hash, path
 	) latest ON latest.layer_id = e.layer_id AND latest.path_hash = e.path_hash AND latest.path = e.path AND latest.entry_seq = e.entry_seq
-WHERE e.layer_id = ?
+WHERE ` + s.scope.AndAs("e", "e.layer_id = ?") + `
 ORDER BY e.entry_seq, e.path`
-	args = append(args, layerID)
+	args = append(args, s.scope.Args(layerID)...)
 	rows, err := s.db.QueryContext(ctx, query, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list fs layer entries: %w", err)
@@ -735,14 +750,14 @@ func (s *Store) CreateFSLayerCheckpoint(ctx context.Context, checkpoint *FSLayer
 	}
 	defer func() { _ = tx.Rollback() }()
 	var existingLayerID string
-	if err := tx.QueryRowContext(ctx, `SELECT layer_id FROM fs_layers WHERE layer_id = ? FOR UPDATE`, checkpoint.LayerID).Scan(&existingLayerID); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT layer_id FROM fs_layers WHERE `+s.scope.And(`layer_id = ?`)+` FOR UPDATE`, s.scope.Args(checkpoint.LayerID)...).Scan(&existingLayerID); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
 		}
 		return fmt.Errorf("read fs layer %s: %w", checkpoint.LayerID, err)
 	}
 	var seq sql.NullInt64
-	if err := tx.QueryRowContext(ctx, `SELECT MAX(entry_seq) FROM fs_layer_entries WHERE layer_id = ?`, checkpoint.LayerID).Scan(&seq); err != nil {
+	if err := tx.QueryRowContext(ctx, `SELECT MAX(entry_seq) FROM fs_layer_entries WHERE `+s.scope.And(`layer_id = ?`), s.scope.Args(checkpoint.LayerID)...).Scan(&seq); err != nil {
 		return fmt.Errorf("read fs layer max seq: %w", err)
 	}
 	if seq.Valid {
@@ -751,15 +766,16 @@ func (s *Store) CreateFSLayerCheckpoint(ctx context.Context, checkpoint *FSLayer
 		checkpoint.DurableSeq = 0
 	}
 	_, err = tx.ExecContext(ctx, `
-INSERT INTO fs_layer_checkpoints (checkpoint_id, layer_id, durable_seq, label, created_at)
-VALUES (?, ?, ?, ?, UTC_TIMESTAMP(3))`,
-		checkpoint.CheckpointID, checkpoint.LayerID, checkpoint.DurableSeq, checkpoint.Label)
+INSERT INTO fs_layer_checkpoints (`+s.scope.InsCols(`checkpoint_id, layer_id, durable_seq, label, created_at`)+`)
+VALUES (`+s.scope.InsVals(`?, ?, ?, ?, UTC_TIMESTAMP(3)`)+`)`,
+		s.scope.Args(checkpoint.CheckpointID, checkpoint.LayerID, checkpoint.DurableSeq, checkpoint.Label)...)
 	if err != nil {
 		return fmt.Errorf("create fs layer checkpoint %s: %w", checkpoint.CheckpointID, err)
 	}
 	if _, err := tx.ExecContext(ctx, `
 UPDATE fs_layers SET durable_seq = GREATEST(durable_seq, ?), updated_at = UTC_TIMESTAMP(3)
-WHERE layer_id = ?`, checkpoint.DurableSeq, checkpoint.LayerID); err != nil {
+WHERE `+s.scope.And(`layer_id = ?`),
+		append([]any{checkpoint.DurableSeq}, s.scope.Args(checkpoint.LayerID)...)...); err != nil {
 		return fmt.Errorf("update fs layer durable seq %s: %w", checkpoint.LayerID, err)
 	}
 	if err := tx.Commit(); err != nil {
@@ -776,7 +792,7 @@ func (s *Store) GetFSLayerCheckpoint(ctx context.Context, checkpointID string) (
 	row := s.db.QueryRowContext(ctx, `
 SELECT checkpoint_id, layer_id, durable_seq, label, created_at
 FROM fs_layer_checkpoints
-WHERE checkpoint_id = ?`, checkpointID)
+WHERE `+s.scope.And(`checkpoint_id = ?`), s.scope.Args(checkpointID)...)
 	return scanFSLayerCheckpoint(row)
 }
 
@@ -791,9 +807,9 @@ func (s *Store) ListFSLayerEvents(ctx context.Context, layerID string, since int
 	rows, err := s.db.QueryContext(ctx, `
 SELECT event_id, layer_id, seq, actor_id, op, path, created_at
 FROM fs_layer_events
-WHERE layer_id = ? AND seq > ?
+WHERE `+s.scope.And(`layer_id = ? AND seq > ?`)+`
 ORDER BY seq ASC
-LIMIT ?`, layerID, since, limit)
+LIMIT ?`, s.scope.Args(layerID, since, limit)...)
 	if err != nil {
 		return nil, fmt.Errorf("list fs layer events %s: %w", layerID, err)
 	}
@@ -844,8 +860,8 @@ func (s *Store) listFSLayersByName(ctx context.Context, name string) ([]FSLayer,
 	rows, err := s.db.QueryContext(ctx, `
 SELECT layer_id, base_root_path, name, state, durability_mode, actor_id, durable_seq, created_at, updated_at, sealed_at
 FROM fs_layers
-WHERE name = ?
-ORDER BY updated_at DESC, layer_id`, name)
+WHERE `+s.scope.And(`name = ?`)+`
+ORDER BY updated_at DESC, layer_id`, s.scope.Args(name)...)
 	if err != nil {
 		return nil, fmt.Errorf("list fs layers by name: %w", err)
 	}
@@ -853,13 +869,26 @@ ORDER BY updated_at DESC, layer_id`, name)
 	return s.scanFSLayersWithTags(ctx, rows, "list fs layers by name")
 }
 
+// fsLayerJoinArgs prepends the two fs_id bind arguments used when a query
+// filters both fs_layer join aliases in shared shape; standalone shape
+// leaves args unchanged.
+func (s *Store) fsLayerJoinArgs(args ...any) []any {
+	if s.scope.Shared() {
+		return append([]any{s.scope.FsID(), s.scope.FsID()}, args...)
+	}
+	return args
+}
+
 func (s *Store) listFSLayersByTag(ctx context.Context, key, value string, hasValue bool) ([]FSLayer, error) {
+	// The same layer_id can exist under two fs_ids in shared shape, so both
+	// join aliases get an fs_id predicate: one-sided filtering could join a
+	// tag row to another tenant's layer row (or duplicate the result rows).
 	query := `
 SELECT l.layer_id, l.base_root_path, l.name, l.state, l.durability_mode, l.actor_id, l.durable_seq, l.created_at, l.updated_at, l.sealed_at
 FROM fs_layers l
 JOIN fs_layer_tags t ON t.layer_id = l.layer_id
-WHERE t.tag_key = ?`
-	args := []any{key}
+WHERE ` + s.scope.AndAs("l", s.scope.AndAs("t", "t.tag_key = ?"))
+	args := s.fsLayerJoinArgs(key)
 	if hasValue {
 		query += ` AND t.tag_value = ?`
 		args = append(args, value)
@@ -905,13 +934,13 @@ func (s *Store) loadFSLayerTags(ctx context.Context, layer *FSLayer) error {
 }
 
 func (s *Store) replaceFSLayerTagsTx(ctx context.Context, tx *sql.Tx, layerID string, tags map[string]string) error {
-	if _, err := tx.ExecContext(ctx, `DELETE FROM fs_layer_tags WHERE layer_id = ?`, layerID); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM fs_layer_tags WHERE `+s.scope.And(`layer_id = ?`), s.scope.Args(layerID)...); err != nil {
 		return fmt.Errorf("delete fs layer tags %s: %w", layerID, err)
 	}
 	for key, value := range tags {
 		if _, err := tx.ExecContext(ctx, `
-INSERT INTO fs_layer_tags (layer_id, tag_key, tag_value, created_at)
-VALUES (?, ?, ?, UTC_TIMESTAMP(3))`, layerID, key, value); err != nil {
+INSERT INTO fs_layer_tags (`+s.scope.InsCols(`layer_id, tag_key, tag_value, created_at`)+`)
+VALUES (`+s.scope.InsVals(`?, ?, ?, UTC_TIMESTAMP(3)`)+`)`, s.scope.Args(layerID, key, value)...); err != nil {
 			return fmt.Errorf("insert fs layer tag %s:%s: %w", layerID, key, err)
 		}
 	}

--- a/pkg/datastore/fs_layer_shared_test.go
+++ b/pkg/datastore/fs_layer_shared_test.go
@@ -1,0 +1,425 @@
+package datastore
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"testing"
+)
+
+// runFSLayerCoreScenario exercises the fs layer flow (create, tags, ref
+// resolution, state transitions, entries, checkpoints, events, rollback)
+// against a store. It is run against both schema shapes to prove parity.
+func runFSLayerCoreScenario(t *testing.T, store *Store, prefix string) {
+	t.Helper()
+	ctx := context.Background()
+
+	// Layer round trip with tags and name/tag ref resolution.
+	layer := FSLayer{
+		LayerID:        prefix + "-layer-1",
+		BaseRootPath:   "/work",
+		Name:           prefix + " agent task",
+		Tags:           map[string]string{"task": "auth", "env": "dev"},
+		DurabilityMode: FSLayerDurabilityRestoreSafe,
+		ActorID:        "actor-1",
+	}
+	if err := store.CreateFSLayer(ctx, &layer); err != nil {
+		t.Fatalf("CreateFSLayer: %v", err)
+	}
+	got, err := store.GetFSLayer(ctx, prefix+"-layer-1")
+	if err != nil {
+		t.Fatalf("GetFSLayer: %v", err)
+	}
+	if got.BaseRootPath != "/work/" || got.Name != prefix+" agent task" || got.State != FSLayerStateActive || got.ActorID != "actor-1" {
+		t.Fatalf("unexpected layer: %+v", got)
+	}
+	if got.Tags["task"] != "auth" || got.Tags["env"] != "dev" {
+		t.Fatalf("unexpected layer tags: %+v", got.Tags)
+	}
+	for _, ref := range []string{prefix + " agent task", "task=auth", "tag:env"} {
+		byRef, err := store.ResolveFSLayerRef(ctx, ref)
+		if err != nil {
+			t.Fatalf("ResolveFSLayerRef %q: %v", ref, err)
+		}
+		if byRef.LayerID != prefix+"-layer-1" {
+			t.Fatalf("ResolveFSLayerRef %q = %+v, want %s", ref, byRef, prefix+"-layer-1")
+		}
+	}
+	layers, err := store.ListFSLayers(ctx)
+	if err != nil {
+		t.Fatalf("ListFSLayers: %v", err)
+	}
+	if len(layers) != 1 || layers[0].LayerID != prefix+"-layer-1" {
+		t.Fatalf("layers = %+v, want only %s", layers, prefix+"-layer-1")
+	}
+	if err := store.SetFSLayerState(ctx, prefix+"-layer-1", FSLayerStateSealed); err != nil {
+		t.Fatalf("SetFSLayerState: %v", err)
+	}
+	got, err = store.GetFSLayer(ctx, prefix+"-layer-1")
+	if err != nil {
+		t.Fatalf("GetFSLayer sealed: %v", err)
+	}
+	if got.State != FSLayerStateSealed || got.SealedAt == nil {
+		t.Fatalf("sealed layer = %+v, want sealed with sealed_at", got)
+	}
+
+	// Entries and checkpoints on a second layer.
+	entriesLayer := prefix + "-layer-entries"
+	if err := store.CreateFSLayer(ctx, &FSLayer{LayerID: entriesLayer, BaseRootPath: "/repo"}); err != nil {
+		t.Fatalf("CreateFSLayer entries: %v", err)
+	}
+	if err := store.UpsertFSLayerEntry(ctx, &FSLayerEntry{LayerID: entriesLayer, Path: "/repo/tmp", Op: FSLayerEntryOpMkdir}); err != nil {
+		t.Fatalf("UpsertFSLayerEntry dir: %v", err)
+	}
+	if err := store.UpsertFSLayerEntry(ctx, &FSLayerEntry{LayerID: entriesLayer, Path: "/repo/tmp/link", Op: FSLayerEntryOpSymlink, ContentText: "/repo/tmp/a.txt"}); err != nil {
+		t.Fatalf("UpsertFSLayerEntry symlink: %v", err)
+	}
+	if err := store.UpsertFSLayerEntry(ctx, &FSLayerEntry{LayerID: entriesLayer, Path: "/repo/tmp/a.txt", Op: FSLayerEntryOpUpsert, Kind: FSLayerEntryKindFile, ContentBlob: []byte("hello"), ContentType: "text/plain", SizeBytes: 5}); err != nil {
+		t.Fatalf("UpsertFSLayerEntry file: %v", err)
+	}
+	gotDir, err := store.GetFSLayerEntry(ctx, entriesLayer, "/repo/tmp/")
+	if err != nil {
+		t.Fatalf("GetFSLayerEntry dir: %v", err)
+	}
+	if gotDir.Path != "/repo/tmp/" || gotDir.Kind != FSLayerEntryKindDir || gotDir.Mode != 0o755 {
+		t.Fatalf("dir entry = %+v", gotDir)
+	}
+	gotFile, err := store.GetFSLayerEntry(ctx, entriesLayer, "/repo/tmp/a.txt")
+	if err != nil {
+		t.Fatalf("GetFSLayerEntry file: %v", err)
+	}
+	if gotFile.EntrySeq != 3 || !bytes.Equal(gotFile.ContentBlob, []byte("hello")) || gotFile.ParentPath != "/repo/tmp/" {
+		t.Fatalf("file entry = %+v", gotFile)
+	}
+	entries, err := store.ListFSLayerEntries(ctx, entriesLayer)
+	if err != nil {
+		t.Fatalf("ListFSLayerEntries: %v", err)
+	}
+	if len(entries) != 3 || entries[0].Path != "/repo/tmp/" || entries[1].Path != "/repo/tmp/link" || entries[2].Path != "/repo/tmp/a.txt" {
+		t.Fatalf("entries = %+v", entries)
+	}
+	checkpoint := FSLayerCheckpoint{CheckpointID: prefix + "-ckpt-1", LayerID: entriesLayer, Label: "restore point"}
+	if err := store.CreateFSLayerCheckpoint(ctx, &checkpoint); err != nil {
+		t.Fatalf("CreateFSLayerCheckpoint: %v", err)
+	}
+	gotCheckpoint, err := store.GetFSLayerCheckpoint(ctx, prefix+"-ckpt-1")
+	if err != nil {
+		t.Fatalf("GetFSLayerCheckpoint: %v", err)
+	}
+	if gotCheckpoint.DurableSeq != 3 || gotCheckpoint.Label != "restore point" {
+		t.Fatalf("checkpoint = %+v, want durable_seq=3", gotCheckpoint)
+	}
+	gotLayer, err := store.GetFSLayer(ctx, entriesLayer)
+	if err != nil {
+		t.Fatalf("GetFSLayer entries: %v", err)
+	}
+	if gotLayer.DurableSeq != 3 {
+		t.Fatalf("layer durable_seq=%d, want 3", gotLayer.DurableSeq)
+	}
+	if err := store.UpsertFSLayerEntry(ctx, &FSLayerEntry{LayerID: entriesLayer, Path: "/repo/tmp/a.txt", Op: FSLayerEntryOpUpsert, Kind: FSLayerEntryKindFile, ContentBlob: []byte("goodbye"), ContentType: "text/plain", SizeBytes: 7}); err != nil {
+		t.Fatalf("UpsertFSLayerEntry file v2: %v", err)
+	}
+	current, err := store.GetFSLayerEntry(ctx, entriesLayer, "/repo/tmp/a.txt")
+	if err != nil {
+		t.Fatalf("GetFSLayerEntry current: %v", err)
+	}
+	if current.EntrySeq != 4 || !bytes.Equal(current.ContentBlob, []byte("goodbye")) {
+		t.Fatalf("current entry = %+v", current)
+	}
+	logEntries, err := store.ListFSLayerEntryLog(ctx, entriesLayer)
+	if err != nil {
+		t.Fatalf("ListFSLayerEntryLog: %v", err)
+	}
+	if len(logEntries) != 4 || logEntries[0].EntrySeq != 1 || logEntries[3].EntrySeq != 4 {
+		t.Fatalf("log entries = %+v, want full ordered log", logEntries)
+	}
+	atCheckpoint, err := store.GetFSLayerEntryAtSeq(ctx, entriesLayer, "/repo/tmp/a.txt", gotCheckpoint.DurableSeq)
+	if err != nil {
+		t.Fatalf("GetFSLayerEntryAtSeq: %v", err)
+	}
+	if atCheckpoint.EntrySeq != 3 || !bytes.Equal(atCheckpoint.ContentBlob, []byte("hello")) {
+		t.Fatalf("checkpoint entry = %+v, want seq=3 hello", atCheckpoint)
+	}
+	checkpointEntries, err := store.ListFSLayerEntriesAtSeq(ctx, entriesLayer, gotCheckpoint.DurableSeq)
+	if err != nil {
+		t.Fatalf("ListFSLayerEntriesAtSeq: %v", err)
+	}
+	if len(checkpointEntries) != 3 || checkpointEntries[2].EntrySeq != 3 || !bytes.Equal(checkpointEntries[2].ContentBlob, []byte("hello")) {
+		t.Fatalf("checkpoint entries = %+v", checkpointEntries)
+	}
+	checkpointLog, err := store.ListFSLayerEntryLogAtSeq(ctx, entriesLayer, gotCheckpoint.DurableSeq)
+	if err != nil {
+		t.Fatalf("ListFSLayerEntryLogAtSeq: %v", err)
+	}
+	if len(checkpointLog) != 3 || checkpointLog[0].EntrySeq != 1 || checkpointLog[2].EntrySeq != 3 {
+		t.Fatalf("checkpoint log = %+v, want ordered entries through checkpoint", checkpointLog)
+	}
+
+	// Rollback emits a synthetic event once; a repeated rollback is a no-op.
+	rollbackLayer := prefix + "-layer-rb"
+	if err := store.CreateFSLayer(ctx, &FSLayer{LayerID: rollbackLayer, BaseRootPath: "/repo"}); err != nil {
+		t.Fatalf("CreateFSLayer rollback: %v", err)
+	}
+	if err := store.UpsertFSLayerEntry(ctx, &FSLayerEntry{LayerID: rollbackLayer, Path: "/repo/a.txt", Op: FSLayerEntryOpUpsert, Kind: FSLayerEntryKindFile, ContentBlob: []byte("data")}); err != nil {
+		t.Fatalf("UpsertFSLayerEntry rollback layer: %v", err)
+	}
+	priorEvents, err := store.ListFSLayerEvents(ctx, rollbackLayer, 0, 1000)
+	if err != nil {
+		t.Fatalf("ListFSLayerEvents before rollback: %v", err)
+	}
+	if len(priorEvents) != 1 || priorEvents[0].Op != "upsert" {
+		t.Fatalf("prior events = %+v, want 1 upsert event", priorEvents)
+	}
+	if err := store.RollbackFSLayer(ctx, rollbackLayer); err != nil {
+		t.Fatalf("RollbackFSLayer: %v", err)
+	}
+	events, err := store.ListFSLayerEvents(ctx, rollbackLayer, 0, 1000)
+	if err != nil {
+		t.Fatalf("ListFSLayerEvents after rollback: %v", err)
+	}
+	if len(events) != 2 || events[1].Op != "rollback" || events[1].Seq <= priorEvents[0].Seq {
+		t.Fatalf("events after rollback = %+v, want upsert then rollback with increasing seq", events)
+	}
+	if err := store.RollbackFSLayer(ctx, rollbackLayer); err != nil {
+		t.Fatalf("RollbackFSLayer idempotent: %v", err)
+	}
+	events2, err := store.ListFSLayerEvents(ctx, rollbackLayer, 0, 1000)
+	if err != nil {
+		t.Fatalf("ListFSLayerEvents after idempotent rollback: %v", err)
+	}
+	if len(events2) != len(events) {
+		t.Fatalf("events after idempotent rollback = %d, want %d (no re-emit)", len(events2), len(events))
+	}
+	rolledBack, err := store.GetFSLayer(ctx, rollbackLayer)
+	if err != nil {
+		t.Fatalf("GetFSLayer after rollback: %v", err)
+	}
+	if rolledBack.State != FSLayerStateAbandoned || rolledBack.SealedAt == nil {
+		t.Fatalf("rollback layer = %+v, want abandoned with sealed_at", rolledBack)
+	}
+
+	// State transition conflicts.
+	commitLayer := prefix + "-layer-commit"
+	if err := store.CreateFSLayer(ctx, &FSLayer{LayerID: commitLayer, BaseRootPath: "/repo"}); err != nil {
+		t.Fatalf("CreateFSLayer commit: %v", err)
+	}
+	if err := store.BeginFSLayerCommit(ctx, commitLayer); err != nil {
+		t.Fatalf("BeginFSLayerCommit: %v", err)
+	}
+	if err := store.BeginFSLayerCommit(ctx, commitLayer); !errors.Is(err, ErrFSLayerStateConflict) {
+		t.Fatalf("BeginFSLayerCommit reentry err=%v, want ErrFSLayerStateConflict", err)
+	}
+	if err := store.UpsertFSLayerEntry(ctx, &FSLayerEntry{LayerID: commitLayer, Path: "/repo/late.txt", Op: FSLayerEntryOpUpsert, Kind: FSLayerEntryKindFile, ContentBlob: []byte("late")}); !errors.Is(err, ErrFSLayerStateConflict) {
+		t.Fatalf("UpsertFSLayerEntry committing err=%v, want ErrFSLayerStateConflict", err)
+	}
+	if err := store.SetFSLayerStateIf(ctx, commitLayer, []FSLayerState{FSLayerStateActive}, FSLayerStateSealed); !errors.Is(err, ErrFSLayerStateConflict) {
+		t.Fatalf("SetFSLayerStateIf err=%v, want ErrFSLayerStateConflict", err)
+	}
+}
+
+// TestFSLayerSharedShapeParity runs the same scenario used by the standalone
+// fs layer tests against the shared (fs_id) schema shape.
+func TestFSLayerSharedShapeParity(t *testing.T) {
+	installSharedFSLayerSchema(t)
+	store := newSharedStore(t, 4301001)
+	runFSLayerCoreScenario(t, store, "shr")
+}
+
+// TestFSLayerSharedShapeCrossTenantIsolation proves fs layer rows of one
+// fs_id are invisible to another fs_id, and that the same layer_id (plus
+// entry paths, event seqs, and checkpoint ids) can coexist under both fs_ids.
+func TestFSLayerSharedShapeCrossTenantIsolation(t *testing.T) {
+	installSharedFSLayerSchema(t)
+	ctx := context.Background()
+	storeA := newSharedStore(t, 4301002)
+	storeB := newSharedStore(t, 4301003)
+
+	// Same layer_id under both fs_ids must coexist.
+	if err := storeA.CreateFSLayer(ctx, &FSLayer{
+		LayerID:      "layer-iso",
+		BaseRootPath: "/work",
+		Name:         "alpha",
+		Tags:         map[string]string{"shared": "yes", "env": "a"},
+	}); err != nil {
+		t.Fatalf("CreateFSLayer A: %v", err)
+	}
+	if err := storeB.CreateFSLayer(ctx, &FSLayer{
+		LayerID:      "layer-iso",
+		BaseRootPath: "/work",
+		Name:         "beta",
+		Tags:         map[string]string{"shared": "yes", "env": "b"},
+	}); err != nil {
+		t.Fatalf("CreateFSLayer B: %v", err)
+	}
+	gotA, err := storeA.GetFSLayer(ctx, "layer-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotB, err := storeB.GetFSLayer(ctx, "layer-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotA.Name != "alpha" || gotB.Name != "beta" || gotA.Tags["env"] != "a" || gotB.Tags["env"] != "b" {
+		t.Fatalf("cross-tenant layers mixed up: A=%+v B=%+v", gotA, gotB)
+	}
+	layersA, err := storeA.ListFSLayers(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	layersB, err := storeB.ListFSLayers(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(layersA) != 1 || layersA[0].Name != "alpha" || len(layersB) != 1 || layersB[0].Name != "beta" {
+		t.Fatalf("list leaks across fs_id: A=%+v B=%+v", layersA, layersB)
+	}
+
+	// Name and tag refs resolve within the fs_id only. The shared=yes tag
+	// exists on BOTH layers: resolving it must return exactly the caller's
+	// own layer (not an ambiguous match across the join).
+	for _, tc := range []struct {
+		store   *Store
+		name    string
+		wantRef string
+		wantErr bool
+	}{
+		{storeA, "A by name", "alpha", false},
+		{storeB, "B by foreign name", "alpha", true},
+		{storeA, "A by own tag", "env=a", false},
+		{storeA, "A by foreign tag", "env=b", true},
+		{storeA, "A by colliding tag", "shared=yes", false},
+		{storeB, "B by colliding tag", "shared=yes", false},
+	} {
+		got, err := tc.store.ResolveFSLayerRef(ctx, tc.wantRef)
+		if tc.wantErr {
+			if !errors.Is(err, ErrNotFound) {
+				t.Fatalf("%s: ResolveFSLayerRef %q err=%v, want ErrNotFound", tc.name, tc.wantRef, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Fatalf("%s: ResolveFSLayerRef %q: %v", tc.name, tc.wantRef, err)
+		}
+		if got.LayerID != "layer-iso" {
+			t.Fatalf("%s: ResolveFSLayerRef %q = %+v, want layer-iso", tc.name, tc.wantRef, got)
+		}
+	}
+
+	// Entries and events never cross fs_id.
+	if err := storeA.UpsertFSLayerEntry(ctx, &FSLayerEntry{
+		LayerID: "layer-iso", Path: "/work/a.txt", Op: FSLayerEntryOpUpsert,
+		Kind: FSLayerEntryKindFile, ContentBlob: []byte("a-data"),
+	}); err != nil {
+		t.Fatalf("UpsertFSLayerEntry A: %v", err)
+	}
+	entriesA, err := storeA.ListFSLayerEntries(ctx, "layer-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entriesA) != 1 || entriesA[0].Path != "/work/a.txt" {
+		t.Fatalf("A entries = %+v", entriesA)
+	}
+	entriesB, err := storeB.ListFSLayerEntries(ctx, "layer-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entriesB) != 0 {
+		t.Fatalf("B sees %d entries, want 0 (cross-tenant leak)", len(entriesB))
+	}
+	if _, err := storeB.GetFSLayerEntry(ctx, "layer-iso", "/work/a.txt"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("B GetFSLayerEntry err=%v, want ErrNotFound", err)
+	}
+	eventsA, err := storeA.ListFSLayerEvents(ctx, "layer-iso", 0, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	eventsB, err := storeB.ListFSLayerEvents(ctx, "layer-iso", 0, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(eventsA) != 1 || len(eventsB) != 0 {
+		t.Fatalf("event leak: A=%+v B=%+v", eventsA, eventsB)
+	}
+
+	// Same checkpoint_id under both fs_ids coexists with independent seqs.
+	if err := storeA.CreateFSLayerCheckpoint(ctx, &FSLayerCheckpoint{CheckpointID: "ckpt-iso", LayerID: "layer-iso"}); err != nil {
+		t.Fatalf("CreateFSLayerCheckpoint A: %v", err)
+	}
+	if err := storeB.CreateFSLayerCheckpoint(ctx, &FSLayerCheckpoint{CheckpointID: "ckpt-iso", LayerID: "layer-iso"}); err != nil {
+		t.Fatalf("CreateFSLayerCheckpoint B: %v", err)
+	}
+	ckptA, err := storeA.GetFSLayerCheckpoint(ctx, "ckpt-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	ckptB, err := storeB.GetFSLayerCheckpoint(ctx, "ckpt-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ckptA.DurableSeq != 1 || ckptB.DurableSeq != 0 {
+		t.Fatalf("checkpoints mixed up: A=%+v B=%+v", ckptA, ckptB)
+	}
+
+	// State changes and rollback stay inside the fs_id.
+	if err := storeB.SetFSLayerState(ctx, "layer-iso", FSLayerStateSealed); err != nil {
+		t.Fatalf("SetFSLayerState B: %v", err)
+	}
+	if err := storeB.RollbackFSLayer(ctx, "layer-iso"); err != nil {
+		t.Fatalf("RollbackFSLayer B: %v", err)
+	}
+	gotB, err = storeB.GetFSLayer(ctx, "layer-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotB.State != FSLayerStateAbandoned {
+		t.Fatalf("B layer state=%q, want abandoned", gotB.State)
+	}
+	gotA, err = storeA.GetFSLayer(ctx, "layer-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotA.State != FSLayerStateActive {
+		t.Fatalf("A layer state=%q, want active (untouched by B)", gotA.State)
+	}
+	eventsA, err = storeA.ListFSLayerEvents(ctx, "layer-iso", 0, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(eventsA) != 1 || eventsA[0].Op != "upsert" {
+		t.Fatalf("A events changed by B's rollback: %+v", eventsA)
+	}
+	eventsB, err = storeB.ListFSLayerEvents(ctx, "layer-iso", 0, 1000)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(eventsB) != 1 || eventsB[0].Op != "rollback" {
+		t.Fatalf("B events = %+v, want one rollback event", eventsB)
+	}
+}
+
+// TestFSLayerSharedShapeStoresFsID asserts every fs layer table row written
+// by the core scenario carries the scope's fs_id as its row key.
+func TestFSLayerSharedShapeStoresFsID(t *testing.T) {
+	installSharedFSLayerSchema(t)
+	const fsID int64 = 4301004
+	store := newSharedStore(t, fsID)
+	runFSLayerCoreScenario(t, store, "fsid")
+
+	for _, tbl := range []string{"fs_layers", "fs_layer_tags", "fs_layer_entries", "fs_layer_events", "fs_layer_checkpoints"} {
+		var got int64
+		err := store.DB().QueryRow("SELECT COUNT(*) FROM "+tbl+" WHERE fs_id != ?", fsID).Scan(&got)
+		if err != nil {
+			t.Fatalf("count %s rows with foreign fs_id: %v", tbl, err)
+		}
+		if got != 0 {
+			t.Fatalf("%s has %d rows with fs_id != %d", tbl, got, fsID)
+		}
+		var total int64
+		if err := store.DB().QueryRow("SELECT COUNT(*) FROM " + tbl).Scan(&total); err != nil {
+			t.Fatalf("count %s: %v", tbl, err)
+		}
+		if total == 0 {
+			t.Fatalf("%s is empty; scenario should have written rows", tbl)
+		}
+	}
+}

--- a/pkg/datastore/git_shared_test.go
+++ b/pkg/datastore/git_shared_test.go
@@ -1,0 +1,429 @@
+package datastore
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// runGitWorkspaceCoreScenario exercises the git workspace flow (workspace
+// upsert/ODKU, lookup by id and root, tree nodes, git state, object packs,
+// overlay entries, soft delete) against a store. It is run against both
+// schema shapes to prove behavioral parity.
+func runGitWorkspaceCoreScenario(t *testing.T, store *Store, prefix string) {
+	t.Helper()
+	ctx := context.Background()
+	sha1 := strings.Repeat("1", 40)
+	sha2 := strings.Repeat("2", 40)
+	wsID := prefix + "-ws"
+	root := "/" + prefix + "-repo/"
+
+	ws := GitWorkspace{
+		WorkspaceID: wsID,
+		RootPath:    root,
+		RepoURL:     "https://github.com/example/repo.git",
+		BranchName:  "main",
+		BaseCommit:  sha1,
+		HeadCommit:  sha1,
+		Mode:        GitWorkspaceModeFast,
+		Kind:        GitWorkspaceKindMain,
+	}
+	if err := store.UpsertGitWorkspace(ctx, ws); err != nil {
+		t.Fatalf("UpsertGitWorkspace: %v", err)
+	}
+	got, err := store.GetGitWorkspace(ctx, wsID)
+	if err != nil {
+		t.Fatalf("GetGitWorkspace: %v", err)
+	}
+	if got.RootPath != root || got.BranchName != "main" || got.HeadCommit != sha1 ||
+		got.Mode != GitWorkspaceModeFast || got.Kind != GitWorkspaceKindMain || got.Status != GitWorkspaceStatusLive {
+		t.Fatalf("unexpected workspace: %+v", got)
+	}
+	// Upsert again to exercise the ON DUPLICATE KEY UPDATE branch.
+	ws.HeadCommit = sha2
+	ws.BranchName = "feature"
+	if err := store.UpsertGitWorkspace(ctx, ws); err != nil {
+		t.Fatalf("UpsertGitWorkspace update: %v", err)
+	}
+	got, err = store.GetGitWorkspace(ctx, wsID)
+	if err != nil {
+		t.Fatalf("GetGitWorkspace after update: %v", err)
+	}
+	if got.HeadCommit != sha2 || got.BranchName != "feature" {
+		t.Fatalf("workspace after ODKU = %+v", got)
+	}
+	byRoot, err := store.GetGitWorkspaceByRoot(ctx, "/"+prefix+"-repo")
+	if err != nil {
+		t.Fatalf("GetGitWorkspaceByRoot: %v", err)
+	}
+	if byRoot.WorkspaceID != wsID {
+		t.Fatalf("GetGitWorkspaceByRoot = %+v, want %s", byRoot, wsID)
+	}
+	list, err := store.ListGitWorkspaces(ctx)
+	if err != nil {
+		t.Fatalf("ListGitWorkspaces: %v", err)
+	}
+	if len(list) != 1 || list[0].WorkspaceID != wsID {
+		t.Fatalf("workspaces = %+v, want only %s", list, wsID)
+	}
+
+	// Tree nodes are replaced per (workspace, commit).
+	nodes := []GitTreeNode{
+		{Path: "a.txt", Kind: GitTreeNodeKindFile, Mode: "100644", ObjectSHA: sha1, SizeBytes: 3},
+		{Path: "dir/b.txt", Kind: GitTreeNodeKindFile, Mode: "100644", ObjectSHA: sha2, SizeBytes: 5},
+	}
+	if err := store.ReplaceGitTreeNodes(ctx, wsID, sha1, nodes); err != nil {
+		t.Fatalf("ReplaceGitTreeNodes: %v", err)
+	}
+	tree, err := store.ListGitTreeNodes(ctx, wsID, sha1)
+	if err != nil {
+		t.Fatalf("ListGitTreeNodes: %v", err)
+	}
+	if len(tree) != 2 || tree[0].Path != "a.txt" || tree[1].Path != "dir/b.txt" {
+		t.Fatalf("tree = %+v", tree)
+	}
+	if tree[1].ParentPath != "dir" || tree[1].Name != "b.txt" || tree[1].WorkspaceID != wsID || tree[1].CommitSHA != sha1 {
+		t.Fatalf("tree node = %+v", tree[1])
+	}
+	if err := store.ReplaceGitTreeNodes(ctx, wsID, sha1, []GitTreeNode{
+		{Path: "c.txt", Kind: GitTreeNodeKindFile, Mode: "100644", ObjectSHA: sha1, SizeBytes: 1},
+	}); err != nil {
+		t.Fatalf("ReplaceGitTreeNodes second: %v", err)
+	}
+	tree, err = store.ListGitTreeNodes(ctx, wsID, sha1)
+	if err != nil {
+		t.Fatalf("ListGitTreeNodes second: %v", err)
+	}
+	if len(tree) != 1 || tree[0].Path != "c.txt" {
+		t.Fatalf("tree after replace = %+v, want only c.txt", tree)
+	}
+
+	// Git state round trip plus ODKU update.
+	stateBlob := []byte("state-blob")
+	if err := store.UpsertGitState(ctx, GitState{
+		WorkspaceID: wsID, CheckpointCommit: sha1, StorageType: "db9",
+		StorageRef: prefix + "-state-1", ChecksumSHA256: "sum1",
+		SizeBytes: int64(len(stateBlob)), ContentBlob: stateBlob,
+	}); err != nil {
+		t.Fatalf("UpsertGitState: %v", err)
+	}
+	state, err := store.GetGitState(ctx, wsID)
+	if err != nil {
+		t.Fatalf("GetGitState: %v", err)
+	}
+	if state.StorageRef != prefix+"-state-1" || !bytes.Equal(state.ContentBlob, stateBlob) {
+		t.Fatalf("git state = %+v", state)
+	}
+	if err := store.UpsertGitState(ctx, GitState{WorkspaceID: wsID, CheckpointCommit: sha2, StorageType: "db9", StorageRef: prefix + "-state-2"}); err != nil {
+		t.Fatalf("UpsertGitState update: %v", err)
+	}
+	state, err = store.GetGitState(ctx, wsID)
+	if err != nil {
+		t.Fatalf("GetGitState after update: %v", err)
+	}
+	if state.StorageRef != prefix+"-state-2" || state.CheckpointCommit != sha2 {
+		t.Fatalf("git state after ODKU = %+v", state)
+	}
+
+	// Object pack round trip; listing returns metadata only.
+	packBlob := []byte("PACK test")
+	if err := store.UpsertGitObjectPack(ctx, GitObjectPack{
+		WorkspaceID: wsID, PackID: prefix + "-pack-1", ChecksumSHA256: "psum",
+		SizeBytes: int64(len(packBlob)), ContentBlob: packBlob,
+	}); err != nil {
+		t.Fatalf("UpsertGitObjectPack: %v", err)
+	}
+	pack, err := store.GetGitObjectPack(ctx, wsID, prefix+"-pack-1")
+	if err != nil {
+		t.Fatalf("GetGitObjectPack: %v", err)
+	}
+	if pack.ChecksumSHA256 != "psum" || pack.SizeBytes != int64(len(packBlob)) || !bytes.Equal(pack.ContentBlob, packBlob) {
+		t.Fatalf("pack = %+v", pack)
+	}
+	packs, err := store.ListGitObjectPacks(ctx, wsID)
+	if err != nil {
+		t.Fatalf("ListGitObjectPacks: %v", err)
+	}
+	if len(packs) != 1 || packs[0].PackID != prefix+"-pack-1" || len(packs[0].ContentBlob) != 0 {
+		t.Fatalf("listed packs = %+v, want metadata only", packs)
+	}
+
+	// Overlay entries round trip plus ODKU update.
+	overlayBlob := []byte("dirty")
+	if err := store.UpsertGitOverlayEntry(ctx, GitOverlayEntry{
+		WorkspaceID: wsID, Path: "dirty.txt", Op: GitOverlayOpUpsert, Kind: GitOverlayKindFile,
+		Mode: "100644", StorageType: "db9", StorageRef: prefix + "-ov-1",
+		SizeBytes: int64(len(overlayBlob)), ContentBlob: overlayBlob,
+	}); err != nil {
+		t.Fatalf("UpsertGitOverlayEntry: %v", err)
+	}
+	entry, err := store.GetGitOverlayEntry(ctx, wsID, "dirty.txt")
+	if err != nil {
+		t.Fatalf("GetGitOverlayEntry: %v", err)
+	}
+	if entry.StorageRef != prefix+"-ov-1" || entry.Op != GitOverlayOpUpsert || !bytes.Equal(entry.ContentBlob, overlayBlob) {
+		t.Fatalf("overlay entry = %+v", entry)
+	}
+	if err := store.UpsertGitOverlayEntry(ctx, GitOverlayEntry{
+		WorkspaceID: wsID, Path: "dirty.txt", Op: GitOverlayOpChmod, Kind: GitOverlayKindFile,
+		Mode: "100755", StorageType: "db9", StorageRef: prefix + "-ov-2",
+	}); err != nil {
+		t.Fatalf("UpsertGitOverlayEntry update: %v", err)
+	}
+	entry, err = store.GetGitOverlayEntry(ctx, wsID, "dirty.txt")
+	if err != nil {
+		t.Fatalf("GetGitOverlayEntry after update: %v", err)
+	}
+	if entry.StorageRef != prefix+"-ov-2" || entry.Op != GitOverlayOpChmod || entry.Mode != "100755" {
+		t.Fatalf("overlay entry after ODKU = %+v", entry)
+	}
+	entries, err := store.ListGitOverlayEntries(ctx, wsID)
+	if err != nil {
+		t.Fatalf("ListGitOverlayEntries: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Path != "dirty.txt" {
+		t.Fatalf("overlay entries = %+v", entries)
+	}
+
+	// Soft delete hides the workspace from listings while the row stays
+	// readable with deleted status.
+	if err := store.DeleteGitWorkspace(ctx, wsID); err != nil {
+		t.Fatalf("DeleteGitWorkspace: %v", err)
+	}
+	list, err = store.ListGitWorkspaces(ctx)
+	if err != nil {
+		t.Fatalf("ListGitWorkspaces after delete: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("workspaces after delete = %+v, want empty", list)
+	}
+	got, err = store.GetGitWorkspace(ctx, wsID)
+	if err != nil {
+		t.Fatalf("GetGitWorkspace after delete: %v", err)
+	}
+	if got.Status != GitWorkspaceStatusDeleted {
+		t.Fatalf("workspace status=%q, want %q", got.Status, GitWorkspaceStatusDeleted)
+	}
+}
+
+// TestGitSharedShapeParity runs the same scenario used by the standalone git
+// workspace tests against the shared (fs_id) schema shape.
+func TestGitSharedShapeParity(t *testing.T) {
+	installSharedGitSchema(t)
+	store := newSharedStore(t, 4302001)
+	runGitWorkspaceCoreScenario(t, store, "shr")
+}
+
+// TestGitSharedShapeCrossTenantIsolation proves git workspace rows of one
+// fs_id are invisible to another fs_id, and that the same workspace_id,
+// root_path, commit sha, pack_id, and overlay path can coexist under both
+// fs_ids.
+func TestGitSharedShapeCrossTenantIsolation(t *testing.T) {
+	installSharedGitSchema(t)
+	ctx := context.Background()
+	storeA := newSharedStore(t, 4302002)
+	storeB := newSharedStore(t, 4302003)
+	sha1 := strings.Repeat("1", 40)
+	sha2 := strings.Repeat("2", 40)
+
+	// Same workspace_id and root_path under both fs_ids must coexist.
+	for _, tc := range []struct {
+		store  *Store
+		branch string
+		head   string
+	}{
+		{storeA, "main-a", sha1},
+		{storeB, "main-b", sha2},
+	} {
+		if err := tc.store.UpsertGitWorkspace(ctx, GitWorkspace{
+			WorkspaceID: "ws-iso",
+			RootPath:    "/repo-iso/",
+			RepoURL:     "https://github.com/example/repo.git",
+			BranchName:  tc.branch,
+			BaseCommit:  sha1,
+			HeadCommit:  tc.head,
+		}); err != nil {
+			t.Fatalf("UpsertGitWorkspace %s: %v", tc.branch, err)
+		}
+	}
+	gotA, err := storeA.GetGitWorkspace(ctx, "ws-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotB, err := storeB.GetGitWorkspace(ctx, "ws-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotA.BranchName != "main-a" || gotB.BranchName != "main-b" {
+		t.Fatalf("cross-tenant workspaces mixed up: A=%+v B=%+v", gotA, gotB)
+	}
+	byRoot, err := storeA.GetGitWorkspaceByRoot(ctx, "/repo-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if byRoot.BranchName != "main-a" {
+		t.Fatalf("GetGitWorkspaceByRoot A = %+v, want branch main-a", byRoot)
+	}
+	listA, err := storeA.ListGitWorkspaces(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	listB, err := storeB.ListGitWorkspaces(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listA) != 1 || listA[0].BranchName != "main-a" || len(listB) != 1 || listB[0].BranchName != "main-b" {
+		t.Fatalf("list leaks across fs_id: A=%+v B=%+v", listA, listB)
+	}
+
+	// Tree nodes with the same (workspace, commit, path) key coexist per
+	// fs_id and replace independently.
+	if err := storeA.ReplaceGitTreeNodes(ctx, "ws-iso", sha1, []GitTreeNode{
+		{Path: "a-only.txt", Kind: GitTreeNodeKindFile, Mode: "100644", ObjectSHA: sha1},
+		{Path: "shared.txt", Kind: GitTreeNodeKindFile, Mode: "100644", ObjectSHA: sha1},
+	}); err != nil {
+		t.Fatalf("ReplaceGitTreeNodes A: %v", err)
+	}
+	if err := storeB.ReplaceGitTreeNodes(ctx, "ws-iso", sha1, []GitTreeNode{
+		{Path: "b-only.txt", Kind: GitTreeNodeKindFile, Mode: "100644", ObjectSHA: sha2},
+		{Path: "shared.txt", Kind: GitTreeNodeKindFile, Mode: "100644", ObjectSHA: sha2},
+	}); err != nil {
+		t.Fatalf("ReplaceGitTreeNodes B: %v", err)
+	}
+	treeA, err := storeA.ListGitTreeNodes(ctx, "ws-iso", sha1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(treeA) != 2 || treeA[0].Path != "a-only.txt" || treeA[1].Path != "shared.txt" || treeA[1].ObjectSHA != sha1 {
+		t.Fatalf("A tree = %+v", treeA)
+	}
+	treeB, err := storeB.ListGitTreeNodes(ctx, "ws-iso", sha1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(treeB) != 2 || treeB[0].Path != "b-only.txt" || treeB[1].Path != "shared.txt" || treeB[1].ObjectSHA != sha2 {
+		t.Fatalf("B tree = %+v", treeB)
+	}
+
+	// Git state upserts stay inside the fs_id.
+	if err := storeA.UpsertGitState(ctx, GitState{WorkspaceID: "ws-iso", CheckpointCommit: sha1, StorageRef: "state-ref-a"}); err != nil {
+		t.Fatalf("UpsertGitState A: %v", err)
+	}
+	if err := storeB.UpsertGitState(ctx, GitState{WorkspaceID: "ws-iso", CheckpointCommit: sha2, StorageRef: "state-ref-b"}); err != nil {
+		t.Fatalf("UpsertGitState B: %v", err)
+	}
+	if err := storeA.UpsertGitState(ctx, GitState{WorkspaceID: "ws-iso", CheckpointCommit: sha2, StorageRef: "state-ref-a2"}); err != nil {
+		t.Fatalf("UpsertGitState A update: %v", err)
+	}
+	stateA, err := storeA.GetGitState(ctx, "ws-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	stateB, err := storeB.GetGitState(ctx, "ws-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stateA.StorageRef != "state-ref-a2" || stateB.StorageRef != "state-ref-b" {
+		t.Fatalf("git state mixed up: A=%+v B=%+v", stateA, stateB)
+	}
+
+	// Same pack_id under both fs_ids coexists.
+	if err := storeA.UpsertGitObjectPack(ctx, GitObjectPack{WorkspaceID: "ws-iso", PackID: "pack-iso", ChecksumSHA256: "sum-a", ContentBlob: []byte("PACK-A")}); err != nil {
+		t.Fatalf("UpsertGitObjectPack A: %v", err)
+	}
+	if err := storeB.UpsertGitObjectPack(ctx, GitObjectPack{WorkspaceID: "ws-iso", PackID: "pack-iso", ChecksumSHA256: "sum-b", ContentBlob: []byte("PACK-B")}); err != nil {
+		t.Fatalf("UpsertGitObjectPack B: %v", err)
+	}
+	packA, err := storeA.GetGitObjectPack(ctx, "ws-iso", "pack-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	packB, err := storeB.GetGitObjectPack(ctx, "ws-iso", "pack-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if packA.ChecksumSHA256 != "sum-a" || !bytes.Equal(packA.ContentBlob, []byte("PACK-A")) ||
+		packB.ChecksumSHA256 != "sum-b" || !bytes.Equal(packB.ContentBlob, []byte("PACK-B")) {
+		t.Fatalf("packs mixed up: A=%+v B=%+v", packA, packB)
+	}
+	packsB, err := storeB.ListGitObjectPacks(ctx, "ws-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packsB) != 1 || packsB[0].ChecksumSHA256 != "sum-b" {
+		t.Fatalf("B packs = %+v, want only sum-b", packsB)
+	}
+
+	// Same overlay path under both fs_ids coexists.
+	if err := storeA.UpsertGitOverlayEntry(ctx, GitOverlayEntry{WorkspaceID: "ws-iso", Path: "dirty.txt", StorageRef: "ov-a"}); err != nil {
+		t.Fatalf("UpsertGitOverlayEntry A: %v", err)
+	}
+	if err := storeB.UpsertGitOverlayEntry(ctx, GitOverlayEntry{WorkspaceID: "ws-iso", Path: "dirty.txt", StorageRef: "ov-b"}); err != nil {
+		t.Fatalf("UpsertGitOverlayEntry B: %v", err)
+	}
+	entryA, err := storeA.GetGitOverlayEntry(ctx, "ws-iso", "dirty.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	entryB, err := storeB.GetGitOverlayEntry(ctx, "ws-iso", "dirty.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if entryA.StorageRef != "ov-a" || entryB.StorageRef != "ov-b" {
+		t.Fatalf("overlay entries mixed up: A=%+v B=%+v", entryA, entryB)
+	}
+
+	// Soft delete never crosses fs_id.
+	if err := storeA.DeleteGitWorkspace(ctx, "ws-iso"); err != nil {
+		t.Fatalf("DeleteGitWorkspace A: %v", err)
+	}
+	listA, err = storeA.ListGitWorkspaces(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listA) != 0 {
+		t.Fatalf("A workspaces after delete = %+v, want empty", listA)
+	}
+	gotB, err = storeB.GetGitWorkspace(ctx, "ws-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotB.Status != GitWorkspaceStatusLive || gotB.BranchName != "main-b" {
+		t.Fatalf("B workspace changed by A's delete: %+v", gotB)
+	}
+	listB, err = storeB.ListGitWorkspaces(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(listB) != 1 {
+		t.Fatalf("B workspaces = %+v, want 1", listB)
+	}
+}
+
+// TestGitSharedShapeStoresFsID asserts every git workspace table row written
+// by the core scenario carries the scope's fs_id as its row key.
+func TestGitSharedShapeStoresFsID(t *testing.T) {
+	installSharedGitSchema(t)
+	const fsID int64 = 4302004
+	store := newSharedStore(t, fsID)
+	runGitWorkspaceCoreScenario(t, store, "fsid")
+
+	for _, tbl := range []string{"git_workspaces", "git_workspace_tree_nodes", "git_workspace_git_state", "git_workspace_object_packs", "git_workspace_overlay"} {
+		var got int64
+		err := store.DB().QueryRow("SELECT COUNT(*) FROM "+tbl+" WHERE fs_id != ?", fsID).Scan(&got)
+		if err != nil {
+			t.Fatalf("count %s rows with foreign fs_id: %v", tbl, err)
+		}
+		if got != 0 {
+			t.Fatalf("%s has %d rows with fs_id != %d", tbl, got, fsID)
+		}
+		var total int64
+		if err := store.DB().QueryRow("SELECT COUNT(*) FROM " + tbl).Scan(&total); err != nil {
+			t.Fatalf("count %s: %v", tbl, err)
+		}
+		if total == 0 {
+			t.Fatalf("%s is empty; scenario should have written rows", tbl)
+		}
+	}
+}

--- a/pkg/datastore/git_workspace.go
+++ b/pkg/datastore/git_workspace.go
@@ -151,10 +151,10 @@ func (s *Store) UpsertGitWorkspace(ctx context.Context, ws GitWorkspace) error {
 	}
 	_, err = s.db.ExecContext(ctx, `
 INSERT INTO git_workspaces (
-	workspace_id, root_path, repo_url, remote_name, branch_name,
+	`+s.scope.InsCols(`workspace_id, root_path, repo_url, remote_name, branch_name,
 	base_commit, head_commit, mode, workspace_kind, common_workspace_id,
-	worktree_name, gitdir_rel, status, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3))
+	worktree_name, gitdir_rel, status, created_at, updated_at`)+`
+) VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3)`)+`)
 ON DUPLICATE KEY UPDATE
 	repo_url = VALUES(repo_url),
 	remote_name = VALUES(remote_name),
@@ -168,9 +168,9 @@ ON DUPLICATE KEY UPDATE
 	gitdir_rel = VALUES(gitdir_rel),
 	status = VALUES(status),
 	updated_at = UTC_TIMESTAMP(3)`,
-		ws.WorkspaceID, ws.RootPath, ws.RepoURL, ws.RemoteName, ws.BranchName,
-		ws.BaseCommit, ws.HeadCommit, string(ws.Mode), string(ws.Kind), ws.CommonID,
-		ws.WorktreeName, ws.GitDirRel, string(ws.Status))
+		s.scope.Args(ws.WorkspaceID, ws.RootPath, ws.RepoURL, ws.RemoteName, ws.BranchName,
+			ws.BaseCommit, ws.HeadCommit, string(ws.Mode), string(ws.Kind), ws.CommonID,
+			ws.WorktreeName, ws.GitDirRel, string(ws.Status))...)
 	if err != nil {
 		return fmt.Errorf("upsert git workspace %s: %w", ws.WorkspaceID, err)
 	}
@@ -183,7 +183,7 @@ SELECT workspace_id, root_path, repo_url, remote_name, branch_name,
 	base_commit, head_commit, mode, workspace_kind, common_workspace_id,
 	worktree_name, gitdir_rel, status, created_at, updated_at
 FROM git_workspaces
-WHERE workspace_id = ?`, workspaceID)
+WHERE `+s.scope.And(`workspace_id = ?`), s.scope.Args(workspaceID)...)
 	return scanGitWorkspace(row)
 }
 
@@ -197,7 +197,7 @@ func (s *Store) GetGitWorkspaceByRoot(ctx context.Context, rootPath string) (*Gi
 		base_commit, head_commit, mode, workspace_kind, common_workspace_id,
 		worktree_name, gitdir_rel, status, created_at, updated_at
 	FROM git_workspaces
-	WHERE root_path = ?`, root)
+	WHERE `+s.scope.And(`root_path = ?`), s.scope.Args(root)...)
 	return scanGitWorkspace(row)
 }
 
@@ -207,8 +207,8 @@ SELECT workspace_id, root_path, repo_url, remote_name, branch_name,
 	base_commit, head_commit, mode, workspace_kind, common_workspace_id,
 	worktree_name, gitdir_rel, status, created_at, updated_at
 FROM git_workspaces
-WHERE status = ?
-	ORDER BY root_path`, string(GitWorkspaceStatusLive))
+WHERE `+s.scope.And(`status = ?`)+`
+	ORDER BY root_path`, s.scope.Args(string(GitWorkspaceStatusLive))...)
 	if err != nil {
 		return nil, fmt.Errorf("list git workspaces: %w", err)
 	}
@@ -234,7 +234,8 @@ func (s *Store) DeleteGitWorkspace(ctx context.Context, workspaceID string) erro
 	res, err := s.db.ExecContext(ctx, `
 	UPDATE git_workspaces
 	SET status = ?, updated_at = UTC_TIMESTAMP(3)
-	WHERE workspace_id = ?`, string(GitWorkspaceStatusDeleted), workspaceID)
+	WHERE `+s.scope.And(`workspace_id = ?`),
+		append([]any{string(GitWorkspaceStatusDeleted)}, s.scope.Args(workspaceID)...)...)
 	if err != nil {
 		return fmt.Errorf("delete git workspace %s: %w", workspaceID, err)
 	}
@@ -322,15 +323,15 @@ func (s *Store) ReplaceGitTreeNodes(ctx context.Context, workspaceID, commitSHA 
 	}()
 	if _, err = tx.ExecContext(ctx, `
 DELETE FROM git_workspace_tree_nodes
-WHERE workspace_id = ? AND commit_sha = ?`, workspaceID, commitSHA); err != nil {
+WHERE `+s.scope.And(`workspace_id = ? AND commit_sha = ?`), s.scope.Args(workspaceID, commitSHA)...); err != nil {
 		return fmt.Errorf("delete git tree nodes: %w", err)
 	}
 	if len(nodes) > 0 {
 		stmt, prepErr := tx.PrepareContext(ctx, `
 INSERT INTO git_workspace_tree_nodes (
-	workspace_id, commit_sha, path, path_hash, parent_path, parent_path_hash,
-	name, kind, mode, object_sha, size_bytes, created_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3))`)
+	`+s.scope.InsCols(`workspace_id, commit_sha, path, path_hash, parent_path, parent_path_hash,
+	name, kind, mode, object_sha, size_bytes, created_at`)+`
+) VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3)`)+`)`)
 		if prepErr != nil {
 			return fmt.Errorf("prepare insert git tree node: %w", prepErr)
 		}
@@ -362,10 +363,10 @@ INSERT INTO git_workspace_tree_nodes (
 			} else if n.Name != name {
 				return fmt.Errorf("insert git tree node %s: name mismatch", n.Path)
 			}
-			if _, err = stmt.ExecContext(ctx,
+			if _, err = stmt.ExecContext(ctx, s.scope.Args(
 				n.WorkspaceID, n.CommitSHA, n.Path, gitPathHash(n.Path), n.ParentPath, gitPathHash(n.ParentPath),
 				n.Name, string(n.Kind), n.Mode, n.ObjectSHA, n.SizeBytes,
-			); err != nil {
+			)...); err != nil {
 				return fmt.Errorf("insert git tree node %s: %w", n.Path, err)
 			}
 		}
@@ -382,8 +383,8 @@ func (s *Store) ListGitTreeNodes(ctx context.Context, workspaceID, commitSHA str
 SELECT workspace_id, commit_sha, path, parent_path, name, kind, mode,
 	object_sha, size_bytes, created_at
 FROM git_workspace_tree_nodes
-WHERE workspace_id = ? AND commit_sha = ?
-ORDER BY path`, workspaceID, commitSHA)
+WHERE `+s.scope.And(`workspace_id = ? AND commit_sha = ?`)+`
+ORDER BY path`, s.scope.Args(workspaceID, commitSHA)...)
 	if err != nil {
 		return nil, fmt.Errorf("list git tree nodes: %w", err)
 	}
@@ -413,9 +414,9 @@ func (s *Store) UpsertGitState(ctx context.Context, state GitState) error {
 	}
 	_, err := s.db.ExecContext(ctx, `
 INSERT INTO git_workspace_git_state (
-	workspace_id, checkpoint_commit, storage_type, storage_ref, storage_ref_hash,
-	checksum_sha256, size_bytes, content_blob, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3))
+	`+s.scope.InsCols(`workspace_id, checkpoint_commit, storage_type, storage_ref, storage_ref_hash,
+	checksum_sha256, size_bytes, content_blob, created_at, updated_at`)+`
+) VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3)`)+`)
 ON DUPLICATE KEY UPDATE
 	checkpoint_commit = VALUES(checkpoint_commit),
 	storage_type = VALUES(storage_type),
@@ -425,8 +426,8 @@ ON DUPLICATE KEY UPDATE
 	size_bytes = VALUES(size_bytes),
 	content_blob = VALUES(content_blob),
 	updated_at = UTC_TIMESTAMP(3)`,
-		state.WorkspaceID, state.CheckpointCommit, state.StorageType, state.StorageRef,
-		state.StorageRefHash, state.ChecksumSHA256, state.SizeBytes, state.ContentBlob)
+		s.scope.Args(state.WorkspaceID, state.CheckpointCommit, state.StorageType, state.StorageRef,
+			state.StorageRefHash, state.ChecksumSHA256, state.SizeBytes, state.ContentBlob)...)
 	if err != nil {
 		return fmt.Errorf("upsert git state %s: %w", state.WorkspaceID, err)
 	}
@@ -438,7 +439,7 @@ func (s *Store) GetGitState(ctx context.Context, workspaceID string) (*GitState,
 SELECT workspace_id, checkpoint_commit, storage_type, storage_ref, storage_ref_hash,
 	checksum_sha256, size_bytes, content_blob, created_at, updated_at
 FROM git_workspace_git_state
-WHERE workspace_id = ?`, workspaceID)
+WHERE `+s.scope.And(`workspace_id = ?`), s.scope.Args(workspaceID)...)
 	var state GitState
 	if err := row.Scan(
 		&state.WorkspaceID, &state.CheckpointCommit, &state.StorageType, &state.StorageRef,
@@ -464,13 +465,13 @@ func (s *Store) UpsertGitObjectPack(ctx context.Context, pack GitObjectPack) err
 	}
 	_, err := s.db.ExecContext(ctx, `
 INSERT INTO git_workspace_object_packs (
-	workspace_id, pack_id, checksum_sha256, size_bytes, content_blob, created_at
-) VALUES (?, ?, ?, ?, ?, UTC_TIMESTAMP(3))
+	`+s.scope.InsCols(`workspace_id, pack_id, checksum_sha256, size_bytes, content_blob, created_at`)+`
+) VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, UTC_TIMESTAMP(3)`)+`)
 ON DUPLICATE KEY UPDATE
 	checksum_sha256 = VALUES(checksum_sha256),
 	size_bytes = VALUES(size_bytes),
 	content_blob = VALUES(content_blob)`,
-		pack.WorkspaceID, pack.PackID, pack.ChecksumSHA256, pack.SizeBytes, pack.ContentBlob)
+		s.scope.Args(pack.WorkspaceID, pack.PackID, pack.ChecksumSHA256, pack.SizeBytes, pack.ContentBlob)...)
 	if err != nil {
 		return fmt.Errorf("upsert git object pack %s: %w", pack.PackID, err)
 	}
@@ -481,8 +482,8 @@ func (s *Store) ListGitObjectPacks(ctx context.Context, workspaceID string) ([]G
 	rows, err := s.db.QueryContext(ctx, `
 SELECT workspace_id, pack_id, checksum_sha256, size_bytes, created_at
 FROM git_workspace_object_packs
-WHERE workspace_id = ?
-ORDER BY created_at, pack_id`, workspaceID)
+WHERE `+s.scope.And(`workspace_id = ?`)+`
+ORDER BY created_at, pack_id`, s.scope.Args(workspaceID)...)
 	if err != nil {
 		return nil, fmt.Errorf("list git object packs: %w", err)
 	}
@@ -507,7 +508,7 @@ func (s *Store) GetGitObjectPack(ctx context.Context, workspaceID, packID string
 	row := s.db.QueryRowContext(ctx, `
 SELECT workspace_id, pack_id, checksum_sha256, size_bytes, content_blob, created_at
 FROM git_workspace_object_packs
-WHERE workspace_id = ? AND pack_id = ?`, workspaceID, packID)
+WHERE `+s.scope.And(`workspace_id = ? AND pack_id = ?`), s.scope.Args(workspaceID, packID)...)
 	var pack GitObjectPack
 	if err := row.Scan(
 		&pack.WorkspaceID, &pack.PackID, &pack.ChecksumSHA256, &pack.SizeBytes, &pack.ContentBlob, &pack.CreatedAt,
@@ -540,9 +541,9 @@ func (s *Store) UpsertGitOverlayEntry(ctx context.Context, entry GitOverlayEntry
 	}
 	_, err = s.db.ExecContext(ctx, `
 INSERT INTO git_workspace_overlay (
-	workspace_id, path, path_hash, op, kind, mode, storage_type, storage_ref, storage_ref_hash,
-	checksum_sha256, size_bytes, base_object_sha, content_blob, created_at, updated_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3))
+	`+s.scope.InsCols(`workspace_id, path, path_hash, op, kind, mode, storage_type, storage_ref, storage_ref_hash,
+	checksum_sha256, size_bytes, base_object_sha, content_blob, created_at, updated_at`)+`
+) VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(3), UTC_TIMESTAMP(3)`)+`)
 ON DUPLICATE KEY UPDATE
 	path = VALUES(path),
 	op = VALUES(op),
@@ -556,8 +557,8 @@ ON DUPLICATE KEY UPDATE
 	base_object_sha = VALUES(base_object_sha),
 	content_blob = VALUES(content_blob),
 	updated_at = UTC_TIMESTAMP(3)`,
-		entry.WorkspaceID, entry.Path, gitPathHash(entry.Path), string(entry.Op), string(entry.Kind), entry.Mode, entry.StorageType, entry.StorageRef,
-		entry.StorageRefHash, entry.ChecksumSHA256, entry.SizeBytes, entry.BaseObjectSHA, entry.ContentBlob)
+		s.scope.Args(entry.WorkspaceID, entry.Path, gitPathHash(entry.Path), string(entry.Op), string(entry.Kind), entry.Mode, entry.StorageType, entry.StorageRef,
+			entry.StorageRefHash, entry.ChecksumSHA256, entry.SizeBytes, entry.BaseObjectSHA, entry.ContentBlob)...)
 	if err != nil {
 		return fmt.Errorf("upsert git overlay entry %s: %w", entry.Path, err)
 	}
@@ -569,8 +570,8 @@ func (s *Store) ListGitOverlayEntries(ctx context.Context, workspaceID string) (
 SELECT workspace_id, path, op, kind, mode, storage_type, storage_ref, storage_ref_hash,
 	checksum_sha256, size_bytes, base_object_sha, content_blob, created_at, updated_at
 FROM git_workspace_overlay
-WHERE workspace_id = ?
-ORDER BY path`, workspaceID)
+WHERE `+s.scope.And(`workspace_id = ?`)+`
+ORDER BY path`, s.scope.Args(workspaceID)...)
 	if err != nil {
 		return nil, fmt.Errorf("list git overlay entries: %w", err)
 	}
@@ -604,7 +605,7 @@ func (s *Store) GetGitOverlayEntry(ctx context.Context, workspaceID, relPath str
 SELECT workspace_id, path, op, kind, mode, storage_type, storage_ref, storage_ref_hash,
 	checksum_sha256, size_bytes, base_object_sha, content_blob, created_at, updated_at
 FROM git_workspace_overlay
-	WHERE workspace_id = ? AND path_hash = ? AND path = ?`, workspaceID, gitPathHash(relPath), relPath)
+	WHERE `+s.scope.And(`workspace_id = ? AND path_hash = ? AND path = ?`), s.scope.Args(workspaceID, gitPathHash(relPath), relPath)...)
 	var e GitOverlayEntry
 	var op, kind string
 	if err := row.Scan(

--- a/pkg/datastore/inode.go
+++ b/pkg/datastore/inode.go
@@ -24,20 +24,20 @@ type Inode struct {
 // InsertInode inserts an inode row.
 func (s *Store) InsertInode(ctx context.Context, inode *Inode) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO inodes
-		(inode_id, size_bytes, revision, mode, status, created_at, mtime, confirmed_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		inode.InodeID, inode.SizeBytes, inode.Revision, inode.Mode, inode.Status,
-		inode.CreatedAt.UTC(), inode.Mtime.UTC(), nilTime(inode.ConfirmedAt), nilTime(inode.ExpiresAt))
+		(`+s.scope.InsCols(`inode_id, size_bytes, revision, mode, status, created_at, mtime, confirmed_at, expires_at`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(inode.InodeID, inode.SizeBytes, inode.Revision, inode.Mode, inode.Status,
+			inode.CreatedAt.UTC(), inode.Mtime.UTC(), nilTime(inode.ConfirmedAt), nilTime(inode.ExpiresAt))...)
 	return err
 }
 
 // InsertInodeTx inserts an inode row inside an existing transaction.
 func (s *Store) InsertInodeTx(db execer, inode *Inode) error {
 	_, err := db.Exec(`INSERT INTO inodes
-		(inode_id, size_bytes, revision, mode, status, created_at, mtime, confirmed_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		inode.InodeID, inode.SizeBytes, inode.Revision, inode.Mode, inode.Status,
-		inode.CreatedAt.UTC(), inode.Mtime.UTC(), nilTime(inode.ConfirmedAt), nilTime(inode.ExpiresAt))
+		(`+s.scope.InsCols(`inode_id, size_bytes, revision, mode, status, created_at, mtime, confirmed_at, expires_at`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(inode.InodeID, inode.SizeBytes, inode.Revision, inode.Mode, inode.Status,
+			inode.CreatedAt.UTC(), inode.Mtime.UTC(), nilTime(inode.ConfirmedAt), nilTime(inode.ExpiresAt))...)
 	return err
 }
 
@@ -45,27 +45,28 @@ func (s *Store) InsertInodeTx(db execer, inode *Inode) error {
 func (s *Store) GetInode(ctx context.Context, inodeID string) (*Inode, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT inode_id, size_bytes, revision, mode, status,
 		created_at, mtime, confirmed_at, expires_at
-		FROM inodes WHERE inode_id = ?`, inodeID)
+		FROM inodes WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(inodeID)...)
 	return scanInode(row)
 }
 
 // UpdateInodeContentTx updates inode metadata (size, revision, status, mtime) inside a transaction.
 func (s *Store) UpdateInodeContentTx(db execer, inodeID string, sizeBytes, revision int64, status FileStatus, confirmedAt time.Time) error {
 	_, err := db.Exec(`UPDATE inodes SET size_bytes = ?, revision = ?, status = ?, mtime = ?, confirmed_at = ?
-		WHERE inode_id = ?`,
-		sizeBytes, revision, status, confirmedAt.UTC(), confirmedAt.UTC(), inodeID)
+		WHERE `+s.scope.And(`inode_id = ?`),
+		append([]any{sizeBytes, revision, status, confirmedAt.UTC(), confirmedAt.UTC()}, s.scope.Args(inodeID)...)...)
 	return err
 }
 
 // UpdateInodeModeTx updates the mode (permission bits) of an inode.
 func (s *Store) UpdateInodeModeTx(db execer, inodeID string, mode uint32) error {
-	_, err := db.Exec(`UPDATE inodes SET mode = ? WHERE inode_id = ?`, mode, inodeID)
+	_, err := db.Exec(`UPDATE inodes SET mode = ? WHERE `+s.scope.And(`inode_id = ?`),
+		append([]any{mode}, s.scope.Args(inodeID)...)...)
 	return err
 }
 
 // MarkInodeDeletedTx marks an inode as DELETED inside a transaction.
 func (s *Store) MarkInodeDeletedTx(db execer, inodeID string) error {
-	_, err := db.Exec(`UPDATE inodes SET status = 'DELETED' WHERE inode_id = ?`, inodeID)
+	_, err := db.Exec(`UPDATE inodes SET status = 'DELETED' WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(inodeID)...)
 	return err
 }
 

--- a/pkg/datastore/journal.go
+++ b/pkg/datastore/journal.go
@@ -67,7 +67,7 @@ func (s *Store) CreateJournal(ctx context.Context, tenantID string, req journal.
 	for attempt := 0; attempt < maxCreateAttempts; attempt++ {
 		out = nil
 		err = s.InTx(ctx, func(tx *sql.Tx) error {
-			existing, existingCreateHash, err := selectJournalTx(ctx, tx, tenantID, req.JournalID, true)
+			existing, existingCreateHash, err := s.selectJournalTx(ctx, tx, tenantID, req.JournalID, true)
 			if err == nil {
 				if existingCreateHash != createHash {
 					return ErrJournalConflict
@@ -78,15 +78,15 @@ func (s *Store) CreateJournal(ctx context.Context, tenantID string, req journal.
 			if !errors.Is(err, ErrNotFound) {
 				return err
 			}
-			_, err = tx.ExecContext(ctx, `INSERT INTO journals
-			(tenant_id, journal_id, kind, title, actor_type, actor_id, source, meta, retention,
+			_, err = tx.ExecContext(ctx, fmt.Sprintf(`INSERT INTO journals
+			(%s, journal_id, kind, title, actor_type, actor_id, source, meta, retention,
 			 next_seq, genesis, create_hash, genesis_hash, head_hash, created_at, updated_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)`,
-				tenantID, req.JournalID, req.Kind, nullStr(req.Title), nullStr(req.Actor.Type), nullStr(req.Actor.ID),
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)`, s.tenantCol()),
+				s.tenantArg(tenantID), req.JournalID, req.Kind, nullStr(req.Title), nullStr(req.Actor.Type), nullStr(req.Actor.ID),
 				nullStr(req.Source), nullJSON(metaRaw), nullJSON(req.Retention), string(genesisRaw), createHash,
 				genesisHash, genesisHash, now, now)
 			if isUniqueViolation(err) {
-				existing, existingCreateHash, readErr := selectJournalTx(ctx, tx, tenantID, req.JournalID, true)
+				existing, existingCreateHash, readErr := s.selectJournalTx(ctx, tx, tenantID, req.JournalID, true)
 				if readErr != nil {
 					return ErrJournalConflict
 				}
@@ -100,10 +100,10 @@ func (s *Store) CreateJournal(ctx context.Context, tenantID string, req journal.
 				return err
 			}
 			for _, label := range req.Labels {
-				if _, err := tx.ExecContext(ctx, `INSERT INTO journal_labels
-				(tenant_id, label_key, label_hash, label_value, journal_id, created_at, source_seq)
-				VALUES (?, ?, ?, ?, ?, ?, NULL)`,
-					tenantID, label.Key, journal.LabelHash(label.Key, label.Value), label.Value, req.JournalID, now); err != nil {
+				if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT INTO journal_labels
+				(%s, label_key, label_hash, label_value, journal_id, created_at, source_seq)
+				VALUES (?, ?, ?, ?, ?, ?, NULL)`, s.tenantCol()),
+					s.tenantArg(tenantID), label.Key, journal.LabelHash(label.Key, label.Value), label.Value, req.JournalID, now); err != nil {
 					return err
 				}
 			}
@@ -211,14 +211,14 @@ func (s *Store) AppendJournalEntries(ctx context.Context, tenantID, journalID, a
 	}
 	var out *journal.AppendResponse
 	err = s.InTx(ctx, func(tx *sql.Tx) error {
-		current, _, err := selectJournalTx(ctx, tx, tenantID, journalID, true)
+		current, _, err := s.selectJournalTx(ctx, tx, tenantID, journalID, true)
 		if err != nil {
 			return err
 		}
 		if current.ClosedAt != nil {
 			return ErrJournalClosed
 		}
-		if existing, err := selectAppendRequestTx(ctx, tx, tenantID, journalID, appendID); err == nil {
+		if existing, err := s.selectAppendRequestTx(ctx, tx, tenantID, journalID, appendID); err == nil {
 			if existing.requestHash != requestHash || existing.writerType != writer.Type ||
 				existing.writerID != writer.ID || existing.effectiveSource != effectiveSource {
 				return ErrIdempotencyConflict
@@ -275,11 +275,11 @@ func (s *Store) AppendJournalEntries(ctx context.Context, tenantID, journalID, a
 		firstSeq := inserted[0].Seq
 		lastSeq := inserted[len(inserted)-1].Seq
 		headHash := inserted[len(inserted)-1].EntryHash
-		if _, err := tx.ExecContext(ctx, `INSERT INTO journal_append_requests
-			(tenant_id, journal_id, append_id, request_hash, writer_type, writer_id, effective_source,
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT INTO journal_append_requests
+			(%s, journal_id, append_id, request_hash, writer_type, writer_id, effective_source,
 			 first_seq, last_seq, count, head_hash, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			tenantID, journalID, appendID, requestHash, writer.Type, writer.ID, effectiveSource,
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.tenantCol()),
+			s.tenantArg(tenantID), journalID, appendID, requestHash, writer.Type, writer.ID, effectiveSource,
 			firstSeq, lastSeq, len(inserted), headHash, observedAt); err != nil {
 			if isUniqueViolation(err) {
 				return ErrIdempotencyConflict
@@ -287,14 +287,14 @@ func (s *Store) AppendJournalEntries(ctx context.Context, tenantID, journalID, a
 			return err
 		}
 		for _, entry := range inserted {
-			if err := insertJournalEntryTx(ctx, tx, entry); err != nil {
+			if err := s.insertJournalEntryTx(ctx, tx, entry); err != nil {
 				return err
 			}
 		}
-		if _, err := tx.ExecContext(ctx, `UPDATE journals
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`UPDATE journals
 			SET next_seq = ?, head_hash = ?, updated_at = ?
-			WHERE tenant_id = ? AND journal_id = ?`,
-			lastSeq+1, headHash, observedAt, tenantID, journalID); err != nil {
+			WHERE %s = ? AND journal_id = ?`, s.tenantCol()),
+			lastSeq+1, headHash, observedAt, s.tenantArg(tenantID), journalID); err != nil {
 			return err
 		}
 		out = &journal.AppendResponse{
@@ -329,17 +329,17 @@ func (s *Store) ListJournalEntries(ctx context.Context, tenantID, journalID stri
 		return nil, fmt.Errorf("%w: %v", ErrJournalValidation, err)
 	}
 	limit = journal.NormalizeLimit(limit)
-	rows, err := s.db.QueryContext(ctx, selectEntryColumns()+`
+	rows, err := s.db.QueryContext(ctx, s.selectEntryColumns()+fmt.Sprintf(`
 		FROM journal_entries
-		WHERE tenant_id = ? AND journal_id = ? AND seq > ?
+		WHERE %[1]s = ? AND journal_id = ? AND seq > ?
 		ORDER BY seq
-		LIMIT ?`, tenantID, journalID, afterSeq, limit)
+		LIMIT ?`, s.tenantCol()), s.tenantArg(tenantID), journalID, afterSeq, limit)
 	if err != nil {
 		opErr = err
 		return nil, err
 	}
 	defer func() { _ = rows.Close() }()
-	out, err := scanEntryRows(rows)
+	out, err := scanEntryRows(rows, tenantID)
 	if err != nil {
 		opErr = err
 		return nil, err
@@ -394,8 +394,8 @@ func (s *Store) VerifyJournal(ctx context.Context, tenantID, journalID string) (
 
 	var genesisRaw []byte
 	var storedGenesisHash, storedHead string
-	err := s.db.QueryRowContext(ctx, `SELECT genesis, genesis_hash, head_hash
-		FROM journals WHERE tenant_id = ? AND journal_id = ?`, tenantID, journalID).
+	err := s.db.QueryRowContext(ctx, fmt.Sprintf(`SELECT genesis, genesis_hash, head_hash
+		FROM journals WHERE %s = ? AND journal_id = ?`, s.tenantCol()), s.tenantArg(tenantID), journalID).
 		Scan(&genesisRaw, &storedGenesisHash, &storedHead)
 	if err != nil {
 		opErr = err
@@ -505,19 +505,20 @@ func (r appendRequestRow) response(journalID, appendID string) *journal.AppendRe
 	}
 }
 
-func selectJournalTx(ctx context.Context, tx *sql.Tx, tenantID, journalID string, forUpdate bool) (*journal.Journal, string, error) {
-	query := `SELECT tenant_id, journal_id, kind, title, actor_type, actor_id, source, meta, retention,
+func (s *Store) selectJournalTx(ctx context.Context, tx *sql.Tx, tenantID, journalID string, forUpdate bool) (*journal.Journal, string, error) {
+	query := fmt.Sprintf(`SELECT %s, journal_id, kind, title, actor_type, actor_id, source, meta, retention,
 		next_seq, genesis_hash, head_hash, created_at, updated_at, closed_at, create_hash
-		FROM journals WHERE tenant_id = ? AND journal_id = ?`
+		FROM journals WHERE %[1]s = ? AND journal_id = ?`, s.tenantCol())
 	if forUpdate {
 		query += " FOR UPDATE"
 	}
-	row := tx.QueryRowContext(ctx, query, tenantID, journalID)
+	row := tx.QueryRowContext(ctx, query, s.tenantArg(tenantID), journalID)
 	j, createHash, err := scanJournal(row)
 	if err != nil {
 		return nil, "", err
 	}
-	labels, err := selectJournalLabelsTx(ctx, tx, tenantID, journalID)
+	j.TenantID = tenantID
+	labels, err := s.selectJournalLabelsTx(ctx, tx, tenantID, journalID)
 	if err != nil {
 		return nil, "", err
 	}
@@ -528,11 +529,11 @@ func selectJournalTx(ctx context.Context, tx *sql.Tx, tenantID, journalID string
 	return j, createHash, nil
 }
 
-func selectJournalLabelsTx(ctx context.Context, tx *sql.Tx, tenantID, journalID string) ([]journal.Label, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT label_key, label_value
+func (s *Store) selectJournalLabelsTx(ctx context.Context, tx *sql.Tx, tenantID, journalID string) ([]journal.Label, error) {
+	rows, err := tx.QueryContext(ctx, fmt.Sprintf(`SELECT label_key, label_value
 		FROM journal_labels
-		WHERE tenant_id = ? AND journal_id = ?
-		ORDER BY label_key, label_value`, tenantID, journalID)
+		WHERE %s = ? AND journal_id = ?
+		ORDER BY label_key, label_value`, s.tenantCol()), s.tenantArg(tenantID), journalID)
 	if err != nil {
 		return nil, err
 	}
@@ -550,7 +551,7 @@ func selectJournalLabelsTx(ctx context.Context, tx *sql.Tx, tenantID, journalID 
 
 func (s *Store) journalExists(ctx context.Context, tenantID, journalID string) (bool, error) {
 	var one int
-	err := s.db.QueryRowContext(ctx, `SELECT 1 FROM journals WHERE tenant_id = ? AND journal_id = ?`, tenantID, journalID).Scan(&one)
+	err := s.db.QueryRowContext(ctx, fmt.Sprintf(`SELECT 1 FROM journals WHERE %s = ? AND journal_id = ?`, s.tenantCol()), s.tenantArg(tenantID), journalID).Scan(&one)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return false, nil
@@ -593,13 +594,13 @@ func scanJournal(row interface{ Scan(dest ...any) error }) (*journal.Journal, st
 	return &j, createHash, nil
 }
 
-func selectAppendRequestTx(ctx context.Context, tx *sql.Tx, tenantID, journalID, appendID string) (*appendRequestRow, error) {
+func (s *Store) selectAppendRequestTx(ctx context.Context, tx *sql.Tx, tenantID, journalID, appendID string) (*appendRequestRow, error) {
 	var r appendRequestRow
-	err := tx.QueryRowContext(ctx, `SELECT request_hash, writer_type, writer_id, effective_source,
+	err := tx.QueryRowContext(ctx, fmt.Sprintf(`SELECT request_hash, writer_type, writer_id, effective_source,
 		first_seq, last_seq, count, head_hash
 		FROM journal_append_requests
-		WHERE tenant_id = ? AND journal_id = ? AND append_id = ?`,
-		tenantID, journalID, appendID).
+		WHERE %s = ? AND journal_id = ? AND append_id = ?`, s.tenantCol()),
+		s.tenantArg(tenantID), journalID, appendID).
 		Scan(&r.requestHash, &r.writerType, &r.writerID, &r.effectiveSource,
 			&r.firstSeq, &r.lastSeq, &r.count, &r.headHash)
 	if err != nil {
@@ -611,7 +612,7 @@ func selectAppendRequestTx(ctx context.Context, tx *sql.Tx, tenantID, journalID,
 	return &r, nil
 }
 
-func insertJournalEntryTx(ctx context.Context, tx *sql.Tx, entry journal.Entry) error {
+func (s *Store) insertJournalEntryTx(ctx context.Context, tx *sql.Tx, entry journal.Entry) error {
 	subjectsRaw, err := json.Marshal(entry.Subjects)
 	if err != nil {
 		return err
@@ -621,12 +622,12 @@ func insertJournalEntryTx(ctx context.Context, tx *sql.Tx, entry journal.Entry) 
 	if err != nil {
 		return err
 	}
-	if _, err := tx.ExecContext(ctx, `INSERT INTO journal_entries
-		(tenant_id, journal_id, seq, entry_id, type, schema_version, status, occurred_at, observed_at,
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT INTO journal_entries
+		(%s, journal_id, seq, entry_id, type, schema_version, status, occurred_at, observed_at,
 		 actor_type, actor_id, source, parent_entry_id, correlation_id, subjects, summary, artifact_refs,
 		 prev_hash, entry_hash)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		entry.TenantID, entry.JournalID, entry.Seq, entry.EntryID, entry.Type, entry.SchemaVersion,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.tenantCol()),
+		s.tenantArg(entry.TenantID), entry.JournalID, entry.Seq, entry.EntryID, entry.Type, entry.SchemaVersion,
 		nullStr(entry.Status), entry.OccurredAt, entry.ObservedAt, nullStr(entry.Actor.Type),
 		nullStr(entry.Actor.ID), entry.Source, nullStr(entry.ParentEntryID), nullStr(entry.CorrelationID),
 		nullJSON(subjectsRaw), nullJSON(summaryRaw), nullJSON(artifactRefsRaw), entry.PrevHash, entry.EntryHash); err != nil {
@@ -637,10 +638,10 @@ func insertJournalEntryTx(ctx context.Context, tx *sql.Tx, entry journal.Entry) 
 		if err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(ctx, `INSERT INTO journal_entry_subjects
-			(tenant_id, subject_type, subject_hash, subject_id, occurred_at, observed_at, journal_id, seq, entry_id)
-			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			entry.TenantID, subjectType, journal.SubjectHash(subjectType, subjectID), subjectID,
+		if _, err := tx.ExecContext(ctx, fmt.Sprintf(`INSERT INTO journal_entry_subjects
+			(%s, subject_type, subject_hash, subject_id, occurred_at, observed_at, journal_id, seq, entry_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.tenantCol()),
+			s.tenantArg(entry.TenantID), subjectType, journal.SubjectHash(subjectType, subjectID), subjectID,
 			entry.OccurredAt, entry.ObservedAt, entry.JournalID, entry.Seq, entry.EntryID); err != nil {
 			return err
 		}
@@ -648,15 +649,16 @@ func insertJournalEntryTx(ctx context.Context, tx *sql.Tx, entry journal.Entry) 
 	return nil
 }
 
-func selectEntryColumns() string {
-	return `SELECT tenant_id, journal_id, seq, entry_id, type, schema_version, status, occurred_at, observed_at,
+func (s *Store) selectEntryColumns() string {
+	return fmt.Sprintf(`SELECT %s, journal_id, seq, entry_id, type, schema_version, status, occurred_at, observed_at,
 		actor_type, actor_id, source, parent_entry_id, correlation_id, subjects, summary, artifact_refs,
-		prev_hash, entry_hash `
+		prev_hash, entry_hash `, s.tenantCol())
 }
 
-func selectEntryColumnsAlias(alias string) string {
+func (s *Store) selectEntryColumnsAlias(alias string) string {
 	prefix := alias + "."
-	return `SELECT ` + prefix + `tenant_id, ` + prefix + `journal_id, ` + prefix + `seq, ` +
+	col := prefix + s.tenantCol()
+	return `SELECT ` + col + `, ` + prefix + `journal_id, ` + prefix + `seq, ` +
 		prefix + `entry_id, ` + prefix + `type, ` + prefix + `schema_version, ` + prefix + `status, ` +
 		prefix + `occurred_at, ` + prefix + `observed_at, ` + prefix + `actor_type, ` + prefix + `actor_id, ` +
 		prefix + `source, ` + prefix + `parent_entry_id, ` + prefix + `correlation_id, ` +
@@ -664,10 +666,13 @@ func selectEntryColumnsAlias(alias string) string {
 		prefix + `prev_hash, ` + prefix + `entry_hash `
 }
 
-func scanEntryRows(rows *sql.Rows) ([]journal.Entry, error) {
+// scanEntryRows scans journal entry rows and stamps each entry's TenantID
+// with tenantID: in shared shape the leading column is fs_id (numeric), and
+// the app-layer tenant UUID comes from the request scope, not the row.
+func scanEntryRows(rows *sql.Rows, tenantID string) ([]journal.Entry, error) {
 	var out []journal.Entry
 	for rows.Next() {
-		entry, err := scanEntry(rows)
+		entry, err := scanEntry(rows, tenantID)
 		if err != nil {
 			return nil, err
 		}
@@ -676,7 +681,7 @@ func scanEntryRows(rows *sql.Rows) ([]journal.Entry, error) {
 	return out, rows.Err()
 }
 
-func scanEntry(row interface{ Scan(dest ...any) error }) (*journal.Entry, error) {
+func scanEntry(row interface{ Scan(dest ...any) error }, tenantID string) (*journal.Entry, error) {
 	var e journal.Entry
 	var status, actorType, actorID, parentEntryID, correlationID sql.NullString
 	var subjectsRaw, summaryRaw, artifactRefsRaw []byte
@@ -685,6 +690,7 @@ func scanEntry(row interface{ Scan(dest ...any) error }) (*journal.Entry, error)
 		&correlationID, &subjectsRaw, &summaryRaw, &artifactRefsRaw, &e.PrevHash, &e.EntryHash); err != nil {
 		return nil, err
 	}
+	e.TenantID = tenantID
 	e.Status = status.String
 	e.Actor = journal.Actor{Type: actorType.String, ID: actorID.String}
 	e.ParentEntryID = parentEntryID.String
@@ -704,10 +710,10 @@ func scanEntry(row interface{ Scan(dest ...any) error }) (*journal.Entry, error)
 }
 
 func (s *Store) loadJournalEntrySubjects(ctx context.Context, tenantID, journalID string, firstSeq, lastSeq int64) (map[int64][]string, bool, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT seq, subject_type, subject_hash, subject_id
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`SELECT seq, subject_type, subject_hash, subject_id
 		FROM journal_entry_subjects
-		WHERE tenant_id = ? AND journal_id = ? AND seq >= ? AND seq <= ?
-		ORDER BY seq`, tenantID, journalID, firstSeq, lastSeq)
+		WHERE %s = ? AND journal_id = ? AND seq >= ? AND seq <= ?
+		ORDER BY seq`, s.tenantCol()), s.tenantArg(tenantID), journalID, firstSeq, lastSeq)
 	if err != nil {
 		return nil, false, err
 	}
@@ -747,10 +753,10 @@ func (s *Store) loadJournalEntrySubjects(ctx context.Context, tenantID, journalI
 }
 
 func (s *Store) loadJournalLabels(ctx context.Context, tenantID, journalID string) ([]journal.Label, bool, error) {
-	rows, err := s.db.QueryContext(ctx, `SELECT label_key, label_hash, label_value
+	rows, err := s.db.QueryContext(ctx, fmt.Sprintf(`SELECT label_key, label_hash, label_value
 		FROM journal_labels
-		WHERE tenant_id = ? AND journal_id = ?
-		ORDER BY label_key, label_value`, tenantID, journalID)
+		WHERE %s = ? AND journal_id = ?
+		ORDER BY label_key, label_value`, s.tenantCol()), s.tenantArg(tenantID), journalID)
 	if err != nil {
 		return nil, false, err
 	}
@@ -818,10 +824,11 @@ func equalLabels(a, b []journal.Label) bool {
 func (s *Store) searchJournalEntries(ctx context.Context, tenantID string, req journal.SearchRequest) ([]journal.SearchMatch, error) {
 	var b strings.Builder
 	args := []any{}
+	col := s.tenantCol()
 	labels := journal.NormalizeLabels(req.Labels)
 	labelAnchored := false
 	if req.Entries {
-		b.WriteString(selectEntryColumnsAlias("e"))
+		b.WriteString(s.selectEntryColumnsAlias("e"))
 	} else {
 		b.WriteString(`SELECT e.journal_id, e.seq, e.type, e.status, e.observed_at `)
 	}
@@ -830,26 +837,26 @@ func (s *Store) searchJournalEntries(ctx context.Context, tenantID string, req j
 		if err != nil {
 			return nil, err
 		}
-		b.WriteString(`FROM journal_entry_subjects s JOIN journal_entries e
-			ON e.tenant_id = s.tenant_id AND e.journal_id = s.journal_id AND e.seq = s.seq
-			JOIN journals j ON j.tenant_id = e.tenant_id AND j.journal_id = e.journal_id
-			WHERE s.tenant_id = ? AND s.subject_type = ? AND s.subject_hash = ? AND s.subject_id = ? `)
-		args = append(args, tenantID, subjectType, journal.SubjectHash(subjectType, subjectID), subjectID)
+		b.WriteString(fmt.Sprintf(`FROM journal_entry_subjects s JOIN journal_entries e
+			ON e.%[1]s = s.%[1]s AND e.journal_id = s.journal_id AND e.seq = s.seq
+			JOIN journals j ON j.%[1]s = e.%[1]s AND j.journal_id = e.journal_id
+			WHERE s.%[1]s = ? AND s.subject_type = ? AND s.subject_hash = ? AND s.subject_id = ? `, col))
+		args = append(args, s.tenantArg(tenantID), subjectType, journal.SubjectHash(subjectType, subjectID), subjectID)
 	} else if len(labels) > 0 {
 		first := labels[0]
 		labelAnchored = true
-		b.WriteString(`FROM journal_labels l JOIN journals j
-			ON j.tenant_id = l.tenant_id AND j.journal_id = l.journal_id
-			JOIN journal_entries e ON e.tenant_id = j.tenant_id AND e.journal_id = j.journal_id
-			WHERE l.tenant_id = ? AND l.label_key = ? AND l.label_hash = ? AND l.label_value = ? `)
-		args = append(args, tenantID, first.Key, journal.LabelHash(first.Key, first.Value), first.Value)
+		b.WriteString(fmt.Sprintf(`FROM journal_labels l JOIN journals j
+			ON j.%[1]s = l.%[1]s AND j.journal_id = l.journal_id
+			JOIN journal_entries e ON e.%[1]s = j.%[1]s AND e.journal_id = j.journal_id
+			WHERE l.%[1]s = ? AND l.label_key = ? AND l.label_hash = ? AND l.label_value = ? `, col))
+		args = append(args, s.tenantArg(tenantID), first.Key, journal.LabelHash(first.Key, first.Value), first.Value)
 	} else {
-		b.WriteString(`FROM journal_entries e
-			JOIN journals j ON j.tenant_id = e.tenant_id AND j.journal_id = e.journal_id
-			WHERE e.tenant_id = ? `)
-		args = append(args, tenantID)
+		b.WriteString(fmt.Sprintf(`FROM journal_entries e
+			JOIN journals j ON j.%[1]s = e.%[1]s AND j.journal_id = e.journal_id
+			WHERE e.%[1]s = ? `, col))
+		args = append(args, s.tenantArg(tenantID))
 	}
-	if err := appendEntryFilters(&b, &args, req, labelAnchored); err != nil {
+	if err := appendEntryFilters(&b, &args, req, labelAnchored, col); err != nil {
 		return nil, err
 	}
 	b.WriteString(` ORDER BY e.observed_at DESC, e.journal_id DESC, e.seq DESC LIMIT ?`)
@@ -863,7 +870,7 @@ func (s *Store) searchJournalEntries(ctx context.Context, tenantID string, req j
 	var out []journal.SearchMatch
 	for rows.Next() {
 		if req.Entries {
-			entry, err := scanEntry(rows)
+			entry, err := scanEntry(rows, tenantID)
 			if err != nil {
 				return nil, err
 			}
@@ -893,7 +900,7 @@ func (s *Store) searchJournalEntries(ctx context.Context, tenantID string, req j
 	return out, rows.Err()
 }
 
-func appendEntryFilters(b *strings.Builder, args *[]any, req journal.SearchRequest, skipFirstLabel bool) error {
+func appendEntryFilters(b *strings.Builder, args *[]any, req journal.SearchRequest, skipFirstLabel bool, col string) error {
 	if req.Type != "" {
 		b.WriteString(`AND e.type = ? `)
 		*args = append(*args, req.Type)
@@ -932,9 +939,9 @@ func appendEntryFilters(b *strings.Builder, args *[]any, req journal.SearchReque
 			if err != nil {
 				return err
 			}
-			b.WriteString(`AND EXISTS (SELECT 1 FROM journal_entry_subjects sx
-			WHERE sx.tenant_id = e.tenant_id AND sx.journal_id = e.journal_id AND sx.seq = e.seq
-			AND sx.subject_type = ? AND sx.subject_hash = ? AND sx.subject_id = ?) `)
+			fmt.Fprintf(b, `AND EXISTS (SELECT 1 FROM journal_entry_subjects sx
+			WHERE sx.%[1]s = e.%[1]s AND sx.journal_id = e.journal_id AND sx.seq = e.seq
+			AND sx.subject_type = ? AND sx.subject_hash = ? AND sx.subject_id = ?) `, col)
 			*args = append(*args, subjectType, journal.SubjectHash(subjectType, subjectID), subjectID)
 		}
 	}
@@ -943,9 +950,9 @@ func appendEntryFilters(b *strings.Builder, args *[]any, req journal.SearchReque
 		labels = labels[1:]
 	}
 	for _, label := range labels {
-		b.WriteString(`AND EXISTS (SELECT 1 FROM journal_labels lx
-			WHERE lx.tenant_id = j.tenant_id AND lx.journal_id = j.journal_id
-			AND lx.label_key = ? AND lx.label_hash = ? AND lx.label_value = ?) `)
+		fmt.Fprintf(b, `AND EXISTS (SELECT 1 FROM journal_labels lx
+			WHERE lx.%[1]s = j.%[1]s AND lx.journal_id = j.journal_id
+			AND lx.label_key = ? AND lx.label_hash = ? AND lx.label_value = ?) `, col)
 		*args = append(*args, label.Key, journal.LabelHash(label.Key, label.Value), label.Value)
 	}
 	return nil
@@ -955,18 +962,19 @@ func (s *Store) searchJournalLabels(ctx context.Context, tenantID string, req jo
 	labels := journal.NormalizeLabels(req.Labels)
 	var b strings.Builder
 	args := []any{}
+	col := s.tenantCol()
 	b.WriteString(`SELECT j.journal_id, j.kind, j.title, j.created_at, `)
 	if len(labels) > 0 {
 		first := labels[0]
 		b.WriteString(`l.created_at FROM `)
-		b.WriteString(`journal_labels l JOIN journals j
-			ON j.tenant_id = l.tenant_id AND j.journal_id = l.journal_id
-			WHERE l.tenant_id = ? AND l.label_key = ? AND l.label_hash = ? AND l.label_value = ? `)
-		args = append(args, tenantID, first.Key, journal.LabelHash(first.Key, first.Value), first.Value)
+		b.WriteString(fmt.Sprintf(`journal_labels l JOIN journals j
+			ON j.%[1]s = l.%[1]s AND j.journal_id = l.journal_id
+			WHERE l.%[1]s = ? AND l.label_key = ? AND l.label_hash = ? AND l.label_value = ? `, col))
+		args = append(args, s.tenantArg(tenantID), first.Key, journal.LabelHash(first.Key, first.Value), first.Value)
 	} else {
 		b.WriteString(`j.created_at FROM `)
-		b.WriteString(`journals j WHERE j.tenant_id = ? `)
-		args = append(args, tenantID)
+		b.WriteString(fmt.Sprintf(`journals j WHERE j.%s = ? `, col))
+		args = append(args, s.tenantArg(tenantID))
 	}
 	if req.Kind != "" {
 		b.WriteString(`AND j.kind = ? `)
@@ -1001,9 +1009,9 @@ func (s *Store) searchJournalLabels(ctx context.Context, tenantID string, req jo
 		if i == 0 {
 			continue
 		}
-		b.WriteString(`AND EXISTS (SELECT 1 FROM journal_labels lx
-			WHERE lx.tenant_id = j.tenant_id AND lx.journal_id = j.journal_id
-			AND lx.label_key = ? AND lx.label_hash = ? AND lx.label_value = ?) `)
+		b.WriteString(fmt.Sprintf(`AND EXISTS (SELECT 1 FROM journal_labels lx
+			WHERE lx.%[1]s = j.%[1]s AND lx.journal_id = j.journal_id
+			AND lx.label_key = ? AND lx.label_hash = ? AND lx.label_value = ?) `, col))
 		args = append(args, label.Key, journal.LabelHash(label.Key, label.Value), label.Value)
 	}
 	if len(labels) > 0 {

--- a/pkg/datastore/journal.go
+++ b/pkg/datastore/journal.go
@@ -513,11 +513,10 @@ func (s *Store) selectJournalTx(ctx context.Context, tx *sql.Tx, tenantID, journ
 		query += " FOR UPDATE"
 	}
 	row := tx.QueryRowContext(ctx, query, s.tenantArg(tenantID), journalID)
-	j, createHash, err := scanJournal(row)
+	j, createHash, err := scanJournal(row, tenantID)
 	if err != nil {
 		return nil, "", err
 	}
-	j.TenantID = tenantID
 	labels, err := s.selectJournalLabelsTx(ctx, tx, tenantID, journalID)
 	if err != nil {
 		return nil, "", err
@@ -561,13 +560,19 @@ func (s *Store) journalExists(ctx context.Context, tenantID, journalID string) (
 	return true, nil
 }
 
-func scanJournal(row interface{ Scan(dest ...any) error }) (*journal.Journal, string, error) {
+// scanJournal scans one journals row. The leading column is the tenant
+// discriminator (tenant_id in standalone shape, fs_id in shared shape); it is
+// discarded and tenantID — the authoritative identity the caller resolved —
+// is stamped onto the result instead, so a shared-shape numeric fs_id can
+// never leak into Journal.TenantID.
+func scanJournal(row interface{ Scan(dest ...any) error }, tenantID string) (*journal.Journal, string, error) {
 	var j journal.Journal
 	var title, actorType, actorID, source sql.NullString
 	var metaRaw, retentionRaw []byte
 	var closedAt sql.NullTime
 	var createHash string
-	if err := row.Scan(&j.TenantID, &j.JournalID, &j.Kind, &title, &actorType, &actorID, &source,
+	var tenantDiscriminator any
+	if err := row.Scan(&tenantDiscriminator, &j.JournalID, &j.Kind, &title, &actorType, &actorID, &source,
 		&metaRaw, &retentionRaw, &j.NextSeq, &j.GenesisHash, &j.HeadHash, &j.CreatedAt,
 		&j.UpdatedAt, &closedAt, &createHash); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -575,6 +580,7 @@ func scanJournal(row interface{ Scan(dest ...any) error }) (*journal.Journal, st
 		}
 		return nil, "", err
 	}
+	j.TenantID = tenantID
 	j.Title = title.String
 	j.Actor = journal.Actor{Type: actorType.String, ID: actorID.String}
 	j.Source = source.String

--- a/pkg/datastore/journal_shared_test.go
+++ b/pkg/datastore/journal_shared_test.go
@@ -1,0 +1,277 @@
+package datastore
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/journal"
+	"github.com/mem9-ai/drive9/pkg/tenant/schema"
+)
+
+// installSharedJournalSchema swaps the 5 journal tables to the shared shape.
+func installSharedJournalSchema(t *testing.T) {
+	t.Helper()
+	journalTables := []string{
+		"journal_entry_subjects",
+		"journal_entries",
+		"journal_append_requests",
+		"journal_labels",
+		"journals",
+	}
+	installSharedTables(t, journalTables, schema.JournalMySQLSharedSchemaStatements())
+}
+
+// newSharedJournalStore opens a Store bound to the shared journal schema with
+// the given fs_id as its tenant row key.
+func newSharedJournalStore(t *testing.T, fsID int64) *Store {
+	t.Helper()
+	return newSharedStore(t, fsID)
+}
+
+// runJournalCoreScenario exercises the journal core flow (create, idempotent
+// create, conflicting create, append, idempotent append, conflicting append,
+// list, search, verify) against a store. It is run against both schema
+// shapes to prove behavioral parity.
+func runJournalCoreScenario(t *testing.T, store *Store, tenantID, journalID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	created, err := store.CreateJournal(ctx, tenantID, journal.CreateRequest{
+		JournalID: journalID,
+		Kind:      "agent",
+		Title:     "test run",
+		Meta:      map[string]string{"repo": "github.com/mem9-ai/drive9"},
+		Labels:    []journal.Label{{Key: "env", Value: "test"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateJournal: %v", err)
+	}
+	if created.TenantID != tenantID {
+		t.Fatalf("created TenantID = %q, want %q", created.TenantID, tenantID)
+	}
+	if created.HeadHash == "" || created.GenesisHash != created.HeadHash {
+		t.Fatalf("genesis/head hash mismatch: %#v", created)
+	}
+
+	createdAgain, err := store.CreateJournal(ctx, tenantID, journal.CreateRequest{
+		JournalID: journalID,
+		Kind:      "agent",
+		Title:     "test run",
+		Meta:      map[string]string{"repo": "github.com/mem9-ai/drive9"},
+		Labels:    []journal.Label{{Key: "env", Value: "test"}},
+	})
+	if err != nil {
+		t.Fatalf("CreateJournal retry: %v", err)
+	}
+	if createdAgain.JournalID != created.JournalID || createdAgain.HeadHash != created.HeadHash {
+		t.Fatalf("idempotent create = %#v, want %#v", createdAgain, created)
+	}
+	if _, err := store.CreateJournal(ctx, tenantID, journal.CreateRequest{
+		JournalID: journalID,
+		Kind:      "agent",
+		Title:     "different",
+	}); !errors.Is(err, ErrJournalConflict) {
+		t.Fatalf("CreateJournal conflict err = %v, want ErrJournalConflict", err)
+	}
+
+	occurred := time.Date(2026, 5, 12, 1, 2, 3, 456789000, time.UTC)
+	entryInput := []journal.EntryInput{{
+		Type:       "tool.call.completed",
+		Status:     "ok",
+		OccurredAt: &occurred,
+		Subjects:   []string{"tool:exec_command"},
+		Summary:    []byte(`{"cmd":"go test ./..."}`),
+	}}
+	resp, err := store.AppendJournalEntries(ctx, tenantID, journalID, "app_test", JournalWriter{Type: "api_key", ID: "key-1"}, entryInput)
+	if err != nil {
+		t.Fatalf("AppendJournalEntries: %v", err)
+	}
+	if resp.FirstSeq != 1 || resp.LastSeq != 1 || resp.Count != 1 || resp.HeadHash == "" {
+		t.Fatalf("append response = %#v", resp)
+	}
+	if resp.Idempotent {
+		t.Fatalf("fresh append marked idempotent: %#v", resp)
+	}
+	respAgain, err := store.AppendJournalEntries(ctx, tenantID, journalID, "app_test", JournalWriter{Type: "api_key", ID: "key-1"}, entryInput)
+	if err != nil {
+		t.Fatalf("AppendJournalEntries retry: %v", err)
+	}
+	wantReplay := *resp
+	wantReplay.Idempotent = true
+	if *respAgain != wantReplay {
+		t.Fatalf("idempotent append = %#v, want %#v", respAgain, wantReplay)
+	}
+	if _, err := store.AppendJournalEntries(ctx, tenantID, journalID, "app_test", JournalWriter{Type: "api_key", ID: "key-1"}, []journal.EntryInput{{
+		Type:     "tool.call.completed",
+		Status:   "error",
+		Subjects: []string{"tool:exec_command"},
+	}}); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("AppendJournalEntries conflict err = %v, want ErrIdempotencyConflict", err)
+	}
+
+	entries, err := store.ListJournalEntries(ctx, tenantID, journalID, 0, 10)
+	if err != nil {
+		t.Fatalf("ListJournalEntries: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Seq != 1 || entries[0].Source != journal.SourceSelf {
+		t.Fatalf("entries = %#v", entries)
+	}
+	if entries[0].TenantID != tenantID {
+		t.Fatalf("entry TenantID = %q, want %q", entries[0].TenantID, tenantID)
+	}
+	if entries[0].Actor.Type != "api_key" || entries[0].Actor.ID != "key-1" {
+		t.Fatalf("entry actor = %#v, want authenticated writer fallback", entries[0].Actor)
+	}
+	if got := journal.FormatTime(entries[0].OccurredAt); got != "2026-05-12T01:02:03.456Z" {
+		t.Fatalf("occurred_at = %s, want millisecond UTC canonicalization", got)
+	}
+
+	matches, err := store.SearchJournal(ctx, tenantID, journal.SearchRequest{
+		Subjects: []string{"tool:exec_command"},
+		Limit:    10,
+	})
+	if err != nil {
+		t.Fatalf("SearchJournal: %v", err)
+	}
+	if len(matches) != 1 || matches[0].JournalID != journalID || matches[0].Seq != 1 {
+		t.Fatalf("matches = %#v", matches)
+	}
+	matches, err = store.SearchJournal(ctx, tenantID, journal.SearchRequest{
+		ActorType: "api_key",
+		ActorID:   "key-1",
+		Limit:     10,
+	})
+	if err != nil {
+		t.Fatalf("SearchJournal actor: %v", err)
+	}
+	if len(matches) != 1 || matches[0].JournalID != journalID || matches[0].Seq != 1 {
+		t.Fatalf("actor matches = %#v", matches)
+	}
+
+	verify, err := store.VerifyJournal(ctx, tenantID, journalID)
+	if err != nil {
+		t.Fatalf("VerifyJournal: %v", err)
+	}
+	if !verify.OK || !verify.HashChainOK || verify.Entries != 1 || verify.HeadHash != resp.HeadHash {
+		t.Fatalf("verify = %#v", verify)
+	}
+	if verify.ProjectionOK == nil || !*verify.ProjectionOK {
+		t.Fatalf("verify projection_ok = %#v, want true", verify.ProjectionOK)
+	}
+}
+
+// TestJournalSharedShapeParity runs the same scenario used by the standalone
+// journal tests against the shared (fs_id) schema shape.
+func TestJournalSharedShapeParity(t *testing.T) {
+	installSharedJournalSchema(t)
+	store := newSharedJournalStore(t, 4200001)
+	runJournalCoreScenario(t, store, "tenant-shared-parity", "jrn_shared_parity")
+}
+
+// TestJournalSharedShapeCrossTenantIsolation proves rows of one fs_id are
+// invisible to another fs_id on the same shared tables, and that the same
+// journal_id can coexist under two fs_ids with independent sequences.
+func TestJournalSharedShapeCrossTenantIsolation(t *testing.T) {
+	installSharedJournalSchema(t)
+	ctx := context.Background()
+	storeA := newSharedJournalStore(t, 4200002)
+	storeB := newSharedJournalStore(t, 4200003)
+	tenantA, tenantB := "tenant-iso-a", "tenant-iso-b"
+
+	// Same journal_id under two different fs_ids must coexist.
+	for _, tc := range []struct {
+		store    *Store
+		tenantID string
+	}{
+		{storeA, tenantA},
+		{storeB, tenantB},
+	} {
+		if _, err := tc.store.CreateJournal(ctx, tc.tenantID, journal.CreateRequest{
+			JournalID: "jrn_iso",
+			Kind:      "agent",
+		}); err != nil {
+			t.Fatalf("CreateJournal %s: %v", tc.tenantID, err)
+		}
+	}
+	if _, err := storeA.AppendJournalEntries(ctx, tenantA, "jrn_iso", "app_a", JournalWriter{Type: "api_key", ID: "k"}, []journal.EntryInput{{
+		Type:     "note",
+		Subjects: []string{"file:/a-only"},
+	}}); err != nil {
+		t.Fatalf("append A: %v", err)
+	}
+
+	// B must not see A's entries; B's own journal has an independent seq space.
+	entriesB, err := storeB.ListJournalEntries(ctx, tenantB, "jrn_iso", 0, 10)
+	if err != nil {
+		t.Fatalf("ListJournalEntries B: %v", err)
+	}
+	if len(entriesB) != 0 {
+		t.Fatalf("B sees %d entries, want 0 (cross-tenant leak)", len(entriesB))
+	}
+	matchesB, err := storeB.SearchJournal(ctx, tenantB, journal.SearchRequest{Subjects: []string{"file:/a-only"}, Limit: 10})
+	if err != nil {
+		t.Fatalf("SearchJournal B: %v", err)
+	}
+	if len(matchesB) != 0 {
+		t.Fatalf("B search sees %d matches, want 0 (cross-tenant leak)", len(matchesB))
+	}
+	respB, err := storeB.AppendJournalEntries(ctx, tenantB, "jrn_iso", "app_b", JournalWriter{Type: "api_key", ID: "k"}, []journal.EntryInput{{
+		Type:     "note",
+		Subjects: []string{"file:/b-only"},
+	}})
+	if err != nil {
+		t.Fatalf("append B: %v", err)
+	}
+	if respB.FirstSeq != 1 {
+		t.Fatalf("B first seq = %d, want 1 (seq space must be per fs_id)", respB.FirstSeq)
+	}
+
+	// A journal id that only A created must be invisible to B.
+	if _, err := storeA.CreateJournal(ctx, tenantA, journal.CreateRequest{JournalID: "jrn_a_only", Kind: "agent"}); err != nil {
+		t.Fatalf("CreateJournal jrn_a_only: %v", err)
+	}
+	if _, err := storeB.ListJournalEntries(ctx, tenantB, "jrn_a_only", 0, 10); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("B list jrn_a_only err = %v, want ErrNotFound", err)
+	}
+	if _, err := storeB.VerifyJournal(ctx, tenantB, "jrn_a_only"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("B verify jrn_a_only err = %v, want ErrNotFound", err)
+	}
+}
+
+// TestJournalSharedShapeStoresFsID asserts every journal table row carries
+// the scope's fs_id as its tenant discriminator.
+func TestJournalSharedShapeStoresFsID(t *testing.T) {
+	installSharedJournalSchema(t)
+	const fsID int64 = 4200004
+	store := newSharedJournalStore(t, fsID)
+	runJournalCoreScenario(t, store, "tenant-fsid-check", "jrn_fsid")
+
+	for _, tbl := range []string{"journals", "journal_labels", "journal_append_requests", "journal_entries", "journal_entry_subjects"} {
+		var got int64
+		err := store.DB().QueryRow("SELECT COUNT(*) FROM "+tbl+" WHERE fs_id != ?", fsID).Scan(&got)
+		if err != nil {
+			t.Fatalf("count %s rows with foreign fs_id: %v", tbl, err)
+		}
+		if got != 0 {
+			t.Fatalf("%s has %d rows with fs_id != %d", tbl, got, fsID)
+		}
+		var total int64
+		if err := store.DB().QueryRow("SELECT COUNT(*) FROM " + tbl).Scan(&total); err != nil {
+			t.Fatalf("count %s: %v", tbl, err)
+		}
+		if total == 0 {
+			t.Fatalf("%s is empty; scenario should have written rows", tbl)
+		}
+	}
+	// No residual tenant_id column in the shared shape.
+	var n int
+	if err := store.DB().QueryRow(`SELECT COUNT(*) FROM information_schema.columns
+		WHERE table_schema = DATABASE() AND table_name = 'journals' AND column_name = 'tenant_id'`).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 0 {
+		t.Fatal("shared journals table still has tenant_id column")
+	}
+}

--- a/pkg/datastore/llm_usage.go
+++ b/pkg/datastore/llm_usage.go
@@ -6,9 +6,9 @@ import (
 
 // InsertLLMUsage records one billable LLM call.
 func (s *Store) InsertLLMUsage(taskType, taskID string, costMillicents, rawUnits int64, rawUnitType string) error {
-	_, err := s.db.Exec(`INSERT INTO llm_usage (task_type, task_id, cost_millicents, raw_units, raw_unit_type, created_at)
-		VALUES (?, ?, ?, ?, ?, ?)`,
-		taskType, taskID, costMillicents, rawUnits, rawUnitType, time.Now().UTC())
+	_, err := s.db.Exec(`INSERT INTO llm_usage (`+s.scope.InsCols(`task_type, task_id, cost_millicents, raw_units, raw_unit_type, created_at`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(taskType, taskID, costMillicents, rawUnits, rawUnitType, time.Now().UTC())...)
 	return err
 }
 
@@ -18,6 +18,7 @@ func (s *Store) MonthlyLLMCostMillicents() (int64, error) {
 	now := time.Now().UTC()
 	monthStart := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
 	var total int64
-	err := s.db.QueryRow(`SELECT COALESCE(SUM(cost_millicents), 0) FROM llm_usage WHERE created_at >= ?`, monthStart).Scan(&total)
+	err := s.db.QueryRow(`SELECT COALESCE(SUM(cost_millicents), 0) FROM llm_usage WHERE `+s.scope.And(`created_at >= ?`),
+		s.scope.Args(monthStart)...).Scan(&total)
 	return total, err
 }

--- a/pkg/datastore/purge.go
+++ b/pkg/datastore/purge.go
@@ -1,0 +1,88 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+// purgeBatchSize bounds each DELETE batch when purging a tenant from shared
+// tables, so a large tenant does not produce one huge statement.
+const purgeBatchSize = 10000
+
+// sharedPurgeTables lists every shared-schema table in child-before-parent
+// order for tenant data purges. llm_usage is deliberately absent (no shared
+// table; the central meta DB ledger is authoritative).
+var sharedPurgeTables = []string{
+	"journal_entry_subjects",
+	"journal_entries",
+	"journal_append_requests",
+	"journal_labels",
+	"journals",
+	"vault_audit_log",
+	"vault_grants",
+	"vault_tokens",
+	"vault_secret_fields",
+	"vault_secrets",
+	"vault_policies",
+	"vault_deks",
+	"git_workspace_object_packs",
+	"git_workspace_overlay",
+	"git_workspace_git_state",
+	"git_workspace_tree_nodes",
+	"git_workspaces",
+	"fs_layer_checkpoints",
+	"fs_layer_events",
+	"fs_layer_tags",
+	"fs_layer_entries",
+	"fs_layers",
+	"fs_events",
+	"semantic_tasks",
+	"file_gc_tasks",
+	"uploads",
+	"file_tags",
+	"file_nodes",
+	"semantic",
+	"contents",
+	"inodes",
+}
+
+// NewStoreWithDB wraps an externally owned *sql.DB (e.g. a shared-pool handle
+// serving many tenants) with the given scope. Close is a no-op — the owner
+// controls the handle's lifetime. No legacy-files detection runs: shared
+// schema databases never carry the legacy files table.
+func NewStoreWithDB(db *sql.DB, scope Scope) *Store {
+	return &Store{db: db, scope: scope, externalDB: true}
+}
+
+// PurgeTenantData deletes all rows belonging to this store's tenant (fs_id)
+// from every shared-schema table, in bounded batches. It is only valid on
+// shared-scope stores; on a standalone store it returns an error because the
+// tables have no fs_id column to restrict by.
+//
+// The purge runs without a transaction: each batch commits independently, so
+// a large tenant's purge is interruptible and does not hold long-lived locks.
+// Callers orchestrating a tenant delete must treat the operation as
+// resumable — re-running it after a failure simply continues.
+func (s *Store) PurgeTenantData(ctx context.Context) error {
+	if !s.scope.Shared() {
+		return fmt.Errorf("purge tenant data requires shared scope")
+	}
+	for _, tbl := range sharedPurgeTables {
+		for {
+			res, err := s.db.ExecContext(ctx,
+				"DELETE FROM "+tbl+" WHERE fs_id = ? LIMIT ?", s.scope.FsID(), purgeBatchSize)
+			if err != nil {
+				if isMissingTableError(err) {
+					break
+				}
+				return fmt.Errorf("purge table %s: %w", tbl, err)
+			}
+			n, err := res.RowsAffected()
+			if err != nil || n == 0 {
+				break
+			}
+		}
+	}
+	return nil
+}

--- a/pkg/datastore/purge.go
+++ b/pkg/datastore/purge.go
@@ -2,7 +2,6 @@ package datastore
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
 )
 
@@ -47,14 +46,6 @@ var sharedPurgeTables = []string{
 	"inodes",
 }
 
-// NewStoreWithDB wraps an externally owned *sql.DB (e.g. a shared-pool handle
-// serving many tenants) with the given scope. Close is a no-op — the owner
-// controls the handle's lifetime. No legacy-files detection runs: shared
-// schema databases never carry the legacy files table.
-func NewStoreWithDB(db *sql.DB, scope Scope) *Store {
-	return &Store{db: db, scope: scope, externalDB: true}
-}
-
 // PurgeTenantData deletes all rows belonging to this store's tenant (fs_id)
 // from every shared-schema table, in bounded batches. It is only valid on
 // shared-scope stores; on a standalone store it returns an error because the
@@ -79,7 +70,10 @@ func (s *Store) PurgeTenantData(ctx context.Context) error {
 				return fmt.Errorf("purge table %s: %w", tbl, err)
 			}
 			n, err := res.RowsAffected()
-			if err != nil || n == 0 {
+			if err != nil {
+				return fmt.Errorf("purge table %s rows affected: %w", tbl, err)
+			}
+			if n == 0 {
 				break
 			}
 		}

--- a/pkg/datastore/purge_test.go
+++ b/pkg/datastore/purge_test.go
@@ -1,0 +1,107 @@
+package datastore
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/journal"
+	"github.com/mem9-ai/drive9/pkg/tenant/schema"
+)
+
+// TestPurgeTenantDataSharedShape seeds rows for two fs_ids across the shared
+// table groups, purges one tenant, and asserts its rows are gone everywhere
+// while the other tenant is untouched.
+func TestPurgeTenantDataSharedShape(t *testing.T) {
+	installSharedCoreFSSchema(t)
+	installSharedJournalSchema(t)
+	installSharedFSLayerSchema(t)
+	installSharedGitSchema(t)
+	installSharedTables(t, []string{
+		"vault_audit_log", "vault_grants", "vault_tokens", "vault_secret_fields",
+		"vault_secrets", "vault_policies", "vault_deks",
+	}, schema.VaultMySQLSharedSchemaStatements())
+
+	ctx := context.Background()
+	const fsA, fsB int64 = 4500001, 4500002
+	storeA := newSharedStore(t, fsA)
+	storeB := newSharedStore(t, fsB)
+	now := time.Now()
+
+	for _, tc := range []struct {
+		store *Store
+		pfx   string
+	}{
+		{storeA, "purge-a"},
+		{storeB, "purge-b"},
+	} {
+		if err := tc.store.InsertFile(ctx, &File{
+			FileID: tc.pfx + "-file", StorageType: StorageDB9, StorageRef: "inline:" + tc.pfx,
+			SizeBytes: 1, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+		}); err != nil {
+			t.Fatalf("InsertFile %s: %v", tc.pfx, err)
+		}
+		if err := tc.store.InsertNode(ctx, &FileNode{
+			NodeID: tc.pfx + "-node", Path: "/" + tc.pfx + "/f.txt", ParentPath: "/" + tc.pfx,
+			Name: "f.txt", FileID: tc.pfx + "-file", CreatedAt: now,
+		}); err != nil {
+			t.Fatalf("InsertNode %s: %v", tc.pfx, err)
+		}
+		if _, err := tc.store.CreateJournal(ctx, tc.pfx, journal.CreateRequest{JournalID: "jrn_purge", Kind: "agent"}); err != nil {
+			t.Fatalf("CreateJournal %s: %v", tc.pfx, err)
+		}
+		if _, err := tc.store.AppendJournalEntries(ctx, tc.pfx, "jrn_purge", "app-purge", JournalWriter{Type: "api_key", ID: "k"}, []journal.EntryInput{{Type: "note", Subjects: []string{"file:/x"}}}); err != nil {
+			t.Fatalf("AppendJournalEntries %s: %v", tc.pfx, err)
+		}
+		if _, err := tc.store.InsertFSEvent(ctx, "/"+tc.pfx+"/f.txt", "write", "test", now.UnixMilli()); err != nil {
+			t.Fatalf("InsertFSEvent %s: %v", tc.pfx, err)
+		}
+		if _, err := tc.store.DB().Exec(`INSERT INTO vault_deks (fs_id, wrapped_dek) VALUES (?, X'01')`,
+			tc.store.Scope().FsID()); err != nil {
+			t.Fatalf("insert vault_deks %s: %v", tc.pfx, err)
+		}
+	}
+
+	if err := storeA.PurgeTenantData(ctx); err != nil {
+		t.Fatalf("PurgeTenantData A: %v", err)
+	}
+
+	// Tenant A: everything gone.
+	for _, tbl := range []string{
+		"file_nodes", "inodes", "contents", "fs_events", "journals", "journal_entries", "vault_deks",
+	} {
+		if n := countFsIDRows(t, storeA, tbl, fsA); n != 0 {
+			t.Fatalf("A %s rows after purge = %d, want 0", tbl, n)
+		}
+	}
+	// Tenant B: fully intact (file, dentry, journal, events, vault row).
+	if _, err := storeB.GetFile(ctx, "purge-b-file"); err != nil {
+		t.Fatalf("B GetFile after A purge: %v", err)
+	}
+	if _, err := storeB.GetNode(ctx, "/purge-b/f.txt"); err != nil {
+		t.Fatalf("B GetNode after A purge: %v", err)
+	}
+	entries, err := storeB.ListJournalEntries(ctx, "purge-b", "jrn_purge", 0, 10)
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("B journal entries = %d, %v; want 1, nil", len(entries), err)
+	}
+	if n := countFsIDRows(t, storeB, "vault_deks", fsB); n != 1 {
+		t.Fatalf("B vault_deks rows = %d, want 1", n)
+	}
+	eventsB, err := storeB.ListFSEventsSince(ctx, 0, 10)
+	if err != nil || len(eventsB) != 1 {
+		t.Fatalf("B fs events = %d, %v; want 1, nil", len(eventsB), err)
+	}
+
+	// Purge is idempotent: a second run is a no-op success.
+	if err := storeA.PurgeTenantData(ctx); err != nil {
+		t.Fatalf("PurgeTenantData A second run: %v", err)
+	}
+}
+
+func TestPurgeTenantDataRejectsStandalone(t *testing.T) {
+	store := newJournalStore(t) // standalone scope
+	if err := store.PurgeTenantData(context.Background()); err == nil {
+		t.Fatal("expected error on standalone store")
+	}
+}

--- a/pkg/datastore/scope.go
+++ b/pkg/datastore/scope.go
@@ -69,14 +69,30 @@ func (s Scope) And(pred string) string {
 }
 
 // AndAs is And with a table-alias qualifier, for JOIN queries: shared shape
-// emits "<alias>.fs_id = ? AND <pred>". Filter the driving table of the join;
-// entity ids (inode_id, file_id, layer_id, workspace_id, ...) are globally
-// unique, so a one-sided fs_id predicate is sufficient for correctness.
+// emits "<alias>.fs_id = ? AND <pred>". In shared shape entity ids (inode_id,
+// file_id, layer_id, workspace_id, ...) are unique only within a tenant —
+// the composite (fs_id, id) keys deliberately allow the same id under two
+// fs_ids — so EVERY alias of a multi-table join must carry an fs_id
+// predicate (scopeWhereAnd for inner joins, AndOn for LEFT JOIN ON clauses),
+// never just the driving table.
 func (s Scope) AndAs(alias, pred string) string {
 	if s.shared {
 		return alias + ".fs_id = ? AND " + pred
 	}
 	return pred
+}
+
+// AndOn appends "AND <alias>.fs_id = ?" to a JOIN ON condition in shared
+// shape and returns it unchanged in standalone shape. Use it for LEFT JOINs:
+// a WHERE-clause fs_id predicate on the right table would discard the
+// null-extended rows and silently turn the LEFT JOIN into an INNER JOIN.
+// The bind argument belongs before the WHERE arguments (ON clauses precede
+// WHERE textually).
+func (s Scope) AndOn(cond, alias string) string {
+	if s.shared {
+		return cond + " AND " + alias + ".fs_id = ?"
+	}
+	return cond
 }
 
 // Args prepends the fs_id bind argument in shared shape and returns args

--- a/pkg/datastore/scope.go
+++ b/pkg/datastore/scope.go
@@ -1,0 +1,116 @@
+package datastore
+
+// Scope describes how a Store addresses tenant rows in the underlying
+// database, and is the single injection point for the two schema shapes
+// (docs/TENANT_DB_REDESIGN.md §15.3):
+//
+//   - standalone: per-tenant databases whose tables have no fs_id column
+//     (every pre-existing tenant DB). Scope emits no fs_id predicates.
+//   - shared: a database shared by many tenants whose tables carry an
+//     fs_id BIGINT column as the leading row key. Scope injects fs_id into
+//     every predicate and column list.
+//
+// A Store holds one Scope fixed at construction; datastore methods never
+// take tenant/fs parameters for Core FS tables. Journal and vault tables
+// already carry a tenant discriminator column, so for those tables Scope
+// only switches the column name and value (TenantCol/TenantArg).
+type Scope struct {
+	fsID   int64
+	shared bool
+}
+
+// StandaloneScope returns the Scope for a per-tenant database with the
+// current (no fs_id column) schema shape. fsID is the tenant's registered
+// internal id; it is retained for logging and future routing use but is
+// never emitted into SQL.
+func StandaloneScope(fsID int64) Scope {
+	return Scope{fsID: fsID}
+}
+
+// SharedScope returns the Scope for a shared database whose tables carry an
+// fs_id column. fsID must be the tenant's registered id from fs_registry.
+func SharedScope(fsID int64) Scope {
+	return Scope{fsID: fsID, shared: true}
+}
+
+// Shared reports whether the Store addresses a shared-schema database.
+func (s Scope) Shared() bool { return s.shared }
+
+// FsID returns the tenant's internal numeric id (0 when unknown).
+func (s Scope) FsID() int64 { return s.fsID }
+
+// TenantCol returns the tenant-discriminator column name used by journal and
+// vault tables: "tenant_id" in standalone shape, "fs_id" in shared shape.
+func (s Scope) TenantCol() string {
+	if s.shared {
+		return "fs_id"
+	}
+	return "tenant_id"
+}
+
+// TenantArg returns the tenant-discriminator value for journal and vault
+// queries: the tenant UUID string in standalone shape, the internal fs_id in
+// shared shape.
+func (s Scope) TenantArg(tenantID string) any {
+	if s.shared {
+		return s.fsID
+	}
+	return tenantID
+}
+
+// And prefixes a WHERE predicate with "fs_id = ? AND " in shared shape and
+// returns it unchanged in standalone shape. pred must be a fixed string,
+// never user input.
+func (s Scope) And(pred string) string {
+	if s.shared {
+		return "fs_id = ? AND " + pred
+	}
+	return pred
+}
+
+// AndAs is And with a table-alias qualifier, for JOIN queries: shared shape
+// emits "<alias>.fs_id = ? AND <pred>". Filter the driving table of the join;
+// entity ids (inode_id, file_id, layer_id, workspace_id, ...) are globally
+// unique, so a one-sided fs_id predicate is sufficient for correctness.
+func (s Scope) AndAs(alias, pred string) string {
+	if s.shared {
+		return alias + ".fs_id = ? AND " + pred
+	}
+	return pred
+}
+
+// Args prepends the fs_id bind argument in shared shape and returns args
+// unchanged in standalone shape.
+func (s Scope) Args(args ...any) []any {
+	if s.shared {
+		return append([]any{s.fsID}, args...)
+	}
+	return args
+}
+
+// InsCols prefixes an INSERT column list with "fs_id, " in shared shape and
+// returns it unchanged in standalone shape.
+func (s Scope) InsCols(cols string) string {
+	if s.shared {
+		return "fs_id, " + cols
+	}
+	return cols
+}
+
+// InsVals prefixes an INSERT VALUES placeholder list with "?, " in shared
+// shape and returns it unchanged in standalone shape.
+func (s Scope) InsVals(vals string) string {
+	if s.shared {
+		return "?, " + vals
+	}
+	return vals
+}
+
+// tenantCol returns the tenant-discriminator column name for journal/vault
+// tables under this Store's schema shape.
+func (s *Store) tenantCol() string { return s.scope.TenantCol() }
+
+// tenantArg returns the bind value for the tenant discriminator of
+// journal/vault tables: tenantID in standalone shape, the scope's fs_id in
+// shared shape.
+func (s *Store) tenantArg(tenantID string) any { return s.scope.TenantArg(tenantID) }

--- a/pkg/datastore/search.go
+++ b/pkg/datastore/search.go
@@ -76,10 +76,9 @@ func subtreeCond(prefix string) (string, []any) {
 
 // scopeWhereAnd prefixes a WHERE predicate with one fs_id predicate per JOIN
 // alias in shared shape and returns it unchanged in standalone shape. Every
-// joined alias is filtered, not just the driving table: entity ids are
-// globally unique ULIDs in production, but if ids ever collide the bare
-// id-only join conditions would otherwise fan out across tenants and leak
-// rows sideways.
+// joined alias is filtered, not just the driving table: in shared shape
+// entity ids are unique only within a tenant, so an id-only join condition
+// would fan out across tenants and leak rows sideways on collision.
 func scopeWhereAnd(scope Scope, pred string, aliases ...string) string {
 	for i := len(aliases) - 1; i >= 0; i-- {
 		pred = scope.AndAs(aliases[i], pred)

--- a/pkg/datastore/search.go
+++ b/pkg/datastore/search.go
@@ -74,9 +74,35 @@ func subtreeCond(prefix string) (string, []any) {
 	return "(fn.path = ? OR fn.path LIKE ?)", []any{prefix, prefix + "/%"}
 }
 
+// scopeWhereAnd prefixes a WHERE predicate with one fs_id predicate per JOIN
+// alias in shared shape and returns it unchanged in standalone shape. Every
+// joined alias is filtered, not just the driving table: entity ids are
+// globally unique ULIDs in production, but if ids ever collide the bare
+// id-only join conditions would otherwise fan out across tenants and leak
+// rows sideways.
+func scopeWhereAnd(scope Scope, pred string, aliases ...string) string {
+	for i := len(aliases) - 1; i >= 0; i-- {
+		pred = scope.AndAs(aliases[i], pred)
+	}
+	return pred
+}
+
+// scopeWhereArgs prepends one fs_id bind argument per alias, matching the
+// predicate order produced by scopeWhereAnd.
+func scopeWhereArgs(scope Scope, aliases int, args ...any) []any {
+	if !scope.Shared() {
+		return args
+	}
+	out := make([]any, 0, aliases+len(args))
+	for i := 0; i < aliases; i++ {
+		out = append(out, scope.FsID())
+	}
+	return append(out, args...)
+}
+
 // VectorSearch runs a vector similarity search for the supplied embedding.
 func (s *Store) VectorSearch(ctx context.Context, queryEmbedding []float32, pathPrefix string, limit int) ([]SearchResult, error) {
-	q, args, ok := buildVectorSearchQuery(queryEmbedding, pathPrefix, limit)
+	q, args, ok := buildVectorSearchQueryScoped(s.scope, queryEmbedding, pathPrefix, limit)
 	if !ok {
 		return nil, nil
 	}
@@ -85,7 +111,7 @@ func (s *Store) VectorSearch(ctx context.Context, queryEmbedding []float32, path
 
 // VectorSearchByText runs a TiDB-side text-query vector similarity search.
 func (s *Store) VectorSearchByText(ctx context.Context, queryText, pathPrefix string, limit int) ([]SearchResult, error) {
-	q, args, ok := buildVectorSearchByTextQuery(queryText, pathPrefix, limit)
+	q, args, ok := buildVectorSearchByTextQueryScoped(s.scope, queryText, pathPrefix, limit)
 	if !ok {
 		return nil, nil
 	}
@@ -120,6 +146,13 @@ func (s *Store) runVectorSearch(ctx context.Context, q string, args []any) ([]Se
 }
 
 func buildVectorSearchQuery(queryEmbedding []float32, pathPrefix string, limit int) (string, []any, bool) {
+	return buildVectorSearchQueryScoped(StandaloneScope(0), queryEmbedding, pathPrefix, limit)
+}
+
+// buildVectorSearchQueryScoped builds the vector search query for the given
+// schema-shape scope. In shared shape every joined alias carries an fs_id
+// predicate (see scopeWhereAnd).
+func buildVectorSearchQueryScoped(scope Scope, queryEmbedding []float32, pathPrefix string, limit int) (string, []any, bool) {
 	if len(queryEmbedding) == 0 {
 		return "", nil, false
 	}
@@ -127,40 +160,50 @@ func buildVectorSearchQuery(queryEmbedding []float32, pathPrefix string, limit i
 	vecParam := embedding.FormatVector(queryEmbedding)
 	args := []any{vecParam}
 
+	var condArgs []any
 	if pathPrefix != "" && pathPrefix != "/" {
 		cond, pargs := subtreeCond(pathPrefix)
 		conds = append(conds, cond)
-		args = append(args, pargs...)
+		condArgs = append(condArgs, pargs...)
 	}
+	// The fs_id predicates lead the WHERE clause in shared shape, so their
+	// bind arguments go right after the SELECT-list distance placeholder.
+	args = append(args, scopeWhereArgs(scope, 3, condArgs...)...)
 	args = append(args, vecParam, limit)
 
 	q := `SELECT fn.path, fn.name, i.size_bytes,
 		VEC_EMBED_COSINE_DISTANCE(s.embedding, ?) AS distance
 		FROM file_nodes fn JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE ` + strings.Join(conds, " AND ") + `
+		WHERE ` + scopeWhereAnd(scope, strings.Join(conds, " AND "), "fn", "i", "s") + `
 		ORDER BY VEC_EMBED_COSINE_DISTANCE(s.embedding, ?)
 	LIMIT ?`
 	return q, args, true
 }
 
 func buildVectorSearchByTextQuery(queryText, pathPrefix string, limit int) (string, []any, bool) {
+	return buildVectorSearchByTextQueryScoped(StandaloneScope(0), queryText, pathPrefix, limit)
+}
+
+func buildVectorSearchByTextQueryScoped(scope Scope, queryText, pathPrefix string, limit int) (string, []any, bool) {
 	if strings.TrimSpace(queryText) == "" {
 		return "", nil, false
 	}
 	conds := []string{"i.status = 'CONFIRMED'", "s.embedding IS NOT NULL"}
 	args := []any{queryText}
 
+	var condArgs []any
 	if pathPrefix != "" && pathPrefix != "/" {
 		cond, pargs := subtreeCond(pathPrefix)
 		conds = append(conds, cond)
-		args = append(args, pargs...)
+		condArgs = append(condArgs, pargs...)
 	}
+	args = append(args, scopeWhereArgs(scope, 3, condArgs...)...)
 	args = append(args, limit)
 
 	q := `SELECT fn.path, fn.name, i.size_bytes,
 		VEC_EMBED_COSINE_DISTANCE(s.embedding, ?) AS distance
 		FROM file_nodes fn JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE ` + strings.Join(conds, " AND ") + `
+		WHERE ` + scopeWhereAnd(scope, strings.Join(conds, " AND "), "fn", "i", "s") + `
 		ORDER BY distance
 		LIMIT ?`
 	return q, args, true
@@ -168,7 +211,7 @@ func buildVectorSearchByTextQuery(queryText, pathPrefix string, limit int) (stri
 
 // VectorSearchDescription runs a vector similarity search over files.description_embedding.
 func (s *Store) VectorSearchDescription(ctx context.Context, queryEmbedding []float32, pathPrefix string, limit int) ([]SearchResult, error) {
-	q, args, ok := buildVectorSearchDescriptionQuery(queryEmbedding, pathPrefix, limit)
+	q, args, ok := buildVectorSearchDescriptionQueryScoped(s.scope, queryEmbedding, pathPrefix, limit)
 	if !ok {
 		return nil, nil
 	}
@@ -178,14 +221,14 @@ func (s *Store) VectorSearchDescription(ctx context.Context, queryEmbedding []fl
 // VectorSearchDescriptionByText runs a TiDB-side text-query vector similarity search
 // over files.description_embedding.
 func (s *Store) VectorSearchDescriptionByText(ctx context.Context, queryText, pathPrefix string, limit int) ([]SearchResult, error) {
-	q, args, ok := buildVectorSearchDescriptionByTextQuery(queryText, pathPrefix, limit)
+	q, args, ok := buildVectorSearchDescriptionByTextQueryScoped(s.scope, queryText, pathPrefix, limit)
 	if !ok {
 		return nil, nil
 	}
 	return s.runVectorSearch(ctx, q, args)
 }
 
-func buildVectorSearchDescriptionQuery(queryEmbedding []float32, pathPrefix string, limit int) (string, []any, bool) {
+func buildVectorSearchDescriptionQueryScoped(scope Scope, queryEmbedding []float32, pathPrefix string, limit int) (string, []any, bool) {
 	if len(queryEmbedding) == 0 {
 		return "", nil, false
 	}
@@ -193,23 +236,25 @@ func buildVectorSearchDescriptionQuery(queryEmbedding []float32, pathPrefix stri
 	vecParam := embedding.FormatVector(queryEmbedding)
 	args := []any{vecParam}
 
+	var condArgs []any
 	if pathPrefix != "" && pathPrefix != "/" {
 		cond, pargs := subtreeCond(pathPrefix)
 		conds = append(conds, cond)
-		args = append(args, pargs...)
+		condArgs = append(condArgs, pargs...)
 	}
+	args = append(args, scopeWhereArgs(scope, 3, condArgs...)...)
 	args = append(args, vecParam, limit)
 
 	q := `SELECT fn.path, fn.name, i.size_bytes,
 		VEC_EMBED_COSINE_DISTANCE(s.description_embedding, ?) AS distance
 		FROM file_nodes fn JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE ` + strings.Join(conds, " AND ") + `
+		WHERE ` + scopeWhereAnd(scope, strings.Join(conds, " AND "), "fn", "i", "s") + `
 		ORDER BY VEC_EMBED_COSINE_DISTANCE(s.description_embedding, ?)
 	LIMIT ?`
 	return q, args, true
 }
 
-func buildVectorSearchDescriptionByTextQuery(queryText, pathPrefix string, limit int) (string, []any, bool) {
+func buildVectorSearchDescriptionByTextQueryScoped(scope Scope, queryText, pathPrefix string, limit int) (string, []any, bool) {
 	if strings.TrimSpace(queryText) == "" {
 		return "", nil, false
 	}
@@ -218,19 +263,21 @@ func buildVectorSearchDescriptionByTextQuery(queryText, pathPrefix string, limit
 	conds := []string{"i.status = 'CONFIRMED'", "s.description_embedding IS NOT NULL"}
 	args := []any{queryText}
 
+	var condArgs []any
 	if pathPrefix != "" && pathPrefix != "/" {
 		cond, pargs := subtreeCond(pathPrefix)
 		conds = append(conds, cond)
-		args = append(args, pargs...)
+		condArgs = append(condArgs, pargs...)
 	}
+	args = append(args, scopeWhereArgs(scope, 3, condArgs...)...)
 	args = append(args, limit)
 
 	q := `SELECT fn.path, fn.name, i.size_bytes,
 		VEC_EMBED_COSINE_DISTANCE(s.description_embedding, ?) AS distance
 		FROM file_nodes fn JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE ` + strings.Join(conds, " AND ") + `
+		WHERE ` + scopeWhereAnd(scope, strings.Join(conds, " AND "), "fn", "i", "s") + `
 		ORDER BY distance
-	LIMIT ?`
+		LIMIT ?`
 	return q, args, true
 }
 
@@ -247,40 +294,7 @@ func ftsSafe(s string) string {
 
 // FTSSearch runs a full-text search over files.content_text and files.description.
 func (s *Store) FTSSearch(ctx context.Context, query, pathPrefix string, limit int) ([]SearchResult, error) {
-	safe := ftsSafe(query)
-
-	var args []any
-	args = append(args, limit)
-
-	contentExpr := "fts_match_word('" + safe + "', content_text)"
-	descExpr := "fts_match_word('" + safe + "', description)"
-
-	innerQ := `SELECT inode_id, MAX(score) AS score FROM (
-		SELECT inode_id, ` + contentExpr + ` AS score
-		FROM semantic WHERE ` + contentExpr + `
-		UNION ALL
-		SELECT inode_id, ` + descExpr + ` AS score
-		FROM semantic WHERE ` + descExpr + `
-	) fts GROUP BY inode_id ORDER BY score DESC LIMIT ?`
-
-	var outerConds []string
-	var outerArgs []any
-	if pathPrefix != "" && pathPrefix != "/" {
-		cond, pargs := subtreeCond(pathPrefix)
-		outerConds = append(outerConds, cond)
-		outerArgs = append(outerArgs, pargs...)
-	}
-
-	outerConds = append([]string{"i.status = 'CONFIRMED'"}, outerConds...)
-	q := `SELECT fn.path, fn.name, i.size_bytes, fts.score
-		FROM (` + innerQ + `) fts
-		JOIN file_nodes fn ON COALESCE(fn.inode_id, fn.file_id) = fts.inode_id
-		JOIN inodes i ON i.inode_id = fts.inode_id`
-	if len(outerConds) > 0 {
-		q += ` WHERE ` + strings.Join(outerConds, " AND ")
-	}
-
-	allArgs := append(args, outerArgs...)
+	q, allArgs := buildFTSSearchQuery(s.scope, ftsSafe(query), pathPrefix, limit)
 	rows, err := s.db.QueryContext(ctx, q, allArgs...)
 	if err != nil {
 		return nil, err
@@ -303,6 +317,47 @@ func (s *Store) FTSSearch(ctx context.Context, query, pathPrefix string, limit i
 	return out, nil
 }
 
+// buildFTSSearchQuery assembles the full-text search query for the given
+// schema-shape scope. safeQuery must already be escaped with ftsSafe.
+func buildFTSSearchQuery(scope Scope, safeQuery, pathPrefix string, limit int) (string, []any) {
+	contentExpr := "fts_match_word('" + safeQuery + "', content_text)"
+	descExpr := "fts_match_word('" + safeQuery + "', description)"
+
+	// In shared shape the fs_id predicate must live inside each UNION branch
+	// (before the GROUP BY/LIMIT aggregation), otherwise other tenants' rows
+	// compete for the shared LIMIT and dilute per-tenant recall.
+	innerQ := `SELECT inode_id, MAX(score) AS score FROM (
+		SELECT inode_id, ` + contentExpr + ` AS score
+		FROM semantic WHERE ` + scope.And(contentExpr) + `
+		UNION ALL
+		SELECT inode_id, ` + descExpr + ` AS score
+		FROM semantic WHERE ` + scope.And(descExpr) + `
+	) fts GROUP BY inode_id ORDER BY score DESC LIMIT ?`
+
+	args := append(scope.Args(), scope.Args()...)
+	args = append(args, limit)
+
+	var outerConds []string
+	var outerArgs []any
+	if pathPrefix != "" && pathPrefix != "/" {
+		cond, pargs := subtreeCond(pathPrefix)
+		outerConds = append(outerConds, cond)
+		outerArgs = append(outerArgs, pargs...)
+	}
+
+	outerConds = append([]string{"i.status = 'CONFIRMED'"}, outerConds...)
+	q := `SELECT fn.path, fn.name, i.size_bytes, fts.score
+		FROM (` + innerQ + `) fts
+		JOIN file_nodes fn ON COALESCE(fn.inode_id, fn.file_id) = fts.inode_id
+		JOIN inodes i ON i.inode_id = fts.inode_id`
+	if len(outerConds) > 0 {
+		q += ` WHERE ` + scopeWhereAnd(scope, strings.Join(outerConds, " AND "), "fn", "i")
+		outerArgs = scopeWhereArgs(scope, 2, outerArgs...)
+	}
+
+	return q, append(args, outerArgs...)
+}
+
 // KeywordSearch runs a LIKE-based fallback search when semantic ranking is unavailable.
 func (s *Store) KeywordSearch(ctx context.Context, query, pathPrefix string, limit int) ([]SearchResult, error) {
 	conds := []string{"i.status = 'CONFIRMED'", "s.content_text LIKE CONCAT('%', ?, '%')"}
@@ -317,10 +372,10 @@ func (s *Store) KeywordSearch(ctx context.Context, query, pathPrefix string, lim
 
 	q := `SELECT fn.path, fn.name, i.size_bytes
 		FROM file_nodes fn JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE ` + strings.Join(conds, " AND ") + `
+		WHERE ` + scopeWhereAnd(s.scope, strings.Join(conds, " AND "), "fn", "i", "s") + `
 		ORDER BY i.confirmed_at DESC LIMIT ?`
 
-	rows, err := s.db.QueryContext(ctx, q, args...)
+	rows, err := s.db.QueryContext(ctx, q, scopeWhereArgs(s.scope, 3, args...)...)
 	if err != nil {
 		return nil, err
 	}
@@ -357,11 +412,11 @@ func (s *Store) Find(ctx context.Context, f *FindFilter) ([]SearchResult, error)
 	}
 	if f.TagKey != "" {
 		if f.TagValue != "" {
-			conds = append(conds, `EXISTS (SELECT 1 FROM file_tags t WHERE t.file_id = i.inode_id AND t.tag_key = ? AND t.tag_value = ?)`)
-			args = append(args, f.TagKey, f.TagValue)
+			conds = append(conds, `EXISTS (SELECT 1 FROM file_tags t WHERE `+s.scope.AndAs("t", `t.file_id = i.inode_id AND t.tag_key = ? AND t.tag_value = ?`)+`)`)
+			args = append(args, s.scope.Args(f.TagKey, f.TagValue)...)
 		} else {
-			conds = append(conds, `EXISTS (SELECT 1 FROM file_tags t WHERE t.file_id = i.inode_id AND t.tag_key = ?)`)
-			args = append(args, f.TagKey)
+			conds = append(conds, `EXISTS (SELECT 1 FROM file_tags t WHERE `+s.scope.AndAs("t", `t.file_id = i.inode_id AND t.tag_key = ?`)+`)`)
+			args = append(args, s.scope.Args(f.TagKey)...)
 		}
 	}
 	if f.After != nil {
@@ -384,10 +439,10 @@ func (s *Store) Find(ctx context.Context, f *FindFilter) ([]SearchResult, error)
 
 	q := `SELECT fn.path, fn.name, i.size_bytes
 		FROM file_nodes fn JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id
-		WHERE ` + strings.Join(conds, " AND ") + `
+		WHERE ` + scopeWhereAnd(s.scope, strings.Join(conds, " AND "), "fn", "i") + `
 		ORDER BY fn.path LIMIT ?`
 
-	rows, err := s.db.QueryContext(ctx, q, args...)
+	rows, err := s.db.QueryContext(ctx, q, scopeWhereArgs(s.scope, 2, args...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/datastore/search_shared_test.go
+++ b/pkg/datastore/search_shared_test.go
@@ -1,0 +1,137 @@
+package datastore
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+// insertSharedSearchFixture writes one confirmed file (inode + dentry +
+// semantic row) directly with an explicit fs_id. Store write methods are not
+// scope-aware yet, so shared-shape fixtures bypass them.
+func insertSharedSearchFixture(t *testing.T, s *Store, fsID int64, inodeID, path, contentText string) {
+	t.Helper()
+	now := time.Now()
+	if _, err := s.DB().Exec(`INSERT INTO inodes
+		(fs_id, inode_id, size_bytes, revision, status, confirmed_at)
+		VALUES (?, ?, ?, 1, 'CONFIRMED', ?)`,
+		fsID, inodeID, len(contentText), now); err != nil {
+		t.Fatalf("insert inode %s: %v", inodeID, err)
+	}
+	parent := "/"
+	name := path
+	if idx := strings.LastIndex(strings.TrimSuffix(path, "/"), "/"); idx >= 0 {
+		parent = path[:idx+1]
+		name = path[idx+1:]
+	}
+	if _, err := s.DB().Exec(`INSERT INTO file_nodes
+		(fs_id, node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, inode_id, created_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?)`,
+		fsID, "node-"+inodeID, path, fileNodePathHash(path), parent, fileNodePathHash(parent), name, inodeID, inodeID, now); err != nil {
+		t.Fatalf("insert file_node %s: %v", path, err)
+	}
+	if _, err := s.DB().Exec(`INSERT INTO semantic (fs_id, inode_id, content_text) VALUES (?, ?, ?)`,
+		fsID, inodeID, contentText); err != nil {
+		t.Fatalf("insert semantic %s: %v", inodeID, err)
+	}
+}
+
+// TestBuildVectorSearchQuerySharedShape asserts the scoped vector query
+// filters every joined alias and binds the fs_ids right after the
+// SELECT-list distance placeholder.
+func TestBuildVectorSearchQuerySharedShape(t *testing.T) {
+	const fsID int64 = 4400004
+	q, args, ok := buildVectorSearchQueryScoped(SharedScope(fsID), []float32{0.1, 0.2, 0.3}, "/docs/", 7)
+	if !ok {
+		t.Fatal("expected non-empty query embedding to build vector search SQL")
+	}
+	if !strings.Contains(q, "fn.fs_id = ? AND i.fs_id = ? AND s.fs_id = ? AND i.status = 'CONFIRMED'") {
+		t.Fatalf("shared vector search SQL missing leading fs_id predicates: %s", q)
+	}
+	wantArgs := []any{"[0.1,0.2,0.3]", fsID, fsID, fsID, "/docs", "/docs/%", "[0.1,0.2,0.3]", 7}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("shared vector search args=%#v, want %#v", args, wantArgs)
+	}
+}
+
+// TestBuildFTSSearchQuerySharedShape asserts the fs_id predicate lands inside
+// each UNION branch (before aggregation/LIMIT) and on each outer-join alias
+// in shared shape, and that the standalone shape stays free of fs_id
+// predicates.
+func TestBuildFTSSearchQuerySharedShape(t *testing.T) {
+	const fsID int64 = 4400005
+	q, args := buildFTSSearchQuery(SharedScope(fsID), "hello", "/", 5)
+	if got := strings.Count(q, "fs_id = ?"); got != 4 {
+		t.Fatalf("shared FTS SQL has %d fs_id predicates, want 4 (2 UNION branches + 2 outer aliases): %s", got, q)
+	}
+	if !strings.Contains(q, "FROM semantic WHERE fs_id = ? AND fts_match_word('hello', content_text)") {
+		t.Fatalf("content_text UNION branch missing leading fs_id predicate: %s", q)
+	}
+	if strings.Contains(q, "fts.fs_id") {
+		t.Fatalf("fs_id predicate must not leak onto the derived table: %s", q)
+	}
+	wantArgs := []any{fsID, fsID, 5, fsID, fsID}
+	if !reflect.DeepEqual(args, wantArgs) {
+		t.Fatalf("shared FTS args=%#v, want %#v", args, wantArgs)
+	}
+
+	qStandalone, argsStandalone := buildFTSSearchQuery(StandaloneScope(0), "hello", "/", 5)
+	if strings.Contains(qStandalone, "fs_id") {
+		t.Fatalf("standalone FTS SQL must not reference fs_id: %s", qStandalone)
+	}
+	if !reflect.DeepEqual(argsStandalone, []any{5}) {
+		t.Fatalf("standalone FTS args=%#v, want [5]", argsStandalone)
+	}
+}
+
+// TestKeywordSearchSharedShapeParity runs the LIKE-based keyword search (the
+// only search path plain MySQL supports) against the shared schema shape.
+func TestKeywordSearchSharedShapeParity(t *testing.T) {
+	installSharedCoreFSSchema(t)
+	const fsID int64 = 4400001
+	store := newSharedStore(t, fsID)
+	insertSharedSearchFixture(t, store, fsID, "ino-kw1", "/docs/hello.txt", "hello semantic world")
+	insertSharedSearchFixture(t, store, fsID, "ino-kw2", "/docs/other.txt", "unrelated content")
+
+	results, err := store.KeywordSearch(context.Background(), "semantic", "/", 10)
+	if err != nil {
+		t.Fatalf("KeywordSearch: %v", err)
+	}
+	if len(results) != 1 || results[0].Path != "/docs/hello.txt" {
+		t.Fatalf("results = %#v, want only /docs/hello.txt", results)
+	}
+	if results[0].SizeBytes != int64(len("hello semantic world")) {
+		t.Fatalf("size = %d, want %d", results[0].SizeBytes, len("hello semantic world"))
+	}
+}
+
+// TestKeywordSearchSharedShapeCrossTenantIsolation proves identical rows
+// under two fs_ids stay invisible to each other: each store's keyword search
+// returns only its own tenant's dentry.
+func TestKeywordSearchSharedShapeCrossTenantIsolation(t *testing.T) {
+	installSharedCoreFSSchema(t)
+	const fsA, fsB int64 = 4400002, 4400003
+	storeA := newSharedStore(t, fsA)
+	storeB := newSharedStore(t, fsB)
+
+	// Same inode_id and content_text under both fs_ids, distinct paths.
+	insertSharedSearchFixture(t, storeA, fsA, "ino-shared", "/a/secret.txt", "cross-tenant probe token")
+	insertSharedSearchFixture(t, storeB, fsB, "ino-shared", "/b/secret.txt", "cross-tenant probe token")
+
+	resultsA, err := storeA.KeywordSearch(context.Background(), "probe token", "/", 10)
+	if err != nil {
+		t.Fatalf("KeywordSearch A: %v", err)
+	}
+	if len(resultsA) != 1 || resultsA[0].Path != "/a/secret.txt" {
+		t.Fatalf("A results = %#v, want only /a/secret.txt (cross-tenant leak?)", resultsA)
+	}
+	resultsB, err := storeB.KeywordSearch(context.Background(), "probe token", "/", 10)
+	if err != nil {
+		t.Fatalf("KeywordSearch B: %v", err)
+	}
+	if len(resultsB) != 1 || resultsB[0].Path != "/b/secret.txt" {
+		t.Fatalf("B results = %#v, want only /b/secret.txt (cross-tenant leak?)", resultsB)
+	}
+}

--- a/pkg/datastore/semantic.go
+++ b/pkg/datastore/semantic.go
@@ -19,20 +19,20 @@ type Semantic struct {
 // InsertSemantic inserts a semantic row.
 func (s *Store) InsertSemantic(ctx context.Context, semantic *Semantic) error {
 	_, err := s.db.ExecContext(ctx, `INSERT INTO semantic
-		(inode_id, content_text, description, embedding_revision, description_embedding_revision)
-		VALUES (?, ?, ?, ?, ?)`,
-		semantic.InodeID, nullStr(semantic.ContentText), nullStr(semantic.Description),
-		nullInt64Ptr(semantic.EmbeddingRevision), nullInt64Ptr(semantic.DescriptionEmbeddingRevision))
+		(`+s.scope.InsCols(`inode_id, content_text, description, embedding_revision, description_embedding_revision`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(semantic.InodeID, nullStr(semantic.ContentText), nullStr(semantic.Description),
+			nullInt64Ptr(semantic.EmbeddingRevision), nullInt64Ptr(semantic.DescriptionEmbeddingRevision))...)
 	return err
 }
 
 // InsertSemanticTx inserts a semantic row inside an existing transaction.
 func (s *Store) InsertSemanticTx(db execer, semantic *Semantic) error {
 	_, err := db.Exec(`INSERT INTO semantic
-		(inode_id, content_text, description, embedding_revision, description_embedding_revision)
-		VALUES (?, ?, ?, ?, ?)`,
-		semantic.InodeID, nullStr(semantic.ContentText), nullStr(semantic.Description),
-		nullInt64Ptr(semantic.EmbeddingRevision), nullInt64Ptr(semantic.DescriptionEmbeddingRevision))
+		(`+s.scope.InsCols(`inode_id, content_text, description, embedding_revision, description_embedding_revision`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(semantic.InodeID, nullStr(semantic.ContentText), nullStr(semantic.Description),
+			nullInt64Ptr(semantic.EmbeddingRevision), nullInt64Ptr(semantic.DescriptionEmbeddingRevision))...)
 	return err
 }
 
@@ -40,7 +40,7 @@ func (s *Store) InsertSemanticTx(db execer, semantic *Semantic) error {
 func (s *Store) GetSemantic(ctx context.Context, inodeID string) (*Semantic, error) {
 	row := s.db.QueryRowContext(ctx, `SELECT inode_id, content_text, description,
 		embedding_revision, description_embedding_revision
-		FROM semantic WHERE inode_id = ?`, inodeID)
+		FROM semantic WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(inodeID)...)
 	return scanSemantic(row)
 }
 
@@ -50,8 +50,8 @@ func (s *Store) UpdateSemanticTx(db execer, inodeID string, contentText, descrip
 		content_text = ?, description = ?,
 		embedding = NULL, embedding_revision = NULL,
 		description_embedding = NULL, description_embedding_revision = NULL
-		WHERE inode_id = ?`,
-		nullStr(contentText), nullStr(description), inodeID)
+		WHERE `+s.scope.And(`inode_id = ?`),
+		append([]any{nullStr(contentText), nullStr(description)}, s.scope.Args(inodeID)...)...)
 	return err
 }
 
@@ -60,8 +60,8 @@ func (s *Store) UpdateSemanticTx(db execer, inodeID string, contentText, descrip
 func (s *Store) updateSemanticNoEmbedTx(db execer, inodeID string, contentText, description string) error {
 	_, err := db.Exec(`UPDATE semantic SET
 		content_text = ?, description = ?
-		WHERE inode_id = ?`,
-		nullStr(contentText), nullStr(description), inodeID)
+		WHERE `+s.scope.And(`inode_id = ?`),
+		append([]any{nullStr(contentText), nullStr(description)}, s.scope.Args(inodeID)...)...)
 	return err
 }
 

--- a/pkg/datastore/semantic_tasks.go
+++ b/pkg/datastore/semantic_tasks.go
@@ -81,9 +81,9 @@ func (s *Store) ObserveSemanticTasks(ctx context.Context, now time.Time) (out *S
 	obs := &SemanticTaskObservation{}
 
 	rows, err := s.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM semantic_tasks
-		WHERE status IN (?, ?, ?)
+		WHERE `+s.scope.And(`status IN (?, ?, ?)`)+`
 		GROUP BY status`,
-		semantic.TaskQueued, semantic.TaskProcessing, semantic.TaskDeadLettered)
+		s.scope.Args(semantic.TaskQueued, semantic.TaskProcessing, semantic.TaskDeadLettered)...)
 	if err != nil {
 		return nil, err
 	}
@@ -112,10 +112,10 @@ func (s *Store) ObserveSemanticTasks(ctx context.Context, now time.Time) (out *S
 
 	var availableAt sql.NullTime
 	err = s.db.QueryRowContext(ctx, `SELECT available_at FROM semantic_tasks
-		WHERE status = ? AND available_at <= ?
+		WHERE `+s.scope.And(`status = ? AND available_at <= ?`)+`
 		ORDER BY available_at, created_at, task_id
 		LIMIT 1`,
-		semantic.TaskQueued, now).Scan(&availableAt)
+		s.scope.Args(semantic.TaskQueued, now)...).Scan(&availableAt)
 	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil, err
 	}
@@ -153,21 +153,21 @@ func (s *Store) enqueueSemanticTask(db execer, task *semantic.Task) (bool, error
 	}
 
 	_, err := db.Exec(`INSERT INTO semantic_tasks
-		(task_id, task_type, resource_id, resource_version, status, attempt_count, max_attempts,
+		(`+s.scope.InsCols(`task_id, task_type, resource_id, resource_version, status, attempt_count, max_attempts,
 		 receipt, leased_at, lease_until, available_at, payload_json, last_error,
-		 created_at, updated_at, completed_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		task.TaskID, task.TaskType, task.ResourceID, task.ResourceVersion, status, task.AttemptCount,
-		maxAttempts, nullStr(task.Receipt), nilTime(task.LeasedAt), nilTime(task.LeaseUntil),
-		availableAt.UTC(), nilBytes(task.PayloadJSON), nullStr(task.LastError),
-		createdAt.UTC(), updatedAt.UTC(), nilTime(task.CompletedAt))
+		 created_at, updated_at, completed_at`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(task.TaskID, task.TaskType, task.ResourceID, task.ResourceVersion, status, task.AttemptCount,
+			maxAttempts, nullStr(task.Receipt), nilTime(task.LeasedAt), nilTime(task.LeaseUntil),
+			availableAt.UTC(), nilBytes(task.PayloadJSON), nullStr(task.LastError),
+			createdAt.UTC(), updatedAt.UTC(), nilTime(task.CompletedAt))...)
 	if err == nil {
 		return true, nil
 	}
 	if !isUniqueViolation(err) {
 		return false, err
 	}
-	duplicate, dupErr := semanticTaskExistsByResource(db, task.TaskType, task.ResourceID, task.ResourceVersion)
+	duplicate, dupErr := s.semanticTaskExistsByResource(db, task.TaskType, task.ResourceID, task.ResourceVersion)
 	if dupErr != nil {
 		return false, dupErr
 	}
@@ -194,8 +194,8 @@ func (s *Store) ensureSemanticTaskQueuedTx(tx *sql.Tx, task *semantic.Task) (boo
 		attempt_count, max_attempts, receipt, leased_at, lease_until, available_at,
 		payload_json, last_error, created_at, updated_at, completed_at
 		FROM semantic_tasks
-		WHERE task_type = ? AND resource_id = ? AND resource_version = ?
-		FOR UPDATE`, task.TaskType, task.ResourceID, task.ResourceVersion)
+		WHERE `+s.scope.And(`task_type = ? AND resource_id = ? AND resource_version = ?`)+`
+		FOR UPDATE`, s.scope.Args(task.TaskType, task.ResourceID, task.ResourceVersion)...)
 	existing, err := scanSemanticTask(row)
 	if err != nil {
 		return false, err
@@ -219,8 +219,9 @@ func (s *Store) ensureSemanticTaskQueuedTx(tx *sql.Tx, task *semantic.Task) (boo
 	_, err = tx.Exec(`UPDATE semantic_tasks SET status = ?, receipt = NULL, leased_at = NULL,
 		lease_until = NULL, available_at = ?, payload_json = ?, last_error = NULL,
 		max_attempts = ?, completed_at = NULL, updated_at = ?
-		WHERE task_id = ?`,
-		semantic.TaskQueued, availableAt.UTC(), nilBytes(payload), maxAttempts, now, existing.TaskID)
+		WHERE `+s.scope.And(`task_id = ?`),
+		append([]any{semantic.TaskQueued, availableAt.UTC(), nilBytes(payload), maxAttempts, now},
+			s.scope.Args(existing.TaskID)...)...)
 	if err != nil {
 		return false, err
 	}
@@ -256,7 +257,7 @@ func (s *Store) claimSemanticTask(ctx context.Context, now time.Time, leaseDurat
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	query, args := claimSemanticTaskQuery(now, normalizedTypes)
+	query, args := s.claimSemanticTaskQuery(now, normalizedTypes)
 	row := tx.QueryRowContext(ctx, query, args...)
 	task, scanErr := scanSemanticTask(row)
 	if scanErr != nil {
@@ -271,9 +272,9 @@ func (s *Store) claimSemanticTask(ctx context.Context, now time.Time, leaseDurat
 	leaseUntil := now.Add(leaseDuration)
 	res, err := tx.ExecContext(ctx, `UPDATE semantic_tasks SET status = ?, attempt_count = attempt_count + 1,
 		receipt = ?, leased_at = ?, lease_until = ?, updated_at = ?
-		WHERE task_id = ? AND status = ? AND available_at <= ?`,
-		semantic.TaskProcessing, receipt, leasedAt, leaseUntil, now,
-		task.TaskID, semantic.TaskQueued, now)
+		WHERE `+s.scope.And(`task_id = ? AND status = ? AND available_at <= ?`),
+		append([]any{semantic.TaskProcessing, receipt, leasedAt, leaseUntil, now},
+			s.scope.Args(task.TaskID, semantic.TaskQueued, now)...)...)
 	if err != nil {
 		return nil, false, err
 	}
@@ -317,13 +318,13 @@ func normalizeClaimTaskTypes(taskTypes []semantic.TaskType) ([]semantic.TaskType
 	return normalized, nil
 }
 
-func claimSemanticTaskQuery(now time.Time, taskTypes []semantic.TaskType) (string, []any) {
+func (s *Store) claimSemanticTaskQuery(now time.Time, taskTypes []semantic.TaskType) (string, []any) {
 	query := `SELECT task_id, task_type, resource_id, resource_version, status,
 		attempt_count, max_attempts, receipt, leased_at, lease_until, available_at,
 		payload_json, last_error, created_at, updated_at, completed_at
 		FROM semantic_tasks
-		WHERE status = ?`
-	args := []any{semantic.TaskQueued}
+		WHERE ` + s.scope.And(`status = ?`)
+	args := s.scope.Args(semantic.TaskQueued)
 	if len(taskTypes) == 1 {
 		query += ` AND task_type = ?`
 		args = append(args, taskTypes[0])
@@ -360,8 +361,9 @@ func (s *Store) AckSemanticTask(ctx context.Context, taskID, receipt string) (er
 	now := semanticTaskLeaseNow()
 	res, err := s.db.ExecContext(ctx, `UPDATE semantic_tasks SET status = ?, receipt = NULL,
 		leased_at = NULL, lease_until = NULL, completed_at = ?, updated_at = ?
-		WHERE task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`,
-		semantic.TaskSucceeded, now, now, taskID, semantic.TaskProcessing, receipt, now)
+		WHERE `+s.scope.And(`task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`),
+		append([]any{semantic.TaskSucceeded, now, now},
+			s.scope.Args(taskID, semantic.TaskProcessing, receipt, now)...)...)
 	if err != nil {
 		return err
 	}
@@ -384,8 +386,9 @@ func (s *Store) DeadLetterSemanticTask(ctx context.Context, taskID, receipt, las
 	now := semanticTaskLeaseNow()
 	res, err := s.db.ExecContext(ctx, `UPDATE semantic_tasks SET status = ?, receipt = NULL,
 		leased_at = NULL, lease_until = NULL, last_error = ?, completed_at = ?, updated_at = ?
-		WHERE task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`,
-		semantic.TaskDeadLettered, nullStr(lastErr), now, now, taskID, semantic.TaskProcessing, receipt, now)
+		WHERE `+s.scope.And(`task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`),
+		append([]any{semantic.TaskDeadLettered, nullStr(lastErr), now, now},
+			s.scope.Args(taskID, semantic.TaskProcessing, receipt, now)...)...)
 	if err != nil {
 		return err
 	}
@@ -415,8 +418,9 @@ func (s *Store) RenewSemanticTask(ctx context.Context, taskID, receipt string, l
 	}
 	leaseUntil = now.Add(leaseDuration)
 	res, err := s.db.ExecContext(ctx, `UPDATE semantic_tasks SET lease_until = ?, updated_at = ?
-		WHERE task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`,
-		leaseUntil, now, taskID, semantic.TaskProcessing, receipt, now)
+		WHERE `+s.scope.And(`task_id = ? AND status = ? AND receipt = ? AND lease_until IS NOT NULL AND lease_until > ?`),
+		append([]any{leaseUntil, now},
+			s.scope.Args(taskID, semantic.TaskProcessing, receipt, now)...)...)
 	if err != nil {
 		return time.Time{}, err
 	}
@@ -458,7 +462,7 @@ func (s *Store) RetrySemanticTask(ctx context.Context, taskID, receipt string, r
 	row := tx.QueryRowContext(ctx, `SELECT task_id, task_type, resource_id, resource_version, status,
 		attempt_count, max_attempts, receipt, leased_at, lease_until, available_at,
 		payload_json, last_error, created_at, updated_at, completed_at
-		FROM semantic_tasks WHERE task_id = ? FOR UPDATE`, taskID)
+		FROM semantic_tasks WHERE `+s.scope.And(`task_id = ?`)+` FOR UPDATE`, s.scope.Args(taskID)...)
 	task, err := scanSemanticTask(row)
 	if err != nil {
 		if errors.Is(err, semantic.ErrTaskNotFound) {
@@ -473,11 +477,13 @@ func (s *Store) RetrySemanticTask(ctx context.Context, taskID, receipt string, r
 	if task.AttemptCount >= task.MaxAttempts {
 		_, err = tx.ExecContext(ctx, `UPDATE semantic_tasks SET status = ?, receipt = NULL, leased_at = NULL,
 			lease_until = NULL, last_error = ?, completed_at = ?, updated_at = ?
-			WHERE task_id = ?`, semantic.TaskDeadLettered, nullStr(lastErr), now, now, taskID)
+			WHERE `+s.scope.And(`task_id = ?`),
+			append([]any{semantic.TaskDeadLettered, nullStr(lastErr), now, now}, s.scope.Args(taskID)...)...)
 	} else {
 		_, err = tx.ExecContext(ctx, `UPDATE semantic_tasks SET status = ?, receipt = NULL, leased_at = NULL,
 			lease_until = NULL, available_at = ?, last_error = ?, completed_at = NULL, updated_at = ?
-			WHERE task_id = ?`, semantic.TaskQueued, retryAt, nullStr(lastErr), now, taskID)
+			WHERE `+s.scope.And(`task_id = ?`),
+			append([]any{semantic.TaskQueued, retryAt, nullStr(lastErr), now}, s.scope.Args(taskID)...)...)
 	}
 	if err != nil {
 		return err
@@ -503,9 +509,9 @@ func (s *Store) RecoverExpiredSemanticTasks(ctx context.Context, now time.Time, 
 	defer func() { _ = tx.Rollback() }()
 
 	query := `SELECT task_id FROM semantic_tasks
-		WHERE status = ? AND lease_until IS NOT NULL AND lease_until < ?
+		WHERE ` + s.scope.And(`status = ? AND lease_until IS NOT NULL AND lease_until < ?`) + `
 		ORDER BY lease_until, created_at, task_id`
-	args := []any{semantic.TaskProcessing, now}
+	args := s.scope.Args(semantic.TaskProcessing, now)
 	if limit > 0 {
 		query += ` LIMIT ?`
 		args = append(args, limit)
@@ -532,8 +538,9 @@ func (s *Store) RecoverExpiredSemanticTasks(ctx context.Context, now time.Time, 
 	for _, taskID := range taskIDs {
 		res, err := tx.ExecContext(ctx, `UPDATE semantic_tasks SET status = ?, receipt = NULL,
 			leased_at = NULL, lease_until = NULL, available_at = ?, updated_at = ?
-			WHERE task_id = ? AND status = ? AND lease_until IS NOT NULL AND lease_until < ?`,
-			semantic.TaskQueued, now, now, taskID, semantic.TaskProcessing, now)
+			WHERE `+s.scope.And(`task_id = ? AND status = ? AND lease_until IS NOT NULL AND lease_until < ?`),
+			append([]any{semantic.TaskQueued, now, now},
+				s.scope.Args(taskID, semantic.TaskProcessing, now)...)...)
 		if err != nil {
 			return 0, err
 		}
@@ -550,11 +557,11 @@ func (s *Store) RecoverExpiredSemanticTasks(ctx context.Context, now time.Time, 
 	return recovered, nil
 }
 
-func semanticTaskExistsByResource(db execer, taskType semantic.TaskType, resourceID string, resourceVersion int64) (bool, error) {
+func (s *Store) semanticTaskExistsByResource(db execer, taskType semantic.TaskType, resourceID string, resourceVersion int64) (bool, error) {
 	var count int
 	err := db.QueryRow(`SELECT COUNT(*) FROM semantic_tasks
-		WHERE task_type = ? AND resource_id = ? AND resource_version = ?`,
-		taskType, resourceID, resourceVersion).Scan(&count)
+		WHERE `+s.scope.And(`task_type = ? AND resource_id = ? AND resource_version = ?`),
+		s.scope.Args(taskType, resourceID, resourceVersion)...).Scan(&count)
 	if err != nil {
 		return false, err
 	}
@@ -563,7 +570,7 @@ func semanticTaskExistsByResource(db execer, taskType semantic.TaskType, resourc
 
 func (s *Store) semanticTaskLeaseError(ctx context.Context, taskID string) error {
 	var count int
-	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM semantic_tasks WHERE task_id = ?`, taskID).Scan(&count)
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM semantic_tasks WHERE `+s.scope.And(`task_id = ?`), s.scope.Args(taskID)...).Scan(&count)
 	if err != nil {
 		return err
 	}

--- a/pkg/datastore/semantic_tasks_shared_test.go
+++ b/pkg/datastore/semantic_tasks_shared_test.go
@@ -1,0 +1,568 @@
+package datastore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/semantic"
+)
+
+// runSemanticTaskCoreScenario exercises the semantic task queue flow
+// (enqueue, duplicate suppression, claim, ack, requeue, retry, recover,
+// dead-letter, observe) against a store. It is run against both schema
+// shapes to prove behavioral parity.
+func runSemanticTaskCoreScenario(t *testing.T, store *Store, idPrefix string) {
+	t.Helper()
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	// Enqueue creates; a second enqueue for the same resource tuple is a
+	// no-op even with a different task id.
+	created, err := store.EnqueueSemanticTask(ctx, newSemanticTask(idPrefix+"-task-1", idPrefix+"-file-1", 1, base, base))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !created {
+		t.Fatal("expected task to be created")
+	}
+	created, err = store.EnqueueSemanticTask(ctx, newSemanticTask(idPrefix+"-task-dup", idPrefix+"-file-1", 1, base.Add(time.Second), base.Add(time.Second)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created {
+		t.Fatal("duplicate enqueue should not create a second task")
+	}
+
+	// Claim → ack. A wrong receipt is a lease mismatch.
+	claimed, found, err := store.ClaimSemanticTask(ctx, base.Add(time.Second), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		t.Fatal("expected claim to find queued task")
+	}
+	if claimed.TaskID != idPrefix+"-task-1" || claimed.AttemptCount != 1 {
+		t.Fatalf("unexpected claim result: %+v", claimed)
+	}
+	if claimed.Receipt == "" || claimed.LeasedAt == nil || claimed.LeaseUntil == nil {
+		t.Fatalf("claim did not populate lease fields: %+v", claimed)
+	}
+	if err := store.AckSemanticTask(ctx, claimed.TaskID, "wrong-receipt"); !errors.Is(err, semantic.ErrTaskLeaseMismatch) {
+		t.Fatalf("ack error=%v, want %v", err, semantic.ErrTaskLeaseMismatch)
+	}
+	if err := store.AckSemanticTask(ctx, claimed.TaskID, claimed.Receipt); err != nil {
+		t.Fatal(err)
+	}
+	task := mustGetSharedSemanticTask(t, store, claimed.TaskID)
+	if task.Status != semantic.TaskSucceeded || task.CompletedAt == nil {
+		t.Fatalf("ack should succeed the task with completed_at: %+v", task)
+	}
+
+	// EnsureSemanticTaskQueued re-queues the terminal task in place.
+	queued, err := store.EnsureSemanticTaskQueued(ctx, &semantic.Task{
+		TaskID:          idPrefix + "-task-requeue",
+		TaskType:        semantic.TaskTypeEmbed,
+		ResourceID:      idPrefix + "-file-1",
+		ResourceVersion: 1,
+		Status:          semantic.TaskQueued,
+		MaxAttempts:     3,
+		AvailableAt:     base.Add(time.Hour),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !queued {
+		t.Fatal("expected ensure to requeue succeeded task")
+	}
+	task = mustGetSharedSemanticTask(t, store, claimed.TaskID)
+	if task.Status != semantic.TaskQueued || task.CompletedAt != nil || task.Receipt != "" {
+		t.Fatalf("requeue should clear terminal/lease fields: %+v", task)
+	}
+
+	// Retry → recover → dead-letter on a fresh task (max attempts 3).
+	if _, err := store.EnqueueSemanticTask(ctx, newSemanticTask(idPrefix+"-task-2", idPrefix+"-file-2", 1, base, base)); err != nil {
+		t.Fatal(err)
+	}
+	claimed2, found, err := store.ClaimSemanticTask(ctx, base.Add(time.Second), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || claimed2.TaskID != idPrefix+"-task-2" || claimed2.AttemptCount != 1 {
+		t.Fatalf("unexpected claim result: found=%v task=%+v", found, claimed2)
+	}
+	retryAt := base.Add(5 * time.Second)
+	if err := store.RetrySemanticTask(ctx, claimed2.TaskID, claimed2.Receipt, retryAt, "temporary failure"); err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := store.ClaimSemanticTask(ctx, base.Add(4*time.Second), time.Second); err != nil {
+		t.Fatal(err)
+	} else if found {
+		t.Fatal("task should not be claimable before retry_at")
+	}
+	reclaimed, found, err := store.ClaimSemanticTask(ctx, retryAt.Add(time.Second), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || reclaimed.AttemptCount != 2 {
+		t.Fatalf("expected reclaim at retry_at with attempt 2: found=%v task=%+v", found, reclaimed)
+	}
+	recoveredAt := retryAt.Add(3 * time.Second)
+	recovered, err := store.RecoverExpiredSemanticTasks(ctx, recoveredAt, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered != 1 {
+		t.Fatalf("recovered=%d, want 1", recovered)
+	}
+	recoveredTask, found, err := store.ClaimSemanticTask(ctx, recoveredAt.Add(time.Second), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || recoveredTask.AttemptCount != 3 {
+		t.Fatalf("expected recovered task with attempt 3: found=%v task=%+v", found, recoveredTask)
+	}
+	if err := store.RetrySemanticTask(ctx, recoveredTask.TaskID, recoveredTask.Receipt, recoveredAt.Add(3*time.Second), "permanent failure"); err != nil {
+		t.Fatal(err)
+	}
+	task = mustGetSharedSemanticTask(t, store, recoveredTask.TaskID)
+	if task.Status != semantic.TaskDeadLettered || task.CompletedAt == nil {
+		t.Fatalf("max-attempt retry should dead-letter: %+v", task)
+	}
+
+	// Type-filtered claim skips older tasks of other types.
+	if _, err := store.EnqueueSemanticTask(ctx, newSemanticTaskOfType(semantic.TaskTypeImgExtractText, idPrefix+"-task-img", idPrefix+"-file-img", 1, base, base)); err != nil {
+		t.Fatal(err)
+	}
+	filtered, found, err := store.ClaimSemanticTask(ctx, base.Add(time.Minute), time.Minute, semantic.TaskTypeImgExtractText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || filtered.TaskID != idPrefix+"-task-img" {
+		t.Fatalf("filtered claim = found=%v task=%+v, want %s", found, filtered, idPrefix+"-task-img")
+	}
+	if err := store.AckSemanticTask(ctx, filtered.TaskID, filtered.Receipt); err != nil {
+		t.Fatal(err)
+	}
+
+	// Queue observation is scoped to this store: one future queued task and
+	// one dead-lettered task, no currently claimable work.
+	obs, err := store.ObserveSemanticTasks(ctx, base.Add(2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obs.Queued != 1 || obs.Processing != 0 || obs.DeadLettered != 1 {
+		t.Fatalf("observation = %+v, want queued=1 processing=0 dead_lettered=1", obs)
+	}
+	if obs.OldestClaimableAvailableAt != nil {
+		t.Fatalf("oldest claimable = %s, want nil (only a future task is queued)", obs.OldestClaimableAvailableAt.UTC())
+	}
+}
+
+// runFileGCTaskCoreScenario exercises the file GC task flow (enqueue,
+// duplicate suppression, get, claim, ack, retry, recover, S3 ref listing)
+// against a store. It is run against both schema shapes to prove parity.
+func runFileGCTaskCoreScenario(t *testing.T, store *Store, idPrefix string) {
+	t.Helper()
+	ctx := context.Background()
+	base := time.Now().UTC()
+
+	task1 := &FileGCTask{
+		TaskID:      idPrefix + "-gc-1",
+		FileID:      idPrefix + "-file-1",
+		StorageType: StorageS3,
+		StorageRef:  "s3://bucket/" + idPrefix + "-blob-1",
+		SizeBytes:   42,
+		ContentType: "text/plain",
+		AvailableAt: base,
+	}
+	inserted, err := store.EnqueueFileGCTaskTx(store.DB(), task1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inserted {
+		t.Fatal("expected file gc task to be created")
+	}
+	inserted, err = store.EnqueueFileGCTaskTx(store.DB(), task1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inserted {
+		t.Fatal("duplicate file gc enqueue should be a no-op")
+	}
+	got, err := store.GetFileGCTaskByFileID(ctx, task1.FileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != FileGCTaskQueued || got.StorageRef != task1.StorageRef || got.SizeBytes != 42 {
+		t.Fatalf("unexpected file gc task: %+v", got)
+	}
+	count, err := store.CountQueuedFileGCTasks(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Fatalf("queued file gc count=%d, want 1", count)
+	}
+
+	claimed, found, err := store.ClaimFileGCTask(ctx, base.Add(time.Second), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || claimed.TaskID != task1.TaskID || claimed.AttemptCount != 1 || claimed.Receipt == "" {
+		t.Fatalf("unexpected claim result: found=%v task=%+v", found, claimed)
+	}
+	if err := store.AckFileGCTask(ctx, claimed.TaskID, "wrong-receipt"); !errors.Is(err, ErrFileGCTaskLeaseMismatch) {
+		t.Fatalf("ack error=%v, want %v", err, ErrFileGCTaskLeaseMismatch)
+	}
+	if err := store.AckFileGCTask(ctx, claimed.TaskID, claimed.Receipt); err != nil {
+		t.Fatal(err)
+	}
+	got, err = store.GetFileGCTaskByFileID(ctx, task1.FileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != FileGCTaskSucceeded || got.CompletedAt == nil {
+		t.Fatalf("ack should succeed the file gc task: %+v", got)
+	}
+
+	// Retry → recover on a second task; file GC retries indefinitely
+	// (max_attempts 0), so the final retry requeues instead of dead-lettering.
+	task2 := &FileGCTask{
+		TaskID:      idPrefix + "-gc-2",
+		FileID:      idPrefix + "-file-2",
+		StorageType: StorageS3,
+		StorageRef:  "s3://bucket/" + idPrefix + "-blob-2",
+		SizeBytes:   7,
+		AvailableAt: base,
+	}
+	if _, err := store.EnqueueFileGCTaskTx(store.DB(), task2); err != nil {
+		t.Fatal(err)
+	}
+	claimed2, found, err := store.ClaimFileGCTask(ctx, base.Add(time.Second), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || claimed2.TaskID != task2.TaskID {
+		t.Fatalf("unexpected claim result: found=%v task=%+v", found, claimed2)
+	}
+	retryAt := base.Add(5 * time.Second)
+	if err := store.RetryFileGCTask(ctx, claimed2.TaskID, claimed2.Receipt, retryAt, "temporary failure"); err != nil {
+		t.Fatal(err)
+	}
+	if _, found, err := store.ClaimFileGCTask(ctx, base.Add(4*time.Second), time.Second); err != nil {
+		t.Fatal(err)
+	} else if found {
+		t.Fatal("file gc task should not be claimable before retry_at")
+	}
+	reclaimed, found, err := store.ClaimFileGCTask(ctx, retryAt.Add(time.Second), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || reclaimed.AttemptCount != 2 {
+		t.Fatalf("expected reclaim with attempt 2: found=%v task=%+v", found, reclaimed)
+	}
+	recoveredAt := retryAt.Add(3 * time.Second)
+	recovered, err := store.RecoverExpiredFileGCTasks(ctx, recoveredAt, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered != 1 {
+		t.Fatalf("recovered=%d, want 1", recovered)
+	}
+	recoveredTask, found, err := store.ClaimFileGCTask(ctx, recoveredAt.Add(time.Second), time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || recoveredTask.AttemptCount != 3 {
+		t.Fatalf("expected recovered task with attempt 3: found=%v task=%+v", found, recoveredTask)
+	}
+	if err := store.RetryFileGCTask(ctx, recoveredTask.TaskID, recoveredTask.Receipt, recoveredAt.Add(3*time.Second), "still failing"); err != nil {
+		t.Fatal(err)
+	}
+	got, err = store.GetFileGCTaskByFileID(ctx, task2.FileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != FileGCTaskQueued {
+		t.Fatalf("file gc retry with max_attempts=0 should requeue: %+v", got)
+	}
+
+	// S3 ref listing paginates by storage_ref cursor.
+	refs, cursor, err := store.ListFileGCTaskS3Refs(ctx, "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].StorageRef != task1.StorageRef || cursor != task1.StorageRef {
+		t.Fatalf("first ref page = %+v cursor=%q, want [%s]", refs, cursor, task1.StorageRef)
+	}
+	refs, cursor, err = store.ListFileGCTaskS3Refs(ctx, cursor, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refs) != 1 || refs[0].StorageRef != task2.StorageRef || cursor != "" {
+		t.Fatalf("second ref page = %+v cursor=%q, want [%s]", refs, cursor, task2.StorageRef)
+	}
+}
+
+// mustGetSharedSemanticTask reads one task row through the store's scope so
+// the same helper works against both schema shapes.
+func mustGetSharedSemanticTask(t *testing.T, store *Store, taskID string) *semantic.Task {
+	t.Helper()
+	row := store.DB().QueryRow(`SELECT task_id, task_type, resource_id, resource_version, status,
+		attempt_count, max_attempts, receipt, leased_at, lease_until, available_at,
+		payload_json, last_error, created_at, updated_at, completed_at
+		FROM semantic_tasks WHERE `+store.scope.And(`task_id = ?`), store.scope.Args(taskID)...)
+	task, err := scanSemanticTask(row)
+	if err != nil {
+		t.Fatalf("get semantic task %s: %v", taskID, err)
+	}
+	return task
+}
+
+// TestSemanticTasksSharedShapeParity runs the same task-queue scenario used
+// by the standalone tests against the shared (fs_id) schema shape.
+func TestSemanticTasksSharedShapeParity(t *testing.T) {
+	installSharedCoreFSSchema(t)
+	store := newSharedStore(t, 4300001)
+	runSemanticTaskCoreScenario(t, store, "shr-parity")
+	runFileGCTaskCoreScenario(t, store, "shr-parity")
+}
+
+// TestSemanticTasksSharedShapeCrossTenantIsolation proves semantic task rows
+// of one fs_id are invisible to another fs_id on the same shared table, and
+// that the same task_id/resource tuple can coexist under both fs_ids.
+func TestSemanticTasksSharedShapeCrossTenantIsolation(t *testing.T) {
+	installSharedCoreFSSchema(t)
+	ctx := context.Background()
+	storeA := newSharedStore(t, 4300002)
+	storeB := newSharedStore(t, 4300003)
+	base := time.Now().UTC()
+
+	// Same task_id and resource tuple under both fs_ids must coexist.
+	for _, store := range []*Store{storeA, storeB} {
+		created, err := store.EnqueueSemanticTask(ctx, newSemanticTask("task-iso", "file-iso", 1, base, base))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !created {
+			t.Fatal("expected per-tenant task rows to coexist")
+		}
+	}
+	// Duplicate suppression stays inside the fs_id: re-enqueueing A's tuple
+	// with a different task id is a no-op for A and must not touch B's row.
+	created, err := storeA.EnqueueSemanticTask(ctx, newSemanticTask("task-iso-dup", "file-iso", 1, base, base))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created {
+		t.Fatal("duplicate enqueue within A should not create a second task")
+	}
+
+	// Each store claims only its own identical row.
+	claimedA, found, err := storeA.ClaimSemanticTask(ctx, base.Add(time.Second), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || claimedA.TaskID != "task-iso" {
+		t.Fatalf("A claim = found=%v task=%+v", found, claimedA)
+	}
+	claimedB, found, err := storeB.ClaimSemanticTask(ctx, base.Add(time.Second), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || claimedB.TaskID != "task-iso" || claimedB.AttemptCount != 1 {
+		t.Fatalf("B claim = found=%v task=%+v, want its own untouched row", found, claimedB)
+	}
+
+	// B cannot ack with A's receipt; A's row is unaffected.
+	if err := storeB.AckSemanticTask(ctx, "task-iso", claimedA.Receipt); !errors.Is(err, semantic.ErrTaskLeaseMismatch) {
+		t.Fatalf("B ack with A receipt err=%v, want %v", err, semantic.ErrTaskLeaseMismatch)
+	}
+	if err := storeA.AckSemanticTask(ctx, "task-iso", claimedA.Receipt); err != nil {
+		t.Fatal(err)
+	}
+	if task := mustGetSharedSemanticTask(t, storeA, "task-iso"); task.Status != semantic.TaskSucceeded {
+		t.Fatalf("A task status=%q, want %q", task.Status, semantic.TaskSucceeded)
+	}
+
+	// Recover never crosses fs_id: A has no expired processing task, B does.
+	recovered, err := storeA.RecoverExpiredSemanticTasks(ctx, base.Add(2*time.Minute), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered != 0 {
+		t.Fatalf("A recovered=%d, want 0", recovered)
+	}
+	recovered, err = storeB.RecoverExpiredSemanticTasks(ctx, base.Add(2*time.Minute), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered != 1 {
+		t.Fatalf("B recovered=%d, want 1", recovered)
+	}
+
+	// Queue observation is scoped per fs_id.
+	obsA, err := storeA.ObserveSemanticTasks(ctx, base.Add(2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obsA.Queued != 0 || obsA.Processing != 0 || obsA.DeadLettered != 0 {
+		t.Fatalf("A observation = %+v, want all zero", obsA)
+	}
+	obsB, err := storeB.ObserveSemanticTasks(ctx, base.Add(2*time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if obsB.Queued != 1 || obsB.Processing != 0 || obsB.DeadLettered != 0 {
+		t.Fatalf("B observation = %+v, want queued=1", obsB)
+	}
+}
+
+// TestFileGCTasksSharedShapeCrossTenantIsolation proves file GC rows of one
+// fs_id are invisible to another fs_id, and that the same file_id/task_id can
+// coexist under both fs_ids.
+func TestFileGCTasksSharedShapeCrossTenantIsolation(t *testing.T) {
+	installSharedCoreFSSchema(t)
+	ctx := context.Background()
+	storeA := newSharedStore(t, 4300004)
+	storeB := newSharedStore(t, 4300005)
+	base := time.Now().UTC()
+
+	// Same file_id (and therefore default task_id) under both fs_ids must
+	// coexist; the storage refs differ so listing scoping is observable.
+	for i, store := range []*Store{storeA, storeB} {
+		inserted, err := store.EnqueueFileGCTaskTx(store.DB(), &FileGCTask{
+			FileID:      "file-gc-iso",
+			StorageType: StorageS3,
+			StorageRef:  fmt.Sprintf("s3://bucket/iso-blob-%c", 'a'+i),
+			SizeBytes:   int64(10 + i),
+			AvailableAt: base,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !inserted {
+			t.Fatal("expected per-tenant file gc rows to coexist")
+		}
+	}
+	gotA, err := storeA.GetFileGCTaskByFileID(ctx, "file-gc-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	gotB, err := storeB.GetFileGCTaskByFileID(ctx, "file-gc-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotA.StorageRef != "s3://bucket/iso-blob-a" || gotB.StorageRef != "s3://bucket/iso-blob-b" {
+		t.Fatalf("cross-tenant file gc rows mixed up: A=%+v B=%+v", gotA, gotB)
+	}
+	for name, store := range map[string]*Store{"A": storeA, "B": storeB} {
+		count, err := store.CountQueuedFileGCTasks(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if count != 1 {
+			t.Fatalf("%s queued file gc count=%d, want 1", name, count)
+		}
+	}
+
+	// A claims and acks its own row; B's identical row stays queued.
+	claimedA, found, err := storeA.ClaimFileGCTask(ctx, base.Add(time.Second), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || claimedA.StorageRef != "s3://bucket/iso-blob-a" {
+		t.Fatalf("A claim = found=%v task=%+v", found, claimedA)
+	}
+	if err := storeA.AckFileGCTask(ctx, claimedA.TaskID, claimedA.Receipt); err != nil {
+		t.Fatal(err)
+	}
+	gotB, err = storeB.GetFileGCTaskByFileID(ctx, "file-gc-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotB.Status != FileGCTaskQueued || gotB.AttemptCount != 0 {
+		t.Fatalf("B row changed by A's claim/ack: %+v", gotB)
+	}
+
+	// S3 ref listing never crosses fs_id.
+	refsA, _, err := storeA.ListFileGCTaskS3Refs(ctx, "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refsA) != 1 || refsA[0].StorageRef != "s3://bucket/iso-blob-a" {
+		t.Fatalf("A refs = %+v, want only iso-blob-a", refsA)
+	}
+	refsB, _, err := storeB.ListFileGCTaskS3Refs(ctx, "", 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(refsB) != 1 || refsB[0].StorageRef != "s3://bucket/iso-blob-b" {
+		t.Fatalf("B refs = %+v, want only iso-blob-b", refsB)
+	}
+
+	// B cannot retry A's completed task id: B's own row is claimed below and
+	// A's row stays succeeded. Recover never crosses fs_id either.
+	claimedB, found, err := storeB.ClaimFileGCTask(ctx, base.Add(time.Second), time.Minute)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found || claimedB.StorageRef != "s3://bucket/iso-blob-b" {
+		t.Fatalf("B claim = found=%v task=%+v", found, claimedB)
+	}
+	recovered, err := storeA.RecoverExpiredFileGCTasks(ctx, base.Add(2*time.Minute), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered != 0 {
+		t.Fatalf("A recovered=%d, want 0", recovered)
+	}
+	recovered, err = storeB.RecoverExpiredFileGCTasks(ctx, base.Add(2*time.Minute), 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovered != 1 {
+		t.Fatalf("B recovered=%d, want 1", recovered)
+	}
+	if err := storeB.RetryFileGCTask(ctx, claimedA.TaskID, claimedA.Receipt, base.Add(3*time.Minute), "cross"); !errors.Is(err, ErrFileGCTaskLeaseMismatch) {
+		t.Fatalf("B retry with A receipt err=%v, want %v", err, ErrFileGCTaskLeaseMismatch)
+	}
+	gotA, err = storeA.GetFileGCTaskByFileID(ctx, "file-gc-iso")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotA.Status != FileGCTaskSucceeded {
+		t.Fatalf("A row changed by B's retry: %+v", gotA)
+	}
+}
+
+// TestSemanticTasksSharedShapeStoresFsID asserts every task row written by
+// the core scenarios carries the scope's fs_id as its row key.
+func TestSemanticTasksSharedShapeStoresFsID(t *testing.T) {
+	installSharedCoreFSSchema(t)
+	const fsID int64 = 4300006
+	store := newSharedStore(t, fsID)
+	runSemanticTaskCoreScenario(t, store, "fsid-sem")
+	runFileGCTaskCoreScenario(t, store, "fsid-gc")
+
+	for _, tbl := range []string{"semantic_tasks", "file_gc_tasks"} {
+		var got int64
+		err := store.DB().QueryRow("SELECT COUNT(*) FROM "+tbl+" WHERE fs_id != ?", fsID).Scan(&got)
+		if err != nil {
+			t.Fatalf("count %s rows with foreign fs_id: %v", tbl, err)
+		}
+		if got != 0 {
+			t.Fatalf("%s has %d rows with fs_id != %d", tbl, got, fsID)
+		}
+		var total int64
+		if err := store.DB().QueryRow("SELECT COUNT(*) FROM " + tbl).Scan(&total); err != nil {
+			t.Fatalf("count %s: %v", tbl, err)
+		}
+		if total == 0 {
+			t.Fatalf("%s is empty; scenario should have written rows", tbl)
+		}
+	}
+}

--- a/pkg/datastore/shared_test_helper_test.go
+++ b/pkg/datastore/shared_test_helper_test.go
@@ -49,13 +49,15 @@ func installSharedTables(t *testing.T, tables []string, stmts []string) {
 
 var coreFSSharedTables = []string{
 	"file_nodes", "inodes", "contents", "semantic", "file_tags",
-	"uploads", "semantic_tasks", "file_gc_tasks", "llm_usage", "fs_events",
+	"uploads", "semantic_tasks", "file_gc_tasks", "fs_events",
 }
 
-// installSharedCoreFSSchema swaps the 10 Core FS tables to the shared shape.
+// installSharedCoreFSSchema swaps the 9 Core FS tables to the shared shape.
+// It also drops the standalone llm_usage table so the test database matches a
+// real shared-schema database, which has no llm_usage at all.
 func installSharedCoreFSSchema(t *testing.T) {
 	t.Helper()
-	installSharedTables(t, coreFSSharedTables, schema.CoreFSMySQLSharedSchemaStatements())
+	installSharedTables(t, append(append([]string{}, coreFSSharedTables...), "llm_usage"), schema.CoreFSMySQLSharedSchemaStatements())
 }
 
 var fsLayerSharedTables = []string{

--- a/pkg/datastore/shared_test_helper_test.go
+++ b/pkg/datastore/shared_test_helper_test.go
@@ -1,0 +1,92 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/tenant/schema"
+)
+
+// installSharedTables drops the named tables, applies the given shared
+// (fs_id) DDL, and restores the standalone schema on cleanup. Tests in this
+// package run sequentially, so the swap is safe. A second database cannot be
+// used instead: the testcontainer MySQL user only has privileges on the test
+// database. The restore cleanup is registered before applying the DDL so a
+// failed apply cannot leak shared-shape tables into later tests.
+func installSharedTables(t *testing.T, tables []string, stmts []string) {
+	t.Helper()
+	drop := func(db *sql.DB) {
+		t.Helper()
+		for _, tbl := range tables {
+			if _, err := db.Exec("DROP TABLE IF EXISTS " + tbl); err != nil {
+				t.Fatalf("drop %s: %v", tbl, err)
+			}
+		}
+	}
+	db, err := sql.Open("mysql", testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	drop(db)
+	t.Cleanup(func() {
+		db, err := sql.Open("mysql", testDSN)
+		if err != nil {
+			t.Errorf("reopen test db for schema restore: %v", err)
+			return
+		}
+		defer func() { _ = db.Close() }()
+		drop(db)
+		initDatastoreSchema(t, testDSN)
+	})
+	for _, stmt := range stmts {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("apply shared schema: %v", err)
+		}
+	}
+}
+
+var coreFSSharedTables = []string{
+	"file_nodes", "inodes", "contents", "semantic", "file_tags",
+	"uploads", "semantic_tasks", "file_gc_tasks", "llm_usage", "fs_events",
+}
+
+// installSharedCoreFSSchema swaps the 10 Core FS tables to the shared shape.
+func installSharedCoreFSSchema(t *testing.T) {
+	t.Helper()
+	installSharedTables(t, coreFSSharedTables, schema.CoreFSMySQLSharedSchemaStatements())
+}
+
+var fsLayerSharedTables = []string{
+	"fs_layer_checkpoints", "fs_layer_events", "fs_layer_tags", "fs_layer_entries", "fs_layers",
+}
+
+// installSharedFSLayerSchema swaps the 5 FS Layer tables to the shared shape.
+func installSharedFSLayerSchema(t *testing.T) {
+	t.Helper()
+	installSharedTables(t, fsLayerSharedTables, schema.FSLayerMySQLSharedSchemaStatements())
+}
+
+var gitSharedTables = []string{
+	"git_workspace_object_packs", "git_workspace_overlay", "git_workspace_git_state",
+	"git_workspace_tree_nodes", "git_workspaces",
+}
+
+// installSharedGitSchema swaps the 5 Git Workspace tables to the shared shape.
+func installSharedGitSchema(t *testing.T) {
+	t.Helper()
+	installSharedTables(t, gitSharedTables, schema.GitWorkspaceMySQLSharedSchemaStatements())
+}
+
+// newSharedStore opens a Store bound to the shared schema with the given
+// fs_id as its tenant row key.
+func newSharedStore(t *testing.T, fsID int64) *Store {
+	t.Helper()
+	store, err := OpenForTenantScoped(context.Background(), testDSN, "", "", SharedScope(fsID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = store.Close() })
+	return store
+}

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -151,6 +150,7 @@ type Upload struct {
 type Store struct {
 	db             *sql.DB
 	useLegacyFiles bool // true when the legacy `files` table exists and needs dual-write
+	scope          Scope
 }
 
 func Open(dsn string) (*Store, error) {
@@ -162,6 +162,13 @@ func OpenForTenant(ctx context.Context, dsn, tenantID string) (*Store, error) {
 }
 
 func OpenForTenantWithOrg(ctx context.Context, dsn, tenantID, tidbCloudOrgID string) (*Store, error) {
+	return OpenForTenantScoped(ctx, dsn, tenantID, tidbCloudOrgID, StandaloneScope(0))
+}
+
+// OpenForTenantScoped opens a Store whose SQL is shaped by scope: standalone
+// (per-tenant DB, no fs_id columns) or shared (multi-tenant DB with fs_id
+// row keys). The scope is fixed for the lifetime of the Store.
+func OpenForTenantScoped(ctx context.Context, dsn, tenantID, tidbCloudOrgID string, scope Scope) (*Store, error) {
 	lower := strings.ToLower(dsn)
 	if strings.Contains(lower, "multistatements=true") || strings.Contains(lower, "multistatements=1") {
 		return nil, fmt.Errorf("multiStatements is not allowed in production DSN")
@@ -170,7 +177,7 @@ func OpenForTenantWithOrg(ctx context.Context, dsn, tenantID, tidbCloudOrgID str
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}
-	s := &Store{db: db}
+	s := &Store{db: db, scope: scope}
 	hasLegacy, err := s.detectLegacyFiles(ctx)
 	if err != nil {
 		_ = mysqlutil.CloseInstrumented(db)
@@ -182,6 +189,9 @@ func OpenForTenantWithOrg(ctx context.Context, dsn, tenantID, tidbCloudOrgID str
 
 func (s *Store) Close() error { return mysqlutil.CloseInstrumented(s.db) }
 func (s *Store) DB() *sql.DB  { return s.db }
+
+// Scope returns the schema-shape scope fixed at construction.
+func (s *Store) Scope() Scope { return s.scope }
 
 // HasLegacyFiles reports whether the legacy `files` table exists in this
 // tenant database. When false, all writes skip the `files` table entirely
@@ -252,10 +262,10 @@ func (s *Store) InsertNode(ctx context.Context, n *FileNode) error {
 		opErr = ErrInvalidRootDentry
 		return ErrInvalidRootDentry
 	}
-	_, err := s.db.ExecContext(ctx, `INSERT INTO file_nodes (node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, inode_id, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		n.NodeID, n.Path, fileNodePathHash(n.Path), n.ParentPath, fileNodePathHash(n.ParentPath),
-		n.Name, n.IsDirectory, nullStr(n.FileID), nullStr(n.InodeID), n.CreatedAt.UTC())
+	_, err := s.db.ExecContext(ctx, `INSERT INTO file_nodes (`+s.scope.InsCols(`node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, inode_id, created_at`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(n.NodeID, n.Path, fileNodePathHash(n.Path), n.ParentPath, fileNodePathHash(n.ParentPath),
+			n.Name, n.IsDirectory, nullStr(n.FileID), nullStr(n.InodeID), n.CreatedAt.UTC())...)
 	if isUniqueViolation(err) {
 		opErr = ErrPathConflict
 		return ErrPathConflict
@@ -270,7 +280,7 @@ func (s *Store) GetNode(ctx context.Context, path string) (*FileNode, error) {
 	defer observeStoreOp(ctx, "get_node", start, &opErr)
 
 	row := s.db.QueryRowContext(ctx, `SELECT node_id, path, parent_path, name, is_directory, file_id, inode_id, created_at
-		FROM file_nodes WHERE path_hash = ? AND path = ?`, fileNodePathHash(path), path)
+		FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`), s.scope.Args(fileNodePathHash(path), path)...)
 	n, err := scanNode(row)
 	opErr = err
 	return n, err
@@ -284,8 +294,8 @@ func (s *Store) NodeExists(ctx context.Context, path string) (exists bool, err e
 	defer observeStoreOp(ctx, "node_exists", start, &err)
 
 	var one int
-	err = s.db.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE path_hash = ? AND path = ? LIMIT 1`,
-		fileNodePathHash(path), path).Scan(&one)
+	err = s.db.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`)+` LIMIT 1`,
+		s.scope.Args(fileNodePathHash(path), path)...).Scan(&one)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}
@@ -300,7 +310,8 @@ func (s *Store) ListNodes(ctx context.Context, parentPath string) (out []*FileNo
 	defer observeStoreOp(ctx, "list_nodes", start, &err)
 
 	rows, err := s.db.QueryContext(ctx, `SELECT node_id, path, parent_path, name, is_directory, file_id, inode_id, created_at
-		FROM file_nodes WHERE parent_path_hash = ? AND parent_path = ? ORDER BY name`, fileNodePathHash(parentPath), parentPath)
+		FROM file_nodes WHERE `+s.scope.And(`parent_path_hash = ? AND parent_path = ?`)+` ORDER BY name`,
+		s.scope.Args(fileNodePathHash(parentPath), parentPath)...)
 	if err != nil {
 		return nil, err
 	}
@@ -327,7 +338,8 @@ func (s *Store) DeleteNode(ctx context.Context, path string) (err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "delete_node", start, &err)
 
-	res, err := s.db.ExecContext(ctx, `DELETE FROM file_nodes WHERE path_hash = ? AND path = ?`, fileNodePathHash(path), path)
+	res, err := s.db.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`),
+		s.scope.Args(fileNodePathHash(path), path)...)
 	if err != nil {
 		return err
 	}
@@ -349,14 +361,15 @@ func (s *Store) DeleteEmptyDir(ctx context.Context, path string) (err error) {
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	hasChildren, err := dirHasChildrenTx(ctx, tx, path)
+	hasChildren, err := s.dirHasChildrenTx(ctx, tx, path)
 	if err != nil {
 		return err
 	}
 	if hasChildren {
 		return fmt.Errorf("directory not empty: %s", path)
 	}
-	res, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE path_hash = ? AND path = ? AND is_directory = 1`, fileNodePathHash(path), path)
+	res, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ? AND is_directory = 1`),
+		s.scope.Args(fileNodePathHash(path), path)...)
 	if err != nil {
 		return err
 	}
@@ -373,7 +386,7 @@ func (s *Store) DeleteNodesByPrefix(ctx context.Context, prefix string) (n int64
 	defer observeStoreOp(ctx, "delete_nodes_by_prefix", start, &err)
 
 	where, args := pathPrefixPredicate("path", prefix)
-	res, err := s.db.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+where, args...)
+	res, err := s.db.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+s.scope.And(where), s.scope.Args(args...)...)
 	if err != nil {
 		return 0, err
 	}
@@ -389,8 +402,9 @@ func (s *Store) UpdateNodePath(ctx context.Context, oldPath, newPath, newParentP
 		return ErrInvalidRootDentry
 	}
 	res, err := s.db.ExecContext(ctx, `UPDATE file_nodes SET path = ?, path_hash = ?, parent_path = ?, parent_path_hash = ?, name = ?
-		WHERE path_hash = ? AND path = ?`,
-		newPath, fileNodePathHash(newPath), newParentPath, fileNodePathHash(newParentPath), newName, fileNodePathHash(oldPath), oldPath)
+		WHERE `+s.scope.And(`path_hash = ? AND path = ?`),
+		append([]any{newPath, fileNodePathHash(newPath), newParentPath, fileNodePathHash(newParentPath), newName},
+			s.scope.Args(fileNodePathHash(oldPath), oldPath)...)...)
 	if err != nil {
 		return err
 	}
@@ -423,8 +437,8 @@ func (s *Store) RenameFileReplacingTarget(ctx context.Context, oldPath, newPath,
 		isDir  bool
 	}
 	var old nodeRef
-	err = tx.QueryRow(`SELECT node_id, file_id, is_directory FROM file_nodes WHERE path_hash = ? AND path = ? FOR UPDATE`,
-		fileNodePathHash(oldPath), oldPath).Scan(&old.nodeID, &old.fileID, &old.isDir)
+	err = tx.QueryRow(`SELECT node_id, file_id, is_directory FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`)+` FOR UPDATE`,
+		s.scope.Args(fileNodePathHash(oldPath), oldPath)...).Scan(&old.nodeID, &old.fileID, &old.isDir)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -440,8 +454,8 @@ func (s *Store) RenameFileReplacingTarget(ctx context.Context, oldPath, newPath,
 
 	var dst nodeRef
 	hasDst := false
-	err = tx.QueryRow(`SELECT node_id, file_id, is_directory FROM file_nodes WHERE path_hash = ? AND path = ? FOR UPDATE`,
-		fileNodePathHash(newPath), newPath).Scan(&dst.nodeID, &dst.fileID, &dst.isDir)
+	err = tx.QueryRow(`SELECT node_id, file_id, is_directory FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`)+` FOR UPDATE`,
+		s.scope.Args(fileNodePathHash(newPath), newPath)...).Scan(&dst.nodeID, &dst.fileID, &dst.isDir)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			return nil, err
@@ -454,13 +468,13 @@ func (s *Store) RenameFileReplacingTarget(ctx context.Context, oldPath, newPath,
 		if dst.nodeID == old.nodeID {
 			return nil, tx.Commit()
 		}
-		if _, err := tx.Exec(`DELETE FROM file_nodes WHERE node_id = ?`, dst.nodeID); err != nil {
+		if _, err := tx.Exec(`DELETE FROM file_nodes WHERE `+s.scope.And(`node_id = ?`), s.scope.Args(dst.nodeID)...); err != nil {
 			return nil, err
 		}
 	}
 
-	res, err := tx.Exec(`UPDATE file_nodes SET path = ?, path_hash = ?, parent_path = ?, parent_path_hash = ?, name = ? WHERE node_id = ?`,
-		newPath, fileNodePathHash(newPath), newParentPath, fileNodePathHash(newParentPath), newName, old.nodeID)
+	res, err := tx.Exec(`UPDATE file_nodes SET path = ?, path_hash = ?, parent_path = ?, parent_path_hash = ?, name = ? WHERE `+s.scope.And(`node_id = ?`),
+		append([]any{newPath, fileNodePathHash(newPath), newParentPath, fileNodePathHash(newParentPath), newName}, s.scope.Args(old.nodeID)...)...)
 	if isUniqueViolation(err) {
 		return nil, ErrPathConflict
 	}
@@ -474,7 +488,7 @@ func (s *Store) RenameFileReplacingTarget(ctx context.Context, oldPath, newPath,
 
 	if hasDst && dst.fileID.Valid && dst.fileID.String != "" {
 		var count int64
-		if err := tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE file_id = ? FOR UPDATE`, dst.fileID.String).Scan(&count); err != nil {
+		if err := tx.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE `+s.scope.And(`file_id = ?`)+` FOR UPDATE`, s.scope.Args(dst.fileID.String)...).Scan(&count); err != nil {
 			return nil, err
 		}
 		if count == 0 {
@@ -483,10 +497,10 @@ func (s *Store) RenameFileReplacingTarget(ctx context.Context, oldPath, newPath,
 					return nil, err
 				}
 			}
-			if _, err := tx.Exec(`UPDATE inodes SET status = 'DELETED' WHERE inode_id = ?`, dst.fileID.String); err != nil {
+			if _, err := tx.Exec(`UPDATE inodes SET status = 'DELETED' WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(dst.fileID.String)...); err != nil {
 				return nil, err
 			}
-			if _, err := tx.Exec(`DELETE FROM file_tags WHERE file_id = ?`, dst.fileID.String); err != nil {
+			if _, err := tx.Exec(`DELETE FROM file_tags WHERE `+s.scope.And(`file_id = ?`), s.scope.Args(dst.fileID.String)...); err != nil {
 				return nil, err
 			}
 			f, err := s.scanFileForGCTx(tx, dst.fileID.String)
@@ -531,8 +545,8 @@ func (s *Store) RenameFileNoReplace(ctx context.Context, oldPath, newPath, newPa
 		isDir  bool
 	}
 	var old nodeRef
-	err = tx.QueryRowContext(ctx, `SELECT node_id, is_directory FROM file_nodes WHERE path_hash = ? AND path = ? FOR UPDATE`,
-		fileNodePathHash(oldPath), oldPath).Scan(&old.nodeID, &old.isDir)
+	err = tx.QueryRowContext(ctx, `SELECT node_id, is_directory FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`)+` FOR UPDATE`,
+		s.scope.Args(fileNodePathHash(oldPath), oldPath)...).Scan(&old.nodeID, &old.isDir)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
@@ -547,8 +561,8 @@ func (s *Store) RenameFileNoReplace(ctx context.Context, oldPath, newPath, newPa
 	}
 
 	var dst nodeRef
-	err = tx.QueryRowContext(ctx, `SELECT node_id, is_directory FROM file_nodes WHERE path_hash = ? AND path = ? FOR UPDATE`,
-		fileNodePathHash(newPath), newPath).Scan(&dst.nodeID, &dst.isDir)
+	err = tx.QueryRowContext(ctx, `SELECT node_id, is_directory FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`)+` FOR UPDATE`,
+		s.scope.Args(fileNodePathHash(newPath), newPath)...).Scan(&dst.nodeID, &dst.isDir)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			return err
@@ -561,7 +575,8 @@ func (s *Store) RenameFileNoReplace(ctx context.Context, oldPath, newPath, newPa
 	}
 
 	res, err := tx.ExecContext(ctx, `UPDATE file_nodes SET path = ?, path_hash = ?, parent_path = ?, parent_path_hash = ?, name = ?
-		WHERE node_id = ?`, newPath, fileNodePathHash(newPath), newParentPath, fileNodePathHash(newParentPath), newName, old.nodeID)
+		WHERE `+s.scope.And(`node_id = ?`),
+		append([]any{newPath, fileNodePathHash(newPath), newParentPath, fileNodePathHash(newParentPath), newName}, s.scope.Args(old.nodeID)...)...)
 	if err != nil {
 		if strings.Contains(err.Error(), "Duplicate entry") {
 			return ErrPathConflict
@@ -598,7 +613,8 @@ func (s *Store) RenameDir(ctx context.Context, oldPrefix, newPrefix string) (cou
 	defer func() { _ = tx.Rollback() }()
 
 	rows, err := tx.QueryContext(ctx, `SELECT node_id, path, parent_path, name FROM file_nodes
-		WHERE path = ? OR path LIKE ? ORDER BY path FOR UPDATE`, oldPrefix, oldPrefix+"%")
+		WHERE `+s.andAsGrouped("", `path = ? OR path LIKE ?`)+` ORDER BY path FOR UPDATE`,
+		s.scope.Args(oldPrefix, oldPrefix+"%")...)
 	if err != nil {
 		return 0, err
 	}
@@ -632,8 +648,8 @@ func (s *Store) RenameDir(ctx context.Context, oldPrefix, newPrefix string) (cou
 		isDir  bool
 	}
 	var dst dstRef
-	err = tx.QueryRowContext(ctx, `SELECT node_id, is_directory FROM file_nodes WHERE path_hash = ? AND path = ? FOR UPDATE`,
-		fileNodePathHash(newPrefix), newPrefix).Scan(&dst.nodeID, &dst.isDir)
+	err = tx.QueryRowContext(ctx, `SELECT node_id, is_directory FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`)+` FOR UPDATE`,
+		s.scope.Args(fileNodePathHash(newPrefix), newPrefix)...).Scan(&dst.nodeID, &dst.isDir)
 	if err != nil {
 		if !errors.Is(err, sql.ErrNoRows) {
 			return 0, err
@@ -642,8 +658,8 @@ func (s *Store) RenameDir(ctx context.Context, oldPrefix, newPrefix string) (cou
 		if !dst.isDir {
 			return 0, ErrPathConflict
 		}
-		childRows, err := tx.QueryContext(ctx, `SELECT node_id FROM file_nodes WHERE parent_path_hash = ? AND parent_path = ? FOR UPDATE`,
-			fileNodePathHash(newPrefix), newPrefix)
+		childRows, err := tx.QueryContext(ctx, `SELECT node_id FROM file_nodes WHERE `+s.scope.And(`parent_path_hash = ? AND parent_path = ?`)+` FOR UPDATE`,
+			s.scope.Args(fileNodePathHash(newPrefix), newPrefix)...)
 		if err != nil {
 			return 0, err
 		}
@@ -654,19 +670,19 @@ func (s *Store) RenameDir(ctx context.Context, oldPrefix, newPrefix string) (cou
 		if hasChild {
 			return 0, ErrPathConflict
 		}
-		if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE node_id = ?`, dst.nodeID); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+s.scope.And(`node_id = ?`), s.scope.Args(dst.nodeID)...); err != nil {
 			return 0, err
 		}
 	}
 
-	stmt, err := tx.PrepareContext(ctx, `UPDATE file_nodes SET path = ?, path_hash = ?, parent_path = ?, parent_path_hash = ?, name = ? WHERE node_id = ?`)
+	stmt, err := tx.PrepareContext(ctx, `UPDATE file_nodes SET path = ?, path_hash = ?, parent_path = ?, parent_path_hash = ?, name = ? WHERE `+s.scope.And(`node_id = ?`))
 	if err != nil {
 		return 0, err
 	}
 	defer func() { _ = stmt.Close() }()
 
 	for _, u := range updates {
-		if _, err := stmt.Exec(u.newPath, fileNodePathHash(u.newPath), u.newParent, fileNodePathHash(u.newParent), u.newName, u.nodeID); err != nil {
+		if _, err := stmt.Exec(append([]any{u.newPath, fileNodePathHash(u.newPath), u.newParent, fileNodePathHash(u.newParent), u.newName}, s.scope.Args(u.nodeID)...)...); err != nil {
 			if isUniqueViolation(err) {
 				return 0, ErrPathConflict
 			}
@@ -685,7 +701,7 @@ func (s *Store) RefCount(ctx context.Context, fileID string) (count int64, err e
 	start := time.Now()
 	defer observeStoreOp(ctx, "ref_count", start, &err)
 
-	err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM file_nodes WHERE file_id = ?`, fileID).Scan(&count)
+	err = s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM file_nodes WHERE `+s.scope.And(`file_id = ?`), s.scope.Args(fileID)...).Scan(&count)
 	return count, err
 }
 
@@ -715,8 +731,8 @@ func (s *Store) RefCounts(ctx context.Context, fileIDs []string) (counts map[str
 		}
 		batch := unique[start:end]
 		rows, err := s.db.QueryContext(ctx,
-			`SELECT file_id, COUNT(*) FROM file_nodes WHERE file_id IN (`+questionPlaceholders(len(batch))+`) GROUP BY file_id`,
-			stringsToAny(batch)...)
+			`SELECT file_id, COUNT(*) FROM file_nodes WHERE `+s.scope.And(`file_id IN (`+questionPlaceholders(len(batch))+`)`)+` GROUP BY file_id`,
+			s.scope.Args(stringsToAny(batch)...)...)
 		if err != nil {
 			return nil, err
 		}
@@ -765,8 +781,8 @@ func (s *Store) LinkFileNodeTx(ctx context.Context, db execer, srcPath, dstPath,
 	}
 	if dstParentPath != "/" {
 		var parentIsDir bool
-		err := db.QueryRowContext(ctx, `SELECT is_directory FROM file_nodes WHERE path_hash = ? AND path = ? FOR UPDATE`,
-			fileNodePathHash(dstParentPath), dstParentPath).Scan(&parentIsDir)
+		err := db.QueryRowContext(ctx, `SELECT is_directory FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`)+` FOR UPDATE`,
+			s.scope.Args(fileNodePathHash(dstParentPath), dstParentPath)...).Scan(&parentIsDir)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrNotFound
@@ -780,8 +796,8 @@ func (s *Store) LinkFileNodeTx(ctx context.Context, db execer, srcPath, dstPath,
 
 	var fileID, inodeID sql.NullString
 	var isDir bool
-	err := db.QueryRowContext(ctx, `SELECT file_id, inode_id, is_directory FROM file_nodes WHERE path_hash = ? AND path = ? FOR UPDATE`,
-		fileNodePathHash(srcPath), srcPath).Scan(&fileID, &inodeID, &isDir)
+	err := db.QueryRowContext(ctx, `SELECT file_id, inode_id, is_directory FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`)+` FOR UPDATE`,
+		s.scope.Args(fileNodePathHash(srcPath), srcPath)...).Scan(&fileID, &inodeID, &isDir)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
@@ -801,9 +817,9 @@ func (s *Store) LinkFileNodeTx(ctx context.Context, db execer, srcPath, dstPath,
 	if inodeID.Valid && inodeID.String != "" {
 		linkInodeID = inodeID.String
 	}
-	_, err = db.Exec(`INSERT INTO file_nodes (node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, inode_id, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, 0, ?, ?, ?)`,
-		nodeID, dstPath, fileNodePathHash(dstPath), dstParentPath, fileNodePathHash(dstParentPath), dstName, fileID.String, linkInodeID, createdAt.UTC())
+	_, err = db.Exec(`INSERT INTO file_nodes (`+s.scope.InsCols(`node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, inode_id, created_at`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, 0, ?, ?, ?`)+`)`,
+		s.scope.Args(nodeID, dstPath, fileNodePathHash(dstPath), dstParentPath, fileNodePathHash(dstParentPath), dstName, fileID.String, linkInodeID, createdAt.UTC())...)
 	if isUniqueViolation(err) {
 		return ErrPathConflict
 	}
@@ -829,7 +845,7 @@ func (s *Store) EnsureParentDirs(ctx context.Context, path string, genID func() 
 		if err != nil {
 			return err
 		}
-		err = ensureParentDirsWithExecer(ctx, tx, path, genID)
+		err = s.ensureParentDirsWithExecer(ctx, tx, path, genID)
 		if err != nil {
 			_ = tx.Rollback()
 			if isDeadlock(err) && attempt < maxAttempts-1 {
@@ -970,8 +986,8 @@ func (s *Store) HasConfirmedS3StorageRef(ctx context.Context, storageRefHash, st
 	}
 	row := s.db.QueryRowContext(ctx, `SELECT 1
 		FROM contents c JOIN inodes i ON i.inode_id = c.inode_id
-		WHERE c.storage_type = ? AND i.status = ? AND c.storage_ref_hash = ? AND c.storage_ref = ?
-		LIMIT 1`, StorageS3, StatusConfirmed, storageRefHash, storageRef)
+		WHERE `+s.scope.AndAs("c", `c.storage_type = ? AND i.status = ? AND c.storage_ref_hash = ? AND c.storage_ref = ?`)+`
+		LIMIT 1`, s.scope.Args(StorageS3, StatusConfirmed, storageRefHash, storageRef)...)
 	var one int
 	if err := row.Scan(&one); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1023,7 +1039,7 @@ func (s *Store) UpdateFileContent(ctx context.Context, fileID string, storageTyp
 		}
 	} else {
 		var currentRev int64
-		if err := tx.QueryRow(`SELECT revision FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' FOR UPDATE`, fileID).Scan(&currentRev); err != nil {
+		if err := tx.QueryRow(`SELECT revision FROM inodes WHERE `+s.scope.And(`inode_id = ? AND status = 'CONFIRMED'`)+` FOR UPDATE`, s.scope.Args(fileID)...).Scan(&currentRev); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return 0, ErrNotFound
 			}
@@ -1037,7 +1053,7 @@ func (s *Store) UpdateFileContent(ctx context.Context, fileID string, storageTyp
 		return 0, fmt.Errorf("update inode: %w", err)
 	}
 	var encryptionMode StorageEncryptionMode
-	if err := tx.QueryRow(`SELECT storage_encryption_mode FROM contents WHERE inode_id = ?`, fileID).Scan(&encryptionMode); err != nil {
+	if err := tx.QueryRow(`SELECT storage_encryption_mode FROM contents WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(fileID)...).Scan(&encryptionMode); err != nil {
 		return 0, fmt.Errorf("read encryption mode: %w", err)
 	}
 	if err := s.UpdateContentTx(tx, fileID, storageType, storageRef, contentType, checksum, contentBlob, encryptionMode); err != nil {
@@ -1094,15 +1110,15 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 		}
 		if expectedRevision > 0 {
 			if _, err := db.Exec(`UPDATE semantic SET content_text = ?
-				WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`,
-				nullStr(contentText), fileID, fileID, expectedRevision); err != nil {
+				WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`),
+				append([]any{nullStr(contentText)}, s.scope.Args(fileID, fileID, expectedRevision)...)...); err != nil {
 				return nil, fmt.Errorf("update semantic content_text: %w", err)
 			}
 			return res, nil
 		}
 		if _, err := db.Exec(`UPDATE semantic SET content_text = ?
-			WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED')`,
-			nullStr(contentText), fileID, fileID); err != nil {
+			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED')`),
+			append([]any{nullStr(contentText)}, s.scope.Args(fileID, fileID)...)...); err != nil {
 			return nil, fmt.Errorf("update semantic content_text: %w", err)
 		}
 		return res, nil
@@ -1110,12 +1126,12 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 	// New tenant without legacy files: write directly to semantic.
 	if expectedRevision > 0 {
 		return db.Exec(`UPDATE semantic SET content_text = ?
-			WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`,
-			nullStr(contentText), fileID, fileID, expectedRevision)
+			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`),
+			append([]any{nullStr(contentText)}, s.scope.Args(fileID, fileID, expectedRevision)...)...)
 	}
 	return db.Exec(`UPDATE semantic SET content_text = ?
-		WHERE inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED')`,
-		nullStr(contentText), fileID, fileID)
+		WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED')`),
+		append([]any{nullStr(contentText)}, s.scope.Args(fileID, fileID)...)...)
 }
 
 // ReplaceFileTagsTx replaces all tags for fileID inside an existing transaction.
@@ -1124,7 +1140,7 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 // the current write revision. Passing an empty map clears all existing tags.
 // Callers that intend to preserve the current tag set must skip this call.
 func (s *Store) ReplaceFileTagsTx(db execer, fileID string, tags map[string]string) error {
-	if _, err := db.Exec(`DELETE FROM file_tags WHERE file_id = ?`, fileID); err != nil {
+	if _, err := db.Exec(`DELETE FROM file_tags WHERE `+s.scope.And(`file_id = ?`), s.scope.Args(fileID)...); err != nil {
 		return err
 	}
 	if len(tags) == 0 {
@@ -1138,7 +1154,8 @@ func (s *Store) ReplaceFileTagsTx(db execer, fileID string, tags map[string]stri
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		if _, err := db.Exec(`INSERT INTO file_tags (file_id, tag_key, tag_value) VALUES (?, ?, ?)`, fileID, k, tags[k]); err != nil {
+		if _, err := db.Exec(`INSERT INTO file_tags (`+s.scope.InsCols(`file_id, tag_key, tag_value`)+`) VALUES (`+s.scope.InsVals(`?, ?, ?`)+`)`,
+			s.scope.Args(fileID, k, tags[k])...); err != nil {
 			return err
 		}
 	}
@@ -1156,7 +1173,7 @@ func (s *Store) ReplaceFileTagsByPrefixTx(db execer, fileID string, prefix strin
 		return fmt.Errorf("tag prefix is required")
 	}
 	pattern := likeLiteralPrefixPattern(prefix)
-	if _, err := db.Exec(`DELETE FROM file_tags WHERE file_id = ? AND tag_key LIKE ? ESCAPE '\\'`, fileID, pattern); err != nil {
+	if _, err := db.Exec(`DELETE FROM file_tags WHERE `+s.scope.And(`file_id = ? AND tag_key LIKE ? ESCAPE '\\'`), s.scope.Args(fileID, pattern)...); err != nil {
 		return err
 	}
 	if len(tags) == 0 {
@@ -1173,7 +1190,8 @@ func (s *Store) ReplaceFileTagsByPrefixTx(db execer, fileID string, prefix strin
 	sort.Strings(keys)
 
 	for _, k := range keys {
-		if _, err := db.Exec(`INSERT INTO file_tags (file_id, tag_key, tag_value) VALUES (?, ?, ?)`, fileID, k, tags[k]); err != nil {
+		if _, err := db.Exec(`INSERT INTO file_tags (`+s.scope.InsCols(`file_id, tag_key, tag_value`)+`) VALUES (`+s.scope.InsVals(`?, ?, ?`)+`)`,
+			s.scope.Args(fileID, k, tags[k])...); err != nil {
 			return err
 		}
 	}
@@ -1190,7 +1208,7 @@ func (s *Store) GetFileTags(ctx context.Context, fileID string) (out map[string]
 	start := time.Now()
 	defer observeStoreOp(ctx, "get_file_tags", start, &err)
 
-	rows, err := s.db.QueryContext(ctx, `SELECT tag_key, tag_value FROM file_tags WHERE file_id = ? ORDER BY tag_key`, fileID)
+	rows, err := s.db.QueryContext(ctx, `SELECT tag_key, tag_value FROM file_tags WHERE `+s.scope.And(`file_id = ?`)+` ORDER BY tag_key`, s.scope.Args(fileID)...)
 	if err != nil {
 		return nil, err
 	}
@@ -1238,7 +1256,7 @@ func (s *Store) GetFileStorageMetaForUpdateTx(db execer, fileID string) (*FileSt
 	var contentType sql.NullString
 	err := db.QueryRow(`SELECT c.storage_type, c.storage_ref, i.revision, i.size_bytes, COALESCE(c.content_type, '')
 		FROM inodes i JOIN contents c ON i.inode_id = c.inode_id
-		WHERE i.inode_id = ? AND i.status = 'CONFIRMED' FOR UPDATE`, fileID).Scan(
+		WHERE `+s.scope.AndAs("i", `i.inode_id = ? AND i.status = 'CONFIRMED'`)+` FOR UPDATE`, s.scope.Args(fileID)...).Scan(
 		&m.StorageType, &m.StorageRef, &m.Revision, &m.SizeBytes, &contentType)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1253,7 +1271,8 @@ func (s *Store) GetFileStorageMetaForUpdateTx(db execer, fileID string) (*FileSt
 func (s *Store) CompleteUploadTx(db execer, uploadID string) error {
 	_, err := db.Exec(`UPDATE uploads SET status = 'COMPLETED',
 		updated_at = ?
-		WHERE upload_id = ? AND status = 'UPLOADING'`, time.Now().UTC(), uploadID)
+		WHERE `+s.scope.And(`upload_id = ? AND status = 'UPLOADING'`),
+		append([]any{time.Now().UTC()}, s.scope.Args(uploadID)...)...)
 	return err
 }
 
@@ -1281,14 +1300,15 @@ func (s *Store) Chmod(ctx context.Context, path string, mode uint32) (err error)
 	}
 
 	var currentMode uint32
-	if err := s.db.QueryRowContext(ctx, `SELECT mode FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED'`, inodeID).Scan(&currentMode); err != nil {
+	if err := s.db.QueryRowContext(ctx, `SELECT mode FROM inodes WHERE `+s.scope.And(`inode_id = ? AND status = 'CONFIRMED'`), s.scope.Args(inodeID)...).Scan(&currentMode); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
 		}
 		return err
 	}
 	mode = (mode & permissionModeMask) | (currentMode & fileTypeModeMask)
-	res, err := s.db.ExecContext(ctx, `UPDATE inodes SET mode = ? WHERE inode_id = ? AND status = 'CONFIRMED'`, mode, inodeID)
+	res, err := s.db.ExecContext(ctx, `UPDATE inodes SET mode = ? WHERE `+s.scope.And(`inode_id = ? AND status = 'CONFIRMED'`),
+		append([]any{mode}, s.scope.Args(inodeID)...)...)
 	if err != nil {
 		return err
 	}
@@ -1299,7 +1319,7 @@ func (s *Store) Chmod(ctx context.Context, path string, mode uint32) (err error)
 }
 
 func (s *Store) EnsureParentDirsTx(db execer, path string, genID func() string) error {
-	return ensureParentDirsWithExecer(context.Background(), db, path, genID)
+	return s.ensureParentDirsWithExecer(context.Background(), db, path, genID)
 }
 
 // deterministicNodeID returns a stable 64-char hex ID derived from the path.
@@ -1317,7 +1337,7 @@ func deterministicNodeID(path string) string {
 // derived from the path so concurrent attempts to create the same missing
 // parent cannot leak orphan inodes, even on TiDB which does not support gap
 // locking for SELECT ... FOR UPDATE on non-existing rows.
-func ensureParentDirsWithExecer(ctx context.Context, db execer, path string, genID func() string) error {
+func (s *Store) ensureParentDirsWithExecer(ctx context.Context, db execer, path string, genID func() string) error {
 	var ancestors []string
 	cur := path
 	for {
@@ -1337,8 +1357,8 @@ func ensureParentDirsWithExecer(ctx context.Context, db execer, path string, gen
 		// Check if the directory already exists and has an inode_id.
 		var existingInodeID sql.NullString
 		selectErr := db.QueryRowContext(ctx,
-			`SELECT inode_id FROM file_nodes WHERE path_hash = ? AND path = ? AND is_directory = 1`,
-			fileNodePathHash(dirPath), dirPath).Scan(&existingInodeID)
+			`SELECT inode_id FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ? AND is_directory = 1`),
+			s.scope.Args(fileNodePathHash(dirPath), dirPath)...).Scan(&existingInodeID)
 		if selectErr == nil && existingInodeID.Valid {
 			// Already exists and has an inode_id — nothing to do.
 			continue
@@ -1353,9 +1373,9 @@ func ensureParentDirsWithExecer(ctx context.Context, db execer, path string, gen
 		// as well as MySQL because it does not rely on gap locking.
 		nodeID := deterministicNodeID(dirPath)
 		_, err := db.ExecContext(ctx, `INSERT IGNORE INTO inodes
-			(inode_id, size_bytes, revision, mode, status, created_at, mtime)
-			VALUES (?, 0, 1, ?, 'CONFIRMED', ?, ?)`,
-			nodeID, 0o755, now, now)
+			(`+s.scope.InsCols(`inode_id, size_bytes, revision, mode, status, created_at, mtime`)+`)
+			VALUES (`+s.scope.InsVals(`?, 0, 1, ?, 'CONFIRMED', ?, ?`)+`)`,
+			s.scope.Args(nodeID, 0o755, now, now)...)
 		if err != nil {
 			return fmt.Errorf("ensure parent inode %s: %w", dirPath, err)
 		}
@@ -1364,8 +1384,8 @@ func ensureParentDirsWithExecer(ctx context.Context, db execer, path string, gen
 			// Directory row exists from pre-migration (inode_id was NULL).
 			// Backfill the inode_id.
 			_, err = db.ExecContext(ctx,
-				`UPDATE file_nodes SET inode_id = ? WHERE path_hash = ? AND path = ? AND is_directory = 1`,
-				nodeID, fileNodePathHash(dirPath), dirPath)
+				`UPDATE file_nodes SET inode_id = ? WHERE `+s.scope.And(`path_hash = ? AND path = ? AND is_directory = 1`),
+				append([]any{nodeID}, s.scope.Args(fileNodePathHash(dirPath), dirPath)...)...)
 			if err != nil {
 				return fmt.Errorf("backfill parent inode_id %s: %w", dirPath, err)
 			}
@@ -1374,10 +1394,10 @@ func ensureParentDirsWithExecer(ctx context.Context, db execer, path string, gen
 
 		// Directory does not exist — insert the dentry.
 		_, err = db.ExecContext(ctx, `INSERT INTO file_nodes
-			(node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, inode_id, created_at)
-			VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?)
+			(`+s.scope.InsCols(`node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, inode_id, created_at`)+`)
+			VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, 1, ?, ?`)+`)
 			ON DUPLICATE KEY UPDATE node_id = node_id`,
-			nodeID, dirPath, fileNodePathHash(dirPath), pp, fileNodePathHash(pp), name, nodeID, now)
+			s.scope.Args(nodeID, dirPath, fileNodePathHash(dirPath), pp, fileNodePathHash(pp), name, nodeID, now)...)
 		if err != nil && !isUniqueViolation(err) {
 			return fmt.Errorf("ensure parent %s: %w", dirPath, err)
 		}
@@ -1394,10 +1414,10 @@ func (s *Store) InsertNodeTx(db execer, n *FileNode) error {
 			return err
 		}
 	}
-	_, err := db.Exec(`INSERT INTO file_nodes (node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, inode_id, created_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		n.NodeID, n.Path, fileNodePathHash(n.Path), n.ParentPath, fileNodePathHash(n.ParentPath),
-		n.Name, n.IsDirectory, nullStr(n.FileID), nullStr(n.InodeID), n.CreatedAt.UTC())
+	_, err := db.Exec(`INSERT INTO file_nodes (`+s.scope.InsCols(`node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, inode_id, created_at`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(n.NodeID, n.Path, fileNodePathHash(n.Path), n.ParentPath, fileNodePathHash(n.ParentPath),
+			n.Name, n.IsDirectory, nullStr(n.FileID), nullStr(n.InodeID), n.CreatedAt.UTC())...)
 	if isUniqueViolation(err) {
 		return ErrPathConflict
 	}
@@ -1417,7 +1437,7 @@ func (s *Store) lockConfirmedFileForAttachTx(db execer, fileID string) error {
 			return ErrNotFound
 		}
 	}
-	if err := db.QueryRow(`SELECT status FROM inodes WHERE inode_id = ? FOR UPDATE`, fileID).Scan(&status); err != nil {
+	if err := db.QueryRow(`SELECT status FROM inodes WHERE `+s.scope.And(`inode_id = ?`)+` FOR UPDATE`, s.scope.Args(fileID)...).Scan(&status); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
 		}
@@ -1439,7 +1459,7 @@ func (s *Store) MarkFileDeleted(ctx context.Context, fileID string) (err error) 
 			return err
 		}
 	}
-	_, err = s.db.ExecContext(ctx, `UPDATE inodes SET status = 'DELETED' WHERE inode_id = ?`, fileID)
+	_, err = s.db.ExecContext(ctx, `UPDATE inodes SET status = 'DELETED' WHERE `+s.scope.And(`inode_id = ?`), s.scope.Args(fileID)...)
 	return err
 }
 
@@ -1447,7 +1467,7 @@ func (s *Store) MarkFileDeleted(ctx context.Context, fileID string) (err error) 
 // entities in the current tenant database.
 func (s *Store) ConfirmedStorageBytesTx(db execer) (int64, error) {
 	var total sql.NullInt64
-	if err := db.QueryRow(`SELECT COALESCE(SUM(size_bytes), 0) FROM inodes WHERE status = 'CONFIRMED'`).Scan(&total); err != nil {
+	if err := db.QueryRow(`SELECT COALESCE(SUM(size_bytes), 0) FROM inodes WHERE `+s.scope.And(`status = 'CONFIRMED'`), s.scope.Args()...).Scan(&total); err != nil {
 		return 0, err
 	}
 	return total.Int64, nil
@@ -1460,7 +1480,7 @@ func (s *Store) ConfirmedStorageBytesTx(db execer) (int64, error) {
 // are not enqueued.
 func (s *Store) ConfirmedMediaFileCountTx(db execer) (int64, error) {
 	var count sql.NullInt64
-	if err := db.QueryRow(`SELECT COUNT(*) FROM inodes i JOIN contents c ON i.inode_id = c.inode_id WHERE i.status = 'CONFIRMED' AND (c.content_type LIKE 'image/%' OR c.content_type LIKE 'audio/%')`).Scan(&count); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM inodes i JOIN contents c ON i.inode_id = c.inode_id WHERE `+s.scope.AndAs("i", `i.status = 'CONFIRMED' AND (c.content_type LIKE 'image/%' OR c.content_type LIKE 'audio/%')`), s.scope.Args()...).Scan(&count); err != nil {
 		return 0, err
 	}
 	return count.Int64, nil
@@ -1473,6 +1493,11 @@ func (s *Store) ActiveUploadReservedBytesTx(db execer) (int64, error) {
 	// TODO: This aggregation joins uploads -> file_nodes -> files on every quota
 	// check. If upload concurrency grows, re-evaluate the access path and add a
 	// more targeted uploads status/index strategy or a pre-aggregated quota state.
+	//
+	// In shared shape the fs_id predicate on the uploads driving alias is not
+	// enough: target paths are not globally unique, so the file_nodes join must
+	// also carry fs_id in its ON clause or one tenant's upload could join
+	// another tenant's dentry at the same path and misread its size.
 	err := db.QueryRow(`SELECT COALESCE(SUM(
 		CASE
 			WHEN u.total_size > COALESCE(i.size_bytes, 0) THEN u.total_size - COALESCE(i.size_bytes, 0)
@@ -1480,9 +1505,10 @@ func (s *Store) ActiveUploadReservedBytesTx(db execer) (int64, error) {
 		END
 	), 0)
 		FROM uploads u
-		LEFT JOIN file_nodes fn ON fn.path_hash = u.target_path_hash AND fn.path = u.target_path
+		LEFT JOIN file_nodes fn ON `+s.scope.AndAs("fn", `fn.path_hash = u.target_path_hash AND fn.path = u.target_path`)+`
 		LEFT JOIN inodes i ON i.inode_id = COALESCE(fn.inode_id, fn.file_id) AND i.status = 'CONFIRMED'
-		WHERE u.status IN ('INITIATED', 'UPLOADING') AND u.expires_at > ?`, time.Now().UTC()).Scan(&total)
+		WHERE `+s.scope.AndAs("u", `u.status IN ('INITIATED', 'UPLOADING') AND u.expires_at > ?`),
+		append(s.scope.Args(), s.scope.Args(time.Now().UTC())...)...).Scan(&total)
 	if err != nil {
 		return 0, err
 	}
@@ -1496,8 +1522,8 @@ func (s *Store) ConfirmedFileSizeByPathTx(db execer, path string) (int64, error)
 	err := db.QueryRow(`SELECT i.size_bytes
 		FROM file_nodes fn
 		JOIN inodes i ON i.inode_id = COALESCE(fn.inode_id, fn.file_id)
-		WHERE fn.path_hash = ? AND fn.path = ? AND fn.is_directory = 0 AND i.status = 'CONFIRMED'
-		LIMIT 1`, fileNodePathHash(path), path).Scan(&size)
+		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ? AND fn.is_directory = 0 AND i.status = 'CONFIRMED'`)+`
+		LIMIT 1`, s.scope.Args(fileNodePathHash(path), path)...).Scan(&size)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
 	}
@@ -1527,14 +1553,14 @@ func (s *Store) ListConfirmedFileSummaries(ctx context.Context, cursor string, l
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT i.inode_id, i.size_bytes, COALESCE(c.content_type, '')
 			 FROM inodes i JOIN contents c ON i.inode_id = c.inode_id
-			 WHERE i.status = 'CONFIRMED'
-			 ORDER BY i.inode_id ASC LIMIT ?`, limit)
+			 WHERE `+s.scope.AndAs("i", `i.status = 'CONFIRMED'`)+`
+			 ORDER BY i.inode_id ASC LIMIT ?`, s.scope.Args(limit)...)
 	} else {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT i.inode_id, i.size_bytes, COALESCE(c.content_type, '')
 			 FROM inodes i JOIN contents c ON i.inode_id = c.inode_id
-			 WHERE i.status = 'CONFIRMED' AND i.inode_id > ?
-			 ORDER BY i.inode_id ASC LIMIT ?`, cursor, limit)
+			 WHERE `+s.scope.AndAs("i", `i.status = 'CONFIRMED' AND i.inode_id > ?`)+`
+			 ORDER BY i.inode_id ASC LIMIT ?`, s.scope.Args(cursor, limit)...)
 	}
 	if err != nil {
 		return nil, "", fmt.Errorf("query confirmed files: %w", err)
@@ -1574,14 +1600,14 @@ func (s *Store) ListConfirmedS3Refs(ctx context.Context, cursor string, limit in
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT c.storage_ref, c.storage_ref_hash
 			 FROM contents c JOIN inodes i ON i.inode_id = c.inode_id
-			 WHERE i.status = 'CONFIRMED' AND c.storage_type = 's3' AND c.storage_ref <> ''
-			 ORDER BY c.storage_ref ASC LIMIT ?`, limit)
+			 WHERE `+s.scope.AndAs("i", `i.status = 'CONFIRMED' AND c.storage_type = 's3' AND c.storage_ref <> ''`)+`
+			 ORDER BY c.storage_ref ASC LIMIT ?`, s.scope.Args(limit)...)
 	} else {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT c.storage_ref, c.storage_ref_hash
 			 FROM contents c JOIN inodes i ON i.inode_id = c.inode_id
-			 WHERE i.status = 'CONFIRMED' AND c.storage_type = 's3' AND c.storage_ref <> '' AND c.storage_ref > ?
-			 ORDER BY c.storage_ref ASC LIMIT ?`, cursor, limit)
+			 WHERE `+s.scope.AndAs("i", `i.status = 'CONFIRMED' AND c.storage_type = 's3' AND c.storage_ref <> '' AND c.storage_ref > ?`)+`
+			 ORDER BY c.storage_ref ASC LIMIT ?`, s.scope.Args(cursor, limit)...)
 	}
 	if err != nil {
 		return nil, "", fmt.Errorf("query confirmed s3 refs: %w", err)
@@ -1613,8 +1639,8 @@ func (s *Store) HasActiveUploads(ctx context.Context) (bool, error) {
 	var one int
 	err := s.db.QueryRowContext(ctx,
 		`SELECT 1 FROM uploads
-		 WHERE status IN ('INITIATED', 'UPLOADING') AND expires_at > ?
-		 LIMIT 1`, time.Now().UTC()).Scan(&one)
+		 WHERE `+s.scope.And(`status IN ('INITIATED', 'UPLOADING') AND expires_at > ?`)+`
+		 LIMIT 1`, s.scope.Args(time.Now().UTC())...).Scan(&one)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
 	}
@@ -1626,14 +1652,14 @@ func (s *Store) HasActiveUploads(ctx context.Context) (bool, error) {
 
 func (s *Store) SanitizeForkRuntimeState(ctx context.Context) error {
 	return s.InTx(ctx, func(tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, `DELETE fn FROM file_nodes fn JOIN inodes i ON i.inode_id = COALESCE(fn.inode_id, fn.file_id) WHERE i.status <> 'CONFIRMED'`); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE fn FROM file_nodes fn JOIN inodes i ON i.inode_id = COALESCE(fn.inode_id, fn.file_id) WHERE `+s.scope.AndAs("i", `i.status <> 'CONFIRMED'`), s.scope.Args()...); err != nil {
 			return err
 		}
 		now := time.Now().UTC()
-		if _, err := tx.ExecContext(ctx, `UPDATE contents c JOIN inodes i ON i.inode_id = c.inode_id SET c.storage_ref = '', c.storage_ref_hash = '', c.content_blob = NULL WHERE i.status <> 'CONFIRMED'`); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE contents c JOIN inodes i ON i.inode_id = c.inode_id SET c.storage_ref = '', c.storage_ref_hash = '', c.content_blob = NULL WHERE `+s.scope.AndAs("i", `i.status <> 'CONFIRMED'`), s.scope.Args()...); err != nil {
 			return err
 		}
-		if _, err := tx.ExecContext(ctx, `UPDATE inodes SET status = 'DELETED', expires_at = ? WHERE status <> 'CONFIRMED'`, now); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE inodes SET status = 'DELETED', expires_at = ? WHERE `+s.scope.And(`status <> 'CONFIRMED'`), append([]any{now}, s.scope.Args()...)...); err != nil {
 			return err
 		}
 		if s.useLegacyFiles {
@@ -1641,20 +1667,30 @@ func (s *Store) SanitizeForkRuntimeState(ctx context.Context) error {
 				return err
 			}
 		}
-		for _, stmt := range []string{
-			`DELETE FROM uploads`,
-			`DELETE FROM file_gc_tasks`,
-			`DELETE FROM semantic_tasks`,
-			`DELETE FROM llm_usage`,
-			`DELETE FROM vault_audit_log`,
-			`DELETE FROM vault_grants`,
-			`DELETE FROM vault_tokens`,
-			`DELETE FROM vault_secret_fields`,
-			`DELETE FROM vault_secrets`,
-			`DELETE FROM vault_policies`,
-			`DELETE FROM vault_deks`,
+		// Whole-table wipes. In shared shape every one of these tables carries
+		// an fs_id column (vault tables included), so the DELETE must be
+		// restricted to this tenant's rows — unscoped it would destroy other
+		// tenants' runtime state.
+		for _, tbl := range []string{
+			"uploads",
+			"file_gc_tasks",
+			"semantic_tasks",
+			"llm_usage",
+			"vault_audit_log",
+			"vault_grants",
+			"vault_tokens",
+			"vault_secret_fields",
+			"vault_secrets",
+			"vault_policies",
+			"vault_deks",
 		} {
-			if _, err := tx.ExecContext(ctx, stmt); err != nil {
+			stmt := `DELETE FROM ` + tbl
+			args := []any(nil)
+			if s.scope.Shared() {
+				stmt += ` WHERE fs_id = ?`
+				args = s.scope.Args()
+			}
+			if _, err := tx.ExecContext(ctx, stmt, args...); err != nil {
 				if isMissingTableError(err) {
 					continue
 				}
@@ -1707,8 +1743,8 @@ func (s *Store) StatTx(ctx context.Context, db execer, path string) (out *NodeWi
 		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
 		LEFT JOIN contents c ON i.inode_id = c.inode_id
 		LEFT JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE fn.path_hash = ? AND fn.path = ?
-		LIMIT 1`, fileNodePathHash(path), path)
+		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ?`)+`
+		LIMIT 1`, s.scope.Args(fileNodePathHash(path), path)...)
 	return scanNodeWithFileWithBlob(row)
 }
 
@@ -1725,9 +1761,9 @@ func (s *Store) StatPathFallback(ctx context.Context, primaryPath, fallbackPath 
 		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
 		LEFT JOIN contents c ON i.inode_id = c.inode_id
 		LEFT JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE (fn.path_hash = ? AND fn.path = ?) OR (fn.path_hash = ? AND fn.path = ?)
+		WHERE `+s.andAsGrouped("fn", `(fn.path_hash = ? AND fn.path = ?) OR (fn.path_hash = ? AND fn.path = ?)`)+`
 		ORDER BY CASE WHEN fn.path = ? THEN 0 ELSE 1 END
-		LIMIT 1`, fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)
+		LIMIT 1`, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)
 	out, err = scanNodeWithFileWithBlob(row)
 	return out, err
 }
@@ -1743,9 +1779,9 @@ func (s *Store) StatPathFallbackLite(ctx context.Context, primaryPath, fallbackP
 		i.inode_id, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at
 		FROM file_nodes fn
 		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
-		WHERE (fn.path_hash = ? AND fn.path = ?) OR (fn.path_hash = ? AND fn.path = ?)
+		WHERE `+s.andAsGrouped("fn", `(fn.path_hash = ? AND fn.path = ?) OR (fn.path_hash = ? AND fn.path = ?)`)+`
 		ORDER BY CASE WHEN fn.path = ? THEN 0 ELSE 1 END
-		LIMIT 1`, fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)
+		LIMIT 1`, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)
 	out, err = scanNodeWithFileLite(row)
 	return out, err
 }
@@ -1759,8 +1795,8 @@ func (s *Store) StatLite(ctx context.Context, path string) (out *NodeWithFile, e
 		i.inode_id, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at
 		FROM file_nodes fn
 		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
-		WHERE fn.path_hash = ? AND fn.path = ?
-		LIMIT 1`, fileNodePathHash(path), path)
+		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ?`)+`
+		LIMIT 1`, s.scope.Args(fileNodePathHash(path), path)...)
 	out, err = scanNodeWithFileLite(row)
 	return out, err
 }
@@ -1778,8 +1814,8 @@ func (s *Store) StatForRead(ctx context.Context, path string) (out *NodeWithFile
 		FROM file_nodes fn
 		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
 		LEFT JOIN contents c ON i.inode_id = c.inode_id
-		WHERE fn.path_hash = ? AND fn.path = ?
-		LIMIT 1`, fileNodePathHash(path), path)
+		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ?`)+`
+		LIMIT 1`, s.scope.Args(fileNodePathHash(path), path)...)
 	out, err = scanNodeWithFileForRead(row)
 	return out, err
 }
@@ -1794,9 +1830,9 @@ func (s *Store) StatPathFallbackForRead(ctx context.Context, primaryPath, fallba
 		FROM file_nodes fn
 		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
 		LEFT JOIN contents c ON i.inode_id = c.inode_id
-		WHERE (fn.path_hash = ? AND fn.path = ?) OR (fn.path_hash = ? AND fn.path = ?)
+		WHERE `+s.andAsGrouped("fn", `(fn.path_hash = ? AND fn.path = ?) OR (fn.path_hash = ? AND fn.path = ?)`)+`
 		ORDER BY CASE WHEN fn.path = ? THEN 0 ELSE 1 END
-		LIMIT 1`, fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)
+		LIMIT 1`, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)
 	out, err = scanNodeWithFileForRead(row)
 	return out, err
 }
@@ -1813,9 +1849,9 @@ func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWith
 		FROM file_nodes fn
 		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
 		LEFT JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE fn.parent_path_hash = ? AND fn.parent_path = ?
+		WHERE ` + s.scope.AndAs("fn", `fn.parent_path_hash = ? AND fn.parent_path = ?`) + `
 		ORDER BY fn.name`
-	rows, err := s.db.QueryContext(ctx, q, fileNodePathHash(parentPath), parentPath)
+	rows, err := s.db.QueryContext(ctx, q, s.scope.Args(fileNodePathHash(parentPath), parentPath)...)
 	if err != nil {
 		return nil, err
 	}
@@ -1896,7 +1932,8 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 		return nil, ErrNotFound
 	}
 
-	if _, err := tx.Exec(`DELETE FROM file_nodes WHERE path_hash = ? AND path = ?`, fileNodePathHash(path), path); err != nil {
+	if _, err := tx.Exec(`DELETE FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ?`),
+		s.scope.Args(fileNodePathHash(path), path)...); err != nil {
 		return nil, err
 	}
 
@@ -1908,7 +1945,7 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 	}
 
 	var count int64
-	err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM file_nodes WHERE file_id = ? FOR UPDATE`, candidate.fileID).Scan(&count)
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM file_nodes WHERE `+s.scope.And(`file_id = ?`)+` FOR UPDATE`, s.scope.Args(candidate.fileID)...).Scan(&count)
 	if err != nil {
 		return nil, err
 	}
@@ -1924,7 +1961,7 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 	if err := s.markFilesDeletedTx(ctx, tx, []string{candidate.fileID}); err != nil {
 		return nil, err
 	}
-	if err := deleteFileTagsByIDsTx(ctx, tx, []string{candidate.fileID}); err != nil {
+	if err := s.deleteFileTagsByIDsTx(ctx, tx, []string{candidate.fileID}); err != nil {
 		return nil, err
 	}
 
@@ -1955,7 +1992,7 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 	defer func() { _ = tx.Rollback() }()
 
 	rows, err := tx.QueryContext(ctx, `SELECT DISTINCT file_id FROM file_nodes
-		WHERE (path = ? OR path LIKE ?) AND file_id IS NOT NULL`, dirPath, dirPath+"%")
+		WHERE `+s.scope.And(`(path = ? OR path LIKE ?) AND file_id IS NOT NULL`), s.scope.Args(dirPath, dirPath+"%")...)
 	if err != nil {
 		return nil, err
 	}
@@ -1974,8 +2011,8 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 		return nil, err
 	}
 
-	if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE path = ? OR path LIKE ?`,
-		dirPath, dirPath+"%"); err != nil {
+	if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+s.andAsGrouped("", `path = ? OR path LIKE ?`),
+		s.scope.Args(dirPath, dirPath+"%")...); err != nil {
 		return nil, err
 	}
 
@@ -1990,7 +2027,7 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 	if err := s.markFilesDeletedTx(ctx, tx, orphanIDs); err != nil {
 		return nil, err
 	}
-	if err := deleteFileTagsByIDsTx(ctx, tx, orphanIDs); err != nil {
+	if err := s.deleteFileTagsByIDsTx(ctx, tx, orphanIDs); err != nil {
 		return nil, err
 	}
 
@@ -2038,8 +2075,8 @@ func (s *Store) scanDeleteCandidateTx(ctx context.Context, tx *sql.Tx, path stri
 		LEFT JOIN inodes i ON i.inode_id = fn.file_id
 		LEFT JOIN contents c ON c.inode_id = fn.file_id
 		LEFT JOIN semantic s ON s.inode_id = fn.file_id
-		WHERE fn.path_hash = ? AND fn.path = ?
-		FOR UPDATE`, fileNodePathHash(path), path)
+		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ?`)+`
+		FOR UPDATE`, s.scope.Args(fileNodePathHash(path), path)...)
 	return scanSplitDeleteCandidate(row)
 }
 
@@ -2127,8 +2164,9 @@ func (s *Store) scanOrphanedFilesByIDTx(ctx context.Context, tx *sql.Tx, fileIDs
 				FROM inodes i
 				JOIN contents c ON c.inode_id = i.inode_id
 				LEFT JOIN semantic s ON s.inode_id = i.inode_id
-				WHERE i.inode_id IN (` + placeholders + `)
-				  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE fn.file_id = i.inode_id)`
+				WHERE ` + s.scope.AndAs("i", `i.inode_id IN (`+placeholders+`)
+				  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE fn.file_id = i.inode_id)`)
+			args = s.scope.Args(args...)
 		}
 		rows, err := tx.QueryContext(ctx, query, args...)
 		if err != nil {
@@ -2205,7 +2243,7 @@ func (s *Store) lockFileIDsForDeleteTx(ctx context.Context, tx *sql.Tx, fileIDs 
 				return err
 			}
 		}
-		rows, err := tx.QueryContext(ctx, `SELECT inode_id FROM inodes WHERE inode_id IN (`+placeholders+`) FOR UPDATE`, args...)
+		rows, err := tx.QueryContext(ctx, `SELECT inode_id FROM inodes WHERE `+s.scope.And(`inode_id IN (`+placeholders+`)`)+` FOR UPDATE`, s.scope.Args(args...)...)
 		if err != nil {
 			return err
 		}
@@ -2248,7 +2286,7 @@ func (s *Store) markFilesDeletedTx(ctx context.Context, tx *sql.Tx, fileIDs []st
 				return err
 			}
 		}
-		if _, err := tx.ExecContext(ctx, `UPDATE inodes SET status = 'DELETED' WHERE inode_id IN (`+placeholders+`)`, args...); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE inodes SET status = 'DELETED' WHERE `+s.scope.And(`inode_id IN (`+placeholders+`)`), s.scope.Args(args...)...); err != nil {
 			return err
 		}
 	}
@@ -2287,7 +2325,7 @@ func fileFromLegacyGCScan(fileID string, storageType, storageRef, encMode, encKe
 	return f
 }
 
-func deleteFileTagsByIDsTx(ctx context.Context, tx *sql.Tx, fileIDs []string) error {
+func (s *Store) deleteFileTagsByIDsTx(ctx context.Context, tx *sql.Tx, fileIDs []string) error {
 	for start := 0; start < len(fileIDs); start += deleteFileIDBatchSize {
 		end := start + deleteFileIDBatchSize
 		if end > len(fileIDs) {
@@ -2297,7 +2335,8 @@ func deleteFileTagsByIDsTx(ctx context.Context, tx *sql.Tx, fileIDs []string) er
 		if len(batch) == 0 {
 			continue
 		}
-		_, err := tx.ExecContext(ctx, `DELETE FROM file_tags WHERE file_id IN (`+questionPlaceholders(len(batch))+`)`, stringsToAny(batch)...)
+		_, err := tx.ExecContext(ctx, `DELETE FROM file_tags WHERE `+s.scope.And(`file_id IN (`+questionPlaceholders(len(batch))+`)`),
+			s.scope.Args(stringsToAny(batch)...)...)
 		if err != nil {
 			return err
 		}
@@ -2313,9 +2352,10 @@ func stringsToAny(values []string) []any {
 	return args
 }
 
-func dirHasChildrenTx(ctx context.Context, tx *sql.Tx, path string) (bool, error) {
+func (s *Store) dirHasChildrenTx(ctx context.Context, tx *sql.Tx, path string) (bool, error) {
 	var one int
-	err := tx.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE parent_path_hash = ? AND parent_path = ? LIMIT 1 FOR UPDATE`, fileNodePathHash(path), path).Scan(&one)
+	err := tx.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE `+s.scope.And(`parent_path_hash = ? AND parent_path = ?`)+` LIMIT 1 FOR UPDATE`,
+		s.scope.Args(fileNodePathHash(path), path)...).Scan(&one)
 	if err == nil {
 		return true, nil
 	}
@@ -2327,6 +2367,21 @@ func dirHasChildrenTx(ctx context.Context, tx *sql.Tx, path string) (bool, error
 
 func pathPrefixPredicate(column, prefix string) (string, []any) {
 	return "BINARY " + column + " LIKE BINARY ? ESCAPE '\\\\'", []any{likeLiteralPrefixPattern(prefix)}
+}
+
+// andAsGrouped prefixes pred with the scope's fs_id predicate for WHERE
+// clauses whose top-level OR would otherwise escape the fs_id conjunct:
+// shared shape wraps pred in parentheses before applying And/AndAs. alias may
+// be empty for unqualified predicates. Standalone shape returns pred
+// byte-identical.
+func (s *Store) andAsGrouped(alias, pred string) string {
+	if !s.scope.Shared() {
+		return pred
+	}
+	if alias == "" {
+		return s.scope.And("(" + pred + ")")
+	}
+	return s.scope.AndAs(alias, "("+pred+")")
 }
 
 // --- uploads operations ---
@@ -2342,15 +2397,15 @@ func (s *Store) InsertUpload(ctx context.Context, u *Upload) (err error) {
 func (s *Store) InsertUploadTx(db execer, u *Upload) error {
 	mode := uploadStorageEncryptionModeForWrite(u.StorageEncryptionMode)
 	_, err := db.Exec(`INSERT INTO uploads
-		(upload_id, file_id, target_path, target_path_hash, s3_upload_id, s3_key, storage_encryption_mode,
+		(`+s.scope.InsCols(`upload_id, file_id, target_path, target_path_hash, s3_upload_id, s3_key, storage_encryption_mode,
 		 storage_encryption_key_id, total_size, part_size,
-		 parts_total, expected_revision, status, fingerprint_sha256, idempotency_key, description, created_at, updated_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		u.UploadID, u.FileID, u.TargetPath, fileNodePathHash(u.TargetPath), u.S3UploadID, u.S3Key,
-		mode, storageEncryptionKeyIDForWrite(mode, u.StorageEncryptionKeyID),
-		u.TotalSize, u.PartSize, u.PartsTotal, nullInt64Ptr(u.ExpectedRevision), u.Status,
-		nullStr(u.FingerprintSHA), nullStr(u.IdempotencyKey), nullStr(u.Description),
-		u.CreatedAt.UTC(), u.UpdatedAt.UTC(), u.ExpiresAt.UTC())
+		 parts_total, expected_revision, status, fingerprint_sha256, idempotency_key, description, created_at, updated_at, expires_at`)+`)
+		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`,
+		s.scope.Args(u.UploadID, u.FileID, u.TargetPath, fileNodePathHash(u.TargetPath), u.S3UploadID, u.S3Key,
+			mode, storageEncryptionKeyIDForWrite(mode, u.StorageEncryptionKeyID),
+			u.TotalSize, u.PartSize, u.PartsTotal, nullInt64Ptr(u.ExpectedRevision), u.Status,
+			nullStr(u.FingerprintSHA), nullStr(u.IdempotencyKey), nullStr(u.Description),
+			u.CreatedAt.UTC(), u.UpdatedAt.UTC(), u.ExpiresAt.UTC())...)
 	if isUniqueViolation(err) {
 		// Distinguish constraint: idx_idempotency (duplicate key) vs idx_uploads_active (concurrent path).
 		// MySQL embeds the constraint name in the error message; no structured alternative exists.
@@ -2373,7 +2428,7 @@ func (s *Store) GetUpload(ctx context.Context, uploadID string) (out *Upload, er
 		storage_encryption_mode, storage_encryption_key_id,
 		total_size, part_size, parts_total, expected_revision, status, fingerprint_sha256, idempotency_key,
 		description, created_at, updated_at, expires_at
-		FROM uploads WHERE upload_id = ?`, uploadID)
+		FROM uploads WHERE `+s.scope.And(`upload_id = ?`), s.scope.Args(uploadID)...)
 	queryContextDurationMs := datastorePhaseMs(queryStart)
 	if err != nil {
 		opErr = err
@@ -2462,8 +2517,8 @@ func (s *Store) GetUploadByPath(ctx context.Context, targetPath string) (out *Up
 		storage_encryption_mode, storage_encryption_key_id,
 		total_size, part_size, parts_total, expected_revision, status, fingerprint_sha256, idempotency_key,
 		description, created_at, updated_at, expires_at
-		FROM uploads WHERE target_path_hash = ? AND target_path = ? AND status IN ('INITIATED', 'UPLOADING') AND expires_at > ?
-		ORDER BY created_at DESC LIMIT 1`, fileNodePathHash(targetPath), targetPath, time.Now().UTC())
+		FROM uploads WHERE `+s.scope.And(`target_path_hash = ? AND target_path = ? AND status IN ('INITIATED', 'UPLOADING') AND expires_at > ?`)+`
+		ORDER BY created_at DESC LIMIT 1`, s.scope.Args(fileNodePathHash(targetPath), targetPath, time.Now().UTC())...)
 	out, err = scanUpload(row)
 	return out, err
 }
@@ -2474,7 +2529,8 @@ func (s *Store) CompleteUpload(ctx context.Context, uploadID string) (err error)
 
 	_, err = s.db.ExecContext(ctx, `UPDATE uploads SET status = 'COMPLETED',
 		updated_at = ?
-		WHERE upload_id = ? AND status = 'UPLOADING'`, time.Now().UTC(), uploadID)
+		WHERE `+s.scope.And(`upload_id = ? AND status = 'UPLOADING'`),
+		append([]any{time.Now().UTC()}, s.scope.Args(uploadID)...)...)
 	return err
 }
 
@@ -2484,7 +2540,8 @@ func (s *Store) AbortUpload(ctx context.Context, uploadID string) (err error) {
 
 	_, err = s.db.ExecContext(ctx, `UPDATE uploads SET status = 'ABORTED',
 		updated_at = ?
-		WHERE upload_id = ? AND status = 'UPLOADING'`, time.Now().UTC(), uploadID)
+		WHERE `+s.scope.And(`upload_id = ? AND status = 'UPLOADING'`),
+		append([]any{time.Now().UTC()}, s.scope.Args(uploadID)...)...)
 	return err
 }
 
@@ -2497,7 +2554,8 @@ func (s *Store) AbortUploadV2(ctx context.Context, uploadID string) (aborted boo
 
 	res, err := s.db.ExecContext(ctx, `UPDATE uploads SET status = 'ABORTED',
 		updated_at = ?
-		WHERE upload_id = ? AND status IN ('INITIATED', 'UPLOADING')`, time.Now().UTC(), uploadID)
+		WHERE `+s.scope.And(`upload_id = ? AND status IN ('INITIATED', 'UPLOADING')`),
+		append([]any{time.Now().UTC()}, s.scope.Args(uploadID)...)...)
 	if err != nil {
 		return false, err
 	}
@@ -2515,7 +2573,8 @@ func (s *Store) UpdateUploadStatus(ctx context.Context, uploadID string, status 
 
 	_, err = s.db.ExecContext(ctx, `UPDATE uploads SET status = ?,
 		updated_at = ?
-		WHERE upload_id = ?`, string(status), time.Now().UTC(), uploadID)
+		WHERE `+s.scope.And(`upload_id = ?`),
+		append([]any{string(status), time.Now().UTC()}, s.scope.Args(uploadID)...)...)
 	return err
 }
 
@@ -2527,7 +2586,8 @@ func (s *Store) TransitionUploadStatus(ctx context.Context, uploadID string, exp
 
 	res, err := s.db.ExecContext(ctx, `UPDATE uploads SET status = ?,
 		updated_at = ?
-		WHERE upload_id = ? AND status = ?`, string(newStatus), time.Now().UTC(), uploadID, string(expectedStatus))
+		WHERE `+s.scope.And(`upload_id = ? AND status = ?`),
+		append([]any{string(newStatus), time.Now().UTC()}, s.scope.Args(uploadID, string(expectedStatus))...)...)
 	if err != nil {
 		return err
 	}
@@ -2549,8 +2609,8 @@ func (s *Store) ListUploadsByPath(ctx context.Context, targetPath string, status
 		storage_encryption_mode, storage_encryption_key_id,
 		total_size, part_size, parts_total, expected_revision, status, fingerprint_sha256, idempotency_key,
 		description, created_at, updated_at, expires_at
-		FROM uploads WHERE target_path_hash = ? AND target_path = ? AND status = ?
-		ORDER BY created_at DESC`, fileNodePathHash(targetPath), targetPath, status)
+		FROM uploads WHERE `+s.scope.And(`target_path_hash = ? AND target_path = ? AND status = ?`)+`
+		ORDER BY created_at DESC`, s.scope.Args(fileNodePathHash(targetPath), targetPath, status)...)
 	if err != nil {
 		return nil, err
 	}
@@ -2680,7 +2740,7 @@ func (s *Store) scanFileForGCTx(db execer, fileID string) (*File, error) {
 		FROM inodes i
 		JOIN contents c ON i.inode_id = c.inode_id
 		LEFT JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE i.inode_id = ?`, fileID).Scan(
+		WHERE `+s.scope.AndAs("i", `i.inode_id = ?`), s.scope.Args(fileID)...).Scan(
 		&f.StorageType, &f.StorageRef, &f.SizeBytes, &contentType, &embRev)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -3004,12 +3064,6 @@ func isDeadlock(err error) bool {
 	return strings.Contains(msg, "Deadlock found") || strings.Contains(msg, "deadlock")
 }
 
-var wsNorm = regexp.MustCompile(`\s+`)
-
-func normalizeSQL(s string) string {
-	return wsNorm.ReplaceAllString(strings.TrimSpace(s), " ")
-}
-
 func datastorePhaseMs(start time.Time) float64 {
 	return float64(time.Since(start).Microseconds()) / 1000.0
 }
@@ -3066,129 +3120,4 @@ func shouldLogStoreOpFailure(result string) bool {
 	default:
 		return true
 	}
-}
-
-func (s *Store) ExecSQL(ctx context.Context, query string) (out []map[string]interface{}, err error) {
-	start := time.Now()
-	defer func() {
-		result := "ok"
-		if err != nil {
-			result = "error"
-		}
-		metrics.RecordOperation("datastore", "exec_sql", result, time.Since(start))
-	}()
-
-	q := strings.TrimSpace(query)
-	norm := strings.ToUpper(normalizeSQL(q))
-
-	isSelect := strings.HasPrefix(norm, "SELECT")
-	if strings.HasPrefix(norm, "WITH") {
-		hasDML := strings.Contains(norm, "INSERT") ||
-			strings.Contains(norm, "UPDATE") ||
-			strings.Contains(norm, "DELETE") ||
-			strings.Contains(norm, "DROP") ||
-			strings.Contains(norm, "ALTER") ||
-			strings.Contains(norm, "TRUNCATE")
-		if !hasDML {
-			isSelect = true
-		}
-	}
-	isTagWrite := strings.HasPrefix(norm, "INSERT INTO FILE_TAGS") ||
-		strings.HasPrefix(norm, "UPDATE FILE_TAGS") ||
-		strings.HasPrefix(norm, "DELETE FROM FILE_TAGS")
-
-	if isTagWrite {
-		if strings.HasPrefix(norm, "UPDATE") || strings.HasPrefix(norm, "DELETE") {
-			if strings.Contains(norm, " JOIN ") || strings.Contains(norm, " USING ") {
-				return nil, fmt.Errorf("multi-table DML not allowed; single-table statements on file_tags only")
-			}
-			if strings.HasPrefix(norm, "UPDATE") {
-				setIdx := strings.Index(norm, " SET ")
-				if setIdx > 0 && strings.Contains(norm[:setIdx], ",") {
-					return nil, fmt.Errorf("multi-table DML not allowed; single-table statements on file_tags only")
-				}
-			}
-			if strings.HasPrefix(norm, "DELETE") {
-				fromIdx := strings.Index(norm, " FROM ")
-				if fromIdx > 0 {
-					rest := norm[fromIdx+6:]
-					endIdx := strings.IndexAny(rest, " ;")
-					if endIdx < 0 {
-						endIdx = len(rest)
-					}
-					tablePart := rest[:endIdx]
-					if strings.Contains(tablePart, ",") {
-						return nil, fmt.Errorf("multi-table DML not allowed; single-table statements on file_tags only")
-					}
-				}
-			}
-		}
-	}
-
-	if !isSelect && !isTagWrite {
-		err = fmt.Errorf("only SELECT queries and INSERT/UPDATE/DELETE on file_tags are allowed")
-		logger.Warn(ctx, "datastore_exec_sql_rejected", zap.Int("query_len", len(q)), zap.Error(err))
-		return nil, err
-	}
-	if s == nil || s.db == nil {
-		err = fmt.Errorf("database is closed")
-		logger.Error(ctx, "datastore_exec_sql_closed", zap.Error(err))
-		return nil, err
-	}
-
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	if isTagWrite {
-		res, err := s.db.ExecContext(ctx, q)
-		if err != nil {
-			logger.Error(ctx, "datastore_exec_sql_tag_write_failed", zap.Int("query_len", len(q)), zap.Error(err))
-			return nil, err
-		}
-		affected, _ := res.RowsAffected()
-		return []map[string]interface{}{{"rows_affected": affected}}, nil
-	}
-
-	rows, err := s.db.QueryContext(ctx, q)
-	if err != nil {
-		logger.Error(ctx, "datastore_exec_sql_query_failed", zap.Int("query_len", len(q)), zap.Error(err))
-		return nil, err
-	}
-	defer func() { _ = rows.Close() }()
-
-	cols, err := rows.Columns()
-	if err != nil {
-		return nil, err
-	}
-
-	const maxRows = 1000
-	result := make([]map[string]interface{}, 0)
-	for rows.Next() {
-		if len(result) >= maxRows {
-			break
-		}
-		vals := make([]interface{}, len(cols))
-		ptrs := make([]interface{}, len(cols))
-		for i := range vals {
-			ptrs[i] = &vals[i]
-		}
-		if err := rows.Scan(ptrs...); err != nil {
-			return nil, err
-		}
-		row := make(map[string]interface{}, len(cols))
-		for i, col := range cols {
-			v := vals[i]
-			if b, ok := v.([]byte); ok {
-				row[col] = string(b)
-			} else {
-				row[col] = v
-			}
-		}
-		result = append(result, row)
-	}
-	if err := rows.Err(); err != nil {
-		logger.Error(ctx, "datastore_exec_sql_scan_failed", zap.Int("query_len", len(q)), zap.Error(err))
-		return nil, err
-	}
-	return result, nil
 }

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1670,12 +1670,15 @@ func (s *Store) SanitizeForkRuntimeState(ctx context.Context) error {
 		// Whole-table wipes. In shared shape every one of these tables carries
 		// an fs_id column (vault tables included), so the DELETE must be
 		// restricted to this tenant's rows — unscoped it would destroy other
-		// tenants' runtime state.
-		for _, tbl := range []string{
-			"uploads",
-			"file_gc_tasks",
-			"semantic_tasks",
-			"llm_usage",
+		// tenants' runtime state. llm_usage is standalone-only (the central
+		// meta DB ledger is authoritative in shared deployments) and is wiped
+		// only there; a leftover standalone llm_usage table on a shared DB has
+		// no fs_id column to restrict by, so it must not be touched.
+		wipeTables := []string{"uploads", "file_gc_tasks", "semantic_tasks"}
+		if !s.scope.Shared() {
+			wipeTables = append(wipeTables, "llm_usage")
+		}
+		wipeTables = append(wipeTables,
 			"vault_audit_log",
 			"vault_grants",
 			"vault_tokens",
@@ -1683,7 +1686,8 @@ func (s *Store) SanitizeForkRuntimeState(ctx context.Context) error {
 			"vault_secrets",
 			"vault_policies",
 			"vault_deks",
-		} {
+		)
+		for _, tbl := range wipeTables {
 			stmt := `DELETE FROM ` + tbl
 			args := []any(nil)
 			if s.scope.Shared() {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -151,6 +151,9 @@ type Store struct {
 	db             *sql.DB
 	useLegacyFiles bool // true when the legacy `files` table exists and needs dual-write
 	scope          Scope
+	// externalDB marks a Store wrapping a handle owned by someone else (a
+	// shared-pool *sql.DB serving many tenants); Close must not close it.
+	externalDB bool
 }
 
 func Open(dsn string) (*Store, error) {
@@ -187,7 +190,12 @@ func OpenForTenantScoped(ctx context.Context, dsn, tenantID, tidbCloudOrgID stri
 	return s, nil
 }
 
-func (s *Store) Close() error { return mysqlutil.CloseInstrumented(s.db) }
+func (s *Store) Close() error {
+	if s.externalDB {
+		return nil
+	}
+	return mysqlutil.CloseInstrumented(s.db)
+}
 func (s *Store) DB() *sql.DB  { return s.db }
 
 // Scope returns the schema-shape scope fixed at construction.

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -198,6 +198,14 @@ func (s *Store) Close() error {
 }
 func (s *Store) DB() *sql.DB  { return s.db }
 
+// NewStoreWithDB wraps an externally owned *sql.DB (e.g. a shared-pool handle
+// serving many tenants) with the given scope. Close is a no-op — the owner
+// controls the handle's lifetime. No legacy-files detection runs: shared
+// schema databases never carry the legacy files table.
+func NewStoreWithDB(db *sql.DB, scope Scope) *Store {
+	return &Store{db: db, scope: scope, externalDB: true}
+}
+
 // Scope returns the schema-shape scope fixed at construction.
 func (s *Store) Scope() Scope { return s.scope }
 
@@ -994,8 +1002,8 @@ func (s *Store) HasConfirmedS3StorageRef(ctx context.Context, storageRefHash, st
 	}
 	row := s.db.QueryRowContext(ctx, `SELECT 1
 		FROM contents c JOIN inodes i ON i.inode_id = c.inode_id
-		WHERE `+s.scope.AndAs("c", `c.storage_type = ? AND i.status = ? AND c.storage_ref_hash = ? AND c.storage_ref = ?`)+`
-		LIMIT 1`, s.scope.Args(StorageS3, StatusConfirmed, storageRefHash, storageRef)...)
+		WHERE `+scopeWhereAnd(s.scope, `c.storage_type = ? AND i.status = ? AND c.storage_ref_hash = ? AND c.storage_ref = ?`, "c", "i")+`
+		LIMIT 1`, scopeWhereArgs(s.scope, 2, StorageS3, StatusConfirmed, storageRefHash, storageRef)...)
 	var one int
 	if err := row.Scan(&one); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1118,15 +1126,15 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 		}
 		if expectedRevision > 0 {
 			if _, err := db.Exec(`UPDATE semantic SET content_text = ?
-				WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`),
-				append([]any{nullStr(contentText)}, s.scope.Args(fileID, fileID, expectedRevision)...)...); err != nil {
+				WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND status = 'CONFIRMED' AND revision = ?`)+`)`),
+				append([]any{nullStr(contentText)}, append(s.scope.Args(fileID), s.scope.Args(fileID, expectedRevision)...)...)...); err != nil {
 				return nil, fmt.Errorf("update semantic content_text: %w", err)
 			}
 			return res, nil
 		}
 		if _, err := db.Exec(`UPDATE semantic SET content_text = ?
-			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED')`),
-			append([]any{nullStr(contentText)}, s.scope.Args(fileID, fileID)...)...); err != nil {
+			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND status = 'CONFIRMED'`)+`)`),
+			append([]any{nullStr(contentText)}, append(s.scope.Args(fileID), s.scope.Args(fileID)...)...)...); err != nil {
 			return nil, fmt.Errorf("update semantic content_text: %w", err)
 		}
 		return res, nil
@@ -1134,12 +1142,12 @@ func (s *Store) updateFileSearchTextExec(db execer, fileID string, expectedRevis
 	// New tenant without legacy files: write directly to semantic.
 	if expectedRevision > 0 {
 		return db.Exec(`UPDATE semantic SET content_text = ?
-			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED' AND revision = ?)`),
-			append([]any{nullStr(contentText)}, s.scope.Args(fileID, fileID, expectedRevision)...)...)
+			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND status = 'CONFIRMED' AND revision = ?`)+`)`),
+			append([]any{nullStr(contentText)}, append(s.scope.Args(fileID), s.scope.Args(fileID, expectedRevision)...)...)...)
 	}
 	return db.Exec(`UPDATE semantic SET content_text = ?
-		WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE inode_id = ? AND status = 'CONFIRMED')`),
-		append([]any{nullStr(contentText)}, s.scope.Args(fileID, fileID)...)...)
+		WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND status = 'CONFIRMED'`)+`)`),
+		append([]any{nullStr(contentText)}, append(s.scope.Args(fileID), s.scope.Args(fileID)...)...)...)
 }
 
 // ReplaceFileTagsTx replaces all tags for fileID inside an existing transaction.
@@ -1264,7 +1272,7 @@ func (s *Store) GetFileStorageMetaForUpdateTx(db execer, fileID string) (*FileSt
 	var contentType sql.NullString
 	err := db.QueryRow(`SELECT c.storage_type, c.storage_ref, i.revision, i.size_bytes, COALESCE(c.content_type, '')
 		FROM inodes i JOIN contents c ON i.inode_id = c.inode_id
-		WHERE `+s.scope.AndAs("i", `i.inode_id = ? AND i.status = 'CONFIRMED'`)+` FOR UPDATE`, s.scope.Args(fileID)...).Scan(
+		WHERE `+scopeWhereAnd(s.scope, `i.inode_id = ? AND i.status = 'CONFIRMED'`, "i", "c")+` FOR UPDATE`, scopeWhereArgs(s.scope, 2, fileID)...).Scan(
 		&m.StorageType, &m.StorageRef, &m.Revision, &m.SizeBytes, &contentType)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -1488,7 +1496,7 @@ func (s *Store) ConfirmedStorageBytesTx(db execer) (int64, error) {
 // are not enqueued.
 func (s *Store) ConfirmedMediaFileCountTx(db execer) (int64, error) {
 	var count sql.NullInt64
-	if err := db.QueryRow(`SELECT COUNT(*) FROM inodes i JOIN contents c ON i.inode_id = c.inode_id WHERE `+s.scope.AndAs("i", `i.status = 'CONFIRMED' AND (c.content_type LIKE 'image/%' OR c.content_type LIKE 'audio/%')`), s.scope.Args()...).Scan(&count); err != nil {
+	if err := db.QueryRow(`SELECT COUNT(*) FROM inodes i JOIN contents c ON i.inode_id = c.inode_id WHERE `+scopeWhereAnd(s.scope, `i.status = 'CONFIRMED' AND (c.content_type LIKE 'image/%' OR c.content_type LIKE 'audio/%')`, "i", "c"), scopeWhereArgs(s.scope, 2)...).Scan(&count); err != nil {
 		return 0, err
 	}
 	return count.Int64, nil
@@ -1505,7 +1513,10 @@ func (s *Store) ActiveUploadReservedBytesTx(db execer) (int64, error) {
 	// In shared shape the fs_id predicate on the uploads driving alias is not
 	// enough: target paths are not globally unique, so the file_nodes join must
 	// also carry fs_id in its ON clause or one tenant's upload could join
-	// another tenant's dentry at the same path and misread its size.
+	// another tenant's dentry at the same path and misread its size. The
+	// inodes join needs the same guard: inode ids are unique only within a
+	// tenant in shared shape, so an unscoped join could read another tenant's
+	// confirmed size and understate this tenant's reservation.
 	err := db.QueryRow(`SELECT COALESCE(SUM(
 		CASE
 			WHEN u.total_size > COALESCE(i.size_bytes, 0) THEN u.total_size - COALESCE(i.size_bytes, 0)
@@ -1514,9 +1525,9 @@ func (s *Store) ActiveUploadReservedBytesTx(db execer) (int64, error) {
 	), 0)
 		FROM uploads u
 		LEFT JOIN file_nodes fn ON `+s.scope.AndAs("fn", `fn.path_hash = u.target_path_hash AND fn.path = u.target_path`)+`
-		LEFT JOIN inodes i ON i.inode_id = COALESCE(fn.inode_id, fn.file_id) AND i.status = 'CONFIRMED'
+		LEFT JOIN inodes i ON `+s.scope.AndOn(`i.inode_id = COALESCE(fn.inode_id, fn.file_id) AND i.status = 'CONFIRMED'`, "i")+`
 		WHERE `+s.scope.AndAs("u", `u.status IN ('INITIATED', 'UPLOADING') AND u.expires_at > ?`),
-		append(s.scope.Args(), s.scope.Args(time.Now().UTC())...)...).Scan(&total)
+		append(append(s.scope.Args(), s.scope.Args()...), s.scope.Args(time.Now().UTC())...)...).Scan(&total)
 	if err != nil {
 		return 0, err
 	}
@@ -1530,8 +1541,8 @@ func (s *Store) ConfirmedFileSizeByPathTx(db execer, path string) (int64, error)
 	err := db.QueryRow(`SELECT i.size_bytes
 		FROM file_nodes fn
 		JOIN inodes i ON i.inode_id = COALESCE(fn.inode_id, fn.file_id)
-		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ? AND fn.is_directory = 0 AND i.status = 'CONFIRMED'`)+`
-		LIMIT 1`, s.scope.Args(fileNodePathHash(path), path)...).Scan(&size)
+		WHERE `+scopeWhereAnd(s.scope, `fn.path_hash = ? AND fn.path = ? AND fn.is_directory = 0 AND i.status = 'CONFIRMED'`, "fn", "i")+`
+		LIMIT 1`, scopeWhereArgs(s.scope, 2, fileNodePathHash(path), path)...).Scan(&size)
 	if errors.Is(err, sql.ErrNoRows) {
 		return 0, nil
 	}
@@ -1561,14 +1572,14 @@ func (s *Store) ListConfirmedFileSummaries(ctx context.Context, cursor string, l
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT i.inode_id, i.size_bytes, COALESCE(c.content_type, '')
 			 FROM inodes i JOIN contents c ON i.inode_id = c.inode_id
-			 WHERE `+s.scope.AndAs("i", `i.status = 'CONFIRMED'`)+`
-			 ORDER BY i.inode_id ASC LIMIT ?`, s.scope.Args(limit)...)
+			 WHERE `+scopeWhereAnd(s.scope, `i.status = 'CONFIRMED'`, "i", "c")+`
+			 ORDER BY i.inode_id ASC LIMIT ?`, scopeWhereArgs(s.scope, 2, limit)...)
 	} else {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT i.inode_id, i.size_bytes, COALESCE(c.content_type, '')
 			 FROM inodes i JOIN contents c ON i.inode_id = c.inode_id
-			 WHERE `+s.scope.AndAs("i", `i.status = 'CONFIRMED' AND i.inode_id > ?`)+`
-			 ORDER BY i.inode_id ASC LIMIT ?`, s.scope.Args(cursor, limit)...)
+			 WHERE `+scopeWhereAnd(s.scope, `i.status = 'CONFIRMED' AND i.inode_id > ?`, "i", "c")+`
+			 ORDER BY i.inode_id ASC LIMIT ?`, scopeWhereArgs(s.scope, 2, cursor, limit)...)
 	}
 	if err != nil {
 		return nil, "", fmt.Errorf("query confirmed files: %w", err)
@@ -1608,14 +1619,14 @@ func (s *Store) ListConfirmedS3Refs(ctx context.Context, cursor string, limit in
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT c.storage_ref, c.storage_ref_hash
 			 FROM contents c JOIN inodes i ON i.inode_id = c.inode_id
-			 WHERE `+s.scope.AndAs("i", `i.status = 'CONFIRMED' AND c.storage_type = 's3' AND c.storage_ref <> ''`)+`
-			 ORDER BY c.storage_ref ASC LIMIT ?`, s.scope.Args(limit)...)
+			 WHERE `+scopeWhereAnd(s.scope, `i.status = 'CONFIRMED' AND c.storage_type = 's3' AND c.storage_ref <> ''`, "c", "i")+`
+			 ORDER BY c.storage_ref ASC LIMIT ?`, scopeWhereArgs(s.scope, 2, limit)...)
 	} else {
 		rows, err = s.db.QueryContext(ctx,
 			`SELECT c.storage_ref, c.storage_ref_hash
 			 FROM contents c JOIN inodes i ON i.inode_id = c.inode_id
-			 WHERE `+s.scope.AndAs("i", `i.status = 'CONFIRMED' AND c.storage_type = 's3' AND c.storage_ref <> '' AND c.storage_ref > ?`)+`
-			 ORDER BY c.storage_ref ASC LIMIT ?`, s.scope.Args(cursor, limit)...)
+			 WHERE `+scopeWhereAnd(s.scope, `i.status = 'CONFIRMED' AND c.storage_type = 's3' AND c.storage_ref <> '' AND c.storage_ref > ?`, "c", "i")+`
+			 ORDER BY c.storage_ref ASC LIMIT ?`, scopeWhereArgs(s.scope, 2, cursor, limit)...)
 	}
 	if err != nil {
 		return nil, "", fmt.Errorf("query confirmed s3 refs: %w", err)
@@ -1660,11 +1671,11 @@ func (s *Store) HasActiveUploads(ctx context.Context) (bool, error) {
 
 func (s *Store) SanitizeForkRuntimeState(ctx context.Context) error {
 	return s.InTx(ctx, func(tx *sql.Tx) error {
-		if _, err := tx.ExecContext(ctx, `DELETE fn FROM file_nodes fn JOIN inodes i ON i.inode_id = COALESCE(fn.inode_id, fn.file_id) WHERE `+s.scope.AndAs("i", `i.status <> 'CONFIRMED'`), s.scope.Args()...); err != nil {
+		if _, err := tx.ExecContext(ctx, `DELETE fn FROM file_nodes fn JOIN inodes i ON i.inode_id = COALESCE(fn.inode_id, fn.file_id) WHERE `+scopeWhereAnd(s.scope, `i.status <> 'CONFIRMED'`, "fn", "i"), scopeWhereArgs(s.scope, 2)...); err != nil {
 			return err
 		}
 		now := time.Now().UTC()
-		if _, err := tx.ExecContext(ctx, `UPDATE contents c JOIN inodes i ON i.inode_id = c.inode_id SET c.storage_ref = '', c.storage_ref_hash = '', c.content_blob = NULL WHERE `+s.scope.AndAs("i", `i.status <> 'CONFIRMED'`), s.scope.Args()...); err != nil {
+		if _, err := tx.ExecContext(ctx, `UPDATE contents c JOIN inodes i ON i.inode_id = c.inode_id SET c.storage_ref = '', c.storage_ref_hash = '', c.content_blob = NULL WHERE `+scopeWhereAnd(s.scope, `i.status <> 'CONFIRMED'`, "c", "i"), scopeWhereArgs(s.scope, 2)...); err != nil {
 			return err
 		}
 		if _, err := tx.ExecContext(ctx, `UPDATE inodes SET status = 'DELETED', expires_at = ? WHERE `+s.scope.And(`status <> 'CONFIRMED'`), append([]any{now}, s.scope.Args()...)...); err != nil {
@@ -1752,11 +1763,11 @@ func (s *Store) StatTx(ctx context.Context, db execer, path string) (out *NodeWi
 		c.checksum_sha256, i.revision, i.mode, s.embedding_revision, i.status, c.source_id, s.content_text,
 		s.description, s.description_embedding_revision, i.created_at, i.confirmed_at, i.expires_at
 		FROM file_nodes fn
-		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
-		LEFT JOIN contents c ON i.inode_id = c.inode_id
-		LEFT JOIN semantic s ON i.inode_id = s.inode_id
+		LEFT JOIN inodes i ON `+s.scope.AndOn(`COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'`, "i")+`
+		LEFT JOIN contents c ON `+s.scope.AndOn(`i.inode_id = c.inode_id`, "c")+`
+		LEFT JOIN semantic s ON `+s.scope.AndOn(`i.inode_id = s.inode_id`, "s")+`
 		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ?`)+`
-		LIMIT 1`, s.scope.Args(fileNodePathHash(path), path)...)
+		LIMIT 1`, scopeWhereArgs(s.scope, 3, s.scope.Args(fileNodePathHash(path), path)...)...)
 	return scanNodeWithFileWithBlob(row)
 }
 
@@ -1770,12 +1781,12 @@ func (s *Store) StatPathFallback(ctx context.Context, primaryPath, fallbackPath 
 		c.checksum_sha256, i.revision, i.mode, s.embedding_revision, i.status, c.source_id, s.content_text,
 		s.description, s.description_embedding_revision, i.created_at, i.confirmed_at, i.expires_at
 		FROM file_nodes fn
-		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
-		LEFT JOIN contents c ON i.inode_id = c.inode_id
-		LEFT JOIN semantic s ON i.inode_id = s.inode_id
+		LEFT JOIN inodes i ON `+s.scope.AndOn(`COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'`, "i")+`
+		LEFT JOIN contents c ON `+s.scope.AndOn(`i.inode_id = c.inode_id`, "c")+`
+		LEFT JOIN semantic s ON `+s.scope.AndOn(`i.inode_id = s.inode_id`, "s")+`
 		WHERE `+s.andAsGrouped("fn", `(fn.path_hash = ? AND fn.path = ?) OR (fn.path_hash = ? AND fn.path = ?)`)+`
 		ORDER BY CASE WHEN fn.path = ? THEN 0 ELSE 1 END
-		LIMIT 1`, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)
+		LIMIT 1`, scopeWhereArgs(s.scope, 3, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)...)
 	out, err = scanNodeWithFileWithBlob(row)
 	return out, err
 }
@@ -1790,10 +1801,10 @@ func (s *Store) StatPathFallbackLite(ctx context.Context, primaryPath, fallbackP
 	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
 		i.inode_id, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at
 		FROM file_nodes fn
-		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
+		LEFT JOIN inodes i ON `+s.scope.AndOn(`COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'`, "i")+`
 		WHERE `+s.andAsGrouped("fn", `(fn.path_hash = ? AND fn.path = ?) OR (fn.path_hash = ? AND fn.path = ?)`)+`
 		ORDER BY CASE WHEN fn.path = ? THEN 0 ELSE 1 END
-		LIMIT 1`, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)
+		LIMIT 1`, scopeWhereArgs(s.scope, 1, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)...)
 	out, err = scanNodeWithFileLite(row)
 	return out, err
 }
@@ -1806,9 +1817,9 @@ func (s *Store) StatLite(ctx context.Context, path string) (out *NodeWithFile, e
 	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
 		i.inode_id, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at
 		FROM file_nodes fn
-		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
+		LEFT JOIN inodes i ON `+s.scope.AndOn(`COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'`, "i")+`
 		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ?`)+`
-		LIMIT 1`, s.scope.Args(fileNodePathHash(path), path)...)
+		LIMIT 1`, scopeWhereArgs(s.scope, 1, s.scope.Args(fileNodePathHash(path), path)...)...)
 	out, err = scanNodeWithFileLite(row)
 	return out, err
 }
@@ -1824,10 +1835,10 @@ func (s *Store) StatForRead(ctx context.Context, path string) (out *NodeWithFile
 	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
 		i.inode_id, c.storage_type, c.storage_ref, c.content_blob, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at
 		FROM file_nodes fn
-		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
-		LEFT JOIN contents c ON i.inode_id = c.inode_id
+		LEFT JOIN inodes i ON `+s.scope.AndOn(`COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'`, "i")+`
+		LEFT JOIN contents c ON `+s.scope.AndOn(`i.inode_id = c.inode_id`, "c")+`
 		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ?`)+`
-		LIMIT 1`, s.scope.Args(fileNodePathHash(path), path)...)
+		LIMIT 1`, scopeWhereArgs(s.scope, 2, s.scope.Args(fileNodePathHash(path), path)...)...)
 	out, err = scanNodeWithFileForRead(row)
 	return out, err
 }
@@ -1840,11 +1851,11 @@ func (s *Store) StatPathFallbackForRead(ctx context.Context, primaryPath, fallba
 	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
 		i.inode_id, c.storage_type, c.storage_ref, c.content_blob, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at
 		FROM file_nodes fn
-		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
-		LEFT JOIN contents c ON i.inode_id = c.inode_id
+		LEFT JOIN inodes i ON `+s.scope.AndOn(`COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'`, "i")+`
+		LEFT JOIN contents c ON `+s.scope.AndOn(`i.inode_id = c.inode_id`, "c")+`
 		WHERE `+s.andAsGrouped("fn", `(fn.path_hash = ? AND fn.path = ?) OR (fn.path_hash = ? AND fn.path = ?)`)+`
 		ORDER BY CASE WHEN fn.path = ? THEN 0 ELSE 1 END
-		LIMIT 1`, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)
+		LIMIT 1`, scopeWhereArgs(s.scope, 2, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)...)
 	out, err = scanNodeWithFileForRead(row)
 	return out, err
 }
@@ -1859,11 +1870,11 @@ func (s *Store) ListDir(ctx context.Context, parentPath string) (out []*NodeWith
 		i.inode_id, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at,
 		s.embedding_revision
 		FROM file_nodes fn
-		LEFT JOIN inodes i ON COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'
-		LEFT JOIN semantic s ON i.inode_id = s.inode_id
+		LEFT JOIN inodes i ON `+s.scope.AndOn(`COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'`, "i")+`
+		LEFT JOIN semantic s ON `+s.scope.AndOn(`i.inode_id = s.inode_id`, "s")+`
 		WHERE ` + s.scope.AndAs("fn", `fn.parent_path_hash = ? AND fn.parent_path = ?`) + `
 		ORDER BY fn.name`
-	rows, err := s.db.QueryContext(ctx, q, s.scope.Args(fileNodePathHash(parentPath), parentPath)...)
+	rows, err := s.db.QueryContext(ctx, q, scopeWhereArgs(s.scope, 2, s.scope.Args(fileNodePathHash(parentPath), parentPath)...)...)
 	if err != nil {
 		return nil, err
 	}
@@ -2084,11 +2095,11 @@ func (s *Store) scanDeleteCandidateTx(ctx context.Context, tx *sql.Tx, path stri
 		c.storage_type, c.storage_ref, i.size_bytes, COALESCE(c.content_type, ''),
 		s.embedding_revision
 		FROM file_nodes fn
-		LEFT JOIN inodes i ON i.inode_id = fn.file_id
-		LEFT JOIN contents c ON c.inode_id = fn.file_id
-		LEFT JOIN semantic s ON s.inode_id = fn.file_id
+		LEFT JOIN inodes i ON `+s.scope.AndOn(`i.inode_id = fn.file_id`, "i")+`
+		LEFT JOIN contents c ON `+s.scope.AndOn(`c.inode_id = fn.file_id`, "c")+`
+		LEFT JOIN semantic s ON `+s.scope.AndOn(`s.inode_id = fn.file_id`, "s")+`
 		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ?`)+`
-		FOR UPDATE`, s.scope.Args(fileNodePathHash(path), path)...)
+		FOR UPDATE`, scopeWhereArgs(s.scope, 3, s.scope.Args(fileNodePathHash(path), path)...)...)
 	return scanSplitDeleteCandidate(row)
 }
 
@@ -2175,10 +2186,10 @@ func (s *Store) scanOrphanedFilesByIDTx(ctx context.Context, tx *sql.Tx, fileIDs
 				COALESCE(c.content_type, ''), s.embedding_revision
 				FROM inodes i
 				JOIN contents c ON c.inode_id = i.inode_id
-				LEFT JOIN semantic s ON s.inode_id = i.inode_id
-				WHERE ` + s.scope.AndAs("i", `i.inode_id IN (`+placeholders+`)
-				  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE fn.file_id = i.inode_id)`)
-			args = s.scope.Args(args...)
+				LEFT JOIN semantic s ON ` + s.scope.AndOn(`s.inode_id = i.inode_id`, "s") + `
+				WHERE ` + s.scope.AndAs("i", s.scope.AndAs("c", `i.inode_id IN (`+placeholders+`)
+				  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE `+s.scope.AndAs("fn", `fn.file_id = i.inode_id`)+`)`))
+			args = append(scopeWhereArgs(s.scope, 2, s.scope.Args(args...)...), s.scope.Args()...)
 		}
 		rows, err := tx.QueryContext(ctx, query, args...)
 		if err != nil {
@@ -2751,8 +2762,8 @@ func (s *Store) scanFileForGCTx(db execer, fileID string) (*File, error) {
 		s.embedding_revision
 		FROM inodes i
 		JOIN contents c ON i.inode_id = c.inode_id
-		LEFT JOIN semantic s ON i.inode_id = s.inode_id
-		WHERE `+s.scope.AndAs("i", `i.inode_id = ?`), s.scope.Args(fileID)...).Scan(
+		LEFT JOIN semantic s ON `+s.scope.AndOn(`i.inode_id = s.inode_id`, "s")+`
+		WHERE `+scopeWhereAnd(s.scope, `i.inode_id = ?`, "i", "c"), scopeWhereArgs(s.scope, 3, fileID)...).Scan(
 		&f.StorageType, &f.StorageRef, &f.SizeBytes, &contentType, &embRev)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/datastore/store_shared_collision_test.go
+++ b/pkg/datastore/store_shared_collision_test.go
@@ -1,0 +1,329 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+)
+
+// TestStoreSharedShapeCollidingIDs is the regression suite for the shared
+// scoping contract: entity ids (inode_id / file_id) are unique only within a
+// tenant, so two fs_ids may legitimately hold the SAME entity id. Every
+// multi-table relationship must correlate fs_id on all aliases/subqueries —
+// before that was enforced, a colliding id let one tenant read another
+// tenant's metadata, suppress its GC, accept a stale embedding writeback, or
+// wipe its rows during fork sanitization.
+func TestStoreSharedShapeCollidingIDs(t *testing.T) {
+	installSharedCoreFSNoLegacy(t)
+	ctx := context.Background()
+	const fsA, fsB int64 = 4400001, 4400002
+	now := time.Now()
+
+	insert := func(store *Store, fileID string, status FileStatus, size int64, ref string) {
+		t.Helper()
+		f := &File{
+			FileID: fileID, StorageType: StorageS3, StorageRef: ref,
+			ContentType: "text/plain", SizeBytes: size, Revision: 1, Status: status,
+			CreatedAt: now,
+		}
+		if status == StatusConfirmed {
+			f.ConfirmedAt = &now
+		}
+		if err := store.InsertFile(ctx, f); err != nil {
+			t.Fatalf("InsertFile %s: %v", fileID, err)
+		}
+	}
+	link := func(store *Store, path, fileID string) {
+		t.Helper()
+		if err := store.EnsureParentDirs(ctx, path, genID); err != nil {
+			t.Fatalf("EnsureParentDirs %s: %v", path, err)
+		}
+		name := path
+		for i := len(path) - 1; i >= 0; i-- {
+			if path[i] == '/' {
+				name = path[i+1:]
+				break
+			}
+		}
+		parent := path[:len(path)-len(name)]
+		if err := store.InsertNode(ctx, &FileNode{
+			NodeID: fileID + "-node", Path: path, ParentPath: parent,
+			Name: name, FileID: fileID, CreatedAt: now,
+		}); err != nil {
+			t.Fatalf("InsertNode %s: %v", path, err)
+		}
+	}
+
+	t.Run("StatDoesNotLeakAcrossCollidingIDs", func(t *testing.T) {
+		storeA := newSharedStore(t, fsA)
+		storeB := newSharedStore(t, fsB)
+		// A has only a dentry + pending inode; B holds a confirmed inode under
+		// the SAME id. A's stat must not pick up B's confirmed metadata.
+		insert(storeA, "col-stat", StatusPending, 0, "s3://a/pending")
+		link(storeA, "/colvec/stat.bin", "col-stat")
+		insert(storeB, "col-stat", StatusConfirmed, 999, "s3://b/confirmed")
+
+		nf, err := storeA.StatTx(ctx, storeA.db, "/colvec/stat.bin")
+		if err != nil {
+			t.Fatalf("A StatTx: %v", err)
+		}
+		if nf.File != nil {
+			t.Fatalf("A StatTx attached another tenant's file: %+v", nf.File)
+		}
+		lite, err := storeA.StatLite(ctx, "/colvec/stat.bin")
+		if err != nil {
+			t.Fatalf("A StatLite: %v", err)
+		}
+		if lite.File != nil {
+			t.Fatalf("A StatLite attached another tenant's file: %+v", lite.File)
+		}
+
+		// Once A confirms its own inode under the same id, A's stat must
+		// deterministically return A's row, never B's.
+		if _, err := storeA.db.Exec(`UPDATE inodes SET status = 'CONFIRMED', size_bytes = 5, confirmed_at = ?
+			WHERE fs_id = ? AND inode_id = 'col-stat'`, now, fsA); err != nil {
+			t.Fatalf("confirm A inode: %v", err)
+		}
+		nf, err = storeA.StatTx(ctx, storeA.db, "/colvec/stat.bin")
+		if err != nil {
+			t.Fatalf("A StatTx after confirm: %v", err)
+		}
+		if nf.File == nil || nf.File.SizeBytes != 5 || nf.File.StorageRef != "s3://a/pending" {
+			t.Fatalf("A StatTx = %+v, want A's own confirmed row", nf.File)
+		}
+	})
+
+	t.Run("StorageRefCheckIgnoresOtherTenants", func(t *testing.T) {
+		storeA := newSharedStore(t, fsA)
+		storeB := newSharedStore(t, fsB)
+		// Only B has a confirmed S3 file at ref R. A's GC liveness check on R
+		// must report dead so A never suppresses collection of its own object
+		// because of B's row.
+		insert(storeB, "col-ref", StatusConfirmed, 1, "s3://shared-bucket/object-r")
+
+		ok, err := storeA.HasConfirmedS3StorageRef(ctx, StorageRefHash("s3://shared-bucket/object-r"), "s3://shared-bucket/object-r")
+		if err != nil {
+			t.Fatalf("A HasConfirmedS3StorageRef: %v", err)
+		}
+		if ok {
+			t.Fatal("A sees B's confirmed storage ref as live")
+		}
+		ok, err = storeB.HasConfirmedS3StorageRef(ctx, StorageRefHash("s3://shared-bucket/object-r"), "s3://shared-bucket/object-r")
+		if err != nil {
+			t.Fatalf("B HasConfirmedS3StorageRef: %v", err)
+		}
+		if !ok {
+			t.Fatal("B lost sight of its own confirmed storage ref")
+		}
+	})
+
+	t.Run("MediaCountAndQuotaReadsAreIsolated", func(t *testing.T) {
+		storeA := newSharedStore(t, fsA)
+		storeB := newSharedStore(t, fsB)
+		// Same inode id, media content, confirmed — but only under B.
+		insert(storeB, "col-media", StatusConfirmed, 10, "s3://b/img")
+		if _, err := storeB.db.Exec(`UPDATE contents SET content_type = 'image/png' WHERE fs_id = ? AND inode_id = 'col-media'`, fsB); err != nil {
+			t.Fatalf("mark B content image: %v", err)
+		}
+
+		var countA int64
+		if err := storeA.InTx(ctx, func(tx *sql.Tx) error {
+			var err error
+			countA, err = storeA.ConfirmedMediaFileCountTx(tx)
+			return err
+		}); err != nil {
+			t.Fatalf("A ConfirmedMediaFileCountTx: %v", err)
+		}
+		if countA != 0 {
+			t.Fatalf("A media count = %d, want 0 (B has the media file)", countA)
+		}
+
+		// A has a dentry whose pending inode id collides with B's confirmed
+		// inode; A's confirmed-size read at that path must be zero.
+		insert(storeA, "col-media", StatusPending, 0, "s3://a/pending")
+		link(storeA, "/colvec/media.bin", "col-media")
+		var sizeA int64
+		if err := storeA.InTx(ctx, func(tx *sql.Tx) error {
+			var err error
+			sizeA, err = storeA.ConfirmedFileSizeByPathTx(tx, "/colvec/media.bin")
+			return err
+		}); err != nil {
+			t.Fatalf("A ConfirmedFileSizeByPathTx: %v", err)
+		}
+		if sizeA != 0 {
+			t.Fatalf("A confirmed size = %d, want 0 (A's inode is pending)", sizeA)
+		}
+	})
+
+	t.Run("UploadReservationIgnoresOtherTenants", func(t *testing.T) {
+		storeA := newSharedStore(t, fsA)
+		storeB := newSharedStore(t, fsB)
+		// B has a confirmed 100-byte file at the exact path A is uploading to.
+		// A's 10-byte reservation must stay 10: joining B's dentry/inode would
+		// subtract B's size and understate A's quota.
+		insert(storeB, "col-up", StatusConfirmed, 100, "s3://b/existing")
+		link(storeB, "/colvec/up.bin", "col-up")
+		if err := storeA.InsertUpload(ctx, &Upload{
+			UploadID: "col-up-upload", FileID: "col-up", TargetPath: "/colvec/up.bin",
+			S3UploadID: "s3up-col", S3Key: "key-col", TotalSize: 10, PartSize: 5, PartsTotal: 2,
+			Status: UploadUploading, IdempotencyKey: "idem-col-up", CreatedAt: now, UpdatedAt: now,
+			ExpiresAt: now.Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("A InsertUpload: %v", err)
+		}
+
+		var reserved int64
+		if err := storeA.InTx(ctx, func(tx *sql.Tx) error {
+			var err error
+			reserved, err = storeA.ActiveUploadReservedBytesTx(tx)
+			return err
+		}); err != nil {
+			t.Fatalf("A ActiveUploadReservedBytesTx: %v", err)
+		}
+		if reserved != 10 {
+			t.Fatalf("A reserved = %d, want 10 (B's 100-byte file must not offset it)", reserved)
+		}
+	})
+
+	t.Run("ListConfirmedReadsAreIsolated", func(t *testing.T) {
+		storeA := newSharedStore(t, fsA)
+		storeB := newSharedStore(t, fsB)
+		insert(storeB, "col-list-1", StatusConfirmed, 1, "s3://b/l1")
+		insert(storeB, "col-list-2", StatusConfirmed, 1, "s3://b/l2")
+
+		summaries, _, err := storeA.ListConfirmedFileSummaries(ctx, "", 100)
+		if err != nil {
+			t.Fatalf("A ListConfirmedFileSummaries: %v", err)
+		}
+		for _, s := range summaries {
+			if s.FileID == "col-list-1" || s.FileID == "col-list-2" {
+				t.Fatalf("A summaries contain B's file: %+v", s)
+			}
+		}
+		refs, _, err := storeA.ListConfirmedS3Refs(ctx, "", 100)
+		if err != nil {
+			t.Fatalf("A ListConfirmedS3Refs: %v", err)
+		}
+		for _, r := range refs {
+			if r.StorageRef == "s3://b/l1" || r.StorageRef == "s3://b/l2" {
+				t.Fatalf("A refs contain B's ref: %+v", r)
+			}
+		}
+	})
+
+	t.Run("OrphanScanIgnoresOtherTenantsDentries", func(t *testing.T) {
+		storeA := newSharedStore(t, fsA)
+		storeB := newSharedStore(t, fsB)
+		// A has a confirmed inode with no dentry of its own; B has a dentry
+		// pointing at the SAME id. From A's perspective the inode is an orphan
+		// and must be GC-able — B's dentry must not suppress that.
+		insert(storeA, "col-orph", StatusConfirmed, 7, "s3://a/orphan")
+		insert(storeB, "col-orph", StatusConfirmed, 7, "s3://b/live")
+		link(storeB, "/colvec/orph.bin", "col-orph")
+
+		var orphans []*File
+		if err := storeA.InTx(ctx, func(tx *sql.Tx) error {
+			var err error
+			orphans, err = storeA.scanOrphanedFilesByIDTx(ctx, tx, []string{"col-orph"})
+			return err
+		}); err != nil {
+			t.Fatalf("A scanOrphanedFilesByIDTx: %v", err)
+		}
+		if len(orphans) != 1 || orphans[0].FileID != "col-orph" || orphans[0].StorageRef != "s3://a/orphan" {
+			t.Fatalf("A orphans = %+v, want A's own col-orph row", orphans)
+		}
+	})
+
+	t.Run("EmbeddingWritebackChecksOwnTenantRevision", func(t *testing.T) {
+		storeA := newSharedStore(t, fsA)
+		storeB := newSharedStore(t, fsB)
+		// Same inode id, different revisions: A at rev 1, B at rev 2. A
+		// writeback gated on rev 2 must not fire by matching B's inode.
+		insert(storeA, "col-emb", StatusConfirmed, 1, "s3://a/emb")
+		insert(storeB, "col-emb", StatusConfirmed, 1, "s3://b/emb")
+		if _, err := storeB.db.Exec(`UPDATE inodes SET revision = 2 WHERE fs_id = ? AND inode_id = 'col-emb'`, fsB); err != nil {
+			t.Fatalf("bump B revision: %v", err)
+		}
+
+		updated, err := storeA.UpdateFileEmbedding(ctx, "col-emb", 2, []float32{0.1, 0.2})
+		if err != nil {
+			t.Fatalf("A UpdateFileEmbedding rev2: %v", err)
+		}
+		if updated {
+			t.Fatal("A embedding writeback matched B's revision-2 inode")
+		}
+		updated, err = storeA.UpdateFileEmbedding(ctx, "col-emb", 1, []float32{0.1, 0.2})
+		if err != nil {
+			t.Fatalf("A UpdateFileEmbedding rev1: %v", err)
+		}
+		if !updated {
+			t.Fatal("A embedding writeback lost its own revision-1 inode")
+		}
+	})
+
+	t.Run("GCScanReadsOwnTenantRow", func(t *testing.T) {
+		storeA := newSharedStore(t, fsA)
+		storeB := newSharedStore(t, fsB)
+		// Same id confirmed under both tenants with different refs: A's GC
+		// scan must deterministically read A's ref, never B's.
+		insert(storeA, "col-gc", StatusConfirmed, 1, "s3://a/gc")
+		insert(storeB, "col-gc", StatusConfirmed, 1, "s3://b/gc")
+
+		var f *File
+		if err := storeA.InTx(ctx, func(tx *sql.Tx) error {
+			var err error
+			f, err = storeA.scanFileForGCTx(tx, "col-gc")
+			return err
+		}); err != nil {
+			t.Fatalf("A scanFileForGCTx: %v", err)
+		}
+		if f.StorageRef != "s3://a/gc" {
+			t.Fatalf("A GC scan storage_ref = %q, want s3://a/gc", f.StorageRef)
+		}
+	})
+
+	t.Run("SanitizeDoesNotTouchCollidingIDs", func(t *testing.T) {
+		// A real shared DB also carries the shared vault tables; sanitize
+		// wipes them per fs_id, so install them in shared shape.
+		installSharedVaultSchema(t)
+		// Fresh fs_ids so earlier subtests' rows cannot interfere.
+		const fsC, fsD int64 = 4400003, 4400004
+		storeC := newSharedStore(t, fsC)
+		storeD := newSharedStore(t, fsD)
+		// C: pending inode + dentry under id X (upload-time runtime state).
+		// D: confirmed file + dentry under the SAME id X. Sanitizing C must
+		// leave every D row untouched.
+		insert(storeC, "col-san", StatusPending, 0, "s3://c/pending")
+		link(storeC, "/colvec/c-pending.bin", "col-san")
+		insert(storeD, "col-san", StatusConfirmed, 42, "s3://d/confirmed")
+		link(storeD, "/colvec/d-confirmed.bin", "col-san")
+
+		if err := storeC.SanitizeForkRuntimeState(ctx); err != nil {
+			t.Fatalf("C SanitizeForkRuntimeState: %v", err)
+		}
+
+		if _, err := storeD.GetNode(ctx, "/colvec/d-confirmed.bin"); err != nil {
+			t.Fatalf("D dentry destroyed by C's sanitize: %v", err)
+		}
+		inodeD, err := storeD.GetInode(ctx, "col-san")
+		if err != nil {
+			t.Fatalf("D GetInode: %v", err)
+		}
+		if inodeD.Status != StatusConfirmed {
+			t.Fatalf("D inode status = %q, want CONFIRMED", inodeD.Status)
+		}
+		contentD, err := storeD.GetContent(ctx, "col-san")
+		if err != nil {
+			t.Fatalf("D GetContent: %v", err)
+		}
+		if contentD.StorageRef != "s3://d/confirmed" {
+			t.Fatalf("D content ref = %q, want untouched", contentD.StorageRef)
+		}
+		// C's own runtime state is gone.
+		if _, err := storeC.GetNode(ctx, "/colvec/c-pending.bin"); !errors.Is(err, ErrNotFound) {
+			t.Fatalf("C pending dentry err = %v, want ErrNotFound", err)
+		}
+	})
+}

--- a/pkg/datastore/store_shared_test.go
+++ b/pkg/datastore/store_shared_test.go
@@ -74,7 +74,7 @@ func countFsIDRows(t *testing.T, s *Store, tbl string, fsID int64) int64 {
 // runStoreCoreScenario exercises the Core FS flows — create file (inode,
 // content, semantic, dentry), get/list by path and by parent, overwrite with
 // revision bump, tag replace/query, upload reservation lifecycle, ref-checked
-// delete with GC enqueue, and llm_usage accounting — against a store. It runs
+// delete with GC enqueue — against a store. It runs
 // against the shared schema shape to prove behavioral parity with the
 // standalone flows covered by store_test.go / file_tx_test.go.
 func runStoreCoreScenario(t *testing.T, s *Store, pfx string) {
@@ -329,18 +329,6 @@ func runStoreCoreScenario(t *testing.T, s *Store, pfx string) {
 	if task.Status != FileGCTaskQueued || task.StorageRef != "inline:"+pfx+":v2" {
 		t.Fatalf("gc task = %+v", task)
 	}
-
-	// llm_usage accounting.
-	if err := s.InsertLLMUsage("img_extract_text", pfx+"-llm", 42, 1, "image"); err != nil {
-		t.Fatalf("InsertLLMUsage: %v", err)
-	}
-	cost, err := s.MonthlyLLMCostMillicents()
-	if err != nil {
-		t.Fatalf("MonthlyLLMCostMillicents: %v", err)
-	}
-	if cost != 42 {
-		t.Fatalf("monthly llm cost = %d, want 42", cost)
-	}
 }
 
 // TestStoreSharedShapeParity runs the Core FS scenario against the shared
@@ -358,7 +346,7 @@ func TestStoreSharedShapeParity(t *testing.T) {
 // TestStoreSharedShapeCrossTenantIsolation proves rows of one fs_id are
 // invisible to another fs_id on the same shared tables: the same path can
 // coexist under two fs_ids (UNIQUE (fs_id, path_hash)), and reads, writes,
-// deletes, uploads, and llm_usage never cross the tenant boundary.
+// deletes, and uploads never cross the tenant boundary.
 func TestStoreSharedShapeCrossTenantIsolation(t *testing.T) {
 	installSharedCoreFSNoLegacy(t)
 	ctx := context.Background()
@@ -477,20 +465,6 @@ func TestStoreSharedShapeCrossTenantIsolation(t *testing.T) {
 		t.Fatalf("B upload status after A abort = %q, want UPLOADING", upB.Status)
 	}
 
-	// llm_usage sums stay per-tenant.
-	if err := storeA.InsertLLMUsage("embed", "iso-a-llm", 100, 1, "req"); err != nil {
-		t.Fatalf("InsertLLMUsage A: %v", err)
-	}
-	if err := storeB.InsertLLMUsage("embed", "iso-b-llm", 7, 1, "req"); err != nil {
-		t.Fatalf("InsertLLMUsage B: %v", err)
-	}
-	if cost, err := storeA.MonthlyLLMCostMillicents(); err != nil || cost != 100 {
-		t.Fatalf("A monthly llm cost = %d, %v; want 100, nil", cost, err)
-	}
-	if cost, err := storeB.MonthlyLLMCostMillicents(); err != nil || cost != 7 {
-		t.Fatalf("B monthly llm cost = %d, %v; want 7, nil", cost, err)
-	}
-
 	// A delete under A must not touch B's dentry or file.
 	if err := storeA.DeleteNode(ctx, "/iso/shared.txt"); err != nil {
 		t.Fatalf("DeleteNode A: %v", err)
@@ -535,11 +509,11 @@ func TestStoreSharedShapeStoresFsID(t *testing.T) {
 	}
 
 	// The scenario writes file_nodes, inodes, contents, semantic, file_tags,
-	// uploads, and llm_usage directly; the ref-checked delete additionally
-	// enqueues a file_gc_tasks row.
+	// and uploads directly; the ref-checked delete additionally enqueues a
+	// file_gc_tasks row.
 	for _, tbl := range []string{
 		"file_nodes", "inodes", "contents", "semantic", "file_tags",
-		"uploads", "llm_usage", "file_gc_tasks",
+		"uploads", "file_gc_tasks",
 	} {
 		requireOnlyFsIDRows(t, store, tbl, fsID)
 	}
@@ -547,8 +521,8 @@ func TestStoreSharedShapeStoresFsID(t *testing.T) {
 
 // TestSanitizeForkRuntimeStateSharedShape proves the fork sanitize only wipes
 // its own fs_id's runtime state on the shared schema: pending upload state,
-// uploads, task tables, llm_usage, and vault rows of the other tenant must
-// survive untouched.
+// uploads, task tables, and vault rows of the other tenant must survive
+// untouched.
 func TestSanitizeForkRuntimeStateSharedShape(t *testing.T) {
 	installSharedCoreFSNoLegacy(t)
 	installSharedVaultSchema(t)
@@ -596,9 +570,6 @@ func TestSanitizeForkRuntimeStateSharedShape(t *testing.T) {
 		}); err != nil {
 			t.Fatalf("InsertUpload %s: %v", tc.pfx, err)
 		}
-		if err := tc.store.InsertLLMUsage("embed", tc.pfx+"-llm", 11, 1, "req"); err != nil {
-			t.Fatalf("InsertLLMUsage %s: %v", tc.pfx, err)
-		}
 		// Rows in the task/vault tables that sanitize wipes wholesale.
 		if _, err := tc.store.DB().Exec(`INSERT INTO file_gc_tasks (fs_id, task_id, file_id, storage_type, storage_ref, status)
 			VALUES (?, ?, ?, 'db9', 'ref', 'QUEUED')`, tc.fsID, "gc-"+tc.pfx, "file-"+tc.pfx); err != nil {
@@ -641,10 +612,7 @@ func TestSanitizeForkRuntimeStateSharedShape(t *testing.T) {
 	if _, err := storeA.GetUpload(ctx, "san-a-upload"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("A upload err = %v, want ErrNotFound", err)
 	}
-	if cost, err := storeA.MonthlyLLMCostMillicents(); err != nil || cost != 0 {
-		t.Fatalf("A monthly llm cost after sanitize = %d, %v; want 0, nil", cost, err)
-	}
-	for _, tbl := range []string{"uploads", "file_gc_tasks", "semantic_tasks", "llm_usage", "vault_deks"} {
+	for _, tbl := range []string{"uploads", "file_gc_tasks", "semantic_tasks", "vault_deks"} {
 		if n := countFsIDRows(t, storeA, tbl, fsA); n != 0 {
 			t.Fatalf("A %s rows after sanitize = %d, want 0", tbl, n)
 		}
@@ -664,10 +632,7 @@ func TestSanitizeForkRuntimeStateSharedShape(t *testing.T) {
 	if _, err := storeB.GetUpload(ctx, "san-b-upload"); err != nil {
 		t.Fatalf("B upload: %v", err)
 	}
-	if cost, err := storeB.MonthlyLLMCostMillicents(); err != nil || cost != 11 {
-		t.Fatalf("B monthly llm cost = %d, %v; want 11, nil", cost, err)
-	}
-	for _, tbl := range []string{"uploads", "file_gc_tasks", "semantic_tasks", "llm_usage", "vault_deks"} {
+	for _, tbl := range []string{"uploads", "file_gc_tasks", "semantic_tasks", "vault_deks"} {
 		if n := countFsIDRows(t, storeB, tbl, fsB); n != 1 {
 			t.Fatalf("B %s rows = %d, want 1", tbl, n)
 		}

--- a/pkg/datastore/store_shared_test.go
+++ b/pkg/datastore/store_shared_test.go
@@ -1,0 +1,675 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/tenant/schema"
+)
+
+// installSharedCoreFSNoLegacy swaps the Core FS tables to the shared (fs_id)
+// shape and drops the legacy files table: shared databases never carry it, so
+// the shared store must run with useLegacyFiles=false. The installSharedTables
+// cleanup restores the full standalone schema, files table included.
+func installSharedCoreFSNoLegacy(t *testing.T) {
+	t.Helper()
+	installSharedCoreFSSchema(t)
+	db, err := sql.Open("mysql", testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = db.Close() }()
+	if _, err := db.Exec(`DROP TABLE IF EXISTS files`); err != nil {
+		t.Fatalf("drop legacy files table: %v", err)
+	}
+}
+
+var vaultSharedTables = []string{
+	"vault_audit_log", "vault_grants", "vault_tokens", "vault_secret_fields",
+	"vault_secrets", "vault_policies", "vault_deks",
+}
+
+// installSharedVaultSchema swaps the 7 vault tables to the shared (fs_id)
+// shape so SanitizeForkRuntimeState can be exercised against its full table
+// list: in shared shape its wholesale DELETEs must carry fs_id predicates.
+func installSharedVaultSchema(t *testing.T) {
+	t.Helper()
+	installSharedTables(t, vaultSharedTables, schema.VaultMySQLSharedSchemaStatements())
+}
+
+// requireOnlyFsIDRows asserts tbl holds at least one row and that every row
+// carries fsID: a shared table must never contain rows stamped with another
+// tenant's fs_id.
+func requireOnlyFsIDRows(t *testing.T, s *Store, tbl string, fsID int64) {
+	t.Helper()
+	var foreign int64
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM "+tbl+" WHERE fs_id != ?", fsID).Scan(&foreign); err != nil {
+		t.Fatalf("count %s rows with foreign fs_id: %v", tbl, err)
+	}
+	if foreign != 0 {
+		t.Fatalf("%s has %d rows with fs_id != %d", tbl, foreign, fsID)
+	}
+	var total int64
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM " + tbl).Scan(&total); err != nil {
+		t.Fatalf("count %s: %v", tbl, err)
+	}
+	if total == 0 {
+		t.Fatalf("%s is empty; scenario should have written rows", tbl)
+	}
+}
+
+// countFsIDRows returns the number of rows in tbl stamped with fsID.
+func countFsIDRows(t *testing.T, s *Store, tbl string, fsID int64) int64 {
+	t.Helper()
+	var n int64
+	if err := s.DB().QueryRow("SELECT COUNT(*) FROM "+tbl+" WHERE fs_id = ?", fsID).Scan(&n); err != nil {
+		t.Fatalf("count %s rows for fs_id %d: %v", tbl, fsID, err)
+	}
+	return n
+}
+
+// runStoreCoreScenario exercises the Core FS flows — create file (inode,
+// content, semantic, dentry), get/list by path and by parent, overwrite with
+// revision bump, tag replace/query, upload reservation lifecycle, ref-checked
+// delete with GC enqueue, and llm_usage accounting — against a store. It runs
+// against the shared schema shape to prove behavioral parity with the
+// standalone flows covered by store_test.go / file_tx_test.go.
+func runStoreCoreScenario(t *testing.T, s *Store, pfx string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now()
+
+	// Create file: inserts inode/content/semantic rows plus the dentry.
+	fileID := pfx + "-file"
+	filePath := "/" + pfx + "/docs/a.txt"
+	if err := s.InsertFile(ctx, &File{
+		FileID: fileID, StorageType: StorageDB9, StorageRef: "inline:" + pfx + ":v1",
+		ContentBlob: []byte("hello " + pfx), ContentType: "text/plain",
+		SizeBytes: 6, Revision: 1, Status: StatusConfirmed,
+		ContentText: "hello " + pfx, CreatedAt: now, ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatalf("InsertFile: %v", err)
+	}
+	if err := s.EnsureParentDirs(ctx, filePath, genID); err != nil {
+		t.Fatalf("EnsureParentDirs: %v", err)
+	}
+	if err := s.InsertNode(ctx, &FileNode{
+		NodeID: fileID + "-node", Path: filePath, ParentPath: "/" + pfx + "/docs/",
+		Name: "a.txt", FileID: fileID, CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("InsertNode: %v", err)
+	}
+
+	// Get/list by path and by parent.
+	node, err := s.GetNode(ctx, filePath)
+	if err != nil {
+		t.Fatalf("GetNode: %v", err)
+	}
+	if node.NodeID != fileID+"-node" || node.FileID != fileID {
+		t.Fatalf("node = %+v", node)
+	}
+	if exists, err := s.NodeExists(ctx, filePath); err != nil || !exists {
+		t.Fatalf("NodeExists = %v, %v; want true, nil", exists, err)
+	}
+	nodes, err := s.ListNodes(ctx, "/"+pfx+"/docs/")
+	if err != nil {
+		t.Fatalf("ListNodes: %v", err)
+	}
+	if len(nodes) != 1 || nodes[0].Path != filePath {
+		t.Fatalf("nodes = %+v", nodes)
+	}
+	stat, err := s.Stat(ctx, filePath)
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if stat.File == nil || stat.File.SizeBytes != 6 || stat.File.ContentText != "hello "+pfx {
+		t.Fatalf("stat = %+v", stat)
+	}
+	lite, err := s.StatLite(ctx, filePath)
+	if err != nil {
+		t.Fatalf("StatLite: %v", err)
+	}
+	if lite.File == nil || lite.File.Revision != 1 {
+		t.Fatalf("stat lite = %+v", lite)
+	}
+	forRead, err := s.StatForRead(ctx, filePath)
+	if err != nil {
+		t.Fatalf("StatForRead: %v", err)
+	}
+	if forRead.File == nil || string(forRead.File.ContentBlob) != "hello "+pfx {
+		t.Fatalf("stat for read = %+v", forRead)
+	}
+	fallback, err := s.StatPathFallback(ctx, "/"+pfx+"/missing.txt", filePath)
+	if err != nil {
+		t.Fatalf("StatPathFallback: %v", err)
+	}
+	if fallback.Node.Path != filePath {
+		t.Fatalf("stat fallback path = %q, want %q", fallback.Node.Path, filePath)
+	}
+	entries, err := s.ListDir(ctx, "/"+pfx+"/docs/")
+	if err != nil {
+		t.Fatalf("ListDir: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Node.Name != "a.txt" || entries[0].File == nil {
+		t.Fatalf("dir entries = %+v", entries)
+	}
+	got, err := s.GetFile(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetFile: %v", err)
+	}
+	if got.StorageType != StorageDB9 || got.ContentText != "hello "+pfx || got.Revision != 1 {
+		t.Fatalf("file = %+v", got)
+	}
+
+	// Overwrite: content update bumps the revision across the split tables.
+	newRev, err := s.UpdateFileContent(ctx, fileID, StorageDB9, "inline:"+pfx+":v2",
+		"text/plain", "sum2", "hello v2 "+pfx, []byte("hello v2 "+pfx), 10, "")
+	if err != nil {
+		t.Fatalf("UpdateFileContent: %v", err)
+	}
+	if newRev != 2 {
+		t.Fatalf("new revision = %d, want 2", newRev)
+	}
+	got, err = s.GetFile(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetFile after overwrite: %v", err)
+	}
+	if got.Revision != 2 || got.SizeBytes != 10 || got.ContentText != "hello v2 "+pfx || got.StorageRef != "inline:"+pfx+":v2" {
+		t.Fatalf("file after overwrite = %+v", got)
+	}
+
+	// Tags: full replace, then a second replace that shrinks the set.
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.ReplaceFileTagsTx(tx, fileID, map[string]string{"owner": pfx, "topic": "shared"})
+	}); err != nil {
+		t.Fatalf("ReplaceFileTagsTx initial: %v", err)
+	}
+	tags, err := s.GetFileTags(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetFileTags: %v", err)
+	}
+	if len(tags) != 2 || tags["owner"] != pfx || tags["topic"] != "shared" {
+		t.Fatalf("tags = %+v", tags)
+	}
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.ReplaceFileTagsTx(tx, fileID, map[string]string{"owner": pfx + "-2"})
+	}); err != nil {
+		t.Fatalf("ReplaceFileTagsTx replace: %v", err)
+	}
+	tags, err = s.GetFileTags(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetFileTags after replace: %v", err)
+	}
+	if len(tags) != 1 || tags["owner"] != pfx+"-2" {
+		t.Fatalf("tags after replace = %+v", tags)
+	}
+
+	// Upload reservation lifecycle: insert, reserve quota, complete; then a
+	// second upload that is aborted.
+	upload := &Upload{
+		UploadID: pfx + "-upload", FileID: pfx + "-up-file", TargetPath: "/" + pfx + "/up.bin",
+		S3UploadID: "s3up-" + pfx, S3Key: "key-" + pfx, TotalSize: 100, PartSize: 50, PartsTotal: 2,
+		Status: UploadUploading, IdempotencyKey: "idem-" + pfx, CreatedAt: now, UpdatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	}
+	if err := s.InsertUpload(ctx, upload); err != nil {
+		t.Fatalf("InsertUpload: %v", err)
+	}
+	dup := *upload
+	dup.UploadID = pfx + "-upload-dup"
+	if err := s.InsertUpload(ctx, &dup); !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("InsertUpload dup err = %v, want ErrIdempotencyConflict", err)
+	}
+	gotUpload, err := s.GetUploadByPath(ctx, "/"+pfx+"/up.bin")
+	if err != nil {
+		t.Fatalf("GetUploadByPath: %v", err)
+	}
+	if gotUpload.UploadID != upload.UploadID || gotUpload.Status != UploadUploading {
+		t.Fatalf("upload = %+v", gotUpload)
+	}
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		reserved, err := s.ActiveUploadReservedBytesTx(tx)
+		if err != nil {
+			return err
+		}
+		if reserved != 100 {
+			t.Fatalf("reserved bytes = %d, want 100", reserved)
+		}
+		confirmed, err := s.ConfirmedStorageBytesTx(tx)
+		if err != nil {
+			return err
+		}
+		if confirmed != 10 {
+			t.Fatalf("confirmed bytes = %d, want 10", confirmed)
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("quota tx: %v", err)
+	}
+	if err := s.CompleteUpload(ctx, upload.UploadID); err != nil {
+		t.Fatalf("CompleteUpload: %v", err)
+	}
+	gotUpload, err = s.GetUpload(ctx, upload.UploadID)
+	if err != nil {
+		t.Fatalf("GetUpload after complete: %v", err)
+	}
+	if gotUpload.Status != UploadCompleted {
+		t.Fatalf("upload status = %q, want COMPLETED", gotUpload.Status)
+	}
+	if _, err := s.GetUploadByPath(ctx, "/"+pfx+"/up.bin"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetUploadByPath after complete err = %v, want ErrNotFound", err)
+	}
+	abortedUpload := &Upload{
+		UploadID: pfx + "-upload-2", FileID: pfx + "-up-file-2", TargetPath: "/" + pfx + "/up2.bin",
+		S3UploadID: "s3up2-" + pfx, S3Key: "key2-" + pfx, TotalSize: 8, PartSize: 4, PartsTotal: 2,
+		Status: UploadUploading, IdempotencyKey: "idem2-" + pfx, CreatedAt: now, UpdatedAt: now,
+		ExpiresAt: now.Add(time.Hour),
+	}
+	if err := s.InsertUpload(ctx, abortedUpload); err != nil {
+		t.Fatalf("InsertUpload 2: %v", err)
+	}
+	if err := s.AbortUpload(ctx, abortedUpload.UploadID); err != nil {
+		t.Fatalf("AbortUpload: %v", err)
+	}
+	gotUpload, err = s.GetUpload(ctx, abortedUpload.UploadID)
+	if err != nil {
+		t.Fatalf("GetUpload after abort: %v", err)
+	}
+	if gotUpload.Status != UploadAborted {
+		t.Fatalf("upload 2 status = %q, want ABORTED", gotUpload.Status)
+	}
+
+	// Delete with ref check: a second link keeps the file alive; deleting the
+	// last link marks the inode DELETED and enqueues the GC task.
+	linkPath := "/" + pfx + "/docs/b.txt"
+	if err := s.LinkFileNode(ctx, filePath, linkPath, "/"+pfx+"/docs/", "b.txt", fileID+"-link-node", now); err != nil {
+		t.Fatalf("LinkFileNode: %v", err)
+	}
+	deleted, err := s.DeleteFileWithRefCheck(ctx, filePath)
+	if err != nil {
+		t.Fatalf("DeleteFileWithRefCheck first link: %v", err)
+	}
+	if deleted != nil {
+		t.Fatalf("deleted = %+v, want nil (file should survive with refs)", deleted)
+	}
+	if _, err := s.GetNode(ctx, filePath); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetNode deleted link err = %v, want ErrNotFound", err)
+	}
+	if _, err := s.GetNode(ctx, linkPath); err != nil {
+		t.Fatalf("remaining link node: %v", err)
+	}
+	got, err = s.GetFile(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetFile after first delete: %v", err)
+	}
+	if got.Status != StatusConfirmed {
+		t.Fatalf("file status after first delete = %q, want CONFIRMED", got.Status)
+	}
+	deleted, err = s.DeleteFileWithRefCheck(ctx, linkPath)
+	if err != nil {
+		t.Fatalf("DeleteFileWithRefCheck last link: %v", err)
+	}
+	if deleted == nil || deleted.Status != StatusDeleted {
+		t.Fatalf("deleted = %+v, want DELETED file", deleted)
+	}
+	got, err = s.GetFile(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetFile after last delete: %v", err)
+	}
+	if got.Status != StatusDeleted {
+		t.Fatalf("file status after last delete = %q, want DELETED", got.Status)
+	}
+	task, err := s.GetFileGCTaskByFileID(ctx, fileID)
+	if err != nil {
+		t.Fatalf("GetFileGCTaskByFileID: %v", err)
+	}
+	if task.Status != FileGCTaskQueued || task.StorageRef != "inline:"+pfx+":v2" {
+		t.Fatalf("gc task = %+v", task)
+	}
+
+	// llm_usage accounting.
+	if err := s.InsertLLMUsage("img_extract_text", pfx+"-llm", 42, 1, "image"); err != nil {
+		t.Fatalf("InsertLLMUsage: %v", err)
+	}
+	cost, err := s.MonthlyLLMCostMillicents()
+	if err != nil {
+		t.Fatalf("MonthlyLLMCostMillicents: %v", err)
+	}
+	if cost != 42 {
+		t.Fatalf("monthly llm cost = %d, want 42", cost)
+	}
+}
+
+// TestStoreSharedShapeParity runs the Core FS scenario against the shared
+// (fs_id) schema shape without the legacy files table, mirroring the
+// standalone coverage in store_test.go / file_tx_test.go.
+func TestStoreSharedShapeParity(t *testing.T) {
+	installSharedCoreFSNoLegacy(t)
+	store := newSharedStore(t, 4300001)
+	if store.HasLegacyFiles() {
+		t.Fatal("shared store must run without the legacy files table")
+	}
+	runStoreCoreScenario(t, store, "shpar")
+}
+
+// TestStoreSharedShapeCrossTenantIsolation proves rows of one fs_id are
+// invisible to another fs_id on the same shared tables: the same path can
+// coexist under two fs_ids (UNIQUE (fs_id, path_hash)), and reads, writes,
+// deletes, uploads, and llm_usage never cross the tenant boundary.
+func TestStoreSharedShapeCrossTenantIsolation(t *testing.T) {
+	installSharedCoreFSNoLegacy(t)
+	ctx := context.Background()
+	storeA := newSharedStore(t, 4300002)
+	storeB := newSharedStore(t, 4300003)
+	now := time.Now()
+
+	// Same path created under two fs_ids must coexist.
+	for _, tc := range []struct {
+		store  *Store
+		fileID string
+		text   string
+	}{
+		{storeA, "iso-a-file", "hello iso a"},
+		{storeB, "iso-b-file", "hello iso b"},
+	} {
+		if err := tc.store.InsertFile(ctx, &File{
+			FileID: tc.fileID, StorageType: StorageDB9, StorageRef: "inline:" + tc.fileID,
+			ContentType: "text/plain", SizeBytes: 4, Revision: 1, Status: StatusConfirmed,
+			ContentText: tc.text, CreatedAt: now, ConfirmedAt: &now,
+		}); err != nil {
+			t.Fatalf("InsertFile %s: %v", tc.fileID, err)
+		}
+		if err := tc.store.EnsureParentDirs(ctx, "/iso/shared.txt", genID); err != nil {
+			t.Fatalf("EnsureParentDirs %s: %v", tc.fileID, err)
+		}
+		if err := tc.store.InsertNode(ctx, &FileNode{
+			NodeID: tc.fileID + "-node", Path: "/iso/shared.txt", ParentPath: "/iso/",
+			Name: "shared.txt", FileID: tc.fileID, CreatedAt: now,
+		}); err != nil {
+			t.Fatalf("InsertNode %s: %v", tc.fileID, err)
+		}
+		if err := tc.store.InTx(ctx, func(tx *sql.Tx) error {
+			return tc.store.ReplaceFileTagsTx(tx, tc.fileID, map[string]string{"owner": tc.fileID})
+		}); err != nil {
+			t.Fatalf("ReplaceFileTagsTx %s: %v", tc.fileID, err)
+		}
+		// Same upload target path reserved under both fs_ids must coexist
+		// (idx_uploads_active is per fs_id).
+		if err := tc.store.InsertUpload(ctx, &Upload{
+			UploadID: tc.fileID + "-upload", FileID: tc.fileID + "-up", TargetPath: "/iso/up.bin",
+			S3UploadID: "s3up-" + tc.fileID, S3Key: "key-" + tc.fileID, TotalSize: 10, PartSize: 5, PartsTotal: 2,
+			Status: UploadUploading, IdempotencyKey: "idem-" + tc.fileID, CreatedAt: now, UpdatedAt: now,
+			ExpiresAt: now.Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("InsertUpload %s: %v", tc.fileID, err)
+		}
+	}
+
+	// Each store resolves the shared path to its own dentry and file.
+	nodeA, err := storeA.GetNode(ctx, "/iso/shared.txt")
+	if err != nil {
+		t.Fatalf("GetNode A: %v", err)
+	}
+	if nodeA.FileID != "iso-a-file" {
+		t.Fatalf("A node = %+v, want iso-a-file", nodeA)
+	}
+	nodeB, err := storeB.GetNode(ctx, "/iso/shared.txt")
+	if err != nil {
+		t.Fatalf("GetNode B: %v", err)
+	}
+	if nodeB.FileID != "iso-b-file" {
+		t.Fatalf("B node = %+v, want iso-b-file", nodeB)
+	}
+	nodesB, err := storeB.ListNodes(ctx, "/iso/")
+	if err != nil {
+		t.Fatalf("ListNodes B: %v", err)
+	}
+	if len(nodesB) != 1 || nodesB[0].FileID != "iso-b-file" {
+		t.Fatalf("B nodes = %+v, want only iso-b-file", nodesB)
+	}
+
+	// A write under A must not leak into B: A bumps its revision, B is unchanged.
+	if _, err := storeA.UpdateFileContent(ctx, "iso-a-file", StorageDB9, "inline:iso-a-file:v2",
+		"text/plain", "sum", "hello iso a v2", []byte("hello iso a v2"), 9, ""); err != nil {
+		t.Fatalf("UpdateFileContent A: %v", err)
+	}
+	fileB, err := storeB.GetFile(ctx, "iso-b-file")
+	if err != nil {
+		t.Fatalf("GetFile B: %v", err)
+	}
+	if fileB.Revision != 1 || fileB.ContentText != "hello iso b" || fileB.SizeBytes != 4 {
+		t.Fatalf("B file after A write = %+v, want unchanged", fileB)
+	}
+
+	// Tag replace under A must not touch B's tags.
+	if err := storeA.InTx(ctx, func(tx *sql.Tx) error {
+		return storeA.ReplaceFileTagsTx(tx, "iso-a-file", map[string]string{"owner": "replaced"})
+	}); err != nil {
+		t.Fatalf("ReplaceFileTagsTx A: %v", err)
+	}
+	tagsB, err := storeB.GetFileTags(ctx, "iso-b-file")
+	if err != nil {
+		t.Fatalf("GetFileTags B: %v", err)
+	}
+	if len(tagsB) != 1 || tagsB["owner"] != "iso-b-file" {
+		t.Fatalf("B tags after A replace = %+v, want unchanged", tagsB)
+	}
+
+	// Upload reads/aborts stay per-tenant.
+	upB, err := storeB.GetUploadByPath(ctx, "/iso/up.bin")
+	if err != nil {
+		t.Fatalf("GetUploadByPath B: %v", err)
+	}
+	if upB.UploadID != "iso-b-file-upload" {
+		t.Fatalf("B upload = %+v, want iso-b-file-upload", upB)
+	}
+	if aborted, err := storeA.AbortUploadV2(ctx, "iso-a-file-upload"); err != nil || !aborted {
+		t.Fatalf("AbortUploadV2 A = %v, %v; want true, nil", aborted, err)
+	}
+	upB, err = storeB.GetUpload(ctx, "iso-b-file-upload")
+	if err != nil {
+		t.Fatalf("GetUpload B: %v", err)
+	}
+	if upB.Status != UploadUploading {
+		t.Fatalf("B upload status after A abort = %q, want UPLOADING", upB.Status)
+	}
+
+	// llm_usage sums stay per-tenant.
+	if err := storeA.InsertLLMUsage("embed", "iso-a-llm", 100, 1, "req"); err != nil {
+		t.Fatalf("InsertLLMUsage A: %v", err)
+	}
+	if err := storeB.InsertLLMUsage("embed", "iso-b-llm", 7, 1, "req"); err != nil {
+		t.Fatalf("InsertLLMUsage B: %v", err)
+	}
+	if cost, err := storeA.MonthlyLLMCostMillicents(); err != nil || cost != 100 {
+		t.Fatalf("A monthly llm cost = %d, %v; want 100, nil", cost, err)
+	}
+	if cost, err := storeB.MonthlyLLMCostMillicents(); err != nil || cost != 7 {
+		t.Fatalf("B monthly llm cost = %d, %v; want 7, nil", cost, err)
+	}
+
+	// A delete under A must not touch B's dentry or file.
+	if err := storeA.DeleteNode(ctx, "/iso/shared.txt"); err != nil {
+		t.Fatalf("DeleteNode A: %v", err)
+	}
+	if _, err := storeA.GetNode(ctx, "/iso/shared.txt"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("A GetNode after delete err = %v, want ErrNotFound", err)
+	}
+	if _, err := storeB.GetNode(ctx, "/iso/shared.txt"); err != nil {
+		t.Fatalf("B GetNode after A delete: %v", err)
+	}
+	fileB, err = storeB.GetFile(ctx, "iso-b-file")
+	if err != nil {
+		t.Fatalf("B GetFile after A delete: %v", err)
+	}
+	if fileB.Status != StatusConfirmed {
+		t.Fatalf("B file status after A delete = %q, want CONFIRMED", fileB.Status)
+	}
+}
+
+// TestStoreSharedShapeStoresFsID asserts every Core FS table row written by
+// the scenario carries the scope's fs_id as its tenant discriminator.
+func TestStoreSharedShapeStoresFsID(t *testing.T) {
+	installSharedCoreFSNoLegacy(t)
+	const fsID int64 = 4300004
+	store := newSharedStore(t, fsID)
+	runStoreCoreScenario(t, store, "shfsid")
+
+	// The scenario's ref-checked delete removes its file's tags; leave one
+	// tagged file behind so file_tags is covered by the fs_id row check.
+	ctx := context.Background()
+	now := time.Now()
+	if err := store.InsertFile(ctx, &File{
+		FileID: "shfsid-keep", StorageType: StorageDB9, StorageRef: "inline:shfsid-keep",
+		SizeBytes: 1, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatalf("InsertFile keep: %v", err)
+	}
+	if err := store.InTx(ctx, func(tx *sql.Tx) error {
+		return store.ReplaceFileTagsTx(tx, "shfsid-keep", map[string]string{"owner": "shfsid"})
+	}); err != nil {
+		t.Fatalf("ReplaceFileTagsTx keep: %v", err)
+	}
+
+	// The scenario writes file_nodes, inodes, contents, semantic, file_tags,
+	// uploads, and llm_usage directly; the ref-checked delete additionally
+	// enqueues a file_gc_tasks row.
+	for _, tbl := range []string{
+		"file_nodes", "inodes", "contents", "semantic", "file_tags",
+		"uploads", "llm_usage", "file_gc_tasks",
+	} {
+		requireOnlyFsIDRows(t, store, tbl, fsID)
+	}
+}
+
+// TestSanitizeForkRuntimeStateSharedShape proves the fork sanitize only wipes
+// its own fs_id's runtime state on the shared schema: pending upload state,
+// uploads, task tables, llm_usage, and vault rows of the other tenant must
+// survive untouched.
+func TestSanitizeForkRuntimeStateSharedShape(t *testing.T) {
+	installSharedCoreFSNoLegacy(t)
+	installSharedVaultSchema(t)
+	ctx := context.Background()
+	const fsA, fsB int64 = 4300010, 4300011
+	storeA := newSharedStore(t, fsA)
+	storeB := newSharedStore(t, fsB)
+	now := time.Now()
+
+	// Seed the same runtime state for two tenants.
+	for _, tc := range []struct {
+		store *Store
+		pfx   string
+		fsID  int64
+	}{
+		{storeA, "san-a", fsA},
+		{storeB, "san-b", fsB},
+	} {
+		// Pending upload-time file: sanitize must delete its dentry, wipe its
+		// content ref, and mark the inode DELETED.
+		if err := tc.store.InsertFile(ctx, &File{
+			FileID: tc.pfx + "-pending", StorageType: StorageS3, StorageRef: "s3://" + tc.pfx + "/pending",
+			SizeBytes: 5, Revision: 1, Status: StatusPending, CreatedAt: now,
+		}); err != nil {
+			t.Fatalf("InsertFile pending %s: %v", tc.pfx, err)
+		}
+		if err := tc.store.InsertNode(ctx, &FileNode{
+			NodeID: tc.pfx + "-pending-node", Path: "/" + tc.pfx + "/pending.bin", ParentPath: "/",
+			Name: "pending.bin", FileID: tc.pfx + "-pending", CreatedAt: now,
+		}); err != nil {
+			t.Fatalf("InsertNode pending %s: %v", tc.pfx, err)
+		}
+		// Confirmed file: sanitize must leave it untouched.
+		if err := tc.store.InsertFile(ctx, &File{
+			FileID: tc.pfx + "-confirmed", StorageType: StorageDB9, StorageRef: "inline:" + tc.pfx,
+			SizeBytes: 3, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+		}); err != nil {
+			t.Fatalf("InsertFile confirmed %s: %v", tc.pfx, err)
+		}
+		if err := tc.store.InsertUpload(ctx, &Upload{
+			UploadID: tc.pfx + "-upload", FileID: tc.pfx + "-up-file", TargetPath: "/" + tc.pfx + "/up.bin",
+			S3UploadID: "s3up-" + tc.pfx, S3Key: "key-" + tc.pfx, TotalSize: 10, PartSize: 5, PartsTotal: 2,
+			Status: UploadUploading, IdempotencyKey: "idem-" + tc.pfx, CreatedAt: now, UpdatedAt: now,
+			ExpiresAt: now.Add(time.Hour),
+		}); err != nil {
+			t.Fatalf("InsertUpload %s: %v", tc.pfx, err)
+		}
+		if err := tc.store.InsertLLMUsage("embed", tc.pfx+"-llm", 11, 1, "req"); err != nil {
+			t.Fatalf("InsertLLMUsage %s: %v", tc.pfx, err)
+		}
+		// Rows in the task/vault tables that sanitize wipes wholesale.
+		if _, err := tc.store.DB().Exec(`INSERT INTO file_gc_tasks (fs_id, task_id, file_id, storage_type, storage_ref, status)
+			VALUES (?, ?, ?, 'db9', 'ref', 'QUEUED')`, tc.fsID, "gc-"+tc.pfx, "file-"+tc.pfx); err != nil {
+			t.Fatalf("insert file_gc_tasks %s: %v", tc.pfx, err)
+		}
+		if _, err := tc.store.DB().Exec(`INSERT INTO semantic_tasks (fs_id, task_id, task_type, resource_id, resource_version, status)
+			VALUES (?, ?, 'embed', ?, 1, 'PENDING')`, tc.fsID, "st-"+tc.pfx, "res-"+tc.pfx); err != nil {
+			t.Fatalf("insert semantic_tasks %s: %v", tc.pfx, err)
+		}
+		if _, err := tc.store.DB().Exec(`INSERT INTO vault_deks (fs_id, wrapped_dek) VALUES (?, X'01')`, tc.fsID); err != nil {
+			t.Fatalf("insert vault_deks %s: %v", tc.pfx, err)
+		}
+	}
+
+	if err := storeA.SanitizeForkRuntimeState(ctx); err != nil {
+		t.Fatalf("SanitizeForkRuntimeState A: %v", err)
+	}
+
+	// Tenant A runtime state is gone; confirmed data survives.
+	if _, err := storeA.GetNode(ctx, "/san-a/pending.bin"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("A pending node err = %v, want ErrNotFound", err)
+	}
+	inodeA, err := storeA.GetInode(ctx, "san-a-pending")
+	if err != nil {
+		t.Fatalf("A GetInode: %v", err)
+	}
+	if inodeA.Status != StatusDeleted || inodeA.ExpiresAt == nil {
+		t.Fatalf("A pending inode = %+v, want DELETED with expires_at", inodeA)
+	}
+	contentA, err := storeA.GetContent(ctx, "san-a-pending")
+	if err != nil {
+		t.Fatalf("A GetContent: %v", err)
+	}
+	if contentA.StorageRef != "" {
+		t.Fatalf("A pending content storage_ref = %q, want wiped", contentA.StorageRef)
+	}
+	if _, err := storeA.GetFile(ctx, "san-a-confirmed"); err != nil {
+		t.Fatalf("A confirmed file must survive sanitize: %v", err)
+	}
+	if _, err := storeA.GetUpload(ctx, "san-a-upload"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("A upload err = %v, want ErrNotFound", err)
+	}
+	if cost, err := storeA.MonthlyLLMCostMillicents(); err != nil || cost != 0 {
+		t.Fatalf("A monthly llm cost after sanitize = %d, %v; want 0, nil", cost, err)
+	}
+	for _, tbl := range []string{"uploads", "file_gc_tasks", "semantic_tasks", "llm_usage", "vault_deks"} {
+		if n := countFsIDRows(t, storeA, tbl, fsA); n != 0 {
+			t.Fatalf("A %s rows after sanitize = %d, want 0", tbl, n)
+		}
+	}
+
+	// Tenant B is fully intact.
+	if _, err := storeB.GetNode(ctx, "/san-b/pending.bin"); err != nil {
+		t.Fatalf("B pending node: %v", err)
+	}
+	inodeB, err := storeB.GetInode(ctx, "san-b-pending")
+	if err != nil {
+		t.Fatalf("B GetInode: %v", err)
+	}
+	if inodeB.Status != StatusPending {
+		t.Fatalf("B pending inode status = %q, want PENDING", inodeB.Status)
+	}
+	if _, err := storeB.GetUpload(ctx, "san-b-upload"); err != nil {
+		t.Fatalf("B upload: %v", err)
+	}
+	if cost, err := storeB.MonthlyLLMCostMillicents(); err != nil || cost != 11 {
+		t.Fatalf("B monthly llm cost = %d, %v; want 11, nil", cost, err)
+	}
+	for _, tbl := range []string{"uploads", "file_gc_tasks", "semantic_tasks", "llm_usage", "vault_deks"} {
+		if n := countFsIDRows(t, storeB, tbl, fsB); n != 1 {
+			t.Fatalf("B %s rows = %d, want 1", tbl, n)
+		}
+	}
+}

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -33,7 +33,10 @@ const sharedDBStatusActive = "active"
 
 // SharedDB is one physical database registered in db_pool. PasswordCipher
 // holds the same encrypted envelope as tenants.db_password; the plaintext
-// never crosses this layer. MaxTenants of 0 means unlimited.
+// never crosses this layer. TLSMode is the go-sql-driver tls DSN parameter
+// verbatim ("true", "skip-verify", a custom registered config name, or ""
+// for plaintext) so the runtime handle reopens the DB with exactly the TLS
+// mode it was registered with. MaxTenants of 0 means unlimited.
 type SharedDB struct {
 	DbID           int64
 	OrgID          string
@@ -43,7 +46,7 @@ type SharedDB struct {
 	User           string
 	PasswordCipher []byte
 	Name           string
-	TLS            bool
+	TLSMode        string
 	MaxTenants     int
 	TenantCount    int
 	Status         string
@@ -96,6 +99,9 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 	if in.MaxTenants < 0 {
 		return 0, fmt.Errorf("max tenants must not be negative")
 	}
+	if len(in.TLSMode) > 32 {
+		return 0, fmt.Errorf("tls mode %q is too long", in.TLSMode)
+	}
 	role := in.Role
 	if role == "" {
 		role = SharedDBRoleShared
@@ -114,7 +120,7 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 			"db_password = VALUES(db_password), db_tls = VALUES(db_tls), "+
 			"max_tenants = VALUES(max_tenants), status = VALUES(status)",
 		in.OrgID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
-		boolToInt(in.TLS), in.MaxTenants, status); err != nil {
+		in.TLSMode, in.MaxTenants, status); err != nil {
 		return 0, fmt.Errorf("upsert db_pool row: %w", err)
 	}
 	// ON DUPLICATE KEY UPDATE does not reliably report the existing
@@ -172,9 +178,14 @@ func (s *Store) FindSharedDBForOrg(ctx context.Context, orgID string) (db *Share
 }
 
 func (s *Store) findActiveSharedDB(ctx context.Context, orgID string) (*SharedDB, error) {
+	// Capacity is enforced at selection time: a pool at its max_tenants limit
+	// is invisible to new placements (0 means unlimited). tenant_count is a
+	// denormalized counter, so a rare drift can over- or under-admit; closing
+	// that fully needs a transactional reserve, which is a planned follow-up.
 	db, err := scanSharedDBRow(s.db.QueryRowContext(ctx,
 		"SELECT "+sharedDBSelectColumns+" FROM db_pool "+
-			"WHERE org_id = ? AND `role` = ? AND status = ? ORDER BY db_id LIMIT 1",
+			"WHERE org_id = ? AND `role` = ? AND status = ? "+
+			"AND (max_tenants = 0 OR tenant_count < max_tenants) ORDER BY db_id LIMIT 1",
 		orgID, SharedDBRoleShared, sharedDBStatusActive))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -190,20 +201,18 @@ func (s *Store) ListSharedDBs(ctx context.Context) (out []*SharedDB, err error) 
 	start := time.Now()
 	defer observeMeta(ctx, "list_shared_dbs", start, &err)
 	rows, err := s.db.QueryContext(ctx,
-		"SELECT "+sharedDBSelectColumns+" FROM db_pool WHERE status = ? ORDER BY db_id",
-		sharedDBStatusActive)
+		"SELECT "+sharedDBSelectColumns+" FROM db_pool WHERE `role` = ? AND status = ? ORDER BY db_id",
+		SharedDBRoleShared, sharedDBStatusActive)
 	if err != nil {
 		return nil, fmt.Errorf("list shared dbs: %w", err)
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var rec SharedDB
-		var tls int
 		if err = rows.Scan(&rec.DbID, &rec.OrgID, &rec.Role, &rec.Host, &rec.Port, &rec.User,
-			&rec.PasswordCipher, &rec.Name, &tls, &rec.MaxTenants, &rec.TenantCount, &rec.Status); err != nil {
+			&rec.PasswordCipher, &rec.Name, &rec.TLSMode, &rec.MaxTenants, &rec.TenantCount, &rec.Status); err != nil {
 			return nil, err
 		}
-		rec.TLS = tls == 1
 		out = append(out, &rec)
 	}
 	return out, rows.Err()
@@ -273,6 +282,11 @@ func (s *Store) UpsertTenantPlacement(ctx context.Context, p *TenantPlacement) (
 	if status == "" {
 		status = sharedDBStatusActive
 	}
+	switch status {
+	case sharedDBStatusActive, "migrating":
+	default:
+		return fmt.Errorf("unsupported placement status %q", status)
+	}
 	var target any
 	if p.TargetDbID != nil {
 		target = *p.TargetDbID
@@ -333,11 +347,9 @@ func (s *Store) DeleteTenantPlacement(ctx context.Context, fsID int64) (err erro
 // scanSharedDBRow scans one db_pool row selected with sharedDBSelectColumns.
 func scanSharedDBRow(row *sql.Row) (*SharedDB, error) {
 	var rec SharedDB
-	var tls int
 	if err := row.Scan(&rec.DbID, &rec.OrgID, &rec.Role, &rec.Host, &rec.Port, &rec.User,
-		&rec.PasswordCipher, &rec.Name, &tls, &rec.MaxTenants, &rec.TenantCount, &rec.Status); err != nil {
+		&rec.PasswordCipher, &rec.Name, &rec.TLSMode, &rec.MaxTenants, &rec.TenantCount, &rec.Status); err != nil {
 		return nil, err
 	}
-	rec.TLS = tls == 1
 	return &rec, nil
 }

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -344,18 +344,34 @@ func (s *Store) DeleteTenantPlacement(ctx context.Context, fsID int64) (err erro
 	return nil
 }
 
-// ErrSharedDBCapacityExhausted is returned by ReserveSharedDBPlacement when
-// the target pool has no free capacity (max_tenants reached).
+// ErrSharedDBCapacityExhausted is returned when a shared-pool reservation
+// cannot be made because the target pool has no free capacity
+// (max_tenants reached).
 var ErrSharedDBCapacityExhausted = errors.New("shared db capacity exhausted")
 
-// ReserveSharedDBPlacement atomically reserves one capacity slot on a shared
-// DB and records the tenant's placement in a single transaction: the counter
-// increment is conditional on free capacity, so two concurrent provisions
-// cannot both take the last slot, and the placement row never exists without
-// its reserved capacity (or vice versa).
-func (s *Store) ReserveSharedDBPlacement(ctx context.Context, p *TenantPlacement) (err error) {
+// CompleteSharedTenantProvision atomically performs every meta write that
+// turns a pending tenant into a live shared-pool tenant, in one transaction:
+//
+//  1. the conditional capacity reservation (two concurrent provisions
+//     cannot take the same last slot — the loser gets
+//     ErrSharedDBCapacityExhausted),
+//  2. the placement insert,
+//  3. the provider re-label and active-status transition on the tenant row
+//     (ErrNotFound when the tenant row does not exist), and
+//  4. the owner API key insert (ErrDuplicate on key id collision).
+//
+// Either all of it commits or none does: a shared tenant can never become
+// active without its placement row, its reserved capacity, and its owner
+// key, and a failed attempt leaves no partial state behind.
+func (s *Store) CompleteSharedTenantProvision(ctx context.Context, tenantID, provider string, p *TenantPlacement, k *APIKey) (err error) {
 	start := time.Now()
-	defer observeMeta(ctx, "reserve_shared_db_placement", start, &err)
+	defer observeMeta(ctx, "complete_shared_tenant_provision", start, &err)
+	if tenantID == "" {
+		return fmt.Errorf("tenant id is required")
+	}
+	if provider == "" {
+		return fmt.Errorf("provider is required")
+	}
 	if p == nil {
 		return fmt.Errorf("tenant placement is required")
 	}
@@ -366,12 +382,20 @@ func (s *Store) ReserveSharedDBPlacement(ctx context.Context, p *TenantPlacement
 		return fmt.Errorf("db_id must be positive")
 	}
 	if p.Placement != PlacementShared || p.SchemaShape != SchemaShapeShared {
-		return fmt.Errorf("reserve requires shared placement and schema shape")
+		return fmt.Errorf("provision requires shared placement and schema shape")
+	}
+	if k == nil {
+		return fmt.Errorf("api key is required")
+	}
+	scopeKind, err := apiKeyScopeKindForInsert(k)
+	if err != nil {
+		return err
 	}
 	status := p.Status
 	if status == "" {
 		status = sharedDBStatusActive
 	}
+	now := time.Now().UTC()
 	return s.InTx(ctx, func(tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx,
 			`UPDATE db_pool SET tenant_count = tenant_count + 1
@@ -395,6 +419,32 @@ func (s *Store) ReserveSharedDBPlacement(ctx context.Context, p *TenantPlacement
 				VALUES (?, ?, ?, ?, ?, ?)`,
 			p.FsID, p.DbID, p.Placement, p.SchemaShape, status, target); err != nil {
 			return fmt.Errorf("insert placement for fs_id %d: %w", p.FsID, err)
+		}
+		res, err = tx.ExecContext(ctx,
+			`UPDATE tenants SET provider = ?, status = ?, updated_at = ? WHERE id = ?`,
+			provider, TenantActive, now, tenantID)
+		if err != nil {
+			return fmt.Errorf("activate tenant %s: %w", tenantID, err)
+		}
+		affected, err = res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("activate tenant rows affected for %s: %w", tenantID, err)
+		}
+		if affected == 0 {
+			return ErrNotFound
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_api_keys
+			(id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, scope_kind,
+			 issued_by_provider, issued_by_subject_key, issued_by_metadata_json,
+			 issued_at, revoked_at, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			k.ID, k.TenantID, k.KeyName, k.JWTCiphertext, k.JWTHash, k.TokenVersion, k.Status, scopeKind,
+			k.IssuedByProvider, k.IssuedBySubjectKey, nullableBytes(k.IssuedByMetadataJSON),
+			k.IssuedAt.UTC(), k.RevokedAt, k.CreatedAt.UTC(), k.UpdatedAt.UTC()); err != nil {
+			if isDuplicateEntry(err) {
+				return ErrDuplicate
+			}
+			return fmt.Errorf("insert owner api key: %w", err)
 		}
 		return nil
 	})

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -344,6 +344,107 @@ func (s *Store) DeleteTenantPlacement(ctx context.Context, fsID int64) (err erro
 	return nil
 }
 
+// ErrSharedDBCapacityExhausted is returned by ReserveSharedDBPlacement when
+// the target pool has no free capacity (max_tenants reached).
+var ErrSharedDBCapacityExhausted = errors.New("shared db capacity exhausted")
+
+// ReserveSharedDBPlacement atomically reserves one capacity slot on a shared
+// DB and records the tenant's placement in a single transaction: the counter
+// increment is conditional on free capacity, so two concurrent provisions
+// cannot both take the last slot, and the placement row never exists without
+// its reserved capacity (or vice versa).
+func (s *Store) ReserveSharedDBPlacement(ctx context.Context, p *TenantPlacement) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "reserve_shared_db_placement", start, &err)
+	if p == nil {
+		return fmt.Errorf("tenant placement is required")
+	}
+	if p.FsID <= 0 {
+		return fmt.Errorf("fs_id must be positive")
+	}
+	if p.DbID <= 0 {
+		return fmt.Errorf("db_id must be positive")
+	}
+	if p.Placement != PlacementShared || p.SchemaShape != SchemaShapeShared {
+		return fmt.Errorf("reserve requires shared placement and schema shape")
+	}
+	status := p.Status
+	if status == "" {
+		status = sharedDBStatusActive
+	}
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx,
+			`UPDATE db_pool SET tenant_count = tenant_count + 1
+				WHERE db_id = ? AND (max_tenants = 0 OR tenant_count < max_tenants)`, p.DbID)
+		if err != nil {
+			return fmt.Errorf("reserve capacity on db %d: %w", p.DbID, err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("reserve capacity rows affected for db %d: %w", p.DbID, err)
+		}
+		if affected == 0 {
+			return ErrSharedDBCapacityExhausted
+		}
+		var target any
+		if p.TargetDbID != nil {
+			target = *p.TargetDbID
+		}
+		if _, err := tx.ExecContext(ctx,
+			`INSERT INTO tenant_placements (fs_id, db_id, placement, schema_shape, status, target_db_id)
+				VALUES (?, ?, ?, ?, ?, ?)`,
+			p.FsID, p.DbID, p.Placement, p.SchemaShape, status, target); err != nil {
+			return fmt.Errorf("insert placement for fs_id %d: %w", p.FsID, err)
+		}
+		return nil
+	})
+}
+
+// DeleteTenantPlacementAndDecrCount atomically removes a tenant's placement
+// and releases its capacity slot in a single transaction. Making the two
+// writes atomic keeps the shared delete path retry-safe: a failure rolls both
+// back, so a retried delete re-enters with the placement row still present
+// and cannot orphan the row or double-decrement the counter. Returns
+// ErrNotFound when the placement row does not exist.
+func (s *Store) DeleteTenantPlacementAndDecrCount(ctx context.Context, fsID, dbID int64) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_tenant_placement_and_decr_count", start, &err)
+	if fsID <= 0 {
+		return fmt.Errorf("fs_id must be positive")
+	}
+	if dbID <= 0 {
+		return fmt.Errorf("db_id must be positive")
+	}
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `DELETE FROM tenant_placements WHERE fs_id = ?`, fsID)
+		if err != nil {
+			return fmt.Errorf("delete tenant placement for fs_id %d: %w", fsID, err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("delete tenant placement rows affected for fs_id %d: %w", fsID, err)
+		}
+		if affected == 0 {
+			return ErrNotFound
+		}
+		res, err = tx.ExecContext(ctx,
+			`UPDATE db_pool SET tenant_count = GREATEST(tenant_count - 1, 0) WHERE db_id = ?`, dbID)
+		if err != nil {
+			return fmt.Errorf("release capacity on db %d: %w", dbID, err)
+		}
+		affected, err = res.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("release capacity rows affected for db %d: %w", dbID, err)
+		}
+		if affected == 0 {
+			// The placement pointed at a pool row that no longer exists —
+			// a data-integrity problem the caller must not silently pass.
+			return ErrNotFound
+		}
+		return nil
+	})
+}
+
 // scanSharedDBRow scans one db_pool row selected with sharedDBSelectColumns.
 func scanSharedDBRow(row *sql.Row) (*SharedDB, error) {
 	var rec SharedDB

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -1,0 +1,343 @@
+package meta
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// SharedDBOrgWildcard is the org_id sentinel matching any TiDB Cloud
+// organization that has no exact db_pool row.
+const SharedDBOrgWildcard = "*"
+
+// SharedDBRoleShared marks a db_pool row as a multi-tenant shared-schema
+// database. A "dedicated" role is reserved for future use and rejected for
+// now.
+const SharedDBRoleShared = "shared"
+
+// Placement values for TenantPlacement.Placement.
+const (
+	PlacementShared    = "shared"
+	PlacementDedicated = "dedicated"
+)
+
+// Schema shape values for TenantPlacement.SchemaShape.
+const (
+	SchemaShapeStandalone = "standalone"
+	SchemaShapeShared     = "shared"
+)
+
+const sharedDBStatusActive = "active"
+
+// SharedDB is one physical database registered in db_pool. PasswordCipher
+// holds the same encrypted envelope as tenants.db_password; the plaintext
+// never crosses this layer. MaxTenants of 0 means unlimited.
+type SharedDB struct {
+	DbID           int64
+	OrgID          string
+	Role           string
+	Host           string
+	Port           int
+	User           string
+	PasswordCipher []byte
+	Name           string
+	TLS            bool
+	MaxTenants     int
+	TenantCount    int
+	Status         string
+}
+
+// TenantPlacement maps one filesystem (fs_id) to the physical database that
+// hosts it. TargetDbID is reserved for future migrations; Epoch is reserved
+// for optimistic concurrency during migrations and stays 1 unless a migration
+// explicitly bumps it.
+type TenantPlacement struct {
+	FsID        int64
+	DbID        int64
+	Placement   string
+	SchemaShape string
+	Status      string
+	TargetDbID  *int64
+	Epoch       int64
+}
+
+// sharedDBSelectColumns lists the db_pool columns read into SharedDB. The
+// `role` column is backtick-quoted because ROLE is reserved in MySQL 8.0.
+const sharedDBSelectColumns = "db_id, org_id, `role`, db_host, db_port, db_user, db_password, " +
+	"db_name, db_tls, max_tenants, tenant_count, status"
+
+// RegisterSharedDB registers a physical database in db_pool, upserting on the
+// uk_db_pool_endpoint (org_id, db_host, db_name) natural key. On a duplicate
+// endpoint the connection fields are refreshed and tenant_count is preserved;
+// the existing db_id is re-fetched and returned.
+func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "register_shared_db", start, &err)
+	if in == nil {
+		return 0, fmt.Errorf("shared db is required")
+	}
+	if in.Host == "" {
+		return 0, fmt.Errorf("db host is required")
+	}
+	if in.Port <= 0 {
+		return 0, fmt.Errorf("db port must be positive")
+	}
+	if in.User == "" {
+		return 0, fmt.Errorf("db user is required")
+	}
+	if len(in.PasswordCipher) == 0 {
+		return 0, fmt.Errorf("db password cipher is required")
+	}
+	if in.Name == "" {
+		return 0, fmt.Errorf("db name is required")
+	}
+	if in.MaxTenants < 0 {
+		return 0, fmt.Errorf("max tenants must not be negative")
+	}
+	role := in.Role
+	if role == "" {
+		role = SharedDBRoleShared
+	}
+	if role != SharedDBRoleShared {
+		return 0, fmt.Errorf("unsupported db role %q", role)
+	}
+	status := in.Status
+	if status == "" {
+		status = sharedDBStatusActive
+	}
+	if _, err := s.db.ExecContext(ctx,
+		"INSERT INTO db_pool (org_id, `role`, db_host, db_port, db_user, db_password, db_name, "+
+			"db_tls, max_tenants, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "+
+			"ON DUPLICATE KEY UPDATE db_port = VALUES(db_port), db_user = VALUES(db_user), "+
+			"db_password = VALUES(db_password), db_tls = VALUES(db_tls), "+
+			"max_tenants = VALUES(max_tenants), status = VALUES(status)",
+		in.OrgID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
+		boolToInt(in.TLS), in.MaxTenants, status); err != nil {
+		return 0, fmt.Errorf("upsert db_pool row: %w", err)
+	}
+	// ON DUPLICATE KEY UPDATE does not reliably report the existing
+	// auto-increment id via LastInsertId, so re-fetch by endpoint.
+	err = s.db.QueryRowContext(ctx,
+		`SELECT db_id FROM db_pool WHERE org_id = ? AND db_host = ? AND db_name = ?`,
+		in.OrgID, in.Host, in.Name).Scan(&dbID)
+	if err != nil {
+		return 0, fmt.Errorf("resolve db_id after upsert: %w", err)
+	}
+	return dbID, nil
+}
+
+// GetSharedDB returns the db_pool row for dbID, or ErrNotFound.
+func (s *Store) GetSharedDB(ctx context.Context, dbID int64) (db *SharedDB, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "get_shared_db", start, &err)
+	if dbID <= 0 {
+		return nil, fmt.Errorf("db_id must be positive")
+	}
+	db, err = scanSharedDBRow(s.db.QueryRowContext(ctx,
+		"SELECT "+sharedDBSelectColumns+" FROM db_pool WHERE db_id = ?", dbID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get shared db %d: %w", dbID, err)
+	}
+	return db, nil
+}
+
+// FindSharedDBForOrg returns the active shared database serving orgID: an
+// exact org_id match wins over the '*' wildcard row. An empty orgID matches
+// only the wildcard row. Returns ErrNotFound when neither exists.
+func (s *Store) FindSharedDBForOrg(ctx context.Context, orgID string) (db *SharedDB, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "find_shared_db_for_org", start, &err)
+	if orgID != "" && orgID != SharedDBOrgWildcard {
+		db, err = s.findActiveSharedDB(ctx, orgID)
+		if err == nil {
+			return db, nil
+		}
+		if !errors.Is(err, ErrNotFound) {
+			return nil, err
+		}
+	}
+	db, err = s.findActiveSharedDB(ctx, SharedDBOrgWildcard)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	return db, nil
+}
+
+func (s *Store) findActiveSharedDB(ctx context.Context, orgID string) (*SharedDB, error) {
+	db, err := scanSharedDBRow(s.db.QueryRowContext(ctx,
+		"SELECT "+sharedDBSelectColumns+" FROM db_pool "+
+			"WHERE org_id = ? AND `role` = ? AND status = ? ORDER BY db_id LIMIT 1",
+		orgID, SharedDBRoleShared, sharedDBStatusActive))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find shared db for org %q: %w", orgID, err)
+	}
+	return db, nil
+}
+
+// ListSharedDBs returns all active db_pool rows ordered by db_id.
+func (s *Store) ListSharedDBs(ctx context.Context) (out []*SharedDB, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_shared_dbs", start, &err)
+	rows, err := s.db.QueryContext(ctx,
+		"SELECT "+sharedDBSelectColumns+" FROM db_pool WHERE status = ? ORDER BY db_id",
+		sharedDBStatusActive)
+	if err != nil {
+		return nil, fmt.Errorf("list shared dbs: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var rec SharedDB
+		var tls int
+		if err = rows.Scan(&rec.DbID, &rec.OrgID, &rec.Role, &rec.Host, &rec.Port, &rec.User,
+			&rec.PasswordCipher, &rec.Name, &tls, &rec.MaxTenants, &rec.TenantCount, &rec.Status); err != nil {
+			return nil, err
+		}
+		rec.TLS = tls == 1
+		out = append(out, &rec)
+	}
+	return out, rows.Err()
+}
+
+// IncrSharedDBTenantCount adjusts the denormalized tenant_count of a db_pool
+// row by delta (negative to decrement), clamped at >= 0. Returns ErrNotFound
+// when dbID is unknown.
+func (s *Store) IncrSharedDBTenantCount(ctx context.Context, dbID int64, delta int) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "incr_shared_db_tenant_count", start, &err)
+	if dbID <= 0 {
+		return fmt.Errorf("db_id must be positive")
+	}
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE db_pool SET tenant_count = GREATEST(tenant_count + ?, 0) WHERE db_id = ?`,
+		delta, dbID)
+	if err != nil {
+		return fmt.Errorf("adjust tenant_count for db %d: %w", dbID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("tenant_count rows affected for db %d: %w", dbID, err)
+	}
+	if affected > 0 {
+		return nil
+	}
+	// MySQL reports 0 affected rows when the value did not change (delta 0 or
+	// a clamp no-op); confirm the row exists before reporting success.
+	var one int
+	err = s.db.QueryRowContext(ctx, `SELECT 1 FROM db_pool WHERE db_id = ?`, dbID).Scan(&one)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("check shared db %d: %w", dbID, err)
+	}
+	return nil
+}
+
+// UpsertTenantPlacement records or replaces the placement of a filesystem.
+// The epoch is left untouched by upserts: it stays at its default of 1 unless
+// a migration explicitly bumps it.
+func (s *Store) UpsertTenantPlacement(ctx context.Context, p *TenantPlacement) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "upsert_tenant_placement", start, &err)
+	if p == nil {
+		return fmt.Errorf("tenant placement is required")
+	}
+	if p.FsID <= 0 {
+		return fmt.Errorf("fs_id must be positive")
+	}
+	if p.DbID <= 0 {
+		return fmt.Errorf("db_id must be positive")
+	}
+	switch p.Placement {
+	case PlacementShared, PlacementDedicated:
+	default:
+		return fmt.Errorf("unsupported placement %q", p.Placement)
+	}
+	switch p.SchemaShape {
+	case SchemaShapeStandalone, SchemaShapeShared:
+	default:
+		return fmt.Errorf("unsupported schema shape %q", p.SchemaShape)
+	}
+	status := p.Status
+	if status == "" {
+		status = sharedDBStatusActive
+	}
+	var target any
+	if p.TargetDbID != nil {
+		target = *p.TargetDbID
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT INTO tenant_placements (fs_id, db_id, placement, schema_shape, status, target_db_id)
+			VALUES (?, ?, ?, ?, ?, ?)
+			ON DUPLICATE KEY UPDATE db_id = VALUES(db_id), placement = VALUES(placement),
+				schema_shape = VALUES(schema_shape), status = VALUES(status),
+				target_db_id = VALUES(target_db_id)`,
+		p.FsID, p.DbID, p.Placement, p.SchemaShape, status, target); err != nil {
+		return fmt.Errorf("upsert tenant placement for fs_id %d: %w", p.FsID, err)
+	}
+	return nil
+}
+
+// GetTenantPlacement returns the placement for fsID, or ErrNotFound. Callers
+// treat a missing row as "standalone, legacy path".
+func (s *Store) GetTenantPlacement(ctx context.Context, fsID int64) (p *TenantPlacement, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "get_tenant_placement", start, &err)
+	if fsID <= 0 {
+		return nil, fmt.Errorf("fs_id must be positive")
+	}
+	var target sql.NullInt64
+	p = &TenantPlacement{}
+	err = s.db.QueryRowContext(ctx,
+		`SELECT fs_id, db_id, placement, schema_shape, status, target_db_id, epoch
+			FROM tenant_placements WHERE fs_id = ?`, fsID).
+		Scan(&p.FsID, &p.DbID, &p.Placement, &p.SchemaShape, &p.Status, &target, &p.Epoch)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get tenant placement for fs_id %d: %w", fsID, err)
+	}
+	if target.Valid {
+		p.TargetDbID = &target.Int64
+	}
+	return p, nil
+}
+
+// DeleteTenantPlacement removes the placement for fsID. It is idempotent:
+// deleting an unknown fsID succeeds.
+func (s *Store) DeleteTenantPlacement(ctx context.Context, fsID int64) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_tenant_placement", start, &err)
+	if fsID <= 0 {
+		return fmt.Errorf("fs_id must be positive")
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`DELETE FROM tenant_placements WHERE fs_id = ?`, fsID); err != nil {
+		return fmt.Errorf("delete tenant placement for fs_id %d: %w", fsID, err)
+	}
+	return nil
+}
+
+// scanSharedDBRow scans one db_pool row selected with sharedDBSelectColumns.
+func scanSharedDBRow(row *sql.Row) (*SharedDB, error) {
+	var rec SharedDB
+	var tls int
+	if err := row.Scan(&rec.DbID, &rec.OrgID, &rec.Role, &rec.Host, &rec.Port, &rec.User,
+		&rec.PasswordCipher, &rec.Name, &tls, &rec.MaxTenants, &rec.TenantCount, &rec.Status); err != nil {
+		return nil, err
+	}
+	rec.TLS = tls == 1
+	return &rec, nil
+}

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -640,3 +640,53 @@ func TestDeleteTenantPlacementAndDecrCountIsAtomic(t *testing.T) {
 		t.Fatalf("placement must survive rolled-back delete: %v", err)
 	}
 }
+
+// TestCompleteSharedTenantProvisionRollsBackOnKeyFailure covers the named
+// failure class from review: the owner key insert fails (duplicate key id)
+// inside the provision transaction, so the capacity reservation, the
+// placement, AND the active/provider transition must all roll back with it —
+// the tenant can never be left active without its placement and key.
+func TestCompleteSharedTenantProvisionRollsBackOnKeyFailure(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		OrgID: "org-keyfail", Host: "h", Port: 4000, User: "u",
+		PasswordCipher: []byte("c"), Name: "keyfail_db",
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	seedPendingTenant(t, s, "tenant-keyfail")
+	fsID, err := s.EnsureFsID(ctx, "tenant-keyfail")
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	// Pre-insert a key with the same id, so the tx's key insert duplicates.
+	if err := s.InsertAPIKey(ctx, testOwnerKey("tenant-keyfail")); err != nil {
+		t.Fatalf("seed duplicate key: %v", err)
+	}
+	err = s.CompleteSharedTenantProvision(ctx, "tenant-keyfail", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-keyfail"))
+	if !errors.Is(err, ErrDuplicate) {
+		t.Fatalf("provision error = %v, want ErrDuplicate", err)
+	}
+	tenant, err := s.GetTenant(ctx, "tenant-keyfail")
+	if err != nil {
+		t.Fatalf("GetTenant: %v", err)
+	}
+	if tenant.Provider != "tidb_cloud_native" || tenant.Status != TenantPending {
+		t.Fatalf("tenant = provider %q status %q, want unchanged tidb_cloud_native/pending", tenant.Provider, tenant.Status)
+	}
+	if _, err := s.GetTenantPlacement(ctx, fsID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("placement after key-failure rollback = %v, want ErrNotFound", err)
+	}
+	db, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if db.TenantCount != 0 {
+		t.Fatalf("TenantCount = %d, want 0 after key-failure rollback", db.TenantCount)
+	}
+}

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -1,0 +1,367 @@
+package meta
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func registerTestSharedDB(t *testing.T, s *Store, orgID, host, name string) int64 {
+	t.Helper()
+	id, err := s.RegisterSharedDB(context.Background(), &SharedDB{
+		OrgID:          orgID,
+		Host:           host,
+		Port:           4000,
+		User:           "root",
+		PasswordCipher: []byte("cipher-" + name),
+		Name:           name,
+		TLS:            true,
+		MaxTenants:     100,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB %s/%s: %v", orgID, name, err)
+	}
+	if id <= 0 {
+		t.Fatalf("RegisterSharedDB %s/%s returned db_id = %d, want positive", orgID, name, id)
+	}
+	return id
+}
+
+func TestRegisterSharedDBRoundTrip(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	id := registerTestSharedDB(t, s, "org-a", "shared-a.example.com", "shared_db_a")
+
+	got, err := s.GetSharedDB(ctx, id)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.DbID != id {
+		t.Fatalf("DbID = %d, want %d", got.DbID, id)
+	}
+	if got.OrgID != "org-a" {
+		t.Fatalf("OrgID = %q, want org-a", got.OrgID)
+	}
+	if got.Role != SharedDBRoleShared {
+		t.Fatalf("Role = %q, want %q", got.Role, SharedDBRoleShared)
+	}
+	if got.Host != "shared-a.example.com" {
+		t.Fatalf("Host = %q, want shared-a.example.com", got.Host)
+	}
+	if got.Port != 4000 {
+		t.Fatalf("Port = %d, want 4000", got.Port)
+	}
+	if got.User != "root" {
+		t.Fatalf("User = %q, want root", got.User)
+	}
+	if string(got.PasswordCipher) != "cipher-shared_db_a" {
+		t.Fatalf("PasswordCipher = %q, want cipher-shared_db_a", got.PasswordCipher)
+	}
+	if got.Name != "shared_db_a" {
+		t.Fatalf("Name = %q, want shared_db_a", got.Name)
+	}
+	if !got.TLS {
+		t.Fatal("TLS = false, want true")
+	}
+	if got.MaxTenants != 100 {
+		t.Fatalf("MaxTenants = %d, want 100", got.MaxTenants)
+	}
+	if got.TenantCount != 0 {
+		t.Fatalf("TenantCount = %d, want 0", got.TenantCount)
+	}
+	if got.Status != sharedDBStatusActive {
+		t.Fatalf("Status = %q, want active", got.Status)
+	}
+
+	if _, err := s.GetSharedDB(ctx, id+100000); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetSharedDB unknown id error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	first := registerTestSharedDB(t, s, "org-a", "shared-a.example.com", "shared_db_a")
+	if err := s.IncrSharedDBTenantCount(ctx, first, 3); err != nil {
+		t.Fatalf("IncrSharedDBTenantCount: %v", err)
+	}
+
+	second, err := s.RegisterSharedDB(ctx, &SharedDB{
+		OrgID:          "org-a",
+		Host:           "shared-a.example.com",
+		Port:           5000,
+		User:           "app",
+		PasswordCipher: []byte("rotated-cipher"),
+		Name:           "shared_db_a",
+		TLS:            false,
+		MaxTenants:     200,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB upsert: %v", err)
+	}
+	if second != first {
+		t.Fatalf("upsert allocated new db_id %d, want existing %d", second, first)
+	}
+
+	got, err := s.GetSharedDB(ctx, first)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.Port != 5000 || got.User != "app" || string(got.PasswordCipher) != "rotated-cipher" ||
+		got.MaxTenants != 200 || got.TLS {
+		t.Fatalf("upsert did not refresh connection fields: %+v", got)
+	}
+	if got.TenantCount != 3 {
+		t.Fatalf("TenantCount = %d, want preserved 3", got.TenantCount)
+	}
+}
+
+func TestRegisterSharedDBValidation(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	valid := func() *SharedDB {
+		return &SharedDB{
+			OrgID:          "org-a",
+			Host:           "h",
+			Port:           4000,
+			User:           "u",
+			PasswordCipher: []byte("c"),
+			Name:           "n",
+		}
+	}
+	cases := map[string]func(*SharedDB){
+		"missing host":      func(d *SharedDB) { d.Host = "" },
+		"non-positive port": func(d *SharedDB) { d.Port = 0 },
+		"missing user":      func(d *SharedDB) { d.User = "" },
+		"missing password":  func(d *SharedDB) { d.PasswordCipher = nil },
+		"missing name":      func(d *SharedDB) { d.Name = "" },
+		"negative max":      func(d *SharedDB) { d.MaxTenants = -1 },
+		"reserved role":     func(d *SharedDB) { d.Role = "dedicated" },
+	}
+	for name, mutate := range cases {
+		in := valid()
+		mutate(in)
+		if _, err := s.RegisterSharedDB(ctx, in); err == nil {
+			t.Fatalf("%s: expected error, got nil", name)
+		}
+	}
+}
+
+func TestFindSharedDBForOrgExactThenWildcard(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	orgID := registerTestSharedDB(t, s, "org-exact", "shared-exact.example.com", "shared_db_exact")
+	wildID := registerTestSharedDB(t, s, SharedDBOrgWildcard, "shared-wild.example.com", "shared_db_wild")
+
+	got, err := s.FindSharedDBForOrg(ctx, "org-exact")
+	if err != nil {
+		t.Fatalf("FindSharedDBForOrg exact: %v", err)
+	}
+	if got.DbID != orgID {
+		t.Fatalf("exact match db_id = %d, want %d", got.DbID, orgID)
+	}
+
+	got, err = s.FindSharedDBForOrg(ctx, "org-other")
+	if err != nil {
+		t.Fatalf("FindSharedDBForOrg fallback: %v", err)
+	}
+	if got.DbID != wildID {
+		t.Fatalf("wildcard fallback db_id = %d, want %d", got.DbID, wildID)
+	}
+
+	got, err = s.FindSharedDBForOrg(ctx, "")
+	if err != nil {
+		t.Fatalf("FindSharedDBForOrg empty org: %v", err)
+	}
+	if got.DbID != wildID {
+		t.Fatalf("empty org db_id = %d, want wildcard %d", got.DbID, wildID)
+	}
+}
+
+func TestFindSharedDBForOrgNotFound(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	registerTestSharedDB(t, s, "org-exact", "shared-exact.example.com", "shared_db_exact")
+
+	if _, err := s.FindSharedDBForOrg(ctx, "org-missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("FindSharedDBForOrg miss error = %v, want ErrNotFound", err)
+	}
+	if _, err := s.FindSharedDBForOrg(ctx, ""); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("FindSharedDBForOrg empty org error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestListSharedDBs(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	first := registerTestSharedDB(t, s, "org-a", "shared-a.example.com", "shared_db_a")
+	second := registerTestSharedDB(t, s, SharedDBOrgWildcard, "shared-wild.example.com", "shared_db_wild")
+	// A non-active row must not appear in the list.
+	if _, err := s.RegisterSharedDB(ctx, &SharedDB{
+		OrgID:          "org-b",
+		Host:           "shared-draining.example.com",
+		Port:           4000,
+		User:           "root",
+		PasswordCipher: []byte("cipher"),
+		Name:           "shared_db_draining",
+		Status:         "draining",
+	}); err != nil {
+		t.Fatalf("RegisterSharedDB draining: %v", err)
+	}
+
+	list, err := s.ListSharedDBs(ctx)
+	if err != nil {
+		t.Fatalf("ListSharedDBs: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("ListSharedDBs returned %d rows, want 2", len(list))
+	}
+	if list[0].DbID != first || list[1].DbID != second {
+		t.Fatalf("ListSharedDBs order = [%d %d], want [%d %d]",
+			list[0].DbID, list[1].DbID, first, second)
+	}
+}
+
+func TestIncrSharedDBTenantCountClampsAtZero(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	id := registerTestSharedDB(t, s, "org-a", "shared-a.example.com", "shared_db_a")
+
+	wantCount := func(want int) {
+		t.Helper()
+		got, err := s.GetSharedDB(ctx, id)
+		if err != nil {
+			t.Fatalf("GetSharedDB: %v", err)
+		}
+		if got.TenantCount != want {
+			t.Fatalf("TenantCount = %d, want %d", got.TenantCount, want)
+		}
+	}
+
+	if err := s.IncrSharedDBTenantCount(ctx, id, 5); err != nil {
+		t.Fatalf("IncrSharedDBTenantCount +5: %v", err)
+	}
+	wantCount(5)
+	if err := s.IncrSharedDBTenantCount(ctx, id, -2); err != nil {
+		t.Fatalf("IncrSharedDBTenantCount -2: %v", err)
+	}
+	wantCount(3)
+	if err := s.IncrSharedDBTenantCount(ctx, id, -10); err != nil {
+		t.Fatalf("IncrSharedDBTenantCount -10: %v", err)
+	}
+	wantCount(0)
+
+	if err := s.IncrSharedDBTenantCount(ctx, id+100000, 1); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("IncrSharedDBTenantCount unknown db error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestTenantPlacementUpsertGetDelete(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	p := &TenantPlacement{
+		FsID:        42,
+		DbID:        7,
+		Placement:   PlacementShared,
+		SchemaShape: SchemaShapeShared,
+	}
+	if err := s.UpsertTenantPlacement(ctx, p); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+
+	got, err := s.GetTenantPlacement(ctx, 42)
+	if err != nil {
+		t.Fatalf("GetTenantPlacement: %v", err)
+	}
+	if got.FsID != 42 || got.DbID != 7 || got.Placement != PlacementShared ||
+		got.SchemaShape != SchemaShapeShared {
+		t.Fatalf("placement mismatch: %+v", got)
+	}
+	if got.Status != sharedDBStatusActive {
+		t.Fatalf("Status = %q, want active", got.Status)
+	}
+	if got.TargetDbID != nil {
+		t.Fatalf("TargetDbID = %v, want nil", *got.TargetDbID)
+	}
+	if got.Epoch != 1 {
+		t.Fatalf("Epoch = %d, want 1", got.Epoch)
+	}
+
+	// Re-upsert replaces the mutable fields; the epoch stays at 1.
+	target := int64(9)
+	if err := s.UpsertTenantPlacement(ctx, &TenantPlacement{
+		FsID:        42,
+		DbID:        8,
+		Placement:   PlacementDedicated,
+		SchemaShape: SchemaShapeStandalone,
+		TargetDbID:  &target,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement replace: %v", err)
+	}
+	got, err = s.GetTenantPlacement(ctx, 42)
+	if err != nil {
+		t.Fatalf("GetTenantPlacement after replace: %v", err)
+	}
+	if got.DbID != 8 || got.Placement != PlacementDedicated || got.SchemaShape != SchemaShapeStandalone {
+		t.Fatalf("replaced placement mismatch: %+v", got)
+	}
+	if got.TargetDbID == nil || *got.TargetDbID != 9 {
+		t.Fatalf("TargetDbID = %v, want 9", got.TargetDbID)
+	}
+	if got.Epoch != 1 {
+		t.Fatalf("Epoch after replace = %d, want 1", got.Epoch)
+	}
+
+	if err := s.DeleteTenantPlacement(ctx, 42); err != nil {
+		t.Fatalf("DeleteTenantPlacement: %v", err)
+	}
+	if _, err := s.GetTenantPlacement(ctx, 42); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetTenantPlacement after delete error = %v, want ErrNotFound", err)
+	}
+	// Delete is idempotent.
+	if err := s.DeleteTenantPlacement(ctx, 42); err != nil {
+		t.Fatalf("DeleteTenantPlacement again: %v", err)
+	}
+}
+
+func TestTenantPlacementValidation(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	valid := func() *TenantPlacement {
+		return &TenantPlacement{
+			FsID:        1,
+			DbID:        1,
+			Placement:   PlacementShared,
+			SchemaShape: SchemaShapeShared,
+		}
+	}
+	cases := map[string]func(*TenantPlacement){
+		"non-positive fs_id":   func(p *TenantPlacement) { p.FsID = 0 },
+		"non-positive db_id":   func(p *TenantPlacement) { p.DbID = 0 },
+		"unknown placement":    func(p *TenantPlacement) { p.Placement = "bogus" },
+		"unknown schema shape": func(p *TenantPlacement) { p.SchemaShape = "bogus" },
+	}
+	for name, mutate := range cases {
+		p := valid()
+		mutate(p)
+		if err := s.UpsertTenantPlacement(ctx, p); err == nil {
+			t.Fatalf("%s: expected error, got nil", name)
+		}
+	}
+}
+
+func TestGetTenantPlacementNotFound(t *testing.T) {
+	s := newControlStore(t)
+	if _, err := s.GetTenantPlacement(context.Background(), 123456); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetTenantPlacement error = %v, want ErrNotFound", err)
+	}
+}

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 )
 
 func registerTestSharedDB(t *testing.T, s *Store, orgID, host, name string) int64 {
@@ -415,45 +416,172 @@ func TestGetTenantPlacementNotFound(t *testing.T) {
 	}
 }
 
-func TestReserveSharedDBPlacementEnforcesCapacityAtomically(t *testing.T) {
+func seedPendingTenant(t *testing.T, s *Store, tenantID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := s.InsertTenant(context.Background(), &Tenant{
+		ID: tenantID, Status: TenantPending, Provider: "tidb_cloud_native",
+		DBPasswordCipher: []byte{}, SchemaVersion: 1, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("InsertTenant: %v", err)
+	}
+}
+
+func testOwnerKey(tenantID string) *APIKey {
+	now := time.Now().UTC()
+	return &APIKey{
+		ID: "key-" + tenantID, TenantID: tenantID, KeyName: "default",
+		JWTCiphertext: []byte("cipher-" + tenantID), JWTHash: "hash-" + tenantID,
+		TokenVersion: 1, Status: APIKeyActive, ScopeKind: APIKeyScopeKindOwner,
+		IssuedAt: now, CreatedAt: now, UpdatedAt: now,
+	}
+}
+
+func TestCompleteSharedTenantProvisionCommitsAtomically(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 
 	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
-		OrgID: "org-reserve", Host: "h", Port: 4000, User: "u",
-		PasswordCipher: []byte("c"), Name: "reserve_db", MaxTenants: 2,
+		OrgID: "org-complete", Host: "h", Port: 4000, User: "u",
+		PasswordCipher: []byte("c"), Name: "complete_db", MaxTenants: 5,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
 	}
-	reserve := func(fsID int64) error {
-		return s.ReserveSharedDBPlacement(ctx, &TenantPlacement{
-			FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
-		})
+	seedPendingTenant(t, s, "tenant-complete-1")
+	fsID, err := s.EnsureFsID(ctx, "tenant-complete-1")
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
 	}
-	if err := reserve(101); err != nil {
-		t.Fatalf("reserve 101: %v", err)
+	if err := s.CompleteSharedTenantProvision(ctx, "tenant-complete-1", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-complete-1")); err != nil {
+		t.Fatalf("CompleteSharedTenantProvision: %v", err)
 	}
-	if err := reserve(102); err != nil {
-		t.Fatalf("reserve 102: %v", err)
+
+	tenant, err := s.GetTenant(ctx, "tenant-complete-1")
+	if err != nil {
+		t.Fatalf("GetTenant: %v", err)
 	}
-	// The third reservation exceeds max_tenants=2 and must fail without
-	// writing a placement row.
-	if err := reserve(103); !errors.Is(err, ErrSharedDBCapacityExhausted) {
-		t.Fatalf("reserve 103 error = %v, want ErrSharedDBCapacityExhausted", err)
+	if tenant.Provider != "tidb_cloud_native_shared" || tenant.Status != TenantActive {
+		t.Fatalf("tenant = provider %q status %q, want tidb_cloud_native_shared/active", tenant.Provider, tenant.Status)
 	}
-	if _, err := s.GetTenantPlacement(ctx, 103); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("placement 103 after failed reserve = %v, want ErrNotFound", err)
+	p, err := s.GetTenantPlacement(ctx, fsID)
+	if err != nil {
+		t.Fatalf("GetTenantPlacement: %v", err)
 	}
-	got, err := s.GetSharedDB(ctx, dbID)
+	if p.DbID != dbID || p.Placement != PlacementShared {
+		t.Fatalf("placement = %+v", p)
+	}
+	db, err := s.GetSharedDB(ctx, dbID)
 	if err != nil {
 		t.Fatalf("GetSharedDB: %v", err)
 	}
-	if got.TenantCount != 2 {
-		t.Fatalf("TenantCount = %d, want 2 (no leak from failed reserve)", got.TenantCount)
+	if db.TenantCount != 1 {
+		t.Fatalf("TenantCount = %d, want 1", db.TenantCount)
 	}
-	if _, err := s.GetTenantPlacement(ctx, 101); err != nil {
-		t.Fatalf("placement 101 missing after successful reserve: %v", err)
+	var keyCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ?`, "tenant-complete-1").Scan(&keyCount); err != nil {
+		t.Fatal(err)
+	}
+	if keyCount != 1 {
+		t.Fatalf("owner keys = %d, want 1", keyCount)
+	}
+}
+
+func TestCompleteSharedTenantProvisionCapacityExhaustedLeavesNoPartialState(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		OrgID: "org-capped", Host: "h", Port: 4000, User: "u",
+		PasswordCipher: []byte("c"), Name: "capped_db", MaxTenants: 1,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	seedPendingTenant(t, s, "tenant-cap-1")
+	seedPendingTenant(t, s, "tenant-cap-2")
+	fs1, _ := s.EnsureFsID(ctx, "tenant-cap-1")
+	fs2, _ := s.EnsureFsID(ctx, "tenant-cap-2")
+	if err := s.CompleteSharedTenantProvision(ctx, "tenant-cap-1", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fs1, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-cap-1")); err != nil {
+		t.Fatalf("first provision: %v", err)
+	}
+	err = s.CompleteSharedTenantProvision(ctx, "tenant-cap-2", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fs2, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-cap-2"))
+	if !errors.Is(err, ErrSharedDBCapacityExhausted) {
+		t.Fatalf("second provision error = %v, want ErrSharedDBCapacityExhausted", err)
+	}
+
+	// Nothing of the losing provision may persist.
+	if _, err := s.GetTenantPlacement(ctx, fs2); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("loser placement = %v, want ErrNotFound", err)
+	}
+	tenant, err := s.GetTenant(ctx, "tenant-cap-2")
+	if err != nil {
+		t.Fatalf("GetTenant: %v", err)
+	}
+	if tenant.Provider != "tidb_cloud_native" || tenant.Status != TenantPending {
+		t.Fatalf("loser tenant = provider %q status %q, want unchanged tidb_cloud_native/pending", tenant.Provider, tenant.Status)
+	}
+	var keyCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ?`, "tenant-cap-2").Scan(&keyCount); err != nil {
+		t.Fatal(err)
+	}
+	if keyCount != 0 {
+		t.Fatalf("loser owner keys = %d, want 0", keyCount)
+	}
+	db, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if db.TenantCount != 1 {
+		t.Fatalf("TenantCount = %d, want 1 (no leak)", db.TenantCount)
+	}
+}
+
+func TestCompleteSharedTenantProvisionRollsBackOnMissingTenant(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		OrgID: "org-rollback", Host: "h", Port: 4000, User: "u",
+		PasswordCipher: []byte("c"), Name: "rollback_db",
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	fsID, err := s.EnsureFsID(ctx, "tenant-ghost")
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	// No tenant row for tenant-ghost: the tenant update fails and the whole
+	// transaction must roll back — no placement, no capacity, no key.
+	err = s.CompleteSharedTenantProvision(ctx, "tenant-ghost", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-ghost"))
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("provision error = %v, want ErrNotFound", err)
+	}
+	if _, err := s.GetTenantPlacement(ctx, fsID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("placement after rollback = %v, want ErrNotFound", err)
+	}
+	db, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if db.TenantCount != 0 {
+		t.Fatalf("TenantCount = %d, want 0 after rollback", db.TenantCount)
+	}
+	var keyCount int
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ?`, "tenant-ghost").Scan(&keyCount); err != nil {
+		t.Fatal(err)
+	}
+	if keyCount != 0 {
+		t.Fatalf("owner keys after rollback = %d, want 0", keyCount)
 	}
 }
 
@@ -468,16 +596,21 @@ func TestDeleteTenantPlacementAndDecrCountIsAtomic(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
 	}
-	if err := s.ReserveSharedDBPlacement(ctx, &TenantPlacement{
-		FsID: 201, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
-	}); err != nil {
-		t.Fatalf("reserve: %v", err)
+	seedPendingTenant(t, s, "tenant-release-1")
+	fsID, err := s.EnsureFsID(ctx, "tenant-release-1")
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if err := s.CompleteSharedTenantProvision(ctx, "tenant-release-1", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-release-1")); err != nil {
+		t.Fatalf("provision: %v", err)
 	}
 
-	if err := s.DeleteTenantPlacementAndDecrCount(ctx, 201, dbID); err != nil {
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, fsID, dbID); err != nil {
 		t.Fatalf("DeleteTenantPlacementAndDecrCount: %v", err)
 	}
-	if _, err := s.GetTenantPlacement(ctx, 201); !errors.Is(err, ErrNotFound) {
+	if _, err := s.GetTenantPlacement(ctx, fsID); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("placement after delete = %v, want ErrNotFound", err)
 	}
 	got, err := s.GetSharedDB(ctx, dbID)

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -15,7 +15,7 @@ func registerTestSharedDB(t *testing.T, s *Store, orgID, host, name string) int6
 		User:           "root",
 		PasswordCipher: []byte("cipher-" + name),
 		Name:           name,
-		TLS:            true,
+		TLSMode:        "skip-verify",
 		MaxTenants:     100,
 	})
 	if err != nil {
@@ -61,8 +61,8 @@ func TestRegisterSharedDBRoundTrip(t *testing.T) {
 	if got.Name != "shared_db_a" {
 		t.Fatalf("Name = %q, want shared_db_a", got.Name)
 	}
-	if !got.TLS {
-		t.Fatal("TLS = false, want true")
+	if got.TLSMode != "skip-verify" {
+		t.Fatalf("TLSMode = %q, want skip-verify", got.TLSMode)
 	}
 	if got.MaxTenants != 100 {
 		t.Fatalf("MaxTenants = %d, want 100", got.MaxTenants)
@@ -95,7 +95,7 @@ func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 		User:           "app",
 		PasswordCipher: []byte("rotated-cipher"),
 		Name:           "shared_db_a",
-		TLS:            false,
+		TLSMode:        "true",
 		MaxTenants:     200,
 	})
 	if err != nil {
@@ -110,7 +110,7 @@ func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 		t.Fatalf("GetSharedDB: %v", err)
 	}
 	if got.Port != 5000 || got.User != "app" || string(got.PasswordCipher) != "rotated-cipher" ||
-		got.MaxTenants != 200 || got.TLS {
+		got.MaxTenants != 200 || got.TLSMode != "true" {
 		t.Fatalf("upsert did not refresh connection fields: %+v", got)
 	}
 	if got.TenantCount != 3 {
@@ -349,6 +349,7 @@ func TestTenantPlacementValidation(t *testing.T) {
 		"non-positive db_id":   func(p *TenantPlacement) { p.DbID = 0 },
 		"unknown placement":    func(p *TenantPlacement) { p.Placement = "bogus" },
 		"unknown schema shape": func(p *TenantPlacement) { p.SchemaShape = "bogus" },
+		"unknown status":       func(p *TenantPlacement) { p.Status = "bogus" },
 	}
 	for name, mutate := range cases {
 		p := valid()
@@ -356,6 +357,54 @@ func TestTenantPlacementValidation(t *testing.T) {
 		if err := s.UpsertTenantPlacement(ctx, p); err == nil {
 			t.Fatalf("%s: expected error, got nil", name)
 		}
+	}
+}
+
+func TestFindSharedDBForOrgSkipsFullPools(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	// The exact-org pool is capped at 1 tenant; once full, selection must
+	// fall through to the wildcard pool rather than overfill it.
+	fullID := registerTestSharedDB(t, s, "org-capped", "shared-capped.example.com", "shared_db_capped")
+	if _, err := s.RegisterSharedDB(ctx, &SharedDB{
+		OrgID:          "org-capped",
+		Host:           "shared-capped.example.com",
+		Port:           4000,
+		User:           "root",
+		PasswordCipher: []byte("cipher"),
+		Name:           "shared_db_capped",
+		MaxTenants:     1,
+	}); err != nil {
+		t.Fatalf("cap pool at 1: %v", err)
+	}
+	wildID := registerTestSharedDB(t, s, SharedDBOrgWildcard, "shared-wild.example.com", "shared_db_wild")
+
+	got, err := s.FindSharedDBForOrg(ctx, "org-capped")
+	if err != nil {
+		t.Fatalf("FindSharedDBForOrg before full: %v", err)
+	}
+	if got.DbID != fullID {
+		t.Fatalf("before full db_id = %d, want exact pool %d", got.DbID, fullID)
+	}
+
+	if err := s.IncrSharedDBTenantCount(ctx, fullID, 1); err != nil {
+		t.Fatalf("fill pool: %v", err)
+	}
+	got, err = s.FindSharedDBForOrg(ctx, "org-capped")
+	if err != nil {
+		t.Fatalf("FindSharedDBForOrg after full: %v", err)
+	}
+	if got.DbID != wildID {
+		t.Fatalf("after full db_id = %d, want wildcard %d", got.DbID, wildID)
+	}
+
+	// With no wildcard fallback, a full pool reads as not found.
+	if _, err := s.db.Exec(`DELETE FROM db_pool WHERE db_id = ?`, wildID); err != nil {
+		t.Fatalf("remove wildcard: %v", err)
+	}
+	if _, err := s.FindSharedDBForOrg(ctx, "org-capped"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("full pool without fallback error = %v, want ErrNotFound", err)
 	}
 }
 

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -414,3 +414,96 @@ func TestGetTenantPlacementNotFound(t *testing.T) {
 		t.Fatalf("GetTenantPlacement error = %v, want ErrNotFound", err)
 	}
 }
+
+func TestReserveSharedDBPlacementEnforcesCapacityAtomically(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		OrgID: "org-reserve", Host: "h", Port: 4000, User: "u",
+		PasswordCipher: []byte("c"), Name: "reserve_db", MaxTenants: 2,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	reserve := func(fsID int64) error {
+		return s.ReserveSharedDBPlacement(ctx, &TenantPlacement{
+			FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+		})
+	}
+	if err := reserve(101); err != nil {
+		t.Fatalf("reserve 101: %v", err)
+	}
+	if err := reserve(102); err != nil {
+		t.Fatalf("reserve 102: %v", err)
+	}
+	// The third reservation exceeds max_tenants=2 and must fail without
+	// writing a placement row.
+	if err := reserve(103); !errors.Is(err, ErrSharedDBCapacityExhausted) {
+		t.Fatalf("reserve 103 error = %v, want ErrSharedDBCapacityExhausted", err)
+	}
+	if _, err := s.GetTenantPlacement(ctx, 103); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("placement 103 after failed reserve = %v, want ErrNotFound", err)
+	}
+	got, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.TenantCount != 2 {
+		t.Fatalf("TenantCount = %d, want 2 (no leak from failed reserve)", got.TenantCount)
+	}
+	if _, err := s.GetTenantPlacement(ctx, 101); err != nil {
+		t.Fatalf("placement 101 missing after successful reserve: %v", err)
+	}
+}
+
+func TestDeleteTenantPlacementAndDecrCountIsAtomic(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		OrgID: "org-release", Host: "h", Port: 4000, User: "u",
+		PasswordCipher: []byte("c"), Name: "release_db",
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	if err := s.ReserveSharedDBPlacement(ctx, &TenantPlacement{
+		FsID: 201, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("reserve: %v", err)
+	}
+
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, 201, dbID); err != nil {
+		t.Fatalf("DeleteTenantPlacementAndDecrCount: %v", err)
+	}
+	if _, err := s.GetTenantPlacement(ctx, 201); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("placement after delete = %v, want ErrNotFound", err)
+	}
+	got, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.TenantCount != 0 {
+		t.Fatalf("TenantCount = %d, want 0", got.TenantCount)
+	}
+
+	// Missing placement: ErrNotFound.
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, 299, dbID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("delete missing placement error = %v, want ErrNotFound", err)
+	}
+
+	// When the pool row is gone, the whole tx must roll back: the placement
+	// row survives so the caller can retry instead of orphaning it.
+	if err := s.UpsertTenantPlacement(ctx, &TenantPlacement{
+		FsID: 301, DbID: dbID + 999, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("seed orphan-candidate placement: %v", err)
+	}
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, 301, dbID+999); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("delete with missing pool error = %v, want ErrNotFound", err)
+	}
+	if _, err := s.GetTenantPlacement(ctx, 301); err != nil {
+		t.Fatalf("placement must survive rolled-back delete: %v", err)
+	}
+}

--- a/pkg/meta/fs_registry.go
+++ b/pkg/meta/fs_registry.go
@@ -8,6 +8,26 @@ import (
 	"time"
 )
 
+// withMetaLockConflictRetry runs fn with a few bounded retries on InnoDB
+// lock-conflict errors (1213/1205/40001), which are expected when concurrent
+// provision/Acquire paths allocate fs_ids for different tenants at the same
+// time (unique-index gap locks on fs_registry). Mirrors the retry pattern
+// used by the quota reservation path.
+func withMetaLockConflictRetry(fn func() error) error {
+	const maxAttempts = 4
+	var err error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		if err = fn(); err == nil {
+			return nil
+		}
+		if !isMetaLockConflictError(err) {
+			return err
+		}
+		time.Sleep(time.Duration(20*(1<<attempt)) * time.Millisecond)
+	}
+	return err
+}
+
 // EnsureFsID returns the internal numeric fs_id for tenantID, allocating a new
 // one on first call. The mapping is stable for the lifetime of the tenant and
 // is safe to call concurrently: allocation uses INSERT IGNORE against the
@@ -25,8 +45,11 @@ func (s *Store) EnsureFsID(ctx context.Context, tenantID string) (fsID int64, er
 	if !errors.Is(err, ErrNotFound) {
 		return 0, err
 	}
-	if _, err := s.db.ExecContext(ctx,
-		`INSERT IGNORE INTO fs_registry (tenant_id) VALUES (?)`, tenantID); err != nil {
+	if err := withMetaLockConflictRetry(func() error {
+		_, err := s.db.ExecContext(ctx,
+			`INSERT IGNORE INTO fs_registry (tenant_id) VALUES (?)`, tenantID)
+		return err
+	}); err != nil {
 		return 0, fmt.Errorf("insert fs_registry row: %w", err)
 	}
 	fsID, err = s.ResolveFsID(ctx, tenantID)

--- a/pkg/meta/fs_registry.go
+++ b/pkg/meta/fs_registry.go
@@ -1,0 +1,92 @@
+package meta
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// EnsureFsID returns the internal numeric fs_id for tenantID, allocating a new
+// one on first call. The mapping is stable for the lifetime of the tenant and
+// is safe to call concurrently: allocation uses INSERT IGNORE against the
+// UNIQUE tenant_id column, so a losing racer re-reads the winner's id.
+func (s *Store) EnsureFsID(ctx context.Context, tenantID string) (fsID int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "ensure_fs_id", start, &err)
+	if tenantID == "" {
+		return 0, fmt.Errorf("tenant id is required")
+	}
+	fsID, err = s.ResolveFsID(ctx, tenantID)
+	if err == nil {
+		return fsID, nil
+	}
+	if !errors.Is(err, ErrNotFound) {
+		return 0, err
+	}
+	if _, err := s.db.ExecContext(ctx,
+		`INSERT IGNORE INTO fs_registry (tenant_id) VALUES (?)`, tenantID); err != nil {
+		return 0, fmt.Errorf("insert fs_registry row: %w", err)
+	}
+	fsID, err = s.ResolveFsID(ctx, tenantID)
+	if err != nil {
+		return 0, fmt.Errorf("resolve fs_id after insert: %w", err)
+	}
+	return fsID, nil
+}
+
+// ResolveFsID returns the fs_id for tenantID, or ErrNotFound when the tenant
+// has not been registered yet.
+func (s *Store) ResolveFsID(ctx context.Context, tenantID string) (fsID int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "resolve_fs_id", start, &err)
+	if tenantID == "" {
+		return 0, fmt.Errorf("tenant id is required")
+	}
+	err = s.db.QueryRowContext(ctx,
+		`SELECT fs_id FROM fs_registry WHERE tenant_id = ?`, tenantID).Scan(&fsID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, ErrNotFound
+		}
+		return 0, fmt.Errorf("resolve fs_id for tenant %s: %w", tenantID, err)
+	}
+	return fsID, nil
+}
+
+// ResolveTenantID returns the tenant UUID for fsID, or ErrNotFound.
+func (s *Store) ResolveTenantID(ctx context.Context, fsID int64) (tenantID string, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "resolve_tenant_id", start, &err)
+	if fsID <= 0 {
+		return "", fmt.Errorf("fs_id must be positive")
+	}
+	err = s.db.QueryRowContext(ctx,
+		`SELECT tenant_id FROM fs_registry WHERE fs_id = ?`, fsID).Scan(&tenantID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrNotFound
+		}
+		return "", fmt.Errorf("resolve tenant for fs_id %d: %w", fsID, err)
+	}
+	return tenantID, nil
+}
+
+// BackfillFsRegistry registers every tenant that has no fs_id yet. It is
+// idempotent and intended to run once at startup (leader-gated) so existing
+// tenants are pre-allocated fs_ids before the routing layer needs them.
+func (s *Store) BackfillFsRegistry(ctx context.Context) (inserted int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "backfill_fs_registry", start, &err)
+	res, err := s.db.ExecContext(ctx,
+		`INSERT IGNORE INTO fs_registry (tenant_id) SELECT id FROM tenants`)
+	if err != nil {
+		return 0, fmt.Errorf("backfill fs_registry: %w", err)
+	}
+	inserted, err = res.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("backfill fs_registry rows affected: %w", err)
+	}
+	return inserted, nil
+}

--- a/pkg/meta/fs_registry.go
+++ b/pkg/meta/fs_registry.go
@@ -6,14 +6,18 @@ import (
 	"errors"
 	"fmt"
 	"time"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"go.uber.org/zap"
 )
 
 // withMetaLockConflictRetry runs fn with a few bounded retries on InnoDB
 // lock-conflict errors (1213/1205/40001), which are expected when concurrent
 // provision/Acquire paths allocate fs_ids for different tenants at the same
-// time (unique-index gap locks on fs_registry). Mirrors the retry pattern
-// used by the quota reservation path.
-func withMetaLockConflictRetry(fn func() error) error {
+// time (unique-index gap locks on fs_registry). Mirrors the quota path's
+// retryMetaLockConflict: context cancellation aborts the backoff and each
+// retry is logged so deadlock storms stay visible.
+func withMetaLockConflictRetry(ctx context.Context, operation string, fn func() error) error {
 	const maxAttempts = 4
 	var err error
 	for attempt := 0; attempt < maxAttempts; attempt++ {
@@ -23,7 +27,15 @@ func withMetaLockConflictRetry(fn func() error) error {
 		if !isMetaLockConflictError(err) {
 			return err
 		}
-		time.Sleep(time.Duration(20*(1<<attempt)) * time.Millisecond)
+		logger.Warn(ctx, "meta_lock_conflict_retry",
+			zap.String("operation", operation),
+			zap.Int("attempt", attempt+1),
+			zap.Error(err))
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(time.Duration(20*(1<<attempt)) * time.Millisecond):
+		}
 	}
 	return err
 }
@@ -45,7 +57,7 @@ func (s *Store) EnsureFsID(ctx context.Context, tenantID string) (fsID int64, er
 	if !errors.Is(err, ErrNotFound) {
 		return 0, err
 	}
-	if err := withMetaLockConflictRetry(func() error {
+	if err := withMetaLockConflictRetry(ctx, "ensure_fs_id", func() error {
 		_, err := s.db.ExecContext(ctx,
 			`INSERT IGNORE INTO fs_registry (tenant_id) VALUES (?)`, tenantID)
 		return err

--- a/pkg/meta/fs_registry_test.go
+++ b/pkg/meta/fs_registry_test.go
@@ -1,0 +1,133 @@
+package meta
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestEnsureFsIDAllocatesAndStaysStable(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	id1, err := s.EnsureFsID(ctx, "tenant-fs-a")
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if id1 <= 0 {
+		t.Fatalf("fs_id = %d, want positive", id1)
+	}
+	again, err := s.EnsureFsID(ctx, "tenant-fs-a")
+	if err != nil {
+		t.Fatalf("EnsureFsID again: %v", err)
+	}
+	if again != id1 {
+		t.Fatalf("EnsureFsID not stable: first %d, second %d", id1, again)
+	}
+
+	id2, err := s.EnsureFsID(ctx, "tenant-fs-b")
+	if err != nil {
+		t.Fatalf("EnsureFsID second tenant: %v", err)
+	}
+	if id2 == id1 {
+		t.Fatalf("distinct tenants share fs_id %d", id1)
+	}
+}
+
+func TestEnsureFsIDRejectsEmptyTenant(t *testing.T) {
+	s := newControlStore(t)
+	if _, err := s.EnsureFsID(context.Background(), ""); err == nil {
+		t.Fatal("expected error for empty tenant id")
+	}
+}
+
+func TestResolveFsIDNotFound(t *testing.T) {
+	s := newControlStore(t)
+	_, err := s.ResolveFsID(context.Background(), "tenant-never-registered")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("ResolveFsID error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestResolveTenantIDRoundTrip(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	id, err := s.EnsureFsID(ctx, "tenant-roundtrip")
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	tenantID, err := s.ResolveTenantID(ctx, id)
+	if err != nil {
+		t.Fatalf("ResolveTenantID: %v", err)
+	}
+	if tenantID != "tenant-roundtrip" {
+		t.Fatalf("ResolveTenantID = %q, want tenant-roundtrip", tenantID)
+	}
+	if _, err := s.ResolveTenantID(ctx, id+100000); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("ResolveTenantID unknown id error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestInsertTenantAllocatesFsID(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	if err := s.InsertTenant(ctx, &Tenant{
+		ID:               "tenant-auto-fs",
+		Status:           TenantPending,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "db_tenant_auto_fs",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("InsertTenant: %v", err)
+	}
+	if _, err := s.ResolveFsID(ctx, "tenant-auto-fs"); err != nil {
+		t.Fatalf("ResolveFsID after InsertTenant: %v", err)
+	}
+}
+
+func TestBackfillFsRegistryIsIdempotent(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	// Insert tenants with raw SQL to simulate pre-existing rows from before
+	// fs_registry existed (InsertTenant itself now allocates fs_ids).
+	for _, id := range []string{"tenant-backfill-1", "tenant-backfill-2"} {
+		if _, err := s.DB().ExecContext(ctx, `INSERT INTO tenants
+			(id, status, db_host, db_port, db_user, db_password, db_name, provider, created_at, updated_at)
+			VALUES (?, 'active', '127.0.0.1', 4000, 'root', ?, ?, 'tidb_zero', NOW(3), NOW(3))`,
+			id, []byte("cipher"), "db_"+id); err != nil {
+			t.Fatalf("insert legacy tenant %s: %v", id, err)
+		}
+	}
+
+	inserted, err := s.BackfillFsRegistry(ctx)
+	if err != nil {
+		t.Fatalf("BackfillFsRegistry: %v", err)
+	}
+	if inserted != 2 {
+		t.Fatalf("first backfill inserted %d rows, want 2", inserted)
+	}
+	again, err := s.BackfillFsRegistry(ctx)
+	if err != nil {
+		t.Fatalf("BackfillFsRegistry again: %v", err)
+	}
+	if again != 0 {
+		t.Fatalf("second backfill inserted %d rows, want 0", again)
+	}
+
+	for _, id := range []string{"tenant-backfill-1", "tenant-backfill-2"} {
+		if _, err := s.ResolveFsID(ctx, id); err != nil {
+			t.Fatalf("ResolveFsID %s after backfill: %v", id, err)
+		}
+	}
+}

--- a/pkg/meta/fs_registry_test.go
+++ b/pkg/meta/fs_registry_test.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 )
@@ -39,6 +40,35 @@ func TestEnsureFsIDRejectsEmptyTenant(t *testing.T) {
 	s := newControlStore(t)
 	if _, err := s.EnsureFsID(context.Background(), ""); err == nil {
 		t.Fatal("expected error for empty tenant id")
+	}
+}
+
+// TestEnsureFsIDConcurrent exercises the documented "safe to call
+// concurrently" contract: many goroutines racing the first allocation for
+// the same tenant must all observe the same fs_id.
+func TestEnsureFsIDConcurrent(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	const racers = 16
+	ids := make([]int64, racers)
+	errs := make([]error, racers)
+	var wg sync.WaitGroup
+	for i := 0; i < racers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			ids[i], errs[i] = s.EnsureFsID(ctx, "tenant-fs-race")
+		}(i)
+	}
+	wg.Wait()
+	for i := 0; i < racers; i++ {
+		if errs[i] != nil {
+			t.Fatalf("racer %d: %v", i, errs[i])
+		}
+		if ids[i] != ids[0] {
+			t.Fatalf("racer %d got fs_id %d, want %d", i, ids[i], ids[0])
+		}
 	}
 }
 

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -558,7 +558,8 @@ func metaInitSchemaStatements() []string {
 		// database to a TiDB Cloud organization; the '*' wildcard row serves
 		// organizations without an exact entry. db_password holds the same
 		// encrypted envelope as tenants.db_password. tenant_count is maintained
-		// via IncrSharedDBTenantCount as placements are created and removed.
+		// atomically with placement writes via ReserveSharedDBPlacement and
+		// DeleteTenantPlacementAndDecrCount.
 		// The `role` column name is backtick-quoted because ROLE is a reserved
 		// word in MySQL 8.0.
 		`CREATE TABLE IF NOT EXISTS db_pool (

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -570,7 +570,7 @@ func metaInitSchemaStatements() []string {
 			db_user      VARCHAR(255) NOT NULL,
 			db_password  VARBINARY(2048) NOT NULL,
 			db_name      VARCHAR(255) NOT NULL,
-			db_tls       TINYINT(1) NOT NULL DEFAULT 1,
+			db_tls       VARCHAR(32) NOT NULL DEFAULT '',
 			max_tenants  INT NOT NULL DEFAULT 0,
 			tenant_count INT NOT NULL DEFAULT 0,
 			status       VARCHAR(20) NOT NULL DEFAULT 'active',
@@ -1518,7 +1518,7 @@ func (s *Store) InsertTenant(ctx context.Context, t *Tenant) (err error) {
 	// fs_ids through EnsureFsID, and the two-table write below (tenants +
 	// fs_registry) can deadlock with them on the unique index of
 	// fs_registry.tenant_id. The deadlock victim retries cleanly.
-	return withMetaLockConflictRetry(func() error {
+	return withMetaLockConflictRetry(ctx, "insert_tenant", func() error {
 		return s.InTx(ctx, func(tx *sql.Tx) error {
 			_, err := tx.ExecContext(ctx, `INSERT INTO tenants
 			(id, status, kind, parent_tenant_id, storage_namespace_id, db_host, db_port, db_user, db_password, db_name, db_tls,
@@ -2955,6 +2955,25 @@ func (s *Store) UpdateTenantStatus(ctx context.Context, id string, status Tenant
 	start := time.Now()
 	defer observeMeta(ctx, "update_tenant_status", start, &err)
 	res, err := s.db.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ? WHERE id = ?`, status, time.Now().UTC(), id)
+	if err != nil {
+		return err
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// UpdateTenantProvider rewrites a tenant's persisted provider. It exists for
+// the shared-pool placement path, where the tenant row is inserted with the
+// request provider (e.g. tidb_cloud_native) and must be re-labeled as
+// tidb_cloud_native_shared once placement on a shared-schema DB is decided,
+// so provider-driven capability checks classify the tenant correctly.
+func (s *Store) UpdateTenantProvider(ctx context.Context, id, provider string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_tenant_provider", start, &err)
+	res, err := s.db.ExecContext(ctx, `UPDATE tenants SET provider = ?, updated_at = ? WHERE id = ?`, provider, time.Now().UTC(), id)
 	if err != nil {
 		return err
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -548,6 +548,11 @@ func metaInitSchemaStatements() []string {
 			INDEX idx_tenant_namespace (storage_namespace_id, kind, status),
 			INDEX idx_tenant_parent (parent_tenant_id)
 		)`,
+		`CREATE TABLE IF NOT EXISTS fs_registry (
+			fs_id      BIGINT AUTO_INCREMENT PRIMARY KEY,
+			tenant_id  VARCHAR(64) NOT NULL UNIQUE,
+			created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+		)`,
 		`CREATE TABLE IF NOT EXISTS tenant_auto_embedding_profiles (
 			tenant_id      VARCHAR(64) PRIMARY KEY,
 			embedding_mode VARCHAR(32) NULL,
@@ -1466,19 +1471,29 @@ func schemaSnippet(stmt string) string {
 func (s *Store) InsertTenant(ctx context.Context, t *Tenant) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "insert_tenant", start, &err)
-	_, err = s.db.ExecContext(ctx, `INSERT INTO tenants
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		_, err := tx.ExecContext(ctx, `INSERT INTO tenants
 		(id, status, kind, parent_tenant_id, storage_namespace_id, db_host, db_port, db_user, db_password, db_name, db_tls,
 		 provider, cluster_id, branch_id, claim_url, claim_expires_at, schema_version,
 		 s3_encryption_mode, s3_kms_key_id, s3_bucket_key_enabled, created_at, updated_at)
 		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		t.ID, t.Status, tenantKindForInsert(t), t.ParentTenantID, t.StorageNamespaceID,
-		t.DBHost, t.DBPort, t.DBUser, t.DBPasswordCipher, t.DBName, boolToInt(t.DBTLS),
-		t.Provider, nullStr(t.ClusterID), t.BranchID, nullStr(t.ClaimURL), t.ClaimExpiresAt, t.SchemaVersion,
-		tenantS3EncryptionModeForInsert(t), t.S3KMSKeyID, boolToInt(tenantS3BucketKeyEnabledForInsert(t)),
-		t.CreatedAt.UTC(), t.UpdatedAt.UTC())
-	if isDuplicateEntry(err) {
-		return ErrDuplicate
-	}
+			t.ID, t.Status, tenantKindForInsert(t), t.ParentTenantID, t.StorageNamespaceID,
+			t.DBHost, t.DBPort, t.DBUser, t.DBPasswordCipher, t.DBName, boolToInt(t.DBTLS),
+			t.Provider, nullStr(t.ClusterID), t.BranchID, nullStr(t.ClaimURL), t.ClaimExpiresAt, t.SchemaVersion,
+			tenantS3EncryptionModeForInsert(t), t.S3KMSKeyID, boolToInt(tenantS3BucketKeyEnabledForInsert(t)),
+			t.CreatedAt.UTC(), t.UpdatedAt.UTC())
+		if isDuplicateEntry(err) {
+			return ErrDuplicate
+		}
+		if err != nil {
+			return err
+		}
+		// Every tenant gets a stable internal fs_id at creation time (see
+		// fs_registry). INSERT IGNORE keeps this idempotent for tenants that
+		// were pre-registered by BackfillFsRegistry.
+		_, err = tx.ExecContext(ctx, `INSERT IGNORE INTO fs_registry (tenant_id) VALUES (?)`, t.ID)
+		return err
+	})
 	return err
 }
 

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -1514,30 +1514,35 @@ func schemaSnippet(stmt string) string {
 func (s *Store) InsertTenant(ctx context.Context, t *Tenant) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "insert_tenant", start, &err)
-	err = s.InTx(ctx, func(tx *sql.Tx) error {
-		_, err := tx.ExecContext(ctx, `INSERT INTO tenants
-		(id, status, kind, parent_tenant_id, storage_namespace_id, db_host, db_port, db_user, db_password, db_name, db_tls,
-		 provider, cluster_id, branch_id, claim_url, claim_expires_at, schema_version,
-		 s3_encryption_mode, s3_kms_key_id, s3_bucket_key_enabled, created_at, updated_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			t.ID, t.Status, tenantKindForInsert(t), t.ParentTenantID, t.StorageNamespaceID,
-			t.DBHost, t.DBPort, t.DBUser, t.DBPasswordCipher, t.DBName, boolToInt(t.DBTLS),
-			t.Provider, nullStr(t.ClusterID), t.BranchID, nullStr(t.ClaimURL), t.ClaimExpiresAt, t.SchemaVersion,
-			tenantS3EncryptionModeForInsert(t), t.S3KMSKeyID, boolToInt(tenantS3BucketKeyEnabledForInsert(t)),
-			t.CreatedAt.UTC(), t.UpdatedAt.UTC())
-		if isDuplicateEntry(err) {
-			return ErrDuplicate
-		}
-		if err != nil {
+	// Retry the whole tx on lock conflicts: concurrent cold Acquires allocate
+	// fs_ids through EnsureFsID, and the two-table write below (tenants +
+	// fs_registry) can deadlock with them on the unique index of
+	// fs_registry.tenant_id. The deadlock victim retries cleanly.
+	return withMetaLockConflictRetry(func() error {
+		return s.InTx(ctx, func(tx *sql.Tx) error {
+			_, err := tx.ExecContext(ctx, `INSERT INTO tenants
+			(id, status, kind, parent_tenant_id, storage_namespace_id, db_host, db_port, db_user, db_password, db_name, db_tls,
+			 provider, cluster_id, branch_id, claim_url, claim_expires_at, schema_version,
+			 s3_encryption_mode, s3_kms_key_id, s3_bucket_key_enabled, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+				t.ID, t.Status, tenantKindForInsert(t), t.ParentTenantID, t.StorageNamespaceID,
+				t.DBHost, t.DBPort, t.DBUser, t.DBPasswordCipher, t.DBName, boolToInt(t.DBTLS),
+				t.Provider, nullStr(t.ClusterID), t.BranchID, nullStr(t.ClaimURL), t.ClaimExpiresAt, t.SchemaVersion,
+				tenantS3EncryptionModeForInsert(t), t.S3KMSKeyID, boolToInt(tenantS3BucketKeyEnabledForInsert(t)),
+				t.CreatedAt.UTC(), t.UpdatedAt.UTC())
+			if isDuplicateEntry(err) {
+				return ErrDuplicate
+			}
+			if err != nil {
+				return err
+			}
+			// Every tenant gets a stable internal fs_id at creation time (see
+			// fs_registry). INSERT IGNORE keeps this idempotent for tenants that
+			// were pre-registered by BackfillFsRegistry.
+			_, err = tx.ExecContext(ctx, `INSERT IGNORE INTO fs_registry (tenant_id) VALUES (?)`, t.ID)
 			return err
-		}
-		// Every tenant gets a stable internal fs_id at creation time (see
-		// fs_registry). INSERT IGNORE keeps this idempotent for tenants that
-		// were pre-registered by BackfillFsRegistry.
-		_, err = tx.ExecContext(ctx, `INSERT IGNORE INTO fs_registry (tenant_id) VALUES (?)`, t.ID)
-		return err
+		})
 	})
-	return err
 }
 
 func (s *Store) UpsertTenantAutoEmbeddingProfile(ctx context.Context, p *TenantAutoEmbeddingProfile) (err error) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -553,6 +553,49 @@ func metaInitSchemaStatements() []string {
 			tenant_id  VARCHAR(64) NOT NULL UNIQUE,
 			created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
 		)`,
+		// db_pool is the fleet-wide registry of physical databases available
+		// for tenant placement under the shared-schema layout. org_id scopes a
+		// database to a TiDB Cloud organization; the '*' wildcard row serves
+		// organizations without an exact entry. db_password holds the same
+		// encrypted envelope as tenants.db_password. tenant_count is maintained
+		// via IncrSharedDBTenantCount as placements are created and removed.
+		// The `role` column name is backtick-quoted because ROLE is a reserved
+		// word in MySQL 8.0.
+		`CREATE TABLE IF NOT EXISTS db_pool (
+			db_id        BIGINT AUTO_INCREMENT PRIMARY KEY,
+			org_id       VARCHAR(64) NOT NULL DEFAULT '',
+			` + "`role`" + `       VARCHAR(20) NOT NULL,
+			db_host      VARCHAR(255) NOT NULL,
+			db_port      INT NOT NULL,
+			db_user      VARCHAR(255) NOT NULL,
+			db_password  VARBINARY(2048) NOT NULL,
+			db_name      VARCHAR(255) NOT NULL,
+			db_tls       TINYINT(1) NOT NULL DEFAULT 1,
+			max_tenants  INT NOT NULL DEFAULT 0,
+			tenant_count INT NOT NULL DEFAULT 0,
+			status       VARCHAR(20) NOT NULL DEFAULT 'active',
+			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host, db_name),
+			INDEX idx_db_pool_org (org_id, status)
+		)`,
+		// tenant_placements records which physical database (db_pool row) hosts
+		// each filesystem (fs_registry row). A missing row means the tenant
+		// still lives on its legacy standalone database. epoch is reserved for
+		// optimistic concurrency during future migrations; it stays 1 unless a
+		// migration explicitly bumps it.
+		`CREATE TABLE IF NOT EXISTS tenant_placements (
+			fs_id        BIGINT PRIMARY KEY,
+			db_id        BIGINT NOT NULL,
+			placement    VARCHAR(20) NOT NULL,
+			schema_shape VARCHAR(20) NOT NULL,
+			status       VARCHAR(20) NOT NULL DEFAULT 'active',
+			target_db_id BIGINT NULL,
+			epoch        BIGINT NOT NULL DEFAULT 1,
+			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			INDEX idx_placement_db (db_id, status)
+		)`,
 		`CREATE TABLE IF NOT EXISTS tenant_auto_embedding_profiles (
 			tenant_id      VARCHAR(64) PRIMARY KEY,
 			embedding_mode VARCHAR(32) NULL,

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -21,6 +21,10 @@ const (
 	RoleMeta       = "meta"
 	RoleUser       = "user"
 	RoleUserSchema = "user_schema"
+	// RoleShared labels *sql.DB handles to shared-schema databases that serve
+	// many tenants at once (fs_id row keys). Pool limits for this role must be
+	// sized for the whole cluster, not for one tenant.
+	RoleShared = "shared"
 )
 
 const (

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -21,6 +21,13 @@ const (
 	defaultUserSchemaConnMaxIdleTime = 20 * time.Second
 	defaultUserSchemaMaxOpenConns    = 8
 	defaultUserSchemaMaxIdleConns    = 2
+	// Shared-schema handles serve many tenants through one *sql.DB, so they
+	// get meta-like lifetimes and a much larger connection budget than
+	// per-tenant user pools.
+	defaultSharedConnMaxLifetime = 5 * time.Minute
+	defaultSharedConnMaxIdleTime = 1 * time.Minute
+	defaultSharedMaxOpenConns    = 50
+	defaultSharedMaxIdleConns    = 10
 )
 
 // ApplyPoolDefaults rotates and prunes idle connections before common LB/NAT
@@ -54,6 +61,8 @@ func defaultPoolLifetime(role string) (time.Duration, time.Duration) {
 		return defaultUserConnMaxLifetime, defaultUserConnMaxIdleTime
 	case RoleUserSchema:
 		return defaultUserSchemaConnMaxLifetime, defaultUserSchemaConnMaxIdleTime
+	case RoleShared:
+		return defaultSharedConnMaxLifetime, defaultSharedConnMaxIdleTime
 	default:
 		return defaultMetaConnMaxLifetime, defaultMetaConnMaxIdleTime
 	}
@@ -67,6 +76,8 @@ func defaultPoolLimits(role string) (int, int) {
 		return defaultUserMaxOpenConns, defaultUserMaxIdleConns
 	case RoleUserSchema:
 		return defaultUserSchemaMaxOpenConns, defaultUserSchemaMaxIdleConns
+	case RoleShared:
+		return defaultSharedMaxOpenConns, defaultSharedMaxIdleConns
 	default:
 		return 0, 0
 	}
@@ -89,6 +100,8 @@ func rolePoolEnvKey(role, suffix string) string {
 		return "DRIVE9_USER_DB_" + suffix
 	case RoleUserSchema:
 		return "DRIVE9_USER_SCHEMA_DB_" + suffix
+	case RoleShared:
+		return "DRIVE9_SHARED_DB_" + suffix
 	default:
 		return ""
 	}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1648,37 +1648,52 @@ func tenantPoolCreateDatabaseLockKey(cred tenant.CredentialProvisionRequest) str
 	return "create:" + key
 }
 
-func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) (*provisionTenantResult, *meta.TenantPool, bool, error) {
+// claimAdminTenantFromPool tries to hand out a pre-warmed tenant from the
+// caller org's tenant pool. sharedPoolMatched reports that the org has a
+// registered shared-schema pool instead — callers decide what that means
+// (admin create fails closed; the owner provision path falls through to
+// provisionTenant, which routes the tenant onto the shared pool).
+func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) (*provisionTenantResult, *meta.TenantPool, bool, bool, error) {
 	claimStarted := time.Now()
 	manager, ok := s.provisioner.(tenant.TenantPoolClusterManager)
 	if !ok {
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "reason", "pool_manager_unavailable", "duration_ms", durationMillis(claimStarted))...)
-		return nil, nil, false, nil
+		return nil, nil, false, false, nil
 	}
 	if _, ok := s.provisioner.(tenant.ManagedClusterLister); !ok {
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "reason", "managed_cluster_lister_unavailable", "duration_ms", durationMillis(claimStarted))...)
-		return nil, nil, false, nil
+		return nil, nil, false, false, nil
 	}
 	stageStarted := time.Now()
 	orgID, err := s.firstManagedOrganization(ctx, cred)
 	if err != nil || orgID == "" {
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_org_lookup_done", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "duration_ms", durationMillis(stageStarted), "has_error", err != nil)...)
-		return nil, nil, false, err
+		return nil, nil, false, false, err
 	}
 	logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_org_lookup_done", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
+	// An org with a registered shared-schema pool places new tenants on it;
+	// the warm pool (pre-provisioned dedicated clusters) must not hand out a
+	// different tenant shape. Fall through to provisionTenant, which routes
+	// the tenant onto the shared pool.
+	if sharedDB, sharedErr := s.meta.FindSharedDBForOrg(ctx, orgID); sharedErr == nil && sharedDB != nil {
+		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "reason", "shared_pool_registered", "duration_ms", durationMillis(claimStarted))...)
+		return nil, nil, false, true, nil
+	} else if sharedErr != nil && !errors.Is(sharedErr, meta.ErrNotFound) {
+		return nil, nil, false, false, sharedErr
+	}
 	stageStarted = time.Now()
 	pool, err := s.meta.GetTenantPoolByOrganization(ctx, orgID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_pool_lookup_missed", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
-			return nil, nil, false, nil
+			return nil, nil, false, false, nil
 		}
-		return nil, nil, false, err
+		return nil, nil, false, false, err
 	}
 	logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_pool_lookup_done", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "pool_size", pool.Size, "pool_status", pool.Status, "duration_ms", durationMillis(stageStarted))...)
 	if pool.Status != meta.TenantPoolActive {
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "reason", "pool_inactive", "pool_status", pool.Status, "duration_ms", durationMillis(claimStarted))...)
-		return nil, nil, false, nil
+		return nil, nil, false, false, nil
 	}
 	defer s.refreshTenantPoolCapacity(ctx, pool)
 	s.resumePendingTenantPoolAsync(ctx, pool, cred)
@@ -1687,9 +1702,9 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
 			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_free_tenant_missed", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
-			return nil, pool, false, nil
+			return nil, pool, false, false, nil
 		}
-		return nil, nil, false, err
+		return nil, nil, false, false, err
 	}
 	logProvisionStage(ctx, "admin_tenant_pool_claim_free_tenant_claimed", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "cluster_id", row.Binding.ClusterID, "status", row.Tenant.Status)
 	usedAt := time.Now().UTC()
@@ -1702,7 +1717,7 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 	cloudCfg, err := manager.MarkClusterPoolUsed(ctx, cluster, cred, usedAt, opts)
 	if err != nil {
 		s.releaseClaimedPoolTenant(ctx, manager, cluster, cred, row.Tenant.ID, "mark_used_error")
-		return nil, nil, false, err
+		return nil, nil, false, false, err
 	}
 	logProvisionStage(ctx, "admin_tenant_pool_claim_cluster_marked_used", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "cluster_id", cluster.ClusterID, "quota_requested", quotaOpt != nil)
 	success := false
@@ -1718,7 +1733,7 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 	if quotaOpt != nil {
 		qp, err := quotaConfigPatchFromRequest(*quotaOpt)
 		if err != nil {
-			return nil, nil, false, err
+			return nil, nil, false, false, err
 		}
 		if qp.MaxStorageBytes != nil {
 			quotaSeed.MaxStorageBytes = qp.MaxStorageBytes
@@ -1738,19 +1753,19 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		quotaSeed.TiDBCloudSpendingLimitCheckedAt = &checkedAt
 	}
 	if err := s.meta.SetQuotaConfigPatch(ctx, row.Tenant.ID, quotaSeed); err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, false, err
 	}
 	logProvisionStage(ctx, "admin_tenant_pool_claim_quota_seeded", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "create_time_spending_limit", cloudCfg != nil && cloudCfg.TiDBCloudSpendingLimitMonthly != nil)
 	stageStarted = time.Now()
 	plainPass, err := s.pool.Decrypt(ctx, row.Tenant.DBPasswordCipher)
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, false, err
 	}
 	logProvisionStage(ctx, "admin_tenant_pool_claim_db_password_decrypted", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID)
 	stageStarted = time.Now()
 	apiToken, apiKeyID, err := s.issueOwnerAPIKey(ctx, row.Tenant.ID, "default", 1, apiKeyIssueSource{})
 	if err != nil {
-		return nil, nil, false, err
+		return nil, nil, false, false, err
 	}
 	logProvisionStage(ctx, "admin_tenant_pool_claim_api_key_issued", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "api_key_id", apiKeyID)
 	cloudProvider, region := provisioningCloudRegion(s.provisioner)
@@ -1766,7 +1781,7 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		CloudProvider:  cloudProvider,
 		Region:         region,
 		OrganizationID: row.Binding.OrganizationID,
-	}, pool, true, nil
+	}, pool, true, false, nil
 }
 
 func (s *Server) releaseClaimedPoolTenant(ctx context.Context, manager tenant.TenantPoolClusterManager, cluster *tenant.ClusterInfo, cred tenant.CredentialProvisionRequest, tenantID, reason string) {

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -171,7 +171,8 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 	}
 	poolClaimStarted := time.Now()
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_started", "provider", tenant.ProviderTiDBCloudNative, "quota_requested", quotaOpt != nil)...)
-	if res, pool, claimed, err := s.claimAdminTenantFromPool(r.Context(), cred, quotaOpt); err != nil {
+	res, pool, claimed, sharedPoolMatched, err := s.claimAdminTenantFromPool(r.Context(), cred, quotaOpt)
+	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_failed", "provider", tenant.ProviderTiDBCloudNative, "duration_ms", durationMillis(poolClaimStarted), "error", err)...)
 		status, msg := clientFacingErrorResponse(http.StatusBadGateway, "claim tenant pool tenant failed", err)
 		errJSON(w, status, msg)
@@ -196,8 +197,18 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_create_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted))...)
 		return
 	}
+	// The admin tenant API is cluster-centric (org binding, cluster existence
+	// checks, per-cluster quota): a tenant placed on a shared-schema DB has no
+	// per-tenant cluster and would be unmanageable through this surface. Fail
+	// closed when the caller's org matches a shared pool instead of creating
+	// a tenant with no valid admin lifecycle. (The owner provision API below
+	// routes the same org onto the shared pool instead.)
+	if sharedPoolMatched {
+		errJSON(w, http.StatusConflict, "tenant org is registered for shared-pool placement, which the admin tenant API does not support")
+		return
+	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_missed", "provider", tenant.ProviderTiDBCloudNative, "duration_ms", durationMillis(poolClaimStarted))...)
-	res, err := s.provisionTenant(r.Context(), provisionTenantOptions{
+	res, err = s.provisionTenant(r.Context(), provisionTenantOptions{
 		KeyName:               "default",
 		TokenVersion:          1,
 		CredentialProvisioner: &cred,

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -314,16 +314,14 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 	if source.Status != meta.TenantActive {
 		return nil, forkErr(http.StatusConflict, "source tenant is not active")
 	}
-	if !s.forkProviderSupported(source.Provider) {
-		return nil, forkErr(http.StatusConflict, "fork is not supported in this TiDBCloud mode")
-	}
 	// Fork today is a TiDB Cloud Branch of the source tenant's own cluster;
 	// shared-schema tenants have no per-tenant cluster to branch, so reject
 	// explicitly instead of misrouting the branch onto the shared DB.
-	if shared, err := s.tenantIsSharedSchema(ctx, source.ID); err != nil {
-		return nil, err
-	} else if shared {
+	if tenant.IsSharedSchemaProvider(source.Provider) {
 		return nil, forkErr(http.StatusConflict, "fork is not supported for shared-pool tenants")
+	}
+	if !s.forkProviderSupported(source.Provider) {
+		return nil, forkErr(http.StatusConflict, "fork is not supported in this TiDBCloud mode")
 	}
 	credentialReq, err = s.resolveForkCredentialRequest(source.Provider, credentialReq)
 	if err != nil {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -317,6 +317,14 @@ func (s *Server) createForkTenant(ctx context.Context, sourceTenantID, displayNa
 	if !s.forkProviderSupported(source.Provider) {
 		return nil, forkErr(http.StatusConflict, "fork is not supported in this TiDBCloud mode")
 	}
+	// Fork today is a TiDB Cloud Branch of the source tenant's own cluster;
+	// shared-schema tenants have no per-tenant cluster to branch, so reject
+	// explicitly instead of misrouting the branch onto the shared DB.
+	if shared, err := s.tenantIsSharedSchema(ctx, source.ID); err != nil {
+		return nil, err
+	} else if shared {
+		return nil, forkErr(http.StatusConflict, "fork is not supported for shared-pool tenants")
+	}
 	credentialReq, err = s.resolveForkCredentialRequest(source.Provider, credentialReq)
 	if err != nil {
 		return nil, forkErr(http.StatusBadRequest, err.Error())

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -2237,7 +2237,7 @@ func TestTenantPoolClaimMissTriggersPendingMetadataResume(t *testing.T) {
 		t.Fatalf("upsert binding: %v", err)
 	}
 
-	res, pool, claimed, err := rt.server.claimAdminTenantFromPool(ctx, tenant.CredentialProvisionRequest{
+	res, pool, claimed, _, err := rt.server.claimAdminTenantFromPool(ctx, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	}, nil)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -2321,7 +2321,7 @@ func TestTenantPoolClaimSeedsQuotaConfigWithoutExplicitQuota(t *testing.T) {
 		t.Fatalf("upsert binding: %v", err)
 	}
 
-	res, _, claimed, err := rt.server.claimAdminTenantFromPool(ctx, tenant.CredentialProvisionRequest{
+	res, _, claimed, _, err := rt.server.claimAdminTenantFromPool(ctx, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	}, nil)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5027,8 +5027,17 @@ func (s *Server) updateTenantSchemaVersionForProfile(ctx context.Context, tenant
 // tenant should follow the normal per-tenant provisioning path. Lookup
 // failures are returned as errors — never silently treated as "no pool",
 // which would provision the wrong tenant shape on a transient meta outage.
+//
+// Only TiDB-dialect providers may route to a shared pool (the shared schema
+// is TiDB/MySQL DDL): db9 tenants are PostgreSQL-backed and engine-
+// incompatible, so a wildcard pool must never capture them.
 func (s *Server) findSharedDBForProvision(ctx context.Context, provider string, opts provisionTenantOptions) (*meta.SharedDB, error) {
 	if s.meta == nil {
+		return nil, nil
+	}
+	switch provider {
+	case tenant.ProviderTiDBCloudNative, tenant.ProviderTiDBCloudNativeShared, tenant.ProviderTiDBZero:
+	default:
 		return nil, nil
 	}
 	orgID := ""
@@ -5098,19 +5107,23 @@ func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string,
 	}); err != nil {
 		return fail(err)
 	}
-	if err := s.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+	// Capacity and placement are reserved atomically: two concurrent
+	// provisions cannot take the same last slot, and a placement row never
+	// exists without its reserved capacity.
+	if err := s.meta.ReserveSharedDBPlacement(ctx, &meta.TenantPlacement{
 		FsID:        fsID,
 		DbID:        sharedDB.DbID,
 		Placement:   meta.PlacementShared,
 		SchemaShape: meta.SchemaShapeShared,
 	}); err != nil {
+		if errors.Is(err, meta.ErrSharedDBCapacityExhausted) {
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			return nil, newProvisionTenantError(http.StatusConflict, "shared pool is at capacity", err)
+		}
 		return fail(err)
 	}
 	if err := s.meta.UpdateTenantProvider(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
 		return fail(err)
-	}
-	if err := s.meta.IncrSharedDBTenantCount(ctx, sharedDB.DbID, 1); err != nil {
-		logger.Warn(ctx, "server_event", eventFields(ctx, "shared_pool_tenant_count_failed", "tenant_id", tenantID, "error", err)...)
 	}
 	if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantActive); err != nil {
 		return fail(err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -807,6 +807,16 @@ func (s *Server) startLeaderWorkers() {
 	if s.meta != nil {
 		s.replayWorker = backend.StartMutationReplayWorker(tenant.NewMetaQuotaAdapter(s.meta))
 		s.expirySweepWorker = backend.StartExpirySweepWorker(s.meta)
+		// One-time fs_registry backfill so pre-existing tenants hold a stable
+		// internal fs_id before the routing layer needs it. Idempotent.
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			inserted, err := s.meta.BackfillFsRegistry(workerCtx)
+			if err != nil {
+				logger.Error(workerCtx, "server_event", eventFields(workerCtx, "fs_registry_backfill_failed", "error", err)...)
+				return
+			}
+			logger.Info(workerCtx, "server_event", eventFields(workerCtx, "fs_registry_backfill_done", "inserted", inserted)...)
+		})
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
 			ticker := time.NewTicker(tenantCountMetricsInterval)
 			defer ticker.Stop()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5083,7 +5083,17 @@ func (s *Server) findSharedDBForProvision(ctx context.Context, provider string, 
 // carry plain VECTOR columns — per-tenant EMBED_TEXT generated columns are
 // impossible), marks the tenant active, and issues the owner key.
 func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string, sharedDB *meta.SharedDB, provider, keyName string, opts provisionTenantOptions, now time.Time) (*provisionTenantResult, error) {
+	// Once the placement is reserved, every later failure must release it:
+	// the reservation holds a capacity slot and a routing row that nothing
+	// else reclaims, so a transient failure would permanently leak both.
+	fsID := int64(0)
+	reserved := false
 	fail := func(err error) (*provisionTenantResult, error) {
+		if reserved {
+			if cerr := s.meta.DeleteTenantPlacementAndDecrCount(context.Background(), fsID, sharedDB.DbID); cerr != nil {
+				logger.Error(ctx, "server_event", eventFields(ctx, "shared_pool_reserve_compensate_failed", "tenant_id", tenantID, "db_id", sharedDB.DbID, "error", cerr)...)
+			}
+		}
 		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
 		}
@@ -5122,6 +5132,7 @@ func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string,
 		}
 		return fail(err)
 	}
+	reserved = true
 	if err := s.meta.UpdateTenantProvider(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
 		return fail(err)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5053,11 +5053,19 @@ func (s *Server) findSharedDBForProvision(ctx context.Context, provider string, 
 		return nil
 	}
 	orgID := ""
-	if provider == tenant.ProviderTiDBCloudNative && opts.CredentialProvisioner != nil {
-		if id, err := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner); err == nil {
-			orgID = id
-		} else {
-			logger.Warn(ctx, "server_event", eventFields(ctx, "provision_org_resolve_failed", "error", err)...)
+	if provider == tenant.ProviderTiDBCloudNative {
+		if opts.CredentialProvisioner != nil {
+			if id, err := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner); err == nil {
+				orgID = id
+			} else {
+				logger.Warn(ctx, "server_event", eventFields(ctx, "provision_org_resolve_failed", "error", err)...)
+			}
+		}
+		if orgID == "" {
+			// Never fall back to the wildcard pool when the tenant's org cannot
+			// be resolved: an unresolved org must stay on the dedicated path
+			// even if a wildcard pool exists.
+			return nil
 		}
 	}
 	sharedDB, err := s.meta.FindSharedDBForOrg(ctx, orgID)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5077,23 +5077,15 @@ func (s *Server) findSharedDBForProvision(ctx context.Context, provider string, 
 
 // provisionTenantOnSharedDB completes provisioning for a tenant placed on a
 // shared-schema database: no cluster is created and the schema already exists
-// there. It writes the placement, re-labels the tenant row with the shared
-// provider (tidb_cloud_native_shared) so provider-driven capability checks
-// classify it correctly, forces the fts_only embedding profile (shared tables
-// carry plain VECTOR columns — per-tenant EMBED_TEXT generated columns are
-// impossible), marks the tenant active, and issues the owner key.
+// there. After the idempotent identity/profile steps, every state-changing
+// meta write — the capacity reservation and placement, the provider re-label
+// (tidb_cloud_native_shared, so provider-driven capability checks classify
+// the tenant correctly), the active-status transition, and the owner key —
+// commits in ONE meta transaction (CompleteSharedTenantProvision). A failed
+// provision therefore leaves no partial state: no active shared tenant
+// without a placement row, no capacity leak, no orphaned key.
 func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string, sharedDB *meta.SharedDB, provider, keyName string, opts provisionTenantOptions, now time.Time) (*provisionTenantResult, error) {
-	// Once the placement is reserved, every later failure must release it:
-	// the reservation holds a capacity slot and a routing row that nothing
-	// else reclaims, so a transient failure would permanently leak both.
-	fsID := int64(0)
-	reserved := false
 	fail := func(err error) (*provisionTenantResult, error) {
-		if reserved {
-			if cerr := s.meta.DeleteTenantPlacementAndDecrCount(context.Background(), fsID, sharedDB.DbID); cerr != nil {
-				logger.Error(ctx, "server_event", eventFields(ctx, "shared_pool_reserve_compensate_failed", "tenant_id", tenantID, "db_id", sharedDB.DbID, "error", cerr)...)
-			}
-		}
 		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
 		}
@@ -5109,6 +5101,8 @@ func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string,
 	if err != nil {
 		return fail(err)
 	}
+	// Forces the fts_only embedding profile (shared tables carry plain VECTOR
+	// columns — per-tenant EMBED_TEXT generated columns are impossible).
 	if err := s.meta.UpsertTenantAutoEmbeddingProfile(ctx, &meta.TenantAutoEmbeddingProfile{
 		TenantID:      tenantID,
 		EmbeddingMode: meta.TenantEmbeddingModeFTSOnly,
@@ -5117,32 +5111,25 @@ func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string,
 	}); err != nil {
 		return fail(err)
 	}
-	// Capacity and placement are reserved atomically: two concurrent
-	// provisions cannot take the same last slot, and a placement row never
-	// exists without its reserved capacity.
-	if err := s.meta.ReserveSharedDBPlacement(ctx, &meta.TenantPlacement{
+	// Token generation and encryption are pure computation — build the key
+	// material first so its insert can join the atomic transition.
+	apiToken, apiKeyID, keyRec, err := s.buildOwnerAPIKey(ctx, tenantID, keyName, opts.TokenVersion, opts.APIKeySource)
+	if err != nil {
+		return fail(err)
+	}
+	if err := s.meta.CompleteSharedTenantProvision(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, &meta.TenantPlacement{
 		FsID:        fsID,
 		DbID:        sharedDB.DbID,
 		Placement:   meta.PlacementShared,
 		SchemaShape: meta.SchemaShapeShared,
-	}); err != nil {
+	}, keyRec); err != nil {
 		if errors.Is(err, meta.ErrSharedDBCapacityExhausted) {
 			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 			return nil, newProvisionTenantError(http.StatusConflict, "shared pool is at capacity", err)
 		}
 		return fail(err)
 	}
-	reserved = true
-	if err := s.meta.UpdateTenantProvider(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
-		return fail(err)
-	}
-	if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantActive); err != nil {
-		return fail(err)
-	}
-	apiToken, apiKeyID, err := s.issueOwnerAPIKey(ctx, tenantID, keyName, opts.TokenVersion, opts.APIKeySource)
-	if err != nil {
-		return fail(err)
-	}
+	metricEvent(ctx, "metadb_query", "api", "insert_api_key", "result", "ok")
 	logger.Info(ctx, "server_event", eventFields(ctx, "provision_shared_pool_placed", "tenant_id", tenantID, "provider", tenant.ProviderTiDBCloudNativeShared, "db_id", sharedDB.DbID, "org_id", sharedDB.OrgID)...)
 	metricEvent(ctx, "tenant_provision", "provider", tenant.ProviderTiDBCloudNativeShared, "result", "shared_pool")
 	return &provisionTenantResult{
@@ -5512,24 +5499,27 @@ func (s *Server) startProvisionedTenantSchemaInit(ctx context.Context, res *prov
 	})
 }
 
-func (s *Server) issueOwnerAPIKey(ctx context.Context, tenantID, keyName string, tokenVersion int, source apiKeyIssueSource) (rawToken, apiKeyID string, err error) {
+// buildOwnerAPIKey generates the owner token and encrypts it, returning the
+// API key record ready for persistence. It performs no writes, so callers
+// can fold the insert into a larger transaction.
+func (s *Server) buildOwnerAPIKey(ctx context.Context, tenantID, keyName string, tokenVersion int, source apiKeyIssueSource) (rawToken, apiKeyID string, rec *meta.APIKey, err error) {
 	if tokenVersion <= 0 {
 		tokenVersion, err = newScopedTokenVersion()
 		if err != nil {
-			return "", "", err
+			return "", "", nil, err
 		}
 	}
 	rawToken, err = token.IssueTokenWithJournalPermissions(s.tokenSecret, tenantID, tokenVersion, time.Time{}, ownerJournalPermissionList())
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 	cipherToken, err := s.pool.Encrypt(ctx, []byte(rawToken))
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
 	now := time.Now().UTC()
 	apiKeyID = token.NewID()
-	if err := s.meta.InsertAPIKey(ctx, &meta.APIKey{
+	return rawToken, apiKeyID, &meta.APIKey{
 		ID:                   apiKeyID,
 		TenantID:             tenantID,
 		KeyName:              keyName,
@@ -5544,7 +5534,15 @@ func (s *Server) issueOwnerAPIKey(ctx context.Context, tenantID, keyName string,
 		IssuedAt:             now,
 		CreatedAt:            now,
 		UpdatedAt:            now,
-	}); err != nil {
+	}, nil
+}
+
+func (s *Server) issueOwnerAPIKey(ctx context.Context, tenantID, keyName string, tokenVersion int, source apiKeyIssueSource) (rawToken, apiKeyID string, err error) {
+	rawToken, apiKeyID, rec, err := s.buildOwnerAPIKey(ctx, tenantID, keyName, tokenVersion, source)
+	if err != nil {
+		return "", "", err
+	}
+	if err := s.meta.InsertAPIKey(ctx, rec); err != nil {
 		return "", "", err
 	}
 	metricEvent(ctx, "metadb_query", "api", "insert_api_key", "result", "ok")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5021,6 +5021,114 @@ func (s *Server) updateTenantSchemaVersionForProfile(ctx context.Context, tenant
 	return nil
 }
 
+// tenantIsSharedSchema reports whether the tenant is placed on a
+// shared-schema database. Tenants without a placement row are standalone.
+func (s *Server) tenantIsSharedSchema(ctx context.Context, tenantID string) (bool, error) {
+	if s.meta == nil {
+		return false, nil
+	}
+	fsID, err := s.meta.ResolveFsID(ctx, tenantID)
+	if errors.Is(err, meta.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("resolve fs_id: %w", err)
+	}
+	placement, err := s.meta.GetTenantPlacement(ctx, fsID)
+	if errors.Is(err, meta.ErrNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("resolve tenant placement: %w", err)
+	}
+	return placement.SchemaShape == meta.SchemaShapeShared, nil
+}
+
+// findSharedDBForProvision resolves whether the tenant being provisioned
+// should be placed on a shared-schema database: a registered shared pool for
+// the request's org, or the wildcard pool. Returns nil when the tenant should
+// follow the normal per-tenant provisioning path.
+func (s *Server) findSharedDBForProvision(ctx context.Context, provider string, opts provisionTenantOptions) *meta.SharedDB {
+	if s.meta == nil {
+		return nil
+	}
+	orgID := ""
+	if provider == tenant.ProviderTiDBCloudNative && opts.CredentialProvisioner != nil {
+		if id, err := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner); err == nil {
+			orgID = id
+		} else {
+			logger.Warn(ctx, "server_event", eventFields(ctx, "provision_org_resolve_failed", "error", err)...)
+		}
+	}
+	sharedDB, err := s.meta.FindSharedDBForOrg(ctx, orgID)
+	if err != nil {
+		if !errors.Is(err, meta.ErrNotFound) {
+			logger.Warn(ctx, "server_event", eventFields(ctx, "shared_pool_lookup_failed", "error", err)...)
+		}
+		return nil
+	}
+	return sharedDB
+}
+
+// provisionTenantOnSharedDB completes provisioning for a tenant placed on a
+// shared-schema database: no cluster is created and the schema already exists
+// there. It writes the placement, forces the fts_only embedding profile
+// (shared tables carry plain VECTOR columns — per-tenant EMBED_TEXT generated
+// columns are impossible), marks the tenant active, and issues the owner key.
+func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string, sharedDB *meta.SharedDB, provider, keyName string, opts provisionTenantOptions, now time.Time) (*provisionTenantResult, error) {
+	fail := func(err error) (*provisionTenantResult, error) {
+		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
+			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
+		}
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to place tenant on shared pool", err)
+	}
+	// Create-time spending limits are per-cluster in the shared world and are
+	// managed on the shared DB itself, not per tenant.
+	if opts.Quota != nil && opts.Quota.TiDBCloudSpendingLimit != nil {
+		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+		return nil, newProvisionTenantError(http.StatusBadRequest, "tidbcloud spending limit is not supported for shared-pool tenants", fmt.Errorf("spending limit requested for shared-pool tenant"))
+	}
+	fsID, err := s.meta.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		return fail(err)
+	}
+	if err := s.meta.UpsertTenantAutoEmbeddingProfile(ctx, &meta.TenantAutoEmbeddingProfile{
+		TenantID:      tenantID,
+		EmbeddingMode: meta.TenantEmbeddingModeFTSOnly,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}); err != nil {
+		return fail(err)
+	}
+	if err := s.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID:        fsID,
+		DbID:        sharedDB.DbID,
+		Placement:   meta.PlacementShared,
+		SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		return fail(err)
+	}
+	if err := s.meta.IncrSharedDBTenantCount(ctx, sharedDB.DbID, 1); err != nil {
+		logger.Warn(ctx, "server_event", eventFields(ctx, "shared_pool_tenant_count_failed", "tenant_id", tenantID, "error", err)...)
+	}
+	if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantActive); err != nil {
+		return fail(err)
+	}
+	apiToken, apiKeyID, err := s.issueOwnerAPIKey(ctx, tenantID, keyName, opts.TokenVersion, opts.APIKeySource)
+	if err != nil {
+		return fail(err)
+	}
+	logger.Info(ctx, "server_event", eventFields(ctx, "provision_shared_pool_placed", "tenant_id", tenantID, "provider", provider, "db_id", sharedDB.DbID, "org_id", sharedDB.OrgID)...)
+	metricEvent(ctx, "tenant_provision", "provider", provider, "result", "shared_pool")
+	return &provisionTenantResult{
+		TenantID: tenantID,
+		APIKey:   apiToken,
+		APIKeyID: apiKeyID,
+		Status:   meta.TenantActive,
+		Provider: provider,
+	}, nil
+}
+
 func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOptions) (*provisionTenantResult, error) {
 	rawProvider := s.provisioner.ProviderType()
 	provider, err := tenant.NormalizeProvider(rawProvider)
@@ -5076,6 +5184,13 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	}
 	metricEvent(ctx, "metadb_query", "api", "insert_tenant", "result", "ok")
 	logProvisionStage(ctx, "provision_tenant_inserted", tenantID, provider, stageStarted, "status", meta.TenantPending)
+
+	// Shared-pool placement: when a shared-schema database is registered for
+	// this tenant's org (or a wildcard pool exists), the tenant is placed on
+	// it directly — no cluster is created and the schema already exists there.
+	if sharedDB := s.findSharedDBForProvision(ctx, provider, opts); sharedDB != nil {
+		return s.provisionTenantOnSharedDB(ctx, tenantID, sharedDB, provider, keyName, opts, now)
+	}
 
 	if autoProfile != nil {
 		stageStarted = time.Now()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -165,7 +165,7 @@ func (s *Server) provisionerForTenantProvider(provider string) tenant.Provisione
 	switch provider {
 	case tenant.ProviderTiDBCloudStarterLegacy:
 		return s.legacyStarterProvisioner
-	case tenant.ProviderTiDBCloudNative, tenant.ProviderTiDBZero, tenant.ProviderDB9:
+	case tenant.ProviderTiDBCloudNative, tenant.ProviderTiDBZero, tenant.ProviderDB9, tenant.ProviderTiDBCloudNativeShared:
 		return s.provisioner
 	default:
 		return nil
@@ -4464,7 +4464,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	if provider == tenant.ProviderTiDBCloudNative && credentialReq != nil {
 		poolClaimStarted := time.Now()
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_started", "provider", provider, "quota_requested", quotaReq != nil)...)
-		if res, pool, claimed, err := s.claimAdminTenantFromPool(r.Context(), *credentialReq, quotaReq); err != nil {
+		if res, pool, claimed, _, err := s.claimAdminTenantFromPool(r.Context(), *credentialReq, quotaReq); err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_failed", "provider", provider, "duration_ms", durationMillis(poolClaimStarted), "error", err)...)
 			metricEvent(r.Context(), "tenant_provision", "provider", provider, "result", provisionTenantPoolClaimMetricResult(err))
 			status, msg := clientFacingErrorResponse(http.StatusBadGateway, "claim tenant pool tenant failed", err)
@@ -5021,39 +5021,18 @@ func (s *Server) updateTenantSchemaVersionForProfile(ctx context.Context, tenant
 	return nil
 }
 
-// tenantIsSharedSchema reports whether the tenant is placed on a
-// shared-schema database. Tenants without a placement row are standalone.
-func (s *Server) tenantIsSharedSchema(ctx context.Context, tenantID string) (bool, error) {
-	if s.meta == nil {
-		return false, nil
-	}
-	fsID, err := s.meta.ResolveFsID(ctx, tenantID)
-	if errors.Is(err, meta.ErrNotFound) {
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("resolve fs_id: %w", err)
-	}
-	placement, err := s.meta.GetTenantPlacement(ctx, fsID)
-	if errors.Is(err, meta.ErrNotFound) {
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("resolve tenant placement: %w", err)
-	}
-	return placement.SchemaShape == meta.SchemaShapeShared, nil
-}
-
 // findSharedDBForProvision resolves whether the tenant being provisioned
 // should be placed on a shared-schema database: a registered shared pool for
-// the request's org, or the wildcard pool. Returns nil when the tenant should
-// follow the normal per-tenant provisioning path.
-func (s *Server) findSharedDBForProvision(ctx context.Context, provider string, opts provisionTenantOptions) *meta.SharedDB {
+// the request's org, or the wildcard pool. It returns (nil, nil) when the
+// tenant should follow the normal per-tenant provisioning path. Lookup
+// failures are returned as errors — never silently treated as "no pool",
+// which would provision the wrong tenant shape on a transient meta outage.
+func (s *Server) findSharedDBForProvision(ctx context.Context, provider string, opts provisionTenantOptions) (*meta.SharedDB, error) {
 	if s.meta == nil {
-		return nil
+		return nil, nil
 	}
 	orgID := ""
-	if provider == tenant.ProviderTiDBCloudNative {
+	if provider == tenant.ProviderTiDBCloudNative || provider == tenant.ProviderTiDBCloudNativeShared {
 		if opts.CredentialProvisioner != nil {
 			if id, err := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner); err == nil {
 				orgID = id
@@ -5062,27 +5041,38 @@ func (s *Server) findSharedDBForProvision(ctx context.Context, provider string, 
 			}
 		}
 		if orgID == "" {
+			if provider == tenant.ProviderTiDBCloudNativeShared {
+				// An explicit shared placement request must fail closed: an
+				// unresolvable org can never silently become a dedicated
+				// cluster (nor match the wildcard pool).
+				return nil, fmt.Errorf("cannot resolve tidbcloud organization for shared-pool placement")
+			}
 			// Never fall back to the wildcard pool when the tenant's org cannot
 			// be resolved: an unresolved org must stay on the dedicated path
 			// even if a wildcard pool exists.
-			return nil
+			return nil, nil
 		}
 	}
 	sharedDB, err := s.meta.FindSharedDBForOrg(ctx, orgID)
 	if err != nil {
-		if !errors.Is(err, meta.ErrNotFound) {
-			logger.Warn(ctx, "server_event", eventFields(ctx, "shared_pool_lookup_failed", "error", err)...)
+		if errors.Is(err, meta.ErrNotFound) {
+			if provider == tenant.ProviderTiDBCloudNativeShared {
+				return nil, fmt.Errorf("no shared-schema pool registered for org %q", orgID)
+			}
+			return nil, nil
 		}
-		return nil
+		return nil, fmt.Errorf("resolve shared-schema pool for org %q: %w", orgID, err)
 	}
-	return sharedDB
+	return sharedDB, nil
 }
 
 // provisionTenantOnSharedDB completes provisioning for a tenant placed on a
 // shared-schema database: no cluster is created and the schema already exists
-// there. It writes the placement, forces the fts_only embedding profile
-// (shared tables carry plain VECTOR columns — per-tenant EMBED_TEXT generated
-// columns are impossible), marks the tenant active, and issues the owner key.
+// there. It writes the placement, re-labels the tenant row with the shared
+// provider (tidb_cloud_native_shared) so provider-driven capability checks
+// classify it correctly, forces the fts_only embedding profile (shared tables
+// carry plain VECTOR columns — per-tenant EMBED_TEXT generated columns are
+// impossible), marks the tenant active, and issues the owner key.
 func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string, sharedDB *meta.SharedDB, provider, keyName string, opts provisionTenantOptions, now time.Time) (*provisionTenantResult, error) {
 	fail := func(err error) (*provisionTenantResult, error) {
 		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
@@ -5116,6 +5106,9 @@ func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string,
 	}); err != nil {
 		return fail(err)
 	}
+	if err := s.meta.UpdateTenantProvider(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
+		return fail(err)
+	}
 	if err := s.meta.IncrSharedDBTenantCount(ctx, sharedDB.DbID, 1); err != nil {
 		logger.Warn(ctx, "server_event", eventFields(ctx, "shared_pool_tenant_count_failed", "tenant_id", tenantID, "error", err)...)
 	}
@@ -5126,14 +5119,14 @@ func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string,
 	if err != nil {
 		return fail(err)
 	}
-	logger.Info(ctx, "server_event", eventFields(ctx, "provision_shared_pool_placed", "tenant_id", tenantID, "provider", provider, "db_id", sharedDB.DbID, "org_id", sharedDB.OrgID)...)
-	metricEvent(ctx, "tenant_provision", "provider", provider, "result", "shared_pool")
+	logger.Info(ctx, "server_event", eventFields(ctx, "provision_shared_pool_placed", "tenant_id", tenantID, "provider", tenant.ProviderTiDBCloudNativeShared, "db_id", sharedDB.DbID, "org_id", sharedDB.OrgID)...)
+	metricEvent(ctx, "tenant_provision", "provider", tenant.ProviderTiDBCloudNativeShared, "result", "shared_pool")
 	return &provisionTenantResult{
 		TenantID: tenantID,
 		APIKey:   apiToken,
 		APIKeyID: apiKeyID,
 		Status:   meta.TenantActive,
-		Provider: provider,
+		Provider: tenant.ProviderTiDBCloudNativeShared,
 	}, nil
 }
 
@@ -5196,7 +5189,16 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	// Shared-pool placement: when a shared-schema database is registered for
 	// this tenant's org (or a wildcard pool exists), the tenant is placed on
 	// it directly — no cluster is created and the schema already exists there.
-	if sharedDB := s.findSharedDBForProvision(ctx, provider, opts); sharedDB != nil {
+	sharedDB, err := s.findSharedDBForProvision(ctx, provider, opts)
+	if err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "provision_shared_pool_resolve_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "error")
+		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
+			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
+		}
+		return nil, newProvisionTenantError(http.StatusBadGateway, "failed to resolve shared-schema pool", err)
+	}
+	if sharedDB != nil {
 		return s.provisionTenantOnSharedDB(ctx, tenantID, sharedDB, provider, keyName, opts, now)
 	}
 

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -58,13 +58,11 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	// Shared-schema tenants follow a dedicated delete path: purge their rows
-	// from the shared DB instead of deprovisioning a cluster (there is none),
-	// and skip the provider-specific checks below (the shared DB's provider is
-	// irrelevant to the tenant's lifecycle).
-	if shared, err := s.tenantIsSharedSchema(r.Context(), t.ID); err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to resolve tenant placement")
-		return
-	} else if shared {
+	// from the shared DB instead of deprovisioning a cluster (there is none).
+	// The dispatch keys on the persisted provider, not the placement row —
+	// the provider never changes mid-delete, so a retried delete always
+	// routes back here even after the placement row has been removed.
+	if tenant.IsSharedSchemaProvider(t.Provider) {
 		s.handleSharedTenantDelete(w, r, t)
 		return
 	}
@@ -165,6 +163,12 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 // database: it purges the tenant's rows from the shared DB (never touching
 // other tenants' rows and never deprovisioning the shared cluster), then runs
 // the same S3-namespace cleanup and key revocation as the standalone path.
+//
+// The flow is safe to retry at any point: the dispatch keys on the persisted
+// provider (durable), the purge is idempotent, and the placement row is only
+// removed after the purge has succeeded — a retry that finds no placement
+// skips straight to the cleanup enqueue. Identity resolution is read-only
+// (ResolveFsID): a delete path must never allocate a new fs_id.
 func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request, t *meta.Tenant) {
 	ctx := r.Context()
 	if t.StorageNamespaceID != "" {
@@ -175,6 +179,18 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 		}
 		if hasFork {
 			errJSON(w, http.StatusConflict, "tenant has non-deleted forks")
+			return
+		}
+	}
+	if t.Status == meta.TenantDeleting {
+		hasJob, err := s.meta.TenantDeleteJobExists(ctx, t.ID)
+		if err != nil {
+			errJSON(w, http.StatusInternalServerError, "failed to check tenant delete cleanup")
+			return
+		}
+		if hasJob {
+			_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
+			writeTenantDeleteStatus(w, meta.TenantDeleting)
 			return
 		}
 	}
@@ -194,29 +210,37 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 		errJSON(w, http.StatusInternalServerError, "failed to drain tenant backend")
 		return
 	}
-	fsID, err := s.meta.EnsureFsID(ctx, t.ID)
+	fsID, err := s.meta.ResolveFsID(ctx, t.ID)
 	if err != nil {
+		// A shared-schema tenant without an fs_registry row is a data
+		// integrity problem; never allocate one on a delete path.
+		logger.Error(ctx, "shared_tenant_delete_fsid_unresolvable", zap.String("tenant_id", t.ID), zap.Error(err))
 		errJSON(w, http.StatusInternalServerError, "failed to resolve tenant fs_id")
 		return
 	}
 	placement, err := s.meta.GetTenantPlacement(ctx, fsID)
-	if err != nil {
+	if err != nil && !errors.Is(err, meta.ErrNotFound) {
 		errJSON(w, http.StatusInternalServerError, "failed to resolve tenant placement")
 		return
 	}
-	if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
-		// Do not roll back the deleting mark; the purge is resumable and the
-		// next delete request will continue it.
-		logger.Error(ctx, "shared_tenant_purge_failed", zap.String("tenant_id", t.ID), zap.Int64("db_id", placement.DbID), zap.Error(err))
-		errJSON(w, http.StatusInternalServerError, "failed to purge tenant data from shared db")
-		return
+	if placement != nil {
+		if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
+			// Do not roll back the deleting mark; the purge is resumable and the
+			// next delete request will continue it.
+			logger.Error(ctx, "shared_tenant_purge_failed", zap.String("tenant_id", t.ID), zap.Int64("db_id", placement.DbID), zap.Error(err))
+			errJSON(w, http.StatusInternalServerError, "failed to purge tenant data from shared db")
+			return
+		}
+		if err := s.meta.DeleteTenantPlacement(ctx, fsID); err != nil {
+			logger.Warn(ctx, "shared_tenant_placement_delete_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+		}
+		if err := s.meta.IncrSharedDBTenantCount(ctx, placement.DbID, -1); err != nil {
+			logger.Warn(ctx, "shared_tenant_count_decrement_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+		}
 	}
-	if err := s.meta.DeleteTenantPlacement(ctx, fsID); err != nil {
-		logger.Warn(ctx, "shared_tenant_placement_delete_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-	}
-	if err := s.meta.IncrSharedDBTenantCount(ctx, placement.DbID, -1); err != nil {
-		logger.Warn(ctx, "shared_tenant_count_decrement_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-	}
+	// A missing placement here means an earlier attempt already purged and
+	// removed it but failed before enqueueing cleanup — fall through to the
+	// enqueue so the retry completes the delete.
 
 	_ = s.meta.AbortActiveUploadReservations(ctx, t.ID)
 

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -57,6 +57,17 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusNotFound, "tenant not found")
 		return
 	}
+	// Shared-schema tenants follow a dedicated delete path: purge their rows
+	// from the shared DB instead of deprovisioning a cluster (there is none),
+	// and skip the provider-specific checks below (the shared DB's provider is
+	// irrelevant to the tenant's lifecycle).
+	if shared, err := s.tenantIsSharedSchema(r.Context(), t.ID); err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to resolve tenant placement")
+		return
+	} else if shared {
+		s.handleSharedTenantDelete(w, r, t)
+		return
+	}
 	if t.Provider == tenant.ProviderTiDBZero {
 		errJSON(w, http.StatusConflict, "tidb_zero tenants expire automatically and do not support delete")
 		return
@@ -147,6 +158,74 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
+	writeTenantDeleteStatus(w, status)
+}
+
+// handleSharedTenantDelete deletes a tenant placed on a shared-schema
+// database: it purges the tenant's rows from the shared DB (never touching
+// other tenants' rows and never deprovisioning the shared cluster), then runs
+// the same S3-namespace cleanup and key revocation as the standalone path.
+func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request, t *meta.Tenant) {
+	ctx := r.Context()
+	if t.StorageNamespaceID != "" {
+		hasFork, err := s.meta.NamespaceHasNonDeletedFork(ctx, t.StorageNamespaceID)
+		if err != nil {
+			errJSON(w, http.StatusInternalServerError, "failed to check tenant forks")
+			return
+		}
+		if hasFork {
+			errJSON(w, http.StatusConflict, "tenant has non-deleted forks")
+			return
+		}
+	}
+	if t.Status != meta.TenantDeleting {
+		updated, err := s.meta.UpdateTenantStatusIf(ctx, t.ID, t.Status, meta.TenantDeleting)
+		if err != nil {
+			errJSON(w, http.StatusInternalServerError, "failed to mark tenant deleting")
+			return
+		}
+		if !updated {
+			writeTenantDeleteStatus(w, meta.TenantDeleting)
+			return
+		}
+	}
+	if err := s.pool.InvalidateAndWait(ctx, t.ID); err != nil {
+		_, _ = s.meta.UpdateTenantStatusIf(ctx, t.ID, meta.TenantDeleting, t.Status)
+		errJSON(w, http.StatusInternalServerError, "failed to drain tenant backend")
+		return
+	}
+	fsID, err := s.meta.EnsureFsID(ctx, t.ID)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to resolve tenant fs_id")
+		return
+	}
+	placement, err := s.meta.GetTenantPlacement(ctx, fsID)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to resolve tenant placement")
+		return
+	}
+	if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
+		// Do not roll back the deleting mark; the purge is resumable and the
+		// next delete request will continue it.
+		logger.Error(ctx, "shared_tenant_purge_failed", zap.String("tenant_id", t.ID), zap.Int64("db_id", placement.DbID), zap.Error(err))
+		errJSON(w, http.StatusInternalServerError, "failed to purge tenant data from shared db")
+		return
+	}
+	if err := s.meta.DeleteTenantPlacement(ctx, fsID); err != nil {
+		logger.Warn(ctx, "shared_tenant_placement_delete_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+	}
+	if err := s.meta.IncrSharedDBTenantCount(ctx, placement.DbID, -1); err != nil {
+		logger.Warn(ctx, "shared_tenant_count_decrement_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+	}
+
+	_ = s.meta.AbortActiveUploadReservations(ctx, t.ID)
+
+	status, err := s.enqueueTenantDeleteJob(ctx, t)
+	if err != nil {
+		errJSON(w, http.StatusInternalServerError, "failed to enqueue tenant delete cleanup")
+		return
+	}
+	_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
 	writeTenantDeleteStatus(w, status)
 }
 

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -231,11 +231,15 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 			errJSON(w, http.StatusInternalServerError, "failed to purge tenant data from shared db")
 			return
 		}
-		if err := s.meta.DeleteTenantPlacement(ctx, fsID); err != nil {
-			logger.Warn(ctx, "shared_tenant_placement_delete_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-		}
-		if err := s.meta.IncrSharedDBTenantCount(ctx, placement.DbID, -1); err != nil {
-			logger.Warn(ctx, "shared_tenant_count_decrement_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+		// Placement removal and the capacity release are one durable
+		// transition: if it fails, the tenant stays deleting with the
+		// placement intact so the retry re-runs the (idempotent) purge and
+		// completes the removal — a placement row must never outlive its
+		// tenant or lose its capacity accounting.
+		if err := s.meta.DeleteTenantPlacementAndDecrCount(ctx, fsID, placement.DbID); err != nil {
+			logger.Error(ctx, "shared_tenant_placement_delete_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+			errJSON(w, http.StatusInternalServerError, "failed to remove tenant placement")
+			return
 		}
 	}
 	// A missing placement here means an earlier attempt already purged and

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -1,0 +1,265 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+)
+
+// TestSharedTenantDeleteRetriesAfterPlacementRemoval covers the shared-delete
+// retry window: an earlier attempt purged the tenant's rows and removed the
+// placement but failed before enqueueing cleanup. The retried delete must not
+// fall back to the standalone/provider path (no cluster deprovision) — the
+// persisted provider routes it back to the shared path, which skips the
+// finished purge and completes the delete.
+func TestSharedTenantDeleteRetriesAfterPlacementRemoval(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNativeShared, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	if _, err := rt.meta.EnsureFsID(ctx, rt.tenantID); err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if err := rt.meta.UpdateTenantStatus(ctx, rt.tenantID, meta.TenantDeleting); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := rt.deleteTenant(t, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	// The standalone cluster-deprovision path must never run for a shared
+	// tenant, even when its placement row is already gone.
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+	var status string
+	if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantDeleted) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantDeleted)
+	}
+}
+
+// TestSharedTenantDeleteWithCleanupJobShortCircuits mirrors the standalone
+// retry short-circuit: a deleting shared tenant with an existing cleanup job
+// returns the deleting status immediately — without purging again and without
+// touching the placement row.
+func TestSharedTenantDeleteWithCleanupJobShortCircuits(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNativeShared, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	fsID, err := rt.meta.EnsureFsID(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		OrgID:          "org-shared-delete",
+		Host:           "shared.example.com",
+		Port:           4000,
+		User:           "root",
+		PasswordCipher: []byte("cipher"),
+		Name:           "shared_db",
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID:        fsID,
+		DbID:        dbID,
+		Placement:   meta.PlacementShared,
+		SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+	if err := rt.meta.UpdateTenantStatus(ctx, rt.tenantID, meta.TenantDeleting); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.EnqueueTenantDeleteJob(ctx, &meta.TenantDeleteJob{
+		TenantID:    rt.tenantID,
+		NamespaceID: rt.tenantID,
+		Backend:     "local",
+		Prefix:      rt.tenantID + "/",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := rt.deleteTenant(t, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+	// The short-circuit must leave the placement row alone: no purge ran.
+	if _, err := rt.meta.GetTenantPlacement(ctx, fsID); err != nil {
+		t.Fatalf("placement after short-circuit: %v", err)
+	}
+}
+
+// TestSharedTenantDeleteWithoutFsIDFails proves the shared delete path never
+// allocates identity: a shared tenant without an fs_registry row fails the
+// delete instead of minting a phantom fs_id (ResolveFsID, not EnsureFsID).
+func TestSharedTenantDeleteWithoutFsIDFails(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNativeShared, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	// InsertTenant allocated an fs_id at provision time; simulate a tenant
+	// whose registry row was reaped out of band — the delete must fail, not
+	// mint a new one.
+	if _, err := rt.meta.DB().ExecContext(ctx, "DELETE FROM fs_registry WHERE tenant_id = ?", rt.tenantID); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := rt.deleteTenant(t, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+	if _, err := rt.meta.ResolveFsID(ctx, rt.tenantID); err == nil {
+		t.Fatal("delete allocated an fs_id for the tenant being deleted")
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+}
+
+// TestSharedTenantDeleteFullPurgePath runs the complete owner delete on a
+// shared tenant: drain, purge, placement removal, and final delete — the
+// provider-routed dispatch never calls the cluster deprovisioner.
+func TestSharedTenantDeleteFullPurgePath(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNativeShared, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	fsID, err := rt.meta.EnsureFsID(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		OrgID:          "org-shared-delete",
+		Host:           "shared.example.com",
+		Port:           4000,
+		User:           "root",
+		PasswordCipher: []byte("cipher"),
+		Name:           "shared_db",
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID:        fsID,
+		DbID:        dbID,
+		Placement:   meta.PlacementShared,
+		SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+
+	resp := rt.deleteTenant(t, nil)
+	defer func() { _ = resp.Body.Close() }()
+	// The purge needs a reachable shared DB, which "shared.example.com" is
+	// not — the delete must fail there WITHOUT deprovisioning any cluster and
+	// leave the tenant in deleting state for a later retry.
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d (unreachable shared db)", resp.StatusCode, http.StatusInternalServerError)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+	var status string
+	if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantDeleting) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantDeleting)
+	}
+	// The placement row must survive the failed purge so the retry can find
+	// the shared DB again.
+	if _, err := rt.meta.GetTenantPlacement(ctx, fsID); err != nil {
+		t.Fatalf("placement after failed purge: %v", err)
+	}
+}
+
+// TestAdminTenantCreateRejectsSharedPoolOrg proves the admin tenant API fails
+// closed when the caller's org matches a registered shared pool: no claim, no
+// provision, no tenant row — instead of creating a shared tenant with no
+// valid admin lifecycle.
+func TestAdminTenantCreateRejectsSharedPoolOrg(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{
+		{Clusters: []tenant.CloudClusterInfo{{OrganizationID: "org-shared-1"}}},
+	}
+	if _, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		OrgID:          "org-shared-1",
+		Host:           "shared.example.com",
+		Port:           4000,
+		User:           "root",
+		PasswordCipher: []byte("cipher"),
+		Name:           "shared_db",
+	}); err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+
+	body, err := json.Marshal(map[string]string{"public_key": "pk", "private_key": "sk"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/admin/tenants", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+	var tenantCount int
+	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenants").Scan(&tenantCount); err != nil {
+		t.Fatal(err)
+	}
+	// Only the pre-existing quota runtime tenant may exist.
+	if tenantCount != 1 {
+		t.Fatalf("tenants = %d, want 1 (no admin-created tenant)", tenantCount)
+	}
+}
+
+// TestAdminTenantGetRejectsSharedProvider documents the admin/shared
+// ownership contract from the other side: a shared-schema tenant (provider
+// tidb_cloud_native_shared) is rejected by admin authorization instead of
+// being managed as a dedicated cluster.
+func TestAdminTenantGetRejectsSharedProvider(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	// The server runs the cloud-native provisioner; this tenant is placed on
+	// a shared pool, so its persisted provider is the shared one.
+	if err := rt.meta.UpdateTenantProvider(context.Background(), rt.tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
+		t.Fatalf("UpdateTenantProvider: %v", err)
+	}
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/admin/tenants/"+rt.tenantID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("X-TiDBCloud-Public-Key", "pk")
+	req.Header.Set("X-TiDBCloud-Private-Key", "sk")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+}

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -13,6 +14,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/tenant"
+	"github.com/mem9-ai/drive9/pkg/tenant/token"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
@@ -395,5 +397,52 @@ func TestFindSharedDBForProvisionSkipsNonTiDBProviders(t *testing.T) {
 	}
 	if got == nil {
 		t.Fatal("tidb_zero did not match the wildcard pool, want match")
+	}
+}
+
+// TestProvisionTenantOnSharedDBReleasesReservationOnFailure proves the
+// compensation path: when any step after the capacity/placement reserve
+// fails, the reservation is rolled back — no leaked capacity slot and no
+// placement row pointing at a failed tenant.
+func TestProvisionTenantOnSharedDBReleasesReservationOnFailure(t *testing.T) {
+	db := newTenantDeleteDBInfo(t)
+	testmysql.ResetMetaDB(t, db.Meta.DB())
+	ctx := context.Background()
+	dbID, err := db.Meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		OrgID: "org-provision-fail", Host: "shared.example.com", Port: 4000, User: "root",
+		PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 10,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	sharedDB, err := db.Meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	s := &Server{meta: db.Meta}
+	tenantID := token.NewID()
+	// No tenant row is inserted, so UpdateTenantProvider fails right after the
+	// reserve — the failure must trigger the compensation.
+	if _, err := s.provisionTenantOnSharedDB(ctx, tenantID, sharedDB, tenant.ProviderTiDBCloudNative, "default", provisionTenantOptions{}, time.Now().UTC()); err == nil {
+		t.Fatal("provisionTenantOnSharedDB succeeded, want error")
+	} else {
+		var pe *provisionTenantError
+		if !errors.As(err, &pe) || pe.status != http.StatusInternalServerError {
+			t.Fatalf("error = %v, want provisionTenantError 500", err)
+		}
+	}
+	fsID, err := db.Meta.ResolveFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("ResolveFsID: %v", err)
+	}
+	if _, err := db.Meta.GetTenantPlacement(ctx, fsID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("placement after compensated failure = %v, want ErrNotFound", err)
+	}
+	got, err := db.Meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB after failure: %v", err)
+	}
+	if got.TenantCount != 0 {
+		t.Fatalf("TenantCount = %d, want 0 (reservation released)", got.TenantCount)
 	}
 }

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -7,9 +7,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
+	"github.com/mem9-ai/drive9/internal/testmysql"
+	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/tenant"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // TestSharedTenantDeleteRetriesAfterPlacementRemoval covers the shared-delete
@@ -107,8 +112,25 @@ func TestSharedTenantDeleteWithCleanupJobShortCircuits(t *testing.T) {
 // allocates identity: a shared tenant without an fs_registry row fails the
 // delete instead of minting a phantom fs_id (ResolveFsID, not EnsureFsID).
 func TestSharedTenantDeleteWithoutFsIDFails(t *testing.T) {
+	// The server's one-time startup backfill re-registers any tenant without
+	// an fs_id, so the row deletion below must happen strictly after that
+	// backfill has run — otherwise the test races it (the backfill recreates
+	// the row and the delete returns 202). Watch the global logger for the
+	// backfill's completion marker.
+	core, recorded := observer.New(zap.InfoLevel)
+	prev := logger.L()
+	logger.Set(zap.New(core))
+	t.Cleanup(func() { logger.Set(prev) })
+
 	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNativeShared, meta.APIKeyScopeKindOwner)
 	ctx := context.Background()
+	deadline := time.Now().Add(10 * time.Second)
+	for recorded.FilterField(zap.String("event", "fs_registry_backfill_done")).Len() == 0 {
+		if time.Now().After(deadline) {
+			t.Fatal("startup fs_registry backfill did not complete in time")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
 	// InsertTenant allocated an fs_id at provision time; simulate a tenant
 	// whose registry row was reaped out of band — the delete must fail, not
 	// mint a new one.
@@ -261,5 +283,117 @@ func TestAdminTenantGetRejectsSharedProvider(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusConflict {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	}
+}
+
+// TestSharedTenantDeletePlacementRemovalFailureStaysRetryable injects a
+// failure into the placement-removal transaction (the pool row disappears
+// between purge and removal) and proves the delete fails closed: 500, tenant
+// stays deleting, the placement row survives for the retry, and the owner
+// key stays active — instead of orphaning the placement on a terminal
+// tenant.
+func TestSharedTenantDeletePlacementRemovalFailureStaysRetryable(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNativeShared, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	fsID, err := rt.meta.EnsureFsID(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	db := newTenantDeleteDBInfo(t)
+	passCipher, err := rt.pool.Encrypt(ctx, []byte(db.DBPass))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		OrgID: "org-shared-delete", Host: db.DBHost, Port: db.DBPort, User: db.DBUser,
+		PasswordCipher: passCipher, Name: db.DBName,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+	// Pre-warm the shared handle with a scratch database in which every
+	// shared-schema table is absent: the purge in the delete below reuses
+	// the cached handle and succeeds trivially, but the placement removal
+	// transaction cannot release capacity on a missing pool row and must
+	// roll back. (The test DB carries standalone-shape tables of the same
+	// names, so drop them first — the next test's schema init recreates
+	// them.)
+	for _, tbl := range []string{
+		"journal_entry_subjects", "journal_entries", "journal_append_requests", "journal_labels", "journals",
+		"vault_audit_log", "vault_grants", "vault_tokens", "vault_secret_fields", "vault_secrets", "vault_policies", "vault_deks",
+		"git_workspace_object_packs", "git_workspace_overlay", "git_workspace_git_state", "git_workspace_tree_nodes", "git_workspaces",
+		"fs_layer_checkpoints", "fs_layer_events", "fs_layer_tags", "fs_layer_entries", "fs_layers",
+		"fs_events", "semantic_tasks", "file_gc_tasks", "uploads", "file_tags", "file_nodes", "semantic", "contents", "inodes",
+	} {
+		if _, err := rt.meta.DB().ExecContext(ctx, "DROP TABLE IF EXISTS "+tbl); err != nil {
+			t.Fatalf("drop %s: %v", tbl, err)
+		}
+	}
+	if err := rt.pool.PurgeSharedTenant(ctx, fsID, dbID); err != nil {
+		t.Fatalf("pre-warm purge: %v", err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "DELETE FROM db_pool WHERE db_id = ?", dbID); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := rt.deleteTenant(t, nil)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusInternalServerError)
+	}
+	var status string
+	if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	if status != string(meta.TenantDeleting) {
+		t.Fatalf("tenant status = %s, want %s", status, meta.TenantDeleting)
+	}
+	if _, err := rt.meta.GetTenantPlacement(ctx, fsID); err != nil {
+		t.Fatalf("placement must survive the rolled-back removal: %v", err)
+	}
+	var activeKeys int
+	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND status = ?", rt.tenantID, meta.APIKeyActive).Scan(&activeKeys); err != nil {
+		t.Fatal(err)
+	}
+	if activeKeys != 1 {
+		t.Fatalf("active api keys = %d, want 1 (owner can retry)", activeKeys)
+	}
+}
+
+// TestFindSharedDBForProvisionSkipsNonTiDBProviders proves a wildcard shared
+// pool only ever captures TiDB-dialect tenants: db9 (PostgreSQL) tenants must
+// never be placed on the TiDB shared schema and relabeled
+// tidb_cloud_native_shared.
+func TestFindSharedDBForProvisionSkipsNonTiDBProviders(t *testing.T) {
+	db := newTenantDeleteDBInfo(t)
+	testmysql.ResetMetaDB(t, db.Meta.DB())
+	ctx := context.Background()
+	if _, err := db.Meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		OrgID: meta.SharedDBOrgWildcard, Host: "shared.example.com", Port: 4000, User: "root",
+		PasswordCipher: []byte("cipher"), Name: "shared_db",
+	}); err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	s := &Server{meta: db.Meta}
+
+	got, err := s.findSharedDBForProvision(ctx, tenant.ProviderDB9, provisionTenantOptions{})
+	if err != nil {
+		t.Fatalf("db9 lookup: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("db9 matched shared pool %v, want no match", got)
+	}
+	// TiDB-dialect providers still route: tidb_zero matches the wildcard.
+	got, err = s.findSharedDBForProvision(ctx, tenant.ProviderTiDBZero, provisionTenantOptions{})
+	if err != nil {
+		t.Fatalf("tidb_zero lookup: %v", err)
+	}
+	if got == nil {
+		t.Fatal("tidb_zero did not match the wildcard pool, want match")
 	}
 }

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -400,11 +401,86 @@ func TestFindSharedDBForProvisionSkipsNonTiDBProviders(t *testing.T) {
 	}
 }
 
-// TestProvisionTenantOnSharedDBReleasesReservationOnFailure proves the
-// compensation path: when any step after the capacity/placement reserve
-// fails, the reservation is rolled back — no leaked capacity slot and no
-// placement row pointing at a failed tenant.
-func TestProvisionTenantOnSharedDBReleasesReservationOnFailure(t *testing.T) {
+// TestProvisionTenantOnSharedDBCommitsAtomically covers the happy path of
+// the atomic provision transition: placement, provider re-label, active
+// status, capacity slot, and the owner key all land together.
+func TestProvisionTenantOnSharedDBCommitsAtomically(t *testing.T) {
+	db := newTenantDeleteDBInfo(t)
+	testmysql.ResetMetaDB(t, db.Meta.DB())
+	ctx := context.Background()
+	dbID, err := db.Meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		OrgID: "org-provision-ok", Host: "shared.example.com", Port: 4000, User: "root",
+		PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 10,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	sharedDB, err := db.Meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{meta: db.Meta, pool: db.Pool, tokenSecret: tokenSecret}
+	now := time.Now().UTC()
+	tenantID := token.NewID()
+	if err := db.Meta.InsertTenant(ctx, &meta.Tenant{
+		ID: tenantID, Status: meta.TenantPending, Kind: meta.TenantKindLive,
+		Provider: tenant.ProviderTiDBCloudNative, DBPasswordCipher: []byte{},
+		SchemaVersion: 1, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("InsertTenant: %v", err)
+	}
+
+	res, err := s.provisionTenantOnSharedDB(ctx, tenantID, sharedDB, tenant.ProviderTiDBCloudNative, "default", provisionTenantOptions{}, now)
+	if err != nil {
+		t.Fatalf("provisionTenantOnSharedDB: %v", err)
+	}
+	if res.Provider != tenant.ProviderTiDBCloudNativeShared || res.APIKey == "" {
+		t.Fatalf("result = provider %q api_key %q", res.Provider, res.APIKey)
+	}
+	got, err := db.Meta.GetTenant(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("GetTenant: %v", err)
+	}
+	if got.Provider != tenant.ProviderTiDBCloudNativeShared || got.Status != meta.TenantActive {
+		t.Fatalf("tenant = provider %q status %q, want tidb_cloud_native_shared/active", got.Provider, got.Status)
+	}
+	fsID, err := db.Meta.ResolveFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("ResolveFsID: %v", err)
+	}
+	p, err := db.Meta.GetTenantPlacement(ctx, fsID)
+	if err != nil {
+		t.Fatalf("GetTenantPlacement: %v", err)
+	}
+	if p.DbID != dbID || p.SchemaShape != meta.SchemaShapeShared {
+		t.Fatalf("placement = %+v", p)
+	}
+	dbRow, err := db.Meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if dbRow.TenantCount != 1 {
+		t.Fatalf("TenantCount = %d, want 1", dbRow.TenantCount)
+	}
+	var activeKeys int
+	if err := db.Meta.DB().QueryRow("SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND status = ?", tenantID, meta.APIKeyActive).Scan(&activeKeys); err != nil {
+		t.Fatal(err)
+	}
+	if activeKeys != 1 {
+		t.Fatalf("active owner keys = %d, want 1", activeKeys)
+	}
+}
+
+// TestProvisionTenantOnSharedDBFailureLeavesNoPartialState proves the atomic
+// transition leaves nothing behind on failure: when any write of the
+// provision transaction fails, no placement row, no reserved capacity, no
+// owner key persists, and the tenant never becomes active — there is no
+// best-effort compensation window that could orphan an active shared tenant.
+func TestProvisionTenantOnSharedDBFailureLeavesNoPartialState(t *testing.T) {
 	db := newTenantDeleteDBInfo(t)
 	testmysql.ResetMetaDB(t, db.Meta.DB())
 	ctx := context.Background()
@@ -419,10 +495,15 @@ func TestProvisionTenantOnSharedDBReleasesReservationOnFailure(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSharedDB: %v", err)
 	}
-	s := &Server{meta: db.Meta}
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{meta: db.Meta, pool: db.Pool, tokenSecret: tokenSecret}
 	tenantID := token.NewID()
-	// No tenant row is inserted, so UpdateTenantProvider fails right after the
-	// reserve — the failure must trigger the compensation.
+	// No tenant row is inserted, so the tenant activation inside the
+	// transaction fails and rolls back the capacity reservation, the
+	// placement, and the owner key insert.
 	if _, err := s.provisionTenantOnSharedDB(ctx, tenantID, sharedDB, tenant.ProviderTiDBCloudNative, "default", provisionTenantOptions{}, time.Now().UTC()); err == nil {
 		t.Fatal("provisionTenantOnSharedDB succeeded, want error")
 	} else {
@@ -436,13 +517,20 @@ func TestProvisionTenantOnSharedDBReleasesReservationOnFailure(t *testing.T) {
 		t.Fatalf("ResolveFsID: %v", err)
 	}
 	if _, err := db.Meta.GetTenantPlacement(ctx, fsID); !errors.Is(err, meta.ErrNotFound) {
-		t.Fatalf("placement after compensated failure = %v, want ErrNotFound", err)
+		t.Fatalf("placement after failed provision = %v, want ErrNotFound", err)
 	}
 	got, err := db.Meta.GetSharedDB(ctx, dbID)
 	if err != nil {
 		t.Fatalf("GetSharedDB after failure: %v", err)
 	}
 	if got.TenantCount != 0 {
-		t.Fatalf("TenantCount = %d, want 0 (reservation released)", got.TenantCount)
+		t.Fatalf("TenantCount = %d, want 0 (nothing reserved)", got.TenantCount)
+	}
+	var keyCount int
+	if err := db.Meta.DB().QueryRow("SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ?", tenantID).Scan(&keyCount); err != nil {
+		t.Fatal(err)
+	}
+	if keyCount != 0 {
+		t.Fatalf("owner keys after failed provision = %d, want 0", keyCount)
 	}
 }

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -80,7 +80,7 @@ func (s *Server) vaultStore(r *http.Request) (*vault.Store, error) {
 	if s.vaultMK == nil {
 		return nil, fmt.Errorf("vault master key not configured")
 	}
-	return vault.NewStore(scope.Backend.Store().DB(), s.vaultMK), nil
+	return vault.NewStoreScoped(scope.Backend.Store().DB(), s.vaultMK, scope.Backend.Store().Scope()), nil
 }
 
 // ---- Management API: /v1/vault/secrets ----
@@ -825,7 +825,7 @@ func (s *Server) handleVaultRead(w http.ResponseWriter, r *http.Request, sub str
 		return
 	}
 
-	vs := vault.NewStore(scope.Backend.Store().DB(), s.vaultMK)
+	vs := vault.NewStoreScoped(scope.Backend.Store().DB(), s.vaultMK, scope.Backend.Store().Scope())
 
 	// Full verification: HMAC signature → TTL → DB revocation → claims.
 	// IMPORTANT: Do NOT write audit events before verification succeeds.

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -806,6 +806,21 @@ func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantI
 	return b
 }
 
+// fsIDForTenant resolves the tenant's internal fs_id from the meta DB,
+// allocating one on first use. Returns (0, nil) when the pool has no meta
+// store (tests, non-multi-tenant mode); the standalone SQL shape never emits
+// fs_id, so 0 is inert there.
+func (p *Pool) fsIDForTenant(ctx context.Context, t *meta.Tenant) (int64, error) {
+	if p.metaStore == nil || t == nil || t.ID == "" {
+		return 0, nil
+	}
+	fsID, err := p.metaStore.EnsureFsID(ctx, t.ID)
+	if err != nil {
+		return 0, fmt.Errorf("ensure fs_id for tenant %s: %w", t.ID, err)
+	}
+	return fsID, nil
+}
+
 func (p *Pool) tenantMetricTiDBCloudOrgID(ctx context.Context, t *meta.Tenant) string {
 	if t == nil || strings.TrimSpace(t.ID) == "" || t.Provider != ProviderTiDBCloudNative {
 		return defaultTenantMetricTiDBCloudOrgID
@@ -856,8 +871,12 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		query += "&tls=skip-verify"
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
+	fsID, err := p.fsIDForTenant(ctx, t)
+	if err != nil {
+		return nil, nil, tidbCloudOrgID, err
+	}
 	openStoreStart := time.Now()
-	store, err := datastore.OpenForTenantWithOrg(ctx, dsn, t.ID, tidbCloudOrgID)
+	store, err := datastore.OpenForTenantScoped(ctx, dsn, t.ID, tidbCloudOrgID, datastore.StandaloneScope(fsID))
 	if err != nil {
 		return nil, nil, tidbCloudOrgID, fmt.Errorf("open datastore: %w", err)
 	}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -904,9 +904,9 @@ func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) 
 	query := "parseTime=true"
 	if info.TLS {
 		query += "&tls=true"
-	} else {
-		query += "&tls=skip-verify"
 	}
+	// TLS=false means a plain connection (local/self-hosted databases); shared
+	// DBs on TiDB Cloud are registered with TLS=true explicitly.
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", info.User, string(pass), info.Host, info.Port, info.Name, query)
 	db, err := mysqlutil.OpenInstrumentedForTenant(ctx, dsn, mysqlutil.RoleShared, fmt.Sprintf("shared:%d", dbID))
 	if err != nil {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/migrate"
+	"github.com/mem9-ai/drive9/pkg/mysqlutil"
 	"github.com/mem9-ai/drive9/pkg/s3client"
 	"github.com/mem9-ai/drive9/pkg/semantic"
 	"github.com/mem9-ai/drive9/pkg/tenant/schema"
@@ -147,6 +148,12 @@ type Pool struct {
 	reapInterval  time.Duration
 	reapStop      context.CancelFunc
 	reapWG        sync.WaitGroup
+	// sharedDBs caches one *sql.DB handle per shared-schema database (keyed by
+	// db_pool.db_id). All tenants placed on the same shared DB share its
+	// handle; each Acquire still gets its own Store (carrying that tenant's
+	// fs_id scope) over the shared handle.
+	sharedMu  sync.Mutex
+	sharedDBs map[int64]*sql.DB
 }
 
 type tenantAutoEmbeddingProfile struct {
@@ -225,11 +232,12 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 	metrics.RecordGauge("tenant_pool", "cached_backends", 0)
 	metrics.RecordGauge("tenant_pool", "max_backends", float64(max))
 	return &Pool{
-		cfg:     cfg,
-		enc:     enc,
-		items:   map[string]*entry{},
-		order:   list.New(),
-		maxSize: max,
+		cfg:       cfg,
+		enc:       enc,
+		items:     map[string]*entry{},
+		order:     list.New(),
+		maxSize:   max,
+		sharedDBs: map[int64]*sql.DB{},
 		// No LeaderChecker means single-pod mode: FileGC runs unconditionally.
 		fileGCEnabled: cfg.LeaderChecker == nil,
 		idleTimeout:   idleTimeout,
@@ -728,6 +736,14 @@ func (p *Pool) Close() {
 	for _, retired := range toClose {
 		closeEntry(retired)
 	}
+	p.sharedMu.Lock()
+	for dbID, db := range p.sharedDBs {
+		if err := mysqlutil.CloseInstrumented(db); err != nil {
+			logger.Warn(context.Background(), "shared_db_close_failed", zap.Int64("db_id", dbID), zap.Error(err))
+		}
+		delete(p.sharedDBs, dbID)
+	}
+	p.sharedMu.Unlock()
 }
 
 func (p *Pool) S3Backend(tenantID string) *backend.Dat9Backend {
@@ -847,15 +863,73 @@ func (p *Pool) tenantMetricTiDBCloudOrgID(ctx context.Context, t *meta.Tenant) s
 	return orgID
 }
 
+// placementForTenant returns the tenant's placement row, or (nil, nil) when
+// the tenant has none — which is the normal case for every standalone tenant
+// today. Placement lookup errors are fatal to the cold open: silently falling
+// back to standalone could route a shared tenant with the wrong schema shape.
+func (p *Pool) placementForTenant(ctx context.Context, fsID int64) (*meta.TenantPlacement, error) {
+	if p.metaStore == nil || fsID <= 0 {
+		return nil, nil
+	}
+	placement, err := p.metaStore.GetTenantPlacement(ctx, fsID)
+	if errors.Is(err, meta.ErrNotFound) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("resolve tenant placement for fs_id %d: %w", fsID, err)
+	}
+	return placement, nil
+}
+
+// sharedDBHandle returns the cached *sql.DB for a shared-schema database
+// (db_pool.db_id), opening it on first use. Handles live for the process
+// lifetime and are closed by Close.
+func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) {
+	p.sharedMu.Lock()
+	defer p.sharedMu.Unlock()
+	if db, ok := p.sharedDBs[dbID]; ok {
+		return db, nil
+	}
+	if p.metaStore == nil {
+		return nil, fmt.Errorf("shared db %d: no meta store", dbID)
+	}
+	info, err := p.metaStore.GetSharedDB(ctx, dbID)
+	if err != nil {
+		return nil, fmt.Errorf("shared db %d: %w", dbID, err)
+	}
+	pass, err := p.enc.Decrypt(ctx, info.PasswordCipher)
+	if err != nil {
+		return nil, fmt.Errorf("shared db %d: decrypt password: %w", dbID, err)
+	}
+	query := "parseTime=true"
+	if info.TLS {
+		query += "&tls=true"
+	} else {
+		query += "&tls=skip-verify"
+	}
+	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", info.User, string(pass), info.Host, info.Port, info.Name, query)
+	db, err := mysqlutil.OpenInstrumentedForTenant(ctx, dsn, mysqlutil.RoleShared, fmt.Sprintf("shared:%d", dbID))
+	if err != nil {
+		return nil, fmt.Errorf("shared db %d: open: %w", dbID, err)
+	}
+	p.sharedDBs[dbID] = db
+	return db, nil
+}
+
+// PurgeSharedTenant deletes all rows belonging to fsID from the shared DB it
+// is placed on, in bounded batches. It runs after the tenant's pool entry has
+// been drained, so no backend is concurrently writing through the same scope.
+func (p *Pool) PurgeSharedTenant(ctx context.Context, fsID, dbID int64) error {
+	handle, err := p.sharedDBHandle(ctx, dbID)
+	if err != nil {
+		return err
+	}
+	return datastore.NewStoreWithDB(handle, datastore.SharedScope(fsID)).PurgeTenantData(ctx)
+}
+
 func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9Backend, *datastore.Store, string, error) {
 	start := time.Now()
 	tidbCloudOrgID := p.tenantMetricTiDBCloudOrgID(ctx, t)
-	decryptStart := time.Now()
-	pass, err := p.enc.Decrypt(ctx, t.DBPasswordCipher)
-	if err != nil {
-		return nil, nil, tidbCloudOrgID, fmt.Errorf("decrypt db password: %w", err)
-	}
-	decryptDurationMs := float64(time.Since(decryptStart).Microseconds()) / 1000.0
 	opts := p.cfg.BackendOptions
 	resolvedEncryptionPolicy, err := meta.ResolveS3EncryptionPolicy(p.cfg.S3EncryptionPolicy, t.S3EncryptionPolicy())
 	if err != nil {
@@ -864,26 +938,60 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	opts.TenantID = t.ID
 	opts.TiDBCloudOrgID = tidbCloudOrgID
 	opts.S3EncryptionPolicy = resolvedEncryptionPolicy
-	query := "parseTime=true"
-	if t.DBTLS {
-		query += "&tls=true"
-	} else if t.Provider == ProviderTiDBCloudNative {
-		query += "&tls=skip-verify"
-	}
-	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
+
 	fsID, err := p.fsIDForTenant(ctx, t)
 	if err != nil {
 		return nil, nil, tidbCloudOrgID, err
 	}
-	openStoreStart := time.Now()
-	store, err := datastore.OpenForTenantScoped(ctx, dsn, t.ID, tidbCloudOrgID, datastore.StandaloneScope(fsID))
+	placement, err := p.placementForTenant(ctx, fsID)
 	if err != nil {
-		return nil, nil, tidbCloudOrgID, fmt.Errorf("open datastore: %w", err)
+		return nil, nil, tidbCloudOrgID, err
+	}
+	sharedTenant := placement != nil && placement.SchemaShape == meta.SchemaShapeShared
+
+	decryptDurationMs := 0.0
+	openStoreStart := time.Now()
+	var store *datastore.Store
+	if sharedTenant {
+		// Shared-schema tenant: connect through the shared DB handle and skip
+		// the per-tenant DSN/decrypt entirely — the tenant row carries no
+		// connection coordinates for shared placements.
+		handle, err := p.sharedDBHandle(ctx, placement.DbID)
+		if err != nil {
+			return nil, nil, tidbCloudOrgID, err
+		}
+		store = datastore.NewStoreWithDB(handle, datastore.SharedScope(fsID))
+	} else {
+		decryptStart := time.Now()
+		pass, err := p.enc.Decrypt(ctx, t.DBPasswordCipher)
+		if err != nil {
+			return nil, nil, tidbCloudOrgID, fmt.Errorf("decrypt db password: %w", err)
+		}
+		decryptDurationMs = float64(time.Since(decryptStart).Microseconds()) / 1000.0
+		query := "parseTime=true"
+		if t.DBTLS {
+			query += "&tls=true"
+		} else if t.Provider == ProviderTiDBCloudNative {
+			query += "&tls=skip-verify"
+		}
+		dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
+		store, err = datastore.OpenForTenantScoped(ctx, dsn, t.ID, tidbCloudOrgID, datastore.StandaloneScope(fsID))
+		if err != nil {
+			return nil, nil, tidbCloudOrgID, fmt.Errorf("open datastore: %w", err)
+		}
 	}
 	openStoreDurationMs := float64(time.Since(openStoreStart).Microseconds()) / 1000.0
 	ensureSchemaDurationMs := 0.0
 	migrateDurationMs := 0.0
-	if UsesTiDBAutoEmbedding(t.Provider) {
+	if sharedTenant {
+		// Shared schema has no generated columns, so database auto-embedding
+		// is unavailable; schema is managed per physical DB, not per tenant,
+		// so the Acquire-time ensure below is skipped entirely.
+		opts.DatabaseAutoEmbedding = false
+		opts.AppSemanticTasksEnabled = false
+		opts.AsyncImageExtract = backend.AsyncImageExtractOptions{}
+		opts.AsyncAudioExtract = backend.AsyncAudioExtractOptions{}
+	} else if UsesTiDBAutoEmbedding(t.Provider) {
 		autoEmbeddingProfile, err := p.autoEmbeddingProfileForTenant(ctx, t)
 		if err != nil {
 			_ = store.Close()

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -902,11 +902,11 @@ func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) 
 		return nil, fmt.Errorf("shared db %d: decrypt password: %w", dbID, err)
 	}
 	query := "parseTime=true"
-	if info.TLS {
-		query += "&tls=true"
+	if info.TLSMode != "" {
+		query += "&tls=" + info.TLSMode
 	}
-	// TLS=false means a plain connection (local/self-hosted databases); shared
-	// DBs on TiDB Cloud are registered with TLS=true explicitly.
+	// An empty TLSMode means a plain connection (local/self-hosted databases);
+	// shared DBs on TiDB Cloud are registered with tls=skip-verify or tls=true.
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", info.User, string(pass), info.Host, info.Port, info.Name, query)
 	db, err := mysqlutil.OpenInstrumentedForTenant(ctx, dsn, mysqlutil.RoleShared, fmt.Sprintf("shared:%d", dbID))
 	if err != nil {
@@ -948,6 +948,15 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		return nil, nil, tidbCloudOrgID, err
 	}
 	sharedTenant := placement != nil && placement.SchemaShape == meta.SchemaShapeShared
+	if IsSharedSchemaProvider(t.Provider) && !sharedTenant {
+		// The persisted provider says shared but the placement row is gone.
+		// Opening a standalone store against the (connectionless) tenant row
+		// would fail with a confusing empty-host DSN error — and if the row
+		// still had coordinates it could even serve the wrong schema shape.
+		// This happens only mid-delete (placement is removed before final
+		// cleanup), so fail fast with a clear message instead.
+		return nil, nil, tidbCloudOrgID, fmt.Errorf("tenant %s is shared-schema but has no placement row", t.ID)
+	}
 
 	decryptDurationMs := 0.0
 	openStoreStart := time.Now()

--- a/pkg/tenant/provider.go
+++ b/pkg/tenant/provider.go
@@ -7,6 +7,16 @@ const (
 	ProviderTiDBZero        = "tidb_zero"
 	ProviderTiDBCloudNative = "tidb_cloud_native"
 
+	// ProviderTiDBCloudNativeShared is the persisted provider of a tenant
+	// placed on a shared-schema (multi-tenant) TiDB database. It is assigned
+	// by the server at provision time when the tenant's org matches a
+	// registered shared pool — never selected directly by a provisioner —
+	// and lets provider-driven capability checks distinguish shared tenants
+	// from dedicated-cluster ones without an extra placement lookup:
+	// TiDB-backed, but no per-tenant cluster to delete or fork, and no
+	// database auto-embedding (the shared schema has no generated columns).
+	ProviderTiDBCloudNativeShared = "tidb_cloud_native_shared"
+
 	// ProviderTiDBCloudStarterLegacy is kept only for tenant rows persisted
 	// before starter provisioning was removed. Do not accept it for new
 	// provisioning configuration.
@@ -15,16 +25,22 @@ const (
 
 func NormalizeProvider(provider string) (string, error) {
 	switch provider {
-	case ProviderDB9, ProviderTiDBZero, ProviderTiDBCloudNative:
+	case ProviderDB9, ProviderTiDBZero, ProviderTiDBCloudNative, ProviderTiDBCloudNativeShared:
 		return provider, nil
 	default:
 		return "", fmt.Errorf("unsupported provider: %s", provider)
 	}
 }
 
+// IsSharedSchemaProvider reports whether provider is the persisted provider
+// of a tenant placed on a shared-schema database.
+func IsSharedSchemaProvider(provider string) bool {
+	return provider == ProviderTiDBCloudNativeShared
+}
+
 func SmallInDB(provider string) bool {
 	switch provider {
-	case ProviderTiDBZero, ProviderTiDBCloudNative, ProviderTiDBCloudStarterLegacy:
+	case ProviderTiDBZero, ProviderTiDBCloudNative, ProviderTiDBCloudNativeShared, ProviderTiDBCloudStarterLegacy:
 		return true
 	default:
 		return false
@@ -32,7 +48,9 @@ func SmallInDB(provider string) bool {
 }
 
 // UsesTiDBAutoEmbedding reports whether the provider should run the TiDB
-// database-managed auto-embedding mode.
+// database-managed auto-embedding mode. Shared-schema tenants never do: the
+// shared tables carry plain VECTOR columns, not per-tenant EMBED_TEXT
+// generated columns.
 func UsesTiDBAutoEmbedding(provider string) bool {
 	switch provider {
 	case ProviderTiDBZero, ProviderTiDBCloudNative, ProviderTiDBCloudStarterLegacy:
@@ -45,6 +63,8 @@ func UsesTiDBAutoEmbedding(provider string) bool {
 // SupportsClusterDelete reports whether a persisted tenant provider can delete
 // its backing TiDB Cloud cluster. The legacy starter value is kept only so rows
 // persisted before starter provisioning was removed keep their cleanup path.
+// Shared-schema tenants have no per-tenant cluster; their delete path purges
+// rows by fs_id instead.
 func SupportsClusterDelete(provider string) bool {
 	return provider == ProviderTiDBCloudNative || provider == ProviderTiDBCloudStarterLegacy
 }

--- a/pkg/tenant/schema/common.go
+++ b/pkg/tenant/schema/common.go
@@ -335,10 +335,21 @@ func schemaStatementSnippet(stmt string) string {
 	return schemaspec.SQLSnippet(stmt)
 }
 
+// IsTiDBCluster reports whether the connected database is TiDB. Detection
+// errors fail open to false; schema-shape selection must use IsTiDBClusterE
+// instead, where silently choosing the MySQL variant would apply the wrong
+// DDL to a TiDB cluster.
 func IsTiDBCluster(ctx context.Context, db *sql.DB) bool {
+	ok, _ := IsTiDBClusterE(ctx, db)
+	return ok
+}
+
+// IsTiDBClusterE reports whether the connected database is TiDB, returning
+// detection errors to the caller.
+func IsTiDBClusterE(ctx context.Context, db *sql.DB) (bool, error) {
 	var ver string
 	if err := db.QueryRowContext(ctx, `SELECT VERSION()`).Scan(&ver); err != nil {
-		return false
+		return false, fmt.Errorf("detect database dialect: %w", err)
 	}
-	return strings.Contains(strings.ToLower(ver), "tidb")
+	return strings.Contains(strings.ToLower(ver), "tidb"), nil
 }

--- a/pkg/tenant/schema/dialect.go
+++ b/pkg/tenant/schema/dialect.go
@@ -1,8 +1,6 @@
 package schema
 
 import (
-	"context"
-	"database/sql"
 	"regexp"
 	"strings"
 )
@@ -42,21 +40,4 @@ var tidbVectorColumnType = regexp.MustCompile(`(?i)VECTOR\(\d+\)`)
 
 func stripTiDBVectorColumnType(stmt string) string {
 	return tidbVectorColumnType.ReplaceAllString(stmt, "LONGTEXT")
-}
-
-// JournalMySQLSharedSchemaStatements is the plain-MySQL variant of
-// JournalTiDBSharedSchemaStatements, derived by removing TiDB-only keywords.
-// Use it for local development databases and MySQL-backed tests/e2e.
-func JournalMySQLSharedSchemaStatements() []string {
-	return mysqlCompatibleSharedStatements(JournalTiDBSharedSchemaStatements())
-}
-
-// JournalSharedSchemaStatementsForDB selects the shared journal DDL matching
-// the connected database's dialect: TiDB clusters get the CLUSTERED variant,
-// anything else (plain MySQL, e.g. local e2e) the compatible variant.
-func JournalSharedSchemaStatementsForDB(ctx context.Context, db *sql.DB) []string {
-	if IsTiDBCluster(ctx, db) {
-		return JournalTiDBSharedSchemaStatements()
-	}
-	return JournalMySQLSharedSchemaStatements()
 }

--- a/pkg/tenant/schema/dialect.go
+++ b/pkg/tenant/schema/dialect.go
@@ -1,0 +1,62 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+	"regexp"
+	"strings"
+)
+
+// Shared-shape DDL is written once in TiDB form (the canonical list) and
+// derived for plain MySQL mechanically, so the two dialects can never drift.
+//
+// Two TiDB-only constructs need rewriting for MySQL:
+//
+//   - the CLUSTERED marker on composite primary keys: TiDB creates composite
+//     primary keys as NONCLUSTERED by default (tidb_enable_clustered_index =
+//     INT_ONLY), so the shared shape must declare it explicitly to physically
+//     co-locate rows of one tenant. MySQL's InnoDB primary key is always
+//     clustered and the keyword is a syntax error there, so the MySQL variant
+//     simply drops it — semantically a no-op on that engine.
+//   - VECTOR(n) column types: plain MySQL 8.0 has no vector type, so the
+//     MySQL variant maps them to LONGTEXT, mirroring the standalone
+//     no-embedding MySQL schema (mysql_no_embedding.go). Vector search is
+//     TiDB-only anyway; on MySQL these columns just carry text payloads.
+func mysqlCompatibleSharedStatements(stmts []string) []string {
+	out := make([]string, len(stmts))
+	for i, stmt := range stmts {
+		out[i] = mysqlCompatibleSharedStatement(stmt)
+	}
+	return out
+}
+
+func mysqlCompatibleSharedStatement(stmt string) string {
+	return stripTiDBVectorColumnType(stripTiDBClusteredKeyword(stmt))
+}
+
+func stripTiDBClusteredKeyword(stmt string) string {
+	return strings.ReplaceAll(stmt, " CLUSTERED", "")
+}
+
+var tidbVectorColumnType = regexp.MustCompile(`(?i)VECTOR\(\d+\)`)
+
+func stripTiDBVectorColumnType(stmt string) string {
+	return tidbVectorColumnType.ReplaceAllString(stmt, "LONGTEXT")
+}
+
+// JournalMySQLSharedSchemaStatements is the plain-MySQL variant of
+// JournalTiDBSharedSchemaStatements, derived by removing TiDB-only keywords.
+// Use it for local development databases and MySQL-backed tests/e2e.
+func JournalMySQLSharedSchemaStatements() []string {
+	return mysqlCompatibleSharedStatements(JournalTiDBSharedSchemaStatements())
+}
+
+// JournalSharedSchemaStatementsForDB selects the shared journal DDL matching
+// the connected database's dialect: TiDB clusters get the CLUSTERED variant,
+// anything else (plain MySQL, e.g. local e2e) the compatible variant.
+func JournalSharedSchemaStatementsForDB(ctx context.Context, db *sql.DB) []string {
+	if IsTiDBCluster(ctx, db) {
+		return JournalTiDBSharedSchemaStatements()
+	}
+	return JournalMySQLSharedSchemaStatements()
+}

--- a/pkg/tenant/schema/fs_layer.go
+++ b/pkg/tenant/schema/fs_layer.go
@@ -88,6 +88,116 @@ func FSLayerTiDBSchemaStatements() []string {
 	}
 }
 
+// FSLayerTiDBSharedSchemaStatements returns the FS layer DDL for the shared
+// (multi-tenant) schema shape on TiDB (docs/TENANT_DB_REDESIGN.md §5.2.3): the
+// same tables as FSLayerTiDBSchemaStatements, but every table gains an fs_id
+// BIGINT discriminator as its first column and every primary key, unique key,
+// and index is prefixed with fs_id so one tenant's rows stay physically
+// co-located. Composite primary keys are declared CLUSTERED — TiDB creates
+// them NONCLUSTERED by default. For plain MySQL use
+// FSLayerMySQLSharedSchemaStatements (same shape without the keyword). Keep
+// both in lockstep with FSLayerTiDBSchemaStatements — the drift test in
+// fs_layer_shared_test.go enforces parity.
+func FSLayerTiDBSharedSchemaStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS fs_layers (
+			fs_id BIGINT NOT NULL,
+			layer_id        VARCHAR(64) NOT NULL,
+			base_root_path  VARCHAR(512) NOT NULL,
+			name            VARCHAR(255) NOT NULL DEFAULT '',
+			state           VARCHAR(32) NOT NULL DEFAULT 'active',
+			durability_mode VARCHAR(32) NOT NULL DEFAULT 'restore-safe',
+			actor_id        VARCHAR(255) NOT NULL DEFAULT '',
+			durable_seq     BIGINT NOT NULL DEFAULT 0,
+			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			sealed_at       DATETIME(3),
+			PRIMARY KEY (fs_id, layer_id) CLUSTERED,
+			KEY idx_fs_layers_state (fs_id, state, updated_at),
+			KEY idx_fs_layers_base_root (fs_id, base_root_path),
+			KEY idx_fs_layers_name (fs_id, name, updated_at)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS fs_layer_tags (
+			fs_id BIGINT NOT NULL,
+			layer_id   VARCHAR(64) NOT NULL,
+			tag_key    VARCHAR(255) NOT NULL,
+			tag_value  VARCHAR(255) NOT NULL DEFAULT '',
+			created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, layer_id, tag_key) CLUSTERED,
+			KEY idx_fs_layer_tags_kv (fs_id, tag_key, tag_value),
+			KEY idx_fs_layer_tags_key (fs_id, tag_key)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS fs_layer_entries (
+			fs_id BIGINT NOT NULL,
+			layer_id         VARCHAR(64) NOT NULL,
+			path             VARCHAR(1024) NOT NULL,
+			path_hash        VARCHAR(64) NOT NULL,
+			parent_path      VARCHAR(1024) NOT NULL,
+			parent_path_hash VARCHAR(64) NOT NULL,
+			name             VARCHAR(255) NOT NULL,
+			op               VARCHAR(16) NOT NULL,
+			kind             VARCHAR(16) NOT NULL DEFAULT 'file',
+			base_inode_id    VARCHAR(64) NOT NULL DEFAULT '',
+			base_revision    BIGINT NOT NULL DEFAULT 0,
+			storage_type     VARCHAR(32) NOT NULL DEFAULT '',
+			storage_ref      TEXT NOT NULL,
+			storage_ref_hash VARCHAR(64) NOT NULL DEFAULT '',
+			storage_encryption_mode   VARCHAR(32) NOT NULL DEFAULT 'none',
+			storage_encryption_key_id VARCHAR(255) NOT NULL DEFAULT '',
+			content_blob     LONGBLOB,
+			content_type     VARCHAR(255),
+			content_text     LONGTEXT,
+			checksum_sha256  VARCHAR(128) NOT NULL DEFAULT '',
+			size_bytes       BIGINT NOT NULL DEFAULT 0,
+			mode             INT NOT NULL DEFAULT 420,
+			entry_seq        BIGINT NOT NULL DEFAULT 0,
+			created_at       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at       DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, layer_id, path_hash, entry_seq) CLUSTERED,
+			KEY idx_fs_layer_entries_parent (fs_id, layer_id, parent_path_hash),
+			KEY idx_fs_layer_entries_seq (fs_id, layer_id, entry_seq),
+			KEY idx_fs_layer_entries_op (fs_id, layer_id, op)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS fs_layer_events (
+			fs_id BIGINT NOT NULL,
+			event_id        VARCHAR(64) NOT NULL,
+			layer_id        VARCHAR(64) NOT NULL,
+			seq             BIGINT NOT NULL,
+			actor_id        VARCHAR(255) NOT NULL DEFAULT '',
+			op              VARCHAR(32) NOT NULL,
+			path            VARCHAR(1024) NOT NULL,
+			before_json     JSON,
+			after_json      JSON,
+			idempotency_key VARCHAR(255) NOT NULL DEFAULT '',
+			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, event_id) CLUSTERED,
+			UNIQUE KEY uk_fs_layer_events_seq (fs_id, layer_id, seq),
+			KEY idx_fs_layer_events_created (fs_id, layer_id, created_at)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS fs_layer_checkpoints (
+			fs_id BIGINT NOT NULL,
+			checkpoint_id VARCHAR(64) NOT NULL,
+			layer_id      VARCHAR(64) NOT NULL,
+			durable_seq   BIGINT NOT NULL DEFAULT 0,
+			label         VARCHAR(255) NOT NULL DEFAULT '',
+			created_at    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, checkpoint_id) CLUSTERED,
+			KEY idx_fs_layer_checkpoints_layer (fs_id, layer_id, created_at)
+		)`,
+	}
+}
+
+// FSLayerMySQLSharedSchemaStatements is the plain-MySQL variant of
+// FSLayerTiDBSharedSchemaStatements, derived by removing TiDB-only keywords.
+// Use it for local development databases and MySQL-backed tests/e2e.
+func FSLayerMySQLSharedSchemaStatements() []string {
+	return mysqlCompatibleSharedStatements(FSLayerTiDBSharedSchemaStatements())
+}
+
 // FSLayerDB9SchemaStatements is the PostgreSQL/db9 equivalent of
 // FSLayerTiDBSchemaStatements.
 func FSLayerDB9SchemaStatements() []string {

--- a/pkg/tenant/schema/fs_layer_shared_test.go
+++ b/pkg/tenant/schema/fs_layer_shared_test.go
@@ -1,0 +1,21 @@
+package schema
+
+import "testing"
+
+// TestFSLayerSharedSchemaMatchesStandaloneModuloFsID pins the shared FS layer
+// DDL to the standalone one: every shared table must be the standalone table
+// plus an fs_id BIGINT NOT NULL discriminator column in first position, with
+// fs_id prefixed onto the primary key and every unique key / index. The
+// comparison uses the MySQL variant, which carries no TiDB-only CLUSTERED
+// keyword.
+func TestFSLayerSharedSchemaMatchesStandaloneModuloFsID(t *testing.T) {
+	assertSharedDriftParity(t, FSLayerTiDBSchemaStatements(), FSLayerMySQLSharedSchemaStatements())
+}
+
+// TestFSLayerTiDBSharedSchemaDeclaresClusteredPKs ensures the TiDB variant
+// declares every composite primary key CLUSTERED (TiDB defaults composite PKs
+// to NONCLUSTERED, which would scatter each tenant's rows), and that the
+// MySQL variant differs only by the removed keyword.
+func TestFSLayerTiDBSharedSchemaDeclaresClusteredPKs(t *testing.T) {
+	assertClusteredVariantParity(t, FSLayerTiDBSharedSchemaStatements(), FSLayerMySQLSharedSchemaStatements(), 5)
+}

--- a/pkg/tenant/schema/git_shared_test.go
+++ b/pkg/tenant/schema/git_shared_test.go
@@ -1,0 +1,339 @@
+package schema
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/drive9/internal/schemaspec"
+)
+
+// TestGitWorkspaceSharedSchemaMatchesStandaloneModuloFsID pins the shared git
+// workspace DDL to the standalone one: every shared table must be the
+// standalone table plus an fs_id BIGINT NOT NULL discriminator column in
+// first position, with fs_id prefixed onto the primary key and every unique
+// key / index. The comparison uses the MySQL variant, which carries no
+// TiDB-only CLUSTERED keyword; the repair-style ALTERs in the standalone list
+// are folded into the parsed standalone shape so they cannot drift either.
+func TestGitWorkspaceSharedSchemaMatchesStandaloneModuloFsID(t *testing.T) {
+	assertSharedDriftParity(t, GitWorkspaceTiDBSchemaStatements(), GitWorkspaceMySQLSharedSchemaStatements())
+}
+
+// TestGitWorkspaceTiDBSharedSchemaDeclaresClusteredPKs ensures the TiDB
+// variant declares every composite primary key CLUSTERED (TiDB defaults
+// composite PKs to NONCLUSTERED, which would scatter each tenant's rows), and
+// that the MySQL variant differs only by the removed keyword.
+func TestGitWorkspaceTiDBSharedSchemaDeclaresClusteredPKs(t *testing.T) {
+	assertClusteredVariantParity(t, GitWorkspaceTiDBSharedSchemaStatements(), GitWorkspaceMySQLSharedSchemaStatements(), 5)
+}
+
+// driftColumn is one parsed column definition: name, normalized type, and
+// normalized attributes (nullability/defaults) with any inline PRIMARY KEY
+// marker removed — key membership is tracked separately on driftTable.
+type driftColumn struct {
+	name  string
+	dtype string
+	attrs string
+}
+
+// driftKey is one parsed non-primary key / unique constraint.
+type driftKey struct {
+	name   string
+	unique bool
+	cols   []string
+}
+
+// driftTable is the parsed shape of one table: columns in declaration order,
+// primary key columns, and secondary keys.
+type driftTable struct {
+	name    string
+	columns []driftColumn
+	pk      []string
+	keys    []driftKey
+}
+
+// assertSharedDriftParity compares a standalone statement list against its
+// shared (fs_id) counterpart per table: shared columns must equal fs_id
+// BIGINT NOT NULL followed by the standalone columns (order, types, and
+// attributes preserved), and the shared primary key / unique keys / indexes
+// must equal the standalone constraint columns with an fs_id prefix.
+func assertSharedDriftParity(t *testing.T, standalone, shared []string) {
+	t.Helper()
+	wantTables := parseDriftTables(t, standalone)
+	gotTables := parseDriftTables(t, shared)
+	for name := range wantTables {
+		if _, ok := gotTables[name]; !ok {
+			t.Errorf("table %s missing from shared schema", name)
+		}
+	}
+	for name := range gotTables {
+		if _, ok := wantTables[name]; !ok {
+			t.Errorf("table %s missing from standalone schema", name)
+		}
+	}
+	for name, want := range wantTables {
+		got, ok := gotTables[name]
+		if !ok {
+			continue
+		}
+		assertTableDriftParity(t, want, got)
+	}
+}
+
+func assertTableDriftParity(t *testing.T, want, got *driftTable) {
+	t.Helper()
+	if len(got.columns) != len(want.columns)+1 {
+		t.Errorf("table %s: shared column count %d, want %d (standalone %d + fs_id)",
+			want.name, len(got.columns), len(want.columns)+1, len(want.columns))
+		return
+	}
+	fsID := got.columns[0]
+	if fsID.name != "fs_id" || fsID.dtype != "bigint" || fsID.attrs != "not null" {
+		t.Errorf("table %s: first shared column = %q %q %q, want fs_id bigint not null",
+			want.name, fsID.name, fsID.dtype, fsID.attrs)
+	}
+	for i, wc := range want.columns {
+		gc := got.columns[i+1]
+		wantAttrs := wc.attrs
+		if slices.Contains(want.pk, wc.name) && !strings.Contains(wantAttrs, "not null") {
+			// Standalone primary key members are implicitly NOT NULL; the
+			// shared shape declares it explicitly because the primary key
+			// constraint is declared separately from the column.
+			wantAttrs = strings.TrimSpace("not null " + wantAttrs)
+		}
+		if gc.name != wc.name || gc.dtype != wc.dtype || gc.attrs != wantAttrs {
+			t.Errorf("table %s: column %d drift: standalone (%s %s %s), shared (%s %s %s)",
+				want.name, i, wc.name, wc.dtype, wantAttrs, gc.name, gc.dtype, gc.attrs)
+		}
+	}
+	wantPK := append([]string{"fs_id"}, want.pk...)
+	if !slices.Equal(got.pk, wantPK) {
+		t.Errorf("table %s: primary key drift: standalone %v, shared %v, want %v",
+			want.name, want.pk, got.pk, wantPK)
+	}
+	gotKeys := make(map[string]driftKey, len(got.keys))
+	for _, k := range got.keys {
+		gotKeys[k.name] = k
+	}
+	if len(got.keys) != len(want.keys) {
+		t.Errorf("table %s: shared key count %d, want %d", want.name, len(got.keys), len(want.keys))
+	}
+	for _, wk := range want.keys {
+		gk, ok := gotKeys[wk.name]
+		if !ok {
+			t.Errorf("table %s: key %s missing from shared schema", want.name, wk.name)
+			continue
+		}
+		if gk.unique != wk.unique {
+			t.Errorf("table %s: key %s uniqueness drift: standalone unique=%v, shared unique=%v",
+				want.name, wk.name, wk.unique, gk.unique)
+		}
+		wantCols := append([]string{"fs_id"}, wk.cols...)
+		if !slices.Equal(gk.cols, wantCols) {
+			t.Errorf("table %s: key %s drift: standalone %v, shared %v, want %v",
+				want.name, wk.name, wk.cols, gk.cols, wantCols)
+		}
+	}
+	for _, gk := range got.keys {
+		found := slices.ContainsFunc(want.keys, func(wk driftKey) bool { return wk.name == gk.name })
+		if !found {
+			t.Errorf("table %s: unexpected shared key %s", want.name, gk.name)
+		}
+	}
+}
+
+// assertClusteredVariantParity ensures the TiDB shared variant declares every
+// primary key CLUSTERED (one per table) and that the MySQL variant differs
+// only by the removed keyword.
+func assertClusteredVariantParity(t *testing.T, tidb, mysql []string, wantTables int) {
+	t.Helper()
+	if len(tidb) != len(mysql) {
+		t.Fatalf("variant length mismatch: tidb %d, mysql %d", len(tidb), len(mysql))
+	}
+	clusteredTables := 0
+	for i := range tidb {
+		if strings.Contains(tidb[i], "PRIMARY KEY") {
+			if !strings.Contains(tidb[i], " CLUSTERED") {
+				t.Errorf("statement %d has a primary key without CLUSTERED:\n%s", i, tidb[i])
+			} else {
+				clusteredTables++
+			}
+		}
+		if strings.Contains(mysql[i], "CLUSTERED") {
+			t.Errorf("mysql variant retains CLUSTERED keyword:\n%s", mysql[i])
+		}
+		if got, want := mysql[i], stripTiDBClusteredKeyword(tidb[i]); got != want {
+			t.Errorf("statement %d variants differ beyond the keyword:\ntidb stripped: %s\nmysql: %s", i, want, got)
+		}
+	}
+	if clusteredTables != wantTables {
+		t.Fatalf("clustered primary keys = %d, want %d (one per table)", clusteredTables, wantTables)
+	}
+}
+
+// parseDriftTables parses CREATE TABLE / CREATE INDEX / ALTER TABLE ADD COLUMN
+// statements into per-table shapes. Standalone lists declare indexes as
+// separate CREATE INDEX statements and may carry repair-style ALTERs; shared
+// lists declare everything inline — parsing both into the same shape lets the
+// drift tests compare them structurally.
+func parseDriftTables(t *testing.T, stmts []string) map[string]*driftTable {
+	t.Helper()
+	tables := make(map[string]*driftTable)
+	for _, stmt := range stmts {
+		n := schemaspec.NormalizeSQLFragment(stmt)
+		switch {
+		case strings.HasPrefix(n, "create table"):
+			tb := parseDriftCreateTable(t, stmt)
+			if _, dup := tables[tb.name]; dup {
+				t.Fatalf("duplicate CREATE TABLE for %s", tb.name)
+			}
+			tables[tb.name] = tb
+		case strings.HasPrefix(n, "create unique index"), strings.HasPrefix(n, "create index"):
+			key, table := parseDriftCreateIndex(t, stmt)
+			tb, ok := tables[table]
+			if !ok {
+				t.Fatalf("CREATE INDEX %s references unknown table %s", key.name, table)
+			}
+			tb.keys = append(tb.keys, key)
+		case strings.HasPrefix(n, "alter table"):
+			table, col := parseDriftAlterAddColumn(t, stmt)
+			tb, ok := tables[table]
+			if !ok {
+				t.Fatalf("ALTER TABLE references unknown table %s", table)
+			}
+			// Repair-style ADD COLUMNs are folded into the shared CREATE
+			// TABLE; the standalone list may repeat columns the CREATE TABLE
+			// already declares.
+			if !driftHasColumn(tb, col.name) {
+				tb.columns = append(tb.columns, col)
+			}
+		default:
+			t.Fatalf("unhandled schema statement: %s", schemaspec.SQLSnippet(stmt))
+		}
+	}
+	return tables
+}
+
+func parseDriftCreateTable(t *testing.T, stmt string) *driftTable {
+	t.Helper()
+	name, defs, ok, err := schemaspec.ParseCreateTableStatement(stmt)
+	if err != nil || !ok {
+		t.Fatalf("parse CREATE TABLE: ok=%v err=%v", ok, err)
+	}
+	tb := &driftTable{name: name}
+	for _, def := range schemaspec.SplitTopLevelComma(defs) {
+		n := schemaspec.NormalizeSQLFragment(def)
+		switch {
+		case strings.HasPrefix(n, "primary key"):
+			tb.pk = splitDriftKeyColumns(def)
+		case strings.HasPrefix(n, "unique key "), strings.HasPrefix(n, "unique index "):
+			tb.keys = append(tb.keys, driftKey{name: driftKeyName(t, def), unique: true, cols: splitDriftKeyColumns(def)})
+		case strings.HasPrefix(n, "key "), strings.HasPrefix(n, "index "):
+			tb.keys = append(tb.keys, driftKey{name: driftKeyName(t, def), cols: splitDriftKeyColumns(def)})
+		default:
+			col, isPK := parseDriftColumn(def)
+			tb.columns = append(tb.columns, col)
+			if isPK {
+				tb.pk = []string{col.name}
+			}
+		}
+	}
+	return tb
+}
+
+func parseDriftCreateIndex(t *testing.T, stmt string) (driftKey, string) {
+	t.Helper()
+	n := schemaspec.NormalizeSQLFragment(stmt)
+	rest := strings.TrimPrefix(n, "create unique index ")
+	unique := rest != n
+	if !unique {
+		rest = strings.TrimPrefix(n, "create index ")
+	}
+	rest = strings.TrimPrefix(rest, "if not exists ")
+	onIdx := strings.Index(rest, " on ")
+	if onIdx < 0 {
+		t.Fatalf("CREATE INDEX without ON clause: %s", stmt)
+	}
+	keyName := rest[:onIdx]
+	tableAndCols := rest[onIdx+len(" on "):]
+	parenIdx := strings.Index(tableAndCols, "(")
+	if parenIdx < 0 {
+		t.Fatalf("CREATE INDEX without column list: %s", stmt)
+	}
+	table := strings.TrimSpace(tableAndCols[:parenIdx])
+	key := driftKey{name: keyName, unique: unique, cols: splitDriftKeyColumns(tableAndCols[parenIdx:])}
+	return key, table
+}
+
+func parseDriftAlterAddColumn(t *testing.T, stmt string) (string, driftColumn) {
+	t.Helper()
+	n := schemaspec.NormalizeSQLFragment(stmt)
+	rest := strings.TrimPrefix(n, "alter table ")
+	table, rest := schemaspec.SplitIdentifierAndRest(rest)
+	colDef, ok := strings.CutPrefix(rest, "add column ")
+	if !ok {
+		t.Fatalf("unsupported ALTER TABLE statement (only ADD COLUMN repairs): %s", stmt)
+	}
+	col, isPK := parseDriftColumn(colDef)
+	if isPK {
+		t.Fatalf("unexpected ALTER TABLE ADD COLUMN ... PRIMARY KEY: %s", stmt)
+	}
+	return table, col
+}
+
+// parseDriftColumn parses one column definition. It reports whether the
+// column carries an inline PRIMARY KEY marker; the marker is stripped from
+// the returned attributes because key membership is compared separately.
+func parseDriftColumn(def string) (driftColumn, bool) {
+	name, rest := schemaspec.SplitIdentifierAndRest(def)
+	dtype := schemaspec.ParseColumnType(rest)
+	attrs := schemaspec.NormalizeSQLFragment(strings.TrimSpace(rest[len(dtype):]))
+	isPK := strings.Contains(attrs, "primary key")
+	if isPK {
+		attrs = schemaspec.NormalizeSQLFragment(strings.ReplaceAll(attrs, "primary key", ""))
+	}
+	return driftColumn{
+		name:  strings.ToLower(name),
+		dtype: schemaspec.NormalizeSQLFragment(dtype),
+		attrs: attrs,
+	}, isPK
+}
+
+// splitDriftKeyColumns extracts the lowercased column list from a key /
+// primary key definition, dropping any index prefix lengths (e.g. col(16)).
+func splitDriftKeyColumns(def string) []string {
+	start := strings.Index(def, "(")
+	end := strings.LastIndex(def, ")")
+	if start < 0 || end <= start {
+		return nil
+	}
+	parts := strings.Split(def[start+1:end], ",")
+	cols := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(strings.Trim(p, "`"))
+		if i := strings.Index(p, "("); i >= 0 {
+			p = p[:i]
+		}
+		cols = append(cols, strings.ToLower(p))
+	}
+	return cols
+}
+
+// driftKeyName returns the lowercased key name from an inline key definition
+// such as "UNIQUE KEY uk_foo (a, b)" or "KEY idx_foo (a)".
+func driftKeyName(t *testing.T, def string) string {
+	t.Helper()
+	idx := strings.Index(def, "(")
+	if idx < 0 {
+		t.Fatalf("key definition without column list: %s", def)
+	}
+	fields := strings.Fields(def[:idx])
+	if len(fields) == 0 {
+		t.Fatalf("key definition without name: %s", def)
+	}
+	return strings.ToLower(strings.Trim(fields[len(fields)-1], "`"))
+}
+
+func driftHasColumn(tb *driftTable, name string) bool {
+	return slices.ContainsFunc(tb.columns, func(c driftColumn) bool { return c.name == name })
+}

--- a/pkg/tenant/schema/git_workspace.go
+++ b/pkg/tenant/schema/git_workspace.go
@@ -98,6 +98,120 @@ func GitWorkspaceTiDBSchemaStatements() []string {
 	}
 }
 
+// GitWorkspaceTiDBSharedSchemaStatements returns the git workspace DDL for the
+// shared (multi-tenant) schema shape on TiDB (docs/TENANT_DB_REDESIGN.md
+// §5.2.3): the same tables as GitWorkspaceTiDBSchemaStatements, but every
+// table gains an fs_id BIGINT discriminator as its first column and every
+// primary key, unique key, and index is prefixed with fs_id so one tenant's
+// rows stay physically co-located. Composite primary keys are declared
+// CLUSTERED — TiDB creates them NONCLUSTERED by default. The standalone
+// repair-style ALTER TABLE ... ADD COLUMN statements are folded into the
+// CREATE TABLE here: shared schemas are created fresh, so there is nothing to
+// repair. For plain MySQL use GitWorkspaceMySQLSharedSchemaStatements (same
+// shape without the keyword). Keep both in lockstep with
+// GitWorkspaceTiDBSchemaStatements — the drift test in git_shared_test.go
+// enforces parity.
+func GitWorkspaceTiDBSharedSchemaStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS git_workspaces (
+			fs_id BIGINT NOT NULL,
+			workspace_id VARCHAR(64) NOT NULL,
+			root_path    VARCHAR(512) NOT NULL,
+			repo_url     TEXT NOT NULL,
+			remote_name  VARCHAR(128) NOT NULL DEFAULT 'origin',
+			branch_name  VARCHAR(255) NOT NULL DEFAULT '',
+			base_commit  VARCHAR(64) NOT NULL DEFAULT '',
+			head_commit  VARCHAR(64) NOT NULL DEFAULT '',
+			mode         VARCHAR(32) NOT NULL DEFAULT 'fast',
+			workspace_kind VARCHAR(16) NOT NULL DEFAULT 'main',
+			common_workspace_id VARCHAR(64) NOT NULL DEFAULT '',
+			worktree_name VARCHAR(255) NOT NULL DEFAULT '',
+			gitdir_rel VARCHAR(1024) NOT NULL DEFAULT '',
+			status       VARCHAR(32) NOT NULL DEFAULT 'active',
+			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, workspace_id) CLUSTERED,
+			UNIQUE KEY uk_git_workspaces_root (fs_id, root_path),
+			KEY idx_git_workspaces_status (fs_id, status, updated_at),
+			KEY idx_git_workspaces_common (fs_id, common_workspace_id, status)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS git_workspace_tree_nodes (
+			fs_id BIGINT NOT NULL,
+			workspace_id VARCHAR(64) NOT NULL,
+			commit_sha   VARCHAR(64) NOT NULL,
+			path         VARCHAR(1024) NOT NULL,
+			path_hash    VARCHAR(64) NOT NULL,
+			parent_path  VARCHAR(1024) NOT NULL DEFAULT '',
+			parent_path_hash VARCHAR(64) NOT NULL DEFAULT '',
+			name         VARCHAR(255) NOT NULL,
+			kind         VARCHAR(16) NOT NULL,
+			mode         VARCHAR(16) NOT NULL,
+			object_sha   VARCHAR(64) NOT NULL DEFAULT '',
+			size_bytes   BIGINT NOT NULL DEFAULT -1,
+			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, workspace_id, commit_sha, path_hash) CLUSTERED,
+			KEY idx_git_tree_parent (fs_id, workspace_id, commit_sha, parent_path_hash)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS git_workspace_git_state (
+			fs_id BIGINT NOT NULL,
+			workspace_id      VARCHAR(64) NOT NULL,
+			checkpoint_commit VARCHAR(64) NOT NULL DEFAULT '',
+			storage_type      VARCHAR(32) NOT NULL DEFAULT '',
+			storage_ref       TEXT NOT NULL,
+			storage_ref_hash  VARCHAR(64) NOT NULL DEFAULT '',
+			checksum_sha256   VARCHAR(128) NOT NULL DEFAULT '',
+			size_bytes        BIGINT NOT NULL DEFAULT 0,
+			content_blob      LONGBLOB,
+			created_at        DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at        DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, workspace_id) CLUSTERED,
+			KEY idx_git_state_ref_hash (fs_id, storage_ref_hash)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS git_workspace_object_packs (
+			fs_id BIGINT NOT NULL,
+			workspace_id    VARCHAR(64) NOT NULL,
+			pack_id         VARCHAR(64) NOT NULL,
+			checksum_sha256 VARCHAR(128) NOT NULL DEFAULT '',
+			size_bytes      BIGINT NOT NULL DEFAULT 0,
+			content_blob    LONGBLOB,
+			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, workspace_id, pack_id) CLUSTERED,
+			KEY idx_git_object_packs_created (fs_id, workspace_id, created_at)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS git_workspace_overlay (
+			fs_id BIGINT NOT NULL,
+			workspace_id    VARCHAR(64) NOT NULL,
+			path            VARCHAR(1024) NOT NULL,
+			path_hash       VARCHAR(64) NOT NULL,
+			op              VARCHAR(16) NOT NULL,
+			kind            VARCHAR(16) NOT NULL DEFAULT 'file',
+			mode            VARCHAR(16) NOT NULL DEFAULT '',
+			storage_type    VARCHAR(32) NOT NULL DEFAULT '',
+			storage_ref     TEXT NOT NULL,
+			storage_ref_hash VARCHAR(64) NOT NULL DEFAULT '',
+			checksum_sha256 VARCHAR(128) NOT NULL DEFAULT '',
+			size_bytes      BIGINT NOT NULL DEFAULT 0,
+			base_object_sha VARCHAR(64) NOT NULL DEFAULT '',
+			content_blob    LONGBLOB,
+			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, workspace_id, path_hash) CLUSTERED,
+			KEY idx_git_overlay_op (fs_id, workspace_id, op)
+		)`,
+	}
+}
+
+// GitWorkspaceMySQLSharedSchemaStatements is the plain-MySQL variant of
+// GitWorkspaceTiDBSharedSchemaStatements, derived by removing TiDB-only
+// keywords. Use it for local development databases and MySQL-backed tests/e2e.
+func GitWorkspaceMySQLSharedSchemaStatements() []string {
+	return mysqlCompatibleSharedStatements(GitWorkspaceTiDBSharedSchemaStatements())
+}
+
 // GitWorkspaceDB9SchemaStatements is the PostgreSQL/db9 equivalent of
 // GitWorkspaceTiDBSchemaStatements.
 func GitWorkspaceDB9SchemaStatements() []string {

--- a/pkg/tenant/schema/journal.go
+++ b/pkg/tenant/schema/journal.go
@@ -1,5 +1,10 @@
 package schema
 
+import (
+	"context"
+	"database/sql"
+)
+
 // JournalTiDBSchemaStatements returns the tenant journal DDL used by TiDB and
 // MySQL-compatible tenants. The first implementation intentionally creates
 // the Phase 1 tables only: artifacts, filesystem projection, and seals are
@@ -315,4 +320,26 @@ func JournalDB9SchemaStatements() []string {
 		`CREATE INDEX IF NOT EXISTS idx_journal_entry_subjects_entry ON journal_entry_subjects(tenant_id, entry_id)`,
 		`CREATE INDEX IF NOT EXISTS idx_journal_entry_subjects_journal_seq ON journal_entry_subjects(tenant_id, journal_id, seq)`,
 	}
+}
+
+// JournalMySQLSharedSchemaStatements is the plain-MySQL variant of
+// JournalTiDBSharedSchemaStatements, derived by removing TiDB-only keywords.
+// Use it for local development databases and MySQL-backed tests/e2e.
+func JournalMySQLSharedSchemaStatements() []string {
+	return mysqlCompatibleSharedStatements(JournalTiDBSharedSchemaStatements())
+}
+
+// JournalSharedSchemaStatementsForDB selects the shared journal DDL matching
+// the connected database's dialect: TiDB clusters get the CLUSTERED variant,
+// anything else (plain MySQL, e.g. local e2e) the compatible variant. Dialect
+// detection failures are returned, never silently treated as MySQL.
+func JournalSharedSchemaStatementsForDB(ctx context.Context, db *sql.DB) ([]string, error) {
+	isTiDB, err := IsTiDBClusterE(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if isTiDB {
+		return JournalTiDBSharedSchemaStatements(), nil
+	}
+	return JournalMySQLSharedSchemaStatements(), nil
 }

--- a/pkg/tenant/schema/journal.go
+++ b/pkg/tenant/schema/journal.go
@@ -104,6 +104,116 @@ func JournalTiDBSchemaStatements() []string {
 	}
 }
 
+// JournalTiDBSharedSchemaStatements returns the journal DDL for the shared
+// (multi-tenant) schema shape on TiDB: identical to
+// JournalTiDBSchemaStatements except the tenant_id VARCHAR(64) discriminator
+// column is replaced by fs_id BIGINT in every table, primary key, unique key,
+// and index. Composite primary keys are declared CLUSTERED — TiDB creates
+// them NONCLUSTERED by default, and the shared shape relies on clustered
+// keys to physically co-locate one tenant's rows. For plain MySQL use
+// JournalMySQLSharedSchemaStatements (same shape without the keyword).
+// Keep both in lockstep with JournalTiDBSchemaStatements — the drift test in
+// journal_shared_test.go enforces parity.
+func JournalTiDBSharedSchemaStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS journals (
+			fs_id          BIGINT        NOT NULL,
+			journal_id     VARCHAR(64)  NOT NULL,
+			kind           VARCHAR(64)  NOT NULL,
+			title          VARCHAR(255) NULL,
+			actor_type     VARCHAR(64)  NULL,
+			actor_id       VARCHAR(255) NULL,
+			source         VARCHAR(64)  NULL,
+			meta           JSON         NULL,
+			retention      JSON         NULL,
+			next_seq       BIGINT       NOT NULL DEFAULT 1,
+			genesis        JSON         NOT NULL,
+			create_hash    VARCHAR(128) NOT NULL,
+			genesis_hash   VARCHAR(128) NOT NULL,
+			head_hash      VARCHAR(128) NOT NULL,
+			created_at     DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at     DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			closed_at      DATETIME(3)  NULL,
+			PRIMARY KEY (fs_id, journal_id) CLUSTERED,
+			KEY idx_kind_created (fs_id, kind, created_at, journal_id),
+			KEY idx_actor_created (fs_id, actor_type, actor_id, created_at, journal_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS journal_labels (
+			fs_id        BIGINT        NOT NULL,
+			label_key    VARCHAR(128) NOT NULL,
+			label_hash   VARCHAR(128) NOT NULL,
+			label_value  TEXT         NOT NULL,
+			journal_id   VARCHAR(64)  NOT NULL,
+			created_at   DATETIME(3)  NOT NULL,
+			source_seq   BIGINT       NULL,
+			PRIMARY KEY (fs_id, label_key, label_hash, created_at, journal_id) CLUSTERED,
+			UNIQUE KEY uk_label_journal (fs_id, journal_id, label_key, label_hash),
+			KEY idx_journal (fs_id, journal_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS journal_append_requests (
+			fs_id            BIGINT        NOT NULL,
+			journal_id       VARCHAR(64)  NOT NULL,
+			append_id        VARCHAR(128) NOT NULL,
+			request_hash     VARCHAR(128) NOT NULL,
+			writer_type      VARCHAR(64)  NOT NULL,
+			writer_id        VARCHAR(255) NOT NULL,
+			effective_source VARCHAR(64)  NOT NULL,
+			first_seq        BIGINT       NOT NULL,
+			last_seq         BIGINT       NOT NULL,
+			count            INT          NOT NULL,
+			head_hash        VARCHAR(128) NOT NULL,
+			created_at       DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			expires_at       DATETIME(3)  NULL,
+			PRIMARY KEY (fs_id, journal_id, append_id) CLUSTERED,
+			KEY idx_created (fs_id, created_at),
+			KEY idx_expires (fs_id, expires_at)
+		)`,
+		`CREATE TABLE IF NOT EXISTS journal_entries (
+			fs_id            BIGINT        NOT NULL,
+			journal_id       VARCHAR(64)  NOT NULL,
+			seq              BIGINT       NOT NULL,
+			entry_id         VARCHAR(64)  NOT NULL,
+			type             VARCHAR(128) NOT NULL,
+			schema_version   INT          NOT NULL DEFAULT 1,
+			status           VARCHAR(64)  NULL,
+			occurred_at      DATETIME(3)  NOT NULL,
+			observed_at      DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			actor_type       VARCHAR(64)  NULL,
+			actor_id         VARCHAR(255) NULL,
+			source           VARCHAR(64)  NOT NULL,
+			parent_entry_id  VARCHAR(64)  NULL,
+			correlation_id   VARCHAR(128) NULL,
+			subjects         JSON         NULL,
+			summary          JSON         NULL,
+			artifact_refs    JSON         NULL,
+			prev_hash        VARCHAR(128) NOT NULL,
+			entry_hash       VARCHAR(128) NOT NULL,
+			PRIMARY KEY (fs_id, journal_id, seq) CLUSTERED,
+			UNIQUE KEY uk_entry_id (fs_id, entry_id),
+			KEY idx_type_observed (fs_id, type, observed_at, journal_id, seq),
+			KEY idx_type_status_observed (fs_id, type, status, observed_at, journal_id, seq),
+			KEY idx_status_observed (fs_id, status, observed_at, journal_id, seq),
+			KEY idx_actor_observed (fs_id, actor_type, actor_id, observed_at, journal_id, seq),
+			KEY idx_parent_observed (fs_id, parent_entry_id, observed_at, journal_id, seq),
+			KEY idx_correlation_observed (fs_id, correlation_id, observed_at, journal_id, seq)
+		)`,
+		`CREATE TABLE IF NOT EXISTS journal_entry_subjects (
+			fs_id        BIGINT        NOT NULL,
+			subject_type VARCHAR(64)  NOT NULL,
+			subject_hash VARCHAR(128) NOT NULL,
+			subject_id   TEXT         NOT NULL,
+			occurred_at  DATETIME(3)  NOT NULL,
+			observed_at  DATETIME(3)  NOT NULL,
+			journal_id   VARCHAR(64)  NOT NULL,
+			seq          BIGINT       NOT NULL,
+			entry_id     VARCHAR(64)  NOT NULL,
+			PRIMARY KEY (fs_id, subject_type, subject_hash, observed_at, journal_id, seq) CLUSTERED,
+			KEY idx_entry (fs_id, entry_id),
+			KEY idx_journal_seq (fs_id, journal_id, seq)
+		)`,
+	}
+}
+
 // JournalDB9SchemaStatements returns the PostgreSQL-shaped journal DDL for the
 // db9 tenant init path. Runtime journal storage currently uses the MySQL/TiDB
 // datastore implementation; this keeps exported schemas structurally aligned.

--- a/pkg/tenant/schema/journal_shared_test.go
+++ b/pkg/tenant/schema/journal_shared_test.go
@@ -1,0 +1,61 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/drive9/internal/schemaspec"
+)
+
+// TestJournalSharedSchemaMatchesStandaloneModuloFsID pins the shared journal
+// DDL to the standalone one: after renaming the tenant discriminator column
+// (tenant_id VARCHAR(64) -> fs_id BIGINT), the normalized statements must be
+// identical, so the two shapes cannot drift apart silently. The comparison
+// uses the MySQL variant, which carries no TiDB-only CLUSTERED keyword.
+func TestJournalSharedSchemaMatchesStandaloneModuloFsID(t *testing.T) {
+	standalone := JournalTiDBSchemaStatements()
+	shared := JournalMySQLSharedSchemaStatements()
+	if len(standalone) != len(shared) {
+		t.Fatalf("statement count mismatch: standalone %d, shared %d", len(standalone), len(shared))
+	}
+	for i := range standalone {
+		want := schemaspec.NormalizeSQLFragment(standalone[i])
+		want = strings.ReplaceAll(want, "tenant_id varchar(64)", "fs_id bigint")
+		want = strings.ReplaceAll(want, "tenant_id", "fs_id")
+		got := schemaspec.NormalizeSQLFragment(shared[i])
+		if got != want {
+			t.Errorf("statement %d drift:\nstandalone (tenant_id->fs_id): %s\nshared (mysql): %s", i, want, got)
+		}
+	}
+}
+
+// TestJournalTiDBSharedSchemaDeclaresClusteredPKs ensures the TiDB variant
+// declares every composite primary key CLUSTERED (TiDB defaults composite PKs
+// to NONCLUSTERED, which would scatter each tenant's rows), and that the
+// MySQL variant differs only by the removed keyword.
+func TestJournalTiDBSharedSchemaDeclaresClusteredPKs(t *testing.T) {
+	tidb := JournalTiDBSharedSchemaStatements()
+	mysql := JournalMySQLSharedSchemaStatements()
+	if len(tidb) != len(mysql) {
+		t.Fatalf("variant length mismatch: tidb %d, mysql %d", len(tidb), len(mysql))
+	}
+	clusteredTables := 0
+	for i := range tidb {
+		if strings.Contains(tidb[i], "PRIMARY KEY") {
+			if !strings.Contains(tidb[i], " CLUSTERED") {
+				t.Errorf("statement %d has a primary key without CLUSTERED:\n%s", i, tidb[i])
+			} else {
+				clusteredTables++
+			}
+		}
+		if strings.Contains(mysql[i], "CLUSTERED") {
+			t.Errorf("mysql variant retains CLUSTERED keyword:\n%s", mysql[i])
+		}
+		if got, want := mysql[i], stripTiDBClusteredKeyword(tidb[i]); got != want {
+			t.Errorf("statement %d variants differ beyond the keyword:\ntidb stripped: %s\nmysql: %s", i, want, got)
+		}
+	}
+	if clusteredTables != 5 {
+		t.Fatalf("clustered primary keys = %d, want 5 (one per journal table)", clusteredTables)
+	}
+}

--- a/pkg/tenant/schema/shared.go
+++ b/pkg/tenant/schema/shared.go
@@ -1,0 +1,76 @@
+package schema
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"go.uber.org/zap"
+)
+
+// SharedTiDBSchemaStatements returns the complete shared (multi-tenant) schema
+// DDL for TiDB in one list: the Core FS, journal, vault, git workspace, and FS
+// layer shared shapes concatenated in creation order. The shared schema has 31
+// tables; llm_usage is deliberately omitted (the central meta DB ledger is
+// authoritative in multi-tenant deployments — see
+// CoreFSTiDBSharedSchemaStatements). There are no foreign keys, so statement
+// order is informational only. For plain MySQL use SharedMySQLSchemaStatements.
+//
+// Schema versioning for shared databases is intentionally not wired up yet:
+// per-physical-DB versioning arrives with the routing phase, so init is a
+// plain idempotent apply of this statement list for now.
+func SharedTiDBSchemaStatements() []string {
+	stmts := CoreFSTiDBSharedSchemaStatements()
+	stmts = append(stmts, JournalTiDBSharedSchemaStatements()...)
+	stmts = append(stmts, VaultTiDBSharedSchemaStatements()...)
+	stmts = append(stmts, GitWorkspaceTiDBSharedSchemaStatements()...)
+	stmts = append(stmts, FSLayerTiDBSharedSchemaStatements()...)
+	return stmts
+}
+
+// SharedMySQLSchemaStatements is the plain-MySQL variant of
+// SharedTiDBSchemaStatements, derived by removing TiDB-only keywords. Use it
+// for local development databases and MySQL-backed tests/e2e.
+func SharedMySQLSchemaStatements() []string {
+	return mysqlCompatibleSharedStatements(SharedTiDBSchemaStatements())
+}
+
+// SharedSchemaStatementsForDB selects the shared schema DDL matching the
+// connected database's dialect: TiDB clusters get the CLUSTERED variant,
+// anything else (plain MySQL, e.g. local e2e) the compatible variant.
+func SharedSchemaStatementsForDB(ctx context.Context, db *sql.DB) []string {
+	if IsTiDBCluster(ctx, db) {
+		return SharedTiDBSchemaStatements()
+	}
+	return SharedMySQLSchemaStatements()
+}
+
+// InitSharedSchema initializes the shared (multi-tenant) schema on the
+// database at dsn: it applies SharedSchemaStatementsForDB with the usual
+// idempotent-DDL error tolerance (already-exists / duplicate key / duplicate
+// column errors are skipped) and then, on TiDB clusters only, best-effort
+// applies the optional FTS/vector indexes. Those optional indexes require
+// TiDB Cloud features — plain TiDB without columnar support rejects them — so
+// their failures are tolerated with a warning instead of failing init.
+func InitSharedSchema(ctx context.Context, dsn string) error {
+	db, err := OpenTiDBSchemaDB(ctx, dsn)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = closeTiDBSchemaDB(db) }()
+	if err := ExecSchemaStatementsParallelByTableContext(ctx, db, SharedSchemaStatementsForDB(ctx, db)); err != nil {
+		return err
+	}
+	if !IsTiDBCluster(ctx, db) {
+		return nil
+	}
+	skipped, err := ExecOptionalSchemaStatements(ctx, db, TiDBSharedOptionalSchemaStatements())
+	if err != nil {
+		logger.Warn(ctx, "shared_schema_optional_indexes_failed", zap.Error(err))
+	} else if skipped > 0 {
+		logger.Warn(ctx, "shared_schema_optional_indexes_skipped",
+			zap.Int("skipped_count", skipped),
+			zap.String("reason", "unsupported_tidb_features"))
+	}
+	return nil
+}

--- a/pkg/tenant/schema/shared.go
+++ b/pkg/tenant/schema/shared.go
@@ -37,12 +37,19 @@ func SharedMySQLSchemaStatements() []string {
 
 // SharedSchemaStatementsForDB selects the shared schema DDL matching the
 // connected database's dialect: TiDB clusters get the CLUSTERED variant,
-// anything else (plain MySQL, e.g. local e2e) the compatible variant.
-func SharedSchemaStatementsForDB(ctx context.Context, db *sql.DB) []string {
-	if IsTiDBCluster(ctx, db) {
-		return SharedTiDBSchemaStatements()
+// anything else (plain MySQL, e.g. local e2e) the compatible variant. A
+// dialect-detection failure is an error, never a silent MySQL fallback —
+// applying the non-CLUSTERED variant to a TiDB cluster would lose row
+// co-location without any visible failure.
+func SharedSchemaStatementsForDB(ctx context.Context, db *sql.DB) ([]string, error) {
+	isTiDB, err := IsTiDBClusterE(ctx, db)
+	if err != nil {
+		return nil, err
 	}
-	return SharedMySQLSchemaStatements()
+	if isTiDB {
+		return SharedTiDBSchemaStatements(), nil
+	}
+	return SharedMySQLSchemaStatements(), nil
 }
 
 // InitSharedSchema initializes the shared (multi-tenant) schema on the
@@ -58,7 +65,11 @@ func InitSharedSchema(ctx context.Context, dsn string) error {
 		return err
 	}
 	defer func() { _ = closeTiDBSchemaDB(db) }()
-	if err := ExecSchemaStatementsParallelByTableContext(ctx, db, SharedSchemaStatementsForDB(ctx, db)); err != nil {
+	stmts, err := SharedSchemaStatementsForDB(ctx, db)
+	if err != nil {
+		return err
+	}
+	if err := ExecSchemaStatementsParallelByTableContext(ctx, db, stmts); err != nil {
 		return err
 	}
 	if !IsTiDBCluster(ctx, db) {

--- a/pkg/tenant/schema/shared_test.go
+++ b/pkg/tenant/schema/shared_test.go
@@ -115,7 +115,10 @@ func TestSharedMySQLSchemaStatementsDialect(t *testing.T) {
 func TestSharedSchemaStatementsForDBSelectsMySQL(t *testing.T) {
 	db := testmysql.OpenDB(t, testDSN)
 
-	got := SharedSchemaStatementsForDB(context.Background(), db)
+	got, err := SharedSchemaStatementsForDB(context.Background(), db)
+	if err != nil {
+		t.Fatalf("SharedSchemaStatementsForDB: %v", err)
+	}
 	want := SharedMySQLSchemaStatements()
 	if len(got) != len(want) {
 		t.Fatalf("ForDB returned %d statements, want %d", len(got), len(want))

--- a/pkg/tenant/schema/shared_test.go
+++ b/pkg/tenant/schema/shared_test.go
@@ -1,0 +1,128 @@
+package schema
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/drive9/internal/schemaspec"
+	"github.com/mem9-ai/drive9/internal/testmysql"
+)
+
+// sharedSchemaTables lists the 31 tables of the shared (multi-tenant) schema
+// shape across the five statement groups. llm_usage is intentionally absent:
+// the central meta DB ledger is authoritative in multi-tenant deployments.
+var sharedSchemaTables = []string{
+	// Core FS (9).
+	"file_nodes",
+	"inodes",
+	"contents",
+	"semantic",
+	"file_tags",
+	"uploads",
+	"semantic_tasks",
+	"file_gc_tasks",
+	"fs_events",
+	// Journal (5).
+	"journals",
+	"journal_labels",
+	"journal_append_requests",
+	"journal_entries",
+	"journal_entry_subjects",
+	// Vault (7).
+	"vault_deks",
+	"vault_secrets",
+	"vault_secret_fields",
+	"vault_tokens",
+	"vault_grants",
+	"vault_policies",
+	"vault_audit_log",
+	// Git workspace (5).
+	"git_workspaces",
+	"git_workspace_tree_nodes",
+	"git_workspace_git_state",
+	"git_workspace_object_packs",
+	"git_workspace_overlay",
+	// FS layer (5).
+	"fs_layers",
+	"fs_layer_tags",
+	"fs_layer_entries",
+	"fs_layer_events",
+	"fs_layer_checkpoints",
+}
+
+// TestSharedTiDBSchemaStatementsContainsAllTables pins the aggregate list to
+// exactly the 31 expected tables across the five groups: every statement must
+// be a CREATE TABLE for one of them, with no duplicates and no extras.
+func TestSharedTiDBSchemaStatementsContainsAllTables(t *testing.T) {
+	stmts := SharedTiDBSchemaStatements()
+	if len(stmts) != len(sharedSchemaTables) {
+		t.Fatalf("shared schema has %d statements, want %d", len(stmts), len(sharedSchemaTables))
+	}
+	seen := make(map[string]bool, len(stmts))
+	for i, stmt := range stmts {
+		tableName, _, ok, err := schemaspec.ParseCreateTableStatement(stmt)
+		if err != nil || !ok {
+			t.Fatalf("statement %d is not a CREATE TABLE: ok=%t err=%v", i, ok, err)
+		}
+		if seen[tableName] {
+			t.Errorf("duplicate CREATE TABLE for %s", tableName)
+		}
+		seen[tableName] = true
+	}
+	for _, tableName := range sharedSchemaTables {
+		if !seen[tableName] {
+			t.Errorf("shared schema missing table %s", tableName)
+		}
+	}
+	if seen["llm_usage"] {
+		t.Errorf("shared schema must not contain llm_usage")
+	}
+}
+
+// TestSharedMySQLSchemaStatementsDialect ensures the MySQL variant carries no
+// TiDB-only constructs — no CLUSTERED keyword and no VECTOR(n) column types —
+// while keeping the same 31 tables.
+func TestSharedMySQLSchemaStatementsDialect(t *testing.T) {
+	stmts := SharedMySQLSchemaStatements()
+	if len(stmts) != len(sharedSchemaTables) {
+		t.Fatalf("mysql shared schema has %d statements, want %d", len(stmts), len(sharedSchemaTables))
+	}
+	seen := make(map[string]bool, len(stmts))
+	for i, stmt := range stmts {
+		if strings.Contains(stmt, "CLUSTERED") {
+			t.Errorf("mysql variant retains CLUSTERED keyword:\n%s", stmt)
+		}
+		if tidbVectorColumnType.MatchString(stmt) {
+			t.Errorf("mysql variant retains VECTOR(n) column type:\n%s", stmt)
+		}
+		tableName, _, ok, err := schemaspec.ParseCreateTableStatement(stmt)
+		if err != nil || !ok {
+			t.Fatalf("statement %d is not a CREATE TABLE: ok=%t err=%v", i, ok, err)
+		}
+		seen[tableName] = true
+	}
+	for _, tableName := range sharedSchemaTables {
+		if !seen[tableName] {
+			t.Errorf("mysql shared schema missing table %s", tableName)
+		}
+	}
+}
+
+// TestSharedSchemaStatementsForDBSelectsMySQL verifies that the dialect
+// selector returns the MySQL-compatible variant against a plain MySQL
+// instance.
+func TestSharedSchemaStatementsForDBSelectsMySQL(t *testing.T) {
+	db := testmysql.OpenDB(t, testDSN)
+
+	got := SharedSchemaStatementsForDB(context.Background(), db)
+	want := SharedMySQLSchemaStatements()
+	if len(got) != len(want) {
+		t.Fatalf("ForDB returned %d statements, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if schemaspec.NormalizeSQLFragment(got[i]) != schemaspec.NormalizeSQLFragment(want[i]) {
+			t.Errorf("statement %d differs from the MySQL variant:\nForDB: %s\nMySQL: %s", i, got[i], want[i])
+		}
+	}
+}

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -3023,7 +3023,9 @@ func isUniqueIndexRepairSQL(sqlText string) bool {
 func isFulltextOrVectorIndexRepairSQL(sqlText string) bool {
 	normalized := normalizeSQLFragment(sqlText)
 	return strings.Contains(normalized, " add fulltext index ") ||
-		strings.Contains(normalized, " add vector index ")
+		strings.Contains(normalized, " add vector index ") ||
+		strings.HasPrefix(normalized, "create fulltext index ") ||
+		strings.HasPrefix(normalized, "create vector index ")
 }
 
 func parseUniqueIndexRepairStatement(stmt string) (tidbUniqueIndexRepair, bool) {

--- a/pkg/tenant/schema/tidb_auto_test.go
+++ b/pkg/tenant/schema/tidb_auto_test.go
@@ -1944,3 +1944,24 @@ func (r *testRepairRows) Next(dest []driver.Value) error {
 	r.index++
 	return nil
 }
+
+func TestIsFulltextOrVectorIndexRepairSQLCoversCreateIndexForms(t *testing.T) {
+	cases := []struct {
+		stmt string
+		want bool
+	}{
+		{"ALTER TABLE semantic ADD FULLTEXT INDEX idx_semantic_fts_content(content_text) WITH PARSER MULTILINGUAL", true},
+		{"ALTER TABLE semantic ADD VECTOR INDEX idx_semantic_cosine((VEC_COSINE_DISTANCE(embedding))) ADD_COLUMNAR_REPLICA_ON_DEMAND", true},
+		// Repair-planner output form for a missing index (self-hosted engines
+		// without FTS/vector support must be able to skip these).
+		{"CREATE FULLTEXT INDEX idx_semantic_fts_content ON semantic(content_text) WITH PARSER MULTILINGUAL", true},
+		{"CREATE VECTOR INDEX idx_semantic_cosine ON semantic(embedding)", true},
+		{"CREATE UNIQUE INDEX idx_path ON file_nodes(path_hash)", false},
+		{"CREATE INDEX idx_parent ON file_nodes(parent_path_hash, name)", false},
+	}
+	for _, tc := range cases {
+		if got := isFulltextOrVectorIndexRepairSQL(tc.stmt); got != tc.want {
+			t.Errorf("isFulltextOrVectorIndexRepairSQL(%q) = %v, want %v", tc.stmt, got, tc.want)
+		}
+	}
+}

--- a/pkg/tenant/schema/tidb_shared.go
+++ b/pkg/tenant/schema/tidb_shared.go
@@ -1,0 +1,242 @@
+package schema
+
+import (
+	"strconv"
+)
+
+// CoreFSTiDBSharedSchemaStatements returns the Core FS DDL for the shared
+// (multi-tenant) schema shape on TiDB: the ten Core FS tables mirrored from
+// tidbAppEmbeddingBaseSchemaStatements with an fs_id BIGINT NOT NULL
+// discriminator as the first column of every table. Composite primary keys
+// are prefixed with fs_id and declared CLUSTERED — TiDB creates composite
+// primary keys NONCLUSTERED by default, and the shared shape relies on
+// clustered keys to physically co-locate one tenant's rows. Every secondary
+// index and unique constraint is likewise prefixed with fs_id. Column
+// definitions otherwise mirror the standalone ones verbatim, so primary key
+// member columns pick up their implicit NOT NULL from the key itself.
+//
+// Two documented exceptions keep their global AUTO_INCREMENT physical primary
+// key unchanged (docs/TENANT_DB_REDESIGN.md §5.4) and only gain the fs_id
+// column plus (fs_id, ...) lookup indexes:
+//
+//   - llm_usage: id stays the primary key; idx_llm_usage_created stays
+//     unprefixed; idx_llm_usage_fs (fs_id, created_at) is new.
+//   - fs_events: seq stays the primary key; idx_fs_events_created stays
+//     unprefixed; idx_fs_events_fs_seq (fs_id, seq) is new.
+//
+// The uploads repair artifact (the standalone ALTER TABLE uploads ADD COLUMN
+// expected_revision) is folded directly into the CREATE TABLE. The semantic
+// table keeps app-managed plain VECTOR columns — no generated columns and no
+// EMBED_TEXT — and carries no FTS/vector indexes here; those live in
+// TiDBSharedOptionalSchemaStatements.
+//
+// For plain MySQL use CoreFSMySQLSharedSchemaStatements (same shape without
+// the CLUSTERED keyword). Keep both in lockstep with
+// tidbAppEmbeddingBaseSchemaStatements — the drift test in
+// tidb_shared_test.go enforces parity.
+func CoreFSTiDBSharedSchemaStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS file_nodes (
+			fs_id            BIGINT       NOT NULL,
+			node_id          VARCHAR(64),
+			path             TEXT         NOT NULL,
+			path_hash        VARCHAR(64)  NOT NULL DEFAULT '',
+			parent_path      TEXT         NOT NULL,
+			parent_path_hash VARCHAR(64)  NOT NULL DEFAULT '',
+			name             VARCHAR(255) NOT NULL,
+			is_directory     BOOLEAN      NOT NULL DEFAULT FALSE,
+			file_id          VARCHAR(64),
+			inode_id         VARCHAR(64),
+			created_at       DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, node_id) CLUSTERED,
+			UNIQUE KEY idx_path (fs_id, path_hash),
+			KEY idx_parent (fs_id, parent_path_hash, name),
+			KEY idx_file_id (fs_id, file_id),
+			KEY idx_inode_id (fs_id, inode_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS inodes (
+			fs_id        BIGINT       NOT NULL,
+			inode_id     VARCHAR(64),
+			size_bytes   BIGINT       NOT NULL DEFAULT 0,
+			revision     BIGINT       NOT NULL DEFAULT 1,
+			mode         INT UNSIGNED NOT NULL DEFAULT 420,
+			status       VARCHAR(32)  NOT NULL DEFAULT 'PENDING',
+			created_at   DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			mtime        DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			confirmed_at DATETIME(3),
+			expires_at   DATETIME(3),
+			PRIMARY KEY (fs_id, inode_id) CLUSTERED,
+			KEY idx_inodes_status (fs_id, status, created_at)
+		)`,
+		`CREATE TABLE IF NOT EXISTS contents (
+			fs_id                     BIGINT       NOT NULL,
+			inode_id                  VARCHAR(64),
+			storage_type              VARCHAR(32)  NOT NULL,
+			storage_ref               TEXT         NOT NULL,
+			storage_ref_hash          VARCHAR(64)  NOT NULL DEFAULT '',
+			storage_encryption_mode   VARCHAR(16)  NOT NULL DEFAULT 'legacy',
+			storage_encryption_key_id VARCHAR(256) NOT NULL DEFAULT '',
+			content_blob              LONGBLOB,
+			content_type              VARCHAR(255),
+			checksum_sha256           VARCHAR(128),
+			source_id                 VARCHAR(255),
+			PRIMARY KEY (fs_id, inode_id) CLUSTERED,
+			KEY idx_contents_storage_ref_hash (fs_id, storage_ref_hash)
+		)`,
+		`CREATE TABLE IF NOT EXISTS semantic (
+			fs_id                          BIGINT      NOT NULL,
+			inode_id                       VARCHAR(64),
+			content_text                   LONGTEXT,
+			description                    LONGTEXT,
+			embedding                      VECTOR(` + strconv.Itoa(TiDBAutoEmbeddingDimensions) + `),
+			embedding_revision             BIGINT,
+			description_embedding          VECTOR(` + strconv.Itoa(TiDBAutoEmbeddingDimensions) + `),
+			description_embedding_revision BIGINT,
+			PRIMARY KEY (fs_id, inode_id) CLUSTERED
+		)`,
+		`CREATE TABLE IF NOT EXISTS file_tags (
+			fs_id     BIGINT       NOT NULL,
+			file_id   VARCHAR(64)  NOT NULL,
+			inode_id  VARCHAR(64),
+			tag_key   VARCHAR(255) NOT NULL,
+			tag_value VARCHAR(255) NOT NULL DEFAULT '',
+			PRIMARY KEY (fs_id, file_id, tag_key) CLUSTERED,
+			KEY idx_kv (fs_id, tag_key, tag_value)
+		)`,
+		`CREATE TABLE IF NOT EXISTS uploads (
+			fs_id                     BIGINT        NOT NULL,
+			upload_id                 VARCHAR(64),
+			file_id                   VARCHAR(64)   NOT NULL,
+			inode_id                  VARCHAR(64),
+			target_path               TEXT          NOT NULL,
+			target_path_hash          VARCHAR(64)   NOT NULL DEFAULT '',
+			s3_upload_id              VARCHAR(255)  NOT NULL,
+			s3_key                    VARCHAR(2048) NOT NULL,
+			storage_encryption_mode   VARCHAR(16)   NOT NULL DEFAULT 'none',
+			storage_encryption_key_id VARCHAR(256)  NOT NULL DEFAULT '',
+			total_size                BIGINT        NOT NULL,
+			part_size                 BIGINT        NOT NULL,
+			parts_total               INT           NOT NULL,
+			expected_revision         BIGINT        NULL,
+			status                    VARCHAR(32)   NOT NULL DEFAULT 'UPLOADING',
+			fingerprint_sha256        VARCHAR(128),
+			idempotency_key           VARCHAR(255),
+			description               LONGTEXT,
+			created_at                DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at                DATETIME(3)   NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			expires_at                DATETIME(3)   NOT NULL,
+			active_target_path_hash   VARCHAR(64)   AS (CASE WHEN status = 'UPLOADING' THEN target_path_hash ELSE NULL END) VIRTUAL,
+			PRIMARY KEY (fs_id, upload_id) CLUSTERED,
+			KEY idx_upload_path (fs_id, target_path_hash, status),
+			UNIQUE KEY idx_idempotency (fs_id, idempotency_key),
+			UNIQUE KEY idx_uploads_active (fs_id, active_target_path_hash)
+		)`,
+		`CREATE TABLE IF NOT EXISTS semantic_tasks (
+			fs_id            BIGINT       NOT NULL,
+			task_id          VARCHAR(64),
+			task_type        VARCHAR(32)  NOT NULL,
+			resource_id      VARCHAR(64)  NOT NULL,
+			resource_version BIGINT       NOT NULL,
+			status           VARCHAR(20)  NOT NULL,
+			attempt_count    INT          NOT NULL DEFAULT 0,
+			max_attempts     INT          NOT NULL DEFAULT 5,
+			receipt          VARCHAR(128) NULL,
+			leased_at        DATETIME(3)  NULL,
+			lease_until      DATETIME(3)  NULL,
+			available_at     DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			payload_json     JSON         NULL,
+			last_error       TEXT         NULL,
+			created_at       DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at       DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			completed_at     DATETIME(3)  NULL,
+			PRIMARY KEY (fs_id, task_id) CLUSTERED,
+			UNIQUE KEY uk_task_resource_version (fs_id, task_type, resource_id, resource_version),
+			KEY idx_task_claim (fs_id, status, available_at, lease_until, created_at),
+			KEY idx_task_claim_type (fs_id, status, task_type, available_at, created_at, task_id)
+		)`,
+		`CREATE TABLE IF NOT EXISTS file_gc_tasks (
+			fs_id         BIGINT       NOT NULL,
+			task_id       VARCHAR(64),
+			file_id       VARCHAR(64)  NOT NULL,
+			inode_id      VARCHAR(64),
+			storage_type  VARCHAR(32)  NOT NULL,
+			storage_ref   TEXT         NOT NULL,
+			size_bytes    BIGINT       NOT NULL DEFAULT 0,
+			content_type  VARCHAR(255) NULL,
+			status        VARCHAR(20)  NOT NULL,
+			attempt_count INT          NOT NULL DEFAULT 0,
+			max_attempts  INT          NOT NULL DEFAULT 0,
+			receipt       VARCHAR(128) NULL,
+			leased_at     DATETIME(3)  NULL,
+			lease_until   DATETIME(3)  NULL,
+			available_at  DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			last_error    TEXT         NULL,
+			created_at    DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at    DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			completed_at  DATETIME(3)  NULL,
+			PRIMARY KEY (fs_id, task_id) CLUSTERED,
+			UNIQUE KEY uk_file_gc_file_id (fs_id, file_id),
+			UNIQUE KEY uk_file_gc_inode_id (fs_id, inode_id),
+			KEY idx_file_gc_claim (fs_id, status, available_at, lease_until, created_at)
+		)`,
+		`CREATE TABLE IF NOT EXISTS llm_usage (
+			fs_id           BIGINT      NOT NULL,
+			id              BIGINT      AUTO_INCREMENT PRIMARY KEY,
+			task_type       VARCHAR(32) NOT NULL,
+			task_id         VARCHAR(64) NOT NULL,
+			cost_millicents BIGINT      NOT NULL DEFAULT 0,
+			raw_units       BIGINT      NOT NULL DEFAULT 0,
+			raw_unit_type   VARCHAR(16) NOT NULL,
+			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			KEY idx_llm_usage_created (created_at),
+			KEY idx_llm_usage_fs (fs_id, created_at)
+		)`,
+		`CREATE TABLE IF NOT EXISTS fs_events (
+			fs_id      BIGINT       NOT NULL,
+			seq        BIGINT       UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+			path       TEXT         NOT NULL,
+			op         VARCHAR(64)  NOT NULL,
+			actor      VARCHAR(255),
+			ts         BIGINT       NOT NULL,
+			created_at DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			KEY idx_fs_events_created (created_at),
+			KEY idx_fs_events_fs_seq (fs_id, seq)
+		)`,
+	}
+}
+
+// CoreFSMySQLSharedSchemaStatements is the plain-MySQL variant of
+// CoreFSTiDBSharedSchemaStatements, derived by removing TiDB-only keywords.
+// Use it for local development databases and MySQL-backed tests/e2e.
+func CoreFSMySQLSharedSchemaStatements() []string {
+	return mysqlCompatibleSharedStatements(CoreFSTiDBSharedSchemaStatements())
+}
+
+// TiDBSharedOptionalSchemaStatements returns the TiDB-only optional semantic
+// indexes (full-text + vector) for the shared schema shape, mirroring
+// tidbAppEmbeddingOptionalSchemaStatements verbatim: the statements reference
+// columns, not tenant keys, so no fs_id changes are needed. There is no MySQL
+// variant — plain MySQL has no comparable FTS parser or vector index support.
+//
+// Note: the vector index expression (VEC_COSINE_DISTANCE here versus the
+// query-side VEC_EMBED_COSINE_DISTANCE) is pending Phase-0 verification (D3 in
+// docs/TENANT_DB_REDESIGN.md), so this list may change once that lands.
+func TiDBSharedOptionalSchemaStatements() []string {
+	return []string{
+
+		`ALTER TABLE semantic
+			ADD FULLTEXT INDEX idx_semantic_fts_content(content_text)
+			WITH PARSER MULTILINGUAL
+			ADD_COLUMNAR_REPLICA_ON_DEMAND`,
+		`ALTER TABLE semantic
+			ADD FULLTEXT INDEX idx_semantic_fts_description(description)
+			WITH PARSER MULTILINGUAL
+			ADD_COLUMNAR_REPLICA_ON_DEMAND`,
+		`ALTER TABLE semantic
+			ADD VECTOR INDEX idx_semantic_cosine((VEC_COSINE_DISTANCE(embedding)))
+			ADD_COLUMNAR_REPLICA_ON_DEMAND`,
+		`ALTER TABLE semantic
+			ADD VECTOR INDEX idx_semantic_desc_cosine((VEC_COSINE_DISTANCE(description_embedding)))
+			ADD_COLUMNAR_REPLICA_ON_DEMAND`,
+	}
+}

--- a/pkg/tenant/schema/tidb_shared.go
+++ b/pkg/tenant/schema/tidb_shared.go
@@ -15,14 +15,18 @@ import (
 // definitions otherwise mirror the standalone ones verbatim, so primary key
 // member columns pick up their implicit NOT NULL from the key itself.
 //
-// Two documented exceptions keep their global AUTO_INCREMENT physical primary
-// key unchanged (docs/TENANT_DB_REDESIGN.md §5.4) and only gain the fs_id
-// column plus (fs_id, ...) lookup indexes:
+// fs_events is the one documented exception that keeps its global
+// AUTO_INCREMENT physical primary key unchanged and only gains the fs_id
+// column plus an (fs_id, ...) lookup index: seq stays the primary key;
+// idx_fs_events_created stays unprefixed; idx_fs_events_fs_seq (fs_id, seq)
+// is new.
 //
-//   - llm_usage: id stays the primary key; idx_llm_usage_created stays
-//     unprefixed; idx_llm_usage_fs (fs_id, created_at) is new.
-//   - fs_events: seq stays the primary key; idx_fs_events_created stays
-//     unprefixed; idx_fs_events_fs_seq (fs_id, seq) is new.
+// llm_usage is deliberately NOT part of the shared schema. The central meta
+// DB ledger (tenant_llm_usage) is authoritative in multi-tenant deployments —
+// the backend only writes the tenant-DB llm_usage when server quota is not
+// active (single-tenant/local mode), which shared-schema databases never run.
+// Carrying the table in shared shape would duplicate the central ledger for
+// no reader.
 //
 // The uploads repair artifact (the standalone ALTER TABLE uploads ADD COLUMN
 // expected_revision) is folded directly into the CREATE TABLE. The semantic
@@ -178,18 +182,6 @@ func CoreFSTiDBSharedSchemaStatements() []string {
 			UNIQUE KEY uk_file_gc_file_id (fs_id, file_id),
 			UNIQUE KEY uk_file_gc_inode_id (fs_id, inode_id),
 			KEY idx_file_gc_claim (fs_id, status, available_at, lease_until, created_at)
-		)`,
-		`CREATE TABLE IF NOT EXISTS llm_usage (
-			fs_id           BIGINT      NOT NULL,
-			id              BIGINT      AUTO_INCREMENT PRIMARY KEY,
-			task_type       VARCHAR(32) NOT NULL,
-			task_id         VARCHAR(64) NOT NULL,
-			cost_millicents BIGINT      NOT NULL DEFAULT 0,
-			raw_units       BIGINT      NOT NULL DEFAULT 0,
-			raw_unit_type   VARCHAR(16) NOT NULL,
-			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-			KEY idx_llm_usage_created (created_at),
-			KEY idx_llm_usage_fs (fs_id, created_at)
 		)`,
 		`CREATE TABLE IF NOT EXISTS fs_events (
 			fs_id      BIGINT       NOT NULL,

--- a/pkg/tenant/schema/tidb_shared.go
+++ b/pkg/tenant/schema/tidb_shared.go
@@ -17,9 +17,10 @@ import (
 //
 // fs_events is the one documented exception that keeps its global
 // AUTO_INCREMENT physical primary key unchanged and only gains the fs_id
-// column plus an (fs_id, ...) lookup index: seq stays the primary key;
+// column plus (fs_id, ...) lookup indexes: seq stays the primary key;
 // idx_fs_events_created stays unprefixed; idx_fs_events_fs_seq (fs_id, seq)
-// is new.
+// and idx_fs_events_fs_created (fs_id, created_at) — the per-tenant
+// retention-delete path — are new.
 //
 // llm_usage is deliberately NOT part of the shared schema. The central meta
 // DB ledger (tenant_llm_usage) is authoritative in multi-tenant deployments —
@@ -192,7 +193,8 @@ func CoreFSTiDBSharedSchemaStatements() []string {
 			ts         BIGINT       NOT NULL,
 			created_at DATETIME(3)  NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			KEY idx_fs_events_created (created_at),
-			KEY idx_fs_events_fs_seq (fs_id, seq)
+			KEY idx_fs_events_fs_seq (fs_id, seq),
+			KEY idx_fs_events_fs_created (fs_id, created_at)
 		)`,
 	}
 }

--- a/pkg/tenant/schema/tidb_shared_test.go
+++ b/pkg/tenant/schema/tidb_shared_test.go
@@ -41,7 +41,8 @@ var sharedCoreFSUnprefixedIndexes = map[string]bool{
 // sharedCoreFSOnlyIndexes lists the (fs_id, ...) lookup indexes that exist
 // only in the shared shape, with their expected column lists.
 var sharedCoreFSOnlyIndexes = map[string][]string{
-	"idx_fs_events_fs_seq": {"fs_id", "seq"},
+	"idx_fs_events_fs_seq":     {"fs_id", "seq"},
+	"idx_fs_events_fs_created": {"fs_id", "created_at"},
 }
 
 type sharedCoreFSColumn struct {
@@ -210,8 +211,20 @@ func TestCoreFSTiDBSharedSchemaDeclaresClusteredPKs(t *testing.T) {
 // TestCoreFSSharedSchemaOmitsLLMUsage guards the intentional absence of
 // llm_usage from the shared schema: the central meta DB ledger
 // (tenant_llm_usage) is authoritative in multi-tenant deployments, so the
-// tenant-DB duplicate is not carried into shared shape.
+// tenant-DB duplicate is not carried into shared shape. The standalone
+// baseline must still contain it — otherwise this exclusion test would pass
+// silently against a schema that lost llm_usage on both shapes.
 func TestCoreFSSharedSchemaOmitsLLMUsage(t *testing.T) {
+	standaloneHasLLMUsage := false
+	for _, stmt := range tidbAppEmbeddingBaseSchemaStatements() {
+		if strings.Contains(stmt, "llm_usage") {
+			standaloneHasLLMUsage = true
+			break
+		}
+	}
+	if !standaloneHasLLMUsage {
+		t.Fatal("standalone baseline no longer contains llm_usage; re-evaluate the shared-schema exclusion instead of letting it pass silently")
+	}
 	for name, stmts := range map[string][]string{
 		"tidb":  CoreFSTiDBSharedSchemaStatements(),
 		"mysql": CoreFSMySQLSharedSchemaStatements(),

--- a/pkg/tenant/schema/tidb_shared_test.go
+++ b/pkg/tenant/schema/tidb_shared_test.go
@@ -1,0 +1,366 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/drive9/internal/schemaspec"
+)
+
+// sharedCoreFSTables lists the ten Core FS tables that
+// CoreFSTiDBSharedSchemaStatements mirrors from
+// tidbAppEmbeddingBaseSchemaStatements. Git workspace, fs_layer, journal, and
+// vault statements in the standalone list are out of scope here.
+var sharedCoreFSTables = []string{
+	"file_nodes",
+	"inodes",
+	"contents",
+	"semantic",
+	"file_tags",
+	"uploads",
+	"semantic_tasks",
+	"file_gc_tasks",
+	"llm_usage",
+	"fs_events",
+}
+
+// sharedCoreFSPhysicalPKTables documents the two exception tables that keep
+// their global AUTO_INCREMENT physical primary key unchanged in the shared
+// shape (docs/TENANT_DB_REDESIGN.md §5.4) instead of gaining an fs_id-prefixed
+// composite primary key.
+var sharedCoreFSPhysicalPKTables = map[string]bool{
+	"llm_usage": true,
+	"fs_events": true,
+}
+
+// sharedCoreFSUnprefixedIndexes whitelists the standalone indexes that stay
+// without an fs_id prefix in the shared shape (both live on the exception
+// tables above).
+var sharedCoreFSUnprefixedIndexes = map[string]bool{
+	"idx_llm_usage_created": true,
+	"idx_fs_events_created": true,
+}
+
+// sharedCoreFSOnlyIndexes lists the (fs_id, ...) lookup indexes that exist
+// only in the shared shape, with their expected column lists.
+var sharedCoreFSOnlyIndexes = map[string][]string{
+	"idx_llm_usage_fs":     {"fs_id", "created_at"},
+	"idx_fs_events_fs_seq": {"fs_id", "seq"},
+}
+
+type sharedCoreFSColumn struct {
+	name string
+	// def is the normalized column definition with any inline PRIMARY KEY
+	// marker removed, so standalone and shared shapes compare equal.
+	def string
+}
+
+type sharedCoreFSKey struct {
+	unique bool
+	cols   []string
+}
+
+type sharedCoreFSTable struct {
+	columns []sharedCoreFSColumn
+	pk      []string
+	keys    map[string]sharedCoreFSKey
+}
+
+// TestCoreFSSharedSchemaMatchesStandaloneModuloFsID pins the shared Core FS
+// DDL to the standalone one: the shared shape must be exactly the standalone
+// shape plus an fs_id BIGINT NOT NULL first column, an fs_id prefix on the
+// primary key and on every secondary index / unique constraint — modulo the
+// documented llm_usage / fs_events exceptions. Any column, type, default, or
+// key change on either side that is not mirrored on the other fails here.
+// The comparison uses the MySQL shared variant, which carries no TiDB-only
+// CLUSTERED keyword and maps VECTOR(n) columns to LONGTEXT (plain MySQL has
+// no vector type); the standalone side is normalized the same way.
+func TestCoreFSSharedSchemaMatchesStandaloneModuloFsID(t *testing.T) {
+	standalone := parseSharedCoreFSSchema(t, tidbAppEmbeddingBaseSchemaStatements())
+	shared := parseSharedCoreFSSchema(t, CoreFSMySQLSharedSchemaStatements())
+
+	for _, tableName := range sharedCoreFSTables {
+		standaloneTable, ok := standalone[tableName]
+		if !ok {
+			t.Fatalf("standalone DDL missing core table %s", tableName)
+		}
+		sharedTable, ok := shared[tableName]
+		if !ok {
+			t.Fatalf("shared DDL missing core table %s", tableName)
+		}
+
+		// Columns: fs_id BIGINT NOT NULL first, then the standalone columns in
+		// the same order with identical definitions (modulo the VECTOR→LONGTEXT
+		// MySQL rewrite).
+		wantColumns := make([]sharedCoreFSColumn, 0, len(standaloneTable.columns)+1)
+		wantColumns = append(wantColumns, sharedCoreFSColumn{name: "fs_id", def: "fs_id bigint not null"})
+		for _, col := range standaloneTable.columns {
+			wantColumns = append(wantColumns, sharedCoreFSColumn{name: col.name, def: schemaspec.NormalizeSQLFragment(stripTiDBVectorColumnType(col.def))})
+		}
+		if len(sharedTable.columns) != len(wantColumns) {
+			t.Errorf("table %s: shared has %d columns, want %d (fs_id + standalone)",
+				tableName, len(sharedTable.columns), len(wantColumns))
+		}
+		for i := 0; i < len(wantColumns) && i < len(sharedTable.columns); i++ {
+			if sharedTable.columns[i] != wantColumns[i] {
+				t.Errorf("table %s column %d: shared %q, want %q",
+					tableName, i, sharedTable.columns[i].def, wantColumns[i].def)
+			}
+		}
+
+		// Primary key: fs_id prefix, except on the documented exception tables.
+		wantPK := make([]string, 0, len(standaloneTable.pk)+1)
+		if !sharedCoreFSPhysicalPKTables[tableName] {
+			wantPK = append(wantPK, "fs_id")
+		}
+		wantPK = append(wantPK, standaloneTable.pk...)
+		if !equalSharedCoreFSColumns(sharedTable.pk, wantPK) {
+			t.Errorf("table %s: shared primary key %v, want %v", tableName, sharedTable.pk, wantPK)
+		}
+
+		// Keys: every standalone key appears in shared with an fs_id prefix,
+		// except the whitelisted unprefixed indexes.
+		for keyName, standaloneKey := range standaloneTable.keys {
+			sharedKey, ok := sharedTable.keys[keyName]
+			if !ok {
+				t.Errorf("table %s: shared missing key %s", tableName, keyName)
+				continue
+			}
+			if sharedKey.unique != standaloneKey.unique {
+				t.Errorf("table %s key %s: shared unique=%t, standalone unique=%t",
+					tableName, keyName, sharedKey.unique, standaloneKey.unique)
+			}
+			wantCols := make([]string, 0, len(standaloneKey.cols)+1)
+			if !sharedCoreFSUnprefixedIndexes[keyName] {
+				wantCols = append(wantCols, "fs_id")
+			}
+			wantCols = append(wantCols, standaloneKey.cols...)
+			if !equalSharedCoreFSColumns(sharedKey.cols, wantCols) {
+				t.Errorf("table %s key %s: shared columns %v, want %v",
+					tableName, keyName, sharedKey.cols, wantCols)
+			}
+		}
+		// And shared has no extra keys beyond the whitelisted shared-only ones.
+		for keyName, sharedKey := range sharedTable.keys {
+			if wantCols, ok := sharedCoreFSOnlyIndexes[keyName]; ok {
+				if sharedKey.unique {
+					t.Errorf("table %s key %s: shared-only index must not be unique", tableName, keyName)
+				}
+				if !equalSharedCoreFSColumns(sharedKey.cols, wantCols) {
+					t.Errorf("table %s key %s: shared columns %v, want %v",
+						tableName, keyName, sharedKey.cols, wantCols)
+				}
+				continue
+			}
+			if _, ok := standaloneTable.keys[keyName]; !ok {
+				t.Errorf("table %s: shared-only key %s is not whitelisted", tableName, keyName)
+			}
+		}
+	}
+}
+
+// TestCoreFSTiDBSharedSchemaDeclaresClusteredPKs ensures the TiDB variant
+// declares every composite primary key CLUSTERED (TiDB defaults composite PKs
+// to NONCLUSTERED, which would scatter each tenant's rows), that the two
+// exception tables keep their inline AUTO_INCREMENT primary key, and that the
+// MySQL variant differs only by the mechanical dialect rewrites (CLUSTERED
+// removal, VECTOR→LONGTEXT).
+func TestCoreFSTiDBSharedSchemaDeclaresClusteredPKs(t *testing.T) {
+	tidbStmts := CoreFSTiDBSharedSchemaStatements()
+	mysqlStmts := CoreFSMySQLSharedSchemaStatements()
+	if len(tidbStmts) != len(mysqlStmts) {
+		t.Fatalf("variant length mismatch: tidb %d, mysql %d", len(tidbStmts), len(mysqlStmts))
+	}
+	if len(tidbStmts) != len(sharedCoreFSTables) {
+		t.Fatalf("shared DDL has %d statements, want %d (one per core table)",
+			len(tidbStmts), len(sharedCoreFSTables))
+	}
+	clusteredTables := 0
+	for i := range tidbStmts {
+		tableName, _, ok, err := schemaspec.ParseCreateTableStatement(tidbStmts[i])
+		if err != nil || !ok {
+			t.Fatalf("statement %d is not a CREATE TABLE: %v", i, err)
+		}
+		compositePK := strings.Contains(tidbStmts[i], "PRIMARY KEY (")
+		switch {
+		case sharedCoreFSPhysicalPKTables[tableName]:
+			if compositePK {
+				t.Errorf("table %s: exception table must keep its inline AUTO_INCREMENT primary key:\n%s",
+					tableName, tidbStmts[i])
+			}
+			if strings.Contains(tidbStmts[i], "CLUSTERED") {
+				t.Errorf("table %s: exception table must not declare CLUSTERED:\n%s", tableName, tidbStmts[i])
+			}
+		case !compositePK:
+			t.Errorf("table %s: no composite primary key and not a documented exception:\n%s",
+				tableName, tidbStmts[i])
+		case !strings.Contains(tidbStmts[i], " CLUSTERED"):
+			t.Errorf("table %s: composite primary key without CLUSTERED:\n%s", tableName, tidbStmts[i])
+		default:
+			clusteredTables++
+		}
+		if strings.Contains(mysqlStmts[i], "CLUSTERED") {
+			t.Errorf("mysql variant retains CLUSTERED keyword:\n%s", mysqlStmts[i])
+		}
+		if got, want := mysqlStmts[i], mysqlCompatibleSharedStatement(tidbStmts[i]); got != want {
+			t.Errorf("statement %d variants differ beyond the dialect rewrites:\ntidb rewritten: %s\nmysql: %s", i, want, got)
+		}
+	}
+	if want := len(sharedCoreFSTables) - len(sharedCoreFSPhysicalPKTables); clusteredTables != want {
+		t.Errorf("clustered composite primary keys = %d, want %d", clusteredTables, want)
+	}
+}
+
+// TestTiDBSharedOptionalSchemaMatchesStandalone pins the shared optional
+// semantic indexes to the standalone ones: the statements reference columns,
+// not tenant keys, so they must stay identical.
+func TestTiDBSharedOptionalSchemaMatchesStandalone(t *testing.T) {
+	standalone := tidbAppEmbeddingOptionalSchemaStatements()
+	shared := TiDBSharedOptionalSchemaStatements()
+	if len(standalone) != len(shared) {
+		t.Fatalf("statement count mismatch: standalone %d, shared %d", len(standalone), len(shared))
+	}
+	for i := range standalone {
+		if got, want := schemaspec.NormalizeSQLFragment(shared[i]), schemaspec.NormalizeSQLFragment(standalone[i]); got != want {
+			t.Errorf("optional statement %d drift:\nstandalone: %s\nshared: %s", i, want, got)
+		}
+	}
+}
+
+// parseSharedCoreFSSchema extracts the ten Core FS table shapes from a mixed
+// schema statement list: CREATE TABLE bodies supply columns, primary keys,
+// and table-level keys; standalone CREATE [UNIQUE] INDEX statements are
+// attached to their table afterwards.
+func parseSharedCoreFSSchema(t *testing.T, stmts []string) map[string]*sharedCoreFSTable {
+	t.Helper()
+	wanted := make(map[string]bool, len(sharedCoreFSTables))
+	for _, name := range sharedCoreFSTables {
+		wanted[name] = true
+	}
+	type externalIndex struct {
+		table string
+		name  string
+		key   sharedCoreFSKey
+	}
+	tables := make(map[string]*sharedCoreFSTable)
+	var indexes []externalIndex
+	for _, stmt := range stmts {
+		normalized := schemaspec.NormalizeSQLFragment(stmt)
+		switch {
+		case strings.HasPrefix(normalized, "create table "):
+			tableName, table := parseSharedCoreFSCreateTable(t, stmt)
+			if wanted[tableName] {
+				tables[tableName] = table
+			}
+		case strings.HasPrefix(normalized, "create unique index "), strings.HasPrefix(normalized, "create index "):
+			tableName, keyName, key := parseSharedCoreFSCreateIndex(t, stmt)
+			if wanted[tableName] {
+				indexes = append(indexes, externalIndex{table: tableName, name: keyName, key: key})
+			}
+		}
+	}
+	for _, idx := range indexes {
+		table, ok := tables[idx.table]
+		if !ok {
+			t.Fatalf("index %s targets core table %s with no CREATE TABLE in the list", idx.name, idx.table)
+		}
+		table.keys[idx.name] = idx.key
+	}
+	return tables
+}
+
+func parseSharedCoreFSCreateTable(t *testing.T, stmt string) (string, *sharedCoreFSTable) {
+	t.Helper()
+	tableName, definitions, ok, err := schemaspec.ParseCreateTableStatement(stmt)
+	if err != nil || !ok {
+		t.Fatalf("parse create table: ok=%t err=%v", ok, err)
+	}
+	table := &sharedCoreFSTable{keys: make(map[string]sharedCoreFSKey)}
+	for _, def := range schemaspec.SplitTopLevelComma(definitions) {
+		normalized := schemaspec.NormalizeSQLFragment(def)
+		switch {
+		case strings.HasPrefix(normalized, "primary key"):
+			table.pk = parseSharedCoreFSKeyColumns(t, tableName, normalized)
+		case strings.HasPrefix(normalized, "unique key "):
+			keyName, cols := parseSharedCoreFSTableKey(t, tableName, normalized, "unique key ")
+			table.keys[keyName] = sharedCoreFSKey{unique: true, cols: cols}
+		case strings.HasPrefix(normalized, "key "):
+			keyName, cols := parseSharedCoreFSTableKey(t, tableName, normalized, "key ")
+			table.keys[keyName] = sharedCoreFSKey{unique: false, cols: cols}
+		default:
+			columnName, rest := schemaspec.SplitIdentifierAndRest(def)
+			columnDef := schemaspec.NormalizeSQLFragment(columnName + " " + rest)
+			if strings.Contains(columnDef, " primary key") {
+				table.pk = append(table.pk, strings.ToLower(columnName))
+				columnDef = strings.ReplaceAll(columnDef, " primary key", "")
+			}
+			table.columns = append(table.columns, sharedCoreFSColumn{name: strings.ToLower(columnName), def: columnDef})
+		}
+	}
+	return tableName, table
+}
+
+func parseSharedCoreFSCreateIndex(t *testing.T, stmt string) (tableName, keyName string, key sharedCoreFSKey) {
+	t.Helper()
+	normalized := schemaspec.NormalizeSQLFragment(stmt)
+	rest := ""
+	switch {
+	case strings.HasPrefix(normalized, "create unique index "):
+		key.unique = true
+		rest = strings.TrimPrefix(normalized, "create unique index ")
+	case strings.HasPrefix(normalized, "create index "):
+		rest = strings.TrimPrefix(normalized, "create index ")
+	default:
+		t.Fatalf("not a CREATE INDEX statement: %q", stmt)
+	}
+	onIdx := strings.Index(rest, " on ")
+	if onIdx < 0 {
+		t.Fatalf("malformed CREATE INDEX statement: %q", stmt)
+	}
+	keyName = strings.TrimSpace(rest[:onIdx])
+	tablePart := rest[onIdx+len(" on "):]
+	openIdx := strings.Index(tablePart, "(")
+	if openIdx < 0 {
+		t.Fatalf("malformed CREATE INDEX statement: %q", stmt)
+	}
+	tableName = strings.TrimSpace(tablePart[:openIdx])
+	key.cols = parseSharedCoreFSKeyColumns(t, tableName, tablePart)
+	return tableName, keyName, key
+}
+
+func parseSharedCoreFSTableKey(t *testing.T, tableName, clause, prefix string) (string, []string) {
+	t.Helper()
+	rest := strings.TrimPrefix(clause, prefix)
+	openIdx := strings.Index(rest, "(")
+	if openIdx < 0 {
+		t.Fatalf("table %s: malformed key clause %q", tableName, clause)
+	}
+	return strings.TrimSpace(rest[:openIdx]), parseSharedCoreFSKeyColumns(t, tableName, rest)
+}
+
+func parseSharedCoreFSKeyColumns(t *testing.T, tableName, clause string) []string {
+	t.Helper()
+	openIdx := strings.Index(clause, "(")
+	closeIdx := strings.LastIndex(clause, ")")
+	if openIdx < 0 || closeIdx < openIdx {
+		t.Fatalf("table %s: malformed key clause %q", tableName, clause)
+	}
+	parts := strings.Split(clause[openIdx+1:closeIdx], ",")
+	cols := make([]string, 0, len(parts))
+	for _, part := range parts {
+		cols = append(cols, strings.TrimSpace(part))
+	}
+	return cols
+}
+
+func equalSharedCoreFSColumns(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/tenant/schema/tidb_shared_test.go
+++ b/pkg/tenant/schema/tidb_shared_test.go
@@ -7,10 +7,12 @@ import (
 	"github.com/mem9-ai/drive9/internal/schemaspec"
 )
 
-// sharedCoreFSTables lists the ten Core FS tables that
+// sharedCoreFSTables lists the nine Core FS tables that
 // CoreFSTiDBSharedSchemaStatements mirrors from
 // tidbAppEmbeddingBaseSchemaStatements. Git workspace, fs_layer, journal, and
-// vault statements in the standalone list are out of scope here.
+// vault statements in the standalone list are out of scope here. llm_usage is
+// intentionally NOT mirrored: the central meta DB ledger is authoritative in
+// multi-tenant deployments, so the shared schema drops the duplicate table.
 var sharedCoreFSTables = []string{
 	"file_nodes",
 	"inodes",
@@ -20,31 +22,25 @@ var sharedCoreFSTables = []string{
 	"uploads",
 	"semantic_tasks",
 	"file_gc_tasks",
-	"llm_usage",
 	"fs_events",
 }
 
-// sharedCoreFSPhysicalPKTables documents the two exception tables that keep
-// their global AUTO_INCREMENT physical primary key unchanged in the shared
-// shape (docs/TENANT_DB_REDESIGN.md §5.4) instead of gaining an fs_id-prefixed
-// composite primary key.
+// sharedCoreFSPhysicalPKTables documents the exception table that keeps its
+// global AUTO_INCREMENT physical primary key unchanged in the shared shape
+// instead of gaining an fs_id-prefixed composite primary key.
 var sharedCoreFSPhysicalPKTables = map[string]bool{
-	"llm_usage": true,
 	"fs_events": true,
 }
 
 // sharedCoreFSUnprefixedIndexes whitelists the standalone indexes that stay
-// without an fs_id prefix in the shared shape (both live on the exception
-// tables above).
+// without an fs_id prefix in the shared shape (on the exception table above).
 var sharedCoreFSUnprefixedIndexes = map[string]bool{
-	"idx_llm_usage_created": true,
 	"idx_fs_events_created": true,
 }
 
 // sharedCoreFSOnlyIndexes lists the (fs_id, ...) lookup indexes that exist
 // only in the shared shape, with their expected column lists.
 var sharedCoreFSOnlyIndexes = map[string][]string{
-	"idx_llm_usage_fs":     {"fs_id", "created_at"},
 	"idx_fs_events_fs_seq": {"fs_id", "seq"},
 }
 
@@ -70,8 +66,8 @@ type sharedCoreFSTable struct {
 // DDL to the standalone one: the shared shape must be exactly the standalone
 // shape plus an fs_id BIGINT NOT NULL first column, an fs_id prefix on the
 // primary key and on every secondary index / unique constraint — modulo the
-// documented llm_usage / fs_events exceptions. Any column, type, default, or
-// key change on either side that is not mirrored on the other fails here.
+// documented fs_events exception. Any column, type, default, or key change on
+// either side that is not mirrored on the other fails here.
 // The comparison uses the MySQL shared variant, which carries no TiDB-only
 // CLUSTERED keyword and maps VECTOR(n) columns to LONGTEXT (plain MySQL has
 // no vector type); the standalone side is normalized the same way.
@@ -161,10 +157,10 @@ func TestCoreFSSharedSchemaMatchesStandaloneModuloFsID(t *testing.T) {
 
 // TestCoreFSTiDBSharedSchemaDeclaresClusteredPKs ensures the TiDB variant
 // declares every composite primary key CLUSTERED (TiDB defaults composite PKs
-// to NONCLUSTERED, which would scatter each tenant's rows), that the two
-// exception tables keep their inline AUTO_INCREMENT primary key, and that the
-// MySQL variant differs only by the mechanical dialect rewrites (CLUSTERED
-// removal, VECTOR→LONGTEXT).
+// to NONCLUSTERED, which would scatter each tenant's rows), that the
+// fs_events exception table keeps its inline AUTO_INCREMENT primary key, and
+// that the MySQL variant differs only by the mechanical dialect rewrites
+// (CLUSTERED removal, VECTOR→LONGTEXT).
 func TestCoreFSTiDBSharedSchemaDeclaresClusteredPKs(t *testing.T) {
 	tidbStmts := CoreFSTiDBSharedSchemaStatements()
 	mysqlStmts := CoreFSMySQLSharedSchemaStatements()
@@ -208,6 +204,23 @@ func TestCoreFSTiDBSharedSchemaDeclaresClusteredPKs(t *testing.T) {
 	}
 	if want := len(sharedCoreFSTables) - len(sharedCoreFSPhysicalPKTables); clusteredTables != want {
 		t.Errorf("clustered composite primary keys = %d, want %d", clusteredTables, want)
+	}
+}
+
+// TestCoreFSSharedSchemaOmitsLLMUsage guards the intentional absence of
+// llm_usage from the shared schema: the central meta DB ledger
+// (tenant_llm_usage) is authoritative in multi-tenant deployments, so the
+// tenant-DB duplicate is not carried into shared shape.
+func TestCoreFSSharedSchemaOmitsLLMUsage(t *testing.T) {
+	for name, stmts := range map[string][]string{
+		"tidb":  CoreFSTiDBSharedSchemaStatements(),
+		"mysql": CoreFSMySQLSharedSchemaStatements(),
+	} {
+		for _, stmt := range stmts {
+			if strings.Contains(stmt, "llm_usage") {
+				t.Errorf("%s shared variant must not reference llm_usage:\n%s", name, stmt)
+			}
+		}
 	}
 }
 

--- a/pkg/tenant/schema/vault.go
+++ b/pkg/tenant/schema/vault.go
@@ -93,3 +93,113 @@ func VaultTiDBSchemaStatements() []string {
 		)`,
 	}
 }
+
+// VaultTiDBSharedSchemaStatements returns the vault DDL for the shared
+// (multi-tenant) schema shape on TiDB: identical to VaultTiDBSchemaStatements
+// except the tenant_id VARCHAR(64) discriminator column is replaced by
+// fs_id BIGINT in every table, unique key, and index, and vault_secret_fields
+// — which has no tenant column in the standalone shape — gains fs_id BIGINT
+// as its first column. The composite primary key of vault_secret_fields is
+// declared CLUSTERED: TiDB creates composite primary keys NONCLUSTERED by
+// default, and the shared shape relies on clustered keys to physically
+// co-locate one tenant's rows. vault_deks keeps its single-column integer
+// primary key, which TiDB clusters by default, so it needs no keyword. For
+// plain MySQL use VaultMySQLSharedSchemaStatements (same shape without the
+// keyword). Keep both in lockstep with VaultTiDBSchemaStatements — the drift
+// test in vault_shared_test.go enforces parity.
+func VaultTiDBSharedSchemaStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS vault_deks (
+			fs_id        BIGINT PRIMARY KEY,
+			wrapped_dek  BLOB NOT NULL,
+			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_secrets (
+			secret_id    VARCHAR(64) PRIMARY KEY,
+			fs_id        BIGINT NOT NULL,
+			name         VARCHAR(255) NOT NULL,
+			secret_type  VARCHAR(32) NOT NULL DEFAULT 'generic',
+			revision     BIGINT NOT NULL DEFAULT 1,
+			created_by   VARCHAR(255) NOT NULL,
+			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			deleted_at   DATETIME(3),
+			UNIQUE INDEX uk_vault_secrets_tenant_name (fs_id, name),
+			INDEX idx_vault_secrets_tenant (fs_id)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_secret_fields (
+			fs_id           BIGINT NOT NULL,
+			secret_id       VARCHAR(64) NOT NULL,
+			field_name      VARCHAR(255) NOT NULL,
+			encrypted_value BLOB NOT NULL,
+			nonce           BLOB NOT NULL,
+			PRIMARY KEY (fs_id, secret_id, field_name) CLUSTERED
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_tokens (
+			token_id      VARCHAR(64) PRIMARY KEY,
+			fs_id         BIGINT NOT NULL,
+			agent_id      VARCHAR(255) NOT NULL,
+			task_id       VARCHAR(255),
+			scope_json    JSON NOT NULL,
+			issued_at     DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			expires_at    DATETIME(3) NOT NULL,
+			revoked_at    DATETIME(3),
+			revoked_by    VARCHAR(255),
+			revoke_reason VARCHAR(255),
+			INDEX idx_vault_token_tenant (fs_id),
+			INDEX idx_vault_token_agent (agent_id)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_grants (
+			grant_id       VARCHAR(64) PRIMARY KEY,
+			fs_id          BIGINT NOT NULL,
+			issuer         VARCHAR(256) NOT NULL,
+			principal_type VARCHAR(16) NOT NULL,
+			agent          VARCHAR(128) NOT NULL,
+			scope_json     JSON NOT NULL,
+			perm           VARCHAR(8) NOT NULL,
+			label_hint     VARCHAR(128),
+			issued_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			expires_at     DATETIME(3) NOT NULL,
+			revoked_at     DATETIME(3),
+			revoked_by     VARCHAR(128),
+			revoke_reason  VARCHAR(256),
+			INDEX idx_vault_grants_tenant (fs_id),
+			INDEX idx_vault_grants_expires (expires_at)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_policies (
+			policy_id   VARCHAR(64) PRIMARY KEY,
+			fs_id       BIGINT NOT NULL,
+			name        VARCHAR(255) NOT NULL,
+			rules_json  JSON NOT NULL,
+			created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+		)`,
+
+		`CREATE TABLE IF NOT EXISTS vault_audit_log (
+			event_id     VARCHAR(64) PRIMARY KEY,
+			fs_id        BIGINT NOT NULL,
+			event_type   VARCHAR(32) NOT NULL,
+			token_id     VARCHAR(64),
+			agent_id     VARCHAR(255),
+			task_id      VARCHAR(255),
+			secret_name  VARCHAR(255),
+			field_name   VARCHAR(255),
+			adapter      VARCHAR(16),
+			detail_json  JSON,
+			timestamp    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			INDEX idx_vault_audit_tenant_time (fs_id, timestamp),
+			INDEX idx_vault_audit_secret (secret_name, timestamp)
+		)`,
+	}
+}
+
+// VaultMySQLSharedSchemaStatements is the plain-MySQL variant of
+// VaultTiDBSharedSchemaStatements, derived by removing TiDB-only keywords.
+// Use it for local development databases and MySQL-backed tests/e2e.
+func VaultMySQLSharedSchemaStatements() []string {
+	return mysqlCompatibleSharedStatements(VaultTiDBSharedSchemaStatements())
+}

--- a/pkg/tenant/schema/vault.go
+++ b/pkg/tenant/schema/vault.go
@@ -99,14 +99,14 @@ func VaultTiDBSchemaStatements() []string {
 // except the tenant_id VARCHAR(64) discriminator column is replaced by
 // fs_id BIGINT in every table, unique key, and index, and vault_secret_fields
 // — which has no tenant column in the standalone shape — gains fs_id BIGINT
-// as its first column. The composite primary key of vault_secret_fields is
-// declared CLUSTERED: TiDB creates composite primary keys NONCLUSTERED by
-// default, and the shared shape relies on clustered keys to physically
-// co-locate one tenant's rows. vault_deks keeps its single-column integer
-// primary key, which TiDB clusters by default, so it needs no keyword. For
-// plain MySQL use VaultMySQLSharedSchemaStatements (same shape without the
-// keyword). Keep both in lockstep with VaultTiDBSchemaStatements — the drift
-// test in vault_shared_test.go enforces parity.
+// as its first column. Every table's primary key leads with fs_id and is
+// declared CLUSTERED, physically co-locating one tenant's rows like the
+// other shared table groups do; composite keys need the keyword because TiDB
+// creates composite primary keys NONCLUSTERED by default (vault_deks keeps
+// its single-column integer primary key, which TiDB clusters by default).
+// For plain MySQL use VaultMySQLSharedSchemaStatements (same shape without
+// the keyword). Keep both in lockstep with VaultTiDBSchemaStatements — the
+// drift test in vault_shared_test.go enforces parity.
 func VaultTiDBSharedSchemaStatements() []string {
 	return []string{
 		`CREATE TABLE IF NOT EXISTS vault_deks (
@@ -116,7 +116,7 @@ func VaultTiDBSharedSchemaStatements() []string {
 		)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_secrets (
-			secret_id    VARCHAR(64) PRIMARY KEY,
+			secret_id    VARCHAR(64) NOT NULL,
 			fs_id        BIGINT NOT NULL,
 			name         VARCHAR(255) NOT NULL,
 			secret_type  VARCHAR(32) NOT NULL DEFAULT 'generic',
@@ -125,8 +125,8 @@ func VaultTiDBSharedSchemaStatements() []string {
 			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			deleted_at   DATETIME(3),
-			UNIQUE INDEX uk_vault_secrets_tenant_name (fs_id, name),
-			INDEX idx_vault_secrets_tenant (fs_id)
+			PRIMARY KEY (fs_id, secret_id) CLUSTERED,
+			UNIQUE INDEX uk_vault_secrets_tenant_name (fs_id, name)
 		)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_secret_fields (
@@ -139,7 +139,7 @@ func VaultTiDBSharedSchemaStatements() []string {
 		)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_tokens (
-			token_id      VARCHAR(64) PRIMARY KEY,
+			token_id      VARCHAR(64) NOT NULL,
 			fs_id         BIGINT NOT NULL,
 			agent_id      VARCHAR(255) NOT NULL,
 			task_id       VARCHAR(255),
@@ -149,12 +149,12 @@ func VaultTiDBSharedSchemaStatements() []string {
 			revoked_at    DATETIME(3),
 			revoked_by    VARCHAR(255),
 			revoke_reason VARCHAR(255),
-			INDEX idx_vault_token_tenant (fs_id),
+			PRIMARY KEY (fs_id, token_id) CLUSTERED,
 			INDEX idx_vault_token_agent (agent_id)
 		)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_grants (
-			grant_id       VARCHAR(64) PRIMARY KEY,
+			grant_id       VARCHAR(64) NOT NULL,
 			fs_id          BIGINT NOT NULL,
 			issuer         VARCHAR(256) NOT NULL,
 			principal_type VARCHAR(16) NOT NULL,
@@ -167,20 +167,21 @@ func VaultTiDBSharedSchemaStatements() []string {
 			revoked_at     DATETIME(3),
 			revoked_by     VARCHAR(128),
 			revoke_reason  VARCHAR(256),
-			INDEX idx_vault_grants_tenant (fs_id),
+			PRIMARY KEY (fs_id, grant_id) CLUSTERED,
 			INDEX idx_vault_grants_expires (expires_at)
 		)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_policies (
-			policy_id   VARCHAR(64) PRIMARY KEY,
+			policy_id   VARCHAR(64) NOT NULL,
 			fs_id       BIGINT NOT NULL,
 			name        VARCHAR(255) NOT NULL,
 			rules_json  JSON NOT NULL,
-			created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+			created_at  DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, policy_id) CLUSTERED
 		)`,
 
 		`CREATE TABLE IF NOT EXISTS vault_audit_log (
-			event_id     VARCHAR(64) PRIMARY KEY,
+			event_id     VARCHAR(64) NOT NULL,
 			fs_id        BIGINT NOT NULL,
 			event_type   VARCHAR(32) NOT NULL,
 			token_id     VARCHAR(64),
@@ -191,6 +192,7 @@ func VaultTiDBSharedSchemaStatements() []string {
 			adapter      VARCHAR(16),
 			detail_json  JSON,
 			timestamp    DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (fs_id, event_id) CLUSTERED,
 			INDEX idx_vault_audit_tenant_time (fs_id, timestamp),
 			INDEX idx_vault_audit_secret (secret_name, timestamp)
 		)`,

--- a/pkg/tenant/schema/vault_shared_test.go
+++ b/pkg/tenant/schema/vault_shared_test.go
@@ -9,17 +9,41 @@ import (
 
 // TestVaultSharedSchemaMatchesStandaloneModuloFsID pins the shared vault DDL
 // to the standalone one: for the six tables that carry a tenant discriminator
-// column, renaming tenant_id VARCHAR(64) -> fs_id BIGINT in the normalized
-// standalone statements must reproduce the shared statements exactly, so the
-// two shapes cannot drift apart silently. vault_secret_fields is skipped here
-// — it has no tenant column and gains fs_id structurally; it is covered by
-// TestVaultSharedSecretFieldsGainsFsID. The comparison uses the MySQL
-// variant, which carries no TiDB-only CLUSTERED keyword.
+// column, the shared statement must be exactly the standalone statement with
+// tenant_id VARCHAR(64) renamed to fs_id BIGINT, plus two structural changes
+// the rename cannot express:
+//
+//   - the standalone single-column inline PRIMARY KEY on the surrogate id
+//     column becomes a table-level composite PRIMARY KEY (fs_id, <id>), so
+//     one tenant's rows stay physically co-located;
+//   - single-column tenant indexes (idx_vault_*_tenant) are dropped: the
+//     composite primary key's fs_id prefix already serves those lookups.
+//
+// vault_secret_fields is skipped here — it has no tenant column and gains
+// fs_id structurally; it is covered by TestVaultSharedSecretFieldsGainsFsID.
+// The comparison uses the MySQL variant, which carries no TiDB-only
+// CLUSTERED keyword.
 func TestVaultSharedSchemaMatchesStandaloneModuloFsID(t *testing.T) {
 	standalone := VaultTiDBSchemaStatements()
 	shared := VaultMySQLSharedSchemaStatements()
 	if len(standalone) != len(shared) {
 		t.Fatalf("statement count mismatch: standalone %d, shared %d", len(standalone), len(shared))
+	}
+	// idColumn maps each table whose inline single-column primary key becomes
+	// a composite (fs_id, <id>) primary key in shared shape.
+	idColumn := map[string]string{
+		"vault_secrets":   "secret_id",
+		"vault_tokens":    "token_id",
+		"vault_grants":    "grant_id",
+		"vault_policies":  "policy_id",
+		"vault_audit_log": "event_id",
+	}
+	// droppedTenantIdx names the single-column tenant indexes removed in
+	// shared shape because the composite primary key prefix covers them.
+	droppedTenantIdx := map[string]bool{
+		"index idx_vault_secrets_tenant (fs_id)": true,
+		"index idx_vault_token_tenant (fs_id)":   true,
+		"index idx_vault_grants_tenant (fs_id)":  true,
 	}
 	renamed := 0
 	for i := range standalone {
@@ -34,12 +58,42 @@ func TestVaultSharedSchemaMatchesStandaloneModuloFsID(t *testing.T) {
 		if name == "vault_secret_fields" {
 			continue
 		}
-		want := schemaspec.NormalizeSQLFragment(standalone[i])
-		want = strings.ReplaceAll(want, "tenant_id varchar(64)", "fs_id bigint")
-		want = strings.ReplaceAll(want, "tenant_id", "fs_id")
-		got := schemaspec.NormalizeSQLFragment(shared[i])
-		if got != want {
-			t.Errorf("table %s drift:\nstandalone (tenant_id->fs_id): %s\nshared (mysql): %s", name, want, got)
+		standaloneDefs := createTableDefinitions(t, VaultTiDBSchemaStatements(), name)
+		var want []string
+		for _, def := range standaloneDefs {
+			def = strings.ReplaceAll(def, "tenant_id varchar(64)", "fs_id bigint")
+			def = strings.ReplaceAll(def, "tenant_id", "fs_id")
+			if idCol, ok := idColumn[name]; ok && strings.HasPrefix(def, idCol+" ") {
+				// The inline PRIMARY KEY attribute implies NOT NULL; the
+				// composite table-level key makes the column explicitly so.
+				def = strings.TrimSuffix(def, " primary key") + " not null"
+			}
+			if droppedTenantIdx[def] {
+				continue
+			}
+			want = append(want, def)
+		}
+		if idCol, ok := idColumn[name]; ok {
+			// Insert the composite primary key before the first index
+			// definition, or at the end when the table has none.
+			pk := "primary key (fs_id, " + idCol + ")"
+			at := len(want)
+			for j, def := range want {
+				if strings.HasPrefix(def, "index ") || strings.HasPrefix(def, "unique index ") {
+					at = j
+					break
+				}
+			}
+			want = append(want[:at], append([]string{pk}, want[at:]...)...)
+		}
+		got := createTableDefinitions(t, VaultMySQLSharedSchemaStatements(), name)
+		if len(got) != len(want) {
+			t.Fatalf("table %s definition count drift: got %d, want %d\ngot:  %v\nwant: %v", name, len(got), len(want), got, want)
+		}
+		for j := range want {
+			if got[j] != want[j] {
+				t.Errorf("table %s definition %d drift:\nstandalone-derived: %s\nshared (mysql):     %s", name, j, want[j], got[j])
+			}
 		}
 		renamed++
 	}
@@ -104,8 +158,8 @@ func TestVaultTiDBSharedSchemaDeclaresClusteredPKs(t *testing.T) {
 			t.Errorf("statement %d variants differ beyond the keyword:\ntidb stripped: %s\nmysql: %s", i, want, got)
 		}
 	}
-	if compositePKs != 1 {
-		t.Fatalf("composite primary keys = %d, want 1 (vault_secret_fields)", compositePKs)
+	if compositePKs != 6 {
+		t.Fatalf("composite primary keys = %d, want 6 (every vault table except vault_deks)", compositePKs)
 	}
 }
 

--- a/pkg/tenant/schema/vault_shared_test.go
+++ b/pkg/tenant/schema/vault_shared_test.go
@@ -1,0 +1,160 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/drive9/internal/schemaspec"
+)
+
+// TestVaultSharedSchemaMatchesStandaloneModuloFsID pins the shared vault DDL
+// to the standalone one: for the six tables that carry a tenant discriminator
+// column, renaming tenant_id VARCHAR(64) -> fs_id BIGINT in the normalized
+// standalone statements must reproduce the shared statements exactly, so the
+// two shapes cannot drift apart silently. vault_secret_fields is skipped here
+// — it has no tenant column and gains fs_id structurally; it is covered by
+// TestVaultSharedSecretFieldsGainsFsID. The comparison uses the MySQL
+// variant, which carries no TiDB-only CLUSTERED keyword.
+func TestVaultSharedSchemaMatchesStandaloneModuloFsID(t *testing.T) {
+	standalone := VaultTiDBSchemaStatements()
+	shared := VaultMySQLSharedSchemaStatements()
+	if len(standalone) != len(shared) {
+		t.Fatalf("statement count mismatch: standalone %d, shared %d", len(standalone), len(shared))
+	}
+	renamed := 0
+	for i := range standalone {
+		name, _, ok, err := schemaspec.ParseCreateTableStatement(standalone[i])
+		if err != nil || !ok {
+			t.Fatalf("parse standalone statement %d: ok=%v err=%v", i, ok, err)
+		}
+		sharedName, _, ok, err := schemaspec.ParseCreateTableStatement(shared[i])
+		if err != nil || !ok || sharedName != name {
+			t.Fatalf("statement %d table mismatch: standalone %q, shared %q (ok=%v err=%v)", i, name, sharedName, ok, err)
+		}
+		if name == "vault_secret_fields" {
+			continue
+		}
+		want := schemaspec.NormalizeSQLFragment(standalone[i])
+		want = strings.ReplaceAll(want, "tenant_id varchar(64)", "fs_id bigint")
+		want = strings.ReplaceAll(want, "tenant_id", "fs_id")
+		got := schemaspec.NormalizeSQLFragment(shared[i])
+		if got != want {
+			t.Errorf("table %s drift:\nstandalone (tenant_id->fs_id): %s\nshared (mysql): %s", name, want, got)
+		}
+		renamed++
+	}
+	if renamed != 6 {
+		t.Fatalf("renamed tables = %d, want 6 (all vault tables except vault_secret_fields)", renamed)
+	}
+}
+
+// TestVaultSharedSecretFieldsGainsFsID pins the one structural change the
+// text rewrite cannot express: vault_secret_fields has no tenant column in
+// the standalone shape, so the shared table must consist of fs_id BIGINT NOT
+// NULL followed by the standalone columns, with the primary key extended to
+// (fs_id, secret_id, field_name). The comparison uses the MySQL variant,
+// which carries no TiDB-only CLUSTERED keyword.
+func TestVaultSharedSecretFieldsGainsFsID(t *testing.T) {
+	standaloneDefs := createTableDefinitions(t, VaultTiDBSchemaStatements(), "vault_secret_fields")
+	sharedDefs := createTableDefinitions(t, VaultMySQLSharedSchemaStatements(), "vault_secret_fields")
+
+	standaloneCols, standalonePK := splitPrimaryKeyDef(t, standaloneDefs)
+	sharedCols, sharedPK := splitPrimaryKeyDef(t, sharedDefs)
+
+	if want := "primary key (secret_id, field_name)"; standalonePK != want {
+		t.Fatalf("standalone primary key = %q, want %q", standalonePK, want)
+	}
+	if want := "primary key (fs_id, secret_id, field_name)"; sharedPK != want {
+		t.Errorf("shared primary key = %q, want %q", sharedPK, want)
+	}
+
+	wantCols := append([]string{"fs_id bigint not null"}, standaloneCols...)
+	if len(sharedCols) != len(wantCols) {
+		t.Fatalf("shared column count = %d, want %d", len(sharedCols), len(wantCols))
+	}
+	for i := range wantCols {
+		if sharedCols[i] != wantCols[i] {
+			t.Errorf("column %d = %q, want %q", i, sharedCols[i], wantCols[i])
+		}
+	}
+}
+
+// TestVaultTiDBSharedSchemaDeclaresClusteredPKs ensures the TiDB variant
+// declares every composite primary key CLUSTERED (TiDB defaults composite PKs
+// to NONCLUSTERED, which would scatter each tenant's rows), and that the
+// MySQL variant differs only by the removed keyword.
+func TestVaultTiDBSharedSchemaDeclaresClusteredPKs(t *testing.T) {
+	tidb := VaultTiDBSharedSchemaStatements()
+	mysql := VaultMySQLSharedSchemaStatements()
+	if len(tidb) != len(mysql) {
+		t.Fatalf("variant length mismatch: tidb %d, mysql %d", len(tidb), len(mysql))
+	}
+	compositePKs := 0
+	for i := range tidb {
+		if hasCompositePrimaryKey(tidb[i]) {
+			compositePKs++
+			if !strings.Contains(tidb[i], " CLUSTERED") {
+				t.Errorf("statement %d has a composite primary key without CLUSTERED:\n%s", i, tidb[i])
+			}
+		}
+		if strings.Contains(mysql[i], "CLUSTERED") {
+			t.Errorf("mysql variant retains CLUSTERED keyword:\n%s", mysql[i])
+		}
+		if got, want := mysql[i], stripTiDBClusteredKeyword(tidb[i]); got != want {
+			t.Errorf("statement %d variants differ beyond the keyword:\ntidb stripped: %s\nmysql: %s", i, want, got)
+		}
+	}
+	if compositePKs != 1 {
+		t.Fatalf("composite primary keys = %d, want 1 (vault_secret_fields)", compositePKs)
+	}
+}
+
+// createTableDefinitions returns the normalized top-level column/constraint
+// definitions of the named table in stmts.
+func createTableDefinitions(t *testing.T, stmts []string, table string) []string {
+	t.Helper()
+	for _, stmt := range stmts {
+		name, defs, ok, err := schemaspec.ParseCreateTableStatement(stmt)
+		if err != nil {
+			t.Fatalf("parse statement: %v", err)
+		}
+		if !ok || name != table {
+			continue
+		}
+		parts := schemaspec.SplitTopLevelComma(defs)
+		normalized := make([]string, len(parts))
+		for i, part := range parts {
+			normalized[i] = schemaspec.NormalizeSQLFragment(part)
+		}
+		return normalized
+	}
+	t.Fatalf("table %q not found", table)
+	return nil
+}
+
+// splitPrimaryKeyDef separates the trailing PRIMARY KEY constraint from the
+// column definitions.
+func splitPrimaryKeyDef(t *testing.T, defs []string) (cols []string, pk string) {
+	t.Helper()
+	last := defs[len(defs)-1]
+	if !strings.HasPrefix(last, "primary key") {
+		t.Fatalf("last definition is not a primary key: %q", last)
+	}
+	return defs[:len(defs)-1], last
+}
+
+// hasCompositePrimaryKey reports whether stmt declares a table-level primary
+// key over more than one column (as opposed to an inline single-column
+// PRIMARY KEY attribute).
+func hasCompositePrimaryKey(stmt string) bool {
+	idx := strings.Index(stmt, "PRIMARY KEY (")
+	if idx < 0 {
+		return false
+	}
+	rest := stmt[idx+len("PRIMARY KEY ("):]
+	end := strings.Index(rest, ")")
+	if end < 0 {
+		return false
+	}
+	return strings.Contains(rest[:end], ",")
+}

--- a/pkg/tenant/schemadump/schemadump.go
+++ b/pkg/tenant/schemadump/schemadump.go
@@ -9,12 +9,21 @@ import (
 	tenantschema "github.com/mem9-ai/drive9/pkg/tenant/schema"
 )
 
-const usage = "usage: drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_native>"
+const usage = "usage: drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_native|shared>"
+
+// ProviderShared is the dump-only provider for the shared (multi-tenant)
+// schema shape: all tenant tables in one physical database, discriminated by
+// an fs_id column. It is not a tenant provisioning provider, so it is
+// resolved here rather than in pkg/tenant.
+const ProviderShared = "shared"
 
 // ResolveProvider normalizes a schema dump provider selection.
 func ResolveProvider(provider string) (string, error) {
 	if provider == "" {
 		return "", fmt.Errorf("%s", usage)
+	}
+	if provider == ProviderShared {
+		return ProviderShared, nil
 	}
 	normalized, err := tenant.NormalizeProvider(provider)
 	if err != nil {
@@ -30,6 +39,8 @@ func Statements(provider string) ([]string, error) {
 		return tenantschema.CloneStatements(tenantdb9.InitSchemaStatements()), nil
 	case tenant.ProviderTiDBZero, tenant.ProviderTiDBCloudNative:
 		return tenantschema.InitTiDBTenantSchemaStatementsForMode(tenantschema.TiDBEmbeddingModeAuto)
+	case ProviderShared:
+		return tenantschema.CloneStatements(tenantschema.SharedTiDBSchemaStatements()), nil
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", provider)
 	}

--- a/pkg/tenant/schemadump/schemadump.go
+++ b/pkg/tenant/schemadump/schemadump.go
@@ -9,21 +9,12 @@ import (
 	tenantschema "github.com/mem9-ai/drive9/pkg/tenant/schema"
 )
 
-const usage = "usage: drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_native|shared>"
-
-// ProviderShared is the dump-only provider for the shared (multi-tenant)
-// schema shape: all tenant tables in one physical database, discriminated by
-// an fs_id column. It is not a tenant provisioning provider, so it is
-// resolved here rather than in pkg/tenant.
-const ProviderShared = "shared"
+const usage = "usage: drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_native|tidb_cloud_native_shared>"
 
 // ResolveProvider normalizes a schema dump provider selection.
 func ResolveProvider(provider string) (string, error) {
 	if provider == "" {
 		return "", fmt.Errorf("%s", usage)
-	}
-	if provider == ProviderShared {
-		return ProviderShared, nil
 	}
 	normalized, err := tenant.NormalizeProvider(provider)
 	if err != nil {
@@ -39,7 +30,7 @@ func Statements(provider string) ([]string, error) {
 		return tenantschema.CloneStatements(tenantdb9.InitSchemaStatements()), nil
 	case tenant.ProviderTiDBZero, tenant.ProviderTiDBCloudNative:
 		return tenantschema.InitTiDBTenantSchemaStatementsForMode(tenantschema.TiDBEmbeddingModeAuto)
-	case ProviderShared:
+	case tenant.ProviderTiDBCloudNativeShared:
 		return tenantschema.CloneStatements(tenantschema.SharedTiDBSchemaStatements()), nil
 	default:
 		return nil, fmt.Errorf("unsupported provider: %s", provider)

--- a/pkg/vault/grant.go
+++ b/pkg/vault/grant.go
@@ -77,11 +77,11 @@ func (s *Store) IssueGrant(
 
 	scopeJSON, _ := json.Marshal(scope)
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO vault_grants (
-			grant_id, tenant_id, issuer, principal_type, agent, scope_json,
+		fmt.Sprintf(`INSERT INTO vault_grants (
+			grant_id, %s, issuer, principal_type, agent, scope_json,
 			perm, label_hint, issued_at, expires_at
-		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		grantID, tenantID, issuer, string(principal), agent, scopeJSON,
+		) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.tenantCol()),
+		grantID, s.tenantArg(tenantID), issuer, string(principal), agent, scopeJSON,
 		string(perm), nullableString(labelHint), now, expiresAt,
 	)
 	if err != nil {
@@ -110,8 +110,9 @@ func (s *Store) IssueGrant(
 //  5. scope validity (via VerifyGrant)
 //  6. DB revocation (scoped to tenant for isolation)
 //
-// Per pr-a-jwt-implementation.md §4 step 6: the DB query MUST filter on
-// tenant_id to prevent cross-tenant token reuse.
+// Per pr-a-jwt-implementation.md §4 step 6: the DB query MUST filter on the
+// tenant discriminator (tenant_id in standalone shape, fs_id in shared shape)
+// to prevent cross-tenant token reuse.
 //
 // The iss claim is additionally checked against expectedIssuer; a mismatch
 // fails closed. An empty expectedIssuer disables this check (useful for unit
@@ -140,8 +141,8 @@ func (s *Store) VerifyAndResolveGrant(
 
 	var revokedAt *time.Time
 	err = s.db.QueryRowContext(ctx,
-		`SELECT revoked_at FROM vault_grants WHERE tenant_id = ? AND grant_id = ?`,
-		tenantID, claims.GrantID,
+		fmt.Sprintf(`SELECT revoked_at FROM vault_grants WHERE %s = ? AND grant_id = ?`, s.tenantCol()),
+		s.tenantArg(tenantID), claims.GrantID,
 	).Scan(&revokedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("grant not found")
@@ -160,9 +161,9 @@ func (s *Store) VerifyAndResolveGrant(
 func (s *Store) RevokeGrant(ctx context.Context, tenantID, grantID, revokedBy, reason string) error {
 	now := time.Now()
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE vault_grants SET revoked_at = ?, revoked_by = ?, revoke_reason = ?
-		 WHERE tenant_id = ? AND grant_id = ? AND revoked_at IS NULL`,
-		now, revokedBy, reason, tenantID, grantID,
+		fmt.Sprintf(`UPDATE vault_grants SET revoked_at = ?, revoked_by = ?, revoke_reason = ?
+		 WHERE %s = ? AND grant_id = ? AND revoked_at IS NULL`, s.tenantCol()),
+		now, revokedBy, reason, s.tenantArg(tenantID), grantID,
 	)
 	if err != nil {
 		return fmt.Errorf("revoke grant: %w", err)

--- a/pkg/vault/store.go
+++ b/pkg/vault/store.go
@@ -8,21 +8,40 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/mem9-ai/drive9/pkg/datastore"
 )
 
 // Store provides CRUD operations for the vault data model.
 type Store struct {
-	db *sql.DB
-	mk *MasterKey
+	db    *sql.DB
+	mk    *MasterKey
+	scope datastore.Scope
 }
 
-// NewStore creates a new vault store.
+// NewStore creates a new vault store for the standalone (per-tenant DB)
+// schema shape.
 func NewStore(db *sql.DB, mk *MasterKey) *Store {
-	return &Store{db: db, mk: mk}
+	return NewStoreScoped(db, mk, datastore.StandaloneScope(0))
+}
+
+// NewStoreScoped creates a new vault store whose SQL is shaped by scope:
+// standalone tables key tenant rows by tenant_id, the shared (multi-tenant)
+// schema keys them by fs_id (see pkg/datastore.Scope).
+func NewStoreScoped(db *sql.DB, mk *MasterKey, scope datastore.Scope) *Store {
+	return &Store{db: db, mk: mk, scope: scope}
 }
 
 // DB returns the underlying database connection.
 func (s *Store) DB() *sql.DB { return s.db }
+
+// tenantCol returns the tenant-discriminator column name for vault tables
+// under this Store's schema shape.
+func (s *Store) tenantCol() string { return s.scope.TenantCol() }
+
+// tenantArg returns the bind value for the tenant discriminator of vault
+// tables: tenantID in standalone shape, the scope's fs_id in shared shape.
+func (s *Store) tenantArg(tenantID string) any { return s.scope.TenantArg(tenantID) }
 
 // ---- DEK Management ----
 
@@ -30,7 +49,8 @@ func (s *Store) DB() *sql.DB { return s.db }
 func (s *Store) GetOrCreateDEK(ctx context.Context, tenantID string) ([]byte, error) {
 	var wrappedDEK []byte
 	err := s.db.QueryRowContext(ctx,
-		`SELECT wrapped_dek FROM vault_deks WHERE tenant_id = ?`, tenantID,
+		fmt.Sprintf(`SELECT wrapped_dek FROM vault_deks WHERE %s = ?`, s.tenantCol()),
+		s.tenantArg(tenantID),
 	).Scan(&wrappedDEK)
 
 	if err == nil {
@@ -46,8 +66,8 @@ func (s *Store) GetOrCreateDEK(ctx context.Context, tenantID string) ([]byte, er
 		return nil, err
 	}
 	_, err = s.db.ExecContext(ctx,
-		`INSERT IGNORE INTO vault_deks (tenant_id, wrapped_dek) VALUES (?, ?)`,
-		tenantID, wrappedDEK,
+		fmt.Sprintf(`INSERT IGNORE INTO vault_deks (%s, wrapped_dek) VALUES (?, ?)`, s.tenantCol()),
+		s.tenantArg(tenantID), wrappedDEK,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert DEK: %w", err)
@@ -55,7 +75,8 @@ func (s *Store) GetOrCreateDEK(ctx context.Context, tenantID string) ([]byte, er
 
 	// Re-read in case of race (another process inserted first).
 	err = s.db.QueryRowContext(ctx,
-		`SELECT wrapped_dek FROM vault_deks WHERE tenant_id = ?`, tenantID,
+		fmt.Sprintf(`SELECT wrapped_dek FROM vault_deks WHERE %s = ?`, s.tenantCol()),
+		s.tenantArg(tenantID),
 	).Scan(&wrappedDEK)
 	if err != nil {
 		return nil, fmt.Errorf("re-read DEK: %w", err)
@@ -91,9 +112,9 @@ func (s *Store) CreateSecret(ctx context.Context, tenantID, name, createdBy stri
 	defer func() { _ = tx.Rollback() }()
 
 	_, err = tx.ExecContext(ctx,
-		`INSERT INTO vault_secrets (secret_id, tenant_id, name, secret_type, revision, created_by, created_at, updated_at)
-		 VALUES (?, ?, ?, ?, 1, ?, ?, ?)`,
-		secretID, tenantID, name, string(secretType), createdBy, now, now,
+		fmt.Sprintf(`INSERT INTO vault_secrets (secret_id, %s, name, secret_type, revision, created_by, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, 1, ?, ?, ?)`, s.tenantCol()),
+		secretID, s.tenantArg(tenantID), name, string(secretType), createdBy, now, now,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("insert secret: %w", err)
@@ -105,9 +126,11 @@ func (s *Store) CreateSecret(ctx context.Context, tenantID, name, createdBy stri
 			return nil, fmt.Errorf("encrypt field %s: %w", fieldName, err)
 		}
 		_, err = tx.ExecContext(ctx,
-			`INSERT INTO vault_secret_fields (secret_id, field_name, encrypted_value, nonce)
-			 VALUES (?, ?, ?, ?)`,
-			secretID, fieldName, ciphertext, nonce,
+			fmt.Sprintf(`INSERT INTO vault_secret_fields (%s)
+			 VALUES (%s)`,
+				s.scope.InsCols("secret_id, field_name, encrypted_value, nonce"),
+				s.scope.InsVals("?, ?, ?, ?")),
+			s.scope.Args(secretID, fieldName, ciphertext, nonce)...,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("insert field %s: %w", fieldName, err)
@@ -134,9 +157,9 @@ func (s *Store) CreateSecret(ctx context.Context, tenantID, name, createdBy stri
 func (s *Store) GetSecret(ctx context.Context, tenantID, name string) (*Secret, error) {
 	var sec Secret
 	err := s.db.QueryRowContext(ctx,
-		`SELECT secret_id, tenant_id, name, secret_type, revision, created_by, created_at, updated_at, deleted_at
-		 FROM vault_secrets WHERE tenant_id = ? AND name = ? AND deleted_at IS NULL`,
-		tenantID, name,
+		fmt.Sprintf(`SELECT secret_id, %[1]s, name, secret_type, revision, created_by, created_at, updated_at, deleted_at
+		 FROM vault_secrets WHERE %[1]s = ? AND name = ? AND deleted_at IS NULL`, s.tenantCol()),
+		s.tenantArg(tenantID), name,
 	).Scan(&sec.SecretID, &sec.TenantID, &sec.Name, &sec.SecretType, &sec.Revision,
 		&sec.CreatedBy, &sec.CreatedAt, &sec.UpdatedAt, &sec.DeletedAt)
 	if err == sql.ErrNoRows {
@@ -145,15 +168,18 @@ func (s *Store) GetSecret(ctx context.Context, tenantID, name string) (*Secret, 
 	if err != nil {
 		return nil, err
 	}
+	// In shared shape the row stores fs_id, not the tenant UUID; the
+	// app-layer tenant id comes from the request scope.
+	sec.TenantID = tenantID
 	return &sec, nil
 }
 
 // ListSecrets returns metadata for all non-deleted secrets in a tenant.
 func (s *Store) ListSecrets(ctx context.Context, tenantID string) ([]*Secret, error) {
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT secret_id, tenant_id, name, secret_type, revision, created_by, created_at, updated_at
-		 FROM vault_secrets WHERE tenant_id = ? AND deleted_at IS NULL ORDER BY name`,
-		tenantID,
+		fmt.Sprintf(`SELECT secret_id, %[1]s, name, secret_type, revision, created_by, created_at, updated_at
+		 FROM vault_secrets WHERE %[1]s = ? AND deleted_at IS NULL ORDER BY name`, s.tenantCol()),
+		s.tenantArg(tenantID),
 	)
 	if err != nil {
 		return nil, err
@@ -167,6 +193,8 @@ func (s *Store) ListSecrets(ctx context.Context, tenantID string) ([]*Secret, er
 			&sec.Revision, &sec.CreatedBy, &sec.CreatedAt, &sec.UpdatedAt); err != nil {
 			return nil, err
 		}
+		// In shared shape the row stores fs_id; stamp the app-layer tenant id.
+		sec.TenantID = tenantID
 		secrets = append(secrets, &sec)
 	}
 	return secrets, rows.Err()
@@ -190,10 +218,10 @@ func (s *Store) UpdateSecret(ctx context.Context, tenantID, name, updatedBy stri
 	now := time.Now()
 
 	err = tx.QueryRowContext(ctx,
-		`SELECT secret_id, revision FROM vault_secrets
-		 WHERE tenant_id = ? AND name = ? AND deleted_at IS NULL
-		 FOR UPDATE`,
-		tenantID, name,
+		fmt.Sprintf(`SELECT secret_id, revision FROM vault_secrets
+		 WHERE %s = ? AND name = ? AND deleted_at IS NULL
+		 FOR UPDATE`, s.tenantCol()),
+		s.tenantArg(tenantID), name,
 	).Scan(&secretID, &revision)
 	if err == sql.ErrNoRows {
 		return nil, ErrNotFound
@@ -204,15 +232,18 @@ func (s *Store) UpdateSecret(ctx context.Context, tenantID, name, updatedBy stri
 
 	newRevision := revision + 1
 	_, err = tx.ExecContext(ctx,
-		`UPDATE vault_secrets SET revision = ?, updated_at = ? WHERE secret_id = ?`,
-		newRevision, now, secretID,
+		fmt.Sprintf(`UPDATE vault_secrets SET revision = ?, updated_at = ? WHERE %s`, s.scope.And("secret_id = ?")),
+		append([]any{newRevision, now}, s.scope.Args(secretID)...)...,
 	)
 	if err != nil {
 		return nil, err
 	}
 
 	// Delete old fields, insert new ones.
-	_, err = tx.ExecContext(ctx, `DELETE FROM vault_secret_fields WHERE secret_id = ?`, secretID)
+	_, err = tx.ExecContext(ctx,
+		fmt.Sprintf(`DELETE FROM vault_secret_fields WHERE %s`, s.scope.And("secret_id = ?")),
+		s.scope.Args(secretID)...,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -222,9 +253,11 @@ func (s *Store) UpdateSecret(ctx context.Context, tenantID, name, updatedBy stri
 			return nil, fmt.Errorf("encrypt field %s: %w", fieldName, err)
 		}
 		_, err = tx.ExecContext(ctx,
-			`INSERT INTO vault_secret_fields (secret_id, field_name, encrypted_value, nonce)
-			 VALUES (?, ?, ?, ?)`,
-			secretID, fieldName, ciphertext, nonce,
+			fmt.Sprintf(`INSERT INTO vault_secret_fields (%s)
+			 VALUES (%s)`,
+				s.scope.InsCols("secret_id, field_name, encrypted_value, nonce"),
+				s.scope.InsVals("?, ?, ?, ?")),
+			s.scope.Args(secretID, fieldName, ciphertext, nonce)...,
 		)
 		if err != nil {
 			return nil, err
@@ -267,8 +300,8 @@ func (s *Store) DeleteSecret(ctx context.Context, tenantID, name string) error {
 
 	var secretID string
 	err = tx.QueryRowContext(ctx,
-		`SELECT secret_id FROM vault_secrets WHERE tenant_id = ? AND name = ?`,
-		tenantID, name,
+		fmt.Sprintf(`SELECT secret_id FROM vault_secrets WHERE %s = ? AND name = ?`, s.tenantCol()),
+		s.tenantArg(tenantID), name,
 	).Scan(&secretID)
 	if err == sql.ErrNoRows {
 		return ErrNotFound
@@ -278,12 +311,14 @@ func (s *Store) DeleteSecret(ctx context.Context, tenantID, name string) error {
 	}
 
 	if _, err := tx.ExecContext(ctx,
-		`DELETE FROM vault_secret_fields WHERE secret_id = ?`, secretID,
+		fmt.Sprintf(`DELETE FROM vault_secret_fields WHERE %s`, s.scope.And("secret_id = ?")),
+		s.scope.Args(secretID)...,
 	); err != nil {
 		return err
 	}
 	if _, err := tx.ExecContext(ctx,
-		`DELETE FROM vault_secrets WHERE secret_id = ?`, secretID,
+		fmt.Sprintf(`DELETE FROM vault_secrets WHERE %s`, s.scope.And("secret_id = ?")),
+		s.scope.Args(secretID)...,
 	); err != nil {
 		return err
 	}
@@ -302,8 +337,8 @@ func (s *Store) ReadSecretFields(ctx context.Context, tenantID, name string) (ma
 	}
 
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT field_name, encrypted_value, nonce FROM vault_secret_fields WHERE secret_id = ?`,
-		sec.SecretID,
+		fmt.Sprintf(`SELECT field_name, encrypted_value, nonce FROM vault_secret_fields WHERE %s`, s.scope.And("secret_id = ?")),
+		s.scope.Args(sec.SecretID)...,
 	)
 	if err != nil {
 		return nil, err
@@ -339,8 +374,8 @@ func (s *Store) ReadSecretField(ctx context.Context, tenantID, name, fieldName s
 
 	var ciphertext, nonce []byte
 	err = s.db.QueryRowContext(ctx,
-		`SELECT encrypted_value, nonce FROM vault_secret_fields WHERE secret_id = ? AND field_name = ?`,
-		sec.SecretID, fieldName,
+		fmt.Sprintf(`SELECT encrypted_value, nonce FROM vault_secret_fields WHERE %s`, s.scope.And("secret_id = ? AND field_name = ?")),
+		s.scope.Args(sec.SecretID, fieldName)...,
 	).Scan(&ciphertext, &nonce)
 	if err == sql.ErrNoRows {
 		return nil, ErrFieldNotFound
@@ -383,9 +418,9 @@ func (s *Store) IssueCapToken(ctx context.Context, tenantID, agentID, taskID str
 
 	scopeJSON, _ := json.Marshal(scope)
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO vault_tokens (token_id, tenant_id, agent_id, task_id, scope_json, issued_at, expires_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
-		tokenID, tenantID, agentID, taskID, scopeJSON, now, expiresAt,
+		fmt.Sprintf(`INSERT INTO vault_tokens (token_id, %s, agent_id, task_id, scope_json, issued_at, expires_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`, s.tenantCol()),
+		tokenID, s.tenantArg(tenantID), agentID, taskID, scopeJSON, now, expiresAt,
 	)
 	if err != nil {
 		return "", nil, fmt.Errorf("insert token: %w", err)
@@ -414,8 +449,8 @@ func (s *Store) VerifyAndResolveCapToken(ctx context.Context, tenantID, raw stri
 	// DB revocation check — scoped to tenant for isolation.
 	var revokedAt *time.Time
 	err = s.db.QueryRowContext(ctx,
-		`SELECT revoked_at FROM vault_tokens WHERE tenant_id = ? AND token_id = ?`,
-		tenantID, claims.TokenID,
+		fmt.Sprintf(`SELECT revoked_at FROM vault_tokens WHERE %s = ? AND token_id = ?`, s.tenantCol()),
+		s.tenantArg(tenantID), claims.TokenID,
 	).Scan(&revokedAt)
 	if err == sql.ErrNoRows {
 		return nil, fmt.Errorf("token not found")
@@ -435,9 +470,9 @@ func (s *Store) VerifyAndResolveCapToken(ctx context.Context, tenantID, raw stri
 func (s *Store) RevokeCapToken(ctx context.Context, tenantID, tokenID, revokedBy, reason string) error {
 	now := time.Now()
 	res, err := s.db.ExecContext(ctx,
-		`UPDATE vault_tokens SET revoked_at = ?, revoked_by = ?, revoke_reason = ?
-		 WHERE tenant_id = ? AND token_id = ? AND revoked_at IS NULL`,
-		now, revokedBy, reason, tenantID, tokenID,
+		fmt.Sprintf(`UPDATE vault_tokens SET revoked_at = ?, revoked_by = ?, revoke_reason = ?
+		 WHERE %s = ? AND token_id = ? AND revoked_at IS NULL`, s.tenantCol()),
+		now, revokedBy, reason, s.tenantArg(tenantID), tokenID,
 	)
 	if err != nil {
 		return err
@@ -464,9 +499,9 @@ func (s *Store) WriteAuditEvent(ctx context.Context, event *AuditEvent) error {
 		detailJSON, _ = json.Marshal(event.Detail)
 	}
 	_, err := s.db.ExecContext(ctx,
-		`INSERT INTO vault_audit_log (event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		event.EventID, event.TenantID, event.EventType, event.TokenID, event.AgentID,
+		fmt.Sprintf(`INSERT INTO vault_audit_log (event_id, %s, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, s.tenantCol()),
+		event.EventID, s.tenantArg(event.TenantID), event.EventType, event.TokenID, event.AgentID,
 		event.TaskID, event.SecretName, event.FieldName, event.Adapter, detailJSON, event.Timestamp,
 	)
 	return err
@@ -477,14 +512,15 @@ func (s *Store) QueryAuditLog(ctx context.Context, tenantID string, secretName s
 	var query string
 	var args []any
 
+	col := s.tenantCol()
 	if secretName != "" {
-		query = `SELECT event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp
-			FROM vault_audit_log WHERE tenant_id = ? AND secret_name = ? ORDER BY timestamp DESC LIMIT ?`
-		args = []any{tenantID, secretName, limit}
+		query = fmt.Sprintf(`SELECT event_id, %[1]s, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp
+			FROM vault_audit_log WHERE %[1]s = ? AND secret_name = ? ORDER BY timestamp DESC LIMIT ?`, col)
+		args = []any{s.tenantArg(tenantID), secretName, limit}
 	} else {
-		query = `SELECT event_id, tenant_id, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp
-			FROM vault_audit_log WHERE tenant_id = ? ORDER BY timestamp DESC LIMIT ?`
-		args = []any{tenantID, limit}
+		query = fmt.Sprintf(`SELECT event_id, %[1]s, event_type, token_id, agent_id, task_id, secret_name, field_name, adapter, detail_json, timestamp
+			FROM vault_audit_log WHERE %[1]s = ? ORDER BY timestamp DESC LIMIT ?`, col)
+		args = []any{s.tenantArg(tenantID), limit}
 	}
 
 	rows, err := s.db.QueryContext(ctx, query, args...)
@@ -501,6 +537,8 @@ func (s *Store) QueryAuditLog(ctx context.Context, tenantID string, secretName s
 			&ev.TaskID, &ev.SecretName, &ev.FieldName, &ev.Adapter, &detailJSON, &ev.Timestamp); err != nil {
 			return nil, err
 		}
+		// In shared shape the row stores fs_id; stamp the app-layer tenant id.
+		ev.TenantID = tenantID
 		if detailJSON != nil {
 			_ = json.Unmarshal(detailJSON, &ev.Detail)
 		}

--- a/pkg/vault/store_shared_test.go
+++ b/pkg/vault/store_shared_test.go
@@ -1,0 +1,407 @@
+package vault
+
+import (
+	"context"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/datastore"
+	"github.com/mem9-ai/drive9/pkg/tenant/schema"
+)
+
+var vaultSharedTables = []string{
+	"vault_audit_log",
+	"vault_grants",
+	"vault_tokens",
+	"vault_secret_fields",
+	"vault_secrets",
+	"vault_deks",
+	"vault_policies",
+}
+
+// installSharedVaultSchema swaps the 7 vault tables to the shared (fs_id)
+// shape and restores the standalone schema on cleanup. Tests in this package
+// run sequentially, so the swap is safe. A second database cannot be used
+// instead: the testcontainer MySQL user only has privileges on the test
+// database.
+func installSharedVaultSchema(t *testing.T) {
+	t.Helper()
+	drop := func() {
+		t.Helper()
+		for _, tbl := range vaultSharedTables {
+			if _, err := testDB.Exec("DROP TABLE IF EXISTS " + tbl); err != nil {
+				t.Fatalf("drop %s: %v", tbl, err)
+			}
+		}
+	}
+	drop()
+	if err := schema.ExecSchemaStatements(testDB, schema.VaultMySQLSharedSchemaStatements()); err != nil {
+		t.Fatalf("apply shared vault schema: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, tbl := range vaultSharedTables {
+			if _, err := testDB.Exec("DROP TABLE IF EXISTS " + tbl); err != nil {
+				t.Errorf("restore: drop %s: %v", tbl, err)
+			}
+		}
+		if err := schema.ExecSchemaStatements(testDB, schema.VaultTiDBSchemaStatements()); err != nil {
+			t.Errorf("restore standalone vault schema: %v", err)
+		}
+	})
+}
+
+// newSharedTestMasterKey returns a fresh random master key.
+func newSharedTestMasterKey(t *testing.T) *MasterKey {
+	t.Helper()
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		t.Fatal(err)
+	}
+	mk, err := NewMasterKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return mk
+}
+
+// newSharedVaultStore returns a Store bound to the shared vault schema with
+// the given fs_id as its tenant row key.
+func newSharedVaultStore(t *testing.T, fsID int64, mk *MasterKey) *Store {
+	t.Helper()
+	return NewStoreScoped(testDB, mk, datastore.SharedScope(fsID))
+}
+
+// runVaultCoreScenario exercises the vault core flow (DEK round trip, secret
+// CRUD, capability tokens, grants, audit log) against a store. It is run
+// against both schema shapes to prove behavioral parity.
+func runVaultCoreScenario(t *testing.T, s *Store, tenantID string) {
+	t.Helper()
+	ctx := context.Background()
+
+	// DEK round trip: stable across calls.
+	dek1, err := s.GetOrCreateDEK(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("GetOrCreateDEK: %v", err)
+	}
+	dek2, err := s.GetOrCreateDEK(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("GetOrCreateDEK second call: %v", err)
+	}
+	if string(dek1) != string(dek2) {
+		t.Fatal("DEK should be stable across calls")
+	}
+
+	// Secret create / get / read.
+	sec, err := s.CreateSecret(ctx, tenantID, "db-prod", "agent-1", SecretTypeDatabase, map[string][]byte{
+		"username": []byte("admin"),
+		"password": []byte("s3cret"),
+	})
+	if err != nil {
+		t.Fatalf("CreateSecret: %v", err)
+	}
+	if sec.TenantID != tenantID {
+		t.Fatalf("created TenantID = %q, want %q", sec.TenantID, tenantID)
+	}
+	got, err := s.GetSecret(ctx, tenantID, "db-prod")
+	if err != nil {
+		t.Fatalf("GetSecret: %v", err)
+	}
+	if got.SecretID != sec.SecretID || got.TenantID != tenantID {
+		t.Fatalf("GetSecret = %#v, want id %s tenant %q", got, sec.SecretID, tenantID)
+	}
+	decrypted, err := s.ReadSecretFields(ctx, tenantID, "db-prod")
+	if err != nil {
+		t.Fatalf("ReadSecretFields: %v", err)
+	}
+	if string(decrypted["username"]) != "admin" || string(decrypted["password"]) != "s3cret" {
+		t.Fatalf("decrypted fields mismatch: %v", decrypted)
+	}
+	pw, err := s.ReadSecretField(ctx, tenantID, "db-prod", "password")
+	if err != nil {
+		t.Fatalf("ReadSecretField: %v", err)
+	}
+	if string(pw) != "s3cret" {
+		t.Fatalf("ReadSecretField mismatch: %q", pw)
+	}
+	list, err := s.ListSecrets(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("ListSecrets: %v", err)
+	}
+	if len(list) != 1 || list[0].Name != "db-prod" || list[0].TenantID != tenantID {
+		t.Fatalf("ListSecrets unexpected: %#v", list)
+	}
+
+	// Update bumps revision and re-encrypts fields.
+	updated, err := s.UpdateSecret(ctx, tenantID, "db-prod", "agent-1", map[string][]byte{
+		"username": []byte("admin"),
+		"password": []byte("n3wpass"),
+	})
+	if err != nil {
+		t.Fatalf("UpdateSecret: %v", err)
+	}
+	if updated.Revision != 2 {
+		t.Fatalf("expected revision 2, got %d", updated.Revision)
+	}
+	pw2, err := s.ReadSecretField(ctx, tenantID, "db-prod", "password")
+	if err != nil {
+		t.Fatalf("ReadSecretField after update: %v", err)
+	}
+	if string(pw2) != "n3wpass" {
+		t.Fatalf("updated password mismatch: %q", pw2)
+	}
+
+	// Capability token: issue / verify / revoke.
+	tokenStr, capToken, err := s.IssueCapToken(ctx, tenantID, "agent-1", "task-1", []string{"db-prod"}, time.Hour)
+	if err != nil {
+		t.Fatalf("IssueCapToken: %v", err)
+	}
+	resolved, err := s.VerifyAndResolveCapToken(ctx, tenantID, tokenStr)
+	if err != nil {
+		t.Fatalf("VerifyAndResolveCapToken: %v", err)
+	}
+	if resolved.TokenID != capToken.TokenID {
+		t.Fatalf("token ID mismatch: %s != %s", resolved.TokenID, capToken.TokenID)
+	}
+	if err := s.RevokeCapToken(ctx, tenantID, capToken.TokenID, "admin", "test revoke"); err != nil {
+		t.Fatalf("RevokeCapToken: %v", err)
+	}
+	if _, err := s.VerifyAndResolveCapToken(ctx, tenantID, tokenStr); err == nil {
+		t.Fatal("expected error for revoked token")
+	}
+
+	// Grant: issue / verify / revoke.
+	const issuer = "https://vault-test.invalid"
+	grantStr, grant, err := s.IssueGrant(ctx, tenantID, issuer, PrincipalDelegated, "agent-1",
+		[]string{"db-prod"}, GrantPermRead, time.Hour, "")
+	if err != nil {
+		t.Fatalf("IssueGrant: %v", err)
+	}
+	claims, err := s.VerifyAndResolveGrant(ctx, tenantID, issuer, grantStr)
+	if err != nil {
+		t.Fatalf("VerifyAndResolveGrant: %v", err)
+	}
+	if claims.GrantID != grant.GrantID {
+		t.Fatalf("grant ID mismatch: %s != %s", claims.GrantID, grant.GrantID)
+	}
+	if err := s.RevokeGrant(ctx, tenantID, grant.GrantID, "admin", "test revoke"); err != nil {
+		t.Fatalf("RevokeGrant: %v", err)
+	}
+	if _, err := s.VerifyAndResolveGrant(ctx, tenantID, issuer, grantStr); err == nil {
+		t.Fatal("expected error for revoked grant")
+	}
+
+	// Audit: write and query back, with and without the secret filter.
+	if err := s.WriteAuditEvent(ctx, &AuditEvent{
+		TenantID:   tenantID,
+		EventType:  "secret.read",
+		AgentID:    "agent-1",
+		SecretName: "db-prod",
+		FieldName:  "password",
+		Adapter:    "env",
+		Detail:     map[string]string{"reason": "task execution"},
+	}); err != nil {
+		t.Fatalf("WriteAuditEvent: %v", err)
+	}
+	events, err := s.QueryAuditLog(ctx, tenantID, "", 10)
+	if err != nil {
+		t.Fatalf("QueryAuditLog: %v", err)
+	}
+	if len(events) != 1 || events[0].TenantID != tenantID || events[0].SecretName != "db-prod" {
+		t.Fatalf("unexpected audit events: %#v", events)
+	}
+	events, err = s.QueryAuditLog(ctx, tenantID, "db-prod", 10)
+	if err != nil {
+		t.Fatalf("QueryAuditLog by secret: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected 1 audit event for db-prod, got %d", len(events))
+	}
+
+	// Delete frees the (tenant, name) unique slot for recreate.
+	if err := s.DeleteSecret(ctx, tenantID, "db-prod"); err != nil {
+		t.Fatalf("DeleteSecret: %v", err)
+	}
+	if _, err := s.GetSecret(ctx, tenantID, "db-prod"); err != ErrNotFound {
+		t.Fatalf("expected ErrNotFound after delete, got: %v", err)
+	}
+	if _, err := s.CreateSecret(ctx, tenantID, "db-prod", "agent-2", SecretTypeGeneric,
+		map[string][]byte{"host": []byte("db2.example.com")}); err != nil {
+		t.Fatalf("CreateSecret after delete should succeed, got: %v", err)
+	}
+}
+
+// TestVaultSharedShapeParity runs the same core flow covered by the
+// standalone store tests against the shared (fs_id) schema shape.
+func TestVaultSharedShapeParity(t *testing.T) {
+	installSharedVaultSchema(t)
+	store := newSharedVaultStore(t, 4300001, newSharedTestMasterKey(t))
+	runVaultCoreScenario(t, store, "tenant-shared-parity")
+}
+
+// TestVaultSharedShapeCrossTenantIsolation proves rows of one fs_id are
+// invisible to another fs_id on the same shared tables, and that the same
+// secret name can coexist under two fs_ids with independent values.
+func TestVaultSharedShapeCrossTenantIsolation(t *testing.T) {
+	installSharedVaultSchema(t)
+	ctx := context.Background()
+	mk := newSharedTestMasterKey(t)
+	storeA := newSharedVaultStore(t, 4300002, mk)
+	storeB := newSharedVaultStore(t, 4300003, mk)
+	tenantA, tenantB := "tenant-iso-a", "tenant-iso-b"
+
+	// Same secret name under two different fs_ids must coexist.
+	if _, err := storeA.CreateSecret(ctx, tenantA, "shared-name", "agent-a", SecretTypeGeneric,
+		map[string][]byte{"password": []byte("a-secret")}); err != nil {
+		t.Fatalf("CreateSecret A: %v", err)
+	}
+	if _, err := storeB.CreateSecret(ctx, tenantB, "shared-name", "agent-b", SecretTypeGeneric,
+		map[string][]byte{"password": []byte("b-secret")}); err != nil {
+		t.Fatalf("CreateSecret B: %v", err)
+	}
+
+	// Each side reads only its own value.
+	pwA, err := storeA.ReadSecretField(ctx, tenantA, "shared-name", "password")
+	if err != nil {
+		t.Fatalf("ReadSecretField A: %v", err)
+	}
+	if string(pwA) != "a-secret" {
+		t.Fatalf("A password = %q, want a-secret", pwA)
+	}
+	pwB, err := storeB.ReadSecretField(ctx, tenantB, "shared-name", "password")
+	if err != nil {
+		t.Fatalf("ReadSecretField B: %v", err)
+	}
+	if string(pwB) != "b-secret" {
+		t.Fatalf("B password = %q, want b-secret", pwB)
+	}
+
+	// A name that only A created is invisible to B.
+	if _, err := storeA.CreateSecret(ctx, tenantA, "a-only", "agent-a", SecretTypeGeneric,
+		map[string][]byte{"k": []byte("v")}); err != nil {
+		t.Fatalf("CreateSecret a-only: %v", err)
+	}
+	if _, err := storeB.GetSecret(ctx, tenantB, "a-only"); err != ErrNotFound {
+		t.Fatalf("B GetSecret a-only err = %v, want ErrNotFound", err)
+	}
+	if _, err := storeB.ReadSecretFields(ctx, tenantB, "a-only"); err != ErrNotFound {
+		t.Fatalf("B ReadSecretFields a-only err = %v, want ErrNotFound", err)
+	}
+	listB, err := storeB.ListSecrets(ctx, tenantB)
+	if err != nil {
+		t.Fatalf("ListSecrets B: %v", err)
+	}
+	if len(listB) != 1 || listB[0].Name != "shared-name" {
+		t.Fatalf("B sees %d secrets, want only its own: %#v", len(listB), listB)
+	}
+
+	// Updates stay on their own side.
+	if _, err := storeB.UpdateSecret(ctx, tenantB, "shared-name", "agent-b",
+		map[string][]byte{"password": []byte("b-secret-2")}); err != nil {
+		t.Fatalf("UpdateSecret B: %v", err)
+	}
+	pwA2, err := storeA.ReadSecretField(ctx, tenantA, "shared-name", "password")
+	if err != nil {
+		t.Fatalf("ReadSecretField A after B update: %v", err)
+	}
+	if string(pwA2) != "a-secret" {
+		t.Fatalf("A password after B update = %q, want a-secret (cross-tenant write)", pwA2)
+	}
+
+	// B cannot revoke A's tokens or grants, and A's rows survive the attempts.
+	tokenStrA, capA, err := storeA.IssueCapToken(ctx, tenantA, "agent-a", "", []string{"shared-name"}, time.Hour)
+	if err != nil {
+		t.Fatalf("IssueCapToken A: %v", err)
+	}
+	if err := storeB.RevokeCapToken(ctx, tenantB, capA.TokenID, "agent-b", "x"); err != ErrNotFound {
+		t.Fatalf("B RevokeCapToken A's token err = %v, want ErrNotFound", err)
+	}
+	if _, err := storeA.VerifyAndResolveCapToken(ctx, tenantA, tokenStrA); err != nil {
+		t.Fatalf("A's token must survive B's revoke attempt: %v", err)
+	}
+	const issuer = "https://vault-test.invalid"
+	grantStrA, grantA, err := storeA.IssueGrant(ctx, tenantA, issuer,
+		PrincipalDelegated, "agent-a", []string{"shared-name"}, GrantPermRead, time.Hour, "")
+	if err != nil {
+		t.Fatalf("IssueGrant A: %v", err)
+	}
+	if err := storeB.RevokeGrant(ctx, tenantB, grantA.GrantID, "agent-b", "x"); err != ErrNotFound {
+		t.Fatalf("B RevokeGrant A's grant err = %v, want ErrNotFound", err)
+	}
+	if _, err := storeA.VerifyAndResolveGrant(ctx, tenantA, issuer, grantStrA); err != nil {
+		t.Fatalf("A's grant must survive B's revoke attempt: %v", err)
+	}
+
+	// Audit rows written under A are invisible to B.
+	if err := storeA.WriteAuditEvent(ctx, &AuditEvent{
+		TenantID:   tenantA,
+		EventType:  "secret.read",
+		SecretName: "a-only",
+	}); err != nil {
+		t.Fatalf("WriteAuditEvent A: %v", err)
+	}
+	eventsB, err := storeB.QueryAuditLog(ctx, tenantB, "", 10)
+	if err != nil {
+		t.Fatalf("QueryAuditLog B: %v", err)
+	}
+	if len(eventsB) != 0 {
+		t.Fatalf("B sees %d audit events, want 0 (cross-tenant leak)", len(eventsB))
+	}
+
+	// Deletes stay on their own side.
+	if err := storeB.DeleteSecret(ctx, tenantB, "shared-name"); err != nil {
+		t.Fatalf("DeleteSecret B: %v", err)
+	}
+	if _, err := storeA.GetSecret(ctx, tenantA, "shared-name"); err != nil {
+		t.Fatalf("A's secret must survive B's delete: %v", err)
+	}
+}
+
+// TestVaultSharedShapeStoresFsID asserts every vault table row carries the
+// scope's fs_id as its tenant discriminator.
+func TestVaultSharedShapeStoresFsID(t *testing.T) {
+	installSharedVaultSchema(t)
+	const fsID int64 = 4300004
+	store := newSharedVaultStore(t, fsID, newSharedTestMasterKey(t))
+	runVaultCoreScenario(t, store, "tenant-fsid-check")
+
+	for _, tbl := range vaultSharedTables {
+		var got int64
+		err := store.DB().QueryRow("SELECT COUNT(*) FROM "+tbl+" WHERE fs_id != ?", fsID).Scan(&got)
+		if err != nil {
+			t.Fatalf("count %s rows with foreign fs_id: %v", tbl, err)
+		}
+		if got != 0 {
+			t.Fatalf("%s has %d rows with fs_id != %d", tbl, got, fsID)
+		}
+		if tbl == "vault_policies" {
+			continue // no writer path for policies in pkg/vault
+		}
+		var total int64
+		if err := store.DB().QueryRow("SELECT COUNT(*) FROM " + tbl).Scan(&total); err != nil {
+			t.Fatalf("count %s: %v", tbl, err)
+		}
+		if total == 0 {
+			t.Fatalf("%s is empty; scenario should have written rows", tbl)
+		}
+	}
+	// No residual tenant_id column in the shared shape, and vault_secret_fields
+	// gained fs_id as its leading column.
+	for _, tc := range []struct {
+		table, column string
+		want          int
+	}{
+		{"vault_secrets", "tenant_id", 0},
+		{"vault_secret_fields", "fs_id", 1},
+	} {
+		var n int
+		if err := store.DB().QueryRow(`SELECT COUNT(*) FROM information_schema.columns
+			WHERE table_schema = DATABASE() AND table_name = ? AND column_name = ?`,
+			tc.table, tc.column).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != tc.want {
+			t.Fatalf("%s.%s column count = %d, want %d", tc.table, tc.column, n, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Implements the first phase of the tenant-DB shared-schema redesign plus the **minimal shared-DB runtime**: tenants in an org with a registered shared-schema database are provisioned onto it instead of getting a dedicated cluster. Existing standalone tenants are fully untouched (production SQL is byte-identical, proven by the unchanged existing test suite).

Scope: identity (`fs_id`), shared-schema DDL for 31 of the 32 tenant tables, dual-shape datastore/vault layer, placement metadata, routing, shared-pool provisioning, shared-tenant lifecycle, and a local end-to-end smoke for shared mode. Migration / hotspot scheduling / fork / quota semantics / backup-restore adaptations are intentionally out of scope — but cross-tenant correctness is covered end to end (see tests).

**Design doc**: `docs/TENANT_DB_REDESIGN.md` — the full redesign proposal (English) is committed with this PR.

## What's included

**Identity**
- `fs_registry` (tenant UUID ↔ fs_id BIGINT): allocated atomically in `InsertTenant`; leader-gated startup backfill; `EnsureFsID`/`ResolveFsID`/`ResolveTenantID`.
- `db_pool` (shared DB registry: connection coords, org binding with `*` wildcard, capacity) and `tenant_placements` (fs_id → db_id, placement, schema shape) with CRUD.

**Shared schema (31 tables: core FS 9, journal 5, vault 7, git 5, fs_layer 5)**
- One canonical TiDB list per group; `PRIMARY KEY (fs_id, ...) CLUSTERED` explicit (TiDB defaults composite PKs to NONCLUSTERED). MySQL variants **derived mechanically** (strip `CLUSTERED`, `VECTOR(n)→LONGTEXT`). Per-group drift tests enforce standalone↔shared parity.
- `semantic` uses plain `VECTOR(n)` (app-managed; FTS/vector indexes in an optional TiDB-only list). `fs_events` keeps its global AUTO_INCREMENT PK + `(fs_id, seq)` index. Repair-era ALTERs folded into CREATE TABLEs.
- `llm_usage` deliberately omitted: the backend only writes tenant-DB `llm_usage` when server quota is inactive (single-tenant/local mode), which shared-schema DBs never run — central `tenant_llm_usage` is authoritative.
- Aggregate init: `SharedTiDBSchemaStatements()` + `SharedMySQLSchemaStatements()` + `SharedSchemaStatementsForDB()` + `InitSharedSchema()` + `dump-init-sql --provider tidb_cloud_native_shared`.

**Dual-shape datastore / vault**
- `Scope` as the single shape injection point; standalone SQL byte-identical. All SQL scope-ified across core FS, journal, vault, tasks, fs_layer, git, search, fs_events.
- `ExecSQL` rejects shared shape (`ErrExecSQLNotSupportedShared`). `SanitizeForkRuntimeState` DELETEs are fs_id-restricted in shared shape.
- Dual-shape tests for every group: parity / cross-fs_id isolation / raw-SQL fs_id row checks.

**Routing (minimal)**
- Pool resolves fs_id → placement at cold Acquire. Shared tenants connect through **one `*sql.DB` handle per shared DB** (db_id-keyed registry, `RoleShared` pool limits, default 50 open / 10 idle, `DRIVE9_SHARED_DB_MAX_*` overrides) with a per-tenant fs_id-scoped `Store` over it (`NewStoreWithDB`; `Close` never closes the shared handle).
- Per-tenant schema ensure and auto-embedding are skipped for shared placements. Placement lookup failure is fatal to the cold open (never silently falls back to the wrong shape).

**Provisioning & lifecycle**
- `provisionTenant`: org-aware shared placement — a tenant goes to the shared pool **only** when its org is explicitly registered in `db_pool` (or an operator intentionally registers the `*` wildcard, which logs a loud startup warning). Unresolvable orgs (e.g. `tidb_cloud_native` org lookup failure) never fall back to the wildcard — they stay on the dedicated path. `DRIVE9_SHARED_POOL_ORG` is required whenever the DSN is set (no silent wildcard default). No cluster creation, instant `active`, forced `fts_only` embedding profile; create-time spending limit rejected for shared tenants.
- `fork` rejected for shared-schema tenants (no per-tenant cluster to branch).
- Shared-tenant delete: drains the pool entry, purges rows in bounded batches (`PurgeTenantData`, resumable), removes the placement, and **never deprovisions the shared cluster**. S3 namespace cleanup and key revocation unchanged.
- Startup env registration: `DRIVE9_SHARED_POOL_DSN` + `DRIVE9_SHARED_POOL_ORG` (default `*`) initializes the shared schema and registers the pool.

## Review round 2 (changes requested by qiffang / srstack)

**Scoping contract (critical)**
- Every alias of multi-table JOINs and EXISTS subqueries now carries an fs_id predicate — no more one-sided scoping (`store.go` stat/quota/ref/sanitize/GC joins, `embedding_writeback.go` writeback checks). New `Scope.AndOn` handles LEFT JOIN ON clauses; the "globally unique ids make one-sided scoping sufficient" assumption is deleted from the docs.
- New colliding-ID regression suite (`store_shared_collision_test.go`): the same inode/file ids live under two fs_ids across stat, storage-ref liveness, media count, confirmed-size, upload reservation, list summaries/refs, orphan scan, GC scan, embedding writeback, and fork sanitize — each asserts strict tenant containment.

**First-class shared provider**
- Shared tenants persist `tidb_cloud_native_shared` (`pkg/tenant/provider.go`), classified as TiDB-backed with no DB auto-embedding and no per-tenant cluster delete/fork. `schemadump` uses the same constant; the dump-only `ProviderShared` special case is gone (`--provider tidb_cloud_native_shared`).
- Delete dispatch keys on this durable provider instead of the placement row; the delete path is read-only (`ResolveFsID`, no phantom fs_id allocation), keeps the placement until purge succeeds, short-circuits on existing cleanup jobs, and treats a missing placement on retry as purge-complete → enqueue. `createBackend` fails closed when provider says shared but placement is gone.

**Pool, capacity, TLS**
- `findSharedDBForProvision` propagates meta lookup failures (no silent dedicated fallback); explicit `tidb_cloud_native_shared` requests fail closed when no pool matches. `max_tenants` is enforced at selection (full pools are invisible). The shared DB TLS mode is persisted verbatim (`skip-verify`/custom configs no longer collapse to `tls=true`/plaintext). Warm-pool claims skip orgs with a registered shared pool, so an org can never be handed a dedicated shape by accident.

**Admin contract**
- `handleAdminTenantCreate` returns 409 when the caller's org matches a shared pool (admin lifecycle is cluster-centric); admin get/quota/delete reject shared-provider tenants explicitly instead of deprovisioning a nonexistent cluster. Owner-API delete handles shared tenants end to end.

**Vault PKs + misc**
- All 7 shared vault tables now use composite `(fs_id, ...)` clustered PKs like every other group (redundant single-column tenant indexes dropped). `fs_events` gains `(fs_id, created_at)` for per-tenant retention deletes.
- Dialect detection errors propagate in shared schema selection (no silent MySQL-variant DDL on TiDB). Purge returns `RowsAffected` errors. `withMetaLockConflictRetry` honors ctx + logs. `scanJournal` no longer leaks numeric fs_id into `Journal.TenantID`. `EnsureFsID` concurrent-allocation test; placement status validated; `NewStoreWithDB`/journal MySQL variant relocated next to their owners; `llm_usage` exclusion test now positively asserts the standalone baseline.

**Bot findings concurred by dat9-dev2**: purge `RowsAffected` (fixed), dialect fail-open (fixed), `file_tags` raw-SQL allowlist (already covered — the shared guard rejects before the allowlist; test pins it).

New regressions: `store_shared_collision_test.go` (9 subtests), `tenant_delete_shared_test.go` (retry-after-placement-removal, cleanup-job short-circuit, no-fs_id 500, full purge path without cluster deprovision, admin create 409 on shared org, admin get 409 on shared provider), pool-capacity skip test, TLS mode round-trip.

## Non-mechanical spots reviewers should look at

1. `SanitizeForkRuntimeState` — previously predicate-less whole-table DELETEs; now fs_id-restricted in shared shape.
2. `ExecSQL` shared guard — raw agent SQL can't be made tenant-safe.
3. Multi-alias fs_id filtering where entity ids can collide across tenants (`ActiveUploadReservedBytesTx`, search JOINs, `listFSLayersByTag`). Tests deliberately use colliding ids.
4. `vault_secret_fields` — no tenant column standalone; gains fs_id in shared.
5. `pool.createBackend` shared branch — placement resolution, handle registry, ensure/auto-embedding skip.
6. `provisionTenantOnSharedDB` — instant-active path; org matching semantics (exact org → wildcard).
7. `handleSharedTenantDelete` — purge ordering (drain → purge → placement removal → S3 cleanup).

## Review round 3 (changes requested by qiffang / srstack)

- **Atomic placement transitions**: capacity reserve + placement insert in one tx (`ReserveSharedDBPlacement` — conditional increment, loser gets 409, no oversell); placement removal + capacity release in one tx (`DeleteTenantPlacementAndDecrCount` — failure rolls back, delete stays retryable, no orphaned placement / double-decrement).
- **Engine guard**: `findSharedDBForProvision` never routes non-TiDB-dialect providers (db9) to a shared pool — a wildcard pool cannot relabel a PostgreSQL tenant.
- **De-flaked** `TestSharedTenantDeleteWithoutFsIDFails` (synchronizes with the one-time startup backfill via zaptest observer).
- **e2e script**: trapped exit code folded into final status (hard `set -e` aborts can't report success); `detect_runtime` only when a container is needed; external DSNs probed via the local `mysql` client — the documented container-skip mode now works end to end.

## Test plan

- [x] `go build ./...`, `make lint` — 0 issues
- [x] `go test` all affected packages: datastore, meta, tenant, tenant/schema, schemadump, vault, mysqlutil, backend, client, server, cmd/... — pass
- [x] Existing tests unchanged (standalone byte-identical SQL proof)
- [x] New dual-shape tests per group (parity / isolation / fs_id rows)
- [x] **`e2e/shared-mode-smoke-test.sh` — 43/43 pass** against real engines (MySQL meta DB + TiDB v8.5.6 for shared and standalone DBs): provision onto shared pool (instant active), CRUD, cross-tenant isolation, raw-SQL fs_id checks, **`file_nodes` is `TIDB_PK_TYPE=CLUSTERED` on TiDB**, SSE events on a shared tenant, multipart upload, fork rejection (409), standalone/shared coexistence without leakage, server restart persistence, tenant delete with shared purge
- [x] `drive9-server schema dump-init-sql --provider tidb_cloud_native_shared` — 31 tables, CLUSTERED present

## Follow-ups (tracked here so review can close)

- Shared `semantic` vector/FTS index form (pending Phase-0 ⑦: `VEC_COSINE_DISTANCE` vs `VEC_EMBED_COSINE_DISTANCE` index hit).
- Self-hosted TiDB note: schema repair now tolerates missing FTS/vector support (CREATE INDEX forms skip with a warn); Acquire-time fts_only validation still requires those indexes, so self-hosted engines need the `-skip-ensure` bootstrap used by the e2e harness.
- TiDB-backed (tidb_zero) shared-shape e2e — dual-shape tests currently run on MySQL; the e2e script accepts `META_DSN`/`SHARED_DSN` for a TiDB run.
- Org-exact shared placement needs a TiDB Cloud environment for end-to-end verification (local e2e covers only the wildcard path; exact-org matching is currently covered by `pkg/meta` unit tests): register a shared DB for one specific org, provision a tenant there to verify placement, and a tenant in another org to verify it stays dedicated.
- Phase 2 full: placement cache + epoch fencing + routing hot update (needed for migration).
- Phase 3 full: shared-pool auto-provisioning; cluster-level retention sweep for shared tables (design doc 13.16).
- Independent small cleanups: drop meta `sse_notify_outbox`; retire meta legacy `llm_usage` ledger + fallback SUM read; confirm `vault_policies` has no reader/writer then remove from both shapes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared-schema (fs_id-scoped) storage with shared DB/placement management, shared provisioning, and tenant purging.
  * Added shared-schema DDL initialization/generation and expanded shared-mode smoke-test coverage.
  * Introduced a guarded SQL execution entry point with restrictions for shared-schema stores.
* **Bug Fixes**
  * Strengthened tenant isolation across datastore operations to prevent cross-tenant data access.
  * Improved shared-tenant deletion to purge only the selected tenant’s data; `POST /v1/fork` is rejected for shared-pool tenants.
* **Documentation**
  * Added detailed tenant DB redesign documentation and updated setup/provisioning examples for the shared provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

