### PR TITLE
Add MaxVideoLLMFiles to tenant_quota_config and env config for MaxMediaLLMFiles

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -736,6 +736,8 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 	if strings.TrimSpace(os.Getenv("DRIVE9_QUOTA_SOURCE")) != "" {
 		return backend.Options{}, fmt.Errorf("DRIVE9_QUOTA_SOURCE has been removed; central quota is now driven by meta-store wiring")
 	}
+	opts.MaxMediaLLMFiles = envInt64("DRIVE9_MEDIA_EXTRACT_MAX_FILES", 0)
+
 	opts.MaxTenantStorageBytes = envInt64("DRIVE9_MAX_TENANT_STORAGE_BYTES", 50*(1<<30))
 	if opts.MaxTenantStorageBytes <= 0 {
 		return backend.Options{}, fmt.Errorf("DRIVE9_MAX_TENANT_STORAGE_BYTES must be a positive integer")

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -637,3 +637,37 @@ func TestEnvDurationCompat(t *testing.T) {
 		}
 	})
 }
+
+func TestBuildBackendOptionsFromEnvMaxMediaLLMFiles(t *testing.T) {
+	const key = "DRIVE9_MEDIA_EXTRACT_MAX_FILES"
+	keys := []string{
+		key,
+		"DRIVE9_QUERY_EMBED_API_BASE",
+		"DRIVE9_QUERY_EMBED_API_KEY",
+		"DRIVE9_QUERY_EMBED_MODEL",
+		"DRIVE9_IMAGE_EXTRACT_ENABLED",
+		"DRIVE9_AUDIO_EXTRACT_ENABLED",
+		"DRIVE9_AUDIO_EXTRACT_MODE",
+		"DRIVE9_VIDEO_EXTRACT_TENANT_ALLOWLIST",
+	}
+	restore := snapshotEnv(t, keys)
+	t.Cleanup(func() { restoreEnv(t, restore) })
+	unsetEnv(t, keys)
+
+	opts, err := buildBackendOptionsFromEnv()
+	if err != nil {
+		t.Fatalf("buildBackendOptionsFromEnv: %v", err)
+	}
+	if opts.MaxMediaLLMFiles != 0 {
+		t.Fatalf("MaxMediaLLMFiles unset = %d, want 0", opts.MaxMediaLLMFiles)
+	}
+
+	setEnv(t, key, "100")
+	opts, err = buildBackendOptionsFromEnv()
+	if err != nil {
+		t.Fatalf("buildBackendOptionsFromEnv: %v", err)
+	}
+	if opts.MaxMediaLLMFiles != 100 {
+		t.Fatalf("MaxMediaLLMFiles = %d, want 100", opts.MaxMediaLLMFiles)
+	}
+}

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -286,6 +286,9 @@ func recordTenantQuotaSnapshot(tenantID, tidbCloudOrgID string, usage *QuotaUsag
 	if cfg.MaxMediaLLMFiles > 0 {
 		metrics.RecordTenantMediaFilesWithOrg(tenantID, tidbCloudOrgID, "limit", cfg.MaxMediaLLMFiles)
 	}
+	if cfg.MaxVideoLLMFiles > 0 {
+		metrics.RecordTenantVideoFilesWithOrg(tenantID, tidbCloudOrgID, "limit", cfg.MaxVideoLLMFiles)
+	}
 }
 
 func quotaMediaDelta(oldIsMedia, newIsMedia bool) int64 {
@@ -377,9 +380,14 @@ func (b *Dat9Backend) mediaLLMQuotaExceededTx(tx *sql.Tx) bool {
 // videoLLMQuotaExceededTx checks whether the tenant has exceeded its per-tenant
 // video extraction quota. Counts every video_extract_visual task row (any
 // status) — each Vision API call consumes one unit, including re-extractions
-// of the same file.
+// of the same file. Prefers per-tenant central config (MaxVideoLLMFiles) when
+// available; falls back to the process-level default.
 func (b *Dat9Backend) videoLLMQuotaExceededTx(ctx context.Context, tx *sql.Tx) bool {
-	if b.maxVideoLLMFiles <= 0 {
+	limit := b.maxVideoLLMFiles
+	if cfg := b.cachedQuotaConfig(ctx); cfg != nil && cfg.MaxVideoLLMFiles > 0 {
+		limit = cfg.MaxVideoLLMFiles
+	}
+	if limit <= 0 {
 		return false
 	}
 	var count int64
@@ -387,7 +395,7 @@ func (b *Dat9Backend) videoLLMQuotaExceededTx(ctx context.Context, tx *sql.Tx) b
 		logger.Warn(ctx, "video_llm_quota_check_fail_open", zap.Error(err))
 		return false
 	}
-	return count >= b.maxVideoLLMFiles
+	return count >= limit
 }
 
 // ensureTenantStorageQuotaTx is the legacy tenant-DB storage quota check.

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -110,7 +110,7 @@ func (f *fakeMetaQuotaStore) GetQuotaConfigVersion(ctx context.Context, tenantID
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if cfg, ok := f.config[tenantID]; ok {
-		return fmt.Sprintf("%d:%d:%d:%d:%d:%d", cfg.MaxStorageBytes, cfg.MaxFileSizeBytes, cfg.MaxFileCount, cfg.MaxMediaLLMFiles, cfg.MaxVideoLLMFiles, cfg.MaxMonthlyCostMC), nil
+		return fmt.Sprintf("v3:%d:%d:%d:%d:%d:%d", cfg.MaxStorageBytes, cfg.MaxFileSizeBytes, cfg.MaxFileCount, cfg.MaxMediaLLMFiles, cfg.MaxVideoLLMFiles, cfg.MaxMonthlyCostMC), nil
 	}
 	return "", nil
 }

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -101,6 +101,7 @@ func (f *fakeMetaQuotaStore) GetQuotaConfig(ctx context.Context, tenantID string
 		MaxFileSizeBytes: meta.DefaultMaxFileSizeBytes(),
 		MaxFileCount:     0,
 		MaxMediaLLMFiles: 500,
+		MaxVideoLLMFiles: 50,
 		MaxMonthlyCostMC: 0,
 	}, nil
 }
@@ -109,7 +110,7 @@ func (f *fakeMetaQuotaStore) GetQuotaConfigVersion(ctx context.Context, tenantID
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if cfg, ok := f.config[tenantID]; ok {
-		return fmt.Sprintf("%d:%d:%d:%d:%d", cfg.MaxStorageBytes, cfg.MaxFileSizeBytes, cfg.MaxFileCount, cfg.MaxMediaLLMFiles, cfg.MaxMonthlyCostMC), nil
+		return fmt.Sprintf("%d:%d:%d:%d:%d:%d", cfg.MaxStorageBytes, cfg.MaxFileSizeBytes, cfg.MaxFileCount, cfg.MaxMediaLLMFiles, cfg.MaxVideoLLMFiles, cfg.MaxMonthlyCostMC), nil
 	}
 	return "", nil
 }

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -82,6 +82,7 @@ type QuotaConfigView struct {
 	MaxFileSizeBytes int64
 	MaxFileCount     int64
 	MaxMediaLLMFiles int64
+	MaxVideoLLMFiles int64
 	MaxMonthlyCostMC int64
 }
 

--- a/pkg/backend/video_extract_test.go
+++ b/pkg/backend/video_extract_test.go
@@ -2,9 +2,12 @@ package backend
 
 import (
 	"context"
+	"database/sql"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 type staticVideoExtractor struct {
@@ -315,6 +318,43 @@ func TestVideoLLMQuotaCustom(t *testing.T) {
 	})
 	if b.maxVideoLLMFiles != 10 {
 		t.Fatalf("maxVideoLLMFiles=%d, want 10", b.maxVideoLLMFiles)
+	}
+}
+
+func TestVideoLLMQuotaEnforcementUsesCentralConfig(t *testing.T) {
+	b, fake := newCentralQuotaBackend(t)
+	fake.config["tenant-a"].MaxVideoLLMFiles = 2
+	ctx := context.Background()
+
+	insertVideoTask := func(tx *sql.Tx, id string) error {
+		now := time.Now().UTC()
+		_, err := tx.ExecContext(ctx,
+			`INSERT INTO semantic_tasks
+			 (task_id, task_type, resource_id, resource_version, status, attempt_count, max_attempts,
+			  receipt, payload_json, created_at, updated_at)
+			 VALUES (?, 'video_extract_visual', ?, ?, 'queued', 0, 3,
+			         ?, '{}', ?, ?)`,
+			id, "file-"+id, 1, id[:8], now, now)
+		return err
+	}
+
+	err := b.store.InTx(ctx, func(tx *sql.Tx) error {
+		if err := insertVideoTask(tx, uuid.NewString()); err != nil {
+			return err
+		}
+		if b.videoLLMQuotaExceededTx(ctx, tx) {
+			t.Error("quota should not be exceeded at 1 task with limit=2 from central config")
+		}
+		if err := insertVideoTask(tx, uuid.NewString()); err != nil {
+			return err
+		}
+		if !b.videoLLMQuotaExceededTx(ctx, tx) {
+			t.Error("quota should be exceeded at 2 tasks with limit=2 from central config")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("transaction failed: %v", err)
 	}
 }
 

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -692,6 +692,7 @@ func metaInitSchemaStatements() []string {
 			max_file_size_bytes   BIGINT NOT NULL DEFAULT 0,
 			max_file_count        BIGINT NOT NULL DEFAULT 0,
 			max_media_llm_files   BIGINT NOT NULL DEFAULT 500,
+			max_video_llm_files   BIGINT NOT NULL DEFAULT 50,
 			max_monthly_cost_mc   BIGINT NOT NULL DEFAULT 0,
 			quota_limits_overridden TINYINT(1) NOT NULL DEFAULT 1,
 			tidbcloud_spending_limit BIGINT NULL,

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1113,6 +1113,13 @@ func TestMetaSchemaSpecTracksPrimaryKeyConstraint(t *testing.T) {
 	if checkedAt.addSQL != "ALTER TABLE tenant_quota_config ADD COLUMN tidbcloud_spending_limit_checked_at DATETIME(3) NULL" {
 		t.Fatalf("tidbcloud_spending_limit_checked_at addSQL = %q", checkedAt.addSQL)
 	}
+	videoLLM, ok := table.columns["max_video_llm_files"]
+	if !ok {
+		t.Fatal("tenant_quota_config schema missing max_video_llm_files")
+	}
+	if videoLLM.addSQL != "ALTER TABLE tenant_quota_config ADD COLUMN max_video_llm_files BIGINT NOT NULL DEFAULT 50" {
+		t.Fatalf("max_video_llm_files addSQL = %q", videoLLM.addSQL)
+	}
 }
 
 func TestMetaSchemaSpecIncludesTenantS3EncryptionColumns(t *testing.T) {
@@ -1719,6 +1726,7 @@ func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
 		max_file_size_bytes BIGINT NOT NULL,
 		max_file_count BIGINT NOT NULL,
 		max_media_llm_files BIGINT NOT NULL,
+		max_video_llm_files BIGINT NOT NULL,
 		max_monthly_cost_mc BIGINT NOT NULL,
 		quota_limits_overridden TINYINT(1) NOT NULL DEFAULT 1,
 		tidbcloud_spending_limit BIGINT NULL,

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1712,6 +1712,7 @@ func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
 			"max_file_size_bytes":                 {columnType: "bigint"},
 			"max_file_count":                      {columnType: "bigint"},
 			"max_media_llm_files":                 {columnType: "bigint"},
+			"max_video_llm_files":                 {columnType: "bigint"},
 			"max_monthly_cost_mc":                 {columnType: "bigint"},
 			"quota_limits_overridden":             {columnType: "tinyint(1)"},
 			"tidbcloud_spending_limit":            {columnType: "bigint"},

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -29,8 +29,9 @@ type QuotaConfig struct {
 	MaxStorageBytes  int64
 	MaxFileSizeBytes int64
 	MaxFileCount     int64 // 0 = unlimited
-	MaxMediaLLMFiles int64
-	MaxMonthlyCostMC int64 // millicents; 0 = disabled
+	MaxMediaLLMFiles  int64
+	MaxVideoLLMFiles  int64
+	MaxMonthlyCostMC  int64 // millicents; 0 = disabled
 	// QuotaLimitsOverridden tracks whether storage/file quota columns should
 	// override process defaults. Spending-limit-only rows keep this false.
 	QuotaLimitsOverridden bool
@@ -149,12 +150,12 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 	var checkedAt sql.NullTime
 	err = s.db.QueryRowContext(ctx,
 		`SELECT max_storage_bytes, max_file_size_bytes, max_file_count,
-		        max_media_llm_files, max_monthly_cost_mc, quota_limits_overridden,
+		        max_media_llm_files, max_video_llm_files, max_monthly_cost_mc, quota_limits_overridden,
 		        tidbcloud_spending_limit, tidbcloud_spending_limit_checked_at,
 		        created_at, updated_at
 		 FROM tenant_quota_config WHERE tenant_id = ?`, tenantID,
 	).Scan(&cfg.MaxStorageBytes, &cfg.MaxFileSizeBytes, &cfg.MaxFileCount,
-		&cfg.MaxMediaLLMFiles, &cfg.MaxMonthlyCostMC, &cfg.QuotaLimitsOverridden,
+		&cfg.MaxMediaLLMFiles, &cfg.MaxVideoLLMFiles, &cfg.MaxMonthlyCostMC, &cfg.QuotaLimitsOverridden,
 		&spendingLimit, &checkedAt, &cfg.CreatedAt, &cfg.UpdatedAt)
 	if err == sql.ErrNoRows {
 		// Return defaults when no per-tenant config exists.
@@ -162,6 +163,7 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
 		cfg.MaxFileCount = 0
 		cfg.MaxMediaLLMFiles = 500
+		cfg.MaxVideoLLMFiles = 50
 		cfg.MaxMonthlyCostMC = 0
 		cfg.QuotaLimitsOverridden = false
 		return cfg, nil
@@ -174,6 +176,7 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
 		cfg.MaxFileCount = 0
 		cfg.MaxMediaLLMFiles = 500
+		cfg.MaxVideoLLMFiles = 50
 		cfg.MaxMonthlyCostMC = 0
 	} else if cfg.MaxFileSizeBytes <= 0 {
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
@@ -194,13 +197,13 @@ func (s *Store) GetQuotaConfigVersion(ctx context.Context, tenantID string) (str
 	var err error
 	defer observeMeta(ctx, "get_quota_config_version", start, &err)
 
-	var maxStorageBytes, maxFileSizeBytes, maxFileCount, maxMediaLLMFiles, maxMonthlyCostMC int64
+	var maxStorageBytes, maxFileSizeBytes, maxFileCount, maxMediaLLMFiles, maxVideoLLMFiles, maxMonthlyCostMC int64
 	var quotaLimitsOverridden bool
 	err = s.db.QueryRowContext(ctx,
 		`SELECT max_storage_bytes, max_file_size_bytes, max_file_count,
-		        max_media_llm_files, max_monthly_cost_mc, quota_limits_overridden
+		        max_media_llm_files, max_video_llm_files, max_monthly_cost_mc, quota_limits_overridden
 		 FROM tenant_quota_config WHERE tenant_id = ?`, tenantID,
-	).Scan(&maxStorageBytes, &maxFileSizeBytes, &maxFileCount, &maxMediaLLMFiles, &maxMonthlyCostMC, &quotaLimitsOverridden)
+	).Scan(&maxStorageBytes, &maxFileSizeBytes, &maxFileCount, &maxMediaLLMFiles, &maxVideoLLMFiles, &maxMonthlyCostMC, &quotaLimitsOverridden)
 	if err == sql.ErrNoRows {
 		logger.Info(ctx, "quota_config_not_found_using_defaults",
 			zap.String("tenant_id", tenantID))
@@ -213,7 +216,7 @@ func (s *Store) GetQuotaConfigVersion(ctx context.Context, tenantID string) (str
 	if !quotaLimitsOverridden {
 		return "", nil
 	}
-	return fmt.Sprintf("v2:%d:%d:%d:%d:%d", maxStorageBytes, maxFileSizeBytes, maxFileCount, maxMediaLLMFiles, maxMonthlyCostMC), nil
+	return fmt.Sprintf("v3:%d:%d:%d:%d:%d:%d", maxStorageBytes, maxFileSizeBytes, maxFileCount, maxMediaLLMFiles, maxVideoLLMFiles, maxMonthlyCostMC), nil
 }
 
 // SetQuotaConfig upserts per-tenant quota configuration.
@@ -224,20 +227,21 @@ func (s *Store) SetQuotaConfig(ctx context.Context, cfg *QuotaConfig) error {
 
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
-		                                  max_media_llm_files, max_monthly_cost_mc, quota_limits_overridden,
+		                                  max_media_llm_files, max_video_llm_files, max_monthly_cost_mc, quota_limits_overridden,
 		                                  tidbcloud_spending_limit, tidbcloud_spending_limit_checked_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON DUPLICATE KEY UPDATE
 		   max_storage_bytes = VALUES(max_storage_bytes),
 		   max_file_size_bytes = VALUES(max_file_size_bytes),
 		   max_file_count = VALUES(max_file_count),
 		   max_media_llm_files = VALUES(max_media_llm_files),
+		   max_video_llm_files = VALUES(max_video_llm_files),
 		   max_monthly_cost_mc = VALUES(max_monthly_cost_mc),
 		   quota_limits_overridden = VALUES(quota_limits_overridden),
 		   tidbcloud_spending_limit = VALUES(tidbcloud_spending_limit),
 		   tidbcloud_spending_limit_checked_at = VALUES(tidbcloud_spending_limit_checked_at)`,
 		cfg.TenantID, cfg.MaxStorageBytes, cfg.MaxFileSizeBytes, cfg.MaxFileCount,
-		cfg.MaxMediaLLMFiles, cfg.MaxMonthlyCostMC, true,
+		cfg.MaxMediaLLMFiles, cfg.MaxVideoLLMFiles, cfg.MaxMonthlyCostMC, true,
 		nullInt64FromPtr(cfg.TiDBCloudSpendingLimit), nullTimeFromPtr(cfg.TiDBCloudSpendingLimitCheckedAt))
 	return err
 }

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -79,6 +79,9 @@ func TestGetQuotaConfigUsesConfiguredDefaultStorageBytes(t *testing.T) {
 	if cfg.MaxMediaLLMFiles != 500 {
 		t.Errorf("MaxMediaLLMFiles = %d, want default 500", cfg.MaxMediaLLMFiles)
 	}
+	if cfg.MaxVideoLLMFiles != 50 {
+		t.Errorf("MaxVideoLLMFiles = %d, want default 50", cfg.MaxVideoLLMFiles)
+	}
 	if cfg.MaxMonthlyCostMC != 0 {
 		t.Errorf("MaxMonthlyCostMC = %d, want default 0", cfg.MaxMonthlyCostMC)
 	}
@@ -166,6 +169,7 @@ func TestGetQuotaConfigVersion(t *testing.T) {
 		MaxFileSizeBytes: 234,
 		MaxFileCount:     345,
 		MaxMediaLLMFiles: 456,
+		MaxVideoLLMFiles: 567,
 		MaxMonthlyCostMC: 789,
 	}); err != nil {
 		t.Fatal(err)
@@ -199,6 +203,7 @@ func TestSetQuotaStorageBytesUpdatesStorageOnly(t *testing.T) {
 		MaxFileSizeBytes: 101,
 		MaxFileCount:     102,
 		MaxMediaLLMFiles: 200,
+		MaxVideoLLMFiles: 210,
 		MaxMonthlyCostMC: 300,
 	}); err != nil {
 		t.Fatal(err)
@@ -210,8 +215,8 @@ func TestSetQuotaStorageBytesUpdatesStorageOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.MaxStorageBytes != 999 || cfg.MaxFileSizeBytes != 101 || cfg.MaxFileCount != 102 || cfg.MaxMediaLLMFiles != 200 || cfg.MaxMonthlyCostMC != 300 {
-		t.Errorf("cfg = %+v, want storage=999 file_size=101 file_count=102 media=200 monthly=300", cfg)
+	if cfg.MaxStorageBytes != 999 || cfg.MaxFileSizeBytes != 101 || cfg.MaxFileCount != 102 || cfg.MaxMediaLLMFiles != 200 || cfg.MaxVideoLLMFiles != 210 || cfg.MaxMonthlyCostMC != 300 {
+		t.Errorf("cfg = %+v, want storage=999 file_size=101 file_count=102 media=200 video=210 monthly=300", cfg)
 	}
 }
 
@@ -226,7 +231,7 @@ func TestSetQuotaStorageBytesInsertsInternalDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.MaxStorageBytes != 12345 || cfg.MaxFileSizeBytes != DefaultMaxFileSizeBytes() || cfg.MaxFileCount != 0 || cfg.MaxMediaLLMFiles != 500 || cfg.MaxMonthlyCostMC != 0 {
+	if cfg.MaxStorageBytes != 12345 || cfg.MaxFileSizeBytes != DefaultMaxFileSizeBytes() || cfg.MaxFileCount != 0 || cfg.MaxMediaLLMFiles != 500 || cfg.MaxVideoLLMFiles != 50 || cfg.MaxMonthlyCostMC != 0 {
 		t.Errorf("cfg = %+v, want storage patch with internal defaults", cfg)
 	}
 }
@@ -275,6 +280,7 @@ func TestSetQuotaConfigPatchUpdatesExternalFieldsOnly(t *testing.T) {
 		MaxFileSizeBytes: 200,
 		MaxFileCount:     300,
 		MaxMediaLLMFiles: 400,
+		MaxVideoLLMFiles: 410,
 		MaxMonthlyCostMC: 500,
 	}); err != nil {
 		t.Fatal(err)
@@ -291,7 +297,7 @@ func TestSetQuotaConfigPatchUpdatesExternalFieldsOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.MaxStorageBytes != 100 || cfg.MaxFileSizeBytes != 222 || cfg.MaxFileCount != 333 || cfg.MaxMediaLLMFiles != 400 || cfg.MaxMonthlyCostMC != 500 {
+	if cfg.MaxStorageBytes != 100 || cfg.MaxFileSizeBytes != 222 || cfg.MaxFileCount != 333 || cfg.MaxMediaLLMFiles != 400 || cfg.MaxVideoLLMFiles != 410 || cfg.MaxMonthlyCostMC != 500 {
 		t.Fatalf("cfg = %+v", cfg)
 	}
 }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -79,6 +79,7 @@ var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total",
 var tenantCount = tenantMeter.Float64Gauge("drive9_tenant_count", "Tenant count by status")
 var tenantStorageBytes = tenantMeter.Float64Gauge("drive9_tenant_storage_bytes", "Tenant storage bytes by tenant/tidbcloud_org/state")
 var tenantMediaFiles = tenantMeter.Float64Gauge("drive9_tenant_media_files", "Tenant media file count by tenant/tidbcloud_org/state")
+var tenantVideoFiles = tenantMeter.Float64Gauge("drive9_tenant_video_files", "Tenant video extraction count by tenant/tidbcloud_org/state")
 
 // SSE-specific instruments. SSE connection lifetimes are recorded here, not
 // in drive9_http_request_duration_seconds (which would pollute HTTP latency
@@ -484,6 +485,22 @@ func RecordTenantMediaFilesWithOrg(tenantID, tidbCloudOrgID, state string, count
 	}
 	RegisterModule("tenant_usage")
 	tenantMediaFiles.Set(float64(count),
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+		Attr("state", cleanMetricValue(state, "unknown")),
+	)
+}
+
+func RecordTenantVideoFiles(tenantID, state string, count int64) {
+	RecordTenantVideoFilesWithOrg(tenantID, "", state, count)
+}
+
+func RecordTenantVideoFilesWithOrg(tenantID, tidbCloudOrgID, state string, count int64) {
+	if count < 0 {
+		return
+	}
+	RegisterModule("tenant_usage")
+	tenantVideoFiles.Set(float64(count),
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
 		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("state", cleanMetricValue(state, "unknown")),

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -250,6 +250,7 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 	RecordTenantFileBytesWithOrg(tenantID, orgID, "surface_org_label_test", "write", "out", 20)
 	RecordTenantStorageBytesWithOrg(tenantID, orgID, "confirmed", 30)
 	RecordTenantMediaFilesWithOrg(tenantID, orgID, "confirmed", 40)
+	RecordTenantVideoFilesWithOrg(tenantID, orgID, "limit", 50)
 	RecordSSEInFlightWithOrg(tenantID, orgID, 1)
 	RecordSSEPhase1WithOrg(tenantID, orgID, time.Second)
 	RecordSSEEventSentWithOrg(tenantID, orgID, "write")
@@ -271,6 +272,7 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 		`drive9_tenant_file_bytes_total{action="write",direction="out",surface="surface_org_label_test",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 20`,
 		`drive9_tenant_storage_bytes{state="confirmed",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 30.000000`,
 		`drive9_tenant_media_files{state="confirmed",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 40.000000`,
+		`drive9_tenant_video_files{state="limit",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 50.000000`,
 		`drive9_sse_inflight_connections{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1.000000`,
 		`drive9_sse_phase1_duration_seconds_count{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
 		`drive9_sse_events_sent_total{op="write",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,

--- a/pkg/tenant/quota_adapter.go
+++ b/pkg/tenant/quota_adapter.go
@@ -36,6 +36,7 @@ func (a *metaQuotaAdapter) GetQuotaConfig(ctx context.Context, tenantID string) 
 		MaxFileSizeBytes: cfg.MaxFileSizeBytes,
 		MaxFileCount:     cfg.MaxFileCount,
 		MaxMediaLLMFiles: cfg.MaxMediaLLMFiles,
+		MaxVideoLLMFiles: cfg.MaxVideoLLMFiles,
 		MaxMonthlyCostMC: cfg.MaxMonthlyCostMC,
 	}, nil
 }


### PR DESCRIPTION
## Summary

1. Add `max_video_llm_files` column to `tenant_quota_config` with `DEFAULT 50`
2. Add `DRIVE9_MEDIA_EXTRACT_MAX_FILES` env var for `MaxMediaLLMFiles` (matching the existing `DRIVE9_VIDEO_EXTRACT_MAX_FILES` style)

## Changes

| File | Change |
|------|--------|
| `cmd/drive9-server/main.go` | Add `DRIVE9_MEDIA_EXTRACT_MAX_FILES` env |
| `pkg/meta/quota.go` | Add `MaxVideoLLMFiles` to `QuotaConfig`, update `GetQuotaConfig`/`SetQuotaConfig`/`GetQuotaConfigVersion` |
| `pkg/meta/meta.go` | Add `max_video_llm_files BIGINT NOT NULL DEFAULT 50` to CREATE TABLE |
| `pkg/backend/quota_store.go` | Add `MaxVideoLLMFiles` to `QuotaConfigView` |
| `pkg/tenant/quota_adapter.go` | Bridge `MaxVideoLLMFiles` in adapter |
| `pkg/meta/meta_test.go` | Update schema spec test |
| `pkg/meta/quota_setting_test.go` | Update 6 assertions |
| `pkg/backend/quota_migration_test.go` | Update fake store defaults and version format |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a configurable per-tenant limit for video files processed by media analysis.
  * Added support for configuring the maximum number of media files through `DRIVE9_MEDIA_EXTRACT_MAX_FILES`.
  * New tenants receive a default limit of 50 video files.

* **Bug Fixes**
  * The server no longer fails to start when the deprecated `DRIVE9_QUOTA_SOURCE` setting is present.
  * Quota settings and migrations now consistently preserve the video file limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->