### PR TITLE
Configurable media/video defaults, video counter, remove quota_limits_overridden, skip TiDB Cloud API on GET

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -137,16 +137,7 @@ func main() {
 			meta.SetDefaultMaxStorageBytes(v)
 		}
 	}
-	if raw := os.Getenv("DRIVE9_MEDIA_EXTRACT_MAX_FILES"); raw != "" {
-		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
-			meta.SetDefaultMaxMediaLLMFiles(v)
-		}
-	}
-	if raw := os.Getenv("DRIVE9_VIDEO_EXTRACT_MAX_FILES"); raw != "" {
-		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
-			meta.SetDefaultMaxVideoLLMFiles(v)
-		}
-	}
+	applyQuotaDefaultsFromEnv()
 	defer func() { _ = store.Close() }()
 
 	// Continuously probe the long-lived metadata ("meta") store so a control-plane
@@ -738,6 +729,19 @@ func publicBaseURL(listenAddr string) string {
 		fmt.Fprintf(os.Stderr, "drive9-server: DRIVE9_PUBLIC_URL is required when listen address is %q (wildcard or non-loopback). Set DRIVE9_PUBLIC_URL to the externally reachable base URL.\n", listenAddr)
 		os.Exit(1)
 		return "" // unreachable
+	}
+}
+
+func applyQuotaDefaultsFromEnv() {
+	if raw := os.Getenv("DRIVE9_MEDIA_EXTRACT_MAX_FILES"); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
+			meta.SetDefaultMaxMediaLLMFiles(v)
+		}
+	}
+	if raw := os.Getenv("DRIVE9_VIDEO_EXTRACT_MAX_FILES"); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
+			meta.SetDefaultMaxVideoLLMFiles(v)
+		}
 	}
 }
 

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -137,6 +137,16 @@ func main() {
 			meta.SetDefaultMaxStorageBytes(v)
 		}
 	}
+	if raw := os.Getenv("DRIVE9_MEDIA_EXTRACT_MAX_FILES"); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
+			meta.SetDefaultMaxMediaLLMFiles(v)
+		}
+	}
+	if raw := os.Getenv("DRIVE9_VIDEO_EXTRACT_MAX_FILES"); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
+			meta.SetDefaultMaxVideoLLMFiles(v)
+		}
+	}
 	defer func() { _ = store.Close() }()
 
 	// Continuously probe the long-lived metadata ("meta") store so a control-plane
@@ -736,8 +746,6 @@ func buildBackendOptionsFromEnv() (backend.Options, error) {
 	if strings.TrimSpace(os.Getenv("DRIVE9_QUOTA_SOURCE")) != "" {
 		return backend.Options{}, fmt.Errorf("DRIVE9_QUOTA_SOURCE has been removed; central quota is now driven by meta-store wiring")
 	}
-	opts.MaxMediaLLMFiles = envInt64("DRIVE9_MEDIA_EXTRACT_MAX_FILES", 0)
-
 	opts.MaxTenantStorageBytes = envInt64("DRIVE9_MAX_TENANT_STORAGE_BYTES", 50*(1<<30))
 	if opts.MaxTenantStorageBytes <= 0 {
 		return backend.Options{}, fmt.Errorf("DRIVE9_MAX_TENANT_STORAGE_BYTES must be a positive integer")

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -638,36 +639,51 @@ func TestEnvDurationCompat(t *testing.T) {
 	})
 }
 
-func TestBuildBackendOptionsFromEnvMaxMediaLLMFiles(t *testing.T) {
-	const key = "DRIVE9_MEDIA_EXTRACT_MAX_FILES"
+func TestStartupEnvsSetMetaMediaAndVideoDefaults(t *testing.T) {
 	keys := []string{
-		key,
-		"DRIVE9_QUERY_EMBED_API_BASE",
-		"DRIVE9_QUERY_EMBED_API_KEY",
-		"DRIVE9_QUERY_EMBED_MODEL",
-		"DRIVE9_IMAGE_EXTRACT_ENABLED",
-		"DRIVE9_AUDIO_EXTRACT_ENABLED",
-		"DRIVE9_AUDIO_EXTRACT_MODE",
-		"DRIVE9_VIDEO_EXTRACT_TENANT_ALLOWLIST",
+		"DRIVE9_MEDIA_EXTRACT_MAX_FILES",
+		"DRIVE9_VIDEO_EXTRACT_MAX_FILES",
 	}
 	restore := snapshotEnv(t, keys)
 	t.Cleanup(func() { restoreEnv(t, restore) })
 	unsetEnv(t, keys)
 
-	opts, err := buildBackendOptionsFromEnv()
-	if err != nil {
-		t.Fatalf("buildBackendOptionsFromEnv: %v", err)
+	origMedia := meta.DefaultMaxMediaLLMFiles()
+	origVideo := meta.DefaultMaxVideoLLMFiles()
+	defer func() {
+		meta.SetDefaultMaxMediaLLMFiles(origMedia)
+		meta.SetDefaultMaxVideoLLMFiles(origVideo)
+	}()
+
+	if meta.DefaultMaxMediaLLMFiles() != 500 {
+		t.Fatalf("default media = %d, want 500", meta.DefaultMaxMediaLLMFiles())
 	}
-	if opts.MaxMediaLLMFiles != 0 {
-		t.Fatalf("MaxMediaLLMFiles unset = %d, want 0", opts.MaxMediaLLMFiles)
+	if meta.DefaultMaxVideoLLMFiles() != 50 {
+		t.Fatalf("default video = %d, want 50", meta.DefaultMaxVideoLLMFiles())
 	}
 
-	setEnv(t, key, "100")
-	opts, err = buildBackendOptionsFromEnv()
-	if err != nil {
-		t.Fatalf("buildBackendOptionsFromEnv: %v", err)
+	setEnv(t, "DRIVE9_MEDIA_EXTRACT_MAX_FILES", "10000")
+	setEnv(t, "DRIVE9_VIDEO_EXTRACT_MAX_FILES", "10000")
+	parseAndApplyStartupEnvs()
+
+	if meta.DefaultMaxMediaLLMFiles() != 10000 {
+		t.Fatalf("default media = %d, want 10000", meta.DefaultMaxMediaLLMFiles())
 	}
-	if opts.MaxMediaLLMFiles != 100 {
-		t.Fatalf("MaxMediaLLMFiles = %d, want 100", opts.MaxMediaLLMFiles)
+	if meta.DefaultMaxVideoLLMFiles() != 10000 {
+		t.Fatalf("default video = %d, want 10000", meta.DefaultMaxVideoLLMFiles())
+	}
+}
+
+// parseAndApplyStartupEnvs mirrors the startup env parsing for the media/video default quotas.
+func parseAndApplyStartupEnvs() {
+	if raw := os.Getenv("DRIVE9_MEDIA_EXTRACT_MAX_FILES"); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
+			meta.SetDefaultMaxMediaLLMFiles(v)
+		}
+	}
+	if raw := os.Getenv("DRIVE9_VIDEO_EXTRACT_MAX_FILES"); raw != "" {
+		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
+			meta.SetDefaultMaxVideoLLMFiles(v)
+		}
 	}
 }

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"os"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -656,34 +655,20 @@ func TestStartupEnvsSetMetaMediaAndVideoDefaults(t *testing.T) {
 	}()
 
 	if meta.DefaultMaxMediaLLMFiles() != 500 {
-		t.Fatalf("default media = %d, want 500", meta.DefaultMaxMediaLLMFiles())
+		t.Errorf("default media = %d, want 500", meta.DefaultMaxMediaLLMFiles())
 	}
 	if meta.DefaultMaxVideoLLMFiles() != 50 {
-		t.Fatalf("default video = %d, want 50", meta.DefaultMaxVideoLLMFiles())
+		t.Errorf("default video = %d, want 50", meta.DefaultMaxVideoLLMFiles())
 	}
 
 	setEnv(t, "DRIVE9_MEDIA_EXTRACT_MAX_FILES", "10000")
 	setEnv(t, "DRIVE9_VIDEO_EXTRACT_MAX_FILES", "10000")
-	parseAndApplyStartupEnvs()
+	applyQuotaDefaultsFromEnv()
 
 	if meta.DefaultMaxMediaLLMFiles() != 10000 {
-		t.Fatalf("default media = %d, want 10000", meta.DefaultMaxMediaLLMFiles())
+		t.Errorf("default media = %d, want 10000", meta.DefaultMaxMediaLLMFiles())
 	}
 	if meta.DefaultMaxVideoLLMFiles() != 10000 {
-		t.Fatalf("default video = %d, want 10000", meta.DefaultMaxVideoLLMFiles())
-	}
-}
-
-// parseAndApplyStartupEnvs mirrors the startup env parsing for the media/video default quotas.
-func parseAndApplyStartupEnvs() {
-	if raw := os.Getenv("DRIVE9_MEDIA_EXTRACT_MAX_FILES"); raw != "" {
-		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
-			meta.SetDefaultMaxMediaLLMFiles(v)
-		}
-	}
-	if raw := os.Getenv("DRIVE9_VIDEO_EXTRACT_MAX_FILES"); raw != "" {
-		if v, err := strconv.ParseInt(raw, 10, 64); err == nil && v > 0 {
-			meta.SetDefaultMaxVideoLLMFiles(v)
-		}
+		t.Errorf("default video = %d, want 10000", meta.DefaultMaxVideoLLMFiles())
 	}
 }

--- a/pkg/backend/llm_usage_test.go
+++ b/pkg/backend/llm_usage_test.go
@@ -40,7 +40,8 @@ func (m *mockQuotaStore) EnsureQuotaUsageRow(_ context.Context, _ string) error 
 func (m *mockQuotaStore) IncrStorageBytes(_ context.Context, _ string, _ int64) error   { return nil }
 func (m *mockQuotaStore) IncrReservedBytes(_ context.Context, _ string, _ int64) error  { return nil }
 func (m *mockQuotaStore) IncrFileCount(_ context.Context, _ string, _ int64) error      { return nil }
-func (m *mockQuotaStore) IncrMediaFileCount(_ context.Context, _ string, _ int64) error { return nil }
+func (m *mockQuotaStore) IncrMediaFileCount(_ context.Context, _ string, _ int64) error  { return nil }
+func (m *mockQuotaStore) IncrVideoFileCount(_ context.Context, _ string, _ int64) error  { return nil }
 func (m *mockQuotaStore) TransferReservedToConfirmed(_ context.Context, _ string, _, _ int64) error {
 	return nil
 }
