### PR TITLE
feat: add shared DB pool cache handle and tenant gauges

### DIFF
--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -56,6 +56,8 @@ var sharedDBPoolTotal = serviceMeter.Float64Gauge("drive9_shared_db_pool_total",
 var sharedDBPoolCapacity = serviceMeter.Float64Gauge("drive9_shared_db_pool_capacity", "Physical shared DB-pool capacity by tidbcloud_org_id/db_pool_id/db_pool_uuid/type")
 var sharedDBPoolTenants = serviceMeter.Float64Gauge("drive9_shared_db_pool_tenants", "Physical shared DB-pool tenant count by tidbcloud_org_id/db_pool_id/db_pool_uuid/state")
 var sharedDBPoolSpendingLimit = serviceMeter.Float64Gauge("drive9_shared_db_pool_spending_limit", "Physical shared DB-pool spending limit by tidbcloud_org_id/db_pool_id/db_pool_uuid/type")
+var sharedDBPoolCacheHandles = serviceMeter.Float64Gauge("drive9_shared_db_pool_cache_handles", "Per-pod cached physical shared DB handles by tidbcloud_org_id/db_pool_id/db_pool_uuid")
+var sharedDBPoolCacheTenants = serviceMeter.Float64Gauge("drive9_shared_db_pool_cache_tenants", "Per-pod active tenant backend refs on a cached shared DB handle by tidbcloud_org_id/db_pool_id/db_pool_uuid")
 var tidbCloudRBACCacheRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_rbac_cache_requests_total", "TiDB Cloud API key to cluster RBAC cache requests by path/scope/result")
 var tidbCloudOpenAPIRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_openapi_requests_total", "TiDB Cloud OpenAPI requests by path/operation/result")
 var tidbCloudSpendingLimitSyncTotal = serviceMeter.Int64Counter("drive9_tidbcloud_spending_limit_sync_total", "TiDB Cloud spending limit local sync outcomes by source/result")
@@ -239,6 +241,35 @@ func sharedDBPoolAttrs(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, dimens
 		Attr("db_pool_id", strconv.FormatInt(dbPoolID, 10)),
 		Attr("db_pool_uuid", cleanMetricValue(dbPoolUUID, "unknown")),
 		Attr(dimension, cleanMetricValue(value, "unknown")),
+	}
+}
+
+func RecordSharedDBPoolCacheHandles(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID string, count int64) {
+	RegisterModule("shared_db_pool")
+	sharedDBPoolCacheHandles.Set(float64(count), sharedDBPoolCacheAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID)...)
+}
+
+func DeleteSharedDBPoolCacheHandles(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID string) {
+	sharedDBPoolCacheHandles.Delete(sharedDBPoolCacheAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID)...)
+}
+
+func RecordSharedDBPoolCacheTenants(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID string, count int64) {
+	if count < 0 {
+		return
+	}
+	RegisterModule("shared_db_pool")
+	sharedDBPoolCacheTenants.Set(float64(count), sharedDBPoolCacheAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID)...)
+}
+
+func DeleteSharedDBPoolCacheTenants(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID string) {
+	sharedDBPoolCacheTenants.Delete(sharedDBPoolCacheAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID)...)
+}
+
+func sharedDBPoolCacheAttrs(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID string) []Attribute {
+	return []Attribute{
+		Attr("tidbcloud_org_id", cleanMetricValue(tidbCloudOrgID, "unknown")),
+		Attr("db_pool_id", strconv.FormatInt(dbPoolID, 10)),
+		Attr("db_pool_uuid", cleanMetricValue(dbPoolUUID, "unknown")),
 	}
 }
 

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -245,6 +245,9 @@ func sharedDBPoolAttrs(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID, dimens
 }
 
 func RecordSharedDBPoolCacheHandles(tidbCloudOrgID string, dbPoolID int64, dbPoolUUID string, count int64) {
+	if count < 0 {
+		return
+	}
 	RegisterModule("shared_db_pool")
 	sharedDBPoolCacheHandles.Set(float64(count), sharedDBPoolCacheAttrs(tidbCloudOrgID, dbPoolID, dbPoolUUID)...)
 }

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -156,8 +156,16 @@ type Pool struct {
 	sharedDBs        map[int64]*sql.DB
 	sharedDBRefs     map[int64]int
 	sharedDBLastUsed map[int64]time.Time
+	sharedDBLabels   map[int64]sharedDBMetricLabels
 	sharedDBOpenMu   map[int64]*sync.Mutex
 	sharedDBClosed   bool
+}
+
+// sharedDBMetricLabels remembers the metric identity of a cached shared DB
+// handle so ref-count gauges and series cleanup do not need a meta lookup.
+type sharedDBMetricLabels struct {
+	orgID string
+	uuid  string
 }
 
 type tenantAutoEmbeddingProfile struct {
@@ -247,6 +255,7 @@ func NewPool(cfg PoolConfig, enc encrypt.Encryptor) *Pool {
 		sharedDBs:        map[int64]*sql.DB{},
 		sharedDBRefs:     map[int64]int{},
 		sharedDBLastUsed: map[int64]time.Time{},
+		sharedDBLabels:   map[int64]sharedDBMetricLabels{},
 		sharedDBOpenMu:   map[int64]*sync.Mutex{},
 		// No LeaderChecker means single-pod mode: FileGC runs unconditionally.
 		fileGCEnabled: cfg.LeaderChecker == nil,
@@ -763,6 +772,7 @@ func (p *Pool) Close() {
 		delete(p.sharedDBs, dbID)
 		delete(p.sharedDBRefs, dbID)
 		delete(p.sharedDBLastUsed, dbID)
+		p.deleteSharedDBCacheMetricsLocked(dbID)
 	}
 	p.sharedMu.Unlock()
 	for _, item := range sharedToClose {
@@ -948,6 +958,7 @@ func (p *Pool) retainSharedDB(dbID int64) {
 	p.sharedMu.Lock()
 	p.sharedDBRefs[dbID]++
 	p.sharedDBLastUsed[dbID] = time.Now()
+	p.recordSharedDBCacheTenantsLocked(dbID)
 	p.sharedMu.Unlock()
 }
 
@@ -966,7 +977,30 @@ func (p *Pool) releaseSharedDB(dbID int64) {
 		delete(p.sharedDBRefs, dbID)
 	}
 	p.sharedDBLastUsed[dbID] = time.Now()
+	p.recordSharedDBCacheTenantsLocked(dbID)
 	p.sharedMu.Unlock()
+}
+
+// recordSharedDBCacheTenantsLocked emits the per-handle active-tenant gauge.
+// Caller must hold p.sharedMu.
+func (p *Pool) recordSharedDBCacheTenantsLocked(dbID int64) {
+	labels, ok := p.sharedDBLabels[dbID]
+	if !ok {
+		return
+	}
+	metrics.RecordSharedDBPoolCacheTenants(labels.orgID, dbID, labels.uuid, int64(p.sharedDBRefs[dbID]))
+}
+
+// deleteSharedDBCacheMetricsLocked removes both cache series for a handle that
+// is leaving the cache. Caller must hold p.sharedMu.
+func (p *Pool) deleteSharedDBCacheMetricsLocked(dbID int64) {
+	labels, ok := p.sharedDBLabels[dbID]
+	if !ok {
+		return
+	}
+	metrics.DeleteSharedDBPoolCacheHandles(labels.orgID, dbID, labels.uuid)
+	metrics.DeleteSharedDBPoolCacheTenants(labels.orgID, dbID, labels.uuid)
+	delete(p.sharedDBLabels, dbID)
 }
 
 // reapIdleSharedDBs closes physical shared-DB handles only after no cached or
@@ -992,6 +1026,7 @@ func (p *Pool) reapIdleSharedDBs(now time.Time) {
 		delete(p.sharedDBs, dbID)
 		delete(p.sharedDBRefs, dbID)
 		delete(p.sharedDBLastUsed, dbID)
+		p.deleteSharedDBCacheMetricsLocked(dbID)
 	}
 	p.sharedMu.Unlock()
 	for _, item := range toClose {
@@ -1080,6 +1115,9 @@ func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) 
 	}
 	p.sharedDBs[dbID] = db
 	p.sharedDBLastUsed[dbID] = time.Now()
+	p.sharedDBLabels[dbID] = sharedDBMetricLabels{orgID: info.TiDBCloudOrganizationID, uuid: info.UUID}
+	metrics.RecordSharedDBPoolCacheHandles(info.TiDBCloudOrganizationID, dbID, info.UUID, 1)
+	metrics.RecordSharedDBPoolCacheTenants(info.TiDBCloudOrganizationID, dbID, info.UUID, int64(p.sharedDBRefs[dbID]))
 	p.sharedMu.Unlock()
 	return db, nil
 }
