### PR TITLE
fix: map backend errors to appropriate HTTP status codes

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -81,13 +81,13 @@ func adminTenantPoolError(status int, message string) error {
 	return &adminTenantPoolHTTPError{status: status, message: message}
 }
 
-func writeAdminTenantPoolError(w http.ResponseWriter, err error) {
+func writeAdminTenantPoolError(w http.ResponseWriter, r *http.Request, err error) {
 	var httpErr *adminTenantPoolHTTPError
 	if errors.As(err, &httpErr) {
 		errJSON(w, httpErr.status, httpErr.message)
 		return
 	}
-	errJSON(w, http.StatusInternalServerError, err.Error())
+	writeBackendError(w, r, err)
 }
 
 func (s *Server) adminTenantPoolHandler() http.Handler {
@@ -164,7 +164,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 				return nil
 			} else if !errors.Is(err, meta.ErrNotFound) {
 				metricResult = "error"
-				errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
+				errJSON(w, backendErrorStatus(r.Context(), err), "tenant pool lookup failed")
 				return nil
 			}
 		}
@@ -185,7 +185,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 				return nil
 			}
 			metricResult = "error"
-			errJSON(w, http.StatusInternalServerError, "failed to persist tenant pool")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to persist tenant pool")
 			return nil
 		}
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_create_pool_persisted",
@@ -237,7 +237,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 						return nil
 					}
 					metricResult = "error"
-					errJSON(w, http.StatusInternalServerError, "failed to update tenant pool organization")
+					errJSON(w, backendErrorStatus(r.Context(), err), "failed to update tenant pool organization")
 					return nil
 				}
 				logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_create_org_persisted",
@@ -287,7 +287,7 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 			"duration_ms", durationMillis(createStarted),
 			"error", err)...)
 		metricResult = adminTenantPoolMetricResult(err)
-		writeAdminTenantPoolError(w, err)
+		writeAdminTenantPoolError(w, r, err)
 		return
 	}
 }
@@ -304,7 +304,7 @@ func (s *Server) handleAdminTenantPoolGet(w http.ResponseWriter, r *http.Request
 	}
 	freeSize, slotSize, err := s.tenantPoolSizes(r.Context(), pool.OrganizationID)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, err.Error())
+		writeBackendError(w, r, err)
 		return
 	}
 	s.recordTenantPoolCapacity(pool.PoolID, pool.OrganizationID, pool.Size, freeSize)
@@ -499,7 +499,7 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 			"target_pool_size", *req.PoolSize,
 			"duration_ms", durationMillis(updateStarted),
 			"error", err)...)
-		writeAdminTenantPoolError(w, err)
+		writeAdminTenantPoolError(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_update_done",
@@ -628,7 +628,7 @@ func (s *Server) handleAdminTenantPoolDelete(w http.ResponseWriter, r *http.Requ
 			"duration_ms", durationMillis(deleteStarted),
 			"error", err)...)
 		metricResult = adminTenantPoolMetricResult(err)
-		writeAdminTenantPoolError(w, err)
+		writeAdminTenantPoolError(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_delete_done",
@@ -659,7 +659,7 @@ func (s *Server) authorizedTenantPool(w http.ResponseWriter, r *http.Request, cr
 			errJSON(w, http.StatusNotFound, "tenant pool not found")
 			return nil, false
 		}
-		errJSON(w, http.StatusInternalServerError, "tenant pool lookup failed")
+		errJSON(w, backendErrorStatus(r.Context(), err), "tenant pool lookup failed")
 		return nil, false
 	}
 	return pool, true

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -233,7 +233,7 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 			errJSON(w, pe.status, pe.message)
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, "failed to provision tenant")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to provision tenant")
 		return
 	}
 	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, res.OrganizationID, classifyTenantRequest(r))
@@ -279,7 +279,7 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 	includeQuota := parseBoolQuery(r, "include_quota")
 	rows, err := s.meta.ListTenantsByTiDBCloudResources(r.Context(), authorizedBindings, offset, pageSize+1)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "tenant list failed")
+		errJSON(w, backendErrorStatus(r.Context(), err), "tenant list failed")
 		return
 	}
 	nextPage := 0
@@ -312,7 +312,7 @@ func (s *Server) handleAdminTenantGet(w http.ResponseWriter, r *http.Request, te
 	quota, err := s.loadAdminTenantQuotaSummary(r.Context(), t)
 	if err != nil {
 		logger.Warn(r.Context(), "admin_tenant_quota_lookup_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-		errJSON(w, http.StatusInternalServerError, "quota lookup failed")
+		errJSON(w, backendErrorStatus(r.Context(), err), "quota lookup failed")
 		return
 	}
 	writeJSON(w, http.StatusOK, s.adminTenantResponse(t, binding, quota))
@@ -394,7 +394,7 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 	if t.StorageNamespaceID != "" {
 		hasFork, err := s.meta.NamespaceHasNonDeletedFork(r.Context(), t.StorageNamespaceID)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "failed to check tenant forks")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to check tenant forks")
 			return
 		}
 		if hasFork {
@@ -405,7 +405,7 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 	if t.Status == meta.TenantDeleting {
 		hasJob, err := s.meta.TenantDeleteJobExists(r.Context(), t.ID)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "failed to check tenant delete cleanup")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to check tenant delete cleanup")
 			return
 		}
 		if hasJob {
@@ -426,7 +426,7 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 	if t.Status != meta.TenantDeleting {
 		updated, err := s.meta.UpdateTenantStatusIf(r.Context(), t.ID, t.Status, meta.TenantDeleting)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "failed to mark tenant deleting")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to mark tenant deleting")
 			return
 		}
 		if !updated {
@@ -438,7 +438,7 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 		if t.Status != meta.TenantDeleting {
 			_, _ = s.meta.UpdateTenantStatusIf(r.Context(), t.ID, meta.TenantDeleting, t.Status)
 		}
-		errJSON(w, http.StatusInternalServerError, "failed to drain tenant backend")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to drain tenant backend")
 		return
 	}
 	if err := s.deprovisionTenantCluster(r.Context(), t, cred); err != nil {
@@ -452,7 +452,7 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 	_ = s.meta.AbortActiveUploadReservations(r.Context(), t.ID)
 	status, err := s.enqueueTenantDeleteJob(r.Context(), t)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to enqueue tenant delete cleanup")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to enqueue tenant delete cleanup")
 		return
 	}
 	_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
@@ -467,7 +467,7 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 			errJSON(w, http.StatusNotFound, "tenant not found")
 			return nil, nil, false
 		}
-		errJSON(w, http.StatusInternalServerError, "tenant lookup failed")
+		errJSON(w, backendErrorStatus(r.Context(), err), "tenant lookup failed")
 		return nil, nil, false
 	}
 	if t.Status == meta.TenantDeleted {
@@ -500,7 +500,7 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 			errJSON(w, http.StatusNotFound, "tenant tidbcloud organization binding not found")
 			return nil, nil, false
 		}