@@ -50,7 +51,8 @@ func (m *mockQuotaStore) AtomicReserveAndInsertUpload(_ context.Context, _ *Uplo
 func (m *mockQuotaStore) IncrStorageBytesTx(_ *sql.Tx, _ string, _ int64) error   { return nil }
 func (m *mockQuotaStore) IncrReservedBytesTx(_ *sql.Tx, _ string, _ int64) error  { return nil }
 func (m *mockQuotaStore) IncrFileCountTx(_ *sql.Tx, _ string, _ int64) error      { return nil }
-func (m *mockQuotaStore) IncrMediaFileCountTx(_ *sql.Tx, _ string, _ int64) error { return nil }
+func (m *mockQuotaStore) IncrMediaFileCountTx(_ *sql.Tx, _ string, _ int64) error  { return nil }
+func (m *mockQuotaStore) IncrVideoFileCountTx(_ *sql.Tx, _ string, _ int64) error  { return nil }
 func (m *mockQuotaStore) TransferReservedToConfirmedTx(_ *sql.Tx, _ string, _, _ int64) error {
 	return nil
 }

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -253,7 +253,7 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 	if opts.MaxMediaLLMFiles > 0 {
 		b.maxMediaLLMFiles = opts.MaxMediaLLMFiles
 	} else {
-		b.maxMediaLLMFiles = defaultMaxMediaLLMFiles
+		b.maxMediaLLMFiles = meta.DefaultMaxMediaLLMFiles()
 	}
 	if opts.MaxTenantStorageBytes > 0 {
 		b.maxTenantStorageBytes = opts.MaxTenantStorageBytes
@@ -366,7 +366,7 @@ func (b *Dat9Backend) configureOptions(opts Options) {
 		if v.MaxVideoLLMFiles > 0 {
 			b.maxVideoLLMFiles = v.MaxVideoLLMFiles
 		} else {
-			b.maxVideoLLMFiles = defaultMaxVideoLLMFiles
+			b.maxVideoLLMFiles = meta.DefaultMaxVideoLLMFiles()
 		}
 		logger.Info(backgroundWithTrace(), "backend_video_extract_runtime_configured",
 			zap.Duration("task_timeout", v.TaskTimeout),

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -277,6 +277,7 @@ func recordTenantQuotaSnapshot(tenantID, tidbCloudOrgID string, usage *QuotaUsag
 	metrics.RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, "confirmed", usage.StorageBytes)
 	metrics.RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, "reserved", usage.ReservedBytes)
 	metrics.RecordTenantMediaFilesWithOrg(tenantID, tidbCloudOrgID, "confirmed", usage.MediaFileCount)
+	metrics.RecordTenantVideoFilesWithOrg(tenantID, tidbCloudOrgID, "confirmed", usage.VideoFileCount)
 	if cfg == nil {
 		return
 	}

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -173,6 +173,17 @@ func (f *fakeMetaQuotaStore) IncrMediaFileCountTx(tx *sql.Tx, tenantID string, d
 	return f.IncrMediaFileCount(context.Background(), tenantID, delta)
 }
 
+func (f *fakeMetaQuotaStore) IncrVideoFileCount(ctx context.Context, tenantID string, delta int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.ensureUsageLocked(tenantID).VideoFileCount += delta
+	return nil
+}
+
+func (f *fakeMetaQuotaStore) IncrVideoFileCountTx(tx *sql.Tx, tenantID string, delta int64) error {
+	return f.IncrVideoFileCount(context.Background(), tenantID, delta)
+}
+
 func (f *fakeMetaQuotaStore) TransferReservedToConfirmed(ctx context.Context, tenantID string, reservedDelta, storageDelta int64) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -30,12 +30,14 @@ type MetaQuotaStore interface {
 	IncrReservedBytes(ctx context.Context, tenantID string, delta int64) error
 	IncrFileCount(ctx context.Context, tenantID string, delta int64) error
 	IncrMediaFileCount(ctx context.Context, tenantID string, delta int64) error
+	IncrVideoFileCount(ctx context.Context, tenantID string, delta int64) error
 	TransferReservedToConfirmed(ctx context.Context, tenantID string, reservedDelta, storageDelta int64) error
 	AtomicReserveAndInsertUpload(ctx context.Context, r *UploadReservationView) error
 	IncrStorageBytesTx(tx *sql.Tx, tenantID string, delta int64) error
 	IncrReservedBytesTx(tx *sql.Tx, tenantID string, delta int64) error
 	IncrFileCountTx(tx *sql.Tx, tenantID string, delta int64) error
 	IncrMediaFileCountTx(tx *sql.Tx, tenantID string, delta int64) error
+	IncrVideoFileCountTx(tx *sql.Tx, tenantID string, delta int64) error
 	TransferReservedToConfirmedTx(tx *sql.Tx, tenantID string, reservedDelta, storageDelta int64) error
 
 	// File meta (server-authored shadow state)
@@ -93,6 +95,7 @@ type QuotaUsageView struct {
 	ReservedBytes  int64
 	FileCount      int64
 	MediaFileCount int64
+	VideoFileCount int64
 }
 
 // FileMetaView is the backend-side view of per-file quota metadata.

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -92,6 +92,9 @@ func (b *Dat9Backend) enqueueExtractSemanticTasksTx(ctx context.Context, tx *sql
 			if err != nil {
 				return enqueued, err
 			}
+			if created && b.metaStore != nil {
+				_ = b.metaStore.IncrVideoFileCount(ctx, b.tenantID, 1)
+			}
 			enqueued = enqueued || created
 		}
 	}

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -7,7 +7,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/semantic"
+	"go.uber.org/zap"
 )
 
 // The enqueue helpers report whether a task row was actually created (the
@@ -93,7 +95,10 @@ func (b *Dat9Backend) enqueueExtractSemanticTasksTx(ctx context.Context, tx *sql
 				return enqueued, err
 			}
 			if created && b.metaStore != nil {
-				_ = b.metaStore.IncrVideoFileCount(ctx, b.tenantID, 1)
+				if err := b.metaStore.IncrVideoFileCount(ctx, b.tenantID, 1); err != nil {
+					logger.Warn(ctx, "video_llm_central_count_failed",
+						zap.String("tenant_id", b.tenantID), zap.Error(err))
+				}
 			}
 			enqueued = enqueued || created
 		}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -706,6 +706,7 @@ func metaInitSchemaStatements() []string {
 			reserved_bytes     BIGINT NOT NULL DEFAULT 0,
 			file_count         BIGINT NOT NULL DEFAULT 0,
 			media_file_count   BIGINT NOT NULL DEFAULT 0,
+			video_file_count   BIGINT NOT NULL DEFAULT 0,
 			updated_at         DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3)
 		)`,
 		`CREATE TABLE IF NOT EXISTS tenant_file_meta (

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -149,6 +149,7 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 	cfg := &QuotaConfig{TenantID: tenantID}
 	var spendingLimit sql.NullInt64
 	var checkedAt sql.NullTime
+	var quotaOverridden bool
 	err = s.db.QueryRowContext(ctx,
 		`SELECT max_storage_bytes, max_file_size_bytes, max_file_count,
 		        max_media_llm_files, max_video_llm_files, max_monthly_cost_mc, quota_limits_overridden,
@@ -156,30 +157,22 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 		        created_at, updated_at
 		 FROM tenant_quota_config WHERE tenant_id = ?`, tenantID,
 	).Scan(&cfg.MaxStorageBytes, &cfg.MaxFileSizeBytes, &cfg.MaxFileCount,
-		&cfg.MaxMediaLLMFiles, &cfg.MaxVideoLLMFiles, &cfg.MaxMonthlyCostMC, &cfg.QuotaLimitsOverridden,
+		&cfg.MaxMediaLLMFiles, &cfg.MaxVideoLLMFiles, &cfg.MaxMonthlyCostMC, &quotaOverridden,
 		&spendingLimit, &checkedAt, &cfg.CreatedAt, &cfg.UpdatedAt)
 	if err == sql.ErrNoRows {
-		// Return defaults when no per-tenant config exists.
 		cfg.MaxStorageBytes = DefaultMaxStorageBytes()
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
 		cfg.MaxFileCount = 0
 		cfg.MaxMediaLLMFiles = DefaultMaxMediaLLMFiles()
 		cfg.MaxVideoLLMFiles = DefaultMaxVideoLLMFiles()
 		cfg.MaxMonthlyCostMC = 0
-		cfg.QuotaLimitsOverridden = false
 		return cfg, nil
 	}
 	if err != nil {
 		return nil, err
 	}
-	if !cfg.QuotaLimitsOverridden {
-		cfg.MaxStorageBytes = DefaultMaxStorageBytes()
-		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
-		cfg.MaxFileCount = 0
-		cfg.MaxMediaLLMFiles = DefaultMaxMediaLLMFiles()
-		cfg.MaxVideoLLMFiles = DefaultMaxVideoLLMFiles()
-		cfg.MaxMonthlyCostMC = 0
-	} else if cfg.MaxFileSizeBytes <= 0 {
+	cfg.QuotaLimitsOverridden = quotaOverridden
+	if cfg.MaxFileSizeBytes <= 0 {
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
 	}
 	cfg.TiDBCloudSpendingLimit = ptrFromNullInt64(spendingLimit)
@@ -199,12 +192,11 @@ func (s *Store) GetQuotaConfigVersion(ctx context.Context, tenantID string) (str
 	defer observeMeta(ctx, "get_quota_config_version", start, &err)
 
 	var maxStorageBytes, maxFileSizeBytes, maxFileCount, maxMediaLLMFiles, maxVideoLLMFiles, maxMonthlyCostMC int64
-	var quotaLimitsOverridden bool
 	err = s.db.QueryRowContext(ctx,
 		`SELECT max_storage_bytes, max_file_size_bytes, max_file_count,
-		        max_media_llm_files, max_video_llm_files, max_monthly_cost_mc, quota_limits_overridden
+		        max_media_llm_files, max_video_llm_files, max_monthly_cost_mc
 		 FROM tenant_quota_config WHERE tenant_id = ?`, tenantID,
-	).Scan(&maxStorageBytes, &maxFileSizeBytes, &maxFileCount, &maxMediaLLMFiles, &maxVideoLLMFiles, &maxMonthlyCostMC, &quotaLimitsOverridden)
+	).Scan(&maxStorageBytes, &maxFileSizeBytes, &maxFileCount, &maxMediaLLMFiles, &maxVideoLLMFiles, &maxMonthlyCostMC)
 	if err == sql.ErrNoRows {
 		logger.Info(ctx, "quota_config_not_found_using_defaults",
 			zap.String("tenant_id", tenantID))
@@ -213,9 +205,6 @@ func (s *Store) GetQuotaConfigVersion(ctx context.Context, tenantID string) (str
 	}
 	if err != nil {
 		return "", fmt.Errorf("get quota config version for tenant %q: %w", tenantID, err)
-	}
-	if !quotaLimitsOverridden {
-		return "", nil
 	}
 	return fmt.Sprintf("v3:%d:%d:%d:%d:%d:%d", maxStorageBytes, maxFileSizeBytes, maxFileCount, maxMediaLLMFiles, maxVideoLLMFiles, maxMonthlyCostMC), nil
 }

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -340,12 +340,13 @@ func (s *Store) SetTiDBCloudSpendingLimitIfNotUpdatedAfter(ctx context.Context, 
 	res, err := s.db.ExecContext(ctx,
 		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
 		                                  quota_limits_overridden, tidbcloud_spending_limit,
-		                                  tidbcloud_spending_limit_checked_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		                                  tidbcloud_spending_limit_checked_at, max_media_llm_files, max_video_llm_files)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON DUPLICATE KEY UPDATE
 		   tidbcloud_spending_limit = IF(updated_at < ?, VALUES(tidbcloud_spending_limit), tidbcloud_spending_limit),
 		   tidbcloud_spending_limit_checked_at = IF(updated_at < ?, VALUES(tidbcloud_spending_limit_checked_at), tidbcloud_spending_limit_checked_at)`,
 		tenantID, DefaultMaxStorageBytes(), int64(0), int64(0), false, sql.NullInt64{Int64: limit, Valid: true}, sql.NullTime{Time: checkedAt, Valid: true},
+			DefaultMaxMediaLLMFiles(), DefaultMaxVideoLLMFiles(),
 		observedCutoff, observedCutoff)
 	if err != nil {
 		return false, fmt.Errorf("set tidbcloud spending limit for tenant %q: %w", tenantID, err)

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -50,6 +50,7 @@ type QuotaUsage struct {
 	ReservedBytes  int64
 	FileCount      int64
 	MediaFileCount int64
+	VideoFileCount int64
 	UpdatedAt      time.Time
 }
 
@@ -428,9 +429,9 @@ func (s *Store) GetQuotaUsage(ctx context.Context, tenantID string) (*QuotaUsage
 
 	u := &QuotaUsage{TenantID: tenantID}
 	err = s.db.QueryRowContext(ctx,
-		`SELECT storage_bytes, reserved_bytes, file_count, media_file_count, updated_at
+		`SELECT storage_bytes, reserved_bytes, file_count, media_file_count, video_file_count, updated_at
 		 FROM tenant_quota_usage WHERE tenant_id = ?`, tenantID,
-	).Scan(&u.StorageBytes, &u.ReservedBytes, &u.FileCount, &u.MediaFileCount, &u.UpdatedAt)
+	).Scan(&u.StorageBytes, &u.ReservedBytes, &u.FileCount, &u.MediaFileCount, &u.VideoFileCount, &u.UpdatedAt)
 	if err == sql.ErrNoRows {
 		return u, nil // zero counters
 	}
@@ -557,6 +558,32 @@ func (s *Store) IncrMediaFileCount(ctx context.Context, tenantID string, delta i
 func (s *Store) IncrMediaFileCountTx(tx *sql.Tx, tenantID string, delta int64) error {
 	res, err := tx.Exec(
 		`UPDATE tenant_quota_usage SET media_file_count = media_file_count + ? WHERE tenant_id = ?`,
+		delta, tenantID)
+	if err != nil {
+		return err
+	}
+	return ensureRowsAffected(res, tenantID)
+}
+
+// IncrVideoFileCount atomically adjusts the video_file_count counter.
+func (s *Store) IncrVideoFileCount(ctx context.Context, tenantID string, delta int64) error {
+	start := time.Now()
+	var err error
+	defer observeMeta(ctx, "incr_video_file_count", start, &err)
+
+	res, err := s.db.ExecContext(ctx,
+		`UPDATE tenant_quota_usage SET video_file_count = video_file_count + ? WHERE tenant_id = ?`,
+		delta, tenantID)
+	if err != nil {
+		return err
+	}
+	return ensureRowsAffected(res, tenantID)
+}
+
+// IncrVideoFileCountTx atomically adjusts the video_file_count counter inside a transaction.
+func (s *Store) IncrVideoFileCountTx(tx *sql.Tx, tenantID string, delta int64) error {
+	res, err := tx.Exec(
+		`UPDATE tenant_quota_usage SET video_file_count = video_file_count + ? WHERE tenant_id = ?`,
 		delta, tenantID)
 	if err != nil {
 		return err

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -162,8 +162,8 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 		cfg.MaxStorageBytes = DefaultMaxStorageBytes()
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
 		cfg.MaxFileCount = 0
-		cfg.MaxMediaLLMFiles = 500
-		cfg.MaxVideoLLMFiles = 50
+		cfg.MaxMediaLLMFiles = DefaultMaxMediaLLMFiles()
+		cfg.MaxVideoLLMFiles = DefaultMaxVideoLLMFiles()
 		cfg.MaxMonthlyCostMC = 0
 		cfg.QuotaLimitsOverridden = false
 		return cfg, nil
@@ -175,8 +175,8 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 		cfg.MaxStorageBytes = DefaultMaxStorageBytes()
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
 		cfg.MaxFileCount = 0
-		cfg.MaxMediaLLMFiles = 500
-		cfg.MaxVideoLLMFiles = 50
+		cfg.MaxMediaLLMFiles = DefaultMaxMediaLLMFiles()
+		cfg.MaxVideoLLMFiles = DefaultMaxVideoLLMFiles()
 		cfg.MaxMonthlyCostMC = 0
 	} else if cfg.MaxFileSizeBytes <= 0 {
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
@@ -289,6 +289,8 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 	}
 	insertSpendingLimit := nullInt64FromPtr(patch.TiDBCloudSpendingLimit)
 	insertCheckedAt := nullTimeFromPtr(patch.TiDBCloudSpendingLimitCheckedAt)
+	insertMediaLLM := DefaultMaxMediaLLMFiles()
+	insertVideoLLM := DefaultMaxVideoLLMFiles()
 	updateStorage := sql.NullInt64{}
 	if patch.MaxStorageBytes != nil {
 		updateStorage = sql.NullInt64{Int64: *patch.MaxStorageBytes, Valid: true}
@@ -306,8 +308,8 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
 		                                  quota_limits_overridden, tidbcloud_spending_limit,
-		                                  tidbcloud_spending_limit_checked_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)
+		                                  tidbcloud_spending_limit_checked_at, max_media_llm_files, max_video_llm_files)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 			 ON DUPLICATE KEY UPDATE
 			   max_storage_bytes = COALESCE(?, max_storage_bytes),
 			   max_file_size_bytes = COALESCE(?, max_file_size_bytes),
@@ -315,8 +317,11 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 			   /* Storage quota overrides are sticky once any storage/file limit is explicitly set. */
 			   quota_limits_overridden = IF(?, 1, quota_limits_overridden),
 			   tidbcloud_spending_limit = COALESCE(?, tidbcloud_spending_limit),
-			   tidbcloud_spending_limit_checked_at = COALESCE(?, tidbcloud_spending_limit_checked_at)`,
+			   tidbcloud_spending_limit_checked_at = COALESCE(?, tidbcloud_spending_limit_checked_at),
+			   max_media_llm_files = COALESCE(NULL, max_media_llm_files),
+			   max_video_llm_files = COALESCE(NULL, max_video_llm_files)`,
 		tenantID, insertStorage, insertFileSize, insertFileCount, quotaLimitOverrideSet, insertSpendingLimit, insertCheckedAt,
+			insertMediaLLM, insertVideoLLM,
 		updateStorage, updateFileSize, updateFileCount, quotaLimitOverrideSet, updateSpendingLimit, updateCheckedAt)
 	if err != nil {
 		return fmt.Errorf("set quota config patch for tenant %q: %w", tenantID, err)
@@ -592,10 +597,14 @@ func (s *Store) TransferReservedToConfirmedTx(tx *sql.Tx, tenantID string, reser
 // defaultMaxStorageBytes is the fallback limit when no per-tenant config row exists.
 var defaultMaxStorageBytes atomic.Int64
 var defaultMaxFileSizeBytes atomic.Int64
+var defaultMaxMediaLLMFiles atomic.Int64
+var defaultMaxVideoLLMFiles atomic.Int64
 
 func init() {
 	defaultMaxStorageBytes.Store(int64(50 * (1 << 30)))  // 50 GiB
 	defaultMaxFileSizeBytes.Store(int64(10 * (1 << 30))) // 10 GiB
+	defaultMaxMediaLLMFiles.Store(int64(500))
+	defaultMaxVideoLLMFiles.Store(int64(50))
 }
 
 // SetDefaultMaxStorageBytes overrides the per-tenant fallback storage quota.
@@ -617,6 +626,26 @@ func SetDefaultMaxFileSizeBytes(bytes int64) {
 
 // DefaultMaxFileSizeBytes returns the configured per-tenant fallback file size quota.
 func DefaultMaxFileSizeBytes() int64 { return defaultMaxFileSizeBytes.Load() }
+
+// SetDefaultMaxMediaLLMFiles overrides the per-tenant fallback media LLM file limit.
+func SetDefaultMaxMediaLLMFiles(n int64) {
+	if n > 0 {
+		defaultMaxMediaLLMFiles.Store(n)
+	}
+}
+
+// DefaultMaxMediaLLMFiles returns the configured per-tenant fallback media LLM file limit.
+func DefaultMaxMediaLLMFiles() int64 { return defaultMaxMediaLLMFiles.Load() }
+
+// SetDefaultMaxVideoLLMFiles overrides the per-tenant fallback video LLM file limit.
+func SetDefaultMaxVideoLLMFiles(n int64) {
+	if n > 0 {
+		defaultMaxVideoLLMFiles.Store(n)
+	}
+}
+
+// DefaultMaxVideoLLMFiles returns the configured per-tenant fallback video LLM file limit.
+func DefaultMaxVideoLLMFiles() int64 { return defaultMaxVideoLLMFiles.Load() }
 
 const (
 	metaLockConflictRetryAttempts = 4

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -307,9 +307,7 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 			   /* Storage quota overrides are sticky once any storage/file limit is explicitly set. */
 			   quota_limits_overridden = IF(?, 1, quota_limits_overridden),
 			   tidbcloud_spending_limit = COALESCE(?, tidbcloud_spending_limit),
-			   tidbcloud_spending_limit_checked_at = COALESCE(?, tidbcloud_spending_limit_checked_at),
-			   max_media_llm_files = COALESCE(NULL, max_media_llm_files),
-			   max_video_llm_files = COALESCE(NULL, max_video_llm_files)`,
+			   tidbcloud_spending_limit_checked_at = COALESCE(?, tidbcloud_spending_limit_checked_at)`,
 		tenantID, insertStorage, insertFileSize, insertFileCount, quotaLimitOverrideSet, insertSpendingLimit, insertCheckedAt,
 			insertMediaLLM, insertVideoLLM,
 		updateStorage, updateFileSize, updateFileCount, quotaLimitOverrideSet, updateSpendingLimit, updateCheckedAt)

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -120,8 +120,8 @@ func TestQuotaConfigStoresTiDBCloudSpendingLimitWithoutStorageVersion(t *testing
 	if err != nil {
 		t.Fatal(err)
 	}
-	if version != "" {
-		t.Fatalf("storage quota version = %q, want empty", version)
+	if version == "" {
+		t.Fatalf("storage quota version should be non-empty when config row exists")
 	}
 
 	updated := int64(123)

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1710,18 +1710,27 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 			s.releaseClaimedPoolTenant(ctx, manager, cluster, cred, row.Tenant.ID, "claim_error")
 		}
 	}()
-	if quotaOpt != nil {
-		stageStarted = time.Now()
-		quotaReq := *quotaOpt
-		quotaReq.TenantID = row.Tenant.ID
-		if err := s.applyQuotaLocalConfig(ctx, "pool_claim", row.Tenant.ID, quotaReq); err != nil {
-			return nil, nil, false, err
-		}
-		logProvisionStage(ctx, "admin_tenant_pool_claim_quota_local_config_applied", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID)
-	}
 	stageStarted = time.Now()
 	quotaSeed := meta.QuotaConfigPatch{
 		TiDBCloudSpendingLimit: tidbCloudSpendingLimitFromCloud(cloudCfg),
+	}
+	if quotaOpt != nil {
+		qp, err := quotaConfigPatchFromRequest(*quotaOpt)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		if qp.MaxStorageBytes != nil {
+			quotaSeed.MaxStorageBytes = qp.MaxStorageBytes
+		}
+		if qp.MaxFileSizeBytes != nil {
+			quotaSeed.MaxFileSizeBytes = qp.MaxFileSizeBytes
+		}
+		if qp.MaxFileCount != nil {
+			quotaSeed.MaxFileCount = qp.MaxFileCount
+		}
+		if qp.TiDBCloudSpendingLimit != nil {
+			quotaSeed.TiDBCloudSpendingLimit = qp.TiDBCloudSpendingLimit
+		}
 	}
 	if cloudCfg != nil {
 		checkedAt := time.Now().UTC()

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -111,6 +111,10 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusForbidden, "API key tenant does not match requested tenant")
 		return
 	}
+	if t.Provider != tenant.ProviderTiDBCloudNative {
+		errJSON(w, http.StatusConflict, "tidbcloud credential quota query is only supported for tidb_cloud_native tenants")
+		return
+	}
 	cred, err := quotaCredentials(req)
 	if err != nil {
 		errJSON(w, http.StatusBadRequest, err.Error())

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -223,16 +223,15 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
+	if t.Provider != tenant.ProviderTiDBCloudNative {
+		errJSON(w, http.StatusConflict, "quota setting is only supported for tidb_cloud_native tenants")
+		return
+	}
 	if err := s.rejectQuotaSetForTenantStatus(t); err != nil {
 		errJSON(w, http.StatusConflict, err.Error())
 		return
 	}
-	if !s.tidbCloudRBACAllowed(cred, t.ClusterID, "quota_set") {
-		errJSON(w, http.StatusForbidden, "rbac check failed")
-		return
-	}
-	s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
-	if err := s.applyQuotaLocalConfig(r.Context(), "quota_set", t.ID, req); err != nil {
+	if err := s.applyQuotaSet(r.Context(), "quota_set", t, cred, req); err != nil {
 		writeQuotaSetError(w, r.Context(), err, "update")
 		return
 	}

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -89,74 +89,38 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	req := decodeQuotaGetRequest(r)
-	hasTiDBCloudCreds := req.PublicKey != "" || req.PrivateKey != ""
 	t, ok := s.quotaTenant(w, r.Context(), req.TenantID)
 	if !ok {
-		return
-	}
-	if t.Provider != tenant.ProviderTiDBCloudNative {
-		errJSON(w, http.StatusConflict, "tidbcloud credential quota query is only supported for tidb_cloud_native tenants")
 		return
 	}
 	if strings.TrimSpace(t.ClusterID) == "" {
 		errJSON(w, http.StatusNotFound, quotaBackendNotFoundMessage)
 		return
 	}
-	getter, ok := s.provisioner.(tenant.QuotaGetter)
-	if !ok {
-		errJSON(w, http.StatusNotFound, "quota query not enabled")
-		return
-	}
-	cfg, err := s.meta.GetQuotaConfig(r.Context(), t.ID)
-	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "quota config lookup failed")
-		return
-	}
-	if cfg.TiDBCloudSpendingLimit != nil && bearerToken(r) != "" {
+	if bearerToken(r) != "" {
 		apiKeyTenant, apiKeyErr := s.resolveQuotaAPIKey(r.Context(), r)
 		if apiKeyErr == nil && apiKeyTenant != nil && apiKeyTenant.Tenant.ID == t.ID {
 			setRequestMetricTenant(r.Context(), t.ID, apiKeyTenant.APIKey.ID, t.Provider, apiKeyTenant.TiDBCloudOrgID, classifyTenantRequest(r))
 			s.writeQuotaResponse(w, r, t)
 			return
 		}
-		if !hasTiDBCloudCreds {
-			if apiKeyErr != nil {
-				writeQuotaAPIKeyError(w, r.Context(), apiKeyErr)
-				return
-			}
-			errJSON(w, http.StatusForbidden, "API key tenant does not match requested tenant")
+		if apiKeyErr != nil {
+			writeQuotaAPIKeyError(w, r.Context(), apiKeyErr)
 			return
 		}
+		errJSON(w, http.StatusForbidden, "API key tenant does not match requested tenant")
+		return
 	}
 	cred, err := quotaCredentials(req)
 	if err != nil {
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	needRefresh := false
-	if cfg.TiDBCloudSpendingLimit == nil {
-		metrics.RecordTiDBCloudSpendingLimitMissing("quota_get")
-		metrics.RecordTiDBCloudRBACCacheRequest("quota_get", "cluster", "bypass")
-		needRefresh = true
-	} else if !s.tidbCloudRBACAllowed(cred, t.ClusterID, "quota_get") {
-		needRefresh = true
+	if !s.tidbCloudRBACAllowed(cred, t.ClusterID, "quota_get") {
+		errJSON(w, http.StatusForbidden, "rbac check failed")
+		return
 	}
-	if needRefresh {
-		observedAt := time.Now().UTC()
-		cloudCfg, err := getter.GetQuota(r.Context(), clusterInfoFromTenant(t), cred)
-		if err != nil {
-			metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "error")
-			writeQuotaCredentialError(w, r.Context(), err, "query")
-			return
-		}
-		metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "ok")
-		s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
-		if err := s.syncTiDBCloudSpendingLimit(r.Context(), "quota_get", t.ID, cloudCfg, observedAt); err != nil {
-			logger.Warn(r.Context(), "tidbcloud_spending_limit_sync_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-			errJSON(w, http.StatusInternalServerError, "quota config update failed")
-			return
-		}
-	}
+	s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
 	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, s.tenantMetricTiDBCloudOrgID(r.Context(), t), classifyTenantRequest(r))
 	s.writeQuotaResponse(w, r, t)
 }
@@ -259,15 +223,16 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if t.Provider != tenant.ProviderTiDBCloudNative {
-		errJSON(w, http.StatusConflict, "quota setting is only supported for tidb_cloud_native tenants")
-		return
-	}
 	if err := s.rejectQuotaSetForTenantStatus(t); err != nil {
 		errJSON(w, http.StatusConflict, err.Error())
 		return
 	}
-	if err := s.applyQuotaSet(r.Context(), "quota_set", t, cred, req); err != nil {
+	if !s.tidbCloudRBACAllowed(cred, t.ClusterID, "quota_set") {
+		errJSON(w, http.StatusForbidden, "rbac check failed")
+		return
+	}
+	s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
+	if err := s.applyQuotaLocalConfig(r.Context(), "quota_set", t.ID, req); err != nil {
 		writeQuotaSetError(w, r.Context(), err, "update")
 		return
 	}

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -126,7 +126,6 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 			errJSON(w, http.StatusNotFound, "quota query not enabled")
 			return
 		}
-		metrics.RecordTiDBCloudRBACCacheRequest("quota_get", "cluster", "bypass")
 		observedAt := time.Now().UTC()
 		cloudCfg, err := getter.GetQuota(r.Context(), clusterInfoFromTenant(t), cred)
 		if err != nil {

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -117,10 +117,25 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if !s.tidbCloudRBACAllowed(cred, t.ClusterID, "quota_get") {
-		errJSON(w, http.StatusForbidden, "rbac check failed")
-		return
+		getter, ok := s.provisioner.(tenant.QuotaGetter)
+		if !ok {
+			errJSON(w, http.StatusNotFound, "quota query not enabled")
+			return
+		}
+		metrics.RecordTiDBCloudRBACCacheRequest("quota_get", "cluster", "bypass")
+		observedAt := time.Now().UTC()
+		cloudCfg, err := getter.GetQuota(r.Context(), clusterInfoFromTenant(t), cred)
+		if err != nil {
+			metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "error")
+			writeQuotaCredentialError(w, r.Context(), err, "query")
+			return
+		}
+		metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "ok")
+		s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
+		if err := s.syncTiDBCloudSpendingLimit(r.Context(), "quota_get", t.ID, cloudCfg, observedAt); err != nil {
+			logger.Warn(r.Context(), "tidbcloud_spending_limit_sync_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+		}
 	}
-	s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
 	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, s.tenantMetricTiDBCloudOrgID(r.Context(), t), classifyTenantRequest(r))
 	s.writeQuotaResponse(w, r, t)
 }

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -475,6 +475,7 @@ func TestQuotaGetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.defaultPublicKey = "default-pk"
 	rt.prov.defaultPrivateKey = "default-sk"
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "default-pk", PrivateKey: "default-sk"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -483,27 +484,23 @@ func TestQuotaGetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("get calls = %d, want 1", got)
-	}
-	lastCredentials := rt.prov.lastCredentialsSnapshot()
-	if lastCredentials.PublicKey != "default-pk" || lastCredentials.PrivateKey != "default-sk" {
-		t.Fatalf("last credentials = %#v", lastCredentials)
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("get calls = %d, want 0", got)
 	}
 }
 
 func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	spendingLimit := int64(10000)
-	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
 	ctx := context.Background()
 	if err := rt.meta.SetQuotaConfig(ctx, &meta.QuotaConfig{
-		TenantID:         rt.tenantID,
-		MaxStorageBytes:  123 * quotaStorageSizeBytes,
-		MaxFileSizeBytes: 12 * quotaStorageSizeBytes,
-		MaxFileCount:     34,
-		MaxMediaLLMFiles: 56,
-		MaxMonthlyCostMC: 789,
+		TenantID:                  rt.tenantID,
+		MaxStorageBytes:           123 * quotaStorageSizeBytes,
+		MaxFileSizeBytes:          12 * quotaStorageSizeBytes,
+		MaxFileCount:              34,
+		MaxMediaLLMFiles:          56,
+		MaxMonthlyCostMC:          789,
+		TiDBCloudSpendingLimit:    &spendingLimit,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -516,6 +513,7 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	if err := rt.meta.IncrReservedBytes(ctx, rt.tenantID, 11); err != nil {
 		t.Fatal(err)
 	}
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
@@ -538,13 +536,6 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	}
 	if out.Config.MaxStorageSize != 123 || out.Config.MaxFileSize != 12 || out.Config.MaxFileCount != 34 || out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
 		t.Fatalf("config = %#v", out.Config)
-	}
-	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
-		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)
 	}
 	if out.Usage.StorageBytes != 321 || out.Usage.ReservedBytes != 11 || out.Usage.FileCount != 9 {
 		t.Fatalf("usage = %#v", out.Usage)
@@ -625,6 +616,7 @@ func TestSyncTiDBCloudSpendingLimitSkipsNewerLocalAtSameTimestampTick(t *testing
 
 func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -633,26 +625,19 @@ func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d", resp.StatusCode)
 	}
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("get calls = %d, want 1", got)
-	}
-	if got := rt.prov.updateCalls.Load(); got != 0 {
-		t.Fatalf("update calls = %d, want 0", got)
-	}
-	lastCluster := rt.prov.lastClusterSnapshot()
-	if lastCluster == nil || lastCluster.ClusterID != "cluster-quota-1" || lastCluster.TenantID != rt.tenantID {
-		t.Fatalf("last cluster = %#v", lastCluster)
-	}
-	lastCredentials := rt.prov.lastCredentialsSnapshot()
-	if lastCredentials.PublicKey != "public-1" || lastCredentials.PrivateKey != "private-1" {
-		t.Fatalf("last credentials = %#v", lastCredentials)
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("get calls = %d, want 0", got)
 	}
 }
 
 func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	spendingLimit := int64(222)
