### PR TITLE
fix: rename global cluster ID index

### DIFF
--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -380,6 +380,9 @@ func (s *Store) migrate() (err error) {
 	if err != nil {
 		return fmt.Errorf("parse meta schema statements: %w", err)
 	}
+	if err := migrateLegacyDBPoolClusterIDIndex(ctx, s.db); err != nil {
+		return err
+	}
 	if err := dropObsoleteMetaIndexes(ctx, s.db); err != nil {
 		return err
 	}
@@ -460,9 +463,13 @@ func expandManagedDBPoolSchema(ctx context.Context, db *sql.DB) error {
 		WHERE max_tenants > 0 AND tenant_count >= max_tenants AND soft_cap_reached = 0`); err != nil {
 		return fmt.Errorf("backfill db_pool.soft_cap_reached: %w", err)
 	}
+	return ensureDBPoolClusterIDUniqueIndex(ctx, db)
+}
+
+func ensureDBPoolClusterIDUniqueIndex(ctx context.Context, db *sql.DB) error {
 	exists, err := metaIndexExists(ctx, db, "db_pool", "uk_db_pool_cluster_id")
 	if err != nil {
-		return fmt.Errorf("check db_pool cloud resource unique index: %w", err)
+		return fmt.Errorf("check db_pool cluster id unique index: %w", err)
 	}
 	if !exists {
 		var duplicateCount int
@@ -473,14 +480,31 @@ func expandManagedDBPoolSchema(ctx context.Context, db *sql.DB) error {
 			GROUP BY cluster_id
 			HAVING COUNT(*) > 1
 		) duplicates`).Scan(&duplicateCount); err != nil {
-			return fmt.Errorf("preflight db_pool cloud resource unique index: %w", err)
+			return fmt.Errorf("preflight db_pool cluster id unique index: %w", err)
 		}
 		if duplicateCount > 0 {
-			return fmt.Errorf("preflight db_pool cloud resource unique index: found %d duplicate cluster ids", duplicateCount)
+			return fmt.Errorf("preflight db_pool cluster id unique index: found %d duplicate cluster ids", duplicateCount)
 		}
 		if _, err := db.ExecContext(ctx, `CREATE UNIQUE INDEX uk_db_pool_cluster_id ON db_pool(cluster_id)`); err != nil && !isIgnorableMetaSchemaError(err) {
-			return fmt.Errorf("create db_pool cloud resource unique index: %w", err)
+			return fmt.Errorf("create db_pool cluster id unique index: %w", err)
 		}
+	}
+	return nil
+}
+
+func migrateLegacyDBPoolClusterIDIndex(ctx context.Context, db *sql.DB) error {
+	exists, err := metaIndexExists(ctx, db, "db_pool", "uk_db_pool_cloud_resource")
+	if err != nil {
+		return fmt.Errorf("check legacy db_pool cluster id unique index: %w", err)
+	}
+	if !exists {
+		return nil
+	}
+	if err := ensureDBPoolClusterIDUniqueIndex(ctx, db); err != nil {
+		return err
+	}
+	if err := dropMetaIndexIfExists(ctx, db, "db_pool", "uk_db_pool_cloud_resource"); err != nil {
+		return fmt.Errorf("drop legacy db_pool cluster id unique index: %w", err)
 	}
 	return nil
 }
