### PR TITLE
test: retry MySQL testcontainer start on Docker ephemeral port race

### DIFF
--- a/internal/testmysql/testmysql.go
+++ b/internal/testmysql/testmysql.go
@@ -36,12 +36,28 @@ func Start(ctx context.Context) (*Instance, error) {
 	ctx, cancel := context.WithTimeout(ctx, 4*time.Minute)
 	defer cancel()
 
-	c, err := tcmysql.Run(ctx,
-		"mysql:8.0.36",
-		tcmysql.WithDatabase("dat9_test"),
-		tcmysql.WithUsername("dat9"),
-		tcmysql.WithPassword("dat9pass"),
-	)
+	// The MySQL container asks Docker for an ephemeral host port, but Docker's
+	// port allocator can lose a race on busy CI runners and fail container
+	// start with "failed to bind host port ...: address already in use".
+	// Retrying picks a fresh port and is far cheaper than re-running the job.
+	var c *tcmysql.MySQLContainer
+	var err error
+	for attempt := 1; ; attempt++ {
+		c, err = tcmysql.Run(ctx,
+			"mysql:8.0.36",
+			tcmysql.WithDatabase("dat9_test"),
+			tcmysql.WithUsername("dat9"),
+			tcmysql.WithPassword("dat9pass"),
+		)
+		if err == nil || attempt >= 3 || !isPortBindConflict(err) {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, fmt.Errorf("start mysql container: %w", ctx.Err())
+		case <-time.After(time.Duration(attempt) * 2 * time.Second):
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("start mysql container: %w", err)
 	}
@@ -159,6 +175,17 @@ func ResetDBWithoutFiles(t *testing.T, db *sql.DB) {
 			t.Fatalf("reset test db: %v", err)
 		}
 	}
+}
+
+// isPortBindConflict reports whether a container-start failure is Docker's
+// ephemeral host-port allocation race, which a retry can recover from.
+func isPortBindConflict(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "failed to bind host port") &&
+		strings.Contains(msg, "address already in use")
 }
 
 func isMissingTableError(err error) bool {

--- a/internal/testmysql/testmysql_test.go
+++ b/internal/testmysql/testmysql_test.go
@@ -1,0 +1,44 @@
+package testmysql
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsPortBindConflict(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "docker ephemeral port race",
+			err: errors.New("start container: Error response from daemon: failed to set up container networking: " +
+				"driver failed programming external connectivity on endpoint foo (abc): " +
+				"failed to bind host port for 0.0.0.0::172.18.0.2:3306/tcp: address already in use"),
+			want: true,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "image pull failure",
+			err:  errors.New("Error response from daemon: pull access denied for mysql:nope"),
+			want: false,
+		},
+		{
+			name: "address in use without bind context",
+			err:  errors.New("listen tcp :3306: address already in use"),
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPortBindConflict(tc.err); got != tc.want {
+				t.Errorf("isPortBindConflict(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

CI's `make test` / `make test-failpoint` steps flake with:

```
setup mysql test instance: start mysql container: ... Error response from daemon:
failed to set up container networking: driver failed programming external connectivity on endpoint ...:
failed to bind host port for 0.0.0.0::172.18.0.2:3306/tcp: address already in use
```

Seen at least 3 times recently (runs 29730070989, 29728174538, 29696704434); re-running the job goes green.

## Root cause

The MySQL testcontainer asks Docker for an **ephemeral** host port. Under load, Docker's port allocator can lose a race (another process grabs the picked port between allocation and bind) and the container start fails. Nothing in this repo pins a fixed host port — this is a known Docker daemon flake, not a test bug.

## Fix

`internal/testmysql.Start` now retries container startup up to 3 times (2s/4s backoff) when the error matches the port-bind signature (`failed to bind host port` + `address already in use`). Any other startup error still fails immediately. Context cancellation is honored between attempts.

## Testing

- New unit test `TestIsPortBindConflict` covers the matcher (positive case mirrors the real CI error text).
- Ran a real container-backed test: `make test TEST_RUN='TestInsertAndGetNode' TEST_PKGS='./pkg/datastore/...'` → ok.
- `golangci-lint run internal/testmysql/` → 0 issues.