-	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
+	ctx := context.Background()
+	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &spendingLimit}); err != nil {
+		t.Fatal(err)
+	}
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -663,18 +648,7 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 		t.Fatalf("first status = %d, want 200: %s", resp.StatusCode, body)
 	}
 	_ = resp.Body.Close()
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("get calls after first request = %d, want 1", got)
-	}
-	cfg, err := rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
-		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)
-	}
 
-	rt.prov.getErr = errors.New("should not call TiDB Cloud while RBAC cache and local spending limit are present")
 	resp2 := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
 	defer func() { _ = resp2.Body.Close() }()
 	if resp2.StatusCode != http.StatusOK {
@@ -688,33 +662,30 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 	if out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
 		t.Fatalf("response spending limit = %#v, want %d", out.Config.TiDBCloudSpendingLimit, spendingLimit)
 	}
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("get calls after cached request = %d, want 1", got)
+
+	updatedLimit := int64(333)
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-2"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &updatedLimit}); err != nil {
+		t.Fatal(err)
 	}
 
-	rt.prov.getErr = nil
-	updatedLimit := int64(333)
-	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &updatedLimit}
 	resp3 := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-2", "")
 	defer func() { _ = resp3.Body.Close() }()
 	if resp3.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp3.Body)
 		t.Fatalf("third status = %d, want 200: %s", resp3.StatusCode, body)
 	}
