### PR TITLE
fix: correct shared DB pool uniqueness

### DIFF
--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -559,10 +559,10 @@ func (s *Store) FindSharedDBForEmergency(ctx context.Context, organizationID str
 	return db, nil
 }
 
-// RegisterSharedDB registers a physical database in db_pool, upserting on the
-// uk_db_pool_endpoint (org_id, db_host, db_name, db_user) natural key. On a duplicate
-// endpoint the connection fields are refreshed and tenant_count is preserved;
-// the existing db_id is re-fetched and returned.
+// RegisterSharedDB registers a manually configured physical database in
+// db_pool. Its stable UUID is derived from organization and user when omitted;
+// managed cloud pools use CreateManagedSharedDBPool and global cluster_id
+// uniqueness instead.
 func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "register_shared_db", start, &err)
@@ -570,10 +570,6 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 		return 0, fmt.Errorf("shared db is required")
 	}
 	organizationID, err := validateSharedDBOrganizationID(in.TiDBCloudOrganizationID)
-	if err != nil {
-		return 0, err
-	}
-	poolUUID, err := sharedDBUUID(in.UUID)
 	if err != nil {
 		return 0, err
 	}
@@ -585,6 +581,15 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 	}
 	if in.User == "" {
 		return 0, fmt.Errorf("db user is required")
+	}
+	poolUUID := strings.TrimSpace(in.UUID)
+	if poolUUID == "" {
+		poolUUID = uuid.NewSHA1(uuid.NameSpaceOID, []byte(organizationID+"\x00"+in.User)).String()
+	} else {
+		poolUUID, err = sharedDBUUID(poolUUID)
+		if err != nil {
+			return 0, err
+		}
 	}
 	if len(in.PasswordCipher) == 0 {
 		return 0, fmt.Errorf("db password cipher is required")
@@ -612,7 +617,8 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 	if _, err := s.db.ExecContext(ctx,
 		"INSERT INTO db_pool (uuid, org_id, `role`, db_host, db_port, db_user, db_password, db_name, "+
 			"db_tls, max_tenants, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "+
-			"ON DUPLICATE KEY UPDATE db_port = VALUES(db_port), db_user = VALUES(db_user), "+
+			"ON DUPLICATE KEY UPDATE org_id = VALUES(org_id), db_host = VALUES(db_host), "+
+			"db_port = VALUES(db_port), db_user = VALUES(db_user), db_name = VALUES(db_name), "+
 			"db_password = VALUES(db_password), db_tls = VALUES(db_tls), "+
 			"max_tenants = VALUES(max_tenants), status = VALUES(status)",
 		poolUUID, organizationID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
@@ -620,10 +626,9 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 		return 0, fmt.Errorf("upsert db_pool row: %w", err)
 	}
 	// ON DUPLICATE KEY UPDATE does not reliably report the existing
-	// auto-increment id via LastInsertId, so re-fetch by endpoint.
+	// auto-increment id via LastInsertId, so re-fetch by UUID.
 	err = s.db.QueryRowContext(ctx,
-		`SELECT db_id FROM db_pool WHERE org_id = ? AND db_host = ? AND db_name = ? AND db_user = ?`,
-		organizationID, in.Host, in.Name, in.User).Scan(&dbID)
+		`SELECT db_id FROM db_pool WHERE uuid = ?`, poolUUID).Scan(&dbID)
 	if err != nil {
 		return 0, fmt.Errorf("resolve db_id after upsert: %w", err)
 	}

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -560,9 +560,9 @@ func (s *Store) FindSharedDBForEmergency(ctx context.Context, organizationID str
 }
 
 // RegisterSharedDB registers a manually configured physical database in
-// db_pool. Its stable UUID is derived from organization and user when omitted;
-// managed cloud pools use CreateManagedSharedDBPool and global cluster_id
-// uniqueness instead.
+// db_pool. Its stable UUID is derived from the full manual connection identity
+// when omitted; managed cloud pools use CreateManagedSharedDBPool and global
+// cluster_id uniqueness instead.
 func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "register_shared_db", start, &err)
