### PR TITLE
Keep quota reads side-effect free and tune MySQL pool lifetimes

### DIFF
--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -9,15 +9,15 @@ import (
 )
 
 const (
-	defaultMetaConnMaxLifetime       = 5 * time.Minute
-	defaultMetaConnMaxIdleTime       = 45 * time.Second
+	defaultMetaConnMaxLifetime       = 10 * time.Minute
+	defaultMetaConnMaxIdleTime       = 1 * time.Minute
 	defaultMetaMaxOpenConns          = 100
 	defaultMetaMaxIdleConns          = 20
 	defaultUserConnMaxLifetime       = 5 * time.Minute
 	defaultUserConnMaxIdleTime       = 1 * time.Minute
 	defaultUserMaxOpenConns          = 6
 	defaultUserMaxIdleConns          = 2
-	defaultUserSchemaConnMaxLifetime = 1 * time.Minute
+	defaultUserSchemaConnMaxLifetime = 3 * time.Minute
 	defaultUserSchemaConnMaxIdleTime = 20 * time.Second
 	defaultUserSchemaMaxOpenConns    = 8
 	defaultUserSchemaMaxIdleConns    = 2

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -232,8 +232,7 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	listStarted := time.Now().UTC()
-	clusters, clustersFromCache, err := s.listAllManagedClusters(r.Context(), cred, "", "admin_tenant_list")
+	clusters, _, err := s.listAllManagedClusters(r.Context(), cred, "", "admin_tenant_list")
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "list tenants")
 		return
@@ -263,28 +262,6 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 	if len(rows) > pageSize {
 		rows = rows[:pageSize]
 		nextPage = page + 1
-	}
-	clusterMap := cloudClusterMap(clusters)
-	if includeQuota {
-		if err := s.syncAdminTenantSpendingLimits(r.Context(), rows, clusterMap, listStarted); err != nil {
-			logger.Warn(r.Context(), "admin_tenant_spending_limit_sync_failed", zap.Error(err))
-			errJSON(w, http.StatusInternalServerError, "quota lookup failed")
-			return
-		}
-		if clustersFromCache && s.adminTenantRowsNeedSpendingLimitBackfill(r.Context(), "admin_tenant_list", rows) {
-			listStarted = time.Now().UTC()
-			clusters, _, err = s.listAllManagedClustersFresh(r.Context(), cred, "", "admin_tenant_list")
-			if err != nil {
-				writeAdminTiDBCloudError(w, r.Context(), err, "list tenants")
-				return
-			}
-			clusterMap = cloudClusterMap(clusters)
-			if err := s.syncAdminTenantSpendingLimits(r.Context(), rows, clusterMap, listStarted); err != nil {
-				logger.Warn(r.Context(), "admin_tenant_spending_limit_sync_failed", zap.Error(err))
-				errJSON(w, http.StatusInternalServerError, "quota lookup failed")
-				return
-			}
-		}
 	}
 	out := make([]adminTenantResponse, 0, len(rows))
 	for _, row := range rows {
@@ -476,17 +453,7 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 		errJSON(w, http.StatusNotFound, "tenant not found")
 		return nil, nil, false
 	}
-	allowCache := true
-	if loadQuota {
-		cfg, err := s.meta.GetQuotaConfig(r.Context(), tenantID)
-		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "quota config lookup failed")
-			return nil, nil, false
-		}
-		allowCache = cfg.TiDBCloudSpendingLimit != nil
-	}
-	listStarted := time.Now().UTC()
-	clusters, _, err := s.listAllManagedClustersCached(r.Context(), cred, binding.ClusterID, allowCache, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
+	clusters, _, err := s.listAllManagedClustersCached(r.Context(), cred, binding.ClusterID, true, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
 		return nil, nil, false
@@ -507,26 +474,16 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 		errJSON(w, http.StatusForbidden, "no permission to access tenant with TiDB Cloud API key")
 		return nil, nil, false
 	}
-	var authorizedCluster tenant.CloudClusterInfo
 	authorized := false
 	for _, cluster := range clusters {
 		if cluster.ClusterID == binding.ClusterID && cluster.OrganizationID == binding.OrganizationID {
 			authorized = true
-			authorizedCluster = cluster
 			break
 		}
 	}
 	if !authorized {
 		errJSON(w, http.StatusForbidden, "no permission to access tenant with TiDB Cloud API key")
 		return nil, nil, false
-	}
-	if loadQuota {
-		cloudCfg := &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: authorizedCluster.TiDBCloudSpendingLimitMonthly}
-		if err := s.syncTiDBCloudSpendingLimit(r.Context(), "admin_tenant_get", t.ID, cloudCfg, listStarted); err != nil {
-			logger.Warn(r.Context(), "admin_tenant_spending_limit_sync_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-			errJSON(w, http.StatusInternalServerError, "quota lookup failed")
-			return nil, nil, false
-		}
 	}
 	return t, binding, true
 }