-	if got := rt.prov.getCalls.Load(); got != 2 {
-		t.Fatalf("get calls after new credential = %d, want 2", got)
-	}
-	cfg, err = rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
-	if err != nil {
+	if err := json.NewDecoder(resp3.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != updatedLimit {
-		t.Fatalf("updated spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, updatedLimit)
+	if out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != updatedLimit {
+		t.Fatalf("updated spending limit = %#v, want %d", out.Config.TiDBCloudSpendingLimit, updatedLimit)
 	}
 }
 
 func TestDeprecatedQuotaGetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -724,8 +695,8 @@ func TestDeprecatedQuotaGetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 200 without tenant-org binding: %s", resp.StatusCode, body)
 	}
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("get calls = %d, want 1", got)
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("get calls = %d, want 0", got)
 	}
 	if got := rt.prov.listCalls.Load(); got != 0 {
 		t.Fatalf("list calls = %d, want 0", got)
@@ -745,16 +716,7 @@ func TestQuotaSetChecksClusterWritePermissionBeforeMaxStorageUpdate(t *testing.T
 	}); err != nil {
 		t.Fatal(err)
 	}
-	rt.prov.markHook = func() error {
-		cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
-		if err != nil {
-			return err
-		}
-		if cfg.MaxStorageBytes != 100 {
-			return fmt.Errorf("max storage bytes before label patch = %d, want old value 100", cfg.MaxStorageBytes)
-		}
-		return nil
-	}
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -771,12 +733,8 @@ func TestQuotaSetChecksClusterWritePermissionBeforeMaxStorageUpdate(t *testing.T
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
 	}
-	if got := rt.prov.markCalls.Load(); got != 1 {
-		t.Fatalf("mark calls = %d, want 1", got)
-	}
-	calls := rt.prov.callsSnapshot()
-	if len(calls) != 1 || calls[0] != "mark" {
-		t.Fatalf("calls = %#v, want mark only", calls)
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("mark calls = %d, want 0", got)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
 	if err != nil {
@@ -789,6 +747,7 @@ func TestQuotaSetChecksClusterWritePermissionBeforeMaxStorageUpdate(t *testing.T
 
 func TestDeprecatedQuotaSetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -803,8 +762,8 @@ func TestDeprecatedQuotaSetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 200 without tenant-org binding: %s", resp.StatusCode, body)
 	}
-	if got := rt.prov.markCalls.Load(); got != 1 {
-		t.Fatalf("mark calls = %d, want 1", got)
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("mark calls = %d, want 0", got)
 	}
 	if got := rt.prov.listCalls.Load(); got != 0 {
 		t.Fatalf("list calls = %d, want 0", got)
@@ -851,16 +810,7 @@ func TestQuotaSetChecksClusterWritePermissionBeforeFileLimitUpdate(t *testing.T)
 	}); err != nil {
 		t.Fatal(err)
 	}
-	rt.prov.markHook = func() error {
-		cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
-		if err != nil {
-			return err
-		}
-		if cfg.MaxFileSizeBytes != 200 || cfg.MaxFileCount != 300 {
-			return fmt.Errorf("file limits before label patch = size:%d count:%d, want old values", cfg.MaxFileSizeBytes, cfg.MaxFileCount)
-		}
-		return nil
-	}
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -878,12 +828,8 @@ func TestQuotaSetChecksClusterWritePermissionBeforeFileLimitUpdate(t *testing.T)
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
 	}
-	if got := rt.prov.markCalls.Load(); got != 1 {
-		t.Fatalf("mark calls = %d, want 1", got)
-	}
-	calls := rt.prov.callsSnapshot()
-	if len(calls) != 1 || calls[0] != "mark" {
-		t.Fatalf("calls = %#v, want mark only", calls)
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("mark calls = %d, want 0", got)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
 	if err != nil {
@@ -897,7 +843,7 @@ func TestQuotaSetChecksClusterWritePermissionBeforeFileLimitUpdate(t *testing.T)
 func TestQuotaSetSpendingLimitOnlyPersistsSpendingLimitConfig(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	spendingLimit := int64(0)
-	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -911,19 +857,11 @@ func TestQuotaSetSpendingLimitOnlyPersistsSpendingLimitConfig(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d", resp.StatusCode)
 	}
-	if got := rt.prov.updateCalls.Load(); got != 1 {
-		t.Fatalf("update calls = %d, want 1", got)
+	if got := rt.prov.updateCalls.Load(); got != 0 {
+		t.Fatalf("update calls = %d, want 0", got)
 	}
-	if got := rt.prov.markCalls.Load(); got != 1 {
-		t.Fatalf("mark calls = %d, want 1", got)
-	}
-	calls := rt.prov.callsSnapshot()
-	if len(calls) != 2 || calls[0] != "mark" || calls[1] != "update" {
-		t.Fatalf("calls = %#v, want mark before update", calls)
-	}
-	lastOptions := rt.prov.lastOptionsSnapshot()
-	if lastOptions.TiDBCloudSpendingLimitMonthly == nil || *lastOptions.TiDBCloudSpendingLimitMonthly != spendingLimit {
-		t.Fatalf("spending limit option = %#v, want %d", lastOptions.TiDBCloudSpendingLimitMonthly, spendingLimit)
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("mark calls = %d, want 0", got)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
 	if err != nil {
@@ -1017,6 +955,7 @@ func TestQuotaSetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.defaultPublicKey = "default-pk"
 	rt.prov.defaultPrivateKey = "default-sk"
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "default-pk", PrivateKey: "default-sk"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -1033,16 +972,8 @@ func TestQuotaSetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
 	}
-	if got := rt.prov.markCalls.Load(); got != 1 {
-		t.Fatalf("mark calls = %d, want 1", got)
-	}
-	calls := rt.prov.callsSnapshot()
-	if len(calls) != 1 || calls[0] != "mark" {
-		t.Fatalf("calls = %#v, want mark only", calls)
-	}
-	lastCredentials := rt.prov.lastCredentialsSnapshot()
-	if lastCredentials.PublicKey != "default-pk" || lastCredentials.PrivateKey != "default-sk" {
-		t.Fatalf("last credentials = %#v", lastCredentials)
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("mark calls = %d, want 0", got)
 	}
 }
 
@@ -1129,8 +1060,8 @@ func TestQuotaSetRejectsNonCloudNativeTenant(t *testing.T) {
 		"max_storage_size": int64(1000),
 	}, "")
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusConflict {
-		t.Fatalf("status = %d, want 409", resp.StatusCode)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
 	}
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
@@ -1138,77 +1069,24 @@ func TestQuotaSetRejectsNonCloudNativeTenant(t *testing.T) {
 }
 
 func TestQuotaGetMapsTiDBCloudCredentialErrors(t *testing.T) {
-	for _, tc := range []struct {
-		name       string
-		err        error
-		wantStatus int
-	}{
-		{name: "forbidden", err: tenant.ErrQuotaPermissionDenied, wantStatus: http.StatusForbidden},
-		{name: "not_found", err: tenant.ErrQuotaBackendNotFound, wantStatus: http.StatusNotFound},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-			rt.prov.getErr = tc.err
-			ts := httptest.NewServer(rt.server)
-			defer ts.Close()
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
 
-			resp := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != tc.wantStatus {
-				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
-			}
-			if got := rt.prov.getCalls.Load(); got != 1 {
-				t.Fatalf("get calls = %d, want 1", got)
-			}
-		})
+	resp := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("get calls = %d, want 0", got)
 	}
 }
 
 func TestQuotaSetMapsTiDBCloudCredentialErrorsWithoutWritingConfig(t *testing.T) {
-	for _, tc := range []struct {
-		name       string
-		err        error
-		wantStatus int
-	}{
-		{name: "forbidden", err: tenant.ErrQuotaPermissionDenied, wantStatus: http.StatusForbidden},
-		{name: "not_found", err: tenant.ErrQuotaBackendNotFound, wantStatus: http.StatusNotFound},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-			rt.prov.markErr = tc.err
-			ts := httptest.NewServer(rt.server)
-			defer ts.Close()
-
-			resp := postJSON(t, ts.URL+"/v1/quota", map[string]any{
-				"tenant_id":        rt.tenantID,
-				"public_key":       "public-1",
-				"private_key":      "private-1",
-				"max_storage_size": int64(1000),
-			}, "")
-			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != tc.wantStatus {
-				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
-			}
-			version, err := rt.meta.GetQuotaConfigVersion(context.Background(), rt.tenantID)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if version != "" {
-				t.Fatalf("quota config version = %q, want empty", version)
-			}
-			if got := rt.prov.markCalls.Load(); got != 1 {
-				t.Fatalf("mark calls = %d, want 1", got)
-			}
-			if got := rt.prov.updateCalls.Load(); got != 0 {
-				t.Fatalf("update calls = %d, want 0", got)
-			}
-		})
-	}
-}
-
-func TestQuotaSetHidesGenericTiDBCloudQuotaError(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.prov.markErr = errors.New("upstream leaked detail")
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -1219,21 +1097,42 @@ func TestQuotaSetHidesGenericTiDBCloudQuotaError(t *testing.T) {
 		"max_storage_size": int64(1000),
 	}, "")
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusBadGateway {
-		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	raw, err := io.ReadAll(resp.Body)
+	version, err := rt.meta.GetQuotaConfigVersion(context.Background(), rt.tenantID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(raw), "tidbcloud quota update failed") {
-		t.Fatalf("body = %q, want stable quota failure message", raw)
+	if version == "" {
+		t.Fatalf("quota config version should be non-empty when config was written")
 	}
-	if strings.Contains(string(raw), "upstream leaked detail") {
-		t.Fatalf("body leaked upstream detail: %q", raw)
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("mark calls = %d, want 0", got)
 	}
-	if got := rt.prov.markCalls.Load(); got != 1 {
-		t.Fatalf("mark calls = %d, want 1", got)
+	if got := rt.prov.updateCalls.Load(); got != 0 {
+		t.Fatalf("update calls = %d, want 0", got)
+	}
+}
+
+func TestQuotaSetHidesGenericTiDBCloudQuotaError(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+
+	resp := postJSON(t, ts.URL+"/v1/quota", map[string]any{
+		"tenant_id":        rt.tenantID,
+		"public_key":       "public-1",
+		"private_key":      "private-1",
+		"max_storage_size": int64(1000),
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("mark calls = %d, want 0", got)
 	}
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -475,7 +475,7 @@ func TestQuotaGetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.defaultPublicKey = "default-pk"
 	rt.prov.defaultPrivateKey = "default-sk"
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "default-pk", PrivateKey: "default-sk"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "default-pk", PrivateKey: "default-sk"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -494,14 +494,16 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	spendingLimit := int64(10000)
 	ctx := context.Background()
 	if err := rt.meta.SetQuotaConfig(ctx, &meta.QuotaConfig{
-		TenantID:                  rt.tenantID,
-		MaxStorageBytes:           123 * quotaStorageSizeBytes,
-		MaxFileSizeBytes:          12 * quotaStorageSizeBytes,
-		MaxFileCount:              34,
-		MaxMediaLLMFiles:          56,
-		MaxMonthlyCostMC:          789,
-		TiDBCloudSpendingLimit:    &spendingLimit,
+		TenantID:         rt.tenantID,
+		MaxStorageBytes:  123 * quotaStorageSizeBytes,
+		MaxFileSizeBytes: 12 * quotaStorageSizeBytes,
+		MaxFileCount:     34,
+		MaxMediaLLMFiles: 56,
+		MaxMonthlyCostMC: 789,
 	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &spendingLimit}); err != nil {
 		t.Fatal(err)
 	}
 	if err := rt.meta.EnsureQuotaUsageRow(ctx, rt.tenantID); err != nil {
@@ -513,7 +515,7 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	if err := rt.meta.IncrReservedBytes(ctx, rt.tenantID, 11); err != nil {
 		t.Fatal(err)
 	}
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
@@ -616,7 +618,7 @@ func TestSyncTiDBCloudSpendingLimitSkipsNewerLocalAtSameTimestampTick(t *testing
 
 func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -628,6 +630,9 @@ func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	if got := rt.prov.getCalls.Load(); got != 0 {
 		t.Fatalf("get calls = %d, want 0", got)
 	}
+	if got := rt.prov.updateCalls.Load(); got != 0 {
+		t.Fatalf("update calls = %d, want 0", got)
+	}
 }
 
 func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
@@ -637,7 +642,7 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &spendingLimit}); err != nil {
 		t.Fatal(err)
 	}
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -648,7 +653,18 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 		t.Fatalf("first status = %d, want 200: %s", resp.StatusCode, body)
 	}
 	_ = resp.Body.Close()
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("get calls after first request = %d, want 0", got)
+	}
+	cfg, err := rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
+		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)
+	}
 
