### PR TITLE
Fix pool default spending limit not persisted when quotaOpt is nil

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -873,6 +873,12 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 				cleanupOnError = true
 				return nil, err
 			}
+			logProvisionStage(ctx, "admin_tenant_pool_free_tenant_quota_local_config_applied", tenantID, provider, stageStarted,
+				"pool_id", poolID,
+				"organization_id", orgID,
+				"cluster_id", cluster.ClusterID)
+		}
+		if batchCloudCfg != nil && batchCloudCfg.TiDBCloudSpendingLimitMonthly != nil {
 			if err := s.syncTiDBCloudSpendingLimit(ctx, "pool_create", tenantID, batchCloudCfg, time.Time{}); err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_spending_limit_sync_failed",
 					zap.String("tenant_id", tenantID),
@@ -881,11 +887,6 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 					zap.String("cluster_id", cluster.ClusterID),
 					zap.Error(err))
 			}
-			logProvisionStage(ctx, "admin_tenant_pool_free_tenant_quota_local_config_applied", tenantID, provider, stageStarted,
-				"pool_id", poolID,
-				"organization_id", orgID,
-				"cluster_id", cluster.ClusterID,
-				"create_time_spending_limit", batchCloudCfg != nil && batchCloudCfg.TiDBCloudSpendingLimitMonthly != nil)
 		}
 		results = append(results, res)
 	}

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -30,6 +30,7 @@ type quotaTestProvisioner struct {
 	getErr                      error
 	deprovisionErr              error
 	cloudCfg                    *tenant.QuotaCloudConfig
+	batchPoolCloudCfg           *tenant.QuotaCloudConfig
 	defaultPublicKey            string
 	defaultPrivateKey           string
 	markHook                    func() error
@@ -254,7 +255,7 @@ func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota
 			out[len(out)-1].Username = "u.root"
 		}
 	}
