### PR TITLE
feat: allow disabling the tenant safety-net scan with interval=0

### DIFF
--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -305,7 +305,7 @@ func main() {
 		TenantOutboxCursorFlushInterval: envDuration("DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS", 5000*time.Millisecond),
 		TenantShardRefreshInterval:      envDuration("DRIVE9_TENANT_SHARD_REFRESH_MS", 5000*time.Millisecond),
 		TenantMaintenanceInterval:       envDuration("DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS", 300000*time.Millisecond),
-		SafetyNetScanInterval:           envDuration("DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS", 300000*time.Millisecond),
+		SafetyNetScanInterval:           envDuration("DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS", 5*time.Minute),
 	})
 	defer srv.Close()
 	logLocalStartupStep(startupCtx, startupStart, stepStart, "create_server")
@@ -420,7 +420,8 @@ environment:
   DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS   poller cursor flush interval (default: 5000)
   DRIVE9_TENANT_SHARD_REFRESH_MS         shard resolver ring refresh (default: 5000)
   DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS  piggyback maintenance throttle (default: 300000)
-  DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS     leader safety-net scan interval (default: 300000)
+  DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS     per-pod safety-net scan interval as a Go
+                    duration (e.g. 5m, 24h); 0 disables the scan (default: 5m)
 
   Image extraction (async image -> text for search):
   DRIVE9_IMAGE_EXTRACT_ENABLED true|false (default: false)

--- a/cmd/drive9-server-local/main.go
+++ b/cmd/drive9-server-local/main.go
@@ -301,11 +301,11 @@ func main() {
 		Logger:                          srvLogger,
 		SemanticEmbedder:                semanticEmbedder,
 		TenantWorkers:                   workerOpts,
-		TenantOutboxPollInterval:        envDuration("DRIVE9_TENANT_OUTBOX_POLL_INTERVAL_MS", 200*time.Millisecond),
-		TenantOutboxCursorFlushInterval: envDuration("DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS", 5000*time.Millisecond),
-		TenantShardRefreshInterval:      envDuration("DRIVE9_TENANT_SHARD_REFRESH_MS", 5000*time.Millisecond),
-		TenantMaintenanceInterval:       envDuration("DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS", 300000*time.Millisecond),
-		SafetyNetScanInterval:           envDuration("DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS", 5*time.Minute),
+		TenantOutboxPollInterval:        envDurationCompat("DRIVE9_TENANT_OUTBOX_POLL_INTERVAL", "DRIVE9_TENANT_OUTBOX_POLL_INTERVAL_MS", 200*time.Millisecond),
+		TenantOutboxCursorFlushInterval: envDurationCompat("DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_INTERVAL", "DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS", 5*time.Second),
+		TenantShardRefreshInterval:      envDurationCompat("DRIVE9_TENANT_SHARD_REFRESH_INTERVAL", "DRIVE9_TENANT_SHARD_REFRESH_MS", 5*time.Second),
+		TenantMaintenanceInterval:       envDurationCompat("DRIVE9_TENANT_MAINTENANCE_INTERVAL", "DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS", 5*time.Minute),
+		SafetyNetScanInterval:           envDurationCompat("DRIVE9_SAFETY_NET_SCAN_INTERVAL", "DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS", 5*time.Minute),
 	})
 	defer srv.Close()
 	logLocalStartupStep(startupCtx, startupStart, stepStart, "create_server")
@@ -416,12 +416,17 @@ environment:
   DRIVE9_SEMANTIC_RETRY_BASE_MS base retry backoff in milliseconds (default: 200)
   DRIVE9_SEMANTIC_RETRY_MAX_MS max retry backoff in milliseconds (default: 30000)
   DRIVE9_SEMANTIC_PER_TENANT_CONCURRENCY max concurrent tasks per tenant (default: 1)
