### PR TITLE
e2e: existing-tenant regression + shared-mode isolation and full smokes

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -104,6 +104,47 @@ DRIVE9_TIDBCLOUD_PRIVATE_KEY="$DRIVE9_TIDBCLOUD_PRIVATE_KEY" \
 bash e2e/native-smoke-test.sh
 ```
 
+#### Existing-tenant regression
+
+After a dev release, run `api-smoke-test.sh` and `cli-smoke-test.sh` twice:
+once against an existing tenant (set `DRIVE9_API_KEY`) and once against a fresh
+provision (unset `DRIVE9_API_KEY`). In existing-tenant mode both suites skip
+provision and reuse the tenant; `api-smoke-test.sh` also cleans up its
+timestamped test tree at the end, and the upload-limit boundary checks default
+to `0` because reserving `total_size` against an existing tenant's quota can
+spuriously fail with 507.
+
+```bash
+# Export credentials from the current drive9 ctx tenant
+# (--reveal prints the full key; keep it out of logs/screenshots)
+eval "$(drive9 ctx show --json --reveal | jq -r '"export DRIVE9_BASE=\(.server)\nexport DRIVE9_API_KEY=\(.api_key)"')"
+
+# Pass 1 — existing tenant
+bash e2e/api-smoke-test.sh
+bash e2e/cli-smoke-test.sh
+
+# Or run the whole smoke-all matrix in existing-tenant mode (re-exports
+# DRIVE9_API_KEY to every sub-suite). Set RUN_API_ONLY=1 for just the core
+# api + cli pair, RUN_FUSE_SMOKE=0 on hosts without real FUSE.
+RUN_API_ONLY=1 bash e2e/smoke-all.sh
+
+# Pass 2 — fresh tenant
+unset DRIVE9_API_KEY
+bash e2e/api-smoke-test.sh
+bash e2e/cli-smoke-test.sh
+```
+
+Useful knobs for existing-tenant runs:
+
+- `RUN_CLI_FORK_CHECKS=0` — skip the fork flow. Recommended for shared-schema
+  tenants (which reject `/v1/fork` with 409) or very large tenants where
+  forking is undesirable.
+- `RUN_LARGE_FILE=0` — skip the 100MB API large-file upload.
+- `RUN_SEMANTIC_CHECKS=0` / `RUN_CLI_SEMANTIC_CHECKS=0` — skip semantic recall
+  checks when no embedding endpoint is available.
+- `RUN_UPLOAD_LIMIT_BOUNDARY=1` / `RUN_CLI_UPLOAD_LIMIT_BOUNDARY=1` — force the
+  upload-limit boundary checks back on in existing-tenant mode.
+
 ### Local via `drive9-server-local`
 
 When the task is specifically about local validation on this machine, prefer
@@ -201,6 +242,8 @@ use the same value as `DRIVE9_API_KEY` here.
 ### `api-smoke-test.sh`
 
 1. `POST /v1/provision` returns `202` with `tenant_id`, `api_key`, and `status`
+   — honors `DRIVE9_API_KEY`: when set, step 1 skips provision (emits SKIP
+   checks) and reuses the existing tenant
 2. `GET /v1/status` polled until `active`
 3. `GET /v1/fs/?list` returns `entries[]`
 4. Nested `mkdir` (`/team/...`) across multi-level paths
@@ -216,6 +259,8 @@ use the same value as `DRIVE9_API_KEY` here.
 14. Large multipart upload (`POST /v1/uploads/initiate` + presigned part uploads + complete + download checksum)
 
 15. Upload-limit boundary (`10GiB` initiate accepted, `10GiB+1` rejected)
+16. Cleanup test tree (existing-tenant mode only): `DELETE /v1/fs/team-${TS}?recursive`
+    removes the timestamped test tree so an existing tenant is not polluted
 
 ### `api-smoke-test-existing-key.sh`
 
@@ -225,7 +270,8 @@ use the same value as `DRIVE9_API_KEY` here.
 
 ### `cli-smoke-test.sh`
 
-1. Provision + readiness polling
+1. Provision + readiness polling — honors `DRIVE9_API_KEY`: when set, step 1
+   skips provision and reuses the existing tenant
 2. Prepare `drive9` CLI binary (build local or download official release)
 3. CLI fork flow (`ctx add`, `ctx fork`, fork readiness polling, fork-context file read/write, fork delete)
 4. CLI small-file flow (`cp`, `ls`, `cat`, `mv`, `symlink`, `hardlink`, `rm`)
@@ -506,6 +552,13 @@ enabled.
 5. Runs `portable-pack-unpack-e2e.sh` when `RUN_PORTABLE_PACK_E2E=1`
 6. Aggregates pass/fail at script level for quick regression checks
 
+Re-exports `DRIVE9_API_KEY` when set so every sub-suite that honors it (api,
+cli, journal, layer-fs, fuse, posix-permission, git suites, portable pack)
+runs in existing-tenant mode in one shot. Set `RUN_API_ONLY=1` to run only the
+core api + cli pair (useful for a quick existing-tenant regression). Set
+`RUN_FUSE_SMOKE=0` to skip FUSE (and derived `RUN_LAYER_FUSE_SMOKE`); macOS
+WebDAV fallback cannot satisfy symlink/hardlink asserts.
+
 ### `native-smoke-test.sh`
 
 Manual-only: requires TiDB Cloud API credentials. Not wired into CI.
@@ -538,17 +591,32 @@ with `DRIVE9_SHARED_POOL_DSN` registered as a wildcard shared pool.
 
 1. Two tenants provision — both placed on the shared DB and `active` immediately (no cluster creation)
 2. File CRUD + mkdir + directory listing on tenant A
-3. Cross-tenant isolation: same path under tenant B holds different content; B cannot read A's nested file
+3. Cross-tenant isolation:
+   - same path under A/B holds different content; B cannot read A's nested file
+   - root `?list`: B does not see A's `/docs`; B listing A's dir is 404 or 200+empty (no A children)
+   - `?grep` / `?find`: B does not return A's marker file or `note.txt`
+   - B `copy` / `hardlink` / `rename` / `delete` against A's paths returns 404; A's content intact
+   - B delete of own `/a.txt` leaves A's same-path file intact
+   - concurrent same-path writes: each tenant still reads only its own bytes
 4. Raw SQL on TiDB: rows share tables with distinct `fs_id`s; `file_nodes` is `TIDB_PK_TYPE=CLUSTERED`; no `llm_usage` table
-5. SSE `/v1/events` stream delivers initial reset + file event on a shared tenant
-6. Multipart upload (v2 initiate/parts/complete) on a shared tenant, served via redirect
+5. SSE `/v1/events`: B stream delivers reset + file event; A stream gets reset but does **not** receive B's file event
+6. Multipart upload (v2 initiate/parts/complete) on a shared tenant, served via redirect; A cannot read B's completed object; A cannot complete B's in-flight `upload_id`
 7. `POST /v1/fork` on a shared tenant is rejected (409)
 8. Standalone tenant coexistence (registered directly via `e2e/harness/standalone-tenant` with `-skip-ensure`): standalone CRUD, no `fs_id` column in its tables, no row leakage either direction
 9. Server restart persistence: both shared and standalone backends keep working
 10. `DELETE /v1/tenant` on A: shared rows purged (`file_nodes`/`inodes` empty for A's fs_id), A's key revoked (401/403), B and standalone fully intact
+11. Full `api-smoke-test.sh` then `cli-smoke-test.sh` against the same shared
+    server: each suite provisions its own fresh tenant (`DRIVE9_API_KEY` is
+    cleared). Semantic checks are forced off (`RUN_SEMANTIC_CHECKS=0`,
+    `RUN_CLI_SEMANTIC_CHECKS=0`) because the server boots with
+    `DRIVE9_DISABLE_AUTO_EMBEDDING=true`. CLI fork is forced off
+    (`RUN_CLI_FORK_CHECKS=0`) because shared tenants reject `/v1/fork` with 409.
+    SQL checks are forced off (`RUN_SQL_CHECKS=0`) because `POST /v1/sql` is
+    unsupported on shared-schema stores (`ErrExecSQLNotSupportedShared` → 400).
 
 Knobs: `META_DSN` / `SHARED_DSN` / `STANDALONE_DSN` (skip the containers),
-`KEEP_DB=1`, `DRIVE9_SHARED_E2E_DB_RUNTIME`, `DRIVE9_SHARED_E2E_MYSQL_IMAGE`,
+`KEEP_DB=1`, `RUN_SHARED_API_CLI_SMOKE=0` (skip nested api/cli suites),
+`DRIVE9_SHARED_E2E_DB_RUNTIME`, `DRIVE9_SHARED_E2E_MYSQL_IMAGE`,
 `DRIVE9_SHARED_E2E_TIDB_IMAGE`, `DRIVE9_SHARED_E2E_DB_PASSWORD`.
 
 ### `harness/standalone-tenant`
@@ -566,6 +634,8 @@ engines without FTS/vector support such as self-hosted TiDB.
 | `DRIVE9_BASE` | `http://127.0.0.1:9009` | all scripts |
 | `DRIVE9_IMAGE_FIXTURE_PATH` | `e2e/fixtures/cat03.jpg` | `api-smoke-test.sh`, `cli-smoke-test.sh` |
 | `DRIVE9_API_KEY` | - | `api-smoke-test-existing-key.sh` |
