### PR TITLE
fix: propagate shared org and quota sizes

### DIFF
--- a/pkg/backend/mutation_replay.go
+++ b/pkg/backend/mutation_replay.go
@@ -222,6 +222,10 @@ func (w *MutationReplayWorker) recordPendingBacklog(ctx context.Context) {
 	current := make(map[string]string, len(observations))
 	for _, obs := range observations {
 		orgID := normalizeTenantMetricTiDBCloudOrgID(obs.TiDBCloudOrgID)
+		if previousOrgID, ok := w.observedBacklogTenants[obs.TenantID]; ok && previousOrgID != orgID {
+			metrics.RecordTenantGaugeWithOrg(obs.TenantID, previousOrgID, "mutation_replay", "pending_mutations", 0)
+			metrics.RecordTenantGaugeWithOrg(obs.TenantID, previousOrgID, "mutation_replay", "oldest_pending_age_seconds", 0)
+		}
 		current[obs.TenantID] = orgID
 		w.observedBacklogTenants[obs.TenantID] = orgID
 		metrics.RecordTenantGaugeWithOrg(obs.TenantID, orgID, "mutation_replay", "pending_mutations", float64(obs.PendingCount))

--- a/pkg/backend/mutation_replay_metrics_test.go
+++ b/pkg/backend/mutation_replay_metrics_test.go
@@ -13,18 +13,18 @@ import (
 func TestMutationReplayWorkerRecordsPendingBacklogGauges(t *testing.T) {
 	fake := newFakeMetaQuotaStore()
 	fake.mutations = []fakeMutationRecord{
-		{tenantID: "tenant-backlog", id: 1, typ: "file_create", status: "pending", data: []byte(`{}`), createdAt: time.Now().Add(-2 * time.Second)},
-		{tenantID: "tenant-backlog", id: 2, typ: "file_create", status: "pending", data: []byte(`{}`), createdAt: time.Now().Add(-time.Second)},
+		{tenantID: "tenant-backlog", tidbCloudOrgID: "org-backlog", id: 1, typ: "file_create", status: "pending", data: []byte(`{}`), createdAt: time.Now().Add(-2 * time.Second)},
+		{tenantID: "tenant-backlog", tidbCloudOrgID: "org-backlog", id: 2, typ: "file_create", status: "pending", data: []byte(`{}`), createdAt: time.Now().Add(-time.Second)},
 	}
 
 	w := &MutationReplayWorker{store: fake}
 	w.recordPendingBacklog(context.Background())
 
 	metricsText := readBackendMetrics()
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-backlog",tidbcloud_org_id="guest"} 2`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-backlog",tidbcloud_org_id="org-backlog"} 2`) {
 		t.Errorf("metrics missing pending mutation backlog gauge: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-backlog",tidbcloud_org_id="guest"}`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-backlog",tidbcloud_org_id="org-backlog"}`) {
 		t.Errorf("metrics missing oldest pending age gauge: %s", metricsText)
 	}
 
@@ -35,11 +35,31 @@ func TestMutationReplayWorkerRecordsPendingBacklogGauges(t *testing.T) {
 	w.recordPendingBacklog(context.Background())
 
 	metricsText = readBackendMetrics()
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-backlog",tidbcloud_org_id="guest"} 0`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-backlog",tidbcloud_org_id="org-backlog"} 0`) {
 		t.Errorf("metrics did not clear pending mutation backlog gauge: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-backlog",tidbcloud_org_id="guest"} 0`) {
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-backlog",tidbcloud_org_id="org-backlog"} 0`) {
 		t.Errorf("metrics did not clear oldest pending age gauge: %s", metricsText)
+	}
+}
+
+func TestMutationReplayWorkerClearsPreviousOrganizationGauge(t *testing.T) {
+	fake := newFakeMetaQuotaStore()
+	fake.mutations = []fakeMutationRecord{
+		{tenantID: "tenant-org-change", id: 1, typ: "file_create", status: "pending", data: []byte(`{}`), createdAt: time.Now().Add(-time.Second)},
+	}
+	w := &MutationReplayWorker{store: fake}
+	w.recordPendingBacklog(context.Background())
+
+	fake.mutations[0].tidbCloudOrgID = "org-current"
+	w.recordPendingBacklog(context.Background())
+
+	metricsText := readBackendMetrics()
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-org-change",tidbcloud_org_id="guest"} 0`) {
+		t.Fatalf("previous guest backlog gauge was not cleared: %s", metricsText)
+	}
+	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-org-change",tidbcloud_org_id="org-current"} 1`) {
+		t.Fatalf("current org backlog gauge was not recorded: %s", metricsText)
 	}
 }
 

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -19,13 +19,14 @@ import (
 var errFakeMutationAlreadyApplied = errors.New("mutation already applied")
 
 type fakeMutationRecord struct {
-	tenantID   string
-	id         int64
-	typ        string
-	status     string
-	retryCount int
-	data       []byte
-	createdAt  time.Time
+	tenantID       string
+	tidbCloudOrgID string
+	id             int64
+	typ            string
+	status         string
+	retryCount     int
+	data           []byte
+	createdAt      time.Time
 }
 
 type fakeMetaQuotaStore struct {
@@ -391,12 +392,13 @@ func (f *fakeMetaQuotaStore) InsertMutationLog(ctx context.Context, entry *Mutat
 	id := f.nextID
 	f.nextID++
 	f.mutations = append(f.mutations, fakeMutationRecord{
-		tenantID:  entry.TenantID,
-		id:        id,
-		typ:       entry.MutationType,
-		status:    "pending",
-		data:      append([]byte(nil), entry.MutationData...),
-		createdAt: time.Now().UTC(),
+		tenantID:       entry.TenantID,
+		tidbCloudOrgID: entry.TiDBCloudOrgID,
+		id:             id,
+		typ:            entry.MutationType,
+		status:         "pending",
+		data:           append([]byte(nil), entry.MutationData...),
+		createdAt:      time.Now().UTC(),
 	})
 	return id, nil
 }
@@ -413,11 +415,12 @@ func (f *fakeMetaQuotaStore) ListPendingMutations(ctx context.Context, minAge ti
 			continue
 		}
 		out = append(out, MutationLogView{
-			ID:           m.id,
-			TenantID:     m.tenantID,
-			MutationType: m.typ,
-			MutationData: append([]byte(nil), m.data...),
-			RetryCount:   m.retryCount,
+			ID:             m.id,
+			TenantID:       m.tenantID,
+			TiDBCloudOrgID: m.tidbCloudOrgID,
+			MutationType:   m.typ,
+			MutationData:   append([]byte(nil), m.data...),
+			RetryCount:     m.retryCount,
 		})
 		if len(out) >= limit {
 			break
@@ -439,7 +442,7 @@ func (f *fakeMetaQuotaStore) ObservePendingMutations(ctx context.Context) ([]Mut
 		}
 		obs := byTenant[m.tenantID]
 		if obs == nil {
-			obs = &MutationBacklogView{TenantID: m.tenantID}
+			obs = &MutationBacklogView{TenantID: m.tenantID, TiDBCloudOrgID: m.tidbCloudOrgID}
 			byTenant[m.tenantID] = obs
 		}
 		obs.PendingCount++

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2888,11 +2888,15 @@ func (s *Store) ResolveByAPIKeyHash(ctx context.Context, hash string) (out *Tena
 			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
 			k.id, k.tenant_id, k.key_name, k.jwt_ciphertext, k.jwt_hash, k.token_version, k.status, k.scope_kind,
 			k.issued_by_provider, k.issued_by_subject_key, k.issued_by_metadata_json, k.issued_at,
-			k.revoked_at, k.created_at, k.updated_at, COALESCE(b.organization_id, '')
+			k.revoked_at, k.created_at, k.updated_at,
+			COALESCE(CASE WHEN t.provider = ? THEN d.org_id ELSE b.organization_id END, '')
 		FROM tenant_api_keys k
 		JOIN tenants t ON t.id = k.tenant_id
 		LEFT JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = t.id
-		WHERE k.jwt_hash = ?`, hash)
+		LEFT JOIN fs_registry f ON f.tenant_id = t.id
+		LEFT JOIN tenant_placements p ON p.fs_id = f.fs_id
+		LEFT JOIN db_pool d ON d.db_id = p.db_id
+		WHERE k.jwt_hash = ?`, tidbCloudNativeSharedProvider, hash)
 
 	var rec TenantWithAPIKey
 	var dbTLS int

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -4477,13 +4477,19 @@ func (s *Store) ListTenantNotifySince(ctx context.Context, afterID uint64, limit
 		limit = 1000
 	}
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT o.id, o.tenant_id, COALESCE(b.organization_id, ''), o.work_mask, o.created_at
+		`SELECT o.id, o.tenant_id,
+		        COALESCE(CASE WHEN t.provider = ? THEN d.org_id ELSE b.organization_id END, ''),
+		        o.work_mask, o.created_at
 		 FROM tenant_notify_outbox o
+		 LEFT JOIN tenants t ON t.id = o.tenant_id
 		 LEFT JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = o.tenant_id
+		 LEFT JOIN fs_registry f ON f.tenant_id = o.tenant_id
+		 LEFT JOIN tenant_placements p ON p.fs_id = f.fs_id
+		 LEFT JOIN db_pool d ON d.db_id = p.db_id
 		 WHERE o.id > ?
 		 ORDER BY o.id
 		 LIMIT ?`,
-		afterID, limit)
+		tidbCloudNativeSharedProvider, afterID, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -27,6 +27,35 @@ func newControlStore(t *testing.T) *Store {
 	return s
 }
 
+func insertSharedTenantPlacementForOrgTest(t *testing.T, s *Store, tenantID, organizationID string) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := s.InsertTenant(ctx, &Tenant{
+		ID: tenantID, Status: TenantActive, Kind: TenantKindLive,
+		Provider: tidbCloudNativeSharedProvider, DBPasswordCipher: []byte{}, DBTLS: true,
+		SchemaVersion: 1, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fsID, err := s.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		TiDBCloudOrganizationID: organizationID, Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertTenantPlacement(ctx, &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestMetaDBMetrics(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC()
@@ -261,29 +290,7 @@ func TestResolveByAPIKeyHashUsesSharedDBOrganization(t *testing.T) {
 	ctx := context.Background()
 	now := time.Now().UTC()
 	tenantID := "shared-api-key-org"
-	if err := s.InsertTenant(ctx, &Tenant{
-		ID: tenantID, Status: TenantActive, Kind: TenantKindLive,
-		Provider: tidbCloudNativeSharedProvider, DBPasswordCipher: []byte{}, DBTLS: true,
-		SchemaVersion: 1, CreatedAt: now, UpdatedAt: now,
-	}); err != nil {
-		t.Fatal(err)
-	}
-	fsID, err := s.EnsureFsID(ctx, tenantID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
-		TiDBCloudOrganizationID: "org-shared-api-key", Host: "shared.example.com", Port: 4000,
-		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := s.UpsertTenantPlacement(ctx, &TenantPlacement{
-		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
-	}); err != nil {
-		t.Fatal(err)
-	}
+	insertSharedTenantPlacementForOrgTest(t, s, tenantID, "org-shared-api-key")
 	if err := s.InsertAPIKey(ctx, &APIKey{
 		ID: "shared-api-key", TenantID: tenantID, KeyName: "default",
 		JWTCiphertext: []byte("jwt-cipher"), JWTHash: "shared-api-key-hash", TokenVersion: 1,
@@ -932,6 +939,89 @@ func TestListTenantNotifySinceIncludesTiDBCloudOrgBinding(t *testing.T) {
 	if rows[0].TiDBCloudOrgID != "org-notify" {
 		t.Fatalf("notify row org = %q, want org-notify", rows[0].TiDBCloudOrgID)
 	}
+}
+
+func TestListTenantNotifySinceUsesSharedDBOrganization(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	if _, err := s.DB().ExecContext(ctx, `DELETE FROM tenant_notify_outbox`); err != nil {
+		t.Fatal(err)
+	}
+	tenantID := "notify-shared-tenant"
+	insertSharedTenantPlacementForOrgTest(t, s, tenantID, "org-notify-shared")
+	if err := s.InsertTenantNotify(ctx, tenantID, 3); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := s.ListTenantNotifySince(ctx, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("notify row count = %d, want 1", len(rows))
+	}
+	if rows[0].TiDBCloudOrgID != "org-notify-shared" {
+		t.Fatalf("notify row org = %q, want org-notify-shared", rows[0].TiDBCloudOrgID)
+	}
+}
+
+func TestListPendingMutationsUsesSharedDBOrganization(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	if _, err := s.DB().ExecContext(ctx, `DELETE FROM quota_mutation_log`); err != nil {
+		t.Fatal(err)
+	}
+	tenantID := "mutation-shared-tenant"
+	insertSharedTenantPlacementForOrgTest(t, s, tenantID, "org-mutation-shared")
+	id, err := s.InsertMutationLog(ctx, &MutationLogEntry{
+		TenantID: tenantID, MutationType: "file_create", MutationData: []byte(`{"file_id":"f1"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE quota_mutation_log SET created_at = ? WHERE id = ?`, time.Now().UTC().Add(-time.Minute), id); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := s.ListPendingMutations(ctx, 0, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("mutation row count = %d, want 1", len(rows))
+	}
+	if rows[0].TiDBCloudOrgID != "org-mutation-shared" {
+		t.Fatalf("mutation row org = %q, want org-mutation-shared", rows[0].TiDBCloudOrgID)
+	}
+}
+
+func TestObservePendingMutationsUsesSharedDBOrganization(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	if _, err := s.DB().ExecContext(ctx, `DELETE FROM quota_mutation_log`); err != nil {
+		t.Fatal(err)
+	}
+	tenantID := "mutation-observe-shared-tenant"
+	insertSharedTenantPlacementForOrgTest(t, s, tenantID, "org-mutation-observe-shared")
+	if _, err := s.InsertMutationLog(ctx, &MutationLogEntry{
+		TenantID: tenantID, MutationType: "file_delete", MutationData: []byte(`{"file_id":"f1"}`),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rows, err := s.ObservePendingMutations(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		if row.TenantID == tenantID {
+			if row.TiDBCloudOrgID != "org-mutation-observe-shared" {
+				t.Fatalf("mutation observation org = %q, want org-mutation-observe-shared", row.TiDBCloudOrgID)
+			}
+			return
+		}
+	}
+	t.Fatalf("missing mutation observation for tenant %q", tenantID)
 }
 
 func TestListTenantsByStatus(t *testing.T) {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -256,6 +256,55 @@ func TestInsertAndResolveByAPIKeyHash(t *testing.T) {
 	}
 }
 
+func TestResolveByAPIKeyHashUsesSharedDBOrganization(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	tenantID := "shared-api-key-org"
+	if err := s.InsertTenant(ctx, &Tenant{
+		ID: tenantID, Status: TenantActive, Kind: TenantKindLive,
+		Provider: tidbCloudNativeSharedProvider, DBPasswordCipher: []byte{}, DBTLS: true,
+		SchemaVersion: 1, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fsID, err := s.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-shared-api-key", Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.UpsertTenantPlacement(ctx, &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertAPIKey(ctx, &APIKey{
+		ID: "shared-api-key", TenantID: tenantID, KeyName: "default",
+		JWTCiphertext: []byte("jwt-cipher"), JWTHash: "shared-api-key-hash", TokenVersion: 1,
+		Status: APIKeyActive, ScopeKind: APIKeyScopeKindOwner,
+		IssuedAt: now, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.ResolveByAPIKeyHash(ctx, "shared-api-key-hash")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.TiDBCloudOrgID != "org-shared-api-key" {
+		t.Fatalf("resolved org = %q, want org-shared-api-key", got.TiDBCloudOrgID)
+	}
+	if got.Tenant.TiDBCloudOrgID != "org-shared-api-key" {
+		t.Fatalf("tenant org = %q, want org-shared-api-key", got.Tenant.TiDBCloudOrgID)
+	}
+}
+
 func TestInsertAndGetExternalBinding(t *testing.T) {
 	s := newControlStore(t)
 	now := time.Now().UTC()

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -29,6 +29,9 @@ func newControlStore(t *testing.T) *Store {
 
 func insertSharedTenantPlacementForOrgTest(t *testing.T, s *Store, tenantID, organizationID string) {
 	t.Helper()
+	t.Cleanup(func() {
+		testmysql.ResetMetaDB(t, s.DB())
+	})
 	ctx := context.Background()
 	now := time.Now().UTC()
 	if err := s.InsertTenant(ctx, &Tenant{

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -1312,12 +1312,18 @@ func (s *Store) ListPendingMutations(ctx context.Context, minAge time.Duration, 
 	}
 	cutoff := time.Now().UTC().Add(-minAge)
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT q.id, q.tenant_id, COALESCE(b.organization_id, ''), q.mutation_type, q.mutation_data, q.status, q.retry_count, q.created_at, q.applied_at
+		`SELECT q.id, q.tenant_id,
+		        COALESCE(CASE WHEN t.provider = ? THEN d.org_id ELSE b.organization_id END, ''),
+		        q.mutation_type, q.mutation_data, q.status, q.retry_count, q.created_at, q.applied_at
 		 FROM quota_mutation_log q
+		 LEFT JOIN tenants t ON t.id = q.tenant_id
 		 LEFT JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = q.tenant_id
+		 LEFT JOIN fs_registry f ON f.tenant_id = q.tenant_id
+		 LEFT JOIN tenant_placements p ON p.fs_id = f.fs_id
+		 LEFT JOIN db_pool d ON d.db_id = p.db_id
 		 WHERE q.status = 'pending' AND q.created_at < ?
 		 ORDER BY q.tenant_id, q.id ASC
-		 LIMIT ?`, cutoff, limit)
+		 LIMIT ?`, tidbCloudNativeSharedProvider, cutoff, limit)
 	if err != nil {
 		return nil, err
 	}
@@ -1341,12 +1347,18 @@ func (s *Store) ObservePendingMutations(ctx context.Context) ([]MutationBacklogO
 	defer observeMeta(ctx, "observe_pending_mutations", start, &err)
 
 	rows, err := s.db.QueryContext(ctx,
-		`SELECT q.tenant_id, COALESCE(b.organization_id, ''), COUNT(*), MIN(q.created_at)
+		`SELECT q.tenant_id,
+		        COALESCE(CASE WHEN t.provider = ? THEN d.org_id ELSE b.organization_id END, ''),
+		        COUNT(*), MIN(q.created_at)
 		 FROM quota_mutation_log q FORCE INDEX (idx_pending_tenant_age)
+		 LEFT JOIN tenants t ON t.id = q.tenant_id
 		 LEFT JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = q.tenant_id
+		 LEFT JOIN fs_registry f ON f.tenant_id = q.tenant_id
+		 LEFT JOIN tenant_placements p ON p.fs_id = f.fs_id
+		 LEFT JOIN db_pool d ON d.db_id = p.db_id
 		 WHERE q.status = 'pending'
-		 GROUP BY q.tenant_id, b.organization_id
-		 ORDER BY q.tenant_id`)
+		 GROUP BY q.tenant_id, t.provider, d.org_id, b.organization_id
+		 ORDER BY q.tenant_id`, tidbCloudNativeSharedProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -484,10 +484,12 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 			errJSON(w, http.StatusInternalServerError, "tenant pool membership lookup failed")
 			return nil, nil, false
 		}
-		if _, err := s.authorizeSharedQuotaCredentials(r.Context(), t, cred, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster)); err != nil {
+		physical, err := s.authorizeSharedQuotaCredentials(r.Context(), t, cred, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
+		if err != nil {
 			writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
 			return nil, nil, false
 		}
+		setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, physical.TiDBCloudOrganizationID, classifyTenantRequest(r))
 		return t, nil, true
 	}
 	if t.Provider != tenant.ProviderTiDBCloudNative {
@@ -520,6 +522,7 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 		}
 		for _, cluster := range clusters {
 			if cluster.OrganizationID == binding.OrganizationID {
+				setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, binding.OrganizationID, classifyTenantRequest(r))
 				return t, binding, true
 			}
 		}
@@ -539,6 +542,7 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 		errJSON(w, http.StatusForbidden, "no permission to access tenant with TiDB Cloud API key")
 		return nil, nil, false
 	}
+	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, binding.OrganizationID, classifyTenantRequest(r))
 	return t, binding, true
 }
 

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/encrypt"
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/tenant/token"
 	"go.uber.org/zap"
@@ -540,6 +541,88 @@ func TestTenantStatusWithValidKey(t *testing.T) {
 	}
 	if out.MaxUploadBytes != srv.maxUploadBytes {
 		t.Fatalf("max_upload_bytes = %d, want %d", out.MaxUploadBytes, srv.maxUploadBytes)
+	}
+}
+
+func TestSharedTenantStatusLogsAndMetricsUseDBOrganization(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+	ctx := context.Background()
+	if err := rt.meta.UpdateTenantProvider(ctx, rt.tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
+		t.Fatal(err)
+	}
+	fsID, err := rt.meta.EnsureFsID(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-status-output", Host: "shared-status.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_status_db",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	core, recorded := observer.New(zap.InfoLevel)
+	srv := NewWithConfig(Config{
+		Meta: rt.meta, Pool: rt.pool, TokenSecret: rt.tokenSecret, Logger: zap.New(core),
+	})
+	defer srv.Close()
+	ts := httptest.NewServer(srv)
+	defer ts.Close()
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer "+rt.token)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
+	}
+
+	assertOrgLog := func(message, event string) {
+		t.Helper()
+		entries := recorded.FilterMessage(message).All()
+		found := false
+		for _, entry := range entries {
+			fields := entry.ContextMap()
+			if event != "" && fields["event"] != event {
+				continue
+			}
+			if fields["tenant_id"] != rt.tenantID {
+				continue
+			}
+			found = true
+			if fields["tidbcloud_org_id"] != "org-shared-status-output" {
+				t.Fatalf("%s/%s org = %v, want org-shared-status-output", message, event, fields["tidbcloud_org_id"])
+			}
+		}
+		if !found {
+			t.Fatalf("%s/%s logs do not contain tenant %q", message, event, rt.tenantID)
+		}
+	}
+	assertOrgLog("http_request", "")
+	assertOrgLog("server_event", "tenant_status_ok")
+
+	recorder := httptest.NewRecorder()
+	metrics.WritePrometheus(recorder)
+	metricsText := recorder.Body.String()
+	wantMetric := `drive9_tenant_requests_total{action="get",result="ok",status_class="2xx",surface="status",tenant_id="` + rt.tenantID + `",tidbcloud_org_id="org-shared-status-output"}`
+	if !strings.Contains(metricsText, wantMetric) {
+		t.Fatalf("missing shared status request metric %q", wantMetric)
+	}
+	wrongMetric := `drive9_tenant_requests_total{action="get",result="ok",status_class="2xx",surface="status",tenant_id="` + rt.tenantID + `",tidbcloud_org_id="guest"}`
+	if strings.Contains(metricsText, wrongMetric) {
+		t.Fatalf("shared status request metric used guest org %q", wrongMetric)
 	}
 }
 

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -589,7 +589,7 @@ func TestSharedTenantStatusLogsAndMetricsUseDBOrganization(t *testing.T) {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
 
-	assertOrgLog := func(message, event string) {
+	assertOrgLog := func(t *testing.T, message, event string) {
 		t.Helper()
 		entries := recorded.FilterMessage(message).All()
 		found := false
@@ -610,8 +610,8 @@ func TestSharedTenantStatusLogsAndMetricsUseDBOrganization(t *testing.T) {
 			t.Fatalf("%s/%s logs do not contain tenant %q", message, event, rt.tenantID)
 		}
 	}
-	assertOrgLog("http_request", "")
-	assertOrgLog("server_event", "tenant_status_ok")
+	assertOrgLog(t, "http_request", "")
+	assertOrgLog(t, "server_event", "tenant_status_ok")
 
 	recorder := httptest.NewRecorder()
 	metrics.WritePrometheus(recorder)

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -30,6 +30,13 @@ const defaultTenantMetricTiDBCloudOrgID = "guest"
 func eventFields(ctx context.Context, event string, kv ...any) []zap.Field {
 	fields := make([]zap.Field, 0, len(kv)/2+3)
 	fields = append(fields, zap.String("event", event))
+	hasTiDBCloudOrgID := false
+	for i := 0; i+1 < len(kv); i += 2 {
+		if strings.ReplaceAll(fmt.Sprint(kv[i]), " ", "_") == "tidbcloud_org_id" {
+			hasTiDBCloudOrgID = true
+			break
+		}
+	}
 	if scope := ScopeFromContext(ctx); scope != nil {
 		if scope.TenantID != "" {
 			fields = append(fields, zap.String("tenant_id", scope.TenantID))
@@ -37,8 +44,15 @@ func eventFields(ctx context.Context, event string, kv ...any) []zap.Field {
 		if scope.APIKeyID != "" {
 			fields = append(fields, zap.String("api_key_id", scope.APIKeyID))
 		}
-		if scope.TiDBCloudOrgID != "" {
+		if scope.TiDBCloudOrgID != "" && !hasTiDBCloudOrgID {
 			fields = append(fields, zap.String("tidbcloud_org_id", scope.TiDBCloudOrgID))
+			hasTiDBCloudOrgID = true
+		}
+	}
+	if !hasTiDBCloudOrgID {
+		_, _, _, metricOrgID := requestMetricScope(ctx)
+		if metricOrgID != "" {
+			fields = append(fields, zap.String("tidbcloud_org_id", metricOrgID))
 		}
 	}
 	for i := 0; i+1 < len(kv); i += 2 {

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -153,6 +153,26 @@ func TestSetRequestMetricTenantMovesInFlightLabel(t *testing.T) {
 	}
 }
 
+func TestEventFieldsDoesNotDuplicateExplicitTiDBCloudOrgID(t *testing.T) {
+	ctx := withRequestMetricState(context.Background(), &requestMetricState{})
+	setRequestMetricTenant(ctx, "tenant-a", "", "", "org-request", tenantRequestClass{surface: "status", action: "get"})
+
+	fields := eventFields(ctx, "test_event", "tidbcloud_org_id", "org-explicit")
+	count := 0
+	for _, field := range fields {
+		if field.Key != "tidbcloud_org_id" {
+			continue
+		}
+		count++
+		if field.String != "org-explicit" {
+			t.Fatalf("tidbcloud_org_id = %q, want org-explicit", field.String)
+		}
+	}
+	if count != 1 {
+		t.Fatalf("tidbcloud_org_id field count = %d, want 1", count)
+	}
+}
+
 func TestRequestTenantMetricScopeFallbackLeavesOrgEmpty(t *testing.T) {
 	req, err := http.NewRequest(http.MethodGet, "http://example.test/s3/objects/blob", nil)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -154,6 +154,9 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	if res.Provider != tenant.ProviderTiDBCloudNativeShared || res.Status != meta.TenantProvisioning {
 		t.Fatalf("result = provider %q status %q, want shared/provisioning", res.Provider, res.Status)
 	}
+	if res.OrganizationID != "org-shared" {
+		t.Fatalf("organization ID = %q, want org-shared", res.OrganizationID)
+	}
 	tenantRow, err := metaStore.GetTenant(context.Background(), res.TenantID)
 	if err != nil {
 		t.Fatalf("GetTenant: %v", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5226,11 +5226,12 @@ func (s *Server) provisionTenantOnSharedDBMode(ctx context.Context, tenantID str
 		status = meta.TenantProvisioning
 	}
 	return &provisionTenantResult{
-		TenantID: tenantID,
-		APIKey:   apiToken,
-		APIKeyID: apiKeyID,
-		Status:   status,
-		Provider: tenant.ProviderTiDBCloudNativeShared,
+		TenantID:       tenantID,
+		APIKey:         apiToken,
+		APIKeyID:       apiKeyID,
+		Status:         status,
+		Provider:       tenant.ProviderTiDBCloudNativeShared,
+		OrganizationID: strings.TrimSpace(sharedDB.TiDBCloudOrganizationID),
 	}, nil
 }
 

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -98,10 +98,16 @@ func generateManagedSharedDBRootPassword(length int) (string, error) {
 
 func (s *Server) materializeSharedTenantQuota(ctx context.Context, tenantID string, opts provisionTenantOptions) error {
 	virtualLimit := s.sharedTenantVirtualSpendingLimit(opts)
+	var patch meta.QuotaConfigPatch
 	if opts.Quota != nil {
 		req := *opts.Quota
 		req.TenantID = tenantID
 		if err := s.validateQuotaSetRequest(req); err != nil {
+			return err
+		}
+		var err error
+		patch, err = quotaConfigPatchFromRequest(req)
+		if err != nil {
 			return err
 		}
 	}
@@ -114,16 +120,14 @@ func (s *Server) materializeSharedTenantQuota(ctx context.Context, tenantID stri
 		MaxVideoLLMFiles:       meta.DefaultMaxVideoLLMFiles(),
 		TiDBCloudSpendingLimit: &virtualLimit,
 	}
-	if opts.Quota != nil {
-		if opts.Quota.MaxStorageSize != nil {
-			cfg.MaxStorageBytes = *opts.Quota.MaxStorageSize
-		}
-		if opts.Quota.MaxFileSize != nil {
-			cfg.MaxFileSizeBytes = *opts.Quota.MaxFileSize
-		}
-		if opts.Quota.MaxFileCount != nil {
-			cfg.MaxFileCount = *opts.Quota.MaxFileCount
-		}
+	if patch.MaxStorageBytes != nil {
+		cfg.MaxStorageBytes = *patch.MaxStorageBytes
+	}
+	if patch.MaxFileSizeBytes != nil {
+		cfg.MaxFileSizeBytes = *patch.MaxFileSizeBytes
+	}
+	if patch.MaxFileCount != nil {
+		cfg.MaxFileCount = *patch.MaxFileCount
 	}
 	if err := s.meta.SetQuotaConfig(ctx, cfg); err != nil {
 		return fmt.Errorf("materialize shared tenant quota: %w", err)

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -383,6 +383,16 @@ func TestAdminTenantGetAuthorizesSharedProviderThroughPhysicalPool(t *testing.T)
 	}); err != nil {
 		t.Fatalf("UpsertTenantPlacement: %v", err)
 	}
+	metricReq := httptest.NewRequest(http.MethodGet, "/v1/admin/tenants/"+rt.tenantID, nil)
+	metricReq = metricReq.WithContext(withRequestMetricState(metricReq.Context(), &requestMetricState{}))
+	if _, _, ok := rt.server.authorizedAdminTenant(httptest.NewRecorder(), metricReq, rt.tenantID,
+		tenant.CredentialProvisionRequest{PublicKey: "pk", PrivateKey: "sk"}, true, false); !ok {
+		t.Fatal("shared admin tenant authorization failed")
+	}
+	metricTenantID, _, metricProvider, metricOrgID := requestMetricScope(metricReq.Context())
+	if metricTenantID != rt.tenantID || metricProvider != tenant.ProviderTiDBCloudNativeShared || metricOrgID != "org-shared-admin" {
+		t.Fatalf("request metric scope = tenant %q provider %q org %q", metricTenantID, metricProvider, metricOrgID)
+	}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -308,6 +309,52 @@ func TestAdminTenantCreateRejectsSharedPoolWithoutCloudIdentity(t *testing.T) {
 	}
 	if tenantCount != 2 {
 		t.Fatalf("tenants after manageable create = %d, want 2", tenantCount)
+	}
+}
+
+func TestAdminTenantCreatePersistsSharedQuotaSizesInBytes(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{ClusterID: "cluster-shared-quota", OrganizationID: "org-shared-quota"}},
+	}}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-quota", Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE db_pool SET cluster_id = ? WHERE db_id = ?", "cluster-shared-quota", dbID); err != nil {
+		t.Fatal(err)
+	}
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	resp := postJSON(t, ts.URL+"/v1/admin/tenants", map[string]any{
+		"public_key": "pk", "private_key": "sk",
+		"max_storage_size": int64(500), "max_file_size": int64(10), "max_file_count": int64(100),
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusAccepted {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d: %s", resp.StatusCode, http.StatusAccepted, body)
+	}
+	var out adminTenantCreateResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := rt.meta.GetQuotaConfig(ctx, out.TenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.MaxStorageBytes != 500*quotaStorageSizeBytes {
+		t.Fatalf("max storage bytes = %d, want %d", cfg.MaxStorageBytes, 500*quotaStorageSizeBytes)
+	}
+	if cfg.MaxFileSizeBytes != 10*quotaStorageSizeBytes {
+		t.Fatalf("max file size bytes = %d, want %d", cfg.MaxFileSizeBytes, 10*quotaStorageSizeBytes)
+	}
+	if cfg.MaxFileCount != 100 {
+		t.Fatalf("max file count = %d, want 100", cfg.MaxFileCount)
 	}
 }
 

--- a/pkg/server/tenant_outbox_poller_test.go
+++ b/pkg/server/tenant_outbox_poller_test.go
@@ -2,10 +2,13 @@ package server
 
 import (
 	"context"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 // mockKicker records kicks for deterministic testing of the poller.
@@ -34,17 +37,22 @@ func TestTenantOutboxPollerShardFilter(t *testing.T) {
 }
 
 func TestTenantOutboxPollerPassesOrgToWorker(t *testing.T) {
-	t.Parallel()
 	buses := newEventBuses()
 	k := &mockKicker{}
 	p := newTenantOutboxPoller(nil, buses, k, nil, "pod1", 0, 0)
-	row := meta.TenantNotifyRow{ID: 1, TenantID: "t1", TiDBCloudOrgID: "org-t1", WorkMask: WorkFileGC, CreatedAt: time.Now()}
+	row := meta.TenantNotifyRow{ID: 1, TenantID: "tenant-outbox-org-metric", TiDBCloudOrgID: "org-outbox-metric", WorkMask: WorkFileGC, CreatedAt: time.Now()}
 	p.dispatch(context.Background(), row)
 	if len(k.kicks) != 1 {
 		t.Fatalf("expected 1 kick, got %d", len(k.kicks))
 	}
-	if k.kicks[0].tidbCloudOrgID != "org-t1" {
-		t.Fatalf("kick org = %q, want org-t1", k.kicks[0].tidbCloudOrgID)
+	if k.kicks[0].tidbCloudOrgID != "org-outbox-metric" {
+		t.Fatalf("kick org = %q, want org-outbox-metric", k.kicks[0].tidbCloudOrgID)
+	}
+	recorder := httptest.NewRecorder()
+	metrics.WritePrometheus(recorder)
+	want := `drive9_service_operations_total{component="user_db_access",operation="outbox_dispatch_kick",result="ok",tenant_id="tenant-outbox-org-metric",tidbcloud_org_id="org-outbox-metric"}`
+	if !strings.Contains(recorder.Body.String(), want) {
+		t.Fatalf("missing org-scoped outbox dispatch metric %q", want)
 	}
 }
 

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -864,7 +864,7 @@ func (p *Pool) fsIDForTenant(ctx context.Context, t *meta.Tenant) (int64, error)
 }
 
 func (p *Pool) tenantMetricTiDBCloudOrgID(ctx context.Context, t *meta.Tenant) string {
-	if t == nil || strings.TrimSpace(t.ID) == "" || t.Provider != ProviderTiDBCloudNative {
+	if t == nil || strings.TrimSpace(t.ID) == "" || !UsesTiDBCloudNativeCredentials(t.Provider) {
 		return defaultTenantMetricTiDBCloudOrgID
 	}
 	if orgID := strings.TrimSpace(t.TiDBCloudOrgID); orgID != "" {
@@ -872,6 +872,22 @@ func (p *Pool) tenantMetricTiDBCloudOrgID(ctx context.Context, t *meta.Tenant) s
 	}
 	if p == nil || p.metaStore == nil {
 		return defaultTenantMetricTiDBCloudOrgID
+	}
+	if IsSharedSchemaProvider(t.Provider) {
+		sharedDB, err := p.metaStore.GetSharedDBForTenant(ctx, t.ID)
+		if err != nil {
+			if !errors.Is(err, meta.ErrNotFound) {
+				logger.Warn(ctx, "tenant_pool_metric_shared_org_lookup_failed",
+					zap.String("tenant_id", t.ID),
+					zap.Error(err))
+			}
+			return defaultTenantMetricTiDBCloudOrgID
+		}
+		orgID := strings.TrimSpace(sharedDB.TiDBCloudOrganizationID)
+		if orgID == "" {
+			return defaultTenantMetricTiDBCloudOrgID
+		}
+		return orgID
 	}
 	binding, err := p.metaStore.GetTenantTiDBCloudOrgBinding(ctx, t.ID)
 	if err != nil {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -440,6 +440,51 @@ func TestTenantMetricTiDBCloudOrgIDUsesPreResolvedTenantOrg(t *testing.T) {
 	}
 }
 
+func TestTenantMetricTiDBCloudOrgIDUsesSharedDBPool(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	ctx := context.Background()
+	now := time.Now().UTC()
+	tenantID := "tenant-shared-metric-org"
+	if err := metaStore.InsertTenant(ctx, &meta.Tenant{
+		ID: tenantID, Status: meta.TenantActive, Kind: meta.TenantKindLive,
+		Provider: ProviderTiDBCloudNativeShared, DBPasswordCipher: []byte{}, DBTLS: true,
+		SchemaVersion: 1, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	fsID, err := metaStore.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := metaStore.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-metric", Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	pool := NewPool(PoolConfig{}, nil)
+	pool.SetMetaStore(metaStore)
+	t.Cleanup(pool.Close)
+
+	got := pool.tenantMetricTiDBCloudOrgID(ctx, &meta.Tenant{
+		ID: tenantID, Status: meta.TenantActive, Provider: ProviderTiDBCloudNativeShared,
+	})
+	if got != "org-shared-metric" {
+		t.Fatalf("org = %q, want org-shared-metric", got)
+	}
+}
+
 func TestPoolAcquireInvalidateDefersCloseUntilRelease(t *testing.T) {
 	pool, tenant := newTestPoolAndTenant(t, 2, "tenant-a")
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- resolve shared tenant TiDB Cloud organization IDs from the physical shared DB pool during API-key authentication and backend creation
- propagate the shared pool organization through provisioning, admin item requests, tenant notify dispatch, quota mutation replay, request logs, server-event logs, and Prometheus metrics instead of falling back to `guest`
- clear the previous mutation-backlog gauge label when a tenant organization label changes, so the old `guest` series does not remain non-zero
- convert admin-create storage and file quota values from MiB to bytes through the existing quota patch conversion path

## Root cause

Shared tenants do not have `tenant_tidbcloud_org_bindings` rows, but several request and background paths only consulted that dedicated-native mapping. The shared provision result also omitted the pool organization. In addition, `server_event` fields only read `TenantScope`, while `/v1/status` resolves the tenant into request metric state without installing a scope. Separately, shared quota materialization persisted raw MiB request values directly into byte columns.

Shared provider dispatch now consistently resolves the organization through `fs_registry -> tenant_placements -> db_pool.org_id`; dedicated native continues to use `tenant_tidbcloud_org_bindings.organization_id`.

## Verification

- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -run "^(TestEventFieldsDoesNotDuplicateExplicitTiDBCloudOrgID|TestSharedTenantStatusLogsAndMetricsUseDBOrganization|TestTenantOutboxPollerPassesOrgToWorker)$" -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/backend -run "^(TestMutationReplayWorkerRecordsPendingBacklogGauges|TestMutationReplayWorkerClearsPreviousOrganizationGauge)$" -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/meta -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant -count=1`
- `GOCACHE=/tmp/drive9-go-cache go build ./...`
- `GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint`
- `git diff --check`

The full `pkg/server` run was also attempted locally, but the repository-wide suite hit the known MySQL test lifecycle failure class (`database is closed` / canceled localhost lookups) after many server instances were started. The focused shared output tests above pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved TiDB Cloud organization identification for shared tenants across provisioning, authorization, status reporting, and background processing.
  - Corrected logs and metrics to consistently show the organization associated with a shared database.
  - Prevented duplicate organization labels in request telemetry.
  - Cleared stale mutation backlog metrics when a tenant moves between organizations.
  - Ensured shared quota limits are persisted accurately, including byte-based storage values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->