### PR TITLE
feat: add TiDB Cloud Native shared DB control plane

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -679,7 +679,7 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY optional default TiDB Cloud API private key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT true|false to use TiDB Cloud private endpoint hosts for tidb_cloud_native
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS soft capacity for new managed shared DB pools (default: 100)
-  DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO emergency hard-cap ratio after physical create failure (default: 1.2)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO emergency hard-cap ratio > 1 after physical create failure (default: 1.2)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO reopen ratio for a latched shared pool (default: 0.8)
   DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT default managed shared DB-pool spending target (default: 10000000)
   DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings (also accepts public_host:private_host);
@@ -1192,8 +1192,8 @@ func sharedDBHardCapRatioFromEnv() (float64, error) {
 		return server.DefaultSharedDBHardCapRatio, nil
 	}
 	v, err := strconv.ParseFloat(raw, 64)
-	if err != nil || v < 1 || math.IsNaN(v) || math.IsInf(v, 0) {
-		return 0, fmt.Errorf("invalid DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO=%q: must be a finite number >= 1", raw)
+	if err != nil || v <= 1 || math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, fmt.Errorf("invalid DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO=%q: must be a finite number > 1", raw)
 	}
 	return v, nil
 }

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -12,6 +12,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
+	"math"
 	"net"
 	"os"
 	"strconv"
@@ -187,6 +188,22 @@ func main() {
 	if err != nil {
 		die(err)
 	}
+	sharedDBHardCapRatio, err := sharedDBHardCapRatioFromEnv()
+	if err != nil {
+		die(err)
+	}
+	sharedDBReopenRatio, err := sharedDBReopenRatioFromEnv()
+	if err != nil {
+		die(err)
+	}
+	sharedDBMaxTenants, err := sharedDBMaxTenantsFromEnv()
+	if err != nil {
+		die(err)
+	}
+	sharedDBDefaultSpendingLimit, err := sharedDBDefaultSpendingLimitFromEnv()
+	if err != nil {
+		die(err)
+	}
 	maxUploadBytes := server.DefaultMaxUploadBytes
 	if raw := os.Getenv("DRIVE9_MAX_UPLOAD_BYTES"); raw != "" {
 		maxUploadBytes, err = strconv.ParseInt(raw, 10, 64)
@@ -218,14 +235,14 @@ func main() {
 	switch providerType {
 	case tenant.ProviderTiDBZero:
 		provisioner, provisionerErr = tidbzero.NewProvisionerFromEnv()
-	case tenant.ProviderTiDBCloudNative:
+	case tenant.ProviderTiDBCloudNative, tenant.ProviderTiDBCloudNativeShared:
 		provisioner, provisionerErr = tidbcloudnative.NewProvisionerFromEnv()
 	case tenant.ProviderDB9:
 		provisioner, provisionerErr = db9.NewProvisionerFromEnv()
 	}
 	if provisionerErr != nil {
 		isWanted := false
-		if providerType == tenant.ProviderTiDBCloudNative && os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_API_URL") != "" {
+		if tenant.UsesTiDBCloudNativeCredentials(providerType) && os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_API_URL") != "" {
 			isWanted = true
 		}
 		if isWanted {
@@ -428,6 +445,11 @@ func main() {
 		Meta:                            store,
 		Pool:                            pool,
 		Provisioner:                     provisioner,
+		DefaultTenantProvider:           providerType,
+		SharedDBMaxTenants:              sharedDBMaxTenants,
+		SharedDBHardCapRatio:            sharedDBHardCapRatio,
+		SharedDBReopenRatio:             sharedDBReopenRatio,
+		SharedDBDefaultSpendingLimit:    sharedDBDefaultSpendingLimit,
 		LegacyStarterProvisioner:        legacyStarterProvisioner,
 		TokenSecret:                     tokenSecret,
 		VaultMasterKey:                  vaultMasterKey,
@@ -498,14 +520,14 @@ func registerSharedPoolFromEnv(ctx context.Context, metaStore *meta.Store, pool 
 		tlsMode = ""
 	}
 	_, err = metaStore.RegisterSharedDB(ctx, &meta.SharedDB{
-		OrgID:          orgID,
-		Role:           meta.SharedDBRoleShared,
-		Host:           host,
-		Port:           port,
-		User:           cfg.User,
-		PasswordCipher: passCipher,
-		Name:           cfg.DBName,
-		TLSMode:        tlsMode,
+		TiDBCloudOrganizationID: orgID,
+		Role:                    meta.SharedDBRoleShared,
+		Host:                    host,
+		Port:                    port,
+		User:                    cfg.User,
+		PasswordCipher:          passCipher,
+		Name:                    cfg.DBName,
+		TLSMode:                 tlsMode,
 	})
 	return err
 }
@@ -590,7 +612,7 @@ func usage(out io.Writer, exitCode int) {
 	_, _ = fmt.Fprintf(out, `usage:
   drive9-server [listen-addr]
   drive9-server version
-  drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_native>
+  drive9-server schema dump-init-sql --provider <db9|tidb_zero|tidb_cloud_native|tidb_cloud_native_shared>
 
 environment:
   DRIVE9_LISTEN_ADDR serve listen address (default: :9009)
@@ -607,8 +629,10 @@ environment:
   DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS max idle connections for tenant schema-init DB pools (default: 2)
   DRIVE9_SHARED_POOL_DSN register a shared-schema DB at startup and place matching tenants on it (empty = disabled)
   DRIVE9_SHARED_POOL_ORG TiDB Cloud org the shared pool serves (required when DSN is set; '*' = all orgs, loud warn)
-  DRIVE9_SHARED_DB_MAX_OPEN_CONNS max open connections for each shared-schema DB handle (default: 50)
-  DRIVE9_SHARED_DB_MAX_IDLE_CONNS max idle connections for each shared-schema DB handle (default: 10)
+  DRIVE9_SHARED_DB_MAX_OPEN_CONNS max open connections for each shared-schema DB handle (default: 300)
+  DRIVE9_SHARED_DB_MAX_IDLE_CONNS max idle connections for each shared-schema DB handle (default: 50)
+  DRIVE9_SHARED_DB_CONN_MAX_LIFETIME maximum shared connection lifetime (default: 30m)
+  DRIVE9_SHARED_DB_CONN_MAX_IDLE_TIME maximum shared connection idle time (default: 5m)
   DRIVE9_DB_HEALTH_PROBE_INTERVAL_SECONDS DB health probe interval seconds (default: 15)
   DRIVE9_DB_HEALTH_PROBE_TIMEOUT_SECONDS DB health probe timeout seconds (default: 3)
   DRIVE9_DB_HEALTH_PROBE_META_ENABLED true|false to probe the control-plane DB (default: true)
@@ -645,7 +669,7 @@ environment:
                                     required by openai, cohere, jina_ai, gemini, huggingface, nvidia_nim, nvidia
   DRIVE9_TIDB_AUTO_EMBEDDING_API_BASE provider base endpoint for models that require it
                                      optional for openai models; set it for Azure OpenAI endpoints
-  DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_native (default for provisioning)
+  DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_native|tidb_cloud_native_shared (default for provisioning)
   DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT default TiDB Cloud Cluster spendingLimit.monthly; native defaults to 1000 when unset
   DRIVE9_TIDBCLOUD_NATIVE_API_URL TiDB Cloud Cluster API base URL for tidb_cloud_native
   DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER cloud provider for tidb_cloud_native cluster creation, e.g. aws
@@ -654,6 +678,10 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY optional default TiDB Cloud API public key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY optional default TiDB Cloud API private key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT true|false to use TiDB Cloud private endpoint hosts for tidb_cloud_native
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS soft capacity for new managed shared DB pools (default: 100)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO emergency hard-cap ratio after physical create failure (default: 1.2)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO reopen ratio for a latched shared pool (default: 0.8)
+  DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT default managed shared DB-pool spending target (default: 10000000)
   DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings (also accepts public_host:private_host);
                                              when set, disables legacy single-host private endpoint overrides
   DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST legacy tencentcloud private endpoint fallback host, used only when host map is unset
@@ -1154,6 +1182,54 @@ func tenantPoolRefillFreeRatioFromEnv() (float64, error) {
 	v, err := strconv.ParseFloat(raw, 64)
 	if err != nil || v <= 0 || v > 1 || v != v {
 		return 0, fmt.Errorf("invalid DRIVE9_TENANT_POOL_REFILL_FREE_RATIO=%q: must be a number in (0,1]", raw)
+	}
+	return v, nil
+}
+
+func sharedDBHardCapRatioFromEnv() (float64, error) {
+	raw := strings.TrimSpace(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO"))
+	if raw == "" {
+		return server.DefaultSharedDBHardCapRatio, nil
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v < 1 || math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, fmt.Errorf("invalid DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO=%q: must be a finite number >= 1", raw)
+	}
+	return v, nil
+}
+
+func sharedDBReopenRatioFromEnv() (float64, error) {
+	raw := strings.TrimSpace(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO"))
+	if raw == "" {
+		return server.DefaultSharedDBReopenRatio, nil
+	}
+	v, err := strconv.ParseFloat(raw, 64)
+	if err != nil || v <= 0 || v >= 1 || math.IsNaN(v) || math.IsInf(v, 0) {
+		return 0, fmt.Errorf("invalid DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO=%q: must be a finite number in (0,1)", raw)
+	}
+	return v, nil
+}
+
+func sharedDBMaxTenantsFromEnv() (int, error) {
+	raw := strings.TrimSpace(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS"))
+	if raw == "" {
+		return 100, nil
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil || v <= 0 {
+		return 0, fmt.Errorf("invalid DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS=%q: must be a positive integer", raw)
+	}
+	return v, nil
+}
+
+func sharedDBDefaultSpendingLimitFromEnv() (int64, error) {
+	raw := strings.TrimSpace(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT"))
+	if raw == "" {
+		return 10_000_000, nil
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v <= 0 || v > int64(1<<31-1) {
+		return 0, fmt.Errorf("invalid DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT=%q: must be in (0,%d]", raw, int64(1<<31-1))
 	}
 	return v, nil
 }

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -145,6 +145,117 @@ func TestTenantPoolRefillFreeRatioFromEnv(t *testing.T) {
 	}
 }
 
+func TestSharedDBHardCapRatioFromEnv(t *testing.T) {
+	const key = "DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO"
+	restore := snapshotEnv(t, []string{key})
+	t.Cleanup(func() { restoreEnv(t, restore) })
+
+	unsetEnv(t, []string{key})
+	got, err := sharedDBHardCapRatioFromEnv()
+	if err != nil {
+		t.Fatalf("sharedDBHardCapRatioFromEnv empty: %v", err)
+	}
+	if got != server.DefaultSharedDBHardCapRatio {
+		t.Fatalf("empty hard cap ratio = %f, want %f", got, server.DefaultSharedDBHardCapRatio)
+	}
+
+	setEnv(t, key, "1.1")
+	got, err = sharedDBHardCapRatioFromEnv()
+	if err != nil {
+		t.Fatalf("sharedDBHardCapRatioFromEnv valid: %v", err)
+	}
+	if got != 1.1 {
+		t.Fatalf("hard cap ratio = %f, want 1.1", got)
+	}
+
+	for _, raw := range []string{"0.9", "NaN", "+Inf", "bad"} {
+		setEnv(t, key, raw)
+		if _, err := sharedDBHardCapRatioFromEnv(); err == nil {
+			t.Fatalf("sharedDBHardCapRatioFromEnv(%q) error = nil, want error", raw)
+		}
+	}
+}
+
+func TestSharedDBReopenRatioFromEnv(t *testing.T) {
+	const key = "DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO"
+	restore := snapshotEnv(t, []string{key})
+	t.Cleanup(func() { restoreEnv(t, restore) })
+
+	unsetEnv(t, []string{key})
+	got, err := sharedDBReopenRatioFromEnv()
+	if err != nil {
+		t.Fatalf("sharedDBReopenRatioFromEnv empty: %v", err)
+	}
+	if got != server.DefaultSharedDBReopenRatio {
+		t.Fatalf("empty reopen ratio = %f, want %f", got, server.DefaultSharedDBReopenRatio)
+	}
+
+	setEnv(t, key, "0.65")
+	got, err = sharedDBReopenRatioFromEnv()
+	if err != nil {
+		t.Fatalf("sharedDBReopenRatioFromEnv valid: %v", err)
+	}
+	if got != 0.65 {
+		t.Fatalf("reopen ratio = %f, want 0.65", got)
+	}
+
+	for _, raw := range []string{"0", "-0.1", "1", "NaN", "+Inf", "bad"} {
+		setEnv(t, key, raw)
+		if _, err := sharedDBReopenRatioFromEnv(); err == nil {
+			t.Fatalf("sharedDBReopenRatioFromEnv(%q) error = nil, want error", raw)
+		}
+	}
+}
+
+func TestSharedDBCapacityConfigFromEnv(t *testing.T) {
+	keys := []string{
+		"DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS",
+		"DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT",
+	}
+	restore := snapshotEnv(t, keys)
+	t.Cleanup(func() { restoreEnv(t, restore) })
+
+	unsetEnv(t, keys)
+	maxTenants, err := sharedDBMaxTenantsFromEnv()
+	if err != nil {
+		t.Fatalf("sharedDBMaxTenantsFromEnv empty: %v", err)
+	}
+	if maxTenants != 100 {
+		t.Fatalf("empty max tenants = %d, want 100", maxTenants)
+	}
+	spendingLimit, err := sharedDBDefaultSpendingLimitFromEnv()
+	if err != nil {
+		t.Fatalf("sharedDBDefaultSpendingLimitFromEnv empty: %v", err)
+	}
+	if spendingLimit != 10_000_000 {
+		t.Fatalf("empty spending limit = %d, want 10000000", spendingLimit)
+	}
+
+	setEnv(t, keys[0], "250")
+	maxTenants, err = sharedDBMaxTenantsFromEnv()
+	if err != nil || maxTenants != 250 {
+		t.Fatalf("valid max tenants = %d/%v, want 250/nil", maxTenants, err)
+	}
+	setEnv(t, keys[1], "20000000")
+	spendingLimit, err = sharedDBDefaultSpendingLimitFromEnv()
+	if err != nil || spendingLimit != 20_000_000 {
+		t.Fatalf("valid spending limit = %d/%v, want 20000000/nil", spendingLimit, err)
+	}
+
+	for _, raw := range []string{"0", "-1", "bad"} {
+		setEnv(t, keys[0], raw)
+		if _, err := sharedDBMaxTenantsFromEnv(); err == nil {
+			t.Fatalf("max tenants %q error = nil, want error", raw)
+		}
+	}
+	for _, raw := range []string{"0", "-1", "2147483648", "bad"} {
+		setEnv(t, keys[1], raw)
+		if _, err := sharedDBDefaultSpendingLimitFromEnv(); err == nil {
+			t.Fatalf("spending limit %q error = nil, want error", raw)
+		}
+	}
+}
+
 func TestDBHealthProbeOptionsFromEnvDefaults(t *testing.T) {
 	keys := []string{
 		"DRIVE9_DB_HEALTH_PROBE_META_ENABLED",

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -168,7 +168,7 @@ func TestSharedDBHardCapRatioFromEnv(t *testing.T) {
 		t.Fatalf("hard cap ratio = %f, want 1.1", got)
 	}
 
-	for _, raw := range []string{"0.9", "NaN", "+Inf", "bad"} {
+	for _, raw := range []string{"0.9", "1", "NaN", "+Inf", "bad"} {
 		setEnv(t, key, raw)
 		if _, err := sharedDBHardCapRatioFromEnv(); err == nil {
 			t.Fatalf("sharedDBHardCapRatioFromEnv(%q) error = nil, want error", raw)

--- a/cmd/drive9-server/schema_test.go
+++ b/cmd/drive9-server/schema_test.go
@@ -38,6 +38,30 @@ func TestSchemaDumpInitSQLByProvider(t *testing.T) {
 	}
 }
 
+func TestSchemaDumpInitSQLByProviderShared(t *testing.T) {
+	out := captureSchemaStdout(t, func() {
+		if err := runSchemaCommand([]string{"dump-init-sql", "--provider", "tidb_cloud_native_shared"}); err != nil {
+			t.Fatalf("dump shared provider schema: %v", err)
+		}
+	})
+
+	if got := strings.Count(out, "CREATE TABLE IF NOT EXISTS"); got != 30 {
+		t.Fatalf("shared schema table count = %d, want 30", got)
+	}
+	if !strings.Contains(out, "fs_id") || !strings.Contains(out, "PRIMARY KEY (fs_id, node_id) CLUSTERED") {
+		t.Fatalf("shared dump is missing fs_id-scoped schema: %q", out)
+	}
+	if !strings.Contains(out, "VECTOR") {
+		t.Fatalf("shared dump is missing vector columns: %q", out)
+	}
+	if strings.Contains(out, "GENERATED ALWAYS AS (EMBED_TEXT") {
+		t.Fatalf("shared dump contains database auto embedding: %q", out)
+	}
+	if !strings.Contains(out, "CREATE TABLE IF NOT EXISTS vault_deks") {
+		t.Fatalf("shared dump missing vault schema: %q", out)
+	}
+}
+
 func TestSchemaDumpInitSQLByProviderIncludesVault(t *testing.T) {
 	for _, provider := range []string{"tidb_zero", "tidb_cloud_native"} {
 		t.Run(provider, func(t *testing.T) {

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
+	"strings"
 	"time"
 )
 
@@ -29,7 +31,51 @@ const (
 	SchemaShapeShared     = "shared"
 )
 
-const sharedDBStatusActive = "active"
+const (
+	SharedDBStatusProvisioning = "provisioning"
+	SharedDBStatusActive       = "active"
+	SharedDBStatusFailed       = "failed"
+	SharedDBStatusDraining     = "draining"
+)
+
+const sharedDBStatusActive = SharedDBStatusActive
+
+// SharedDBCapacityMode selects the capacity bound used by a reservation.
+type SharedDBCapacityMode string
+
+const (
+	SharedDBCapacityNormal    SharedDBCapacityMode = "normal"
+	SharedDBCapacityEmergency SharedDBCapacityMode = "emergency"
+)
+
+// SharedDBHardCap computes runtime emergency capacity from a persisted soft
+// capacity. The ratio is deliberately not stored in db_pool.
+func SharedDBHardCap(softCap int, ratio float64) (int, error) {
+	if softCap <= 0 {
+		return 0, fmt.Errorf("soft capacity must be positive")
+	}
+	if math.IsNaN(ratio) || math.IsInf(ratio, 0) || ratio < 1 {
+		return 0, fmt.Errorf("hard-cap ratio must be finite and at least 1")
+	}
+	value := float64(softCap) * ratio
+	if value > float64(int(^uint(0)>>1)) {
+		return 0, fmt.Errorf("hard capacity overflows int")
+	}
+	return int(math.Ceil(value)), nil
+}
+
+// SharedDBReopenThresholdForRatio computes the runtime hysteresis threshold.
+// The ratio is intentionally not persisted in db_pool; it is deployment
+// policy and must be in the open interval (0,1).
+func SharedDBReopenThresholdForRatio(softCap int, ratio float64) (int, error) {
+	if softCap <= 0 {
+		return 0, nil
+	}
+	if math.IsNaN(ratio) || math.IsInf(ratio, 0) || ratio <= 0 || ratio >= 1 {
+		return 0, fmt.Errorf("reopen ratio must be finite and in (0,1)")
+	}
+	return int(math.Floor(float64(softCap) * ratio)), nil
+}
 
 // SharedDB is one physical database registered in db_pool. PasswordCipher
 // holds the same encrypted envelope as tenants.db_password; the plaintext
@@ -38,18 +84,27 @@ const sharedDBStatusActive = "active"
 // for plaintext) so the runtime handle reopens the DB with exactly the TLS
 // mode it was registered with. MaxTenants of 0 means unlimited.
 type SharedDB struct {
-	DbID           int64
-	OrgID          string
-	Role           string
-	Host           string
-	Port           int
-	User           string
-	PasswordCipher []byte
-	Name           string
-	TLSMode        string
-	MaxTenants     int
-	TenantCount    int
-	Status         string
+	ID                      int64
+	TiDBCloudOrganizationID string
+	ClusterID               string
+	ProvisioningKey         []byte
+	CloudProvider           string
+	Region                  string
+	Role                    string
+	Host                    string
+	Port                    int
+	User                    string
+	PasswordCipher          []byte
+	Name                    string
+	TLSMode                 string
+	MaxTenants              int
+	TenantCount             int
+	SoftCapReached          bool
+	SpendingLimit           *int64
+	SchemaVersion           int
+	Status                  string
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
 }
 
 // TenantPlacement maps one filesystem (fs_id) to the physical database that
@@ -66,10 +121,384 @@ type TenantPlacement struct {
 	Epoch       int64
 }
 
+// SharedDBPoolMetricSnapshot is the central-meta view used by the existing
+// tenant metrics pass. TenantCount is the capacity counter maintained with
+// placement writes; TenantStates and TenantSpendingLimitSum are recomputed
+// from placements so counter drift remains visible in exported metrics.
+type SharedDBPoolMetricSnapshot struct {
+	ID                      int64
+	TiDBCloudOrganizationID string
+	Status                  string
+	MaxTenants              int
+	TenantCount             int
+	SoftCapReached          bool
+	SpendingLimit           *int64
+	TenantSpendingLimitSum  int64
+	TenantStates            []SharedDBPoolTenantStateCount
+}
+
+// SharedDBPoolTenantStateCount is one persisted tenant-status count within a
+// physical shared DB pool.
+type SharedDBPoolTenantStateCount struct {
+	State TenantStatus
+	Count int64
+}
+
 // sharedDBSelectColumns lists the db_pool columns read into SharedDB. The
 // `role` column is backtick-quoted because ROLE is reserved in MySQL 8.0.
-const sharedDBSelectColumns = "db_id, org_id, `role`, db_host, db_port, db_user, db_password, " +
-	"db_name, db_tls, max_tenants, tenant_count, status"
+const sharedDBSelectColumns = "db_id, org_id, cluster_id, provisioning_key, cloud_provider, region, " +
+	"`role`, db_host, db_port, db_user, db_password, db_name, db_tls, max_tenants, tenant_count, " +
+	"soft_cap_reached, spending_limit, schema_version, status, created_at, updated_at"
+
+// CreateManagedSharedDBPool commits the durable identity and fixed business
+// policy for one Drive9-managed physical pool before any TiDB Cloud API call.
+// Connection and cluster fields intentionally remain NULL while provisioning.
+func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "create_managed_shared_db_pool", start, &err)
+	if in == nil {
+		return 0, fmt.Errorf("shared db pool is required")
+	}
+	if len(in.ProvisioningKey) != 32 {
+		return 0, fmt.Errorf("provisioning key must be a 32-byte SHA-256 fingerprint")
+	}
+	if in.CloudProvider == "" {
+		return 0, fmt.Errorf("cloud provider is required")
+	}
+	if in.Region == "" {
+		return 0, fmt.Errorf("region is required")
+	}
+	if in.MaxTenants <= 0 {
+		return 0, fmt.Errorf("managed max tenants must be positive")
+	}
+	if in.SpendingLimit == nil || *in.SpendingLimit <= 0 {
+		return 0, fmt.Errorf("managed spending limit must be positive")
+	}
+	if *in.SpendingLimit > int64(1<<31-1) {
+		return 0, fmt.Errorf("managed spending limit exceeds TiDB Cloud int32 maximum")
+	}
+	var organizationID any
+	if in.TiDBCloudOrganizationID != "" {
+		organizationID = in.TiDBCloudOrganizationID
+	}
+	var passwordCipher any
+	if len(in.PasswordCipher) != 0 {
+		passwordCipher = in.PasswordCipher
+	}
+	var databaseName any
+	if in.Name != "" {
+		databaseName = in.Name
+	}
+	res, err := s.db.ExecContext(ctx, `INSERT INTO db_pool
+		(org_id, provisioning_key, cloud_provider, region, `+"`role`"+`, db_tls,
+		 db_password, db_name, max_tenants, tenant_count, soft_cap_reached, spending_limit, schema_version, status)
+		VALUES (?, ?, ?, ?, ?, '', ?, ?, ?, 0, 0, ?, 0, ?)`, organizationID, in.ProvisioningKey,
+		in.CloudProvider, in.Region, SharedDBRoleShared, passwordCipher, databaseName,
+		in.MaxTenants, *in.SpendingLimit,
+		SharedDBStatusProvisioning)
+	if err != nil {
+		return 0, fmt.Errorf("insert managed db_pool row: %w", err)
+	}
+	id, err = res.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("resolve managed db_pool id: %w", err)
+	}
+	return id, nil
+}
+
+// UpdateManagedSharedDBPoolCloudResult persists the cloud identity and any
+// connection metadata currently available for a provisional managed pool. It
+// clears provisioning_key only after the organization identity is durable.
+// The pool remains provisioning until its shared schema is ready.
+func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *SharedDB) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_managed_shared_db_pool_cloud_result", start, &err)
+	if in == nil || in.ID <= 0 {
+		return fmt.Errorf("managed shared db pool id must be positive")
+	}
+	if in.TiDBCloudOrganizationID == "" {
+		return fmt.Errorf("tidbcloud organization id is required")
+	}
+	if in.ClusterID == "" {
+		return fmt.Errorf("cluster id is required")
+	}
+	if in.Port < 0 {
+		return fmt.Errorf("db port must not be negative")
+	}
+	if len(in.TLSMode) > 32 {
+		return fmt.Errorf("tls mode %q is too long", in.TLSMode)
+	}
+	nullString := func(value string) any {
+		if value == "" {
+			return nil
+		}
+		return value
+	}
+	nullInt := func(value int) any {
+		if value == 0 {
+			return nil
+		}
+		return value
+	}
+	nullBytes := func(value []byte) any {
+		if len(value) == 0 {
+			return nil
+		}
+		return value
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool
+		SET org_id = ?, cluster_id = ?, provisioning_key = NULL,
+			db_host = COALESCE(?, db_host), db_port = COALESCE(?, db_port),
+			db_user = COALESCE(?, db_user), db_password = COALESCE(?, db_password),
+			db_name = COALESCE(?, db_name), db_tls = ?
+		WHERE db_id = ? AND status = ?`,
+		in.TiDBCloudOrganizationID, in.ClusterID, nullString(in.Host), nullInt(in.Port),
+		nullString(in.User), nullBytes(in.PasswordCipher), nullString(in.Name), in.TLSMode,
+		in.ID, SharedDBStatusProvisioning)
+	if err != nil {
+		return fmt.Errorf("persist cloud result for db pool %d: %w", in.ID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("cloud result rows affected for db pool %d: %w", in.ID, err)
+	}
+	if affected == 0 {
+		var organizationID, clusterID sql.NullString
+		checkErr := s.db.QueryRowContext(ctx, `SELECT org_id, cluster_id FROM db_pool
+			WHERE db_id = ? AND status = ?`, in.ID, SharedDBStatusProvisioning).
+			Scan(&organizationID, &clusterID)
+		if errors.Is(checkErr, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		if checkErr != nil {
+			return fmt.Errorf("confirm cloud result for db pool %d: %w", in.ID, checkErr)
+		}
+		if organizationID.String != in.TiDBCloudOrganizationID || clusterID.String != in.ClusterID {
+			return fmt.Errorf("db pool %d cloud identity is %q/%q, not %q/%q", in.ID,
+				organizationID.String, clusterID.String, in.TiDBCloudOrganizationID, in.ClusterID)
+		}
+	}
+	return nil
+}
+
+// PrepareManagedSharedDBPoolRoot durably stores the root credential and
+// database name before the first Cloud create call. It is idempotent for a
+// provisioning row that has not yet acquired a cluster identity.
+func (s *Store) PrepareManagedSharedDBPoolRoot(ctx context.Context, dbID int64, passwordCipher []byte, databaseName string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "prepare_managed_shared_db_pool_root", start, &err)
+	if dbID <= 0 {
+		return fmt.Errorf("db pool id must be positive")
+	}
+	if len(passwordCipher) == 0 {
+		return fmt.Errorf("managed root password cipher is required")
+	}
+	if databaseName == "" {
+		return fmt.Errorf("managed database name is required")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool
+		SET db_password = COALESCE(db_password, ?), db_name = COALESCE(db_name, ?)
+		WHERE db_id = ? AND status = ? AND cluster_id IS NULL`,
+		passwordCipher, databaseName, dbID, SharedDBStatusProvisioning)
+	if err != nil {
+		return fmt.Errorf("prepare managed db pool %d root credential: %w", dbID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("prepare managed db pool %d rows affected: %w", dbID, err)
+	}
+	if affected > 0 {
+		return nil
+	}
+	var exists int
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM db_pool WHERE db_id = ? AND status = ? AND cluster_id IS NULL
+		AND db_password IS NOT NULL AND db_name IS NOT NULL`, dbID, SharedDBStatusProvisioning).Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// UpdateSharedDBSchemaVersion records the checked-in shared schema version
+// after the idempotent ensure succeeds.
+func (s *Store) UpdateSharedDBSchemaVersion(ctx context.Context, dbID int64, version int) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_shared_db_schema_version", start, &err)
+	if dbID <= 0 {
+		return fmt.Errorf("db_id must be positive")
+	}
+	if version <= 0 {
+		return fmt.Errorf("schema version must be positive")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET schema_version = ? WHERE db_id = ?`, version, dbID)
+	if err != nil {
+		return fmt.Errorf("update schema version for db pool %d: %w", dbID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("schema version rows affected for db pool %d: %w", dbID, err)
+	}
+	if affected == 0 {
+		var exists int
+		if scanErr := s.db.QueryRowContext(ctx, `SELECT 1 FROM db_pool WHERE db_id = ?`, dbID).Scan(&exists); scanErr != nil {
+			if errors.Is(scanErr, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return scanErr
+		}
+	}
+	return nil
+}
+
+// ActivateSharedDBPool flips a managed pool to active only after the cloud
+// identity, connection fields, and shared schema version are complete.
+func (s *Store) ActivateSharedDBPool(ctx context.Context, dbID int64) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "activate_shared_db_pool", start, &err)
+	if dbID <= 0 {
+		return fmt.Errorf("db_id must be positive")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?
+		WHERE db_id = ? AND status = ? AND org_id IS NOT NULL AND cluster_id IS NOT NULL
+			AND db_host IS NOT NULL AND db_port IS NOT NULL AND db_user IS NOT NULL
+			AND db_password IS NOT NULL AND db_name IS NOT NULL AND schema_version > 0`,
+		SharedDBStatusActive, dbID, SharedDBStatusProvisioning)
+	if err != nil {
+		return fmt.Errorf("activate db pool %d: %w", dbID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("activate db pool rows affected %d: %w", dbID, err)
+	}
+	if affected > 0 {
+		return nil
+	}
+	var status string
+	if scanErr := s.db.QueryRowContext(ctx, `SELECT status FROM db_pool WHERE db_id = ?`, dbID).Scan(&status); scanErr != nil {
+		if errors.Is(scanErr, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return scanErr
+	}
+	if status == SharedDBStatusActive {
+		return nil
+	}
+	return fmt.Errorf("db pool %d is not ready for activation", dbID)
+}
+
+func (s *Store) MarkSharedDBPoolFailed(ctx context.Context, dbID int64) error {
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ? AND status = ?`,
+		SharedDBStatusFailed, dbID, SharedDBStatusProvisioning)
+	if err != nil {
+		return err
+	}
+	if n, _ := res.RowsAffected(); n == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+// ListSharedDBsByStatus returns shared DB-pool rows in stable ID order.
+func (s *Store) ListSharedDBsByStatus(ctx context.Context, status string, limit int) (out []*SharedDB, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_shared_dbs_by_status", start, &err)
+	switch status {
+	case SharedDBStatusProvisioning, SharedDBStatusActive, SharedDBStatusFailed, SharedDBStatusDraining:
+	default:
+		return nil, fmt.Errorf("unsupported shared db status %q", status)
+	}
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := s.db.QueryContext(ctx, "SELECT "+sharedDBSelectColumns+" FROM db_pool "+
+		"WHERE `role` = ? AND status = ? ORDER BY db_id LIMIT ?", SharedDBRoleShared, status, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list shared dbs in status %q: %w", status, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		rec, scanErr := scanSharedDBScanner(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
+// FindSharedDBForAllocation selects the oldest eligible exact-organization
+// pool, preferring active over provisioning. Before organization resolution,
+// callers may instead supply the 32-byte provisioning fingerprint. Managed
+// rows enforce exact virtual spending-limit headroom; manual rows with a NULL
+// spending target retain their compatibility behavior.
+func (s *Store) FindSharedDBForAllocation(ctx context.Context, organizationID string, provisioningKey []byte, tenantSpendingLimit int64) (db *SharedDB, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "find_shared_db_for_allocation", start, &err)
+	if tenantSpendingLimit < 0 {
+		return nil, fmt.Errorf("tenant spending limit must not be negative")
+	}
+	identityColumn := "org_id"
+	var identity any = organizationID
+	if organizationID == "" {
+		if len(provisioningKey) != 32 {
+			return nil, fmt.Errorf("organization id or 32-byte provisioning key is required")
+		}
+		identityColumn = "provisioning_key"
+		identity = provisioningKey
+	}
+	query := "SELECT " + sharedDBSelectColumns + " FROM db_pool d " +
+		"WHERE d." + identityColumn + " = ? AND d.`role` = ? " +
+		"AND d.status IN (?, ?) " +
+		"AND (d.max_tenants = 0 OR (d.soft_cap_reached = 0 AND d.tenant_count < d.max_tenants)) " +
+		`AND (d.spending_limit IS NULL OR
+			COALESCE((SELECT SUM(q.tidbcloud_spending_limit)
+				FROM tenant_placements p
+				JOIN fs_registry f ON f.fs_id = p.fs_id
+				JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id
+				WHERE p.db_id = d.db_id), 0) + ? < d.spending_limit)
+		ORDER BY CASE d.status WHEN 'active' THEN 0 ELSE 1 END, d.db_id LIMIT 1`
+	db, err = scanSharedDBRow(s.db.QueryRowContext(ctx, query, identity, SharedDBRoleShared,
+		SharedDBStatusActive, SharedDBStatusProvisioning, tenantSpendingLimit))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find shared db for allocation: %w", err)
+	}
+	return db, nil
+}
+
+// FindSharedDBForEmergency selects the least-loaded active managed pool below
+// the caller-computed hard cap. It is used only after a physical create failure
+// on a direct request; refill and prewarm must never call it.
+func (s *Store) FindSharedDBForEmergency(ctx context.Context, organizationID string, hardCap int, tenantSpendingLimit int64) (*SharedDB, error) {
+	if organizationID == "" {
+		return nil, fmt.Errorf("organization id is required")
+	}
+	if hardCap <= 0 || tenantSpendingLimit < 0 {
+		return nil, fmt.Errorf("invalid emergency capacity arguments")
+	}
+	query := "SELECT " + sharedDBSelectColumns + " FROM db_pool d " +
+		"WHERE d.org_id = ? AND d.`role` = ? AND d.status = ? " +
+		"AND d.max_tenants > 0 AND d.tenant_count < ? AND d.spending_limit IS NOT NULL " +
+		`AND COALESCE((SELECT SUM(q.tidbcloud_spending_limit)
+			FROM tenant_placements p
+			JOIN fs_registry f ON f.fs_id = p.fs_id
+			JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id
+			WHERE p.db_id = d.db_id), 0) + ? < d.spending_limit
+		ORDER BY d.tenant_count ASC, d.db_id ASC LIMIT 1`
+	db, err := scanSharedDBRow(s.db.QueryRowContext(ctx, query, organizationID, SharedDBRoleShared,
+		SharedDBStatusActive, hardCap, tenantSpendingLimit))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("find emergency shared db: %w", err)
+	}
+	return db, nil
+}
 
 // RegisterSharedDB registers a physical database in db_pool, upserting on the
 // uk_db_pool_endpoint (org_id, db_host, db_name) natural key. On a duplicate
@@ -119,7 +548,7 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 			"ON DUPLICATE KEY UPDATE db_port = VALUES(db_port), db_user = VALUES(db_user), "+
 			"db_password = VALUES(db_password), db_tls = VALUES(db_tls), "+
 			"max_tenants = VALUES(max_tenants), status = VALUES(status)",
-		in.OrgID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
+		in.TiDBCloudOrganizationID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
 		in.TLSMode, in.MaxTenants, status); err != nil {
 		return 0, fmt.Errorf("upsert db_pool row: %w", err)
 	}
@@ -127,7 +556,7 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 	// auto-increment id via LastInsertId, so re-fetch by endpoint.
 	err = s.db.QueryRowContext(ctx,
 		`SELECT db_id FROM db_pool WHERE org_id = ? AND db_host = ? AND db_name = ?`,
-		in.OrgID, in.Host, in.Name).Scan(&dbID)
+		in.TiDBCloudOrganizationID, in.Host, in.Name).Scan(&dbID)
 	if err != nil {
 		return 0, fmt.Errorf("resolve db_id after upsert: %w", err)
 	}
@@ -148,6 +577,22 @@ func (s *Store) GetSharedDB(ctx context.Context, dbID int64) (db *SharedDB, err 
 			return nil, ErrNotFound
 		}
 		return nil, fmt.Errorf("get shared db %d: %w", dbID, err)
+	}
+	return db, nil
+}
+
+// GetSharedDBForTenant resolves the physical shared resource identity used by
+// credential authorization and metrics. tenants.cluster_id is intentionally
+// not involved for shared-schema tenants.
+func (s *Store) GetSharedDBForTenant(ctx context.Context, tenantID string) (*SharedDB, error) {
+	db, err := scanSharedDBRow(s.db.QueryRowContext(ctx, `SELECT `+sharedDBSelectColumns+`
+		FROM db_pool WHERE db_id = (SELECT p.db_id FROM tenant_placements p
+		JOIN fs_registry f ON f.fs_id = p.fs_id WHERE f.tenant_id = ?)`, tenantID))
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
 	}
 	return db, nil
 }
@@ -178,14 +623,13 @@ func (s *Store) FindSharedDBForOrg(ctx context.Context, orgID string) (db *Share
 }
 
 func (s *Store) findActiveSharedDB(ctx context.Context, orgID string) (*SharedDB, error) {
-	// Capacity is enforced at selection time: a pool at its max_tenants limit
-	// is invisible to new placements (0 means unlimited). tenant_count is a
-	// denormalized counter, so a rare drift can over- or under-admit; closing
-	// that fully needs a transactional reserve, which is a planned follow-up.
+	// Capacity is enforced at selection time: normal allocation only sees open
+	// soft-cap pools (0 means unlimited); the transactional reserve remains the
+	// final guard against races.
 	db, err := scanSharedDBRow(s.db.QueryRowContext(ctx,
 		"SELECT "+sharedDBSelectColumns+" FROM db_pool "+
 			"WHERE org_id = ? AND `role` = ? AND status = ? "+
-			"AND (max_tenants = 0 OR tenant_count < max_tenants) ORDER BY db_id LIMIT 1",
+			"AND (max_tenants = 0 OR (soft_cap_reached = 0 AND tenant_count < max_tenants)) ORDER BY db_id LIMIT 1",
 		orgID, SharedDBRoleShared, sharedDBStatusActive))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -208,14 +652,84 @@ func (s *Store) ListSharedDBs(ctx context.Context) (out []*SharedDB, err error) 
 	}
 	defer func() { _ = rows.Close() }()
 	for rows.Next() {
-		var rec SharedDB
-		if err = rows.Scan(&rec.DbID, &rec.OrgID, &rec.Role, &rec.Host, &rec.Port, &rec.User,
-			&rec.PasswordCipher, &rec.Name, &rec.TLSMode, &rec.MaxTenants, &rec.TenantCount, &rec.Status); err != nil {
+		rec, scanErr := scanSharedDBScanner(rows)
+		if scanErr != nil {
+			err = scanErr
 			return nil, err
 		}
-		out = append(out, &rec)
+		out = append(out, rec)
 	}
 	return out, rows.Err()
+}
+
+// ListSharedDBPoolMetricSnapshots returns one snapshot per physical shared
+// database. It is intentionally a read-only aggregate used by the existing
+// tenant metrics pass; it does not reconcile or mutate capacity counters.
+func (s *Store) ListSharedDBPoolMetricSnapshots(ctx context.Context) (out []SharedDBPoolMetricSnapshot, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_shared_db_pool_metric_snapshots", start, &err)
+	rows, err := s.db.QueryContext(ctx, `SELECT
+			d.db_id, COALESCE(d.org_id, ''), d.status, d.max_tenants, d.tenant_count, d.soft_cap_reached,
+			d.spending_limit, COALESCE(quota.tenant_sum, 0),
+			COALESCE(states.tenant_status, ''), COALESCE(states.tenant_count, 0)
+		FROM db_pool d
+		LEFT JOIN (
+			SELECT p.db_id, COALESCE(SUM(q.tidbcloud_spending_limit), 0) AS tenant_sum
+			FROM tenant_placements p
+			JOIN fs_registry f ON f.fs_id = p.fs_id
+			JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id
+			GROUP BY p.db_id
+		) quota ON quota.db_id = d.db_id
+		LEFT JOIN (
+			SELECT p.db_id, t.status AS tenant_status, COUNT(*) AS tenant_count
+			FROM tenant_placements p
+			JOIN fs_registry f ON f.fs_id = p.fs_id
+			JOIN tenants t ON t.id = f.tenant_id
+			GROUP BY p.db_id, t.status
+		) states ON states.db_id = d.db_id
+		WHERE d.`+"`role`"+` = ?
+		ORDER BY d.db_id, states.tenant_status`, SharedDBRoleShared)
+	if err != nil {
+		return nil, fmt.Errorf("list shared db pool metric snapshots: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	byID := make(map[int64]int)
+	for rows.Next() {
+		var id int64
+		var organizationID, status, tenantStatus string
+		var maxTenants, tenantCount int
+		var softCapReached bool
+		var spendingLimit sql.NullInt64
+		var tenantSpendingLimitSum, stateCount int64
+		if err := rows.Scan(&id, &organizationID, &status, &maxTenants, &tenantCount, &softCapReached,
+			&spendingLimit, &tenantSpendingLimitSum, &tenantStatus, &stateCount); err != nil {
+			return nil, fmt.Errorf("scan shared db pool metric snapshot: %w", err)
+		}
+		index, ok := byID[id]
+		if !ok {
+			snapshot := SharedDBPoolMetricSnapshot{
+				ID: id, TiDBCloudOrganizationID: organizationID, Status: status,
+				MaxTenants: maxTenants, TenantCount: tenantCount, SoftCapReached: softCapReached,
+				TenantSpendingLimitSum: tenantSpendingLimitSum,
+			}
+			if spendingLimit.Valid {
+				value := spendingLimit.Int64
+				snapshot.SpendingLimit = &value
+			}
+			out = append(out, snapshot)
+			index = len(out) - 1
+			byID[id] = index
+		}
+		if tenantStatus != "" && stateCount > 0 {
+			out[index].TenantStates = append(out[index].TenantStates, SharedDBPoolTenantStateCount{
+				State: TenantStatus(tenantStatus), Count: stateCount,
+			})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list shared db pool metric snapshot rows: %w", err)
+	}
+	return out, nil
 }
 
 // IncrSharedDBTenantCount adjusts the denormalized tenant_count of a db_pool
@@ -349,6 +863,14 @@ func (s *Store) DeleteTenantPlacement(ctx context.Context, fsID int64) (err erro
 // (max_tenants reached).
 var ErrSharedDBCapacityExhausted = errors.New("shared db capacity exhausted")
 
+// ErrSharedDBSpendingLimitExceeded is returned when a managed pool's fixed
+// spending target cannot accommodate a new or increased tenant virtual limit.
+var ErrSharedDBSpendingLimitExceeded = errors.New("shared db spending limit exceeded")
+
+// ErrSharedDBQuotaNotMaterialized is returned when a managed-pool reservation
+// is attempted before the tenant's effective quota row has been persisted.
+var ErrSharedDBQuotaNotMaterialized = errors.New("shared tenant quota is not materialized")
+
 // CompleteSharedTenantProvision atomically performs every meta write that
 // turns a pending tenant into a live shared-pool tenant, in one transaction:
 //
@@ -356,21 +878,42 @@ var ErrSharedDBCapacityExhausted = errors.New("shared db capacity exhausted")
 //     cannot take the same last slot — the loser gets
 //     ErrSharedDBCapacityExhausted),
 //  2. the placement insert,
-//  3. the provider re-label and active-status transition on the tenant row
-//     (ErrNotFound when the tenant row does not exist), and
+//  3. the provider re-label and readiness transition on the tenant row
+//     (active only when the DB pool is active; otherwise provisioning), and
 //  4. the owner API key insert (ErrDuplicate on key id collision).
 //
 // Either all of it commits or none does: a shared tenant can never become
 // active without its placement row, its reserved capacity, and its owner
 // key, and a failed attempt leaves no partial state behind.
 func (s *Store) CompleteSharedTenantProvision(ctx context.Context, tenantID, provider string, p *TenantPlacement, k *APIKey) (err error) {
+	return s.completeSharedTenantProvision(ctx, tenantID, provider, p, k, nil, SharedDBCapacityNormal, 0)
+}
+
+// CompleteSharedTenantProvisionEmergency uses a caller-computed runtime hard
+// cap. It is reserved for direct-request fallback after physical DB creation
+// fails; tenant-pool refill must use the normal wrapper.
+func (s *Store) CompleteSharedTenantProvisionEmergency(ctx context.Context, tenantID, provider string, p *TenantPlacement, k *APIKey, hardCap int) error {
+	if hardCap <= 0 {
+		return fmt.Errorf("emergency hard cap must be positive")
+	}
+	return s.completeSharedTenantProvision(ctx, tenantID, provider, p, k, nil, SharedDBCapacityEmergency, hardCap)
+}
+
+// CompleteSharedTenantPoolMember reserves a shared placement and records a
+// free logical-pool membership in the same transaction. Prewarmed members do
+// not receive an owner key until claim.
+func (s *Store) CompleteSharedTenantPoolMember(ctx context.Context, tenantID, provider string, p *TenantPlacement, membership *TenantPoolMembership) error {
+	return s.completeSharedTenantProvision(ctx, tenantID, provider, p, nil, membership, SharedDBCapacityNormal, 0)
+}
+
+func (s *Store) completeSharedTenantProvision(ctx context.Context, tenantID, provider string, p *TenantPlacement, k *APIKey, membership *TenantPoolMembership, capacityMode SharedDBCapacityMode, hardCap int) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "complete_shared_tenant_provision", start, &err)
 	if tenantID == "" {
 		return fmt.Errorf("tenant id is required")
 	}
-	if provider == "" {
-		return fmt.Errorf("provider is required")
+	if provider != tidbCloudNativeSharedProvider {
+		return fmt.Errorf("shared tenant provider %q is required", tidbCloudNativeSharedProvider)
 	}
 	if p == nil {
 		return fmt.Errorf("tenant placement is required")
@@ -384,12 +927,23 @@ func (s *Store) CompleteSharedTenantProvision(ctx context.Context, tenantID, pro
 	if p.Placement != PlacementShared || p.SchemaShape != SchemaShapeShared {
 		return fmt.Errorf("provision requires shared placement and schema shape")
 	}
-	if k == nil {
-		return fmt.Errorf("api key is required")
+	if k == nil && membership == nil {
+		return fmt.Errorf("api key or tenant pool membership is required")
 	}
-	scopeKind, err := apiKeyScopeKindForInsert(k)
-	if err != nil {
-		return err
+	if capacityMode != SharedDBCapacityNormal && capacityMode != SharedDBCapacityEmergency {
+		return fmt.Errorf("unsupported shared db capacity mode %q", capacityMode)
+	}
+	var scopeKind APIKeyScopeKind
+	if k != nil {
+		scopeKind, err = apiKeyScopeKindForInsert(k)
+		if err != nil {
+			return err
+		}
+	}
+	if membership != nil {
+		if membership.TenantID != tenantID || strings.TrimSpace(membership.PoolID) == "" {
+			return fmt.Errorf("valid tenant pool membership is required")
+		}
 	}
 	status := p.Status
 	if status == "" {
@@ -397,9 +951,89 @@ func (s *Store) CompleteSharedTenantProvision(ctx context.Context, tenantID, pro
 	}
 	now := time.Now().UTC()
 	return s.InTx(ctx, func(tx *sql.Tx) error {
-		res, err := tx.ExecContext(ctx,
-			`UPDATE db_pool SET tenant_count = tenant_count + 1
-				WHERE db_id = ? AND (max_tenants = 0 OR tenant_count < max_tenants)`, p.DbID)
+		var dedicatedBindingCount int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM tenant_tidbcloud_org_bindings
+			WHERE tenant_id = ?`, tenantID).Scan(&dedicatedBindingCount); err != nil {
+			return err
+		}
+		if dedicatedBindingCount != 0 {
+			return fmt.Errorf("tenant %q already has a dedicated tidbcloud org binding", tenantID)
+		}
+		var dbPoolStatus string
+		var clusterID sql.NullString
+		var maxTenants, tenantCount int
+		var softCapReached bool
+		var poolSpendingLimit sql.NullInt64
+		if err := tx.QueryRowContext(ctx, `SELECT status, cluster_id, max_tenants, tenant_count, soft_cap_reached, spending_limit
+			FROM db_pool WHERE db_id = ? FOR UPDATE`, p.DbID).
+			Scan(&dbPoolStatus, &clusterID, &maxTenants, &tenantCount, &softCapReached, &poolSpendingLimit); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("lock db pool %d: %w", p.DbID, err)
+		}
+		switch capacityMode {
+		case SharedDBCapacityNormal:
+			if dbPoolStatus != SharedDBStatusActive && (dbPoolStatus != SharedDBStatusProvisioning || (membership == nil && (!clusterID.Valid || clusterID.String == ""))) {
+				return fmt.Errorf("db pool %d is not physically ready: status=%s cluster=%q membership=%t: %w", p.DbID, dbPoolStatus, clusterID.String, membership != nil, ErrSharedDBCapacityExhausted)
+			}
+			if maxTenants > 0 && (softCapReached || tenantCount >= maxTenants) {
+				return fmt.Errorf("db pool %d soft capacity exhausted: count=%d max=%d latch=%t: %w", p.DbID, tenantCount, maxTenants, softCapReached, ErrSharedDBCapacityExhausted)
+			}
+		case SharedDBCapacityEmergency:
+			if dbPoolStatus != SharedDBStatusActive || maxTenants <= 0 || hardCap < maxTenants || tenantCount >= hardCap || !poolSpendingLimit.Valid {
+				return ErrSharedDBCapacityExhausted
+			}
+		}
+		if poolSpendingLimit.Valid {
+			var tenantSpendingLimit sql.NullInt64
+			if err := tx.QueryRowContext(ctx, `SELECT tidbcloud_spending_limit
+				FROM tenant_quota_config WHERE tenant_id = ? FOR UPDATE`, tenantID).
+				Scan(&tenantSpendingLimit); err != nil {
+				if errors.Is(err, sql.ErrNoRows) {
+					return ErrSharedDBQuotaNotMaterialized
+				}
+				return fmt.Errorf("load quota for tenant %s: %w", tenantID, err)
+			}
+			if !tenantSpendingLimit.Valid {
+				return ErrSharedDBQuotaNotMaterialized
+			}
+			var currentSum int64
+			if err := tx.QueryRowContext(ctx, `SELECT COALESCE(SUM(q.tidbcloud_spending_limit), 0)
+				FROM tenant_placements p
+				JOIN fs_registry f ON f.fs_id = p.fs_id
+				JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id
+				WHERE p.db_id = ?`, p.DbID).Scan(&currentSum); err != nil {
+				return fmt.Errorf("sum tenant spending limits for db pool %d: %w", p.DbID, err)
+			}
+			prospective := currentSum + tenantSpendingLimit.Int64
+			if prospective < currentSum || prospective > int64(1<<31-1) || prospective >= poolSpendingLimit.Int64 {
+				return ErrSharedDBSpendingLimitExceeded
+			}
+		}
+		var res sql.Result
+		if capacityMode == SharedDBCapacityEmergency {
+			res, err = tx.ExecContext(ctx, `UPDATE db_pool
+				SET tenant_count = tenant_count + 1, soft_cap_reached = 1
+				WHERE db_id = ? AND status = ? AND spending_limit IS NOT NULL
+					AND max_tenants > 0 AND tenant_count + 1 <= ?`,
+				p.DbID, SharedDBStatusActive, hardCap)
+		} else {
+			normalQuery := `UPDATE db_pool
+				SET soft_cap_reached = CASE
+					WHEN max_tenants > 0 AND tenant_count + 1 >= max_tenants THEN 1
+					ELSE soft_cap_reached END,
+					tenant_count = tenant_count + 1
+				WHERE db_id = ? AND (%s)
+					AND (max_tenants = 0 OR (soft_cap_reached = 0 AND tenant_count + 1 <= max_tenants))`
+			if membership != nil {
+				normalQuery = fmt.Sprintf(normalQuery, "status IN (?, ?)")
+				res, err = tx.ExecContext(ctx, normalQuery, p.DbID, SharedDBStatusActive, SharedDBStatusProvisioning)
+			} else {
+				normalQuery = fmt.Sprintf(normalQuery, "status = ? OR (status = ? AND cluster_id IS NOT NULL)")
+				res, err = tx.ExecContext(ctx, normalQuery, p.DbID, SharedDBStatusActive, SharedDBStatusProvisioning)
+			}
+		}
 		if err != nil {
 			return fmt.Errorf("reserve capacity on db %d: %w", p.DbID, err)
 		}
@@ -409,6 +1043,15 @@ func (s *Store) CompleteSharedTenantProvision(ctx context.Context, tenantID, pro
 		}
 		if affected == 0 {
 			return ErrSharedDBCapacityExhausted
+		}
+		var tenantStatus TenantStatus
+		switch dbPoolStatus {
+		case SharedDBStatusActive:
+			tenantStatus = TenantActive
+		case SharedDBStatusProvisioning:
+			tenantStatus = TenantProvisioning
+		default:
+			return fmt.Errorf("db pool %d is not allocatable in status %q", p.DbID, dbPoolStatus)
 		}
 		var target any
 		if p.TargetDbID != nil {
@@ -422,7 +1065,7 @@ func (s *Store) CompleteSharedTenantProvision(ctx context.Context, tenantID, pro
 		}
 		res, err = tx.ExecContext(ctx,
 			`UPDATE tenants SET provider = ?, status = ?, updated_at = ? WHERE id = ?`,
-			provider, TenantActive, now, tenantID)
+			provider, tenantStatus, now, tenantID)
 		if err != nil {
 			return fmt.Errorf("activate tenant %s: %w", tenantID, err)
 		}
@@ -433,30 +1076,125 @@ func (s *Store) CompleteSharedTenantProvision(ctx context.Context, tenantID, pro
 		if affected == 0 {
 			return ErrNotFound
 		}
-		if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_api_keys
+		if k != nil {
+			if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_api_keys
 			(id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, scope_kind,
 			 issued_by_provider, issued_by_subject_key, issued_by_metadata_json,
 			 issued_at, revoked_at, created_at, updated_at)
 			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-			k.ID, k.TenantID, k.KeyName, k.JWTCiphertext, k.JWTHash, k.TokenVersion, k.Status, scopeKind,
-			k.IssuedByProvider, k.IssuedBySubjectKey, nullableBytes(k.IssuedByMetadataJSON),
-			k.IssuedAt.UTC(), k.RevokedAt, k.CreatedAt.UTC(), k.UpdatedAt.UTC()); err != nil {
-			if isDuplicateEntry(err) {
-				return ErrDuplicate
+				k.ID, k.TenantID, k.KeyName, k.JWTCiphertext, k.JWTHash, k.TokenVersion, k.Status, scopeKind,
+				k.IssuedByProvider, k.IssuedBySubjectKey, nullableBytes(k.IssuedByMetadataJSON),
+				k.IssuedAt.UTC(), k.RevokedAt, k.CreatedAt.UTC(), k.UpdatedAt.UTC()); err != nil {
+				if isDuplicateEntry(err) {
+					return ErrDuplicate
+				}
+				return fmt.Errorf("insert owner api key: %w", err)
 			}
-			return fmt.Errorf("insert owner api key: %w", err)
+		}
+		if membership != nil {
+			createdAt := membership.CreatedAt
+			if createdAt.IsZero() {
+				createdAt = now
+			}
+			var organizationID any
+			if strings.TrimSpace(membership.TiDBCloudOrganizationID) != "" {
+				organizationID = strings.TrimSpace(membership.TiDBCloudOrganizationID)
+			}
+			if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_pool_memberships
+				(tenant_id, tidbcloud_organization_id, pool_id, pool_status, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?)`, tenantID, organizationID, membership.PoolID,
+				TenantPoolBindingFree, createdAt, now); err != nil {
+				if isDuplicateEntry(err) {
+					return ErrDuplicate
+				}
+				return fmt.Errorf("insert tenant pool membership: %w", err)
+			}
 		}
 		return nil
 	})
+}
+
+// ActivateSharedTenantsBatch activates ready shared tenants after their
+// physical DB pool becomes active. Direct-create tenants are eligible through
+// an owner key; prewarmed tenants are eligible through a free pool membership.
+func (s *Store) ActivateSharedTenantsBatch(ctx context.Context, dbID int64, limit int) (activated int, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "activate_shared_tenants_batch", start, &err)
+	if dbID <= 0 {
+		return 0, fmt.Errorf("db_id must be positive")
+	}
+	if limit <= 0 {
+		return 0, fmt.Errorf("activation limit must be positive")
+	}
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		var poolStatus string
+		if scanErr := tx.QueryRowContext(ctx, `SELECT status FROM db_pool WHERE db_id = ? FOR UPDATE`, dbID).Scan(&poolStatus); scanErr != nil {
+			if errors.Is(scanErr, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return scanErr
+		}
+		if poolStatus != SharedDBStatusActive {
+			return fmt.Errorf("db pool %d is not active", dbID)
+		}
+		rows, queryErr := tx.QueryContext(ctx, `SELECT t.id
+			FROM tenants t
+			JOIN fs_registry f ON f.tenant_id = t.id
+			JOIN tenant_placements p ON p.fs_id = f.fs_id
+			WHERE p.db_id = ? AND p.status = ? AND t.provider = ? AND t.status = ?
+				AND (EXISTS (SELECT 1 FROM tenant_api_keys k
+					WHERE k.tenant_id = t.id AND k.scope_kind = ? AND k.status = ?)
+					OR EXISTS (SELECT 1 FROM tenant_pool_memberships m
+						WHERE m.tenant_id = t.id AND m.pool_status = ?))
+			ORDER BY t.created_at, t.id LIMIT ? FOR UPDATE`, dbID, SharedDBStatusActive,
+			tidbCloudNativeSharedProvider, TenantProvisioning, APIKeyScopeKindOwner, APIKeyActive,
+			TenantPoolBindingFree, limit)
+		if queryErr != nil {
+			return queryErr
+		}
+		var tenantIDs []string
+		for rows.Next() {
+			var tenantID string
+			if scanErr := rows.Scan(&tenantID); scanErr != nil {
+				_ = rows.Close()
+				return scanErr
+			}
+			tenantIDs = append(tenantIDs, tenantID)
+		}
+		if rowsErr := rows.Err(); rowsErr != nil {
+			_ = rows.Close()
+			return rowsErr
+		}
+		if closeErr := rows.Close(); closeErr != nil {
+			return closeErr
+		}
+		now := time.Now().UTC()
+		for _, tenantID := range tenantIDs {
+			res, updateErr := tx.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ?
+				WHERE id = ? AND status = ? AND provider = ?`, TenantActive, now, tenantID,
+				TenantProvisioning, tidbCloudNativeSharedProvider)
+			if updateErr != nil {
+				return updateErr
+			}
+			n, rowsErr := res.RowsAffected()
+			if rowsErr != nil {
+				return rowsErr
+			}
+			activated += int(n)
+		}
+		return nil
+	})
+	return activated, err
 }
 
 // DeleteTenantPlacementAndDecrCount atomically removes a tenant's placement
 // and releases its capacity slot in a single transaction. Making the two
 // writes atomic keeps the shared delete path retry-safe: a failure rolls both
 // back, so a retried delete re-enters with the placement row still present
-// and cannot orphan the row or double-decrement the counter. Returns
+// and cannot orphan the row or double-decrement the counter. The reopen ratio
+// is runtime policy supplied by the server and is never persisted. Returns
 // ErrNotFound when the placement row does not exist.
-func (s *Store) DeleteTenantPlacementAndDecrCount(ctx context.Context, fsID, dbID int64) (err error) {
+func (s *Store) DeleteTenantPlacementAndDecrCount(ctx context.Context, fsID, dbID int64, reopenRatio float64) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "delete_tenant_placement_and_decr_count", start, &err)
 	if fsID <= 0 {
@@ -464,6 +1202,9 @@ func (s *Store) DeleteTenantPlacementAndDecrCount(ctx context.Context, fsID, dbI
 	}
 	if dbID <= 0 {
 		return fmt.Errorf("db_id must be positive")
+	}
+	if _, err := SharedDBReopenThresholdForRatio(1, reopenRatio); err != nil {
+		return err
 	}
 	return s.InTx(ctx, func(tx *sql.Tx) error {
 		res, err := tx.ExecContext(ctx, `DELETE FROM tenant_placements WHERE fs_id = ?`, fsID)
@@ -477,30 +1218,72 @@ func (s *Store) DeleteTenantPlacementAndDecrCount(ctx context.Context, fsID, dbI
 		if affected == 0 {
 			return ErrNotFound
 		}
-		res, err = tx.ExecContext(ctx,
-			`UPDATE db_pool SET tenant_count = GREATEST(tenant_count - 1, 0) WHERE db_id = ?`, dbID)
+		var maxTenants, tenantCount int
+		var softCapReached bool
+		if err := tx.QueryRowContext(ctx, `SELECT max_tenants, tenant_count, soft_cap_reached FROM db_pool WHERE db_id = ? FOR UPDATE`, dbID).
+			Scan(&maxTenants, &tenantCount, &softCapReached); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("lock capacity for db %d: %w", dbID, err)
+		}
+		reopenThreshold, err := SharedDBReopenThresholdForRatio(maxTenants, reopenRatio)
+		if err != nil {
+			return err
+		}
+		newTenantCount := tenantCount - 1
+		if newTenantCount < 0 {
+			newTenantCount = 0
+		}
+		nextSoftCapReached := softCapReached
+		if maxTenants > 0 && newTenantCount <= reopenThreshold {
+			nextSoftCapReached = false
+		}
+		_, err = tx.ExecContext(ctx, `UPDATE db_pool
+			SET soft_cap_reached = ?, tenant_count = ?
+			WHERE db_id = ?`, nextSoftCapReached, newTenantCount, dbID)
 		if err != nil {
 			return fmt.Errorf("release capacity on db %d: %w", dbID, err)
 		}
-		affected, err = res.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("release capacity rows affected for db %d: %w", dbID, err)
-		}
-		if affected == 0 {
-			// The placement pointed at a pool row that no longer exists —
-			// a data-integrity problem the caller must not silently pass.
-			return ErrNotFound
-		}
+		// The SELECT ... FOR UPDATE above already established that the pool
+		// exists. RowsAffected may be zero when the delete leaves both values
+		// unchanged (for example an already-zero counter), which is still a
+		// valid atomic placement release.
 		return nil
 	})
 }
 
 // scanSharedDBRow scans one db_pool row selected with sharedDBSelectColumns.
 func scanSharedDBRow(row *sql.Row) (*SharedDB, error) {
+	return scanSharedDBScanner(row)
+}
+
+type sharedDBScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanSharedDBScanner(row sharedDBScanner) (*SharedDB, error) {
 	var rec SharedDB
-	if err := row.Scan(&rec.DbID, &rec.OrgID, &rec.Role, &rec.Host, &rec.Port, &rec.User,
-		&rec.PasswordCipher, &rec.Name, &rec.TLSMode, &rec.MaxTenants, &rec.TenantCount, &rec.Status); err != nil {
+	var organizationID, clusterID, cloudProvider, region sql.NullString
+	var host, user, name sql.NullString
+	var port, spendingLimit sql.NullInt64
+	if err := row.Scan(&rec.ID, &organizationID, &clusterID, &rec.ProvisioningKey, &cloudProvider, &region,
+		&rec.Role, &host, &port, &user, &rec.PasswordCipher, &name, &rec.TLSMode,
+		&rec.MaxTenants, &rec.TenantCount, &rec.SoftCapReached, &spendingLimit, &rec.SchemaVersion, &rec.Status,
+		&rec.CreatedAt, &rec.UpdatedAt); err != nil {
 		return nil, err
+	}
+	rec.TiDBCloudOrganizationID = organizationID.String
+	rec.ClusterID = clusterID.String
+	rec.CloudProvider = cloudProvider.String
+	rec.Region = region.String
+	rec.Host = host.String
+	rec.Port = int(port.Int64)
+	rec.User = user.String
+	rec.Name = name.String
+	if spendingLimit.Valid {
+		value := spendingLimit.Int64
+		rec.SpendingLimit = &value
 	}
 	return &rec, nil
 }

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -389,12 +389,25 @@ func (s *Store) ActivateSharedDBPool(ctx context.Context, dbID int64) (err error
 }
 
 func (s *Store) MarkSharedDBPoolFailed(ctx context.Context, dbID int64) error {
-	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ? AND status = ?`,
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?
+		WHERE db_id = ? AND status = ? AND tenant_count = 0`,
 		SharedDBStatusFailed, dbID, SharedDBStatusProvisioning)
 	if err != nil {
 		return err
 	}
 	if n, _ := res.RowsAffected(); n == 0 {
+		var status string
+		var tenantCount int
+		if err := s.db.QueryRowContext(ctx, `SELECT status, tenant_count FROM db_pool WHERE db_id = ?`, dbID).
+			Scan(&status, &tenantCount); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return err
+		}
+		if status == SharedDBStatusProvisioning && tenantCount > 0 {
+			return fmt.Errorf("db pool %d has %d placed tenants and cannot be marked failed", dbID, tenantCount)
+		}
 		return ErrNotFound
 	}
 	return nil
@@ -471,18 +484,18 @@ func (s *Store) FindSharedDBForAllocation(ctx context.Context, organizationID st
 }
 
 // FindSharedDBForEmergency selects the least-loaded active managed pool below
-// the caller-computed hard cap. It is used only after a physical create failure
-// on a direct request; refill and prewarm must never call it.
-func (s *Store) FindSharedDBForEmergency(ctx context.Context, organizationID string, hardCap int, tenantSpendingLimit int64) (*SharedDB, error) {
+// its own runtime-derived hard cap. It is used only after a physical create
+// failure on a direct request; refill and prewarm must never call it.
+func (s *Store) FindSharedDBForEmergency(ctx context.Context, organizationID string, hardCapRatio float64, tenantSpendingLimit int64) (*SharedDB, error) {
 	if organizationID == "" {
 		return nil, fmt.Errorf("organization id is required")
 	}
-	if hardCap <= 0 || tenantSpendingLimit < 0 {
+	if hardCapRatio <= 1 || tenantSpendingLimit < 0 {
 		return nil, fmt.Errorf("invalid emergency capacity arguments")
 	}
 	query := "SELECT " + sharedDBSelectColumns + " FROM db_pool d " +
 		"WHERE d.org_id = ? AND d.`role` = ? AND d.status = ? " +
-		"AND d.max_tenants > 0 AND d.tenant_count < ? AND d.spending_limit IS NOT NULL " +
+		"AND d.max_tenants > 0 AND d.tenant_count < CEIL(d.max_tenants * ?) AND d.spending_limit IS NOT NULL " +
 		`AND COALESCE((SELECT SUM(q.tidbcloud_spending_limit)
 			FROM tenant_placements p
 			JOIN fs_registry f ON f.fs_id = p.fs_id
@@ -490,7 +503,7 @@ func (s *Store) FindSharedDBForEmergency(ctx context.Context, organizationID str
 			WHERE p.db_id = d.db_id), 0) + ? < d.spending_limit
 		ORDER BY d.tenant_count ASC, d.db_id ASC LIMIT 1`
 	db, err := scanSharedDBRow(s.db.QueryRowContext(ctx, query, organizationID, SharedDBRoleShared,
-		SharedDBStatusActive, hardCap, tenantSpendingLimit))
+		SharedDBStatusActive, hardCapRatio, tenantSpendingLimit))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -1007,6 +1020,8 @@ func (s *Store) completeSharedTenantProvision(ctx context.Context, tenantID, pro
 				return fmt.Errorf("sum tenant spending limits for db pool %d: %w", p.DbID, err)
 			}
 			prospective := currentSum + tenantSpendingLimit.Int64
+			// Keep strict headroom: the physical pool spending limit must remain
+			// greater than, never merely equal to, the sum of tenant virtual limits.
 			if prospective < currentSum || prospective > int64(1<<31-1) || prospective >= poolSpendingLimit.Int64 {
 				return ErrSharedDBSpendingLimitExceeded
 			}

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -1,23 +1,82 @@
 package meta
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"math"
 	"testing"
 	"time"
 )
 
+func TestSharedDBCapacityBounds(t *testing.T) {
+	tests := []struct {
+		name       string
+		softCap    int
+		ratio      float64
+		wantHard   int
+		wantReopen int
+		wantErr    bool
+	}{
+		{name: "default", softCap: 100, ratio: 1.2, wantHard: 120, wantReopen: 80},
+		{name: "ceil fractional", softCap: 101, ratio: 1.1, wantHard: 112, wantReopen: 80},
+		{name: "ratio below one", softCap: 100, ratio: 0.9, wantErr: true},
+		{name: "nan ratio", softCap: 100, ratio: math.NaN(), wantErr: true},
+		{name: "infinite ratio", softCap: 100, ratio: math.Inf(1), wantErr: true},
+		{name: "non-positive soft cap", softCap: 0, ratio: 1.2, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			hard, err := SharedDBHardCap(tt.softCap, tt.ratio)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("SharedDBHardCap(%d, %v) error = nil, want error", tt.softCap, tt.ratio)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("SharedDBHardCap(%d, %v): %v", tt.softCap, tt.ratio, err)
+			}
+			if hard != tt.wantHard {
+				t.Fatalf("hard cap = %d, want %d", hard, tt.wantHard)
+			}
+			reopen, reopenErr := SharedDBReopenThresholdForRatio(tt.softCap, 0.8)
+			if reopenErr != nil {
+				t.Fatalf("reopen threshold: %v", reopenErr)
+			}
+			if reopen != tt.wantReopen {
+				t.Fatalf("reopen threshold = %d, want %d", reopen, tt.wantReopen)
+			}
+		})
+	}
+}
+
+func TestSharedDBReopenThresholdForRatio(t *testing.T) {
+	got, err := SharedDBReopenThresholdForRatio(10, 0.65)
+	if err != nil {
+		t.Fatalf("SharedDBReopenThresholdForRatio: %v", err)
+	}
+	if got != 6 {
+		t.Fatalf("reopen threshold = %d, want 6", got)
+	}
+	for _, ratio := range []float64{0, 1, math.NaN(), math.Inf(1)} {
+		if _, err := SharedDBReopenThresholdForRatio(10, ratio); err == nil {
+			t.Fatalf("ratio %v error = nil, want error", ratio)
+		}
+	}
+}
+
 func registerTestSharedDB(t *testing.T, s *Store, orgID, host, name string) int64 {
 	t.Helper()
 	id, err := s.RegisterSharedDB(context.Background(), &SharedDB{
-		OrgID:          orgID,
-		Host:           host,
-		Port:           4000,
-		User:           "root",
-		PasswordCipher: []byte("cipher-" + name),
-		Name:           name,
-		TLSMode:        "skip-verify",
-		MaxTenants:     100,
+		TiDBCloudOrganizationID: orgID,
+		Host:                    host,
+		Port:                    4000,
+		User:                    "root",
+		PasswordCipher:          []byte("cipher-" + name),
+		Name:                    name,
+		TLSMode:                 "skip-verify",
+		MaxTenants:              100,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB %s/%s: %v", orgID, name, err)
@@ -38,11 +97,11 @@ func TestRegisterSharedDBRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSharedDB: %v", err)
 	}
-	if got.DbID != id {
-		t.Fatalf("DbID = %d, want %d", got.DbID, id)
+	if got.ID != id {
+		t.Fatalf("ID = %d, want %d", got.ID, id)
 	}
-	if got.OrgID != "org-a" {
-		t.Fatalf("OrgID = %q, want org-a", got.OrgID)
+	if got.TiDBCloudOrganizationID != "org-a" {
+		t.Fatalf("TiDBCloudOrganizationID = %q, want org-a", got.TiDBCloudOrganizationID)
 	}
 	if got.Role != SharedDBRoleShared {
 		t.Fatalf("Role = %q, want %q", got.Role, SharedDBRoleShared)
@@ -80,6 +139,82 @@ func TestRegisterSharedDBRoundTrip(t *testing.T) {
 	}
 }
 
+func TestCreateManagedSharedDBPoolPersistsDurableProvisioningPlan(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := int64(10_000_000)
+	provisioningKey := make([]byte, 32)
+	for i := range provisioningKey {
+		provisioningKey[i] = byte(i + 1)
+	}
+
+	id, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-managed",
+		ProvisioningKey:         provisioningKey,
+		CloudProvider:           "aws",
+		Region:                  "us-east-1",
+		MaxTenants:              100,
+		SpendingLimit:           &spendingLimit,
+		PasswordCipher:          []byte("durable-root-cipher"),
+		Name:                    "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if id <= 0 {
+		t.Fatalf("managed db pool id = %d, want positive", id)
+	}
+
+	got, err := s.GetSharedDB(ctx, id)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.ID != id || got.TiDBCloudOrganizationID != "org-managed" || got.CloudProvider != "aws" || got.Region != "us-east-1" {
+		t.Fatalf("managed db pool identity = %+v", got)
+	}
+	if got.Status != SharedDBStatusProvisioning || got.MaxTenants != 100 || got.SpendingLimit == nil || *got.SpendingLimit != spendingLimit {
+		t.Fatalf("managed db pool policy = %+v", got)
+	}
+	if got.Host != "" || got.Port != 0 || got.User != "" || got.Name != "tidbcloud_fs" || string(got.PasswordCipher) != "durable-root-cipher" {
+		t.Fatalf("provisional pool unexpectedly has connection metadata: %+v", got)
+	}
+	if string(got.ProvisioningKey) != string(provisioningKey) {
+		t.Fatalf("provisioning key = %x, want %x", got.ProvisioningKey, provisioningKey)
+	}
+}
+
+func TestCreateManagedSharedDBPoolRejectsUnboundedOrInvalidPolicy(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	valid := func() *SharedDB {
+		spendingLimit := int64(10_000_000)
+		return &SharedDB{
+			TiDBCloudOrganizationID: "org-managed", ProvisioningKey: make([]byte, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+		}
+	}
+	tests := map[string]func(*SharedDB){
+		"zero capacity":       func(in *SharedDB) { in.MaxTenants = 0 },
+		"missing fingerprint": func(in *SharedDB) { in.ProvisioningKey = nil },
+		"missing cloud":       func(in *SharedDB) { in.CloudProvider = "" },
+		"missing region":      func(in *SharedDB) { in.Region = "" },
+		"missing spending":    func(in *SharedDB) { in.SpendingLimit = nil },
+		"int32 overflow": func(in *SharedDB) {
+			value := int64(1 << 31)
+			in.SpendingLimit = &value
+		},
+	}
+	for name, mutate := range tests {
+		t.Run(name, func(t *testing.T) {
+			in := valid()
+			mutate(in)
+			if _, err := s.CreateManagedSharedDBPool(ctx, in); err == nil {
+				t.Fatal("CreateManagedSharedDBPool succeeded, want validation error")
+			}
+		})
+	}
+}
+
 func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
@@ -90,14 +225,14 @@ func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 	}
 
 	second, err := s.RegisterSharedDB(ctx, &SharedDB{
-		OrgID:          "org-a",
-		Host:           "shared-a.example.com",
-		Port:           5000,
-		User:           "app",
-		PasswordCipher: []byte("rotated-cipher"),
-		Name:           "shared_db_a",
-		TLSMode:        "true",
-		MaxTenants:     200,
+		TiDBCloudOrganizationID: "org-a",
+		Host:                    "shared-a.example.com",
+		Port:                    5000,
+		User:                    "app",
+		PasswordCipher:          []byte("rotated-cipher"),
+		Name:                    "shared_db_a",
+		TLSMode:                 "true",
+		MaxTenants:              200,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB upsert: %v", err)
@@ -125,12 +260,12 @@ func TestRegisterSharedDBValidation(t *testing.T) {
 
 	valid := func() *SharedDB {
 		return &SharedDB{
-			OrgID:          "org-a",
-			Host:           "h",
-			Port:           4000,
-			User:           "u",
-			PasswordCipher: []byte("c"),
-			Name:           "n",
+			TiDBCloudOrganizationID: "org-a",
+			Host:                    "h",
+			Port:                    4000,
+			User:                    "u",
+			PasswordCipher:          []byte("c"),
+			Name:                    "n",
 		}
 	}
 	cases := map[string]func(*SharedDB){
@@ -162,24 +297,24 @@ func TestFindSharedDBForOrgExactThenWildcard(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindSharedDBForOrg exact: %v", err)
 	}
-	if got.DbID != orgID {
-		t.Fatalf("exact match db_id = %d, want %d", got.DbID, orgID)
+	if got.ID != orgID {
+		t.Fatalf("exact match db_id = %d, want %d", got.ID, orgID)
 	}
 
 	got, err = s.FindSharedDBForOrg(ctx, "org-other")
 	if err != nil {
 		t.Fatalf("FindSharedDBForOrg fallback: %v", err)
 	}
-	if got.DbID != wildID {
-		t.Fatalf("wildcard fallback db_id = %d, want %d", got.DbID, wildID)
+	if got.ID != wildID {
+		t.Fatalf("wildcard fallback db_id = %d, want %d", got.ID, wildID)
 	}
 
 	got, err = s.FindSharedDBForOrg(ctx, "")
 	if err != nil {
 		t.Fatalf("FindSharedDBForOrg empty org: %v", err)
 	}
-	if got.DbID != wildID {
-		t.Fatalf("empty org db_id = %d, want wildcard %d", got.DbID, wildID)
+	if got.ID != wildID {
+		t.Fatalf("empty org db_id = %d, want wildcard %d", got.ID, wildID)
 	}
 }
 
@@ -205,13 +340,13 @@ func TestListSharedDBs(t *testing.T) {
 	second := registerTestSharedDB(t, s, SharedDBOrgWildcard, "shared-wild.example.com", "shared_db_wild")
 	// A non-active row must not appear in the list.
 	if _, err := s.RegisterSharedDB(ctx, &SharedDB{
-		OrgID:          "org-b",
-		Host:           "shared-draining.example.com",
-		Port:           4000,
-		User:           "root",
-		PasswordCipher: []byte("cipher"),
-		Name:           "shared_db_draining",
-		Status:         "draining",
+		TiDBCloudOrganizationID: "org-b",
+		Host:                    "shared-draining.example.com",
+		Port:                    4000,
+		User:                    "root",
+		PasswordCipher:          []byte("cipher"),
+		Name:                    "shared_db_draining",
+		Status:                  "draining",
 	}); err != nil {
 		t.Fatalf("RegisterSharedDB draining: %v", err)
 	}
@@ -223,9 +358,9 @@ func TestListSharedDBs(t *testing.T) {
 	if len(list) != 2 {
 		t.Fatalf("ListSharedDBs returned %d rows, want 2", len(list))
 	}
-	if list[0].DbID != first || list[1].DbID != second {
+	if list[0].ID != first || list[1].ID != second {
 		t.Fatalf("ListSharedDBs order = [%d %d], want [%d %d]",
-			list[0].DbID, list[1].DbID, first, second)
+			list[0].ID, list[1].ID, first, second)
 	}
 }
 
@@ -369,13 +504,13 @@ func TestFindSharedDBForOrgSkipsFullPools(t *testing.T) {
 	// fall through to the wildcard pool rather than overfill it.
 	fullID := registerTestSharedDB(t, s, "org-capped", "shared-capped.example.com", "shared_db_capped")
 	if _, err := s.RegisterSharedDB(ctx, &SharedDB{
-		OrgID:          "org-capped",
-		Host:           "shared-capped.example.com",
-		Port:           4000,
-		User:           "root",
-		PasswordCipher: []byte("cipher"),
-		Name:           "shared_db_capped",
-		MaxTenants:     1,
+		TiDBCloudOrganizationID: "org-capped",
+		Host:                    "shared-capped.example.com",
+		Port:                    4000,
+		User:                    "root",
+		PasswordCipher:          []byte("cipher"),
+		Name:                    "shared_db_capped",
+		MaxTenants:              1,
 	}); err != nil {
 		t.Fatalf("cap pool at 1: %v", err)
 	}
@@ -385,8 +520,8 @@ func TestFindSharedDBForOrgSkipsFullPools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindSharedDBForOrg before full: %v", err)
 	}
-	if got.DbID != fullID {
-		t.Fatalf("before full db_id = %d, want exact pool %d", got.DbID, fullID)
+	if got.ID != fullID {
+		t.Fatalf("before full db_id = %d, want exact pool %d", got.ID, fullID)
 	}
 
 	if err := s.IncrSharedDBTenantCount(ctx, fullID, 1); err != nil {
@@ -396,8 +531,8 @@ func TestFindSharedDBForOrgSkipsFullPools(t *testing.T) {
 	if err != nil {
 		t.Fatalf("FindSharedDBForOrg after full: %v", err)
 	}
-	if got.DbID != wildID {
-		t.Fatalf("after full db_id = %d, want wildcard %d", got.DbID, wildID)
+	if got.ID != wildID {
+		t.Fatalf("after full db_id = %d, want wildcard %d", got.ID, wildID)
 	}
 
 	// With no wildcard fallback, a full pool reads as not found.
@@ -437,12 +572,151 @@ func testOwnerKey(tenantID string) *APIKey {
 	}
 }
 
+func completeTestSharedTenant(t *testing.T, s *Store, dbID int64, tenantID string, emergencyHardCap int) int64 {
+	t.Helper()
+	ctx := context.Background()
+	seedPendingTenant(t, s, tenantID)
+	fsID, err := s.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID %s: %v", tenantID, err)
+	}
+	virtualLimit := int64(100)
+	if err := s.SetQuotaConfigPatch(ctx, tenantID, QuotaConfigPatch{TiDBCloudSpendingLimit: &virtualLimit}); err != nil {
+		t.Fatalf("SetQuotaConfigPatch %s: %v", tenantID, err)
+	}
+	placement := &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}
+	if emergencyHardCap > 0 {
+		err = s.CompleteSharedTenantProvisionEmergency(ctx, tenantID, "tidb_cloud_native_shared", placement, testOwnerKey(tenantID), emergencyHardCap)
+	} else {
+		err = s.CompleteSharedTenantProvision(ctx, tenantID, "tidb_cloud_native_shared", placement, testOwnerKey(tenantID))
+	}
+	if err != nil {
+		t.Fatalf("complete shared tenant %s: %v", tenantID, err)
+	}
+	return fsID
+}
+
+func TestCompleteSharedTenantProvisionSoftHardCapacityAndHysteresis(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := int64(10_000)
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-hysteresis", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 2, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?, cluster_id = 'cluster-hysteresis', db_host = 'h', db_port = 4000,
+		db_user = 'u', db_password = 'c', db_name = 'hysteresis_db' WHERE db_id = ?`, SharedDBStatusActive, dbID); err != nil {
+		t.Fatalf("activate managed pool: %v", err)
+	}
+	fs1 := completeTestSharedTenant(t, s, dbID, "tenant-hysteresis-1", 0)
+	fs2 := completeTestSharedTenant(t, s, dbID, "tenant-hysteresis-2", 0)
+	db, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB at soft cap: %v", err)
+	}
+	if db.TenantCount != 2 || !db.SoftCapReached {
+		t.Fatalf("pool at soft cap = count %d latch %v, want 2/true", db.TenantCount, db.SoftCapReached)
+	}
+
+	seedPendingTenant(t, s, "tenant-hysteresis-normal-rejected")
+	fsRejected, _ := s.EnsureFsID(ctx, "tenant-hysteresis-normal-rejected")
+	err = s.CompleteSharedTenantProvision(ctx, "tenant-hysteresis-normal-rejected", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsRejected, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-hysteresis-normal-rejected"))
+	if !errors.Is(err, ErrSharedDBCapacityExhausted) {
+		t.Fatalf("normal over soft cap error = %v, want ErrSharedDBCapacityExhausted", err)
+	}
+
+	fs3 := completeTestSharedTenant(t, s, dbID, "tenant-hysteresis-3", 3)
+	db, _ = s.GetSharedDB(ctx, dbID)
+	if db.TenantCount != 3 || !db.SoftCapReached {
+		t.Fatalf("pool at hard cap = count %d latch %v, want 3/true", db.TenantCount, db.SoftCapReached)
+	}
+
+	seedPendingTenant(t, s, "tenant-hysteresis-hard-rejected")
+	fsHardRejected, _ := s.EnsureFsID(ctx, "tenant-hysteresis-hard-rejected")
+	err = s.CompleteSharedTenantProvisionEmergency(ctx, "tenant-hysteresis-hard-rejected", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsHardRejected, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-hysteresis-hard-rejected"), 3)
+	if !errors.Is(err, ErrSharedDBCapacityExhausted) {
+		t.Fatalf("over hard cap error = %v, want ErrSharedDBCapacityExhausted", err)
+	}
+
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, fs3, dbID, 0.8); err != nil {
+		t.Fatalf("delete overflow placement: %v", err)
+	}
+	db, _ = s.GetSharedDB(ctx, dbID)
+	if db.TenantCount != 2 || !db.SoftCapReached {
+		t.Fatalf("pool above reopen threshold = count %d latch %v, want 2/true", db.TenantCount, db.SoftCapReached)
+	}
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, fs2, dbID, 0.8); err != nil {
+		t.Fatalf("delete to reopen threshold: %v", err)
+	}
+	db, _ = s.GetSharedDB(ctx, dbID)
+	if db.TenantCount != 1 || db.SoftCapReached {
+		t.Fatalf("pool at reopen threshold = count %d latch %v, want 1/false", db.TenantCount, db.SoftCapReached)
+	}
+	if _, err := s.GetTenantPlacement(ctx, fs1); err != nil {
+		t.Fatalf("remaining placement: %v", err)
+	}
+}
+
+func TestCompleteSharedTenantProvisionDoesNotUpdateOtherProvisioningPools(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := int64(100_000)
+	targetID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-target", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 10, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool target: %v", err)
+	}
+	otherID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-other", ProvisioningKey: bytes.Repeat([]byte{2}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 10, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool other: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool
+		SET status = ?, cluster_id = 'target-cluster', db_host = 'target-host', db_port = 4000,
+			db_user = 'u', db_password = 'c', db_name = 'target_db' WHERE db_id = ?`, SharedDBStatusActive, targetID); err != nil {
+		t.Fatalf("activate target pool: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET cluster_id = 'other-cluster' WHERE db_id = ?`, otherID); err != nil {
+		t.Fatalf("seed other provisioning cluster: %v", err)
+	}
+
+	completeTestSharedTenant(t, s, targetID, "tenant-direct-create-parentheses", 0)
+
+	target, err := s.GetSharedDB(ctx, targetID)
+	if err != nil {
+		t.Fatalf("GetSharedDB target: %v", err)
+	}
+	other, err := s.GetSharedDB(ctx, otherID)
+	if err != nil {
+		t.Fatalf("GetSharedDB other: %v", err)
+	}
+	if target.TenantCount != 1 {
+		t.Fatalf("target tenant_count = %d, want 1", target.TenantCount)
+	}
+	if other.TenantCount != 0 || other.SoftCapReached {
+		t.Fatalf("other tenant_count/latch = %d/%v, want 0/false", other.TenantCount, other.SoftCapReached)
+	}
+}
+
 func TestCompleteSharedTenantProvisionCommitsAtomically(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 
 	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
-		OrgID: "org-complete", Host: "h", Port: 4000, User: "u",
+		TiDBCloudOrganizationID: "org-complete", Host: "h", Port: 4000, User: "u",
 		PasswordCipher: []byte("c"), Name: "complete_db", MaxTenants: 5,
 	})
 	if err != nil {
@@ -489,12 +763,283 @@ func TestCompleteSharedTenantProvisionCommitsAtomically(t *testing.T) {
 	}
 }
 
+func TestCompleteSharedTenantProvisionKeepsTenantProvisioningUntilDBPoolIsActive(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := int64(10_000_000)
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-provisioning", ProvisioningKey: make([]byte, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET cluster_id = 'cluster-provisioning' WHERE db_id = ?`, dbID); err != nil {
+		t.Fatalf("mark provisioning cluster created: %v", err)
+	}
+	seedPendingTenant(t, s, "tenant-on-provisioning-pool")
+	virtualLimit := int64(1000)
+	if err := s.SetQuotaConfigPatch(ctx, "tenant-on-provisioning-pool", QuotaConfigPatch{TiDBCloudSpendingLimit: &virtualLimit}); err != nil {
+		t.Fatalf("SetQuotaConfigPatch: %v", err)
+	}
+	fsID, err := s.EnsureFsID(ctx, "tenant-on-provisioning-pool")
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if err := s.CompleteSharedTenantProvision(ctx, "tenant-on-provisioning-pool", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-on-provisioning-pool")); err != nil {
+		t.Fatalf("CompleteSharedTenantProvision: %v", err)
+	}
+	tenant, err := s.GetTenant(ctx, "tenant-on-provisioning-pool")
+	if err != nil {
+		t.Fatalf("GetTenant: %v", err)
+	}
+	if tenant.Status != TenantProvisioning || tenant.Provider != "tidb_cloud_native_shared" {
+		t.Fatalf("tenant = provider %q status %q, want shared/provisioning", tenant.Provider, tenant.Status)
+	}
+	placement, err := s.GetTenantPlacement(ctx, fsID)
+	if err != nil {
+		t.Fatalf("GetTenantPlacement: %v", err)
+	}
+	if placement.Status != SharedDBStatusActive {
+		t.Fatalf("placement status = %q, want active routing", placement.Status)
+	}
+}
+
+func TestManagedSharedDBPoolCloudResultSchemaAndActivation(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := int64(10_000_000)
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		ProvisioningKey: make([]byte, 32), CloudProvider: "aws", Region: "us-east-1",
+		MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	cloudResult := &SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-managed", ClusterID: "cluster-managed",
+		Host: "shared.example.com", Port: 4000, User: "root", PasswordCipher: []byte("root-cipher"),
+		Name: "tidbcloud_fs", TLSMode: "true",
+	}
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, cloudResult); err != nil {
+		t.Fatalf("UpdateManagedSharedDBPoolCloudResult: %v", err)
+	}
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, cloudResult); err != nil {
+		t.Fatalf("idempotent UpdateManagedSharedDBPoolCloudResult: %v", err)
+	}
+	got, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB after cloud result: %v", err)
+	}
+	if got.TiDBCloudOrganizationID != "org-managed" || got.ClusterID != "cluster-managed" || got.Host != "shared.example.com" || got.Port != 4000 {
+		t.Fatalf("cloud result not persisted: %+v", got)
+	}
+	if len(got.ProvisioningKey) != 0 {
+		t.Fatalf("provisioning key = %x, want cleared after organization is durable", got.ProvisioningKey)
+	}
+	if got.Status != SharedDBStatusProvisioning {
+		t.Fatalf("status after cloud result = %q, want provisioning", got.Status)
+	}
+
+	if err := s.UpdateSharedDBSchemaVersion(ctx, dbID, 17); err != nil {
+		t.Fatalf("UpdateSharedDBSchemaVersion: %v", err)
+	}
+	if err := s.ActivateSharedDBPool(ctx, dbID); err != nil {
+		t.Fatalf("ActivateSharedDBPool: %v", err)
+	}
+	got, err = s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB after activate: %v", err)
+	}
+	if got.Status != SharedDBStatusActive || got.SchemaVersion != 17 {
+		t.Fatalf("activated pool = status %q schema %d, want active/17", got.Status, got.SchemaVersion)
+	}
+	rows, err := s.ListSharedDBsByStatus(ctx, SharedDBStatusActive, 10)
+	if err != nil {
+		t.Fatalf("ListSharedDBsByStatus: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != dbID {
+		t.Fatalf("active rows = %+v, want db %d", rows, dbID)
+	}
+}
+
+func TestActivateSharedTenantsBatchRequiresReadyPoolPlacementAndOwnerKey(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := int64(10_000_000)
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-activation", ProvisioningKey: make([]byte, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET cluster_id = 'cluster-activation' WHERE db_id = ?`, dbID); err != nil {
+		t.Fatalf("mark activation cluster created: %v", err)
+	}
+	for _, tenantID := range []string{"tenant-activate-1", "tenant-activate-2"} {
+		seedPendingTenant(t, s, tenantID)
+		limit := int64(1000)
+		if err := s.SetQuotaConfigPatch(ctx, tenantID, QuotaConfigPatch{TiDBCloudSpendingLimit: &limit}); err != nil {
+			t.Fatalf("SetQuotaConfigPatch %s: %v", tenantID, err)
+		}
+		fsID, err := s.EnsureFsID(ctx, tenantID)
+		if err != nil {
+			t.Fatalf("EnsureFsID %s: %v", tenantID, err)
+		}
+		if err := s.CompleteSharedTenantProvision(ctx, tenantID, "tidb_cloud_native_shared", &TenantPlacement{
+			FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+		}, testOwnerKey(tenantID)); err != nil {
+			t.Fatalf("CompleteSharedTenantProvision %s: %v", tenantID, err)
+		}
+	}
+	if _, err := s.db.ExecContext(ctx, `DELETE FROM tenant_api_keys WHERE tenant_id = ?`, "tenant-activate-2"); err != nil {
+		t.Fatalf("remove second owner key: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?, db_host = 'h', db_port = 4000,
+		db_user = 'u', db_password = 'c', db_name = 'n', schema_version = 1 WHERE db_id = ?`, SharedDBStatusActive, dbID); err != nil {
+		t.Fatalf("mark pool active: %v", err)
+	}
+
+	activated, err := s.ActivateSharedTenantsBatch(ctx, dbID, 100)
+	if err != nil {
+		t.Fatalf("ActivateSharedTenantsBatch: %v", err)
+	}
+	if activated != 1 {
+		t.Fatalf("activated = %d, want 1", activated)
+	}
+	first, _ := s.GetTenant(ctx, "tenant-activate-1")
+	second, _ := s.GetTenant(ctx, "tenant-activate-2")
+	if first.Status != TenantActive || second.Status != TenantProvisioning {
+		t.Fatalf("statuses = %q/%q, want active/provisioning", first.Status, second.Status)
+	}
+}
+
+func TestFindSharedDBForAllocationPrefersActiveAndChecksManagedHeadroom(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := int64(2_001)
+	provisioningID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-allocate", ProvisioningKey: make([]byte, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool provisioning: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET cluster_id = 'cluster-allocate-provisioning' WHERE db_id = ?`, provisioningID); err != nil {
+		t.Fatalf("mark provisioning cluster created: %v", err)
+	}
+	activeID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-allocate", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool active: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?, db_host = 'h', db_port = 4000,
+		db_user = 'u', db_password = 'c', db_name = CONCAT('n', db_id), schema_version = 1 WHERE db_id = ?`, SharedDBStatusActive, activeID); err != nil {
+		t.Fatalf("activate second pool: %v", err)
+	}
+
+	got, err := s.FindSharedDBForAllocation(ctx, "org-allocate", nil, 1000)
+	if err != nil {
+		t.Fatalf("FindSharedDBForAllocation active: %v", err)
+	}
+	if got.ID != activeID {
+		t.Fatalf("allocation chose %d, want active pool %d before provisioning %d", got.ID, activeID, provisioningID)
+	}
+
+	seedPendingTenant(t, s, "tenant-headroom")
+	limit := int64(1500)
+	if err := s.SetQuotaConfigPatch(ctx, "tenant-headroom", QuotaConfigPatch{TiDBCloudSpendingLimit: &limit}); err != nil {
+		t.Fatalf("SetQuotaConfigPatch: %v", err)
+	}
+	fsID, _ := s.EnsureFsID(ctx, "tenant-headroom")
+	if err := s.CompleteSharedTenantProvision(ctx, "tenant-headroom", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsID, DbID: activeID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-headroom")); err != nil {
+		t.Fatalf("CompleteSharedTenantProvision: %v", err)
+	}
+	got, err = s.FindSharedDBForAllocation(ctx, "org-allocate", nil, 1000)
+	if err != nil {
+		t.Fatalf("FindSharedDBForAllocation fallback: %v", err)
+	}
+	if got.ID != provisioningID {
+		t.Fatalf("allocation with exhausted active headroom chose %d, want provisioning %d", got.ID, provisioningID)
+	}
+}
+
+func TestUpdateSharedTenantQuotaConfigChecksManagedHeadroomAtomically(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingTarget := int64(3_001)
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-quota", ProvisioningKey: make([]byte, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET cluster_id = 'cluster-quota' WHERE db_id = ?`, dbID); err != nil {
+		t.Fatalf("mark quota cluster created: %v", err)
+	}
+	for _, tenantID := range []string{"tenant-shared-quota-1", "tenant-shared-quota-2"} {
+		seedPendingTenant(t, s, tenantID)
+		limit := int64(1000)
+		if err := s.SetQuotaConfig(ctx, &QuotaConfig{
+			TenantID: tenantID, MaxStorageBytes: 100, MaxFileSizeBytes: 10,
+			MaxMediaLLMFiles: 1, MaxVideoLLMFiles: 1, TiDBCloudSpendingLimit: &limit,
+		}); err != nil {
+			t.Fatalf("SetQuotaConfig %s: %v", tenantID, err)
+		}
+		fsID, _ := s.EnsureFsID(ctx, tenantID)
+		if err := s.CompleteSharedTenantProvision(ctx, tenantID, "tidb_cloud_native_shared", &TenantPlacement{
+			FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+		}, testOwnerKey(tenantID)); err != nil {
+			t.Fatalf("CompleteSharedTenantProvision %s: %v", tenantID, err)
+		}
+	}
+
+	withinHeadroom := int64(1500)
+	storage := int64(200)
+	if err := s.UpdateSharedTenantQuotaConfig(ctx, "tenant-shared-quota-1", QuotaConfigPatch{
+		MaxStorageBytes: &storage, TiDBCloudSpendingLimit: &withinHeadroom,
+	}); err != nil {
+		t.Fatalf("UpdateSharedTenantQuotaConfig within headroom: %v", err)
+	}
+	cfg, err := s.GetQuotaConfig(ctx, "tenant-shared-quota-1")
+	if err != nil {
+		t.Fatalf("GetQuotaConfig: %v", err)
+	}
+	if cfg.MaxStorageBytes != storage || cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != withinHeadroom {
+		t.Fatalf("updated quota = %+v", cfg)
+	}
+
+	noHeadroom := int64(2001)
+	storageOnFailure := int64(300)
+	err = s.UpdateSharedTenantQuotaConfig(ctx, "tenant-shared-quota-1", QuotaConfigPatch{
+		MaxStorageBytes: &storageOnFailure, TiDBCloudSpendingLimit: &noHeadroom,
+	})
+	if !errors.Is(err, ErrSharedDBSpendingLimitExceeded) {
+		t.Fatalf("headroom error = %v, want ErrSharedDBSpendingLimitExceeded", err)
+	}
+	cfg, err = s.GetQuotaConfig(ctx, "tenant-shared-quota-1")
+	if err != nil {
+		t.Fatalf("GetQuotaConfig after rejected update: %v", err)
+	}
+	if cfg.MaxStorageBytes != storage || cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != withinHeadroom {
+		t.Fatalf("rejected update changed quota: %+v", cfg)
+	}
+}
+
 func TestCompleteSharedTenantProvisionCapacityExhaustedLeavesNoPartialState(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 
 	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
-		OrgID: "org-capped", Host: "h", Port: 4000, User: "u",
+		TiDBCloudOrganizationID: "org-capped", Host: "h", Port: 4000, User: "u",
 		PasswordCipher: []byte("c"), Name: "capped_db", MaxTenants: 1,
 	})
 	if err != nil {
@@ -548,7 +1093,7 @@ func TestCompleteSharedTenantProvisionRollsBackOnMissingTenant(t *testing.T) {
 	ctx := context.Background()
 
 	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
-		OrgID: "org-rollback", Host: "h", Port: 4000, User: "u",
+		TiDBCloudOrganizationID: "org-rollback", Host: "h", Port: 4000, User: "u",
 		PasswordCipher: []byte("c"), Name: "rollback_db",
 	})
 	if err != nil {
@@ -590,7 +1135,7 @@ func TestDeleteTenantPlacementAndDecrCountIsAtomic(t *testing.T) {
 	ctx := context.Background()
 
 	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
-		OrgID: "org-release", Host: "h", Port: 4000, User: "u",
+		TiDBCloudOrganizationID: "org-release", Host: "h", Port: 4000, User: "u",
 		PasswordCipher: []byte("c"), Name: "release_db",
 	})
 	if err != nil {
@@ -607,7 +1152,7 @@ func TestDeleteTenantPlacementAndDecrCountIsAtomic(t *testing.T) {
 		t.Fatalf("provision: %v", err)
 	}
 
-	if err := s.DeleteTenantPlacementAndDecrCount(ctx, fsID, dbID); err != nil {
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, fsID, dbID, 0.8); err != nil {
 		t.Fatalf("DeleteTenantPlacementAndDecrCount: %v", err)
 	}
 	if _, err := s.GetTenantPlacement(ctx, fsID); !errors.Is(err, ErrNotFound) {
@@ -620,9 +1165,12 @@ func TestDeleteTenantPlacementAndDecrCountIsAtomic(t *testing.T) {
 	if got.TenantCount != 0 {
 		t.Fatalf("TenantCount = %d, want 0", got.TenantCount)
 	}
+	if got.SoftCapReached {
+		t.Fatal("unlimited pool soft-cap latch = true, want false")
+	}
 
 	// Missing placement: ErrNotFound.
-	if err := s.DeleteTenantPlacementAndDecrCount(ctx, 299, dbID); !errors.Is(err, ErrNotFound) {
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, 299, dbID, 0.8); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("delete missing placement error = %v, want ErrNotFound", err)
 	}
 
@@ -633,11 +1181,48 @@ func TestDeleteTenantPlacementAndDecrCountIsAtomic(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("seed orphan-candidate placement: %v", err)
 	}
-	if err := s.DeleteTenantPlacementAndDecrCount(ctx, 301, dbID+999); !errors.Is(err, ErrNotFound) {
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, 301, dbID+999, 0.8); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("delete with missing pool error = %v, want ErrNotFound", err)
 	}
 	if _, err := s.GetTenantPlacement(ctx, 301); err != nil {
 		t.Fatalf("placement must survive rolled-back delete: %v", err)
+	}
+}
+
+func TestDeleteTenantPlacementAndDecrCountUsesReopenRatio(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-release-ratio", Host: "h", Port: 4000, User: "u",
+		PasswordCipher: []byte("c"), Name: "release_ratio_db", MaxTenants: 10,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	seedPendingTenant(t, s, "tenant-release-ratio")
+	fsID, err := s.EnsureFsID(ctx, "tenant-release-ratio")
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if err := s.UpsertTenantPlacement(ctx, &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET tenant_count = 6, soft_cap_reached = 1 WHERE db_id = ?`, dbID); err != nil {
+		t.Fatalf("seed capacity: %v", err)
+	}
+
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, fsID, dbID, 0.65); err != nil {
+		t.Fatalf("DeleteTenantPlacementAndDecrCount: %v", err)
+	}
+	got, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.TenantCount != 5 || got.SoftCapReached {
+		t.Fatalf("capacity after delete = count %d latch %v, want 5/false", got.TenantCount, got.SoftCapReached)
 	}
 }
 
@@ -651,7 +1236,7 @@ func TestCompleteSharedTenantProvisionRollsBackOnKeyFailure(t *testing.T) {
 	ctx := context.Background()
 
 	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
-		OrgID: "org-keyfail", Host: "h", Port: 4000, User: "u",
+		TiDBCloudOrganizationID: "org-keyfail", Host: "h", Port: 4000, User: "u",
 		PasswordCipher: []byte("c"), Name: "keyfail_db",
 	})
 	if err != nil {

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -215,6 +215,33 @@ func TestCreateManagedSharedDBPoolRejectsUnboundedOrInvalidPolicy(t *testing.T) 
 	}
 }
 
+func TestMarkSharedDBPoolFailedRejectsPoolWithTenants(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := int64(10_000)
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-failed-with-tenants", ProvisioningKey: bytes.Repeat([]byte{7}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 10, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET tenant_count = 1 WHERE db_id = ?`, dbID); err != nil {
+		t.Fatalf("seed tenant count: %v", err)
+	}
+
+	if err := s.MarkSharedDBPoolFailed(ctx, dbID); err == nil {
+		t.Fatal("MarkSharedDBPoolFailed succeeded for a pool with tenants")
+	}
+	got, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.Status != SharedDBStatusProvisioning {
+		t.Fatalf("status = %q, want provisioning", got.Status)
+	}
+}
+
 func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -393,9 +393,6 @@ func (s *Store) migrate() (err error) {
 	if err := expandManagedDBPoolSchema(ctx, s.db); err != nil {
 		return err
 	}
-	if err := removeQuotaLimitsOverriddenColumn(ctx, s.db); err != nil {
-		return err
-	}
 	if err := backfillTiDBCloudOrgBindingBranchIDs(ctx, s.db); err != nil {
 		return err
 	}
@@ -411,23 +408,6 @@ func (s *Store) migrate() (err error) {
 	}
 	if len(diffs) > 0 {
 		return &metaSchemaDiffError{diffs: diffs}
-	}
-	return nil
-}
-
-func removeQuotaLimitsOverriddenColumn(ctx context.Context, db *sql.DB) error {
-	var exists int
-	if err := db.QueryRowContext(ctx, `SELECT COUNT(*)
-		FROM information_schema.columns
-		WHERE table_schema = DATABASE() AND table_name = 'tenant_quota_config'
-		  AND column_name = 'quota_limits_overridden'`).Scan(&exists); err != nil {
-		return fmt.Errorf("inspect tenant_quota_config.quota_limits_overridden: %w", err)
-	}
-	if exists == 0 {
-		return nil
-	}
-	if _, err := db.ExecContext(ctx, `ALTER TABLE tenant_quota_config DROP COLUMN quota_limits_overridden`); err != nil && !isIgnorableMetaSchemaError(err) {
-		return fmt.Errorf("drop tenant_quota_config.quota_limits_overridden: %w", err)
 	}
 	return nil
 }
@@ -846,6 +826,7 @@ func metaInitSchemaStatements() []string {
 			max_media_llm_files   BIGINT NOT NULL DEFAULT 500,
 			max_video_llm_files   BIGINT NOT NULL DEFAULT 50,
 			max_monthly_cost_mc   BIGINT NOT NULL DEFAULT 0,
+			quota_limits_overridden TINYINT(1) NOT NULL DEFAULT 1,
 			tidbcloud_spending_limit BIGINT NULL,
 			tidbcloud_spending_limit_checked_at DATETIME(3) NULL,
 			created_at            DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -52,6 +52,7 @@ var allTenantStatuses = []TenantStatus{
 }
 
 const tidbCloudNativeProvider = "tidb_cloud_native"
+const tidbCloudNativeSharedProvider = "tidb_cloud_native_shared"
 const maxTiDBCloudOrgBindingDuplicateTuples = 20
 
 type TenantKind string
@@ -389,6 +390,12 @@ func (s *Store) migrate() (err error) {
 	if err := applyMetaSchemaRepairs(ctx, s.db, plannedMetaSchemaRepairs(diffs)); err != nil {
 		return err
 	}
+	if err := expandManagedDBPoolSchema(ctx, s.db); err != nil {
+		return err
+	}
+	if err := removeQuotaLimitsOverriddenColumn(ctx, s.db); err != nil {
+		return err
+	}
 	if err := backfillTiDBCloudOrgBindingBranchIDs(ctx, s.db); err != nil {
 		return err
 	}
@@ -404,6 +411,94 @@ func (s *Store) migrate() (err error) {
 	}
 	if len(diffs) > 0 {
 		return &metaSchemaDiffError{diffs: diffs}
+	}
+	return nil
+}
+
+func removeQuotaLimitsOverriddenColumn(ctx context.Context, db *sql.DB) error {
+	var exists int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM information_schema.columns
+		WHERE table_schema = DATABASE() AND table_name = 'tenant_quota_config'
+		  AND column_name = 'quota_limits_overridden'`).Scan(&exists); err != nil {
+		return fmt.Errorf("inspect tenant_quota_config.quota_limits_overridden: %w", err)
+	}
+	if exists == 0 {
+		return nil
+	}
+	if _, err := db.ExecContext(ctx, `ALTER TABLE tenant_quota_config DROP COLUMN quota_limits_overridden`); err != nil && !isIgnorableMetaSchemaError(err) {
+		return fmt.Errorf("drop tenant_quota_config.quota_limits_overridden: %w", err)
+	}
+	return nil
+}
+
+func expandManagedDBPoolSchema(ctx context.Context, db *sql.DB) error {
+	nullableColumns := []struct {
+		name       string
+		definition string
+	}{
+		{name: "org_id", definition: "VARCHAR(64) NULL"},
+		{name: "db_host", definition: "VARCHAR(255) NULL"},
+		{name: "db_port", definition: "INT NULL"},
+		{name: "db_user", definition: "VARCHAR(255) NULL"},
+		{name: "db_password", definition: "VARBINARY(2048) NULL"},
+		{name: "db_name", definition: "VARCHAR(255) NULL"},
+	}
+	for _, column := range nullableColumns {
+		var nullable string
+		if err := db.QueryRowContext(ctx, `SELECT is_nullable
+			FROM information_schema.columns
+			WHERE table_schema = DATABASE() AND table_name = 'db_pool' AND column_name = ?`, column.name).Scan(&nullable); err != nil {
+			return fmt.Errorf("inspect db_pool.%s nullability: %w", column.name, err)
+		}
+		if nullable == "YES" {
+			continue
+		}
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("ALTER TABLE db_pool MODIFY COLUMN %s %s", column.name, column.definition)); err != nil {
+			return fmt.Errorf("make db_pool.%s nullable: %w", column.name, err)
+		}
+	}
+
+	var softCapColumnExists int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM information_schema.columns
+		WHERE table_schema = DATABASE() AND table_name = 'db_pool' AND column_name = 'soft_cap_reached'`).Scan(&softCapColumnExists); err != nil {
+		return fmt.Errorf("inspect db_pool.soft_cap_reached: %w", err)
+	}
+	if softCapColumnExists == 0 {
+		if _, err := db.ExecContext(ctx, `ALTER TABLE db_pool ADD COLUMN soft_cap_reached TINYINT(1) NOT NULL DEFAULT 0 AFTER tenant_count`); err != nil {
+			return fmt.Errorf("add db_pool.soft_cap_reached: %w", err)
+		}
+	}
+	// Only ever open the latch during migration. Do not clear a latched pool
+	// below the soft cap here; deletion owns the hysteresis transition.
+	if _, err := db.ExecContext(ctx, `UPDATE db_pool
+		SET soft_cap_reached = 1
+		WHERE max_tenants > 0 AND tenant_count >= max_tenants AND soft_cap_reached = 0`); err != nil {
+		return fmt.Errorf("backfill db_pool.soft_cap_reached: %w", err)
+	}
+
+	exists, err := metaIndexExists(ctx, db, "db_pool", "uk_db_pool_cloud_resource")
+	if err != nil {
+		return fmt.Errorf("check db_pool cloud resource unique index: %w", err)
+	}
+	if !exists {
+		var duplicateCount int
+		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM (
+			SELECT org_id, cluster_id
+			FROM db_pool
+			WHERE org_id IS NOT NULL AND cluster_id IS NOT NULL
+			GROUP BY org_id, cluster_id
+			HAVING COUNT(*) > 1
+		) duplicates`).Scan(&duplicateCount); err != nil {
+			return fmt.Errorf("preflight db_pool cloud resource unique index: %w", err)
+		}
+		if duplicateCount > 0 {
+			return fmt.Errorf("preflight db_pool cloud resource unique index: found %d duplicate cloud resource tuples", duplicateCount)
+		}
+		if _, err := db.ExecContext(ctx, `CREATE UNIQUE INDEX uk_db_pool_cloud_resource ON db_pool(org_id, cluster_id)`); err != nil && !isIgnorableMetaSchemaError(err) {
+			return fmt.Errorf("create db_pool cloud resource unique index: %w", err)
+		}
 	}
 	return nil
 }
@@ -558,27 +653,36 @@ func metaInitSchemaStatements() []string {
 		// database to a TiDB Cloud organization; the '*' wildcard row serves
 		// organizations without an exact entry. db_password holds the same
 		// encrypted envelope as tenants.db_password. tenant_count is maintained
-		// atomically with placement writes via ReserveSharedDBPlacement and
+		// atomically with placement writes via CompleteSharedTenantProvision and
 		// DeleteTenantPlacementAndDecrCount.
 		// The `role` column name is backtick-quoted because ROLE is a reserved
 		// word in MySQL 8.0.
 		`CREATE TABLE IF NOT EXISTS db_pool (
 			db_id        BIGINT AUTO_INCREMENT PRIMARY KEY,
-			org_id       VARCHAR(64) NOT NULL DEFAULT '',
+			org_id       VARCHAR(64) NULL,
+			cluster_id   VARCHAR(255) NULL,
+			provisioning_key VARBINARY(32) NULL,
+			cloud_provider VARCHAR(32) NULL,
+			region       VARCHAR(64) NULL,
 			` + "`role`" + `       VARCHAR(20) NOT NULL,
-			db_host      VARCHAR(255) NOT NULL,
-			db_port      INT NOT NULL,
-			db_user      VARCHAR(255) NOT NULL,
-			db_password  VARBINARY(2048) NOT NULL,
-			db_name      VARCHAR(255) NOT NULL,
+			db_host      VARCHAR(255) NULL,
+			db_port      INT NULL,
+			db_user      VARCHAR(255) NULL,
+			db_password  VARBINARY(2048) NULL,
+			db_name      VARCHAR(255) NULL,
 			db_tls       VARCHAR(32) NOT NULL DEFAULT '',
 			max_tenants  INT NOT NULL DEFAULT 0,
 			tenant_count INT NOT NULL DEFAULT 0,
+			soft_cap_reached TINYINT(1) NOT NULL DEFAULT 0,
+			spending_limit BIGINT NULL,
+			schema_version INT UNSIGNED NOT NULL DEFAULT 0,
 			status       VARCHAR(20) NOT NULL DEFAULT 'active',
 			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			UNIQUE INDEX uk_db_pool_cloud_resource (org_id, cluster_id),
 			UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host, db_name),
-			INDEX idx_db_pool_org (org_id, status)
+			INDEX idx_db_pool_allocate (org_id, status, db_id),
+			INDEX idx_db_pool_provisioning_key (provisioning_key, status, db_id)
 		)`,
 		// tenant_placements records which physical database (db_pool row) hosts
 		// each filesystem (fs_registry row). A missing row means the tenant
@@ -711,6 +815,17 @@ func metaInitSchemaStatements() []string {
 			UNIQUE INDEX uk_tidbcloud_pool_org (organization_id),
 			INDEX idx_tidbcloud_pool_status (status, created_at)
 		)`,
+		`CREATE TABLE IF NOT EXISTS tenant_pool_memberships (
+			tenant_id                    VARCHAR(64) PRIMARY KEY,
+			tidbcloud_organization_id    VARCHAR(64) NULL,
+			pool_id                      VARCHAR(64) NOT NULL,
+			pool_status                  VARCHAR(20) NOT NULL DEFAULT 'free',
+			used_at                      DATETIME(3) NULL,
+			created_at                   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			updated_at                   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			INDEX idx_tenant_pool_claim (pool_id, pool_status, created_at, tenant_id),
+			INDEX idx_tenant_pool_org_status (tidbcloud_organization_id, pool_status, pool_id, created_at, tenant_id)
+		)`,
 		`CREATE TABLE IF NOT EXISTS tenant_api_key_fs_scopes (
 			tenant_id   VARCHAR(64) NOT NULL,
 			api_key_id  VARCHAR(64) NOT NULL,
@@ -731,7 +846,6 @@ func metaInitSchemaStatements() []string {
 			max_media_llm_files   BIGINT NOT NULL DEFAULT 500,
 			max_video_llm_files   BIGINT NOT NULL DEFAULT 50,
 			max_monthly_cost_mc   BIGINT NOT NULL DEFAULT 0,
-			quota_limits_overridden TINYINT(1) NOT NULL DEFAULT 1,
 			tidbcloud_spending_limit BIGINT NULL,
 			tidbcloud_spending_limit_checked_at DATETIME(3) NULL,
 			created_at            DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
@@ -1695,9 +1809,12 @@ func (s *Store) UpsertTenantTiDBCloudOrgBinding(ctx context.Context, b *TenantTi
 	branchID := strings.TrimSpace(b.BranchID)
 	// tenants.branch_id is the source of truth; callers cannot override the
 	// branch dimension used for duplicate-ownership checks.
-	if tenantBranchID, ok, lookupErr := s.lookupTenantBranchID(ctx, tenantID); lookupErr != nil {
+	if tenantBranchID, tenantProvider, ok, lookupErr := s.lookupTenantBindingIdentity(ctx, tenantID); lookupErr != nil {
 		return lookupErr
 	} else if ok {
+		if tenantProvider == tidbCloudNativeSharedProvider {
+			return fmt.Errorf("shared tenant %q cannot own a dedicated tidbcloud org binding", tenantID)
+		}
 		branchID = tenantBranchID
 	}
 	now := time.Now().UTC()
@@ -1746,19 +1863,20 @@ func deleteStaleTiDBCloudOrgBindingConflicts(ctx context.Context, q metaQueryExe
 	return nil
 }
 
-func (s *Store) lookupTenantBranchID(ctx context.Context, tenantID string) (string, bool, error) {
-	var branchID sql.NullString
-	err := s.db.QueryRowContext(ctx, `SELECT branch_id FROM tenants WHERE id = ?`, tenantID).Scan(&branchID)
+func (s *Store) lookupTenantBindingIdentity(ctx context.Context, tenantID string) (branchID, provider string, ok bool, err error) {
+	var nullableBranchID sql.NullString
+	err = s.db.QueryRowContext(ctx, `SELECT branch_id, provider FROM tenants WHERE id = ?`, tenantID).
+		Scan(&nullableBranchID, &provider)
 	if errors.Is(err, sql.ErrNoRows) {
-		return "", false, nil
+		return "", "", false, nil
 	}
 	if err != nil {
-		return "", false, err
+		return "", "", false, err
 	}
-	if branchID.Valid {
-		return strings.TrimSpace(branchID.String), true, nil
+	if nullableBranchID.Valid {
+		return strings.TrimSpace(nullableBranchID.String), provider, true, nil
 	}
-	return "", true, nil
+	return "", provider, true, nil
 }
 
 func (s *Store) withTiDBCloudOrgBindingLock(ctx context.Context, organizationID, clusterID, branchID string, fn func(context.Context, metaQueryExecer) error) (err error) {
@@ -1960,6 +2078,11 @@ func (s *Store) countFreeTenantPoolBindingsByStatus(ctx context.Context, organiz
 	if err = row.Scan(&out); err != nil {
 		return 0, err
 	}
+	shared, err := s.CountFreeTenantPoolMemberships(ctx, organizationID, statuses)
+	if err != nil {
+		return 0, err
+	}
+	out += shared
 	return out, nil
 }
 
@@ -1978,20 +2101,25 @@ func (s *Store) CountTenantPoolBindingsByStatus(ctx context.Context) (out []Tena
 			UNION ALL
 			SELECT ? AS pool_status
 		) statuses
-		LEFT JOIN tenant_tidbcloud_org_bindings b
+		LEFT JOIN (
+			SELECT tenant_id, organization_id, pool_id, pool_status
+			FROM tenant_tidbcloud_org_bindings
+			UNION ALL
+			SELECT tenant_id, tidbcloud_organization_id AS organization_id, pool_id, pool_status
+			FROM tenant_pool_memberships
+		) b
 			ON b.pool_id = p.pool_id
 			AND b.organization_id = p.organization_id
 			AND b.pool_status = statuses.pool_status
 		LEFT JOIN tenants t
 			ON t.id = b.tenant_id
-			AND t.provider = ?
 			AND t.status <> ?
 		WHERE p.pool_id <> ''
 			AND p.organization_id IS NOT NULL
 			AND p.organization_id <> ''
 		GROUP BY p.pool_id, p.organization_id, statuses.pool_status
 		ORDER BY p.pool_id, p.organization_id, statuses.pool_status`,
-		TenantPoolBindingFree, TenantPoolBindingUsed, tidbCloudNativeProvider, TenantDeleted)
+		TenantPoolBindingFree, TenantPoolBindingUsed, TenantDeleted)
 	if err != nil {
 		return nil, fmt.Errorf("count tenant pool bindings by status query: %w", err)
 	}
@@ -2183,6 +2311,63 @@ func (s *Store) DeleteTenantPool(ctx context.Context, poolID string) (err error)
 		return ErrNotFound
 	}
 	return nil
+}
+
+func (s *Store) DetachUsedTenantPoolBindings(ctx context.Context, poolID string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE tenant_tidbcloud_org_bindings
+		SET pool_id = '', updated_at = ? WHERE pool_id = ? AND pool_status = ?`,
+		time.Now().UTC(), strings.TrimSpace(poolID), TenantPoolBindingUsed)
+	return err
+}
+
+// DeleteTenantPoolAndDetachUsedMembers atomically removes logical-pool
+// ownership from used native/shared members and deletes the logical pool row.
+func (s *Store) DeleteTenantPoolAndDetachUsedMembers(ctx context.Context, poolID string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_tenant_pool_and_detach_used_members", start, &err)
+	poolID = strings.TrimSpace(poolID)
+	if poolID == "" {
+		return fmt.Errorf("pool_id is required")
+	}
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		var freeTenantID string
+		if err := tx.QueryRowContext(ctx, `SELECT tenant_id FROM tenant_tidbcloud_org_bindings
+			WHERE pool_id = ? AND pool_status = ? LIMIT 1 FOR UPDATE`,
+			poolID, TenantPoolBindingFree).Scan(&freeTenantID); err == nil {
+			return fmt.Errorf("tenant pool %q still has free native member %q", poolID, freeTenantID)
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		if err := tx.QueryRowContext(ctx, `SELECT tenant_id FROM tenant_pool_memberships
+			WHERE pool_id = ? AND pool_status = ? LIMIT 1 FOR UPDATE`,
+			poolID, TenantPoolBindingFree).Scan(&freeTenantID); err == nil {
+			return fmt.Errorf("tenant pool %q still has free shared member %q", poolID, freeTenantID)
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+		now := time.Now().UTC()
+		if _, err := tx.ExecContext(ctx, `UPDATE tenant_tidbcloud_org_bindings
+			SET pool_id = '', updated_at = ? WHERE pool_id = ? AND pool_status = ?`,
+			now, poolID, TenantPoolBindingUsed); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM tenant_pool_memberships
+			WHERE pool_id = ? AND pool_status = ?`, poolID, TenantPoolBindingUsed); err != nil {
+			return err
+		}
+		res, err := tx.ExecContext(ctx, `DELETE FROM tenant_tidbcloud_pools WHERE pool_id = ?`, poolID)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
 }
 
 func (s *Store) UpdateTenantPoolBindingStatus(ctx context.Context, tenantID string, status TenantPoolBindingStatus, usedAt *time.Time) (err error) {
@@ -2458,6 +2643,58 @@ func (s *Store) WithTenantPoolLock(ctx context.Context, poolID string, fn func(c
 		}
 	}()
 
+	return fn(ctx)
+}
+
+// WithSharedDBAllocationLock serializes compact DB-pool selection and durable
+// pool planning for one TiDB Cloud organization or unresolved credential
+// fingerprint. It deliberately follows the existing tenant-pool named-lock
+// behavior, including holding the advisory lock across the callback's single
+// bounded Cloud call when a caller chooses to do so.
+func (s *Store) WithSharedDBAllocationLock(ctx context.Context, identity string, fn func(context.Context) error) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "shared_db_allocation_lock", start, &err)
+	if strings.TrimSpace(identity) == "" {
+		return fmt.Errorf("shared db allocation identity is required")
+	}
+	if fn == nil {
+		return fmt.Errorf("shared db allocation lock callback is required")
+	}
+	sum := sha256.Sum256([]byte(identity))
+	lockName := "d9_dbpool:" + hex.EncodeToString(sum[:20])
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	var databaseName sql.NullString
+	if err := conn.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&databaseName); err != nil {
+		return err
+	}
+	lockName = tenantPoolDatabaseLockName(lockName, databaseName.String)
+	var got sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, tenantPoolLockTimeoutSeconds).Scan(&got); err != nil {
+		return err
+	}
+	if !got.Valid {
+		return fmt.Errorf("shared db allocation named lock returned NULL")
+	}
+	if got.Int64 != 1 {
+		return fmt.Errorf("timed out waiting for shared db allocation named lock")
+	}
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), tenantPoolReleaseLockTimeout)
+		defer cancel()
+		var released sql.NullInt64
+		releaseErr := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&released)
+		if releaseErr != nil {
+			err = errors.Join(err, releaseErr)
+			return
+		}
+		if !released.Valid || released.Int64 != 1 {
+			err = errors.Join(err, fmt.Errorf("shared db allocation named lock was not held by current connection"))
+		}
+	}()
 	return fn(ctx)
 }
 

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1098,13 +1098,6 @@ func TestMetaSchemaSpecTracksPrimaryKeyConstraint(t *testing.T) {
 	if spendingLimit.addSQL != "ALTER TABLE tenant_quota_config ADD COLUMN tidbcloud_spending_limit BIGINT NULL" {
 		t.Fatalf("tidbcloud_spending_limit addSQL = %q", spendingLimit.addSQL)
 	}
-	quotaOverride, ok := table.columns["quota_limits_overridden"]
-	if !ok {
-		t.Fatal("tenant_quota_config schema missing quota_limits_overridden")
-	}
-	if quotaOverride.addSQL != "ALTER TABLE tenant_quota_config ADD COLUMN quota_limits_overridden TINYINT(1) NOT NULL DEFAULT 1" {
-		t.Fatalf("quota_limits_overridden addSQL = %q", quotaOverride.addSQL)
-	}
 	checkedAt, ok := table.columns["tidbcloud_spending_limit_checked_at"]
 	if !ok {
 		t.Fatal("tenant_quota_config schema missing tidbcloud_spending_limit_checked_at")
@@ -1364,6 +1357,124 @@ func TestMetaSchemaSpecIncludesTiDBCloudOrgBindings(t *testing.T) {
 	}
 }
 
+func TestMetaSchemaSpecIncludesManagedSharedDBControlPlane(t *testing.T) {
+	dbPool := mustMetaTableSpec(t, mustMetaSpec(t), "db_pool")
+	for _, column := range []string{
+		"db_id", "org_id", "cluster_id", "provisioning_key", "cloud_provider", "region",
+		"role", "db_host", "db_port", "db_user", "db_password", "db_name", "db_tls",
+		"max_tenants", "tenant_count", "soft_cap_reached", "spending_limit", "schema_version", "status",
+		"created_at", "updated_at",
+	} {
+		if _, ok := dbPool.columns[column]; !ok {
+			t.Fatalf("db_pool schema missing %s", column)
+		}
+	}
+	for _, index := range []string{
+		"primary", "uk_db_pool_cloud_resource", "uk_db_pool_endpoint",
+		"idx_db_pool_allocate", "idx_db_pool_provisioning_key",
+	} {
+		if _, ok := dbPool.indexes[index]; !ok {
+			t.Fatalf("db_pool schema missing index %s", index)
+		}
+	}
+
+	memberships := mustMetaTableSpec(t, mustMetaSpec(t), "tenant_pool_memberships")
+	for _, column := range []string{
+		"tenant_id", "tidbcloud_organization_id", "pool_id", "pool_status", "used_at", "created_at", "updated_at",
+	} {
+		if _, ok := memberships.columns[column]; !ok {
+			t.Fatalf("tenant_pool_memberships schema missing %s", column)
+		}
+	}
+	if _, ok := memberships.columns["organization_id"]; ok {
+		t.Fatal("tenant_pool_memberships must not use ambiguous organization_id column")
+	}
+	for _, index := range []string{"primary", "idx_tenant_pool_claim", "idx_tenant_pool_org_status"} {
+		if _, ok := memberships.indexes[index]; !ok {
+			t.Fatalf("tenant_pool_memberships schema missing index %s", index)
+		}
+	}
+}
+
+func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	if _, err := s.DB().ExecContext(ctx, `DROP TABLE db_pool`); err != nil {
+		t.Fatalf("drop current db_pool: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = s.DB().ExecContext(context.Background(), `DROP TABLE IF EXISTS db_pool`)
+		if err := s.migrate(); err != nil {
+			t.Errorf("restore current db_pool schema: %v", err)
+		}
+	})
+	if _, err := s.DB().ExecContext(ctx, `CREATE TABLE db_pool (
+		db_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+		org_id VARCHAR(64) NOT NULL DEFAULT '',
+		`+"`role`"+` VARCHAR(20) NOT NULL,
+		db_host VARCHAR(255) NOT NULL,
+		db_port INT NOT NULL,
+		db_user VARCHAR(255) NOT NULL,
+		db_password VARBINARY(2048) NOT NULL,
+		db_name VARCHAR(255) NOT NULL,
+		db_tls VARCHAR(32) NOT NULL DEFAULT '',
+		max_tenants INT NOT NULL DEFAULT 0,
+		tenant_count INT NOT NULL DEFAULT 0,
+		status VARCHAR(20) NOT NULL DEFAULT 'active',
+		created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+		UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host, db_name),
+		INDEX idx_db_pool_org (org_id, status)
+	)`); err != nil {
+		t.Fatalf("create legacy db_pool: %v", err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `INSERT INTO db_pool
+		(org_id, `+"`role`"+`, db_host, db_port, db_user, db_password, db_name, max_tenants)
+		VALUES ('org-legacy', 'shared', 'legacy.example.com', 4000, 'root', X'01', 'legacy_db', 2)`); err != nil {
+		t.Fatalf("insert legacy db_pool row: %v", err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET tenant_count = 2 WHERE org_id = 'org-legacy'`); err != nil {
+		t.Fatalf("fill legacy db_pool row: %v", err)
+	}
+
+	if err := s.migrate(); err != nil {
+		t.Fatalf("migrate legacy db_pool: %v", err)
+	}
+
+	for _, column := range []string{"org_id", "db_host", "db_port", "db_user", "db_password", "db_name"} {
+		var nullable string
+		if err := s.DB().QueryRowContext(ctx, `SELECT is_nullable
+			FROM information_schema.columns
+			WHERE table_schema = DATABASE() AND table_name = 'db_pool' AND column_name = ?`, column).Scan(&nullable); err != nil {
+			t.Fatalf("load db_pool.%s nullability: %v", column, err)
+		}
+		if nullable != "YES" {
+			t.Fatalf("db_pool.%s is_nullable = %q, want YES", column, nullable)
+		}
+	}
+	for _, index := range []string{"uk_db_pool_cloud_resource", "idx_db_pool_allocate", "idx_db_pool_provisioning_key"} {
+		exists, err := metaIndexExists(ctx, s.DB(), "db_pool", index)
+		if err != nil {
+			t.Fatalf("check %s: %v", index, err)
+		}
+		if !exists {
+			t.Fatalf("db_pool index %s was not created", index)
+		}
+	}
+	var status string
+	var softCapReached bool
+	var spendingLimit *int64
+	if err := s.DB().QueryRowContext(ctx, `SELECT status, spending_limit, soft_cap_reached FROM db_pool WHERE org_id = 'org-legacy'`).Scan(&status, &spendingLimit, &softCapReached); err != nil {
+		t.Fatalf("load migrated legacy row: %v", err)
+	}
+	if status != "active" || spendingLimit != nil {
+		t.Fatalf("legacy row status/spending_limit = %q/%v, want active/NULL", status, spendingLimit)
+	}
+	if !softCapReached {
+		t.Fatal("legacy row at max_tenants must be backfilled with soft_cap_reached=true")
+	}
+}
+
 func TestUpsertTenantTiDBCloudOrgBindingRejectsDuplicateLiveClusterBranch(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
@@ -1388,6 +1499,23 @@ func TestUpsertTenantTiDBCloudOrgBindingRejectsDuplicateLiveClusterBranch(t *tes
 	})
 	if !errors.Is(err, ErrDuplicate) {
 		t.Fatalf("duplicate cluster branch upsert err = %v, want ErrDuplicate", err)
+	}
+}
+
+func TestUpsertTenantTiDBCloudOrgBindingRejectsSharedTenant(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	insertTiDBCloudBindingTenant(t, s, "binding-shared-tenant", TenantKindLive, TenantActive, "", "", now)
+	if err := s.UpdateTenantProvider(ctx, "binding-shared-tenant", "tidb_cloud_native_shared"); err != nil {
+		t.Fatalf("mark tenant shared: %v", err)
+	}
+	err := s.UpsertTenantTiDBCloudOrgBinding(ctx, &TenantTiDBCloudOrgBinding{
+		TenantID: "binding-shared-tenant", OrganizationID: "org-shared",
+		ClusterID: "cluster-shared", CreatedAt: now, UpdatedAt: now,
+	})
+	if err == nil || !strings.Contains(err.Error(), "shared tenant") {
+		t.Fatalf("shared binding error = %v, want shared tenant rejection", err)
 	}
 }
 
@@ -1713,7 +1841,6 @@ func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
 			"max_media_llm_files":                 {columnType: "bigint"},
 			"max_video_llm_files":                 {columnType: "bigint"},
 			"max_monthly_cost_mc":                 {columnType: "bigint"},
-			"quota_limits_overridden":             {columnType: "tinyint(1)"},
 			"tidbcloud_spending_limit":            {columnType: "bigint"},
 			"tidbcloud_spending_limit_checked_at": {columnType: "datetime(3)"},
 			"created_at":                          {columnType: "datetime(3)"},
@@ -1728,7 +1855,6 @@ func TestDiffMetaTableMetaReportsMissingPrimaryKeyConstraint(t *testing.T) {
 		max_media_llm_files BIGINT NOT NULL,
 		max_video_llm_files BIGINT NOT NULL,
 		max_monthly_cost_mc BIGINT NOT NULL,
-		quota_limits_overridden TINYINT(1) NOT NULL DEFAULT 1,
 		tidbcloud_spending_limit BIGINT NULL,
 		tidbcloud_spending_limit_checked_at DATETIME(3) NULL,
 		created_at DATETIME(3) NOT NULL,

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -29,12 +29,9 @@ type QuotaConfig struct {
 	MaxStorageBytes  int64
 	MaxFileSizeBytes int64
 	MaxFileCount     int64 // 0 = unlimited
-	MaxMediaLLMFiles  int64
-	MaxVideoLLMFiles  int64
-	MaxMonthlyCostMC  int64 // millicents; 0 = disabled
-	// QuotaLimitsOverridden tracks whether storage/file quota columns should
-	// override process defaults. Spending-limit-only rows keep this false.
-	QuotaLimitsOverridden bool
+	MaxMediaLLMFiles int64
+	MaxVideoLLMFiles int64
+	MaxMonthlyCostMC int64 // millicents; 0 = disabled
 	// TiDBCloudSpendingLimit is nullable because existing tenants may not have
 	// been backfilled from TiDB Cloud yet; 0 is a valid explicit spending limit.
 	TiDBCloudSpendingLimit          *int64
@@ -70,12 +67,6 @@ func (p QuotaConfigPatch) AnySet() bool {
 		p.MaxFileCount != nil ||
 		p.TiDBCloudSpendingLimit != nil ||
 		p.TiDBCloudSpendingLimitCheckedAt != nil
-}
-
-func (p QuotaConfigPatch) quotaLimitOverrideSet() bool {
-	return p.MaxStorageBytes != nil ||
-		p.MaxFileSizeBytes != nil ||
-		p.MaxFileCount != nil
 }
 
 // FileMeta tracks per-file quota-relevant metadata in the server DB.
@@ -149,15 +140,14 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 	cfg := &QuotaConfig{TenantID: tenantID}
 	var spendingLimit sql.NullInt64
 	var checkedAt sql.NullTime
-	var quotaOverridden bool
 	err = s.db.QueryRowContext(ctx,
 		`SELECT max_storage_bytes, max_file_size_bytes, max_file_count,
-		        max_media_llm_files, max_video_llm_files, max_monthly_cost_mc, quota_limits_overridden,
+		        max_media_llm_files, max_video_llm_files, max_monthly_cost_mc,
 		        tidbcloud_spending_limit, tidbcloud_spending_limit_checked_at,
 		        created_at, updated_at
 		 FROM tenant_quota_config WHERE tenant_id = ?`, tenantID,
 	).Scan(&cfg.MaxStorageBytes, &cfg.MaxFileSizeBytes, &cfg.MaxFileCount,
-		&cfg.MaxMediaLLMFiles, &cfg.MaxVideoLLMFiles, &cfg.MaxMonthlyCostMC, &quotaOverridden,
+		&cfg.MaxMediaLLMFiles, &cfg.MaxVideoLLMFiles, &cfg.MaxMonthlyCostMC,
 		&spendingLimit, &checkedAt, &cfg.CreatedAt, &cfg.UpdatedAt)
 	if err == sql.ErrNoRows {
 		cfg.MaxStorageBytes = DefaultMaxStorageBytes()
@@ -171,7 +161,6 @@ func (s *Store) GetQuotaConfig(ctx context.Context, tenantID string) (*QuotaConf
 	if err != nil {
 		return nil, err
 	}
-	cfg.QuotaLimitsOverridden = quotaOverridden
 	if cfg.MaxFileSizeBytes <= 0 {
 		cfg.MaxFileSizeBytes = DefaultMaxFileSizeBytes()
 	}
@@ -217,9 +206,9 @@ func (s *Store) SetQuotaConfig(ctx context.Context, cfg *QuotaConfig) error {
 
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
-		                                  max_media_llm_files, max_video_llm_files, max_monthly_cost_mc, quota_limits_overridden,
+		                                  max_media_llm_files, max_video_llm_files, max_monthly_cost_mc,
 		                                  tidbcloud_spending_limit, tidbcloud_spending_limit_checked_at)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 		 ON DUPLICATE KEY UPDATE
 		   max_storage_bytes = VALUES(max_storage_bytes),
 		   max_file_size_bytes = VALUES(max_file_size_bytes),
@@ -227,11 +216,10 @@ func (s *Store) SetQuotaConfig(ctx context.Context, cfg *QuotaConfig) error {
 		   max_media_llm_files = VALUES(max_media_llm_files),
 		   max_video_llm_files = VALUES(max_video_llm_files),
 		   max_monthly_cost_mc = VALUES(max_monthly_cost_mc),
-		   quota_limits_overridden = VALUES(quota_limits_overridden),
 		   tidbcloud_spending_limit = VALUES(tidbcloud_spending_limit),
 		   tidbcloud_spending_limit_checked_at = VALUES(tidbcloud_spending_limit_checked_at)`,
 		cfg.TenantID, cfg.MaxStorageBytes, cfg.MaxFileSizeBytes, cfg.MaxFileCount,
-		cfg.MaxMediaLLMFiles, cfg.MaxVideoLLMFiles, cfg.MaxMonthlyCostMC, true,
+		cfg.MaxMediaLLMFiles, cfg.MaxVideoLLMFiles, cfg.MaxMonthlyCostMC,
 		nullInt64FromPtr(cfg.TiDBCloudSpendingLimit), nullTimeFromPtr(cfg.TiDBCloudSpendingLimitCheckedAt))
 	return err
 }
@@ -245,12 +233,13 @@ func (s *Store) SetQuotaStorageBytes(ctx context.Context, tenantID string, maxSt
 	defer observeMeta(ctx, "set_quota_storage_bytes", start, &err)
 
 	_, err = s.db.ExecContext(ctx,
-		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, quota_limits_overridden)
-		 VALUES (?, ?, 1)
+		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes,
+		                                  max_media_llm_files, max_video_llm_files)
+		 VALUES (?, ?, ?, ?, ?)
 		 ON DUPLICATE KEY UPDATE
-		   max_storage_bytes = VALUES(max_storage_bytes),
-		   quota_limits_overridden = 1`,
-		tenantID, maxStorageBytes)
+		   max_storage_bytes = VALUES(max_storage_bytes)`,
+		tenantID, maxStorageBytes, DefaultMaxFileSizeBytes(),
+		DefaultMaxMediaLLMFiles(), DefaultMaxVideoLLMFiles())
 	if err != nil {
 		return fmt.Errorf("set quota storage bytes for tenant %q: %w", tenantID, err)
 	}
@@ -264,12 +253,11 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 	var err error
 	defer observeMeta(ctx, "set_quota_config_patch", start, &err)
 
-	quotaLimitOverrideSet := patch.quotaLimitOverrideSet()
 	insertStorage := DefaultMaxStorageBytes()
 	if patch.MaxStorageBytes != nil {
 		insertStorage = *patch.MaxStorageBytes
 	}
-	insertFileSize := int64(0)
+	insertFileSize := DefaultMaxFileSizeBytes()
 	if patch.MaxFileSizeBytes != nil {
 		insertFileSize = *patch.MaxFileSizeBytes
 	}
@@ -297,24 +285,114 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 	updateCheckedAt := nullTimeFromPtr(patch.TiDBCloudSpendingLimitCheckedAt)
 	_, err = s.db.ExecContext(ctx,
 		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
-		                                  quota_limits_overridden, tidbcloud_spending_limit,
+		                                  tidbcloud_spending_limit,
 		                                  tidbcloud_spending_limit_checked_at, max_media_llm_files, max_video_llm_files)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 			 ON DUPLICATE KEY UPDATE
 			   max_storage_bytes = COALESCE(?, max_storage_bytes),
 			   max_file_size_bytes = COALESCE(?, max_file_size_bytes),
 			   max_file_count = COALESCE(?, max_file_count),
-			   /* Storage quota overrides are sticky once any storage/file limit is explicitly set. */
-			   quota_limits_overridden = IF(?, 1, quota_limits_overridden),
 			   tidbcloud_spending_limit = COALESCE(?, tidbcloud_spending_limit),
 			   tidbcloud_spending_limit_checked_at = COALESCE(?, tidbcloud_spending_limit_checked_at)`,
-		tenantID, insertStorage, insertFileSize, insertFileCount, quotaLimitOverrideSet, insertSpendingLimit, insertCheckedAt,
-			insertMediaLLM, insertVideoLLM,
-		updateStorage, updateFileSize, updateFileCount, quotaLimitOverrideSet, updateSpendingLimit, updateCheckedAt)
+		tenantID, insertStorage, insertFileSize, insertFileCount, insertSpendingLimit, insertCheckedAt,
+		insertMediaLLM, insertVideoLLM,
+		updateStorage, updateFileSize, updateFileCount, updateSpendingLimit, updateCheckedAt)
 	if err != nil {
 		return fmt.Errorf("set quota config patch for tenant %q: %w", tenantID, err)
 	}
 	return nil
+}
+
+// UpdateSharedTenantQuotaConfig atomically applies the externally writable
+// quota fields for a placed shared tenant. For a managed DB pool it locks the
+// physical pool, computes the exact prospective virtual spending-limit sum,
+// and rejects the entire patch when the fixed target has no headroom.
+func (s *Store) UpdateSharedTenantQuotaConfig(ctx context.Context, tenantID string, patch QuotaConfigPatch) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "update_shared_tenant_quota_config", start, &err)
+	if strings.TrimSpace(tenantID) == "" {
+		return fmt.Errorf("tenant id is required")
+	}
+	if !patch.AnySet() {
+		return nil
+	}
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		var dbID int64
+		var poolSpendingLimit sql.NullInt64
+		if scanErr := tx.QueryRowContext(ctx, `SELECT d.db_id, d.spending_limit
+			FROM tenants t
+			JOIN fs_registry f ON f.tenant_id = t.id
+			JOIN tenant_placements p ON p.fs_id = f.fs_id
+			JOIN db_pool d ON d.db_id = p.db_id
+			WHERE t.id = ? AND t.provider = ? AND p.status = ?
+			FOR UPDATE`, tenantID, "tidb_cloud_native_shared", SharedDBStatusActive).
+			Scan(&dbID, &poolSpendingLimit); scanErr != nil {
+			if errors.Is(scanErr, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("lock shared tenant placement: %w", scanErr)
+		}
+		var maxStorage, maxFileSize, maxFileCount int64
+		var currentSpending sql.NullInt64
+		var checkedAt sql.NullTime
+		if scanErr := tx.QueryRowContext(ctx, `SELECT max_storage_bytes, max_file_size_bytes,
+			max_file_count, tidbcloud_spending_limit, tidbcloud_spending_limit_checked_at
+			FROM tenant_quota_config WHERE tenant_id = ? FOR UPDATE`, tenantID).
+			Scan(&maxStorage, &maxFileSize, &maxFileCount, &currentSpending, &checkedAt); scanErr != nil {
+			if errors.Is(scanErr, sql.ErrNoRows) {
+				return ErrSharedDBQuotaNotMaterialized
+			}
+			return fmt.Errorf("lock shared tenant quota: %w", scanErr)
+		}
+		if !currentSpending.Valid {
+			return ErrSharedDBQuotaNotMaterialized
+		}
+		nextSpending := currentSpending.Int64
+		if patch.TiDBCloudSpendingLimit != nil {
+			nextSpending = *patch.TiDBCloudSpendingLimit
+		}
+		if poolSpendingLimit.Valid && nextSpending > currentSpending.Int64 {
+			var currentSum int64
+			if sumErr := tx.QueryRowContext(ctx, `SELECT COALESCE(SUM(q.tidbcloud_spending_limit), 0)
+				FROM tenant_placements p
+				JOIN fs_registry f ON f.fs_id = p.fs_id
+				JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id
+				WHERE p.db_id = ?`, dbID).Scan(&currentSum); sumErr != nil {
+				return fmt.Errorf("sum shared tenant spending limits: %w", sumErr)
+			}
+			prospective := currentSum - currentSpending.Int64 + nextSpending
+			if prospective < 0 || prospective > int64(1<<31-1) || prospective >= poolSpendingLimit.Int64 {
+				return ErrSharedDBSpendingLimitExceeded
+			}
+		}
+		if patch.MaxStorageBytes != nil {
+			maxStorage = *patch.MaxStorageBytes
+		}
+		if patch.MaxFileSizeBytes != nil {
+			maxFileSize = *patch.MaxFileSizeBytes
+		}
+		if patch.MaxFileCount != nil {
+			maxFileCount = *patch.MaxFileCount
+		}
+		if patch.TiDBCloudSpendingLimitCheckedAt != nil {
+			checkedAt = sql.NullTime{Time: patch.TiDBCloudSpendingLimitCheckedAt.UTC(), Valid: true}
+		}
+		res, updateErr := tx.ExecContext(ctx, `UPDATE tenant_quota_config
+			SET max_storage_bytes = ?, max_file_size_bytes = ?, max_file_count = ?,
+				tidbcloud_spending_limit = ?, tidbcloud_spending_limit_checked_at = ?
+			WHERE tenant_id = ?`, maxStorage, maxFileSize, maxFileCount, nextSpending, checkedAt, tenantID)
+		if updateErr != nil {
+			return fmt.Errorf("update shared tenant quota: %w", updateErr)
+		}
+		affected, rowsErr := res.RowsAffected()
+		if rowsErr != nil {
+			return rowsErr
+		}
+		if affected == 0 {
+			return ErrNotFound
+		}
+		return nil
+	})
 }
 
 // SetTiDBCloudSpendingLimitIfNotUpdatedAfter stores a TiDB Cloud spending-limit
@@ -339,14 +417,14 @@ func (s *Store) SetTiDBCloudSpendingLimitIfNotUpdatedAfter(ctx context.Context, 
 	observedCutoff := observedAt.UTC().Truncate(time.Millisecond)
 	res, err := s.db.ExecContext(ctx,
 		`INSERT INTO tenant_quota_config (tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
-		                                  quota_limits_overridden, tidbcloud_spending_limit,
+		                                  tidbcloud_spending_limit,
 		                                  tidbcloud_spending_limit_checked_at, max_media_llm_files, max_video_llm_files)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 		 ON DUPLICATE KEY UPDATE
 		   tidbcloud_spending_limit = IF(updated_at < ?, VALUES(tidbcloud_spending_limit), tidbcloud_spending_limit),
 		   tidbcloud_spending_limit_checked_at = IF(updated_at < ?, VALUES(tidbcloud_spending_limit_checked_at), tidbcloud_spending_limit_checked_at)`,
-		tenantID, DefaultMaxStorageBytes(), int64(0), int64(0), false, sql.NullInt64{Int64: limit, Valid: true}, sql.NullTime{Time: checkedAt, Valid: true},
-			DefaultMaxMediaLLMFiles(), DefaultMaxVideoLLMFiles(),
+		tenantID, DefaultMaxStorageBytes(), DefaultMaxFileSizeBytes(), int64(0), sql.NullInt64{Int64: limit, Valid: true}, sql.NullTime{Time: checkedAt, Valid: true},
+		DefaultMaxMediaLLMFiles(), DefaultMaxVideoLLMFiles(),
 		observedCutoff, observedCutoff)
 	if err != nil {
 		return false, fmt.Errorf("set tidbcloud spending limit for tenant %q: %w", tenantID, err)
@@ -396,12 +474,6 @@ func (s *Store) CopyQuotaConfig(ctx context.Context, sourceTenantID, destTenantI
 	cfg, err := s.GetQuotaConfig(ctx, sourceTenantID)
 	if err != nil {
 		return err
-	}
-	if !cfg.QuotaLimitsOverridden {
-		return s.SetQuotaConfigPatch(ctx, destTenantID, QuotaConfigPatch{
-			TiDBCloudSpendingLimit:          cfg.TiDBCloudSpendingLimit,
-			TiDBCloudSpendingLimitCheckedAt: cfg.TiDBCloudSpendingLimitCheckedAt,
-		})
 	}
 	cfg.TenantID = destTenantID
 	return s.SetQuotaConfig(ctx, cfg)
@@ -705,12 +777,12 @@ func (s *Store) atomicReserveAndInsertUploadOnce(ctx context.Context, r *UploadR
 			     file_count = file_count + ?
 			 WHERE tenant_id = ?
 			   AND storage_bytes + reserved_bytes + ? <=
-			       COALESCE((SELECT CASE WHEN quota_limits_overridden THEN max_storage_bytes ELSE NULL END
+			       COALESCE((SELECT max_storage_bytes
 			                 FROM tenant_quota_config WHERE tenant_id = ?), ?)
 			   AND (? <= 0 OR
-			        COALESCE((SELECT CASE WHEN quota_limits_overridden THEN max_file_count ELSE NULL END
+			        COALESCE((SELECT max_file_count
 			                  FROM tenant_quota_config WHERE tenant_id = ?), 0) <= 0 OR
-			        file_count + ? <= COALESCE((SELECT CASE WHEN quota_limits_overridden THEN max_file_count ELSE NULL END
+			        file_count + ? <= COALESCE((SELECT max_file_count
 			                                    FROM tenant_quota_config WHERE tenant_id = ?), 0))`,
 			r.ReservedBytes, r.FileCountDelta, r.TenantID, r.ReservedBytes, r.TenantID, DefaultMaxStorageBytes(),
 			r.FileCountDelta, r.TenantID, r.FileCountDelta, r.TenantID)
@@ -800,21 +872,20 @@ func (s *Store) uploadReservationQuotaErrorTx(ctx context.Context, tx *sql.Tx, r
 		return nil
 	}
 	var maxStorageBytes, maxFileCount sql.NullInt64
-	var quotaLimitsOverridden bool
 	if err := tx.QueryRowContext(ctx,
-		`SELECT max_storage_bytes, max_file_count, quota_limits_overridden
+		`SELECT max_storage_bytes, max_file_count
 		 FROM tenant_quota_config WHERE tenant_id = ?`, r.TenantID,
-	).Scan(&maxStorageBytes, &maxFileCount, &quotaLimitsOverridden); err != nil && !errors.Is(err, sql.ErrNoRows) {
+	).Scan(&maxStorageBytes, &maxFileCount); err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return nil
 	}
 	storageLimit := DefaultMaxStorageBytes()
-	if quotaLimitsOverridden && maxStorageBytes.Valid {
+	if maxStorageBytes.Valid {
 		storageLimit = maxStorageBytes.Int64
 	}
 	if storageLimit > 0 && storageBytes+reservedBytes+r.ReservedBytes > storageLimit {
 		return ErrStorageQuotaExceeded
 	}
-	if r.FileCountDelta > 0 && quotaLimitsOverridden && maxFileCount.Valid && maxFileCount.Int64 > 0 && fileCount+r.FileCountDelta > maxFileCount.Int64 {
+	if r.FileCountDelta > 0 && maxFileCount.Valid && maxFileCount.Int64 > 0 && fileCount+r.FileCountDelta > maxFileCount.Int64 {
 		return ErrFileCountQuotaExceeded
 	}
 	return nil

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -88,6 +88,9 @@ func TestGetQuotaConfigUsesConfiguredDefaultStorageBytes(t *testing.T) {
 }
 
 func TestQuotaConfigStoresTiDBCloudSpendingLimitWithoutStorageVersion(t *testing.T) {
+	originalFileSizeDefault := DefaultMaxFileSizeBytes()
+	defer SetDefaultMaxFileSizeBytes(originalFileSizeDefault)
+
 	s := newControlStore(t)
 	ctx := context.Background()
 
@@ -113,8 +116,13 @@ func TestQuotaConfigStoresTiDBCloudSpendingLimitWithoutStorageVersion(t *testing
 	if cfg.MaxStorageBytes != DefaultMaxStorageBytes() || cfg.MaxFileSizeBytes != DefaultMaxFileSizeBytes() || cfg.MaxFileCount != 0 {
 		t.Fatalf("storage quota fields = %#v, want defaults", cfg)
 	}
-	if cfg.QuotaLimitsOverridden {
-		t.Fatalf("QuotaLimitsOverridden = true, want false for spending-only row")
+	SetDefaultMaxFileSizeBytes(originalFileSizeDefault + 1)
+	cfg, err = s.GetQuotaConfig(ctx, "tenant-spending-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MaxFileSizeBytes != originalFileSizeDefault {
+		t.Fatalf("materialized MaxFileSizeBytes = %d after default changed, want %d", cfg.MaxFileSizeBytes, originalFileSizeDefault)
 	}
 	version, err := s.GetQuotaConfigVersion(ctx, "tenant-spending-only")
 	if err != nil {
@@ -146,8 +154,25 @@ func TestQuotaConfigStoresTiDBCloudSpendingLimitWithoutStorageVersion(t *testing
 	if cfg.TiDBCloudSpendingLimitCheckedAt == nil {
 		t.Fatal("spending limit checked_at = nil, want timestamp")
 	}
-	if cfg.QuotaLimitsOverridden {
-		t.Fatalf("QuotaLimitsOverridden after checked_at = true, want false")
+}
+
+func TestGetQuotaConfigUsesDefaultFileSizeForExistingZeroRow(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	if _, err := s.DB().ExecContext(ctx, `INSERT INTO tenant_quota_config
+		(tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count,
+		 max_media_llm_files, max_video_llm_files, max_monthly_cost_mc)
+		VALUES (?, ?, 0, 0, ?, ?, 0)`, "tenant-zero-file-size", DefaultMaxStorageBytes(),
+		DefaultMaxMediaLLMFiles(), DefaultMaxVideoLLMFiles()); err != nil {
+		t.Fatalf("insert quota row: %v", err)
+	}
+
+	cfg, err := s.GetQuotaConfig(ctx, "tenant-zero-file-size")
+	if err != nil {
+		t.Fatalf("GetQuotaConfig: %v", err)
+	}
+	if cfg.MaxFileSizeBytes != DefaultMaxFileSizeBytes() {
+		t.Fatalf("MaxFileSizeBytes = %d, want default %d", cfg.MaxFileSizeBytes, DefaultMaxFileSizeBytes())
 	}
 }
 
@@ -236,7 +261,7 @@ func TestSetQuotaStorageBytesInsertsInternalDefaults(t *testing.T) {
 	}
 }
 
-func TestSetQuotaStorageBytesOverridesSpendingOnlyRow(t *testing.T) {
+func TestSetQuotaStorageBytesPreservesSpendingOnlyRowValue(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 
@@ -244,26 +269,15 @@ func TestSetQuotaStorageBytesOverridesSpendingOnlyRow(t *testing.T) {
 	if err := s.SetQuotaConfigPatch(ctx, "tenant-spending-then-storage", QuotaConfigPatch{TiDBCloudSpendingLimit: &spendingLimit}); err != nil {
 		t.Fatal(err)
 	}
-	cfg, err := s.GetQuotaConfig(ctx, "tenant-spending-then-storage")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if cfg.QuotaLimitsOverridden {
-		t.Fatal("QuotaLimitsOverridden after spending-only patch = true, want false")
-	}
-
 	if err := s.SetQuotaStorageBytes(ctx, "tenant-spending-then-storage", 12345); err != nil {
 		t.Fatal(err)
 	}
-	cfg, err = s.GetQuotaConfig(ctx, "tenant-spending-then-storage")
+	cfg, err := s.GetQuotaConfig(ctx, "tenant-spending-then-storage")
 	if err != nil {
 		t.Fatal(err)
 	}
 	if cfg.MaxStorageBytes != 12345 {
 		t.Fatalf("MaxStorageBytes = %d, want 12345", cfg.MaxStorageBytes)
-	}
-	if !cfg.QuotaLimitsOverridden {
-		t.Fatal("QuotaLimitsOverridden = false, want true after storage override")
 	}
 	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != spendingLimit {
 		t.Fatalf("TiDBCloudSpendingLimit = %#v, want %d", cfg.TiDBCloudSpendingLimit, spendingLimit)

--- a/pkg/meta/tenant_pool_membership.go
+++ b/pkg/meta/tenant_pool_membership.go
@@ -1,0 +1,424 @@
+package meta
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// TenantPoolMembership is the shared-provider membership record for the
+// provider-agnostic logical tenant pool. Native membership remains in
+// tenant_tidbcloud_org_bindings.
+type TenantPoolMembership struct {
+	TenantID                string
+	TiDBCloudOrganizationID string
+	PoolID                  string
+	PoolStatus              TenantPoolBindingStatus
+	UsedAt                  *time.Time
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
+}
+
+type TenantWithPoolMembership struct {
+	Tenant     Tenant
+	Membership TenantPoolMembership
+}
+
+func (s *Store) UpsertTenantPoolMembership(ctx context.Context, membership *TenantPoolMembership) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "upsert_tenant_pool_membership", start, &err)
+	if membership == nil {
+		return fmt.Errorf("tenant pool membership is required")
+	}
+	if strings.TrimSpace(membership.TenantID) == "" {
+		return fmt.Errorf("tenant_id is required")
+	}
+	if strings.TrimSpace(membership.PoolID) == "" {
+		return fmt.Errorf("pool_id is required")
+	}
+	status := membership.PoolStatus
+	if status == "" {
+		status = TenantPoolBindingFree
+	}
+	if status != TenantPoolBindingFree && status != TenantPoolBindingUsed {
+		return fmt.Errorf("unsupported tenant pool membership status %q", status)
+	}
+	createdAt := membership.CreatedAt
+	if createdAt.IsZero() {
+		createdAt = time.Now().UTC()
+	}
+	updatedAt := membership.UpdatedAt
+	if updatedAt.IsZero() {
+		updatedAt = createdAt
+	}
+	var organizationID any
+	if strings.TrimSpace(membership.TiDBCloudOrganizationID) != "" {
+		organizationID = strings.TrimSpace(membership.TiDBCloudOrganizationID)
+	}
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		var provider string
+		if err := tx.QueryRowContext(ctx, `SELECT provider FROM tenants WHERE id = ? FOR UPDATE`,
+			membership.TenantID).Scan(&provider); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("lock tenant for pool membership %s: %w", membership.TenantID, err)
+		}
+		if provider != tidbCloudNativeSharedProvider {
+			return fmt.Errorf("tenant %q with provider %q cannot use shared pool membership",
+				membership.TenantID, provider)
+		}
+		var dedicatedBindingCount int
+		if err := tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM tenant_tidbcloud_org_bindings
+			WHERE tenant_id = ?`, membership.TenantID).Scan(&dedicatedBindingCount); err != nil {
+			return err
+		}
+		if dedicatedBindingCount != 0 {
+			return fmt.Errorf("tenant %q already has a dedicated tidbcloud org binding", membership.TenantID)
+		}
+		var existingOrganizationID sql.NullString
+		lookupErr := tx.QueryRowContext(ctx, `SELECT tidbcloud_organization_id FROM tenant_pool_memberships
+			WHERE tenant_id = ? FOR UPDATE`, membership.TenantID).Scan(&existingOrganizationID)
+		if errors.Is(lookupErr, sql.ErrNoRows) {
+			_, insertErr := tx.ExecContext(ctx, `INSERT INTO tenant_pool_memberships
+				(tenant_id, tidbcloud_organization_id, pool_id, pool_status, used_at, created_at, updated_at)
+				VALUES (?, ?, ?, ?, ?, ?, ?)`, membership.TenantID, organizationID, membership.PoolID,
+				status, membership.UsedAt, createdAt, updatedAt)
+			if insertErr != nil {
+				return fmt.Errorf("insert tenant pool membership for %s: %w", membership.TenantID, insertErr)
+			}
+			return nil
+		}
+		if lookupErr != nil {
+			return fmt.Errorf("lock tenant pool membership for %s: %w", membership.TenantID, lookupErr)
+		}
+		incomingOrganizationID := strings.TrimSpace(membership.TiDBCloudOrganizationID)
+		if existingOrganizationID.Valid && existingOrganizationID.String != "" && incomingOrganizationID != "" &&
+			existingOrganizationID.String != incomingOrganizationID {
+			return fmt.Errorf("tenant pool membership organization is immutable: have %q, got %q",
+				existingOrganizationID.String, incomingOrganizationID)
+		}
+		if existingOrganizationID.Valid && existingOrganizationID.String != "" {
+			organizationID = existingOrganizationID.String
+		}
+		_, updateErr := tx.ExecContext(ctx, `UPDATE tenant_pool_memberships
+			SET tidbcloud_organization_id = ?, pool_id = ?, pool_status = ?, used_at = ?, updated_at = ?
+			WHERE tenant_id = ?`, organizationID, membership.PoolID, status, membership.UsedAt,
+			updatedAt, membership.TenantID)
+		if updateErr != nil {
+			return fmt.Errorf("update tenant pool membership for %s: %w", membership.TenantID, updateErr)
+		}
+		return nil
+	})
+}
+
+func (s *Store) GetTenantPoolMembership(ctx context.Context, tenantID string) (membership *TenantPoolMembership, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "get_tenant_pool_membership", start, &err)
+	membership = &TenantPoolMembership{}
+	var organizationID sql.NullString
+	var usedAt sql.NullTime
+	err = s.db.QueryRowContext(ctx, `SELECT tenant_id, tidbcloud_organization_id, pool_id, pool_status,
+		used_at, created_at, updated_at FROM tenant_pool_memberships WHERE tenant_id = ?`, tenantID).
+		Scan(&membership.TenantID, &organizationID, &membership.PoolID, &membership.PoolStatus,
+			&usedAt, &membership.CreatedAt, &membership.UpdatedAt)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get tenant pool membership for %s: %w", tenantID, err)
+	}
+	membership.TiDBCloudOrganizationID = organizationID.String
+	if usedAt.Valid {
+		t := usedAt.Time
+		membership.UsedAt = &t
+	}
+	return membership, nil
+}
+
+func (s *Store) ClaimTenantPoolMembership(ctx context.Context, tenantID, poolID string, usedAt time.Time) (claimed bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "claim_tenant_pool_membership", start, &err)
+	if usedAt.IsZero() {
+		usedAt = time.Now().UTC()
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE tenant_pool_memberships
+		SET pool_status = ?, used_at = ?, updated_at = ?
+		WHERE tenant_id = ? AND pool_id = ? AND pool_status = ?`,
+		TenantPoolBindingUsed, usedAt, usedAt, tenantID, poolID, TenantPoolBindingFree)
+	if err != nil {
+		return false, fmt.Errorf("claim tenant pool membership for %s: %w", tenantID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("claim tenant pool membership rows affected for %s: %w", tenantID, err)
+	}
+	return affected == 1, nil
+}
+
+func (s *Store) GetOldestFreeTenantPoolMembership(ctx context.Context, poolID string) (*TenantWithPoolMembership, error) {
+	return s.getFreeTenantPoolMembershipCandidate(ctx, poolID, false)
+}
+
+func (s *Store) GetNewestFreeTenantPoolMembership(ctx context.Context, poolID string) (*TenantWithPoolMembership, error) {
+	return s.getFreeTenantPoolMembershipCandidate(ctx, poolID, true)
+}
+
+func (s *Store) GetNewestFreeTenantPoolMembershipForDelete(ctx context.Context, poolID string) (*TenantWithPoolMembership, error) {
+	var tenantID string
+	err := s.db.QueryRowContext(ctx, `SELECT m.tenant_id FROM tenant_pool_memberships m
+		JOIN tenants t ON t.id = m.tenant_id
+		WHERE m.pool_id = ? AND m.pool_status = ? AND t.status IN (?, ?, ?, ?)
+		ORDER BY m.created_at DESC, m.tenant_id DESC LIMIT 1`, poolID, TenantPoolBindingFree,
+		TenantPending, TenantProvisioning, TenantActive, TenantFailed).Scan(&tenantID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	t, err := s.GetTenant(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	m, err := s.GetTenantPoolMembership(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	return &TenantWithPoolMembership{Tenant: *t, Membership: *m}, nil
+}
+
+func (s *Store) getFreeTenantPoolMembershipCandidate(ctx context.Context, poolID string, newest bool) (*TenantWithPoolMembership, error) {
+	direction := "ASC"
+	if newest {
+		direction = "DESC"
+	}
+	var tenantID string
+	err := s.db.QueryRowContext(ctx, `SELECT m.tenant_id
+		FROM tenant_pool_memberships m
+		JOIN tenants t ON t.id = m.tenant_id
+		WHERE m.pool_id = ? AND m.pool_status = ? AND t.status = ?
+		ORDER BY m.created_at `+direction+`, m.tenant_id `+direction+` LIMIT 1`,
+		poolID, TenantPoolBindingFree, TenantActive).Scan(&tenantID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, ErrNotFound
+		}
+		return nil, fmt.Errorf("get free tenant pool membership candidate: %w", err)
+	}
+	tenant, err := s.GetTenant(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	membership, err := s.GetTenantPoolMembership(ctx, tenantID)
+	if err != nil {
+		return nil, err
+	}
+	return &TenantWithPoolMembership{Tenant: *tenant, Membership: *membership}, nil
+}
+
+func (s *Store) DeleteTenantPoolMembership(ctx context.Context, tenantID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM tenant_pool_memberships WHERE tenant_id = ?`, tenantID)
+	if err != nil {
+		return fmt.Errorf("delete tenant pool membership for %s: %w", tenantID, err)
+	}
+	return nil
+}
+
+func (s *Store) MarkFreeSharedTenantPoolTenantDeleting(ctx context.Context, tenantID string, from TenantStatus) (bool, error) {
+	var updated bool
+	err := s.InTx(ctx, func(tx *sql.Tx) error {
+		var id string
+		if err := tx.QueryRowContext(ctx, `SELECT t.id FROM tenants t
+			JOIN tenant_pool_memberships m ON m.tenant_id = t.id
+			WHERE t.id = ? AND t.status = ? AND m.pool_status = ? FOR UPDATE`, tenantID, from,
+			TenantPoolBindingFree).Scan(&id); err != nil {
+			return err
+		}
+		res, err := tx.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ?
+			WHERE id = ? AND status = ?`, TenantDeleting, time.Now().UTC(), tenantID, from)
+		if err != nil {
+			return err
+		}
+		n, _ := res.RowsAffected()
+		updated = n == 1
+		return nil
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	return updated, err
+}
+
+func (s *Store) CountFreeTenantPoolMemberships(ctx context.Context, organizationID string, statuses []TenantStatus) (int, error) {
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" || len(statuses) == 0 {
+		return 0, fmt.Errorf("organization id and tenant statuses are required")
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(statuses)), ",")
+	args := []any{organizationID, TenantPoolBindingFree, tidbCloudNativeSharedProvider}
+	for _, status := range statuses {
+		args = append(args, status)
+	}
+	var count int
+	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM tenant_pool_memberships m
+		JOIN tenants t ON t.id = m.tenant_id
+		WHERE m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?
+			AND t.status IN (`+placeholders+`)`, args...).Scan(&count)
+	return count, err
+}
+
+// UpdateTenantPoolMembershipOrganization fills the query/metrics dimension
+// after a first Cloud cluster resolves the organization identity.
+func (s *Store) UpdateTenantPoolMembershipOrganization(ctx context.Context, poolID, organizationID string) error {
+	poolID = strings.TrimSpace(poolID)
+	organizationID = strings.TrimSpace(organizationID)
+	if poolID == "" || organizationID == "" {
+		return fmt.Errorf("pool id and tidbcloud organization id are required")
+	}
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		rows, err := tx.QueryContext(ctx, `SELECT tidbcloud_organization_id
+			FROM tenant_pool_memberships WHERE pool_id = ? FOR UPDATE`, poolID)
+		if err != nil {
+			return fmt.Errorf("lock tenant pool memberships for %s: %w", poolID, err)
+		}
+		for rows.Next() {
+			var existing sql.NullString
+			if err := rows.Scan(&existing); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			if existing.Valid && existing.String != "" && existing.String != organizationID {
+				_ = rows.Close()
+				return fmt.Errorf("tenant pool membership organization is immutable: have %q, got %q",
+					existing.String, organizationID)
+			}
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		_, err = tx.ExecContext(ctx, `UPDATE tenant_pool_memberships
+			SET tidbcloud_organization_id = ?, updated_at = ?
+			WHERE pool_id = ? AND (tidbcloud_organization_id IS NULL OR tidbcloud_organization_id = '')`,
+			organizationID, time.Now().UTC(), poolID)
+		return err
+	})
+}
+
+// DetachUsedTenantPoolMemberships removes logical-pool ownership from claimed
+// shared tenants while leaving their tenant and physical DB placement intact.
+func (s *Store) DetachUsedTenantPoolMemberships(ctx context.Context, poolID string) error {
+	_, err := s.db.ExecContext(ctx, `DELETE FROM tenant_pool_memberships
+		WHERE pool_id = ? AND pool_status = ?`, strings.TrimSpace(poolID), TenantPoolBindingUsed)
+	return err
+}
+
+// ClaimSharedTenantPoolMembership atomically finalizes a free shared member:
+// quota patch, capacity-headroom validation, membership CAS, and owner key.
+func (s *Store) ClaimSharedTenantPoolMembership(ctx context.Context, tenantID, poolID string, patch QuotaConfigPatch, k *APIKey) (err error) {
+	if strings.TrimSpace(tenantID) == "" || strings.TrimSpace(poolID) == "" || k == nil {
+		return fmt.Errorf("tenant id, pool id, and api key are required")
+	}
+	scopeKind, err := apiKeyScopeKindForInsert(k)
+	if err != nil {
+		return err
+	}
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		var dbID int64
+		var poolLimit sql.NullInt64
+		if err := tx.QueryRowContext(ctx, `SELECT p.db_id, d.spending_limit
+			FROM tenant_pool_memberships m
+			JOIN tenants t ON t.id = m.tenant_id
+			JOIN fs_registry f ON f.tenant_id = t.id
+			JOIN tenant_placements p ON p.fs_id = f.fs_id
+			JOIN db_pool d ON d.db_id = p.db_id
+			WHERE m.tenant_id = ? AND m.pool_id = ? AND m.pool_status = ?
+				AND t.provider = ? AND t.status = ? FOR UPDATE`, tenantID, poolID,
+			TenantPoolBindingFree, tidbCloudNativeSharedProvider, TenantActive).Scan(&dbID, &poolLimit); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return err
+		}
+		var storage, fileSize, fileCount int64
+		var spending sql.NullInt64
+		var checkedAt sql.NullTime
+		if err := tx.QueryRowContext(ctx, `SELECT max_storage_bytes, max_file_size_bytes,
+			max_file_count, tidbcloud_spending_limit, tidbcloud_spending_limit_checked_at
+			FROM tenant_quota_config WHERE tenant_id = ? FOR UPDATE`, tenantID).
+			Scan(&storage, &fileSize, &fileCount, &spending, &checkedAt); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrSharedDBQuotaNotMaterialized
+			}
+			return err
+		}
+		if !spending.Valid {
+			return ErrSharedDBQuotaNotMaterialized
+		}
+		nextSpending := spending.Int64
+		if patch.TiDBCloudSpendingLimit != nil {
+			nextSpending = *patch.TiDBCloudSpendingLimit
+		}
+		if poolLimit.Valid && nextSpending > spending.Int64 {
+			var currentSum int64
+			if err := tx.QueryRowContext(ctx, `SELECT COALESCE(SUM(q.tidbcloud_spending_limit), 0)
+				FROM tenant_placements p JOIN fs_registry f ON f.fs_id = p.fs_id
+				JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id WHERE p.db_id = ?`, dbID).Scan(&currentSum); err != nil {
+				return err
+			}
+			prospective := currentSum - spending.Int64 + nextSpending
+			if prospective < 0 || prospective > int64(1<<31-1) || prospective >= poolLimit.Int64 {
+				return ErrSharedDBSpendingLimitExceeded
+			}
+		}
+		if patch.MaxStorageBytes != nil {
+			storage = *patch.MaxStorageBytes
+		}
+		if patch.MaxFileSizeBytes != nil {
+			fileSize = *patch.MaxFileSizeBytes
+		}
+		if patch.MaxFileCount != nil {
+			fileCount = *patch.MaxFileCount
+		}
+		if patch.TiDBCloudSpendingLimitCheckedAt != nil {
+			checkedAt = sql.NullTime{Time: patch.TiDBCloudSpendingLimitCheckedAt.UTC(), Valid: true}
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE tenant_quota_config SET max_storage_bytes = ?,
+			max_file_size_bytes = ?, max_file_count = ?, tidbcloud_spending_limit = ?,
+			tidbcloud_spending_limit_checked_at = ? WHERE tenant_id = ?`, storage, fileSize,
+			fileCount, nextSpending, checkedAt, tenantID); err != nil {
+			return err
+		}
+		now := time.Now().UTC()
+		res, err := tx.ExecContext(ctx, `UPDATE tenant_pool_memberships SET pool_status = ?, used_at = ?, updated_at = ?
+			WHERE tenant_id = ? AND pool_id = ? AND pool_status = ?`, TenantPoolBindingUsed, now, now,
+			tenantID, poolID, TenantPoolBindingFree)
+		if err != nil {
+			return err
+		}
+		if n, _ := res.RowsAffected(); n != 1 {
+			return ErrNotFound
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_api_keys
+			(id, tenant_id, key_name, jwt_ciphertext, jwt_hash, token_version, status, scope_kind,
+			 issued_by_provider, issued_by_subject_key, issued_by_metadata_json,
+			 issued_at, revoked_at, created_at, updated_at)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, k.ID, k.TenantID, k.KeyName,
+			k.JWTCiphertext, k.JWTHash, k.TokenVersion, k.Status, scopeKind, k.IssuedByProvider,
+			k.IssuedBySubjectKey, nullableBytes(k.IssuedByMetadataJSON), k.IssuedAt.UTC(), k.RevokedAt,
+			k.CreatedAt.UTC(), k.UpdatedAt.UTC()); err != nil {
+			if isDuplicateEntry(err) {
+				return ErrDuplicate
+			}
+			return err
+		}
+		return nil
+	})
+}

--- a/pkg/meta/tenant_pool_membership_test.go
+++ b/pkg/meta/tenant_pool_membership_test.go
@@ -1,0 +1,237 @@
+package meta
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestTenantPoolMembershipRoundTripAndClaimCAS(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	insertTenantForPoolMembershipTest(t, s, "shared-member-1", TenantActive, now)
+
+	if err := s.UpsertTenantPoolMembership(ctx, &TenantPoolMembership{
+		TenantID:                "shared-member-1",
+		TiDBCloudOrganizationID: "org-1",
+		PoolID:                  "pool-1",
+		PoolStatus:              TenantPoolBindingFree,
+		CreatedAt:               now,
+		UpdatedAt:               now,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPoolMembership: %v", err)
+	}
+
+	got, err := s.GetTenantPoolMembership(ctx, "shared-member-1")
+	if err != nil {
+		t.Fatalf("GetTenantPoolMembership: %v", err)
+	}
+	if got.TenantID != "shared-member-1" || got.TiDBCloudOrganizationID != "org-1" || got.PoolID != "pool-1" || got.PoolStatus != TenantPoolBindingFree || got.UsedAt != nil {
+		t.Fatalf("membership = %+v", got)
+	}
+	conflict := *got
+	conflict.TiDBCloudOrganizationID = "org-2"
+	if err := s.UpsertTenantPoolMembership(ctx, &conflict); err == nil {
+		t.Fatal("conflicting organization update succeeded")
+	}
+	got, err = s.GetTenantPoolMembership(ctx, "shared-member-1")
+	if err != nil {
+		t.Fatalf("GetTenantPoolMembership after conflict: %v", err)
+	}
+	if got.TiDBCloudOrganizationID != "org-1" {
+		t.Fatalf("organization after conflict = %q, want org-1", got.TiDBCloudOrganizationID)
+	}
+
+	claimedAt := now.Add(time.Second)
+	claimed, err := s.ClaimTenantPoolMembership(ctx, "shared-member-1", "pool-1", claimedAt)
+	if err != nil {
+		t.Fatalf("ClaimTenantPoolMembership: %v", err)
+	}
+	if !claimed {
+		t.Fatal("first claim lost CAS")
+	}
+	claimed, err = s.ClaimTenantPoolMembership(ctx, "shared-member-1", "pool-1", claimedAt.Add(time.Second))
+	if err != nil {
+		t.Fatalf("second ClaimTenantPoolMembership: %v", err)
+	}
+	if claimed {
+		t.Fatal("second claim won CAS")
+	}
+	got, err = s.GetTenantPoolMembership(ctx, "shared-member-1")
+	if err != nil {
+		t.Fatalf("GetTenantPoolMembership after claim: %v", err)
+	}
+	if got.PoolStatus != TenantPoolBindingUsed || got.UsedAt == nil || !got.UsedAt.Equal(claimedAt) {
+		t.Fatalf("claimed membership = %+v", got)
+	}
+}
+
+func TestOldestFreeTenantPoolMembershipRequiresActiveTenant(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	insertTenantForPoolMembershipTest(t, s, "shared-member-provisioning", TenantProvisioning, now)
+	insertTenantForPoolMembershipTest(t, s, "shared-member-active", TenantActive, now.Add(time.Second))
+	for i, tenantID := range []string{"shared-member-provisioning", "shared-member-active"} {
+		createdAt := now.Add(time.Duration(i) * time.Second)
+		if err := s.UpsertTenantPoolMembership(ctx, &TenantPoolMembership{
+			TenantID: tenantID, TiDBCloudOrganizationID: "org-1", PoolID: "pool-1",
+			PoolStatus: TenantPoolBindingFree, CreatedAt: createdAt, UpdatedAt: createdAt,
+		}); err != nil {
+			t.Fatalf("UpsertTenantPoolMembership(%s): %v", tenantID, err)
+		}
+	}
+
+	got, err := s.GetOldestFreeTenantPoolMembership(ctx, "pool-1")
+	if err != nil {
+		t.Fatalf("GetOldestFreeTenantPoolMembership: %v", err)
+	}
+	if got.Tenant.ID != "shared-member-active" {
+		t.Fatalf("oldest eligible tenant = %q, want shared-member-active", got.Tenant.ID)
+	}
+}
+
+func TestTenantPoolMembershipRejectsNativeTenant(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	if err := s.InsertTenant(ctx, &Tenant{
+		ID: "native-member-rejected", Status: TenantActive, Provider: tidbCloudNativeProvider,
+		DBPasswordCipher: []byte{}, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("InsertTenant: %v", err)
+	}
+	err := s.UpsertTenantPoolMembership(ctx, &TenantPoolMembership{
+		TenantID: "native-member-rejected", TiDBCloudOrganizationID: "org-1", PoolID: "pool-1",
+		PoolStatus: TenantPoolBindingFree, CreatedAt: now, UpdatedAt: now,
+	})
+	if err == nil {
+		t.Fatal("native tenant was inserted into shared membership table")
+	}
+	if _, getErr := s.GetTenantPoolMembership(ctx, "native-member-rejected"); !errors.Is(getErr, ErrNotFound) {
+		t.Fatalf("membership after rejected write = %v, want ErrNotFound", getErr)
+	}
+}
+
+func TestUpdateTenantPoolMembershipOrganizationFillsOnce(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	insertTenantForPoolMembershipTest(t, s, "shared-member-org-fill", TenantProvisioning, now)
+	if err := s.UpsertTenantPoolMembership(ctx, &TenantPoolMembership{
+		TenantID: "shared-member-org-fill", PoolID: "pool-org-fill",
+		PoolStatus: TenantPoolBindingFree, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPoolMembership: %v", err)
+	}
+
+	if err := s.UpdateTenantPoolMembershipOrganization(ctx, "pool-org-fill", "org-1"); err != nil {
+		t.Fatalf("initial organization fill: %v", err)
+	}
+	got, err := s.GetTenantPoolMembership(ctx, "shared-member-org-fill")
+	if err != nil {
+		t.Fatalf("GetTenantPoolMembership after fill: %v", err)
+	}
+	if got.TiDBCloudOrganizationID != "org-1" {
+		t.Fatalf("organization after fill = %q, want org-1", got.TiDBCloudOrganizationID)
+	}
+
+	if err := s.UpdateTenantPoolMembershipOrganization(ctx, "pool-org-fill", "org-2"); err == nil {
+		t.Fatal("conflicting organization fill succeeded")
+	}
+	got, err = s.GetTenantPoolMembership(ctx, "shared-member-org-fill")
+	if err != nil {
+		t.Fatalf("GetTenantPoolMembership after conflict: %v", err)
+	}
+	if got.TiDBCloudOrganizationID != "org-1" {
+		t.Fatalf("organization after conflict = %q, want org-1", got.TiDBCloudOrganizationID)
+	}
+}
+
+func TestDeleteTenantPoolAndDetachUsedMembersHandlesBothProviders(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	if err := s.CreateTenantPool(ctx, &TenantPool{
+		PoolID: "pool-delete-mixed", OrganizationID: "org-delete-mixed", Size: 2,
+		Status: TenantPoolDeleting, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("CreateTenantPool: %v", err)
+	}
+	if err := s.InsertTenant(ctx, &Tenant{
+		ID: "native-used", Status: TenantActive, Provider: tidbCloudNativeProvider,
+		DBPasswordCipher: []byte{}, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("InsertTenant native-used: %v", err)
+	}
+	if err := s.UpsertTenantTiDBCloudOrgBinding(ctx, &TenantTiDBCloudOrgBinding{
+		TenantID: "native-used", OrganizationID: "org-delete-mixed", ClusterID: "cluster-native-used",
+		PoolID: "pool-delete-mixed", PoolStatus: TenantPoolBindingUsed, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertTenantTiDBCloudOrgBinding: %v", err)
+	}
+	insertTenantForPoolMembershipTest(t, s, "shared-used", TenantActive, now)
+	if err := s.UpsertTenantPoolMembership(ctx, &TenantPoolMembership{
+		TenantID: "shared-used", TiDBCloudOrganizationID: "org-delete-mixed",
+		PoolID: "pool-delete-mixed", PoolStatus: TenantPoolBindingUsed, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPoolMembership: %v", err)
+	}
+	insertTenantForPoolMembershipTest(t, s, "shared-free", TenantActive, now)
+	if err := s.UpsertTenantPoolMembership(ctx, &TenantPoolMembership{
+		TenantID: "shared-free", TiDBCloudOrganizationID: "org-delete-mixed",
+		PoolID: "pool-delete-mixed", PoolStatus: TenantPoolBindingFree, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPoolMembership shared-free: %v", err)
+	}
+
+	if err := s.DeleteTenantPoolAndDetachUsedMembers(ctx, "pool-delete-mixed"); err == nil {
+		t.Fatal("pool deletion succeeded while a free member remained")
+	}
+	pool, err := s.GetTenantPoolByID(ctx, "pool-delete-mixed")
+	if err != nil || pool.PoolID != "pool-delete-mixed" {
+		t.Fatalf("pool after rejected delete = %+v, %v", pool, err)
+	}
+	nativeBinding, err := s.GetTenantTiDBCloudOrgBinding(ctx, "native-used")
+	if err != nil {
+		t.Fatalf("GetTenantTiDBCloudOrgBinding after rejected delete: %v", err)
+	}
+	if nativeBinding.PoolID != "pool-delete-mixed" {
+		t.Fatalf("native binding detached by rejected delete: %+v", nativeBinding)
+	}
+	if _, err := s.GetTenantPoolMembership(ctx, "shared-used"); err != nil {
+		t.Fatalf("shared used membership removed by rejected delete: %v", err)
+	}
+	if err := s.DeleteTenantPoolMembership(ctx, "shared-free"); err != nil {
+		t.Fatalf("DeleteTenantPoolMembership shared-free: %v", err)
+	}
+
+	if err := s.DeleteTenantPoolAndDetachUsedMembers(ctx, "pool-delete-mixed"); err != nil {
+		t.Fatalf("DeleteTenantPoolAndDetachUsedMembers: %v", err)
+	}
+	if _, err := s.GetTenantPoolByID(ctx, "pool-delete-mixed"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetTenantPoolByID after delete = %v, want ErrNotFound", err)
+	}
+	nativeBinding, err = s.GetTenantTiDBCloudOrgBinding(ctx, "native-used")
+	if err != nil {
+		t.Fatalf("GetTenantTiDBCloudOrgBinding: %v", err)
+	}
+	if nativeBinding.PoolID != "" || nativeBinding.PoolStatus != TenantPoolBindingUsed {
+		t.Fatalf("native binding after detach = %+v", nativeBinding)
+	}
+	if _, err := s.GetTenantPoolMembership(ctx, "shared-used"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("shared membership after detach = %v, want ErrNotFound", err)
+	}
+}
+
+func insertTenantForPoolMembershipTest(t *testing.T, s *Store, tenantID string, status TenantStatus, now time.Time) {
+	t.Helper()
+	if err := s.InsertTenant(context.Background(), &Tenant{
+		ID: tenantID, Status: status, DBHost: "", DBPort: 0, DBUser: "", DBPasswordCipher: []byte{},
+		DBName: "", Provider: "tidb_cloud_native_shared", SchemaVersion: 0, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("InsertTenant(%s): %v", tenantID, err)
+	}
+}

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -52,6 +52,10 @@ var tenantPoolMetadataResumeWaitTotal = serviceMeter.Int64Counter("drive9_tenant
 var tenantPoolMetadataResumeWaitDuration = serviceMeter.Float64Histogram("drive9_tenant_pool_metadata_resume_wait_duration_seconds", "Tenant pool metadata resume wait duration by pool_id/organization_id/scope/result", tenantPoolMetadataResumeWaitDurationBounds)
 var tenantPoolCapacity = serviceMeter.Float64Gauge("drive9_tenant_pool_capacity", "Tenant pool capacity by pool_id/organization_id/state")
 var tenantPoolBindings = serviceMeter.Float64Gauge("drive9_tenant_pool_bindings", "Tenant pool binding count by pool_id/tidbcloud_org_id/status")
+var sharedDBPoolTotal = serviceMeter.Float64Gauge("drive9_shared_db_pool_total", "Physical shared DB-pool count by tidbcloud_org_id/status")
+var sharedDBPoolCapacity = serviceMeter.Float64Gauge("drive9_shared_db_pool_capacity", "Physical shared DB-pool capacity by tidbcloud_org_id/db_pool_id/type")
+var sharedDBPoolTenants = serviceMeter.Float64Gauge("drive9_shared_db_pool_tenants", "Physical shared DB-pool tenant count by tidbcloud_org_id/db_pool_id/state")
+var sharedDBPoolSpendingLimit = serviceMeter.Float64Gauge("drive9_shared_db_pool_spending_limit", "Physical shared DB-pool spending limit by tidbcloud_org_id/db_pool_id/type")
 var tidbCloudRBACCacheRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_rbac_cache_requests_total", "TiDB Cloud API key to cluster RBAC cache requests by path/scope/result")
 var tidbCloudOpenAPIRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_openapi_requests_total", "TiDB Cloud OpenAPI requests by path/operation/result")
 var tidbCloudSpendingLimitSyncTotal = serviceMeter.Int64Counter("drive9_tidbcloud_spending_limit_sync_total", "TiDB Cloud spending limit local sync outcomes by source/result")
@@ -185,6 +189,62 @@ func DeleteTenantPoolBindings(poolID, tidbCloudOrgID, poolStatus string) {
 		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("status", cleanMetricValue(poolStatus, "unknown")),
 	)
+}
+
+func RecordSharedDBPoolTotal(tidbCloudOrgID, status string, count int64) {
+	if count < 0 {
+		return
+	}
+	RegisterModule("shared_db_pool")
+	sharedDBPoolTotal.Set(float64(count),
+		Attr("tidbcloud_org_id", cleanMetricValue(tidbCloudOrgID, "unknown")),
+		Attr("status", cleanMetricValue(status, "unknown")),
+	)
+}
+
+func DeleteSharedDBPoolTotal(tidbCloudOrgID, status string) {
+	sharedDBPoolTotal.Delete(
+		Attr("tidbcloud_org_id", cleanMetricValue(tidbCloudOrgID, "unknown")),
+		Attr("status", cleanMetricValue(status, "unknown")),
+	)
+}
+
+func RecordSharedDBPoolCapacity(tidbCloudOrgID string, dbPoolID int64, capacityType string, value int64) {
+	RegisterModule("shared_db_pool")
+	sharedDBPoolCapacity.Set(float64(value), sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "type", capacityType)...)
+}
+
+func DeleteSharedDBPoolCapacity(tidbCloudOrgID string, dbPoolID int64, capacityType string) {
+	sharedDBPoolCapacity.Delete(sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "type", capacityType)...)
+}
+
+func RecordSharedDBPoolTenants(tidbCloudOrgID string, dbPoolID int64, state string, count int64) {
+	if count < 0 {
+		return
+	}
+	RegisterModule("shared_db_pool")
+	sharedDBPoolTenants.Set(float64(count), sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "state", state)...)
+}
+
+func DeleteSharedDBPoolTenants(tidbCloudOrgID string, dbPoolID int64, state string) {
+	sharedDBPoolTenants.Delete(sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "state", state)...)
+}
+
+func RecordSharedDBPoolSpendingLimit(tidbCloudOrgID string, dbPoolID int64, limitType string, value int64) {
+	RegisterModule("shared_db_pool")
+	sharedDBPoolSpendingLimit.Set(float64(value), sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "type", limitType)...)
+}
+
+func DeleteSharedDBPoolSpendingLimit(tidbCloudOrgID string, dbPoolID int64, limitType string) {
+	sharedDBPoolSpendingLimit.Delete(sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "type", limitType)...)
+}
+
+func sharedDBPoolAttrs(tidbCloudOrgID string, dbPoolID int64, dimension, value string) []Attribute {
+	return []Attribute{
+		Attr("tidbcloud_org_id", cleanMetricValue(tidbCloudOrgID, "unknown")),
+		Attr("db_pool_id", strconv.FormatInt(dbPoolID, 10)),
+		Attr(dimension, cleanMetricValue(value, "unknown")),
+	}
 }
 
 func DeleteTenantCounters(tenantID string) {

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -24,10 +24,10 @@ const (
 	// Shared-schema handles serve many tenants through one *sql.DB, so they
 	// get meta-like lifetimes and a much larger connection budget than
 	// per-tenant user pools.
-	defaultSharedConnMaxLifetime = 5 * time.Minute
-	defaultSharedConnMaxIdleTime = 1 * time.Minute
-	defaultSharedMaxOpenConns    = 50
-	defaultSharedMaxIdleConns    = 10
+	defaultSharedConnMaxLifetime = 30 * time.Minute
+	defaultSharedConnMaxIdleTime = 5 * time.Minute
+	defaultSharedMaxOpenConns    = 300
+	defaultSharedMaxIdleConns    = 50
 )
 
 // ApplyPoolDefaults rotates and prunes idle connections before common LB/NAT
@@ -38,12 +38,13 @@ const (
 //   - DRIVE9_META_DB_MAX_OPEN_CONNS / DRIVE9_META_DB_MAX_IDLE_CONNS
 //   - DRIVE9_USER_DB_MAX_OPEN_CONNS / DRIVE9_USER_DB_MAX_IDLE_CONNS
 //   - DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS / DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS
+//   - DRIVE9_SHARED_DB_MAX_OPEN_CONNS / DRIVE9_SHARED_DB_MAX_IDLE_CONNS
+//   - DRIVE9_SHARED_DB_CONN_MAX_LIFETIME / DRIVE9_SHARED_DB_CONN_MAX_IDLE_TIME
 //
-// The limits apply to each *sql.DB pool, not to all pools in the process. In a
-// multi-pod deployment, set these so pod_count * pools_per_pod * maxOpenConns
-// stays within TiDB max_connections.
+// The limits apply to each *sql.DB pool. In a multi-pod deployment, size them
+// against TiDB max_connections and the expected number of active shared pools.
 func ApplyPoolDefaults(db *sql.DB, role string) {
-	lifetime, idleTime := defaultPoolLifetime(role)
+	lifetime, idleTime := poolLifetime(role)
 	db.SetConnMaxLifetime(lifetime)
 	db.SetConnMaxIdleTime(idleTime)
 	maxOpen, maxIdle := defaultPoolLimits(role)
@@ -53,6 +54,15 @@ func ApplyPoolDefaults(db *sql.DB, role string) {
 	if v := poolEnvInt(role, "MAX_IDLE_CONNS", maxIdle); v >= 0 {
 		db.SetMaxIdleConns(v)
 	}
+}
+
+func poolLifetime(role string) (time.Duration, time.Duration) {
+	lifetime, idleTime := defaultPoolLifetime(role)
+	if role != RoleShared {
+		return lifetime, idleTime
+	}
+	return poolEnvDuration(role, "CONN_MAX_LIFETIME", lifetime),
+		poolEnvDuration(role, "CONN_MAX_IDLE_TIME", idleTime)
 }
 
 func defaultPoolLifetime(role string) (time.Duration, time.Duration) {
@@ -90,6 +100,22 @@ func poolEnvInt(role, suffix string, def int) int {
 		}
 	}
 	return def
+}
+
+func poolEnvDuration(role, suffix string, def time.Duration) time.Duration {
+	key := rolePoolEnvKey(role, suffix)
+	if key == "" {
+		return def
+	}
+	raw := os.Getenv(key)
+	if raw == "" {
+		return def
+	}
+	value, err := time.ParseDuration(raw)
+	if err != nil || value <= 0 {
+		return def
+	}
+	return value
 }
 
 func rolePoolEnvKey(role, suffix string) string {

--- a/pkg/mysqlutil/pool_test.go
+++ b/pkg/mysqlutil/pool_test.go
@@ -1,6 +1,9 @@
 package mysqlutil
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestPoolEnvIntUsesRoleSpecificValue(t *testing.T) {
 	t.Setenv("DRIVE9_META_DB_MAX_OPEN_CONNS", "20")
@@ -59,6 +62,14 @@ func TestDefaultPoolLifetime(t *testing.T) {
 	if idleTime != defaultUserSchemaConnMaxIdleTime {
 		t.Fatalf("user schema idle time = %s, want %s", idleTime, defaultUserSchemaConnMaxIdleTime)
 	}
+
+	lifetime, idleTime = defaultPoolLifetime(RoleShared)
+	if lifetime != 30*time.Minute {
+		t.Fatalf("shared lifetime = %s, want 30m", lifetime)
+	}
+	if idleTime != 5*time.Minute {
+		t.Fatalf("shared idle time = %s, want 5m", idleTime)
+	}
 }
 
 func TestDefaultPoolLimits(t *testing.T) {
@@ -84,5 +95,19 @@ func TestDefaultPoolLimits(t *testing.T) {
 	}
 	if maxIdle != defaultUserSchemaMaxIdleConns {
 		t.Fatalf("user schema max idle = %d, want %d", maxIdle, defaultUserSchemaMaxIdleConns)
+	}
+
+	maxOpen, maxIdle = defaultPoolLimits(RoleShared)
+	if maxOpen != 300 || maxIdle != 50 {
+		t.Fatalf("shared limits = %d/%d, want 300/50", maxOpen, maxIdle)
+	}
+}
+
+func TestSharedPoolDurationEnv(t *testing.T) {
+	t.Setenv("DRIVE9_SHARED_DB_CONN_MAX_LIFETIME", "45m")
+	t.Setenv("DRIVE9_SHARED_DB_CONN_MAX_IDLE_TIME", "12m")
+	lifetime, idleTime := poolLifetime(RoleShared)
+	if lifetime != 45*time.Minute || idleTime != 12*time.Minute {
+		t.Fatalf("shared env durations = %s/%s, want 45m/12m", lifetime, idleTime)
 	}
 }

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1114,9 +1114,9 @@ func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, p
 	}
 	created, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, requests, cred)
 	if createErr != nil && len(created) == 0 {
-		logger.Warn(ctx, "managed_shared_db_batch_create_ambiguous",
+		logger.Warn(ctx, "managed_shared_db_batch_create_failed",
 			zap.Int("db_pool_count", len(requests)), zap.Error(createErr))
-		return resolvedOrg, nil
+		return resolvedOrg, createErr
 	}
 	for _, info := range created {
 		if info == nil || rows[info.DBPoolID] == nil {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -47,6 +48,30 @@ type adminTenantPoolStatus string
 const adminTenantPoolStatusCreating adminTenantPoolStatus = "creating"
 
 const adminTenantPoolMetricsComponent = "admin_tenant_pool"
+
+const tenantPoolClaimCASRetryLimit = 8
+
+func retryTenantPoolClaimCAS[T any](attempt func() (T, error)) (T, error) {
+	var zero T
+	var lastErr error
+	for range tenantPoolClaimCASRetryLimit {
+		result, err := attempt()
+		if err == nil {
+			return result, nil
+		}
+		if !errors.Is(err, meta.ErrNotFound) {
+			return zero, err
+		}
+		lastErr = err
+	}
+	return zero, fmt.Errorf("tenant pool claim remained busy after %d attempts: %w",
+		tenantPoolClaimCASRetryLimit, lastErr)
+}
+
+type tenantPoolClaimSelection struct {
+	sharedResult *provisionTenantResult
+	native       *meta.TenantWithTiDBCloudOrgBinding
+}
 
 func (e *adminTenantPoolHTTPError) Error() string {
 	return e.message
@@ -578,7 +603,7 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 			"deleted_free_tenants", deleted,
 			"duration_ms", durationMillis(stageStarted))...)
 		stageStarted = time.Now()
-		if err := s.meta.DeleteTenantPool(ctx, pool.PoolID); err != nil {
+		if err := s.meta.DeleteTenantPoolAndDetachUsedMembers(ctx, pool.PoolID); err != nil {
 			return adminTenantPoolError(http.StatusInternalServerError, "failed to delete tenant pool")
 		}
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_delete_metadata_deleted",
@@ -693,6 +718,9 @@ func (s *Server) firstManagedOrganization(ctx context.Context, cred tenant.Crede
 }
 
 func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count int, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*provisionTenantResult, error) {
+	if s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared {
+		return s.createFreeSharedPoolTenants(ctx, poolID, count, cred, quotaOpt)
+	}
 	manager, ok := s.provisioner.(tenant.TenantPoolClusterManager)
 	if !ok {
 		return nil, fmt.Errorf("tenant pool provisioning not enabled")
@@ -909,6 +937,156 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 	cleanupOnError = false
 	s.startPoolClustersMetadataResume(ctx, poolID, pendingResume, cred)
 	return results, nil
+}
+
+func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string, count int, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*provisionTenantResult, error) {
+	if count <= 0 {
+		return []*provisionTenantResult{}, nil
+	}
+	if _, ok := s.provisioner.(tenant.SharedDBPoolProvisioner); !ok {
+		return nil, fmt.Errorf("shared tenant pool provisioning not enabled")
+	}
+	pool, err := s.meta.GetTenantPoolByID(ctx, poolID)
+	if err != nil {
+		return nil, err
+	}
+	now := time.Now().UTC()
+	createdPoolIDs := make(map[int64]struct{})
+	provisioningPoolIDs := make(map[int64]struct{})
+	results := make([]*provisionTenantResult, 0, count)
+	for i := 0; i < count; i++ {
+		tenantID := token.NewID()
+		if err := s.insertPendingPoolTenant(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, now); err != nil {
+			return results, err
+		}
+		fsID, err := s.meta.EnsureFsID(ctx, tenantID)
+		if err != nil {
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			return results, err
+		}
+		opts := provisionTenantOptions{Quota: quotaOpt}
+		if err := s.materializeSharedTenantQuota(ctx, tenantID, opts); err != nil {
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			return results, err
+		}
+		virtualLimit := s.sharedTenantVirtualSpendingLimit(opts)
+		var selected *meta.SharedDB
+		selected, created, err := s.allocateManagedSharedDB(ctx, cred, virtualLimit, func(db *meta.SharedDB) error {
+			return s.meta.CompleteSharedTenantPoolMember(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared,
+				&meta.TenantPlacement{FsID: fsID, DbID: db.ID, Placement: meta.PlacementShared,
+					SchemaShape: meta.SchemaShapeShared, Status: meta.SharedDBStatusActive},
+				&meta.TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: pool.OrganizationID,
+					PoolID: poolID, PoolStatus: meta.TenantPoolBindingFree, CreatedAt: now, UpdatedAt: now})
+		})
+		if err != nil {
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			return results, err
+		}
+		if created {
+			createdPoolIDs[selected.ID] = struct{}{}
+		}
+		if selected.Status == meta.SharedDBStatusProvisioning {
+			provisioningPoolIDs[selected.ID] = struct{}{}
+		}
+		resultStatus := meta.TenantProvisioning
+		if selected.Status == meta.SharedDBStatusActive {
+			resultStatus = meta.TenantActive
+		}
+		results = append(results, &provisionTenantResult{TenantID: tenantID,
+			Status: resultStatus, Provider: tenant.ProviderTiDBCloudNativeShared,
+			CloudProvider: selected.CloudProvider, Region: selected.Region,
+			OrganizationID: selected.TiDBCloudOrganizationID})
+	}
+	createdIDs := make([]int64, 0, len(createdPoolIDs))
+	for id := range createdPoolIDs {
+		createdIDs = append(createdIDs, id)
+	}
+	sort.Slice(createdIDs, func(i, j int) bool { return createdIDs[i] < createdIDs[j] })
+	resolvedOrg, err := s.provisionManagedSharedDBPoolsBatch(ctx, createdIDs, cred)
+	if err != nil {
+		return results, err
+	}
+	if pool.OrganizationID == "" && resolvedOrg != "" {
+		if err := s.meta.UpdateTenantPoolOrganization(ctx, poolID, resolvedOrg); err != nil {
+			return results, err
+		}
+		if err := s.meta.UpdateTenantPoolMembershipOrganization(ctx, poolID, resolvedOrg); err != nil {
+			return results, err
+		}
+		for _, result := range results {
+			result.OrganizationID = resolvedOrg
+		}
+	}
+	provisioningIDs := make([]int64, 0, len(provisioningPoolIDs))
+	for dbID := range provisioningPoolIDs {
+		provisioningIDs = append(provisioningIDs, dbID)
+	}
+	s.scheduleManagedSharedDBContinuations(ctx, provisioningIDs, cred)
+	return results, nil
+}
+
+func (s *Server) provisionManagedSharedDBPoolsBatch(ctx context.Context, dbIDs []int64, cred tenant.CredentialProvisionRequest) (string, error) {
+	if len(dbIDs) == 0 {
+		return "", nil
+	}
+	provisioner := s.provisioner.(tenant.SharedDBPoolProvisioner)
+	resolvedOrg := ""
+	for start := 0; start < len(dbIDs); start += 10 {
+		end := start + 10
+		if end > len(dbIDs) {
+			end = len(dbIDs)
+		}
+		requests := make([]tenant.SharedDBPoolCreateRequest, 0, end-start)
+		rows := make(map[int64]*meta.SharedDB, end-start)
+		for _, dbID := range dbIDs[start:end] {
+			row, err := s.meta.GetSharedDB(ctx, dbID)
+			if err != nil {
+				return resolvedOrg, err
+			}
+			plain, err := s.pool.Decrypt(ctx, row.PasswordCipher)
+			if err != nil {
+				return resolvedOrg, err
+			}
+			if row.SpendingLimit == nil {
+				return resolvedOrg, fmt.Errorf("managed db pool %d has no spending target", dbID)
+			}
+			rows[dbID] = row
+			requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID,
+				DatabaseName: row.Name, RootPassword: string(plain), SpendingLimitMonthly: *row.SpendingLimit})
+		}
+		created, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, requests, cred)
+		if createErr != nil && len(created) == 0 {
+			logger.Warn(ctx, "managed_shared_db_batch_create_ambiguous",
+				zap.Int("db_pool_count", len(requests)), zap.Error(createErr))
+			continue
+		}
+		for _, info := range created {
+			if info == nil || rows[info.DBPoolID] == nil {
+				return resolvedOrg, fmt.Errorf("shared db batch returned an unknown db pool")
+			}
+			row := rows[info.DBPoolID]
+			if info.OrganizationID == "" {
+				info.OrganizationID = row.TiDBCloudOrganizationID
+			}
+			if info.DBName == "" {
+				info.DBName = row.Name
+			}
+			if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{ID: info.DBPoolID,
+				TiDBCloudOrganizationID: info.OrganizationID, ClusterID: info.ClusterID, Host: info.Host,
+				Port: info.Port, User: info.Username, PasswordCipher: row.PasswordCipher, Name: info.DBName,
+				TLSMode: map[bool]string{true: "true", false: "skip-verify"}[dbTLSForProvisionedTenant(tenant.ProviderTiDBCloudNativeShared)]}); err != nil {
+				return resolvedOrg, err
+			}
+			if resolvedOrg == "" {
+				resolvedOrg = info.OrganizationID
+			}
+		}
+		if createErr != nil {
+			logger.Warn(ctx, "managed_shared_db_batch_create_partial",
+				zap.Int("requested", len(requests)), zap.Int("persisted", len(created)), zap.Error(createErr))
+		}
+	}
+	return resolvedOrg, nil
 }
 
 func (s *Server) markTenantPoolTenantFailed(ctx context.Context, tenantID, reason string) {
@@ -1338,102 +1516,100 @@ func (s *Server) deleteNewestFreePoolTenants(ctx context.Context, poolID, organi
 	remaining := count
 	deleted := 0
 	for deleteAll || remaining > 0 {
-		limit := remaining
-		if deleteAll {
-			limit = 100
-		}
-		var rows []meta.TenantWithTiDBCloudOrgBinding
+		var native *meta.TenantWithTiDBCloudOrgBinding
+		var nativeRows []meta.TenantWithTiDBCloudOrgBinding
 		var err error
 		if deleteAll {
-			rows, err = s.meta.ListFreeTenantPoolBindingsForDelete(ctx, organizationID, true, limit)
+			nativeRows, err = s.meta.ListFreeTenantPoolBindingsForDelete(ctx, organizationID, true, 1)
 		} else {
-			rows, err = s.meta.ListTenantPoolFreeSlotsForDelete(ctx, organizationID, true, limit)
+			nativeRows, err = s.meta.ListTenantPoolFreeSlotsForDelete(ctx, organizationID, true, 1)
 		}
 		if err != nil {
-			logger.Warn(ctx, "admin_tenant_pool_free_tenant_delete_list_failed",
-				zap.String("pool_id", poolID),
-				zap.String("organization_id", organizationID),
-				zap.Bool("delete_all", deleteAll),
-				zap.Error(err))
 			return deleted, err
 		}
-		if len(rows) == 0 {
+		if len(nativeRows) > 0 {
+			native = &nativeRows[0]
+		}
+		shared, sharedErr := s.meta.GetNewestFreeTenantPoolMembershipForDelete(ctx, poolID)
+		if sharedErr != nil && !errors.Is(sharedErr, meta.ErrNotFound) {
+			return deleted, sharedErr
+		}
+		if native == nil && shared == nil {
 			if deleteAll {
 				return deleted, nil
 			}
 			return deleted, fmt.Errorf("not enough free tenants to delete")
 		}
-		progressed := false
-		for _, row := range rows {
-			t := row.Tenant
-			stageStarted := time.Now()
-			updated, err := s.meta.MarkFreeTenantPoolTenantDeleting(ctx, t.ID, t.Status)
+		useShared := shared != nil && (native == nil || shared.Membership.CreatedAt.After(native.Binding.CreatedAt) ||
+			(shared.Membership.CreatedAt.Equal(native.Binding.CreatedAt) && shared.Tenant.ID > native.Tenant.ID))
+		if useShared {
+			updated, err := s.meta.MarkFreeSharedTenantPoolTenantDeleting(ctx, shared.Tenant.ID, shared.Tenant.Status)
 			if err != nil {
-				logger.Warn(ctx, "admin_tenant_pool_free_tenant_delete_mark_deleting_failed",
-					zap.String("tenant_id", t.ID),
-					zap.String("provider", t.Provider),
-					zap.String("pool_id", poolID),
-					zap.String("organization_id", organizationID),
-					zap.String("cluster_id", t.ClusterID),
-					zap.Error(err))
 				return deleted, err
 			}
 			if !updated {
 				continue
 			}
-			progressed = true
-			logProvisionStage(ctx, "admin_tenant_pool_free_tenant_delete_claimed", t.ID, t.Provider, stageStarted,
-				"pool_id", poolID,
-				"organization_id", organizationID,
-				"cluster_id", t.ClusterID,
-				"status", t.Status,
-				"delete_all", deleteAll)
-			stageStarted = time.Now()
-			if err := s.deprovisionTenantCluster(ctx, &t, cred); err != nil {
-				_, _ = s.meta.UpdateTenantStatusIf(context.Background(), t.ID, meta.TenantDeleting, t.Status)
-				logProvisionStage(ctx, "admin_tenant_pool_free_tenant_delete_cluster_failed", t.ID, t.Provider, stageStarted,
-					"pool_id", poolID,
-					"organization_id", organizationID,
-					"cluster_id", t.ClusterID,
-					"delete_all", deleteAll,
-					"error", err)
+			if err := s.deleteFreeSharedPoolTenant(ctx, &shared.Tenant); err != nil {
+				_, _ = s.meta.UpdateTenantStatusIf(context.Background(), shared.Tenant.ID, meta.TenantDeleting, shared.Tenant.Status)
 				return deleted, err
 			}
-			logProvisionStage(ctx, "admin_tenant_pool_free_tenant_delete_cluster_deleted", t.ID, t.Provider, stageStarted,
-				"pool_id", poolID,
-				"organization_id", organizationID,
-				"cluster_id", t.ClusterID,
-				"delete_all", deleteAll)
-			stageStarted = time.Now()
+		} else {
+			t := native.Tenant
+			updated, err := s.meta.MarkFreeTenantPoolTenantDeleting(ctx, t.ID, t.Status)
+			if err != nil {
+				return deleted, err
+			}
+			if !updated {
+				continue
+			}
+			if err := s.deprovisionTenantCluster(ctx, &t, cred); err != nil {
+				_, _ = s.meta.UpdateTenantStatusIf(context.Background(), t.ID, meta.TenantDeleting, t.Status)
+				return deleted, err
+			}
 			_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
 			if err := s.meta.MarkTenantDeleted(ctx, t.ID); err != nil {
 				_ = s.meta.UpdateTenantStatus(context.Background(), t.ID, meta.TenantFailed)
-				logProvisionStage(ctx, "admin_tenant_pool_free_tenant_delete_mark_deleted_failed", t.ID, t.Provider, stageStarted,
-					"pool_id", poolID,
-					"organization_id", organizationID,
-					"cluster_id", t.ClusterID,
-					"delete_all", deleteAll,
-					"error", err)
 				return deleted, err
 			}
-			deleted++
-			logProvisionStage(ctx, "admin_tenant_pool_free_tenant_delete_marked_deleted", t.ID, t.Provider, stageStarted,
-				"pool_id", poolID,
-				"organization_id", organizationID,
-				"cluster_id", t.ClusterID,
-				"delete_all", deleteAll)
-			if !deleteAll {
-				remaining--
-			}
-			if !deleteAll && remaining == 0 {
-				break
-			}
 		}
-		if !progressed {
-			return deleted, fmt.Errorf("not enough free tenants to delete")
+		deleted++
+		if !deleteAll {
+			remaining--
 		}
 	}
 	return deleted, nil
+}
+
+func (s *Server) deleteFreeSharedPoolTenant(ctx context.Context, t *meta.Tenant) error {
+	if t == nil {
+		return meta.ErrNotFound
+	}
+	if err := s.pool.InvalidateAndWait(ctx, t.ID); err != nil {
+		return err
+	}
+	fsID, err := s.meta.ResolveFsID(ctx, t.ID)
+	if err != nil {
+		return err
+	}
+	placement, err := s.meta.GetTenantPlacement(ctx, fsID)
+	if err != nil && !errors.Is(err, meta.ErrNotFound) {
+		return err
+	}
+	if placement != nil {
+		if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
+			return err
+		}
+		if err := s.meta.DeleteTenantPlacementAndDecrCount(ctx, fsID, placement.DbID, s.sharedDBReopenRatio); err != nil {
+			return err
+		}
+	}
+	if err := s.meta.DeleteTenantPoolMembership(ctx, t.ID); err != nil {
+		return err
+	}
+	_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
+	_, err = s.enqueueTenantDeleteJob(ctx, t)
+	return err
 }
 
 func (s *Server) cleanupCreatedPoolTenants(ctx context.Context, results []*provisionTenantResult, cred tenant.CredentialProvisionRequest, reason string) {
@@ -1671,20 +1847,21 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		return nil, nil, false, false, err
 	}
 	logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_org_lookup_done", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
-	// An org with a registered shared-schema pool places new tenants on it;
-	// the warm pool (pre-provisioned dedicated clusters) must not hand out a
-	// different tenant shape. Fall through to provisionTenant, which routes
-	// the tenant onto the shared pool.
-	if sharedDB, sharedErr := s.meta.FindSharedDBForOrg(ctx, orgID); sharedErr == nil && sharedDB != nil {
-		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "reason", "shared_pool_registered", "duration_ms", durationMillis(claimStarted))...)
-		return nil, nil, false, true, nil
-	} else if sharedErr != nil && !errors.Is(sharedErr, meta.ErrNotFound) {
-		return nil, nil, false, false, sharedErr
-	}
 	stageStarted = time.Now()
 	pool, err := s.meta.GetTenantPoolByOrganization(ctx, orgID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
+			// A registered external/manual shared DB remains a provision target,
+			// but it must not bypass an existing logical pool's mixed inventory.
+			// This check therefore runs only after the logical pool lookup misses.
+			if sharedDB, sharedErr := s.meta.FindSharedDBForOrg(ctx, orgID); sharedErr == nil && sharedDB != nil {
+				logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped",
+					"provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID,
+					"reason", "external_shared_pool_registered", "duration_ms", durationMillis(claimStarted))...)
+				return nil, nil, false, true, nil
+			} else if sharedErr != nil && !errors.Is(sharedErr, meta.ErrNotFound) {
+				return nil, nil, false, false, sharedErr
+			}
 			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_pool_lookup_missed", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
 			return nil, nil, false, false, nil
 		}
@@ -1698,13 +1875,44 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 	defer s.refreshTenantPoolCapacity(ctx, pool)
 	s.resumePendingTenantPoolAsync(ctx, pool, cred)
 	stageStarted = time.Now()
-	row, err := s.meta.ClaimOldestFreeTenantPoolBinding(ctx, orgID)
-	if err != nil {
-		if errors.Is(err, meta.ErrNotFound) {
-			logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_free_tenant_missed", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
-			return nil, pool, false, false, nil
+	selection, err := retryTenantPoolClaimCAS(func() (tenantPoolClaimSelection, error) {
+		var nativeCandidate *meta.TenantWithTiDBCloudOrgBinding
+		if rows, listErr := s.meta.ListFreeTenantPoolBindings(ctx, orgID, false, 1); listErr != nil {
+			return tenantPoolClaimSelection{}, listErr
+		} else if len(rows) > 0 {
+			nativeCandidate = &rows[0]
 		}
+		sharedCandidate, sharedErr := s.meta.GetOldestFreeTenantPoolMembership(ctx, pool.PoolID)
+		if sharedErr != nil && !errors.Is(sharedErr, meta.ErrNotFound) {
+			return tenantPoolClaimSelection{}, sharedErr
+		}
+		if sharedCandidate != nil && (nativeCandidate == nil || sharedCandidate.Membership.CreatedAt.Before(nativeCandidate.Binding.CreatedAt) ||
+			(sharedCandidate.Membership.CreatedAt.Equal(nativeCandidate.Binding.CreatedAt) && sharedCandidate.Tenant.ID < nativeCandidate.Tenant.ID)) {
+			result, claimErr := s.claimSharedTenantPoolMember(ctx, pool, sharedCandidate, quotaOpt)
+			if claimErr != nil {
+				return tenantPoolClaimSelection{}, claimErr
+			}
+			return tenantPoolClaimSelection{sharedResult: result}, nil
+		}
+		if nativeCandidate == nil {
+			return tenantPoolClaimSelection{}, nil
+		}
+		row, claimErr := s.meta.ClaimOldestFreeTenantPoolBinding(ctx, orgID)
+		if claimErr != nil {
+			return tenantPoolClaimSelection{}, claimErr
+		}
+		return tenantPoolClaimSelection{native: row}, nil
+	})
+	if err != nil {
 		return nil, nil, false, false, err
+	}
+	if selection.sharedResult != nil {
+		return selection.sharedResult, pool, true, false, nil
+	}
+	row := selection.native
+	if row == nil {
+		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_free_tenant_missed", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
+		return nil, pool, false, false, nil
 	}
 	logProvisionStage(ctx, "admin_tenant_pool_claim_free_tenant_claimed", row.Tenant.ID, row.Tenant.Provider, stageStarted, "pool_id", pool.PoolID, "organization_id", orgID, "cluster_id", row.Binding.ClusterID, "status", row.Tenant.Status)
 	usedAt := time.Now().UTC()
@@ -1782,6 +1990,43 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		Region:         region,
 		OrganizationID: row.Binding.OrganizationID,
 	}, pool, true, false, nil
+}
+
+func (s *Server) claimSharedTenantPoolMember(ctx context.Context, pool *meta.TenantPool, row *meta.TenantWithPoolMembership, quotaOpt *quotaRequest) (*provisionTenantResult, error) {
+	if pool == nil || row == nil {
+		return nil, meta.ErrNotFound
+	}
+	var patch meta.QuotaConfigPatch
+	if quotaOpt != nil {
+		var err error
+		patch, err = quotaConfigPatchFromRequest(*quotaOpt)
+		if err != nil {
+			return nil, err
+		}
+	}
+	rawToken, apiKeyID, key, err := s.buildOwnerAPIKey(ctx, row.Tenant.ID, "default", 1, apiKeyIssueSource{})
+	if err != nil {
+		return nil, err
+	}
+	if err := s.meta.ClaimSharedTenantPoolMembership(ctx, row.Tenant.ID, pool.PoolID, patch, key); err != nil {
+		return nil, err
+	}
+	fsID, err := s.meta.ResolveFsID(ctx, row.Tenant.ID)
+	if err != nil {
+		return nil, err
+	}
+	placement, err := s.meta.GetTenantPlacement(ctx, fsID)
+	if err != nil {
+		return nil, err
+	}
+	dbPool, err := s.meta.GetSharedDB(ctx, placement.DbID)
+	if err != nil {
+		return nil, err
+	}
+	return &provisionTenantResult{TenantID: row.Tenant.ID, APIKey: rawToken, APIKeyID: apiKeyID,
+		Status: meta.TenantActive, Provider: tenant.ProviderTiDBCloudNativeShared,
+		CloudProvider: dbPool.CloudProvider, Region: dbPool.Region,
+		OrganizationID: row.Membership.TiDBCloudOrganizationID}, nil
 }
 
 func (s *Server) releaseClaimedPoolTenant(ctx context.Context, manager tenant.TenantPoolClusterManager, cluster *tenant.ClusterInfo, cred tenant.CredentialProvisionRequest, tenantID, reason string) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -210,6 +210,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 				"requested_count", *req.PoolSize,
 				"duration_ms", durationMillis(stageStarted),
 				"error", err)...)
+			s.cleanupCreatedPoolTenants(ctx, results, cred, "create_free_tenants_error")
 			s.deleteTenantPoolMetadata(ctx, poolID, "create_free_tenants_error")
 			metricResult = "cluster_error"
 			status, msg := clientFacingErrorResponse(http.StatusBadGateway, "create tenant pool failed", err)
@@ -1036,55 +1037,111 @@ func (s *Server) provisionManagedSharedDBPoolsBatch(ctx context.Context, dbIDs [
 		if end > len(dbIDs) {
 			end = len(dbIDs)
 		}
-		requests := make([]tenant.SharedDBPoolCreateRequest, 0, end-start)
-		rows := make(map[int64]*meta.SharedDB, end-start)
-		for _, dbID := range dbIDs[start:end] {
-			row, err := s.meta.GetSharedDB(ctx, dbID)
-			if err != nil {
-				return resolvedOrg, err
-			}
-			plain, err := s.pool.Decrypt(ctx, row.PasswordCipher)
-			if err != nil {
-				return resolvedOrg, err
-			}
-			if row.SpendingLimit == nil {
-				return resolvedOrg, fmt.Errorf("managed db pool %d has no spending target", dbID)
-			}
-			rows[dbID] = row
-			requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID,
-				DatabaseName: row.Name, RootPassword: string(plain), SpendingLimitMonthly: *row.SpendingLimit})
+		chunkOrg, err := s.provisionManagedSharedDBPoolsBatchChunk(ctx, provisioner, dbIDs[start:end], cred)
+		if err != nil {
+			return resolvedOrg, err
 		}
-		created, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, requests, cred)
-		if createErr != nil && len(created) == 0 {
-			logger.Warn(ctx, "managed_shared_db_batch_create_ambiguous",
-				zap.Int("db_pool_count", len(requests)), zap.Error(createErr))
+		if resolvedOrg == "" {
+			resolvedOrg = chunkOrg
+		}
+	}
+	return resolvedOrg, nil
+}
+
+func (s *Server) provisionManagedSharedDBPoolsBatchChunk(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) (string, error) {
+	for attempt := 0; attempt < 2; attempt++ {
+		first, err := s.meta.GetSharedDB(ctx, dbIDs[0])
+		if err != nil {
+			return "", err
+		}
+		identity := sharedDBAllocationIdentity(first.TiDBCloudOrganizationID, first.ProvisioningKey)
+		restartWithOrganization := false
+		resolvedOrg := ""
+		err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+			current, err := s.meta.GetSharedDB(lockCtx, dbIDs[0])
+			if err != nil {
+				return err
+			}
+			if first.TiDBCloudOrganizationID == "" && current.TiDBCloudOrganizationID != "" {
+				restartWithOrganization = true
+				return nil
+			}
+			var createErr error
+			resolvedOrg, createErr = s.provisionManagedSharedDBPoolsBatchLocked(lockCtx, provisioner, dbIDs, cred)
+			return createErr
+		})
+		if err != nil {
+			return resolvedOrg, err
+		}
+		if !restartWithOrganization {
+			return resolvedOrg, nil
+		}
+	}
+	return "", fmt.Errorf("shared DB pool batch allocation identity kept changing")
+}
+
+func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) (string, error) {
+	requests := make([]tenant.SharedDBPoolCreateRequest, 0, len(dbIDs))
+	rows := make(map[int64]*meta.SharedDB, len(dbIDs))
+	resolvedOrg := ""
+	for _, dbID := range dbIDs {
+		row, err := s.meta.GetSharedDB(ctx, dbID)
+		if err != nil {
+			return resolvedOrg, err
+		}
+		if resolvedOrg == "" {
+			resolvedOrg = row.TiDBCloudOrganizationID
+		}
+		// A concurrent direct continuation may have completed physical creation
+		// before this batch acquired the organization lock. Its cluster must be
+		// adopted/refreshed by the normal continuation, never created again.
+		if row.ClusterID != "" {
 			continue
 		}
-		for _, info := range created {
-			if info == nil || rows[info.DBPoolID] == nil {
-				return resolvedOrg, fmt.Errorf("shared db batch returned an unknown db pool")
-			}
-			row := rows[info.DBPoolID]
-			if info.OrganizationID == "" {
-				info.OrganizationID = row.TiDBCloudOrganizationID
-			}
-			if info.DBName == "" {
-				info.DBName = row.Name
-			}
-			if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{ID: info.DBPoolID,
-				TiDBCloudOrganizationID: info.OrganizationID, ClusterID: info.ClusterID, Host: info.Host,
-				Port: info.Port, User: info.Username, PasswordCipher: row.PasswordCipher, Name: info.DBName,
-				TLSMode: map[bool]string{true: "true", false: "skip-verify"}[dbTLSForProvisionedTenant(tenant.ProviderTiDBCloudNativeShared)]}); err != nil {
-				return resolvedOrg, err
-			}
-			if resolvedOrg == "" {
-				resolvedOrg = info.OrganizationID
-			}
+		plain, err := s.pool.Decrypt(ctx, row.PasswordCipher)
+		if err != nil {
+			return resolvedOrg, err
 		}
-		if createErr != nil {
-			logger.Warn(ctx, "managed_shared_db_batch_create_partial",
-				zap.Int("requested", len(requests)), zap.Int("persisted", len(created)), zap.Error(createErr))
+		if row.SpendingLimit == nil {
+			return resolvedOrg, fmt.Errorf("managed db pool %d has no spending target", dbID)
 		}
+		rows[dbID] = row
+		requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID,
+			DatabaseName: row.Name, RootPassword: string(plain), SpendingLimitMonthly: *row.SpendingLimit})
+	}
+	if len(requests) == 0 {
+		return resolvedOrg, nil
+	}
+	created, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, requests, cred)
+	if createErr != nil && len(created) == 0 {
+		logger.Warn(ctx, "managed_shared_db_batch_create_ambiguous",
+			zap.Int("db_pool_count", len(requests)), zap.Error(createErr))
+		return resolvedOrg, nil
+	}
+	for _, info := range created {
+		if info == nil || rows[info.DBPoolID] == nil {
+			return resolvedOrg, fmt.Errorf("shared db batch returned an unknown db pool")
+		}
+		row := rows[info.DBPoolID]
+		if info.OrganizationID == "" {
+			info.OrganizationID = row.TiDBCloudOrganizationID
+		}
+		if info.DBName == "" {
+			info.DBName = row.Name
+		}
+		if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{ID: info.DBPoolID,
+			TiDBCloudOrganizationID: info.OrganizationID, ClusterID: info.ClusterID, Host: info.Host,
+			Port: info.Port, User: info.Username, PasswordCipher: row.PasswordCipher, Name: info.DBName,
+			TLSMode: map[bool]string{true: "true", false: "skip-verify"}[dbTLSForProvisionedTenant(tenant.ProviderTiDBCloudNativeShared)]}); err != nil {
+			return resolvedOrg, err
+		}
+		if resolvedOrg == "" {
+			resolvedOrg = info.OrganizationID
+		}
+	}
+	if createErr != nil {
+		logger.Warn(ctx, "managed_shared_db_batch_create_partial",
+			zap.Int("requested", len(requests)), zap.Int("persisted", len(created)), zap.Error(createErr))
 	}
 	return resolvedOrg, nil
 }
@@ -1597,8 +1654,16 @@ func (s *Server) deleteFreeSharedPoolTenant(ctx context.Context, t *meta.Tenant)
 		return err
 	}
 	if placement != nil {
-		if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
+		dbPool, err := s.meta.GetSharedDB(ctx, placement.DbID)
+		if err != nil {
 			return err
+		}
+		connectionReady := dbPool.Status == meta.SharedDBStatusActive && dbPool.Host != "" &&
+			dbPool.Port > 0 && dbPool.User != "" && len(dbPool.PasswordCipher) > 0 && dbPool.Name != ""
+		if connectionReady {
+			if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
+				return err
+			}
 		}
 		if err := s.meta.DeleteTenantPlacementAndDecrCount(ctx, fsID, placement.DbID, s.sharedDBReopenRatio); err != nil {
 			return err
@@ -1622,6 +1687,14 @@ func (s *Server) cleanupCreatedPoolTenants(ctx context.Context, results []*provi
 		t, err := s.meta.GetTenant(cleanupCtx, tenantID)
 		if err != nil {
 			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_get_tenant_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
+			continue
+		}
+		if t.Provider == tenant.ProviderTiDBCloudNativeShared {
+			if err := s.deleteFreeSharedPoolTenant(cleanupCtx, t); err != nil {
+				logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_shared_member_failed",
+					zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
+				_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			}
 			continue
 		}
 		if err := s.deprovisionTenantCluster(cleanupCtx, t, cred); err != nil {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -2069,6 +2069,21 @@ func (s *Server) claimSharedTenantPoolMember(ctx context.Context, pool *meta.Ten
 	if pool == nil || row == nil {
 		return nil, meta.ErrNotFound
 	}
+	// Resolve immutable free-member routing metadata before the claim commits.
+	// A transient read failure must not strand a used member whose owner token
+	// was committed but never returned to the caller.
+	fsID, err := s.meta.ResolveFsID(ctx, row.Tenant.ID)
+	if err != nil {
+		return nil, err
+	}
+	placement, err := s.meta.GetTenantPlacement(ctx, fsID)
+	if err != nil {
+		return nil, err
+	}
+	dbPool, err := s.meta.GetSharedDB(ctx, placement.DbID)
+	if err != nil {
+		return nil, err
+	}
 	var patch meta.QuotaConfigPatch
 	if quotaOpt != nil {
 		var err error
@@ -2082,18 +2097,6 @@ func (s *Server) claimSharedTenantPoolMember(ctx context.Context, pool *meta.Ten
 		return nil, err
 	}
 	if err := s.meta.ClaimSharedTenantPoolMembership(ctx, row.Tenant.ID, pool.PoolID, patch, key); err != nil {
-		return nil, err
-	}
-	fsID, err := s.meta.ResolveFsID(ctx, row.Tenant.ID)
-	if err != nil {
-		return nil, err
-	}
-	placement, err := s.meta.GetTenantPlacement(ctx, fsID)
-	if err != nil {
-		return nil, err
-	}
-	dbPool, err := s.meta.GetSharedDB(ctx, placement.DbID)
-	if err != nil {
 		return nil, err
 	}
 	return &provisionTenantResult{TenantID: row.Tenant.ID, APIKey: rawToken, APIKeyID: apiKeyID,

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -229,6 +229,134 @@ func TestSharedTenantPoolRefillOneThousandPlansTenPoolsInOneBatch(t *testing.T) 
 	}
 }
 
+func TestAdminTenantPoolCreateCleansPartialSharedMembersOnBatchFailure(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer poolManager.Close()
+	poolManager.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		managedClusters:   []tenant.CloudClusterInfo{{OrganizationID: "org-shared-cleanup"}},
+		sharedPoolResults: []*tenant.SharedDBPoolInfo{{DBPoolID: 999999, ClusterID: "cluster-unknown", OrganizationID: "org-shared-cleanup"}}}
+	secret := make([]byte, 32)
+	_, _ = rand.Read(secret)
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: secret})
+	defer srv.Close()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+
+	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key": "public", "private_key": "private", "pool_size": 1,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusBadGateway {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d: %s", resp.StatusCode, http.StatusBadGateway, body)
+	}
+	var memberships, placements, tenantCount int
+	if err := metaStore.DB().QueryRowContext(context.Background(), `SELECT COUNT(*) FROM tenant_pool_memberships
+		WHERE tidbcloud_organization_id = ?`, "org-shared-cleanup").Scan(&memberships); err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.DB().QueryRowContext(context.Background(), `SELECT COUNT(*) FROM tenant_placements p
+		JOIN db_pool d ON d.db_id = p.db_id WHERE d.org_id = ?`, "org-shared-cleanup").Scan(&placements); err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.DB().QueryRowContext(context.Background(), `SELECT COALESCE(SUM(tenant_count), 0)
+		FROM db_pool WHERE org_id = ?`, "org-shared-cleanup").Scan(&tenantCount); err != nil {
+		t.Fatal(err)
+	}
+	if memberships != 0 || placements != 0 || tenantCount != 0 {
+		t.Fatalf("partial shared cleanup left memberships=%d placements=%d tenant_count=%d", memberships, placements, tenantCount)
+	}
+}
+
+func TestDeleteFreeSharedPoolTenantSkipsPurgeWhenDBPoolIsUnready(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.server.defaultTenantProvider = tenant.ProviderTiDBCloudNativeShared
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID: "pool-unready-delete", OrganizationID: "org-unready-delete", Size: 1,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	tenantID := "shared-unready-delete"
+	if err := rt.server.insertPendingPoolTenant(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.server.materializeSharedTenantQuota(ctx, tenantID, provisionTenantOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	passwordCipher, err := rt.server.pool.Encrypt(ctx, []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := int64(10_000_000)
+	dbID, err := rt.meta.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-unready-delete", ProvisioningKey: make([]byte, 32),
+		CloudProvider: "aws", Region: "us-east-1",
+		MaxTenants: 100, SpendingLimit: &spendingTarget, PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-unready-delete", ClusterID: "cluster-unready-delete",
+		PasswordCipher: passwordCipher, Name: "tidbcloud_fs", TLSMode: "true",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fsID, err := rt.meta.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.CompleteSharedTenantPoolMember(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared,
+		&meta.TenantPlacement{FsID: fsID, DbID: dbID, Placement: meta.PlacementShared,
+			SchemaShape: meta.SchemaShapeShared, Status: meta.SharedDBStatusActive},
+		&meta.TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: "org-unready-delete",
+			PoolID: "pool-unready-delete", PoolStatus: meta.TenantPoolBindingFree, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	tenantRow, err := rt.meta.GetTenant(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rt.meta.MarkFreeSharedTenantPoolTenantDeleting(ctx, tenantID, tenantRow.Status); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.server.deleteFreeSharedPoolTenant(ctx, tenantRow); err != nil {
+		t.Fatalf("deleteFreeSharedPoolTenant: %v", err)
+	}
+	if _, err := rt.meta.GetTenantPlacement(ctx, fsID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("placement lookup error = %v, want ErrNotFound", err)
+	}
+	if _, err := rt.meta.GetTenantPoolMembership(ctx, tenantID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("membership lookup error = %v, want ErrNotFound", err)
+	}
+	dbPool, err := rt.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dbPool.TenantCount != 0 {
+		t.Fatalf("db pool tenant_count = %d, want 0", dbPool.TenantCount)
+	}
+}
+
 func TestAdminTenantPoolMetadataResumeResultRank(t *testing.T) {
 	ordered := []string{"ok", "canceled", "deadline_exceeded", "bad_conn", "error", "unknown"}
 	for i := 1; i < len(ordered); i++ {

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"crypto/rand"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -13,9 +15,219 @@ import (
 	"testing"
 	"time"
 
+	"github.com/mem9-ai/drive9/internal/testmysql"
+	"github.com/mem9-ai/drive9/pkg/encrypt"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
+
+func TestRetryTenantPoolClaimCASSucceedsOnEighthAttempt(t *testing.T) {
+	attempts := 0
+	got, err := retryTenantPoolClaimCAS(func() (int, error) {
+		attempts++
+		if attempts < tenantPoolClaimCASRetryLimit {
+			return 0, meta.ErrNotFound
+		}
+		return 42, nil
+	})
+	if err != nil {
+		t.Fatalf("retryTenantPoolClaimCAS: %v", err)
+	}
+	if got != 42 || attempts != tenantPoolClaimCASRetryLimit {
+		t.Fatalf("result=%d attempts=%d, want 42/%d", got, attempts, tenantPoolClaimCASRetryLimit)
+	}
+}
+
+func TestRetryTenantPoolClaimCASStopsAfterLimit(t *testing.T) {
+	attempts := 0
+	_, err := retryTenantPoolClaimCAS(func() (int, error) {
+		attempts++
+		return 0, meta.ErrNotFound
+	})
+	if err == nil || !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("err = %v, want wrapped ErrNotFound", err)
+	}
+	if attempts != tenantPoolClaimCASRetryLimit {
+		t.Fatalf("attempts=%d, want %d", attempts, tenantPoolClaimCASRetryLimit)
+	}
+}
+
+func TestRetryTenantPoolClaimCASDoesNotRetryBusinessError(t *testing.T) {
+	wantErr := errors.New("quota headroom exceeded")
+	attempts := 0
+	_, err := retryTenantPoolClaimCAS(func() (int, error) {
+		attempts++
+		return 0, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("err = %v, want %v", err, wantErr)
+	}
+	if attempts != 1 {
+		t.Fatalf("attempts=%d, want 1", attempts)
+	}
+}
+
+func TestTenantPoolClaimUsesNativeInventoryBeforeExternalSharedPool(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{OrganizationID: "org-mixed-inventory"}},
+	}}
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID: "pool-mixed-inventory", OrganizationID: "org-mixed-inventory", Size: 1,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("CreateTenantPool: %v", err)
+	}
+	nativeTenantID := insertAdminPoolFreeTenant(t, rt, "pool-mixed-inventory", "org-mixed-inventory", 1)
+	if _, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-mixed-inventory", Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	}); err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+
+	res, pool, claimed, sharedPoolMatched, err := rt.server.claimAdminTenantFromPool(ctx,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}, nil)
+	if err != nil {
+		t.Fatalf("claimAdminTenantFromPool: %v", err)
+	}
+	if !claimed || sharedPoolMatched || pool == nil || res == nil {
+		t.Fatalf("claim = result=%+v pool=%+v claimed=%v sharedMatched=%v", res, pool, claimed, sharedPoolMatched)
+	}
+	if res.TenantID != nativeTenantID || res.Provider != tenant.ProviderTiDBCloudNative {
+		t.Fatalf("claimed result = %+v, want native tenant %s", res, nativeTenantID)
+	}
+}
+
+func TestTenantPoolClaimConsumesMixedInventoryInGlobalAgeOrder(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.server.defaultTenantProvider = tenant.ProviderTiDBCloudNativeShared
+	ctx := context.Background()
+	orgPage := &tenant.ManagedClusterListResult{
+		Clusters: []tenant.CloudClusterInfo{{OrganizationID: "org-mixed-age"}},
+	}
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{orgPage, orgPage}
+	now := time.Now().UTC()
+	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
+		PoolID: "pool-mixed-age", OrganizationID: "org-mixed-age", Size: 2,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("CreateTenantPool: %v", err)
+	}
+	nativeTenantID := insertAdminPoolFreeTenant(t, rt, "pool-mixed-age", "org-mixed-age", 1)
+	passwordCipher, err := rt.server.pool.Encrypt(ctx, []byte("shared-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-mixed-age", Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: passwordCipher, Name: "shared_db", MaxTenants: 10,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	sharedTenantID := "pool-mixed-age-shared"
+	sharedCreatedAt := now.Add(time.Hour)
+	if err := rt.server.insertPendingPoolTenant(ctx, sharedTenantID, tenant.ProviderTiDBCloudNativeShared, sharedCreatedAt); err != nil {
+		t.Fatalf("insertPendingPoolTenant: %v", err)
+	}
+	if err := rt.server.materializeSharedTenantQuota(ctx, sharedTenantID, provisionTenantOptions{}); err != nil {
+		t.Fatalf("materializeSharedTenantQuota: %v", err)
+	}
+	fsID, err := rt.meta.EnsureFsID(ctx, sharedTenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if err := rt.meta.CompleteSharedTenantPoolMember(ctx, sharedTenantID, tenant.ProviderTiDBCloudNativeShared,
+		&meta.TenantPlacement{FsID: fsID, DbID: dbID, Placement: meta.PlacementShared,
+			SchemaShape: meta.SchemaShapeShared, Status: meta.SharedDBStatusActive},
+		&meta.TenantPoolMembership{TenantID: sharedTenantID, TiDBCloudOrganizationID: "org-mixed-age",
+			PoolID: "pool-mixed-age", PoolStatus: meta.TenantPoolBindingFree,
+			CreatedAt: sharedCreatedAt, UpdatedAt: sharedCreatedAt}); err != nil {
+		t.Fatalf("CompleteSharedTenantPoolMember: %v", err)
+	}
+
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}
+	first, _, claimed, _, err := rt.server.claimAdminTenantFromPool(ctx, cred, nil)
+	if err != nil || !claimed {
+		t.Fatalf("first claim = %+v, claimed=%v, err=%v", first, claimed, err)
+	}
+	if first.TenantID != nativeTenantID || first.Provider != tenant.ProviderTiDBCloudNative {
+		t.Fatalf("first claim = %+v, want older native tenant %s", first, nativeTenantID)
+	}
+	second, _, claimed, _, err := rt.server.claimAdminTenantFromPool(ctx, cred, nil)
+	if err != nil || !claimed {
+		t.Fatalf("second claim = %+v, claimed=%v, err=%v", second, claimed, err)
+	}
+	if second.TenantID != sharedTenantID || second.Provider != tenant.ProviderTiDBCloudNativeShared {
+		t.Fatalf("second claim = %+v, want shared tenant %s", second, sharedTenantID)
+	}
+	if second.TenantDSN != "" {
+		t.Fatalf("shared claim TenantDSN = %q, want empty", second.TenantDSN)
+	}
+}
+
+func TestSharedTenantPoolRefillOneThousandPlansTenPoolsInOneBatch(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer poolManager.Close()
+	poolManager.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		managedClusters: []tenant.CloudClusterInfo{{OrganizationID: "org-shared"}}}
+	secret := make([]byte, 32)
+	_, _ = rand.Read(secret)
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: secret})
+	defer srv.Close()
+	now := time.Now().UTC()
+	if err := metaStore.CreateTenantPool(context.Background(), &meta.TenantPool{PoolID: "pool-shared-1000",
+		OrganizationID: "org-shared", Size: 1000, Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	results, err := srv.createFreePoolTenants(context.Background(), "pool-shared-1000", 1000,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}, nil)
+	if err != nil {
+		t.Fatalf("createFreePoolTenants: %v", err)
+	}
+	if len(results) != 1000 {
+		t.Fatalf("results = %d, want 1000", len(results))
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
+		t.Fatalf("shared batch calls = %d, want 1", got)
+	}
+	if got := prov.sharedPoolBatchMembers.Load(); got != 10 {
+		t.Fatalf("shared batch members = %d, want 10", got)
+	}
+	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusProvisioning, 20)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 10 {
+		t.Fatalf("managed pools = %d, want 10", len(rows))
+	}
+	slots, err := metaStore.CountTenantPoolFreeSlots(context.Background(), "org-shared")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slots != 1000 {
+		t.Fatalf("free slots = %d, want 1000", slots)
+	}
+}
 
 func TestAdminTenantPoolMetadataResumeResultRank(t *testing.T) {
 	ordered := []string{"ok", "canceled", "deadline_exceeded", "bad_conn", "error", "unknown"}

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -301,6 +301,8 @@ type serverMetrics struct {
 	tenantInFlight    map[string]int64
 	tenantPoolBindMu  sync.Mutex
 	tenantPoolBinding map[tenantPoolBindingMetricKey]struct{}
+	sharedDBPoolMu    sync.Mutex
+	sharedDBPool      map[sharedDBPoolMetricKey]struct{}
 }
 
 func newServerMetrics() *serverMetrics {
@@ -310,6 +312,7 @@ func newServerMetrics() *serverMetrics {
 		routes:            map[string]int64{},
 		tenantInFlight:    map[string]int64{},
 		tenantPoolBinding: map[tenantPoolBindingMetricKey]struct{}{},
+		sharedDBPool:      map[sharedDBPoolMetricKey]struct{}{},
 	}
 }
 
@@ -849,8 +852,18 @@ func (s *Server) tenantMetricTiDBCloudOrgID(ctx context.Context, t *meta.Tenant)
 }
 
 func tenantMetricTiDBCloudOrgIDFromMeta(ctx context.Context, metaStore *meta.Store, t *meta.Tenant) string {
-	if metaStore == nil || t == nil || strings.TrimSpace(t.ID) == "" || t.Provider != tenant.ProviderTiDBCloudNative {
+	if metaStore == nil || t == nil || strings.TrimSpace(t.ID) == "" || !tenant.UsesTiDBCloudNativeCredentials(t.Provider) {
 		return defaultTenantMetricTiDBCloudOrgID
+	}
+	if tenant.IsSharedSchemaProvider(t.Provider) {
+		pool, err := metaStore.GetSharedDBForTenant(ctx, t.ID)
+		if err != nil {
+			if !errors.Is(err, meta.ErrNotFound) {
+				logger.Warn(ctx, "server_metric_shared_org_lookup_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+			}
+			return defaultTenantMetricTiDBCloudOrgID
+		}
+		return normalizeTenantMetricTiDBCloudOrgID(pool.TiDBCloudOrganizationID)
 	}
 	if orgID := strings.TrimSpace(t.TiDBCloudOrgID); orgID != "" {
 		return normalizeTenantMetricTiDBCloudOrgID(orgID)

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -274,6 +274,139 @@ func TestProvisionTiDBCloudNativeSharedFallsBackToHardCapacityAfterCreateFailure
 	}
 }
 
+func TestProvisionTiDBCloudNativeSharedEmergencyUsesCandidateHardCap(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer p.Close()
+	p.SetMetaStore(metaStore)
+	provisionErr := errors.New("cloud create unavailable")
+	prov := &fakeProvisioner{
+		provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		sharedPoolBatchErr: provisionErr,
+		managedClusters:    []tenant.CloudClusterInfo{{OrganizationID: "org-candidate-hard-cap", ClusterID: "cluster-existing"}},
+	}
+	spendingTarget := int64(10_000_000)
+	createActive := func(maxTenants, tenantCount int, clusterID string) int64 {
+		t.Helper()
+		dbID, createErr := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+			TiDBCloudOrganizationID: "org-candidate-hard-cap", ProvisioningKey: bytes.Repeat([]byte{byte(maxTenants)}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: maxTenants, SpendingLimit: &spendingTarget,
+		})
+		if createErr != nil {
+			t.Fatalf("CreateManagedSharedDBPool: %v", createErr)
+		}
+		if _, createErr = metaStore.DB().ExecContext(context.Background(), `UPDATE db_pool
+			SET status = ?, cluster_id = ?, db_host = ?, db_port = 4000, db_user = 'u', db_password = 'c',
+				db_name = ?, tenant_count = ?, soft_cap_reached = 1 WHERE db_id = ?`,
+			meta.SharedDBStatusActive, clusterID, "h-"+clusterID, "shared_"+clusterID, tenantCount, dbID); createErr != nil {
+			t.Fatalf("activate emergency pool: %v", createErr)
+		}
+		return dbID
+	}
+	_ = createActive(50, 60, "cluster-old-small")
+	wantDBID := createActive(100, 100, "cluster-current-size")
+
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: p, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32),
+		SharedDBHardCapRatio: 1.2})
+	defer srv.Close()
+	res, err := srv.provisionTenant(context.Background(), provisionTenantOptions{
+		CredentialProvisioner: &tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"},
+	})
+	if err != nil {
+		t.Fatalf("provisionTenant fallback: %v", err)
+	}
+	placement, err := metaStore.GetTenantPlacement(context.Background(), mustResolveFsID(t, metaStore, res.TenantID))
+	if err != nil {
+		t.Fatalf("GetTenantPlacement: %v", err)
+	}
+	if placement.DbID != wantDBID {
+		t.Fatalf("fallback placement db = %d, want candidate-sized pool %d", placement.DbID, wantDBID)
+	}
+}
+
+func TestProvisionTiDBCloudNativeSharedRetriesCapacityRace(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer p.Close()
+	p.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		managedClusters: []tenant.CloudClusterInfo{{OrganizationID: "org-direct-race", ClusterID: "cluster-existing"}}}
+	spendingTarget := int64(10_000_000)
+	for i := 0; i < 2; i++ {
+		dbID, createErr := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+			TiDBCloudOrganizationID: "org-direct-race", ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 1, SpendingLimit: &spendingTarget,
+		})
+		if createErr != nil {
+			t.Fatalf("CreateManagedSharedDBPool: %v", createErr)
+		}
+		if _, createErr = metaStore.DB().ExecContext(context.Background(), `UPDATE db_pool
+			SET status = ?, cluster_id = ?, db_host = ?, db_port = 4000, db_user = 'u', db_password = 'c',
+				db_name = ? WHERE db_id = ?`, meta.SharedDBStatusActive, fmt.Sprintf("cluster-%d", i),
+			fmt.Sprintf("h-%d", i), fmt.Sprintf("shared_%d", i), dbID); createErr != nil {
+			t.Fatalf("activate pool: %v", createErr)
+		}
+	}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: p, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
+	defer srv.Close()
+
+	start := make(chan struct{})
+	errs := make(chan error, 2)
+	var wg sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, provisionErr := srv.provisionTenant(context.Background(), provisionTenantOptions{
+				CredentialProvisioner: &tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"},
+			})
+			errs <- provisionErr
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for provisionErr := range errs {
+		if provisionErr != nil {
+			t.Fatalf("concurrent provision returned capacity race: %v", provisionErr)
+		}
+	}
+	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusActive, 10)
+	if err != nil {
+		t.Fatalf("ListSharedDBsByStatus: %v", err)
+	}
+	if len(rows) != 2 || rows[0].TenantCount != 1 || rows[1].TenantCount != 1 {
+		t.Fatalf("active pool counts = %+v, want one tenant in each pool", rows)
+	}
+}
+
 func TestProvisionTiDBCloudNativeSharedResumesExistingProvisioningPool(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -568,6 +701,48 @@ func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	}
 	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
 		t.Fatalf("physical create calls = %d, want 1", got)
+	}
+}
+
+func TestManagedSharedDBBatchCreateReturnsTotalFailure(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := int64(10_000_000)
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-batch-failure", ProvisioningKey: bytes.Repeat([]byte{9}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+		PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("cloud batch rejected")
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, sharedPoolBatchErr: wantErr}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
+	defer srv.Close()
+
+	_, err = srv.provisionManagedSharedDBPoolsBatch(context.Background(), []int64{dbID},
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("batch error = %v, want %v", err, wantErr)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -56,6 +56,10 @@ type fakeProvisioner struct {
 	managedClusters        []tenant.CloudClusterInfo
 	sharedPoolResults      []*tenant.SharedDBPoolInfo
 	sharedPoolBatchErr     error
+	sharedPoolBatchStarted chan struct{}
+	sharedPoolBatchRelease <-chan struct{}
+	sharedPoolWaitCalls    atomic.Int32
+	sharedPoolWaitErr      error
 }
 
 type failingEncryptor struct {
@@ -340,6 +344,233 @@ func TestProvisionTiDBCloudNativeSharedResumesExistingProvisioningPool(t *testin
 	}
 }
 
+func TestProvisionTiDBCloudNativeSharedUsesRegisteredManualDBPool(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("manual-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := metaStore.RegisterSharedDB(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-manual-shared", Host: "manual.example.com", Port: 4000,
+		User: "root", PasswordCipher: passwordCipher, Name: "manual_shared", MaxTenants: 100,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative,
+		managedClusters: []tenant.CloudClusterInfo{{OrganizationID: "org-manual-shared"}}}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
+	defer srv.Close()
+	virtualLimit := int64(4321)
+	res, err := srv.provisionTenant(context.Background(), provisionTenantOptions{
+		CredentialProvisioner: &tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"},
+		Quota:                 &quotaRequest{quotaFields: quotaFields{TiDBCloudSpendingLimit: &virtualLimit}},
+	})
+	if err != nil {
+		t.Fatalf("provisionTenant: %v", err)
+	}
+	placement, err := metaStore.GetTenantPlacement(context.Background(), mustResolveFsID(t, metaStore, res.TenantID))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if placement.DbID != dbID {
+		t.Fatalf("placement db = %d, want manual db pool %d", placement.DbID, dbID)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 0 {
+		t.Fatalf("managed physical create calls = %d, want 0", got)
+	}
+	quota, err := metaStore.GetQuotaConfig(context.Background(), res.TenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if quota.TiDBCloudSpendingLimit == nil || *quota.TiDBCloudSpendingLimit != virtualLimit {
+		t.Fatalf("virtual spending limit = %#v, want %d", quota.TiDBCloudSpendingLimit, virtualLimit)
+	}
+}
+
+func TestProvisionTiDBCloudNativeRejectsSpendingLimitOnRegisteredSharedDBPool(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("manual-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := metaStore.RegisterSharedDB(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-native-manual", Host: "manual.example.com", Port: 4000,
+		User: "root", PasswordCipher: passwordCipher, Name: "manual_shared", MaxTenants: 100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative,
+		managedClusters: []tenant.CloudClusterInfo{{OrganizationID: "org-native-manual"}}}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNative, TokenSecret: make([]byte, 32),
+		DisableDatabaseAutoEmbedding: true})
+	defer srv.Close()
+	spendingLimit := int64(4321)
+	_, err = srv.provisionTenant(context.Background(), provisionTenantOptions{
+		CredentialProvisioner: &tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"},
+		Quota:                 &quotaRequest{quotaFields: quotaFields{TiDBCloudSpendingLimit: &spendingLimit}},
+	})
+	if err == nil || !strings.Contains(err.Error(), "spending limit requested for shared-pool tenant") {
+		t.Fatalf("provisionTenant error = %v, want registered shared DB spending-limit rejection", err)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 0 {
+		t.Fatalf("shared DB physical create calls = %d, want 0", got)
+	}
+}
+
+func TestManagedSharedDBContinuationWaitsForConnectionMetadata(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := int64(10_000_000)
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-metadata-wait", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1",
+		MaxTenants: 100, SpendingLimit: &spendingTarget, PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.UpdateManagedSharedDBPoolCloudResult(context.Background(), &meta.SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-metadata-wait", ClusterID: "cluster-metadata-wait",
+		PasswordCipher: passwordCipher, Name: "tidbcloud_fs", TLSMode: "true",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitErr := errors.New("metadata wait stopped")
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative,
+		sharedPoolResults: []*tenant.SharedDBPoolInfo{{DBPoolID: dbID, ClusterID: "cluster-metadata-wait", OrganizationID: "org-metadata-wait"}},
+		sharedPoolWaitErr: waitErr}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
+	defer srv.Close()
+	err = srv.continueManagedSharedDBPool(context.Background(), dbID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	if !errors.Is(err, waitErr) {
+		t.Fatalf("continueManagedSharedDBPool error = %v, want %v", err, waitErr)
+	}
+	if got := prov.sharedPoolWaitCalls.Load(); got != 1 {
+		t.Fatalf("shared metadata wait calls = %d, want 1", got)
+	}
+}
+
+func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := int64(10_000_000)
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-batch-lock", ProvisioningKey: bytes.Repeat([]byte{2}, 32),
+		CloudProvider: "aws", Region: "us-east-1",
+		MaxTenants: 100, SpendingLimit: &spendingTarget, PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative,
+		sharedPoolBatchStarted: started, sharedPoolBatchRelease: release,
+		sharedPoolResults: []*tenant.SharedDBPoolInfo{{ClusterID: "cluster-batch-lock", OrganizationID: "org-batch-lock",
+			Host: "db.example.com", Port: 4000, Username: "u.root", DBName: "tidbcloud_fs"}}}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
+	defer srv.Close()
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}
+	batchDone := make(chan error, 1)
+	go func() {
+		_, err := srv.provisionManagedSharedDBPoolsBatch(context.Background(), []int64{dbID}, cred)
+		batchDone <- err
+	}()
+	<-started
+	ensureDone := make(chan error, 1)
+	go func() {
+		_, err := srv.ensureManagedSharedDBPhysical(context.Background(), dbID, cred)
+		ensureDone <- err
+	}()
+	secondCreateStarted := false
+	select {
+	case <-started:
+		secondCreateStarted = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(release)
+	if err := <-batchDone; err != nil {
+		t.Fatalf("batch create: %v", err)
+	}
+	if err := <-ensureDone; err != nil {
+		t.Fatalf("concurrent ensure: %v", err)
+	}
+	if secondCreateStarted {
+		t.Fatal("concurrent ensure issued a duplicate physical create while batch create was in flight")
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
+		t.Fatalf("physical create calls = %d, want 1", got)
+	}
+}
+
 func mustResolveFsID(t *testing.T, store *meta.Store, tenantID string) int64 {
 	t.Helper()
 	fsID, err := store.ResolveFsID(context.Background(), tenantID)
@@ -359,9 +590,22 @@ func (f *fakeProvisioner) ListManagedClusters(_ context.Context, _ tenant.Creden
 	return &tenant.ManagedClusterListResult{Clusters: append([]tenant.CloudClusterInfo(nil), f.managedClusters...)}, nil
 }
 
-func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(_ context.Context, requests []tenant.SharedDBPoolCreateRequest, _ tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, requests []tenant.SharedDBPoolCreateRequest, _ tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
 	f.sharedPoolBatchCalls.Add(1)
 	f.sharedPoolBatchMembers.Add(int32(len(requests)))
+	if f.sharedPoolBatchStarted != nil {
+		select {
+		case f.sharedPoolBatchStarted <- struct{}{}:
+		default:
+		}
+	}
+	if f.sharedPoolBatchRelease != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-f.sharedPoolBatchRelease:
+		}
+	}
 	if f.sharedPoolBatchErr != nil {
 		return nil, f.sharedPoolBatchErr
 	}
@@ -393,6 +637,21 @@ func (f *fakeProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context, _ i
 	for _, row := range f.sharedPoolResults {
 		if row != nil && row.ClusterID == clusterID {
 			copyRow := *row
+			return &copyRow, nil
+		}
+	}
+	return nil, nil
+}
+
+func (f *fakeProvisioner) WaitForSharedDBPoolMetadataWithCredentials(_ context.Context, dbPoolID int64, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+	f.sharedPoolWaitCalls.Add(1)
+	if f.sharedPoolWaitErr != nil {
+		return nil, f.sharedPoolWaitErr
+	}
+	for _, row := range f.sharedPoolResults {
+		if row != nil && row.ClusterID == clusterID {
+			copyRow := *row
+			copyRow.DBPoolID = dbPoolID
 			return &copyRow, nil
 		}
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -44,6 +44,8 @@ type fakeProvisioner struct {
 	deprovisionCalls       atomic.Int32
 	quotaMarkCalls         atomic.Int32
 	quotaUpdateCalls       atomic.Int32
+	sharedPoolBatchCalls   atomic.Int32
+	sharedPoolBatchMembers atomic.Int32
 	lastCredentialReq      tenant.CredentialProvisionRequest
 	lastDeprovision        *tenant.ClusterInfo
 	lastQuotaCluster       *tenant.ClusterInfo
@@ -51,6 +53,9 @@ type fakeProvisioner struct {
 	lastCreateQuotaOptions tenant.QuotaUpdateOptions
 	defaultPublicKey       string
 	defaultPrivateKey      string
+	managedClusters        []tenant.CloudClusterInfo
+	sharedPoolResults      []*tenant.SharedDBPoolInfo
+	sharedPoolBatchErr     error
 }
 
 type failingEncryptor struct {
@@ -83,9 +88,316 @@ func (f *fakeProvisioner) DefaultCredentials() (tenant.CredentialProvisionReques
 
 func (f *fakeProvisioner) ProviderType() string { return f.provider }
 
+func TestDefaultTenantProviderIsIndependentFromProvisionerType(t *testing.T) {
+	srv := NewWithConfig(Config{
+		Provisioner:           &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative},
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared,
+	})
+	if srv.defaultTenantProvider != tenant.ProviderTiDBCloudNativeShared {
+		t.Fatalf("defaultTenantProvider = %q, want %q", srv.defaultTenantProvider, tenant.ProviderTiDBCloudNativeShared)
+	}
+	if srv.provisioner.ProviderType() != tenant.ProviderTiDBCloudNative {
+		t.Fatalf("provisioner provider = %q, want native Cloud implementation", srv.provisioner.ProviderType())
+	}
+}
+
+func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+
+	prov := &fakeProvisioner{
+		provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		defaultPublicKey: "public", defaultPrivateKey: "private",
+		sharedPoolResults: []*tenant.SharedDBPoolInfo{{
+			ClusterID: "cluster-shared", OrganizationID: "org-shared", Password: "root-pass", DBName: "tidbcloud_fs",
+		}},
+	}
+	tokenSecret := make([]byte, 32)
+	if _, err := rand.Read(tokenSecret); err != nil {
+		t.Fatal(err)
+	}
+	srv := NewWithConfig(Config{
+		Meta: metaStore, Pool: pool, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: tokenSecret,
+	})
+	defer srv.Close()
+	virtualLimit := int64(2000)
+	res, err := srv.provisionTenant(context.Background(), provisionTenantOptions{
+		CredentialProvisioner: &tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"},
+		Quota:                 &quotaRequest{quotaFields: quotaFields{TiDBCloudSpendingLimit: &virtualLimit}},
+	})
+	if err != nil {
+		t.Fatalf("provisionTenant: %v", err)
+	}
+	if res.Provider != tenant.ProviderTiDBCloudNativeShared || res.Status != meta.TenantProvisioning {
+		t.Fatalf("result = provider %q status %q, want shared/provisioning", res.Provider, res.Status)
+	}
+	tenantRow, err := metaStore.GetTenant(context.Background(), res.TenantID)
+	if err != nil {
+		t.Fatalf("GetTenant: %v", err)
+	}
+	if tenantRow.Status != meta.TenantProvisioning || tenantRow.Provider != tenant.ProviderTiDBCloudNativeShared {
+		t.Fatalf("tenant = provider %q status %q", tenantRow.Provider, tenantRow.Status)
+	}
+	fsID, err := metaStore.ResolveFsID(context.Background(), res.TenantID)
+	if err != nil {
+		t.Fatalf("GetFsID: %v", err)
+	}
+	placement, err := metaStore.GetTenantPlacement(context.Background(), fsID)
+	if err != nil {
+		t.Fatalf("GetTenantPlacement: %v", err)
+	}
+	dbPool, err := metaStore.GetSharedDB(context.Background(), placement.DbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if dbPool.MaxTenants != 100 || dbPool.TenantCount != 1 || dbPool.SpendingLimit == nil || *dbPool.SpendingLimit != 10_000_000 {
+		t.Fatalf("managed pool policy = %+v", dbPool)
+	}
+	quota, err := metaStore.GetQuotaConfig(context.Background(), res.TenantID)
+	if err != nil {
+		t.Fatalf("GetQuotaConfig: %v", err)
+	}
+	if quota.TiDBCloudSpendingLimit == nil || *quota.TiDBCloudSpendingLimit != virtualLimit {
+		t.Fatalf("virtual spending limit = %#v, want %d", quota.TiDBCloudSpendingLimit, virtualLimit)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for prov.sharedPoolBatchCalls.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if prov.sharedPoolBatchCalls.Load() != 1 {
+		t.Fatalf("shared pool batch calls = %d, want 1", prov.sharedPoolBatchCalls.Load())
+	}
+}
+
+func TestProvisionTiDBCloudNativeSharedFallsBackToHardCapacityAfterCreateFailure(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	p := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer p.Close()
+	p.SetMetaStore(metaStore)
+	provisionErr := errors.New("cloud create unavailable")
+	prov := &fakeProvisioner{
+		provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		sharedPoolBatchErr: provisionErr,
+		managedClusters:    []tenant.CloudClusterInfo{{OrganizationID: "org-emergency", ClusterID: "cluster-existing"}},
+	}
+	spendingTarget := int64(10_000)
+	activeID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-emergency", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 2, SpendingLimit: &spendingTarget,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := metaStore.DB().ExecContext(context.Background(), `UPDATE db_pool SET status = ?, cluster_id = 'cluster-existing', db_host = 'h', db_port = 4000,
+		db_user = 'u', db_password = 'c', db_name = 'shared_db' WHERE db_id = ?`, meta.SharedDBStatusActive, activeID); err != nil {
+		t.Fatalf("activate emergency pool: %v", err)
+	}
+	for i := 1; i <= 2; i++ {
+		tenantID := fmt.Sprintf("emergency-existing-%d", i)
+		now := time.Now().UTC()
+		if err := metaStore.InsertTenant(context.Background(), &meta.Tenant{ID: tenantID, Status: meta.TenantPending, Provider: tenant.ProviderTiDBCloudNativeShared, DBPasswordCipher: []byte{}, SchemaVersion: 1, CreatedAt: now, UpdatedAt: now}); err != nil {
+			t.Fatalf("InsertTenant %s: %v", tenantID, err)
+		}
+		limit := int64(1000)
+		if err := metaStore.SetQuotaConfigPatch(context.Background(), tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &limit}); err != nil {
+			t.Fatalf("SetQuotaConfigPatch %s: %v", tenantID, err)
+		}
+		fsID, err := metaStore.EnsureFsID(context.Background(), tenantID)
+		if err != nil {
+			t.Fatalf("EnsureFsID %s: %v", tenantID, err)
+		}
+		key := &meta.APIKey{ID: "key-" + tenantID, TenantID: tenantID, KeyName: "default", JWTCiphertext: []byte("cipher"), JWTHash: "hash-" + tenantID,
+			TokenVersion: 1, Status: meta.APIKeyActive, ScopeKind: meta.APIKeyScopeKindOwner, IssuedAt: now, CreatedAt: now, UpdatedAt: now}
+		if err := metaStore.CompleteSharedTenantProvision(context.Background(), tenantID, tenant.ProviderTiDBCloudNativeShared, &meta.TenantPlacement{FsID: fsID, DbID: activeID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared}, key); err != nil {
+			t.Fatalf("CompleteSharedTenantProvision %s: %v", tenantID, err)
+		}
+	}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: p, Provisioner: prov, DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
+	defer srv.Close()
+	res, err := srv.provisionTenant(context.Background(), provisionTenantOptions{CredentialProvisioner: &tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}})
+	if err != nil {
+		t.Fatalf("provisionTenant fallback: %v", err)
+	}
+	fsID, err := metaStore.ResolveFsID(context.Background(), res.TenantID)
+	if err != nil {
+		t.Fatalf("ResolveFsID: %v", err)
+	}
+	placement, err := metaStore.GetTenantPlacement(context.Background(), fsID)
+	if err != nil {
+		t.Fatalf("GetTenantPlacement: %v", err)
+	}
+	if placement.DbID != activeID {
+		t.Fatalf("fallback placement db = %d, want active pool %d", placement.DbID, activeID)
+	}
+	if prov.sharedPoolBatchCalls.Load() != 1 {
+		t.Fatalf("physical create calls = %d, want 1", prov.sharedPoolBatchCalls.Load())
+	}
+	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusProvisioning, 10)
+	if err != nil {
+		t.Fatalf("ListSharedDBsByStatus: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ClusterID != "" || rows[0].TenantCount != 0 {
+		t.Fatalf("unresolved provisional pool = %+v, want empty physical/count", rows)
+	}
+}
+
+func TestProvisionTiDBCloudNativeSharedResumesExistingProvisioningPool(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{
+		provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		sharedPoolResults: []*tenant.SharedDBPoolInfo{{
+			ClusterID: "cluster-existing", OrganizationID: "org-shared", Password: "root-pass", DBName: "tidbcloud_fs",
+		}},
+	}
+	spendingTarget := int64(10_000_000)
+	provisioningKey := sharedDBProvisioningKey(tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		ProvisioningKey: provisioningKey, CloudProvider: "aws", Region: "us-east-1",
+		MaxTenants: 100, SpendingLimit: &spendingTarget,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	tokenSecret := make([]byte, 32)
+	_, _ = rand.Read(tokenSecret)
+	srv := NewWithConfig(Config{
+		Meta: metaStore, Pool: pool, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: tokenSecret,
+	})
+	defer srv.Close()
+	res, err := srv.provisionTenant(context.Background(), provisionTenantOptions{
+		CredentialProvisioner: &tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"},
+	})
+	if err != nil {
+		t.Fatalf("provisionTenant: %v", err)
+	}
+	if res.Status != meta.TenantProvisioning {
+		t.Fatalf("status = %q, want provisioning", res.Status)
+	}
+	placement, err := metaStore.GetTenantPlacement(context.Background(), mustResolveFsID(t, metaStore, res.TenantID))
+	if err != nil {
+		t.Fatalf("GetTenantPlacement: %v", err)
+	}
+	if placement.DbID != dbID {
+		t.Fatalf("placement db = %d, want existing pool %d", placement.DbID, dbID)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for prov.sharedPoolBatchCalls.Load() == 0 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if prov.sharedPoolBatchCalls.Load() != 1 {
+		t.Fatalf("shared pool batch calls = %d, want resume call", prov.sharedPoolBatchCalls.Load())
+	}
+	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusProvisioning, 10)
+	if err != nil {
+		t.Fatalf("ListSharedDBsByStatus: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != dbID {
+		t.Fatalf("provisioning pools = %+v, want only %d", rows, dbID)
+	}
+}
+
+func mustResolveFsID(t *testing.T, store *meta.Store, tenantID string) int64 {
+	t.Helper()
+	fsID, err := store.ResolveFsID(context.Background(), tenantID)
+	if err != nil {
+		t.Fatalf("ResolveFsID: %v", err)
+	}
+	return fsID
+}
+
 func (f *fakeProvisioner) ProvisioningCloudProvider() string { return f.cloudProvider }
 
 func (f *fakeProvisioner) ProvisioningRegion() string { return f.region }
+
+func (f *fakeProvisioner) DefaultTiDBCloudSpendingLimit() int64 { return 1000 }
+
+func (f *fakeProvisioner) ListManagedClusters(_ context.Context, _ tenant.CredentialProvisionRequest, _ tenant.ManagedClusterListOptions) (*tenant.ManagedClusterListResult, error) {
+	return &tenant.ManagedClusterListResult{Clusters: append([]tenant.CloudClusterInfo(nil), f.managedClusters...)}, nil
+}
+
+func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(_ context.Context, requests []tenant.SharedDBPoolCreateRequest, _ tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+	f.sharedPoolBatchCalls.Add(1)
+	f.sharedPoolBatchMembers.Add(int32(len(requests)))
+	if f.sharedPoolBatchErr != nil {
+		return nil, f.sharedPoolBatchErr
+	}
+	if len(f.sharedPoolResults) > 0 {
+		out := make([]*tenant.SharedDBPoolInfo, len(f.sharedPoolResults))
+		for i, row := range f.sharedPoolResults {
+			copyRow := *row
+			if copyRow.DBPoolID == 0 && i < len(requests) {
+				copyRow.DBPoolID = requests[i].DBPoolID
+			}
+			out[i] = &copyRow
+		}
+		return out, nil
+	}
+	out := make([]*tenant.SharedDBPoolInfo, 0, len(requests))
+	for _, req := range requests {
+		out = append(out, &tenant.SharedDBPoolInfo{
+			DBPoolID: req.DBPoolID, ClusterID: fmt.Sprintf("cluster-%d", req.DBPoolID),
+			OrganizationID: "org-shared", Password: "root-pass", DBName: req.DatabaseName,
+		})
+	}
+	return out, nil
+}
+
+func (f *fakeProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context, _ int64, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+	if clusterID == "" {
+		return nil, nil
+	}
+	for _, row := range f.sharedPoolResults {
+		if row != nil && row.ClusterID == clusterID {
+			copyRow := *row
+			return &copyRow, nil
+		}
+	}
+	return nil, nil
+}
 
 func (f *fakeProvisioner) InitSchema(_ context.Context, dsn string) error {
 	if f.initErr != nil {

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -93,7 +93,7 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if strings.TrimSpace(t.ClusterID) == "" {
+	if !tenant.IsSharedSchemaProvider(t.Provider) && strings.TrimSpace(t.ClusterID) == "" {
 		errJSON(w, http.StatusNotFound, quotaBackendNotFoundMessage)
 		return
 	}
@@ -109,6 +109,21 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		errJSON(w, http.StatusForbidden, "API key tenant does not match requested tenant")
+		return
+	}
+	if t.Provider == tenant.ProviderTiDBCloudNativeShared {
+		cred, err := quotaCredentials(req)
+		if err != nil {
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		physical, err := s.authorizeSharedQuotaCredentials(r.Context(), t, cred, "quota_get")
+		if err != nil {
+			writeQuotaCredentialError(w, r.Context(), err, "query")
+			return
+		}
+		setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, physical.TiDBCloudOrganizationID, classifyTenantRequest(r))
+		s.writeQuotaResponse(w, r, t)
 		return
 	}
 	if t.Provider != tenant.ProviderTiDBCloudNative {
@@ -237,7 +252,7 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	if t.Provider != tenant.ProviderTiDBCloudNative {
+	if t.Provider != tenant.ProviderTiDBCloudNative && t.Provider != tenant.ProviderTiDBCloudNativeShared {
 		errJSON(w, http.StatusConflict, "quota setting is only supported for tidb_cloud_native tenants")
 		return
 	}
@@ -245,12 +260,72 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusConflict, err.Error())
 		return
 	}
-	if err := s.applyQuotaSet(r.Context(), "quota_set", t, cred, req); err != nil {
+	var sharedPhysical *meta.SharedDB
+	if t.Provider == tenant.ProviderTiDBCloudNativeShared {
+		physical, err := s.authorizeSharedQuotaCredentials(r.Context(), t, cred, "quota_set")
+		if err != nil {
+			writeQuotaSetError(w, r.Context(), err, "authorize")
+			return
+		}
+		if err := s.applySharedQuotaSet(r.Context(), t, req); err != nil {
+			writeQuotaSetError(w, r.Context(), err, "update")
+			return
+		}
+		sharedPhysical = physical
+	} else if err := s.applyQuotaSet(r.Context(), "quota_set", t, cred, req); err != nil {
 		writeQuotaSetError(w, r.Context(), err, "update")
 		return
 	}
-	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, s.tenantMetricTiDBCloudOrgID(r.Context(), t), classifyTenantRequest(r))
+	metricOrgID := ""
+	if t.Provider == tenant.ProviderTiDBCloudNativeShared {
+		// The shared authorization path already resolved the physical pool;
+		// reuse its organization label instead of issuing another meta query.
+		metricOrgID = sharedPhysical.TiDBCloudOrganizationID
+	} else {
+		metricOrgID = s.tenantMetricTiDBCloudOrgID(r.Context(), t)
+	}
+	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, metricOrgID, classifyTenantRequest(r))
 	s.writeQuotaResponse(w, r, t)
+}
+
+func (s *Server) authorizeSharedQuotaCredentials(ctx context.Context, t *meta.Tenant, cred tenant.CredentialProvisionRequest, metricPath string) (*meta.SharedDB, error) {
+	physical, err := s.meta.GetSharedDBForTenant(ctx, t.ID)
+	if err != nil || strings.TrimSpace(physical.ClusterID) == "" {
+		return nil, tenant.ErrQuotaBackendNotFound
+	}
+	if s.tidbCloudRBACAllowed(cred, physical.ClusterID, metricPath) {
+		return physical, nil
+	}
+	getter, ok := s.provisioner.(tenant.QuotaGetter)
+	if !ok {
+		return nil, errQuotaSettingNotEnabled
+	}
+	if _, err := getter.GetQuota(ctx, &tenant.ClusterInfo{
+		ClusterID:      physical.ClusterID,
+		OrganizationID: physical.TiDBCloudOrganizationID,
+		Provider:       tenant.ProviderTiDBCloudNative,
+	}, cred); err != nil {
+		return nil, err
+	}
+	s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{
+		ClusterID:      physical.ClusterID,
+		OrganizationID: physical.TiDBCloudOrganizationID,
+	})
+	return physical, nil
+}
+
+func (s *Server) applySharedQuotaSet(ctx context.Context, t *meta.Tenant, req quotaRequest) error {
+	patch, err := quotaConfigPatchFromRequest(req)
+	if err != nil {
+		return err
+	}
+	if err := s.meta.UpdateSharedTenantQuotaConfig(ctx, t.ID, patch); err != nil {
+		return err
+	}
+	if err := s.meta.EnsureQuotaUsageRow(ctx, t.ID); err != nil {
+		return fmt.Errorf("%w: quota usage initialization failed: %w", errQuotaLocalUpdateFailed, err)
+	}
+	return nil
 }
 
 func decodeQuotaRequest(w http.ResponseWriter, r *http.Request) (quotaRequest, error) {
@@ -500,7 +575,7 @@ func (s *Server) writeQuotaResponse(w http.ResponseWriter, r *http.Request, t *m
 		TenantID:       t.ID,
 		Provider:       t.Provider,
 		Status:         string(t.Status),
-		SupportsUpdate: t.Provider == tenant.ProviderTiDBCloudNative,
+		SupportsUpdate: tenant.UsesTiDBCloudNativeCredentials(t.Provider),
 		Config: quotaConfigResponse{
 			MaxStorageSize:         quotaStorageBytesToSize(cfg.MaxStorageBytes),
 			MaxFileSize:            quotaStorageBytesToSize(cfg.MaxFileSizeBytes),
@@ -565,6 +640,8 @@ func writeQuotaSetError(w http.ResponseWriter, ctx context.Context, err error, a
 
 func quotaSetErrorStatusMessage(err error, action string) (int, string, bool) {
 	switch {
+	case errors.Is(err, meta.ErrSharedDBSpendingLimitExceeded):
+		return http.StatusConflict, "shared database spending limit capacity exceeded", true
 	case errors.Is(err, errQuotaSettingNotEnabled):
 		return http.StatusNotFound, "quota setting not enabled", true
 	case errors.Is(err, errQuotaLocalUpdateFailed):

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -560,6 +560,85 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 	}
 }
 
+func TestSharedQuotaGetAndSetUseLocalVirtualValueWithoutCloudMutation(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNativeShared)
+	ctx := context.Background()
+	if _, err := rt.meta.DB().ExecContext(ctx, `UPDATE tenants SET cluster_id = '' WHERE id = ?`, rt.tenantID); err != nil {
+		t.Fatalf("clear tenant cluster id: %v", err)
+	}
+	spendingTarget := int64(10_000_000)
+	dbID, err := rt.meta.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-quota", ProvisioningKey: make([]byte, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	fsID, err := rt.meta.ResolveFsID(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatalf("ResolveFsID: %v", err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+	if err := rt.meta.IncrSharedDBTenantCount(ctx, dbID, 1); err != nil {
+		t.Fatalf("IncrSharedDBTenantCount: %v", err)
+	}
+	if err := rt.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-shared-quota", ClusterID: "cluster-shared-quota",
+	}); err != nil {
+		t.Fatalf("UpdateManagedSharedDBPoolCloudResult: %v", err)
+	}
+	initialLimit := int64(1000)
+	if err := rt.meta.SetQuotaConfig(ctx, &meta.QuotaConfig{
+		TenantID: rt.tenantID, MaxStorageBytes: 100 * quotaStorageSizeBytes,
+		MaxFileSizeBytes: 10 * quotaStorageSizeBytes, MaxMediaLLMFiles: 1,
+		MaxVideoLLMFiles: 1, TiDBCloudSpendingLimit: &initialLimit,
+	}); err != nil {
+		t.Fatalf("SetQuotaConfig: %v", err)
+	}
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+
+	getResp := getQuota(t, ts.URL, rt.tenantID, "", "", rt.apiKey)
+	defer func() { _ = getResp.Body.Close() }()
+	if getResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(getResp.Body)
+		t.Fatalf("GET status = %d body=%s", getResp.StatusCode, raw)
+	}
+	var getOut quotaResponse
+	if err := json.NewDecoder(getResp.Body).Decode(&getOut); err != nil {
+		t.Fatal(err)
+	}
+	if !getOut.SupportsUpdate || getOut.Config.TiDBCloudSpendingLimit == nil || *getOut.Config.TiDBCloudSpendingLimit != initialLimit {
+		t.Fatalf("GET response = %+v", getOut)
+	}
+
+	updatedLimit := int64(2000)
+	setResp := postJSON(t, ts.URL+"/v1/quota", map[string]any{
+		"tenant_id": rt.tenantID, "public_key": "public", "private_key": "private",
+		"tidbcloud_spending_limit": updatedLimit,
+	}, "")
+	defer func() { _ = setResp.Body.Close() }()
+	if setResp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(setResp.Body)
+		t.Fatalf("SET status = %d body=%s", setResp.StatusCode, raw)
+	}
+	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != updatedLimit {
+		t.Fatalf("persisted shared limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, updatedLimit)
+	}
+	if rt.prov.getCalls.Load() != 1 || rt.prov.markCalls.Load() != 0 || rt.prov.updateCalls.Load() != 0 {
+		t.Fatalf("shared quota Cloud calls: get=%d mark=%d update=%d; want one read-only authorization call",
+			rt.prov.getCalls.Load(), rt.prov.markCalls.Load(), rt.prov.updateCalls.Load())
+	}
+}
+
 func TestQuotaGetUsesDrive9APIKeyWhenLocalSpendingLimitExists(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	spendingLimit := int64(10000)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
@@ -43,9 +44,17 @@ import (
 )
 
 type Config struct {
-	Meta        *meta.Store
-	Pool        *tenant.Pool
-	Provisioner tenant.Provisioner
+	Meta                  *meta.Store
+	Pool                  *tenant.Pool
+	Provisioner           tenant.Provisioner
+	DefaultTenantProvider string
+	// SharedDBMaxTenants and SharedDBDefaultSpendingLimit apply only to new
+	// managed tidb_cloud_native_shared pools. Zero values use the documented
+	// defaults (100 tenants and 10,000,000 monthly units).
+	SharedDBMaxTenants           int
+	SharedDBHardCapRatio         float64
+	SharedDBReopenRatio          float64
+	SharedDBDefaultSpendingLimit int64
 	// LegacyStarterProvisioner is only used for delete/fork compatibility on
 	// persisted tidb_cloud_starter tenants. New starter provisioning remains
 	// disabled and NormalizeProvider does not accept tidb_cloud_starter.
@@ -173,42 +182,47 @@ func (s *Server) provisionerForTenantProvider(provider string) tenant.Provisione
 }
 
 type Server struct {
-	fallback                  *backend.Dat9Backend
-	meta                      *meta.Store
-	pool                      *tenant.Pool
-	provisioner               tenant.Provisioner
-	legacyStarterProvisioner  tenant.Provisioner
-	tokenSecret               []byte
-	localTenantAPIKey         string
-	vaultMK                   *vault.MasterKey
-	vaultIssuerURL            string
-	publicURL                 string
-	maxUploadBytes            int64
-	tenantPoolMaxSize         int
-	tenantPoolRefillFreeRatio float64
-	inlineThreshold           int64
-	metrics                   *serverMetrics
-	logger                    *zap.Logger
-	mux                       *http.ServeMux
-	events                    *eventBuses
-	tenantWorker              *tenantWorkerManager
-	shardResolver             *semanticShardResolver
-	journalCursorSecret       []byte
-	objectGCWorker            *objectGCWorker
-	slockOAuth                SlockOAuthClient
-	tidbAutoEmbedding         tenantAutoEmbeddingDefault
-	disableDBAutoEmbed        bool
-	forkWorkerCtx             context.Context
-	forkWorkerCancel          context.CancelFunc
-	forkWorkerWG              sync.WaitGroup
-	forkWorkerMu              sync.Mutex
-	forkWorkerClosed          bool
-	tenantPoolLocks           sync.Map
-	tenantPoolCreateLocks     sync.Map
-	tenantPoolResumeJobs      sync.Map
-	tidbCloudRBACCache        *tidbCloudRBACCache
-	schemaInitErrors          sync.Map
-	leader                    *leader.Manager
+	fallback                     *backend.Dat9Backend
+	meta                         *meta.Store
+	pool                         *tenant.Pool
+	provisioner                  tenant.Provisioner
+	defaultTenantProvider        string
+	sharedDBMaxTenants           int
+	sharedDBHardCapRatio         float64
+	sharedDBReopenRatio          float64
+	sharedDBDefaultSpendingLimit int64
+	legacyStarterProvisioner     tenant.Provisioner
+	tokenSecret                  []byte
+	localTenantAPIKey            string
+	vaultMK                      *vault.MasterKey
+	vaultIssuerURL               string
+	publicURL                    string
+	maxUploadBytes               int64
+	tenantPoolMaxSize            int
+	tenantPoolRefillFreeRatio    float64
+	inlineThreshold              int64
+	metrics                      *serverMetrics
+	logger                       *zap.Logger
+	mux                          *http.ServeMux
+	events                       *eventBuses
+	tenantWorker                 *tenantWorkerManager
+	shardResolver                *semanticShardResolver
+	journalCursorSecret          []byte
+	objectGCWorker               *objectGCWorker
+	slockOAuth                   SlockOAuthClient
+	tidbAutoEmbedding            tenantAutoEmbeddingDefault
+	disableDBAutoEmbed           bool
+	forkWorkerCtx                context.Context
+	forkWorkerCancel             context.CancelFunc
+	forkWorkerWG                 sync.WaitGroup
+	forkWorkerMu                 sync.Mutex
+	forkWorkerClosed             bool
+	tenantPoolLocks              sync.Map
+	tenantPoolCreateLocks        sync.Map
+	tenantPoolResumeJobs         sync.Map
+	tidbCloudRBACCache           *tidbCloudRBACCache
+	schemaInitErrors             sync.Map
+	leader                       *leader.Manager
 	// leaderWorkerCtx gates leader-only background schedulers. When leadership
 	// changes, this context is cancelled and recreated. Workers that use it
 	// (pending tenant reconciler, tenant delete cleanup, one-time resume tasks)
@@ -276,6 +290,14 @@ const DefaultTenantPoolMaxSize = 200
 // active free tenant count falls below 80% of the configured pool size.
 const DefaultTenantPoolRefillFreeRatio = 0.8
 
+// DefaultSharedDBHardCapRatio lets direct shared provisioning temporarily use
+// 20% emergency headroom after physical DB creation fails.
+const DefaultSharedDBHardCapRatio = 1.2
+
+// DefaultSharedDBReopenRatio reopens a latched shared pool once usage falls
+// to 80% of its persisted soft capacity.
+const DefaultSharedDBReopenRatio = 0.8
+
 // TenantStatusResponse is the JSON body of GET /v1/status. Fields are filled
 // per authenticated tenant so callers can discover their effective limits
 // before initiating uploads. MaxUploadBytes is currently process-wide but the
@@ -342,26 +364,43 @@ func NewWithConfig(cfg Config) *Server {
 		tenantPoolMaxSize = DefaultTenantPoolMaxSize
 	}
 	tenantPoolRefillFreeRatio := normalizeTenantPoolRefillFreeRatio(cfg.TenantPoolRefillFreeRatio)
+	sharedDBHardCapRatio := cfg.SharedDBHardCapRatio
+	if sharedDBHardCapRatio < 1 || sharedDBHardCapRatio != sharedDBHardCapRatio || math.IsInf(sharedDBHardCapRatio, 0) {
+		sharedDBHardCapRatio = DefaultSharedDBHardCapRatio
+	}
+	sharedDBReopenRatio := cfg.SharedDBReopenRatio
+	if sharedDBReopenRatio <= 0 || sharedDBReopenRatio >= 1 || sharedDBReopenRatio != sharedDBReopenRatio || math.IsInf(sharedDBReopenRatio, 0) {
+		sharedDBReopenRatio = DefaultSharedDBReopenRatio
+	}
+	defaultTenantProvider := strings.TrimSpace(cfg.DefaultTenantProvider)
+	if defaultTenantProvider == "" && cfg.Provisioner != nil {
+		defaultTenantProvider = cfg.Provisioner.ProviderType()
+	}
 	forkWorkerCtx, forkWorkerCancel := context.WithCancel(context.Background())
 	s := &Server{
-		fallback:                  cfg.Backend,
-		meta:                      cfg.Meta,
-		pool:                      cfg.Pool,
-		tokenSecret:               cfg.TokenSecret,
-		localTenantAPIKey:         strings.TrimSpace(cfg.LocalTenantAPIKey),
-		vaultMK:                   vaultMK,
-		vaultIssuerURL:            strings.TrimSpace(cfg.VaultIssuerURL),
-		publicURL:                 strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
-		provisioner:               cfg.Provisioner,
-		legacyStarterProvisioner:  cfg.LegacyStarterProvisioner,
-		maxUploadBytes:            maxUpload,
-		tenantPoolMaxSize:         tenantPoolMaxSize,
-		tenantPoolRefillFreeRatio: tenantPoolRefillFreeRatio,
-		inlineThreshold:           inlineThreshold,
-		metrics:                   newServerMetrics(),
-		logger:                    logger,
-		events:                    newEventBuses(),
-		slockOAuth:                cfg.SlockOAuth,
+		fallback:                     cfg.Backend,
+		meta:                         cfg.Meta,
+		pool:                         cfg.Pool,
+		tokenSecret:                  cfg.TokenSecret,
+		localTenantAPIKey:            strings.TrimSpace(cfg.LocalTenantAPIKey),
+		vaultMK:                      vaultMK,
+		vaultIssuerURL:               strings.TrimSpace(cfg.VaultIssuerURL),
+		publicURL:                    strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
+		provisioner:                  cfg.Provisioner,
+		defaultTenantProvider:        defaultTenantProvider,
+		sharedDBMaxTenants:           cfg.SharedDBMaxTenants,
+		sharedDBHardCapRatio:         sharedDBHardCapRatio,
+		sharedDBReopenRatio:          sharedDBReopenRatio,
+		sharedDBDefaultSpendingLimit: cfg.SharedDBDefaultSpendingLimit,
+		legacyStarterProvisioner:     cfg.LegacyStarterProvisioner,
+		maxUploadBytes:               maxUpload,
+		tenantPoolMaxSize:            tenantPoolMaxSize,
+		tenantPoolRefillFreeRatio:    tenantPoolRefillFreeRatio,
+		inlineThreshold:              inlineThreshold,
+		metrics:                      newServerMetrics(),
+		logger:                       logger,
+		events:                       newEventBuses(),
+		slockOAuth:                   cfg.SlockOAuth,
 		tidbAutoEmbedding: tenantAutoEmbeddingDefault{
 			config:  defaultTiDBAutoEmbeddingConfig(cfg.TiDBAutoEmbeddingConfig),
 			apiKey:  strings.TrimSpace(cfg.TiDBAutoEmbeddingAPIKey),
@@ -768,6 +807,9 @@ func (s *Server) startLeaderWorkers() {
 			s.resumeProvisioningTenantsWithCtx(workerCtx)
 		})
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			s.resumeManagedSharedDBPoolsWithCtx(workerCtx)
+		})
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
 			s.resumeDeletingForkTenantsWithCtx(workerCtx)
 		})
 		// Periodic tenant delete cleanup.
@@ -822,6 +864,7 @@ func (s *Server) startLeaderWorkers() {
 			defer ticker.Stop()
 			s.observeTenantCounts(workerCtx)
 			s.observeTenantPoolBindingCounts(workerCtx)
+			s.observeSharedDBPoolMetrics(workerCtx)
 			for {
 				select {
 				case <-workerCtx.Done():
@@ -829,6 +872,7 @@ func (s *Server) startLeaderWorkers() {
 				case <-ticker.C:
 					s.observeTenantCounts(workerCtx)
 					s.observeTenantPoolBindingCounts(workerCtx)
+					s.observeSharedDBPoolMetrics(workerCtx)
 				}
 			}
 		})
@@ -960,6 +1004,7 @@ func (s *Server) stopLeaderWorkers() {
 	}
 	if s.metrics != nil {
 		s.metrics.clearTenantPoolBindingSnapshot()
+		s.metrics.clearSharedDBPoolSnapshot()
 	}
 	// In multi-tenant mode the tenant worker is started/stopped in
 	// startNotifyInfrastructure. In single-tenant mode (s.meta == nil) it is
@@ -1005,6 +1050,12 @@ func (s *Server) resumeProvisioningTenantsWithCtx(ctx context.Context) {
 	}
 	for i := range tenants {
 		t := tenants[i]
+		if t.Provider == tenant.ProviderTiDBCloudNativeShared {
+			// Shared tenants never run per-tenant schema initialization. Their
+			// physical DB-pool continuation owns schema readiness and activates
+			// every placed provisioning tenant after the pool becomes active.
+			continue
+		}
 		if t.Kind == meta.TenantKindFork {
 			logger.Info(ctx, "resume_provisioning_fork",
 				zap.String("tenant_id", t.ID),
@@ -1249,7 +1300,7 @@ func tenantDSN(user, password, host string, port int, dbName string, tlsEnabled 
 	query := "parseTime=true"
 	if tlsEnabled {
 		query += "&tls=true"
-	} else if provider == tenant.ProviderTiDBCloudNative {
+	} else if tenant.UsesTiDBCloudNativeCredentials(provider) {
 		query += "&tls=skip-verify"
 	}
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", user, password, host, port, dbName, query)
@@ -4403,7 +4454,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusNotFound, "provisioner not configured")
 		return
 	}
-	provider := s.provisioner.ProviderType()
+	provider := s.defaultTenantProvider
 	provider, err := tenant.NormalizeProvider(provider)
 	if err != nil {
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "provision_provider_invalid", "provider", provider, "error", err)...)
@@ -4413,7 +4464,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 	}
 	var credentialReq *tenant.CredentialProvisionRequest
 	var quotaReq *quotaRequest
-	if provider == tenant.ProviderTiDBCloudNative {
+	if tenant.UsesTiDBCloudNativeCredentials(provider) {
 		decoded, err := decodeCredentialProvisionRequest(w, r)
 		if err != nil {
 			if !errors.Is(err, tenant.ErrCredentialsRequired) {
@@ -4461,7 +4512,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	if provider == tenant.ProviderTiDBCloudNative && credentialReq != nil {
+	if tenant.UsesTiDBCloudNativeCredentials(provider) && credentialReq != nil {
 		poolClaimStarted := time.Now()
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_started", "provider", provider, "quota_requested", quotaReq != nil)...)
 		if res, pool, claimed, _, err := s.claimAdminTenantFromPool(r.Context(), *credentialReq, quotaReq); err != nil {
@@ -5085,17 +5136,19 @@ func (s *Server) findSharedDBForProvision(ctx context.Context, provider string, 
 // provision therefore leaves no partial state: no active shared tenant
 // without a placement row, no capacity leak, no orphaned key.
 func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string, sharedDB *meta.SharedDB, provider, keyName string, opts provisionTenantOptions, now time.Time) (*provisionTenantResult, error) {
+	return s.provisionTenantOnSharedDBMode(ctx, tenantID, sharedDB, provider, keyName, opts, now, meta.SharedDBCapacityNormal, 0)
+}
+
+func (s *Server) provisionTenantOnSharedDBEmergency(ctx context.Context, tenantID string, sharedDB *meta.SharedDB, provider, keyName string, opts provisionTenantOptions, now time.Time, hardCap int) (*provisionTenantResult, error) {
+	return s.provisionTenantOnSharedDBMode(ctx, tenantID, sharedDB, provider, keyName, opts, now, meta.SharedDBCapacityEmergency, hardCap)
+}
+
+func (s *Server) provisionTenantOnSharedDBMode(ctx context.Context, tenantID string, sharedDB *meta.SharedDB, provider, keyName string, opts provisionTenantOptions, now time.Time, capacityMode meta.SharedDBCapacityMode, hardCap int) (*provisionTenantResult, error) {
 	fail := func(err error) (*provisionTenantResult, error) {
 		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
 			logger.Error(ctx, "server_event", eventFields(ctx, "provision_mark_failed_update_error", "tenant_id", tenantID, "provider", provider, "error", uerr)...)
 		}
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to place tenant on shared pool", err)
-	}
-	// Create-time spending limits are per-cluster in the shared world and are
-	// managed on the shared DB itself, not per tenant.
-	if opts.Quota != nil && opts.Quota.TiDBCloudSpendingLimit != nil {
-		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-		return nil, newProvisionTenantError(http.StatusBadRequest, "tidbcloud spending limit is not supported for shared-pool tenants", fmt.Errorf("spending limit requested for shared-pool tenant"))
 	}
 	fsID, err := s.meta.EnsureFsID(ctx, tenantID)
 	if err != nil {
@@ -5117,39 +5170,49 @@ func (s *Server) provisionTenantOnSharedDB(ctx context.Context, tenantID string,
 	if err != nil {
 		return fail(err)
 	}
-	if err := s.meta.CompleteSharedTenantProvision(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, &meta.TenantPlacement{
+	placement := &meta.TenantPlacement{
 		FsID:        fsID,
-		DbID:        sharedDB.DbID,
+		DbID:        sharedDB.ID,
 		Placement:   meta.PlacementShared,
 		SchemaShape: meta.SchemaShapeShared,
-	}, keyRec); err != nil {
-		if errors.Is(err, meta.ErrSharedDBCapacityExhausted) {
-			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-			return nil, newProvisionTenantError(http.StatusConflict, "shared pool is at capacity", err)
+	}
+	var provisionErr error
+	if capacityMode == meta.SharedDBCapacityEmergency {
+		provisionErr = s.meta.CompleteSharedTenantProvisionEmergency(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, placement, keyRec, hardCap)
+	} else {
+		provisionErr = s.meta.CompleteSharedTenantProvision(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, placement, keyRec)
+	}
+	if provisionErr != nil {
+		if errors.Is(provisionErr, meta.ErrSharedDBCapacityExhausted) || errors.Is(provisionErr, meta.ErrSharedDBSpendingLimitExceeded) {
+			return nil, newProvisionTenantError(http.StatusConflict, "shared pool is at capacity", provisionErr)
 		}
-		return fail(err)
+		return fail(provisionErr)
 	}
 	metricEvent(ctx, "metadb_query", "api", "insert_api_key", "result", "ok")
-	logger.Info(ctx, "server_event", eventFields(ctx, "provision_shared_pool_placed", "tenant_id", tenantID, "provider", tenant.ProviderTiDBCloudNativeShared, "db_id", sharedDB.DbID, "org_id", sharedDB.OrgID)...)
+	logger.Info(ctx, "server_event", eventFields(ctx, "provision_shared_pool_placed", "tenant_id", tenantID, "provider", tenant.ProviderTiDBCloudNativeShared, "db_id", sharedDB.ID, "org_id", sharedDB.TiDBCloudOrganizationID)...)
 	metricEvent(ctx, "tenant_provision", "provider", tenant.ProviderTiDBCloudNativeShared, "result", "shared_pool")
+	status := meta.TenantActive
+	if sharedDB.Status == meta.SharedDBStatusProvisioning {
+		status = meta.TenantProvisioning
+	}
 	return &provisionTenantResult{
 		TenantID: tenantID,
 		APIKey:   apiToken,
 		APIKeyID: apiKeyID,
-		Status:   meta.TenantActive,
+		Status:   status,
 		Provider: tenant.ProviderTiDBCloudNativeShared,
 	}, nil
 }
 
 func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOptions) (*provisionTenantResult, error) {
-	rawProvider := s.provisioner.ProviderType()
+	rawProvider := s.defaultTenantProvider
 	provider, err := tenant.NormalizeProvider(rawProvider)
 	if err != nil {
 		logger.Warn(ctx, "server_event", eventFields(ctx, "provision_provider_invalid", "provider", rawProvider, "error", err)...)
 		metricEvent(ctx, "tenant_provision", "provider", rawProvider, "result", "error")
 		return nil, newProvisionTenantError(http.StatusBadRequest, err.Error(), err)
 	}
-	if provider == tenant.ProviderTiDBCloudNative && opts.CredentialProvisioner == nil {
+	if tenant.UsesTiDBCloudNativeCredentials(provider) && opts.CredentialProvisioner == nil {
 		if defaultReq := resolveDefaultCredentials(s.provisioner); defaultReq == nil {
 			return nil, newProvisionTenantError(http.StatusBadRequest, "public_key and private_key are required", fmt.Errorf("public_key and private_key are required"))
 		} else {
@@ -5196,6 +5259,53 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	}
 	metricEvent(ctx, "metadb_query", "api", "insert_tenant", "result", "ok")
 	logProvisionStage(ctx, "provision_tenant_inserted", tenantID, provider, stageStarted, "status", meta.TenantPending)
+	if provider == tenant.ProviderTiDBCloudNativeShared {
+		if opts.CredentialProvisioner == nil {
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			return nil, newProvisionTenantError(http.StatusBadRequest, tenant.ErrCredentialsRequired.Error(), tenant.ErrCredentialsRequired)
+		}
+		if err := s.materializeSharedTenantQuota(ctx, tenantID, opts); err != nil {
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			return nil, newProvisionTenantError(http.StatusBadRequest, err.Error(), err)
+		}
+		var res *provisionTenantResult
+		virtualLimit := s.sharedTenantVirtualSpendingLimit(opts)
+		sharedDB, created, err := s.allocateManagedSharedDB(ctx, *opts.CredentialProvisioner, virtualLimit, nil)
+		if err != nil {
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			return nil, newProvisionTenantError(http.StatusBadGateway, "failed to allocate shared database", err)
+		}
+		if created || sharedDB.ClusterID == "" || sharedDB.Host == "" || sharedDB.Port <= 0 || sharedDB.User == "" {
+			plannedDB := sharedDB
+			sharedDB, err = s.ensureManagedSharedDBPhysical(ctx, plannedDB.ID, *opts.CredentialProvisioner)
+			if err != nil {
+				orgID, orgErr := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner)
+				if orgErr == nil {
+					hardCap, hardErr := s.managedSharedDBHardCap(plannedDB.MaxTenants)
+					if hardErr == nil {
+						fallback, findErr := s.meta.FindSharedDBForEmergency(ctx, orgID, hardCap, virtualLimit)
+						if findErr == nil {
+							res, findErr = s.provisionTenantOnSharedDBEmergency(ctx, tenantID, fallback, provider, keyName, opts, now, hardCap)
+							if findErr == nil {
+								return res, nil
+							}
+						}
+					}
+				}
+				_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+				return nil, newProvisionTenantError(http.StatusBadGateway, "failed to create shared database", err)
+			}
+		}
+		res, err = s.provisionTenantOnSharedDB(ctx, tenantID, sharedDB, provider, keyName, opts, now)
+		if err != nil {
+			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+			return nil, err
+		}
+		if created || sharedDB.Status == meta.SharedDBStatusProvisioning {
+			s.scheduleManagedSharedDBContinuation(ctx, sharedDB.ID, *opts.CredentialProvisioner)
+		}
+		return res, nil
+	}
 
 	// Shared-pool placement: when a shared-schema database is registered for
 	// this tenant's org (or a wildcard pool exists), the tenant is placed on
@@ -5471,7 +5581,7 @@ func (s *Server) cleanupProvisionedClusterAfterProvisionFailure(ctx context.Cont
 }
 
 func dbTLSForProvisionedTenant(provider string) bool {
-	if provider != tenant.ProviderTiDBCloudNative {
+	if !tenant.UsesTiDBCloudNativeCredentials(provider) {
 		return true
 	}
 	v := strings.TrimSpace(strings.ToLower(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT")))

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5150,6 +5150,15 @@ func (s *Server) provisionTenantOnSharedDBMode(ctx context.Context, tenantID str
 		}
 		return nil, newProvisionTenantError(http.StatusInternalServerError, "failed to place tenant on shared pool", err)
 	}
+	// Only the managed shared provider materializes a per-tenant virtual
+	// spending limit. Legacy native/zero routing to a manually registered shared
+	// DB pool must keep failing closed instead of silently dropping the request.
+	if provider != tenant.ProviderTiDBCloudNativeShared && opts.Quota != nil && opts.Quota.TiDBCloudSpendingLimit != nil {
+		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+		return nil, newProvisionTenantError(http.StatusBadRequest,
+			"tidbcloud spending limit is not supported for shared-pool tenants",
+			fmt.Errorf("spending limit requested for shared-pool tenant"))
+	}
 	fsID, err := s.meta.EnsureFsID(ctx, tenantID)
 	if err != nil {
 		return fail(err)
@@ -5275,7 +5284,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 			return nil, newProvisionTenantError(http.StatusBadGateway, "failed to allocate shared database", err)
 		}
-		if created || sharedDB.ClusterID == "" || sharedDB.Host == "" || sharedDB.Port <= 0 || sharedDB.User == "" {
+		if sharedDB.SpendingLimit != nil && (created || sharedDB.ClusterID == "" || sharedDB.Host == "" || sharedDB.Port <= 0 || sharedDB.User == "") {
 			plannedDB := sharedDB
 			sharedDB, err = s.ensureManagedSharedDBPhysical(ctx, plannedDB.ID, *opts.CredentialProvisioner)
 			if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5143,6 +5143,29 @@ func (s *Server) provisionTenantOnSharedDBEmergency(ctx context.Context, tenantI
 	return s.provisionTenantOnSharedDBMode(ctx, tenantID, sharedDB, provider, keyName, opts, now, meta.SharedDBCapacityEmergency, hardCap)
 }
 
+func (s *Server) provisionTenantOnManagedSharedDB(ctx context.Context, tenantID string, sharedDB *meta.SharedDB, provider, keyName string, opts provisionTenantOptions, now time.Time) (*provisionTenantResult, error) {
+	current, err := s.meta.GetSharedDB(ctx, sharedDB.ID)
+	if err != nil {
+		return nil, err
+	}
+	identity := sharedDBAllocationIdentity(current.TiDBCloudOrganizationID, current.ProvisioningKey)
+	var result *provisionTenantResult
+	err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+		locked, loadErr := s.meta.GetSharedDB(lockCtx, current.ID)
+		if loadErr != nil {
+			return loadErr
+		}
+		var provisionErr error
+		result, provisionErr = s.provisionTenantOnSharedDB(lockCtx, tenantID, locked, provider, keyName, opts, now)
+		return provisionErr
+	})
+	return result, err
+}
+
+func isSharedDBReservationConflict(err error) bool {
+	return errors.Is(err, meta.ErrSharedDBCapacityExhausted) || errors.Is(err, meta.ErrSharedDBSpendingLimitExceeded)
+}
+
 func (s *Server) provisionTenantOnSharedDBMode(ctx context.Context, tenantID string, sharedDB *meta.SharedDB, provider, keyName string, opts provisionTenantOptions, now time.Time, capacityMode meta.SharedDBCapacityMode, hardCap int) (*provisionTenantResult, error) {
 	fail := func(err error) (*provisionTenantResult, error) {
 		if uerr := s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed); uerr != nil {
@@ -5277,43 +5300,53 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 			return nil, newProvisionTenantError(http.StatusBadRequest, err.Error(), err)
 		}
-		var res *provisionTenantResult
 		virtualLimit := s.sharedTenantVirtualSpendingLimit(opts)
-		sharedDB, created, err := s.allocateManagedSharedDB(ctx, *opts.CredentialProvisioner, virtualLimit, nil)
-		if err != nil {
-			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-			return nil, newProvisionTenantError(http.StatusBadGateway, "failed to allocate shared database", err)
-		}
-		if sharedDB.SpendingLimit != nil && (created || sharedDB.ClusterID == "" || sharedDB.Host == "" || sharedDB.Port <= 0 || sharedDB.User == "") {
-			plannedDB := sharedDB
-			sharedDB, err = s.ensureManagedSharedDBPhysical(ctx, plannedDB.ID, *opts.CredentialProvisioner)
-			if err != nil {
-				orgID, orgErr := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner)
-				if orgErr == nil {
-					hardCap, hardErr := s.managedSharedDBHardCap(plannedDB.MaxTenants)
-					if hardErr == nil {
-						fallback, findErr := s.meta.FindSharedDBForEmergency(ctx, orgID, hardCap, virtualLimit)
+		var lastConflict error
+		for attempt := 0; attempt < 2; attempt++ {
+			sharedDB, created, allocateErr := s.allocateManagedSharedDB(ctx, *opts.CredentialProvisioner, virtualLimit, nil)
+			if allocateErr != nil {
+				_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+				return nil, newProvisionTenantError(http.StatusBadGateway, "failed to allocate shared database", allocateErr)
+			}
+			if sharedDB.SpendingLimit != nil && (created || sharedDB.ClusterID == "" || sharedDB.Host == "" || sharedDB.Port <= 0 || sharedDB.User == "") {
+				sharedDB, err = s.ensureManagedSharedDBPhysical(ctx, sharedDB.ID, *opts.CredentialProvisioner)
+				if err != nil {
+					orgID, orgErr := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner)
+					if orgErr == nil {
+						fallback, findErr := s.meta.FindSharedDBForEmergency(ctx, orgID, s.sharedDBHardCapRatio, virtualLimit)
 						if findErr == nil {
-							res, findErr = s.provisionTenantOnSharedDBEmergency(ctx, tenantID, fallback, provider, keyName, opts, now, hardCap)
-							if findErr == nil {
-								return res, nil
+							hardCap, hardErr := s.managedSharedDBHardCap(fallback.MaxTenants)
+							if hardErr == nil {
+								res, reserveErr := s.provisionTenantOnSharedDBEmergency(ctx, tenantID, fallback, provider, keyName, opts, now, hardCap)
+								if reserveErr == nil {
+									return res, nil
+								}
+								if isSharedDBReservationConflict(reserveErr) {
+									lastConflict = reserveErr
+									continue
+								}
 							}
 						}
 					}
+					_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+					return nil, newProvisionTenantError(http.StatusBadGateway, "failed to create shared database", err)
+				}
+			}
+			res, reserveErr := s.provisionTenantOnManagedSharedDB(ctx, tenantID, sharedDB, provider, keyName, opts, now)
+			if reserveErr != nil {
+				if isSharedDBReservationConflict(reserveErr) {
+					lastConflict = reserveErr
+					continue
 				}
 				_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-				return nil, newProvisionTenantError(http.StatusBadGateway, "failed to create shared database", err)
+				return nil, reserveErr
 			}
+			if created || sharedDB.Status == meta.SharedDBStatusProvisioning {
+				s.scheduleManagedSharedDBContinuation(ctx, sharedDB.ID, *opts.CredentialProvisioner)
+			}
+			return res, nil
 		}
-		res, err = s.provisionTenantOnSharedDB(ctx, tenantID, sharedDB, provider, keyName, opts, now)
-		if err != nil {
-			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-			return nil, err
-		}
-		if created || sharedDB.Status == meta.SharedDBStatusProvisioning {
-			s.scheduleManagedSharedDBContinuation(ctx, sharedDB.ID, *opts.CredentialProvisioner)
-		}
-		return res, nil
+		return nil, lastConflict
 	}
 
 	// Shared-pool placement: when a shared-schema database is registered for

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -837,6 +837,7 @@ func (s *Server) startLeaderWorkers() {
 						return
 					case <-ticker.C:
 						s.resumePendingTenantsWithCtx(workerCtx)
+						s.resumeManagedSharedDBPoolsWithCtx(workerCtx)
 					}
 				}
 			})
@@ -5309,7 +5310,8 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 				return nil, newProvisionTenantError(http.StatusBadGateway, "failed to allocate shared database", allocateErr)
 			}
 			if sharedDB.SpendingLimit != nil && (created || sharedDB.ClusterID == "" || sharedDB.Host == "" || sharedDB.Port <= 0 || sharedDB.User == "") {
-				sharedDB, err = s.ensureManagedSharedDBPhysical(ctx, sharedDB.ID, *opts.CredentialProvisioner)
+				plannedDB := sharedDB
+				sharedDB, err = s.ensureManagedSharedDBPhysical(ctx, plannedDB.ID, *opts.CredentialProvisioner)
 				if err != nil {
 					orgID, orgErr := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner)
 					if orgErr == nil {
@@ -5319,6 +5321,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 							if hardErr == nil {
 								res, reserveErr := s.provisionTenantOnSharedDBEmergency(ctx, tenantID, fallback, provider, keyName, opts, now, hardCap)
 								if reserveErr == nil {
+									s.scheduleManagedSharedDBContinuation(ctx, plannedDB.ID, *opts.CredentialProvisioner)
 									return res, nil
 								}
 								if isSharedDBReservationConflict(reserveErr) {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -434,6 +434,12 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64, 
 	return result, err
 }
 
+// continueManagedSharedDBPoolLocked intentionally keeps the organization
+// allocation lock through physical ensure, system-user setup, schema ensure,
+// and activation. Continuations are dispatched sequentially and are not a
+// request-QPS path; the wider lock preserves the existing single-owner Cloud
+// mutation model and prevents another allocator from observing half-ready
+// connection metadata. The readiness poll is the one long wait kept outside.
 func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo *meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
 	dbID := poolInfo.ID
 	var err error

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -240,9 +240,23 @@ func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs
 			if workerCtx.Err() != nil {
 				return
 			}
-			if err := s.continueManagedSharedDBPool(workerCtx, dbID, cred); err != nil {
-				logger.Warn(workerCtx, "managed_shared_db_pool_continue_failed",
-					zap.Int64("db_pool_id", dbID), zap.Error(err))
+			for attempt := 0; attempt < 2; attempt++ {
+				err := s.continueManagedSharedDBPool(workerCtx, dbID, cred)
+				if err == nil {
+					break
+				}
+				if attempt == 1 {
+					logger.Warn(workerCtx, "managed_shared_db_pool_continue_failed",
+						zap.Int64("db_pool_id", dbID), zap.Error(err))
+					break
+				}
+				timer := time.NewTimer(time.Second)
+				select {
+				case <-workerCtx.Done():
+					timer.Stop()
+					return
+				case <-timer.C:
+				}
 			}
 		}
 	})

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -23,6 +23,8 @@ const (
 	sharedTenantActivationBatchSize     = 100
 )
 
+var errSharedDBConnectionMetadataNotReady = errors.New("shared DB pool connection metadata is not ready")
+
 type defaultTiDBCloudSpendingLimitProvider interface {
 	DefaultTiDBCloudSpendingLimit() int64
 }
@@ -268,6 +270,30 @@ func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
 }
 
 func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) error {
+	for metadataAttempt := 0; metadataAttempt < 2; metadataAttempt++ {
+		err := s.continueManagedSharedDBPoolOnce(ctx, dbID, cred)
+		if !errors.Is(err, errSharedDBConnectionMetadataNotReady) {
+			return err
+		}
+		waiter, ok := s.provisioner.(tenant.SharedDBPoolMetadataWaiter)
+		if !ok {
+			return err
+		}
+		poolInfo, loadErr := s.meta.GetSharedDB(ctx, dbID)
+		if loadErr != nil {
+			return loadErr
+		}
+		if poolInfo.ClusterID == "" {
+			return err
+		}
+		if _, waitErr := waiter.WaitForSharedDBPoolMetadataWithCredentials(ctx, dbID, poolInfo.ClusterID, cred); waitErr != nil {
+			return waitErr
+		}
+	}
+	return fmt.Errorf("%w: db pool %d", errSharedDBConnectionMetadataNotReady, dbID)
+}
+
+func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) error {
 	for attempt := 0; attempt < 2; attempt++ {
 		poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
 		if err != nil {
@@ -497,7 +523,7 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 		}
 	}
 	if poolInfo.Host == "" || poolInfo.Port <= 0 || poolInfo.User == "" || len(poolInfo.PasswordCipher) == 0 || poolInfo.Name == "" {
-		return fmt.Errorf("shared db pool %d connection metadata is not ready", dbID)
+		return fmt.Errorf("%w: db pool %d", errSharedDBConnectionMetadataNotReady, dbID)
 	}
 	plain, err := s.pool.Decrypt(ctx, poolInfo.PasswordCipher)
 	if err != nil {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -1,0 +1,554 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"math/big"
+	"slices"
+	"strings"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+	"go.uber.org/zap"
+)
+
+const (
+	defaultManagedSharedDBMaxTenants    = 100
+	defaultManagedSharedDBSpendingLimit = int64(10_000_000)
+	defaultSharedTenantSpendingLimit    = int64(1000)
+	sharedTenantActivationBatchSize     = 100
+)
+
+type defaultTiDBCloudSpendingLimitProvider interface {
+	DefaultTiDBCloudSpendingLimit() int64
+}
+
+type defaultSharedDatabaseNameProvider interface {
+	DefaultSharedDatabaseName() string
+}
+
+func (s *Server) managedSharedDBPolicy() (maxTenants int, spendingLimit int64) {
+	maxTenants = s.sharedDBMaxTenants
+	if maxTenants <= 0 {
+		maxTenants = defaultManagedSharedDBMaxTenants
+	}
+	spendingLimit = s.sharedDBDefaultSpendingLimit
+	if spendingLimit <= 0 {
+		spendingLimit = defaultManagedSharedDBSpendingLimit
+	}
+	return maxTenants, spendingLimit
+}
+
+func (s *Server) managedSharedDBHardCap(softCap int) (int, error) {
+	ratio := s.sharedDBHardCapRatio
+	if ratio < 1 || ratio != ratio {
+		ratio = DefaultSharedDBHardCapRatio
+	}
+	return meta.SharedDBHardCap(softCap, ratio)
+}
+
+func (s *Server) sharedTenantVirtualSpendingLimit(opts provisionTenantOptions) int64 {
+	if opts.Quota != nil && opts.Quota.TiDBCloudSpendingLimit != nil {
+		return *opts.Quota.TiDBCloudSpendingLimit
+	}
+	if provider, ok := s.provisioner.(defaultTiDBCloudSpendingLimitProvider); ok {
+		return provider.DefaultTiDBCloudSpendingLimit()
+	}
+	return defaultSharedTenantSpendingLimit
+}
+
+func sharedDBProvisioningKey(req tenant.CredentialProvisionRequest) []byte {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(req.PublicKey)))
+	return sum[:]
+}
+
+func sharedDBAllocationIdentity(organizationID string, provisioningKey []byte) string {
+	if organizationID != "" {
+		return "org:" + organizationID
+	}
+	return fmt.Sprintf("credential:%x", provisioningKey)
+}
+
+func managedSharedDBDSN(info *meta.SharedDB, password string) string {
+	query := "parseTime=true"
+	if info.TLSMode != "" {
+		query += "&tls=" + info.TLSMode
+	}
+	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", info.User, password, info.Host, info.Port, info.Name, query)
+}
+
+func generateManagedSharedDBRootPassword(length int) (string, error) {
+	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	if length <= 0 {
+		return "", fmt.Errorf("password length must be positive")
+	}
+	out := make([]byte, length)
+	max := big.NewInt(int64(len(chars)))
+	for i := range out {
+		n, err := rand.Int(rand.Reader, max)
+		if err != nil {
+			return "", err
+		}
+		out[i] = chars[n.Int64()]
+	}
+	return string(out), nil
+}
+
+func (s *Server) materializeSharedTenantQuota(ctx context.Context, tenantID string, opts provisionTenantOptions) error {
+	virtualLimit := s.sharedTenantVirtualSpendingLimit(opts)
+	if opts.Quota != nil {
+		req := *opts.Quota
+		req.TenantID = tenantID
+		if err := s.validateQuotaSetRequest(req); err != nil {
+			return err
+		}
+	}
+	cfg := &meta.QuotaConfig{
+		TenantID:               tenantID,
+		MaxStorageBytes:        meta.DefaultMaxStorageBytes(),
+		MaxFileSizeBytes:       meta.DefaultMaxFileSizeBytes(),
+		MaxFileCount:           0,
+		MaxMediaLLMFiles:       meta.DefaultMaxMediaLLMFiles(),
+		MaxVideoLLMFiles:       meta.DefaultMaxVideoLLMFiles(),
+		TiDBCloudSpendingLimit: &virtualLimit,
+	}
+	if opts.Quota != nil {
+		if opts.Quota.MaxStorageSize != nil {
+			cfg.MaxStorageBytes = *opts.Quota.MaxStorageSize
+		}
+		if opts.Quota.MaxFileSize != nil {
+			cfg.MaxFileSizeBytes = *opts.Quota.MaxFileSize
+		}
+		if opts.Quota.MaxFileCount != nil {
+			cfg.MaxFileCount = *opts.Quota.MaxFileCount
+		}
+	}
+	if err := s.meta.SetQuotaConfig(ctx, cfg); err != nil {
+		return fmt.Errorf("materialize shared tenant quota: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.CredentialProvisionRequest, tenantSpendingLimit int64, reserve func(*meta.SharedDB) error) (sharedDB *meta.SharedDB, created bool, err error) {
+	organizationID, resolveErr := s.firstManagedOrganization(ctx, cred)
+	if resolveErr != nil {
+		return nil, false, fmt.Errorf("resolve tidbcloud organization: %w", resolveErr)
+	}
+	provisioningKey := sharedDBProvisioningKey(cred)
+	identity := sharedDBAllocationIdentity(organizationID, provisioningKey)
+	err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+		for attempt := 0; attempt < 2; attempt++ {
+			candidate, findErr := s.meta.FindSharedDBForAllocation(lockCtx, organizationID, provisioningKey, tenantSpendingLimit)
+			if findErr == nil {
+				sharedDB = candidate
+			} else if !errors.Is(findErr, meta.ErrNotFound) {
+				return findErr
+			} else if organizationID != "" {
+				manual, manualErr := s.meta.FindSharedDBForOrg(lockCtx, organizationID)
+				if manualErr == nil && manual.SpendingLimit == nil {
+					sharedDB = manual
+				} else if manualErr != nil && !errors.Is(manualErr, meta.ErrNotFound) {
+					return manualErr
+				}
+			}
+			if sharedDB == nil {
+				maxTenants, configuredFloor := s.managedSharedDBPolicy()
+				fixedTarget := configuredFloor
+				if tenantSpendingLimit >= maxInt32 {
+					return meta.ErrSharedDBSpendingLimitExceeded
+				}
+				if tenantSpendingLimit+1 > fixedTarget {
+					fixedTarget = tenantSpendingLimit + 1
+				}
+				cloudProvider, region := provisioningCloudRegion(s.provisioner)
+				rootPassword, passwordErr := generateManagedSharedDBRootPassword(24)
+				if passwordErr != nil {
+					return passwordErr
+				}
+				passwordCipher, encryptErr := s.pool.Encrypt(lockCtx, []byte(rootPassword))
+				if encryptErr != nil {
+					return fmt.Errorf("encrypt shared db root password: %w", encryptErr)
+				}
+				id, createErr := s.meta.CreateManagedSharedDBPool(lockCtx, &meta.SharedDB{
+					TiDBCloudOrganizationID: organizationID,
+					ProvisioningKey:         provisioningKey,
+					CloudProvider:           cloudProvider,
+					Region:                  region,
+					MaxTenants:              maxTenants,
+					SpendingLimit:           &fixedTarget,
+					PasswordCipher:          passwordCipher,
+					Name:                    s.defaultSharedDatabaseName(),
+				})
+				if createErr != nil {
+					return createErr
+				}
+				sharedDB, createErr = s.meta.GetSharedDB(lockCtx, id)
+				if createErr != nil {
+					return createErr
+				}
+				created = true
+			}
+			if reserve == nil {
+				return nil
+			}
+			reserveErr := reserve(sharedDB)
+			if reserveErr == nil {
+				return nil
+			}
+			if !errors.Is(reserveErr, meta.ErrSharedDBCapacityExhausted) && !errors.Is(reserveErr, meta.ErrSharedDBSpendingLimitExceeded) {
+				return reserveErr
+			}
+			sharedDB = nil
+			created = false
+		}
+		return meta.ErrSharedDBCapacityExhausted
+	})
+	return sharedDB, created, err
+}
+
+func (s *Server) defaultSharedDatabaseName() string {
+	if provider, ok := s.provisioner.(defaultSharedDatabaseNameProvider); ok {
+		if name := strings.TrimSpace(provider.DefaultSharedDatabaseName()); name != "" {
+			return name
+		}
+	}
+	return "tidbcloud_fs"
+}
+
+func (s *Server) scheduleManagedSharedDBContinuation(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) {
+	s.scheduleManagedSharedDBContinuations(ctx, []int64{dbID}, cred)
+}
+
+// scheduleManagedSharedDBContinuations runs one request batch sequentially.
+// Every continuation acquires the same organization-level named lock. Starting
+// one goroutine per DB pool would let all waiters pin dedicated meta *sql.Conn
+// values and can exhaust the connection pool before the lock holder finishes.
+func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs []int64, cred tenant.CredentialProvisionRequest) {
+	if len(dbIDs) == 0 {
+		return
+	}
+	ids := append([]int64(nil), dbIDs...)
+	slices.Sort(ids)
+	s.startServerWorker(ctx, func(workerCtx context.Context) {
+		for _, dbID := range ids {
+			if workerCtx.Err() != nil {
+				return
+			}
+			if err := s.continueManagedSharedDBPool(workerCtx, dbID, cred); err != nil {
+				logger.Warn(workerCtx, "managed_shared_db_pool_continue_failed",
+					zap.Int64("db_pool_id", dbID), zap.Error(err))
+			}
+		}
+	})
+}
+
+func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
+	cred := resolveDefaultCredentials(s.provisioner)
+	if cred == nil {
+		return
+	}
+	rows, err := s.meta.ListSharedDBsByStatus(ctx, meta.SharedDBStatusProvisioning, 1000)
+	if err != nil {
+		logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.Error(err))
+		return
+	}
+	for _, row := range rows {
+		if ctx.Err() != nil {
+			return
+		}
+		if err := s.continueManagedSharedDBPool(ctx, row.ID, *cred); err != nil {
+			logger.Warn(ctx, "managed_shared_db_pool_resume_failed",
+				zap.Int64("db_pool_id", row.ID), zap.Error(err))
+		}
+	}
+}
+
+func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) error {
+	for attempt := 0; attempt < 2; attempt++ {
+		poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
+		if err != nil {
+			return err
+		}
+		identity := sharedDBAllocationIdentity(poolInfo.TiDBCloudOrganizationID, poolInfo.ProvisioningKey)
+		restartWithOrganization := false
+		err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+			current, loadErr := s.meta.GetSharedDB(lockCtx, dbID)
+			if loadErr != nil {
+				return loadErr
+			}
+			if poolInfo.TiDBCloudOrganizationID == "" && current.TiDBCloudOrganizationID != "" {
+				restartWithOrganization = true
+				return nil
+			}
+			return s.continueManagedSharedDBPoolLocked(lockCtx, current, cred)
+		})
+		if err != nil {
+			return err
+		}
+		if !restartWithOrganization {
+			return nil
+		}
+	}
+	return fmt.Errorf("db pool %d allocation identity kept changing", dbID)
+}
+
+// ensureManagedSharedDBPhysicalLocked performs only the physical create/adopt
+// stage. It deliberately does not wait for endpoint readiness, system-user
+// setup, schema initialization, or activation so direct requests can fall back
+// to an existing active pool when Cloud create fails.
+func (s *Server) ensureManagedSharedDBPhysicalLocked(ctx context.Context, poolInfo *meta.SharedDB, cred tenant.CredentialProvisionRequest) (*meta.SharedDB, error) {
+	if poolInfo == nil {
+		return nil, fmt.Errorf("managed shared db pool is required")
+	}
+	if poolInfo.ClusterID != "" && poolInfo.Host != "" && poolInfo.Port > 0 && poolInfo.User != "" {
+		return poolInfo, nil
+	}
+	provisioner, ok := s.provisioner.(tenant.SharedDBPoolProvisioner)
+	if !ok {
+		return nil, fmt.Errorf("provisioner does not support managed shared db pools")
+	}
+	if len(poolInfo.PasswordCipher) == 0 || poolInfo.Name == "" {
+		rootPassword, err := generateManagedSharedDBRootPassword(24)
+		if err != nil {
+			return nil, err
+		}
+		passwordCipher, err := s.pool.Encrypt(ctx, []byte(rootPassword))
+		if err != nil {
+			return nil, fmt.Errorf("encrypt shared db root password: %w", err)
+		}
+		if err := s.meta.PrepareManagedSharedDBPoolRoot(ctx, poolInfo.ID, passwordCipher, s.defaultSharedDatabaseName()); err != nil {
+			return nil, err
+		}
+		poolInfo, err = s.meta.GetSharedDB(ctx, poolInfo.ID)
+		if err != nil {
+			return nil, err
+		}
+	}
+	plainRootPassword, err := s.pool.Decrypt(ctx, poolInfo.PasswordCipher)
+	if err != nil {
+		return nil, fmt.Errorf("decrypt shared db root password: %w", err)
+	}
+	if poolInfo.SpendingLimit == nil {
+		return nil, fmt.Errorf("managed db pool %d has no spending target", poolInfo.ID)
+	}
+	result, err := provisioner.LoadSharedDBPoolWithCredentials(ctx, poolInfo.ID, poolInfo.ClusterID, cred)
+	if err != nil {
+		if errors.Is(err, tenant.ErrSharedDBPoolAmbiguous) {
+			if markErr := s.meta.MarkSharedDBPoolFailed(ctx, poolInfo.ID); markErr != nil {
+				return nil, errors.Join(err, markErr)
+			}
+		}
+		return nil, err
+	}
+	var provisionErr error
+	if result == nil {
+		if poolInfo.ClusterID != "" {
+			return nil, fmt.Errorf("managed shared cluster %q was not found", poolInfo.ClusterID)
+		}
+		results, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, []tenant.SharedDBPoolCreateRequest{{
+			DBPoolID: poolInfo.ID, DatabaseName: poolInfo.Name, RootPassword: string(plainRootPassword),
+			SpendingLimitMonthly: *poolInfo.SpendingLimit,
+		}}, cred)
+		provisionErr = createErr
+		if createErr != nil && len(results) == 0 {
+			return nil, createErr
+		}
+		if len(results) != 1 || results[0] == nil || results[0].DBPoolID != poolInfo.ID {
+			return nil, fmt.Errorf("shared db pool create returned no unique result for %d", poolInfo.ID)
+		}
+		result = results[0]
+	}
+	if result.OrganizationID == "" {
+		result.OrganizationID = poolInfo.TiDBCloudOrganizationID
+	}
+	if result.DBName == "" {
+		result.DBName = poolInfo.Name
+	}
+	tlsMode := "true"
+	if !dbTLSForProvisionedTenant(tenant.ProviderTiDBCloudNativeShared) {
+		tlsMode = "skip-verify"
+	}
+	if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{
+		ID: poolInfo.ID, TiDBCloudOrganizationID: result.OrganizationID, ClusterID: result.ClusterID,
+		Host: result.Host, Port: result.Port, User: result.Username, PasswordCipher: poolInfo.PasswordCipher,
+		Name: result.DBName, TLSMode: tlsMode,
+	}); err != nil {
+		return nil, err
+	}
+	poolInfo, err = s.meta.GetSharedDB(ctx, poolInfo.ID)
+	if err != nil {
+		return nil, err
+	}
+	if provisionErr != nil {
+		return nil, provisionErr
+	}
+	return poolInfo, nil
+}
+
+func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) (*meta.SharedDB, error) {
+	poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		return nil, err
+	}
+	identity := sharedDBAllocationIdentity(poolInfo.TiDBCloudOrganizationID, poolInfo.ProvisioningKey)
+	var result *meta.SharedDB
+	err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+		current, err := s.meta.GetSharedDB(lockCtx, dbID)
+		if err != nil {
+			return err
+		}
+		var ensureErr error
+		result, ensureErr = s.ensureManagedSharedDBPhysicalLocked(lockCtx, current, cred)
+		return ensureErr
+	})
+	return result, err
+}
+
+func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo *meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
+	dbID := poolInfo.ID
+	var err error
+	if poolInfo.Status == meta.SharedDBStatusActive {
+		return nil
+	}
+	provisioner, ok := s.provisioner.(tenant.SharedDBPoolProvisioner)
+	if !ok {
+		return fmt.Errorf("provisioner does not support managed shared db pools")
+	}
+	if len(poolInfo.PasswordCipher) == 0 || poolInfo.Name == "" {
+		rootPassword, passwordErr := generateManagedSharedDBRootPassword(24)
+		if passwordErr != nil {
+			return passwordErr
+		}
+		passwordCipher, encryptErr := s.pool.Encrypt(ctx, []byte(rootPassword))
+		if encryptErr != nil {
+			return fmt.Errorf("encrypt shared db root password: %w", encryptErr)
+		}
+		if err := s.meta.PrepareManagedSharedDBPoolRoot(ctx, dbID, passwordCipher, s.defaultSharedDatabaseName()); err != nil {
+			return err
+		}
+		poolInfo, err = s.meta.GetSharedDB(ctx, dbID)
+		if err != nil {
+			return err
+		}
+	}
+	plainRootPassword, err := s.pool.Decrypt(ctx, poolInfo.PasswordCipher)
+	if err != nil {
+		return fmt.Errorf("decrypt shared db root password: %w", err)
+	}
+	needsMetadata := poolInfo.ClusterID == "" || poolInfo.Host == "" || poolInfo.Port <= 0 || poolInfo.User == ""
+	if needsMetadata {
+		if poolInfo.SpendingLimit == nil {
+			return fmt.Errorf("managed db pool %d has no spending target", dbID)
+		}
+		result, loadErr := provisioner.LoadSharedDBPoolWithCredentials(ctx, dbID, poolInfo.ClusterID, cred)
+		if loadErr != nil {
+			if errors.Is(loadErr, tenant.ErrSharedDBPoolAmbiguous) {
+				if markErr := s.meta.MarkSharedDBPoolFailed(ctx, dbID); markErr != nil {
+					return errors.Join(loadErr, markErr)
+				}
+			}
+			return loadErr
+		}
+		var provisionErr error
+		if result == nil {
+			if poolInfo.ClusterID != "" {
+				return fmt.Errorf("managed shared cluster %q was not found", poolInfo.ClusterID)
+			}
+			results, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, []tenant.SharedDBPoolCreateRequest{{
+				DBPoolID: dbID, DatabaseName: poolInfo.Name, RootPassword: string(plainRootPassword),
+				SpendingLimitMonthly: *poolInfo.SpendingLimit,
+			}}, cred)
+			provisionErr = createErr
+			if createErr != nil && len(results) == 0 {
+				return createErr
+			}
+			if len(results) != 1 || results[0] == nil || results[0].DBPoolID != dbID {
+				return fmt.Errorf("shared db pool create returned no unique result for %d", dbID)
+			}
+			result = results[0]
+		}
+		if result.OrganizationID == "" {
+			result.OrganizationID = poolInfo.TiDBCloudOrganizationID
+		}
+		if result.DBName == "" {
+			result.DBName = poolInfo.Name
+		}
+		tlsMode := "true"
+		if !dbTLSForProvisionedTenant(tenant.ProviderTiDBCloudNativeShared) {
+			tlsMode = "skip-verify"
+		}
+		if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{
+			ID: dbID, TiDBCloudOrganizationID: result.OrganizationID, ClusterID: result.ClusterID,
+			Host: result.Host, Port: result.Port, User: result.Username, PasswordCipher: poolInfo.PasswordCipher,
+			Name: result.DBName, TLSMode: tlsMode,
+		}); err != nil {
+			return err
+		}
+		poolInfo, err = s.meta.GetSharedDB(ctx, dbID)
+		if err != nil {
+			return err
+		}
+		if provisionErr != nil {
+			return provisionErr
+		}
+	}
+	if poolInfo.Host == "" || poolInfo.Port <= 0 || poolInfo.User == "" || len(poolInfo.PasswordCipher) == 0 || poolInfo.Name == "" {
+		return fmt.Errorf("shared db pool %d connection metadata is not ready", dbID)
+	}
+	plain, err := s.pool.Decrypt(ctx, poolInfo.PasswordCipher)
+	if err != nil {
+		return fmt.Errorf("decrypt shared db root password: %w", err)
+	}
+	dsn := managedSharedDBDSN(poolInfo, string(plain))
+	if ensurer, ok := s.provisioner.(tenantDatabaseEnsurer); ok {
+		if err := ensurer.EnsureDatabase(ctx, dsn); err != nil {
+			return err
+		}
+	}
+	if userProvisioner, ok := s.provisioner.(nativeSystemUserProvisioner); ok {
+		username, password, ensureErr := userProvisioner.EnsureSystemUser(ctx, dsn, fmt.Sprintf("db-pool-%d", dbID))
+		if ensureErr != nil {
+			return ensureErr
+		}
+		passwordCipher, encryptErr := s.pool.Encrypt(ctx, []byte(password))
+		if encryptErr != nil {
+			return encryptErr
+		}
+		if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{
+			ID: dbID, TiDBCloudOrganizationID: poolInfo.TiDBCloudOrganizationID, ClusterID: poolInfo.ClusterID,
+			Host: poolInfo.Host, Port: poolInfo.Port, User: username, PasswordCipher: passwordCipher,
+			Name: poolInfo.Name, TLSMode: poolInfo.TLSMode,
+		}); err != nil {
+			return err
+		}
+	}
+	if err := s.pool.EnsureSharedDBReady(ctx, dbID); err != nil {
+		return err
+	}
+	if updater, ok := s.provisioner.(tenant.QuotaUpdater); ok && poolInfo.SpendingLimit != nil {
+		_, patchErr := updater.UpdateQuota(ctx, &tenant.ClusterInfo{
+			ClusterID: poolInfo.ClusterID, OrganizationID: poolInfo.TiDBCloudOrganizationID,
+			Provider: tenant.ProviderTiDBCloudNative,
+		}, cred, tenant.QuotaUpdateOptions{TiDBCloudSpendingLimitMonthly: poolInfo.SpendingLimit})
+		if patchErr != nil {
+			logger.Warn(ctx, "managed_shared_db_spending_limit_sync_failed",
+				zap.Int64("db_pool_id", dbID), zap.Error(patchErr))
+		}
+	}
+	if err := s.meta.ActivateSharedDBPool(ctx, dbID); err != nil {
+		return err
+	}
+	for {
+		activated, activateErr := s.meta.ActivateSharedTenantsBatch(ctx, dbID, sharedTenantActivationBatchSize)
+		if activateErr != nil {
+			return activateErr
+		}
+		if activated < sharedTenantActivationBatchSize {
+			return nil
+		}
+	}
+}

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -242,6 +242,9 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 			return
 		}
 	}
+	// Capacity is released before membership removal on purpose: if this
+	// delete fails, the retry-safe tenant remains deleting without hiding a
+	// slot that is already available to other allocations.
 	if err := s.meta.DeleteTenantPoolMembership(ctx, t.ID); err != nil {
 		logger.Error(ctx, "shared_tenant_pool_membership_delete_failed", zap.String("tenant_id", t.ID), zap.Error(err))
 		errJSON(w, http.StatusInternalServerError, "failed to remove shared tenant pool membership")

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -236,11 +236,16 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 		// placement intact so the retry re-runs the (idempotent) purge and
 		// completes the removal — a placement row must never outlive its
 		// tenant or lose its capacity accounting.
-		if err := s.meta.DeleteTenantPlacementAndDecrCount(ctx, fsID, placement.DbID); err != nil {
+		if err := s.meta.DeleteTenantPlacementAndDecrCount(ctx, fsID, placement.DbID, s.sharedDBReopenRatio); err != nil {
 			logger.Error(ctx, "shared_tenant_placement_delete_failed", zap.String("tenant_id", t.ID), zap.Error(err))
 			errJSON(w, http.StatusInternalServerError, "failed to remove tenant placement")
 			return
 		}
+	}
+	if err := s.meta.DeleteTenantPoolMembership(ctx, t.ID); err != nil {
+		logger.Error(ctx, "shared_tenant_pool_membership_delete_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+		errJSON(w, http.StatusInternalServerError, "failed to remove shared tenant pool membership")
+		return
 	}
 	// A missing placement here means an earlier attempt already purged and
 	// removed it but failed before enqueueing cleanup — fall through to the

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -341,21 +342,27 @@ func TestSharedTenantDeletePlacementRemovalFailureStaysRetryable(t *testing.T) {
 		"fs_layer_checkpoints", "fs_layer_events", "fs_layer_tags", "fs_layer_entries", "fs_layers",
 		"fs_events", "semantic_tasks", "file_gc_tasks", "uploads", "file_tags", "file_nodes", "semantic", "contents", "inodes",
 	}
-	dropSharedTables := func() {
+	dropSharedTables := func(t *testing.T) error {
+		t.Helper()
 		for _, tbl := range sharedTables {
 			if _, err := rt.meta.DB().ExecContext(ctx, "DROP TABLE IF EXISTS "+tbl); err != nil {
-				t.Errorf("drop %s: %v", tbl, err)
+				return fmt.Errorf("drop %s: %w", tbl, err)
 			}
 		}
+		return nil
 	}
-	dropSharedTables()
 	t.Cleanup(func() {
 		if err := rt.pool.InvalidateSharedDB(dbID); err != nil {
 			t.Errorf("invalidate shared database: %v", err)
 		}
-		dropSharedTables()
+		if err := dropSharedTables(t); err != nil {
+			t.Errorf("cleanup shared tables: %v", err)
+		}
 		initServerTenantSchema(t, testDSN)
 	})
+	if err := dropSharedTables(t); err != nil {
+		t.Fatalf("prepare missing shared tables: %v", err)
+	}
 	if err := rt.pool.PurgeSharedTenant(ctx, fsID, dbID); err != nil {
 		t.Fatalf("pre-warm purge: %v", err)
 	}

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -35,6 +35,12 @@ func TestSharedTenantDeleteRetriesAfterPlacementRemoval(t *testing.T) {
 	if err := rt.meta.UpdateTenantStatus(ctx, rt.tenantID, meta.TenantDeleting); err != nil {
 		t.Fatal(err)
 	}
+	if err := rt.meta.UpsertTenantPoolMembership(ctx, &meta.TenantPoolMembership{
+		TenantID: rt.tenantID, TiDBCloudOrganizationID: "org-shared-delete", PoolID: "pool-shared-delete",
+		PoolStatus: meta.TenantPoolBindingUsed,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPoolMembership: %v", err)
+	}
 
 	resp := rt.deleteTenant(t, nil)
 	defer func() { _ = resp.Body.Close() }()
@@ -53,6 +59,9 @@ func TestSharedTenantDeleteRetriesAfterPlacementRemoval(t *testing.T) {
 	if status != string(meta.TenantDeleted) {
 		t.Fatalf("tenant status = %s, want %s", status, meta.TenantDeleted)
 	}
+	if _, err := rt.meta.GetTenantPoolMembership(ctx, rt.tenantID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("shared membership after delete = %v, want ErrNotFound", err)
+	}
 }
 
 // TestSharedTenantDeleteWithCleanupJobShortCircuits mirrors the standalone
@@ -67,12 +76,12 @@ func TestSharedTenantDeleteWithCleanupJobShortCircuits(t *testing.T) {
 		t.Fatalf("EnsureFsID: %v", err)
 	}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
-		OrgID:          "org-shared-delete",
-		Host:           "shared.example.com",
-		Port:           4000,
-		User:           "root",
-		PasswordCipher: []byte("cipher"),
-		Name:           "shared_db",
+		TiDBCloudOrganizationID: "org-shared-delete",
+		Host:                    "shared.example.com",
+		Port:                    4000,
+		User:                    "root",
+		PasswordCipher:          []byte("cipher"),
+		Name:                    "shared_db",
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -165,12 +174,12 @@ func TestSharedTenantDeleteFullPurgePath(t *testing.T) {
 		t.Fatalf("EnsureFsID: %v", err)
 	}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
-		OrgID:          "org-shared-delete",
-		Host:           "shared.example.com",
-		Port:           4000,
-		User:           "root",
-		PasswordCipher: []byte("cipher"),
-		Name:           "shared_db",
+		TiDBCloudOrganizationID: "org-shared-delete",
+		Host:                    "shared.example.com",
+		Port:                    4000,
+		User:                    "root",
+		PasswordCipher:          []byte("cipher"),
+		Name:                    "shared_db",
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -220,12 +229,12 @@ func TestAdminTenantCreateRejectsSharedPoolOrg(t *testing.T) {
 		{Clusters: []tenant.CloudClusterInfo{{OrganizationID: "org-shared-1"}}},
 	}
 	if _, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
-		OrgID:          "org-shared-1",
-		Host:           "shared.example.com",
-		Port:           4000,
-		User:           "root",
-		PasswordCipher: []byte("cipher"),
-		Name:           "shared_db",
+		TiDBCloudOrganizationID: "org-shared-1",
+		Host:                    "shared.example.com",
+		Port:                    4000,
+		User:                    "root",
+		PasswordCipher:          []byte("cipher"),
+		Name:                    "shared_db",
 	}); err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
 	}
@@ -308,7 +317,7 @@ func TestSharedTenantDeletePlacementRemovalFailureStaysRetryable(t *testing.T) {
 		t.Fatal(err)
 	}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
-		OrgID: "org-shared-delete", Host: db.DBHost, Port: db.DBPort, User: db.DBUser,
+		TiDBCloudOrganizationID: "org-shared-delete", Host: db.DBHost, Port: db.DBPort, User: db.DBUser,
 		PasswordCipher: passCipher, Name: db.DBName,
 	})
 	if err != nil {
@@ -377,7 +386,7 @@ func TestFindSharedDBForProvisionSkipsNonTiDBProviders(t *testing.T) {
 	testmysql.ResetMetaDB(t, db.Meta.DB())
 	ctx := context.Background()
 	if _, err := db.Meta.RegisterSharedDB(ctx, &meta.SharedDB{
-		OrgID: meta.SharedDBOrgWildcard, Host: "shared.example.com", Port: 4000, User: "root",
+		TiDBCloudOrganizationID: meta.SharedDBOrgWildcard, Host: "shared.example.com", Port: 4000, User: "root",
 		PasswordCipher: []byte("cipher"), Name: "shared_db",
 	}); err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -409,7 +418,7 @@ func TestProvisionTenantOnSharedDBCommitsAtomically(t *testing.T) {
 	testmysql.ResetMetaDB(t, db.Meta.DB())
 	ctx := context.Background()
 	dbID, err := db.Meta.RegisterSharedDB(ctx, &meta.SharedDB{
-		OrgID: "org-provision-ok", Host: "shared.example.com", Port: 4000, User: "root",
+		TiDBCloudOrganizationID: "org-provision-ok", Host: "shared.example.com", Port: 4000, User: "root",
 		PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 10,
 	})
 	if err != nil {
@@ -485,7 +494,7 @@ func TestProvisionTenantOnSharedDBFailureLeavesNoPartialState(t *testing.T) {
 	testmysql.ResetMetaDB(t, db.Meta.DB())
 	ctx := context.Background()
 	dbID, err := db.Meta.RegisterSharedDB(ctx, &meta.SharedDB{
-		OrgID: "org-provision-fail", Host: "shared.example.com", Port: 4000, User: "root",
+		TiDBCloudOrganizationID: "org-provision-fail", Host: "shared.example.com", Port: 4000, User: "root",
 		PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 10,
 	})
 	if err != nil {

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -328,24 +328,34 @@ func TestSharedTenantDeletePlacementRemovalFailureStaysRetryable(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("UpsertTenantPlacement: %v", err)
 	}
-	// Pre-warm the shared handle with a scratch database in which every
-	// shared-schema table is absent: the purge in the delete below reuses
-	// the cached handle and succeeds trivially, but the placement removal
-	// transaction cannot release capacity on a missing pool row and must
-	// roll back. (The test DB carries standalone-shape tables of the same
-	// names, so drop them first — the next test's schema init recreates
-	// them.)
-	for _, tbl := range []string{
+	// Pre-warm the shared handle with a database in which every shared-schema
+	// table is absent: the purge in the delete below reuses the cached handle and
+	// succeeds trivially, but the placement removal transaction cannot release
+	// capacity on a missing pool row and must roll back. Restore the standalone
+	// shape in cleanup so this shared-schema test cannot pollute later tests in
+	// the package-wide database.
+	sharedTables := []string{
 		"journal_entry_subjects", "journal_entries", "journal_append_requests", "journal_labels", "journals",
 		"vault_audit_log", "vault_grants", "vault_tokens", "vault_secret_fields", "vault_secrets", "vault_deks",
 		"git_workspace_object_packs", "git_workspace_overlay", "git_workspace_git_state", "git_workspace_tree_nodes", "git_workspaces",
 		"fs_layer_checkpoints", "fs_layer_events", "fs_layer_tags", "fs_layer_entries", "fs_layers",
 		"fs_events", "semantic_tasks", "file_gc_tasks", "uploads", "file_tags", "file_nodes", "semantic", "contents", "inodes",
-	} {
-		if _, err := rt.meta.DB().ExecContext(ctx, "DROP TABLE IF EXISTS "+tbl); err != nil {
-			t.Fatalf("drop %s: %v", tbl, err)
+	}
+	dropSharedTables := func() {
+		for _, tbl := range sharedTables {
+			if _, err := rt.meta.DB().ExecContext(ctx, "DROP TABLE IF EXISTS "+tbl); err != nil {
+				t.Errorf("drop %s: %v", tbl, err)
+			}
 		}
 	}
+	dropSharedTables()
+	t.Cleanup(func() {
+		if err := rt.pool.InvalidateSharedDB(dbID); err != nil {
+			t.Errorf("invalidate shared database: %v", err)
+		}
+		dropSharedTables()
+		initServerTenantSchema(t, testDSN)
+	})
 	if err := rt.pool.PurgeSharedTenant(ctx, fsID, dbID); err != nil {
 		t.Fatalf("pre-warm purge: %v", err)
 	}

--- a/pkg/server/tenant_metrics.go
+++ b/pkg/server/tenant_metrics.go
@@ -17,6 +17,20 @@ type tenantPoolBindingMetricKey struct {
 	status         string
 }
 
+const (
+	sharedDBPoolMetricTotal    = "total"
+	sharedDBPoolMetricCapacity = "capacity"
+	sharedDBPoolMetricTenants  = "tenants"
+	sharedDBPoolMetricSpending = "spending_limit"
+)
+
+type sharedDBPoolMetricKey struct {
+	kind           string
+	dbPoolID       int64
+	tidbCloudOrgID string
+	dimension      string
+}
+
 func (s *Server) observeTenantCounts(ctx context.Context) {
 	if s.meta == nil {
 		return
@@ -67,6 +81,79 @@ func (s *Server) observeTenantPoolBindingCounts(ctx context.Context) {
 	}
 }
 
+func (s *Server) observeSharedDBPoolMetrics(ctx context.Context) {
+	if s.meta == nil {
+		return
+	}
+	start := time.Now()
+	snapshots, err := s.meta.ListSharedDBPoolMetricSnapshots(ctx)
+	metrics.RecordOperation("shared_db_pool", "observe", metrics.ResultForError(err), time.Since(start))
+	if err != nil {
+		if ctx.Err() == nil {
+			logger.Warn(ctx, "shared_db_pool_metrics_failed", zap.Error(err))
+		}
+		return
+	}
+
+	next := make(map[sharedDBPoolMetricKey]struct{})
+	totals := make(map[sharedDBPoolMetricKey]int64)
+	for _, snapshot := range snapshots {
+		orgID := snapshot.TiDBCloudOrganizationID
+		totalKey := sharedDBPoolMetricKey{
+			kind: sharedDBPoolMetricTotal, tidbCloudOrgID: orgID, dimension: snapshot.Status,
+		}
+		totals[totalKey]++
+
+		free := int64(0)
+		if snapshot.MaxTenants > snapshot.TenantCount && !snapshot.SoftCapReached {
+			free = int64(snapshot.MaxTenants - snapshot.TenantCount)
+		}
+		hardMax := int64(0)
+		if snapshot.MaxTenants > 0 {
+			if hard, hardErr := s.managedSharedDBHardCap(snapshot.MaxTenants); hardErr == nil {
+				hardMax = int64(hard)
+			}
+		}
+		for capacityType, value := range map[string]int64{
+			"soft_max": int64(snapshot.MaxTenants), "hard_max": hardMax,
+			"used": int64(snapshot.TenantCount), "free": free,
+		} {
+			metrics.RecordSharedDBPoolCapacity(orgID, snapshot.ID, capacityType, value)
+			next[sharedDBPoolMetricKey{
+				kind: sharedDBPoolMetricCapacity, dbPoolID: snapshot.ID,
+				tidbCloudOrgID: orgID, dimension: capacityType,
+			}] = struct{}{}
+		}
+		for _, state := range snapshot.TenantStates {
+			metrics.RecordSharedDBPoolTenants(orgID, snapshot.ID, string(state.State), state.Count)
+			next[sharedDBPoolMetricKey{
+				kind: sharedDBPoolMetricTenants, dbPoolID: snapshot.ID,
+				tidbCloudOrgID: orgID, dimension: string(state.State),
+			}] = struct{}{}
+		}
+		if snapshot.SpendingLimit != nil {
+			for limitType, value := range map[string]int64{
+				"target":     *snapshot.SpendingLimit,
+				"tenant_sum": snapshot.TenantSpendingLimitSum,
+				"headroom":   *snapshot.SpendingLimit - snapshot.TenantSpendingLimitSum,
+			} {
+				metrics.RecordSharedDBPoolSpendingLimit(orgID, snapshot.ID, limitType, value)
+				next[sharedDBPoolMetricKey{
+					kind: sharedDBPoolMetricSpending, dbPoolID: snapshot.ID,
+					tidbCloudOrgID: orgID, dimension: limitType,
+				}] = struct{}{}
+			}
+		}
+	}
+	for key, count := range totals {
+		metrics.RecordSharedDBPoolTotal(key.tidbCloudOrgID, key.dimension, count)
+		next[key] = struct{}{}
+	}
+	if s.metrics != nil {
+		s.metrics.syncSharedDBPoolSnapshot(next)
+	}
+}
+
 func (m *serverMetrics) syncTenantPoolBindingSnapshot(next map[tenantPoolBindingMetricKey]struct{}) {
 	if m == nil {
 		return
@@ -92,4 +179,44 @@ func (m *serverMetrics) clearTenantPoolBindingSnapshot() {
 		metrics.DeleteTenantPoolBindings(prev.poolID, prev.tidbCloudOrgID, prev.status)
 	}
 	m.tenantPoolBinding = map[tenantPoolBindingMetricKey]struct{}{}
+}
+
+func (m *serverMetrics) syncSharedDBPoolSnapshot(next map[sharedDBPoolMetricKey]struct{}) {
+	if m == nil {
+		return
+	}
+	m.sharedDBPoolMu.Lock()
+	defer m.sharedDBPoolMu.Unlock()
+	for prev := range m.sharedDBPool {
+		if _, ok := next[prev]; ok {
+			continue
+		}
+		deleteSharedDBPoolMetric(prev)
+	}
+	m.sharedDBPool = next
+}
+
+func (m *serverMetrics) clearSharedDBPoolSnapshot() {
+	if m == nil {
+		return
+	}
+	m.sharedDBPoolMu.Lock()
+	defer m.sharedDBPoolMu.Unlock()
+	for prev := range m.sharedDBPool {
+		deleteSharedDBPoolMetric(prev)
+	}
+	m.sharedDBPool = map[sharedDBPoolMetricKey]struct{}{}
+}
+
+func deleteSharedDBPoolMetric(key sharedDBPoolMetricKey) {
+	switch key.kind {
+	case sharedDBPoolMetricTotal:
+		metrics.DeleteSharedDBPoolTotal(key.tidbCloudOrgID, key.dimension)
+	case sharedDBPoolMetricCapacity:
+		metrics.DeleteSharedDBPoolCapacity(key.tidbCloudOrgID, key.dbPoolID, key.dimension)
+	case sharedDBPoolMetricTenants:
+		metrics.DeleteSharedDBPoolTenants(key.tidbCloudOrgID, key.dbPoolID, key.dimension)
+	case sharedDBPoolMetricSpending:
+		metrics.DeleteSharedDBPoolSpendingLimit(key.tidbCloudOrgID, key.dbPoolID, key.dimension)
+	}
 }

--- a/pkg/server/tenant_metrics_test.go
+++ b/pkg/server/tenant_metrics_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -137,20 +138,137 @@ func TestObserveTenantCountsRecordsAllRealStatuses(t *testing.T) {
 	}
 }
 
-func TestStopLeaderWorkersClearsTenantPoolBindingSnapshot(t *testing.T) {
-	key := tenantPoolBindingMetricKey{
+func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.T) {
+	initServerTenantSchema(t, testDSN)
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	ctx := context.Background()
+	spendingLimit := int64(10_000)
+	dbID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-db-metrics",
+		ProvisioningKey:         make([]byte, 32),
+		CloudProvider:           "aws",
+		Region:                  "us-east-1",
+		MaxTenants:              5,
+		SpendingLimit:           &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool active: %v", err)
+	}
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, meta.SharedDBStatusActive, dbID); err != nil {
+		t.Fatalf("activate db pool: %v", err)
+	}
+	if _, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-db-metrics",
+		ProvisioningKey:         []byte("12345678901234567890123456789012"),
+		CloudProvider:           "aws",
+		Region:                  "us-east-1",
+		MaxTenants:              5,
+		SpendingLimit:           &spendingLimit,
+	}); err != nil {
+		t.Fatalf("CreateManagedSharedDBPool provisioning: %v", err)
+	}
+
+	now := time.Now().UTC()
+	for _, tc := range []struct {
+		tenantID     string
+		status       meta.TenantStatus
+		virtualLimit int64
+	}{
+		{tenantID: "tenant-shared-metrics-active", status: meta.TenantActive, virtualLimit: 1_000},
+		{tenantID: "tenant-shared-metrics-provisioning", status: meta.TenantProvisioning, virtualLimit: 2_000},
+	} {
+		insertSharedDBMetricTenant(t, metaStore, tc.tenantID, tc.status, now)
+		if err := metaStore.SetQuotaConfigPatch(ctx, tc.tenantID, meta.QuotaConfigPatch{TiDBCloudSpendingLimit: &tc.virtualLimit}); err != nil {
+			t.Fatalf("SetQuotaConfigPatch %s: %v", tc.tenantID, err)
+		}
+		fsID, err := metaStore.EnsureFsID(ctx, tc.tenantID)
+		if err != nil {
+			t.Fatalf("EnsureFsID %s: %v", tc.tenantID, err)
+		}
+		if err := metaStore.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+			FsID: fsID, DbID: dbID, Placement: meta.PlacementShared,
+			SchemaShape: meta.SchemaShapeShared, Status: meta.SharedDBStatusActive,
+		}); err != nil {
+			t.Fatalf("UpsertTenantPlacement %s: %v", tc.tenantID, err)
+		}
+		if err := metaStore.IncrSharedDBTenantCount(ctx, dbID, 1); err != nil {
+			t.Fatalf("IncrSharedDBTenantCount %s: %v", tc.tenantID, err)
+		}
+	}
+
+	s := &Server{meta: metaStore, metrics: newServerMetrics()}
+	s.observeSharedDBPoolMetrics(ctx)
+
+	rec := httptest.NewRecorder()
+	s.metrics.writePrometheus(rec)
+	text := rec.Body.String()
+	dbPoolID := fmt.Sprint(dbID)
+	for _, want := range []string{
+		`drive9_shared_db_pool_total{status="active",tidbcloud_org_id="org-shared-db-metrics"} 1`,
+		`drive9_shared_db_pool_total{status="provisioning",tidbcloud_org_id="org-shared-db-metrics"} 1`,
+		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="soft_max"} 5`,
+		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="hard_max"} 6`,
+		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="used"} 2`,
+		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="free"} 3`,
+		`drive9_shared_db_pool_tenants{db_pool_id="` + dbPoolID + `",state="active",tidbcloud_org_id="org-shared-db-metrics"} 1`,
+		`drive9_shared_db_pool_tenants{db_pool_id="` + dbPoolID + `",state="provisioning",tidbcloud_org_id="org-shared-db-metrics"} 1`,
+		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="target"} 10000`,
+		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="tenant_sum"} 3000`,
+		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="headroom"} 7000`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing shared DB-pool metric %q:\n%s", want, text)
+		}
+	}
+	for _, line := range strings.Split(text, "\n") {
+		if strings.HasPrefix(line, "drive9_shared_db_pool_") && strings.Contains(line, "organization_id=") {
+			t.Fatalf("shared DB-pool metrics must use tidbcloud_org_id:\n%s", text)
+		}
+	}
+
+	if _, err := metaStore.DB().ExecContext(ctx, `DELETE FROM tenant_placements`); err != nil {
+		t.Fatalf("delete placements: %v", err)
+	}
+	if _, err := metaStore.DB().ExecContext(ctx, `DELETE FROM db_pool`); err != nil {
+		t.Fatalf("delete db pools: %v", err)
+	}
+	s.observeSharedDBPoolMetrics(ctx)
+	rec = httptest.NewRecorder()
+	s.metrics.writePrometheus(rec)
+	if strings.Contains(rec.Body.String(), `db_pool_id="`+dbPoolID+`"`) {
+		t.Fatalf("deleted shared DB-pool metrics should be removed after next observation:\n%s", rec.Body.String())
+	}
+}
+
+func TestStopLeaderWorkersClearsMetricSnapshots(t *testing.T) {
+	tenantPoolKey := tenantPoolBindingMetricKey{
 		poolID:         "pool-leader-loss-clear",
 		tidbCloudOrgID: "org-leader-loss-clear",
 		status:         string(meta.TenantPoolBindingUsed),
 	}
+	sharedDBKey := sharedDBPoolMetricKey{
+		kind: sharedDBPoolMetricCapacity, dbPoolID: 987654,
+		tidbCloudOrgID: "org-shared-leader-loss-clear", dimension: "used",
+	}
 	s := &Server{metrics: newServerMetrics(), leaderWorkersStarted: true}
-	metrics.RecordTenantPoolBindings(key.poolID, key.tidbCloudOrgID, key.status, 1)
-	s.metrics.syncTenantPoolBindingSnapshot(map[tenantPoolBindingMetricKey]struct{}{key: struct{}{}})
+	metrics.RecordTenantPoolBindings(tenantPoolKey.poolID, tenantPoolKey.tidbCloudOrgID, tenantPoolKey.status, 1)
+	s.metrics.syncTenantPoolBindingSnapshot(map[tenantPoolBindingMetricKey]struct{}{tenantPoolKey: {}})
+	metrics.RecordSharedDBPoolCapacity(sharedDBKey.tidbCloudOrgID, sharedDBKey.dbPoolID, sharedDBKey.dimension, 1)
+	s.metrics.syncSharedDBPoolSnapshot(map[sharedDBPoolMetricKey]struct{}{sharedDBKey: {}})
 
 	rec := httptest.NewRecorder()
 	s.metrics.writePrometheus(rec)
 	if !strings.Contains(rec.Body.String(), `drive9_tenant_pool_bindings{pool_id="pool-leader-loss-clear",status="used",tidbcloud_org_id="org-leader-loss-clear"} 1`) {
 		t.Fatalf("missing tenant pool binding metric before leadership loss:\n%s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `drive9_shared_db_pool_capacity{db_pool_id="987654",tidbcloud_org_id="org-shared-leader-loss-clear",type="used"} 1`) {
+		t.Fatalf("missing shared DB-pool metric before leadership loss:\n%s", rec.Body.String())
 	}
 
 	s.stopLeaderWorkers()
@@ -159,6 +277,9 @@ func TestStopLeaderWorkersClearsTenantPoolBindingSnapshot(t *testing.T) {
 	s.metrics.writePrometheus(rec)
 	if strings.Contains(rec.Body.String(), `drive9_tenant_pool_bindings{pool_id="pool-leader-loss-clear"`) {
 		t.Fatalf("tenant pool binding metric should be removed after leadership loss:\n%s", rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), `drive9_shared_db_pool_capacity{db_pool_id="987654"`) {
+		t.Fatalf("shared DB-pool metric should be removed after leadership loss:\n%s", rec.Body.String())
 	}
 }
 
@@ -202,5 +323,26 @@ func insertTenantPoolMetricTenant(t *testing.T, s *meta.Store, tenantID, cluster
 		UpdatedAt:        now,
 	}); err != nil {
 		t.Fatalf("insert tenant %s: %v", tenantID, err)
+	}
+}
+
+func insertSharedDBMetricTenant(t *testing.T, s *meta.Store, tenantID string, status meta.TenantStatus, now time.Time) {
+	t.Helper()
+	if err := s.InsertTenant(context.Background(), &meta.Tenant{
+		ID:               tenantID,
+		Status:           status,
+		Kind:             meta.TenantKindLive,
+		DBHost:           "shared.example.com",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tidbcloud_fs",
+		DBTLS:            true,
+		Provider:         tenant.ProviderTiDBCloudNativeShared,
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatalf("insert shared tenant %s: %v", tenantID, err)
 	}
 }

--- a/pkg/server/upload_test.go
+++ b/pkg/server/upload_test.go
@@ -1530,6 +1530,29 @@ func TestNewWithConfigRejectsNaNTenantPoolRefillFreeRatio(t *testing.T) {
 	}
 }
 
+func TestNewWithConfigUsesSharedDBReopenRatio(t *testing.T) {
+	s := NewWithConfig(Config{SharedDBReopenRatio: 0.65})
+	if s.sharedDBReopenRatio != 0.65 {
+		t.Fatalf("sharedDBReopenRatio = %f, want 0.65", s.sharedDBReopenRatio)
+	}
+}
+
+func TestNewWithConfigUsesDefaultSharedDBReopenRatio(t *testing.T) {
+	s := NewWithConfig(Config{})
+	if s.sharedDBReopenRatio != DefaultSharedDBReopenRatio {
+		t.Fatalf("default sharedDBReopenRatio = %f, want %f", s.sharedDBReopenRatio, DefaultSharedDBReopenRatio)
+	}
+}
+
+func TestNewWithConfigRejectsInvalidSharedDBReopenRatio(t *testing.T) {
+	for _, ratio := range []float64{0, 1, math.NaN(), math.Inf(1)} {
+		s := NewWithConfig(Config{SharedDBReopenRatio: ratio})
+		if s.sharedDBReopenRatio != DefaultSharedDBReopenRatio {
+			t.Fatalf("invalid sharedDBReopenRatio %v = %f, want %f", ratio, s.sharedDBReopenRatio, DefaultSharedDBReopenRatio)
+		}
+	}
+}
+
 func TestDeclaredContentLengthOverMaxRejected(t *testing.T) {
 	base, _ := newTestServerWithS3(t)
 	s := NewWithConfig(Config{Backend: base.fallback, MaxUploadBytes: 10})

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -936,6 +936,10 @@ func (p *Pool) releaseSharedDB(dbID int64) {
 		return
 	}
 	p.sharedMu.Lock()
+	if _, ok := p.sharedDBs[dbID]; !ok {
+		p.sharedMu.Unlock()
+		return
+	}
 	if refs := p.sharedDBRefs[dbID]; refs > 1 {
 		p.sharedDBRefs[dbID] = refs - 1
 	} else {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -156,6 +156,8 @@ type Pool struct {
 	sharedDBs        map[int64]*sql.DB
 	sharedDBRefs     map[int64]int
 	sharedDBLastUsed map[int64]time.Time
+	sharedDBOpenMu   map[int64]*sync.Mutex
+	sharedDBClosed   bool
 }
 
 type tenantAutoEmbeddingProfile struct {
@@ -245,6 +247,7 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 		sharedDBs:        map[int64]*sql.DB{},
 		sharedDBRefs:     map[int64]int{},
 		sharedDBLastUsed: map[int64]time.Time{},
+		sharedDBOpenMu:   map[int64]*sync.Mutex{},
 		// No LeaderChecker means single-pod mode: FileGC runs unconditionally.
 		fileGCEnabled: cfg.LeaderChecker == nil,
 		idleTimeout:   idleTimeout,
@@ -753,6 +756,7 @@ func (p *Pool) Close() {
 		db *sql.DB
 	}
 	p.sharedMu.Lock()
+	p.sharedDBClosed = true
 	sharedToClose := make([]sharedDBToClose, 0, len(p.sharedDBs))
 	for dbID, db := range p.sharedDBs {
 		sharedToClose = append(sharedToClose, sharedDBToClose{id: dbID, db: db})
@@ -986,11 +990,35 @@ func (p *Pool) reapIdleSharedDBs(now time.Time) {
 // for defaultSharedDBHandleIdleTTL and is then closed by the existing reaper.
 func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) {
 	p.sharedMu.Lock()
-	defer p.sharedMu.Unlock()
 	if db, ok := p.sharedDBs[dbID]; ok {
 		p.sharedDBLastUsed[dbID] = time.Now()
+		p.sharedMu.Unlock()
 		return db, nil
 	}
+	if p.sharedDBClosed {
+		p.sharedMu.Unlock()
+		return nil, fmt.Errorf("shared db pool is closed")
+	}
+	openMu := p.sharedDBOpenMu[dbID]
+	if openMu == nil {
+		openMu = &sync.Mutex{}
+		p.sharedDBOpenMu[dbID] = openMu
+	}
+	p.sharedMu.Unlock()
+
+	openMu.Lock()
+	defer openMu.Unlock()
+	p.sharedMu.Lock()
+	if db, ok := p.sharedDBs[dbID]; ok {
+		p.sharedDBLastUsed[dbID] = time.Now()
+		p.sharedMu.Unlock()
+		return db, nil
+	}
+	if p.sharedDBClosed {
+		p.sharedMu.Unlock()
+		return nil, fmt.Errorf("shared db pool is closed")
+	}
+	p.sharedMu.Unlock()
 	if p.metaStore == nil {
 		return nil, fmt.Errorf("shared db %d: no meta store", dbID)
 	}
@@ -1024,8 +1052,15 @@ func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) 
 			return nil, fmt.Errorf("shared db %d: persist schema version: %w", dbID, err)
 		}
 	}
+	p.sharedMu.Lock()
+	if p.sharedDBClosed {
+		p.sharedMu.Unlock()
+		_ = mysqlutil.CloseInstrumented(db)
+		return nil, fmt.Errorf("shared db pool is closed")
+	}
 	p.sharedDBs[dbID] = db
 	p.sharedDBLastUsed[dbID] = time.Now()
+	p.sharedMu.Unlock()
 	return db, nil
 }
 
@@ -1042,6 +1077,15 @@ func (p *Pool) InvalidateSharedDB(dbID int64) error {
 	if dbID <= 0 {
 		return fmt.Errorf("shared db id must be positive")
 	}
+	p.sharedMu.Lock()
+	openMu := p.sharedDBOpenMu[dbID]
+	if openMu == nil {
+		openMu = &sync.Mutex{}
+		p.sharedDBOpenMu[dbID] = openMu
+	}
+	p.sharedMu.Unlock()
+	openMu.Lock()
+	defer openMu.Unlock()
 	p.sharedMu.Lock()
 	db := p.sharedDBs[dbID]
 	delete(p.sharedDBs, dbID)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -149,11 +149,13 @@ type Pool struct {
 	reapStop      context.CancelFunc
 	reapWG        sync.WaitGroup
 	// sharedDBs caches one *sql.DB handle per shared-schema database (keyed by
-	// db_pool.db_id). All tenants placed on the same shared DB share its
+	// db_pool.id). All tenants placed on the same shared DB share its
 	// handle; each Acquire still gets its own Store (carrying that tenant's
 	// fs_id scope) over the shared handle.
-	sharedMu  sync.Mutex
-	sharedDBs map[int64]*sql.DB
+	sharedMu         sync.Mutex
+	sharedDBs        map[int64]*sql.DB
+	sharedDBRefs     map[int64]int
+	sharedDBLastUsed map[int64]time.Time
 }
 
 type tenantAutoEmbeddingProfile struct {
@@ -167,9 +169,11 @@ var (
 	applyTiDBAutoEmbeddingProviderConfig    = schema.ApplyTiDBAutoEmbeddingProviderConfig
 	ensureTiDBSchemaForAutoEmbeddingProfile = schema.EnsureTiDBSchemaForAutoEmbeddingProfile
 	ensureTiDBSchemaForFTSOnlyProfile       = schema.EnsureTiDBSchemaForFTSOnlyProfile
+	ensureSharedDBSchema                    = schema.EnsureSharedSchema
 	defaultTenantPoolDrainTimeout           = 30 * time.Second
 	defaultTenantPoolMaxTenants             = 1024
 	defaultTenantPoolIdleReapInterval       = 2 * time.Minute
+	defaultSharedDBHandleIdleTTL            = 30 * time.Minute
 )
 
 func ensureTiDBSchemaForEmbeddingMode(ctx context.Context, db *sql.DB, mode string, profile schema.TiDBAutoEmbeddingProfile) error {
@@ -217,6 +221,7 @@ type entry struct {
 	refs               int
 	retired            bool
 	lastUsed           time.Time // refreshed by Get/Acquire/S3Backend (foreground + durable work) and on Acquire release; never by AcquireCached
+	sharedDBID         int64     // db_pool.id for shared-schema tenants; zero for standalone tenants
 }
 
 func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
@@ -232,12 +237,14 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 	metrics.RecordGauge("tenant_pool", "cached_backends", 0)
 	metrics.RecordGauge("tenant_pool", "max_backends", float64(max))
 	return &Pool{
-		cfg:       cfg,
-		enc:       enc,
-		items:     map[string]*entry{},
-		order:     list.New(),
-		maxSize:   max,
-		sharedDBs: map[int64]*sql.DB{},
+		cfg:              cfg,
+		enc:              enc,
+		items:            map[string]*entry{},
+		order:            list.New(),
+		maxSize:          max,
+		sharedDBs:        map[int64]*sql.DB{},
+		sharedDBRefs:     map[int64]int{},
+		sharedDBLastUsed: map[int64]time.Time{},
 		// No LeaderChecker means single-pod mode: FileGC runs unconditionally.
 		fileGCEnabled: cfg.LeaderChecker == nil,
 		idleTimeout:   idleTimeout,
@@ -316,6 +323,7 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 	if err != nil {
 		return nil, err
 	}
+	sharedDBID := p.sharedDBIDForStore(st)
 
 	p.mu.Lock()
 	if e, ok := p.items[t.ID]; ok {
@@ -331,9 +339,10 @@ func (p *Pool) Get(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Backen
 			toClose = append(toClose, removed)
 		}
 	}
-	e := &entry{tenantID: t.ID, storageNamespaceID: t.StorageNamespaceID, s3EncryptionPolicy: s3EncryptionPolicy, backend: b, store: st, lastUsed: time.Now()}
+	e := &entry{tenantID: t.ID, storageNamespaceID: t.StorageNamespaceID, s3EncryptionPolicy: s3EncryptionPolicy, backend: b, store: st, lastUsed: time.Now(), sharedDBID: sharedDBID}
 	e.elem = p.order.PushFront(e)
 	p.items[t.ID] = e
+	p.retainSharedDB(sharedDBID)
 	for p.order.Len() > p.maxSize {
 		oldest := p.order.Back()
 		if oldest != nil {
@@ -403,6 +412,7 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 		metrics.RecordTenantOperationWithOrg(t.ID, tidbCloudOrgID, "user_db_access", "acquire_cold_open", "error", time.Since(createBackendStart))
 		return nil, nil, err
 	}
+	sharedDBID := p.sharedDBIDForStore(st)
 	createBackendDurationMs := float64(time.Since(createBackendStart).Microseconds()) / 1000.0
 	// Cold-open success: a tenant TiDB was opened from scratch (cache miss).
 	// This is the canonical "a serverless TiDB was woken up" signal — the
@@ -429,9 +439,10 @@ func (p *Pool) Acquire(ctx context.Context, t *meta.Tenant) (out *backend.Dat9Ba
 			toClose = append(toClose, removed)
 		}
 	}
-	e := &entry{tenantID: t.ID, storageNamespaceID: t.StorageNamespaceID, s3EncryptionPolicy: s3EncryptionPolicy, backend: b, store: st, refs: 1, lastUsed: time.Now()}
+	e := &entry{tenantID: t.ID, storageNamespaceID: t.StorageNamespaceID, s3EncryptionPolicy: s3EncryptionPolicy, backend: b, store: st, refs: 1, lastUsed: time.Now(), sharedDBID: sharedDBID}
 	e.elem = p.order.PushFront(e)
 	p.items[t.ID] = e
+	p.retainSharedDB(sharedDBID)
 	for p.order.Len() > p.maxSize {
 		oldest := p.order.Back()
 		if oldest != nil {
@@ -716,6 +727,7 @@ func (p *Pool) reapOnce(ctx context.Context) {
 	for _, retired := range toClose {
 		p.closeEntry(retired)
 	}
+	p.reapIdleSharedDBs(now)
 }
 
 func (p *Pool) Close() {
@@ -736,14 +748,24 @@ func (p *Pool) Close() {
 	for _, retired := range toClose {
 		p.closeEntry(retired)
 	}
+	type sharedDBToClose struct {
+		id int64
+		db *sql.DB
+	}
 	p.sharedMu.Lock()
+	sharedToClose := make([]sharedDBToClose, 0, len(p.sharedDBs))
 	for dbID, db := range p.sharedDBs {
-		if err := mysqlutil.CloseInstrumented(db); err != nil {
-			logger.Warn(context.Background(), "shared_db_close_failed", zap.Int64("db_id", dbID), zap.Error(err))
-		}
+		sharedToClose = append(sharedToClose, sharedDBToClose{id: dbID, db: db})
 		delete(p.sharedDBs, dbID)
+		delete(p.sharedDBRefs, dbID)
+		delete(p.sharedDBLastUsed, dbID)
 	}
 	p.sharedMu.Unlock()
+	for _, item := range sharedToClose {
+		if err := mysqlutil.CloseInstrumented(item.db); err != nil {
+			logger.Warn(context.Background(), "shared_db_close_failed", zap.Int64("db_id", item.id), zap.Error(err))
+		}
+	}
 }
 
 func (p *Pool) S3Backend(tenantID string) *backend.Dat9Backend {
@@ -881,13 +903,88 @@ func (p *Pool) placementForTenant(ctx context.Context, fsID int64) (*meta.Tenant
 	return placement, nil
 }
 
+// sharedDBIDForStore identifies whether a newly created tenant store uses one
+// of this pool's physical shared-DB handles. It is called only on cold opens,
+// before the tenant backend is inserted into the LRU.
+func (p *Pool) sharedDBIDForStore(store *datastore.Store) int64 {
+	if store == nil {
+		return 0
+	}
+	db := store.DB()
+	p.sharedMu.Lock()
+	defer p.sharedMu.Unlock()
+	for dbID, shared := range p.sharedDBs {
+		if shared == db {
+			return dbID
+		}
+	}
+	return 0
+}
+
+func (p *Pool) retainSharedDB(dbID int64) {
+	if dbID <= 0 {
+		return
+	}
+	p.sharedMu.Lock()
+	p.sharedDBRefs[dbID]++
+	p.sharedDBLastUsed[dbID] = time.Now()
+	p.sharedMu.Unlock()
+}
+
+func (p *Pool) releaseSharedDB(dbID int64) {
+	if dbID <= 0 {
+		return
+	}
+	p.sharedMu.Lock()
+	if refs := p.sharedDBRefs[dbID]; refs > 1 {
+		p.sharedDBRefs[dbID] = refs - 1
+	} else {
+		delete(p.sharedDBRefs, dbID)
+	}
+	p.sharedDBLastUsed[dbID] = time.Now()
+	p.sharedMu.Unlock()
+}
+
+// reapIdleSharedDBs closes physical shared-DB handles only after no cached or
+// active tenant backend references them and the handle has then stayed unused
+// for the longer shared-handle TTL. The existing tenant-pool reaper invokes
+// this; no separate worker is needed.
+func (p *Pool) reapIdleSharedDBs(now time.Time) {
+	type sharedDBToClose struct {
+		id int64
+		db *sql.DB
+	}
+	var toClose []sharedDBToClose
+	p.sharedMu.Lock()
+	for dbID, db := range p.sharedDBs {
+		if p.sharedDBRefs[dbID] > 0 {
+			continue
+		}
+		lastUsed := p.sharedDBLastUsed[dbID]
+		if lastUsed.IsZero() || now.Sub(lastUsed) <= defaultSharedDBHandleIdleTTL {
+			continue
+		}
+		toClose = append(toClose, sharedDBToClose{id: dbID, db: db})
+		delete(p.sharedDBs, dbID)
+		delete(p.sharedDBRefs, dbID)
+		delete(p.sharedDBLastUsed, dbID)
+	}
+	p.sharedMu.Unlock()
+	for _, item := range toClose {
+		if err := mysqlutil.CloseInstrumented(item.db); err != nil {
+			logger.Warn(context.Background(), "shared_db_idle_close_failed", zap.Int64("db_id", item.id), zap.Error(err))
+		}
+	}
+}
+
 // sharedDBHandle returns the cached *sql.DB for a shared-schema database
-// (db_pool.db_id), opening it on first use. Handles live for the process
-// lifetime and are closed by Close.
+// (db_pool.id), opening it on first use. An unreferenced handle remains warm
+// for defaultSharedDBHandleIdleTTL and is then closed by the existing reaper.
 func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) {
 	p.sharedMu.Lock()
 	defer p.sharedMu.Unlock()
 	if db, ok := p.sharedDBs[dbID]; ok {
+		p.sharedDBLastUsed[dbID] = time.Now()
 		return db, nil
 	}
 	if p.metaStore == nil {
@@ -908,12 +1005,49 @@ func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) 
 	// An empty TLSMode means a plain connection (local/self-hosted databases);
 	// shared DBs on TiDB Cloud are registered with tls=skip-verify or tls=true.
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", info.User, string(pass), info.Host, info.Port, info.Name, query)
-	db, err := mysqlutil.OpenInstrumentedForTenant(ctx, dsn, mysqlutil.RoleShared, fmt.Sprintf("shared:%d", dbID))
+	db, err := mysqlutil.OpenInstrumentedForTenantWithOrg(ctx, dsn, mysqlutil.RoleShared,
+		fmt.Sprintf("shared:%d", dbID), info.TiDBCloudOrganizationID)
 	if err != nil {
 		return nil, fmt.Errorf("shared db %d: open: %w", dbID, err)
 	}
+	if info.SchemaVersion != schema.CurrentSharedTiDBSchemaVersion {
+		if err := ensureSharedDBSchema(ctx, db); err != nil {
+			_ = mysqlutil.CloseInstrumented(db)
+			return nil, fmt.Errorf("shared db %d: ensure schema: %w", dbID, err)
+		}
+		if err := p.metaStore.UpdateSharedDBSchemaVersion(ctx, dbID, schema.CurrentSharedTiDBSchemaVersion); err != nil {
+			_ = mysqlutil.CloseInstrumented(db)
+			return nil, fmt.Errorf("shared db %d: persist schema version: %w", dbID, err)
+		}
+	}
 	p.sharedDBs[dbID] = db
+	p.sharedDBLastUsed[dbID] = time.Now()
 	return db, nil
+}
+
+// EnsureSharedDBReady opens the shared physical DB through the normal cache
+// path, which also compares and applies the checked-in shared schema version.
+func (p *Pool) EnsureSharedDBReady(ctx context.Context, dbID int64) error {
+	_, err := p.sharedDBHandle(ctx, dbID)
+	return err
+}
+
+// InvalidateSharedDB removes and closes one cached physical shared-DB handle.
+// A later access reopens it from the current db_pool connection metadata.
+func (p *Pool) InvalidateSharedDB(dbID int64) error {
+	if dbID <= 0 {
+		return fmt.Errorf("shared db id must be positive")
+	}
+	p.sharedMu.Lock()
+	db := p.sharedDBs[dbID]
+	delete(p.sharedDBs, dbID)
+	delete(p.sharedDBRefs, dbID)
+	delete(p.sharedDBLastUsed, dbID)
+	p.sharedMu.Unlock()
+	if db == nil {
+		return nil
+	}
+	return mysqlutil.CloseInstrumented(db)
 }
 
 // PurgeSharedTenant deletes all rows belonging to fsID from the shared DB it
@@ -1376,6 +1510,7 @@ func (p *Pool) closeEntry(e *entry) {
 	if e.store != nil {
 		_ = e.store.Close()
 	}
+	p.releaseSharedDB(e.sharedDBID)
 	p.mu.Lock()
 	_, active := p.items[e.tenantID]
 	p.mu.Unlock()

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -278,6 +279,96 @@ func TestSharedDBSchemaIsCheckedLazilyAndRetriedAfterFailure(t *testing.T) {
 	}
 	if ensureCalls != 2 {
 		t.Fatalf("schema ensure calls after current-version reopen = %d, want 2", ensureCalls)
+	}
+}
+
+func TestSharedDBColdOpensDoNotBlockDifferentDBPools(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	dsnCfg, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, portText, err := net.SplitHostPort(dsnCfg.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passwordCipher, err := enc.Encrypt(context.Background(), []byte(dsnCfg.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	register := func(orgID string) int64 {
+		t.Helper()
+		dbID, err := metaStore.RegisterSharedDB(context.Background(), &meta.SharedDB{
+			TiDBCloudOrganizationID: orgID, Host: host, Port: port,
+			User: dsnCfg.User, PasswordCipher: passwordCipher, Name: dsnCfg.DBName,
+			MaxTenants: 100, Status: meta.SharedDBStatusActive,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		return dbID
+	}
+	dbID1 := register("org-concurrent-open-1")
+	dbID2 := register("org-concurrent-open-2")
+	pool := NewPool(PoolConfig{}, enc)
+	pool.SetMetaStore(metaStore)
+	t.Cleanup(pool.Close)
+
+	var ensureCalls atomic.Int32
+	firstEnsureStarted := make(chan struct{})
+	releaseFirstEnsure := make(chan struct{})
+	previousEnsure := ensureSharedDBSchema
+	ensureSharedDBSchema = func(ctx context.Context, db *sql.DB) error {
+		if ensureCalls.Add(1) == 1 {
+			close(firstEnsureStarted)
+			<-releaseFirstEnsure
+		}
+		return db.PingContext(ctx)
+	}
+	t.Cleanup(func() { ensureSharedDBSchema = previousEnsure })
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- pool.EnsureSharedDBReady(context.Background(), dbID1) }()
+	<-firstEnsureStarted
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- pool.EnsureSharedDBReady(context.Background(), dbID2) }()
+
+	var secondErr error
+	secondBlocked := false
+	select {
+	case secondErr = <-secondDone:
+	case <-time.After(time.Second):
+		secondBlocked = true
+	}
+	close(releaseFirstEnsure)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first shared DB open: %v", err)
+	}
+	if secondBlocked {
+		secondErr = <-secondDone
+	}
+	if secondErr != nil {
+		t.Fatalf("second shared DB open: %v", secondErr)
+	}
+	if secondBlocked {
+		t.Fatal("cold open for one shared DB blocked an unrelated shared DB")
 	}
 }
 

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -119,6 +119,13 @@ func TestPoolInvalidateSharedDBClosesOnlySelectedHandle(t *testing.T) {
 	if err := pool.InvalidateSharedDB(1); err != nil {
 		t.Fatalf("second InvalidateSharedDB: %v", err)
 	}
+	pool.releaseSharedDB(1)
+	if _, ok := pool.sharedDBRefs[1]; ok {
+		t.Fatal("release recreated refs for an invalidated shared DB")
+	}
+	if _, ok := pool.sharedDBLastUsed[1]; ok {
+		t.Fatal("release recreated last-used state for an invalidated shared DB")
+	}
 }
 
 func TestSharedDBHandleIdleReapUsesLongerTTLAndSkipsReferencedHandles(t *testing.T) {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/rand"
 	"database/sql"
+	"errors"
 	"fmt"
+	"net"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -77,6 +79,199 @@ func TestPoolInvalidateRecordsCachedBackendGauge(t *testing.T) {
 
 	pool.Invalidate(tenant.ID)
 	assertCachedBackendGauge(t, 0)
+}
+
+func TestPoolInvalidateSharedDBClosesOnlySelectedHandle(t *testing.T) {
+	pool := NewPool(PoolConfig{}, nil)
+	t.Cleanup(pool.Close)
+	db1, err := sql.Open("mysql", testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	db2, err := sql.Open("mysql", testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := db1.Ping(); err != nil {
+		t.Fatal(err)
+	}
+	if err := db2.Ping(); err != nil {
+		t.Fatal(err)
+	}
+	pool.sharedDBs[1] = db1
+	pool.sharedDBs[2] = db2
+
+	if err := pool.InvalidateSharedDB(1); err != nil {
+		t.Fatalf("InvalidateSharedDB: %v", err)
+	}
+	if _, ok := pool.sharedDBs[1]; ok {
+		t.Fatal("invalidated shared DB remains cached")
+	}
+	if _, ok := pool.sharedDBs[2]; !ok {
+		t.Fatal("unrelated shared DB was removed")
+	}
+	if err := db1.Ping(); err == nil {
+		t.Fatal("invalidated shared DB handle remains open")
+	}
+	if err := db2.Ping(); err != nil {
+		t.Fatalf("unrelated shared DB handle was closed: %v", err)
+	}
+	if err := pool.InvalidateSharedDB(1); err != nil {
+		t.Fatalf("second InvalidateSharedDB: %v", err)
+	}
+}
+
+func TestSharedDBHandleIdleReapUsesLongerTTLAndSkipsReferencedHandles(t *testing.T) {
+	pool := NewPool(PoolConfig{IdleTimeout: 5 * time.Minute}, nil)
+	t.Cleanup(pool.Close)
+	now := time.Now()
+
+	openDB := func() *sql.DB {
+		t.Helper()
+		db, err := sql.Open("mysql", testDSN)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := db.Ping(); err != nil {
+			t.Fatal(err)
+		}
+		return db
+	}
+	expired := openDB()
+	recent := openDB()
+	referenced := openDB()
+	pool.sharedDBs[1] = expired
+	pool.sharedDBs[2] = recent
+	pool.sharedDBs[3] = referenced
+	pool.sharedDBLastUsed[1] = now.Add(-defaultSharedDBHandleIdleTTL - time.Second)
+	pool.sharedDBLastUsed[2] = now.Add(-10 * time.Minute)
+	pool.retainSharedDB(3)
+	pool.sharedDBLastUsed[3] = now.Add(-defaultSharedDBHandleIdleTTL - time.Second)
+
+	pool.reapIdleSharedDBs(now)
+
+	if _, ok := pool.sharedDBs[1]; ok {
+		t.Fatal("expired unreferenced shared handle remains cached")
+	}
+	if err := expired.Ping(); err == nil {
+		t.Fatal("expired unreferenced shared handle remains open")
+	}
+	if _, ok := pool.sharedDBs[2]; !ok {
+		t.Fatal("recent shared handle was evicted at tenant 5m TTL")
+	}
+	if _, ok := pool.sharedDBs[3]; !ok {
+		t.Fatal("referenced shared handle was evicted")
+	}
+
+	pool.releaseSharedDB(3)
+	releasedAt := pool.sharedDBLastUsed[3]
+	pool.reapIdleSharedDBs(releasedAt.Add(defaultSharedDBHandleIdleTTL + time.Second))
+	if _, ok := pool.sharedDBs[3]; ok {
+		t.Fatal("released shared handle remains cached after its no-reference TTL")
+	}
+	if err := referenced.Ping(); err == nil {
+		t.Fatal("released shared handle remains open after its no-reference TTL")
+	}
+}
+
+func TestSharedDBSchemaIsCheckedLazilyAndRetriedAfterFailure(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	dsnCfg, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, portText, err := net.SplitHostPort(dsnCfg.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passwordCipher, err := enc.Encrypt(context.Background(), []byte(dsnCfg.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := metaStore.RegisterSharedDB(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-lazy-schema", Host: host, Port: port,
+		User: dsnCfg.User, PasswordCipher: passwordCipher, Name: dsnCfg.DBName,
+		MaxTenants: 100, Status: meta.SharedDBStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := NewPool(PoolConfig{}, enc)
+	pool.SetMetaStore(metaStore)
+	t.Cleanup(pool.Close)
+
+	wantErr := errors.New("schema apply failed")
+	ensureCalls := 0
+	previousEnsure := ensureSharedDBSchema
+	ensureSharedDBSchema = func(ctx context.Context, db *sql.DB) error {
+		ensureCalls++
+		if err := db.PingContext(ctx); err != nil {
+			return err
+		}
+		if ensureCalls == 1 {
+			return wantErr
+		}
+		return nil
+	}
+	t.Cleanup(func() { ensureSharedDBSchema = previousEnsure })
+
+	if err := pool.EnsureSharedDBReady(context.Background(), dbID); !errors.Is(err, wantErr) {
+		t.Fatalf("first EnsureSharedDBReady = %v, want %v", err, wantErr)
+	}
+	if _, ok := pool.sharedDBs[dbID]; ok {
+		t.Fatal("failed schema ensure cached the shared DB handle")
+	}
+	info, err := metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.SchemaVersion != 0 {
+		t.Fatalf("schema version after failure = %d, want 0", info.SchemaVersion)
+	}
+
+	if err := pool.EnsureSharedDBReady(context.Background(), dbID); err != nil {
+		t.Fatalf("second EnsureSharedDBReady: %v", err)
+	}
+	if err := pool.EnsureSharedDBReady(context.Background(), dbID); err != nil {
+		t.Fatalf("cached EnsureSharedDBReady: %v", err)
+	}
+	if ensureCalls != 2 {
+		t.Fatalf("schema ensure calls = %d, want 2", ensureCalls)
+	}
+	info, err = metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.SchemaVersion != schema.CurrentSharedTiDBSchemaVersion {
+		t.Fatalf("schema version = %d, want %d", info.SchemaVersion, schema.CurrentSharedTiDBSchemaVersion)
+	}
+
+	if err := pool.InvalidateSharedDB(dbID); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.EnsureSharedDBReady(context.Background(), dbID); err != nil {
+		t.Fatalf("reopen current schema: %v", err)
+	}
+	if ensureCalls != 2 {
+		t.Fatalf("schema ensure calls after current-version reopen = %d, want 2", ensureCalls)
+	}
 }
 
 func assertCachedBackendGauge(t *testing.T, want int) {

--- a/pkg/tenant/provider.go
+++ b/pkg/tenant/provider.go
@@ -9,9 +9,8 @@ const (
 
 	// ProviderTiDBCloudNativeShared is the persisted provider of a tenant
 	// placed on a shared-schema (multi-tenant) TiDB database. It is assigned
-	// by the server at provision time when the tenant's org matches a
-	// registered shared pool — never selected directly by a provisioner —
-	// and lets provider-driven capability checks distinguish shared tenants
+	// as the independent new-tenant default while reusing the native TiDB
+	// Cloud provisioner, and lets provider-driven capability checks distinguish shared tenants
 	// from dedicated-cluster ones without an extra placement lookup:
 	// TiDB-backed, but no per-tenant cluster to delete or fork, and no
 	// database auto-embedding (the shared schema has no generated columns).
@@ -36,6 +35,12 @@ func NormalizeProvider(provider string) (string, error) {
 // of a tenant placed on a shared-schema database.
 func IsSharedSchemaProvider(provider string) bool {
 	return provider == ProviderTiDBCloudNativeShared
+}
+
+// UsesTiDBCloudNativeCredentials reports whether provider uses the TiDB Cloud
+// Native public/private-key request and default-credential contract.
+func UsesTiDBCloudNativeCredentials(provider string) bool {
+	return provider == ProviderTiDBCloudNative || provider == ProviderTiDBCloudNativeShared
 }
 
 func SmallInDB(provider string) bool {

--- a/pkg/tenant/provider_test.go
+++ b/pkg/tenant/provider_test.go
@@ -54,3 +54,16 @@ func TestSupportsClusterDelete(t *testing.T) {
 		}
 	}
 }
+
+func TestUsesTiDBCloudNativeCredentials(t *testing.T) {
+	for _, provider := range []string{ProviderTiDBCloudNative, ProviderTiDBCloudNativeShared} {
+		if !UsesTiDBCloudNativeCredentials(provider) {
+			t.Fatalf("%s should use the TiDB Cloud native credential family", provider)
+		}
+	}
+	for _, provider := range []string{ProviderDB9, ProviderTiDBZero, ProviderTiDBCloudStarterLegacy} {
+		if UsesTiDBCloudNativeCredentials(provider) {
+			t.Fatalf("%s should not use the TiDB Cloud native credential family", provider)
+		}
+	}
+}

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -72,6 +72,32 @@ type TenantPoolClusterManager interface {
 	MarkClusterPoolFree(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) error
 }
 
+type SharedDBPoolCreateRequest struct {
+	DBPoolID             int64
+	DatabaseName         string
+	RootPassword         string
+	SpendingLimitMonthly int64
+}
+
+type SharedDBPoolInfo struct {
+	DBPoolID       int64
+	ClusterID      string
+	OrganizationID string
+	Host           string
+	Port           int
+	Username       string
+	Password       string
+	DBName         string
+}
+
+type SharedDBPoolProvisioner interface {
+	Provisioner
+	BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, requests []SharedDBPoolCreateRequest, req CredentialProvisionRequest) ([]*SharedDBPoolInfo, error)
+	LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoolID int64, clusterID string, req CredentialProvisionRequest) (*SharedDBPoolInfo, error)
+}
+
+var ErrSharedDBPoolAmbiguous = errors.New("multiple shared db pool cloud resources found")
+
 type TenantPoolClusterMetadataWaiter interface {
 	Provisioner
 	WaitForPoolClusterMetadata(ctx context.Context, cluster *ClusterInfo, req CredentialProvisionRequest) (*ClusterInfo, error)

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -92,8 +92,15 @@ type SharedDBPoolInfo struct {
 
 type SharedDBPoolProvisioner interface {
 	Provisioner
+	// BatchProvisionSharedDBPoolsWithCredentials may return the successfully
+	// decoded subset together with a non-nil error. Callers must persist/process
+	// every returned result before handling the error.
 	BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, requests []SharedDBPoolCreateRequest, req CredentialProvisionRequest) ([]*SharedDBPoolInfo, error)
 	LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoolID int64, clusterID string, req CredentialProvisionRequest) (*SharedDBPoolInfo, error)
+}
+
+type SharedDBPoolMetadataWaiter interface {
+	WaitForSharedDBPoolMetadataWithCredentials(ctx context.Context, dbPoolID int64, clusterID string, req CredentialProvisionRequest) (*SharedDBPoolInfo, error)
 }
 
 var ErrSharedDBPoolAmbiguous = errors.New("multiple shared db pool cloud resources found")

--- a/pkg/tenant/schema/shared.go
+++ b/pkg/tenant/schema/shared.go
@@ -15,10 +15,6 @@ import (
 // authoritative in multi-tenant deployments — see
 // CoreFSTiDBSharedSchemaStatements). There are no foreign keys, so statement
 // order is informational only. For plain MySQL use SharedMySQLSchemaStatements.
-//
-// Schema versioning for shared databases is intentionally not wired up yet:
-// per-physical-DB versioning arrives with the routing phase, so init is a
-// plain idempotent apply of this statement list for now.
 func SharedTiDBSchemaStatements() []string {
 	stmts := CoreFSTiDBSharedSchemaStatements()
 	stmts = append(stmts, JournalTiDBSharedSchemaStatements()...)
@@ -27,6 +23,11 @@ func SharedTiDBSchemaStatements() []string {
 	stmts = append(stmts, FSLayerTiDBSharedSchemaStatements()...)
 	return stmts
 }
+
+// CurrentSharedTiDBSchemaVersion is derived from the checked-in shared schema
+// SQL. A physical DB pool stores this value only after its idempotent ensure
+// succeeds, so normal opens can skip repeated DDL work.
+var CurrentSharedTiDBSchemaVersion = currentTiDBTenantSchemaVersion(SharedTiDBSchemaStatements())
 
 // SharedMySQLSchemaStatements is the plain-MySQL variant of
 // SharedTiDBSchemaStatements, derived by removing TiDB-only keywords. Use it
@@ -65,6 +66,13 @@ func InitSharedSchema(ctx context.Context, dsn string) error {
 		return err
 	}
 	defer func() { _ = closeTiDBSchemaDB(db) }()
+	return EnsureSharedSchema(ctx, db)
+}
+
+// EnsureSharedSchema applies the shared schema through an already-open
+// physical DB handle. This is used by the shared connection cache so schema
+// comparison and initialization happen once at DB-pool open time.
+func EnsureSharedSchema(ctx context.Context, db *sql.DB) error {
 	stmts, err := SharedSchemaStatementsForDB(ctx, db)
 	if err != nil {
 		return err

--- a/pkg/tenant/schema/shared_test.go
+++ b/pkg/tenant/schema/shared_test.go
@@ -79,6 +79,20 @@ func TestSharedTiDBSchemaStatementsContainsAllTables(t *testing.T) {
 	}
 }
 
+func TestCurrentSharedTiDBSchemaVersionIsDerivedFromSharedStatements(t *testing.T) {
+	if CurrentSharedTiDBSchemaVersion <= 0 {
+		t.Fatalf("CurrentSharedTiDBSchemaVersion = %d, want positive", CurrentSharedTiDBSchemaVersion)
+	}
+	if got, want := CurrentSharedTiDBSchemaVersion, currentTiDBTenantSchemaVersion(SharedTiDBSchemaStatements()); got != want {
+		t.Fatalf("CurrentSharedTiDBSchemaVersion = %d, want derived value %d", got, want)
+	}
+	changed := append([]string(nil), SharedTiDBSchemaStatements()...)
+	changed[0] += "\nCREATE INDEX idx_version_probe ON file_nodes (fs_id)"
+	if got := currentTiDBTenantSchemaVersion(changed); got == CurrentSharedTiDBSchemaVersion {
+		t.Fatalf("derived version did not change after schema content change: %d", got)
+	}
+}
+
 // TestSharedMySQLSchemaStatementsDialect ensures the MySQL variant carries no
 // TiDB-only constructs — no CLUSTERED keyword and no VECTOR(n) column types —
 // while keeping the same 30 tables.

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -67,8 +67,6 @@ const (
 	upstreamClusterBodyLimit = 1 << 20
 )
 
-const SharedDBPoolStatusProvisioning = "provisioning"
-
 var (
 	immutableLabelKeys = []string{
 		"tidb.cloud/project",
@@ -530,10 +528,9 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 			"rootPassword": password,
 			"region":       map[string]string{"name": p.regionName()},
 			"labels": map[string]string{
-				Drive9ManagedLabel:    "true",
-				Drive9ProviderLabel:   tenant.ProviderTiDBCloudNativeShared,
-				Drive9DBPoolIDLabel:   id,
-				Drive9PoolStatusLabel: SharedDBPoolStatusProvisioning,
+				Drive9ManagedLabel:  "true",
+				Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+				Drive9DBPoolIDLabel: id,
 			},
 			"spendingLimit": map[string]int32{"monthly": int32(input.SpendingLimitMonthly)},
 		}})

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -595,6 +595,9 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 		out = append(out, result)
 	}
 	sort.Slice(out, func(i, j int) bool { return out[i].DBPoolID < out[j].DBPoolID })
+	// Preserve decoded successes with partialErr as required by the
+	// SharedDBPoolProvisioner contract; callers persist these before retrying
+	// omitted DB pools through the continuation path.
 	return out, partialErr
 }
 
@@ -637,7 +640,11 @@ func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoo
 	if len(matches) != 1 {
 		return nil, fmt.Errorf("%w: found %d managed shared clusters for db pool %d", tenant.ErrSharedDBPoolAmbiguous, len(matches), dbPoolID)
 	}
-	info := &matches[0]
+	return p.sharedDBPoolInfoFromCluster(dbPoolID, &matches[0])
+}
+
+func (p *Provisioner) sharedDBPoolInfoFromCluster(dbPoolID int64, info *clusterInfo) (*tenant.SharedDBPoolInfo, error) {
+	wantID := strconv.FormatInt(dbPoolID, 10)
 	if got := strings.TrimSpace(info.Labels[Drive9ManagedLabel]); got != "true" {
 		return nil, fmt.Errorf("cluster %q has %s label %q, want %q", info.ClusterID, Drive9ManagedLabel, got, "true")
 	}
@@ -660,6 +667,28 @@ func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoo
 		result.Username = strings.TrimSpace(info.UserPrefix) + ".root"
 	}
 	return result, nil
+}
+
+// WaitForSharedDBPoolMetadataWithCredentials reuses the existing TiDB Cloud
+// Native endpoint/user/org readiness poll for a managed shared DB pool.
+func (p *Provisioner) WaitForSharedDBPoolMetadataWithCredentials(ctx context.Context, dbPoolID int64, clusterID string, req tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, tenant.ErrCredentialsRequired
+	}
+	if dbPoolID <= 0 {
+		return nil, fmt.Errorf("db pool id must be positive")
+	}
+	clusterID = strings.TrimSpace(clusterID)
+	if clusterID == "" {
+		return nil, fmt.Errorf("cluster id is required")
+	}
+	info, err := p.waitForClusterProvisionMetadata(ctx, publicKey, privateKey, clusterID)
+	if err != nil {
+		return nil, err
+	}
+	return p.sharedDBPoolInfoFromCluster(dbPoolID, info)
 }
 
 type batchClusterMetadataTarget struct {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -625,6 +625,7 @@ func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoo
 		}
 		for _, info := range infos {
 			if strings.TrimSpace(info.Labels[Drive9DBPoolIDLabel]) == wantID &&
+				strings.TrimSpace(info.Labels[Drive9ManagedLabel]) == "true" &&
 				strings.TrimSpace(info.Labels[Drive9ProviderLabel]) == tenant.ProviderTiDBCloudNativeShared {
 				matches = append(matches, info)
 			}
@@ -637,6 +638,12 @@ func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoo
 		return nil, fmt.Errorf("%w: found %d managed shared clusters for db pool %d", tenant.ErrSharedDBPoolAmbiguous, len(matches), dbPoolID)
 	}
 	info := &matches[0]
+	if got := strings.TrimSpace(info.Labels[Drive9ManagedLabel]); got != "true" {
+		return nil, fmt.Errorf("cluster %q has %s label %q, want %q", info.ClusterID, Drive9ManagedLabel, got, "true")
+	}
+	if got := strings.TrimSpace(info.Labels[Drive9ProviderLabel]); got != tenant.ProviderTiDBCloudNativeShared {
+		return nil, fmt.Errorf("cluster %q has %s label %q, want %q", info.ClusterID, Drive9ProviderLabel, got, tenant.ProviderTiDBCloudNativeShared)
+	}
 	if got := strings.TrimSpace(info.Labels[Drive9DBPoolIDLabel]); got != wantID {
 		return nil, fmt.Errorf("cluster %q has db pool label %q, want %q", info.ClusterID, got, wantID)
 	}

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -58,12 +58,16 @@ const (
 	Drive9PoolStatusLabel      = "drive9.ai/status"
 	Drive9PoolIDLabel          = "drive9.ai/pool_id"
 	Drive9PoolUsedAtLabel      = "drive9.ai/used_at"
+	Drive9ProviderLabel        = "drive9.ai/provider"
+	Drive9DBPoolIDLabel        = "drive9.ai/db_pool_id"
 	Drive9QuotaUpdateAtLabel   = "drive9.ai/update_quota_at"
 	TiDBCloudOrganizationLabel = "tidb.cloud/organization"
 
 	upstreamErrorBodyLimit   = 2048
 	upstreamClusterBodyLimit = 1 << 20
 )
+
+const SharedDBPoolStatusProvisioning = "provisioning"
 
 var (
 	immutableLabelKeys = []string{
@@ -161,6 +165,17 @@ func (p *Provisioner) DefaultCredentials() (tenant.CredentialProvisionRequest, b
 }
 
 func (p *Provisioner) ProvisioningRegion() string { return p.region }
+
+// DefaultTiDBCloudSpendingLimit returns the effective native create default so
+// shared tenants can persist the same value as local compatibility metadata.
+func (p *Provisioner) DefaultTiDBCloudSpendingLimit() int64 {
+	if p.defaultSpendLimit == nil {
+		return 0
+	}
+	return int64(*p.defaultSpendLimit)
+}
+
+func (p *Provisioner) DefaultSharedDatabaseName() string { return p.defaultDatabaseName }
 
 func (p *Provisioner) InitSchema(ctx context.Context, dsn string) error {
 	// Direct callers still need database creation; the server auto-embedding
@@ -472,6 +487,172 @@ func (p *Provisioner) BatchProvisionFreeClustersWithCredentialsAndQuota(ctx cont
 		cloudCfg.TiDBCloudSpendingLimitMonthly = ptrInt64(*spendingLimit)
 	}
 	return out, cloudCfg, nil
+}
+
+func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, inputs []tenant.SharedDBPoolCreateRequest, req tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, tenant.ErrCredentialsRequired
+	}
+	if len(inputs) == 0 {
+		return []*tenant.SharedDBPoolInfo{}, nil
+	}
+	if len(inputs) > 10 {
+		return nil, fmt.Errorf("shared db pool batch size %d exceeds 10", len(inputs))
+	}
+	requests := make([]map[string]any, 0, len(inputs))
+	passwords := make(map[int64]string, len(inputs))
+	databaseNames := make(map[int64]string, len(inputs))
+	for _, input := range inputs {
+		if input.DBPoolID <= 0 {
+			return nil, fmt.Errorf("db pool id must be positive")
+		}
+		if _, exists := passwords[input.DBPoolID]; exists {
+			return nil, fmt.Errorf("duplicate db pool id %d", input.DBPoolID)
+		}
+		if err := validateTiDBCloudSpendingLimit(input.SpendingLimitMonthly); err != nil {
+			return nil, err
+		}
+		dbName, err := p.resolveDatabaseName(input.DatabaseName)
+		if err != nil {
+			return nil, err
+		}
+		password := strings.TrimSpace(input.RootPassword)
+		if password == "" {
+			return nil, fmt.Errorf("root password is required for db pool %d", input.DBPoolID)
+		}
+		passwords[input.DBPoolID] = password
+		databaseNames[input.DBPoolID] = dbName
+		id := strconv.FormatInt(input.DBPoolID, 10)
+		requests = append(requests, map[string]any{"cluster": map[string]any{
+			"displayName":  clusterDisplayName(id),
+			"rootPassword": password,
+			"region":       map[string]string{"name": p.regionName()},
+			"labels": map[string]string{
+				Drive9ManagedLabel:    "true",
+				Drive9ProviderLabel:   tenant.ProviderTiDBCloudNativeShared,
+				Drive9DBPoolIDLabel:   id,
+				Drive9PoolStatusLabel: SharedDBPoolStatusProvisioning,
+			},
+			"spendingLimit": map[string]int32{"monthly": int32(input.SpendingLimitMonthly)},
+		}})
+	}
+	body, err := json.Marshal(map[string]any{"requests": requests})
+	if err != nil {
+		return nil, err
+	}
+	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodPost, p.apiURL+"/v1beta1/clusters:batchCreate", body)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
+		if readErr != nil {
+			return nil, readErr
+		}
+		return nil, fmt.Errorf("%s", statusError("batch provision shared db pools", resp.StatusCode, sanitizeUpstreamBody(raw)))
+	}
+	raw, err := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
+	if err != nil {
+		return nil, err
+	}
+	var created clusterListResponse
+	if err := json.Unmarshal(raw, &created); err != nil {
+		return nil, err
+	}
+	var partialErr error
+	if len(created.Clusters) != len(inputs) {
+		partialErr = fmt.Errorf("tidbcloud native shared batch provision returned %d clusters, want %d", len(created.Clusters), len(inputs))
+	}
+	out := make([]*tenant.SharedDBPoolInfo, 0, len(created.Clusters))
+	for i := range created.Clusters {
+		info := &created.Clusters[i]
+		id, err := strconv.ParseInt(strings.TrimSpace(info.Labels[Drive9DBPoolIDLabel]), 10, 64)
+		if err != nil || id <= 0 {
+			return nil, fmt.Errorf("tidbcloud native shared batch response has invalid %s label for cluster %q", Drive9DBPoolIDLabel, info.ClusterID)
+		}
+		password, ok := passwords[id]
+		if !ok {
+			return nil, fmt.Errorf("tidbcloud native shared batch response returned unknown db pool id %d", id)
+		}
+		result := &tenant.SharedDBPoolInfo{
+			DBPoolID: id, ClusterID: strings.TrimSpace(info.ClusterID),
+			OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
+			Password:       password, DBName: databaseNames[id],
+		}
+		if result.ClusterID == "" {
+			return nil, fmt.Errorf("tidbcloud native shared batch response missing cluster id for db pool %d", id)
+		}
+		if !p.clusterProvisionMetadataIncomplete(info) {
+			result.Host, result.Port, err = p.resolveClusterEndpoint(info)
+			if err != nil {
+				return nil, err
+			}
+			result.Username = strings.TrimSpace(info.UserPrefix) + ".root"
+		}
+		out = append(out, result)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].DBPoolID < out[j].DBPoolID })
+	return out, partialErr
+}
+
+// LoadSharedDBPoolWithCredentials finds an existing managed shared cluster by
+// its durable db-pool label, or refreshes a known cluster by ID. A nil result
+// means no matching cluster exists yet. Multiple label matches fail closed.
+func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoolID int64, clusterID string, req tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, tenant.ErrCredentialsRequired
+	}
+	if dbPoolID <= 0 {
+		return nil, fmt.Errorf("db pool id must be positive")
+	}
+	wantID := strconv.FormatInt(dbPoolID, 10)
+	var matches []clusterInfo
+	if strings.TrimSpace(clusterID) != "" {
+		info, err := p.getClusterBasicInfoWithCredentials(ctx, publicKey, privateKey, strings.TrimSpace(clusterID))
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, *info)
+	} else {
+		infos, err := p.listClusterInfosWithCredentials(ctx, publicKey, privateKey, nil, 100)
+		if err != nil {
+			return nil, err
+		}
+		for _, info := range infos {
+			if strings.TrimSpace(info.Labels[Drive9DBPoolIDLabel]) == wantID &&
+				strings.TrimSpace(info.Labels[Drive9ProviderLabel]) == tenant.ProviderTiDBCloudNativeShared {
+				matches = append(matches, info)
+			}
+		}
+	}
+	if len(matches) == 0 {
+		return nil, nil
+	}
+	if len(matches) != 1 {
+		return nil, fmt.Errorf("%w: found %d managed shared clusters for db pool %d", tenant.ErrSharedDBPoolAmbiguous, len(matches), dbPoolID)
+	}
+	info := &matches[0]
+	if got := strings.TrimSpace(info.Labels[Drive9DBPoolIDLabel]); got != wantID {
+		return nil, fmt.Errorf("cluster %q has db pool label %q, want %q", info.ClusterID, got, wantID)
+	}
+	result := &tenant.SharedDBPoolInfo{
+		DBPoolID: dbPoolID, ClusterID: strings.TrimSpace(info.ClusterID),
+		OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
+	}
+	if !p.clusterProvisionMetadataIncomplete(info) {
+		var err error
+		result.Host, result.Port, err = p.resolveClusterEndpoint(info)
+		if err != nil {
+			return nil, err
+		}
+		result.Username = strings.TrimSpace(info.UserPrefix) + ".root"
+	}
+	return result, nil
 }
 
 type batchClusterMetadataTarget struct {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -536,6 +536,52 @@ func TestLoadSharedDBPoolWithClusterIDRejectsNonSharedLabels(t *testing.T) {
 	}
 }
 
+func TestWaitForSharedDBPoolMetadataUsesNativeReadinessPoll(t *testing.T) {
+	origPoll := tidbCloudNativePollInterval
+	tidbCloudNativePollInterval = time.Millisecond
+	t.Cleanup(func() { tidbCloudNativePollInterval = origPoll })
+
+	var authorizedGets atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-shared-wait", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodGet || r.URL.Path != "/v1beta1/clusters/cluster-pool-41" {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		response := map[string]any{
+			"clusterId": "cluster-pool-41", "state": "ACTIVE",
+			"labels": map[string]string{
+				Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+				Drive9DBPoolIDLabel: "41", TiDBCloudOrganizationLabel: "org-1",
+			},
+		}
+		if authorizedGets.Add(1) > 1 {
+			response["userPrefix"] = "u1"
+			response["endpoints"] = map[string]any{"public": map[string]any{"host": "shared.example", "port": 4000}}
+		}
+		_ = json.NewEncoder(w).Encode(response)
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{apiURL: ts.URL, client: ts.Client()}
+	got, err := p.WaitForSharedDBPoolMetadataWithCredentials(context.Background(), 41, "cluster-pool-41",
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	if err != nil {
+		t.Fatalf("WaitForSharedDBPoolMetadataWithCredentials: %v", err)
+	}
+	if authorizedGets.Load() != 2 {
+		t.Fatalf("authorized GETs = %d, want 2", authorizedGets.Load())
+	}
+	if got.DBPoolID != 41 || got.ClusterID != "cluster-pool-41" || got.OrganizationID != "org-1" ||
+		got.Host != "shared.example" || got.Port != 4000 || got.Username != "u1.root" {
+		t.Fatalf("shared DB pool metadata = %+v", got)
+	}
+}
+
 func TestBatchProvisionFreeClustersDefersIncompletePublicHostWithoutMetadataWait(t *testing.T) {
 	var listCalls atomic.Int32
 	handlerErrs := make(chan error, 2)

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -404,6 +404,87 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 	}
 }
 
+func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
+	var gotBody struct {
+		Requests []struct {
+			Cluster struct {
+				DisplayName   string            `json:"displayName"`
+				RootPassword  string            `json:"rootPassword"`
+				Labels        map[string]string `json:"labels"`
+				SpendingLimit struct {
+					Monthly int32 `json:"monthly"`
+				} `json:"spendingLimit"`
+			} `json:"cluster"`
+		} `json:"requests"`
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-shared", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/v1beta1/clusters:batchCreate" {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"clusters": []map[string]any{
+			{
+				"clusterId": "cluster-pool-41", "state": "CREATING",
+				"labels": map[string]string{
+					TiDBCloudOrganizationLabel: "org-1", Drive9DBPoolIDLabel: "41",
+				},
+			},
+			{
+				"clusterId": "cluster-pool-42", "state": "CREATING",
+				"labels": map[string]string{
+					TiDBCloudOrganizationLabel: "org-1", Drive9DBPoolIDLabel: "42",
+				},
+			},
+		}})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL: ts.URL, cloudProvider: "aws", region: "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName, client: ts.Client(),
+	}
+	got, err := p.BatchProvisionSharedDBPoolsWithCredentials(context.Background(), []tenant.SharedDBPoolCreateRequest{
+		{DBPoolID: 41, RootPassword: "durable-password-41", SpendingLimitMonthly: 10_000_000},
+		{DBPoolID: 42, RootPassword: "durable-password-42", SpendingLimitMonthly: 10_000_000},
+	}, tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	if err != nil {
+		t.Fatalf("BatchProvisionSharedDBPoolsWithCredentials: %v", err)
+	}
+	if len(gotBody.Requests) != 2 {
+		t.Fatalf("requests = %d, want 2", len(gotBody.Requests))
+	}
+	for i, request := range gotBody.Requests {
+		id := fmt.Sprintf("%d", 41+i)
+		if request.Cluster.DisplayName != "tidbcloud-fs-"+id {
+			t.Fatalf("request %d displayName = %q", i, request.Cluster.DisplayName)
+		}
+		if request.Cluster.RootPassword != "durable-password-"+id || request.Cluster.SpendingLimit.Monthly != 10_000_000 {
+			t.Fatalf("request %d password/spending invalid: %+v", i, request.Cluster)
+		}
+		wantLabels := map[string]string{
+			Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+			Drive9DBPoolIDLabel: id, Drive9PoolStatusLabel: SharedDBPoolStatusProvisioning,
+		}
+		for key, want := range wantLabels {
+			if request.Cluster.Labels[key] != want {
+				t.Fatalf("request %d label %s = %q, want %q", i, key, request.Cluster.Labels[key], want)
+			}
+		}
+	}
+	if len(got) != 2 || got[0].DBPoolID != 41 || got[0].ClusterID != "cluster-pool-41" || got[1].DBPoolID != 42 || got[1].ClusterID != "cluster-pool-42" {
+		t.Fatalf("shared pool results = %#v", got)
+	}
+}
+
 func TestBatchProvisionFreeClustersDefersIncompletePublicHostWithoutMetadataWait(t *testing.T) {
 	var listCalls atomic.Int32
 	handlerErrs := make(chan error, 2)

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -485,6 +485,57 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 	}
 }
 
+func TestLoadSharedDBPoolWithClusterIDRejectsNonSharedLabels(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		labels    map[string]string
+		wantLabel string
+	}{
+		{
+			name: "wrong provider",
+			labels: map[string]string{
+				Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNative,
+				Drive9DBPoolIDLabel: "41",
+			},
+			wantLabel: Drive9ProviderLabel,
+		},
+		{
+			name: "not managed",
+			labels: map[string]string{
+				Drive9ManagedLabel: "false", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+				Drive9DBPoolIDLabel: "41",
+			},
+			wantLabel: Drive9ManagedLabel,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Authorization") == "" {
+					w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-shared-load", qop="auth"`)
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				if r.Method != http.MethodGet || r.URL.Path != "/v1beta1/clusters/cluster-pool-41" {
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"clusterId": "cluster-pool-41", "state": "ACTIVE", "labels": tc.labels,
+				})
+			}))
+			defer ts.Close()
+
+			p := &Provisioner{apiURL: ts.URL, client: ts.Client()}
+			_, err := p.LoadSharedDBPoolWithCredentials(context.Background(), 41, "cluster-pool-41", tenant.CredentialProvisionRequest{
+				PublicKey: "public", PrivateKey: "private",
+			})
+			if err == nil || !strings.Contains(err.Error(), tc.wantLabel) {
+				t.Fatalf("LoadSharedDBPoolWithCredentials error = %v, want %s label rejection", err, tc.wantLabel)
+			}
+		})
+	}
+}
+
 func TestBatchProvisionFreeClustersDefersIncompletePublicHostWithoutMetadataWait(t *testing.T) {
 	var listCalls atomic.Int32
 	handlerErrs := make(chan error, 2)

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -472,12 +472,15 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 		}
 		wantLabels := map[string]string{
 			Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
-			Drive9DBPoolIDLabel: id, Drive9PoolStatusLabel: SharedDBPoolStatusProvisioning,
+			Drive9DBPoolIDLabel: id,
 		}
 		for key, want := range wantLabels {
 			if request.Cluster.Labels[key] != want {
 				t.Fatalf("request %d label %s = %q, want %q", i, key, request.Cluster.Labels[key], want)
 			}
+		}
+		if _, ok := request.Cluster.Labels[Drive9PoolStatusLabel]; ok {
+			t.Fatalf("request %d unexpectedly has shared lifecycle label %s", i, Drive9PoolStatusLabel)
 		}
 	}
 	if len(got) != 2 || got[0].DBPoolID != 41 || got[0].ClusterID != "cluster-pool-41" || got[1].DBPoolID != 42 || got[1].ClusterID != "cluster-pool-42" {


### PR DESCRIPTION
## Summary
- add `tidb_cloud_native_shared` provisioning with managed physical DB pools, compact placement, tenant-pool membership, batch cluster creation, and soft/hard capacity hysteresis
- dispatch existing tenant lifecycle operations from persisted provider state; shared deletion purges only the tenant fs/S3 scope, while shared fork and database auto embedding remain unsupported
- add virtual tenant spending-limit compatibility, shared DB pool metrics, lazy shared-schema initialization, and reference-aware shared connection pooling

## Validation
- `go test ./pkg/mysqlutil ./pkg/tenant -count=1`
- `go test ./pkg/meta -count=1`
- `go test ./cmd/drive9-server -count=1`
- `go test ./pkg/server -run "(Shared|TenantPool|Quota)" -count=1`
- `go build ./...`
- `make lint`
- `git diff --check`

## Notes
- `docs/superpowers/` is intentionally excluded from this PR.
- Related alert coverage: https://github.com/tidbcloud/runbooks/pull/2685

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added end-to-end support for the `tidb_cloud_native_shared` tenant provider, including `schema dump-init-sql` and provisioning flow.
  * Configurable shared-DB capacity and spending behavior via new environment variables (hard-cap ratios, reopen ratio, max tenants, default spending limit).
  * Added shared DB pool metrics (capacity, tenant counts, and spending headroom) and improved shared DB connection/schema readiness handling.

* **Bug Fixes**
  * Improved shared-pool tenant allocation, emergency/normal capacity handling, and reopen-ratio-aware deletion.
  * Shared quota GET/SET now targets shared DB spending limits and returns clear conflict status when spending is exceeded.

* **Tests**
  * Expanded coverage for shared provisioning, quotas, pool lifecycle, metrics, schema behavior, and environment parsing/validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

### Rolling upgrade note

`quota_limits_overridden` remains physically present in this release for rolling-upgrade and rollback safety. New code ignores the column and enforces the persisted quota values, including for existing rows; the physical column drop is deferred to a later release after old binaries are no longer running.