+| `DRIVE9_API_KEY` | - | `api-smoke-test.sh` (optional; when set, skip provision and reuse the tenant; cleanup test tree at end) |
+| `DRIVE9_API_KEY` | - | `cli-smoke-test.sh` (optional; when set, skip provision and reuse the tenant) |
 | `DRIVE9_API_KEY` | - | `fuse-smoke-test.sh` (optional; skip provision when set) |
 | `DRIVE9_API_KEY` | - | `posix-permission-smoke-test.sh` (optional; skip provision when set) |
 | `POLL_TIMEOUT_S` | `300` (api smoke), `120` (other smoke), `60` (existing-key) | polling scripts |
@@ -575,16 +645,17 @@ engines without FTS/vector support such as self-hosted TiDB.
 | `BATCH_SMALL_FILE_COUNT` | `10` | `api-smoke-test.sh` |
 | `REQUEST_MAX_RETRIES` | `8` | `api-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
 | `REQUEST_RETRY_SLEEP_S` | `2` | `api-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
-| `RUN_UPLOAD_LIMIT_BOUNDARY` | `1` | `api-smoke-test.sh` |
+| `RUN_UPLOAD_LIMIT_BOUNDARY` | `1` (defaults to `0` when `DRIVE9_API_KEY` is set) | `api-smoke-test.sh` |
 | `UPLOAD_LIMIT_BYTES` | `10737418240` | `api-smoke-test.sh` |
 | `RUN_SEMANTIC_CHECKS` | `1` | `api-smoke-test.sh` |
+| `RUN_SQL_CHECKS` | `1` | `api-smoke-test.sh` (set `0` for shared-schema; `POST /v1/sql` is unsupported there) |
 | `SEMANTIC_TIMEOUT_S` | `90` | `api-smoke-test.sh` |
 | `SEMANTIC_INTERVAL_S` | `3` | `api-smoke-test.sh` |
 | `CLI_LARGE_FILE_MB` | `100` | `cli-smoke-test.sh` |
 | `CLI_BATCH_SMALL_FILE_COUNT` | `10` | `cli-smoke-test.sh` |
 | `CLI_MAX_RETRIES` | `8` | `cli-smoke-test.sh` |
 | `CLI_RETRY_SLEEP_S` | `2` | `cli-smoke-test.sh` |
-| `RUN_CLI_UPLOAD_LIMIT_BOUNDARY` | `1` | `cli-smoke-test.sh` |
+| `RUN_CLI_UPLOAD_LIMIT_BOUNDARY` | `1` (defaults to `0` when `DRIVE9_API_KEY` is set) | `cli-smoke-test.sh` |
 | `CLI_UPLOAD_LIMIT_BYTES` | `10737418240` | `cli-smoke-test.sh` |
 | `RUN_CLI_SEMANTIC_CHECKS` | `1` | `cli-smoke-test.sh` |
 | `RUN_CLI_FORK_CHECKS` | `1` (auto-skip when `/v1/fork` is unavailable) | `cli-smoke-test.sh` |
@@ -642,6 +713,8 @@ engines without FTS/vector support such as self-hosted TiDB.
 | `RUN_FUSE_UMOUNT_DURABLE` | `0` (`1` in release gate) | `fuse-smoke-test.sh` |
 | `RUN_FUSE_LOG_AUDIT` | `0` (`1` in release gate) | `fuse-smoke-test.sh` |
 | `RUN_GIT_WORKSPACE_SMOKE` | `0` | `smoke-all.sh` |
+| `RUN_API_ONLY` | `0` | `smoke-all.sh` (run only api + cli, skip the rest) |
+| `RUN_SHARED_API_CLI_SMOKE` | `1` | `shared-mode-smoke-test.sh` (run nested api + cli suites after shared-mode checks; each suite fresh-provisions; fork/semantic forced off) |
 | `RUN_PORTABLE_PACK_E2E` | `0` | `smoke-all.sh`; `portable-pack-unpack-e2e.sh` is required separately by `local-e2e.yml` |
 | `GIT_WORKSPACE_REPOS` | `drive9=...,kimi-cli=...,kimi-code=...` | `git-workspace-smoke-test.sh` |
 | `GIT_WORKSPACE_SCENARIOS` | `agent_edit_add_commit,agent_patch_apply,sandbox_restore,fast_worktree` | `git-workspace-smoke-test.sh` |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -13,9 +13,9 @@ including local single-tenant validation via `drive9-server-local`.
 
 | Script | What it validates |
 |--------|--------------------|
-| `api-smoke-test.sh` | Fresh provisioning, status polling, nested+batch file ops, hardlink/copy/rename/delete checks, grep/find checks, semantic text recall, image-associated recall, sql checks, large multipart upload+download |
+| `api-smoke-test.sh` | Fresh provisioning, status polling, nested+batch file ops, hardlink/copy/rename/delete checks, grep/find checks, semantic text recall, image-associated recall, sql checks, large multipart upload+download; honors `DRIVE9_API_KEY` to skip provision and reuse an existing tenant (cleans up its test tree in that mode) |
 | `api-smoke-test-existing-key.sh` | Existing API key status/list checks |
-| `cli-smoke-test.sh` | End-to-end CLI workflow including `fs symlink`, `fs hardlink`, default-slot `pack`/`unpack`, `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download |
+| `cli-smoke-test.sh` | End-to-end CLI workflow including `fs symlink`, `fs hardlink`, default-slot `pack`/`unpack`, `fs grep`/`fs find`, semantic/image-associated recall checks, image `fs cp`+`fs find`, and large multipart `fs cp` upload/download; honors `DRIVE9_API_KEY` to skip provision and reuse an existing tenant |
 | `layer-fs-smoke-test.sh` | Layer filesystem API+CLI+FUSE workflow: create by name/tag, diff/checkpoint lookup, rollback, commit, scope rejection, conflict detection, mkdir/upsert/whiteout/rename/symlink/chmod entries, and checkpoint/full restore into fresh local roots |
 | `layer-fs-smoke-test-realdev.sh` | Manual realdev wrapper for `layer-fs-smoke-test.sh`; defaults to the shared dev endpoint and enables strict FUSE restore coverage without being wired into `local-e2e` CI |
 | `portable-pack-unpack-e2e.sh` | Portable profile pack/unpack over a deterministic local repo: offline npm `file:` install creates `node_modules`, Git staged/unstaged/untracked status changes are captured, pack writes the default hidden archive, fresh local-root unpack restores overlay files, symlinks, `.git`, `node_modules`, branch, HEAD, and `git status` |
@@ -33,7 +33,7 @@ including local single-tenant validation via `drive9-server-local`.
 | `posix-permission-smoke-test.sh` | POSIX permission coverage: API mkdir/chmod mode propagation, CLI `fs chmod`, FUSE `chmod`/`mkdir -m` with remote and local stat parity |
 | `native-smoke-test.sh` | TiDB Cloud Native tenant lifecycle: CLI provision with credentials, status poll, basic fs ops (mkdir/cp/cat/ls/rm), delete + verification, trap cleanup on failure |
 | `pjdfstest-suite.sh` | On-demand Linux/macOS pjdfstest POSIX compatibility suite over a real Drive9 FUSE mount; `pjdfstests.sh` and `posix-feature-matrix.sh` are aliases |
-| `smoke-all.sh` | Runs API + CLI + journal + layer FS + FUSE + POSIX permission smoke scripts in sequence with aggregated pass/fail; set `RUN_FUSE_SMOKE=0` to skip FUSE symlink/hardlink coverage, `RUN_GIT_OPS_SMOKE=1` to include lightweight Git coverage, `RUN_GIT_WORKSPACE_SMOKE=1` to include heavier Git workspace coverage, and `RUN_PORTABLE_PACK_E2E=1` to include portable pack/unpack coverage |
+| `smoke-all.sh` | Runs API + CLI + journal + layer FS + FUSE + POSIX permission smoke scripts in sequence with aggregated pass/fail; re-exports `DRIVE9_API_KEY` so every sub-suite runs in existing-tenant mode when set; set `RUN_FUSE_SMOKE=0` to skip FUSE symlink/hardlink coverage, `RUN_API_ONLY=1` to run only the core api + cli pair, `RUN_GIT_OPS_SMOKE=1` to include lightweight Git coverage, `RUN_GIT_WORKSPACE_SMOKE=1` to include heavier Git workspace coverage, and `RUN_PORTABLE_PACK_E2E=1` to include portable pack/unpack coverage |
 | `local-smoke.sh` | Starts `drive9-server-local` with a disposable local DB by default, then runs `smoke-all.sh` with semantic checks disabled and FUSE smoke skipped unless `RUN_FUSE_SMOKE=1` |
 
 ## CI automation tiers
@@ -196,6 +196,46 @@ bash e2e/smoke-all.sh
 # Include portable profile pack/unpack coverage in smoke-all.
 RUN_PORTABLE_PACK_E2E=1 bash e2e/smoke-all.sh
 ```
