### PR TITLE
fix: parallelize managed shared pool refill

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -441,14 +441,24 @@ func main() {
 	}
 
 	die(server.NewWithConfig(server.Config{
-		Meta:                            store,
-		Pool:                            pool,
-		Provisioner:                     provisioner,
-		DefaultTenantProvider:           providerType,
-		SharedDBMaxTenants:              sharedDBMaxTenants,
-		SharedDBHardCapRatio:            sharedDBHardCapRatio,
-		SharedDBReopenRatio:             sharedDBReopenRatio,
-		SharedDBSpendingLimit:           sharedDBDefaultSpendingLimit,
+		Meta:                  store,
+		Pool:                  pool,
+		Provisioner:           provisioner,
+		DefaultTenantProvider: providerType,
+		SharedDBMaxTenants:    sharedDBMaxTenants,
+		SharedDBHardCapRatio:  sharedDBHardCapRatio,
+		SharedDBReopenRatio:   sharedDBReopenRatio,
+		SharedDBSpendingLimit: sharedDBDefaultSpendingLimit,
+		ManagedSharedDBCloudBatchSize: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE",
+			server.DefaultManagedSharedDBCloudBatchSize),
+		ManagedSharedDBMetadataWorkers: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_WORKERS",
+			server.DefaultManagedSharedDBMetadataWorkers),
+		ManagedSharedDBMetadataBatchSize: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_BATCH_SIZE",
+			server.DefaultManagedSharedDBMetadataBatchSize),
+		ManagedSharedDBMetadataPollInterval: envDuration("DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_POLL_INTERVAL",
+			server.DefaultManagedSharedDBMetadataPollInterval),
+		ManagedSharedDBProvisioningWorkers: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_PROVISIONING_WORKERS",
+			server.DefaultManagedSharedDBProvisioningWorkers),
 		LegacyStarterProvisioner:        legacyStarterProvisioner,
 		TokenSecret:                     tokenSecret,
 		VaultMasterKey:                  vaultMasterKey,
@@ -685,6 +695,11 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO emergency hard-cap ratio > 1 after physical create failure (default: 1.2)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO reopen ratio for a latched shared pool (default: 0.8)
   DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT physical spending-limit target for new managed shared DB pools (default: 1000000)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE physical pools per Cloud create request (default: 10)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_WORKERS concurrent pending metadata workers (default: 15)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_BATCH_SIZE physical pools per metadata list request (default: 30)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_POLL_INTERVAL delay between metadata list rounds (default: 15s)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_PROVISIONING_WORKERS concurrent shared schema-init workers (default: 100)
   DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings (also accepts public_host:private_host);
                                              when set, disables legacy single-host private endpoint overrides
   DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST legacy tencentcloud private endpoint fallback host, used only when host map is unset

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -697,10 +697,10 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO emergency hard-cap ratio > 1 after physical create failure (default: 1.2)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO reopen ratio for a latched shared pool (default: 0.8)
   DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT physical spending-limit target for new managed shared DB pools (default: 1000000)
-  DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE physical pools per Cloud create request (default: 10)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE physical pools per Cloud create request (default and maximum: 10)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_REFILL_POOL_LIMIT maximum physical shared DBs added by one refill wave (default: 50)
-  DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_WORKERS concurrent pending metadata workers (default: 15)
-  DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_BATCH_SIZE physical pools per metadata list request (default: 30)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_WORKERS concurrent pending metadata workers (default and maximum: 15)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_BATCH_SIZE physical pools per metadata list request (default and maximum: 30)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_POLL_INTERVAL delay between metadata list rounds (default: 15s)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_PROVISIONING_WORKERS concurrent shared schema-init workers (default: 100)
   DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings (also accepts public_host:private_host);

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -451,6 +451,8 @@ func main() {
 		SharedDBSpendingLimit: sharedDBDefaultSpendingLimit,
 		ManagedSharedDBCloudBatchSize: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE",
 			server.DefaultManagedSharedDBCloudBatchSize),
+		ManagedSharedDBRefillPoolLimit: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_REFILL_POOL_LIMIT",
+			server.DefaultManagedSharedDBRefillPoolLimit),
 		ManagedSharedDBMetadataWorkers: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_WORKERS",
 			server.DefaultManagedSharedDBMetadataWorkers),
 		ManagedSharedDBMetadataBatchSize: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_BATCH_SIZE",
@@ -696,6 +698,7 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO reopen ratio for a latched shared pool (default: 0.8)
   DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT physical spending-limit target for new managed shared DB pools (default: 1000000)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE physical pools per Cloud create request (default: 10)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_REFILL_POOL_LIMIT maximum physical shared DBs added by one refill wave (default: 50)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_WORKERS concurrent pending metadata workers (default: 15)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_BATCH_SIZE physical pools per metadata list request (default: 30)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_POLL_INTERVAL delay between metadata list rounds (default: 15s)

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2157,6 +2157,20 @@ func (s *Store) CountTenantPoolFreeSlots(ctx context.Context, organizationID str
 	return s.countFreeTenantPoolBindingsByStatus(ctx, organizationID, []TenantStatus{TenantPending, TenantProvisioning, TenantActive})
 }
 
+const countFreeTenantPoolBindingsSQL = `SELECT COALESCE(SUM(slot_count), 0) FROM (
+	SELECT COUNT(*) AS slot_count
+		FROM tenant_tidbcloud_org_bindings b
+		STRAIGHT_JOIN tenants t ON t.id = b.tenant_id
+		WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = ?
+			AND t.status IN (%s)
+	UNION ALL
+	SELECT COUNT(*) AS slot_count
+		FROM tenant_pool_memberships m
+		STRAIGHT_JOIN tenants t ON t.id = m.tenant_id
+		WHERE m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?
+			AND t.status IN (%s)
+) inventory`
+
 func (s *Store) countFreeTenantPoolBindingsByStatus(ctx context.Context, organizationID string, statuses []TenantStatus) (out int, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "count_free_tidbcloud_pool_bindings", start, &err)
@@ -2168,24 +2182,19 @@ func (s *Store) countFreeTenantPoolBindingsByStatus(ctx context.Context, organiz
 		return 0, fmt.Errorf("tenant statuses are required")
 	}
 	placeholders := strings.TrimRight(strings.Repeat("?,", len(statuses)), ",")
-	args := make([]any, 0, 3+len(statuses))
+	args := make([]any, 0, 6+2*len(statuses))
 	args = append(args, organizationID, TenantPoolBindingFree, tidbCloudNativeProvider)
 	for _, status := range statuses {
 		args = append(args, status)
 	}
-	row := s.db.QueryRowContext(ctx, `SELECT COUNT(*)
-		FROM tenant_tidbcloud_org_bindings b
-		JOIN tenants t ON t.id = b.tenant_id
-		WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = ?
-			AND t.status IN (`+placeholders+`)`, args...)
+	args = append(args, organizationID, TenantPoolBindingFree, tidbCloudNativeSharedProvider)
+	for _, status := range statuses {
+		args = append(args, status)
+	}
+	row := s.db.QueryRowContext(ctx, fmt.Sprintf(countFreeTenantPoolBindingsSQL, placeholders, placeholders), args...)
 	if err = row.Scan(&out); err != nil {
 		return 0, err
 	}
-	shared, err := s.CountFreeTenantPoolMemberships(ctx, organizationID, statuses)
-	if err != nil {
-		return 0, err
-	}
-	out += shared
 	return out, nil
 }
 

--- a/pkg/meta/tenant_pool_membership.go
+++ b/pkg/meta/tenant_pool_membership.go
@@ -27,6 +27,11 @@ type TenantWithPoolMembership struct {
 	Membership TenantPoolMembership
 }
 
+const countFreeTenantPoolMembershipsSQL = `SELECT COUNT(*) FROM tenant_pool_memberships m
+	STRAIGHT_JOIN tenants t ON t.id = m.tenant_id
+	WHERE m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?
+		AND t.status IN (%s)`
+
 func (s *Store) UpsertTenantPoolMembership(ctx context.Context, membership *TenantPoolMembership) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "upsert_tenant_pool_membership", start, &err)
@@ -264,10 +269,7 @@ func (s *Store) CountFreeTenantPoolMemberships(ctx context.Context, organization
 		args = append(args, status)
 	}
 	var count int
-	err := s.db.QueryRowContext(ctx, `SELECT COUNT(*) FROM tenant_pool_memberships m
-		JOIN tenants t ON t.id = m.tenant_id
-		WHERE m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?
-			AND t.status IN (`+placeholders+`)`, args...).Scan(&count)
+	err := s.db.QueryRowContext(ctx, fmt.Sprintf(countFreeTenantPoolMembershipsSQL, placeholders), args...).Scan(&count)
 	return count, err
 }
 

--- a/pkg/meta/tenant_pool_membership.go
+++ b/pkg/meta/tenant_pool_membership.go
@@ -27,6 +27,7 @@ type TenantWithPoolMembership struct {
 	Membership TenantPoolMembership
 }
 
