### PR TITLE
Tolerate interior fs_events seq holes in EventBus gap detection

### DIFF
--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -134,6 +134,10 @@ func (eb *EventBus) Seq(ctx context.Context) uint64 {
 //   - since == 0: initial_sync
 //   - since < oldestSeq: events pruned between client cursor and retained window
 //   - since > headSeq: server_restart (client cursor ahead of head)
+//
+// Interior seq holes (other tenants interleaved on a shared-schema table, or
+// AUTO_INCREMENT ids burned by rolled-back inserts) are NOT a reset
+// condition: no events of this tenant were lost, so delivery continues.
 func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []ChangeEvent, headSeq uint64, ok bool) {
 	store := eb.store.Load()
 	if store == nil {
@@ -175,13 +179,21 @@ func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []Cha
 		})
 	}
 	if len(events) > 0 {
-		// Got rows: check for a gap between the client's cursor and the
-		// first retained event. If since+1 < first event seq, events were
-		// pruned in between → reset to avoid silently missing them.
+		// Got rows: a gap between the client's cursor and the first returned
+		// event means one of two things. Either events were pruned at the left
+		// edge of the retained window (the client missed real events → reset),
+		// or the hole is interior: other tenants' interleaved seqs on a
+		// shared-schema fs_events table, or AUTO_INCREMENT ids burned by
+		// rolled-back inserts (no events lost → deliver normally). Pruning
+		// only happens at the left edge, so compare against the oldest
+		// retained seq to tell them apart.
 		firstSeq := events[0].Seq
 		if since+1 < firstSeq {
-			headSeq = events[len(events)-1].Seq
-			return nil, headSeq, false // gap detected → reset
+			oldest := oldestSeqSafeWithMetric(ctx, store, eb.tenantID)
+			if int64(since)+1 < oldest {
+				headSeq = events[len(events)-1].Seq
+				return nil, headSeq, false // pruned gap → reset
+			}
 		}
 		headSeq = events[len(events)-1].Seq
 		return events, headSeq, true

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -115,6 +115,80 @@ func TestEventBusEventsSinceReplays(t *testing.T) {
 	}
 }
 
+// Interior seq holes (e.g. AUTO_INCREMENT ids burned by rolled-back inserts,
+// or other tenants interleaved on a shared-schema table) must NOT trigger a
+// reset: no events of this tenant were lost, so delivery continues normally.
+func TestEventBusEventsSinceInteriorGapDelivers(t *testing.T) {
+	store := newTestStoreForEventBus(t)
+	bus := NewEventBus("test-tenant", store)
+	ctx := context.Background()
+
+	seq1, err := store.InsertFSEvent(ctx, "/a.txt", "write", "actor1", time.Now().UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq2, err := store.InsertFSEvent(ctx, "/hole.txt", "write", "actor1", time.Now().UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq3, err := store.InsertFSEvent(ctx, "/b.txt", "write", "actor1", time.Now().UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Burn the middle seq, leaving an interior hole at seq2 while seq1 stays
+	// retained (the cursor is not behind the oldest event).
+	if _, err := store.DB().ExecContext(ctx, `DELETE FROM fs_events WHERE seq = ?`, seq2); err != nil {
+		t.Fatal(err)
+	}
+
+	events, headSeq, ok := bus.EventsSince(ctx, uint64(seq1))
+	if !ok {
+		t.Fatal("EventsSince with an interior hole should deliver, not reset")
+	}
+	if len(events) != 1 || events[0].Path != "/b.txt" {
+		t.Fatalf("events = %+v, want only /b.txt", events)
+	}
+	if headSeq != uint64(seq3) {
+		t.Fatalf("headSeq = %d, want %d", headSeq, seq3)
+	}
+}
+
+// A gap reaching back past the oldest retained seq means events were pruned
+// after the client's cursor — that must still reset.
+func TestEventBusEventsSincePrunedGapResets(t *testing.T) {
+	store := newTestStoreForEventBus(t)
+	bus := NewEventBus("test-tenant", store)
+	ctx := context.Background()
+
+	seq1, err := store.InsertFSEvent(ctx, "/a.txt", "write", "actor1", time.Now().UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq2, err := store.InsertFSEvent(ctx, "/b.txt", "write", "actor1", time.Now().UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+	seq3, err := store.InsertFSEvent(ctx, "/c.txt", "write", "actor1", time.Now().UnixMilli())
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Prune everything through seq2, so the client's cursor (seq1) falls
+	// behind the oldest retained event (seq3).
+	for _, seq := range []int64{seq1, seq2} {
+		if _, err := store.DB().ExecContext(ctx, `DELETE FROM fs_events WHERE seq = ?`, seq); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	events, headSeq, ok := bus.EventsSince(ctx, uint64(seq1))
+	if ok {
+		t.Fatalf("EventsSince with a pruned gap should reset, got events %+v", events)
+	}
+	if headSeq != uint64(seq3) {
+		t.Fatalf("headSeq = %d, want %d", headSeq, seq3)
+	}
+}
+
 func TestEventBusSeq(t *testing.T) {
 	store := newTestStoreForEventBus(t)
 	bus := NewEventBus("test-tenant", store)


### PR DESCRIPTION
## Summary

`EventBus.EventsSince` previously treated **any** seq hole between the client cursor and the first returned event as "events were pruned" and forced a client reset:

```go
if since+1 < firstSeq { return nil, headSeq, false }
```

That assumption is wrong in two cases:

1. **Shared-schema `fs_events` tables** (one table serving many tenants): other tenants' interleaved seqs make per-tenant holes the norm — every poll would detect a "gap" and reset continuously (reset storm).
2. **Standalone tables**: rolled-back inserts burn AUTO_INCREMENT ids, creating the same benign interior holes.

Pruning only ever happens at the **left edge** of the retained window, so a gap is now a reset condition only when the cursor falls behind the oldest retained seq (`since+1 < oldest`) — identical semantics as before for actual pruning, and interior holes are delivered through. The no-rows branch already used exactly this comparison; this PR makes the got-rows branch consistent with it and updates the doc comment.

This is a prerequisite for moving `fs_events` onto shared (fs_id-keyed) tables.

## Test plan

- [x] `go test ./pkg/server/ -run 'TestEventBus' -count=1 -v` — all pass
- [x] New `TestEventBusEventsSinceInteriorGapDelivers`: burned middle seq → delivered, no reset (previously would have reset)
- [x] New `TestEventBusEventsSincePrunedGapResets`: left-edge pruning past the cursor → still resets
- [x] `bin/golangci-lint run ./pkg/server/...` — 0 issues
