### PR TITLE
metrics: add counter/histogram/gauge cleanup on tenant close

### DIFF
--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -187,6 +187,16 @@ func DeleteTenantPoolBindings(poolID, tidbCloudOrgID, poolStatus string) {
 	)
 }
 
+func DeleteTenantCounters(tenantID string) {
+	tenantID = cleanMetricValue(tenantID, "unknown")
+	if tenantID == "unknown" {
+		return
+	}
+	globalRegistry.DeleteCountersByLabel("tenant_id", tenantID)
+	globalRegistry.DeleteHistogramsByLabel("tenant_id", tenantID)
+	globalRegistry.DeleteGaugesByLabel("tenant_id", tenantID)
+}
+
 func RecordTiDBCloudRBACCacheRequest(path, scope, result string) {
 	RegisterModule("tidbcloud_quota")
 	tidbCloudRBACCacheRequestsTotal.Add(1,

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -468,3 +468,59 @@ func TestRecordDBOperationOmitsTenantID(t *testing.T) {
 		t.Fatalf("db operation metrics must not carry tenant_id:\n%s", text)
 	}
 }
+
+func TestDeleteTenantCounters(t *testing.T) {
+	const tenantID = "tenant-delete-counter-test"
+	const tidbCloudOrgID = "org-delete-counter"
+
+	RecordTenantOperationCountWithOrg(tenantID, tidbCloudOrgID, "cmp", "op", "ok")
+	RecordTenantRequestCountWithOrg(tenantID, tidbCloudOrgID, "api", "read", "ok", 200)
+	RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, "api", "", "upload", 1024)
+	RecordSSEConnectionWithOrg(tenantID, tidbCloudOrgID, "mount", time.Second)
+	RecordSSEEventSentWithOrg(tenantID, tidbCloudOrgID, "write")
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `tenant_id="`+tenantID+`"`) {
+		t.Fatalf("tenant_id not found before delete:\n%s", text)
+	}
+
+	DeleteTenantCounters(tenantID)
+
+	rec2 := httptest.NewRecorder()
+	WritePrometheus(rec2)
+	text2 := rec2.Body.String()
+
+	counterNames := []string{
+		"drive9_service_operations_total",
+		"drive9_tenant_requests_total",
+		"drive9_tenant_http_bytes_total",
+		"drive9_sse_connections_total",
+		"drive9_sse_events_sent_total",
+	}
+	histogramNames := []string{
+		"drive9_sse_connection_duration_seconds_bucket",
+		"drive9_sse_connection_duration_seconds_count",
+		"drive9_sse_connection_duration_seconds_sum",
+	}
+	for _, line := range strings.Split(text2, "\n") {
+		if !strings.Contains(line, `tenant_id="`+tenantID+`"`) {
+			continue
+		}
+		for _, name := range counterNames {
+			if strings.HasPrefix(line, name) {
+				t.Fatalf("counter line with tenant_id still present: %s", line)
+			}
+		}
+		for _, name := range histogramNames {
+			if strings.HasPrefix(line, name) {
+				t.Fatalf("histogram line with tenant_id still present: %s", line)
+			}
+		}
+	}
+}
+
+func TestDeleteTenantCountersEmptyIsNoop(t *testing.T) {
+	DeleteTenantCounters("")
+}

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -478,6 +478,7 @@ func TestDeleteTenantCounters(t *testing.T) {
 	RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, "api", "", "upload", 1024)
 	RecordSSEConnectionWithOrg(tenantID, tidbCloudOrgID, "mount", time.Second)
 	RecordSSEEventSentWithOrg(tenantID, tidbCloudOrgID, "write")
+	RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, "api", "read", 3)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
@@ -504,20 +505,35 @@ func TestDeleteTenantCounters(t *testing.T) {
 		"drive9_sse_connection_duration_seconds_count",
 		"drive9_sse_connection_duration_seconds_sum",
 	}
