### PR TITLE
Add tenant pool binding metrics

### DIFF
--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -6,6 +6,8 @@ This directory uses a usage-first layout plus focused incident drill-downs.
 
 This dashboard set expects the `drive9_*` Prometheus namespace. The previous `dat9_*` metric names are intentionally not dual-emitted by Drive9 after this metrics contract rewrite. Existing external dashboards, alerts, and recording rules must be migrated from `dat9_*` to `drive9_*` at the same time as this server rollout.
 
+`drive9_tenant_count` also changes its label contract. The old synthetic series such as `drive9_tenant_count{state="total_non_deleted"}` and `drive9_tenant_count{state="active"}` are not emitted. Use `drive9_tenant_count{status="<real status>"}` instead, where status is one of `pending`, `provisioning`, `active`, `failed`, `suspended`, `deleting`, or `deleted`. Dashboards or alerts that need "non-deleted" totals should aggregate the real statuses they want to include instead of depending on a synthetic metric state.
+
 ## 1. Usage dashboard
 
 - `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, HTTP transport bytes, storage/media quota state, latency, and non-OK rates by TiDB Cloud org/tenant/surface/action. Use this to answer `who is using Drive9, how much, and through which workflows?`
@@ -14,6 +16,8 @@ Tenant usage metrics intentionally allow `tenant_id` and `tidbcloud_org_id` as P
 
 ## Tenant metric contract
 
+- `drive9_tenant_count`: tenant count by real tenant `status`.
+- `drive9_tenant_pool_bindings`: tenant-pool binding count by `pool_id`, `tidbcloud_org_id`, and binding `status=free|used`. The binding label is `status`, not `pool_status`.
 - `drive9_tenant_requests_total`: request count by `tenant_id`, `tidbcloud_org_id`, `surface`, `action`, `result`, and `status_class`.
 - `drive9_tenant_request_duration_seconds`: request latency histogram by `surface` and `status_class`.
 - `drive9_tenant_inflight_requests`: current in-flight request gauge by `tenant_id`, `tidbcloud_org_id`, `surface`, and `action`.

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -8,19 +8,19 @@ This dashboard set expects the `drive9_*` Prometheus namespace. The previous `da
 
 ## 1. Usage dashboard
 
-- `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, HTTP transport bytes, storage/media quota state, latency, and non-OK rates by tenant/surface/action. Use this to answer `who is using Drive9, how much, and through which workflows?`
+- `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, HTTP transport bytes, storage/media quota state, latency, and non-OK rates by TiDB Cloud org/tenant/surface/action. Use this to answer `who is using Drive9, how much, and through which workflows?`
 
-Tenant usage metrics intentionally allow `tenant_id` as a Prometheus label, but keep high-cardinality values out of labels: no path, file ID, upload ID, API key ID, raw URL, user agent, or trace ID.
+Tenant usage metrics intentionally allow `tenant_id` and `tidbcloud_org_id` as Prometheus labels, but keep high-cardinality values out of labels: no path, file ID, upload ID, API key ID, raw URL, user agent, or trace ID. When a tenant has no TiDB Cloud org binding, or a hot path cannot safely resolve the binding without extra work, `tidbcloud_org_id` is reported as `guest`.
 
 ## Tenant metric contract
 
-- `drive9_tenant_requests_total`: request count by `tenant_id`, `surface`, `action`, `result`, and `status_class`.
+- `drive9_tenant_requests_total`: request count by `tenant_id`, `tidbcloud_org_id`, `surface`, `action`, `result`, and `status_class`.
 - `drive9_tenant_request_duration_seconds`: request latency histogram by `surface` and `status_class`.
-- `drive9_tenant_inflight_requests`: current in-flight request gauge by `tenant_id`, `surface`, and `action`.
-- `drive9_tenant_http_bytes_total`: HTTP transport bytes by `tenant_id`, `surface`, and `direction=request|response`.
-- `drive9_tenant_file_bytes_total`: logical file bytes by `tenant_id`, `surface`, `action`, and `direction=read|write`.
-- `drive9_tenant_storage_bytes`: opportunistically published quota storage gauge by `tenant_id` and `state=confirmed|reserved|limit`.
-- `drive9_tenant_media_files`: opportunistically published quota media-file gauge by `tenant_id` and `state=confirmed|limit`.
+- `drive9_tenant_inflight_requests`: current in-flight request gauge by `tenant_id`, `tidbcloud_org_id`, `surface`, and `action`.
+- `drive9_tenant_http_bytes_total`: HTTP transport bytes by `tenant_id`, `tidbcloud_org_id`, `surface`, and `direction=request|response`.
+- `drive9_tenant_file_bytes_total`: logical file bytes by `tenant_id`, `tidbcloud_org_id`, `surface`, `action`, and `direction=read|write`.
+- `drive9_tenant_storage_bytes`: opportunistically published quota storage gauge by `tenant_id`, `tidbcloud_org_id`, and `state=confirmed|reserved|limit`.
+- `drive9_tenant_media_files`: opportunistically published quota media-file gauge by `tenant_id`, `tidbcloud_org_id`, and `state=confirmed|limit`.
 
 ## 2. Service overview dashboards
 

--- a/docs/grafana/drive9-tenant-usage-dashboard.json
+++ b/docs/grafana/drive9-tenant-usage-dashboard.json
@@ -664,7 +664,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, ((drive9_tenant_media_files{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"confirmed\"} / on (tenant_id, tidbcloud_org_id) drive9_tenant_media_files{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"limit\"}) and on (tenant_id, tidbcloud_org_id) (drive9_tenant_media_files{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"limit\"} > 0)))",
+          "expr": "topk(15, ((sum by (tenant_id, tidbcloud_org_id) (drive9_tenant_media_files{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"confirmed\"}) / sum by (tenant_id, tidbcloud_org_id) (drive9_tenant_media_files{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"limit\"})) and on (tenant_id, tidbcloud_org_id) (sum by (tenant_id, tidbcloud_org_id) (drive9_tenant_media_files{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"limit\"}) > 0)))",
           "legendFormat": "{{tenant_id}} / {{tidbcloud_org_id}} media files",
           "refId": "B"
         }

--- a/docs/grafana/drive9-tenant-usage-dashboard.json
+++ b/docs/grafana/drive9-tenant-usage-dashboard.json
@@ -15,7 +15,7 @@
       }
     ]
   },
-  "description": "Tenant usage dashboard: request frequency, logical file IO, transport bytes, latency, and errors by tenant/surface/action.",
+  "description": "Tenant usage dashboard: request frequency, logical file IO, transport bytes, latency, and errors by TiDB Cloud org/tenant/surface/action.",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -94,7 +94,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "count(count by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]) > 0))",
+          "expr": "count(count by (tenant_id) (rate(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]) > 0))",
           "legendFormat": "active tenants",
           "refId": "A"
         }
@@ -140,7 +140,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
           "legendFormat": "requests/s",
           "refId": "A"
         }
@@ -186,7 +186,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(drive9_tenant_file_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
+          "expr": "sum(rate(drive9_tenant_file_bytes_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
           "legendFormat": "file bytes/s",
           "refId": "A"
         }
@@ -232,7 +232,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\",result!=\"ok\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])), 0.000001)",
+          "expr": "sum(rate(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\",result!=\"ok\"}[$__rate_interval])) / clamp_min(sum(rate(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])), 0.000001)",
           "legendFormat": "non-ok ratio",
           "refId": "A"
         }
@@ -278,8 +278,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, sum by (tenant_id) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}}",
+          "expr": "topk(15, sum by (tenant_id, tidbcloud_org_id) (rate(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
+          "legendFormat": "{{tenant_id}} / {{tidbcloud_org_id}}",
           "refId": "A"
         }
       ],
@@ -324,8 +324,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, sum by (tenant_id, direction) (rate(drive9_tenant_file_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} {{direction}}",
+          "expr": "topk(15, sum by (tenant_id, tidbcloud_org_id, direction) (rate(drive9_tenant_file_bytes_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval])))",
+          "legendFormat": "{{tenant_id}} / {{tidbcloud_org_id}} {{direction}}",
           "refId": "A"
         }
       ],
@@ -370,7 +370,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (surface, action) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
+          "expr": "sum by (surface, action) (rate(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"}[$__rate_interval]))",
           "legendFormat": "{{surface}}/{{action}}",
           "refId": "A"
         }
@@ -471,8 +471,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, sum by (tenant_id, result) (rate(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\",result!=\"ok\"}[$__rate_interval])))",
-          "legendFormat": "{{tenant_id}} {{result}}",
+          "expr": "topk(15, sum by (tenant_id, tidbcloud_org_id, result) (rate(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\",result!=\"ok\"}[$__rate_interval])))",
+          "legendFormat": "{{tenant_id}} / {{tidbcloud_org_id}} {{result}}",
           "refId": "A"
         }
       ],
@@ -517,7 +517,7 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (surface, direction) (rate(drive9_tenant_http_bytes_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval]))",
+          "expr": "sum by (surface, direction) (rate(drive9_tenant_http_bytes_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval]))",
           "legendFormat": "{{surface}} {{direction}}",
           "refId": "A"
         }
@@ -563,8 +563,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "sum by (tenant_id, surface, action) (drive9_tenant_inflight_requests{tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"})",
-          "legendFormat": "{{tenant_id}} {{surface}}/{{action}}",
+          "expr": "sum by (tenant_id, tidbcloud_org_id, surface, action) (drive9_tenant_inflight_requests{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\",action=~\"$action\"})",
+          "legendFormat": "{{tenant_id}} / {{tidbcloud_org_id}} {{surface}}/{{action}}",
           "refId": "A"
         }
       ],
@@ -609,8 +609,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, drive9_tenant_storage_bytes{tenant_id=~\"$tenant\",state=~\"confirmed|reserved\"})",
-          "legendFormat": "{{tenant_id}} {{state}}",
+          "expr": "topk(15, drive9_tenant_storage_bytes{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=~\"confirmed|reserved\"})",
+          "legendFormat": "{{tenant_id}} / {{tidbcloud_org_id}} {{state}}",
           "refId": "A"
         }
       ],
@@ -655,8 +655,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, ((sum by (tenant_id) (drive9_tenant_storage_bytes{tenant_id=~\"$tenant\",state=~\"confirmed|reserved\"}) / sum by (tenant_id) (drive9_tenant_storage_bytes{tenant_id=~\"$tenant\",state=\"limit\"})) and on (tenant_id) (sum by (tenant_id) (drive9_tenant_storage_bytes{tenant_id=~\"$tenant\",state=\"limit\"}) > 0)))",
-          "legendFormat": "{{tenant_id}} storage",
+          "expr": "topk(15, ((sum by (tenant_id, tidbcloud_org_id) (drive9_tenant_storage_bytes{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=~\"confirmed|reserved\"}) / sum by (tenant_id, tidbcloud_org_id) (drive9_tenant_storage_bytes{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"limit\"})) and on (tenant_id, tidbcloud_org_id) (sum by (tenant_id, tidbcloud_org_id) (drive9_tenant_storage_bytes{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"limit\"}) > 0)))",
+          "legendFormat": "{{tenant_id}} / {{tidbcloud_org_id}} storage",
           "refId": "A"
         },
         {
@@ -664,8 +664,8 @@
             "type": "prometheus",
             "uid": "${datasource}"
           },
-          "expr": "topk(15, ((drive9_tenant_media_files{tenant_id=~\"$tenant\",state=\"confirmed\"} / on (tenant_id) drive9_tenant_media_files{tenant_id=~\"$tenant\",state=\"limit\"}) and on (tenant_id) (drive9_tenant_media_files{tenant_id=~\"$tenant\",state=\"limit\"} > 0)))",
-          "legendFormat": "{{tenant_id}} media files",
+          "expr": "topk(15, ((drive9_tenant_media_files{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"confirmed\"} / on (tenant_id, tidbcloud_org_id) drive9_tenant_media_files{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"limit\"}) and on (tenant_id, tidbcloud_org_id) (drive9_tenant_media_files{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",state=\"limit\"} > 0)))",
+          "legendFormat": "{{tenant_id}} / {{tidbcloud_org_id}} media files",
           "refId": "B"
         }
       ],
@@ -711,14 +711,39 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(drive9_tenant_requests_total, tenant_id)",
+        "definition": "label_values(drive9_tenant_requests_total, tidbcloud_org_id)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "TiDB Org",
+        "multi": true,
+        "name": "org",
+        "options": [],
+        "query": "label_values(drive9_tenant_requests_total, tidbcloud_org_id)",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${datasource}"
+        },
+        "definition": "label_values(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\"}, tenant_id)",
         "hide": 0,
         "includeAll": true,
         "label": "Tenant",
         "multi": true,
         "name": "tenant",
         "options": [],
-        "query": "label_values(drive9_tenant_requests_total, tenant_id)",
+        "query": "label_values(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\"}, tenant_id)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -736,14 +761,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\"}, surface)",
+        "definition": "label_values(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\"}, surface)",
         "hide": 0,
         "includeAll": true,
         "label": "Surface",
         "multi": true,
         "name": "surface",
         "options": [],
-        "query": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\"}, surface)",
+        "query": "label_values(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\"}, surface)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -761,14 +786,14 @@
           "type": "prometheus",
           "uid": "${datasource}"
         },
-        "definition": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
+        "definition": "label_values(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
         "hide": 0,
         "includeAll": true,
         "label": "Action",
         "multi": true,
         "name": "action",
         "options": [],
-        "query": "label_values(drive9_tenant_requests_total{tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
+        "query": "label_values(drive9_tenant_requests_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\"}, action)",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/pkg/backend/audio_extract.go
+++ b/pkg/backend/audio_extract.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pingcap/failpoint"
 
 	"github.com/mem9-ai/drive9/pkg/datastore"
-	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 // AudioExtractRequest is the input to a pluggable audio->text extractor.
@@ -285,7 +284,7 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 	start := time.Now()
 	var result AudioExtractResult
 	defer func() {
-		metrics.RecordTenantOperation(b.tenantID, "audio_extract", "process", legacyAudioExtractMetricResult(result), time.Since(start))
+		b.recordTenantOperation("audio_extract", "process", legacyAudioExtractMetricResult(result), time.Since(start))
 	}()
 
 	if !b.SupportsAsyncAudioExtract() {
@@ -293,7 +292,7 @@ func (b *Dat9Backend) ProcessAudioExtractTask(ctx context.Context, task AudioExt
 		return result, fmt.Errorf("async audio extract runtime not configured")
 	}
 	if b.monthlyLLMCostExceededCheck(ctx) {
-		metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "process_skip", "budget_exhausted", 0)
+		b.recordTenantOperation("llm_cost_budget", "process_skip", "budget_exhausted", 0)
 		result = AudioExtractResultBudgetExhausted
 		return result, nil
 	}

--- a/pkg/backend/audio_extract_test.go
+++ b/pkg/backend/audio_extract_test.go
@@ -99,7 +99,7 @@ func TestAsyncAudioExtractMetricsExposed(t *testing.T) {
 	if !strings.Contains(metricsText, "drive9_module_up{module=\"audio_extract\"} 1") {
 		t.Fatalf("metrics missing audio_extract module availability: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\",tenant_id=\"\"} 4096") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\",tenant_id=\"\",tidbcloud_org_id=\"guest\"} 4096") {
 		t.Fatalf("metrics missing audio_extract runtime gauge: %s", metricsText)
 	}
 	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"audio_extract\",operation=\"process\",result=\"ok\"}") {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -106,6 +106,7 @@ type Dat9Backend struct {
 
 	// Central quota enforcement (Rev 4 migration).
 	tenantID           string
+	tidbCloudOrgID     string
 	storageNamespaceID string
 	metaStore          MetaQuotaStore // nil when central quota is not wired (tests, fallback)
 	quotaConfigCache   *quotaConfigCache
@@ -169,6 +170,7 @@ func newBaseBackend(store *datastore.Store) *Dat9Backend {
 		entropy:             ulid.Monotonic(rand.New(rand.NewSource(time.Now().UnixNano())), 0),
 		inlineThreshold:     DefaultInlineThreshold,
 		textExtractMaxBytes: DefaultTextExtractMaxBytes,
+		tidbCloudOrgID:      defaultTenantMetricTiDBCloudOrgID,
 		runtimeMetricsID:    globalBackendRuntimeMetrics.allocateID(),
 	}
 }
@@ -250,7 +252,7 @@ func (b *Dat9Backend) Create(path string) error {
 
 func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "create", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "create", err, start) }()
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
@@ -327,7 +329,7 @@ func (b *Dat9Backend) CreateCtx(ctx context.Context, path string) (err error) {
 // payload and whose inode mode carries the POSIX symlink file type bits.
 func (b *Dat9Backend) CreateSymlinkCtx(ctx context.Context, linkPath, target string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "create_symlink", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "create_symlink", err, start) }()
 
 	data := []byte(target)
 	if target == "" || strings.ContainsRune(target, 0) || len(data) > MaxSymlinkTargetBytes {
@@ -403,7 +405,7 @@ func (b *Dat9Backend) Mkdir(path string, perm uint32) error {
 
 func (b *Dat9Backend) MkdirCtx(ctx context.Context, path string, perm uint32) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "mkdir", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "mkdir", err, start) }()
 
 	dirPath, err := pathutil.CanonicalizeDir(path)
 	if err != nil {
@@ -451,7 +453,7 @@ func (b *Dat9Backend) Chmod(path string, mode uint32) error {
 
 func (b *Dat9Backend) ChmodCtx(ctx context.Context, path string, mode uint32) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "chmod", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "chmod", err, start) }()
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
@@ -473,7 +475,7 @@ func (b *Dat9Backend) Remove(path string) error {
 
 func (b *Dat9Backend) RemoveCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "remove", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "remove", err, start) }()
 
 	path, node, err := b.resolveNodePath(ctx, path)
 	if err != nil {
@@ -494,7 +496,7 @@ func (b *Dat9Backend) RemoveCtx(ctx context.Context, path string) (err error) {
 
 func (b *Dat9Backend) RemoveFileCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "remove_file", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "remove_file", err, start) }()
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
@@ -512,7 +514,7 @@ func (b *Dat9Backend) RemoveFileCtx(ctx context.Context, path string) (err error
 
 func (b *Dat9Backend) RemoveDirCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "remove_dir", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "remove_dir", err, start) }()
 
 	path, err = pathutil.CanonicalizeDir(path)
 	if err != nil {
@@ -530,7 +532,7 @@ func (b *Dat9Backend) RemoveAll(path string) error {
 
 func (b *Dat9Backend) RemoveAllCtx(ctx context.Context, path string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "remove_all", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "remove_all", err, start) }()
 
 	path, node, err := b.resolveNodePath(ctx, path)
 	if err != nil {
@@ -559,7 +561,7 @@ func (b *Dat9Backend) Read(path string, offset int64, size int64) ([]byte, error
 
 func (b *Dat9Backend) ReadCtx(ctx context.Context, path string, offset int64, size int64) (data []byte, err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "read", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "read", err, start) }()
 
 	path, err = pathutil.Canonicalize(path)
 	if err != nil {
@@ -640,7 +642,7 @@ func (b *Dat9Backend) WriteCtxIfRevisionWithTagsResult(ctx context.Context, path
 	var statDuration time.Duration
 	var implementationDuration time.Duration
 	defer func() {
-		observeBackend(ctx, b.tenantID, "write", err, start)
+		observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "write", err, start)
 		if !timingEnabled {
 			return
 		}
@@ -1344,7 +1346,7 @@ func (b *Dat9Backend) ReadDirCtx(ctx context.Context, path string) (infos []file
 	var canonicalPath string
 	var listDuration time.Duration
 	defer func() {
-		observeBackend(ctx, b.tenantID, "read_dir", err, start)
+		observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "read_dir", err, start)
 		fields := []zap.Field{
 			zap.String("path", path),
 			zap.String("canonical_path", canonicalPath),
@@ -1539,7 +1541,7 @@ func (b *Dat9Backend) ReadPlanCtx(ctx context.Context, path string) (plan *ReadP
 	var size int64
 	phase := "canonicalize"
 	defer func() {
-		observeBackend(ctx, b.tenantID, "read_plan", err, start)
+		observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "read_plan", err, start)
 		fields := []zap.Field{
 			zap.String("path", path),
 			zap.String("phase", phase),
@@ -1620,7 +1622,7 @@ func (b *Dat9Backend) ReadPlanCtx(ctx context.Context, path string) (plan *ReadP
 // without reading or presigning object storage data.
 func (b *Dat9Backend) ReadInlinePlanCtx(ctx context.Context, path string) (plan *ReadPlan, err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "read_inline_plan", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "read_inline_plan", err, start) }()
 
 	resolvedPath, err := pathutil.Canonicalize(path)
 	if err != nil {
@@ -1695,7 +1697,7 @@ func (b *Dat9Backend) Rename(oldPath, newPath string) error {
 
 func (b *Dat9Backend) RenameCtx(ctx context.Context, oldPath, newPath string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "rename", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "rename", err, start) }()
 
 	oldPath, node, err := b.resolveNodePath(ctx, oldPath)
 	if err != nil {
@@ -1733,7 +1735,7 @@ func (b *Dat9Backend) RenameCtx(ctx context.Context, oldPath, newPath string) (e
 // if the target path already exists.
 func (b *Dat9Backend) RenameFileNoReplaceCtx(ctx context.Context, oldPath, newPath string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "rename_file_no_replace", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "rename_file_no_replace", err, start) }()
 
 	oldPath, node, err := b.resolveNodePath(ctx, oldPath)
 	if err != nil {
@@ -1794,7 +1796,7 @@ func (b *Dat9Backend) CopyFile(srcPath, dstPath string) error {
 
 func (b *Dat9Backend) CopyFileCtx(ctx context.Context, srcPath, dstPath string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "copy_file", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "copy_file", err, start) }()
 
 	srcPath, err = pathutil.Canonicalize(srcPath)
 	if err != nil {
@@ -1839,7 +1841,7 @@ func (b *Dat9Backend) HardlinkFile(srcPath, dstPath string) error {
 
 func (b *Dat9Backend) HardlinkFileCtx(ctx context.Context, srcPath, dstPath string) (err error) {
 	start := time.Now()
-	defer func() { observeBackend(ctx, b.tenantID, "hardlink_file", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "hardlink_file", err, start) }()
 
 	dstPath, err = pathutil.Canonicalize(dstPath)
 	if err != nil {
@@ -2103,7 +2105,7 @@ func extractText(data []byte, contentType string, maxBytes int64) string {
 func (b *Dat9Backend) ExecSQL(ctx context.Context, query string) ([]map[string]interface{}, error) {
 	start := time.Now()
 	rows, err := b.store.ExecSQL(ctx, query)
-	observeBackend(ctx, b.tenantID, "exec_sql", err, start)
+	observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "exec_sql", err, start)
 	if err != nil {
 		logger.Error(ctx, "backend_exec_sql_failed", zap.Int("query_len", len(query)), zap.Error(err))
 		return nil, err
@@ -2114,7 +2116,7 @@ func (b *Dat9Backend) ExecSQL(ctx context.Context, query string) ([]map[string]i
 func (b *Dat9Backend) Grep(ctx context.Context, query, pathPrefix string, limit int) ([]datastore.SearchResult, error) {
 	start := time.Now()
 	var err error
-	defer func() { observeBackend(ctx, b.tenantID, "grep", err, start) }()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "grep", err, start) }()
 
 	if strings.TrimSpace(query) == "" {
 		err = fmt.Errorf("empty query")
@@ -2262,7 +2264,7 @@ func mergeVectorResults(a, b []datastore.SearchResult) []datastore.SearchResult 
 func (b *Dat9Backend) Find(ctx context.Context, f *datastore.FindFilter) ([]datastore.SearchResult, error) {
 	start := time.Now()
 	rows, err := b.store.Find(ctx, f)
-	observeBackend(ctx, b.tenantID, "find", err, start)
+	observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "find", err, start)
 	if err != nil {
 		logger.Error(ctx, "backend_find_failed", zap.String("path", f.PathPrefix), zap.String("name", f.NameGlob), zap.Error(err))
 		return nil, err
@@ -2270,8 +2272,8 @@ func (b *Dat9Backend) Find(ctx context.Context, f *datastore.FindFilter) ([]data
 	return rows, nil
 }
 
-func observeBackend(ctx context.Context, tenantID, op string, err error, start time.Time) {
-	metrics.RecordTenantOperation(tenantID, "backend", op, backendResultForError(err), time.Since(start))
+func observeBackend(ctx context.Context, tenantID, tidbCloudOrgID, op string, err error, start time.Time) {
+	metrics.RecordTenantOperationWithOrg(tenantID, tidbCloudOrgID, "backend", op, backendResultForError(err), time.Since(start))
 }
 
 func backendResultForError(err error) string {

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -146,13 +146,13 @@ type Dat9Backend struct {
 	maxAudioExtractTextBytes int
 
 	// Durable video visual extraction (semantic_tasks only; no local queue).
-	videoExtractEnabled          bool
-	videoExtractAllTenants       bool                // "*" allowlist
-	videoExtractor               VideoTextExtractor
-	videoExtractTimeout          time.Duration
-	videoExtractMaxSize          int64
-	maxVideoExtractTextBytes     int
-	videoExtractTenantAllowlist  map[string]struct{} // nil or empty = no tenant (fail-closed)
+	videoExtractEnabled         bool
+	videoExtractAllTenants      bool // "*" allowlist
+	videoExtractor              VideoTextExtractor
+	videoExtractTimeout         time.Duration
+	videoExtractMaxSize         int64
+	maxVideoExtractTextBytes    int
+	videoExtractTenantAllowlist map[string]struct{} // nil or empty = no tenant (fail-closed)
 	maxVideoLLMFiles            int64               // per-tenant video file quota
 
 	runtimeMetricsID uint64
@@ -161,7 +161,7 @@ type Dat9Backend struct {
 	// enqueued durable work (semantic task, file_gc task, quota outbox row),
 	// so the unified tenant worker can claim it immediately instead of waiting
 	// for a kick from the outbox poller.
-	workEnqueuedNotifier atomic.Pointer[func(workMask int)]
+	workEnqueuedNotifier atomic.Pointer[func(workMask int, tidbCloudOrgID string)]
 
 	// Monthly LLM cost budget (P1).
 	maxMonthlyLLMCostMillicents     int64
@@ -187,11 +187,12 @@ func newBaseBackend(store *datastore.Store) *Dat9Backend {
 
 // SetWorkEnqueuedNotifier registers fn to run after a write or upload commit
 // that enqueues durable work (semantic task, file_gc task, or quota outbox row).
-// The workMask argument tells the caller which work types were enqueued. fn
-// must be cheap and non-blocking: it is invoked inline on the write path. A
-// dropped or missing notification is safe — work is durable and the unified
-// outbox poller + safety-net scan claim it eventually.
-func (b *Dat9Backend) SetWorkEnqueuedNotifier(fn func(workMask int)) {
+// The workMask argument tells the caller which work types were enqueued, and
+// tidbCloudOrgID carries the backend's resolved org metric label. fn must be
+// cheap and non-blocking: it is invoked inline on the write path. A dropped or
+// missing notification is safe — work is durable and the unified outbox poller
+// + safety-net scan claim it eventually.
+func (b *Dat9Backend) SetWorkEnqueuedNotifier(fn func(workMask int, tidbCloudOrgID string)) {
 	if b == nil {
 		return
 	}
@@ -203,7 +204,7 @@ func (b *Dat9Backend) notifyWorkEnqueued(workMask int) {
 		return
 	}
 	if fn := b.workEnqueuedNotifier.Load(); fn != nil && *fn != nil {
-		(*fn)(workMask)
+		(*fn)(workMask, b.TiDBCloudOrgID())
 	}
 }
 

--- a/pkg/backend/file_gc_worker.go
+++ b/pkg/backend/file_gc_worker.go
@@ -44,33 +44,32 @@ func (b *Dat9Backend) ProcessOneFileGCTask(ctx context.Context) (bool, error) {
 
 func (b *Dat9Backend) processOneFileGCTask(ctx context.Context, opts FileGCWorkerOptions) (processed bool, err error) {
 	start := time.Now()
-	tenantID := b.tenantID
 	task, found, err := b.store.ClaimFileGCTask(ctx, time.Now().UTC(), opts.LeaseDuration)
 	if err != nil {
-		metrics.RecordTenantOperation(tenantID, "file_gc", "claim", metrics.ResultForError(err), time.Since(start))
+		b.recordTenantOperation("file_gc", "claim", metrics.ResultForError(err), time.Since(start))
 		return false, err
 	}
 	if !found {
-		metrics.RecordTenantOperation(tenantID, "file_gc", "claim", "empty", time.Since(start))
+		b.recordTenantOperation("file_gc", "claim", "empty", time.Since(start))
 		return false, nil
 	}
 
 	err = b.processFileGCTask(ctx, task)
 	if err == nil {
 		if ackErr := b.store.AckFileGCTask(ctx, task.TaskID, task.Receipt); ackErr != nil {
-			metrics.RecordTenantOperation(tenantID, "file_gc", "ack", metrics.ResultForError(ackErr), time.Since(start))
+			b.recordTenantOperation("file_gc", "ack", metrics.ResultForError(ackErr), time.Since(start))
 			return true, ackErr
 		}
-		metrics.RecordTenantOperation(tenantID, "file_gc", "process", "ok", time.Since(start))
+		b.recordTenantOperation("file_gc", "process", "ok", time.Since(start))
 		return true, nil
 	}
 
 	retryAt := time.Now().UTC().Add(fileGCRetryDelay(task.AttemptCount, opts.RetryBase, opts.RetryMax))
 	if retryErr := b.store.RetryFileGCTask(ctx, task.TaskID, task.Receipt, retryAt, err.Error()); retryErr != nil {
-		metrics.RecordTenantOperation(tenantID, "file_gc", "retry", metrics.ResultForError(retryErr), time.Since(start))
+		b.recordTenantOperation("file_gc", "retry", metrics.ResultForError(retryErr), time.Since(start))
 		return true, fmt.Errorf("process file gc task %s: %w; update retry: %v", task.TaskID, err, retryErr)
 	}
-	metrics.RecordTenantOperation(tenantID, "file_gc", "process", metrics.ResultForError(err), time.Since(start))
+	b.recordTenantOperation("file_gc", "process", metrics.ResultForError(err), time.Since(start))
 	return true, err
 }
 

--- a/pkg/backend/image_extract.go
+++ b/pkg/backend/image_extract.go
@@ -13,16 +13,16 @@ import (
 	"github.com/pingcap/failpoint"
 
 	"github.com/mem9-ai/drive9/pkg/datastore"
-	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 // ImageExtractRequest is the input to a pluggable image->text extractor.
 type ImageExtractRequest struct {
-	TenantID    string
-	FileID      string
-	Path        string
-	ContentType string
-	Data        []byte
+	TenantID       string
+	TiDBCloudOrgID string
+	FileID         string
+	Path           string
+	ContentType    string
+	Data           []byte
 }
 
 // ImageTextExtractor extracts searchable text from image bytes.
@@ -95,7 +95,7 @@ func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExt
 		return ImageExtractResultRuntimeNotConfigured, fmt.Errorf("async image extract runtime not configured")
 	}
 	if b.monthlyLLMCostExceededCheck(ctx) {
-		metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "process_skip", "budget_exhausted", 0)
+		b.recordTenantOperation("llm_cost_budget", "process_skip", "budget_exhausted", 0)
 		return ImageExtractResultBudgetExhausted, nil
 	}
 
@@ -133,11 +133,12 @@ func (b *Dat9Backend) ProcessImageExtractTask(ctx context.Context, task ImageExt
 
 	taskCtx, cancel := context.WithTimeout(ctx, b.imageExtractTimeout)
 	text, imageUsage, err := b.imageExtractor.ExtractImageText(taskCtx, ImageExtractRequest{
-		TenantID:    b.tenantID,
-		FileID:      task.FileID,
-		Path:        task.Path,
-		ContentType: ct,
-		Data:        data,
+		TenantID:       b.tenantID,
+		TiDBCloudOrgID: b.tidbCloudOrgID,
+		FileID:         task.FileID,
+		Path:           task.Path,
+		ContentType:    ct,
+		Data:           data,
 	})
 	cancel()
 	if err != nil {

--- a/pkg/backend/image_extract_basic.go
+++ b/pkg/backend/image_extract_basic.go
@@ -68,7 +68,7 @@ func (e *fallbackImageTextExtractor) ExtractImageText(ctx context.Context, req I
 			zap.String("path", req.Path),
 			zap.String("content_type", req.ContentType),
 			zap.Error(err))
-		metrics.RecordTenantOperation(req.TenantID, "image_extract", "fallback", "primary_error", 0)
+		metrics.RecordTenantOperationWithOrg(req.TenantID, req.TiDBCloudOrgID, "image_extract", "fallback", "primary_error", 0)
 		return "", usage, fmt.Errorf("primary image extractor: %w", err)
 	}
 	if strings.TrimSpace(text) != "" {
@@ -77,6 +77,6 @@ func (e *fallbackImageTextExtractor) ExtractImageText(ctx context.Context, req I
 	logger.Warn(ctx, "backend_image_extract_primary_empty_use_fallback", zap.String("tenant_id", req.TenantID),
 		zap.String("file_id", req.FileID),
 		zap.String("path", req.Path))
-	metrics.RecordTenantOperation(req.TenantID, "image_extract", "fallback", "primary_empty", 0)
+	metrics.RecordTenantOperationWithOrg(req.TenantID, req.TiDBCloudOrgID, "image_extract", "fallback", "primary_empty", 0)
 	return e.fallback.ExtractImageText(ctx, req)
 }

--- a/pkg/backend/llm_usage.go
+++ b/pkg/backend/llm_usage.go
@@ -4,7 +4,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
-	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 // ImageExtractUsage reports the resource consumption of one Vision API call.
@@ -40,7 +39,7 @@ func (b *Dat9Backend) recordImageExtractUsage(taskID string, usage ImageExtractU
 				zap.String("task_type", "img_extract_text"),
 				zap.String("task_id", taskID),
 				zap.Error(err))
-			metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "usage_insert", "error", 0)
+			b.recordTenantOperation("llm_cost_budget", "usage_insert", "error", 0)
 		}
 	}
 	if err := b.syncCentralLLMCostRecord(backgroundWithTrace(), "img_extract_text", taskID, cost, totalTokens, "tokens"); err != nil {
@@ -49,7 +48,7 @@ func (b *Dat9Backend) recordImageExtractUsage(taskID string, usage ImageExtractU
 			zap.String("task_type", "img_extract_text"),
 			zap.String("task_id", taskID),
 			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "llm_cost_record", "log_error", 0)
+		b.recordTenantOperation("central_quota", "llm_cost_record", "log_error", 0)
 	}
 }
 
@@ -82,7 +81,7 @@ func (b *Dat9Backend) recordAudioExtractUsage(taskID string, usage AudioExtractU
 				zap.String("task_type", "audio_extract_text"),
 				zap.String("task_id", taskID),
 				zap.Error(err))
-			metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "usage_insert", "error", 0)
+			b.recordTenantOperation("llm_cost_budget", "usage_insert", "error", 0)
 		}
 	}
 	if err := b.syncCentralLLMCostRecord(backgroundWithTrace(), "audio_extract_text", taskID, cost, rawUnits, rawUnitType); err != nil {
@@ -91,7 +90,7 @@ func (b *Dat9Backend) recordAudioExtractUsage(taskID string, usage AudioExtractU
 			zap.String("task_type", "audio_extract_text"),
 			zap.String("task_id", taskID),
 			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "llm_cost_record", "log_error", 0)
+		b.recordTenantOperation("central_quota", "llm_cost_record", "log_error", 0)
 	}
 }
 
@@ -130,7 +129,7 @@ func (b *Dat9Backend) monthlyLLMCostExceeded() bool {
 	total, err := b.store.MonthlyLLMCostMillicents()
 	if err != nil {
 		logger.Warn(backgroundWithTrace(), "llm_cost_budget_check_fail_open", zap.String("tenant_id", b.tenantID), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "llm_cost_budget", "quota_check", "fail_open", 0)
+		b.recordTenantOperation("llm_cost_budget", "quota_check", "fail_open", 0)
 		return false
 	}
 	return total > b.maxMonthlyLLMCostMillicents

--- a/pkg/backend/mutation_replay.go
+++ b/pkg/backend/mutation_replay.go
@@ -64,7 +64,7 @@ type MutationReplayWorker struct {
 	store                  MetaQuotaStore
 	cancel                 context.CancelFunc
 	done                   chan struct{}
-	observedBacklogTenants map[string]struct{}
+	observedBacklogTenants map[string]string
 	lastBacklogObservation time.Time
 }
 
@@ -79,7 +79,7 @@ func StartMutationReplayWorker(store MetaQuotaStore) *MutationReplayWorker {
 		store:                  store,
 		cancel:                 cancel,
 		done:                   make(chan struct{}),
-		observedBacklogTenants: make(map[string]struct{}),
+		observedBacklogTenants: make(map[string]string),
 	}
 	go w.run(ctx)
 	return w
@@ -176,11 +176,11 @@ func (w *MutationReplayWorker) replayBatch(ctx context.Context) (fatal bool) {
 					zap.Int64("log_id", entry.ID),
 					zap.Error(rErr))
 			}
-			metrics.RecordTenantOperationCount(entry.TenantID, "mutation_replay", entry.MutationType, metrics.ResultForError(err))
+			metrics.RecordTenantOperationCountWithOrg(entry.TenantID, entry.TiDBCloudOrgID, "mutation_replay", entry.MutationType, metrics.ResultForError(err))
 			blockedTenants[entry.TenantID] = struct{}{}
 			failed++
 		} else {
-			metrics.RecordTenantOperationCount(entry.TenantID, "mutation_replay", entry.MutationType, "ok")
+			metrics.RecordTenantOperationCountWithOrg(entry.TenantID, entry.TiDBCloudOrgID, "mutation_replay", entry.MutationType, "ok")
 			applied++
 		}
 	}
@@ -209,7 +209,7 @@ func (w *MutationReplayWorker) recordPendingBacklogIfDue(ctx context.Context) {
 
 func (w *MutationReplayWorker) recordPendingBacklog(ctx context.Context) {
 	if w.observedBacklogTenants == nil {
-		w.observedBacklogTenants = make(map[string]struct{})
+		w.observedBacklogTenants = make(map[string]string)
 	}
 	w.lastBacklogObservation = time.Now()
 	start := time.Now()
@@ -219,28 +219,29 @@ func (w *MutationReplayWorker) recordPendingBacklog(ctx context.Context) {
 		metrics.RecordOperation("mutation_replay", "observe_pending", metrics.ResultForError(err), time.Since(start))
 		return
 	}
-	current := make(map[string]struct{}, len(observations))
+	current := make(map[string]string, len(observations))
 	for _, obs := range observations {
-		current[obs.TenantID] = struct{}{}
-		w.observedBacklogTenants[obs.TenantID] = struct{}{}
-		metrics.RecordTenantGauge(obs.TenantID, "mutation_replay", "pending_mutations", float64(obs.PendingCount))
-		metrics.RecordTenantGauge(obs.TenantID, "mutation_replay", "oldest_pending_age_seconds", obs.OldestPendingAgeSeconds)
+		orgID := normalizeTenantMetricTiDBCloudOrgID(obs.TiDBCloudOrgID)
+		current[obs.TenantID] = orgID
+		w.observedBacklogTenants[obs.TenantID] = orgID
+		metrics.RecordTenantGaugeWithOrg(obs.TenantID, orgID, "mutation_replay", "pending_mutations", float64(obs.PendingCount))
+		metrics.RecordTenantGaugeWithOrg(obs.TenantID, orgID, "mutation_replay", "oldest_pending_age_seconds", obs.OldestPendingAgeSeconds)
 	}
-	for tenantID := range w.observedBacklogTenants {
+	for tenantID, orgID := range w.observedBacklogTenants {
 		if _, ok := current[tenantID]; ok {
 			continue
 		}
-		metrics.RecordTenantGauge(tenantID, "mutation_replay", "pending_mutations", 0)
-		metrics.RecordTenantGauge(tenantID, "mutation_replay", "oldest_pending_age_seconds", 0)
+		metrics.RecordTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "pending_mutations", 0)
+		metrics.RecordTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "oldest_pending_age_seconds", 0)
 		delete(w.observedBacklogTenants, tenantID)
 	}
 	metrics.RecordOperation("mutation_replay", "observe_pending", "ok", time.Since(start))
 }
 
 func (w *MutationReplayWorker) clearPendingBacklogGauges() {
-	for tenantID := range w.observedBacklogTenants {
-		metrics.RecordTenantGauge(tenantID, "mutation_replay", "pending_mutations", 0)
-		metrics.RecordTenantGauge(tenantID, "mutation_replay", "oldest_pending_age_seconds", 0)
+	for tenantID, orgID := range w.observedBacklogTenants {
+		metrics.RecordTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "pending_mutations", 0)
+		metrics.RecordTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "oldest_pending_age_seconds", 0)
 		delete(w.observedBacklogTenants, tenantID)
 	}
 }

--- a/pkg/backend/mutation_replay_metrics_test.go
+++ b/pkg/backend/mutation_replay_metrics_test.go
@@ -21,10 +21,10 @@ func TestMutationReplayWorkerRecordsPendingBacklogGauges(t *testing.T) {
 	w.recordPendingBacklog(context.Background())
 
 	metricsText := readBackendMetrics()
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-backlog"} 2`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-backlog",tidbcloud_org_id="guest"} 2`) {
 		t.Errorf("metrics missing pending mutation backlog gauge: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-backlog"}`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-backlog",tidbcloud_org_id="guest"}`) {
 		t.Errorf("metrics missing oldest pending age gauge: %s", metricsText)
 	}
 
@@ -35,18 +35,18 @@ func TestMutationReplayWorkerRecordsPendingBacklogGauges(t *testing.T) {
 	w.recordPendingBacklog(context.Background())
 
 	metricsText = readBackendMetrics()
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-backlog"} 0`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-backlog",tidbcloud_org_id="guest"} 0`) {
 		t.Errorf("metrics did not clear pending mutation backlog gauge: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-backlog"} 0`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-backlog",tidbcloud_org_id="guest"} 0`) {
 		t.Errorf("metrics did not clear oldest pending age gauge: %s", metricsText)
 	}
 }
 
 func TestMutationReplayWorkerClearsPendingBacklogGaugesOnStop(t *testing.T) {
 	w := &MutationReplayWorker{
-		observedBacklogTenants: map[string]struct{}{
-			"tenant-stop": {},
+		observedBacklogTenants: map[string]string{
+			"tenant-stop": "guest",
 		},
 	}
 	metrics.RecordTenantGauge("tenant-stop", "mutation_replay", "pending_mutations", 3)
@@ -55,10 +55,10 @@ func TestMutationReplayWorkerClearsPendingBacklogGaugesOnStop(t *testing.T) {
 	w.clearPendingBacklogGauges()
 
 	metricsText := readBackendMetrics()
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-stop"} 0`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-stop",tidbcloud_org_id="guest"} 0`) {
 		t.Errorf("metrics did not clear pending mutation backlog gauge on stop: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-stop"} 0`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-stop",tidbcloud_org_id="guest"} 0`) {
 		t.Errorf("metrics did not clear oldest pending age gauge on stop: %s", metricsText)
 	}
 	if len(w.observedBacklogTenants) != 0 {
@@ -99,8 +99,8 @@ func TestMutationReplayWorkerRunDoesNotClearPendingBacklogGaugesOnFatalExit(t *t
 	w := &MutationReplayWorker{
 		store: store,
 		done:  make(chan struct{}),
-		observedBacklogTenants: map[string]struct{}{
-			"tenant-fatal-run": {},
+		observedBacklogTenants: map[string]string{
+			"tenant-fatal-run": "guest",
 		},
 	}
 	metrics.RecordTenantGauge("tenant-fatal-run", "mutation_replay", "pending_mutations", 5)
@@ -109,10 +109,10 @@ func TestMutationReplayWorkerRunDoesNotClearPendingBacklogGaugesOnFatalExit(t *t
 	w.run(context.Background())
 
 	metricsText := readBackendMetrics()
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-fatal-run"} 5`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-fatal-run",tidbcloud_org_id="guest"} 5`) {
 		t.Errorf("fatal run should keep pending mutation backlog gauge: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-fatal-run"} 13`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-fatal-run",tidbcloud_org_id="guest"} 13`) {
 		t.Errorf("fatal run should keep oldest pending age gauge: %s", metricsText)
 	}
 }

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -69,6 +69,9 @@ type Options struct {
 	LLMCostBudget LLMCostBudgetOptions
 	// TenantID is used for per-write S3 encryption context and audit metadata.
 	TenantID string
+	// TiDBCloudOrgID is used only as the tidbcloud_org_id label on tenant
+	// metrics. Empty means "guest".
+	TiDBCloudOrgID string
 	// StorageNamespaceID is the control-plane namespace for S3 object lifecycle.
 	StorageNamespaceID string
 	// S3EncryptionPolicy is the already-resolved policy for this backend.
@@ -163,6 +166,7 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 	if opts.TenantID != "" {
 		b.tenantID = opts.TenantID
 	}
+	b.tidbCloudOrgID = normalizeTenantMetricTiDBCloudOrgID(opts.TiDBCloudOrgID)
 	if opts.StorageNamespaceID != "" {
 		b.storageNamespaceID = opts.StorageNamespaceID
 	}

--- a/pkg/backend/patch.go
+++ b/pkg/backend/patch.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/datastore"
 	"github.com/mem9-ai/drive9/pkg/logger"
-	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/pathutil"
 	"github.com/mem9-ai/drive9/pkg/s3client"
 	"go.uber.org/zap"
@@ -148,44 +147,44 @@ func appendDirtyPartNumbers(baseSize int64, newSize int64, partSize int64) []int
 func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path string, newSize int64, dirtyParts []int, clientPartSize int64, expectedRevision int64) (*PatchPlan, error) {
 	start := time.Now()
 	if err := b.ensureUploadSizeAllowed(newSize); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if err := b.ensureFileSizeQuota(ctx, newSize); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}
 
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if err := rejectRootFileNodePath(path); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if b.s3 == nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, ErrS3NotConfigured
 	}
 
 	// Look up existing file to get its S3 key
 	nf, err := b.store.Stat(ctx, path)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("stat existing file: %w", err)
 	}
 	if nf.File == nil || nf.File.StorageType != datastore.StorageS3 {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("%w: %s", ErrNotS3Stored, path)
 	}
 	if expectedRevision == 0 {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "conflict", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "conflict", time.Since(start))
 		return nil, datastore.ErrRevisionConflict
 	}
 	if expectedRevision > 0 && nf.File.Revision != expectedRevision {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "conflict", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "conflict", time.Since(start))
 		return nil, datastore.ErrRevisionConflict
 	}
 
@@ -200,12 +199,12 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 		partSize = s3client.PartSize
 	}
 	if partSize > s3client.MaxPartSize {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("part_size %d exceeds S3 per-part limit of %d", partSize, s3client.MaxPartSize)
 	}
 	newParts := s3client.CalcParts(newSize, partSize)
 	if len(newParts) > MaxMultipartParts {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("part_size %d produces %d parts for size %d, exceeds S3 limit of %d", partSize, len(newParts), newSize, MaxMultipartParts)
 	}
 
@@ -221,7 +220,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 	mpu, err := b.s3.CreateMultipartUpload(ctx, newS3Key, s3client.ChecksumAlgoNone, encOpts)
 	if err != nil {
 		logger.Error(ctx, "backend_patch_upload_create_mpu_failed", zap.String("tenant_id", b.tenantID), zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 
@@ -257,7 +256,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 			if err != nil {
 				_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
 				logger.Error(ctx, "backend_patch_upload_copy_failed", zap.String("tenant_id", b.tenantID), zap.String("path", path), zap.Int("part", p.Number), zap.Error(err))
-				metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+				b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 				return nil, fmt.Errorf("copy part %d: %w", p.Number, err)
 			}
 			plan.CopiedParts = append(plan.CopiedParts, p.Number)
@@ -267,7 +266,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 			if err != nil {
 				_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
 				logger.Error(ctx, "backend_patch_upload_presign_failed", zap.String("tenant_id", b.tenantID), zap.String("path", path), zap.Int("part", p.Number), zap.Error(err))
-				metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+				b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 				return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
 			}
 
@@ -314,7 +313,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 	reserved, err := b.reserveUploadOnServer(ctx, uploadID, path, newSize, 0)
 	if err != nil {
 		_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "quota_exceeded", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "quota_exceeded", time.Since(start))
 		return nil, err
 	}
 
@@ -328,7 +327,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 			b.abortUploadReservation(ctx, uploadID, newSize)
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("lookup active upload for %s: %w", path, err)
 	}
 	if existing != nil {
@@ -337,7 +336,7 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 				b.abortUploadReservation(ctx, uploadID, newSize)
 			}
 			_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
-			metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+			b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 			return nil, fmt.Errorf("supersede active upload for %s: %w", path, err)
 		}
 	}
@@ -384,12 +383,12 @@ func (b *Dat9Backend) InitiatePatchUploadIfRevision(ctx context.Context, path st
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, newS3Key, mpu.UploadID)
 		logger.Error(ctx, "backend_patch_upload_insert_upload_failed", zap.String("tenant_id", b.tenantID), zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "patch_upload", "error", time.Since(start))
 		return nil, err
 	}
 
 	plan.UploadID = uploadID
-	metrics.RecordTenantOperation(b.tenantID, "backend", "patch_upload", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "patch_upload", "ok", time.Since(start))
 
 	logger.Info(ctx, "backend_patch_upload_initiated", zap.String("tenant_id", b.tenantID),
 		zap.String("path", path),

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -378,13 +378,13 @@ func (b *Dat9Backend) mediaLLMQuotaExceededTx(tx *sql.Tx) bool {
 // video extraction quota. Counts every video_extract_visual task row (any
 // status) — each Vision API call consumes one unit, including re-extractions
 // of the same file.
-func (b *Dat9Backend) videoLLMQuotaExceededTx(tx *sql.Tx) bool {
+func (b *Dat9Backend) videoLLMQuotaExceededTx(ctx context.Context, tx *sql.Tx) bool {
 	if b.maxVideoLLMFiles <= 0 {
 		return false
 	}
 	var count int64
-	if err := tx.QueryRow(`SELECT COUNT(*) FROM semantic_tasks WHERE task_type = 'video_extract_visual'`).Scan(&count); err != nil {
-		logger.Warn(backgroundWithTrace(), "video_llm_quota_check_fail_open", zap.Error(err))
+	if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM semantic_tasks WHERE task_type = 'video_extract_visual'`).Scan(&count); err != nil {
+		logger.Warn(ctx, "video_llm_quota_check_fail_open", zap.Error(err))
 		return false
 	}
 	return count >= b.maxVideoLLMFiles

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -94,7 +94,7 @@ func (b *Dat9Backend) monthlyLLMCostExceededServer(ctx context.Context) bool {
 	if err != nil {
 		logger.Warn(ctx, "server_llm_cost_check_fail_open",
 			zap.String("tenant_id", b.tenantID), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "llm_cost_check", "fail_open", time.Since(start))
+		b.recordTenantOperation("server_quota", "llm_cost_check", "fail_open", time.Since(start))
 		return false // fail-open
 	}
 	// Use per-tenant config if available, otherwise fall back to global default.
@@ -124,17 +124,17 @@ func (b *Dat9Backend) ensureFileSizeQuota(ctx context.Context, size int64) error
 	}
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_size_check", "fail_open", 0)
+		b.recordTenantOperation("server_quota", "file_size_check", "fail_open", 0)
 		return nil
 	}
 	if cfg.MaxFileSizeBytes <= 0 {
 		return nil
 	}
 	if size > cfg.MaxFileSizeBytes {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_size_check", "exceeded", 0)
+		b.recordTenantOperation("server_quota", "file_size_check", "exceeded", 0)
 		return fmt.Errorf("%w: server limit=%d requested=%d", ErrFileSizeQuotaExceeded, cfg.MaxFileSizeBytes, size)
 	}
-	metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_size_check", "ok", 0)
+	b.recordTenantOperation("server_quota", "file_size_check", "ok", 0)
 	return nil
 }
 
@@ -154,10 +154,10 @@ func (b *Dat9Backend) ensureStorageQuotaServer(ctx context.Context, tx *sql.Tx, 
 		return nil
 	}
 	if result.exceeded() {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "storage_check", "exceeded", 0)
+		b.recordTenantOperation("server_quota", "storage_check", "exceeded", 0)
 		return result.quotaExceededError()
 	}
-	metrics.RecordTenantOperation(b.tenantID, "server_quota", "storage_check", "ok", 0)
+	b.recordTenantOperation("server_quota", "storage_check", "ok", 0)
 	return nil
 }
 
@@ -171,7 +171,7 @@ func (b *Dat9Backend) ensureFileCountQuotaServer(ctx context.Context, tx *sql.Tx
 	}
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check", "fail_open", 0)
+		b.recordTenantOperation("server_quota", "file_count_check", "fail_open", 0)
 		return nil
 	}
 	if cfg.MaxFileCount <= 0 {
@@ -179,18 +179,18 @@ func (b *Dat9Backend) ensureFileCountQuotaServer(ctx context.Context, tx *sql.Tx
 	}
 	usage := b.cachedQuotaUsage(ctx)
 	if usage == nil {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check", "fail_open", 0)
+		b.recordTenantOperation("server_quota", "file_count_check", "fail_open", 0)
 		return nil
 	}
-	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
+	recordTenantQuotaSnapshot(b.tenantID, b.tidbCloudOrgID, usage, cfg)
 	_, pendingFileDelta, _ := b.pendingCentralMutationDeltas(ctx)
 	projected := usage.FileCount + pendingFileDelta + currentFileDelta
 	if projected > cfg.MaxFileCount {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check", "exceeded", 0)
+		b.recordTenantOperation("server_quota", "file_count_check", "exceeded", 0)
 		return fmt.Errorf("%w: server limit=%d used=%d pending=%d delta=%d",
 			ErrFileCountQuotaExceeded, cfg.MaxFileCount, usage.FileCount, pendingFileDelta, currentFileDelta)
 	}
-	metrics.RecordTenantOperation(b.tenantID, "server_quota", "file_count_check", "ok", 0)
+	b.recordTenantOperation("server_quota", "file_count_check", "ok", 0)
 	return nil
 }
 
@@ -202,7 +202,7 @@ func (b *Dat9Backend) checkStorageQuotaServerTx(ctx context.Context, tx *sql.Tx,
 
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "storage_check", "fail_open", 0)
+		b.recordTenantOperation("server_quota", "storage_check", "fail_open", 0)
 		return result, false // fail-open: config unavailable
 	}
 	if cfg.MaxStorageBytes <= 0 {
@@ -210,10 +210,10 @@ func (b *Dat9Backend) checkStorageQuotaServerTx(ctx context.Context, tx *sql.Tx,
 	}
 	usage := b.cachedQuotaUsage(ctx)
 	if usage == nil {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "storage_check", "fail_open", 0)
+		b.recordTenantOperation("server_quota", "storage_check", "fail_open", 0)
 		return result, false // fail-open: usage unavailable
 	}
-	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
+	recordTenantQuotaSnapshot(b.tenantID, b.tidbCloudOrgID, usage, cfg)
 	pendingStorageDelta, _, _ := b.pendingCentralMutationDeltas(ctx)
 	result.checked = true
 	result.limitBytes = cfg.MaxStorageBytes
@@ -270,21 +270,21 @@ func (b *Dat9Backend) cachedQuotaUsage(ctx context.Context) *QuotaUsageView {
 
 // --- Server-side media file count (Rev 4 migration) ---
 
-func recordTenantQuotaSnapshot(tenantID string, usage *QuotaUsageView, cfg *QuotaConfigView) {
+func recordTenantQuotaSnapshot(tenantID, tidbCloudOrgID string, usage *QuotaUsageView, cfg *QuotaConfigView) {
 	if tenantID == "" || usage == nil {
 		return
 	}
-	metrics.RecordTenantStorageBytes(tenantID, "confirmed", usage.StorageBytes)
-	metrics.RecordTenantStorageBytes(tenantID, "reserved", usage.ReservedBytes)
-	metrics.RecordTenantMediaFiles(tenantID, "confirmed", usage.MediaFileCount)
+	metrics.RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, "confirmed", usage.StorageBytes)
+	metrics.RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, "reserved", usage.ReservedBytes)
+	metrics.RecordTenantMediaFilesWithOrg(tenantID, tidbCloudOrgID, "confirmed", usage.MediaFileCount)
 	if cfg == nil {
 		return
 	}
 	if cfg.MaxStorageBytes > 0 {
-		metrics.RecordTenantStorageBytes(tenantID, "limit", cfg.MaxStorageBytes)
+		metrics.RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, "limit", cfg.MaxStorageBytes)
 	}
 	if cfg.MaxMediaLLMFiles > 0 {
-		metrics.RecordTenantMediaFiles(tenantID, "limit", cfg.MaxMediaLLMFiles)
+		metrics.RecordTenantMediaFilesWithOrg(tenantID, tidbCloudOrgID, "limit", cfg.MaxMediaLLMFiles)
 	}
 }
 
@@ -305,7 +305,7 @@ func quotaMediaDelta(oldIsMedia, newIsMedia bool) int64 {
 func (b *Dat9Backend) mediaLLMQuotaExceededServerTx(ctx context.Context, tx *sql.Tx, currentMediaDelta int64) bool {
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "media_check", "fail_open", 0)
+		b.recordTenantOperation("server_quota", "media_check", "fail_open", 0)
 		return false
 	}
 	if cfg.MaxMediaLLMFiles <= 0 {
@@ -313,10 +313,10 @@ func (b *Dat9Backend) mediaLLMQuotaExceededServerTx(ctx context.Context, tx *sql
 	}
 	usage := b.cachedQuotaUsage(ctx)
 	if usage == nil {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "media_check", "fail_open", 0)
+		b.recordTenantOperation("server_quota", "media_check", "fail_open", 0)
 		return false
 	}
-	recordTenantQuotaSnapshot(b.tenantID, usage, cfg)
+	recordTenantQuotaSnapshot(b.tenantID, b.tidbCloudOrgID, usage, cfg)
 	_, _, pendingMediaDelta := b.pendingCentralMutationDeltas(ctx)
 	return usage.MediaFileCount+pendingMediaDelta+currentMediaDelta > cfg.MaxMediaLLMFiles
 }
@@ -368,7 +368,7 @@ func (b *Dat9Backend) mediaLLMQuotaExceededTx(tx *sql.Tx) bool {
 	count, err := b.store.ConfirmedMediaFileCountTx(tx)
 	if err != nil {
 		logger.Warn(backgroundWithTrace(), "media_llm_quota_check_fail_open", zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "media_llm_budget", "quota_check", "fail_open", 0)
+		b.recordTenantOperation("media_llm_budget", "quota_check", "fail_open", 0)
 		return false
 	}
 	return count > b.maxMediaLLMFiles

--- a/pkg/backend/quota_cache.go
+++ b/pkg/backend/quota_cache.go
@@ -77,8 +77,9 @@ func cloneQuotaConfigView(cfg *QuotaConfigView) *QuotaConfigView {
 // only removes repeated config reads and uses version polling so config changes
 // converge without a cross-server invalidation channel.
 type quotaConfigCache struct {
-	tenantID string
-	store    MetaQuotaStore
+	tenantID       string
+	tidbCloudOrgID string
+	store          MetaQuotaStore
 
 	mu       sync.RWMutex
 	snapshot *quotaConfigSnapshot
@@ -92,13 +93,14 @@ type quotaConfigCache struct {
 // Backend construction must stay cheap for read-only operations such as ls, so
 // the initial load is lazy: the first quota check loads config on demand and
 // the background refresher keeps it current after that.
-func newQuotaConfigCache(tenantID string, store MetaQuotaStore) *quotaConfigCache {
+func newQuotaConfigCache(tenantID, tidbCloudOrgID string, store MetaQuotaStore) *quotaConfigCache {
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &quotaConfigCache{
-		tenantID: tenantID,
-		store:    store,
-		cancel:   cancel,
-		done:     make(chan struct{}),
+		tenantID:       tenantID,
+		tidbCloudOrgID: normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID),
+		store:          store,
+		cancel:         cancel,
+		done:           make(chan struct{}),
 	}
 	go c.run(ctx)
 	return c
@@ -130,23 +132,23 @@ func (c *quotaConfigCache) load(ctx context.Context) *QuotaConfigView {
 	if err != nil {
 		logger.Warn(ctx, "quota_config_cache_config_failed",
 			zap.String("tenant_id", c.tenantID), zap.Error(err))
-		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "load", "config_error", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "quota_config_cache", "load", "config_error", time.Since(start))
 		return nil
 	}
 	if cfg == nil {
-		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "load", "config_empty", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "quota_config_cache", "load", "config_empty", time.Since(start))
 		return nil
 	}
 	c.mu.Lock()
 	if c.snapshot != nil && c.snapshot.config != nil {
 		existing := cloneQuotaConfigView(c.snapshot.config)
 		c.mu.Unlock()
-		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "load", "raced_refresh", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "quota_config_cache", "load", "raced_refresh", time.Since(start))
 		return existing
 	}
 	c.snapshot = &quotaConfigSnapshot{config: cloneQuotaConfigView(cfg), version: ""}
 	c.mu.Unlock()
-	metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "load", "ok", time.Since(start))
+	metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "quota_config_cache", "load", "ok", time.Since(start))
 	return cloneQuotaConfigView(cfg)
 }
 
@@ -175,7 +177,7 @@ func (c *quotaConfigCache) refresh(ctx context.Context) {
 	if err != nil {
 		logger.Warn(ctx, "quota_config_cache_version_failed",
 			zap.String("tenant_id", c.tenantID), zap.Error(err))
-		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "refresh", "version_error", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "quota_config_cache", "refresh", "version_error", time.Since(start))
 		return
 	}
 
@@ -183,7 +185,7 @@ func (c *quotaConfigCache) refresh(ctx context.Context) {
 	snapshot := c.snapshot
 	if snapshot != nil && snapshot.version == version {
 		c.mu.RUnlock()
-		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "refresh", "unchanged", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "quota_config_cache", "refresh", "unchanged", time.Since(start))
 		return
 	}
 	c.mu.RUnlock()
@@ -192,13 +194,13 @@ func (c *quotaConfigCache) refresh(ctx context.Context) {
 	if err != nil {
 		logger.Warn(ctx, "quota_config_cache_config_failed",
 			zap.String("tenant_id", c.tenantID), zap.Error(err))
-		metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "refresh", "config_error", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "quota_config_cache", "refresh", "config_error", time.Since(start))
 		return
 	}
 	c.mu.Lock()
 	c.snapshot = &quotaConfigSnapshot{config: cloneQuotaConfigView(cfg), version: version}
 	c.mu.Unlock()
-	metrics.RecordTenantOperation(c.tenantID, "quota_config_cache", "refresh", "ok", time.Since(start))
+	metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "quota_config_cache", "refresh", "ok", time.Since(start))
 }
 
 type quotaUsageSnapshot struct {
@@ -212,20 +214,21 @@ type quotaUsageSnapshot struct {
 // usage snapshot that is stale by at most ttl; strict upload reservations must
 // continue to call loadQuotaUsage directly.
 type quotaUsageCache struct {
-	tenantID string
-	store    MetaQuotaStore
-	ttl      time.Duration
+	tenantID       string
+	tidbCloudOrgID string
+	store          MetaQuotaStore
+	ttl            time.Duration
 
 	mu       sync.RWMutex
 	snapshot *quotaUsageSnapshot
 	loadMu   sync.Mutex
 }
 
-func newQuotaUsageCache(tenantID string, store MetaQuotaStore, ttl time.Duration) *quotaUsageCache {
+func newQuotaUsageCache(tenantID, tidbCloudOrgID string, store MetaQuotaStore, ttl time.Duration) *quotaUsageCache {
 	if ttl <= 0 {
 		ttl = quotaUsageCacheTTL
 	}
-	return &quotaUsageCache{tenantID: tenantID, store: store, ttl: ttl}
+	return &quotaUsageCache{tenantID: tenantID, tidbCloudOrgID: normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID), store: store, ttl: ttl}
 }
 
 func (c *quotaUsageCache) get(ctx context.Context) *QuotaUsageView {
@@ -246,11 +249,11 @@ func (c *quotaUsageCache) get(ctx context.Context) *QuotaUsageView {
 	if err != nil {
 		logger.Warn(ctx, "server_quota_usage_fail_open",
 			zap.String("tenant_id", c.tenantID), zap.Error(err))
-		metrics.RecordTenantOperation(c.tenantID, "server_quota", "usage_cache", "load_error", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "server_quota", "usage_cache", "load_error", time.Since(start))
 		return nil
 	}
 	if usage == nil {
-		metrics.RecordTenantOperation(c.tenantID, "server_quota", "usage_cache", "load_empty", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "server_quota", "usage_cache", "load_empty", time.Since(start))
 		return nil
 	}
 	copied := *usage
@@ -260,7 +263,7 @@ func (c *quotaUsageCache) get(ctx context.Context) *QuotaUsageView {
 		expiresAt: time.Now().Add(c.ttl),
 	}
 	c.mu.Unlock()
-	metrics.RecordTenantOperation(c.tenantID, "server_quota", "usage_cache", "load_ok", time.Since(start))
+	metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "server_quota", "usage_cache", "load_ok", time.Since(start))
 	return cloneQuotaUsageView(usage)
 }
 
@@ -312,10 +315,11 @@ type quotaPendingDeltasLoader func(context.Context) (storageDelta, fileDelta, me
 // have been logged but not yet applied. It deliberately has no tenant-DB
 // fallback: runtime quota admission must not SUM quota_outbox from the user DB.
 type quotaPendingDeltasCache struct {
-	tenantID   string
-	load       quotaPendingDeltasLoader
-	ttl        time.Duration
-	pendingTTL time.Duration
+	tenantID       string
+	tidbCloudOrgID string
+	load           quotaPendingDeltasLoader
+	ttl            time.Duration
+	pendingTTL     time.Duration
 
 	mu                  sync.RWMutex
 	snapshot            *quotaPendingDeltasSnapshot
@@ -326,11 +330,11 @@ type quotaPendingDeltasCache struct {
 	loadMu              sync.Mutex
 }
 
-func newQuotaPendingDeltasCache(tenantID string, load quotaPendingDeltasLoader, ttl time.Duration) *quotaPendingDeltasCache {
+func newQuotaPendingDeltasCache(tenantID, tidbCloudOrgID string, load quotaPendingDeltasLoader, ttl time.Duration) *quotaPendingDeltasCache {
 	if ttl <= 0 {
 		ttl = quotaPendingDeltasCacheTTL
 	}
-	return &quotaPendingDeltasCache{tenantID: tenantID, load: load, ttl: ttl, pendingTTL: localPendingMutationTTL()}
+	return &quotaPendingDeltasCache{tenantID: tenantID, tidbCloudOrgID: normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID), load: load, ttl: ttl, pendingTTL: localPendingMutationTTL()}
 }
 
 func localPendingMutationTTL() time.Duration {
@@ -377,7 +381,7 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 	storageDelta, fileDelta, mediaDelta, err := c.load(ctx)
 	if err != nil {
 		logger.Warn(ctx, "server_quota_pending_outbox_delta_fail_open", zap.String("tenant_id", c.tenantID), zap.Error(err))
-		metrics.RecordTenantOperation(c.tenantID, "server_quota", "pending_delta_cache", "load_error", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "server_quota", "pending_delta_cache", "load_error", time.Since(start))
 		return quotaPendingDeltas{}, false
 	}
 	deltas := quotaPendingDeltas{
@@ -397,7 +401,7 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 		// A local mutation raced this DB load. This legacy loader path is kept
 		// only for tests; runtime central quota uses in-memory deltas with no
 		// tenant DB read.
-		metrics.RecordTenantOperation(c.tenantID, "server_quota", "pending_delta_cache", "raced_local_delta", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "server_quota", "pending_delta_cache", "raced_local_delta", time.Since(start))
 		return deltas, true
 	}
 	c.snapshot = &quotaPendingDeltasSnapshot{
@@ -405,7 +409,7 @@ func (c *quotaPendingDeltasCache) get(ctx context.Context) (quotaPendingDeltas, 
 		expiresAt: expiresAt,
 	}
 	c.mu.Unlock()
-	metrics.RecordTenantOperation(c.tenantID, "server_quota", "pending_delta_cache", "load_ok", time.Since(start))
+	metrics.RecordTenantOperationWithOrg(c.tenantID, c.tidbCloudOrgID, "server_quota", "pending_delta_cache", "load_ok", time.Since(start))
 	return deltas, true
 }
 

--- a/pkg/backend/quota_cache_test.go
+++ b/pkg/backend/quota_cache_test.go
@@ -54,7 +54,7 @@ func (m *cacheTestStore) GetQuotaConfigVersion(ctx context.Context, tenantID str
 func TestQuotaConfigCacheLazyLoad(t *testing.T) {
 	store := newCacheTestStore()
 	store.config["t1"] = &QuotaConfigView{MaxStorageBytes: 1000}
-	c := newQuotaConfigCache("t1", store)
+	c := newQuotaConfigCache("t1", "", store)
 	defer c.stop()
 
 	cfg := c.get()
@@ -89,7 +89,7 @@ func TestQuotaConfigCacheLazyLoad(t *testing.T) {
 func TestQuotaConfigCacheRefreshFailOpenOnVersionError(t *testing.T) {
 	store := newCacheTestStore()
 	store.versionErr = context.DeadlineExceeded
-	c := newQuotaConfigCache("t1", store)
+	c := newQuotaConfigCache("t1", "", store)
 	defer c.stop()
 
 	c.refresh(context.Background())
@@ -110,7 +110,7 @@ func TestQuotaConfigCacheRefreshFailOpenOnVersionError(t *testing.T) {
 func TestQuotaConfigCacheRefreshOnlyLoadsConfigWhenVersionChanges(t *testing.T) {
 	store := newCacheTestStore()
 	store.config["t1"] = &QuotaConfigView{MaxStorageBytes: 1000}
-	c := newQuotaConfigCache("t1", store)
+	c := newQuotaConfigCache("t1", "", store)
 	defer c.stop()
 
 	c.refresh(context.Background())
@@ -155,7 +155,7 @@ func TestQuotaConfigCacheRefreshOnlyLoadsConfigWhenVersionChanges(t *testing.T) 
 func TestQuotaConfigCacheLazyLoadDoesNotOverwriteRefreshedSnapshot(t *testing.T) {
 	store := newCacheTestStore()
 	store.config["t1"] = &QuotaConfigView{MaxStorageBytes: 1000}
-	c := newQuotaConfigCache("t1", store)
+	c := newQuotaConfigCache("t1", "", store)
 	defer c.stop()
 
 	store.configHook = func() {
@@ -183,7 +183,7 @@ func TestQuotaConfigCacheLazyLoadDoesNotOverwriteRefreshedSnapshot(t *testing.T)
 func TestQuotaConfigCacheLazyLoadReturnsDefensiveCopy(t *testing.T) {
 	store := newCacheTestStore()
 	store.config["t1"] = &QuotaConfigView{MaxStorageBytes: 1000}
-	c := newQuotaConfigCache("t1", store)
+	c := newQuotaConfigCache("t1", "", store)
 	defer c.stop()
 
 	cfg := c.load(context.Background())
@@ -204,7 +204,7 @@ func TestQuotaConfigCacheLazyLoadReturnsDefensiveCopy(t *testing.T) {
 func TestQuotaUsageCacheUsesTTL(t *testing.T) {
 	store := newCacheTestStore()
 	store.usage["t1"] = &QuotaUsageView{TenantID: "t1", StorageBytes: 10}
-	c := newQuotaUsageCache("t1", store, time.Hour)
+	c := newQuotaUsageCache("t1", "", store, time.Hour)
 
 	first := c.get(context.Background())
 	if first == nil || first.StorageBytes != 10 {
@@ -225,7 +225,7 @@ func TestQuotaUsageCacheUsesTTL(t *testing.T) {
 func TestQuotaUsageCacheCoalescesConcurrentMisses(t *testing.T) {
 	store := newCacheTestStore()
 	store.usage["t1"] = &QuotaUsageView{TenantID: "t1", StorageBytes: 10}
-	c := newQuotaUsageCache("t1", store, time.Hour)
+	c := newQuotaUsageCache("t1", "", store, time.Hour)
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var once sync.Once
@@ -258,7 +258,7 @@ func TestQuotaUsageCacheCoalescesConcurrentMisses(t *testing.T) {
 func TestQuotaUsageCacheInvalidateForcesReload(t *testing.T) {
 	store := newCacheTestStore()
 	store.usage["t1"] = &QuotaUsageView{TenantID: "t1", StorageBytes: 10}
-	c := newQuotaUsageCache("t1", store, time.Hour)
+	c := newQuotaUsageCache("t1", "", store, time.Hour)
 
 	first := c.get(context.Background())
 	if first == nil || first.StorageBytes != 10 {
@@ -286,7 +286,7 @@ func TestQuotaPendingDeltasCacheUsesTTLAndLocalAdjustments(t *testing.T) {
 	storage := int64(10)
 	file := int64(1)
 	media := int64(0)
-	c := newQuotaPendingDeltasCache("test-tenant", func(context.Context) (int64, int64, int64, error) {
+	c := newQuotaPendingDeltasCache("test-tenant", "", func(context.Context) (int64, int64, int64, error) {
 		calls.Add(1)
 		return storage, file, media, nil
 	}, time.Hour)
@@ -319,7 +319,7 @@ func TestQuotaPendingDeltasCachePublishesConservativeSnapshotWhenLocalDeltaRaces
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var once sync.Once
-	c := newQuotaPendingDeltasCache("test-tenant", func(context.Context) (int64, int64, int64, error) {
+	c := newQuotaPendingDeltasCache("test-tenant", "", func(context.Context) (int64, int64, int64, error) {
 		calls.Add(1)
 		once.Do(func() { close(started) })
 		<-release
@@ -364,7 +364,7 @@ func TestQuotaPendingDeltasCacheIgnoresNegativeRaceDeltasWhenPublishing(t *testi
 	started := make(chan struct{})
 	release := make(chan struct{})
 	var once sync.Once
-	c := newQuotaPendingDeltasCache("test-tenant", func(context.Context) (int64, int64, int64, error) {
+	c := newQuotaPendingDeltasCache("test-tenant", "", func(context.Context) (int64, int64, int64, error) {
 		calls.Add(1)
 		once.Do(func() { close(started) })
 		<-release
@@ -405,7 +405,7 @@ func TestQuotaPendingDeltasCacheIgnoresNegativeRaceDeltasWhenPublishing(t *testi
 }
 
 func TestQuotaPendingDeltasCacheExpiresNoLoaderPending(t *testing.T) {
-	c := newQuotaPendingDeltasCache("test-tenant", nil, time.Hour)
+	c := newQuotaPendingDeltasCache("test-tenant", "", nil, time.Hour)
 	c.pendingTTL = 10 * time.Millisecond
 
 	c.addPending(8, 1, -1)
@@ -428,7 +428,7 @@ func TestQuotaPendingDeltasCacheExpiresNoLoaderPending(t *testing.T) {
 }
 
 func TestQuotaPendingDeltasCacheClearPreventsExpiryDoubleSubtract(t *testing.T) {
-	c := newQuotaPendingDeltasCache("test-tenant", nil, time.Hour)
+	c := newQuotaPendingDeltasCache("test-tenant", "", nil, time.Hour)
 	c.pendingTTL = 10 * time.Millisecond
 
 	c.addPending(8, 1, 0)
@@ -452,7 +452,7 @@ func TestQuotaPendingDeltasCacheClearPreventsExpiryDoubleSubtract(t *testing.T) 
 }
 
 func TestQuotaPendingDeltasCacheClearAfterExpiryDoesNotGoNegative(t *testing.T) {
-	c := newQuotaPendingDeltasCache("test-tenant", nil, time.Hour)
+	c := newQuotaPendingDeltasCache("test-tenant", "", nil, time.Hour)
 	c.pendingTTL = 10 * time.Millisecond
 
 	c.addPending(8, 1, 0)
@@ -476,7 +476,7 @@ func TestQuotaPendingDeltasCacheClearAfterExpiryDoesNotGoNegative(t *testing.T) 
 }
 
 func TestQuotaPendingDeltasCacheRemovesPositiveRaceDeltasOnClearAndExpire(t *testing.T) {
-	c := newQuotaPendingDeltasCache("test-tenant", nil, time.Hour)
+	c := newQuotaPendingDeltasCache("test-tenant", "", nil, time.Hour)
 	c.pendingTTL = 10 * time.Millisecond
 
 	c.addPending(8, 1, -1)
@@ -497,7 +497,7 @@ func TestQuotaPendingDeltasCacheRemovesPositiveRaceDeltasOnClearAndExpire(t *tes
 
 func TestQuotaConfigCacheStop(t *testing.T) {
 	store := newCacheTestStore()
-	c := newQuotaConfigCache("t1", store)
+	c := newQuotaConfigCache("t1", "", store)
 	c.stop()
 	// Should not panic or block.
 }

--- a/pkg/backend/quota_mutation.go
+++ b/pkg/backend/quota_mutation.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
-	"github.com/mem9-ai/drive9/pkg/metrics"
 	"go.uber.org/zap"
 )
 
@@ -103,7 +102,7 @@ func (b *Dat9Backend) logQuotaMutation(ctx context.Context, mutationType string,
 			zap.String("tenant_id", b.tenantID),
 			zap.String("mutation_type", mutationType),
 			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "log_error", time.Duration(0))
+		b.recordTenantOperation("central_quota", mutationType, "log_error", time.Duration(0))
 		return 0, err
 	}
 	return logID, nil
@@ -124,14 +123,14 @@ func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType strin
 			zap.String("mutation_type", mutationType),
 			zap.Int64("log_id", logID),
 			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "pending", time.Duration(0))
+		b.recordTenantOperation("central_quota", mutationType, "pending", time.Duration(0))
 		return
 	}
 	if b.quotaUsageCache != nil {
 		b.quotaUsageCache.invalidate()
 	}
 	b.clearPendingCentralMutationDeltas(pending.storageDelta, pending.fileDelta, pending.mediaDelta)
-	metrics.RecordTenantOperation(b.tenantID, "central_quota", mutationType, "ok", time.Duration(0))
+	b.recordTenantOperation("central_quota", mutationType, "ok", time.Duration(0))
 }
 
 // logAndEnqueueMutation atomically logs a mutation and enqueues its apply

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -4,12 +4,16 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
+
+const defaultTenantMetricTiDBCloudOrgID = "guest"
 
 // MetaQuotaStore defines the interface for central quota operations on the
 // drive9 server DB. Implemented by *meta.Store; injected via Pool to avoid
@@ -121,17 +125,19 @@ type LLMUsageView struct {
 
 // MutationLogView is the backend-side view of a quota mutation log entry.
 type MutationLogView struct {
-	ID           int64 // populated only when read from ListPendingMutations
-	TenantID     string
-	MutationType string
-	MutationData json.RawMessage
-	RetryCount   int // populated only when read from ListPendingMutations
+	ID             int64 // populated only when read from ListPendingMutations
+	TenantID       string
+	TiDBCloudOrgID string
+	MutationType   string
+	MutationData   json.RawMessage
+	RetryCount     int // populated only when read from ListPendingMutations
 }
 
 // MutationBacklogView is a tenant-level observation of pending quota mutation
 // replay work. It is used only for runtime metrics and alerting.
 type MutationBacklogView struct {
 	TenantID                string
+	TiDBCloudOrgID          string
 	PendingCount            int64
 	OldestPendingAgeSeconds float64
 }
@@ -139,7 +145,7 @@ type MutationBacklogView struct {
 // SetMetaQuotaStore sets the central quota store on the backend.
 // Called by tenant.Pool after backend creation.
 func (b *Dat9Backend) SetMetaQuotaStore(ctx context.Context, tenantID string, mqs MetaQuotaStore) {
-	b.tenantID = tenantID
+	b.SetTenantMetricScope(tenantID, b.tidbCloudOrgID)
 	b.metaStore = mqs
 	if mqs != nil {
 		if err := mqs.EnsureQuotaUsageRow(ctx, tenantID); err != nil {
@@ -149,14 +155,41 @@ func (b *Dat9Backend) SetMetaQuotaStore(ctx context.Context, tenantID string, mq
 		}
 	}
 	if mqs != nil {
-		b.quotaConfigCache = newQuotaConfigCache(tenantID, mqs)
-		b.quotaUsageCache = newQuotaUsageCache(tenantID, mqs, quotaUsageCacheTTL)
-		b.quotaPendingCache = newQuotaPendingDeltasCache(b.tenantID, nil, quotaPendingDeltasCacheTTL)
+		b.quotaConfigCache = newQuotaConfigCache(tenantID, b.tidbCloudOrgID, mqs)
+		b.quotaUsageCache = newQuotaUsageCache(tenantID, b.tidbCloudOrgID, mqs, quotaUsageCacheTTL)
+		b.quotaPendingCache = newQuotaPendingDeltasCache(b.tenantID, b.tidbCloudOrgID, nil, quotaPendingDeltasCacheTTL)
 		b.startMutationWorker()
 	}
+}
+
+// SetTenantMetricScope sets the tenant dimensions used by backend-owned
+// metrics. It does not perform tenant lookup; callers must pass the resolved
+// TiDB Cloud org explicitly.
+func (b *Dat9Backend) SetTenantMetricScope(tenantID, tidbCloudOrgID string) {
+	if strings.TrimSpace(tenantID) != "" {
+		b.tenantID = tenantID
+	}
+	b.tidbCloudOrgID = normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID)
 }
 
 // TenantID returns the tenant identifier for this backend instance.
 func (b *Dat9Backend) TenantID() string {
 	return b.tenantID
+}
+
+// TiDBCloudOrgID returns the TiDB Cloud org label value for tenant metrics.
+func (b *Dat9Backend) TiDBCloudOrgID() string {
+	return normalizeTenantMetricTiDBCloudOrgID(b.tidbCloudOrgID)
+}
+
+func normalizeTenantMetricTiDBCloudOrgID(orgID string) string {
+	orgID = strings.TrimSpace(orgID)
+	if orgID == "" {
+		return defaultTenantMetricTiDBCloudOrgID
+	}
+	return orgID
+}
+
+func (b *Dat9Backend) recordTenantOperation(component, operation, result string, d time.Duration) {
+	metrics.RecordTenantOperationWithOrg(b.tenantID, b.tidbCloudOrgID, component, operation, result, d)
 }

--- a/pkg/backend/runtime_metrics_test.go
+++ b/pkg/backend/runtime_metrics_test.go
@@ -40,16 +40,16 @@ func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
 	}
 	// Image extract delivery is now durable (semantic_tasks), so queue capacity
 	// and workers are always 0 — the semantic worker handles processing.
-	if !strings.Contains(metricsText, 	"drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\",tenant_id=\"\"} 0") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\",tenant_id=\"\",tidbcloud_org_id=\"guest\"} 0") {
 		t.Fatalf("metrics missing aggregated image queue capacity: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, 	"drive9_service_gauge{component=\"image_extract\",name=\"workers\",tenant_id=\"\"} 0") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"workers\",tenant_id=\"\",tidbcloud_org_id=\"guest\"} 0") {
 		t.Fatalf("metrics missing aggregated image workers: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\",tenant_id=\"\"} 4096") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\",tenant_id=\"\",tidbcloud_org_id=\"guest\"} 4096") {
 		t.Fatalf("metrics missing aggregated audio max bytes: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\",tenant_id=\"\"} 3") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\",tenant_id=\"\",tidbcloud_org_id=\"guest\"} 3") {
 		t.Fatalf("metrics missing aggregated audio timeout: %s", metricsText)
 	}
 
@@ -59,19 +59,19 @@ func TestBackendRuntimeMetricsAggregateAcrossBackends(t *testing.T) {
 	if !strings.Contains(metricsText, "drive9_module_up{module=\"image_extract\"} 1") {
 		t.Fatalf("metrics should keep image_extract available while one backend remains: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, 	"drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\",tenant_id=\"\"} 0") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"queue_capacity\",tenant_id=\"\",tidbcloud_org_id=\"guest\"} 0") {
 		t.Fatalf("metrics should keep image queue capacity at 0 after one backend closes: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, 	"drive9_service_gauge{component=\"image_extract\",name=\"workers\",tenant_id=\"\"} 0") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"image_extract\",name=\"workers\",tenant_id=\"\",tidbcloud_org_id=\"guest\"} 0") {
 		t.Fatalf("metrics should keep image workers at 0 after one backend closes: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\",tenant_id=\"\"} 2048") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_audio_bytes\",tenant_id=\"\",tidbcloud_org_id=\"guest\"} 2048") {
 		t.Fatalf("metrics should retain remaining audio max bytes: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_extract_text_bytes\",tenant_id=\"\"} 555") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"max_extract_text_bytes\",tenant_id=\"\",tidbcloud_org_id=\"guest\"} 555") {
 		t.Fatalf("metrics should retain remaining audio text limit: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\",tenant_id=\"\"} 2") {
+	if !strings.Contains(metricsText, "drive9_service_gauge{component=\"audio_extract\",name=\"task_timeout_seconds\",tenant_id=\"\",tidbcloud_org_id=\"guest\"} 2") {
 		t.Fatalf("metrics should retain remaining audio timeout: %s", metricsText)
 	}
 

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/semantic"
 )
 
@@ -51,7 +50,7 @@ func (b *Dat9Backend) enqueueExtractSemanticTasksTx(ctx context.Context, tx *sql
 		return false, nil
 	}
 	if b.mediaLLMQuotaExceededCheckTx(ctx, tx, currentMediaDelta) {
-		metrics.RecordTenantOperation(b.tenantID, "media_llm_budget", "enqueue_skip", "quota_exceeded", 0)
+		b.recordTenantOperation("media_llm_budget", "enqueue_skip", "quota_exceeded", 0)
 		return false, nil
 	}
 	enqueued := false

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -85,7 +85,7 @@ func (b *Dat9Backend) enqueueExtractSemanticTasksTx(ctx context.Context, tx *sql
 	}
 	// Video has its own independent quota.
 	if isVideo {
-		if b.videoLLMQuotaExceededTx(tx) {
+		if b.videoLLMQuotaExceededTx(ctx, tx) {
 			b.recordTenantOperation("video_llm_budget", "enqueue_skip", "quota_exceeded", 0)
 		} else {
 			created, err := b.enqueueVideoExtractTaskTx(tx, fileID, revision, path, contentType)

--- a/pkg/backend/upload.go
+++ b/pkg/backend/upload.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/datastore"
 	"github.com/mem9-ai/drive9/pkg/logger"
-	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/pathutil"
 	"github.com/mem9-ai/drive9/pkg/s3client"
 	"go.uber.org/zap"
@@ -252,40 +251,40 @@ func (b *Dat9Backend) InitiateUploadWithChecksums(ctx context.Context, path stri
 func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context, path string, totalSize int64, partChecksums []string, expectedRevision int64, description string) (*UploadPlan, error) {
 	start := time.Now()
 	if utf8.RuneCountInString(description) > MaxDescriptionLen {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("description exceeds %d characters", MaxDescriptionLen)
 	}
 	if err := b.ensureUploadSizeAllowed(totalSize); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if err := b.ensureFileSizeQuota(ctx, totalSize); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
 		logger.Warn(ctx, "backend_initiate_upload_invalid_path", zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if err := rejectRootFileNodePath(path); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if b.s3 == nil {
 		err := ErrS3NotConfigured
 		logger.Error(ctx, "backend_initiate_upload_s3_missing", zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
 	_, targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
 	if err != nil {
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "conflict", time.Since(start))
+			b.recordTenantOperation("backend", "initiate_upload", "conflict", time.Since(start))
 		} else {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+			b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		}
 		return nil, err
 	}
@@ -297,7 +296,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 	// remote side effects.
 	parts := s3client.CalcParts(totalSize, s3client.PartSize)
 	if len(partChecksums) > 0 && len(partChecksums) != len(parts) {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("%w: got %d, expected %d", ErrPartChecksumCountMismatch, len(partChecksums), len(parts))
 	}
 
@@ -305,7 +304,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoCRC32C, encOpts)
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_create_multipart_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 
@@ -320,7 +319,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 		if err != nil {
 			_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 			logger.Error(ctx, "backend_initiate_upload_presign_failed", zap.String("path", path), zap.Int("part_number", p.Number), zap.Error(err))
-			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+			b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 			return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
 		}
 		urls[i] = u
@@ -334,7 +333,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 	reserved, err := b.reserveUploadOnServer(ctx, uploadID, path, totalSize, uploadFileCountDelta(targetExists))
 	if err != nil {
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "quota_exceeded", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "quota_exceeded", time.Since(start))
 		return nil, err
 	}
 
@@ -348,7 +347,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 			b.abortUploadReservation(ctx, uploadID, totalSize)
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("lookup active upload for %s: %w", path, err)
 	}
 	if existing != nil {
@@ -357,7 +356,7 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 				b.abortUploadReservation(ctx, uploadID, totalSize)
 			}
 			_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+			b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 			return nil, fmt.Errorf("supersede active upload for %s: %w", path, err)
 		}
 	}
@@ -408,10 +407,10 @@ func (b *Dat9Backend) InitiateUploadWithChecksumsIfRevision(ctx context.Context,
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 		logger.Error(ctx, "backend_initiate_upload_insert_upload_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload", "error", time.Since(start))
 		return nil, err
 	}
-	metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "initiate_upload", "ok", time.Since(start))
 
 	return &UploadPlan{
 		UploadID: uploadID,
@@ -431,41 +430,41 @@ func (b *Dat9Backend) InitiateUploadV2(ctx context.Context, path string, totalSi
 func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path string, totalSize int64, expectedRevision int64, description string) (*UploadPlanV2, error) {
 	start := time.Now()
 	if utf8.RuneCountInString(description) > MaxDescriptionLen {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, fmt.Errorf("description exceeds %d characters", MaxDescriptionLen)
 	}
 	validateStart := time.Now()
 	if err := b.ensureUploadSizeAllowed(totalSize); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	if err := b.ensureFileSizeQuota(ctx, totalSize); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
 		logger.Warn(ctx, "backend_initiate_upload_v2_invalid_path", zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	if err := rejectRootFileNodePath(path); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	if b.s3 == nil {
 		err := ErrS3NotConfigured
 		logger.Error(ctx, "backend_initiate_upload_v2_s3_missing", zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	_, targetExists, err := b.validateUploadTargetRevision(ctx, path, expectedRevision)
 	if err != nil {
 		if errors.Is(err, datastore.ErrRevisionConflict) {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "conflict", time.Since(start))
+			b.recordTenantOperation("backend", "initiate_upload_v2", "conflict", time.Since(start))
 		} else {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+			b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		}
 		return nil, err
 	}
@@ -478,7 +477,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 	if len(parts) > MaxMultipartParts {
 		err := fmt.Errorf("file too large: %d parts exceeds S3 limit of %d", len(parts), MaxMultipartParts)
 		logger.Warn(ctx, "backend_initiate_upload_v2_too_many_parts", zap.String("path", path), zap.Int("parts", len(parts)), zap.Int64("total_size", totalSize))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 
@@ -493,7 +492,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 	mpu, err := b.s3.CreateMultipartUpload(ctx, s3Key, s3client.ChecksumAlgoNone, encOpts)
 	if err != nil {
 		logger.Error(ctx, "backend_initiate_upload_v2_create_multipart_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, fmt.Errorf("create multipart upload: %w", err)
 	}
 	createMultipartDurationMs := uploadPhaseMs(createMultipartStart)
@@ -507,7 +506,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 	reserved, err := b.reserveUploadOnServer(ctx, uploadID, path, totalSize, uploadFileCountDelta(targetExists))
 	if err != nil {
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "quota_exceeded", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "quota_exceeded", time.Since(start))
 		return nil, err
 	}
 
@@ -518,7 +517,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 			b.abortUploadReservation(ctx, uploadID, totalSize)
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, fmt.Errorf("lookup active upload for %s: %w", path, err)
 	}
 	if existing != nil {
@@ -530,7 +529,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 				b.abortUploadReservation(ctx, uploadID, totalSize)
 			}
 			_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
-			metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+			b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 			return nil, fmt.Errorf("supersede active upload for %s: %w", path, err)
 		}
 	}
@@ -595,7 +594,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		}
 		_ = b.s3.AbortMultipartUpload(ctx, s3Key, mpu.UploadID)
 		logger.Error(ctx, "backend_initiate_upload_v2_insert_upload_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "initiate_upload_v2", "error", time.Since(start))
 		return nil, err
 	}
 	txDurationMs := uploadPhaseMs(txStart)
@@ -613,7 +612,7 @@ func (b *Dat9Backend) InitiateUploadV2IfRevision(ctx context.Context, path strin
 		zap.Float64("tx_ms", txDurationMs),
 		zap.Float64("total_ms", uploadPhaseMs(start)),
 	)
-	metrics.RecordTenantOperation(b.tenantID, "backend", "initiate_upload_v2", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "initiate_upload_v2", "ok", time.Since(start))
 
 	return &UploadPlanV2{
 		UploadID:   uploadID,
@@ -653,24 +652,24 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_part", "error", time.Since(start))
 		return nil, err
 	}
 	upload, err = b.ensureUploadPresignable(ctx, uploadID, upload)
 	if err != nil {
 		switch {
 		case errors.Is(err, datastore.ErrUploadExpired):
-			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "expired", time.Since(start))
+			b.recordTenantOperation("backend", "presign_part", "expired", time.Since(start))
 		case errors.Is(err, datastore.ErrUploadNotActive):
-			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "not_active", time.Since(start))
+			b.recordTenantOperation("backend", "presign_part", "not_active", time.Since(start))
 		default:
 			logger.Error(ctx, "backend_presign_part_ensure_presignable_failed", zap.String("upload_id", uploadID), zap.Error(err))
-			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "error", time.Since(start))
+			b.recordTenantOperation("backend", "presign_part", "error", time.Since(start))
 		}
 		return nil, err
 	}
 	if partNumber < 1 || partNumber > upload.PartsTotal {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_part", "error", time.Since(start))
 		return nil, uploadClientProtocolErrorf("invalid part number %d: must be between 1 and %d", partNumber, upload.PartsTotal)
 	}
 
@@ -679,16 +678,16 @@ func (b *Dat9Backend) PresignPart(ctx context.Context, uploadID string, partNumb
 
 	checksumSHA256, err := resolveChecksumSHA256(checksum)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_part", "error", time.Since(start))
 		return nil, err
 	}
 	u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, partNumber, partSize, s3client.ChecksumAlgoSHA256, checksumSHA256, s3client.UploadTTL)
 	if err != nil {
 		logger.Error(ctx, "backend_presign_part_failed", zap.String("upload_id", uploadID), zap.Int("part_number", partNumber), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_part", "error", time.Since(start))
 		return nil, fmt.Errorf("presign part %d: %w", partNumber, err)
 	}
-	metrics.RecordTenantOperation(b.tenantID, "backend", "presign_part", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "presign_part", "ok", time.Since(start))
 	return u, nil
 }
 
@@ -700,7 +699,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 	getUploadStart := time.Now()
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_parts", "error", time.Since(start))
 		return nil, err
 	}
 	getUploadDurationMs := uploadPhaseMs(getUploadStart)
@@ -711,12 +710,12 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 	if err != nil {
 		switch {
 		case errors.Is(err, datastore.ErrUploadExpired):
-			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "expired", time.Since(start))
+			b.recordTenantOperation("backend", "presign_parts", "expired", time.Since(start))
 		case errors.Is(err, datastore.ErrUploadNotActive):
-			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "not_active", time.Since(start))
+			b.recordTenantOperation("backend", "presign_parts", "not_active", time.Since(start))
 		default:
 			logger.Error(ctx, "backend_presign_parts_ensure_presignable_failed", zap.String("upload_id", uploadID), zap.Error(err))
-			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
+			b.recordTenantOperation("backend", "presign_parts", "error", time.Since(start))
 		}
 		return nil, err
 	}
@@ -724,14 +723,14 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		statusTransitionDurationMs = uploadPhaseMs(statusTransitionStart)
 	}
 	if len(entries) > MaxPresignBatch {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_parts", "error", time.Since(start))
 		return nil, uploadClientProtocolErrorf("batch too large: %d parts exceeds limit of %d", len(entries), MaxPresignBatch)
 	}
 	// Reject duplicate part numbers in the batch.
 	seen := make(map[int]bool, len(entries))
 	for _, e := range entries {
 		if seen[e.PartNumber] {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
+			b.recordTenantOperation("backend", "presign_parts", "error", time.Since(start))
 			return nil, uploadClientProtocolErrorf("duplicate part number %d in batch", e.PartNumber)
 		}
 		seen[e.PartNumber] = true
@@ -749,7 +748,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 	for i, e := range entries {
 		pn := e.PartNumber
 		if pn < 1 || pn > upload.PartsTotal {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
+			b.recordTenantOperation("backend", "presign_parts", "error", time.Since(start))
 			return nil, uploadClientProtocolErrorf("invalid part number %d: must be between 1 and %d", pn, upload.PartsTotal)
 		}
 		partSize := parts[pn-1].Size
@@ -758,7 +757,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		resolveChecksumDurationMs := uploadPhaseMs(resolveChecksumStart)
 		resolveChecksumTotalMs += resolveChecksumDurationMs
 		if err != nil {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
+			b.recordTenantOperation("backend", "presign_parts", "error", time.Since(start))
 			return nil, err
 		}
 		s3PresignStart := time.Now()
@@ -770,7 +769,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		}
 		if err != nil {
 			logger.Error(ctx, "backend_presign_parts_failed", zap.String("upload_id", uploadID), zap.Int("part_number", pn), zap.Error(err))
-			metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "error", time.Since(start))
+			b.recordTenantOperation("backend", "presign_parts", "error", time.Since(start))
 			return nil, fmt.Errorf("presign part %d: %w", pn, err)
 		}
 		urls[i] = u
@@ -795,7 +794,7 @@ func (b *Dat9Backend) PresignParts(ctx context.Context, uploadID string, entries
 		zap.Float64("s3_presign_max_ms", s3PresignMaxMs),
 		zap.Float64("total_ms", uploadPhaseMs(start)),
 	)
-	metrics.RecordTenantOperation(b.tenantID, "backend", "presign_parts", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "presign_parts", "ok", time.Since(start))
 	return urls, nil
 }
 
@@ -822,24 +821,24 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	getUploadStart := time.Now()
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 		return err
 	}
 	getUploadDurationMs := uploadPhaseMs(getUploadStart)
 	if upload.Status != datastore.UploadUploading {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "not_active", time.Since(start))
+		b.recordTenantOperation("backend", "confirm_upload_v2", "not_active", time.Since(start))
 		return datastore.ErrUploadNotActive
 	}
 	if time.Now().After(upload.ExpiresAt) {
 		_ = b.AbortUploadV2(ctx, uploadID)
-		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "expired", time.Since(start))
+		b.recordTenantOperation("backend", "confirm_upload_v2", "expired", time.Since(start))
 		return datastore.ErrUploadExpired
 	}
 
 	// Validate client-supplied part count
 	clientValidationStart := time.Now()
 	if len(clientParts) != upload.PartsTotal {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 		return uploadClientProtocolErrorf("part count mismatch: client sent %d, expected %d", len(clientParts), upload.PartsTotal)
 	}
 
@@ -847,11 +846,11 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	clientPartMap := make(map[int]string, len(clientParts))
 	for _, cp := range clientParts {
 		if _, dup := clientPartMap[cp.Number]; dup {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
+			b.recordTenantOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 			return uploadClientProtocolErrorf("duplicate part number %d in complete request", cp.Number)
 		}
 		if cp.Number < 1 || cp.Number > upload.PartsTotal {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
+			b.recordTenantOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 			return uploadClientProtocolErrorf("invalid part number %d: must be between 1 and %d", cp.Number, upload.PartsTotal)
 		}
 		clientPartMap[cp.Number] = cp.ETag
@@ -863,7 +862,7 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	s3Parts, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
 	if err != nil {
 		logger.Error(ctx, "backend_confirm_upload_v2_list_parts_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 		return fmt.Errorf("list parts: %w", err)
 	}
 	listPartsDurationMs := uploadPhaseMs(listPartsStart)
@@ -877,11 +876,11 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	for partNum, clientETag := range clientPartMap {
 		s3ETag, ok := s3PartMap[partNum]
 		if !ok {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
+			b.recordTenantOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 			return uploadClientProtocolErrorf("part %d not found in S3", partNum)
 		}
 		if normalizeETag(clientETag) != normalizeETag(s3ETag) {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
+			b.recordTenantOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 			return uploadClientProtocolErrorf("part %d ETag mismatch: client=%q, S3=%q", partNum, clientETag, s3ETag)
 		}
 	}
@@ -891,12 +890,12 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 	sizeValidationStart := time.Now()
 	expectedParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	if len(s3Parts) != len(expectedParts) {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "incomplete", time.Since(start))
+		b.recordTenantOperation("backend", "confirm_upload_v2", "incomplete", time.Since(start))
 		return uploadClientProtocolErrorf("incomplete upload: S3 has %d parts, expected %d", len(s3Parts), len(expectedParts))
 	}
 	for i, p := range s3Parts {
 		if p.Size != expectedParts[i].Size {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "error", time.Since(start))
+			b.recordTenantOperation("backend", "confirm_upload_v2", "error", time.Since(start))
 			return uploadClientProtocolErrorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
 		}
 	}
@@ -919,7 +918,7 @@ func (b *Dat9Backend) ConfirmUploadV2WithTags(ctx context.Context, uploadID stri
 		zap.Float64("finalize_upload_ms", finalizeDurationMs),
 		zap.Float64("total_ms", uploadPhaseMs(start)),
 	)
-	metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload_v2", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "confirm_upload_v2", "ok", time.Since(start))
 	return nil
 }
 
@@ -940,11 +939,11 @@ func (b *Dat9Backend) ConfirmUploadWithTags(ctx context.Context, uploadID string
 
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "confirm_upload", "error", time.Since(start))
 		return err
 	}
 	if upload.Status != datastore.UploadUploading {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "not_active", time.Since(start))
+		b.recordTenantOperation("backend", "confirm_upload", "not_active", time.Since(start))
 		return datastore.ErrUploadNotActive
 	}
 
@@ -952,28 +951,28 @@ func (b *Dat9Backend) ConfirmUploadWithTags(ctx context.Context, uploadID string
 	parts, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
 	if err != nil {
 		logger.Error(ctx, "backend_confirm_upload_list_parts_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "confirm_upload", "error", time.Since(start))
 		return fmt.Errorf("list parts: %w", err)
 	}
 
 	// Verify all parts are present, correctly sized, and have ETags
 	if len(parts) != upload.PartsTotal {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "incomplete", time.Since(start))
+		b.recordTenantOperation("backend", "confirm_upload", "incomplete", time.Since(start))
 		return uploadClientProtocolErrorf("incomplete upload: got %d parts, expected %d", len(parts), upload.PartsTotal)
 	}
 	expectedParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	for i, p := range parts {
 		if p.Size != expectedParts[i].Size {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "error", time.Since(start))
+			b.recordTenantOperation("backend", "confirm_upload", "error", time.Since(start))
 			return uploadClientProtocolErrorf("part %d size mismatch: got %d, expected %d", p.Number, p.Size, expectedParts[i].Size)
 		}
 		if p.ETag == "" {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "error", time.Since(start))
+			b.recordTenantOperation("backend", "confirm_upload", "error", time.Since(start))
 			return uploadClientProtocolErrorf("part %d missing ETag", p.Number)
 		}
 	}
 
-	metrics.RecordTenantOperation(b.tenantID, "backend", "confirm_upload", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "confirm_upload", "ok", time.Since(start))
 	return b.finalizeUpload(ctx, upload, parts, tags)
 }
 
@@ -987,7 +986,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	start := time.Now()
 	uploadID := upload.UploadID
 	if err := rejectRootFileNodePath(upload.TargetPath); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "finalize_upload", "error", time.Since(start))
 		return err
 	}
 	expectedRevision := uploadExpectedRevision(upload)
@@ -997,10 +996,10 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 				zap.String("tenant_id", b.tenantID),
 				zap.String("upload_id", uploadID),
 				zap.Error(err))
-			metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_mark_completing", "error", time.Since(start))
+			b.recordTenantOperation("central_quota", "upload_mark_completing", "error", time.Since(start))
 			return fmt.Errorf("mark central quota upload completing: %w", err)
 		}
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_mark_completing", "ok", 0)
+		b.recordTenantOperation("central_quota", "upload_mark_completing", "ok", 0)
 	}
 
 	completeMultipartStart := time.Now()
@@ -1013,13 +1012,13 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 					zap.String("tenant_id", b.tenantID),
 					zap.String("upload_id", uploadID),
 					zap.Error(resetErr))
-				metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_reset_active", "error", time.Since(start))
+				b.recordTenantOperation("central_quota", "upload_reset_active", "error", time.Since(start))
 			} else {
-				metrics.RecordTenantOperation(b.tenantID, "central_quota", "upload_reset_active", "ok", time.Since(start))
+				b.recordTenantOperation("central_quota", "upload_reset_active", "ok", time.Since(start))
 			}
 			cancelCleanup()
 		}
-		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "finalize_upload", "error", time.Since(start))
 		return fmt.Errorf("complete multipart: %w", err)
 	}
 	completeMultipartDurationMs := uploadPhaseMs(completeMultipartStart)
@@ -1234,7 +1233,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		quotaCleanupCtx, cancelQuotaCleanup := postS3UploadFinalizeContext(ctx)
 		b.abortUploadReservation(quotaCleanupCtx, uploadID, upload.TotalSize)
 		cancelQuotaCleanup()
-		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "finalize_upload", "error", time.Since(start))
 		return err
 	}
 	txDurationMs := uploadPhaseMs(txStart)
@@ -1244,7 +1243,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 	quotaCtx, cancelQuota := postS3UploadFinalizeContext(ctx)
 	defer cancelQuota()
 	if err := b.completeUploadReservation(quotaCtx, uploadID, upload.TotalSize, confirmedFileID, oldSizeBytes, oldIsMedia, upload.TotalSize, newIsMedia); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "finalize_upload", "error", time.Since(start))
 		return postCommitQuotaMutationError("record central quota upload complete", err)
 	}
 
@@ -1270,7 +1269,7 @@ func (b *Dat9Backend) finalizeUpload(ctx context.Context, upload *datastore.Uplo
 		zap.Float64("tx_ms", txDurationMs),
 		zap.Float64("total_ms", uploadPhaseMs(start)),
 	)
-	metrics.RecordTenantOperation(b.tenantID, "backend", "finalize_upload", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "finalize_upload", "ok", time.Since(start))
 	return nil
 }
 
@@ -1284,11 +1283,11 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "resume_upload", "error", time.Since(start))
 		return nil, err
 	}
 	if upload.Status != datastore.UploadUploading {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "not_active", time.Since(start))
+		b.recordTenantOperation("backend", "resume_upload", "not_active", time.Since(start))
 		return nil, datastore.ErrUploadNotActive
 	}
 
@@ -1300,7 +1299,7 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 			logger.Warn(ctx, "backend_resume_upload_abort_expired_failed", zap.String("upload_id", uploadID), zap.Error(err))
 		}
 		_ = b.store.AbortUpload(ctx, uploadID)
-		metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "expired", time.Since(start))
+		b.recordTenantOperation("backend", "resume_upload", "expired", time.Since(start))
 		return nil, datastore.ErrUploadExpired
 	}
 
@@ -1308,7 +1307,7 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 	uploaded, err := b.s3.ListParts(ctx, upload.S3Key, upload.S3UploadID)
 	if err != nil {
 		logger.Error(ctx, "backend_resume_upload_list_parts_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "resume_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("list parts: %w", err)
 	}
 
@@ -1320,7 +1319,7 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 	// Calculate all expected parts
 	allParts := s3client.CalcParts(upload.TotalSize, upload.PartSize)
 	if len(partChecksums) > 0 && len(partChecksums) != len(allParts) {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "resume_upload", "error", time.Since(start))
 		return nil, fmt.Errorf("%w: got %d, expected %d", ErrPartChecksumCountMismatch, len(partChecksums), len(allParts))
 	}
 
@@ -1337,13 +1336,13 @@ func (b *Dat9Backend) ResumeUploadWithChecksums(ctx context.Context, uploadID st
 		u, err := b.s3.PresignUploadPart(ctx, upload.S3Key, upload.S3UploadID, p.Number, p.Size, s3client.ChecksumAlgoCRC32C, checksum, s3client.UploadTTL)
 		if err != nil {
 			logger.Error(ctx, "backend_resume_upload_presign_failed", zap.String("upload_id", uploadID), zap.Int("part_number", p.Number), zap.Error(err))
-			metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "error", time.Since(start))
+			b.recordTenantOperation("backend", "resume_upload", "error", time.Since(start))
 			return nil, fmt.Errorf("presign part %d: %w", p.Number, err)
 		}
 		urls = append(urls, u)
 	}
 
-	metrics.RecordTenantOperation(b.tenantID, "backend", "resume_upload", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "resume_upload", "ok", time.Since(start))
 	return &UploadPlan{
 		UploadID: uploadID,
 		Key:      upload.S3Key,
@@ -1357,23 +1356,23 @@ func (b *Dat9Backend) AbortUpload(ctx context.Context, uploadID string) error {
 	start := time.Now()
 	upload, err := b.store.GetUpload(ctx, uploadID)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "abort_upload", "error", time.Since(start))
 		return err
 	}
 	if upload.Status != datastore.UploadUploading {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload", "not_active", time.Since(start))
+		b.recordTenantOperation("backend", "abort_upload", "not_active", time.Since(start))
 		return datastore.ErrUploadNotActive
 	}
 
 	_ = b.s3.AbortMultipartUpload(ctx, upload.S3Key, upload.S3UploadID)
 	if err := b.store.AbortUpload(ctx, uploadID); err != nil {
 		logger.Error(ctx, "backend_abort_upload_store_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload", "error", time.Since(start))
+		b.recordTenantOperation("backend", "abort_upload", "error", time.Since(start))
 		return err
 	}
 	// Release server-side reservation.
 	b.abortUploadReservation(ctx, uploadID, upload.TotalSize)
-	metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "abort_upload", "ok", time.Since(start))
 	return nil
 }
 
@@ -1390,26 +1389,26 @@ func (b *Dat9Backend) abortUploadV2(ctx context.Context, uploadID string) (bool,
 	if err != nil {
 		// Not found → idempotent success
 		if errors.Is(err, datastore.ErrNotFound) {
-			metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "ok", time.Since(start))
+			b.recordTenantOperation("backend", "abort_upload_v2", "ok", time.Since(start))
 			return false, nil
 		}
-		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "abort_upload_v2", "error", time.Since(start))
 		return false, err
 	}
 	// Already terminal → idempotent success
 	if upload.Status == datastore.UploadAborted || upload.Status == datastore.UploadCompleted || upload.Status == datastore.UploadExpired {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "ok", time.Since(start))
+		b.recordTenantOperation("backend", "abort_upload_v2", "ok", time.Since(start))
 		return false, nil
 	}
 
 	aborted, err := b.store.AbortUploadV2(ctx, uploadID)
 	if err != nil {
 		logger.Error(ctx, "backend_abort_upload_v2_store_failed", zap.String("upload_id", uploadID), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "error", time.Since(start))
+		b.recordTenantOperation("backend", "abort_upload_v2", "error", time.Since(start))
 		return false, err
 	}
 	if !aborted {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "ok", time.Since(start))
+		b.recordTenantOperation("backend", "abort_upload_v2", "ok", time.Since(start))
 		return false, nil
 	}
 	_ = b.s3.AbortMultipartUpload(ctx, upload.S3Key, upload.S3UploadID)
@@ -1421,7 +1420,7 @@ func (b *Dat9Backend) abortUploadV2(ctx context.Context, uploadID string) (bool,
 	}
 	// Release server-side reservation.
 	b.abortUploadReservation(ctx, uploadID, upload.TotalSize)
-	metrics.RecordTenantOperation(b.tenantID, "backend", "abort_upload_v2", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "abort_upload_v2", "ok", time.Since(start))
 	return true, nil
 }
 
@@ -1447,36 +1446,36 @@ func (b *Dat9Backend) PresignGetObject(ctx context.Context, path string) (string
 	start := time.Now()
 	path, err := pathutil.Canonicalize(path)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", err
 	}
 	if path == "/" {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", datastore.ErrNotFound
 	}
 	nf, err := b.store.Stat(ctx, path)
 	if err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", err
 	}
 	if nf.File == nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", fmt.Errorf("no file entity for path: %s", path)
 	}
 	if nf.File.StorageType != datastore.StorageS3 {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", fmt.Errorf("%w: %s", ErrNotS3Stored, path)
 	}
 	if b.s3 == nil {
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", ErrS3NotConfigured
 	}
 	url, err := b.s3.PresignGetObject(ctx, nf.File.StorageRef, s3client.DownloadTTL)
 	if err != nil {
 		logger.Error(ctx, "backend_presign_get_object_failed", zap.String("path", path), zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "error", time.Since(start))
+		b.recordTenantOperation("backend", "presign_get_object", "error", time.Since(start))
 		return "", err
 	}
-	metrics.RecordTenantOperation(b.tenantID, "backend", "presign_get_object", "ok", time.Since(start))
+	b.recordTenantOperation("backend", "presign_get_object", "ok", time.Since(start))
 	return url, nil
 }

--- a/pkg/backend/upload_reservation.go
+++ b/pkg/backend/upload_reservation.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
-	"github.com/mem9-ai/drive9/pkg/metrics"
 	"go.uber.org/zap"
 )
 
@@ -47,7 +46,7 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 		logger.Info(ctx, "central_quota_reserve_upload_duplicate",
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "duplicate", time.Since(start))
+		b.recordTenantOperation("central_quota", "reserve_upload", "duplicate", time.Since(start))
 		return true, nil
 	} else if err != nil && !errors.Is(err, ErrReservationNotFound) {
 		logger.Warn(ctx, "central_quota_reserve_upload_duplicate_lookup_failed",
@@ -70,19 +69,19 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 	b.mutationMu.Lock()
 	defer b.mutationMu.Unlock()
 	if err := b.ensureUploadReserveFitsPendingQuota(ctx, totalSize, fileCountDelta); err != nil {
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
+		b.recordTenantOperation("central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
 		return false, err
 	}
 	err := b.metaStore.AtomicReserveAndInsertUpload(ctx, reservation)
 	switch {
 	case err == nil:
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "ok", time.Since(start))
+		b.recordTenantOperation("central_quota", "reserve_upload", "ok", time.Since(start))
 		return true, nil
 	case errors.Is(err, ErrStorageQuotaExceeded):
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
+		b.recordTenantOperation("central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
 		return false, err
 	case errors.Is(err, ErrFileCountQuotaExceeded):
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
+		b.recordTenantOperation("central_quota", "reserve_upload", "quota_exceeded", time.Since(start))
 		return false, err
 	case errors.Is(err, ErrReservationAlreadyExists):
 		// Idempotent retry: reservation already exists from an earlier initiate.
@@ -90,7 +89,7 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 		logger.Info(ctx, "central_quota_reserve_upload_duplicate",
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "duplicate", time.Since(start))
+		b.recordTenantOperation("central_quota", "reserve_upload", "duplicate", time.Since(start))
 		return true, nil
 	case errors.Is(err, ErrQuotaReservationBusy):
 		logger.Warn(ctx, "central_quota_reserve_upload_busy_fail_open",
@@ -98,7 +97,7 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 			zap.String("upload_id", uploadID),
 			zap.Int64("size", totalSize),
 			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "busy_fail_open", time.Since(start))
+		b.recordTenantOperation("central_quota", "reserve_upload", "busy_fail_open", time.Since(start))
 		return false, nil
 	default:
 		logger.Warn(ctx, "central_quota_reserve_upload_failed",
@@ -106,7 +105,7 @@ func (b *Dat9Backend) reserveUploadOnServer(ctx context.Context, uploadID, targe
 			zap.String("upload_id", uploadID),
 			zap.Int64("size", totalSize),
 			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "reserve_upload", "fail_open", time.Since(start))
+		b.recordTenantOperation("central_quota", "reserve_upload", "fail_open", time.Since(start))
 		// Fail-open: allow the upload to proceed when the server DB is down.
 		return false, nil
 	}
@@ -118,7 +117,7 @@ func (b *Dat9Backend) ensureUploadReserveFitsPendingQuota(ctx context.Context, t
 	}
 	cfg := b.cachedQuotaConfig(ctx)
 	if cfg == nil {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "upload_reserve_pending_check", "fail_open", 0)
+		b.recordTenantOperation("server_quota", "upload_reserve_pending_check", "fail_open", 0)
 		return nil
 	}
 	if cfg.MaxStorageBytes <= 0 && (fileCountDelta <= 0 || cfg.MaxFileCount <= 0) {
@@ -126,7 +125,7 @@ func (b *Dat9Backend) ensureUploadReserveFitsPendingQuota(ctx context.Context, t
 	}
 	usage := b.loadQuotaUsage(ctx)
 	if usage == nil {
-		metrics.RecordTenantOperation(b.tenantID, "server_quota", "upload_reserve_pending_check", "fail_open", 0)
+		b.recordTenantOperation("server_quota", "upload_reserve_pending_check", "fail_open", 0)
 		return nil
 	}
 	pendingStorageDelta, pendingFileDelta, _ := b.pendingCentralMutationDeltas(ctx)
@@ -179,15 +178,15 @@ func (b *Dat9Backend) abortUploadReservation(ctx context.Context, uploadID strin
 			zap.String("tenant_id", b.tenantID),
 			zap.String("upload_id", uploadID),
 			zap.Error(err))
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "error", time.Since(start))
+		b.recordTenantOperation("central_quota", "abort_reservation", "error", time.Since(start))
 		return
 	}
 	if !aborted {
-		metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "skip_no_reservation", time.Since(start))
+		b.recordTenantOperation("central_quota", "abort_reservation", "skip_no_reservation", time.Since(start))
 		return
 	}
 
-	metrics.RecordTenantOperation(b.tenantID, "central_quota", "abort_reservation", "ok", time.Since(start))
+	b.recordTenantOperation("central_quota", "abort_reservation", "ok", time.Since(start))
 }
 
 // --- Mutation log helpers ---

--- a/pkg/backend/video_extract.go
+++ b/pkg/backend/video_extract.go
@@ -122,8 +122,8 @@ func (b *Dat9Backend) SupportsAsyncVideoExtract() bool {
 	return b != nil && b.videoExtractEnabled && b.videoExtractor != nil
 }
 
-// errVideoExtractSourceTooLarge signals the video exceeds MaxVideoBytes.
-var errVideoExtractSourceTooLarge = errors.New("video extract source exceeds configured max bytes")
+// ErrVideoExtractSourceTooLarge signals the video exceeds MaxVideoBytes.
+var ErrVideoExtractSourceTooLarge = errors.New("video extract source exceeds configured max bytes")
 
 // ProcessVideoExtractTask runs visual extraction for one durable
 // video_extract_visual task. Terminal business outcomes return a nil error;
@@ -175,7 +175,7 @@ func (b *Dat9Backend) ProcessVideoExtractTask(ctx context.Context, task VideoExt
 
 	data, err := b.loadVideoBytesForExtract(ctx, f)
 	if err != nil {
-		if errors.Is(err, errVideoExtractSourceTooLarge) {
+		if errors.Is(err, ErrVideoExtractSourceTooLarge) {
 			result = VideoExtractResultTooLarge
 			return result, nil
 		}
@@ -183,15 +183,17 @@ func (b *Dat9Backend) ProcessVideoExtractTask(ctx context.Context, task VideoExt
 		return result, fmt.Errorf("load video bytes: %w", err)
 	}
 
-	taskCtx, cancel := context.WithTimeout(ctx, b.videoExtractTimeout)
-	text, videoUsage, err := b.videoExtractor.ExtractVideoText(taskCtx, VideoExtractRequest{
-		TenantID:    b.tenantID,
-		FileID:      task.FileID,
-		Path:        task.Path,
-		ContentType: resolvedMIME,
-		Data:        data,
-	})
-	cancel()
+	text, videoUsage, err := func() (string, VideoExtractUsage, error) {
+		taskCtx, cancel := context.WithTimeout(ctx, b.videoExtractTimeout)
+		defer cancel()
+		return b.videoExtractor.ExtractVideoText(taskCtx, VideoExtractRequest{
+			TenantID:    b.tenantID,
+			FileID:      task.FileID,
+			Path:        task.Path,
+			ContentType: resolvedMIME,
+			Data:        data,
+		})
+	}()
 	if err != nil {
 		result = VideoExtractResultExtractError
 		return result, fmt.Errorf("extract video text: %w", err)
@@ -256,11 +258,11 @@ func injectedVideoExtractWritebackError(name string) error {
 
 func (b *Dat9Backend) loadVideoBytesForExtract(ctx context.Context, f *datastore.File) ([]byte, error) {
 	if b.videoExtractMaxSize > 0 && f.SizeBytes > b.videoExtractMaxSize {
-		return nil, errVideoExtractSourceTooLarge
+		return nil, ErrVideoExtractSourceTooLarge
 	}
 	if f.StorageType == datastore.StorageDB9 {
 		if b.videoExtractMaxSize > 0 && int64(len(f.ContentBlob)) > b.videoExtractMaxSize {
-			return nil, errVideoExtractSourceTooLarge
+			return nil, ErrVideoExtractSourceTooLarge
 		}
 		return append([]byte(nil), f.ContentBlob...), nil
 	}
@@ -285,7 +287,7 @@ func (b *Dat9Backend) loadVideoBytesForExtract(ctx context.Context, f *datastore
 		return nil, err
 	}
 	if b.videoExtractMaxSize > 0 && int64(len(data)) > b.videoExtractMaxSize {
-		return nil, errVideoExtractSourceTooLarge
+		return nil, ErrVideoExtractSourceTooLarge
 	}
 	return data, nil
 }

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -158,11 +158,15 @@ func Open(dsn string) (*Store, error) {
 }
 
 func OpenForTenant(ctx context.Context, dsn, tenantID string) (*Store, error) {
+	return OpenForTenantWithOrg(ctx, dsn, tenantID, "")
+}
+
+func OpenForTenantWithOrg(ctx context.Context, dsn, tenantID, tidbCloudOrgID string) (*Store, error) {
 	lower := strings.ToLower(dsn)
 	if strings.Contains(lower, "multistatements=true") || strings.Contains(lower, "multistatements=1") {
 		return nil, fmt.Errorf("multiStatements is not allowed in production DSN")
 	}
-	db, err := mysqlutil.OpenInstrumentedForTenant(ctx, dsn, mysqlutil.RoleUser, tenantID)
+	db, err := mysqlutil.OpenInstrumentedForTenantWithOrg(ctx, dsn, mysqlutil.RoleUser, tenantID, tidbCloudOrgID)
 	if err != nil {
 		return nil, fmt.Errorf("open db: %w", err)
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -41,6 +41,16 @@ const (
 	TenantDeleted      TenantStatus = "deleted"
 )
 
+var allTenantStatuses = []TenantStatus{
+	TenantPending,
+	TenantProvisioning,
+	TenantActive,
+	TenantFailed,
+	TenantSuspended,
+	TenantDeleting,
+	TenantDeleted,
+}
+
 const tidbCloudNativeProvider = "tidb_cloud_native"
 const maxTiDBCloudOrgBindingDuplicateTuples = 20
 
@@ -91,8 +101,25 @@ type Tenant struct {
 }
 
 type TenantCounts struct {
-	TotalNonDeleted int64
-	Active          int64
+	Statuses []TenantStatusCount
+}
+
+type TenantStatusCount struct {
+	Status TenantStatus
+	Count  int64
+}
+
+func TenantStatuses() []TenantStatus {
+	return append([]TenantStatus(nil), allTenantStatuses...)
+}
+
+func (c TenantCounts) Count(status TenantStatus) int64 {
+	for _, rec := range c.Statuses {
+		if rec.Status == status {
+			return rec.Count
+		}
+	}
+	return 0
 }
 
 type TenantAutoEmbeddingProfile struct {
@@ -232,8 +259,9 @@ type APIKeyFSScope struct {
 }
 
 type TenantWithAPIKey struct {
-	Tenant Tenant
-	APIKey APIKey
+	Tenant         Tenant
+	APIKey         APIKey
+	TiDBCloudOrgID string
 }
 
 type ExternalBinding struct {
@@ -288,6 +316,13 @@ type TenantPool struct {
 	Status         TenantPoolStatus
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
+}
+
+type TenantPoolBindingStatusCount struct {
+	PoolID         string
+	OrganizationID string
+	Status         TenantPoolBindingStatus
+	Count          int64
 }
 
 type Store struct {
@@ -1886,6 +1921,51 @@ func (s *Store) countFreeTenantPoolBindingsByStatus(ctx context.Context, organiz
 	return out, nil
 }
 
+func (s *Store) CountTenantPoolBindingsByStatus(ctx context.Context) (out []TenantPoolBindingStatusCount, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "count_tidbcloud_pool_bindings_by_status", start, &err)
+	rows, err := s.db.QueryContext(ctx, `SELECT
+			p.pool_id,
+			p.organization_id,
+			statuses.pool_status,
+			COUNT(t.id)
+		FROM tenant_tidbcloud_pools p
+		JOIN (
+			SELECT ? AS pool_status
+			UNION ALL
+			SELECT ? AS pool_status
+		) statuses
+		LEFT JOIN tenant_tidbcloud_org_bindings b
+			ON b.pool_id = p.pool_id
+			AND b.organization_id = p.organization_id
+			AND b.pool_status = statuses.pool_status
+		LEFT JOIN tenants t
+			ON t.id = b.tenant_id
+			AND t.provider = ?
+			AND t.status <> ?
+		WHERE p.pool_id <> ''
+			AND p.organization_id IS NOT NULL
+			AND p.organization_id <> ''
+		GROUP BY p.pool_id, p.organization_id, statuses.pool_status
+		ORDER BY p.pool_id, p.organization_id, statuses.pool_status`,
+		TenantPoolBindingFree, TenantPoolBindingUsed, tidbCloudNativeProvider, TenantDeleted)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var rec TenantPoolBindingStatusCount
+		if err := rows.Scan(&rec.PoolID, &rec.OrganizationID, &rec.Status, &rec.Count); err != nil {
+			return nil, err
+		}
+		out = append(out, rec)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (s *Store) ListFreeTenantPoolBindings(ctx context.Context, organizationID string, newestFirst bool, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "list_free_tidbcloud_pool_bindings", start, &err)
@@ -2372,9 +2452,10 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
 			k.id, k.tenant_id, k.key_name, k.jwt_ciphertext, k.jwt_hash, k.token_version, k.status, k.scope_kind,
 			k.issued_by_provider, k.issued_by_subject_key, k.issued_by_metadata_json, k.issued_at,
-			k.revoked_at, k.created_at, k.updated_at
+			k.revoked_at, k.created_at, k.updated_at, COALESCE(b.organization_id, '')
 		FROM tenant_api_keys k
 		JOIN tenants t ON t.id = k.tenant_id
+		LEFT JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = t.id
 		WHERE k.jwt_hash = ?`, hash)
 
 	var rec TenantWithAPIKey
@@ -2398,7 +2479,7 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 		&rec.APIKey.ID, &rec.APIKey.TenantID, &rec.APIKey.KeyName, &rec.APIKey.JWTCiphertext,
 		&rec.APIKey.JWTHash, &rec.APIKey.TokenVersion, &rec.APIKey.Status, &rec.APIKey.ScopeKind,
 		&issuedByProvider, &issuedBySubjectKey, &issuedByMetadataJSON, &rec.APIKey.IssuedAt,
-		&revokedAt, &rec.APIKey.CreatedAt, &rec.APIKey.UpdatedAt,
+		&revokedAt, &rec.APIKey.CreatedAt, &rec.APIKey.UpdatedAt, &rec.TiDBCloudOrgID,
 	); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			err = ErrNotFound
@@ -2631,16 +2712,32 @@ func (s *Store) ListTenantsByStatus(ctx context.Context, status TenantStatus, li
 func (s *Store) CountTenants(ctx context.Context) (out TenantCounts, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "count_tenants", start, &err)
-	err = s.db.QueryRowContext(ctx, `
-		SELECT
-			COUNT(*),
-			COALESCE(SUM(CASE WHEN status = ? THEN 1 ELSE 0 END), 0)
-		FROM tenants
-		WHERE status <> ?`, TenantActive, TenantDeleted).Scan(&out.TotalNonDeleted, &out.Active)
-	if err != nil {
-		err = fmt.Errorf("count tenants: %w", err)
+	counts := make(map[TenantStatus]int64, len(allTenantStatuses))
+	for _, status := range allTenantStatuses {
+		counts[status] = 0
 	}
-	return out, err
+	rows, err := s.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM tenants GROUP BY status`)
+	if err != nil {
+		return out, fmt.Errorf("count tenants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var status TenantStatus
+		var count int64
+		if err := rows.Scan(&status, &count); err != nil {
+			return out, fmt.Errorf("scan tenant count: %w", err)
+		}
+		if _, ok := counts[status]; ok {
+			counts[status] = count
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return out, fmt.Errorf("count tenants rows: %w", err)
+	}
+	for _, status := range allTenantStatuses {
+		out.Statuses = append(out.Statuses, TenantStatusCount{Status: status, Count: counts[status]})
+	}
+	return out, nil
 }
 
 // ListTenantsByStatusAfter returns one keyset page of tenants after

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -88,6 +88,7 @@ type Tenant struct {
 	DBName             string
 	DBTLS              bool
 	Provider           string
+	TiDBCloudOrgID     string
 	ClusterID          string
 	BranchID           string
 	ClaimURL           string
@@ -1928,6 +1929,7 @@ func (s *Store) CountTenantPoolBindingsByStatus(ctx context.Context) (out []Tena
 			p.pool_id,
 			p.organization_id,
 			statuses.pool_status,
+			/* Count only live tenant slots; deleted-tenant bindings are cleanup debt, not usable capacity. */
 			COUNT(t.id)
 		FROM tenant_tidbcloud_pools p
 		JOIN (
@@ -2509,6 +2511,7 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 		t := revokedAt.Time.UTC()
 		rec.APIKey.RevokedAt = &t
 	}
+	rec.Tenant.TiDBCloudOrgID = rec.TiDBCloudOrgID
 	if issuedByProvider.Valid {
 		rec.APIKey.IssuedByProvider = issuedByProvider.String
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -4071,10 +4071,11 @@ func (s *Store) DeleteSubscriptionsForStalePods(ctx context.Context) (n int64, e
 // lightweight work signal: tenant_id identifies the tenant and work_mask is a
 // bitmask of work types to dispatch (SSE, semantic, file_gc, quota).
 type TenantNotifyRow struct {
-	ID        uint64
-	TenantID  string
-	WorkMask  int
-	CreatedAt time.Time
+	ID             uint64
+	TenantID       string
+	TiDBCloudOrgID string
+	WorkMask       int
+	CreatedAt      time.Time
 }
 
 // InsertTenantNotify writes a unified work signal to tenant_notify_outbox.
@@ -4100,7 +4101,12 @@ func (s *Store) ListTenantNotifySince(ctx context.Context, afterID uint64, limit
 		limit = 1000
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, tenant_id, work_mask, created_at FROM tenant_notify_outbox WHERE id > ? ORDER BY id LIMIT ?`,
+		`SELECT o.id, o.tenant_id, COALESCE(b.organization_id, ''), o.work_mask, o.created_at
+		 FROM tenant_notify_outbox o
+		 LEFT JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = o.tenant_id
+		 WHERE o.id > ?
+		 ORDER BY o.id
+		 LIMIT ?`,
 		afterID, limit)
 	if err != nil {
 		return nil, err
@@ -4108,7 +4114,7 @@ func (s *Store) ListTenantNotifySince(ctx context.Context, afterID uint64, limit
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
 		var rec TenantNotifyRow
-		if err = rows.Scan(&rec.ID, &rec.TenantID, &rec.WorkMask, &rec.CreatedAt); err != nil {
+		if err = rows.Scan(&rec.ID, &rec.TenantID, &rec.TiDBCloudOrgID, &rec.WorkMask, &rec.CreatedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, rec)

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -875,11 +875,22 @@ func TestCountTenants(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got.TotalNonDeleted != 3 {
-		t.Errorf("TotalNonDeleted = %d, want 3", got.TotalNonDeleted)
+	want := map[TenantStatus]int64{
+		TenantPending:      0,
+		TenantProvisioning: 1,
+		TenantActive:       1,
+		TenantFailed:       1,
+		TenantSuspended:    0,
+		TenantDeleting:     0,
+		TenantDeleted:      1,
 	}
-	if got.Active != 1 {
-		t.Errorf("Active = %d, want 1", got.Active)
+	if len(got.Statuses) != len(want) {
+		t.Fatalf("status count length = %d, want %d: %+v", len(got.Statuses), len(want), got.Statuses)
+	}
+	for status, wantCount := range want {
+		if got.Count(status) != wantCount {
+			t.Errorf("count[%s] = %d, want %d", status, got.Count(status), wantCount)
+		}
 	}
 }
 
@@ -1547,6 +1558,78 @@ func TestClaimOldestFreeTenantPoolBindingRequiresActiveTenant(t *testing.T) {
 	}
 	if provisioningBinding.PoolStatus != TenantPoolBindingFree {
 		t.Errorf("provisioning pool status = %s, want %s", provisioningBinding.PoolStatus, TenantPoolBindingFree)
+	}
+}
+
+func TestCountTenantPoolBindingsByStatusGroupsByPoolOrganizationAndStatus(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for _, pool := range []TenantPool{
+		{
+			PoolID:         "pool-binding-counts-a",
+			OrganizationID: "org-binding-counts-a",
+			Size:           4,
+			Status:         TenantPoolActive,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+		{
+			PoolID:         "pool-binding-counts-empty",
+			OrganizationID: "org-binding-counts-empty",
+			Size:           2,
+			Status:         TenantPoolActive,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		},
+	} {
+		if err := s.CreateTenantPool(ctx, &pool); err != nil {
+			t.Fatalf("create tenant pool %s: %v", pool.PoolID, err)
+		}
+	}
+	for _, tc := range []struct {
+		tenantID string
+		cluster  string
+		status   TenantStatus
+		pool     TenantPoolBindingStatus
+	}{
+		{tenantID: "binding-counts-free-1", cluster: "cluster-binding-counts-free-1", status: TenantActive, pool: TenantPoolBindingFree},
+		{tenantID: "binding-counts-free-2", cluster: "cluster-binding-counts-free-2", status: TenantProvisioning, pool: TenantPoolBindingFree},
+		{tenantID: "binding-counts-used-1", cluster: "cluster-binding-counts-used-1", status: TenantActive, pool: TenantPoolBindingUsed},
+		{tenantID: "binding-counts-deleted-1", cluster: "cluster-binding-counts-deleted-1", status: TenantDeleted, pool: TenantPoolBindingFree},
+	} {
+		insertTiDBCloudBindingTenant(t, s, tc.tenantID, TenantKindLive, tc.status, tc.cluster, "", now)
+		if err := s.UpsertTenantTiDBCloudOrgBinding(ctx, &TenantTiDBCloudOrgBinding{
+			TenantID:       tc.tenantID,
+			OrganizationID: "org-binding-counts-a",
+			ClusterID:      tc.cluster,
+			PoolID:         "pool-binding-counts-a",
+			PoolStatus:     tc.pool,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}); err != nil {
+			t.Fatalf("upsert binding %s: %v", tc.tenantID, err)
+		}
+	}
+
+	counts, err := s.CountTenantPoolBindingsByStatus(ctx)
+	if err != nil {
+		t.Fatalf("count tenant pool bindings by status: %v", err)
+	}
+	got := map[string]int64{}
+	for _, count := range counts {
+		got[count.PoolID+"|"+count.OrganizationID+"|"+string(count.Status)] = count.Count
+	}
+	want := map[string]int64{
+		"pool-binding-counts-a|org-binding-counts-a|free":         2,
+		"pool-binding-counts-a|org-binding-counts-a|used":         1,
+		"pool-binding-counts-empty|org-binding-counts-empty|free": 0,
+		"pool-binding-counts-empty|org-binding-counts-empty|used": 0,
+	}
+	for key, wantCount := range want {
+		if got[key] != wantCount {
+			t.Fatalf("count %s = %d, want %d; all counts=%v", key, got[key], wantCount, got)
+		}
 	}
 }
 

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -128,6 +128,15 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 	if err := s.InsertTenant(context.Background(), tenant); err != nil {
 		t.Fatal(err)
 	}
+	if err := s.UpsertTenantTiDBCloudOrgBinding(context.Background(), &TenantTiDBCloudOrgBinding{
+		TenantID:       tenant.ID,
+		OrganizationID: "org-resolved",
+		ClusterID:      "cluster-resolved",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	key := &APIKey{
 		ID:            "k1",
 		TenantID:      tenant.ID,
@@ -153,6 +162,12 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 	}
 	if got.Tenant.Status != TenantActive {
 		t.Fatalf("unexpected tenant status: %s", got.Tenant.Status)
+	}
+	if got.TiDBCloudOrgID != "org-resolved" {
+		t.Fatalf("resolved org = %q, want org-resolved", got.TiDBCloudOrgID)
+	}
+	if got.Tenant.TiDBCloudOrgID != "org-resolved" {
+		t.Fatalf("tenant org = %q, want org-resolved", got.Tenant.TiDBCloudOrgID)
 	}
 	if got.Tenant.S3EncryptionMode != S3EncryptionModeInherit {
 		t.Fatalf("unexpected tenant encryption mode: %s", got.Tenant.S3EncryptionMode)

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -800,6 +800,53 @@ func TestFinalizeTenantDeleteUpdatesJobNamespaceAndTenant(t *testing.T) {
 	}
 }
 
+func TestListTenantNotifySinceIncludesTiDBCloudOrgBinding(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	tenantID := "notify-binding-tenant"
+	if err := s.InsertTenant(ctx, &Tenant{
+		ID:                 tenantID,
+		Status:             TenantActive,
+		StorageNamespaceID: "notify-binding-ns",
+		DBHost:             "127.0.0.1",
+		DBPort:             4000,
+		DBUser:             "root",
+		DBPasswordCipher:   []byte("cipher"),
+		DBName:             "tenant_notify_binding",
+		DBTLS:              true,
+		Provider:           tidbCloudNativeProvider,
+		SchemaVersion:      1,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertTenantTiDBCloudOrgBinding(ctx, &TenantTiDBCloudOrgBinding{
+		TenantID:       tenantID,
+		OrganizationID: "org-notify",
+		ClusterID:      "cluster-notify",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertTenantNotify(ctx, tenantID, 3); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := s.ListTenantNotifySince(ctx, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("notify row count = %d, want 1", len(rows))
+	}
+	if rows[0].TiDBCloudOrgID != "org-notify" {
+		t.Fatalf("notify row org = %q, want org-notify", rows[0].TiDBCloudOrgID)
+	}
+}
+
 func TestListTenantsByStatus(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC()

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -705,7 +705,7 @@ func retryMetaLockConflict(ctx context.Context, tenantID, metricOperation, logOp
 			zap.String("operation", logOperation),
 			zap.Int("attempt", attempt),
 			zap.Error(err))
-		metrics.RecordTenantOperationCountWithOrg(tenantID, "guest", "central_quota", metricOperation, "lock_conflict_retry")
+		metrics.RecordTenantOperationCountWithOrg(tenantID, "", "central_quota", metricOperation, "lock_conflict_retry")
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -115,20 +115,22 @@ type LLMUsageRecord struct {
 
 // MutationLogEntry represents a durable outbox entry for quota state mutations.
 type MutationLogEntry struct {
-	ID           int64
-	TenantID     string
-	MutationType string // file_create, file_overwrite, file_delete, upload_initiate, upload_complete, upload_abort, llm_cost_record
-	MutationData json.RawMessage
-	Status       string // "pending", "applied", "failed"
-	RetryCount   int
-	CreatedAt    time.Time
-	AppliedAt    *time.Time
+	ID             int64
+	TenantID       string
+	TiDBCloudOrgID string
+	MutationType   string // file_create, file_overwrite, file_delete, upload_initiate, upload_complete, upload_abort, llm_cost_record
+	MutationData   json.RawMessage
+	Status         string // "pending", "applied", "failed"
+	RetryCount     int
+	CreatedAt      time.Time
+	AppliedAt      *time.Time
 }
 
 // MutationBacklogObservation is a tenant-level view of pending quota mutation
 // replay work for metrics and alerts.
 type MutationBacklogObservation struct {
 	TenantID                string
+	TiDBCloudOrgID          string
 	PendingCount            int64
 	OldestPendingAgeSeconds float64
 }
@@ -703,7 +705,7 @@ func retryMetaLockConflict(ctx context.Context, tenantID, metricOperation, logOp
 			zap.String("operation", logOperation),
 			zap.Int("attempt", attempt),
 			zap.Error(err))
-		metrics.RecordTenantOperationCount(tenantID, "central_quota", metricOperation, "lock_conflict_retry")
+		metrics.RecordTenantOperationCountWithOrg(tenantID, "guest", "central_quota", metricOperation, "lock_conflict_retry")
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
@@ -1208,10 +1210,11 @@ func (s *Store) ListPendingMutations(ctx context.Context, minAge time.Duration, 
 	}
 	cutoff := time.Now().UTC().Add(-minAge)
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT id, tenant_id, mutation_type, mutation_data, status, retry_count, created_at, applied_at
-		 FROM quota_mutation_log
-		 WHERE status = 'pending' AND created_at < ?
-		 ORDER BY tenant_id, id ASC
+		`SELECT q.id, q.tenant_id, COALESCE(b.organization_id, ''), q.mutation_type, q.mutation_data, q.status, q.retry_count, q.created_at, q.applied_at
+		 FROM quota_mutation_log q
+		 LEFT JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = q.tenant_id
+		 WHERE q.status = 'pending' AND q.created_at < ?
+		 ORDER BY q.tenant_id, q.id ASC
 		 LIMIT ?`, cutoff, limit)
 	if err != nil {
 		return nil, err
@@ -1221,7 +1224,7 @@ func (s *Store) ListPendingMutations(ctx context.Context, minAge time.Duration, 
 	var entries []MutationLogEntry
 	for rows.Next() {
 		var e MutationLogEntry
-		if err := rows.Scan(&e.ID, &e.TenantID, &e.MutationType, &e.MutationData, &e.Status, &e.RetryCount, &e.CreatedAt, &e.AppliedAt); err != nil {
+		if err := rows.Scan(&e.ID, &e.TenantID, &e.TiDBCloudOrgID, &e.MutationType, &e.MutationData, &e.Status, &e.RetryCount, &e.CreatedAt, &e.AppliedAt); err != nil {
 			return entries, err
 		}
 		entries = append(entries, e)
@@ -1236,11 +1239,12 @@ func (s *Store) ObservePendingMutations(ctx context.Context) ([]MutationBacklogO
 	defer observeMeta(ctx, "observe_pending_mutations", start, &err)
 
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT tenant_id, COUNT(*), MIN(created_at)
-		 FROM quota_mutation_log FORCE INDEX (idx_pending_tenant_age)
-		 WHERE status = 'pending'
-		 GROUP BY tenant_id
-		 ORDER BY tenant_id`)
+		`SELECT q.tenant_id, COALESCE(b.organization_id, ''), COUNT(*), MIN(q.created_at)
+		 FROM quota_mutation_log q FORCE INDEX (idx_pending_tenant_age)
+		 LEFT JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = q.tenant_id
+		 WHERE q.status = 'pending'
+		 GROUP BY q.tenant_id, b.organization_id
+		 ORDER BY q.tenant_id`)
 	if err != nil {
 		return nil, err
 	}
@@ -1251,7 +1255,7 @@ func (s *Store) ObservePendingMutations(ctx context.Context) ([]MutationBacklogO
 	for rows.Next() {
 		var obs MutationBacklogObservation
 		var oldest time.Time
-		if err = rows.Scan(&obs.TenantID, &obs.PendingCount, &oldest); err != nil {
+		if err = rows.Scan(&obs.TenantID, &obs.TiDBCloudOrgID, &obs.PendingCount, &oldest); err != nil {
 			return out, err
 		}
 		age := now.Sub(oldest.UTC()).Seconds()

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -394,7 +394,7 @@ func TestRetryMetaLockConflictRetriesDeadlock(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	metrics.WritePrometheus(rec)
-	if !strings.Contains(rec.Body.String(), `drive9_service_operations_total{component="central_quota",operation="reserve_upload",result="lock_conflict_retry",tenant_id="tenant-retry-metric"} 2`) {
+	if !strings.Contains(rec.Body.String(), `drive9_service_operations_total{component="central_quota",operation="reserve_upload",result="lock_conflict_retry",tenant_id="tenant-retry-metric",tidbcloud_org_id="guest"} 2`) {
 		t.Fatalf("missing lock conflict retry metric:\n%s", rec.Body.String())
 	}
 }

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -20,13 +20,15 @@ type dbProbeState struct {
 }
 
 type registeredDB struct {
-	role     string
-	tenantID string
+	role           string
+	tenantID       string
+	tidbCloudOrgID string
 }
 
 type dbMetricKey struct {
-	role     string
-	tenantID string
+	role           string
+	tenantID       string
+	tidbCloudOrgID string
 }
 
 type dbMetrics struct {
@@ -93,12 +95,16 @@ func RegisterDB(role string, db *sql.DB) {
 }
 
 func RegisterTenantDB(role, tenantID string, db *sql.DB) {
+	RegisterTenantDBWithOrg(role, tenantID, "", db)
+}
+
+func RegisterTenantDBWithOrg(role, tenantID, tidbCloudOrgID string, db *sql.DB) {
 	if db == nil {
 		return
 	}
 	RegisterModule("db")
 	globalDB.mu.Lock()
-	globalDB.dbs[db] = registeredDB{role: role, tenantID: tenantID}
+	globalDB.dbs[db] = registeredDB{role: role, tenantID: tenantID, tidbCloudOrgID: tidbCloudOrgID}
 	globalDB.mu.Unlock()
 }
 
@@ -431,8 +437,9 @@ func writeDBPoolCloses(w http.ResponseWriter, key dbMetricKey, labels, reason st
 
 func (p registeredDB) metricKey() dbMetricKey {
 	return dbMetricKey{
-		role:     cleanMetricValue(p.role, "unknown"),
-		tenantID: cleanMetricValue(p.tenantID, "unknown"),
+		role:           cleanMetricValue(p.role, "unknown"),
+		tenantID:       cleanMetricValue(p.tenantID, "unknown"),
+		tidbCloudOrgID: cleanTiDBCloudOrgID(p.tidbCloudOrgID),
 	}
 }
 
@@ -482,7 +489,7 @@ func observeDBProbeDuration(start time.Time, role, result string) {
 func dbLabels(key dbMetricKey) string {
 	labels := fmt.Sprintf("role=\"%s\"", EscapePromLabel(key.role))
 	if key.hasTenantID() {
-		labels += fmt.Sprintf(",tenant_id=\"%s\"", EscapePromLabel(key.tenantID))
+		labels += fmt.Sprintf(",tenant_id=\"%s\",tidbcloud_org_id=\"%s\"", EscapePromLabel(key.tenantID), EscapePromLabel(key.tidbCloudOrgID))
 	}
 	return labels
 }
@@ -500,7 +507,10 @@ func sortedDBMetricKeys(totals map[dbMetricKey]dbPoolTotals) []dbMetricKey {
 		if keys[i].role != keys[j].role {
 			return keys[i].role < keys[j].role
 		}
-		return keys[i].tenantID < keys[j].tenantID
+		if keys[i].tenantID != keys[j].tenantID {
+			return keys[i].tenantID < keys[j].tenantID
+		}
+		return keys[i].tidbCloudOrgID < keys[j].tidbCloudOrgID
 	})
 	return keys
 }

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -133,6 +133,7 @@ func TestDBHealthProbeSkipsTenantPools(t *testing.T) {
 	const (
 		role     = "user"
 		tenantID = "tenant-db-metrics-test"
+		orgID    = "org-db-metrics-test"
 	)
 
 	healthy := &atomic.Bool{}
@@ -145,7 +146,7 @@ func TestDBHealthProbeSkipsTenantPools(t *testing.T) {
 		_ = db.Close()
 	})
 
-	RegisterTenantDB(role, tenantID, db)
+	RegisterTenantDBWithOrg(role, tenantID, orgID, db)
 	globalDB.probeOnce(context.Background(), time.Second, nil)
 	out := renderDB(t)
 
@@ -155,19 +156,19 @@ func TestDBHealthProbeSkipsTenantPools(t *testing.T) {
 	if strings.Contains(out, `drive9_db_unreachable_pools{role="user"`) {
 		t.Fatalf("expected user pool to have no unreachable probe series, got:\n%s", out)
 	}
-	if !strings.Contains(out, `drive9_db_pool_registered{role="user",tenant_id="`+tenantID+`"} 1`) {
+	if !strings.Contains(out, `drive9_db_pool_registered{role="user",tenant_id="`+tenantID+`",tidbcloud_org_id="`+orgID+`"} 1`) {
 		t.Fatalf("expected tenant pool_registered series, got:\n%s", out)
 	}
-	if strings.Contains(out, `drive9_db_pool_wait_count_total{role="user",tenant_id="`+tenantID+`"`) {
+	if strings.Contains(out, `drive9_db_pool_wait_count_total{role="user",tenant_id="`+tenantID+`",tidbcloud_org_id="`+orgID+`"`) {
 		t.Fatalf("expected tenant pool with zero wait count to omit wait count series, got:\n%s", out)
 	}
-	if strings.Contains(out, `drive9_db_pool_wait_duration_seconds_total{role="user",tenant_id="`+tenantID+`"`) {
+	if strings.Contains(out, `drive9_db_pool_wait_duration_seconds_total{role="user",tenant_id="`+tenantID+`",tidbcloud_org_id="`+orgID+`"`) {
 		t.Fatalf("expected tenant pool with zero wait duration to omit wait duration series, got:\n%s", out)
 	}
-	if strings.Contains(out, `drive9_db_pool_closes_total{role="user",tenant_id="`+tenantID+`"`) {
+	if strings.Contains(out, `drive9_db_pool_closes_total{role="user",tenant_id="`+tenantID+`",tidbcloud_org_id="`+orgID+`"`) {
 		t.Fatalf("expected tenant pool with zero closes to omit close series, got:\n%s", out)
 	}
-	if strings.Contains(out, `drive9_db_pool_connections{role="user",tenant_id="`+tenantID+`"`) {
+	if strings.Contains(out, `drive9_db_pool_connections{role="user",tenant_id="`+tenantID+`",tidbcloud_org_id="`+orgID+`"`) {
 		t.Fatalf("expected tenant pool with no open connections to omit pool connection series, got:\n%s", out)
 	}
 	rec := httptest.NewRecorder()
@@ -233,7 +234,7 @@ func TestDBPoolConnectionsIncludesTenantPoolsWithOpenConnections(t *testing.T) {
 	}
 
 	out := renderDB(t)
-	if !strings.Contains(out, `drive9_db_pool_connections{role="user",tenant_id="`+tenantID+`",state="open"} 1`) {
+	if !strings.Contains(out, `drive9_db_pool_connections{role="user",tenant_id="`+tenantID+`",tidbcloud_org_id="guest",state="open"} 1`) {
 		t.Fatalf("expected tenant pool with open connections to emit pool connection series, got:\n%s", out)
 	}
 }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -16,6 +16,8 @@ var operationDurationBounds = []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.
 var httpDurationBounds = []float64{0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10, 15, 20, 30, 60}
 var tenantPoolMetadataResumeWaitDurationBounds = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 240, 480, 600, 900, 1200}
 
+const tenantMetricGuestTiDBCloudOrgID = "guest"
+
 // sseConnectionDurationBounds covers SSE connection lifetimes, which can
 // range from sub-second probes to long-lived mounts. Buckets extend well
 // beyond httpDurationBounds so long-lived connections are visible without
@@ -49,6 +51,7 @@ var serviceGauge = serviceMeter.Float64Gauge("drive9_service_gauge", "Service ga
 var tenantPoolMetadataResumeWaitTotal = serviceMeter.Int64Counter("drive9_tenant_pool_metadata_resume_wait_total", "Tenant pool metadata resume wait attempts by pool_id/organization_id/scope/result")
 var tenantPoolMetadataResumeWaitDuration = serviceMeter.Float64Histogram("drive9_tenant_pool_metadata_resume_wait_duration_seconds", "Tenant pool metadata resume wait duration by pool_id/organization_id/scope/result", tenantPoolMetadataResumeWaitDurationBounds)
 var tenantPoolCapacity = serviceMeter.Float64Gauge("drive9_tenant_pool_capacity", "Tenant pool capacity by pool_id/organization_id/state")
+var tenantPoolBindings = serviceMeter.Float64Gauge("drive9_tenant_pool_bindings", "Tenant pool binding count by pool_id/tidbcloud_org_id/pool_status")
 var tidbCloudRBACCacheRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_rbac_cache_requests_total", "TiDB Cloud API key to cluster RBAC cache requests by path/scope/result")
 var tidbCloudOpenAPIRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_openapi_requests_total", "TiDB Cloud OpenAPI requests by path/operation/result")
 var tidbCloudSpendingLimitSyncTotal = serviceMeter.Int64Counter("drive9_tidbcloud_spending_limit_sync_total", "TiDB Cloud spending limit local sync outcomes by source/result")
@@ -68,37 +71,37 @@ var fuseRemoteOperationsTotal = fuseMeter.Int64Counter("drive9_fuse_remote_opera
 var fuseRemoteOperationDuration = fuseMeter.Float64Histogram("drive9_fuse_remote_operation_duration_seconds", "Remote FUSE operation duration histogram", operationDurationBounds)
 var fuseRemoteOperationBytes = fuseMeter.Int64Counter("drive9_fuse_remote_operation_bytes_total", "Bytes processed by remote FUSE operation/result")
 
-var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/surface/action/result/status_class")
+var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/tidbcloud_org/surface/action/result/status_class")
 var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_duration_seconds", "Tenant request duration histogram by surface/status_class", httpDurationBounds)
-var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/surface/action")
-var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/surface/direction")
-var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/surface/action/direction")
-var tenantCount = tenantMeter.Float64Gauge("drive9_tenant_count", "Tenant count by state")
-var tenantStorageBytes = tenantMeter.Float64Gauge("drive9_tenant_storage_bytes", "Tenant storage bytes by state")
-var tenantMediaFiles = tenantMeter.Float64Gauge("drive9_tenant_media_files", "Tenant media file count by state")
+var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/tidbcloud_org/surface/action")
+var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/tidbcloud_org/surface/direction")
+var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/tidbcloud_org/surface/action/direction")
+var tenantCount = tenantMeter.Float64Gauge("drive9_tenant_count", "Tenant count by status")
+var tenantStorageBytes = tenantMeter.Float64Gauge("drive9_tenant_storage_bytes", "Tenant storage bytes by tenant/tidbcloud_org/state")
+var tenantMediaFiles = tenantMeter.Float64Gauge("drive9_tenant_media_files", "Tenant media file count by tenant/tidbcloud_org/state")
 
 // SSE-specific instruments. SSE connection lifetimes are recorded here, not
 // in drive9_http_request_duration_seconds (which would pollute HTTP latency
 // alerts — SSE connections live as long as the client stays subscribed).
-var sseConnectionsTotal = sseMeter.Int64Counter("drive9_sse_connections_total", "SSE /v1/events connections opened by tenant_id/reason")
-var sseConnectionDuration = sseMeter.Float64Histogram("drive9_sse_connection_duration_seconds", "SSE connection lifetime (client stay-open duration, not request processing time)", sseConnectionDurationBounds)
-var sseInflight = sseMeter.Float64Gauge("drive9_sse_inflight_connections", "Active SSE /v1/events connections by tenant_id")
-var ssePhase1Duration = sseMeter.Float64Histogram("drive9_sse_phase1_duration_seconds", "SSE Phase-1 replay/reset duration (one EventsSince call + buffered stream)", ssePhase1DurationBounds)
-var sseEventsSentTotal = sseMeter.Int64Counter("drive9_sse_events_sent_total", "SSE events sent to clients by type/tenant_id")
-var sseResetsSentTotal = sseMeter.Int64Counter("drive9_sse_resets_sent_total", "SSE reset events sent by reason/tenant_id")
-var sseHeartbeatsSentTotal = sseMeter.Int64Counter("drive9_sse_heartbeats_sent_total", "SSE heartbeat events sent by tenant_id")
+var sseConnectionsTotal = sseMeter.Int64Counter("drive9_sse_connections_total", "SSE /v1/events connections opened by tenant_id/tidbcloud_org_id/reason")
+var sseConnectionDuration = sseMeter.Float64Histogram("drive9_sse_connection_duration_seconds", "SSE connection lifetime by tenant_id/tidbcloud_org_id (client stay-open duration, not request processing time)", sseConnectionDurationBounds)
+var sseInflight = sseMeter.Float64Gauge("drive9_sse_inflight_connections", "Active SSE /v1/events connections by tenant_id/tidbcloud_org_id")
+var ssePhase1Duration = sseMeter.Float64Histogram("drive9_sse_phase1_duration_seconds", "SSE Phase-1 replay/reset duration by tenant_id/tidbcloud_org_id (one EventsSince call + buffered stream)", ssePhase1DurationBounds)
+var sseEventsSentTotal = sseMeter.Int64Counter("drive9_sse_events_sent_total", "SSE events sent to clients by type/tenant_id/tidbcloud_org_id")
+var sseResetsSentTotal = sseMeter.Int64Counter("drive9_sse_resets_sent_total", "SSE reset events sent by reason/tenant_id/tidbcloud_org_id")
+var sseHeartbeatsSentTotal = sseMeter.Int64Counter("drive9_sse_heartbeats_sent_total", "SSE heartbeat events sent by tenant_id/tidbcloud_org_id")
 
 // Event-bus query instruments. Covers all fs_events DB reads (events_since,
 // poll, latest, oldest) so DB pressure and table growth on the events path
 // are observable without direct DB access.
 var eventBusQueryDuration = serviceMeter.Float64Histogram("drive9_event_bus_query_duration_seconds", "Event-bus fs_events query duration by operation/result", eventBusQueryDurationBounds)
-var eventBusPollFailuresTotal = sseMeter.Int64Counter("drive9_event_bus_poll_failures_total", "Event-bus cross-pod poll query failures by tenant_id")
-var eventBusPublishErrorsTotal = sseMeter.Int64Counter("drive9_event_bus_publish_errors_total", "Event-bus fs_events INSERT failures by tenant_id")
+var eventBusPollFailuresTotal = sseMeter.Int64Counter("drive9_event_bus_poll_failures_total", "Event-bus cross-pod poll query failures by tenant_id/tidbcloud_org_id")
+var eventBusPublishErrorsTotal = sseMeter.Int64Counter("drive9_event_bus_publish_errors_total", "Event-bus fs_events INSERT failures by tenant_id/tidbcloud_org_id")
 
 // fs_events table instruments. Compensates for the lack of direct TiDB
 // access: row count and prune volume are reported by the server itself.
-var fsEventsRows = sseMeter.Float64Gauge("drive9_fs_events_rows", "fs_events table row count by tenant_id")
-var fsEventsPrunedTotal = sseMeter.Int64Counter("drive9_fs_events_pruned_total", "fs_events rows pruned by retention cleanup by tenant_id")
+var fsEventsRows = sseMeter.Float64Gauge("drive9_fs_events_rows", "fs_events table row count by tenant_id/tidbcloud_org_id")
+var fsEventsPrunedTotal = sseMeter.Int64Counter("drive9_fs_events_pruned_total", "fs_events rows pruned by retention cleanup by tenant_id/tidbcloud_org_id")
 
 func RegisterModule(module string) {
 	globalRegistry.RegisterModule(module)
@@ -113,27 +116,30 @@ func RecordOperation(component, operation, result string, d time.Duration) {
 }
 
 func RecordTenantOperation(tenantID, component, operation, result string, d time.Duration) {
+	RecordTenantOperationWithOrg(tenantID, "", component, operation, result, d)
+}
+
+func RecordTenantOperationWithOrg(tenantID, tidbCloudOrgID, component, operation, result string, d time.Duration) {
 	component = cleanMetricValue(component, "unknown")
 	operation = cleanMetricValue(operation, "unknown")
 	result = cleanMetricValue(result, "unknown")
 	tenantID = cleanMetricValue(tenantID, "unknown")
+	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	RegisterModule(component)
-	baseAttrs := [4]Attribute{
+	baseAttrs := []Attribute{
 		Attr("component", component),
 		Attr("operation", operation),
 		Attr("result", result),
 	}
-	counterAttrs := baseAttrs[:3]
+	counterAttrs := baseAttrs
 	if tenantID != "unknown" {
-		baseAttrs[3] = Attr("tenant_id", tenantID)
-		counterAttrs = baseAttrs[:4]
+		counterAttrs = append(counterAttrs, Attr("tenant_id", tenantID), Attr("tidbcloud_org_id", tidbCloudOrgID))
 	}
 	serviceOperationsTotal.Add(1, counterAttrs...)
 	if d <= 0 {
 		return
 	}
-	durationAttrs := baseAttrs[:3]
-	serviceOperationDuration.Observe(d.Seconds(), durationAttrs...)
+	serviceOperationDuration.Observe(d.Seconds(), baseAttrs...)
 }
 
 func RecordTenantPoolMetadataResumeWait(poolID, organizationID, scope, result string, d time.Duration) {
@@ -157,6 +163,18 @@ func RecordTenantPoolCapacity(poolID, organizationID, state string, value float6
 		Attr("pool_id", cleanMetricValue(poolID, "unknown")),
 		Attr("organization_id", cleanMetricValue(organizationID, "unknown")),
 		Attr("state", cleanMetricValue(state, "unknown")),
+	)
+}
+
+func RecordTenantPoolBindings(poolID, tidbCloudOrgID, poolStatus string, count int64) {
+	if count < 0 {
+		return
+	}
+	RegisterModule("admin_tenant_pool")
+	tenantPoolBindings.Set(float64(count),
+		Attr("pool_id", cleanMetricValue(poolID, "unknown")),
+		Attr("tidbcloud_org_id", cleanMetricValue(tidbCloudOrgID, "unknown")),
+		Attr("pool_status", cleanMetricValue(poolStatus, "unknown")),
 	)
 }
 
@@ -218,10 +236,15 @@ func ResultForError(err error) string {
 // duration sample. Use it for per-entry counters when one wall-clock duration
 // would be duplicated across many logical items in the same batch.
 func RecordTenantOperationCount(tenantID, component, operation, result string) {
+	RecordTenantOperationCountWithOrg(tenantID, "", component, operation, result)
+}
+
+func RecordTenantOperationCountWithOrg(tenantID, tidbCloudOrgID, component, operation, result string) {
 	component = cleanMetricValue(component, "unknown")
 	operation = cleanMetricValue(operation, "unknown")
 	result = cleanMetricValue(result, "unknown")
 	tenantID = cleanMetricValue(tenantID, "unknown")
+	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	RegisterModule(component)
 	attrs := []Attribute{
 		Attr("component", component),
@@ -229,7 +252,7 @@ func RecordTenantOperationCount(tenantID, component, operation, result string) {
 		Attr("result", result),
 	}
 	if tenantID != "unknown" {
-		attrs = append(attrs, Attr("tenant_id", tenantID))
+		attrs = append(attrs, Attr("tenant_id", tenantID), Attr("tidbcloud_org_id", tidbCloudOrgID))
 	}
 	serviceOperationsTotal.Add(1, attrs...)
 }
@@ -239,11 +262,21 @@ func RecordGauge(component, name string, value float64) {
 }
 
 func RecordTenantGauge(tenantID, component, name string, value float64) {
+	RecordTenantGaugeWithOrg(tenantID, "", component, name, value)
+}
+
+func RecordTenantGaugeWithOrg(tenantID, tidbCloudOrgID, component, name string, value float64) {
 	component = cleanMetricValue(component, "unknown")
 	name = cleanMetricValue(name, "unknown")
 	tenantID = strings.TrimSpace(tenantID)
+	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	RegisterModule(component)
-	serviceGauge.Set(value, Attr("component", component), Attr("name", name), Attr("tenant_id", tenantID))
+	serviceGauge.Set(value,
+		Attr("component", component),
+		Attr("name", name),
+		Attr("tenant_id", tenantID),
+		Attr("tidbcloud_org_id", tidbCloudOrgID),
+	)
 }
 
 func RecordHTTPRequest(method, route string, status int, d time.Duration) {
@@ -285,13 +318,19 @@ func RecordHTTPRequestCount(method, route string, status int) {
 // RecordTenantRequestCount records only the tenant request counter, not the
 // duration histogram. Companion to RecordHTTPRequestCount for SSE routes.
 func RecordTenantRequestCount(tenantID, surface, action, result string, status int) {
+	RecordTenantRequestCountWithOrg(tenantID, "", surface, action, result, status)
+}
+
+func RecordTenantRequestCountWithOrg(tenantID, tidbCloudOrgID, surface, action, result string, status int) {
 	tenantID = cleanMetricValue(tenantID, "unknown")
+	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	surface = cleanMetricValue(surface, "other")
 	action = cleanMetricValue(action, "other")
 	result = cleanMetricValue(result, "unknown")
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
 		Attr("tenant_id", tenantID),
+		Attr("tidbcloud_org_id", tidbCloudOrgID),
 		Attr("surface", surface),
 		Attr("action", action),
 		Attr("result", result),
@@ -315,12 +354,17 @@ func RecordEvent(event string, labels ...string) {
 }
 
 func RecordTenantEvent(tenantID, event string, labels ...string) {
+	RecordTenantEventWithOrg(tenantID, "", event, labels...)
+}
+
+func RecordTenantEventWithOrg(tenantID, tidbCloudOrgID, event string, labels ...string) {
 	RegisterModule("server")
 	attrs := make([]Attribute, 0, len(labels)/2+2)
 	attrs = append(attrs, Attr("event", cleanMetricValue(event, "unknown")))
 	tenantID = cleanMetricValue(tenantID, "unknown")
+	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	if tenantID != "unknown" {
-		attrs = append(attrs, Attr("tenant_id", tenantID))
+		attrs = append(attrs, Attr("tenant_id", tenantID), Attr("tidbcloud_org_id", tidbCloudOrgID))
 	}
 	for i := 0; i+1 < len(labels); i += 2 {
 		attrs = append(attrs, Attr(labels[i], labels[i+1]))
@@ -329,7 +373,12 @@ func RecordTenantEvent(tenantID, event string, labels ...string) {
 }
 
 func RecordTenantRequest(tenantID, surface, action, result string, status int, d time.Duration) {
+	RecordTenantRequestWithOrg(tenantID, "", surface, action, result, status, d)
+}
+
+func RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, surface, action, result string, status int, d time.Duration) {
 	tenantID = cleanMetricValue(tenantID, "unknown")
+	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	surface = cleanMetricValue(surface, "other")
 	action = cleanMetricValue(action, "other")
 	result = cleanMetricValue(result, "unknown")
@@ -340,6 +389,7 @@ func RecordTenantRequest(tenantID, surface, action, result string, status int, d
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
 		Attr("tenant_id", tenantID),
+		Attr("tidbcloud_org_id", tidbCloudOrgID),
 		Attr("surface", surface),
 		Attr("action", action),
 		Attr("result", result),
@@ -356,17 +406,30 @@ func RecordTenantRequest(tenantID, surface, action, result string, status int, d
 }
 
 func RecordTenantHTTPBytes(tenantID, surface, _, direction string, bytes int64) {
-	recordTenantHTTPBytes(tenantID, surface, direction, bytes)
+	RecordTenantHTTPBytesWithOrg(tenantID, "", surface, "", direction, bytes)
+}
+
+func RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, surface, _, direction string, bytes int64) {
+	recordTenantHTTPBytes(tenantID, tidbCloudOrgID, surface, direction, bytes)
 }
 
 func RecordTenantFileBytes(tenantID, surface, action, direction string, bytes int64) {
-	recordTenantBytes(tenantFileBytes, tenantID, surface, action, direction, bytes)
+	RecordTenantFileBytesWithOrg(tenantID, "", surface, action, direction, bytes)
+}
+
+func RecordTenantFileBytesWithOrg(tenantID, tidbCloudOrgID, surface, action, direction string, bytes int64) {
+	recordTenantBytes(tenantFileBytes, tenantID, tidbCloudOrgID, surface, action, direction, bytes)
 }
 
 func RecordTenantInFlight(tenantID, surface, action string, value float64) {
+	RecordTenantInFlightWithOrg(tenantID, "", surface, action, value)
+}
+
+func RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, surface, action string, value float64) {
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("surface", cleanMetricValue(surface, "other")),
 		Attr("action", cleanMetricValue(action, "other")),
 	}
@@ -377,58 +440,70 @@ func RecordTenantInFlight(tenantID, surface, action string, value float64) {
 	tenantInflight.Set(value, attrs...)
 }
 
-func RecordTenantCount(state string, count int64) {
+func RecordTenantCount(status string, count int64) {
 	if count < 0 {
 		return
 	}
 	RegisterModule("tenant_usage")
 	tenantCount.Set(float64(count),
-		Attr("state", cleanMetricValue(state, "unknown")),
+		Attr("status", cleanMetricValue(status, "unknown")),
 	)
 }
 
 func RecordTenantStorageBytes(tenantID, state string, bytes int64) {
+	RecordTenantStorageBytesWithOrg(tenantID, "", state, bytes)
+}
+
+func RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, state string, bytes int64) {
 	if bytes < 0 {
 		return
 	}
 	RegisterModule("tenant_usage")
 	tenantStorageBytes.Set(float64(bytes),
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("state", cleanMetricValue(state, "unknown")),
 	)
 }
 
 func RecordTenantMediaFiles(tenantID, state string, count int64) {
+	RecordTenantMediaFilesWithOrg(tenantID, "", state, count)
+}
+
+func RecordTenantMediaFilesWithOrg(tenantID, tidbCloudOrgID, state string, count int64) {
 	if count < 0 {
 		return
 	}
 	RegisterModule("tenant_usage")
 	tenantMediaFiles.Set(float64(count),
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("state", cleanMetricValue(state, "unknown")),
 	)
 }
 
-func recordTenantBytes(counter *Int64Counter, tenantID, surface, action, direction string, bytes int64) {
+func recordTenantBytes(counter *Int64Counter, tenantID, tidbCloudOrgID, surface, action, direction string, bytes int64) {
 	if bytes <= 0 {
 		return
 	}
 	RegisterModule("tenant_usage")
 	counter.Add(bytes,
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("surface", cleanMetricValue(surface, "other")),
 		Attr("action", cleanMetricValue(action, "other")),
 		Attr("direction", cleanMetricValue(direction, "unknown")),
 	)
 }
 
-func recordTenantHTTPBytes(tenantID, surface, direction string, bytes int64) {
+func recordTenantHTTPBytes(tenantID, tidbCloudOrgID, surface, direction string, bytes int64) {
 	if bytes <= 0 {
 		return
 	}
 	RegisterModule("tenant_usage")
 	tenantHTTPBytes.Add(bytes,
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("surface", cleanMetricValue(surface, "other")),
 		Attr("direction", cleanMetricValue(direction, "unknown")),
 	)
@@ -467,13 +542,25 @@ func RecordFuseRemoteOperation(operation, result string, d time.Duration, bytes 
 // live as long as the client stays subscribed, so mixing them into the HTTP
 // latency histogram would make all HTTP P95/P99 alerts meaningless.
 func RecordSSEConnection(tenantID, reason string, d time.Duration) {
+	RecordSSEConnectionWithOrg(tenantID, "", reason, d)
+}
+
+func RecordSSEConnectionWithOrg(tenantID, tidbCloudOrgID, reason string, d time.Duration) {
 	RegisterModule("sse")
 	tenantID = cleanMetricValue(tenantID, "unknown")
-	sseConnectionsTotal.Add(1, Attr("tenant_id", tenantID), Attr("reason", cleanMetricValue(reason, "unknown")))
+	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
+	sseConnectionsTotal.Add(1,
+		Attr("tenant_id", tenantID),
+		Attr("tidbcloud_org_id", tidbCloudOrgID),
+		Attr("reason", cleanMetricValue(reason, "unknown")),
+	)
 	if d <= 0 {
 		return
 	}
-	sseConnectionDuration.Observe(d.Seconds(), Attr("tenant_id", tenantID))
+	sseConnectionDuration.Observe(d.Seconds(),
+		Attr("tenant_id", tenantID),
+		Attr("tidbcloud_org_id", tidbCloudOrgID),
+	)
 }
 
 // RecordSSEInFlight sets the active SSE connection count for a tenant. The
@@ -481,44 +568,75 @@ func RecordSSEConnection(tenantID, reason string, d time.Duration) {
 // on unsubscribe); this records the current value so the gauge reflects the
 // true number of live SSE connections per tenant.
 func RecordSSEInFlight(tenantID string, count float64) {
+	RecordSSEInFlightWithOrg(tenantID, "", count)
+}
+
+func RecordSSEInFlightWithOrg(tenantID, tidbCloudOrgID string, count float64) {
 	if count < 0 {
 		count = 0
 	}
 	RegisterModule("sse")
-	sseInflight.Set(count, Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+	sseInflight.Set(count,
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+	)
 }
 
 // RecordSSEPhase1 records the duration of the SSE Phase-1 replay/reset stage.
 func RecordSSEPhase1(tenantID string, d time.Duration) {
+	RecordSSEPhase1WithOrg(tenantID, "", d)
+}
+
+func RecordSSEPhase1WithOrg(tenantID, tidbCloudOrgID string, d time.Duration) {
 	if d <= 0 {
 		return
 	}
 	RegisterModule("sse")
-	ssePhase1Duration.Observe(d.Seconds(), Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+	ssePhase1Duration.Observe(d.Seconds(),
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+	)
 }
 
 // RecordSSEEventSent records a single SSE file_changed event delivery.
 func RecordSSEEventSent(tenantID, op string) {
+	RecordSSEEventSentWithOrg(tenantID, "", op)
+}
+
+func RecordSSEEventSentWithOrg(tenantID, tidbCloudOrgID, op string) {
 	RegisterModule("sse")
 	sseEventsSentTotal.Add(1,
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("op", cleanMetricValue(op, "unknown")),
 	)
 }
 
 // RecordSSEResetSent records an SSE reset event delivery.
 func RecordSSEResetSent(tenantID, reason string) {
+	RecordSSEResetSentWithOrg(tenantID, "", reason)
+}
+
+func RecordSSEResetSentWithOrg(tenantID, tidbCloudOrgID, reason string) {
 	RegisterModule("sse")
 	sseResetsSentTotal.Add(1,
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("reason", cleanMetricValue(reason, "unknown")),
 	)
 }
 
 // RecordSSEHeartbeatSent records an SSE heartbeat delivery.
 func RecordSSEHeartbeatSent(tenantID string) {
+	RecordSSEHeartbeatSentWithOrg(tenantID, "")
+}
+
+func RecordSSEHeartbeatSentWithOrg(tenantID, tidbCloudOrgID string) {
 	RegisterModule("sse")
-	sseHeartbeatsSentTotal.Add(1, Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+	sseHeartbeatsSentTotal.Add(1,
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+	)
 }
 
 // RecordEventBusQuery records the duration of an fs_events DB query. Unlike
@@ -538,35 +656,63 @@ func RecordEventBusQuery(tenantID, operation, result string, d time.Duration) {
 // RecordEventBusPollFailure records a cross-pod poll query failure (previously
 // only logged, not metriced).
 func RecordEventBusPollFailure(tenantID string) {
+	RecordEventBusPollFailureWithOrg(tenantID, "")
+}
+
+func RecordEventBusPollFailureWithOrg(tenantID, tidbCloudOrgID string) {
 	RegisterModule("sse")
-	eventBusPollFailuresTotal.Add(1, Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+	eventBusPollFailuresTotal.Add(1,
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+	)
 }
 
 // RecordEventBusPublishError records an fs_events INSERT failure.
 func RecordEventBusPublishError(tenantID string) {
+	RecordEventBusPublishErrorWithOrg(tenantID, "")
+}
+
+func RecordEventBusPublishErrorWithOrg(tenantID, tidbCloudOrgID string) {
 	RegisterModule("sse")
-	eventBusPublishErrorsTotal.Add(1, Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+	eventBusPublishErrorsTotal.Add(1,
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+	)
 }
 
 // RecordFSEventsRows records the current fs_events row count for a tenant.
 // This compensates for the lack of direct TiDB access: the leader cleanup
 // goroutine samples the count and reports it here.
 func RecordFSEventsRows(tenantID string, count int64) {
+	RecordFSEventsRowsWithOrg(tenantID, "", count)
+}
+
+func RecordFSEventsRowsWithOrg(tenantID, tidbCloudOrgID string, count int64) {
 	if count < 0 {
 		return
 	}
 	RegisterModule("sse")
-	fsEventsRows.Set(float64(count), Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+	fsEventsRows.Set(float64(count),
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+	)
 }
 
 // RecordFSEventsPruned records the number of fs_events rows deleted by
 // retention cleanup.
 func RecordFSEventsPruned(tenantID string, count int64) {
+	RecordFSEventsPrunedWithOrg(tenantID, "", count)
+}
+
+func RecordFSEventsPrunedWithOrg(tenantID, tidbCloudOrgID string, count int64) {
 	if count <= 0 {
 		return
 	}
 	RegisterModule("sse")
-	fsEventsPrunedTotal.Add(count, Attr("tenant_id", cleanMetricValue(tenantID, "unknown")))
+	fsEventsPrunedTotal.Add(count,
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+	)
 }
 
 func WritePrometheus(w http.ResponseWriter) {
@@ -586,6 +732,10 @@ func cleanMetricValue(value, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func cleanTiDBCloudOrgID(orgID string) string {
+	return cleanMetricValue(orgID, tenantMetricGuestTiDBCloudOrgID)
 }
 
 func statusClass(status int) string {

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -39,12 +39,12 @@ func TestRecordTenantOperationCountDoesNotRecordDuration(t *testing.T) {
 	const component = "counter_only_test_component"
 	const operation = "counter_only_test_operation"
 
-	RecordTenantOperationCount("tenant-a", component, operation, "ok")
+	RecordTenantOperationCountWithOrg("tenant-a", "org-counter-only", component, operation, "ok")
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-a"} 1`) {
+	if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-a",tidbcloud_org_id="org-counter-only"} 1`) {
 		t.Fatalf("missing counter-only operation total:\n%s", text)
 	}
 	if strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-a"}`) {
@@ -56,12 +56,12 @@ func TestRecordTenantOperationZeroDurationDoesNotRecordDuration(t *testing.T) {
 	const component = "zero_duration_test_component"
 	const operation = "zero_duration_test_operation"
 
-	RecordTenantOperation("tenant-zero", component, operation, "ok", 0)
+	RecordTenantOperationWithOrg("tenant-zero", "org-zero-duration", component, operation, "ok", 0)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-zero"} 1`) {
+	if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-zero",tidbcloud_org_id="org-zero-duration"} 1`) {
 		t.Fatalf("missing zero-duration operation total:\n%s", text)
 	}
 	if strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-zero"}`) {
@@ -75,12 +75,12 @@ func TestRecordTenantOperationOmitsTenantFromDurationHistograms(t *testing.T) {
 	for _, component := range []string{"backend", "central_quota", "file_gc", "quota_config_cache", "server_quota", "user_db_access", "vault"} {
 		t.Run(component, func(t *testing.T) {
 			tenantID := "tenant-duration-omit-" + component
-			RecordTenantOperation(tenantID, component, operation, "ok", time.Second)
+			RecordTenantOperationWithOrg(tenantID, "org-"+component, component, operation, "ok", time.Second)
 
 			rec := httptest.NewRecorder()
 			WritePrometheus(rec)
 			text := rec.Body.String()
-			if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="`+tenantID+`"} 1`) {
+			if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="`+tenantID+`",tidbcloud_org_id="org-`+component+`"} 1`) {
 				t.Fatalf("missing tenant-scoped operation total:\n%s", text)
 			}
 			if !strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok"} 1`) {
@@ -100,12 +100,12 @@ func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 		action   = "request_duration_action"
 	)
 
-	RecordTenantRequest(tenantID, surface, action, "ok", 201, time.Second)
+	RecordTenantRequestWithOrg(tenantID, "org-request-duration", surface, action, "ok", 201, time.Second)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_requests_total{action="`+action+`",result="ok",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`"} 1`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="`+action+`",result="ok",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`",tidbcloud_org_id="org-request-duration"} 1`) {
 		t.Errorf("missing tenant-scoped request total:\n%s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_count{status_class="2xx",surface="`+surface+`"} 1`) {
@@ -131,7 +131,7 @@ func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_requests_total{action="zero_action",result="ok",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`"} 1`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="zero_action",result="ok",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`",tidbcloud_org_id="guest"} 1`) {
 		t.Errorf("missing zero-duration tenant request total:\n%s", text)
 	}
 	if strings.Contains(text, `drive9_tenant_request_duration_seconds_count{surface="zero_surface"`) {
@@ -142,12 +142,12 @@ func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
 func TestRecordSSEConnectionZeroDurationDoesNotRecordDuration(t *testing.T) {
 	const tenantID = "tenant-zero-sse-connection"
 
-	RecordSSEConnection(tenantID, "closed", 0)
+	RecordSSEConnectionWithOrg(tenantID, "org-sse-zero", "closed", 0)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_sse_connections_total{reason="closed",tenant_id="`+tenantID+`"} 1`) {
+	if !strings.Contains(text, `drive9_sse_connections_total{reason="closed",tenant_id="`+tenantID+`",tidbcloud_org_id="org-sse-zero"} 1`) {
 		t.Fatalf("missing zero-duration SSE connection total:\n%s", text)
 	}
 	if strings.Contains(text, `drive9_sse_connection_duration_seconds_count{tenant_id="`+tenantID+`"}`) {
@@ -198,37 +198,100 @@ func TestRecordTenantInFlightDeletesZeroValue(t *testing.T) {
 		action   = "inflight_delete_action"
 	)
 
-	RecordTenantInFlight(tenantID, surface, action, 1)
+	RecordTenantInFlightWithOrg(tenantID, "org-inflight-delete", surface, action, 1)
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_inflight_requests{action="`+action+`",surface="`+surface+`",tenant_id="`+tenantID+`"} 1.000000`) {
+	if !strings.Contains(text, `drive9_tenant_inflight_requests{action="`+action+`",surface="`+surface+`",tenant_id="`+tenantID+`",tidbcloud_org_id="org-inflight-delete"} 1.000000`) {
 		t.Errorf("missing tenant in-flight gauge:\n%s", text)
 	}
 
-	RecordTenantInFlight(tenantID, surface, action, 0)
+	RecordTenantInFlightWithOrg(tenantID, "org-inflight-delete", surface, action, 0)
 	rec = httptest.NewRecorder()
 	WritePrometheus(rec)
 	text = rec.Body.String()
-	if strings.Contains(text, `drive9_tenant_inflight_requests{action="`+action+`",surface="`+surface+`",tenant_id="`+tenantID+`"}`) {
+	if strings.Contains(text, `drive9_tenant_inflight_requests{action="`+action+`",surface="`+surface+`",tenant_id="`+tenantID+`",tidbcloud_org_id="org-inflight-delete"}`) {
 		t.Errorf("tenant in-flight gauge should be deleted at zero:\n%s", text)
 	}
 }
 
-func TestRecordTenantCountIncludesState(t *testing.T) {
-	RecordTenantCount("total_non_deleted_test", 7)
-	RecordTenantCount("active_test", 3)
+func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
+	const (
+		tenantID = "tenant-org-label-test"
+		orgID    = "org-label-test"
+	)
+
+	RecordTenantGaugeWithOrg(tenantID, orgID, "component_org_label_test", "gauge", 1)
+	RecordTenantEventWithOrg(tenantID, orgID, "event_org_label_test", "result", "ok")
+	RecordTenantRequestCountWithOrg(tenantID, orgID, "surface_org_label_test", "action", "ok", 200)
+	RecordTenantHTTPBytesWithOrg(tenantID, orgID, "surface_org_label_test", "ignored", "request", 10)
+	RecordTenantFileBytesWithOrg(tenantID, orgID, "surface_org_label_test", "write", "out", 20)
+	RecordTenantStorageBytesWithOrg(tenantID, orgID, "confirmed", 30)
+	RecordTenantMediaFilesWithOrg(tenantID, orgID, "confirmed", 40)
+	RecordSSEInFlightWithOrg(tenantID, orgID, 1)
+	RecordSSEPhase1WithOrg(tenantID, orgID, time.Second)
+	RecordSSEEventSentWithOrg(tenantID, orgID, "write")
+	RecordSSEResetSentWithOrg(tenantID, orgID, "seq_too_old")
+	RecordSSEHeartbeatSentWithOrg(tenantID, orgID)
+	RecordEventBusPollFailureWithOrg(tenantID, orgID)
+	RecordEventBusPublishErrorWithOrg(tenantID, orgID)
+	RecordFSEventsRowsWithOrg(tenantID, orgID, 50)
+	RecordFSEventsPrunedWithOrg(tenantID, orgID, 60)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
 	for _, want := range []string{
-		`drive9_tenant_count{state="total_non_deleted_test"} 7.000000`,
-		`drive9_tenant_count{state="active_test"} 3.000000`,
+		`drive9_service_gauge{component="component_org_label_test",name="gauge",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1.000000`,
+		`drive9_business_events_total{event="event_org_label_test",result="ok",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_tenant_requests_total{action="action",result="ok",status_class="2xx",surface="surface_org_label_test",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_tenant_http_bytes_total{direction="request",surface="surface_org_label_test",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 10`,
+		`drive9_tenant_file_bytes_total{action="write",direction="out",surface="surface_org_label_test",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 20`,
+		`drive9_tenant_storage_bytes{state="confirmed",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 30.000000`,
+		`drive9_tenant_media_files{state="confirmed",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 40.000000`,
+		`drive9_sse_inflight_connections{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1.000000`,
+		`drive9_sse_phase1_duration_seconds_count{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_sse_events_sent_total{op="write",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_sse_resets_sent_total{reason="seq_too_old",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_sse_heartbeats_sent_total{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_event_bus_poll_failures_total{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_event_bus_publish_errors_total{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_fs_events_rows{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 50.000000`,
+		`drive9_fs_events_pruned_total{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 60`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing org-scoped tenant metric %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestRecordTenantCountUsesStatus(t *testing.T) {
+	RecordTenantCount("pending_test", 1)
+	RecordTenantCount("provisioning_test", 2)
+	RecordTenantCount("active_test", 3)
+	RecordTenantCount("failed_test", 4)
+	RecordTenantCount("suspended_test", 5)
+	RecordTenantCount("deleting_test", 6)
+	RecordTenantCount("deleted_test", 7)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	for _, want := range []string{
+		`drive9_tenant_count{status="pending_test"} 1.000000`,
+		`drive9_tenant_count{status="provisioning_test"} 2.000000`,
+		`drive9_tenant_count{status="active_test"} 3.000000`,
+		`drive9_tenant_count{status="failed_test"} 4.000000`,
+		`drive9_tenant_count{status="suspended_test"} 5.000000`,
+		`drive9_tenant_count{status="deleting_test"} 6.000000`,
+		`drive9_tenant_count{status="deleted_test"} 7.000000`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Errorf("missing tenant count metric %q:\n%s", want, text)
 		}
+	}
+	if strings.Contains(text, `drive9_tenant_non_deleted_count`) || strings.Contains(text, `total_non_deleted`) {
+		t.Fatalf("tenant count metrics must only use real status values:\n%s", text)
 	}
 }
 
@@ -300,6 +363,24 @@ func TestRecordTenantPoolCapacityIncludesPoolOrganizationAndState(t *testing.T) 
 	}
 	if !strings.Contains(text, `drive9_tenant_pool_capacity{organization_id="`+organizationID+`",pool_id="`+poolID+`",state="free"} 1`) {
 		t.Fatalf("missing tenant pool free capacity gauge:\n%s", text)
+	}
+}
+
+func TestRecordTenantPoolBindingsIncludesPoolTiDBCloudOrgAndStatus(t *testing.T) {
+	const poolID = "pool-binding-metrics-test"
+	const orgID = "org-binding-metrics-test"
+
+	RecordTenantPoolBindings(poolID, orgID, "free", 3)
+	RecordTenantPoolBindings(poolID, orgID, "used", 2)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_tenant_pool_bindings{pool_id="`+poolID+`",pool_status="free",tidbcloud_org_id="`+orgID+`"} 3`) {
+		t.Fatalf("missing tenant pool free binding gauge:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_pool_bindings{pool_id="`+poolID+`",pool_status="used",tidbcloud_org_id="`+orgID+`"} 2`) {
+		t.Fatalf("missing tenant pool used binding gauge:\n%s", text)
 	}
 }
 

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -11,6 +11,25 @@ import (
 	"time"
 )
 
+func hasMetricLineWith(text, metric string, fragments ...string) bool {
+	for _, line := range strings.Split(text, "\n") {
+		if !strings.HasPrefix(line, metric+"{") && !strings.HasPrefix(line, metric+" ") {
+			continue
+		}
+		matches := true
+		for _, fragment := range fragments {
+			if !strings.Contains(line, fragment) {
+				matches = false
+				break
+			}
+		}
+		if matches {
+			return true
+		}
+	}
+	return false
+}
+
 func TestResultForError(t *testing.T) {
 	tests := []struct {
 		name string
@@ -111,14 +130,17 @@ func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_count{status_class="2xx",surface="`+surface+`"} 1`) {
 		t.Errorf("missing reduced request duration histogram:\n%s", text)
 	}
+	if hasMetricLineWith(text, "drive9_tenant_requests_total", `status="201"`) {
+		t.Errorf("tenant request total unexpectedly carried raw status label:\n%s", text)
+	}
 	for _, unexpected := range []string{
-		`drive9_tenant_requests_total{result="ok",status="201"`,
-		`drive9_tenant_request_duration_seconds_count{action="` + action + `"`,
-		`drive9_tenant_request_duration_seconds_count{result="ok"`,
-		`drive9_tenant_request_duration_seconds_count{status_class="2xx",surface="` + surface + `",tenant_id="` + tenantID + `"`,
+		`action="` + action + `"`,
+		`result="ok"`,
+		`tenant_id="` + tenantID + `"`,
+		`tidbcloud_org_id="org-request-duration"`,
 	} {
-		if strings.Contains(text, unexpected) {
-			t.Errorf("tenant request metric unexpectedly carried high-cardinality label %q:\n%s", unexpected, text)
+		if hasMetricLineWith(text, "drive9_tenant_request_duration_seconds_count", unexpected) {
+			t.Errorf("tenant request duration unexpectedly carried label %q:\n%s", unexpected, text)
 		}
 	}
 }
@@ -134,7 +156,7 @@ func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
 	if !strings.Contains(text, `drive9_tenant_requests_total{action="zero_action",result="ok",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`",tidbcloud_org_id="guest"} 1`) {
 		t.Errorf("missing zero-duration tenant request total:\n%s", text)
 	}
-	if strings.Contains(text, `drive9_tenant_request_duration_seconds_count{surface="zero_surface"`) {
+	if hasMetricLineWith(text, "drive9_tenant_request_duration_seconds_count", `surface="zero_surface"`) {
 		t.Errorf("zero-duration tenant request unexpectedly recorded a duration:\n%s", text)
 	}
 }
@@ -150,7 +172,7 @@ func TestRecordSSEConnectionZeroDurationDoesNotRecordDuration(t *testing.T) {
 	if !strings.Contains(text, `drive9_sse_connections_total{reason="closed",tenant_id="`+tenantID+`",tidbcloud_org_id="org-sse-zero"} 1`) {
 		t.Fatalf("missing zero-duration SSE connection total:\n%s", text)
 	}
-	if strings.Contains(text, `drive9_sse_connection_duration_seconds_count{tenant_id="`+tenantID+`"}`) {
+	if hasMetricLineWith(text, "drive9_sse_connection_duration_seconds_count", `tenant_id="`+tenantID+`"`) {
 		t.Fatalf("zero-duration SSE connection unexpectedly recorded a duration:\n%s", text)
 	}
 }
@@ -167,10 +189,10 @@ func TestRecordTenantDurationMetricsSkipZeroDuration(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if strings.Contains(text, `drive9_sse_phase1_duration_seconds_count{tenant_id="`+phaseTenant+`"}`) {
+	if hasMetricLineWith(text, "drive9_sse_phase1_duration_seconds_count", `tenant_id="`+phaseTenant+`"`) {
 		t.Fatalf("zero-duration SSE phase1 unexpectedly recorded a duration:\n%s", text)
 	}
-	if strings.Contains(text, `drive9_event_bus_query_duration_seconds_count{operation="events_since",result="ok",tenant_id="`+eventBusTenant+`"}`) {
+	if hasMetricLineWith(text, "drive9_event_bus_query_duration_seconds_count", `operation="events_since"`, `result="ok"`) {
 		t.Fatalf("zero-duration event bus query unexpectedly recorded a duration:\n%s", text)
 	}
 }

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -33,13 +33,17 @@ func OpenInstrumented(ctx context.Context, dsn, role string) (*sql.DB, error) {
 }
 
 func OpenInstrumentedForTenant(ctx context.Context, dsn, role, tenantID string) (*sql.DB, error) {
+	return OpenInstrumentedForTenantWithOrg(ctx, dsn, role, tenantID, "")
+}
+
+func OpenInstrumentedForTenantWithOrg(ctx context.Context, dsn, role, tenantID, tidbCloudOrgID string) (*sql.DB, error) {
 	connector, err := (&mysql.MySQLDriver{}).OpenConnector(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open mysql connector: %w", err)
 	}
 	db := sql.OpenDB(instrumentedConnector{base: connector, role: role})
 	ApplyPoolDefaults(db, role)
-	metrics.RegisterTenantDB(role, tenantID, db)
+	metrics.RegisterTenantDBWithOrg(role, tenantID, tidbCloudOrgID, db)
 	if err := db.PingContext(ctx); err != nil {
 		metrics.UnregisterDB(db)
 		_ = db.Close()

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -178,7 +178,7 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		return
 	} else if claimed {
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
-		setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+		setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, res.OrganizationID, classifyTenantRequest(r))
 		s.forgetTiDBCloudRBACList(cred)
 		if res.Status == meta.TenantProvisioning {
 			s.startProvisionedTenantSchemaInit(r.Context(), res)
@@ -212,7 +212,7 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		errJSON(w, http.StatusInternalServerError, "failed to provision tenant")
 		return
 	}
-	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, res.OrganizationID, classifyTenantRequest(r))
 	s.forgetTiDBCloudRBACList(cred)
 	s.startProvisionedTenantSchemaInit(r.Context(), res)
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -472,7 +472,7 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 		b, release, err := pool.Acquire(r.Context(), tenant)
 		// Capability-token request-path acquire: same baseline signal as the
 		// API-key path above, but for the /v1/vault/read surface.
-		authAcquireOrgID := defaultTenantMetricTiDBCloudOrgID
+		authAcquireOrgID := ""
 		if b != nil {
 			authAcquireOrgID = b.TiDBCloudOrgID()
 		}

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -28,6 +28,7 @@ type TenantScope struct {
 	APIKeyID           string
 	TokenVersion       int
 	Provider           string
+	TiDBCloudOrgID     string
 	Backend            *backend.Dat9Backend
 	JournalPermissions map[string]bool
 	ScopeKind          meta.APIKeyScopeKind
@@ -204,7 +205,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
-		setRequestMetricTenant(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID, resolved.Tenant.Provider, classifyTenantRequest(r))
+		setRequestMetricTenant(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID, resolved.Tenant.Provider, resolved.TiDBCloudOrgID, classifyTenantRequest(r))
 
 		if resolved.APIKey.Status != meta.APIKeyActive {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_key_inactive", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "status", resolved.APIKey.Status)...)
@@ -327,7 +328,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 		// Request-path acquire: this is the expected hot-path user-DB access,
 		// driven by real traffic. Record so scan-detection alerts can compare
 		// periodic-path rates against this baseline.
-		metrics.RecordTenantOperation(resolved.Tenant.ID, "user_db_access", "auth_acquire", metrics.ResultForError(err), time.Since(acquireStart))
+		metrics.RecordTenantOperationWithOrg(resolved.Tenant.ID, resolved.TiDBCloudOrgID, "user_db_access", "auth_acquire", metrics.ResultForError(err), time.Since(acquireStart))
 		if err != nil {
 			if isClientCanceled(r.Context(), err) {
 				logAuthClientCanceled(r.Context(), "backend_load_client_canceled", "tenant_id", resolved.Tenant.ID)
@@ -347,6 +348,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			zap.String("method", r.Method),
 			zap.String("tenant_id", resolved.Tenant.ID),
 			zap.String("api_key_id", resolved.APIKey.ID),
+			zap.String("tidbcloud_org_id", b.TiDBCloudOrgID()),
 			zap.Float64("resolve_api_key_hash_ms", resolveDurationMs),
 			zap.Float64("decrypt_token_ms", decryptDurationMs),
 			zap.Float64("verify_token_ms", verifyDurationMs),
@@ -359,6 +361,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			APIKeyID:           resolved.APIKey.ID,
 			TokenVersion:       resolved.APIKey.TokenVersion,
 			Provider:           resolved.Tenant.Provider,
+			TiDBCloudOrgID:     b.TiDBCloudOrgID(),
 			Backend:            b,
 			JournalPermissions: journalPermissionsFromClaims(claims),
 			ScopeKind:          scopeKind,
@@ -425,6 +428,7 @@ func handleDeleteNoAcquireAuth(w http.ResponseWriter, r *http.Request, pool *ten
 		APIKeyID:           resolved.APIKey.ID,
 		TokenVersion:       resolved.APIKey.TokenVersion,
 		Provider:           resolved.Tenant.Provider,
+		TiDBCloudOrgID:     resolved.TiDBCloudOrgID,
 		JournalPermissions: journalPermissionsFromClaims(claims),
 		ScopeKind:          scopeKind,
 		IsScoped:           isScoped,
@@ -468,7 +472,11 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 		b, release, err := pool.Acquire(r.Context(), tenant)
 		// Capability-token request-path acquire: same baseline signal as the
 		// API-key path above, but for the /v1/vault/read surface.
-		metrics.RecordTenantOperation(tenantID, "user_db_access", "auth_acquire", metrics.ResultForError(err), time.Since(capAcquireStart))
+		authAcquireOrgID := defaultTenantMetricTiDBCloudOrgID
+		if b != nil {
+			authAcquireOrgID = b.TiDBCloudOrgID()
+		}
+		metrics.RecordTenantOperationWithOrg(tenantID, authAcquireOrgID, "user_db_access", "auth_acquire", metrics.ResultForError(err), time.Since(capAcquireStart))
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "capability_backend_load_failed", "tenant_id", tenantID, "error", err)...)
 			errJSON(w, http.StatusInternalServerError, "backend unavailable")
@@ -476,7 +484,7 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 		}
 		defer release()
 
-		scope := &TenantScope{TenantID: tenantID, Provider: tenant.Provider, Backend: b}
+		scope := &TenantScope{TenantID: tenantID, Provider: tenant.Provider, TiDBCloudOrgID: b.TiDBCloudOrgID(), Backend: b}
 		setRequestMetricScope(r.Context(), scope, classifyTenantRequest(r))
 		sub := strings.TrimPrefix(r.URL.Path, "/v1/vault/read")
 		s.handleVaultRead(w, r.WithContext(withScope(r.Context(), scope)), sub)

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -88,9 +88,21 @@ func (eb *EventBus) SetStore(store *datastore.Store) {
 
 // SetMetricOrgID updates the org label for this bus without touching its store.
 func (eb *EventBus) SetMetricOrgID(tidbCloudOrgID string) {
+	nextOrgID := normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID)
 	eb.mu.Lock()
-	eb.tidbCloudOrgID = normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID)
+	prevOrgID := normalizeTenantMetricTiDBCloudOrgID(eb.tidbCloudOrgID)
+	if prevOrgID == nextOrgID {
+		eb.tidbCloudOrgID = nextOrgID
+		eb.mu.Unlock()
+		return
+	}
+	listeners := len(eb.listeners)
+	eb.tidbCloudOrgID = nextOrgID
 	eb.mu.Unlock()
+	if listeners > 0 {
+		metrics.RecordSSEInFlightWithOrg(eb.tenantID, prevOrgID, 0)
+		metrics.RecordSSEInFlightWithOrg(eb.tenantID, nextOrgID, float64(listeners))
+	}
 }
 
 // HasListeners returns true if this bus currently has at least one subscriber.

--- a/pkg/server/eventbus.go
+++ b/pkg/server/eventbus.go
@@ -43,18 +43,25 @@ const (
 // A podNotifier additionally pushes notifications to peers for <10ms latency.
 // Neither path touches a tenant TiDB unless that tenant actually has new events.
 type EventBus struct {
-	tenantID string
-	store    atomic.Pointer[datastore.Store]
-	mu       sync.Mutex
-	listeners map[uint64]chan struct{}
-	nextID    uint64
+	tenantID       string
+	tidbCloudOrgID string
+	store          atomic.Pointer[datastore.Store]
+	mu             sync.Mutex
+	listeners      map[uint64]chan struct{}
+	nextID         uint64
 }
 
 // NewEventBus creates a new EventBus backed by the given tenant store.
 func NewEventBus(tenantID string, store *datastore.Store) *EventBus {
+	return NewEventBusWithOrg(tenantID, "", store)
+}
+
+// NewEventBusWithOrg creates a new EventBus with explicit tenant metric org scope.
+func NewEventBusWithOrg(tenantID, tidbCloudOrgID string, store *datastore.Store) *EventBus {
 	eb := &EventBus{
-		tenantID:  tenantID,
-		listeners: make(map[uint64]chan struct{}),
+		tenantID:       tenantID,
+		tidbCloudOrgID: normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID),
+		listeners:      make(map[uint64]chan struct{}),
 	}
 	eb.store.Store(store)
 	return eb
@@ -65,11 +72,25 @@ func (eb *EventBus) TenantID() string {
 	return eb.tenantID
 }
 
+// TiDBCloudOrgID returns the org label value used by tenant-scoped SSE metrics.
+func (eb *EventBus) TiDBCloudOrgID() string {
+	eb.mu.Lock()
+	defer eb.mu.Unlock()
+	return normalizeTenantMetricTiDBCloudOrgID(eb.tidbCloudOrgID)
+}
+
 // SetStore atomically updates the backing store. Called by eventBuses.get
 // when the pool invalidates and recreates a backend (closing the old store
 // and opening a new one).
 func (eb *EventBus) SetStore(store *datastore.Store) {
 	eb.store.Store(store)
+}
+
+// SetMetricOrgID updates the org label for this bus without touching its store.
+func (eb *EventBus) SetMetricOrgID(tidbCloudOrgID string) {
+	eb.mu.Lock()
+	eb.tidbCloudOrgID = normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID)
+	eb.mu.Unlock()
 }
 
 // HasListeners returns true if this bus currently has at least one subscriber.
@@ -108,7 +129,7 @@ func (eb *EventBus) Subscribe() (uint64, chan struct{}) {
 	eb.nextID++
 	ch := make(chan struct{}, eventBusListenerChanSize)
 	eb.listeners[id] = ch
-	metrics.RecordSSEInFlight(eb.tenantID, float64(len(eb.listeners)))
+	metrics.RecordSSEInFlightWithOrg(eb.tenantID, eb.tidbCloudOrgID, float64(len(eb.listeners)))
 	return id, ch
 }
 
@@ -119,7 +140,7 @@ func (eb *EventBus) Unsubscribe(id uint64) {
 		delete(eb.listeners, id)
 		close(ch)
 	}
-	metrics.RecordSSEInFlight(eb.tenantID, float64(len(eb.listeners)))
+	metrics.RecordSSEInFlightWithOrg(eb.tenantID, eb.tidbCloudOrgID, float64(len(eb.listeners)))
 	eb.mu.Unlock()
 }
 
@@ -160,7 +181,7 @@ func (eb *EventBus) EventsSince(ctx context.Context, since uint64) (events []Cha
 			zap.Uint64("since", since),
 			zap.Float64("query_ms", float64(time.Since(queryStart).Microseconds())/1000),
 			zap.Error(err))
-		metrics.RecordTenantOperation(eb.tenantID, "event_bus", "query", metrics.ResultForError(err), 0)
+		metrics.RecordTenantOperationWithOrg(eb.tenantID, eb.TiDBCloudOrgID(), "event_bus", "query", metrics.ResultForError(err), 0)
 		headSeq = since // keep the client's cursor unchanged
 		return nil, headSeq, true
 	}

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/mem9-ai/drive9/internal/testmysql"
 	"github.com/mem9-ai/drive9/pkg/datastore"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 func newTestStoreForEventBus(t *testing.T) *datastore.Store {
@@ -65,6 +67,25 @@ func TestEventBusSubscribeAndNotify(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for signal")
+	}
+}
+
+func TestEventBusSetMetricOrgIDMovesInFlightGauge(t *testing.T) {
+	const tenantID = "eventbus-relabel-tenant"
+	bus := NewEventBusWithOrg(tenantID, "", nil)
+	subID, _ := bus.Subscribe()
+	defer bus.Unsubscribe(subID)
+
+	bus.SetMetricOrgID("org-eventbus-relabel")
+
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_sse_inflight_connections{tenant_id="`+tenantID+`",tidbcloud_org_id="guest"} 0.000000`) {
+		t.Fatalf("old guest in-flight series was not zeroed:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_sse_inflight_connections{tenant_id="`+tenantID+`",tidbcloud_org_id="org-eventbus-relabel"} 1.000000`) {
+		t.Fatalf("new org in-flight series was not recorded:\n%s", text)
 	}
 }
 

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -694,7 +694,7 @@ func requestTenantMetricScope(r *http.Request) (tenantID, tidbCloudOrgID string)
 		return tenantID, tidbCloudOrgID
 	}
 	if fallback := requestTenantID(r); fallback != "" {
-		return fallback, defaultTenantMetricTiDBCloudOrgID
+		return fallback, ""
 	}
 	return "", ""
 }
@@ -755,7 +755,7 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	}()
 
 	if strings.HasPrefix(r.URL.Path, "/s3/") {
-		setRequestMetricTenant(r.Context(), requestTenantID(r), "", "", defaultTenantMetricTiDBCloudOrgID, classifyTenantRequest(r))
+		setRequestMetricTenant(r.Context(), requestTenantID(r), "", "", "", classifyTenantRequest(r))
 	}
 
 	next.ServeHTTP(rw, r)

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -852,6 +852,9 @@ func tenantMetricTiDBCloudOrgIDFromMeta(ctx context.Context, metaStore *meta.Sto
 	if metaStore == nil || t == nil || strings.TrimSpace(t.ID) == "" || t.Provider != tenant.ProviderTiDBCloudNative {
 		return defaultTenantMetricTiDBCloudOrgID
 	}
+	if orgID := strings.TrimSpace(t.TiDBCloudOrgID); orgID != "" {
+		return normalizeTenantMetricTiDBCloudOrgID(orgID)
+	}
 	binding, err := metaStore.GetTenantTiDBCloudOrgBinding(ctx, t.ID)
 	if err != nil {
 		if !errors.Is(err, meta.ErrNotFound) {

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -10,7 +11,9 @@ import (
 	"time"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
+	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/traceid"
 	"go.uber.org/zap"
 )
@@ -22,6 +25,8 @@ const (
 	requestMetricsKey
 )
 
+const defaultTenantMetricTiDBCloudOrgID = "guest"
+
 func eventFields(ctx context.Context, event string, kv ...any) []zap.Field {
 	fields := make([]zap.Field, 0, len(kv)/2+3)
 	fields = append(fields, zap.String("event", event))
@@ -31,6 +36,9 @@ func eventFields(ctx context.Context, event string, kv ...any) []zap.Field {
 		}
 		if scope.APIKeyID != "" {
 			fields = append(fields, zap.String("api_key_id", scope.APIKeyID))
+		}
+		if scope.TiDBCloudOrgID != "" {
+			fields = append(fields, zap.String("tidbcloud_org_id", scope.TiDBCloudOrgID))
 		}
 	}
 	for i := 0; i+1 < len(kv); i += 2 {
@@ -46,6 +54,7 @@ func eventFields(ctx context.Context, event string, kv ...any) []zap.Field {
 type requestMetricState struct {
 	mu             sync.Mutex
 	tenantID       string
+	tidbCloudOrgID string
 	apiKeyID       string
 	provider       string
 	surface        string
@@ -143,14 +152,15 @@ func setRequestMetricScope(ctx context.Context, scope *TenantScope, class tenant
 	if scope == nil {
 		return
 	}
-	setRequestMetricTenant(ctx, scope.TenantID, scope.APIKeyID, scope.Provider, class)
+	setRequestMetricTenant(ctx, scope.TenantID, scope.APIKeyID, scope.Provider, scope.TiDBCloudOrgID, class)
 }
 
-func setRequestMetricTenant(ctx context.Context, tenantID, apiKeyID, provider string, class tenantRequestClass) {
+func setRequestMetricTenant(ctx context.Context, tenantID, apiKeyID, provider, tidbCloudOrgID string, class tenantRequestClass) {
 	state := requestMetricStateFromContext(ctx)
 	if state == nil || tenantID == "" {
 		return
 	}
+	tidbCloudOrgID = normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID)
 	surface := strings.TrimSpace(class.surface)
 	if surface == "" {
 		surface = "other"
@@ -160,31 +170,35 @@ func setRequestMetricTenant(ctx context.Context, tenantID, apiKeyID, provider st
 		action = "other"
 	}
 
-	var oldTenantID, oldSurface, oldAction string
+	var oldTenantID, oldTiDBCloudOrgID, oldSurface, oldAction string
 	var shouldMove bool
 	state.mu.Lock()
 	if state.tenantInFlight {
-		shouldMove = state.tenantID != tenantID || state.surface != surface || state.action != action
+		shouldMove = state.tenantID != tenantID || state.tidbCloudOrgID != tidbCloudOrgID || state.surface != surface || state.action != action
 		if shouldMove {
 			oldTenantID = state.tenantID
+			oldTiDBCloudOrgID = state.tidbCloudOrgID
 			oldSurface = state.surface
 			oldAction = state.action
+			state.tidbCloudOrgID = tidbCloudOrgID
 			state.surface = surface
 			state.action = action
 		}
 		state.tenantID = tenantID
+		state.tidbCloudOrgID = tidbCloudOrgID
 		state.apiKeyID = apiKeyID
 		state.provider = provider
 		state.mu.Unlock()
 		if shouldMove {
 			if m := metricsFromContext(ctx); m != nil {
-				m.adjustTenantInFlight(oldTenantID, oldSurface, oldAction, -1)
-				m.adjustTenantInFlight(tenantID, surface, action, 1)
+				m.adjustTenantInFlight(oldTenantID, oldTiDBCloudOrgID, oldSurface, oldAction, -1)
+				m.adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, action, 1)
 			}
 		}
 		return
 	}
 	state.tenantID = tenantID
+	state.tidbCloudOrgID = tidbCloudOrgID
 	state.apiKeyID = apiKeyID
 	state.provider = provider
 	state.surface = surface
@@ -193,18 +207,18 @@ func setRequestMetricTenant(ctx context.Context, tenantID, apiKeyID, provider st
 	state.mu.Unlock()
 
 	if m := metricsFromContext(ctx); m != nil {
-		m.adjustTenantInFlight(tenantID, surface, action, 1)
+		m.adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, action, 1)
 	}
 }
 
-func requestMetricScope(ctx context.Context) (tenantID, apiKeyID, provider string) {
+func requestMetricScope(ctx context.Context) (tenantID, apiKeyID, provider, tidbCloudOrgID string) {
 	state := requestMetricStateFromContext(ctx)
 	if state == nil {
-		return "", "", ""
+		return "", "", "", ""
 	}
 	state.mu.Lock()
 	defer state.mu.Unlock()
-	return state.tenantID, state.apiKeyID, state.provider
+	return state.tenantID, state.apiKeyID, state.provider, state.tidbCloudOrgID
 }
 
 func requestMetricClass(ctx context.Context) (tenantRequestClass, bool) {
@@ -258,13 +272,14 @@ func finishRequestMetricTenant(ctx context.Context) {
 		return
 	}
 	tenantID := state.tenantID
+	tidbCloudOrgID := state.tidbCloudOrgID
 	surface := state.surface
 	action := state.action
 	state.tenantInFlight = false
 	state.mu.Unlock()
 
 	if m := metricsFromContext(ctx); m != nil {
-		m.adjustTenantInFlight(tenantID, surface, action, -1)
+		m.adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, action, -1)
 	}
 }
 
@@ -273,8 +288,8 @@ func metricEvent(ctx context.Context, event string, labels ...string) {
 	if m == nil {
 		return
 	}
-	tenantID, _, _ := requestMetricScope(ctx)
-	m.recordEvent(tenantID, event, labels...)
+	tenantID, _, _, tidbCloudOrgID := requestMetricScope(ctx)
+	m.recordEvent(tenantID, tidbCloudOrgID, event, labels...)
 }
 
 type serverMetrics struct {
@@ -303,8 +318,8 @@ func (m *serverMetrics) recordBodyRead(method, route string, status int, bodyByt
 	metrics.RecordHTTPRequestBodyRead(method, route, status, bodyBytes, d)
 }
 
-func (m *serverMetrics) recordEvent(tenantID, event string, labels ...string) {
-	metrics.RecordTenantEvent(tenantID, event, labels...)
+func (m *serverMetrics) recordEvent(tenantID, tidbCloudOrgID, event string, labels ...string) {
+	metrics.RecordTenantEventWithOrg(tenantID, tidbCloudOrgID, event, labels...)
 }
 
 func (m *serverMetrics) writePrometheus(w http.ResponseWriter) {
@@ -327,11 +342,12 @@ func (m *serverMetrics) adjustRouteInFlight(route string, delta int64) int64 {
 	return next
 }
 
-func (m *serverMetrics) adjustTenantInFlight(tenantID, surface, action string, delta int64) int64 {
+func (m *serverMetrics) adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, action string, delta int64) int64 {
 	tenantID = strings.TrimSpace(tenantID)
 	if tenantID == "" {
 		return 0
 	}
+	tidbCloudOrgID = normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID)
 	surface = strings.TrimSpace(surface)
 	if surface == "" {
 		surface = "other"
@@ -340,23 +356,23 @@ func (m *serverMetrics) adjustTenantInFlight(tenantID, surface, action string, d
 	if action == "" {
 		action = "other"
 	}
-	key := tenantInFlightKey(tenantID, surface, action)
+	key := tenantInFlightKey(tenantID, tidbCloudOrgID, surface, action)
 
 	m.tenantMu.Lock()
 	defer m.tenantMu.Unlock()
 	next := m.tenantInFlight[key] + delta
 	if next <= 0 {
 		delete(m.tenantInFlight, key)
-		metrics.RecordTenantInFlight(tenantID, surface, action, 0)
+		metrics.RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, surface, action, 0)
 		return 0
 	}
 	m.tenantInFlight[key] = next
-	metrics.RecordTenantInFlight(tenantID, surface, action, float64(next))
+	metrics.RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, surface, action, float64(next))
 	return next
 }
 
-func tenantInFlightKey(tenantID, surface, action string) string {
-	return tenantID + "\x00" + surface + "\x00" + action
+func tenantInFlightKey(tenantID, tidbCloudOrgID, surface, action string) string {
+	return tenantID + "\x00" + tidbCloudOrgID + "\x00" + surface + "\x00" + action
 }
 
 type observedResponseWriter struct {
@@ -654,7 +670,7 @@ func tenantRequestResult(status int) string {
 }
 
 func requestTenantID(r *http.Request) string {
-	tenantID, _, _ := requestMetricScope(r.Context())
+	tenantID, _, _, _ := requestMetricScope(r.Context())
 	if tenantID != "" {
 		return tenantID
 	}
@@ -669,8 +685,19 @@ func requestTenantID(r *http.Request) string {
 	return ""
 }
 
+func requestTenantMetricScope(r *http.Request) (tenantID, tidbCloudOrgID string) {
+	tenantID, _, _, tidbCloudOrgID = requestMetricScope(r.Context())
+	if tenantID != "" {
+		return tenantID, tidbCloudOrgID
+	}
+	if fallback := requestTenantID(r); fallback != "" {
+		return fallback, defaultTenantMetricTiDBCloudOrgID
+	}
+	return "", ""
+}
+
 func recordTenantHTTPRequest(r *http.Request, status int, d time.Duration, responseBytes int) {
-	tenantID := requestTenantID(r)
+	tenantID, tidbCloudOrgID := requestTenantMetricScope(r)
 	if tenantID == "" {
 		return
 	}
@@ -678,21 +705,21 @@ func recordTenantHTTPRequest(r *http.Request, status int, d time.Duration, respo
 	if scopedClass, ok := requestMetricClass(r.Context()); ok {
 		class = scopedClass
 	}
-	metrics.RecordTenantRequest(tenantID, class.surface, class.action, tenantRequestResult(status), status, d)
+	metrics.RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, class.surface, class.action, tenantRequestResult(status), status, d)
 	if r.ContentLength > 0 {
-		metrics.RecordTenantHTTPBytes(tenantID, class.surface, class.action, "request", r.ContentLength)
+		metrics.RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, class.surface, class.action, "request", r.ContentLength)
 	}
 	if responseBytes > 0 {
-		metrics.RecordTenantHTTPBytes(tenantID, class.surface, class.action, "response", int64(responseBytes))
+		metrics.RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, class.surface, class.action, "response", int64(responseBytes))
 	}
 }
 
 func recordTenantFileBytes(ctx context.Context, surface, action, direction string, bytes int64) {
-	tenantID, _, _ := requestMetricScope(ctx)
+	tenantID, _, _, tidbCloudOrgID := requestMetricScope(ctx)
 	if tenantID == "" || bytes <= 0 {
 		return
 	}
-	metrics.RecordTenantFileBytes(tenantID, surface, action, direction, bytes)
+	metrics.RecordTenantFileBytesWithOrg(tenantID, tidbCloudOrgID, surface, action, direction, bytes)
 }
 
 func generateTraceID() string { return traceid.Generate() }
@@ -725,7 +752,7 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	}()
 
 	if strings.HasPrefix(r.URL.Path, "/s3/") {
-		setRequestMetricTenant(r.Context(), requestTenantID(r), "", "", classifyTenantRequest(r))
+		setRequestMetricTenant(r.Context(), requestTenantID(r), "", "", defaultTenantMetricTiDBCloudOrgID, classifyTenantRequest(r))
 	}
 
 	next.ServeHTTP(rw, r)
@@ -768,7 +795,7 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 		recordTenantHTTPRequest(r, ow.status, dur, ow.size)
 	}
 
-	tenantID, apiKeyID, _ := requestMetricScope(r.Context())
+	tenantID, apiKeyID, _, tidbCloudOrgID := requestMetricScope(r.Context())
 
 	fields := []zap.Field{
 		zap.String("method", r.Method),
@@ -786,6 +813,9 @@ func (s *Server) observe(next http.Handler, w http.ResponseWriter, r *http.Reque
 	if apiKeyID != "" {
 		fields = append(fields, zap.String("api_key_id", apiKeyID))
 	}
+	if tidbCloudOrgID != "" {
+		fields = append(fields, zap.String("tidbcloud_org_id", tidbCloudOrgID))
+	}
 	if route == "/metrics" || route == "/healthz" {
 		return
 	}
@@ -798,4 +828,35 @@ func (s *Server) handleMetrics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.metrics.writePrometheus(w)
+}
+
+func normalizeTenantMetricTiDBCloudOrgID(orgID string) string {
+	orgID = strings.TrimSpace(orgID)
+	if orgID == "" {
+		return defaultTenantMetricTiDBCloudOrgID
+	}
+	return orgID
+}
+
+func (s *Server) tenantMetricTiDBCloudOrgID(ctx context.Context, t *meta.Tenant) string {
+	if s == nil {
+		return defaultTenantMetricTiDBCloudOrgID
+	}
+	return tenantMetricTiDBCloudOrgIDFromMeta(ctx, s.meta, t)
+}
+
+func tenantMetricTiDBCloudOrgIDFromMeta(ctx context.Context, metaStore *meta.Store, t *meta.Tenant) string {
+	if metaStore == nil || t == nil || strings.TrimSpace(t.ID) == "" || t.Provider != tenant.ProviderTiDBCloudNative {
+		return defaultTenantMetricTiDBCloudOrgID
+	}
+	binding, err := metaStore.GetTenantTiDBCloudOrgBinding(ctx, t.ID)
+	if err != nil {
+		if !errors.Is(err, meta.ErrNotFound) {
+			logger.Warn(ctx, "server_metric_org_lookup_failed",
+				zap.String("tenant_id", t.ID),
+				zap.Error(err))
+		}
+		return defaultTenantMetricTiDBCloudOrgID
+	}
+	return normalizeTenantMetricTiDBCloudOrgID(binding.OrganizationID)
 }

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -121,7 +121,7 @@ func TestRequestTenantID(t *testing.T) {
 	}
 	ctx := withRequestMetricState(req.Context(), &requestMetricState{})
 	req = req.WithContext(ctx)
-	setRequestMetricTenant(req.Context(), "tenant-a", "", "", tenantRequestClass{surface: "object_store", action: "get_object"})
+	setRequestMetricTenant(req.Context(), "tenant-a", "", "", "org-a", tenantRequestClass{surface: "object_store", action: "get_object"})
 	if got := requestTenantID(req); got != "tenant-a" {
 		t.Fatalf("requestTenantID with verified scope = %q, want tenant-a", got)
 	}
@@ -134,16 +134,16 @@ func TestSetRequestMetricTenantMovesInFlightLabel(t *testing.T) {
 	ctx = withRequestMetricState(ctx, state)
 	class := tenantRequestClass{surface: "object_store", action: "upload_part"}
 
-	setRequestMetricTenant(ctx, "local", "", "", class)
-	if got := m.tenantInFlight[tenantInFlightKey("local", "object_store", "upload_part")]; got != 1 {
+	setRequestMetricTenant(ctx, "local", "", "", "", class)
+	if got := m.tenantInFlight[tenantInFlightKey("local", defaultTenantMetricTiDBCloudOrgID, "object_store", "upload_part")]; got != 1 {
 		t.Fatalf("local in-flight = %d, want 1", got)
 	}
 
-	setRequestMetricTenant(ctx, "tenant-a", "", "", class)
-	if got := m.tenantInFlight[tenantInFlightKey("local", "object_store", "upload_part")]; got != 0 {
+	setRequestMetricTenant(ctx, "tenant-a", "", "", "org-a", class)
+	if got := m.tenantInFlight[tenantInFlightKey("local", defaultTenantMetricTiDBCloudOrgID, "object_store", "upload_part")]; got != 0 {
 		t.Fatalf("local in-flight after move = %d, want 0", got)
 	}
-	if got := m.tenantInFlight[tenantInFlightKey("tenant-a", "object_store", "upload_part")]; got != 1 {
+	if got := m.tenantInFlight[tenantInFlightKey("tenant-a", "org-a", "object_store", "upload_part")]; got != 1 {
 		t.Fatalf("tenant-a in-flight = %d, want 1", got)
 	}
 

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -153,6 +153,22 @@ func TestSetRequestMetricTenantMovesInFlightLabel(t *testing.T) {
 	}
 }
 
+func TestRequestTenantMetricScopeFallbackLeavesOrgEmpty(t *testing.T) {
+	req, err := http.NewRequest(http.MethodGet, "http://example.test/s3/objects/blob", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req = req.WithContext(withRequestMetricState(req.Context(), &requestMetricState{}))
+
+	tenantID, tidbCloudOrgID := requestTenantMetricScope(req)
+	if tenantID != "local" {
+		t.Fatalf("tenant id = %q, want local", tenantID)
+	}
+	if tidbCloudOrgID != "" {
+		t.Fatalf("tidb cloud org id = %q, want empty", tidbCloudOrgID)
+	}
+}
+
 type flushRecorder struct {
 	header  http.Header
 	flushed bool

--- a/pkg/server/object_gc_worker.go
+++ b/pkg/server/object_gc_worker.go
@@ -153,14 +153,14 @@ func (w *objectGCWorker) processCandidate(ctx context.Context, candidate meta.Ob
 		// Acquire failure: could not open the owner tenant TiDB for this GC
 		// candidate. Record so the warning alert can detect a GC path that is
 		// churning cold opens or hitting bad connections.
-		metrics.RecordTenantOperation(owner.ID, "user_db_access", "object_gc_acquire", metrics.ResultForError(err), time.Since(acquireStart))
+		metrics.RecordTenantOperationWithOrg(owner.ID, tenantMetricTiDBCloudOrgIDFromMeta(ctx, w.meta, owner), "user_db_access", "object_gc_acquire", metrics.ResultForError(err), time.Since(acquireStart))
 		return err
 	}
 	defer release()
 	// Acquire success: the owner tenant TiDB is now open for this GC check.
 	// Object-GC is leader-gated and opens cold tenants — a spike here is a
 	// potential billing-storm contributor, hence the warning alert.
-	metrics.RecordTenantOperation(owner.ID, "user_db_access", "object_gc_acquire", "ok", time.Since(acquireStart))
+	metrics.RecordTenantOperationWithOrg(owner.ID, b.TiDBCloudOrgID(), "user_db_access", "object_gc_acquire", "ok", time.Since(acquireStart))
 
 	reachable, err := b.HasConfirmedS3StorageRef(ctx, candidate.StorageRefHash, candidate.StorageRef)
 	if err != nil {

--- a/pkg/server/object_gc_worker.go
+++ b/pkg/server/object_gc_worker.go
@@ -153,7 +153,7 @@ func (w *objectGCWorker) processCandidate(ctx context.Context, candidate meta.Ob
 		// Acquire failure: could not open the owner tenant TiDB for this GC
 		// candidate. Record so the warning alert can detect a GC path that is
 		// churning cold opens or hitting bad connections.
-		metrics.RecordTenantOperationWithOrg(owner.ID, tenantMetricTiDBCloudOrgIDFromMeta(ctx, w.meta, owner), "user_db_access", "object_gc_acquire", metrics.ResultForError(err), time.Since(acquireStart))
+		metrics.RecordTenantOperationWithOrg(owner.ID, "", "user_db_access", "object_gc_acquire", metrics.ResultForError(err), time.Since(acquireStart))
 		return err
 	}
 	defer release()

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -115,7 +115,7 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 	if cfg.TiDBCloudSpendingLimit != nil && bearerToken(r) != "" {
 		apiKeyTenant, apiKeyErr := s.resolveQuotaAPIKey(r.Context(), r)
 		if apiKeyErr == nil && apiKeyTenant != nil && apiKeyTenant.Tenant.ID == t.ID {
-			setRequestMetricTenant(r.Context(), t.ID, apiKeyTenant.APIKey.ID, t.Provider, classifyTenantRequest(r))
+			setRequestMetricTenant(r.Context(), t.ID, apiKeyTenant.APIKey.ID, t.Provider, apiKeyTenant.TiDBCloudOrgID, classifyTenantRequest(r))
 			s.writeQuotaResponse(w, r, t)
 			return
 		}
@@ -157,7 +157,7 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, classifyTenantRequest(r))
+	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, s.tenantMetricTiDBCloudOrgID(r.Context(), t), classifyTenantRequest(r))
 	s.writeQuotaResponse(w, r, t)
 }
 
@@ -271,7 +271,7 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 		writeQuotaSetError(w, r.Context(), err, "update")
 		return
 	}
-	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, classifyTenantRequest(r))
+	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, s.tenantMetricTiDBCloudOrgID(r.Context(), t), classifyTenantRequest(r))
 	s.writeQuotaResponse(w, r, t)
 }
 

--- a/pkg/server/safety_net_scan.go
+++ b/pkg/server/safety_net_scan.go
@@ -118,7 +118,8 @@ func (s *Server) safetyNetScan(ctx context.Context) {
 				// this tenant's user DB this cycle. A spike in this rate is a
 				// precursor to a scan touching many DBs — the warning alert
 				// catches it before it becomes a billing storm.
-				metrics.RecordTenantOperationCount(t.ID, "user_db_access", "safety_net_tenant_scan", "ok")
+				tidbCloudOrgID := b.TiDBCloudOrgID()
+				metrics.RecordTenantOperationCountWithOrg(t.ID, tidbCloudOrgID, "user_db_access", "safety_net_tenant_scan", "ok")
 				needKick := false
 				// Recover expired semantic task leases.
 				if recovered, err := store.RecoverExpiredSemanticTasks(ctx, now, safetyNetRecoverLimit); err != nil {
@@ -126,10 +127,10 @@ func (s *Server) safetyNetScan(ctx context.Context) {
 						logger.Warn(ctx, "safety_net_scan_semantic_recover_failed",
 							zap.String("tenant_id", t.ID), zap.Error(err))
 					}
-					metrics.RecordTenantOperationCount(t.ID, "user_db_access", "safety_net_semantic_recover", "error")
+					metrics.RecordTenantOperationCountWithOrg(t.ID, tidbCloudOrgID, "user_db_access", "safety_net_semantic_recover", "error")
 				} else if recovered > 0 {
-					metrics.RecordTenantOperation(t.ID, "semantic_worker", "safety_net_recover", "ok", 0)
-					metrics.RecordTenantOperationCount(t.ID, "user_db_access", "safety_net_semantic_recover", "ok")
+					metrics.RecordTenantOperationWithOrg(t.ID, tidbCloudOrgID, "semantic_worker", "safety_net_recover", "ok", 0)
+					metrics.RecordTenantOperationCountWithOrg(t.ID, tidbCloudOrgID, "user_db_access", "safety_net_semantic_recover", "ok")
 					needKick = true
 				}
 				// Recover expired file_gc leases.
@@ -138,9 +139,9 @@ func (s *Server) safetyNetScan(ctx context.Context) {
 						logger.Warn(ctx, "safety_net_scan_file_gc_recover_failed",
 							zap.String("tenant_id", t.ID), zap.Error(err))
 					}
-					metrics.RecordTenantOperationCount(t.ID, "user_db_access", "safety_net_file_gc_recover", "error")
+					metrics.RecordTenantOperationCountWithOrg(t.ID, tidbCloudOrgID, "user_db_access", "safety_net_file_gc_recover", "error")
 				} else if recovered > 0 {
-					metrics.RecordTenantOperationCount(t.ID, "user_db_access", "safety_net_file_gc_recover", "ok")
+					metrics.RecordTenantOperationCountWithOrg(t.ID, tidbCloudOrgID, "user_db_access", "safety_net_file_gc_recover", "ok")
 					needKick = true
 				}
 				// Check for unclaimed queued semantic tasks. If the outbox

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -943,6 +943,9 @@ func (s *Server) stopLeaderWorkers() {
 	if expirySweepWorker != nil {
 		expirySweepWorker.Stop()
 	}
+	if s.metrics != nil {
+		s.metrics.clearTenantPoolBindingSnapshot()
+	}
 	// In multi-tenant mode the tenant worker is started/stopped in
 	// startNotifyInfrastructure. In single-tenant mode (s.meta == nil) it is
 	// started here in startLeaderWorkers and must be stopped here too.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -476,7 +476,7 @@ func NewWithConfig(cfg Config) *Server {
 				http.Error(w, "not found", http.StatusNotFound)
 				return
 			}
-			setRequestMetricTenant(r.Context(), tenantID, "", "", classifyTenantRequest(r))
+			setRequestMetricTenant(r.Context(), tenantID, "", "", b.TiDBCloudOrgID(), classifyTenantRequest(r))
 			subReq := r.Clone(r.Context())
 			subURL := *r.URL
 			subURL.Path = "/" + sub
@@ -803,12 +803,14 @@ func (s *Server) startLeaderWorkers() {
 			ticker := time.NewTicker(tenantCountMetricsInterval)
 			defer ticker.Stop()
 			s.observeTenantCounts(workerCtx)
+			s.observeTenantPoolBindingCounts(workerCtx)
 			for {
 				select {
 				case <-workerCtx.Done():
 					return
 				case <-ticker.C:
 					s.observeTenantCounts(workerCtx)
+					s.observeTenantPoolBindingCounts(workerCtx)
 				}
 			}
 		})
@@ -1681,7 +1683,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
-	setRequestMetricTenant(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID, resolved.Tenant.Provider, classifyTenantRequest(r))
+	setRequestMetricTenant(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID, resolved.Tenant.Provider, resolved.TiDBCloudOrgID, classifyTenantRequest(r))
 	if resolved.APIKey.Status != meta.APIKeyActive {
 		metricEvent(r.Context(), "auth", "result", "key_inactive")
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_key_inactive", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "status", resolved.APIKey.Status)...)
@@ -1780,7 +1782,7 @@ func (s *Server) handleLocalTenantStatus(w http.ResponseWriter, r *http.Request)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
-	setRequestMetricTenant(r.Context(), "local", "local", "local", classifyTenantRequest(r))
+	setRequestMetricTenant(r.Context(), "local", "local", "local", defaultTenantMetricTiDBCloudOrgID, classifyTenantRequest(r))
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_ok", "tenant_id", "local", "status", "active")...)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(TenantStatusResponse{
@@ -4452,7 +4454,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 			return
 		} else if claimed {
 			logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
-			setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+			setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, res.OrganizationID, classifyTenantRequest(r))
 			s.forgetTiDBCloudRBACList(*credentialReq)
 			if res.Status == meta.TenantProvisioning {
 				s.startProvisionedTenantSchemaInit(r.Context(), res)
@@ -4483,7 +4485,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusInternalServerError, "failed to provision tenant")
 		return
 	}
-	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, classifyTenantRequest(r))
+	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, res.OrganizationID, classifyTenantRequest(r))
 	if credentialReq != nil {
 		s.forgetTiDBCloudRBACList(*credentialReq)
 	}
@@ -5019,7 +5021,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	tenantID := token.NewID()
 	provisionStarted := time.Now()
 	logger.Info(ctx, "server_event", eventFields(ctx, "provision_requested", "tenant_id", tenantID, "provider", provider)...)
-	setRequestMetricTenant(ctx, tenantID, "", provider, tenantRequestClass{surface: "provision", action: "post"})
+	setRequestMetricTenant(ctx, tenantID, "", provider, defaultTenantMetricTiDBCloudOrgID, tenantRequestClass{surface: "provision", action: "post"})
 
 	keyName := strings.TrimSpace(opts.KeyName)
 	if keyName == "" {
@@ -5368,7 +5370,7 @@ func (s *Server) issueOwnerAPIKey(ctx context.Context, tenantID, keyName string,
 // compatibility path so e2e scripts can obtain one stable API key without
 // enabling the multi-tenant provision flow.
 func (s *Server) handleLocalTenantProvision(w http.ResponseWriter, r *http.Request) {
-	setRequestMetricTenant(r.Context(), "local", "local", "local", classifyTenantRequest(r))
+	setRequestMetricTenant(r.Context(), "local", "local", "local", defaultTenantMetricTiDBCloudOrgID, classifyTenantRequest(r))
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_requested", "tenant_id", "local", "provider", "local")...)
 	metricEvent(r.Context(), "tenant_provision", "provider", "local", "result", "ok")
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -493,16 +493,16 @@ func NewWithConfig(cfg Config) *Server {
 		// quota work triggers an immediate in-process kick (~0ms latency for
 		// same-pod writes) plus a best-effort outbox INSERT for cross-pod
 		// delivery. The pool wires each backend's notifier to call
-		// SetWorkEnqueuedNotifier which invokes the tenant worker's Kick.
+		// SetWorkEnqueuedNotifier which invokes the tenant worker's org-aware kick.
 		if cfg.Pool != nil {
-			cfg.Pool.SetTenantWorkNotifier(func(tenantID string, workMask int) {
-				s.tenantWorker.Kick(tenantID, workMask)
+			cfg.Pool.SetTenantWorkNotifier(func(tenantID, tidbCloudOrgID string, workMask int) {
+				s.tenantWorker.KickWithOrg(tenantID, tidbCloudOrgID, workMask)
 				s.insertTenantNotify(tenantID, workMask)
 			})
 		}
 		if cfg.Backend != nil {
-			cfg.Backend.SetWorkEnqueuedNotifier(func(workMask int) {
-				s.tenantWorker.Kick(tenantLocalID, workMask)
+			cfg.Backend.SetWorkEnqueuedNotifier(func(workMask int, tidbCloudOrgID string) {
+				s.tenantWorker.KickWithOrg(tenantLocalID, tidbCloudOrgID, workMask)
 				s.insertTenantNotify(tenantLocalID, workMask)
 			})
 		}
@@ -1782,7 +1782,7 @@ func (s *Server) handleLocalTenantStatus(w http.ResponseWriter, r *http.Request)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
-	setRequestMetricTenant(r.Context(), "local", "local", "local", defaultTenantMetricTiDBCloudOrgID, classifyTenantRequest(r))
+	setRequestMetricTenant(r.Context(), "local", "local", "local", "", classifyTenantRequest(r))
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_ok", "tenant_id", "local", "status", "active")...)
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(TenantStatusResponse{
@@ -5021,7 +5021,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	tenantID := token.NewID()
 	provisionStarted := time.Now()
 	logger.Info(ctx, "server_event", eventFields(ctx, "provision_requested", "tenant_id", tenantID, "provider", provider)...)
-	setRequestMetricTenant(ctx, tenantID, "", provider, defaultTenantMetricTiDBCloudOrgID, tenantRequestClass{surface: "provision", action: "post"})
+	setRequestMetricTenant(ctx, tenantID, "", provider, "", tenantRequestClass{surface: "provision", action: "post"})
 
 	keyName := strings.TrimSpace(opts.KeyName)
 	if keyName == "" {
@@ -5370,7 +5370,7 @@ func (s *Server) issueOwnerAPIKey(ctx context.Context, tenantID, keyName string,
 // compatibility path so e2e scripts can obtain one stable API key without
 // enabling the multi-tenant provision flow.
 func (s *Server) handleLocalTenantProvision(w http.ResponseWriter, r *http.Request) {
-	setRequestMetricTenant(r.Context(), "local", "local", "local", defaultTenantMetricTiDBCloudOrgID, classifyTenantRequest(r))
+	setRequestMetricTenant(r.Context(), "local", "local", "local", "", classifyTenantRequest(r))
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_requested", "tenant_id", "local", "provider", "local")...)
 	metricEvent(r.Context(), "tenant_provision", "provider", "local", "result", "ok")
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2236,31 +2236,31 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `drive9_db_pool_registered{role="user"`) {
 		t.Fatalf("expected user db pool metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_requests_total{action="write",result="ok",status_class="2xx",surface="fs",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="write",result="ok",status_class="2xx",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Errorf("expected tenant request usage metric in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_bucket{status_class="2xx",surface="fs",le="0.1"}`) {
 		t.Errorf("expected tenant request duration usage metric in response: %s", text)
 	}
-	if strings.Contains(text, `drive9_tenant_inflight_requests{action="read",surface="fs",tenant_id="local"}`) {
+	if strings.Contains(text, `drive9_tenant_inflight_requests{action="read",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Errorf("completed tenant in-flight usage metric should be removed: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_http_bytes_total{direction="request",surface="fs",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_tenant_http_bytes_total{direction="request",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Errorf("expected tenant HTTP byte metric in response: %s", text)
 	}
 	if strings.Contains(text, `drive9_tenant_http_bytes_total{action="`) {
 		t.Errorf("tenant HTTP byte metric should not carry action: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="write",direction="write",surface="fs",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="write",direction="write",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Fatalf("expected tenant file write byte metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="read",direction="read",surface="fs",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="read",direction="read",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Fatalf("expected tenant file read byte metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="fs_write",result="ok",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="fs_write",result="ok",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Fatalf("expected fs_write tenant event metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="fs_read",result="ok",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="fs_read",result="ok",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Fatalf("expected fs_read tenant event metric in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_business_events_total{event="tenant_provision",result="error"}`) {
@@ -2359,13 +2359,13 @@ func TestUploadActionMetrics(t *testing.T) {
 	body, _ := io.ReadAll(metricsResp.Body)
 	text := string(body)
 
-	if !strings.Contains(text, `drive9_business_events_total{event="upload_complete",result="error",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_complete",result="error",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Fatalf("expected upload_complete metric, got: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="upload_resume",result="error",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_resume",result="error",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Fatalf("expected upload_resume metric, got: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="upload_abort",result="error",tenant_id="local"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_abort",result="error",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Fatalf("expected upload_abort metric, got: %s", text)
 	}
 }

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -206,7 +206,7 @@ func (s *Server) tenantEventBus(r *http.Request) *EventBus {
 	if s.fallback != nil {
 		store = s.fallback.Store()
 	}
-	return s.events.getWithOrg("", defaultTenantMetricTiDBCloudOrgID, store)
+	return s.events.getWithOrg("", "", store)
 }
 
 func (s *Server) publishEvent(r *http.Request, path, op string) {

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -138,9 +138,14 @@ func newEventBuses() *eventBuses {
 }
 
 func (ebs *eventBuses) get(tenantID string, store *datastore.Store) *EventBus {
+	return ebs.getWithOrg(tenantID, "", store)
+}
+
+func (ebs *eventBuses) getWithOrg(tenantID, tidbCloudOrgID string, store *datastore.Store) *EventBus {
 	ebs.mu.Lock()
 	defer ebs.mu.Unlock()
 	if bus, ok := ebs.buses[tenantID]; ok {
+		bus.SetMetricOrgID(tidbCloudOrgID)
 		// Refresh the store reference if a non-nil store is provided: the pool
 		// may have invalidated and recreated the backend (closing the old store
 		// and opening a new one), so the cached bus's store could be stale/closed.
@@ -152,7 +157,7 @@ func (ebs *eventBuses) get(tenantID string, store *datastore.Store) *EventBus {
 		}
 		return bus
 	}
-	bus := NewEventBus(tenantID, store)
+	bus := NewEventBusWithOrg(tenantID, tidbCloudOrgID, store)
 	ebs.buses[tenantID] = bus
 	return bus
 }
@@ -190,14 +195,18 @@ func (ebs *eventBuses) activeTenantIDs() []string {
 func (s *Server) tenantEventBus(r *http.Request) *EventBus {
 	scope := ScopeFromContext(r.Context())
 	if scope != nil && scope.Backend != nil {
-		return s.events.get(scope.TenantID, scope.Backend.Store())
+		tidbCloudOrgID := scope.TiDBCloudOrgID
+		if tidbCloudOrgID == "" {
+			tidbCloudOrgID = scope.Backend.TiDBCloudOrgID()
+		}
+		return s.events.getWithOrg(scope.TenantID, tidbCloudOrgID, scope.Backend.Store())
 	}
 	// Single-tenant / fallback mode.
 	var store *datastore.Store
 	if s.fallback != nil {
 		store = s.fallback.Store()
 	}
-	return s.events.get("", store)
+	return s.events.getWithOrg("", defaultTenantMetricTiDBCloudOrgID, store)
 }
 
 func (s *Server) publishEvent(r *http.Request, path, op string) {
@@ -227,8 +236,8 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 				zap.String("path", path),
 				zap.String("op", op),
 				zap.Error(err))
-			metrics.RecordTenantOperation(bus.tenantID, "event_bus", "publish", metrics.ResultForError(err), 0)
-			metrics.RecordEventBusPublishError(bus.tenantID)
+			metrics.RecordTenantOperationWithOrg(bus.tenantID, bus.TiDBCloudOrgID(), "event_bus", "publish", metrics.ResultForError(err), 0)
+			metrics.RecordEventBusPublishErrorWithOrg(bus.tenantID, bus.TiDBCloudOrgID())
 		}
 	}
 
@@ -329,6 +338,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 
 	bus := s.tenantEventBus(r)
 	tenantID := bus.tenantID
+	tidbCloudOrgID := bus.TiDBCloudOrgID()
 	connStart := time.Now()
 	// Track SSE inflight and connection lifetime. The inflight count is
 	// derived from the EventBus listener set (adjusted in Subscribe/
@@ -336,7 +346,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// dedicated SSE metrics (NOT the HTTP duration histogram — see the
 	// route guard in observe).
 	defer func() {
-		metrics.RecordSSEConnection(tenantID, "closed", time.Since(connStart))
+		metrics.RecordSSEConnectionWithOrg(tenantID, tidbCloudOrgID, "closed", time.Since(connStart))
 	}()
 
 	subID, notify := bus.Subscribe()
@@ -374,7 +384,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 		sendSSEReset(bw, headSeq, reason)
-		metrics.RecordSSEResetSent(tenantID, reason)
+		metrics.RecordSSEResetSentWithOrg(tenantID, tidbCloudOrgID, reason)
 		lastSeen = headSeq
 	} else {
 		for _, ev := range events {
@@ -382,9 +392,9 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			if isStructuralOp(ev.Op) {
 				// Structural ops are emitted as reset events (see sendSSEEvent),
 				// so count them as resets, not file_changed deliveries.
-				metrics.RecordSSEResetSent(tenantID, "structural_change")
+				metrics.RecordSSEResetSentWithOrg(tenantID, tidbCloudOrgID, "structural_change")
 			} else {
-				metrics.RecordSSEEventSent(tenantID, ev.Op)
+				metrics.RecordSSEEventSentWithOrg(tenantID, tidbCloudOrgID, ev.Op)
 			}
 			lastSeen = ev.Seq
 		}
@@ -394,13 +404,13 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 	// were marked unverified on disconnect become verified without waiting
 	// for the periodic heartbeat.
 	sendSSEHeartbeat(bw, lastSeen)
-	metrics.RecordSSEHeartbeatSent(tenantID)
+	metrics.RecordSSEHeartbeatSentWithOrg(tenantID, tidbCloudOrgID)
 	// Flush initial replay/reset immediately so the client receives the
 	// cursor position without waiting for the periodic heartbeat.
 	if err := bw.Flush(); err != nil {
 		return
 	}
-	metrics.RecordSSEPhase1(tenantID, time.Since(phase1Start))
+	metrics.RecordSSEPhase1WithOrg(tenantID, tidbCloudOrgID, time.Since(phase1Start))
 
 	// Phase 2: Live stream with micro-batching.
 	// The notify channel catches same-pod events instantly. A 1s poll ticker
@@ -429,7 +439,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		liveEvents, liveHead, liveOK := bus.EventsSince(ctx, lastSeen)
 		if !liveOK {
 			sendSSEReset(bw, liveHead, "seq_too_old")
-			metrics.RecordSSEResetSent(tenantID, "seq_too_old")
+			metrics.RecordSSEResetSentWithOrg(tenantID, tidbCloudOrgID, "seq_too_old")
 			lastSeen = liveHead
 			if err := bw.Flush(); err != nil {
 				return false
@@ -443,9 +453,9 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 		for _, ev := range liveEvents {
 			sendSSEEvent(bw, ev)
 			if isStructuralOp(ev.Op) {
-				metrics.RecordSSEResetSent(tenantID, "structural_change")
+				metrics.RecordSSEResetSentWithOrg(tenantID, tidbCloudOrgID, "structural_change")
 			} else {
-				metrics.RecordSSEEventSent(tenantID, ev.Op)
+				metrics.RecordSSEEventSentWithOrg(tenantID, tidbCloudOrgID, ev.Op)
 			}
 			lastSeen = ev.Seq
 		}
@@ -477,7 +487,7 @@ func (s *Server) handleEvents(w http.ResponseWriter, r *http.Request) {
 			return
 		case <-heartbeat.C:
 			sendSSEHeartbeat(bw, lastSeen)
-			metrics.RecordSSEHeartbeatSent(tenantID)
+			metrics.RecordSSEHeartbeatSentWithOrg(tenantID, tidbCloudOrgID)
 			if err := bw.Flush(); err != nil {
 				return
 			}

--- a/pkg/server/tenant_metrics.go
+++ b/pkg/server/tenant_metrics.go
@@ -7,6 +7,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
@@ -24,6 +25,29 @@ func (s *Server) observeTenantCounts(ctx context.Context) {
 		}
 		return
 	}
-	metrics.RecordTenantCount("total_non_deleted", counts.TotalNonDeleted)
-	metrics.RecordTenantCount("active", counts.Active)
+	for _, count := range counts.Statuses {
+		metrics.RecordTenantCount(string(count.Status), count.Count)
+	}
+}
+
+func (s *Server) observeTenantPoolBindingCounts(ctx context.Context) {
+	if s.meta == nil {
+		return
+	}
+	start := time.Now()
+	counts, err := s.meta.CountTenantPoolBindingsByStatus(ctx)
+	result := metrics.ResultForError(err)
+	metrics.RecordOperation(adminTenantPoolMetricsComponent, "count_pool_bindings", result, time.Since(start))
+	if err != nil {
+		if ctx.Err() == nil {
+			logger.Warn(ctx, "tenant_pool_binding_metrics_failed", zap.String("detail", err.Error()))
+		}
+		return
+	}
+	for _, count := range counts {
+		switch count.Status {
+		case meta.TenantPoolBindingFree, meta.TenantPoolBindingUsed:
+			metrics.RecordTenantPoolBindings(count.PoolID, count.OrganizationID, string(count.Status), count.Count)
+		}
+	}
 }

--- a/pkg/server/tenant_metrics.go
+++ b/pkg/server/tenant_metrics.go
@@ -81,3 +81,15 @@ func (m *serverMetrics) syncTenantPoolBindingSnapshot(next map[tenantPoolBinding
 	}
 	m.tenantPoolBinding = next
 }
+
+func (m *serverMetrics) clearTenantPoolBindingSnapshot() {
+	if m == nil {
+		return
+	}
+	m.tenantPoolBindMu.Lock()
+	defer m.tenantPoolBindMu.Unlock()
+	for prev := range m.tenantPoolBinding {
+		metrics.DeleteTenantPoolBindings(prev.poolID, prev.tidbCloudOrgID, prev.status)
+	}
+	m.tenantPoolBinding = map[tenantPoolBindingMetricKey]struct{}{}
+}

--- a/pkg/server/tenant_metrics_test.go
+++ b/pkg/server/tenant_metrics_test.go
@@ -1,0 +1,164 @@
+package server
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/internal/testmysql"
+	"github.com/mem9-ai/drive9/pkg/meta"
+)
+
+func TestObserveTenantPoolBindingCountsRecordsUsedAndFreeByPoolAndOrg(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := metaStore.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-observe-bindings",
+		OrganizationID: "org-observe-bindings",
+		Size:           3,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create tenant pool: %v", err)
+	}
+	for _, tc := range []struct {
+		tenantID string
+		status   meta.TenantPoolBindingStatus
+	}{
+		{tenantID: "tenant-observe-free-1", status: meta.TenantPoolBindingFree},
+		{tenantID: "tenant-observe-free-2", status: meta.TenantPoolBindingFree},
+		{tenantID: "tenant-observe-used-1", status: meta.TenantPoolBindingUsed},
+	} {
+		insertTenantPoolMetricTenant(t, metaStore, tc.tenantID, "cluster-"+tc.tenantID, now)
+		if err := metaStore.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+			TenantID:       tc.tenantID,
+			OrganizationID: "org-observe-bindings",
+			ClusterID:      "cluster-" + tc.tenantID,
+			PoolID:         "pool-observe-bindings",
+			PoolStatus:     tc.status,
+			CreatedAt:      now,
+			UpdatedAt:      now,
+		}); err != nil {
+			t.Fatalf("upsert binding %s: %v", tc.tenantID, err)
+		}
+	}
+
+	s := &Server{meta: metaStore, metrics: newServerMetrics()}
+	s.observeTenantPoolBindingCounts(ctx)
+
+	rec := httptest.NewRecorder()
+	s.metrics.writePrometheus(rec)
+	text := rec.Body.String()
+	for _, want := range []string{
+		`drive9_tenant_pool_bindings{pool_id="pool-observe-bindings",pool_status="free",tidbcloud_org_id="org-observe-bindings"} 2`,
+		`drive9_tenant_pool_bindings{pool_id="pool-observe-bindings",pool_status="used",tidbcloud_org_id="org-observe-bindings"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing tenant pool binding metric %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestObserveTenantCountsRecordsAllRealStatuses(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	now := time.Now().UTC()
+	for _, tc := range []struct {
+		tenantID string
+		status   meta.TenantStatus
+	}{
+		{tenantID: "tenant-count-pending", status: meta.TenantPending},
+		{tenantID: "tenant-count-provisioning", status: meta.TenantProvisioning},
+		{tenantID: "tenant-count-active", status: meta.TenantActive},
+		{tenantID: "tenant-count-failed", status: meta.TenantFailed},
+		{tenantID: "tenant-count-suspended", status: meta.TenantSuspended},
+		{tenantID: "tenant-count-deleting", status: meta.TenantDeleting},
+		{tenantID: "tenant-count-deleted", status: meta.TenantDeleted},
+	} {
+		insertTenantMetricTenant(t, metaStore, tc.tenantID, tc.status, now)
+	}
+
+	s := &Server{meta: metaStore, metrics: newServerMetrics()}
+	s.observeTenantCounts(context.Background())
+
+	rec := httptest.NewRecorder()
+	s.metrics.writePrometheus(rec)
+	text := rec.Body.String()
+	for _, status := range []meta.TenantStatus{
+		meta.TenantPending,
+		meta.TenantProvisioning,
+		meta.TenantActive,
+		meta.TenantFailed,
+		meta.TenantSuspended,
+		meta.TenantDeleting,
+		meta.TenantDeleted,
+	} {
+		want := `drive9_tenant_count{status="` + string(status) + `"} 1.000000`
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing tenant count metric %q:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "drive9_tenant_non_deleted_count") || strings.Contains(text, "total_non_deleted") {
+		t.Fatalf("tenant count metrics must only use real status values:\n%s", text)
+	}
+}
+
+func insertTenantMetricTenant(t *testing.T, s *meta.Store, tenantID string, status meta.TenantStatus, now time.Time) {
+	t.Helper()
+	if err := s.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               tenantID,
+		Status:           status,
+		Kind:             meta.TenantKindLive,
+		DBHost:           "db.example.com",
+		DBPort:           4000,
+		DBUser:           "u.root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant %s: %v", tenantID, err)
+	}
+}
+
+func insertTenantPoolMetricTenant(t *testing.T, s *meta.Store, tenantID, clusterID string, now time.Time) {
+	t.Helper()
+	if err := s.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		Kind:             meta.TenantKindLive,
+		DBHost:           "db.example.com",
+		DBPort:           4000,
+		DBUser:           "u.root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         "tidb_cloud_native",
+		ClusterID:        clusterID,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant %s: %v", tenantID, err)
+	}
+}

--- a/pkg/server/tenant_metrics_test.go
+++ b/pkg/server/tenant_metrics_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mem9-ai/drive9/internal/testmysql"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
@@ -133,6 +134,31 @@ func TestObserveTenantCountsRecordsAllRealStatuses(t *testing.T) {
 	}
 	if strings.Contains(text, "drive9_tenant_non_deleted_count") || strings.Contains(text, "total_non_deleted") {
 		t.Fatalf("tenant count metrics must only use real status values:\n%s", text)
+	}
+}
+
+func TestStopLeaderWorkersClearsTenantPoolBindingSnapshot(t *testing.T) {
+	key := tenantPoolBindingMetricKey{
+		poolID:         "pool-leader-loss-clear",
+		tidbCloudOrgID: "org-leader-loss-clear",
+		status:         string(meta.TenantPoolBindingUsed),
+	}
+	s := &Server{metrics: newServerMetrics(), leaderWorkersStarted: true}
+	metrics.RecordTenantPoolBindings(key.poolID, key.tidbCloudOrgID, key.status, 1)
+	s.metrics.syncTenantPoolBindingSnapshot(map[tenantPoolBindingMetricKey]struct{}{key: struct{}{}})
+
+	rec := httptest.NewRecorder()
+	s.metrics.writePrometheus(rec)
+	if !strings.Contains(rec.Body.String(), `drive9_tenant_pool_bindings{pool_id="pool-leader-loss-clear",status="used",tidbcloud_org_id="org-leader-loss-clear"} 1`) {
+		t.Fatalf("missing tenant pool binding metric before leadership loss:\n%s", rec.Body.String())
+	}
+
+	s.stopLeaderWorkers()
+
+	rec = httptest.NewRecorder()
+	s.metrics.writePrometheus(rec)
+	if strings.Contains(rec.Body.String(), `drive9_tenant_pool_bindings{pool_id="pool-leader-loss-clear"`) {
+		t.Fatalf("tenant pool binding metric should be removed after leadership loss:\n%s", rec.Body.String())
 	}
 }
 

--- a/pkg/server/tenant_outbox_poller.go
+++ b/pkg/server/tenant_outbox_poller.go
@@ -214,7 +214,7 @@ func (p *tenantOutboxPoller) dispatch(ctx context.Context, row meta.TenantNotify
 			// worker. This gives a baseline rate of "kicks dispatched" to
 			// compare against actual tenant_worker_acquire — a divergence
 			// (kicks without acquires) points to lost work.
-			metrics.RecordTenantOperationCount(row.TenantID, "user_db_access", "outbox_dispatch_kick", "ok")
+			metrics.RecordTenantOperationCountWithOrg(row.TenantID, defaultTenantMetricTiDBCloudOrgID, "user_db_access", "outbox_dispatch_kick", "ok")
 		}
 	}
 }

--- a/pkg/server/tenant_outbox_poller.go
+++ b/pkg/server/tenant_outbox_poller.go
@@ -16,7 +16,7 @@ import (
 // (semantic/file_gc/quota) to the unified worker. The worker deduplicates
 // kicks by tenant and OR-accumulates the work_mask.
 type outboxKicker interface {
-	Kick(tenantID string, workMask int)
+	KickWithOrg(tenantID, tidbCloudOrgID string, workMask int)
 }
 
 const (
@@ -209,12 +209,12 @@ func (p *tenantOutboxPoller) dispatch(ctx context.Context, row meta.TenantNotify
 		// Sharded work: only the shard owner processes it. Other pods skip;
 		// the safety-net scan recovers any work whose kick was lost.
 		if p.shardFn(row.TenantID) {
-			p.worker.Kick(row.TenantID, shardedMask)
+			p.worker.KickWithOrg(row.TenantID, row.TiDBCloudOrgID, shardedMask)
 			// Record the kick that will trigger a tenant-DB access via the
 			// worker. This gives a baseline rate of "kicks dispatched" to
 			// compare against actual tenant_worker_acquire — a divergence
 			// (kicks without acquires) points to lost work.
-			metrics.RecordTenantOperationCountWithOrg(row.TenantID, defaultTenantMetricTiDBCloudOrgID, "user_db_access", "outbox_dispatch_kick", "ok")
+			metrics.RecordTenantOperationCountWithOrg(row.TenantID, row.TiDBCloudOrgID, "user_db_access", "outbox_dispatch_kick", "ok")
 		}
 	}
 }

--- a/pkg/server/tenant_outbox_poller_test.go
+++ b/pkg/server/tenant_outbox_poller_test.go
@@ -13,8 +13,8 @@ type mockKicker struct {
 	kicks []kickMsg
 }
 
-func (m *mockKicker) Kick(tenantID string, workMask int) {
-	m.kicks = append(m.kicks, kickMsg{tenantID: tenantID, workMask: workMask})
+func (m *mockKicker) KickWithOrg(tenantID, tidbCloudOrgID string, workMask int) {
+	m.kicks = append(m.kicks, kickMsg{tenantID: tenantID, tidbCloudOrgID: tidbCloudOrgID, workMask: workMask})
 }
 
 func TestTenantOutboxPollerShardFilter(t *testing.T) {
@@ -30,6 +30,21 @@ func TestTenantOutboxPollerShardFilter(t *testing.T) {
 	}
 	if k.kicks[0].workMask != WorkSemantic {
 		t.Fatalf("expected WorkSemantic mask, got %d", k.kicks[0].workMask)
+	}
+}
+
+func TestTenantOutboxPollerPassesOrgToWorker(t *testing.T) {
+	t.Parallel()
+	buses := newEventBuses()
+	k := &mockKicker{}
+	p := newTenantOutboxPoller(nil, buses, k, nil, "pod1", 0, 0)
+	row := meta.TenantNotifyRow{ID: 1, TenantID: "t1", TiDBCloudOrgID: "org-t1", WorkMask: WorkFileGC, CreatedAt: time.Now()}
+	p.dispatch(context.Background(), row)
+	if len(k.kicks) != 1 {
+		t.Fatalf("expected 1 kick, got %d", len(k.kicks))
+	}
+	if k.kicks[0].tidbCloudOrgID != "org-t1" {
+		t.Fatalf("kick org = %q, want org-t1", k.kicks[0].tidbCloudOrgID)
 	}
 }
 

--- a/pkg/server/tenant_worker.go
+++ b/pkg/server/tenant_worker.go
@@ -132,8 +132,14 @@ func ValidateDurableAsyncExtractRequiresTenantWorker(cfg Config, template backen
 
 // kickMsg carries a tenant ID and accumulated work mask to a worker goroutine.
 type kickMsg struct {
-	tenantID string
-	workMask int
+	tenantID       string
+	tidbCloudOrgID string
+	workMask       int
+}
+
+type pendingKick struct {
+	tidbCloudOrgID string
+	workMask       int
 }
 
 // tenantWorkerManager is the unified worker that processes kicks from the
@@ -154,7 +160,7 @@ type tenantWorkerManager struct {
 	mu          sync.Mutex
 	inflight    map[string]int
 	processing  int
-	kickPending map[string]int // tenantID → accumulated work_mask
+	kickPending map[string]pendingKick // tenantID → accumulated work_mask + best-known org id
 
 	kicks chan kickMsg
 
@@ -206,7 +212,7 @@ func newTenantWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Store
 	opts.normalize()
 	m.opts = opts
 	m.inflight = make(map[string]int)
-	m.kickPending = make(map[string]int)
+	m.kickPending = make(map[string]pendingKick)
 	m.lastMaintenance = make(map[string]time.Time)
 	m.kicks = make(chan kickMsg, tenantKickQueueCapacity)
 	return m
@@ -219,27 +225,45 @@ func newTenantWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Store
 // the buffer is full — flushDelayedKicks re-enqueues it on the next ticker
 // tick, and the safety-net scan remains the durable fallback path.
 func (m *tenantWorkerManager) Kick(tenantID string, workMask int) {
+	m.KickWithOrg(tenantID, "", workMask)
+}
+
+// KickWithOrg is Kick with an already-resolved TiDB Cloud org label. Callers
+// without a resolved org should pass an empty string and let metrics normalize
+// it to the shared guest label.
+func (m *tenantWorkerManager) KickWithOrg(tenantID, tidbCloudOrgID string, workMask int) {
 	if m == nil || tenantID == "" || workMask == 0 {
 		return
 	}
 	m.mu.Lock()
 	if pending, ok := m.kickPending[tenantID]; ok {
-		m.kickPending[tenantID] = pending | workMask
+		pending.workMask |= workMask
+		pending.tidbCloudOrgID = mergeKickOrgID(pending.tidbCloudOrgID, tidbCloudOrgID)
+		m.kickPending[tenantID] = pending
 		m.mu.Unlock()
-		metrics.RecordTenantOperationWithOrg(tenantID, defaultTenantMetricTiDBCloudOrgID, "tenant_worker", "kick", "coalesced", 0)
+		metrics.RecordTenantOperationWithOrg(tenantID, pending.tidbCloudOrgID, "tenant_worker", "kick", "coalesced", 0)
 		return
 	}
-	m.kickPending[tenantID] = workMask
+	tidbCloudOrgID = strings.TrimSpace(tidbCloudOrgID)
+	m.kickPending[tenantID] = pendingKick{tidbCloudOrgID: tidbCloudOrgID, workMask: workMask}
 	m.mu.Unlock()
 	select {
-	case m.kicks <- kickMsg{tenantID: tenantID, workMask: workMask}:
-		metrics.RecordTenantOperationWithOrg(tenantID, defaultTenantMetricTiDBCloudOrgID, "tenant_worker", "kick", "queued", 0)
+	case m.kicks <- kickMsg{tenantID: tenantID, tidbCloudOrgID: tidbCloudOrgID, workMask: workMask}:
+		metrics.RecordTenantOperationWithOrg(tenantID, tidbCloudOrgID, "tenant_worker", "kick", "queued", 0)
 	default:
 		// Channel full: leave kickPending so flushDelayedKicks (ticked from
 		// workerLoop) re-enqueues when the channel has space. The work mask is
 		// already recorded in kickPending above; do NOT clear it.
-		metrics.RecordTenantOperationWithOrg(tenantID, defaultTenantMetricTiDBCloudOrgID, "tenant_worker", "kick", "delayed", 0)
+		metrics.RecordTenantOperationWithOrg(tenantID, tidbCloudOrgID, "tenant_worker", "kick", "delayed", 0)
 	}
+}
+
+func mergeKickOrgID(current, next string) string {
+	next = strings.TrimSpace(next)
+	if next != "" {
+		return next
+	}
+	return current
 }
 
 func (m *tenantWorkerManager) clearKickPending(tenantID string) {
@@ -248,15 +272,20 @@ func (m *tenantWorkerManager) clearKickPending(tenantID string) {
 	m.mu.Unlock()
 }
 
-// pendingWorkMask returns the accumulated work mask for a tenant (0 if none
-// pending), and clears the pending entry. Called by the worker before
+// takePendingKick returns the accumulated work mask and best-known org id for
+// a tenant, and clears the pending entry. Called by the worker before
 // dispatching so a kick arriving during processing triggers a fresh kick.
-func (m *tenantWorkerManager) takePendingWorkMask(tenantID string) int {
+func (m *tenantWorkerManager) takePendingKick(tenantID string) pendingKick {
 	m.mu.Lock()
-	mask := m.kickPending[tenantID]
+	pending := m.kickPending[tenantID]
 	delete(m.kickPending, tenantID)
 	m.mu.Unlock()
-	return mask
+	return pending
+}
+
+func (m *tenantWorkerManager) takePendingWorkMask(tenantID string) int {
+	pending := m.takePendingKick(tenantID)
+	return pending.workMask
 }
 
 // flushDelayedKicks re-enqueues kicks that were left pending when the kicks
@@ -271,18 +300,18 @@ func (m *tenantWorkerManager) flushDelayedKicks() {
 		m.mu.Unlock()
 		return
 	}
-	pending := make(map[string]int, len(m.kickPending))
-	for tenantID, mask := range m.kickPending {
-		pending[tenantID] = mask
+	pending := make(map[string]pendingKick, len(m.kickPending))
+	for tenantID, entry := range m.kickPending {
+		pending[tenantID] = entry
 	}
 	m.mu.Unlock()
-	for tenantID, mask := range pending {
+	for tenantID, entry := range pending {
 		select {
-		case m.kicks <- kickMsg{tenantID: tenantID, workMask: mask}:
+		case m.kicks <- kickMsg{tenantID: tenantID, tidbCloudOrgID: entry.tidbCloudOrgID, workMask: entry.workMask}:
 			// Successfully (re-)queued. Leave the kickPending entry in place:
 			// the worker merges it via takePendingWorkMask after claiming the
 			// slot, so any further coalesced kicks are not lost.
-			metrics.RecordTenantOperationWithOrg(tenantID, defaultTenantMetricTiDBCloudOrgID, "tenant_worker", "kick", "flushed", 0)
+			metrics.RecordTenantOperationWithOrg(tenantID, entry.tidbCloudOrgID, "tenant_worker", "kick", "flushed", 0)
 		default:
 			// Still full; leave pending for the next tick.
 		}
@@ -348,7 +377,7 @@ func (m *tenantWorkerManager) workerLoop(ctx context.Context, workerID int) {
 			logger.Info(ctx, "tenant_worker_stopped", zap.Int("worker_id", workerID))
 			return
 		case msg := <-m.kicks:
-			m.processKicked(ctx, msg.tenantID, msg.workMask)
+			m.processKicked(ctx, msg.tenantID, msg.tidbCloudOrgID, msg.workMask)
 		case <-ticker.C:
 			// Re-enqueue delayed kicks now that the channel may have space.
 			m.flushDelayedKicks()
@@ -400,7 +429,7 @@ func (m *tenantWorkerManager) shouldPollFallback() bool {
 // selected work types. workMask selects which drains run. After draining, it
 // recovers expired leases and runs piggyback maintenance (throttled). The
 // tenant is re-kicked if more work remains.
-func (m *tenantWorkerManager) processKicked(ctx context.Context, tenantID string, workMask int) {
+func (m *tenantWorkerManager) processKicked(ctx context.Context, tenantID, tidbCloudOrgID string, workMask int) {
 	// Do NOT clear kickPending here — a kick coalesced while this message was
 	// in the channel must be consumed after acquiring the tenant slot.
 	ref, ok := m.kickRef(ctx, tenantID)
@@ -412,9 +441,11 @@ func (m *tenantWorkerManager) processKicked(ctx context.Context, tenantID string
 		// Another worker holds the slot; leave kickPending for that worker to consume.
 		return
 	}
-	// Merge any work mask that coalesced while this kick was queued.
-	workMask |= m.takePendingWorkMask(tenantID)
-	target, err := m.targetForRef(ctx, ref)
+	// Merge any work that coalesced while this kick was queued.
+	pending := m.takePendingKick(tenantID)
+	workMask |= pending.workMask
+	tidbCloudOrgID = mergeKickOrgID(tidbCloudOrgID, pending.tidbCloudOrgID)
+	target, err := m.targetForRef(ctx, ref, tidbCloudOrgID)
 	if err != nil {
 		logger.Warn(ctx, "tenant_worker_kick_open_store_failed",
 			zap.String("tenant_id", ref.id),
@@ -460,10 +491,10 @@ func (m *tenantWorkerManager) processKicked(ctx context.Context, tenantID string
 
 	// Re-kick if there's pending work accumulated during processing, or if a
 	// drain hit its cap (more work likely remains for that type).
-	pending := m.takePendingWorkMask(tenantID)
-	reKick := pending | reKickMask
+	pending = m.takePendingKick(tenantID)
+	reKick := pending.workMask | reKickMask
 	if reKick != 0 {
-		m.Kick(tenantID, reKick)
+		m.KickWithOrg(tenantID, mergeKickOrgID(target.metricOrgID(), pending.tidbCloudOrgID), reKick)
 	}
 }
 
@@ -619,7 +650,7 @@ func (m *tenantWorkerManager) hasShardedWorkForTenant(provider string) bool {
 	return true
 }
 
-func (m *tenantWorkerManager) targetForRef(ctx context.Context, ref semanticTenantRef) (*tenantTarget, error) {
+func (m *tenantWorkerManager) targetForRef(ctx context.Context, ref semanticTenantRef, tidbCloudOrgID string) (*tenantTarget, error) {
 	if ref.id == tenantLocalID {
 		if m.fallback == nil {
 			return nil, fmt.Errorf("backend missing for %s", ref.id)
@@ -642,12 +673,12 @@ func (m *tenantWorkerManager) targetForRef(ctx context.Context, ref semanticTena
 		// Kick-driven acquire failure: a kick arrived but the tenant TiDB could
 		// not be opened. Record so the major alert can detect sustained worker
 		// acquire errors (kicks not reaching the tenant DB).
-		metrics.RecordTenantOperationWithOrg(ref.tenant.ID, tenantMetricTiDBCloudOrgIDFromMeta(ctx, m.meta, ref.tenant), "user_db_access", "tenant_worker_acquire", metrics.ResultForError(err), time.Since(acquireStart))
+		metrics.RecordTenantOperationWithOrg(ref.tenant.ID, tidbCloudOrgID, "user_db_access", "tenant_worker_acquire", metrics.ResultForError(err), time.Since(acquireStart))
 		return nil, fmt.Errorf("acquire tenant backend: %w", err)
 	}
 	if b == nil {
 		release()
-		metrics.RecordTenantOperationWithOrg(ref.tenant.ID, tenantMetricTiDBCloudOrgIDFromMeta(ctx, m.meta, ref.tenant), "user_db_access", "tenant_worker_acquire", "error", time.Since(acquireStart))
+		metrics.RecordTenantOperationWithOrg(ref.tenant.ID, tidbCloudOrgID, "user_db_access", "tenant_worker_acquire", "error", time.Since(acquireStart))
 		return nil, fmt.Errorf("backend missing for %s", ref.id)
 	}
 	// Kick-driven acquire success: the tenant TiDB is now open for this kick.

--- a/pkg/server/tenant_worker.go
+++ b/pkg/server/tenant_worker.go
@@ -166,10 +166,18 @@ type tenantWorkerManager struct {
 
 type tenantTarget struct {
 	tenantID         string
+	tidbCloudOrgID   string
 	backend          *backend.Dat9Backend
 	store            *datastore.Store
 	allowedTaskTypes []semantic.TaskType
 	release          func()
+}
+
+func (t *tenantTarget) metricOrgID() string {
+	if t == nil {
+		return defaultTenantMetricTiDBCloudOrgID
+	}
+	return normalizeTenantMetricTiDBCloudOrgID(t.tidbCloudOrgID)
 }
 
 func newTenantWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Store, pool *tenant.Pool, embedder embedding.Client, opts TenantWorkerOptions, maintenanceInterval time.Duration) *tenantWorkerManager {
@@ -218,19 +226,19 @@ func (m *tenantWorkerManager) Kick(tenantID string, workMask int) {
 	if pending, ok := m.kickPending[tenantID]; ok {
 		m.kickPending[tenantID] = pending | workMask
 		m.mu.Unlock()
-		metrics.RecordTenantOperation(tenantID, "tenant_worker", "kick", "coalesced", 0)
+		metrics.RecordTenantOperationWithOrg(tenantID, defaultTenantMetricTiDBCloudOrgID, "tenant_worker", "kick", "coalesced", 0)
 		return
 	}
 	m.kickPending[tenantID] = workMask
 	m.mu.Unlock()
 	select {
 	case m.kicks <- kickMsg{tenantID: tenantID, workMask: workMask}:
-		metrics.RecordTenantOperation(tenantID, "tenant_worker", "kick", "queued", 0)
+		metrics.RecordTenantOperationWithOrg(tenantID, defaultTenantMetricTiDBCloudOrgID, "tenant_worker", "kick", "queued", 0)
 	default:
 		// Channel full: leave kickPending so flushDelayedKicks (ticked from
 		// workerLoop) re-enqueues when the channel has space. The work mask is
 		// already recorded in kickPending above; do NOT clear it.
-		metrics.RecordTenantOperation(tenantID, "tenant_worker", "kick", "delayed", 0)
+		metrics.RecordTenantOperationWithOrg(tenantID, defaultTenantMetricTiDBCloudOrgID, "tenant_worker", "kick", "delayed", 0)
 	}
 }
 
@@ -274,7 +282,7 @@ func (m *tenantWorkerManager) flushDelayedKicks() {
 			// Successfully (re-)queued. Leave the kickPending entry in place:
 			// the worker merges it via takePendingWorkMask after claiming the
 			// slot, so any further coalesced kicks are not lost.
-			metrics.RecordTenantOperation(tenantID, "tenant_worker", "kick", "flushed", 0)
+			metrics.RecordTenantOperationWithOrg(tenantID, defaultTenantMetricTiDBCloudOrgID, "tenant_worker", "kick", "flushed", 0)
 		default:
 			// Still full; leave pending for the next tick.
 		}
@@ -503,14 +511,14 @@ func (m *tenantWorkerManager) recoverExpired(ctx context.Context, target *tenant
 	recovered, err := target.store.RecoverExpiredSemanticTasks(ctx, time.Now().UTC(), semanticRecoverLimit)
 	if err != nil {
 		if !isContextDoneErr(err) {
-			metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "recover", "error", time.Since(start))
+			metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "recover", "error", time.Since(start))
 			logger.Warn(ctx, "tenant_worker_recover_failed",
 				zap.String("tenant_id", target.tenantID), zap.Error(err))
 		}
 		return
 	}
 	if recovered > 0 {
-		metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "recover", "ok", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "recover", "ok", time.Since(start))
 		logger.Info(ctx, "tenant_worker_recover_ok",
 			zap.String("tenant_id", target.tenantID),
 			zap.Int("recovered", recovered))
@@ -536,7 +544,7 @@ func (m *tenantWorkerManager) piggybackMaintenance(ctx context.Context, target *
 
 	// fs_events cleanup: prune rows older than fsEventsRetention.
 	if count, err := target.store.CountFSEvents(ctx); err == nil {
-		metrics.RecordFSEventsRows(target.tenantID, count)
+		metrics.RecordFSEventsRowsWithOrg(target.tenantID, target.metricOrgID(), count)
 	}
 	if n, err := target.store.DeleteFSEventsBefore(ctx, now.Add(-fsEventsRetention)); err != nil {
 		if ctx.Err() == nil {
@@ -544,7 +552,7 @@ func (m *tenantWorkerManager) piggybackMaintenance(ctx context.Context, target *
 				zap.String("tenant_id", target.tenantID), zap.Error(err))
 		}
 	} else {
-		metrics.RecordFSEventsPruned(target.tenantID, n)
+		metrics.RecordFSEventsPrunedWithOrg(target.tenantID, target.metricOrgID(), n)
 	}
 
 	// Observation metrics: sample queue depth + dead-letter count.
@@ -560,7 +568,7 @@ func (m *tenantWorkerManager) observeTenant(ctx context.Context, target *tenantT
 		}
 		return
 	}
-	metrics.RecordTenantGauge(target.tenantID, "semantic_worker", "dead_lettered", float64(obs.DeadLettered))
+	metrics.RecordTenantGaugeWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "dead_lettered", float64(obs.DeadLettered))
 	tenantLag := float64(0)
 	if obs.OldestClaimableAvailableAt != nil {
 		tenantLag = now.UTC().Sub(obs.OldestClaimableAvailableAt.UTC()).Seconds()
@@ -568,7 +576,7 @@ func (m *tenantWorkerManager) observeTenant(ctx context.Context, target *tenantT
 			tenantLag = 0
 		}
 	}
-	metrics.RecordTenantGauge(target.tenantID, "semantic_worker", "queue_lag_seconds", tenantLag)
+	metrics.RecordTenantGaugeWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "queue_lag_seconds", tenantLag)
 }
 
 // kickRef resolves a kicked tenant ID to a schedulable ref, applying the same
@@ -618,6 +626,7 @@ func (m *tenantWorkerManager) targetForRef(ctx context.Context, ref semanticTena
 		}
 		return &tenantTarget{
 			tenantID:         ref.id,
+			tidbCloudOrgID:   m.fallback.TiDBCloudOrgID(),
 			backend:          m.fallback,
 			store:            m.fallback.Store(),
 			allowedTaskTypes: m.taskTypesForTarget(m.fallback),
@@ -633,20 +642,21 @@ func (m *tenantWorkerManager) targetForRef(ctx context.Context, ref semanticTena
 		// Kick-driven acquire failure: a kick arrived but the tenant TiDB could
 		// not be opened. Record so the major alert can detect sustained worker
 		// acquire errors (kicks not reaching the tenant DB).
-		metrics.RecordTenantOperation(ref.tenant.ID, "user_db_access", "tenant_worker_acquire", metrics.ResultForError(err), time.Since(acquireStart))
+		metrics.RecordTenantOperationWithOrg(ref.tenant.ID, tenantMetricTiDBCloudOrgIDFromMeta(ctx, m.meta, ref.tenant), "user_db_access", "tenant_worker_acquire", metrics.ResultForError(err), time.Since(acquireStart))
 		return nil, fmt.Errorf("acquire tenant backend: %w", err)
 	}
 	if b == nil {
 		release()
-		metrics.RecordTenantOperation(ref.tenant.ID, "user_db_access", "tenant_worker_acquire", "error", time.Since(acquireStart))
+		metrics.RecordTenantOperationWithOrg(ref.tenant.ID, tenantMetricTiDBCloudOrgIDFromMeta(ctx, m.meta, ref.tenant), "user_db_access", "tenant_worker_acquire", "error", time.Since(acquireStart))
 		return nil, fmt.Errorf("backend missing for %s", ref.id)
 	}
 	// Kick-driven acquire success: the tenant TiDB is now open for this kick.
 	// The rate follows write traffic (kicks are produced by writes). A spike
 	// uncorrelated with writes would suggest a scan path regressing.
-	metrics.RecordTenantOperation(ref.tenant.ID, "user_db_access", "tenant_worker_acquire", "ok", time.Since(acquireStart))
+	metrics.RecordTenantOperationWithOrg(ref.tenant.ID, b.TiDBCloudOrgID(), "user_db_access", "tenant_worker_acquire", "ok", time.Since(acquireStart))
 	return &tenantTarget{
 		tenantID:         ref.id,
+		tidbCloudOrgID:   b.TiDBCloudOrgID(),
 		backend:          b,
 		store:            b.Store(),
 		allowedTaskTypes: m.taskTypesForTarget(b),
@@ -671,7 +681,7 @@ func (m *tenantWorkerManager) claimAndProcessOne(ctx context.Context, target *te
 	claimStart := time.Now()
 	task, found, err := target.store.ClaimSemanticTask(ctx, time.Now().UTC(), m.opts.LeaseDuration, target.allowedTaskTypes...)
 	if err != nil {
-		metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "claim", "error", time.Since(claimStart))
+		metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "claim", "error", time.Since(claimStart))
 		logger.Warn(ctx, "tenant_worker_claim_failed",
 			append([]zap.Field{
 				zap.String("tenant_id", target.tenantID),
@@ -683,7 +693,7 @@ func (m *tenantWorkerManager) claimAndProcessOne(ctx context.Context, target *te
 	if !found {
 		return false
 	}
-	metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "claim", "ok", time.Since(claimStart))
+	metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "claim", "ok", time.Since(claimStart))
 	logger.Info(ctx, "tenant_worker_claim_ok",
 		append([]zap.Field{
 			zap.String("tenant_id", target.tenantID),

--- a/pkg/server/tenant_worker_semantic.go
+++ b/pkg/server/tenant_worker_semantic.go
@@ -74,8 +74,9 @@ func (m *tenantWorkerManager) processTask(ctx context.Context, target *tenantTar
 	start := time.Now()
 	result := "ok"
 	tenantID := target.tenantID
+	tidbCloudOrgID := target.metricOrgID()
 	defer func() {
-		metrics.RecordTenantOperation(tenantID, "semantic_worker", string(task.TaskType), result, time.Since(start))
+		metrics.RecordTenantOperationWithOrg(tenantID, tidbCloudOrgID, "semantic_worker", string(task.TaskType), result, time.Since(start))
 	}()
 	leaseExec := m.startTaskLeaseExecution(ctx, target, task)
 	var (
@@ -100,7 +101,7 @@ func (m *tenantWorkerManager) processTask(ctx context.Context, target *tenantTar
 	m.injectBeforeSemanticTaskFinalize(target.tenantID, target.store, task, outcome)
 	// Re-check ownership after the handler returns so tests can deterministically
 	// force a lease-loss window before any terminal state mutation happens.
-	stillOwned, err := m.semanticTaskStillOwned(ctx, target.tenantID, target.store, task, outcome.result)
+	stillOwned, err := m.semanticTaskStillOwned(ctx, target, task, outcome.result)
 	if err != nil {
 		logger.Warn(ctx, "tenant_worker_finalize_ownership_check_failed",
 			append([]zap.Field{
@@ -114,9 +115,9 @@ func (m *tenantWorkerManager) processTask(ctx context.Context, target *tenantTar
 	case semanticTaskActionAck:
 		m.ackTask(ctx, target.tenantID, target.store, task, outcome.message)
 	case semanticTaskActionRetry:
-		m.retryTask(ctx, target.tenantID, target.store, task, outcome.message)
+		m.retryTask(ctx, target, task, outcome.message)
 	case semanticTaskActionDeadLetter:
-		m.deadLetterTask(ctx, target.tenantID, target.store, task, outcome.message)
+		m.deadLetterTask(ctx, target, task, outcome.message)
 	}
 }
 
@@ -138,12 +139,14 @@ func (m *tenantWorkerManager) ackTask(ctx context.Context, tenantID string, stor
 		}, semanticTaskLogFields(task)...)...)
 }
 
-func (m *tenantWorkerManager) retryTask(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task, message string) {
+func (m *tenantWorkerManager) retryTask(ctx context.Context, target *tenantTarget, task *semantic.Task, message string) {
 	start := time.Now()
+	tenantID := target.tenantID
+	store := target.store
 	retryAt := time.Now().UTC().Add(m.retryDelay(task.AttemptCount))
 	willDeadLetter := task.AttemptCount >= task.MaxAttempts
 	if err := store.RetrySemanticTask(ctx, task.TaskID, task.Receipt, retryAt, message); err != nil {
-		metrics.RecordTenantOperation(tenantID, "semantic_worker", "retry", "error", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(tenantID, target.metricOrgID(), "semantic_worker", "retry", "error", time.Since(start))
 		logger.Warn(ctx, "tenant_worker_retry_failed",
 			append([]zap.Field{
 				zap.String("tenant_id", tenantID),
@@ -157,7 +160,7 @@ func (m *tenantWorkerManager) retryTask(ctx context.Context, tenantID string, st
 		result = "dead_lettered"
 		logMessage = "tenant_worker_dead_lettered"
 	}
-	metrics.RecordTenantOperation(tenantID, "semantic_worker", "retry", result, time.Since(start))
+	metrics.RecordTenantOperationWithOrg(tenantID, target.metricOrgID(), "semantic_worker", "retry", result, time.Since(start))
 	fields := append([]zap.Field{
 		zap.String("tenant_id", tenantID),
 		zap.String("result", result),
@@ -169,10 +172,12 @@ func (m *tenantWorkerManager) retryTask(ctx context.Context, tenantID string, st
 	logger.Warn(ctx, logMessage, fields...)
 }
 
-func (m *tenantWorkerManager) deadLetterTask(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task, message string) {
+func (m *tenantWorkerManager) deadLetterTask(ctx context.Context, target *tenantTarget, task *semantic.Task, message string) {
 	start := time.Now()
+	tenantID := target.tenantID
+	store := target.store
 	if err := store.DeadLetterSemanticTask(ctx, task.TaskID, task.Receipt, message); err != nil {
-		metrics.RecordTenantOperation(tenantID, "semantic_worker", "dead_letter", "error", time.Since(start))
+		metrics.RecordTenantOperationWithOrg(tenantID, target.metricOrgID(), "semantic_worker", "dead_letter", "error", time.Since(start))
 		logger.Warn(ctx, "tenant_worker_dead_letter_failed",
 			append([]zap.Field{
 				zap.String("tenant_id", tenantID),
@@ -180,7 +185,7 @@ func (m *tenantWorkerManager) deadLetterTask(ctx context.Context, tenantID strin
 			}, append(semanticTaskLogFields(task), zap.Error(err))...)...)
 		return
 	}
-	metrics.RecordTenantOperation(tenantID, "semantic_worker", "dead_letter", "dead_lettered", time.Since(start))
+	metrics.RecordTenantOperationWithOrg(tenantID, target.metricOrgID(), "semantic_worker", "dead_letter", "dead_lettered", time.Since(start))
 	logger.Warn(ctx, "tenant_worker_dead_lettered",
 		append([]zap.Field{
 			zap.String("tenant_id", tenantID),
@@ -305,10 +310,10 @@ func (e *semanticTaskLeaseExecution) run(m *tenantWorkerManager, target *tenantT
 			leaseUntil, err := target.store.RenewSemanticTask(e.ctx, task.TaskID, task.Receipt, m.opts.LeaseDuration)
 			if err != nil {
 				if errors.Is(err, semantic.ErrTaskLeaseMismatch) || errors.Is(err, semantic.ErrTaskNotFound) {
-					metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "renew", "error", time.Since(renewStart))
+					metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "renew", "error", time.Since(renewStart))
 					e.markLeaseLost()
 					failpoint.InjectCall("semanticWorkerOnLeaseLost", target.tenantID, target.store, task, err)
-					metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "lease_lost", "ok", time.Since(renewStart))
+					metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "lease_lost", "ok", time.Since(renewStart))
 					logger.Warn(e.ctx, "tenant_worker_lease_lost",
 						append([]zap.Field{
 							zap.String("tenant_id", target.tenantID),
@@ -322,7 +327,7 @@ func (e *semanticTaskLeaseExecution) run(m *tenantWorkerManager, target *tenantT
 					e.logStopped(m, target, task)
 					return
 				}
-				metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "renew", "error", time.Since(renewStart))
+				metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "renew", "error", time.Since(renewStart))
 				logger.Warn(e.ctx, "tenant_worker_lease_renew_failed",
 					append([]zap.Field{
 						zap.String("tenant_id", target.tenantID),
@@ -332,7 +337,7 @@ func (e *semanticTaskLeaseExecution) run(m *tenantWorkerManager, target *tenantT
 			}
 			e.recordRenewedLease(leaseUntil)
 			failpoint.InjectCall("semanticWorkerAfterRenew", target.tenantID, target.store, task, leaseUntil)
-			metrics.RecordTenantOperation(target.tenantID, "semantic_worker", "renew", "ok", time.Since(renewStart))
+			metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "renew", "ok", time.Since(renewStart))
 		}
 	}
 }
@@ -488,7 +493,9 @@ func (m *tenantWorkerManager) processAudioExtractTask(ctx context.Context, b *ba
 	return semanticTaskOutcome{action: semanticTaskActionAck, result: string(result), message: string(result)}
 }
 
-func (m *tenantWorkerManager) semanticTaskStillOwned(ctx context.Context, tenantID string, store *datastore.Store, task *semantic.Task, result string) (bool, error) {
+func (m *tenantWorkerManager) semanticTaskStillOwned(ctx context.Context, target *tenantTarget, task *semantic.Task, result string) (bool, error) {
+	tenantID := target.tenantID
+	store := target.store
 	if store == nil || task == nil {
 		return false, fmt.Errorf("check semantic task ownership: nil store or task")
 	}
@@ -503,7 +510,7 @@ func (m *tenantWorkerManager) semanticTaskStillOwned(ctx context.Context, tenant
 	if count > 0 {
 		return true, nil
 	}
-	metrics.RecordTenantOperation(tenantID, "semantic_worker", "lease_lost", "ok", 0)
+	metrics.RecordTenantOperationWithOrg(tenantID, target.metricOrgID(), "semantic_worker", "lease_lost", "ok", 0)
 	logger.Warn(ctx, "tenant_worker_finalize_skipped_lease_lost",
 		append([]zap.Field{
 			zap.String("tenant_id", tenantID),

--- a/pkg/server/tenant_worker_test.go
+++ b/pkg/server/tenant_worker_test.go
@@ -35,22 +35,31 @@ func TestTenantWorkerKickAccumulation(t *testing.T) {
 	// kick dedup logic directly with a manually constructed manager.
 	m := &tenantWorkerManager{
 		inflight:    make(map[string]int),
-		kickPending: make(map[string]int),
+		kickPending: make(map[string]pendingKick),
 		kicks:       make(chan kickMsg, tenantKickQueueCapacity),
 	}
 	// First kick should be queued.
-	m.Kick("t1", WorkSemantic)
+	m.KickWithOrg("t1", "org-t1", WorkSemantic)
 	if len(m.kicks) != 1 {
 		t.Fatalf("expected 1 queued kick, got %d", len(m.kicks))
 	}
+	msg := <-m.kicks
+	if msg.tidbCloudOrgID != "org-t1" {
+		t.Fatalf("queued kick org = %q, want org-t1", msg.tidbCloudOrgID)
+	}
+	m.kicks <- msg
 	// Second kick for same tenant should coalesce (OR-accumulate mask).
 	m.Kick("t1", WorkFileGC)
 	// kickPending should have the accumulated mask.
 	m.mu.Lock()
-	pending := m.kickPending["t1"]
+	pending := m.kickPending["t1"].workMask
+	orgID := m.kickPending["t1"].tidbCloudOrgID
 	m.mu.Unlock()
 	if pending != WorkSemantic|WorkFileGC {
 		t.Fatalf("expected accumulated mask %d, got %d", WorkSemantic|WorkFileGC, pending)
+	}
+	if orgID != "org-t1" {
+		t.Fatalf("pending kick org = %q, want org-t1", orgID)
 	}
 	// Only one kick should be in the channel (coalesced, not duplicated).
 	if len(m.kicks) != 1 {
@@ -62,7 +71,7 @@ func TestTenantWorkerKickEmptyIgnored(t *testing.T) {
 	t.Parallel()
 	m := &tenantWorkerManager{
 		inflight:    make(map[string]int),
-		kickPending: make(map[string]int),
+		kickPending: make(map[string]pendingKick),
 		kicks:       make(chan kickMsg, tenantKickQueueCapacity),
 	}
 	m.Kick("t1", 0)
@@ -79,10 +88,10 @@ func TestTenantWorkerTakePendingWorkMask(t *testing.T) {
 	t.Parallel()
 	m := &tenantWorkerManager{
 		inflight:    make(map[string]int),
-		kickPending: make(map[string]int),
+		kickPending: make(map[string]pendingKick),
 		kicks:       make(chan kickMsg, tenantKickQueueCapacity),
 	}
-	m.kickPending["t1"] = WorkSemantic | WorkFileGC
+	m.kickPending["t1"] = pendingKick{workMask: WorkSemantic | WorkFileGC, tidbCloudOrgID: "org-t1"}
 	mask := m.takePendingWorkMask("t1")
 	if mask != WorkSemantic|WorkFileGC {
 		t.Fatalf("expected mask %d, got %d", WorkSemantic|WorkFileGC, mask)
@@ -91,5 +100,26 @@ func TestTenantWorkerTakePendingWorkMask(t *testing.T) {
 	mask2 := m.takePendingWorkMask("t1")
 	if mask2 != 0 {
 		t.Fatalf("expected 0 after take, got %d", mask2)
+	}
+}
+
+func TestTenantWorkerTakePendingKickIncludesOrg(t *testing.T) {
+	t.Parallel()
+	m := &tenantWorkerManager{
+		inflight:    make(map[string]int),
+		kickPending: make(map[string]pendingKick),
+		kicks:       make(chan kickMsg, tenantKickQueueCapacity),
+	}
+	m.kickPending["t1"] = pendingKick{workMask: WorkSemantic, tidbCloudOrgID: "org-t1"}
+
+	pending := m.takePendingKick("t1")
+	if pending.workMask != WorkSemantic {
+		t.Fatalf("pending mask = %d, want %d", pending.workMask, WorkSemantic)
+	}
+	if pending.tidbCloudOrgID != "org-t1" {
+		t.Fatalf("pending org = %q, want org-t1", pending.tidbCloudOrgID)
+	}
+	if _, ok := m.kickPending["t1"]; ok {
+		t.Fatal("pending kick should be cleared")
 	}
 }

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -62,7 +62,7 @@ var errVaultUnsupported = errors.New("vault is not supported for this provider")
 func recordVaultOperation(ctx context.Context, tenantID, op string, start time.Time, result string) {
 	scopeTenantID, _, _, tidbCloudOrgID := requestMetricScope(ctx)
 	if scopeTenantID != tenantID {
-		tidbCloudOrgID = defaultTenantMetricTiDBCloudOrgID
+		tidbCloudOrgID = ""
 	}
 	metrics.RecordTenantOperationWithOrg(tenantID, tidbCloudOrgID, "vault", op, result, time.Since(start))
 }

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -58,8 +59,12 @@ func (s *Server) handleVault(w http.ResponseWriter, r *http.Request) {
 
 var errVaultUnsupported = errors.New("vault is not supported for this provider")
 
-func recordVaultOperation(tenantID, op string, start time.Time, result string) {
-	metrics.RecordTenantOperation(tenantID, "vault", op, result, time.Since(start))
+func recordVaultOperation(ctx context.Context, tenantID, op string, start time.Time, result string) {
+	scopeTenantID, _, _, tidbCloudOrgID := requestMetricScope(ctx)
+	if scopeTenantID != tenantID {
+		tidbCloudOrgID = defaultTenantMetricTiDBCloudOrgID
+	}
+	metrics.RecordTenantOperationWithOrg(tenantID, tidbCloudOrgID, "vault", op, result, time.Since(start))
 }
 
 // vaultStore returns the vault store for the current tenant.
@@ -146,7 +151,7 @@ func (s *Server) handleVaultSecrets(w http.ResponseWriter, r *http.Request, sub 
 func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "secret_create", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "secret_create", start, result) }()
 
 	var req struct {
 		Name       string            `json:"name"`
@@ -213,7 +218,7 @@ func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request,
 func (s *Server) handleVaultSecretList(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "secret_list", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "secret_list", start, result) }()
 
 	secrets, err := vs.ListSecrets(r.Context(), tenantID)
 	if err != nil {
@@ -231,7 +236,7 @@ func (s *Server) handleVaultSecretList(w http.ResponseWriter, r *http.Request, v
 func (s *Server) handleVaultSecretGet(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "secret_get", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "secret_get", start, result) }()
 
 	sec, err := vs.GetSecret(r.Context(), tenantID, name)
 	if err != nil {
@@ -253,7 +258,7 @@ func (s *Server) handleVaultSecretGet(w http.ResponseWriter, r *http.Request, vs
 func (s *Server) handleVaultSecretReadValue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, secretName string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "secret_read_value", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "secret_read_value", start, result) }()
 
 	fields, err := vs.ReadSecretFields(r.Context(), tenantID, secretName)
 	if err != nil {
@@ -301,7 +306,7 @@ func (s *Server) handleVaultSecretReadValue(w http.ResponseWriter, r *http.Reque
 func (s *Server) handleVaultSecretReadField(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, secretName, fieldName string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "secret_read_field", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "secret_read_field", start, result) }()
 
 	plaintext, err := vs.ReadSecretField(r.Context(), tenantID, secretName, fieldName)
 	if err != nil {
@@ -332,7 +337,7 @@ func (s *Server) handleVaultSecretReadField(w http.ResponseWriter, r *http.Reque
 func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "secret_update", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "secret_update", start, result) }()
 
 	var req struct {
 		Fields    map[string]string `json:"fields"`
@@ -387,7 +392,7 @@ func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request,
 func (s *Server) handleVaultSecretDelete(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, name string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "secret_delete", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "secret_delete", start, result) }()
 
 	err := vs.DeleteSecret(r.Context(), tenantID, name)
 	if err != nil {
@@ -448,7 +453,7 @@ func (s *Server) handleVaultTokens(w http.ResponseWriter, r *http.Request, sub s
 func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "token_issue", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "token_issue", start, result) }()
 
 	var req struct {
 		AgentID string   `json:"agent_id"`
@@ -508,7 +513,7 @@ func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, v
 func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, tokenID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "token_revoke", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "token_revoke", start, result) }()
 
 	var req struct {
 		RevokedBy string `json:"revoked_by"`
@@ -589,7 +594,7 @@ func (s *Server) handleVaultGrants(w http.ResponseWriter, r *http.Request, sub s
 func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "grant_issue", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "grant_issue", start, result) }()
 
 	// Grants require a canonical server URL for the `iss` claim. If the
 	// operator hasn't configured one, we cannot mint non-forgeable tokens:
@@ -678,7 +683,7 @@ func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, v
 func (s *Server) handleVaultGrantRevoke(w http.ResponseWriter, r *http.Request, vs *vault.Store, tenantID, grantID string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(tenantID, "grant_revoke", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), tenantID, "grant_revoke", start, result) }()
 
 	var req struct {
 		RevokedBy string `json:"revoked_by"`
@@ -732,7 +737,7 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	auditTenantID := scope.TenantID
-	defer func() { recordVaultOperation(auditTenantID, "audit_query", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), auditTenantID, "audit_query", start, result) }()
 
 	if r.Method != http.MethodGet {
 		result = "invalid_argument"
@@ -908,7 +913,7 @@ func (s *Server) verifyGrantReadToken(r *http.Request, vs *vault.Store, tenantID
 func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(p.TenantID, "read_enumerate", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), p.TenantID, "read_enumerate", start, result) }()
 
 	scopedNames := vault.ScopedSecretNames(p.Scope)
 	// Filter to secrets that actually exist.
@@ -939,7 +944,7 @@ func (s *Server) handleVaultReadEnumerate(w http.ResponseWriter, r *http.Request
 func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal, secretName string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(p.TenantID, "read_secret", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), p.TenantID, "read_secret", start, result) }()
 
 	// Scope check.
 	allFields, allowedFields := vault.AllowedFields(p.Scope, secretName)
@@ -1016,7 +1021,7 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs *vault.Store, p *vaultReadPrincipal, secretName, fieldName string) {
 	start := time.Now()
 	result := "ok"
-	defer func() { recordVaultOperation(p.TenantID, "read_field", start, result) }()
+	defer func() { recordVaultOperation(r.Context(), p.TenantID, "read_field", start, result) }()
 
 	// Scope check.
 	if !vault.CheckScope(p.Scope, secretName, fieldName) {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -138,7 +138,7 @@ type Pool struct {
 	items              map[string]*entry
 	order              *list.List
 	maxSize            int
-	tenantWorkNotifier atomic.Pointer[func(tenantID string, workMask int)]
+	tenantWorkNotifier atomic.Pointer[func(tenantID, tidbCloudOrgID string, workMask int)]
 	// fileGCEnabled is retained for backward compatibility but no longer used:
 	// FileGC is now kick-driven through the unified tenant worker, not a
 	// per-backend goroutine.
@@ -243,11 +243,12 @@ func (p *Pool) SetMetaStore(ms *meta.Store) {
 	p.metaStore = ms
 }
 
-// SetTenantWorkNotifier registers a callback invoked with the tenant ID and a
-// work mask whenever one of this pool's backends commits durable work (semantic
-// task, file_gc task, quota outbox row), so the tenant worker can claim the new
-// work immediately instead of waiting for a periodic scan.
-func (p *Pool) SetTenantWorkNotifier(fn func(tenantID string, workMask int)) {
+// SetTenantWorkNotifier registers a callback invoked with the tenant ID, TiDB
+// Cloud org ID, and work mask whenever one of this pool's backends commits
+// durable work (semantic task, file_gc task, quota outbox row), so the tenant
+// worker can claim the new work immediately instead of waiting for a periodic
+// scan.
+func (p *Pool) SetTenantWorkNotifier(fn func(tenantID, tidbCloudOrgID string, workMask int)) {
 	if p == nil {
 		return
 	}
@@ -258,9 +259,9 @@ func (p *Pool) wireTenantWorkNotifier(b *backend.Dat9Backend, tenantID string) {
 	// Resolve the notifier at call time, not wire time, so backends created
 	// before SetTenantWorkNotifier (e.g. during tenant resume on startup) still
 	// notify once the tenant worker registers.
-	b.SetWorkEnqueuedNotifier(func(workMask int) {
+	b.SetWorkEnqueuedNotifier(func(workMask int, tidbCloudOrgID string) {
 		if fn := p.tenantWorkNotifier.Load(); fn != nil && *fn != nil {
-			(*fn)(tenantID, workMask)
+			(*fn)(tenantID, tidbCloudOrgID, workMask)
 		}
 	})
 }
@@ -515,7 +516,7 @@ func (p *Pool) AcquireCached(t *meta.Tenant) (b *backend.Dat9Backend, release fu
 		// This is the warm-only invariant working as designed — the safety-net
 		// must never open a cold tenant TiDB. Record so the invariant-violation
 		// alert can confirm AcquireCached is staying warm-only.
-		metrics.RecordTenantOperationWithOrg(t.ID, defaultTenantMetricTiDBCloudOrgID, "user_db_access", "acquire_cached", "cold_skipped", 0)
+		metrics.RecordTenantOperationWithOrg(t.ID, "", "user_db_access", "acquire_cached", "cold_skipped", 0)
 		return nil, nil, false
 	}
 	if e.s3EncryptionPolicy != s3EncryptionPolicy || (t.StorageNamespaceID != "" && e.storageNamespaceID != t.StorageNamespaceID) {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -806,7 +806,13 @@ func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantI
 }
 
 func (p *Pool) tenantMetricTiDBCloudOrgID(ctx context.Context, t *meta.Tenant) string {
-	if p == nil || p.metaStore == nil || t == nil || strings.TrimSpace(t.ID) == "" || t.Provider != ProviderTiDBCloudNative {
+	if t == nil || strings.TrimSpace(t.ID) == "" || t.Provider != ProviderTiDBCloudNative {
+		return defaultTenantMetricTiDBCloudOrgID
+	}
+	if orgID := strings.TrimSpace(t.TiDBCloudOrgID); orgID != "" {
+		return orgID
+	}
+	if p == nil || p.metaStore == nil {
 		return defaultTenantMetricTiDBCloudOrgID
 	}
 	binding, err := p.metaStore.GetTenantTiDBCloudOrgBinding(ctx, t.ID)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -301,7 +301,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 		p.mu.Unlock()
 	}
 
-	b, st, err := p.createBackend(ctx, t)
+	b, st, _, err := p.createBackend(ctx, t)
 	if err != nil {
 		return nil, err
 	}
@@ -384,11 +384,11 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	}
 
 	createBackendStart := time.Now()
-	b, st, err := p.createBackend(ctx, t)
+	b, st, tidbCloudOrgID, err := p.createBackend(ctx, t)
 	if err != nil {
 		// Cold-open failure: a tenant TiDB open was attempted but failed.
 		// Record so alerts can detect a scan path that is churning cold opens.
-		metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cold_open", "error", time.Since(createBackendStart))
+		metrics.RecordTenantOperationWithOrg(t.ID, tidbCloudOrgID, "user_db_access", "acquire_cold_open", "error", time.Since(createBackendStart))
 		return nil, nil, err
 	}
 	createBackendDurationMs := float64(time.Since(createBackendStart).Microseconds()) / 1000.0
@@ -396,7 +396,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	// This is the canonical "a serverless TiDB was woken up" signal — the
 	// primary billing-storm indicator. PR #660 eliminated periodic scans that
 	// caused cold opens at scale; this metric guards against regressions.
-	metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cold_open", "ok", time.Since(createBackendStart))
+	metrics.RecordTenantOperationWithOrg(t.ID, tidbCloudOrgID, "user_db_access", "acquire_cold_open", "ok", time.Since(createBackendStart))
 
 	p.mu.Lock()
 	if e, ok := p.items[t.ID]; ok {
@@ -515,7 +515,7 @@ func (p *Pool) AcquireCached(t *meta.Tenant) (b *backend.Dat9Backend, release fu
 		// This is the warm-only invariant working as designed — the safety-net
 		// must never open a cold tenant TiDB. Record so the invariant-violation
 		// alert can confirm AcquireCached is staying warm-only.
-		metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cached", "cold_skipped", 0)
+		metrics.RecordTenantOperationWithOrg(t.ID, defaultTenantMetricTiDBCloudOrgID, "user_db_access", "acquire_cached", "cold_skipped", 0)
 		return nil, nil, false
 	}
 	if e.s3EncryptionPolicy != s3EncryptionPolicy || (t.StorageNamespaceID != "" && e.storageNamespaceID != t.StorageNamespaceID) {
@@ -523,14 +523,14 @@ func (p *Pool) AcquireCached(t *meta.Tenant) (b *backend.Dat9Backend, release fu
 		// Stale-skip: the cached backend's encryption policy / storage namespace
 		// no longer matches the tenant. The safety-net defers to the next write
 		// kick. Record so this rare edge case is observable.
-		metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cached", "stale_skipped", 0)
+		metrics.RecordTenantOperationWithOrg(t.ID, e.backend.TiDBCloudOrgID(), "user_db_access", "acquire_cached", "stale_skipped", 0)
 		return nil, nil, false
 	}
 	e.refs++
 	p.order.MoveToFront(e.elem)
 	p.mu.Unlock()
 	metrics.RecordOperation("tenant_pool", "cache_lookup", "hit", 0)
-	metrics.RecordTenantOperation(t.ID, "user_db_access", "acquire_cached", "hit", 0)
+	metrics.RecordTenantOperationWithOrg(t.ID, e.backend.TiDBCloudOrgID(), "user_db_access", "acquire_cached", "hit", 0)
 	return e.backend, p.makeReleaseNoRefresh(e), true
 }
 
@@ -804,20 +804,42 @@ func (p *Pool) LoadS3Backend(ctx context.Context, metaStore *meta.Store, tenantI
 	return b
 }
 
-func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9Backend, *datastore.Store, error) {
+func (p *Pool) tenantMetricTiDBCloudOrgID(ctx context.Context, t *meta.Tenant) string {
+	if p == nil || p.metaStore == nil || t == nil || strings.TrimSpace(t.ID) == "" || t.Provider != ProviderTiDBCloudNative {
+		return defaultTenantMetricTiDBCloudOrgID
+	}
+	binding, err := p.metaStore.GetTenantTiDBCloudOrgBinding(ctx, t.ID)
+	if err != nil {
+		if !errors.Is(err, meta.ErrNotFound) {
+			logger.Warn(ctx, "tenant_pool_metric_org_lookup_failed",
+				zap.String("tenant_id", t.ID),
+				zap.Error(err))
+		}
+		return defaultTenantMetricTiDBCloudOrgID
+	}
+	orgID := strings.TrimSpace(binding.OrganizationID)
+	if orgID == "" {
+		return defaultTenantMetricTiDBCloudOrgID
+	}
+	return orgID
+}
+
+func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9Backend, *datastore.Store, string, error) {
 	start := time.Now()
+	tidbCloudOrgID := p.tenantMetricTiDBCloudOrgID(ctx, t)
 	decryptStart := time.Now()
 	pass, err := p.enc.Decrypt(ctx, t.DBPasswordCipher)
 	if err != nil {
-		return nil, nil, fmt.Errorf("decrypt db password: %w", err)
+		return nil, nil, tidbCloudOrgID, fmt.Errorf("decrypt db password: %w", err)
 	}
 	decryptDurationMs := float64(time.Since(decryptStart).Microseconds()) / 1000.0
 	opts := p.cfg.BackendOptions
 	resolvedEncryptionPolicy, err := meta.ResolveS3EncryptionPolicy(p.cfg.S3EncryptionPolicy, t.S3EncryptionPolicy())
 	if err != nil {
-		return nil, nil, fmt.Errorf("resolve s3 encryption policy: %w", err)
+		return nil, nil, tidbCloudOrgID, fmt.Errorf("resolve s3 encryption policy: %w", err)
 	}
 	opts.TenantID = t.ID
+	opts.TiDBCloudOrgID = tidbCloudOrgID
 	opts.S3EncryptionPolicy = resolvedEncryptionPolicy
 	query := "parseTime=true"
 	if t.DBTLS {
@@ -827,9 +849,9 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	}
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", t.DBUser, string(pass), t.DBHost, t.DBPort, t.DBName, query)
 	openStoreStart := time.Now()
-	store, err := datastore.OpenForTenant(ctx, dsn, t.ID)
+	store, err := datastore.OpenForTenantWithOrg(ctx, dsn, t.ID, tidbCloudOrgID)
 	if err != nil {
-		return nil, nil, fmt.Errorf("open datastore: %w", err)
+		return nil, nil, tidbCloudOrgID, fmt.Errorf("open datastore: %w", err)
 	}
 	openStoreDurationMs := float64(time.Since(openStoreStart).Microseconds()) / 1000.0
 	ensureSchemaDurationMs := 0.0
@@ -838,13 +860,13 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		autoEmbeddingProfile, err := p.autoEmbeddingProfileForTenant(ctx, t)
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, fmt.Errorf("resolve tenant auto-embedding profile: %w", err)
+			return nil, nil, tidbCloudOrgID, fmt.Errorf("resolve tenant auto-embedding profile: %w", err)
 		}
 		if autoEmbeddingProfile.mode == meta.TenantEmbeddingModeAuto {
 			opts.DatabaseAutoEmbedding = true
 			if err := applyTiDBAutoEmbeddingProviderConfig(ctx, store.DB(), autoEmbeddingProfile.provider); err != nil {
 				_ = store.Close()
-				return nil, nil, fmt.Errorf("apply tenant auto-embedding provider config: %w", err)
+				return nil, nil, tidbCloudOrgID, fmt.Errorf("apply tenant auto-embedding provider config: %w", err)
 			}
 		} else {
 			opts.DatabaseAutoEmbedding = false
@@ -856,14 +878,14 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			targetSchemaVersion, err := TiDBTenantSchemaVersionForEmbeddingMode(autoEmbeddingProfile.mode, autoEmbeddingProfile.schemaProfile)
 			if err != nil {
 				_ = store.Close()
-				return nil, nil, fmt.Errorf("resolve tenant embedding schema version: %w", err)
+				return nil, nil, tidbCloudOrgID, fmt.Errorf("resolve tenant embedding schema version: %w", err)
 			}
 			if t.SchemaVersion != targetSchemaVersion {
 				ensureSchemaStart := time.Now()
 				schemaCtx := schema.WithTenantID(ctx, t.ID)
 				if err := ensureTiDBSchemaForEmbeddingMode(schemaCtx, store.DB(), autoEmbeddingProfile.mode, autoEmbeddingProfile.schemaProfile); err != nil {
 					_ = store.Close()
-					return nil, nil, fmt.Errorf("ensure tidb embedding schema: %w", err)
+					return nil, nil, tidbCloudOrgID, fmt.Errorf("ensure tidb embedding schema: %w", err)
 				}
 				ensureSchemaDurationMs += float64(time.Since(ensureSchemaStart).Microseconds()) / 1000.0
 				if p.metaStore != nil {
@@ -884,7 +906,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			if autoEmbeddingProfile.modeWasNull && p.metaStore != nil {
 				if _, modeErr := p.metaStore.SetTenantAutoEmbeddingProfileModeIfNull(ctx, t.ID, autoEmbeddingProfile.mode); modeErr != nil {
 					_ = store.Close()
-					return nil, nil, fmt.Errorf("persist tenant embedding mode: %w", modeErr)
+					return nil, nil, tidbCloudOrgID, fmt.Errorf("persist tenant embedding mode: %w", modeErr)
 				}
 			}
 		}
@@ -895,7 +917,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 	if store.HasLegacyFiles() {
 		if err := p.migrateSplitTables(ctx, store.DB(), t.Provider); err != nil {
 			_ = store.Close()
-			return nil, nil, fmt.Errorf("migrate split tables: %w", err)
+			return nil, nil, tidbCloudOrgID, fmt.Errorf("migrate split tables: %w", err)
 		}
 	}
 	migrateDurationMs = float64(time.Since(migrateStart).Microseconds()) / 1000.0
@@ -903,7 +925,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		ns, err := p.resolveStorageNamespace(ctx, t, "s3", p.cfg.S3Bucket)
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, err
+			return nil, nil, tidbCloudOrgID, err
 		}
 		opts.StorageNamespaceID = ns.ID
 		prefix := ns.Prefix
@@ -921,7 +943,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		})
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, fmt.Errorf("create aws s3 client: %w", err)
+			return nil, nil, tidbCloudOrgID, fmt.Errorf("create aws s3 client: %w", err)
 		}
 		s3ClientDurationMs := float64(time.Since(s3ClientStart).Microseconds()) / 1000.0
 		smallInDB := SmallInDB(t.Provider)
@@ -929,7 +951,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		b, err := backend.NewWithS3ModeAndOptions(store, s3c, smallInDB, opts)
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, fmt.Errorf("create backend with s3 mode: %w", err)
+			return nil, nil, tidbCloudOrgID, fmt.Errorf("create backend with s3 mode: %w", err)
 		}
 		backendCreateDurationMs := float64(time.Since(backendCreateStart).Microseconds()) / 1000.0
 		totalDuration := time.Since(start)
@@ -946,13 +968,13 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			zap.Float64("total_ms", durationMs(totalDuration)))
 		p.wireQuotaStore(ctx, b, t.ID)
 		p.wireTenantWorkNotifier(b, t.ID)
-		return b, store, nil
+		return b, store, tidbCloudOrgID, nil
 	}
 	if p.cfg.S3Dir != "" {
 		ns, err := p.resolveStorageNamespace(ctx, t, "local", "")
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, err
+			return nil, nil, tidbCloudOrgID, err
 		}
 		opts.StorageNamespaceID = ns.ID
 		localPrefix := strings.Trim(ns.Prefix, "/")
@@ -962,7 +984,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		s3c, err := s3client.NewLocal(s3Dir, s3BaseURL)
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, fmt.Errorf("create local s3 client: %w", err)
+			return nil, nil, tidbCloudOrgID, fmt.Errorf("create local s3 client: %w", err)
 		}
 		s3ClientDurationMs := float64(time.Since(s3ClientStart).Microseconds()) / 1000.0
 		smallInDB := SmallInDB(t.Provider)
@@ -970,7 +992,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		b, err := backend.NewWithS3ModeAndOptions(store, s3c, smallInDB, opts)
 		if err != nil {
 			_ = store.Close()
-			return nil, nil, fmt.Errorf("create backend with local s3 mode: %w", err)
+			return nil, nil, tidbCloudOrgID, fmt.Errorf("create backend with local s3 mode: %w", err)
 		}
 		backendCreateDurationMs := float64(time.Since(backendCreateStart).Microseconds()) / 1000.0
 		totalDuration := time.Since(start)
@@ -987,13 +1009,13 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 			zap.Float64("total_ms", durationMs(totalDuration)))
 		p.wireQuotaStore(ctx, b, t.ID)
 		p.wireTenantWorkNotifier(b, t.ID)
-		return b, store, nil
+		return b, store, tidbCloudOrgID, nil
 	}
 	backendCreateStart := time.Now()
 	b, err := backend.NewWithOptions(store, opts)
 	if err != nil {
 		_ = store.Close()
-		return nil, nil, fmt.Errorf("create backend: %w", err)
+		return nil, nil, tidbCloudOrgID, fmt.Errorf("create backend: %w", err)
 	}
 	backendCreateDurationMs := float64(time.Since(backendCreateStart).Microseconds()) / 1000.0
 	totalDuration := time.Since(start)
@@ -1010,7 +1032,7 @@ func (p *Pool) createBackend(ctx context.Context, t *meta.Tenant) (*backend.Dat9
 		zap.Float64("total_ms", durationMs(totalDuration)))
 	p.wireQuotaStore(ctx, b, t.ID)
 	p.wireTenantWorkNotifier(b, t.ID)
-	return b, store, nil
+	return b, store, tidbCloudOrgID, nil
 }
 
 func (p *Pool) migrateSplitTables(ctx context.Context, db *sql.DB, provider string) error {
@@ -1213,6 +1235,7 @@ const (
 	tenantPoolResultAuthFailed           tenantPoolResult = "auth_failed"
 	tenantPoolResultUsageQuotaExhausted  tenantPoolResult = "usage_quota_exhausted"
 	tenantPoolResultError                tenantPoolResult = "error"
+	defaultTenantMetricTiDBCloudOrgID    string           = "guest"
 	mysqlErrAccessDenied                 uint16           = 1045
 	mysqlErrUsageQuotaExhaustedCandidate uint16           = 1105
 )

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -77,6 +77,19 @@ func TestPoolAcquireTimingFieldsClassifyColdOpen(t *testing.T) {
 	}
 }
 
+func TestTenantMetricTiDBCloudOrgIDUsesPreResolvedTenantOrg(t *testing.T) {
+	pool := NewPool(PoolConfig{}, nil)
+	got := pool.tenantMetricTiDBCloudOrgID(context.Background(), &meta.Tenant{
+		ID:             "tenant-pre-resolved-org",
+		Status:         meta.TenantActive,
+		Provider:       ProviderTiDBCloudNative,
+		TiDBCloudOrgID: "org-pre-resolved",
+	})
+	if got != "org-pre-resolved" {
+		t.Fatalf("org = %q, want org-pre-resolved", got)
+	}
+}
+
 func TestPoolAcquireInvalidateDefersCloseUntilRelease(t *testing.T) {
 	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-a")
 	ctx := context.Background()

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -436,7 +436,7 @@ func TestPoolCreateBackendSkipsSchemaEnsureWhenVersionMatches(t *testing.T) {
 		applyTiDBAutoEmbeddingProviderConfig = origApply
 	})
 
-	backend, store, err := pool.createBackend(context.Background(), tenant)
+	backend, store, _, err := pool.createBackend(context.Background(), tenant)
 	if err != nil {
 		t.Fatalf("createBackend(): %v", err)
 	}
@@ -470,7 +470,7 @@ func TestPoolCreateBackendEnsuresSchemaForTiDBCloudNative(t *testing.T) {
 		applyTiDBAutoEmbeddingProviderConfig = origApply
 	})
 
-	backend, store, err := pool.createBackend(context.Background(), tenant)
+	backend, store, _, err := pool.createBackend(context.Background(), tenant)
 	if err != nil {
 		t.Fatalf("createBackend(): %v", err)
 	}
@@ -515,7 +515,7 @@ func TestPoolCreateBackendRepairsFTSOnlySchemaWhenDatabaseAutoEmbeddingDisabled(
 		applyTiDBAutoEmbeddingProviderConfig = origApply
 	})
 
-	b, store, err := pool.createBackend(context.Background(), tenant)
+	b, store, _, err := pool.createBackend(context.Background(), tenant)
 	if err != nil {
 		t.Fatalf("createBackend(): %v", err)
 	}

--- a/pkg/tenant/quota_adapter.go
+++ b/pkg/tenant/quota_adapter.go
@@ -281,11 +281,12 @@ func (a *metaQuotaAdapter) ListPendingMutations(ctx context.Context, minAge time
 	views := make([]backend.MutationLogView, len(entries))
 	for i, e := range entries {
 		views[i] = backend.MutationLogView{
-			ID:           e.ID,
-			TenantID:     e.TenantID,
-			MutationType: e.MutationType,
-			MutationData: e.MutationData,
-			RetryCount:   e.RetryCount,
+			ID:             e.ID,
+			TenantID:       e.TenantID,
+			TiDBCloudOrgID: e.TiDBCloudOrgID,
+			MutationType:   e.MutationType,
+			MutationData:   e.MutationData,
+			RetryCount:     e.RetryCount,
 		}
 	}
 	return views, nil
@@ -300,6 +301,7 @@ func (a *metaQuotaAdapter) ObservePendingMutations(ctx context.Context) ([]backe
 	for i, e := range entries {
 		views[i] = backend.MutationBacklogView{
 			TenantID:                e.TenantID,
+			TiDBCloudOrgID:          e.TiDBCloudOrgID,
 			PendingCount:            e.PendingCount,
 			OldestPendingAgeSeconds: e.OldestPendingAgeSeconds,
 		}


### PR DESCRIPTION
## Summary
- add `drive9_tenant_pool_bindings{pool_id,status,tidbcloud_org_id}` for tenant pool binding counts where `status` is `free` or `used`
- keep `drive9_tenant_count{status=...}` scoped to real tenant statuses only: `pending`, `provisioning`, `active`, `failed`, `suspended`, `deleting`, `deleted`
- refresh tenant and pool binding counts from the leader metrics loop, emitting zero values for statuses with no current rows
- document the breaking `drive9_tenant_count` migration from legacy `state=...` series to real `status=...` series

## Tests
- `go test ./pkg/metrics -run 'TestRecordTenantCountUsesStatus|TestRecordTenantPoolBindingsIncludesPoolTiDBCloudOrgAndStatus' -count=1`
- `go test ./pkg/meta -run 'TestCountTenants|TestCountTenantPoolBindingsByStatusGroupsByPoolOrganizationAndStatus' -count=1`
- `go test ./pkg/server -run 'TestObserveTenantCountsRecordsAllRealStatuses|TestObserveTenantPoolBindingCountsRecordsUsedAndFreeByPoolAndOrg' -count=1`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `drive9_tenant_pool_bindings` metrics grouped by pool ID, TiDB Cloud org, and binding status (free/used), including pools with no bindings.
  * Expanded tenant/server/DB and related operation metrics to include `tidbcloud_org_id` for better multi-org visibility.
  * Updated Grafana tenant usage dashboard to support org-scoped exploration.
* **Bug Fixes**
  * Tenant counting now reports by real tenant status via a `status` label, removing legacy aggregate naming.
  * Binding and tenant counts now filter invalid pool/org values and exclude deleted tenants for cleaner reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->