### PR TITLE
Refactor managed cluster cache helper

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -685,7 +685,7 @@ func (s *Server) firstManagedOrganization(ctx context.Context, cred tenant.Crede
 	// request path (warm-pool claim + shared-pool check) and across
 	// consecutive provisions do not each cost a TiDB Cloud list call. The
 	// cache is invalidated on tenant mutations (forgetTiDBCloudRBACList).
-	clusters, _, err := s.listAllManagedClustersCached(ctx, cred, "", true, "provision_org_resolve")
+	clusters, err := s.listAllManagedClusters(ctx, cred, "", "provision_org_resolve")
 	if err != nil || len(clusters) == 0 {
 		return "", err
 	}

--- a/pkg/server/admin_tenant_pool_cache_test.go
+++ b/pkg/server/admin_tenant_pool_cache_test.go
@@ -54,3 +54,31 @@ func TestFirstManagedOrganizationUsesRBACCache(t *testing.T) {
 		t.Fatalf("list calls after forget = %d, want 2", got)
 	}
 }
+
+func TestListAllManagedClustersUsesRBACCache(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{ClusterID: "c1", OrganizationID: "org-1"}},
+	}}
+	ctx := context.Background()
+	cred := tenant.CredentialProvisionRequest{PublicKey: "pk", PrivateKey: "sk"}
+
+	clusters, err := rt.server.listAllManagedClusters(ctx, cred, "", "test_managed_cluster_list")
+	if err != nil {
+		t.Fatalf("first list: %v", err)
+	}
+	if len(clusters) != 1 || clusters[0].ClusterID != "c1" || clusters[0].OrganizationID != "org-1" {
+		t.Fatalf("first clusters = %#v", clusters)
+	}
+
+	clusters, err = rt.server.listAllManagedClusters(ctx, cred, "", "test_managed_cluster_list")
+	if err != nil {
+		t.Fatalf("cached list: %v", err)
+	}
+	if len(clusters) != 1 || clusters[0].ClusterID != "c1" || clusters[0].OrganizationID != "org-1" {
+		t.Fatalf("cached clusters = %#v", clusters)
+	}
+	if got := rt.prov.listCalls.Load(); got != 1 {
+		t.Fatalf("list calls = %d, want 1", got)
+	}
+}

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -243,7 +243,7 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	clusters, _, err := s.listAllManagedClusters(r.Context(), cred, "", "admin_tenant_list")
+	clusters, err := s.listAllManagedClusters(r.Context(), cred, "", "admin_tenant_list")
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "list tenants")
 		return
@@ -464,13 +464,13 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 		errJSON(w, http.StatusNotFound, "tenant not found")
 		return nil, nil, false
 	}
-	clusters, _, err := s.listAllManagedClustersCached(r.Context(), cred, binding.ClusterID, true, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
+	clusters, err := s.listAllManagedClusters(r.Context(), cred, binding.ClusterID, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
 		return nil, nil, false
 	}
 	if len(clusters) == 0 && allowDeletingMissingCluster && t.Status == meta.TenantDeleting {
-		clusters, _, err = s.listAllManagedClusters(r.Context(), cred, "", adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
+		clusters, err = s.listAllManagedClusters(r.Context(), cred, "", adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
 		if err != nil {
 			writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
 			return nil, nil, false
@@ -510,35 +510,27 @@ func adminTenantMetricPath(loadQuota bool, allowDeletingMissingCluster bool) str
 	}
 }
 
-func (s *Server) listAllManagedClusters(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, bool, error) {
-	return s.listAllManagedClustersCached(ctx, cred, clusterID, true, metricPath)
-}
-
-func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID string, allowCache bool, metricPath string) ([]tenant.CloudClusterInfo, bool, error) {
+func (s *Server) listAllManagedClusters(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, error) {
 	clusterID = strings.TrimSpace(clusterID)
 	scope := "list"
 	if clusterID != "" {
 		scope = "cluster"
 	}
-	if allowCache {
-		if clusterID != "" {
-			if cluster, ok := s.tidbCloudRBACCache.getCluster(cred, clusterID); ok {
-				if cluster.OrganizationID != "" {
-					metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "hit")
-					return []tenant.CloudClusterInfo{cluster}, true, nil
-				}
+	if clusterID != "" {
+		if cluster, ok := s.tidbCloudRBACCache.getCluster(cred, clusterID); ok {
+			if cluster.OrganizationID != "" {
+				metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "hit")
+				return []tenant.CloudClusterInfo{cluster}, nil
 			}
-		} else if clusters, ok := s.tidbCloudRBACCache.getClusterList(cred); ok {
-			metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "hit")
-			return clusters, true, nil
 		}
-		metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "miss")
-	} else {
-		metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "bypass")
+	} else if clusters, ok := s.tidbCloudRBACCache.getClusterList(cred); ok {
+		metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "hit")
+		return clusters, nil
 	}
+	metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "miss")
 	lister, ok := s.provisioner.(tenant.ManagedClusterLister)
 	if !ok {
-		return nil, false, fmt.Errorf("managed cluster list not enabled")
+		return nil, fmt.Errorf("managed cluster list not enabled")
 	}
 	var out []tenant.CloudClusterInfo
 	pageToken := ""
@@ -550,14 +542,14 @@ func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.C
 		})
 		if err != nil {
 			metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "list_managed_clusters", "error")
-			return nil, false, err
+			return nil, err
 		}
 		metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "list_managed_clusters", "ok")
 		if page == nil {
 			if clusterID == "" {
 				s.tidbCloudRBACCache.rememberClusterList(cred, out)
 			}
-			return out, false, nil
+			return out, nil
 		}
 		out = append(out, page.Clusters...)
 		pageToken = strings.TrimSpace(page.NextPageToken)
@@ -569,7 +561,7 @@ func (s *Server) listAllManagedClustersCached(ctx context.Context, cred tenant.C
 					s.rememberTiDBCloudRBAC(cred, cluster)
 				}
 			}
-			return out, false, nil
+			return out, nil
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- fold the RBAC cache path into `listAllManagedClusters`
- remove the redundant cached helper, cache toggle, cache-origin return value, and unreachable bypass metric
- add regression coverage confirming repeated managed-cluster lists use the RBAC cache

## Test plan

- `go test ./pkg/server -run "^(TestListAllManagedClustersUsesRBACCache|TestFirstManagedOrganizationUsesRBACCache)$" -count=1`
- `make lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved admin tenant authorization and listing by using more reliable managed-cluster data.
  * Ensured tenant credential flows consistently resolve the correct managed organization.
  * Reduced unnecessary provider requests when retrieving managed-cluster information.

* **Tests**
  * Added coverage confirming managed-cluster results are reused correctly across repeated requests.
  * Verified cached data remains accurate during organization and tenant authorization flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->