-		errJSON(w, http.StatusInternalServerError, "tenant organization binding lookup failed")
+		errJSON(w, backendErrorStatus(r.Context(), err), "tenant organization binding lookup failed")
 		return nil, nil, false
 	}
 	if binding.PoolStatus == meta.TenantPoolBindingFree {
@@ -655,7 +655,7 @@ func (s *Server) writeAdminQuotaResponse(w http.ResponseWriter, r *http.Request,
 	quota, err := s.loadAdminTenantQuotaSummary(r.Context(), t)
 	if err != nil {
 		logger.Warn(r.Context(), "admin_tenant_quota_lookup_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-		errJSON(w, http.StatusInternalServerError, "quota lookup failed")
+		errJSON(w, backendErrorStatus(r.Context(), err), "quota lookup failed")
 		return
 	}
 	writeJSON(w, http.StatusOK, adminQuotaResponse{

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -62,7 +62,8 @@ func isQuotaError(err error) bool {
 		return strings.Contains(strings.ToLower(mysqlErr.Message), "quota")
 	}
 	msg := strings.ToLower(err.Error())
-	return strings.Contains(msg, "error 1105") && strings.Contains(msg, "quota")
+	idx := strings.Index(msg, "error 1105")
+	return idx >= 0 && strings.Contains(msg[idx:], "quota")
 }
 
 func isSchemaMigrationError(err error) bool {

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/drive9/pkg/backend"
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
@@ -55,6 +56,10 @@ const statusClientClosedRequest = 499
 func isQuotaError(err error) bool {
 	if err == nil {
 		return false
+	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) && mysqlErr.Number == 1105 {
+		return strings.Contains(strings.ToLower(mysqlErr.Message), "quota")
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "error 1105") && strings.Contains(msg, "quota")

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -52,21 +52,56 @@ const (
 
 const statusClientClosedRequest = 499
 
+func isQuotaError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "error 1105") && strings.Contains(msg, "quota")
+}
+
+func isSchemaMigrationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "ensure tidb auto-embedding schema") ||
+		strings.Contains(msg, "validate tidb auto-embedding schema") ||
+		strings.Contains(msg, "migrate split tables") ||
+		strings.Contains(msg, "detect legacy files table")
+}
+
 func sanitizeClientError(err error) string {
 	if err == nil {
 		return "backend unavailable"
 	}
-	msg := strings.ToLower(err.Error())
-	if strings.Contains(msg, "error 1105") && strings.Contains(msg, "quota") {
+	if isQuotaError(err) {
 		return "tenant usage quota exceeded"
 	}
-	if strings.Contains(msg, "ensure tidb auto-embedding schema") ||
-		strings.Contains(msg, "validate tidb auto-embedding schema") ||
-		strings.Contains(msg, "migrate split tables") ||
-		strings.Contains(msg, "detect legacy files table") {
+	if isSchemaMigrationError(err) {
 		return "tenant metadata error"
 	}
 	return "backend unavailable"
+}
+
+func backendErrorStatus(ctx context.Context, err error) int {
+	if isClientCanceled(ctx, err) {
+		return statusClientClosedRequest
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return http.StatusGatewayTimeout
+	}
+	if isQuotaError(err) {
+		return http.StatusPaymentRequired
+	}
+	if isSchemaMigrationError(err) {
+		return http.StatusBadGateway
+	}
+	return http.StatusInternalServerError
+}
+
+func writeBackendError(w http.ResponseWriter, r *http.Request, err error) {
+	errJSON(w, backendErrorStatus(r.Context(), err), sanitizeClientError(err))
 }
 
 func ScopeFromContext(ctx context.Context) *TenantScope {
@@ -195,7 +230,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_backend_unavailable", "error", err)...)
 			metricEvent(r.Context(), "auth", "result", "meta_backend_error")
-			errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
+			errJSON(w, backendErrorStatus(r.Context(), err), "auth backend unavailable")
 			return
 		}
 
@@ -225,7 +260,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_decrypt_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 			metricEvent(r.Context(), "auth", "result", "decrypt_failed")
-			errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
+			errJSON(w, backendErrorStatus(r.Context(), err), "auth backend unavailable")
 			return
 		}
 		if subtle.ConstantTimeCompare([]byte(tok), plain) != 1 {
@@ -305,14 +340,14 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 				}
 				logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_fs_scope_load_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 				metricEvent(r.Context(), "auth", "result", "fs_scope_load_failed")
-				errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
+				errJSON(w, backendErrorStatus(r.Context(), err), "auth backend unavailable")
 				return
 			}
 			fsScopes, err = fsScopesFromMeta(rows)
 			if err != nil {
 				logger.Error(r.Context(), "server_event", eventFields(r.Context(), "auth_fs_scope_invalid", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
 				metricEvent(r.Context(), "auth", "result", "fs_scope_invalid")
-				errJSON(w, http.StatusInternalServerError, "invalid API key scope policy")
+				errJSON(w, backendErrorStatus(r.Context(), err), "invalid API key scope policy")
 				return
 			}
 		default:
@@ -337,7 +372,7 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "backend_load_failed", "tenant_id", resolved.Tenant.ID, "error", err)...)
 			metricEvent(r.Context(), "tenant_backend", "result", "load_failed")
-			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+			writeBackendError(w, r, err)
 			return
 		}
 		defer release()
@@ -479,7 +514,7 @@ func (s *Server) capabilityAuthMiddleware(metaStore *meta.Store, pool *tenant.Po
 		metrics.RecordTenantOperationWithOrg(tenantID, authAcquireOrgID, "user_db_access", "auth_acquire", metrics.ResultForError(err), time.Since(capAcquireStart))
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "capability_backend_load_failed", "tenant_id", tenantID, "error", err)...)
-			errJSON(w, http.StatusInternalServerError, "backend unavailable")
+			errJSON(w, backendErrorStatus(r.Context(), err), "backend unavailable")
 			return
 		}
 		defer release()

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -73,7 +73,9 @@ func isSchemaMigrationError(err error) bool {
 	return strings.Contains(msg, "ensure tidb auto-embedding schema") ||
 		strings.Contains(msg, "validate tidb auto-embedding schema") ||
 		strings.Contains(msg, "migrate split tables") ||
-		strings.Contains(msg, "detect legacy files table")
+		strings.Contains(msg, "detect legacy files table") ||
+		strings.Contains(msg, "meta schema contract mismatch") ||
+		strings.Contains(msg, "tidb schema contract mismatch")
 }
 
 func sanitizeClientError(err error) string {

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -789,7 +789,7 @@ func TestBackendErrorStatus(t *testing.T) {
 				ctx = c
 			}
 			if got := backendErrorStatus(ctx, tt.err); got != tt.want {
-				t.Fatalf("backendErrorStatus() = %d, want %d", got, tt.want)
+				t.Errorf("backendErrorStatus() = %d, want %d", got, tt.want)
 			}
 		})
 	}

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -731,6 +731,11 @@ func TestSanitizeClientError_Fallback(t *testing.T) {
 			t.Fatalf("input=%q: got %q, want %q", tc, got, "backend unavailable")
 		}
 	}
