### PR TITLE
fix: restore pending state for shared DB pool metadata wait

### DIFF
--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -317,8 +317,9 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 		if in.Name != "" {
 			name = in.Name
 		}
-		nextStatus := SharedDBStatusPending
-		if host != "" && port > 0 && user != "" && len(password) > 0 && name != "" {
+		nextStatus := currentStatus
+		metadataReady := host != "" && port > 0 && user != "" && len(password) > 0 && name != ""
+		if currentStatus == SharedDBStatusPending && metadataReady {
 			nextStatus = SharedDBStatusProvisioning
 		}
 		if _, err := tx.ExecContext(ctx, `UPDATE db_pool
@@ -331,17 +332,15 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 			nullString(in.Name), in.TLSMode, nextStatus, in.ID); err != nil {
 			return fmt.Errorf("persist cloud result for db pool %d: %w", in.ID, err)
 		}
-		tenantStatus := TenantPending
-		if nextStatus == SharedDBStatusProvisioning {
-			tenantStatus = TenantProvisioning
-		}
-		if _, err := tx.ExecContext(ctx, `UPDATE tenants t
-			JOIN fs_registry f ON f.tenant_id = t.id
-			JOIN tenant_placements p ON p.fs_id = f.fs_id
-			SET t.status = ?, t.updated_at = ?
-			WHERE p.db_id = ? AND t.provider = ? AND t.status IN (?, ?)`, tenantStatus, time.Now().UTC(),
-			in.ID, tidbCloudNativeSharedProvider, TenantPending, TenantProvisioning); err != nil {
-			return fmt.Errorf("advance tenants for db pool %d: %w", in.ID, err)
+		if nextStatus == SharedDBStatusProvisioning && metadataReady {
+			if _, err := tx.ExecContext(ctx, `UPDATE tenants t
+				JOIN fs_registry f ON f.tenant_id = t.id
+				JOIN tenant_placements p ON p.fs_id = f.fs_id
+				SET t.status = ?, t.updated_at = ?
+				WHERE p.db_id = ? AND t.provider = ? AND t.status = ?`, TenantProvisioning, time.Now().UTC(),
+				in.ID, tidbCloudNativeSharedProvider, TenantPending); err != nil {
+				return fmt.Errorf("advance tenants for db pool %d: %w", in.ID, err)
+			}
 		}
 		return nil
 	})
@@ -349,8 +348,7 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 
 // PrepareManagedSharedDBPoolRoot durably stores the root credential and
 // database name before the first Cloud create call. It is idempotent for a
-// pending or legacy provisioning row that has not yet acquired a cluster
-// identity.
+// pending row that has not yet acquired a cluster identity.
 func (s *Store) PrepareManagedSharedDBPoolRoot(ctx context.Context, dbID int64, passwordCipher []byte, databaseName string) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "prepare_managed_shared_db_pool_root", start, &err)
@@ -365,8 +363,8 @@ func (s *Store) PrepareManagedSharedDBPoolRoot(ctx context.Context, dbID int64, 
 	}
 	res, err := s.db.ExecContext(ctx, `UPDATE db_pool
 		SET db_password = COALESCE(db_password, ?), db_name = COALESCE(db_name, ?)
-		WHERE db_id = ? AND status IN (?, ?) AND cluster_id IS NULL`,
-		passwordCipher, databaseName, dbID, SharedDBStatusPending, SharedDBStatusProvisioning)
+		WHERE db_id = ? AND status = ? AND cluster_id IS NULL`,
+		passwordCipher, databaseName, dbID, SharedDBStatusPending)
 	if err != nil {
 		return fmt.Errorf("prepare managed db pool %d root credential: %w", dbID, err)
 	}
@@ -378,8 +376,8 @@ func (s *Store) PrepareManagedSharedDBPoolRoot(ctx context.Context, dbID int64, 
 		return nil
 	}
 	var exists int
-	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM db_pool WHERE db_id = ? AND status IN (?, ?) AND cluster_id IS NULL
-		AND db_password IS NOT NULL AND db_name IS NOT NULL`, dbID, SharedDBStatusPending, SharedDBStatusProvisioning).Scan(&exists); err != nil {
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM db_pool WHERE db_id = ? AND status = ? AND cluster_id IS NULL
+		AND db_password IS NOT NULL AND db_name IS NOT NULL`, dbID, SharedDBStatusPending).Scan(&exists); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
 		}

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -40,6 +40,7 @@ const (
 const PlacementStatusDeleting = "deleting"
 
 const (
+	SharedDBStatusPending      = "pending"
 	SharedDBStatusProvisioning = "provisioning"
 	SharedDBStatusActive       = "active"
 	SharedDBStatusFailed       = "failed"
@@ -228,7 +229,7 @@ func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id
 		VALUES (?, ?, ?, ?, ?, ?, '', ?, ?, ?, 0, 0, ?, 0, ?)`, poolUUID, organizationID, in.ProvisioningKey,
 		in.CloudProvider, in.Region, SharedDBRoleShared, passwordCipher, databaseName,
 		in.MaxTenants, *in.SpendingLimit,
-		SharedDBStatusProvisioning)
+		SharedDBStatusPending)
 	if err != nil {
 		return 0, fmt.Errorf("insert managed db_pool row: %w", err)
 	}
@@ -240,9 +241,10 @@ func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id
 }
 
 // UpdateManagedSharedDBPoolCloudResult persists the cloud identity and any
-// connection metadata currently available for a provisional managed pool. It
-// clears provisioning_key only after the organization identity is durable.
-// The pool remains provisioning until its shared schema is ready.
+// connection metadata currently available for a managed pool. A pool stays
+// pending while connection metadata is incomplete, transitions to
+// provisioning once the metadata is ready, and remains provisioning until its
+// shared schema is ready.
 func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *SharedDB) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "update_managed_shared_db_pool_cloud_result", start, &err)
@@ -279,44 +281,76 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 		}
 		return value
 	}
-	res, err := s.db.ExecContext(ctx, `UPDATE db_pool
-		SET org_id = ?, cluster_id = ?, provisioning_key = NULL,
-			db_host = COALESCE(?, db_host), db_port = COALESCE(?, db_port),
-			db_user = COALESCE(?, db_user), db_password = COALESCE(?, db_password),
-			db_name = COALESCE(?, db_name), db_tls = ?
-		WHERE db_id = ? AND status = ?`,
-		in.TiDBCloudOrganizationID, in.ClusterID, nullString(in.Host), nullInt(in.Port),
-		nullString(in.User), nullBytes(in.PasswordCipher), nullString(in.Name), in.TLSMode,
-		in.ID, SharedDBStatusProvisioning)
-	if err != nil {
-		return fmt.Errorf("persist cloud result for db pool %d: %w", in.ID, err)
-	}
-	affected, err := res.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("cloud result rows affected for db pool %d: %w", in.ID, err)
-	}
-	if affected == 0 {
-		var organizationID, clusterID sql.NullString
-		checkErr := s.db.QueryRowContext(ctx, `SELECT org_id, cluster_id FROM db_pool
-			WHERE db_id = ? AND status = ?`, in.ID, SharedDBStatusProvisioning).
-			Scan(&organizationID, &clusterID)
-		if errors.Is(checkErr, sql.ErrNoRows) {
+	return s.InTx(ctx, func(tx *sql.Tx) error {
+		var currentHost, currentUser, currentName sql.NullString
+		var currentPort sql.NullInt64
+		var currentPassword []byte
+		var currentStatus string
+		if err := tx.QueryRowContext(ctx, `SELECT db_host, db_port, db_user, db_password, db_name, status
+			FROM db_pool WHERE db_id = ? FOR UPDATE`, in.ID).
+			Scan(&currentHost, &currentPort, &currentUser, &currentPassword, &currentName, &currentStatus); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return fmt.Errorf("lock cloud result for db pool %d: %w", in.ID, err)
+		}
+		if currentStatus != SharedDBStatusPending && currentStatus != SharedDBStatusProvisioning {
 			return ErrNotFound
 		}
-		if checkErr != nil {
-			return fmt.Errorf("confirm cloud result for db pool %d: %w", in.ID, checkErr)
+		host := currentHost.String
+		if in.Host != "" {
+			host = in.Host
 		}
-		if organizationID.String != in.TiDBCloudOrganizationID || clusterID.String != in.ClusterID {
-			return fmt.Errorf("db pool %d cloud identity is %q/%q, not %q/%q", in.ID,
-				organizationID.String, clusterID.String, in.TiDBCloudOrganizationID, in.ClusterID)
+		port := int(currentPort.Int64)
+		if in.Port > 0 {
+			port = in.Port
 		}
-	}
-	return nil
+		user := currentUser.String
+		if in.User != "" {
+			user = in.User
+		}
+		password := currentPassword
+		if len(in.PasswordCipher) > 0 {
+			password = in.PasswordCipher
+		}
+		name := currentName.String
+		if in.Name != "" {
+			name = in.Name
+		}
+		nextStatus := SharedDBStatusPending
+		if host != "" && port > 0 && user != "" && len(password) > 0 && name != "" {
+			nextStatus = SharedDBStatusProvisioning
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE db_pool
+			SET org_id = ?, cluster_id = ?, provisioning_key = NULL,
+				db_host = COALESCE(?, db_host), db_port = COALESCE(?, db_port),
+				db_user = COALESCE(?, db_user), db_password = COALESCE(?, db_password),
+				db_name = COALESCE(?, db_name), db_tls = ?, status = ?
+			WHERE db_id = ?`, in.TiDBCloudOrganizationID, in.ClusterID,
+			nullString(in.Host), nullInt(in.Port), nullString(in.User), nullBytes(in.PasswordCipher),
+			nullString(in.Name), in.TLSMode, nextStatus, in.ID); err != nil {
+			return fmt.Errorf("persist cloud result for db pool %d: %w", in.ID, err)
+		}
+		tenantStatus := TenantPending
+		if nextStatus == SharedDBStatusProvisioning {
+			tenantStatus = TenantProvisioning
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE tenants t
+			JOIN fs_registry f ON f.tenant_id = t.id
+			JOIN tenant_placements p ON p.fs_id = f.fs_id
+			SET t.status = ?, t.updated_at = ?
+			WHERE p.db_id = ? AND t.provider = ? AND t.status IN (?, ?)`, tenantStatus, time.Now().UTC(),
+			in.ID, tidbCloudNativeSharedProvider, TenantPending, TenantProvisioning); err != nil {
+			return fmt.Errorf("advance tenants for db pool %d: %w", in.ID, err)
+		}
+		return nil
+	})
 }
 
 // PrepareManagedSharedDBPoolRoot durably stores the root credential and
 // database name before the first Cloud create call. It is idempotent for a
-// provisioning row that has not yet acquired a cluster identity.
+// pending or legacy provisioning row that has not yet acquired a cluster
+// identity.
 func (s *Store) PrepareManagedSharedDBPoolRoot(ctx context.Context, dbID int64, passwordCipher []byte, databaseName string) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "prepare_managed_shared_db_pool_root", start, &err)
@@ -331,8 +365,8 @@ func (s *Store) PrepareManagedSharedDBPoolRoot(ctx context.Context, dbID int64, 
 	}
 	res, err := s.db.ExecContext(ctx, `UPDATE db_pool
 		SET db_password = COALESCE(db_password, ?), db_name = COALESCE(db_name, ?)
-		WHERE db_id = ? AND status = ? AND cluster_id IS NULL`,
-		passwordCipher, databaseName, dbID, SharedDBStatusProvisioning)
+		WHERE db_id = ? AND status IN (?, ?) AND cluster_id IS NULL`,
+		passwordCipher, databaseName, dbID, SharedDBStatusPending, SharedDBStatusProvisioning)
 	if err != nil {
 		return fmt.Errorf("prepare managed db pool %d root credential: %w", dbID, err)
 	}
@@ -344,8 +378,8 @@ func (s *Store) PrepareManagedSharedDBPoolRoot(ctx context.Context, dbID int64, 
 		return nil
 	}
 	var exists int
-	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM db_pool WHERE db_id = ? AND status = ? AND cluster_id IS NULL
-		AND db_password IS NOT NULL AND db_name IS NOT NULL`, dbID, SharedDBStatusProvisioning).Scan(&exists); err != nil {
+	if err := s.db.QueryRowContext(ctx, `SELECT 1 FROM db_pool WHERE db_id = ? AND status IN (?, ?) AND cluster_id IS NULL
+		AND db_password IS NOT NULL AND db_name IS NOT NULL`, dbID, SharedDBStatusPending, SharedDBStatusProvisioning).Scan(&exists); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return ErrNotFound
 		}
@@ -423,8 +457,8 @@ func (s *Store) ActivateSharedDBPool(ctx context.Context, dbID int64) (err error
 
 func (s *Store) MarkSharedDBPoolFailed(ctx context.Context, dbID int64) error {
 	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?
-		WHERE db_id = ? AND status = ? AND tenant_count = 0`,
-		SharedDBStatusFailed, dbID, SharedDBStatusProvisioning)
+		WHERE db_id = ? AND status IN (?, ?) AND tenant_count = 0`,
+		SharedDBStatusFailed, dbID, SharedDBStatusPending, SharedDBStatusProvisioning)
 	if err != nil {
 		return err
 	}
@@ -438,7 +472,7 @@ func (s *Store) MarkSharedDBPoolFailed(ctx context.Context, dbID int64) error {
 			}
 			return err
 		}
-		if status == SharedDBStatusProvisioning && tenantCount > 0 {
+		if (status == SharedDBStatusPending || status == SharedDBStatusProvisioning) && tenantCount > 0 {
 			return fmt.Errorf("db pool %d has %d placed tenants and cannot be marked failed", dbID, tenantCount)
 		}
 		return ErrNotFound
@@ -451,7 +485,7 @@ func (s *Store) ListSharedDBsByStatus(ctx context.Context, status string, limit 
 	start := time.Now()
 	defer observeMeta(ctx, "list_shared_dbs_by_status", start, &err)
 	switch status {
-	case SharedDBStatusProvisioning, SharedDBStatusActive, SharedDBStatusFailed, SharedDBStatusDraining:
+	case SharedDBStatusPending, SharedDBStatusProvisioning, SharedDBStatusActive, SharedDBStatusFailed, SharedDBStatusDraining:
 	default:
 		return nil, fmt.Errorf("unsupported shared db status %q", status)
 	}
@@ -475,7 +509,7 @@ func (s *Store) ListSharedDBsByStatus(ctx context.Context, status string, limit 
 }
 
 // FindSharedDBForAllocation selects the oldest eligible exact-organization
-// pool, preferring active over provisioning. Managed rows use one fixed
+// pool, preferring active over provisioning over pending. Managed rows use one fixed
 // physical spending limit, so tenant virtual values do not participate in
 // allocation.
 func (s *Store) FindSharedDBForAllocation(ctx context.Context, organizationID string) (db *SharedDB, err error) {
@@ -487,11 +521,11 @@ func (s *Store) FindSharedDBForAllocation(ctx context.Context, organizationID st
 	}
 	query := "SELECT " + sharedDBSelectColumns + " FROM db_pool d " +
 		"WHERE d.org_id = ? AND d.`role` = ? " +
-		"AND d.status IN (?, ?) " +
+		"AND d.status IN (?, ?, ?) " +
 		"AND d.max_tenants > 0 AND d.soft_cap_reached = 0 AND d.tenant_count < d.max_tenants " +
-		"ORDER BY CASE d.status WHEN 'active' THEN 0 ELSE 1 END, d.db_id LIMIT 1"
+		"ORDER BY CASE d.status WHEN 'active' THEN 0 WHEN 'provisioning' THEN 1 ELSE 2 END, d.db_id LIMIT 1"
 	db, err = scanSharedDBRow(s.db.QueryRowContext(ctx, query, organizationID, SharedDBRoleShared,
-		SharedDBStatusActive, SharedDBStatusProvisioning))
+		SharedDBStatusActive, SharedDBStatusProvisioning, SharedDBStatusPending))
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -882,14 +916,15 @@ var ErrSharedDBCapacityExhausted = errors.New("shared db capacity exhausted")
 var ErrSharedDBQuotaNotMaterialized = errors.New("shared tenant quota is not materialized")
 
 // CompleteSharedTenantProvision atomically performs every meta write that
-// turns a pending tenant into a live shared-pool tenant, in one transaction:
+// places a pending tenant into a shared pool, in one transaction:
 //
 //  1. the conditional capacity reservation (two concurrent provisions
 //     cannot take the same last slot — the loser gets
 //     ErrSharedDBCapacityExhausted),
 //  2. the placement insert,
 //  3. the provider re-label and readiness transition on the tenant row
-//     (active only when the DB pool is active; otherwise provisioning), and
+//     (pending while connection metadata is incomplete, provisioning while
+//     schema init is running, and active only when the DB pool is active), and
 //  4. the owner API key insert (ErrDuplicate on key id collision).
 //
 // Either all of it commits or none does: a shared tenant can never become
@@ -983,7 +1018,9 @@ func (s *Store) completeSharedTenantProvision(ctx context.Context, tenantID, pro
 		}
 		switch capacityMode {
 		case SharedDBCapacityNormal:
-			if dbPoolStatus != SharedDBStatusActive && (dbPoolStatus != SharedDBStatusProvisioning || (membership == nil && (!clusterID.Valid || clusterID.String == ""))) {
+			if dbPoolStatus != SharedDBStatusActive &&
+				((dbPoolStatus != SharedDBStatusProvisioning && dbPoolStatus != SharedDBStatusPending) ||
+					(membership == nil && (!clusterID.Valid || clusterID.String == ""))) {
 				return fmt.Errorf("db pool %d is not physically ready: status=%s cluster=%q membership=%t: %w", p.DbID, dbPoolStatus, clusterID.String, membership != nil, ErrSharedDBCapacityExhausted)
 			}
 			if maxTenants <= 0 || softCapReached || tenantCount >= maxTenants {
@@ -1010,11 +1047,11 @@ func (s *Store) completeSharedTenantProvision(ctx context.Context, tenantID, pro
 				WHERE db_id = ? AND (%s)
 					AND max_tenants > 0 AND soft_cap_reached = 0 AND tenant_count + 1 <= max_tenants`
 			if membership != nil {
-				normalQuery = fmt.Sprintf(normalQuery, "status IN (?, ?)")
-				res, err = tx.ExecContext(ctx, normalQuery, p.DbID, SharedDBStatusActive, SharedDBStatusProvisioning)
+				normalQuery = fmt.Sprintf(normalQuery, "status IN (?, ?, ?)")
+				res, err = tx.ExecContext(ctx, normalQuery, p.DbID, SharedDBStatusActive, SharedDBStatusProvisioning, SharedDBStatusPending)
 			} else {
-				normalQuery = fmt.Sprintf(normalQuery, "status = ? OR (status = ? AND cluster_id IS NOT NULL)")
-				res, err = tx.ExecContext(ctx, normalQuery, p.DbID, SharedDBStatusActive, SharedDBStatusProvisioning)
+				normalQuery = fmt.Sprintf(normalQuery, "status = ? OR (status IN (?, ?) AND cluster_id IS NOT NULL)")
+				res, err = tx.ExecContext(ctx, normalQuery, p.DbID, SharedDBStatusActive, SharedDBStatusProvisioning, SharedDBStatusPending)
 			}
 		}
 		if err != nil {
@@ -1033,6 +1070,8 @@ func (s *Store) completeSharedTenantProvision(ctx context.Context, tenantID, pro
 			tenantStatus = TenantActive
 		case SharedDBStatusProvisioning:
 			tenantStatus = TenantProvisioning
+		case SharedDBStatusPending:
+			tenantStatus = TenantPending
 		default:
 			return fmt.Errorf("db pool %d is not allocatable in status %q", p.DbID, dbPoolStatus)
 		}

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -1007,36 +1007,6 @@ func TestManagedSharedDBPoolCloudResultSchemaAndActivation(t *testing.T) {
 	}
 }
 