+
+#### Existing-tenant regression
+
+After a dev release, run `api-smoke-test.sh` and `cli-smoke-test.sh` twice:
+once against an existing tenant (set `DRIVE9_API_KEY`) and once against a fresh
+provision (unset `DRIVE9_API_KEY`). In existing-tenant mode both suites skip
+provision and reuse the tenant; `api-smoke-test.sh` also cleans up its
+timestamped test tree at the end, and the upload-limit boundary checks default
+to `0` because reserving `total_size` against an existing tenant's quota can
+spuriously fail with 507.
+
+```bash
+# Export credentials from the current drive9 ctx tenant
+# (--reveal prints the full key; keep it out of logs/screenshots)
+eval "$(drive9 ctx show --json --reveal | jq -r '"export DRIVE9_BASE=\(.server)\nexport DRIVE9_API_KEY=\(.api_key)"')"
+
+# Pass 1 — existing tenant
+bash e2e/api-smoke-test.sh
+bash e2e/cli-smoke-test.sh
+
+# Or run the whole smoke-all matrix in existing-tenant mode (re-exports
+# DRIVE9_API_KEY to every sub-suite). Set RUN_API_ONLY=1 for just the core
+# api + cli pair, RUN_FUSE_SMOKE=0 on hosts without real FUSE.
+RUN_API_ONLY=1 bash e2e/smoke-all.sh
+
+# Pass 2 — fresh tenant
+unset DRIVE9_API_KEY
+bash e2e/api-smoke-test.sh
+bash e2e/cli-smoke-test.sh
+```
+
+Useful knobs for existing-tenant runs:
+
+- `RUN_CLI_FORK_CHECKS=0` — skip the fork flow (shared-schema tenants reject
+  `/v1/fork` with 409; very large tenants should not be forked).
+- `RUN_LARGE_FILE=0` — skip the 100MB API large-file upload.
+- `RUN_SEMANTIC_CHECKS=0` / `RUN_CLI_SEMANTIC_CHECKS=0` — skip semantic recall
+  checks when no embedding endpoint is available.
+- `RUN_UPLOAD_LIMIT_BOUNDARY=1` / `RUN_CLI_UPLOAD_LIMIT_BOUNDARY=1` — force the
+  upload-limit boundary checks back on in existing-tenant mode.
 
 #### On-demand pjdfstest POSIX compatibility suite
 
@@ -437,9 +477,9 @@ CLI_SOURCE=official bash e2e/git-workspace-smoke-test.sh
   `GIT_OPS_CLONE_TIMEOUT_S`, `GIT_OPS_KEEP_ARTIFACTS`, and
   `GIT_OPS_TRACE_GIT`.
 - CLI source knobs are `CLI_SOURCE` (`build` or `official`), `CLI_RELEASE_BASE_URL`, and optional `CLI_RELEASE_VERSION`.
-- API upload-limit boundary check is enabled by default via `RUN_UPLOAD_LIMIT_BOUNDARY=1`.
+- API upload-limit boundary check is enabled by default via `RUN_UPLOAD_LIMIT_BOUNDARY=1`. It defaults to `0` when `DRIVE9_API_KEY` is set (existing-tenant mode), because reserving `total_size` against an already-consumed quota can spuriously fail with 507.
 - `UPLOAD_LIMIT_BYTES` controls the boundary value checked by API e2e (default `10737418240`).
-- CLI upload-limit boundary check is enabled by default via `RUN_CLI_UPLOAD_LIMIT_BOUNDARY=1`.
+- CLI upload-limit boundary check is enabled by default via `RUN_CLI_UPLOAD_LIMIT_BOUNDARY=1`. It defaults to `0` when `DRIVE9_API_KEY` is set (existing-tenant mode), for the same reason as the API check.
 - `CLI_UPLOAD_LIMIT_BYTES` controls the boundary value checked by CLI e2e (default `10737418240`).
 - `fuse-smoke-test.sh` will `SKIP` when host prerequisites are missing (for example no `/dev/fuse`) unless `FUSE_STRICT_PREREQS=1`.
 - `fuse-release-gate.sh` is the strict CI/release entry point and enables git clone/status/log, durable `umount --timeout` remount checks, mount-log audit, manifest read correctness, and SQLite rollback-journal correctness. Set `RUN_FUSE_ALL_WORKLOADS=1` to add concurrency stress, fsx-style POSIX coverage, and threshold-free performance metrics in one command. Set `RUN_FUSE_SQLITE_CORRECTNESS=0` to skip SQLite temporarily while diagnosing host-specific FUSE failures, `RUN_FUSE_CONCURRENCY_STRESS=1` to add bounded concurrency stress, `RUN_FUSE_POSIX_FSX=1` to add fsx-style POSIX coverage, or `RUN_FUSE_PERFORMANCE_BASELINE=1` to add threshold-free performance metrics.

--- a/e2e/api-smoke-test.sh
+++ b/e2e/api-smoke-test.sh
@@ -1,8 +1,20 @@
 #!/usr/bin/env bash
 # drive9 API smoke test against a live drive9-server deployment.
 #
+# Tenant mode:
+#  - Fresh (default): POST /v1/provision a new tenant, then run the suite.
+#  - Existing (DRIVE9_API_KEY set): skip provision and reuse the tenant the
+#    key belongs to. Step 1 skips provision and emits SKIP checks so the
+#    PASS/FAIL/SKIP/TOTAL accounting stays consistent. The upload-limit
+#    boundary check (step 15) defaults to OFF in this mode because reserving
+#    `total_size` against an existing tenant's quota can spuriously fail with
+#    507; an explicit RUN_UPLOAD_LIMIT_BOUNDARY=1 still wins. A final
+#    cleanup step removes the timestamped test tree (`team-${TS}`) so the
+#    existing tenant is not polluted.
+#
 # Coverage:
 #  1) Provision tenant (expect 202, tenant_id + api_key + status)
+#     - honors DRIVE9_API_KEY: skips provision when set
 #  2) Poll tenant status via GET /v1/status until active
 #  3) Root list
 #  4) Nested mkdir (multi-level directories)
@@ -17,11 +29,13 @@
 # 13) Final list verification
 # 14) 100MB multipart upload via POST /v1/uploads/initiate + download checksum
 # 15) Max-upload boundary check (limit allowed, limit+1 rejected)
+# 16) Cleanup test tree (existing tenant mode only)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASE="${DRIVE9_BASE:-http://127.0.0.1:9009}"
+API_KEY="${DRIVE9_API_KEY:-}"
 DRIVE9_IMAGE_FIXTURE_PATH="${DRIVE9_IMAGE_FIXTURE_PATH:-$SCRIPT_DIR/fixtures/cat03.jpg}"
 POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-300}"
 POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
@@ -30,11 +44,23 @@ LARGE_FILE_MB="${LARGE_FILE_MB:-100}"
 BATCH_SMALL_FILE_COUNT="${BATCH_SMALL_FILE_COUNT:-10}"
 REQUEST_MAX_RETRIES="${REQUEST_MAX_RETRIES:-8}"
 REQUEST_RETRY_SLEEP_S="${REQUEST_RETRY_SLEEP_S:-2}"
-RUN_UPLOAD_LIMIT_BOUNDARY="${RUN_UPLOAD_LIMIT_BOUNDARY:-1}"
+# Upload-limit boundary check defaults to OFF in existing-tenant mode: reserving
+# `total_size` against a tenant that already consumed quota can spuriously fail
+# with 507. An explicit RUN_UPLOAD_LIMIT_BOUNDARY still wins.
+if [ -z "${RUN_UPLOAD_LIMIT_BOUNDARY:-}" ]; then
+  if [ -n "$API_KEY" ]; then
+    RUN_UPLOAD_LIMIT_BOUNDARY=0
+  else
+    RUN_UPLOAD_LIMIT_BOUNDARY=1
+  fi
+fi
 UPLOAD_LIMIT_BYTES="${UPLOAD_LIMIT_BYTES:-10737418240}"
 SEMANTIC_TIMEOUT_S="${SEMANTIC_TIMEOUT_S:-90}"
 SEMANTIC_INTERVAL_S="${SEMANTIC_INTERVAL_S:-3}"
 RUN_SEMANTIC_CHECKS="${RUN_SEMANTIC_CHECKS:-1}"