-	return out, nil, p.batchPoolErr
+	return out, p.batchPoolCloudCfg, p.batchPoolErr
 }
 
 func (p *quotaTestProvisioner) WaitForPoolClusterMetadata(_ context.Context, cluster *tenant.ClusterInfo, req tenant.CredentialProvisionRequest) (*tenant.ClusterInfo, error) {
@@ -2656,6 +2657,11 @@ func TestAdminTenantPoolReplenishUsesDefaultSpendingLimit(t *testing.T) {
 		t.Fatalf("create pool: %v", err)
 	}
 
+	defaultLimit := int64(1000)
+	rt.prov.batchPoolCloudCfg = &tenant.QuotaCloudConfig{
+		TiDBCloudSpendingLimitMonthly: &defaultLimit,
+	}
+
 	rt.server.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
@@ -2668,6 +2674,28 @@ func TestAdminTenantPoolReplenishUsesDefaultSpendingLimit(t *testing.T) {
 	lastOptions := rt.prov.lastOptionsSnapshot()
 	if lastOptions.TiDBCloudSpendingLimitMonthly != nil {
 		t.Fatalf("replenish spending limit = %#v, want nil", lastOptions.TiDBCloudSpendingLimitMonthly)
+	}
+
+	tenants, err := rt.meta.ListTenantsByStatus(ctx, meta.TenantActive, 10)
+	if err != nil {
+		t.Fatalf("list tenants: %v", err)
+	}
+	var poolTenantID string
+	for _, tenant := range tenants {
+		if tenant.ID != rt.tenantID {
+			poolTenantID = tenant.ID
+			break
+		}
+	}
+	if poolTenantID == "" {
+		t.Fatal("no pool tenant created by replenish")
+	}
+	cfg, err := rt.meta.GetQuotaConfig(ctx, poolTenantID)
+	if err != nil {
+		t.Fatalf("get quota config: %v", err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != defaultLimit {
+		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, defaultLimit)
 	}
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -447,7 +447,18 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 	}
 	for _, err := range errs {
 		if err != nil {
-			return fallbackBatchClusterInfos(created.Clusters, dbName, passwords), nil, err
+			cfgs := fallbackBatchClusterInfos(created.Clusters, dbName, passwords)
+			cloudCfg := &tenant.QuotaCloudConfig{Labels: map[string]string{
+				Drive9ManagedLabel:  "true",
+				Drive9PoolStatusLabel: "free",
+			}}
+			if poolID := strings.TrimSpace(opts.TenantPoolID); poolID != "" {
+				cloudCfg.Labels[Drive9PoolIDLabel] = poolID
+			}
+			if spendingLimit != nil {
+				cloudCfg.TiDBCloudSpendingLimitMonthly = ptrInt64(*spendingLimit)
+			}
+			return cfgs, cloudCfg, err
 		}
 	}
 	cloudCfg := &tenant.QuotaCloudConfig{Labels: map[string]string{

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -449,7 +449,7 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 		if err != nil {
 			cfgs := fallbackBatchClusterInfos(created.Clusters, dbName, passwords)
 			cloudCfg := &tenant.QuotaCloudConfig{Labels: map[string]string{
-				Drive9ManagedLabel:  "true",
+				Drive9ManagedLabel:    "true",
 				Drive9PoolStatusLabel: "free",
 			}}
 			if poolID := strings.TrimSpace(opts.TenantPoolID); poolID != "" {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -2098,3 +2098,66 @@ func TestClusterInfoFromResponseUsesClusterPrivateHostBeforeLegacyOverride(t *te
 		t.Fatalf("Host with empty private host = %q, want alicloud.override.internal", out.Host)
 	}
 }
+
+func TestBatchProvisionFreeClustersReturnsSpendingLimitOnPartialFailure(t *testing.T) {
+	defaultLimit := int32(1000)
+	handlerErrs := make(chan error, 2)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/v1beta1/clusters:batchCreate" {
+			handlerErrs <- fmt.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"clusters": []map[string]any{
+				{
+					"clusterId":  "cluster-1",
+					"state":      "ACTIVE",
+					"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1", Drive9TenantIDLabel: "tenant-1"},
+					"userPrefix": "u1",
+					"endpoints":  map[string]any{"public": map[string]any{"host": "db1.example", "port": 4000}},
+				},
+				{
+					"clusterId":  "cluster-2",
+					"state":      "ACTIVE",
+					"labels":     map[string]string{TiDBCloudOrganizationLabel: "org-1"},
+					"userPrefix": "u2",
+					"endpoints":  map[string]any{"public": map[string]any{"host": "db2.example", "port": 4000}},
+				},
+			},
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL:              ts.URL,
+		cloudProvider:       "aws",
+		region:              "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+		defaultSpendLimit:   &defaultLimit,
+		client:              ts.Client(),
+	}
+	clusters, cloudCfg, err := p.BatchProvisionFreeClustersWithCredentialsAndQuota(
+		context.Background(),
+		[]string{"tenant-1", "tenant-2"},
+		tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"},
+		tenant.QuotaUpdateOptions{},
+	)
+	if err == nil {
+		t.Fatal("expected error from missing tenant ID label")
+	}
+	if len(clusters) != 2 {
+		t.Fatalf("clusters = %d, want 2 (with fallback)", len(clusters))
+	}
+	if cloudCfg == nil {
+		t.Fatal("cloud config is nil on partial failure, want non-nil with spending limit")
+	}
+	if cloudCfg.TiDBCloudSpendingLimitMonthly == nil || *cloudCfg.TiDBCloudSpendingLimitMonthly != int64(defaultLimit) {
+		t.Fatalf("spending limit = %#v, want %d", cloudCfg.TiDBCloudSpendingLimitMonthly, defaultLimit)
+	}
+}


### PR DESCRIPTION
## Problem

During pool creation, the provisioner applies the default spending limit (e.g. 1000 from `DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT`) to the TiDB Cloud cluster, but `syncTiDBCloudSpendingLimit` was inside the `if quotaOpt != nil` guard. When `quotaOpt == nil` (always true for pool create), the spending limit was discarded and `tidbcloud_spending_limit` was stored as NULL in `tenant_quota_config`.

## Fix

Move `syncTiDBCloudSpendingLimit` outside the `quotaOpt != nil` guard. It now runs whenever `batchCloudCfg.TiDBCloudSpendingLimitMonthly != nil`, regardless of `quotaOpt`.

## Other reviewer findings addressed

- **quota_limits_overridden in AtomicReserveAndInsertUpload**: intentionally kept. This flag gates storage/file_count enforcement during strict upload reservations. Spending-only rows (flag=0) have no limits to enforce. The read path (GetQuotaConfig) was already cleaned up in #762.
- **video_file_count reliability**: observability-only counter, enforcement uses live COUNT(*) query. Eventual consistency accepted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved default monthly spending-limit settings when replenishing tenant pools.
  * Improved partial batch-provisioning failures by retaining quota and spending-limit configuration while returning fallback cluster details.
* **Tests**
  * Added coverage for spending-limit persistence during pool replenishment.
  * Added coverage for partial provisioning failures and returned quota configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->