### PR TITLE
fix: label shared clusters with customer organization

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1106,7 +1106,8 @@ func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, p
 		}
 		rows[dbID] = row
 		requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID, DBPoolUUID: row.UUID,
-			DatabaseName: row.Name, RootPassword: string(plain), SpendingLimitMonthly: *row.SpendingLimit})
+			CustomerOrganizationID: strings.TrimSpace(row.TiDBCloudOrganizationID), DatabaseName: row.Name,
+			RootPassword: string(plain), SpendingLimitMonthly: *row.SpendingLimit})
 	}
 	if len(requests) == 0 {
 		return resolvedOrg, nil

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -46,6 +46,8 @@ type fakeProvisioner struct {
 	quotaUpdateCalls        atomic.Int32
 	sharedPoolBatchCalls    atomic.Int32
 	sharedPoolBatchMembers  atomic.Int32
+	sharedPoolBatchMu       sync.Mutex
+	sharedPoolBatchRequests []tenant.SharedDBPoolCreateRequest
 	lastCredentialReq       tenant.CredentialProvisionRequest
 	lastDeprovision         *tenant.ClusterInfo
 	lastQuotaCluster        *tenant.ClusterInfo
@@ -64,6 +66,7 @@ type fakeProvisioner struct {
 	managedClusters         []tenant.CloudClusterInfo
 	sharedPoolResults       []*tenant.SharedDBPoolInfo
 	sharedPoolBatchErr      error
+	sharedPoolPartialErr    error
 	sharedPoolBatchStarted  chan struct{}
 	sharedPoolBatchRelease  <-chan struct{}
 	sharedPoolWaitCalls     atomic.Int32
@@ -139,6 +142,12 @@ func (f *fakeProvisioner) iamCredentialsSnapshot() []tenant.CredentialProvisionR
 	f.iamMu.Lock()
 	defer f.iamMu.Unlock()
 	return append([]tenant.CredentialProvisionRequest(nil), f.iamCredentials...)
+}
+
+func (f *fakeProvisioner) sharedPoolBatchRequestsSnapshot() []tenant.SharedDBPoolCreateRequest {
+	f.sharedPoolBatchMu.Lock()
+	defer f.sharedPoolBatchMu.Unlock()
+	return append([]tenant.SharedDBPoolCreateRequest(nil), f.sharedPoolBatchRequests...)
 }
 
 func (f *fakeProvisioner) ProviderType() string { return f.provider }
@@ -251,6 +260,10 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	}
 	if got := prov.lastSharedCredentialReq; got.PublicKey != "shared-public" || got.PrivateKey != "shared-private" {
 		t.Fatalf("shared physical credential = %+v, want configured shared credential", got)
+	}
+	requests := prov.sharedPoolBatchRequestsSnapshot()
+	if len(requests) != 1 || requests[0].CustomerOrganizationID != "customer-org" {
+		t.Fatalf("shared physical create requests = %+v, want customer organization customer-org", requests)
 	}
 	iamCredentials := prov.iamCredentialsSnapshot()
 	if len(iamCredentials) != 1 || iamCredentials[0].PublicKey != "public" || iamCredentials[0].PrivateKey != "private" {
@@ -700,6 +713,63 @@ func TestManagedSharedDBContinuationWaitsForConnectionMetadata(t *testing.T) {
 	}
 }
 
+func TestManagedSharedDBContinuationPassesCustomerOrganizationToPhysicalCreate(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(pool.Close)
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-continuation-label", ProvisioningKey: bytes.Repeat([]byte{7}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+		PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantErr := errors.New("stop after physical create")
+	prov := &fakeProvisioner{
+		provider: tenant.ProviderTiDBCloudNative,
+		sharedPoolResults: []*tenant.SharedDBPoolInfo{{
+			DBPoolID: dbID, DBPoolUUID: row.UUID, ClusterID: "cluster-continuation-label", DBName: "tidbcloud_fs",
+		}},
+		sharedPoolPartialErr: wantErr,
+	}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov}
+	err = srv.continueManagedSharedDBPoolLocked(context.Background(), row, tenant.CredentialProvisionRequest{
+		PublicKey: "shared-public", PrivateKey: "shared-private",
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("continueManagedSharedDBPoolLocked error = %v, want %v", err, wantErr)
+	}
+	requests := prov.sharedPoolBatchRequestsSnapshot()
+	if len(requests) != 1 || requests[0].CustomerOrganizationID != "org-continuation-label" {
+		t.Fatalf("continuation physical create requests = %+v, want customer organization org-continuation-label", requests)
+	}
+}
+
 func TestRetryManagedSharedDBContinuationRecoversAfterMoreThanTwoFailures(t *testing.T) {
 	origWindow, origInitialBackoff, origMaxBackoff := schemaInitRetryWindow, schemaInitInitialBackoff, schemaInitMaxBackoff
 	schemaInitRetryWindow = time.Second
@@ -1022,6 +1092,10 @@ func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
 		t.Fatalf("physical create calls = %d, want 1", got)
 	}
+	requests := prov.sharedPoolBatchRequestsSnapshot()
+	if len(requests) != 1 || requests[0].CustomerOrganizationID != "org-batch-lock" {
+		t.Fatalf("batch physical create requests = %+v, want customer organization org-batch-lock", requests)
+	}
 }
 
 func TestManagedSharedDBBatchCreateReturnsTotalFailure(t *testing.T) {
@@ -1088,6 +1162,9 @@ func (f *fakeProvisioner) ListManagedClusters(_ context.Context, _ tenant.Creden
 
 func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, requests []tenant.SharedDBPoolCreateRequest, cred tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
 	f.lastSharedCredentialReq = cred
+	f.sharedPoolBatchMu.Lock()
+	f.sharedPoolBatchRequests = append(f.sharedPoolBatchRequests, requests...)
+	f.sharedPoolBatchMu.Unlock()
 	f.sharedPoolBatchCalls.Add(1)
 	f.sharedPoolBatchMembers.Add(int32(len(requests)))
 	if f.sharedPoolBatchStarted != nil {
@@ -1118,7 +1195,7 @@ func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context
 			}
 			out[i] = &copyRow
 		}
-		return out, nil
+		return out, f.sharedPoolPartialErr
 	}
 	out := make([]*tenant.SharedDBPoolInfo, 0, len(requests))
 	for _, req := range requests {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -46,8 +46,7 @@ type fakeProvisioner struct {
 	quotaUpdateCalls        atomic.Int32
 	sharedPoolBatchCalls    atomic.Int32
 	sharedPoolBatchMembers  atomic.Int32
-	sharedPoolBatchMu       sync.Mutex
-	sharedPoolBatchRequests []tenant.SharedDBPoolCreateRequest
+	sharedPoolBatchRequests chan []tenant.SharedDBPoolCreateRequest
 	lastCredentialReq       tenant.CredentialProvisionRequest
 	lastDeprovision         *tenant.ClusterInfo
 	lastQuotaCluster        *tenant.ClusterInfo
@@ -144,12 +143,6 @@ func (f *fakeProvisioner) iamCredentialsSnapshot() []tenant.CredentialProvisionR
 	return append([]tenant.CredentialProvisionRequest(nil), f.iamCredentials...)
 }
 
-func (f *fakeProvisioner) sharedPoolBatchRequestsSnapshot() []tenant.SharedDBPoolCreateRequest {
-	f.sharedPoolBatchMu.Lock()
-	defer f.sharedPoolBatchMu.Unlock()
-	return append([]tenant.SharedDBPoolCreateRequest(nil), f.sharedPoolBatchRequests...)
-}
-
 func (f *fakeProvisioner) ProviderType() string { return f.provider }
 
 func TestDefaultTenantProviderIsIndependentFromProvisionerType(t *testing.T) {
@@ -189,7 +182,8 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 		provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
 		defaultPublicKey: "public", defaultPrivateKey: "private",
 		defaultSharedPublicKey: "shared-public", defaultSharedPrivateKey: "shared-private",
-		identityOrg: "customer-org",
+		identityOrg:             "customer-org",
+		sharedPoolBatchRequests: make(chan []tenant.SharedDBPoolCreateRequest, 1),
 		sharedPoolResults: []*tenant.SharedDBPoolInfo{{
 			ClusterID: "cluster-shared", OrganizationID: "physical-org", Password: "root-pass", DBName: "tidbcloud_fs",
 		}},
@@ -261,7 +255,7 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	if got := prov.lastSharedCredentialReq; got.PublicKey != "shared-public" || got.PrivateKey != "shared-private" {
 		t.Fatalf("shared physical credential = %+v, want configured shared credential", got)
 	}
-	requests := prov.sharedPoolBatchRequestsSnapshot()
+	requests := <-prov.sharedPoolBatchRequests
 	if len(requests) != 1 || requests[0].CustomerOrganizationID != "customer-org" {
 		t.Fatalf("shared physical create requests = %+v, want customer organization customer-org", requests)
 	}
@@ -751,7 +745,8 @@ func TestManagedSharedDBContinuationPassesCustomerOrganizationToPhysicalCreate(t
 	}
 	wantErr := errors.New("stop after physical create")
 	prov := &fakeProvisioner{
-		provider: tenant.ProviderTiDBCloudNative,
+		provider:                tenant.ProviderTiDBCloudNative,
+		sharedPoolBatchRequests: make(chan []tenant.SharedDBPoolCreateRequest, 1),
 		sharedPoolResults: []*tenant.SharedDBPoolInfo{{
 			DBPoolID: dbID, DBPoolUUID: row.UUID, ClusterID: "cluster-continuation-label", DBName: "tidbcloud_fs",
 		}},
@@ -764,7 +759,7 @@ func TestManagedSharedDBContinuationPassesCustomerOrganizationToPhysicalCreate(t
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("continueManagedSharedDBPoolLocked error = %v, want %v", err, wantErr)
 	}
-	requests := prov.sharedPoolBatchRequestsSnapshot()
+	requests := <-prov.sharedPoolBatchRequests
 	if len(requests) != 1 || requests[0].CustomerOrganizationID != "org-continuation-label" {
 		t.Fatalf("continuation physical create requests = %+v, want customer organization org-continuation-label", requests)
 	}
@@ -1057,6 +1052,7 @@ func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	release := make(chan struct{})
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative,
 		sharedPoolBatchStarted: started, sharedPoolBatchRelease: release,
+		sharedPoolBatchRequests: make(chan []tenant.SharedDBPoolCreateRequest, 1),
 		sharedPoolResults: []*tenant.SharedDBPoolInfo{{ClusterID: "cluster-batch-lock", OrganizationID: "org-batch-lock",
 			Host: "db.example.com", Port: 4000, Username: "u.root", DBName: "tidbcloud_fs"}}}
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov,
@@ -1092,7 +1088,7 @@ func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
 		t.Fatalf("physical create calls = %d, want 1", got)
 	}
-	requests := prov.sharedPoolBatchRequestsSnapshot()
+	requests := <-prov.sharedPoolBatchRequests
 	if len(requests) != 1 || requests[0].CustomerOrganizationID != "org-batch-lock" {
 		t.Fatalf("batch physical create requests = %+v, want customer organization org-batch-lock", requests)
 	}
@@ -1162,9 +1158,9 @@ func (f *fakeProvisioner) ListManagedClusters(_ context.Context, _ tenant.Creden
 
 func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, requests []tenant.SharedDBPoolCreateRequest, cred tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
 	f.lastSharedCredentialReq = cred
-	f.sharedPoolBatchMu.Lock()
-	f.sharedPoolBatchRequests = append(f.sharedPoolBatchRequests, requests...)
-	f.sharedPoolBatchMu.Unlock()
+	if f.sharedPoolBatchRequests != nil {
+		f.sharedPoolBatchRequests <- append([]tenant.SharedDBPoolCreateRequest(nil), requests...)
+	}
 	f.sharedPoolBatchCalls.Add(1)
 	f.sharedPoolBatchMembers.Add(int32(len(requests)))
 	if f.sharedPoolBatchStarted != nil {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -496,8 +496,9 @@ func (s *Server) ensureManagedSharedDBPhysicalLocked(ctx context.Context, poolIn
 			return nil, fmt.Errorf("managed shared cluster %q was not found", poolInfo.ClusterID)
 		}
 		results, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, []tenant.SharedDBPoolCreateRequest{{
-			DBPoolID: poolInfo.ID, DBPoolUUID: poolInfo.UUID, DatabaseName: poolInfo.Name, RootPassword: string(plainRootPassword),
-			SpendingLimitMonthly: *poolInfo.SpendingLimit,
+			DBPoolID: poolInfo.ID, DBPoolUUID: poolInfo.UUID,
+			CustomerOrganizationID: strings.TrimSpace(poolInfo.TiDBCloudOrganizationID), DatabaseName: poolInfo.Name,
+			RootPassword: string(plainRootPassword), SpendingLimitMonthly: *poolInfo.SpendingLimit,
 		}}, cred)
 		provisionErr = createErr
 		if createErr != nil && len(results) == 0 {
@@ -629,8 +630,9 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 				return fmt.Errorf("managed shared cluster %q was not found", poolInfo.ClusterID)
 			}
 			results, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, []tenant.SharedDBPoolCreateRequest{{
-				DBPoolID: dbID, DBPoolUUID: poolInfo.UUID, DatabaseName: poolInfo.Name, RootPassword: string(plainRootPassword),
-				SpendingLimitMonthly: *poolInfo.SpendingLimit,
+				DBPoolID: dbID, DBPoolUUID: poolInfo.UUID,
+				CustomerOrganizationID: strings.TrimSpace(poolInfo.TiDBCloudOrganizationID), DatabaseName: poolInfo.Name,
+				RootPassword: string(plainRootPassword), SpendingLimitMonthly: *poolInfo.SpendingLimit,
 			}}, cred)
 			provisionErr = createErr
 			if createErr != nil && len(results) == 0 {

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -92,11 +92,12 @@ type TenantPoolClusterManager interface {
 }
 
 type SharedDBPoolCreateRequest struct {
-	DBPoolID             int64
-	DBPoolUUID           string
-	DatabaseName         string
-	RootPassword         string
-	SpendingLimitMonthly int64
+	DBPoolID               int64
+	DBPoolUUID             string
+	CustomerOrganizationID string
+	DatabaseName           string
+	RootPassword           string
+	SpendingLimitMonthly   int64
 }
 
 type SharedDBPoolInfo struct {

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -58,15 +58,16 @@ const (
 	cloudProviderAliCloud     = "alicloud"
 	cloudProviderAWS          = "aws"
 
-	Drive9ManagedLabel         = "drive9.ai/managed"
-	Drive9TenantIDLabel        = "drive9.ai/tenant_id"
-	Drive9PoolStatusLabel      = "drive9.ai/status"
-	Drive9PoolIDLabel          = "drive9.ai/pool_id"
-	Drive9PoolUsedAtLabel      = "drive9.ai/used_at"
-	Drive9ProviderLabel        = "drive9.ai/provider"
-	Drive9DBPoolUUIDLabel      = "drive9.ai/db_pool_uuid"
-	Drive9QuotaUpdateAtLabel   = "drive9.ai/update_quota_at"
-	TiDBCloudOrganizationLabel = "tidb.cloud/organization"
+	Drive9ManagedLabel              = "drive9.ai/managed"
+	Drive9TenantIDLabel             = "drive9.ai/tenant_id"
+	Drive9PoolStatusLabel           = "drive9.ai/status"
+	Drive9PoolIDLabel               = "drive9.ai/pool_id"
+	Drive9PoolUsedAtLabel           = "drive9.ai/used_at"
+	Drive9ProviderLabel             = "drive9.ai/provider"
+	Drive9DBPoolUUIDLabel           = "drive9.ai/db_pool_uuid"
+	Drive9CustomerOrganizationLabel = "drive9.ai/customer_organization"
+	Drive9QuotaUpdateAtLabel        = "drive9.ai/update_quota_at"
+	TiDBCloudOrganizationLabel      = "tidb.cloud/organization"
 
 	upstreamErrorBodyLimit   = 2048
 	upstreamClusterBodyLimit = 1 << 20
@@ -599,6 +600,10 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 		if _, exists := inputsByUUID[poolUUID]; exists {
 			return nil, fmt.Errorf("duplicate db pool uuid %s", poolUUID)
 		}
+		customerOrganizationID := strings.TrimSpace(input.CustomerOrganizationID)
+		if customerOrganizationID == "" {
+			return nil, fmt.Errorf("customer organization is required for db pool %d", input.DBPoolID)
+		}
 		if err := validateTiDBCloudSpendingLimit(input.SpendingLimitMonthly); err != nil {
 			return nil, err
 		}
@@ -611,6 +616,7 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 			return nil, fmt.Errorf("root password is required for db pool %d", input.DBPoolID)
 		}
 		input.DBPoolUUID = poolUUID
+		input.CustomerOrganizationID = customerOrganizationID
 		input.RootPassword = password
 		inputsByUUID[poolUUID] = input
 		databaseNames[poolUUID] = dbName
@@ -619,9 +625,10 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 			"rootPassword": password,
 			"region":       map[string]string{"name": p.regionName()},
 			"labels": map[string]string{
-				Drive9ManagedLabel:    "true",
-				Drive9ProviderLabel:   tenant.ProviderTiDBCloudNativeShared,
-				Drive9DBPoolUUIDLabel: poolUUID,
+				Drive9ManagedLabel:              "true",
+				Drive9ProviderLabel:             tenant.ProviderTiDBCloudNativeShared,
+				Drive9DBPoolUUIDLabel:           poolUUID,
+				Drive9CustomerOrganizationLabel: input.CustomerOrganizationID,
 			},
 			"spendingLimit": map[string]int32{"monthly": int32(input.SpendingLimitMonthly)},
 		}})

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -807,8 +807,8 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 		defaultDatabaseName: DefaultDatabaseName, client: ts.Client(),
 	}
 	got, err := p.BatchProvisionSharedDBPoolsWithCredentials(context.Background(), []tenant.SharedDBPoolCreateRequest{
-		{DBPoolID: 41, DBPoolUUID: poolUUIDs[0], RootPassword: "durable-password-41", SpendingLimitMonthly: 1_000_000},
-		{DBPoolID: 42, DBPoolUUID: poolUUIDs[1], RootPassword: "durable-password-42", SpendingLimitMonthly: 1_000_000},
+		{DBPoolID: 41, DBPoolUUID: poolUUIDs[0], CustomerOrganizationID: "customer-org-41", RootPassword: "durable-password-41", SpendingLimitMonthly: 1_000_000},
+		{DBPoolID: 42, DBPoolUUID: poolUUIDs[1], CustomerOrganizationID: "customer-org-42", RootPassword: "durable-password-42", SpendingLimitMonthly: 1_000_000},
 	}, tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
 	if err != nil {
 		t.Fatalf("BatchProvisionSharedDBPoolsWithCredentials: %v", err)
@@ -826,7 +826,7 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 		}
 		wantLabels := map[string]string{
 			Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
-			Drive9DBPoolUUIDLabel: poolUUIDs[i],
+			Drive9DBPoolUUIDLabel: poolUUIDs[i], Drive9CustomerOrganizationLabel: "customer-org-" + id,
 		}
 		for key, want := range wantLabels {
 			if request.Cluster.Labels[key] != want {
@@ -840,6 +840,30 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 	if len(got) != 2 || got[0].DBPoolID != 41 || got[0].DBPoolUUID != poolUUIDs[0] || got[0].ClusterID != "cluster-pool-41" ||
 		got[1].DBPoolID != 42 || got[1].DBPoolUUID != poolUUIDs[1] || got[1].ClusterID != "cluster-pool-42" {
 		t.Fatalf("shared pool results = %#v", got)
+	}
+}
+
+func TestBatchProvisionSharedDBPoolsRejectsMissingCustomerOrganizationBeforeRequest(t *testing.T) {
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL: ts.URL, cloudProvider: "aws", region: "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName, client: ts.Client(),
+	}
+	_, err := p.BatchProvisionSharedDBPoolsWithCredentials(context.Background(), []tenant.SharedDBPoolCreateRequest{{
+		DBPoolID: 41, DBPoolUUID: "11111111-1111-4111-8111-111111111111",
+		RootPassword: "durable-password-41", SpendingLimitMonthly: 1_000_000,
+	}}, tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	if err == nil || !strings.Contains(err.Error(), "customer organization") {
+		t.Fatalf("BatchProvisionSharedDBPoolsWithCredentials error = %v, want missing customer organization", err)
+	}
+	if got := calls.Load(); got != 0 {
+		t.Fatalf("TiDB Cloud request calls = %d, want 0", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- propagate the logical customer organization through batch, direct, and continuation shared DB cluster creation paths
- label newly created tidb_cloud_native_shared clusters with drive9.ai/customer_organization
- reject a missing customer organization before issuing the TiDB Cloud batch-create request

## Test plan

- go test ./pkg/tenant/... -count=1
- go test ./pkg/server -count=1 -run '^(TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning|TestManagedSharedDBContinuationWaitsForConnectionMetadata|TestManagedSharedDBContinuationPassesCustomerOrganizationToPhysicalCreate|TestManagedSharedDBBatchCreateUsesAllocationLock|TestManagedSharedDBBatchCreateReturnsTotalFailure)$'
- go test ./pkg/server -run '^$' -count=1
- make lint

## Verification note

The full pkg/server suite already failed in the pre-change baseline. A post-change fail-fast run stopped at the unrelated TestAdminTenantPoolUpdateShrinkPartialFailureReconcilesSize; that test passes when run in isolation after a transient local testcontainers/Ryuk port collision cleared.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shared database pool provisioning now associates each pool with its customer organization.
  * Customer organization information is included in managed pool creation and continuation flows.
  * Provisioning requests are rejected when the required customer organization information is missing.

* **Bug Fixes**
  * Improved organization metadata propagation during shared database pool creation and recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->