### PR TITLE
Defer incomplete TiDB Cloud batch metadata without blocking

### DIFF
--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -422,7 +422,6 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 	}
 	out := make([]*tenant.ClusterInfo, len(created.Clusters))
 	errs := make([]error, len(created.Clusters))
-	pending := make([]batchClusterMetadataTarget, 0, len(created.Clusters))
 	for i := range created.Clusters {
 		i := i
 		info := created.Clusters[i]
@@ -441,19 +440,10 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 			continue
 		}
 		if p.clusterProvisionMetadataIncomplete(&info) {
-			pending = append(pending, batchClusterMetadataTarget{
-				index:    i,
-				tenantID: tenantID,
-				password: password,
-				dbName:   dbName,
-				initial:  info,
-			})
+			out[i] = fallbackBatchClusterInfo(info, dbName, passwords)
 			continue
 		}
 		out[i], errs[i] = p.clusterInfoFromResponse(tenantID, dbName, password, &info)
-	}
-	if len(pending) > 0 {
-		p.waitForBatchClusterProvisionMetadata(ctx, publicKey, privateKey, strings.TrimSpace(opts.TenantPoolID), pending, out, errs)
 	}
 	for _, err := range errs {
 		if err != nil {
@@ -661,18 +651,21 @@ func batchMetadataPollInterval() time.Duration {
 func fallbackBatchClusterInfos(clusters []clusterInfo, dbName string, passwords map[string]string) []*tenant.ClusterInfo {
 	out := make([]*tenant.ClusterInfo, 0, len(clusters))
 	for i := range clusters {
-		info := clusters[i]
-		tenantID := strings.TrimSpace(info.Labels[Drive9TenantIDLabel])
-		out = append(out, &tenant.ClusterInfo{
-			TenantID:       tenantID,
-			ClusterID:      strings.TrimSpace(info.ClusterID),
-			OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
-			Password:       passwords[tenantID],
-			DBName:         dbName,
-			Provider:       tenant.ProviderTiDBCloudNative,
-		})
+		out = append(out, fallbackBatchClusterInfo(clusters[i], dbName, passwords))
 	}
 	return out
+}
+
+func fallbackBatchClusterInfo(info clusterInfo, dbName string, passwords map[string]string) *tenant.ClusterInfo {
+	tenantID := strings.TrimSpace(info.Labels[Drive9TenantIDLabel])
+	return &tenant.ClusterInfo{
+		TenantID:       tenantID,
+		ClusterID:      strings.TrimSpace(info.ClusterID),
+		OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
+		Password:       passwords[tenantID],
+		DBName:         dbName,
+		Provider:       tenant.ProviderTiDBCloudNative,
+	}
 }
 
 func (p *Provisioner) WaitForPoolClusterMetadata(ctx context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) (*tenant.ClusterInfo, error) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -422,6 +422,7 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 	}
 	out := make([]*tenant.ClusterInfo, len(created.Clusters))
 	errs := make([]error, len(created.Clusters))
+	pending := make([]batchClusterMetadataTarget, 0, len(created.Clusters))
 	for i := range created.Clusters {
 		i := i
 		info := created.Clusters[i]
@@ -439,7 +440,20 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 			errs[i] = fmt.Errorf("tidbcloud native batch response missing cluster id for tenant %q", tenantID)
 			continue
 		}
+		if p.clusterProvisionMetadataIncomplete(&info) {
+			pending = append(pending, batchClusterMetadataTarget{
+				index:    i,
+				tenantID: tenantID,
+				password: password,
+				dbName:   dbName,
+				initial:  info,
+			})
+			continue
+		}
 		out[i], errs[i] = p.clusterInfoFromResponse(tenantID, dbName, password, &info)
+	}
+	if len(pending) > 0 {
+		p.waitForBatchClusterProvisionMetadata(ctx, publicKey, privateKey, strings.TrimSpace(opts.TenantPoolID), pending, out, errs)
 	}
 	for _, err := range errs {
 		if err != nil {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -404,7 +404,11 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 	}
 }
 
-func TestBatchProvisionFreeClustersReturnsCreatedClustersWithoutMetadataWait(t *testing.T) {
+func TestBatchProvisionFreeClustersWaitsForPublicHost(t *testing.T) {
+	origPoll := tidbCloudNativeBatchMetadataPollInterval
+	tidbCloudNativeBatchMetadataPollInterval = time.Millisecond
+	t.Cleanup(func() { tidbCloudNativeBatchMetadataPollInterval = origPoll })
+
 	var listCalls atomic.Int32
 	handlerErrs := make(chan error, 2)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -434,8 +438,25 @@ func TestBatchProvisionFreeClustersReturnsCreatedClustersWithoutMetadataWait(t *
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			listCalls.Add(1)
-			handlerErrs <- fmt.Errorf("unexpected metadata wait request %q", r.URL.String())
-			http.Error(w, "unexpected metadata wait", http.StatusInternalServerError)
+			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-2"`) || !strings.Contains(filter, Drive9ManagedLabel) {
+				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
+				http.Error(w, "unexpected filter", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusters": []map[string]any{
+					{
+						"clusterId": "cluster-2",
+						"state":     "ACTIVE",
+						"labels": map[string]string{
+							TiDBCloudOrganizationLabel: "org-1",
+							Drive9TenantIDLabel:        "tenant-2",
+						},
+						"userPrefix": "u2",
+						"endpoints":  map[string]any{"public": map[string]any{"host": "db2.example", "port": 4000}},
+					},
+				},
+			})
 		default:
 			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.String())
 			http.Error(w, "unexpected request", http.StatusInternalServerError)
@@ -458,8 +479,8 @@ func TestBatchProvisionFreeClustersReturnsCreatedClustersWithoutMetadataWait(t *
 		t.Fatalf("BatchProvisionFreeClustersWithCredentialsAndQuota: %v", err)
 	}
 	assertNoHandlerError(t, handlerErrs)
-	if listCalls.Load() != 0 {
-		t.Fatalf("metadata list calls = %d, want 0", listCalls.Load())
+	if listCalls.Load() != 1 {
+		t.Fatalf("metadata list calls = %d, want 1", listCalls.Load())
 	}
 	if len(out) != 2 {
 		t.Fatalf("clusters = %d, want 2: %#v", len(out), out)
@@ -470,8 +491,90 @@ func TestBatchProvisionFreeClustersReturnsCreatedClustersWithoutMetadataWait(t *
 	if out[0].Password == "" || out[1].Password == "" {
 		t.Fatalf("clusters did not preserve generated passwords: %#v", out)
 	}
-	if out[1].Host != "" || out[1].Port != 0 {
-		t.Fatalf("incomplete cluster connection = %#v, want no endpoint", out[1])
+	if out[1].Host != "db2.example" || out[1].Port != 4000 || out[1].Username != "u2.root" {
+		t.Fatalf("cluster 2 connection = %#v", out[1])
+	}
+}
+
+func TestBatchProvisionFreeClustersWaitsForPrivateEndpointPublicHost(t *testing.T) {
+	origPoll := tidbCloudNativeBatchMetadataPollInterval
+	tidbCloudNativeBatchMetadataPollInterval = time.Millisecond
+	t.Cleanup(func() { tidbCloudNativeBatchMetadataPollInterval = origPoll })
+
+	var listCalls atomic.Int32
+	handlerErrs := make(chan error, 2)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1beta1/clusters:batchCreate":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusters": []map[string]any{
+					{
+						"clusterId":  "cluster-1",
+						"state":      "ACTIVE",
+						"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-1"},
+						"userPrefix": "u1",
+						"endpoints":  map[string]any{"private": map[string]any{"port": 4001}},
+					},
+				},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
+			listCalls.Add(1)
+			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-1"`) || !strings.Contains(filter, Drive9ManagedLabel) {
+				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
+				http.Error(w, "unexpected filter", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"clusters": []map[string]any{
+					{
+						"clusterId": "cluster-1",
+						"state":     "ACTIVE",
+						"labels": map[string]string{
+							TiDBCloudOrganizationLabel: "org-1",
+							Drive9TenantIDLabel:        "tenant-1",
+						},
+						"userPrefix": "u1",
+						"endpoints": map[string]any{
+							"public":  map[string]any{"host": "public-a.example", "port": 4000},
+							"private": map[string]any{"port": 4001},
+						},
+					},
+				},
+			})
+		default:
+			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.String())
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:                 ts.URL,
+		cloudProvider:          "aws",
+		region:                 "us-east-1",
+		defaultDatabaseName:    DefaultDatabaseName,
+		usePrivateEndpoint:     true,
+		privateEndpointHostMap: map[string]string{"public-a.example": "private-a.internal"},
+		client:                 ts.Client(),
+	}
+	out, _, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(context.Background(), []string{"tenant-1"}, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	}, tenant.QuotaUpdateOptions{})
+	if err != nil {
+		t.Fatalf("BatchProvisionFreeClustersWithCredentialsAndQuota: %v", err)
+	}
+	assertNoHandlerError(t, handlerErrs)
+	if listCalls.Load() != 1 {
+		t.Fatalf("metadata list calls = %d, want 1", listCalls.Load())
+	}
+	if len(out) != 1 || out[0].Host != "private-a.internal" || out[0].Port != 4001 || out[0].Username != "u1.root" {
+		t.Fatalf("clusters = %#v", out)
 	}
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -404,11 +404,7 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 	}
 }
 