+	// Non-quota 1105 wrapped with "quota" in prefix should not be classified as quota error.
+	err := fmt.Errorf("set quota config for tenant: Error 1105 (HY000): connection refused")
+	if got := sanitizeClientError(err); got != "backend unavailable" {
+		t.Fatalf("non-quota 1105 with quota prefix: got %q, want %q", got, "backend unavailable")
+	}
 }
 
 func TestBackendErrorStatus(t *testing.T) {
@@ -758,6 +763,11 @@ func TestBackendErrorStatus(t *testing.T) {
 			name: "tidb quota error lower case",
 			err:  fmt.Errorf("error 1105 (hy000): quota limit reached"),
 			want: http.StatusPaymentRequired,
+		},
+		{
+			name: "non-quota 1105 wrapped with quota prefix",
+			err:  fmt.Errorf("set quota config for tenant: Error 1105 (HY000): connection refused"),
+			want: http.StatusInternalServerError,
 		},
 		{
 			name: "schema migration error",

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -729,6 +730,68 @@ func TestSanitizeClientError_Fallback(t *testing.T) {
 		if got != "backend unavailable" {
 			t.Fatalf("input=%q: got %q, want %q", tc, got, "backend unavailable")
 		}
+	}
+}
+
+func TestBackendErrorStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{
+			name: "client canceled context",
+			err:  context.Canceled,
+			want: statusClientClosedRequest,
+		},
+		{
+			name: "deadline exceeded",
+			err:  context.DeadlineExceeded,
+			want: http.StatusGatewayTimeout,
+		},
+		{
+			name: "tidb quota error 1105",
+			err:  fmt.Errorf("open db: Error 1105 (HY000): Due to the usage quota being exhausted"),
+			want: http.StatusPaymentRequired,
+		},
+		{
+			name: "tidb quota error lower case",
+			err:  fmt.Errorf("error 1105 (hy000): quota limit reached"),
+			want: http.StatusPaymentRequired,
+		},
+		{
+			name: "schema migration error",
+			err:  fmt.Errorf("migrate split tables: Error 1146: Table doesn't exist"),
+			want: http.StatusBadGateway,
+		},
+		{
+			name: "unknown error",
+			err:  fmt.Errorf("some random error"),
+			want: http.StatusInternalServerError,
+		},
+		{
+			name: "nil error",
+			err:  nil,
+			want: http.StatusInternalServerError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			switch {
+			case errors.Is(tt.err, context.Canceled):
+				c, cancel := context.WithCancel(context.Background())
+				cancel()
+				ctx = c
+			case errors.Is(tt.err, context.DeadlineExceeded):
+				c, cancel := context.WithTimeout(context.Background(), 0)
+				cancel()
+				ctx = c
+			}
+			if got := backendErrorStatus(ctx, tt.err); got != tt.want {
+				t.Fatalf("backendErrorStatus() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -734,7 +734,7 @@ func TestSanitizeClientError_Fallback(t *testing.T) {
 	// Non-quota 1105 wrapped with "quota" in prefix should not be classified as quota error.
 	err := fmt.Errorf("set quota config for tenant: Error 1105 (HY000): connection refused")
 	if got := sanitizeClientError(err); got != "backend unavailable" {
-		t.Fatalf("non-quota 1105 with quota prefix: got %q, want %q", got, "backend unavailable")
+		t.Errorf("non-quota 1105 with quota prefix: got %q, want %q", got, "backend unavailable")
 	}
 }
 

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -932,7 +932,7 @@ func (s *Server) handleForkDelete(w http.ResponseWriter, r *http.Request) {
 			errJSON(w, http.StatusNotFound, "tenant not found")
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, "tenant lookup failed")
+		errJSON(w, backendErrorStatus(r.Context(), err), "tenant lookup failed")
 		return
 	}
 	if t.Kind != meta.TenantKindFork {
@@ -959,7 +959,7 @@ func (s *Server) handleForkDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	updated, err := s.meta.UpdateTenantStatusIf(r.Context(), t.ID, t.Status, meta.TenantDeleting)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to mark tenant deleting")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to mark tenant deleting")
 		return
 	}
 	if !updated {

--- a/pkg/server/fs_authorization.go
+++ b/pkg/server/fs_authorization.go
@@ -254,7 +254,7 @@ func authorizeUploadSession(ctx context.Context, w http.ResponseWriter, scope *T
 			errJSON(w, http.StatusGone, "upload expired")
 			return nil, err
 		}
-		errJSON(w, http.StatusInternalServerError, "upload session lookup failed")
+		errJSON(w, backendErrorStatus(ctx, err), "upload session lookup failed")
 		return nil, err
 	}
 	if authErr := scope.AuthorizeFS(op, upload.TargetPath); authErr != nil {

--- a/pkg/server/fs_layer.go
+++ b/pkg/server/fs_layer.go
@@ -454,7 +454,7 @@ func (s *Server) handleFSLayerObjectRead(w http.ResponseWriter, r *http.Request,
 	rc, err := b.OpenFSLayerEntryData(r.Context(), entry)
 	if err != nil {
 		logger.Error(r.Context(), "fs_layer_object_read_failed", eventFields(r.Context(), "fs_layer_object_read_failed", "path", entry.Path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	defer func() { _ = rc.Close() }()
@@ -520,7 +520,7 @@ func (s *Server) handleFSLayerObjectUpload(w http.ResponseWriter, r *http.Reques
 	entry, err := b.PutFSLayerObject(r.Context(), layer.LayerID, prepared.Path, body, size)
 	if err != nil {
 		logger.Error(r.Context(), "fs_layer_object_upload_failed", eventFields(r.Context(), "fs_layer_object_upload_failed", "path", prepared.Path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	entry.LayerID = layer.LayerID
@@ -731,7 +731,7 @@ func (s *Server) handleFSLayerCommit(w http.ResponseWriter, r *http.Request, b *
 	if err := validateFSLayerCommitSnapshots(snapshots); err != nil {
 		_ = store.SetFSLayerStateIf(r.Context(), layer.LayerID, []datastore.FSLayerState{datastore.FSLayerStateCommitting}, datastore.FSLayerStateConflicted)
 		logger.Error(r.Context(), "fs_layer_commit_validate_failed", eventFields(r.Context(), "fs_layer_commit_validate_failed", "layer_id", layer.LayerID, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	rollbackCtx, rollbackCancel := context.WithTimeout(context.WithoutCancel(r.Context()), fsLayerRollbackTimeout)
@@ -744,11 +744,11 @@ func (s *Server) handleFSLayerCommit(w http.ResponseWriter, r *http.Request, b *
 			_ = store.SetFSLayerStateIf(rollbackCtx, layer.LayerID, []datastore.FSLayerState{datastore.FSLayerStateCommitting}, datastore.FSLayerStateConflicted)
 			if rollbackErr != nil {
 				logger.Error(r.Context(), "fs_layer_commit_apply_failed", eventFields(r.Context(), "fs_layer_commit_apply_failed", "path", entries[i].Path, "error", err, "rollback_error", rollbackErr)...)
-				errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+				writeBackendError(w, r, err)
 				return
 			}
 			logger.Error(r.Context(), "fs_layer_commit_apply_failed", eventFields(r.Context(), "fs_layer_commit_apply_failed", "path", entries[i].Path, "error", err)...)
-			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+			writeBackendError(w, r, err)
 			return
 		}
 		markFSLayerEntryTouched(touchedPaths, &entries[i])
@@ -758,11 +758,11 @@ func (s *Server) handleFSLayerCommit(w http.ResponseWriter, r *http.Request, b *
 		_ = store.SetFSLayerStateIf(rollbackCtx, layer.LayerID, []datastore.FSLayerState{datastore.FSLayerStateCommitting}, datastore.FSLayerStateConflicted)
 		if rollbackErr != nil {
 			logger.Error(r.Context(), "fs_layer_commit_finalize_failed", eventFields(r.Context(), "fs_layer_commit_finalize_failed", "layer_id", layer.LayerID, "error", err, "rollback_error", rollbackErr)...)
-			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+			writeBackendError(w, r, err)
 			return
 		}
 		logger.Error(r.Context(), "fs_layer_commit_finalize_failed", eventFields(r.Context(), "fs_layer_commit_finalize_failed", "layer_id", layer.LayerID, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -1683,7 +1683,7 @@ func writeFSLayerStoreError(w http.ResponseWriter, r *http.Request, err error) {
 		return
 	}
 	logger.Error(r.Context(), "fs_layer_store_error", eventFields(r.Context(), "fs_layer_store_error", "error", err)...)
-	errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+	writeBackendError(w, r, err)
 }
 
 func toFSLayerResponse(layer *datastore.FSLayer) fsLayerResponse {

--- a/pkg/server/git_workspace.go
+++ b/pkg/server/git_workspace.go
@@ -834,7 +834,7 @@ func writeGitWorkspaceStoreError(w http.ResponseWriter, r *http.Request, err err
 		return
 	}
 	logger.Error(r.Context(), "git_workspace_store_error", eventFields(r.Context(), "git_workspace_store_error", "error", err)...)
-	errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+	writeBackendError(w, r, err)
 }
 
 func toGitWorkspaceResponse(ws *datastore.GitWorkspace) gitWorkspaceResponse {

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -207,7 +207,7 @@ func writeQuotaAPIKeyError(w http.ResponseWriter, ctx context.Context, err error
 		errJSON(w, http.StatusNotFound, "quota query not enabled")
 	default:
 		logger.Warn(ctx, "quota_api_key_auth_failed", zap.Error(err))
-		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
+		errJSON(w, backendErrorStatus(ctx, err), "auth backend unavailable")
 	}
 }
 
@@ -547,7 +547,7 @@ func (s *Server) quotaTenant(w http.ResponseWriter, ctx context.Context, tenantI
 			errJSON(w, http.StatusNotFound, "tenant not found")
 			return nil, false
 		}
-		errJSON(w, http.StatusInternalServerError, "tenant lookup failed")
+		errJSON(w, backendErrorStatus(ctx, err), "tenant lookup failed")
 		return nil, false
 	}
 	if t.Status == meta.TenantDeleted {
@@ -560,12 +560,12 @@ func (s *Server) quotaTenant(w http.ResponseWriter, ctx context.Context, tenantI
 func (s *Server) writeQuotaResponse(w http.ResponseWriter, r *http.Request, t *meta.Tenant) {
 	cfg, err := s.meta.GetQuotaConfig(r.Context(), t.ID)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "quota config lookup failed")
+		errJSON(w, backendErrorStatus(r.Context(), err), "quota config lookup failed")
 		return
 	}
 	usage, err := s.meta.GetQuotaUsage(r.Context(), t.ID)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "quota usage lookup failed")
+		errJSON(w, backendErrorStatus(r.Context(), err), "quota usage lookup failed")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1740,7 +1740,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		}
 		metricEvent(r.Context(), "auth", "result", "meta_backend_error")
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_meta_unavailable", "error", err)...)
-		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
+		errJSON(w, backendErrorStatus(r.Context(), err), "auth backend unavailable")
 		return
 	}
 	if subtle.ConstantTimeCompare([]byte(token.HashToken(tok)), []byte(resolved.APIKey.JWTHash)) != 1 {
@@ -1760,7 +1760,7 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		metricEvent(r.Context(), "auth", "result", "decrypt_failed")
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_decrypt_failed", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, "auth backend unavailable")
+		errJSON(w, backendErrorStatus(r.Context(), err), "auth backend unavailable")
 		return
 	}
 	if subtle.ConstantTimeCompare([]byte(tok), plain) != 1 {
@@ -1951,7 +1951,7 @@ func (s *Server) handleRead(w http.ResponseWriter, r *http.Request, path string)
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "read_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "fs_read", "result", "error")
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 
@@ -2012,7 +2012,7 @@ func (s *Server) handleList(w http.ResponseWriter, r *http.Request, path string)
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "list_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "userdb_query", "api", "list", "result", "error")
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	metricEvent(r.Context(), "userdb_query", "api", "list", "result", "ok")
@@ -2111,7 +2111,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "stat_metadata_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 
@@ -2125,7 +2125,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 	nlink, err := nodeLinkCount(r.Context(), b, nf)
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "stat_metadata_refcount_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	if nf.File != nil {
@@ -2145,7 +2145,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 		tags, err = b.Store().GetFileTags(r.Context(), nf.File.FileID)
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "stat_metadata_load_tags_failed", "path", path, "error", err)...)
-			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+			writeBackendError(w, r, err)
 			return
 		}
 	} else {
@@ -2297,7 +2297,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "write_upload_initiate_failed", "path", path, "error", err)...)
 			metricEvent(r.Context(), "fs_write", "result", "error")
-			errJSONInternalStorage(w)
+			errJSONInternalStorage(w, r, err)
 			return
 		}
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "write_upload_initiated", "path", path, "parts", len(plan.Parts))...)
@@ -2374,7 +2374,7 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "write_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "fs_write", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "write_ok", "path", path, "bytes", len(data))...)
@@ -2553,7 +2553,7 @@ func (s *Server) handlePatch(w http.ResponseWriter, r *http.Request, path string
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "patch_upload_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "fs_patch", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 
@@ -2651,7 +2651,7 @@ func (s *Server) handleAppend(w http.ResponseWriter, r *http.Request, path strin
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "append_upload_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "fs_append", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 
@@ -2932,12 +2932,12 @@ func (s *Server) handleBatchWrite(w http.ResponseWriter, r *http.Request) {
 	backendResults, err := b.BatchWriteCtx(r.Context(), backendItems)
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "batch_write_failed", "error", err)...)
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	if len(backendResults) != len(allowedIndexes) {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "batch_write_result_count_mismatch", "expected", len(allowedIndexes), "got", len(backendResults))...)
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 
@@ -3236,7 +3236,7 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path strin
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "delete_failed", "path", path, "recursive", recursive, "kind", kind, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "delete_ok", "path", path, "recursive", recursive, "kind", kind)...)
@@ -3276,7 +3276,7 @@ func (s *Server) handleCopy(w http.ResponseWriter, r *http.Request, dstPath stri
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "copy_failed", "src_path", srcPath, "dst_path", dstPath, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "copy_ok", "src_path", srcPath, "dst_path", dstPath)...)
@@ -3320,7 +3320,7 @@ func (s *Server) handleHardlink(w http.ResponseWriter, r *http.Request, dstPath 
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "hardlink_failed", "src_path", srcPath, "dst_path", dstPath, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "hardlink_ok", "src_path", srcPath, "dst_path", dstPath)...)
@@ -3364,7 +3364,7 @@ func (s *Server) handleRename(w http.ResponseWriter, r *http.Request, newPath st
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "rename_failed", "old_path", oldPath, "new_path", newPath, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "rename_ok", "old_path", oldPath, "new_path", newPath)...)
@@ -3398,7 +3398,7 @@ func (s *Server) handleMkdir(w http.ResponseWriter, r *http.Request, path string
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "mkdir_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "mkdir_ok", "path", path)...)
@@ -3440,7 +3440,7 @@ func (s *Server) handleChmod(w http.ResponseWriter, r *http.Request, path string
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "chmod_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "chmod_ok", "path", path)...)
@@ -3467,7 +3467,7 @@ func (s *Server) handleCreate(w http.ResponseWriter, r *http.Request, path strin
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "create_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "create_ok", "path", path)...)
@@ -3529,7 +3529,7 @@ func (s *Server) handleSymlink(w http.ResponseWriter, r *http.Request, path stri
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "symlink_failed", "path", path, "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "symlink_ok", "path", path)...)
@@ -3581,7 +3581,7 @@ func (s *Server) handleUploads(w http.ResponseWriter, r *http.Request) {
 		if errJSONInvalidRootDentry(w, err) {
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	metricEvent(r.Context(), "metadb_query", "api", "uploads_list", "result", "ok")
@@ -3714,7 +3714,7 @@ func (s *Server) handleUploadInitiate(w http.ResponseWriter, r *http.Request, b 
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_failed", "path", req.Path, "error", err)...)
 		metricEvent(r.Context(), "fs_write", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_initiate_ok", "path", req.Path, "parts", len(plan.Parts))...)
@@ -3788,7 +3788,7 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 			}
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_failed", "upload_id", uploadID, "error", err)...)
 			metricEvent(r.Context(), "upload_complete", "result", "error")
-			errJSONInternalStorage(w)
+			errJSONInternalStorage(w, r, err)
 			return
 		}
 	}
@@ -3829,7 +3829,7 @@ func (s *Server) handleUploadComplete(w http.ResponseWriter, r *http.Request, up
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "upload_complete", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_complete_ok", "upload_id", uploadID)...)
@@ -3886,7 +3886,7 @@ func (s *Server) handleUploadResume(w http.ResponseWriter, r *http.Request, uplo
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "upload_resume", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_resume_ok", "upload_id", uploadID, "parts", len(plan.Parts))...)
@@ -4058,7 +4058,7 @@ func (s *Server) handleUploadAbort(w http.ResponseWriter, r *http.Request, uploa
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "upload_abort_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "upload_abort", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "upload_abort_ok", "upload_id", uploadID)...)
@@ -4180,7 +4180,7 @@ func (s *Server) handleV2UploadInitiate(w http.ResponseWriter, r *http.Request) 
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_failed", "path", req.Path, "error", err)...)
 		metricEvent(r.Context(), "v2_upload_initiate", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_initiate_ok", "path", req.Path, "part_size", plan.PartSize, "total_parts", plan.TotalParts)...)
@@ -4241,7 +4241,7 @@ func (s *Server) handleV2PresignPart(w http.ResponseWriter, r *http.Request, upl
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_failed", "upload_id", uploadID, "part_number", req.PartNumber, "error", err)...)
 		metricEvent(r.Context(), "v2_presign_part", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_part_ok", "upload_id", uploadID, "part_number", req.PartNumber)...)
@@ -4297,7 +4297,7 @@ func (s *Server) handleV2PresignBatch(w http.ResponseWriter, r *http.Request, up
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "v2_presign_batch", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_presign_batch_ok", "upload_id", uploadID, "count", len(urls))...)
@@ -4353,7 +4353,7 @@ func (s *Server) handleV2UploadComplete(w http.ResponseWriter, r *http.Request, 
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "v2_upload_complete", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	if err := b.ConfirmUploadV2WithTags(r.Context(), uploadID, req.Parts, req.Tags); err != nil {
@@ -4394,7 +4394,7 @@ func (s *Server) handleV2UploadComplete(w http.ResponseWriter, r *http.Request, 
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "v2_upload_complete", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_complete_ok", "upload_id", uploadID)...)
@@ -4420,7 +4420,7 @@ func (s *Server) handleV2UploadAbort(w http.ResponseWriter, r *http.Request, upl
 	if err := b.AbortUploadV2(r.Context(), uploadID); err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_abort_failed", "upload_id", uploadID, "error", err)...)
 		metricEvent(r.Context(), "v2_upload_abort", "result", "error")
-		errJSONInternalStorage(w)
+		errJSONInternalStorage(w, r, err)
 		return
 	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "v2_upload_abort_ok", "upload_id", uploadID)...)
@@ -4548,7 +4548,7 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 			errJSON(w, pe.status, pe.message)
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, "failed to provision tenant")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to provision tenant")
 		return
 	}
 	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, res.OrganizationID, classifyTenantRequest(r))
@@ -5938,8 +5938,8 @@ func errJSONInvalidRootDentry(w http.ResponseWriter, err error) bool {
 
 const internalStorageErrorMessage = "storage backend unavailable; contact support"
 
-func errJSONInternalStorage(w http.ResponseWriter) {
-	errJSON(w, http.StatusInternalServerError, internalStorageErrorMessage)
+func errJSONInternalStorage(w http.ResponseWriter, r *http.Request, err error) {
+	errJSON(w, backendErrorStatus(r.Context(), err), internalStorageErrorMessage)
 }
 
 func (s *Server) handleSQL(w http.ResponseWriter, r *http.Request) {
@@ -6014,14 +6014,14 @@ func (s *Server) handleGrep(w http.ResponseWriter, r *http.Request, path string)
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "grep_failed", "path", path, "query_len", len(query), "limit", limit, "error", err)...)
 		metricEvent(r.Context(), "userdb_query", "api", "grep", "result", "error")
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	if layerRef := strings.TrimSpace(r.URL.Query().Get("layer")); layerRef != "" {
 		results, err = overlayFSLayerGrep(r.Context(), b, layerRef, query, path, limit, results)
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "grep_layer_failed", "path", path, "query_len", len(query), "limit", limit, "layer", layerRef, "error", err)...)
-			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+			writeBackendError(w, r, err)
 			return
 		}
 	}
@@ -6098,14 +6098,14 @@ func (s *Server) handleFind(w http.ResponseWriter, r *http.Request, path string)
 	if err != nil {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "find_failed", "path", path, "error", err)...)
 		metricEvent(r.Context(), "userdb_query", "api", "find", "result", "error")
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	if layerRef := strings.TrimSpace(q.Get("layer")); layerRef != "" {
 		results, err = overlayFSLayerFind(r.Context(), b, layerRef, f, results)
 		if err != nil {
 			logger.Error(r.Context(), "server_event", eventFields(r.Context(), "find_layer_failed", "path", path, "layer", layerRef, "error", err)...)
-			errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+			writeBackendError(w, r, err)
 			return
 		}
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2937,7 +2937,7 @@ func (s *Server) handleBatchWrite(w http.ResponseWriter, r *http.Request) {
 	}
 	if len(backendResults) != len(allowedIndexes) {
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "batch_write_result_count_mismatch", "expected", len(allowedIndexes), "got", len(backendResults))...)
-		errJSONInternalStorage(w, r, err)
+		errJSONInternalStorage(w, r, fmt.Errorf("batch write result count mismatch: expected %d, got %d", len(allowedIndexes), len(backendResults)))
 		return
 	}
 

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -458,13 +458,14 @@ func (s *Server) handleSlockCallback(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "slock_tenant_provision_failed", "error", err)...)
+		status := backendErrorStatus(r.Context(), err)
 		if wantsJSON(r) {
-			errJSON(w, backendErrorStatus(r.Context(), err), "slock tenant provision failed")
+			errJSON(w, status, "slock tenant provision failed")
 			return
 		}
 		setSlockCallbackNoStoreHeaders(w)
 		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		w.WriteHeader(http.StatusInternalServerError)
+		w.WriteHeader(status)
 		_, _ = fmt.Fprint(w, "<!doctype html><html><body style='font-family:sans-serif;padding:40px;text-align:center;background:#0a0908;color:#ede8e0'><h1>Provisioning Error</h1><p style='color:#c75050'>slock tenant provision failed</p></body></html>")
 		return
 	}

--- a/pkg/server/slock.go
+++ b/pkg/server/slock.go
@@ -459,7 +459,7 @@ func (s *Server) handleSlockCallback(w http.ResponseWriter, r *http.Request) {
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "slock_tenant_provision_failed", "error", err)...)
 		if wantsJSON(r) {
-			errJSON(w, http.StatusInternalServerError, "slock tenant provision failed")
+			errJSON(w, backendErrorStatus(r.Context(), err), "slock tenant provision failed")
 			return
 		}
 		setSlockCallbackNoStoreHeaders(w)

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -46,7 +46,7 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 			errJSON(w, http.StatusNotFound, "tenant not found")
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, "tenant lookup failed")
+		errJSON(w, backendErrorStatus(r.Context(), err), "tenant lookup failed")
 		return
 	}
 	if t.Kind != meta.TenantKindLive {
@@ -77,7 +77,7 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 	if t.StorageNamespaceID != "" {
 		hasFork, err := s.meta.NamespaceHasNonDeletedFork(r.Context(), t.StorageNamespaceID)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "failed to check tenant forks")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to check tenant forks")
 			return
 		}
 		if hasFork {
@@ -90,7 +90,7 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 	if t.Status == meta.TenantDeleting {
 		hasJob, err := s.meta.TenantDeleteJobExists(r.Context(), t.ID)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "failed to check tenant delete cleanup")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to check tenant delete cleanup")
 			return
 		}
 		if hasJob {
@@ -119,7 +119,7 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 	if t.Status != meta.TenantDeleting {
 		updated, err := s.meta.UpdateTenantStatusIf(r.Context(), t.ID, t.Status, meta.TenantDeleting)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "failed to mark tenant deleting")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to mark tenant deleting")
 			return
 		}
 		if !updated {
@@ -132,7 +132,7 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 		if t.Status != meta.TenantDeleting {
 			_, _ = s.meta.UpdateTenantStatusIf(r.Context(), t.ID, meta.TenantDeleting, t.Status)
 		}
-		errJSON(w, http.StatusInternalServerError, "failed to drain tenant backend")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to drain tenant backend")
 		return
 	}
 	if err := s.deprovisionTenantCluster(r.Context(), t, req); err != nil {
@@ -152,7 +152,7 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 		// cleanup is durably enqueued so the same owner can retry the delete
 		// request. This matters for tidb_cloud_native because customer TiDB Cloud
 		// credentials are accepted per request and are not stored server-side.
-		errJSON(w, http.StatusInternalServerError, "failed to enqueue tenant delete cleanup")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to enqueue tenant delete cleanup")
 		return
 	}
 	_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
@@ -184,7 +184,7 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 	if t.StorageNamespaceID != "" {
 		hasFork, err := s.meta.NamespaceHasNonDeletedFork(ctx, t.StorageNamespaceID)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "failed to check tenant forks")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to check tenant forks")
 			return
 		}
 		if hasFork {
@@ -195,7 +195,7 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 	if t.Status == meta.TenantDeleting {
 		hasJob, err := s.meta.TenantDeleteJobExists(ctx, t.ID)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "failed to check tenant delete cleanup")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to check tenant delete cleanup")
 			return
 		}
 		deleteJobExists = hasJob
@@ -203,7 +203,7 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 	if t.Status != meta.TenantDeleting {
 		updated, err := s.meta.UpdateTenantStatusIf(ctx, t.ID, t.Status, meta.TenantDeleting)
 		if err != nil {
-			errJSON(w, http.StatusInternalServerError, "failed to mark tenant deleting")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to mark tenant deleting")
 			return
 		}
 		if !updated {
@@ -213,7 +213,7 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 	}
 	if err := s.pool.InvalidateAndWait(ctx, t.ID); err != nil {
 		_, _ = s.meta.UpdateTenantStatusIf(ctx, t.ID, meta.TenantDeleting, t.Status)
-		errJSON(w, http.StatusInternalServerError, "failed to drain tenant backend")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to drain tenant backend")
 		return
 	}
 	fsID, err := s.meta.ResolveFsID(ctx, t.ID)
@@ -221,12 +221,12 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 		// A shared-schema tenant without an fs_registry row is a data
 		// integrity problem; never allocate one on a delete path.
 		logger.Error(ctx, "shared_tenant_delete_fsid_unresolvable", zap.String("tenant_id", t.ID), zap.Error(err))
-		errJSON(w, http.StatusInternalServerError, "failed to resolve tenant fs_id")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to resolve tenant fs_id")
 		return
 	}
 	placement, err := s.meta.GetTenantPlacement(ctx, fsID)
 	if err != nil && !errors.Is(err, meta.ErrNotFound) {
-		errJSON(w, http.StatusInternalServerError, "failed to resolve tenant placement")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to resolve tenant placement")
 		return
 	}
 	if deleteJobExists && placement != nil && placement.Status == meta.PlacementStatusDeleting {
@@ -240,7 +240,7 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 				// Do not roll back the deleting mark; the purge is resumable and the
 				// next delete request will continue it.
 				logger.Error(ctx, "shared_tenant_purge_failed", zap.String("tenant_id", t.ID), zap.Int64("db_id", placement.DbID), zap.Error(err))
-				errJSON(w, http.StatusInternalServerError, "failed to purge tenant data from shared db")
+				errJSON(w, backendErrorStatus(r.Context(), err), "failed to purge tenant data from shared db")
 				return
 			}
 
@@ -248,12 +248,12 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 			markDeleted := t.StorageNamespaceID == ""
 			if err := s.meta.FinalizeSharedTenantDeleteMetadata(ctx, t.ID, fsID, placement.DbID, s.sharedDBReopenRatio, markDeleted); err != nil {
 				logger.Error(ctx, "shared_tenant_metadata_finalize_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-				errJSON(w, http.StatusInternalServerError, "failed to finalize shared tenant deletion")
+				errJSON(w, backendErrorStatus(r.Context(), err), "failed to finalize shared tenant deletion")
 				return
 			}
 			if markDeleted {
 				_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
-				writeStatus(w, meta.TenantDeleted)
+				writeTenantDeleteStatus(w, meta.TenantDeleted)
 				return
 			}
 		}
@@ -263,12 +263,12 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 			var enqueueErr error
 			status, enqueueErr = s.enqueueTenantDeleteJob(ctx, t)
 			if enqueueErr != nil {
-				errJSON(w, http.StatusInternalServerError, "failed to enqueue tenant delete cleanup")
+				errJSON(w, backendErrorStatus(r.Context(), err), "failed to enqueue tenant delete cleanup")
 				return
 			}
 		}
 		_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
-		writeStatus(w, status)
+		writeTenantDeleteStatus(w, status)
 		return
 	}
 	logger.Error(ctx, "shared_tenant_delete_placement_missing", zap.String("tenant_id", t.ID), zap.Int64("fs_id", fsID))

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -263,7 +263,7 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 			var enqueueErr error
 			status, enqueueErr = s.enqueueTenantDeleteJob(ctx, t)
 			if enqueueErr != nil {
-				errJSON(w, backendErrorStatus(r.Context(), err), "failed to enqueue tenant delete cleanup")
+				errJSON(w, backendErrorStatus(r.Context(), enqueueErr), "failed to enqueue tenant delete cleanup")
 				return
 			}
 		}