+// Pin the join order because one organization's free memberships are much more selective than all shared tenants.
 const countFreeTenantPoolMembershipsSQL = `SELECT COUNT(*) FROM tenant_pool_memberships m
 	STRAIGHT_JOIN tenants t ON t.id = m.tenant_id
 	WHERE m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?

--- a/pkg/meta/tenant_pool_membership_test.go
+++ b/pkg/meta/tenant_pool_membership_test.go
@@ -3,9 +3,16 @@ package meta
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 )
+
+func TestFreeTenantPoolMembershipCountPinsMembershipTableFirst(t *testing.T) {
+	if !strings.Contains(countFreeTenantPoolMembershipsSQL, "FROM tenant_pool_memberships m\n\tSTRAIGHT_JOIN tenants t") {
+		t.Fatalf("count query does not pin tenant_pool_memberships as the driving table: %s", countFreeTenantPoolMembershipsSQL)
+	}
+}
 
 func TestTenantPoolMembershipRoundTripAndClaimCAS(t *testing.T) {
 	s := newControlStore(t)

--- a/pkg/meta/tenant_pool_membership_test.go
+++ b/pkg/meta/tenant_pool_membership_test.go
@@ -14,6 +14,20 @@ func TestFreeTenantPoolMembershipCountPinsMembershipTableFirst(t *testing.T) {
 	}
 }
 
+func TestFreeTenantPoolBindingCountCombinesNativeAndSharedInventory(t *testing.T) {
+	if strings.Count(countFreeTenantPoolBindingsSQL, "UNION ALL") != 1 {
+		t.Fatalf("count query must combine native and shared inventory in one statement: %s", countFreeTenantPoolBindingsSQL)
+	}
+	for _, want := range []string{
+		"FROM tenant_tidbcloud_org_bindings b\n\t\tSTRAIGHT_JOIN tenants t",
+		"FROM tenant_pool_memberships m\n\t\tSTRAIGHT_JOIN tenants t",
+	} {
+		if !strings.Contains(countFreeTenantPoolBindingsSQL, want) {
+			t.Fatalf("count query missing pinned branch %q: %s", want, countFreeTenantPoolBindingsSQL)
+		}
+	}
+}
+
 func TestTenantPoolMembershipRoundTripAndClaimCAS(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -51,9 +51,15 @@ const adminTenantPoolMetricsComponent = "admin_tenant_pool"
 
 const tenantPoolClaimCASRetryLimit = 8
 
+const sharedTenantPoolCreateConcurrency = 50
+
+const (
+	managedSharedDBCloudBatchSize        = 10
+	managedSharedDBCloudBatchConcurrency = 10
+)
+
 func retryTenantPoolClaimCAS[T any](attempt func() (T, error)) (T, error) {
 	var zero T
-	var lastErr error
 	for range tenantPoolClaimCASRetryLimit {
 		result, err := attempt()
 		if err == nil {
@@ -62,10 +68,8 @@ func retryTenantPoolClaimCAS[T any](attempt func() (T, error)) (T, error) {
 		if !errors.Is(err, meta.ErrNotFound) {
 			return zero, err
 		}
-		lastErr = err
 	}
-	return zero, fmt.Errorf("tenant pool claim remained busy after %d attempts: %w",
-		tenantPoolClaimCASRetryLimit, lastErr)
+	return zero, nil
 }
 
 type tenantPoolClaimSelection struct {
@@ -936,90 +940,58 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 	return results, nil
 }
 
-func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string, count int, cred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*provisionTenantResult, error) {
+func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string, count int, _ tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*provisionTenantResult, error) {
 	if count <= 0 {
 		return []*provisionTenantResult{}, nil
 	}
 	if _, ok := s.provisioner.(tenant.SharedDBPoolProvisioner); !ok {
 		return nil, fmt.Errorf("shared tenant pool provisioning not enabled")
 	}
+	sharedCred, err := s.sharedDBCloudCredentials()
+	if err != nil {
+		return nil, err
+	}
 	pool, err := s.meta.GetTenantPoolByID(ctx, poolID)
 	if err != nil {
 		return nil, err
 	}
+	organizationID := strings.TrimSpace(pool.OrganizationID)
+	if organizationID == "" {
+		return nil, fmt.Errorf("shared tenant pool organization is required")
+	}
 	now := time.Now().UTC()
-	createdPoolIDs := make(map[int64]struct{})
+	outcomes := runSharedPoolTenantCreateWorkers(ctx, count, func() sharedPoolTenantCreateOutcome {
+		return s.createFreeSharedPoolTenant(ctx, poolID, organizationID, sharedCred, quotaOpt, now)
+	})
 	continuationPoolIDs := make(map[int64]struct{})
 	results := make([]*provisionTenantResult, 0, count)
 	resultPoolIDs := make([]int64, 0, count)
-	for i := 0; i < count; i++ {
-		tenantID := token.NewID()
-		if err := s.insertPendingPoolTenant(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, now); err != nil {
-			return results, err
+	var createErr error
+	for _, outcome := range outcomes {
+		if outcome.err != nil {
+			createErr = errors.Join(createErr, outcome.err)
+			continue
 		}
-		fsID, err := s.meta.EnsureFsID(ctx, tenantID)
-		if err != nil {
-			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-			return results, err
+		results = append(results, outcome.result)
+		resultPoolIDs = append(resultPoolIDs, outcome.dbID)
+		if outcome.needsContinuation {
+			continuationPoolIDs[outcome.dbID] = struct{}{}
 		}
-		opts := provisionTenantOptions{Quota: quotaOpt}
-		if err := s.materializeSharedTenantQuota(ctx, tenantID, opts); err != nil {
-			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-			return results, err
-		}
-		var selected *meta.SharedDB
-		selected, created, err := s.allocateManagedSharedDB(ctx, cred, func(db *meta.SharedDB) error {
-			return s.meta.CompleteSharedTenantPoolMember(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared,
-				&meta.TenantPlacement{FsID: fsID, DbID: db.ID, Placement: meta.PlacementShared,
-					SchemaShape: meta.SchemaShapeShared, Status: meta.SharedDBStatusActive},
-				&meta.TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: pool.OrganizationID,
-					PoolID: poolID, PoolStatus: meta.TenantPoolBindingFree, CreatedAt: now, UpdatedAt: now})
-		})
-		if err != nil {
-			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-			return results, err
-		}
-		if created {
-			createdPoolIDs[selected.ID] = struct{}{}
-		}
-		if selected.Status == meta.SharedDBStatusPending || selected.Status == meta.SharedDBStatusProvisioning {
-			continuationPoolIDs[selected.ID] = struct{}{}
-		}
-		resultStatus := meta.TenantPending
-		switch selected.Status {
-		case meta.SharedDBStatusProvisioning:
-			resultStatus = meta.TenantProvisioning
-		case meta.SharedDBStatusActive:
-			resultStatus = meta.TenantActive
-		}
-		results = append(results, &provisionTenantResult{TenantID: tenantID,
-			Status: resultStatus, Provider: tenant.ProviderTiDBCloudNativeShared,
-			CloudProvider: selected.CloudProvider, Region: selected.Region,
-			OrganizationID: selected.TiDBCloudOrganizationID})
-		resultPoolIDs = append(resultPoolIDs, selected.ID)
 	}
-	createdIDs := make([]int64, 0, len(createdPoolIDs))
-	for id := range createdPoolIDs {
-		createdIDs = append(createdIDs, id)
+	if createErr != nil {
+		return results, createErr
 	}
-	sort.Slice(createdIDs, func(i, j int) bool { return createdIDs[i] < createdIDs[j] })
-	resolvedOrg, err := s.provisionManagedSharedDBPoolsBatch(ctx, createdIDs)
+	continuationIDs := make([]int64, 0, len(continuationPoolIDs))
+	for id := range continuationPoolIDs {
+		continuationIDs = append(continuationIDs, id)
+	}
+	sort.Slice(continuationIDs, func(i, j int) bool { return continuationIDs[i] < continuationIDs[j] })
+	_, err = s.provisionManagedSharedDBPoolsBatchWithCredentials(ctx, continuationIDs, sharedCred)
 	if err != nil {
 		return results, err
 	}
-	if pool.OrganizationID == "" && resolvedOrg != "" {
-		if err := s.meta.UpdateTenantPoolOrganization(ctx, poolID, resolvedOrg); err != nil {
-			return results, err
-		}
-		if err := s.meta.UpdateTenantPoolMembershipOrganization(ctx, poolID, resolvedOrg); err != nil {
-			return results, err
-		}
-		for _, result := range results {
-			result.OrganizationID = resolvedOrg
-		}
-	}
-	createdPoolStatuses := make(map[int64]meta.TenantStatus, len(createdIDs))
-	for _, dbID := range createdIDs {
+	continuationPoolStatuses := make(map[int64]meta.TenantStatus, len(continuationIDs))
+	for _, dbID := range continuationIDs {
 		sharedDB, err := s.meta.GetSharedDB(ctx, dbID)
 		if err != nil {
 			return results, err
@@ -1031,57 +1003,116 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 		case meta.SharedDBStatusActive:
 			status = meta.TenantActive
 		}
-		createdPoolStatuses[dbID] = status
+		continuationPoolStatuses[dbID] = status
 	}
 	for i, dbID := range resultPoolIDs {
-		if status, ok := createdPoolStatuses[dbID]; ok {
+		if status, ok := continuationPoolStatuses[dbID]; ok {
 			results[i].Status = status
 		}
 	}
-	continuationIDs := make([]int64, 0, len(continuationPoolIDs))
-	for dbID := range continuationPoolIDs {
-		continuationIDs = append(continuationIDs, dbID)
-	}
 	s.scheduleManagedSharedDBContinuations(ctx, continuationIDs)
 	return results, nil
+}
+
+func runSharedPoolTenantCreateWorkers(ctx context.Context, count int, create func() sharedPoolTenantCreateOutcome) []sharedPoolTenantCreateOutcome {
+	outcomes := make([]sharedPoolTenantCreateOutcome, count)
+	jobs := make(chan int)
+	var wg sync.WaitGroup
+	for range min(count, sharedTenantPoolCreateConcurrency) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := range jobs {
+				if ctx.Err() != nil {
+					outcomes[i].err = ctx.Err()
+					continue
+				}
+				outcomes[i] = create()
+			}
+		}()
+	}
+	for i := range count {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	return outcomes
+}
+
+type sharedPoolTenantCreateOutcome struct {
+	result            *provisionTenantResult
+	dbID              int64
+	needsContinuation bool
+	err               error
+}
+
+func (s *Server) createFreeSharedPoolTenant(ctx context.Context, poolID, organizationID string, sharedCred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest, now time.Time) sharedPoolTenantCreateOutcome {
+	tenantID := token.NewID()
+	fail := func(err error) sharedPoolTenantCreateOutcome {
+		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+		return sharedPoolTenantCreateOutcome{err: err}
+	}
+	if err := s.insertPendingPoolTenant(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, now); err != nil {
+		return sharedPoolTenantCreateOutcome{err: err}
+	}
+	fsID, err := s.meta.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		return fail(err)
+	}
+	if err := s.materializeSharedTenantQuota(ctx, tenantID, provisionTenantOptions{Quota: quotaOpt}); err != nil {
+		return fail(err)
+	}
+	selected, _, err := s.allocateManagedSharedDBForOrganization(ctx, organizationID, sharedCred, func(db *meta.SharedDB) error {
+		return s.meta.CompleteSharedTenantPoolMember(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared,
+			&meta.TenantPlacement{FsID: fsID, DbID: db.ID, Placement: meta.PlacementShared,
+				SchemaShape: meta.SchemaShapeShared, Status: meta.SharedDBStatusActive},
+			&meta.TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: organizationID,
+				PoolID: poolID, PoolStatus: meta.TenantPoolBindingFree, CreatedAt: now, UpdatedAt: now})
+	})
+	if err != nil {
+		return fail(err)
+	}
+	resultStatus := meta.TenantPending
+	switch selected.Status {
+	case meta.SharedDBStatusProvisioning:
+		resultStatus = meta.TenantProvisioning
+	case meta.SharedDBStatusActive:
+		resultStatus = meta.TenantActive
+	}
+	return sharedPoolTenantCreateOutcome{
+		result: &provisionTenantResult{TenantID: tenantID, Status: resultStatus,
+			Provider: tenant.ProviderTiDBCloudNativeShared, CloudProvider: selected.CloudProvider,
+			Region: selected.Region, OrganizationID: selected.TiDBCloudOrganizationID},
+		dbID:              selected.ID,
+		needsContinuation: selected.Status == meta.SharedDBStatusPending || selected.Status == meta.SharedDBStatusProvisioning,
+	}
 }
 
 func (s *Server) provisionManagedSharedDBPoolsBatch(ctx context.Context, dbIDs []int64) (string, error) {
 	if len(dbIDs) == 0 {
 		return "", nil
 	}
-	provisioner := s.provisioner.(tenant.SharedDBPoolProvisioner)
-	resolvedOrg := ""
-	for start := 0; start < len(dbIDs); start += 10 {
-		end := start + 10
-		if end > len(dbIDs) {
-			end = len(dbIDs)
-		}
-		chunkOrg, err := s.provisionManagedSharedDBPoolsBatchChunk(ctx, provisioner, dbIDs[start:end])
-		if err != nil {
-			return resolvedOrg, err
-		}
-		if resolvedOrg == "" {
-			resolvedOrg = chunkOrg
-		}
+	cred, err := s.sharedDBCloudCredentials()
+	if err != nil {
+		return "", err
 	}
-	return resolvedOrg, nil
+	return s.provisionManagedSharedDBPoolsBatchWithCredentials(ctx, dbIDs, cred)
 }
 
-func (s *Server) provisionManagedSharedDBPoolsBatchChunk(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64) (string, error) {
+func (s *Server) provisionManagedSharedDBPoolsBatchWithCredentials(ctx context.Context, dbIDs []int64, cred tenant.CredentialProvisionRequest) (string, error) {
+	if len(dbIDs) == 0 {
+		return "", nil
+	}
+	provisioner := s.provisioner.(tenant.SharedDBPoolProvisioner)
 	for attempt := 0; attempt < 2; attempt++ {
 		first, err := s.meta.GetSharedDB(ctx, dbIDs[0])
-		if err != nil {
-			return "", err
-		}
-		cred, err := s.sharedDBCloudCredentials()
 		if err != nil {
 			return "", err
 		}
 		identity := sharedDBAllocationIdentity(first.TiDBCloudOrganizationID, first.ProvisioningKey)
 		restartWithOrganization := false
 		resolvedOrg := ""
-		err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+		err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
 			current, err := s.meta.GetSharedDB(lockCtx, dbIDs[0])
 			if err != nil {
 				return err
@@ -1137,20 +1168,52 @@ func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, p
 	if len(requests) == 0 {
 		return resolvedOrg, nil
 	}
+	type batchResult struct {
+		err error
+	}
+	batchCount := (len(requests) + managedSharedDBCloudBatchSize - 1) / managedSharedDBCloudBatchSize
+	batchResults := make([]batchResult, batchCount)
+	batchSlots := make(chan struct{}, min(batchCount, managedSharedDBCloudBatchConcurrency))
+	var wg sync.WaitGroup
+	for batchIndex, start := 0, 0; start < len(requests); batchIndex, start = batchIndex+1, start+managedSharedDBCloudBatchSize {
+		end := min(start+managedSharedDBCloudBatchSize, len(requests))
+		chunk := append([]tenant.SharedDBPoolCreateRequest(nil), requests[start:end]...)
+		wg.Add(1)
+		go func(batchIndex int, chunk []tenant.SharedDBPoolCreateRequest) {
+			defer wg.Done()
+			select {
+			case batchSlots <- struct{}{}:
+				defer func() { <-batchSlots }()
+			case <-ctx.Done():
+				batchResults[batchIndex].err = ctx.Err()
+				return
+			}
+			batchResults[batchIndex].err = s.provisionManagedSharedDBPoolsBatchChunkLocked(ctx, provisioner, chunk, rows, cred)
+		}(batchIndex, chunk)
+	}
+	wg.Wait()
+	var batchErr error
+	for _, result := range batchResults {
+		batchErr = errors.Join(batchErr, result.err)
+	}
+	return resolvedOrg, batchErr
+}
+
+func (s *Server) provisionManagedSharedDBPoolsBatchChunkLocked(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, requests []tenant.SharedDBPoolCreateRequest, rows map[int64]*meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
 	created, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, requests, cred)
 	if createErr != nil && len(created) == 0 {
 		logger.Warn(ctx, "managed_shared_db_batch_create_failed",
 			zap.Int("db_pool_count", len(requests)), zap.Error(createErr))
-		return resolvedOrg, createErr
+		return createErr
 	}
 	for _, info := range created {
 		if info == nil || rows[info.DBPoolID] == nil || rows[info.DBPoolID].UUID != info.DBPoolUUID {
-			return resolvedOrg, fmt.Errorf("shared db batch returned an unknown db pool")
+			return fmt.Errorf("shared db batch returned an unknown db pool")
 		}
 		row := rows[info.DBPoolID]
 		logicalOrganizationID := strings.TrimSpace(row.TiDBCloudOrganizationID)
 		if logicalOrganizationID == "" {
-			return resolvedOrg, fmt.Errorf("managed shared db pool customer organization is required")
+			return fmt.Errorf("managed shared db pool customer organization is required")
 		}
 		if info.DBName == "" {
 			info.DBName = row.Name
@@ -1159,17 +1222,14 @@ func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, p
 			TiDBCloudOrganizationID: logicalOrganizationID, ClusterID: info.ClusterID, Host: info.Host,
 			Port: info.Port, User: info.Username, PasswordCipher: row.PasswordCipher, Name: info.DBName,
 			TLSMode: map[bool]string{true: "true", false: "skip-verify"}[dbTLSForProvisionedTenant(tenant.ProviderTiDBCloudNativeShared)]}); err != nil {
-			return resolvedOrg, err
-		}
-		if resolvedOrg == "" {
-			resolvedOrg = logicalOrganizationID
+			return err
 		}
 	}
 	if createErr != nil {
 		logger.Warn(ctx, "managed_shared_db_batch_create_partial",
 			zap.Int("requested", len(requests)), zap.Int("persisted", len(created)), zap.Error(createErr))
 	}
-	return resolvedOrg, nil
+	return nil
 }
 
 func (s *Server) markTenantPoolTenantFailed(ctx context.Context, tenantID, reason string) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1838,11 +1838,15 @@ func firstResultOrganizationID(results []*provisionTenantResult) string {
 }
 
 func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {
-	if pool == nil || pool.OrganizationID == "" || pool.Size <= 0 {
+	if pool == nil || pool.PoolID == "" || pool.OrganizationID == "" || pool.Size <= 0 {
+		return
+	}
+	if !s.beginTenantPoolReplenishment(pool.PoolID) {
 		return
 	}
 	workerCtx := backgroundWithTrace(ctx)
-	s.startServerWorker(workerCtx, func(ctx context.Context) {
+	if !s.startServerWorker(workerCtx, func(ctx context.Context) {
+		defer s.finishTenantPoolReplenishment(pool.PoolID)
 		replenishStarted := time.Now()
 		metricResult := "ok"
 		defer func() {
@@ -1866,13 +1870,13 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				metricResult = "skipped"
 				return nil
 			}
-			defer s.refreshTenantPoolCapacity(ctx, current)
 			freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
 				metricResult = "error"
 				return nil
 			}
+			s.recordTenantPoolCapacity(current.PoolID, current.OrganizationID, current.Size, freeSize)
 			if !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
 				logger.Info(ctx, "admin_tenant_pool_replenish_skipped",
 					zap.String("pool_id", current.PoolID),
@@ -1897,6 +1901,7 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				metricResult = "noop"
 				return nil
 			}
+			defer s.refreshTenantPoolCapacity(ctx, current)
 			if s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared {
 				maxTenants, _ := s.managedSharedDBPolicy()
 				missing = managedSharedDBRefillTenantCount(missing, maxTenants, s.managedSharedDBRefillPoolLimit)
@@ -1915,7 +1920,9 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			logger.Warn(ctx, "admin_tenant_pool_replenish_lock_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
 			metricResult = adminTenantPoolMetricResult(err)
 		}
-	})
+	}) {
+		s.finishTenantPoolReplenishment(pool.PoolID)
+	}
 }
 
 func (s *Server) tenantPoolBelowRefillWatermark(freeSize, poolSize int) bool {
@@ -1989,6 +1996,18 @@ func (s *Server) tenantPoolLock(poolID string) *sync.Mutex {
 	}
 	v, _ := s.tenantPoolLocks.LoadOrStore(poolID, &sync.Mutex{})
 	return v.(*sync.Mutex)
+}
+
+func (s *Server) beginTenantPoolReplenishment(poolID string) bool {
+	if strings.TrimSpace(poolID) == "" {
+		return false
+	}
+	_, loaded := s.tenantPoolReplenishJobs.LoadOrStore(poolID, struct{}{})
+	return !loaded
+}
+
+func (s *Server) finishTenantPoolReplenishment(poolID string) {
+	s.tenantPoolReplenishJobs.Delete(poolID)
 }
 
 func (s *Server) tenantPoolCreateLock(cred tenant.CredentialProvisionRequest) *sync.Mutex {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -53,9 +53,7 @@ const tenantPoolClaimCASRetryLimit = 8
 
 const sharedTenantPoolCreateConcurrency = 50
 
-const managedSharedDBRefillPoolLimit = 50
-
-func managedSharedDBRefillTenantCount(missing, maxTenants int) int {
+func managedSharedDBRefillTenantCount(missing, maxTenants, poolLimit int) int {
 	if missing <= 0 {
 		return 0
 	}
@@ -64,8 +62,11 @@ func managedSharedDBRefillTenantCount(missing, maxTenants int) int {
 	}
 	maxInt := int(^uint(0) >> 1)
 	limit := maxInt
-	if maxTenants <= maxInt/managedSharedDBRefillPoolLimit {
-		limit = maxTenants * managedSharedDBRefillPoolLimit
+	if poolLimit <= 0 {
+		poolLimit = DefaultManagedSharedDBRefillPoolLimit
+	}
+	if maxTenants <= maxInt/poolLimit {
+		limit = maxTenants * poolLimit
 	}
 	return min(missing, limit)
 }
@@ -1889,7 +1890,7 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			}
 			if s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared {
 				maxTenants, _ := s.managedSharedDBPolicy()
-				missing = managedSharedDBRefillTenantCount(missing, maxTenants)
+				missing = managedSharedDBRefillTenantCount(missing, maxTenants, s.managedSharedDBRefillPoolLimit)
 			}
 			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
 			if err != nil {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -53,10 +53,7 @@ const tenantPoolClaimCASRetryLimit = 8
 
 const sharedTenantPoolCreateConcurrency = 50
 
-const (
-	managedSharedDBCloudBatchSize        = 10
-	managedSharedDBCloudBatchConcurrency = 10
-)
+const tenantPoolRefillWaveLimit = 50
 
 func retryTenantPoolClaimCAS[T any](attempt func() (T, error)) (T, error) {
 	var zero T
@@ -1171,25 +1168,28 @@ func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, p
 	type batchResult struct {
 		err error
 	}
-	batchCount := (len(requests) + managedSharedDBCloudBatchSize - 1) / managedSharedDBCloudBatchSize
+	batchSize := s.managedSharedDBCloudBatchSize
+	if batchSize <= 0 {
+		batchSize = DefaultManagedSharedDBCloudBatchSize
+	}
+	batchCount := (len(requests) + batchSize - 1) / batchSize
 	batchResults := make([]batchResult, batchCount)
-	batchSlots := make(chan struct{}, min(batchCount, managedSharedDBCloudBatchConcurrency))
+	batches := make([][]tenant.SharedDBPoolCreateRequest, 0, batchCount)
+	for start := 0; start < len(requests); start += batchSize {
+		end := min(start+batchSize, len(requests))
+		batches = append(batches, append([]tenant.SharedDBPoolCreateRequest(nil), requests[start:end]...))
+	}
 	var wg sync.WaitGroup
-	for batchIndex, start := 0, 0; start < len(requests); batchIndex, start = batchIndex+1, start+managedSharedDBCloudBatchSize {
-		end := min(start+managedSharedDBCloudBatchSize, len(requests))
-		chunk := append([]tenant.SharedDBPoolCreateRequest(nil), requests[start:end]...)
+	for batchIndex := range batches {
 		wg.Add(1)
-		go func(batchIndex int, chunk []tenant.SharedDBPoolCreateRequest) {
+		go func() {
 			defer wg.Done()
-			select {
-			case batchSlots <- struct{}{}:
-				defer func() { <-batchSlots }()
-			case <-ctx.Done():
-				batchResults[batchIndex].err = ctx.Err()
+			if err := ctx.Err(); err != nil {
+				batchResults[batchIndex].err = err
 				return
 			}
-			batchResults[batchIndex].err = s.provisionManagedSharedDBPoolsBatchChunkLocked(ctx, provisioner, chunk, rows, cred)
-		}(batchIndex, chunk)
+			batchResults[batchIndex].err = s.provisionManagedSharedDBPoolsBatchChunkLocked(ctx, provisioner, batches[batchIndex], rows, cred)
+		}()
 	}
 	wg.Wait()
 	var batchErr error
@@ -1872,6 +1872,7 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				metricResult = "noop"
 				return nil
 			}
+			missing = min(missing, tenantPoolRefillWaveLimit)
 			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1116,7 +1116,10 @@ func (s *Server) provisionManagedSharedDBPoolsBatchWithCredentials(ctx context.C
 	if len(dbIDs) == 0 {
 		return "", nil
 	}
-	provisioner := s.provisioner.(tenant.SharedDBPoolProvisioner)
+	provisioner, ok := s.provisioner.(tenant.SharedDBPoolProvisioner)
+	if !ok {
+		return "", fmt.Errorf("provisioner does not support managed shared db pools")
+	}
 	for attempt := 0; attempt < 2; attempt++ {
 		first, err := s.meta.GetSharedDB(ctx, dbIDs[0])
 		if err != nil {
@@ -1222,14 +1225,18 @@ func (s *Server) provisionManagedSharedDBPoolsBatchChunkLocked(ctx context.Conte
 			zap.Int("db_pool_count", len(requests)), zap.Error(createErr))
 		return createErr
 	}
+	var persistErr error
+	persisted := 0
 	for _, info := range created {
 		if info == nil || rows[info.DBPoolID] == nil || rows[info.DBPoolID].UUID != info.DBPoolUUID {
-			return fmt.Errorf("shared db batch returned an unknown db pool")
+			persistErr = errors.Join(persistErr, fmt.Errorf("shared db batch returned an unknown db pool"))
+			continue
 		}
 		row := rows[info.DBPoolID]
 		logicalOrganizationID := strings.TrimSpace(row.TiDBCloudOrganizationID)
 		if logicalOrganizationID == "" {
-			return fmt.Errorf("managed shared db pool customer organization is required")
+			persistErr = errors.Join(persistErr, fmt.Errorf("managed shared db pool %d customer organization is required", info.DBPoolID))
+			continue
 		}
 		if info.DBName == "" {
 			info.DBName = row.Name
@@ -1238,14 +1245,16 @@ func (s *Server) provisionManagedSharedDBPoolsBatchChunkLocked(ctx context.Conte
 			TiDBCloudOrganizationID: logicalOrganizationID, ClusterID: info.ClusterID, Host: info.Host,
 			Port: info.Port, User: info.Username, PasswordCipher: row.PasswordCipher, Name: info.DBName,
 			TLSMode: map[bool]string{true: "true", false: "skip-verify"}[dbTLSForProvisionedTenant(tenant.ProviderTiDBCloudNativeShared)]}); err != nil {
-			return err
+			persistErr = errors.Join(persistErr, err)
+			continue
 		}
+		persisted++
 	}
 	if createErr != nil {
 		logger.Warn(ctx, "managed_shared_db_batch_create_partial",
-			zap.Int("requested", len(requests)), zap.Int("persisted", len(created)), zap.Error(createErr))
+			zap.Int("requested", len(requests)), zap.Int("persisted", persisted), zap.Error(createErr))
 	}
-	return nil
+	return errors.Join(createErr, persistErr)
 }
 
 func (s *Server) markTenantPoolTenantFailed(ctx context.Context, tenantID, reason string) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -58,7 +58,7 @@ const adminTenantPoolMetricsComponent = "admin_tenant_pool"
 const tenantPoolClaimCASRetryLimit = 8
 
 const (
-	sharedTenantPoolCreateConcurrency    = 10
+	sharedTenantPoolCreateConcurrency    = 30
 	tenantPoolReplenishMinInterval       = time.Second
 	tenantPoolPendingResumeEmptyInterval = 15 * time.Second
 )

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -43,6 +43,12 @@ type tenantPoolResumeJob struct {
 	rerun atomic.Bool
 }
 
+type tenantPoolWorkGate struct {
+	mu          sync.Mutex
+	running     bool
+	nextAllowed time.Time
+}
+
 type adminTenantPoolStatus string
 
 const adminTenantPoolStatusCreating adminTenantPoolStatus = "creating"
@@ -51,7 +57,11 @@ const adminTenantPoolMetricsComponent = "admin_tenant_pool"
 
 const tenantPoolClaimCASRetryLimit = 8
 
-const sharedTenantPoolCreateConcurrency = 50
+const (
+	sharedTenantPoolCreateConcurrency    = 10
+	tenantPoolReplenishMinInterval       = time.Second
+	tenantPoolPendingResumeEmptyInterval = 15 * time.Second
+)
 
 func managedSharedDBRefillTenantCount(missing, maxTenants, poolLimit int) int {
 	if missing <= 0 {
@@ -706,21 +716,6 @@ func (s *Server) recordTenantPoolCapacity(poolID, organizationID string, size, f
 	}
 	metrics.RecordTenantPoolCapacity(poolID, organizationID, "size", float64(size))
 	metrics.RecordTenantPoolCapacity(poolID, organizationID, "free", float64(freeSize))
-}
-
-func (s *Server) refreshTenantPoolCapacity(ctx context.Context, pool *meta.TenantPool) {
-	if s == nil || s.meta == nil || pool == nil || pool.OrganizationID == "" {
-		return
-	}
-	freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, pool.OrganizationID)
-	if err != nil {
-		logger.Warn(ctx, "admin_tenant_pool_capacity_refresh_failed",
-			zap.String("pool_id", pool.PoolID),
-			zap.String("organization_id", pool.OrganizationID),
-			zap.Error(err))
-		return
-	}
-	s.recordTenantPoolCapacity(pool.PoolID, pool.OrganizationID, pool.Size, freeSize)
 }
 
 func (s *Server) firstManagedOrganization(ctx context.Context, cred tenant.CredentialProvisionRequest) (string, error) {
@@ -1852,11 +1847,45 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 		defer func() {
 			metrics.RecordOperation(adminTenantPoolMetricsComponent, "replenish", metricResult, time.Since(replenishStarted))
 		}()
+		current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
+		if err != nil {
+			if !errors.Is(err, meta.ErrNotFound) {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
+				metricResult = "error"
+			} else {
+				metricResult = "not_found"
+			}
+			return
+		}
+		if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
+			metricResult = "skipped"
+			return
+		}
+		freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
+		if err != nil {
+			logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+			metricResult = "error"
+			return
+		}
+		s.recordTenantPoolCapacity(current.PoolID, current.OrganizationID, current.Size, freeSize)
+		if !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
+			logger.Info(ctx, "admin_tenant_pool_replenish_skipped",
+				zap.String("pool_id", current.PoolID),
+				zap.String("organization_id", current.OrganizationID),
+				zap.Int("pool_size", current.Size),
+				zap.Int("free_size", freeSize),
+				zap.Float64("refill_free_ratio", s.effectiveTenantPoolRefillFreeRatio()))
+			metricResult = "noop"
+			return
+		}
+
+		// The common no-op path returns before taking either lock. Re-check all
+		// capacity state under the distributed lock before provisioning.
 		lock := s.tenantPoolLock(pool.PoolID)
 		lock.Lock()
 		defer lock.Unlock()
 		if err := s.meta.WithTenantPoolLock(ctx, pool.PoolID, func(ctx context.Context) error {
-			current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
+			current, err = s.meta.GetTenantPoolByID(ctx, pool.PoolID)
 			if err != nil {
 				if !errors.Is(err, meta.ErrNotFound) {
 					logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
@@ -1870,7 +1899,7 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				metricResult = "skipped"
 				return nil
 			}
-			freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
+			freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
 				metricResult = "error"
@@ -1901,7 +1930,6 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				metricResult = "noop"
 				return nil
 			}
-			defer s.refreshTenantPoolCapacity(ctx, current)
 			if s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared {
 				maxTenants, _ := s.managedSharedDBPolicy()
 				missing = managedSharedDBRefillTenantCount(missing, maxTenants, s.managedSharedDBRefillPoolLimit)
@@ -1946,15 +1974,29 @@ func (s *Server) resumePendingTenantPoolAsync(ctx context.Context, pool *meta.Te
 	if pool == nil || pool.OrganizationID == "" || pool.PoolID == "" {
 		return
 	}
+	if actual, ok := s.tenantPoolResumeJobs.Load(pool.PoolID); ok {
+		if existing, typeOK := actual.(*tenantPoolResumeJob); typeOK {
+			existing.rerun.Store(true)
+		}
+		return
+	}
+	if !s.beginTenantPoolResumeScan(pool.PoolID) {
+		return
+	}
 	workerCtx := backgroundWithTrace(ctx)
-	s.startServerWorker(workerCtx, func(ctx context.Context) {
+	if !s.startServerWorker(workerCtx, func(ctx context.Context) {
+		empty := false
+		defer func() { s.finishTenantPoolResumeScan(pool.PoolID, empty) }()
 		clusters, err := s.pendingTenantPoolResumeClusters(ctx, pool.PoolID, pool.Size)
 		if err != nil {
 			logger.Warn(ctx, "admin_tenant_pool_pending_resume_list_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
 			return
 		}
+		empty = len(clusters) == 0
 		s.startPoolClustersMetadataResume(ctx, pool.PoolID, clusters, cred)
-	})
+	}) {
+		s.finishTenantPoolResumeScan(pool.PoolID, false)
+	}
 }
 
 func (s *Server) pendingTenantPoolResumeClusters(ctx context.Context, poolID string, limit int) ([]*tenant.ClusterInfo, error) {
@@ -1999,15 +2041,77 @@ func (s *Server) tenantPoolLock(poolID string) *sync.Mutex {
 }
 
 func (s *Server) beginTenantPoolReplenishment(poolID string) bool {
+	return s.beginTenantPoolReplenishmentAt(poolID, time.Now())
+}
+
+func (s *Server) beginTenantPoolReplenishmentAt(poolID string, now time.Time) bool {
 	if strings.TrimSpace(poolID) == "" {
 		return false
 	}
-	_, loaded := s.tenantPoolReplenishJobs.LoadOrStore(poolID, struct{}{})
-	return !loaded
+	value, _ := s.tenantPoolReplenishJobs.LoadOrStore(poolID, &tenantPoolWorkGate{})
+	gate := value.(*tenantPoolWorkGate)
+	gate.mu.Lock()
+	defer gate.mu.Unlock()
+	if gate.running || now.Before(gate.nextAllowed) {
+		return false
+	}
+	gate.running = true
+	return true
 }
 
 func (s *Server) finishTenantPoolReplenishment(poolID string) {
-	s.tenantPoolReplenishJobs.Delete(poolID)
+	s.finishTenantPoolReplenishmentAt(poolID, time.Now())
+}
+
+func (s *Server) finishTenantPoolReplenishmentAt(poolID string, now time.Time) {
+	value, ok := s.tenantPoolReplenishJobs.Load(poolID)
+	if !ok {
+		return
+	}
+	gate := value.(*tenantPoolWorkGate)
+	gate.mu.Lock()
+	gate.running = false
+	gate.nextAllowed = now.Add(tenantPoolReplenishMinInterval)
+	gate.mu.Unlock()
+}
+
+func (s *Server) beginTenantPoolResumeScan(poolID string) bool {
+	return s.beginTenantPoolResumeScanAt(poolID, time.Now())
+}
+
+func (s *Server) beginTenantPoolResumeScanAt(poolID string, now time.Time) bool {
+	if strings.TrimSpace(poolID) == "" {
+		return false
+	}
+	value, _ := s.tenantPoolResumeScans.LoadOrStore(poolID, &tenantPoolWorkGate{})
+	gate := value.(*tenantPoolWorkGate)
+	gate.mu.Lock()
+	defer gate.mu.Unlock()
+	if gate.running || now.Before(gate.nextAllowed) {
+		return false
+	}
+	gate.running = true
+	return true
+}
+
+func (s *Server) finishTenantPoolResumeScan(poolID string, empty bool) {
+	s.finishTenantPoolResumeScanAt(poolID, time.Now(), empty)
+}
+
+func (s *Server) finishTenantPoolResumeScanAt(poolID string, now time.Time, empty bool) {
+	value, ok := s.tenantPoolResumeScans.Load(poolID)
+	if !ok {
+		return
+	}
+	gate := value.(*tenantPoolWorkGate)
+	gate.mu.Lock()
+	gate.running = false
+	if empty {
+		gate.nextAllowed = now.Add(tenantPoolPendingResumeEmptyInterval)
+	} else {
+		gate.nextAllowed = time.Time{}
+	}
+	gate.mu.Unlock()
 }
 
 func (s *Server) tenantPoolCreateLock(cred tenant.CredentialProvisionRequest) *sync.Mutex {
@@ -2078,7 +2182,6 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "reason", "pool_inactive", "pool_status", pool.Status, "duration_ms", durationMillis(claimStarted))...)
 		return nil, nil, false, false, nil
 	}
-	defer s.refreshTenantPoolCapacity(ctx, pool)
 	s.resumePendingTenantPoolAsync(ctx, pool, cred)
 	stageStarted = time.Now()
 	selection, err := retryTenantPoolClaimCAS(func() (tenantPoolClaimSelection, error) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -53,7 +53,22 @@ const tenantPoolClaimCASRetryLimit = 8
 
 const sharedTenantPoolCreateConcurrency = 50
 
-const tenantPoolRefillWaveLimit = 50
+const managedSharedDBRefillPoolLimit = 50
+
+func managedSharedDBRefillTenantCount(missing, maxTenants int) int {
+	if missing <= 0 {
+		return 0
+	}
+	if maxTenants <= 0 {
+		maxTenants = defaultManagedSharedDBMaxTenants
+	}
+	maxInt := int(^uint(0) >> 1)
+	limit := maxInt
+	if maxTenants <= maxInt/managedSharedDBRefillPoolLimit {
+		limit = maxTenants * managedSharedDBRefillPoolLimit
+	}
+	return min(missing, limit)
+}
 
 func retryTenantPoolClaimCAS[T any](attempt func() (T, error)) (T, error) {
 	var zero T
@@ -1872,7 +1887,10 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				metricResult = "noop"
 				return nil
 			}
-			missing = min(missing, tenantPoolRefillWaveLimit)
+			if s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared {
+				maxTenants, _ := s.managedSharedDBPolicy()
+				missing = managedSharedDBRefillTenantCount(missing, maxTenants)
+			}
 			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1016,23 +1016,15 @@ func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
 	}
 }
 
-func TestAdminTenantPoolReplenishCapsOneWaveAtFifty(t *testing.T) {
-	rt, _ := newAdminTenantPoolRuntime(t)
-	ctx := context.Background()
-	now := time.Now().UTC()
-	pool := &meta.TenantPool{PoolID: "pool-refill-cap", OrganizationID: "org-1", Size: 100,
-		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}
-	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
-		t.Fatalf("create pool: %v", err)
+func TestManagedSharedDBRefillCapsOneWaveAtFiftyPhysicalPools(t *testing.T) {
+	if got := managedSharedDBRefillTenantCount(10_000, 100); got != 5_000 {
+		t.Fatalf("refill tenant count = %d, want capacity of 50 physical pools", got)
 	}
-	rt.server.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"})
-	rt.server.forkWorkerWG.Wait()
-	free, err := rt.meta.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
-	if err != nil {
-		t.Fatalf("count free slots: %v", err)
+	if got := managedSharedDBRefillTenantCount(1_600, 100); got != 1_600 {
+		t.Fatalf("refill tenant count = %d, want all 1600 tenants across 16 physical pools", got)
 	}
-	if free != tenantPoolRefillWaveLimit {
-		t.Fatalf("free slots = %d, want one refill wave capped at %d", free, tenantPoolRefillWaveLimit)
+	if got := managedSharedDBRefillTenantCount(100, 1); got != 50 {
+		t.Fatalf("refill tenant count with one tenant per DB = %d, want 50", got)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1017,14 +1017,17 @@ func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
 }
 
 func TestManagedSharedDBRefillCapsOneWaveAtFiftyPhysicalPools(t *testing.T) {
-	if got := managedSharedDBRefillTenantCount(10_000, 100); got != 5_000 {
+	if got := managedSharedDBRefillTenantCount(10_000, 100, 50); got != 5_000 {
 		t.Fatalf("refill tenant count = %d, want capacity of 50 physical pools", got)
 	}
-	if got := managedSharedDBRefillTenantCount(1_600, 100); got != 1_600 {
+	if got := managedSharedDBRefillTenantCount(1_600, 100, 50); got != 1_600 {
 		t.Fatalf("refill tenant count = %d, want all 1600 tenants across 16 physical pools", got)
 	}
-	if got := managedSharedDBRefillTenantCount(100, 1); got != 50 {
+	if got := managedSharedDBRefillTenantCount(100, 1, 50); got != 50 {
 		t.Fatalf("refill tenant count with one tenant per DB = %d, want 50", got)
+	}
+	if got := managedSharedDBRefillTenantCount(10_000, 100, 12); got != 1_200 {
+		t.Fatalf("refill tenant count with configured 12-DB limit = %d, want 1200", got)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1016,6 +1016,26 @@ func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
 	}
 }
 
+func TestAdminTenantPoolReplenishCapsOneWaveAtFifty(t *testing.T) {
+	rt, _ := newAdminTenantPoolRuntime(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{PoolID: "pool-refill-cap", OrganizationID: "org-1", Size: 100,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	rt.server.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"})
+	rt.server.forkWorkerWG.Wait()
+	free, err := rt.meta.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
+	if err != nil {
+		t.Fatalf("count free slots: %v", err)
+	}
+	if free != tenantPoolRefillWaveLimit {
+		t.Fatalf("free slots = %d, want one refill wave capped at %d", free, tenantPoolRefillWaveLimit)
+	}
+}
+
 func TestTenantPoolEffectiveRefillRatioRejectsNaN(t *testing.T) {
 	s := &Server{tenantPoolRefillFreeRatio: math.NaN()}
 	if got := s.effectiveTenantPoolRefillFreeRatio(); got != DefaultTenantPoolRefillFreeRatio {

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -151,6 +151,13 @@ func TestTenantPoolClaimConsumesMixedInventoryInGlobalAgeOrder(t *testing.T) {
 			CreatedAt: sharedCreatedAt, UpdatedAt: sharedCreatedAt}); err != nil {
 		t.Fatalf("CompleteSharedTenantPoolMember: %v", err)
 	}
+	free, err := rt.meta.CountFreeTenantPoolBindings(ctx, "org-mixed-age")
+	if err != nil {
+		t.Fatalf("CountFreeTenantPoolBindings: %v", err)
+	}
+	if free != 2 {
+		t.Fatalf("mixed native/shared free inventory = %d, want 2", free)
+	}
 
 	cred := tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}
 	first, _, claimed, _, err := rt.server.claimAdminTenantFromPool(ctx, cred, nil)
@@ -287,37 +294,38 @@ func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T
 	}
 }
 
-func TestSharedTenantPoolRefillRunsFiftyTenantWorkers(t *testing.T) {
-	started := make(chan struct{}, sharedTenantPoolCreateConcurrency+1)
+func TestSharedTenantPoolRefillLimitsTenantWorkersToTen(t *testing.T) {
+	const wantConcurrency = 10
+	started := make(chan struct{}, wantConcurrency+1)
 	release := make(chan struct{})
 	done := make(chan []sharedPoolTenantCreateOutcome, 1)
 	go func() {
-		done <- runSharedPoolTenantCreateWorkers(context.Background(), sharedTenantPoolCreateConcurrency+1, func() sharedPoolTenantCreateOutcome {
+		done <- runSharedPoolTenantCreateWorkers(context.Background(), wantConcurrency+1, func() sharedPoolTenantCreateOutcome {
 			started <- struct{}{}
 			<-release
 			return sharedPoolTenantCreateOutcome{}
 		})
 	}()
-	for i := 0; i < sharedTenantPoolCreateConcurrency; i++ {
+	for i := 0; i < wantConcurrency; i++ {
 		select {
 		case <-started:
 		case <-time.After(500 * time.Millisecond):
 			close(release)
 			<-done
-			t.Fatalf("started %d/%d tenant workers before release", i, sharedTenantPoolCreateConcurrency)
+			t.Fatalf("started %d/%d tenant workers before release", i, wantConcurrency)
 		}
 	}
 	select {
 	case <-started:
 		close(release)
 		<-done
-		t.Fatal("started a 51st tenant worker while 50 were still in flight")
+		t.Fatal("started an 11th tenant worker while 10 were still in flight")
 	case <-time.After(100 * time.Millisecond):
 	}
 	close(release)
 	outcomes := <-done
-	if len(outcomes) != sharedTenantPoolCreateConcurrency+1 {
-		t.Fatalf("outcomes = %d, want %d", len(outcomes), sharedTenantPoolCreateConcurrency+1)
+	if len(outcomes) != wantConcurrency+1 {
+		t.Fatalf("outcomes = %d, want %d", len(outcomes), wantConcurrency+1)
 	}
 }
 
@@ -953,12 +961,47 @@ func TestAdminTenantPoolReplenishSkipsAtFreeWatermark(t *testing.T) {
 	for i := 1; i <= 8; i++ {
 		insertAdminPoolFreeTenant(t, rt, pool.PoolID, pool.OrganizationID, i)
 	}
+	lockHeld := make(chan struct{})
+	releaseLock := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- rt.meta.WithTenantPoolLock(ctx, pool.PoolID, func(context.Context) error {
+			close(lockHeld)
+			<-releaseLock
+			return nil
+		})
+	}()
+	select {
+	case <-lockHeld:
+	case err := <-lockDone:
+		t.Fatalf("hold tenant pool lock: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out acquiring tenant pool lock for test")
+	}
+	var releaseOnce sync.Once
+	release := func() { releaseOnce.Do(func() { close(releaseLock) }) }
+	t.Cleanup(func() {
+		release()
+		<-lockDone
+	})
 
 	rt.server.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	})
-	rt.server.forkWorkerWG.Wait()
+	workerDone := make(chan struct{})
+	go func() {
+		rt.server.forkWorkerWG.Wait()
+		close(workerDone)
+	}()
+	select {
+	case <-workerDone:
+	case <-time.After(time.Second):
+		release()
+		<-workerDone
+		t.Fatal("above-watermark replenish waited for the MySQL tenant pool lock")
+	}
+	release()
 
 	if got := rt.prov.batchPoolCalls.Load(); got != 0 {
 		t.Fatalf("batch pool calls = %d, want 0", got)
@@ -974,20 +1017,59 @@ func TestAdminTenantPoolReplenishSkipsAtFreeWatermark(t *testing.T) {
 
 func TestTenantPoolReplenishmentCoalescesConcurrentTriggersByPool(t *testing.T) {
 	s := &Server{}
+	now := time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
 
-	if !s.beginTenantPoolReplenishment("pool-1") {
+	if !s.beginTenantPoolReplenishmentAt("pool-1", now) {
 		t.Fatal("first trigger was not accepted")
 	}
-	if s.beginTenantPoolReplenishment("pool-1") {
+	if s.beginTenantPoolReplenishmentAt("pool-1", now) {
 		t.Fatal("concurrent trigger for the same pool was accepted")
 	}
-	if !s.beginTenantPoolReplenishment("pool-2") {
+	if !s.beginTenantPoolReplenishmentAt("pool-2", now) {
 		t.Fatal("trigger for a different pool was not accepted")
 	}
 
-	s.finishTenantPoolReplenishment("pool-1")
-	if !s.beginTenantPoolReplenishment("pool-1") {
-		t.Fatal("trigger was not accepted after the previous job finished")
+	s.finishTenantPoolReplenishmentAt("pool-1", now)
+	if s.beginTenantPoolReplenishmentAt("pool-1", now.Add(tenantPoolReplenishMinInterval-time.Nanosecond)) {
+		t.Fatal("trigger was accepted during the per-pool minimum interval")
+	}
+	if !s.beginTenantPoolReplenishmentAt("pool-1", now.Add(tenantPoolReplenishMinInterval)) {
+		t.Fatal("trigger was not accepted after the per-pool minimum interval")
+	}
+}
+
+func TestTenantPoolPendingResumeScanCooldownAfterEmptyResult(t *testing.T) {
+	s := &Server{}
+	now := time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
+
+	if !s.beginTenantPoolResumeScanAt("pool-1", now) {
+		t.Fatal("first pending resume scan was not accepted")
+	}
+	if s.beginTenantPoolResumeScanAt("pool-1", now) {
+		t.Fatal("concurrent pending resume scan was accepted")
+	}
+	s.finishTenantPoolResumeScanAt("pool-1", now, true)
+	if s.beginTenantPoolResumeScanAt("pool-1", now.Add(tenantPoolPendingResumeEmptyInterval-time.Nanosecond)) {
+		t.Fatal("empty pending resume scan was retried during cooldown")
+	}
+	if !s.beginTenantPoolResumeScanAt("pool-1", now.Add(tenantPoolPendingResumeEmptyInterval)) {
+		t.Fatal("pending resume scan was not accepted after cooldown")
+	}
+}
+
+func TestTenantPoolPendingResumeRequestsRerunBeforeListing(t *testing.T) {
+	s := &Server{}
+	job := &tenantPoolResumeJob{}
+	s.tenantPoolResumeJobs.Store("pool-1", job)
+
+	s.resumePendingTenantPoolAsync(context.Background(), &meta.TenantPool{
+		PoolID:         "pool-1",
+		OrganizationID: "org-1",
+		Size:           10,
+	}, tenant.CredentialProvisionRequest{})
+
+	if !job.rerun.Load() {
+		t.Fatal("active metadata resume job did not receive a rerun request")
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"crypto/rand"
 	"errors"
@@ -38,14 +39,17 @@ func TestRetryTenantPoolClaimCASSucceedsOnEighthAttempt(t *testing.T) {
 	}
 }
 
-func TestRetryTenantPoolClaimCASStopsAfterLimit(t *testing.T) {
+func TestRetryTenantPoolClaimCASReturnsMissAfterLimit(t *testing.T) {
 	attempts := 0
-	_, err := retryTenantPoolClaimCAS(func() (int, error) {
+	got, err := retryTenantPoolClaimCAS(func() (int, error) {
 		attempts++
 		return 0, meta.ErrNotFound
 	})
-	if err == nil || !errors.Is(err, meta.ErrNotFound) {
-		t.Fatalf("err = %v, want wrapped ErrNotFound", err)
+	if err != nil {
+		t.Fatalf("err = %v, want nil for exhausted claim miss", err)
+	}
+	if got != 0 {
+		t.Fatalf("result = %d, want zero value", got)
 	}
 	if attempts != tenantPoolClaimCASRetryLimit {
 		t.Fatalf("attempts=%d, want %d", attempts, tenantPoolClaimCASRetryLimit)
@@ -168,7 +172,72 @@ func TestTenantPoolClaimConsumesMixedInventoryInGlobalAgeOrder(t *testing.T) {
 	}
 }
 
-func TestSharedTenantPoolRefillOneThousandPlansTenPoolsInOneBatch(t *testing.T) {
+func TestSharedTenantPoolRefillPlansTenPoolsInOneBatch(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer poolManager.Close()
+	poolManager.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
+	secret := make([]byte, 32)
+	_, _ = rand.Read(secret)
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 1, TokenSecret: secret})
+	defer srv.Close()
+	now := time.Now().UTC()
+	if err := metaStore.CreateTenantPool(context.Background(), &meta.TenantPool{PoolID: "pool-shared-10",
+		OrganizationID: "org-shared-ten-pools", Size: 10, Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	results, err := srv.createFreePoolTenants(context.Background(), "pool-shared-10", 10,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}, nil)
+	if err != nil {
+		t.Fatalf("createFreePoolTenants: %v", err)
+	}
+	if len(results) != 10 {
+		t.Fatalf("results = %d, want 10", len(results))
+	}
+	for _, result := range results {
+		if result.Status != meta.TenantPending {
+			t.Fatalf("tenant %s status = %q, want pending while connection metadata is incomplete", result.TenantID, result.Status)
+		}
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
+		t.Fatalf("shared batch calls = %d, want 1", got)
+	}
+	if got := prov.sharedPoolBatchMembers.Load(); got != 10 {
+		t.Fatalf("shared batch members = %d, want 10", got)
+	}
+	var managedPools int
+	if err := metaStore.DB().QueryRowContext(context.Background(), `SELECT COUNT(*) FROM db_pool
+		WHERE org_id = ? AND status = ?`, "org-shared-ten-pools", meta.SharedDBStatusPending).Scan(&managedPools); err != nil {
+		t.Fatal(err)
+	}
+	if managedPools != 10 {
+		t.Fatalf("managed pools = %d, want 10", managedPools)
+	}
+	slots, err := metaStore.CountTenantPoolFreeSlots(context.Background(), "org-shared-ten-pools")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if slots != 10 {
+		t.Fatalf("free slots = %d, want 10", slots)
+	}
+}
+
+func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -187,49 +256,122 @@ func TestSharedTenantPoolRefillOneThousandPlansTenPoolsInOneBatch(t *testing.T) 
 	defer poolManager.Close()
 	poolManager.SetMetaStore(metaStore)
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
-		managedClusters: []tenant.CloudClusterInfo{{OrganizationID: "org-shared"}}}
-	secret := make([]byte, 32)
-	_, _ = rand.Read(secret)
+		sharedPoolBatchErr: errors.New("stop after managed pool planning")}
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
-		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: secret})
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
 	defer srv.Close()
 	now := time.Now().UTC()
-	if err := metaStore.CreateTenantPool(context.Background(), &meta.TenantPool{PoolID: "pool-shared-1000",
-		OrganizationID: "org-shared", Size: 1000, Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}); err != nil {
+	if err := metaStore.CreateTenantPool(context.Background(), &meta.TenantPool{PoolID: "pool-shared-credential",
+		OrganizationID: "org-shared", Size: 1, Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}); err != nil {
 		t.Fatal(err)
 	}
-	results, err := srv.createFreePoolTenants(context.Background(), "pool-shared-1000", 1000,
-		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}, nil)
+	_, err = srv.createFreeSharedPoolTenants(context.Background(), "pool-shared-credential", 1,
+		tenant.CredentialProvisionRequest{PublicKey: "customer-public", PrivateKey: "customer-private"}, nil)
+	if err == nil {
+		t.Fatal("createFreeSharedPoolTenants succeeded, want forced batch failure")
+	}
+	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusPending, 10)
 	if err != nil {
-		t.Fatalf("createFreePoolTenants: %v", err)
+		t.Fatal(err)
 	}
-	if len(results) != 1000 {
-		t.Fatalf("results = %d, want 1000", len(results))
+	if len(rows) != 1 {
+		t.Fatalf("managed pools = %d, want 1", len(rows))
 	}
-	for _, result := range results {
-		if result.Status != meta.TenantPending {
-			t.Fatalf("tenant %s status = %q, want pending while connection metadata is incomplete", result.TenantID, result.Status)
+	wantProvisioningKey := sharedDBProvisioningKey(tenant.CredentialProvisionRequest{PublicKey: "shared-public"})
+	if !bytes.Equal(rows[0].ProvisioningKey, wantProvisioningKey) {
+		t.Fatalf("managed pool provisioning key = %x, want server-owned shared credential key %x",
+			rows[0].ProvisioningKey, wantProvisioningKey)
+	}
+	if got := prov.iamCalls.Load(); got != 0 {
+		t.Fatalf("identity lookups = %d, want 0", got)
+	}
+}
+
+func TestSharedTenantPoolRefillRunsFiftyTenantWorkers(t *testing.T) {
+	started := make(chan struct{}, sharedTenantPoolCreateConcurrency+1)
+	release := make(chan struct{})
+	done := make(chan []sharedPoolTenantCreateOutcome, 1)
+	go func() {
+		done <- runSharedPoolTenantCreateWorkers(context.Background(), sharedTenantPoolCreateConcurrency+1, func() sharedPoolTenantCreateOutcome {
+			started <- struct{}{}
+			<-release
+			return sharedPoolTenantCreateOutcome{}
+		})
+	}()
+	for i := 0; i < sharedTenantPoolCreateConcurrency; i++ {
+		select {
+		case <-started:
+		case <-time.After(500 * time.Millisecond):
+			close(release)
+			<-done
+			t.Fatalf("started %d/%d tenant workers before release", i, sharedTenantPoolCreateConcurrency)
 		}
 	}
-	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
-		t.Fatalf("shared batch calls = %d, want 1", got)
+	select {
+	case <-started:
+		close(release)
+		<-done
+		t.Fatal("started a 51st tenant worker while 50 were still in flight")
+	case <-time.After(100 * time.Millisecond):
 	}
-	if got := prov.sharedPoolBatchMembers.Load(); got != 10 {
-		t.Fatalf("shared batch members = %d, want 10", got)
+	close(release)
+	outcomes := <-done
+	if len(outcomes) != sharedTenantPoolCreateConcurrency+1 {
+		t.Fatalf("outcomes = %d, want %d", len(outcomes), sharedTenantPoolCreateConcurrency+1)
 	}
-	rows, err := metaStore.ListSharedDBsByStatus(context.Background(), meta.SharedDBStatusPending, 20)
+}
+
+func TestSharedTenantPoolRefillUsesExistingCapacityWithoutIdentityLookup(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 10 {
-		t.Fatalf("managed pools = %d, want 10", len(rows))
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
 	}
-	slots, err := metaStore.CountTenantPoolFreeSlots(context.Background(), "org-shared")
+	enc, err := encrypt.NewLocalAESEncryptor(master)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if slots != 1000 {
-		t.Fatalf("free slots = %d, want 1000", slots)
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer poolManager.Close()
+	poolManager.SetMetaStore(metaStore)
+	passwordCipher, err := poolManager.Encrypt(context.Background(), []byte("shared-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := metaStore.RegisterSharedDB(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-shared-existing", Host: "shared.example.com", Port: 4000,
+		User: "root", PasswordCipher: passwordCipher, Name: "tidbcloud_fs", MaxTenants: 100,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Now().UTC()
+	if err := metaStore.CreateTenantPool(context.Background(), &meta.TenantPool{
+		PoolID: "pool-shared-existing", OrganizationID: "org-shared-existing", Size: 50,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, identityOrg: "org-shared-existing"}
+	srv := &Server{meta: metaStore, pool: poolManager, provisioner: prov,
+		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour)}
+	results, err := srv.createFreeSharedPoolTenants(context.Background(), "pool-shared-existing", 50,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}, nil)
+	if err != nil {
+		t.Fatalf("createFreeSharedPoolTenants: %v", err)
+	}
+	if len(results) != 50 {
+		t.Fatalf("results = %d, want 50", len(results))
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 0 {
+		t.Fatalf("physical batch calls = %d, want 0 for existing capacity", got)
+	}
+	if got := prov.iamCalls.Load(); got != 0 {
+		t.Fatalf("identity lookups = %d, want 0 when tenant pool organization is known", got)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -972,6 +972,25 @@ func TestAdminTenantPoolReplenishSkipsAtFreeWatermark(t *testing.T) {
 	}
 }
 
+func TestTenantPoolReplenishmentCoalescesConcurrentTriggersByPool(t *testing.T) {
+	s := &Server{}
+
+	if !s.beginTenantPoolReplenishment("pool-1") {
+		t.Fatal("first trigger was not accepted")
+	}
+	if s.beginTenantPoolReplenishment("pool-1") {
+		t.Fatal("concurrent trigger for the same pool was accepted")
+	}
+	if !s.beginTenantPoolReplenishment("pool-2") {
+		t.Fatal("trigger for a different pool was not accepted")
+	}
+
+	s.finishTenantPoolReplenishment("pool-1")
+	if !s.beginTenantPoolReplenishment("pool-1") {
+		t.Fatal("trigger was not accepted after the previous job finished")
+	}
+}
+
 func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
 	rt, _ := newAdminTenantPoolRuntime(t)
 	ctx := context.Background()

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -294,8 +294,8 @@ func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T
 	}
 }
 
-func TestSharedTenantPoolRefillLimitsTenantWorkersToTen(t *testing.T) {
-	const wantConcurrency = 10
+func TestSharedTenantPoolRefillLimitsTenantWorkersToThirty(t *testing.T) {
+	const wantConcurrency = 30
 	started := make(chan struct{}, wantConcurrency+1)
 	release := make(chan struct{})
 	done := make(chan []sharedPoolTenantCreateOutcome, 1)
@@ -319,7 +319,7 @@ func TestSharedTenantPoolRefillLimitsTenantWorkersToTen(t *testing.T) {
 	case <-started:
 		close(release)
 		<-done
-		t.Fatal("started an 11th tenant worker while 10 were still in flight")
+		t.Fatal("started a 31st tenant worker while 30 were still in flight")
 	case <-time.After(100 * time.Millisecond):
 	}
 	close(release)

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/drive9/internal/testmysql"
 	"github.com/mem9-ai/drive9/pkg/encrypt"
+	"github.com/mem9-ai/drive9/pkg/leader"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	tenantschema "github.com/mem9-ai/drive9/pkg/tenant/schema"
@@ -26,54 +27,58 @@ import (
 )
 
 type fakeProvisioner struct {
-	provider                string
-	cloudProvider           string
-	region                  string
-	cluster                 *tenant.ClusterInfo
-	initErr                 error
-	provisionErr            error
-	systemUserErr           error
-	systemUsername          string
-	systemPassword          string
-	deprovisionErr          error
-	quotaMarkErr            error
-	quotaUpdateErr          error
-	provisionCalls          atomic.Int32
-	credentialCalls         atomic.Int32
-	credentialQuotaCalls    atomic.Int32
-	systemUserCalls         atomic.Int32
-	deprovisionCalls        atomic.Int32
-	quotaMarkCalls          atomic.Int32
-	quotaUpdateCalls        atomic.Int32
-	sharedPoolBatchCalls    atomic.Int32
-	sharedPoolBatchMembers  atomic.Int32
-	sharedPoolBatchRequests chan []tenant.SharedDBPoolCreateRequest
-	lastCredentialReq       tenant.CredentialProvisionRequest
-	lastDeprovision         *tenant.ClusterInfo
-	lastQuotaCluster        *tenant.ClusterInfo
-	lastQuotaOptions        tenant.QuotaUpdateOptions
-	lastCreateQuotaOptions  tenant.QuotaUpdateOptions
-	defaultPublicKey        string
-	defaultPrivateKey       string
-	defaultSharedPublicKey  string
-	defaultSharedPrivateKey string
-	sharedPoolMu            sync.Mutex
-	lastSharedCredentialReq tenant.CredentialProvisionRequest
-	iamCalls                atomic.Int32
-	iamMu                   sync.Mutex
-	iamCredentials          []tenant.CredentialProvisionRequest
-	identityOrg             string
-	identityRole            string
-	managedClusters         []tenant.CloudClusterInfo
-	sharedPoolResults       []*tenant.SharedDBPoolInfo
-	sharedPoolBatchErr      error
-	sharedPoolPartialErr    error
-	sharedPoolBatchStarted  chan struct{}
-	sharedPoolBatchRelease  <-chan struct{}
-	sharedPoolWaitCalls     atomic.Int32
-	sharedPoolWaitErr       error
-	sharedPoolLoadIDs       chan int64
-	sharedPoolWaitRelease   <-chan struct{}
+	provider                    string
+	cloudProvider               string
+	region                      string
+	cluster                     *tenant.ClusterInfo
+	initErr                     error
+	provisionErr                error
+	systemUserErr               error
+	systemUsername              string
+	systemPassword              string
+	deprovisionErr              error
+	quotaMarkErr                error
+	quotaUpdateErr              error
+	provisionCalls              atomic.Int32
+	credentialCalls             atomic.Int32
+	credentialQuotaCalls        atomic.Int32
+	systemUserCalls             atomic.Int32
+	deprovisionCalls            atomic.Int32
+	quotaMarkCalls              atomic.Int32
+	quotaUpdateCalls            atomic.Int32
+	sharedPoolBatchCalls        atomic.Int32
+	sharedPoolBatchMembers      atomic.Int32
+	sharedPoolBatchRequests     chan []tenant.SharedDBPoolCreateRequest
+	lastCredentialReq           tenant.CredentialProvisionRequest
+	lastDeprovision             *tenant.ClusterInfo
+	lastQuotaCluster            *tenant.ClusterInfo
+	lastQuotaOptions            tenant.QuotaUpdateOptions
+	lastCreateQuotaOptions      tenant.QuotaUpdateOptions
+	defaultPublicKey            string
+	defaultPrivateKey           string
+	defaultSharedPublicKey      string
+	defaultSharedPrivateKey     string
+	sharedPoolMu                sync.Mutex
+	lastSharedCredentialReq     tenant.CredentialProvisionRequest
+	iamCalls                    atomic.Int32
+	iamMu                       sync.Mutex
+	iamCredentials              []tenant.CredentialProvisionRequest
+	identityOrg                 string
+	identityRole                string
+	managedClusters             []tenant.CloudClusterInfo
+	sharedPoolResults           []*tenant.SharedDBPoolInfo
+	sharedPoolBatchErr          error
+	sharedPoolPartialErr        error
+	sharedPoolBatchStarted      chan struct{}
+	sharedPoolBatchRelease      <-chan struct{}
+	sharedPoolWaitCalls         atomic.Int32
+	sharedPoolBatchLoadCalls    atomic.Int32
+	sharedPoolBatchLoadMembers  atomic.Int32
+	sharedPoolBatchLoadRequests chan []tenant.SharedDBPoolLoadRequest
+	sharedPoolBatchLoadFunc     func([]tenant.SharedDBPoolLoadRequest) ([]*tenant.SharedDBPoolInfo, error)
+	sharedPoolWaitErr           error
+	sharedPoolLoadIDs           chan int64
+	sharedPoolWaitRelease       <-chan struct{}
 }
 
 type failingEncryptor struct {
@@ -157,6 +162,206 @@ func TestDefaultTenantProviderIsIndependentFromProvisionerType(t *testing.T) {
 	}
 	if srv.provisioner.ProviderType() != tenant.ProviderTiDBCloudNative {
 		t.Fatalf("provisioner provider = %q, want native Cloud implementation", srv.provisioner.ProviderType())
+	}
+}
+
+func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
+	defaults := NewWithConfig(Config{})
+	t.Cleanup(defaults.Close)
+	if defaults.managedSharedDBCloudBatchSize != 10 ||
+		defaults.managedSharedDBMetadataWorkers != 15 || defaults.managedSharedDBMetadataBatchSize != 30 ||
+		defaults.managedSharedDBMetadataPollInterval != 15*time.Second || defaults.managedSharedDBProvisioningWorkers != 100 {
+		t.Fatalf("managed shared defaults = cloud_batch(%d) metadata(%d,%d,%s) provisioning(%d)",
+			defaults.managedSharedDBCloudBatchSize,
+			defaults.managedSharedDBMetadataWorkers, defaults.managedSharedDBMetadataBatchSize, defaults.managedSharedDBMetadataPollInterval,
+			defaults.managedSharedDBProvisioningWorkers)
+	}
+	overrides := NewWithConfig(Config{
+		ManagedSharedDBCloudBatchSize:  3,
+		ManagedSharedDBMetadataWorkers: 5, ManagedSharedDBMetadataBatchSize: 6, ManagedSharedDBMetadataPollInterval: 7 * time.Second,
+		ManagedSharedDBProvisioningWorkers: 8,
+	})
+	t.Cleanup(overrides.Close)
+	if overrides.managedSharedDBCloudBatchSize != 3 ||
+		overrides.managedSharedDBMetadataWorkers != 5 || overrides.managedSharedDBMetadataBatchSize != 6 ||
+		overrides.managedSharedDBMetadataPollInterval != 7*time.Second || overrides.managedSharedDBProvisioningWorkers != 8 {
+		t.Fatalf("managed shared overrides were not retained")
+	}
+	capped := NewWithConfig(Config{ManagedSharedDBCloudBatchSize: 11, ManagedSharedDBMetadataWorkers: 16, ManagedSharedDBMetadataBatchSize: 31})
+	t.Cleanup(capped.Close)
+	if capped.managedSharedDBCloudBatchSize != 10 || capped.managedSharedDBMetadataWorkers != 15 || capped.managedSharedDBMetadataBatchSize != 30 {
+		t.Fatalf("managed shared safety caps = cloud batch %d, metadata workers %d, metadata batch %d",
+			capped.managedSharedDBCloudBatchSize, capped.managedSharedDBMetadataWorkers, capped.managedSharedDBMetadataBatchSize)
+	}
+}
+
+func TestRunManagedSharedDBProvisioningJobsHonorsWorkerLimit(t *testing.T) {
+	started := make(chan int64, 3)
+	release := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		runManagedSharedDBProvisioningJobs(context.Background(), 2, nil, []int64{1, 2, 3}, func(_ context.Context, dbID int64) {
+			started <- dbID
+			<-release
+		})
+		close(done)
+	}()
+	for i := 0; i < 2; i++ {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatalf("started %d/2 provisioning workers", i)
+		}
+	}
+	select {
+	case <-started:
+		t.Fatal("started a third provisioning job while two workers were busy")
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("provisioning jobs did not finish")
+	}
+}
+
+func TestManagedSharedDBContinuationDoesNotStartOnFollower(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	mgr := leader.NewManager(metaStore.DB())
+	srv := &Server{leader: mgr}
+	called := make(chan struct{}, 1)
+	if srv.startManagedSharedDBWorker(context.Background(), func(context.Context) { called <- struct{}{} }) {
+		t.Fatal("follower started managed shared DB continuation")
+	}
+	select {
+	case <-called:
+		t.Fatal("follower ran managed shared DB continuation")
+	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestRunManagedSharedDBProvisioningQueueRequeuesWithoutBlockingWorker(t *testing.T) {
+	var mu sync.Mutex
+	order := make([]int64, 0, 3)
+	attempts := make(map[int64]int)
+	failed := runManagedSharedDBProvisioningQueue(context.Background(), 1, nil, []int64{1, 2},
+		time.Second, 20*time.Millisecond, 20*time.Millisecond,
+		func(_ context.Context, dbID int64) error {
+			mu.Lock()
+			defer mu.Unlock()
+			order = append(order, dbID)
+			attempts[dbID]++
+			if dbID == 1 && attempts[dbID] == 1 {
+				return errors.New("retry")
+			}
+			return nil
+		}, nil)
+	if len(failed) != 0 {
+		t.Fatalf("failed jobs = %v", failed)
+	}
+	if !slices.Equal(order, []int64{1, 2, 1}) {
+		t.Fatalf("provisioning order = %v, want failed job requeued behind ready work", order)
+	}
+}
+
+func TestManagedSharedDBMetadataWorkerRefillsReadySlots(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(pool.Close)
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	rows := make([]*meta.SharedDB, 0, 4)
+	for i := 0; i < 4; i++ {
+		dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+			TiDBCloudOrganizationID: "org-metadata-batch", ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+			PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := metaStore.UpdateManagedSharedDBPoolCloudResult(context.Background(), &meta.SharedDB{
+			ID: dbID, TiDBCloudOrganizationID: "org-metadata-batch", ClusterID: fmt.Sprintf("cluster-%d", dbID),
+			PasswordCipher: passwordCipher, Name: "tidbcloud_fs", TLSMode: "true",
+		}); err != nil {
+			t.Fatal(err)
+		}
+		row, err := metaStore.GetSharedDB(context.Background(), dbID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rows = append(rows, row)
+	}
+	call := 0
+	requestBatches := make([][]int64, 0, 3)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}
+	prov.sharedPoolBatchLoadFunc = func(requests []tenant.SharedDBPoolLoadRequest) ([]*tenant.SharedDBPoolInfo, error) {
+		call++
+		ids := make([]int64, 0, len(requests))
+		for _, request := range requests {
+			ids = append(ids, request.DBPoolID)
+		}
+		requestBatches = append(requestBatches, ids)
+		ready := requests
+		if call == 1 {
+			ready = requests[:1]
+		}
+		out := make([]*tenant.SharedDBPoolInfo, 0, len(ready))
+		for _, request := range ready {
+			out = append(out, &tenant.SharedDBPoolInfo{DBPoolID: request.DBPoolID, DBPoolUUID: request.DBPoolUUID,
+				ClusterID: request.ClusterID, Host: "10.4.48.2", Port: 4000,
+				Username: fmt.Sprintf("u%d.root", request.DBPoolID), DBName: "tidbcloud_fs"})
+		}
+		return out, nil
+	}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov,
+		managedSharedDBMetadataWorkers: 1, managedSharedDBMetadataBatchSize: 2,
+		managedSharedDBMetadataPollInterval: time.Millisecond, managedSharedDBMetadataSlots: make(chan struct{}, 1)}
+	readyIDs := make([]int64, 0, 4)
+	srv.pollManagedSharedDBMetadataWithReady(context.Background(), rows, func(ids []int64) {
+		readyIDs = append(readyIDs, ids...)
+	})
+	if len(requestBatches) != 3 || !slices.Equal(requestBatches[0], []int64{rows[0].ID, rows[1].ID}) ||
+		!slices.Equal(requestBatches[1], []int64{rows[1].ID, rows[2].ID}) ||
+		!slices.Equal(requestBatches[2], []int64{rows[3].ID}) {
+		t.Fatalf("metadata request batches = %v", requestBatches)
+	}
+	if len(readyIDs) != 4 {
+		t.Fatalf("ready IDs = %v, want all four", readyIDs)
+	}
+	if got := prov.iamCalls.Load(); got != 0 {
+		t.Fatalf("IAM calls = %d, want 0", got)
+	}
+	for _, row := range rows {
+		got, err := metaStore.GetSharedDB(context.Background(), row.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got.Status != meta.SharedDBStatusProvisioning {
+			t.Fatalf("db pool %d status = %q, want provisioning", row.ID, got.Status)
+		}
 	}
 }
 
@@ -823,113 +1028,11 @@ func TestManagedSharedDBContinuationPassesCustomerOrganizationToPhysicalCreate(t
 	}
 }
 
-func TestRetryManagedSharedDBContinuationRecoversAfterMoreThanTwoFailures(t *testing.T) {
-	origWindow, origInterval := schemaInitRetryWindow, managedSharedDBContinuationInterval
-	schemaInitRetryWindow = time.Second
-	managedSharedDBContinuationInterval = time.Millisecond
-	t.Cleanup(func() {
-		schemaInitRetryWindow = origWindow
-		managedSharedDBContinuationInterval = origInterval
-	})
-
-	attempts := 0
-	err := retryManagedSharedDBContinuation(context.Background(), func() error {
-		attempts++
-		if attempts <= 3 {
-			return errors.New("root authentication is not ready")
-		}
-		return nil
-	})
-	if err != nil {
-		t.Fatalf("retryManagedSharedDBContinuation error = %v", err)
-	}
-	if attempts != 4 {
-		t.Fatalf("attempts = %d, want 4", attempts)
-	}
-}
-
-func TestRetryManagedSharedDBContinuationsStartsEveryPoolConcurrently(t *testing.T) {
-	started := make(chan int, 3)
-	release := make(chan struct{})
-	states := make([]managedSharedDBContinuation, 3)
-	for i := range states {
-		poolIndex := i
-		states[i] = managedSharedDBContinuation{ctx: context.Background(), continuePool: func() error {
-			started <- poolIndex
-			<-release
-			return nil
-		}}
-	}
-	done := make(chan struct{})
-	go func() {
-		retryManagedSharedDBContinuations(context.Background(), states)
-		close(done)
-	}()
-
-	for i := 0; i < len(states); i++ {
-		select {
-		case <-started:
-		case <-time.After(500 * time.Millisecond):
-			close(release)
-			<-done
-			t.Fatalf("started %d/%d continuation attempts before release", i, len(states))
-		}
-	}
-	close(release)
-	<-done
-	for i := range states {
-		if !states[i].done || states[i].lastErr != nil {
-			t.Fatalf("continuation state %d = %#v, want complete", i, states[i])
-		}
-	}
-}
-
-func TestRetryManagedSharedDBContinuationsLimitsConcurrentPoolsToOneHundred(t *testing.T) {
-	started := make(chan struct{}, managedSharedDBContinuationLimit+1)
-	release := make(chan struct{})
-	states := make([]managedSharedDBContinuation, managedSharedDBContinuationLimit+1)
-	for i := range states {
-		states[i] = managedSharedDBContinuation{ctx: context.Background(), continuePool: func() error {
-			started <- struct{}{}
-			<-release
-			return nil
-		}}
-	}
-	done := make(chan struct{})
-	go func() {
-		retryManagedSharedDBContinuations(context.Background(), states)
-		close(done)
-	}()
-	for i := 0; i < managedSharedDBContinuationLimit; i++ {
-		select {
-		case <-started:
-		case <-time.After(500 * time.Millisecond):
-			close(release)
-			<-done
-			t.Fatalf("started %d/%d continuation attempts before release", i, managedSharedDBContinuationLimit)
-		}
-	}
-	select {
-	case <-started:
-		close(release)
-		<-done
-		t.Fatal("started a 101st continuation while 100 were still in flight")
-	case <-time.After(100 * time.Millisecond):
-	}
-	close(release)
-	<-done
-	if len(started) != 1 {
-		t.Fatalf("continuations started after release = %d, want 1", len(started))
-	}
-}
-
 func TestManagedSharedDBContinuationBatchesDoNotEnterBlockingMetadataWait(t *testing.T) {
-	origWindow, origInterval := schemaInitRetryWindow, managedSharedDBContinuationInterval
+	origWindow := schemaInitRetryWindow
 	schemaInitRetryWindow = 100 * time.Millisecond
-	managedSharedDBContinuationInterval = 5 * time.Millisecond
 	t.Cleanup(func() {
 		schemaInitRetryWindow = origWindow
-		managedSharedDBContinuationInterval = origInterval
 	})
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -1211,28 +1314,21 @@ func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, identityOrg: "org-parallel-batches",
 		sharedPoolBatchStarted: started, sharedPoolBatchRelease: release, sharedPoolBatchRequests: requests}
 	srv := &Server{meta: metaStore, pool: pool, provisioner: prov,
-		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour)}
+		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour), managedSharedDBCloudBatchSize: 10}
 	done := make(chan error, 1)
 	go func() {
 		_, batchErr := srv.provisionManagedSharedDBPoolsBatch(context.Background(), dbIDs)
 		done <- batchErr
 	}()
 
-	for i := 0; i < managedSharedDBCloudBatchConcurrency; i++ {
+	for i := 0; i < 11; i++ {
 		select {
 		case <-started:
 		case <-time.After(500 * time.Millisecond):
 			close(release)
 			<-done
-			t.Fatalf("started %d/%d Cloud batch requests before release", i, managedSharedDBCloudBatchConcurrency)
+			t.Fatalf("started %d/11 Cloud batch requests before release", i)
 		}
-	}
-	select {
-	case <-started:
-		close(release)
-		<-done
-		t.Fatal("started an eleventh Cloud batch while ten were still in flight")
-	case <-time.After(100 * time.Millisecond):
 	}
 	close(release)
 	if err := <-done; err != nil {
@@ -1390,6 +1486,39 @@ func (f *fakeProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context, dbP
 		}
 	}
 	return nil, nil
+}
+
+func (f *fakeProvisioner) BatchLoadSharedDBPoolsWithCredentials(_ context.Context, requests []tenant.SharedDBPoolLoadRequest, _ tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+	f.sharedPoolBatchLoadCalls.Add(1)
+	f.sharedPoolBatchLoadMembers.Add(int32(len(requests)))
+	copyRequests := append([]tenant.SharedDBPoolLoadRequest(nil), requests...)
+	if f.sharedPoolLoadIDs != nil {
+		for _, request := range copyRequests {
+			select {
+			case f.sharedPoolLoadIDs <- request.DBPoolID:
+			default:
+			}
+		}
+	}
+	if f.sharedPoolBatchLoadRequests != nil {
+		f.sharedPoolBatchLoadRequests <- copyRequests
+	}
+	if f.sharedPoolBatchLoadFunc != nil {
+		return f.sharedPoolBatchLoadFunc(copyRequests)
+	}
+	out := make([]*tenant.SharedDBPoolInfo, 0, len(requests))
+	for _, request := range requests {
+		for _, row := range f.sharedPoolResults {
+			if row != nil && row.ClusterID == request.ClusterID {
+				copyRow := *row
+				copyRow.DBPoolID = request.DBPoolID
+				copyRow.DBPoolUUID = request.DBPoolUUID
+				out = append(out, &copyRow)
+				break
+			}
+		}
+	}
+	return out, nil
 }
 
 func (f *fakeProvisioner) WaitForSharedDBPoolMetadataWithCredentials(ctx context.Context, dbPoolID int64, dbPoolUUID, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -269,6 +269,12 @@ func TestRunManagedSharedDBProvisioningQueueRequeuesWithoutBlockingWorker(t *tes
 	}
 }
 
+func TestManagedSharedDBProvisioningBackoffCapsAtFifteenSeconds(t *testing.T) {
+	if managedSharedDBProvisioningMaxBackoff != 15*time.Second {
+		t.Fatalf("shared provisioning max backoff = %s, want 15s", managedSharedDBProvisioningMaxBackoff)
+	}
+}
+
 func TestManagedSharedDBMetadataWorkerRefillsReadySlots(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -56,6 +57,7 @@ type fakeProvisioner struct {
 	defaultPrivateKey       string
 	defaultSharedPublicKey  string
 	defaultSharedPrivateKey string
+	sharedPoolMu            sync.Mutex
 	lastSharedCredentialReq tenant.CredentialProvisionRequest
 	iamCalls                atomic.Int32
 	iamMu                   sync.Mutex
@@ -252,7 +254,7 @@ func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsPending(t *test
 	if prov.sharedPoolBatchCalls.Load() != 1 {
 		t.Fatalf("shared pool batch calls = %d, want 1", prov.sharedPoolBatchCalls.Load())
 	}
-	if got := prov.lastSharedCredentialReq; got.PublicKey != "shared-public" || got.PrivateKey != "shared-private" {
+	if got := prov.lastSharedCredentialRequest(); got.PublicKey != "shared-public" || got.PrivateKey != "shared-private" {
 		t.Fatalf("shared physical credential = %+v, want configured shared credential", got)
 	}
 	requests := <-prov.sharedPoolBatchRequests
@@ -822,14 +824,12 @@ func TestManagedSharedDBContinuationPassesCustomerOrganizationToPhysicalCreate(t
 }
 
 func TestRetryManagedSharedDBContinuationRecoversAfterMoreThanTwoFailures(t *testing.T) {
-	origWindow, origInitialBackoff, origMaxBackoff := schemaInitRetryWindow, schemaInitInitialBackoff, schemaInitMaxBackoff
+	origWindow, origInterval := schemaInitRetryWindow, managedSharedDBContinuationInterval
 	schemaInitRetryWindow = time.Second
-	schemaInitInitialBackoff = time.Millisecond
-	schemaInitMaxBackoff = 2 * time.Millisecond
+	managedSharedDBContinuationInterval = time.Millisecond
 	t.Cleanup(func() {
 		schemaInitRetryWindow = origWindow
-		schemaInitInitialBackoff = origInitialBackoff
-		schemaInitMaxBackoff = origMaxBackoff
+		managedSharedDBContinuationInterval = origInterval
 	})
 
 	attempts := 0
@@ -848,51 +848,88 @@ func TestRetryManagedSharedDBContinuationRecoversAfterMoreThanTwoFailures(t *tes
 	}
 }
 
-func TestRetryManagedSharedDBContinuationsAvoidsHeadOfLineBlocking(t *testing.T) {
-	origWindow, origInitialBackoff, origMaxBackoff := schemaInitRetryWindow, schemaInitInitialBackoff, schemaInitMaxBackoff
-	schemaInitRetryWindow = time.Second
-	schemaInitInitialBackoff = time.Millisecond
-	schemaInitMaxBackoff = 2 * time.Millisecond
-	t.Cleanup(func() {
-		schemaInitRetryWindow = origWindow
-		schemaInitInitialBackoff = origInitialBackoff
-		schemaInitMaxBackoff = origMaxBackoff
-	})
+func TestRetryManagedSharedDBContinuationsStartsEveryPoolConcurrently(t *testing.T) {
+	started := make(chan int, 3)
+	release := make(chan struct{})
+	states := make([]managedSharedDBContinuation, 3)
+	for i := range states {
+		poolIndex := i
+		states[i] = managedSharedDBContinuation{ctx: context.Background(), continuePool: func() error {
+			started <- poolIndex
+			<-release
+			return nil
+		}}
+	}
+	done := make(chan struct{})
+	go func() {
+		retryManagedSharedDBContinuations(context.Background(), states)
+		close(done)
+	}()
 
-	var order []string
-	firstAttempts := 0
-	states := []managedSharedDBContinuation{
-		{ctx: context.Background(), continuePool: func() error {
-			order = append(order, "first")
-			firstAttempts++
-			if firstAttempts <= 3 {
-				return errors.New("first pool is not ready")
-			}
-			return nil
-		}},
-		{ctx: context.Background(), continuePool: func() error {
-			order = append(order, "second")
-			return nil
-		}},
+	for i := 0; i < len(states); i++ {
+		select {
+		case <-started:
+		case <-time.After(500 * time.Millisecond):
+			close(release)
+			<-done
+			t.Fatalf("started %d/%d continuation attempts before release", i, len(states))
+		}
 	}
-	retryManagedSharedDBContinuations(context.Background(), states)
-	if len(order) < 2 || order[0] != "first" || order[1] != "second" {
-		t.Fatalf("attempt order = %#v, want second pool attempted in the first round", order)
+	close(release)
+	<-done
+	for i := range states {
+		if !states[i].done || states[i].lastErr != nil {
+			t.Fatalf("continuation state %d = %#v, want complete", i, states[i])
+		}
 	}
-	if !states[0].done || states[0].lastErr != nil || !states[1].done || states[1].lastErr != nil {
-		t.Fatalf("continuation states = %#v, want both complete", states)
+}
+
+func TestRetryManagedSharedDBContinuationsLimitsConcurrentPoolsToOneHundred(t *testing.T) {
+	started := make(chan struct{}, managedSharedDBContinuationLimit+1)
+	release := make(chan struct{})
+	states := make([]managedSharedDBContinuation, managedSharedDBContinuationLimit+1)
+	for i := range states {
+		states[i] = managedSharedDBContinuation{ctx: context.Background(), continuePool: func() error {
+			started <- struct{}{}
+			<-release
+			return nil
+		}}
+	}
+	done := make(chan struct{})
+	go func() {
+		retryManagedSharedDBContinuations(context.Background(), states)
+		close(done)
+	}()
+	for i := 0; i < managedSharedDBContinuationLimit; i++ {
+		select {
+		case <-started:
+		case <-time.After(500 * time.Millisecond):
+			close(release)
+			<-done
+			t.Fatalf("started %d/%d continuation attempts before release", i, managedSharedDBContinuationLimit)
+		}
+	}
+	select {
+	case <-started:
+		close(release)
+		<-done
+		t.Fatal("started a 101st continuation while 100 were still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	<-done
+	if len(started) != 1 {
+		t.Fatalf("continuations started after release = %d, want 1", len(started))
 	}
 }
 
 func TestManagedSharedDBContinuationBatchesDoNotEnterBlockingMetadataWait(t *testing.T) {
-	origWindow, origInitialBackoff, origMaxBackoff := schemaInitRetryWindow, schemaInitInitialBackoff, schemaInitMaxBackoff
+	origWindow, origInterval := schemaInitRetryWindow, managedSharedDBContinuationInterval
 	schemaInitRetryWindow = 100 * time.Millisecond
-	schemaInitInitialBackoff = 5 * time.Millisecond
-	schemaInitMaxBackoff = 10 * time.Millisecond
+	managedSharedDBContinuationInterval = 5 * time.Millisecond
 	t.Cleanup(func() {
 		schemaInitRetryWindow = origWindow
-		schemaInitInitialBackoff = origInitialBackoff
-		schemaInitMaxBackoff = origMaxBackoff
+		managedSharedDBContinuationInterval = origInterval
 	})
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -957,22 +994,22 @@ func TestManagedSharedDBContinuationBatchesDoNotEnterBlockingMetadataWait(t *tes
 	})
 	srv.scheduleManagedSharedDBContinuations(context.Background(), []int64{firstID, secondID})
 
-	select {
-	case got := <-loadIDs:
-		if got != firstID {
-			t.Fatalf("first continuation = %d, want %d", got, firstID)
+	expectConcurrentIDs := func(ids <-chan int64, phase string) {
+		t.Helper()
+		seen := make(map[int64]bool, 2)
+		for i := 0; i < 2; i++ {
+			select {
+			case got := <-ids:
+				seen[got] = true
+			case <-time.After(time.Second):
+				t.Fatalf("%s continuation %d/2 was not attempted concurrently", phase, i+1)
+			}
 		}
-	case <-time.After(time.Second):
-		t.Fatal("first continuation was not attempted")
-	}
-	select {
-	case got := <-loadIDs:
-		if got != secondID {
-			t.Fatalf("second continuation = %d, want %d", got, secondID)
+		if !seen[firstID] || !seen[secondID] {
+			t.Fatalf("%s continuation IDs = %v, want %d and %d", phase, seen, firstID, secondID)
 		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("second continuation was blocked behind the first pool metadata waiter")
 	}
+	expectConcurrentIDs(loadIDs, "scheduled")
 	if got := prov.sharedPoolWaitCalls.Load(); got != 0 {
 		t.Fatalf("scheduled continuation metadata waiter calls = %d, want 0", got)
 	}
@@ -999,22 +1036,7 @@ func TestManagedSharedDBContinuationBatchesDoNotEnterBlockingMetadataWait(t *tes
 		defer close(resumeDone)
 		srv.resumePendingManagedSharedDBPoolsWithCtx(resumeCtx)
 	}()
-	select {
-	case got := <-resumeLoadIDs:
-		if got != firstID {
-			t.Fatalf("first resumed continuation = %d, want %d", got, firstID)
-		}
-	case <-time.After(time.Second):
-		t.Fatal("first resumed continuation was not attempted")
-	}
-	select {
-	case got := <-resumeLoadIDs:
-		if got != secondID {
-			t.Fatalf("second resumed continuation = %d, want %d", got, secondID)
-		}
-	case <-time.After(250 * time.Millisecond):
-		t.Fatal("second resumed continuation was blocked behind the first pool metadata waiter")
-	}
+	expectConcurrentIDs(resumeLoadIDs, "resumed")
 	cancelResume()
 	<-resumeDone
 }
@@ -1150,6 +1172,89 @@ func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	}
 }
 
+func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbIDs := make([]int64, 0, 101)
+	for i := 0; i < 101; i++ {
+		dbID, createErr := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+			TiDBCloudOrganizationID: "org-parallel-batches", ProvisioningKey: bytes.Repeat([]byte{3}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+			PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+		})
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		dbIDs = append(dbIDs, dbID)
+	}
+	started := make(chan struct{}, 11)
+	release := make(chan struct{})
+	requests := make(chan []tenant.SharedDBPoolCreateRequest, 11)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, identityOrg: "org-parallel-batches",
+		sharedPoolBatchStarted: started, sharedPoolBatchRelease: release, sharedPoolBatchRequests: requests}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov,
+		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour)}
+	done := make(chan error, 1)
+	go func() {
+		_, batchErr := srv.provisionManagedSharedDBPoolsBatch(context.Background(), dbIDs)
+		done <- batchErr
+	}()
+
+	for i := 0; i < managedSharedDBCloudBatchConcurrency; i++ {
+		select {
+		case <-started:
+		case <-time.After(500 * time.Millisecond):
+			close(release)
+			<-done
+			t.Fatalf("started %d/%d Cloud batch requests before release", i, managedSharedDBCloudBatchConcurrency)
+		}
+	}
+	select {
+	case <-started:
+		close(release)
+		<-done
+		t.Fatal("started an eleventh Cloud batch while ten were still in flight")
+	case <-time.After(100 * time.Millisecond):
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("batch create: %v", err)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 11 {
+		t.Fatalf("batch calls = %d, want 11", got)
+	}
+	if got := prov.sharedPoolBatchMembers.Load(); got != 101 {
+		t.Fatalf("batch members = %d, want 101", got)
+	}
+	sizes := make([]int, 0, 11)
+	for i := 0; i < 11; i++ {
+		sizes = append(sizes, len(<-requests))
+	}
+	slices.Sort(sizes)
+	wantSizes := []int{1, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10}
+	if !slices.Equal(sizes, wantSizes) {
+		t.Fatalf("batch sizes = %v, want %v", sizes, wantSizes)
+	}
+}
+
 func TestManagedSharedDBBatchCreateReturnsTotalFailure(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -1213,7 +1318,9 @@ func (f *fakeProvisioner) ListManagedClusters(_ context.Context, _ tenant.Creden
 }
 
 func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Context, requests []tenant.SharedDBPoolCreateRequest, cred tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+	f.sharedPoolMu.Lock()
 	f.lastSharedCredentialReq = cred
+	f.sharedPoolMu.Unlock()
 	if f.sharedPoolBatchRequests != nil {
 		f.sharedPoolBatchRequests <- append([]tenant.SharedDBPoolCreateRequest(nil), requests...)
 	}
@@ -1257,6 +1364,12 @@ func (f *fakeProvisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context
 		})
 	}
 	return out, nil
+}
+
+func (f *fakeProvisioner) lastSharedCredentialRequest() tenant.CredentialProvisionRequest {
+	f.sharedPoolMu.Lock()
+	defer f.sharedPoolMu.Unlock()
+	return f.lastSharedCredentialReq
 }
 
 func (f *fakeProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context, dbPoolID int64, dbPoolUUID, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -418,6 +418,52 @@ func TestManagedSharedDBMetadataWorkerRefillsReadySlots(t *testing.T) {
 	}
 }
 
+func TestManagedSharedDBMetadataRefillSlotSerializesAndRespectsContext(t *testing.T) {
+	slot := make(chan struct{}, 1)
+	firstStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		firstDone <- withManagedSharedDBMetadataRefillSlot(context.Background(), slot, func() {
+			close(firstStarted)
+			<-releaseFirst
+		})
+	}()
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first metadata refill did not acquire the slot")
+	}
+
+	waiterCtx, cancel := context.WithCancel(context.Background())
+	waiterDone := make(chan error, 1)
+	go func() {
+		waiterDone <- withManagedSharedDBMetadataRefillSlot(waiterCtx, slot, func() {
+			t.Error("cancelled metadata refill entered the critical section")
+		})
+	}()
+	cancel()
+	select {
+	case err := <-waiterDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("cancelled metadata refill error = %v, want context.Canceled", err)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Error("cancelled metadata refill remained blocked on the slot")
+	}
+
+	close(releaseFirst)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first metadata refill: %v", err)
+	}
+	select {
+	case slot <- struct{}{}:
+		<-slot
+	default:
+		t.Fatal("metadata refill slot was not released")
+	}
+}
+
 func TestProvisionTiDBCloudNativeSharedPlansManagedPoolAndReturnsPending(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -250,7 +250,7 @@ func TestRunManagedSharedDBProvisioningQueueRequeuesWithoutBlockingWorker(t *tes
 	order := make([]int64, 0, 3)
 	attempts := make(map[int64]int)
 	failed := runManagedSharedDBProvisioningQueue(context.Background(), 1, nil, []int64{1, 2},
-		time.Second, 20*time.Millisecond, 20*time.Millisecond,
+		time.Second, 20*time.Millisecond, 20*time.Millisecond, 0,
 		func(_ context.Context, dbID int64) error {
 			mu.Lock()
 			defer mu.Unlock()
@@ -272,6 +272,32 @@ func TestRunManagedSharedDBProvisioningQueueRequeuesWithoutBlockingWorker(t *tes
 func TestManagedSharedDBProvisioningBackoffCapsAtFifteenSeconds(t *testing.T) {
 	if managedSharedDBProvisioningMaxBackoff != 15*time.Second {
 		t.Fatalf("shared provisioning max backoff = %s, want 15s", managedSharedDBProvisioningMaxBackoff)
+	}
+	if managedSharedDBProvisioningCooldown != 10*time.Second {
+		t.Fatalf("shared provisioning worker cooldown = %s, want 10s", managedSharedDBProvisioningCooldown)
+	}
+}
+
+func TestManagedSharedDBProvisioningWorkerRestsBetweenJobs(t *testing.T) {
+	const cooldown = 25 * time.Millisecond
+	started := make([]time.Time, 0, 2)
+	var mu sync.Mutex
+	failed := runManagedSharedDBProvisioningQueue(context.Background(), 1, nil, []int64{1, 2},
+		time.Second, time.Millisecond, time.Millisecond, cooldown,
+		func(_ context.Context, _ int64) error {
+			mu.Lock()
+			started = append(started, time.Now())
+			mu.Unlock()
+			return nil
+		}, nil)
+	if len(failed) != 0 {
+		t.Fatalf("failed jobs = %v", failed)
+	}
+	if len(started) != 2 {
+		t.Fatalf("started jobs = %d, want 2", len(started))
+	}
+	if gap := started[1].Sub(started[0]); gap < cooldown {
+		t.Fatalf("worker started next job after %s, want at least %s", gap, cooldown)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -17,9 +17,13 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
 	"github.com/mem9-ai/drive9/internal/testmysql"
 	"github.com/mem9-ai/drive9/pkg/encrypt"
 	"github.com/mem9-ai/drive9/pkg/leader"
+	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	tenantschema "github.com/mem9-ai/drive9/pkg/tenant/schema"
@@ -211,6 +215,19 @@ func TestManagedSharedDBContinuationDoesNotStartOnFollower(t *testing.T) {
 	case <-called:
 		t.Fatal("follower ran managed shared DB continuation")
 	case <-time.After(20 * time.Millisecond):
+	}
+
+	core, observed := observer.New(zap.InfoLevel)
+	ctx := logger.WithContext(context.Background(), zap.New(core))
+	srv.scheduleManagedSharedDBContinuations(ctx, []int64{22, 11})
+	entries := observed.FilterMessage("managed_shared_db_continuation_deferred").All()
+	if len(entries) != 1 {
+		t.Fatalf("deferred continuation logs = %d, want 1", len(entries))
+	}
+	fields := entries[0].ContextMap()
+	if fields["reason"] != "not_leader" || fields["db_pool_count"] != int64(2) ||
+		fields["first_db_pool_id"] != int64(11) || fields["last_db_pool_id"] != int64(22) {
+		t.Fatalf("deferred continuation fields = %#v", fields)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -195,37 +195,6 @@ func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 	}
 }
 
-func TestRunManagedSharedDBProvisioningJobsHonorsWorkerLimit(t *testing.T) {
-	started := make(chan int64, 3)
-	release := make(chan struct{})
-	done := make(chan struct{})
-	go func() {
-		runManagedSharedDBProvisioningJobs(context.Background(), 2, nil, []int64{1, 2, 3}, func(_ context.Context, dbID int64) {
-			started <- dbID
-			<-release
-		})
-		close(done)
-	}()
-	for i := 0; i < 2; i++ {
-		select {
-		case <-started:
-		case <-time.After(time.Second):
-			t.Fatalf("started %d/2 provisioning workers", i)
-		}
-	}
-	select {
-	case <-started:
-		t.Fatal("started a third provisioning job while two workers were busy")
-	case <-time.After(50 * time.Millisecond):
-	}
-	close(release)
-	select {
-	case <-done:
-	case <-time.After(time.Second):
-		t.Fatal("provisioning jobs did not finish")
-	}
-}
-
 func TestManagedSharedDBContinuationDoesNotStartOnFollower(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -242,6 +211,58 @@ func TestManagedSharedDBContinuationDoesNotStartOnFollower(t *testing.T) {
 	case <-called:
 		t.Fatal("follower ran managed shared DB continuation")
 	case <-time.After(20 * time.Millisecond):
+	}
+}
+
+func TestManagedSharedDBResumeLoopDoesNotOverlapPasses(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	started := make(chan struct{}, 2)
+	release := make(chan struct{}, 2)
+	done := make(chan struct{})
+	var running atomic.Int32
+	var maxRunning atomic.Int32
+	go func() {
+		runManagedSharedDBResumeLoop(ctx, 10*time.Millisecond, func(context.Context) {
+			current := running.Add(1)
+			for {
+				observed := maxRunning.Load()
+				if current <= observed || maxRunning.CompareAndSwap(observed, current) {
+					break
+				}
+			}
+			started <- struct{}{}
+			<-release
+			running.Add(-1)
+		})
+		close(done)
+	}()
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("initial managed shared DB resume pass did not start")
+	}
+	time.Sleep(50 * time.Millisecond)
+	select {
+	case <-started:
+		t.Fatal("managed shared DB resume loop started an overlapping pass")
+	default:
+	}
+	release <- struct{}{}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("managed shared DB resume loop did not run after the first pass completed")
+	}
+	cancel()
+	release <- struct{}{}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("managed shared DB resume loop did not stop after cancellation")
+	}
+	if got := maxRunning.Load(); got != 1 {
+		t.Fatalf("maximum concurrent resume passes = %d, want 1", got)
 	}
 }
 
@@ -1307,6 +1328,115 @@ func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	}
 }
 
+func TestSharedDBAllocationLockWaitRespectsContextAndCleansUp(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	srv := &Server{meta: metaStore}
+
+	holderStarted := make(chan struct{})
+	releaseHolder := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- srv.withSharedDBAllocationLock(context.Background(), "org:cancel-lock", func(context.Context) error {
+			close(holderStarted)
+			<-releaseHolder
+			return nil
+		})
+	}()
+	select {
+	case <-holderStarted:
+	case <-time.After(time.Second):
+		t.Fatal("allocation lock holder did not start")
+	}
+
+	waiterCtx, cancel := context.WithCancel(context.Background())
+	waiterDone := make(chan error, 1)
+	go func() {
+		waiterDone <- srv.withSharedDBAllocationLock(waiterCtx, "org:cancel-lock", func(context.Context) error {
+			return errors.New("cancelled waiter entered critical section")
+		})
+	}()
+	cancel()
+	select {
+	case waitErr := <-waiterDone:
+		if !errors.Is(waitErr, context.Canceled) {
+			t.Errorf("cancelled waiter error = %v, want context.Canceled", waitErr)
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Error("cancelled waiter remained blocked on the local allocation lock")
+	}
+	close(releaseHolder)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("allocation lock holder: %v", err)
+	}
+	select {
+	case waitErr := <-waiterDone:
+		if !errors.Is(waitErr, context.Canceled) {
+			t.Errorf("eventual cancelled waiter error = %v, want context.Canceled", waitErr)
+		}
+	default:
+	}
+	entries := 0
+	srv.sharedDBAllocationLocks.Range(func(_, _ any) bool {
+		entries++
+		return true
+	})
+	if entries != 0 {
+		t.Fatalf("allocation lock entries after all users finished = %d, want 0", entries)
+	}
+}
+
+func TestEnsureManagedSharedDBPhysicalUsesPoolLockForKnownCluster(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-known-cluster", ProvisioningKey: bytes.Repeat([]byte{7}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+		PasswordCipher: []byte("cipher"), Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.UpdateManagedSharedDBPoolCloudResult(context.Background(), &meta.SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-known-cluster", ClusterID: "cluster-known",
+		Host: "db.example.com", Port: 4000, User: "prefix.root", PasswordCipher: []byte("cipher"), Name: "tidbcloud_fs", TLSMode: "true",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	srv := &Server{meta: metaStore, provisioner: &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}}
+	identity := fmt.Sprintf("org:org-known-cluster:db_pool:%d", dbID)
+	holderStarted := make(chan struct{})
+	releaseHolder := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- srv.withSharedDBAllocationLock(context.Background(), identity, func(context.Context) error {
+			close(holderStarted)
+			<-releaseHolder
+			return nil
+		})
+	}()
+	<-holderStarted
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	_, err = srv.ensureManagedSharedDBPhysical(ctx, dbID)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("known-cluster ensure error = %v, want context deadline while pool lock is held", err)
+	}
+	close(releaseHolder)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("pool lock holder: %v", err)
+	}
+}
+
 func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -1423,6 +1553,67 @@ func TestManagedSharedDBBatchCreateReturnsTotalFailure(t *testing.T) {
 	_, err = srv.provisionManagedSharedDBPoolsBatch(context.Background(), []int64{dbID})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("batch error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestManagedSharedDBBatchCreateRejectsUnsupportedProvisioner(t *testing.T) {
+	srv := &Server{provisioner: nonBranchOnlyProvisioner{}}
+	_, err := srv.provisionManagedSharedDBPoolsBatchWithCredentials(context.Background(), []int64{1}, tenant.CredentialProvisionRequest{})
+	if err == nil || !strings.Contains(err.Error(), "does not support managed shared db pools") {
+		t.Fatalf("batch create error = %v, want unsupported provisioner", err)
+	}
+}
+
+func TestManagedSharedDBBatchCreatePersistsResultsAfterInvalidEntry(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	rows := make(map[int64]*meta.SharedDB, 2)
+	requests := make([]tenant.SharedDBPoolCreateRequest, 0, 2)
+	for i := 0; i < 2; i++ {
+		dbID, createErr := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+			TiDBCloudOrganizationID: "org-partial-persist", ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+			PasswordCipher: []byte("cipher"), Name: "tidbcloud_fs",
+		})
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		row, loadErr := metaStore.GetSharedDB(context.Background(), dbID)
+		if loadErr != nil {
+			t.Fatal(loadErr)
+		}
+		rows[dbID] = row
+		requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID, DBPoolUUID: row.UUID})
+	}
+	partialErr := errors.New("partial cloud response")
+	second := rows[requests[1].DBPoolID]
+	prov := &fakeProvisioner{
+		provider: tenant.ProviderTiDBCloudNative,
+		sharedPoolResults: []*tenant.SharedDBPoolInfo{
+			{DBPoolID: 999999, DBPoolUUID: "unknown", ClusterID: "cluster-unknown"},
+			{DBPoolID: second.ID, DBPoolUUID: second.UUID, ClusterID: "cluster-persisted", Host: "db.example.com", Port: 4000, Username: "prefix.root", DBName: second.Name},
+		},
+		sharedPoolPartialErr: partialErr,
+	}
+	srv := &Server{meta: metaStore}
+	err = srv.provisionManagedSharedDBPoolsBatchChunkLocked(context.Background(), prov, requests, rows, tenant.CredentialProvisionRequest{})
+	if !errors.Is(err, partialErr) {
+		t.Fatalf("batch create error = %v, want partial cloud error", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "unknown db pool") {
+		t.Fatalf("batch create error = %v, want invalid result error", err)
+	}
+	persisted, err := metaStore.GetSharedDB(context.Background(), second.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted.ClusterID != "cluster-persisted" {
+		t.Fatalf("later cloud result cluster_id = %q, want cluster-persisted", persisted.ClusterID)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -168,21 +168,21 @@ func TestDefaultTenantProviderIsIndependentFromProvisionerType(t *testing.T) {
 func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 	defaults := NewWithConfig(Config{})
 	t.Cleanup(defaults.Close)
-	if defaults.managedSharedDBCloudBatchSize != 10 ||
+	if defaults.managedSharedDBCloudBatchSize != 10 || defaults.managedSharedDBRefillPoolLimit != 50 ||
 		defaults.managedSharedDBMetadataWorkers != 15 || defaults.managedSharedDBMetadataBatchSize != 30 ||
 		defaults.managedSharedDBMetadataPollInterval != 15*time.Second || defaults.managedSharedDBProvisioningWorkers != 100 {
-		t.Fatalf("managed shared defaults = cloud_batch(%d) metadata(%d,%d,%s) provisioning(%d)",
-			defaults.managedSharedDBCloudBatchSize,
+		t.Fatalf("managed shared defaults = cloud_batch(%d) refill_pool_limit(%d) metadata(%d,%d,%s) provisioning(%d)",
+			defaults.managedSharedDBCloudBatchSize, defaults.managedSharedDBRefillPoolLimit,
 			defaults.managedSharedDBMetadataWorkers, defaults.managedSharedDBMetadataBatchSize, defaults.managedSharedDBMetadataPollInterval,
 			defaults.managedSharedDBProvisioningWorkers)
 	}
 	overrides := NewWithConfig(Config{
-		ManagedSharedDBCloudBatchSize:  3,
+		ManagedSharedDBCloudBatchSize: 3, ManagedSharedDBRefillPoolLimit: 12,
 		ManagedSharedDBMetadataWorkers: 5, ManagedSharedDBMetadataBatchSize: 6, ManagedSharedDBMetadataPollInterval: 7 * time.Second,
 		ManagedSharedDBProvisioningWorkers: 8,
 	})
 	t.Cleanup(overrides.Close)
-	if overrides.managedSharedDBCloudBatchSize != 3 ||
+	if overrides.managedSharedDBCloudBatchSize != 3 || overrides.managedSharedDBRefillPoolLimit != 12 ||
 		overrides.managedSharedDBMetadataWorkers != 5 || overrides.managedSharedDBMetadataBatchSize != 6 ||
 		overrides.managedSharedDBMetadataPollInterval != 7*time.Second || overrides.managedSharedDBProvisioningWorkers != 8 {
 		t.Fatalf("managed shared overrides were not retained")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -237,6 +237,7 @@ type Server struct {
 	forkWorkerMu                        sync.Mutex
 	forkWorkerClosed                    bool
 	tenantPoolLocks                     sync.Map
+	tenantPoolReplenishJobs             sync.Map
 	tenantPoolCreateLocks               sync.Map
 	sharedDBAllocationLocks             sync.Map
 	tenantPoolResumeJobs                sync.Map

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -54,6 +54,13 @@ type Config struct {
 	SharedDBHardCapRatio  float64
 	SharedDBReopenRatio   float64
 	SharedDBSpendingLimit int64
+	// Managed shared-pool concurrency and polling controls. Zero values use
+	// the exported defaults below.
+	ManagedSharedDBCloudBatchSize       int
+	ManagedSharedDBMetadataWorkers      int
+	ManagedSharedDBMetadataBatchSize    int
+	ManagedSharedDBMetadataPollInterval time.Duration
+	ManagedSharedDBProvisioningWorkers  int
 	// LegacyStarterProvisioner is only used for delete/fork compatibility on
 	// persisted tidb_cloud_starter tenants. New starter provisioning remains
 	// disabled and NormalizeProvider does not accept tidb_cloud_starter.
@@ -181,50 +188,59 @@ func (s *Server) provisionerForTenantProvider(provider string) tenant.Provisione
 }
 
 type Server struct {
-	fallback                  *backend.Dat9Backend
-	meta                      *meta.Store
-	pool                      *tenant.Pool
-	provisioner               tenant.Provisioner
-	defaultTenantProvider     string
-	sharedDBMaxTenants        int
-	sharedDBHardCapRatio      float64
-	sharedDBReopenRatio       float64
-	sharedDBSpendingLimit     int64
-	legacyStarterProvisioner  tenant.Provisioner
-	tokenSecret               []byte
-	localTenantAPIKey         string
-	vaultMK                   *vault.MasterKey
-	vaultIssuerURL            string
-	publicURL                 string
-	maxUploadBytes            int64
-	tenantPoolMaxSize         int
-	tenantPoolRefillFreeRatio float64
-	inlineThreshold           int64
-	metrics                   *serverMetrics
-	logger                    *zap.Logger
-	mux                       *http.ServeMux
-	events                    *eventBuses
-	tenantWorker              *tenantWorkerManager
-	shardResolver             *semanticShardResolver
-	journalCursorSecret       []byte
-	objectGCWorker            *objectGCWorker
-	slockOAuth                SlockOAuthClient
-	tidbAutoEmbedding         tenantAutoEmbeddingDefault
-	disableDBAutoEmbed        bool
-	forkWorkerCtx             context.Context
-	forkWorkerCancel          context.CancelFunc
-	forkWorkerWG              sync.WaitGroup
-	forkWorkerMu              sync.Mutex
-	forkWorkerClosed          bool
-	tenantPoolLocks           sync.Map
-	tenantPoolCreateLocks     sync.Map
-	sharedDBAllocationLocks   sync.Map
-	tenantPoolResumeJobs      sync.Map
-	tenantFailedCleanupJobs   sync.Map
-	tenantFailedCleanupRunner tenantFailedCleanupRunner
-	tidbCloudRBACCache        *tidbCloudRBACCache
-	schemaInitErrors          sync.Map
-	leader                    *leader.Manager
+	fallback                            *backend.Dat9Backend
+	meta                                *meta.Store
+	pool                                *tenant.Pool
+	provisioner                         tenant.Provisioner
+	defaultTenantProvider               string
+	sharedDBMaxTenants                  int
+	sharedDBHardCapRatio                float64
+	sharedDBReopenRatio                 float64
+	sharedDBSpendingLimit               int64
+	managedSharedDBCloudBatchSize       int
+	managedSharedDBMetadataWorkers      int
+	managedSharedDBMetadataBatchSize    int
+	managedSharedDBMetadataPollInterval time.Duration
+	managedSharedDBProvisioningWorkers  int
+	managedSharedDBMetadataSlots        chan struct{}
+	managedSharedDBProvisioningSlots    chan struct{}
+	managedSharedDBMetadataJobs         sync.Map
+	managedSharedDBProvisioningJobs     sync.Map
+	legacyStarterProvisioner            tenant.Provisioner
+	tokenSecret                         []byte
+	localTenantAPIKey                   string
+	vaultMK                             *vault.MasterKey
+	vaultIssuerURL                      string
+	publicURL                           string
+	maxUploadBytes                      int64
+	tenantPoolMaxSize                   int
+	tenantPoolRefillFreeRatio           float64
+	inlineThreshold                     int64
+	metrics                             *serverMetrics
+	logger                              *zap.Logger
+	mux                                 *http.ServeMux
+	events                              *eventBuses
+	tenantWorker                        *tenantWorkerManager
+	shardResolver                       *semanticShardResolver
+	journalCursorSecret                 []byte
+	objectGCWorker                      *objectGCWorker
+	slockOAuth                          SlockOAuthClient
+	tidbAutoEmbedding                   tenantAutoEmbeddingDefault
+	disableDBAutoEmbed                  bool
+	forkWorkerCtx                       context.Context
+	forkWorkerCancel                    context.CancelFunc
+	forkWorkerWG                        sync.WaitGroup
+	forkWorkerMu                        sync.Mutex
+	forkWorkerClosed                    bool
+	tenantPoolLocks                     sync.Map
+	tenantPoolCreateLocks               sync.Map
+	sharedDBAllocationLocks             sync.Map
+	tenantPoolResumeJobs                sync.Map
+	tenantFailedCleanupJobs             sync.Map
+	tenantFailedCleanupRunner           tenantFailedCleanupRunner
+	tidbCloudRBACCache                  *tidbCloudRBACCache
+	schemaInitErrors                    sync.Map
+	leader                              *leader.Manager
 	// leaderWorkerCtx gates leader-only background schedulers. When leadership
 	// changes, this context is cancelled and recreated. Workers that use it
 	// (pending tenant reconciler, tenant delete cleanup, one-time resume tasks)
@@ -271,7 +287,6 @@ var (
 	schemaInitRetryWindow                     = 10 * time.Minute
 	schemaInitInitialBackoff                  = 2 * time.Second
 	schemaInitMaxBackoff                      = 30 * time.Second
-	managedSharedDBContinuationInterval       = 15 * time.Second
 	tenantPoolMetadataResumeWaitTimeout       = 10 * time.Minute
 	tenantPoolMetadataResumePersistTimeout    = 2 * time.Minute
 	tenantPoolMetadataResumeGroupSize         = 10
@@ -304,6 +319,14 @@ const DefaultSharedDBReopenRatio = 0.8
 // DefaultManagedSharedDBSpendingLimit is the physical spending-limit target
 // persisted for a new managed shared DB pool when no override is configured.
 const DefaultManagedSharedDBSpendingLimit = int64(1_000_000)
+
+const (
+	DefaultManagedSharedDBCloudBatchSize       = 10
+	DefaultManagedSharedDBMetadataWorkers      = 15
+	DefaultManagedSharedDBMetadataBatchSize    = 30
+	DefaultManagedSharedDBMetadataPollInterval = 15 * time.Second
+	DefaultManagedSharedDBProvisioningWorkers  = 100
+)
 
 // TenantStatusResponse is the JSON body of GET /v1/status. Fields are filled
 // per authenticated tenant so callers can discover their effective limits
@@ -383,35 +406,65 @@ func NewWithConfig(cfg Config) *Server {
 	if sharedDBSpendingLimit <= 0 {
 		sharedDBSpendingLimit = DefaultManagedSharedDBSpendingLimit
 	}
+	managedSharedDBCloudBatchSize := cfg.ManagedSharedDBCloudBatchSize
+	if managedSharedDBCloudBatchSize <= 0 {
+		managedSharedDBCloudBatchSize = DefaultManagedSharedDBCloudBatchSize
+	}
+	managedSharedDBCloudBatchSize = min(managedSharedDBCloudBatchSize, DefaultManagedSharedDBCloudBatchSize)
+	managedSharedDBMetadataWorkers := cfg.ManagedSharedDBMetadataWorkers
+	if managedSharedDBMetadataWorkers <= 0 {
+		managedSharedDBMetadataWorkers = DefaultManagedSharedDBMetadataWorkers
+	}
+	managedSharedDBMetadataWorkers = min(managedSharedDBMetadataWorkers, DefaultManagedSharedDBMetadataWorkers)
+	managedSharedDBMetadataBatchSize := cfg.ManagedSharedDBMetadataBatchSize
+	if managedSharedDBMetadataBatchSize <= 0 {
+		managedSharedDBMetadataBatchSize = DefaultManagedSharedDBMetadataBatchSize
+	}
+	managedSharedDBMetadataBatchSize = min(managedSharedDBMetadataBatchSize, DefaultManagedSharedDBMetadataBatchSize)
+	managedSharedDBMetadataPollInterval := cfg.ManagedSharedDBMetadataPollInterval
+	if managedSharedDBMetadataPollInterval <= 0 {
+		managedSharedDBMetadataPollInterval = DefaultManagedSharedDBMetadataPollInterval
+	}
+	managedSharedDBProvisioningWorkers := cfg.ManagedSharedDBProvisioningWorkers
+	if managedSharedDBProvisioningWorkers <= 0 {
+		managedSharedDBProvisioningWorkers = DefaultManagedSharedDBProvisioningWorkers
+	}
 	defaultTenantProvider := strings.TrimSpace(cfg.DefaultTenantProvider)
 	if defaultTenantProvider == "" && cfg.Provisioner != nil {
 		defaultTenantProvider = cfg.Provisioner.ProviderType()
 	}
 	forkWorkerCtx, forkWorkerCancel := context.WithCancel(context.Background())
 	s := &Server{
-		fallback:                  cfg.Backend,
-		meta:                      cfg.Meta,
-		pool:                      cfg.Pool,
-		tokenSecret:               cfg.TokenSecret,
-		localTenantAPIKey:         strings.TrimSpace(cfg.LocalTenantAPIKey),
-		vaultMK:                   vaultMK,
-		vaultIssuerURL:            strings.TrimSpace(cfg.VaultIssuerURL),
-		publicURL:                 strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
-		provisioner:               cfg.Provisioner,
-		defaultTenantProvider:     defaultTenantProvider,
-		sharedDBMaxTenants:        cfg.SharedDBMaxTenants,
-		sharedDBHardCapRatio:      sharedDBHardCapRatio,
-		sharedDBReopenRatio:       sharedDBReopenRatio,
-		sharedDBSpendingLimit:     sharedDBSpendingLimit,
-		legacyStarterProvisioner:  cfg.LegacyStarterProvisioner,
-		maxUploadBytes:            maxUpload,
-		tenantPoolMaxSize:         tenantPoolMaxSize,
-		tenantPoolRefillFreeRatio: tenantPoolRefillFreeRatio,
-		inlineThreshold:           inlineThreshold,
-		metrics:                   newServerMetrics(),
-		logger:                    logger,
-		events:                    newEventBuses(),
-		slockOAuth:                cfg.SlockOAuth,
+		fallback:                            cfg.Backend,
+		meta:                                cfg.Meta,
+		pool:                                cfg.Pool,
+		tokenSecret:                         cfg.TokenSecret,
+		localTenantAPIKey:                   strings.TrimSpace(cfg.LocalTenantAPIKey),
+		vaultMK:                             vaultMK,
+		vaultIssuerURL:                      strings.TrimSpace(cfg.VaultIssuerURL),
+		publicURL:                           strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
+		provisioner:                         cfg.Provisioner,
+		defaultTenantProvider:               defaultTenantProvider,
+		sharedDBMaxTenants:                  cfg.SharedDBMaxTenants,
+		sharedDBHardCapRatio:                sharedDBHardCapRatio,
+		sharedDBReopenRatio:                 sharedDBReopenRatio,
+		sharedDBSpendingLimit:               sharedDBSpendingLimit,
+		managedSharedDBCloudBatchSize:       managedSharedDBCloudBatchSize,
+		managedSharedDBMetadataWorkers:      managedSharedDBMetadataWorkers,
+		managedSharedDBMetadataBatchSize:    managedSharedDBMetadataBatchSize,
+		managedSharedDBMetadataPollInterval: managedSharedDBMetadataPollInterval,
+		managedSharedDBProvisioningWorkers:  managedSharedDBProvisioningWorkers,
+		managedSharedDBMetadataSlots:        make(chan struct{}, managedSharedDBMetadataWorkers),
+		managedSharedDBProvisioningSlots:    make(chan struct{}, managedSharedDBProvisioningWorkers),
+		legacyStarterProvisioner:            cfg.LegacyStarterProvisioner,
+		maxUploadBytes:                      maxUpload,
+		tenantPoolMaxSize:                   tenantPoolMaxSize,
+		tenantPoolRefillFreeRatio:           tenantPoolRefillFreeRatio,
+		inlineThreshold:                     inlineThreshold,
+		metrics:                             newServerMetrics(),
+		logger:                              logger,
+		events:                              newEventBuses(),
+		slockOAuth:                          cfg.SlockOAuth,
 		tidbAutoEmbedding: tenantAutoEmbeddingDefault{
 			config:  defaultTiDBAutoEmbeddingConfig(cfg.TiDBAutoEmbeddingConfig),
 			apiKey:  strings.TrimSpace(cfg.TiDBAutoEmbeddingAPIKey),
@@ -817,11 +870,53 @@ func (s *Server) startLeaderWorkers() {
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
 			s.resumeProvisioningTenantsWithCtx(workerCtx)
 		})
+		sharedPollInterval := s.managedSharedDBMetadataPollInterval
+		if sharedPollInterval <= 0 {
+			sharedPollInterval = DefaultManagedSharedDBMetadataPollInterval
+		}
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
-			s.resumePendingManagedSharedDBPoolsWithCtx(workerCtx)
+			ticker := time.NewTicker(sharedPollInterval)
+			defer ticker.Stop()
+			var wg sync.WaitGroup
+			defer wg.Wait()
+			run := func() {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					s.resumePendingManagedSharedDBPoolsWithCtx(workerCtx)
+				}()
+			}
+			run()
+			for {
+				select {
+				case <-workerCtx.Done():
+					return
+				case <-ticker.C:
+					run()
+				}
+			}
 		})
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
-			s.resumeProvisioningManagedSharedDBPoolsWithCtx(workerCtx)
+			ticker := time.NewTicker(sharedPollInterval)
+			defer ticker.Stop()
+			var wg sync.WaitGroup
+			defer wg.Wait()
+			run := func() {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					s.resumeProvisioningManagedSharedDBPoolsWithCtx(workerCtx)
+				}()
+			}
+			run()
+			for {
+				select {
+				case <-workerCtx.Done():
+					return
+				case <-ticker.C:
+					run()
+				}
+			}
 		})
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
 			s.resumeDeletingForkTenantsWithCtx(workerCtx)
@@ -851,8 +946,6 @@ func (s *Server) startLeaderWorkers() {
 						return
 					case <-ticker.C:
 						s.resumePendingTenantsWithCtx(workerCtx)
-						s.resumePendingManagedSharedDBPoolsWithCtx(workerCtx)
-						s.resumeProvisioningManagedSharedDBPoolsWithCtx(workerCtx)
 					}
 				}
 			})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -57,6 +57,7 @@ type Config struct {
 	// Managed shared-pool concurrency and polling controls. Zero values use
 	// the exported defaults below.
 	ManagedSharedDBCloudBatchSize       int
+	ManagedSharedDBRefillPoolLimit      int
 	ManagedSharedDBMetadataWorkers      int
 	ManagedSharedDBMetadataBatchSize    int
 	ManagedSharedDBMetadataPollInterval time.Duration
@@ -198,6 +199,7 @@ type Server struct {
 	sharedDBReopenRatio                 float64
 	sharedDBSpendingLimit               int64
 	managedSharedDBCloudBatchSize       int
+	managedSharedDBRefillPoolLimit      int
 	managedSharedDBMetadataWorkers      int
 	managedSharedDBMetadataBatchSize    int
 	managedSharedDBMetadataPollInterval time.Duration
@@ -322,6 +324,7 @@ const DefaultManagedSharedDBSpendingLimit = int64(1_000_000)
 
 const (
 	DefaultManagedSharedDBCloudBatchSize       = 10
+	DefaultManagedSharedDBRefillPoolLimit      = 50
 	DefaultManagedSharedDBMetadataWorkers      = 15
 	DefaultManagedSharedDBMetadataBatchSize    = 30
 	DefaultManagedSharedDBMetadataPollInterval = 15 * time.Second
@@ -411,6 +414,10 @@ func NewWithConfig(cfg Config) *Server {
 		managedSharedDBCloudBatchSize = DefaultManagedSharedDBCloudBatchSize
 	}
 	managedSharedDBCloudBatchSize = min(managedSharedDBCloudBatchSize, DefaultManagedSharedDBCloudBatchSize)
+	managedSharedDBRefillPoolLimit := cfg.ManagedSharedDBRefillPoolLimit
+	if managedSharedDBRefillPoolLimit <= 0 {
+		managedSharedDBRefillPoolLimit = DefaultManagedSharedDBRefillPoolLimit
+	}
 	managedSharedDBMetadataWorkers := cfg.ManagedSharedDBMetadataWorkers
 	if managedSharedDBMetadataWorkers <= 0 {
 		managedSharedDBMetadataWorkers = DefaultManagedSharedDBMetadataWorkers
@@ -450,6 +457,7 @@ func NewWithConfig(cfg Config) *Server {
 		sharedDBReopenRatio:                 sharedDBReopenRatio,
 		sharedDBSpendingLimit:               sharedDBSpendingLimit,
 		managedSharedDBCloudBatchSize:       managedSharedDBCloudBatchSize,
+		managedSharedDBRefillPoolLimit:      managedSharedDBRefillPoolLimit,
 		managedSharedDBMetadataWorkers:      managedSharedDBMetadataWorkers,
 		managedSharedDBMetadataBatchSize:    managedSharedDBMetadataBatchSize,
 		managedSharedDBMetadataPollInterval: managedSharedDBMetadataPollInterval,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -218,6 +218,7 @@ type Server struct {
 	forkWorkerClosed          bool
 	tenantPoolLocks           sync.Map
 	tenantPoolCreateLocks     sync.Map
+	sharedDBAllocationLocks   sync.Map
 	tenantPoolResumeJobs      sync.Map
 	tenantFailedCleanupJobs   sync.Map
 	tenantFailedCleanupRunner tenantFailedCleanupRunner
@@ -270,6 +271,7 @@ var (
 	schemaInitRetryWindow                     = 10 * time.Minute
 	schemaInitInitialBackoff                  = 2 * time.Second
 	schemaInitMaxBackoff                      = 30 * time.Second
+	managedSharedDBContinuationInterval       = 15 * time.Second
 	tenantPoolMetadataResumeWaitTimeout       = 10 * time.Minute
 	tenantPoolMetadataResumePersistTimeout    = 2 * time.Minute
 	tenantPoolMetadataResumeGroupSize         = 10
@@ -5171,7 +5173,7 @@ func (s *Server) provisionTenantOnManagedSharedDB(ctx context.Context, tenantID 
 	}
 	identity := sharedDBAllocationIdentity(current.TiDBCloudOrganizationID, current.ProvisioningKey)
 	var result *provisionTenantResult
-	err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+	err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
 		locked, loadErr := s.meta.GetSharedDB(lockCtx, current.ID)
 		if loadErr != nil {
 			return loadErr

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -241,6 +241,7 @@ type Server struct {
 	tenantPoolCreateLocks               sync.Map
 	sharedDBAllocationLocks             sync.Map
 	tenantPoolResumeJobs                sync.Map
+	tenantPoolResumeScans               sync.Map
 	tenantFailedCleanupJobs             sync.Map
 	tenantFailedCleanupRunner           tenantFailedCleanupRunner
 	tidbCloudRBACCache                  *tidbCloudRBACCache

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,7 +55,9 @@ type Config struct {
 	SharedDBReopenRatio   float64
 	SharedDBSpendingLimit int64
 	// Managed shared-pool concurrency and polling controls. Zero values use
-	// the exported defaults below.
+	// the exported defaults below. CloudBatchSize, MetadataWorkers, and
+	// MetadataBatchSize are safety-capped at their defaults; RefillPoolLimit
+	// and ProvisioningWorkers accept larger configured values.
 	ManagedSharedDBCloudBatchSize       int
 	ManagedSharedDBRefillPoolLimit      int
 	ManagedSharedDBMetadataWorkers      int
@@ -847,6 +849,20 @@ func (s *Server) Close() {
 	s.stopNotifyInfrastructure()
 }
 
+func runManagedSharedDBResumeLoop(ctx context.Context, interval time.Duration, resume func(context.Context)) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	resume(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			resume(ctx)
+		}
+	}
+}
+
 // startLeaderWorkers launches the background schedulers that should run only
 // on the leader pod: the fork-worker group (pending tenant reconciler, tenant
 // delete cleanup, one-time resume tasks), the semantic and object GC workers,
@@ -882,50 +898,13 @@ func (s *Server) startLeaderWorkers() {
 		if sharedPollInterval <= 0 {
 			sharedPollInterval = DefaultManagedSharedDBMetadataPollInterval
 		}
-		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
-			ticker := time.NewTicker(sharedPollInterval)
-			defer ticker.Stop()
-			var wg sync.WaitGroup
-			defer wg.Wait()
-			run := func() {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					s.resumePendingManagedSharedDBPoolsWithCtx(workerCtx)
-				}()
-			}
-			run()
-			for {
-				select {
-				case <-workerCtx.Done():
-					return
-				case <-ticker.C:
-					run()
-				}
-			}
-		})
-		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
-			ticker := time.NewTicker(sharedPollInterval)
-			defer ticker.Stop()
-			var wg sync.WaitGroup
-			defer wg.Wait()
-			run := func() {
-				wg.Add(1)
-				go func() {
-					defer wg.Done()
-					s.resumeProvisioningManagedSharedDBPoolsWithCtx(workerCtx)
-				}()
-			}
-			run()
-			for {
-				select {
-				case <-workerCtx.Done():
-					return
-				case <-ticker.C:
-					run()
-				}
-			}
-		})
+		startManagedSharedDBResumeLoop := func(resume func(context.Context)) {
+			s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+				runManagedSharedDBResumeLoop(workerCtx, sharedPollInterval, resume)
+			})
+		}
+		startManagedSharedDBResumeLoop(s.resumePendingManagedSharedDBPoolsWithCtx)
+		startManagedSharedDBResumeLoop(s.resumeProvisioningManagedSharedDBPoolsWithCtx)
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
 			s.resumeDeletingForkTenantsWithCtx(workerCtx)
 		})

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -23,6 +23,7 @@ const (
 	defaultSharedTenantSpendingLimit      = int64(1000)
 	sharedTenantActivationBatchSize       = 100
 	managedSharedDBProvisioningMaxBackoff = 15 * time.Second
+	managedSharedDBProvisioningCooldown   = 10 * time.Second
 )
 
 var errSharedDBConnectionMetadataNotReady = errors.New("shared DB pool connection metadata is not ready")
@@ -387,6 +388,7 @@ func (s *Server) runManagedSharedDBProvisioning(ctx context.Context, dbIDs []int
 	}
 	failed := runManagedSharedDBProvisioningQueue(ctx, workers, s.managedSharedDBProvisioningSlots, owned,
 		schemaInitRetryWindow, schemaInitInitialBackoff, managedSharedDBProvisioningMaxBackoff,
+		managedSharedDBProvisioningCooldown,
 		func(jobCtx context.Context, dbID int64) error {
 			err := s.continueManagedSharedDBPoolOnce(jobCtx, dbID)
 			if errors.Is(err, meta.ErrNotFound) {
@@ -419,7 +421,7 @@ func runManagedSharedDBProvisioningQueue(
 	workers int,
 	slots chan struct{},
 	dbIDs []int64,
-	retryWindow, initialBackoff, maxBackoff time.Duration,
+	retryWindow, initialBackoff, maxBackoff, workerCooldown time.Duration,
 	run func(context.Context, int64) error,
 	onRetry func(int64, int, time.Duration, error),
 ) map[int64]error {
@@ -440,6 +442,9 @@ func runManagedSharedDBProvisioningQueue(
 	jobs := make(chan *managedSharedDBProvisioningJob, len(dbIDs))
 	results := make(chan managedSharedDBProvisioningResult, workers)
 	retries := make(chan *managedSharedDBProvisioningJob, len(dbIDs))
+	done := make(chan struct{})
+	var stopOnce sync.Once
+	stopWorkers := func() { stopOnce.Do(func() { close(done) }) }
 	seen := make(map[int64]struct{}, len(dbIDs))
 	remaining := 0
 	for _, dbID := range dbIDs {
@@ -458,7 +463,28 @@ func runManagedSharedDBProvisioningQueue(
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for job := range jobs {
+			first := true
+			for {
+				if !first && workerCooldown > 0 {
+					timer := time.NewTimer(workerCooldown)
+					select {
+					case <-done:
+						timer.Stop()
+						return
+					case <-ctx.Done():
+						timer.Stop()
+						return
+					case <-timer.C:
+					}
+				}
+				var job *managedSharedDBProvisioningJob
+				select {
+				case <-done:
+					return
+				case <-ctx.Done():
+					return
+				case job = <-jobs:
+				}
 				if slots != nil {
 					select {
 					case slots <- struct{}{}:
@@ -475,20 +501,21 @@ func runManagedSharedDBProvisioningQueue(
 				case <-ctx.Done():
 					return
 				}
+				first = false
 			}
 		}()
 	}
 	for remaining > 0 {
 		select {
 		case <-ctx.Done():
-			close(jobs)
+			stopWorkers()
 			wg.Wait()
 			return failed
 		case job := <-retries:
 			select {
 			case jobs <- job:
 			case <-ctx.Done():
-				close(jobs)
+				stopWorkers()
 				wg.Wait()
 				return failed
 			}
@@ -513,17 +540,19 @@ func runManagedSharedDBProvisioningQueue(
 				timer := time.NewTimer(delay)
 				defer timer.Stop()
 				select {
+				case <-done:
 				case <-ctx.Done():
 				case <-timer.C:
 					select {
 					case retries <- job:
+					case <-done:
 					case <-ctx.Done():
 					}
 				}
 			}(job, retryIn)
 		}
 	}
-	close(jobs)
+	stopWorkers()
 	wg.Wait()
 	return failed
 }

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	defaultManagedSharedDBMaxTenants = 100
-	defaultSharedTenantSpendingLimit = int64(1000)
-	sharedTenantActivationBatchSize  = 100
+	defaultManagedSharedDBMaxTenants      = 100
+	defaultSharedTenantSpendingLimit      = int64(1000)
+	sharedTenantActivationBatchSize       = 100
+	managedSharedDBProvisioningMaxBackoff = 15 * time.Second
 )
 
 var errSharedDBConnectionMetadataNotReady = errors.New("shared DB pool connection metadata is not ready")
@@ -385,7 +386,7 @@ func (s *Server) runManagedSharedDBProvisioning(ctx context.Context, dbIDs []int
 		workers = DefaultManagedSharedDBProvisioningWorkers
 	}
 	failed := runManagedSharedDBProvisioningQueue(ctx, workers, s.managedSharedDBProvisioningSlots, owned,
-		schemaInitRetryWindow, schemaInitInitialBackoff, schemaInitMaxBackoff,
+		schemaInitRetryWindow, schemaInitInitialBackoff, managedSharedDBProvisioningMaxBackoff,
 		func(jobCtx context.Context, dbID int64) error {
 			err := s.continueManagedSharedDBPoolOnce(jobCtx, dbID)
 			if errors.Is(err, meta.ErrNotFound) {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -85,11 +85,54 @@ func sharedDBAllocationIdentity(organizationID string, provisioningKey []byte) s
 	return fmt.Sprintf("credential:%x", provisioningKey)
 }
 
+type sharedDBAllocationLocalLock struct {
+	mu        sync.Mutex
+	semaphore chan struct{}
+	refs      int
+}
+
+func (s *Server) acquireSharedDBAllocationLocalLock(ctx context.Context, identity string) (*sharedDBAllocationLocalLock, error) {
+	for {
+		candidate := &sharedDBAllocationLocalLock{semaphore: make(chan struct{}, 1)}
+		value, _ := s.sharedDBAllocationLocks.LoadOrStore(identity, candidate)
+		localLock := value.(*sharedDBAllocationLocalLock)
+		localLock.mu.Lock()
+		current, loaded := s.sharedDBAllocationLocks.Load(identity)
+		if !loaded || current != localLock {
+			localLock.mu.Unlock()
+			continue
+		}
+		localLock.refs++
+		localLock.mu.Unlock()
+
+		select {
+		case localLock.semaphore <- struct{}{}:
+			return localLock, nil
+		case <-ctx.Done():
+			s.releaseSharedDBAllocationLocalLock(identity, localLock, false)
+			return nil, ctx.Err()
+		}
+	}
+}
+
+func (s *Server) releaseSharedDBAllocationLocalLock(identity string, localLock *sharedDBAllocationLocalLock, held bool) {
+	if held {
+		<-localLock.semaphore
+	}
+	localLock.mu.Lock()
+	localLock.refs--
+	if localLock.refs == 0 {
+		s.sharedDBAllocationLocks.CompareAndDelete(identity, localLock)
+	}
+	localLock.mu.Unlock()
+}
+
 func (s *Server) withSharedDBAllocationLock(ctx context.Context, identity string, fn func(context.Context) error) error {
-	value, _ := s.sharedDBAllocationLocks.LoadOrStore(identity, &sync.Mutex{})
-	localLock := value.(*sync.Mutex)
-	localLock.Lock()
-	defer localLock.Unlock()
+	localLock, err := s.acquireSharedDBAllocationLocalLock(ctx, identity)
+	if err != nil {
+		return err
+	}
+	defer s.releaseSharedDBAllocationLocalLock(identity, localLock, true)
 	return s.meta.WithSharedDBAllocationLock(ctx, identity, fn)
 }
 
@@ -557,44 +600,6 @@ func runManagedSharedDBProvisioningQueue(
 	return failed
 }
 
-func runManagedSharedDBProvisioningJobs(ctx context.Context, workers int, slots chan struct{}, dbIDs []int64, run func(context.Context, int64)) {
-	if workers <= 0 || len(dbIDs) == 0 {
-		return
-	}
-	jobs := make(chan int64)
-	var wg sync.WaitGroup
-	for range min(workers, len(dbIDs)) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for dbID := range jobs {
-				if slots != nil {
-					select {
-					case slots <- struct{}{}:
-					case <-ctx.Done():
-						return
-					}
-				}
-				run(ctx, dbID)
-				if slots != nil {
-					<-slots
-				}
-			}
-		}()
-	}
-	for _, dbID := range dbIDs {
-		select {
-		case jobs <- dbID:
-		case <-ctx.Done():
-			close(jobs)
-			wg.Wait()
-			return
-		}
-	}
-	close(jobs)
-	wg.Wait()
-}
-
 func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows []*meta.SharedDB, onReady func([]int64)) {
 	owned := make([]*meta.SharedDB, 0, len(rows))
 	for _, row := range rows {
@@ -945,6 +950,9 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) 
 			return nil, err
 		}
 		identity := sharedDBAllocationIdentity(poolInfo.TiDBCloudOrganizationID, poolInfo.ProvisioningKey)
+		if strings.TrimSpace(poolInfo.ClusterID) != "" {
+			identity = fmt.Sprintf("%s:db_pool:%d", identity, poolInfo.ID)
+		}
 		var result *meta.SharedDB
 		restartWithOrganization := false
 		err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -600,6 +600,17 @@ func runManagedSharedDBProvisioningQueue(
 	return failed
 }
 
+func withManagedSharedDBMetadataRefillSlot(ctx context.Context, slot chan struct{}, refill func()) error {
+	select {
+	case slot <- struct{}{}:
+		defer func() { <-slot }()
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	refill()
+	return nil
+}
+
 func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows []*meta.SharedDB, onReady func([]int64)) {
 	owned := make([]*meta.SharedDB, 0, len(rows))
 	for _, row := range rows {
@@ -646,14 +657,44 @@ func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows 
 		known[row.ID] = struct{}{}
 	}
 	var queueMu sync.Mutex
+	refillSlot := make(chan struct{}, 1)
+	takeLocked := func(limit int) []*meta.SharedDB {
+		limit = min(limit, len(queue))
+		out := append([]*meta.SharedDB(nil), queue[:limit]...)
+		queue = queue[limit:]
+		return out
+	}
 	take := func(limit int) []*meta.SharedDB {
+		if limit <= 0 {
+			return nil
+		}
 		queueMu.Lock()
-		defer queueMu.Unlock()
-		if len(queue) < limit {
+		if len(queue) >= limit {
+			out := takeLocked(limit)
+			queueMu.Unlock()
+			return out
+		}
+		queueMu.Unlock()
+
+		var out []*meta.SharedDB
+		if err := withManagedSharedDBMetadataRefillSlot(ctx, refillSlot, func() {
+			// Another worker may have refilled the queue while this worker was
+			// waiting for the single refill slot.
+			queueMu.Lock()
+			if len(queue) >= limit {
+				out = takeLocked(limit)
+				queueMu.Unlock()
+				return
+			}
+			queueMu.Unlock()
+
 			fresh, listErr := s.meta.ListSharedDBsByStatus(ctx, meta.SharedDBStatusPending, 1000)
 			if listErr != nil {
 				logger.Warn(ctx, "managed_shared_db_pool_metadata_refill_failed", zap.Error(listErr))
-			} else {
+			}
+			queueMu.Lock()
+			defer queueMu.Unlock()
+			if listErr == nil {
 				for _, row := range fresh {
 					if strings.TrimSpace(row.ClusterID) == "" {
 						continue
@@ -669,10 +710,10 @@ func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows 
 					queue = append(queue, row)
 				}
 			}
+			out = takeLocked(limit)
+		}); err != nil {
+			return nil
 		}
-		limit = min(limit, len(queue))
-		out := append([]*meta.SharedDB(nil), queue[:limit]...)
-		queue = queue[limit:]
 		return out
 	}
 	workerCount := min(workers, (len(owned)+batchSize-1)/batchSize)

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
@@ -21,6 +22,7 @@ const (
 	defaultManagedSharedDBMaxTenants = 100
 	defaultSharedTenantSpendingLimit = int64(1000)
 	sharedTenantActivationBatchSize  = 100
+	managedSharedDBContinuationLimit = 100
 )
 
 var errSharedDBConnectionMetadataNotReady = errors.New("shared DB pool connection metadata is not ready")
@@ -80,6 +82,14 @@ func sharedDBAllocationIdentity(organizationID string, provisioningKey []byte) s
 		return "org:" + organizationID
 	}
 	return fmt.Sprintf("credential:%x", provisioningKey)
+}
+
+func (s *Server) withSharedDBAllocationLock(ctx context.Context, identity string, fn func(context.Context) error) error {
+	value, _ := s.sharedDBAllocationLocks.LoadOrStore(identity, &sync.Mutex{})
+	localLock := value.(*sync.Mutex)
+	localLock.Lock()
+	defer localLock.Unlock()
+	return s.meta.WithSharedDBAllocationLock(ctx, identity, fn)
 }
 
 func managedSharedDBDSN(info *meta.SharedDB, password string) string {
@@ -163,9 +173,35 @@ func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.Creden
 	if resolveErr != nil {
 		return nil, false, fmt.Errorf("resolve tidbcloud organization: %w", resolveErr)
 	}
+	return s.allocateManagedSharedDBForOrganization(ctx, organizationID, cred, reserve)
+}
+
+func (s *Server) allocateManagedSharedDBForOrganization(ctx context.Context, organizationID string, cred tenant.CredentialProvisionRequest, reserve func(*meta.SharedDB) error) (sharedDB *meta.SharedDB, created bool, err error) {
+	// Capacity reservation is transactional in CompleteSharedTenant* and does
+	// not need the organization-wide planning lock. This fast path lets tenant
+	// pool refill consume existing capacity concurrently; the lock below is
+	// reserved for planning a new physical pool.
+	if reserve != nil {
+		for attempt := 0; attempt < 2; attempt++ {
+			candidate, findErr := s.meta.FindSharedDBForAllocation(ctx, organizationID)
+			if errors.Is(findErr, meta.ErrNotFound) {
+				break
+			}
+			if findErr != nil {
+				return nil, false, findErr
+			}
+			reserveErr := reserve(candidate)
+			if reserveErr == nil {
+				return candidate, false, nil
+			}
+			if !errors.Is(reserveErr, meta.ErrSharedDBCapacityExhausted) {
+				return nil, false, reserveErr
+			}
+		}
+	}
 	provisioningKey := sharedDBProvisioningKey(cred)
 	identity := sharedDBAllocationIdentity(organizationID, provisioningKey)
-	err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+	err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
 		for attempt := 0; attempt < 2; attempt++ {
 			candidate, findErr := s.meta.FindSharedDBForAllocation(lockCtx, organizationID)
 			if findErr == nil {
@@ -242,11 +278,8 @@ func (s *Server) scheduleManagedSharedDBContinuation(ctx context.Context, dbID i
 }
 
 // scheduleManagedSharedDBContinuations retries one request batch in rounds.
-// Each pool gets one non-blocking continuation attempt per round; metadata
-// readiness is polled by the outer backoff so one pool cannot hold the batch in
-// the provider's long waiter. Starting one goroutine per DB pool would let all
-// waiters pin dedicated meta *sql.Conn values and can exhaust the connection
-// pool before the lock holder finishes.
+// Each pool gets one concurrent, non-blocking continuation attempt per round;
+// metadata readiness is polled every 15 seconds with bounded concurrency.
 func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs []int64) {
 	if len(dbIDs) == 0 {
 		return
@@ -306,20 +339,42 @@ func retryManagedSharedDBContinuation(ctx context.Context, continuePool func() e
 
 func retryManagedSharedDBContinuations(ctx context.Context, states []managedSharedDBContinuation) {
 	deadline := time.Now().Add(schemaInitRetryWindow)
-	backoff := schemaInitInitialBackoff
 	attempt := 1
 	for {
+		pendingIndexes := make([]int, 0, len(states))
+		for i := range states {
+			if !states[i].done {
+				pendingIndexes = append(pendingIndexes, i)
+			}
+		}
+		var wg sync.WaitGroup
+		jobs := make(chan int)
+		for range min(len(pendingIndexes), managedSharedDBContinuationLimit) {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for i := range jobs {
+					if err := ctx.Err(); err != nil {
+						states[i].lastErr = err
+						continue
+					}
+					if err := states[i].continuePool(); err == nil {
+						states[i].done = true
+						states[i].lastErr = nil
+					} else {
+						states[i].lastErr = err
+					}
+				}
+			}()
+		}
+		for _, i := range pendingIndexes {
+			jobs <- i
+		}
+		close(jobs)
+		wg.Wait()
 		pending := 0
 		for i := range states {
-			if states[i].done {
-				continue
-			}
-			if err := states[i].continuePool(); err == nil {
-				states[i].done = true
-				states[i].lastErr = nil
-				continue
-			} else {
-				states[i].lastErr = err
+			if !states[i].done {
 				pending++
 			}
 		}
@@ -330,7 +385,7 @@ func retryManagedSharedDBContinuations(ctx context.Context, states []managedShar
 		if remaining <= 0 {
 			return
 		}
-		retryIn := min(backoff, remaining)
+		retryIn := min(managedSharedDBContinuationInterval, remaining)
 		for i := range states {
 			if states[i].done || states[i].lastErr == nil {
 				continue
@@ -352,9 +407,6 @@ func retryManagedSharedDBContinuations(ctx context.Context, states []managedShar
 			}
 			return
 		case <-timer.C:
-		}
-		if backoff < schemaInitMaxBackoff {
-			backoff = min(backoff*2, schemaInitMaxBackoff)
 		}
 		attempt++
 	}
@@ -428,8 +480,11 @@ func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64
 			return err
 		}
 		identity := sharedDBAllocationIdentity(poolInfo.TiDBCloudOrganizationID, poolInfo.ProvisioningKey)
+		if strings.TrimSpace(poolInfo.ClusterID) != "" {
+			identity = fmt.Sprintf("%s:db_pool:%d", identity, poolInfo.ID)
+		}
 		restartWithOrganization := false
-		err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+		err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
 			current, loadErr := s.meta.GetSharedDB(lockCtx, dbID)
 			if loadErr != nil {
 				return loadErr
@@ -558,7 +613,7 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) 
 		identity := sharedDBAllocationIdentity(poolInfo.TiDBCloudOrganizationID, poolInfo.ProvisioningKey)
 		var result *meta.SharedDB
 		restartWithOrganization := false
-		err = s.meta.WithSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+		err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
 			current, loadErr := s.meta.GetSharedDB(lockCtx, dbID)
 			if loadErr != nil {
 				return loadErr
@@ -581,12 +636,11 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) 
 	return nil, fmt.Errorf("db pool %d allocation identity kept changing", dbID)
 }
 
-// continueManagedSharedDBPoolLocked intentionally keeps the organization
-// allocation lock through physical ensure, schema ensure, and activation.
-// Continuations are dispatched sequentially and are not a
-// request-QPS path; the wider lock preserves the existing single-owner Cloud
-// mutation model and prevents another allocator from observing half-ready
-// connection metadata. The readiness poll is the one long wait kept outside.
+// continueManagedSharedDBPoolLocked keeps one durable allocation lock through
+// physical ensure, schema ensure, and activation. Pools with a known cluster
+// ID use a per-pool lock so metadata and schema work can advance concurrently;
+// pools without a cluster ID retain the organization lock to prevent duplicate
+// physical creation.
 func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo *meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
 	dbID := poolInfo.ID
 	var err error

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -327,9 +327,20 @@ func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs
 	}
 	ids := append([]int64(nil), dbIDs...)
 	slices.Sort(ids)
-	s.startManagedSharedDBWorker(ctx, func(workerCtx context.Context) {
+	if s.startManagedSharedDBWorker(ctx, func(workerCtx context.Context) {
 		s.runManagedSharedDBContinuations(workerCtx, ids)
-	})
+	}) {
+		return
+	}
+	reason := "server_stopping"
+	if s.leader != nil {
+		reason = "not_leader"
+	}
+	logger.Info(ctx, "managed_shared_db_continuation_deferred",
+		zap.String("reason", reason),
+		zap.Int("db_pool_count", len(ids)),
+		zap.Int64("first_db_pool_id", ids[0]),
+		zap.Int64("last_db_pool_id", ids[len(ids)-1]))
 }
 
 func (s *Server) startManagedSharedDBWorker(ctx context.Context, fn func(context.Context)) bool {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -22,7 +22,6 @@ const (
 	defaultManagedSharedDBMaxTenants = 100
 	defaultSharedTenantSpendingLimit = int64(1000)
 	sharedTenantActivationBatchSize  = 100
-	managedSharedDBContinuationLimit = 100
 )
 
 var errSharedDBConnectionMetadataNotReady = errors.New("shared DB pool connection metadata is not ready")
@@ -277,168 +276,473 @@ func (s *Server) scheduleManagedSharedDBContinuation(ctx context.Context, dbID i
 	s.scheduleManagedSharedDBContinuations(ctx, []int64{dbID})
 }
 
-// scheduleManagedSharedDBContinuations retries one request batch in rounds.
-// Each pool gets one concurrent, non-blocking continuation attempt per round;
-// metadata readiness is polled every 15 seconds with bounded concurrency.
 func (s *Server) scheduleManagedSharedDBContinuations(ctx context.Context, dbIDs []int64) {
 	if len(dbIDs) == 0 {
 		return
 	}
 	ids := append([]int64(nil), dbIDs...)
 	slices.Sort(ids)
-	s.startServerWorker(ctx, func(workerCtx context.Context) {
-		states := make([]managedSharedDBContinuation, 0, len(ids))
-		for _, dbID := range ids {
-			if workerCtx.Err() != nil {
-				return
-			}
-			states = append(states, s.managedSharedDBContinuation(workerCtx, dbID))
-		}
-		retryManagedSharedDBContinuations(workerCtx, states)
-		for i := range states {
-			if !states[i].done && states[i].lastErr != nil && states[i].ctx.Err() == nil {
-				logger.Warn(states[i].ctx, "managed_shared_db_pool_continue_failed", zap.Error(states[i].lastErr))
-			}
-		}
+	s.startManagedSharedDBWorker(ctx, func(workerCtx context.Context) {
+		s.runManagedSharedDBContinuations(workerCtx, ids)
 	})
 }
 
-type managedSharedDBContinuation struct {
-	ctx          context.Context
-	continuePool func() error
-	done         bool
-	lastErr      error
-}
-
-func (s *Server) managedSharedDBContinuation(ctx context.Context, dbID int64) managedSharedDBContinuation {
-	poolCtx := ctx
-	if poolInfo, err := s.meta.GetSharedDB(ctx, dbID); err == nil {
-		poolCtx = logger.WithContext(ctx, logger.FromContext(ctx).With(
-			zap.Int64("db_pool_id", poolInfo.ID),
-			zap.String("db_pool_uuid", poolInfo.UUID),
-			zap.String("tidbcloud_org_id", poolInfo.TiDBCloudOrganizationID),
-		))
+func (s *Server) startManagedSharedDBWorker(ctx context.Context, fn func(context.Context)) bool {
+	if s.leader == nil {
+		return s.startServerWorker(ctx, fn)
 	}
-	return managedSharedDBContinuation{ctx: poolCtx, continuePool: func() error {
-		poolInfo, err := s.meta.GetSharedDB(poolCtx, dbID)
+	s.leaderWorkerMu.Lock()
+	if !s.leaderWorkersStarted || !s.leader.IsLeader() || s.leaderWorkerCtx == nil {
+		s.leaderWorkerMu.Unlock()
+		return false
+	}
+	workerCtx := contextWithTrace(s.leaderWorkerCtx, ctx)
+	s.leaderWorkerWG.Add(1)
+	s.leaderWorkerMu.Unlock()
+	go func() {
+		defer s.leaderWorkerWG.Done()
+		fn(workerCtx)
+	}()
+	return true
+}
+
+func (s *Server) runManagedSharedDBContinuations(ctx context.Context, dbIDs []int64) {
+	pendingWithoutCluster := make([]int64, 0, len(dbIDs))
+	for _, dbID := range dbIDs {
+		row, err := s.meta.GetSharedDB(ctx, dbID)
 		if err != nil {
-			return err
+			logger.Warn(ctx, "managed_shared_db_pool_continue_load_failed", zap.Int64("db_pool_id", dbID), zap.Error(err))
+			continue
 		}
-		if poolInfo.Status != meta.SharedDBStatusPending && poolInfo.Status != meta.SharedDBStatusProvisioning {
-			return nil
+		if row.Status == meta.SharedDBStatusPending && strings.TrimSpace(row.ClusterID) == "" {
+			pendingWithoutCluster = append(pendingWithoutCluster, dbID)
 		}
-		return s.continueManagedSharedDBPoolOnce(poolCtx, dbID)
-	}}
-}
+	}
+	if len(pendingWithoutCluster) > 0 {
+		cred, err := s.sharedDBCloudCredentials()
+		if err != nil {
+			logger.Warn(ctx, "managed_shared_db_pool_create_credentials_failed", zap.Error(err))
+		} else if _, err := s.provisionManagedSharedDBPoolsBatchWithCredentials(ctx, pendingWithoutCluster, cred); err != nil {
+			logger.Warn(ctx, "managed_shared_db_pool_batch_create_failed", zap.Int("db_pool_count", len(pendingWithoutCluster)), zap.Error(err))
+		}
+	}
 
-func retryManagedSharedDBContinuation(ctx context.Context, continuePool func() error) error {
-	states := []managedSharedDBContinuation{{ctx: ctx, continuePool: continuePool}}
-	retryManagedSharedDBContinuations(ctx, states)
-	return states[0].lastErr
-}
-
-func retryManagedSharedDBContinuations(ctx context.Context, states []managedSharedDBContinuation) {
-	deadline := time.Now().Add(schemaInitRetryWindow)
-	attempt := 1
-	for {
-		pendingIndexes := make([]int, 0, len(states))
-		for i := range states {
-			if !states[i].done {
-				pendingIndexes = append(pendingIndexes, i)
+	pending := make([]*meta.SharedDB, 0, len(dbIDs))
+	provisioning := make([]int64, 0, len(dbIDs))
+	for _, dbID := range dbIDs {
+		row, err := s.meta.GetSharedDB(ctx, dbID)
+		if err != nil {
+			continue
+		}
+		switch row.Status {
+		case meta.SharedDBStatusPending:
+			if strings.TrimSpace(row.ClusterID) != "" {
+				pending = append(pending, row)
 			}
+		case meta.SharedDBStatusProvisioning:
+			provisioning = append(provisioning, row.ID)
 		}
-		var wg sync.WaitGroup
-		jobs := make(chan int)
-		for range min(len(pendingIndexes), managedSharedDBContinuationLimit) {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for i := range jobs {
-					if err := ctx.Err(); err != nil {
-						states[i].lastErr = err
-						continue
-					}
-					if err := states[i].continuePool(); err == nil {
-						states[i].done = true
-						states[i].lastErr = nil
-					} else {
-						states[i].lastErr = err
+	}
+	var provisioningWG sync.WaitGroup
+	startProvisioning := func(ids []int64) {
+		if len(ids) == 0 {
+			return
+		}
+		ids = append([]int64(nil), ids...)
+		provisioningWG.Add(1)
+		go func() {
+			defer provisioningWG.Done()
+			s.runManagedSharedDBProvisioning(ctx, ids)
+		}()
+	}
+	startProvisioning(provisioning)
+	if len(pending) > 0 {
+		s.pollManagedSharedDBMetadataWithReady(ctx, pending, startProvisioning)
+	}
+	provisioningWG.Wait()
+}
+
+func (s *Server) runManagedSharedDBProvisioning(ctx context.Context, dbIDs []int64) {
+	owned := make([]int64, 0, len(dbIDs))
+	for _, dbID := range dbIDs {
+		if dbID <= 0 {
+			continue
+		}
+		if _, loaded := s.managedSharedDBProvisioningJobs.LoadOrStore(dbID, struct{}{}); !loaded {
+			owned = append(owned, dbID)
+		}
+	}
+	if len(owned) == 0 {
+		return
+	}
+	defer func() {
+		for _, dbID := range owned {
+			s.managedSharedDBProvisioningJobs.Delete(dbID)
+		}
+	}()
+	workers := s.managedSharedDBProvisioningWorkers
+	if workers <= 0 {
+		workers = DefaultManagedSharedDBProvisioningWorkers
+	}
+	failed := runManagedSharedDBProvisioningQueue(ctx, workers, s.managedSharedDBProvisioningSlots, owned,
+		schemaInitRetryWindow, schemaInitInitialBackoff, schemaInitMaxBackoff,
+		func(jobCtx context.Context, dbID int64) error {
+			err := s.continueManagedSharedDBPoolOnce(jobCtx, dbID)
+			if errors.Is(err, meta.ErrNotFound) {
+				return nil
+			}
+			return err
+		}, func(dbID int64, attempt int, retryIn time.Duration, err error) {
+			logger.Warn(ctx, "managed_shared_db_pool_provisioning_retry", zap.Int64("db_pool_id", dbID),
+				zap.Int("attempt", attempt), zap.Duration("retry_in", retryIn), zap.Error(err))
+		})
+	for dbID, err := range failed {
+		logger.Warn(ctx, "managed_shared_db_pool_provisioning_failed", zap.Int64("db_pool_id", dbID), zap.Error(err))
+	}
+}
+
+type managedSharedDBProvisioningJob struct {
+	dbID     int64
+	attempt  int
+	backoff  time.Duration
+	deadline time.Time
+}
+
+type managedSharedDBProvisioningResult struct {
+	job *managedSharedDBProvisioningJob
+	err error
+}
+
+func runManagedSharedDBProvisioningQueue(
+	ctx context.Context,
+	workers int,
+	slots chan struct{},
+	dbIDs []int64,
+	retryWindow, initialBackoff, maxBackoff time.Duration,
+	run func(context.Context, int64) error,
+	onRetry func(int64, int, time.Duration, error),
+) map[int64]error {
+	failed := make(map[int64]error)
+	if workers <= 0 || len(dbIDs) == 0 {
+		return failed
+	}
+	if retryWindow <= 0 {
+		retryWindow = schemaInitRetryWindow
+	}
+	if initialBackoff <= 0 {
+		initialBackoff = schemaInitInitialBackoff
+	}
+	if maxBackoff < initialBackoff {
+		maxBackoff = initialBackoff
+	}
+	deadline := time.Now().Add(retryWindow)
+	jobs := make(chan *managedSharedDBProvisioningJob, len(dbIDs))
+	results := make(chan managedSharedDBProvisioningResult, workers)
+	retries := make(chan *managedSharedDBProvisioningJob, len(dbIDs))
+	seen := make(map[int64]struct{}, len(dbIDs))
+	remaining := 0
+	for _, dbID := range dbIDs {
+		if dbID <= 0 {
+			continue
+		}
+		if _, ok := seen[dbID]; ok {
+			continue
+		}
+		seen[dbID] = struct{}{}
+		jobs <- &managedSharedDBProvisioningJob{dbID: dbID, attempt: 1, backoff: initialBackoff, deadline: deadline}
+		remaining++
+	}
+	var wg sync.WaitGroup
+	for range min(workers, remaining) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for job := range jobs {
+				if slots != nil {
+					select {
+					case slots <- struct{}{}:
+					case <-ctx.Done():
+						return
 					}
 				}
-			}()
-		}
-		for _, i := range pendingIndexes {
-			jobs <- i
-		}
-		close(jobs)
-		wg.Wait()
-		pending := 0
-		for i := range states {
-			if !states[i].done {
-				pending++
+				err := run(ctx, job.dbID)
+				if slots != nil {
+					<-slots
+				}
+				select {
+				case results <- managedSharedDBProvisioningResult{job: job, err: err}:
+				case <-ctx.Done():
+					return
+				}
 			}
-		}
-		if pending == 0 {
-			return
-		}
-		remaining := time.Until(deadline)
-		if remaining <= 0 {
-			return
-		}
-		retryIn := min(managedSharedDBContinuationInterval, remaining)
-		for i := range states {
-			if states[i].done || states[i].lastErr == nil {
-				continue
-			}
-			logger.Warn(states[i].ctx, "managed_shared_db_pool_continue_retry",
-				zap.Int("attempt", attempt),
-				zap.Duration("retry_in", retryIn),
-				zap.Duration("remaining", remaining),
-				zap.Error(states[i].lastErr))
-		}
-		timer := time.NewTimer(retryIn)
+		}()
+	}
+	for remaining > 0 {
 		select {
 		case <-ctx.Done():
-			timer.Stop()
-			for i := range states {
-				if !states[i].done {
-					states[i].lastErr = ctx.Err()
+			close(jobs)
+			wg.Wait()
+			return failed
+		case job := <-retries:
+			select {
+			case jobs <- job:
+			case <-ctx.Done():
+				close(jobs)
+				wg.Wait()
+				return failed
+			}
+		case result := <-results:
+			if result.err == nil {
+				remaining--
+				continue
+			}
+			job := result.job
+			retryIn := min(job.backoff, time.Until(job.deadline))
+			if retryIn <= 0 {
+				failed[job.dbID] = result.err
+				remaining--
+				continue
+			}
+			if onRetry != nil {
+				onRetry(job.dbID, job.attempt, retryIn, result.err)
+			}
+			job.attempt++
+			job.backoff = min(job.backoff*2, maxBackoff)
+			go func(job *managedSharedDBProvisioningJob, delay time.Duration) {
+				timer := time.NewTimer(delay)
+				defer timer.Stop()
+				select {
+				case <-ctx.Done():
+				case <-timer.C:
+					select {
+					case retries <- job:
+					case <-ctx.Done():
+					}
+				}
+			}(job, retryIn)
+		}
+	}
+	close(jobs)
+	wg.Wait()
+	return failed
+}
+
+func runManagedSharedDBProvisioningJobs(ctx context.Context, workers int, slots chan struct{}, dbIDs []int64, run func(context.Context, int64)) {
+	if workers <= 0 || len(dbIDs) == 0 {
+		return
+	}
+	jobs := make(chan int64)
+	var wg sync.WaitGroup
+	for range min(workers, len(dbIDs)) {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for dbID := range jobs {
+				if slots != nil {
+					select {
+					case slots <- struct{}{}:
+					case <-ctx.Done():
+						return
+					}
+				}
+				run(ctx, dbID)
+				if slots != nil {
+					<-slots
 				}
 			}
-			return
-		case <-timer.C:
-		}
-		attempt++
+		}()
 	}
+	for _, dbID := range dbIDs {
+		select {
+		case jobs <- dbID:
+		case <-ctx.Done():
+			close(jobs)
+			wg.Wait()
+			return
+		}
+	}
+	close(jobs)
+	wg.Wait()
+}
+
+func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows []*meta.SharedDB, onReady func([]int64)) {
+	owned := make([]*meta.SharedDB, 0, len(rows))
+	for _, row := range rows {
+		if row == nil || row.ID <= 0 {
+			continue
+		}
+		if _, loaded := s.managedSharedDBMetadataJobs.LoadOrStore(row.ID, struct{}{}); !loaded {
+			owned = append(owned, row)
+		}
+	}
+	if len(owned) == 0 {
+		return
+	}
+	defer func() {
+		for _, row := range owned {
+			s.managedSharedDBMetadataJobs.Delete(row.ID)
+		}
+	}()
+	loader, ok := s.provisioner.(tenant.SharedDBPoolBatchLoader)
+	if !ok {
+		logger.Warn(ctx, "managed_shared_db_pool_metadata_batch_unsupported")
+		return
+	}
+	cred, err := s.sharedDBCloudCredentials()
+	if err != nil {
+		logger.Warn(ctx, "managed_shared_db_pool_metadata_credentials_failed", zap.Error(err))
+		return
+	}
+	batchSize := s.managedSharedDBMetadataBatchSize
+	if batchSize <= 0 {
+		batchSize = DefaultManagedSharedDBMetadataBatchSize
+	}
+	workers := s.managedSharedDBMetadataWorkers
+	if workers <= 0 {
+		workers = DefaultManagedSharedDBMetadataWorkers
+	}
+	pollInterval := s.managedSharedDBMetadataPollInterval
+	if pollInterval <= 0 {
+		pollInterval = DefaultManagedSharedDBMetadataPollInterval
+	}
+	queue := append([]*meta.SharedDB(nil), owned...)
+	known := make(map[int64]struct{}, len(owned))
+	for _, row := range owned {
+		known[row.ID] = struct{}{}
+	}
+	var queueMu sync.Mutex
+	take := func(limit int) []*meta.SharedDB {
+		queueMu.Lock()
+		defer queueMu.Unlock()
+		if len(queue) < limit {
+			fresh, listErr := s.meta.ListSharedDBsByStatus(ctx, meta.SharedDBStatusPending, 1000)
+			if listErr != nil {
+				logger.Warn(ctx, "managed_shared_db_pool_metadata_refill_failed", zap.Error(listErr))
+			} else {
+				for _, row := range fresh {
+					if strings.TrimSpace(row.ClusterID) == "" {
+						continue
+					}
+					if _, ok := known[row.ID]; ok {
+						continue
+					}
+					if _, loaded := s.managedSharedDBMetadataJobs.LoadOrStore(row.ID, struct{}{}); loaded {
+						continue
+					}
+					known[row.ID] = struct{}{}
+					owned = append(owned, row)
+					queue = append(queue, row)
+				}
+			}
+		}
+		limit = min(limit, len(queue))
+		out := append([]*meta.SharedDB(nil), queue[:limit]...)
+		queue = queue[limit:]
+		return out
+	}
+	workerCount := min(workers, (len(owned)+batchSize-1)/batchSize)
+	deadline := time.Now().Add(schemaInitRetryWindow)
+	var wg sync.WaitGroup
+	for range workerCount {
+		group := take(batchSize)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if s.managedSharedDBMetadataSlots != nil {
+				select {
+				case s.managedSharedDBMetadataSlots <- struct{}{}:
+					defer func() { <-s.managedSharedDBMetadataSlots }()
+				case <-ctx.Done():
+					return
+				}
+			}
+			attempt := 1
+			for len(group) > 0 && time.Now().Before(deadline) {
+				requests := make([]tenant.SharedDBPoolLoadRequest, 0, len(group))
+				byID := make(map[int64]*meta.SharedDB, len(group))
+				for _, row := range group {
+					requests = append(requests, tenant.SharedDBPoolLoadRequest{DBPoolID: row.ID, DBPoolUUID: row.UUID, ClusterID: row.ClusterID})
+					byID[row.ID] = row
+				}
+				infos, loadErr := loader.BatchLoadSharedDBPoolsWithCredentials(ctx, requests, cred)
+				ready := make(map[int64]struct{}, len(infos))
+				readyIDs := make([]int64, 0, len(infos))
+				for _, info := range infos {
+					if info == nil {
+						continue
+					}
+					row := byID[info.DBPoolID]
+					if row == nil || strings.TrimSpace(info.Host) == "" || info.Port <= 0 || strings.TrimSpace(info.Username) == "" {
+						continue
+					}
+					name := info.DBName
+					if name == "" {
+						name = row.Name
+					}
+					if err := s.meta.UpdateManagedSharedDBPoolCloudResult(ctx, &meta.SharedDB{ID: row.ID, TiDBCloudOrganizationID: row.TiDBCloudOrganizationID, ClusterID: info.ClusterID, Host: info.Host, Port: info.Port, User: info.Username, PasswordCipher: row.PasswordCipher, Name: name, TLSMode: row.TLSMode}); err != nil {
+						logger.Warn(ctx, "managed_shared_db_pool_metadata_persist_failed", zap.Int64("db_pool_id", row.ID), zap.Error(err))
+						continue
+					}
+					ready[row.ID] = struct{}{}
+					readyIDs = append(readyIDs, row.ID)
+				}
+				if loadErr != nil {
+					logger.Warn(ctx, "managed_shared_db_pool_metadata_retry", zap.Int("attempt", attempt), zap.Int("db_pool_count", len(group)), zap.Duration("retry_in", pollInterval), zap.Error(loadErr))
+				}
+				if len(ready) > 0 {
+					remaining := group[:0]
+					for _, row := range group {
+						if _, ok := ready[row.ID]; !ok {
+							remaining = append(remaining, row)
+						}
+					}
+					group = remaining
+					group = append(group, take(len(ready))...)
+					if onReady != nil {
+						onReady(readyIDs)
+					}
+				}
+				if len(group) == 0 {
+					return
+				}
+				timer := time.NewTimer(min(pollInterval, time.Until(deadline)))
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					return
+				case <-timer.C:
+				}
+				attempt++
+			}
+		}()
+	}
+	wg.Wait()
 }
 
 func (s *Server) resumeProvisioningManagedSharedDBPoolsWithCtx(ctx context.Context) {
-	s.resumeManagedSharedDBPoolsByStatus(ctx, meta.SharedDBStatusProvisioning)
+	rows, err := s.meta.ListSharedDBsByStatus(ctx, meta.SharedDBStatusProvisioning, 1000)
+	if err != nil {
+		logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.String("status", meta.SharedDBStatusProvisioning), zap.Error(err))
+		return
+	}
+	ids := make([]int64, 0, len(rows))
+	for _, row := range rows {
+		ids = append(ids, row.ID)
+	}
+	s.runManagedSharedDBProvisioning(ctx, ids)
 }
 
 func (s *Server) resumePendingManagedSharedDBPoolsWithCtx(ctx context.Context) {
-	s.resumeManagedSharedDBPoolsByStatus(ctx, meta.SharedDBStatusPending)
-}
-
-func (s *Server) resumeManagedSharedDBPoolsByStatus(ctx context.Context, status string) {
-	rows, err := s.meta.ListSharedDBsByStatus(ctx, status, 1000)
+	rows, err := s.meta.ListSharedDBsByStatus(ctx, meta.SharedDBStatusPending, 1000)
 	if err != nil {
-		logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.String("status", status), zap.Error(err))
+		logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.String("status", meta.SharedDBStatusPending), zap.Error(err))
 		return
 	}
-	states := make([]managedSharedDBContinuation, 0, len(rows))
+	ids := make([]int64, 0, len(rows))
 	for _, row := range rows {
-		if ctx.Err() != nil {
-			return
-		}
-		states = append(states, s.managedSharedDBContinuation(ctx, row.ID))
+		ids = append(ids, row.ID)
 	}
-	retryManagedSharedDBContinuations(ctx, states)
-	for i := range states {
-		if !states[i].done && states[i].lastErr != nil && states[i].ctx.Err() == nil {
-			logger.Warn(states[i].ctx, "managed_shared_db_pool_resume_failed", zap.Error(states[i].lastErr))
-		}
-	}
+	s.runManagedSharedDBContinuations(ctx, ids)
 }
 
 func (s *Server) continueManagedSharedDBPool(ctx context.Context, dbID int64) error {

--- a/pkg/server/testmain_test.go
+++ b/pkg/server/testmain_test.go
@@ -13,11 +13,11 @@ var testDSN string
 
 func TestMain(m *testing.M) {
 	_ = os.Setenv("DRIVE9_META_DB_MAX_OPEN_CONNS", "8")
-	_ = os.Setenv("DRIVE9_META_DB_MAX_IDLE_CONNS", "0")
+	_ = os.Setenv("DRIVE9_META_DB_MAX_IDLE_CONNS", "1")
 	_ = os.Setenv("DRIVE9_USER_DB_MAX_OPEN_CONNS", "2")
-	_ = os.Setenv("DRIVE9_USER_DB_MAX_IDLE_CONNS", "0")
+	_ = os.Setenv("DRIVE9_USER_DB_MAX_IDLE_CONNS", "1")
 	_ = os.Setenv("DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS", "4")
-	_ = os.Setenv("DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS", "0")
+	_ = os.Setenv("DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS", "1")
 
 	inst, err := testmysql.Start(context.Background())
 	if err != nil {

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -112,6 +112,16 @@ type SharedDBPoolInfo struct {
 	DBName         string
 }
 
+type SharedDBPoolLoadRequest struct {
+	DBPoolID   int64
+	DBPoolUUID string
+	ClusterID  string
+}
+
+type SharedDBPoolBatchLoader interface {
+	BatchLoadSharedDBPoolsWithCredentials(ctx context.Context, requests []SharedDBPoolLoadRequest, req CredentialProvisionRequest) ([]*SharedDBPoolInfo, error)
+}
+
 type SharedDBPoolProvisioner interface {
 	Provisioner
 	// BatchProvisionSharedDBPoolsWithCredentials may return the successfully

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -743,6 +743,60 @@ func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoo
 	return p.sharedDBPoolInfoFromCluster(dbPoolID, wantUUID, &matches[0])
 }
 
+// BatchLoadSharedDBPoolsWithCredentials refreshes multiple known managed
+// shared clusters with one TiDB Cloud list request. Incomplete endpoint/user
+// metadata is returned as an info with empty connection fields so callers can
+// keep the pool pending and poll it again later.
+func (p *Provisioner) BatchLoadSharedDBPoolsWithCredentials(ctx context.Context, requests []tenant.SharedDBPoolLoadRequest, req tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, tenant.ErrCredentialsRequired
+	}
+	if len(requests) == 0 {
+		return nil, nil
+	}
+	targets := make(map[string]tenant.SharedDBPoolLoadRequest, len(requests))
+	clusterIDs := make([]string, 0, len(requests))
+	for _, request := range requests {
+		if request.DBPoolID <= 0 {
+			return nil, fmt.Errorf("db pool id must be positive")
+		}
+		parsedUUID, err := uuid.Parse(strings.TrimSpace(request.DBPoolUUID))
+		if err != nil {
+			return nil, fmt.Errorf("db pool %d has invalid uuid %q: %w", request.DBPoolID, request.DBPoolUUID, err)
+		}
+		clusterID := strings.TrimSpace(request.ClusterID)
+		if clusterID == "" {
+			return nil, fmt.Errorf("db pool %d cluster id is required", request.DBPoolID)
+		}
+		request.DBPoolUUID = parsedUUID.String()
+		request.ClusterID = clusterID
+		targets[clusterID] = request
+		clusterIDs = append(clusterIDs, clusterID)
+	}
+	infos, err := p.listClusterInfosWithCredentials(ctx, publicKey, privateKey, clusterIDs, len(clusterIDs))
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*tenant.SharedDBPoolInfo, 0, len(infos))
+	var partialErr error
+	for i := range infos {
+		target, ok := targets[strings.TrimSpace(infos[i].ClusterID)]
+		if !ok {
+			continue
+		}
+		result, convertErr := p.sharedDBPoolInfoFromCluster(target.DBPoolID, target.DBPoolUUID, &infos[i])
+		if convertErr != nil {
+			partialErr = errors.Join(partialErr, convertErr)
+			continue
+		}
+		out = append(out, result)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].DBPoolID < out[j].DBPoolID })
+	return out, partialErr
+}
+
 func (p *Provisioner) sharedDBPoolInfoFromCluster(dbPoolID int64, dbPoolUUID string, info *clusterInfo) (*tenant.SharedDBPoolInfo, error) {
 	if got := strings.TrimSpace(info.Labels[Drive9ManagedLabel]); got != "true" {
 		return nil, fmt.Errorf("cluster %q has %s label %q, want %q", info.ClusterID, Drive9ManagedLabel, got, "true")

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -976,6 +976,54 @@ func TestLoadSharedDBPoolWithoutClusterIDMatchesUUID(t *testing.T) {
 	}
 }
 
+func TestBatchLoadSharedDBPoolsUsesOneClusterListRequest(t *testing.T) {
+	const firstUUID = "11111111-1111-4111-8111-111111111111"
+	const secondUUID = "22222222-2222-4222-8222-222222222222"
+	var authorizedCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-shared-batch-load", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		authorizedCalls.Add(1)
+		if r.Method != http.MethodGet || r.URL.Path != "/v1beta1/clusters" {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		if filter := r.URL.Query().Get("filter"); !strings.Contains(filter, `clusterId = "cluster-1,cluster-2"`) {
+			http.Error(w, "missing batched cluster filter: "+filter, http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"clusters": []map[string]any{
+			{"clusterId": "cluster-1", "state": "ACTIVE", "userPrefix": "u1",
+				"endpoints": map[string]any{"public": map[string]any{"host": "shared.example", "port": 4000}},
+				"labels": map[string]string{Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+					Drive9DBPoolUUIDLabel: firstUUID, TiDBCloudOrganizationLabel: "org-1"}},
+			{"clusterId": "cluster-2", "state": "CREATING",
+				"labels": map[string]string{Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+					Drive9DBPoolUUIDLabel: secondUUID, TiDBCloudOrganizationLabel: "org-1"}},
+		}})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{apiURL: ts.URL, client: ts.Client()}
+	got, err := p.BatchLoadSharedDBPoolsWithCredentials(context.Background(), []tenant.SharedDBPoolLoadRequest{
+		{DBPoolID: 1, DBPoolUUID: firstUUID, ClusterID: "cluster-1"},
+		{DBPoolID: 2, DBPoolUUID: secondUUID, ClusterID: "cluster-2"},
+	}, tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	if err != nil {
+		t.Fatalf("BatchLoadSharedDBPoolsWithCredentials: %v", err)
+	}
+	if authorizedCalls.Load() != 1 {
+		t.Fatalf("authorized list calls = %d, want 1", authorizedCalls.Load())
+	}
+	if len(got) != 2 || got[0].Host != "shared.example" || got[0].Port != 4000 || got[0].Username != "u1.root" ||
+		got[1].Host != "" || got[1].Port != 0 || got[1].Username != "" {
+		t.Fatalf("batch loaded shared pools = %+v", got)
+	}
+}
+
 func TestWaitForSharedDBPoolMetadataUsesNativeReadinessPoll(t *testing.T) {
 	const poolUUID = "11111111-1111-4111-8111-111111111111"
 	origPoll := tidbCloudNativePollInterval


### PR DESCRIPTION
## Summary

- refill shared tenant pools with a fixed 50-worker pipeline and treat exhausted claim CAS retries as a normal miss that falls through to active provisioning
- create physical shared pools in concurrent 10-pool batches with at most 10 Cloud requests, while ensuring all selected pending pools join the same create wave
- resume metadata/schema work with a fixed 100-worker pool and 15-second retries; reuse server-owned shared credentials without IAM calls in refill workers
- retain one idle test DB connection per pool to prevent CI TCP port exhaustion without saturating MySQL connections

## Test plan

- GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -count=1 -timeout=10m
- GOCACHE=/tmp/drive9-go-cache go test ./pkg/tenant/tidbcloudnative -count=1
- GOCACHE=/tmp/drive9-go-cache go test -race ./pkg/server -run TestSharedTenantPoolRefillRunsFiftyTenantWorkers\|TestRetryManagedSharedDBContinuationsStartsEveryPoolConcurrently\|TestRetryManagedSharedDBContinuationsLimitsConcurrentPoolsToOneHundred -count=1 -timeout=3m
- GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Shared-tenant pool refills complete faster with parallel per-tenant provisioning and more efficient managed shared DB continuation handling.
  - Managed shared DB provisioning/refill now runs in concurrent cloud batches with safer sizing, cooldown/backoff behavior, and improved coordination to reduce duplicate work.
  - Tenant-pool replenishment and pending-resume scans are coalesced per pool with minimum intervals and added cooldown after empty scans.
  - CAS retry now returns a non-error “miss” after exhausting “not found” failures.
  - Added configurable TiDB Cloud managed shared DB tuning via new environment variables (documented in usage output).
- **Tests**
  - Expanded coverage for concurrency limits, batching behavior, locking/cancellation, cooldown/coalescing, and updated retry expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->