### PR TITLE
seed quota config at tenant creation time

### DIFF
--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -13,8 +13,8 @@ const (
 	defaultMetaConnMaxIdleTime       = 45 * time.Second
 	defaultMetaMaxOpenConns          = 100
 	defaultMetaMaxIdleConns          = 20
-	defaultUserConnMaxLifetime       = 45 * time.Second
-	defaultUserConnMaxIdleTime       = 30 * time.Second
+	defaultUserConnMaxLifetime       = 5 * time.Minute
+	defaultUserConnMaxIdleTime       = 1 * time.Minute
 	defaultUserMaxOpenConns          = 6
 	defaultUserMaxIdleConns          = 2
 	defaultUserSchemaConnMaxLifetime = 1 * time.Minute

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1720,11 +1720,14 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		logProvisionStage(ctx, "admin_tenant_pool_claim_quota_local_config_applied", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID)
 	}
 	stageStarted = time.Now()
-	now := time.Now().UTC()
-	if err := s.meta.SetQuotaConfigPatch(ctx, row.Tenant.ID, meta.QuotaConfigPatch{
-		TiDBCloudSpendingLimit:           tidbCloudSpendingLimitFromCloud(cloudCfg),
-		TiDBCloudSpendingLimitCheckedAt: &now,
-	}); err != nil {
+	quotaSeed := meta.QuotaConfigPatch{
+		TiDBCloudSpendingLimit: tidbCloudSpendingLimitFromCloud(cloudCfg),
+	}
+	if cloudCfg != nil {
+		checkedAt := time.Now().UTC()
+		quotaSeed.TiDBCloudSpendingLimitCheckedAt = &checkedAt
+	}
+	if err := s.meta.SetQuotaConfigPatch(ctx, row.Tenant.ID, quotaSeed); err != nil {
 		return nil, nil, false, err
 	}
 	logProvisionStage(ctx, "admin_tenant_pool_claim_quota_seeded", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "create_time_spending_limit", cloudCfg != nil && cloudCfg.TiDBCloudSpendingLimitMonthly != nil)

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1717,11 +1717,17 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		if err := s.applyQuotaLocalConfig(ctx, "pool_claim", row.Tenant.ID, quotaReq); err != nil {
 			return nil, nil, false, err
 		}
-		if err := s.syncTiDBCloudSpendingLimit(ctx, "pool_claim", row.Tenant.ID, cloudCfg, time.Time{}); err != nil {
-			return nil, nil, false, err
-		}
-		logProvisionStage(ctx, "admin_tenant_pool_claim_quota_local_config_applied", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "create_time_spending_limit", cloudCfg != nil && cloudCfg.TiDBCloudSpendingLimitMonthly != nil)
+		logProvisionStage(ctx, "admin_tenant_pool_claim_quota_local_config_applied", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID)
 	}
+	stageStarted = time.Now()
+	now := time.Now().UTC()
+	if err := s.meta.SetQuotaConfigPatch(ctx, row.Tenant.ID, meta.QuotaConfigPatch{
+		TiDBCloudSpendingLimit:           tidbCloudSpendingLimitFromCloud(cloudCfg),
+		TiDBCloudSpendingLimitCheckedAt: &now,
+	}); err != nil {
+		return nil, nil, false, err
+	}
+	logProvisionStage(ctx, "admin_tenant_pool_claim_quota_seeded", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "create_time_spending_limit", cloudCfg != nil && cloudCfg.TiDBCloudSpendingLimitMonthly != nil)
 	stageStarted = time.Now()
 	plainPass, err := s.pool.Decrypt(ctx, row.Tenant.DBPasswordCipher)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -908,6 +908,106 @@ func TestProvisionTiDBCloudNativeCreateQuotaSkipsQuotaPatch(t *testing.T) {
 	}
 }
 