-  DRIVE9_TENANT_OUTBOX_POLL_INTERVAL_MS  unified outbox poll interval (default: 200)
-  DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS   poller cursor flush interval (default: 5000)
-  DRIVE9_TENANT_SHARD_REFRESH_MS         shard resolver ring refresh (default: 5000)
-  DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS  piggyback maintenance throttle (default: 300000)
-  DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS     per-pod safety-net scan interval as a Go
-                    duration (e.g. 5m, 24h); 0 disables the scan (default: 5m)
+  DRIVE9_TENANT_OUTBOX_POLL_INTERVAL     unified outbox poll interval (default: 200ms)
+  DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_INTERVAL
+                    poller cursor flush interval (default: 5s)
+  DRIVE9_TENANT_SHARD_REFRESH_INTERVAL   shard resolver ring refresh (default: 5s)
+  DRIVE9_TENANT_MAINTENANCE_INTERVAL     piggyback maintenance throttle (default: 5m)
+  DRIVE9_SAFETY_NET_SCAN_INTERVAL        per-pod safety-net scan interval (default: 5m);
+                    0 disables the scan
+  Interval vars accept Go durations (e.g. 500ms, 5m). The former *_MS names
+  (DRIVE9_TENANT_OUTBOX_POLL_INTERVAL_MS, DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS,
+  DRIVE9_TENANT_SHARD_REFRESH_MS, DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS,
+  DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS) are deprecated but still honored.
 
   Image extraction (async image -> text for search):
   DRIVE9_IMAGE_EXTRACT_ENABLED true|false (default: false)
@@ -855,4 +860,19 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return v
+}
+
+// envDurationCompat reads a Go-duration env var under its canonical name. When
+// the canonical name is unset but the deprecated legacy name is set, the legacy
+// value is honored with a deprecation warning. The canonical name wins when
+// both are set.
+func envDurationCompat(canonical, deprecated string, fallback time.Duration) time.Duration {
+	if strings.TrimSpace(os.Getenv(canonical)) != "" {
+		return envDuration(canonical, fallback)
+	}
+	if strings.TrimSpace(os.Getenv(deprecated)) != "" {
+		fmt.Fprintf(os.Stderr, "warning: %s is deprecated, use %s instead\n", deprecated, canonical)
+		return envDuration(deprecated, fallback)
+	}
+	return fallback
 }

--- a/cmd/drive9-server-local/main_test.go
+++ b/cmd/drive9-server-local/main_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mem9-ai/drive9/pkg/backend"
 	"github.com/mem9-ai/drive9/pkg/meta"
@@ -689,4 +690,29 @@ func TestLocalStubAudioTextExtractorTranscript(t *testing.T) {
 	if got != want {
 		t.Fatalf("transcript=%q, want %q", got, want)
 	}
+}
+
+func TestEnvDurationCompat(t *testing.T) {
+	const canonical = "DRIVE9_TEST_DURATION_COMPAT"
+	const deprecated = "DRIVE9_TEST_DURATION_COMPAT_DEPRECATED_MS"
+	fallback := 5 * time.Minute
+
+	t.Run("fallback when neither is set", func(t *testing.T) {
+		if got := envDurationCompat(canonical, deprecated, fallback); got != fallback {
+			t.Fatalf("expected fallback %v, got %v", fallback, got)
+		}
+	})
+	t.Run("canonical wins when both are set", func(t *testing.T) {
+		t.Setenv(canonical, "10s")
+		t.Setenv(deprecated, "20s")
+		if got := envDurationCompat(canonical, deprecated, fallback); got != 10*time.Second {
+			t.Fatalf("expected canonical 10s, got %v", got)
+		}
+	})
+	t.Run("deprecated name honored when canonical is unset", func(t *testing.T) {
+		t.Setenv(deprecated, "20s")
+		if got := envDurationCompat(canonical, deprecated, fallback); got != 20*time.Second {
+			t.Fatalf("expected deprecated 20s, got %v", got)
+		}
+	})
 }

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -423,11 +423,11 @@ func main() {
 		TiDBAutoEmbeddingAPIBase:        autoEmbeddingAPIBase,
 		DisableDatabaseAutoEmbedding:    disableDatabaseAutoEmbedding,
 		Leader:                          leaderManager,
-		TenantOutboxPollInterval:        envDuration("DRIVE9_TENANT_OUTBOX_POLL_INTERVAL_MS", 200*time.Millisecond),
-		TenantOutboxCursorFlushInterval: envDuration("DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS", 5000*time.Millisecond),
-		TenantShardRefreshInterval:      envDuration("DRIVE9_TENANT_SHARD_REFRESH_MS", 5000*time.Millisecond),
-		TenantMaintenanceInterval:       envDuration("DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS", 300000*time.Millisecond),
-		SafetyNetScanInterval:           envDuration("DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS", 5*time.Minute),
+		TenantOutboxPollInterval:        envDurationCompat("DRIVE9_TENANT_OUTBOX_POLL_INTERVAL", "DRIVE9_TENANT_OUTBOX_POLL_INTERVAL_MS", 200*time.Millisecond),
+		TenantOutboxCursorFlushInterval: envDurationCompat("DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_INTERVAL", "DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS", 5*time.Second),
+		TenantShardRefreshInterval:      envDurationCompat("DRIVE9_TENANT_SHARD_REFRESH_INTERVAL", "DRIVE9_TENANT_SHARD_REFRESH_MS", 5*time.Second),
+		TenantMaintenanceInterval:       envDurationCompat("DRIVE9_TENANT_MAINTENANCE_INTERVAL", "DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS", 5*time.Minute),
+		SafetyNetScanInterval:           envDurationCompat("DRIVE9_SAFETY_NET_SCAN_INTERVAL", "DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS", 5*time.Minute),
 		SSENotifyRetention:              sseNotifyRetention,
 		PodID:                           podID,
 		PodAddr:                         podAddr,
@@ -607,12 +607,17 @@ environment:
                     outbox poller is the primary cross-pod path).
   DRIVE9_SSE_NOTIFY_RETENTION      how long tenant_notify_outbox rows are kept before
                     leader pruning (default: 1h)