+# Raw POST /v1/sql is unsupported on shared-schema stores (returns 400).
+# Set RUN_SQL_CHECKS=0 for shared-mode / fs_id backends.
+RUN_SQL_CHECKS="${RUN_SQL_CHECKS:-1}"
 
 PASS=0
 FAIL=0
@@ -207,9 +233,16 @@ wait_grep_contains_path() {
   check_eq "$desc" "$found" "true"
 }
 
+if [ -n "$API_KEY" ]; then
+  TENANT_MODE="existing (DRIVE9_API_KEY)"
+else
+  TENANT_MODE="fresh provision"
+fi
+
 echo "========================================================"
 echo "  drive9 API smoke test"
 echo "  Base URL : $BASE"
+echo "  Tenant   : $TENANT_MODE"
 echo "  Image fixture : $DRIVE9_IMAGE_FIXTURE_PATH"
 echo "  Started  : $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 echo "========================================================"
@@ -233,18 +266,27 @@ SEM_TEXT_OTHER="${ROOT_DIR}/notes/dog-story-${TS}.txt"
 IMAGE_CAPTION_REMOTE="${ROOT_DIR}/assets/icon-${TS}.caption.txt"
 
 step "1" "Provision tenant"
-resp=$(curl_body_code POST "$BASE/v1/provision")
-code=$(http_code "$resp")
-body=$(json_body "$resp")
-check_eq "POST /v1/provision returns 202" "$code" "202"
+if [ -z "$API_KEY" ]; then
+  resp=$(curl_body_code POST "$BASE/v1/provision")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  check_eq "POST /v1/provision returns 202" "$code" "202"
 
-API_KEY=$(printf '%s' "$body" | jq -r '.api_key // empty')
-TENANT_ID=$(printf '%s' "$body" | jq -r '.tenant_id // empty')
-INIT_STATUS=$(printf '%s' "$body" | jq -r '.status // empty')
-check_cmd "response contains tenant_id" test -n "$TENANT_ID"
-check_cmd "response contains api_key" test -n "$API_KEY"
-check_cmd "provision response status is provisioning or active (got=$INIT_STATUS)" bash -c 'case "$1" in provisioning|active) exit 0;; *) exit 1;; esac' _ "$INIT_STATUS"
-check_cmd "provision response contains api_key, status, tenant_id" bash -c "echo \"\$1\" | jq -e '.api_key and .status and .tenant_id' >/dev/null" _ "$body"
+  API_KEY=$(printf '%s' "$body" | jq -r '.api_key // empty')
+  TENANT_ID=$(printf '%s' "$body" | jq -r '.tenant_id // empty')
+  INIT_STATUS=$(printf '%s' "$body" | jq -r '.status // empty')
+  check_cmd "response contains tenant_id" test -n "$TENANT_ID"
+  check_cmd "response contains api_key" test -n "$API_KEY"
+  check_cmd "provision response status is provisioning or active (got=$INIT_STATUS)" bash -c 'case "$1" in provisioning|active) exit 0;; *) exit 1;; esac' _ "$INIT_STATUS"
+  check_cmd "provision response contains api_key, status, tenant_id" bash -c "echo \"\$1\" | jq -e '.api_key and .status and .tenant_id' >/dev/null" _ "$body"
+else
+  info "using existing DRIVE9_API_KEY (skip provision)"
+  skip_check "POST /v1/provision returns 202"
+  skip_check "response contains tenant_id"
+  skip_check "response contains api_key"
+  skip_check "provision response status is provisioning or active"
+  skip_check "provision response contains api_key, status, tenant_id"
+fi
 
 step "2" "Poll tenant status via /v1/status"
 deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
@@ -528,14 +570,20 @@ else
 fi
 
 step "11" "SQL endpoint sanity"
-sql_req='{"query":"SELECT 1 AS n"}'
-sql_body="$(mktemp)"
-code=$(curl -sS -o "$sql_body" -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" --data-binary "$sql_req" "$BASE/v1/sql")
-body=$(cat "$sql_body")
-rm -f "$sql_body"
-check_eq "POST /v1/sql returns 200" "$code" "200"
-sql_n=$(printf '%s' "$body" | jq -r '.[0].n')
-check_eq "SQL query result n=1" "$sql_n" "1"
+if [ "$RUN_SQL_CHECKS" = "1" ]; then
+  sql_req='{"query":"SELECT 1 AS n"}'
+  sql_body="$(mktemp)"
+  code=$(curl -sS -o "$sql_body" -w "%{http_code}" -X POST -H "Authorization: Bearer $API_KEY" -H "Content-Type: application/json" --data-binary "$sql_req" "$BASE/v1/sql")
+  body=$(cat "$sql_body")
+  rm -f "$sql_body"
+  check_eq "POST /v1/sql returns 200" "$code" "200"
+  sql_n=$(printf '%s' "$body" | jq -r '.[0].n')
+  check_eq "SQL query result n=1" "$sql_n" "1"
+else
+  info "SQL endpoint checks skipped (RUN_SQL_CHECKS=$RUN_SQL_CHECKS)"
+  skip_check "POST /v1/sql returns 200"
+  skip_check "SQL query result n=1"
+fi
 
 step "12" "Copy, hardlink, rename, delete"
 copy_body="$(mktemp)"
@@ -865,6 +913,13 @@ PY
 fi
 
 rm -f "$IMAGE_LOCAL"
+
+if [ -n "$API_KEY" ] && [ -n "${DRIVE9_API_KEY:-}" ]; then
+  step "16" "Cleanup test tree (existing tenant mode)"
+  resp=$(curl_body_code DELETE "$BASE/v1/fs/$ROOT_DIR?recursive" "$API_KEY")
+  code=$(http_code "$resp")
+  check_eq "DELETE /v1/fs/$ROOT_DIR?recursive returns 200" "$code" "200"
+fi
 
 echo
 echo "========================================================"

--- a/e2e/cli-smoke-test.sh
+++ b/e2e/cli-smoke-test.sh
@@ -1,10 +1,21 @@
 #!/usr/bin/env bash
 # drive9 CLI smoke test against a live deployment.
+#
+# Tenant mode:
+#  - Fresh (default): POST /v1/provision a new tenant, then run the suite.
+#  - Existing (DRIVE9_API_KEY set): skip provision and reuse the tenant the
+#    key belongs to. The CLI upload-limit boundary check (step [9]) defaults
+#    to OFF in this mode because reserving `total_size` against an existing
+#    tenant's quota can spuriously fail with 507; an explicit
+#    RUN_CLI_UPLOAD_LIMIT_BOUNDARY=1 still wins. The rest of the suite
+#    (fork flow, small-file ops, pack/archive, step [8] cleanup) is already
+#    compatible with an existing tenant and unchanged.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BASE="${DRIVE9_BASE:-http://127.0.0.1:9009}"
+API_KEY="${DRIVE9_API_KEY:-}"
 DRIVE9_IMAGE_FIXTURE_PATH="${DRIVE9_IMAGE_FIXTURE_PATH:-$SCRIPT_DIR/fixtures/cat03.jpg}"
 POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-120}"
 POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
@@ -15,7 +26,16 @@ CLI_LARGE_FILE_MB="${CLI_LARGE_FILE_MB:-100}"
 CLI_BATCH_SMALL_FILE_COUNT="${CLI_BATCH_SMALL_FILE_COUNT:-10}"
 CLI_MAX_RETRIES="${CLI_MAX_RETRIES:-8}"
 CLI_RETRY_SLEEP_S="${CLI_RETRY_SLEEP_S:-2}"
-RUN_CLI_UPLOAD_LIMIT_BOUNDARY="${RUN_CLI_UPLOAD_LIMIT_BOUNDARY:-1}"
+# CLI upload-limit boundary check defaults to OFF in existing-tenant mode
+# (same rationale as the API suite). An explicit RUN_CLI_UPLOAD_LIMIT_BOUNDARY
+# still wins.
+if [ -z "${RUN_CLI_UPLOAD_LIMIT_BOUNDARY:-}" ]; then
+  if [ -n "$API_KEY" ]; then
+    RUN_CLI_UPLOAD_LIMIT_BOUNDARY=0
+  else
+    RUN_CLI_UPLOAD_LIMIT_BOUNDARY=1
+  fi
+fi
 CLI_UPLOAD_LIMIT_BYTES="${CLI_UPLOAD_LIMIT_BYTES:-10737418240}"
 CLI_SEMANTIC_TIMEOUT_S="${CLI_SEMANTIC_TIMEOUT_S:-90}"
 CLI_SEMANTIC_INTERVAL_S="${CLI_SEMANTIC_INTERVAL_S:-3}"