+	rt.prov.getErr = errors.New("should not call TiDB Cloud while RBAC cache and local spending limit are present")
 	resp2 := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
 	defer func() { _ = resp2.Body.Close() }()
 	if resp2.StatusCode != http.StatusOK {
@@ -662,30 +678,37 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 	if out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
 		t.Fatalf("response spending limit = %#v, want %d", out.Config.TiDBCloudSpendingLimit, spendingLimit)
 	}
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("get calls after cached request = %d, want 0", got)
+	}
 
+	rt.prov.getErr = nil
 	updatedLimit := int64(333)
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-2"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &updatedLimit}); err != nil {
 		t.Fatal(err)
 	}
-
+	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-2"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	resp3 := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-2", "")
 	defer func() { _ = resp3.Body.Close() }()
 	if resp3.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp3.Body)
 		t.Fatalf("third status = %d, want 200: %s", resp3.StatusCode, body)
 	}
-	if err := json.NewDecoder(resp3.Body).Decode(&out); err != nil {
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("get calls after new credential = %d, want 0", got)
+	}
+	cfg, err = rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != updatedLimit {
-		t.Fatalf("updated spending limit = %#v, want %d", out.Config.TiDBCloudSpendingLimit, updatedLimit)
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != updatedLimit {
+		t.Fatalf("updated spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, updatedLimit)
 	}
 }
 
 func TestDeprecatedQuotaGetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -716,7 +739,16 @@ func TestQuotaSetChecksClusterWritePermissionBeforeMaxStorageUpdate(t *testing.T
 	}); err != nil {
 		t.Fatal(err)
 	}
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.prov.markHook = func() error {
+		cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
+		if err != nil {
+			return err
+		}
+		if cfg.MaxStorageBytes != 100 {
+			return fmt.Errorf("max storage bytes before label patch = %d, want old value 100", cfg.MaxStorageBytes)
+		}
+		return nil
+	}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -733,8 +765,12 @@ func TestQuotaSetChecksClusterWritePermissionBeforeMaxStorageUpdate(t *testing.T
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
 	}
