### PR TITLE
Refill tenant pool at a fixed rate with async dispatch

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -183,10 +183,11 @@ func main() {
 	if err != nil {
 		die(err)
 	}
-	tenantPoolRefillFreeRatio, err := tenantPoolRefillFreeRatioFromEnv()
+	tenantPoolRefillBatchSize, err := tenantPoolRefillBatchSizeFromEnv()
 	if err != nil {
 		die(err)
 	}
+	tenantPoolRefillInterval := envDuration("DRIVE9_TENANT_POOL_REFILL_INTERVAL", server.DefaultTenantPoolRefillInterval)
 	maxUploadBytes := server.DefaultMaxUploadBytes
 	if raw := os.Getenv("DRIVE9_MAX_UPLOAD_BYTES"); raw != "" {
 		maxUploadBytes, err = strconv.ParseInt(raw, 10, 64)
@@ -436,7 +437,8 @@ func main() {
 		S3Dir:                           s3cfg.Dir,
 		MaxUploadBytes:                  maxUploadBytes,
 		TenantPoolMaxSize:               tenantPoolMaxSize,
-		TenantPoolRefillFreeRatio:       tenantPoolRefillFreeRatio,
+		TenantPoolRefillBatchSize:       tenantPoolRefillBatchSize,
+		TenantPoolRefillInterval:        tenantPoolRefillInterval,
 		InlineThreshold:                 backendOptions.InlineThreshold,
 		Logger:                          srvLogger,
 		SemanticEmbedder:                semanticEmbedder,
@@ -659,7 +661,10 @@ environment:
   DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST legacy tencentcloud private endpoint fallback host, used only when host map is unset
   DRIVE9_TIDBCLOUD_ALICLOUD_PRIVATE_ENDPOINT_DOMAIN legacy alicloud private endpoint fallback domain, used only when host map is unset
   DRIVE9_TENANT_POOL_MAX_SIZE maximum admin tenant pool size (default: %d)
-  DRIVE9_TENANT_POOL_REFILL_FREE_RATIO claim-triggered refill runs when active free tenants fall below this ratio (default: %.2f)
+  DRIVE9_TENANT_POOL_REFILL_BATCH_SIZE async cluster creations dispatched per refill round (default: %d)
+  DRIVE9_TENANT_POOL_REFILL_INTERVAL delay between refill dispatch rounds (default: %s);
+                                             caps the cluster-creation start rate at batch-size/interval,
+                                             independent of how long individual creations take
   DRIVE9_SLOCK_ORIGIN Slock browser origin; when set, enables /v1/auth/slock/*
   DRIVE9_SLOCK_API_ORIGIN Slock API origin (required when DRIVE9_SLOCK_ORIGIN is set)
   DRIVE9_SLOCK_CLIENT_ID Slock connected-app client id (required when DRIVE9_SLOCK_ORIGIN is set)
@@ -757,7 +762,7 @@ environment:
 schema tooling:
   dump-init-sql writes the exact init schema SQL to stdout so external systems
   can stay in sync with drive9's schema source of truth.
-`, server.DefaultMaxUploadBytes, meta.DefaultMaxStorageBytes(), server.DefaultTenantPoolMaxSize, server.DefaultTenantPoolRefillFreeRatio)
+`, server.DefaultMaxUploadBytes, meta.DefaultMaxStorageBytes(), server.DefaultTenantPoolMaxSize, server.DefaultTenantPoolRefillBatchSize, server.DefaultTenantPoolRefillInterval)
 	os.Exit(exitCode)
 }
 
@@ -1146,14 +1151,14 @@ func tenantPoolMaxSizeFromEnv() (int, error) {
 	return v, nil
 }
 
-func tenantPoolRefillFreeRatioFromEnv() (float64, error) {
-	raw := strings.TrimSpace(os.Getenv("DRIVE9_TENANT_POOL_REFILL_FREE_RATIO"))
+func tenantPoolRefillBatchSizeFromEnv() (int, error) {
+	raw := strings.TrimSpace(os.Getenv("DRIVE9_TENANT_POOL_REFILL_BATCH_SIZE"))
 	if raw == "" {
-		return server.DefaultTenantPoolRefillFreeRatio, nil
+		return server.DefaultTenantPoolRefillBatchSize, nil
 	}
-	v, err := strconv.ParseFloat(raw, 64)
-	if err != nil || v <= 0 || v > 1 || v != v {
-		return 0, fmt.Errorf("invalid DRIVE9_TENANT_POOL_REFILL_FREE_RATIO=%q: must be a number in (0,1]", raw)
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return 0, fmt.Errorf("invalid DRIVE9_TENANT_POOL_REFILL_BATCH_SIZE=%q: must be a positive integer", raw)
 	}
 	return v, nil
 }

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -114,33 +114,33 @@ func TestTenantPoolMaxSizeFromEnv(t *testing.T) {
 	}
 }
 
-func TestTenantPoolRefillFreeRatioFromEnv(t *testing.T) {
-	const key = "DRIVE9_TENANT_POOL_REFILL_FREE_RATIO"
+func TestTenantPoolRefillBatchSizeFromEnv(t *testing.T) {
+	const key = "DRIVE9_TENANT_POOL_REFILL_BATCH_SIZE"
 	restore := snapshotEnv(t, []string{key})
 	t.Cleanup(func() { restoreEnv(t, restore) })
 
 	unsetEnv(t, []string{key})
-	got, err := tenantPoolRefillFreeRatioFromEnv()
+	got, err := tenantPoolRefillBatchSizeFromEnv()
 	if err != nil {
-		t.Fatalf("tenantPoolRefillFreeRatioFromEnv empty: %v", err)
+		t.Fatalf("tenantPoolRefillBatchSizeFromEnv empty: %v", err)
 	}
-	if got != server.DefaultTenantPoolRefillFreeRatio {
-		t.Fatalf("empty refill ratio = %f, want %f", got, server.DefaultTenantPoolRefillFreeRatio)
+	if got != server.DefaultTenantPoolRefillBatchSize {
+		t.Fatalf("empty refill batch size = %d, want %d", got, server.DefaultTenantPoolRefillBatchSize)
 	}
 
-	setEnv(t, key, "0.75")
-	got, err = tenantPoolRefillFreeRatioFromEnv()
+	setEnv(t, key, "5")
+	got, err = tenantPoolRefillBatchSizeFromEnv()
 	if err != nil {
-		t.Fatalf("tenantPoolRefillFreeRatioFromEnv valid: %v", err)
+		t.Fatalf("tenantPoolRefillBatchSizeFromEnv valid: %v", err)
 	}
-	if got != 0.75 {
-		t.Fatalf("refill ratio = %f, want 0.75", got)
+	if got != 5 {
+		t.Fatalf("refill batch size = %d, want 5", got)
 	}
 
-	for _, raw := range []string{"0", "-0.1", "1.1", "NaN", "bad"} {
+	for _, raw := range []string{"0", "-1", "bad"} {
 		setEnv(t, key, raw)
-		if _, err := tenantPoolRefillFreeRatioFromEnv(); err == nil {
-			t.Fatalf("tenantPoolRefillFreeRatioFromEnv(%q) error = nil, want error", raw)
+		if _, err := tenantPoolRefillBatchSizeFromEnv(); err == nil {
+			t.Fatalf("tenantPoolRefillBatchSizeFromEnv(%q) error = nil, want error", raw)
 		}
 	}
 }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2265,6 +2265,78 @@ func (s *Store) MarkFreeTenantPoolTenantDeleting(ctx context.Context, tenantID s
 	return updated, nil
 }
 
+// FailStalePlaceholderTenantPoolTenants fails pending pool tenants whose
+// binding still carries a placeholder cluster id (cluster creation in flight
+// or abandoned) older than the cutoff. Failing the tenant frees the slot from
+// CountTenantPoolFreeSlots so the refill worker replaces it. If the abandoned
+// creation later completes, the creator observes the non-pending tenant and
+// deprovisions the cluster instead of resurrecting the slot. Returns the
+// number of tenants marked failed.
+func (s *Store) FailStalePlaceholderTenantPoolTenants(ctx context.Context, organizationID, clusterIDPrefix string, olderThan time.Time, limit int) (failed int, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "fail_stale_placeholder_tidbcloud_pool_tenants", start, &err)
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" {
+		return 0, fmt.Errorf("organization_id is required")
+	}
+	if strings.TrimSpace(clusterIDPrefix) == "" {
+		return 0, fmt.Errorf("cluster id prefix is required")
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		rows, queryErr := tx.QueryContext(ctx, `SELECT t.id
+			FROM tenants t
+			JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = t.id
+			WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = ? AND t.status = ?
+				AND b.cluster_id LIKE ? AND b.created_at < ?
+			ORDER BY b.created_at ASC
+			LIMIT ? FOR UPDATE`,
+			organizationID, TenantPoolBindingFree, tidbCloudNativeProvider, TenantPending,
+			clusterIDPrefix+"%", olderThan.UTC(), limit)
+		if queryErr != nil {
+			return queryErr
+		}
+		var ids []string
+		for rows.Next() {
+			var id string
+			if scanErr := rows.Scan(&id); scanErr != nil {
+				_ = rows.Close()
+				return scanErr
+			}
+			ids = append(ids, id)
+		}
+		if closeErr := rows.Close(); closeErr != nil {
+			return closeErr
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		if len(ids) == 0 {
+			return nil
+		}
+		placeholders := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
+		args := make([]any, 0, len(ids)+3)
+		args = append(args, TenantFailed, time.Now().UTC(), TenantPending)
+		for _, id := range ids {
+			args = append(args, id)
+		}
+		res, execErr := tx.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ?
+			WHERE status = ? AND id IN (`+placeholders+`)`, args...)
+		if execErr != nil {
+			return execErr
+		}
+		n, _ := res.RowsAffected()
+		failed = int(n)
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return failed, nil
+}
+
 func (s *Store) ListTenantsByTiDBCloudOrganizations(ctx context.Context, organizationIDs []string, offset, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "list_tenants_by_tidbcloud_orgs", start, &err)

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -42,6 +42,68 @@ type tenantPoolResumeJob struct {
 	rerun atomic.Bool
 }
 
+// tenantPoolRefillJob coordinates the per-pool background refill worker. The
+// credential is kept in memory only (never persisted) and is refreshed on
+// every kick so key rotation is picked up on the next round.
+type tenantPoolRefillJob struct {
+	rerun atomic.Bool
+	mu    sync.Mutex
+	cred  tenant.CredentialProvisionRequest
+	// inflight counts async cluster creations dispatched but not yet finished.
+	// The worker stays alive until they settle so failures reopen the deficit
+	// while the worker is still around to retry it.
+	inflight atomic.Int32
+	// consecutiveFailures counts finished creations that failed in a row; the
+	// worker stops at tenantPoolRefillMaxConsecutiveFailures (e.g. invalid
+	// credentials) instead of hammering the TiDB Cloud API forever.
+	consecutiveFailures atomic.Int32
+	lastReapNanos       atomic.Int64
+}
+
+func (j *tenantPoolRefillJob) setCred(cred tenant.CredentialProvisionRequest) {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	j.cred = cred
+}
+
+func (j *tenantPoolRefillJob) getCred() tenant.CredentialProvisionRequest {
+	j.mu.Lock()
+	defer j.mu.Unlock()
+	return j.cred
+}
+
+// tenantPoolRefillMaxConsecutiveFailures stops the refill worker after this
+// many consecutive failed creations. The next claim kicks a fresh worker.
+const tenantPoolRefillMaxConsecutiveFailures = 5
+
+// tenantPoolPlaceholderClusterIDPrefix prefixes the cluster id of pool
+// bindings whose cluster creation is still in flight. The placeholder binding
+// makes in-flight creations visible to CountTenantPoolFreeSlots (including
+// across pods), so the dispatcher never over-provisions; the pending tenant
+// behind it is not claimable (claims require Active) and not resumable.
+const tenantPoolPlaceholderClusterIDPrefix = "pending:"
+
+func isTenantPoolPlaceholderClusterID(clusterID string) bool {
+	return strings.HasPrefix(clusterID, tenantPoolPlaceholderClusterIDPrefix)
+}
+
+const (
+	// tenantPoolPlaceholderMaxAge bounds how long a placeholder may occupy a
+	// slot before the reaper fails its tenant and frees the slot for retry.
+	tenantPoolPlaceholderMaxAge = 15 * time.Minute
+	// tenantPoolPlaceholderReapInterval throttles reaper sweeps inside the
+	// refill worker loop.
+	tenantPoolPlaceholderReapInterval = time.Minute
+)
+
+// Refill round outcomes, also used as the replenish operation metric result.
+const (
+	refillRoundCreated = "ok"
+	refillRoundFull    = "noop_full"
+	refillRoundExit    = "exit"
+	refillRoundError   = "error"
+)
+
 type adminTenantPoolStatus string
 
 const adminTenantPoolStatusCreating adminTenantPoolStatus = "creating"
@@ -693,8 +755,7 @@ func (s *Server) firstManagedOrganization(ctx context.Context, cred tenant.Crede
 }
 
 func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count int, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*provisionTenantResult, error) {
-	manager, ok := s.provisioner.(tenant.TenantPoolClusterManager)
-	if !ok {
+	if _, ok := s.provisioner.(tenant.TenantPoolClusterManager); !ok {
 		return nil, fmt.Errorf("tenant pool provisioning not enabled")
 	}
 	if count <= 0 {
@@ -721,12 +782,29 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 		"pool_id", poolID,
 		"count", len(tenantIDs),
 		"duration_ms", durationMillis(stageStarted))...)
+	clusters, batchCloudCfg, err := s.batchProvisionFreePoolClusters(ctx, poolID, tenantIDs, cred, quotaOpt)
+	if err != nil && len(clusters) == 0 {
+		return nil, err
+	}
+	return s.persistFreePoolClusters(ctx, poolID, tenantIDs, clusters, batchCloudCfg, cred, quotaOpt)
+}
+
+// batchProvisionFreePoolClusters issues the TiDB Cloud batchCreate call for
+// the given pending pool tenants. On a total failure it cleans up and marks
+// the tenants failed before returning the error; partial responses (some
+// clusters, plus an error) are returned for the caller to persist.
+func (s *Server) batchProvisionFreePoolClusters(ctx context.Context, poolID string, tenantIDs []string, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*tenant.ClusterInfo, *tenant.QuotaCloudConfig, error) {
+	manager, ok := s.provisioner.(tenant.TenantPoolClusterManager)
+	if !ok {
+		return nil, nil, fmt.Errorf("tenant pool provisioning not enabled")
+	}
+	provider := tenant.ProviderTiDBCloudNative
 	var opts tenant.QuotaUpdateOptions
 	if quotaOpt != nil {
 		opts.TiDBCloudSpendingLimitMonthly = quotaOpt.TiDBCloudSpendingLimit
 	}
 	opts.TenantPoolID = poolID
-	stageStarted = time.Now()
+	stageStarted := time.Now()
 	logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_batch_create_started",
 		"provider", provider,
 		"pool_id", poolID,
@@ -744,7 +822,7 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 		for _, tenantID := range tenantIDs {
 			s.markTenantPoolTenantFailed(ctx, tenantID, "batch_provision_error")
 		}
-		return nil, err
+		return nil, nil, err
 	}
 	logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_batch_create_done",
 		"provider", provider,
@@ -759,6 +837,16 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 			zap.Int("cluster_count", len(clusters)),
 			zap.Error(err))
 	}
+	return clusters, batchCloudCfg, err
+}
+
+// persistFreePoolClusters persists batch-created clusters as free pool
+// tenants: binding upsert, connection metadata, quota seeding, and metadata
+// resume for incomplete clusters. On error it deprovisions the affected
+// clusters and marks the tenants failed.
+func (s *Server) persistFreePoolClusters(ctx context.Context, poolID string, tenantIDs []string, clusters []*tenant.ClusterInfo, batchCloudCfg *tenant.QuotaCloudConfig, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*provisionTenantResult, error) {
+	provider := tenant.ProviderTiDBCloudNative
+	now := time.Now().UTC()
 	cleanupOnError := true
 	defer func() {
 		if cleanupOnError {
@@ -771,6 +859,7 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 	discardedTenants := make(map[string]struct{}, len(clusters))
 	cloudProvider, region := provisioningCloudRegion(s.provisioner)
 	poolOrgID := ""
+	var stageStarted time.Time
 	for _, cluster := range clusters {
 		if cluster == nil {
 			continue
@@ -1389,21 +1478,34 @@ func (s *Server) deleteNewestFreePoolTenants(ctx context.Context, poolID, organi
 				"status", t.Status,
 				"delete_all", deleteAll)
 			stageStarted = time.Now()
-			if err := s.deprovisionTenantCluster(ctx, &t, cred); err != nil {
-				_, _ = s.meta.UpdateTenantStatusIf(context.Background(), t.ID, meta.TenantDeleting, t.Status)
-				logProvisionStage(ctx, "admin_tenant_pool_free_tenant_delete_cluster_failed", t.ID, t.Provider, stageStarted,
+			if isTenantPoolPlaceholderClusterID(row.Binding.ClusterID) {
+				// Placeholder slot: the cluster creation is still in flight
+				// (or abandoned), so there is nothing to deprovision yet. The
+				// async creator observes the reclaimed (non-pending) tenant
+				// when its TiDB Cloud call returns and deprovisions the
+				// cluster itself.
+				logProvisionStage(ctx, "admin_tenant_pool_free_tenant_delete_placeholder_skipped", t.ID, t.Provider, stageStarted,
+					"pool_id", poolID,
+					"organization_id", organizationID,
+					"cluster_id", row.Binding.ClusterID,
+					"delete_all", deleteAll)
+			} else {
+				if err := s.deprovisionTenantCluster(ctx, &t, cred); err != nil {
+					_, _ = s.meta.UpdateTenantStatusIf(context.Background(), t.ID, meta.TenantDeleting, t.Status)
+					logProvisionStage(ctx, "admin_tenant_pool_free_tenant_delete_cluster_failed", t.ID, t.Provider, stageStarted,
+						"pool_id", poolID,
+						"organization_id", organizationID,
+						"cluster_id", t.ClusterID,
+						"delete_all", deleteAll,
+						"error", err)
+					return deleted, err
+				}
+				logProvisionStage(ctx, "admin_tenant_pool_free_tenant_delete_cluster_deleted", t.ID, t.Provider, stageStarted,
 					"pool_id", poolID,
 					"organization_id", organizationID,
 					"cluster_id", t.ClusterID,
-					"delete_all", deleteAll,
-					"error", err)
-				return deleted, err
+					"delete_all", deleteAll)
 			}
-			logProvisionStage(ctx, "admin_tenant_pool_free_tenant_delete_cluster_deleted", t.ID, t.Provider, stageStarted,
-				"pool_id", poolID,
-				"organization_id", organizationID,
-				"cluster_id", t.ClusterID,
-				"delete_all", deleteAll)
 			stageStarted = time.Now()
 			_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
 			if err := s.meta.MarkTenantDeleted(ctx, t.ID); err != nil {
@@ -1479,98 +1581,267 @@ func firstResultOrganizationID(results []*provisionTenantResult) string {
 	return ""
 }
 
-func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {
-	if pool == nil || pool.OrganizationID == "" || pool.Size <= 0 {
+// kickTenantPoolRefill starts (or nudges) the per-pool background refill
+// worker after a successful claim. The worker tops the pool up at a fixed
+// rate — TenantPoolRefillBatchSize tenants per TenantPoolRefillInterval —
+// whenever the pool has fewer free slots than its configured size. Claim
+// bursts only drain the pool; they no longer trigger a catch-up batch, so the
+// TiDB Cloud API sees a steady creation rate decoupled from request bursts.
+func (s *Server) kickTenantPoolRefill(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {
+	if pool == nil || pool.PoolID == "" || pool.OrganizationID == "" || pool.Size <= 0 {
+		return
+	}
+	poolID := pool.PoolID
+	job := &tenantPoolRefillJob{}
+	job.setCred(cred)
+	if actual, loaded := s.tenantPoolRefillJobs.LoadOrStore(poolID, job); loaded {
+		existing, ok := actual.(*tenantPoolRefillJob)
+		if !ok {
+			return
+		}
+		existing.setCred(cred)
+		existing.rerun.Store(true)
 		return
 	}
 	workerCtx := backgroundWithTrace(ctx)
 	s.startServerWorker(workerCtx, func(ctx context.Context) {
-		replenishStarted := time.Now()
-		metricResult := "ok"
-		defer func() {
-			metrics.RecordOperation(adminTenantPoolMetricsComponent, "replenish", metricResult, time.Since(replenishStarted))
-		}()
-		lock := s.tenantPoolLock(pool.PoolID)
-		lock.Lock()
-		defer lock.Unlock()
-		if err := s.meta.WithTenantPoolLock(ctx, pool.PoolID, func(ctx context.Context) error {
-			current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
-			if err != nil {
-				if !errors.Is(err, meta.ErrNotFound) {
-					logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
-					metricResult = "error"
-				} else {
-					metricResult = "not_found"
-				}
-				return nil
-			}
-			if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
-				metricResult = "skipped"
-				return nil
-			}
-			defer s.refreshTenantPoolCapacity(ctx, current)
-			freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
-			if err != nil {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-				metricResult = "error"
-				return nil
-			}
-			if !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
-				logger.Info(ctx, "admin_tenant_pool_replenish_skipped",
-					zap.String("pool_id", current.PoolID),
-					zap.String("organization_id", current.OrganizationID),
-					zap.Int("pool_size", current.Size),
-					zap.Int("free_size", freeSize),
-					zap.Float64("refill_free_ratio", s.effectiveTenantPoolRefillFreeRatio()))
-				metricResult = "noop"
-				return nil
-			}
-			// Trigger on active free tenants, but size refill against all free
-			// slots, including in-flight pending/provisioning tenants, so
-			// concurrent replenishment does not double-provision.
-			slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
-			if err != nil {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-				metricResult = "error"
-				return nil
-			}
-			missing := current.Size - slotSize
-			if missing <= 0 {
-				metricResult = "noop"
-				return nil
-			}
-			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
-			if err != nil {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-				metricResult = "cluster_error"
-				return nil
-			}
-			for _, res := range results {
-				s.startProvisionedTenantSchemaInit(ctx, res)
-			}
-			return nil
-		}); err != nil {
-			logger.Warn(ctx, "admin_tenant_pool_replenish_lock_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
-			metricResult = adminTenantPoolMetricResult(err)
-		}
+		defer s.tenantPoolRefillJobs.Delete(poolID)
+		s.runTenantPoolRefillWorker(ctx, poolID, job)
 	})
 }
 
-func (s *Server) tenantPoolBelowRefillWatermark(freeSize, poolSize int) bool {
-	if poolSize <= 0 {
-		return false
+func (s *Server) runTenantPoolRefillWorker(ctx context.Context, poolID string, job *tenantPoolRefillJob) {
+	batchSize, interval := s.tenantPoolRefillConfig()
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if fails := job.consecutiveFailures.Load(); fails >= tenantPoolRefillMaxConsecutiveFailures {
+			logger.Warn(ctx, "admin_tenant_pool_refill_worker_stopped",
+				zap.String("pool_id", poolID),
+				zap.Int32("consecutive_failures", fails),
+				zap.String("reason", "max_consecutive_failures"))
+			return
+		}
+		result := s.tenantPoolRefillRound(ctx, poolID, job, batchSize)
+		if result == refillRoundExit {
+			return
+		}
+		if result == refillRoundFull && job.inflight.Load() == 0 {
+			// Pool is full and nothing is in flight: exit unless a claim
+			// kicked us mid-round — the claim may have drained a slot after
+			// our count. A later claim starts a fresh worker either way; the
+			// deficit is durable in the DB.
+			if !job.rerun.Swap(false) {
+				return
+			}
+		}
+		// Always pace dispatch rounds at the configured interval: this is the
+		// token bucket that caps the cluster-creation start rate at
+		// batchSize/interval regardless of how long individual creations take.
+		timer := time.NewTimer(interval)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
 	}
-	if freeSize < 0 {
-		freeSize = 0
-	}
-	return float64(freeSize)/float64(poolSize) < s.effectiveTenantPoolRefillFreeRatio()
 }
 
-func (s *Server) effectiveTenantPoolRefillFreeRatio() float64 {
-	if s == nil {
-		return DefaultTenantPoolRefillFreeRatio
+// tenantPoolRefillRound dispatches up to batchSize async cluster creations
+// when the pool is below its configured size, and reports the round outcome.
+// Each dispatched creation first records a pending tenant plus a placeholder
+// binding (inside the pool locks), so its slot is immediately visible to every
+// pod's deficit accounting while the TiDB Cloud call runs.
+func (s *Server) tenantPoolRefillRound(ctx context.Context, poolID string, job *tenantPoolRefillJob, batchSize int) string {
+	roundStarted := time.Now()
+	result := refillRoundCreated
+	defer func() {
+		metrics.RecordOperation(adminTenantPoolMetricsComponent, "replenish", result, time.Since(roundStarted))
+	}()
+	lock := s.tenantPoolLock(poolID)
+	lock.Lock()
+	defer lock.Unlock()
+	if err := s.meta.WithTenantPoolLock(ctx, poolID, func(ctx context.Context) error {
+		current, err := s.meta.GetTenantPoolByID(ctx, poolID)
+		if err != nil {
+			if errors.Is(err, meta.ErrNotFound) {
+				result = refillRoundExit
+				return nil
+			}
+			logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", poolID), zap.Error(err))
+			result = refillRoundError
+			return nil
+		}
+		if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
+			result = refillRoundExit
+			return nil
+		}
+		defer s.refreshTenantPoolCapacity(ctx, current)
+		s.reapStaleTenantPoolPlaceholders(ctx, current, job)
+		// Size the refill against all free slots — active, provisioning, and
+		// placeholder (in-flight) — so concurrent dispatch (and concurrent
+		// pods) never over-provision.
+		slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
+		if err != nil {
+			logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", poolID), zap.Error(err))
+			result = refillRoundError
+			return nil
+		}
+		deficit := current.Size - slotSize
+		if deficit <= 0 {
+			result = refillRoundFull
+			return nil
+		}
+		if deficit > batchSize {
+			deficit = batchSize
+		}
+		now := time.Now().UTC()
+		dispatched := 0
+		for i := 0; i < deficit; i++ {
+			tenantID := token.NewID()
+			if err := s.insertPendingPoolTenant(ctx, tenantID, tenant.ProviderTiDBCloudNative, now); err != nil {
+				logger.Warn(ctx, "admin_tenant_pool_refill_insert_pending_failed", zap.String("pool_id", poolID), zap.Error(err))
+				result = refillRoundError
+				break
+			}
+			if err := s.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+				TenantID:       tenantID,
+				OrganizationID: current.OrganizationID,
+				ClusterID:      tenantPoolPlaceholderClusterIDPrefix + tenantID,
+				PoolID:         poolID,
+				PoolStatus:     meta.TenantPoolBindingFree,
+				CreatedAt:      now,
+				UpdatedAt:      now,
+			}); err != nil {
+				logger.Warn(ctx, "admin_tenant_pool_refill_placeholder_failed", zap.String("pool_id", poolID), zap.Error(err))
+				s.markTenantPoolTenantFailed(ctx, tenantID, "placeholder_insert_error")
+				result = refillRoundError
+				break
+			}
+			job.inflight.Add(1)
+			cred := job.getCred()
+			orgID := current.OrganizationID
+			s.startServerWorker(ctx, func(workerCtx context.Context) {
+				s.finishAsyncPoolClusterProvision(workerCtx, poolID, orgID, tenantID, cred, job)
+			})
+			dispatched++
+		}
+		if dispatched > 0 {
+			logger.Info(ctx, "admin_tenant_pool_refill_round_dispatched",
+				zap.String("pool_id", poolID),
+				zap.String("organization_id", current.OrganizationID),
+				zap.Int("pool_size", current.Size),
+				zap.Int("slot_size", slotSize),
+				zap.Int("dispatched_count", dispatched))
+		}
+		return nil
+	}); err != nil {
+		logger.Warn(ctx, "admin_tenant_pool_replenish_lock_failed", zap.String("pool_id", poolID), zap.Error(err))
+		result = refillRoundError
 	}
-	return normalizeTenantPoolRefillFreeRatio(s.tenantPoolRefillFreeRatio)
+	return result
+}
+
+// finishAsyncPoolClusterProvision completes one placeholder-dispatched
+// cluster creation: it calls TiDB Cloud outside any lock (this can take tens
+// of seconds), then persists the result under the pool locks. If the
+// placeholder was reclaimed while the call ran (pool shrink/delete, or the
+// stale-placeholder reaper), the created cluster is deprovisioned instead of
+// resurrecting the slot.
+func (s *Server) finishAsyncPoolClusterProvision(ctx context.Context, poolID, organizationID, tenantID string, cred tenant.CredentialProvisionRequest, job *tenantPoolRefillJob) {
+	defer job.inflight.Add(-1)
+	success := false
+	defer func() {
+		if success {
+			job.consecutiveFailures.Store(0)
+		} else {
+			job.consecutiveFailures.Add(1)
+		}
+	}()
+	clusters, batchCloudCfg, err := s.batchProvisionFreePoolClusters(ctx, poolID, []string{tenantID}, cred, nil)
+	if err != nil && len(clusters) == 0 {
+		// The batch helper already marked the tenant failed, which frees the
+		// placeholder slot for a later dispatch round.
+		return
+	}
+	reclaimed := false
+	persistRan := false
+	lock := s.tenantPoolLock(poolID)
+	lock.Lock()
+	persistErr := s.meta.WithTenantPoolLock(ctx, poolID, func(ctx context.Context) error {
+		t, lookupErr := s.meta.GetTenant(ctx, tenantID)
+		if lookupErr != nil {
+			if errors.Is(lookupErr, meta.ErrNotFound) {
+				reclaimed = true
+				return nil
+			}
+			return lookupErr
+		}
+		if t.Status != meta.TenantPending {
+			reclaimed = true
+			return nil
+		}
+		persistRan = true
+		results, err := s.persistFreePoolClusters(ctx, poolID, []string{tenantID}, clusters, batchCloudCfg, cred, nil)
+		if err != nil {
+			return err
+		}
+		for _, res := range results {
+			s.startProvisionedTenantSchemaInit(ctx, res)
+		}
+		success = len(results) > 0
+		return nil
+	})
+	lock.Unlock()
+	if reclaimed {
+		logger.Info(ctx, "admin_tenant_pool_async_provision_reclaimed",
+			zap.String("pool_id", poolID),
+			zap.String("organization_id", organizationID),
+			zap.String("tenant_id", tenantID))
+		s.cleanupPoolProvisionedClusters(ctx, clusters, cred, []string{tenantID}, "placeholder_reclaimed")
+		return
+	}
+	if persistErr != nil {
+		logger.Warn(ctx, "admin_tenant_pool_async_provision_persist_failed",
+			zap.String("pool_id", poolID),
+			zap.String("organization_id", organizationID),
+			zap.String("tenant_id", tenantID),
+			zap.Error(persistErr))
+		if !persistRan {
+			// The lock or the tenant lookup failed before persistence could
+			// run; nothing has cleaned up the created clusters yet.
+			s.cleanupPoolProvisionedClusters(ctx, clusters, cred, []string{tenantID}, "persist_lock_error")
+			s.markTenantPoolTenantFailed(ctx, tenantID, "persist_lock_error")
+		}
+	}
+}
+
+// reapStaleTenantPoolPlaceholders fails pool tenants whose placeholder
+// binding is older than tenantPoolPlaceholderMaxAge, freeing slots whose
+// cluster creation was abandoned (e.g. by a crashed pod). Runs at most once
+// per tenantPoolPlaceholderReapInterval; callers must hold the pool locks.
+func (s *Server) reapStaleTenantPoolPlaceholders(ctx context.Context, pool *meta.TenantPool, job *tenantPoolRefillJob) {
+	now := time.Now()
+	if now.UnixNano()-job.lastReapNanos.Load() < int64(tenantPoolPlaceholderReapInterval) {
+		return
+	}
+	job.lastReapNanos.Store(now.UnixNano())
+	failed, err := s.meta.FailStalePlaceholderTenantPoolTenants(ctx, pool.OrganizationID, tenantPoolPlaceholderClusterIDPrefix, now.Add(-tenantPoolPlaceholderMaxAge), 100)
+	if err != nil {
+		logger.Warn(ctx, "admin_tenant_pool_placeholder_reap_failed",
+			zap.String("pool_id", pool.PoolID),
+			zap.String("organization_id", pool.OrganizationID),
+			zap.Error(err))
+		return
+	}
+	if failed > 0 {
+		logger.Info(ctx, "admin_tenant_pool_placeholders_reaped",
+			zap.String("pool_id", pool.PoolID),
+			zap.String("organization_id", pool.OrganizationID),
+			zap.Int("failed_count", failed))
+	}
 }
 
 func (s *Server) resumePendingTenantPoolAsync(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {
@@ -1605,6 +1876,11 @@ func (s *Server) pendingTenantPoolResumeClusters(ctx context.Context, poolID str
 	}
 	clusters := make([]*tenant.ClusterInfo, 0, len(rows))
 	for _, row := range rows {
+		if isTenantPoolPlaceholderClusterID(row.Binding.ClusterID) {
+			// Placeholder bindings have no real cluster or credentials yet;
+			// their async creator owns them.
+			continue
+		}
 		plainPass, err := s.pool.Decrypt(ctx, row.Tenant.DBPasswordCipher)
 		if err != nil || strings.TrimSpace(string(plainPass)) == "" {
 			logger.Warn(ctx, "admin_tenant_pool_pending_resume_password_failed",

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -384,12 +383,12 @@ func TestTenantPoolMetadataResumePersistContextPreservesServerCancellation(t *te
 	}
 }
 
-func TestAdminTenantPoolReplenishSkipsAtFreeWatermark(t *testing.T) {
+func TestAdminTenantPoolRefillSkipsWhenPoolFull(t *testing.T) {
 	rt, _ := newAdminTenantPoolRuntime(t)
 	ctx := context.Background()
 	now := time.Now().UTC()
 	pool := &meta.TenantPool{
-		PoolID:         "pool-watermark-skip",
+		PoolID:         "pool-refill-full",
 		OrganizationID: "org-1",
 		Size:           10,
 		Status:         meta.TenantPoolActive,
@@ -399,11 +398,11 @@ func TestAdminTenantPoolReplenishSkipsAtFreeWatermark(t *testing.T) {
 	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
 		t.Fatalf("create pool: %v", err)
 	}
-	for i := 1; i <= 8; i++ {
+	for i := 1; i <= 10; i++ {
 		insertAdminPoolFreeTenant(t, rt, pool.PoolID, pool.OrganizationID, i)
 	}
 
-	rt.server.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
+	rt.server.kickTenantPoolRefill(ctx, pool, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	})
@@ -412,21 +411,19 @@ func TestAdminTenantPoolReplenishSkipsAtFreeWatermark(t *testing.T) {
 	if got := rt.prov.batchPoolCalls.Load(); got != 0 {
 		t.Fatalf("batch pool calls = %d, want 0", got)
 	}
-	free, err := rt.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID)
-	if err != nil {
-		t.Fatalf("count free: %v", err)
-	}
-	if free != 8 {
-		t.Fatalf("free size = %d, want 8", free)
+	if _, ok := rt.server.tenantPoolRefillJobs.Load(pool.PoolID); ok {
+		t.Fatalf("refill job for %s still registered after worker exit", pool.PoolID)
 	}
 }
 
-func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
+func TestAdminTenantPoolRefillTopsUpInFixedBatches(t *testing.T) {
 	rt, _ := newAdminTenantPoolRuntime(t)
+	rt.server.tenantPoolRefillBatchSize = 2
+	rt.server.tenantPoolRefillInterval = time.Millisecond
 	ctx := context.Background()
 	now := time.Now().UTC()
 	pool := &meta.TenantPool{
-		PoolID:         "pool-watermark-refill",
+		PoolID:         "pool-refill-batches",
 		OrganizationID: "org-1",
 		Size:           10,
 		Status:         meta.TenantPoolActive,
@@ -440,14 +437,20 @@ func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
 		insertAdminPoolFreeTenant(t, rt, pool.PoolID, pool.OrganizationID, i)
 	}
 
-	rt.server.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
-		PublicKey:  "public-1",
-		PrivateKey: "private-1",
-	})
+	// Repeated kicks coalesce into a single worker via the rerun flag.
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}
+	rt.server.kickTenantPoolRefill(ctx, pool, cred)
+	rt.server.kickTenantPoolRefill(ctx, pool, cred)
+	rt.server.kickTenantPoolRefill(ctx, pool, cred)
 	rt.server.forkWorkerWG.Wait()
 
-	if got := rt.prov.batchPoolCalls.Load(); got != 1 {
-		t.Fatalf("batch pool calls = %d, want 1", got)
+	// Deficit 3: three separate one-cluster create calls dispatched across
+	// rounds (2 + 1), never one catch-up batch of 3.
+	if got := rt.prov.batchPoolCalls.Load(); got != 3 {
+		t.Fatalf("batch pool calls = %d, want 3", got)
+	}
+	if _, ok := rt.server.tenantPoolRefillJobs.Load(pool.PoolID); ok {
+		t.Fatalf("refill job for %s still registered after worker exit", pool.PoolID)
 	}
 	deadline := time.Now().Add(5 * time.Second)
 	for {
@@ -465,10 +468,287 @@ func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
 	}
 }
 
-func TestTenantPoolEffectiveRefillRatioRejectsNaN(t *testing.T) {
-	s := &Server{tenantPoolRefillFreeRatio: math.NaN()}
-	if got := s.effectiveTenantPoolRefillFreeRatio(); got != DefaultTenantPoolRefillFreeRatio {
-		t.Fatalf("effective refill ratio = %f, want %f", got, DefaultTenantPoolRefillFreeRatio)
+func TestAdminTenantPoolRefillWorkerStopsAfterConsecutiveFailures(t *testing.T) {
+	rt, _ := newAdminTenantPoolRuntime(t)
+	rt.server.tenantPoolRefillBatchSize = 1
+	rt.server.tenantPoolRefillInterval = time.Millisecond
+	// Every batch returns a cluster without a tenant id, so no pool tenant can
+	// be persisted and every refill round fails.
+	rt.prov.batchPoolMissingTenant = map[int]bool{0: true}
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID:         "pool-refill-failing",
+		OrganizationID: "org-1",
+		Size:           10,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	for i := 1; i <= 7; i++ {
+		insertAdminPoolFreeTenant(t, rt, pool.PoolID, pool.OrganizationID, i)
+	}
+
+	rt.server.kickTenantPoolRefill(ctx, pool, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	rt.server.forkWorkerWG.Wait()
+
+	// The breaker counts failures as async creations finish, so a few
+	// already-dispatched calls may land after the limit trips: the worker
+	// must stop promptly, not at exactly N calls.
+	if got := rt.prov.batchPoolCalls.Load(); got < tenantPoolRefillMaxConsecutiveFailures || got > tenantPoolRefillMaxConsecutiveFailures+5 {
+		t.Fatalf("batch pool calls = %d, want within [%d, %d] (worker stops after consecutive failures)", got, tenantPoolRefillMaxConsecutiveFailures, tenantPoolRefillMaxConsecutiveFailures+5)
+	}
+	if _, ok := rt.server.tenantPoolRefillJobs.Load(pool.PoolID); ok {
+		t.Fatalf("refill job for %s still registered after worker exit", pool.PoolID)
+	}
+}
+
+func TestAdminTenantPoolRefillWorkerExitsWhenPoolDeleted(t *testing.T) {
+	rt, _ := newAdminTenantPoolRuntime(t)
+	rt.server.tenantPoolRefillInterval = time.Millisecond
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID:         "pool-refill-deleted",
+		OrganizationID: "org-1",
+		Size:           10,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	if err := rt.meta.DeleteTenantPool(ctx, pool.PoolID); err != nil {
+		t.Fatalf("delete pool: %v", err)
+	}
+
+	rt.server.kickTenantPoolRefill(ctx, pool, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	rt.server.forkWorkerWG.Wait()
+
+	if got := rt.prov.batchPoolCalls.Load(); got != 0 {
+		t.Fatalf("batch pool calls = %d, want 0", got)
+	}
+}
+
+func TestTenantPoolRefillConfigDefaults(t *testing.T) {
+	s := &Server{}
+	batchSize, interval := s.tenantPoolRefillConfig()
+	if batchSize != DefaultTenantPoolRefillBatchSize {
+		t.Fatalf("default refill batch size = %d, want %d", batchSize, DefaultTenantPoolRefillBatchSize)
+	}
+	if interval != DefaultTenantPoolRefillInterval {
+		t.Fatalf("default refill interval = %s, want %s", interval, DefaultTenantPoolRefillInterval)
+	}
+}
+
+func TestAdminTenantPoolRefillPlaceholderSlotsVisibleInFlight(t *testing.T) {
+	rt, _ := newAdminTenantPoolRuntime(t)
+	rt.server.tenantPoolRefillBatchSize = 3
+	rt.server.tenantPoolRefillInterval = time.Millisecond
+	block := make(chan struct{})
+	rt.prov.batchPoolHook = func(int) { <-block }
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID:         "pool-refill-placeholder",
+		OrganizationID: "org-1",
+		Size:           10,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	for i := 1; i <= 7; i++ {
+		insertAdminPoolFreeTenant(t, rt, pool.PoolID, pool.OrganizationID, i)
+	}
+
+	rt.server.kickTenantPoolRefill(ctx, pool, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+
+	// While the three creates are blocked in flight, their placeholder
+	// bindings already occupy pool slots (so no pod over-provisions)...
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		slots, err := rt.meta.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
+		if err != nil {
+			t.Fatalf("count slots: %v", err)
+		}
+		if slots == 10 && rt.prov.batchPoolCalls.Load() == 3 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("slots = %d, calls = %d; want 10 slots (7 free + 3 placeholders) and 3 calls", slots, rt.prov.batchPoolCalls.Load())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	// ...but they are not active free tenants, so claims cannot take them.
+	free, err := rt.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID)
+	if err != nil {
+		t.Fatalf("count free: %v", err)
+	}
+	if free != 7 {
+		t.Fatalf("active free size = %d, want 7 while creations are in flight", free)
+	}
+
+	close(block)
+	rt.server.forkWorkerWG.Wait()
+
+	deadline = time.Now().Add(5 * time.Second)
+	for {
+		free, err = rt.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID)
+		if err != nil {
+			t.Fatalf("count free: %v", err)
+		}
+		if free == 10 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("free size = %d, want 10 after refill", free)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestAdminTenantPoolRefillReapsStalePlaceholders(t *testing.T) {
+	rt, _ := newAdminTenantPoolRuntime(t)
+	rt.server.tenantPoolRefillBatchSize = 3
+	rt.server.tenantPoolRefillInterval = time.Millisecond
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID:         "pool-refill-reaper",
+		OrganizationID: "org-1",
+		Size:           10,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	for i := 1; i <= 7; i++ {
+		insertAdminPoolFreeTenant(t, rt, pool.PoolID, pool.OrganizationID, i)
+	}
+	staleTenantID := insertAdminPoolPlaceholderTenant(t, rt, pool.PoolID, pool.OrganizationID, "stale-1", now.Add(-tenantPoolPlaceholderMaxAge - time.Minute))
+
+	rt.server.kickTenantPoolRefill(ctx, pool, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	rt.server.forkWorkerWG.Wait()
+
+	// The stale placeholder was reaped (tenant failed, slot freed) and the
+	// freed slot was refilled like any other deficit.
+	stale, err := rt.meta.GetTenant(ctx, staleTenantID)
+	if err != nil {
+		t.Fatalf("get stale tenant: %v", err)
+	}
+	if stale.Status != meta.TenantFailed {
+		t.Fatalf("stale placeholder tenant status = %s, want %s", stale.Status, meta.TenantFailed)
+	}
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		free, err := rt.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID)
+		if err != nil {
+			t.Fatalf("count free: %v", err)
+		}
+		if free == 10 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("free size = %d, want 10 after refill", free)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestAdminTenantPoolRefillReclaimedPlaceholderDeprovisionsCluster(t *testing.T) {
+	rt, _ := newAdminTenantPoolRuntime(t)
+	rt.server.tenantPoolRefillBatchSize = 1
+	rt.server.tenantPoolRefillInterval = 200 * time.Millisecond
+	block := make(chan struct{})
+	var once sync.Once
+	rt.prov.batchPoolHook = func(int) { once.Do(func() { <-block }) }
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID:         "pool-refill-reclaim",
+		OrganizationID: "org-1",
+		Size:           10,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	// Backdate the free tenants so the dispatcher's placeholder is the newest
+	// slot and gets picked by the shrink below.
+	for i := 1; i <= 7; i++ {
+		insertAdminPoolFreeTenantAt(t, rt, pool.PoolID, pool.OrganizationID, i, now.Add(-time.Duration(10-i)*time.Second))
+	}
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}
+	rt.server.kickTenantPoolRefill(ctx, pool, cred)
+
+	// Wait for the placeholder creation to be in flight.
+	var placeholderTenantID string
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		rows, err := rt.meta.ListTenantPoolFreeSlotsForDelete(ctx, pool.OrganizationID, true, 1)
+		if err != nil {
+			t.Fatalf("list slots: %v", err)
+		}
+		if len(rows) == 1 && isTenantPoolPlaceholderClusterID(rows[0].Binding.ClusterID) && rt.prov.batchPoolCalls.Load() == 1 {
+			placeholderTenantID = rows[0].Tenant.ID
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("no in-flight placeholder observed; calls = %d", rt.prov.batchPoolCalls.Load())
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Shrink reclaims the placeholder slot while its create call is blocked:
+	// no cloud deprovision yet — there is no real cluster.
+	deleted, err := rt.server.deleteNewestFreePoolTenants(ctx, pool.PoolID, pool.OrganizationID, 1, cred, false)
+	if err != nil {
+		t.Fatalf("shrink: %v", err)
+	}
+	if deleted != 1 {
+		t.Fatalf("deleted = %d, want 1", deleted)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0 for a placeholder slot", got)
+	}
+
+	close(block)
+	rt.server.forkWorkerWG.Wait()
+
+	// When the blocked create returned, the creator saw the reclaimed tenant
+	// and deprovisioned the cluster instead of resurrecting the slot.
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1 (reclaimed creation cleaned up)", got)
+	}
+	reclaimed, err := rt.meta.GetTenant(ctx, placeholderTenantID)
+	if err != nil {
+		t.Fatalf("get reclaimed tenant: %v", err)
+	}
+	if reclaimed.Status != meta.TenantDeleted {
+		t.Fatalf("reclaimed placeholder tenant status = %s, want %s", reclaimed.Status, meta.TenantDeleted)
 	}
 }
 
@@ -490,8 +770,13 @@ func newAdminTenantPoolRuntime(t *testing.T) (*quotaRuntime, *adminTenantPoolSch
 
 func insertAdminPoolFreeTenant(t *testing.T, rt *quotaRuntime, poolID, organizationID string, index int) string {
 	t.Helper()
+	return insertAdminPoolFreeTenantAt(t, rt, poolID, organizationID, index, time.Now().UTC().Add(time.Duration(index)*time.Second))
+}
+
+func insertAdminPoolFreeTenantAt(t *testing.T, rt *quotaRuntime, poolID, organizationID string, index int, createdAt time.Time) string {
+	t.Helper()
 	ctx := context.Background()
-	now := time.Now().UTC().Add(time.Duration(index) * time.Second)
+	now := createdAt
 	tenantID := fmt.Sprintf("%s-free-%d", poolID, index)
 	clusterID := fmt.Sprintf("%s-cluster-%d", poolID, index)
 	passCipher, err := rt.server.pool.Encrypt(ctx, []byte("pool-pass"))
@@ -525,6 +810,39 @@ func insertAdminPoolFreeTenant(t *testing.T, rt *quotaRuntime, poolID, organizat
 		UpdatedAt:      now,
 	}); err != nil {
 		t.Fatalf("upsert binding %s: %v", tenantID, err)
+	}
+	return tenantID
+}
+
+// insertAdminPoolPlaceholderTenant inserts a pending pool tenant with a
+// placeholder binding, mimicking a refill creation that was dispatched (or
+// abandoned) but never completed.
+func insertAdminPoolPlaceholderTenant(t *testing.T, rt *quotaRuntime, poolID, organizationID, suffix string, createdAt time.Time) string {
+	t.Helper()
+	ctx := context.Background()
+	tenantID := fmt.Sprintf("%s-placeholder-%s", poolID, suffix)
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID:               tenantID,
+		Status:           meta.TenantPending,
+		DBPasswordCipher: []byte{},
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNative,
+		SchemaVersion:    1,
+		CreatedAt:        createdAt,
+		UpdatedAt:        createdAt,
+	}); err != nil {
+		t.Fatalf("insert placeholder tenant %s: %v", tenantID, err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID:       tenantID,
+		OrganizationID: organizationID,
+		ClusterID:      tenantPoolPlaceholderClusterIDPrefix + tenantID,
+		PoolID:         poolID,
+		PoolStatus:     meta.TenantPoolBindingFree,
+		CreatedAt:      createdAt,
+		UpdatedAt:      createdAt,
+	}); err != nil {
+		t.Fatalf("upsert placeholder binding %s: %v", tenantID, err)
 	}
 	return tenantID
 }

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -184,7 +184,7 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		if res.Status == meta.TenantProvisioning {
 			s.startProvisionedTenantSchemaInit(r.Context(), res)
 		}
-		s.replenishTenantPoolAsync(r.Context(), pool, cred)
+		s.kickTenantPoolRefill(r.Context(), pool, cred)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(adminTenantCreateResponse{

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -53,6 +53,7 @@ type quotaTestProvisioner struct {
 	listErr                     error
 	listPages                   []*tenant.ManagedClusterListResult
 	batchPoolErr                error
+	batchPoolHook               func(call int)
 	batchPoolOmitConnectionInfo bool
 	batchPoolEmptyPassword      bool
 	batchPoolMissingOrg         map[int]bool
@@ -227,8 +228,11 @@ func (p *quotaTestProvisioner) ListManagedClusters(_ context.Context, req tenant
 }
 
 func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(_ context.Context, tenantIDs []string, req tenant.CredentialProvisionRequest, opts tenant.QuotaUpdateOptions) ([]*tenant.ClusterInfo, *tenant.QuotaCloudConfig, error) {
-	p.batchPoolCalls.Add(1)
+	call := int(p.batchPoolCalls.Add(1))
 	p.recordCall("batch_pool", req, nil, &opts)
+	if p.batchPoolHook != nil {
+		p.batchPoolHook(call)
+	}
 	out := make([]*tenant.ClusterInfo, 0, len(tenantIDs))
 	for i, tenantID := range tenantIDs {
 		password := "pool-pass"
@@ -237,7 +241,7 @@ func (p *quotaTestProvisioner) BatchProvisionFreeClustersWithCredentialsAndQuota
 		}
 		out = append(out, &tenant.ClusterInfo{
 			TenantID:       tenantID,
-			ClusterID:      fmt.Sprintf("pool-cluster-%d", i+1),
+			ClusterID:      fmt.Sprintf("pool-cluster-%d-%d", call, i+1),
 			OrganizationID: "org-1",
 			Password:       password,
 			DBName:         "tidbcloud_fs",
@@ -2059,8 +2063,8 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissi
 		t.Fatalf("deprovision calls = %d, want 1", got)
 	}
 	lastDeprovision := rt.prov.lastDeprovisionSnapshot()
-	if lastDeprovision == nil || lastDeprovision.ClusterID != "pool-cluster-2" {
-		t.Fatalf("last deprovision = %#v, want pool-cluster-2", lastDeprovision)
+	if lastDeprovision == nil || lastDeprovision.ClusterID != "pool-cluster-1-2" {
+		t.Fatalf("last deprovision = %#v, want pool-cluster-1-2", lastDeprovision)
 	}
 }
 
@@ -2109,8 +2113,8 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneTenantLabelMissin
 		t.Fatalf("deprovision calls = %d, want 1", got)
 	}
 	lastDeprovision := rt.prov.lastDeprovisionSnapshot()
-	if lastDeprovision == nil || lastDeprovision.ClusterID != "pool-cluster-2" {
-		t.Fatalf("last deprovision = %#v, want pool-cluster-2", lastDeprovision)
+	if lastDeprovision == nil || lastDeprovision.ClusterID != "pool-cluster-1-2" {
+		t.Fatalf("last deprovision = %#v, want pool-cluster-1-2", lastDeprovision)
 	}
 }
 
@@ -2563,7 +2567,7 @@ func TestAdminTenantPoolReplenishSkipsDeletedOrShrunkPool(t *testing.T) {
 		t.Fatalf("shrink pool: %v", err)
 	}
 
-	rt.server.replenishTenantPoolAsync(ctx, stalePool, tenant.CredentialProvisionRequest{
+	rt.server.kickTenantPoolRefill(ctx, stalePool, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	})
@@ -2754,7 +2758,7 @@ func TestAdminTenantPoolReplenishUsesDefaultSpendingLimit(t *testing.T) {
 		TiDBCloudSpendingLimitMonthly: &defaultLimit,
 	}
 
-	rt.server.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
+	rt.server.kickTenantPoolRefill(ctx, pool, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -63,11 +63,16 @@ type Config struct {
 	// <= 0 are normalized to DefaultTenantPoolMaxSize; the pool is never
 	// intentionally uncapped.
 	TenantPoolMaxSize int
-	// TenantPoolRefillFreeRatio controls when claim-triggered asynchronous pool
-	// refill creates replacement tenants. Refill runs only when active free
-	// tenants fall below this ratio of the configured pool size. Values outside
-	// (0,1] are normalized to DefaultTenantPoolRefillFreeRatio.
-	TenantPoolRefillFreeRatio float64
+	// TenantPoolRefillBatchSize caps how many async cluster creations the
+	// claim-triggered background refill worker dispatches per round. Values
+	// <= 0 are normalized to DefaultTenantPoolRefillBatchSize.
+	TenantPoolRefillBatchSize int
+	// TenantPoolRefillInterval is the delay between refill dispatch rounds.
+	// It is the token bucket for cluster creation: the start rate is capped
+	// at TenantPoolRefillBatchSize/TenantPoolRefillInterval regardless of how
+	// long individual creations take. Values <= 0 are normalized to
+	// DefaultTenantPoolRefillInterval.
+	TenantPoolRefillInterval time.Duration
 	// InlineThreshold is the server-wide DB-inline vs S3 cutoff surfaced to
 	// clients via /v1/status. When 0, the value is inferred from
 	// cfg.Backend.InlineThreshold() (or omitted in responses if no backend).
@@ -185,7 +190,8 @@ type Server struct {
 	publicURL                 string
 	maxUploadBytes            int64
 	tenantPoolMaxSize         int
-	tenantPoolRefillFreeRatio float64
+	tenantPoolRefillBatchSize int
+	tenantPoolRefillInterval  time.Duration
 	inlineThreshold           int64
 	metrics                   *serverMetrics
 	logger                    *zap.Logger
@@ -206,6 +212,7 @@ type Server struct {
 	tenantPoolLocks           sync.Map
 	tenantPoolCreateLocks     sync.Map
 	tenantPoolResumeJobs      sync.Map
+	tenantPoolRefillJobs      sync.Map
 	tidbCloudRBACCache        *tidbCloudRBACCache
 	schemaInitErrors          sync.Map
 	leader                    *leader.Manager
@@ -272,9 +279,14 @@ const DefaultMaxUploadBytes int64 = 10 * (1 << 30) // 10 GiB
 // configuration with a positive value.
 const DefaultTenantPoolMaxSize = 200
 
-// DefaultTenantPoolRefillFreeRatio delays claim-triggered pool refill until the
-// active free tenant count falls below 80% of the configured pool size.
-const DefaultTenantPoolRefillFreeRatio = 0.8
+// DefaultTenantPoolRefillBatchSize caps how many replacement tenants the
+// claim-triggered refill worker creates per round.
+const DefaultTenantPoolRefillBatchSize = 1
+
+// DefaultTenantPoolRefillInterval is the default delay between refill worker
+// rounds. With the default batch size the steady refill rate is 1 tenant per
+// second, independent of the claim burst rate.
+const DefaultTenantPoolRefillInterval = time.Second
 
 // TenantStatusResponse is the JSON body of GET /v1/status. Fields are filled
 // per authenticated tenant so callers can discover their effective limits
@@ -341,7 +353,14 @@ func NewWithConfig(cfg Config) *Server {
 	if tenantPoolMaxSize <= 0 {
 		tenantPoolMaxSize = DefaultTenantPoolMaxSize
 	}
-	tenantPoolRefillFreeRatio := normalizeTenantPoolRefillFreeRatio(cfg.TenantPoolRefillFreeRatio)
+	tenantPoolRefillBatchSize := cfg.TenantPoolRefillBatchSize
+	if tenantPoolRefillBatchSize <= 0 {
+		tenantPoolRefillBatchSize = DefaultTenantPoolRefillBatchSize
+	}
+	tenantPoolRefillInterval := cfg.TenantPoolRefillInterval
+	if tenantPoolRefillInterval <= 0 {
+		tenantPoolRefillInterval = DefaultTenantPoolRefillInterval
+	}
 	forkWorkerCtx, forkWorkerCancel := context.WithCancel(context.Background())
 	s := &Server{
 		fallback:                  cfg.Backend,
@@ -356,7 +375,8 @@ func NewWithConfig(cfg Config) *Server {
 		legacyStarterProvisioner:  cfg.LegacyStarterProvisioner,
 		maxUploadBytes:            maxUpload,
 		tenantPoolMaxSize:         tenantPoolMaxSize,
-		tenantPoolRefillFreeRatio: tenantPoolRefillFreeRatio,
+		tenantPoolRefillBatchSize: tenantPoolRefillBatchSize,
+		tenantPoolRefillInterval:  tenantPoolRefillInterval,
 		inlineThreshold:           inlineThreshold,
 		metrics:                   newServerMetrics(),
 		logger:                    logger,
@@ -552,11 +572,18 @@ func NewWithConfig(cfg Config) *Server {
 	return s
 }
 
-func normalizeTenantPoolRefillFreeRatio(ratio float64) float64 {
-	if ratio <= 0 || ratio > 1 || ratio != ratio {
-		return DefaultTenantPoolRefillFreeRatio
+// tenantPoolRefillConfig returns the normalized refill dispatch pacing: at
+// most batchSize async creations started per interval.
+func (s *Server) tenantPoolRefillConfig() (batchSize int, interval time.Duration) {
+	batchSize = s.tenantPoolRefillBatchSize
+	if batchSize <= 0 {
+		batchSize = DefaultTenantPoolRefillBatchSize
 	}
-	return ratio
+	interval = s.tenantPoolRefillInterval
+	if interval <= 0 {
+		interval = DefaultTenantPoolRefillInterval
+	}
+	return batchSize, interval
 }
 
 // insertTenantNotify writes a best-effort unified outbox row so other pods
@@ -4477,7 +4504,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 			if res.Status == meta.TenantProvisioning {
 				s.startProvisionedTenantSchemaInit(r.Context(), res)
 			}
-			s.replenishTenantPoolAsync(r.Context(), pool, *credentialReq)
+			s.kickTenantPoolRefill(r.Context(), pool, *credentialReq)
 			if quotaReq != nil && quotaReq.TiDBCloudSpendingLimit != nil {
 				metricEvent(r.Context(), "tenant_provision", "provider", provider, "quota", "create_time_spending_limit")
 			}

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"hash/crc32"
 	"io"
-	"math"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1516,17 +1515,23 @@ func TestNewWithConfigUsesDefaultTenantPoolMaxSize(t *testing.T) {
 	}
 }
 
-func TestNewWithConfigUsesDefaultTenantPoolRefillFreeRatio(t *testing.T) {
+func TestNewWithConfigUsesDefaultTenantPoolRefillConfig(t *testing.T) {
 	s := NewWithConfig(Config{})
-	if s.tenantPoolRefillFreeRatio != DefaultTenantPoolRefillFreeRatio {
-		t.Fatalf("default tenantPoolRefillFreeRatio = %f, want %f", s.tenantPoolRefillFreeRatio, DefaultTenantPoolRefillFreeRatio)
+	if s.tenantPoolRefillBatchSize != DefaultTenantPoolRefillBatchSize {
+		t.Fatalf("default tenantPoolRefillBatchSize = %d, want %d", s.tenantPoolRefillBatchSize, DefaultTenantPoolRefillBatchSize)
+	}
+	if s.tenantPoolRefillInterval != DefaultTenantPoolRefillInterval {
+		t.Fatalf("default tenantPoolRefillInterval = %s, want %s", s.tenantPoolRefillInterval, DefaultTenantPoolRefillInterval)
 	}
 }
 
-func TestNewWithConfigRejectsNaNTenantPoolRefillFreeRatio(t *testing.T) {
-	s := NewWithConfig(Config{TenantPoolRefillFreeRatio: math.NaN()})
-	if s.tenantPoolRefillFreeRatio != DefaultTenantPoolRefillFreeRatio {
-		t.Fatalf("NaN tenantPoolRefillFreeRatio = %f, want %f", s.tenantPoolRefillFreeRatio, DefaultTenantPoolRefillFreeRatio)
+func TestNewWithConfigNormalizesInvalidTenantPoolRefillConfig(t *testing.T) {
+	s := NewWithConfig(Config{TenantPoolRefillBatchSize: -1, TenantPoolRefillInterval: -time.Second})
+	if s.tenantPoolRefillBatchSize != DefaultTenantPoolRefillBatchSize {
+		t.Fatalf("invalid tenantPoolRefillBatchSize = %d, want %d", s.tenantPoolRefillBatchSize, DefaultTenantPoolRefillBatchSize)
+	}
+	if s.tenantPoolRefillInterval != DefaultTenantPoolRefillInterval {
+		t.Fatalf("invalid tenantPoolRefillInterval = %s, want %s", s.tenantPoolRefillInterval, DefaultTenantPoolRefillInterval)
 	}
 }
 


### PR DESCRIPTION
## Motivation

Claim-triggered pool refill waited until free tenants dropped below 80% of pool size, then batch-created the **entire deficit in one call** — a 600-slot pool dipping below 480 free triggered a single catch-up batch of 120+ clusters, a request storm against the TiDB Cloud API.

## New model: queue with a fixed-rate producer

A per-pool background worker (kicked by claims, credentials kept in memory only) treats the pool as a queue: whenever it is not full, it dispatches cluster creations at a fixed, configurable rate — `TenantPoolRefillBatchSize` per `TenantPoolRefillInterval`, default **1/s** — decoupled from both claim bursts and `batchCreate` latency (tens of seconds in practice). Pool capacity now only absorbs peaks; the producer keeps pace with average consumption.

Initial pool create (POST) and admin grow (PATCH) keep their explicit one-shot batch behavior.

## Correctness under async dispatch

- **In-flight visibility**: each dispatched creation first records a pending tenant plus a placeholder binding (`cluster_id = "pending:<tenantID>") inside the pool locks, so in-flight creations occupy slots in `CountTenantPoolFreeSlots` across pods and the dispatcher never over-provisions. Placeholder tenants stay `Pending`: claims (Active-only) can't take them, the metadata-resume path skips them.
- **No resurrection on reclaim**: the async finisher persists under the same pool locks used by shrink/delete and rechecks tenant status first; if the placeholder was reclaimed (shrink, pool delete, or the reaper) while the API call ran, the created cluster is deprovisioned instead of resurrecting the slot. Shrink/delete skips cloud deprovision for placeholder slots.
- **Orphan reaper + circuit breaker**: placeholder tenants older than 15 min (e.g. abandoned by a crashed pod) are failed to free the slot; the worker stops after 5 consecutive creation failures and is re-kicked by the next claim.

`createFreePoolTenants` is split into `batchProvisionFreePoolClusters` + `persistFreePoolClusters` so the admin batch path and the async finisher share the persistence logic.

## Config changes (breaking)

- Removed: `DRIVE9_TENANT_POOL_REFILL_FREE_RATIO` (silently ignored now — call out in release notes)
- Added: `DRIVE9_TENANT_POOL_REFILL_BATCH_SIZE` (default 1), `DRIVE9_TENANT_POOL_REFILL_INTERVAL` (default 1s)

Note: with N pods each running a worker, aggregate creation rate is N × configured rate (same multi-pod behavior as the previous claim-triggered refill; DB locks still prevent over-provisioning).

## Tests

- New: placeholder slots visible in flight (counted as slots, not claimable), stale-placeholder reaper frees and refills slots, reclaimed placeholder deprovisions the created cluster, worker stops after consecutive failures, coalesced kicks, pool-full/deleted worker exit.
- Updated: refill batching expectations (async one-cluster calls), env parsing tests, fake provisioner generates per-call unique cluster IDs (real `uk_tidbcloud_org_cluster_branch` constraint).
- Verified: `make test TEST_PKGS='./pkg/server'` full suite, `./pkg/meta`, `./cmd/drive9-server`, `make lint` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Tenant pool refilling now occurs in configurable batches at a steady interval.
  - Added configuration options for refill batch size and interval.
  - Pool capacity is replenished automatically after tenants are claimed.

- **Bug Fixes**
  - Improved handling of stalled or abandoned tenant provisioning.
  - Prevented incomplete provisioning from occupying pool capacity indefinitely.
  - Ensured reclaimed in-progress slots are cleaned up safely.

- **Documentation**
  - Updated command-line help text with the new refill settings and rate-limiting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->