### PR TITLE
fix: chunk shared tenant pool replenishment

### DIFF
--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1898,6 +1898,8 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 		sharedProvider := s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared
 		createdAny := false
 		sharedWaveRemaining := 0
+		// A started shared wave accounts for in-flight pending/provisioning slots;
+		// sharedWaveRemaining is the hard cap that guarantees termination.
 		for {
 			if err := ctx.Err(); err != nil {
 				metricResult = adminTenantPoolMetricResult(err)

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1948,82 +1948,35 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				return
 			}
 
-			// The common no-op path returns before taking either lock. Re-check all
-			// capacity state under the distributed lock before provisioning. Shared
-			// refills do one physical-DB-sized batch per lock hold; the loop below
-			// reacquires it only after this batch has been persisted.
-			batchCreated := 0
-			lock := s.tenantPoolLock(pool.PoolID)
-			lock.Lock()
-			lockErr := s.meta.WithTenantPoolLock(ctx, pool.PoolID, func(ctx context.Context) error {
-				current, err = s.meta.GetTenantPoolByID(ctx, pool.PoolID)
-				if err != nil {
-					if !errors.Is(err, meta.ErrNotFound) {
-						logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
-						metricResult = "error"
-					} else {
-						metricResult = "not_found"
-					}
-					return nil
-				}
-				if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
-					metricResult = "skipped"
-					return nil
-				}
-				freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
-				if err != nil {
-					logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-					metricResult = "error"
-					return nil
-				}
-				s.recordTenantPoolCapacity(current.PoolID, current.OrganizationID, current.Size, freeSize)
-				if !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
-					logger.Info(ctx, "admin_tenant_pool_replenish_skipped",
-						zap.String("pool_id", current.PoolID),
-						zap.String("organization_id", current.OrganizationID),
-						zap.Int("pool_size", current.Size),
-						zap.Int("free_size", freeSize),
-						zap.Float64("refill_free_ratio", s.effectiveTenantPoolRefillFreeRatio()))
-					metricResult = "noop"
-					return nil
-				}
-				// Trigger on active free tenants, but size refill against all free
-				// slots, including in-flight pending/provisioning tenants, so
-				// concurrent replenishment does not double-provision.
-				slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
-				if err != nil {
-					logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-					metricResult = "error"
-					return nil
-				}
-				missing := current.Size - slotSize
-				if missing <= 0 {
-					metricResult = "noop"
-					return nil
-				}
-				if sharedProvider {
-					maxTenants, _ := s.managedSharedDBPolicy()
-					missing = managedSharedDBRefillBatchTenantCount(missing, maxTenants, s.managedSharedDBRefillPoolLimit)
-				}
-				results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
-				if err != nil {
-					logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-					metricResult = "cluster_error"
-					return nil
-				}
-				batchCreated = len(results)
-				for _, res := range results {
-					s.startProvisionedTenantSchemaInit(ctx, res)
-				}
-				return nil
-			})
-			lock.Unlock()
-			if lockErr != nil {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_lock_failed", zap.String("pool_id", pool.PoolID), zap.Error(lockErr))
-				metricResult = adminTenantPoolMetricResult(lockErr)
+			// The initial watermark check above avoids a slot COUNT on the common
+			// no-op path. Re-read durable slots before every batch because other
+			// Pods may replenish this pool concurrently; over-create is bounded and
+			// acceptable, while pending/provisioning slots prevent under-counting.
+			slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
+			if err != nil {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+				metricResult = "error"
 				return
 			}
-			if !sharedProvider || batchCreated == 0 {
+			missing := current.Size - slotSize
+			if missing <= 0 {
+				metricResult = "noop"
+				return
+			}
+			if sharedProvider {
+				maxTenants, _ := s.managedSharedDBPolicy()
+				missing = managedSharedDBRefillBatchTenantCount(missing, maxTenants, s.managedSharedDBRefillPoolLimit)
+			}
+			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
+			if err != nil {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+				metricResult = "cluster_error"
+				return
+			}
+			for _, res := range results {
+				s.startProvisionedTenantSchemaInit(ctx, res)
+			}
+			if !sharedProvider || len(results) == 0 {
 				return
 			}
 		}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -81,6 +81,21 @@ func managedSharedDBRefillTenantCount(missing, maxTenants, poolLimit int) int {
 	return min(missing, limit)
 }
 
+// managedSharedDBRefillBatchTenantCount bounds one refill attempt to a single
+// physical shared database capacity. The larger pool limit remains a defensive
+// cap for planning, while the tenant-pool named lock is released between these
+// batches so a large refill cannot hold it across multiple cloud requests.
+func managedSharedDBRefillBatchTenantCount(missing, maxTenants, poolLimit int) int {
+	missing = managedSharedDBRefillTenantCount(missing, maxTenants, poolLimit)
+	if missing <= 0 {
+		return 0
+	}
+	if maxTenants <= 0 {
+		maxTenants = defaultManagedSharedDBMaxTenants
+	}
+	return min(missing, maxTenants)
+}
+
 func retryTenantPoolClaimCAS[T any](attempt func() (T, error)) (T, error) {
 	var zero T
 	for range tenantPoolClaimCASRetryLimit {
@@ -1895,45 +1910,13 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 		defer func() {
 			metrics.RecordOperation(adminTenantPoolMetricsComponent, "replenish", metricResult, time.Since(replenishStarted))
 		}()
-		current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
-		if err != nil {
-			if !errors.Is(err, meta.ErrNotFound) {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
-				metricResult = "error"
-			} else {
-				metricResult = "not_found"
+		sharedProvider := s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared
+		for {
+			if err := ctx.Err(); err != nil {
+				metricResult = adminTenantPoolMetricResult(err)
+				return
 			}
-			return
-		}
-		if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
-			metricResult = "skipped"
-			return
-		}
-		freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
-		if err != nil {
-			logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-			metricResult = "error"
-			return
-		}
-		s.recordTenantPoolCapacity(current.PoolID, current.OrganizationID, current.Size, freeSize)
-		if !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
-			logger.Info(ctx, "admin_tenant_pool_replenish_skipped",
-				zap.String("pool_id", current.PoolID),
-				zap.String("organization_id", current.OrganizationID),
-				zap.Int("pool_size", current.Size),
-				zap.Int("free_size", freeSize),
-				zap.Float64("refill_free_ratio", s.effectiveTenantPoolRefillFreeRatio()))
-			metricResult = "noop"
-			return
-		}
-
-		// The common no-op path returns before taking either lock. Re-check all
-		// capacity state under the distributed lock before provisioning.
-		lock := s.tenantPoolLock(pool.PoolID)
-		lock.Lock()
-		defer lock.Unlock()
-		if err := s.meta.WithTenantPoolLock(ctx, pool.PoolID, func(ctx context.Context) error {
-			current, err = s.meta.GetTenantPoolByID(ctx, pool.PoolID)
+			current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
 			if err != nil {
 				if !errors.Is(err, meta.ErrNotFound) {
 					logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
@@ -1941,17 +1924,17 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				} else {
 					metricResult = "not_found"
 				}
-				return nil
+				return
 			}
 			if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
 				metricResult = "skipped"
-				return nil
+				return
 			}
-			freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
+			freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
 			if err != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
 				metricResult = "error"
-				return nil
+				return
 			}
 			s.recordTenantPoolCapacity(current.PoolID, current.OrganizationID, current.Size, freeSize)
 			if !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
@@ -1962,39 +1945,87 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 					zap.Int("free_size", freeSize),
 					zap.Float64("refill_free_ratio", s.effectiveTenantPoolRefillFreeRatio()))
 				metricResult = "noop"
+				return
+			}
+
+			// The common no-op path returns before taking either lock. Re-check all
+			// capacity state under the distributed lock before provisioning. Shared
+			// refills do one physical-DB-sized batch per lock hold; the loop below
+			// reacquires it only after this batch has been persisted.
+			batchCreated := 0
+			lock := s.tenantPoolLock(pool.PoolID)
+			lock.Lock()
+			lockErr := s.meta.WithTenantPoolLock(ctx, pool.PoolID, func(ctx context.Context) error {
+				current, err = s.meta.GetTenantPoolByID(ctx, pool.PoolID)
+				if err != nil {
+					if !errors.Is(err, meta.ErrNotFound) {
+						logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
+						metricResult = "error"
+					} else {
+						metricResult = "not_found"
+					}
+					return nil
+				}
+				if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
+					metricResult = "skipped"
+					return nil
+				}
+				freeSize, err = s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
+				if err != nil {
+					logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+					metricResult = "error"
+					return nil
+				}
+				s.recordTenantPoolCapacity(current.PoolID, current.OrganizationID, current.Size, freeSize)
+				if !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
+					logger.Info(ctx, "admin_tenant_pool_replenish_skipped",
+						zap.String("pool_id", current.PoolID),
+						zap.String("organization_id", current.OrganizationID),
+						zap.Int("pool_size", current.Size),
+						zap.Int("free_size", freeSize),
+						zap.Float64("refill_free_ratio", s.effectiveTenantPoolRefillFreeRatio()))
+					metricResult = "noop"
+					return nil
+				}
+				// Trigger on active free tenants, but size refill against all free
+				// slots, including in-flight pending/provisioning tenants, so
+				// concurrent replenishment does not double-provision.
+				slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
+				if err != nil {
+					logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+					metricResult = "error"
+					return nil
+				}
+				missing := current.Size - slotSize
+				if missing <= 0 {
+					metricResult = "noop"
+					return nil
+				}
+				if sharedProvider {
+					maxTenants, _ := s.managedSharedDBPolicy()
+					missing = managedSharedDBRefillBatchTenantCount(missing, maxTenants, s.managedSharedDBRefillPoolLimit)
+				}
+				results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
+				if err != nil {
+					logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+					metricResult = "cluster_error"
+					return nil
+				}
+				batchCreated = len(results)
+				for _, res := range results {
+					s.startProvisionedTenantSchemaInit(ctx, res)
+				}
 				return nil
+			})
+			lock.Unlock()
+			if lockErr != nil {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_lock_failed", zap.String("pool_id", pool.PoolID), zap.Error(lockErr))
+				metricResult = adminTenantPoolMetricResult(lockErr)
+				return
 			}