@@ -544,10 +501,6 @@ func adminTenantMetricPath(loadQuota bool, allowDeletingMissingCluster bool) str
 
 func (s *Server) listAllManagedClusters(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, bool, error) {
 	return s.listAllManagedClustersCached(ctx, cred, clusterID, true, metricPath)
-}
-
-func (s *Server) listAllManagedClustersFresh(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, bool, error) {
-	return s.listAllManagedClustersCached(ctx, cred, clusterID, false, metricPath)
 }
 
 func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string, allowCache bool, metricPath string) ([]tenant.CloudClusterInfo, bool, error) {
@@ -684,45 +637,6 @@ func authorizedTiDBCloudOrgClusterBindings(clusters []tenant.CloudClusterInfo) [
 		out = append(out, meta.TenantTiDBCloudOrgBinding{OrganizationID: orgID, ClusterID: clusterID})
 	}
 	return out
-}
-
-func cloudClusterMap(clusters []tenant.CloudClusterInfo) map[string]tenant.CloudClusterInfo {
-	out := make(map[string]tenant.CloudClusterInfo, len(clusters))
-	for _, cluster := range clusters {
-		if cluster.ClusterID != "" {
-			out[cluster.ClusterID] = cluster
-		}
-	}
-	return out
-}
-
-func (s *Server) syncAdminTenantSpendingLimits(ctx context.Context, rows []meta.TenantWithTiDBCloudOrgBinding, clusters map[string]tenant.CloudClusterInfo, observedAt time.Time) error {
-	for _, row := range rows {
-		cluster, ok := clusters[row.Binding.ClusterID]
-		if !ok || cluster.OrganizationID != row.Binding.OrganizationID {
-			continue
-		}
-		if err := s.syncTiDBCloudSpendingLimit(ctx, "admin_tenant_list", row.Tenant.ID, &tenant.QuotaCloudConfig{
-			TiDBCloudSpendingLimitMonthly: cluster.TiDBCloudSpendingLimitMonthly,
-		}, observedAt); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func (s *Server) adminTenantRowsNeedSpendingLimitBackfill(ctx context.Context, metricPath string, rows []meta.TenantWithTiDBCloudOrgBinding) bool {
-	for _, row := range rows {
-		cfg, err := s.meta.GetQuotaConfig(ctx, row.Tenant.ID)
-		if err != nil {
-			return false
-		}
-		if cfg.TiDBCloudSpendingLimit == nil && cfg.TiDBCloudSpendingLimitCheckedAt == nil {
-			metrics.RecordTiDBCloudSpendingLimitMissing(metricPath)
-			return true
-		}
-	}
-	return false
 }
 
 func adminCredentialsFromHeaders(r *http.Request) (tenant.CredentialProvisionRequest, error) {

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -126,8 +126,7 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 			errJSON(w, http.StatusNotFound, "quota query not enabled")
 			return
 		}
-		observedAt := time.Now().UTC()
-		cloudCfg, err := getter.GetQuota(r.Context(), clusterInfoFromTenant(t), cred)
+		_, err := getter.GetQuota(r.Context(), clusterInfoFromTenant(t), cred)
 		if err != nil {
 			metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "error")
 			writeQuotaCredentialError(w, r.Context(), err, "query")
@@ -135,9 +134,6 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		}
 		metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "ok")
 		s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