@@ -1111,6 +1149,7 @@ func (p *Pool) InvalidateSharedDB(dbID int64) error {
 	delete(p.sharedDBs, dbID)
 	delete(p.sharedDBRefs, dbID)
 	delete(p.sharedDBLastUsed, dbID)
+	p.deleteSharedDBCacheMetricsLocked(dbID)
 	p.sharedMu.Unlock()
 	if db == nil {
 		return nil

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -182,6 +182,121 @@ func TestSharedDBHandleIdleReapUsesLongerTTLAndSkipsReferencedHandles(t *testing
 	}
 }
 
+func registerSharedDBForCacheMetrics(t *testing.T, orgID string) (*meta.Store, *Pool, int64, string) {
+	t.Helper()
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	dsnCfg, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, portText, err := net.SplitHostPort(dsnCfg.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passwordCipher, err := enc.Encrypt(context.Background(), []byte(dsnCfg.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := metaStore.RegisterSharedDB(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: orgID, Host: host, Port: port,
+		User: dsnCfg.User, PasswordCipher: passwordCipher, Name: dsnCfg.DBName,
+		MaxTenants: 100, Status: meta.SharedDBStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousEnsure := ensureSharedDBSchema
+	ensureSharedDBSchema = func(ctx context.Context, db *sql.DB) error {
+		return db.PingContext(ctx)
+	}
+	t.Cleanup(func() { ensureSharedDBSchema = previousEnsure })
+	pool := NewPool(PoolConfig{}, enc)
+	pool.SetMetaStore(metaStore)
+	t.Cleanup(pool.Close)
+	if err := pool.EnsureSharedDBReady(context.Background(), dbID); err != nil {
+		t.Fatal(err)
+	}
+	info, err := metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return metaStore, pool, dbID, info.UUID
+}
+
+func assertSharedDBCacheMetric(t *testing.T, series string, wantPresent bool) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	text := rec.Body.String()
+	if wantPresent && !strings.Contains(text, series) {
+		t.Fatalf("missing shared DB cache metric %q:\n%s", series, text)
+	}
+	if !wantPresent && strings.Contains(text, series) {
+		t.Fatalf("stale shared DB cache metric %q:\n%s", series, text)
+	}
+}
+
+func TestSharedDBCacheMetricsTrackHandleLifecycle(t *testing.T) {
+	_, pool, dbID, uuid := registerSharedDBForCacheMetrics(t, "org-cache-metrics")
+	dbPoolID := strconv.FormatInt(dbID, 10)
+	labels := `db_pool_id="` + dbPoolID + `",db_pool_uuid="` + uuid + `",tidbcloud_org_id="org-cache-metrics"`
+	handleSeries := `drive9_shared_db_pool_cache_handles{` + labels + `}`
+	tenantsSeries := func(value string) string {
+		return `drive9_shared_db_pool_cache_tenants{` + labels + `} ` + value
+	}
+
+	assertSharedDBCacheMetric(t, handleSeries+` 1.000000`, true)
+	assertSharedDBCacheMetric(t, tenantsSeries(`0.000000`), true)
+
+	pool.retainSharedDB(dbID)
+	assertSharedDBCacheMetric(t, tenantsSeries(`1.000000`), true)
+	pool.retainSharedDB(dbID)
+	assertSharedDBCacheMetric(t, tenantsSeries(`2.000000`), true)
+	pool.releaseSharedDB(dbID)
+	assertSharedDBCacheMetric(t, tenantsSeries(`1.000000`), true)
+	pool.releaseSharedDB(dbID)
+	assertSharedDBCacheMetric(t, tenantsSeries(`0.000000`), true)
+
+	if err := pool.InvalidateSharedDB(dbID); err != nil {
+		t.Fatal(err)
+	}
+	assertSharedDBCacheMetric(t, handleSeries, false)
+	assertSharedDBCacheMetric(t, `drive9_shared_db_pool_cache_tenants{`+labels+`}`, false)
+}
+
+func TestSharedDBCacheMetricsDeletedOnIdleReap(t *testing.T) {
+	_, pool, dbID, uuid := registerSharedDBForCacheMetrics(t, "org-cache-reap")
+	dbPoolID := strconv.FormatInt(dbID, 10)
+	labels := `db_pool_id="` + dbPoolID + `",db_pool_uuid="` + uuid + `",tidbcloud_org_id="org-cache-reap"`
+	handleSeries := `drive9_shared_db_pool_cache_handles{` + labels + `}`
+	assertSharedDBCacheMetric(t, handleSeries+` 1.000000`, true)
+
+	pool.sharedMu.Lock()
+	pool.sharedDBLastUsed[dbID] = time.Now().Add(-defaultSharedDBHandleIdleTTL - time.Second)
+	pool.sharedMu.Unlock()
+	pool.reapIdleSharedDBs(time.Now())
+
+	assertSharedDBCacheMetric(t, handleSeries, false)
+	assertSharedDBCacheMetric(t, `drive9_shared_db_pool_cache_tenants{`+labels+`}`, false)
+}
+
 func TestSharedDBSchemaIsCheckedLazilyAndRetriedAfterFailure(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -298,6 +298,20 @@ func TestSharedDBCacheMetricsDeletedOnIdleReap(t *testing.T) {
 	assertSharedDBCacheMetric(t, `drive9_shared_db_pool_cache_tenants{`+labels+`}`, false)
 }
 
+func TestSharedDBCacheMetricsDeletedOnPoolClose(t *testing.T) {
+	_, pool, dbID, uuid := registerSharedDBForCacheMetrics(t, "org-cache-close")
+	dbPoolID := strconv.FormatInt(dbID, 10)
+	labels := `db_pool_id="` + dbPoolID + `",db_pool_uuid="` + uuid + `",tidbcloud_org_id="org-cache-close"`
+	handleSeries := `drive9_shared_db_pool_cache_handles{` + labels + `}`
+	assertSharedDBCacheMetric(t, handleSeries+` 1.000000`, true)
+	assertSharedDBCacheMetric(t, `drive9_shared_db_pool_cache_tenants{`+labels+`} 0.000000`, true)
+
+	pool.Close()
+
+	assertSharedDBCacheMetric(t, handleSeries, false)
+	assertSharedDBCacheMetric(t, `drive9_shared_db_pool_cache_tenants{`+labels+`}`, false)
+}
+
 func TestSharedDBSchemaIsCheckedLazilyAndRetriedAfterFailure(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -184,7 +184,7 @@ func TestSharedDBHandleIdleReapUsesLongerTTLAndSkipsReferencedHandles(t *testing
 
 func registerSharedDBForCacheMetrics(t *testing.T, orgID string) (*meta.Store, *Pool, int64, string) {
 	t.Helper()
-	metaStore, err := meta.Open(testDSN)
+	metaStore, err := meta.OpenContext(context.Background(), testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,6 +287,7 @@ func TestSharedDBCacheMetricsDeletedOnIdleReap(t *testing.T) {
 	labels := `db_pool_id="` + dbPoolID + `",db_pool_uuid="` + uuid + `",tidbcloud_org_id="org-cache-reap"`
 	handleSeries := `drive9_shared_db_pool_cache_handles{` + labels + `}`
 	assertSharedDBCacheMetric(t, handleSeries+` 1.000000`, true)
+	assertSharedDBCacheMetric(t, `drive9_shared_db_pool_cache_tenants{`+labels+`} 0.000000`, true)
 
 	pool.sharedMu.Lock()
 	pool.sharedDBLastUsed[dbID] = time.Now().Add(-defaultSharedDBHandleIdleTTL - time.Second)


### PR DESCRIPTION
## Summary

Add per-pod Prometheus gauges for the shared DB handle cache in the tenant pool (`p.sharedDBs`), which previously had no visibility:

- `drive9_shared_db_pool_cache_handles{tidbcloud_org_id,db_pool_id,db_pool_uuid}` = 1 per cached physical `*sql.DB` handle (`sum()` gives total cached handles per pod)
- `drive9_shared_db_pool_cache_tenants{tidbcloud_org_id,db_pool_id,db_pool_uuid}` = current `sharedDBRefs` count (active tenant backends on that handle)

## Implementation

- `pkg/metrics/operations.go`: two new gauges + Record/Delete functions, following the existing `drive9_shared_db_pool_*` family
- `pkg/tenant/pool.go`: new `sharedDBLabels` map captures orgID/uuid at handle open; gauges emitted on `sharedDBHandle` (open), `retain/releaseSharedDB` (ref changes); series deleted on `reapIdleSharedDBs` / `InvalidateSharedDB` / `Close` to prevent stale series
- `pkg/tenant/pool_test.go`: lifecycle test (open → retain×2 → release×2 → invalidate) and idle-reap deletion test

## Alerts

Companion alert rules in tidbcloud/runbooks (separate PR).

## Test plan

- [x] `make lint` — 0 issues
- [x] `make test TEST_PKGS='./pkg/tenant'` — pass
- [x] `make test TEST_PKGS='./pkg/metrics'` — pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new per-shared-DB Prometheus gauges for cached handles and active tenants, labeled by organization and shared DB pool identifiers.
  * Metrics are now created, updated, and removed automatically as shared DB cache entries are retained, released, invalidated, idle-reaped, or closed.

* **Tests**
  * Extended Prometheus metric assertions to verify gauge lifecycle updates across retain/release, deletion after invalidation, and cleanup after idle reaping and pool close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->