-func TestPartialCloudResultRestoresLegacyProvisioningPoolToPending(t *testing.T) {
-	s := newControlStore(t)
-	ctx := context.Background()
-	spendingLimit := MaxTiDBCloudSpendingLimit
-	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
-		TiDBCloudOrganizationID: "org-legacy-pending", ProvisioningKey: make([]byte, 32),
-		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
-		PasswordCipher: []byte("root-cipher"), Name: "tidbcloud_fs",
-	})
-	if err != nil {
-		t.Fatalf("CreateManagedSharedDBPool: %v", err)
-	}
-	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, SharedDBStatusProvisioning, dbID); err != nil {
-		t.Fatalf("seed legacy provisioning status: %v", err)
-	}
-	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, &SharedDB{
-		ID: dbID, TiDBCloudOrganizationID: "org-legacy-pending", ClusterID: "cluster-legacy-pending",
-		PasswordCipher: []byte("root-cipher"), Name: "tidbcloud_fs", TLSMode: "true",
-	}); err != nil {
-		t.Fatalf("UpdateManagedSharedDBPoolCloudResult: %v", err)
-	}
-	got, err := s.GetSharedDB(ctx, dbID)
-	if err != nil {
-		t.Fatalf("GetSharedDB: %v", err)
-	}
-	if got.Status != SharedDBStatusPending {
-		t.Fatalf("legacy incomplete pool status = %q, want pending", got.Status)
-	}
-}
-
 func TestActivateSharedTenantsBatchRequiresReadyPoolPlacementAndOwnerKey(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -144,7 +144,7 @@ func TestRegisterSharedDBRoundTrip(t *testing.T) {
 	}
 }
 
