### PR TITLE
fix: recover first shared tenant and unify admin APIs

### DIFF
--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -37,6 +37,11 @@ const (
 	SchemaShapeShared     = "shared"
 )
 
+// PlacementStatusDeleting retains the physical resource identity while a
+// durable tenant cleanup job is still running. Capacity has already been
+// released, so allocators must not treat this row as active inventory.
+const PlacementStatusDeleting = "deleting"
+
 const (
 	SharedDBStatusProvisioning = "provisioning"
 	SharedDBStatusActive       = "active"
@@ -1191,50 +1196,108 @@ func (s *Store) DeleteTenantPlacementAndDecrCount(ctx context.Context, fsID, dbI
 		return err
 	}
 	return s.InTx(ctx, func(tx *sql.Tx) error {
-		res, err := tx.ExecContext(ctx, `DELETE FROM tenant_placements WHERE fs_id = ?`, fsID)
-		if err != nil {
-			return fmt.Errorf("delete tenant placement for fs_id %d: %w", fsID, err)
+		return releaseTenantPlacementAndDecrCountTx(ctx, tx, fsID, dbID, reopenRatio, true)
+	})
+}
+
+// FinalizeSharedTenantDeleteMetadata atomically releases shared DB capacity
+// and logical-pool membership. Tenants requiring external cleanup retain a
+// deleting placement as their authorization anchor until job finalization;
+// tenants without external cleanup remove placement and become deleted in the
+// same transaction. A failed transition always retains the active placement.
+func (s *Store) FinalizeSharedTenantDeleteMetadata(ctx context.Context, tenantID string, fsID, dbID int64, reopenRatio float64, markDeleted bool) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "finalize_shared_tenant_delete_metadata", start, &err)
+	if strings.TrimSpace(tenantID) == "" {
+		return fmt.Errorf("tenant id is required")
+	}
+	if fsID <= 0 {
+		return fmt.Errorf("fs_id must be positive")
+	}
+	if dbID <= 0 {
+		return fmt.Errorf("db_id must be positive")
+	}
+	if _, err := SharedDBReopenThresholdForRatio(1, reopenRatio); err != nil {
+		return err
+	}
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		if err := releaseTenantPlacementAndDecrCountTx(ctx, tx, fsID, dbID, reopenRatio, markDeleted); err != nil {
+			return err
 		}
-		affected, err := res.RowsAffected()
-		if err != nil {
-			return fmt.Errorf("delete tenant placement rows affected for fs_id %d: %w", fsID, err)
+		if _, err := tx.ExecContext(ctx, `DELETE FROM tenant_pool_memberships WHERE tenant_id = ?`, tenantID); err != nil {
+			return fmt.Errorf("delete tenant pool membership for %s: %w", tenantID, err)
 		}
-		if affected == 0 {
-			return ErrNotFound
+		if !markDeleted {
+			return nil
 		}
-		var maxTenants, tenantCount int
-		var softCapReached bool
-		if err := tx.QueryRowContext(ctx, `SELECT max_tenants, tenant_count, soft_cap_reached FROM db_pool WHERE db_id = ? FOR UPDATE`, dbID).
-			Scan(&maxTenants, &tenantCount, &softCapReached); err != nil {
-			if errors.Is(err, sql.ErrNoRows) {
-				return ErrNotFound
-			}
-			return fmt.Errorf("lock capacity for db %d: %w", dbID, err)
-		}
-		reopenThreshold, err := SharedDBReopenThresholdForRatio(maxTenants, reopenRatio)
+		now := time.Now().UTC()
+		res, err := tx.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ? WHERE id = ?`, TenantDeleted, now, tenantID)
 		if err != nil {
 			return err
 		}
-		newTenantCount := tenantCount - 1
-		if newTenantCount < 0 {
-			newTenantCount = 0
+		if err := requireAffected(res); err != nil {
+			return err
 		}
-		nextSoftCapReached := softCapReached
-		if maxTenants > 0 && newTenantCount <= reopenThreshold {
-			nextSoftCapReached = false
+		if _, err := tx.ExecContext(ctx, `DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?`, tenantID); err != nil {
+			return err
 		}
-		_, err = tx.ExecContext(ctx, `UPDATE db_pool
-			SET soft_cap_reached = ?, tenant_count = ?
-			WHERE db_id = ?`, nextSoftCapReached, newTenantCount, dbID)
-		if err != nil {
-			return fmt.Errorf("release capacity on db %d: %w", dbID, err)
-		}
-		// The SELECT ... FOR UPDATE above already established that the pool
-		// exists. RowsAffected may be zero when the delete leaves both values
-		// unchanged (for example an already-zero counter), which is still a
-		// valid atomic placement release.
 		return nil
 	})
+}
+
+func releaseTenantPlacementAndDecrCountTx(ctx context.Context, tx *sql.Tx, fsID, dbID int64, reopenRatio float64, deletePlacement bool) error {
+	var (
+		res sql.Result
+		err error
+	)
+	if deletePlacement {
+		res, err = tx.ExecContext(ctx, `DELETE FROM tenant_placements WHERE fs_id = ? AND db_id = ?`, fsID, dbID)
+	} else {
+		res, err = tx.ExecContext(ctx, `UPDATE tenant_placements SET status = ?
+			WHERE fs_id = ? AND db_id = ? AND status <> ?`, PlacementStatusDeleting, fsID, dbID, PlacementStatusDeleting)
+	}
+	if err != nil {
+		return fmt.Errorf("release tenant placement for fs_id %d: %w", fsID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("delete tenant placement rows affected for fs_id %d: %w", fsID, err)
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	var maxTenants, tenantCount int
+	var softCapReached bool
+	if err := tx.QueryRowContext(ctx, `SELECT max_tenants, tenant_count, soft_cap_reached FROM db_pool WHERE db_id = ? FOR UPDATE`, dbID).
+		Scan(&maxTenants, &tenantCount, &softCapReached); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return fmt.Errorf("lock capacity for db %d: %w", dbID, err)
+	}
+	reopenThreshold, err := SharedDBReopenThresholdForRatio(maxTenants, reopenRatio)
+	if err != nil {
+		return err
+	}
+	newTenantCount := tenantCount - 1
+	if newTenantCount < 0 {
+		newTenantCount = 0
+	}
+	nextSoftCapReached := softCapReached
+	if maxTenants > 0 && newTenantCount <= reopenThreshold {
+		nextSoftCapReached = false
+	}
+	_, err = tx.ExecContext(ctx, `UPDATE db_pool
+			SET soft_cap_reached = ?, tenant_count = ?
+			WHERE db_id = ?`, nextSoftCapReached, newTenantCount, dbID)
+	if err != nil {
+		return fmt.Errorf("release capacity on db %d: %w", dbID, err)
+	}
+	// The SELECT ... FOR UPDATE above already established that the pool
+	// exists. RowsAffected may be zero when the delete leaves both values
+	// unchanged (for example an already-zero counter), which is still a
+	// valid atomic placement release.
+	return nil
 }
 
 // scanSharedDBRow scans one db_pool row selected with sharedDBSelectColumns.

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -1301,6 +1301,78 @@ func TestDeleteTenantPlacementAndDecrCountUsesReopenRatio(t *testing.T) {
 	}
 }
 
+func TestFinalizeSharedTenantDeleteMetadataIsAtomic(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-finalize-delete", Host: "h", Port: 4000, User: "u",
+		PasswordCipher: []byte("c"), Name: "finalize_delete_db",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedPendingTenant(t, s, "tenant-finalize-delete")
+	fsID, err := s.EnsureFsID(ctx, "tenant-finalize-delete")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CompleteSharedTenantProvision(ctx, "tenant-finalize-delete", tidbCloudNativeSharedProvider, &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-finalize-delete")); err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.FinalizeSharedTenantDeleteMetadata(ctx, "missing-tenant", fsID, dbID, 0.8, true)
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("FinalizeSharedTenantDeleteMetadata error = %v, want ErrNotFound", err)
+	}
+	if _, err := s.GetTenantPlacement(ctx, fsID); err != nil {
+		t.Fatalf("placement did not roll back: %v", err)
+	}
+	pool, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pool.TenantCount != 1 {
+		t.Fatalf("tenant count after rollback = %d, want 1", pool.TenantCount)
+	}
+
+	if err := s.FinalizeSharedTenantDeleteMetadata(ctx, "tenant-finalize-delete", fsID, dbID, 0.8, true); err != nil {
+		t.Fatalf("FinalizeSharedTenantDeleteMetadata: %v", err)
+	}
+	if _, err := s.GetTenantPlacement(ctx, fsID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("placement after finalize = %v, want ErrNotFound", err)
+	}
+	tenant, err := s.GetTenant(ctx, "tenant-finalize-delete")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tenant.Status != TenantDeleted {
+		t.Fatalf("tenant status = %s, want %s", tenant.Status, TenantDeleted)
+	}
+
+	seedPendingTenant(t, s, "tenant-finalize-job")
+	jobFsID, err := s.EnsureFsID(ctx, "tenant-finalize-job")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CompleteSharedTenantProvision(ctx, "tenant-finalize-job", tidbCloudNativeSharedProvider, &TenantPlacement{
+		FsID: jobFsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-finalize-job")); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.FinalizeSharedTenantDeleteMetadata(ctx, "tenant-finalize-job", jobFsID, dbID, 0.8, false); err != nil {
+		t.Fatalf("FinalizeSharedTenantDeleteMetadata with external cleanup: %v", err)
+	}
+	placement, err := s.GetTenantPlacement(ctx, jobFsID)
+	if err != nil {
+		t.Fatalf("authorization placement missing: %v", err)
+	}
+	if placement.Status != PlacementStatusDeleting {
+		t.Fatalf("placement status = %q, want %q", placement.Status, PlacementStatusDeleting)
+	}
+}
+
 // TestCompleteSharedTenantProvisionRollsBackOnKeyFailure covers the named
 // failure class from review: the owner key insert fails (duplicate key id)
 // inside the provision transaction, so the capacity reservation, the

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2615,16 +2615,21 @@ func (s *Store) ListTenantsByTiDBCloudResources(ctx context.Context, bindings []
 	}
 	placeholders := make([]string, 0, len(bindings))
 	resourceArgs := make([]any, 0, len(bindings)*2)
+	clusterPlaceholders := make([]string, 0, len(bindings))
+	clusterArgs := make([]any, 0, len(bindings))
 	for _, binding := range bindings {
 		placeholders = append(placeholders, "(?, ?)")
 		resourceArgs = append(resourceArgs, binding.OrganizationID, binding.ClusterID)
+		clusterPlaceholders = append(clusterPlaceholders, "?")
+		clusterArgs = append(clusterArgs, binding.ClusterID)
 	}
 	resources := strings.Join(placeholders, ",")
+	clusters := strings.Join(clusterPlaceholders, ",")
 	args := []any{TenantDeleted, tidbCloudNativeProvider}
 	args = append(args, resourceArgs...)
 	args = append(args, TenantPoolBindingFree, tidbCloudNativeSharedProvider)
-	args = append(args, resourceArgs...)
-	args = append(args, limit, offset)
+	args = append(args, clusterArgs...)
+	args = append(args, TenantPoolBindingFree, limit, offset)
 	query := `SELECT
 			t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
 			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
@@ -2643,7 +2648,11 @@ func (s *Store) ListTenantsByTiDBCloudResources(ctx context.Context, bindings []
 				JOIN tenant_placements p ON p.fs_id = f.fs_id
 				JOIN db_pool d ON d.db_id = p.db_id
 				WHERE f.tenant_id = t.id
-					AND (d.org_id, d.cluster_id) IN (` + resources + `)
+					AND d.cluster_id IN (` + clusters + `)
+					AND NOT EXISTS (
+						SELECT 1 FROM tenant_pool_memberships m
+						WHERE m.tenant_id = t.id AND m.pool_status = ?
+					)
 			))
 		)
 		ORDER BY t.created_at DESC, t.id DESC