+func TestProvisionSeedsQuotaConfigWithoutExplicitQuota(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{
+		provider:      tenant.ProviderTiDBCloudNative,
+		cloudProvider: "aws",
+		region:        "us-east-1",
+		cluster: &tenant.ClusterInfo{
+			ClusterID:      "native-cluster-seed-quota",
+			OrganizationID: "org-1",
+			Host:           "db.example",
+			Port:           4000,
+			Username:       "u1.root",
+			Password:       "db-pass",
+			DBName:         "customer_db",
+		},
+	}
+
+	srv := NewWithConfig(Config{
+		Meta:                         metaStore,
+		Pool:                         pool,
+		Provisioner:                  prov,
+		TokenSecret:                  tokenSecret,
+		DisableDatabaseAutoEmbedding: true,
+	})
+	defer srv.Close()
+
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	body, _ := json.Marshal(map[string]string{
+		"public_key":  "public-1",
+		"private_key": "private-1",
+	})
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/provision", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+
+	var out map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if out["tenant_id"] == "" || out["api_key"] == "" || out["status"] != string(meta.TenantProvisioning) {
+		t.Fatalf("unexpected response: %+v", out)
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		var status string
+		if err := metaStore.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", out["tenant_id"]).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status == string(meta.TenantActive) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("tenant did not become active in time: status=%s", status)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	cfg, err := metaStore.GetQuotaConfig(context.Background(), out["tenant_id"])
+	if err != nil {
+		t.Fatalf("get quota config: %v", err)
+	}
+	if cfg.TiDBCloudSpendingLimit != nil {
+		t.Fatalf("spending limit = %d, want nil", *cfg.TiDBCloudSpendingLimit)
+	}
+	if cfg.TiDBCloudSpendingLimitCheckedAt != nil {
+		t.Fatalf("checked_at = %v, want nil", cfg.TiDBCloudSpendingLimitCheckedAt)
+	}
+}
+
 func TestProvisionTiDBCloudNativeCreateTimeQuotaRequiresQuotaProvisioner(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -307,6 +307,12 @@ func (p *quotaTestProvisioner) WaitForPoolClustersMetadata(_ context.Context, cl
 func (p *quotaTestProvisioner) MarkClusterPoolUsed(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest, _ time.Time, opts tenant.QuotaUpdateOptions) (*tenant.QuotaCloudConfig, error) {
 	p.markPoolUsedCalls.Add(1)
 	p.recordCall("mark_pool_used", req, cluster, &opts)
+	if p.cloudCfg != nil {
+		return p.cloudCfg, nil
+	}
+	if opts.TiDBCloudSpendingLimitMonthly == nil {
+		return nil, nil
+	}
 	return &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: opts.TiDBCloudSpendingLimitMonthly}, nil
 }
 
@@ -2240,8 +2246,8 @@ func TestTenantPoolClaimSeedsQuotaConfigWithoutExplicitQuota(t *testing.T) {
 	if cfg.TiDBCloudSpendingLimit != nil {
 		t.Fatalf("spending limit = %d, want nil", *cfg.TiDBCloudSpendingLimit)
 	}
-	if cfg.TiDBCloudSpendingLimitCheckedAt == nil {
-		t.Fatal("checked_at is nil, want non-nil (cloud was observed)")
+	if cfg.TiDBCloudSpendingLimitCheckedAt != nil {
+		t.Fatalf("checked_at = %v, want nil without a cloud observation", cfg.TiDBCloudSpendingLimitCheckedAt)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -2168,6 +2168,83 @@ func TestTenantPoolClaimMissTriggersPendingMetadataResume(t *testing.T) {
 	}
 }
 
+func TestTenantPoolClaimSeedsQuotaConfigWithoutExplicitQuota(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{
+			ClusterID:      "cluster-pool-claim-seed",
+			OrganizationID: "org-1",
+		}},
+	}}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID:         "pool-seed-quota",
+		OrganizationID: "org-1",
+		Size:           1,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	passCipher, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
+	if err != nil {
+		t.Fatalf("encrypt password: %v", err)
+	}
+	tenantID := "pool-claim-seed-quota"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantActive,
+		DBHost:           "db.example.com",
+		DBPort:           4000,
+		DBUser:           "u.root",
+		DBPasswordCipher: passCipher,
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		ClusterID:        "cluster-pool-claim-seed",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert tenant: %v", err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       tenantID,
+		OrganizationID: "org-1",
+		ClusterID:      "cluster-pool-claim-seed",
+		PoolID:         "pool-seed-quota",
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatalf("upsert binding: %v", err)
+	}
+
+	res, _, claimed, err := rt.server.claimAdminTenantFromPool(ctx, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	}, nil)
+	if err != nil {
+		t.Fatalf("claim from pool: %v", err)
+	}
+	if !claimed || res == nil {
+		t.Fatalf("claim result res=%#v claimed=%v, want claimed", res, claimed)
+	}
+
+	cfg, err := rt.meta.GetQuotaConfig(ctx, res.TenantID)
+	if err != nil {
+		t.Fatalf("get quota config: %v", err)
+	}
+	if cfg.TiDBCloudSpendingLimit != nil {
+		t.Fatalf("spending limit = %d, want nil", *cfg.TiDBCloudSpendingLimit)
+	}
+	if cfg.TiDBCloudSpendingLimitCheckedAt == nil {
+		t.Fatal("checked_at is nil, want non-nil (cloud was observed)")
+	}
+}
+
 func TestTenantPoolMetadataResumeRerunsWhenTriggeredWhileActive(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5210,17 +5210,23 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
 			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to set tenant quota", err)
 		}