--- a/pkg/server/tokens.go
+++ b/pkg/server/tokens.go
@@ -129,18 +129,18 @@ func (s *Server) handleScopedTokenIssue(w http.ResponseWriter, r *http.Request, 
 
 	tokenVersion, err := newScopedTokenVersion()
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to issue token")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to issue token")
 		return
 	}
 	expiresAt := time.Now().UTC().Add(time.Duration(req.TTLSeconds) * time.Second)
 	rawToken, err := token.IssueTokenWithExpiry(s.tokenSecret, scope.TenantID, tokenVersion, expiresAt)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to issue token")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to issue token")
 		return
 	}
 	cipherToken, err := s.pool.Encrypt(r.Context(), []byte(rawToken))
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to encrypt token")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to encrypt token")
 		return
 	}
 
@@ -163,7 +163,7 @@ func (s *Server) handleScopedTokenIssue(w http.ResponseWriter, r *http.Request, 
 			errJSON(w, http.StatusConflict, "token already exists")
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, "failed to persist token")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to persist token")
 		return
 	}
 
@@ -188,7 +188,7 @@ func (s *Server) handleScopedTokenIssue(w http.ResponseWriter, r *http.Request, 
 
 	rows, err := s.meta.ListAPIKeyFSScopes(r.Context(), scope.TenantID, apiKeyID)
 	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to load token scopes")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to load token scopes")
 		return
 	}
 	resp := scopedTokenResponse{
@@ -210,7 +210,7 @@ func (s *Server) handleScopedTokenRevoke(w http.ResponseWriter, r *http.Request,
 			errJSON(w, http.StatusNotFound, "token not found or already revoked")
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, "failed to revoke token")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to revoke token")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -234,7 +234,7 @@ func (s *Server) handleScopedTokenRevokeByAPIKey(w http.ResponseWriter, r *http.
 			errJSON(w, http.StatusNotFound, "token not found or already revoked")
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, "failed to revoke token")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to revoke token")
 		return
 	}
 	if resolved.APIKey.TenantID != scope.TenantID || resolved.APIKey.ScopeKind != meta.APIKeyScopeKindFS {
@@ -246,7 +246,7 @@ func (s *Server) handleScopedTokenRevokeByAPIKey(w http.ResponseWriter, r *http.
 			errJSON(w, http.StatusNotFound, "token not found or already revoked")
 			return
 		}
-		errJSON(w, http.StatusInternalServerError, "failed to revoke token")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to revoke token")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -93,7 +93,7 @@ func (s *Server) handleVaultSecrets(w http.ResponseWriter, r *http.Request, sub 
 			return
 		}
 		logger.Error(r.Context(), "vault_secrets_store_failed", eventFields(r.Context(), "vault_secrets_store_failed", "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	scope := ScopeFromContext(r.Context())
@@ -200,7 +200,7 @@ func (s *Server) handleVaultSecretCreate(w http.ResponseWriter, r *http.Request,
 				"tenant_id", tenantID,
 				"secret_name", req.Name,
 				"error", err.Error())...)
-		errJSON(w, http.StatusInternalServerError, "failed to create secret")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to create secret")
 		return
 	}
 