-func TestBatchProvisionFreeClustersWaitsForPublicHost(t *testing.T) {
-	origPoll := tidbCloudNativeBatchMetadataPollInterval
-	tidbCloudNativeBatchMetadataPollInterval = time.Millisecond
-	t.Cleanup(func() { tidbCloudNativeBatchMetadataPollInterval = origPoll })
-
+func TestBatchProvisionFreeClustersDefersIncompletePublicHostWithoutMetadataWait(t *testing.T) {
 	var listCalls atomic.Int32
 	handlerErrs := make(chan error, 2)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -438,25 +434,8 @@ func TestBatchProvisionFreeClustersWaitsForPublicHost(t *testing.T) {
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			listCalls.Add(1)
-			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-2"`) || !strings.Contains(filter, Drive9ManagedLabel) {
-				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
-				http.Error(w, "unexpected filter", http.StatusBadRequest)
-				return
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"clusters": []map[string]any{
-					{
-						"clusterId": "cluster-2",
-						"state":     "ACTIVE",
-						"labels": map[string]string{
-							TiDBCloudOrganizationLabel: "org-1",
-							Drive9TenantIDLabel:        "tenant-2",
-						},
-						"userPrefix": "u2",
-						"endpoints":  map[string]any{"public": map[string]any{"host": "db2.example", "port": 4000}},
-					},
-				},
-			})
+			handlerErrs <- fmt.Errorf("unexpected metadata wait request %q", r.URL.String())
+			http.Error(w, "unexpected metadata wait", http.StatusInternalServerError)
 		default:
 			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.String())
 			http.Error(w, "unexpected request", http.StatusInternalServerError)