-		if err := s.syncTiDBCloudSpendingLimit(ctx, "provision", tenantID, provisionCloudCfg, time.Time{}); err != nil {
-			logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
-			metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
-			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
-			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to set tenant quota", err)
-		}
-		if provisionCloudCfg != nil && provisionCloudCfg.TiDBCloudSpendingLimitMonthly != nil {
-			metricEvent(ctx, "tenant_provision", "provider", provider, "quota", "create_time_spending_limit")
-		}
-		logProvisionStage(ctx, "provision_quota_local_config_applied", tenantID, provider, stageStarted, "create_time_spending_limit", provisionCloudCfg != nil && provisionCloudCfg.TiDBCloudSpendingLimitMonthly != nil)
+		logProvisionStage(ctx, "provision_quota_local_config_applied", tenantID, provider, stageStarted)
 	}
+	stageStarted = time.Now()
+	checkedAt := time.Now().UTC()
+	if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, meta.QuotaConfigPatch{
+		TiDBCloudSpendingLimit:           tidbCloudSpendingLimitFromCloud(provisionCloudCfg),
+		TiDBCloudSpendingLimitCheckedAt: &checkedAt,
+	}); err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
+		s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
+		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to set tenant quota", err)
+	}
+	if provisionCloudCfg != nil && provisionCloudCfg.TiDBCloudSpendingLimitMonthly != nil {
+		metricEvent(ctx, "tenant_provision", "provider", provider, "quota", "create_time_spending_limit")
+	}
+	logProvisionStage(ctx, "provision_quota_seeded", tenantID, provider, stageStarted, "create_time_spending_limit", provisionCloudCfg != nil && provisionCloudCfg.TiDBCloudSpendingLimitMonthly != nil)
 
 	stageStarted = time.Now()
 	apiToken, apiKeyID, err := s.issueOwnerAPIKey(ctx, tenantID, keyName, opts.TokenVersion, opts.APIKeySource)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5213,11 +5213,14 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 		logProvisionStage(ctx, "provision_quota_local_config_applied", tenantID, provider, stageStarted)
 	}
 	stageStarted = time.Now()