@@ -1049,9 +1073,6 @@ func dropObsoleteMetaIndexes(ctx context.Context, db *sql.DB) error {
 	}
 	if err := dropMetaIndexIfExists(ctx, db, "db_pool", "uk_db_pool_endpoint"); err != nil {
 		return fmt.Errorf("drop obsolete meta index uk_db_pool_endpoint: %w", err)
-	}
-	if err := dropMetaIndexIfExists(ctx, db, "db_pool", "uk_db_pool_cloud_resource"); err != nil {
-		return fmt.Errorf("drop obsolete meta index uk_db_pool_cloud_resource: %w", err)
 	}
 	return nil
 }

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -460,7 +460,7 @@ func expandManagedDBPoolSchema(ctx context.Context, db *sql.DB) error {
 		WHERE max_tenants > 0 AND tenant_count >= max_tenants AND soft_cap_reached = 0`); err != nil {
 		return fmt.Errorf("backfill db_pool.soft_cap_reached: %w", err)
 	}
-	exists, err := metaIndexExists(ctx, db, "db_pool", "uk_db_pool_cloud_resource")
+	exists, err := metaIndexExists(ctx, db, "db_pool", "uk_db_pool_cluster_id")
 	if err != nil {
 		return fmt.Errorf("check db_pool cloud resource unique index: %w", err)
 	}
@@ -478,7 +478,7 @@ func expandManagedDBPoolSchema(ctx context.Context, db *sql.DB) error {
 		if duplicateCount > 0 {
 			return fmt.Errorf("preflight db_pool cloud resource unique index: found %d duplicate cluster ids", duplicateCount)
 		}
-		if _, err := db.ExecContext(ctx, `CREATE UNIQUE INDEX uk_db_pool_cloud_resource ON db_pool(cluster_id)`); err != nil && !isIgnorableMetaSchemaError(err) {
+		if _, err := db.ExecContext(ctx, `CREATE UNIQUE INDEX uk_db_pool_cluster_id ON db_pool(cluster_id)`); err != nil && !isIgnorableMetaSchemaError(err) {
 			return fmt.Errorf("create db_pool cloud resource unique index: %w", err)
 		}
 	}
@@ -755,7 +755,7 @@ func metaInitSchemaStatements() []string {
 			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			UNIQUE INDEX uk_db_pool_uuid (uuid),
-			UNIQUE INDEX uk_db_pool_cloud_resource (cluster_id),
+			UNIQUE INDEX uk_db_pool_cluster_id (cluster_id),
 			INDEX idx_db_pool_allocate (org_id, status, db_id),
 			INDEX idx_db_pool_provisioning_key (provisioning_key, status, db_id)
 		)`,
@@ -1050,8 +1050,7 @@ func dropObsoleteMetaIndexes(ctx context.Context, db *sql.DB) error {
 	if err := dropMetaIndexIfExists(ctx, db, "db_pool", "uk_db_pool_endpoint"); err != nil {
 		return fmt.Errorf("drop obsolete meta index uk_db_pool_endpoint: %w", err)
 	}
-	if err := dropMetaIndexIfColumns(ctx, db, "db_pool", "uk_db_pool_cloud_resource",
-		[]string{"org_id", "cluster_id"}); err != nil {
+	if err := dropMetaIndexIfExists(ctx, db, "db_pool", "uk_db_pool_cloud_resource"); err != nil {
 		return fmt.Errorf("drop obsolete meta index uk_db_pool_cloud_resource: %w", err)
 	}
 	return nil

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1536,7 +1536,7 @@ func TestMetaSchemaSpecIncludesManagedSharedDBControlPlane(t *testing.T) {
 		}
 	}
 	for _, index := range []string{
-		"primary", "uk_db_pool_uuid", "uk_db_pool_cloud_resource",
+		"primary", "uk_db_pool_uuid", "uk_db_pool_cluster_id",
 		"idx_db_pool_allocate", "idx_db_pool_provisioning_key",
 	} {
 		if _, ok := dbPool.indexes[index]; !ok {
@@ -1565,14 +1565,14 @@ func TestMetaSchemaSpecIncludesManagedSharedDBControlPlane(t *testing.T) {
 	}
 }
 
-func TestDBPoolCloudResourceIndexUsesGloballyUniqueClusterID(t *testing.T) {
+func TestDBPoolClusterIDIndexIsGloballyUnique(t *testing.T) {
 	s := newControlStore(t)
-	columns, err := loadMetaIndexColumns(context.Background(), s.DB(), "db_pool", "uk_db_pool_cloud_resource")
+	columns, err := loadMetaIndexColumns(context.Background(), s.DB(), "db_pool", "uk_db_pool_cluster_id")
 	if err != nil {
-		t.Fatalf("load uk_db_pool_cloud_resource columns: %v", err)
+		t.Fatalf("load uk_db_pool_cluster_id columns: %v", err)
 	}
 	if want := []string{"cluster_id"}; !sameStringSlice(columns, want) {
-		t.Fatalf("uk_db_pool_cloud_resource columns = %v, want %v", columns, want)
+		t.Fatalf("uk_db_pool_cluster_id columns = %v, want %v", columns, want)
 	}
 }
 
@@ -1591,6 +1591,7 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 	if _, err := s.DB().ExecContext(ctx, `CREATE TABLE db_pool (
 		db_id BIGINT AUTO_INCREMENT PRIMARY KEY,
 		org_id VARCHAR(64) NOT NULL DEFAULT '',
+		cluster_id VARCHAR(255) NULL,
 		`+"`role`"+` VARCHAR(20) NOT NULL,
 		db_host VARCHAR(255) NOT NULL,
 		db_port INT NOT NULL,
@@ -1604,6 +1605,7 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 		created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 		updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 		UNIQUE INDEX uk_db_pool_endpoint (org_id, db_host, db_name),
+		UNIQUE INDEX uk_db_pool_cloud_resource (org_id, cluster_id),
 		INDEX idx_db_pool_org (org_id, status)
 	)`); err != nil {
 		t.Fatalf("create legacy db_pool: %v", err)
@@ -1632,7 +1634,7 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 			t.Fatalf("db_pool.%s is_nullable = %q, want YES", column, nullable)
 		}
 	}
-	for _, index := range []string{"uk_db_pool_uuid", "uk_db_pool_cloud_resource", "idx_db_pool_allocate", "idx_db_pool_provisioning_key"} {
+	for _, index := range []string{"uk_db_pool_uuid", "uk_db_pool_cluster_id", "idx_db_pool_allocate", "idx_db_pool_provisioning_key"} {
 		exists, err := metaIndexExists(ctx, s.DB(), "db_pool", index)
 		if err != nil {
 			t.Fatalf("check %s: %v", index, err)
@@ -1647,6 +1649,13 @@ func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 	}
 	if endpointIndexExists {
 		t.Fatal("legacy uk_db_pool_endpoint was not dropped")
+	}
+	legacyCloudIndexExists, err := metaIndexExists(ctx, s.DB(), "db_pool", "uk_db_pool_cloud_resource")
+	if err != nil {
+		t.Fatalf("check uk_db_pool_cloud_resource: %v", err)
+	}
+	if legacyCloudIndexExists {
+		t.Fatal("legacy uk_db_pool_cloud_resource was not dropped")
 	}
 	var dbPoolUUID, status string
 	var softCapReached bool

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1576,6 +1576,58 @@ func TestDBPoolClusterIDIndexIsGloballyUnique(t *testing.T) {
 	}
 }
 
+func TestMigrateKeepsLegacyClusterIDIndexWhenReplacementCannotBeCreated(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	if _, err := s.DB().ExecContext(ctx, `DROP TABLE db_pool`); err != nil {
+		t.Fatalf("drop current db_pool: %v", err)
+	}
+	t.Cleanup(func() {
+		_, _ = s.DB().ExecContext(context.Background(), `DROP TABLE IF EXISTS db_pool`)
+		if err := s.migrate(); err != nil {
+			t.Errorf("restore current db_pool schema: %v", err)
+		}
+	})
+	if _, err := s.DB().ExecContext(ctx, `CREATE TABLE db_pool (
+		db_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+		org_id VARCHAR(64) NOT NULL DEFAULT '',
+		cluster_id VARCHAR(255) NULL,
+		`+"`role`"+` VARCHAR(20) NOT NULL,
+		db_host VARCHAR(255) NOT NULL,
+		db_port INT NOT NULL,
+		db_user VARCHAR(255) NOT NULL,
+		db_password VARBINARY(2048) NOT NULL,
+		db_name VARCHAR(255) NOT NULL,
+		db_tls VARCHAR(32) NOT NULL DEFAULT '',
+		max_tenants INT NOT NULL DEFAULT 0,
+		tenant_count INT NOT NULL DEFAULT 0,
+		status VARCHAR(20) NOT NULL DEFAULT 'active',
+		created_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+		updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
+		UNIQUE INDEX uk_db_pool_cloud_resource (org_id, cluster_id)
+	)`); err != nil {
+		t.Fatalf("create legacy db_pool: %v", err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `INSERT INTO db_pool
+		(org_id, cluster_id, `+"`role`"+`, db_host, db_port, db_user, db_password, db_name)
+		VALUES
+		('org-a', 'duplicate-cluster', 'shared', 'shared.example.com', 4000, 'user-a', X'01', 'shared_db'),
+		('org-b', 'duplicate-cluster', 'shared', 'shared.example.com', 4000, 'user-b', X'02', 'shared_db')`); err != nil {
+		t.Fatalf("insert duplicate legacy cluster ids: %v", err)
+	}
+
+	if err := s.migrate(); err == nil {
+		t.Fatal("migrate duplicate legacy cluster ids error = nil, want error")
+	}
+	legacyIndexExists, err := metaIndexExists(ctx, s.DB(), "db_pool", "uk_db_pool_cloud_resource")
+	if err != nil {
+		t.Fatalf("check uk_db_pool_cloud_resource: %v", err)
+	}
+	if !legacyIndexExists {
+		t.Fatal("legacy uk_db_pool_cloud_resource was dropped before its replacement was created")
+	}
+}
+
 func TestMigrateExpandsLegacyDBPoolForManagedProvisioning(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- rename the global cluster_id unique index to uk_db_pool_cluster_id
- drop the legacy uk_db_pool_cloud_resource name during migration
- avoid reusing the composite index name when creating the single-column index
- verify migration removes the legacy name and creates the new index

## Verification

- make test TEST_PKGS=./pkg/meta TEST_RUN=TestMigrateExpandsLegacyDBPoolForManagedProvisioning\|TestDBPoolClusterIDIndexIsGloballyUnique
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated database pool migrations to enforce cluster ID uniqueness consistently.
  * Added safeguards that detect duplicate cluster IDs before applying the new constraint.
  * Preserved the legacy uniqueness constraint when the replacement cannot be created.
  * Removed obsolete database indexes during migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->