@@ -3861,6 +3870,11 @@ func (s *Store) FinalizeTenantDelete(ctx context.Context, tenantID, namespaceID 
 			return err
 		}
 		if _, err := tx.ExecContext(ctx, `DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?`, tenantID); err != nil {
+			return err
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE p FROM tenant_placements p
+			JOIN fs_registry f ON f.fs_id = p.fs_id
+			WHERE f.tenant_id = ? AND p.status = ?`, tenantID, PlacementStatusDeleting); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2597,6 +2597,65 @@ func (s *Store) ListTenantsByTiDBCloudOrgClusterBindings(ctx context.Context, bi
 	return scanTenantBindingRows(rows)
 }
 
+// ListTenantsByTiDBCloudResources lists dedicated tenants through their
+// tenant binding and shared tenants through the physical db_pool resource.
+// Pagination is applied after both provider sources are combined.
+func (s *Store) ListTenantsByTiDBCloudResources(ctx context.Context, bindings []TenantTiDBCloudOrgBinding, offset, limit int) (out []Tenant, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_tenants_by_tidbcloud_resources", start, &err)
+	bindings = compactTiDBCloudOrgClusterBindings(bindings)
+	if len(bindings) == 0 {
+		return []Tenant{}, nil
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	placeholders := make([]string, 0, len(bindings))
+	resourceArgs := make([]any, 0, len(bindings)*2)
+	for _, binding := range bindings {
+		placeholders = append(placeholders, "(?, ?)")
+		resourceArgs = append(resourceArgs, binding.OrganizationID, binding.ClusterID)
+	}
+	resources := strings.Join(placeholders, ",")
+	args := []any{TenantDeleted, tidbCloudNativeProvider}
+	args = append(args, resourceArgs...)
+	args = append(args, TenantPoolBindingFree, tidbCloudNativeSharedProvider)
+	args = append(args, resourceArgs...)
+	args = append(args, limit, offset)
+	query := `SELECT
+			t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
+			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
+			t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
+			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at
+		FROM tenants t
+		WHERE t.status <> ? AND (
+			(t.provider = ? AND EXISTS (
+				SELECT 1 FROM tenant_tidbcloud_org_bindings b
+				WHERE b.tenant_id = t.id
+					AND (b.organization_id, b.cluster_id) IN (` + resources + `)
+					AND b.pool_status <> ?
+			)) OR
+			(t.provider = ? AND EXISTS (
+				SELECT 1 FROM fs_registry f
+				JOIN tenant_placements p ON p.fs_id = f.fs_id
+				JOIN db_pool d ON d.db_id = p.db_id
+				WHERE f.tenant_id = t.id
+					AND (d.org_id, d.cluster_id) IN (` + resources + `)
+			))
+		)
+		ORDER BY t.created_at DESC, t.id DESC
+		LIMIT ? OFFSET ?`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	return scanTenantRows(rows)
+}
+
 func compactStrings(values []string) []string {
 	out := make([]string, 0, len(values))
 	seen := make(map[string]bool, len(values))

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -787,6 +787,25 @@ func TestFinalizeTenantDeleteUpdatesJobNamespaceAndTenant(t *testing.T) {
 	if !updated {
 		t.Fatal("MarkTenantDeleteJobRunning updated = false, want true")
 	}
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-delete-finalize", Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_delete_finalize",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	fsID, err := s.EnsureFsID(ctx, "delete-finalize-tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertTenantPlacement(ctx, &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().ExecContext(ctx, "UPDATE tenant_placements SET status = ? WHERE fs_id = ?", PlacementStatusDeleting, fsID); err != nil {
+		t.Fatal(err)
+	}
 	if err := s.FinalizeTenantDelete(ctx, "delete-finalize-tenant", "delete-finalize-ns", 11, 2); err != nil {
 		t.Fatal(err)
 	}
@@ -813,6 +832,9 @@ func TestFinalizeTenantDeleteUpdatesJobNamespaceAndTenant(t *testing.T) {
 	}
 	if _, err := s.GetTenantTiDBCloudOrgBinding(ctx, "delete-finalize-tenant"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("org binding err = %v, want %v", err, ErrNotFound)
+	}
+	if _, err := s.GetTenantPlacement(ctx, fsID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("deleting placement after finalization = %v, want %v", err, ErrNotFound)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1898,9 +1898,8 @@ func tenantPoolCreateDatabaseLockKey(cred tenant.CredentialProvisionRequest) str
 
 // claimAdminTenantFromPool tries to hand out a pre-warmed tenant from the
 // caller org's tenant pool. sharedPoolMatched reports that the org has a
-// registered shared-schema pool instead — callers decide what that means
-// (admin create fails closed; the owner provision path falls through to
-// provisionTenant, which routes the tenant onto the shared pool).
+// registered shared-schema pool instead, so callers can route provisioning
+// through the shared provider.
 func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) (*provisionTenantResult, *meta.TenantPool, bool, bool, error) {
 	claimStarted := time.Now()
 	manager, ok := s.provisioner.(tenant.TenantPoolClusterManager)

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -197,22 +197,17 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_create_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted))...)
 		return
 	}
-	// The admin tenant API is cluster-centric (org binding, cluster existence
-	// checks, per-cluster quota): a tenant placed on a shared-schema DB has no
-	// per-tenant cluster and would be unmanageable through this surface. Fail
-	// closed when the caller's org matches a shared pool instead of creating
-	// a tenant with no valid admin lifecycle. (The owner provision API below
-	// routes the same org onto the shared pool instead.)
-	if sharedPoolMatched {
-		errJSON(w, http.StatusConflict, "tenant org is registered for shared-pool placement, which the admin tenant API does not support")
-		return
-	}
 	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_missed", "provider", tenant.ProviderTiDBCloudNative, "duration_ms", durationMillis(poolClaimStarted))...)
+	provider := ""
+	if sharedPoolMatched {
+		provider = tenant.ProviderTiDBCloudNativeShared
+	}
 	res, err = s.provisionTenant(r.Context(), provisionTenantOptions{
 		KeyName:               "default",
 		TokenVersion:          1,
 		CredentialProvisioner: &cred,
 		Quota:                 quotaOpt,
+		Provider:              provider,
 	})
 	if err != nil {
 		var pe *provisionTenantError
@@ -264,7 +259,7 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	includeQuota := parseBoolQuery(r, "include_quota")
-	rows, err := s.meta.ListTenantsByTiDBCloudOrgClusterBindings(r.Context(), authorizedBindings, offset, pageSize+1)
+	rows, err := s.meta.ListTenantsByTiDBCloudResources(r.Context(), authorizedBindings, offset, pageSize+1)
 	if err != nil {
 		errJSON(w, http.StatusInternalServerError, "tenant list failed")
 		return
@@ -275,12 +270,13 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 		nextPage = page + 1
 	}
 	out := make([]adminTenantResponse, 0, len(rows))
-	for _, row := range rows {
+	for i := range rows {
+		row := &rows[i]
 		var quota *adminTenantQuotaSummary
 		if includeQuota {
-			quota = s.adminTenantQuotaSummary(r.Context(), &row.Tenant)
+			quota = s.adminTenantQuotaSummary(r.Context(), row)
 		}
-		out = append(out, s.adminTenantResponse(&row.Tenant, &row.Binding, quota))
+		out = append(out, s.adminTenantResponse(row, nil, quota))
 	}
 	writeJSON(w, http.StatusOK, adminTenantListResponse{Tenants: out, Page: page, PageSize: pageSize, NextPage: nextPage})
 }
@@ -331,8 +327,14 @@ func (s *Server) handleAdminTenantQuotaSet(w http.ResponseWriter, r *http.Reques
 		errJSON(w, http.StatusConflict, err.Error())
 		return
 	}
-	if err := s.applyQuotaSet(r.Context(), "admin_tenant_quota_set", t, cred, quotaReq); err != nil {
-		writeQuotaSetError(w, r.Context(), err, "update")
+	var applyErr error
+	if t.Provider == tenant.ProviderTiDBCloudNativeShared {
+		applyErr = s.applySharedQuotaSet(r.Context(), t, quotaReq)
+	} else {
+		applyErr = s.applyQuotaSet(r.Context(), "admin_tenant_quota_set", t, cred, quotaReq)
+	}
+	if applyErr != nil {
+		writeQuotaSetError(w, r.Context(), applyErr, "update")
 		return
 	}
 	s.writeAdminQuotaResponse(w, r, t)
@@ -362,6 +364,11 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 	}
 	if t.Status == meta.TenantDeleted {
 		errJSON(w, http.StatusNotFound, "tenant not found")
+		return
+	}
+	if t.Provider == tenant.ProviderTiDBCloudNativeShared {
+		s.handleSharedTenantDelete(w, r, t)
+		s.forgetTiDBCloudRBACList(cred)
 		return
 	}
 	if t.StorageNamespaceID != "" {
@@ -443,12 +450,19 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 		errJSON(w, http.StatusInternalServerError, "tenant lookup failed")
 		return nil, nil, false
 	}
-	if t.Provider != tenant.ProviderTiDBCloudNative {
-		errJSON(w, http.StatusConflict, "admin tenant API is only supported for tidb_cloud_native tenants")
-		return nil, nil, false
-	}
 	if t.Status == meta.TenantDeleted {
 		errJSON(w, http.StatusNotFound, "tenant not found")
+		return nil, nil, false
+	}
+	if t.Provider == tenant.ProviderTiDBCloudNativeShared {
+		if _, err := s.authorizeSharedQuotaCredentials(r.Context(), t, cred, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster)); err != nil {
+			writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
+			return nil, nil, false
+		}
+		return t, nil, true
+	}
+	if t.Provider != tenant.ProviderTiDBCloudNative {
+		errJSON(w, http.StatusConflict, "admin tenant API is only supported for tidb_cloud_native or tidb_cloud_native_shared tenants")
 		return nil, nil, false
 	}
 	binding, err := s.meta.GetTenantTiDBCloudOrgBinding(r.Context(), tenantID)

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -385,7 +385,9 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	if t.Provider == tenant.ProviderTiDBCloudNativeShared {
-		s.handleSharedTenantDelete(w, r, t)
+		s.handleSharedTenantDeleteWithStatusWriter(w, r, t, func(w http.ResponseWriter, status meta.TenantStatus) {
+			writeJSON(w, http.StatusAccepted, adminTenantDeleteResponse{TenantID: t.ID, Status: string(status)})
+		})
 		s.forgetTiDBCloudRBACList(cred)
 		return
 	}
@@ -473,6 +475,15 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 		return nil, nil, false
 	}
 	if t.Provider == tenant.ProviderTiDBCloudNativeShared {
+		membership, membershipErr := s.meta.GetTenantPoolMembership(r.Context(), tenantID)
+		if membershipErr == nil && membership.PoolStatus == meta.TenantPoolBindingFree {
+			errJSON(w, http.StatusNotFound, "tenant not found")
+			return nil, nil, false
+		}
+		if membershipErr != nil && !errors.Is(membershipErr, meta.ErrNotFound) {
+			errJSON(w, http.StatusInternalServerError, "tenant pool membership lookup failed")
+			return nil, nil, false
+		}
 		if _, err := s.authorizeSharedQuotaCredentials(r.Context(), t, cred, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster)); err != nil {
 			writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
 			return nil, nil, false

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -197,11 +197,29 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_create_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted))...)
 		return
 	}
-	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_missed", "provider", tenant.ProviderTiDBCloudNative, "duration_ms", durationMillis(poolClaimStarted))...)
 	provider := ""
 	if sharedPoolMatched {
+		orgID, resolveErr := s.firstManagedOrganization(r.Context(), cred)
+		if resolveErr != nil {
+			writeAdminTiDBCloudError(w, r.Context(), resolveErr, "resolve shared tenant pool")
+			return
+		}
+		sharedDB, findErr := s.meta.FindSharedDBForOrg(r.Context(), orgID)
+		if findErr != nil {
+			errJSON(w, http.StatusInternalServerError, "shared tenant pool lookup failed")
+			return
+		}
+		if strings.TrimSpace(sharedDB.ClusterID) == "" {
+			errJSON(w, http.StatusConflict, "shared tenant pool has no TiDB Cloud cluster identity")
+			return
+		}
 		provider = tenant.ProviderTiDBCloudNativeShared
 	}
+	logProvider := tenant.ProviderTiDBCloudNative
+	if provider != "" {
+		logProvider = provider
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_missed", "provider", logProvider, "duration_ms", durationMillis(poolClaimStarted))...)
 	res, err = s.provisionTenant(r.Context(), provisionTenantOptions{
 		KeyName:               "default",
 		TokenVersion:          1,

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -60,6 +60,8 @@ type fakeProvisioner struct {
 	sharedPoolBatchRelease <-chan struct{}
 	sharedPoolWaitCalls    atomic.Int32
 	sharedPoolWaitErr      error
+	sharedPoolLoadIDs      chan int64
+	sharedPoolWaitRelease  <-chan struct{}
 }
 
 type failingEncryptor struct {
@@ -696,6 +698,143 @@ func TestRetryManagedSharedDBContinuationsAvoidsHeadOfLineBlocking(t *testing.T)
 	}
 }
 
+func TestManagedSharedDBContinuationBatchesDoNotEnterBlockingMetadataWait(t *testing.T) {
+	origWindow, origInitialBackoff, origMaxBackoff := schemaInitRetryWindow, schemaInitInitialBackoff, schemaInitMaxBackoff
+	schemaInitRetryWindow = 100 * time.Millisecond
+	schemaInitInitialBackoff = 5 * time.Millisecond
+	schemaInitMaxBackoff = 10 * time.Millisecond
+	t.Cleanup(func() {
+		schemaInitRetryWindow = origWindow
+		schemaInitInitialBackoff = origInitialBackoff
+		schemaInitMaxBackoff = origMaxBackoff
+	})
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(pool.Close)
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	createPool := func(clusterID string, provisioningByte byte) int64 {
+		t.Helper()
+		dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+			TiDBCloudOrganizationID: "org-scheduled-metadata", ProvisioningKey: bytes.Repeat([]byte{provisioningByte}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+			PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := metaStore.UpdateManagedSharedDBPoolCloudResult(context.Background(), &meta.SharedDB{
+			ID: dbID, TiDBCloudOrganizationID: "org-scheduled-metadata", ClusterID: clusterID,
+			PasswordCipher: passwordCipher, Name: "tidbcloud_fs", TLSMode: "true",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		return dbID
+	}
+	firstID := createPool("cluster-scheduled-first", 1)
+	secondID := createPool("cluster-scheduled-second", 2)
+	waitRelease := make(chan struct{})
+	loadIDs := make(chan int64, 8)
+	prov := &fakeProvisioner{
+		provider:          tenant.ProviderTiDBCloudNative,
+		defaultPublicKey:  "public",
+		defaultPrivateKey: "private",
+		sharedPoolResults: []*tenant.SharedDBPoolInfo{
+			{DBPoolID: firstID, ClusterID: "cluster-scheduled-first", OrganizationID: "org-scheduled-metadata"},
+			{DBPoolID: secondID, ClusterID: "cluster-scheduled-second", OrganizationID: "org-scheduled-metadata"},
+		},
+		sharedPoolLoadIDs:     loadIDs,
+		sharedPoolWaitRelease: waitRelease,
+	}
+	workerCtx, cancel := context.WithCancel(context.Background())
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov, forkWorkerCtx: workerCtx}
+	t.Cleanup(func() {
+		cancel()
+		srv.forkWorkerWG.Wait()
+	})
+	srv.scheduleManagedSharedDBContinuations(context.Background(), []int64{firstID, secondID}, tenant.CredentialProvisionRequest{
+		PublicKey: "public", PrivateKey: "private",
+	})
+
+	select {
+	case got := <-loadIDs:
+		if got != firstID {
+			t.Fatalf("first continuation = %d, want %d", got, firstID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first continuation was not attempted")
+	}
+	select {
+	case got := <-loadIDs:
+		if got != secondID {
+			t.Fatalf("second continuation = %d, want %d", got, secondID)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("second continuation was blocked behind the first pool metadata waiter")
+	}
+	if got := prov.sharedPoolWaitCalls.Load(); got != 0 {
+		t.Fatalf("scheduled continuation metadata waiter calls = %d, want 0", got)
+	}
+	scheduledDone := make(chan struct{})
+	go func() {
+		srv.forkWorkerWG.Wait()
+		close(scheduledDone)
+	}()
+	select {
+	case <-scheduledDone:
+	case <-time.After(time.Second):
+		t.Fatal("scheduled continuation batch did not finish within its retry window")
+	}
+
+	resumeLoadIDs := make(chan int64, 8)
+	prov.sharedPoolLoadIDs = resumeLoadIDs
+	resumeCtx, cancelResume := context.WithCancel(context.Background())
+	resumeDone := make(chan struct{})
+	t.Cleanup(func() {
+		cancelResume()
+		<-resumeDone
+	})
+	go func() {
+		defer close(resumeDone)
+		srv.resumeManagedSharedDBPoolsWithCtx(resumeCtx)
+	}()
+	select {
+	case got := <-resumeLoadIDs:
+		if got != firstID {
+			t.Fatalf("first resumed continuation = %d, want %d", got, firstID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("first resumed continuation was not attempted")
+	}
+	select {
+	case got := <-resumeLoadIDs:
+		if got != secondID {
+			t.Fatalf("second resumed continuation = %d, want %d", got, secondID)
+		}
+	case <-time.After(250 * time.Millisecond):
+		t.Fatal("second resumed continuation was blocked behind the first pool metadata waiter")
+	}
+	cancelResume()
+	<-resumeDone
+}
+
 func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -871,7 +1010,13 @@ func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context
 	return out, nil
 }
 
-func (f *fakeProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context, _ int64, dbPoolUUID, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+func (f *fakeProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context, dbPoolID int64, dbPoolUUID, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+	if f.sharedPoolLoadIDs != nil {
+		select {
+		case f.sharedPoolLoadIDs <- dbPoolID:
+		default:
+		}
+	}
 	if clusterID == "" {
 		return nil, nil
 	}
@@ -885,8 +1030,15 @@ func (f *fakeProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context, _ i
 	return nil, nil
 }
 
-func (f *fakeProvisioner) WaitForSharedDBPoolMetadataWithCredentials(_ context.Context, dbPoolID int64, dbPoolUUID, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+func (f *fakeProvisioner) WaitForSharedDBPoolMetadataWithCredentials(ctx context.Context, dbPoolID int64, dbPoolUUID, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
 	f.sharedPoolWaitCalls.Add(1)
+	if f.sharedPoolWaitRelease != nil {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-f.sharedPoolWaitRelease:
+		}
+	}
 	if f.sharedPoolWaitErr != nil {
 		return nil, f.sharedPoolWaitErr
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -633,6 +633,33 @@ func TestManagedSharedDBContinuationWaitsForConnectionMetadata(t *testing.T) {
 	}
 }
 
+func TestRetryManagedSharedDBContinuationRecoversAfterMoreThanTwoFailures(t *testing.T) {
+	origWindow, origInitialBackoff, origMaxBackoff := schemaInitRetryWindow, schemaInitInitialBackoff, schemaInitMaxBackoff
+	schemaInitRetryWindow = time.Second
+	schemaInitInitialBackoff = time.Millisecond
+	schemaInitMaxBackoff = 2 * time.Millisecond
+	t.Cleanup(func() {
+		schemaInitRetryWindow = origWindow
+		schemaInitInitialBackoff = origInitialBackoff
+		schemaInitMaxBackoff = origMaxBackoff
+	})
+
+	attempts := 0
+	err := retryManagedSharedDBContinuation(context.Background(), func() error {
+		attempts++
+		if attempts <= 3 {
+			return errors.New("root authentication is not ready")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("retryManagedSharedDBContinuation error = %v", err)
+	}
+	if attempts != 4 {
+		t.Fatalf("attempts = %d, want 4", attempts)
+	}
+}
+
 func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -660,6 +660,42 @@ func TestRetryManagedSharedDBContinuationRecoversAfterMoreThanTwoFailures(t *tes
 	}
 }
 
+func TestRetryManagedSharedDBContinuationsAvoidsHeadOfLineBlocking(t *testing.T) {
+	origWindow, origInitialBackoff, origMaxBackoff := schemaInitRetryWindow, schemaInitInitialBackoff, schemaInitMaxBackoff
+	schemaInitRetryWindow = time.Second
+	schemaInitInitialBackoff = time.Millisecond
+	schemaInitMaxBackoff = 2 * time.Millisecond
+	t.Cleanup(func() {
+		schemaInitRetryWindow = origWindow
+		schemaInitInitialBackoff = origInitialBackoff
+		schemaInitMaxBackoff = origMaxBackoff
+	})
+
+	var order []string
+	firstAttempts := 0
+	states := []managedSharedDBContinuation{
+		{ctx: context.Background(), continuePool: func() error {
+			order = append(order, "first")
+			firstAttempts++
+			if firstAttempts <= 3 {
+				return errors.New("first pool is not ready")
+			}
+			return nil
+		}},
+		{ctx: context.Background(), continuePool: func() error {
+			order = append(order, "second")
+			return nil
+		}},
+	}
+	retryManagedSharedDBContinuations(context.Background(), states)
+	if len(order) < 2 || order[0] != "first" || order[1] != "second" {
+		t.Fatalf("attempt order = %#v, want second pool attempted in the first round", order)
+	}
+	if !states[0].done || states[0].lastErr != nil || !states[1].done || states[1].lastErr != nil {
+		t.Fatalf("continuation states = %#v, want both complete", states)
+	}
+}
+
 func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1409,6 +1409,56 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	wildcardTenantID := "tenant-shared-wildcard-authorized"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID: wildcardTenantID, Status: meta.TenantActive, Kind: meta.TenantKindLive,
+		Provider: tenant.ProviderTiDBCloudNativeShared, SchemaVersion: 1, DBPasswordCipher: []byte{},
+		CreatedAt: now.Add(4 * time.Second), UpdatedAt: now.Add(4 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	wildcardFsID, err := rt.meta.ResolveFsID(ctx, wildcardTenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wildcardDBID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: meta.SharedDBOrgWildcard, Host: "shared-wildcard-list.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE db_pool SET cluster_id = ? WHERE db_id = ?", "cluster-allowed", wildcardDBID); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: wildcardFsID, DbID: wildcardDBID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	freeSharedTenantID := "tenant-shared-free-member"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID: freeSharedTenantID, Status: meta.TenantActive, Kind: meta.TenantKindLive,
+		Provider: tenant.ProviderTiDBCloudNativeShared, SchemaVersion: 1, DBPasswordCipher: []byte{},
+		CreatedAt: now.Add(5 * time.Second), UpdatedAt: now.Add(5 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	freeSharedFsID, err := rt.meta.ResolveFsID(ctx, freeSharedTenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: freeSharedFsID, DbID: sharedDBID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpsertTenantPoolMembership(ctx, &meta.TenantPoolMembership{
+		TenantID: freeSharedTenantID, TiDBCloudOrganizationID: "org-1", PoolID: "shared-pool-1",
+		PoolStatus: meta.TenantPoolBindingFree,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	otherTenantID := "tenant-other-cluster"
 	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
 		ID:               otherTenantID,
@@ -1498,8 +1548,8 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if len(out.Tenants) != 2 || out.Tenants[0].TenantID != sharedTenantID || out.Tenants[1].TenantID != rt.tenantID {
-		t.Fatalf("tenants = %#v, want authorized shared tenant %s and dedicated tenant %s", out.Tenants, sharedTenantID, rt.tenantID)
+	if len(out.Tenants) != 3 || out.Tenants[0].TenantID != wildcardTenantID || out.Tenants[1].TenantID != sharedTenantID || out.Tenants[2].TenantID != rt.tenantID {
+		t.Fatalf("tenants = %#v, want wildcard shared tenant %s, shared tenant %s, and dedicated tenant %s", out.Tenants, wildcardTenantID, sharedTenantID, rt.tenantID)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1382,6 +1382,33 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	sharedTenantID := "tenant-shared-authorized"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID: sharedTenantID, Status: meta.TenantActive, Kind: meta.TenantKindLive,
+		Provider: tenant.ProviderTiDBCloudNativeShared, SchemaVersion: 1, DBPasswordCipher: []byte{},
+		CreatedAt: now.Add(3 * time.Second), UpdatedAt: now.Add(3 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	sharedFsID, err := rt.meta.ResolveFsID(ctx, sharedTenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sharedDBID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-1", Host: "shared-list.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE db_pool SET cluster_id = ? WHERE db_id = ?", "cluster-allowed", sharedDBID); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: sharedFsID, DbID: sharedDBID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	otherTenantID := "tenant-other-cluster"
 	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
 		ID:               otherTenantID,
@@ -1471,8 +1498,8 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if len(out.Tenants) != 1 || out.Tenants[0].TenantID != rt.tenantID {
-		t.Fatalf("tenants = %#v, want only authorized tenant %s", out.Tenants, rt.tenantID)
+	if len(out.Tenants) != 2 || out.Tenants[0].TenantID != sharedTenantID || out.Tenants[1].TenantID != rt.tenantID {
+		t.Fatalf("tenants = %#v, want authorized shared tenant %s and dedicated tenant %s", out.Tenants, sharedTenantID, rt.tenantID)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1551,6 +1551,21 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	if len(out.Tenants) != 3 || out.Tenants[0].TenantID != wildcardTenantID || out.Tenants[1].TenantID != sharedTenantID || out.Tenants[2].TenantID != rt.tenantID {
 		t.Fatalf("tenants = %#v, want wildcard shared tenant %s, shared tenant %s, and dedicated tenant %s", out.Tenants, wildcardTenantID, sharedTenantID, rt.tenantID)
 	}
+	freeReq, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/admin/tenants/"+freeSharedTenantID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	freeReq.Header.Set(quotaPublicKeyHeader, "public-1")
+	freeReq.Header.Set(quotaPrivateKeyHeader, "private-1")
+	freeResp, err := http.DefaultClient.Do(freeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = freeResp.Body.Close() }()
+	if freeResp.StatusCode != http.StatusNotFound {
+		body, _ := io.ReadAll(freeResp.Body)
+		t.Fatalf("free shared member get status = %d, want 404: %s", freeResp.StatusCode, body)
+	}
 }
 
 func TestAdminTenantListIncludeQuotaDoesNotBackfillSpendingLimit(t *testing.T) {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4812,6 +4812,7 @@ type provisionTenantOptions struct {
 	APIKeySource          apiKeyIssueSource
 	CredentialProvisioner *tenant.CredentialProvisionRequest
 	Quota                 *quotaRequest
+	Provider              string
 }
 
 type provisionTenantResult struct {
@@ -5218,7 +5219,7 @@ func (s *Server) provisionTenantOnSharedDBMode(ctx context.Context, tenantID str
 		return fail(provisionErr)
 	}
 	metricEvent(ctx, "metadb_query", "api", "insert_api_key", "result", "ok")
-	logger.Info(ctx, "server_event", eventFields(ctx, "provision_shared_pool_placed", "tenant_id", tenantID, "provider", tenant.ProviderTiDBCloudNativeShared, "db_id", sharedDB.ID, "org_id", sharedDB.TiDBCloudOrganizationID)...)
+	logger.Info(ctx, "server_event", eventFields(ctx, "provision_shared_pool_placed", "tenant_id", tenantID, "provider", tenant.ProviderTiDBCloudNativeShared, "db_pool_id", sharedDB.ID, "db_pool_uuid", sharedDB.UUID, "tidbcloud_org_id", sharedDB.TiDBCloudOrganizationID)...)
 	metricEvent(ctx, "tenant_provision", "provider", tenant.ProviderTiDBCloudNativeShared, "result", "shared_pool")
 	status := meta.TenantActive
 	if sharedDB.Status == meta.SharedDBStatusProvisioning {
@@ -5235,6 +5236,9 @@ func (s *Server) provisionTenantOnSharedDBMode(ctx context.Context, tenantID str
 
 func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOptions) (*provisionTenantResult, error) {
 	rawProvider := s.defaultTenantProvider
+	if opts.Provider != "" {
+		rawProvider = opts.Provider
+	}
 	provider, err := tenant.NormalizeProvider(rawProvider)
 	if err != nil {
 		logger.Warn(ctx, "server_event", eventFields(ctx, "provision_provider_invalid", "provider", rawProvider, "error", err)...)

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -226,6 +226,7 @@ func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs
 	ids := append([]int64(nil), dbIDs...)
 	slices.Sort(ids)
 	s.startServerWorker(ctx, func(workerCtx context.Context) {
+		states := make([]managedSharedDBContinuation, 0, len(ids))
 		for _, dbID := range ids {
 			if workerCtx.Err() != nil {
 				return
@@ -238,46 +239,87 @@ func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs
 					zap.String("tidbcloud_org_id", poolInfo.TiDBCloudOrganizationID),
 				))
 			}
-			err := retryManagedSharedDBContinuation(poolCtx, func() error {
-				poolInfo, loadErr := s.meta.GetSharedDB(poolCtx, dbID)
+			id := dbID
+			states = append(states, managedSharedDBContinuation{ctx: poolCtx, continuePool: func() error {
+				poolInfo, loadErr := s.meta.GetSharedDB(poolCtx, id)
 				if loadErr != nil {
 					return loadErr
 				}
 				if poolInfo.Status != meta.SharedDBStatusProvisioning {
 					return nil
 				}
-				return s.continueManagedSharedDBPool(poolCtx, dbID, cred)
-			})
-			if err != nil && poolCtx.Err() == nil {
-				logger.Warn(poolCtx, "managed_shared_db_pool_continue_failed", zap.Error(err))
+				return s.continueManagedSharedDBPool(poolCtx, id, cred)
+			}})
+		}
+		retryManagedSharedDBContinuations(workerCtx, states)
+		for i := range states {
+			if !states[i].done && states[i].lastErr != nil && states[i].ctx.Err() == nil {
+				logger.Warn(states[i].ctx, "managed_shared_db_pool_continue_failed", zap.Error(states[i].lastErr))
 			}
 		}
 	})
 }
 
+type managedSharedDBContinuation struct {
+	ctx          context.Context
+	continuePool func() error
+	done         bool
+	lastErr      error
+}
+
 func retryManagedSharedDBContinuation(ctx context.Context, continuePool func() error) error {
+	states := []managedSharedDBContinuation{{ctx: ctx, continuePool: continuePool}}
+	retryManagedSharedDBContinuations(ctx, states)
+	return states[0].lastErr
+}
+
+func retryManagedSharedDBContinuations(ctx context.Context, states []managedSharedDBContinuation) {
 	deadline := time.Now().Add(schemaInitRetryWindow)
 	backoff := schemaInitInitialBackoff
 	attempt := 1
 	for {
-		err := continuePool()
-		if err == nil {
-			return nil
+		pending := 0
+		for i := range states {
+			if states[i].done {
+				continue
+			}
+			if err := states[i].continuePool(); err == nil {
+				states[i].done = true
+				states[i].lastErr = nil
+				continue
+			} else {
+				states[i].lastErr = err
+				pending++
+			}
+		}
+		if pending == 0 {
+			return
 		}
 		remaining := time.Until(deadline)
 		if remaining <= 0 {
-			return err
+			return
 		}
-		logger.Warn(ctx, "managed_shared_db_pool_continue_retry",
-			zap.Int("attempt", attempt),
-			zap.Duration("retry_in", min(backoff, remaining)),
-			zap.Duration("remaining", remaining),
-			zap.Error(err))
-		timer := time.NewTimer(min(backoff, remaining))
+		retryIn := min(backoff, remaining)
+		for i := range states {
+			if states[i].done || states[i].lastErr == nil {
+				continue
+			}
+			logger.Warn(states[i].ctx, "managed_shared_db_pool_continue_retry",
+				zap.Int("attempt", attempt),
+				zap.Duration("retry_in", retryIn),
+				zap.Duration("remaining", remaining),
+				zap.Error(states[i].lastErr))
+		}
+		timer := time.NewTimer(retryIn)
 		select {
 		case <-ctx.Done():
 			timer.Stop()
-			return ctx.Err()
+			for i := range states {
+				if !states[i].done {
+					states[i].lastErr = ctx.Err()
+				}
+			}
+			return
 		case <-timer.C:
 		}
 		if backoff < schemaInitMaxBackoff {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -230,26 +230,61 @@ func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs
 			if workerCtx.Err() != nil {
 				return
 			}
-			for attempt := 0; attempt < 2; attempt++ {
-				err := s.continueManagedSharedDBPool(workerCtx, dbID, cred)
-				if err == nil {
-					break
+			poolCtx := workerCtx
+			if poolInfo, err := s.meta.GetSharedDB(workerCtx, dbID); err == nil {
+				poolCtx = logger.WithContext(workerCtx, logger.FromContext(workerCtx).With(
+					zap.Int64("db_pool_id", poolInfo.ID),
+					zap.String("db_pool_uuid", poolInfo.UUID),
+					zap.String("tidbcloud_org_id", poolInfo.TiDBCloudOrganizationID),
+				))
+			}
+			err := retryManagedSharedDBContinuation(poolCtx, func() error {
+				poolInfo, loadErr := s.meta.GetSharedDB(poolCtx, dbID)
+				if loadErr != nil {
+					return loadErr
 				}
-				if attempt == 1 {
-					logger.Warn(workerCtx, "managed_shared_db_pool_continue_failed",
-						zap.Int64("db_pool_id", dbID), zap.Error(err))
-					break
+				if poolInfo.Status != meta.SharedDBStatusProvisioning {
+					return nil
 				}
-				timer := time.NewTimer(time.Second)
-				select {
-				case <-workerCtx.Done():
-					timer.Stop()
-					return
-				case <-timer.C:
-				}
+				return s.continueManagedSharedDBPool(poolCtx, dbID, cred)
+			})
+			if err != nil && poolCtx.Err() == nil {
+				logger.Warn(poolCtx, "managed_shared_db_pool_continue_failed", zap.Error(err))
 			}
 		}
 	})
+}
+
+func retryManagedSharedDBContinuation(ctx context.Context, continuePool func() error) error {
+	deadline := time.Now().Add(schemaInitRetryWindow)
+	backoff := schemaInitInitialBackoff
+	attempt := 1
+	for {
+		err := continuePool()
+		if err == nil {
+			return nil
+		}
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return err
+		}
+		logger.Warn(ctx, "managed_shared_db_pool_continue_retry",
+			zap.Int("attempt", attempt),
+			zap.Duration("retry_in", min(backoff, remaining)),
+			zap.Duration("remaining", remaining),
+			zap.Error(err))
+		timer := time.NewTimer(min(backoff, remaining))
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return ctx.Err()
+		case <-timer.C:
+		}
+		if backoff < schemaInitMaxBackoff {
+			backoff = min(backoff*2, schemaInitMaxBackoff)
+		}
+		attempt++
+	}
 }
 
 func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
@@ -268,7 +303,10 @@ func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
 		}
 		if err := s.continueManagedSharedDBPool(ctx, row.ID, *cred); err != nil {
 			logger.Warn(ctx, "managed_shared_db_pool_resume_failed",
-				zap.Int64("db_pool_id", row.ID), zap.Error(err))
+				zap.Int64("db_pool_id", row.ID),
+				zap.String("db_pool_uuid", row.UUID),
+				zap.String("tidbcloud_org_id", row.TiDBCloudOrganizationID),
+				zap.Error(err))
 		}
 	}
 }
@@ -572,7 +610,10 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 		}, cred, tenant.QuotaUpdateOptions{TiDBCloudSpendingLimitMonthly: poolInfo.SpendingLimit})
 		if patchErr != nil {
 			logger.Warn(ctx, "managed_shared_db_spending_limit_sync_failed",
-				zap.Int64("db_pool_id", dbID), zap.Error(patchErr))
+				zap.Int64("db_pool_id", dbID),
+				zap.String("db_pool_uuid", poolInfo.UUID),
+				zap.String("tidbcloud_org_id", poolInfo.TiDBCloudOrganizationID),
+				zap.Error(patchErr))
 		}
 	}
 	if err := s.meta.ActivateSharedDBPool(ctx, dbID); err != nil {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -215,10 +215,12 @@ func (s *Server) scheduleManagedSharedDBContinuation(ctx context.Context, dbID i
 	s.scheduleManagedSharedDBContinuations(ctx, []int64{dbID}, cred)
 }
 
-// scheduleManagedSharedDBContinuations runs one request batch sequentially.
-// Every continuation acquires the same organization-level named lock. Starting
-// one goroutine per DB pool would let all waiters pin dedicated meta *sql.Conn
-// values and can exhaust the connection pool before the lock holder finishes.
+// scheduleManagedSharedDBContinuations retries one request batch in rounds.
+// Each pool gets one non-blocking continuation attempt per round; metadata
+// readiness is polled by the outer backoff so one pool cannot hold the batch in
+// the provider's long waiter. Starting one goroutine per DB pool would let all
+// waiters pin dedicated meta *sql.Conn values and can exhaust the connection
+// pool before the lock holder finishes.
 func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs []int64, cred tenant.CredentialProvisionRequest) {
 	if len(dbIDs) == 0 {
 		return
@@ -231,25 +233,7 @@ func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs
 			if workerCtx.Err() != nil {
 				return
 			}
-			poolCtx := workerCtx
-			if poolInfo, err := s.meta.GetSharedDB(workerCtx, dbID); err == nil {
-				poolCtx = logger.WithContext(workerCtx, logger.FromContext(workerCtx).With(
-					zap.Int64("db_pool_id", poolInfo.ID),
-					zap.String("db_pool_uuid", poolInfo.UUID),
-					zap.String("tidbcloud_org_id", poolInfo.TiDBCloudOrganizationID),
-				))
-			}
-			id := dbID
-			states = append(states, managedSharedDBContinuation{ctx: poolCtx, continuePool: func() error {
-				poolInfo, loadErr := s.meta.GetSharedDB(poolCtx, id)
-				if loadErr != nil {
-					return loadErr
-				}
-				if poolInfo.Status != meta.SharedDBStatusProvisioning {
-					return nil
-				}
-				return s.continueManagedSharedDBPool(poolCtx, id, cred)
-			}})
+			states = append(states, s.managedSharedDBContinuation(workerCtx, dbID, cred))
 		}
 		retryManagedSharedDBContinuations(workerCtx, states)
 		for i := range states {
@@ -265,6 +249,27 @@ type managedSharedDBContinuation struct {
 	continuePool func() error
 	done         bool
 	lastErr      error
+}
+
+func (s *Server) managedSharedDBContinuation(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) managedSharedDBContinuation {
+	poolCtx := ctx
+	if poolInfo, err := s.meta.GetSharedDB(ctx, dbID); err == nil {
+		poolCtx = logger.WithContext(ctx, logger.FromContext(ctx).With(
+			zap.Int64("db_pool_id", poolInfo.ID),
+			zap.String("db_pool_uuid", poolInfo.UUID),
+			zap.String("tidbcloud_org_id", poolInfo.TiDBCloudOrganizationID),
+		))
+	}
+	return managedSharedDBContinuation{ctx: poolCtx, continuePool: func() error {
+		poolInfo, err := s.meta.GetSharedDB(poolCtx, dbID)
+		if err != nil {
+			return err
+		}
+		if poolInfo.Status != meta.SharedDBStatusProvisioning {
+			return nil
+		}
+		return s.continueManagedSharedDBPoolOnce(poolCtx, dbID, cred)
+	}}
 }
 
 func retryManagedSharedDBContinuation(ctx context.Context, continuePool func() error) error {
@@ -339,16 +344,17 @@ func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
 		logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.Error(err))
 		return
 	}
+	states := make([]managedSharedDBContinuation, 0, len(rows))
 	for _, row := range rows {
 		if ctx.Err() != nil {
 			return
 		}
-		if err := s.continueManagedSharedDBPool(ctx, row.ID, *cred); err != nil {
-			logger.Warn(ctx, "managed_shared_db_pool_resume_failed",
-				zap.Int64("db_pool_id", row.ID),
-				zap.String("db_pool_uuid", row.UUID),
-				zap.String("tidbcloud_org_id", row.TiDBCloudOrganizationID),
-				zap.Error(err))
+		states = append(states, s.managedSharedDBContinuation(ctx, row.ID, *cred))
+	}
+	retryManagedSharedDBContinuations(ctx, states)
+	for i := range states {
+		if !states[i].done && states[i].lastErr != nil && states[i].ctx.Err() == nil {
+			logger.Warn(states[i].ctx, "managed_shared_db_pool_resume_failed", zap.Error(states[i].lastErr))
 		}
 	}
 }

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -165,12 +165,13 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 // the same S3-namespace cleanup and key revocation as the standalone path.
 //
 // The flow is safe to retry at any point: the dispatch keys on the persisted
-// provider (durable), the purge is idempotent, and the placement row is only
-// removed after the purge has succeeded — a retry that finds no placement
-// skips straight to the cleanup enqueue. Identity resolution is read-only
+// provider (durable), the purge is idempotent, and external cleanup retains a
+// deleting placement as the physical-resource authorization anchor until the
+// cleanup worker reaches the terminal state. Identity resolution is read-only
 // (ResolveFsID): a delete path must never allocate a new fs_id.
 func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request, t *meta.Tenant) {
 	ctx := r.Context()
+	deleteJobExists := false
 	if t.StorageNamespaceID != "" {
 		hasFork, err := s.meta.NamespaceHasNonDeletedFork(ctx, t.StorageNamespaceID)
 		if err != nil {
@@ -188,11 +189,7 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 			errJSON(w, http.StatusInternalServerError, "failed to check tenant delete cleanup")
 			return
 		}
-		if hasJob {
-			_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
-			writeTenantDeleteStatus(w, meta.TenantDeleting)
-			return
-		}
+		deleteJobExists = hasJob
 	}
 	if t.Status != meta.TenantDeleting {
 		updated, err := s.meta.UpdateTenantStatusIf(ctx, t.ID, t.Status, meta.TenantDeleting)
@@ -223,46 +220,50 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 		errJSON(w, http.StatusInternalServerError, "failed to resolve tenant placement")
 		return
 	}
+	if deleteJobExists && placement != nil && placement.Status == meta.PlacementStatusDeleting {
+		_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
+		writeTenantDeleteStatus(w, meta.TenantDeleting)
+		return
+	}
 	if placement != nil {
-		if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
-			// Do not roll back the deleting mark; the purge is resumable and the
-			// next delete request will continue it.
-			logger.Error(ctx, "shared_tenant_purge_failed", zap.String("tenant_id", t.ID), zap.Int64("db_id", placement.DbID), zap.Error(err))
-			errJSON(w, http.StatusInternalServerError, "failed to purge tenant data from shared db")
-			return
+		if placement.Status != meta.PlacementStatusDeleting {
+			if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
+				// Do not roll back the deleting mark; the purge is resumable and the
+				// next delete request will continue it.
+				logger.Error(ctx, "shared_tenant_purge_failed", zap.String("tenant_id", t.ID), zap.Int64("db_id", placement.DbID), zap.Error(err))
+				errJSON(w, http.StatusInternalServerError, "failed to purge tenant data from shared db")
+				return
+			}
+
+			_ = s.meta.AbortActiveUploadReservations(ctx, t.ID)
+			markDeleted := t.StorageNamespaceID == ""
+			if err := s.meta.FinalizeSharedTenantDeleteMetadata(ctx, t.ID, fsID, placement.DbID, s.sharedDBReopenRatio, markDeleted); err != nil {
+				logger.Error(ctx, "shared_tenant_metadata_finalize_failed", zap.String("tenant_id", t.ID), zap.Error(err))
+				errJSON(w, http.StatusInternalServerError, "failed to finalize shared tenant deletion")
+				return
+			}
+			if markDeleted {
+				_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
+				writeTenantDeleteStatus(w, meta.TenantDeleted)
+				return
+			}
 		}
-		// Placement removal and the capacity release are one durable
-		// transition: if it fails, the tenant stays deleting with the
-		// placement intact so the retry re-runs the (idempotent) purge and
-		// completes the removal — a placement row must never outlive its
-		// tenant or lose its capacity accounting.
-		if err := s.meta.DeleteTenantPlacementAndDecrCount(ctx, fsID, placement.DbID, s.sharedDBReopenRatio); err != nil {
-			logger.Error(ctx, "shared_tenant_placement_delete_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-			errJSON(w, http.StatusInternalServerError, "failed to remove tenant placement")
-			return
+
+		status := meta.TenantDeleting
+		if !deleteJobExists {
+			var enqueueErr error
+			status, enqueueErr = s.enqueueTenantDeleteJob(ctx, t)
+			if enqueueErr != nil {
+				errJSON(w, http.StatusInternalServerError, "failed to enqueue tenant delete cleanup")
+				return
+			}
 		}
-	}
-	// Capacity is released before membership removal on purpose: if this
-	// delete fails, the retry-safe tenant remains deleting without hiding a
-	// slot that is already available to other allocations.
-	if err := s.meta.DeleteTenantPoolMembership(ctx, t.ID); err != nil {
-		logger.Error(ctx, "shared_tenant_pool_membership_delete_failed", zap.String("tenant_id", t.ID), zap.Error(err))
-		errJSON(w, http.StatusInternalServerError, "failed to remove shared tenant pool membership")
+		_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
+		writeTenantDeleteStatus(w, status)
 		return
 	}
-	// A missing placement here means an earlier attempt already purged and
-	// removed it but failed before enqueueing cleanup — fall through to the
-	// enqueue so the retry completes the delete.
-
-	_ = s.meta.AbortActiveUploadReservations(ctx, t.ID)
-
-	status, err := s.enqueueTenantDeleteJob(ctx, t)
-	if err != nil {
-		errJSON(w, http.StatusInternalServerError, "failed to enqueue tenant delete cleanup")
-		return
-	}
-	_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
-	writeTenantDeleteStatus(w, status)
+	logger.Error(ctx, "shared_tenant_delete_placement_missing", zap.String("tenant_id", t.ID), zap.Int64("fs_id", fsID))
+	errJSON(w, http.StatusInternalServerError, "shared tenant placement is missing")
 }
 
 func (s *Server) enqueueTenantDeleteJob(ctx context.Context, t *meta.Tenant) (meta.TenantStatus, error) {

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -170,6 +170,15 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 // cleanup worker reaches the terminal state. Identity resolution is read-only
 // (ResolveFsID): a delete path must never allocate a new fs_id.
 func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request, t *meta.Tenant) {
+	s.handleSharedTenantDeleteWithStatusWriter(w, r, t, writeTenantDeleteStatus)
+}
+
+func (s *Server) handleSharedTenantDeleteWithStatusWriter(
+	w http.ResponseWriter,
+	r *http.Request,
+	t *meta.Tenant,
+	writeStatus func(http.ResponseWriter, meta.TenantStatus),
+) {
 	ctx := r.Context()
 	deleteJobExists := false
 	if t.StorageNamespaceID != "" {
@@ -198,7 +207,7 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 			return
 		}
 		if !updated {
-			writeTenantDeleteStatus(w, meta.TenantDeleting)
+			writeStatus(w, meta.TenantDeleting)
 			return
 		}
 	}
@@ -222,7 +231,7 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 	}
 	if deleteJobExists && placement != nil && placement.Status == meta.PlacementStatusDeleting {
 		_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
-		writeTenantDeleteStatus(w, meta.TenantDeleting)
+		writeStatus(w, meta.TenantDeleting)
 		return
 	}
 	if placement != nil {
@@ -244,7 +253,7 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 			}
 			if markDeleted {
 				_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
-				writeTenantDeleteStatus(w, meta.TenantDeleted)
+				writeStatus(w, meta.TenantDeleted)
 				return
 			}
 		}
@@ -259,7 +268,7 @@ func (s *Server) handleSharedTenantDelete(w http.ResponseWriter, r *http.Request
 			}
 		}
 		_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
-		writeTenantDeleteStatus(w, status)
+		writeStatus(w, status)
 		return
 	}
 	logger.Error(ctx, "shared_tenant_delete_placement_missing", zap.String("tenant_id", t.ID), zap.Int64("fs_id", fsID))

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -219,15 +219,11 @@ func TestSharedTenantDeleteFullPurgePath(t *testing.T) {
 	}
 }
 
-// TestAdminTenantCreateRejectsSharedPoolOrg proves the admin tenant API fails
-// closed when the caller's org matches a registered shared pool: no claim, no
-// provision, no tenant row — instead of creating a shared tenant with no
-// valid admin lifecycle.
-func TestAdminTenantCreateRejectsSharedPoolOrg(t *testing.T) {
+func TestAdminTenantCreateUsesRegisteredSharedPool(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{
-		{Clusters: []tenant.CloudClusterInfo{{OrganizationID: "org-shared-1"}}},
+		{Clusters: []tenant.CloudClusterInfo{{ClusterID: "cluster-org-probe", OrganizationID: "org-shared-1"}}},
 	}
 	if _, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-1",
@@ -256,29 +252,42 @@ func TestAdminTenantCreateRejectsSharedPoolOrg(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusConflict {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
 	}
 	var tenantCount int
 	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenants").Scan(&tenantCount); err != nil {
 		t.Fatal(err)
 	}
-	// Only the pre-existing quota runtime tenant may exist.
-	if tenantCount != 1 {
-		t.Fatalf("tenants = %d, want 1 (no admin-created tenant)", tenantCount)
+	if tenantCount != 2 {
+		t.Fatalf("tenants = %d, want 2", tenantCount)
 	}
 }
 
-// TestAdminTenantGetRejectsSharedProvider documents the admin/shared
-// ownership contract from the other side: a shared-schema tenant (provider
-// tidb_cloud_native_shared) is rejected by admin authorization instead of
-// being managed as a dedicated cluster.
-func TestAdminTenantGetRejectsSharedProvider(t *testing.T) {
+func TestAdminTenantGetAuthorizesSharedProviderThroughPhysicalPool(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	// The server runs the cloud-native provisioner; this tenant is placed on
-	// a shared pool, so its persisted provider is the shared one.
-	if err := rt.meta.UpdateTenantProvider(context.Background(), rt.tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
+	ctx := context.Background()
+	if err := rt.meta.UpdateTenantProvider(ctx, rt.tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
 		t.Fatalf("UpdateTenantProvider: %v", err)
+	}
+	fsID, err := rt.meta.EnsureFsID(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-admin", ClusterID: "cluster-shared-admin",
+		Host: "shared.example.com", Port: 4000, User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE db_pool SET cluster_id = ? WHERE db_id = ?", "cluster-shared-admin", dbID); err != nil {
+		t.Fatalf("set shared cluster_id: %v", err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
 	}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
@@ -294,8 +303,131 @@ func TestAdminTenantGetRejectsSharedProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusConflict {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := rt.prov.getCalls.Load(); got != 1 {
+		t.Fatalf("physical pool authorization calls = %d, want 1", got)
+	}
+	cluster := rt.prov.lastClusterSnapshot()
+	if cluster == nil || cluster.ClusterID != "cluster-shared-admin" || cluster.OrganizationID != "org-shared-admin" {
+		t.Fatalf("authorized physical cluster = %#v", cluster)
+	}
+}
+
+func TestAdminTenantQuotaSetSharedUpdatesVirtualQuotaOnly(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	if err := rt.meta.UpdateTenantProvider(ctx, rt.tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
+		t.Fatalf("UpdateTenantProvider: %v", err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE tenants SET cluster_id = NULL WHERE id = ?", rt.tenantID); err != nil {
+		t.Fatalf("clear tenant cluster_id: %v", err)
+	}
+	fsID, err := rt.meta.EnsureFsID(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-admin", Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE db_pool SET cluster_id = ? WHERE db_id = ?", "cluster-shared-admin", dbID); err != nil {
+		t.Fatalf("set shared cluster_id: %v", err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+	if err := rt.meta.EnsureQuotaUsageRow(ctx, rt.tenantID); err != nil {
+		t.Fatalf("EnsureQuotaUsageRow: %v", err)
+	}
+	virtualSpendingLimit := int64(100000)
+	if err := rt.meta.SetQuotaConfig(ctx, &meta.QuotaConfig{
+		TenantID: rt.tenantID, MaxStorageBytes: meta.DefaultMaxStorageBytes(),
+		MaxFileSizeBytes: meta.DefaultMaxFileSizeBytes(), TiDBCloudSpendingLimit: &virtualSpendingLimit,
+	}); err != nil {
+		t.Fatalf("SetQuotaConfig: %v", err)
+	}
+
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+	resp := postJSON(t, ts.URL+"/v1/admin/tenants/"+rt.tenantID+"/quota", map[string]any{
+		"public_key": "pk", "private_key": "sk", "max_storage_size": int64(200),
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("physical quota mark calls = %d, want 0", got)
+	}
+	if got := rt.prov.updateCalls.Load(); got != 0 {
+		t.Fatalf("physical quota update calls = %d, want 0", got)
+	}
+	cfg, err := rt.meta.GetQuotaConfig(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatalf("GetQuotaConfig: %v", err)
+	}
+	if cfg.MaxStorageBytes != 200*quotaStorageSizeBytes {
+		t.Fatalf("MaxStorageBytes = %d, want %d", cfg.MaxStorageBytes, 200*quotaStorageSizeBytes)
+	}
+}
+
+func TestAdminTenantDeleteSharedNeverDeprovisionsPhysicalPool(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	if err := rt.meta.UpdateTenantProvider(ctx, rt.tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
+		t.Fatalf("UpdateTenantProvider: %v", err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE tenants SET cluster_id = NULL WHERE id = ?", rt.tenantID); err != nil {
+		t.Fatalf("clear tenant cluster_id: %v", err)
+	}
+	fsID, err := rt.meta.EnsureFsID(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-admin-delete", Host: "127.0.0.1", Port: 1,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE db_pool SET cluster_id = ? WHERE db_id = ?", "cluster-shared-admin-delete", dbID); err != nil {
+		t.Fatalf("set shared cluster_id: %v", err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+	req, err := http.NewRequest(http.MethodDelete, ts.URL+"/v1/admin/tenants/"+rt.tenantID,
+		bytes.NewBufferString(`{"public_key":"pk","private_key":"sk"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d for unreachable shared DB purge", resp.StatusCode, http.StatusInternalServerError)
+	}
+	if got := rt.prov.markCalls.Load(); got != 0 {
+		t.Fatalf("physical quota mark calls = %d, want 0", got)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("physical cluster deprovision calls = %d, want 0", got)
 	}
 }
 

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -21,26 +21,43 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 )
 