-			// Trigger on active free tenants, but size refill against all free
-			// slots, including in-flight pending/provisioning tenants, so
-			// concurrent replenishment does not double-provision.
-			slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
-			if err != nil {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-				metricResult = "error"
-				return nil
+			if !sharedProvider || batchCreated == 0 {
+				return
 			}
-			missing := current.Size - slotSize
-			if missing <= 0 {
-				metricResult = "noop"
-				return nil
-			}
-			if s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared {
-				maxTenants, _ := s.managedSharedDBPolicy()
-				missing = managedSharedDBRefillTenantCount(missing, maxTenants, s.managedSharedDBRefillPoolLimit)
-			}
-			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
-			if err != nil {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-				metricResult = "cluster_error"
-				return nil
-			}
-			for _, res := range results {
-				s.startProvisionedTenantSchemaInit(ctx, res)
-			}
-			return nil
-		}); err != nil {
-			logger.Warn(ctx, "admin_tenant_pool_replenish_lock_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
-			metricResult = adminTenantPoolMetricResult(err)
 		}
 	}) {
 		s.finishTenantPoolReplenishment(pool.PoolID)

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -81,21 +81,6 @@ func managedSharedDBRefillTenantCount(missing, maxTenants, poolLimit int) int {
 	return min(missing, limit)
 }
 
-// managedSharedDBRefillBatchTenantCount bounds one refill attempt to a single
-// physical shared database capacity. The larger pool limit remains a defensive
-// cap for planning, while the tenant-pool named lock is released between these
-// batches so a large refill cannot hold it across multiple cloud requests.
-func managedSharedDBRefillBatchTenantCount(missing, maxTenants, poolLimit int) int {
-	missing = managedSharedDBRefillTenantCount(missing, maxTenants, poolLimit)
-	if missing <= 0 {
-		return 0
-	}
-	if maxTenants <= 0 {
-		maxTenants = defaultManagedSharedDBMaxTenants
-	}
-	return min(missing, maxTenants)
-}
-
 func retryTenantPoolClaimCAS[T any](attempt func() (T, error)) (T, error) {
 	var zero T
 	for range tenantPoolClaimCASRetryLimit {
@@ -1911,6 +1896,8 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			metrics.RecordOperation(adminTenantPoolMetricsComponent, "replenish", metricResult, time.Since(replenishStarted))
 		}()
 		sharedProvider := s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared
+		createdAny := false
+		sharedWaveRemaining := 0
 		for {
 			if err := ctx.Err(); err != nil {
 				metricResult = adminTenantPoolMetricResult(err)
@@ -1937,7 +1924,7 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 				return
 			}
 			s.recordTenantPoolCapacity(current.PoolID, current.OrganizationID, current.Size, freeSize)
-			if !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
+			if !createdAny && !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
 				logger.Info(ctx, "admin_tenant_pool_replenish_skipped",
 					zap.String("pool_id", current.PoolID),
 					zap.String("organization_id", current.OrganizationID),
@@ -1960,12 +1947,20 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			}
 			missing := current.Size - slotSize
 			if missing <= 0 {
-				metricResult = "noop"
+				if !createdAny {
+					metricResult = "noop"
+				}
 				return
 			}
 			if sharedProvider {
 				maxTenants, _ := s.managedSharedDBPolicy()
-				missing = managedSharedDBRefillBatchTenantCount(missing, maxTenants, s.managedSharedDBRefillPoolLimit)
+				if !createdAny {
+					sharedWaveRemaining = managedSharedDBRefillTenantCount(missing, maxTenants, s.managedSharedDBRefillPoolLimit)
+				}
+				if sharedWaveRemaining <= 0 {
+					return
+				}
+				missing = min(missing, sharedWaveRemaining, maxTenants)
 			}
 			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
 			if err != nil {
@@ -1976,7 +1971,17 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			for _, res := range results {
 				s.startProvisionedTenantSchemaInit(ctx, res)
 			}
+			if len(results) > 0 {
+				createdAny = true
+				metricResult = "ok"
+				if sharedProvider {
+					sharedWaveRemaining -= len(results)
+				}
+			}
 			if !sharedProvider || len(results) == 0 {
+				return
+			}
+			if sharedWaveRemaining <= 0 {
 				return
 			}
 		}

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1160,6 +1160,30 @@ func TestAdminTenantPoolReplenishChunksLargeRefill(t *testing.T) {
 		t.Fatalf("create pool: %v", err)
 	}
 
+	lockHeld := make(chan struct{})
+	releaseLock := make(chan struct{})
+	lockDone := make(chan error, 1)
+	go func() {
+		lockDone <- metaStore.WithTenantPoolLock(ctx, pool.PoolID, func(context.Context) error {
+			close(lockHeld)
+			<-releaseLock
+			return nil
+		})
+	}()
+	select {
+	case <-lockHeld:
+	case err := <-lockDone:
+		t.Fatalf("hold tenant pool lock: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out acquiring tenant pool lock for test")
+	}
+	t.Cleanup(func() {
+		close(releaseLock)
+		if err := <-lockDone; err != nil {
+			t.Errorf("release tenant pool lock: %v", err)
+		}
+	})
+
 	srv.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1117,6 +1117,72 @@ func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
 	}
 }
 
+func TestAdminTenantPoolReplenishChunksLargeRefill(t *testing.T) {
+	oldRetryWindow := schemaInitRetryWindow
+	schemaInitRetryWindow = 100 * time.Millisecond
+	t.Cleanup(func() { schemaInitRetryWindow = oldRetryWindow })
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer poolManager.Close()
+	poolManager.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 100,
+		TokenSecret: make([]byte, 32)})
+	defer srv.Close()
+	// Make each refill batch visible as one cloud batch. The production default
+	// is smaller, but the physical pool count is independent of this test knob.
+	srv.managedSharedDBCloudBatchSize = 250
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID:         "pool-large-refill",
+		OrganizationID: "org-1",
+		Size:           250,
+		Status:         meta.TenantPoolActive,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	if err := metaStore.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	srv.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		if got := prov.sharedPoolBatchCalls.Load(); got >= 3 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("shared cloud batch calls = %d, want three bounded refill batches", prov.sharedPoolBatchCalls.Load())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	free, err := metaStore.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
+	if err != nil {
+		t.Fatalf("count free: %v", err)
+	}
+	if free != pool.Size {
+		t.Fatalf("free size = %d, want %d after refill", free, pool.Size)
+	}
+}
+
 func TestManagedSharedDBRefillCapsOneWaveAtFiftyPhysicalPools(t *testing.T) {
 	if got := managedSharedDBRefillTenantCount(10_000, 100, 50); got != 5_000 {
 		t.Fatalf("refill tenant count = %d, want capacity of 50 physical pools", got)
@@ -1129,6 +1195,12 @@ func TestManagedSharedDBRefillCapsOneWaveAtFiftyPhysicalPools(t *testing.T) {
 	}
 	if got := managedSharedDBRefillTenantCount(10_000, 100, 12); got != 1_200 {
 		t.Fatalf("refill tenant count with configured 12-DB limit = %d, want 1200", got)
+	}
+	if got := managedSharedDBRefillBatchTenantCount(10_000, 100, 50); got != 100 {
+		t.Fatalf("refill batch tenant count = %d, want one physical DB capacity", got)
+	}
+	if got := managedSharedDBRefillBatchTenantCount(50, 100, 50); got != 50 {
+		t.Fatalf("small refill batch tenant count = %d, want 50", got)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1198,6 +1198,7 @@ func TestAdminTenantPoolReplenishChunksLargeRefill(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+	deadline = time.Now().Add(10 * time.Second)
 	for {
 		free, err := metaStore.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
 		if err != nil {

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1198,12 +1198,88 @@ func TestAdminTenantPoolReplenishChunksLargeRefill(t *testing.T) {
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	free, err := metaStore.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
-	if err != nil {
-		t.Fatalf("count free: %v", err)
+	for {
+		free, err := metaStore.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
+		if err != nil {
+			t.Fatalf("count free: %v", err)
+		}
+		if free == pool.Size {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("free size = %d, want %d after refill", free, pool.Size)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	if free != pool.Size {
-		t.Fatalf("free size = %d, want %d after refill", free, pool.Size)
+}
+
+func TestAdminTenantPoolReplenishContinuesPastWatermarkToFillSlots(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer poolManager.Close()
+	poolManager.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 200,
+		TokenSecret: make([]byte, 32)})
+	defer srv.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{PoolID: "pool-watermark-shared", OrganizationID: "org-watermark-shared",
+		Size: 250, Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}
+	if err := metaStore.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+	passwordCipher, err := poolManager.Encrypt(ctx, []byte("shared-pass"))
+	if err != nil {
+		t.Fatalf("encrypt shared password: %v", err)
+	}
+	if _, err := metaStore.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: pool.OrganizationID,
+		Host:                    "shared.example.com",
+		Port:                    4000,
+		User:                    "root",
+		PasswordCipher:          passwordCipher,
+		Name:                    "tidbcloud_fs",
+		MaxTenants:              200,
+	}); err != nil {
+		t.Fatalf("register shared db: %v", err)
+	}
+	if _, err := srv.createFreeSharedPoolTenants(ctx, pool.PoolID, 100,
+		tenant.CredentialProvisionRequest{PublicKey: "public-1", PrivateKey: "private-1"}, nil); err != nil {
+		t.Fatalf("seed shared pool: %v", err)
+	}
+
+	srv.replenishTenantPoolAsync(ctx, pool, tenant.CredentialProvisionRequest{
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		free, err := metaStore.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
+		if err != nil {
+			t.Fatalf("count free slots: %v", err)
+		}
+		if free == pool.Size {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("free slots = %d, want %d after refill", free, pool.Size)
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
 }
 
@@ -1219,12 +1295,6 @@ func TestManagedSharedDBRefillCapsOneWaveAtFiftyPhysicalPools(t *testing.T) {
 	}
 	if got := managedSharedDBRefillTenantCount(10_000, 100, 12); got != 1_200 {
 		t.Fatalf("refill tenant count with configured 12-DB limit = %d, want 1200", got)
-	}
-	if got := managedSharedDBRefillBatchTenantCount(10_000, 100, 50); got != 100 {
-		t.Fatalf("refill batch tenant count = %d, want one physical DB capacity", got)
-	}
-	if got := managedSharedDBRefillBatchTenantCount(50, 100, 50); got != 50 {
-		t.Fatalf("small refill batch tenant count = %d, want 50", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove the tenant-pool distributed MySQL `GET_LOCK` from replenishment workers.
- Keep shared replenishment bounded to one physical-DB capacity per batch (`maxTenants`).
- Preserve the configured refill wave cap (`managedSharedDBRefillPoolLimit`) across all batches started by one trigger.
- Re-read durable active/pending/provisioning slots before every batch; concurrent Pods may cause bounded over-create, but they will not under-create because in-flight slots are counted.
- Keep the per-Pod replenish coalescing gate and the shared DB organization allocation lock.
- Keep native tenant-pool replenishment behavior unchanged.

## Design

The tenant-pool refill path is intentionally lockless across Pods. The initial active-free watermark check decides whether a refill wave should start. Once a wave starts, subsequent batches continue until durable free slots reach the pool target or the configured wave budget is exhausted; the active-free watermark is not re-applied between batches.

Correctness comes from durable slot accounting and transactional shared-DB capacity reservation:

- `active`, `pending`, and `provisioning` entries all consume pool slots;
- each batch is bounded by one physical shared DB capacity;
- the shared DB organization allocation lock prevents duplicate physical DB planning;
- the per-DB transaction prevents `tenant_count` from exceeding `maxTenants`;
- the next claim or durable-state scan starts another bounded wave if a previous wave failed or the pool remains below target.

## Why

The previous implementation held a tenant-pool named lock while performing tenant creation, shared DB allocation, cloud requests, result persistence, and schema-init scheduling. Large pools could exceed the 300-second MySQL named-lock wait timeout and cause other Pods to fail replenishment with `admin_tenant_pool_replenish_lock_failed`.

The refill path no longer depends on that lock. Multiple Pods can replenish concurrently, while bounded batches and durable slot rechecks prevent runaway creation and preserve the no-under-create behavior.

## Verification

- `go test ./pkg/server ./pkg/meta -count=1`
- `go test -race ./pkg/server -run 'TestAdminTenantPoolReplenish|TestManagedSharedDBRefill' -count=1`
- `make lint`
- `CGO_ENABLED=0 go build ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved tenant pool replenishment to continue across multiple batches until available capacity is filled.
  - Added safeguards for shared-provider pools to prevent over-provisioning during large refill operations.
  - Improved handling and reporting of replenishment errors.

- **Tests**
  - Added coverage for large, batched refills.
  - Added validation that replenishment continues beyond the refill threshold until the pool is fully populated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->