-func TestCreateManagedSharedDBPoolPersistsDurableProvisioningPlan(t *testing.T) {
+func TestCreateManagedSharedDBPoolPersistsDurablePendingPlan(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 	spendingLimit := int64(2_000_000)
@@ -180,7 +180,7 @@ func TestCreateManagedSharedDBPoolPersistsDurableProvisioningPlan(t *testing.T) 
 	if _, err := uuid.Parse(got.UUID); err != nil {
 		t.Fatalf("managed db pool UUID = %q: %v", got.UUID, err)
 	}
-	if got.Status != SharedDBStatusProvisioning || got.MaxTenants != 100 || got.SpendingLimit == nil || *got.SpendingLimit != spendingLimit {
+	if got.Status != SharedDBStatusPending || got.MaxTenants != 100 || got.SpendingLimit == nil || *got.SpendingLimit != spendingLimit {
 		t.Fatalf("managed db pool policy = %+v", got)
 	}
 	if got.Host != "" || got.Port != 0 || got.User != "" || got.Name != "tidbcloud_fs" || string(got.PasswordCipher) != "durable-root-cipher" {
@@ -253,8 +253,8 @@ func TestMarkSharedDBPoolFailedRejectsPoolWithTenants(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSharedDB: %v", err)
 	}
-	if got.Status != SharedDBStatusProvisioning {
-		t.Fatalf("status = %q, want provisioning", got.Status)
+	if got.Status != SharedDBStatusPending {
+		t.Fatalf("status = %q, want pending", got.Status)
 	}
 }
 
@@ -861,7 +861,7 @@ func TestCompleteSharedTenantProvisionCommitsAtomically(t *testing.T) {
 	}
 }
 
-func TestCompleteSharedTenantProvisionKeepsTenantProvisioningUntilDBPoolIsActive(t *testing.T) {
+func TestCompleteSharedTenantProvisionKeepsTenantPendingUntilConnectionMetadataIsReady(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 	spendingLimit := MaxTiDBCloudSpendingLimit
@@ -893,8 +893,8 @@ func TestCompleteSharedTenantProvisionKeepsTenantProvisioningUntilDBPoolIsActive
 	if err != nil {
 		t.Fatalf("GetTenant: %v", err)
 	}
-	if tenant.Status != TenantProvisioning || tenant.Provider != "tidb_cloud_native_shared" {
-		t.Fatalf("tenant = provider %q status %q, want shared/provisioning", tenant.Provider, tenant.Status)
+	if tenant.Status != TenantPending || tenant.Provider != "tidb_cloud_native_shared" {
+		t.Fatalf("tenant = provider %q status %q, want shared/pending", tenant.Provider, tenant.Status)
 	}
 	placement, err := s.GetTenantPlacement(ctx, fsID)
 	if err != nil {
@@ -916,20 +916,57 @@ func TestManagedSharedDBPoolCloudResultSchemaAndActivation(t *testing.T) {
 	if err != nil {
 		t.Fatalf("CreateManagedSharedDBPool: %v", err)
 	}
+	partialCloudResult := &SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-managed", ClusterID: "cluster-managed",
+		PasswordCipher: []byte("root-cipher"), Name: "tidbcloud_fs", TLSMode: "true",
+	}
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, partialCloudResult); err != nil {
+		t.Fatalf("UpdateManagedSharedDBPoolCloudResult partial: %v", err)
+	}
+	got, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB after partial cloud result: %v", err)
+	}
+	if got.Status != SharedDBStatusPending || got.ClusterID != "cluster-managed" || got.Host != "" || got.Port != 0 || got.User != "" {
+		t.Fatalf("partial cloud result = %+v, want pending without connection metadata", got)
+	}
+
+	seedPendingTenant(t, s, "tenant-managed-pending")
+	virtualLimit := int64(1000)
+	if err := s.SetQuotaConfigPatch(ctx, "tenant-managed-pending", QuotaConfigPatch{TiDBCloudSpendingLimit: &virtualLimit}); err != nil {
+		t.Fatalf("SetQuotaConfigPatch: %v", err)
+	}
+	fsID, err := s.EnsureFsID(ctx, "tenant-managed-pending")
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if err := s.CompleteSharedTenantProvision(ctx, "tenant-managed-pending", "tidb_cloud_native_shared", &TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared,
+	}, testOwnerKey("tenant-managed-pending")); err != nil {
+		t.Fatalf("CompleteSharedTenantProvision: %v", err)
+	}
+	pendingTenant, err := s.GetTenant(ctx, "tenant-managed-pending")
+	if err != nil {
+		t.Fatalf("GetTenant pending: %v", err)
+	}
+	if pendingTenant.Status != TenantPending {
+		t.Fatalf("tenant before connection metadata = %q, want pending", pendingTenant.Status)
+	}
+
 	cloudResult := &SharedDB{
 		ID: dbID, TiDBCloudOrganizationID: "org-managed", ClusterID: "cluster-managed",
 		Host: "shared.example.com", Port: 4000, User: "root", PasswordCipher: []byte("root-cipher"),
 		Name: "tidbcloud_fs", TLSMode: "true",
 	}
 	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, cloudResult); err != nil {
-		t.Fatalf("UpdateManagedSharedDBPoolCloudResult: %v", err)
+		t.Fatalf("UpdateManagedSharedDBPoolCloudResult complete: %v", err)
 	}
 	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, cloudResult); err != nil {
 		t.Fatalf("idempotent UpdateManagedSharedDBPoolCloudResult: %v", err)
 	}
-	got, err := s.GetSharedDB(ctx, dbID)
+	got, err = s.GetSharedDB(ctx, dbID)
 	if err != nil {
-		t.Fatalf("GetSharedDB after cloud result: %v", err)
+		t.Fatalf("GetSharedDB after complete cloud result: %v", err)
 	}
 	if got.TiDBCloudOrganizationID != "org-managed" || got.ClusterID != "cluster-managed" || got.Host != "shared.example.com" || got.Port != 4000 {
 		t.Fatalf("cloud result not persisted: %+v", got)
@@ -939,6 +976,13 @@ func TestManagedSharedDBPoolCloudResultSchemaAndActivation(t *testing.T) {
 	}
 	if got.Status != SharedDBStatusProvisioning {
 		t.Fatalf("status after cloud result = %q, want provisioning", got.Status)
+	}
+	provisioningTenant, err := s.GetTenant(ctx, "tenant-managed-pending")
+	if err != nil {
+		t.Fatalf("GetTenant provisioning: %v", err)
+	}
+	if provisioningTenant.Status != TenantProvisioning {
+		t.Fatalf("tenant after connection metadata = %q, want provisioning", provisioningTenant.Status)
 	}
 
 	if err := s.UpdateSharedDBSchemaVersion(ctx, dbID, 17); err != nil {
@@ -960,6 +1004,36 @@ func TestManagedSharedDBPoolCloudResultSchemaAndActivation(t *testing.T) {
 	}
 	if len(rows) != 1 || rows[0].ID != dbID {
 		t.Fatalf("active rows = %+v, want db %d", rows, dbID)
+	}
+}
+
+func TestPartialCloudResultRestoresLegacyProvisioningPoolToPending(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-legacy-pending", ProvisioningKey: make([]byte, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+		PasswordCipher: []byte("root-cipher"), Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, SharedDBStatusProvisioning, dbID); err != nil {
+		t.Fatalf("seed legacy provisioning status: %v", err)
+	}
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, &SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-legacy-pending", ClusterID: "cluster-legacy-pending",
+		PasswordCipher: []byte("root-cipher"), Name: "tidbcloud_fs", TLSMode: "true",
+	}); err != nil {
+		t.Fatalf("UpdateManagedSharedDBPoolCloudResult: %v", err)
+	}
+	got, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.Status != SharedDBStatusPending {
+		t.Fatalf("legacy incomplete pool status = %q, want pending", got.Status)
 	}
 }
 