-// TestSharedTenantDeleteRetriesAfterPlacementRemoval covers the shared-delete
-// retry window: an earlier attempt purged the tenant's rows and removed the
-// placement but failed before enqueueing cleanup. The retried delete must not
-// fall back to the standalone/provider path (no cluster deprovision) — the
-// persisted provider routes it back to the shared path, which skips the
-// finished purge and completes the delete.
-func TestSharedTenantDeleteRetriesAfterPlacementRemoval(t *testing.T) {
+// TestSharedTenantDeleteRetriesFromDeletingPlacement covers the retry window
+// after tenant data and capacity were released but before external cleanup was
+// durably enqueued. The deleting placement retains authorization and lets the
+// same shared-provider path enqueue cleanup without touching the cluster.
+func TestSharedTenantDeleteRetriesFromDeletingPlacement(t *testing.T) {
 	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBCloudNativeShared, meta.APIKeyScopeKindOwner)
 	ctx := context.Background()
-	if _, err := rt.meta.EnsureFsID(ctx, rt.tenantID); err != nil {
+	fsID, err := rt.meta.EnsureFsID(ctx, rt.tenantID)
+	if err != nil {
 		t.Fatalf("EnsureFsID: %v", err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-delete", Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE tenant_placements SET status = ? WHERE fs_id = ?", meta.PlacementStatusDeleting, fsID); err != nil {
+		t.Fatalf("mark placement deleting: %v", err)
+	}
+	if err := rt.meta.UpsertStorageNamespace(ctx, &meta.StorageNamespace{
+		ID: "namespace-delete-retry", OwnerTenantID: rt.tenantID, Backend: "local",
+		Prefix: rt.tenantID + "/", State: meta.StorageNamespaceActive,
+	}); err != nil {
+		t.Fatalf("UpsertStorageNamespace: %v", err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE tenants SET storage_namespace_id = ? WHERE id = ?", "namespace-delete-retry", rt.tenantID); err != nil {
+		t.Fatalf("set storage namespace: %v", err)
 	}
 	if err := rt.meta.UpdateTenantStatus(ctx, rt.tenantID, meta.TenantDeleting); err != nil {
 		t.Fatal(err)
-	}
-	if err := rt.meta.UpsertTenantPoolMembership(ctx, &meta.TenantPoolMembership{
-		TenantID: rt.tenantID, TiDBCloudOrganizationID: "org-shared-delete", PoolID: "pool-shared-delete",
-		PoolStatus: meta.TenantPoolBindingUsed,
-	}); err != nil {
-		t.Fatalf("UpsertTenantPoolMembership: %v", err)
 	}
 
 	resp := rt.deleteTenant(t, nil)
@@ -53,15 +70,19 @@ func TestSharedTenantDeleteRetriesAfterPlacementRemoval(t *testing.T) {
 	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
 		t.Fatalf("deprovision calls = %d, want 0", got)
 	}
-	var status string
-	if err := rt.meta.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", rt.tenantID).Scan(&status); err != nil {
+	hasJob, err := rt.meta.TenantDeleteJobExists(ctx, rt.tenantID)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if status != string(meta.TenantDeleted) {
-		t.Fatalf("tenant status = %s, want %s", status, meta.TenantDeleted)
+	if !hasJob {
+		t.Fatal("tenant delete cleanup job was not enqueued")
 	}
-	if _, err := rt.meta.GetTenantPoolMembership(ctx, rt.tenantID); !errors.Is(err, meta.ErrNotFound) {
-		t.Fatalf("shared membership after delete = %v, want ErrNotFound", err)
+	placement, err := rt.meta.GetTenantPlacement(ctx, fsID)
+	if err != nil {
+		t.Fatalf("deleting placement after retry: %v", err)
+	}
+	if placement.Status != meta.PlacementStatusDeleting {
+		t.Fatalf("placement status = %q, want %q", placement.Status, meta.PlacementStatusDeleting)
 	}
 }
 
@@ -94,6 +115,9 @@ func TestSharedTenantDeleteWithCleanupJobShortCircuits(t *testing.T) {
 		SchemaShape: meta.SchemaShapeShared,
 	}); err != nil {
 		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE tenant_placements SET status = ? WHERE fs_id = ?", meta.PlacementStatusDeleting, fsID); err != nil {
+		t.Fatalf("mark placement deleting: %v", err)
 	}
 	if err := rt.meta.UpdateTenantStatus(ctx, rt.tenantID, meta.TenantDeleting); err != nil {
 		t.Fatal(err)
@@ -219,20 +243,21 @@ func TestSharedTenantDeleteFullPurgePath(t *testing.T) {
 	}
 }
 
-func TestAdminTenantCreateUsesRegisteredSharedPool(t *testing.T) {
+func TestAdminTenantCreateRejectsSharedPoolWithoutCloudIdentity(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
 	rt.prov.listPages = []*tenant.ManagedClusterListResult{
 		{Clusters: []tenant.CloudClusterInfo{{ClusterID: "cluster-org-probe", OrganizationID: "org-shared-1"}}},
 	}
-	if _, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-1",
 		Host:                    "shared.example.com",
 		Port:                    4000,
 		User:                    "root",
 		PasswordCipher:          []byte("cipher"),
 		Name:                    "shared_db",
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
 	}
 
@@ -252,15 +277,37 @@ func TestAdminTenantCreateUsesRegisteredSharedPool(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusAccepted {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusAccepted)
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusConflict)
 	}
 	var tenantCount int
 	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenants").Scan(&tenantCount); err != nil {
 		t.Fatal(err)
 	}
+	if tenantCount != 1 {
+		t.Fatalf("tenants = %d, want 1", tenantCount)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE db_pool SET cluster_id = ? WHERE db_id = ?", "cluster-shared-admin-create", dbID); err != nil {
+		t.Fatalf("set shared cluster identity: %v", err)
+	}
+	manageableReq, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/admin/tenants", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	manageableReq.Header.Set("Content-Type", "application/json")
+	manageableResp, err := http.DefaultClient.Do(manageableReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = manageableResp.Body.Close() }()
+	if manageableResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("manageable shared pool status = %d, want %d", manageableResp.StatusCode, http.StatusAccepted)
+	}
+	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenants").Scan(&tenantCount); err != nil {
+		t.Fatal(err)
+	}
 	if tenantCount != 2 {
-		t.Fatalf("tenants = %d, want 2", tenantCount)
+		t.Fatalf("tenants after manageable create = %d, want 2", tenantCount)
 	}
 }
 