-		if err := s.syncTiDBCloudSpendingLimit(r.Context(), "quota_get", t.ID, cloudCfg, observedAt); err != nil {
-			logger.Warn(r.Context(), "tidbcloud_spending_limit_sync_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-		}
 	}
 	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, s.tenantMetricTiDBCloudOrgID(r.Context(), t), classifyTenantRequest(r))
 	s.writeQuotaResponse(w, r, t)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -495,16 +495,18 @@ func TestQuotaGetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 
 func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	spendingLimit := int64(10000)
-	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
+	localSpendingLimit := int64(9000)
+	cloudSpendingLimit := int64(10000)
+	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &cloudSpendingLimit}
 	ctx := context.Background()
 	if err := rt.meta.SetQuotaConfig(ctx, &meta.QuotaConfig{
-		TenantID:         rt.tenantID,
-		MaxStorageBytes:  123 * quotaStorageSizeBytes,
-		MaxFileSizeBytes: 12 * quotaStorageSizeBytes,
-		MaxFileCount:     34,
-		MaxMediaLLMFiles: 56,
-		MaxMonthlyCostMC: 789,
+		TenantID:               rt.tenantID,
+		MaxStorageBytes:        123 * quotaStorageSizeBytes,
+		MaxFileSizeBytes:       12 * quotaStorageSizeBytes,
+		MaxFileCount:           34,
+		MaxMediaLLMFiles:       56,
+		MaxMonthlyCostMC:       789,
+		TiDBCloudSpendingLimit: &localSpendingLimit,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -537,15 +539,18 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	if out.TenantID != rt.tenantID || !out.SupportsUpdate {
 		t.Fatalf("response tenant/update = %#v", out)
 	}
-	if out.Config.MaxStorageSize != 123 || out.Config.MaxFileSize != 12 || out.Config.MaxFileCount != 34 || out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
+	if out.Config.MaxStorageSize != 123 || out.Config.MaxFileSize != 12 || out.Config.MaxFileCount != 34 || out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != localSpendingLimit {
 		t.Fatalf("config = %#v", out.Config)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
-		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != localSpendingLimit {
+		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, localSpendingLimit)
+	}
+	if cfg.TiDBCloudSpendingLimitCheckedAt != nil {
+		t.Fatalf("checked_at = %v, want nil after GET", cfg.TiDBCloudSpendingLimitCheckedAt)
 	}
 	if out.Usage.StorageBytes != 321 || out.Usage.ReservedBytes != 11 || out.Usage.FileCount != 9 {
 		t.Fatalf("usage = %#v", out.Usage)
@@ -650,7 +655,7 @@ func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	}
 }
 
-func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
+func TestQuotaGetCachesTiDBCloudRBACWithoutBackfillingSpendingLimit(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	spendingLimit := int64(222)
 	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
@@ -671,8 +676,11 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
-		t.Fatalf("persisted spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)
+	if cfg.TiDBCloudSpendingLimit != nil {
+		t.Fatalf("persisted spending limit = %#v, want nil", cfg.TiDBCloudSpendingLimit)
+	}
+	if cfg.TiDBCloudSpendingLimitCheckedAt != nil {
+		t.Fatalf("checked_at = %v, want nil after GET", cfg.TiDBCloudSpendingLimitCheckedAt)
 	}
 
 	rt.prov.getErr = errors.New("should not call TiDB Cloud while RBAC cache and local spending limit are present")
@@ -686,8 +694,8 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 	if err := json.NewDecoder(resp2.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if out.Config.TiDBCloudSpendingLimit == nil || *out.Config.TiDBCloudSpendingLimit != spendingLimit {
-		t.Fatalf("response spending limit = %#v, want %d", out.Config.TiDBCloudSpendingLimit, spendingLimit)
+	if out.Config.TiDBCloudSpendingLimit != nil {
+		t.Fatalf("response spending limit = %#v, want nil", out.Config.TiDBCloudSpendingLimit)
 	}
 	if got := rt.prov.getCalls.Load(); got != 1 {
 		t.Fatalf("get calls after cached request = %d, want 1", got)
@@ -709,8 +717,11 @@ func TestQuotaGetCachesTiDBCloudRBACAndBackfillsSpendingLimit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != updatedLimit {
-		t.Fatalf("updated spending limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, updatedLimit)
+	if cfg.TiDBCloudSpendingLimit != nil {
+		t.Fatalf("updated spending limit = %#v, want nil", cfg.TiDBCloudSpendingLimit)
+	}
+	if cfg.TiDBCloudSpendingLimitCheckedAt != nil {
+		t.Fatalf("checked_at = %v, want nil after GET with new credentials", cfg.TiDBCloudSpendingLimitCheckedAt)
 	}
 }
 
@@ -1385,6 +1396,78 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	}
 }
 
+func TestAdminTenantListIncludeQuotaDoesNotBackfillSpendingLimit(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       rt.tenantID,
+		OrganizationID: "org-1",
+		ClusterID:      "cluster-quota-1",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.SetQuotaConfig(ctx, &meta.QuotaConfig{
+		TenantID:         rt.tenantID,
+		MaxStorageBytes:  100 * quotaStorageSizeBytes,
+		MaxFileSizeBytes: 10 * quotaStorageSizeBytes,
+		MaxFileCount:     7,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.EnsureQuotaUsageRow(ctx, rt.tenantID); err != nil {
+		t.Fatal(err)
+	}
+	cloudSpendingLimit := int64(12345)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{
+			ClusterID:                     "cluster-quota-1",
+			OrganizationID:                "org-1",
+			TiDBCloudSpendingLimitMonthly: &cloudSpendingLimit,
+		}},
+	}}
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/admin/tenants?include_quota=true", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set(quotaPublicKeyHeader, "public-1")
+	req.Header.Set(quotaPrivateKeyHeader, "private-1")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want 200: %s", resp.StatusCode, body)
+	}
+	var out adminTenantListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out.Tenants) != 1 || out.Tenants[0].Quota == nil {
+		t.Fatalf("tenants = %#v, want one tenant with quota", out.Tenants)
+	}
+	if out.Tenants[0].Quota.Config.TiDBCloudSpendingLimit != nil {
+		t.Fatalf("response spending limit = %#v, want local nil value", out.Tenants[0].Quota.Config.TiDBCloudSpendingLimit)
+	}
+	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit != nil || cfg.TiDBCloudSpendingLimitCheckedAt != nil {
+		t.Fatalf("quota config mutated by GET: %#v", cfg)
+	}
+	if got := rt.prov.listCalls.Load(); got != 1 {
+		t.Fatalf("list calls = %d, want 1", got)
+	}
+}
+
 func TestAdminTenantGetHidesFreePoolTenant(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
@@ -1523,23 +1606,25 @@ func TestAdminTenantGetUsesListClusterAuthorizationAndReturnsQuota(t *testing.T)
 	}); err != nil {
 		t.Fatal(err)
 	}
+	localSpendingLimit := int64(7000)
 	if err := rt.meta.SetQuotaConfig(ctx, &meta.QuotaConfig{
-		TenantID:         rt.tenantID,
-		MaxStorageBytes:  100 * quotaStorageSizeBytes,
-		MaxFileSizeBytes: 10 * quotaStorageSizeBytes,
-		MaxFileCount:     7,
+		TenantID:               rt.tenantID,
+		MaxStorageBytes:        100 * quotaStorageSizeBytes,
+		MaxFileSizeBytes:       10 * quotaStorageSizeBytes,
+		MaxFileCount:           7,
+		TiDBCloudSpendingLimit: &localSpendingLimit,
 	}); err != nil {
 		t.Fatal(err)
 	}
 	if err := rt.meta.EnsureQuotaUsageRow(ctx, rt.tenantID); err != nil {
 		t.Fatal(err)
 	}
-	spendingLimit := int64(12345)
+	cloudSpendingLimit := int64(12345)
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
 		Clusters: []tenant.CloudClusterInfo{{
 			ClusterID:                     "cluster-quota-1",
 			OrganizationID:                "org-1",
-			TiDBCloudSpendingLimitMonthly: &spendingLimit,
+			TiDBCloudSpendingLimitMonthly: &cloudSpendingLimit,
 		}},
 	}}
 	ts := httptest.NewServer(rt.server)