@@ -116,8 +136,14 @@ prepare_cli_binary() {
   esac
 }
 
+if [ -n "$API_KEY" ]; then
+  TENANT_MODE="existing (DRIVE9_API_KEY)"
+else
+  TENANT_MODE="fresh provision"
+fi
 echo "=== drive9 CLI smoke test ==="
 echo "BASE=$BASE"
+echo "Tenant=$TENANT_MODE"
 echo "CLI_SOURCE=$CLI_SOURCE"
 echo "IMAGE_FIXTURE=$DRIVE9_IMAGE_FIXTURE_PATH"
 
@@ -130,11 +156,16 @@ fi
 check_cmd "local image fixture exists" test -s "$DRIVE9_IMAGE_FIXTURE_PATH"
 
 echo "[1] provision tenant"
-pfile="$(mktemp)"
-pcode=$(curl -sS -o "$pfile" -w "%{http_code}" -X POST "$BASE/v1/provision")
-check_eq "POST /v1/provision returns 202" "$pcode" "202"
-API_KEY=$(jq -r '.api_key // empty' "$pfile")
-check_cmd "provision returns api_key" test -n "$API_KEY"
+if [ -n "$API_KEY" ]; then
+  echo "using existing DRIVE9_API_KEY (skip provision)"
+  check_eq "use provided DRIVE9_API_KEY" "true" "true"
+else
+  pfile="$(mktemp)"
+  pcode=$(curl -sS -o "$pfile" -w "%{http_code}" -X POST "$BASE/v1/provision")
+  check_eq "POST /v1/provision returns 202" "$pcode" "202"
+  API_KEY=$(jq -r '.api_key // empty' "$pfile")
+  check_cmd "provision returns api_key" test -n "$API_KEY"
+fi
 
 echo "[2] wait tenant active"
 deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
@@ -1026,7 +1057,7 @@ PY
   rm -f "$boundary_over_payload" "$over_file"
 fi
 
-rm -f "$pfile" "$CLI_BIN" "$SMALL_LOCAL" "$HARDLINK_LOCAL" "$IMAGE_LOCAL" "$LARGE_LOCAL" "$LARGE_DOWNLOADED"
+rm -f "${pfile:-}" "$CLI_BIN" "$SMALL_LOCAL" "$HARDLINK_LOCAL" "$IMAGE_LOCAL" "$LARGE_LOCAL" "$LARGE_DOWNLOADED"
 rm -f "$TAG_LOCAL"
 rm -f "$FORK_LOCAL"
 rm -f "/tmp/drive9-cli-sem-target-${TS}.txt" "/tmp/drive9-cli-sem-other-${TS}.txt" "/tmp/drive9-cli-image-caption-${TS}.txt"

--- a/e2e/shared-mode-smoke-test.sh
+++ b/e2e/shared-mode-smoke-test.sh
@@ -6,11 +6,18 @@
 #                            standalone tenant DB (coexistence)
 #
 # Covers: provision onto shared pool (instant active), CRUD, cross-tenant
-# isolation, SSE events, multipart upload, fork rejection, shared delete +
-# purge, server restart persistence, and standalone↔shared coexistence.
+# isolation (read/list/grep/find/copy/hardlink/rename/delete, concurrent
+# same-path writes, SSE non-leak, multipart session ownership), SSE events,
+# multipart upload, fork rejection, shared delete + purge, server restart
+# persistence, standalone↔shared coexistence, then the full
+# api-smoke-test.sh + cli-smoke-test.sh suites against the same shared
+# server (each suite provisions its own fresh tenant; fork/sql/semantic skipped).
 #
 # Override endpoints to skip containers:
 #   META_DSN=... SHARED_DSN=... STANDALONE_DSN=... bash e2e/shared-mode-smoke-test.sh
+#
+# Knobs:
+#   RUN_SHARED_API_CLI_SMOKE=0  skip the nested api/cli suites (default 1)
 
 set -euo pipefail
 
@@ -30,6 +37,10 @@ STANDALONE_DSN="${STANDALONE_DSN:-}"
 KEEP_DB="${KEEP_DB:-0}"
 POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-180}"
 POLL_INTERVAL_S="${POLL_INTERVAL_S:-2}"
+# After the shared-mode-specific checks, re-run the full API + CLI smoke suites
+# against this shared server. Each suite provisions its own tenant (DRIVE9_API_KEY
+# is cleared). Default on; set RUN_SHARED_API_CLI_SMOKE=0 to skip.
+RUN_SHARED_API_CLI_SMOKE="${RUN_SHARED_API_CLI_SMOKE:-1}"
 
 # Remember which endpoints were supplied externally: the container startup
 # paths assign these variables too, and only externally supplied endpoints
@@ -180,7 +191,53 @@ http() { # method path [api_key] [body]
   code=$(curl "${args[@]}" "http://127.0.0.1:${SERVER_PORT}${path}" 2>/dev/null) || code="000"
   printf '%s|%s' "$code" "$(cat "$TMP_DIR/resp.json" 2>/dev/null || true)"
 }