-  DRIVE9_TENANT_OUTBOX_POLL_INTERVAL_MS  unified outbox poll interval (default: 200)
-  DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS   how often the poller persists its cursor (default: 5000)
-  DRIVE9_TENANT_SHARD_REFRESH_MS         shard resolver pod ring refresh interval (default: 5000)
-  DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS  piggyback maintenance throttle per tenant (default: 300000)
-  DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS     per-pod safety-net scan interval as a Go
-                    duration (e.g. 5m, 24h); 0 disables the scan (default: 5m)
+  DRIVE9_TENANT_OUTBOX_POLL_INTERVAL     unified outbox poll interval (default: 200ms)
+  DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_INTERVAL
+                    how often the poller persists its cursor (default: 5s)
+  DRIVE9_TENANT_SHARD_REFRESH_INTERVAL   shard resolver pod ring refresh interval (default: 5s)
+  DRIVE9_TENANT_MAINTENANCE_INTERVAL     piggyback maintenance throttle per tenant (default: 5m)
+  DRIVE9_SAFETY_NET_SCAN_INTERVAL        per-pod safety-net scan interval (default: 5m);
+                    0 disables the scan
+  Interval vars accept Go durations (e.g. 500ms, 5m). The former *_MS names
+  (DRIVE9_TENANT_OUTBOX_POLL_INTERVAL_MS, DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS,
+  DRIVE9_TENANT_SHARD_REFRESH_MS, DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS,
+  DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS) are deprecated but still honored.
 
   S3 storage (set DRIVE9_S3_BUCKET to enable AWS S3, otherwise local mock):
   DRIVE9_S3_BUCKET   S3 bucket name (enables AWS S3 mode)
@@ -1083,4 +1088,19 @@ func envDuration(key string, fallback time.Duration) time.Duration {
 		return fallback
 	}
 	return v