@@ -615,23 +615,39 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 	if status == "" {
 		status = sharedDBStatusActive
 	}
-	if _, err := s.db.ExecContext(ctx,
-		"INSERT INTO db_pool (uuid, org_id, `role`, db_host, db_port, db_user, db_password, db_name, "+
-			"db_tls, max_tenants, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "+
-			"ON DUPLICATE KEY UPDATE org_id = VALUES(org_id), db_host = VALUES(db_host), "+
-			"db_port = VALUES(db_port), db_user = VALUES(db_user), db_name = VALUES(db_name), "+
-			"db_password = VALUES(db_password), db_tls = VALUES(db_tls), "+
-			"max_tenants = VALUES(max_tenants), status = VALUES(status)",
-		poolUUID, organizationID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
-		in.TLSMode, in.MaxTenants, status); err != nil {
-		return 0, fmt.Errorf("upsert db_pool row: %w", err)
-	}
-	// ON DUPLICATE KEY UPDATE does not reliably report the existing
-	// auto-increment id via LastInsertId, so re-fetch by UUID.
-	err = s.db.QueryRowContext(ctx,
-		`SELECT db_id FROM db_pool WHERE uuid = ?`, poolUUID).Scan(&dbID)
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		err := tx.QueryRowContext(ctx, `SELECT db_id FROM db_pool
+			WHERE org_id = ? AND db_host = ? AND db_name = ? AND db_user = ?
+			ORDER BY db_id LIMIT 1 FOR UPDATE`, organizationID, in.Host, in.Name, in.User).Scan(&dbID)
+		if err == nil {
+			if _, err := tx.ExecContext(ctx, `UPDATE db_pool
+				SET db_port = ?, db_password = ?, db_tls = ?, max_tenants = ?, status = ?
+				WHERE db_id = ?`, in.Port, in.PasswordCipher, in.TLSMode, in.MaxTenants, status, dbID); err != nil {
+				return fmt.Errorf("update existing manual db_pool row: %w", err)
+			}
+			return nil
+		}
+		if !errors.Is(err, sql.ErrNoRows) {
+			return fmt.Errorf("find existing manual db_pool row: %w", err)
+		}
+		if _, err := tx.ExecContext(ctx,
+			"INSERT INTO db_pool (uuid, org_id, `role`, db_host, db_port, db_user, db_password, db_name, "+
+				"db_tls, max_tenants, status) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) "+
+				"ON DUPLICATE KEY UPDATE org_id = VALUES(org_id), db_host = VALUES(db_host), "+
+				"db_port = VALUES(db_port), db_user = VALUES(db_user), db_name = VALUES(db_name), "+
+				"db_password = VALUES(db_password), db_tls = VALUES(db_tls), "+
+				"max_tenants = VALUES(max_tenants), status = VALUES(status)",
+			poolUUID, organizationID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
+			in.TLSMode, in.MaxTenants, status); err != nil {
+			return fmt.Errorf("upsert manual db_pool row: %w", err)
+		}
+		if err := tx.QueryRowContext(ctx, `SELECT db_id FROM db_pool WHERE uuid = ?`, poolUUID).Scan(&dbID); err != nil {
+			return fmt.Errorf("resolve db_id after upsert: %w", err)
+		}
+		return nil
+	})
 	if err != nil {
-		return 0, fmt.Errorf("resolve db_id after upsert: %w", err)
+		return 0, err
 	}
 	return dbID, nil
 }

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -584,7 +584,8 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 	}
 	poolUUID := strings.TrimSpace(in.UUID)
 	if poolUUID == "" {
-		poolUUID = uuid.NewSHA1(uuid.NameSpaceOID, []byte(organizationID+"\x00"+in.User)).String()
+		poolUUID = uuid.NewSHA1(uuid.NameSpaceOID, []byte(strings.Join(
+			[]string{organizationID, in.Host, in.Name, in.User}, "\x00"))).String()
 	} else {
 		poolUUID, err = sharedDBUUID(poolUUID)
 		if err != nil {

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -560,7 +560,7 @@ func (s *Store) FindSharedDBForEmergency(ctx context.Context, organizationID str
 }
 
 // RegisterSharedDB registers a physical database in db_pool, upserting on the
-// uk_db_pool_endpoint (org_id, db_host, db_name) natural key. On a duplicate
+// uk_db_pool_endpoint (org_id, db_host, db_name, db_user) natural key. On a duplicate
 // endpoint the connection fields are refreshed and tenant_count is preserved;
 // the existing db_id is re-fetched and returned.
 func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64, err error) {
@@ -622,8 +622,8 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 	// ON DUPLICATE KEY UPDATE does not reliably report the existing
 	// auto-increment id via LastInsertId, so re-fetch by endpoint.
 	err = s.db.QueryRowContext(ctx,
-		`SELECT db_id FROM db_pool WHERE org_id = ? AND db_host = ? AND db_name = ?`,
-		organizationID, in.Host, in.Name).Scan(&dbID)
+		`SELECT db_id FROM db_pool WHERE org_id = ? AND db_host = ? AND db_name = ? AND db_user = ?`,
+		organizationID, in.Host, in.Name, in.User).Scan(&dbID)
 	if err != nil {
 		return 0, fmt.Errorf("resolve db_id after upsert: %w", err)
 	}

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -305,6 +305,43 @@ func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 	}
 }
 