@@ -223,7 +223,7 @@ func (s *Server) handleVaultSecretList(w http.ResponseWriter, r *http.Request, v
 	secrets, err := vs.ListSecrets(r.Context(), tenantID)
 	if err != nil {
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to list secrets")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to list secrets")
 		return
 	}
 	if secrets == nil {
@@ -246,7 +246,7 @@ func (s *Server) handleVaultSecretGet(w http.ResponseWriter, r *http.Request, vs
 			return
 		}
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to get secret")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to get secret")
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
@@ -268,7 +268,7 @@ func (s *Server) handleVaultSecretReadValue(w http.ResponseWriter, r *http.Reque
 			return
 		}
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to read secret")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to read secret")
 		return
 	}
 
@@ -316,7 +316,7 @@ func (s *Server) handleVaultSecretReadField(w http.ResponseWriter, r *http.Reque
 			return
 		}
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to read field")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to read field")
 		return
 	}
 
@@ -375,7 +375,7 @@ func (s *Server) handleVaultSecretUpdate(w http.ResponseWriter, r *http.Request,
 				"tenant_id", tenantID,
 				"secret_name", name,
 				"error", err.Error())...)
-		errJSON(w, http.StatusInternalServerError, "failed to update secret")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to update secret")
 		return
 	}
 