@@ -428,6 +475,28 @@ func TestAdminTenantDeleteSharedNeverDeprovisionsPhysicalPool(t *testing.T) {
 	}
 	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
 		t.Fatalf("physical cluster deprovision calls = %d, want 0", got)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE tenant_placements SET status = ? WHERE fs_id = ?", meta.PlacementStatusDeleting, fsID); err != nil {
+		t.Fatalf("mark placement deleting: %v", err)
+	}
+	if err := rt.meta.EnqueueTenantDeleteJob(ctx, &meta.TenantDeleteJob{
+		TenantID: rt.tenantID, NamespaceID: "namespace-delete-retry", Backend: "local", Prefix: rt.tenantID + "/",
+	}); err != nil {
+		t.Fatalf("EnqueueTenantDeleteJob: %v", err)
+	}
+	retryReq, err := http.NewRequest(http.MethodDelete, ts.URL+"/v1/admin/tenants/"+rt.tenantID,
+		bytes.NewBufferString(`{"public_key":"pk","private_key":"sk"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	retryReq.Header.Set("Content-Type", "application/json")
+	retryResp, err := http.DefaultClient.Do(retryReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = retryResp.Body.Close() }()
+	if retryResp.StatusCode != http.StatusAccepted {
+		t.Fatalf("retry status = %d, want %d", retryResp.StatusCode, http.StatusAccepted)
 	}
 }
 

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -498,6 +498,13 @@ func TestAdminTenantDeleteSharedNeverDeprovisionsPhysicalPool(t *testing.T) {
 	if retryResp.StatusCode != http.StatusAccepted {
 		t.Fatalf("retry status = %d, want %d", retryResp.StatusCode, http.StatusAccepted)
 	}
+	var deleteResponse adminTenantDeleteResponse
+	if err := json.NewDecoder(retryResp.Body).Decode(&deleteResponse); err != nil {
+		t.Fatalf("decode shared admin delete response: %v", err)
+	}
+	if deleteResponse.TenantID != rt.tenantID || deleteResponse.Status != string(meta.TenantDeleting) {
+		t.Fatalf("shared admin delete response = %+v, want tenant_id %s and status %s", deleteResponse, rt.tenantID, meta.TenantDeleting)
+	}
 }
 
 // TestSharedTenantDeletePlacementRemovalFailureStaysRetryable injects a

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -1026,6 +1026,11 @@ func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) 
 	if err != nil {
 		return nil, fmt.Errorf("shared db %d: %w", dbID, err)
 	}
+	ctx = logger.WithContext(ctx, logger.FromContext(ctx).With(
+		zap.Int64("db_pool_id", info.ID),
+		zap.String("db_pool_uuid", info.UUID),
+		zap.String("tidbcloud_org_id", info.TiDBCloudOrganizationID),
+	))
 	pass, err := p.enc.Decrypt(ctx, info.PasswordCipher)
 	if err != nil {
 		return nil, fmt.Errorf("shared db %d: decrypt password: %w", dbID, err)

--- a/pkg/tenant/schema/shared.go
+++ b/pkg/tenant/schema/shared.go
@@ -3,6 +3,8 @@ package schema
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"strings"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"go.uber.org/zap"
@@ -28,6 +30,17 @@ func SharedTiDBSchemaStatements() []string {
 // SQL. A physical DB pool stores this value only after its idempotent ensure
 // succeeds, so normal opens can skip repeated DDL work.
 var CurrentSharedTiDBSchemaVersion = currentTiDBTenantSchemaVersion(SharedTiDBSchemaStatements())
+
+type sharedSchemaDiffError struct {
+	diffs []tidbSchemaDiff
+}
+
+func (e *sharedSchemaDiffError) Error() string {
+	if e == nil || len(e.diffs) == 0 {
+		return ""
+	}
+	return "shared schema contract mismatch: " + strings.Join(summarizeTiDBSchemaDiffs(e.diffs), "; ")
+}
 
 // SharedMySQLSchemaStatements is the plain-MySQL variant of
 // SharedTiDBSchemaStatements, derived by removing TiDB-only keywords. Use it
@@ -80,6 +93,9 @@ func EnsureSharedSchema(ctx context.Context, db *sql.DB) error {
 	if err := ExecSchemaStatementsParallelByTableContext(ctx, db, stmts); err != nil {
 		return err
 	}
+	if err := ensureSharedSchemaContract(ctx, db, stmts); err != nil {
+		return err
+	}
 	if !IsTiDBCluster(ctx, db) {
 		return nil
 	}
@@ -90,6 +106,43 @@ func EnsureSharedSchema(ctx context.Context, db *sql.DB) error {
 		logger.Warn(ctx, "shared_schema_optional_indexes_skipped",
 			zap.Int("skipped_count", skipped),
 			zap.String("reason", "unsupported_tidb_features"))
+	}
+	return nil
+}
+
+func ensureSharedSchemaContract(ctx context.Context, db *sql.DB, stmts []string) error {
+	spec, err := tidbSchemaSpecFromStatements(stmts)
+	if err != nil {
+		return fmt.Errorf("build shared schema contract: %w", err)
+	}
+	const maxRepairPasses = 6
+	for range maxRepairPasses {
+		diffs, _, err := diffTiDBTables(ctx, db, spec.tables)
+		if err != nil {
+			return err
+		}
+		if len(diffs) == 0 {
+			return nil
+		}
+		for _, diff := range diffs {
+			if diff.repairSQL == "" || !isSafeTiDBRepairDiff(diff) {
+				return &sharedSchemaDiffError{diffs: diffs}
+			}
+		}
+		repairs := plannedTiDBSchemaRepairs(diffs)
+		if len(repairs) == 0 {
+			return &sharedSchemaDiffError{diffs: diffs}
+		}
+		if err := applyTiDBSchemaRepairs(ctx, db, repairs); err != nil {
+			return err
+		}
+	}
+	diffs, _, err := diffTiDBTables(ctx, db, spec.tables)
+	if err != nil {
+		return err
+	}
+	if len(diffs) > 0 {
+		return &sharedSchemaDiffError{diffs: diffs}
 	}
 	return nil
 }

--- a/pkg/tenant/schema/shared.go
+++ b/pkg/tenant/schema/shared.go
@@ -37,7 +37,7 @@ type sharedSchemaDiffError struct {
 
 func (e *sharedSchemaDiffError) Error() string {
 	if e == nil || len(e.diffs) == 0 {
-		return ""
+		return "shared schema contract mismatch"
 	}
 	return "shared schema contract mismatch: " + strings.Join(summarizeTiDBSchemaDiffs(e.diffs), "; ")
 }

--- a/pkg/tenant/schema/shared_test.go
+++ b/pkg/tenant/schema/shared_test.go
@@ -95,6 +95,33 @@ func TestCurrentSharedTiDBSchemaVersionIsDerivedFromSharedStatements(t *testing.
 	}
 }
 
+func TestSharedSchemaContractUsesSharedStatementShape(t *testing.T) {
+	spec, err := tidbSchemaSpecFromStatements(SharedTiDBSchemaStatements())
+	if err != nil {
+		t.Fatalf("tidbSchemaSpecFromStatements: %v", err)
+	}
+	foundFileNodes := false
+	foundFileGCTasks := false
+	for _, table := range spec.tables {
+		switch table.name {
+		case "file_nodes":
+			foundFileNodes = true
+			idx, ok := table.indexes["idx_path"]
+			if !ok || !equalStringSlices(idx.columns, []string{"fs_id", "path_hash"}) {
+				t.Fatalf("shared file_nodes.idx_path columns = %#v, want fs_id/path_hash", idx.columns)
+			}
+		case "file_gc_tasks":
+			foundFileGCTasks = true
+			if !equalStringSlices(table.primaryKey.columns, []string{"fs_id", "task_id"}) {
+				t.Fatalf("shared file_gc_tasks primary key = %#v, want fs_id/task_id", table.primaryKey.columns)
+			}
+		}
+	}
+	if !foundFileNodes || !foundFileGCTasks {
+		t.Fatalf("shared contract missing required core tables: file_nodes=%v file_gc_tasks=%v", foundFileNodes, foundFileGCTasks)
+	}
+}
+
 // TestSharedMySQLSchemaStatementsDialect ensures the MySQL variant carries no
 // TiDB-only constructs — no CLUSTERED keyword and no VECTOR(n) column types —
 // while keeping the same 30 tables.

--- a/pkg/tenant/schema/shared_test.go
+++ b/pkg/tenant/schema/shared_test.go
@@ -2,6 +2,8 @@ package schema
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"strings"
 	"testing"
 
@@ -139,6 +141,53 @@ func TestSharedSchemaStatementsForDBSelectsMySQL(t *testing.T) {
 	for i := range want {
 		if schemaspec.NormalizeSQLFragment(got[i]) != schemaspec.NormalizeSQLFragment(want[i]) {
 			t.Errorf("statement %d differs from the MySQL variant:\nForDB: %s\nMySQL: %s", i, got[i], want[i])
+		}
+	}
+}
+
+func TestEnsureSharedSchemaRejectsExistingStandaloneTableShape(t *testing.T) {
+	db := testmysql.OpenDB(t, testDSN)
+	testmysql.ResetDB(t, db)
+	dropSharedSchemaTables(t, db)
+	t.Cleanup(func() { dropSharedSchemaTables(t, db) })
+	if _, err := db.ExecContext(context.Background(), `CREATE TABLE file_gc_tasks (
+		task_id VARCHAR(64) PRIMARY KEY,
+		file_id VARCHAR(64) NOT NULL,
+		storage_type VARCHAR(32) NOT NULL
+	)`); err != nil {
+		t.Fatalf("create standalone file_gc_tasks: %v", err)
+	}
+
+	err := EnsureSharedSchema(context.Background(), db)
+	if err == nil {
+		t.Fatal("EnsureSharedSchema succeeded with standalone file_gc_tasks shape")
+	}
+	var diffErr *sharedSchemaDiffError
+	if !errors.As(err, &diffErr) {
+		t.Fatalf("EnsureSharedSchema error = %v, want sharedSchemaDiffError", err)
+	}
+	if !strings.Contains(err.Error(), "file_gc_tasks") || !strings.Contains(err.Error(), "primary key") {
+		t.Fatalf("EnsureSharedSchema error = %v, want file_gc_tasks primary-key mismatch", err)
+	}
+}
+
+func TestEnsureSharedSchemaValidatesFreshSchema(t *testing.T) {
+	db := testmysql.OpenDB(t, testDSN)
+	testmysql.ResetDB(t, db)
+	dropSharedSchemaTables(t, db)
+	t.Cleanup(func() { dropSharedSchemaTables(t, db) })
+	if err := EnsureSharedSchema(context.Background(), db); err != nil {
+		t.Fatalf("EnsureSharedSchema fresh database: %v", err)
+	}
+}
+
+func dropSharedSchemaTables(t *testing.T, db interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}) {
+	t.Helper()
+	for _, tableName := range sharedSchemaTables {
+		if _, err := db.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+tableName); err != nil {
+			t.Fatalf("drop shared table %s: %v", tableName, err)
 		}
 	}
 }

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -712,6 +712,7 @@ type tidbColumnSpec struct {
 
 type tidbIndexSpec struct {
 	createSQL string
+	columns   []string
 }
 
 type tidbPrimaryKeySpec struct {
@@ -1957,7 +1958,10 @@ func tidbSchemaSpecFromStatements(stmts []string) (tidbSchemaSpec, error) {
 		if tables[tableIndex].indexes == nil {
 			tables[tableIndex].indexes = make(map[string]tidbIndexSpec)
 		}
-		tables[tableIndex].indexes[indexName] = tidbIndexSpec{createSQL: strings.TrimSpace(createSQL)}
+		tables[tableIndex].indexes[indexName] = tidbIndexSpec{
+			createSQL: strings.TrimSpace(createSQL),
+			columns:   parseIndexColumnList(createSQL),
+		}
 	}
 	return tidbSchemaSpec{tables: tables}, nil
 }
@@ -1983,7 +1987,10 @@ func parseCreateTableSpec(stmt string) (tidbTableSpec, bool, error) {
 			continue
 		}
 		if indexName, createSQL, ok := parseInlineIndexDefinition(tableName, def); ok {
-			indexes[indexName] = tidbIndexSpec{createSQL: createSQL}
+			indexes[indexName] = tidbIndexSpec{
+				createSQL: createSQL,
+				columns:   parseIndexColumnList(createSQL),
+			}
 			continue
 		}
 		if isConstraintDefinition(def) {
@@ -2426,7 +2433,10 @@ func diffTiDBTableMetaWithObservedIndexes(table tidbTableSpec, meta tidbTableMet
 			}
 			if observedIndexColumnsOK && isPathHashIndexName(table.name, name) {
 				observedColumns := observedIndexColumns[strings.ToLower(name)]
-				expectedColumns := expectedPathHashIndexColumns(table.name, name)
+				expectedColumns := spec.columns
+				if len(expectedColumns) == 0 {
+					expectedColumns = expectedPathHashIndexColumns(table.name, name)
+				}
 				if len(expectedColumns) > 0 && len(observedColumns) > 0 && !equalStringSlices(observedColumns, expectedColumns) {
 					diffs = append(diffs, tidbSchemaDiff{
 						kind:      tidbSchemaDiffMissingIndex,

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -2434,9 +2434,6 @@ func diffTiDBTableMetaWithObservedIndexes(table tidbTableSpec, meta tidbTableMet
 			if observedIndexColumnsOK && isPathHashIndexName(table.name, name) {
 				observedColumns := observedIndexColumns[strings.ToLower(name)]
 				expectedColumns := spec.columns
-				if len(expectedColumns) == 0 {
-					expectedColumns = expectedPathHashIndexColumns(table.name, name)
-				}
 				if len(expectedColumns) > 0 && len(observedColumns) > 0 && !equalStringSlices(observedColumns, expectedColumns) {
 					diffs = append(diffs, tidbSchemaDiff{
 						kind:      tidbSchemaDiffMissingIndex,


### PR DESCRIPTION
## Summary

- keep managed shared DB continuation retrying with the existing native schema retry window/backoff so the first tenant recovers when TiDB Cloud root authentication is not ready yet
- validate shared schema shape with the existing TiDB diff/repair primitives before persisting schema version, and add db_pool_uuid to shared DB lifecycle/schema logs
- make the existing admin tenant API treat dedicated native and native shared tenants uniformly for create, list, get, quota update, and delete while authorizing shared tenants through the physical db_pool resource

## Verification

- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant/schema ./pkg/tenant ./pkg/meta -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -run 'TestAdminTenant|TestManagedSharedDB|TestRetryManagedSharedDBContinuation' -count=1`\n- `GOCACHE=/tmp/drive9-go-cache go build ./...`\n- `GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added shared-pool (shared) tenant support in the admin interface, including create, list, authorization, quota updates, and deletion.
  - Tenant listing now uses resource-based pagination to include eligible dedicated and shared tenants.
- **Reliability**
  - Improved shared-DB provisioning continuation with adaptive, deadline-based retries and better per-pool context.
  - Added shared-schema contract validation during initialization to detect safe/unsafe drift.
- **Bug Fixes**
  - Prevented shared-tenant deletion/cleanup from incorrectly deprovisioning physical clusters or applying the wrong quota changes; improved “deleting” placement handling and atomic metadata finalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->