### PR TITLE
Resolve tenant org through the RBAC cluster-list cache

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -681,15 +681,15 @@ func (s *Server) refreshTenantPoolCapacity(ctx context.Context, pool *meta.Tenan
 }
 
 func (s *Server) firstManagedOrganization(ctx context.Context, cred tenant.CredentialProvisionRequest) (string, error) {
-	lister, ok := s.provisioner.(tenant.ManagedClusterLister)
-	if !ok {
-		return "", fmt.Errorf("managed cluster list not enabled")
-	}
-	page, err := lister.ListManagedClusters(ctx, cred, tenant.ManagedClusterListOptions{PageSize: 1})
-	if err != nil || page == nil || len(page.Clusters) == 0 {
+	// Resolve through the RBAC list cache so repeated org lookups on the same
+	// request path (warm-pool claim + shared-pool check) and across
+	// consecutive provisions do not each cost a TiDB Cloud list call. The
+	// cache is invalidated on tenant mutations (forgetTiDBCloudRBACList).
+	clusters, _, err := s.listAllManagedClustersCached(ctx, cred, "", true, "provision_org_resolve")
+	if err != nil || len(clusters) == 0 {
 		return "", err
 	}
-	return strings.TrimSpace(page.Clusters[0].OrganizationID), nil
+	return strings.TrimSpace(clusters[0].OrganizationID), nil
 }
 
 func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count int, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*provisionTenantResult, error) {

--- a/pkg/server/admin_tenant_pool_cache_test.go
+++ b/pkg/server/admin_tenant_pool_cache_test.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/tenant"
+)
+
+// TestFirstManagedOrganizationUsesRBACCache proves org resolution for
+// provisioning reuses the RBAC cluster-list cache: repeated lookups for the
+// same credential cost one TiDB Cloud list call, and forgetting the cache
+// forces a fresh fetch.
+func TestFirstManagedOrganizationUsesRBACCache(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{
+		{Clusters: []tenant.CloudClusterInfo{{ClusterID: "c1", OrganizationID: "org-cached-1"}}},
+		{Clusters: []tenant.CloudClusterInfo{{ClusterID: "c2", OrganizationID: "org-cached-2"}}},
+	}
+	ctx := context.Background()
+	cred := tenant.CredentialProvisionRequest{PublicKey: "pk", PrivateKey: "sk"}
+
+	org, err := rt.server.firstManagedOrganization(ctx, cred)
+	if err != nil {
+		t.Fatalf("first lookup: %v", err)
+	}
+	if org != "org-cached-1" {
+		t.Fatalf("org = %q, want org-cached-1", org)
+	}
+	// The second lookup for the same credential must hit the cache: no
+	// additional list call, and the org from the cached page is returned
+	// (not the second scripted page).
+	org, err = rt.server.firstManagedOrganization(ctx, cred)
+	if err != nil {
+		t.Fatalf("second lookup: %v", err)
+	}
+	if org != "org-cached-1" {
+		t.Fatalf("cached org = %q, want org-cached-1", org)
+	}
+	if got := rt.prov.listCalls.Load(); got != 1 {
+		t.Fatalf("list calls = %d, want 1", got)
+	}
+
+	// Forgetting the list forces a fresh API fetch (second scripted page).
+	rt.server.forgetTiDBCloudRBACList(cred)
+	org, err = rt.server.firstManagedOrganization(ctx, cred)
+	if err != nil {
+		t.Fatalf("lookup after forget: %v", err)
+	}
+	if org != "org-cached-2" {
+		t.Fatalf("org after forget = %q, want org-cached-2", org)
+	}
+	if got := rt.prov.listCalls.Load(); got != 2 {
+		t.Fatalf("list calls after forget = %d, want 2", got)
+	}
+}


### PR DESCRIPTION
## Summary

`firstManagedOrganization` called `ListManagedClusters` directly, bypassing the existing 1h RBAC cluster-list cache. On a provision request that checks both the warm pool (`claimAdminTenantFromPool`) and the shared-schema pool (`findSharedDBForProvision`, #753), the same credential paid one TiDB Cloud list call **per check**. Routing it through `listAllManagedClustersCached`:

- first lookup populates the cache, repeated checks on the same request path hit it
- consecutive provisions with the same credential hit it for the TTL window
- tenant mutations keep invalidating via `forgetTiDBCloudRBACList` (unchanged)

Small, self-contained follow-up split out of #753 review discussion.

## Test plan

- [x] New regression `TestFirstManagedOrganizationUsesRBACCache`: two lookups for one credential → one list call; `forgetTiDBCloudRBACList` → fresh fetch
- [x] Full `pkg/server` suite — pass
- [x] `make lint` — 0 issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved managed organization selection by using cached access-control information.
  * Removed failures caused by unavailable managed-cluster listing support.
  * Ensured organization data refreshes correctly after cached permissions are cleared.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->