@@ -1583,8 +1668,15 @@ func TestAdminTenantGetUsesListClusterAuthorizationAndReturnsQuota(t *testing.T)
 	if out.Quota == nil || out.Quota.Config.MaxStorageSize != 100 || out.Quota.Config.MaxFileSize != 10 || out.Quota.Config.MaxFileCount != 7 {
 		t.Fatalf("quota = %#v, want config in response", out.Quota)
 	}
-	if out.Quota.Config.TiDBCloudSpendingLimit == nil || *out.Quota.Config.TiDBCloudSpendingLimit != spendingLimit {
-		t.Fatalf("spending limit = %#v, want %d", out.Quota.Config.TiDBCloudSpendingLimit, spendingLimit)
+	if out.Quota.Config.TiDBCloudSpendingLimit == nil || *out.Quota.Config.TiDBCloudSpendingLimit != localSpendingLimit {
+		t.Fatalf("spending limit = %#v, want local value %d", out.Quota.Config.TiDBCloudSpendingLimit, localSpendingLimit)
+	}
+	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != localSpendingLimit || cfg.TiDBCloudSpendingLimitCheckedAt != nil {
+		t.Fatalf("quota config mutated by GET: %#v", cfg)
 	}
 	if got := rt.prov.listCalls.Load(); got != 1 {
 		t.Fatalf("list calls = %d, want 1", got)
@@ -1619,8 +1711,8 @@ func TestAdminTenantGetUsesListClusterAuthorizationAndReturnsQuota(t *testing.T)
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if out.Quota == nil || out.Quota.Config.TiDBCloudSpendingLimit == nil || *out.Quota.Config.TiDBCloudSpendingLimit != spendingLimit {
-		t.Fatalf("cached spending limit = %#v, want %d", out.Quota, spendingLimit)
+	if out.Quota == nil || out.Quota.Config.TiDBCloudSpendingLimit == nil || *out.Quota.Config.TiDBCloudSpendingLimit != localSpendingLimit {
+		t.Fatalf("cached spending limit = %#v, want local value %d", out.Quota, localSpendingLimit)
 	}
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -772,10 +772,11 @@ func (p *Provisioner) MarkClusterPoolUsed(ctx context.Context, cluster *tenant.C
 		}
 	}
 	clusterID := strings.TrimSpace(cluster.ClusterID)
-	labels, err := p.getClusterLabelsWithCredentials(ctx, publicKey, privateKey, clusterID)
+	info, err := p.getClusterBasicInfoWithCredentials(ctx, publicKey, privateKey, clusterID)
 	if err != nil {
-		return nil, fmt.Errorf("load cluster labels: %w", err)
+		return nil, fmt.Errorf("load cluster basic info: %w", err)
 	}
+	labels := info.Labels
 	labels[Drive9ManagedLabel] = "true"
 	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
 		labels[Drive9TenantIDLabel] = tenantID
@@ -809,10 +810,11 @@ func (p *Provisioner) MarkClusterPoolFree(ctx context.Context, cluster *tenant.C
 		return fmt.Errorf("cluster id is required")
 	}
 	clusterID := strings.TrimSpace(cluster.ClusterID)
-	labels, err := p.getClusterLabelsWithCredentials(ctx, publicKey, privateKey, clusterID)
+	info, err := p.getClusterBasicInfoWithCredentials(ctx, publicKey, privateKey, clusterID)
 	if err != nil {
-		return fmt.Errorf("load cluster labels: %w", err)
+		return fmt.Errorf("load cluster basic info: %w", err)
 	}
+	labels := info.Labels
 	labels[Drive9ManagedLabel] = "true"
 	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
 		labels[Drive9TenantIDLabel] = tenantID
@@ -1053,10 +1055,11 @@ func (p *Provisioner) MarkQuotaUpdateStarted(ctx context.Context, cluster *tenan
 		return nil, fmt.Errorf("cluster id is required")
 	}
 	clusterID := strings.TrimSpace(cluster.ClusterID)
-	labels, err := p.getClusterLabelsWithCredentials(ctx, publicKey, privateKey, clusterID)
+	info, err := p.getClusterBasicInfoWithCredentials(ctx, publicKey, privateKey, clusterID)
 	if err != nil {
-		return nil, fmt.Errorf("load cluster labels: %w", err)
+		return nil, fmt.Errorf("load cluster basic info: %w", err)
 	}
+	labels := info.Labels
 	labels[Drive9ManagedLabel] = "true"
 	if tenantID := strings.TrimSpace(cluster.TenantID); tenantID != "" {
 		labels[Drive9TenantIDLabel] = tenantID
@@ -1107,11 +1110,15 @@ func (p *Provisioner) GetQuota(ctx context.Context, cluster *tenant.ClusterInfo,
 	if cluster == nil || strings.TrimSpace(cluster.ClusterID) == "" {
 		return nil, fmt.Errorf("cluster id is required")
 	}
-	_, cloudCfg, err := p.clusterQuotaInfo(ctx, publicKey, privateKey, strings.TrimSpace(cluster.ClusterID))
+	info, err := p.getClusterBasicInfoWithCredentials(ctx, publicKey, privateKey, strings.TrimSpace(cluster.ClusterID))
 	if err != nil {
-		return nil, fmt.Errorf("load cluster quota info: %w", err)
+		return nil, fmt.Errorf("load cluster basic info: %w", err)
 	}
-	return cloudCfg, nil
+	labels := make(map[string]string, len(info.Labels))
+	for key, value := range info.Labels {
+		labels[key] = value
+	}
+	return &tenant.QuotaCloudConfig{Labels: labels}, nil
 }
 
 func (p *Provisioner) ListManagedClusters(ctx context.Context, req tenant.CredentialProvisionRequest, opts tenant.ManagedClusterListOptions) (*tenant.ManagedClusterListResult, error) {
@@ -1194,11 +1201,11 @@ func (p *Provisioner) listClusterInfosPageWithCredentials(ctx context.Context, p
 	return list.Clusters, strings.TrimSpace(list.NextPageToken), nil
 }
 
-func (p *Provisioner) getClusterLabelsWithCredentials(ctx context.Context, publicKey, privateKey, clusterID string) (map[string]string, error) {
+func (p *Provisioner) getClusterBasicInfoWithCredentials(ctx context.Context, publicKey, privateKey, clusterID string) (*clusterInfo, error) {
 	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s?view=BASIC", p.apiURL, url.PathEscape(clusterID))
 	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
 	if err != nil {
-		return nil, fmt.Errorf("get cluster labels: %w", err)
+		return nil, fmt.Errorf("get cluster basic info: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
@@ -1216,44 +1223,10 @@ func (p *Provisioner) getClusterLabelsWithCredentials(ctx context.Context, publi
 	if err != nil {
 		return nil, fmt.Errorf("parse cluster info: %w", err)
 	}
-	labels := make(map[string]string, len(info.Labels))
-	for k, v := range info.Labels {
-		labels[k] = v
+	if info.Labels == nil {
+		info.Labels = make(map[string]string)
 	}
-	return labels, nil
-}
-
-func (p *Provisioner) clusterQuotaInfo(ctx context.Context, publicKey, privateKey, clusterID string) (map[string]string, *tenant.QuotaCloudConfig, error) {
-	endpoint := fmt.Sprintf("%s/v1beta1/clusters/%s", p.apiURL, url.PathEscape(clusterID))
-	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
-	if err != nil {
-		return nil, nil, fmt.Errorf("get cluster quota info: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
-		if readErr != nil {
-			return nil, nil, fmt.Errorf("read cluster get error body: %w", readErr)
-		}
-		return nil, nil, quotaStatusError("cluster get", resp.StatusCode, sanitizeUpstreamBody(raw))
-	}
-	raw, readErr := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
-	if readErr != nil {
-		return nil, nil, fmt.Errorf("read cluster body: %w", readErr)
-	}
-	info, err := parseClusterInfo(raw)
-	if err != nil {
-		return nil, nil, fmt.Errorf("parse cluster quota info: %w", err)
-	}
-	labels := make(map[string]string, len(info.Labels)+3)
-	for k, v := range info.Labels {
-		labels[k] = v
-	}
-	cloudCfg := &tenant.QuotaCloudConfig{}
-	if info.SpendingLimit != nil {
-		cloudCfg.TiDBCloudSpendingLimitMonthly = ptrInt64(int64(info.SpendingLimit.Monthly))
-	}
-	return labels, cloudCfg, nil
+	return info, nil
 }
 
 func (p *Provisioner) updateSpendingLimitWithCredentials(ctx context.Context, publicKey, privateKey, clusterID string, monthly int64) error {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1393,9 +1393,10 @@ func TestUpdateQuotaRejectsInvalidSpendingLimitBeforeRequest(t *testing.T) {
 	}
 }
 
-func TestGetQuotaOnlyGetsCluster(t *testing.T) {
+func TestGetQuotaUsesBasicClusterInfoForAuthorization(t *testing.T) {
 	var patchCalled bool
 	var getCalled bool
+	var gotRawQuery string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {
 			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-1", qop="auth"`)
@@ -1405,6 +1406,7 @@ func TestGetQuotaOnlyGetsCluster(t *testing.T) {
 		switch r.Method {
 		case http.MethodGet:
 			getCalled = true
+			gotRawQuery = r.URL.RawQuery
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"clusterId": "cluster-1",
 				"labels":    map[string]string{Drive9ManagedLabel: "true"},
@@ -1431,12 +1433,15 @@ func TestGetQuotaOnlyGetsCluster(t *testing.T) {
 	if !getCalled {
 		t.Fatal("GET was not called")
 	}
+	if gotRawQuery != "view=BASIC" {
+		t.Fatalf("query = %q, want view=BASIC", gotRawQuery)
+	}
 	if patchCalled {
 		t.Fatal("PATCH should not be called for read-only quota authorization")
 	}
 }
 
-func TestGetQuotaReadsSpendingLimit(t *testing.T) {
+func TestGetQuotaDoesNotReadSpendingLimit(t *testing.T) {
 	var patchCalled bool
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {
@@ -1475,8 +1480,14 @@ func TestGetQuotaReadsSpendingLimit(t *testing.T) {
 	if patchCalled {
 		t.Fatal("PATCH should not be called for quota query")
 	}
-	if cfg == nil || cfg.TiDBCloudSpendingLimitMonthly == nil || *cfg.TiDBCloudSpendingLimitMonthly != 15000 {
-		t.Fatalf("quota cloud config = %#v, want spending limit 15000", cfg)
+	if cfg == nil {
+		t.Fatal("quota cloud config was nil")
+	}
+	if cfg.TiDBCloudSpendingLimitMonthly != nil {
+		t.Fatalf("spending limit = %#v, want nil for BASIC authorization", cfg.TiDBCloudSpendingLimitMonthly)
+	}
+	if cfg.Labels[Drive9ManagedLabel] != "true" {
+		t.Fatalf("labels = %#v, want parsed BASIC labels", cfg.Labels)
 	}
 }
 


### PR DESCRIPTION
## Summary

- validate TiDB Cloud credential-based quota reads with BASIC cluster information only on RBAC cache misses, while preserving the local Drive9 API-key fast path
- stop quota and admin read endpoints from backfilling cloud spending limits into the meta database; explicit quota updates and lifecycle seeds remain unchanged
- increase default meta and user-schema connection lifetimes and the meta idle timeout

## Test Plan

- [x] go test ./pkg/mysqlutil -count=1
- [x] go test ./pkg/tenant/tidbcloudnative -count=1
- [x] go test ./pkg/server -run Test\(QuotaGet\|DeprecatedQuotaGet\|QuotaSet\|AdminTenantGet\|AdminTenantList\|AdminTenantQuotaSet\|AdminTenantPoolReplenishUsesDefaultSpendingLimit\) -count=1
- [x] make lint
- [x] git diff --check origin/main...HEAD

## Full server test note

A full go test ./pkg/server -count=1 was attempted twice. In both runs, the package-local MySQL test instance returned invalid connection after roughly two minutes, causing cascading failures in later token, upload, and vault tests. No quota or admin-quota assertion failed, and the focused affected test set above passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Quota and tenant administration views no longer overwrite or backfill locally configured spending limits when retrieving quota information.
  * Quota responses continue to include current quota details without triggering background spending-limit synchronization.
  * Improved connection pool defaults help maintain connections longer during normal operation.

* **Tests**
  * Added coverage confirming quota and tenant requests preserve local spending-limit settings and avoid unintended updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->