@@ -402,7 +402,7 @@ func (s *Server) handleVaultSecretDelete(w http.ResponseWriter, r *http.Request,
 			return
 		}
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to delete secret")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to delete secret")
 		return
 	}
 
@@ -426,7 +426,7 @@ func (s *Server) handleVaultTokens(w http.ResponseWriter, r *http.Request, sub s
 			return
 		}
 		logger.Error(r.Context(), "vault_tokens_store_failed", eventFields(r.Context(), "vault_tokens_store_failed", "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	scope := ScopeFromContext(r.Context())
@@ -489,7 +489,7 @@ func (s *Server) handleVaultTokenIssue(w http.ResponseWriter, r *http.Request, v
 	tokenStr, capToken, err := vs.IssueCapToken(r.Context(), tenantID, req.AgentID, req.TaskID, req.Scope, ttl)
 	if err != nil {
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to issue token")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to issue token")
 		return
 	}
 
@@ -533,7 +533,7 @@ func (s *Server) handleVaultTokenRevoke(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to revoke token")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to revoke token")
 		return
 	}
 
@@ -568,7 +568,7 @@ func (s *Server) handleVaultGrants(w http.ResponseWriter, r *http.Request, sub s
 			return
 		}
 		logger.Error(r.Context(), "vault_grants_store_failed", eventFields(r.Context(), "vault_grants_store_failed", "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 	scope := ScopeFromContext(r.Context())
@@ -644,7 +644,7 @@ func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, v
 		// surface the same way but prefixed "insert grant:" — map to 500.
 		if strings.HasPrefix(err.Error(), "insert grant") {
 			result = "error"
-			errJSON(w, http.StatusInternalServerError, "failed to issue grant")
+			errJSON(w, backendErrorStatus(r.Context(), err), "failed to issue grant")
 			return
 		}
 		result = "invalid_argument"
@@ -702,7 +702,7 @@ func (s *Server) handleVaultGrantRevoke(w http.ResponseWriter, r *http.Request, 
 			return
 		}
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to revoke grant")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to revoke grant")
 		return
 	}
 
@@ -753,7 +753,7 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 		}
 		result = "error"
 		logger.Error(r.Context(), "vault_audit_store_failed", eventFields(r.Context(), "vault_audit_store_failed", "error", err)...)
