### PR TITLE
fix: group managed shared DB batch creation by organization

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1115,6 +1115,52 @@ func (s *Server) provisionManagedSharedDBPoolsBatchWithCredentials(ctx context.C
 	if !ok {
 		return "", fmt.Errorf("provisioner does not support managed shared db pools")
 	}
+	type allocationGroup struct {
+		dbIDs []int64
+	}
+	groupsByIdentity := make(map[string]*allocationGroup)
+	groups := make([]*allocationGroup, 0)
+	for _, dbID := range dbIDs {
+		row, err := s.meta.GetSharedDB(ctx, dbID)
+		if err != nil {
+			return "", err
+		}
+		identity := sharedDBAllocationIdentity(row.TiDBCloudOrganizationID, row.ProvisioningKey)
+		group := groupsByIdentity[identity]
+		if group == nil {
+			group = &allocationGroup{}
+			groupsByIdentity[identity] = group
+			groups = append(groups, group)
+		}
+		group.dbIDs = append(group.dbIDs, dbID)
+	}
+	type groupResult struct {
+		organizationID string
+		err            error
+	}
+	results := make([]groupResult, len(groups))
+	var wg sync.WaitGroup
+	for groupIndex := range groups {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			results[groupIndex].organizationID, results[groupIndex].err = s.provisionManagedSharedDBPoolAllocationGroup(
+				ctx, provisioner, groups[groupIndex].dbIDs, cred)
+		}()
+	}
+	wg.Wait()
+	resolvedOrg := ""
+	var groupErr error
+	for _, result := range results {
+		if resolvedOrg == "" {
+			resolvedOrg = result.organizationID
+		}
+		groupErr = errors.Join(groupErr, result.err)
+	}
+	return resolvedOrg, groupErr
+}
+
+func (s *Server) provisionManagedSharedDBPoolAllocationGroup(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) (string, error) {
 	for attempt := 0; attempt < 2; attempt++ {
 		first, err := s.meta.GetSharedDB(ctx, dbIDs[0])
 		if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -1576,6 +1576,102 @@ func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
 	}
 }
 
+func TestManagedSharedDBBatchCreateLocksEachAllocationIdentityIndependently(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	type testPool struct {
+		organizationID  string
+		provisioningKey []byte
+		dbID            int64
+	}
+	testPools := []testPool{
+		{organizationID: "org-batch-a", provisioningKey: bytes.Repeat([]byte{1}, 32)},
+		{organizationID: "org-batch-b", provisioningKey: bytes.Repeat([]byte{2}, 32)},
+	}
+	dbIDs := make([]int64, 0, len(testPools))
+	for i := range testPools {
+		dbID, createErr := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+			TiDBCloudOrganizationID: testPools[i].organizationID, ProvisioningKey: testPools[i].provisioningKey,
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+			PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+		})
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		testPools[i].dbID = dbID
+		dbIDs = append(dbIDs, dbID)
+	}
+
+	requests := make(chan []tenant.SharedDBPoolCreateRequest, len(testPools))
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, sharedPoolBatchRequests: requests}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov,
+		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour), managedSharedDBCloudBatchSize: 10}
+	holderStarted := make(chan struct{})
+	releaseHolder := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- srv.withSharedDBAllocationLock(context.Background(),
+			sharedDBAllocationIdentity(testPools[0].organizationID, testPools[0].provisioningKey),
+			func(context.Context) error {
+				close(holderStarted)
+				<-releaseHolder
+				return nil
+			})
+	}()
+	<-holderStarted
+
+	batchDone := make(chan error, 1)
+	go func() {
+		_, batchErr := srv.provisionManagedSharedDBPoolsBatchWithCredentials(
+			context.Background(), dbIDs, tenant.CredentialProvisionRequest{})
+		batchDone <- batchErr
+	}()
+	select {
+	case request := <-requests:
+		if len(request) != 1 || request[0].CustomerOrganizationID != testPools[1].organizationID {
+			t.Fatalf("first unlocked batch request = %+v, want only organization %q", request, testPools[1].organizationID)
+		}
+	case <-time.After(500 * time.Millisecond):
+		close(releaseHolder)
+		<-holderDone
+		<-batchDone
+		t.Fatal("unlocked organization did not start while the other allocation identity was locked")
+	}
+	close(releaseHolder)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("allocation lock holder: %v", err)
+	}
+	if err := <-batchDone; err != nil {
+		t.Fatalf("batch create: %v", err)
+	}
+	select {
+	case request := <-requests:
+		if len(request) != 1 || request[0].CustomerOrganizationID != testPools[0].organizationID {
+			t.Fatalf("blocked batch request = %+v, want only organization %q", request, testPools[0].organizationID)
+		}
+	default:
+		t.Fatal("blocked organization batch request was not issued after its allocation lock was released")
+	}
+}
+
 func TestManagedSharedDBBatchCreateReturnsTotalFailure(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {


### PR DESCRIPTION
## Summary

- split mixed managed shared DB create waves by the existing allocation identity
- acquire the correct allocation lock independently for each organization/credential group
- let distinct identity groups proceed concurrently while preserving the existing per-group retry and Cloud batch chunking behavior
- join group errors so successful groups can still persist their Cloud results
- add a regression test proving an unlocked organization advances while another organization lock is held and that Cloud requests never mix organizations

## Review context

Follow-up to the valid cross-organization batch-lock finding on #790. Other late findings were reviewed and do not require code changes in this follow-up.

## Test plan

- `GOCACHE=/tmp/drive9-go-cache go test -race ./pkg/server -run 'TestManagedSharedDBBatchCreateLocksEachAllocationIdentityIndependently|TestManagedSharedDBBatchCreateRunsAllChunksConcurrently|TestManagedSharedDBBatchCreateReturnsTotalFailure|TestManagedSharedDBContinuation' -count=1`\n- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/server -count=1`\n- `GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint`\n- `GOCACHE=/tmp/drive9-go-cache CGO_ENABLED=0 go build ./...`\n- `git diff --check`