+}
+
+// envDurationCompat reads a Go-duration env var under its canonical name. When
+// the canonical name is unset but the deprecated legacy name is set, the legacy
+// value is honored with a deprecation warning. The canonical name wins when
+// both are set.
+func envDurationCompat(canonical, deprecated string, fallback time.Duration) time.Duration {
+	if strings.TrimSpace(os.Getenv(canonical)) != "" {
+		return envDuration(canonical, fallback)
+	}
+	if strings.TrimSpace(os.Getenv(deprecated)) != "" {
+		fmt.Fprintf(os.Stderr, "warning: %s is deprecated, use %s instead\n", deprecated, canonical)
+		return envDuration(deprecated, fallback)
+	}
+	return fallback
 }

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -427,7 +427,7 @@ func main() {
 		TenantOutboxCursorFlushInterval: envDuration("DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS", 5000*time.Millisecond),
 		TenantShardRefreshInterval:      envDuration("DRIVE9_TENANT_SHARD_REFRESH_MS", 5000*time.Millisecond),
 		TenantMaintenanceInterval:       envDuration("DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS", 300000*time.Millisecond),
-		SafetyNetScanInterval:           envDuration("DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS", 300000*time.Millisecond),
+		SafetyNetScanInterval:           envDuration("DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS", 5*time.Minute),
 		SSENotifyRetention:              sseNotifyRetention,
 		PodID:                           podID,
 		PodAddr:                         podAddr,
@@ -611,7 +611,8 @@ environment:
   DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS   how often the poller persists its cursor (default: 5000)
   DRIVE9_TENANT_SHARD_REFRESH_MS         shard resolver pod ring refresh interval (default: 5000)
   DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS  piggyback maintenance throttle per tenant (default: 300000)
-  DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS     leader safety-net scan interval (default: 300000)
+  DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS     per-pod safety-net scan interval as a Go
+                    duration (e.g. 5m, 24h); 0 disables the scan (default: 5m)
 
   S3 storage (set DRIVE9_S3_BUCKET to enable AWS S3, otherwise local mock):
   DRIVE9_S3_BUCKET   S3 bucket name (enables AWS S3 mode)

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mem9-ai/drive9/pkg/backend"
 	"github.com/mem9-ai/drive9/pkg/meta"
@@ -610,4 +611,29 @@ func setEnv(t *testing.T, key, value string) {
 	if err := os.Setenv(key, value); err != nil {
 		t.Fatalf("set %s: %v", key, err)
 	}
+}
+
+func TestEnvDurationCompat(t *testing.T) {
+	const canonical = "DRIVE9_TEST_DURATION_COMPAT"
+	const deprecated = "DRIVE9_TEST_DURATION_COMPAT_DEPRECATED_MS"
+	fallback := 5 * time.Minute
+
+	t.Run("fallback when neither is set", func(t *testing.T) {
+		if got := envDurationCompat(canonical, deprecated, fallback); got != fallback {
+			t.Fatalf("expected fallback %v, got %v", fallback, got)
+		}
+	})
+	t.Run("canonical wins when both are set", func(t *testing.T) {
+		t.Setenv(canonical, "10s")
+		t.Setenv(deprecated, "20s")
+		if got := envDurationCompat(canonical, deprecated, fallback); got != 10*time.Second {
+			t.Fatalf("expected canonical 10s, got %v", got)
+		}
+	})
+	t.Run("deprecated name honored when canonical is unset", func(t *testing.T) {
+		t.Setenv(deprecated, "20s")
+		if got := envDurationCompat(canonical, deprecated, fallback); got != 20*time.Second {
+			t.Fatalf("expected deprecated 20s, got %v", got)
+		}
+	})
 }

--- a/pkg/server/safety_net_scan.go
+++ b/pkg/server/safety_net_scan.go
@@ -18,9 +18,10 @@ const (
 	safetyNetRecoverLimit = 64
 )
 
-// safetyNetScan is a periodic (5min) scan that recovers expired leases and
-// discovers unclaimed queued tasks for tenants this pod owns. It runs on every
-// pod (not leader-gated) and filters by shard ownership.
+// safetyNetScan is a periodic scan (SafetyNetScanInterval; 5min by default in
+// the server binaries, disabled when non-positive) that recovers expired
+// leases and discovers unclaimed queued tasks for tenants this pod owns. It
+// runs on every pod (not leader-gated) and filters by shard ownership.
 //
 // **Design constraint — warm-only, never opens cold tenant TiDBs:**
 // The scan exclusively uses AcquireCached (warm-only). A cold tenant whose

--- a/pkg/server/safety_net_scan_test.go
+++ b/pkg/server/safety_net_scan_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/mem9-ai/drive9/pkg/meta"
 )