@@ -996,9 +1070,16 @@ func TestActivateSharedTenantsBatchRequiresReadyPoolPlacementAndOwnerKey(t *test
 	if _, err := s.db.ExecContext(ctx, `DELETE FROM tenant_api_keys WHERE tenant_id = ?`, "tenant-activate-2"); err != nil {
 		t.Fatalf("remove second owner key: %v", err)
 	}
-	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?, db_host = 'h', db_port = 4000,
-		db_user = 'u', db_password = 'c', db_name = 'n', schema_version = 1 WHERE db_id = ?`, SharedDBStatusActive, dbID); err != nil {
-		t.Fatalf("mark pool active: %v", err)
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, &SharedDB{ID: dbID,
+		TiDBCloudOrganizationID: "org-activation", ClusterID: "cluster-activation", Host: "h", Port: 4000,
+		User: "u", PasswordCipher: []byte("c"), Name: "n"}); err != nil {
+		t.Fatalf("complete pool connection metadata: %v", err)
+	}
+	if err := s.UpdateSharedDBSchemaVersion(ctx, dbID, 1); err != nil {
+		t.Fatalf("mark pool schema ready: %v", err)
+	}
+	if err := s.ActivateSharedDBPool(ctx, dbID); err != nil {
+		t.Fatalf("activate pool: %v", err)
 	}
 
 	activated, err := s.ActivateSharedTenantsBatch(ctx, dbID, 100)

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -951,6 +951,7 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 	createdPoolIDs := make(map[int64]struct{})
 	continuationPoolIDs := make(map[int64]struct{})
 	results := make([]*provisionTenantResult, 0, count)
+	resultPoolIDs := make([]int64, 0, count)
 	for i := 0; i < count; i++ {
 		tenantID := token.NewID()
 		if err := s.insertPendingPoolTenant(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, now); err != nil {
@@ -995,6 +996,7 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 			Status: resultStatus, Provider: tenant.ProviderTiDBCloudNativeShared,
 			CloudProvider: selected.CloudProvider, Region: selected.Region,
 			OrganizationID: selected.TiDBCloudOrganizationID})
+		resultPoolIDs = append(resultPoolIDs, selected.ID)
 	}
 	createdIDs := make([]int64, 0, len(createdPoolIDs))
 	for id := range createdPoolIDs {
@@ -1014,6 +1016,26 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 		}
 		for _, result := range results {
 			result.OrganizationID = resolvedOrg
+		}
+	}
+	createdPoolStatuses := make(map[int64]meta.TenantStatus, len(createdIDs))
+	for _, dbID := range createdIDs {
+		sharedDB, err := s.meta.GetSharedDB(ctx, dbID)
+		if err != nil {
+			return results, err
+		}
+		status := meta.TenantPending
+		switch sharedDB.Status {
+		case meta.SharedDBStatusProvisioning:
+			status = meta.TenantProvisioning
+		case meta.SharedDBStatusActive:
+			status = meta.TenantActive
+		}
+		createdPoolStatuses[dbID] = status
+	}
+	for i, dbID := range resultPoolIDs {
+		if status, ok := createdPoolStatuses[dbID]; ok {
+			results[i].Status = status
 		}
 	}
 	continuationIDs := make([]int64, 0, len(continuationPoolIDs))

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -949,7 +949,7 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 	}
 	now := time.Now().UTC()
 	createdPoolIDs := make(map[int64]struct{})
-	provisioningPoolIDs := make(map[int64]struct{})
+	continuationPoolIDs := make(map[int64]struct{})
 	results := make([]*provisionTenantResult, 0, count)
 	for i := 0; i < count; i++ {
 		tenantID := token.NewID()
@@ -981,11 +981,14 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 		if created {
 			createdPoolIDs[selected.ID] = struct{}{}
 		}
-		if selected.Status == meta.SharedDBStatusProvisioning {
-			provisioningPoolIDs[selected.ID] = struct{}{}
+		if selected.Status == meta.SharedDBStatusPending || selected.Status == meta.SharedDBStatusProvisioning {
+			continuationPoolIDs[selected.ID] = struct{}{}
 		}
-		resultStatus := meta.TenantProvisioning
-		if selected.Status == meta.SharedDBStatusActive {
+		resultStatus := meta.TenantPending
+		switch selected.Status {
+		case meta.SharedDBStatusProvisioning:
+			resultStatus = meta.TenantProvisioning
+		case meta.SharedDBStatusActive:
 			resultStatus = meta.TenantActive
 		}
 		results = append(results, &provisionTenantResult{TenantID: tenantID,
@@ -1013,11 +1016,11 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 			result.OrganizationID = resolvedOrg
 		}
 	}
-	provisioningIDs := make([]int64, 0, len(provisioningPoolIDs))
-	for dbID := range provisioningPoolIDs {
-		provisioningIDs = append(provisioningIDs, dbID)
+	continuationIDs := make([]int64, 0, len(continuationPoolIDs))
+	for dbID := range continuationPoolIDs {
+		continuationIDs = append(continuationIDs, dbID)
 	}
-	s.scheduleManagedSharedDBContinuations(ctx, provisioningIDs)
+	s.scheduleManagedSharedDBContinuations(ctx, continuationIDs)
 	return results, nil
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -206,13 +206,18 @@ func TestSharedTenantPoolRefillOneThousandPlansTenPoolsInOneBatch(t *testing.T) 
 	if len(results) != 1000 {
 		t.Fatalf("results = %d, want 1000", len(results))
 	}
+	for _, result := range results {
+		if result.Status != meta.TenantPending {
+			t.Fatalf("tenant %s status = %q, want pending while connection metadata is incomplete", result.TenantID, result.Status)
+		}
+	}
 	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
 		t.Fatalf("shared batch calls = %d, want 1", got)
 	}
 	if got := prov.sharedPoolBatchMembers.Load(); got != 10 {
 		t.Fatalf("shared batch members = %d, want 10", got)
 	}
-	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusProvisioning, 20)
+	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusPending, 20)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -233,6 +233,71 @@ func TestSharedTenantPoolRefillOneThousandPlansTenPoolsInOneBatch(t *testing.T) 
 	}
 }
 
+func TestSharedTenantPoolDefensivelyReportsProvisioningWhenBatchMetadataComplete(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer poolManager.Close()
+	poolManager.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{
+		provider:      tenant.ProviderTiDBCloudNative,
+		cloudProvider: "aws",
+		region:        "us-east-1",
+		managedClusters: []tenant.CloudClusterInfo{{
+			OrganizationID: "org-shared-defensive",
+		}},
+		sharedPoolResults: []*tenant.SharedDBPoolInfo{{
+			ClusterID: "cluster-ready", Host: "127.0.0.1", Port: 4000,
+			Username: "root", DBName: "tidbcloud_fs",
+		}},
+	}
+	secret := make([]byte, 32)
+	if _, err := rand.Read(secret); err != nil {
+		t.Fatal(err)
+	}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: secret})
+	defer srv.Close()
+	now := time.Now().UTC()
+	if err := metaStore.CreateTenantPool(context.Background(), &meta.TenantPool{
+		PoolID: "pool-shared-defensive", OrganizationID: "org-shared-defensive", Size: 1,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := srv.createFreePoolTenants(context.Background(), "pool-shared-defensive", 1,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}, nil)
+	if err != nil {
+		t.Fatalf("createFreePoolTenants: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].Status != meta.TenantProvisioning {
+		t.Fatalf("result status = %q, want provisioning", results[0].Status)
+	}
+	got, err := metaStore.GetTenant(context.Background(), results[0].TenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != meta.TenantProvisioning {
+		t.Fatalf("persisted tenant status = %q, want provisioning", got.Status)
+	}
+}
+
 func TestAdminTenantPoolCreateCleansPartialSharedMembersOnBatchFailure(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -3604,6 +3604,58 @@ func TestReconcilePendingNativePoolTenantWithoutConnectionStaysPending(t *testin
 	}
 }
 
+func TestReconcilePendingSharedPoolTenantWithoutConnectionStaysPending(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	ctx := context.Background()
+	spendingLimit := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-pending-shared", ProvisioningKey: make([]byte, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+		PasswordCipher: []byte("cipher"), Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	tenantID := token.NewID()
+	now := time.Now().UTC().Add(-2 * time.Minute)
+	origStaleAfter := pendingTenantStaleAfter
+	pendingTenantStaleAfter = time.Minute
+	defer func() { pendingTenantStaleAfter = origStaleAfter }()
+	pendingTenant := meta.Tenant{
+		ID: tenantID, Status: meta.TenantPending, Provider: tenant.ProviderTiDBCloudNativeShared,
+		DBPasswordCipher: []byte{}, DBTLS: true, SchemaVersion: 1, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := metaStore.InsertTenant(ctx, &pendingTenant); err != nil {
+		t.Fatal(err)
+	}
+	fsID, err := metaStore.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if err := metaStore.UpsertTenantPlacement(ctx, &meta.TenantPlacement{
+		FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared,
+		Status: meta.SharedDBStatusActive,
+	}); err != nil {
+		t.Fatalf("UpsertTenantPlacement: %v", err)
+	}
+
+	srv := &Server{meta: metaStore}
+	srv.reconcilePendingTenant(ctx, pendingTenant)
+	got, err := metaStore.GetTenant(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != meta.TenantPending {
+		t.Fatalf("shared pool tenant status after reconcile = %s, want %s", got.Status, meta.TenantPending)
+	}
+}
+
 func TestReconcilePendingNativeTenantWithConnectionResumesSchemaInit(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -941,7 +941,7 @@ func TestManagedSharedDBContinuationBatchesDoNotEnterBlockingMetadataWait(t *tes
 	})
 	go func() {
 		defer close(resumeDone)
-		srv.resumeManagedSharedDBPoolsWithCtx(resumeCtx)
+		srv.resumePendingManagedSharedDBPoolsWithCtx(resumeCtx)
 	}()
 	select {
 	case got := <-resumeLoadIDs:

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -707,6 +707,62 @@ func TestManagedSharedDBContinuationWaitsForConnectionMetadata(t *testing.T) {
 	}
 }
 
+func TestManagedSharedDBContinuationRejectsProvisioningPoolWithoutConnectionMetadata(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(pool.Close)
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-provisioning-invariant", ProvisioningKey: bytes.Repeat([]byte{8}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+		PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := metaStore.DB().ExecContext(context.Background(),
+		`UPDATE db_pool SET status = ? WHERE db_id = ?`, meta.SharedDBStatusProvisioning, dbID); err != nil {
+		t.Fatal(err)
+	}
+	row, err := metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov}
+	err = srv.continueManagedSharedDBPoolLocked(context.Background(), row, tenant.CredentialProvisionRequest{
+		PublicKey: "shared-public", PrivateKey: "shared-private",
+	})
+	if err == nil || !strings.Contains(err.Error(), "incomplete connection metadata") {
+		t.Fatalf("continueManagedSharedDBPoolLocked error = %v, want incomplete connection metadata", err)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 0 {
+		t.Fatalf("shared batch calls = %d, want 0", got)
+	}
+	if got := prov.sharedPoolWaitCalls.Load(); got != 0 {
+		t.Fatalf("shared metadata wait calls = %d, want 0", got)
+	}
+}
+
 func TestManagedSharedDBContinuationPassesCustomerOrganizationToPhysicalCreate(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -158,7 +158,7 @@ func TestDefaultTenantProviderIsIndependentFromProvisionerType(t *testing.T) {
 	}
 }
 
-func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t *testing.T) {
+func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsPending(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -207,8 +207,8 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	if err != nil {
 		t.Fatalf("provisionTenant: %v", err)
 	}
-	if res.Provider != tenant.ProviderTiDBCloudNativeShared || res.Status != meta.TenantProvisioning {
-		t.Fatalf("result = provider %q status %q, want shared/provisioning", res.Provider, res.Status)
+	if res.Provider != tenant.ProviderTiDBCloudNativeShared || res.Status != meta.TenantPending {
+		t.Fatalf("result = provider %q status %q, want shared/pending", res.Provider, res.Status)
 	}
 	if res.OrganizationID != "customer-org" {
 		t.Fatalf("organization ID = %q, want customer-org", res.OrganizationID)
@@ -217,7 +217,7 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsProvisioning(t 
 	if err != nil {
 		t.Fatalf("GetTenant: %v", err)
 	}
-	if tenantRow.Status != meta.TenantProvisioning || tenantRow.Provider != tenant.ProviderTiDBCloudNativeShared {
+	if tenantRow.Status != meta.TenantPending || tenantRow.Provider != tenant.ProviderTiDBCloudNativeShared {
 		t.Fatalf("tenant = provider %q status %q", tenantRow.Provider, tenantRow.Status)
 	}
 	fsID, err := metaStore.ResolveFsID(context.Background(), res.TenantID)
@@ -340,7 +340,7 @@ func TestProvisionTiDBCloudNativeSharedFallsBackToHardCapacityAfterCreateFailure
 	if prov.sharedPoolBatchCalls.Load() != 1 {
 		t.Fatalf("physical create calls = %d, want 1", prov.sharedPoolBatchCalls.Load())
 	}
-	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusProvisioning, 10)
+	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusPending, 10)
 	if err != nil {
 		t.Fatalf("ListSharedDBsByStatus: %v", err)
 	}
@@ -482,7 +482,7 @@ func TestProvisionTiDBCloudNativeSharedRetriesCapacityRace(t *testing.T) {
 	}
 }
 
-func TestProvisionTiDBCloudNativeSharedResumesExistingProvisioningPool(t *testing.T) {
+func TestProvisionTiDBCloudNativeSharedResumesExistingPendingPool(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -526,8 +526,8 @@ func TestProvisionTiDBCloudNativeSharedResumesExistingProvisioningPool(t *testin
 	if err != nil {
 		t.Fatalf("provisionTenant: %v", err)
 	}
-	if res.Status != meta.TenantProvisioning {
-		t.Fatalf("status = %q, want provisioning", res.Status)
+	if res.Status != meta.TenantPending {
+		t.Fatalf("status = %q, want pending", res.Status)
 	}
 	placement, err := metaStore.GetTenantPlacement(context.Background(), mustResolveFsID(t, metaStore, res.TenantID))
 	if err != nil {
@@ -543,12 +543,12 @@ func TestProvisionTiDBCloudNativeSharedResumesExistingProvisioningPool(t *testin
 	if prov.sharedPoolBatchCalls.Load() != 1 {
 		t.Fatalf("shared pool batch calls = %d, want resume call", prov.sharedPoolBatchCalls.Load())
 	}
-	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusProvisioning, 10)
+	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusPending, 10)
 	if err != nil {
 		t.Fatalf("ListSharedDBsByStatus: %v", err)
 	}
 	if len(rows) != 1 || rows[0].ID != dbID {
-		t.Fatalf("provisioning pools = %+v, want only %d", rows, dbID)
+		t.Fatalf("pending pools = %+v, want only %d", rows, dbID)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -816,7 +816,10 @@ func (s *Server) startLeaderWorkers() {
 			s.resumeProvisioningTenantsWithCtx(workerCtx)
 		})
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
-			s.resumeManagedSharedDBPoolsWithCtx(workerCtx)
+			s.resumePendingManagedSharedDBPoolsWithCtx(workerCtx)
+		})
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			s.resumeProvisioningManagedSharedDBPoolsWithCtx(workerCtx)
 		})
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
 			s.resumeDeletingForkTenantsWithCtx(workerCtx)
@@ -846,7 +849,8 @@ func (s *Server) startLeaderWorkers() {
 						return
 					case <-ticker.C:
 						s.resumePendingTenantsWithCtx(workerCtx)
-						s.resumeManagedSharedDBPoolsWithCtx(workerCtx)
+						s.resumePendingManagedSharedDBPoolsWithCtx(workerCtx)
+						s.resumeProvisioningManagedSharedDBPoolsWithCtx(workerCtx)
 					}
 				}
 			})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -5225,7 +5225,10 @@ func (s *Server) provisionTenantOnSharedDBMode(ctx context.Context, tenantID str
 	logger.Info(ctx, "server_event", eventFields(ctx, "provision_shared_pool_placed", "tenant_id", tenantID, "provider", tenant.ProviderTiDBCloudNativeShared, "db_pool_id", sharedDB.ID, "db_pool_uuid", sharedDB.UUID, "tidbcloud_org_id", sharedDB.TiDBCloudOrganizationID)...)
 	metricEvent(ctx, "tenant_provision", "provider", tenant.ProviderTiDBCloudNativeShared, "result", "shared_pool")
 	status := meta.TenantActive
-	if sharedDB.Status == meta.SharedDBStatusProvisioning {
+	switch sharedDB.Status {
+	case meta.SharedDBStatusPending:
+		status = meta.TenantPending
+	case meta.SharedDBStatusProvisioning:
 		status = meta.TenantProvisioning
 	}
 	return &provisionTenantResult{
@@ -5353,7 +5356,7 @@ func (s *Server) provisionTenant(ctx context.Context, opts provisionTenantOption
 				_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 				return nil, reserveErr
 			}
-			if created || sharedDB.Status == meta.SharedDBStatusProvisioning {
+			if created || sharedDB.Status == meta.SharedDBStatusPending || sharedDB.Status == meta.SharedDBStatusProvisioning {
 				s.scheduleManagedSharedDBContinuation(ctx, sharedDB.ID)
 			}
 			return res, nil

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1201,6 +1201,22 @@ func (s *Server) reconcilePendingTenant(ctx context.Context, t meta.Tenant) {
 		}
 		return
 	}
+	if t.Provider == tenant.ProviderTiDBCloudNativeShared {
+		_, err := s.meta.GetSharedDBForTenant(ctx, t.ID)
+		if err == nil {
+			logger.Info(ctx, "resume_pending_shared_pool_tenant_skipped",
+				zap.String("tenant_id", t.ID),
+				zap.String("provider", t.Provider),
+				zap.String("reason", "managed_by_shared_pool"))
+			return
+		}
+		if !errors.Is(err, meta.ErrNotFound) {
+			logger.Error(ctx, "resume_pending_shared_pool_tenant_lookup_error",
+				zap.String("tenant_id", t.ID),
+				zap.Error(err))
+			return
+		}
+	}
 	if !isStalePendingTenant(time.Now().UTC(), t) {
 		return
 	}

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -291,7 +291,7 @@ func (s *Server) managedSharedDBContinuation(ctx context.Context, dbID int64) ma
 		if err != nil {
 			return err
 		}
-		if poolInfo.Status != meta.SharedDBStatusProvisioning {
+		if poolInfo.Status != meta.SharedDBStatusPending && poolInfo.Status != meta.SharedDBStatusProvisioning {
 			return nil
 		}
 		return s.continueManagedSharedDBPoolOnce(poolCtx, dbID)
@@ -361,10 +361,14 @@ func retryManagedSharedDBContinuations(ctx context.Context, states []managedShar
 }
 
 func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
-	rows, err := s.meta.ListSharedDBsByStatus(ctx, meta.SharedDBStatusProvisioning, 1000)
-	if err != nil {
-		logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.Error(err))
-		return
+	var rows []*meta.SharedDB
+	for _, status := range []string{meta.SharedDBStatusPending, meta.SharedDBStatusProvisioning} {
+		statusRows, err := s.meta.ListSharedDBsByStatus(ctx, status, 1000)
+		if err != nil {
+			logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.String("status", status), zap.Error(err))
+			return
+		}
+		rows = append(rows, statusRows...)
 	}
 	states := make([]managedSharedDBContinuation, 0, len(rows))
 	for _, row := range rows {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -360,15 +360,19 @@ func retryManagedSharedDBContinuations(ctx context.Context, states []managedShar
 	}
 }
 
-func (s *Server) resumeManagedSharedDBPoolsWithCtx(ctx context.Context) {
-	var rows []*meta.SharedDB
-	for _, status := range []string{meta.SharedDBStatusPending, meta.SharedDBStatusProvisioning} {
-		statusRows, err := s.meta.ListSharedDBsByStatus(ctx, status, 1000)
-		if err != nil {
-			logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.String("status", status), zap.Error(err))
-			return
-		}
-		rows = append(rows, statusRows...)
+func (s *Server) resumeProvisioningManagedSharedDBPoolsWithCtx(ctx context.Context) {
+	s.resumeManagedSharedDBPoolsByStatus(ctx, meta.SharedDBStatusProvisioning)
+}
+
+func (s *Server) resumePendingManagedSharedDBPoolsWithCtx(ctx context.Context) {
+	s.resumeManagedSharedDBPoolsByStatus(ctx, meta.SharedDBStatusPending)
+}
+
+func (s *Server) resumeManagedSharedDBPoolsByStatus(ctx context.Context, status string) {
+	rows, err := s.meta.ListSharedDBsByStatus(ctx, status, 1000)
+	if err != nil {
+		logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.String("status", status), zap.Error(err))
+		return
 	}
 	states := make([]managedSharedDBContinuation, 0, len(rows))
 	for _, row := range rows {
@@ -615,6 +619,9 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 		return fmt.Errorf("decrypt shared db root password: %w", err)
 	}
 	needsMetadata := poolInfo.ClusterID == "" || poolInfo.Host == "" || poolInfo.Port <= 0 || poolInfo.User == ""
+	if poolInfo.Status == meta.SharedDBStatusProvisioning && needsMetadata {
+		return fmt.Errorf("provisioning db pool %d has incomplete connection metadata", dbID)
+	}
 	if needsMetadata {
 		if poolInfo.SpendingLimit == nil {
 			return fmt.Errorf("managed db pool %d has no spending target", dbID)

--- a/pkg/server/tenant_metrics_test.go
+++ b/pkg/server/tenant_metrics_test.go
@@ -150,7 +150,7 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 	ctx := context.Background()
 	spendingLimit := meta.MaxTiDBCloudSpendingLimit
 	const activePoolUUID = "11111111-1111-4111-8111-111111111111"
-	const provisioningPoolUUID = "22222222-2222-4222-8222-222222222222"
+	const pendingPoolUUID = "22222222-2222-4222-8222-222222222222"
 	dbID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
 		UUID:                    activePoolUUID,
 		TiDBCloudOrganizationID: "org-shared-db-metrics",
@@ -166,8 +166,8 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, meta.SharedDBStatusActive, dbID); err != nil {
 		t.Fatalf("activate db pool: %v", err)
 	}
-	provisioningDBID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
-		UUID:                    provisioningPoolUUID,
+	pendingDBID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		UUID:                    pendingPoolUUID,
 		TiDBCloudOrganizationID: "org-shared-db-metrics",
 		ProvisioningKey:         []byte("12345678901234567890123456789012"),
 		CloudProvider:           "aws",
@@ -176,7 +176,7 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 		SpendingLimit:           &spendingLimit,
 	})
 	if err != nil {
-		t.Fatalf("CreateManagedSharedDBPool provisioning: %v", err)
+		t.Fatalf("CreateManagedSharedDBPool pending: %v", err)
 	}
 
 	now := time.Now().UTC()
@@ -214,10 +214,10 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 	s.metrics.writePrometheus(rec)
 	text := rec.Body.String()
 	dbPoolID := fmt.Sprint(dbID)
-	provisioningDBPoolID := fmt.Sprint(provisioningDBID)
+	pendingDBPoolID := fmt.Sprint(pendingDBID)
 	for _, want := range []string{
 		`drive9_shared_db_pool_total{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",status="active",tidbcloud_org_id="org-shared-db-metrics"} 1`,
-		`drive9_shared_db_pool_total{db_pool_id="` + provisioningDBPoolID + `",db_pool_uuid="` + provisioningPoolUUID + `",status="provisioning",tidbcloud_org_id="org-shared-db-metrics"} 1`,
+		`drive9_shared_db_pool_total{db_pool_id="` + pendingDBPoolID + `",db_pool_uuid="` + pendingPoolUUID + `",status="pending",tidbcloud_org_id="org-shared-db-metrics"} 1`,
 		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="soft_max"} 5`,
 		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="hard_max"} 6`,
 		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="used"} 2`,


### PR DESCRIPTION
## Summary

- create managed shared DB pools in `pending` while connection metadata is incomplete
- atomically move the physical pool and placed tenants to `provisioning` once host, port, user, password, and database name are ready
- mirror native lifecycle boundaries: pending recovery performs metadata pull, while provisioning recovery resumes schema initialization
- keep the existing provider pull, retry, schema-init, and activation implementations without adding migration behavior for anomalous historical rows

## Tests

- `make test TEST_PKGS=./pkg/meta`
- `make test TEST_PKGS=./pkg/server TEST_RUN=Shared|Managed`
- `make test TEST_PKGS=./pkg/server TEST_RUN=TestSharedTenantPoolRefillOneThousandPlansTenPoolsInOneBatch`
- targeted pending metadata and phase-specific recovery tests
- `make lint`
- `make build-server`

## Full package note

A full `pkg/server` run still reproduces the pre-existing suite failure with background pollers logging `sql: database is closed`; the shared/managed regression subset passes.