+func TestRegisterSharedDBReusesLegacyRandomUUIDRow(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	result, err := s.db.ExecContext(ctx, `INSERT INTO db_pool
+		(uuid, org_id, `+"`role`"+`, db_host, db_port, db_user, db_password, db_name, db_tls, max_tenants, status)
+		VALUES ('6f5d93ac-e897-4e92-8489-01a24ac0fd2c', 'org-legacy-manual', 'shared',
+			'legacy.example.com', 4000, 'root', X'01', 'legacy_db', 'skip-verify', 100, 'active')`)
+	if err != nil {
+		t.Fatalf("insert legacy manual pool: %v", err)
+	}
+	legacyID, err := result.LastInsertId()
+	if err != nil {
+		t.Fatalf("legacy manual pool id: %v", err)
+	}
+
+	dbID, err := s.RegisterSharedDB(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-legacy-manual", Host: "legacy.example.com", Port: 5000,
+		User: "root", PasswordCipher: []byte("rotated"), Name: "legacy_db",
+		TLSMode: "true", MaxTenants: 200,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	if dbID != legacyID {
+		t.Fatalf("RegisterSharedDB db_id = %d, want legacy row %d", dbID, legacyID)
+	}
+	var count int
+	if err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM db_pool
+		WHERE org_id = 'org-legacy-manual' AND db_host = 'legacy.example.com'
+			AND db_name = 'legacy_db' AND db_user = 'root'`).Scan(&count); err != nil {
+		t.Fatalf("count legacy manual pools: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("legacy manual pool rows = %d, want 1", count)
+	}
+}
+
 func TestRegisterSharedDBValidation(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -275,7 +276,7 @@ func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 		TiDBCloudOrganizationID: "org-a",
 		Host:                    "shared-a.example.com",
 		Port:                    5000,
-		User:                    "app",
+		User:                    "root",
 		PasswordCipher:          []byte("rotated-cipher"),
 		Name:                    "shared_db_a",
 		TLSMode:                 "true",
@@ -292,7 +293,7 @@ func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetSharedDB: %v", err)
 	}
-	if got.Port != 5000 || got.User != "app" || string(got.PasswordCipher) != "rotated-cipher" ||
+	if got.Port != 5000 || got.User != "root" || string(got.PasswordCipher) != "rotated-cipher" ||
 		got.MaxTenants != 200 || got.TLSMode != "true" {
 		t.Fatalf("upsert did not refresh connection fields: %+v", got)
 	}
@@ -1004,6 +1005,42 @@ func TestManagedSharedDBPoolCloudResultSchemaAndActivation(t *testing.T) {
 	}
 	if len(rows) != 1 || rows[0].ID != dbID {
 		t.Fatalf("active rows = %+v, want db %d", rows, dbID)
+	}
+}
+
+func TestManagedSharedDBPoolsAllowSameEndpointWithDifferentUsers(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	ids := make([]int64, 0, 2)
+	for i := 0; i < 2; i++ {
+		dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+			TiDBCloudOrganizationID: "org-shared-endpoint", ProvisioningKey: make([]byte, 32),
+			CloudProvider: "tencentcloud", Region: "ap-beijing", MaxTenants: 100,
+			SpendingLimit: &spendingLimit, PasswordCipher: []byte("root-cipher"), Name: "tidbcloud_fs",
+		})
+		if err != nil {
+			t.Fatalf("CreateManagedSharedDBPool %d: %v", i, err)
+		}
+		ids = append(ids, dbID)
+	}
+	for i, dbID := range ids {
+		if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, &SharedDB{
+			ID: dbID, TiDBCloudOrganizationID: "org-shared-endpoint", ClusterID: fmt.Sprintf("cluster-%d", i),
+			Host: "10.4.48.2", Port: 4000, User: fmt.Sprintf("prefix-%d.root", i),
+			PasswordCipher: []byte("root-cipher"), Name: "tidbcloud_fs", TLSMode: "skip-verify",
+		}); err != nil {
+			t.Fatalf("UpdateManagedSharedDBPoolCloudResult %d: %v", i, err)
+		}
+	}
+	for i, dbID := range ids {
+		got, err := s.GetSharedDB(ctx, dbID)
+		if err != nil {
+			t.Fatalf("GetSharedDB %d: %v", i, err)
+		}
+		if got.Status != SharedDBStatusProvisioning || got.User != fmt.Sprintf("prefix-%d.root", i) {
+			t.Fatalf("shared db %d = status %q user %q, want provisioning/prefix-%d.root", i, got.Status, got.User, i)
+		}
 	}
 }
 

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -756,7 +756,6 @@ func metaInitSchemaStatements() []string {
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			UNIQUE INDEX uk_db_pool_uuid (uuid),
 			UNIQUE INDEX uk_db_pool_cloud_resource (cluster_id),
-			UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host(191), db_name, db_user),
 			INDEX idx_db_pool_allocate (org_id, status, db_id),
 			INDEX idx_db_pool_provisioning_key (provisioning_key, status, db_id)
 		)`,
@@ -1048,8 +1047,8 @@ func dropObsoleteMetaIndexes(ctx context.Context, db *sql.DB) error {
 		[]string{"organization_id", "cluster_id", "created_at", "tenant_id"}); err != nil {
 		return fmt.Errorf("drop obsolete meta index idx_tidbcloud_org_cluster: %w", err)
 	}
-	if err := replaceLegacyDBPoolEndpointUniqueIndex(ctx, db); err != nil {
-		return err
+	if err := dropMetaIndexIfExists(ctx, db, "db_pool", "uk_db_pool_endpoint"); err != nil {
+		return fmt.Errorf("drop obsolete meta index uk_db_pool_endpoint: %w", err)
 	}
 	if err := replaceLegacyDBPoolCloudResourceUniqueIndex(ctx, db); err != nil {
 		return err
@@ -1070,23 +1069,6 @@ func replaceLegacyDBPoolCloudResourceUniqueIndex(ctx context.Context, db *sql.DB
 		ADD UNIQUE INDEX uk_db_pool_cloud_resource (cluster_id)`)
 	if err != nil {
 		return fmt.Errorf("replace db_pool.uk_db_pool_cloud_resource: %w", err)
-	}
-	return nil
-}
-
-func replaceLegacyDBPoolEndpointUniqueIndex(ctx context.Context, db *sql.DB) error {
-	columns, err := loadMetaIndexColumns(ctx, db, "db_pool", "uk_db_pool_endpoint")
-	if err != nil {
-		return fmt.Errorf("inspect db_pool.uk_db_pool_endpoint: %w", err)
-	}
-	if !sameStringSlice(columns, []string{"org_id", "db_host", "db_name"}) {
-		return nil
-	}
-	_, err = db.ExecContext(ctx, `ALTER TABLE db_pool
-		DROP INDEX uk_db_pool_endpoint,
-		ADD UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host(191), db_name, db_user)`)
-	if err != nil {
-		return fmt.Errorf("replace db_pool.uk_db_pool_endpoint: %w", err)
 	}
 	return nil
 }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -467,18 +467,18 @@ func expandManagedDBPoolSchema(ctx context.Context, db *sql.DB) error {
 	if !exists {
 		var duplicateCount int
 		if err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM (
-			SELECT org_id, cluster_id
+			SELECT cluster_id
 			FROM db_pool
-			WHERE org_id IS NOT NULL AND cluster_id IS NOT NULL
-			GROUP BY org_id, cluster_id
+			WHERE cluster_id IS NOT NULL
+			GROUP BY cluster_id
 			HAVING COUNT(*) > 1
 		) duplicates`).Scan(&duplicateCount); err != nil {
 			return fmt.Errorf("preflight db_pool cloud resource unique index: %w", err)
 		}
 		if duplicateCount > 0 {
-			return fmt.Errorf("preflight db_pool cloud resource unique index: found %d duplicate cloud resource tuples", duplicateCount)
+			return fmt.Errorf("preflight db_pool cloud resource unique index: found %d duplicate cluster ids", duplicateCount)
 		}
-		if _, err := db.ExecContext(ctx, `CREATE UNIQUE INDEX uk_db_pool_cloud_resource ON db_pool(org_id, cluster_id)`); err != nil && !isIgnorableMetaSchemaError(err) {
+		if _, err := db.ExecContext(ctx, `CREATE UNIQUE INDEX uk_db_pool_cloud_resource ON db_pool(cluster_id)`); err != nil && !isIgnorableMetaSchemaError(err) {
 			return fmt.Errorf("create db_pool cloud resource unique index: %w", err)
 		}
 	}
@@ -755,7 +755,7 @@ func metaInitSchemaStatements() []string {
 			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			UNIQUE INDEX uk_db_pool_uuid (uuid),
-			UNIQUE INDEX uk_db_pool_cloud_resource (org_id, cluster_id),
+			UNIQUE INDEX uk_db_pool_cloud_resource (cluster_id),
 			UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host(191), db_name, db_user),
 			INDEX idx_db_pool_allocate (org_id, status, db_id),
 			INDEX idx_db_pool_provisioning_key (provisioning_key, status, db_id)
@@ -1050,6 +1050,26 @@ func dropObsoleteMetaIndexes(ctx context.Context, db *sql.DB) error {
 	}
 	if err := replaceLegacyDBPoolEndpointUniqueIndex(ctx, db); err != nil {
 		return err
+	}
+	if err := replaceLegacyDBPoolCloudResourceUniqueIndex(ctx, db); err != nil {
+		return err
+	}
+	return nil
+}
+
+func replaceLegacyDBPoolCloudResourceUniqueIndex(ctx context.Context, db *sql.DB) error {
+	columns, err := loadMetaIndexColumns(ctx, db, "db_pool", "uk_db_pool_cloud_resource")
+	if err != nil {
+		return fmt.Errorf("inspect db_pool.uk_db_pool_cloud_resource: %w", err)
+	}
+	if !sameStringSlice(columns, []string{"org_id", "cluster_id"}) {
+		return nil
+	}
+	_, err = db.ExecContext(ctx, `ALTER TABLE db_pool
+		DROP INDEX uk_db_pool_cloud_resource,
+		ADD UNIQUE INDEX uk_db_pool_cloud_resource (cluster_id)`)
+	if err != nil {
+		return fmt.Errorf("replace db_pool.uk_db_pool_cloud_resource: %w", err)
 	}
 	return nil
 }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -756,7 +756,7 @@ func metaInitSchemaStatements() []string {
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			UNIQUE INDEX uk_db_pool_uuid (uuid),
 			UNIQUE INDEX uk_db_pool_cloud_resource (org_id, cluster_id),
-			UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host, db_name),
+			UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host(191), db_name, db_user),
 			INDEX idx_db_pool_allocate (org_id, status, db_id),
 			INDEX idx_db_pool_provisioning_key (provisioning_key, status, db_id)
 		)`,
@@ -1047,6 +1047,26 @@ func dropObsoleteMetaIndexes(ctx context.Context, db *sql.DB) error {
 	if err := dropMetaIndexIfColumns(ctx, db, "tenant_tidbcloud_org_bindings", "idx_tidbcloud_org_cluster",
 		[]string{"organization_id", "cluster_id", "created_at", "tenant_id"}); err != nil {
 		return fmt.Errorf("drop obsolete meta index idx_tidbcloud_org_cluster: %w", err)
+	}
+	if err := replaceLegacyDBPoolEndpointUniqueIndex(ctx, db); err != nil {
+		return err
+	}
+	return nil
+}
+
+func replaceLegacyDBPoolEndpointUniqueIndex(ctx context.Context, db *sql.DB) error {
+	columns, err := loadMetaIndexColumns(ctx, db, "db_pool", "uk_db_pool_endpoint")
+	if err != nil {
+		return fmt.Errorf("inspect db_pool.uk_db_pool_endpoint: %w", err)
+	}
+	if !sameStringSlice(columns, []string{"org_id", "db_host", "db_name"}) {
+		return nil
+	}
+	_, err = db.ExecContext(ctx, `ALTER TABLE db_pool
+		DROP INDEX uk_db_pool_endpoint,
+		ADD UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host(191), db_name, db_user)`)
+	if err != nil {
+		return fmt.Errorf("replace db_pool.uk_db_pool_endpoint: %w", err)
 	}
 	return nil
 }

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1562,6 +1562,17 @@ func TestMetaSchemaSpecIncludesManagedSharedDBControlPlane(t *testing.T) {
 	}
 }
 
+func TestDBPoolCloudResourceIndexUsesGloballyUniqueClusterID(t *testing.T) {
+	s := newControlStore(t)
+	columns, err := loadMetaIndexColumns(context.Background(), s.DB(), "db_pool", "uk_db_pool_cloud_resource")
+	if err != nil {
+		t.Fatalf("load uk_db_pool_cloud_resource columns: %v", err)
+	}
+	if want := []string{"cluster_id"}; !sameStringSlice(columns, want) {
+		t.Fatalf("uk_db_pool_cloud_resource columns = %v, want %v", columns, want)
+	}
+}
+
 func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1618,7 +1618,7 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 			t.Fatalf("db_pool.%s is_nullable = %q, want YES", column, nullable)
 		}
 	}
-	for _, index := range []string{"uk_db_pool_uuid", "uk_db_pool_cloud_resource", "idx_db_pool_allocate", "idx_db_pool_provisioning_key"} {
+	for _, index := range []string{"uk_db_pool_uuid", "uk_db_pool_cloud_resource", "uk_db_pool_endpoint", "idx_db_pool_allocate", "idx_db_pool_provisioning_key"} {
 		exists, err := metaIndexExists(ctx, s.DB(), "db_pool", index)
 		if err != nil {
 			t.Fatalf("check %s: %v", index, err)
@@ -1626,6 +1626,13 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 		if !exists {
 			t.Fatalf("db_pool index %s was not created", index)
 		}
+	}
+	endpointColumns, err := loadMetaIndexColumns(ctx, s.DB(), "db_pool", "uk_db_pool_endpoint")
+	if err != nil {
+		t.Fatalf("load uk_db_pool_endpoint columns: %v", err)
+	}
+	if want := []string{"org_id", "db_host", "db_name", "db_user"}; !sameStringSlice(endpointColumns, want) {
+		t.Fatalf("uk_db_pool_endpoint columns = %v, want %v", endpointColumns, want)
 	}
 	var dbPoolUUID, status string
 	var softCapReached bool

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1536,12 +1536,15 @@ func TestMetaSchemaSpecIncludesManagedSharedDBControlPlane(t *testing.T) {
 		}
 	}
 	for _, index := range []string{
-		"primary", "uk_db_pool_uuid", "uk_db_pool_cloud_resource", "uk_db_pool_endpoint",
+		"primary", "uk_db_pool_uuid", "uk_db_pool_cloud_resource",
 		"idx_db_pool_allocate", "idx_db_pool_provisioning_key",
 	} {
 		if _, ok := dbPool.indexes[index]; !ok {
 			t.Fatalf("db_pool schema missing index %s", index)
 		}
+	}
+	if _, ok := dbPool.indexes["uk_db_pool_endpoint"]; ok {
+		t.Fatal("db_pool schema must not define endpoint uniqueness")
 	}
 
 	memberships := mustMetaTableSpec(t, mustMetaSpec(t), "tenant_pool_memberships")
@@ -1629,7 +1632,7 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 			t.Fatalf("db_pool.%s is_nullable = %q, want YES", column, nullable)
 		}
 	}
-	for _, index := range []string{"uk_db_pool_uuid", "uk_db_pool_cloud_resource", "uk_db_pool_endpoint", "idx_db_pool_allocate", "idx_db_pool_provisioning_key"} {
+	for _, index := range []string{"uk_db_pool_uuid", "uk_db_pool_cloud_resource", "idx_db_pool_allocate", "idx_db_pool_provisioning_key"} {
 		exists, err := metaIndexExists(ctx, s.DB(), "db_pool", index)
 		if err != nil {
 			t.Fatalf("check %s: %v", index, err)
@@ -1638,12 +1641,12 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 			t.Fatalf("db_pool index %s was not created", index)
 		}
 	}
-	endpointColumns, err := loadMetaIndexColumns(ctx, s.DB(), "db_pool", "uk_db_pool_endpoint")
+	endpointIndexExists, err := metaIndexExists(ctx, s.DB(), "db_pool", "uk_db_pool_endpoint")
 	if err != nil {
-		t.Fatalf("load uk_db_pool_endpoint columns: %v", err)
+		t.Fatalf("check uk_db_pool_endpoint: %v", err)
 	}
-	if want := []string{"org_id", "db_host", "db_name", "db_user"}; !sameStringSlice(endpointColumns, want) {
-		t.Fatalf("uk_db_pool_endpoint columns = %v, want %v", endpointColumns, want)
+	if endpointIndexExists {
+		t.Fatal("legacy uk_db_pool_endpoint was not dropped")
 	}
 	var dbPoolUUID, status string
 	var softCapReached bool


### PR DESCRIPTION
## Summary

- remove endpoint-based uniqueness from db_pool because shared clusters use the same host and database
- enforce physical cloud resource identity with globally unique cluster_id
- drop the legacy endpoint unique index during migration
- keep local/dev DSN registration idempotent through the existing UUID unique key

## Verification

- targeted pkg/meta schema, migration, managed shared pool, and registration tests
- git diff --check