@@ -41,5 +42,20 @@ func TestSafetyNetScanSkipsNilTenant(t *testing.T) {
 	_, _, ok := pool.AcquireCached(nil)
 	if ok {
 		t.Fatal("AcquireCached should return false for nil tenant")
+	}
+}
+
+func TestSafetyNetScanIntervalZeroDisables(t *testing.T) {
+	// A zero SafetyNetScanInterval must be preserved as disabled instead of
+	// falling back to the old 5min default — the default now lives in the
+	// server binaries' env parsing, not in NewWithConfig. A configured
+	// interval passes through untouched.
+	s := NewWithConfig(Config{})
+	if s.safetyNetScanInterval != 0 {
+		t.Fatalf("expected zero SafetyNetScanInterval to be preserved (disabled), got %v", s.safetyNetScanInterval)
+	}
+	s = NewWithConfig(Config{SafetyNetScanInterval: 30 * time.Minute})
+	if s.safetyNetScanInterval != 30*time.Minute {
+		t.Fatalf("expected configured interval to be preserved, got %v", s.safetyNetScanInterval)
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -104,8 +104,8 @@ type Config struct {
 	// active pod ring (default 5s).
 	// TenantMaintenanceInterval throttles piggybacked fs_events cleanup +
 	// observation metrics per tenant (default 5min).
-	// SafetyNetScanInterval is how often the leader runs the safety-net scan
-	// (default 5min).
+	// SafetyNetScanInterval is how often each pod runs the safety-net scan
+	// over its shard's warm tenants. A non-positive value disables the scan.
 	// SSENotifyRetention is how long outbox rows are kept before leader-gated
 	// pruning (default 1h).
 	//
@@ -240,7 +240,8 @@ type Server struct {
 	notifyWG        sync.WaitGroup
 	// sseNotifyRetention is how long outbox rows are kept before leader pruning.
 	sseNotifyRetention time.Duration
-	// safetyNetScanInterval is how often the leader runs the safety-net scan.
+	// safetyNetScanInterval is how often each pod runs the safety-net scan.
+	// Non-positive disables it.
 	safetyNetScanInterval time.Duration
 }
 
@@ -380,9 +381,10 @@ func NewWithConfig(cfg Config) *Server {
 	if s.sseNotifyRetention <= 0 {
 		s.sseNotifyRetention = defaultSSENotifyRetention
 	}
-	if s.safetyNetScanInterval <= 0 {
-		s.safetyNetScanInterval = defaultSafetyNetScanInterval
-	}
+	// safetyNetScanInterval is taken as configured: a non-positive value
+	// disables the safety-net scan entirely (see startNotifyInfrastructure).
+	// The 5min default lives in the server binaries' env fallback, not here,
+	// so a zero Config keeps the scan off.
 	mux := http.NewServeMux()
 
 	var business http.Handler = http.HandlerFunc(s.handleBusiness)
@@ -645,8 +647,12 @@ func (s *Server) startNotifyInfrastructure(cfg Config) {
 	// Safety-net scan runs on every pod (not leader-gated) so each pod
 	// recovers expired leases for its own shard's warm tenants. This
 	// complements the per-pod tenant worker — if a kick is lost, the
-	// safety-net catches it within 5min for any warm tenant owned by this pod.
-	if s.meta != nil && s.pool != nil {
+	// safety-net catches it within one scan interval for any warm tenant
+	// owned by this pod. A non-positive safetyNetScanInterval disables the
+	// scan entirely: outbox kicks remain the primary delivery path, and
+	// lost-kick/expired-lease recovery for idle tenants is deferred to the
+	// tenant's next write.
+	if s.meta != nil && s.pool != nil && s.safetyNetScanInterval > 0 {
 		s.notifyWG.Add(1)
 		go func() {
 			defer s.notifyWG.Done()
@@ -661,6 +667,8 @@ func (s *Server) startNotifyInfrastructure(cfg Config) {
 				}
 			}
 		}()
+	} else if s.meta != nil && s.pool != nil {
+		logger.Info(notifyCtx, "safety_net_scan_disabled")
 	}
 }
 
@@ -874,9 +882,6 @@ const fsEventsRetention = 1 * time.Hour
 // before the leader prunes them. Matches fs_events retention so the outbox
 // doesn't outlive the work it points to.
 const defaultSSENotifyRetention = 1 * time.Hour
-
-// defaultSafetyNetScanInterval is how often the leader runs the safety-net scan.
-const defaultSafetyNetScanInterval = 5 * time.Minute
 
 // tenantNotifyCleanupInterval is how often the leader prunes old outbox rows.
 const tenantNotifyCleanupInterval = 5 * time.Minute


### PR DESCRIPTION
## Why

The 5min safety-net scan is the last periodic per-tenant TiDB touch left after the unified outbox (#660). Each cycle runs four queries against every warm-pool tenant. Tenants that are idle but not yet evicted from the pool (idle TTL 5min + reap 2min) have their serverless clusters woken by these queries — visible as the 5min active-cluster sawtooth (trough ~60 → peak ~200 clusters).

The scan is purely a backstop:

- the outbox poller (200ms, meta-DB only) and in-process write kicks are the primary delivery path;
- every kick already piggybacks expired-lease recovery (`tenant_worker.go`);
- nothing it covers is correctness-critical: lost kicks / expired leases / due retries for an idle tenant are deferred to that tenant's next write.

For deployments where semantic-indexing delay and file-GC delay for idle tenants are acceptable, the scan is now optional.

## What changed

**1. Safety-net scan can be disabled**

- `server.Config.SafetyNetScanInterval <= 0` disables the scan. `NewWithConfig` no longer substitutes the 5min default — the default moves to the binaries' env fallback, so **default behavior is unchanged**.
- `startNotifyInfrastructure` skips the scan goroutine when disabled and logs `safety_net_scan_disabled`.
- Removed the now-unused `defaultSafetyNetScanInterval` const.
- Added `TestSafetyNetScanIntervalZeroDisables`.

**2. Env var rename transition (deprecate misleading `*_MS` names)**

The five tenant interval env vars are parsed with `time.ParseDuration`, so a bare number like `300000` (as the old help text implied) fails to parse and silently falls back to the default. They get canonical names without the `_MS` suffix:

| canonical | deprecated (still honored) |
|---|---|
| `DRIVE9_TENANT_OUTBOX_POLL_INTERVAL` | `DRIVE9_TENANT_OUTBOX_POLL_INTERVAL_MS` |
| `DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_INTERVAL` | `DRIVE9_TENANT_OUTBOX_CURSOR_FLUSH_MS` |
| `DRIVE9_TENANT_SHARD_REFRESH_INTERVAL` | `DRIVE9_TENANT_SHARD_REFRESH_MS` |
| `DRIVE9_TENANT_MAINTENANCE_INTERVAL` | `DRIVE9_TENANT_MAINTENANCE_INTERVAL_MS` |
| `DRIVE9_SAFETY_NET_SCAN_INTERVAL` | `DRIVE9_SAFETY_NET_SCAN_INTERVAL_MS` |

New `envDurationCompat` helper: canonical name wins when both are set; the legacy name logs a deprecation warning to stderr. Existing deployments keep working until they migrate. Help text now documents the new names, the Go-duration format, and the deprecation.

## Usage

Set `DRIVE9_SAFETY_NET_SCAN_INTERVAL=0` (or the deprecated `..._MS` name) to disable the scan. Any Go duration works (`30m`, `24h`); unset keeps 5min.

## Notes / follow-ups

- With the scan off, retry-due tasks for idle tenants wait for the tenant's next write. If tighter retry latency is ever needed without the scan, schedule an in-memory re-kick at `retryAt` in `retryTask` and keep the scan as a crash-only backstop at a long interval.
- The deprecated `*_MS` names can be removed in a later release once deployments have migrated.
- Observe the effect via `user_db_access{...="safety_net_tenant_scan"}` (should drop to zero when disabled) and `acquire_cold_open` (should be unchanged).

## Test

- `go test ./pkg/server/ -run 'TestSafetyNetScan|TestTenantOutboxPoller'` — pass
- Full `go test ./pkg/server/` — pass (194.9s)
- `go test ./cmd/drive9-server/ ./cmd/drive9-server-local/` — pass (incl. new `TestEnvDurationCompat`)
- `golangci-lint run ./cmd/... ./pkg/server/...` — 0 issues