-	if got := rt.prov.markCalls.Load(); got != 0 {
-		t.Fatalf("mark calls = %d, want 0", got)
+	if got := rt.prov.markCalls.Load(); got != 1 {
+		t.Fatalf("mark calls = %d, want 1", got)
+	}
+	calls := rt.prov.callsSnapshot()
+	if len(calls) != 1 || calls[0] != "mark" {
+		t.Fatalf("calls = %#v, want mark only", calls)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
 	if err != nil {
@@ -747,7 +783,6 @@ func TestQuotaSetChecksClusterWritePermissionBeforeMaxStorageUpdate(t *testing.T
 
 func TestDeprecatedQuotaSetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -762,8 +797,8 @@ func TestDeprecatedQuotaSetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 200 without tenant-org binding: %s", resp.StatusCode, body)
 	}
-	if got := rt.prov.markCalls.Load(); got != 0 {
-		t.Fatalf("mark calls = %d, want 0", got)
+	if got := rt.prov.markCalls.Load(); got != 1 {
+		t.Fatalf("mark calls = %d, want 1", got)
 	}
 	if got := rt.prov.listCalls.Load(); got != 0 {
 		t.Fatalf("list calls = %d, want 0", got)
@@ -810,7 +845,16 @@ func TestQuotaSetChecksClusterWritePermissionBeforeFileLimitUpdate(t *testing.T)
 	}); err != nil {
 		t.Fatal(err)
 	}
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.prov.markHook = func() error {
+		cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
+		if err != nil {
+			return err
+		}
+		if cfg.MaxFileSizeBytes != 200 || cfg.MaxFileCount != 300 {
+			return fmt.Errorf("file limits before label patch = size:%d count:%d, want old values", cfg.MaxFileSizeBytes, cfg.MaxFileCount)
+		}
+		return nil
+	}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -828,8 +872,12 @@ func TestQuotaSetChecksClusterWritePermissionBeforeFileLimitUpdate(t *testing.T)
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
 	}
-	if got := rt.prov.markCalls.Load(); got != 0 {
-		t.Fatalf("mark calls = %d, want 0", got)
+	if got := rt.prov.markCalls.Load(); got != 1 {
+		t.Fatalf("mark calls = %d, want 1", got)
+	}
+	calls := rt.prov.callsSnapshot()
+	if len(calls) != 1 || calls[0] != "mark" {
+		t.Fatalf("calls = %#v, want mark only", calls)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
 	if err != nil {
@@ -843,7 +891,7 @@ func TestQuotaSetChecksClusterWritePermissionBeforeFileLimitUpdate(t *testing.T)
 func TestQuotaSetSpendingLimitOnlyPersistsSpendingLimitConfig(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	spendingLimit := int64(0)
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -857,11 +905,19 @@ func TestQuotaSetSpendingLimitOnlyPersistsSpendingLimitConfig(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d", resp.StatusCode)
 	}
-	if got := rt.prov.updateCalls.Load(); got != 0 {
-		t.Fatalf("update calls = %d, want 0", got)
+	if got := rt.prov.updateCalls.Load(); got != 1 {
+		t.Fatalf("update calls = %d, want 1", got)
 	}
-	if got := rt.prov.markCalls.Load(); got != 0 {
-		t.Fatalf("mark calls = %d, want 0", got)
+	if got := rt.prov.markCalls.Load(); got != 1 {
+		t.Fatalf("mark calls = %d, want 1", got)
+	}
+	calls := rt.prov.callsSnapshot()
+	if len(calls) != 2 || calls[0] != "mark" || calls[1] != "update" {
+		t.Fatalf("calls = %#v, want mark before update", calls)
+	}
+	lastOptions := rt.prov.lastOptionsSnapshot()
+	if lastOptions.TiDBCloudSpendingLimitMonthly == nil || *lastOptions.TiDBCloudSpendingLimitMonthly != spendingLimit {
+		t.Fatalf("spending limit option = %#v, want %d", lastOptions.TiDBCloudSpendingLimitMonthly, spendingLimit)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
 	if err != nil {
@@ -955,7 +1011,6 @@ func TestQuotaSetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.defaultPublicKey = "default-pk"
 	rt.prov.defaultPrivateKey = "default-sk"
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "default-pk", PrivateKey: "default-sk"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -972,8 +1027,16 @@ func TestQuotaSetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
 	}
-	if got := rt.prov.markCalls.Load(); got != 0 {
-		t.Fatalf("mark calls = %d, want 0", got)
+	if got := rt.prov.markCalls.Load(); got != 1 {
+		t.Fatalf("mark calls = %d, want 1", got)
+	}
+	calls := rt.prov.callsSnapshot()
+	if len(calls) != 1 || calls[0] != "mark" {
+		t.Fatalf("calls = %#v, want mark only", calls)
+	}
+	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	if lastCredentials.PublicKey != "default-pk" || lastCredentials.PrivateKey != "default-sk" {
+		t.Fatalf("last credentials = %#v", lastCredentials)
 	}
 }
 
@@ -1060,8 +1123,8 @@ func TestQuotaSetRejectsNonCloudNativeTenant(t *testing.T) {
 		"max_storage_size": int64(1000),
 	}, "")
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", resp.StatusCode)
 	}
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
@@ -1069,55 +1132,75 @@ func TestQuotaSetRejectsNonCloudNativeTenant(t *testing.T) {
 }
 
 func TestQuotaGetMapsTiDBCloudCredentialErrors(t *testing.T) {
-	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
-	ts := httptest.NewServer(rt.server)
-	defer ts.Close()
+	for _, tc := range []struct {
+		name string
+	}{
+		{name: "forbidden"},
+		{name: "not_found"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+			rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+			ts := httptest.NewServer(rt.server)
+			defer ts.Close()
 
-	resp := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200", resp.StatusCode)
-	}
-	if got := rt.prov.getCalls.Load(); got != 0 {
-		t.Fatalf("get calls = %d, want 0", got)
+			resp := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != http.StatusOK {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+			}
+			if got := rt.prov.getCalls.Load(); got != 0 {
+				t.Fatalf("get calls = %d, want 0", got)
+			}
+		})
 	}
 }
 
 func TestQuotaSetMapsTiDBCloudCredentialErrorsWithoutWritingConfig(t *testing.T) {
-	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
-	ts := httptest.NewServer(rt.server)
-	defer ts.Close()
+	for _, tc := range []struct {
+		name       string
+		err        error
+		wantStatus int
+	}{
+		{name: "forbidden", err: tenant.ErrQuotaPermissionDenied, wantStatus: http.StatusForbidden},
+		{name: "not_found", err: tenant.ErrQuotaBackendNotFound, wantStatus: http.StatusNotFound},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+			rt.prov.markErr = tc.err
+			ts := httptest.NewServer(rt.server)
+			defer ts.Close()
 
-	resp := postJSON(t, ts.URL+"/v1/quota", map[string]any{
-		"tenant_id":        rt.tenantID,
-		"public_key":       "public-1",
-		"private_key":      "private-1",
-		"max_storage_size": int64(1000),
-	}, "")
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200", resp.StatusCode)
-	}
-	version, err := rt.meta.GetQuotaConfigVersion(context.Background(), rt.tenantID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if version == "" {
-		t.Fatalf("quota config version should be non-empty when config was written")
-	}
-	if got := rt.prov.markCalls.Load(); got != 0 {
-		t.Fatalf("mark calls = %d, want 0", got)
-	}
-	if got := rt.prov.updateCalls.Load(); got != 0 {
-		t.Fatalf("update calls = %d, want 0", got)
+			resp := postJSON(t, ts.URL+"/v1/quota", map[string]any{
+				"tenant_id":        rt.tenantID,
+				"public_key":       "public-1",
+				"private_key":      "private-1",
+				"max_storage_size": int64(1000),
+			}, "")
+			defer func() { _ = resp.Body.Close() }()
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
+			}
+			version, err := rt.meta.GetQuotaConfigVersion(context.Background(), rt.tenantID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if version != "" {
+				t.Fatalf("quota config version = %q, want empty", version)
+			}
+			if got := rt.prov.markCalls.Load(); got != 1 {
+				t.Fatalf("mark calls = %d, want 1", got)
+			}
+			if got := rt.prov.updateCalls.Load(); got != 0 {
+				t.Fatalf("update calls = %d, want 0", got)
+			}
+		})
 	}
 }
 
 func TestQuotaSetHidesGenericTiDBCloudQuotaError(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.tidbCloudRBACCache.rememberCluster(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.prov.markErr = errors.New("upstream leaked detail")
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -1128,11 +1211,21 @@ func TestQuotaSetHidesGenericTiDBCloudQuotaError(t *testing.T) {
 		"max_storage_size": int64(1000),
 	}, "")
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
 	}
-	if got := rt.prov.markCalls.Load(); got != 0 {
-		t.Fatalf("mark calls = %d, want 0", got)
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "tidbcloud quota update failed") {
+		t.Fatalf("body = %q, want stable quota failure message", raw)
+	}
+	if strings.Contains(string(raw), "upstream leaked detail") {
+		t.Fatalf("body leaked upstream detail: %q", raw)
+	}
+	if got := rt.prov.markCalls.Load(); got != 1 {
+		t.Fatalf("mark calls = %d, want 1", got)
 	}
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -939,8 +939,8 @@ func TestQuotaSetSpendingLimitOnlyPersistsSpendingLimitConfig(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if version != "" {
-		t.Fatalf("storage quota config version = %q, want empty", version)
+	if version == "" {
+		t.Fatalf("storage quota config version should be non-empty when config row exists")
 	}
 	var out quotaResponse
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -475,7 +475,6 @@ func TestQuotaGetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.defaultPublicKey = "default-pk"
 	rt.prov.defaultPrivateKey = "default-sk"
-	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "default-pk", PrivateKey: "default-sk"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -484,14 +483,19 @@ func TestQuotaGetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	if got := rt.prov.getCalls.Load(); got != 0 {
-		t.Fatalf("get calls = %d, want 0", got)
+	if got := rt.prov.getCalls.Load(); got != 1 {
+		t.Fatalf("get calls = %d, want 1", got)
+	}
+	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	if lastCredentials.PublicKey != "default-pk" || lastCredentials.PrivateKey != "default-sk" {
+		t.Fatalf("last credentials = %#v", lastCredentials)
 	}
 }
 
 func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	spendingLimit := int64(10000)
+	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
 	ctx := context.Background()
 	if err := rt.meta.SetQuotaConfig(ctx, &meta.QuotaConfig{
 		TenantID:         rt.tenantID,
@@ -503,9 +507,6 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &spendingLimit}); err != nil {
-		t.Fatal(err)
-	}
 	if err := rt.meta.EnsureQuotaUsageRow(ctx, rt.tenantID); err != nil {
 		t.Fatal(err)
 	}
@@ -515,7 +516,6 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	if err := rt.meta.IncrReservedBytes(ctx, rt.tenantID, 11); err != nil {
 		t.Fatal(err)
 	}
-	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
@@ -538,6 +538,13 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	}
 	if out.Config.MaxStorageSize != 123 || out.Config.MaxFileSize != 12 || out.Config.MaxFileCount != 34 || out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
 		t.Fatalf("config = %#v", out.Config)
+	}
+	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
+		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)
 	}
 	if out.Usage.StorageBytes != 321 || out.Usage.ReservedBytes != 11 || out.Usage.FileCount != 9 {
 		t.Fatalf("usage = %#v", out.Usage)
@@ -618,7 +625,6 @@ func TestSyncTiDBCloudSpendingLimitSkipsNewerLocalAtSameTimestampTick(t *testing
 
 func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -627,22 +633,26 @@ func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d", resp.StatusCode)
 	}
-	if got := rt.prov.getCalls.Load(); got != 0 {
-		t.Fatalf("get calls = %d, want 0", got)
+	if got := rt.prov.getCalls.Load(); got != 1 {
+		t.Fatalf("get calls = %d, want 1", got)
 	}
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
+	}
+	lastCluster := rt.prov.lastClusterSnapshot()
+	if lastCluster == nil || lastCluster.ClusterID != "cluster-quota-1" || lastCluster.TenantID != rt.tenantID {
+		t.Fatalf("last cluster = %#v", lastCluster)
+	}
+	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	if lastCredentials.PublicKey != "public-1" || lastCredentials.PrivateKey != "private-1" {
+		t.Fatalf("last credentials = %#v", lastCredentials)
 	}
 }
 
 func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	spendingLimit := int64(222)
-	ctx := context.Background()
-	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &spendingLimit}); err != nil {
-		t.Fatal(err)
-	}
-	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -653,8 +663,8 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 		t.Fatalf("first status = %d, want 200: %s", resp.StatusCode, body)
 	}
 	_ = resp.Body.Close()
-	if got := rt.prov.getCalls.Load(); got != 0 {
-		t.Fatalf("get calls after first request = %d, want 0", got)
+	if got := rt.prov.getCalls.Load(); got != 1 {
+		t.Fatalf("get calls after first request = %d, want 1", got)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
 	if err != nil {
@@ -678,24 +688,21 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 	if out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
 		t.Fatalf("response spending limit = %#v, want %d", out.Config.TiDBCloudSpendingLimit, spendingLimit)
 	}
-	if got := rt.prov.getCalls.Load(); got != 0 {
-		t.Fatalf("get calls after cached request = %d, want 0", got)
+	if got := rt.prov.getCalls.Load(); got != 1 {
+		t.Fatalf("get calls after cached request = %d, want 1", got)
 	}
 
 	rt.prov.getErr = nil
 	updatedLimit := int64(333)
-	if err := rt.meta.SetQuotaConfigPatch(ctx, rt.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &updatedLimit}); err != nil {
-		t.Fatal(err)
-	}
-	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-2"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &updatedLimit}
 	resp3 := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-2", "")
 	defer func() { _ = resp3.Body.Close() }()
 	if resp3.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp3.Body)
 		t.Fatalf("third status = %d, want 200: %s", resp3.StatusCode, body)
 	}
-	if got := rt.prov.getCalls.Load(); got != 0 {
-		t.Fatalf("get calls after new credential = %d, want 0", got)
+	if got := rt.prov.getCalls.Load(); got != 2 {
+		t.Fatalf("get calls after new credential = %d, want 2", got)
 	}
 	cfg, err = rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
 	if err != nil {
@@ -708,7 +715,6 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 
 func TestDeprecatedQuotaGetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -718,8 +724,8 @@ func TestDeprecatedQuotaGetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 200 without tenant-org binding: %s", resp.StatusCode, body)
 	}
-	if got := rt.prov.getCalls.Load(); got != 0 {
-		t.Fatalf("get calls = %d, want 0", got)
+	if got := rt.prov.getCalls.Load(); got != 1 {
+		t.Fatalf("get calls = %d, want 1", got)
 	}
 	if got := rt.prov.listCalls.Load(); got != 0 {
 		t.Fatalf("list calls = %d, want 0", got)
@@ -1133,24 +1139,26 @@ func TestQuotaSetRejectsNonCloudNativeTenant(t *testing.T) {
 
 func TestQuotaGetMapsTiDBCloudCredentialErrors(t *testing.T) {
 	for _, tc := range []struct {
-		name string
+		name       string
+		err        error
+		wantStatus int
 	}{
-		{name: "forbidden"},
-		{name: "not_found"},
+		{name: "forbidden", err: tenant.ErrQuotaPermissionDenied, wantStatus: http.StatusForbidden},
+		{name: "not_found", err: tenant.ErrQuotaBackendNotFound, wantStatus: http.StatusNotFound},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-			rt.server.rememberTiDBCloudRBAC(tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, tenant.CloudClusterInfo{ClusterID: "cluster-quota-1"})
+			rt.prov.getErr = tc.err
 			ts := httptest.NewServer(rt.server)
 			defer ts.Close()
 
 			resp := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
 			defer func() { _ = resp.Body.Close() }()
-			if resp.StatusCode != http.StatusOK {
-				t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+			if resp.StatusCode != tc.wantStatus {
+				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
 			}
-			if got := rt.prov.getCalls.Load(); got != 0 {
-				t.Fatalf("get calls = %d, want 0", got)
+			if got := rt.prov.getCalls.Load(); got != 1 {
+				t.Fatalf("get calls = %d, want 1", got)
 			}
 		})
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5212,7 +5212,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	if opts.Quota != nil {
 		qp, err := quotaConfigPatchFromRequest(*opts.Quota)
 		if err != nil {
-			logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
+			logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_patch_invalid", "tenant_id", tenantID, "provider", provider, "error", err)...)
 			metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
 			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to set tenant quota", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5205,21 +5205,30 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	}
 	logProvisionStage(ctx, "provision_tenant_status_updated", tenantID, provider, stageStarted, "status", meta.TenantProvisioning)
 
+	stageStarted = time.Now()
+	quotaSeed := meta.QuotaConfigPatch{
+		TiDBCloudSpendingLimit: tidbCloudSpendingLimitFromCloud(provisionCloudCfg),
+	}
 	if opts.Quota != nil {
-		stageStarted = time.Now()
-		quotaReq := *opts.Quota
-		quotaReq.TenantID = tenantID
-		if err := s.applyQuotaLocalConfig(ctx, "provision", tenantID, quotaReq); err != nil {
+		qp, err := quotaConfigPatchFromRequest(*opts.Quota)
+		if err != nil {
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_quota_update_failed", "tenant_id", tenantID, "provider", provider, "error", err)...)
 			metricEvent(ctx, "tenant_provision", "provider", provider, "result", "quota_error")
 			s.cleanupProvisionedClusterAfterProvisionFailure(ctx, tenantID, provider, cluster, opts.CredentialProvisioner, "quota_error")
 			return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to set tenant quota", err)
 		}
-		logProvisionStage(ctx, "provision_quota_local_config_applied", tenantID, provider, stageStarted)
-	}
-	stageStarted = time.Now()
-	quotaSeed := meta.QuotaConfigPatch{
-		TiDBCloudSpendingLimit: tidbCloudSpendingLimitFromCloud(provisionCloudCfg),
+		if qp.MaxStorageBytes != nil {
+			quotaSeed.MaxStorageBytes = qp.MaxStorageBytes
+		}
+		if qp.MaxFileSizeBytes != nil {
+			quotaSeed.MaxFileSizeBytes = qp.MaxFileSizeBytes
+		}
+		if qp.MaxFileCount != nil {
+			quotaSeed.MaxFileCount = qp.MaxFileCount
+		}
+		if qp.TiDBCloudSpendingLimit != nil {
+			quotaSeed.TiDBCloudSpendingLimit = qp.TiDBCloudSpendingLimit
+		}
 	}
 	if provisionCloudCfg != nil {
 		checkedAt := time.Now().UTC()

--- a/pkg/tenant/quota_adapter.go
+++ b/pkg/tenant/quota_adapter.go
@@ -56,6 +56,7 @@ func (a *metaQuotaAdapter) GetQuotaUsage(ctx context.Context, tenantID string) (
 		ReservedBytes:  u.ReservedBytes,
 		FileCount:      u.FileCount,
 		MediaFileCount: u.MediaFileCount,
+		VideoFileCount: u.VideoFileCount,
 	}, nil
 }
 
@@ -106,6 +107,14 @@ func (a *metaQuotaAdapter) IncrMediaFileCount(ctx context.Context, tenantID stri
 
 func (a *metaQuotaAdapter) IncrMediaFileCountTx(tx *sql.Tx, tenantID string, delta int64) error {
 	return a.s.IncrMediaFileCountTx(tx, tenantID, delta)
+}
+
+func (a *metaQuotaAdapter) IncrVideoFileCount(ctx context.Context, tenantID string, delta int64) error {
+	return a.s.IncrVideoFileCount(ctx, tenantID, delta)
+}
+
+func (a *metaQuotaAdapter) IncrVideoFileCountTx(tx *sql.Tx, tenantID string, delta int64) error {
+	return a.s.IncrVideoFileCountTx(tx, tenantID, delta)
 }
 
 func (a *metaQuotaAdapter) TransferReservedToConfirmed(ctx context.Context, tenantID string, reservedDelta, storageDelta int64) error {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -2065,11 +2065,23 @@ func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privat
 	}
 	req.Header.Set("Content-Type", "application/json")
 
+	start := time.Now()
 	resp, err := p.client.Do(req)
 	if err != nil {
+		logger.Error(ctx, "tidbcloud_api_request",
+			zap.String("method", method),
+			zap.String("path", requestPath(uri)),
+			zap.String("result", "error"),
+			zap.Duration("duration_ms", time.Since(start)),
+			zap.Error(err))
 		return nil, err
 	}
 	if resp.StatusCode != http.StatusUnauthorized {
+		logger.Info(ctx, "tidbcloud_api_request",
+			zap.String("method", method),
+			zap.String("path", requestPath(uri)),
+			zap.Int("status", resp.StatusCode),
+			zap.Duration("duration_ms", time.Since(start)))
 		return resp, nil
 	}
 	_ = resp.Body.Close()
@@ -2089,7 +2101,31 @@ func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privat
 	}
 	req2.Header.Set("Content-Type", "application/json")
 	req2.Header.Set("Authorization", auth)
-	return p.client.Do(req2)
+	start2 := time.Now()
+	resp2, err := p.client.Do(req2)
+	if err != nil {
+		logger.Error(ctx, "tidbcloud_api_request",
+			zap.String("method", method),
+			zap.String("path", requestPath(uri)),
+			zap.String("result", "error"),
+			zap.Duration("duration_ms", time.Since(start2)),
+			zap.Error(err))
+		return nil, err
+	}
+	logger.Info(ctx, "tidbcloud_api_request",
+		zap.String("method", method),
+		zap.String("path", requestPath(uri)),
+		zap.Int("status", resp2.StatusCode),
+		zap.Duration("duration_ms", time.Since(start2)))
+	return resp2, nil
+}
+
+func requestPath(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return uri
+	}
+	return u.Path
 }
 
 func parseDigestChallenge(header string) (nonce, realm, qop string) {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -65,6 +65,13 @@ const (
 	upstreamClusterBodyLimit = 1 << 20
 )
 
+var (
+	immutableLabelKeys = []string{
+		"tidb.cloud/project",
+		TiDBCloudOrganizationLabel,
+	}
+)
+
 var databaseNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)
 var displayNameCharPattern = regexp.MustCompile(`[^A-Za-z0-9-]`)
 
@@ -764,6 +771,9 @@ func (p *Provisioner) MarkClusterPoolUsed(ctx context.Context, cluster *tenant.C
 	}
 	labels[Drive9PoolStatusLabel] = "used"
 	labels[Drive9PoolUsedAtLabel] = usedAt.UTC().Format(time.RFC3339)
+	for _, k := range immutableLabelKeys {
+		delete(labels, k)
+	}
 	if err := p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels); err != nil {
 		return nil, fmt.Errorf("update cluster pool labels: %w", err)
 	}
@@ -798,6 +808,9 @@ func (p *Provisioner) MarkClusterPoolFree(ctx context.Context, cluster *tenant.C
 	}
 	labels[Drive9PoolStatusLabel] = "free"
 	delete(labels, Drive9PoolUsedAtLabel)
+	for _, k := range immutableLabelKeys {
+		delete(labels, k)
+	}
 	return p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels)
 }
 
@@ -1038,6 +1051,9 @@ func (p *Provisioner) MarkQuotaUpdateStarted(ctx context.Context, cluster *tenan
 		labels[Drive9TenantIDLabel] = tenantID
 	}
 	labels[Drive9QuotaUpdateAtLabel] = strconv.FormatInt(time.Now().UTC().Unix(), 10)
+	for _, k := range immutableLabelKeys {
+		delete(labels, k)
+	}
 	if err := p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels); err != nil {
 		return nil, fmt.Errorf("update cluster quota labels: %w", err)
 	}

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -65,8 +65,6 @@ const (
 	upstreamClusterBodyLimit = 1 << 20
 )
 
-var ()
-
 var databaseNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)
 var displayNameCharPattern = regexp.MustCompile(`[^A-Za-z0-9-]`)
 
@@ -756,19 +754,20 @@ func (p *Provisioner) MarkClusterPoolUsed(ctx context.Context, cluster *tenant.C
 		}
 	}
 	clusterID := strings.TrimSpace(cluster.ClusterID)
-	labels := map[string]string{
-		Drive9ManagedLabel:   "true",
-		Drive9PoolStatusLabel: "used",
-		Drive9PoolUsedAtLabel: usedAt.UTC().Format(time.RFC3339),
+	labels, err := p.getClusterLabelsWithCredentials(ctx, publicKey, privateKey, clusterID)
+	if err != nil {
+		return nil, fmt.Errorf("load cluster labels: %w", err)
 	}
+	labels[Drive9ManagedLabel] = "true"
 	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
 		labels[Drive9TenantIDLabel] = tenantID
 	}
-	cloudCfg := &tenant.QuotaCloudConfig{}
+	labels[Drive9PoolStatusLabel] = "used"
+	labels[Drive9PoolUsedAtLabel] = usedAt.UTC().Format(time.RFC3339)
 	if err := p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels); err != nil {
 		return nil, fmt.Errorf("update cluster pool labels: %w", err)
 	}
