### PR TITLE
fix: clean up failed TiDB Cloud tenants

### DIFF
--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -310,7 +310,20 @@ FORK_LOCAL="$(mktemp)"
 
 drive9_ctx ctx add --name owner --server "$BASE" --api-key "$API_KEY" --mode TiDBCloud >/dev/null
 
-fork_json="$(drive9_ctx ctx fork "$FORK_CTX_NAME" --from owner --tidbcloud-public-key "$PUBLIC_KEY" --tidbcloud-private-key "$PRIVATE_KEY" --json)"
+set +e
+fork_json="$(drive9_ctx ctx fork "$FORK_CTX_NAME" --from owner --tidbcloud-public-key "$PUBLIC_KEY" --tidbcloud-private-key "$PRIVATE_KEY" --json 2>&1)"
+fork_rc=$?
+set -e
+
+if [ "$fork_rc" -ne 0 ] || echo "$fork_json" | grep -qi "not supported\|unsupported\|shared-pool"; then
+  SKIP_FORK=1
+  FAIL_FORK=0
+  echo -e "${YELLOW}SKIP${NC} fork not supported on this deployment, skipping fork checks"
+else
+  SKIP_FORK=0
+  FAIL_FORK=0
+fi
+if [ "$SKIP_FORK" -eq 0 ]; then
 fork_api_key="$(jq -r '.api_key // empty' <<<"$fork_json")"
 fork_tenant_id="$(jq -r '.tenant_id // empty' <<<"$fork_json")"
 fork_status="$(jq -r '.status // empty' <<<"$fork_json")"
@@ -355,6 +368,7 @@ fork_delete_code=$(curl -sS -o "$fork_delete_body" -w "%{http_code}" -X DELETE \
   "$BASE/v1/fork")
 check_eq "DELETE /v1/fork returns 202" "$fork_delete_code" "202"
 rm -f "$fork_delete_body" "$FORK_LOCAL"
+fi
 
 # ── [8] admin tenant list ───────────────────────────────────────────────────
 

--- a/e2e/native-smoke-test.sh
+++ b/e2e/native-smoke-test.sh
@@ -310,20 +310,7 @@ FORK_LOCAL="$(mktemp)"
 
 drive9_ctx ctx add --name owner --server "$BASE" --api-key "$API_KEY" --mode TiDBCloud >/dev/null
 
-set +e
-fork_json="$(drive9_ctx ctx fork "$FORK_CTX_NAME" --from owner --tidbcloud-public-key "$PUBLIC_KEY" --tidbcloud-private-key "$PRIVATE_KEY" --json 2>&1)"
-fork_rc=$?
-set -e
-
-if [ "$fork_rc" -ne 0 ] || echo "$fork_json" | grep -qi "not supported\|unsupported\|shared-pool"; then
-  SKIP_FORK=1
-  FAIL_FORK=0
-  echo -e "${YELLOW}SKIP${NC} fork not supported on this deployment, skipping fork checks"
-else
-  SKIP_FORK=0
-  FAIL_FORK=0
-fi
-if [ "$SKIP_FORK" -eq 0 ]; then
+fork_json="$(drive9_ctx ctx fork "$FORK_CTX_NAME" --from owner --tidbcloud-public-key "$PUBLIC_KEY" --tidbcloud-private-key "$PRIVATE_KEY" --json)"
 fork_api_key="$(jq -r '.api_key // empty' <<<"$fork_json")"
 fork_tenant_id="$(jq -r '.tenant_id // empty' <<<"$fork_json")"
 fork_status="$(jq -r '.status // empty' <<<"$fork_json")"
@@ -368,7 +355,6 @@ fork_delete_code=$(curl -sS -o "$fork_delete_body" -w "%{http_code}" -X DELETE \
   "$BASE/v1/fork")
 check_eq "DELETE /v1/fork returns 202" "$fork_delete_code" "202"
 rm -f "$fork_delete_body" "$FORK_LOCAL"
-fi
 
 # ── [8] admin tenant list ───────────────────────────────────────────────────
 

--- a/internal/testmysql/testmysql.go
+++ b/internal/testmysql/testmysql.go
@@ -128,6 +128,7 @@ func ResetMetaDB(t *testing.T, db *sql.DB) {
 		"DELETE FROM tenant_api_key_fs_scopes",
 		"DELETE FROM tenant_api_keys",
 		"DELETE FROM tenant_external_bindings",
+		"DELETE FROM tenant_pool_memberships",
 		"DELETE FROM tenant_tidbcloud_org_bindings",
 		"DELETE FROM tenant_tidbcloud_pools",
 		"DELETE FROM tenant_placements",

--- a/pkg/meta/tenant_pool_failed_cleanup.go
+++ b/pkg/meta/tenant_pool_failed_cleanup.go
@@ -1,0 +1,237 @@
+package meta
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ListFailedNativeTenantCleanupCandidates lists failed native tenants owned by
+// an organization, excluding bindings already claimed from a pool.
+func (s *Store) ListFailedNativeTenantCleanupCandidates(ctx context.Context, organizationID string, updatedBefore time.Time, limit int) (out []TenantWithTiDBCloudOrgBinding, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_failed_native_tenant_cleanup_candidates", start, &err)
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" {
+		return nil, fmt.Errorf("organization_id is required")
+	}
+	if limit <= 0 {
+		limit = 1
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT
+			t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
+			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
+			t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
+			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at,
+			b.tenant_id, b.organization_id, b.cluster_id, b.branch_id, b.pool_id, b.pool_status, b.used_at, b.created_at, b.updated_at
+		FROM tenant_tidbcloud_org_bindings b
+		JOIN tenants t ON t.id = b.tenant_id
+		WHERE b.organization_id = ?
+			AND (b.pool_status = ? OR b.pool_id = '')
+			AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+		ORDER BY t.updated_at ASC, t.id ASC
+		LIMIT ?`, organizationID, TenantPoolBindingFree, tidbCloudNativeProvider, TenantFailed,
+		updatedBefore.UTC(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list failed native tenant cleanup candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanTenantBindingRows(rows)
+}
+
+// ListFailedSharedTenantCleanupCandidates lists failed shared tenants owned by
+// an organization. A tenant belongs through a free pool membership, or through
+// its physical placement when it has no logical-pool membership.
+func (s *Store) ListFailedSharedTenantCleanupCandidates(ctx context.Context, organizationID string, updatedBefore time.Time, limit int) (out []Tenant, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_failed_shared_tenant_cleanup_candidates", start, &err)
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" {
+		return nil, fmt.Errorf("organization_id is required")
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT
+			c.id, c.status, c.kind, c.parent_tenant_id, c.storage_namespace_id,
+			c.db_host, c.db_port, c.db_user, c.db_password, c.db_name,
+			c.db_tls, c.provider, c.cluster_id, c.branch_id, c.claim_url, c.claim_expires_at, c.schema_version,
+			c.s3_encryption_mode, c.s3_kms_key_id, c.s3_bucket_key_enabled, c.created_at, c.updated_at
+		FROM (
+			SELECT
+				t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
+				t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
+				t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
+				t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at
+			FROM tenant_pool_memberships m
+			JOIN tenants t ON t.id = m.tenant_id
+			WHERE m.tidbcloud_organization_id = ? AND m.pool_status = ?
+				AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+
+			UNION ALL
+
+			SELECT
+				t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
+				t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
+				t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
+				t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at
+			FROM db_pool d
+			JOIN tenant_placements p ON p.db_id = d.db_id
+			JOIN fs_registry f ON f.fs_id = p.fs_id
+			JOIN tenants t ON t.id = f.tenant_id
+			LEFT JOIN tenant_pool_memberships m ON m.tenant_id = t.id
+			WHERE d.org_id = ? AND m.tenant_id IS NULL
+				AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+		) c
+		ORDER BY c.updated_at ASC, c.id ASC
+		LIMIT ?`, organizationID, TenantPoolBindingFree, tidbCloudNativeSharedProvider,
+		TenantFailed, updatedBefore.UTC(), organizationID, tidbCloudNativeSharedProvider,
+		TenantFailed, updatedBefore.UTC(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list failed shared tenant cleanup candidates: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanTenantRows(rows)
+}
+
+// MarkFailedNativeTenantDeleting claims an eligible native cleanup row. The
+// locked read and update both repeat the organization and pool-claim boundary.
+func (s *Store) MarkFailedNativeTenantDeleting(ctx context.Context, tenantID, organizationID string, updatedBefore time.Time) (updated bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "mark_failed_native_tenant_deleting", start, &err)
+	tenantID = strings.TrimSpace(tenantID)
+	organizationID = strings.TrimSpace(organizationID)
+	if tenantID == "" {
+		return false, fmt.Errorf("tenant_id is required")
+	}
+	if organizationID == "" {
+		return false, fmt.Errorf("organization_id is required")
+	}
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		var lockedTenantID string
+		if err := tx.QueryRowContext(ctx, `SELECT t.id
+			FROM tenants t
+			JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = t.id
+			WHERE t.id = ? AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+				AND b.organization_id = ?
+				AND (b.pool_status = ? OR b.pool_id = '')
+			LIMIT 1 FOR UPDATE`, tenantID, tidbCloudNativeProvider, TenantFailed,
+			updatedBefore.UTC(), organizationID, TenantPoolBindingFree).Scan(&lockedTenantID); err != nil {
+			return err
+		}
+		res, err := tx.ExecContext(ctx, `UPDATE tenants t
+			SET t.status = ?, t.updated_at = ?
+			WHERE t.id = ? AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+				AND EXISTS (
+					SELECT 1 FROM tenant_tidbcloud_org_bindings b
+					WHERE b.tenant_id = t.id AND b.organization_id = ?
+						AND (b.pool_status = ? OR b.pool_id = '')
+				)`, TenantDeleting, time.Now().UTC(), lockedTenantID, tidbCloudNativeProvider,
+			TenantFailed, updatedBefore.UTC(), organizationID, TenantPoolBindingFree)
+		if err != nil {
+			return err
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		updated = affected == 1
+		return nil
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("mark failed native tenant %s deleting: %w", tenantID, err)
+	}
+	return updated, nil
+}
+
+// MarkFailedSharedTenantDeleting claims an eligible shared cleanup row. The
+// locked read and update both repeat the organization and membership boundary.
+func (s *Store) MarkFailedSharedTenantDeleting(ctx context.Context, tenantID, organizationID string, updatedBefore time.Time) (updated bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "mark_failed_shared_tenant_deleting", start, &err)
+	tenantID = strings.TrimSpace(tenantID)
+	organizationID = strings.TrimSpace(organizationID)
+	if tenantID == "" {
+		return false, fmt.Errorf("tenant_id is required")
+	}
+	if organizationID == "" {
+		return false, fmt.Errorf("organization_id is required")
+	}
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		var lockedTenantID string
+		if err := tx.QueryRowContext(ctx, `SELECT t.id
+			FROM tenants t
+			WHERE t.id = ? AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+				AND (
+					EXISTS (
+						SELECT 1 FROM tenant_pool_memberships m
+						WHERE m.tenant_id = t.id AND m.pool_status = ?
+							AND m.tidbcloud_organization_id = ?
+					)
+					OR (
+						NOT EXISTS (
+							SELECT 1 FROM tenant_pool_memberships m
+							WHERE m.tenant_id = t.id
+						)
+						AND EXISTS (
+							SELECT 1
+							FROM fs_registry f
+							JOIN tenant_placements p ON p.fs_id = f.fs_id
+							JOIN db_pool d ON d.db_id = p.db_id
+							WHERE f.tenant_id = t.id AND d.org_id = ?
+						)
+					)
+				)
+			LIMIT 1 FOR UPDATE`, tenantID, tidbCloudNativeSharedProvider, TenantFailed,
+			updatedBefore.UTC(), TenantPoolBindingFree, organizationID, organizationID).Scan(&lockedTenantID); err != nil {
+			return err
+		}
+		res, err := tx.ExecContext(ctx, `UPDATE tenants t
+			SET t.status = ?, t.updated_at = ?
+			WHERE t.id = ? AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+				AND (
+					EXISTS (
+						SELECT 1 FROM tenant_pool_memberships m
+						WHERE m.tenant_id = t.id AND m.pool_status = ?
+							AND m.tidbcloud_organization_id = ?
+					)
+					OR (
+						NOT EXISTS (
+							SELECT 1 FROM tenant_pool_memberships m
+							WHERE m.tenant_id = t.id
+						)
+						AND EXISTS (
+							SELECT 1
+							FROM fs_registry f
+							JOIN tenant_placements p ON p.fs_id = f.fs_id
+							JOIN db_pool d ON d.db_id = p.db_id
+							WHERE f.tenant_id = t.id AND d.org_id = ?
+						)
+					)
+				)`, TenantDeleting, time.Now().UTC(), lockedTenantID,
+			tidbCloudNativeSharedProvider, TenantFailed, updatedBefore.UTC(), TenantPoolBindingFree,
+			organizationID, organizationID)
+		if err != nil {
+			return err
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		updated = affected == 1
+		return nil
+	})
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("mark failed shared tenant %s deleting: %w", tenantID, err)
+	}
+	return updated, nil
+}