+# http_hdr METHOD PATH API_KEY HEADER_NAME HEADER_VALUE [HEADER_NAME HEADER_VALUE ...]
+# Used for copy/hardlink/rename which carry the source path in a header.
+http_hdr() {
+  local method="$1" path="$2" key="$3"
+  shift 3
+  local args=(-sS -o "$TMP_DIR/resp.json" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $key")
+  while [ "$#" -ge 2 ]; do
+    args+=(-H "$1: $2")
+    shift 2
+  done
+  local code
+  code=$(curl "${args[@]}" "http://127.0.0.1:${SERVER_PORT}${path}" 2>/dev/null) || code="000"
+  printf '%s|%s' "$code" "$(cat "$TMP_DIR/resp.json" 2>/dev/null || true)"
+}
 field() { printf '%s' "$2" | python3 -c "import sys,json;print(json.load(sys.stdin).get('$1',''))" 2>/dev/null || true; }
+# list_has_name BODY NAME → "true"/"false" for list responses {entries:[{name:...}]}
+list_has_name() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+name = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("false"); raise SystemExit
+entries = data.get("entries") if isinstance(data, dict) else None
+if not isinstance(entries, list):
+    print("false"); raise SystemExit
+print("true" if any(isinstance(e, dict) and e.get("name") == name for e in entries) else "false")
+' "$2" 2>/dev/null || echo "false"
+}
+# search_has_path BODY PATH → "true"/"false" for grep/find arrays [{path:...}].
+# Accepts paths with or without a leading slash (API responses vary by suite).
+search_has_path() {
+  printf '%s' "$1" | python3 -c '
+import json, sys
+want = sys.argv[1].lstrip("/")
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    print("false"); raise SystemExit
+if not isinstance(data, list):
+    print("false"); raise SystemExit
+def norm(p):
+    return (p or "").lstrip("/")
+print("true" if any(isinstance(e, dict) and norm(e.get("path")) == want for e in data) else "false")
+' "$2" 2>/dev/null || echo "false"
+}
 
 start_server() {
   env \
@@ -279,6 +336,102 @@ check_eq "A still reads its own /a.txt content" "hello from A" "${resp#*|}"
 resp=$(http GET /v1/fs/docs/note.txt "$B_KEY")
 check_eq "B cannot read A's /docs/note.txt" "404" "${resp%%|*}"
 
+# ============ 2b. Cross-tenant isolation: list / grep / find / mutations ============
+# A-only marker used for search isolation (unique string B must never see).
+ISOLATION_MARKER="shared-isolation-marker-A-only"
+resp=$(http PUT /v1/fs/docs/secret-a.txt "$A_KEY" "$ISOLATION_MARKER")
+check_eq "A write isolation marker returns 200" "200" "${resp%%|*}"
+
+# Root list: each tenant only sees its own tree (B must not see A's /docs).
+resp=$(http GET "/v1/fs/?list" "$A_KEY")
+check_eq "A root list returns 200" "200" "${resp%%|*}"
+check_eq "A root list includes a.txt" "true" "$(list_has_name "${resp#*|}" "a.txt")"
+check_eq "A root list includes docs/" "true" "$(list_has_name "${resp#*|}" "docs")"
+resp=$(http GET "/v1/fs/?list" "$B_KEY")
+check_eq "B root list returns 200" "200" "${resp%%|*}"
+check_eq "B root list includes a.txt" "true" "$(list_has_name "${resp#*|}" "a.txt")"
+check_eq "B root list does NOT include A's docs/" "false" "$(list_has_name "${resp#*|}" "docs")"
+
+# B listing a directory that only exists under A must not leak A's children.
+# Product behavior: missing dir may be 404 or 200+empty entries; either is fine
+# as long as A's note.txt / secret-a.txt never appear.
+resp=$(http GET "/v1/fs/docs/?list" "$B_KEY")
+B_DOCS_CODE="${resp%%|*}"
+B_DOCS_BODY="${resp#*|}"
+case "$B_DOCS_CODE" in
+  404) pass "B list of A's /docs returns 404" ;;
+  200)
+    pass "B list of A's /docs returns 200 (empty-or-local only)"
+    check_eq "B list /docs does NOT include note.txt" "false" "$(list_has_name "$B_DOCS_BODY" "note.txt")"
+    check_eq "B list /docs does NOT include secret-a.txt" "false" "$(list_has_name "$B_DOCS_BODY" "secret-a.txt")"
+    entry_n=$(printf '%s' "$B_DOCS_BODY" | python3 -c 'import json,sys
+try:
+  d=json.load(sys.stdin); e=d.get("entries") if isinstance(d,dict) else None
+  print(len(e) if isinstance(e,list) else -1)
+except Exception:
+  print(-1)')
+    check_eq "B list /docs entry count is 0" "0" "$entry_n"
+    ;;
+  *) fail "B list of A's /docs unexpected status $B_DOCS_CODE body=$B_DOCS_BODY" ;;
+esac
+
+# Grep: A finds its marker; B's grep for the same string is empty.
+resp=$(http GET "/v1/fs/?grep=shared-isolation-marker-A-only&limit=20" "$A_KEY")
+check_eq "A grep isolation marker returns 200" "200" "${resp%%|*}"
+check_eq "A grep finds /docs/secret-a.txt" "true" "$(search_has_path "${resp#*|}" "/docs/secret-a.txt")"
+resp=$(http GET "/v1/fs/?grep=shared-isolation-marker-A-only&limit=20" "$B_KEY")
+check_eq "B grep isolation marker returns 200" "200" "${resp%%|*}"
+check_eq "B grep does NOT find A's secret" "false" "$(search_has_path "${resp#*|}" "/docs/secret-a.txt")"
+# Empty array is also fine; any hit with A's path is a leak.
+case "${resp#*|}" in *secret-a*|*isolation-marker*) fail "B grep body leaked A content: ${resp#*|}" ;; *) pass "B grep body has no A marker/path" ;; esac
+
+# Find by name: note.txt only exists under A.
+resp=$(http GET "/v1/fs/?find=&name=note.txt" "$A_KEY")
+check_eq "A find note.txt returns 200" "200" "${resp%%|*}"
+check_eq "A find returns /docs/note.txt" "true" "$(search_has_path "${resp#*|}" "/docs/note.txt")"
+resp=$(http GET "/v1/fs/?find=&name=note.txt" "$B_KEY")
+check_eq "B find note.txt returns 200" "200" "${resp%%|*}"
+check_eq "B find does NOT return A's note.txt" "false" "$(search_has_path "${resp#*|}" "/docs/note.txt")"
+
+# Mutations must not reach the other tenant's namespace (source missing → 404).
+resp=$(http_hdr POST "/v1/fs/stolen-copy.txt?copy" "$B_KEY" "X-Dat9-Copy-Source" "/docs/note.txt")
+check_eq "B copy from A's /docs/note.txt returns 404" "404" "${resp%%|*}"
+resp=$(http_hdr POST "/v1/fs/stolen-link.txt?hardlink=1" "$B_KEY" "X-Dat9-Hardlink-Source" "/docs/note.txt")
+check_eq "B hardlink from A's /docs/note.txt returns 404" "404" "${resp%%|*}"
+resp=$(http_hdr POST "/v1/fs/stolen-renamed.txt?rename" "$B_KEY" "X-Dat9-Rename-Source" "/docs/note.txt")
+check_eq "B rename of A's /docs/note.txt returns 404" "404" "${resp%%|*}"
+resp=$(http DELETE /v1/fs/docs/note.txt "$B_KEY")
+check_eq "B delete of A's /docs/note.txt returns 404" "404" "${resp%%|*}"
+resp=$(http GET /v1/fs/docs/note.txt "$A_KEY")
+check_eq "A still has /docs/note.txt after B mutation attempts" "nested note" "${resp#*|}"
+
+# Delete own path must not affect the peer's same-path file.
+resp=$(http DELETE /v1/fs/a.txt "$B_KEY")
+check_eq "B delete own /a.txt returns 200" "200" "${resp%%|*}"
+resp=$(http GET /v1/fs/a.txt "$A_KEY")
+check_eq "A /a.txt intact after B deletes same path" "hello from A" "${resp#*|}"
+resp=$(http GET /v1/fs/a.txt "$B_KEY")
+check_eq "B /a.txt gone after self-delete" "404" "${resp%%|*}"
+# Restore B's /a.txt for later shared-mode steps (restart / standalone checks).
+resp=$(http PUT /v1/fs/a.txt "$B_KEY" "hello from B")
+check_eq "B restore /a.txt returns 200" "200" "${resp%%|*}"
+
+# Concurrent same-path writes: each tenant still reads only its own bytes.
+# Use dedicated curl (not http()) so concurrent jobs do not share resp.json.
+curl -sS -o /dev/null -X PUT \
+  -H "Authorization: Bearer $A_KEY" -H "Content-Type: application/octet-stream" \
+  --data-binary "race-from-A" "http://127.0.0.1:${SERVER_PORT}/v1/fs/race.txt" &
+PID_A=$!
+curl -sS -o /dev/null -X PUT \
+  -H "Authorization: Bearer $B_KEY" -H "Content-Type: application/octet-stream" \
+  --data-binary "race-from-B" "http://127.0.0.1:${SERVER_PORT}/v1/fs/race.txt" &
+PID_B=$!
+wait "$PID_A" "$PID_B" || true
+resp=$(http GET /v1/fs/race.txt "$A_KEY")
+check_eq "A reads own race.txt after concurrent write" "race-from-A" "${resp#*|}"
+resp=$(http GET /v1/fs/race.txt "$B_KEY")
+check_eq "B reads own race.txt after concurrent write" "race-from-B" "${resp#*|}"
+
 # ============ 3. Raw SQL on TiDB: fs_id isolation + CLUSTERED ============
 if [ -n "$TIDB_CONTAINER" ]; then
   A_FS_ID=$(meta_exec "SELECT fs_id FROM $META_DB.fs_registry WHERE tenant_id='$A_TENANT';")
@@ -296,21 +449,37 @@ if [ -n "$TIDB_CONTAINER" ]; then
   check_eq "shared DB has no llm_usage table" "0" "${N:-?}"
 fi
 
-# ============ 4. SSE events on shared tenant ============
+# ============ 4. SSE events on shared tenant (+ cross-tenant non-leak) ============
 SSE_OUT="$TMP_DIR/sse.log"
+SSE_A_OUT="$TMP_DIR/sse-a.log"
 curl -sS -N --max-time 12 -H "Authorization: Bearer $B_KEY" \
   "http://127.0.0.1:$SERVER_PORT/v1/events?since=0" >"$SSE_OUT" 2>/dev/null &
 SSE_PID=$!
+curl -sS -N --max-time 12 -H "Authorization: Bearer $A_KEY" \
+  "http://127.0.0.1:$SERVER_PORT/v1/events?since=0" >"$SSE_A_OUT" 2>/dev/null &
+SSE_A_PID=$!
 sleep 2
 resp=$(http PUT /v1/fs/sse-target.txt "$B_KEY" "sse payload")
 check_eq "B write for SSE returns 200" "200" "${resp%%|*}"
 sleep 4
 kill "$SSE_PID" >/dev/null 2>&1 || true
+kill "$SSE_A_PID" >/dev/null 2>&1 || true
 wait "$SSE_PID" 2>/dev/null || true
+wait "$SSE_A_PID" 2>/dev/null || true
 if grep -q "initial_sync\|server_restart" "$SSE_OUT" && grep -q "sse-target.txt" "$SSE_OUT"; then
   pass "SSE stream delivered reset + file event for shared tenant"
 else
   fail "SSE stream missing events: $(head -c 400 "$SSE_OUT")"
+fi
+if grep -q "initial_sync\|server_restart" "$SSE_A_OUT"; then
+  pass "A SSE stream delivered reset event"
+else
+  fail "A SSE stream missing reset: $(head -c 400 "$SSE_A_OUT")"
+fi
+if grep -q "sse-target.txt" "$SSE_A_OUT"; then
+  fail "A SSE stream leaked B's sse-target.txt event"
+else
+  pass "A SSE stream does not contain B's sse-target.txt"
 fi
 
 # ============ 5. Multipart upload (v2) on shared tenant ============
@@ -381,6 +550,50 @@ else
   resp=$(http GET /v1/fs/big.bin "$B_KEY")
   check_eq "multipart file readable inline" "200" "${resp%%|*}"
 fi
+# Peer tenant must not see the completed multipart object.
+resp=$(http GET /v1/fs/big.bin "$A_KEY")
+check_eq "A cannot read B's multipart /big.bin" "404" "${resp%%|*}"
+# Upload session ownership: A cannot complete B's in-flight upload_id.
+jq -n --arg path "/iso-upload.bin" --argjson total_size 10485760 --arg checksums "$CHECKSUMS" \
+  '{path:$path,total_size:$total_size,part_checksums:($checksums|split(","))}' > "$TMP_DIR/init-iso.json"
+code=$(curl -sS -o "$TMP_DIR/plan-iso.json" -w "%{http_code}" -X POST \
+  -H "Authorization: Bearer $B_KEY" -H "Content-Type: application/json" \
+  --data-binary "@$TMP_DIR/init-iso.json" "http://127.0.0.1:$SERVER_PORT/v1/uploads/initiate")
+check_eq "B isolation multipart initiate returns 202" "202" "$code"
+ISO_UPLOAD_ID=$(jq -r '.upload_id // empty' "$TMP_DIR/plan-iso.json")
+[ -n "$ISO_UPLOAD_ID" ] && pass "B isolation upload_id issued" || fail "B isolation upload_id empty"
+resp=$(http POST "/v1/uploads/$ISO_UPLOAD_ID/complete" "$A_KEY")
+# Wrong-tenant complete must not succeed (404 not-found or 403 forbidden).
+case "${resp%%|*}" in
+  404|403) pass "A cannot complete B's upload session (got ${resp%%|*})" ;;
+  *) fail "A complete of B's upload want 404/403 got ${resp%%|*} body=${resp#*|}" ;;
+esac
+# B can still complete its own session after parts are uploaded.
+python3 - "$TMP_DIR/plan-iso.json" "$BIG_FILE" <<'PY'
+import json, sys, urllib.request
+plan_path, file_path = sys.argv[1], sys.argv[2]
+plan = json.load(open(plan_path))
+with open(file_path, "rb") as data_file:
+    for idx, p in enumerate(plan.get("parts", []), 1):
+        size = int(p["size"])
+        data = data_file.read(size)
+        if len(data) != size:
+            raise SystemExit(f"short read part {idx}")
+        req = urllib.request.Request(p["url"], data=data, method="PUT")
+        req.add_header("Content-Length", str(size))
+        for hk, hv in (p.get("headers") or {}).items():
+            req.add_header(hk, hv)
+        if p.get("checksum_crc32c"):
+            req.add_header("x-amz-checksum-crc32c", p["checksum_crc32c"])
+        with urllib.request.urlopen(req, timeout=120) as resp:
+            if getattr(resp, "status", 200) >= 300:
+                raise SystemExit(f"part {idx} HTTP {resp.status}")
+PY
+check_eq "B isolation multipart parts uploaded" "0" "$?"
+resp=$(http POST "/v1/uploads/$ISO_UPLOAD_ID/complete" "$B_KEY")
+check_eq "B completes own isolation upload" "200" "${resp%%|*}"
+resp=$(http GET /v1/fs/iso-upload.bin "$A_KEY")
+check_eq "A cannot read B's iso-upload.bin" "404" "${resp%%|*}"
 
 # ============ 6. Fork rejected on shared tenant ============
 resp=$(http POST /v1/fork "$B_KEY")
@@ -437,6 +650,43 @@ if [ -n "$TIDB_CONTAINER" ]; then
   check_eq "A's inodes purged from shared DB" "0" "${N:-?}"
   N=$(tidb_exec "SELECT COUNT(*) FROM $SHARED_DB.file_nodes WHERE fs_id=$B_FS_ID;")
   [ "${N:-0}" -ge 1 ] && pass "B's rows still in shared DB" || fail "B's rows missing after A purge"
+fi
+
+# ============ 10. Full API + CLI smoke (fresh tenants each) ============
+# Reuse the live shared-mode server for the broad regression suites. Each
+# suite provisions its own tenant; we intentionally do not hand them A/B/S
+# keys. Semantic checks are off because this server boots with
+# DRIVE9_DISABLE_AUTO_EMBEDDING=true. Fork is unsupported on shared tenants
+# (409), so RUN_CLI_FORK_CHECKS=0.
+run_full_smoke() {
+  local name="$1"
+  local script="$2"
+  log "=== [$name] $script (fresh provision against shared server) ==="
+  set +e
+  # -u DRIVE9_API_KEY forces fresh provision even if the outer env has a key.
+  # Semantic is off (no auto-embedding). Fork is off (shared tenants 409).
+  # SQL is off (ExecSQL is unsupported on shared-schema stores).
+  env -u DRIVE9_API_KEY \
+    DRIVE9_BASE="http://127.0.0.1:$SERVER_PORT" \
+    RUN_SEMANTIC_CHECKS=0 \
+    RUN_CLI_SEMANTIC_CHECKS=0 \
+    RUN_CLI_FORK_CHECKS=0 \
+    RUN_SQL_CHECKS=0 \
+    bash "$script"
+  local rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    pass "$name smoke against shared server"
+  else
+    fail "$name smoke against shared server (rc=$rc)"
+  fi
+}
+
+if [ "$RUN_SHARED_API_CLI_SMOKE" = "1" ]; then
+  run_full_smoke "api" "e2e/api-smoke-test.sh"
+  run_full_smoke "cli" "e2e/cli-smoke-test.sh"
+else
+  log "skipping nested api/cli smoke (RUN_SHARED_API_CLI_SMOKE=$RUN_SHARED_API_CLI_SMOKE)"
 fi
 
 log "all shared-mode e2e checks done"

--- a/e2e/smoke-all.sh
+++ b/e2e/smoke-all.sh
@@ -1,9 +1,31 @@
 #!/usr/bin/env bash
 # Run all drive9 smoke tests (API + CLI + journal + layer FS + FUSE).
+#
+# Tenant mode:
+#  - Fresh (default): each suite provisions its own tenant.
+#  - Existing (DRIVE9_API_KEY set in the environment): every suite that honors
+#    DRIVE9_API_KEY (api, cli, journal, layer-fs, fuse, posix-permission, git
+#    suites, portable pack) skips provision and reuses the tenant the key
+#    belongs to. The key is explicitly re-exported below so a future `env -u`
+#    in run_case cannot silently drop it.
+#
+# Subset knobs:
+#  - RUN_API_ONLY=1 runs only api + cli (the core two). Useful for a quick
+#    existing-tenant regression without pulling in journal/layer-fs/fuse.
+#  - RUN_FUSE_SMOKE=0 skips the FUSE suite (and derives RUN_LAYER_FUSE_SMOKE
+#    from it). macOS WebDAV fallback cannot satisfy symlink/hardlink asserts.
+#  - RUN_GIT_OPS_SMOKE=1 / RUN_GIT_WORKSPACE_SMOKE=1 / RUN_PORTABLE_PACK_E2E=1
+#    opt into the heavier optional suites.
 
 set -euo pipefail
 
 BASE="${DRIVE9_BASE:-http://127.0.0.1:9009}"
+# Re-export explicitly so the existing-tenant intent is durable across run_case
+# subprocesses; do not rely on implicit inheritance.
+if [ -n "${DRIVE9_API_KEY:-}" ]; then
+  export DRIVE9_API_KEY
+fi
+RUN_API_ONLY="${RUN_API_ONLY:-0}"
 RUN_GIT_OPS_SMOKE="${RUN_GIT_OPS_SMOKE:-0}"
 RUN_GIT_WORKSPACE_SMOKE="${RUN_GIT_WORKSPACE_SMOKE:-0}"
 RUN_FUSE_SMOKE="${RUN_FUSE_SMOKE:-1}"
@@ -34,41 +56,63 @@ run_case() {
   fi
 }
 
+skip_case() {
+  local name="$1"
+  local script="$2"
+  local reason="$3"
+  echo
+  echo "=== [$name] $script ==="
+  echo "SKIP [$name] $reason"
+}
+
+if [ -n "${DRIVE9_API_KEY:-}" ]; then
+  TENANT_MODE="existing (DRIVE9_API_KEY)"
+else
+  TENANT_MODE="fresh provision"
+fi
+
 echo "=== drive9 smoke-all ==="
 echo "BASE=$BASE"
+echo "Tenant=$TENANT_MODE"
+if [ "$RUN_API_ONLY" = "1" ]; then
+  echo "RUN_API_ONLY=1 (core two suites only)"
+fi
 
 run_case "api" "e2e/api-smoke-test.sh"
 run_case "cli" "e2e/cli-smoke-test.sh"
-run_case "journal" "e2e/journal-smoke-test.sh"
-run_case "layer-fs" "e2e/layer-fs-smoke-test.sh"
-if [ "$RUN_FUSE_SMOKE" = "1" ]; then
-  run_case "fuse" "e2e/fuse-smoke-test.sh"
+
+if [ "$RUN_API_ONLY" = "1" ]; then
+  skip_case "journal" "e2e/journal-smoke-test.sh" "set RUN_API_ONLY=0 to run journal coverage"
+  skip_case "layer-fs" "e2e/layer-fs-smoke-test.sh" "set RUN_API_ONLY=0 to run layer-fs coverage"
+  skip_case "fuse" "e2e/fuse-smoke-test.sh" "set RUN_API_ONLY=0 to run FUSE coverage"
+  skip_case "posix-permission" "e2e/posix-permission-smoke-test.sh" "set RUN_API_ONLY=0 to run posix-permission coverage"
+  skip_case "git-ops" "e2e/git-ops-smoke-test.sh" "set RUN_API_ONLY=0 to run Git ops coverage"
+  skip_case "git-workspace" "e2e/git-workspace-smoke-test.sh" "set RUN_API_ONLY=0 to run Git workspace coverage"
+  skip_case "portable-pack-unpack" "e2e/portable-pack-unpack-e2e.sh" "set RUN_API_ONLY=0 to run portable pack/unpack coverage"
 else
-  echo
-  echo "=== [fuse] e2e/fuse-smoke-test.sh ==="
-  echo "SKIP [fuse] set RUN_FUSE_SMOKE=1 to run FUSE symlink/hardlink coverage"
-fi
-run_case "posix-permission" "e2e/posix-permission-smoke-test.sh"
-if [ "$RUN_GIT_OPS_SMOKE" = "1" ]; then
-  run_case "git-ops" "e2e/git-ops-smoke-test.sh"
-else
-  echo
-  echo "=== [git-ops] e2e/git-ops-smoke-test.sh ==="
-  echo "SKIP [git-ops] set RUN_GIT_OPS_SMOKE=1 to run lightweight Git clone/status/restore coverage"
-fi
-if [ "$RUN_GIT_WORKSPACE_SMOKE" = "1" ]; then
-  run_case "git-workspace" "e2e/git-workspace-smoke-test.sh"
-else
-  echo
-  echo "=== [git-workspace] e2e/git-workspace-smoke-test.sh ==="
-  echo "SKIP [git-workspace] set RUN_GIT_WORKSPACE_SMOKE=1 to run fast-clone Git workspace coverage"
-fi
-if [ "$RUN_PORTABLE_PACK_E2E" = "1" ]; then
-  run_case "portable-pack-unpack" "e2e/portable-pack-unpack-e2e.sh"
-else
-  echo
-  echo "=== [portable-pack-unpack] e2e/portable-pack-unpack-e2e.sh ==="
-  echo "SKIP [portable-pack-unpack] set RUN_PORTABLE_PACK_E2E=1 to run portable profile pack/unpack coverage"
+  run_case "journal" "e2e/journal-smoke-test.sh"
+  run_case "layer-fs" "e2e/layer-fs-smoke-test.sh"
+  if [ "$RUN_FUSE_SMOKE" = "1" ]; then
+    run_case "fuse" "e2e/fuse-smoke-test.sh"
+  else
+    skip_case "fuse" "e2e/fuse-smoke-test.sh" "set RUN_FUSE_SMOKE=1 to run FUSE symlink/hardlink coverage"
+  fi
+  run_case "posix-permission" "e2e/posix-permission-smoke-test.sh"
+  if [ "$RUN_GIT_OPS_SMOKE" = "1" ]; then
+    run_case "git-ops" "e2e/git-ops-smoke-test.sh"
+  else
+    skip_case "git-ops" "e2e/git-ops-smoke-test.sh" "set RUN_GIT_OPS_SMOKE=1 to run lightweight Git clone/status/restore coverage"
+  fi
+  if [ "$RUN_GIT_WORKSPACE_SMOKE" = "1" ]; then
+    run_case "git-workspace" "e2e/git-workspace-smoke-test.sh"
+  else
+    skip_case "git-workspace" "e2e/git-workspace-smoke-test.sh" "set RUN_GIT_WORKSPACE_SMOKE=1 to run fast-clone Git workspace coverage"
+  fi
+  if [ "$RUN_PORTABLE_PACK_E2E" = "1" ]; then
+    run_case "portable-pack-unpack" "e2e/portable-pack-unpack-e2e.sh"
+  else
+    skip_case "portable-pack-unpack" "e2e/portable-pack-unpack-e2e.sh" "set RUN_PORTABLE_PACK_E2E=1 to run portable profile pack/unpack coverage"
+  fi
 fi
 
 echo


### PR DESCRIPTION
## Summary

This PR tightens two e2e coverage gaps that both matter after shared-schema landed:

1. **Existing-tenant regression** — run the core API/CLI smokes against a live tenant without re-provisioning (post-dev-release check).
2. **Shared-mode depth** — exercise multi-tenant isolation more thoroughly, then re-run the full API + CLI smokes on a real shared-schema server.

### Existing-tenant mode

- `api-smoke-test.sh` / `cli-smoke-test.sh` honor `DRIVE9_API_KEY`: skip `POST /v1/provision` and reuse the tenant.
- API suite cleans up its timestamped `team-${TS}` tree at the end in existing-tenant mode so the tenant is not polluted.
- Upload-limit boundary checks default **off** when `DRIVE9_API_KEY` is set (reserving `total_size` against an already-used quota can spuriously 507); explicit `RUN_*_UPLOAD_LIMIT_BOUNDARY=1` still wins.
- `smoke-all.sh` re-exports `DRIVE9_API_KEY` to every sub-suite and adds `RUN_API_ONLY=1` for a quick api+cli pair.
- Docs updated in `e2e/AGENTS.md` and `e2e/README.md` with the two-pass (existing then fresh) workflow.

```bash
eval "$(drive9 ctx show --json --reveal | jq -r '"export DRIVE9_BASE=\(.server)\nexport DRIVE9_API_KEY=\(.api_key)"')"
RUN_API_ONLY=1 bash e2e/smoke-all.sh   # existing tenant
unset DRIVE9_API_KEY
bash e2e/api-smoke-test.sh && bash e2e/cli-smoke-test.sh  # fresh
```

### Shared-mode smoke expansion

`shared-mode-smoke-test.sh` still owns its specialized shared-schema checks, and now also:

**Cross-tenant isolation (A vs B on the same shared DB)**
- Root `?list` does not leak peer dirs; peer dir list is 404 or 200+empty with no foreign children
- `?grep` / `?find` do not return the other tenant’s marker / `note.txt`
- Peer `copy` / `hardlink` / `rename` / `delete` of foreign paths → 404; source content intact
- Delete own same-path file does not affect the peer
- Concurrent same-path writes: each tenant still reads only its own bytes
- SSE: peer stream gets reset but not the other tenant’s file event
- Multipart: peer cannot read completed object; peer cannot complete foreign `upload_id`

**Nested full suites (fresh tenants each, not reusing A/B keys)**
- After specialized checks, runs `api-smoke-test.sh` then `cli-smoke-test.sh` against the same shared server
- Forces `RUN_CLI_FORK_CHECKS=0` (shared fork → 409)
- Forces `RUN_SEMANTIC_CHECKS=0` / `RUN_CLI_SEMANTIC_CHECKS=0` (server boots with auto-embedding disabled)
- Forces `RUN_SQL_CHECKS=0` (new knob on api-smoke; `POST /v1/sql` is unsupported on shared-schema stores)
- Opt out with `RUN_SHARED_API_CLI_SMOKE=0`

## Test plan

- [x] `RUN_SHARED_API_CLI_SMOKE=0 bash e2e/shared-mode-smoke-test.sh` — isolation + specialized checks green (`passed=83 failed=0`)
- [x] Full `bash e2e/shared-mode-smoke-test.sh` — nested api (94 pass / 13 skip) + cli (86 pass / 11 skip) green after `RUN_SQL_CHECKS=0`
- [ ] Optional: existing-tenant pass against a live ctx tenant  
      `DRIVE9_API_KEY=... RUN_API_ONLY=1 bash e2e/smoke-all.sh`
- [ ] Optional: fresh provision pass with `DRIVE9_API_KEY` unset

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for running API and CLI smoke tests with either fresh or existing tenants.
  * Documented new controls for limiting suites, skipping optional checks, and configuring upload-boundary tests.

* **Testing**
  * Added existing-tenant regression support with optional cleanup.
  * Expanded shared-mode coverage for tenant isolation, SSE events, multipart uploads, and cross-tenant operations.
  * Added clearer skip reporting and configurable API, CLI, and shared-mode test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->