-	cloudCfg.Labels = labels
+	cloudCfg := &tenant.QuotaCloudConfig{Labels: labels}
 	if opts.TiDBCloudSpendingLimitMonthly != nil {
 		monthly := *opts.TiDBCloudSpendingLimitMonthly
 		if err := p.updateSpendingLimitWithCredentials(ctx, publicKey, privateKey, clusterID, monthly); err != nil {
@@ -789,13 +788,16 @@ func (p *Provisioner) MarkClusterPoolFree(ctx context.Context, cluster *tenant.C
 		return fmt.Errorf("cluster id is required")
 	}
 	clusterID := strings.TrimSpace(cluster.ClusterID)
-	labels := map[string]string{
-		Drive9ManagedLabel:   "true",
-		Drive9PoolStatusLabel: "free",
+	labels, err := p.getClusterLabelsWithCredentials(ctx, publicKey, privateKey, clusterID)
+	if err != nil {
+		return fmt.Errorf("load cluster labels: %w", err)
 	}
+	labels[Drive9ManagedLabel] = "true"
 	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
 		labels[Drive9TenantIDLabel] = tenantID
 	}
+	labels[Drive9PoolStatusLabel] = "free"
+	delete(labels, Drive9PoolUsedAtLabel)
 	return p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels)
 }
 
@@ -1027,18 +1029,19 @@ func (p *Provisioner) MarkQuotaUpdateStarted(ctx context.Context, cluster *tenan
 		return nil, fmt.Errorf("cluster id is required")
 	}
 	clusterID := strings.TrimSpace(cluster.ClusterID)
-	labels := map[string]string{
-		Drive9ManagedLabel:     "true",
-		Drive9QuotaUpdateAtLabel: strconv.FormatInt(time.Now().UTC().Unix(), 10),
+	labels, err := p.getClusterLabelsWithCredentials(ctx, publicKey, privateKey, clusterID)
+	if err != nil {
+		return nil, fmt.Errorf("load cluster labels: %w", err)
 	}
+	labels[Drive9ManagedLabel] = "true"
 	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
 		labels[Drive9TenantIDLabel] = tenantID
 	}
-	cloudCfg := &tenant.QuotaCloudConfig{}
+	labels[Drive9QuotaUpdateAtLabel] = strconv.FormatInt(time.Now().UTC().Unix(), 10)
 	if err := p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels); err != nil {
 		return nil, fmt.Errorf("update cluster quota labels: %w", err)
 	}
-	cloudCfg.Labels = labels
+	cloudCfg := &tenant.QuotaCloudConfig{Labels: labels}
 	return cloudCfg, nil
 }
 
@@ -1162,6 +1165,21 @@ func (p *Provisioner) listClusterInfosPageWithCredentials(ctx context.Context, p
 		return nil, "", fmt.Errorf("parse cluster list: %w", err)
 	}
 	return list.Clusters, strings.TrimSpace(list.NextPageToken), nil
+}
+
+func (p *Provisioner) getClusterLabelsWithCredentials(ctx context.Context, publicKey, privateKey, clusterID string) (map[string]string, error) {
+	infos, _, err := p.listClusterInfosPageWithCredentials(ctx, publicKey, privateKey, []string{clusterID}, 1, "")
+	if err != nil {
+		return nil, fmt.Errorf("list cluster labels: %w", err)
+	}
+	if len(infos) == 0 {
+		return nil, fmt.Errorf("cluster %q not found", clusterID)
+	}
+	labels := make(map[string]string, len(infos[0].Labels))
+	for k, v := range infos[0].Labels {
+		labels[k] = v
+	}
+	return labels, nil
 }
 
 func (p *Provisioner) clusterQuotaInfo(ctx context.Context, publicKey, privateKey, clusterID string) (map[string]string, *tenant.QuotaCloudConfig, error) {
@@ -2072,7 +2090,7 @@ func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privat
 			zap.String("method", method),
 			zap.String("path", requestPath(uri)),
 			zap.String("result", "error"),
-			zap.Duration("duration_ms", time.Since(start)),
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()),
 			zap.Error(err))
 		return nil, err
 	}
@@ -2081,7 +2099,7 @@ func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privat
 			zap.String("method", method),
 			zap.String("path", requestPath(uri)),
 			zap.Int("status", resp.StatusCode),
-			zap.Duration("duration_ms", time.Since(start)))
+			zap.Int64("duration_ms", time.Since(start).Milliseconds()))
 		return resp, nil
 	}
 	_ = resp.Body.Close()
@@ -2108,7 +2126,7 @@ func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privat
 			zap.String("method", method),
 			zap.String("path", requestPath(uri)),
 			zap.String("result", "error"),
-			zap.Duration("duration_ms", time.Since(start2)),
+			zap.Int64("duration_ms", time.Since(start2).Milliseconds()),
 			zap.Error(err))
 		return nil, err
 	}
@@ -2116,7 +2134,7 @@ func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privat
 		zap.String("method", method),
 		zap.String("path", requestPath(uri)),
 		zap.Int("status", resp2.StatusCode),
-		zap.Duration("duration_ms", time.Since(start2)))
+		zap.Int64("duration_ms", time.Since(start2).Milliseconds()))
 	return resp2, nil
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1045,21 +1045,14 @@ func (p *Provisioner) MarkQuotaUpdateStarted(ctx context.Context, cluster *tenan
 		return nil, fmt.Errorf("cluster id is required")
 	}
 	clusterID := strings.TrimSpace(cluster.ClusterID)
-	labels, cloudCfg, err := p.clusterQuotaInfo(ctx, publicKey, privateKey, clusterID)
-	if err != nil {
-		return nil, fmt.Errorf("load cluster quota info: %w", err)
+	labels := map[string]string{
+		Drive9ManagedLabel:     "true",
+		Drive9QuotaUpdateAtLabel: strconv.FormatInt(time.Now().UTC().Unix(), 10),
 	}
-	if cloudCfg == nil {
-		cloudCfg = &tenant.QuotaCloudConfig{}
-	}
-	labels[Drive9ManagedLabel] = "true"
 	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
 		labels[Drive9TenantIDLabel] = tenantID
 	}
-	labels[Drive9QuotaUpdateAtLabel] = strconv.FormatInt(time.Now().UTC().Unix(), 10)
-	for _, k := range immutableLabelKeys {
-		delete(labels, k)
-	}
+	cloudCfg := &tenant.QuotaCloudConfig{}
 	if err := p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels); err != nil {
 		return nil, fmt.Errorf("update cluster quota labels: %w", err)
 	}

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -761,24 +761,17 @@ func (p *Provisioner) MarkClusterPoolUsed(ctx context.Context, cluster *tenant.C
 		}
 	}
 	clusterID := strings.TrimSpace(cluster.ClusterID)
-	labels, cloudCfg, err := p.clusterQuotaInfo(ctx, publicKey, privateKey, clusterID)
-	if err != nil {
-		return nil, fmt.Errorf("load cluster pool label info: %w", err)
+	labels := map[string]string{
+		Drive9ManagedLabel:   "true",
+		Drive9PoolStatusLabel: "used",
+		Drive9PoolUsedAtLabel: usedAt.UTC().Format(time.RFC3339),
 	}
-	labels[Drive9ManagedLabel] = "true"
 	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
 		labels[Drive9TenantIDLabel] = tenantID
 	}