+	gaugeNames := []string{
+		"drive9_tenant_inflight_requests",
+	}
+	var failures int
 	for _, line := range strings.Split(text2, "\n") {
 		if !strings.Contains(line, `tenant_id="`+tenantID+`"`) {
 			continue
 		}
 		for _, name := range counterNames {
 			if strings.HasPrefix(line, name) {
-				t.Fatalf("counter line with tenant_id still present: %s", line)
+				t.Errorf("counter line with tenant_id still present: %s", line)
+				failures++
 			}
 		}
 		for _, name := range histogramNames {
 			if strings.HasPrefix(line, name) {
-				t.Fatalf("histogram line with tenant_id still present: %s", line)
+				t.Errorf("histogram line with tenant_id still present: %s", line)
+				failures++
 			}
 		}
+		for _, name := range gaugeNames {
+			if strings.HasPrefix(line, name) {
+				t.Errorf("gauge line with tenant_id still present: %s", line)
+				failures++
+			}
+		}
+	}
+	if failures > 0 {
+		t.Fatalf("%d tenant-scoped lines leaked after DeleteTenantCounters", failures)
 	}
 }
 

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -311,7 +311,12 @@ func (r *Registry) deleteGauge(name, labels string) {
 }
 
 func labelHasKeyValue(labels, match string) bool {
-	return strings.HasSuffix(labels, match) || strings.Contains(labels, match+",")
+	if labels == match {
+		return true
+	}
+	return strings.HasPrefix(labels, match+`,`) ||
+		strings.Contains(labels, `,`+match+`,`) ||
+		strings.HasSuffix(labels, `,`+match)
 }
 
 func (r *Registry) DeleteCountersByLabel(labelKey, labelValue string) {

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -156,6 +156,13 @@ func (c *Int64Counter) Add(value int64, attrs ...Attribute) {
 	c.registry.addCounter(c.name, labelsKey(attrs), value)
 }
 
+func (c *Int64Counter) Delete(attrs ...Attribute) {
+	if c == nil || c.registry == nil {
+		return
+	}
+	c.registry.deleteCounter(c.name, labelsKey(attrs))
+}
+
 func (g *Float64Gauge) Set(value float64, attrs ...Attribute) {
 	if g == nil || g.registry == nil {
 		return
@@ -283,6 +290,16 @@ func (r *Registry) setGauge(name, labels string, value float64) {
 	inst.values[labels] = value
 }
 
+func (r *Registry) deleteCounter(name, labels string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inst := r.counters[name]
+	if inst == nil {
+		return
+	}
+	delete(inst.values, labels)
+}
+
 func (r *Registry) deleteGauge(name, labels string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -291,6 +308,49 @@ func (r *Registry) deleteGauge(name, labels string) {
 		return
 	}
 	delete(inst.values, labels)
+}
+
+func labelHasKeyValue(labels, match string) bool {
+	return strings.HasSuffix(labels, match) || strings.Contains(labels, match+",")
+}
+
+func (r *Registry) DeleteCountersByLabel(labelKey, labelValue string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	match := labelKey + `="` + EscapePromLabel(labelValue) + `"`
+	for _, inst := range r.counters {
+		for labels := range inst.values {
+			if labelHasKeyValue(labels, match) {
+				delete(inst.values, labels)
+			}
+		}
+	}
+}
+
+func (r *Registry) DeleteHistogramsByLabel(labelKey, labelValue string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	match := labelKey + `="` + EscapePromLabel(labelValue) + `"`
+	for _, inst := range r.histograms {
+		for labels := range inst.values {
+			if labelHasKeyValue(labels, match) {
+				delete(inst.values, labels)
+			}
+		}
+	}
+}
+
+func (r *Registry) DeleteGaugesByLabel(labelKey, labelValue string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	match := labelKey + `="` + EscapePromLabel(labelValue) + `"`
+	for _, inst := range r.gauges {
+		for labels := range inst.values {
+			if labelHasKeyValue(labels, match) {
+				delete(inst.values, labels)
+			}
+		}
+	}
 }
 
 func (r *Registry) observeHistogram(name, labels string, value float64) {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -1374,6 +1374,7 @@ func closeEntry(e *entry) {
 	if e.store != nil {
 		_ = e.store.Close()
 	}
+	metrics.DeleteTenantCounters(e.tenantID)
 }
 
 type tenantPoolResult string

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -305,7 +305,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 		}
 		p.mu.Unlock()
 		for _, retired := range toClose {
-			closeEntry(retired)
+			p.closeEntry(retired)
 		}
 		toClose = nil
 	} else {
@@ -347,7 +347,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 	// per-backend goroutine is started here.
 	p.mu.Unlock()
 	for _, retired := range toClose {
-		closeEntry(retired)
+		p.closeEntry(retired)
 	}
 	return b, nil
 }
@@ -388,7 +388,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 		}
 		p.mu.Unlock()
 		for _, retired := range toClose {
-			closeEntry(retired)
+			p.closeEntry(retired)
 		}
 		toClose = nil
 	} else {
@@ -445,7 +445,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 	// per-backend goroutine is started here.
 	p.mu.Unlock()
 	for _, retired := range toClose {
-		closeEntry(retired)
+		p.closeEntry(retired)
 	}
 	metrics.RecordOperation("tenant_pool", "cache_lookup", "miss", 0)
 	totalDuration := time.Since(start)
@@ -461,7 +461,7 @@ func (p *Pool) Invalidate(tenantID string) {
 		toClose = p.removeLocked(e.elem, "invalidate")
 	}
 	p.mu.Unlock()
-	closeEntry(toClose)
+	p.closeEntry(toClose)
 }
 
 func (p *Pool) WaitTenantIdle(ctx context.Context, tenantID string) error {
@@ -556,7 +556,7 @@ func (p *Pool) InvalidateAndWait(ctx context.Context, tenantID string) error {
 		toClose = p.removeLocked(e.elem, "invalidate")
 	}
 	p.mu.Unlock()
-	closeEntry(toClose)
+	p.closeEntry(toClose)
 	if retired == nil || toClose != nil {
 		return nil
 	}
@@ -714,7 +714,7 @@ func (p *Pool) reapOnce(ctx context.Context) {
 	p.recordCachedBackendCountLocked()
 	p.mu.Unlock()
 	for _, retired := range toClose {
-		closeEntry(retired)
+		p.closeEntry(retired)
 	}
 }
 
@@ -734,7 +734,7 @@ func (p *Pool) Close() {
 	}
 	p.mu.Unlock()
 	for _, retired := range toClose {
-		closeEntry(retired)
+		p.closeEntry(retired)
 	}
 	p.sharedMu.Lock()
 	for dbID, db := range p.sharedDBs {
@@ -1361,10 +1361,12 @@ func (p *Pool) releaseEntry(e *entry, refreshLastUsed bool) {
 		toClose = e
 	}
 	p.mu.Unlock()
-	closeEntry(toClose)
+	if toClose != nil {
+		p.closeEntry(toClose)
+	}
 }
 
-func closeEntry(e *entry) {
+func (p *Pool) closeEntry(e *entry) {
 	if e == nil {
 		return
 	}
@@ -1374,7 +1376,12 @@ func closeEntry(e *entry) {
 	if e.store != nil {
 		_ = e.store.Close()
 	}
-	metrics.DeleteTenantCounters(e.tenantID)
+	p.mu.Lock()
+	_, active := p.items[e.tenantID]
+	p.mu.Unlock()
+	if !active {
+		metrics.DeleteTenantCounters(e.tenantID)
+	}
 }
 
 type tenantPoolResult string


### PR DESCRIPTION
## Problem

Tenant-scoped counter, histogram, and gauge metric entries accumulate unbounded over the lifetime of a process. There is no mechanism to remove entries for tenants that are no longer active.

Production observations on the TKE Beijing cluster:
- Single pod `/metrics` response exceeds 35MB (past vmagent maxScrapeSize of 32MiB)
- 7,500+ historical tenant counter entries persist in output
- vmagent suffered repeated OOMKilled restarts due to persistent queue bloat

## Root Cause

- `Int64Counter` has `Add()` but no `Delete()` — counter label sets are write-only
- `Registry.counterInstrument.values` map grows forever
- By contrast, `Float64Gauge` already exposes `Delete()`, but histograms share the same leak

## Changes

- **`pkg/metrics/registry.go`**: Added `Int64Counter.Delete()`, `deleteCounter()`, `DeleteCountersByLabel()`, `DeleteHistogramsByLabel()`, `DeleteGaugesByLabel()` with exact label-value matching
- **`pkg/metrics/operations.go`**: Added `DeleteTenantCounters(tenantID)` — cleans counters, histograms, and gauges for a given tenant
- **`pkg/tenant/pool.go`**: Calls `metrics.DeleteTenantCounters(e.tenantID)` in `closeEntry()`

When a tenant backend is closed (invalidate, shutdown, evict, or idle-reap), all per-tenant counter/histogram/gauge entries are removed from the global registry.

## Verification

- New tests: `TestDeleteTenantCounters`, `TestDeleteTenantCountersEmptyIsNoop`
- All `pkg/metrics` tests pass
- Lint passes with 0 issues