### PR TITLE
fix: stabilize shared DB pool identity and spending limits

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -200,10 +200,6 @@ func main() {
 	if err != nil {
 		die(err)
 	}
-	sharedDBDefaultSpendingLimit, err := sharedDBDefaultSpendingLimitFromEnv()
-	if err != nil {
-		die(err)
-	}
 	maxUploadBytes := server.DefaultMaxUploadBytes
 	if raw := os.Getenv("DRIVE9_MAX_UPLOAD_BYTES"); raw != "" {
 		maxUploadBytes, err = strconv.ParseInt(raw, 10, 64)
@@ -449,7 +445,6 @@ func main() {
 		SharedDBMaxTenants:              sharedDBMaxTenants,
 		SharedDBHardCapRatio:            sharedDBHardCapRatio,
 		SharedDBReopenRatio:             sharedDBReopenRatio,
-		SharedDBDefaultSpendingLimit:    sharedDBDefaultSpendingLimit,
 		LegacyStarterProvisioner:        legacyStarterProvisioner,
 		TokenSecret:                     tokenSecret,
 		VaultMasterKey:                  vaultMasterKey,
@@ -681,7 +676,6 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS soft capacity for new managed shared DB pools (default: 100)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO emergency hard-cap ratio > 1 after physical create failure (default: 1.2)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO reopen ratio for a latched shared pool (default: 0.8)
-  DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT default managed shared DB-pool spending target (default: 10000000)
   DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings (also accepts public_host:private_host);
                                              when set, disables legacy single-host private endpoint overrides
   DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST legacy tencentcloud private endpoint fallback host, used only when host map is unset
@@ -1218,18 +1212,6 @@ func sharedDBMaxTenantsFromEnv() (int, error) {
 	v, err := strconv.Atoi(raw)
 	if err != nil || v <= 0 {
 		return 0, fmt.Errorf("invalid DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS=%q: must be a positive integer", raw)
-	}
-	return v, nil
-}
-
-func sharedDBDefaultSpendingLimitFromEnv() (int64, error) {
-	raw := strings.TrimSpace(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT"))
-	if raw == "" {
-		return 10_000_000, nil
-	}
-	v, err := strconv.ParseInt(raw, 10, 64)
-	if err != nil || v <= 0 || v > int64(1<<31-1) {
-		return 0, fmt.Errorf("invalid DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT=%q: must be in (0,%d]", raw, int64(1<<31-1))
 	}
 	return v, nil
 }

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -208,10 +208,7 @@ func TestSharedDBReopenRatioFromEnv(t *testing.T) {
 }
 
 func TestSharedDBCapacityConfigFromEnv(t *testing.T) {
-	keys := []string{
-		"DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS",
-		"DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT",
-	}
+	keys := []string{"DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS"}
 	restore := snapshotEnv(t, keys)
 	t.Cleanup(func() { restoreEnv(t, restore) })
 
@@ -223,35 +220,15 @@ func TestSharedDBCapacityConfigFromEnv(t *testing.T) {
 	if maxTenants != 100 {
 		t.Fatalf("empty max tenants = %d, want 100", maxTenants)
 	}
-	spendingLimit, err := sharedDBDefaultSpendingLimitFromEnv()
-	if err != nil {
-		t.Fatalf("sharedDBDefaultSpendingLimitFromEnv empty: %v", err)
-	}
-	if spendingLimit != 10_000_000 {
-		t.Fatalf("empty spending limit = %d, want 10000000", spendingLimit)
-	}
-
 	setEnv(t, keys[0], "250")
 	maxTenants, err = sharedDBMaxTenantsFromEnv()
 	if err != nil || maxTenants != 250 {
 		t.Fatalf("valid max tenants = %d/%v, want 250/nil", maxTenants, err)
 	}
-	setEnv(t, keys[1], "20000000")
-	spendingLimit, err = sharedDBDefaultSpendingLimitFromEnv()
-	if err != nil || spendingLimit != 20_000_000 {
-		t.Fatalf("valid spending limit = %d/%v, want 20000000/nil", spendingLimit, err)
-	}
-
 	for _, raw := range []string{"0", "-1", "bad"} {
 		setEnv(t, keys[0], raw)
 		if _, err := sharedDBMaxTenantsFromEnv(); err == nil {
 			t.Fatalf("max tenants %q error = nil, want error", raw)
-		}
-	}
-	for _, raw := range []string{"0", "-1", "2147483648", "bad"} {
-		setEnv(t, keys[1], raw)
-		if _, err := sharedDBDefaultSpendingLimitFromEnv(); err == nil {
-			t.Fatalf("spending limit %q error = nil, want error", raw)
 		}
 	}
 }

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -16,6 +16,10 @@ import (
 // organization that has no exact db_pool row.
 const SharedDBOrgWildcard = "*"
 
+// MaxTiDBCloudSpendingLimit is the spendingLimit.monthly API maximum. In the
+// TiDB Cloud unit, 1,000,000 represents $10,000.
+const MaxTiDBCloudSpendingLimit = int64(1_000_000)
+
 // SharedDBRoleShared marks a db_pool row as a multi-tenant shared-schema
 // database. A "dedicated" role is reserved for future use and rejected for
 // now.
@@ -137,8 +141,8 @@ type TenantPlacement struct {
 
 // SharedDBPoolMetricSnapshot is the central-meta view used by the existing
 // tenant metrics pass. TenantCount is the capacity counter maintained with
-// placement writes; TenantStates and TenantSpendingLimitSum are recomputed
-// from placements so counter drift remains visible in exported metrics.
+// placement writes; TenantStates is recomputed from placements so counter
+// drift remains visible in exported metrics.
 type SharedDBPoolMetricSnapshot struct {
 	ID                      int64
 	UUID                    string
@@ -148,7 +152,6 @@ type SharedDBPoolMetricSnapshot struct {
 	TenantCount             int
 	SoftCapReached          bool
 	SpendingLimit           *int64
-	TenantSpendingLimitSum  int64
 	TenantStates            []SharedDBPoolTenantStateCount
 }
 
@@ -190,11 +193,8 @@ func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id
 	if in.MaxTenants <= 0 {
 		return 0, fmt.Errorf("managed max tenants must be positive")
 	}
-	if in.SpendingLimit == nil || *in.SpendingLimit <= 0 {
-		return 0, fmt.Errorf("managed spending limit must be positive")
-	}
-	if *in.SpendingLimit > int64(1<<31-1) {
-		return 0, fmt.Errorf("managed spending limit exceeds TiDB Cloud int32 maximum")
+	if in.SpendingLimit == nil || *in.SpendingLimit != MaxTiDBCloudSpendingLimit {
+		return 0, fmt.Errorf("managed spending limit must equal TiDB Cloud maximum %d", MaxTiDBCloudSpendingLimit)
 	}
 	var organizationID any
 	if in.TiDBCloudOrganizationID != "" {
@@ -463,14 +463,11 @@ func (s *Store) ListSharedDBsByStatus(ctx context.Context, status string, limit 
 // FindSharedDBForAllocation selects the oldest eligible exact-organization
 // pool, preferring active over provisioning. Before organization resolution,
 // callers may instead supply the 32-byte provisioning fingerprint. Managed
-// rows enforce exact virtual spending-limit headroom; manual rows with a NULL
-// spending target retain their compatibility behavior.
-func (s *Store) FindSharedDBForAllocation(ctx context.Context, organizationID string, provisioningKey []byte, tenantSpendingLimit int64) (db *SharedDB, err error) {
+// rows use one fixed physical spending limit, so tenant virtual values do not
+// participate in allocation.
+func (s *Store) FindSharedDBForAllocation(ctx context.Context, organizationID string, provisioningKey []byte) (db *SharedDB, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "find_shared_db_for_allocation", start, &err)
-	if tenantSpendingLimit < 0 {
-		return nil, fmt.Errorf("tenant spending limit must not be negative")
-	}
 	identityColumn := "org_id"
 	var identity any = organizationID
 	if organizationID == "" {
@@ -484,15 +481,9 @@ func (s *Store) FindSharedDBForAllocation(ctx context.Context, organizationID st
 		"WHERE d." + identityColumn + " = ? AND d.`role` = ? " +
 		"AND d.status IN (?, ?) " +
 		"AND (d.max_tenants = 0 OR (d.soft_cap_reached = 0 AND d.tenant_count < d.max_tenants)) " +
-		`AND (d.spending_limit IS NULL OR
-			COALESCE((SELECT SUM(q.tidbcloud_spending_limit)
-				FROM tenant_placements p
-				JOIN fs_registry f ON f.fs_id = p.fs_id
-				JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id
-				WHERE p.db_id = d.db_id), 0) + ? < d.spending_limit)
-		ORDER BY CASE d.status WHEN 'active' THEN 0 ELSE 1 END, d.db_id LIMIT 1`
+		"ORDER BY CASE d.status WHEN 'active' THEN 0 ELSE 1 END, d.db_id LIMIT 1"
 	db, err = scanSharedDBRow(s.db.QueryRowContext(ctx, query, identity, SharedDBRoleShared,
-		SharedDBStatusActive, SharedDBStatusProvisioning, tenantSpendingLimit))
+		SharedDBStatusActive, SharedDBStatusProvisioning))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -505,24 +496,19 @@ func (s *Store) FindSharedDBForAllocation(ctx context.Context, organizationID st
 // FindSharedDBForEmergency selects the least-loaded active managed pool below
 // its own runtime-derived hard cap. It is used only after a physical create
 // failure on a direct request; refill and prewarm must never call it.
-func (s *Store) FindSharedDBForEmergency(ctx context.Context, organizationID string, hardCapRatio float64, tenantSpendingLimit int64) (*SharedDB, error) {
+func (s *Store) FindSharedDBForEmergency(ctx context.Context, organizationID string, hardCapRatio float64) (*SharedDB, error) {
 	if organizationID == "" {
 		return nil, fmt.Errorf("organization id is required")
 	}
-	if hardCapRatio <= 1 || tenantSpendingLimit < 0 {
+	if hardCapRatio <= 1 {
 		return nil, fmt.Errorf("invalid emergency capacity arguments")
 	}
 	query := "SELECT " + sharedDBSelectColumns + " FROM db_pool d " +
 		"WHERE d.org_id = ? AND d.`role` = ? AND d.status = ? " +
-		"AND d.max_tenants > 0 AND d.tenant_count < CEIL(d.max_tenants * ?) AND d.spending_limit IS NOT NULL " +
-		`AND COALESCE((SELECT SUM(q.tidbcloud_spending_limit)
-			FROM tenant_placements p
-			JOIN fs_registry f ON f.fs_id = p.fs_id
-			JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id
-			WHERE p.db_id = d.db_id), 0) + ? < d.spending_limit
-		ORDER BY d.tenant_count ASC, d.db_id ASC LIMIT 1`
+		"AND d.max_tenants > 0 AND d.tenant_count < CEIL(d.max_tenants * ?) " +
+		"ORDER BY d.tenant_count ASC, d.db_id ASC LIMIT 1"
 	db, err := scanSharedDBRow(s.db.QueryRowContext(ctx, query, organizationID, SharedDBRoleShared,
-		SharedDBStatusActive, hardCapRatio, tenantSpendingLimit))
+		SharedDBStatusActive, hardCapRatio))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -706,16 +692,9 @@ func (s *Store) ListSharedDBPoolMetricSnapshots(ctx context.Context) (out []Shar
 	defer observeMeta(ctx, "list_shared_db_pool_metric_snapshots", start, &err)
 	rows, err := s.db.QueryContext(ctx, `SELECT
 			d.db_id, d.uuid, COALESCE(d.org_id, ''), d.status, d.max_tenants, d.tenant_count, d.soft_cap_reached,
-			d.spending_limit, COALESCE(quota.tenant_sum, 0),
+			d.spending_limit,
 			COALESCE(states.tenant_status, ''), COALESCE(states.tenant_count, 0)
 		FROM db_pool d
-		LEFT JOIN (
-			SELECT p.db_id, COALESCE(SUM(q.tidbcloud_spending_limit), 0) AS tenant_sum
-			FROM tenant_placements p
-			JOIN fs_registry f ON f.fs_id = p.fs_id
-			JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id
-			GROUP BY p.db_id
-		) quota ON quota.db_id = d.db_id
 		LEFT JOIN (
 			SELECT p.db_id, t.status AS tenant_status, COUNT(*) AS tenant_count
 			FROM tenant_placements p
@@ -736,9 +715,9 @@ func (s *Store) ListSharedDBPoolMetricSnapshots(ctx context.Context) (out []Shar
 		var maxTenants, tenantCount int
 		var softCapReached bool
 		var spendingLimit sql.NullInt64
-		var tenantSpendingLimitSum, stateCount int64
+		var stateCount int64
 		if err := rows.Scan(&id, &dbPoolUUID, &organizationID, &status, &maxTenants, &tenantCount, &softCapReached,
-			&spendingLimit, &tenantSpendingLimitSum, &tenantStatus, &stateCount); err != nil {
+			&spendingLimit, &tenantStatus, &stateCount); err != nil {
 			return nil, fmt.Errorf("scan shared db pool metric snapshot: %w", err)
 		}
 		index, ok := byID[id]
@@ -746,7 +725,6 @@ func (s *Store) ListSharedDBPoolMetricSnapshots(ctx context.Context) (out []Shar
 			snapshot := SharedDBPoolMetricSnapshot{
 				ID: id, UUID: dbPoolUUID, TiDBCloudOrganizationID: organizationID, Status: status,
 				MaxTenants: maxTenants, TenantCount: tenantCount, SoftCapReached: softCapReached,
-				TenantSpendingLimitSum: tenantSpendingLimitSum,
 			}
 			if spendingLimit.Valid {
 				value := spendingLimit.Int64
@@ -899,12 +877,8 @@ func (s *Store) DeleteTenantPlacement(ctx context.Context, fsID int64) (err erro
 // (max_tenants reached).
 var ErrSharedDBCapacityExhausted = errors.New("shared db capacity exhausted")
 
-// ErrSharedDBSpendingLimitExceeded is returned when a managed pool's fixed
-// spending target cannot accommodate a new or increased tenant virtual limit.
-var ErrSharedDBSpendingLimitExceeded = errors.New("shared db spending limit exceeded")
-
-// ErrSharedDBQuotaNotMaterialized is returned when a managed-pool reservation
-// is attempted before the tenant's effective quota row has been persisted.
+// ErrSharedDBQuotaNotMaterialized is returned when a shared tenant quota
+// mutation is attempted before the compatibility row has been persisted.
 var ErrSharedDBQuotaNotMaterialized = errors.New("shared tenant quota is not materialized")
 
 // CompleteSharedTenantProvision atomically performs every meta write that
@@ -999,10 +973,9 @@ func (s *Store) completeSharedTenantProvision(ctx context.Context, tenantID, pro
 		var clusterID sql.NullString
 		var maxTenants, tenantCount int
 		var softCapReached bool
-		var poolSpendingLimit sql.NullInt64
-		if err := tx.QueryRowContext(ctx, `SELECT status, cluster_id, max_tenants, tenant_count, soft_cap_reached, spending_limit
+		if err := tx.QueryRowContext(ctx, `SELECT status, cluster_id, max_tenants, tenant_count, soft_cap_reached
 			FROM db_pool WHERE db_id = ? FOR UPDATE`, p.DbID).
-			Scan(&dbPoolStatus, &clusterID, &maxTenants, &tenantCount, &softCapReached, &poolSpendingLimit); err != nil {
+			Scan(&dbPoolStatus, &clusterID, &maxTenants, &tenantCount, &softCapReached); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrNotFound
 			}
@@ -1017,43 +990,15 @@ func (s *Store) completeSharedTenantProvision(ctx context.Context, tenantID, pro
 				return fmt.Errorf("db pool %d soft capacity exhausted: count=%d max=%d latch=%t: %w", p.DbID, tenantCount, maxTenants, softCapReached, ErrSharedDBCapacityExhausted)
 			}
 		case SharedDBCapacityEmergency:
-			if dbPoolStatus != SharedDBStatusActive || maxTenants <= 0 || hardCap < maxTenants || tenantCount >= hardCap || !poolSpendingLimit.Valid {
+			if dbPoolStatus != SharedDBStatusActive || maxTenants <= 0 || hardCap < maxTenants || tenantCount >= hardCap {
 				return ErrSharedDBCapacityExhausted
-			}
-		}
-		if poolSpendingLimit.Valid {
-			var tenantSpendingLimit sql.NullInt64
-			if err := tx.QueryRowContext(ctx, `SELECT tidbcloud_spending_limit
-				FROM tenant_quota_config WHERE tenant_id = ? FOR UPDATE`, tenantID).
-				Scan(&tenantSpendingLimit); err != nil {
-				if errors.Is(err, sql.ErrNoRows) {
-					return ErrSharedDBQuotaNotMaterialized
-				}
-				return fmt.Errorf("load quota for tenant %s: %w", tenantID, err)
-			}
-			if !tenantSpendingLimit.Valid {
-				return ErrSharedDBQuotaNotMaterialized
-			}
-			var currentSum int64
-			if err := tx.QueryRowContext(ctx, `SELECT COALESCE(SUM(q.tidbcloud_spending_limit), 0)
-				FROM tenant_placements p
-				JOIN fs_registry f ON f.fs_id = p.fs_id
-				JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id
-				WHERE p.db_id = ?`, p.DbID).Scan(&currentSum); err != nil {
-				return fmt.Errorf("sum tenant spending limits for db pool %d: %w", p.DbID, err)
-			}
-			prospective := currentSum + tenantSpendingLimit.Int64
-			// Keep strict headroom: the physical pool spending limit must remain
-			// greater than, never merely equal to, the sum of tenant virtual limits.
-			if prospective < currentSum || prospective > int64(1<<31-1) || prospective >= poolSpendingLimit.Int64 {
-				return ErrSharedDBSpendingLimitExceeded
 			}
 		}
 		var res sql.Result
 		if capacityMode == SharedDBCapacityEmergency {
 			res, err = tx.ExecContext(ctx, `UPDATE db_pool
 				SET tenant_count = tenant_count + 1, soft_cap_reached = 1
-				WHERE db_id = ? AND status = ? AND spending_limit IS NOT NULL
+				WHERE db_id = ? AND status = ?
 					AND max_tenants > 0 AND tenant_count + 1 <= ?`,
 				p.DbID, SharedDBStatusActive, hardCap)
 		} else {

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -8,6 +8,8 @@ import (
 	"math"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 // SharedDBOrgWildcard is the org_id sentinel matching any TiDB Cloud
@@ -77,6 +79,17 @@ func SharedDBReopenThresholdForRatio(softCap int, ratio float64) (int, error) {
 	return int(math.Floor(float64(softCap) * ratio)), nil
 }
 
+func sharedDBUUID(raw string) (string, error) {
+	if strings.TrimSpace(raw) == "" {
+		return uuid.NewString(), nil
+	}
+	parsed, err := uuid.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return "", fmt.Errorf("invalid shared db pool uuid %q: %w", raw, err)
+	}
+	return parsed.String(), nil
+}
+
 // SharedDB is one physical database registered in db_pool. PasswordCipher
 // holds the same encrypted envelope as tenants.db_password; the plaintext
 // never crosses this layer. TLSMode is the go-sql-driver tls DSN parameter
@@ -85,6 +98,7 @@ func SharedDBReopenThresholdForRatio(softCap int, ratio float64) (int, error) {
 // mode it was registered with. MaxTenants of 0 means unlimited.
 type SharedDB struct {
 	ID                      int64
+	UUID                    string
 	TiDBCloudOrganizationID string
 	ClusterID               string
 	ProvisioningKey         []byte
@@ -127,6 +141,7 @@ type TenantPlacement struct {
 // from placements so counter drift remains visible in exported metrics.
 type SharedDBPoolMetricSnapshot struct {
 	ID                      int64
+	UUID                    string
 	TiDBCloudOrganizationID string
 	Status                  string
 	MaxTenants              int
@@ -146,7 +161,7 @@ type SharedDBPoolTenantStateCount struct {
 
 // sharedDBSelectColumns lists the db_pool columns read into SharedDB. The
 // `role` column is backtick-quoted because ROLE is reserved in MySQL 8.0.
-const sharedDBSelectColumns = "db_id, org_id, cluster_id, provisioning_key, cloud_provider, region, " +
+const sharedDBSelectColumns = "db_id, uuid, org_id, cluster_id, provisioning_key, cloud_provider, region, " +
 	"`role`, db_host, db_port, db_user, db_password, db_name, db_tls, max_tenants, tenant_count, " +
 	"soft_cap_reached, spending_limit, schema_version, status, created_at, updated_at"
 
@@ -158,6 +173,10 @@ func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id
 	defer observeMeta(ctx, "create_managed_shared_db_pool", start, &err)
 	if in == nil {
 		return 0, fmt.Errorf("shared db pool is required")
+	}
+	poolUUID, err := sharedDBUUID(in.UUID)
+	if err != nil {
+		return 0, err
 	}
 	if len(in.ProvisioningKey) != 32 {
 		return 0, fmt.Errorf("provisioning key must be a 32-byte SHA-256 fingerprint")
@@ -190,9 +209,9 @@ func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id
 		databaseName = in.Name
 	}
 	res, err := s.db.ExecContext(ctx, `INSERT INTO db_pool
-		(org_id, provisioning_key, cloud_provider, region, `+"`role`"+`, db_tls,
+		(uuid, org_id, provisioning_key, cloud_provider, region, `+"`role`"+`, db_tls,
 		 db_password, db_name, max_tenants, tenant_count, soft_cap_reached, spending_limit, schema_version, status)
-		VALUES (?, ?, ?, ?, ?, '', ?, ?, ?, 0, 0, ?, 0, ?)`, organizationID, in.ProvisioningKey,
+		VALUES (?, ?, ?, ?, ?, ?, '', ?, ?, ?, 0, 0, ?, 0, ?)`, poolUUID, organizationID, in.ProvisioningKey,
 		in.CloudProvider, in.Region, SharedDBRoleShared, passwordCipher, databaseName,
 		in.MaxTenants, *in.SpendingLimit,
 		SharedDBStatusProvisioning)
@@ -523,6 +542,10 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 	if in == nil {
 		return 0, fmt.Errorf("shared db is required")
 	}
+	poolUUID, err := sharedDBUUID(in.UUID)
+	if err != nil {
+		return 0, err
+	}
 	if in.Host == "" {
 		return 0, fmt.Errorf("db host is required")
 	}
@@ -556,12 +579,12 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 		status = sharedDBStatusActive
 	}
 	if _, err := s.db.ExecContext(ctx,
-		"INSERT INTO db_pool (org_id, `role`, db_host, db_port, db_user, db_password, db_name, "+
-			"db_tls, max_tenants, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "+
+		"INSERT INTO db_pool (uuid, org_id, `role`, db_host, db_port, db_user, db_password, db_name, "+
+			"db_tls, max_tenants, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "+
 			"ON DUPLICATE KEY UPDATE db_port = VALUES(db_port), db_user = VALUES(db_user), "+
 			"db_password = VALUES(db_password), db_tls = VALUES(db_tls), "+
 			"max_tenants = VALUES(max_tenants), status = VALUES(status)",
-		in.TiDBCloudOrganizationID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
+		poolUUID, in.TiDBCloudOrganizationID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
 		in.TLSMode, in.MaxTenants, status); err != nil {
 		return 0, fmt.Errorf("upsert db_pool row: %w", err)
 	}
@@ -682,7 +705,7 @@ func (s *Store) ListSharedDBPoolMetricSnapshots(ctx context.Context) (out []Shar
 	start := time.Now()
 	defer observeMeta(ctx, "list_shared_db_pool_metric_snapshots", start, &err)
 	rows, err := s.db.QueryContext(ctx, `SELECT
-			d.db_id, COALESCE(d.org_id, ''), d.status, d.max_tenants, d.tenant_count, d.soft_cap_reached,
+			d.db_id, d.uuid, COALESCE(d.org_id, ''), d.status, d.max_tenants, d.tenant_count, d.soft_cap_reached,
 			d.spending_limit, COALESCE(quota.tenant_sum, 0),
 			COALESCE(states.tenant_status, ''), COALESCE(states.tenant_count, 0)
 		FROM db_pool d
@@ -709,19 +732,19 @@ func (s *Store) ListSharedDBPoolMetricSnapshots(ctx context.Context) (out []Shar
 	byID := make(map[int64]int)
 	for rows.Next() {
 		var id int64
-		var organizationID, status, tenantStatus string
+		var dbPoolUUID, organizationID, status, tenantStatus string
 		var maxTenants, tenantCount int
 		var softCapReached bool
 		var spendingLimit sql.NullInt64
 		var tenantSpendingLimitSum, stateCount int64
-		if err := rows.Scan(&id, &organizationID, &status, &maxTenants, &tenantCount, &softCapReached,
+		if err := rows.Scan(&id, &dbPoolUUID, &organizationID, &status, &maxTenants, &tenantCount, &softCapReached,
 			&spendingLimit, &tenantSpendingLimitSum, &tenantStatus, &stateCount); err != nil {
 			return nil, fmt.Errorf("scan shared db pool metric snapshot: %w", err)
 		}
 		index, ok := byID[id]
 		if !ok {
 			snapshot := SharedDBPoolMetricSnapshot{
-				ID: id, TiDBCloudOrganizationID: organizationID, Status: status,
+				ID: id, UUID: dbPoolUUID, TiDBCloudOrganizationID: organizationID, Status: status,
 				MaxTenants: maxTenants, TenantCount: tenantCount, SoftCapReached: softCapReached,
 				TenantSpendingLimitSum: tenantSpendingLimitSum,
 			}
@@ -1282,7 +1305,7 @@ func scanSharedDBScanner(row sharedDBScanner) (*SharedDB, error) {
 	var organizationID, clusterID, cloudProvider, region sql.NullString
 	var host, user, name sql.NullString
 	var port, spendingLimit sql.NullInt64
-	if err := row.Scan(&rec.ID, &organizationID, &clusterID, &rec.ProvisioningKey, &cloudProvider, &region,
+	if err := row.Scan(&rec.ID, &rec.UUID, &organizationID, &clusterID, &rec.ProvisioningKey, &cloudProvider, &region,
 		&rec.Role, &host, &port, &user, &rec.PasswordCipher, &name, &rec.TLSMode,
 		&rec.MaxTenants, &rec.TenantCount, &rec.SoftCapReached, &spendingLimit, &rec.SchemaVersion, &rec.Status,
 		&rec.CreatedAt, &rec.UpdatedAt); err != nil {

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -505,6 +505,7 @@ func (s *Store) FindSharedDBForEmergency(ctx context.Context, organizationID str
 	}
 	query := "SELECT " + sharedDBSelectColumns + " FROM db_pool d " +
 		"WHERE d.org_id = ? AND d.`role` = ? AND d.status = ? " +
+		"AND d.spending_limit IS NOT NULL " +
 		"AND d.max_tenants > 0 AND d.tenant_count < CEIL(d.max_tenants * ?) " +
 		"ORDER BY d.tenant_count ASC, d.db_id ASC LIMIT 1"
 	db, err := scanSharedDBRow(s.db.QueryRowContext(ctx, query, organizationID, SharedDBRoleShared,

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -7,6 +7,8 @@ import (
 	"math"
 	"testing"
 	"time"
+
+	"github.com/google/uuid"
 )
 
 func TestSharedDBCapacityBounds(t *testing.T) {
@@ -100,6 +102,9 @@ func TestRegisterSharedDBRoundTrip(t *testing.T) {
 	if got.ID != id {
 		t.Fatalf("ID = %d, want %d", got.ID, id)
 	}
+	if _, err := uuid.Parse(got.UUID); err != nil {
+		t.Fatalf("UUID = %q: %v", got.UUID, err)
+	}
 	if got.TiDBCloudOrganizationID != "org-a" {
 		t.Fatalf("TiDBCloudOrganizationID = %q, want org-a", got.TiDBCloudOrganizationID)
 	}
@@ -171,6 +176,9 @@ func TestCreateManagedSharedDBPoolPersistsDurableProvisioningPlan(t *testing.T) 
 	}
 	if got.ID != id || got.TiDBCloudOrganizationID != "org-managed" || got.CloudProvider != "aws" || got.Region != "us-east-1" {
 		t.Fatalf("managed db pool identity = %+v", got)
+	}
+	if _, err := uuid.Parse(got.UUID); err != nil {
+		t.Fatalf("managed db pool UUID = %q: %v", got.UUID, err)
 	}
 	if got.Status != SharedDBStatusProvisioning || got.MaxTenants != 100 || got.SpendingLimit == nil || *got.SpendingLimit != spendingLimit {
 		t.Fatalf("managed db pool policy = %+v", got)
@@ -247,6 +255,10 @@ func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 	ctx := context.Background()
 
 	first := registerTestSharedDB(t, s, "org-a", "shared-a.example.com", "shared_db_a")
+	firstRecord, err := s.GetSharedDB(ctx, first)
+	if err != nil {
+		t.Fatalf("GetSharedDB before upsert: %v", err)
+	}
 	if err := s.IncrSharedDBTenantCount(ctx, first, 3); err != nil {
 		t.Fatalf("IncrSharedDBTenantCount: %v", err)
 	}
@@ -278,6 +290,9 @@ func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 	}
 	if got.TenantCount != 3 {
 		t.Fatalf("TenantCount = %d, want preserved 3", got.TenantCount)
+	}
+	if got.UUID != firstRecord.UUID {
+		t.Fatalf("UUID = %q after upsert, want preserved %q", got.UUID, firstRecord.UUID)
 	}
 }
 

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -708,6 +708,39 @@ func TestCompleteSharedTenantProvisionSoftHardCapacityAndHysteresis(t *testing.T
 	}
 }
 
+func TestFindSharedDBForEmergencyExcludesManuallyRegisteredPools(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	if _, err := s.RegisterSharedDB(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-emergency", Host: "manual.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "manual_db", MaxTenants: 100,
+	}); err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	managedID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-emergency", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?, cluster_id = 'cluster-emergency',
+		db_host = 'managed.example.com', db_port = 4000, db_user = 'root', db_password = 'cipher',
+		db_name = 'managed_db' WHERE db_id = ?`, SharedDBStatusActive, managedID); err != nil {
+		t.Fatalf("activate managed pool: %v", err)
+	}
+
+	got, err := s.FindSharedDBForEmergency(ctx, "org-emergency", 1.2)
+	if err != nil {
+		t.Fatalf("FindSharedDBForEmergency: %v", err)
+	}
+	if got.ID != managedID {
+		t.Fatalf("emergency pool = %d, want managed pool %d", got.ID, managedID)
+	}
+}
+
 func TestCompleteSharedTenantProvisionDoesNotUpdateOtherProvisioningPools(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -147,7 +147,7 @@ func TestRegisterSharedDBRoundTrip(t *testing.T) {
 func TestCreateManagedSharedDBPoolPersistsDurableProvisioningPlan(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
-	spendingLimit := int64(10_000_000)
+	spendingLimit := MaxTiDBCloudSpendingLimit
 	provisioningKey := make([]byte, 32)
 	for i := range provisioningKey {
 		provisioningKey[i] = byte(i + 1)
@@ -195,7 +195,7 @@ func TestCreateManagedSharedDBPoolRejectsUnboundedOrInvalidPolicy(t *testing.T) 
 	s := newControlStore(t)
 	ctx := context.Background()
 	valid := func() *SharedDB {
-		spendingLimit := int64(10_000_000)
+		spendingLimit := MaxTiDBCloudSpendingLimit
 		return &SharedDB{
 			TiDBCloudOrganizationID: "org-managed", ProvisioningKey: make([]byte, 32),
 			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
@@ -207,8 +207,8 @@ func TestCreateManagedSharedDBPoolRejectsUnboundedOrInvalidPolicy(t *testing.T) 
 		"missing cloud":       func(in *SharedDB) { in.CloudProvider = "" },
 		"missing region":      func(in *SharedDB) { in.Region = "" },
 		"missing spending":    func(in *SharedDB) { in.SpendingLimit = nil },
-		"int32 overflow": func(in *SharedDB) {
-			value := int64(1 << 31)
+		"physical limit below fixed maximum": func(in *SharedDB) {
+			value := MaxTiDBCloudSpendingLimit - 1
 			in.SpendingLimit = &value
 		},
 	}
@@ -226,7 +226,7 @@ func TestCreateManagedSharedDBPoolRejectsUnboundedOrInvalidPolicy(t *testing.T) 
 func TestMarkSharedDBPoolFailedRejectsPoolWithTenants(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
-	spendingLimit := int64(10_000)
+	spendingLimit := MaxTiDBCloudSpendingLimit
 	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-failed-with-tenants", ProvisioningKey: bytes.Repeat([]byte{7}, 32),
 		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 10, SpendingLimit: &spendingLimit,
@@ -643,7 +643,7 @@ func completeTestSharedTenant(t *testing.T, s *Store, dbID int64, tenantID strin
 func TestCompleteSharedTenantProvisionSoftHardCapacityAndHysteresis(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
-	spendingLimit := int64(10_000)
+	spendingLimit := MaxTiDBCloudSpendingLimit
 	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-hysteresis", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
 		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 2, SpendingLimit: &spendingLimit,
@@ -711,7 +711,7 @@ func TestCompleteSharedTenantProvisionSoftHardCapacityAndHysteresis(t *testing.T
 func TestCompleteSharedTenantProvisionDoesNotUpdateOtherProvisioningPools(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
-	spendingLimit := int64(100_000)
+	spendingLimit := MaxTiDBCloudSpendingLimit
 	targetID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-target", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
 		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 10, SpendingLimit: &spendingLimit,
@@ -808,7 +808,7 @@ func TestCompleteSharedTenantProvisionCommitsAtomically(t *testing.T) {
 func TestCompleteSharedTenantProvisionKeepsTenantProvisioningUntilDBPoolIsActive(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
-	spendingLimit := int64(10_000_000)
+	spendingLimit := MaxTiDBCloudSpendingLimit
 	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-provisioning", ProvisioningKey: make([]byte, 32),
 		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
@@ -852,7 +852,7 @@ func TestCompleteSharedTenantProvisionKeepsTenantProvisioningUntilDBPoolIsActive
 func TestManagedSharedDBPoolCloudResultSchemaAndActivation(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
-	spendingLimit := int64(10_000_000)
+	spendingLimit := MaxTiDBCloudSpendingLimit
 	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
 		ProvisioningKey: make([]byte, 32), CloudProvider: "aws", Region: "us-east-1",
 		MaxTenants: 100, SpendingLimit: &spendingLimit,
@@ -910,7 +910,7 @@ func TestManagedSharedDBPoolCloudResultSchemaAndActivation(t *testing.T) {
 func TestActivateSharedTenantsBatchRequiresReadyPoolPlacementAndOwnerKey(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
-	spendingLimit := int64(10_000_000)
+	spendingLimit := MaxTiDBCloudSpendingLimit
 	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-activation", ProvisioningKey: make([]byte, 32),
 		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
@@ -959,10 +959,10 @@ func TestActivateSharedTenantsBatchRequiresReadyPoolPlacementAndOwnerKey(t *test
 	}
 }
 
-func TestFindSharedDBForAllocationPrefersActiveAndChecksManagedHeadroom(t *testing.T) {
+func TestFindSharedDBForAllocationPrefersActiveWithoutVirtualSpendingHeadroom(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
-	spendingLimit := int64(2_001)
+	spendingLimit := MaxTiDBCloudSpendingLimit
 	provisioningID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-allocate", ProvisioningKey: make([]byte, 32),
 		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
@@ -985,7 +985,7 @@ func TestFindSharedDBForAllocationPrefersActiveAndChecksManagedHeadroom(t *testi
 		t.Fatalf("activate second pool: %v", err)
 	}
 
-	got, err := s.FindSharedDBForAllocation(ctx, "org-allocate", nil, 1000)
+	got, err := s.FindSharedDBForAllocation(ctx, "org-allocate", nil)
 	if err != nil {
 		t.Fatalf("FindSharedDBForAllocation active: %v", err)
 	}
@@ -994,7 +994,7 @@ func TestFindSharedDBForAllocationPrefersActiveAndChecksManagedHeadroom(t *testi
 	}
 
 	seedPendingTenant(t, s, "tenant-headroom")
-	limit := int64(1500)
+	limit := MaxTiDBCloudSpendingLimit
 	if err := s.SetQuotaConfigPatch(ctx, "tenant-headroom", QuotaConfigPatch{TiDBCloudSpendingLimit: &limit}); err != nil {
 		t.Fatalf("SetQuotaConfigPatch: %v", err)
 	}
@@ -1004,19 +1004,19 @@ func TestFindSharedDBForAllocationPrefersActiveAndChecksManagedHeadroom(t *testi
 	}, testOwnerKey("tenant-headroom")); err != nil {
 		t.Fatalf("CompleteSharedTenantProvision: %v", err)
 	}
-	got, err = s.FindSharedDBForAllocation(ctx, "org-allocate", nil, 1000)
+	got, err = s.FindSharedDBForAllocation(ctx, "org-allocate", nil)
 	if err != nil {
 		t.Fatalf("FindSharedDBForAllocation fallback: %v", err)
 	}
-	if got.ID != provisioningID {
-		t.Fatalf("allocation with exhausted active headroom chose %d, want provisioning %d", got.ID, provisioningID)
+	if got.ID != activeID {
+		t.Fatalf("allocation after maximum virtual value chose %d, want active pool %d", got.ID, activeID)
 	}
 }
 
-func TestUpdateSharedTenantQuotaConfigChecksManagedHeadroomAtomically(t *testing.T) {
+func TestUpdateSharedTenantQuotaConfigTreatsSpendingLimitAsVirtualValue(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
-	spendingTarget := int64(3_001)
+	spendingTarget := MaxTiDBCloudSpendingLimit
 	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-quota", ProvisioningKey: make([]byte, 32),
 		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
@@ -1059,20 +1059,20 @@ func TestUpdateSharedTenantQuotaConfigChecksManagedHeadroomAtomically(t *testing
 		t.Fatalf("updated quota = %+v", cfg)
 	}
 
-	noHeadroom := int64(2001)
-	storageOnFailure := int64(300)
+	maximumVirtualValue := MaxTiDBCloudSpendingLimit
+	updatedStorage := int64(300)
 	err = s.UpdateSharedTenantQuotaConfig(ctx, "tenant-shared-quota-1", QuotaConfigPatch{
-		MaxStorageBytes: &storageOnFailure, TiDBCloudSpendingLimit: &noHeadroom,
+		MaxStorageBytes: &updatedStorage, TiDBCloudSpendingLimit: &maximumVirtualValue,
 	})
-	if !errors.Is(err, ErrSharedDBSpendingLimitExceeded) {
-		t.Fatalf("headroom error = %v, want ErrSharedDBSpendingLimitExceeded", err)
+	if err != nil {
+		t.Fatalf("UpdateSharedTenantQuotaConfig maximum virtual value: %v", err)
 	}
 	cfg, err = s.GetQuotaConfig(ctx, "tenant-shared-quota-1")
 	if err != nil {
-		t.Fatalf("GetQuotaConfig after rejected update: %v", err)
+		t.Fatalf("GetQuotaConfig after maximum virtual value: %v", err)
 	}
-	if cfg.MaxStorageBytes != storage || cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != withinHeadroom {
-		t.Fatalf("rejected update changed quota: %+v", cfg)
+	if cfg.MaxStorageBytes != updatedStorage || cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != maximumVirtualValue {
+		t.Fatalf("maximum virtual value update = %+v", cfg)
 	}
 }
 

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -383,6 +383,9 @@ func (s *Store) migrate() (err error) {
 	if err := dropObsoleteMetaIndexes(ctx, s.db); err != nil {
 		return err
 	}
+	if err := ensureDBPoolUUID(ctx, s.db); err != nil {
+		return err
+	}
 	diffs, err := diffMetaSchema(ctx, s.db, spec)
 	if err != nil {
 		return fmt.Errorf("diff meta schema: %w", err)
@@ -478,6 +481,99 @@ func expandManagedDBPoolSchema(ctx context.Context, db *sql.DB) error {
 		}
 		if _, err := db.ExecContext(ctx, `CREATE UNIQUE INDEX uk_db_pool_cloud_resource ON db_pool(org_id, cluster_id)`); err != nil && !isIgnorableMetaSchemaError(err) {
 			return fmt.Errorf("create db_pool cloud resource unique index: %w", err)
+		}
+	}
+	return nil
+}
+
+func ensureDBPoolUUID(ctx context.Context, db *sql.DB) error {
+	var tableExists int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM information_schema.tables
+		WHERE table_schema = DATABASE() AND table_name = 'db_pool'`).Scan(&tableExists); err != nil {
+		return fmt.Errorf("inspect db_pool table for uuid migration: %w", err)
+	}
+	if tableExists == 0 {
+		return nil
+	}
+
+	var columnExists int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM information_schema.columns
+		WHERE table_schema = DATABASE() AND table_name = 'db_pool' AND column_name = 'uuid'`).Scan(&columnExists); err != nil {
+		return fmt.Errorf("inspect db_pool.uuid: %w", err)
+	}
+	if columnExists == 0 {
+		if _, err := db.ExecContext(ctx, `ALTER TABLE db_pool ADD COLUMN uuid CHAR(36) NULL AFTER db_id`); err != nil {
+			return fmt.Errorf("add db_pool.uuid: %w", err)
+		}
+	}
+
+	type dbPoolUUIDRow struct {
+		id   int64
+		uuid sql.NullString
+	}
+	rows, err := db.QueryContext(ctx, `SELECT db_id, uuid FROM db_pool ORDER BY db_id`)
+	if err != nil {
+		return fmt.Errorf("list db_pool rows for uuid migration: %w", err)
+	}
+	var existing []dbPoolUUIDRow
+	for rows.Next() {
+		var row dbPoolUUIDRow
+		if err := rows.Scan(&row.id, &row.uuid); err != nil {
+			_ = rows.Close()
+			return fmt.Errorf("scan db_pool uuid migration row: %w", err)
+		}
+		existing = append(existing, row)
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return fmt.Errorf("iterate db_pool uuid migration rows: %w", err)
+	}
+	if err := rows.Close(); err != nil {
+		return fmt.Errorf("close db_pool uuid migration rows: %w", err)
+	}
+	for _, row := range existing {
+		raw := strings.TrimSpace(row.uuid.String)
+		if raw != "" {
+			value, valueErr := sharedDBUUID(raw)
+			if valueErr != nil {
+				return fmt.Errorf("db_pool %d uuid migration: %w", row.id, valueErr)
+			}
+			if value != raw {
+				if _, err := db.ExecContext(ctx, `UPDATE db_pool SET uuid = ? WHERE db_id = ?`, value, row.id); err != nil {
+					return fmt.Errorf("canonicalize db_pool %d uuid: %w", row.id, err)
+				}
+			}
+			continue
+		}
+		value, valueErr := sharedDBUUID("")
+		if valueErr != nil {
+			return fmt.Errorf("db_pool %d uuid migration: %w", row.id, valueErr)
+		}
+		if _, err := db.ExecContext(ctx, `UPDATE db_pool SET uuid = ?
+			WHERE db_id = ? AND (uuid IS NULL OR uuid = '')`, value, row.id); err != nil {
+			return fmt.Errorf("backfill db_pool %d uuid: %w", row.id, err)
+		}
+	}
+	var isNullable string
+	if err := db.QueryRowContext(ctx, `SELECT is_nullable
+		FROM information_schema.columns
+		WHERE table_schema = DATABASE() AND table_name = 'db_pool' AND column_name = 'uuid'`).Scan(&isNullable); err != nil {
+		return fmt.Errorf("inspect db_pool.uuid nullability: %w", err)
+	}
+	if isNullable != "NO" {
+		if _, err := db.ExecContext(ctx, `ALTER TABLE db_pool MODIFY COLUMN uuid CHAR(36) NOT NULL`); err != nil {
+			return fmt.Errorf("make db_pool.uuid non-null: %w", err)
+		}
+	}
+	exists, err := metaIndexExists(ctx, db, "db_pool", "uk_db_pool_uuid")
+	if err != nil {
+		return fmt.Errorf("check db_pool uuid unique index: %w", err)
+	}
+	if !exists {
+		if _, err := db.ExecContext(ctx, `CREATE UNIQUE INDEX uk_db_pool_uuid ON db_pool(uuid)`); err != nil && !isIgnorableMetaSchemaError(err) {
+			return fmt.Errorf("create db_pool uuid unique index: %w", err)
 		}
 	}
 	return nil
@@ -639,6 +735,7 @@ func metaInitSchemaStatements() []string {
 		// word in MySQL 8.0.
 		`CREATE TABLE IF NOT EXISTS db_pool (
 			db_id        BIGINT AUTO_INCREMENT PRIMARY KEY,
+			uuid         CHAR(36) NOT NULL,
 			org_id       VARCHAR(64) NULL,
 			cluster_id   VARCHAR(255) NULL,
 			provisioning_key VARBINARY(32) NULL,
@@ -659,6 +756,7 @@ func metaInitSchemaStatements() []string {
 			status       VARCHAR(20) NOT NULL DEFAULT 'active',
 			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+			UNIQUE INDEX uk_db_pool_uuid (uuid),
 			UNIQUE INDEX uk_db_pool_cloud_resource (org_id, cluster_id),
 			UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host, db_name),
 			INDEX idx_db_pool_allocate (org_id, status, db_id),

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -460,6 +460,15 @@ func expandManagedDBPoolSchema(ctx context.Context, db *sql.DB) error {
 		WHERE max_tenants > 0 AND tenant_count >= max_tenants AND soft_cap_reached = 0`); err != nil {
 		return fmt.Errorf("backfill db_pool.soft_cap_reached: %w", err)
 	}
+	// A non-NULL spending limit identifies a Drive9-managed shared pool. Older
+	// builds persisted a configurable target that could exceed the TiDB Cloud
+	// API maximum; normalize it before provisioning/recovery resumes. The
+	// predicate makes this safe to rerun on every server startup.
+	if _, err := db.ExecContext(ctx, `UPDATE db_pool SET spending_limit = ?
+		WHERE spending_limit IS NOT NULL AND spending_limit <> ?`,
+		MaxTiDBCloudSpendingLimit, MaxTiDBCloudSpendingLimit); err != nil {
+		return fmt.Errorf("normalize managed db_pool spending limit: %w", err)
+	}
 
 	exists, err := metaIndexExists(ctx, db, "db_pool", "uk_db_pool_cloud_resource")
 	if err != nil {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1512,6 +1512,37 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 	}
 }
 
+func TestMigrateNormalizesManagedSharedDBSpendingLimitToCloudMaximum(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	limit := MaxTiDBCloudSpendingLimit
+	id, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-spending-migration", ProvisioningKey: make([]byte, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &limit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET spending_limit = 10000000 WHERE db_id = ?`, id); err != nil {
+		t.Fatalf("seed legacy spending limit: %v", err)
+	}
+
+	if err := s.migrate(); err != nil {
+		t.Fatalf("migrate legacy spending limit: %v", err)
+	}
+	got, err := s.GetSharedDB(ctx, id)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.SpendingLimit == nil || *got.SpendingLimit != MaxTiDBCloudSpendingLimit {
+		t.Fatalf("spending limit = %v, want %d", got.SpendingLimit, MaxTiDBCloudSpendingLimit)
+	}
+
+	if err := s.migrate(); err != nil {
+		t.Fatalf("repeat spending-limit migration: %v", err)
+	}
+}
+
 func TestUpsertTenantTiDBCloudOrgBindingRejectsDuplicateLiveClusterBranch(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/mem9-ai/drive9/internal/testmysql"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 )
@@ -1360,7 +1362,7 @@ func TestMetaSchemaSpecIncludesTiDBCloudOrgBindings(t *testing.T) {
 func TestMetaSchemaSpecIncludesManagedSharedDBControlPlane(t *testing.T) {
 	dbPool := mustMetaTableSpec(t, mustMetaSpec(t), "db_pool")
 	for _, column := range []string{
-		"db_id", "org_id", "cluster_id", "provisioning_key", "cloud_provider", "region",
+		"db_id", "uuid", "org_id", "cluster_id", "provisioning_key", "cloud_provider", "region",
 		"role", "db_host", "db_port", "db_user", "db_password", "db_name", "db_tls",
 		"max_tenants", "tenant_count", "soft_cap_reached", "spending_limit", "schema_version", "status",
 		"created_at", "updated_at",
@@ -1370,7 +1372,7 @@ func TestMetaSchemaSpecIncludesManagedSharedDBControlPlane(t *testing.T) {
 		}
 	}
 	for _, index := range []string{
-		"primary", "uk_db_pool_cloud_resource", "uk_db_pool_endpoint",
+		"primary", "uk_db_pool_uuid", "uk_db_pool_cloud_resource", "uk_db_pool_endpoint",
 		"idx_db_pool_allocate", "idx_db_pool_provisioning_key",
 	} {
 		if _, ok := dbPool.indexes[index]; !ok {
@@ -1452,7 +1454,7 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 			t.Fatalf("db_pool.%s is_nullable = %q, want YES", column, nullable)
 		}
 	}
-	for _, index := range []string{"uk_db_pool_cloud_resource", "idx_db_pool_allocate", "idx_db_pool_provisioning_key"} {
+	for _, index := range []string{"uk_db_pool_uuid", "uk_db_pool_cloud_resource", "idx_db_pool_allocate", "idx_db_pool_provisioning_key"} {
 		exists, err := metaIndexExists(ctx, s.DB(), "db_pool", index)
 		if err != nil {
 			t.Fatalf("check %s: %v", index, err)
@@ -1461,17 +1463,52 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 			t.Fatalf("db_pool index %s was not created", index)
 		}
 	}
-	var status string
+	var dbPoolUUID, status string
 	var softCapReached bool
 	var spendingLimit *int64
-	if err := s.DB().QueryRowContext(ctx, `SELECT status, spending_limit, soft_cap_reached FROM db_pool WHERE org_id = 'org-legacy'`).Scan(&status, &spendingLimit, &softCapReached); err != nil {
+	if err := s.DB().QueryRowContext(ctx, `SELECT uuid, status, spending_limit, soft_cap_reached FROM db_pool WHERE org_id = 'org-legacy'`).Scan(&dbPoolUUID, &status, &spendingLimit, &softCapReached); err != nil {
 		t.Fatalf("load migrated legacy row: %v", err)
+	}
+	if _, err := uuid.Parse(dbPoolUUID); err != nil {
+		t.Fatalf("migrated db_pool uuid = %q: %v", dbPoolUUID, err)
+	}
+	var uuidNullable string
+	if err := s.DB().QueryRowContext(ctx, `SELECT is_nullable
+		FROM information_schema.columns
+		WHERE table_schema = DATABASE() AND table_name = 'db_pool' AND column_name = 'uuid'`).Scan(&uuidNullable); err != nil {
+		t.Fatalf("load db_pool.uuid nullability: %v", err)
+	}
+	if uuidNullable != "NO" {
+		t.Fatalf("db_pool.uuid is_nullable = %q, want NO", uuidNullable)
 	}
 	if status != "active" || spendingLimit != nil {
 		t.Fatalf("legacy row status/spending_limit = %q/%v, want active/NULL", status, spendingLimit)
 	}
 	if !softCapReached {
 		t.Fatal("legacy row at max_tenants must be backfilled with soft_cap_reached=true")
+	}
+
+	if _, err := s.DB().ExecContext(ctx, `DROP INDEX uk_db_pool_uuid ON db_pool`); err != nil {
+		t.Fatalf("drop db_pool uuid index to simulate partial migration: %v", err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET uuid = UPPER(uuid) WHERE org_id = 'org-legacy'`); err != nil {
+		t.Fatalf("uppercase db_pool uuid to simulate partial migration: %v", err)
+	}
+	if err := s.migrate(); err != nil {
+		t.Fatalf("resume partial db_pool uuid migration: %v", err)
+	}
+	if err := s.migrate(); err != nil {
+		t.Fatalf("repeat completed db_pool uuid migration: %v", err)
+	}
+	var uuidAfterRetries string
+	if err := s.DB().QueryRowContext(ctx, `SELECT uuid FROM db_pool WHERE org_id = 'org-legacy'`).Scan(&uuidAfterRetries); err != nil {
+		t.Fatalf("load db_pool uuid after repeated migration: %v", err)
+	}
+	if uuidAfterRetries != dbPoolUUID {
+		t.Fatalf("db_pool uuid after repeated migration = %q, want stable %q", uuidAfterRetries, dbPoolUUID)
+	}
+	if exists, err := metaIndexExists(ctx, s.DB(), "db_pool", "uk_db_pool_uuid"); err != nil || !exists {
+		t.Fatalf("db_pool uuid index after repeated migration = %t/%v, want true/nil", exists, err)
 	}
 }
 

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -304,9 +304,8 @@ func (s *Store) SetQuotaConfigPatch(ctx context.Context, tenantID string, patch 
 }
 
 // UpdateSharedTenantQuotaConfig atomically applies the externally writable
-// quota fields for a placed shared tenant. For a managed DB pool it locks the
-// physical pool, computes the exact prospective virtual spending-limit sum,
-// and rejects the entire patch when the fixed target has no headroom.
+// quota fields for a placed shared tenant. TiDB Cloud spending limit remains a
+// compatibility-only virtual value and does not affect physical pool capacity.
 func (s *Store) UpdateSharedTenantQuotaConfig(ctx context.Context, tenantID string, patch QuotaConfigPatch) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "update_shared_tenant_quota_config", start, &err)
@@ -318,15 +317,13 @@ func (s *Store) UpdateSharedTenantQuotaConfig(ctx context.Context, tenantID stri
 	}
 	return s.InTx(ctx, func(tx *sql.Tx) error {
 		var dbID int64
-		var poolSpendingLimit sql.NullInt64
-		if scanErr := tx.QueryRowContext(ctx, `SELECT d.db_id, d.spending_limit
+		if scanErr := tx.QueryRowContext(ctx, `SELECT p.db_id
 			FROM tenants t
 			JOIN fs_registry f ON f.tenant_id = t.id
 			JOIN tenant_placements p ON p.fs_id = f.fs_id
-			JOIN db_pool d ON d.db_id = p.db_id
 			WHERE t.id = ? AND t.provider = ? AND p.status = ?
 			FOR UPDATE`, tenantID, "tidb_cloud_native_shared", SharedDBStatusActive).
-			Scan(&dbID, &poolSpendingLimit); scanErr != nil {
+			Scan(&dbID); scanErr != nil {
 			if errors.Is(scanErr, sql.ErrNoRows) {
 				return ErrNotFound
 			}
@@ -350,20 +347,6 @@ func (s *Store) UpdateSharedTenantQuotaConfig(ctx context.Context, tenantID stri
 		nextSpending := currentSpending.Int64
 		if patch.TiDBCloudSpendingLimit != nil {
 			nextSpending = *patch.TiDBCloudSpendingLimit
-		}
-		if poolSpendingLimit.Valid && nextSpending > currentSpending.Int64 {
-			var currentSum int64
-			if sumErr := tx.QueryRowContext(ctx, `SELECT COALESCE(SUM(q.tidbcloud_spending_limit), 0)
-				FROM tenant_placements p
-				JOIN fs_registry f ON f.fs_id = p.fs_id
-				JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id
-				WHERE p.db_id = ?`, dbID).Scan(&currentSum); sumErr != nil {
-				return fmt.Errorf("sum shared tenant spending limits: %w", sumErr)
-			}
-			prospective := currentSum - currentSpending.Int64 + nextSpending
-			if prospective < 0 || prospective > int64(1<<31-1) || prospective >= poolSpendingLimit.Int64 {
-				return ErrSharedDBSpendingLimitExceeded
-			}
 		}
 		if patch.MaxStorageBytes != nil {
 			maxStorage = *patch.MaxStorageBytes

--- a/pkg/meta/tenant_pool_membership.go
+++ b/pkg/meta/tenant_pool_membership.go
@@ -321,7 +321,7 @@ func (s *Store) DetachUsedTenantPoolMemberships(ctx context.Context, poolID stri
 }
 
 // ClaimSharedTenantPoolMembership atomically finalizes a free shared member:
-// quota patch, capacity-headroom validation, membership CAS, and owner key.
+// virtual quota patch, membership CAS, and owner key.
 func (s *Store) ClaimSharedTenantPoolMembership(ctx context.Context, tenantID, poolID string, patch QuotaConfigPatch, k *APIKey) (err error) {
 	if strings.TrimSpace(tenantID) == "" || strings.TrimSpace(poolID) == "" || k == nil {
 		return fmt.Errorf("tenant id, pool id, and api key are required")
@@ -332,16 +332,14 @@ func (s *Store) ClaimSharedTenantPoolMembership(ctx context.Context, tenantID, p
 	}
 	return s.InTx(ctx, func(tx *sql.Tx) error {
 		var dbID int64
-		var poolLimit sql.NullInt64
-		if err := tx.QueryRowContext(ctx, `SELECT p.db_id, d.spending_limit
+		if err := tx.QueryRowContext(ctx, `SELECT p.db_id
 			FROM tenant_pool_memberships m
 			JOIN tenants t ON t.id = m.tenant_id
 			JOIN fs_registry f ON f.tenant_id = t.id
 			JOIN tenant_placements p ON p.fs_id = f.fs_id
-			JOIN db_pool d ON d.db_id = p.db_id
 			WHERE m.tenant_id = ? AND m.pool_id = ? AND m.pool_status = ?
 				AND t.provider = ? AND t.status = ? FOR UPDATE`, tenantID, poolID,
-			TenantPoolBindingFree, tidbCloudNativeSharedProvider, TenantActive).Scan(&dbID, &poolLimit); err != nil {
+			TenantPoolBindingFree, tidbCloudNativeSharedProvider, TenantActive).Scan(&dbID); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrNotFound
 			}
@@ -365,18 +363,6 @@ func (s *Store) ClaimSharedTenantPoolMembership(ctx context.Context, tenantID, p
 		nextSpending := spending.Int64
 		if patch.TiDBCloudSpendingLimit != nil {
 			nextSpending = *patch.TiDBCloudSpendingLimit
-		}
-		if poolLimit.Valid && nextSpending > spending.Int64 {
-			var currentSum int64
-			if err := tx.QueryRowContext(ctx, `SELECT COALESCE(SUM(q.tidbcloud_spending_limit), 0)
-				FROM tenant_placements p JOIN fs_registry f ON f.fs_id = p.fs_id
-				JOIN tenant_quota_config q ON q.tenant_id = f.tenant_id WHERE p.db_id = ?`, dbID).Scan(&currentSum); err != nil {
-				return err
-			}
-			prospective := currentSum - spending.Int64 + nextSpending
-			if prospective < 0 || prospective > int64(1<<31-1) || prospective >= poolLimit.Int64 {
-				return ErrSharedDBSpendingLimitExceeded
-			}
 		}
 		if patch.MaxStorageBytes != nil {
 			storage = *patch.MaxStorageBytes

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -22,12 +22,14 @@ type dbProbeState struct {
 type registeredDB struct {
 	role           string
 	tenantID       string
+	dbPoolUUID     string
 	tidbCloudOrgID string
 }
 
 type dbMetricKey struct {
 	role           string
 	tenantID       string
+	dbPoolUUID     string
 	tidbCloudOrgID string
 }
 
@@ -99,12 +101,22 @@ func RegisterTenantDB(role, tenantID string, db *sql.DB) {
 }
 
 func RegisterTenantDBWithOrg(role, tenantID, tidbCloudOrgID string, db *sql.DB) {
+	registerDB(role, tenantID, "", tidbCloudOrgID, db)
+}
+
+func RegisterSharedDBWithOrg(dbPoolUUID, tidbCloudOrgID string, db *sql.DB) {
+	registerDB("shared", "", dbPoolUUID, tidbCloudOrgID, db)
+}
+
+func registerDB(role, tenantID, dbPoolUUID, tidbCloudOrgID string, db *sql.DB) {
 	if db == nil {
 		return
 	}
 	RegisterModule("db")
 	globalDB.mu.Lock()
-	globalDB.dbs[db] = registeredDB{role: role, tenantID: tenantID, tidbCloudOrgID: tidbCloudOrgID}
+	globalDB.dbs[db] = registeredDB{
+		role: role, tenantID: tenantID, dbPoolUUID: dbPoolUUID, tidbCloudOrgID: tidbCloudOrgID,
+	}
 	globalDB.mu.Unlock()
 }
 
@@ -389,7 +401,7 @@ func writeDBPrometheus(w http.ResponseWriter) {
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_connections gauge")
 	for _, key := range keys {
 		totals := poolTotals[key]
-		if key.hasTenantID() && totals.openConnections == 0 {
+		if key.hasScopedIdentity() && totals.openConnections == 0 {
 			continue
 		}
 		labels := dbLabels(key)
@@ -402,7 +414,7 @@ func writeDBPrometheus(w http.ResponseWriter) {
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_wait_count_total Aggregated database pool wait count by role")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_wait_count_total counter")
 	for _, key := range keys {
-		if key.hasTenantID() && poolTotals[key].waitCount == 0 {
+		if key.hasScopedIdentity() && poolTotals[key].waitCount == 0 {
 			continue
 		}
 		_, _ = fmt.Fprintf(w, "drive9_db_pool_wait_count_total{%s} %d\n", dbLabels(key), poolTotals[key].waitCount)
@@ -411,7 +423,7 @@ func writeDBPrometheus(w http.ResponseWriter) {
 	_, _ = fmt.Fprintln(w, "# HELP drive9_db_pool_wait_duration_seconds_total Aggregated database pool wait duration by role")
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_wait_duration_seconds_total counter")
 	for _, key := range keys {
-		if key.hasTenantID() && poolTotals[key].waitDuration == 0 {
+		if key.hasScopedIdentity() && poolTotals[key].waitDuration == 0 {
 			continue
 		}
 		_, _ = fmt.Fprintf(w, "drive9_db_pool_wait_duration_seconds_total{%s} %.6f\n", dbLabels(key), poolTotals[key].waitDuration)
@@ -429,7 +441,7 @@ func writeDBPrometheus(w http.ResponseWriter) {
 }
 
 func writeDBPoolCloses(w http.ResponseWriter, key dbMetricKey, labels, reason string, value int64) {
-	if key.hasTenantID() && value == 0 {
+	if key.hasScopedIdentity() && value == 0 {
 		return
 	}
 	_, _ = fmt.Fprintf(w, "drive9_db_pool_closes_total{%s,reason=\"%s\"} %d\n", labels, reason, value)
@@ -439,6 +451,7 @@ func (p registeredDB) metricKey() dbMetricKey {
 	return dbMetricKey{
 		role:           cleanMetricValue(p.role, "unknown"),
 		tenantID:       cleanMetricValue(p.tenantID, "unknown"),
+		dbPoolUUID:     cleanMetricValue(p.dbPoolUUID, "unknown"),
 		tidbCloudOrgID: cleanTiDBCloudOrgID(p.tidbCloudOrgID),
 	}
 }
@@ -489,13 +502,27 @@ func observeDBProbeDuration(start time.Time, role, result string) {
 func dbLabels(key dbMetricKey) string {
 	labels := fmt.Sprintf("role=\"%s\"", EscapePromLabel(key.role))
 	if key.hasTenantID() {
-		labels += fmt.Sprintf(",tenant_id=\"%s\",tidbcloud_org_id=\"%s\"", EscapePromLabel(key.tenantID), EscapePromLabel(key.tidbCloudOrgID))
+		labels += fmt.Sprintf(",tenant_id=\"%s\"", EscapePromLabel(key.tenantID))
+	}
+	if key.hasDBPoolUUID() {
+		labels += fmt.Sprintf(",db_pool_uuid=\"%s\"", EscapePromLabel(key.dbPoolUUID))
+	}
+	if key.hasScopedIdentity() {
+		labels += fmt.Sprintf(",tidbcloud_org_id=\"%s\"", EscapePromLabel(key.tidbCloudOrgID))
 	}
 	return labels
 }
 
 func (key dbMetricKey) hasTenantID() bool {
 	return key.tenantID != "" && key.tenantID != "unknown"
+}
+
+func (key dbMetricKey) hasDBPoolUUID() bool {
+	return key.dbPoolUUID != "" && key.dbPoolUUID != "unknown"
+}
+
+func (key dbMetricKey) hasScopedIdentity() bool {
+	return key.hasTenantID() || key.hasDBPoolUUID()
 }
 
 func sortedDBMetricKeys(totals map[dbMetricKey]dbPoolTotals) []dbMetricKey {
@@ -509,6 +536,9 @@ func sortedDBMetricKeys(totals map[dbMetricKey]dbPoolTotals) []dbMetricKey {
 		}
 		if keys[i].tenantID != keys[j].tenantID {
 			return keys[i].tenantID < keys[j].tenantID
+		}
+		if keys[i].dbPoolUUID != keys[j].dbPoolUUID {
+			return keys[i].dbPoolUUID < keys[j].dbPoolUUID
 		}
 		return keys[i].tidbCloudOrgID < keys[j].tidbCloudOrgID
 	})

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -239,6 +239,39 @@ func TestDBPoolConnectionsIncludesTenantPoolsWithOpenConnections(t *testing.T) {
 	}
 }
 
+func TestSharedDBPoolMetricsUseUUIDWithoutTenantLabel(t *testing.T) {
+	const (
+		dbPoolUUID = "11111111-1111-4111-8111-111111111111"
+		orgID      = "org-shared-db-metrics-test"
+	)
+
+	healthy := &atomic.Bool{}
+	healthy.Store(true)
+	db := sql.OpenDB(fakeConnector{healthy: healthy})
+	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
+	t.Cleanup(func() {
+		UnregisterDB(db)
+		_ = db.Close()
+	})
+
+	RegisterSharedDBWithOrg(dbPoolUUID, orgID, db)
+	if err := db.PingContext(context.Background()); err != nil {
+		t.Fatalf("ping shared db: %v", err)
+	}
+
+	out := renderDB(t)
+	want := `drive9_db_pool_connections{role="shared",db_pool_uuid="` + dbPoolUUID + `",tidbcloud_org_id="` + orgID + `",state="open"} 1`
+	if !strings.Contains(out, want) {
+		t.Fatalf("expected shared DB pool UUID labels, got:\n%s", out)
+	}
+	for _, line := range strings.Split(out, "\n") {
+		if strings.Contains(line, `role="shared"`) && strings.Contains(line, "tenant_id=") {
+			t.Fatalf("shared DB pool metrics must not use tenant_id: %s", line)
+		}
+	}
+}
+
 func TestStartDBHealthProbeDisabledDoesNotStart(t *testing.T) {
 	globalDB.mu.Lock()
 	origStarted := globalDB.started

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -52,10 +52,10 @@ var tenantPoolMetadataResumeWaitTotal = serviceMeter.Int64Counter("drive9_tenant
 var tenantPoolMetadataResumeWaitDuration = serviceMeter.Float64Histogram("drive9_tenant_pool_metadata_resume_wait_duration_seconds", "Tenant pool metadata resume wait duration by pool_id/organization_id/scope/result", tenantPoolMetadataResumeWaitDurationBounds)
 var tenantPoolCapacity = serviceMeter.Float64Gauge("drive9_tenant_pool_capacity", "Tenant pool capacity by pool_id/organization_id/state")
 var tenantPoolBindings = serviceMeter.Float64Gauge("drive9_tenant_pool_bindings", "Tenant pool binding count by pool_id/tidbcloud_org_id/status")
-var sharedDBPoolTotal = serviceMeter.Float64Gauge("drive9_shared_db_pool_total", "Physical shared DB-pool count by tidbcloud_org_id/status")
-var sharedDBPoolCapacity = serviceMeter.Float64Gauge("drive9_shared_db_pool_capacity", "Physical shared DB-pool capacity by tidbcloud_org_id/db_pool_id/type")
-var sharedDBPoolTenants = serviceMeter.Float64Gauge("drive9_shared_db_pool_tenants", "Physical shared DB-pool tenant count by tidbcloud_org_id/db_pool_id/state")
-var sharedDBPoolSpendingLimit = serviceMeter.Float64Gauge("drive9_shared_db_pool_spending_limit", "Physical shared DB-pool spending limit by tidbcloud_org_id/db_pool_id/type")
+var sharedDBPoolTotal = serviceMeter.Float64Gauge("drive9_shared_db_pool_total", "Physical shared DB-pool presence by tidbcloud_org_id/db_pool_id/db_pool_uuid/status")
+var sharedDBPoolCapacity = serviceMeter.Float64Gauge("drive9_shared_db_pool_capacity", "Physical shared DB-pool capacity by tidbcloud_org_id/db_pool_id/db_pool_uuid/type")
+var sharedDBPoolTenants = serviceMeter.Float64Gauge("drive9_shared_db_pool_tenants", "Physical shared DB-pool tenant count by tidbcloud_org_id/db_pool_id/db_pool_uuid/state")
+var sharedDBPoolSpendingLimit = serviceMeter.Float64Gauge("drive9_shared_db_pool_spending_limit", "Physical shared DB-pool spending limit by tidbcloud_org_id/db_pool_id/db_pool_uuid/type")
 var tidbCloudRBACCacheRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_rbac_cache_requests_total", "TiDB Cloud API key to cluster RBAC cache requests by path/scope/result")
 var tidbCloudOpenAPIRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_openapi_requests_total", "TiDB Cloud OpenAPI requests by path/operation/result")
 var tidbCloudSpendingLimitSyncTotal = serviceMeter.Int64Counter("drive9_tidbcloud_spending_limit_sync_total", "TiDB Cloud spending limit local sync outcomes by source/result")
@@ -191,58 +191,53 @@ func DeleteTenantPoolBindings(poolID, tidbCloudOrgID, poolStatus string) {
 	)
 }
 
-func RecordSharedDBPoolTotal(tidbCloudOrgID, status string, count int64) {
+func RecordSharedDBPoolTotal(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, status string, count int64) {
 	if count < 0 {
 		return
 	}
 	RegisterModule("shared_db_pool")
-	sharedDBPoolTotal.Set(float64(count),
-		Attr("tidbcloud_org_id", cleanMetricValue(tidbCloudOrgID, "unknown")),
-		Attr("status", cleanMetricValue(status, "unknown")),
-	)
+	sharedDBPoolTotal.Set(float64(count), sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID, "status", status)...)
 }
 
-func DeleteSharedDBPoolTotal(tidbCloudOrgID, status string) {
-	sharedDBPoolTotal.Delete(
-		Attr("tidbcloud_org_id", cleanMetricValue(tidbCloudOrgID, "unknown")),
-		Attr("status", cleanMetricValue(status, "unknown")),
-	)
+func DeleteSharedDBPoolTotal(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, status string) {
+	sharedDBPoolTotal.Delete(sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID, "status", status)...)
 }
 
-func RecordSharedDBPoolCapacity(tidbCloudOrgID string, dbPoolID int64, capacityType string, value int64) {
+func RecordSharedDBPoolCapacity(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, capacityType string, value int64) {
 	RegisterModule("shared_db_pool")
-	sharedDBPoolCapacity.Set(float64(value), sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "type", capacityType)...)
+	sharedDBPoolCapacity.Set(float64(value), sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID, "type", capacityType)...)
 }
 
-func DeleteSharedDBPoolCapacity(tidbCloudOrgID string, dbPoolID int64, capacityType string) {
-	sharedDBPoolCapacity.Delete(sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "type", capacityType)...)
+func DeleteSharedDBPoolCapacity(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, capacityType string) {
+	sharedDBPoolCapacity.Delete(sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID, "type", capacityType)...)
 }
 
-func RecordSharedDBPoolTenants(tidbCloudOrgID string, dbPoolID int64, state string, count int64) {
+func RecordSharedDBPoolTenants(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, state string, count int64) {
 	if count < 0 {
 		return
 	}
 	RegisterModule("shared_db_pool")
-	sharedDBPoolTenants.Set(float64(count), sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "state", state)...)
+	sharedDBPoolTenants.Set(float64(count), sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID, "state", state)...)
 }
 
-func DeleteSharedDBPoolTenants(tidbCloudOrgID string, dbPoolID int64, state string) {
-	sharedDBPoolTenants.Delete(sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "state", state)...)
+func DeleteSharedDBPoolTenants(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, state string) {
+	sharedDBPoolTenants.Delete(sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID, "state", state)...)
 }
 
-func RecordSharedDBPoolSpendingLimit(tidbCloudOrgID string, dbPoolID int64, limitType string, value int64) {
+func RecordSharedDBPoolSpendingLimit(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, limitType string, value int64) {
 	RegisterModule("shared_db_pool")
-	sharedDBPoolSpendingLimit.Set(float64(value), sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "type", limitType)...)
+	sharedDBPoolSpendingLimit.Set(float64(value), sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID, "type", limitType)...)
 }
 
-func DeleteSharedDBPoolSpendingLimit(tidbCloudOrgID string, dbPoolID int64, limitType string) {
-	sharedDBPoolSpendingLimit.Delete(sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, "type", limitType)...)
+func DeleteSharedDBPoolSpendingLimit(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, limitType string) {
+	sharedDBPoolSpendingLimit.Delete(sharedDBPoolAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID, "type", limitType)...)
 }
 
-func sharedDBPoolAttrs(tidbCloudOrgID string, dbPoolID int64, dimension, value string) []Attribute {
+func sharedDBPoolAttrs(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, dimension, value string) []Attribute {
 	return []Attribute{
 		Attr("tidbcloud_org_id", cleanMetricValue(tidbCloudOrgID, "unknown")),
 		Attr("db_pool_id", strconv.FormatInt(dbPoolID, 10)),
+		Attr("db_pool_uuid", cleanMetricValue(dbPoolUUID, "unknown")),
 		Attr(dimension, cleanMetricValue(value, "unknown")),
 	}
 }

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -41,13 +41,25 @@ func OpenInstrumentedForTenant(ctx context.Context, dsn, role, tenantID string) 
 }
 
 func OpenInstrumentedForTenantWithOrg(ctx context.Context, dsn, role, tenantID, tidbCloudOrgID string) (*sql.DB, error) {
+	return openInstrumented(ctx, dsn, role, func(db *sql.DB) {
+		metrics.RegisterTenantDBWithOrg(role, tenantID, tidbCloudOrgID, db)
+	})
+}
+
+func OpenInstrumentedForSharedDB(ctx context.Context, dsn, dbPoolUUID, tidbCloudOrgID string) (*sql.DB, error) {
+	return openInstrumented(ctx, dsn, RoleShared, func(db *sql.DB) {
+		metrics.RegisterSharedDBWithOrg(dbPoolUUID, tidbCloudOrgID, db)
+	})
+}
+
+func openInstrumented(ctx context.Context, dsn, role string, register func(*sql.DB)) (*sql.DB, error) {
 	connector, err := (&mysql.MySQLDriver{}).OpenConnector(dsn)
 	if err != nil {
 		return nil, fmt.Errorf("open mysql connector: %w", err)
 	}
 	db := sql.OpenDB(instrumentedConnector{base: connector, role: role})
 	ApplyPoolDefaults(db, role)
-	metrics.RegisterTenantDBWithOrg(role, tenantID, tidbCloudOrgID, db)
+	register(db)
 	if err := db.PingContext(ctx); err != nil {
 		metrics.UnregisterDB(db)
 		_ = db.Close()

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1106,7 +1106,7 @@ func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, p
 			return resolvedOrg, fmt.Errorf("managed db pool %d has no spending target", dbID)
 		}
 		rows[dbID] = row
-		requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID,
+		requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID, DBPoolUUID: row.UUID,
 			DatabaseName: row.Name, RootPassword: string(plain), SpendingLimitMonthly: *row.SpendingLimit})
 	}
 	if len(requests) == 0 {
@@ -1119,7 +1119,7 @@ func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, p
 		return resolvedOrg, createErr
 	}
 	for _, info := range created {
-		if info == nil || rows[info.DBPoolID] == nil {
+		if info == nil || rows[info.DBPoolID] == nil || rows[info.DBPoolID].UUID != info.DBPoolUUID {
 			return resolvedOrg, fmt.Errorf("shared db batch returned an unknown db pool")
 		}
 		row := rows[info.DBPoolID]

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -970,9 +970,8 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 			return results, err
 		}
-		virtualLimit := s.sharedTenantVirtualSpendingLimit(opts)
 		var selected *meta.SharedDB
-		selected, created, err := s.allocateManagedSharedDB(ctx, cred, virtualLimit, func(db *meta.SharedDB) error {
+		selected, created, err := s.allocateManagedSharedDB(ctx, cred, func(db *meta.SharedDB) error {
 			return s.meta.CompleteSharedTenantPoolMember(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared,
 				&meta.TenantPlacement{FsID: fsID, DbID: db.ID, Placement: meta.PlacementShared,
 					SchemaShape: meta.SchemaShapeShared, Status: meta.SharedDBStatusActive},

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -306,7 +306,7 @@ func TestDeleteFreeSharedPoolTenantSkipsPurgeWhenDBPoolIsUnready(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spendingTarget := int64(10_000_000)
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
 	dbID, err := rt.meta.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-unready-delete", ProvisioningKey: make([]byte, 32),
 		CloudProvider: "aws", Region: "us-east-1",

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -171,7 +171,7 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	if err != nil {
 		t.Fatalf("GetSharedDB: %v", err)
 	}
-	if dbPool.MaxTenants != 100 || dbPool.TenantCount != 1 || dbPool.SpendingLimit == nil || *dbPool.SpendingLimit != 10_000_000 {
+	if dbPool.MaxTenants != 100 || dbPool.TenantCount != 1 || dbPool.SpendingLimit == nil || *dbPool.SpendingLimit != meta.MaxTiDBCloudSpendingLimit {
 		t.Fatalf("managed pool policy = %+v", dbPool)
 	}
 	quota, err := metaStore.GetQuotaConfig(context.Background(), res.TenantID)
@@ -213,7 +213,7 @@ func TestProvisionTiDBCloudNativeSharedFallsBackToHardCapacityAfterCreateFailure
 		sharedPoolBatchErr: provisionErr,
 		managedClusters:    []tenant.CloudClusterInfo{{OrganizationID: "org-emergency", ClusterID: "cluster-existing"}},
 	}
-	spendingTarget := int64(10_000)
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
 	activeID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-emergency", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
 		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 2, SpendingLimit: &spendingTarget,
@@ -297,7 +297,7 @@ func TestProvisionTiDBCloudNativeSharedEmergencyUsesCandidateHardCap(t *testing.
 		sharedPoolBatchErr: provisionErr,
 		managedClusters:    []tenant.CloudClusterInfo{{OrganizationID: "org-candidate-hard-cap", ClusterID: "cluster-existing"}},
 	}
-	spendingTarget := int64(10_000_000)
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
 	createActive := func(maxTenants, tenantCount int, clusterID string) int64 {
 		t.Helper()
 		dbID, createErr := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
@@ -356,7 +356,7 @@ func TestProvisionTiDBCloudNativeSharedRetriesCapacityRace(t *testing.T) {
 	p.SetMetaStore(metaStore)
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
 		managedClusters: []tenant.CloudClusterInfo{{OrganizationID: "org-direct-race", ClusterID: "cluster-existing"}}}
-	spendingTarget := int64(10_000_000)
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
 	for i := 0; i < 2; i++ {
 		dbID, createErr := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
 			TiDBCloudOrganizationID: "org-direct-race", ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
@@ -429,7 +429,7 @@ func TestProvisionTiDBCloudNativeSharedResumesExistingProvisioningPool(t *testin
 			ClusterID: "cluster-existing", OrganizationID: "org-shared", Password: "root-pass", DBName: "tidbcloud_fs",
 		}},
 	}
-	spendingTarget := int64(10_000_000)
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
 	provisioningKey := sharedDBProvisioningKey(tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
 	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
 		ProvisioningKey: provisioningKey, CloudProvider: "aws", Region: "us-east-1",
@@ -601,7 +601,7 @@ func TestManagedSharedDBContinuationWaitsForConnectionMetadata(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spendingTarget := int64(10_000_000)
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
 	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-metadata-wait", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
 		CloudProvider: "aws", Region: "us-east-1",
@@ -653,7 +653,7 @@ func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spendingTarget := int64(10_000_000)
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
 	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-batch-lock", ProvisioningKey: bytes.Repeat([]byte{2}, 32),
 		CloudProvider: "aws", Region: "us-east-1",
@@ -724,7 +724,7 @@ func TestManagedSharedDBBatchCreateReturnsTotalFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	spendingTarget := int64(10_000_000)
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
 	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-batch-failure", ProvisioningKey: bytes.Repeat([]byte{9}, 32),
 		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -791,6 +791,9 @@ func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context
 			if copyRow.DBPoolID == 0 && i < len(requests) {
 				copyRow.DBPoolID = requests[i].DBPoolID
 			}
+			if copyRow.DBPoolUUID == "" && i < len(requests) {
+				copyRow.DBPoolUUID = requests[i].DBPoolUUID
+			}
 			out[i] = &copyRow
 		}
 		return out, nil
@@ -798,27 +801,28 @@ func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context
 	out := make([]*tenant.SharedDBPoolInfo, 0, len(requests))
 	for _, req := range requests {
 		out = append(out, &tenant.SharedDBPoolInfo{
-			DBPoolID: req.DBPoolID, ClusterID: fmt.Sprintf("cluster-%d", req.DBPoolID),
+			DBPoolID: req.DBPoolID, DBPoolUUID: req.DBPoolUUID, ClusterID: fmt.Sprintf("cluster-%d", req.DBPoolID),
 			OrganizationID: "org-shared", Password: "root-pass", DBName: req.DatabaseName,
 		})
 	}
 	return out, nil
 }
 
-func (f *fakeProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context, _ int64, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+func (f *fakeProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context, _ int64, dbPoolUUID, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
 	if clusterID == "" {
 		return nil, nil
 	}
 	for _, row := range f.sharedPoolResults {
 		if row != nil && row.ClusterID == clusterID {
 			copyRow := *row
+			copyRow.DBPoolUUID = dbPoolUUID
 			return &copyRow, nil
 		}
 	}
 	return nil, nil
 }
 
-func (f *fakeProvisioner) WaitForSharedDBPoolMetadataWithCredentials(_ context.Context, dbPoolID int64, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+func (f *fakeProvisioner) WaitForSharedDBPoolMetadataWithCredentials(_ context.Context, dbPoolID int64, dbPoolUUID, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
 	f.sharedPoolWaitCalls.Add(1)
 	if f.sharedPoolWaitErr != nil {
 		return nil, f.sharedPoolWaitErr
@@ -827,6 +831,7 @@ func (f *fakeProvisioner) WaitForSharedDBPoolMetadataWithCredentials(_ context.C
 		if row != nil && row.ClusterID == clusterID {
 			copyRow := *row
 			copyRow.DBPoolID = dbPoolID
+			copyRow.DBPoolUUID = dbPoolUUID
 			return &copyRow, nil
 		}
 	}

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -391,13 +391,11 @@ func (s *Server) validateQuotaSetRequest(req quotaRequest) error {
 	if req.TiDBCloudSpendingLimit != nil && *req.TiDBCloudSpendingLimit > 0 && *req.TiDBCloudSpendingLimit < 10 {
 		return fmt.Errorf("tidbcloud_spending_limit must be 0 or at least 10 RMB")
 	}
-	if req.TiDBCloudSpendingLimit != nil && *req.TiDBCloudSpendingLimit > maxInt32 {
+	if req.TiDBCloudSpendingLimit != nil && *req.TiDBCloudSpendingLimit > meta.MaxTiDBCloudSpendingLimit {
 		return fmt.Errorf("tidbcloud_spending_limit is too large")
 	}
 	return nil
 }
-
-const maxInt32 = int64(1<<31 - 1)
 
 var (
 	errQuotaSettingNotEnabled = errors.New("quota setting not enabled")
@@ -640,8 +638,6 @@ func writeQuotaSetError(w http.ResponseWriter, ctx context.Context, err error, a
 
 func quotaSetErrorStatusMessage(err error, action string) (int, string, bool) {
 	switch {
-	case errors.Is(err, meta.ErrSharedDBSpendingLimitExceeded):
-		return http.StatusConflict, "shared database spending limit capacity exceeded", true
 	case errors.Is(err, errQuotaSettingNotEnabled):
 		return http.StatusNotFound, "quota setting not enabled", true
 	case errors.Is(err, errQuotaLocalUpdateFailed):

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -566,7 +566,7 @@ func TestSharedQuotaGetAndSetUseLocalVirtualValueWithoutCloudMutation(t *testing
 	if _, err := rt.meta.DB().ExecContext(ctx, `UPDATE tenants SET cluster_id = '' WHERE id = ?`, rt.tenantID); err != nil {
 		t.Fatalf("clear tenant cluster id: %v", err)
 	}
-	spendingTarget := int64(10_000_000)
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
 	dbID, err := rt.meta.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-quota", ProvisioningKey: make([]byte, 32),
 		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
@@ -1174,6 +1174,7 @@ func TestQuotaSetRejectsInvalidQuotaValues(t *testing.T) {
 		{name: "negative_file_count", field: "max_file_count", value: -1, wantErr: "max_file_count must be non-negative"},
 		{name: "negative_spending_limit", field: "tidbcloud_spending_limit", value: -1, wantErr: "tidbcloud_spending_limit must be non-negative"},
 		{name: "small_spending_limit", field: "tidbcloud_spending_limit", value: 9, wantErr: "tidbcloud_spending_limit must be 0 or at least 10 RMB"},
+		{name: "spending_limit_above_cloud_maximum", field: "tidbcloud_spending_limit", value: meta.MaxTiDBCloudSpendingLimit + 1, wantErr: "tidbcloud_spending_limit is too large"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,13 +48,11 @@ type Config struct {
 	Pool                  *tenant.Pool
 	Provisioner           tenant.Provisioner
 	DefaultTenantProvider string
-	// SharedDBMaxTenants and SharedDBDefaultSpendingLimit apply only to new
-	// managed tidb_cloud_native_shared pools. Zero values use the documented
-	// defaults (100 tenants and 10,000,000 monthly units).
-	SharedDBMaxTenants           int
-	SharedDBHardCapRatio         float64
-	SharedDBReopenRatio          float64
-	SharedDBDefaultSpendingLimit int64
+	// SharedDBMaxTenants applies only to new managed
+	// tidb_cloud_native_shared pools. Zero uses the default of 100 tenants.
+	SharedDBMaxTenants   int
+	SharedDBHardCapRatio float64
+	SharedDBReopenRatio  float64
 	// LegacyStarterProvisioner is only used for delete/fork compatibility on
 	// persisted tidb_cloud_starter tenants. New starter provisioning remains
 	// disabled and NormalizeProvider does not accept tidb_cloud_starter.
@@ -182,47 +180,46 @@ func (s *Server) provisionerForTenantProvider(provider string) tenant.Provisione
 }
 
 type Server struct {
-	fallback                     *backend.Dat9Backend
-	meta                         *meta.Store
-	pool                         *tenant.Pool
-	provisioner                  tenant.Provisioner
-	defaultTenantProvider        string
-	sharedDBMaxTenants           int
-	sharedDBHardCapRatio         float64
-	sharedDBReopenRatio          float64
-	sharedDBDefaultSpendingLimit int64
-	legacyStarterProvisioner     tenant.Provisioner
-	tokenSecret                  []byte
-	localTenantAPIKey            string
-	vaultMK                      *vault.MasterKey
-	vaultIssuerURL               string
-	publicURL                    string
-	maxUploadBytes               int64
-	tenantPoolMaxSize            int
-	tenantPoolRefillFreeRatio    float64
-	inlineThreshold              int64
-	metrics                      *serverMetrics
-	logger                       *zap.Logger
-	mux                          *http.ServeMux
-	events                       *eventBuses
-	tenantWorker                 *tenantWorkerManager
-	shardResolver                *semanticShardResolver
-	journalCursorSecret          []byte
-	objectGCWorker               *objectGCWorker
-	slockOAuth                   SlockOAuthClient
-	tidbAutoEmbedding            tenantAutoEmbeddingDefault
-	disableDBAutoEmbed           bool
-	forkWorkerCtx                context.Context
-	forkWorkerCancel             context.CancelFunc
-	forkWorkerWG                 sync.WaitGroup
-	forkWorkerMu                 sync.Mutex
-	forkWorkerClosed             bool
-	tenantPoolLocks              sync.Map
-	tenantPoolCreateLocks        sync.Map
-	tenantPoolResumeJobs         sync.Map
-	tidbCloudRBACCache           *tidbCloudRBACCache
-	schemaInitErrors             sync.Map
-	leader                       *leader.Manager
+	fallback                  *backend.Dat9Backend
+	meta                      *meta.Store
+	pool                      *tenant.Pool
+	provisioner               tenant.Provisioner
+	defaultTenantProvider     string
+	sharedDBMaxTenants        int
+	sharedDBHardCapRatio      float64
+	sharedDBReopenRatio       float64
+	legacyStarterProvisioner  tenant.Provisioner
+	tokenSecret               []byte
+	localTenantAPIKey         string
+	vaultMK                   *vault.MasterKey
+	vaultIssuerURL            string
+	publicURL                 string
+	maxUploadBytes            int64
+	tenantPoolMaxSize         int
+	tenantPoolRefillFreeRatio float64
+	inlineThreshold           int64
+	metrics                   *serverMetrics
+	logger                    *zap.Logger
+	mux                       *http.ServeMux
+	events                    *eventBuses
+	tenantWorker              *tenantWorkerManager
+	shardResolver             *semanticShardResolver
+	journalCursorSecret       []byte
+	objectGCWorker            *objectGCWorker
+	slockOAuth                SlockOAuthClient
+	tidbAutoEmbedding         tenantAutoEmbeddingDefault
+	disableDBAutoEmbed        bool
+	forkWorkerCtx             context.Context
+	forkWorkerCancel          context.CancelFunc
+	forkWorkerWG              sync.WaitGroup
+	forkWorkerMu              sync.Mutex
+	forkWorkerClosed          bool
+	tenantPoolLocks           sync.Map
+	tenantPoolCreateLocks     sync.Map
+	tenantPoolResumeJobs      sync.Map
+	tidbCloudRBACCache        *tidbCloudRBACCache
+	schemaInitErrors          sync.Map
+	leader                    *leader.Manager
 	// leaderWorkerCtx gates leader-only background schedulers. When leadership
 	// changes, this context is cancelled and recreated. Workers that use it
 	// (pending tenant reconciler, tenant delete cleanup, one-time resume tasks)
@@ -378,29 +375,28 @@ func NewWithConfig(cfg Config) *Server {
 	}
 	forkWorkerCtx, forkWorkerCancel := context.WithCancel(context.Background())
 	s := &Server{
-		fallback:                     cfg.Backend,
-		meta:                         cfg.Meta,
-		pool:                         cfg.Pool,
-		tokenSecret:                  cfg.TokenSecret,
-		localTenantAPIKey:            strings.TrimSpace(cfg.LocalTenantAPIKey),
-		vaultMK:                      vaultMK,
-		vaultIssuerURL:               strings.TrimSpace(cfg.VaultIssuerURL),
-		publicURL:                    strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
-		provisioner:                  cfg.Provisioner,
-		defaultTenantProvider:        defaultTenantProvider,
-		sharedDBMaxTenants:           cfg.SharedDBMaxTenants,
-		sharedDBHardCapRatio:         sharedDBHardCapRatio,
-		sharedDBReopenRatio:          sharedDBReopenRatio,
-		sharedDBDefaultSpendingLimit: cfg.SharedDBDefaultSpendingLimit,
-		legacyStarterProvisioner:     cfg.LegacyStarterProvisioner,
-		maxUploadBytes:               maxUpload,
-		tenantPoolMaxSize:            tenantPoolMaxSize,
-		tenantPoolRefillFreeRatio:    tenantPoolRefillFreeRatio,
-		inlineThreshold:              inlineThreshold,
-		metrics:                      newServerMetrics(),
-		logger:                       logger,
-		events:                       newEventBuses(),
-		slockOAuth:                   cfg.SlockOAuth,
+		fallback:                  cfg.Backend,
+		meta:                      cfg.Meta,
+		pool:                      cfg.Pool,
+		tokenSecret:               cfg.TokenSecret,
+		localTenantAPIKey:         strings.TrimSpace(cfg.LocalTenantAPIKey),
+		vaultMK:                   vaultMK,
+		vaultIssuerURL:            strings.TrimSpace(cfg.VaultIssuerURL),
+		publicURL:                 strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
+		provisioner:               cfg.Provisioner,
+		defaultTenantProvider:     defaultTenantProvider,
+		sharedDBMaxTenants:        cfg.SharedDBMaxTenants,
+		sharedDBHardCapRatio:      sharedDBHardCapRatio,
+		sharedDBReopenRatio:       sharedDBReopenRatio,
+		legacyStarterProvisioner:  cfg.LegacyStarterProvisioner,
+		maxUploadBytes:            maxUpload,
+		tenantPoolMaxSize:         tenantPoolMaxSize,
+		tenantPoolRefillFreeRatio: tenantPoolRefillFreeRatio,
+		inlineThreshold:           inlineThreshold,
+		metrics:                   newServerMetrics(),
+		logger:                    logger,
+		events:                    newEventBuses(),
+		slockOAuth:                cfg.SlockOAuth,
 		tidbAutoEmbedding: tenantAutoEmbeddingDefault{
 			config:  defaultTiDBAutoEmbeddingConfig(cfg.TiDBAutoEmbeddingConfig),
 			apiKey:  strings.TrimSpace(cfg.TiDBAutoEmbeddingAPIKey),
@@ -5164,7 +5160,7 @@ func (s *Server) provisionTenantOnManagedSharedDB(ctx context.Context, tenantID 
 }
 
 func isSharedDBReservationConflict(err error) bool {
-	return errors.Is(err, meta.ErrSharedDBCapacityExhausted) || errors.Is(err, meta.ErrSharedDBSpendingLimitExceeded)
+	return errors.Is(err, meta.ErrSharedDBCapacityExhausted)
 }
 
 func (s *Server) provisionTenantOnSharedDBMode(ctx context.Context, tenantID string, sharedDB *meta.SharedDB, provider, keyName string, opts provisionTenantOptions, now time.Time, capacityMode meta.SharedDBCapacityMode, hardCap int) (*provisionTenantResult, error) {
@@ -5216,7 +5212,7 @@ func (s *Server) provisionTenantOnSharedDBMode(ctx context.Context, tenantID str
 		provisionErr = s.meta.CompleteSharedTenantProvision(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, placement, keyRec)
 	}
 	if provisionErr != nil {
-		if errors.Is(provisionErr, meta.ErrSharedDBCapacityExhausted) || errors.Is(provisionErr, meta.ErrSharedDBSpendingLimitExceeded) {
+		if errors.Is(provisionErr, meta.ErrSharedDBCapacityExhausted) {
 			return nil, newProvisionTenantError(http.StatusConflict, "shared pool is at capacity", provisionErr)
 		}
 		return fail(provisionErr)
@@ -5301,10 +5297,9 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 			return nil, newProvisionTenantError(http.StatusBadRequest, err.Error(), err)
 		}
-		virtualLimit := s.sharedTenantVirtualSpendingLimit(opts)
 		var lastConflict error
 		for attempt := 0; attempt < 2; attempt++ {
-			sharedDB, created, allocateErr := s.allocateManagedSharedDB(ctx, *opts.CredentialProvisioner, virtualLimit, nil)
+			sharedDB, created, allocateErr := s.allocateManagedSharedDB(ctx, *opts.CredentialProvisioner, nil)
 			if allocateErr != nil {
 				_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 				return nil, newProvisionTenantError(http.StatusBadGateway, "failed to allocate shared database", allocateErr)
@@ -5315,7 +5310,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 				if err != nil {
 					orgID, orgErr := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner)
 					if orgErr == nil {
-						fallback, findErr := s.meta.FindSharedDBForEmergency(ctx, orgID, s.sharedDBHardCapRatio, virtualLimit)
+						fallback, findErr := s.meta.FindSharedDBForEmergency(ctx, orgID, s.sharedDBHardCapRatio)
 						if findErr == nil {
 							hardCap, hardErr := s.managedSharedDBHardCap(fallback.MaxTenants)
 							if hardErr == nil {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -18,10 +18,9 @@ import (
 )
 
 const (
-	defaultManagedSharedDBMaxTenants    = 100
-	defaultManagedSharedDBSpendingLimit = int64(10_000_000)
-	defaultSharedTenantSpendingLimit    = int64(1000)
-	sharedTenantActivationBatchSize     = 100
+	defaultManagedSharedDBMaxTenants = 100
+	defaultSharedTenantSpendingLimit = int64(1000)
+	sharedTenantActivationBatchSize  = 100
 )
 
 var errSharedDBConnectionMetadataNotReady = errors.New("shared DB pool connection metadata is not ready")
@@ -34,16 +33,12 @@ type defaultSharedDatabaseNameProvider interface {
 	DefaultSharedDatabaseName() string
 }
 
-func (s *Server) managedSharedDBPolicy() (maxTenants int, spendingLimit int64) {
-	maxTenants = s.sharedDBMaxTenants
+func (s *Server) managedSharedDBPolicy() int {
+	maxTenants := s.sharedDBMaxTenants
 	if maxTenants <= 0 {
 		maxTenants = defaultManagedSharedDBMaxTenants
 	}
-	spendingLimit = s.sharedDBDefaultSpendingLimit
-	if spendingLimit <= 0 {
-		spendingLimit = defaultManagedSharedDBSpendingLimit
-	}
-	return maxTenants, spendingLimit
+	return maxTenants
 }
 
 func (s *Server) managedSharedDBHardCap(softCap int) (int, error) {
@@ -136,7 +131,7 @@ func (s *Server) materializeSharedTenantQuota(ctx context.Context, tenantID stri
 	return nil
 }
 
-func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.CredentialProvisionRequest, tenantSpendingLimit int64, reserve func(*meta.SharedDB) error) (sharedDB *meta.SharedDB, created bool, err error) {
+func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.CredentialProvisionRequest, reserve func(*meta.SharedDB) error) (sharedDB *meta.SharedDB, created bool, err error) {
 	organizationID, resolveErr := s.firstManagedOrganization(ctx, cred)
 	if resolveErr != nil {
 		return nil, false, fmt.Errorf("resolve tidbcloud organization: %w", resolveErr)
@@ -145,7 +140,7 @@ func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.Creden
 	identity := sharedDBAllocationIdentity(organizationID, provisioningKey)
 	err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
 		for attempt := 0; attempt < 2; attempt++ {
-			candidate, findErr := s.meta.FindSharedDBForAllocation(lockCtx, organizationID, provisioningKey, tenantSpendingLimit)
+			candidate, findErr := s.meta.FindSharedDBForAllocation(lockCtx, organizationID, provisioningKey)
 			if findErr == nil {
 				sharedDB = candidate
 			} else if !errors.Is(findErr, meta.ErrNotFound) {
@@ -159,14 +154,8 @@ func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.Creden
 				}
 			}
 			if sharedDB == nil {
-				maxTenants, configuredFloor := s.managedSharedDBPolicy()
-				fixedTarget := configuredFloor
-				if tenantSpendingLimit >= maxInt32 {
-					return meta.ErrSharedDBSpendingLimitExceeded
-				}
-				if tenantSpendingLimit+1 > fixedTarget {
-					fixedTarget = tenantSpendingLimit + 1
-				}
+				maxTenants := s.managedSharedDBPolicy()
+				fixedTarget := meta.MaxTiDBCloudSpendingLimit
 				cloudProvider, region := provisioningCloudRegion(s.provisioner)
 				rootPassword, passwordErr := generateManagedSharedDBRootPassword(24)
 				if passwordErr != nil {
@@ -202,7 +191,7 @@ func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.Creden
 			if reserveErr == nil {
 				return nil
 			}
-			if !errors.Is(reserveErr, meta.ErrSharedDBCapacityExhausted) && !errors.Is(reserveErr, meta.ErrSharedDBSpendingLimitExceeded) {
+			if !errors.Is(reserveErr, meta.ErrSharedDBCapacityExhausted) {
 				return reserveErr
 			}
 			sharedDB = nil

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -301,7 +301,7 @@ func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64, cr
 		if poolInfo.ClusterID == "" {
 			return err
 		}
-		if _, waitErr := waiter.WaitForSharedDBPoolMetadataWithCredentials(ctx, dbID, poolInfo.ClusterID, cred); waitErr != nil {
+		if _, waitErr := waiter.WaitForSharedDBPoolMetadataWithCredentials(ctx, dbID, poolInfo.UUID, poolInfo.ClusterID, cred); waitErr != nil {
 			return waitErr
 		}
 	}
@@ -376,7 +376,7 @@ func (s *Server) ensureManagedSharedDBPhysicalLocked(ctx context.Context, poolIn
 	if poolInfo.SpendingLimit == nil {
 		return nil, fmt.Errorf("managed db pool %d has no spending target", poolInfo.ID)
 	}
-	result, err := provisioner.LoadSharedDBPoolWithCredentials(ctx, poolInfo.ID, poolInfo.ClusterID, cred)
+	result, err := provisioner.LoadSharedDBPoolWithCredentials(ctx, poolInfo.ID, poolInfo.UUID, poolInfo.ClusterID, cred)
 	if err != nil {
 		if errors.Is(err, tenant.ErrSharedDBPoolAmbiguous) {
 			if markErr := s.meta.MarkSharedDBPoolFailed(ctx, poolInfo.ID); markErr != nil {
@@ -391,14 +391,14 @@ func (s *Server) ensureManagedSharedDBPhysicalLocked(ctx context.Context, poolIn
 			return nil, fmt.Errorf("managed shared cluster %q was not found", poolInfo.ClusterID)
 		}
 		results, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, []tenant.SharedDBPoolCreateRequest{{
-			DBPoolID: poolInfo.ID, DatabaseName: poolInfo.Name, RootPassword: string(plainRootPassword),
+			DBPoolID: poolInfo.ID, DBPoolUUID: poolInfo.UUID, DatabaseName: poolInfo.Name, RootPassword: string(plainRootPassword),
 			SpendingLimitMonthly: *poolInfo.SpendingLimit,
 		}}, cred)
 		provisionErr = createErr
 		if createErr != nil && len(results) == 0 {
 			return nil, createErr
 		}
-		if len(results) != 1 || results[0] == nil || results[0].DBPoolID != poolInfo.ID {
+		if len(results) != 1 || results[0] == nil || results[0].DBPoolID != poolInfo.ID || results[0].DBPoolUUID != poolInfo.UUID {
 			return nil, fmt.Errorf("shared db pool create returned no unique result for %d", poolInfo.ID)
 		}
 		result = results[0]
@@ -491,7 +491,7 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 		if poolInfo.SpendingLimit == nil {
 			return fmt.Errorf("managed db pool %d has no spending target", dbID)
 		}
-		result, loadErr := provisioner.LoadSharedDBPoolWithCredentials(ctx, dbID, poolInfo.ClusterID, cred)
+		result, loadErr := provisioner.LoadSharedDBPoolWithCredentials(ctx, dbID, poolInfo.UUID, poolInfo.ClusterID, cred)
 		if loadErr != nil {
 			if errors.Is(loadErr, tenant.ErrSharedDBPoolAmbiguous) {
 				if markErr := s.meta.MarkSharedDBPoolFailed(ctx, dbID); markErr != nil {
@@ -506,14 +506,14 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 				return fmt.Errorf("managed shared cluster %q was not found", poolInfo.ClusterID)
 			}
 			results, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, []tenant.SharedDBPoolCreateRequest{{
-				DBPoolID: dbID, DatabaseName: poolInfo.Name, RootPassword: string(plainRootPassword),
+				DBPoolID: dbID, DBPoolUUID: poolInfo.UUID, DatabaseName: poolInfo.Name, RootPassword: string(plainRootPassword),
 				SpendingLimitMonthly: *poolInfo.SpendingLimit,
 			}}, cred)
 			provisionErr = createErr
 			if createErr != nil && len(results) == 0 {
 				return createErr
 			}
-			if len(results) != 1 || results[0] == nil || results[0].DBPoolID != dbID {
+			if len(results) != 1 || results[0] == nil || results[0].DBPoolID != dbID || results[0].DBPoolUUID != poolInfo.UUID {
 				return fmt.Errorf("shared db pool create returned no unique result for %d", dbID)
 			}
 			result = results[0]

--- a/pkg/server/tenant_metrics.go
+++ b/pkg/server/tenant_metrics.go
@@ -134,17 +134,11 @@ func (s *Server) observeSharedDBPoolMetrics(ctx context.Context) {
 			}] = struct{}{}
 		}
 		if snapshot.SpendingLimit != nil {
-			for limitType, value := range map[string]int64{
-				"target":     *snapshot.SpendingLimit,
-				"tenant_sum": snapshot.TenantSpendingLimitSum,
-				"headroom":   *snapshot.SpendingLimit - snapshot.TenantSpendingLimitSum,
-			} {
-				metrics.RecordSharedDBPoolSpendingLimit(orgID, snapshot.ID, snapshot.UUID, limitType, value)
-				next[sharedDBPoolMetricKey{
-					kind: sharedDBPoolMetricSpending, dbPoolID: snapshot.ID, dbPoolUUID: snapshot.UUID,
-					tidbCloudOrgID: orgID, dimension: limitType,
-				}] = struct{}{}
-			}
+			metrics.RecordSharedDBPoolSpendingLimit(orgID, snapshot.ID, snapshot.UUID, "target", *snapshot.SpendingLimit)
+			next[sharedDBPoolMetricKey{
+				kind: sharedDBPoolMetricSpending, dbPoolID: snapshot.ID, dbPoolUUID: snapshot.UUID,
+				tidbCloudOrgID: orgID, dimension: "target",
+			}] = struct{}{}
 		}
 	}
 	if s.metrics != nil {

--- a/pkg/server/tenant_metrics.go
+++ b/pkg/server/tenant_metrics.go
@@ -27,6 +27,7 @@ const (
 type sharedDBPoolMetricKey struct {
 	kind           string
 	dbPoolID       int64
+	dbPoolUUID     string
 	tidbCloudOrgID string
 	dimension      string
 }
@@ -96,13 +97,14 @@ func (s *Server) observeSharedDBPoolMetrics(ctx context.Context) {
 	}
 
 	next := make(map[sharedDBPoolMetricKey]struct{})
-	totals := make(map[sharedDBPoolMetricKey]int64)
 	for _, snapshot := range snapshots {
 		orgID := snapshot.TiDBCloudOrganizationID
 		totalKey := sharedDBPoolMetricKey{
-			kind: sharedDBPoolMetricTotal, tidbCloudOrgID: orgID, dimension: snapshot.Status,
+			kind: sharedDBPoolMetricTotal, dbPoolID: snapshot.ID, dbPoolUUID: snapshot.UUID,
+			tidbCloudOrgID: orgID, dimension: snapshot.Status,
 		}
-		totals[totalKey]++
+		metrics.RecordSharedDBPoolTotal(orgID, snapshot.ID, snapshot.UUID, snapshot.Status, 1)
+		next[totalKey] = struct{}{}
 
 		free := int64(0)
 		if snapshot.MaxTenants > snapshot.TenantCount && !snapshot.SoftCapReached {
@@ -118,16 +120,16 @@ func (s *Server) observeSharedDBPoolMetrics(ctx context.Context) {
 			"soft_max": int64(snapshot.MaxTenants), "hard_max": hardMax,
 			"used": int64(snapshot.TenantCount), "free": free,
 		} {
-			metrics.RecordSharedDBPoolCapacity(orgID, snapshot.ID, capacityType, value)
+			metrics.RecordSharedDBPoolCapacity(orgID, snapshot.ID, snapshot.UUID, capacityType, value)
 			next[sharedDBPoolMetricKey{
-				kind: sharedDBPoolMetricCapacity, dbPoolID: snapshot.ID,
+				kind: sharedDBPoolMetricCapacity, dbPoolID: snapshot.ID, dbPoolUUID: snapshot.UUID,
 				tidbCloudOrgID: orgID, dimension: capacityType,
 			}] = struct{}{}
 		}
 		for _, state := range snapshot.TenantStates {
-			metrics.RecordSharedDBPoolTenants(orgID, snapshot.ID, string(state.State), state.Count)
+			metrics.RecordSharedDBPoolTenants(orgID, snapshot.ID, snapshot.UUID, string(state.State), state.Count)
 			next[sharedDBPoolMetricKey{
-				kind: sharedDBPoolMetricTenants, dbPoolID: snapshot.ID,
+				kind: sharedDBPoolMetricTenants, dbPoolID: snapshot.ID, dbPoolUUID: snapshot.UUID,
 				tidbCloudOrgID: orgID, dimension: string(state.State),
 			}] = struct{}{}
 		}
@@ -137,17 +139,13 @@ func (s *Server) observeSharedDBPoolMetrics(ctx context.Context) {
 				"tenant_sum": snapshot.TenantSpendingLimitSum,
 				"headroom":   *snapshot.SpendingLimit - snapshot.TenantSpendingLimitSum,
 			} {
-				metrics.RecordSharedDBPoolSpendingLimit(orgID, snapshot.ID, limitType, value)
+				metrics.RecordSharedDBPoolSpendingLimit(orgID, snapshot.ID, snapshot.UUID, limitType, value)
 				next[sharedDBPoolMetricKey{
-					kind: sharedDBPoolMetricSpending, dbPoolID: snapshot.ID,
+					kind: sharedDBPoolMetricSpending, dbPoolID: snapshot.ID, dbPoolUUID: snapshot.UUID,
 					tidbCloudOrgID: orgID, dimension: limitType,
 				}] = struct{}{}
 			}
 		}
-	}
-	for key, count := range totals {
-		metrics.RecordSharedDBPoolTotal(key.tidbCloudOrgID, key.dimension, count)
-		next[key] = struct{}{}
 	}
 	if s.metrics != nil {
 		s.metrics.syncSharedDBPoolSnapshot(next)
@@ -211,12 +209,12 @@ func (m *serverMetrics) clearSharedDBPoolSnapshot() {
 func deleteSharedDBPoolMetric(key sharedDBPoolMetricKey) {
 	switch key.kind {
 	case sharedDBPoolMetricTotal:
-		metrics.DeleteSharedDBPoolTotal(key.tidbCloudOrgID, key.dimension)
+		metrics.DeleteSharedDBPoolTotal(key.tidbCloudOrgID, key.dbPoolID, key.dbPoolUUID, key.dimension)
 	case sharedDBPoolMetricCapacity:
-		metrics.DeleteSharedDBPoolCapacity(key.tidbCloudOrgID, key.dbPoolID, key.dimension)
+		metrics.DeleteSharedDBPoolCapacity(key.tidbCloudOrgID, key.dbPoolID, key.dbPoolUUID, key.dimension)
 	case sharedDBPoolMetricTenants:
-		metrics.DeleteSharedDBPoolTenants(key.tidbCloudOrgID, key.dbPoolID, key.dimension)
+		metrics.DeleteSharedDBPoolTenants(key.tidbCloudOrgID, key.dbPoolID, key.dbPoolUUID, key.dimension)
 	case sharedDBPoolMetricSpending:
-		metrics.DeleteSharedDBPoolSpendingLimit(key.tidbCloudOrgID, key.dbPoolID, key.dimension)
+		metrics.DeleteSharedDBPoolSpendingLimit(key.tidbCloudOrgID, key.dbPoolID, key.dbPoolUUID, key.dimension)
 	}
 }

--- a/pkg/server/tenant_metrics_test.go
+++ b/pkg/server/tenant_metrics_test.go
@@ -149,7 +149,10 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 
 	ctx := context.Background()
 	spendingLimit := int64(10_000)
+	const activePoolUUID = "11111111-1111-4111-8111-111111111111"
+	const provisioningPoolUUID = "22222222-2222-4222-8222-222222222222"
 	dbID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		UUID:                    activePoolUUID,
 		TiDBCloudOrganizationID: "org-shared-db-metrics",
 		ProvisioningKey:         make([]byte, 32),
 		CloudProvider:           "aws",
@@ -163,14 +166,16 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, meta.SharedDBStatusActive, dbID); err != nil {
 		t.Fatalf("activate db pool: %v", err)
 	}
-	if _, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+	provisioningDBID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		UUID:                    provisioningPoolUUID,
 		TiDBCloudOrganizationID: "org-shared-db-metrics",
 		ProvisioningKey:         []byte("12345678901234567890123456789012"),
 		CloudProvider:           "aws",
 		Region:                  "us-east-1",
 		MaxTenants:              5,
 		SpendingLimit:           &spendingLimit,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("CreateManagedSharedDBPool provisioning: %v", err)
 	}
 
@@ -209,18 +214,19 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 	s.metrics.writePrometheus(rec)
 	text := rec.Body.String()
 	dbPoolID := fmt.Sprint(dbID)
+	provisioningDBPoolID := fmt.Sprint(provisioningDBID)
 	for _, want := range []string{
-		`drive9_shared_db_pool_total{status="active",tidbcloud_org_id="org-shared-db-metrics"} 1`,
-		`drive9_shared_db_pool_total{status="provisioning",tidbcloud_org_id="org-shared-db-metrics"} 1`,
-		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="soft_max"} 5`,
-		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="hard_max"} 6`,
-		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="used"} 2`,
-		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="free"} 3`,
-		`drive9_shared_db_pool_tenants{db_pool_id="` + dbPoolID + `",state="active",tidbcloud_org_id="org-shared-db-metrics"} 1`,
-		`drive9_shared_db_pool_tenants{db_pool_id="` + dbPoolID + `",state="provisioning",tidbcloud_org_id="org-shared-db-metrics"} 1`,
-		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="target"} 10000`,
-		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="tenant_sum"} 3000`,
-		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",tidbcloud_org_id="org-shared-db-metrics",type="headroom"} 7000`,
+		`drive9_shared_db_pool_total{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",status="active",tidbcloud_org_id="org-shared-db-metrics"} 1`,
+		`drive9_shared_db_pool_total{db_pool_id="` + provisioningDBPoolID + `",db_pool_uuid="` + provisioningPoolUUID + `",status="provisioning",tidbcloud_org_id="org-shared-db-metrics"} 1`,
+		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="soft_max"} 5`,
+		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="hard_max"} 6`,
+		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="used"} 2`,
+		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="free"} 3`,
+		`drive9_shared_db_pool_tenants{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",state="active",tidbcloud_org_id="org-shared-db-metrics"} 1`,
+		`drive9_shared_db_pool_tenants{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",state="provisioning",tidbcloud_org_id="org-shared-db-metrics"} 1`,
+		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="target"} 10000`,
+		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="tenant_sum"} 3000`,
+		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="headroom"} 7000`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("missing shared DB-pool metric %q:\n%s", want, text)
@@ -253,13 +259,13 @@ func TestStopLeaderWorkersClearsMetricSnapshots(t *testing.T) {
 		status:         string(meta.TenantPoolBindingUsed),
 	}
 	sharedDBKey := sharedDBPoolMetricKey{
-		kind: sharedDBPoolMetricCapacity, dbPoolID: 987654,
+		kind: sharedDBPoolMetricCapacity, dbPoolID: 987654, dbPoolUUID: "33333333-3333-4333-8333-333333333333",
 		tidbCloudOrgID: "org-shared-leader-loss-clear", dimension: "used",
 	}
 	s := &Server{metrics: newServerMetrics(), leaderWorkersStarted: true}
 	metrics.RecordTenantPoolBindings(tenantPoolKey.poolID, tenantPoolKey.tidbCloudOrgID, tenantPoolKey.status, 1)
 	s.metrics.syncTenantPoolBindingSnapshot(map[tenantPoolBindingMetricKey]struct{}{tenantPoolKey: {}})
-	metrics.RecordSharedDBPoolCapacity(sharedDBKey.tidbCloudOrgID, sharedDBKey.dbPoolID, sharedDBKey.dimension, 1)
+	metrics.RecordSharedDBPoolCapacity(sharedDBKey.tidbCloudOrgID, sharedDBKey.dbPoolID, sharedDBKey.dbPoolUUID, sharedDBKey.dimension, 1)
 	s.metrics.syncSharedDBPoolSnapshot(map[sharedDBPoolMetricKey]struct{}{sharedDBKey: {}})
 
 	rec := httptest.NewRecorder()
@@ -267,7 +273,7 @@ func TestStopLeaderWorkersClearsMetricSnapshots(t *testing.T) {
 	if !strings.Contains(rec.Body.String(), `drive9_tenant_pool_bindings{pool_id="pool-leader-loss-clear",status="used",tidbcloud_org_id="org-leader-loss-clear"} 1`) {
 		t.Fatalf("missing tenant pool binding metric before leadership loss:\n%s", rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), `drive9_shared_db_pool_capacity{db_pool_id="987654",tidbcloud_org_id="org-shared-leader-loss-clear",type="used"} 1`) {
+	if !strings.Contains(rec.Body.String(), `drive9_shared_db_pool_capacity{db_pool_id="987654",db_pool_uuid="33333333-3333-4333-8333-333333333333",tidbcloud_org_id="org-shared-leader-loss-clear",type="used"} 1`) {
 		t.Fatalf("missing shared DB-pool metric before leadership loss:\n%s", rec.Body.String())
 	}
 

--- a/pkg/server/tenant_metrics_test.go
+++ b/pkg/server/tenant_metrics_test.go
@@ -148,7 +148,7 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 	testmysql.ResetMetaDB(t, metaStore.DB())
 
 	ctx := context.Background()
-	spendingLimit := int64(10_000)
+	spendingLimit := meta.MaxTiDBCloudSpendingLimit
 	const activePoolUUID = "11111111-1111-4111-8111-111111111111"
 	const provisioningPoolUUID = "22222222-2222-4222-8222-222222222222"
 	dbID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
@@ -224,9 +224,7 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="free"} 3`,
 		`drive9_shared_db_pool_tenants{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",state="active",tidbcloud_org_id="org-shared-db-metrics"} 1`,
 		`drive9_shared_db_pool_tenants{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",state="provisioning",tidbcloud_org_id="org-shared-db-metrics"} 1`,
-		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="target"} 10000`,
-		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="tenant_sum"} 3000`,
-		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="headroom"} 7000`,
+		`drive9_shared_db_pool_spending_limit{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="target"} 1000000`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("missing shared DB-pool metric %q:\n%s", want, text)
@@ -235,6 +233,10 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 	for _, line := range strings.Split(text, "\n") {
 		if strings.HasPrefix(line, "drive9_shared_db_pool_") && strings.Contains(line, "organization_id=") {
 			t.Fatalf("shared DB-pool metrics must use tidbcloud_org_id:\n%s", text)
+		}
+		if strings.HasPrefix(line, "drive9_shared_db_pool_spending_limit") &&
+			(strings.Contains(line, `type="tenant_sum"`) || strings.Contains(line, `type="headroom"`)) {
+			t.Fatalf("shared DB-pool metrics must not sum virtual tenant spending limits:\n%s", text)
 		}
 	}
 

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -1037,8 +1037,7 @@ func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) 
 	// An empty TLSMode means a plain connection (local/self-hosted databases);
 	// shared DBs on TiDB Cloud are registered with tls=skip-verify or tls=true.
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", info.User, string(pass), info.Host, info.Port, info.Name, query)
-	db, err := mysqlutil.OpenInstrumentedForTenantWithOrg(ctx, dsn, mysqlutil.RoleShared,
-		fmt.Sprintf("shared:%d", dbID), info.TiDBCloudOrganizationID)
+	db, err := mysqlutil.OpenInstrumentedForSharedDB(ctx, dsn, info.UUID, info.TiDBCloudOrganizationID)
 	if err != nil {
 		return nil, fmt.Errorf("shared db %d: open: %w", dbID, err)
 	}

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -74,6 +74,7 @@ type TenantPoolClusterManager interface {
 
 type SharedDBPoolCreateRequest struct {
 	DBPoolID             int64
+	DBPoolUUID           string
 	DatabaseName         string
 	RootPassword         string
 	SpendingLimitMonthly int64
@@ -81,6 +82,7 @@ type SharedDBPoolCreateRequest struct {
 
 type SharedDBPoolInfo struct {
 	DBPoolID       int64
+	DBPoolUUID     string
 	ClusterID      string
 	OrganizationID string
 	Host           string
@@ -96,11 +98,11 @@ type SharedDBPoolProvisioner interface {
 	// decoded subset together with a non-nil error. Callers must persist/process
 	// every returned result before handling the error.
 	BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, requests []SharedDBPoolCreateRequest, req CredentialProvisionRequest) ([]*SharedDBPoolInfo, error)
-	LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoolID int64, clusterID string, req CredentialProvisionRequest) (*SharedDBPoolInfo, error)
+	LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoolID int64, dbPoolUUID, clusterID string, req CredentialProvisionRequest) (*SharedDBPoolInfo, error)
 }
 
 type SharedDBPoolMetadataWaiter interface {
-	WaitForSharedDBPoolMetadataWithCredentials(ctx context.Context, dbPoolID int64, clusterID string, req CredentialProvisionRequest) (*SharedDBPoolInfo, error)
+	WaitForSharedDBPoolMetadataWithCredentials(ctx context.Context, dbPoolID int64, dbPoolUUID, clusterID string, req CredentialProvisionRequest) (*SharedDBPoolInfo, error)
 }
 
 var ErrSharedDBPoolAmbiguous = errors.New("multiple shared db pool cloud resources found")

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -27,6 +27,7 @@ import (
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/tenant/schema"
@@ -1490,14 +1491,13 @@ func (p *Provisioner) updateSpendingLimitWithCredentials(ctx context.Context, pu
 }
 
 func validateTiDBCloudSpendingLimit(monthly int64) error {
-	const maxInt32 = int64(1<<31 - 1)
 	if monthly < 0 {
 		return fmt.Errorf("tidbcloud_spending_limit must be non-negative")
 	}
 	if monthly > 0 && monthly < 10 {
 		return fmt.Errorf("tidbcloud_spending_limit must be 0 or at least 10 RMB")
 	}
-	if monthly > maxInt32 {
+	if monthly > meta.MaxTiDBCloudSpendingLimit {
 		return fmt.Errorf("tidbcloud_spending_limit is too large")
 	}
 	return nil

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	mysql "github.com/go-sql-driver/mysql"
+	"github.com/google/uuid"
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
@@ -59,7 +60,7 @@ const (
 	Drive9PoolIDLabel          = "drive9.ai/pool_id"
 	Drive9PoolUsedAtLabel      = "drive9.ai/used_at"
 	Drive9ProviderLabel        = "drive9.ai/provider"
-	Drive9DBPoolIDLabel        = "drive9.ai/db_pool_id"
+	Drive9DBPoolUUIDLabel      = "drive9.ai/db_pool_uuid"
 	Drive9QuotaUpdateAtLabel   = "drive9.ai/update_quota_at"
 	TiDBCloudOrganizationLabel = "tidb.cloud/organization"
 
@@ -500,14 +501,19 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 		return nil, fmt.Errorf("shared db pool batch size %d exceeds 10", len(inputs))
 	}
 	requests := make([]map[string]any, 0, len(inputs))
-	passwords := make(map[int64]string, len(inputs))
-	databaseNames := make(map[int64]string, len(inputs))
+	inputsByUUID := make(map[string]tenant.SharedDBPoolCreateRequest, len(inputs))
+	databaseNames := make(map[string]string, len(inputs))
 	for _, input := range inputs {
 		if input.DBPoolID <= 0 {
 			return nil, fmt.Errorf("db pool id must be positive")
 		}
-		if _, exists := passwords[input.DBPoolID]; exists {
-			return nil, fmt.Errorf("duplicate db pool id %d", input.DBPoolID)
+		parsedUUID, err := uuid.Parse(strings.TrimSpace(input.DBPoolUUID))
+		if err != nil {
+			return nil, fmt.Errorf("db pool %d has invalid uuid %q: %w", input.DBPoolID, input.DBPoolUUID, err)
+		}
+		poolUUID := parsedUUID.String()
+		if _, exists := inputsByUUID[poolUUID]; exists {
+			return nil, fmt.Errorf("duplicate db pool uuid %s", poolUUID)
 		}
 		if err := validateTiDBCloudSpendingLimit(input.SpendingLimitMonthly); err != nil {
 			return nil, err
@@ -520,17 +526,18 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 		if password == "" {
 			return nil, fmt.Errorf("root password is required for db pool %d", input.DBPoolID)
 		}
-		passwords[input.DBPoolID] = password
-		databaseNames[input.DBPoolID] = dbName
-		id := strconv.FormatInt(input.DBPoolID, 10)
+		input.DBPoolUUID = poolUUID
+		input.RootPassword = password
+		inputsByUUID[poolUUID] = input
+		databaseNames[poolUUID] = dbName
 		requests = append(requests, map[string]any{"cluster": map[string]any{
-			"displayName":  clusterDisplayName(id),
+			"displayName":  clusterDisplayName(poolUUID),
 			"rootPassword": password,
 			"region":       map[string]string{"name": p.regionName()},
 			"labels": map[string]string{
-				Drive9ManagedLabel:  "true",
-				Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
-				Drive9DBPoolIDLabel: id,
+				Drive9ManagedLabel:    "true",
+				Drive9ProviderLabel:   tenant.ProviderTiDBCloudNativeShared,
+				Drive9DBPoolUUIDLabel: poolUUID,
 			},
 			"spendingLimit": map[string]int32{"monthly": int32(input.SpendingLimitMonthly)},
 		}})
@@ -566,21 +573,22 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 	out := make([]*tenant.SharedDBPoolInfo, 0, len(created.Clusters))
 	for i := range created.Clusters {
 		info := &created.Clusters[i]
-		id, err := strconv.ParseInt(strings.TrimSpace(info.Labels[Drive9DBPoolIDLabel]), 10, 64)
-		if err != nil || id <= 0 {
-			return nil, fmt.Errorf("tidbcloud native shared batch response has invalid %s label for cluster %q", Drive9DBPoolIDLabel, info.ClusterID)
+		parsedUUID, err := uuid.Parse(strings.TrimSpace(info.Labels[Drive9DBPoolUUIDLabel]))
+		if err != nil {
+			return nil, fmt.Errorf("tidbcloud native shared batch response has invalid %s label for cluster %q", Drive9DBPoolUUIDLabel, info.ClusterID)
 		}
-		password, ok := passwords[id]
+		poolUUID := parsedUUID.String()
+		input, ok := inputsByUUID[poolUUID]
 		if !ok {
-			return nil, fmt.Errorf("tidbcloud native shared batch response returned unknown db pool id %d", id)
+			return nil, fmt.Errorf("tidbcloud native shared batch response returned unknown db pool uuid %s", poolUUID)
 		}
 		result := &tenant.SharedDBPoolInfo{
-			DBPoolID: id, ClusterID: strings.TrimSpace(info.ClusterID),
+			DBPoolID: input.DBPoolID, DBPoolUUID: poolUUID, ClusterID: strings.TrimSpace(info.ClusterID),
 			OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
-			Password:       password, DBName: databaseNames[id],
+			Password:       input.RootPassword, DBName: databaseNames[poolUUID],
 		}
 		if result.ClusterID == "" {
-			return nil, fmt.Errorf("tidbcloud native shared batch response missing cluster id for db pool %d", id)
+			return nil, fmt.Errorf("tidbcloud native shared batch response missing cluster id for db pool %s", poolUUID)
 		}
 		if !p.clusterProvisionMetadataIncomplete(info) {
 			result.Host, result.Port, err = p.resolveClusterEndpoint(info)
@@ -601,7 +609,7 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 // LoadSharedDBPoolWithCredentials finds an existing managed shared cluster by
 // its durable db-pool label, or refreshes a known cluster by ID. A nil result
 // means no matching cluster exists yet. Multiple label matches fail closed.
-func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoolID int64, clusterID string, req tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoolID int64, dbPoolUUID, clusterID string, req tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
 	publicKey := strings.TrimSpace(req.PublicKey)
 	privateKey := strings.TrimSpace(req.PrivateKey)
 	if publicKey == "" || privateKey == "" {
@@ -610,7 +618,11 @@ func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoo
 	if dbPoolID <= 0 {
 		return nil, fmt.Errorf("db pool id must be positive")
 	}
-	wantID := strconv.FormatInt(dbPoolID, 10)
+	parsedUUID, err := uuid.Parse(strings.TrimSpace(dbPoolUUID))
+	if err != nil {
+		return nil, fmt.Errorf("db pool %d has invalid uuid %q: %w", dbPoolID, dbPoolUUID, err)
+	}
+	wantUUID := parsedUUID.String()
 	var matches []clusterInfo
 	if strings.TrimSpace(clusterID) != "" {
 		info, err := p.getClusterBasicInfoWithCredentials(ctx, publicKey, privateKey, strings.TrimSpace(clusterID))
@@ -624,7 +636,7 @@ func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoo
 			return nil, err
 		}
 		for _, info := range infos {
-			if strings.TrimSpace(info.Labels[Drive9DBPoolIDLabel]) == wantID &&
+			if strings.EqualFold(strings.TrimSpace(info.Labels[Drive9DBPoolUUIDLabel]), wantUUID) &&
 				strings.TrimSpace(info.Labels[Drive9ManagedLabel]) == "true" &&
 				strings.TrimSpace(info.Labels[Drive9ProviderLabel]) == tenant.ProviderTiDBCloudNativeShared {
 				matches = append(matches, info)
@@ -635,24 +647,25 @@ func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoo
 		return nil, nil
 	}
 	if len(matches) != 1 {
-		return nil, fmt.Errorf("%w: found %d managed shared clusters for db pool %d", tenant.ErrSharedDBPoolAmbiguous, len(matches), dbPoolID)
+		return nil, fmt.Errorf("%w: found %d managed shared clusters for db pool %s", tenant.ErrSharedDBPoolAmbiguous, len(matches), wantUUID)
 	}
-	return p.sharedDBPoolInfoFromCluster(dbPoolID, &matches[0])
+	return p.sharedDBPoolInfoFromCluster(dbPoolID, wantUUID, &matches[0])
 }
 
-func (p *Provisioner) sharedDBPoolInfoFromCluster(dbPoolID int64, info *clusterInfo) (*tenant.SharedDBPoolInfo, error) {
-	wantID := strconv.FormatInt(dbPoolID, 10)
+func (p *Provisioner) sharedDBPoolInfoFromCluster(dbPoolID int64, dbPoolUUID string, info *clusterInfo) (*tenant.SharedDBPoolInfo, error) {
 	if got := strings.TrimSpace(info.Labels[Drive9ManagedLabel]); got != "true" {
 		return nil, fmt.Errorf("cluster %q has %s label %q, want %q", info.ClusterID, Drive9ManagedLabel, got, "true")
 	}
 	if got := strings.TrimSpace(info.Labels[Drive9ProviderLabel]); got != tenant.ProviderTiDBCloudNativeShared {
 		return nil, fmt.Errorf("cluster %q has %s label %q, want %q", info.ClusterID, Drive9ProviderLabel, got, tenant.ProviderTiDBCloudNativeShared)
 	}
-	if got := strings.TrimSpace(info.Labels[Drive9DBPoolIDLabel]); got != wantID {
-		return nil, fmt.Errorf("cluster %q has db pool label %q, want %q", info.ClusterID, got, wantID)
+	gotUUID, err := uuid.Parse(strings.TrimSpace(info.Labels[Drive9DBPoolUUIDLabel]))
+	if err != nil || gotUUID.String() != dbPoolUUID {
+		return nil, fmt.Errorf("cluster %q has %s label %q, want %q", info.ClusterID, Drive9DBPoolUUIDLabel,
+			info.Labels[Drive9DBPoolUUIDLabel], dbPoolUUID)
 	}
 	result := &tenant.SharedDBPoolInfo{
-		DBPoolID: dbPoolID, ClusterID: strings.TrimSpace(info.ClusterID),
+		DBPoolID: dbPoolID, DBPoolUUID: dbPoolUUID, ClusterID: strings.TrimSpace(info.ClusterID),
 		OrganizationID: strings.TrimSpace(info.Labels[TiDBCloudOrganizationLabel]),
 	}
 	if !p.clusterProvisionMetadataIncomplete(info) {
@@ -668,7 +681,7 @@ func (p *Provisioner) sharedDBPoolInfoFromCluster(dbPoolID int64, info *clusterI
 
 // WaitForSharedDBPoolMetadataWithCredentials reuses the existing TiDB Cloud
 // Native endpoint/user/org readiness poll for a managed shared DB pool.
-func (p *Provisioner) WaitForSharedDBPoolMetadataWithCredentials(ctx context.Context, dbPoolID int64, clusterID string, req tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+func (p *Provisioner) WaitForSharedDBPoolMetadataWithCredentials(ctx context.Context, dbPoolID int64, dbPoolUUID, clusterID string, req tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
 	publicKey := strings.TrimSpace(req.PublicKey)
 	privateKey := strings.TrimSpace(req.PrivateKey)
 	if publicKey == "" || privateKey == "" {
@@ -676,6 +689,10 @@ func (p *Provisioner) WaitForSharedDBPoolMetadataWithCredentials(ctx context.Con
 	}
 	if dbPoolID <= 0 {
 		return nil, fmt.Errorf("db pool id must be positive")
+	}
+	parsedUUID, err := uuid.Parse(strings.TrimSpace(dbPoolUUID))
+	if err != nil {
+		return nil, fmt.Errorf("db pool %d has invalid uuid %q: %w", dbPoolID, dbPoolUUID, err)
 	}
 	clusterID = strings.TrimSpace(clusterID)
 	if clusterID == "" {
@@ -685,7 +702,7 @@ func (p *Provisioner) WaitForSharedDBPoolMetadataWithCredentials(ctx context.Con
 	if err != nil {
 		return nil, err
 	}
-	return p.sharedDBPoolInfoFromCluster(dbPoolID, info)
+	return p.sharedDBPoolInfoFromCluster(dbPoolID, parsedUUID.String(), info)
 }
 
 type batchClusterMetadataTarget struct {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -545,6 +545,24 @@ func TestLoadSharedDBPoolWithClusterIDRejectsNonSharedLabels(t *testing.T) {
 	}
 }
 
+func TestSharedDBPoolInfoFromKnownClusterRejectsLegacyLocalIDLabel(t *testing.T) {
+	const poolUUID = "11111111-1111-4111-8111-111111111111"
+	p := &Provisioner{}
+	got, err := p.sharedDBPoolInfoFromCluster(41, poolUUID, &clusterInfo{
+		ClusterID: "cluster-pool-41",
+		Labels: map[string]string{
+			Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+			"drive9.ai/db_pool_id": "41", TiDBCloudOrganizationLabel: "org-1",
+		},
+	})
+	if err == nil {
+		t.Fatalf("sharedDBPoolInfoFromCluster accepted legacy local ID label: %+v", got)
+	}
+	if !strings.Contains(err.Error(), Drive9DBPoolUUIDLabel) {
+		t.Fatalf("sharedDBPoolInfoFromCluster error = %q, want missing UUID label", err)
+	}
+}
+
 func TestLoadSharedDBPoolWithoutClusterIDMatchesUUID(t *testing.T) {
 	const wantUUID = "22222222-2222-4222-8222-222222222222"
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -457,8 +457,8 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 		defaultDatabaseName: DefaultDatabaseName, client: ts.Client(),
 	}
 	got, err := p.BatchProvisionSharedDBPoolsWithCredentials(context.Background(), []tenant.SharedDBPoolCreateRequest{
-		{DBPoolID: 41, DBPoolUUID: poolUUIDs[0], RootPassword: "durable-password-41", SpendingLimitMonthly: 10_000_000},
-		{DBPoolID: 42, DBPoolUUID: poolUUIDs[1], RootPassword: "durable-password-42", SpendingLimitMonthly: 10_000_000},
+		{DBPoolID: 41, DBPoolUUID: poolUUIDs[0], RootPassword: "durable-password-41", SpendingLimitMonthly: 1_000_000},
+		{DBPoolID: 42, DBPoolUUID: poolUUIDs[1], RootPassword: "durable-password-42", SpendingLimitMonthly: 1_000_000},
 	}, tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
 	if err != nil {
 		t.Fatalf("BatchProvisionSharedDBPoolsWithCredentials: %v", err)
@@ -471,7 +471,7 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 		if request.Cluster.DisplayName != "tidbcloud-fs-"+poolUUIDs[i] {
 			t.Fatalf("request %d displayName = %q", i, request.Cluster.DisplayName)
 		}
-		if request.Cluster.RootPassword != "durable-password-"+id || request.Cluster.SpendingLimit.Monthly != 10_000_000 {
+		if request.Cluster.RootPassword != "durable-password-"+id || request.Cluster.SpendingLimit.Monthly != 1_000_000 {
 			t.Fatalf("request %d password/spending invalid: %+v", i, request.Cluster)
 		}
 		wantLabels := map[string]string{
@@ -1583,8 +1583,10 @@ func TestUpdateQuotaRejectsInvalidSpendingLimitBeforeRequest(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		monthly int64
+		wantErr string
 	}{
-		{name: "negative", monthly: -1},
+		{name: "negative", monthly: -1, wantErr: "tidbcloud_spending_limit must be non-negative"},
+		{name: "above cloud maximum", monthly: 1_000_001, wantErr: "tidbcloud_spending_limit is too large"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var hit bool
@@ -1610,7 +1612,7 @@ func TestUpdateQuotaRejectsInvalidSpendingLimitBeforeRequest(t *testing.T) {
 			if err == nil {
 				t.Fatal("UpdateQuota error = nil, want spending limit validation error")
 			}
-			if !strings.Contains(err.Error(), "tidbcloud_spending_limit must be non-negative") {
+			if !strings.Contains(err.Error(), tc.wantErr) {
 				t.Fatalf("error = %q", err)
 			}
 			if hit {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -405,6 +405,10 @@ func TestBatchProvisionFreeClustersUsesBatchCreateAndFreeLabel(t *testing.T) {
 }
 
 func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
+	poolUUIDs := []string{
+		"11111111-1111-4111-8111-111111111111",
+		"22222222-2222-4222-8222-222222222222",
+	}
 	var gotBody struct {
 		Requests []struct {
 			Cluster struct {
@@ -435,13 +439,13 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 			{
 				"clusterId": "cluster-pool-41", "state": "CREATING",
 				"labels": map[string]string{
-					TiDBCloudOrganizationLabel: "org-1", Drive9DBPoolIDLabel: "41",
+					TiDBCloudOrganizationLabel: "org-1", Drive9DBPoolUUIDLabel: poolUUIDs[0],
 				},
 			},
 			{
 				"clusterId": "cluster-pool-42", "state": "CREATING",
 				"labels": map[string]string{
-					TiDBCloudOrganizationLabel: "org-1", Drive9DBPoolIDLabel: "42",
+					TiDBCloudOrganizationLabel: "org-1", Drive9DBPoolUUIDLabel: poolUUIDs[1],
 				},
 			},
 		}})
@@ -453,8 +457,8 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 		defaultDatabaseName: DefaultDatabaseName, client: ts.Client(),
 	}
 	got, err := p.BatchProvisionSharedDBPoolsWithCredentials(context.Background(), []tenant.SharedDBPoolCreateRequest{
-		{DBPoolID: 41, RootPassword: "durable-password-41", SpendingLimitMonthly: 10_000_000},
-		{DBPoolID: 42, RootPassword: "durable-password-42", SpendingLimitMonthly: 10_000_000},
+		{DBPoolID: 41, DBPoolUUID: poolUUIDs[0], RootPassword: "durable-password-41", SpendingLimitMonthly: 10_000_000},
+		{DBPoolID: 42, DBPoolUUID: poolUUIDs[1], RootPassword: "durable-password-42", SpendingLimitMonthly: 10_000_000},
 	}, tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
 	if err != nil {
 		t.Fatalf("BatchProvisionSharedDBPoolsWithCredentials: %v", err)
@@ -464,7 +468,7 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 	}
 	for i, request := range gotBody.Requests {
 		id := fmt.Sprintf("%d", 41+i)
-		if request.Cluster.DisplayName != "tidbcloud-fs-"+id {
+		if request.Cluster.DisplayName != "tidbcloud-fs-"+poolUUIDs[i] {
 			t.Fatalf("request %d displayName = %q", i, request.Cluster.DisplayName)
 		}
 		if request.Cluster.RootPassword != "durable-password-"+id || request.Cluster.SpendingLimit.Monthly != 10_000_000 {
@@ -472,7 +476,7 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 		}
 		wantLabels := map[string]string{
 			Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
-			Drive9DBPoolIDLabel: id,
+			Drive9DBPoolUUIDLabel: poolUUIDs[i],
 		}
 		for key, want := range wantLabels {
 			if request.Cluster.Labels[key] != want {
@@ -483,12 +487,14 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 			t.Fatalf("request %d unexpectedly has shared lifecycle label %s", i, Drive9PoolStatusLabel)
 		}
 	}
-	if len(got) != 2 || got[0].DBPoolID != 41 || got[0].ClusterID != "cluster-pool-41" || got[1].DBPoolID != 42 || got[1].ClusterID != "cluster-pool-42" {
+	if len(got) != 2 || got[0].DBPoolID != 41 || got[0].DBPoolUUID != poolUUIDs[0] || got[0].ClusterID != "cluster-pool-41" ||
+		got[1].DBPoolID != 42 || got[1].DBPoolUUID != poolUUIDs[1] || got[1].ClusterID != "cluster-pool-42" {
 		t.Fatalf("shared pool results = %#v", got)
 	}
 }
 
 func TestLoadSharedDBPoolWithClusterIDRejectsNonSharedLabels(t *testing.T) {
+	const poolUUID = "11111111-1111-4111-8111-111111111111"
 	for _, tc := range []struct {
 		name      string
 		labels    map[string]string
@@ -498,7 +504,7 @@ func TestLoadSharedDBPoolWithClusterIDRejectsNonSharedLabels(t *testing.T) {
 			name: "wrong provider",
 			labels: map[string]string{
 				Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNative,
-				Drive9DBPoolIDLabel: "41",
+				Drive9DBPoolUUIDLabel: poolUUID,
 			},
 			wantLabel: Drive9ProviderLabel,
 		},
@@ -506,7 +512,7 @@ func TestLoadSharedDBPoolWithClusterIDRejectsNonSharedLabels(t *testing.T) {
 			name: "not managed",
 			labels: map[string]string{
 				Drive9ManagedLabel: "false", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
-				Drive9DBPoolIDLabel: "41",
+				Drive9DBPoolUUIDLabel: poolUUID,
 			},
 			wantLabel: Drive9ManagedLabel,
 		},
@@ -529,7 +535,7 @@ func TestLoadSharedDBPoolWithClusterIDRejectsNonSharedLabels(t *testing.T) {
 			defer ts.Close()
 
 			p := &Provisioner{apiURL: ts.URL, client: ts.Client()}
-			_, err := p.LoadSharedDBPoolWithCredentials(context.Background(), 41, "cluster-pool-41", tenant.CredentialProvisionRequest{
+			_, err := p.LoadSharedDBPoolWithCredentials(context.Background(), 41, poolUUID, "cluster-pool-41", tenant.CredentialProvisionRequest{
 				PublicKey: "public", PrivateKey: "private",
 			})
 			if err == nil || !strings.Contains(err.Error(), tc.wantLabel) {
@@ -539,7 +545,47 @@ func TestLoadSharedDBPoolWithClusterIDRejectsNonSharedLabels(t *testing.T) {
 	}
 }
 
+func TestLoadSharedDBPoolWithoutClusterIDMatchesUUID(t *testing.T) {
+	const wantUUID = "22222222-2222-4222-8222-222222222222"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-shared-list", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"clusters": []map[string]any{
+			{
+				"clusterId": "cluster-other", "state": "ACTIVE",
+				"labels": map[string]string{
+					Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+					Drive9DBPoolUUIDLabel: "11111111-1111-4111-8111-111111111111",
+				},
+			},
+			{
+				"clusterId": "cluster-wanted", "state": "ACTIVE",
+				"labels": map[string]string{
+					Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+					Drive9DBPoolUUIDLabel: wantUUID, TiDBCloudOrganizationLabel: "org-1",
+				},
+			},
+		}})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{apiURL: ts.URL, client: ts.Client()}
+	got, err := p.LoadSharedDBPoolWithCredentials(context.Background(), 41, wantUUID, "", tenant.CredentialProvisionRequest{
+		PublicKey: "public", PrivateKey: "private",
+	})
+	if err != nil {
+		t.Fatalf("LoadSharedDBPoolWithCredentials: %v", err)
+	}
+	if got == nil || got.DBPoolID != 41 || got.DBPoolUUID != wantUUID || got.ClusterID != "cluster-wanted" {
+		t.Fatalf("shared DB pool = %+v", got)
+	}
+}
+
 func TestWaitForSharedDBPoolMetadataUsesNativeReadinessPoll(t *testing.T) {
+	const poolUUID = "11111111-1111-4111-8111-111111111111"
 	origPoll := tidbCloudNativePollInterval
 	tidbCloudNativePollInterval = time.Millisecond
 	t.Cleanup(func() { tidbCloudNativePollInterval = origPoll })
@@ -559,7 +605,7 @@ func TestWaitForSharedDBPoolMetadataUsesNativeReadinessPoll(t *testing.T) {
 			"clusterId": "cluster-pool-41", "state": "ACTIVE",
 			"labels": map[string]string{
 				Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
-				Drive9DBPoolIDLabel: "41", TiDBCloudOrganizationLabel: "org-1",
+				Drive9DBPoolUUIDLabel: poolUUID, TiDBCloudOrganizationLabel: "org-1",
 			},
 		}
 		if authorizedGets.Add(1) > 1 {
@@ -571,7 +617,7 @@ func TestWaitForSharedDBPoolMetadataUsesNativeReadinessPoll(t *testing.T) {
 	defer ts.Close()
 
 	p := &Provisioner{apiURL: ts.URL, client: ts.Client()}
-	got, err := p.WaitForSharedDBPoolMetadataWithCredentials(context.Background(), 41, "cluster-pool-41",
+	got, err := p.WaitForSharedDBPoolMetadataWithCredentials(context.Background(), 41, poolUUID, "cluster-pool-41",
 		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
 	if err != nil {
 		t.Fatalf("WaitForSharedDBPoolMetadataWithCredentials: %v", err)
@@ -579,7 +625,7 @@ func TestWaitForSharedDBPoolMetadataUsesNativeReadinessPoll(t *testing.T) {
 	if authorizedGets.Load() != 2 {
 		t.Fatalf("authorized GETs = %d, want 2", authorizedGets.Load())
 	}
-	if got.DBPoolID != 41 || got.ClusterID != "cluster-pool-41" || got.OrganizationID != "org-1" ||
+	if got.DBPoolID != 41 || got.DBPoolUUID != poolUUID || got.ClusterID != "cluster-pool-41" || got.OrganizationID != "org-1" ||
 		got.Host != "shared.example" || got.Port != 4000 || got.Username != "u1.root" {
 		t.Fatalf("shared DB pool metadata = %+v", got)
 	}


### PR DESCRIPTION
## Summary
- persist and backfill a globally unique UUID for every shared DB pool, then create `uk_db_pool_uuid` after backfill with an idempotent migration that supports direct upgrades and partial-restart recovery
- use the UUID for TiDB Cloud display names, labels, batch correlation, adoption, recovery, shared DB pool metrics, and shared SQL connection-pool metrics
- resume a known pre-upgrade cluster by its legacy local-ID label only when `cluster_id` is already persisted; label-scan discovery remains UUID-only to avoid cross-server ID collisions
- fix managed shared DB physical spending limit at the TiDB Cloud maximum `1_000_000` ($10,000), normalize existing persisted targets during migration, and keep per-tenant values as compatibility-only virtual metadata
- remove tenant virtual spending-limit sum/headroom from allocation, reservation, claim, quota checks, and DB-pool metrics

## Test Plan
- `go test ./pkg/meta -count=1`
- `go test ./pkg/server -run 'Shared|QuotaSetRejectsInvalidQuotaValues' -count=1`\n- `go test ./pkg/tenant/tidbcloudnative ./pkg/metrics ./pkg/mysqlutil ./pkg/tenant ./cmd/drive9-server -count=1`\n- `go build ./...`\n- `make lint`\n- runbooks PR #2685: `make check-rules`