-	checkedAt := time.Now().UTC()
-	if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, meta.QuotaConfigPatch{
-		TiDBCloudSpendingLimit:           tidbCloudSpendingLimitFromCloud(provisionCloudCfg),
-		TiDBCloudSpendingLimitCheckedAt: &checkedAt,
-	}); err != nil {
+	quotaSeed := meta.QuotaConfigPatch{
+		TiDBCloudSpendingLimit: tidbCloudSpendingLimitFromCloud(provisionCloudCfg),
+	}
+	if provisionCloudCfg != nil {
+		checkedAt := time.Now().UTC()
+		quotaSeed.TiDBCloudSpendingLimitCheckedAt = &checkedAt
+	}
+	if err := s.meta.SetQuotaConfigPatch(ctx, tenantID, quotaSeed); err != nil {
 		logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
 		s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -222,6 +222,8 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 	if reapInterval <= 0 && idleTimeout > 0 {
 		reapInterval = defaultTenantPoolIdleReapInterval
 	}
+	metrics.RecordGauge("tenant_pool", "cached_backends", 0)
+	metrics.RecordGauge("tenant_pool", "max_backends", float64(max))
 	return &Pool{
 		cfg:     cfg,
 		enc:     enc,
@@ -332,6 +334,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 			}
 		}
 	}
+	p.recordCachedBackendCountLocked()
 	// FileGC is now kick-driven through the unified tenant worker; no
 	// per-backend goroutine is started here.
 	p.mu.Unlock()
@@ -429,11 +432,10 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 			}
 		}
 	}
+	p.recordCachedBackendCountLocked()
 	// FileGC is now kick-driven through the unified tenant worker; no
 	// per-backend goroutine is started here.
-	cachedCount := len(p.items)
 	p.mu.Unlock()
-	metrics.RecordGauge("tenant_pool", "cached_backends", float64(cachedCount))
 	for _, retired := range toClose {
 		closeEntry(retired)
 	}
@@ -701,12 +703,11 @@ func (p *Pool) reapOnce(ctx context.Context) {
 			}
 		}
 	}
-	cachedCount := len(p.items)
+	p.recordCachedBackendCountLocked()
 	p.mu.Unlock()
 	for _, retired := range toClose {
 		closeEntry(retired)
 	}