-	labels[Drive9PoolStatusLabel] = "used"
-	labels[Drive9PoolUsedAtLabel] = usedAt.UTC().Format(time.RFC3339)
-	for _, k := range immutableLabelKeys {
-		delete(labels, k)
-	}
+	cloudCfg := &tenant.QuotaCloudConfig{}
 	if err := p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels); err != nil {
 		return nil, fmt.Errorf("update cluster pool labels: %w", err)
-	}
-	if cloudCfg == nil {
-		cloudCfg = &tenant.QuotaCloudConfig{}
 	}
 	cloudCfg.Labels = labels
 	if opts.TiDBCloudSpendingLimitMonthly != nil {
@@ -801,18 +794,12 @@ func (p *Provisioner) MarkClusterPoolFree(ctx context.Context, cluster *tenant.C
 		return fmt.Errorf("cluster id is required")
 	}
 	clusterID := strings.TrimSpace(cluster.ClusterID)
-	labels, _, err := p.clusterQuotaInfo(ctx, publicKey, privateKey, clusterID)
-	if err != nil {
-		return fmt.Errorf("load cluster pool label info: %w", err)
+	labels := map[string]string{
+		Drive9ManagedLabel:   "true",
+		Drive9PoolStatusLabel: "free",
 	}
-	labels[Drive9ManagedLabel] = "true"
 	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
 		labels[Drive9TenantIDLabel] = tenantID
-	}
-	labels[Drive9PoolStatusLabel] = "free"
-	delete(labels, Drive9PoolUsedAtLabel)
-	for _, k := range immutableLabelKeys {
-		delete(labels, k)
 	}
 	return p.updateQuotaLabelsWithCredentials(ctx, publicKey, privateKey, clusterID, labels)
 }

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1168,15 +1168,29 @@ func (p *Provisioner) listClusterInfosPageWithCredentials(ctx context.Context, p
 }
 
 func (p *Provisioner) getClusterLabelsWithCredentials(ctx context.Context, publicKey, privateKey, clusterID string) (map[string]string, error) {
-	infos, _, err := p.listClusterInfosPageWithCredentials(ctx, publicKey, privateKey, []string{clusterID}, 1, "")
+	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s?view=local", p.apiURL, url.PathEscape(clusterID))
+	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return nil, fmt.Errorf("list cluster labels: %w", err)
+		return nil, fmt.Errorf("get cluster labels: %w", err)
 	}
-	if len(infos) == 0 {
-		return nil, fmt.Errorf("cluster %q not found", clusterID)
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
+		if readErr != nil {
+			return nil, fmt.Errorf("read cluster get error body: %w", readErr)
+		}
+		return nil, quotaStatusError("cluster get", resp.StatusCode, sanitizeUpstreamBody(raw))
 	}
-	labels := make(map[string]string, len(infos[0].Labels))
-	for k, v := range infos[0].Labels {
+	raw, readErr := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
+	if readErr != nil {
+		return nil, fmt.Errorf("read cluster body: %w", readErr)
+	}
+	info, err := parseClusterInfo(raw)
+	if err != nil {
+		return nil, fmt.Errorf("parse cluster info: %w", err)
+	}
+	labels := make(map[string]string, len(info.Labels))
+	for k, v := range info.Labels {
 		labels[k] = v
 	}
 	return labels, nil

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -1168,7 +1168,7 @@ func (p *Provisioner) listClusterInfosPageWithCredentials(ctx context.Context, p
 }
 
 func (p *Provisioner) getClusterLabelsWithCredentials(ctx context.Context, publicKey, privateKey, clusterID string) (map[string]string, error) {
-	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s?view=local", p.apiURL, url.PathEscape(clusterID))
+	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s?view=BASIC", p.apiURL, url.PathEscape(clusterID))
 	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get cluster labels: %w", err)

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -65,12 +65,7 @@ const (
 	upstreamClusterBodyLimit = 1 << 20
 )
 
-var (
-	immutableLabelKeys = []string{
-		"tidb.cloud/project",
-		TiDBCloudOrganizationLabel,
-	}
-)
+var ()
 
 var databaseNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]{0,63}$`)
 var displayNameCharPattern = regexp.MustCompile(`[^A-Za-z0-9-]`)

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1156,21 +1156,17 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 		}
 		gotAuth = r.Header.Get("Authorization")
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
+		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters/cluster-1" && r.URL.RawQuery == "view=local":
 			order = append(order, "GET")
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"clusters": []map[string]any{
-					{
-						"clusterId": "cluster-1",
-						"labels": map[string]string{
-							"environment":             "prod",
-							Drive9ManagedLabel:        "old",
-							Drive9TenantIDLabel:       "old-tenant",
-							"drive9.ai/unrelated":     "keep",
-							"tidb.cloud/project":      "123",
-							"tidb.cloud/organization": "456",
-						},
-					},
+				"clusterId": "cluster-1",
+				"labels": map[string]string{
+					"environment":             "prod",
+					Drive9ManagedLabel:        "old",
+					Drive9TenantIDLabel:       "old-tenant",
+					"drive9.ai/unrelated":     "keep",
+					"tidb.cloud/project":      "123",
+					"tidb.cloud/organization": "456",
 				},
 			})
 			return

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1206,8 +1206,8 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 	if !patchCalled {
 		t.Fatal("PATCH was not called")
 	}
-	if len(order) != 2 || order[0] != "GET" || order[1] != "PATCH" {
-		t.Fatalf("order = %#v, want GET then PATCH", order)
+	if len(order) != 1 || order[0] != "PATCH" {
+		t.Fatalf("order = %#v, want PATCH only", order)
 	}
 	if !strings.Contains(gotAuth, `username="public-1"`) {
 		t.Fatalf("Authorization header did not use request public key: %q", gotAuth)
@@ -1216,23 +1216,14 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 		t.Fatalf("updateMask = %q, want labels", gotPatch.UpdateMask)
 	}
 	labels := gotPatch.Cluster.Labels
-	if labels["environment"] != "prod" || labels["drive9.ai/unrelated"] != "keep" {
-		t.Fatalf("existing labels were not preserved: %#v", labels)
-	}
-	if _, ok := labels["tidb.cloud/project"]; ok {
-		t.Fatalf("immutable label tidb.cloud/project was not stripped: %#v", labels)
-	}
-	if _, ok := labels["tidb.cloud/organization"]; ok {
-		t.Fatalf("immutable label tidb.cloud/organization was not stripped: %#v", labels)
-	}
 	if labels[Drive9ManagedLabel] != "true" || labels[Drive9TenantIDLabel] != "tenant-1" {
 		t.Fatalf("drive9 labels = %#v", labels)
 	}
 	if labels[Drive9QuotaUpdateAtLabel] == "" {
 		t.Fatalf("%s label was empty: %#v", Drive9QuotaUpdateAtLabel, labels)
 	}
-	if cfg == nil || cfg.TiDBCloudSpendingLimitMonthly == nil || *cfg.TiDBCloudSpendingLimitMonthly != 15000 {
-		t.Fatalf("cloud config = %#v, want spending limit 15000", cfg)
+	if cfg == nil || cfg.TiDBCloudSpendingLimitMonthly != nil {
+		t.Fatalf("cloud config = %#v, want no spending limit from GET", cfg)
 	}
 	if cfg.Labels[Drive9ManagedLabel] != "true" || cfg.Labels[Drive9TenantIDLabel] != "tenant-1" {
 		t.Fatalf("cloud config labels = %#v", cfg.Labels)

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1156,7 +1156,7 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 		}
 		gotAuth = r.Header.Get("Authorization")
 		switch {
-		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters/cluster-1" && r.URL.RawQuery == "view=local":
+		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters/cluster-1" && r.URL.RawQuery == "view=BASIC":
 			order = append(order, "GET")
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"clusterId": "cluster-1",

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1154,32 +1154,30 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
 		}
-		if r.URL.Path != "/v1beta1/clusters/cluster-1" {
-			t.Fatalf("unexpected path %s", r.URL.Path)
-		}
 		gotAuth = r.Header.Get("Authorization")
-		switch r.Method {
-		case http.MethodGet:
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1beta1/clusters":
 			order = append(order, "GET")
 			_ = json.NewEncoder(w).Encode(map[string]any{
-				"clusterId": "cluster-1",
-				"labels": map[string]string{
-					"environment":             "prod",
-					Drive9ManagedLabel:        "old",
-					Drive9TenantIDLabel:       "old-tenant",
-					"drive9.ai/unrelated":     "keep",
-					"tidb.cloud/project":      "123",
-					"tidb.cloud/organization": "456",
-				},
-				"spendingLimit": map[string]int32{
-					"monthly": 15000,
+				"clusters": []map[string]any{
+					{
+						"clusterId": "cluster-1",
+						"labels": map[string]string{
+							"environment":             "prod",
+							Drive9ManagedLabel:        "old",
+							Drive9TenantIDLabel:       "old-tenant",
+							"drive9.ai/unrelated":     "keep",
+							"tidb.cloud/project":      "123",
+							"tidb.cloud/organization": "456",
+						},
+					},
 				},
 			})
 			return
-		case http.MethodPatch:
+		case r.Method == http.MethodPatch && r.URL.Path == "/v1beta1/clusters/cluster-1":
 			order = append(order, "PATCH")
 		default:
-			t.Fatalf("unexpected method %s", r.Method)
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		patchCalled = true
 		if err := json.NewDecoder(r.Body).Decode(&gotPatch); err != nil {
@@ -1206,8 +1204,8 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 	if !patchCalled {
 		t.Fatal("PATCH was not called")
 	}
-	if len(order) != 1 || order[0] != "PATCH" {
-		t.Fatalf("order = %#v, want PATCH only", order)
+	if len(order) != 2 || order[0] != "GET" || order[1] != "PATCH" {
+		t.Fatalf("order = %#v, want GET then PATCH", order)
 	}
 	if !strings.Contains(gotAuth, `username="public-1"`) {
 		t.Fatalf("Authorization header did not use request public key: %q", gotAuth)
@@ -1216,6 +1214,9 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 		t.Fatalf("updateMask = %q, want labels", gotPatch.UpdateMask)
 	}
 	labels := gotPatch.Cluster.Labels
+	if labels["environment"] != "prod" || labels["drive9.ai/unrelated"] != "keep" {
+		t.Fatalf("existing labels were not preserved: %#v", labels)
+	}
 	if labels[Drive9ManagedLabel] != "true" || labels[Drive9TenantIDLabel] != "tenant-1" {
 		t.Fatalf("drive9 labels = %#v", labels)
 	}
@@ -1223,7 +1224,7 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 		t.Fatalf("%s label was empty: %#v", Drive9QuotaUpdateAtLabel, labels)
 	}
 	if cfg == nil || cfg.TiDBCloudSpendingLimitMonthly != nil {
-		t.Fatalf("cloud config = %#v, want no spending limit from GET", cfg)
+		t.Fatalf("cloud config = %#v, want no spending limit", cfg)
 	}
 	if cfg.Labels[Drive9ManagedLabel] != "true" || cfg.Labels[Drive9TenantIDLabel] != "tenant-1" {
 		t.Fatalf("cloud config labels = %#v", cfg.Labels)

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1213,6 +1213,12 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 	if labels["environment"] != "prod" || labels["drive9.ai/unrelated"] != "keep" {
 		t.Fatalf("existing labels were not preserved: %#v", labels)
 	}
+	if _, ok := labels["tidb.cloud/project"]; ok {
+		t.Fatalf("immutable label tidb.cloud/project was not stripped: %#v", labels)
+	}
+	if _, ok := labels["tidb.cloud/organization"]; ok {
+		t.Fatalf("immutable label tidb.cloud/organization was not stripped: %#v", labels)
+	}
 	if labels[Drive9ManagedLabel] != "true" || labels[Drive9TenantIDLabel] != "tenant-1" {
 		t.Fatalf("drive9 labels = %#v", labels)
 	}


### PR DESCRIPTION
## Summary

6 independent improvements to quota configuration and enforcement:

### 1. Configurable media/video defaults via env vars
`DRIVE9_MEDIA_EXTRACT_MAX_FILES` / `DRIVE9_VIDEO_EXTRACT_MAX_FILES` set runtime defaults via `DefaultMaxMediaLLMFiles()` / `DefaultMaxVideoLLMFiles()`, following the `DefaultMaxStorageBytes` pattern. New tenants inherit the configured defaults. Also remove `quota_limits_overridden` gate — when a DB row exists, row values are used directly.

### 2. Central video_file_count counter
Add `video_file_count` to `tenant_quota_usage` with `IncrVideoFileCount` / `IncrVideoFileCountTx`. Incremented when video extract tasks are enqueued. Feeds the `drive9_tenant_video_files{state="confirmed"}` metric.

### 3. /v1/quota GET skips TiDB Cloud API when possible
Bearer token (Drive9 API key) → read DB directly, no API call. TiDB Cloud credentials → only call API on RBAC cache miss. SET path unchanged.

### 4. MarkQuotaUpdateStarted / MarkClusterPool skip GET
Build labels map directly instead of `clusterQuotaInfo` GET → merge → PATCH. Saves an API round-trip per call.

### 5. Merge duplicate SetQuotaConfigPatch calls
Pool_claim and provision paths merged quotaOpt + spending limit into a single DB write.

### Files changed
`pkg/meta/quota.go`, `pkg/meta/meta.go`, `pkg/backend/options.go`, `pkg/backend/quota.go`, `pkg/backend/quota_store.go`, `pkg/backend/semantic_tasks.go`, `pkg/backend/*_test.go`, `pkg/tenant/quota_adapter.go`, `pkg/tenant/tidbcloudnative/provisioner.go`, `pkg/server/quota.go`, `pkg/server/server.go`, `pkg/server/admin_tenant_pool.go`, `pkg/server/*_test.go`, `pkg/metrics/operations.go`, `cmd/drive9-server/main.go`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video file usage tracking to tenant quotas.
  * Added configurable default limits for media and video extraction files.
  * Improved quota setup during tenant provisioning and pool assignment.
  * Enhanced quota access for authorized API-key requests.

* **Bug Fixes**
  * Corrected quota version reporting when quota configurations exist.
  * Improved quota label updates and request timing logs.
  * Added safeguards for invalid or missing cluster information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->