### PR TITLE
Stop creating the legacy files table in the local no-embedding schema

### DIFF
--- a/pkg/backend/schema_test_helper.go
+++ b/pkg/backend/schema_test_helper.go
@@ -17,6 +17,7 @@ func initBackendSchema(t *testing.T, dsn string) {
 	}
 	defer func() { _ = db.Close() }()
 	stmts := schema.MySQLNoEmbeddingTenantSchemaStatements()
+	stmts = append(stmts, schema.MySQLNoEmbeddingLegacyFilesStatements()...)
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
 			msg := err.Error()

--- a/pkg/client/schema_test_helper.go
+++ b/pkg/client/schema_test_helper.go
@@ -20,6 +20,7 @@ func initClientTenantSchema(t *testing.T, dsn string) {
 	defer func() { _ = db.Close() }()
 
 	stmts := schema.MySQLNoEmbeddingTenantSchemaStatements()
+	stmts = append(stmts, schema.MySQLNoEmbeddingLegacyFilesStatements()...)
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
 			msg := err.Error()

--- a/pkg/datastore/schema_test_helper_test.go
+++ b/pkg/datastore/schema_test_helper_test.go
@@ -18,6 +18,7 @@ func initDatastoreSchema(t *testing.T, dsn string) {
 	defer func() { _ = db.Close() }()
 
 	stmts := schema.MySQLNoEmbeddingTenantSchemaStatements()
+	stmts = append(stmts, schema.MySQLNoEmbeddingLegacyFilesStatements()...)
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
 			msg := err.Error()

--- a/pkg/server/schema_test_helper.go
+++ b/pkg/server/schema_test_helper.go
@@ -18,6 +18,7 @@ func initServerTenantSchema(t *testing.T, dsn string) {
 	defer func() { _ = db.Close() }()
 
 	stmts := schema.MySQLNoEmbeddingTenantSchemaStatements()
+	stmts = append(stmts, schema.MySQLNoEmbeddingLegacyFilesStatements()...)
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
 			msg := err.Error()

--- a/pkg/tenant/schema/mysql_no_embedding.go
+++ b/pkg/tenant/schema/mysql_no_embedding.go
@@ -17,6 +17,12 @@ import (
 // exists to make drive9-server-local and e2e smoke tests runnable against an
 // ordinary MySQL-compatible database while preserving the same core filesystem,
 // layer, journal, git workspace, and vault tables.
+//
+// The legacy `files` table is NOT part of this list: fresh local databases
+// start on the split-table schema only. Tests that exercise the legacy
+// dual-write path can add it explicitly via
+// MySQLNoEmbeddingLegacyFilesStatements; existing databases that already have
+// the table keep working (Store detects it at open time).
 func MySQLNoEmbeddingTenantSchemaStatements() []string {
 	stmts := []string{
 		`CREATE TABLE IF NOT EXISTS file_nodes (
@@ -35,33 +41,6 @@ func MySQLNoEmbeddingTenantSchemaStatements() []string {
 		`CREATE INDEX idx_parent ON file_nodes(parent_path_hash, name)`,
 		`CREATE INDEX idx_file_id ON file_nodes(file_id)`,
 		`CREATE INDEX idx_inode_id ON file_nodes(inode_id)`,
-
-		`CREATE TABLE IF NOT EXISTS files (
-			file_id                    VARCHAR(64) PRIMARY KEY,
-			storage_type               VARCHAR(32) NOT NULL,
-			storage_ref                TEXT NOT NULL,
-			storage_ref_hash           VARCHAR(64) NOT NULL DEFAULT '',
-			storage_encryption_mode    VARCHAR(16) NOT NULL DEFAULT 'legacy',
-			storage_encryption_key_id  VARCHAR(256) NOT NULL DEFAULT '',
-			content_blob               LONGBLOB,
-			content_type               VARCHAR(255),
-			size_bytes                 BIGINT NOT NULL DEFAULT 0,
-			checksum_sha256            VARCHAR(128),
-			revision                   BIGINT NOT NULL DEFAULT 1,
-			status                     VARCHAR(32) NOT NULL DEFAULT 'PENDING',
-			source_id                  VARCHAR(255),
-			content_text               LONGTEXT,
-			description                LONGTEXT,
-			embedding                  LONGTEXT,
-			embedding_revision         BIGINT,
-			description_embedding      LONGTEXT,
-			description_embedding_revision BIGINT,
-			created_at                 DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
-			confirmed_at               DATETIME(3),
-			expires_at                 DATETIME(3)
-		)`,
-		`CREATE INDEX idx_status ON files(status, created_at)`,
-		`CREATE INDEX idx_files_storage_ref_hash ON files(storage_ref_hash)`,
 
 		`CREATE TABLE IF NOT EXISTS inodes (
 			inode_id     VARCHAR(64) PRIMARY KEY,
@@ -264,4 +243,40 @@ func ValidateMySQLNoEmbeddingTenantSchema(ctx context.Context, db *sql.DB) error
 		return fmt.Errorf("local no-embedding schema missing required tables: got %d want %d", count, len(required))
 	}
 	return nil
+}
+
+// MySQLNoEmbeddingLegacyFilesStatements returns the legacy `files` table DDL
+// (and its indexes) for the local no-embedding schema. It is deliberately NOT
+// part of MySQLNoEmbeddingTenantSchemaStatements: fresh databases start on
+// the split-table schema only. These statements exist so tests can opt into
+// the legacy dual-write path explicitly.
+func MySQLNoEmbeddingLegacyFilesStatements() []string {
+	return []string{
+		`CREATE TABLE IF NOT EXISTS files (
+			file_id                    VARCHAR(64) PRIMARY KEY,
+			storage_type               VARCHAR(32) NOT NULL,
+			storage_ref                TEXT NOT NULL,
+			storage_ref_hash           VARCHAR(64) NOT NULL DEFAULT '',
+			storage_encryption_mode    VARCHAR(16) NOT NULL DEFAULT 'legacy',
+			storage_encryption_key_id  VARCHAR(256) NOT NULL DEFAULT '',
+			content_blob               LONGBLOB,
+			content_type               VARCHAR(255),
+			size_bytes                 BIGINT NOT NULL DEFAULT 0,
+			checksum_sha256            VARCHAR(128),
+			revision                   BIGINT NOT NULL DEFAULT 1,
+			status                     VARCHAR(32) NOT NULL DEFAULT 'PENDING',
+			source_id                  VARCHAR(255),
+			content_text               LONGTEXT,
+			description                LONGTEXT,
+			embedding                  LONGTEXT,
+			embedding_revision         BIGINT,
+			description_embedding      LONGTEXT,
+			description_embedding_revision BIGINT,
+			created_at                 DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			confirmed_at               DATETIME(3),
+			expires_at                 DATETIME(3)
+		)`,
+		`CREATE INDEX idx_status ON files(status, created_at)`,
+		`CREATE INDEX idx_files_storage_ref_hash ON files(storage_ref_hash)`,
+	}
 }


### PR DESCRIPTION
## Summary

`MySQLNoEmbeddingTenantSchemaStatements` still created the legacy `files` table, so **every fresh `drive9-server-local` database (and every test database) was born with the pre-split legacy table** and kept dual-writing to it forever (`detectLegacyFiles` → `useLegacyFiles=true`).

- The `files` table and its two indexes are removed from the default statement list — new local databases start on the split-table schema only.
- Existing local databases are unaffected: the table is still detected at open time and the dual-write path runs exactly as before.
- The DDL moves to a separate `MySQLNoEmbeddingLegacyFilesStatements()`, applied explicitly by the datastore/backend/server/client test helpers, so test coverage of the legacy dual-write path is unchanged. This mirrors how `pkg/migrate` and `pkg/tenant` tests already create the table themselves.

Note: production TiDB tenant schemas never created `files` (it is only diffed "if exists"), so after this PR no new database anywhere gets the legacy table.

## Test plan

- [x] `go test ./pkg/datastore/ ./pkg/backend/ ./pkg/client/ ./pkg/tenant/schema/ -count=1` — pass
- [x] `go test ./pkg/server/ -count=1` — pass
- [x] `go build ./...` + `go vet` on touched packages