@@ -479,8 +458,8 @@ func TestBatchProvisionFreeClustersWaitsForPublicHost(t *testing.T) {
 		t.Fatalf("BatchProvisionFreeClustersWithCredentialsAndQuota: %v", err)
 	}
 	assertNoHandlerError(t, handlerErrs)
-	if listCalls.Load() != 1 {
-		t.Fatalf("metadata list calls = %d, want 1", listCalls.Load())
+	if listCalls.Load() != 0 {
+		t.Fatalf("metadata list calls = %d, want 0", listCalls.Load())
 	}
 	if len(out) != 2 {
 		t.Fatalf("clusters = %d, want 2: %#v", len(out), out)
@@ -491,16 +470,12 @@ func TestBatchProvisionFreeClustersWaitsForPublicHost(t *testing.T) {
 	if out[0].Password == "" || out[1].Password == "" {
 		t.Fatalf("clusters did not preserve generated passwords: %#v", out)
 	}
-	if out[1].Host != "db2.example" || out[1].Port != 4000 || out[1].Username != "u2.root" {
-		t.Fatalf("cluster 2 connection = %#v", out[1])
+	if out[1].Host != "" || out[1].Port != 0 || out[1].Username != "" {
+		t.Fatalf("incomplete cluster connection = %#v, want seed without endpoint", out[1])
 	}
 }
 
-func TestBatchProvisionFreeClustersWaitsForPrivateEndpointPublicHost(t *testing.T) {
-	origPoll := tidbCloudNativeBatchMetadataPollInterval
-	tidbCloudNativeBatchMetadataPollInterval = time.Millisecond
-	t.Cleanup(func() { tidbCloudNativeBatchMetadataPollInterval = origPoll })
-
+func TestBatchProvisionFreeClustersDefersPrivateEndpointPublicHostWithoutMappingError(t *testing.T) {
 	var listCalls atomic.Int32
 	handlerErrs := make(chan error, 2)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -524,28 +499,8 @@ func TestBatchProvisionFreeClustersWaitsForPrivateEndpointPublicHost(t *testing.
 			})
 		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			listCalls.Add(1)
-			if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-1"`) || !strings.Contains(filter, Drive9ManagedLabel) {
-				handlerErrs <- fmt.Errorf("unexpected list filter %q", filter)
-				http.Error(w, "unexpected filter", http.StatusBadRequest)
-				return
-			}
-			_ = json.NewEncoder(w).Encode(map[string]any{
-				"clusters": []map[string]any{
-					{
-						"clusterId": "cluster-1",
-						"state":     "ACTIVE",
-						"labels": map[string]string{
-							TiDBCloudOrganizationLabel: "org-1",
-							Drive9TenantIDLabel:        "tenant-1",
-						},
-						"userPrefix": "u1",
-						"endpoints": map[string]any{
-							"public":  map[string]any{"host": "public-a.example", "port": 4000},
-							"private": map[string]any{"port": 4001},
-						},
-					},
-				},
-			})
+			handlerErrs <- fmt.Errorf("unexpected metadata wait request %q", r.URL.String())
+			http.Error(w, "unexpected metadata wait", http.StatusInternalServerError)
 		default:
 			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.String())
 			http.Error(w, "unexpected request", http.StatusInternalServerError)
@@ -570,11 +525,14 @@ func TestBatchProvisionFreeClustersWaitsForPrivateEndpointPublicHost(t *testing.
 		t.Fatalf("BatchProvisionFreeClustersWithCredentialsAndQuota: %v", err)
 	}
 	assertNoHandlerError(t, handlerErrs)
-	if listCalls.Load() != 1 {
-		t.Fatalf("metadata list calls = %d, want 1", listCalls.Load())
+	if listCalls.Load() != 0 {
+		t.Fatalf("metadata list calls = %d, want 0", listCalls.Load())
 	}
-	if len(out) != 1 || out[0].Host != "private-a.internal" || out[0].Port != 4001 || out[0].Username != "u1.root" {
+	if len(out) != 1 || out[0].TenantID != "tenant-1" || out[0].ClusterID != "cluster-1" {
 		t.Fatalf("clusters = %#v", out)
+	}
+	if out[0].Host != "" || out[0].Port != 0 || out[0].Username != "" {
+		t.Fatalf("incomplete cluster connection = %#v, want seed without endpoint", out[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- treat incomplete TiDB Cloud batch cluster metadata as not-ready seed metadata instead of an endpoint resolution error
- keep batch pool provisioning nonblocking while preserving existing asynchronous metadata resume behavior
- remove the unrelated user DB connection max-lifetime change from this PR

## Notes
When TiDB Cloud batchCreate returns a cluster before public/private endpoint metadata is ready, the provisioner now returns a seed `ClusterInfo` without host/port instead of failing host resolution. The admin pool path persists that seed and starts the existing metadata resume flow outside the immediate batch response path, avoiding noisy `admin_tenant_pool_batch_metadata_incomplete` warnings for not-yet-ready clusters and avoiding long cloud polling while holding the tenant pool lock.

## Testing
- `go test ./pkg/tenant/tidbcloudnative -run 'TestBatchProvisionFreeClusters|TestWaitForPoolClustersMetadataUsesList|TestClusterConnectionIncompleteWhenPrivateEndpointMissing|TestProvisionWithCredentials.*Private|TestProvisionWithCredentialsErrorsWhenPrivateHostMappingMissing' -count=1`
- `go test ./pkg/tenant/tidbcloudnative -count=1`
- `git diff --check`