-		errJSON(w, http.StatusInternalServerError, sanitizeClientError(err))
+		writeBackendError(w, r, err)
 		return
 	}
 
@@ -768,7 +768,7 @@ func (s *Server) handleVaultAudit(w http.ResponseWriter, r *http.Request) {
 	events, err := vs.QueryAuditLog(r.Context(), auditTenantID, secretName, limit)
 	if err != nil {
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to query audit log")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to query audit log")
 		return
 	}
 	if events == nil {
@@ -971,7 +971,7 @@ func (s *Server) handleVaultReadSecret(w http.ResponseWriter, r *http.Request, v
 			return
 		}
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to read secret")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to read secret")
 		return
 	}
 
@@ -1047,7 +1047,7 @@ func (s *Server) handleVaultReadField(w http.ResponseWriter, r *http.Request, vs
 			return
 		}
 		result = "error"
-		errJSON(w, http.StatusInternalServerError, "failed to read field")
+		errJSON(w, backendErrorStatus(r.Context(), err), "failed to read field")
 		return
 	}
 

--- a/pkg/server/vault.go
+++ b/pkg/server/vault.go
@@ -641,7 +641,8 @@ func (s *Server) handleVaultGrantIssue(w http.ResponseWriter, r *http.Request, v
 	if err != nil {
 		// IssueGrant returns user-visible validation errors (bad scope /
 		// enum / agent / issuer); map them to 400. Internal DB errors
-		// surface the same way but prefixed "insert grant:" — map to 500.
+		// surface the same way but prefixed "insert grant:" — map to
+		// backend error status.
 		if strings.HasPrefix(err.Error(), "insert grant") {
 			result = "error"
 			errJSON(w, backendErrorStatus(r.Context(), err), "failed to issue grant")


### PR DESCRIPTION
## Summary

Previously all backend errors returned HTTP 500, causing:
- Client disconnects (`context.Canceled`) to show as server errors
- Upstream timeouts (`context.DeadlineExceeded`) to mask as internal errors
- TiDB quota exhaustion (`Error 1105`) to trigger 500 retry storms
- Schema migration failures to pollute error monitoring

## Changes

- Add `backendErrorStatus()` to map error types to HTTP status codes:

| Error | Old Status | New Status |
|---|---|---|
| `context.Canceled` | 500 | **499** |
| `context.DeadlineExceeded` | 500 | **504** |
| TiDB quota 1105 | 500 | **402** |
| Schema migration errors | 500 | **502** |
| Unknown errors | 500 | 500 |

- Add `writeBackendError()` as a unified error response helper
- Extract `isQuotaError()` and `isSchemaMigrationError()` from `sanitizeClientError()`
- Fix 2 sites that leaked `err.Error()` to clients in `admin_tenant_pool.go`
- Update `errJSONInternalStorage` to accept request context for proper status
- Convert all 107 hardcoded-500 sites to use `backendErrorStatus()` or `writeBackendError()`

## Files Changed

13 files, +167 / -132 lines in `pkg/server/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backend-aware HTTP error handling across authentication, storage/filesystem, tenants, quota, tokens, Vault, uploads, and related flows.
  - Responses now use more accurate status codes derived from the underlying backend error (including payment required, gateway failure, client cancellation, and request timeout), while preserving existing behavior for validation, not-found, conflict, and authorization errors.
  - Standardized client-safe error bodies for backend and internal storage failures.
- **Tests**
  - Added coverage for backend error classification and status-code mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->