-	metrics.RecordGauge("tenant_pool", "cached_backends", float64(cachedCount))
 }
 
 func (p *Pool) Close() {
@@ -1175,11 +1176,16 @@ func (p *Pool) removeLocked(elem *list.Element, reason string) *entry {
 	e.elem = nil
 	delete(p.items, e.tenantID)
 	e.retired = true
+	p.recordCachedBackendCountLocked()
 	metrics.RecordOperation("tenant_pool", "remove", reason, 0)
 	if e.refs == 0 {
 		return e
 	}
 	return nil
+}
+
+func (p *Pool) recordCachedBackendCountLocked() {
+	metrics.RecordGauge("tenant_pool", "cached_backends", float64(len(p.items)))
 }
 
 func (p *Pool) makeRelease(e *entry) func() {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -32,6 +32,63 @@ func TestNewPoolUsesDefaultMaxTenants(t *testing.T) {
 	}
 }
 
+func TestNewPoolRecordsBackendCacheCapacityMetrics(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		maxTenants int
+		wantMax    int
+	}{
+		{name: "default capacity", wantMax: defaultTenantPoolMaxTenants},
+		{name: "configured capacity", maxTenants: 7, wantMax: 7},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			NewPool(PoolConfig{MaxTenants: tt.maxTenants}, nil)
+
+			rec := httptest.NewRecorder()
+			metrics.WritePrometheus(rec)
+			text := rec.Body.String()
+			if !strings.Contains(text, `drive9_service_gauge{component="tenant_pool",name="cached_backends",tenant_id="",tidbcloud_org_id="guest"} 0.000000`) {
+				t.Fatalf("missing initialized cached backend gauge:\n%s", text)
+			}
+			wantMax := `drive9_service_gauge{component="tenant_pool",name="max_backends",tenant_id="",tidbcloud_org_id="guest"} ` + strconv.Itoa(tt.wantMax) + `.000000`
+			if !strings.Contains(text, wantMax) {
+				t.Fatalf("missing max backend gauge %q:\n%s", wantMax, text)
+			}
+		})
+	}
+}
+
+func TestPoolGetRecordsCachedBackendGauge(t *testing.T) {
+	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-metric-get")
+	if _, err := pool.Get(context.Background(), tenant); err != nil {
+		t.Fatal(err)
+	}
+	assertCachedBackendGauge(t, 1)
+}
+
+func TestPoolInvalidateRecordsCachedBackendGauge(t *testing.T) {
+	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-metric-invalidate")
+	_, release, err := pool.Acquire(context.Background(), tenant)
+	if err != nil {
+		t.Fatal(err)
+	}
+	release()
+	assertCachedBackendGauge(t, 1)
+
+	pool.Invalidate(tenant.ID)
+	assertCachedBackendGauge(t, 0)
+}
+
+func assertCachedBackendGauge(t *testing.T, want int) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	wantMetric := `drive9_service_gauge{component="tenant_pool",name="cached_backends",tenant_id="",tidbcloud_org_id="guest"} ` + strconv.Itoa(want) + `.000000`
+	if !strings.Contains(rec.Body.String(), wantMetric) {
+		t.Fatalf("missing cached backend gauge %q:\n%s", wantMetric, rec.Body.String())
+	}
+}
+
 func TestNewPoolUsesDocumentedDefaultIdleReapInterval(t *testing.T) {
 	pool := NewPool(PoolConfig{IdleTimeout: time.Minute}, nil)
 	if pool.reapInterval != 2*time.Minute {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -79,8 +79,8 @@ var (
 	ensureDatabaseFunc                        = ensureDatabase
 	tidbCloudNativePollInterval               = 5 * time.Second
 	tidbCloudNativeBatchMetadataGroupSize     = 10
-	tidbCloudNativeBatchMetadataPollInterval  = 15 * time.Second
-	tidbCloudNativeMetadataNotReadyAlertAfter = 5 * time.Minute
+	tidbCloudNativeBatchMetadataPollInterval  = 30 * time.Second
+	tidbCloudNativeMetadataNotReadyAlertAfter = 10 * time.Minute
 )
 
 type Provisioner struct {


### PR DESCRIPTION
Always write the initial quota config row (TiDB Cloud spending limit) during tenant creation, rather than lazily on the first GET /v1/quota call.

## Problem
When a tenant is created without an explicit quota request (`quotaOpt == nil`), no row is written to `tenant_quota_config`. On the first `GET /v1/quota`, the server:
1. Hits `GetQuotaConfig` which returns `sql.ErrNoRows` and falls back to defaults — logs a spurious `meta_op_failed` warn
2. Detects `TiDBCloudSpendingLimit == nil`, makes a cloud API call to fetch the spending limit
3. Calls `syncTiDBCloudSpendingLimit` which internally re-reads `GetQuotaConfig` — another `meta_op_failed` warn
4. Finally writes the row via the sync path

## Fix
Call `SetQuotaConfigPatch` directly at creation time in both paths:
- **Pool claim** (`claimAdminTenantFromPool`): after `MarkClusterPoolUsed` returns `cloudCfg`
- **Direct provision** (`provisionTenant`): after the cluster is provisioned and `provisionCloudCfg` is available

Uses `SetQuotaConfigPatch` directly (not `syncTiDBCloudSpendingLimit`) since at creation time there is no existing row, so CAS/change-detection logic is unnecessary.

This eliminates two spurious `meta_op_failed` warnings per first quota GET and avoids the redundant cloud API round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota handling during tenant provisioning and administration.
  * Quota limits are now recorded with an accurate verification timestamp.
  * Added clearer provisioning status tracking and error handling when quota setup fails.
  * Preserved spending-limit metrics and cleanup behavior for unsuccessful provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->