--- a/pkg/meta/tenant_pool_failed_cleanup.go
+++ b/pkg/meta/tenant_pool_failed_cleanup.go
@@ -55,6 +55,8 @@ func (s *Store) ListFailedSharedTenantCleanupCandidates(ctx context.Context, org
 	if limit <= 0 {
 		limit = 10
 	}
+	// Direct placement attribution intentionally requires an exact organization-owned pool.
+	// Wildcard pools cannot prove a tenant's resolved organization until that identity is persisted per tenant.
 	rows, err := s.db.QueryContext(ctx, `SELECT
 			c.id, c.status, c.kind, c.parent_tenant_id, c.storage_namespace_id,
 			c.db_host, c.db_port, c.db_user, c.db_password, c.db_name,

--- a/pkg/meta/tenant_pool_failed_cleanup_test.go
+++ b/pkg/meta/tenant_pool_failed_cleanup_test.go
@@ -1,0 +1,427 @@
+package meta
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestListFailedNativeTenantCleanupCandidatesUsesOrganizationEligibility(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	cutoff := now.Add(-30 * time.Minute)
+
+	seedNativeCleanupBinding(t, s, "native-free", "org-native", tidbCloudNativeProvider, TenantFailed,
+		"pool-native", TenantPoolBindingFree, now.Add(-4*time.Hour))
+	seedNativeCleanupBinding(t, s, "native-direct", "org-native", tidbCloudNativeProvider, TenantFailed,
+		"", TenantPoolBindingUsed, now.Add(-3*time.Hour))
+	seedNativeCleanupBinding(t, s, "native-claimed", "org-native", tidbCloudNativeProvider, TenantFailed,
+		"pool-native", TenantPoolBindingUsed, now.Add(-5*time.Hour))
+	seedNativeCleanupBinding(t, s, "native-wrong-org", "org-other", tidbCloudNativeProvider, TenantFailed,
+		"", TenantPoolBindingUsed, now.Add(-5*time.Hour))
+	seedNativeCleanupBinding(t, s, "native-recent", "org-native", tidbCloudNativeProvider, TenantFailed,
+		"", TenantPoolBindingUsed, now.Add(-5*time.Minute))
+	seedNativeCleanupBinding(t, s, "native-wrong-provider", "org-native", "tidb_zero", TenantFailed,
+		"", TenantPoolBindingUsed, now.Add(-5*time.Hour))
+	seedNativeCleanupBinding(t, s, "native-active", "org-native", tidbCloudNativeProvider, TenantActive,
+		"", TenantPoolBindingUsed, now.Add(-5*time.Hour))
+
+	got, err := s.ListFailedNativeTenantCleanupCandidates(ctx, "org-native", cutoff, 0)
+	if err != nil {
+		t.Fatalf("ListFailedNativeTenantCleanupCandidates default limit: %v", err)
+	}
+	if ids := tenantBindingIDs(got); fmt.Sprint(ids) != "[native-free]" {
+		t.Fatalf("default native candidates = %v, want oldest eligible tenant", ids)
+	}
+
+	got, err = s.ListFailedNativeTenantCleanupCandidates(ctx, "org-native", cutoff, 10)
+	if err != nil {
+		t.Fatalf("ListFailedNativeTenantCleanupCandidates: %v", err)
+	}
+	if ids := tenantBindingIDs(got); fmt.Sprint(ids) != "[native-free native-direct]" {
+		t.Fatalf("native cleanup candidates = %v, want free pool and direct tenants only", ids)
+	}
+}
+
+func TestListFailedSharedTenantCleanupCandidatesUsesMembershipOrPlacementOrganization(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	cutoff := now.Add(-30 * time.Minute)
+
+	seedSharedCleanupMembership(t, s, "shared-free", "org-shared", tidbCloudNativeSharedProvider,
+		TenantFailed, TenantPoolBindingFree, now.Add(-4*time.Hour))
+	seedSharedCleanupPlacement(t, s, "shared-direct", "org-shared", tidbCloudNativeSharedProvider,
+		TenantFailed, now.Add(-3*time.Hour))
+	for i := 0; i < 9; i++ {
+		seedSharedCleanupMembership(t, s, fmt.Sprintf("shared-extra-%02d", i), "org-shared",
+			tidbCloudNativeSharedProvider, TenantFailed, TenantPoolBindingFree, now.Add(-2*time.Hour))
+	}
+	seedSharedCleanupMembership(t, s, "shared-claimed", "org-shared", tidbCloudNativeSharedProvider,
+		TenantFailed, TenantPoolBindingUsed, now.Add(-5*time.Hour))
+	seedSharedCleanupPlacementForExistingTenant(t, s, "shared-claimed", "org-shared")
+	seedSharedCleanupMembership(t, s, "shared-wrong-membership-org", "org-other", tidbCloudNativeSharedProvider,
+		TenantFailed, TenantPoolBindingFree, now.Add(-5*time.Hour))
+	seedSharedCleanupPlacementForExistingTenant(t, s, "shared-wrong-membership-org", "org-shared")
+	seedSharedCleanupPlacement(t, s, "shared-wrong-placement-org", "org-other", tidbCloudNativeSharedProvider,
+		TenantFailed, now.Add(-5*time.Hour))
+	seedSharedCleanupPlacement(t, s, "shared-recent", "org-shared", tidbCloudNativeSharedProvider,
+		TenantFailed, now.Add(-5*time.Minute))
+	seedSharedCleanupMembership(t, s, "shared-wrong-provider", "org-shared", "tidb_zero",
+		TenantFailed, TenantPoolBindingFree, now.Add(-5*time.Hour))
+	seedSharedCleanupMembership(t, s, "shared-active", "org-shared", tidbCloudNativeSharedProvider,
+		TenantActive, TenantPoolBindingFree, now.Add(-5*time.Hour))
+
+	got, err := s.ListFailedSharedTenantCleanupCandidates(ctx, "org-shared", cutoff, 0)
+	if err != nil {
+		t.Fatalf("ListFailedSharedTenantCleanupCandidates default limit: %v", err)
+	}
+	wantDefault := []string{
+		"shared-free", "shared-direct", "shared-extra-00", "shared-extra-01", "shared-extra-02",
+		"shared-extra-03", "shared-extra-04", "shared-extra-05", "shared-extra-06", "shared-extra-07",
+	}
+	if ids := cleanupTenantIDs(got); fmt.Sprint(ids) != fmt.Sprint(wantDefault) {
+		t.Fatalf("default shared candidates = %v, want %v", ids, wantDefault)
+	}
+
+	got, err = s.ListFailedSharedTenantCleanupCandidates(ctx, "org-shared", cutoff, 20)
+	if err != nil {
+		t.Fatalf("ListFailedSharedTenantCleanupCandidates: %v", err)
+	}
+	wantAll := append(append([]string{}, wantDefault...), "shared-extra-08")
+	if ids := cleanupTenantIDs(got); fmt.Sprint(ids) != fmt.Sprint(wantAll) {
+		t.Fatalf("shared cleanup candidates = %v, want free-membership and direct-placement tenants %v", ids, wantAll)
+	}
+}
+
+func TestFailedTenantCleanupCooldownRestartsAfterTenantUpdate(t *testing.T) {
+	tests := []struct {
+		name string
+		seed func(*testing.T, *Store, string, time.Time)
+		list func(context.Context, *Store, time.Time) (int, error)
+	}{
+		{
+			name: "native",
+			seed: func(t *testing.T, s *Store, tenantID string, updatedAt time.Time) {
+				seedNativeCleanupBinding(t, s, tenantID, "org-cooldown", tidbCloudNativeProvider,
+					TenantFailed, "", TenantPoolBindingUsed, updatedAt)
+			},
+			list: func(ctx context.Context, s *Store, cutoff time.Time) (int, error) {
+				got, err := s.ListFailedNativeTenantCleanupCandidates(ctx, "org-cooldown", cutoff, 10)
+				return len(got), err
+			},
+		},
+		{
+			name: "shared",
+			seed: func(t *testing.T, s *Store, tenantID string, updatedAt time.Time) {
+				seedSharedCleanupPlacement(t, s, tenantID, "org-cooldown", tidbCloudNativeSharedProvider,
+					TenantFailed, updatedAt)
+			},
+			list: func(ctx context.Context, s *Store, cutoff time.Time) (int, error) {
+				got, err := s.ListFailedSharedTenantCleanupCandidates(ctx, "org-cooldown", cutoff, 10)
+				return len(got), err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newControlStore(t)
+			ctx := context.Background()
+			now := time.Now().UTC().Truncate(time.Millisecond)
+			cutoff := now.Add(-30 * time.Minute)
+			tenantID := tt.name + "-cooldown"
+			tt.seed(t, s, tenantID, now.Add(-2*time.Hour))
+
+			if count, err := tt.list(ctx, s, cutoff); err != nil || count != 1 {
+				t.Fatalf("list before tenant update = %d, %v; want one eligible candidate", count, err)
+			}
+			if _, err := s.DB().ExecContext(ctx, `UPDATE tenants SET schema_version = schema_version + 1 WHERE id = ?`, tenantID); err != nil {
+				t.Fatalf("unrelated tenant update: %v", err)
+			}
+			if count, err := tt.list(ctx, s, cutoff); err != nil || count != 0 {
+				t.Fatalf("list after tenant update = %d, %v; want cooldown restarted", count, err)
+			}
+		})
+	}
+}
+
+func TestMarkFailedTenantDeletingHasOneConcurrentWinnerForPoolAndDirectCandidates(t *testing.T) {
+	tests := []struct {
+		name string
+		seed func(*testing.T, *Store, string, time.Time)
+		mark func(context.Context, *Store, string, time.Time) (bool, error)
+	}{
+		{
+			name: "native-free",
+			seed: func(t *testing.T, s *Store, tenantID string, updatedAt time.Time) {
+				seedNativeCleanupBinding(t, s, tenantID, "org-race", tidbCloudNativeProvider,
+					TenantFailed, "pool-race", TenantPoolBindingFree, updatedAt)
+			},
+			mark: func(ctx context.Context, s *Store, tenantID string, cutoff time.Time) (bool, error) {
+				return s.MarkFailedNativeTenantDeleting(ctx, tenantID, "org-race", cutoff)
+			},
+		},
+		{
+			name: "native-direct",
+			seed: func(t *testing.T, s *Store, tenantID string, updatedAt time.Time) {
+				seedNativeCleanupBinding(t, s, tenantID, "org-race", tidbCloudNativeProvider,
+					TenantFailed, "", TenantPoolBindingUsed, updatedAt)
+			},
+			mark: func(ctx context.Context, s *Store, tenantID string, cutoff time.Time) (bool, error) {
+				return s.MarkFailedNativeTenantDeleting(ctx, tenantID, "org-race", cutoff)
+			},
+		},
+		{
+			name: "shared-free",
+			seed: func(t *testing.T, s *Store, tenantID string, updatedAt time.Time) {
+				seedSharedCleanupMembership(t, s, tenantID, "org-race", tidbCloudNativeSharedProvider,
+					TenantFailed, TenantPoolBindingFree, updatedAt)
+			},
+			mark: func(ctx context.Context, s *Store, tenantID string, cutoff time.Time) (bool, error) {
+				return s.MarkFailedSharedTenantDeleting(ctx, tenantID, "org-race", cutoff)
+			},
+		},
+		{
+			name: "shared-direct",
+			seed: func(t *testing.T, s *Store, tenantID string, updatedAt time.Time) {
+				seedSharedCleanupPlacement(t, s, tenantID, "org-race", tidbCloudNativeSharedProvider,
+					TenantFailed, updatedAt)
+			},
+			mark: func(ctx context.Context, s *Store, tenantID string, cutoff time.Time) (bool, error) {
+				return s.MarkFailedSharedTenantDeleting(ctx, tenantID, "org-race", cutoff)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newControlStore(t)
+			ctx := context.Background()
+			now := time.Now().UTC().Truncate(time.Millisecond)
+			cutoff := now.Add(-30 * time.Minute)
+			tenantID := "race-" + tt.name
+			tt.seed(t, s, tenantID, now.Add(-2*time.Hour))
+
+			start := make(chan struct{})
+			results := make(chan bool, 2)
+			errs := make(chan error, 2)
+			var wg sync.WaitGroup
+			for i := 0; i < 2; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					<-start
+					won, err := tt.mark(ctx, s, tenantID, cutoff)
+					results <- won
+					errs <- err
+				}()
+			}
+			close(start)
+			wg.Wait()
+			close(results)
+			close(errs)
+
+			winners := 0
+			for won := range results {
+				if won {
+					winners++
+				}
+			}
+			for err := range errs {
+				if err != nil {
+					t.Fatalf("concurrent mark: %v", err)
+				}
+			}
+			if winners != 1 {
+				t.Fatalf("concurrent winners = %d, want exactly 1", winners)
+			}
+			tenant, err := s.GetTenant(ctx, tenantID)
+			if err != nil || tenant.Status != TenantDeleting {
+				t.Fatalf("tenant after concurrent mark = %+v, %v; want deleting", tenant, err)
+			}
+		})
+	}
+}
+
+func TestMarkFailedTenantDeletingRefusesClaimedWrongOrganizationAndRecent(t *testing.T) {
+	tests := []struct {
+		name string
+		seed func(*testing.T, *Store, string, string, time.Time)
+		mark func(context.Context, *Store, string, time.Time) (bool, error)
+	}{
+		{
+			name: "native-claimed",
+			seed: func(t *testing.T, s *Store, tenantID, _ string, updatedAt time.Time) {
+				seedNativeCleanupBinding(t, s, tenantID, "org-refuse", tidbCloudNativeProvider,
+					TenantFailed, "pool-refuse", TenantPoolBindingUsed, updatedAt)
+			},
+			mark: markNativeCleanupForOrg("org-refuse"),
+		},
+		{
+			name: "native-wrong-org",
+			seed: func(t *testing.T, s *Store, tenantID, _ string, updatedAt time.Time) {
+				seedNativeCleanupBinding(t, s, tenantID, "org-other", tidbCloudNativeProvider,
+					TenantFailed, "", TenantPoolBindingUsed, updatedAt)
+			},
+			mark: markNativeCleanupForOrg("org-refuse"),
+		},
+		{
+			name: "native-recent",
+			seed: func(t *testing.T, s *Store, tenantID, _ string, updatedAt time.Time) {
+				seedNativeCleanupBinding(t, s, tenantID, "org-refuse", tidbCloudNativeProvider,
+					TenantFailed, "", TenantPoolBindingUsed, updatedAt)
+			},
+			mark: markNativeCleanupForOrg("org-refuse"),
+		},
+		{
+			name: "shared-claimed",
+			seed: func(t *testing.T, s *Store, tenantID, _ string, updatedAt time.Time) {
+				seedSharedCleanupMembership(t, s, tenantID, "org-refuse", tidbCloudNativeSharedProvider,
+					TenantFailed, TenantPoolBindingUsed, updatedAt)
+			},
+			mark: markSharedCleanupForOrg("org-refuse"),
+		},
+		{
+			name: "shared-wrong-org",
+			seed: func(t *testing.T, s *Store, tenantID, _ string, updatedAt time.Time) {
+				seedSharedCleanupPlacement(t, s, tenantID, "org-other", tidbCloudNativeSharedProvider,
+					TenantFailed, updatedAt)
+			},
+			mark: markSharedCleanupForOrg("org-refuse"),
+		},
+		{
+			name: "shared-recent",
+			seed: func(t *testing.T, s *Store, tenantID, _ string, updatedAt time.Time) {
+				seedSharedCleanupPlacement(t, s, tenantID, "org-refuse", tidbCloudNativeSharedProvider,
+					TenantFailed, updatedAt)
+			},
+			mark: markSharedCleanupForOrg("org-refuse"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newControlStore(t)
+			ctx := context.Background()
+			now := time.Now().UTC().Truncate(time.Millisecond)
+			tenantID := "refuse-" + tt.name
+			updatedAt := now.Add(-2 * time.Hour)
+			if tt.name == "native-recent" || tt.name == "shared-recent" {
+				updatedAt = now.Add(-5 * time.Minute)
+			}
+			tt.seed(t, s, tenantID, "org-refuse", updatedAt)
+			won, err := tt.mark(ctx, s, tenantID, now.Add(-30*time.Minute))
+			if err != nil {
+				t.Fatalf("mark refused candidate: %v", err)
+			}
+			if won {
+				t.Fatal("mark won for ineligible tenant")
+			}
+			tenant, err := s.GetTenant(ctx, tenantID)
+			if err != nil || tenant.Status != TenantFailed {
+				t.Fatalf("tenant after refused mark = %+v, %v; want failed", tenant, err)
+			}
+		})
+	}
+}
+
+func markNativeCleanupForOrg(organizationID string) func(context.Context, *Store, string, time.Time) (bool, error) {
+	return func(ctx context.Context, s *Store, tenantID string, cutoff time.Time) (bool, error) {
+		return s.MarkFailedNativeTenantDeleting(ctx, tenantID, organizationID, cutoff)
+	}
+}
+
+func markSharedCleanupForOrg(organizationID string) func(context.Context, *Store, string, time.Time) (bool, error) {
+	return func(ctx context.Context, s *Store, tenantID string, cutoff time.Time) (bool, error) {
+		return s.MarkFailedSharedTenantDeleting(ctx, tenantID, organizationID, cutoff)
+	}
+}
+
+func seedNativeCleanupBinding(t *testing.T, s *Store, tenantID, organizationID, provider string, status TenantStatus, poolID string, poolStatus TenantPoolBindingStatus, updatedAt time.Time) {
+	t.Helper()
+	insertCleanupTenant(t, s, tenantID, provider, status, updatedAt)
+	if err := s.UpsertTenantTiDBCloudOrgBinding(context.Background(), &TenantTiDBCloudOrgBinding{
+		TenantID: tenantID, OrganizationID: organizationID, ClusterID: "cluster-" + tenantID,
+		PoolID: poolID, PoolStatus: poolStatus, CreatedAt: updatedAt, UpdatedAt: updatedAt,
+	}); err != nil {
+		t.Fatalf("UpsertTenantTiDBCloudOrgBinding(%s): %v", tenantID, err)
+	}
+}
+
+func seedSharedCleanupMembership(t *testing.T, s *Store, tenantID, organizationID, provider string, status TenantStatus, poolStatus TenantPoolBindingStatus, updatedAt time.Time) {
+	t.Helper()
+	insertCleanupTenant(t, s, tenantID, provider, status, updatedAt)
+	if provider == tidbCloudNativeSharedProvider {
+		if err := s.UpsertTenantPoolMembership(context.Background(), &TenantPoolMembership{
+			TenantID: tenantID, TiDBCloudOrganizationID: organizationID, PoolID: "pool-" + organizationID,
+			PoolStatus: poolStatus, CreatedAt: updatedAt, UpdatedAt: updatedAt,
+		}); err != nil {
+			t.Fatalf("UpsertTenantPoolMembership(%s): %v", tenantID, err)
+		}
+		return
+	}
+	if _, err := s.DB().ExecContext(context.Background(), `INSERT INTO tenant_pool_memberships
+		(tenant_id, tidbcloud_organization_id, pool_id, pool_status, created_at, updated_at)
+		VALUES (?, ?, ?, ?, ?, ?)`, tenantID, organizationID, "pool-"+organizationID,
+		poolStatus, updatedAt, updatedAt); err != nil {
+		t.Fatalf("insert mismatched tenant pool membership %s: %v", tenantID, err)
+	}
+}
+
+func seedSharedCleanupPlacement(t *testing.T, s *Store, tenantID, organizationID, provider string, status TenantStatus, updatedAt time.Time) {
+	t.Helper()
+	insertCleanupTenant(t, s, tenantID, provider, status, updatedAt)
+	seedSharedCleanupPlacementForExistingTenant(t, s, tenantID, organizationID)
+}
+
+func seedSharedCleanupPlacementForExistingTenant(t *testing.T, s *Store, tenantID, organizationID string) {
+	t.Helper()
+	dbID, err := s.RegisterSharedDB(context.Background(), &SharedDB{
+		TiDBCloudOrganizationID: organizationID, Host: "host-" + tenantID, Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "db_" + tenantID,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB(%s): %v", tenantID, err)
+	}
+	fsID, err := s.ResolveFsID(context.Background(), tenantID)
+	if err != nil {
+		t.Fatalf("ResolveFsID(%s): %v", tenantID, err)
+	}
+	if err := s.UpsertTenantPlacement(context.Background(), &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement(%s): %v", tenantID, err)
+	}
+}
+
+func insertCleanupTenant(t *testing.T, s *Store, tenantID, provider string, status TenantStatus, updatedAt time.Time) {
+	t.Helper()
+	if err := s.InsertTenant(context.Background(), &Tenant{
+		ID: tenantID, Status: status, Kind: TenantKindLive, DBHost: "db.example.com", DBPort: 4000,
+		DBUser: "root", DBPasswordCipher: []byte("cipher"), DBName: "tidbcloud_fs", DBTLS: true,
+		Provider: provider, ClusterID: "cluster-" + tenantID, SchemaVersion: 1,
+		CreatedAt: updatedAt, UpdatedAt: updatedAt,
+	}); err != nil {
+		t.Fatalf("InsertTenant(%s): %v", tenantID, err)
+	}
+}
+
+func tenantBindingIDs(rows []TenantWithTiDBCloudOrgBinding) []string {
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.Tenant.ID)
+	}
+	return ids
+}
+
+func cleanupTenantIDs(rows []Tenant) []string {
+	ids := make([]string, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.ID)
+	}
+	return ids
+}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1657,9 +1657,7 @@ func (s *Server) deleteFreeSharedPoolTenant(ctx context.Context, t *meta.Tenant)
 		if err != nil {
 			return err
 		}
-		connectionReady := dbPool.Status == meta.SharedDBStatusActive && dbPool.Host != "" &&
-			dbPool.Port > 0 && dbPool.User != "" && len(dbPool.PasswordCipher) > 0 && dbPool.Name != ""
-		if connectionReady {
+		if sharedDBConnectionReady(dbPool) {
 			if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
 				return err
 			}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1918,6 +1918,8 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		return nil, nil, false, false, err
 	}
 	logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_org_lookup_done", "provider", tenant.ProviderTiDBCloudNative, "organization_id", orgID, "duration_ms", durationMillis(stageStarted))...)
+	cleanupCred := cred
+	defer s.startTenantFailedCleanupAsync(ctx, orgID, cleanupCred)
 	stageStarted = time.Now()
 	pool, err := s.meta.GetTenantPoolByOrganization(ctx, orgID)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -217,6 +217,8 @@ type Server struct {
 	tenantPoolLocks           sync.Map
 	tenantPoolCreateLocks     sync.Map
 	tenantPoolResumeJobs      sync.Map
+	tenantFailedCleanupJobs   sync.Map
+	tenantFailedCleanupRunner tenantFailedCleanupRunner
 	tidbCloudRBACCache        *tidbCloudRBACCache
 	schemaInitErrors          sync.Map
 	leader                    *leader.Manager
@@ -1257,7 +1259,7 @@ func backgroundWithTrace(ctx context.Context) context.Context {
 	return contextWithTrace(context.Background(), ctx)
 }
 
-func (s *Server) startServerWorker(ctx context.Context, fn func(context.Context)) {
+func (s *Server) startServerWorker(ctx context.Context, fn func(context.Context)) bool {
 	workerCtx := backgroundWithTrace(ctx)
 	if s.forkWorkerCtx != nil {
 		workerCtx = contextWithTrace(s.forkWorkerCtx, ctx)
@@ -1267,7 +1269,7 @@ func (s *Server) startServerWorker(ctx context.Context, fn func(context.Context)
 	if s.forkWorkerClosed {
 		s.forkWorkerMu.Unlock()
 		logger.Warn(workerCtx, "server_worker_start_after_close")
-		return
+		return false
 	}
 	s.forkWorkerWG.Add(1)
 	s.forkWorkerMu.Unlock()
@@ -1276,6 +1278,7 @@ func (s *Server) startServerWorker(ctx context.Context, fn func(context.Context)
 		defer s.forkWorkerWG.Done()
 		fn(workerCtx)
 	}()
+	return true
 }
 
 func ensureTrace(ctx context.Context) context.Context {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -25,6 +25,13 @@ const (
 
 var errSharedDBConnectionMetadataNotReady = errors.New("shared DB pool connection metadata is not ready")
 
+func sharedDBConnectionReady(db *meta.SharedDB) bool {
+	return db != nil && db.Status == meta.SharedDBStatusActive &&
+		strings.TrimSpace(db.Host) != "" && db.Port > 0 &&
+		strings.TrimSpace(db.User) != "" && len(db.PasswordCipher) > 0 &&
+		strings.TrimSpace(db.Name) != ""
+}
+
 type defaultTiDBCloudSpendingLimitProvider interface {
 	DefaultTiDBCloudSpendingLimit() int64
 }

--- a/pkg/server/tenant_failed_cleanup.go
+++ b/pkg/server/tenant_failed_cleanup.go
@@ -1,0 +1,410 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+)
+
+var (
+	tenantFailedCleanupRetryDelay      = 15 * time.Minute
+	tenantFailedCleanupRestoreTimeout  = 5 * time.Second
+	tenantFailedCleanupMinInterval     = time.Minute
+	tenantFailedCleanupNativeBatchSize = 1
+	tenantFailedCleanupSharedBatchSize = 10
+)
+
+const (
+	tenantFailedCleanupNativeOperation = "cleanup_failed_tidb_cloud_native"
+	tenantFailedCleanupSharedOperation = "cleanup_failed_tidb_cloud_native_shared"
+)
+
+type failedNativeTenantCleanupLoader func(context.Context, string, time.Time, int) ([]meta.TenantWithTiDBCloudOrgBinding, error)
+type failedSharedTenantCleanupLoader func(context.Context, string, time.Time, int) ([]meta.Tenant, error)
+type failedTenantAPIKeyRevoker func(context.Context, string) error
+type failedTenantStatusUpdater func(context.Context, string, meta.TenantStatus, meta.TenantStatus) (bool, error)
+type tenantFailedCleanupRunner func(context.Context, string, tenant.CredentialProvisionRequest)
+
+type tenantFailedCleanupJobState struct {
+	mu          sync.Mutex
+	active      bool
+	lastStarted time.Time
+}
+
+func (s *Server) startTenantFailedCleanupAsync(
+	ctx context.Context,
+	organizationID string,
+	cred tenant.CredentialProvisionRequest,
+) {
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" {
+		return
+	}
+	value, _ := s.tenantFailedCleanupJobs.LoadOrStore(organizationID, &tenantFailedCleanupJobState{})
+	state := value.(*tenantFailedCleanupJobState)
+	now := time.Now().UTC()
+
+	state.mu.Lock()
+	if state.active {
+		state.mu.Unlock()
+		logger.Info(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_per_pod_skipped",
+			"organization_id", organizationID,
+			"reason", "active")...)
+		return
+	}
+	if tenantFailedCleanupMinInterval > 0 && !state.lastStarted.IsZero() &&
+		now.Sub(state.lastStarted) < tenantFailedCleanupMinInterval {
+		lastStarted := state.lastStarted
+		state.mu.Unlock()
+		logger.Info(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_per_pod_skipped",
+			"organization_id", organizationID,
+			"reason", "cooldown",
+			"last_started", lastStarted,
+			"min_interval", tenantFailedCleanupMinInterval)...)
+		return
+	}
+	previousStart := state.lastStarted
+	state.active = true
+	state.lastStarted = now
+	state.mu.Unlock()
+
+	started := s.startServerWorker(ctx, func(workerCtx context.Context) {
+		defer func() {
+			state.mu.Lock()
+			state.active = false
+			state.mu.Unlock()
+		}()
+		runner := s.tenantFailedCleanupRunner
+		if runner == nil {
+			runner = s.cleanupFailedOrganizationTenants
+		}
+		runner(workerCtx, organizationID, cred)
+	})
+	if started {
+		return
+	}
+	state.mu.Lock()
+	state.active = false
+	state.lastStarted = previousStart
+	state.mu.Unlock()
+}
+
+// cleanupFailedOrganizationTenants synchronously makes one bounded cleanup
+// pass for an organization. Native and shared candidates are independent: a
+// list or candidate failure in either provider never prevents the other pass.
+func (s *Server) cleanupFailedOrganizationTenants(ctx context.Context, organizationID string, cred tenant.CredentialProvisionRequest) {
+	if s.meta == nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_failed",
+			"organization_id", strings.TrimSpace(organizationID),
+			"stage", "meta_unavailable")...)
+		return
+	}
+	s.cleanupFailedOrganizationTenantsWithLoaders(
+		ctx, organizationID, cred,
+		s.meta.ListFailedNativeTenantCleanupCandidates,
+		s.meta.ListFailedSharedTenantCleanupCandidates,
+	)
+}
+
+func (s *Server) cleanupFailedOrganizationTenantsWithLoaders(
+	ctx context.Context,
+	organizationID string,
+	cred tenant.CredentialProvisionRequest,
+	nativeLoader failedNativeTenantCleanupLoader,
+	sharedLoader failedSharedTenantCleanupLoader,
+) {
+	organizationID = strings.TrimSpace(organizationID)
+	cutoff := time.Now().UTC().Add(-tenantFailedCleanupRetryDelay)
+	logger.Info(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_started",
+		"organization_id", organizationID,
+		"cutoff", cutoff,
+		"native_batch_size", tenantFailedCleanupNativeBatchSize,
+		"shared_batch_size", tenantFailedCleanupSharedBatchSize)...)
+	nativeCandidates, err := nativeLoader(
+		ctx, organizationID, cutoff, tenantFailedCleanupNativeBatchSize)
+	if err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_list_failed",
+			"organization_id", organizationID,
+			"provider", tenant.ProviderTiDBCloudNative,
+			"stage", "list",
+			"error", err)...)
+	} else {
+		for i := range nativeCandidates {
+			candidate := &nativeCandidates[i]
+			started := time.Now()
+			owned, cleanupErr := s.cleanupFailedNativeTenant(ctx, organizationID, cutoff, cred, candidate)
+			if owned {
+				metrics.RecordOperation(adminTenantPoolMetricsComponent, tenantFailedCleanupNativeOperation,
+					metrics.ResultForError(cleanupErr), time.Since(started))
+			}
+			if cleanupErr != nil {
+				logger.Error(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_candidate_failed",
+					"organization_id", organizationID,
+					"tenant_id", candidate.Tenant.ID,
+					"provider", tenant.ProviderTiDBCloudNative,
+					"stage", tenantFailedCleanupStage(cleanupErr),
+					"owned", owned,
+					"error", cleanupErr)...)
+			}
+		}
+	}
+
+	sharedCandidates, err := sharedLoader(
+		ctx, organizationID, cutoff, tenantFailedCleanupSharedBatchSize)
+	if err != nil {
+		logger.Error(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_list_failed",
+			"organization_id", organizationID,
+			"provider", tenant.ProviderTiDBCloudNativeShared,
+			"stage", "list",
+			"error", err)...)
+	} else {
+		for i := range sharedCandidates {
+			candidate := &sharedCandidates[i]
+			started := time.Now()
+			owned, cleanupErr := s.cleanupFailedSharedTenant(ctx, organizationID, cutoff, candidate)
+			if owned {
+				metrics.RecordOperation(adminTenantPoolMetricsComponent, tenantFailedCleanupSharedOperation,
+					metrics.ResultForError(cleanupErr), time.Since(started))
+			}
+			if cleanupErr != nil {
+				logger.Error(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_candidate_failed",
+					"organization_id", organizationID,
+					"tenant_id", candidate.ID,
+					"provider", tenant.ProviderTiDBCloudNativeShared,
+					"stage", tenantFailedCleanupStage(cleanupErr),
+					"owned", owned,
+					"error", cleanupErr)...)
+			}
+		}
+	}
+	logger.Info(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_done",
+		"organization_id", organizationID,
+		"cutoff", cutoff,
+		"native_candidates", len(nativeCandidates),
+		"shared_candidates", len(sharedCandidates))...)
+}
+
+func tenantFailedCleanupStage(err error) string {
+	if err == nil {
+		return "done"
+	}
+	stage, _, ok := strings.Cut(err.Error(), ":")
+	if !ok || strings.TrimSpace(stage) == "" {
+		return "candidate"
+	}
+	return strings.TrimSpace(stage)
+}
+
+func (s *Server) cleanupFailedNativeTenant(
+	ctx context.Context,
+	organizationID string,
+	cutoff time.Time,
+	cred tenant.CredentialProvisionRequest,
+	candidate *meta.TenantWithTiDBCloudOrgBinding,
+) (owned bool, err error) {
+	return s.cleanupFailedNativeTenantWithDependencies(
+		ctx, organizationID, cutoff, cred, candidate,
+		s.meta.RevokeTenantAPIKeys,
+		s.meta.UpdateTenantStatusIf,
+	)
+}
+
+func (s *Server) cleanupFailedNativeTenantWithDependencies(
+	ctx context.Context,
+	organizationID string,
+	cutoff time.Time,
+	cred tenant.CredentialProvisionRequest,
+	candidate *meta.TenantWithTiDBCloudOrgBinding,
+	revokeTenantAPIKeys failedTenantAPIKeyRevoker,
+	restoreStatus failedTenantStatusUpdater,
+) (owned bool, err error) {
+	if candidate == nil {
+		return false, fmt.Errorf("claim: native cleanup candidate is required")
+	}
+	tenantID := candidate.Tenant.ID
+	owned, err = s.meta.MarkFailedNativeTenantDeleting(ctx, tenantID, organizationID, cutoff)
+	if err != nil {
+		return false, fmt.Errorf("claim: %w", err)
+	}
+	if !owned {
+		return false, nil
+	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		s.restoreFailedTenantAfterCleanupWithUpdater(
+			ctx, tenantID, tenant.ProviderTiDBCloudNative, organizationID, err, restoreStatus)
+	}()
+
+	t := candidate.Tenant
+	if strings.TrimSpace(t.ClusterID) == "" {
+		t.ClusterID = strings.TrimSpace(candidate.Binding.ClusterID)
+	}
+	if strings.TrimSpace(t.ClusterID) != "" {
+		if err := s.deprovisionTenantCluster(ctx, &t, cred); err != nil {
+			return true, fmt.Errorf("deprovision: %w", err)
+		}
+	} else {
+		logger.Info(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_native_cloud_skipped",
+			"organization_id", organizationID,
+			"tenant_id", tenantID,
+			"provider", tenant.ProviderTiDBCloudNative,
+			"stage", "deprovision",
+			"reason", "cluster_id_empty")...)
+	}
+	if err := revokeTenantAPIKeys(ctx, tenantID); err != nil {
+		logger.Warn(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_revoke_keys_failed",
+			"organization_id", organizationID,
+			"tenant_id", tenantID,
+			"provider", tenant.ProviderTiDBCloudNative,
+			"stage", "revoke_keys",
+			"error", err)...)
+	}
+	if err := s.meta.MarkTenantDeleted(ctx, tenantID); err != nil {
+		return true, fmt.Errorf("finalize_metadata: %w", err)
+	}
+	logger.Info(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_candidate_done",
+		"organization_id", organizationID,
+		"tenant_id", tenantID,
+		"provider", tenant.ProviderTiDBCloudNative,
+		"stage", "done")...)
+	return true, nil
+}
+
+func (s *Server) cleanupFailedSharedTenant(
+	ctx context.Context,
+	organizationID string,
+	cutoff time.Time,
+	candidate *meta.Tenant,
+) (owned bool, err error) {
+	if candidate == nil {
+		return false, fmt.Errorf("claim: shared cleanup candidate is required")
+	}
+	tenantID := candidate.ID
+	owned, err = s.meta.MarkFailedSharedTenantDeleting(ctx, tenantID, organizationID, cutoff)
+	if err != nil {
+		return false, fmt.Errorf("claim: %w", err)
+	}
+	if !owned {
+		return false, nil
+	}
+	defer func() {
+		if err == nil {
+			return
+		}
+		s.restoreFailedTenantAfterCleanup(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, organizationID, err)
+	}()
+
+	if strings.TrimSpace(candidate.StorageNamespaceID) != "" {
+		return true, fmt.Errorf("validate_namespace: failed provisioning tenant has storage namespace %q",
+			candidate.StorageNamespaceID)
+	}
+	if s.pool == nil {
+		return true, fmt.Errorf("invalidate_backend: tenant pool is unavailable")
+	}
+	if err := s.pool.InvalidateAndWait(ctx, tenantID); err != nil {
+		return true, fmt.Errorf("invalidate_backend: %w", err)
+	}
+	fsID, err := s.meta.ResolveFsID(ctx, tenantID)
+	if err != nil {
+		return true, fmt.Errorf("resolve_fs_id: %w", err)
+	}
+	placement, err := s.meta.GetTenantPlacement(ctx, fsID)
+	if err != nil {
+		return true, fmt.Errorf("resolve_placement: %w", err)
+	}
+	dbPool, err := s.meta.GetSharedDB(ctx, placement.DbID)
+	if err != nil {
+		return true, fmt.Errorf("resolve_shared_db: %w", err)
+	}
+	connectionReady := dbPool.Status == meta.SharedDBStatusActive &&
+		strings.TrimSpace(dbPool.Host) != "" && dbPool.Port > 0 &&
+		strings.TrimSpace(dbPool.User) != "" && len(dbPool.PasswordCipher) > 0 &&
+		strings.TrimSpace(dbPool.Name) != ""
+	if connectionReady {
+		if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
+			return true, fmt.Errorf("purge_shared_tenant: %w", err)
+		}
+	} else {
+		logger.Info(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_shared_purge_skipped",
+			"organization_id", organizationID,
+			"tenant_id", tenantID,
+			"provider", tenant.ProviderTiDBCloudNativeShared,
+			"stage", "purge",
+			"db_id", placement.DbID,
+			"db_status", dbPool.Status,
+			"reason", "shared_db_unready")...)
+	}
+	if err := s.meta.AbortActiveUploadReservations(ctx, tenantID); err != nil {
+		logger.Warn(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_abort_reservations_failed",
+			"organization_id", organizationID,
+			"tenant_id", tenantID,
+			"provider", tenant.ProviderTiDBCloudNativeShared,
+			"stage", "abort_reservations",
+			"error", err)...)
+	}
+	if err := s.meta.FinalizeSharedTenantDeleteMetadata(
+		ctx, tenantID, fsID, placement.DbID, s.sharedDBReopenRatio, true); err != nil {
+		return true, fmt.Errorf("finalize_metadata: %w", err)
+	}
+	if err := s.meta.RevokeTenantAPIKeys(ctx, tenantID); err != nil {
+		logger.Warn(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_revoke_keys_failed",
+			"organization_id", organizationID,
+			"tenant_id", tenantID,
+			"provider", tenant.ProviderTiDBCloudNativeShared,
+			"stage", "revoke_keys",
+			"error", err)...)
+	}
+	logger.Info(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_candidate_done",
+		"organization_id", organizationID,
+		"tenant_id", tenantID,
+		"provider", tenant.ProviderTiDBCloudNativeShared,
+		"stage", "done")...)
+	return true, nil
+}
+
+func (s *Server) restoreFailedTenantAfterCleanup(
+	ctx context.Context,
+	tenantID, provider, organizationID string,
+	cleanupErr error,
+) {
+	s.restoreFailedTenantAfterCleanupWithUpdater(
+		ctx, tenantID, provider, organizationID, cleanupErr, s.meta.UpdateTenantStatusIf)
+}
+
+func (s *Server) restoreFailedTenantAfterCleanupWithUpdater(
+	ctx context.Context,
+	tenantID, provider, organizationID string,
+	cleanupErr error,
+	updateStatus failedTenantStatusUpdater,
+) {
+	restoreCtx, cancel := context.WithTimeout(backgroundWithTrace(ctx), tenantFailedCleanupRestoreTimeout)
+	defer cancel()
+	restored, restoreErr := updateStatus(
+		restoreCtx, tenantID, meta.TenantDeleting, meta.TenantFailed)
+	if restoreErr != nil {
+		logger.Error(restoreCtx, "server_event", eventFields(restoreCtx, "tenant_failed_cleanup_restore_failed",
+			"organization_id", organizationID,
+			"tenant_id", tenantID,
+			"provider", provider,
+			"stage", "restore_failed",
+			"cleanup_error", cleanupErr,
+			"error", restoreErr)...)
+		return
+	}
+	logger.Info(restoreCtx, "server_event", eventFields(restoreCtx, "tenant_failed_cleanup_restored",
+		"organization_id", organizationID,
+		"tenant_id", tenantID,
+		"provider", provider,
+		"stage", "restore_failed",
+		"restored", restored,
+		"cleanup_error", cleanupErr)...)
+}

--- a/pkg/server/tenant_failed_cleanup.go
+++ b/pkg/server/tenant_failed_cleanup.go
@@ -325,11 +325,7 @@ func (s *Server) cleanupFailedSharedTenant(
 	if err != nil {
 		return true, fmt.Errorf("resolve_shared_db: %w", err)
 	}
-	connectionReady := dbPool.Status == meta.SharedDBStatusActive &&
-		strings.TrimSpace(dbPool.Host) != "" && dbPool.Port > 0 &&
-		strings.TrimSpace(dbPool.User) != "" && len(dbPool.PasswordCipher) > 0 &&
-		strings.TrimSpace(dbPool.Name) != ""
-	if connectionReady {
+	if sharedDBConnectionReady(dbPool) {
 		if err := s.pool.PurgeSharedTenant(ctx, fsID, placement.DbID); err != nil {
 			return true, fmt.Errorf("purge_shared_tenant: %w", err)
 		}

--- a/pkg/server/tenant_failed_cleanup_test.go
+++ b/pkg/server/tenant_failed_cleanup_test.go
@@ -1,0 +1,782 @@
+package server
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/internal/testmysql"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+	tenantschema "github.com/mem9-ai/drive9/pkg/tenant/schema"
+	"github.com/mem9-ai/drive9/pkg/tenant/token"
+	"github.com/mem9-ai/drive9/pkg/traceid"
+)
+
+const failedCleanupTestOrganizationID = "org-failed-cleanup"
+
+func TestCleanupFailedOrganizationTenantsNativePoolFree(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNative, "cluster-pool-free", "", old)
+	upsertFailedCleanupNativeBinding(t, rt, rt.tenantID, "cluster-pool-free", "pool-native", meta.TenantPoolBindingFree)
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID, cred)
+
+	assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantDeleted)
+	if _, err := rt.meta.GetTenantTiDBCloudOrgBinding(ctx, rt.tenantID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("native binding after cleanup error = %v, want %v", err, meta.ErrNotFound)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	cluster := rt.prov.lastDeprovisionSnapshot()
+	if cluster == nil || cluster.ClusterID != "cluster-pool-free" {
+		t.Fatalf("deprovision cluster = %#v", cluster)
+	}
+	if got := rt.prov.lastCredentialsSnapshot(); got != cred {
+		t.Fatalf("deprovision credentials = %#v, want %#v", got, cred)
+	}
+	assertNoActiveFailedCleanupKeys(t, rt, rt.tenantID)
+}
+
+func TestCleanupFailedOrganizationTenantsNativeDirectBinding(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNative, "cluster-direct", "", old)
+	upsertFailedCleanupNativeBinding(t, rt, rt.tenantID, "cluster-direct", "", meta.TenantPoolBindingUsed)
+
+	rt.server.cleanupFailedOrganizationTenants(context.Background(), failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantDeleted)
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsNativeUsesBindingClusterFallback(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNative, "", "", old)
+	upsertFailedCleanupNativeBinding(t, rt, rt.tenantID, "cluster-binding-fallback", "pool-native", meta.TenantPoolBindingFree)
+
+	rt.server.cleanupFailedOrganizationTenants(context.Background(), failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantDeleted)
+	cluster := rt.prov.lastDeprovisionSnapshot()
+	if cluster == nil || cluster.ClusterID != "cluster-binding-fallback" {
+		t.Fatalf("deprovision cluster = %#v, want binding cluster fallback", cluster)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsNativeDeprovisionFailureRestoresCooldown(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNative, "cluster-fails", "", old)
+	upsertFailedCleanupNativeBinding(t, rt, rt.tenantID, "cluster-fails", "pool-native", meta.TenantPoolBindingFree)
+	rt.prov.deprovisionErr = errors.New("cloud unavailable")
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	failed := assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantFailed)
+	if !failed.UpdatedAt.After(old) {
+		t.Fatalf("updated_at = %s, want after %s", failed.UpdatedAt, old)
+	}
+	if _, err := rt.meta.GetTenantTiDBCloudOrgBinding(ctx, rt.tenantID); err != nil {
+		t.Fatalf("native binding after failed deprovision: %v", err)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls after immediate rerun = %d, want cooldown to keep 1", got)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsNativeRevokeFailureStillFinalizes(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNative, "cluster-revoke-failure", "", old)
+	upsertFailedCleanupNativeBinding(t, rt, rt.tenantID, "cluster-revoke-failure", "pool-native", meta.TenantPoolBindingFree)
+	cutoff := time.Now().UTC()
+	candidates, err := rt.meta.ListFailedNativeTenantCleanupCandidates(
+		ctx, failedCleanupTestOrganizationID, cutoff, 1)
+	if err != nil {
+		t.Fatalf("list native cleanup candidate: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("native cleanup candidates = %d, want 1", len(candidates))
+	}
+	revokeErr := errors.New("revoke metadata unavailable")
+	revokeCalls := 0
+
+	owned, cleanupErr := rt.server.cleanupFailedNativeTenantWithDependencies(
+		ctx, failedCleanupTestOrganizationID, cutoff,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"},
+		&candidates[0],
+		func(context.Context, string) error {
+			revokeCalls++
+			return revokeErr
+		},
+		rt.meta.UpdateTenantStatusIf,
+	)
+
+	if !owned {
+		t.Fatal("native cleanup owned = false, want true")
+	}
+	if cleanupErr != nil {
+		t.Fatalf("native cleanup error = %v, want nil despite revoke failure", cleanupErr)
+	}
+	if revokeCalls != 1 {
+		t.Fatalf("revoke calls = %d, want 1", revokeCalls)
+	}
+	assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantDeleted)
+	if _, err := rt.meta.GetTenantTiDBCloudOrgBinding(ctx, rt.tenantID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("native binding after revoke failure error = %v, want %v", err, meta.ErrNotFound)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls after second pass = %d, want 1", got)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsRestoreIgnoresCallerCancellationAndPreservesTrace(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	if err := rt.meta.UpdateTenantStatus(ctx, rt.tenantID, meta.TenantDeleting); err != nil {
+		t.Fatalf("mark tenant deleting: %v", err)
+	}
+	const wantTraceID = "failed-cleanup-restore-trace"
+	canceledCtx, cancel := context.WithCancel(traceid.With(ctx, wantTraceID))
+	cancel()
+	var (
+		updaterContextErr error
+		gotTraceID        string
+	)
+
+	rt.server.restoreFailedTenantAfterCleanupWithUpdater(
+		canceledCtx, rt.tenantID, tenant.ProviderTiDBCloudNative,
+		failedCleanupTestOrganizationID, errors.New("cleanup failed"),
+		func(updateCtx context.Context, tenantID string, from, to meta.TenantStatus) (bool, error) {
+			updaterContextErr = updateCtx.Err()
+			gotTraceID = traceid.FromContext(updateCtx)
+			return rt.meta.UpdateTenantStatusIf(updateCtx, tenantID, from, to)
+		},
+	)
+
+	if updaterContextErr != nil {
+		t.Fatalf("restore updater context error = %v, want nil despite canceled caller", updaterContextErr)
+	}
+	if gotTraceID != wantTraceID {
+		t.Fatalf("restore trace_id = %q, want %q", gotTraceID, wantTraceID)
+	}
+	assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantFailed)
+}
+
+func TestCleanupFailedOrganizationTenantsRestoreTimeoutPreservesCleanupError(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNative, "cluster-restore-timeout", "", old)
+	upsertFailedCleanupNativeBinding(t, rt, rt.tenantID, "cluster-restore-timeout", "pool-native", meta.TenantPoolBindingFree)
+	cutoff := time.Now().UTC()
+	candidates, err := rt.meta.ListFailedNativeTenantCleanupCandidates(
+		ctx, failedCleanupTestOrganizationID, cutoff, 1)
+	if err != nil {
+		t.Fatalf("list native cleanup candidate: %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("native cleanup candidates = %d, want 1", len(candidates))
+	}
+	originalTimeout := tenantFailedCleanupRestoreTimeout
+	tenantFailedCleanupRestoreTimeout = 25 * time.Millisecond
+	t.Cleanup(func() { tenantFailedCleanupRestoreTimeout = originalTimeout })
+	cleanupCause := errors.New("cloud deprovision failed")
+	rt.prov.deprovisionErr = cleanupCause
+	var updaterErr error
+	started := time.Now()
+
+	owned, cleanupErr := rt.server.cleanupFailedNativeTenantWithDependencies(
+		ctx, failedCleanupTestOrganizationID, cutoff,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"},
+		&candidates[0], rt.meta.RevokeTenantAPIKeys,
+		func(updateCtx context.Context, _ string, _, _ meta.TenantStatus) (bool, error) {
+			<-updateCtx.Done()
+			updaterErr = updateCtx.Err()
+			return false, updaterErr
+		},
+	)
+	elapsed := time.Since(started)
+
+	if !owned {
+		t.Fatal("native cleanup owned = false, want true")
+	}
+	if !errors.Is(cleanupErr, cleanupCause) {
+		t.Fatalf("cleanup error = %v, want original cause %v", cleanupErr, cleanupCause)
+	}
+	if !errors.Is(updaterErr, context.DeadlineExceeded) {
+		t.Fatalf("restore updater error = %v, want %v", updaterErr, context.DeadlineExceeded)
+	}
+	if elapsed > time.Second {
+		t.Fatalf("blocked restore returned after %s, want within 1s", elapsed)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsSkipsClaimedNativeBinding(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNative, "cluster-claimed", "", old)
+	upsertFailedCleanupNativeBinding(t, rt, rt.tenantID, "cluster-claimed", "pool-native", meta.TenantPoolBindingUsed)
+
+	rt.server.cleanupFailedOrganizationTenants(context.Background(), failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantFailed)
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsSharedFreeMemberUnreadyDB(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, rt.tenantID, false)
+	upsertFailedCleanupSharedMembership(t, rt, rt.tenantID, "pool-shared", meta.TenantPoolBindingFree)
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertSharedCleanupCompleted(t, rt, rt.tenantID, fsID, dbID)
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("shared cleanup deprovision calls = %d, want 0", got)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsSharedDirectUnreadyDB(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, rt.tenantID, false)
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertSharedCleanupCompleted(t, rt, rt.tenantID, fsID, dbID)
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("shared cleanup deprovision calls = %d, want 0", got)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsSharedNamespaceGuardRestoresState(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNativeShared, "", "namespace-present", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, rt.tenantID, false)
+	upsertFailedCleanupSharedMembership(t, rt, rt.tenantID, "pool-shared", meta.TenantPoolBindingFree)
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantFailed)
+	assertSharedCleanupStatePreserved(t, rt, rt.tenantID, fsID, dbID)
+}
+
+func TestCleanupFailedOrganizationTenantsSharedMissingPlacementRestoresState(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, rt.tenantID, false)
+	upsertFailedCleanupSharedMembership(t, rt, rt.tenantID, "pool-shared", meta.TenantPoolBindingFree)
+	if err := rt.meta.DeleteTenantPlacement(ctx, fsID); err != nil {
+		t.Fatalf("delete placement for missing-placement setup: %v", err)
+	}
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantFailed)
+	if _, err := rt.meta.GetTenantPoolMembership(ctx, rt.tenantID); err != nil {
+		t.Fatalf("shared membership after missing placement: %v", err)
+	}
+	db, err := rt.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("get shared db: %v", err)
+	}
+	if db.TenantCount != 1 {
+		t.Fatalf("shared tenant count = %d, want 1", db.TenantCount)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsContinuesAcrossProviders(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	nativeID := rt.tenantID
+	setFailedCleanupTenant(t, rt, nativeID, tenant.ProviderTiDBCloudNative, "cluster-native-fails", "", old)
+	upsertFailedCleanupNativeBinding(t, rt, nativeID, "cluster-native-fails", "pool-native", meta.TenantPoolBindingFree)
+	sharedID := insertFailedCleanupTenant(t, rt, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, sharedID, false)
+	upsertFailedCleanupSharedMembership(t, rt, sharedID, "pool-shared", meta.TenantPoolBindingFree)
+	rt.prov.deprovisionErr = errors.New("native cloud failure")
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertFailedCleanupTenantStatus(t, rt, nativeID, meta.TenantFailed)
+	assertSharedCleanupCompleted(t, rt, sharedID, fsID, dbID)
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want native-only 1", got)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsSharedActiveDBPurgesScopedData(t *testing.T) {
+	rt, db := newFailedCleanupRuntimeWithoutWorkers(t)
+	ctx := context.Background()
+	installFailedCleanupSharedSchema(t, rt.meta.DB())
+	old := time.Now().UTC().Add(-time.Hour)
+	tenantID := insertFailedCleanupTenant(t, rt, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	rt.tenantID = tenantID
+	fsID, err := rt.meta.ResolveFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("resolve fs_id: %v", err)
+	}
+	passwordCipher, err := rt.server.pool.Encrypt(ctx, []byte(db.DBPass))
+	if err != nil {
+		t.Fatalf("encrypt shared db password: %v", err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: failedCleanupTestOrganizationID,
+		Host:                    db.DBHost, Port: db.DBPort, User: db.DBUser, PasswordCipher: passwordCipher,
+		Name: db.DBName, MaxTenants: 10, Status: meta.SharedDBStatusActive,
+	})
+	if err != nil {
+		t.Fatalf("register reachable shared db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := rt.server.pool.InvalidateSharedDB(dbID); err != nil {
+			t.Errorf("invalidate reachable shared db: %v", err)
+		}
+	})
+	if _, err := rt.meta.DB().ExecContext(ctx,
+		"UPDATE db_pool SET tenant_count = 1, schema_version = ? WHERE db_id = ?",
+		tenantschema.CurrentSharedTiDBSchemaVersion, dbID); err != nil {
+		t.Fatalf("mark shared db schema ready: %v", err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("upsert reachable shared placement: %v", err)
+	}
+	upsertFailedCleanupSharedMembership(t, rt, tenantID, "pool-shared-reachable", meta.TenantPoolBindingFree)
+	const otherFsID int64 = 987654321
+	if _, err := rt.meta.DB().ExecContext(ctx, `INSERT INTO inodes
+		(fs_id, inode_id, size_bytes, revision, status) VALUES
+		(?, 'cleanup-target', 10, 1, 'CONFIRMED'),
+		(?, 'cleanup-other', 20, 1, 'CONFIRMED')`, fsID, otherFsID); err != nil {
+		t.Fatalf("seed shared-schema inode rows: %v", err)
+	}
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertSharedCleanupCompleted(t, rt, tenantID, fsID, dbID)
+	assertFailedCleanupFSRowCount(t, rt.meta.DB(), "inodes", fsID, 0)
+	assertFailedCleanupFSRowCount(t, rt.meta.DB(), "inodes", otherFsID, 1)
+}
+
+func TestCleanupFailedOrganizationTenantsSharedActiveDBPurgeFailureRestoresState(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, rt.tenantID, true)
+	upsertFailedCleanupSharedMembership(t, rt, rt.tenantID, "pool-shared-unreachable", meta.TenantPoolBindingFree)
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	failed := assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantFailed)
+	if !failed.UpdatedAt.After(old) {
+		t.Fatalf("updated_at = %s, want after %s", failed.UpdatedAt, old)
+	}
+	assertSharedCleanupStatePreserved(t, rt, rt.tenantID, fsID, dbID)
+}
+
+func TestCleanupFailedOrganizationTenantsSharedActiveIncompleteDBSkipsPurge(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, rt.tenantID, false)
+	upsertFailedCleanupSharedMembership(t, rt, rt.tenantID, "pool-shared-incomplete", meta.TenantPoolBindingFree)
+	if _, err := rt.meta.DB().ExecContext(ctx,
+		"UPDATE db_pool SET status = ?, db_password = X'' WHERE db_id = ?",
+		meta.SharedDBStatusActive, dbID); err != nil {
+		t.Fatalf("make active shared db incomplete: %v", err)
+	}
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertSharedCleanupCompleted(t, rt, rt.tenantID, fsID, dbID)
+}
+
+func TestCleanupFailedOrganizationTenantsAbortsActiveAndCompletingReservations(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, rt.tenantID, false)
+	upsertFailedCleanupSharedMembership(t, rt, rt.tenantID, "pool-shared-reservations", meta.TenantPoolBindingFree)
+	for _, reservation := range []*meta.UploadReservation{
+		{TenantID: rt.tenantID, UploadID: "upload-active", ReservedBytes: 40, FileCountDelta: 1, TargetPath: "/active.bin", ExpiresAt: time.Now().Add(time.Hour)},
+		{TenantID: rt.tenantID, UploadID: "upload-completing", ReservedBytes: 60, FileCountDelta: 1, TargetPath: "/completing.bin", ExpiresAt: time.Now().Add(time.Hour)},
+	} {
+		if err := rt.meta.AtomicReserveAndInsertUpload(ctx, reservation); err != nil {
+			t.Fatalf("reserve upload %s: %v", reservation.UploadID, err)
+		}
+	}
+	if err := rt.meta.UpdateUploadReservationStatus(ctx, rt.tenantID, "upload-completing", "completing"); err != nil {
+		t.Fatalf("mark reservation completing: %v", err)
+	}
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertSharedCleanupCompleted(t, rt, rt.tenantID, fsID, dbID)
+	for _, uploadID := range []string{"upload-active", "upload-completing"} {
+		reservation, err := rt.meta.GetUploadReservation(ctx, rt.tenantID, uploadID)
+		if err != nil {
+			t.Fatalf("get reservation %s: %v", uploadID, err)
+		}
+		if reservation.Status != "aborted" {
+			t.Fatalf("reservation %s status = %s, want aborted", uploadID, reservation.Status)
+		}
+	}
+	usage, err := rt.meta.GetQuotaUsage(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatalf("get quota usage: %v", err)
+	}
+	if usage.ReservedBytes != 0 || usage.FileCount != 0 {
+		t.Fatalf("quota usage after abort = %+v, want reserved_bytes=0 file_count=0", usage)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsReservationAbortFailureStillFinalizes(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, rt.tenantID, false)
+	upsertFailedCleanupSharedMembership(t, rt, rt.tenantID, "pool-shared-abort-failure", meta.TenantPoolBindingFree)
+	if err := rt.meta.InsertUploadReservation(ctx, &meta.UploadReservation{
+		TenantID: rt.tenantID, UploadID: "upload-missing-usage", ReservedBytes: 80, FileCountDelta: 1,
+		TargetPath: "/missing-usage.bin", ExpiresAt: time.Now().Add(time.Hour),
+	}); err != nil {
+		t.Fatalf("insert reservation without quota usage: %v", err)
+	}
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertSharedCleanupCompleted(t, rt, rt.tenantID, fsID, dbID)
+	reservation, err := rt.meta.GetUploadReservation(ctx, rt.tenantID, "upload-missing-usage")
+	if err != nil {
+		t.Fatalf("get reservation after best-effort abort failure: %v", err)
+	}
+	if reservation.Status != "active" {
+		t.Fatalf("reservation status = %s, want active after rolled-back abort", reservation.Status)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsResolveFsIDDoesNotCreateRegistry(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	upsertFailedCleanupSharedMembership(t, rt, rt.tenantID, "pool-shared-no-fsid", meta.TenantPoolBindingFree)
+	if _, err := rt.meta.DB().ExecContext(ctx, "DELETE FROM fs_registry WHERE tenant_id = ?", rt.tenantID); err != nil {
+		t.Fatalf("delete fs_registry fixture row: %v", err)
+	}
+
+	rt.server.cleanupFailedOrganizationTenants(ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+
+	assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantFailed)
+	if _, err := rt.meta.GetTenantPoolMembership(ctx, rt.tenantID); err != nil {
+		t.Fatalf("shared membership after fs_id resolution failure: %v", err)
+	}
+	var registryRows int
+	if err := rt.meta.DB().QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM fs_registry WHERE tenant_id = ?", rt.tenantID).Scan(&registryRows); err != nil {
+		t.Fatalf("count fs_registry rows: %v", err)
+	}
+	if registryRows != 0 {
+		t.Fatalf("fs_registry rows = %d, want 0 (cleanup must not allocate fs_id)", registryRows)
+	}
+}
+
+func TestCleanupFailedOrganizationTenantsNativeListFailureContinuesShared(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, rt.tenantID, false)
+	upsertFailedCleanupSharedMembership(t, rt, rt.tenantID, "pool-shared-native-list-failure", meta.TenantPoolBindingFree)
+	sentinel := errors.New("native list unavailable")
+	nativeLoader := func(context.Context, string, time.Time, int) ([]meta.TenantWithTiDBCloudOrgBinding, error) {
+		return nil, sentinel
+	}
+	sharedLoader := func(ctx context.Context, organizationID string, cutoff time.Time, limit int) ([]meta.Tenant, error) {
+		return rt.meta.ListFailedSharedTenantCleanupCandidates(ctx, organizationID, cutoff, limit)
+	}
+
+	rt.server.cleanupFailedOrganizationTenantsWithLoaders(
+		ctx, failedCleanupTestOrganizationID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"},
+		nativeLoader, sharedLoader)
+
+	assertSharedCleanupCompleted(t, rt, rt.tenantID, fsID, dbID)
+}
+
+func setFailedCleanupTenant(t *testing.T, rt *quotaRuntime, tenantID, provider, clusterID, namespaceID string, updatedAt time.Time) {
+	t.Helper()
+	if _, err := rt.meta.DB().ExecContext(context.Background(), `UPDATE tenants
+		SET status = ?, provider = ?, cluster_id = NULLIF(?, ''), storage_namespace_id = ?, updated_at = ?
+		WHERE id = ?`, meta.TenantFailed, provider, clusterID, namespaceID, updatedAt.UTC(), tenantID); err != nil {
+		t.Fatalf("configure failed cleanup tenant %s: %v", tenantID, err)
+	}
+}
+
+func insertFailedCleanupTenant(t *testing.T, rt *quotaRuntime, provider, clusterID, namespaceID string, updatedAt time.Time) string {
+	t.Helper()
+	tenantID := token.NewID()
+	if err := rt.meta.InsertTenant(context.Background(), &meta.Tenant{
+		ID: tenantID, Status: meta.TenantFailed, Kind: meta.TenantKindLive,
+		Provider: provider, ClusterID: clusterID, StorageNamespaceID: namespaceID,
+		DBPasswordCipher: []byte{}, SchemaVersion: 1, CreatedAt: updatedAt, UpdatedAt: updatedAt,
+	}); err != nil {
+		t.Fatalf("insert failed cleanup tenant: %v", err)
+	}
+	return tenantID
+}
+
+func upsertFailedCleanupNativeBinding(t *testing.T, rt *quotaRuntime, tenantID, clusterID, poolID string, status meta.TenantPoolBindingStatus) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(context.Background(), &meta.TenantTiDBCloudOrgBinding{
+		TenantID: tenantID, OrganizationID: failedCleanupTestOrganizationID, ClusterID: clusterID,
+		PoolID: poolID, PoolStatus: status, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert native cleanup binding: %v", err)
+	}
+}
+
+func upsertFailedCleanupSharedMembership(t *testing.T, rt *quotaRuntime, tenantID, poolID string, status meta.TenantPoolBindingStatus) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := rt.meta.UpsertTenantPoolMembership(context.Background(), &meta.TenantPoolMembership{
+		TenantID: tenantID, TiDBCloudOrganizationID: failedCleanupTestOrganizationID,
+		PoolID: poolID, PoolStatus: status, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("upsert shared cleanup membership: %v", err)
+	}
+}
+
+func setFailedCleanupSharedPlacement(t *testing.T, rt *quotaRuntime, tenantID string, ready bool) (int64, int64) {
+	t.Helper()
+	ctx := context.Background()
+	fsID, err := rt.meta.ResolveFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("resolve fs_id: %v", err)
+	}
+	shared := &meta.SharedDB{
+		TiDBCloudOrganizationID: failedCleanupTestOrganizationID,
+		Host:                    fmt.Sprintf("unready-%s.example.com", tenantID),
+		Port:                    4000,
+		User:                    "root",
+		PasswordCipher:          []byte("cipher"),
+		Name:                    fmt.Sprintf("shared_%s", tenantID),
+		MaxTenants:              10,
+		Status:                  meta.SharedDBStatusProvisioning,
+	}
+	if ready {
+		passwordCipher, err := rt.server.pool.Encrypt(ctx, []byte("unreachable-password"))
+		if err != nil {
+			t.Fatalf("encrypt unreachable shared db password: %v", err)
+		}
+		shared.Host = "127.0.0.1"
+		shared.Port = 1
+		shared.PasswordCipher = passwordCipher
+		shared.Status = meta.SharedDBStatusActive
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, shared)
+	if err != nil {
+		t.Fatalf("register shared db: %v", err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatalf("upsert shared placement: %v", err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE db_pool SET tenant_count = 1 WHERE db_id = ?", dbID); err != nil {
+		t.Fatalf("seed shared tenant count: %v", err)
+	}
+	return fsID, dbID
+}
+
+func newFailedCleanupRuntimeWithoutWorkers(t *testing.T) (*quotaRuntime, *testDBInfo) {
+	t.Helper()
+	db := newTenantDeleteDBInfo(t)
+	testmysql.ResetMetaDB(t, db.Meta.DB())
+	testmysql.ResetDB(t, db.Meta.DB())
+	t.Cleanup(func() {
+		testmysql.ResetMetaDB(t, db.Meta.DB())
+		testmysql.ResetDB(t, db.Meta.DB())
+	})
+	prov := &quotaTestProvisioner{provider: tenant.ProviderTiDBCloudNative}
+	server := &Server{
+		meta: db.Meta, pool: db.Pool, provisioner: prov,
+		sharedDBReopenRatio: DefaultSharedDBReopenRatio,
+	}
+	return &quotaRuntime{meta: db.Meta, prov: prov, server: server}, db
+}
+
+var failedCleanupSharedTables = []string{
+	"journal_entry_subjects", "journal_entries", "journal_append_requests", "journal_labels", "journals",
+	"vault_audit_log", "vault_grants", "vault_tokens", "vault_secret_fields", "vault_secrets", "vault_deks",
+	"git_workspace_object_packs", "git_workspace_overlay", "git_workspace_git_state", "git_workspace_tree_nodes", "git_workspaces",
+	"fs_layer_checkpoints", "fs_layer_events", "fs_layer_tags", "fs_layer_entries", "fs_layers",
+	"fs_events", "semantic_tasks", "file_gc_tasks", "uploads", "file_tags", "file_nodes", "semantic", "contents", "inodes",
+}
+
+func installFailedCleanupSharedSchema(t *testing.T, db *sql.DB) {
+	t.Helper()
+	ctx := context.Background()
+	t.Cleanup(func() {
+		dropFailedCleanupSharedTables(t, db)
+		initServerTenantSchema(t, testDSN)
+	})
+	dropFailedCleanupSharedTables(t, db)
+	if err := tenantschema.InitSharedSchema(ctx, testDSN); err != nil {
+		t.Fatalf("initialize shared schema: %v", err)
+	}
+}
+
+func dropFailedCleanupSharedTables(t *testing.T, db *sql.DB) {
+	t.Helper()
+	for _, table := range failedCleanupSharedTables {
+		if _, err := db.ExecContext(context.Background(), "DROP TABLE IF EXISTS "+table); err != nil {
+			t.Fatalf("drop shared table %s: %v", table, err)
+		}
+	}
+}
+
+func assertFailedCleanupFSRowCount(t *testing.T, db *sql.DB, table string, fsID int64, want int) {
+	t.Helper()
+	var got int
+	if err := db.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM "+table+" WHERE fs_id = ?", fsID).Scan(&got); err != nil {
+		t.Fatalf("count %s rows for fs_id %d: %v", table, fsID, err)
+	}
+	if got != want {
+		t.Fatalf("%s rows for fs_id %d = %d, want %d", table, fsID, got, want)
+	}
+}
+
+func assertFailedCleanupTenantStatus(t *testing.T, rt *quotaRuntime, tenantID string, want meta.TenantStatus) *meta.Tenant {
+	t.Helper()
+	got, err := rt.meta.GetTenant(context.Background(), tenantID)
+	if err != nil {
+		t.Fatalf("get tenant %s: %v", tenantID, err)
+	}
+	if got.Status != want {
+		t.Fatalf("tenant %s status = %s, want %s", tenantID, got.Status, want)
+	}
+	return got
+}
+
+func assertSharedCleanupCompleted(t *testing.T, rt *quotaRuntime, tenantID string, fsID, dbID int64) {
+	t.Helper()
+	ctx := context.Background()
+	assertFailedCleanupTenantStatus(t, rt, tenantID, meta.TenantDeleted)
+	if _, err := rt.meta.GetTenantPlacement(ctx, fsID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("shared placement after cleanup error = %v, want %v", err, meta.ErrNotFound)
+	}
+	if _, err := rt.meta.GetTenantPoolMembership(ctx, tenantID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("shared membership after cleanup error = %v, want %v", err, meta.ErrNotFound)
+	}
+	db, err := rt.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("get shared db: %v", err)
+	}
+	if db.TenantCount != 0 {
+		t.Fatalf("shared tenant count = %d, want 0", db.TenantCount)
+	}
+	assertNoActiveFailedCleanupKeys(t, rt, tenantID)
+	if exists, err := rt.meta.TenantDeleteJobExists(ctx, tenantID); err != nil {
+		t.Fatalf("check tenant delete job: %v", err)
+	} else if exists {
+		t.Fatal("shared failed cleanup enqueued a tenant delete job")
+	}
+}
+
+func assertNoActiveFailedCleanupKeys(t *testing.T, rt *quotaRuntime, tenantID string) {
+	t.Helper()
+	var active int
+	if err := rt.meta.DB().QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM tenant_api_keys WHERE tenant_id = ? AND status = ?",
+		tenantID, meta.APIKeyActive).Scan(&active); err != nil {
+		t.Fatalf("count active tenant keys: %v", err)
+	}
+	if active != 0 {
+		t.Fatalf("active tenant keys = %d, want 0", active)
+	}
+}
+
+func assertSharedCleanupStatePreserved(t *testing.T, rt *quotaRuntime, tenantID string, fsID, dbID int64) {
+	t.Helper()
+	ctx := context.Background()
+	if _, err := rt.meta.GetTenantPlacement(ctx, fsID); err != nil {
+		t.Fatalf("shared placement after failed cleanup: %v", err)
+	}
+	if _, err := rt.meta.GetTenantPoolMembership(ctx, tenantID); err != nil {
+		t.Fatalf("shared membership after failed cleanup: %v", err)
+	}
+	db, err := rt.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("get shared db: %v", err)
+	}
+	if db.TenantCount != 1 {
+		t.Fatalf("shared tenant count = %d, want 1", db.TenantCount)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("shared cleanup deprovision calls = %d, want 0", got)
+	}
+}

--- a/pkg/server/tenant_failed_cleanup_test.go
+++ b/pkg/server/tenant_failed_cleanup_test.go
@@ -18,6 +18,40 @@ import (
 
 const failedCleanupTestOrganizationID = "org-failed-cleanup"
 
+func TestSharedDBConnectionReady(t *testing.T) {
+	complete := func() *meta.SharedDB {
+		return &meta.SharedDB{
+			Status:         meta.SharedDBStatusActive,
+			Host:           "shared.example.com",
+			Port:           4000,
+			User:           "root",
+			PasswordCipher: []byte("cipher"),
+			Name:           "shared_db",
+		}
+	}
+	tests := []struct {
+		name  string
+		build func() *meta.SharedDB
+		want  bool
+	}{
+		{name: "nil", build: func() *meta.SharedDB { return nil }},
+		{name: "complete", build: complete, want: true},
+		{name: "provisioning", build: func() *meta.SharedDB { db := complete(); db.Status = meta.SharedDBStatusProvisioning; return db }},
+		{name: "blank host", build: func() *meta.SharedDB { db := complete(); db.Host = " \t"; return db }},
+		{name: "zero port", build: func() *meta.SharedDB { db := complete(); db.Port = 0; return db }},
+		{name: "blank user", build: func() *meta.SharedDB { db := complete(); db.User = " \t"; return db }},
+		{name: "missing password", build: func() *meta.SharedDB { db := complete(); db.PasswordCipher = nil; return db }},
+		{name: "blank database", build: func() *meta.SharedDB { db := complete(); db.Name = " \t"; return db }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sharedDBConnectionReady(tt.build()); got != tt.want {
+				t.Fatalf("sharedDBConnectionReady() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCleanupFailedOrganizationTenantsNativePoolFree(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()

--- a/pkg/server/tenant_failed_cleanup_trigger_test.go
+++ b/pkg/server/tenant_failed_cleanup_trigger_test.go
@@ -1,0 +1,277 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+)
+
+func TestTenantFailedCleanupAsyncCoalescesSameOrganizationWithoutQueuedRerun(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	var calls atomic.Int32
+	s := &Server{
+		tenantFailedCleanupRunner: func(context.Context, string, tenant.CredentialProvisionRequest) {
+			if calls.Add(1) == 1 {
+				close(started)
+			}
+			<-release
+		},
+	}
+
+	startCalls := make(chan struct{})
+	var starters sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		starters.Add(1)
+		go func() {
+			defer starters.Done()
+			<-startCalls
+			s.startTenantFailedCleanupAsync(context.Background(), "  org-one  ", tenant.CredentialProvisionRequest{})
+		}()
+	}
+	close(startCalls)
+	starters.Wait()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup runner did not start")
+	}
+
+	// Calls arriving while the worker is active are dropped, not queued.
+	for i := 0; i < 5; i++ {
+		s.startTenantFailedCleanupAsync(context.Background(), "org-one", tenant.CredentialProvisionRequest{})
+	}
+	close(release)
+	s.forkWorkerWG.Wait()
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("cleanup runner calls = %d, want exactly 1", got)
+	}
+}
+
+func TestTenantFailedCleanupAsyncHonorsCooldownWithoutInvokingRunner(t *testing.T) {
+	var calls atomic.Int32
+	s := &Server{
+		tenantFailedCleanupRunner: func(context.Context, string, tenant.CredentialProvisionRequest) {
+			calls.Add(1)
+		},
+	}
+
+	s.startTenantFailedCleanupAsync(context.Background(), "org-cooldown", tenant.CredentialProvisionRequest{})
+	s.forkWorkerWG.Wait()
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("initial cleanup runner calls = %d, want 1", got)
+	}
+
+	s.startTenantFailedCleanupAsync(context.Background(), "org-cooldown", tenant.CredentialProvisionRequest{})
+	s.forkWorkerWG.Wait()
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("within-interval cleanup runner calls = %d, want 1", got)
+	}
+
+	value, ok := s.tenantFailedCleanupJobs.Load("org-cooldown")
+	if !ok {
+		t.Fatal("cleanup job state not stored")
+	}
+	state := value.(*tenantFailedCleanupJobState)
+	state.mu.Lock()
+	state.lastStarted = time.Now().Add(-2 * tenantFailedCleanupMinInterval)
+	state.mu.Unlock()
+
+	s.startTenantFailedCleanupAsync(context.Background(), "org-cooldown", tenant.CredentialProvisionRequest{})
+	s.forkWorkerWG.Wait()
+	if got := calls.Load(); got != 2 {
+		t.Fatalf("after-interval cleanup runner calls = %d, want 2", got)
+	}
+}
+
+func TestTenantFailedCleanupAsyncRunsDifferentOrganizationsIndependently(t *testing.T) {
+	started := make(chan string, 2)
+	release := make(chan struct{})
+	s := &Server{
+		tenantFailedCleanupRunner: func(_ context.Context, organizationID string, _ tenant.CredentialProvisionRequest) {
+			started <- organizationID
+			<-release
+		},
+	}
+
+	s.startTenantFailedCleanupAsync(context.Background(), " org-a ", tenant.CredentialProvisionRequest{})
+	s.startTenantFailedCleanupAsync(context.Background(), "org-b", tenant.CredentialProvisionRequest{})
+	got := map[string]bool{}
+	for len(got) < 2 {
+		select {
+		case organizationID := <-started:
+			got[organizationID] = true
+		case <-time.After(time.Second):
+			t.Fatalf("started organizations = %v, want org-a and org-b", got)
+		}
+	}
+	close(release)
+	s.forkWorkerWG.Wait()
+	if !got["org-a"] || !got["org-b"] {
+		t.Fatalf("started organizations = %v, want normalized org-a and org-b", got)
+	}
+}
+
+func TestTenantFailedCleanupAsyncSkipsEmptyOrganization(t *testing.T) {
+	var calls atomic.Int32
+	s := &Server{
+		tenantFailedCleanupRunner: func(context.Context, string, tenant.CredentialProvisionRequest) {
+			calls.Add(1)
+		},
+	}
+
+	s.startTenantFailedCleanupAsync(context.Background(), " \t\n ", tenant.CredentialProvisionRequest{})
+	s.forkWorkerWG.Wait()
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("cleanup runner calls = %d, want 0 for empty organization", got)
+	}
+}
+
+func TestTenantFailedCleanupAsyncRollsBackStateWhenServerRejectsWorker(t *testing.T) {
+	var calls atomic.Int32
+	s := &Server{
+		tenantFailedCleanupRunner: func(context.Context, string, tenant.CredentialProvisionRequest) {
+			calls.Add(1)
+		},
+	}
+	previousStart := time.Now().Add(-2 * tenantFailedCleanupMinInterval)
+	state := &tenantFailedCleanupJobState{lastStarted: previousStart}
+	s.tenantFailedCleanupJobs.Store("org-closed", state)
+	s.forkWorkerMu.Lock()
+	s.forkWorkerClosed = true
+	s.forkWorkerMu.Unlock()
+
+	s.startTenantFailedCleanupAsync(context.Background(), "org-closed", tenant.CredentialProvisionRequest{})
+
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("cleanup runner calls = %d, want 0 after server close", got)
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.active {
+		t.Fatal("cleanup job remained active after worker start was rejected")
+	}
+	if !state.lastStarted.Equal(previousStart) {
+		t.Fatalf("cleanup last started = %s, want preserved %s", state.lastStarted, previousStart)
+	}
+}
+
+func TestTenantPoolClaimReturnsWithoutWaitingForFailedCleanupAndPassesCredentials(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{OrganizationID: failedCleanupTestOrganizationID}},
+	}}
+	started := make(chan tenant.CredentialProvisionRequest, 1)
+	release := make(chan struct{})
+	rt.server.tenantFailedCleanupRunner = func(_ context.Context, organizationID string, cred tenant.CredentialProvisionRequest) {
+		if organizationID != failedCleanupTestOrganizationID {
+			t.Errorf("cleanup organization = %q, want %q", organizationID, failedCleanupTestOrganizationID)
+		}
+		started <- cred
+		<-release
+	}
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+	wantCred := tenant.CredentialProvisionRequest{PublicKey: "request-public", PrivateKey: "request-private"}
+	type claimResult struct {
+		result            *provisionTenantResult
+		pool              *meta.TenantPool
+		claimed           bool
+		sharedPoolMatched bool
+		err               error
+	}
+	claimDone := make(chan claimResult, 1)
+	go func() {
+		result, pool, claimed, sharedPoolMatched, err := rt.server.claimAdminTenantFromPool(ctx, wantCred, nil)
+		claimDone <- claimResult{result, pool, claimed, sharedPoolMatched, err}
+	}()
+
+	var gotCred tenant.CredentialProvisionRequest
+	select {
+	case gotCred = <-started:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup runner did not start")
+	}
+	select {
+	case got := <-claimDone:
+		if got.err != nil || got.result != nil || got.pool != nil || got.claimed || got.sharedPoolMatched {
+			t.Fatalf("claim result = %+v, want non-pool miss", got)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("claim waited for asynchronous failed-tenant cleanup")
+	}
+	if gotCred != wantCred {
+		t.Fatalf("cleanup credentials = %#v, want %#v", gotCred, wantCred)
+	}
+	close(release)
+	rt.server.forkWorkerWG.Wait()
+}
+
+func TestTenantPoolClaimTriggersDirectFailedCleanupWithoutLogicalPool(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{OrganizationID: failedCleanupTestOrganizationID}},
+	}}
+	old := time.Now().UTC().Add(-time.Hour)
+	directTenantID := rt.tenantID
+	setFailedCleanupTenant(t, rt, directTenantID, tenant.ProviderTiDBCloudNative, "cluster-direct", "", old)
+	upsertFailedCleanupNativeBinding(t, rt, directTenantID, "cluster-direct", "", meta.TenantPoolBindingUsed)
+	claimedTenantID := insertFailedCleanupTenant(t, rt, tenant.ProviderTiDBCloudNative, "cluster-claimed", "", old.Add(-time.Hour))
+	upsertFailedCleanupNativeBinding(t, rt, claimedTenantID, "cluster-claimed", "pool-claimed", meta.TenantPoolBindingUsed)
+	wantCred := tenant.CredentialProvisionRequest{PublicKey: "public-direct", PrivateKey: "private-direct"}
+
+	result, pool, claimed, sharedPoolMatched, err := rt.server.claimAdminTenantFromPool(ctx, wantCred, nil)
+	if err != nil || result != nil || pool != nil || claimed || sharedPoolMatched {
+		t.Fatalf("claim result = result=%+v pool=%+v claimed=%v shared=%v err=%v, want non-pool miss",
+			result, pool, claimed, sharedPoolMatched, err)
+	}
+	rt.server.forkWorkerWG.Wait()
+
+	assertFailedCleanupTenantStatus(t, rt, directTenantID, meta.TenantDeleted)
+	assertFailedCleanupTenantStatus(t, rt, claimedTenantID, meta.TenantFailed)
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want direct tenant only", got)
+	}
+	if got := rt.prov.lastCredentialsSnapshot(); got != wantCred {
+		t.Fatalf("cleanup deprovision credentials = %#v, want %#v", got, wantCred)
+	}
+}
+
+func TestTenantPoolClaimResultUnaffectedByFailedCleanupError(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
+		Clusters: []tenant.CloudClusterInfo{{OrganizationID: failedCleanupTestOrganizationID}},
+	}}
+	old := time.Now().UTC().Add(-time.Hour)
+	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNative, "cluster-cleanup-fails", "", old)
+	upsertFailedCleanupNativeBinding(t, rt, rt.tenantID, "cluster-cleanup-fails", "", meta.TenantPoolBindingUsed)
+	cleanupErr := errors.New("cloud cleanup failed")
+	rt.prov.deprovisionErr = cleanupErr
+
+	result, pool, claimed, sharedPoolMatched, err := rt.server.claimAdminTenantFromPool(ctx,
+		tenant.CredentialProvisionRequest{PublicKey: "public-failure", PrivateKey: "private-failure"}, nil)
+	if err != nil || result != nil || pool != nil || claimed || sharedPoolMatched {
+		t.Fatalf("claim result = result=%+v pool=%+v claimed=%v shared=%v err=%v, want unaffected non-pool miss",
+			result, pool, claimed, sharedPoolMatched, err)
+	}
+	rt.server.forkWorkerWG.Wait()
+
+	assertFailedCleanupTenantStatus(t, rt, rt.tenantID, meta.TenantFailed)
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+}


### PR DESCRIPTION
## Summary

- add organization-wide failed-tenant selectors and CAS ownership for both `tidb_cloud_native` and `tidb_cloud_native_shared`
- clean failed free-pool and direct tenants while excluding already claimed pool-used tenants
- trigger bounded, best-effort cleanup from the existing claim path with per-Pod organization throttling

## Cleanup behavior

- native cleanup deprovisions the dedicated TiDB Cloud cluster with request-scoped credentials, revokes keys best-effort, then atomically marks the tenant deleted and removes its binding
- shared cleanup never deprovisions the physical shared cluster; it drains the backend, conditionally purges `fs_id`-scoped data when the shared DB is ready, and atomically releases placement, capacity, membership, and tenant metadata
- owned failures restore `deleting -> failed` with an updated retry timestamp and a bounded restore timeout
- selectors wait for a 15-minute tenant cooldown; native batches are limited to 1 and shared batches to 10
- per-Pod cleanup runs at most once per organization per minute; database CAS remains the cross-Pod ownership boundary

## Scope

Included:

- native failed pool bindings with `pool_status=free`
- native direct failed bindings with an empty `pool_id`
- shared failed free memberships
- shared direct failed tenants with no membership and a placement in an organization-owned shared DB

Excluded:

- native claimed bindings with a nonempty `pool_id` and `pool_status=used`
- shared tenants with an existing used membership
- tenants without enough binding, membership, or placement metadata to prove organization ownership

## Test plan

- [x] `GOFLAGS='-count=1' make test TEST_PKGS='./pkg/meta' TEST_RUN='Test(ListFailed|FailedTenantCleanup|MarkFailedTenant|FinalizeSharedTenantDeleteMetadataIsAtomic|TenantPoolMembershipRoundTripAndClaimCAS|ClaimOldestFreeTenantPoolBindingRequiresActiveTenant|OldestFreeTenantPoolMembershipRequiresActiveTenant)'`
- [x] `GOFLAGS='-count=1' make test TEST_PKGS='./pkg/server' TEST_RUN='Test(CleanupFailedOrganizationTenants|TenantFailedCleanupAsync|TenantPoolClaim(ReturnsWithoutWaitingForFailedCleanupAndPassesCredentials|TriggersDirectFailedCleanupWithoutLogicalPool|ResultUnaffectedByFailedCleanupError|UsesNativeInventoryBeforeExternalSharedPool|ConsumesMixedInventoryInGlobalAgeOrder|MissTriggersPendingMetadataResume|SeedsQuotaConfigWithoutExplicitQuota)|DeleteFreeSharedPoolTenantSkipsPurgeWhenDBPoolIsUnready)'`
- [x] `gofmt -d` on all changed Go files
- [x] `git diff --check`

Focused verification was run after rebasing the work onto the latest `origin/main`. No baseline or full-suite test was run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic cleanup for failed native and shared tenants.
  * Cleanup runs asynchronously after tenant pool operations, with per-organization throttling and cooldown controls.
  * Failed tenants are safely claimed, deprovisioned, credentials revoked, shared resources cleaned up, and deletion finalized.
  * Cleanup failures restore tenants to a failed state for later retry.

* **Bug Fixes**
  * Improved concurrency protection to prevent duplicate cleanup.
  * Fork smoke tests now skip unsupported deployments instead of failing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->