### PR TITLE
feat: authorize TiDB Cloud operations through IAM

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -349,21 +349,16 @@ func main() {
 
 		// Optional shared-schema pool: when DRIVE9_SHARED_POOL_DSN is set,
 		// initialize the shared schema on that database and register it in
-		// db_pool so tenants in the matching org are provisioned onto it
-		// instead of getting a dedicated cluster. The org binding is always
-		// explicit — DRIVE9_SHARED_POOL_ORG has no default, and the '*' wildcard
-		// (which places ALL new tenants on the shared pool) is opt-in and loud.
+		// db_pool so tenants in the matching organization are provisioned onto
+		// it instead of getting a dedicated cluster. The organization binding is
+		// always explicit and has no wildcard behavior.
 		if sharedDSN := strings.TrimSpace(os.Getenv("DRIVE9_SHARED_POOL_DSN")); sharedDSN != "" {
 			sharedOrg := strings.TrimSpace(os.Getenv("DRIVE9_SHARED_POOL_ORG"))
 			if sharedOrg == "" {
-				die(fmt.Errorf("DRIVE9_SHARED_POOL_ORG is required when DRIVE9_SHARED_POOL_DSN is set (set an explicit org id; use '*' only to intentionally place ALL new tenants on the shared pool)"))
+				die(fmt.Errorf("DRIVE9_SHARED_POOL_ORG is required when DRIVE9_SHARED_POOL_DSN is set (set one exact TiDB Cloud organization id)"))
 			}
-			if err := registerSharedPoolFromEnv(context.Background(), store, pool, sharedDSN, sharedOrg); err != nil {
+			if err := registerSharedPoolFromEnv(context.Background(), store, pool, sharedDSN, sharedOrg, sharedDBMaxTenants); err != nil {
 				die(fmt.Errorf("register shared pool: %w", err))
-			}
-			if sharedOrg == meta.SharedDBOrgWildcard {
-				logger.Warn(context.Background(), "shared_pool_wildcard_all_new_tenants",
-					zap.String("warning", "ALL new tenants will be provisioned onto the shared pool"))
 			}
 			logger.Info(context.Background(), "shared_pool_registered",
 				zap.String("org", sharedOrg))
@@ -491,7 +486,7 @@ func envOr(key, fallback string) string {
 // dsn and upserts it into db_pool with the given org binding. The DSN carries
 // a plaintext password (local/dev convenience); it is encrypted with the
 // pool's encryptor before persistence, like tenant DB passwords.
-func registerSharedPoolFromEnv(ctx context.Context, metaStore *meta.Store, pool *tenant.Pool, dsn, orgID string) error {
+func registerSharedPoolFromEnv(ctx context.Context, metaStore *meta.Store, pool *tenant.Pool, dsn, orgID string, maxTenants int) error {
 	cfg, err := mysql.ParseDSN(dsn)
 	if err != nil {
 		return fmt.Errorf("parse DRIVE9_SHARED_POOL_DSN: %w", err)
@@ -527,6 +522,7 @@ func registerSharedPoolFromEnv(ctx context.Context, metaStore *meta.Store, pool 
 		PasswordCipher:          passCipher,
 		Name:                    cfg.DBName,
 		TLSMode:                 tlsMode,
+		MaxTenants:              maxTenants,
 	})
 	return err
 }

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -236,6 +236,14 @@ func main() {
 	case tenant.ProviderDB9:
 		provisioner, provisionerErr = db9.NewProvisionerFromEnv()
 	}
+	if provisionerErr == nil && providerType == tenant.ProviderTiDBCloudNativeShared {
+		validator, ok := provisioner.(interface{ ValidateSharedCredentials(context.Context) error })
+		if !ok {
+			provisionerErr = fmt.Errorf("shared TiDB Cloud credential validation is not supported")
+		} else if err := validator.ValidateSharedCredentials(context.Background()); err != nil {
+			provisionerErr = err
+		}
+	}
 	if provisionerErr != nil {
 		if tenant.UsesTiDBCloudNativeCredentials(providerType) {
 			logger.Error(context.Background(), "provisioner_failed", zap.String("provider", providerType), zap.Error(provisionerErr))

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -232,16 +232,12 @@ func main() {
 	case tenant.ProviderTiDBZero:
 		provisioner, provisionerErr = tidbzero.NewProvisionerFromEnv()
 	case tenant.ProviderTiDBCloudNative, tenant.ProviderTiDBCloudNativeShared:
-		provisioner, provisionerErr = tidbcloudnative.NewProvisionerFromEnv()
+		provisioner, provisionerErr = tidbcloudnative.NewProvisionerFromEnv(providerType)
 	case tenant.ProviderDB9:
 		provisioner, provisionerErr = db9.NewProvisionerFromEnv()
 	}
 	if provisionerErr != nil {
-		isWanted := false
-		if tenant.UsesTiDBCloudNativeCredentials(providerType) && os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_API_URL") != "" {
-			isWanted = true
-		}
-		if isWanted {
+		if tenant.UsesTiDBCloudNativeCredentials(providerType) {
 			logger.Error(context.Background(), "provisioner_failed", zap.String("provider", providerType), zap.Error(provisionerErr))
 			os.Exit(1)
 		}
@@ -667,11 +663,14 @@ environment:
   DRIVE9_TENANT_PROVIDER db9|tidb_zero|tidb_cloud_native|tidb_cloud_native_shared (default for provisioning)
   DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT default TiDB Cloud Cluster spendingLimit.monthly; native defaults to 1000 when unset
   DRIVE9_TIDBCLOUD_NATIVE_API_URL TiDB Cloud Cluster API base URL for tidb_cloud_native
+  DRIVE9_TIDBCLOUD_IAM_API_URL TiDB Cloud IAM API base URL; required for tidb_cloud_native and tidb_cloud_native_shared
   DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER cloud provider for tidb_cloud_native cluster creation, e.g. aws
   DRIVE9_TIDBCLOUD_NATIVE_REGION region for tidb_cloud_native cluster creation, e.g. us-east-1
   DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME default tidb_cloud_native database name (default: tidbcloud_fs)
   DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY optional default TiDB Cloud API public key for tidb_cloud_native create/delete when caller omits it
   DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY optional default TiDB Cloud API private key for tidb_cloud_native create/delete when caller omits it
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_PUBLIC_KEY server-managed TiDB Cloud API public key for shared DB pool operations; required for tidb_cloud_native_shared
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_PRIVATE_KEY server-managed TiDB Cloud API private key for shared DB pool operations; required for tidb_cloud_native_shared
   DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT true|false to use TiDB Cloud private endpoint hosts for tidb_cloud_native
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS soft capacity for new managed shared DB pools (default: 100)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO emergency hard-cap ratio > 1 after physical create failure (default: 1.2)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -200,6 +200,10 @@ func main() {
 	if err != nil {
 		die(err)
 	}
+	sharedDBDefaultSpendingLimit, err := sharedDBDefaultSpendingLimitFromEnv()
+	if err != nil {
+		die(err)
+	}
 	maxUploadBytes := server.DefaultMaxUploadBytes
 	if raw := os.Getenv("DRIVE9_MAX_UPLOAD_BYTES"); raw != "" {
 		maxUploadBytes, err = strconv.ParseInt(raw, 10, 64)
@@ -444,6 +448,7 @@ func main() {
 		SharedDBMaxTenants:              sharedDBMaxTenants,
 		SharedDBHardCapRatio:            sharedDBHardCapRatio,
 		SharedDBReopenRatio:             sharedDBReopenRatio,
+		SharedDBSpendingLimit:           sharedDBDefaultSpendingLimit,
 		LegacyStarterProvisioner:        legacyStarterProvisioner,
 		TokenSecret:                     tokenSecret,
 		VaultMasterKey:                  vaultMasterKey,
@@ -679,6 +684,7 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS soft capacity for new managed shared DB pools (default: 100)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO emergency hard-cap ratio > 1 after physical create failure (default: 1.2)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO reopen ratio for a latched shared pool (default: 0.8)
+  DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT physical spending-limit target for new managed shared DB pools (default: 1000000)
   DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings (also accepts public_host:private_host);
                                              when set, disables legacy single-host private endpoint overrides
   DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST legacy tencentcloud private endpoint fallback host, used only when host map is unset
@@ -1215,6 +1221,18 @@ func sharedDBMaxTenantsFromEnv() (int, error) {
 	v, err := strconv.Atoi(raw)
 	if err != nil || v <= 0 {
 		return 0, fmt.Errorf("invalid DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS=%q: must be a positive integer", raw)
+	}
+	return v, nil
+}
+
+func sharedDBDefaultSpendingLimitFromEnv() (int64, error) {
+	raw := strings.TrimSpace(os.Getenv("DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT"))
+	if raw == "" {
+		return server.DefaultManagedSharedDBSpendingLimit, nil
+	}
+	v, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil || v <= 0 || v > int64(math.MaxInt32) {
+		return 0, fmt.Errorf("invalid DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT=%q: must be in (0,%d]", raw, int64(math.MaxInt32))
 	}
 	return v, nil
 }

--- a/cmd/drive9-server/main_test.go
+++ b/cmd/drive9-server/main_test.go
@@ -208,7 +208,10 @@ func TestSharedDBReopenRatioFromEnv(t *testing.T) {
 }
 
 func TestSharedDBCapacityConfigFromEnv(t *testing.T) {
-	keys := []string{"DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS"}
+	keys := []string{
+		"DRIVE9_TIDBCLOUD_NATIVE_SHARED_MAX_TENANTS",
+		"DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT",
+	}
 	restore := snapshotEnv(t, keys)
 	t.Cleanup(func() { restoreEnv(t, restore) })
 
@@ -220,15 +223,33 @@ func TestSharedDBCapacityConfigFromEnv(t *testing.T) {
 	if maxTenants != 100 {
 		t.Fatalf("empty max tenants = %d, want 100", maxTenants)
 	}
+	spendingLimit, err := sharedDBDefaultSpendingLimitFromEnv()
+	if err != nil {
+		t.Fatalf("sharedDBDefaultSpendingLimitFromEnv empty: %v", err)
+	}
+	if spendingLimit != server.DefaultManagedSharedDBSpendingLimit {
+		t.Fatalf("empty spending limit = %d, want %d", spendingLimit, server.DefaultManagedSharedDBSpendingLimit)
+	}
 	setEnv(t, keys[0], "250")
 	maxTenants, err = sharedDBMaxTenantsFromEnv()
 	if err != nil || maxTenants != 250 {
 		t.Fatalf("valid max tenants = %d/%v, want 250/nil", maxTenants, err)
 	}
+	setEnv(t, keys[1], "2000000")
+	spendingLimit, err = sharedDBDefaultSpendingLimitFromEnv()
+	if err != nil || spendingLimit != 2_000_000 {
+		t.Fatalf("valid spending limit = %d/%v, want 2000000/nil", spendingLimit, err)
+	}
 	for _, raw := range []string{"0", "-1", "bad"} {
 		setEnv(t, keys[0], raw)
 		if _, err := sharedDBMaxTenantsFromEnv(); err == nil {
 			t.Fatalf("max tenants %q error = nil, want error", raw)
+		}
+	}
+	for _, raw := range []string{"0", "-1", "2147483648", "bad"} {
+		setEnv(t, keys[1], raw)
+		if _, err := sharedDBDefaultSpendingLimitFromEnv(); err == nil {
+			t.Fatalf("spending limit %q error = nil, want error", raw)
 		}
 	}
 }

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -12,8 +12,9 @@ import (
 	"github.com/google/uuid"
 )
 
-// MaxTiDBCloudSpendingLimit is the spendingLimit.monthly API maximum. In the
-// TiDB Cloud unit, 1,000,000 represents $10,000.
+// MaxTiDBCloudSpendingLimit is the tenant-facing quota API maximum. Physical
+// shared DB pools use a separately configured persisted target. In the TiDB
+// Cloud unit, 1,000,000 represents $10,000.
 const MaxTiDBCloudSpendingLimit = int64(1_000_000)
 
 // SharedDBRoleShared marks a db_pool row as a multi-tenant shared-schema
@@ -210,8 +211,8 @@ func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id
 	if in.MaxTenants <= 0 {
 		return 0, fmt.Errorf("managed max tenants must be positive")
 	}
-	if in.SpendingLimit == nil || *in.SpendingLimit != MaxTiDBCloudSpendingLimit {
-		return 0, fmt.Errorf("managed spending limit must equal TiDB Cloud maximum %d", MaxTiDBCloudSpendingLimit)
+	if in.SpendingLimit == nil || *in.SpendingLimit <= 0 || *in.SpendingLimit > int64(math.MaxInt32) {
+		return 0, fmt.Errorf("managed spending limit must be in (0,%d]", int64(math.MaxInt32))
 	}
 	var passwordCipher any
 	if len(in.PasswordCipher) != 0 {

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -12,10 +12,6 @@ import (
 	"github.com/google/uuid"
 )
 
-// SharedDBOrgWildcard is the org_id sentinel matching any TiDB Cloud
-// organization that has no exact db_pool row.
-const SharedDBOrgWildcard = "*"
-
 // MaxTiDBCloudSpendingLimit is the spendingLimit.monthly API maximum. In the
 // TiDB Cloud unit, 1,000,000 represents $10,000.
 const MaxTiDBCloudSpendingLimit = int64(1_000_000)
@@ -99,12 +95,24 @@ func sharedDBUUID(raw string) (string, error) {
 	return parsed.String(), nil
 }
 
+func validateSharedDBOrganizationID(raw string) (string, error) {
+	organizationID := strings.TrimSpace(raw)
+	if organizationID == "" {
+		return "", fmt.Errorf("tidbcloud organization id is required")
+	}
+	if organizationID != raw || strings.ContainsAny(organizationID, "*%?") {
+		return "", fmt.Errorf("tidbcloud organization id must be an exact value")
+	}
+	return organizationID, nil
+}
+
 // SharedDB is one physical database registered in db_pool. PasswordCipher
 // holds the same encrypted envelope as tenants.db_password; the plaintext
 // never crosses this layer. TLSMode is the go-sql-driver tls DSN parameter
 // verbatim ("true", "skip-verify", a custom registered config name, or ""
 // for plaintext) so the runtime handle reopens the DB with exactly the TLS
-// mode it was registered with. MaxTenants of 0 means unlimited.
+// mode it was registered with. MaxTenants of 0 makes the pool drain-only:
+// existing tenants may leave, but no new tenant may enter.
 type SharedDB struct {
 	ID                      int64
 	UUID                    string
@@ -182,6 +190,10 @@ func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id
 	if in == nil {
 		return 0, fmt.Errorf("shared db pool is required")
 	}
+	organizationID, err := validateSharedDBOrganizationID(in.TiDBCloudOrganizationID)
+	if err != nil {
+		return 0, err
+	}
 	poolUUID, err := sharedDBUUID(in.UUID)
 	if err != nil {
 		return 0, err
@@ -200,10 +212,6 @@ func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id
 	}
 	if in.SpendingLimit == nil || *in.SpendingLimit != MaxTiDBCloudSpendingLimit {
 		return 0, fmt.Errorf("managed spending limit must equal TiDB Cloud maximum %d", MaxTiDBCloudSpendingLimit)
-	}
-	var organizationID any
-	if in.TiDBCloudOrganizationID != "" {
-		organizationID = in.TiDBCloudOrganizationID
 	}
 	var passwordCipher any
 	if len(in.PasswordCipher) != 0 {
@@ -466,28 +474,22 @@ func (s *Store) ListSharedDBsByStatus(ctx context.Context, status string, limit 
 }
 
 // FindSharedDBForAllocation selects the oldest eligible exact-organization
-// pool, preferring active over provisioning. Before organization resolution,
-// callers may instead supply the 32-byte provisioning fingerprint. Managed
-// rows use one fixed physical spending limit, so tenant virtual values do not
-// participate in allocation.
-func (s *Store) FindSharedDBForAllocation(ctx context.Context, organizationID string, provisioningKey []byte) (db *SharedDB, err error) {
+// pool, preferring active over provisioning. Managed rows use one fixed
+// physical spending limit, so tenant virtual values do not participate in
+// allocation.
+func (s *Store) FindSharedDBForAllocation(ctx context.Context, organizationID string) (db *SharedDB, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "find_shared_db_for_allocation", start, &err)
-	identityColumn := "org_id"
-	var identity any = organizationID
-	if organizationID == "" {
-		if len(provisioningKey) != 32 {
-			return nil, fmt.Errorf("organization id or 32-byte provisioning key is required")
-		}
-		identityColumn = "provisioning_key"
-		identity = provisioningKey
+	organizationID, err = validateSharedDBOrganizationID(organizationID)
+	if err != nil {
+		return nil, err
 	}
 	query := "SELECT " + sharedDBSelectColumns + " FROM db_pool d " +
-		"WHERE d." + identityColumn + " = ? AND d.`role` = ? " +
+		"WHERE d.org_id = ? AND d.`role` = ? " +
 		"AND d.status IN (?, ?) " +
-		"AND (d.max_tenants = 0 OR (d.soft_cap_reached = 0 AND d.tenant_count < d.max_tenants)) " +
+		"AND d.max_tenants > 0 AND d.soft_cap_reached = 0 AND d.tenant_count < d.max_tenants " +
 		"ORDER BY CASE d.status WHEN 'active' THEN 0 ELSE 1 END, d.db_id LIMIT 1"
-	db, err = scanSharedDBRow(s.db.QueryRowContext(ctx, query, identity, SharedDBRoleShared,
+	db, err = scanSharedDBRow(s.db.QueryRowContext(ctx, query, organizationID, SharedDBRoleShared,
 		SharedDBStatusActive, SharedDBStatusProvisioning))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -534,6 +536,10 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 	if in == nil {
 		return 0, fmt.Errorf("shared db is required")
 	}
+	organizationID, err := validateSharedDBOrganizationID(in.TiDBCloudOrganizationID)
+	if err != nil {
+		return 0, err
+	}
 	poolUUID, err := sharedDBUUID(in.UUID)
 	if err != nil {
 		return 0, err
@@ -576,7 +582,7 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 			"ON DUPLICATE KEY UPDATE db_port = VALUES(db_port), db_user = VALUES(db_user), "+
 			"db_password = VALUES(db_password), db_tls = VALUES(db_tls), "+
 			"max_tenants = VALUES(max_tenants), status = VALUES(status)",
-		poolUUID, in.TiDBCloudOrganizationID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
+		poolUUID, organizationID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
 		in.TLSMode, in.MaxTenants, status); err != nil {
 		return 0, fmt.Errorf("upsert db_pool row: %w", err)
 	}
@@ -584,7 +590,7 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 	// auto-increment id via LastInsertId, so re-fetch by endpoint.
 	err = s.db.QueryRowContext(ctx,
 		`SELECT db_id FROM db_pool WHERE org_id = ? AND db_host = ? AND db_name = ?`,
-		in.TiDBCloudOrganizationID, in.Host, in.Name).Scan(&dbID)
+		organizationID, in.Host, in.Name).Scan(&dbID)
 	if err != nil {
 		return 0, fmt.Errorf("resolve db_id after upsert: %w", err)
 	}
@@ -625,39 +631,26 @@ func (s *Store) GetSharedDBForTenant(ctx context.Context, tenantID string) (*Sha
 	return db, nil
 }
 
-// FindSharedDBForOrg returns the active shared database serving orgID: an
-// exact org_id match wins over the '*' wildcard row. An empty orgID matches
-// only the wildcard row. Returns ErrNotFound when neither exists.
+// FindSharedDBForOrg returns the oldest open active shared database serving
+// exactly orgID. Shared DB pools never match across organizations.
 func (s *Store) FindSharedDBForOrg(ctx context.Context, orgID string) (db *SharedDB, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "find_shared_db_for_org", start, &err)
-	if orgID != "" && orgID != SharedDBOrgWildcard {
-		db, err = s.findActiveSharedDB(ctx, orgID)
-		if err == nil {
-			return db, nil
-		}
-		if !errors.Is(err, ErrNotFound) {
-			return nil, err
-		}
-	}
-	db, err = s.findActiveSharedDB(ctx, SharedDBOrgWildcard)
+	orgID, err = validateSharedDBOrganizationID(orgID)
 	if err != nil {
-		if errors.Is(err, ErrNotFound) {
-			return nil, ErrNotFound
-		}
 		return nil, err
 	}
-	return db, nil
+	return s.findActiveSharedDB(ctx, orgID)
 }
 
 func (s *Store) findActiveSharedDB(ctx context.Context, orgID string) (*SharedDB, error) {
 	// Capacity is enforced at selection time: normal allocation only sees open
-	// soft-cap pools (0 means unlimited); the transactional reserve remains the
-	// final guard against races.
+	// positive-capacity pools; the transactional reserve remains the final
+	// guard against races.
 	db, err := scanSharedDBRow(s.db.QueryRowContext(ctx,
 		"SELECT "+sharedDBSelectColumns+" FROM db_pool "+
 			"WHERE org_id = ? AND `role` = ? AND status = ? "+
-			"AND (max_tenants = 0 OR (soft_cap_reached = 0 AND tenant_count < max_tenants)) ORDER BY db_id LIMIT 1",
+			"AND max_tenants > 0 AND soft_cap_reached = 0 AND tenant_count < max_tenants ORDER BY db_id LIMIT 1",
 		orgID, SharedDBRoleShared, sharedDBStatusActive))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
@@ -992,7 +985,7 @@ func (s *Store) completeSharedTenantProvision(ctx context.Context, tenantID, pro
 			if dbPoolStatus != SharedDBStatusActive && (dbPoolStatus != SharedDBStatusProvisioning || (membership == nil && (!clusterID.Valid || clusterID.String == ""))) {
 				return fmt.Errorf("db pool %d is not physically ready: status=%s cluster=%q membership=%t: %w", p.DbID, dbPoolStatus, clusterID.String, membership != nil, ErrSharedDBCapacityExhausted)
 			}
-			if maxTenants > 0 && (softCapReached || tenantCount >= maxTenants) {
+			if maxTenants <= 0 || softCapReached || tenantCount >= maxTenants {
 				return fmt.Errorf("db pool %d soft capacity exhausted: count=%d max=%d latch=%t: %w", p.DbID, tenantCount, maxTenants, softCapReached, ErrSharedDBCapacityExhausted)
 			}
 		case SharedDBCapacityEmergency:
@@ -1014,7 +1007,7 @@ func (s *Store) completeSharedTenantProvision(ctx context.Context, tenantID, pro
 					ELSE soft_cap_reached END,
 					tenant_count = tenant_count + 1
 				WHERE db_id = ? AND (%s)
-					AND (max_tenants = 0 OR (soft_cap_reached = 0 AND tenant_count + 1 <= max_tenants))`
+					AND max_tenants > 0 AND soft_cap_reached = 0 AND tenant_count + 1 <= max_tenants`
 			if membership != nil {
 				normalQuery = fmt.Sprintf(normalQuery, "status IN (?, ?)")
 				res, err = tx.ExecContext(ctx, normalQuery, p.DbID, SharedDBStatusActive, SharedDBStatusProvisioning)
@@ -1284,7 +1277,9 @@ func releaseTenantPlacementAndDecrCountTx(ctx context.Context, tx *sql.Tx, fsID,
 		newTenantCount = 0
 	}
 	nextSoftCapReached := softCapReached
-	if maxTenants > 0 && newTenantCount <= reopenThreshold {
+	if maxTenants == 0 {
+		nextSoftCapReached = true
+	} else if newTenantCount <= reopenThreshold {
 		nextSoftCapReached = false
 	}
 	_, err = tx.ExecContext(ctx, `UPDATE db_pool

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -311,13 +311,17 @@ func TestRegisterSharedDBValidation(t *testing.T) {
 		}
 	}
 	cases := map[string]func(*SharedDB){
-		"missing host":      func(d *SharedDB) { d.Host = "" },
-		"non-positive port": func(d *SharedDB) { d.Port = 0 },
-		"missing user":      func(d *SharedDB) { d.User = "" },
-		"missing password":  func(d *SharedDB) { d.PasswordCipher = nil },
-		"missing name":      func(d *SharedDB) { d.Name = "" },
-		"negative max":      func(d *SharedDB) { d.MaxTenants = -1 },
-		"reserved role":     func(d *SharedDB) { d.Role = "dedicated" },
+		"missing organization":  func(d *SharedDB) { d.TiDBCloudOrganizationID = "" },
+		"wildcard organization": func(d *SharedDB) { d.TiDBCloudOrganizationID = "*" },
+		"glob organization":     func(d *SharedDB) { d.TiDBCloudOrganizationID = "org-*" },
+		"sql wildcard org":      func(d *SharedDB) { d.TiDBCloudOrganizationID = "org-%" },
+		"missing host":          func(d *SharedDB) { d.Host = "" },
+		"non-positive port":     func(d *SharedDB) { d.Port = 0 },
+		"missing user":          func(d *SharedDB) { d.User = "" },
+		"missing password":      func(d *SharedDB) { d.PasswordCipher = nil },
+		"missing name":          func(d *SharedDB) { d.Name = "" },
+		"negative max":          func(d *SharedDB) { d.MaxTenants = -1 },
+		"reserved role":         func(d *SharedDB) { d.Role = "dedicated" },
 	}
 	for name, mutate := range cases {
 		in := valid()
@@ -328,12 +332,11 @@ func TestRegisterSharedDBValidation(t *testing.T) {
 	}
 }
 
-func TestFindSharedDBForOrgExactThenWildcard(t *testing.T) {
+func TestFindSharedDBForOrgRequiresExactOrganization(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 
 	orgID := registerTestSharedDB(t, s, "org-exact", "shared-exact.example.com", "shared_db_exact")
-	wildID := registerTestSharedDB(t, s, SharedDBOrgWildcard, "shared-wild.example.com", "shared_db_wild")
 
 	got, err := s.FindSharedDBForOrg(ctx, "org-exact")
 	if err != nil {
@@ -343,20 +346,11 @@ func TestFindSharedDBForOrgExactThenWildcard(t *testing.T) {
 		t.Fatalf("exact match db_id = %d, want %d", got.ID, orgID)
 	}
 
-	got, err = s.FindSharedDBForOrg(ctx, "org-other")
-	if err != nil {
-		t.Fatalf("FindSharedDBForOrg fallback: %v", err)
+	if _, err := s.FindSharedDBForOrg(ctx, "org-other"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("FindSharedDBForOrg other org error = %v, want ErrNotFound", err)
 	}
-	if got.ID != wildID {
-		t.Fatalf("wildcard fallback db_id = %d, want %d", got.ID, wildID)
-	}
-
-	got, err = s.FindSharedDBForOrg(ctx, "")
-	if err != nil {
-		t.Fatalf("FindSharedDBForOrg empty org: %v", err)
-	}
-	if got.ID != wildID {
-		t.Fatalf("empty org db_id = %d, want wildcard %d", got.ID, wildID)
+	if _, err := s.FindSharedDBForOrg(ctx, ""); err == nil {
+		t.Fatal("FindSharedDBForOrg empty organization succeeded")
 	}
 }
 
@@ -369,8 +363,8 @@ func TestFindSharedDBForOrgNotFound(t *testing.T) {
 	if _, err := s.FindSharedDBForOrg(ctx, "org-missing"); !errors.Is(err, ErrNotFound) {
 		t.Fatalf("FindSharedDBForOrg miss error = %v, want ErrNotFound", err)
 	}
-	if _, err := s.FindSharedDBForOrg(ctx, ""); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("FindSharedDBForOrg empty org error = %v, want ErrNotFound", err)
+	if _, err := s.FindSharedDBForOrg(ctx, ""); err == nil {
+		t.Fatal("FindSharedDBForOrg empty organization succeeded")
 	}
 }
 
@@ -379,7 +373,7 @@ func TestListSharedDBs(t *testing.T) {
 	ctx := context.Background()
 
 	first := registerTestSharedDB(t, s, "org-a", "shared-a.example.com", "shared_db_a")
-	second := registerTestSharedDB(t, s, SharedDBOrgWildcard, "shared-wild.example.com", "shared_db_wild")
+	second := registerTestSharedDB(t, s, "org-b", "shared-b.example.com", "shared_db_b")
 	// A non-active row must not appear in the list.
 	if _, err := s.RegisterSharedDB(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-b",
@@ -543,7 +537,7 @@ func TestFindSharedDBForOrgSkipsFullPools(t *testing.T) {
 	ctx := context.Background()
 
 	// The exact-org pool is capped at 1 tenant; once full, selection must
-	// fall through to the wildcard pool rather than overfill it.
+	// return not found rather than overfill it.
 	fullID := registerTestSharedDB(t, s, "org-capped", "shared-capped.example.com", "shared_db_capped")
 	if _, err := s.RegisterSharedDB(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-capped",
@@ -556,8 +550,6 @@ func TestFindSharedDBForOrgSkipsFullPools(t *testing.T) {
 	}); err != nil {
 		t.Fatalf("cap pool at 1: %v", err)
 	}
-	wildID := registerTestSharedDB(t, s, SharedDBOrgWildcard, "shared-wild.example.com", "shared_db_wild")
-
 	got, err := s.FindSharedDBForOrg(ctx, "org-capped")
 	if err != nil {
 		t.Fatalf("FindSharedDBForOrg before full: %v", err)
@@ -569,20 +561,43 @@ func TestFindSharedDBForOrgSkipsFullPools(t *testing.T) {
 	if err := s.IncrSharedDBTenantCount(ctx, fullID, 1); err != nil {
 		t.Fatalf("fill pool: %v", err)
 	}
-	got, err = s.FindSharedDBForOrg(ctx, "org-capped")
-	if err != nil {
-		t.Fatalf("FindSharedDBForOrg after full: %v", err)
+	if _, err := s.FindSharedDBForOrg(ctx, "org-capped"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("full pool error = %v, want ErrNotFound", err)
 	}
-	if got.ID != wildID {
-		t.Fatalf("after full db_id = %d, want wildcard %d", got.ID, wildID)
+}
+
+func TestSharedDBMaxTenantsZeroIsDrainOnly(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	dbID := registerTestSharedDB(t, s, "org-drain-only", "shared-drain.example.com", "shared_db_drain")
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET max_tenants = 0 WHERE db_id = ?`, dbID); err != nil {
+		t.Fatal(err)
 	}
 
-	// With no wildcard fallback, a full pool reads as not found.
-	if _, err := s.db.Exec(`DELETE FROM db_pool WHERE db_id = ?`, wildID); err != nil {
-		t.Fatalf("remove wildcard: %v", err)
+	if _, err := s.FindSharedDBForOrg(ctx, "org-drain-only"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("FindSharedDBForOrg drain-only error = %v, want ErrNotFound", err)
 	}
-	if _, err := s.FindSharedDBForOrg(ctx, "org-capped"); !errors.Is(err, ErrNotFound) {
-		t.Fatalf("full pool without fallback error = %v, want ErrNotFound", err)
+	if _, err := s.FindSharedDBForAllocation(ctx, "org-drain-only"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("FindSharedDBForAllocation drain-only error = %v, want ErrNotFound", err)
+	}
+
+	seedPendingTenant(t, s, "tenant-drain-only")
+	fsID, err := s.EnsureFsID(ctx, "tenant-drain-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.CompleteSharedTenantProvision(ctx, "tenant-drain-only", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-drain-only"))
+	if !errors.Is(err, ErrSharedDBCapacityExhausted) {
+		t.Fatalf("CompleteSharedTenantProvision error = %v, want capacity exhausted", err)
+	}
+	db, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if db.TenantCount != 0 {
+		t.Fatalf("drain-only tenant_count = %d, want 0", db.TenantCount)
 	}
 }
 
@@ -887,7 +902,7 @@ func TestManagedSharedDBPoolCloudResultSchemaAndActivation(t *testing.T) {
 	ctx := context.Background()
 	spendingLimit := MaxTiDBCloudSpendingLimit
 	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
-		ProvisioningKey: make([]byte, 32), CloudProvider: "aws", Region: "us-east-1",
+		TiDBCloudOrganizationID: "org-managed", ProvisioningKey: make([]byte, 32), CloudProvider: "aws", Region: "us-east-1",
 		MaxTenants: 100, SpendingLimit: &spendingLimit,
 	})
 	if err != nil {
@@ -1018,7 +1033,7 @@ func TestFindSharedDBForAllocationPrefersActiveWithoutVirtualSpendingHeadroom(t 
 		t.Fatalf("activate second pool: %v", err)
 	}
 
-	got, err := s.FindSharedDBForAllocation(ctx, "org-allocate", nil)
+	got, err := s.FindSharedDBForAllocation(ctx, "org-allocate")
 	if err != nil {
 		t.Fatalf("FindSharedDBForAllocation active: %v", err)
 	}
@@ -1037,7 +1052,7 @@ func TestFindSharedDBForAllocationPrefersActiveWithoutVirtualSpendingHeadroom(t 
 	}, testOwnerKey("tenant-headroom")); err != nil {
 		t.Fatalf("CompleteSharedTenantProvision: %v", err)
 	}
-	got, err = s.FindSharedDBForAllocation(ctx, "org-allocate", nil)
+	got, err = s.FindSharedDBForAllocation(ctx, "org-allocate")
 	if err != nil {
 		t.Fatalf("FindSharedDBForAllocation fallback: %v", err)
 	}
@@ -1169,7 +1184,7 @@ func TestCompleteSharedTenantProvisionRollsBackOnMissingTenant(t *testing.T) {
 
 	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-rollback", Host: "h", Port: 4000, User: "u",
-		PasswordCipher: []byte("c"), Name: "rollback_db",
+		PasswordCipher: []byte("c"), Name: "rollback_db", MaxTenants: 10,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -1211,7 +1226,7 @@ func TestDeleteTenantPlacementAndDecrCountIsAtomic(t *testing.T) {
 
 	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-release", Host: "h", Port: 4000, User: "u",
-		PasswordCipher: []byte("c"), Name: "release_db",
+		PasswordCipher: []byte("c"), Name: "release_db", MaxTenants: 10,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -1241,7 +1256,7 @@ func TestDeleteTenantPlacementAndDecrCountIsAtomic(t *testing.T) {
 		t.Fatalf("TenantCount = %d, want 0", got.TenantCount)
 	}
 	if got.SoftCapReached {
-		t.Fatal("unlimited pool soft-cap latch = true, want false")
+		t.Fatal("released pool soft-cap latch = true, want false")
 	}
 
 	// Missing placement: ErrNotFound.
@@ -1261,6 +1276,42 @@ func TestDeleteTenantPlacementAndDecrCountIsAtomic(t *testing.T) {
 	}
 	if _, err := s.GetTenantPlacement(ctx, 301); err != nil {
 		t.Fatalf("placement must survive rolled-back delete: %v", err)
+	}
+}
+
+func TestDrainOnlySharedDBAllowsExistingTenantRelease(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-drain-release", Host: "h", Port: 4000, User: "u",
+		PasswordCipher: []byte("c"), Name: "drain_release_db", MaxTenants: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	seedPendingTenant(t, s, "tenant-drain-release")
+	fsID, err := s.EnsureFsID(ctx, "tenant-drain-release")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := s.CompleteSharedTenantProvision(ctx, "tenant-drain-release", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-drain-release")); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET max_tenants = 0 WHERE db_id = ?`, dbID); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.DeleteTenantPlacementAndDecrCount(ctx, fsID, dbID, 0.8); err != nil {
+		t.Fatalf("DeleteTenantPlacementAndDecrCount: %v", err)
+	}
+	db, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if db.TenantCount != 0 || !db.SoftCapReached {
+		t.Fatalf("drain-only pool after release = count %d soft_cap_reached %t, want 0/true", db.TenantCount, db.SoftCapReached)
 	}
 }
 
@@ -1306,7 +1357,7 @@ func TestFinalizeSharedTenantDeleteMetadataIsAtomic(t *testing.T) {
 	ctx := context.Background()
 	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-finalize-delete", Host: "h", Port: 4000, User: "u",
-		PasswordCipher: []byte("c"), Name: "finalize_delete_db",
+		PasswordCipher: []byte("c"), Name: "finalize_delete_db", MaxTenants: 10,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -1384,7 +1435,7 @@ func TestCompleteSharedTenantProvisionRollsBackOnKeyFailure(t *testing.T) {
 
 	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
 		TiDBCloudOrganizationID: "org-keyfail", Host: "h", Port: 4000, User: "u",
-		PasswordCipher: []byte("c"), Name: "keyfail_db",
+		PasswordCipher: []byte("c"), Name: "keyfail_db", MaxTenants: 10,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -147,7 +147,7 @@ func TestRegisterSharedDBRoundTrip(t *testing.T) {
 func TestCreateManagedSharedDBPoolPersistsDurableProvisioningPlan(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
-	spendingLimit := MaxTiDBCloudSpendingLimit
+	spendingLimit := int64(2_000_000)
 	provisioningKey := make([]byte, 32)
 	for i := range provisioningKey {
 		provisioningKey[i] = byte(i + 1)
@@ -207,8 +207,16 @@ func TestCreateManagedSharedDBPoolRejectsUnboundedOrInvalidPolicy(t *testing.T) 
 		"missing cloud":       func(in *SharedDB) { in.CloudProvider = "" },
 		"missing region":      func(in *SharedDB) { in.Region = "" },
 		"missing spending":    func(in *SharedDB) { in.SpendingLimit = nil },
-		"physical limit below fixed maximum": func(in *SharedDB) {
-			value := MaxTiDBCloudSpendingLimit - 1
+		"zero spending": func(in *SharedDB) {
+			value := int64(0)
+			in.SpendingLimit = &value
+		},
+		"negative spending": func(in *SharedDB) {
+			value := int64(-1)
+			in.SpendingLimit = &value
+		},
+		"spending exceeds wire range": func(in *SharedDB) {
+			value := int64(math.MaxInt32) + 1
 			in.SpendingLimit = &value
 		},
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2614,7 +2614,7 @@ func (s *Store) ListTenantsByTiDBCloudOrganization(ctx context.Context, organiza
 		limit = 10
 	}
 	args := []any{TenantDeleted, tidbCloudNativeProvider, organizationID, TenantPoolBindingFree,
-		tidbCloudNativeSharedProvider, organizationID, SharedDBOrgWildcard, TenantPoolBindingFree, limit, offset}
+		tidbCloudNativeSharedProvider, organizationID, TenantPoolBindingFree, limit, offset}
 	query := `SELECT
 			t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
 			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
@@ -2633,7 +2633,7 @@ func (s *Store) ListTenantsByTiDBCloudOrganization(ctx context.Context, organiza
 				JOIN tenant_placements p ON p.fs_id = f.fs_id
 				JOIN db_pool d ON d.db_id = p.db_id
 				WHERE f.tenant_id = t.id
-					AND d.org_id IN (?, ?)
+					AND d.org_id = ?
 					AND NOT EXISTS (
 						SELECT 1 FROM tenant_pool_memberships m
 						WHERE m.tenant_id = t.id AND m.pool_status = ?

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2597,14 +2597,14 @@ func (s *Store) ListTenantsByTiDBCloudOrgClusterBindings(ctx context.Context, bi
 	return scanTenantBindingRows(rows)
 }
 
-// ListTenantsByTiDBCloudResources lists dedicated tenants through their
-// tenant binding and shared tenants through the physical db_pool resource.
-// Pagination is applied after both provider sources are combined.
-func (s *Store) ListTenantsByTiDBCloudResources(ctx context.Context, bindings []TenantTiDBCloudOrgBinding, offset, limit int) (out []Tenant, err error) {
+// ListTenantsByTiDBCloudOrganization lists dedicated and shared tenants owned
+// by one IAM-authenticated TiDB Cloud organization. Pagination is applied
+// after both provider sources are combined.
+func (s *Store) ListTenantsByTiDBCloudOrganization(ctx context.Context, organizationID string, offset, limit int) (out []Tenant, err error) {
 	start := time.Now()
-	defer observeMeta(ctx, "list_tenants_by_tidbcloud_resources", start, &err)
-	bindings = compactTiDBCloudOrgClusterBindings(bindings)
-	if len(bindings) == 0 {
+	defer observeMeta(ctx, "list_tenants_by_tidbcloud_organization", start, &err)
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" {
 		return []Tenant{}, nil
 	}
 	if offset < 0 {
@@ -2613,23 +2613,8 @@ func (s *Store) ListTenantsByTiDBCloudResources(ctx context.Context, bindings []
 	if limit <= 0 {
 		limit = 10
 	}
-	placeholders := make([]string, 0, len(bindings))
-	resourceArgs := make([]any, 0, len(bindings)*2)
-	clusterPlaceholders := make([]string, 0, len(bindings))
-	clusterArgs := make([]any, 0, len(bindings))
-	for _, binding := range bindings {
-		placeholders = append(placeholders, "(?, ?)")
-		resourceArgs = append(resourceArgs, binding.OrganizationID, binding.ClusterID)
-		clusterPlaceholders = append(clusterPlaceholders, "?")
-		clusterArgs = append(clusterArgs, binding.ClusterID)
-	}
-	resources := strings.Join(placeholders, ",")
-	clusters := strings.Join(clusterPlaceholders, ",")
-	args := []any{TenantDeleted, tidbCloudNativeProvider}
-	args = append(args, resourceArgs...)
-	args = append(args, TenantPoolBindingFree, tidbCloudNativeSharedProvider)
-	args = append(args, clusterArgs...)
-	args = append(args, TenantPoolBindingFree, limit, offset)
+	args := []any{TenantDeleted, tidbCloudNativeProvider, organizationID, TenantPoolBindingFree,
+		tidbCloudNativeSharedProvider, organizationID, SharedDBOrgWildcard, TenantPoolBindingFree, limit, offset}
 	query := `SELECT
 			t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
 			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
@@ -2640,7 +2625,7 @@ func (s *Store) ListTenantsByTiDBCloudResources(ctx context.Context, bindings []
 			(t.provider = ? AND EXISTS (
 				SELECT 1 FROM tenant_tidbcloud_org_bindings b
 				WHERE b.tenant_id = t.id
-					AND (b.organization_id, b.cluster_id) IN (` + resources + `)
+					AND b.organization_id = ?
 					AND b.pool_status <> ?
 			)) OR
 			(t.provider = ? AND EXISTS (
@@ -2648,7 +2633,7 @@ func (s *Store) ListTenantsByTiDBCloudResources(ctx context.Context, bindings []
 				JOIN tenant_placements p ON p.fs_id = f.fs_id
 				JOIN db_pool d ON d.db_id = p.db_id
 				WHERE f.tenant_id = t.id
-					AND d.cluster_id IN (` + clusters + `)
+					AND d.org_id IN (?, ?)
 					AND NOT EXISTS (
 						SELECT 1 FROM tenant_pool_memberships m
 						WHERE m.tenant_id = t.id AND m.pool_status = ?

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -460,16 +460,6 @@ func expandManagedDBPoolSchema(ctx context.Context, db *sql.DB) error {
 		WHERE max_tenants > 0 AND tenant_count >= max_tenants AND soft_cap_reached = 0`); err != nil {
 		return fmt.Errorf("backfill db_pool.soft_cap_reached: %w", err)
 	}
-	// A non-NULL spending limit identifies a Drive9-managed shared pool. Older
-	// builds persisted a configurable target that could exceed the TiDB Cloud
-	// API maximum; normalize it before provisioning/recovery resumes. The
-	// predicate makes this safe to rerun on every server startup.
-	if _, err := db.ExecContext(ctx, `UPDATE db_pool SET spending_limit = ?
-		WHERE spending_limit IS NOT NULL AND spending_limit <> ?`,
-		MaxTiDBCloudSpendingLimit, MaxTiDBCloudSpendingLimit); err != nil {
-		return fmt.Errorf("normalize managed db_pool spending limit: %w", err)
-	}
-
 	exists, err := metaIndexExists(ctx, db, "db_pool", "uk_db_pool_cloud_resource")
 	if err != nil {
 		return fmt.Errorf("check db_pool cloud resource unique index: %w", err)

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -735,8 +735,7 @@ func metaInitSchemaStatements() []string {
 		)`,
 		// db_pool is the fleet-wide registry of physical databases available
 		// for tenant placement under the shared-schema layout. org_id scopes a
-		// database to a TiDB Cloud organization; the '*' wildcard row serves
-		// organizations without an exact entry. db_password holds the same
+		// database to one exact TiDB Cloud organization. db_password holds the same
 		// encrypted envelope as tenants.db_password. tenant_count is maintained
 		// atomically with placement writes via CompleteSharedTenantProvision and
 		// DeleteTenantPlacementAndDecrCount.

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1676,7 +1676,7 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 	}
 }
 
-func TestMigrateNormalizesManagedSharedDBSpendingLimitToCloudMaximum(t *testing.T) {
+func TestMigratePreservesManagedSharedDBSpendingLimit(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 	limit := MaxTiDBCloudSpendingLimit
@@ -1687,19 +1687,20 @@ func TestMigrateNormalizesManagedSharedDBSpendingLimitToCloudMaximum(t *testing.
 	if err != nil {
 		t.Fatalf("CreateManagedSharedDBPool: %v", err)
 	}
-	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET spending_limit = 10000000 WHERE db_id = ?`, id); err != nil {
-		t.Fatalf("seed legacy spending limit: %v", err)
+	const configuredLimit = int64(2_000_000)
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET spending_limit = ? WHERE db_id = ?`, configuredLimit, id); err != nil {
+		t.Fatalf("seed configured spending limit: %v", err)
 	}
 
 	if err := s.migrate(); err != nil {
-		t.Fatalf("migrate legacy spending limit: %v", err)
+		t.Fatalf("migrate configured spending limit: %v", err)
 	}
 	got, err := s.GetSharedDB(ctx, id)
 	if err != nil {
 		t.Fatalf("GetSharedDB: %v", err)
 	}
-	if got.SpendingLimit == nil || *got.SpendingLimit != MaxTiDBCloudSpendingLimit {
-		t.Fatalf("spending limit = %v, want %d", got.SpendingLimit, MaxTiDBCloudSpendingLimit)
+	if got.SpendingLimit == nil || *got.SpendingLimit != configuredLimit {
+		t.Fatalf("spending limit = %v, want %d", got.SpendingLimit, configuredLimit)
 	}
 
 	if err := s.migrate(); err != nil {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1026,21 +1026,13 @@ func (s *Server) provisionManagedSharedDBPoolsBatch(ctx context.Context, dbIDs [
 		return "", nil
 	}
 	provisioner := s.provisioner.(tenant.SharedDBPoolProvisioner)
-	first, err := s.meta.GetSharedDB(ctx, dbIDs[0])
-	if err != nil {
-		return "", err
-	}
-	cred, err := s.sharedDBCloudCredentials(ctx, first.TiDBCloudOrganizationID)
-	if err != nil {
-		return "", err
-	}
 	resolvedOrg := ""
 	for start := 0; start < len(dbIDs); start += 10 {
 		end := start + 10
 		if end > len(dbIDs) {
 			end = len(dbIDs)
 		}
-		chunkOrg, err := s.provisionManagedSharedDBPoolsBatchChunk(ctx, provisioner, dbIDs[start:end], cred)
+		chunkOrg, err := s.provisionManagedSharedDBPoolsBatchChunk(ctx, provisioner, dbIDs[start:end])
 		if err != nil {
 			return resolvedOrg, err
 		}
@@ -1051,9 +1043,13 @@ func (s *Server) provisionManagedSharedDBPoolsBatch(ctx context.Context, dbIDs [
 	return resolvedOrg, nil
 }
 
-func (s *Server) provisionManagedSharedDBPoolsBatchChunk(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) (string, error) {
+func (s *Server) provisionManagedSharedDBPoolsBatchChunk(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64) (string, error) {
 	for attempt := 0; attempt < 2; attempt++ {
 		first, err := s.meta.GetSharedDB(ctx, dbIDs[0])
+		if err != nil {
+			return "", err
+		}
+		cred, err := s.sharedDBCloudCredentials(ctx, first.TiDBCloudOrganizationID)
 		if err != nil {
 			return "", err
 		}
@@ -1065,7 +1061,7 @@ func (s *Server) provisionManagedSharedDBPoolsBatchChunk(ctx context.Context, pr
 			if err != nil {
 				return err
 			}
-			if first.TiDBCloudOrganizationID == "" && current.TiDBCloudOrganizationID != "" {
+			if strings.TrimSpace(first.TiDBCloudOrganizationID) != strings.TrimSpace(current.TiDBCloudOrganizationID) {
 				restartWithOrganization = true
 				return nil
 			}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1049,7 +1049,7 @@ func (s *Server) provisionManagedSharedDBPoolsBatchChunk(ctx context.Context, pr
 		if err != nil {
 			return "", err
 		}
-		cred, err := s.sharedDBCloudCredentials(ctx)
+		cred, err := s.sharedDBCloudCredentials()
 		if err != nil {
 			return "", err
 		}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -707,15 +707,11 @@ func (s *Server) refreshTenantPoolCapacity(ctx context.Context, pool *meta.Tenan
 }
 
 func (s *Server) firstManagedOrganization(ctx context.Context, cred tenant.CredentialProvisionRequest) (string, error) {
-	// Resolve through the RBAC list cache so repeated org lookups on the same
-	// request path (warm-pool claim + shared-pool check) and across
-	// consecutive provisions do not each cost a TiDB Cloud list call. The
-	// cache is invalidated on tenant mutations (forgetTiDBCloudRBACList).
-	clusters, err := s.listAllManagedClusters(ctx, cred, "", "provision_org_resolve")
-	if err != nil || len(clusters) == 0 {
+	identity, err := s.resolveTiDBCloudIdentity(ctx, cred, "provision_org_resolve")
+	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(clusters[0].OrganizationID), nil
+	return identity.OrganizationID, nil
 }
 
 func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count int, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*provisionTenantResult, error) {
@@ -1002,7 +998,7 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 		createdIDs = append(createdIDs, id)
 	}
 	sort.Slice(createdIDs, func(i, j int) bool { return createdIDs[i] < createdIDs[j] })
-	resolvedOrg, err := s.provisionManagedSharedDBPoolsBatch(ctx, createdIDs, cred)
+	resolvedOrg, err := s.provisionManagedSharedDBPoolsBatch(ctx, createdIDs)
 	if err != nil {
 		return results, err
 	}
@@ -1021,15 +1017,23 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 	for dbID := range provisioningPoolIDs {
 		provisioningIDs = append(provisioningIDs, dbID)
 	}
-	s.scheduleManagedSharedDBContinuations(ctx, provisioningIDs, cred)
+	s.scheduleManagedSharedDBContinuations(ctx, provisioningIDs)
 	return results, nil
 }
 
-func (s *Server) provisionManagedSharedDBPoolsBatch(ctx context.Context, dbIDs []int64, cred tenant.CredentialProvisionRequest) (string, error) {
+func (s *Server) provisionManagedSharedDBPoolsBatch(ctx context.Context, dbIDs []int64) (string, error) {
 	if len(dbIDs) == 0 {
 		return "", nil
 	}
 	provisioner := s.provisioner.(tenant.SharedDBPoolProvisioner)
+	first, err := s.meta.GetSharedDB(ctx, dbIDs[0])
+	if err != nil {
+		return "", err
+	}
+	cred, err := s.sharedDBCloudCredentials(ctx, first.TiDBCloudOrganizationID)
+	if err != nil {
+		return "", err
+	}
 	resolvedOrg := ""
 	for start := 0; start < len(dbIDs); start += 10 {
 		end := start + 10

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -157,17 +157,6 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 			"provider", tenant.ProviderTiDBCloudNative,
 			"organization_id", orgID,
 			"duration_ms", durationMillis(stageStarted))...)
-		if s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared {
-			if _, err := s.sharedDBCloudCredentials(ctx, orgID); err != nil {
-				metricResult = "cluster_error"
-				if errors.Is(err, errSharedDBCredentialOrganizationMismatch) {
-					errJSON(w, http.StatusForbidden, sharedDBCredentialOrganizationMismatchMessage)
-				} else {
-					writeAdminTiDBCloudError(w, ctx, err, "authorize shared tenant pool")
-				}
-				return nil
-			}
-		}
 		if orgID != "" {
 			if _, err := s.meta.GetTenantPoolByOrganization(ctx, orgID); err == nil {
 				metricResult = "conflict"
@@ -1060,7 +1049,7 @@ func (s *Server) provisionManagedSharedDBPoolsBatchChunk(ctx context.Context, pr
 		if err != nil {
 			return "", err
 		}
-		cred, err := s.sharedDBCloudCredentials(ctx, first.TiDBCloudOrganizationID)
+		cred, err := s.sharedDBCloudCredentials(ctx)
 		if err != nil {
 			return "", err
 		}
@@ -1133,20 +1122,21 @@ func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, p
 			return resolvedOrg, fmt.Errorf("shared db batch returned an unknown db pool")
 		}
 		row := rows[info.DBPoolID]
-		if info.OrganizationID == "" {
-			info.OrganizationID = row.TiDBCloudOrganizationID
+		logicalOrganizationID := strings.TrimSpace(row.TiDBCloudOrganizationID)
+		if logicalOrganizationID == "" {
+			return resolvedOrg, fmt.Errorf("managed shared db pool customer organization is required")
 		}
 		if info.DBName == "" {
 			info.DBName = row.Name
 		}
 		if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{ID: info.DBPoolID,
-			TiDBCloudOrganizationID: info.OrganizationID, ClusterID: info.ClusterID, Host: info.Host,
+			TiDBCloudOrganizationID: logicalOrganizationID, ClusterID: info.ClusterID, Host: info.Host,
 			Port: info.Port, User: info.Username, PasswordCipher: row.PasswordCipher, Name: info.DBName,
 			TLSMode: map[bool]string{true: "true", false: "skip-verify"}[dbTLSForProvisionedTenant(tenant.ProviderTiDBCloudNativeShared)]}); err != nil {
 			return resolvedOrg, err
 		}
 		if resolvedOrg == "" {
-			resolvedOrg = info.OrganizationID
+			resolvedOrg = logicalOrganizationID
 		}
 	}
 	if createErr != nil {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -157,6 +157,17 @@ func (s *Server) handleAdminTenantPoolCreate(w http.ResponseWriter, r *http.Requ
 			"provider", tenant.ProviderTiDBCloudNative,
 			"organization_id", orgID,
 			"duration_ms", durationMillis(stageStarted))...)
+		if s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared {
+			if _, err := s.sharedDBCloudCredentials(ctx, orgID); err != nil {
+				metricResult = "cluster_error"
+				if errors.Is(err, errSharedDBCredentialOrganizationMismatch) {
+					errJSON(w, http.StatusForbidden, sharedDBCredentialOrganizationMismatchMessage)
+				} else {
+					writeAdminTiDBCloudError(w, ctx, err, "authorize shared tenant pool")
+				}
+				return nil
+			}
+		}
 		if orgID != "" {
 			if _, err := s.meta.GetTenantPoolByOrganization(ctx, orgID); err == nil {
 				metricResult = "conflict"

--- a/pkg/server/admin_tenant_pool_cache_test.go
+++ b/pkg/server/admin_tenant_pool_cache_test.go
@@ -2,20 +2,21 @@ package server
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
-// TestFirstManagedOrganizationUsesRBACCache proves org resolution for
-// provisioning reuses the RBAC cluster-list cache: repeated lookups for the
-// same credential cost one TiDB Cloud list call, and forgetting the cache
-// forces a fresh fetch.
-func TestFirstManagedOrganizationUsesRBACCache(t *testing.T) {
+func TestFirstManagedOrganizationUsesIAMIdentityCache(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{
-		{Clusters: []tenant.CloudClusterInfo{{ClusterID: "c1", OrganizationID: "org-cached-1"}}},
-		{Clusters: []tenant.CloudClusterInfo{{ClusterID: "c2", OrganizationID: "org-cached-2"}}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{
+		{OrganizationID: "org-cached-1", Role: tenant.TiDBCloudRoleOrgOwner},
+		{OrganizationID: "org-cached-2", Role: tenant.TiDBCloudRoleProjectOwner},
 	}
 	ctx := context.Background()
 	cred := tenant.CredentialProvisionRequest{PublicKey: "pk", PrivateKey: "sk"}
@@ -27,9 +28,6 @@ func TestFirstManagedOrganizationUsesRBACCache(t *testing.T) {
 	if org != "org-cached-1" {
 		t.Fatalf("org = %q, want org-cached-1", org)
 	}
-	// The second lookup for the same credential must hit the cache: no
-	// additional list call, and the org from the cached page is returned
-	// (not the second scripted page).
 	org, err = rt.server.firstManagedOrganization(ctx, cred)
 	if err != nil {
 		t.Fatalf("second lookup: %v", err)
@@ -37,48 +35,71 @@ func TestFirstManagedOrganizationUsesRBACCache(t *testing.T) {
 	if org != "org-cached-1" {
 		t.Fatalf("cached org = %q, want org-cached-1", org)
 	}
-	if got := rt.prov.listCalls.Load(); got != 1 {
-		t.Fatalf("list calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
 	}
 
-	// Forgetting the list forces a fresh API fetch (second scripted page).
-	rt.server.forgetTiDBCloudRBACList(cred)
-	org, err = rt.server.firstManagedOrganization(ctx, cred)
+	secondCred := tenant.CredentialProvisionRequest{PublicKey: "pk-2", PrivateKey: "sk-2"}
+	org, err = rt.server.firstManagedOrganization(ctx, secondCred)
 	if err != nil {
-		t.Fatalf("lookup after forget: %v", err)
+		t.Fatalf("lookup with second credentials: %v", err)
 	}
 	if org != "org-cached-2" {
-		t.Fatalf("org after forget = %q, want org-cached-2", org)
+		t.Fatalf("org with second credentials = %q, want org-cached-2", org)
 	}
-	if got := rt.prov.listCalls.Load(); got != 2 {
-		t.Fatalf("list calls after forget = %d, want 2", got)
+	if got := rt.prov.iamCalls.Load(); got != 2 {
+		t.Fatalf("IAM calls after second credentials = %d, want 2", got)
 	}
 }
 
-func TestListAllManagedClustersUsesRBACCache(t *testing.T) {
+func TestResolveTiDBCloudIdentityRejectsInsufficientRole(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{ClusterID: "c1", OrganizationID: "org-1"}},
-	}}
-	ctx := context.Background()
-	cred := tenant.CredentialProvisionRequest{PublicKey: "pk", PrivateKey: "sk"}
+	rt.prov.iamErr = tenant.ErrTiDBCloudRoleInsufficient
+	_, err := rt.server.resolveTiDBCloudIdentity(context.Background(), tenant.CredentialProvisionRequest{
+		PublicKey: "pk", PrivateKey: "sk",
+	}, "test_role")
+	if err == nil || !isTiDBCloudRoleInsufficient(err) {
+		t.Fatalf("error = %v, want insufficient role", err)
+	}
+}
 
-	clusters, err := rt.server.listAllManagedClusters(ctx, cred, "", "test_managed_cluster_list")
-	if err != nil {
-		t.Fatalf("first list: %v", err)
+func TestAdminTenantAPIEnabledForSharedProvider(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNativeShared)
+	if !rt.server.adminTenantAPIEnabled() {
+		t.Fatal("admin tenant API must be enabled for tidb_cloud_native_shared")
 	}
-	if len(clusters) != 1 || clusters[0].ClusterID != "c1" || clusters[0].OrganizationID != "org-1" {
-		t.Fatalf("first clusters = %#v", clusters)
-	}
+}
 
-	clusters, err = rt.server.listAllManagedClusters(ctx, cred, "", "test_managed_cluster_list")
+func TestAdminTenantHTTPRejectsInsufficientIAMRoleWithoutLeakingDetails(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.iamErr = fmt.Errorf("%w: org:viewer SENSITIVE_IAM_DETAIL", tenant.ErrTiDBCloudRoleInsufficient)
+	ts := httptest.NewServer(rt.server)
+	defer ts.Close()
+
+	req, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/admin/tenants", nil)
 	if err != nil {
-		t.Fatalf("cached list: %v", err)
+		t.Fatal(err)
 	}
-	if len(clusters) != 1 || clusters[0].ClusterID != "c1" || clusters[0].OrganizationID != "org-1" {
-		t.Fatalf("cached clusters = %#v", clusters)
+	req.Header.Set(quotaPublicKeyHeader, "VIEWERFIXTURE1")
+	req.Header.Set(quotaPrivateKeyHeader, "fixture-private")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
 	}
-	if got := rt.prov.listCalls.Load(); got != 1 {
-		t.Fatalf("list calls = %d, want 1", got)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(string(body), tenant.ErrTiDBCloudRoleInsufficient.Error()) {
+		t.Fatalf("body = %q, want stable insufficient-role error", body)
+	}
+	for _, sensitive := range []string{"SENSITIVE_IAM_DETAIL", "VIEWERFIXTURE1", "fixture-private"} {
+		if strings.Contains(string(body), sensitive) {
+			t.Fatalf("body leaked %q: %s", sensitive, body)
+		}
 	}
 }

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -83,7 +83,7 @@ func TestTenantPoolClaimUsesNativeInventoryBeforeExternalSharedPool(t *testing.T
 	nativeTenantID := insertAdminPoolFreeTenant(t, rt, "pool-mixed-inventory", "org-mixed-inventory", 1)
 	if _, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-mixed-inventory", Host: "shared.example.com", Port: 4000,
-		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 100,
 	}); err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
 	}

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -70,8 +70,8 @@ func TestRetryTenantPoolClaimCASDoesNotRetryBusinessError(t *testing.T) {
 func TestTenantPoolClaimUsesNativeInventoryBeforeExternalSharedPool(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{OrganizationID: "org-mixed-inventory"}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-mixed-inventory", Role: tenant.TiDBCloudRoleOrgOwner,
 	}}
 	now := time.Now().UTC()
 	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
@@ -105,10 +105,9 @@ func TestTenantPoolClaimConsumesMixedInventoryInGlobalAgeOrder(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.server.defaultTenantProvider = tenant.ProviderTiDBCloudNativeShared
 	ctx := context.Background()
-	orgPage := &tenant.ManagedClusterListResult{
-		Clusters: []tenant.CloudClusterInfo{{OrganizationID: "org-mixed-age"}},
-	}
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{orgPage, orgPage}
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-mixed-age", Role: tenant.TiDBCloudRoleProjectOwner,
+	}}
 	now := time.Now().UTC()
 	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
 		PoolID: "pool-mixed-age", OrganizationID: "org-mixed-age", Size: 2,

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -283,45 +283,6 @@ func TestAdminTenantPoolCreateCleansPartialSharedMembersOnBatchFailure(t *testin
 	}
 }
 
-func TestAdminTenantPoolCreateSharedRejectsDifferentCustomerAndSharedOrganizations(t *testing.T) {
-	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.defaultTenantProvider = tenant.ProviderTiDBCloudNativeShared
-	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{
-		{OrganizationID: "org-customer", Role: tenant.TiDBCloudRoleOrgOwner},
-		{OrganizationID: "org-shared", Role: tenant.TiDBCloudRoleOrgOwner},
-	}
-	ts := httptest.NewServer(rt.server)
-	t.Cleanup(ts.Close)
-
-	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
-		"public_key": "customer-public", "private_key": "customer-private", "pool_size": 1,
-	}, "")
-	defer func() { _ = resp.Body.Close() }()
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if resp.StatusCode != http.StatusForbidden {
-		t.Errorf("status = %d, want %d: %s", resp.StatusCode, http.StatusForbidden, body)
-	}
-	if !strings.Contains(string(body), sharedDBCredentialOrganizationMismatchMessage) {
-		t.Errorf("body = %s, want stable organization mismatch message", body)
-	}
-	if strings.Contains(string(body), "org-customer") || strings.Contains(string(body), "org-shared") {
-		t.Errorf("organization IDs leaked in response: %s", body)
-	}
-	if _, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-customer"); !errors.Is(err, meta.ErrNotFound) {
-		t.Errorf("tenant pool lookup error = %v, want ErrNotFound after fail-fast rejection", err)
-	}
-	var pools int
-	if err := rt.meta.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM db_pool").Scan(&pools); err != nil {
-		t.Fatal(err)
-	}
-	if pools != 0 {
-		t.Errorf("db_pool rows = %d, want 0 after fail-fast rejection", pools)
-	}
-}
-
 func TestDeleteFreeSharedPoolTenantSkipsPurgeWhenDBPoolIsUnready(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.server.defaultTenantProvider = tenant.ProviderTiDBCloudNativeShared

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -283,6 +283,45 @@ func TestAdminTenantPoolCreateCleansPartialSharedMembersOnBatchFailure(t *testin
 	}
 }
 
+func TestAdminTenantPoolCreateSharedRejectsDifferentCustomerAndSharedOrganizations(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.server.defaultTenantProvider = tenant.ProviderTiDBCloudNativeShared
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{
+		{OrganizationID: "org-customer", Role: tenant.TiDBCloudRoleOrgOwner},
+		{OrganizationID: "org-shared", Role: tenant.TiDBCloudRoleOrgOwner},
+	}
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+
+	resp := postJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key": "customer-public", "private_key": "customer-private", "pool_size": 1,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Errorf("status = %d, want %d: %s", resp.StatusCode, http.StatusForbidden, body)
+	}
+	if !strings.Contains(string(body), sharedDBCredentialOrganizationMismatchMessage) {
+		t.Errorf("body = %s, want stable organization mismatch message", body)
+	}
+	if strings.Contains(string(body), "org-customer") || strings.Contains(string(body), "org-shared") {
+		t.Errorf("organization IDs leaked in response: %s", body)
+	}
+	if _, err := rt.meta.GetTenantPoolByOrganization(context.Background(), "org-customer"); !errors.Is(err, meta.ErrNotFound) {
+		t.Errorf("tenant pool lookup error = %v, want ErrNotFound after fail-fast rejection", err)
+	}
+	var pools int
+	if err := rt.meta.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM db_pool").Scan(&pools); err != nil {
+		t.Fatal(err)
+	}
+	if pools != 0 {
+		t.Errorf("db_pool rows = %d, want 0 after fail-fast rejection", pools)
+	}
+}
+
 func TestDeleteFreeSharedPoolTenantSkipsPurgeWhenDBPoolIsUnready(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.server.defaultTenantProvider = tenant.ProviderTiDBCloudNativeShared

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -461,7 +461,15 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 			return nil, nil, false
 		}
 		physical, physicalErr := s.meta.GetSharedDBForTenant(r.Context(), t.ID)
-		if physicalErr != nil || physical == nil {
+		if errors.Is(physicalErr, meta.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "tenant shared DB pool not found")
+			return nil, nil, false
+		}
+		if physicalErr != nil {
+			errJSON(w, backendErrorStatus(r.Context(), physicalErr), "tenant shared DB pool lookup failed")
+			return nil, nil, false
+		}
+		if physical == nil {
 			errJSON(w, http.StatusNotFound, "tenant shared DB pool not found")
 			return nil, nil, false
 		}

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
-	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
@@ -139,10 +138,10 @@ func (s *Server) adminTenantAPIEnabled() bool {
 		return false
 	}
 	provider, err := tenant.NormalizeProvider(s.provisioner.ProviderType())
-	if err != nil || provider != tenant.ProviderTiDBCloudNative {
+	if err != nil || (provider != tenant.ProviderTiDBCloudNative && provider != tenant.ProviderTiDBCloudNativeShared) {
 		return false
 	}
-	_, ok := s.provisioner.(tenant.ManagedClusterLister)
+	_, ok := s.provisioner.(tenant.TiDBCloudAPIKeyIdentityResolver)
 	return ok
 }
 
@@ -180,7 +179,6 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 	} else if claimed {
 		logger.Info(r.Context(), "server_event", eventFields(r.Context(), "admin_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
 		setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, res.OrganizationID, classifyTenantRequest(r))
-		s.forgetTiDBCloudRBACList(cred)
 		if res.Status == meta.TenantProvisioning {
 			s.startProvisionedTenantSchemaInit(r.Context(), res)
 		}
@@ -199,20 +197,6 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 	}
 	provider := ""
 	if sharedPoolMatched {
-		orgID, resolveErr := s.firstManagedOrganization(r.Context(), cred)
-		if resolveErr != nil {
-			writeAdminTiDBCloudError(w, r.Context(), resolveErr, "resolve shared tenant pool")
-			return
-		}
-		sharedDB, findErr := s.meta.FindSharedDBForOrg(r.Context(), orgID)
-		if findErr != nil {
-			errJSON(w, http.StatusInternalServerError, "shared tenant pool lookup failed")
-			return
-		}
-		if strings.TrimSpace(sharedDB.ClusterID) == "" {
-			errJSON(w, http.StatusConflict, "shared tenant pool has no TiDB Cloud cluster identity")
-			return
-		}
 		provider = tenant.ProviderTiDBCloudNativeShared
 	}
 	logProvider := tenant.ProviderTiDBCloudNative
@@ -237,7 +221,6 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		return
 	}
 	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, res.OrganizationID, classifyTenantRequest(r))
-	s.forgetTiDBCloudRBACList(cred)
 	s.startProvisionedTenantSchemaInit(r.Context(), res)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusAccepted)
@@ -256,19 +239,9 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	clusters, err := s.listAllManagedClusters(r.Context(), cred, "", "admin_tenant_list")
+	identity, err := s.resolveTiDBCloudIdentity(r.Context(), cred, "admin_tenant_list")
 	if err != nil {
 		writeAdminTiDBCloudError(w, r.Context(), err, "list tenants")
-		return
-	}
-	authorizedBindings := authorizedTiDBCloudOrgClusterBindings(clusters)
-	if len(authorizedBindings) == 0 {
-		pageSize, page, _, err := adminPagination(r)
-		if err != nil {
-			errJSON(w, http.StatusBadRequest, err.Error())
-			return
-		}
-		writeJSON(w, http.StatusOK, adminTenantListResponse{Tenants: []adminTenantResponse{}, Page: page, PageSize: pageSize})
 		return
 	}
 	pageSize, page, offset, err := adminPagination(r)
@@ -277,7 +250,7 @@ func (s *Server) handleAdminTenantList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	includeQuota := parseBoolQuery(r, "include_quota")
-	rows, err := s.meta.ListTenantsByTiDBCloudResources(r.Context(), authorizedBindings, offset, pageSize+1)
+	rows, err := s.meta.ListTenantsByTiDBCloudOrganization(r.Context(), identity.OrganizationID, offset, pageSize+1)
 	if err != nil {
 		errJSON(w, backendErrorStatus(r.Context(), err), "tenant list failed")
 		return
@@ -388,7 +361,6 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 		s.handleSharedTenantDeleteWithStatusWriter(w, r, t, func(w http.ResponseWriter, status meta.TenantStatus) {
 			writeJSON(w, http.StatusAccepted, adminTenantDeleteResponse{TenantID: t.ID, Status: string(status)})
 		})
-		s.forgetTiDBCloudRBACList(cred)
 		return
 	}
 	if t.StorageNamespaceID != "" {
@@ -456,11 +428,15 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
-	s.forgetTiDBCloudRBACList(cred)
 	writeJSON(w, http.StatusAccepted, adminTenantDeleteResponse{TenantID: t.ID, Status: string(status)})
 }
 
 func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, tenantID string, cred tenant.CredentialProvisionRequest, loadQuota bool, allowDeletingMissingCluster bool) (*meta.Tenant, *meta.TenantTiDBCloudOrgBinding, bool) {
+	identity, err := s.resolveTiDBCloudIdentity(r.Context(), cred, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
+	if err != nil {
+		writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
+		return nil, nil, false
+	}
 	t, err := s.meta.GetTenant(r.Context(), tenantID)
 	if err != nil {
 		if errors.Is(err, meta.ErrNotFound) {
@@ -484,9 +460,13 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 			errJSON(w, http.StatusInternalServerError, "tenant pool membership lookup failed")
 			return nil, nil, false
 		}
-		physical, err := s.authorizeSharedQuotaCredentials(r.Context(), t, cred, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
-		if err != nil {
-			writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
+		physical, physicalErr := s.meta.GetSharedDBForTenant(r.Context(), t.ID)
+		if physicalErr != nil || physical == nil {
+			errJSON(w, http.StatusNotFound, "tenant shared DB pool not found")
+			return nil, nil, false
+		}
+		if !tiDBCloudOrganizationMatches(identity.OrganizationID, physical.TiDBCloudOrganizationID) {
+			errJSON(w, http.StatusForbidden, "TiDB Cloud API key organization does not match tenant")
 			return nil, nil, false
 		}
 		setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, physical.TiDBCloudOrganizationID, classifyTenantRequest(r))
@@ -509,37 +489,8 @@ func (s *Server) authorizedAdminTenant(w http.ResponseWriter, r *http.Request, t
 		errJSON(w, http.StatusNotFound, "tenant not found")
 		return nil, nil, false
 	}
-	clusters, err := s.listAllManagedClusters(r.Context(), cred, binding.ClusterID, adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
-	if err != nil {
-		writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
-		return nil, nil, false
-	}
-	if len(clusters) == 0 && allowDeletingMissingCluster && t.Status == meta.TenantDeleting {
-		clusters, err = s.listAllManagedClusters(r.Context(), cred, "", adminTenantMetricPath(loadQuota, allowDeletingMissingCluster))
-		if err != nil {
-			writeAdminTiDBCloudError(w, r.Context(), err, "authorize tenant")
-			return nil, nil, false
-		}
-		for _, cluster := range clusters {
-			if cluster.OrganizationID == binding.OrganizationID {
-				setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, binding.OrganizationID, classifyTenantRequest(r))
-				return t, binding, true
-			}
-		}
-	}
-	if len(clusters) == 0 {
-		errJSON(w, http.StatusForbidden, "no permission to access tenant with TiDB Cloud API key")
-		return nil, nil, false
-	}
-	authorized := false
-	for _, cluster := range clusters {
-		if cluster.ClusterID == binding.ClusterID && cluster.OrganizationID == binding.OrganizationID {
-			authorized = true
-			break
-		}
-	}
-	if !authorized {
-		errJSON(w, http.StatusForbidden, "no permission to access tenant with TiDB Cloud API key")
+	if !tiDBCloudOrganizationMatches(identity.OrganizationID, binding.OrganizationID) {
+		errJSON(w, http.StatusForbidden, "TiDB Cloud API key organization does not match tenant")
 		return nil, nil, false
 	}
 	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, binding.OrganizationID, classifyTenantRequest(r))
@@ -554,62 +505,6 @@ func adminTenantMetricPath(loadQuota bool, allowDeletingMissingCluster bool) str
 		return "admin_tenant_delete"
 	default:
 		return "admin_tenant_quota_set"
-	}
-}
-
-func (s *Server) listAllManagedClusters(ctx context.Context, cred tenant.CredentialProvisionRequest, clusterID, metricPath string) ([]tenant.CloudClusterInfo, error) {
-	clusterID = strings.TrimSpace(clusterID)
-	scope := "list"
-	if clusterID != "" {
-		scope = "cluster"
-	}
-	if clusterID != "" {
-		if cluster, ok := s.tidbCloudRBACCache.getCluster(cred, clusterID); ok {
-			if cluster.OrganizationID != "" {
-				metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "hit")
-				return []tenant.CloudClusterInfo{cluster}, nil
-			}
-		}
-	} else if clusters, ok := s.tidbCloudRBACCache.getClusterList(cred); ok {
-		metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "hit")
-		return clusters, nil
-	}
-	metrics.RecordTiDBCloudRBACCacheRequest(metricPath, scope, "miss")
-	lister, ok := s.provisioner.(tenant.ManagedClusterLister)
-	if !ok {
-		return nil, fmt.Errorf("managed cluster list not enabled")
-	}
-	var out []tenant.CloudClusterInfo
-	pageToken := ""
-	for {
-		page, err := lister.ListManagedClusters(ctx, cred, tenant.ManagedClusterListOptions{
-			PageSize:  100,
-			PageToken: pageToken,
-			ClusterID: clusterID,
-		})
-		if err != nil {
-			metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "list_managed_clusters", "error")
-			return nil, err
-		}
-		metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "list_managed_clusters", "ok")
-		if page == nil {
-			if clusterID == "" {
-				s.tidbCloudRBACCache.rememberClusterList(cred, out)
-			}
-			return out, nil
-		}
-		out = append(out, page.Clusters...)
-		pageToken = strings.TrimSpace(page.NextPageToken)
-		if pageToken == "" || clusterID != "" {
-			if clusterID == "" {
-				s.tidbCloudRBACCache.rememberClusterList(cred, out)
-			} else {
-				for _, cluster := range out {
-					s.rememberTiDBCloudRBAC(cred, cluster)
-				}
-			}
-			return out, nil
-		}
 	}
 }
 
@@ -668,25 +563,6 @@ func (s *Server) writeAdminQuotaResponse(w http.ResponseWriter, r *http.Request,
 		Config:   quota.Config,
 		Usage:    quota.Usage,
 	})
-}
-
-func authorizedTiDBCloudOrgClusterBindings(clusters []tenant.CloudClusterInfo) []meta.TenantTiDBCloudOrgBinding {
-	out := make([]meta.TenantTiDBCloudOrgBinding, 0, len(clusters))
-	seen := make(map[string]bool, len(clusters))
-	for _, cluster := range clusters {
-		orgID := strings.TrimSpace(cluster.OrganizationID)
-		clusterID := strings.TrimSpace(cluster.ClusterID)
-		if orgID == "" || clusterID == "" {
-			continue
-		}
-		key := orgID + "\x00" + clusterID
-		if seen[key] {
-			continue
-		}
-		seen[key] = true
-		out = append(out, meta.TenantTiDBCloudOrgBinding{OrganizationID: orgID, ClusterID: clusterID})
-	}
-	return out
 }
 
 func adminCredentialsFromHeaders(r *http.Request) (tenant.CredentialProvisionRequest, error) {

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -558,7 +558,7 @@ func TestSharedTenantStatusLogsAndMetricsUseDBOrganization(t *testing.T) {
 	}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-status-output", Host: "shared-status.example.com", Port: 4000,
-		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_status_db",
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_status_db", MaxTenants: 100,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -251,10 +251,8 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 		t.Fatalf("shared physical credential = %+v, want configured shared credential", got)
 	}
 	iamCredentials := prov.iamCredentialsSnapshot()
-	if len(iamCredentials) != 2 ||
-		iamCredentials[0].PublicKey != "public" || iamCredentials[0].PrivateKey != "private" ||
-		iamCredentials[1].PublicKey != "shared-public" || iamCredentials[1].PrivateKey != "shared-private" {
-		t.Fatalf("IAM credentials = %+v, want customer authorization followed by shared physical authorization", iamCredentials)
+	if len(iamCredentials) != 1 || iamCredentials[0].PublicKey != "public" || iamCredentials[0].PrivateKey != "private" {
+		t.Fatalf("IAM credentials = %+v, want customer authorization only", iamCredentials)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -180,8 +180,9 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 		provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
 		defaultPublicKey: "public", defaultPrivateKey: "private",
 		defaultSharedPublicKey: "shared-public", defaultSharedPrivateKey: "shared-private",
+		identityOrg: "customer-org",
 		sharedPoolResults: []*tenant.SharedDBPoolInfo{{
-			ClusterID: "cluster-shared", OrganizationID: "org-shared", Password: "root-pass", DBName: "tidbcloud_fs",
+			ClusterID: "cluster-shared", OrganizationID: "physical-org", Password: "root-pass", DBName: "tidbcloud_fs",
 		}},
 	}
 	tokenSecret := make([]byte, 32)
@@ -204,8 +205,8 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	if res.Provider != tenant.ProviderTiDBCloudNativeShared || res.Status != meta.TenantProvisioning {
 		t.Fatalf("result = provider %q status %q, want shared/provisioning", res.Provider, res.Status)
 	}
-	if res.OrganizationID != "org-shared" {
-		t.Fatalf("organization ID = %q, want org-shared", res.OrganizationID)
+	if res.OrganizationID != "customer-org" {
+		t.Fatalf("organization ID = %q, want customer-org", res.OrganizationID)
 	}
 	tenantRow, err := metaStore.GetTenant(context.Background(), res.TenantID)
 	if err != nil {
@@ -228,6 +229,9 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	}
 	if dbPool.MaxTenants != 100 || dbPool.TenantCount != 1 || dbPool.SpendingLimit == nil || *dbPool.SpendingLimit != meta.MaxTiDBCloudSpendingLimit {
 		t.Fatalf("managed pool policy = %+v", dbPool)
+	}
+	if dbPool.TiDBCloudOrganizationID != "customer-org" {
+		t.Fatalf("managed pool organization ID = %q, want customer-org", dbPool.TiDBCloudOrganizationID)
 	}
 	quota, err := metaStore.GetQuotaConfig(context.Background(), res.TenantID)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -25,43 +25,51 @@ import (
 )
 
 type fakeProvisioner struct {
-	provider               string
-	cloudProvider          string
-	region                 string
-	cluster                *tenant.ClusterInfo
-	initErr                error
-	provisionErr           error
-	systemUserErr          error
-	systemUsername         string
-	systemPassword         string
-	deprovisionErr         error
-	quotaMarkErr           error
-	quotaUpdateErr         error
-	provisionCalls         atomic.Int32
-	credentialCalls        atomic.Int32
-	credentialQuotaCalls   atomic.Int32
-	systemUserCalls        atomic.Int32
-	deprovisionCalls       atomic.Int32
-	quotaMarkCalls         atomic.Int32
-	quotaUpdateCalls       atomic.Int32
-	sharedPoolBatchCalls   atomic.Int32
-	sharedPoolBatchMembers atomic.Int32
-	lastCredentialReq      tenant.CredentialProvisionRequest
-	lastDeprovision        *tenant.ClusterInfo
-	lastQuotaCluster       *tenant.ClusterInfo
-	lastQuotaOptions       tenant.QuotaUpdateOptions
-	lastCreateQuotaOptions tenant.QuotaUpdateOptions
-	defaultPublicKey       string
-	defaultPrivateKey      string
-	managedClusters        []tenant.CloudClusterInfo
-	sharedPoolResults      []*tenant.SharedDBPoolInfo
-	sharedPoolBatchErr     error
-	sharedPoolBatchStarted chan struct{}
-	sharedPoolBatchRelease <-chan struct{}
-	sharedPoolWaitCalls    atomic.Int32
-	sharedPoolWaitErr      error
-	sharedPoolLoadIDs      chan int64
-	sharedPoolWaitRelease  <-chan struct{}
+	provider                string
+	cloudProvider           string
+	region                  string
+	cluster                 *tenant.ClusterInfo
+	initErr                 error
+	provisionErr            error
+	systemUserErr           error
+	systemUsername          string
+	systemPassword          string
+	deprovisionErr          error
+	quotaMarkErr            error
+	quotaUpdateErr          error
+	provisionCalls          atomic.Int32
+	credentialCalls         atomic.Int32
+	credentialQuotaCalls    atomic.Int32
+	systemUserCalls         atomic.Int32
+	deprovisionCalls        atomic.Int32
+	quotaMarkCalls          atomic.Int32
+	quotaUpdateCalls        atomic.Int32
+	sharedPoolBatchCalls    atomic.Int32
+	sharedPoolBatchMembers  atomic.Int32
+	lastCredentialReq       tenant.CredentialProvisionRequest
+	lastDeprovision         *tenant.ClusterInfo
+	lastQuotaCluster        *tenant.ClusterInfo
+	lastQuotaOptions        tenant.QuotaUpdateOptions
+	lastCreateQuotaOptions  tenant.QuotaUpdateOptions
+	defaultPublicKey        string
+	defaultPrivateKey       string
+	defaultSharedPublicKey  string
+	defaultSharedPrivateKey string
+	lastSharedCredentialReq tenant.CredentialProvisionRequest
+	iamCalls                atomic.Int32
+	iamMu                   sync.Mutex
+	iamCredentials          []tenant.CredentialProvisionRequest
+	identityOrg             string
+	identityRole            string
+	managedClusters         []tenant.CloudClusterInfo
+	sharedPoolResults       []*tenant.SharedDBPoolInfo
+	sharedPoolBatchErr      error
+	sharedPoolBatchStarted  chan struct{}
+	sharedPoolBatchRelease  <-chan struct{}
+	sharedPoolWaitCalls     atomic.Int32
+	sharedPoolWaitErr       error
+	sharedPoolLoadIDs       chan int64
+	sharedPoolWaitRelease   <-chan struct{}
 }
 
 type failingEncryptor struct {
@@ -90,6 +98,47 @@ func (f *fakeProvisioner) DefaultCredentials() (tenant.CredentialProvisionReques
 		PublicKey:  f.defaultPublicKey,
 		PrivateKey: f.defaultPrivateKey,
 	}, true
+}
+
+func (f *fakeProvisioner) DefaultSharedCredentials() (tenant.CredentialProvisionRequest, bool) {
+	if f.defaultSharedPublicKey == "" && f.defaultSharedPrivateKey == "" {
+		return tenant.CredentialProvisionRequest{PublicKey: "shared-public", PrivateKey: "shared-private"}, true
+	}
+	if f.defaultSharedPublicKey == "" || f.defaultSharedPrivateKey == "" {
+		return tenant.CredentialProvisionRequest{}, false
+	}
+	return tenant.CredentialProvisionRequest{PublicKey: f.defaultSharedPublicKey, PrivateKey: f.defaultSharedPrivateKey}, true
+}
+
+func (f *fakeProvisioner) ResolveAPIKeyIdentity(_ context.Context, req tenant.CredentialProvisionRequest) (*tenant.TiDBCloudAPIKeyIdentity, error) {
+	f.iamCalls.Add(1)
+	f.iamMu.Lock()
+	f.iamCredentials = append(f.iamCredentials, req)
+	f.iamMu.Unlock()
+	orgID := f.identityOrg
+	if orgID == "" && f.cluster != nil {
+		orgID = f.cluster.OrganizationID
+	}
+	if orgID == "" && len(f.managedClusters) > 0 {
+		orgID = f.managedClusters[0].OrganizationID
+	}
+	if orgID == "" && len(f.sharedPoolResults) > 0 {
+		orgID = f.sharedPoolResults[0].OrganizationID
+	}
+	if orgID == "" {
+		orgID = "org-shared"
+	}
+	role := f.identityRole
+	if role == "" {
+		role = tenant.TiDBCloudRoleOrgOwner
+	}
+	return &tenant.TiDBCloudAPIKeyIdentity{OrganizationID: orgID, Role: role}, nil
+}
+
+func (f *fakeProvisioner) iamCredentialsSnapshot() []tenant.CredentialProvisionRequest {
+	f.iamMu.Lock()
+	defer f.iamMu.Unlock()
+	return append([]tenant.CredentialProvisionRequest(nil), f.iamCredentials...)
 }
 
 func (f *fakeProvisioner) ProviderType() string { return f.provider }
@@ -130,6 +179,7 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	prov := &fakeProvisioner{
 		provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
 		defaultPublicKey: "public", defaultPrivateKey: "private",
+		defaultSharedPublicKey: "shared-public", defaultSharedPrivateKey: "shared-private",
 		sharedPoolResults: []*tenant.SharedDBPoolInfo{{
 			ClusterID: "cluster-shared", OrganizationID: "org-shared", Password: "root-pass", DBName: "tidbcloud_fs",
 		}},
@@ -192,6 +242,15 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	}
 	if prov.sharedPoolBatchCalls.Load() != 1 {
 		t.Fatalf("shared pool batch calls = %d, want 1", prov.sharedPoolBatchCalls.Load())
+	}
+	if got := prov.lastSharedCredentialReq; got.PublicKey != "shared-public" || got.PrivateKey != "shared-private" {
+		t.Fatalf("shared physical credential = %+v, want configured shared credential", got)
+	}
+	iamCredentials := prov.iamCredentialsSnapshot()
+	if len(iamCredentials) != 2 ||
+		iamCredentials[0].PublicKey != "public" || iamCredentials[0].PrivateKey != "private" ||
+		iamCredentials[1].PublicKey != "shared-public" || iamCredentials[1].PrivateKey != "shared-private" {
+		t.Fatalf("IAM credentials = %+v, want customer authorization followed by shared physical authorization", iamCredentials)
 	}
 }
 
@@ -437,7 +496,7 @@ func TestProvisionTiDBCloudNativeSharedResumesExistingProvisioningPool(t *testin
 	spendingTarget := meta.MaxTiDBCloudSpendingLimit
 	provisioningKey := sharedDBProvisioningKey(tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
 	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
-		ProvisioningKey: provisioningKey, CloudProvider: "aws", Region: "us-east-1",
+		TiDBCloudOrganizationID: "org-shared", ProvisioningKey: provisioningKey, CloudProvider: "aws", Region: "us-east-1",
 		MaxTenants: 100, SpendingLimit: &spendingTarget,
 	})
 	if err != nil {
@@ -628,8 +687,7 @@ func TestManagedSharedDBContinuationWaitsForConnectionMetadata(t *testing.T) {
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov,
 		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
 	defer srv.Close()
-	err = srv.continueManagedSharedDBPool(context.Background(), dbID,
-		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	err = srv.continueManagedSharedDBPool(context.Background(), dbID)
 	if !errors.Is(err, waitErr) {
 		t.Fatalf("continueManagedSharedDBPool error = %v, want %v", err, waitErr)
 	}
@@ -772,9 +830,7 @@ func TestManagedSharedDBContinuationBatchesDoNotEnterBlockingMetadataWait(t *tes
 		cancel()
 		srv.forkWorkerWG.Wait()
 	})
-	srv.scheduleManagedSharedDBContinuations(context.Background(), []int64{firstID, secondID}, tenant.CredentialProvisionRequest{
-		PublicKey: "public", PrivateKey: "private",
-	})
+	srv.scheduleManagedSharedDBContinuations(context.Background(), []int64{firstID, secondID})
 
 	select {
 	case got := <-loadIDs:
@@ -838,6 +894,62 @@ func TestManagedSharedDBContinuationBatchesDoNotEnterBlockingMetadataWait(t *tes
 	<-resumeDone
 }
 
+func TestManagedSharedDBContinuationKeepsRootAndSkipsSystemUser(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-root", ProvisioningKey: bytes.Repeat([]byte{9}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+		PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.UpdateManagedSharedDBPoolCloudResult(context.Background(), &meta.SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-root", ClusterID: "cluster-root",
+		Host: "127.0.0.1", Port: 1, User: "prefix.root", PasswordCipher: passwordCipher,
+		Name: "tidbcloud_fs", TLSMode: "true",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	row, err := metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	systemUserErr := errors.New("system user creation must not run for shared DB")
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, systemUserErr: systemUserErr}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov, tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour)}
+	err = srv.continueManagedSharedDBPoolLocked(context.Background(), row, tenant.CredentialProvisionRequest{
+		PublicKey: "shared-public", PrivateKey: "shared-private",
+	})
+	if errors.Is(err, systemUserErr) {
+		t.Fatalf("shared continuation attempted system-user creation: %v", err)
+	}
+	if got := prov.systemUserCalls.Load(); got != 0 {
+		t.Fatalf("shared system-user calls = %d, want 0", got)
+	}
+}
+
 func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -876,16 +988,15 @@ func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov,
 		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
 	defer srv.Close()
-	cred := tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}
 	batchDone := make(chan error, 1)
 	go func() {
-		_, err := srv.provisionManagedSharedDBPoolsBatch(context.Background(), []int64{dbID}, cred)
+		_, err := srv.provisionManagedSharedDBPoolsBatch(context.Background(), []int64{dbID})
 		batchDone <- err
 	}()
 	<-started
 	ensureDone := make(chan error, 1)
 	go func() {
-		_, err := srv.ensureManagedSharedDBPhysical(context.Background(), dbID, cred)
+		_, err := srv.ensureManagedSharedDBPhysical(context.Background(), dbID)
 		ensureDone <- err
 	}()
 	secondCreateStarted := false
@@ -939,13 +1050,14 @@ func TestManagedSharedDBBatchCreateReturnsTotalFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	wantErr := errors.New("cloud batch rejected")
-	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, sharedPoolBatchErr: wantErr}
+	prov := &fakeProvisioner{
+		provider: tenant.ProviderTiDBCloudNative, identityOrg: "org-batch-failure", sharedPoolBatchErr: wantErr,
+	}
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov,
 		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
 	defer srv.Close()
 
-	_, err = srv.provisionManagedSharedDBPoolsBatch(context.Background(), []int64{dbID},
-		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	_, err = srv.provisionManagedSharedDBPoolsBatch(context.Background(), []int64{dbID})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("batch error = %v, want %v", err, wantErr)
 	}
@@ -970,9 +1082,10 @@ func (f *fakeProvisioner) ListManagedClusters(_ context.Context, _ tenant.Creden
 	return &tenant.ManagedClusterListResult{Clusters: append([]tenant.CloudClusterInfo(nil), f.managedClusters...)}, nil
 }
 
-func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, requests []tenant.SharedDBPoolCreateRequest, _ tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, requests []tenant.SharedDBPoolCreateRequest, cred tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
 	f.sharedPoolBatchCalls.Add(1)
 	f.sharedPoolBatchMembers.Add(int32(len(requests)))
+	f.lastSharedCredentialReq = cred
 	if f.sharedPoolBatchStarted != nil {
 		select {
 		case f.sharedPoolBatchStarted <- struct{}{}:
@@ -1216,6 +1329,12 @@ func TestClientFacingErrorResponseMapsTiDBCloudClientErrors(t *testing.T) {
 			wantBody:   "access denied",
 		},
 		{
+			name:       "insufficient IAM role hides resolver detail",
+			err:        fmt.Errorf("%w: org:viewer SENSITIVE_RESOLVER_DETAIL", tenant.ErrTiDBCloudRoleInsufficient),
+			wantStatus: http.StatusForbidden,
+			wantBody:   tenant.ErrTiDBCloudRoleInsufficient.Error(),
+		},
+		{
 			name:       "generic error hides detail",
 			err:        errors.New("internal upstream detail"),
 			wantStatus: http.StatusBadGateway,
@@ -1235,6 +1354,9 @@ func TestClientFacingErrorResponseMapsTiDBCloudClientErrors(t *testing.T) {
 			}
 			if strings.Contains(gotMsg, "internal upstream detail") {
 				t.Fatalf("msg = %q, should not expose generic upstream details", gotMsg)
+			}
+			if strings.Contains(gotMsg, "SENSITIVE_RESOLVER_DETAIL") {
+				t.Fatalf("msg = %q, should not expose IAM resolver details", gotMsg)
 			}
 		})
 	}
@@ -1297,6 +1419,13 @@ type credentialOnlyProvisioner struct {
 }
 
 func (f *credentialOnlyProvisioner) ProviderType() string { return f.provider }
+
+func (f *credentialOnlyProvisioner) ResolveAPIKeyIdentity(context.Context, tenant.CredentialProvisionRequest) (*tenant.TiDBCloudAPIKeyIdentity, error) {
+	return &tenant.TiDBCloudAPIKeyIdentity{
+		OrganizationID: f.cluster.OrganizationID,
+		Role:           tenant.TiDBCloudRoleOrgOwner,
+	}, nil
+}
 
 func (f *credentialOnlyProvisioner) InitSchema(_ context.Context, _ string) error { return nil }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -60,6 +60,7 @@ type fakeProvisioner struct {
 	iamMu                   sync.Mutex
 	iamCredentials          []tenant.CredentialProvisionRequest
 	identityOrg             string
+	identityOrgs            map[string]string
 	identityRole            string
 	managedClusters         []tenant.CloudClusterInfo
 	sharedPoolResults       []*tenant.SharedDBPoolInfo
@@ -116,6 +117,11 @@ func (f *fakeProvisioner) ResolveAPIKeyIdentity(_ context.Context, req tenant.Cr
 	f.iamCredentials = append(f.iamCredentials, req)
 	f.iamMu.Unlock()
 	orgID := f.identityOrg
+	if f.identityOrgs != nil {
+		if mapped, ok := f.identityOrgs[req.PublicKey]; ok {
+			orgID = mapped
+		}
+	}
 	if orgID == "" && f.cluster != nil {
 		orgID = f.cluster.OrganizationID
 	}
@@ -251,6 +257,78 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 		iamCredentials[0].PublicKey != "public" || iamCredentials[0].PrivateKey != "private" ||
 		iamCredentials[1].PublicKey != "shared-public" || iamCredentials[1].PrivateKey != "shared-private" {
 		t.Fatalf("IAM credentials = %+v, want customer authorization followed by shared physical authorization", iamCredentials)
+	}
+}
+
+func TestProvisionTiDBCloudNativeSharedRejectsDifferentCustomerAndSharedOrganizations(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{
+		provider:                tenant.ProviderTiDBCloudNative,
+		defaultPublicKey:        "customer-public",
+		defaultPrivateKey:       "customer-private",
+		defaultSharedPublicKey:  "shared-public",
+		defaultSharedPrivateKey: "shared-private",
+		identityOrgs: map[string]string{
+			"customer-public": "org-customer",
+			"shared-public":   "org-shared",
+		},
+	}
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		t.Fatal(err)
+	}
+	srv := NewWithConfig(Config{
+		Meta: metaStore, Pool: pool, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: secret,
+	})
+	defer srv.Close()
+
+	_, err = srv.provisionTenant(context.Background(), provisionTenantOptions{
+		CredentialProvisioner: &tenant.CredentialProvisionRequest{PublicKey: "customer-public", PrivateKey: "customer-private"},
+	})
+	if err == nil {
+		t.Fatal("provisionTenant succeeded, want organization mismatch rejection")
+	}
+	var provisionErr *provisionTenantError
+	if !errors.As(err, &provisionErr) {
+		t.Fatalf("error = %T %v, want provisionTenantError", err, err)
+	}
+	if provisionErr.status != http.StatusForbidden || provisionErr.message != sharedDBCredentialOrganizationMismatchMessage {
+		t.Errorf("provision error = status %d message %q, want 403 and stable mismatch message", provisionErr.status, provisionErr.message)
+	}
+	if strings.Contains(err.Error(), "org-customer") || strings.Contains(err.Error(), "org-shared") {
+		t.Errorf("organization IDs leaked in error: %v", err)
+	}
+	var tenants int
+	if err := metaStore.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM tenants").Scan(&tenants); err != nil {
+		t.Fatalf("count tenants: %v", err)
+	}
+	if tenants != 0 {
+		t.Errorf("tenant rows = %d, want 0 after fail-fast rejection", tenants)
+	}
+	var pools int
+	if err := metaStore.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM db_pool").Scan(&pools); err != nil {
+		t.Fatalf("count db_pool rows: %v", err)
+	}
+	if pools != 0 {
+		t.Errorf("db_pool rows = %d, want 0 after fail-fast rejection", pools)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -191,7 +191,9 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	}
 	srv := NewWithConfig(Config{
 		Meta: metaStore, Pool: pool, Provisioner: prov,
-		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: tokenSecret,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared,
+		SharedDBSpendingLimit: 2_000_000,
+		TokenSecret:           tokenSecret,
 	})
 	defer srv.Close()
 	virtualLimit := int64(2000)
@@ -227,7 +229,7 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	if err != nil {
 		t.Fatalf("GetSharedDB: %v", err)
 	}
-	if dbPool.MaxTenants != 100 || dbPool.TenantCount != 1 || dbPool.SpendingLimit == nil || *dbPool.SpendingLimit != meta.MaxTiDBCloudSpendingLimit {
+	if dbPool.MaxTenants != 100 || dbPool.TenantCount != 1 || dbPool.SpendingLimit == nil || *dbPool.SpendingLimit != 2_000_000 {
 		t.Fatalf("managed pool policy = %+v", dbPool)
 	}
 	if dbPool.TiDBCloudOrganizationID != "customer-org" {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -1083,9 +1083,9 @@ func (f *fakeProvisioner) ListManagedClusters(_ context.Context, _ tenant.Creden
 }
 
 func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, requests []tenant.SharedDBPoolCreateRequest, cred tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+	f.lastSharedCredentialReq = cred
 	f.sharedPoolBatchCalls.Add(1)
 	f.sharedPoolBatchMembers.Add(int32(len(requests)))
-	f.lastSharedCredentialReq = cred
 	if f.sharedPoolBatchStarted != nil {
 		select {
 		case f.sharedPoolBatchStarted <- struct{}{}:

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -60,7 +60,6 @@ type fakeProvisioner struct {
 	iamMu                   sync.Mutex
 	iamCredentials          []tenant.CredentialProvisionRequest
 	identityOrg             string
-	identityOrgs            map[string]string
 	identityRole            string
 	managedClusters         []tenant.CloudClusterInfo
 	sharedPoolResults       []*tenant.SharedDBPoolInfo
@@ -117,11 +116,6 @@ func (f *fakeProvisioner) ResolveAPIKeyIdentity(_ context.Context, req tenant.Cr
 	f.iamCredentials = append(f.iamCredentials, req)
 	f.iamMu.Unlock()
 	orgID := f.identityOrg
-	if f.identityOrgs != nil {
-		if mapped, ok := f.identityOrgs[req.PublicKey]; ok {
-			orgID = mapped
-		}
-	}
 	if orgID == "" && f.cluster != nil {
 		orgID = f.cluster.OrganizationID
 	}
@@ -257,78 +251,6 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 		iamCredentials[0].PublicKey != "public" || iamCredentials[0].PrivateKey != "private" ||
 		iamCredentials[1].PublicKey != "shared-public" || iamCredentials[1].PrivateKey != "shared-private" {
 		t.Fatalf("IAM credentials = %+v, want customer authorization followed by shared physical authorization", iamCredentials)
-	}
-}
-
-func TestProvisionTiDBCloudNativeSharedRejectsDifferentCustomerAndSharedOrganizations(t *testing.T) {
-	metaStore, err := meta.Open(testDSN)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = metaStore.Close() }()
-	testmysql.ResetMetaDB(t, metaStore.DB())
-
-	master := make([]byte, 32)
-	if _, err := rand.Read(master); err != nil {
-		t.Fatal(err)
-	}
-	enc, err := encrypt.NewLocalAESEncryptor(master)
-	if err != nil {
-		t.Fatal(err)
-	}
-	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
-	defer pool.Close()
-	pool.SetMetaStore(metaStore)
-	prov := &fakeProvisioner{
-		provider:                tenant.ProviderTiDBCloudNative,
-		defaultPublicKey:        "customer-public",
-		defaultPrivateKey:       "customer-private",
-		defaultSharedPublicKey:  "shared-public",
-		defaultSharedPrivateKey: "shared-private",
-		identityOrgs: map[string]string{
-			"customer-public": "org-customer",
-			"shared-public":   "org-shared",
-		},
-	}
-	secret := make([]byte, 32)
-	if _, err := rand.Read(secret); err != nil {
-		t.Fatal(err)
-	}
-	srv := NewWithConfig(Config{
-		Meta: metaStore, Pool: pool, Provisioner: prov,
-		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: secret,
-	})
-	defer srv.Close()
-
-	_, err = srv.provisionTenant(context.Background(), provisionTenantOptions{
-		CredentialProvisioner: &tenant.CredentialProvisionRequest{PublicKey: "customer-public", PrivateKey: "customer-private"},
-	})
-	if err == nil {
-		t.Fatal("provisionTenant succeeded, want organization mismatch rejection")
-	}
-	var provisionErr *provisionTenantError
-	if !errors.As(err, &provisionErr) {
-		t.Fatalf("error = %T %v, want provisionTenantError", err, err)
-	}
-	if provisionErr.status != http.StatusForbidden || provisionErr.message != sharedDBCredentialOrganizationMismatchMessage {
-		t.Errorf("provision error = status %d message %q, want 403 and stable mismatch message", provisionErr.status, provisionErr.message)
-	}
-	if strings.Contains(err.Error(), "org-customer") || strings.Contains(err.Error(), "org-shared") {
-		t.Errorf("organization IDs leaked in error: %v", err)
-	}
-	var tenants int
-	if err := metaStore.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM tenants").Scan(&tenants); err != nil {
-		t.Fatalf("count tenants: %v", err)
-	}
-	if tenants != 0 {
-		t.Errorf("tenant rows = %d, want 0 after fail-fast rejection", tenants)
-	}
-	var pools int
-	if err := metaStore.DB().QueryRowContext(context.Background(), "SELECT COUNT(*) FROM db_pool").Scan(&pools); err != nil {
-		t.Fatalf("count db_pool rows: %v", err)
-	}
-	if pools != 0 {
-		t.Errorf("db_pool rows = %d, want 0 after fail-fast rejection", pools)
 	}
 }
 

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -28,9 +28,12 @@ type quotaRequest struct {
 }
 
 type quotaFields struct {
-	MaxStorageSize         *int64 `json:"max_storage_size,omitempty"`
-	MaxFileSize            *int64 `json:"max_file_size,omitempty"`
-	MaxFileCount           *int64 `json:"max_file_count,omitempty"`
+	MaxStorageSize *int64 `json:"max_storage_size,omitempty"`
+	MaxFileSize    *int64 `json:"max_file_size,omitempty"`
+	MaxFileCount   *int64 `json:"max_file_count,omitempty"`
+	// TiDBCloudSpendingLimit is physical for native tenants. For shared tenants,
+	// it is virtual compatibility metadata and does not affect allocation,
+	// capacity, or the shared cluster's physical TiDB Cloud spending limit.
 	TiDBCloudSpendingLimit *int64 `json:"tidbcloud_spending_limit,omitempty"`
 }
 
@@ -51,9 +54,11 @@ type quotaResponse struct {
 }
 
 type quotaConfigResponse struct {
-	MaxStorageSize         int64  `json:"max_storage_size"`
-	MaxFileSize            int64  `json:"max_file_size"`
-	MaxFileCount           int64  `json:"max_file_count"`
+	MaxStorageSize int64 `json:"max_storage_size"`
+	MaxFileSize    int64 `json:"max_file_size"`
+	MaxFileCount   int64 `json:"max_file_count"`
+	// TiDBCloudSpendingLimit is returned for API compatibility. For shared
+	// tenants, it is a virtual value and is not physically enforced.
 	TiDBCloudSpendingLimit *int64 `json:"tidbcloud_spending_limit"`
 }
 

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -135,22 +135,12 @@ func (s *Server) handleQuotaGet(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	if !s.tidbCloudRBACAllowed(cred, t.ClusterID, "quota_get") {
-		getter, ok := s.provisioner.(tenant.QuotaGetter)
-		if !ok {
-			errJSON(w, http.StatusNotFound, "quota query not enabled")
-			return
-		}
-		_, err := getter.GetQuota(r.Context(), clusterInfoFromTenant(t), cred)
-		if err != nil {
-			metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "error")
-			writeQuotaCredentialError(w, r.Context(), err, "query")
-			return
-		}
-		metrics.RecordTiDBCloudOpenAPIRequest("quota_get", "get_quota", "ok")
-		s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
+	binding, err := s.authorizeNativeTenantCredentials(r.Context(), t, cred, "quota_get")
+	if err != nil {
+		writeQuotaCredentialError(w, r.Context(), err, "query")
+		return
 	}
-	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, s.tenantMetricTiDBCloudOrgID(r.Context(), t), classifyTenantRequest(r))
+	setRequestMetricTenant(r.Context(), t.ID, "", t.Provider, binding.OrganizationID, classifyTenantRequest(r))
 	s.writeQuotaResponse(w, r, t)
 }
 
@@ -272,9 +262,15 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		sharedPhysical = physical
-	} else if err := s.applyQuotaSet(r.Context(), "quota_set", t, cred, req); err != nil {
-		writeQuotaSetError(w, r.Context(), err, "update")
-		return
+	} else {
+		if _, err := s.authorizeNativeTenantCredentials(r.Context(), t, cred, "quota_set"); err != nil {
+			writeQuotaSetError(w, r.Context(), err, "authorize")
+			return
+		}
+		if err := s.applyQuotaSet(r.Context(), "quota_set", t, cred, req); err != nil {
+			writeQuotaSetError(w, r.Context(), err, "update")
+			return
+		}
 	}
 	metricOrgID := ""
 	if t.Provider == tenant.ProviderTiDBCloudNativeShared {
@@ -290,27 +286,12 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) authorizeSharedQuotaCredentials(ctx context.Context, t *meta.Tenant, cred tenant.CredentialProvisionRequest, metricPath string) (*meta.SharedDB, error) {
 	physical, err := s.meta.GetSharedDBForTenant(ctx, t.ID)
-	if err != nil || strings.TrimSpace(physical.ClusterID) == "" {
+	if err != nil {
 		return nil, tenant.ErrQuotaBackendNotFound
 	}
-	if s.tidbCloudRBACAllowed(cred, physical.ClusterID, metricPath) {
-		return physical, nil
-	}
-	getter, ok := s.provisioner.(tenant.QuotaGetter)
-	if !ok {
-		return nil, errQuotaSettingNotEnabled
-	}
-	if _, err := getter.GetQuota(ctx, &tenant.ClusterInfo{
-		ClusterID:      physical.ClusterID,
-		OrganizationID: physical.TiDBCloudOrganizationID,
-		Provider:       tenant.ProviderTiDBCloudNative,
-	}, cred); err != nil {
+	if _, err := s.authorizeTiDBCloudOrganization(ctx, cred, physical.TiDBCloudOrganizationID, metricPath); err != nil {
 		return nil, err
 	}
-	s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{
-		ClusterID:      physical.ClusterID,
-		OrganizationID: physical.TiDBCloudOrganizationID,
-	})
 	return physical, nil
 }
 
@@ -433,7 +414,6 @@ func (s *Server) applyQuotaSet(ctx context.Context, metricPath string, t *meta.T
 		return err
 	}
 	metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "mark_quota_update_started", "ok")
-	s.rememberTiDBCloudRBAC(cred, tenant.CloudClusterInfo{ClusterID: t.ClusterID})
 	if req.TiDBCloudSpendingLimit != nil {
 		updatedCloudCfg, err := updater.UpdateQuota(ctx, clusterInfoFromTenant(t), cred, tenant.QuotaUpdateOptions{
 			TiDBCloudSpendingLimitMonthly: req.TiDBCloudSpendingLimit,
@@ -645,24 +625,6 @@ func quotaSetErrorStatusMessage(err error, action string) (int, string, bool) {
 	default:
 		return 0, "", false
 	}
-}
-
-func (s *Server) tidbCloudRBACAllowed(cred tenant.CredentialProvisionRequest, clusterID, metricPath string) bool {
-	_, ok := s.tidbCloudRBACCache.getCluster(cred, clusterID)
-	result := "miss"
-	if ok {
-		result = "hit"
-	}
-	metrics.RecordTiDBCloudRBACCacheRequest(metricPath, "cluster", result)
-	return ok
-}
-
-func (s *Server) rememberTiDBCloudRBAC(cred tenant.CredentialProvisionRequest, cluster tenant.CloudClusterInfo) {
-	s.tidbCloudRBACCache.rememberCluster(cred, cluster)
-}
-
-func (s *Server) forgetTiDBCloudRBACList(cred tenant.CredentialProvisionRequest) {
-	s.tidbCloudRBACCache.forgetClusterList(cred)
 }
 
 func tidbCloudSpendingLimitFromCloud(cloudCfg *tenant.QuotaCloudConfig) *int64 {

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -287,7 +287,10 @@ func (s *Server) handleQuotaSet(w http.ResponseWriter, r *http.Request) {
 func (s *Server) authorizeSharedQuotaCredentials(ctx context.Context, t *meta.Tenant, cred tenant.CredentialProvisionRequest, metricPath string) (*meta.SharedDB, error) {
 	physical, err := s.meta.GetSharedDBForTenant(ctx, t.ID)
 	if err != nil {
-		return nil, tenant.ErrQuotaBackendNotFound
+		if errors.Is(err, meta.ErrNotFound) {
+			return nil, tenant.ErrQuotaBackendNotFound
+		}
+		return nil, fmt.Errorf("get shared DB for tenant: %w", err)
 	}
 	if _, err := s.authorizeTiDBCloudOrganization(ctx, cred, physical.TiDBCloudOrganizationID, metricPath); err != nil {
 		return nil, err

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1458,33 +1458,6 @@ func TestAdminTenantListFiltersByIAMOrganization(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	wildcardTenantID := "tenant-shared-wildcard-authorized"
-	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
-		ID: wildcardTenantID, Status: meta.TenantActive, Kind: meta.TenantKindLive,
-		Provider: tenant.ProviderTiDBCloudNativeShared, SchemaVersion: 1, DBPasswordCipher: []byte{},
-		CreatedAt: now.Add(4 * time.Second), UpdatedAt: now.Add(4 * time.Second),
-	}); err != nil {
-		t.Fatal(err)
-	}
-	wildcardFsID, err := rt.meta.ResolveFsID(ctx, wildcardTenantID)
-	if err != nil {
-		t.Fatal(err)
-	}
-	wildcardDBID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
-		TiDBCloudOrganizationID: meta.SharedDBOrgWildcard, Host: "shared-wildcard-list.example.com", Port: 4000,
-		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE db_pool SET cluster_id = ? WHERE db_id = ?", "cluster-allowed", wildcardDBID); err != nil {
-		t.Fatal(err)
-	}
-	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
-		FsID: wildcardFsID, DbID: wildcardDBID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
-	}); err != nil {
-		t.Fatal(err)
-	}
 	freeSharedTenantID := "tenant-shared-free-member"
 	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
 		ID: freeSharedTenantID, Status: meta.TenantActive, Kind: meta.TenantKindLive,

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1445,7 +1445,7 @@ func TestAdminTenantListFiltersByIAMOrganization(t *testing.T) {
 	}
 	sharedDBID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-1", Host: "shared-list.example.com", Port: 4000,
-		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 100,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -39,6 +39,7 @@ type quotaTestProvisioner struct {
 	markCalls                   atomic.Int32
 	getCalls                    atomic.Int32
 	listCalls                   atomic.Int32
+	iamCalls                    atomic.Int32
 	deprovisionCalls            atomic.Int32
 	batchPoolCalls              atomic.Int32
 	markPoolUsedCalls           atomic.Int32
@@ -47,11 +48,14 @@ type quotaTestProvisioner struct {
 	mu                          sync.Mutex
 	lastCluster                 *tenant.ClusterInfo
 	lastCredentials             tenant.CredentialProvisionRequest
+	lastIAMCredentials          tenant.CredentialProvisionRequest
 	lastOptions                 tenant.QuotaUpdateOptions
 	lastListOptions             tenant.ManagedClusterListOptions
 	lastDeprovision             *tenant.ClusterInfo
 	listErr                     error
 	listPages                   []*tenant.ManagedClusterListResult
+	iamIdentities               []*tenant.TiDBCloudAPIKeyIdentity
+	iamErr                      error
 	batchPoolErr                error
 	batchPoolOmitConnectionInfo bool
 	batchPoolEmptyPassword      bool
@@ -109,16 +113,16 @@ func (p *quotaTestProvisioner) lastCredentialsSnapshot() tenant.CredentialProvis
 	return p.lastCredentials
 }
 
+func (p *quotaTestProvisioner) lastIAMCredentialsSnapshot() tenant.CredentialProvisionRequest {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.lastIAMCredentials
+}
+
 func (p *quotaTestProvisioner) lastOptionsSnapshot() tenant.QuotaUpdateOptions {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	return p.lastOptions
-}
-
-func (p *quotaTestProvisioner) lastListOptionsSnapshot() tenant.ManagedClusterListOptions {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	return p.lastListOptions
 }
 
 func (p *quotaTestProvisioner) lastClusterSnapshot() *tenant.ClusterInfo {
@@ -151,6 +155,25 @@ func (p *quotaTestProvisioner) DefaultCredentials() (tenant.CredentialProvisionR
 		PublicKey:  p.defaultPublicKey,
 		PrivateKey: p.defaultPrivateKey,
 	}, true
+}
+
+func (p *quotaTestProvisioner) ResolveAPIKeyIdentity(_ context.Context, req tenant.CredentialProvisionRequest) (*tenant.TiDBCloudAPIKeyIdentity, error) {
+	call := int(p.iamCalls.Add(1)) - 1
+	p.mu.Lock()
+	p.lastIAMCredentials = req
+	p.mu.Unlock()
+	if p.iamErr != nil {
+		return nil, p.iamErr
+	}
+	if call >= 0 && call < len(p.iamIdentities) && p.iamIdentities[call] != nil {
+		out := *p.iamIdentities[call]
+		return &out, nil
+	}
+	return &tenant.TiDBCloudAPIKeyIdentity{OrganizationID: "org-1", Role: tenant.TiDBCloudRoleOrgOwner}, nil
+}
+
+func (p *quotaTestProvisioner) DefaultSharedCredentials() (tenant.CredentialProvisionRequest, bool) {
+	return tenant.CredentialProvisionRequest{PublicKey: "shared-public", PrivateKey: "shared-private"}, true
 }
 
 func (p *quotaTestProvisioner) Provision(context.Context, string) (*tenant.ClusterInfo, error) {
@@ -397,6 +420,14 @@ func newQuotaRuntime(t *testing.T, provider string) *quotaRuntime {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	if provider == tenant.ProviderTiDBCloudNative {
+		if err := db.Meta.UpsertTenantTiDBCloudOrgBinding(context.Background(), &meta.TenantTiDBCloudOrgBinding{
+			TenantID: tenantID, OrganizationID: "org-1", ClusterID: "cluster-quota-1",
+			CreatedAt: now, UpdatedAt: now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
 	if err := db.Meta.InsertAPIKey(context.Background(), &meta.APIKey{
 		ID:            token.NewID(),
 		TenantID:      tenantID,
@@ -484,10 +515,13 @@ func TestQuotaGetAllowsExplicitDefaultTiDBCloudCredentials(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)
 	}
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("get calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
 	}
-	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("quota get calls = %d, want 0", got)
+	}
+	lastCredentials := rt.prov.lastIAMCredentialsSnapshot()
 	if lastCredentials.PublicKey != "default-pk" || lastCredentials.PrivateKey != "default-sk" {
 		t.Fatalf("last credentials = %#v", lastCredentials)
 	}
@@ -562,6 +596,9 @@ func TestQuotaGetReturnsConfigStorageUsageAndSpendingLimit(t *testing.T) {
 
 func TestSharedQuotaGetAndSetUseLocalVirtualValueWithoutCloudMutation(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNativeShared)
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-shared-quota", Role: tenant.TiDBCloudRoleOrgOwner,
+	}}
 	ctx := context.Background()
 	if _, err := rt.meta.DB().ExecContext(ctx, `UPDATE tenants SET cluster_id = '' WHERE id = ?`, rt.tenantID); err != nil {
 		t.Fatalf("clear tenant cluster id: %v", err)
@@ -585,11 +622,6 @@ func TestSharedQuotaGetAndSetUseLocalVirtualValueWithoutCloudMutation(t *testing
 	}
 	if err := rt.meta.IncrSharedDBTenantCount(ctx, dbID, 1); err != nil {
 		t.Fatalf("IncrSharedDBTenantCount: %v", err)
-	}
-	if err := rt.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{
-		ID: dbID, TiDBCloudOrganizationID: "org-shared-quota", ClusterID: "cluster-shared-quota",
-	}); err != nil {
-		t.Fatalf("UpdateManagedSharedDBPoolCloudResult: %v", err)
 	}
 	initialLimit := int64(1000)
 	if err := rt.meta.SetQuotaConfig(ctx, &meta.QuotaConfig{
@@ -633,9 +665,9 @@ func TestSharedQuotaGetAndSetUseLocalVirtualValueWithoutCloudMutation(t *testing
 	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != updatedLimit {
 		t.Fatalf("persisted shared limit = %#v, want %d", cfg.TiDBCloudSpendingLimit, updatedLimit)
 	}
-	if rt.prov.getCalls.Load() != 1 || rt.prov.markCalls.Load() != 0 || rt.prov.updateCalls.Load() != 0 {
-		t.Fatalf("shared quota Cloud calls: get=%d mark=%d update=%d; want one read-only authorization call",
-			rt.prov.getCalls.Load(), rt.prov.markCalls.Load(), rt.prov.updateCalls.Load())
+	if rt.prov.iamCalls.Load() != 1 || rt.prov.getCalls.Load() != 0 || rt.prov.markCalls.Load() != 0 || rt.prov.updateCalls.Load() != 0 {
+		t.Fatalf("shared quota calls: iam=%d get=%d mark=%d update=%d; want IAM authorization only",
+			rt.prov.iamCalls.Load(), rt.prov.getCalls.Load(), rt.prov.markCalls.Load(), rt.prov.updateCalls.Load())
 	}
 }
 
@@ -718,26 +750,23 @@ func TestQuotaGetUsesTiDBCloudAuthorization(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d", resp.StatusCode)
 	}
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("get calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
+	}
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("quota get calls = %d, want 0", got)
 	}
 	if got := rt.prov.updateCalls.Load(); got != 0 {
 		t.Fatalf("update calls = %d, want 0", got)
 	}
-	lastCluster := rt.prov.lastClusterSnapshot()
-	if lastCluster == nil || lastCluster.ClusterID != "cluster-quota-1" || lastCluster.TenantID != rt.tenantID {
-		t.Fatalf("last cluster = %#v", lastCluster)
-	}
-	lastCredentials := rt.prov.lastCredentialsSnapshot()
+	lastCredentials := rt.prov.lastIAMCredentialsSnapshot()
 	if lastCredentials.PublicKey != "public-1" || lastCredentials.PrivateKey != "private-1" {
 		t.Fatalf("last credentials = %#v", lastCredentials)
 	}
 }
 
-func TestQuotaGetCachesTiDBCloudRBACWithoutBackfillingSpendingLimit(t *testing.T) {
+func TestQuotaGetCachesTiDBCloudIAMRoleWithoutBackfillingSpendingLimit(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	spendingLimit := int64(222)
-	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &spendingLimit}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -748,8 +777,11 @@ func TestQuotaGetCachesTiDBCloudRBACWithoutBackfillingSpendingLimit(t *testing.T
 		t.Fatalf("first status = %d, want 200: %s", resp.StatusCode, body)
 	}
 	_ = resp.Body.Close()
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("get calls after first request = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls after first request = %d, want 1", got)
+	}
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("quota get calls after first request = %d, want 0", got)
 	}
 	cfg, err := rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
 	if err != nil {
@@ -762,7 +794,7 @@ func TestQuotaGetCachesTiDBCloudRBACWithoutBackfillingSpendingLimit(t *testing.T
 		t.Fatalf("checked_at = %v, want nil after GET", cfg.TiDBCloudSpendingLimitCheckedAt)
 	}
 
-	rt.prov.getErr = errors.New("should not call TiDB Cloud while RBAC cache and local spending limit are present")
+	rt.prov.iamErr = errors.New("should not call TiDB Cloud IAM while role cache is present")
 	resp2 := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
 	defer func() { _ = resp2.Body.Close() }()
 	if resp2.StatusCode != http.StatusOK {
@@ -776,21 +808,25 @@ func TestQuotaGetCachesTiDBCloudRBACWithoutBackfillingSpendingLimit(t *testing.T
 	if out.Config.TiDBCloudSpendingLimit != nil {
 		t.Fatalf("response spending limit = %#v, want nil", out.Config.TiDBCloudSpendingLimit)
 	}
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("get calls after cached request = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls after cached request = %d, want 1", got)
+	}
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("quota get calls after cached request = %d, want 0", got)
 	}
 
-	rt.prov.getErr = nil
-	updatedLimit := int64(333)
-	rt.prov.cloudCfg = &tenant.QuotaCloudConfig{TiDBCloudSpendingLimitMonthly: &updatedLimit}
+	rt.prov.iamErr = nil
 	resp3 := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-2", "")
 	defer func() { _ = resp3.Body.Close() }()
 	if resp3.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp3.Body)
 		t.Fatalf("third status = %d, want 200: %s", resp3.StatusCode, body)
 	}
-	if got := rt.prov.getCalls.Load(); got != 2 {
-		t.Fatalf("get calls after new credential = %d, want 2", got)
+	if got := rt.prov.iamCalls.Load(); got != 2 {
+		t.Fatalf("IAM calls after new credential = %d, want 2", got)
+	}
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("quota get calls after new credential = %d, want 0", got)
 	}
 	cfg, err = rt.meta.GetQuotaConfig(context.Background(), rt.tenantID)
 	if err != nil {
@@ -1232,15 +1268,21 @@ func TestQuotaSetRejectsNonCloudNativeTenant(t *testing.T) {
 func TestQuotaGetMapsTiDBCloudCredentialErrors(t *testing.T) {
 	for _, tc := range []struct {
 		name       string
-		err        error
 		wantStatus int
+		setup      func(*testing.T, *quotaRuntime)
 	}{
-		{name: "forbidden", err: tenant.ErrQuotaPermissionDenied, wantStatus: http.StatusForbidden},
-		{name: "not_found", err: tenant.ErrQuotaBackendNotFound, wantStatus: http.StatusNotFound},
+		{name: "forbidden", wantStatus: http.StatusForbidden, setup: func(_ *testing.T, rt *quotaRuntime) {
+			rt.prov.iamErr = tenant.ErrQuotaPermissionDenied
+		}},
+		{name: "not_found", wantStatus: http.StatusNotFound, setup: func(t *testing.T, rt *quotaRuntime) {
+			if _, err := rt.meta.DB().Exec("DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?", rt.tenantID); err != nil {
+				t.Fatal(err)
+			}
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-			rt.prov.getErr = tc.err
+			tc.setup(t, rt)
 			ts := httptest.NewServer(rt.server)
 			defer ts.Close()
 
@@ -1249,8 +1291,8 @@ func TestQuotaGetMapsTiDBCloudCredentialErrors(t *testing.T) {
 			if resp.StatusCode != tc.wantStatus {
 				t.Fatalf("status = %d, want %d", resp.StatusCode, tc.wantStatus)
 			}
-			if got := rt.prov.getCalls.Load(); got != 1 {
-				t.Fatalf("get calls = %d, want 1", got)
+			if got := rt.prov.getCalls.Load(); got != 0 {
+				t.Fatalf("quota get calls = %d, want 0", got)
 			}
 		})
 	}
@@ -1332,9 +1374,11 @@ func TestQuotaSetHidesGenericTiDBCloudQuotaError(t *testing.T) {
 	}
 }
 
-func TestAdminTenantListReturnsEmptyWithoutDBLookupWhenNoManagedClusters(t *testing.T) {
+func TestAdminTenantListReturnsEmptyForIAMOrganizationWithoutTenants(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-empty", Role: tenant.TiDBCloudRoleOrgOwner,
+	}}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -1360,16 +1404,15 @@ func TestAdminTenantListReturnsEmptyWithoutDBLookupWhenNoManagedClusters(t *test
 	if len(out.Tenants) != 0 {
 		t.Fatalf("tenants = %#v, want empty", out.Tenants)
 	}
-	if got := rt.prov.listCalls.Load(); got != 1 {
-		t.Fatalf("list calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
 	}
-	lastListOptions := rt.prov.lastListOptionsSnapshot()
-	if lastListOptions.ClusterID != "" {
-		t.Fatalf("cluster filter = %q, want empty", lastListOptions.ClusterID)
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls = %d, want 0", got)
 	}
 }
 
-func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
+func TestAdminTenantListFiltersByIAMOrganization(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
 	now := time.Now().UTC()
@@ -1487,6 +1530,20 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
+	foreignTenantID := "tenant-foreign-organization"
+	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
+		ID: foreignTenantID, Status: meta.TenantActive, Kind: meta.TenantKindLive,
+		Provider: tenant.ProviderTiDBCloudNative, ClusterID: "cluster-foreign", SchemaVersion: 1,
+		DBPasswordCipher: []byte("cipher"), CreatedAt: now.Add(6 * time.Second), UpdatedAt: now.Add(6 * time.Second),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
+		TenantID: foreignTenantID, OrganizationID: "org-2", ClusterID: "cluster-foreign",
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	freeTenantID := "tenant-free-pool"
 	if err := rt.meta.InsertTenant(ctx, &meta.Tenant{
 		ID:               freeTenantID,
@@ -1517,14 +1574,8 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{
-			ClusterID:      "cluster-allowed",
-			OrganizationID: "org-1",
-		}, {
-			ClusterID:      "cluster-free",
-			OrganizationID: "org-1",
-		}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-1", Role: tenant.TiDBCloudRoleProjectOwner,
 	}}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
@@ -1548,8 +1599,14 @@ func TestAdminTenantListFiltersByAuthorizedClusters(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if len(out.Tenants) != 3 || out.Tenants[0].TenantID != wildcardTenantID || out.Tenants[1].TenantID != sharedTenantID || out.Tenants[2].TenantID != rt.tenantID {
-		t.Fatalf("tenants = %#v, want wildcard shared tenant %s, shared tenant %s, and dedicated tenant %s", out.Tenants, wildcardTenantID, sharedTenantID, rt.tenantID)
+	if len(out.Tenants) != 4 || out.Tenants[0].TenantID != wildcardTenantID || out.Tenants[1].TenantID != sharedTenantID || out.Tenants[2].TenantID != otherTenantID || out.Tenants[3].TenantID != rt.tenantID {
+		t.Fatalf("tenants = %#v, want all non-free tenants in IAM organization", out.Tenants)
+	}
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
+	}
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls = %d, want 0", got)
 	}
 	freeReq, err := http.NewRequest(http.MethodGet, ts.URL+"/v1/admin/tenants/"+freeSharedTenantID, nil)
 	if err != nil {
@@ -1592,13 +1649,8 @@ func TestAdminTenantListIncludeQuotaDoesNotBackfillSpendingLimit(t *testing.T) {
 	if err := rt.meta.EnsureQuotaUsageRow(ctx, rt.tenantID); err != nil {
 		t.Fatal(err)
 	}
-	cloudSpendingLimit := int64(12345)
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{
-			ClusterID:                     "cluster-quota-1",
-			OrganizationID:                "org-1",
-			TiDBCloudSpendingLimitMonthly: &cloudSpendingLimit,
-		}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-1", Role: tenant.TiDBCloudRoleOrgOwner,
 	}}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
@@ -1635,8 +1687,11 @@ func TestAdminTenantListIncludeQuotaDoesNotBackfillSpendingLimit(t *testing.T) {
 	if cfg.TiDBCloudSpendingLimit != nil || cfg.TiDBCloudSpendingLimitCheckedAt != nil {
 		t.Fatalf("quota config mutated by GET: %#v", cfg)
 	}
-	if got := rt.prov.listCalls.Load(); got != 1 {
-		t.Fatalf("list calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
+	}
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls = %d, want 0", got)
 	}
 }
 
@@ -1705,6 +1760,9 @@ func TestAdminTenantGetHidesFreePoolTenant(t *testing.T) {
 
 func TestAdminTenantGetWithoutOrgBindingReturnsNotFound(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	if _, err := rt.meta.DB().Exec("DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?", rt.tenantID); err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -1728,7 +1786,7 @@ func TestAdminTenantGetWithoutOrgBindingReturnsNotFound(t *testing.T) {
 	}
 }
 
-func TestAdminTenantGetRejectsUnauthorizedCluster(t *testing.T) {
+func TestAdminTenantGetRejectsUnauthorizedOrganization(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
 	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
@@ -1740,11 +1798,8 @@ func TestAdminTenantGetRejectsUnauthorizedCluster(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{
-			ClusterID:      "cluster-other",
-			OrganizationID: "org-1",
-		}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-2", Role: tenant.TiDBCloudRoleOrgOwner,
 	}}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
@@ -1762,11 +1817,17 @@ func TestAdminTenantGetRejectsUnauthorizedCluster(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusForbidden {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("status = %d, want 403 for unauthorized cluster: %s", resp.StatusCode, body)
+		t.Fatalf("status = %d, want 403 for unauthorized organization: %s", resp.StatusCode, body)
+	}
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
+	}
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls = %d, want 0", got)
 	}
 }
 
-func TestAdminTenantGetUsesListClusterAuthorizationAndReturnsQuota(t *testing.T) {
+func TestAdminTenantGetUsesIAMOrganizationAuthorizationAndReturnsQuota(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
 	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
@@ -1791,13 +1852,8 @@ func TestAdminTenantGetUsesListClusterAuthorizationAndReturnsQuota(t *testing.T)
 	if err := rt.meta.EnsureQuotaUsageRow(ctx, rt.tenantID); err != nil {
 		t.Fatal(err)
 	}
-	cloudSpendingLimit := int64(12345)
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{
-			ClusterID:                     "cluster-quota-1",
-			OrganizationID:                "org-1",
-			TiDBCloudSpendingLimitMonthly: &cloudSpendingLimit,
-		}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-1", Role: tenant.TiDBCloudRoleProjectOwner,
 	}}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
@@ -1850,18 +1906,17 @@ func TestAdminTenantGetUsesListClusterAuthorizationAndReturnsQuota(t *testing.T)
 	if cfg.TiDBCloudSpendingLimit == nil || *cfg.TiDBCloudSpendingLimit != localSpendingLimit || cfg.TiDBCloudSpendingLimitCheckedAt != nil {
 		t.Fatalf("quota config mutated by GET: %#v", cfg)
 	}
-	if got := rt.prov.listCalls.Load(); got != 1 {
-		t.Fatalf("list calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
 	}
-	lastListOptions := rt.prov.lastListOptionsSnapshot()
-	if lastListOptions.ClusterID != "cluster-quota-1" {
-		t.Fatalf("cluster filter = %q, want cluster-quota-1", lastListOptions.ClusterID)
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls = %d, want 0", got)
 	}
 	if got := rt.prov.markCalls.Load(); got != 0 {
 		t.Fatalf("mark calls = %d, want 0", got)
 	}
 
-	rt.prov.listErr = errors.New("should not call TiDB Cloud while admin RBAC cache and local spending limit are present")
+	rt.prov.iamErr = errors.New("should not call TiDB Cloud IAM while role cache is present")
 	req, err = http.NewRequest(http.MethodGet, ts.URL+"/v1/admin/tenants/"+rt.tenantID, nil)
 	if err != nil {
 		t.Fatal(err)
@@ -1877,8 +1932,11 @@ func TestAdminTenantGetUsesListClusterAuthorizationAndReturnsQuota(t *testing.T)
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("cached status = %d, want 200: %s", resp.StatusCode, body)
 	}
-	if got := rt.prov.listCalls.Load(); got != 1 {
-		t.Fatalf("list calls after cached request = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls after cached request = %d, want 1", got)
+	}
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls after cached request = %d, want 0", got)
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
@@ -2183,9 +2241,11 @@ func TestAdminTenantPoolCreatePersistsClustersWhenMetadataWaitFails(t *testing.T
 	}
 }
 
-func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissing(t *testing.T) {
+func TestAdminTenantPoolCreateUsesIAMOrganizationWhenClusterResponseOmitsIt(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-1", Role: tenant.TiDBCloudRoleOrgOwner,
+	}}
 	rt.prov.batchPoolErr = errors.New("tidbcloud native cluster get status 429")
 	rt.prov.batchPoolOmitConnectionInfo = true
 	rt.prov.batchPoolMissingOrg = map[int]bool{1: true}
@@ -2224,15 +2284,17 @@ func TestAdminTenantPoolCreatePreservesPersistedClustersWhenOneOrganizationMissi
 	if err != nil {
 		t.Fatalf("list pending bindings: %v", err)
 	}
-	if len(rows) != 1 {
-		t.Fatalf("pending bindings = %d, want 1", len(rows))
+	if len(rows) != 2 {
+		t.Fatalf("pending bindings = %d, want 2", len(rows))
 	}
-	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
-		t.Fatalf("deprovision calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
 	}
-	lastDeprovision := rt.prov.lastDeprovisionSnapshot()
-	if lastDeprovision == nil || lastDeprovision.ClusterID != "pool-cluster-2" {
-		t.Fatalf("last deprovision = %#v, want pool-cluster-2", lastDeprovision)
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls = %d, want 0", got)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
 	}
 }
 
@@ -2666,9 +2728,11 @@ func TestAdminTenantPoolUpdateRejectsAboveMaxSize(t *testing.T) {
 	}
 }
 
-func TestAdminTenantPoolCreateCleansUpWhenOrganizationBackfillConflicts(t *testing.T) {
+func TestAdminTenantPoolCreateRejectsExistingIAMOrganizationPoolBeforeCloudCreate(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{}}
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-1", Role: tenant.TiDBCloudRoleOrgOwner,
+	}}
 	ctx := context.Background()
 	now := time.Now().UTC()
 	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
@@ -2694,11 +2758,17 @@ func TestAdminTenantPoolCreateCleansUpWhenOrganizationBackfillConflicts(t *testi
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, body)
 	}
-	if got := rt.prov.batchPoolCalls.Load(); got != 1 {
-		t.Fatalf("batch pool calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
 	}
-	if got := rt.prov.deprovisionCalls.Load(); got != 2 {
-		t.Fatalf("deprovision calls = %d, want 2", got)
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls = %d, want 0", got)
+	}
+	if got := rt.prov.batchPoolCalls.Load(); got != 0 {
+		t.Fatalf("batch pool calls = %d, want 0", got)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 0 {
+		t.Fatalf("deprovision calls = %d, want 0", got)
 	}
 	free, err := rt.meta.CountFreeTenantPoolBindings(ctx, "org-1")
 	if err != nil {
@@ -3301,7 +3371,7 @@ func TestProvisionFallsBackWhenTenantPoolClaimCannotListManagedClusters(t *testi
 	}
 }
 
-func TestAdminTenantQuotaSetRequiresPatchLabelAuthorization(t *testing.T) {
+func TestAdminTenantQuotaSetRequiresIAMOrganizationAuthorization(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
 	if err := rt.meta.UpsertTenantTiDBCloudOrgBinding(ctx, &meta.TenantTiDBCloudOrgBinding{
@@ -3323,11 +3393,8 @@ func TestAdminTenantQuotaSetRequiresPatchLabelAuthorization(t *testing.T) {
 	if err := rt.meta.EnsureQuotaUsageRow(ctx, rt.tenantID); err != nil {
 		t.Fatal(err)
 	}
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{
-			ClusterID:      "cluster-quota-1",
-			OrganizationID: "org-1",
-		}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-1", Role: tenant.TiDBCloudRoleOrgOwner,
 	}}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
@@ -3355,8 +3422,11 @@ func TestAdminTenantQuotaSetRequiresPatchLabelAuthorization(t *testing.T) {
 			t.Fatalf("admin quota response exposed field %q: %s", field, raw)
 		}
 	}
-	if got := rt.prov.listCalls.Load(); got != 1 {
-		t.Fatalf("list calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
+	}
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls = %d, want 0", got)
 	}
 	if got := rt.prov.markCalls.Load(); got != 1 {
 		t.Fatalf("mark calls = %d, want 1", got)
@@ -3372,8 +3442,8 @@ func TestAdminTenantQuotaSetRequiresPatchLabelAuthorization(t *testing.T) {
 		t.Fatalf("max storage bytes = %d, want %d", cfg.MaxStorageBytes, 200*quotaStorageSizeBytes)
 	}
 	calls := rt.prov.callsSnapshot()
-	if len(calls) < 2 || calls[0] != "list" || calls[1] != "mark" {
-		t.Fatalf("calls = %#v, want list then mark", calls)
+	if len(calls) != 1 || calls[0] != "mark" {
+		t.Fatalf("calls = %#v, want mark only after IAM authorization", calls)
 	}
 }
 
@@ -3392,11 +3462,8 @@ func TestAdminTenantQuotaSetRejectsProvisioningTenant(t *testing.T) {
 	}); err != nil {
 		t.Fatal(err)
 	}
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{
-			ClusterID:      "cluster-quota-1",
-			OrganizationID: "org-1",
-		}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-1", Role: tenant.TiDBCloudRoleProjectOwner,
 	}}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
@@ -3411,8 +3478,11 @@ func TestAdminTenantQuotaSetRejectsProvisioningTenant(t *testing.T) {
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 409: %s", resp.StatusCode, body)
 	}
-	if got := rt.prov.listCalls.Load(); got != 1 {
-		t.Fatalf("list calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
+	}
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls = %d, want 0", got)
 	}
 	if got := rt.prov.markCalls.Load(); got != 0 {
 		t.Fatalf("mark calls = %d, want 0", got)
@@ -3446,13 +3516,7 @@ func TestAdminTenantDeleteRetryWithCleanupJobSkipsPatchAfterClusterGone(t *testi
 		t.Fatal(err)
 	}
 	rt.prov.markErr = tenant.ErrQuotaBackendNotFound
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{
-		{},
-		{Clusters: []tenant.CloudClusterInfo{{
-			ClusterID:      "cluster-other-in-org",
-			OrganizationID: "org-1",
-		}}},
-	}
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{OrganizationID: "org-1", Role: tenant.TiDBCloudRoleOrgOwner}}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
@@ -3470,8 +3534,8 @@ func TestAdminTenantDeleteRetryWithCleanupJobSkipsPatchAfterClusterGone(t *testi
 		body, _ := io.ReadAll(resp.Body)
 		t.Fatalf("status = %d, want 202: %s", resp.StatusCode, body)
 	}
-	if got := rt.prov.listCalls.Load(); got != 2 {
-		t.Fatalf("list calls = %d, want cluster lookup then org fallback", got)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
 	}
 	if got := rt.prov.markCalls.Load(); got != 0 {
 		t.Fatalf("mark calls = %d, want 0 for already-enqueued delete retry", got)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -840,19 +840,25 @@ func TestQuotaGetCachesTiDBCloudIAMRoleWithoutBackfillingSpendingLimit(t *testin
 	}
 }
 
-func TestDeprecatedQuotaGetWorksWithoutTiDBCloudOrgBinding(t *testing.T) {
+func TestQuotaGetWithoutTiDBCloudOrgBindingReturnsNotFound(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	if _, err := rt.meta.DB().Exec("DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?", rt.tenantID); err != nil {
+		t.Fatal(err)
+	}
 	ts := httptest.NewServer(rt.server)
 	defer ts.Close()
 
 	resp := getQuota(t, ts.URL, rt.tenantID, "public-1", "private-1", "")
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusNotFound {
 		body, _ := io.ReadAll(resp.Body)
-		t.Fatalf("status = %d, want 200 without tenant-org binding: %s", resp.StatusCode, body)
+		t.Fatalf("status = %d, want 404 without tenant-org binding: %s", resp.StatusCode, body)
 	}
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("get calls = %d, want 1", got)
+	if got := rt.prov.iamCalls.Load(); got != 0 {
+		t.Fatalf("IAM calls = %d, want 0", got)
+	}
+	if got := rt.prov.getCalls.Load(); got != 0 {
+		t.Fatalf("get calls = %d, want 0", got)
 	}
 	if got := rt.prov.listCalls.Load(); got != 0 {
 		t.Fatalf("list calls = %d, want 0", got)
@@ -1599,8 +1605,8 @@ func TestAdminTenantListFiltersByIAMOrganization(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
 		t.Fatal(err)
 	}
-	if len(out.Tenants) != 4 || out.Tenants[0].TenantID != wildcardTenantID || out.Tenants[1].TenantID != sharedTenantID || out.Tenants[2].TenantID != otherTenantID || out.Tenants[3].TenantID != rt.tenantID {
-		t.Fatalf("tenants = %#v, want all non-free tenants in IAM organization", out.Tenants)
+	if len(out.Tenants) != 3 || out.Tenants[0].TenantID != sharedTenantID || out.Tenants[1].TenantID != otherTenantID || out.Tenants[2].TenantID != rt.tenantID {
+		t.Fatalf("tenants = %#v, want non-free tenants explicitly owned by the IAM organization", out.Tenants)
 	}
 	if got := rt.prov.iamCalls.Load(); got != 1 {
 		t.Fatalf("IAM calls = %d, want 1", got)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -1216,7 +1216,7 @@ func TestQuotaSetRejectsInvalidQuotaValues(t *testing.T) {
 		{name: "negative_file_count", field: "max_file_count", value: -1, wantErr: "max_file_count must be non-negative"},
 		{name: "negative_spending_limit", field: "tidbcloud_spending_limit", value: -1, wantErr: "tidbcloud_spending_limit must be non-negative"},
 		{name: "small_spending_limit", field: "tidbcloud_spending_limit", value: 9, wantErr: "tidbcloud_spending_limit must be 0 or at least 10 RMB"},
-		{name: "spending_limit_above_cloud_maximum", field: "tidbcloud_spending_limit", value: meta.MaxTiDBCloudSpendingLimit + 1, wantErr: "tidbcloud_spending_limit is too large"},
+		{name: "spending_limit_above_tenant_api_maximum", field: "tidbcloud_spending_limit", value: meta.MaxTiDBCloudSpendingLimit + 1, wantErr: "tidbcloud_spending_limit is too large"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -48,11 +48,12 @@ type Config struct {
 	Pool                  *tenant.Pool
 	Provisioner           tenant.Provisioner
 	DefaultTenantProvider string
-	// SharedDBMaxTenants applies only to new managed
-	// tidb_cloud_native_shared pools. Zero uses the default of 100 tenants.
-	SharedDBMaxTenants   int
-	SharedDBHardCapRatio float64
-	SharedDBReopenRatio  float64
+	// SharedDBMaxTenants and SharedDBSpendingLimit apply only to new
+	// managed tidb_cloud_native_shared pools. Zero values use their defaults.
+	SharedDBMaxTenants    int
+	SharedDBHardCapRatio  float64
+	SharedDBReopenRatio   float64
+	SharedDBSpendingLimit int64
 	// LegacyStarterProvisioner is only used for delete/fork compatibility on
 	// persisted tidb_cloud_starter tenants. New starter provisioning remains
 	// disabled and NormalizeProvider does not accept tidb_cloud_starter.
@@ -188,6 +189,7 @@ type Server struct {
 	sharedDBMaxTenants        int
 	sharedDBHardCapRatio      float64
 	sharedDBReopenRatio       float64
+	sharedDBSpendingLimit     int64
 	legacyStarterProvisioner  tenant.Provisioner
 	tokenSecret               []byte
 	localTenantAPIKey         string
@@ -297,6 +299,10 @@ const DefaultSharedDBHardCapRatio = 1.2
 // to 80% of its persisted soft capacity.
 const DefaultSharedDBReopenRatio = 0.8
 
+// DefaultManagedSharedDBSpendingLimit is the physical spending-limit target
+// persisted for a new managed shared DB pool when no override is configured.
+const DefaultManagedSharedDBSpendingLimit = int64(1_000_000)
+
 // TenantStatusResponse is the JSON body of GET /v1/status. Fields are filled
 // per authenticated tenant so callers can discover their effective limits
 // before initiating uploads. MaxUploadBytes is currently process-wide but the
@@ -371,6 +377,10 @@ func NewWithConfig(cfg Config) *Server {
 	if sharedDBReopenRatio <= 0 || sharedDBReopenRatio >= 1 || sharedDBReopenRatio != sharedDBReopenRatio || math.IsInf(sharedDBReopenRatio, 0) {
 		sharedDBReopenRatio = DefaultSharedDBReopenRatio
 	}
+	sharedDBSpendingLimit := cfg.SharedDBSpendingLimit
+	if sharedDBSpendingLimit <= 0 {
+		sharedDBSpendingLimit = DefaultManagedSharedDBSpendingLimit
+	}
 	defaultTenantProvider := strings.TrimSpace(cfg.DefaultTenantProvider)
 	if defaultTenantProvider == "" && cfg.Provisioner != nil {
 		defaultTenantProvider = cfg.Provisioner.ProviderType()
@@ -390,6 +400,7 @@ func NewWithConfig(cfg Config) *Server {
 		sharedDBMaxTenants:        cfg.SharedDBMaxTenants,
 		sharedDBHardCapRatio:      sharedDBHardCapRatio,
 		sharedDBReopenRatio:       sharedDBReopenRatio,
+		sharedDBSpendingLimit:     sharedDBSpendingLimit,
 		legacyStarterProvisioner:  cfg.LegacyStarterProvisioner,
 		maxUploadBytes:            maxUpload,
 		tenantPoolMaxSize:         tenantPoolMaxSize,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4591,8 +4591,6 @@ func clientFacingErrorResponse(defaultStatus int, defaultMessage string, err err
 		return http.StatusUnauthorized, msg
 	case errors.Is(err, tenant.ErrQuotaPermissionDenied), errors.Is(err, tenant.ErrTiDBCloudRoleInsufficient), isTiDBCloudStatusError(err, http.StatusForbidden):
 		return http.StatusForbidden, msg
-	case errors.Is(err, errSharedDBCredentialOrganizationMismatch):
-		return http.StatusForbidden, msg
 	default:
 		return defaultStatus, msg
 	}
@@ -4626,8 +4624,6 @@ func clientFacingErrorDetail(err error) string {
 		return tenant.ErrQuotaPermissionDenied.Error()
 	case errors.Is(err, tenant.ErrTiDBCloudRoleInsufficient):
 		return tenant.ErrTiDBCloudRoleInsufficient.Error()
-	case errors.Is(err, errSharedDBCredentialOrganizationMismatch):
-		return sharedDBCredentialOrganizationMismatchMessage
 	case errors.Is(err, tenant.ErrQuotaBackendNotFound):
 		return tenant.ErrQuotaBackendNotFound.Error()
 	default:
@@ -5258,21 +5254,10 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			opts.CredentialProvisioner = defaultReq
 		}
 	}
-	var customerIdentity *tenant.TiDBCloudAPIKeyIdentity
 	if tenant.UsesTiDBCloudNativeCredentials(provider) {
-		customerIdentity, err = s.resolveTiDBCloudIdentity(ctx, *opts.CredentialProvisioner, "provision")
-		if err != nil {
+		if _, err := s.resolveTiDBCloudIdentity(ctx, *opts.CredentialProvisioner, "provision"); err != nil {
 			status, message := clientFacingErrorResponse(http.StatusBadGateway, "TiDB Cloud API key authorization failed", err)
 			return nil, newProvisionTenantError(status, message, err)
-		}
-		if provider == tenant.ProviderTiDBCloudNativeShared {
-			if _, err := s.sharedDBCloudCredentials(ctx, customerIdentity.OrganizationID); err != nil {
-				if errors.Is(err, errSharedDBCredentialOrganizationMismatch) {
-					return nil, newProvisionTenantError(http.StatusForbidden, sharedDBCredentialOrganizationMismatchMessage, err)
-				}
-				status, message := clientFacingErrorResponse(http.StatusBadGateway, "shared TiDB Cloud credential authorization failed", err)
-				return nil, newProvisionTenantError(status, message, err)
-			}
 		}
 	}
 	tenantID := token.NewID()

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5072,45 +5072,36 @@ func (s *Server) updateTenantSchemaVersionForProfile(ctx context.Context, tenant
 }
 
 // findSharedDBForProvision resolves whether the tenant being provisioned
-// should be placed on a shared-schema database: a registered shared pool for
-// the request's org, or the wildcard pool. It returns (nil, nil) when the
+// should be placed on a shared-schema database registered for the request's
+// exact TiDB Cloud organization. It returns (nil, nil) when the
 // tenant should follow the normal per-tenant provisioning path. Lookup
 // failures are returned as errors — never silently treated as "no pool",
 // which would provision the wrong tenant shape on a transient meta outage.
 //
-// Only TiDB-dialect providers may route to a shared pool (the shared schema
-// is TiDB/MySQL DDL): db9 tenants are PostgreSQL-backed and engine-
-// incompatible, so a wildcard pool must never capture them.
+// Only TiDB Cloud providers carry an IAM-resolved organization and may route
+// to an organization-bound shared pool.
 func (s *Server) findSharedDBForProvision(ctx context.Context, provider string, opts provisionTenantOptions) (*meta.SharedDB, error) {
 	if s.meta == nil {
 		return nil, nil
 	}
 	switch provider {
-	case tenant.ProviderTiDBCloudNative, tenant.ProviderTiDBCloudNativeShared, tenant.ProviderTiDBZero:
+	case tenant.ProviderTiDBCloudNative, tenant.ProviderTiDBCloudNativeShared:
 	default:
 		return nil, nil
 	}
 	orgID := ""
-	if provider == tenant.ProviderTiDBCloudNative || provider == tenant.ProviderTiDBCloudNativeShared {
-		if opts.CredentialProvisioner != nil {
-			if id, err := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner); err == nil {
-				orgID = id
-			} else {
-				logger.Warn(ctx, "server_event", eventFields(ctx, "provision_org_resolve_failed", "error", err)...)
-			}
+	if opts.CredentialProvisioner != nil {
+		if id, err := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner); err == nil {
+			orgID = id
+		} else {
+			logger.Warn(ctx, "server_event", eventFields(ctx, "provision_org_resolve_failed", "error", err)...)
 		}
-		if orgID == "" {
-			if provider == tenant.ProviderTiDBCloudNativeShared {
-				// An explicit shared placement request must fail closed: an
-				// unresolvable org can never silently become a dedicated
-				// cluster (nor match the wildcard pool).
-				return nil, fmt.Errorf("cannot resolve tidbcloud organization for shared-pool placement")
-			}
-			// Never fall back to the wildcard pool when the tenant's org cannot
-			// be resolved: an unresolved org must stay on the dedicated path
-			// even if a wildcard pool exists.
-			return nil, nil
+	}
+	if orgID == "" {
+		if provider == tenant.ProviderTiDBCloudNativeShared {
+			return nil, fmt.Errorf("cannot resolve tidbcloud organization for shared-pool placement")
 		}
+		return nil, nil
 	}
 	sharedDB, err := s.meta.FindSharedDBForOrg(ctx, orgID)
 	if err != nil {
@@ -5360,7 +5351,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 	}
 
 	// Shared-pool placement: when a shared-schema database is registered for
-	// this tenant's org (or a wildcard pool exists), the tenant is placed on
+	// this tenant's exact TiDB Cloud organization, the tenant is placed on
 	// it directly — no cluster is created and the schema already exists there.
 	sharedDB, err := s.findSharedDBForProvision(ctx, provider, opts)
 	if err != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4524,7 +4524,6 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		} else if claimed {
 			logger.Info(r.Context(), "server_event", eventFields(r.Context(), "provision_tenant_pool_claim_accepted", "tenant_id", res.TenantID, "provider", res.Provider, "pool_id", pool.PoolID, "organization_id", res.OrganizationID, "duration_ms", durationMillis(poolClaimStarted), "status", res.Status)...)
 			setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, res.OrganizationID, classifyTenantRequest(r))
-			s.forgetTiDBCloudRBACList(*credentialReq)
 			if res.Status == meta.TenantProvisioning {
 				s.startProvisionedTenantSchemaInit(r.Context(), res)
 			}
@@ -4555,9 +4554,6 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	setRequestMetricTenant(r.Context(), res.TenantID, res.APIKeyID, res.Provider, res.OrganizationID, classifyTenantRequest(r))
-	if credentialReq != nil {
-		s.forgetTiDBCloudRBACList(*credentialReq)
-	}
 	s.startProvisionedTenantSchemaInit(r.Context(), res)
 	writeProvisionTenantAccepted(w, res)
 }
@@ -4593,7 +4589,7 @@ func clientFacingErrorResponse(defaultStatus int, defaultMessage string, err err
 		return http.StatusBadRequest, msg
 	case isTiDBCloudStatusError(err, http.StatusUnauthorized):
 		return http.StatusUnauthorized, msg
-	case errors.Is(err, tenant.ErrQuotaPermissionDenied), isTiDBCloudStatusError(err, http.StatusForbidden):
+	case errors.Is(err, tenant.ErrQuotaPermissionDenied), errors.Is(err, tenant.ErrTiDBCloudRoleInsufficient), isTiDBCloudStatusError(err, http.StatusForbidden):
 		return http.StatusForbidden, msg
 	default:
 		return defaultStatus, msg
@@ -4626,6 +4622,8 @@ func clientFacingErrorDetail(err error) string {
 		return tenant.ErrPartialCredentials.Error()
 	case errors.Is(err, tenant.ErrQuotaPermissionDenied):
 		return tenant.ErrQuotaPermissionDenied.Error()
+	case errors.Is(err, tenant.ErrTiDBCloudRoleInsufficient):
+		return tenant.ErrTiDBCloudRoleInsufficient.Error()
 	case errors.Is(err, tenant.ErrQuotaBackendNotFound):
 		return tenant.ErrQuotaBackendNotFound.Error()
 	default:
@@ -5256,6 +5254,12 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			opts.CredentialProvisioner = defaultReq
 		}
 	}
+	if tenant.UsesTiDBCloudNativeCredentials(provider) {
+		if _, err := s.resolveTiDBCloudIdentity(ctx, *opts.CredentialProvisioner, "provision"); err != nil {
+			status, message := clientFacingErrorResponse(http.StatusBadGateway, "TiDB Cloud API key authorization failed", err)
+			return nil, newProvisionTenantError(status, message, err)
+		}
+	}
 	tenantID := token.NewID()
 	provisionStarted := time.Now()
 	logger.Info(ctx, "server_event", eventFields(ctx, "provision_requested", "tenant_id", tenantID, "provider", provider)...)
@@ -5314,7 +5318,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			}
 			if sharedDB.SpendingLimit != nil && (created || sharedDB.ClusterID == "" || sharedDB.Host == "" || sharedDB.Port <= 0 || sharedDB.User == "") {
 				plannedDB := sharedDB
-				sharedDB, err = s.ensureManagedSharedDBPhysical(ctx, plannedDB.ID, *opts.CredentialProvisioner)
+				sharedDB, err = s.ensureManagedSharedDBPhysical(ctx, plannedDB.ID)
 				if err != nil {
 					orgID, orgErr := s.firstManagedOrganization(ctx, *opts.CredentialProvisioner)
 					if orgErr == nil {
@@ -5324,7 +5328,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 							if hardErr == nil {
 								res, reserveErr := s.provisionTenantOnSharedDBEmergency(ctx, tenantID, fallback, provider, keyName, opts, now, hardCap)
 								if reserveErr == nil {
-									s.scheduleManagedSharedDBContinuation(ctx, plannedDB.ID, *opts.CredentialProvisioner)
+									s.scheduleManagedSharedDBContinuation(ctx, plannedDB.ID)
 									return res, nil
 								}
 								if isSharedDBReservationConflict(reserveErr) {
@@ -5348,7 +5352,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 				return nil, reserveErr
 			}
 			if created || sharedDB.Status == meta.SharedDBStatusProvisioning {
-				s.scheduleManagedSharedDBContinuation(ctx, sharedDB.ID, *opts.CredentialProvisioner)
+				s.scheduleManagedSharedDBContinuation(ctx, sharedDB.ID)
 			}
 			return res, nil
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -4591,6 +4591,8 @@ func clientFacingErrorResponse(defaultStatus int, defaultMessage string, err err
 		return http.StatusUnauthorized, msg
 	case errors.Is(err, tenant.ErrQuotaPermissionDenied), errors.Is(err, tenant.ErrTiDBCloudRoleInsufficient), isTiDBCloudStatusError(err, http.StatusForbidden):
 		return http.StatusForbidden, msg
+	case errors.Is(err, errSharedDBCredentialOrganizationMismatch):
+		return http.StatusForbidden, msg
 	default:
 		return defaultStatus, msg
 	}
@@ -4624,6 +4626,8 @@ func clientFacingErrorDetail(err error) string {
 		return tenant.ErrQuotaPermissionDenied.Error()
 	case errors.Is(err, tenant.ErrTiDBCloudRoleInsufficient):
 		return tenant.ErrTiDBCloudRoleInsufficient.Error()
+	case errors.Is(err, errSharedDBCredentialOrganizationMismatch):
+		return sharedDBCredentialOrganizationMismatchMessage
 	case errors.Is(err, tenant.ErrQuotaBackendNotFound):
 		return tenant.ErrQuotaBackendNotFound.Error()
 	default:
@@ -5254,10 +5258,21 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 			opts.CredentialProvisioner = defaultReq
 		}
 	}
+	var customerIdentity *tenant.TiDBCloudAPIKeyIdentity
 	if tenant.UsesTiDBCloudNativeCredentials(provider) {
-		if _, err := s.resolveTiDBCloudIdentity(ctx, *opts.CredentialProvisioner, "provision"); err != nil {
+		customerIdentity, err = s.resolveTiDBCloudIdentity(ctx, *opts.CredentialProvisioner, "provision")
+		if err != nil {
 			status, message := clientFacingErrorResponse(http.StatusBadGateway, "TiDB Cloud API key authorization failed", err)
 			return nil, newProvisionTenantError(status, message, err)
+		}
+		if provider == tenant.ProviderTiDBCloudNativeShared {
+			if _, err := s.sharedDBCloudCredentials(ctx, customerIdentity.OrganizationID); err != nil {
+				if errors.Is(err, errSharedDBCredentialOrganizationMismatch) {
+					return nil, newProvisionTenantError(http.StatusForbidden, sharedDBCredentialOrganizationMismatchMessage, err)
+				}
+				status, message := clientFacingErrorResponse(http.StatusBadGateway, "shared TiDB Cloud credential authorization failed", err)
+				return nil, newProvisionTenantError(status, message, err)
+			}
 		}
 	}
 	tenantID := token.NewID()

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -40,12 +40,16 @@ type defaultSharedDatabaseNameProvider interface {
 	DefaultSharedDatabaseName() string
 }
 
-func (s *Server) managedSharedDBPolicy() int {
-	maxTenants := s.sharedDBMaxTenants
+func (s *Server) managedSharedDBPolicy() (maxTenants int, spendingLimit int64) {
+	maxTenants = s.sharedDBMaxTenants
 	if maxTenants <= 0 {
 		maxTenants = defaultManagedSharedDBMaxTenants
 	}
-	return maxTenants
+	spendingLimit = s.sharedDBSpendingLimit
+	if spendingLimit <= 0 {
+		spendingLimit = DefaultManagedSharedDBSpendingLimit
+	}
+	return maxTenants, spendingLimit
 }
 
 func (s *Server) managedSharedDBHardCap(softCap int) (int, error) {
@@ -177,8 +181,7 @@ func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.Creden
 				}
 			}
 			if sharedDB == nil {
-				maxTenants := s.managedSharedDBPolicy()
-				fixedTarget := meta.MaxTiDBCloudSpendingLimit
+				maxTenants, fixedTarget := s.managedSharedDBPolicy()
 				cloudProvider, region := provisioningCloudRegion(s.provisioner)
 				rootPassword, passwordErr := generateManagedSharedDBRootPassword(24)
 				if passwordErr != nil {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -222,8 +222,8 @@ func (s *Server) defaultSharedDatabaseName() string {
 	return "tidbcloud_fs"
 }
 
-func (s *Server) scheduleManagedSharedDBContinuation(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) {
-	s.scheduleManagedSharedDBContinuations(ctx, []int64{dbID}, cred)
+func (s *Server) scheduleManagedSharedDBContinuation(ctx context.Context, dbID int64) {
+	s.scheduleManagedSharedDBContinuations(ctx, []int64{dbID})
 }
 
 // scheduleManagedSharedDBContinuations retries one request batch in rounds.
@@ -232,7 +232,7 @@ func (s *Server) scheduleManagedSharedDBContinuation(ctx context.Context, dbID i
 // the provider's long waiter. Starting one goroutine per DB pool would let all
 // waiters pin dedicated meta *sql.Conn values and can exhaust the connection
 // pool before the lock holder finishes.
-func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs []int64, cred tenant.CredentialProvisionRequest) {
+func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs []int64) {
 	if len(dbIDs) == 0 {
 		return
 	}
@@ -244,7 +244,7 @@ func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs
 			if workerCtx.Err() != nil {
 				return
 			}
-			states = append(states, s.managedSharedDBContinuation(workerCtx, dbID, cred))
+			states = append(states, s.managedSharedDBContinuation(workerCtx, dbID))
 		}
 		retryManagedSharedDBContinuations(workerCtx, states)
 		for i := range states {
@@ -262,7 +262,7 @@ type managedSharedDBContinuation struct {
 	lastErr      error
 }
 
-func (s *Server) managedSharedDBContinuation(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) managedSharedDBContinuation {
+func (s *Server) managedSharedDBContinuation(ctx context.Context, dbID int64) managedSharedDBContinuation {
 	poolCtx := ctx
 	if poolInfo, err := s.meta.GetSharedDB(ctx, dbID); err == nil {
 		poolCtx = logger.WithContext(ctx, logger.FromContext(ctx).With(
@@ -279,7 +279,7 @@ func (s *Server) managedSharedDBContinuation(ctx context.Context, dbID int64, cr
 		if poolInfo.Status != meta.SharedDBStatusProvisioning {
 			return nil
 		}
-		return s.continueManagedSharedDBPoolOnce(poolCtx, dbID, cred)
+		return s.continueManagedSharedDBPoolOnce(poolCtx, dbID)
 	}}
 }
 
@@ -346,10 +346,6 @@ func retryManagedSharedDBContinuations(ctx context.Context, states []managedShar
 }
 
 func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
-	cred := resolveDefaultCredentials(s.provisioner)
-	if cred == nil {
-		return
-	}
 	rows, err := s.meta.ListSharedDBsByStatus(ctx, meta.SharedDBStatusProvisioning, 1000)
 	if err != nil {
 		logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.Error(err))
@@ -360,7 +356,7 @@ func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
-		states = append(states, s.managedSharedDBContinuation(ctx, row.ID, *cred))
+		states = append(states, s.managedSharedDBContinuation(ctx, row.ID))
 	}
 	retryManagedSharedDBContinuations(ctx, states)
 	for i := range states {
@@ -370,9 +366,17 @@ func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
 	}
 }
 
-func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) error {
+func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64) error {
+	poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		return err
+	}
+	cred, err := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
+	if err != nil {
+		return err
+	}
 	for metadataAttempt := 0; metadataAttempt < 2; metadataAttempt++ {
-		err := s.continueManagedSharedDBPoolOnce(ctx, dbID, cred)
+		err := s.continueManagedSharedDBPoolOnceWithCredentials(ctx, dbID, cred)
 		if !errors.Is(err, errSharedDBConnectionMetadataNotReady) {
 			return err
 		}
@@ -394,7 +398,19 @@ func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64, cr
 	return fmt.Errorf("%w: db pool %d", errSharedDBConnectionMetadataNotReady, dbID)
 }
 
-func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) error {
+func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64) error {
+	poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		return err
+	}
+	cred, err := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
+	if err != nil {
+		return err
+	}
+	return s.continueManagedSharedDBPoolOnceWithCredentials(ctx, dbID, cred)
+}
+
+func (s *Server) continueManagedSharedDBPoolOnceWithCredentials(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) error {
 	for attempt := 0; attempt < 2; attempt++ {
 		poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
 		if err != nil {
@@ -516,8 +532,12 @@ func (s *Server) ensureManagedSharedDBPhysicalLocked(ctx context.Context, poolIn
 	return poolInfo, nil
 }
 
-func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) (*meta.SharedDB, error) {
+func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) (*meta.SharedDB, error) {
 	poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		return nil, err
+	}
+	cred, err := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
 	if err != nil {
 		return nil, err
 	}
@@ -536,8 +556,8 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64, 
 }
 
 // continueManagedSharedDBPoolLocked intentionally keeps the organization
-// allocation lock through physical ensure, system-user setup, schema ensure,
-// and activation. Continuations are dispatched sequentially and are not a
+// allocation lock through physical ensure, schema ensure, and activation.
+// Continuations are dispatched sequentially and are not a
 // request-QPS path; the wider lock preserves the existing single-owner Cloud
 // mutation model and prevents another allocator from observing half-ready
 // connection metadata. The readiness poll is the one long wait kept outside.
@@ -639,23 +659,6 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 	dsn := managedSharedDBDSN(poolInfo, string(plain))
 	if ensurer, ok := s.provisioner.(tenantDatabaseEnsurer); ok {
 		if err := ensurer.EnsureDatabase(ctx, dsn); err != nil {
-			return err
-		}
-	}
-	if userProvisioner, ok := s.provisioner.(nativeSystemUserProvisioner); ok {
-		username, password, ensureErr := userProvisioner.EnsureSystemUser(ctx, dsn, fmt.Sprintf("db-pool-%d", dbID))
-		if ensureErr != nil {
-			return ensureErr
-		}
-		passwordCipher, encryptErr := s.pool.Encrypt(ctx, []byte(password))
-		if encryptErr != nil {
-			return encryptErr
-		}
-		if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{
-			ID: dbID, TiDBCloudOrganizationID: poolInfo.TiDBCloudOrganizationID, ClusterID: poolInfo.ClusterID,
-			Host: poolInfo.Host, Port: poolInfo.Port, User: username, PasswordCipher: passwordCipher,
-			Name: poolInfo.Name, TLSMode: poolInfo.TLSMode,
-		}); err != nil {
 			return err
 		}
 	}

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -383,7 +383,7 @@ func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64) er
 		if poolInfo.ClusterID == "" {
 			return err
 		}
-		cred, credErr := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
+		cred, credErr := s.sharedDBCloudCredentials(ctx)
 		if credErr != nil {
 			return credErr
 		}
@@ -400,7 +400,7 @@ func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64
 		if err != nil {
 			return err
 		}
-		cred, err := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
+		cred, err := s.sharedDBCloudCredentials(ctx)
 		if err != nil {
 			return err
 		}
@@ -493,8 +493,9 @@ func (s *Server) ensureManagedSharedDBPhysicalLocked(ctx context.Context, poolIn
 		}
 		result = results[0]
 	}
-	if result.OrganizationID == "" {
-		result.OrganizationID = poolInfo.TiDBCloudOrganizationID
+	logicalOrganizationID := strings.TrimSpace(poolInfo.TiDBCloudOrganizationID)
+	if logicalOrganizationID == "" {
+		return nil, fmt.Errorf("managed shared db pool customer organization is required")
 	}
 	if result.DBName == "" {
 		result.DBName = poolInfo.Name
@@ -504,7 +505,7 @@ func (s *Server) ensureManagedSharedDBPhysicalLocked(ctx context.Context, poolIn
 		tlsMode = "skip-verify"
 	}
 	if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{
-		ID: poolInfo.ID, TiDBCloudOrganizationID: result.OrganizationID, ClusterID: result.ClusterID,
+		ID: poolInfo.ID, TiDBCloudOrganizationID: logicalOrganizationID, ClusterID: result.ClusterID,
 		Host: result.Host, Port: result.Port, User: result.Username, PasswordCipher: poolInfo.PasswordCipher,
 		Name: result.DBName, TLSMode: tlsMode,
 	}); err != nil {
@@ -526,7 +527,7 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) 
 		if err != nil {
 			return nil, err
 		}
-		cred, err := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
+		cred, err := s.sharedDBCloudCredentials(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -625,8 +626,9 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 			}
 			result = results[0]
 		}
-		if result.OrganizationID == "" {
-			result.OrganizationID = poolInfo.TiDBCloudOrganizationID
+		logicalOrganizationID := strings.TrimSpace(poolInfo.TiDBCloudOrganizationID)
+		if logicalOrganizationID == "" {
+			return fmt.Errorf("managed shared db pool customer organization is required")
 		}
 		if result.DBName == "" {
 			result.DBName = poolInfo.Name
@@ -636,7 +638,7 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 			tlsMode = "skip-verify"
 		}
 		if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{
-			ID: dbID, TiDBCloudOrganizationID: result.OrganizationID, ClusterID: result.ClusterID,
+			ID: dbID, TiDBCloudOrganizationID: logicalOrganizationID, ClusterID: result.ClusterID,
 			Host: result.Host, Port: result.Port, User: result.Username, PasswordCipher: poolInfo.PasswordCipher,
 			Name: result.DBName, TLSMode: tlsMode,
 		}); err != nil {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -367,16 +367,8 @@ func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
 }
 
 func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64) error {
-	poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
-	if err != nil {
-		return err
-	}
-	cred, err := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
-	if err != nil {
-		return err
-	}
 	for metadataAttempt := 0; metadataAttempt < 2; metadataAttempt++ {
-		err := s.continueManagedSharedDBPoolOnceWithCredentials(ctx, dbID, cred)
+		err := s.continueManagedSharedDBPoolOnce(ctx, dbID)
 		if !errors.Is(err, errSharedDBConnectionMetadataNotReady) {
 			return err
 		}
@@ -391,6 +383,10 @@ func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64) er
 		if poolInfo.ClusterID == "" {
 			return err
 		}
+		cred, credErr := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
+		if credErr != nil {
+			return credErr
+		}
 		if _, waitErr := waiter.WaitForSharedDBPoolMetadataWithCredentials(ctx, dbID, poolInfo.UUID, poolInfo.ClusterID, cred); waitErr != nil {
 			return waitErr
 		}
@@ -399,20 +395,12 @@ func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64) er
 }
 
 func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64) error {
-	poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
-	if err != nil {
-		return err
-	}
-	cred, err := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
-	if err != nil {
-		return err
-	}
-	return s.continueManagedSharedDBPoolOnceWithCredentials(ctx, dbID, cred)
-}
-
-func (s *Server) continueManagedSharedDBPoolOnceWithCredentials(ctx context.Context, dbID int64, cred tenant.CredentialProvisionRequest) error {
 	for attempt := 0; attempt < 2; attempt++ {
 		poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
+		if err != nil {
+			return err
+		}
+		cred, err := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
 		if err != nil {
 			return err
 		}
@@ -423,7 +411,7 @@ func (s *Server) continueManagedSharedDBPoolOnceWithCredentials(ctx context.Cont
 			if loadErr != nil {
 				return loadErr
 			}
-			if poolInfo.TiDBCloudOrganizationID == "" && current.TiDBCloudOrganizationID != "" {
+			if strings.TrimSpace(poolInfo.TiDBCloudOrganizationID) != strings.TrimSpace(current.TiDBCloudOrganizationID) {
 				restartWithOrganization = true
 				return nil
 			}
@@ -533,26 +521,39 @@ func (s *Server) ensureManagedSharedDBPhysicalLocked(ctx context.Context, poolIn
 }
 
 func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) (*meta.SharedDB, error) {
-	poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
-	if err != nil {
-		return nil, err
-	}
-	cred, err := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
-	if err != nil {
-		return nil, err
-	}
-	identity := sharedDBAllocationIdentity(poolInfo.TiDBCloudOrganizationID, poolInfo.ProvisioningKey)
-	var result *meta.SharedDB
-	err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
-		current, err := s.meta.GetSharedDB(lockCtx, dbID)
+	for attempt := 0; attempt < 2; attempt++ {
+		poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		var ensureErr error
-		result, ensureErr = s.ensureManagedSharedDBPhysicalLocked(lockCtx, current, cred)
-		return ensureErr
-	})
-	return result, err
+		cred, err := s.sharedDBCloudCredentials(ctx, poolInfo.TiDBCloudOrganizationID)
+		if err != nil {
+			return nil, err
+		}
+		identity := sharedDBAllocationIdentity(poolInfo.TiDBCloudOrganizationID, poolInfo.ProvisioningKey)
+		var result *meta.SharedDB
+		restartWithOrganization := false
+		err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+			current, loadErr := s.meta.GetSharedDB(lockCtx, dbID)
+			if loadErr != nil {
+				return loadErr
+			}
+			if strings.TrimSpace(poolInfo.TiDBCloudOrganizationID) != strings.TrimSpace(current.TiDBCloudOrganizationID) {
+				restartWithOrganization = true
+				return nil
+			}
+			var ensureErr error
+			result, ensureErr = s.ensureManagedSharedDBPhysicalLocked(lockCtx, current, cred)
+			return ensureErr
+		})
+		if err != nil {
+			return nil, err
+		}
+		if !restartWithOrganization {
+			return result, nil
+		}
+	}
+	return nil, fmt.Errorf("db pool %d allocation identity kept changing", dbID)
 }
 
 // continueManagedSharedDBPoolLocked intentionally keeps the organization

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -86,6 +86,18 @@ func managedSharedDBDSN(info *meta.SharedDB, password string) string {
 	return fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", info.User, password, info.Host, info.Port, info.Name, query)
 }
 
+func (s *Server) sharedDBCloudCredentials() (tenant.CredentialProvisionRequest, error) {
+	provider, ok := s.provisioner.(tenant.SharedCredentialProvider)
+	if !ok {
+		return tenant.CredentialProvisionRequest{}, fmt.Errorf("shared TiDB Cloud credentials are not configured")
+	}
+	cred, ok := provider.DefaultSharedCredentials()
+	if !ok {
+		return tenant.CredentialProvisionRequest{}, fmt.Errorf("shared TiDB Cloud credentials are not configured")
+	}
+	return cred, nil
+}
+
 func generateManagedSharedDBRootPassword(length int) (string, error) {
 	const chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 	if length <= 0 {
@@ -383,7 +395,7 @@ func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64) er
 		if poolInfo.ClusterID == "" {
 			return err
 		}
-		cred, credErr := s.sharedDBCloudCredentials(ctx)
+		cred, credErr := s.sharedDBCloudCredentials()
 		if credErr != nil {
 			return credErr
 		}
@@ -400,7 +412,7 @@ func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64
 		if err != nil {
 			return err
 		}
-		cred, err := s.sharedDBCloudCredentials(ctx)
+		cred, err := s.sharedDBCloudCredentials()
 		if err != nil {
 			return err
 		}
@@ -527,7 +539,7 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) 
 		if err != nil {
 			return nil, err
 		}
-		cred, err := s.sharedDBCloudCredentials(ctx)
+		cred, err := s.sharedDBCloudCredentials()
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -163,7 +163,7 @@ func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.Creden
 	identity := sharedDBAllocationIdentity(organizationID, provisioningKey)
 	err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
 		for attempt := 0; attempt < 2; attempt++ {
-			candidate, findErr := s.meta.FindSharedDBForAllocation(lockCtx, organizationID, provisioningKey)
+			candidate, findErr := s.meta.FindSharedDBForAllocation(lockCtx, organizationID)
 			if findErr == nil {
 				sharedDB = candidate
 			} else if !errors.Is(findErr, meta.ErrNotFound) {

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -244,21 +244,20 @@ func TestSharedTenantDeleteFullPurgePath(t *testing.T) {
 	}
 }
 
-func TestAdminTenantCreateRejectsSharedPoolWithoutCloudIdentity(t *testing.T) {
+func TestAdminTenantCreateAllowsSharedPoolWithoutCloudClusterIdentity(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{
-		{Clusters: []tenant.CloudClusterInfo{{ClusterID: "cluster-org-probe", OrganizationID: "org-shared-1"}}},
-	}
-	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-shared-1", Role: tenant.TiDBCloudRoleOrgOwner,
+	}}
+	if _, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-1",
 		Host:                    "shared.example.com",
 		Port:                    4000,
 		User:                    "root",
 		PasswordCipher:          []byte("cipher"),
 		Name:                    "shared_db",
-	})
-	if err != nil {
+	}); err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
 	}
 
@@ -278,45 +277,30 @@ func TestAdminTenantCreateRejectsSharedPoolWithoutCloudIdentity(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusConflict {
-		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusConflict)
+	if resp.StatusCode != http.StatusAccepted {
+		responseBody, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status = %d, want %d: %s", resp.StatusCode, http.StatusAccepted, responseBody)
 	}
 	var tenantCount int
 	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenants").Scan(&tenantCount); err != nil {
 		t.Fatal(err)
 	}
-	if tenantCount != 1 {
-		t.Fatalf("tenants = %d, want 1", tenantCount)
-	}
-	if _, err := rt.meta.DB().ExecContext(ctx, "UPDATE db_pool SET cluster_id = ? WHERE db_id = ?", "cluster-shared-admin-create", dbID); err != nil {
-		t.Fatalf("set shared cluster identity: %v", err)
-	}
-	manageableReq, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/admin/tenants", bytes.NewReader(body))
-	if err != nil {
-		t.Fatal(err)
-	}
-	manageableReq.Header.Set("Content-Type", "application/json")
-	manageableResp, err := http.DefaultClient.Do(manageableReq)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() { _ = manageableResp.Body.Close() }()
-	if manageableResp.StatusCode != http.StatusAccepted {
-		t.Fatalf("manageable shared pool status = %d, want %d", manageableResp.StatusCode, http.StatusAccepted)
-	}
-	if err := rt.meta.DB().QueryRow("SELECT COUNT(*) FROM tenants").Scan(&tenantCount); err != nil {
-		t.Fatal(err)
-	}
 	if tenantCount != 2 {
-		t.Fatalf("tenants after manageable create = %d, want 2", tenantCount)
+		t.Fatalf("tenants = %d, want 2", tenantCount)
+	}
+	if got := rt.prov.listCalls.Load(); got != 0 {
+		t.Fatalf("cluster list calls = %d, want 0", got)
+	}
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM calls = %d, want 1", got)
 	}
 }
 
 func TestAdminTenantCreatePersistsSharedQuotaSizesInBytes(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{ClusterID: "cluster-shared-quota", OrganizationID: "org-shared-quota"}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: "org-shared-quota", Role: tenant.TiDBCloudRoleProjectOwner,
 	}}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-quota", Host: "shared.example.com", Port: 4000,
@@ -360,6 +344,7 @@ func TestAdminTenantCreatePersistsSharedQuotaSizesInBytes(t *testing.T) {
 
 func TestAdminTenantGetAuthorizesSharedProviderThroughPhysicalPool(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{OrganizationID: "org-shared-admin", Role: tenant.TiDBCloudRoleOrgOwner}}
 	ctx := context.Background()
 	if err := rt.meta.UpdateTenantProvider(ctx, rt.tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
 		t.Fatalf("UpdateTenantProvider: %v", err)
@@ -410,17 +395,14 @@ func TestAdminTenantGetAuthorizesSharedProviderThroughPhysicalPool(t *testing.T)
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want %d", resp.StatusCode, http.StatusOK)
 	}
-	if got := rt.prov.getCalls.Load(); got != 1 {
-		t.Fatalf("physical pool authorization calls = %d, want 1", got)
-	}
-	cluster := rt.prov.lastClusterSnapshot()
-	if cluster == nil || cluster.ClusterID != "cluster-shared-admin" || cluster.OrganizationID != "org-shared-admin" {
-		t.Fatalf("authorized physical cluster = %#v", cluster)
+	if got := rt.prov.iamCalls.Load(); got != 1 {
+		t.Fatalf("IAM authorization calls = %d, want 1", got)
 	}
 }
 
 func TestAdminTenantQuotaSetSharedUpdatesVirtualQuotaOnly(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{OrganizationID: "org-shared-admin", Role: tenant.TiDBCloudRoleProjectOwner}}
 	ctx := context.Background()
 	if err := rt.meta.UpdateTenantProvider(ctx, rt.tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
 		t.Fatalf("UpdateTenantProvider: %v", err)
@@ -484,6 +466,7 @@ func TestAdminTenantQuotaSetSharedUpdatesVirtualQuotaOnly(t *testing.T) {
 
 func TestAdminTenantDeleteSharedNeverDeprovisionsPhysicalPool(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{OrganizationID: "org-shared-admin-delete", Role: tenant.TiDBCloudRoleOrgOwner}}
 	ctx := context.Background()
 	if err := rt.meta.UpdateTenantProvider(ctx, rt.tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
 		t.Fatalf("UpdateTenantProvider: %v", err)

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -35,7 +35,7 @@ func TestSharedTenantDeleteRetriesFromDeletingPlacement(t *testing.T) {
 	}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-delete", Host: "shared.example.com", Port: 4000,
-		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 100,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -105,6 +105,7 @@ func TestSharedTenantDeleteWithCleanupJobShortCircuits(t *testing.T) {
 		User:                    "root",
 		PasswordCipher:          []byte("cipher"),
 		Name:                    "shared_db",
+		MaxTenants:              100,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -206,6 +207,7 @@ func TestSharedTenantDeleteFullPurgePath(t *testing.T) {
 		User:                    "root",
 		PasswordCipher:          []byte("cipher"),
 		Name:                    "shared_db",
+		MaxTenants:              100,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -257,6 +259,7 @@ func TestAdminTenantCreateAllowsSharedPoolWithoutCloudClusterIdentity(t *testing
 		User:                    "root",
 		PasswordCipher:          []byte("cipher"),
 		Name:                    "shared_db",
+		MaxTenants:              100,
 	}); err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
 	}
@@ -304,7 +307,7 @@ func TestAdminTenantCreatePersistsSharedQuotaSizesInBytes(t *testing.T) {
 	}}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-quota", Host: "shared.example.com", Port: 4000,
-		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 100,
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -355,7 +358,7 @@ func TestAdminTenantGetAuthorizesSharedProviderThroughPhysicalPool(t *testing.T)
 	}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-admin", ClusterID: "cluster-shared-admin",
-		Host: "shared.example.com", Port: 4000, User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+		Host: "shared.example.com", Port: 4000, User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 100,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -416,7 +419,7 @@ func TestAdminTenantQuotaSetSharedUpdatesVirtualQuotaOnly(t *testing.T) {
 	}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-admin", Host: "shared.example.com", Port: 4000,
-		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 100,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -480,7 +483,7 @@ func TestAdminTenantDeleteSharedNeverDeprovisionsPhysicalPool(t *testing.T) {
 	}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-admin-delete", Host: "127.0.0.1", Port: 1,
-		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 100,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -567,7 +570,7 @@ func TestSharedTenantDeletePlacementRemovalFailureStaysRetryable(t *testing.T) {
 	}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-delete", Host: db.DBHost, Port: db.DBPort, User: db.DBUser,
-		PasswordCipher: passCipher, Name: db.DBName,
+		PasswordCipher: passCipher, Name: db.DBName, MaxTenants: 100,
 	})
 	if err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -651,7 +654,7 @@ func TestFindSharedDBForProvisionSkipsNonTiDBProviders(t *testing.T) {
 	ctx := context.Background()
 	if _, err := db.Meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-exact", Host: "shared.example.com", Port: 4000, User: "root",
-		PasswordCipher: []byte("cipher"), Name: "shared_db",
+		PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 100,
 	}); err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
 	}

--- a/pkg/server/tenant_delete_shared_test.go
+++ b/pkg/server/tenant_delete_shared_test.go
@@ -642,16 +642,15 @@ func TestSharedTenantDeletePlacementRemovalFailureStaysRetryable(t *testing.T) {
 	}
 }
 
-// TestFindSharedDBForProvisionSkipsNonTiDBProviders proves a wildcard shared
-// pool only ever captures TiDB-dialect tenants: db9 (PostgreSQL) tenants must
-// never be placed on the TiDB shared schema and relabeled
-// tidb_cloud_native_shared.
+// TestFindSharedDBForProvisionRequiresCloudOrganization proves that shared
+// placement requires an exact customer organization and never captures
+// providers without TiDB Cloud IAM organization data.
 func TestFindSharedDBForProvisionSkipsNonTiDBProviders(t *testing.T) {
 	db := newTenantDeleteDBInfo(t)
 	testmysql.ResetMetaDB(t, db.Meta.DB())
 	ctx := context.Background()
 	if _, err := db.Meta.RegisterSharedDB(ctx, &meta.SharedDB{
-		TiDBCloudOrganizationID: meta.SharedDBOrgWildcard, Host: "shared.example.com", Port: 4000, User: "root",
+		TiDBCloudOrganizationID: "org-exact", Host: "shared.example.com", Port: 4000, User: "root",
 		PasswordCipher: []byte("cipher"), Name: "shared_db",
 	}); err != nil {
 		t.Fatalf("RegisterSharedDB: %v", err)
@@ -665,13 +664,14 @@ func TestFindSharedDBForProvisionSkipsNonTiDBProviders(t *testing.T) {
 	if got != nil {
 		t.Fatalf("db9 matched shared pool %v, want no match", got)
 	}
-	// TiDB-dialect providers still route: tidb_zero matches the wildcard.
+	// tidb_zero has no IAM organization and therefore cannot match an exact
+	// organization-bound shared pool.
 	got, err = s.findSharedDBForProvision(ctx, tenant.ProviderTiDBZero, provisionTenantOptions{})
 	if err != nil {
 		t.Fatalf("tidb_zero lookup: %v", err)
 	}
-	if got == nil {
-		t.Fatal("tidb_zero did not match the wildcard pool, want match")
+	if got != nil {
+		t.Fatalf("tidb_zero matched shared pool %v, want no match", got)
 	}
 }
 

--- a/pkg/server/tenant_failed_cleanup_test.go
+++ b/pkg/server/tenant_failed_cleanup_test.go
@@ -601,6 +601,12 @@ func TestCleanupFailedOrganizationTenantsNativeListFailureContinuesShared(t *tes
 
 func setFailedCleanupTenant(t *testing.T, rt *quotaRuntime, tenantID, provider, clusterID, namespaceID string, updatedAt time.Time) {
 	t.Helper()
+	if provider == tenant.ProviderTiDBCloudNativeShared {
+		if _, err := rt.meta.DB().ExecContext(context.Background(),
+			"DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?", tenantID); err != nil {
+			t.Fatalf("remove dedicated binding for shared cleanup tenant %s: %v", tenantID, err)
+		}
+	}
 	if _, err := rt.meta.DB().ExecContext(context.Background(), `UPDATE tenants
 		SET status = ?, provider = ?, cluster_id = NULLIF(?, ''), storage_namespace_id = ?, updated_at = ?
 		WHERE id = ?`, meta.TenantFailed, provider, clusterID, namespaceID, updatedAt.UTC(), tenantID); err != nil {

--- a/pkg/server/tenant_failed_cleanup_trigger_test.go
+++ b/pkg/server/tenant_failed_cleanup_trigger_test.go
@@ -165,8 +165,8 @@ func TestTenantFailedCleanupAsyncRollsBackStateWhenServerRejectsWorker(t *testin
 func TestTenantPoolClaimReturnsWithoutWaitingForFailedCleanupAndPassesCredentials(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{OrganizationID: failedCleanupTestOrganizationID}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: failedCleanupTestOrganizationID, Role: tenant.TiDBCloudRoleOrgOwner,
 	}}
 	started := make(chan tenant.CredentialProvisionRequest, 1)
 	release := make(chan struct{})
@@ -222,8 +222,8 @@ func TestTenantPoolClaimReturnsWithoutWaitingForFailedCleanupAndPassesCredential
 func TestTenantPoolClaimTriggersDirectFailedCleanupWithoutLogicalPool(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{OrganizationID: failedCleanupTestOrganizationID}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: failedCleanupTestOrganizationID, Role: tenant.TiDBCloudRoleOrgOwner,
 	}}
 	old := time.Now().UTC().Add(-time.Hour)
 	directTenantID := rt.tenantID
@@ -253,8 +253,8 @@ func TestTenantPoolClaimTriggersDirectFailedCleanupWithoutLogicalPool(t *testing
 func TestTenantPoolClaimResultUnaffectedByFailedCleanupError(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	ctx := context.Background()
-	rt.prov.listPages = []*tenant.ManagedClusterListResult{{
-		Clusters: []tenant.CloudClusterInfo{{OrganizationID: failedCleanupTestOrganizationID}},
+	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
+		OrganizationID: failedCleanupTestOrganizationID, Role: tenant.TiDBCloudRoleOrgOwner,
 	}}
 	old := time.Now().UTC().Add(-time.Hour)
 	setFailedCleanupTenant(t, rt, rt.tenantID, tenant.ProviderTiDBCloudNative, "cluster-cleanup-fails", "", old)

--- a/pkg/server/tidbcloud_iam.go
+++ b/pkg/server/tidbcloud_iam.go
@@ -62,7 +62,10 @@ func (s *Server) authorizeNativeTenantCredentials(ctx context.Context, t *meta.T
 	}
 	binding, err := s.meta.GetTenantTiDBCloudOrgBinding(ctx, t.ID)
 	if err != nil {
-		return nil, tenant.ErrQuotaBackendNotFound
+		if errors.Is(err, meta.ErrNotFound) {
+			return nil, tenant.ErrQuotaBackendNotFound
+		}
+		return nil, fmt.Errorf("get tenant TiDB Cloud organization binding: %w", err)
 	}
 	if _, err := s.authorizeTiDBCloudOrganization(ctx, cred, binding.OrganizationID, metricPath); err != nil {
 		return nil, err

--- a/pkg/server/tidbcloud_iam.go
+++ b/pkg/server/tidbcloud_iam.go
@@ -11,6 +11,10 @@ import (
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
+var errSharedDBCredentialOrganizationMismatch = errors.New("shared TiDB Cloud credential organization mismatch")
+
+const sharedDBCredentialOrganizationMismatchMessage = "shared mode requires the TiDB Cloud API key organization to match the configured shared credential organization"
+
 func (s *Server) resolveTiDBCloudIdentity(ctx context.Context, cred tenant.CredentialProvisionRequest, metricPath string) (*tenant.TiDBCloudAPIKeyIdentity, error) {
 	if identity, ok := s.tidbCloudRBACCache.getIdentity(cred); ok {
 		metrics.RecordTiDBCloudRBACCacheRequest(metricPath, "role", "hit")
@@ -88,7 +92,7 @@ func (s *Server) sharedDBCloudCredentials(ctx context.Context, organizationID st
 	}
 	if strings.TrimSpace(organizationID) != "" && strings.TrimSpace(organizationID) != meta.SharedDBOrgWildcard &&
 		identity.OrganizationID != strings.TrimSpace(organizationID) {
-		return tenant.CredentialProvisionRequest{}, fmt.Errorf("shared TiDB Cloud credential organization %q does not match pool organization %q", identity.OrganizationID, organizationID)
+		return tenant.CredentialProvisionRequest{}, errSharedDBCredentialOrganizationMismatch
 	}
 	return cred, nil
 }

--- a/pkg/server/tidbcloud_iam.go
+++ b/pkg/server/tidbcloud_iam.go
@@ -28,6 +28,10 @@ func (s *Server) resolveTiDBCloudIdentity(ctx context.Context, cred tenant.Crede
 	if identity == nil || strings.TrimSpace(identity.OrganizationID) == "" {
 		return nil, fmt.Errorf("TiDB Cloud IAM identity is missing organization")
 	}
+	// Drive9's TiDB Cloud policy intentionally treats both owner roles as
+	// organization-scoped operators. The IAM lookup replaces the old
+	// cluster-list authorization path; project resource membership is not part
+	// of the local tenant ownership model.
 	if identity.Role != tenant.TiDBCloudRoleOrgOwner && identity.Role != tenant.TiDBCloudRoleProjectOwner {
 		return nil, fmt.Errorf("%w: role %q; org:owner or project:owner is required", tenant.ErrTiDBCloudRoleInsufficient, identity.Role)
 	}
@@ -38,7 +42,7 @@ func (s *Server) resolveTiDBCloudIdentity(ctx context.Context, cred tenant.Crede
 func tiDBCloudOrganizationMatches(identityOrganizationID, resourceOrganizationID string) bool {
 	identityOrganizationID = strings.TrimSpace(identityOrganizationID)
 	resourceOrganizationID = strings.TrimSpace(resourceOrganizationID)
-	return identityOrganizationID != "" && (resourceOrganizationID == identityOrganizationID || resourceOrganizationID == "*")
+	return identityOrganizationID != "" && resourceOrganizationID == identityOrganizationID
 }
 
 func (s *Server) authorizeTiDBCloudOrganization(ctx context.Context, cred tenant.CredentialProvisionRequest, resourceOrganizationID, metricPath string) (*tenant.TiDBCloudAPIKeyIdentity, error) {

--- a/pkg/server/tidbcloud_iam.go
+++ b/pkg/server/tidbcloud_iam.go
@@ -11,10 +11,6 @@ import (
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
-var errSharedDBCredentialOrganizationMismatch = errors.New("shared TiDB Cloud credential organization mismatch")
-
-const sharedDBCredentialOrganizationMismatchMessage = "shared mode requires the TiDB Cloud API key organization to match the configured shared credential organization"
-
 func (s *Server) resolveTiDBCloudIdentity(ctx context.Context, cred tenant.CredentialProvisionRequest, metricPath string) (*tenant.TiDBCloudAPIKeyIdentity, error) {
 	if identity, ok := s.tidbCloudRBACCache.getIdentity(cred); ok {
 		metrics.RecordTiDBCloudRBACCacheRequest(metricPath, "role", "hit")
@@ -77,7 +73,7 @@ func (s *Server) authorizeNativeTenantCredentials(ctx context.Context, t *meta.T
 	return binding, nil
 }
 
-func (s *Server) sharedDBCloudCredentials(ctx context.Context, organizationID string) (tenant.CredentialProvisionRequest, error) {
+func (s *Server) sharedDBCloudCredentials(ctx context.Context) (tenant.CredentialProvisionRequest, error) {
 	provider, ok := s.provisioner.(tenant.SharedCredentialProvider)
 	if !ok {
 		return tenant.CredentialProvisionRequest{}, fmt.Errorf("shared TiDB Cloud credentials are not configured")
@@ -86,13 +82,8 @@ func (s *Server) sharedDBCloudCredentials(ctx context.Context, organizationID st
 	if !ok {
 		return tenant.CredentialProvisionRequest{}, fmt.Errorf("shared TiDB Cloud credentials are not configured")
 	}
-	identity, err := s.resolveTiDBCloudIdentity(ctx, cred, "shared_pool_role")
-	if err != nil {
+	if _, err := s.resolveTiDBCloudIdentity(ctx, cred, "shared_pool_role"); err != nil {
 		return tenant.CredentialProvisionRequest{}, err
-	}
-	if strings.TrimSpace(organizationID) != "" && strings.TrimSpace(organizationID) != meta.SharedDBOrgWildcard &&
-		identity.OrganizationID != strings.TrimSpace(organizationID) {
-		return tenant.CredentialProvisionRequest{}, errSharedDBCredentialOrganizationMismatch
 	}
 	return cred, nil
 }

--- a/pkg/server/tidbcloud_iam.go
+++ b/pkg/server/tidbcloud_iam.go
@@ -73,21 +73,6 @@ func (s *Server) authorizeNativeTenantCredentials(ctx context.Context, t *meta.T
 	return binding, nil
 }
 
-func (s *Server) sharedDBCloudCredentials(ctx context.Context) (tenant.CredentialProvisionRequest, error) {
-	provider, ok := s.provisioner.(tenant.SharedCredentialProvider)
-	if !ok {
-		return tenant.CredentialProvisionRequest{}, fmt.Errorf("shared TiDB Cloud credentials are not configured")
-	}
-	cred, ok := provider.DefaultSharedCredentials()
-	if !ok {
-		return tenant.CredentialProvisionRequest{}, fmt.Errorf("shared TiDB Cloud credentials are not configured")
-	}
-	if _, err := s.resolveTiDBCloudIdentity(ctx, cred, "shared_pool_role"); err != nil {
-		return tenant.CredentialProvisionRequest{}, err
-	}
-	return cred, nil
-}
-
 func isTiDBCloudRoleInsufficient(err error) bool {
 	return errors.Is(err, tenant.ErrTiDBCloudRoleInsufficient)
 }

--- a/pkg/server/tidbcloud_iam.go
+++ b/pkg/server/tidbcloud_iam.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+)
+
+func (s *Server) resolveTiDBCloudIdentity(ctx context.Context, cred tenant.CredentialProvisionRequest, metricPath string) (*tenant.TiDBCloudAPIKeyIdentity, error) {
+	if identity, ok := s.tidbCloudRBACCache.getIdentity(cred); ok {
+		metrics.RecordTiDBCloudRBACCacheRequest(metricPath, "role", "hit")
+		return &identity, nil
+	}
+	metrics.RecordTiDBCloudRBACCacheRequest(metricPath, "role", "miss")
+	resolver, ok := s.provisioner.(tenant.TiDBCloudAPIKeyIdentityResolver)
+	if !ok {
+		return nil, fmt.Errorf("TiDB Cloud IAM identity lookup is not enabled")
+	}
+	identity, err := resolver.ResolveAPIKeyIdentity(ctx, cred)
+	if err != nil {
+		return nil, err
+	}
+	if identity == nil || strings.TrimSpace(identity.OrganizationID) == "" {
+		return nil, fmt.Errorf("TiDB Cloud IAM identity is missing organization")
+	}
+	if identity.Role != tenant.TiDBCloudRoleOrgOwner && identity.Role != tenant.TiDBCloudRoleProjectOwner {
+		return nil, fmt.Errorf("%w: role %q; org:owner or project:owner is required", tenant.ErrTiDBCloudRoleInsufficient, identity.Role)
+	}
+	s.tidbCloudRBACCache.rememberIdentity(cred, *identity)
+	return identity, nil
+}
+
+func tiDBCloudOrganizationMatches(identityOrganizationID, resourceOrganizationID string) bool {
+	identityOrganizationID = strings.TrimSpace(identityOrganizationID)
+	resourceOrganizationID = strings.TrimSpace(resourceOrganizationID)
+	return identityOrganizationID != "" && (resourceOrganizationID == identityOrganizationID || resourceOrganizationID == "*")
+}
+
+func (s *Server) authorizeTiDBCloudOrganization(ctx context.Context, cred tenant.CredentialProvisionRequest, resourceOrganizationID, metricPath string) (*tenant.TiDBCloudAPIKeyIdentity, error) {
+	identity, err := s.resolveTiDBCloudIdentity(ctx, cred, metricPath)
+	if err != nil {
+		return nil, err
+	}
+	if !tiDBCloudOrganizationMatches(identity.OrganizationID, resourceOrganizationID) {
+		return nil, tenant.ErrQuotaPermissionDenied
+	}
+	return identity, nil
+}
+
+func (s *Server) authorizeNativeTenantCredentials(ctx context.Context, t *meta.Tenant, cred tenant.CredentialProvisionRequest, metricPath string) (*meta.TenantTiDBCloudOrgBinding, error) {
+	if t == nil {
+		return nil, tenant.ErrQuotaBackendNotFound
+	}
+	binding, err := s.meta.GetTenantTiDBCloudOrgBinding(ctx, t.ID)
+	if err != nil {
+		return nil, tenant.ErrQuotaBackendNotFound
+	}
+	if _, err := s.authorizeTiDBCloudOrganization(ctx, cred, binding.OrganizationID, metricPath); err != nil {
+		return nil, err
+	}
+	return binding, nil
+}
+
+func (s *Server) sharedDBCloudCredentials(ctx context.Context, organizationID string) (tenant.CredentialProvisionRequest, error) {
+	provider, ok := s.provisioner.(tenant.SharedCredentialProvider)
+	if !ok {
+		return tenant.CredentialProvisionRequest{}, fmt.Errorf("shared TiDB Cloud credentials are not configured")
+	}
+	cred, ok := provider.DefaultSharedCredentials()
+	if !ok {
+		return tenant.CredentialProvisionRequest{}, fmt.Errorf("shared TiDB Cloud credentials are not configured")
+	}
+	identity, err := s.resolveTiDBCloudIdentity(ctx, cred, "shared_pool_role")
+	if err != nil {
+		return tenant.CredentialProvisionRequest{}, err
+	}
+	if strings.TrimSpace(organizationID) != "" && strings.TrimSpace(organizationID) != meta.SharedDBOrgWildcard &&
+		identity.OrganizationID != strings.TrimSpace(organizationID) {
+		return tenant.CredentialProvisionRequest{}, fmt.Errorf("shared TiDB Cloud credential organization %q does not match pool organization %q", identity.OrganizationID, organizationID)
+	}
+	return cred, nil
+}
+
+func isTiDBCloudRoleInsufficient(err error) bool {
+	return errors.Is(err, tenant.ErrTiDBCloudRoleInsufficient)
+}

--- a/pkg/server/tidbcloud_iam_test.go
+++ b/pkg/server/tidbcloud_iam_test.go
@@ -62,7 +62,7 @@ func TestAuthorizedAdminSharedTenantMapsPhysicalLookupBackendErrorToServerError(
 	}
 	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-1", Host: "shared.example.com", Port: 4000,
-		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db", MaxTenants: 100,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/server/tidbcloud_iam_test.go
+++ b/pkg/server/tidbcloud_iam_test.go
@@ -15,7 +15,7 @@ func TestTiDBCloudOrganizationMatchesRequiresExplicitOrganization(t *testing.T) 
 	if !tiDBCloudOrganizationMatches("org-1", "org-1") {
 		t.Fatal("matching organizations should be authorized")
 	}
-	for _, resourceOrganizationID := range []string{"", meta.SharedDBOrgWildcard, "org-2"} {
+	for _, resourceOrganizationID := range []string{"", "*", "org-2"} {
 		if tiDBCloudOrganizationMatches("org-1", resourceOrganizationID) {
 			t.Fatalf("resource organization %q should not be authorized", resourceOrganizationID)
 		}

--- a/pkg/server/tidbcloud_iam_test.go
+++ b/pkg/server/tidbcloud_iam_test.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/meta"
+)
+
+func TestTiDBCloudOrganizationMatchesRequiresExplicitOrganization(t *testing.T) {
+	if !tiDBCloudOrganizationMatches("org-1", "org-1") {
+		t.Fatal("matching organizations should be authorized")
+	}
+	for _, resourceOrganizationID := range []string{"", meta.SharedDBOrgWildcard, "org-2"} {
+		if tiDBCloudOrganizationMatches("org-1", resourceOrganizationID) {
+			t.Fatalf("resource organization %q should not be authorized", resourceOrganizationID)
+		}
+	}
+}

--- a/pkg/server/tidbcloud_iam_test.go
+++ b/pkg/server/tidbcloud_iam_test.go
@@ -1,9 +1,14 @@
 package server
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
 func TestTiDBCloudOrganizationMatchesRequiresExplicitOrganization(t *testing.T) {
@@ -14,5 +19,84 @@ func TestTiDBCloudOrganizationMatchesRequiresExplicitOrganization(t *testing.T) 
 		if tiDBCloudOrganizationMatches("org-1", resourceOrganizationID) {
 			t.Fatalf("resource organization %q should not be authorized", resourceOrganizationID)
 		}
+	}
+}
+
+func TestAuthorizeNativeTenantCredentialsPreservesMetaBackendError(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	tenantRow, err := rt.meta.GetTenant(context.Background(), rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err = rt.server.authorizeNativeTenantCredentials(ctx, tenantRow,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}, "test")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context canceled backend error", err)
+	}
+}
+
+func TestAuthorizeSharedQuotaCredentialsPreservesMetaBackendError(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNativeShared)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	_, err := rt.server.authorizeSharedQuotaCredentials(ctx, &meta.Tenant{ID: rt.tenantID},
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}, "test")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("error = %v, want context canceled backend error", err)
+	}
+}
+
+func TestAuthorizedAdminSharedTenantMapsPhysicalLookupBackendErrorToServerError(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	ctx := context.Background()
+	if err := rt.meta.UpdateTenantProvider(ctx, rt.tenantID, tenant.ProviderTiDBCloudNativeShared); err != nil {
+		t.Fatal(err)
+	}
+	fsID, err := rt.meta.EnsureFsID(ctx, rt.tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := rt.meta.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-1", Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: []byte("cipher"), Name: "shared_db",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	const unavailableTable = "db_pool_admin_lookup_error"
+	if _, err := rt.meta.DB().ExecContext(ctx, "RENAME TABLE db_pool TO "+unavailableTable); err != nil {
+		t.Fatal(err)
+	}
+	renamed := true
+	t.Cleanup(func() {
+		if renamed {
+			_, _ = rt.meta.DB().ExecContext(context.Background(), "RENAME TABLE "+unavailableTable+" TO db_pool")
+		}
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/admin/tenants/"+rt.tenantID, nil)
+	recorder := httptest.NewRecorder()
+	_, _, ok := rt.server.authorizedAdminTenant(recorder, req, rt.tenantID,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}, true, false)
+
+	if _, err := rt.meta.DB().ExecContext(ctx, "RENAME TABLE "+unavailableTable+" TO db_pool"); err != nil {
+		t.Fatal(err)
+	}
+	renamed = false
+	if ok {
+		t.Fatal("authorization unexpectedly succeeded while shared DB lookup failed")
+	}
+	if recorder.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusInternalServerError)
 	}
 }

--- a/pkg/server/tidbcloud_rbac_cache.go
+++ b/pkg/server/tidbcloud_rbac_cache.go
@@ -13,24 +13,16 @@ import (
 const (
 	tidbCloudRBACCacheTTL        = time.Hour
 	tidbCloudRBACCacheMaxEntries = 10000
-	tidbCloudRBACCacheMaxLists   = 1000
 )
 
 type tidbCloudRBACCache struct {
 	mu      sync.RWMutex
 	ttl     time.Duration
-	entries map[string]tidbCloudRBACEntry
-	lists   map[string]tidbCloudRBACListEntry
+	entries map[string]tidbCloudRBACIdentityEntry
 }
 
-type tidbCloudRBACEntry struct {
-	clusterID      string
-	organizationID string
-	expiresAt      time.Time
-}
-
-type tidbCloudRBACListEntry struct {
-	clusters  []tenant.CloudClusterInfo
+type tidbCloudRBACIdentityEntry struct {
+	identity  tenant.TiDBCloudAPIKeyIdentity
 	expiresAt time.Time
 }
 
@@ -38,28 +30,20 @@ func newTiDBCloudRBACCache(ttl time.Duration) *tidbCloudRBACCache {
 	if ttl <= 0 {
 		ttl = tidbCloudRBACCacheTTL
 	}
-	return &tidbCloudRBACCache{
-		ttl:     ttl,
-		entries: make(map[string]tidbCloudRBACEntry),
-		lists:   make(map[string]tidbCloudRBACListEntry),
-	}
+	return &tidbCloudRBACCache{ttl: ttl, entries: make(map[string]tidbCloudRBACIdentityEntry)}
 }
 
-func (c *tidbCloudRBACCache) getCluster(cred tenant.CredentialProvisionRequest, clusterID string) (tenant.CloudClusterInfo, bool) {
+func (c *tidbCloudRBACCache) getIdentity(cred tenant.CredentialProvisionRequest) (tenant.TiDBCloudAPIKeyIdentity, bool) {
 	if c == nil {
-		return tenant.CloudClusterInfo{}, false
+		return tenant.TiDBCloudAPIKeyIdentity{}, false
 	}
-	clusterID = strings.TrimSpace(clusterID)
-	if clusterID == "" {
-		return tenant.CloudClusterInfo{}, false
-	}
-	key := c.entryKey(cred, clusterID)
+	key := c.credentialKey(cred)
 	now := time.Now()
 	c.mu.RLock()
 	entry, ok := c.entries[key]
 	c.mu.RUnlock()
 	if !ok {
-		return tenant.CloudClusterInfo{}, false
+		return tenant.TiDBCloudAPIKeyIdentity{}, false
 	}
 	if now.After(entry.expiresAt) {
 		c.mu.Lock()
@@ -67,109 +51,32 @@ func (c *tidbCloudRBACCache) getCluster(cred tenant.CredentialProvisionRequest, 
 			delete(c.entries, key)
 		}
 		c.mu.Unlock()
-		return tenant.CloudClusterInfo{}, false
+		return tenant.TiDBCloudAPIKeyIdentity{}, false
 	}
-	return tenant.CloudClusterInfo{ClusterID: entry.clusterID, OrganizationID: entry.organizationID}, true
+	return entry.identity, true
 }
 
-func (c *tidbCloudRBACCache) getClusterList(cred tenant.CredentialProvisionRequest) ([]tenant.CloudClusterInfo, bool) {
-	if c == nil {
-		return nil, false
-	}
-	key := c.credentialKey(cred)
-	now := time.Now()
-	c.mu.RLock()
-	entry, ok := c.lists[key]
-	c.mu.RUnlock()
-	if !ok {
-		return nil, false
-	}
-	if now.After(entry.expiresAt) {
-		c.mu.Lock()
-		if current, currentOK := c.lists[key]; currentOK && now.After(current.expiresAt) {
-			delete(c.lists, key)
-		}
-		c.mu.Unlock()
-		return nil, false
-	}
-	out := make([]tenant.CloudClusterInfo, len(entry.clusters))
-	copy(out, entry.clusters)
-	return out, true
-}
-
-func (c *tidbCloudRBACCache) rememberCluster(cred tenant.CredentialProvisionRequest, cluster tenant.CloudClusterInfo) {
+func (c *tidbCloudRBACCache) rememberIdentity(cred tenant.CredentialProvisionRequest, identity tenant.TiDBCloudAPIKeyIdentity) {
 	if c == nil {
 		return
 	}
-	cluster.ClusterID = strings.TrimSpace(cluster.ClusterID)
-	if cluster.ClusterID == "" {
-		return
-	}
-	cluster.OrganizationID = strings.TrimSpace(cluster.OrganizationID)
-	key := c.entryKey(cred, cluster.ClusterID)
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.pruneLocked(time.Now())
-	c.entries[key] = tidbCloudRBACEntry{
-		clusterID:      cluster.ClusterID,
-		organizationID: cluster.OrganizationID,
-		expiresAt:      time.Now().Add(c.ttl),
-	}
-	c.enforceSizeLocked()
-}
-
-func (c *tidbCloudRBACCache) rememberClusterList(cred tenant.CredentialProvisionRequest, clusters []tenant.CloudClusterInfo) {
-	if c == nil {
+	identity.OrganizationID = strings.TrimSpace(identity.OrganizationID)
+	identity.Role = strings.TrimSpace(identity.Role)
+	if identity.OrganizationID == "" || identity.Role == "" {
 		return
 	}
 	now := time.Now()
-	expiresAt := now.Add(c.ttl)
-	seen := make(map[string]bool, len(clusters))
-	out := make([]tenant.CloudClusterInfo, 0, len(clusters))
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.pruneLocked(now)
-	for _, cluster := range clusters {
-		cluster.ClusterID = strings.TrimSpace(cluster.ClusterID)
-		if cluster.ClusterID == "" || seen[cluster.ClusterID] {
-			continue
-		}
-		cluster.OrganizationID = strings.TrimSpace(cluster.OrganizationID)
-		seen[cluster.ClusterID] = true
-		c.entries[c.entryKey(cred, cluster.ClusterID)] = tidbCloudRBACEntry{
-			clusterID:      cluster.ClusterID,
-			organizationID: cluster.OrganizationID,
-			expiresAt:      expiresAt,
-		}
-		out = append(out, tenant.CloudClusterInfo{ClusterID: cluster.ClusterID, OrganizationID: cluster.OrganizationID})
-	}
-	key := c.credentialKey(cred)
-	if len(out) == 0 {
-		delete(c.lists, key)
-		return
-	}
-	c.lists[key] = tidbCloudRBACListEntry{clusters: out, expiresAt: expiresAt}
+	c.entries[c.credentialKey(cred)] = tidbCloudRBACIdentityEntry{identity: identity, expiresAt: now.Add(c.ttl)}
 	c.enforceSizeLocked()
-}
-
-func (c *tidbCloudRBACCache) forgetClusterList(cred tenant.CredentialProvisionRequest) {
-	if c == nil {
-		return
-	}
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	delete(c.lists, c.credentialKey(cred))
 }
 
 func (c *tidbCloudRBACCache) pruneLocked(now time.Time) {
 	for key, entry := range c.entries {
 		if now.After(entry.expiresAt) {
 			delete(c.entries, key)
-		}
-	}
-	for key, entry := range c.lists {
-		if now.After(entry.expiresAt) {
-			delete(c.lists, key)
 		}
 	}
 }
@@ -181,19 +88,9 @@ func (c *tidbCloudRBACCache) enforceSizeLocked() {
 			break
 		}
 	}
-	for len(c.lists) > tidbCloudRBACCacheMaxLists {
-		for key := range c.lists {
-			delete(c.lists, key)
-			break
-		}
-	}
 }
 
 func (c *tidbCloudRBACCache) credentialKey(cred tenant.CredentialProvisionRequest) string {
 	sum := sha256.Sum256([]byte(strings.TrimSpace(cred.PublicKey) + "\x00" + strings.TrimSpace(cred.PrivateKey)))
 	return hex.EncodeToString(sum[:])
-}
-
-func (c *tidbCloudRBACCache) entryKey(cred tenant.CredentialProvisionRequest, clusterID string) string {
-	return c.credentialKey(cred) + "\x00" + strings.TrimSpace(clusterID)
 }

--- a/pkg/server/tidbcloud_rbac_cache_test.go
+++ b/pkg/server/tidbcloud_rbac_cache_test.go
@@ -7,32 +7,17 @@ import (
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
-func TestTiDBCloudRBACCacheDoesNotRetainEmptyListAndSupportsInvalidation(t *testing.T) {
+func TestTiDBCloudRBACCacheStoresOnlyCredentialIdentity(t *testing.T) {
 	cache := newTiDBCloudRBACCache(time.Hour)
 	cred := tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}
+	want := tenant.TiDBCloudAPIKeyIdentity{OrganizationID: "org-1", Role: tenant.TiDBCloudRoleOrgOwner}
 
-	cache.rememberClusterList(cred, nil)
-	if clusters, ok := cache.getClusterList(cred); ok {
-		t.Fatalf("empty list cache hit = %#v, want miss", clusters)
+	if got, ok := cache.getIdentity(cred); ok {
+		t.Fatalf("initial identity cache hit = %+v", got)
 	}
-
-	cache.rememberClusterList(cred, []tenant.CloudClusterInfo{{
-		ClusterID:      "cluster-1",
-		OrganizationID: "org-1",
-	}})
-	clusters, ok := cache.getClusterList(cred)
-	if !ok {
-		t.Fatal("list cache miss, want hit")
-	}
-	if len(clusters) != 1 || clusters[0].ClusterID != "cluster-1" || clusters[0].OrganizationID != "org-1" {
-		t.Fatalf("clusters = %#v", clusters)
-	}
-
-	cache.forgetClusterList(cred)
-	if clusters, ok := cache.getClusterList(cred); ok {
-		t.Fatalf("list cache hit after invalidation = %#v, want miss", clusters)
-	}
-	if cluster, ok := cache.getCluster(cred, "cluster-1"); !ok || cluster.OrganizationID != "org-1" {
-		t.Fatalf("cluster cache after list invalidation = %#v, %v; want cluster auth retained", cluster, ok)
+	cache.rememberIdentity(cred, want)
+	got, ok := cache.getIdentity(cred)
+	if !ok || got != want {
+		t.Fatalf("identity cache = %+v, ok=%v, want %+v", got, ok, want)
 	}
 }

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -11,6 +11,12 @@ var ErrCredentialsRequired = errors.New("public_key and private_key are required
 var ErrPartialCredentials = errors.New("both public_key and private_key must be provided together")
 var ErrQuotaPermissionDenied = errors.New("tidbcloud quota update permission denied")
 var ErrQuotaBackendNotFound = errors.New("tidbcloud quota backend not found")
+var ErrTiDBCloudRoleInsufficient = errors.New("tidbcloud API key role has insufficient permission")
+
+const (
+	TiDBCloudRoleOrgOwner     = "org:owner"
+	TiDBCloudRoleProjectOwner = "project:owner"
+)
 
 type ClusterInfo struct {
 	TenantID       string
@@ -41,6 +47,19 @@ type Deprovisioner interface {
 type CredentialProvisionRequest struct {
 	PublicKey  string
 	PrivateKey string
+}
+
+type TiDBCloudAPIKeyIdentity struct {
+	OrganizationID string
+	Role           string
+}
+
+type TiDBCloudAPIKeyIdentityResolver interface {
+	ResolveAPIKeyIdentity(ctx context.Context, req CredentialProvisionRequest) (*TiDBCloudAPIKeyIdentity, error)
+}
+
+type SharedCredentialProvider interface {
+	DefaultSharedCredentials() (CredentialProvisionRequest, bool)
 }
 
 type QuotaCloudConfig struct {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"math/big"
 	"net"
 	"net/http"
@@ -27,7 +28,6 @@ import (
 	mysql "github.com/go-sql-driver/mysql"
 	"github.com/google/uuid"
 	"github.com/mem9-ai/drive9/pkg/logger"
-	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/tenant/schema"
@@ -1580,7 +1580,7 @@ func validateTiDBCloudSpendingLimit(monthly int64) error {
 	if monthly > 0 && monthly < 10 {
 		return fmt.Errorf("tidbcloud_spending_limit must be 0 or at least 10 RMB")
 	}
-	if monthly > meta.MaxTiDBCloudSpendingLimit {
+	if monthly > int64(math.MaxInt32) {
 		return fmt.Errorf("tidbcloud_spending_limit is too large")
 	}
 	return nil

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -36,12 +36,15 @@ import (
 
 const (
 	EnvTiDBCloudNativeAPIURL                  = "DRIVE9_TIDBCLOUD_NATIVE_API_URL"
+	EnvTiDBCloudIAMAPIURL                     = "DRIVE9_TIDBCLOUD_IAM_API_URL"
 	EnvTiDBCloudNativeCloudProvider           = "DRIVE9_TIDBCLOUD_NATIVE_CLOUD_PROVIDER"
 	EnvTiDBCloudNativeRegion                  = "DRIVE9_TIDBCLOUD_NATIVE_REGION"
 	EnvTiDBCloudNativeDefaultDatabaseName     = "DRIVE9_TIDBCLOUD_NATIVE_DEFAULT_DATABASE_NAME"
 	EnvTiDBCloudDefaultSpendingLimit          = "DRIVE9_TIDBCLOUD_DEFAULT_SPENDING_LIMIT"
 	EnvTiDBCloudNativePublicKey               = "DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY"
 	EnvTiDBCloudNativePrivateKey              = "DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY"
+	EnvTiDBCloudNativeSharedPublicKey         = "DRIVE9_TIDBCLOUD_NATIVE_SHARED_PUBLIC_KEY"
+	EnvTiDBCloudNativeSharedPrivateKey        = "DRIVE9_TIDBCLOUD_NATIVE_SHARED_PRIVATE_KEY"
 	EnvTiDBCloudNativeUsePrivateEndpoint      = "DRIVE9_TIDBCLOUD_NATIVE_USE_PRIVATE_ENDPOINT"
 	EnvTiDBCloudPrivateEndpointHostMap        = "DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP"
 	EnvTiDBCloudTencentPrivateEndpointHost    = "DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST"
@@ -89,12 +92,15 @@ var (
 
 type Provisioner struct {
 	apiURL                      string
+	iamURL                      string
 	cloudProvider               string
 	region                      string
 	defaultDatabaseName         string
 	defaultSpendLimit           *int32
 	defaultPublicKey            string
 	defaultPrivateKey           string
+	defaultSharedPublicKey      string
+	defaultSharedPrivateKey     string
 	usePrivateEndpoint          bool
 	privateEndpointHostMap      map[string]string
 	tencentPrivateEndpointHost  string
@@ -102,8 +108,9 @@ type Provisioner struct {
 	client                      *http.Client
 }
 
-func NewProvisionerFromEnv() (*Provisioner, error) {
+func NewProvisionerFromEnv(providerType string) (*Provisioner, error) {
 	apiURL := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeAPIURL))
+	iamURL := strings.TrimSpace(os.Getenv(EnvTiDBCloudIAMAPIURL))
 	cloudProvider := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeCloudProvider))
 	region := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeRegion))
 	defaultDB := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeDefaultDatabaseName))
@@ -114,12 +121,21 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 	if defaultDB == "" {
 		defaultDB = DefaultDatabaseName
 	}
-	if apiURL == "" || cloudProvider == "" || region == "" {
-		return nil, fmt.Errorf("%s, %s and %s are required", EnvTiDBCloudNativeAPIURL, EnvTiDBCloudNativeCloudProvider, EnvTiDBCloudNativeRegion)
+	if apiURL == "" || iamURL == "" || cloudProvider == "" || region == "" {
+		return nil, fmt.Errorf("%s, %s, %s and %s are required", EnvTiDBCloudNativeAPIURL, EnvTiDBCloudIAMAPIURL, EnvTiDBCloudNativeCloudProvider, EnvTiDBCloudNativeRegion)
 	}
 	parsedAPIURL, err := url.Parse(apiURL)
 	if err != nil || parsedAPIURL.Scheme != "https" || parsedAPIURL.Host == "" {
 		return nil, fmt.Errorf("%s must be a valid https URL", EnvTiDBCloudNativeAPIURL)
+	}
+	parsedIAMURL, err := url.Parse(iamURL)
+	if err != nil || parsedIAMURL.Scheme != "https" || parsedIAMURL.Host == "" {
+		return nil, fmt.Errorf("%s must be a valid https URL", EnvTiDBCloudIAMAPIURL)
+	}
+	sharedPublicKey := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeSharedPublicKey))
+	sharedPrivateKey := strings.TrimSpace(os.Getenv(EnvTiDBCloudNativeSharedPrivateKey))
+	if providerType == tenant.ProviderTiDBCloudNativeShared && (sharedPublicKey == "" || sharedPrivateKey == "") {
+		return nil, fmt.Errorf("%s and %s are required for %s", EnvTiDBCloudNativeSharedPublicKey, EnvTiDBCloudNativeSharedPrivateKey, tenant.ProviderTiDBCloudNativeShared)
 	}
 	if _, err := normalizeDatabaseName(defaultDB); err != nil {
 		return nil, fmt.Errorf("invalid %s: %w", EnvTiDBCloudNativeDefaultDatabaseName, err)
@@ -136,12 +152,15 @@ func NewProvisionerFromEnv() (*Provisioner, error) {
 	}
 	return &Provisioner{
 		apiURL:                      strings.TrimRight(apiURL, "/"),
+		iamURL:                      strings.TrimRight(iamURL, "/"),
 		cloudProvider:               cloudProvider,
 		region:                      region,
 		defaultDatabaseName:         defaultDB,
 		defaultSpendLimit:           defaultSpendLimit,
 		defaultPublicKey:            strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePublicKey)),
 		defaultPrivateKey:           strings.TrimSpace(os.Getenv(EnvTiDBCloudNativePrivateKey)),
+		defaultSharedPublicKey:      sharedPublicKey,
+		defaultSharedPrivateKey:     sharedPrivateKey,
 		usePrivateEndpoint:          usePrivate,
 		privateEndpointHostMap:      hostMap,
 		tencentPrivateEndpointHost:  tencentPrivateHost,
@@ -162,6 +181,56 @@ func (p *Provisioner) DefaultCredentials() (tenant.CredentialProvisionRequest, b
 		PublicKey:  p.defaultPublicKey,
 		PrivateKey: p.defaultPrivateKey,
 	}, true
+}
+
+func (p *Provisioner) DefaultSharedCredentials() (tenant.CredentialProvisionRequest, bool) {
+	if p.defaultSharedPublicKey == "" || p.defaultSharedPrivateKey == "" {
+		return tenant.CredentialProvisionRequest{}, false
+	}
+	return tenant.CredentialProvisionRequest{
+		PublicKey: p.defaultSharedPublicKey, PrivateKey: p.defaultSharedPrivateKey,
+	}, true
+}
+
+func (p *Provisioner) ResolveAPIKeyIdentity(ctx context.Context, req tenant.CredentialProvisionRequest) (*tenant.TiDBCloudAPIKeyIdentity, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, tenant.ErrCredentialsRequired
+	}
+	endpoint := fmt.Sprintf("%s/v1beta1/apikeys/%s", p.iamURL, url.PathEscape(publicKey))
+	resp, err := p.doDigestAuthRequest(ctx, publicKey, privateKey, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		_, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
+		if readErr != nil {
+			return nil, readErr
+		}
+		return nil, fmt.Errorf("%s", statusError("IAM API key lookup", resp.StatusCode, ""))
+	}
+	var info struct {
+		Name      string `json:"name"`
+		AccessKey string `json:"accessKey"`
+		Role      string `json:"role"`
+	}
+	if err := json.NewDecoder(io.LimitReader(resp.Body, upstreamClusterBodyLimit)).Decode(&info); err != nil {
+		return nil, fmt.Errorf("decode IAM API key response: %w", err)
+	}
+	if strings.TrimSpace(info.AccessKey) != publicKey {
+		return nil, fmt.Errorf("IAM API key response does not match request credentials")
+	}
+	parts := strings.Split(strings.Trim(strings.TrimSpace(info.Name), "/"), "/")
+	if len(parts) < 2 || parts[0] != "orgs" || strings.TrimSpace(parts[1]) == "" {
+		return nil, fmt.Errorf("IAM API key response is missing organization")
+	}
+	role := strings.TrimSpace(info.Role)
+	if role != tenant.TiDBCloudRoleOrgOwner && role != tenant.TiDBCloudRoleProjectOwner {
+		return nil, fmt.Errorf("%w: role %q; org:owner or project:owner is required", tenant.ErrTiDBCloudRoleInsufficient, role)
+	}
+	return &tenant.TiDBCloudAPIKeyIdentity{OrganizationID: strings.TrimSpace(parts[1]), Role: role}, nil
 }
 
 func (p *Provisioner) ProvisioningRegion() string { return p.region }
@@ -532,7 +601,7 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 		inputsByUUID[poolUUID] = input
 		databaseNames[poolUUID] = dbName
 		requests = append(requests, map[string]any{"cluster": map[string]any{
-			"displayName":  clusterDisplayName(poolUUID),
+			"displayName":  sharedDBPoolDisplayName(poolUUID),
 			"rootPassword": password,
 			"region":       map[string]string{"name": p.regionName()},
 			"labels": map[string]string{
@@ -1604,6 +1673,15 @@ func clusterDisplayName(tenantID string) string {
 	return strings.TrimRight(name, "-")
 }
 
+func sharedDBPoolDisplayName(poolUUID string) string {
+	const maxDisplayNameLen = 64
+	name := displayNameCharPattern.ReplaceAllString("fs-shared-pool-"+poolUUID, "-")
+	if len(name) <= maxDisplayNameLen {
+		return name
+	}
+	return strings.TrimRight(name[:maxDisplayNameLen], "-")
+}
+
 func (p *Provisioner) resolveDatabaseName(raw string) (string, error) {
 	name := strings.TrimSpace(raw)
 	if name == "" {
@@ -2387,6 +2465,10 @@ func requestPath(uri string) string {
 	u, err := url.Parse(uri)
 	if err != nil {
 		return uri
+	}
+	const iamAPIKeyPath = "/v1beta1/apikeys/"
+	if strings.HasPrefix(u.Path, iamAPIKeyPath) {
+		return iamAPIKeyPath + "***"
 	}
 	return u.Path
 }

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -192,6 +192,20 @@ func (p *Provisioner) DefaultSharedCredentials() (tenant.CredentialProvisionRequ
 	}, true
 }
 
+// ValidateSharedCredentials verifies the server-owned shared credential once
+// during startup. Shared credentials are independent from customer IAM
+// authorization and are never placed in the server's customer RBAC cache.
+func (p *Provisioner) ValidateSharedCredentials(ctx context.Context) error {
+	cred, ok := p.DefaultSharedCredentials()
+	if !ok {
+		return fmt.Errorf("shared TiDB Cloud credentials are not configured")
+	}
+	if _, err := p.ResolveAPIKeyIdentity(ctx, cred); err != nil {
+		return fmt.Errorf("validate shared TiDB Cloud credentials: %w", err)
+	}
+	return nil
+}
+
 func (p *Provisioner) ResolveAPIKeyIdentity(ctx context.Context, req tenant.CredentialProvisionRequest) (*tenant.TiDBCloudAPIKeyIdentity, error) {
 	publicKey := strings.TrimSpace(req.PublicKey)
 	privateKey := strings.TrimSpace(req.PrivateKey)

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -2409,6 +2409,7 @@ func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privat
 	start := time.Now()
 	resp, err := p.client.Do(req)
 	if err != nil {
+		err = redactRequestError(err, uri)
 		logger.Error(ctx, "tidbcloud_api_request",
 			zap.String("method", method),
 			zap.String("path", requestPath(uri)),
@@ -2445,6 +2446,7 @@ func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privat
 	start2 := time.Now()
 	resp2, err := p.client.Do(req2)
 	if err != nil {
+		err = redactRequestError(err, uri)
 		logger.Error(ctx, "tidbcloud_api_request",
 			zap.String("method", method),
 			zap.String("path", requestPath(uri)),
@@ -2459,6 +2461,14 @@ func (p *Provisioner) doDigestAuthRequest(ctx context.Context, publicKey, privat
 		zap.Int("status", resp2.StatusCode),
 		zap.Int64("duration_ms", time.Since(start2).Milliseconds()))
 	return resp2, nil
+}
+
+func redactRequestError(err error, uri string) error {
+	var urlErr *url.Error
+	if !errors.As(err, &urlErr) {
+		return err
+	}
+	return &url.Error{Op: urlErr.Op, URL: requestPath(uri), Err: urlErr.Err}
 }
 
 func requestPath(uri string) string {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -129,6 +129,52 @@ func TestResolveAPIKeyIdentityUsesIAMAPI(t *testing.T) {
 	}
 }
 
+func TestValidateSharedCredentialsUsesConfiguredKeyAtStartup(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		role    string
+		wantErr bool
+	}{
+		{name: "organization owner", role: tenant.TiDBCloudRoleOrgOwner},
+		{name: "project owner", role: tenant.TiDBCloudRoleProjectOwner},
+		{name: "viewer rejected", role: "org:viewer", wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotPath string
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Authorization") == "" {
+					w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-shared-startup", qop="auth"`)
+					w.WriteHeader(http.StatusUnauthorized)
+					return
+				}
+				gotPath = r.URL.Path
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"name": "orgs/1234567890123456789/apiKeys/111111", "accessKey": "SHAREDOWNER1", "role": tc.role,
+				})
+			}))
+			defer ts.Close()
+
+			p := &Provisioner{
+				iamURL: ts.URL, client: ts.Client(),
+				defaultSharedPublicKey: "SHAREDOWNER1", defaultSharedPrivateKey: "test-shared-private",
+			}
+			err := p.ValidateSharedCredentials(context.Background())
+			if tc.wantErr {
+				if !errors.Is(err, tenant.ErrTiDBCloudRoleInsufficient) {
+					t.Errorf("ValidateSharedCredentials error = %v, want insufficient role", err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ValidateSharedCredentials: %v", err)
+			}
+			if gotPath != "/v1beta1/apikeys/SHAREDOWNER1" {
+				t.Errorf("IAM path = %q, want configured shared key", gotPath)
+			}
+		})
+	}
+}
+
 func TestResolveAPIKeyIdentityRejectsInsufficientRole(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") == "" {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -112,10 +112,10 @@ func TestResolveAPIKeyIdentityUsesIAMAPI(t *testing.T) {
 		t.Fatalf("ResolveAPIKeyIdentity: %v", err)
 	}
 	if gotPath != "/v1beta1/apikeys/PROJECTOWNER1" || !strings.Contains(gotAuth, `username="PROJECTOWNER1"`) {
-		t.Fatalf("request path/auth = %q / %q", gotPath, gotAuth)
+		t.Errorf("request path/auth = %q / %q", gotPath, gotAuth)
 	}
 	if identity.OrganizationID != "1234567890123456789" || identity.Role != tenant.TiDBCloudRoleProjectOwner {
-		t.Fatalf("identity = %+v", identity)
+		t.Errorf("identity = %+v", identity)
 	}
 	loggedTrace := false
 	for _, entry := range recorded.AllUntimed() {
@@ -125,7 +125,7 @@ func TestResolveAPIKeyIdentityUsesIAMAPI(t *testing.T) {
 		}
 	}
 	if !loggedTrace {
-		t.Fatalf("IAM success access log missing trace_id %q", wantTraceID)
+		t.Errorf("IAM success access log missing trace_id %q", wantTraceID)
 	}
 }
 
@@ -294,10 +294,10 @@ func TestResolveAPIKeyIdentityRedactsAccessKeyFromTransportErrorsAndLogs(t *test
 		PublicKey: accessKey, PrivateKey: "test-private",
 	})
 	if !errors.Is(err, transportErr) {
-		t.Fatalf("error = %v, want transport error", err)
+		t.Errorf("error = %v, want transport error", err)
 	}
-	if strings.Contains(err.Error(), accessKey) {
-		t.Fatalf("returned error leaked IAM access key: %v", err)
+	if err != nil && strings.Contains(err.Error(), accessKey) {
+		t.Errorf("returned error leaked IAM access key: %v", err)
 	}
 	entries := recorded.AllUntimed()
 	if len(entries) == 0 {
@@ -305,10 +305,10 @@ func TestResolveAPIKeyIdentityRedactsAccessKeyFromTransportErrorsAndLogs(t *test
 	}
 	for _, entry := range entries {
 		if strings.Contains(fmt.Sprint(entry.ContextMap()), accessKey) {
-			t.Fatalf("log entry leaked IAM access key: %+v", entry.ContextMap())
+			t.Errorf("log entry leaked IAM access key: %+v", entry.ContextMap())
 		}
 		if got := entry.ContextMap()["trace_id"]; got != wantTraceID {
-			t.Fatalf("IAM log trace_id = %v, want %q", got, wantTraceID)
+			t.Errorf("IAM log trace_id = %v, want %q", got, wantTraceID)
 		}
 	}
 }

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
@@ -1828,7 +1829,7 @@ func TestMarkQuotaUpdateStartedMergesDrive9Labels(t *testing.T) {
 }
 
 func TestUpdateQuotaPatchesSpendingLimitWithoutLabels(t *testing.T) {
-	monthly := int64(0)
+	monthly := int64(2_000_000)
 	var patchCalls int
 	var gotSpendingPatch struct {
 		Cluster struct {
@@ -1953,7 +1954,7 @@ func TestUpdateQuotaRejectsInvalidSpendingLimitBeforeRequest(t *testing.T) {
 		wantErr string
 	}{
 		{name: "negative", monthly: -1, wantErr: "tidbcloud_spending_limit must be non-negative"},
-		{name: "above cloud maximum", monthly: 1_000_001, wantErr: "tidbcloud_spending_limit is too large"},
+		{name: "above wire maximum", monthly: int64(math.MaxInt32) + 1, wantErr: "tidbcloud_spending_limit is too large"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			var hit bool

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -17,7 +17,242 @@ import (
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
 
+func setRequiredNativeProvisionerEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+}
+
+func TestNewProvisionerFromEnvRequiresIAMURLForNative(t *testing.T) {
+	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
+	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
+	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "")
+
+	_, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
+	if err == nil || !strings.Contains(err.Error(), EnvTiDBCloudIAMAPIURL) {
+		t.Fatalf("error = %v, want missing %s", err, EnvTiDBCloudIAMAPIURL)
+	}
+}
+
+func TestNewProvisionerFromEnvRequiresSharedCredentialsForSharedProvider(t *testing.T) {
+	setRequiredNativeProvisionerEnv(t)
+	t.Setenv(EnvTiDBCloudNativeSharedPublicKey, "")
+	t.Setenv(EnvTiDBCloudNativeSharedPrivateKey, "")
+
+	_, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNativeShared)
+	if err == nil || !strings.Contains(err.Error(), EnvTiDBCloudNativeSharedPublicKey) || !strings.Contains(err.Error(), EnvTiDBCloudNativeSharedPrivateKey) {
+		t.Fatalf("error = %v, want missing shared credential names", err)
+	}
+}
+
+func TestNewProvisionerFromEnvKeepsNativeDefaultsSeparateFromSharedCredentials(t *testing.T) {
+	setRequiredNativeProvisionerEnv(t)
+	t.Setenv(EnvTiDBCloudNativePublicKey, "native-public")
+	t.Setenv(EnvTiDBCloudNativePrivateKey, "native-private")
+	t.Setenv(EnvTiDBCloudNativeSharedPublicKey, "shared-public")
+	t.Setenv(EnvTiDBCloudNativeSharedPrivateKey, "shared-private")
+
+	p, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNativeShared)
+	if err != nil {
+		t.Fatalf("NewProvisionerFromEnv: %v", err)
+	}
+	defaults, ok := p.DefaultCredentials()
+	if !ok || defaults.PublicKey != "native-public" || defaults.PrivateKey != "native-private" {
+		t.Fatalf("native defaults = %+v, ok=%v", defaults, ok)
+	}
+	shared, ok := p.DefaultSharedCredentials()
+	if !ok || shared.PublicKey != "shared-public" || shared.PrivateKey != "shared-private" {
+		t.Fatalf("shared defaults = %+v, ok=%v", shared, ok)
+	}
+}
+
+func TestResolveAPIKeyIdentityUsesIAMAPI(t *testing.T) {
+	var gotPath, gotAuth string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-iam", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		gotPath = r.URL.Path
+		gotAuth = r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name":        "orgs/1234567890123456789/projects/9876543210987654321/apiKeys/111111",
+			"accessKey":   "PROJECTOWNER1",
+			"secretKey":   "************************SENSITIVE_PROJECT_SUFFIX",
+			"displayName": "fixture-project-owner",
+			"role":        "project:owner",
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{iamURL: ts.URL, client: ts.Client()}
+	identity, err := p.ResolveAPIKeyIdentity(context.Background(), tenant.CredentialProvisionRequest{
+		PublicKey: "PROJECTOWNER1", PrivateKey: "test-private",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAPIKeyIdentity: %v", err)
+	}
+	if gotPath != "/v1beta1/apikeys/PROJECTOWNER1" || !strings.Contains(gotAuth, `username="PROJECTOWNER1"`) {
+		t.Fatalf("request path/auth = %q / %q", gotPath, gotAuth)
+	}
+	if identity.OrganizationID != "1234567890123456789" || identity.Role != tenant.TiDBCloudRoleProjectOwner {
+		t.Fatalf("identity = %+v", identity)
+	}
+}
+
+func TestResolveAPIKeyIdentityRejectsInsufficientRole(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-iam", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name":      "orgs/1234567890123456789/apiKeys/222222",
+			"accessKey": "VIEWER1",
+			"secretKey": "************************SENSITIVE_VIEWER_SUFFIX",
+			"role":      "org:viewer",
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{iamURL: ts.URL, client: ts.Client()}
+	_, err := p.ResolveAPIKeyIdentity(context.Background(), tenant.CredentialProvisionRequest{
+		PublicKey: "VIEWER1", PrivateKey: "test-private",
+	})
+	if !errors.Is(err, tenant.ErrTiDBCloudRoleInsufficient) || !strings.Contains(err.Error(), "org:viewer") {
+		t.Fatalf("error = %v, want insufficient-role error", err)
+	}
+	if strings.Contains(err.Error(), "SENSITIVE_VIEWER_SUFFIX") || strings.Contains(err.Error(), "test-private") {
+		t.Fatalf("error leaked secret material: %v", err)
+	}
+}
+
+func TestResolveAPIKeyIdentityAcceptsOrganizationOwnerResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-org-owner", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name":        "orgs/1234567890123456789/apiKeys/222222",
+			"accessKey":   "ORGOWNER1",
+			"secretKey":   "************************SENSITIVE_ORG_SUFFIX",
+			"displayName": "fixture-org-owner",
+			"role":        "org:owner",
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{iamURL: ts.URL, client: ts.Client()}
+	identity, err := p.ResolveAPIKeyIdentity(context.Background(), tenant.CredentialProvisionRequest{
+		PublicKey: "ORGOWNER1", PrivateKey: "test-private",
+	})
+	if err != nil {
+		t.Fatalf("ResolveAPIKeyIdentity: %v", err)
+	}
+	if identity.OrganizationID != "1234567890123456789" || identity.Role != tenant.TiDBCloudRoleOrgOwner {
+		t.Fatalf("identity = %+v", identity)
+	}
+	if strings.Contains(fmt.Sprintf("%+v", identity), "SENSITIVE_ORG_SUFFIX") || strings.Contains(fmt.Sprintf("%+v", identity), "fixture-org-owner") {
+		t.Fatalf("identity retained sensitive IAM response fields: %+v", identity)
+	}
+}
+
+func TestResolveAPIKeyIdentityDoesNotExposeAccessKeysOnMismatch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-mismatch", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name":      "orgs/1234567890123456789/apiKeys/333333",
+			"accessKey": "UNEXPECTEDKEY1",
+			"role":      "org:owner",
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{iamURL: ts.URL, client: ts.Client()}
+	_, err := p.ResolveAPIKeyIdentity(context.Background(), tenant.CredentialProvisionRequest{
+		PublicKey: "REQUESTEDKEY1", PrivateKey: "test-private",
+	})
+	if err == nil {
+		t.Fatal("expected access-key mismatch error")
+	}
+	for _, sensitive := range []string{"UNEXPECTEDKEY1", "REQUESTEDKEY1", "test-private"} {
+		if strings.Contains(err.Error(), sensitive) {
+			t.Fatalf("error leaked credential %q: %v", sensitive, err)
+		}
+	}
+}
+
+func TestResolveAPIKeyIdentityDoesNotExposeIAMErrorBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-error", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"accessKey":"RESPONSEKEY1","secretKey":"SENSITIVE_SECRET","displayName":"SENSITIVE_DISPLAY"}`))
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{iamURL: ts.URL, client: ts.Client()}
+	_, err := p.ResolveAPIKeyIdentity(context.Background(), tenant.CredentialProvisionRequest{
+		PublicKey: "REQUESTKEY1", PrivateKey: "request-private",
+	})
+	if err == nil {
+		t.Fatal("expected IAM status error")
+	}
+	for _, sensitive := range []string{"RESPONSEKEY1", "SENSITIVE_SECRET", "SENSITIVE_DISPLAY", "REQUESTKEY1", "request-private"} {
+		if strings.Contains(err.Error(), sensitive) {
+			t.Fatalf("error leaked IAM response material %q: %v", sensitive, err)
+		}
+	}
+}
+
+func TestResolveAPIKeyIdentityDoesNotExposeMalformedResourceName(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-name", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "SENSITIVE_MALFORMED_RESOURCE", "accessKey": "NAMEFIXTURE1", "role": "org:owner",
+		})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{iamURL: ts.URL, client: ts.Client()}
+	_, err := p.ResolveAPIKeyIdentity(context.Background(), tenant.CredentialProvisionRequest{
+		PublicKey: "NAMEFIXTURE1", PrivateKey: "request-private",
+	})
+	if err == nil {
+		t.Fatal("expected malformed resource-name error")
+	}
+	if strings.Contains(err.Error(), "SENSITIVE_MALFORMED_RESOURCE") || strings.Contains(err.Error(), "NAMEFIXTURE1") || strings.Contains(err.Error(), "request-private") {
+		t.Fatalf("error leaked IAM resource data: %v", err)
+	}
+}
+
+func TestRequestPathRedactsIAMAccessKey(t *testing.T) {
+	got := requestPath("https://iam.tidbapi.com/v1beta1/apikeys/PROJECTOWNER1")
+	if got != "/v1beta1/apikeys/***" {
+		t.Fatalf("request path = %q, want redacted IAM access key", got)
+	}
+}
+
 func TestNewProvisionerFromEnvReadsServerSideConfigOnly(t *testing.T) {
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
 	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
@@ -26,7 +261,7 @@ func TestNewProvisionerFromEnvReadsServerSideConfigOnly(t *testing.T) {
 	t.Setenv("DRIVE9_TIDBCLOUD_NATIVE_PUBLIC_KEY", "must-not-be-read")
 	t.Setenv("DRIVE9_TIDBCLOUD_NATIVE_PRIVATE_KEY", "must-not-be-read")
 
-	p, err := NewProvisionerFromEnv()
+	p, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err != nil {
 		t.Fatalf("NewProvisionerFromEnv: %v", err)
 	}
@@ -45,12 +280,13 @@ func TestNewProvisionerFromEnvReadsServerSideConfigOnly(t *testing.T) {
 }
 
 func TestNewProvisionerFromEnvUsesBuiltinDefaultSpendingLimit(t *testing.T) {
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
 	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
 	t.Setenv(EnvTiDBCloudDefaultSpendingLimit, "")
 
-	p, err := NewProvisionerFromEnv()
+	p, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err != nil {
 		t.Fatalf("NewProvisionerFromEnv: %v", err)
 	}
@@ -60,12 +296,13 @@ func TestNewProvisionerFromEnvUsesBuiltinDefaultSpendingLimit(t *testing.T) {
 }
 
 func TestNewProvisionerFromEnvRejectsTooSmallDefaultSpendingLimit(t *testing.T) {
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
 	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
 	t.Setenv(EnvTiDBCloudDefaultSpendingLimit, "5")
 
-	_, err := NewProvisionerFromEnv()
+	_, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err == nil {
 		t.Fatal("expected invalid default spending limit error")
 	}
@@ -78,11 +315,12 @@ func TestNewProvisionerFromEnvRejectsTooSmallDefaultSpendingLimit(t *testing.T) 
 }
 
 func TestNewProvisionerFromEnvRequiresCloudProviderAndRegion(t *testing.T) {
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "")
 	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
 
-	_, err := NewProvisionerFromEnv()
+	_, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err == nil {
 		t.Fatal("expected missing cloud provider error")
 	}
@@ -92,11 +330,12 @@ func TestNewProvisionerFromEnvRequiresCloudProviderAndRegion(t *testing.T) {
 }
 
 func TestNewProvisionerFromEnvRejectsNonHTTPSAPIURL(t *testing.T) {
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "http://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
 	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
 
-	_, err := NewProvisionerFromEnv()
+	_, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err == nil {
 		t.Fatal("expected invalid api URL error")
 	}
@@ -106,12 +345,13 @@ func TestNewProvisionerFromEnvRejectsNonHTTPSAPIURL(t *testing.T) {
 }
 
 func TestNewProvisionerFromEnvRejectsInvalidDefaultDatabaseName(t *testing.T) {
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
 	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
 	t.Setenv(EnvTiDBCloudNativeDefaultDatabaseName, "test")
 
-	_, err := NewProvisionerFromEnv()
+	_, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err == nil {
 		t.Fatal("expected invalid database name error")
 	}
@@ -121,12 +361,13 @@ func TestNewProvisionerFromEnvRejectsInvalidDefaultDatabaseName(t *testing.T) {
 }
 
 func TestNewProvisionerFromEnvRejectsInvalidDefaultSpendingLimit(t *testing.T) {
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
 	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
 	t.Setenv(EnvTiDBCloudDefaultSpendingLimit, "-1")
 
-	_, err := NewProvisionerFromEnv()
+	_, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err == nil {
 		t.Fatal("expected invalid default spending limit error")
 	}
@@ -468,7 +709,7 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 	}
 	for i, request := range gotBody.Requests {
 		id := fmt.Sprintf("%d", 41+i)
-		if request.Cluster.DisplayName != "tidbcloud-fs-"+poolUUIDs[i] {
+		if request.Cluster.DisplayName != "fs-shared-pool-"+poolUUIDs[i] {
 			t.Fatalf("request %d displayName = %q", i, request.Cluster.DisplayName)
 		}
 		if request.Cluster.RootPassword != "durable-password-"+id || request.Cluster.SpendingLimit.Monthly != 1_000_000 {
@@ -1929,12 +2170,13 @@ func TestWaitForBranchUserWithCredentialsUsesUserPrefix(t *testing.T) {
 }
 
 func TestNewProvisionerFromEnvReadsPrivateEndpointFlag(t *testing.T) {
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
 	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
 
 	defaultUse := false
-	p, err := NewProvisionerFromEnv()
+	p, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err != nil {
 		t.Fatalf("NewProvisionerFromEnv: %v", err)
 	}
@@ -1943,7 +2185,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointFlag(t *testing.T) {
 	}
 
 	t.Setenv(EnvTiDBCloudNativeUsePrivateEndpoint, "true")
-	p, err = NewProvisionerFromEnv()
+	p, err = NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err != nil {
 		t.Fatalf("NewProvisionerFromEnv with true: %v", err)
 	}
@@ -1952,7 +2194,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointFlag(t *testing.T) {
 	}
 
 	t.Setenv(EnvTiDBCloudNativeUsePrivateEndpoint, "1")
-	p, err = NewProvisionerFromEnv()
+	p, err = NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err != nil {
 		t.Fatalf("NewProvisionerFromEnv with 1: %v", err)
 	}
@@ -1961,7 +2203,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointFlag(t *testing.T) {
 	}
 
 	t.Setenv(EnvTiDBCloudNativeUsePrivateEndpoint, "no")
-	p, err = NewProvisionerFromEnv()
+	p, err = NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 	if err != nil {
 		t.Fatalf("NewProvisionerFromEnv with no: %v", err)
 	}
@@ -1971,13 +2213,14 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointFlag(t *testing.T) {
 }
 
 func TestNewProvisionerFromEnvRejectsMalformedPrivateEndpointFlag(t *testing.T) {
+	t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 	t.Setenv(EnvTiDBCloudNativeCloudProvider, "aws")
 	t.Setenv(EnvTiDBCloudNativeRegion, "us-east-1")
 
 	for _, v := range []string{"on", "Y", "ture", "enabled", "2", "enable"} {
 		t.Setenv(EnvTiDBCloudNativeUsePrivateEndpoint, v)
-		_, err := NewProvisionerFromEnv()
+		_, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 		if err == nil {
 			t.Fatalf("expected error for %q, got nil", v)
 		}
@@ -1987,6 +2230,7 @@ func TestNewProvisionerFromEnvRejectsMalformedPrivateEndpointFlag(t *testing.T) 
 func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	setPrivateEnv := func(t *testing.T, provider string) {
 		t.Helper()
+		t.Setenv(EnvTiDBCloudIAMAPIURL, "https://iam.tidbapi.com")
 		t.Setenv(EnvTiDBCloudNativeAPIURL, "https://serverless.tidbapi.com")
 		t.Setenv(EnvTiDBCloudNativeCloudProvider, provider)
 		t.Setenv(EnvTiDBCloudNativeRegion, "ap-southeast-1")
@@ -1998,7 +2242,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 
 	t.Run("alicloud no startup override required", func(t *testing.T) {
 		setPrivateEnv(t, "alicloud")
-		p, err := NewProvisionerFromEnv()
+		p, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 		if err != nil {
 			t.Fatalf("NewProvisionerFromEnv without alicloud host override: %v", err)
 		}
@@ -2010,7 +2254,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	t.Run("alicloud legacy domain fallback", func(t *testing.T) {
 		setPrivateEnv(t, "alicloud")
 		t.Setenv(EnvTiDBCloudAlicloudPrivateEndpointDomain, "alicloud.internal")
-		p, err := NewProvisionerFromEnv()
+		p, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 		if err != nil {
 			t.Fatalf("NewProvisionerFromEnv with alicloud domain: %v", err)
 		}
@@ -2021,7 +2265,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 
 	t.Run("tencentcloud no startup override required", func(t *testing.T) {
 		setPrivateEnv(t, "tencentcloud")
-		p, err := NewProvisionerFromEnv()
+		p, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 		if err != nil {
 			t.Fatalf("NewProvisionerFromEnv without tencentcloud host override: %v", err)
 		}
@@ -2033,7 +2277,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	t.Run("tencentcloud legacy host fallback", func(t *testing.T) {
 		setPrivateEnv(t, "tencentcloud")
 		t.Setenv(EnvTiDBCloudTencentPrivateEndpointHost, "tencent.internal")
-		p, err := NewProvisionerFromEnv()
+		p, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 		if err != nil {
 			t.Fatalf("NewProvisionerFromEnv with tencentcloud host: %v", err)
 		}
@@ -2044,7 +2288,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 
 	t.Run("aws no override required", func(t *testing.T) {
 		setPrivateEnv(t, "aws")
-		p, err := NewProvisionerFromEnv()
+		p, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 		if err != nil {
 			t.Fatalf("NewProvisionerFromEnv with aws and no override: %v", err)
 		}
@@ -2056,7 +2300,7 @@ func TestNewProvisionerFromEnvReadsPrivateEndpointHostMap(t *testing.T) {
 	t.Run("host map", func(t *testing.T) {
 		setPrivateEnv(t, "tencentcloud")
 		t.Setenv(EnvTiDBCloudPrivateEndpointHostMap, "public-a.example=private-a.internal, public-b.example:private-b.internal")
-		p, err := NewProvisionerFromEnv()
+		p, err := NewProvisionerFromEnv(tenant.ProviderTiDBCloudNative)
 		if err != nil {
 			t.Fatalf("NewProvisionerFromEnv with host map: %v", err)
 		}

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -14,8 +14,19 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/tenant"
+	"github.com/mem9-ai/drive9/pkg/traceid"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
 
 func setRequiredNativeProvisionerEnv(t *testing.T) {
 	t.Helper()
@@ -89,8 +100,12 @@ func TestResolveAPIKeyIdentityUsesIAMAPI(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	wantTraceID := "iam-success-trace"
+	core, recorded := observer.New(zap.InfoLevel)
+	ctx := traceid.With(context.Background(), wantTraceID)
+	ctx = logger.WithContext(ctx, zap.New(core).With(zap.String("trace_id", wantTraceID)))
 	p := &Provisioner{iamURL: ts.URL, client: ts.Client()}
-	identity, err := p.ResolveAPIKeyIdentity(context.Background(), tenant.CredentialProvisionRequest{
+	identity, err := p.ResolveAPIKeyIdentity(ctx, tenant.CredentialProvisionRequest{
 		PublicKey: "PROJECTOWNER1", PrivateKey: "test-private",
 	})
 	if err != nil {
@@ -101,6 +116,16 @@ func TestResolveAPIKeyIdentityUsesIAMAPI(t *testing.T) {
 	}
 	if identity.OrganizationID != "1234567890123456789" || identity.Role != tenant.TiDBCloudRoleProjectOwner {
 		t.Fatalf("identity = %+v", identity)
+	}
+	loggedTrace := false
+	for _, entry := range recorded.AllUntimed() {
+		if entry.Message == "tidbcloud_api_request" && entry.ContextMap()["trace_id"] == wantTraceID {
+			loggedTrace = true
+			break
+		}
+	}
+	if !loggedTrace {
+		t.Fatalf("IAM success access log missing trace_id %q", wantTraceID)
 	}
 }
 
@@ -248,6 +273,43 @@ func TestRequestPathRedactsIAMAccessKey(t *testing.T) {
 	got := requestPath("https://iam.tidbapi.com/v1beta1/apikeys/PROJECTOWNER1")
 	if got != "/v1beta1/apikeys/***" {
 		t.Fatalf("request path = %q, want redacted IAM access key", got)
+	}
+}
+
+func TestResolveAPIKeyIdentityRedactsAccessKeyFromTransportErrorsAndLogs(t *testing.T) {
+	accessKey := "TRANSPORTSECRET1"
+	transportErr := errors.New("network unavailable")
+	wantTraceID := "iam-transport-trace"
+	core, recorded := observer.New(zap.ErrorLevel)
+	ctx := traceid.With(context.Background(), wantTraceID)
+	ctx = logger.WithContext(ctx, zap.New(core).With(zap.String("trace_id", wantTraceID)))
+	p := &Provisioner{
+		iamURL: "https://iam.tidbapi.com",
+		client: &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, transportErr
+		})},
+	}
+
+	_, err := p.ResolveAPIKeyIdentity(ctx, tenant.CredentialProvisionRequest{
+		PublicKey: accessKey, PrivateKey: "test-private",
+	})
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("error = %v, want transport error", err)
+	}
+	if strings.Contains(err.Error(), accessKey) {
+		t.Fatalf("returned error leaked IAM access key: %v", err)
+	}
+	entries := recorded.AllUntimed()
+	if len(entries) == 0 {
+		t.Fatal("expected IAM transport error log entry")
+	}
+	for _, entry := range entries {
+		if strings.Contains(fmt.Sprint(entry.ContextMap()), accessKey) {
+			t.Fatalf("log entry leaked IAM access key: %+v", entry.ContextMap())
+		}
+		if got := entry.ContextMap()["trace_id"]; got != wantTraceID {
+			t.Fatalf("IAM log trace_id = %v, want %q", got, wantTraceID)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve TiDB Cloud API-key organization and role through the IAM API for native and shared control-plane operations
- allow only org:owner and project:owner, authorize persisted resources at organization scope, and remove cluster list/get calls used only for RBAC discovery
- require DRIVE9_TIDBCLOUD_IAM_API_URL for native/shared startup and require dedicated DRIVE9_TIDBCLOUD_NATIVE_SHARED_PUBLIC_KEY / PRIVATE_KEY in shared mode
- keep customer/default-native credentials for customer authorization and native Cloud operations, while routing every shared physical DB-pool operation through the configured shared credentials
- use shared physical root credentials directly, stop creating the shared system user, and name new clusters fs-shared-pool-{uuid}
- redact IAM access keys and response details from request logs and client-facing errors

## Behavior

- IAM response names are supported for both org-level and project-level API keys
- project owners are accepted at Drive9 organization scope; TiDB Cloud remains authoritative for project-specific native Cloud permissions
- admin tenant APIs treat tidb_cloud_native and tidb_cloud_native_shared uniformly
- shared virtual quota and manual shared DB authorization no longer depend on a physical cluster_id
- existing default native credential fallback remains unchanged

## Verification

- GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant/tidbcloudnative -count=1
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -run 'TestQuota|TestSharedQuota|TestAdminTenant|TestTenantPool|TestProvisionTiDBCloudNative|TestFirstManagedOrganization|TestTiDBCloudRBACCache|TestManagedSharedDB' -count=1
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/meta ./pkg/tenant ./pkg/tenant/schema ./cmd/drive9-server -count=1
- GOCACHE=/tmp/drive9-go-cache go build ./...
- GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint
- git diff --check

All IAM fixtures use fictional access keys and IDs; no values from the supplied curl examples are retained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added TiDB Cloud IAM identity resolution and organization-scoped authorization for tenant administration and quota operations.
  * Added shared-provider credential validation and organization-driven shared-pool tenant provisioning, including persisting shared pool tenant limits.
* **Bug Fixes**
  * Tenant and quota flows now enforce exact organization matching (including trimming) and return correct HTTP 403/404 responses without leaking sensitive details.
  * Shared DB pool selection and allocation now follow stricter max-tenant rules, including drain-only behavior when max tenants is set to 0.
* **Documentation**
  * Expanded server usage docs with TiDB Cloud IAM and shared-key environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->