### PR TITLE
fix: make shared pool refill durably convergent

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -446,8 +446,6 @@ func main() {
 		SharedDBSpendingLimit: sharedDBDefaultSpendingLimit,
 		ManagedSharedDBCloudBatchSize: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE",
 			server.DefaultManagedSharedDBCloudBatchSize),
-		ManagedSharedDBRefillPoolLimit: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_REFILL_POOL_LIMIT",
-			server.DefaultManagedSharedDBRefillPoolLimit),
 		ManagedSharedDBMetadataWorkers: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_WORKERS",
 			server.DefaultManagedSharedDBMetadataWorkers),
 		ManagedSharedDBMetadataBatchSize: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_BATCH_SIZE",
@@ -460,6 +458,10 @@ func main() {
 			server.DefaultTenantPoolReconcileInterval),
 		TenantPoolReconcileWorkers: envInt("DRIVE9_TENANT_POOL_RECONCILE_WORKERS",
 			server.DefaultTenantPoolReconcileWorkers),
+		TenantPoolReconcileWorkerRest: envDuration("DRIVE9_TENANT_POOL_RECONCILE_WORKER_REST",
+			server.DefaultTenantPoolReconcileWorkerRest),
+		ManagedSharedDBPlannedCapacityLease: envDuration("DRIVE9_TIDBCLOUD_NATIVE_SHARED_PLANNED_CAPACITY_LEASE",
+			server.DefaultManagedSharedDBPlannedCapacityLease),
 		ManagedSharedDBStuckTimeout: envDuration("DRIVE9_TIDBCLOUD_NATIVE_SHARED_STUCK_TIMEOUT",
 			server.DefaultManagedSharedDBStuckTimeout),
 		ManagedSharedDBFailedCleanupInterval: envDuration("DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_INTERVAL",
@@ -687,14 +689,15 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_HARD_CAP_RATIO emergency hard-cap ratio > 1 after physical create failure (default: 1.2)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_REOPEN_RATIO reopen ratio for a latched shared pool (default: 0.8)
   DRIVE9_TIDBCLOUD_NATIVE_DB_POOL_DEFAULT_SPENDING_LIMIT physical spending-limit target for new managed shared DB pools (default: 1000000)
-  DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE physical pools per Cloud create request (default and maximum: 10)
-  DRIVE9_TIDBCLOUD_NATIVE_SHARED_REFILL_POOL_LIMIT maximum physical shared DBs added by one refill wave (default: 50)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE maximum physical pools in one refill Cloud request (default: 50)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_WORKERS concurrent pending metadata workers (default and maximum: 15)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_BATCH_SIZE physical pools per metadata list request (default and maximum: 30)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_POLL_INTERVAL delay between metadata list rounds (default: 15s)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_PROVISIONING_WORKERS concurrent shared schema-init workers (default: 100)
-  DRIVE9_TENANT_POOL_RECONCILE_INTERVAL leader logical-pool refill scan interval (default: 15s)
-  DRIVE9_TENANT_POOL_RECONCILE_WORKERS maximum concurrent leader logical-pool refills (default: 10)
+  DRIVE9_TENANT_POOL_RECONCILE_INTERVAL leader logical-pool refill scan interval (default: 5s)
+  DRIVE9_TENANT_POOL_RECONCILE_WORKERS concurrent queued leader logical-pool refill workers (default: 15)
+  DRIVE9_TENANT_POOL_RECONCILE_WORKER_REST delay before a completed refill worker takes another task (default: 5s)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_PLANNED_CAPACITY_LEASE maximum age for pending/provisioning capacity to offset refill (default: 1m)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_STUCK_TIMEOUT pending/provisioning no-progress timeout (default: 15m)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_INTERVAL failed physical-pool cleanup interval (default: 1m)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_BATCH_SIZE failed physical pools processed per cleanup pass (default: 5)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -460,8 +460,6 @@ func main() {
 			server.DefaultTenantPoolReconcileWorkers),
 		TenantPoolReconcileWorkerRest: envDuration("DRIVE9_TENANT_POOL_RECONCILE_WORKER_REST",
 			server.DefaultTenantPoolReconcileWorkerRest),
-		ManagedSharedDBPlannedCapacityLease: envDuration("DRIVE9_TIDBCLOUD_NATIVE_SHARED_PLANNED_CAPACITY_LEASE",
-			server.DefaultManagedSharedDBPlannedCapacityLease),
 		ManagedSharedDBStuckTimeout: envDuration("DRIVE9_TIDBCLOUD_NATIVE_SHARED_STUCK_TIMEOUT",
 			server.DefaultManagedSharedDBStuckTimeout),
 		ManagedSharedDBFailedCleanupInterval: envDuration("DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_INTERVAL",
@@ -697,7 +695,6 @@ environment:
   DRIVE9_TENANT_POOL_RECONCILE_INTERVAL leader logical-pool refill scan interval (default: 5s)
   DRIVE9_TENANT_POOL_RECONCILE_WORKERS concurrent queued leader logical-pool refill workers (default: 15)
   DRIVE9_TENANT_POOL_RECONCILE_WORKER_REST delay before a completed refill worker takes another task (default: 5s)
-  DRIVE9_TIDBCLOUD_NATIVE_SHARED_PLANNED_CAPACITY_LEASE maximum age for pending/provisioning capacity to offset refill (default: 1m)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_STUCK_TIMEOUT pending/provisioning no-progress timeout (default: 15m)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_INTERVAL failed physical-pool cleanup interval (default: 1m)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_BATCH_SIZE failed physical pools processed per cleanup pass (default: 5)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -456,6 +456,16 @@ func main() {
 			server.DefaultManagedSharedDBMetadataPollInterval),
 		ManagedSharedDBProvisioningWorkers: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_PROVISIONING_WORKERS",
 			server.DefaultManagedSharedDBProvisioningWorkers),
+		TenantPoolReconcileInterval: envDuration("DRIVE9_TENANT_POOL_RECONCILE_INTERVAL",
+			server.DefaultTenantPoolReconcileInterval),
+		TenantPoolReconcileWorkers: envInt("DRIVE9_TENANT_POOL_RECONCILE_WORKERS",
+			server.DefaultTenantPoolReconcileWorkers),
+		ManagedSharedDBStuckTimeout: envDuration("DRIVE9_TIDBCLOUD_NATIVE_SHARED_STUCK_TIMEOUT",
+			server.DefaultManagedSharedDBStuckTimeout),
+		ManagedSharedDBFailedCleanupInterval: envDuration("DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_INTERVAL",
+			server.DefaultManagedSharedDBFailedCleanupInterval),
+		ManagedSharedDBFailedCleanupBatchSize: envInt("DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_BATCH_SIZE",
+			server.DefaultManagedSharedDBFailedCleanupBatchSize),
 		LegacyStarterProvisioner:        legacyStarterProvisioner,
 		TokenSecret:                     tokenSecret,
 		VaultMasterKey:                  vaultMasterKey,
@@ -683,6 +693,11 @@ environment:
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_BATCH_SIZE physical pools per metadata list request (default and maximum: 30)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_POLL_INTERVAL delay between metadata list rounds (default: 15s)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_PROVISIONING_WORKERS concurrent shared schema-init workers (default: 100)
+  DRIVE9_TENANT_POOL_RECONCILE_INTERVAL leader logical-pool refill scan interval (default: 15s)
+  DRIVE9_TENANT_POOL_RECONCILE_WORKERS maximum concurrent leader logical-pool refills (default: 10)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_STUCK_TIMEOUT pending/provisioning no-progress timeout (default: 15m)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_INTERVAL failed physical-pool cleanup interval (default: 1m)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_BATCH_SIZE failed physical pools processed per cleanup pass (default: 5)
   DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings (also accepts public_host:private_host);
                                              when set, disables legacy single-host private endpoint overrides
   DRIVE9_TIDBCLOUD_TENCENT_PRIVATE_ENDPOINT_HOST legacy tencentcloud private endpoint fallback host, used only when host map is unset

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -197,31 +197,83 @@ const sharedDBSelectColumns = "db_id, uuid, org_id, cluster_id, provisioning_key
 func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id int64, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "create_managed_shared_db_pool", start, &err)
+	values, err := managedSharedDBInsertValuesFor(in)
+	if err != nil {
+		return 0, err
+	}
+	return insertManagedSharedDBPool(ctx, s.db, values)
+}
+
+// CreateManagedSharedDBPools atomically persists one complete physical refill
+// wave. A failure in any partition rolls back every plan in the wave.
+func (s *Store) CreateManagedSharedDBPools(ctx context.Context, inputs []*SharedDB) (ids []int64, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "create_managed_shared_db_pools", start, &err)
+	if len(inputs) == 0 {
+		return []int64{}, nil
+	}
+	values := make([]managedSharedDBInsertValues, len(inputs))
+	for i, in := range inputs {
+		values[i], err = managedSharedDBInsertValuesFor(in)
+		if err != nil {
+			return nil, fmt.Errorf("validate managed db pool %d: %w", i, err)
+		}
+	}
+	ids = make([]int64, len(values))
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		for i := range values {
+			id, insertErr := insertManagedSharedDBPool(ctx, tx, values[i])
+			if insertErr != nil {
+				return fmt.Errorf("insert managed db pool %d: %w", i, insertErr)
+			}
+			ids[i] = id
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+type managedSharedDBInsertValues struct {
+	poolUUID        string
+	organizationID  string
+	provisioningKey []byte
+	cloudProvider   string
+	region          string
+	passwordCipher  any
+	databaseName    any
+	maxTenants      int
+	spendingLimit   int64
+}
+
+func managedSharedDBInsertValuesFor(in *SharedDB) (managedSharedDBInsertValues, error) {
 	if in == nil {
-		return 0, fmt.Errorf("shared db pool is required")
+		return managedSharedDBInsertValues{}, fmt.Errorf("shared db pool is required")
 	}
 	organizationID, err := validateSharedDBOrganizationID(in.TiDBCloudOrganizationID)
 	if err != nil {
-		return 0, err
+		return managedSharedDBInsertValues{}, err
 	}
 	poolUUID, err := sharedDBUUID(in.UUID)
 	if err != nil {
-		return 0, err
+		return managedSharedDBInsertValues{}, err
 	}
 	if len(in.ProvisioningKey) != 32 {
-		return 0, fmt.Errorf("provisioning key must be a 32-byte SHA-256 fingerprint")
+		return managedSharedDBInsertValues{}, fmt.Errorf("provisioning key must be a 32-byte SHA-256 fingerprint")
 	}
 	if in.CloudProvider == "" {
-		return 0, fmt.Errorf("cloud provider is required")
+		return managedSharedDBInsertValues{}, fmt.Errorf("cloud provider is required")
 	}
 	if in.Region == "" {
-		return 0, fmt.Errorf("region is required")
+		return managedSharedDBInsertValues{}, fmt.Errorf("region is required")
 	}
 	if in.MaxTenants <= 0 {
-		return 0, fmt.Errorf("managed max tenants must be positive")
+		return managedSharedDBInsertValues{}, fmt.Errorf("managed max tenants must be positive")
 	}
 	if in.SpendingLimit == nil || *in.SpendingLimit <= 0 || *in.SpendingLimit > int64(math.MaxInt32) {
-		return 0, fmt.Errorf("managed spending limit must be in (0,%d]", int64(math.MaxInt32))
+		return managedSharedDBInsertValues{}, fmt.Errorf("managed spending limit must be in (0,%d]", int64(math.MaxInt32))
 	}
 	var passwordCipher any
 	if len(in.PasswordCipher) != 0 {
@@ -231,17 +283,28 @@ func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id
 	if in.Name != "" {
 		databaseName = in.Name
 	}
-	res, err := s.db.ExecContext(ctx, `INSERT INTO db_pool
+	return managedSharedDBInsertValues{poolUUID: poolUUID, organizationID: organizationID,
+		provisioningKey: append([]byte(nil), in.ProvisioningKey...), cloudProvider: in.CloudProvider,
+		region: in.Region, passwordCipher: passwordCipher, databaseName: databaseName,
+		maxTenants: in.MaxTenants, spendingLimit: *in.SpendingLimit}, nil
+}
+
+type managedSharedDBExecer interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+}
+
+func insertManagedSharedDBPool(ctx context.Context, execer managedSharedDBExecer, values managedSharedDBInsertValues) (int64, error) {
+	res, err := execer.ExecContext(ctx, `INSERT INTO db_pool
 		(uuid, org_id, provisioning_key, cloud_provider, region, `+"`role`"+`, db_tls,
 		 db_password, db_name, max_tenants, tenant_count, soft_cap_reached, spending_limit, schema_version, status)
-		VALUES (?, ?, ?, ?, ?, ?, '', ?, ?, ?, 0, 0, ?, 0, ?)`, poolUUID, organizationID, in.ProvisioningKey,
-		in.CloudProvider, in.Region, SharedDBRoleShared, passwordCipher, databaseName,
-		in.MaxTenants, *in.SpendingLimit,
+		VALUES (?, ?, ?, ?, ?, ?, '', ?, ?, ?, 0, 0, ?, 0, ?)`, values.poolUUID, values.organizationID, values.provisioningKey,
+		values.cloudProvider, values.region, SharedDBRoleShared, values.passwordCipher, values.databaseName,
+		values.maxTenants, values.spendingLimit,
 		SharedDBStatusPending)
 	if err != nil {
 		return 0, fmt.Errorf("insert managed db_pool row: %w", err)
 	}
-	id, err = res.LastInsertId()
+	id, err := res.LastInsertId()
 	if err != nil {
 		return 0, fmt.Errorf("resolve managed db_pool id: %w", err)
 	}
@@ -386,6 +449,41 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 		s.apiKeys.evictTenant(tenantID)
 	}
 	return nil
+}
+
+// TouchManagedSharedDBPools records observed Cloud progress without changing
+// lifecycle state. The expected-status guard prevents a late metadata poll
+// from refreshing a pool already failed by the watchdog.
+func (s *Store) TouchManagedSharedDBPools(ctx context.Context, dbIDs []int64, expectedStatus string) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "touch_managed_shared_db_pools", start, &err)
+	if expectedStatus != SharedDBStatusPending && expectedStatus != SharedDBStatusProvisioning {
+		return fmt.Errorf("unsupported shared db heartbeat status %q", expectedStatus)
+	}
+	ids := make([]int64, 0, len(dbIDs))
+	seen := make(map[int64]struct{}, len(dbIDs))
+	for _, dbID := range dbIDs {
+		if dbID <= 0 {
+			continue
+		}
+		if _, ok := seen[dbID]; ok {
+			continue
+		}
+		seen[dbID] = struct{}{}
+		ids = append(ids, dbID)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
+	args := make([]any, 0, 3+len(ids))
+	args = append(args, time.Now().UTC(), SharedDBRoleShared, expectedStatus)
+	for _, dbID := range ids {
+		args = append(args, dbID)
+	}
+	_, err = s.db.ExecContext(ctx, `UPDATE db_pool SET updated_at = ?
+		WHERE `+"`role`"+` = ? AND status = ? AND db_id IN (`+placeholders+`)`, args...)
+	return err
 }
 
 // PrepareManagedSharedDBPoolRoot durably stores the root credential and
@@ -636,6 +734,29 @@ func (s *Store) ClearFailedSharedDBPoolClusterID(ctx context.Context, dbID int64
 	}
 	affected, err := res.RowsAffected()
 	return affected == 1, err
+}
+
+// RepairFailedSharedDBPoolTenantCountIfEmpty repairs denormalized positive
+// drift only when the authoritative placement set is empty.
+func (s *Store) RepairFailedSharedDBPoolTenantCountIfEmpty(ctx context.Context, dbID int64) (repaired bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "repair_failed_shared_db_pool_tenant_count", start, &err)
+	if dbID <= 0 {
+		return false, fmt.Errorf("db_id must be positive")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool
+		SET tenant_count = 0, soft_cap_reached = 0, updated_at = ?
+		WHERE db_id = ? AND role = ? AND status = ? AND tenant_count <> 0
+			AND NOT EXISTS (SELECT 1 FROM tenant_placements p WHERE p.db_id = db_pool.db_id)`,
+		time.Now().UTC(), dbID, SharedDBRoleShared, SharedDBStatusFailed)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return false, err
+	}
+	return affected == 1, nil
 }
 
 // DeleteFailedSharedDBPoolIfEmpty removes only a locally empty failed pool

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -595,7 +595,7 @@ func (s *Store) MarkStuckSharedDBPoolFailed(ctx context.Context, dbID int64, exp
 			return err
 		}
 		if affected != 1 {
-			return nil
+			return fmt.Errorf("fail stuck shared db pool %d affected %d rows, want 1", dbID, affected)
 		}
 		changed = true
 		result = &StuckSharedDBPoolFailure{

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -451,41 +451,6 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 	return nil
 }
 
-// TouchManagedSharedDBPools records observed Cloud progress without changing
-// lifecycle state. The expected-status guard prevents a late metadata poll
-// from refreshing a pool already failed by the watchdog.
-func (s *Store) TouchManagedSharedDBPools(ctx context.Context, dbIDs []int64, expectedStatus string) (err error) {
-	start := time.Now()
-	defer observeMeta(ctx, "touch_managed_shared_db_pools", start, &err)
-	if expectedStatus != SharedDBStatusPending && expectedStatus != SharedDBStatusProvisioning {
-		return fmt.Errorf("unsupported shared db heartbeat status %q", expectedStatus)
-	}
-	ids := make([]int64, 0, len(dbIDs))
-	seen := make(map[int64]struct{}, len(dbIDs))
-	for _, dbID := range dbIDs {
-		if dbID <= 0 {
-			continue
-		}
-		if _, ok := seen[dbID]; ok {
-			continue
-		}
-		seen[dbID] = struct{}{}
-		ids = append(ids, dbID)
-	}
-	if len(ids) == 0 {
-		return nil
-	}
-	placeholders := strings.TrimRight(strings.Repeat("?,", len(ids)), ",")
-	args := make([]any, 0, 3+len(ids))
-	args = append(args, time.Now().UTC(), SharedDBRoleShared, expectedStatus)
-	for _, dbID := range ids {
-		args = append(args, dbID)
-	}
-	_, err = s.db.ExecContext(ctx, `UPDATE db_pool SET updated_at = ?
-		WHERE `+"`role`"+` = ? AND status = ? AND db_id IN (`+placeholders+`)`, args...)
-	return err
-}
-
 // PrepareManagedSharedDBPoolRoot durably stores the root credential and
 // database name before the first Cloud create call. It is idempotent for a
 // pending row that has not yet acquired a cluster identity.

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -782,6 +782,45 @@ func (s *Store) listSharedDBsByStatusAfter(ctx context.Context, status string, a
 	return out, rows.Err()
 }
 
+// ListActiveSharedDBsWithProvisioningTenantsAfter returns active physical
+// pools that still have an eligible shared tenant awaiting final activation.
+// This is the durable recovery path for a crash after physical activation but
+// before ActivateSharedTenantsBatch finishes.
+func (s *Store) ListActiveSharedDBsWithProvisioningTenantsAfter(ctx context.Context, afterID int64, limit int) (out []*SharedDB, err error) {
+	if afterID < 0 {
+		return nil, fmt.Errorf("after db id must not be negative")
+	}
+	if limit <= 0 {
+		limit = 1000
+	}
+	rows, err := s.db.QueryContext(ctx, "SELECT "+sharedDBSelectColumns+` FROM db_pool d
+		WHERE d.`+"`role`"+` = ? AND d.status = ? AND d.db_id > ?
+			AND EXISTS (
+				SELECT 1 FROM tenant_placements p
+				JOIN fs_registry f ON f.fs_id = p.fs_id
+				JOIN tenants t ON t.id = f.tenant_id
+				WHERE p.db_id = d.db_id AND p.status = ? AND t.provider = ? AND t.status = ?
+					AND (EXISTS (SELECT 1 FROM tenant_api_keys k
+						WHERE k.tenant_id = t.id AND k.scope_kind = ? AND k.status = ?)
+						OR EXISTS (SELECT 1 FROM tenant_pool_memberships m
+							WHERE m.tenant_id = t.id AND m.pool_status = ?)))
+		ORDER BY d.db_id LIMIT ?`, SharedDBRoleShared, SharedDBStatusActive, afterID,
+		SharedDBStatusActive, tidbCloudNativeSharedProvider, TenantProvisioning,
+		APIKeyScopeKindOwner, APIKeyActive, TenantPoolBindingFree, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list active shared dbs with provisioning tenants: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		rec, scanErr := scanSharedDBScanner(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, rec)
+	}
+	return out, rows.Err()
+}
+
 // FindSharedDBForAllocation selects the oldest eligible exact-organization
 // pool, preferring active over provisioning over pending. Managed rows use one fixed
 // physical spending limit, so tenant virtual values do not participate in

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -204,38 +204,6 @@ func (s *Store) CreateManagedSharedDBPool(ctx context.Context, in *SharedDB) (id
 	return insertManagedSharedDBPool(ctx, s.db, values)
 }
 
-// CreateManagedSharedDBPools atomically persists one complete physical refill
-// wave. A failure in any partition rolls back every plan in the wave.
-func (s *Store) CreateManagedSharedDBPools(ctx context.Context, inputs []*SharedDB) (ids []int64, err error) {
-	start := time.Now()
-	defer observeMeta(ctx, "create_managed_shared_db_pools", start, &err)
-	if len(inputs) == 0 {
-		return []int64{}, nil
-	}
-	values := make([]managedSharedDBInsertValues, len(inputs))
-	for i, in := range inputs {
-		values[i], err = managedSharedDBInsertValuesFor(in)
-		if err != nil {
-			return nil, fmt.Errorf("validate managed db pool %d: %w", i, err)
-		}
-	}
-	ids = make([]int64, len(values))
-	err = s.InTx(ctx, func(tx *sql.Tx) error {
-		for i := range values {
-			id, insertErr := insertManagedSharedDBPool(ctx, tx, values[i])
-			if insertErr != nil {
-				return fmt.Errorf("insert managed db pool %d: %w", i, insertErr)
-			}
-			ids[i] = id
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, err
-	}
-	return ids, nil
-}
-
 type managedSharedDBInsertValues struct {
 	poolUUID        string
 	organizationID  string
@@ -787,6 +755,8 @@ func (s *Store) listSharedDBsByStatusAfter(ctx context.Context, status string, a
 // This is the durable recovery path for a crash after physical activation but
 // before ActivateSharedTenantsBatch finishes.
 func (s *Store) ListActiveSharedDBsWithProvisioningTenantsAfter(ctx context.Context, afterID int64, limit int) (out []*SharedDB, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_active_shared_dbs_with_provisioning_tenants_after", start, &err)
 	if afterID < 0 {
 		return nil, fmt.Errorf("after db id must not be negative")
 	}

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -140,6 +140,14 @@ type SharedDB struct {
 	UpdatedAt               time.Time
 }
 
+// StuckSharedDBPoolFailure identifies the durable work released when a
+// pending or provisioning physical shared DB makes no progress before a
+// caller-provided cutoff.
+type StuckSharedDBPoolFailure struct {
+	DBID      int64
+	TenantIDs []string
+}
+
 // TenantPlacement maps one filesystem (fs_id) to the physical database that
 // hosts it. TargetDbID is reserved for future migrations; Epoch is reserved
 // for optimistic concurrency during migrations and stays 1 unless a migration
@@ -512,10 +520,156 @@ func (s *Store) MarkSharedDBPoolFailed(ctx context.Context, dbID int64) error {
 	return nil
 }
 
+// MarkStuckSharedDBPoolFailed atomically fails a stale physical pool and its
+// still-pending/provisioning shared tenants. The expected status and
+// updatedBefore cutoff form a CAS guard so concurrent metadata/schema progress
+// wins over the watchdog.
+func (s *Store) MarkStuckSharedDBPoolFailed(ctx context.Context, dbID int64, expectedStatus string, updatedBefore time.Time) (result *StuckSharedDBPoolFailure, changed bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "mark_stuck_shared_db_pool_failed", start, &err)
+	if dbID <= 0 {
+		return nil, false, fmt.Errorf("db_id must be positive")
+	}
+	if expectedStatus != SharedDBStatusPending && expectedStatus != SharedDBStatusProvisioning {
+		return nil, false, fmt.Errorf("unsupported stuck shared db status %q", expectedStatus)
+	}
+	cutoff := updatedBefore.UTC()
+	var tenantIDs []string
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		var status string
+		var updatedAt time.Time
+		if err := tx.QueryRowContext(ctx, `SELECT status, updated_at
+			FROM db_pool WHERE db_id = ? AND role = ? FOR UPDATE`, dbID, SharedDBRoleShared).
+			Scan(&status, &updatedAt); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return err
+		}
+		if status != expectedStatus || updatedAt.After(cutoff) {
+			return nil
+		}
+		rows, err := tx.QueryContext(ctx, `SELECT t.id
+			FROM tenant_placements p
+			JOIN fs_registry f ON f.fs_id = p.fs_id
+			JOIN tenants t ON t.id = f.tenant_id
+			WHERE p.db_id = ? AND t.provider = ? AND t.status IN (?, ?)
+			ORDER BY t.id`, dbID, tidbCloudNativeSharedProvider, TenantPending, TenantProvisioning)
+		if err != nil {
+			return fmt.Errorf("list stuck shared tenants for db pool %d: %w", dbID, err)
+		}
+		for rows.Next() {
+			var tenantID string
+			if err := rows.Scan(&tenantID); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			tenantIDs = append(tenantIDs, tenantID)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+		now := time.Now().UTC()
+		if _, err := tx.ExecContext(ctx, `UPDATE tenants t
+			JOIN fs_registry f ON f.tenant_id = t.id
+			JOIN tenant_placements p ON p.fs_id = f.fs_id
+			SET t.status = ?, t.updated_at = ?
+			WHERE p.db_id = ? AND t.provider = ? AND t.status IN (?, ?)`,
+			TenantFailed, now, dbID, tidbCloudNativeSharedProvider, TenantPending, TenantProvisioning); err != nil {
+			return fmt.Errorf("fail stuck shared tenants for db pool %d: %w", dbID, err)
+		}
+		res, err := tx.ExecContext(ctx, `UPDATE db_pool SET status = ?, updated_at = ?
+			WHERE db_id = ? AND role = ? AND status = ? AND updated_at <= ?`,
+			SharedDBStatusFailed, now, dbID, SharedDBRoleShared, expectedStatus, cutoff)
+		if err != nil {
+			return fmt.Errorf("fail stuck shared db pool %d: %w", dbID, err)
+		}
+		affected, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if affected != 1 {
+			return nil
+		}
+		changed = true
+		result = &StuckSharedDBPoolFailure{
+			DBID: dbID, TenantIDs: append([]string(nil), tenantIDs...),
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	if changed {
+		for _, tenantID := range tenantIDs {
+			s.apiKeys.evictTenant(tenantID)
+		}
+	}
+	return result, changed, nil
+}
+
+// ClearFailedSharedDBPoolClusterID durably records successful Cloud deletion
+// before the local failed pool row is removed. The expected cluster ID makes
+// retries safe if the row changed concurrently.
+func (s *Store) ClearFailedSharedDBPoolClusterID(ctx context.Context, dbID int64, clusterID string) (cleared bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "clear_failed_shared_db_pool_cluster_id", start, &err)
+	if dbID <= 0 {
+		return false, fmt.Errorf("db_id must be positive")
+	}
+	clusterID = strings.TrimSpace(clusterID)
+	if clusterID == "" {
+		return false, fmt.Errorf("cluster_id is required")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool
+		SET cluster_id = NULL, updated_at = ?
+		WHERE db_id = ? AND role = ? AND status = ? AND tenant_count = 0 AND cluster_id = ?`,
+		time.Now().UTC(), dbID, SharedDBRoleShared, SharedDBStatusFailed, clusterID)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	return affected == 1, err
+}
+
+// DeleteFailedSharedDBPoolIfEmpty removes only a locally empty failed pool
+// whose Cloud identity has already been cleared (or never existed).
+func (s *Store) DeleteFailedSharedDBPoolIfEmpty(ctx context.Context, dbID int64) (deleted bool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "delete_failed_shared_db_pool_if_empty", start, &err)
+	if dbID <= 0 {
+		return false, fmt.Errorf("db_id must be positive")
+	}
+	res, err := s.db.ExecContext(ctx, `DELETE FROM db_pool
+		WHERE db_id = ? AND role = ? AND status = ? AND tenant_count = 0 AND cluster_id IS NULL
+			AND NOT EXISTS (SELECT 1 FROM tenant_placements p WHERE p.db_id = db_pool.db_id)`,
+		dbID, SharedDBRoleShared, SharedDBStatusFailed)
+	if err != nil {
+		return false, err
+	}
+	affected, err := res.RowsAffected()
+	return affected == 1, err
+}
+
 // ListSharedDBsByStatus returns shared DB-pool rows in stable ID order.
 func (s *Store) ListSharedDBsByStatus(ctx context.Context, status string, limit int) (out []*SharedDB, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "list_shared_dbs_by_status", start, &err)
+	return s.listSharedDBsByStatusAfter(ctx, status, 0, limit)
+}
+
+// ListSharedDBsByStatusAfter returns one stable keyset page ordered by db_id.
+func (s *Store) ListSharedDBsByStatusAfter(ctx context.Context, status string, afterID int64, limit int) (out []*SharedDB, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_shared_dbs_by_status_after", start, &err)
+	return s.listSharedDBsByStatusAfter(ctx, status, afterID, limit)
+}
+
+func (s *Store) listSharedDBsByStatusAfter(ctx context.Context, status string, afterID int64, limit int) (out []*SharedDB, err error) {
 	switch status {
 	case SharedDBStatusPending, SharedDBStatusProvisioning, SharedDBStatusActive, SharedDBStatusFailed, SharedDBStatusDraining:
 	default:
@@ -525,7 +679,7 @@ func (s *Store) ListSharedDBsByStatus(ctx context.Context, status string, limit 
 		limit = 1000
 	}
 	rows, err := s.db.QueryContext(ctx, "SELECT "+sharedDBSelectColumns+" FROM db_pool "+
-		"WHERE `role` = ? AND status = ? ORDER BY db_id LIMIT ?", SharedDBRoleShared, status, limit)
+		"WHERE `role` = ? AND status = ? AND db_id > ? ORDER BY db_id LIMIT ?", SharedDBRoleShared, status, afterID, limit)
 	if err != nil {
 		return nil, fmt.Errorf("list shared dbs in status %q: %w", status, err)
 	}

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -549,12 +549,14 @@ func (s *Store) MarkStuckSharedDBPoolFailed(ctx context.Context, dbID int64, exp
 		if status != expectedStatus || updatedAt.After(cutoff) {
 			return nil
 		}
+		// Lock the matching tenant rows so the IDs returned to cache eviction and
+		// logs are exactly the rows the conditional failure update can transition.
 		rows, err := tx.QueryContext(ctx, `SELECT t.id
 			FROM tenant_placements p
 			JOIN fs_registry f ON f.fs_id = p.fs_id
 			JOIN tenants t ON t.id = f.tenant_id
 			WHERE p.db_id = ? AND t.provider = ? AND t.status IN (?, ?)
-			ORDER BY t.id`, dbID, tidbCloudNativeSharedProvider, TenantPending, TenantProvisioning)
+			ORDER BY t.id FOR UPDATE`, dbID, tidbCloudNativeSharedProvider, TenantPending, TenantProvisioning)
 		if err != nil {
 			return fmt.Errorf("list stuck shared tenants for db pool %d: %w", dbID, err)
 		}

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -10,6 +10,10 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
 )
 
 func TestSharedDBCapacityBounds(t *testing.T) {
@@ -943,6 +947,40 @@ func TestCompleteSharedTenantProvisionSoftHardCapacityAndHysteresis(t *testing.T
 	}
 	if _, err := s.GetTenantPlacement(ctx, fs1); err != nil {
 		t.Fatalf("remaining placement: %v", err)
+	}
+}
+
+func TestCompleteSharedTenantProvisionCapacityMissDoesNotLogError(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-capacity-log", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 1, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?, cluster_id = 'cluster-capacity-log'
+		WHERE db_id = ?`, SharedDBStatusActive, dbID); err != nil {
+		t.Fatal(err)
+	}
+	completeTestSharedTenant(t, s, dbID, "tenant-capacity-log-full", 0)
+	seedPendingTenant(t, s, "tenant-capacity-log-rejected")
+	fsID, err := s.EnsureFsID(ctx, "tenant-capacity-log-rejected")
+	if err != nil {
+		t.Fatal(err)
+	}
+	core, logs := observer.New(zap.ErrorLevel)
+	logCtx := logger.WithContext(ctx, zap.New(core))
+	err = s.CompleteSharedTenantProvision(logCtx, "tenant-capacity-log-rejected", "tidb_cloud_native_shared",
+		&TenantPlacement{FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared},
+		testOwnerKey("tenant-capacity-log-rejected"))
+	if !errors.Is(err, ErrSharedDBCapacityExhausted) {
+		t.Fatalf("capacity error = %v, want ErrSharedDBCapacityExhausted", err)
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("capacity miss emitted %d error logs, want none: %+v", logs.Len(), logs.All())
 	}
 }
 

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -59,29 +59,6 @@ func TestSharedDBCapacityBounds(t *testing.T) {
 	}
 }
 
-func TestCreateManagedSharedDBPoolsRollsBackWholeWave(t *testing.T) {
-	s := newControlStore(t)
-	ctx := context.Background()
-	spendingLimit := MaxTiDBCloudSpendingLimit
-	duplicateUUID := "8a347c9f-6f08-49e9-a459-25bef73cbf2f"
-	inputs := []*SharedDB{
-		{UUID: duplicateUUID, TiDBCloudOrganizationID: "org-atomic-wave", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
-			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit},
-		{UUID: duplicateUUID, TiDBCloudOrganizationID: "org-atomic-wave", ProvisioningKey: bytes.Repeat([]byte{2}, 32),
-			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit},
-	}
-	if _, err := s.CreateManagedSharedDBPools(ctx, inputs); err == nil {
-		t.Fatal("CreateManagedSharedDBPools succeeded with a duplicate UUID inside the wave")
-	}
-	var rows int
-	if err := s.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, "org-atomic-wave").Scan(&rows); err != nil {
-		t.Fatal(err)
-	}
-	if rows != 0 {
-		t.Fatalf("physical plans after failed wave = %d, want atomic rollback", rows)
-	}
-}
-
 func TestSharedDBReopenThresholdForRatio(t *testing.T) {
 	got, err := SharedDBReopenThresholdForRatio(10, 0.65)
 	if err != nil {

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -417,7 +417,73 @@ func TestCountTenantPoolPlannedSlotsUsesSharedPoolProgressLease(t *testing.T) {
 		t.Fatalf("CountTenantPoolPlannedSlots: %v", err)
 	}
 	if planned != 1 {
-		t.Fatalf("planned slots = %d, want only the unexpired shared plan", planned)
+		t.Fatalf("planned slots = %d, want only the assigned tenant in the unexpired shared plan", planned)
+	}
+}
+
+func TestCountTenantPoolPlannedSlotsIncludesRecentUnstartedPhysicalPool(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	if _, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-unstarted-physical-plan", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	}); err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	planned, err := s.CountTenantPoolPlannedSlots(ctx, "org-unstarted-physical-plan", time.Now().UTC().Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("CountTenantPoolPlannedSlots: %v", err)
+	}
+	if planned != 100 {
+		t.Fatalf("planned slots = %d, want the full capacity of the unstarted staged pool", planned)
+	}
+}
+
+func TestCountTenantPoolPlannedSlotsIncludesRecentActivePoolPlacementGap(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-active-placement-gap", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	for i := 0; i < 2; i++ {
+		tenantID := fmt.Sprintf("tenant-active-placement-gap-%d", i)
+		seedPendingTenant(t, s, tenantID)
+		fsID, err := s.EnsureFsID(ctx, tenantID)
+		if err != nil {
+			t.Fatalf("EnsureFsID %d: %v", i, err)
+		}
+		if err := s.CompleteSharedTenantPoolMember(ctx, tenantID, tidbCloudNativeSharedProvider,
+			&TenantPlacement{FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared},
+			&TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: "org-active-placement-gap",
+				PoolID: "logical-active-placement-gap", PoolStatus: TenantPoolBindingFree}); err != nil {
+			t.Fatalf("CompleteSharedTenantPoolMember %d: %v", i, err)
+		}
+	}
+	if err := s.UpdateTenantStatus(ctx, "tenant-active-placement-gap-0", TenantActive); err != nil {
+		t.Fatalf("activate tenant: %v", err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET status = ?, updated_at = ? WHERE db_id = ?`,
+		SharedDBStatusActive, now, dbID); err != nil {
+		t.Fatalf("activate db pool: %v", err)
+	}
+
+	active, err := s.CountFreeTenantPoolBindings(ctx, "org-active-placement-gap")
+	if err != nil {
+		t.Fatalf("CountFreeTenantPoolBindings: %v", err)
+	}
+	planned, err := s.CountTenantPoolPlannedSlots(ctx, "org-active-placement-gap", now.Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("CountTenantPoolPlannedSlots: %v", err)
+	}
+	if active != 1 || planned != 1 || active+planned != 2 {
+		t.Fatalf("active=%d planned=%d total=%d, want only assigned inventory: active=1 planned=1 total=2", active, planned, active+planned)
 	}
 }
 

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -59,6 +59,29 @@ func TestSharedDBCapacityBounds(t *testing.T) {
 	}
 }
 
+func TestCreateManagedSharedDBPoolsRollsBackWholeWave(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	duplicateUUID := "8a347c9f-6f08-49e9-a459-25bef73cbf2f"
+	inputs := []*SharedDB{
+		{UUID: duplicateUUID, TiDBCloudOrganizationID: "org-atomic-wave", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit},
+		{UUID: duplicateUUID, TiDBCloudOrganizationID: "org-atomic-wave", ProvisioningKey: bytes.Repeat([]byte{2}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit},
+	}
+	if _, err := s.CreateManagedSharedDBPools(ctx, inputs); err == nil {
+		t.Fatal("CreateManagedSharedDBPools succeeded with a duplicate UUID inside the wave")
+	}
+	var rows int
+	if err := s.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, "org-atomic-wave").Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != 0 {
+		t.Fatalf("physical plans after failed wave = %d, want atomic rollback", rows)
+	}
+}
+
 func TestSharedDBReopenThresholdForRatio(t *testing.T) {
 	got, err := SharedDBReopenThresholdForRatio(10, 0.65)
 	if err != nil {
@@ -355,6 +378,112 @@ func TestMarkStuckSharedDBPoolFailedUsesStatusAndUpdatedAtCAS(t *testing.T) {
 	}
 	if result, changed, err := s.MarkStuckSharedDBPoolFailed(ctx, dbID, SharedDBStatusProvisioning, cutoff); err != nil || changed || result != nil {
 		t.Fatalf("wrong-status result=%+v changed=%v err=%v, want unchanged", result, changed, err)
+	}
+}
+
+func TestCountTenantPoolPlannedSlotsUsesSharedPoolProgressLease(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	cutoff := now.Add(-time.Minute)
+	for i, updatedAt := range []time.Time{cutoff.Add(time.Second), cutoff.Add(-time.Second)} {
+		dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+			TiDBCloudOrganizationID: "org-planned-lease", ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+		})
+		if err != nil {
+			t.Fatalf("CreateManagedSharedDBPool %d: %v", i, err)
+		}
+		tenantID := fmt.Sprintf("tenant-planned-lease-%d", i)
+		seedPendingTenant(t, s, tenantID)
+		fsID, err := s.EnsureFsID(ctx, tenantID)
+		if err != nil {
+			t.Fatalf("EnsureFsID %d: %v", i, err)
+		}
+		if err := s.CompleteSharedTenantPoolMember(ctx, tenantID, tidbCloudNativeSharedProvider,
+			&TenantPlacement{FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared},
+			&TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: "org-planned-lease",
+				PoolID: "logical-planned-lease", PoolStatus: TenantPoolBindingFree}); err != nil {
+			t.Fatalf("CompleteSharedTenantPoolMember %d: %v", i, err)
+		}
+		if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, updatedAt, dbID); err != nil {
+			t.Fatalf("set db_pool updated_at %d: %v", i, err)
+		}
+	}
+
+	planned, err := s.CountTenantPoolPlannedSlots(ctx, "org-planned-lease", cutoff)
+	if err != nil {
+		t.Fatalf("CountTenantPoolPlannedSlots: %v", err)
+	}
+	if planned != 1 {
+		t.Fatalf("planned slots = %d, want only the unexpired shared plan", planned)
+	}
+}
+
+func TestTouchManagedSharedDBPoolsHeartbeatsOnlyExpectedStatus(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	ids := make([]int64, 0, 2)
+	for i := 0; i < 2; i++ {
+		dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+			TiDBCloudOrganizationID: fmt.Sprintf("org-heartbeat-%d", i), ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, dbID)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, SharedDBStatusFailed, ids[1]); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id IN (?, ?)`, old, ids[0], ids[1]); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.TouchManagedSharedDBPools(ctx, ids, SharedDBStatusPending); err != nil {
+		t.Fatalf("TouchManagedSharedDBPools: %v", err)
+	}
+	for i, dbID := range ids {
+		row, err := s.GetSharedDB(ctx, dbID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if i == 0 && !row.UpdatedAt.After(old) {
+			t.Fatalf("pending pool updated_at = %s, want heartbeat after %s", row.UpdatedAt, old)
+		}
+		if i == 1 && !row.UpdatedAt.Equal(old) {
+			t.Fatalf("failed pool updated_at = %s, want unchanged %s", row.UpdatedAt, old)
+		}
+	}
+}
+
+func TestRepairFailedSharedDBPoolTenantCountUsesPlacementsAsTruth(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-count-repair", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET status = ?, tenant_count = 7 WHERE db_id = ?`, SharedDBStatusFailed, dbID); err != nil {
+		t.Fatal(err)
+	}
+	repaired, err := s.RepairFailedSharedDBPoolTenantCountIfEmpty(ctx, dbID)
+	if err != nil || !repaired {
+		t.Fatalf("RepairFailedSharedDBPoolTenantCountIfEmpty repaired=%v err=%v", repaired, err)
+	}
+	row, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.TenantCount != 0 {
+		t.Fatalf("tenant_count = %d, want repaired to zero", row.TenantCount)
 	}
 }
 

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -353,6 +353,16 @@ func TestMarkStuckSharedDBPoolFailedAtomicallyFailsPlacedPoolTenants(t *testing.
 			if err != nil || slots != 0 {
 				t.Fatalf("free slots after failure = %d, %v; want 0", slots, err)
 			}
+			lateResult := &SharedDB{ID: dbID, TiDBCloudOrganizationID: "org-stuck",
+				ClusterID: "cluster-late-" + tt.name, Host: "late.example.com", Port: 4000, User: "root",
+				PasswordCipher: []byte("cipher"), Name: "tidbcloud_fs", TLSMode: "true"}
+			if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, lateResult); !errors.Is(err, ErrNotFound) {
+				t.Fatalf("late cloud result after terminal failure = %v, want ErrNotFound", err)
+			}
+			pool, err = s.GetSharedDB(ctx, dbID)
+			if err != nil || pool.Status != SharedDBStatusFailed {
+				t.Fatalf("late cloud result revived failed pool = %+v, %v", pool, err)
+			}
 		})
 	}
 }
@@ -381,13 +391,12 @@ func TestMarkStuckSharedDBPoolFailedUsesStatusAndUpdatedAtCAS(t *testing.T) {
 	}
 }
 
-func TestCountTenantPoolPlannedSlotsUsesSharedPoolProgressLease(t *testing.T) {
+func TestCountTenantPoolPlannedSlotsUsesTerminalState(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 	spendingLimit := MaxTiDBCloudSpendingLimit
 	now := time.Now().UTC().Truncate(time.Millisecond)
-	cutoff := now.Add(-time.Minute)
-	for i, updatedAt := range []time.Time{cutoff.Add(time.Second), cutoff.Add(-time.Second)} {
+	for i, updatedAt := range []time.Time{now.Add(-time.Second), now.Add(-24 * time.Hour)} {
 		dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
 			TiDBCloudOrganizationID: "org-planned-lease", ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
 			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
@@ -412,16 +421,27 @@ func TestCountTenantPoolPlannedSlotsUsesSharedPoolProgressLease(t *testing.T) {
 		}
 	}
 
-	planned, err := s.CountTenantPoolPlannedSlots(ctx, "org-planned-lease", cutoff)
+	planned, err := s.CountTenantPoolPlannedSlots(ctx, "org-planned-lease")
 	if err != nil {
 		t.Fatalf("CountTenantPoolPlannedSlots: %v", err)
 	}
+	if planned != 2 {
+		t.Fatalf("planned slots = %d, want both non-terminal assigned tenants regardless of age", planned)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE org_id = ? ORDER BY db_id LIMIT 1`,
+		SharedDBStatusFailed, "org-planned-lease"); err != nil {
+		t.Fatalf("fail one physical plan: %v", err)
+	}
+	planned, err = s.CountTenantPoolPlannedSlots(ctx, "org-planned-lease")
+	if err != nil {
+		t.Fatalf("CountTenantPoolPlannedSlots after terminal transition: %v", err)
+	}
 	if planned != 1 {
-		t.Fatalf("planned slots = %d, want only the assigned tenant in the unexpired shared plan", planned)
+		t.Fatalf("planned slots after one physical plan failed = %d, want 1", planned)
 	}
 }
 
-func TestCountTenantPoolPlannedSlotsIncludesRecentUnstartedPhysicalPool(t *testing.T) {
+func TestCountTenantPoolPlannedSlotsIncludesUnstartedPhysicalPool(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 	spendingLimit := MaxTiDBCloudSpendingLimit
@@ -431,7 +451,7 @@ func TestCountTenantPoolPlannedSlotsIncludesRecentUnstartedPhysicalPool(t *testi
 	}); err != nil {
 		t.Fatalf("CreateManagedSharedDBPool: %v", err)
 	}
-	planned, err := s.CountTenantPoolPlannedSlots(ctx, "org-unstarted-physical-plan", time.Now().UTC().Add(-time.Minute))
+	planned, err := s.CountTenantPoolPlannedSlots(ctx, "org-unstarted-physical-plan")
 	if err != nil {
 		t.Fatalf("CountTenantPoolPlannedSlots: %v", err)
 	}
@@ -440,7 +460,7 @@ func TestCountTenantPoolPlannedSlotsIncludesRecentUnstartedPhysicalPool(t *testi
 	}
 }
 
-func TestCountTenantPoolPlannedSlotsIncludesRecentActivePoolPlacementGap(t *testing.T) {
+func TestCountTenantPoolPlannedSlotsIncludesActivePoolPlacementGap(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
 	spendingLimit := MaxTiDBCloudSpendingLimit
@@ -478,7 +498,7 @@ func TestCountTenantPoolPlannedSlotsIncludesRecentActivePoolPlacementGap(t *test
 	if err != nil {
 		t.Fatalf("CountFreeTenantPoolBindings: %v", err)
 	}
-	planned, err := s.CountTenantPoolPlannedSlots(ctx, "org-active-placement-gap", now.Add(-time.Minute))
+	planned, err := s.CountTenantPoolPlannedSlots(ctx, "org-active-placement-gap")
 	if err != nil {
 		t.Fatalf("CountTenantPoolPlannedSlots: %v", err)
 	}

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"bytes"
 	"context"
+	"database/sql"
 	"errors"
 	"fmt"
 	"math"
@@ -354,6 +355,97 @@ func TestMarkStuckSharedDBPoolFailedUsesStatusAndUpdatedAtCAS(t *testing.T) {
 	}
 	if result, changed, err := s.MarkStuckSharedDBPoolFailed(ctx, dbID, SharedDBStatusProvisioning, cutoff); err != nil || changed || result != nil {
 		t.Fatalf("wrong-status result=%+v changed=%v err=%v, want unchanged", result, changed, err)
+	}
+}
+
+func TestMarkStuckSharedDBPoolFailedReturnsOnlyTransitionedTenantIDs(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-stuck-race", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	tenantID := "tenant-stuck-race"
+	seedPendingTenant(t, s, tenantID)
+	fsID, err := s.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if err := s.CompleteSharedTenantPoolMember(ctx, tenantID, tidbCloudNativeSharedProvider,
+		&TenantPlacement{FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared},
+		&TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: "org-stuck-race",
+			PoolID: "logical-stuck-race", PoolStatus: TenantPoolBindingFree}); err != nil {
+		t.Fatalf("CompleteSharedTenantPoolMember: %v", err)
+	}
+	stuckAt := time.Now().UTC().Add(-20 * time.Minute).Truncate(time.Millisecond)
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, stuckAt, dbID); err != nil {
+		t.Fatalf("age db pool: %v", err)
+	}
+
+	tenantTx, err := s.DB().BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tenant transition: %v", err)
+	}
+	t.Cleanup(func() { _ = tenantTx.Rollback() })
+	var status TenantStatus
+	if err := tenantTx.QueryRowContext(ctx, `SELECT status FROM tenants WHERE id = ? FOR UPDATE`, tenantID).Scan(&status); err != nil {
+		t.Fatalf("lock tenant: %v", err)
+	}
+	resultCh := make(chan struct {
+		result  *StuckSharedDBPoolFailure
+		changed bool
+		err     error
+	}, 1)
+	go func() {
+		result, changed, failErr := s.MarkStuckSharedDBPoolFailed(ctx, dbID, SharedDBStatusPending, time.Now().UTC().Add(-15*time.Minute))
+		resultCh <- struct {
+			result  *StuckSharedDBPoolFailure
+			changed bool
+			err     error
+		}{result: result, changed: changed, err: failErr}
+	}()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		probeTx, beginErr := s.DB().BeginTx(ctx, nil)
+		if beginErr != nil {
+			t.Fatalf("begin db pool lock probe: %v", beginErr)
+		}
+		var lockedID int64
+		probeErr := probeTx.QueryRowContext(ctx, `SELECT db_id FROM db_pool WHERE db_id = ? FOR UPDATE SKIP LOCKED`, dbID).Scan(&lockedID)
+		_ = probeTx.Rollback()
+		if errors.Is(probeErr, sql.ErrNoRows) {
+			break
+		}
+		if probeErr != nil {
+			t.Fatalf("probe db pool lock: %v", probeErr)
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("stuck-pool watchdog did not acquire the db_pool row")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	if _, err := tenantTx.ExecContext(ctx, `UPDATE tenants SET status = ? WHERE id = ?`, TenantDeleting, tenantID); err != nil {
+		t.Fatalf("advance tenant status: %v", err)
+	}
+	if err := tenantTx.Commit(); err != nil {
+		t.Fatalf("commit tenant transition: %v", err)
+	}
+
+	got := <-resultCh
+	if got.err != nil || !got.changed || got.result == nil {
+		t.Fatalf("failure result=%+v changed=%v err=%v", got.result, got.changed, got.err)
+	}
+	if len(got.result.TenantIDs) != 0 {
+		t.Fatalf("failed tenant IDs = %v, want none for tenant that advanced to deleting", got.result.TenantIDs)
+	}
+	tenantRow, err := s.GetTenant(ctx, tenantID)
+	if err != nil || tenantRow.Status != TenantDeleting {
+		t.Fatalf("tenant after watchdog = %+v, %v; want deleting", tenantRow, err)
 	}
 }
 

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -487,45 +487,6 @@ func TestCountTenantPoolPlannedSlotsIncludesRecentActivePoolPlacementGap(t *test
 	}
 }
 
-func TestTouchManagedSharedDBPoolsHeartbeatsOnlyExpectedStatus(t *testing.T) {
-	s := newControlStore(t)
-	ctx := context.Background()
-	spendingLimit := MaxTiDBCloudSpendingLimit
-	ids := make([]int64, 0, 2)
-	for i := 0; i < 2; i++ {
-		dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
-			TiDBCloudOrganizationID: fmt.Sprintf("org-heartbeat-%d", i), ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
-			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		ids = append(ids, dbID)
-	}
-	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, SharedDBStatusFailed, ids[1]); err != nil {
-		t.Fatal(err)
-	}
-	old := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
-	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id IN (?, ?)`, old, ids[0], ids[1]); err != nil {
-		t.Fatal(err)
-	}
-	if err := s.TouchManagedSharedDBPools(ctx, ids, SharedDBStatusPending); err != nil {
-		t.Fatalf("TouchManagedSharedDBPools: %v", err)
-	}
-	for i, dbID := range ids {
-		row, err := s.GetSharedDB(ctx, dbID)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if i == 0 && !row.UpdatedAt.After(old) {
-			t.Fatalf("pending pool updated_at = %s, want heartbeat after %s", row.UpdatedAt, old)
-		}
-		if i == 1 && !row.UpdatedAt.Equal(old) {
-			t.Fatalf("failed pool updated_at = %s, want unchanged %s", row.UpdatedAt, old)
-		}
-	}
-}
-
 func TestRepairFailedSharedDBPoolTenantCountUsesPlacementsAsTruth(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -259,6 +259,183 @@ func TestMarkSharedDBPoolFailedRejectsPoolWithTenants(t *testing.T) {
 	}
 }
 
+func TestMarkStuckSharedDBPoolFailedAtomicallyFailsPlacedPoolTenants(t *testing.T) {
+	tests := []struct {
+		name          string
+		poolStatus    string
+		tenantStatus  TenantStatus
+		completeCloud bool
+	}{
+		{name: "pending", poolStatus: SharedDBStatusPending, tenantStatus: TenantPending},
+		{name: "provisioning", poolStatus: SharedDBStatusProvisioning, tenantStatus: TenantProvisioning, completeCloud: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newControlStore(t)
+			ctx := context.Background()
+			spendingLimit := MaxTiDBCloudSpendingLimit
+			dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+				TiDBCloudOrganizationID: "org-stuck", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+				CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+			})
+			if err != nil {
+				t.Fatalf("CreateManagedSharedDBPool: %v", err)
+			}
+			seedPendingTenant(t, s, "tenant-stuck-"+tt.name)
+			fsID, err := s.EnsureFsID(ctx, "tenant-stuck-"+tt.name)
+			if err != nil {
+				t.Fatalf("EnsureFsID: %v", err)
+			}
+			if err := s.CompleteSharedTenantPoolMember(ctx, "tenant-stuck-"+tt.name, tidbCloudNativeSharedProvider,
+				&TenantPlacement{FsID: fsID, DbID: dbID, Placement: PlacementShared, SchemaShape: SchemaShapeShared},
+				&TenantPoolMembership{TenantID: "tenant-stuck-" + tt.name, TiDBCloudOrganizationID: "org-stuck",
+					PoolID: "logical-stuck", PoolStatus: TenantPoolBindingFree}); err != nil {
+				t.Fatalf("CompleteSharedTenantPoolMember: %v", err)
+			}
+			if tt.completeCloud {
+				if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, &SharedDB{
+					ID: dbID, TiDBCloudOrganizationID: "org-stuck", ClusterID: "cluster-stuck-" + tt.name,
+					Host: "shared.example.com", Port: 4000, User: "root", PasswordCipher: []byte("cipher"),
+					Name: "tidbcloud_fs", TLSMode: "true",
+				}); err != nil {
+					t.Fatalf("UpdateManagedSharedDBPoolCloudResult: %v", err)
+				}
+			}
+			stuckAt := time.Now().UTC().Add(-20 * time.Minute).Truncate(time.Millisecond)
+			if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, stuckAt, dbID); err != nil {
+				t.Fatalf("age db pool: %v", err)
+			}
+
+			result, changed, err := s.MarkStuckSharedDBPoolFailed(ctx, dbID, tt.poolStatus, time.Now().UTC().Add(-15*time.Minute))
+			if err != nil {
+				t.Fatalf("MarkStuckSharedDBPoolFailed: %v", err)
+			}
+			if !changed || result == nil || result.DBID != dbID || fmt.Sprint(result.TenantIDs) != "[tenant-stuck-"+tt.name+"]" {
+				t.Fatalf("failure result = %+v changed=%v", result, changed)
+			}
+			pool, err := s.GetSharedDB(ctx, dbID)
+			if err != nil || pool.Status != SharedDBStatusFailed {
+				t.Fatalf("failed pool = %+v, %v", pool, err)
+			}
+			tenant, err := s.GetTenant(ctx, "tenant-stuck-"+tt.name)
+			if err != nil || tenant.Status != TenantFailed {
+				t.Fatalf("failed tenant = %+v, %v; previous status %q", tenant, err, tt.tenantStatus)
+			}
+			slots, err := s.CountTenantPoolFreeSlots(ctx, "org-stuck")
+			if err != nil || slots != 0 {
+				t.Fatalf("free slots after failure = %d, %v; want 0", slots, err)
+			}
+		})
+	}
+}
+
+func TestMarkStuckSharedDBPoolFailedUsesStatusAndUpdatedAtCAS(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-not-stuck", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	cutoff := time.Now().UTC().Add(-15 * time.Minute)
+	if result, changed, err := s.MarkStuckSharedDBPoolFailed(ctx, dbID, SharedDBStatusPending, cutoff); err != nil || changed || result != nil {
+		t.Fatalf("recent pool result=%+v changed=%v err=%v, want unchanged", result, changed, err)
+	}
+	old := cutoff.Add(-time.Minute)
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, old, dbID); err != nil {
+		t.Fatalf("age db pool: %v", err)
+	}
+	if result, changed, err := s.MarkStuckSharedDBPoolFailed(ctx, dbID, SharedDBStatusProvisioning, cutoff); err != nil || changed || result != nil {
+		t.Fatalf("wrong-status result=%+v changed=%v err=%v, want unchanged", result, changed, err)
+	}
+}
+
+func TestManagedSharedDBUpdatedAtTracksProgressNotNoOpPolls(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-progress", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	passwordCipher := []byte("cipher")
+	if err := s.PrepareManagedSharedDBPoolRoot(ctx, dbID, passwordCipher, "tidbcloud_fs"); err != nil {
+		t.Fatalf("PrepareManagedSharedDBPoolRoot: %v", err)
+	}
+	partial := &SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-progress", ClusterID: "cluster-progress",
+		PasswordCipher: passwordCipher, Name: "tidbcloud_fs", TLSMode: "skip-verify",
+	}
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, partial); err != nil {
+		t.Fatalf("persist initial partial metadata: %v", err)
+	}
+	stuckAt := time.Now().UTC().Add(-20 * time.Minute).Truncate(time.Millisecond)
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, stuckAt, dbID); err != nil {
+		t.Fatalf("age pending pool: %v", err)
+	}
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, partial); err != nil {
+		t.Fatalf("repeat identical partial metadata: %v", err)
+	}
+	unchanged, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB after no-op poll: %v", err)
+	}
+	if !unchanged.UpdatedAt.Equal(stuckAt) || unchanged.Status != SharedDBStatusPending {
+		t.Fatalf("no-op poll updated pool to status=%s updated_at=%s, want pending at %s",
+			unchanged.Status, unchanged.UpdatedAt, stuckAt)
+	}
+	ready := *partial
+	ready.Host = "shared.example.com"
+	ready.Port = 4000
+	ready.User = "root"
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, &ready); err != nil {
+		t.Fatalf("persist ready metadata: %v", err)
+	}
+	progressed, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB after metadata progress: %v", err)
+	}
+	if progressed.Status != SharedDBStatusProvisioning || !progressed.UpdatedAt.After(stuckAt) {
+		t.Fatalf("metadata progress left pool status=%s updated_at=%s, want provisioning after %s",
+			progressed.Status, progressed.UpdatedAt, stuckAt)
+	}
+}
+
+func TestFinalizeFailedSharedDBPoolCleanupClearsCloudIdentityBeforeDelete(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-cleanup", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET status = ?, cluster_id = ? WHERE db_id = ?`,
+		SharedDBStatusFailed, "cluster-cleanup", dbID); err != nil {
+		t.Fatalf("prepare failed pool: %v", err)
+	}
+	if cleared, err := s.ClearFailedSharedDBPoolClusterID(ctx, dbID, "wrong-cluster"); err != nil || cleared {
+		t.Fatalf("wrong cluster clear = %v, %v; want false", cleared, err)
+	}
+	if cleared, err := s.ClearFailedSharedDBPoolClusterID(ctx, dbID, "cluster-cleanup"); err != nil || !cleared {
+		t.Fatalf("cluster clear = %v, %v; want true", cleared, err)
+	}
+	if deleted, err := s.DeleteFailedSharedDBPoolIfEmpty(ctx, dbID); err != nil || !deleted {
+		t.Fatalf("failed pool delete = %v, %v; want true", deleted, err)
+	}
+	if _, err := s.GetSharedDB(ctx, dbID); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetSharedDB after delete error = %v, want ErrNotFound", err)
+	}
+}
+
 func TestRegisterSharedDBUpsertKeepsIDAndTenantCount(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
@@ -1078,6 +1255,40 @@ func TestManagedSharedDBPoolsAllowSameEndpointWithDifferentUsers(t *testing.T) {
 		if got.Status != SharedDBStatusProvisioning || got.User != fmt.Sprintf("prefix-%d.root", i) {
 			t.Fatalf("shared db %d = status %q user %q, want provisioning/prefix-%d.root", i, got.Status, got.User, i)
 		}
+	}
+}
+
+func TestListSharedDBsByStatusAfterUsesStableKeysetPagination(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	ids := make([]int64, 0, 3)
+	for i := 0; i < 3; i++ {
+		dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+			TiDBCloudOrganizationID: fmt.Sprintf("org-page-%d", i), ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+		})
+		if err != nil {
+			t.Fatalf("CreateManagedSharedDBPool %d: %v", i, err)
+		}
+		ids = append(ids, dbID)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, SharedDBStatusFailed, ids[1]); err != nil {
+		t.Fatalf("change middle pool status: %v", err)
+	}
+	first, err := s.ListSharedDBsByStatusAfter(ctx, SharedDBStatusPending, 0, 1)
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if len(first) != 1 || first[0].ID != ids[0] {
+		t.Fatalf("first page = %+v, want db %d", first, ids[0])
+	}
+	second, err := s.ListSharedDBsByStatusAfter(ctx, SharedDBStatusPending, first[0].ID, 10)
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	if len(second) != 1 || second[0].ID != ids[2] {
+		t.Fatalf("second page = %+v, want db %d", second, ids[2])
 	}
 }
 

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2851,9 +2851,8 @@ func (s *Store) WithTenantPoolLock(ctx context.Context, poolID string, fn func(c
 
 // WithSharedDBAllocationLock serializes compact DB-pool selection and durable
 // pool planning for one TiDB Cloud organization or unresolved credential
-// fingerprint. It deliberately follows the existing tenant-pool named-lock
-// behavior, including holding the advisory lock across the callback's single
-// bounded Cloud call when a caller chooses to do so.
+// fingerprint. Physical Cloud work uses the per-db_pool work locks below so
+// already-planned pools in one organization do not serialize each other.
 func (s *Store) WithSharedDBAllocationLock(ctx context.Context, identity string, fn func(context.Context) error) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "shared_db_allocation_lock", start, &err)
@@ -2899,6 +2898,97 @@ func (s *Store) WithSharedDBAllocationLock(ctx context.Context, identity string,
 		}
 	}()
 	return fn(ctx)
+}
+
+// WithSharedDBPoolWorkLock serializes one lifecycle attempt for a durable
+// db_pool row. Unlike WithSharedDBAllocationLock, this lock is scoped to one
+// physical pool, so unrelated pools in the same organization can enter Cloud
+// create and continuation concurrently. The session-owned advisory lock is
+// released automatically if its process or database connection disappears.
+func (s *Store) WithSharedDBPoolWorkLock(ctx context.Context, dbID int64, fn func(context.Context) error) error {
+	if fn == nil {
+		return fmt.Errorf("shared db pool work lock callback is required")
+	}
+	return s.withSharedDBPoolWorkLocks(ctx, []int64{dbID}, tenantPoolLockTimeoutSeconds, true,
+		func(lockCtx context.Context, _ []int64) error { return fn(lockCtx) })
+}
+
+// WithSharedDBPoolWorkClaims tries to own each supplied physical pool
+// without waiting. The callback receives the subset this connection owns, so
+// one busy pool never delays unrelated members of a Cloud batch. All claims
+// remain held through the callback and are released together afterward.
+func (s *Store) WithSharedDBPoolWorkClaims(ctx context.Context, dbIDs []int64, fn func(context.Context, []int64) error) error {
+	if fn == nil {
+		return fmt.Errorf("shared db pool work claims callback is required")
+	}
+	return s.withSharedDBPoolWorkLocks(ctx, dbIDs, 0, false, fn)
+}
+
+func (s *Store) withSharedDBPoolWorkLocks(ctx context.Context, dbIDs []int64, waitSeconds int, requireAll bool, fn func(context.Context, []int64) error) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "shared_db_pool_work_lock", start, &err)
+	if len(dbIDs) == 0 {
+		return nil
+	}
+	ids := append([]int64(nil), dbIDs...)
+	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
+	unique := ids[:0]
+	for _, dbID := range ids {
+		if dbID <= 0 {
+			return fmt.Errorf("db_id must be positive")
+		}
+		if len(unique) == 0 || unique[len(unique)-1] != dbID {
+			unique = append(unique, dbID)
+		}
+	}
+	conn, err := s.db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	var databaseName sql.NullString
+	if err := conn.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&databaseName); err != nil {
+		return err
+	}
+	lockNames := make([]string, 0, len(unique))
+	ownedIDs := make([]int64, 0, len(unique))
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), tenantPoolReleaseLockTimeout)
+		defer cancel()
+		for i := len(lockNames) - 1; i >= 0; i-- {
+			var released sql.NullInt64
+			releaseErr := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(?)", lockNames[i]).Scan(&released)
+			if releaseErr != nil {
+				err = errors.Join(err, releaseErr)
+				continue
+			}
+			if !released.Valid || released.Int64 != 1 {
+				err = errors.Join(err, fmt.Errorf("shared db pool work named lock was not held by current connection"))
+			}
+		}
+	}()
+	for _, dbID := range unique {
+		lockName := tenantPoolDatabaseLockName(fmt.Sprintf("d9_dbwork:%d", dbID), databaseName.String)
+		var got sql.NullInt64
+		if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, waitSeconds).Scan(&got); err != nil {
+			return err
+		}
+		if !got.Valid {
+			return fmt.Errorf("shared db pool work named lock returned NULL")
+		}
+		if got.Int64 != 1 {
+			if requireAll {
+				return fmt.Errorf("timed out waiting for shared db pool work named lock")
+			}
+			continue
+		}
+		lockNames = append(lockNames, lockName)
+		ownedIDs = append(ownedIDs, dbID)
+	}
+	if len(ownedIDs) == 0 {
+		return nil
+	}
+	return fn(ctx, ownedIDs)
 }
 
 func externalBindingLockName(provider, subjectKey string) string {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -783,7 +783,8 @@ func metaInitSchemaStatements() []string {
 			UNIQUE INDEX uk_db_pool_uuid (uuid),
 			UNIQUE INDEX uk_db_pool_cluster_id (cluster_id),
 			INDEX idx_db_pool_allocate (org_id, status, db_id),
-			INDEX idx_db_pool_provisioning_key (provisioning_key, status, db_id)
+			INDEX idx_db_pool_provisioning_key (provisioning_key, status, db_id),
+			INDEX idx_db_pool_role_status_id (` + "`role`" + `, status, db_id)
 		)`,
 		// tenant_placements records which physical database (db_pool row) hosts
 		// each filesystem (fs_registry row). A missing row means the tenant
@@ -914,7 +915,8 @@ func metaInitSchemaStatements() []string {
 			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			UNIQUE INDEX uk_tidbcloud_pool_org (organization_id),
-			INDEX idx_tidbcloud_pool_status (status, created_at)
+			INDEX idx_tidbcloud_pool_status (status, created_at),
+			INDEX idx_tidbcloud_pool_status_id (status, pool_id)
 		)`,
 		`CREATE TABLE IF NOT EXISTS tenant_pool_memberships (
 			tenant_id                    VARCHAR(64) PRIMARY KEY,
@@ -2126,6 +2128,37 @@ func (s *Store) GetTenantPoolByID(ctx context.Context, poolID string) (out *Tena
 	row := s.db.QueryRowContext(ctx, `SELECT pool_id, organization_id, size, status, created_at, updated_at
 		FROM tenant_tidbcloud_pools WHERE pool_id = ?`, poolID)
 	return scanTenantPoolRow(row)
+}
+
+// ListTenantPoolsByStatusAfter returns one stable keyset page ordered by pool ID.
+func (s *Store) ListTenantPoolsByStatusAfter(ctx context.Context, status TenantPoolStatus, afterPoolID string, limit int) (out []*TenantPool, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_tidbcloud_pools_by_status_after", start, &err)
+	switch status {
+	case TenantPoolActive, TenantPoolDeleting:
+	default:
+		return nil, fmt.Errorf("unsupported tenant pool status %q", status)
+	}
+	if limit <= 0 {
+		limit = 100
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT pool_id, organization_id, size, status, created_at, updated_at
+		FROM tenant_tidbcloud_pools
+		WHERE status = ? AND pool_id > ?
+		ORDER BY pool_id
+		LIMIT ?`, status, strings.TrimSpace(afterPoolID), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list tenant pools in status %q: %w", status, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		rec, scanErr := scanTenantPoolRow(rows)
+		if scanErr != nil {
+			return nil, scanErr
+		}
+		out = append(out, rec)
+	}
+	return out, rows.Err()
 }
 
 func (s *Store) UpdateTenantPoolOrganization(ctx context.Context, poolID, organizationID string) (err error) {

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2514,6 +2514,13 @@ func (s *Store) DeleteTenantPoolAndDetachUsedMembers(ctx context.Context, poolID
 		return fmt.Errorf("pool_id is required")
 	}
 	return s.InTx(ctx, func(tx *sql.Tx) error {
+		var lockedPoolID string
+		if err := tx.QueryRowContext(ctx, `SELECT pool_id FROM tenant_tidbcloud_pools
+			WHERE pool_id = ? FOR UPDATE`, poolID).Scan(&lockedPoolID); errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		} else if err != nil {
+			return err
+		}
 		var freeTenantID string
 		if err := tx.QueryRowContext(ctx, `SELECT tenant_id FROM tenant_tidbcloud_org_bindings
 			WHERE pool_id = ? AND pool_status = ? LIMIT 1 FOR UPDATE`,

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2192,30 +2192,20 @@ func (s *Store) CountTenantPoolFreeSlots(ctx context.Context, organizationID str
 	return s.countFreeTenantPoolBindingsByStatus(ctx, organizationID, []TenantStatus{TenantPending, TenantProvisioning, TenantActive})
 }
 
-// CountTenantPoolPlannedSlots counts free pending/provisioning inventory that
-// still has recent durable progress. Native plans use tenant progress. Shared
-// plans include assigned free tenants plus recently staged managed physical
-// pools whose tenant placement has not started. Once tenant_count is non-zero,
-// only durable memberships count: db_pool does not persist a wave's intended
-// partial fill, so treating all remaining physical capacity as planned could
-// suppress required tenant-pool replenishment.
-func (s *Store) CountTenantPoolPlannedSlots(ctx context.Context, organizationID string, progressCutoff time.Time) (out int, err error) {
+// CountTenantPoolPlannedSlots counts shared free pending/provisioning inventory
+// whose durable physical attempt remains non-terminal. The stuck-pool watchdog
+// is the sole authority that expires a pending/provisioning physical attempt;
+// active physical pools are finalized by the activation reconciler. Native
+// pending tenants are intentionally excluded because leader refill has no
+// request-scoped customer credential with which to advance them.
+func (s *Store) CountTenantPoolPlannedSlots(ctx context.Context, organizationID string) (out int, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "count_tidbcloud_pool_planned_slots", start, &err)
 	organizationID = strings.TrimSpace(organizationID)
 	if organizationID == "" {
 		return 0, fmt.Errorf("organization_id is required")
 	}
-	if progressCutoff.IsZero() {
-		return 0, fmt.Errorf("progress cutoff is required")
-	}
 	row := s.db.QueryRowContext(ctx, `SELECT COALESCE(SUM(slot_count), 0) FROM (
-		SELECT COUNT(*) AS slot_count
-			FROM tenant_tidbcloud_org_bindings b
-			STRAIGHT_JOIN tenants t ON t.id = b.tenant_id
-			WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = ?
-				AND t.status IN (?, ?) AND t.updated_at >= ?
-		UNION ALL
 		SELECT COUNT(*) AS slot_count
 			FROM tenant_pool_memberships m
 			STRAIGHT_JOIN tenants t ON t.id = m.tenant_id
@@ -2223,19 +2213,16 @@ func (s *Store) CountTenantPoolPlannedSlots(ctx context.Context, organizationID 
 			STRAIGHT_JOIN tenant_placements p ON p.fs_id = f.fs_id
 			STRAIGHT_JOIN db_pool d ON d.db_id = p.db_id
 			WHERE m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?
-				AND t.status IN (?, ?) AND d.status IN (?, ?, ?) AND d.updated_at >= ?
+				AND t.status IN (?, ?) AND d.status IN (?, ?, ?)
 		UNION ALL
 		SELECT COALESCE(SUM(GREATEST(d.max_tenants - d.tenant_count, 0)), 0) AS slot_count
 			FROM db_pool d
 			WHERE d.org_id = ? AND d.`+"`role`"+` = ? AND d.provisioning_key IS NOT NULL
-				AND d.status IN (?, ?) AND d.tenant_count = 0
-				AND d.updated_at >= ? AND d.max_tenants > 0
+				AND d.status IN (?, ?) AND d.tenant_count = 0 AND d.max_tenants > 0
 	) inventory`,
-		organizationID, TenantPoolBindingFree, tidbCloudNativeProvider,
-		TenantPending, TenantProvisioning, progressCutoff.UTC(),
 		organizationID, TenantPoolBindingFree, tidbCloudNativeSharedProvider,
-		TenantPending, TenantProvisioning, SharedDBStatusPending, SharedDBStatusProvisioning, SharedDBStatusActive, progressCutoff.UTC(),
-		organizationID, SharedDBRoleShared, SharedDBStatusPending, SharedDBStatusProvisioning, progressCutoff.UTC())
+		TenantPending, TenantProvisioning, SharedDBStatusPending, SharedDBStatusProvisioning, SharedDBStatusActive,
+		organizationID, SharedDBRoleShared, SharedDBStatusPending, SharedDBStatusProvisioning)
 	if err = row.Scan(&out); err != nil {
 		return 0, err
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -4221,6 +4221,10 @@ func observeMeta(ctx context.Context, op string, start time.Time, errp *error) {
 			result = "not_found"
 		case errors.Is(*errp, ErrDuplicate):
 			result = "duplicate"
+		case errors.Is(*errp, ErrSharedDBCapacityExhausted):
+			// Capacity races are an expected allocator miss. The caller either
+			// selects another pool or reports the unrecovered wave failure.
+			result = "capacity_exhausted"
 		case errors.Is(*errp, sql.ErrConnDone):
 			// Connection closed during shutdown — not an unexpected failure.
 			result = "conn_closed"
@@ -4235,6 +4239,9 @@ func observeMeta(ctx context.Context, op string, start time.Time, errp *error) {
 		case "conn_closed":
 			// Connection closed during shutdown — suppress the noisy log and
 			// only record the metric below.
+		case "capacity_exhausted":
+			// Expected allocator outcome; the caller retries another candidate
+			// or reports an unrecovered wave failure.
 		case "not_found", "duplicate":
 			logger.Warn(ctx, "meta_op_failed", zap.String("operation", op), zap.String("result", result), zap.String("detail", (*errp).Error()))
 		case "error":

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2192,6 +2192,46 @@ func (s *Store) CountTenantPoolFreeSlots(ctx context.Context, organizationID str
 	return s.countFreeTenantPoolBindingsByStatus(ctx, organizationID, []TenantStatus{TenantPending, TenantProvisioning, TenantActive})
 }
 
+// CountTenantPoolPlannedSlots counts free pending/provisioning inventory that
+// still has recent durable progress. Native plans use tenant progress; shared
+// plans use their physical db_pool heartbeat so metadata polling can renew the
+// whole partition without rewriting every tenant row.
+func (s *Store) CountTenantPoolPlannedSlots(ctx context.Context, organizationID string, progressCutoff time.Time) (out int, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "count_tidbcloud_pool_planned_slots", start, &err)
+	organizationID = strings.TrimSpace(organizationID)
+	if organizationID == "" {
+		return 0, fmt.Errorf("organization_id is required")
+	}
+	if progressCutoff.IsZero() {
+		return 0, fmt.Errorf("progress cutoff is required")
+	}
+	row := s.db.QueryRowContext(ctx, `SELECT COALESCE(SUM(slot_count), 0) FROM (
+		SELECT COUNT(*) AS slot_count
+			FROM tenant_tidbcloud_org_bindings b
+			STRAIGHT_JOIN tenants t ON t.id = b.tenant_id
+			WHERE b.organization_id = ? AND b.pool_status = ? AND t.provider = ?
+				AND t.status IN (?, ?) AND t.updated_at >= ?
+		UNION ALL
+		SELECT COUNT(*) AS slot_count
+			FROM tenant_pool_memberships m
+			STRAIGHT_JOIN tenants t ON t.id = m.tenant_id
+			STRAIGHT_JOIN fs_registry f ON f.tenant_id = t.id
+			STRAIGHT_JOIN tenant_placements p ON p.fs_id = f.fs_id
+			STRAIGHT_JOIN db_pool d ON d.db_id = p.db_id
+			WHERE m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?
+				AND t.status IN (?, ?) AND d.status IN (?, ?) AND d.updated_at >= ?
+	) inventory`,
+		organizationID, TenantPoolBindingFree, tidbCloudNativeProvider,
+		TenantPending, TenantProvisioning, progressCutoff.UTC(),
+		organizationID, TenantPoolBindingFree, tidbCloudNativeSharedProvider,
+		TenantPending, TenantProvisioning, SharedDBStatusPending, SharedDBStatusProvisioning, progressCutoff.UTC())
+	if err = row.Scan(&out); err != nil {
+		return 0, err
+	}
+	return out, nil
+}
+
 const countFreeTenantPoolBindingsSQL = `SELECT COALESCE(SUM(slot_count), 0) FROM (
 	SELECT COUNT(*) AS slot_count
 		FROM tenant_tidbcloud_org_bindings b

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2193,9 +2193,12 @@ func (s *Store) CountTenantPoolFreeSlots(ctx context.Context, organizationID str
 }
 
 // CountTenantPoolPlannedSlots counts free pending/provisioning inventory that
-// still has recent durable progress. Native plans use tenant progress; shared
-// plans use their physical db_pool heartbeat so metadata polling can renew the
-// whole partition without rewriting every tenant row.
+// still has recent durable progress. Native plans use tenant progress. Shared
+// plans include assigned free tenants plus recently staged managed physical
+// pools whose tenant placement has not started. Once tenant_count is non-zero,
+// only durable memberships count: db_pool does not persist a wave's intended
+// partial fill, so treating all remaining physical capacity as planned could
+// suppress required tenant-pool replenishment.
 func (s *Store) CountTenantPoolPlannedSlots(ctx context.Context, organizationID string, progressCutoff time.Time) (out int, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "count_tidbcloud_pool_planned_slots", start, &err)
@@ -2220,12 +2223,19 @@ func (s *Store) CountTenantPoolPlannedSlots(ctx context.Context, organizationID 
 			STRAIGHT_JOIN tenant_placements p ON p.fs_id = f.fs_id
 			STRAIGHT_JOIN db_pool d ON d.db_id = p.db_id
 			WHERE m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?
-				AND t.status IN (?, ?) AND d.status IN (?, ?) AND d.updated_at >= ?
+				AND t.status IN (?, ?) AND d.status IN (?, ?, ?) AND d.updated_at >= ?
+		UNION ALL
+		SELECT COALESCE(SUM(GREATEST(d.max_tenants - d.tenant_count, 0)), 0) AS slot_count
+			FROM db_pool d
+			WHERE d.org_id = ? AND d.`+"`role`"+` = ? AND d.provisioning_key IS NOT NULL
+				AND d.status IN (?, ?) AND d.tenant_count = 0
+				AND d.updated_at >= ? AND d.max_tenants > 0
 	) inventory`,
 		organizationID, TenantPoolBindingFree, tidbCloudNativeProvider,
 		TenantPending, TenantProvisioning, progressCutoff.UTC(),
 		organizationID, TenantPoolBindingFree, tidbCloudNativeSharedProvider,
-		TenantPending, TenantProvisioning, SharedDBStatusPending, SharedDBStatusProvisioning, progressCutoff.UTC())
+		TenantPending, TenantProvisioning, SharedDBStatusPending, SharedDBStatusProvisioning, SharedDBStatusActive, progressCutoff.UTC(),
+		organizationID, SharedDBRoleShared, SharedDBStatusPending, SharedDBStatusProvisioning, progressCutoff.UTC())
 	if err = row.Scan(&out); err != nil {
 		return 0, err
 	}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1537,11 +1537,15 @@ func TestMetaSchemaSpecIncludesManagedSharedDBControlPlane(t *testing.T) {
 	}
 	for _, index := range []string{
 		"primary", "uk_db_pool_uuid", "uk_db_pool_cluster_id",
-		"idx_db_pool_allocate", "idx_db_pool_provisioning_key",
+		"idx_db_pool_allocate", "idx_db_pool_provisioning_key", "idx_db_pool_role_status_id",
 	} {
 		if _, ok := dbPool.indexes[index]; !ok {
 			t.Fatalf("db_pool schema missing index %s", index)
 		}
+	}
+	pools := mustMetaTableSpec(t, mustMetaSpec(t), "tenant_tidbcloud_pools")
+	if _, ok := pools.indexes["idx_tidbcloud_pool_status_id"]; !ok {
+		t.Fatal("tenant_tidbcloud_pools schema missing idx_tidbcloud_pool_status_id")
 	}
 	if _, ok := dbPool.indexes["uk_db_pool_endpoint"]; ok {
 		t.Fatal("db_pool schema must not define endpoint uniqueness")
@@ -1573,6 +1577,27 @@ func TestDBPoolClusterIDIndexIsGloballyUnique(t *testing.T) {
 	}
 	if want := []string{"cluster_id"}; !sameStringSlice(columns, want) {
 		t.Fatalf("uk_db_pool_cluster_id columns = %v, want %v", columns, want)
+	}
+}
+
+func TestManagedSharedDBPeriodicScanIndexesMatchKeysetQueries(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	for _, tc := range []struct {
+		table string
+		index string
+		want  []string
+	}{
+		{table: "db_pool", index: "idx_db_pool_role_status_id", want: []string{"role", "status", "db_id"}},
+		{table: "tenant_tidbcloud_pools", index: "idx_tidbcloud_pool_status_id", want: []string{"status", "pool_id"}},
+	} {
+		columns, err := loadMetaIndexColumns(ctx, s.DB(), tc.table, tc.index)
+		if err != nil {
+			t.Fatalf("load %s columns: %v", tc.index, err)
+		}
+		if !sameStringSlice(columns, tc.want) {
+			t.Fatalf("%s columns = %v, want %v", tc.index, columns, tc.want)
+		}
 	}
 }
 
@@ -2141,6 +2166,36 @@ func TestCountTenantPoolBindingsByStatusGroupsByPoolOrganizationAndStatus(t *tes
 		if got[key] != wantCount {
 			t.Errorf("count %s = %d, want %d; all counts=%v", key, got[key], wantCount, got)
 		}
+	}
+}
+
+func TestListTenantPoolsByStatusAfterUsesStableKeysetPagination(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for _, pool := range []TenantPool{
+		{PoolID: "pool-a", OrganizationID: "org-a", Size: 1, Status: TenantPoolActive, CreatedAt: now, UpdatedAt: now},
+		{PoolID: "pool-b", OrganizationID: "org-b", Size: 2, Status: TenantPoolDeleting, CreatedAt: now, UpdatedAt: now},
+		{PoolID: "pool-c", OrganizationID: "org-c", Size: 3, Status: TenantPoolActive, CreatedAt: now, UpdatedAt: now},
+	} {
+		if err := s.CreateTenantPool(ctx, &pool); err != nil {
+			t.Fatalf("create tenant pool %s: %v", pool.PoolID, err)
+		}
+	}
+
+	first, err := s.ListTenantPoolsByStatusAfter(ctx, TenantPoolActive, "", 1)
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if len(first) != 1 || first[0].PoolID != "pool-a" {
+		t.Fatalf("first page = %+v, want pool-a", first)
+	}
+	second, err := s.ListTenantPoolsByStatusAfter(ctx, TenantPoolActive, first[0].PoolID, 10)
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	if len(second) != 1 || second[0].PoolID != "pool-c" {
+		t.Fatalf("second page = %+v, want pool-c", second)
 	}
 }
 

--- a/pkg/meta/shared_pool_wave.go
+++ b/pkg/meta/shared_pool_wave.go
@@ -1,0 +1,239 @@
+package meta
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// ManagedSharedDBPoolWaveMember is one logical tenant reservation staged with
+// its physical managed shared DB pool.
+type ManagedSharedDBPoolWaveMember struct {
+	Tenant               *Tenant
+	Membership           *TenantPoolMembership
+	Quota                *QuotaConfig
+	AutoEmbeddingProfile *TenantAutoEmbeddingProfile
+}
+
+// ManagedSharedDBPoolWavePlan describes one physical pool and every logical
+// tenant slot reserved from it before the pool becomes visible to allocators.
+type ManagedSharedDBPoolWavePlan struct {
+	DB      *SharedDB
+	Members []ManagedSharedDBPoolWaveMember
+}
+
+// ManagedSharedDBPoolWaveResult contains durable identifiers created for one
+// physical partition of a refill wave.
+type ManagedSharedDBPoolWaveResult struct {
+	DBID      int64
+	TenantIDs []string
+}
+
+type preparedManagedSharedDBPoolWavePlan struct {
+	values  managedSharedDBInsertValues
+	members []ManagedSharedDBPoolWaveMember
+}
+
+func multiRowPlaceholders(rows, columns int) string {
+	row := "(" + strings.TrimRight(strings.Repeat("?,", columns), ",") + ")"
+	return strings.TrimRight(strings.Repeat(row+",", rows), ",")
+}
+
+// CreateManagedSharedDBPoolTenantWave atomically creates each physical pool
+// together with all logical tenant reservations assigned to it. A direct
+// allocator therefore cannot observe refill-staged physical capacity before
+// tenant_count, placements, and pool memberships account for the wave.
+func (s *Store) CreateManagedSharedDBPoolTenantWave(ctx context.Context, plans []ManagedSharedDBPoolWavePlan) (out []ManagedSharedDBPoolWaveResult, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "create_managed_shared_db_pool_tenant_wave", start, &err)
+	if len(plans) == 0 {
+		return nil, nil
+	}
+	prepared := make([]preparedManagedSharedDBPoolWavePlan, len(plans))
+	seenTenants := make(map[string]struct{})
+	for i := range plans {
+		values, prepErr := managedSharedDBInsertValuesFor(plans[i].DB)
+		if prepErr != nil {
+			return nil, fmt.Errorf("prepare managed shared DB plan %d: %w", i, prepErr)
+		}
+		if len(plans[i].Members) == 0 || len(plans[i].Members) > values.maxTenants {
+			return nil, fmt.Errorf("managed shared DB plan %d has %d members outside capacity 1..%d", i, len(plans[i].Members), values.maxTenants)
+		}
+		for j := range plans[i].Members {
+			member := plans[i].Members[j]
+			if member.Tenant == nil || strings.TrimSpace(member.Tenant.ID) == "" {
+				return nil, fmt.Errorf("managed shared DB plan %d member %d has no tenant", i, j)
+			}
+			tenantID := member.Tenant.ID
+			if _, exists := seenTenants[tenantID]; exists {
+				return nil, fmt.Errorf("duplicate tenant %q in managed shared DB wave", tenantID)
+			}
+			seenTenants[tenantID] = struct{}{}
+			if member.Tenant.Provider != tidbCloudNativeSharedProvider || member.Tenant.Status != TenantPending {
+				return nil, fmt.Errorf("managed shared DB wave tenant %q must be pending shared provider", tenantID)
+			}
+			if member.Membership == nil || member.Membership.TenantID != tenantID || strings.TrimSpace(member.Membership.PoolID) == "" || member.Membership.PoolStatus != TenantPoolBindingFree {
+				return nil, fmt.Errorf("managed shared DB wave tenant %q has invalid free membership", tenantID)
+			}
+			if strings.TrimSpace(member.Membership.TiDBCloudOrganizationID) != values.organizationID {
+				return nil, fmt.Errorf("managed shared DB wave tenant %q organization does not match physical pool", tenantID)
+			}
+			if member.Quota == nil || member.Quota.TenantID != tenantID {
+				return nil, fmt.Errorf("managed shared DB wave tenant %q has invalid quota", tenantID)
+			}
+			if member.AutoEmbeddingProfile != nil && member.AutoEmbeddingProfile.TenantID != tenantID {
+				return nil, fmt.Errorf("managed shared DB wave tenant %q has invalid auto-embedding profile", tenantID)
+			}
+		}
+		prepared[i] = preparedManagedSharedDBPoolWavePlan{values: values, members: plans[i].Members}
+	}
+
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		out = make([]ManagedSharedDBPoolWaveResult, len(prepared))
+		for i := range prepared {
+			dbID, insertErr := insertManagedSharedDBPool(ctx, tx, prepared[i].values)
+			if insertErr != nil {
+				return insertErr
+			}
+			result, insertErr := createManagedSharedDBPoolWaveMembers(ctx, tx, dbID, prepared[i])
+			if insertErr != nil {
+				return fmt.Errorf("stage managed shared DB pool %d: %w", dbID, insertErr)
+			}
+			out[i] = result
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func createManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID int64, plan preparedManagedSharedDBPoolWavePlan) (ManagedSharedDBPoolWaveResult, error) {
+	now := time.Now().UTC()
+	tenantArgs := make([]any, 0, len(plan.members)*22)
+	tenantIDs := make([]string, 0, len(plan.members))
+	for _, member := range plan.members {
+		t := member.Tenant
+		tenantIDs = append(tenantIDs, t.ID)
+		tenantArgs = append(tenantArgs,
+			t.ID, t.Status, tenantKindForInsert(t), t.ParentTenantID, t.StorageNamespaceID,
+			t.DBHost, t.DBPort, t.DBUser, t.DBPasswordCipher, t.DBName, boolToInt(t.DBTLS),
+			t.Provider, nullStr(t.ClusterID), t.BranchID, nullStr(t.ClaimURL), t.ClaimExpiresAt, t.SchemaVersion,
+			tenantS3EncryptionModeForInsert(t), t.S3KMSKeyID, boolToInt(tenantS3BucketKeyEnabledForInsert(t)),
+			t.CreatedAt.UTC(), t.UpdatedAt.UTC())
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO tenants
+		(id, status, kind, parent_tenant_id, storage_namespace_id, db_host, db_port, db_user, db_password, db_name, db_tls,
+		 provider, cluster_id, branch_id, claim_url, claim_expires_at, schema_version,
+		 s3_encryption_mode, s3_kms_key_id, s3_bucket_key_enabled, created_at, updated_at) VALUES `+
+		multiRowPlaceholders(len(plan.members), 22), tenantArgs...); err != nil {
+		if isDuplicateEntry(err) {
+			return ManagedSharedDBPoolWaveResult{}, ErrDuplicate
+		}
+		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave tenants: %w", err)
+	}
+
+	fsArgs := make([]any, len(tenantIDs))
+	for i := range tenantIDs {
+		fsArgs[i] = tenantIDs[i]
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO fs_registry (tenant_id) VALUES `+multiRowPlaceholders(len(tenantIDs), 1), fsArgs...); err != nil {
+		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave fs registry: %w", err)
+	}
+	selectArgs := make([]any, len(tenantIDs))
+	copy(selectArgs, fsArgs)
+	rows, err := tx.QueryContext(ctx, `SELECT tenant_id, fs_id FROM fs_registry WHERE tenant_id IN (`+
+		strings.TrimRight(strings.Repeat("?,", len(tenantIDs)), ",")+`)`, selectArgs...)
+	if err != nil {
+		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("load wave fs registry: %w", err)
+	}
+	fsIDs := make(map[string]int64, len(tenantIDs))
+	for rows.Next() {
+		var tenantID string
+		var fsID int64
+		if err := rows.Scan(&tenantID, &fsID); err != nil {
+			_ = rows.Close()
+			return ManagedSharedDBPoolWaveResult{}, err
+		}
+		fsIDs[tenantID] = fsID
+	}
+	if err := rows.Err(); err != nil {
+		_ = rows.Close()
+		return ManagedSharedDBPoolWaveResult{}, err
+	}
+	if err := rows.Close(); err != nil {
+		return ManagedSharedDBPoolWaveResult{}, err
+	}
+	if len(fsIDs) != len(tenantIDs) {
+		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("resolved %d fs IDs for %d wave tenants", len(fsIDs), len(tenantIDs))
+	}
+
+	quotaArgs := make([]any, 0, len(plan.members)*9)
+	placementArgs := make([]any, 0, len(plan.members)*6)
+	membershipArgs := make([]any, 0, len(plan.members)*6)
+	profileArgs := make([]any, 0, len(plan.members)*9)
+	profileCount := 0
+	for _, member := range plan.members {
+		tenantID := member.Tenant.ID
+		q := member.Quota
+		quotaArgs = append(quotaArgs, q.TenantID, q.MaxStorageBytes, q.MaxFileSizeBytes, q.MaxFileCount,
+			q.MaxMediaLLMFiles, q.MaxVideoLLMFiles, q.MaxMonthlyCostMC,
+			nullInt64FromPtr(q.TiDBCloudSpendingLimit), nullTimeFromPtr(q.TiDBCloudSpendingLimitCheckedAt))
+		placementArgs = append(placementArgs, fsIDs[tenantID], dbID, PlacementShared, SchemaShapeShared, SharedDBStatusActive, nil)
+		m := member.Membership
+		createdAt := m.CreatedAt
+		if createdAt.IsZero() {
+			createdAt = now
+		}
+		updatedAt := m.UpdatedAt
+		if updatedAt.IsZero() {
+			updatedAt = createdAt
+		}
+		membershipArgs = append(membershipArgs, tenantID, strings.TrimSpace(m.TiDBCloudOrganizationID), m.PoolID,
+			TenantPoolBindingFree, createdAt.UTC(), updatedAt.UTC())
+		if p := member.AutoEmbeddingProfile; p != nil {
+			profileCount++
+			profileArgs = append(profileArgs, p.TenantID, nullStr(p.EmbeddingMode), p.Model, p.Dimensions, p.OptionsJSON,
+				nullStr(p.APIBase), nullableBytes(p.APIKeyCipher), p.CreatedAt.UTC(), p.UpdatedAt.UTC())
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_quota_config
+		(tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count, max_media_llm_files, max_video_llm_files,
+		 max_monthly_cost_mc, tidbcloud_spending_limit, tidbcloud_spending_limit_checked_at) VALUES `+
+		multiRowPlaceholders(len(plan.members), 9), quotaArgs...); err != nil {
+		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave quota configs: %w", err)
+	}
+	if profileCount > 0 {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_auto_embedding_profiles
+			(tenant_id, embedding_mode, model, dimensions, options_json, api_base, api_key_cipher, created_at, updated_at) VALUES `+
+			multiRowPlaceholders(profileCount, 9), profileArgs...); err != nil {
+			return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave auto-embedding profiles: %w", err)
+		}
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_placements
+		(fs_id, db_id, placement, schema_shape, status, target_db_id) VALUES `+
+		multiRowPlaceholders(len(plan.members), 6), placementArgs...); err != nil {
+		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave placements: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_pool_memberships
+		(tenant_id, tidbcloud_organization_id, pool_id, pool_status, created_at, updated_at) VALUES `+
+		multiRowPlaceholders(len(plan.members), 6), membershipArgs...); err != nil {
+		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave memberships: %w", err)
+	}
+	res, err := tx.ExecContext(ctx, `UPDATE db_pool SET tenant_count = ?, soft_cap_reached = CASE WHEN ? >= max_tenants THEN 1 ELSE 0 END
+		WHERE db_id = ? AND status = ?`, len(plan.members), len(plan.members), dbID, SharedDBStatusPending)
+	if err != nil {
+		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("reserve wave physical capacity: %w", err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("reserve wave physical capacity rows affected: %w", err)
+	}
+	if affected != 1 {
+		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("reserve wave physical capacity changed %d rows for db pool %d", affected, dbID)
+	}
+	return ManagedSharedDBPoolWaveResult{DBID: dbID, TenantIDs: tenantIDs}, nil
+}

--- a/pkg/meta/shared_pool_wave.go
+++ b/pkg/meta/shared_pool_wave.go
@@ -3,6 +3,7 @@ package meta
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -36,6 +37,13 @@ type preparedManagedSharedDBPoolWavePlan struct {
 	members []ManagedSharedDBPoolWaveMember
 }
 
+type stagedManagedSharedDBPoolWavePlan struct {
+	dbID           int64
+	tenantIDs      []string
+	placementArgs  []any
+	membershipArgs []any
+}
+
 func multiRowPlaceholders(rows, columns int) string {
 	row := "(" + strings.TrimRight(strings.Repeat("?,", columns), ",") + ")"
 	return strings.TrimRight(strings.Repeat(row+",", rows), ",")
@@ -53,6 +61,9 @@ func (s *Store) CreateManagedSharedDBPoolTenantWave(ctx context.Context, plans [
 	}
 	prepared := make([]preparedManagedSharedDBPoolWavePlan, len(plans))
 	seenTenants := make(map[string]struct{})
+	wavePoolID := ""
+	waveOrganizationID := ""
+	waveMemberCount := 0
 	for i := range plans {
 		values, prepErr := managedSharedDBInsertValuesFor(plans[i].DB)
 		if prepErr != nil {
@@ -74,11 +85,21 @@ func (s *Store) CreateManagedSharedDBPoolTenantWave(ctx context.Context, plans [
 			if member.Tenant.Provider != tidbCloudNativeSharedProvider || member.Tenant.Status != TenantPending {
 				return nil, fmt.Errorf("managed shared DB wave tenant %q must be pending shared provider", tenantID)
 			}
-			if member.Membership == nil || member.Membership.TenantID != tenantID || strings.TrimSpace(member.Membership.PoolID) == "" || member.Membership.PoolStatus != TenantPoolBindingFree {
+			memberPoolID := ""
+			if member.Membership != nil {
+				memberPoolID = strings.TrimSpace(member.Membership.PoolID)
+			}
+			if member.Membership == nil || member.Membership.TenantID != tenantID || memberPoolID == "" || member.Membership.PoolStatus != TenantPoolBindingFree {
 				return nil, fmt.Errorf("managed shared DB wave tenant %q has invalid free membership", tenantID)
 			}
 			if strings.TrimSpace(member.Membership.TiDBCloudOrganizationID) != values.organizationID {
 				return nil, fmt.Errorf("managed shared DB wave tenant %q organization does not match physical pool", tenantID)
+			}
+			if wavePoolID == "" {
+				wavePoolID = memberPoolID
+				waveOrganizationID = values.organizationID
+			} else if memberPoolID != wavePoolID || values.organizationID != waveOrganizationID {
+				return nil, fmt.Errorf("managed shared DB wave must belong to one logical pool and organization")
 			}
 			if member.Quota == nil || member.Quota.TenantID != tenantID {
 				return nil, fmt.Errorf("managed shared DB wave tenant %q has invalid quota", tenantID)
@@ -88,22 +109,42 @@ func (s *Store) CreateManagedSharedDBPoolTenantWave(ctx context.Context, plans [
 			}
 		}
 		prepared[i] = preparedManagedSharedDBPoolWavePlan{values: values, members: plans[i].Members}
+		waveMemberCount += len(plans[i].Members)
 	}
 
-	err = s.InTx(ctx, func(tx *sql.Tx) error {
-		out = make([]ManagedSharedDBPoolWaveResult, len(prepared))
-		for i := range prepared {
-			dbID, insertErr := insertManagedSharedDBPool(ctx, tx, prepared[i].values)
-			if insertErr != nil {
-				return insertErr
+	err = withMetaLockConflictRetry(ctx, "create_managed_shared_db_pool_tenant_wave", func() error {
+		attemptOut := make([]ManagedSharedDBPoolWaveResult, len(prepared))
+		staged := make([]stagedManagedSharedDBPoolWavePlan, len(prepared))
+		txErr := s.InTx(ctx, func(tx *sql.Tx) error {
+			for i := range prepared {
+				dbID, insertErr := insertManagedSharedDBPool(ctx, tx, prepared[i].values)
+				if insertErr != nil {
+					return insertErr
+				}
+				staged[i], insertErr = stageManagedSharedDBPoolWaveMembers(ctx, tx, dbID, prepared[i])
+				if insertErr != nil {
+					return fmt.Errorf("stage managed shared DB pool %d: %w", dbID, insertErr)
+				}
+				attemptOut[i] = ManagedSharedDBPoolWaveResult{DBID: dbID, TenantIDs: staged[i].tenantIDs}
 			}
-			result, insertErr := createManagedSharedDBPoolWaveMembers(ctx, tx, dbID, prepared[i])
-			if insertErr != nil {
-				return fmt.Errorf("stage managed shared DB pool %d: %w", dbID, insertErr)
+			// Take logical-pool ownership only after the expensive independent
+			// tenant/quota/profile staging. If delete or shrink committed first,
+			// the complete uncommitted wave rolls back before any membership is
+			// published or Cloud request can start.
+			if validateErr := validateManagedSharedDBPoolWaveOwnership(ctx, tx, wavePoolID, waveOrganizationID, waveMemberCount); validateErr != nil {
+				return validateErr
 			}
-			out[i] = result
+			for i := range staged {
+				if finalizeErr := finalizeManagedSharedDBPoolWaveMembers(ctx, tx, staged[i]); finalizeErr != nil {
+					return fmt.Errorf("finalize managed shared DB pool %d: %w", staged[i].dbID, finalizeErr)
+				}
+			}
+			return nil
+		})
+		if txErr == nil {
+			out = attemptOut
 		}
-		return nil
+		return txErr
 	})
 	if err != nil {
 		return nil, err
@@ -111,7 +152,7 @@ func (s *Store) CreateManagedSharedDBPoolTenantWave(ctx context.Context, plans [
 	return out, nil
 }
 
-func createManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID int64, plan preparedManagedSharedDBPoolWavePlan) (ManagedSharedDBPoolWaveResult, error) {
+func stageManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID int64, plan preparedManagedSharedDBPoolWavePlan) (stagedManagedSharedDBPoolWavePlan, error) {
 	now := time.Now().UTC()
 	tenantArgs := make([]any, 0, len(plan.members)*22)
 	tenantIDs := make([]string, 0, len(plan.members))
@@ -131,9 +172,9 @@ func createManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID 
 		 s3_encryption_mode, s3_kms_key_id, s3_bucket_key_enabled, created_at, updated_at) VALUES `+
 		multiRowPlaceholders(len(plan.members), 22), tenantArgs...); err != nil {
 		if isDuplicateEntry(err) {
-			return ManagedSharedDBPoolWaveResult{}, ErrDuplicate
+			return stagedManagedSharedDBPoolWavePlan{}, ErrDuplicate
 		}
-		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave tenants: %w", err)
+		return stagedManagedSharedDBPoolWavePlan{}, fmt.Errorf("insert wave tenants: %w", err)
 	}
 
 	fsArgs := make([]any, len(tenantIDs))
@@ -141,14 +182,14 @@ func createManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID 
 		fsArgs[i] = tenantIDs[i]
 	}
 	if _, err := tx.ExecContext(ctx, `INSERT INTO fs_registry (tenant_id) VALUES `+multiRowPlaceholders(len(tenantIDs), 1), fsArgs...); err != nil {
-		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave fs registry: %w", err)
+		return stagedManagedSharedDBPoolWavePlan{}, fmt.Errorf("insert wave fs registry: %w", err)
 	}
 	selectArgs := make([]any, len(tenantIDs))
 	copy(selectArgs, fsArgs)
 	rows, err := tx.QueryContext(ctx, `SELECT tenant_id, fs_id FROM fs_registry WHERE tenant_id IN (`+
 		strings.TrimRight(strings.Repeat("?,", len(tenantIDs)), ",")+`)`, selectArgs...)
 	if err != nil {
-		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("load wave fs registry: %w", err)
+		return stagedManagedSharedDBPoolWavePlan{}, fmt.Errorf("load wave fs registry: %w", err)
 	}
 	fsIDs := make(map[string]int64, len(tenantIDs))
 	for rows.Next() {
@@ -156,19 +197,19 @@ func createManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID 
 		var fsID int64
 		if err := rows.Scan(&tenantID, &fsID); err != nil {
 			_ = rows.Close()
-			return ManagedSharedDBPoolWaveResult{}, err
+			return stagedManagedSharedDBPoolWavePlan{}, err
 		}
 		fsIDs[tenantID] = fsID
 	}
 	if err := rows.Err(); err != nil {
 		_ = rows.Close()
-		return ManagedSharedDBPoolWaveResult{}, err
+		return stagedManagedSharedDBPoolWavePlan{}, err
 	}
 	if err := rows.Close(); err != nil {
-		return ManagedSharedDBPoolWaveResult{}, err
+		return stagedManagedSharedDBPoolWavePlan{}, err
 	}
 	if len(fsIDs) != len(tenantIDs) {
-		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("resolved %d fs IDs for %d wave tenants", len(fsIDs), len(tenantIDs))
+		return stagedManagedSharedDBPoolWavePlan{}, fmt.Errorf("resolved %d fs IDs for %d wave tenants", len(fsIDs), len(tenantIDs))
 	}
 
 	quotaArgs := make([]any, 0, len(plan.members)*9)
@@ -204,36 +245,89 @@ func createManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID 
 		(tenant_id, max_storage_bytes, max_file_size_bytes, max_file_count, max_media_llm_files, max_video_llm_files,
 		 max_monthly_cost_mc, tidbcloud_spending_limit, tidbcloud_spending_limit_checked_at) VALUES `+
 		multiRowPlaceholders(len(plan.members), 9), quotaArgs...); err != nil {
-		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave quota configs: %w", err)
+		return stagedManagedSharedDBPoolWavePlan{}, fmt.Errorf("insert wave quota configs: %w", err)
 	}
 	if profileCount > 0 {
 		if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_auto_embedding_profiles
 			(tenant_id, embedding_mode, model, dimensions, options_json, api_base, api_key_cipher, created_at, updated_at) VALUES `+
 			multiRowPlaceholders(profileCount, 9), profileArgs...); err != nil {
-			return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave auto-embedding profiles: %w", err)
+			return stagedManagedSharedDBPoolWavePlan{}, fmt.Errorf("insert wave auto-embedding profiles: %w", err)
 		}
 	}
+	return stagedManagedSharedDBPoolWavePlan{dbID: dbID, tenantIDs: tenantIDs,
+		placementArgs: placementArgs, membershipArgs: membershipArgs}, nil
+}
+
+func validateManagedSharedDBPoolWaveOwnership(ctx context.Context, tx *sql.Tx, poolID, organizationID string, incoming int) error {
+	var currentOrganizationID sql.NullString
+	var size int
+	var status TenantPoolStatus
+	err := tx.QueryRowContext(ctx, `SELECT organization_id, size, status
+		FROM tenant_tidbcloud_pools WHERE pool_id = ? FOR UPDATE`, poolID).Scan(&currentOrganizationID, &size, &status)
+	if errors.Is(err, sql.ErrNoRows) {
+		return ErrNotFound
+	}
+	if err != nil {
+		return fmt.Errorf("lock logical tenant pool %q: %w", poolID, err)
+	}
+	if status != TenantPoolActive {
+		return fmt.Errorf("logical tenant pool %q is %s, want active", poolID, status)
+	}
+	if !currentOrganizationID.Valid || strings.TrimSpace(currentOrganizationID.String) != organizationID {
+		return fmt.Errorf("logical tenant pool %q organization does not match refill wave", poolID)
+	}
+	var nativeSlots, sharedSlots int
+	// Match leader refill accounting: native work is request-credential-owned,
+	// so only active native inventory offsets a leader-owned shared wave.
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM tenant_tidbcloud_org_bindings b
+		STRAIGHT_JOIN tenants t ON t.id = b.tenant_id
+		WHERE b.pool_id = ? AND b.organization_id = ? AND b.pool_status = ? AND t.provider = ?
+			AND t.status = ? FOR UPDATE`,
+		poolID, organizationID, TenantPoolBindingFree, tidbCloudNativeProvider,
+		TenantActive).Scan(&nativeSlots)
+	if err != nil {
+		return fmt.Errorf("count logical tenant pool %q native slots: %w", poolID, err)
+	}
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM tenant_pool_memberships m
+		STRAIGHT_JOIN tenants t ON t.id = m.tenant_id
+		WHERE m.pool_id = ? AND m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?
+			AND t.status IN (?, ?, ?) FOR UPDATE`,
+		poolID, organizationID, TenantPoolBindingFree, tidbCloudNativeSharedProvider,
+		TenantPending, TenantProvisioning, TenantActive).Scan(&sharedSlots)
+	if err != nil {
+		return fmt.Errorf("count logical tenant pool %q shared slots: %w", poolID, err)
+	}
+	current := nativeSlots + sharedSlots
+	if current+incoming > size {
+		return fmt.Errorf("logical tenant pool %q capacity changed: durable=%d incoming=%d size=%d", poolID, current, incoming, size)
+	}
+	return nil
+}
+
+func finalizeManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, staged stagedManagedSharedDBPoolWavePlan) error {
 	if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_placements
 		(fs_id, db_id, placement, schema_shape, status, target_db_id) VALUES `+
-		multiRowPlaceholders(len(plan.members), 6), placementArgs...); err != nil {
-		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave placements: %w", err)
+		multiRowPlaceholders(len(staged.tenantIDs), 6), staged.placementArgs...); err != nil {
+		return fmt.Errorf("insert wave placements: %w", err)
 	}
 	if _, err := tx.ExecContext(ctx, `INSERT INTO tenant_pool_memberships
 		(tenant_id, tidbcloud_organization_id, pool_id, pool_status, created_at, updated_at) VALUES `+
-		multiRowPlaceholders(len(plan.members), 6), membershipArgs...); err != nil {
-		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("insert wave memberships: %w", err)
+		multiRowPlaceholders(len(staged.tenantIDs), 6), staged.membershipArgs...); err != nil {
+		return fmt.Errorf("insert wave memberships: %w", err)
 	}
 	res, err := tx.ExecContext(ctx, `UPDATE db_pool SET tenant_count = ?, soft_cap_reached = CASE WHEN ? >= max_tenants THEN 1 ELSE 0 END
-		WHERE db_id = ? AND status = ?`, len(plan.members), len(plan.members), dbID, SharedDBStatusPending)
+		WHERE db_id = ? AND status = ?`, len(staged.tenantIDs), len(staged.tenantIDs), staged.dbID, SharedDBStatusPending)
 	if err != nil {
-		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("reserve wave physical capacity: %w", err)
+		return fmt.Errorf("reserve wave physical capacity: %w", err)
 	}
 	affected, err := res.RowsAffected()
 	if err != nil {
-		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("reserve wave physical capacity rows affected: %w", err)
+		return fmt.Errorf("reserve wave physical capacity rows affected: %w", err)
 	}
 	if affected != 1 {
-		return ManagedSharedDBPoolWaveResult{}, fmt.Errorf("reserve wave physical capacity changed %d rows for db pool %d", affected, dbID)
+		return fmt.Errorf("reserve wave physical capacity changed %d rows for db pool %d", affected, staged.dbID)
 	}
-	return ManagedSharedDBPoolWaveResult{DBID: dbID, TenantIDs: tenantIDs}, nil
+	return nil
 }

--- a/pkg/meta/shared_pool_wave.go
+++ b/pkg/meta/shared_pool_wave.go
@@ -32,6 +32,14 @@ type ManagedSharedDBPoolWaveResult struct {
 	TenantIDs []string
 }
 
+// ManagedSharedDBPoolWaveResize atomically grows the logical tenant pool with
+// a shared physical-pool reservation wave. ExpectedSize fences stale admin
+// decisions; TargetSize is the capacity limit published with the wave.
+type ManagedSharedDBPoolWaveResize struct {
+	ExpectedSize int
+	TargetSize   int
+}
+
 type preparedManagedSharedDBPoolWavePlan struct {
 	values  managedSharedDBInsertValues
 	members []ManagedSharedDBPoolWaveMember
@@ -53,7 +61,13 @@ func multiRowPlaceholders(rows, columns int) string {
 // together with all logical tenant reservations assigned to it. A direct
 // allocator therefore cannot observe refill-staged physical capacity before
 // tenant_count, placements, and pool memberships account for the wave.
-func (s *Store) CreateManagedSharedDBPoolTenantWave(ctx context.Context, plans []ManagedSharedDBPoolWavePlan) (out []ManagedSharedDBPoolWaveResult, err error) {
+func (s *Store) CreateManagedSharedDBPoolTenantWave(ctx context.Context, plans []ManagedSharedDBPoolWavePlan) ([]ManagedSharedDBPoolWaveResult, error) {
+	return s.CreateManagedSharedDBPoolTenantWaveWithResize(ctx, plans, nil)
+}
+
+// CreateManagedSharedDBPoolTenantWaveWithResize stages a wave and optionally
+// grows its logical pool in the same transaction.
+func (s *Store) CreateManagedSharedDBPoolTenantWaveWithResize(ctx context.Context, plans []ManagedSharedDBPoolWavePlan, resize *ManagedSharedDBPoolWaveResize) (out []ManagedSharedDBPoolWaveResult, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "create_managed_shared_db_pool_tenant_wave", start, &err)
 	if len(plans) == 0 {
@@ -131,7 +145,7 @@ func (s *Store) CreateManagedSharedDBPoolTenantWave(ctx context.Context, plans [
 			// tenant/quota/profile staging. If delete or shrink committed first,
 			// the complete uncommitted wave rolls back before any membership is
 			// published or Cloud request can start.
-			if validateErr := validateManagedSharedDBPoolWaveOwnership(ctx, tx, wavePoolID, waveOrganizationID, waveMemberCount); validateErr != nil {
+			if validateErr := validateManagedSharedDBPoolWaveOwnership(ctx, tx, wavePoolID, waveOrganizationID, waveMemberCount, resize); validateErr != nil {
 				return validateErr
 			}
 			for i := range staged {
@@ -258,7 +272,7 @@ func stageManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID i
 		placementArgs: placementArgs, membershipArgs: membershipArgs}, nil
 }
 
-func validateManagedSharedDBPoolWaveOwnership(ctx context.Context, tx *sql.Tx, poolID, organizationID string, incoming int) error {
+func validateManagedSharedDBPoolWaveOwnership(ctx context.Context, tx *sql.Tx, poolID, organizationID string, incoming int, resize *ManagedSharedDBPoolWaveResize) error {
 	var currentOrganizationID sql.NullString
 	var size int
 	var status TenantPoolStatus
@@ -276,7 +290,18 @@ func validateManagedSharedDBPoolWaveOwnership(ctx context.Context, tx *sql.Tx, p
 	if !currentOrganizationID.Valid || strings.TrimSpace(currentOrganizationID.String) != organizationID {
 		return fmt.Errorf("logical tenant pool %q organization does not match refill wave", poolID)
 	}
-	var nativeSlots, sharedSlots int
+	capacityLimit := size
+	if resize != nil {
+		if resize.ExpectedSize <= 0 || resize.TargetSize <= resize.ExpectedSize {
+			return fmt.Errorf("invalid logical tenant pool grow contract")
+		}
+		if size != resize.ExpectedSize {
+			return fmt.Errorf("logical tenant pool %q size changed: have=%d expected=%d", poolID, size, resize.ExpectedSize)
+		}
+		capacityLimit = resize.TargetSize
+	}
+
+	var nativeSlots, sharedActiveSlots, sharedPlannedSlots int
 	// Match leader refill accounting: native work is request-credential-owned,
 	// so only active native inventory offsets a leader-owned shared wave.
 	err = tx.QueryRowContext(ctx, `SELECT COUNT(*)
@@ -293,15 +318,48 @@ func validateManagedSharedDBPoolWaveOwnership(ctx context.Context, tx *sql.Tx, p
 		FROM tenant_pool_memberships m
 		STRAIGHT_JOIN tenants t ON t.id = m.tenant_id
 		WHERE m.pool_id = ? AND m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?
-			AND t.status IN (?, ?, ?) FOR UPDATE`,
+			AND t.status = ? FOR UPDATE`,
 		poolID, organizationID, TenantPoolBindingFree, tidbCloudNativeSharedProvider,
-		TenantPending, TenantProvisioning, TenantActive).Scan(&sharedSlots)
+		TenantActive).Scan(&sharedActiveSlots)
 	if err != nil {
-		return fmt.Errorf("count logical tenant pool %q shared slots: %w", poolID, err)
+		return fmt.Errorf("count logical tenant pool %q active shared slots: %w", poolID, err)
 	}
-	current := nativeSlots + sharedSlots
-	if current+incoming > size {
-		return fmt.Errorf("logical tenant pool %q capacity changed: durable=%d incoming=%d size=%d", poolID, current, incoming, size)
+	// A pending/provisioning membership is planned capacity only while its fs,
+	// placement, and non-terminal physical DB attempt still exist. This matches
+	// CountTenantPoolPlannedSlots and prevents orphan memberships from fencing
+	// otherwise valid replacement waves.
+	err = tx.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM tenant_pool_memberships m
+		STRAIGHT_JOIN tenants t ON t.id = m.tenant_id
+		STRAIGHT_JOIN fs_registry f ON f.tenant_id = t.id
+		STRAIGHT_JOIN tenant_placements p ON p.fs_id = f.fs_id
+		STRAIGHT_JOIN db_pool d ON d.db_id = p.db_id
+		WHERE m.pool_id = ? AND m.tidbcloud_organization_id = ? AND m.pool_status = ? AND t.provider = ?
+			AND t.status IN (?, ?) AND d.status IN (?, ?, ?) FOR UPDATE`,
+		poolID, organizationID, TenantPoolBindingFree, tidbCloudNativeSharedProvider,
+		TenantPending, TenantProvisioning, SharedDBStatusPending, SharedDBStatusProvisioning, SharedDBStatusActive).
+		Scan(&sharedPlannedSlots)
+	if err != nil {
+		return fmt.Errorf("count logical tenant pool %q planned shared slots: %w", poolID, err)
+	}
+	current := nativeSlots + sharedActiveSlots + sharedPlannedSlots
+	if current+incoming > capacityLimit {
+		return fmt.Errorf("logical tenant pool %q capacity changed: durable=%d incoming=%d size=%d", poolID, current, incoming, capacityLimit)
+	}
+	if resize != nil {
+		res, updateErr := tx.ExecContext(ctx, `UPDATE tenant_tidbcloud_pools
+			SET size = ?, updated_at = ? WHERE pool_id = ? AND size = ? AND status = ?`,
+			resize.TargetSize, time.Now().UTC(), poolID, resize.ExpectedSize, TenantPoolActive)
+		if updateErr != nil {
+			return fmt.Errorf("grow logical tenant pool %q: %w", poolID, updateErr)
+		}
+		updated, rowsErr := res.RowsAffected()
+		if rowsErr != nil {
+			return fmt.Errorf("grow logical tenant pool %q rows affected: %w", poolID, rowsErr)
+		}
+		if updated != 1 {
+			return fmt.Errorf("grow logical tenant pool %q affected %d rows, want 1", poolID, updated)
+		}
 	}
 	return nil
 }

--- a/pkg/meta/tenant_pool_failed_cleanup.go
+++ b/pkg/meta/tenant_pool_failed_cleanup.go
@@ -99,6 +99,39 @@ func (s *Store) ListFailedSharedTenantCleanupCandidates(ctx context.Context, org
 	return scanTenantRows(rows)
 }
 
+// ListFailedSharedTenantCleanupCandidatesByDB scopes one cleanup pass to an
+// exact failed physical pool while reusing the same tenant cleanup state
+// machine as request-triggered organization cleanup.
+func (s *Store) ListFailedSharedTenantCleanupCandidatesByDB(ctx context.Context, dbID int64, updatedBefore time.Time, limit int) (out []Tenant, err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "list_failed_shared_tenant_cleanup_candidates_by_db", start, &err)
+	if dbID <= 0 {
+		return nil, fmt.Errorf("db_id must be positive")
+	}
+	if limit <= 0 {
+		limit = 10
+	}
+	rows, err := s.db.QueryContext(ctx, `SELECT
+			t.id, t.status, t.kind, t.parent_tenant_id, t.storage_namespace_id,
+			t.db_host, t.db_port, t.db_user, t.db_password, t.db_name,
+			t.db_tls, t.provider, t.cluster_id, t.branch_id, t.claim_url, t.claim_expires_at, t.schema_version,
+			t.s3_encryption_mode, t.s3_kms_key_id, t.s3_bucket_key_enabled, t.created_at, t.updated_at
+		FROM tenant_placements p
+		JOIN fs_registry f ON f.fs_id = p.fs_id
+		JOIN tenants t ON t.id = f.tenant_id
+		JOIN db_pool d ON d.db_id = p.db_id
+		WHERE p.db_id = ? AND d.role = ? AND d.status = ?
+			AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+		ORDER BY t.updated_at ASC, t.id ASC
+		LIMIT ?`, dbID, SharedDBRoleShared, SharedDBStatusFailed,
+		tidbCloudNativeSharedProvider, TenantFailed, updatedBefore.UTC(), limit)
+	if err != nil {
+		return nil, fmt.Errorf("list failed shared tenant cleanup candidates for db pool %d: %w", dbID, err)
+	}
+	defer func() { _ = rows.Close() }()
+	return scanTenantRows(rows)
+}
+
 // MarkFailedNativeTenantDeleting claims an eligible native cleanup row. The
 // locked read and update both repeat the organization and pool-claim boundary.
 func (s *Store) MarkFailedNativeTenantDeleting(ctx context.Context, tenantID, organizationID string, updatedBefore time.Time) (updated bool, err error) {

--- a/pkg/meta/tenant_pool_failed_cleanup.go
+++ b/pkg/meta/tenant_pool_failed_cleanup.go
@@ -71,7 +71,7 @@ func (s *Store) ListFailedSharedTenantCleanupCandidates(ctx context.Context, org
 			FROM tenant_pool_memberships m
 			JOIN tenants t ON t.id = m.tenant_id
 			WHERE m.tidbcloud_organization_id = ? AND m.pool_status = ?
-				AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+				AND t.provider = ? AND t.status IN (?, ?) AND t.updated_at <= ?
 
 			UNION ALL
 
@@ -86,12 +86,12 @@ func (s *Store) ListFailedSharedTenantCleanupCandidates(ctx context.Context, org
 			JOIN tenants t ON t.id = f.tenant_id
 			LEFT JOIN tenant_pool_memberships m ON m.tenant_id = t.id
 			WHERE d.org_id = ? AND m.tenant_id IS NULL
-				AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+				AND t.provider = ? AND t.status IN (?, ?) AND t.updated_at <= ?
 		) c
 		ORDER BY c.updated_at ASC, c.id ASC
 		LIMIT ?`, organizationID, TenantPoolBindingFree, tidbCloudNativeSharedProvider,
-		TenantFailed, updatedBefore.UTC(), organizationID, tidbCloudNativeSharedProvider,
-		TenantFailed, updatedBefore.UTC(), limit)
+		TenantFailed, TenantDeleting, updatedBefore.UTC(), organizationID, tidbCloudNativeSharedProvider,
+		TenantFailed, TenantDeleting, updatedBefore.UTC(), limit)
 	if err != nil {
 		return nil, fmt.Errorf("list failed shared tenant cleanup candidates: %w", err)
 	}
@@ -121,10 +121,10 @@ func (s *Store) ListFailedSharedTenantCleanupCandidatesByDB(ctx context.Context,
 		JOIN tenants t ON t.id = f.tenant_id
 		JOIN db_pool d ON d.db_id = p.db_id
 		WHERE p.db_id = ? AND d.role = ? AND d.status = ?
-			AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+			AND t.provider = ? AND t.status IN (?, ?) AND t.updated_at <= ?
 		ORDER BY t.updated_at ASC, t.id ASC
 		LIMIT ?`, dbID, SharedDBRoleShared, SharedDBStatusFailed,
-		tidbCloudNativeSharedProvider, TenantFailed, updatedBefore.UTC(), limit)
+		tidbCloudNativeSharedProvider, TenantFailed, TenantDeleting, updatedBefore.UTC(), limit)
 	if err != nil {
 		return nil, fmt.Errorf("list failed shared tenant cleanup candidates for db pool %d: %w", dbID, err)
 	}
@@ -205,7 +205,7 @@ func (s *Store) MarkFailedSharedTenantDeleting(ctx context.Context, tenantID, or
 		var lockedTenantID string
 		if err := tx.QueryRowContext(ctx, `SELECT t.id
 			FROM tenants t
-			WHERE t.id = ? AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+			WHERE t.id = ? AND t.provider = ? AND t.status IN (?, ?) AND t.updated_at <= ?
 				AND (
 					EXISTS (
 						SELECT 1 FROM tenant_pool_memberships m
@@ -226,13 +226,13 @@ func (s *Store) MarkFailedSharedTenantDeleting(ctx context.Context, tenantID, or
 						)
 					)
 				)
-			LIMIT 1 FOR UPDATE`, tenantID, tidbCloudNativeSharedProvider, TenantFailed,
+			LIMIT 1 FOR UPDATE`, tenantID, tidbCloudNativeSharedProvider, TenantFailed, TenantDeleting,
 			updatedBefore.UTC(), TenantPoolBindingFree, organizationID, organizationID).Scan(&lockedTenantID); err != nil {
 			return err
 		}
 		res, err := tx.ExecContext(ctx, `UPDATE tenants t
 			SET t.status = ?, t.updated_at = ?
-			WHERE t.id = ? AND t.provider = ? AND t.status = ? AND t.updated_at <= ?
+			WHERE t.id = ? AND t.provider = ? AND t.status IN (?, ?) AND t.updated_at <= ?
 				AND (
 					EXISTS (
 						SELECT 1 FROM tenant_pool_memberships m
@@ -253,7 +253,7 @@ func (s *Store) MarkFailedSharedTenantDeleting(ctx context.Context, tenantID, or
 						)
 					)
 				)`, TenantDeleting, time.Now().UTC(), lockedTenantID,
-			tidbCloudNativeSharedProvider, TenantFailed, updatedBefore.UTC(), TenantPoolBindingFree,
+			tidbCloudNativeSharedProvider, TenantFailed, TenantDeleting, updatedBefore.UTC(), TenantPoolBindingFree,
 			organizationID, organizationID)
 		if err != nil {
 			return err

--- a/pkg/meta/tenant_pool_failed_cleanup_test.go
+++ b/pkg/meta/tenant_pool_failed_cleanup_test.go
@@ -120,6 +120,40 @@ func TestListFailedSharedTenantCleanupCandidatesByDBScopesPhysicalPool(t *testin
 	}
 }
 
+func TestFailedSharedTenantCleanupReclaimsStaleDeletingCandidate(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	old := now.Add(-2 * time.Hour)
+	dbID := seedSharedCleanupPlacement(t, s, "shared-stale-deleting", "org-stale-deleting",
+		tidbCloudNativeSharedProvider, TenantFailed, old)
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, SharedDBStatusFailed, dbID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ? WHERE id = ?`,
+		TenantDeleting, old, "shared-stale-deleting"); err != nil {
+		t.Fatal(err)
+	}
+	candidates, err := s.ListFailedSharedTenantCleanupCandidatesByDB(ctx, dbID, now.Add(-30*time.Minute), 10)
+	if err != nil {
+		t.Fatalf("ListFailedSharedTenantCleanupCandidatesByDB: %v", err)
+	}
+	if ids := cleanupTenantIDs(candidates); fmt.Sprint(ids) != "[shared-stale-deleting]" {
+		t.Fatalf("stale deleting candidates = %v, want reclaimed tenant", ids)
+	}
+	owned, err := s.MarkFailedSharedTenantDeleting(ctx, "shared-stale-deleting", "org-stale-deleting", now.Add(-30*time.Minute))
+	if err != nil || !owned {
+		t.Fatalf("MarkFailedSharedTenantDeleting owned=%v err=%v", owned, err)
+	}
+	tenant, err := s.GetTenant(ctx, "shared-stale-deleting")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tenant.Status != TenantDeleting || !tenant.UpdatedAt.After(old) {
+		t.Fatalf("reclaimed tenant = status %q updated_at %s", tenant.Status, tenant.UpdatedAt)
+	}
+}
+
 func TestFailedTenantCleanupCooldownRestartsAfterTenantUpdate(t *testing.T) {
 	tests := []struct {
 		name string

--- a/pkg/meta/tenant_pool_failed_cleanup_test.go
+++ b/pkg/meta/tenant_pool_failed_cleanup_test.go
@@ -97,6 +97,29 @@ func TestListFailedSharedTenantCleanupCandidatesUsesMembershipOrPlacementOrganiz
 	}
 }
 
+func TestListFailedSharedTenantCleanupCandidatesByDBScopesPhysicalPool(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	firstDBID := seedSharedCleanupPlacement(t, s, "shared-db-first", "org-shared", tidbCloudNativeSharedProvider,
+		TenantFailed, now.Add(-2*time.Hour))
+	seedSharedCleanupPlacement(t, s, "shared-db-second", "org-shared", tidbCloudNativeSharedProvider,
+		TenantFailed, now.Add(-3*time.Hour))
+	seedSharedCleanupPlacement(t, s, "shared-db-recent", "org-shared", tidbCloudNativeSharedProvider,
+		TenantFailed, now.Add(-5*time.Minute))
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, SharedDBStatusFailed, firstDBID); err != nil {
+		t.Fatalf("mark first physical pool failed: %v", err)
+	}
+
+	got, err := s.ListFailedSharedTenantCleanupCandidatesByDB(ctx, firstDBID, now.Add(-30*time.Minute), 10)
+	if err != nil {
+		t.Fatalf("ListFailedSharedTenantCleanupCandidatesByDB: %v", err)
+	}
+	if ids := cleanupTenantIDs(got); fmt.Sprint(ids) != "[shared-db-first]" {
+		t.Fatalf("physical DB candidates = %v, want only first DB tenant", ids)
+	}
+}
+
 func TestFailedTenantCleanupCooldownRestartsAfterTenantUpdate(t *testing.T) {
 	tests := []struct {
 		name string
@@ -372,13 +395,13 @@ func seedSharedCleanupMembership(t *testing.T, s *Store, tenantID, organizationI
 	}
 }
 
-func seedSharedCleanupPlacement(t *testing.T, s *Store, tenantID, organizationID, provider string, status TenantStatus, updatedAt time.Time) {
+func seedSharedCleanupPlacement(t *testing.T, s *Store, tenantID, organizationID, provider string, status TenantStatus, updatedAt time.Time) int64 {
 	t.Helper()
 	insertCleanupTenant(t, s, tenantID, provider, status, updatedAt)
-	seedSharedCleanupPlacementForExistingTenant(t, s, tenantID, organizationID)
+	return seedSharedCleanupPlacementForExistingTenant(t, s, tenantID, organizationID)
 }
 
-func seedSharedCleanupPlacementForExistingTenant(t *testing.T, s *Store, tenantID, organizationID string) {
+func seedSharedCleanupPlacementForExistingTenant(t *testing.T, s *Store, tenantID, organizationID string) int64 {
 	t.Helper()
 	dbID, err := s.RegisterSharedDB(context.Background(), &SharedDB{
 		TiDBCloudOrganizationID: organizationID, Host: "host-" + tenantID, Port: 4000,
@@ -396,6 +419,7 @@ func seedSharedCleanupPlacementForExistingTenant(t *testing.T, s *Store, tenantI
 	}); err != nil {
 		t.Fatalf("UpsertTenantPlacement(%s): %v", tenantID, err)
 	}
+	return dbID
 }
 
 func insertCleanupTenant(t *testing.T, s *Store, tenantID, provider string, status TenantStatus, updatedAt time.Time) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -46,8 +46,17 @@ type tenantPoolResumeJob struct {
 type tenantPoolWorkGate struct {
 	mu          sync.Mutex
 	running     bool
+	rerun       bool
+	scheduled   bool
 	nextAllowed time.Time
 }
+
+type tenantPoolReplenishDecision struct {
+	start         bool
+	scheduleAfter time.Duration
+}
+
+type tenantPoolWorkerStarter func(context.Context, func(context.Context)) bool
 
 type adminTenantPoolStatus string
 
@@ -1881,15 +1890,41 @@ func firstResultOrganizationID(results []*provisionTenantResult) string {
 }
 
 func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {
+	s.replenishTenantPoolAsyncWithStarters(ctx, pool, cred, s.startServerWorker, s.startServerWorker)
+}
+
+func (s *Server) replenishTenantPoolLeaderAsync(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {
+	s.replenishTenantPoolAsyncWithStarters(ctx, pool, cred, s.startTenantPoolLeaderReconcileWorker, s.startManagedSharedDBWorker)
+}
+
+func (s *Server) replenishTenantPoolAsyncWithStarters(
+	ctx context.Context,
+	pool *meta.TenantPool,
+	cred tenant.CredentialProvisionRequest,
+	workStarter tenantPoolWorkerStarter,
+	timerStarter tenantPoolWorkerStarter,
+) {
 	if pool == nil || pool.PoolID == "" || pool.OrganizationID == "" || pool.Size <= 0 {
 		return
 	}
-	if !s.beginTenantPoolReplenishment(pool.PoolID) {
+	if workStarter == nil || timerStarter == nil {
+		return
+	}
+	decision := s.requestTenantPoolReplenishmentAt(pool.PoolID, time.Now())
+	if !decision.start {
+		if decision.scheduleAfter > 0 {
+			s.scheduleTenantPoolReplenishment(ctx, pool, cred, decision.scheduleAfter, workStarter, timerStarter)
+		}
 		return
 	}
 	workerCtx := backgroundWithTrace(ctx)
-	if !s.startServerWorker(workerCtx, func(ctx context.Context) {
-		defer s.finishTenantPoolReplenishment(pool.PoolID)
+	if !workStarter(workerCtx, func(ctx context.Context) {
+		defer func() {
+			finished := s.finishTenantPoolReplenishmentAt(pool.PoolID, time.Now())
+			if finished.scheduleAfter > 0 {
+				s.scheduleTenantPoolReplenishment(ctx, pool, cred, finished.scheduleAfter, workStarter, timerStarter)
+			}
+		}()
 		replenishStarted := time.Now()
 		metricResult := "ok"
 		defer func() {
@@ -1988,8 +2023,29 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 			}
 		}
 	}) {
-		s.finishTenantPoolReplenishment(pool.PoolID)
+		_ = s.finishTenantPoolReplenishmentAt(pool.PoolID, time.Now())
 	}
+}
+
+func (s *Server) scheduleTenantPoolReplenishment(
+	ctx context.Context,
+	pool *meta.TenantPool,
+	cred tenant.CredentialProvisionRequest,
+	delay time.Duration,
+	workStarter tenantPoolWorkerStarter,
+	timerStarter tenantPoolWorkerStarter,
+) {
+	workerCtx := backgroundWithTrace(ctx)
+	_ = timerStarter(workerCtx, func(ctx context.Context) {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			s.replenishTenantPoolAsyncWithStarters(ctx, pool, cred, workStarter, timerStarter)
+		}
+	})
 }
 
 func (s *Server) tenantPoolBelowRefillWatermark(freeSize, poolSize int) bool {
@@ -2079,39 +2135,51 @@ func (s *Server) tenantPoolLock(poolID string) *sync.Mutex {
 	return v.(*sync.Mutex)
 }
 
-func (s *Server) beginTenantPoolReplenishment(poolID string) bool {
-	return s.beginTenantPoolReplenishmentAt(poolID, time.Now())
+func (s *Server) beginTenantPoolReplenishmentAt(poolID string, now time.Time) bool {
+	return s.requestTenantPoolReplenishmentAt(poolID, now).start
 }
 
-func (s *Server) beginTenantPoolReplenishmentAt(poolID string, now time.Time) bool {
+func (s *Server) requestTenantPoolReplenishmentAt(poolID string, now time.Time) tenantPoolReplenishDecision {
 	if strings.TrimSpace(poolID) == "" {
-		return false
+		return tenantPoolReplenishDecision{}
 	}
 	value, _ := s.tenantPoolReplenishJobs.LoadOrStore(poolID, &tenantPoolWorkGate{})
 	gate := value.(*tenantPoolWorkGate)
 	gate.mu.Lock()
 	defer gate.mu.Unlock()
-	if gate.running || now.Before(gate.nextAllowed) {
-		return false
+	if gate.running {
+		gate.rerun = true
+		return tenantPoolReplenishDecision{}
+	}
+	if now.Before(gate.nextAllowed) {
+		gate.rerun = true
+		if gate.scheduled {
+			return tenantPoolReplenishDecision{}
+		}
+		gate.scheduled = true
+		return tenantPoolReplenishDecision{scheduleAfter: gate.nextAllowed.Sub(now)}
 	}
 	gate.running = true
-	return true
+	gate.rerun = false
+	gate.scheduled = false
+	return tenantPoolReplenishDecision{start: true}
 }
 
-func (s *Server) finishTenantPoolReplenishment(poolID string) {
-	s.finishTenantPoolReplenishmentAt(poolID, time.Now())
-}
-
-func (s *Server) finishTenantPoolReplenishmentAt(poolID string, now time.Time) {
+func (s *Server) finishTenantPoolReplenishmentAt(poolID string, now time.Time) tenantPoolReplenishDecision {
 	value, ok := s.tenantPoolReplenishJobs.Load(poolID)
 	if !ok {
-		return
+		return tenantPoolReplenishDecision{}
 	}
 	gate := value.(*tenantPoolWorkGate)
 	gate.mu.Lock()
+	defer gate.mu.Unlock()
 	gate.running = false
 	gate.nextAllowed = now.Add(tenantPoolReplenishMinInterval)
-	gate.mu.Unlock()
+	if !gate.rerun || gate.scheduled {
+		return tenantPoolReplenishDecision{}
+	}
+	gate.scheduled = true
+	return tenantPoolReplenishDecision{scheduleAfter: tenantPoolReplenishMinInterval}
 }
 
 func (s *Server) beginTenantPoolResumeScan(poolID string) bool {
@@ -2221,6 +2289,7 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "reason", "pool_inactive", "pool_status", pool.Status, "duration_ms", durationMillis(claimStarted))...)
 		return nil, nil, false, false, nil
 	}
+	defer s.replenishTenantPoolAsync(ctx, pool, cred)
 	s.resumePendingTenantPoolAsync(ctx, pool, cred)
 	stageStarted = time.Now()
 	selection, err := retryTenantPoolClaimCAS(func() (tenantPoolClaimSelection, error) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1214,70 +1214,15 @@ func (s *Server) provisionManagedSharedDBPoolsBatchWithCredentials(ctx context.C
 }
 
 func (s *Server) provisionManagedSharedDBPoolAllocationGroup(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) (string, error) {
-	for attempt := 0; attempt < 2; attempt++ {
-		first, err := s.meta.GetSharedDB(ctx, dbIDs[0])
-		if err != nil {
-			return "", err
-		}
-		identity := sharedDBAllocationIdentity(first.TiDBCloudOrganizationID, first.ProvisioningKey)
-		restartWithOrganization := false
-		resolvedOrg := ""
-		err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
-			current, err := s.meta.GetSharedDB(lockCtx, dbIDs[0])
-			if err != nil {
-				return err
-			}
-			if strings.TrimSpace(first.TiDBCloudOrganizationID) != strings.TrimSpace(current.TiDBCloudOrganizationID) {
-				restartWithOrganization = true
-				return nil
-			}
-			var createErr error
-			resolvedOrg, createErr = s.provisionManagedSharedDBPoolsBatchLocked(lockCtx, provisioner, dbIDs, cred)
-			return createErr
-		})
-		if err != nil {
-			return resolvedOrg, err
-		}
-		if !restartWithOrganization {
-			return resolvedOrg, nil
-		}
+	first, err := s.meta.GetSharedDB(ctx, dbIDs[0])
+	if err != nil {
+		return "", err
 	}
-	return "", fmt.Errorf("shared DB pool batch allocation identity kept changing")
+	resolvedOrg := strings.TrimSpace(first.TiDBCloudOrganizationID)
+	return resolvedOrg, s.provisionManagedSharedDBPoolsBatchForGroup(ctx, provisioner, dbIDs, cred)
 }
 
-func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) (string, error) {
-	requests := make([]tenant.SharedDBPoolCreateRequest, 0, len(dbIDs))
-	rows := make(map[int64]*meta.SharedDB, len(dbIDs))
-	resolvedOrg := ""
-	for _, dbID := range dbIDs {
-		row, err := s.meta.GetSharedDB(ctx, dbID)
-		if err != nil {
-			return resolvedOrg, err
-		}
-		if resolvedOrg == "" {
-			resolvedOrg = row.TiDBCloudOrganizationID
-		}
-		// A concurrent direct continuation may have completed physical creation
-		// before this batch acquired the organization lock. Its cluster must be
-		// adopted/refreshed by the normal continuation, never created again.
-		if row.ClusterID != "" {
-			continue
-		}
-		plain, err := s.pool.Decrypt(ctx, row.PasswordCipher)
-		if err != nil {
-			return resolvedOrg, err
-		}
-		if row.SpendingLimit == nil {
-			return resolvedOrg, fmt.Errorf("managed db pool %d has no spending target", dbID)
-		}
-		rows[dbID] = row
-		requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID, DBPoolUUID: row.UUID,
-			CustomerOrganizationID: strings.TrimSpace(row.TiDBCloudOrganizationID), DatabaseName: row.Name,
-			RootPassword: string(plain), SpendingLimitMonthly: *row.SpendingLimit})
-	}
-	if len(requests) == 0 {
-		return resolvedOrg, nil
-	}
+func (s *Server) provisionManagedSharedDBPoolsBatchForGroup(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) error {
 	type batchResult struct {
 		err error
 	}
@@ -1285,23 +1230,35 @@ func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, p
 	if batchSize <= 0 {
 		batchSize = DefaultManagedSharedDBCloudBatchSize
 	}
-	batchCount := (len(requests) + batchSize - 1) / batchSize
+	batchCount := (len(dbIDs) + batchSize - 1) / batchSize
 	batchResults := make([]batchResult, batchCount)
-	batches := make([][]tenant.SharedDBPoolCreateRequest, 0, batchCount)
-	for start := 0; start < len(requests); start += batchSize {
-		end := min(start+batchSize, len(requests))
-		batches = append(batches, append([]tenant.SharedDBPoolCreateRequest(nil), requests[start:end]...))
+	batches := make([][]int64, 0, batchCount)
+	for start := 0; start < len(dbIDs); start += batchSize {
+		end := min(start+batchSize, len(dbIDs))
+		batches = append(batches, append([]int64(nil), dbIDs[start:end]...))
 	}
+	poolLimit := s.managedSharedDBRefillPoolLimit
+	if poolLimit <= 0 {
+		poolLimit = DefaultManagedSharedDBRefillPoolLimit
+	}
+	batchSlots := make(chan struct{}, max(1, (poolLimit+batchSize-1)/batchSize))
 	var wg sync.WaitGroup
 	for batchIndex := range batches {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			select {
+			case batchSlots <- struct{}{}:
+				defer func() { <-batchSlots }()
+			case <-ctx.Done():
+				batchResults[batchIndex].err = ctx.Err()
+				return
+			}
 			if err := ctx.Err(); err != nil {
 				batchResults[batchIndex].err = err
 				return
 			}
-			batchResults[batchIndex].err = s.provisionManagedSharedDBPoolsBatchChunkLocked(ctx, provisioner, batches[batchIndex], rows, cred)
+			batchResults[batchIndex].err = s.provisionManagedSharedDBPoolsBatchChunk(ctx, provisioner, batches[batchIndex], cred)
 		}()
 	}
 	wg.Wait()
@@ -1309,10 +1266,44 @@ func (s *Server) provisionManagedSharedDBPoolsBatchLocked(ctx context.Context, p
 	for _, result := range batchResults {
 		batchErr = errors.Join(batchErr, result.err)
 	}
-	return resolvedOrg, batchErr
+	return batchErr
 }
 
-func (s *Server) provisionManagedSharedDBPoolsBatchChunkLocked(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, requests []tenant.SharedDBPoolCreateRequest, rows map[int64]*meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
+func (s *Server) provisionManagedSharedDBPoolsBatchChunk(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) error {
+	return s.meta.WithSharedDBPoolWorkClaims(ctx, dbIDs, func(claimCtx context.Context, ownedIDs []int64) error {
+		requests := make([]tenant.SharedDBPoolCreateRequest, 0, len(ownedIDs))
+		rows := make(map[int64]*meta.SharedDB, len(ownedIDs))
+		for _, dbID := range ownedIDs {
+			row, err := s.meta.GetSharedDB(claimCtx, dbID)
+			if err != nil {
+				return err
+			}
+			// Re-read after taking per-pool ownership. A concurrent direct
+			// continuation may have persisted the cluster before this batch
+			// acquired its claim; such rows continue through metadata polling.
+			if row.Status != meta.SharedDBStatusPending || strings.TrimSpace(row.ClusterID) != "" {
+				continue
+			}
+			plain, err := s.pool.Decrypt(claimCtx, row.PasswordCipher)
+			if err != nil {
+				return err
+			}
+			if row.SpendingLimit == nil {
+				return fmt.Errorf("managed db pool %d has no spending target", dbID)
+			}
+			rows[dbID] = row
+			requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID, DBPoolUUID: row.UUID,
+				CustomerOrganizationID: strings.TrimSpace(row.TiDBCloudOrganizationID), DatabaseName: row.Name,
+				RootPassword: string(plain), SpendingLimitMonthly: *row.SpendingLimit})
+		}
+		if len(requests) == 0 {
+			return nil
+		}
+		return s.provisionManagedSharedDBPoolsBatchChunkClaimed(claimCtx, provisioner, requests, rows, cred)
+	})
+}
+
+func (s *Server) provisionManagedSharedDBPoolsBatchChunkClaimed(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, requests []tenant.SharedDBPoolCreateRequest, rows map[int64]*meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
 	created, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, requests, cred)
 	if createErr != nil && len(created) == 0 {
 		logger.Warn(ctx, "managed_shared_db_batch_create_failed",

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1997,7 +1997,7 @@ func (s *Server) replenishTenantPoolAsyncWithStarters(
 				if sharedWaveRemaining <= 0 {
 					return
 				}
-				missing = min(missing, sharedWaveRemaining, maxTenants)
+				missing = min(missing, sharedWaveRemaining)
 			}
 			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
 			if err != nil {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -2058,7 +2058,10 @@ func (s *Server) replenishTenantPoolAsyncWithStarters(
 			}
 		}
 	}) {
-		_ = s.finishTenantPoolReplenishmentAt(pool.PoolID, time.Now())
+		finished := s.finishTenantPoolReplenishmentAt(pool.PoolID, time.Now())
+		if finished.scheduleAfter > 0 {
+			s.scheduleTenantPoolReplenishment(ctx, pool, cred, finished.scheduleAfter, workStarter, timerStarter)
+		}
 	}
 }
 
@@ -2071,7 +2074,7 @@ func (s *Server) scheduleTenantPoolReplenishment(
 	timerStarter tenantPoolWorkerStarter,
 ) {
 	workerCtx := backgroundWithTrace(ctx)
-	_ = timerStarter(workerCtx, func(ctx context.Context) {
+	if timerStarter(workerCtx, func(ctx context.Context) {
 		timer := time.NewTimer(delay)
 		defer timer.Stop()
 		select {
@@ -2080,7 +2083,10 @@ func (s *Server) scheduleTenantPoolReplenishment(
 		case <-timer.C:
 			s.replenishTenantPoolAsyncWithStarters(ctx, pool, cred, workStarter, timerStarter)
 		}
-	})
+	}) {
+		return
+	}
+	s.clearTenantPoolReplenishmentScheduled(pool.PoolID)
 }
 
 func (s *Server) tenantPoolBelowRefillWatermark(freeSize, poolSize int) bool {
@@ -2215,6 +2221,17 @@ func (s *Server) finishTenantPoolReplenishmentAt(poolID string, now time.Time) t
 	}
 	gate.scheduled = true
 	return tenantPoolReplenishDecision{scheduleAfter: tenantPoolReplenishMinInterval}
+}
+
+func (s *Server) clearTenantPoolReplenishmentScheduled(poolID string) {
+	value, ok := s.tenantPoolReplenishJobs.Load(poolID)
+	if !ok {
+		return
+	}
+	gate := value.(*tenantPoolWorkGate)
+	gate.mu.Lock()
+	gate.scheduled = false
+	gate.mu.Unlock()
 }
 
 func (s *Server) beginTenantPoolResumeScan(poolID string) bool {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1300,7 +1300,13 @@ func (s *Server) persistManagedSharedDBPoolCloudResults(ctx context.Context, res
 }
 
 func (s *Server) provisionManagedSharedDBPoolsBatchChunkClaimed(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, requests []tenant.SharedDBPoolCreateRequest, rows map[int64]*meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
-	created, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, requests, cred)
+	if err := s.acquireManagedSharedDBCloudBatchSlot(ctx); err != nil {
+		return err
+	}
+	created, createErr := func() ([]*tenant.SharedDBPoolInfo, error) {
+		defer s.releaseManagedSharedDBCloudBatchSlot()
+		return provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, requests, cred)
+	}()
 	if createErr != nil && len(created) == 0 {
 		logger.Warn(ctx, "managed_shared_db_batch_create_failed",
 			zap.Int("db_pool_count", len(requests)), zap.Error(createErr))
@@ -1312,6 +1318,24 @@ func (s *Server) provisionManagedSharedDBPoolsBatchChunkClaimed(ctx context.Cont
 			zap.Int("requested", len(requests)), zap.Int("persisted", len(persistedIDs)), zap.Error(createErr))
 	}
 	return errors.Join(createErr, persistErr)
+}
+
+func (s *Server) acquireManagedSharedDBCloudBatchSlot(ctx context.Context) error {
+	s.managedSharedDBCloudBatchSlotsOnce.Do(func() {
+		if s.managedSharedDBCloudBatchSlots == nil {
+			s.managedSharedDBCloudBatchSlots = make(chan struct{}, defaultManagedSharedDBCloudBatchConcurrency)
+		}
+	})
+	select {
+	case s.managedSharedDBCloudBatchSlots <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (s *Server) releaseManagedSharedDBCloudBatchSlot() {
+	<-s.managedSharedDBCloudBatchSlots
 }
 
 func (s *Server) markTenantPoolTenantFailed(ctx context.Context, tenantID, reason string) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1223,6 +1223,64 @@ func (s *Server) provisionManagedSharedDBPoolAllocationGroup(ctx context.Context
 }
 
 func (s *Server) provisionManagedSharedDBPoolsBatchForGroup(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) error {
+	return s.meta.WithSharedDBPoolWorkClaims(ctx, dbIDs, func(claimCtx context.Context, ownedIDs []int64) error {
+		return s.provisionManagedSharedDBPoolsBatchGroupClaimed(claimCtx, provisioner, ownedIDs, cred)
+	})
+}
+
+func (s *Server) provisionManagedSharedDBPoolsBatchGroupClaimed(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) error {
+	rows := make(map[int64]*meta.SharedDB, len(dbIDs))
+	loadRequests := make([]tenant.SharedDBPoolLoadRequest, 0, len(dbIDs))
+	for _, dbID := range dbIDs {
+		row, err := s.meta.GetSharedDB(ctx, dbID)
+		if err != nil {
+			return err
+		}
+		// Re-read after taking per-pool ownership. A concurrent direct
+		// continuation may have persisted the cluster before this group
+		// acquired its claim; such rows continue through metadata polling.
+		if row.Status != meta.SharedDBStatusPending || strings.TrimSpace(row.ClusterID) != "" {
+			continue
+		}
+		rows[dbID] = row
+		loadRequests = append(loadRequests, tenant.SharedDBPoolLoadRequest{DBPoolID: dbID, DBPoolUUID: row.UUID})
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+
+	discovered, loadErr := loadManagedSharedDBPoolsBeforeCreate(ctx, provisioner, loadRequests, cred)
+	adopted, persistErr := s.persistManagedSharedDBPoolCloudResults(ctx, discovered, rows)
+	if loadErr != nil || persistErr != nil {
+		// A failed lookup cannot prove that the Cloud POST did not already
+		// succeed, so retry discovery instead of issuing another create.
+		return errors.Join(loadErr, persistErr)
+	}
+
+	requests := make([]tenant.SharedDBPoolCreateRequest, 0, len(rows)-len(adopted))
+	for _, dbID := range dbIDs {
+		row := rows[dbID]
+		if row == nil {
+			continue
+		}
+		if _, ok := adopted[dbID]; ok {
+			continue
+		}
+		plain, err := s.pool.Decrypt(ctx, row.PasswordCipher)
+		if err != nil {
+			return err
+		}
+		if row.SpendingLimit == nil {
+			return fmt.Errorf("managed db pool %d has no spending target", dbID)
+		}
+		requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID, DBPoolUUID: row.UUID,
+			CustomerOrganizationID: strings.TrimSpace(row.TiDBCloudOrganizationID), DatabaseName: row.Name,
+			RootPassword: string(plain), SpendingLimitMonthly: *row.SpendingLimit})
+	}
+	if len(requests) == 0 {
+		return nil
+	}
+
 	type batchResult struct {
 		err error
 	}
@@ -1230,12 +1288,12 @@ func (s *Server) provisionManagedSharedDBPoolsBatchForGroup(ctx context.Context,
 	if batchSize <= 0 {
 		batchSize = DefaultManagedSharedDBCloudBatchSize
 	}
-	batchCount := (len(dbIDs) + batchSize - 1) / batchSize
+	batchCount := (len(requests) + batchSize - 1) / batchSize
 	batchResults := make([]batchResult, batchCount)
-	batches := make([][]int64, 0, batchCount)
-	for start := 0; start < len(dbIDs); start += batchSize {
-		end := min(start+batchSize, len(dbIDs))
-		batches = append(batches, append([]int64(nil), dbIDs[start:end]...))
+	batches := make([][]tenant.SharedDBPoolCreateRequest, 0, batchCount)
+	for start := 0; start < len(requests); start += batchSize {
+		end := min(start+batchSize, len(requests))
+		batches = append(batches, append([]tenant.SharedDBPoolCreateRequest(nil), requests[start:end]...))
 	}
 	poolLimit := s.managedSharedDBRefillPoolLimit
 	if poolLimit <= 0 {
@@ -1258,7 +1316,7 @@ func (s *Server) provisionManagedSharedDBPoolsBatchForGroup(ctx context.Context,
 				batchResults[batchIndex].err = err
 				return
 			}
-			batchResults[batchIndex].err = s.provisionManagedSharedDBPoolsBatchChunk(ctx, provisioner, batches[batchIndex], cred)
+			batchResults[batchIndex].err = s.provisionManagedSharedDBPoolsBatchChunkClaimed(ctx, provisioner, batches[batchIndex], rows, cred)
 		}()
 	}
 	wg.Wait()
@@ -1269,50 +1327,27 @@ func (s *Server) provisionManagedSharedDBPoolsBatchForGroup(ctx context.Context,
 	return batchErr
 }
 
-func (s *Server) provisionManagedSharedDBPoolsBatchChunk(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, dbIDs []int64, cred tenant.CredentialProvisionRequest) error {
-	return s.meta.WithSharedDBPoolWorkClaims(ctx, dbIDs, func(claimCtx context.Context, ownedIDs []int64) error {
-		requests := make([]tenant.SharedDBPoolCreateRequest, 0, len(ownedIDs))
-		rows := make(map[int64]*meta.SharedDB, len(ownedIDs))
-		for _, dbID := range ownedIDs {
-			row, err := s.meta.GetSharedDB(claimCtx, dbID)
-			if err != nil {
-				return err
-			}
-			// Re-read after taking per-pool ownership. A concurrent direct
-			// continuation may have persisted the cluster before this batch
-			// acquired its claim; such rows continue through metadata polling.
-			if row.Status != meta.SharedDBStatusPending || strings.TrimSpace(row.ClusterID) != "" {
-				continue
-			}
-			plain, err := s.pool.Decrypt(claimCtx, row.PasswordCipher)
-			if err != nil {
-				return err
-			}
-			if row.SpendingLimit == nil {
-				return fmt.Errorf("managed db pool %d has no spending target", dbID)
-			}
-			rows[dbID] = row
-			requests = append(requests, tenant.SharedDBPoolCreateRequest{DBPoolID: dbID, DBPoolUUID: row.UUID,
-				CustomerOrganizationID: strings.TrimSpace(row.TiDBCloudOrganizationID), DatabaseName: row.Name,
-				RootPassword: string(plain), SpendingLimitMonthly: *row.SpendingLimit})
+func loadManagedSharedDBPoolsBeforeCreate(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, requests []tenant.SharedDBPoolLoadRequest, cred tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+	if loader, ok := provisioner.(tenant.SharedDBPoolBatchLoader); ok {
+		return loader.BatchLoadSharedDBPoolsWithCredentials(ctx, requests, cred)
+	}
+	loaded := make([]*tenant.SharedDBPoolInfo, 0, len(requests))
+	for _, request := range requests {
+		info, err := provisioner.LoadSharedDBPoolWithCredentials(ctx, request.DBPoolID, request.DBPoolUUID, request.ClusterID, cred)
+		if err != nil {
+			return loaded, err
 		}
-		if len(requests) == 0 {
-			return nil
+		if info != nil {
+			loaded = append(loaded, info)
 		}
-		return s.provisionManagedSharedDBPoolsBatchChunkClaimed(claimCtx, provisioner, requests, rows, cred)
-	})
+	}
+	return loaded, nil
 }
 
-func (s *Server) provisionManagedSharedDBPoolsBatchChunkClaimed(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, requests []tenant.SharedDBPoolCreateRequest, rows map[int64]*meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
-	created, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, requests, cred)
-	if createErr != nil && len(created) == 0 {
-		logger.Warn(ctx, "managed_shared_db_batch_create_failed",
-			zap.Int("db_pool_count", len(requests)), zap.Error(createErr))
-		return createErr
-	}
+func (s *Server) persistManagedSharedDBPoolCloudResults(ctx context.Context, results []*tenant.SharedDBPoolInfo, rows map[int64]*meta.SharedDB) (map[int64]struct{}, error) {
+	persisted := make(map[int64]struct{}, len(results))
 	var persistErr error
-	persisted := 0
-	for _, info := range created {
+	for _, info := range results {
 		if info == nil || rows[info.DBPoolID] == nil || rows[info.DBPoolID].UUID != info.DBPoolUUID {
 			persistErr = errors.Join(persistErr, fmt.Errorf("shared db batch returned an unknown db pool"))
 			continue
@@ -1335,11 +1370,22 @@ func (s *Server) provisionManagedSharedDBPoolsBatchChunkClaimed(ctx context.Cont
 			persistErr = errors.Join(persistErr, err)
 			continue
 		}
-		persisted++
+		persisted[info.DBPoolID] = struct{}{}
 	}
+	return persisted, persistErr
+}
+
+func (s *Server) provisionManagedSharedDBPoolsBatchChunkClaimed(ctx context.Context, provisioner tenant.SharedDBPoolProvisioner, requests []tenant.SharedDBPoolCreateRequest, rows map[int64]*meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
+	created, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, requests, cred)
+	if createErr != nil && len(created) == 0 {
+		logger.Warn(ctx, "managed_shared_db_batch_create_failed",
+			zap.Int("db_pool_count", len(requests)), zap.Error(createErr))
+		return createErr
+	}
+	persistedIDs, persistErr := s.persistManagedSharedDBPoolCloudResults(ctx, created, rows)
 	if createErr != nil {
 		logger.Warn(ctx, "managed_shared_db_batch_create_partial",
-			zap.Int("requested", len(requests)), zap.Int("persisted", persisted), zap.Error(createErr))
+			zap.Int("requested", len(requests)), zap.Int("persisted", len(persistedIDs)), zap.Error(createErr))
 	}
 	return errors.Join(createErr, persistErr)
 }

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -67,7 +67,6 @@ const adminTenantPoolMetricsComponent = "admin_tenant_pool"
 const tenantPoolClaimCASRetryLimit = 8
 
 const (
-	sharedTenantPoolCreateConcurrency    = 30
 	tenantPoolReplenishMinInterval       = time.Second
 	tenantPoolPendingResumeEmptyInterval = 15 * time.Second
 )
@@ -976,7 +975,7 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 	if organizationID == "" {
 		return nil, fmt.Errorf("shared tenant pool organization is required")
 	}
-	partitions, err := s.stageSharedPoolTenantWave(ctx, organizationID, sharedCred, count)
+	partitions, err := s.stageSharedPoolTenantWave(ctx, poolID, organizationID, sharedCred, count, quotaOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -985,30 +984,20 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 		continuationIDs = append(continuationIDs, partition.db.ID)
 	}
 	sort.Slice(continuationIDs, func(i, j int) bool { return continuationIDs[i] < continuationIDs[j] })
-	provisionDone := make(chan error, 1)
-	go func() {
-		_, provisionErr := s.provisionManagedSharedDBPoolsBatchWithCredentials(ctx, continuationIDs, sharedCred)
-		// Start metadata/schema continuation as soon as Cloud accepts the wave;
-		// logical tenant placement continues independently below.
-		s.scheduleManagedSharedDBContinuations(ctx, continuationIDs)
-		provisionDone <- provisionErr
-	}()
-	now := time.Now().UTC()
-	outcomes := runSharedPoolTenantPartitionWorkers(ctx, s.sharedTenantPoolCreateSlots, partitions, func(partition sharedPoolTenantPartition) sharedPoolTenantCreateOutcome {
-		return s.createFreeSharedPoolTenantOnDB(ctx, poolID, organizationID, quotaOpt, now, partition.db)
-	})
+	_, provisionErr := s.provisionManagedSharedDBPoolsBatchWithCredentials(ctx, continuationIDs, sharedCred)
+	// The whole logical reservation wave is durable before Cloud creation
+	// starts, so allocators can only consume genuinely unreserved tail capacity.
+	s.scheduleManagedSharedDBContinuations(ctx, continuationIDs)
 	results := make([]*provisionTenantResult, 0, count)
 	resultPoolIDs := make([]int64, 0, count)
-	var createErr error
-	for _, outcome := range outcomes {
-		if outcome.err != nil {
-			createErr = errors.Join(createErr, outcome.err)
-			continue
+	for _, partition := range partitions {
+		for _, tenantID := range partition.tenantIDs {
+			results = append(results, &provisionTenantResult{TenantID: tenantID, Status: meta.TenantPending,
+				Provider: tenant.ProviderTiDBCloudNativeShared, CloudProvider: partition.db.CloudProvider,
+				Region: partition.db.Region, OrganizationID: organizationID})
+			resultPoolIDs = append(resultPoolIDs, partition.db.ID)
 		}
-		results = append(results, outcome.result)
-		resultPoolIDs = append(resultPoolIDs, outcome.dbID)
 	}
-	provisionErr := <-provisionDone
 	continuationPoolStatuses := make(map[int64]meta.TenantStatus, len(continuationIDs))
 	for _, dbID := range continuationIDs {
 		sharedDB, err := s.meta.GetSharedDB(ctx, dbID)
@@ -1030,15 +1019,15 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 			results[i].Status = status
 		}
 	}
-	return results, errors.Join(createErr, provisionErr)
+	return results, provisionErr
 }
 
 type sharedPoolTenantPartition struct {
-	db          *meta.SharedDB
-	tenantCount int
+	db        *meta.SharedDB
+	tenantIDs []string
 }
 
-func (s *Server) stageSharedPoolTenantWave(ctx context.Context, organizationID string, cred tenant.CredentialProvisionRequest, count int) ([]sharedPoolTenantPartition, error) {
+func (s *Server) stageSharedPoolTenantWave(ctx context.Context, poolID, organizationID string, cred tenant.CredentialProvisionRequest, count int, quotaOpt *quotaRequest) ([]sharedPoolTenantPartition, error) {
 	if count <= 0 {
 		return nil, nil
 	}
@@ -1051,129 +1040,49 @@ func (s *Server) stageSharedPoolTenantWave(ctx context.Context, organizationID s
 	provisioningKey := sharedDBProvisioningKey(cred)
 	maxTenants, _ := s.managedSharedDBPolicy()
 	physicalCount := (count + maxTenants - 1) / maxTenants
-	plans := make([]*meta.SharedDB, 0, physicalCount)
-	assignedCounts := make([]int, 0, physicalCount)
+	plans := make([]meta.ManagedSharedDBPoolWavePlan, 0, physicalCount)
+	now := time.Now().UTC()
 	for remaining > 0 {
 		row, err := s.newManagedSharedDBPlan(ctx, organizationID, provisioningKey)
 		if err != nil {
 			return nil, err
 		}
 		assigned := min(remaining, maxTenants)
-		plans = append(plans, row)
-		assignedCounts = append(assignedCounts, assigned)
+		members := make([]meta.ManagedSharedDBPoolWaveMember, 0, assigned)
+		for range assigned {
+			tenantID := token.NewID()
+			autoProfile, profileErr := s.defaultAutoEmbeddingProfileForTenant(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, now)
+			if profileErr != nil {
+				return nil, fmt.Errorf("build tenant auto-embedding profile: %w", profileErr)
+			}
+			quota, quotaErr := s.sharedTenantQuotaConfig(tenantID, provisionTenantOptions{Quota: quotaOpt})
+			if quotaErr != nil {
+				return nil, quotaErr
+			}
+			members = append(members, meta.ManagedSharedDBPoolWaveMember{
+				Tenant: &meta.Tenant{ID: tenantID, Status: meta.TenantPending, DBPasswordCipher: []byte{}, DBTLS: true,
+					Provider: tenant.ProviderTiDBCloudNativeShared, SchemaVersion: 1, CreatedAt: now, UpdatedAt: now},
+				Membership: &meta.TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: organizationID,
+					PoolID: poolID, PoolStatus: meta.TenantPoolBindingFree, CreatedAt: now, UpdatedAt: now},
+				Quota: quota, AutoEmbeddingProfile: autoProfile,
+			})
+		}
+		plans = append(plans, meta.ManagedSharedDBPoolWavePlan{DB: row, Members: members})
 		remaining -= assigned
 	}
-	ids, err := s.meta.CreateManagedSharedDBPools(ctx, plans)
+	created, err := s.meta.CreateManagedSharedDBPoolTenantWave(ctx, plans)
 	if err != nil {
 		return nil, err
 	}
-	partitions := make([]sharedPoolTenantPartition, 0, len(ids))
-	for i, dbID := range ids {
-		row, loadErr := s.meta.GetSharedDB(ctx, dbID)
+	partitions := make([]sharedPoolTenantPartition, 0, len(created))
+	for _, result := range created {
+		row, loadErr := s.meta.GetSharedDB(ctx, result.DBID)
 		if loadErr != nil {
 			return nil, loadErr
 		}
-		partitions = append(partitions, sharedPoolTenantPartition{db: row, tenantCount: assignedCounts[i]})
+		partitions = append(partitions, sharedPoolTenantPartition{db: row, tenantIDs: result.TenantIDs})
 	}
 	return partitions, nil
-}
-
-func runSharedPoolTenantPartitionWorkers(ctx context.Context, globalSlots chan struct{}, partitions []sharedPoolTenantPartition, create func(sharedPoolTenantPartition) sharedPoolTenantCreateOutcome) []sharedPoolTenantCreateOutcome {
-	if globalSlots == nil {
-		globalSlots = make(chan struct{}, sharedTenantPoolCreateConcurrency)
-	}
-	total := 0
-	for _, partition := range partitions {
-		total += partition.tenantCount
-	}
-	outcomes := make([]sharedPoolTenantCreateOutcome, total)
-	type partitionJob struct {
-		partition sharedPoolTenantPartition
-		offset    int
-	}
-	jobs := make(chan partitionJob, len(partitions))
-	offset := 0
-	for _, partition := range partitions {
-		jobs <- partitionJob{partition: partition, offset: offset}
-		offset += partition.tenantCount
-	}
-	close(jobs)
-	var wg sync.WaitGroup
-	for range min(len(partitions), sharedTenantPoolCreateConcurrency) {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			for job := range jobs {
-				select {
-				case globalSlots <- struct{}{}:
-				case <-ctx.Done():
-					for i := range job.partition.tenantCount {
-						outcomes[job.offset+i].err = ctx.Err()
-					}
-					continue
-				}
-				for i := range job.partition.tenantCount {
-					index := job.offset + i
-					if ctx.Err() != nil {
-						outcomes[index].err = ctx.Err()
-						continue
-					}
-					outcomes[index] = create(job.partition)
-				}
-				<-globalSlots
-			}
-		}()
-	}
-	wg.Wait()
-	return outcomes
-}
-
-type sharedPoolTenantCreateOutcome struct {
-	result *provisionTenantResult
-	dbID   int64
-	err    error
-}
-
-func (s *Server) createFreeSharedPoolTenantOnDB(ctx context.Context, poolID, organizationID string, quotaOpt *quotaRequest, now time.Time, selected *meta.SharedDB) sharedPoolTenantCreateOutcome {
-	tenantID := token.NewID()
-	fail := func(err error) sharedPoolTenantCreateOutcome {
-		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
-		return sharedPoolTenantCreateOutcome{err: err}
-	}
-	if err := s.insertPendingPoolTenant(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, now); err != nil {
-		return sharedPoolTenantCreateOutcome{err: err}
-	}
-	fsID, err := s.meta.EnsureFsID(ctx, tenantID)
-	if err != nil {
-		return fail(err)
-	}
-	if err := s.materializeSharedTenantQuota(ctx, tenantID, provisionTenantOptions{Quota: quotaOpt}); err != nil {
-		return fail(err)
-	}
-	reserve := func(db *meta.SharedDB) error {
-		return s.meta.CompleteSharedTenantPoolMember(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared,
-			&meta.TenantPlacement{FsID: fsID, DbID: db.ID, Placement: meta.PlacementShared,
-				SchemaShape: meta.SchemaShapeShared, Status: meta.SharedDBStatusActive},
-			&meta.TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: organizationID,
-				PoolID: poolID, PoolStatus: meta.TenantPoolBindingFree, CreatedAt: now, UpdatedAt: now})
-	}
-	err = reserve(selected)
-	if err != nil {
-		return fail(err)
-	}
-	resultStatus := meta.TenantPending
-	switch selected.Status {
-	case meta.SharedDBStatusProvisioning:
-		resultStatus = meta.TenantProvisioning
-	case meta.SharedDBStatusActive:
-		resultStatus = meta.TenantActive
-	}
-	return sharedPoolTenantCreateOutcome{
-		result: &provisionTenantResult{TenantID: tenantID, Status: resultStatus,
-			Provider: tenant.ProviderTiDBCloudNativeShared, CloudProvider: selected.CloudProvider,
-			Region: selected.Region, OrganizationID: selected.TiDBCloudOrganizationID},
-		dbID: selected.ID,
-	}
 }
 
 func (s *Server) provisionManagedSharedDBPoolsBatch(ctx context.Context, dbIDs []int64) (string, error) {
@@ -2087,16 +1996,12 @@ func (s *Server) replenishTenantPool(ctx context.Context, pool *meta.TenantPool,
 		}
 
 		// Active inventory is immediately usable. Shared pending/provisioning
-		// inventory offsets missing capacity only while its physical pool has a
-		// recent durable progress heartbeat; stale plans must not suppress a
-		// replacement wave indefinitely.
+		// inventory offsets missing capacity until the stuck-pool watchdog makes
+		// the physical attempt terminal. This avoids a refill/watchdog race at an
+		// independent time-based lease boundary.
 		slotSize := 0
 		if sharedProvider {
-			lease := s.managedSharedDBPlannedCapacityLease
-			if lease <= 0 {
-				lease = DefaultManagedSharedDBPlannedCapacityLease
-			}
-			plannedSize, countErr := s.meta.CountTenantPoolPlannedSlots(ctx, current.OrganizationID, time.Now().UTC().Add(-lease))
+			plannedSize, countErr := s.meta.CountTenantPoolPlannedSlots(ctx, current.OrganizationID)
 			if countErr != nil {
 				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(countErr))
 				metricResult = "error"

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -994,7 +994,7 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 		provisionDone <- provisionErr
 	}()
 	now := time.Now().UTC()
-	outcomes := runSharedPoolTenantPartitionWorkers(ctx, partitions, func(partition sharedPoolTenantPartition) sharedPoolTenantCreateOutcome {
+	outcomes := runSharedPoolTenantPartitionWorkers(ctx, s.sharedTenantPoolCreateSlots, partitions, func(partition sharedPoolTenantPartition) sharedPoolTenantCreateOutcome {
 		return s.createFreeSharedPoolTenantOnDB(ctx, poolID, organizationID, quotaOpt, now, partition.db)
 	})
 	results := make([]*provisionTenantResult, 0, count)
@@ -1078,7 +1078,10 @@ func (s *Server) stageSharedPoolTenantWave(ctx context.Context, organizationID s
 	return partitions, nil
 }
 
-func runSharedPoolTenantPartitionWorkers(ctx context.Context, partitions []sharedPoolTenantPartition, create func(sharedPoolTenantPartition) sharedPoolTenantCreateOutcome) []sharedPoolTenantCreateOutcome {
+func runSharedPoolTenantPartitionWorkers(ctx context.Context, globalSlots chan struct{}, partitions []sharedPoolTenantPartition, create func(sharedPoolTenantPartition) sharedPoolTenantCreateOutcome) []sharedPoolTenantCreateOutcome {
+	if globalSlots == nil {
+		globalSlots = make(chan struct{}, sharedTenantPoolCreateConcurrency)
+	}
 	total := 0
 	for _, partition := range partitions {
 		total += partition.tenantCount
@@ -1101,6 +1104,14 @@ func runSharedPoolTenantPartitionWorkers(ctx context.Context, partitions []share
 		go func() {
 			defer wg.Done()
 			for job := range jobs {
+				select {
+				case globalSlots <- struct{}{}:
+				case <-ctx.Done():
+					for i := range job.partition.tenantCount {
+						outcomes[job.offset+i].err = ctx.Err()
+					}
+					continue
+				}
 				for i := range job.partition.tenantCount {
 					index := job.offset + i
 					if ctx.Err() != nil {
@@ -1109,6 +1120,7 @@ func runSharedPoolTenantPartitionWorkers(ctx context.Context, partitions []share
 					}
 					outcomes[index] = create(job.partition)
 				}
+				<-globalSlots
 			}
 		}()
 	}
@@ -1984,10 +1996,7 @@ func (s *Server) enqueueTenantPoolLeaderReplenishment(ctx context.Context, pool 
 	if s.leader != nil && !s.leader.IsLeader() {
 		return false
 	}
-	// The durable scan visits each logical pool once per pass. Do not use the
-	// request-side per-pool gate here: a later scan may queue another bounded
-	// wave for the same pool while an earlier Cloud request is still running.
-	return s.enqueueTenantPoolReconcileWork(ctx, func(workerCtx context.Context) {
+	return s.enqueueTenantPoolLeaderReconcile(ctx, pool.PoolID, func(workerCtx context.Context) {
 		s.replenishTenantPool(workerCtx, pool, cred)
 	})
 }

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -424,7 +424,13 @@ func (s *Server) handleAdminTenantPoolUpdate(w http.ResponseWriter, r *http.Requ
 				"free_size", freeSize,
 				"slot_size", slotSize,
 				"grow_count", growCount)...)
-			results, err := s.createFreePoolTenants(ctx, pool.PoolID, growCount, cred, nil)
+			var results []*provisionTenantResult
+			if s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared && targetSize > pool.Size {
+				results, err = s.createFreeSharedPoolTenantsWithResize(ctx, pool.PoolID, growCount, cred, nil,
+					&meta.ManagedSharedDBPoolWaveResize{ExpectedSize: pool.Size, TargetSize: targetSize})
+			} else {
+				results, err = s.createFreePoolTenants(ctx, pool.PoolID, growCount, cred, nil)
+			}
 			if err != nil {
 				logger.Error(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_update_grow_failed",
 					"provider", tenant.ProviderTiDBCloudNative,
@@ -957,6 +963,10 @@ func (s *Server) createFreePoolTenants(ctx context.Context, poolID string, count
 }
 
 func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string, count int, _ tenant.CredentialProvisionRequest, quotaOpt *quotaRequest) ([]*provisionTenantResult, error) {
+	return s.createFreeSharedPoolTenantsWithResize(ctx, poolID, count, tenant.CredentialProvisionRequest{}, quotaOpt, nil)
+}
+
+func (s *Server) createFreeSharedPoolTenantsWithResize(ctx context.Context, poolID string, count int, _ tenant.CredentialProvisionRequest, quotaOpt *quotaRequest, resize *meta.ManagedSharedDBPoolWaveResize) ([]*provisionTenantResult, error) {
 	if count <= 0 {
 		return []*provisionTenantResult{}, nil
 	}
@@ -975,7 +985,7 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 	if organizationID == "" {
 		return nil, fmt.Errorf("shared tenant pool organization is required")
 	}
-	partitions, err := s.stageSharedPoolTenantWave(ctx, poolID, organizationID, sharedCred, count, quotaOpt)
+	partitions, err := s.stageSharedPoolTenantWave(ctx, poolID, organizationID, sharedCred, count, quotaOpt, resize)
 	if err != nil {
 		return nil, err
 	}
@@ -1027,7 +1037,7 @@ type sharedPoolTenantPartition struct {
 	tenantIDs []string
 }
 
-func (s *Server) stageSharedPoolTenantWave(ctx context.Context, poolID, organizationID string, cred tenant.CredentialProvisionRequest, count int, quotaOpt *quotaRequest) ([]sharedPoolTenantPartition, error) {
+func (s *Server) stageSharedPoolTenantWave(ctx context.Context, poolID, organizationID string, cred tenant.CredentialProvisionRequest, count int, quotaOpt *quotaRequest, resize *meta.ManagedSharedDBPoolWaveResize) ([]sharedPoolTenantPartition, error) {
 	if count <= 0 {
 		return nil, nil
 	}
@@ -1070,7 +1080,7 @@ func (s *Server) stageSharedPoolTenantWave(ctx context.Context, poolID, organiza
 		plans = append(plans, meta.ManagedSharedDBPoolWavePlan{DB: row, Members: members})
 		remaining -= assigned
 	}
-	created, err := s.meta.CreateManagedSharedDBPoolTenantWave(ctx, plans)
+	created, err := s.meta.CreateManagedSharedDBPoolTenantWaveWithResize(ctx, plans, resize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -72,7 +72,7 @@ const (
 	tenantPoolPendingResumeEmptyInterval = 15 * time.Second
 )
 
-func managedSharedDBRefillTenantCount(missing, maxTenants, poolLimit int) int {
+func managedSharedDBRefillTenantCount(missing, maxTenants, batchSize int) int {
 	if missing <= 0 {
 		return 0
 	}
@@ -81,11 +81,11 @@ func managedSharedDBRefillTenantCount(missing, maxTenants, poolLimit int) int {
 	}
 	maxInt := int(^uint(0) >> 1)
 	limit := maxInt
-	if poolLimit <= 0 {
-		poolLimit = DefaultManagedSharedDBRefillPoolLimit
+	if batchSize <= 0 {
+		batchSize = DefaultManagedSharedDBCloudBatchSize
 	}
-	if maxTenants <= maxInt/poolLimit {
-		limit = maxTenants * poolLimit
+	if maxTenants <= maxInt/batchSize {
+		limit = maxTenants * batchSize
 	}
 	return min(missing, limit)
 }
@@ -1046,19 +1046,34 @@ func (s *Server) stageSharedPoolTenantWave(ctx context.Context, organizationID s
 	// reusing a globally visible oldest candidate. Otherwise multiple Pods can
 	// plan against the same capacity snapshot and recreate the hot-row storm
 	// this partitioned wave is meant to avoid. The caller already caps count by
-	// managedSharedDBRefillPoolLimit, so lock-free over-creation stays bounded.
+	// managedSharedDBCloudBatchSize, so lock-free over-creation stays bounded.
 	remaining := count
 	provisioningKey := sharedDBProvisioningKey(cred)
 	maxTenants, _ := s.managedSharedDBPolicy()
-	partitions := make([]sharedPoolTenantPartition, 0, (count+maxTenants-1)/maxTenants)
+	physicalCount := (count + maxTenants - 1) / maxTenants
+	plans := make([]*meta.SharedDB, 0, physicalCount)
+	assignedCounts := make([]int, 0, physicalCount)
 	for remaining > 0 {
-		row, err := s.createManagedSharedDBPlan(ctx, organizationID, provisioningKey)
+		row, err := s.newManagedSharedDBPlan(ctx, organizationID, provisioningKey)
 		if err != nil {
 			return nil, err
 		}
 		assigned := min(remaining, maxTenants)
-		partitions = append(partitions, sharedPoolTenantPartition{db: row, tenantCount: assigned})
+		plans = append(plans, row)
+		assignedCounts = append(assignedCounts, assigned)
 		remaining -= assigned
+	}
+	ids, err := s.meta.CreateManagedSharedDBPools(ctx, plans)
+	if err != nil {
+		return nil, err
+	}
+	partitions := make([]sharedPoolTenantPartition, 0, len(ids))
+	for i, dbID := range ids {
+		row, loadErr := s.meta.GetSharedDB(ctx, dbID)
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		partitions = append(partitions, sharedPoolTenantPartition{db: row, tenantCount: assignedCounts[i]})
 	}
 	return partitions, nil
 }
@@ -1295,23 +1310,11 @@ func (s *Server) provisionManagedSharedDBPoolsBatchGroupClaimed(ctx context.Cont
 		end := min(start+batchSize, len(requests))
 		batches = append(batches, append([]tenant.SharedDBPoolCreateRequest(nil), requests[start:end]...))
 	}
-	poolLimit := s.managedSharedDBRefillPoolLimit
-	if poolLimit <= 0 {
-		poolLimit = DefaultManagedSharedDBRefillPoolLimit
-	}
-	batchSlots := make(chan struct{}, max(1, (poolLimit+batchSize-1)/batchSize))
 	var wg sync.WaitGroup
 	for batchIndex := range batches {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			select {
-			case batchSlots <- struct{}{}:
-				defer func() { <-batchSlots }()
-			case <-ctx.Done():
-				batchResults[batchIndex].err = ctx.Err()
-				return
-			}
 			if err := ctx.Err(); err != nil {
 				batchResults[batchIndex].err = err
 				return
@@ -1974,8 +1977,19 @@ func (s *Server) replenishTenantPoolAsync(ctx context.Context, pool *meta.Tenant
 	s.replenishTenantPoolAsyncWithStarters(ctx, pool, cred, s.startServerWorker, s.startServerWorker)
 }
 
-func (s *Server) replenishTenantPoolLeaderAsync(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {
-	s.replenishTenantPoolAsyncWithStarters(ctx, pool, cred, s.startTenantPoolLeaderReconcileWorker, s.startManagedSharedDBWorker)
+func (s *Server) enqueueTenantPoolLeaderReplenishment(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) bool {
+	if pool == nil || pool.PoolID == "" || pool.OrganizationID == "" || pool.Size <= 0 {
+		return false
+	}
+	if s.leader != nil && !s.leader.IsLeader() {
+		return false
+	}
+	// The durable scan visits each logical pool once per pass. Do not use the
+	// request-side per-pool gate here: a later scan may queue another bounded
+	// wave for the same pool while an earlier Cloud request is still running.
+	return s.enqueueTenantPoolReconcileWork(ctx, func(workerCtx context.Context) {
+		s.replenishTenantPool(workerCtx, pool, cred)
+	})
 }
 
 func (s *Server) replenishTenantPoolAsyncWithStarters(
@@ -2006,107 +2020,124 @@ func (s *Server) replenishTenantPoolAsyncWithStarters(
 				s.scheduleTenantPoolReplenishment(ctx, pool, cred, finished.scheduleAfter, workStarter, timerStarter)
 			}
 		}()
-		replenishStarted := time.Now()
-		metricResult := "ok"
-		defer func() {
-			metrics.RecordOperation(adminTenantPoolMetricsComponent, "replenish", metricResult, time.Since(replenishStarted))
-		}()
-		sharedProvider := s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared
-		createdAny := false
-		sharedWaveRemaining := 0
-		// A started shared wave accounts for in-flight pending/provisioning slots;
-		// sharedWaveRemaining is the hard cap that guarantees termination.
-		for {
-			if err := ctx.Err(); err != nil {
-				metricResult = adminTenantPoolMetricResult(err)
-				return
-			}
-			current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
-			if err != nil {
-				if !errors.Is(err, meta.ErrNotFound) {
-					logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
-					metricResult = "error"
-				} else {
-					metricResult = "not_found"
-				}
-				return
-			}
-			if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
-				metricResult = "skipped"
-				return
-			}
-			freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
-			if err != nil {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-				metricResult = "error"
-				return
-			}
-			s.recordTenantPoolCapacity(current.PoolID, current.OrganizationID, current.Size, freeSize)
-			if !createdAny && !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
-				logger.Info(ctx, "admin_tenant_pool_replenish_skipped",
-					zap.String("pool_id", current.PoolID),
-					zap.String("organization_id", current.OrganizationID),
-					zap.Int("pool_size", current.Size),
-					zap.Int("free_size", freeSize),
-					zap.Float64("refill_free_ratio", s.effectiveTenantPoolRefillFreeRatio()))
-				metricResult = "noop"
-				return
-			}
-
-			// The initial watermark check above avoids a slot COUNT on the common
-			// no-op path. Re-read durable slots before every batch because other
-			// Pods may replenish this pool concurrently; over-create is bounded and
-			// acceptable, while pending/provisioning slots prevent under-counting.
-			slotSize, err := s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
-			if err != nil {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-				metricResult = "error"
-				return
-			}
-			missing := current.Size - slotSize
-			if missing <= 0 {
-				if !createdAny {
-					metricResult = "noop"
-				}
-				return
-			}
-			if sharedProvider {
-				maxTenants, _ := s.managedSharedDBPolicy()
-				if !createdAny {
-					sharedWaveRemaining = managedSharedDBRefillTenantCount(missing, maxTenants, s.managedSharedDBRefillPoolLimit)
-				}
-				if sharedWaveRemaining <= 0 {
-					return
-				}
-				missing = min(missing, sharedWaveRemaining)
-			}
-			results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
-			if err != nil {
-				logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
-				metricResult = "cluster_error"
-				return
-			}
-			for _, res := range results {
-				s.startProvisionedTenantSchemaInit(ctx, res)
-			}
-			if len(results) > 0 {
-				createdAny = true
-				metricResult = "ok"
-				if sharedProvider {
-					sharedWaveRemaining -= len(results)
-				}
-			}
-			if !sharedProvider || len(results) == 0 {
-				return
-			}
-			if sharedWaveRemaining <= 0 {
-				return
-			}
-		}
+		s.replenishTenantPool(ctx, pool, cred)
 	}) {
 		finished := s.finishTenantPoolReplenishmentAt(pool.PoolID, time.Now())
 		if finished.scheduleAfter > 0 {
 			s.scheduleTenantPoolReplenishment(ctx, pool, cred, finished.scheduleAfter, workStarter, timerStarter)
+		}
+	}
+}
+
+func (s *Server) replenishTenantPool(ctx context.Context, pool *meta.TenantPool, cred tenant.CredentialProvisionRequest) {
+	replenishStarted := time.Now()
+	metricResult := "ok"
+	defer func() {
+		metrics.RecordOperation(adminTenantPoolMetricsComponent, "replenish", metricResult, time.Since(replenishStarted))
+	}()
+	sharedProvider := s.defaultTenantProvider == tenant.ProviderTiDBCloudNativeShared
+	createdAny := false
+	sharedWaveRemaining := 0
+	// A started shared wave accounts for in-flight pending/provisioning slots;
+	// sharedWaveRemaining is the hard cap that guarantees termination.
+	for {
+		if err := ctx.Err(); err != nil {
+			metricResult = adminTenantPoolMetricResult(err)
+			return
+		}
+		current, err := s.meta.GetTenantPoolByID(ctx, pool.PoolID)
+		if err != nil {
+			if !errors.Is(err, meta.ErrNotFound) {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_get_pool_failed", zap.String("pool_id", pool.PoolID), zap.Error(err))
+				metricResult = "error"
+			} else {
+				metricResult = "not_found"
+			}
+			return
+		}
+		if current.Status != meta.TenantPoolActive || current.OrganizationID == "" || current.Size <= 0 {
+			metricResult = "skipped"
+			return
+		}
+		freeSize, err := s.meta.CountFreeTenantPoolBindings(ctx, current.OrganizationID)
+		if err != nil {
+			logger.Warn(ctx, "admin_tenant_pool_replenish_free_count_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+			metricResult = "error"
+			return
+		}
+		s.recordTenantPoolCapacity(current.PoolID, current.OrganizationID, current.Size, freeSize)
+		if !createdAny && !s.tenantPoolBelowRefillWatermark(freeSize, current.Size) {
+			logger.Info(ctx, "admin_tenant_pool_replenish_skipped",
+				zap.String("pool_id", current.PoolID),
+				zap.String("organization_id", current.OrganizationID),
+				zap.Int("pool_size", current.Size),
+				zap.Int("free_size", freeSize),
+				zap.Float64("refill_free_ratio", s.effectiveTenantPoolRefillFreeRatio()))
+			metricResult = "noop"
+			return
+		}
+
+		// Active inventory is immediately usable. Shared pending/provisioning
+		// inventory offsets missing capacity only while its physical pool has a
+		// recent durable progress heartbeat; stale plans must not suppress a
+		// replacement wave indefinitely.
+		slotSize := 0
+		if sharedProvider {
+			lease := s.managedSharedDBPlannedCapacityLease
+			if lease <= 0 {
+				lease = DefaultManagedSharedDBPlannedCapacityLease
+			}
+			plannedSize, countErr := s.meta.CountTenantPoolPlannedSlots(ctx, current.OrganizationID, time.Now().UTC().Add(-lease))
+			if countErr != nil {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(countErr))
+				metricResult = "error"
+				return
+			}
+			slotSize = freeSize + plannedSize
+		} else {
+			var countErr error
+			slotSize, countErr = s.meta.CountTenantPoolFreeSlots(ctx, current.OrganizationID)
+			if countErr != nil {
+				logger.Warn(ctx, "admin_tenant_pool_replenish_count_failed", zap.String("pool_id", current.PoolID), zap.Error(countErr))
+				metricResult = "error"
+				return
+			}
+		}
+		missing := current.Size - slotSize
+		if missing <= 0 {
+			if !createdAny {
+				metricResult = "noop"
+			}
+			return
+		}
+		if sharedProvider {
+			maxTenants, _ := s.managedSharedDBPolicy()
+			if !createdAny {
+				sharedWaveRemaining = managedSharedDBRefillTenantCount(missing, maxTenants, s.managedSharedDBCloudBatchSize)
+			}
+			if sharedWaveRemaining <= 0 {
+				return
+			}
+			missing = min(missing, sharedWaveRemaining)
+		}
+		results, err := s.createFreePoolTenants(ctx, current.PoolID, missing, cred, nil)
+		if err != nil {
+			logger.Warn(ctx, "admin_tenant_pool_replenish_failed", zap.String("pool_id", current.PoolID), zap.Error(err))
+			metricResult = "cluster_error"
+			return
+		}
+		for _, res := range results {
+			s.startProvisionedTenantSchemaInit(ctx, res)
+		}
+		if len(results) > 0 {
+			createdAny = true
+			metricResult = "ok"
+			if sharedProvider {
+				sharedWaveRemaining -= len(results)
+			}
+		}
+		if !sharedProvider || len(results) == 0 || sharedWaveRemaining <= 0 {
+			return
 		}
 	}
 }
@@ -2387,7 +2418,12 @@ func (s *Server) claimAdminTenantFromPool(ctx context.Context, cred tenant.Crede
 		logger.Info(ctx, "server_event", eventFields(ctx, "admin_tenant_pool_claim_skipped", "provider", tenant.ProviderTiDBCloudNative, "pool_id", pool.PoolID, "organization_id", orgID, "reason", "pool_inactive", "pool_status", pool.Status, "duration_ms", durationMillis(claimStarted))...)
 		return nil, nil, false, false, nil
 	}
-	defer s.replenishTenantPoolAsync(ctx, pool, cred)
+	// Native replenishment needs the request-scoped customer credential. Shared
+	// bulk replenishment uses server-owned credentials and is exclusively driven
+	// by the leader reconciler; requests retain only their direct miss fallback.
+	if s.defaultTenantProvider != tenant.ProviderTiDBCloudNativeShared {
+		defer s.replenishTenantPoolAsync(ctx, pool, cred)
+	}
 	s.resumePendingTenantPoolAsync(ctx, pool, cred)
 	stageStarted = time.Now()
 	selection, err := retryTenantPoolClaimCAS(func() (tenantPoolClaimSelection, error) {

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -976,11 +976,27 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 	if organizationID == "" {
 		return nil, fmt.Errorf("shared tenant pool organization is required")
 	}
+	partitions, err := s.stageSharedPoolTenantWave(ctx, organizationID, sharedCred, count)
+	if err != nil {
+		return nil, err
+	}
+	continuationIDs := make([]int64, 0, len(partitions))
+	for _, partition := range partitions {
+		continuationIDs = append(continuationIDs, partition.db.ID)
+	}
+	sort.Slice(continuationIDs, func(i, j int) bool { return continuationIDs[i] < continuationIDs[j] })
+	provisionDone := make(chan error, 1)
+	go func() {
+		_, provisionErr := s.provisionManagedSharedDBPoolsBatchWithCredentials(ctx, continuationIDs, sharedCred)
+		// Start metadata/schema continuation as soon as Cloud accepts the wave;
+		// logical tenant placement continues independently below.
+		s.scheduleManagedSharedDBContinuations(ctx, continuationIDs)
+		provisionDone <- provisionErr
+	}()
 	now := time.Now().UTC()
-	outcomes := runSharedPoolTenantCreateWorkers(ctx, count, func() sharedPoolTenantCreateOutcome {
-		return s.createFreeSharedPoolTenant(ctx, poolID, organizationID, sharedCred, quotaOpt, now)
+	outcomes := runSharedPoolTenantPartitionWorkers(ctx, partitions, func(partition sharedPoolTenantPartition) sharedPoolTenantCreateOutcome {
+		return s.createFreeSharedPoolTenantOnDB(ctx, poolID, organizationID, quotaOpt, now, partition.db)
 	})
-	continuationPoolIDs := make(map[int64]struct{})
 	results := make([]*provisionTenantResult, 0, count)
 	resultPoolIDs := make([]int64, 0, count)
 	var createErr error
@@ -991,27 +1007,14 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 		}
 		results = append(results, outcome.result)
 		resultPoolIDs = append(resultPoolIDs, outcome.dbID)
-		if outcome.needsContinuation {
-			continuationPoolIDs[outcome.dbID] = struct{}{}
-		}
 	}
-	if createErr != nil {
-		return results, createErr
-	}
-	continuationIDs := make([]int64, 0, len(continuationPoolIDs))
-	for id := range continuationPoolIDs {
-		continuationIDs = append(continuationIDs, id)
-	}
-	sort.Slice(continuationIDs, func(i, j int) bool { return continuationIDs[i] < continuationIDs[j] })
-	_, err = s.provisionManagedSharedDBPoolsBatchWithCredentials(ctx, continuationIDs, sharedCred)
-	if err != nil {
-		return results, err
-	}
+	provisionErr := <-provisionDone
 	continuationPoolStatuses := make(map[int64]meta.TenantStatus, len(continuationIDs))
 	for _, dbID := range continuationIDs {
 		sharedDB, err := s.meta.GetSharedDB(ctx, dbID)
 		if err != nil {
-			return results, err
+			provisionErr = errors.Join(provisionErr, err)
+			continue
 		}
 		status := meta.TenantPending
 		switch sharedDB.Status {
@@ -1027,43 +1030,84 @@ func (s *Server) createFreeSharedPoolTenants(ctx context.Context, poolID string,
 			results[i].Status = status
 		}
 	}
-	s.scheduleManagedSharedDBContinuations(ctx, continuationIDs)
-	return results, nil
+	return results, errors.Join(createErr, provisionErr)
 }
 
-func runSharedPoolTenantCreateWorkers(ctx context.Context, count int, create func() sharedPoolTenantCreateOutcome) []sharedPoolTenantCreateOutcome {
-	outcomes := make([]sharedPoolTenantCreateOutcome, count)
-	jobs := make(chan int)
+type sharedPoolTenantPartition struct {
+	db          *meta.SharedDB
+	tenantCount int
+}
+
+func (s *Server) stageSharedPoolTenantWave(ctx context.Context, organizationID string, cred tenant.CredentialProvisionRequest, count int) ([]sharedPoolTenantPartition, error) {
+	if count <= 0 {
+		return nil, nil
+	}
+	// Refill deliberately stages dedicated physical capacity instead of
+	// reusing a globally visible oldest candidate. Otherwise multiple Pods can
+	// plan against the same capacity snapshot and recreate the hot-row storm
+	// this partitioned wave is meant to avoid. The caller already caps count by
+	// managedSharedDBRefillPoolLimit, so lock-free over-creation stays bounded.
+	remaining := count
+	provisioningKey := sharedDBProvisioningKey(cred)
+	maxTenants, _ := s.managedSharedDBPolicy()
+	partitions := make([]sharedPoolTenantPartition, 0, (count+maxTenants-1)/maxTenants)
+	for remaining > 0 {
+		row, err := s.createManagedSharedDBPlan(ctx, organizationID, provisioningKey)
+		if err != nil {
+			return nil, err
+		}
+		assigned := min(remaining, maxTenants)
+		partitions = append(partitions, sharedPoolTenantPartition{db: row, tenantCount: assigned})
+		remaining -= assigned
+	}
+	return partitions, nil
+}
+
+func runSharedPoolTenantPartitionWorkers(ctx context.Context, partitions []sharedPoolTenantPartition, create func(sharedPoolTenantPartition) sharedPoolTenantCreateOutcome) []sharedPoolTenantCreateOutcome {
+	total := 0
+	for _, partition := range partitions {
+		total += partition.tenantCount
+	}
+	outcomes := make([]sharedPoolTenantCreateOutcome, total)
+	type partitionJob struct {
+		partition sharedPoolTenantPartition
+		offset    int
+	}
+	jobs := make(chan partitionJob, len(partitions))
+	offset := 0
+	for _, partition := range partitions {
+		jobs <- partitionJob{partition: partition, offset: offset}
+		offset += partition.tenantCount
+	}
+	close(jobs)
 	var wg sync.WaitGroup
-	for range min(count, sharedTenantPoolCreateConcurrency) {
+	for range min(len(partitions), sharedTenantPoolCreateConcurrency) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			for i := range jobs {
-				if ctx.Err() != nil {
-					outcomes[i].err = ctx.Err()
-					continue
+			for job := range jobs {
+				for i := range job.partition.tenantCount {
+					index := job.offset + i
+					if ctx.Err() != nil {
+						outcomes[index].err = ctx.Err()
+						continue
+					}
+					outcomes[index] = create(job.partition)
 				}
-				outcomes[i] = create()
 			}
 		}()
 	}
-	for i := range count {
-		jobs <- i
-	}
-	close(jobs)
 	wg.Wait()
 	return outcomes
 }
 
 type sharedPoolTenantCreateOutcome struct {
-	result            *provisionTenantResult
-	dbID              int64
-	needsContinuation bool
-	err               error
+	result *provisionTenantResult
+	dbID   int64
+	err    error
 }
 
-func (s *Server) createFreeSharedPoolTenant(ctx context.Context, poolID, organizationID string, sharedCred tenant.CredentialProvisionRequest, quotaOpt *quotaRequest, now time.Time) sharedPoolTenantCreateOutcome {
+func (s *Server) createFreeSharedPoolTenantOnDB(ctx context.Context, poolID, organizationID string, quotaOpt *quotaRequest, now time.Time, selected *meta.SharedDB) sharedPoolTenantCreateOutcome {
 	tenantID := token.NewID()
 	fail := func(err error) sharedPoolTenantCreateOutcome {
 		_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
@@ -1079,13 +1123,14 @@ func (s *Server) createFreeSharedPoolTenant(ctx context.Context, poolID, organiz
 	if err := s.materializeSharedTenantQuota(ctx, tenantID, provisionTenantOptions{Quota: quotaOpt}); err != nil {
 		return fail(err)
 	}
-	selected, _, err := s.allocateManagedSharedDBForOrganization(ctx, organizationID, sharedCred, func(db *meta.SharedDB) error {
+	reserve := func(db *meta.SharedDB) error {
 		return s.meta.CompleteSharedTenantPoolMember(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared,
 			&meta.TenantPlacement{FsID: fsID, DbID: db.ID, Placement: meta.PlacementShared,
 				SchemaShape: meta.SchemaShapeShared, Status: meta.SharedDBStatusActive},
 			&meta.TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: organizationID,
 				PoolID: poolID, PoolStatus: meta.TenantPoolBindingFree, CreatedAt: now, UpdatedAt: now})
-	})
+	}
+	err = reserve(selected)
 	if err != nil {
 		return fail(err)
 	}
@@ -1100,8 +1145,7 @@ func (s *Server) createFreeSharedPoolTenant(ctx context.Context, poolID, organiz
 		result: &provisionTenantResult{TenantID: tenantID, Status: resultStatus,
 			Provider: tenant.ProviderTiDBCloudNativeShared, CloudProvider: selected.CloudProvider,
 			Region: selected.Region, OrganizationID: selected.TiDBCloudOrganizationID},
-		dbID:              selected.ID,
-		needsContinuation: selected.Status == meta.SharedDBStatusPending || selected.Status == meta.SharedDBStatusProvisioning,
+		dbID: selected.ID,
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1521,6 +1521,99 @@ func TestManagedSharedDBRefillCapsOneWaveAtFiftyPhysicalPools(t *testing.T) {
 	}
 }
 
+func TestManagedSharedDBReplenishSubmitsWholePhysicalPoolWaveConcurrently(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer poolManager.Close()
+	poolManager.SetMetaStore(metaStore)
+	batchStarted := make(chan struct{}, 5)
+	batchRelease := make(chan struct{})
+	prov := &fakeProvisioner{
+		provider:               tenant.ProviderTiDBCloudNative,
+		cloudProvider:          "aws",
+		region:                 "us-east-1",
+		sharedPoolBatchStarted: batchStarted,
+		sharedPoolBatchRelease: batchRelease,
+	}
+	workerCtx, cancel := context.WithCancel(context.Background())
+	srv := &Server{
+		meta: metaStore, pool: poolManager, provisioner: prov,
+		defaultTenantProvider: tenant.ProviderTiDBCloudNativeShared,
+		sharedDBMaxTenants:    1, managedSharedDBRefillPoolLimit: 50, managedSharedDBCloudBatchSize: 10,
+		tenantPoolRefillFreeRatio: DefaultTenantPoolRefillFreeRatio,
+		forkWorkerCtx:             workerCtx, forkWorkerCancel: cancel,
+	}
+	defer srv.Close()
+	now := time.Now().UTC()
+	logicalPool := &meta.TenantPool{PoolID: "pool-whole-wave", OrganizationID: "org-whole-wave",
+		Size: 50, Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}
+	if err := metaStore.CreateTenantPool(context.Background(), logicalPool); err != nil {
+		t.Fatal(err)
+	}
+
+	workerDone := make(chan struct{})
+	workStarter := func(ctx context.Context, fn func(context.Context)) bool {
+		go func() {
+			defer close(workerDone)
+			fn(ctx)
+		}()
+		return true
+	}
+	var unexpectedTimer atomic.Bool
+	timerStarter := func(context.Context, func(context.Context)) bool {
+		unexpectedTimer.Store(true)
+		return false
+	}
+	var releaseOnce sync.Once
+	releaseBatches := func() { releaseOnce.Do(func() { close(batchRelease) }) }
+	defer func() {
+		releaseBatches()
+		select {
+		case <-workerDone:
+		case <-time.After(10 * time.Second):
+			t.Error("replenish worker did not stop during test cleanup")
+		}
+	}()
+
+	srv.replenishTenantPoolAsyncWithStarters(context.Background(), logicalPool,
+		tenant.CredentialProvisionRequest{}, workStarter, timerStarter)
+	for i := 0; i < 5; i++ {
+		select {
+		case <-batchStarted:
+		case <-time.After(3 * time.Second):
+			t.Fatalf("started %d/5 Cloud batches before release", i)
+		}
+	}
+	releaseBatches()
+	select {
+	case <-workerDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("whole-wave replenish did not finish")
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 5 {
+		t.Fatalf("Cloud batch calls = %d, want 5", got)
+	}
+	if got := prov.sharedPoolBatchMembers.Load(); got != 50 {
+		t.Fatalf("Cloud batch members = %d, want 50", got)
+	}
+	if unexpectedTimer.Load() {
+		t.Fatal("unexpected replenish rerun timer")
+	}
+}
+
 func TestTenantPoolEffectiveRefillRatioRejectsNaN(t *testing.T) {
 	s := &Server{tenantPoolRefillFreeRatio: math.NaN()}
 	if got := s.effectiveTenantPoolRefillFreeRatio(); got != DefaultTenantPoolRefillFreeRatio {

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -248,6 +248,88 @@ func TestSharedTenantPoolRefillPlansTenPoolsInOneBatch(t *testing.T) {
 	}
 }
 
+func TestSharedTenantPoolRefillStagesWholePhysicalWaveBeforePlacement(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer poolManager.Close()
+	poolManager.SetMetaStore(metaStore)
+	now := time.Now().UTC()
+	if err := metaStore.CreateTenantPool(context.Background(), &meta.TenantPool{
+		PoolID: "pool-stage-wave", OrganizationID: "org-stage-wave", Size: 6,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	batchStarted := make(chan struct{}, 1)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		sharedPoolBatchStarted: batchStarted}
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	srv := &Server{meta: metaStore, pool: poolManager, provisioner: prov,
+		defaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, sharedDBMaxTenants: 2,
+		managedSharedDBCloudBatchSize: 10, forkWorkerCtx: workerCtx, forkWorkerCancel: workerCancel}
+
+	lockConn, err := metaStore.DB().Conn(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lockConn.ExecContext(context.Background(), `LOCK TABLES tenant_quota_config WRITE`); err != nil {
+		_ = lockConn.Close()
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := srv.createFreeSharedPoolTenants(ctx, "pool-stage-wave", 6,
+			tenant.CredentialProvisionRequest{}, nil)
+		done <- err
+	}()
+	t.Cleanup(func() {
+		cancel()
+		_, _ = lockConn.ExecContext(context.Background(), `UNLOCK TABLES`)
+		_ = lockConn.Close()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+			t.Error("shared refill did not stop after releasing quota table lock")
+		}
+		srv.Close()
+	})
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		var managedPools int
+		if err := metaStore.DB().QueryRowContext(context.Background(),
+			`SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, "org-stage-wave").Scan(&managedPools); err != nil {
+			t.Fatal(err)
+		}
+		if managedPools == 3 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("physical pools staged before placement = %d, want complete three-pool wave", managedPools)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	select {
+	case <-batchStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Cloud batch did not start while tenant quota writes were still blocked")
+	}
+}
+
 func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -298,13 +380,17 @@ func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T
 	}
 }
 
-func TestSharedTenantPoolRefillLimitsTenantWorkersToThirty(t *testing.T) {
+func TestSharedTenantPoolRefillLimitsPhysicalPartitionWorkersToThirty(t *testing.T) {
 	const wantConcurrency = 30
 	started := make(chan struct{}, wantConcurrency+1)
 	release := make(chan struct{})
 	done := make(chan []sharedPoolTenantCreateOutcome, 1)
+	partitions := make([]sharedPoolTenantPartition, wantConcurrency+1)
+	for i := range partitions {
+		partitions[i] = sharedPoolTenantPartition{db: &meta.SharedDB{ID: int64(i + 1)}, tenantCount: 1}
+	}
 	go func() {
-		done <- runSharedPoolTenantCreateWorkers(context.Background(), wantConcurrency+1, func() sharedPoolTenantCreateOutcome {
+		done <- runSharedPoolTenantPartitionWorkers(context.Background(), partitions, func(sharedPoolTenantPartition) sharedPoolTenantCreateOutcome {
 			started <- struct{}{}
 			<-release
 			return sharedPoolTenantCreateOutcome{}
@@ -333,7 +419,7 @@ func TestSharedTenantPoolRefillLimitsTenantWorkersToThirty(t *testing.T) {
 	}
 }
 
-func TestSharedTenantPoolRefillUsesExistingCapacityWithoutIdentityLookup(t *testing.T) {
+func TestSharedTenantPoolRefillStagesDedicatedCapacityWithoutIdentityLookup(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -355,10 +441,11 @@ func TestSharedTenantPoolRefillUsesExistingCapacityWithoutIdentityLookup(t *test
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := metaStore.RegisterSharedDB(context.Background(), &meta.SharedDB{
+	existingDBID, err := metaStore.RegisterSharedDB(context.Background(), &meta.SharedDB{
 		TiDBCloudOrganizationID: "org-shared-existing", Host: "shared.example.com", Port: 4000,
 		User: "root", PasswordCipher: passwordCipher, Name: "tidbcloud_fs", MaxTenants: 100,
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatal(err)
 	}
 	now := time.Now().UTC()
@@ -368,7 +455,8 @@ func TestSharedTenantPoolRefillUsesExistingCapacityWithoutIdentityLookup(t *test
 	}); err != nil {
 		t.Fatal(err)
 	}
-	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, identityOrg: "org-shared-existing"}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		identityOrg: "org-shared-existing"}
 	srv := &Server{meta: metaStore, pool: poolManager, provisioner: prov,
 		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour)}
 	results, err := srv.createFreeSharedPoolTenants(context.Background(), "pool-shared-existing", 50,
@@ -379,11 +467,24 @@ func TestSharedTenantPoolRefillUsesExistingCapacityWithoutIdentityLookup(t *test
 	if len(results) != 50 {
 		t.Fatalf("results = %d, want 50", len(results))
 	}
-	if got := prov.sharedPoolBatchCalls.Load(); got != 0 {
-		t.Fatalf("physical batch calls = %d, want 0 for existing capacity", got)
+	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
+		t.Fatalf("physical batch calls = %d, want one dedicated refill wave", got)
 	}
 	if got := prov.iamCalls.Load(); got != 0 {
 		t.Fatalf("identity lookups = %d, want 0 when tenant pool organization is known", got)
+	}
+	var existingTenantCount, physicalPoolCount int
+	if err := metaStore.DB().QueryRowContext(context.Background(),
+		`SELECT tenant_count FROM db_pool WHERE db_id = ?`, existingDBID).Scan(&existingTenantCount); err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.DB().QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, "org-shared-existing").Scan(&physicalPoolCount); err != nil {
+		t.Fatal(err)
+	}
+	if existingTenantCount != 0 || physicalPoolCount != 2 {
+		t.Fatalf("existing tenant_count=%d physical pools=%d, want dedicated staged pool and untouched existing capacity",
+			existingTenantCount, physicalPoolCount)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"database/sql"
 	"errors"
 	"fmt"
 	"io"
@@ -22,6 +23,31 @@ import (
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
+
+func newFollowerLeaderManager(t *testing.T, metaStore *meta.Store) *leader.Manager {
+	t.Helper()
+	ctx := context.Background()
+	conn, err := metaStore.DB().Conn(ctx)
+	if err != nil {
+		t.Fatalf("open leader lock connection: %v", err)
+	}
+	lockName := fmt.Sprintf("d9:test-follower:%d", time.Now().UnixNano())
+	var acquired sql.NullInt64
+	if err := conn.QueryRowContext(ctx, `SELECT GET_LOCK(?, 0)`, lockName).Scan(&acquired); err != nil {
+		_ = conn.Close()
+		t.Fatalf("hold leader lock: %v", err)
+	}
+	if !acquired.Valid || acquired.Int64 != 1 {
+		_ = conn.Close()
+		t.Fatalf("hold leader lock result = %+v, want 1", acquired)
+	}
+	t.Cleanup(func() {
+		var released sql.NullInt64
+		_ = conn.QueryRowContext(context.Background(), `SELECT RELEASE_LOCK(?)`, lockName).Scan(&released)
+		_ = conn.Close()
+	})
+	return leader.NewManager(metaStore.DB(), leader.WithLockName(lockName))
+}
 
 func TestRetryTenantPoolClaimCASSucceedsOnEighthAttempt(t *testing.T) {
 	attempts := 0
@@ -351,7 +377,8 @@ func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
 		sharedPoolBatchErr: errors.New("stop after managed pool planning")}
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
-		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32)})
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: make([]byte, 32),
+		Leader: newFollowerLeaderManager(t, metaStore)})
 	defer srv.Close()
 	now := time.Now().UTC()
 	if err := metaStore.CreateTenantPool(context.Background(), &meta.TenantPool{PoolID: "pool-shared-credential",
@@ -1457,7 +1484,7 @@ func TestAdminTenantPoolReplenishContinuesPastWatermarkToFillSlots(t *testing.T)
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
 		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 200,
-		TokenSecret: make([]byte, 32)})
+		TokenSecret: make([]byte, 32), Leader: newFollowerLeaderManager(t, metaStore)})
 	defer srv.Close()
 	ctx := context.Background()
 	now := time.Now().UTC()

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -130,6 +130,16 @@ func TestTenantPoolClaimUsesNativeInventoryBeforeExternalSharedPool(t *testing.T
 	if res.TenantID != nativeTenantID || res.Provider != tenant.ProviderTiDBCloudNative {
 		t.Fatalf("claimed result = %+v, want native tenant %s", res, nativeTenantID)
 	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, ok := rt.server.tenantPoolReplenishJobs.Load("pool-mixed-inventory"); ok {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("native request did not trigger request-scoped tenant-pool replenishment")
+		}
+		time.Sleep(time.Millisecond)
+	}
 }
 
 func TestTenantPoolClaimConsumesMixedInventoryInGlobalAgeOrder(t *testing.T) {
@@ -194,6 +204,9 @@ func TestTenantPoolClaimConsumesMixedInventoryInGlobalAgeOrder(t *testing.T) {
 	}
 	if first.TenantID != nativeTenantID || first.Provider != tenant.ProviderTiDBCloudNative {
 		t.Fatalf("first claim = %+v, want older native tenant %s", first, nativeTenantID)
+	}
+	if _, ok := rt.server.tenantPoolReplenishJobs.Load("pool-mixed-age"); ok {
+		t.Fatal("shared-default request unexpectedly triggered bulk tenant-pool replenishment")
 	}
 	second, _, claimed, _, err := rt.server.claimAdminTenantFromPool(ctx, cred, nil)
 	if err != nil || !claimed {
@@ -1586,6 +1599,80 @@ func TestSharedTenantPoolLeaderReconcilerRefillsZeroInventory(t *testing.T) {
 	}
 }
 
+func TestSharedTenantPoolRefillReplacesExpiredPlannedCapacity(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(func() { poolManager.Close() })
+	poolManager.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 1,
+		ManagedSharedDBPlannedCapacityLease: time.Minute, TokenSecret: make([]byte, 32),
+		Leader: newFollowerLeaderManager(t, metaStore)})
+	t.Cleanup(func() { srv.Close() })
+	ctx := context.Background()
+	now := time.Now().UTC()
+	logicalPool := &meta.TenantPool{PoolID: "pool-expired-plan", OrganizationID: "org-expired-plan",
+		Size: 1, Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}
+	if err := metaStore.CreateTenantPool(ctx, logicalPool); err != nil {
+		t.Fatalf("CreateTenantPool: %v", err)
+	}
+	spendingLimit := int64(meta.MaxTiDBCloudSpendingLimit)
+	dbID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: logicalPool.OrganizationID, ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 1, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	tenantID := "tenant-expired-plan"
+	if err := srv.insertPendingPoolTenant(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared, now); err != nil {
+		t.Fatalf("insertPendingPoolTenant: %v", err)
+	}
+	fsID, err := metaStore.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if err := metaStore.CompleteSharedTenantPoolMember(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared,
+		&meta.TenantPlacement{FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared},
+		&meta.TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: logicalPool.OrganizationID,
+			PoolID: logicalPool.PoolID, PoolStatus: meta.TenantPoolBindingFree}); err != nil {
+		t.Fatalf("CompleteSharedTenantPoolMember: %v", err)
+	}
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, now.Add(-2*time.Minute), dbID); err != nil {
+		t.Fatalf("age planned pool: %v", err)
+	}
+
+	srv.replenishTenantPoolAsync(ctx, logicalPool, tenant.CredentialProvisionRequest{})
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		var physicalPools int
+		if err := metaStore.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, logicalPool.OrganizationID).Scan(&physicalPools); err != nil {
+			t.Fatalf("count physical pools: %v", err)
+		}
+		if physicalPools >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("physical pools = %d, want replacement for expired planned capacity", physicalPools)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
 func TestLeaderTenantPoolReplenishmentDoesNotStartOnFollower(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -1594,61 +1681,98 @@ func TestLeaderTenantPoolReplenishmentDoesNotStartOnFollower(t *testing.T) {
 	t.Cleanup(func() { _ = metaStore.Close() })
 	mgr := leader.NewManager(metaStore.DB())
 	srv := &Server{
-		leader: mgr, tenantPoolReconcileSlots: make(chan struct{}, 1),
+		leader: mgr, tenantPoolReconcileQueue: make(chan tenantPoolReconcileJob),
 		leaderWorkersStarted: true, leaderWorkerCtx: context.Background(),
 	}
-	srv.replenishTenantPoolLeaderAsync(context.Background(), &meta.TenantPool{
+	if srv.enqueueTenantPoolLeaderReplenishment(context.Background(), &meta.TenantPool{
 		PoolID: "pool-follower", OrganizationID: "org-follower", Size: 1, Status: meta.TenantPoolActive,
-	}, tenant.CredentialProvisionRequest{})
-	value, ok := srv.tenantPoolReplenishJobs.Load("pool-follower")
-	if !ok {
-		t.Fatal("follower trigger did not initialize its local coalescing gate")
+	}, tenant.CredentialProvisionRequest{}) {
+		t.Fatal("follower unexpectedly queued leader refill work")
 	}
-	gate := value.(*tenantPoolWorkGate)
-	gate.mu.Lock()
-	running := gate.running
-	gate.mu.Unlock()
-	if running || len(srv.tenantPoolReconcileSlots) != 0 {
-		t.Fatalf("follower refill running=%v slots=%d, want no leader-owned work", running, len(srv.tenantPoolReconcileSlots))
+	if _, ok := srv.tenantPoolReplenishJobs.Load("pool-follower"); ok {
+		t.Fatal("leader refill unexpectedly initialized the request-side per-pool gate")
 	}
 }
 
-func TestTenantPoolLeaderReconcileWorkersBoundConcurrency(t *testing.T) {
+func TestTenantPoolLeaderReconcileWorkersQueueAndRestBetweenTasks(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	srv := &Server{forkWorkerCtx: ctx, tenantPoolReconcileSlots: make(chan struct{}, 1)}
+	rest := 40 * time.Millisecond
+	srv := &Server{tenantPoolReconcileQueue: make(chan tenantPoolReconcileJob), tenantPoolReconcileWorkerRest: rest}
+	workerDone := make(chan struct{})
+	go func() {
+		defer close(workerDone)
+		srv.runTenantPoolReconcileWorker(ctx)
+	}()
 	firstStarted := make(chan struct{}, 1)
 	release := make(chan struct{})
-	if !srv.startTenantPoolLeaderReconcileWorker(ctx, func(context.Context) {
+	if !srv.enqueueTenantPoolReconcileWork(ctx, func(context.Context) {
 		firstStarted <- struct{}{}
 		<-release
 	}) {
-		t.Fatal("first leader reconcile worker did not start")
+		t.Fatal("first leader reconcile task was not queued")
 	}
 	<-firstStarted
 	secondStarted := make(chan struct{}, 1)
-	secondResult := make(chan bool, 1)
+	secondQueued := make(chan bool, 1)
 	go func() {
-		secondResult <- srv.startTenantPoolLeaderReconcileWorker(ctx, func(context.Context) {
+		secondQueued <- srv.enqueueTenantPoolReconcileWork(ctx, func(context.Context) {
 			secondStarted <- struct{}{}
 		})
 	}()
 	select {
-	case result := <-secondResult:
-		t.Fatalf("second leader reconcile returned %v while the only slot was occupied", result)
-	case <-time.After(50 * time.Millisecond):
+	case <-secondQueued:
+		t.Fatal("second task left the queue while the only worker was occupied")
+	case <-time.After(20 * time.Millisecond):
 	}
+	releasedAt := time.Now()
 	close(release)
 	select {
-	case result := <-secondResult:
-		if !result {
-			t.Fatal("second leader reconcile did not start after a slot was released")
+	case <-secondStarted:
+		if elapsed := time.Since(releasedAt); elapsed < rest {
+			t.Fatalf("queued task started after %s, want worker rest of at least %s", elapsed, rest)
 		}
 	case <-time.After(time.Second):
-		t.Fatal("second leader reconcile remained blocked after a slot was released")
+		t.Fatal("queued task did not start after the first worker rested")
 	}
-	<-secondStarted
-	srv.forkWorkerWG.Wait()
+	if queued := <-secondQueued; !queued {
+		t.Fatal("second leader reconcile task was not queued")
+	}
+	cancel()
+	select {
+	case <-workerDone:
+	case <-time.After(time.Second):
+		t.Fatal("tenant-pool reconcile worker did not stop")
+	}
+}
+
+func TestTenantPoolLeaderReconcileAllowsSamePoolAcrossScans(t *testing.T) {
+	srv := &Server{tenantPoolReconcileQueue: make(chan tenantPoolReconcileJob)}
+	pool := &meta.TenantPool{PoolID: "pool-repeated-scan", OrganizationID: "org-repeated-scan", Size: 100}
+	queued := make(chan bool, 2)
+	for range 2 {
+		go func() {
+			queued <- srv.enqueueTenantPoolLeaderReplenishment(context.Background(), pool, tenant.CredentialProvisionRequest{})
+		}()
+	}
+	for range 2 {
+		select {
+		case job := <-srv.tenantPoolReconcileQueue:
+			if job.run == nil {
+				t.Fatal("queued leader refill has no work")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("same pool was coalesced across leader scans")
+		}
+	}
+	for range 2 {
+		if ok := <-queued; !ok {
+			t.Fatal("same-pool leader refill was not queued")
+		}
+	}
+	if _, ok := srv.tenantPoolReplenishJobs.Load(pool.PoolID); ok {
+		t.Fatal("leader refill unexpectedly used the request-side per-pool gate")
+	}
 }
 
 func TestManagedSharedDBStuckReconcilerFailsPoolAndPlacedTenant(t *testing.T) {
@@ -1794,7 +1918,7 @@ func TestManagedSharedDBReplenishSubmitsWholePhysicalPoolWaveConcurrently(t *tes
 	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
 	defer poolManager.Close()
 	poolManager.SetMetaStore(metaStore)
-	batchStarted := make(chan struct{}, 5)
+	batchStarted := make(chan struct{}, 1)
 	batchRelease := make(chan struct{})
 	prov := &fakeProvisioner{
 		provider:               tenant.ProviderTiDBCloudNative,
@@ -1807,7 +1931,7 @@ func TestManagedSharedDBReplenishSubmitsWholePhysicalPoolWaveConcurrently(t *tes
 	srv := &Server{
 		meta: metaStore, pool: poolManager, provisioner: prov,
 		defaultTenantProvider: tenant.ProviderTiDBCloudNativeShared,
-		sharedDBMaxTenants:    1, managedSharedDBRefillPoolLimit: 50, managedSharedDBCloudBatchSize: 10,
+		sharedDBMaxTenants:    1, managedSharedDBCloudBatchSize: 50,
 		tenantPoolRefillFreeRatio: DefaultTenantPoolRefillFreeRatio,
 		forkWorkerCtx:             workerCtx, forkWorkerCancel: cancel,
 	}
@@ -1845,12 +1969,10 @@ func TestManagedSharedDBReplenishSubmitsWholePhysicalPoolWaveConcurrently(t *tes
 
 	srv.replenishTenantPoolAsyncWithStarters(context.Background(), logicalPool,
 		tenant.CredentialProvisionRequest{}, workStarter, timerStarter)
-	for i := 0; i < 5; i++ {
-		select {
-		case <-batchStarted:
-		case <-time.After(3 * time.Second):
-			t.Fatalf("started %d/5 Cloud batches before release", i)
-		}
+	select {
+	case <-batchStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("Cloud batch did not start")
 	}
 	releaseBatches()
 	select {
@@ -1858,8 +1980,8 @@ func TestManagedSharedDBReplenishSubmitsWholePhysicalPoolWaveConcurrently(t *tes
 	case <-time.After(10 * time.Second):
 		t.Fatal("whole-wave replenish did not finish")
 	}
-	if got := prov.sharedPoolBatchCalls.Load(); got != 5 {
-		t.Fatalf("Cloud batch calls = %d, want 5", got)
+	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
+		t.Fatalf("Cloud batch calls = %d, want 1", got)
 	}
 	if got := prov.sharedPoolBatchMembers.Load(); got != 50 {
 		t.Fatalf("Cloud batch members = %d, want 50", got)

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/mem9-ai/drive9/internal/testmysql"
 	"github.com/mem9-ai/drive9/pkg/encrypt"
+	"github.com/mem9-ai/drive9/pkg/leader"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 )
@@ -1038,6 +1039,68 @@ func TestTenantPoolReplenishmentCoalescesConcurrentTriggersByPool(t *testing.T) 
 	}
 }
 
+func TestTenantPoolReplenishmentRerunsCoalescedTriggerAfterWorkerFinishes(t *testing.T) {
+	s := &Server{}
+	now := time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
+
+	first := s.requestTenantPoolReplenishmentAt("pool-1", now)
+	if !first.start || first.scheduleAfter != 0 {
+		t.Fatalf("first decision = %+v, want immediate start", first)
+	}
+	coalesced := s.requestTenantPoolReplenishmentAt("pool-1", now)
+	if coalesced.start || coalesced.scheduleAfter != 0 {
+		t.Fatalf("running decision = %+v, want coalesced trigger", coalesced)
+	}
+	finished := s.finishTenantPoolReplenishmentAt("pool-1", now)
+	if finished.start || finished.scheduleAfter != tenantPoolReplenishMinInterval {
+		t.Fatalf("finish decision = %+v, want one delayed rerun", finished)
+	}
+	cooldown := s.requestTenantPoolReplenishmentAt("pool-1", now.Add(tenantPoolReplenishMinInterval/2))
+	if cooldown.start || cooldown.scheduleAfter != 0 {
+		t.Fatalf("cooldown decision = %+v, want existing delayed rerun to absorb trigger", cooldown)
+	}
+	rerun := s.requestTenantPoolReplenishmentAt("pool-1", now.Add(tenantPoolReplenishMinInterval))
+	if !rerun.start || rerun.scheduleAfter != 0 {
+		t.Fatalf("rerun decision = %+v, want immediate start after cooldown", rerun)
+	}
+}
+
+func TestLeaderTenantPoolReplenishmentTimerDoesNotConsumeWorkSlot(t *testing.T) {
+	s := &Server{}
+	pool := &meta.TenantPool{PoolID: "pool-leader-rerun", OrganizationID: "org-leader-rerun", Size: 1}
+	value, _ := s.tenantPoolReplenishJobs.LoadOrStore(pool.PoolID, &tenantPoolWorkGate{})
+	gate := value.(*tenantPoolWorkGate)
+	gate.mu.Lock()
+	gate.rerun = true
+	gate.scheduled = true
+	gate.nextAllowed = time.Now()
+	gate.mu.Unlock()
+
+	workStarted := make(chan struct{}, 1)
+	workStarter := func(context.Context, func(context.Context)) bool {
+		workStarted <- struct{}{}
+		return true
+	}
+	timerStarted := make(chan struct{}, 1)
+	timerStarter := func(ctx context.Context, fn func(context.Context)) bool {
+		timerStarted <- struct{}{}
+		go fn(ctx)
+		return true
+	}
+
+	s.scheduleTenantPoolReplenishment(context.Background(), pool, tenant.CredentialProvisionRequest{}, 0, workStarter, timerStarter)
+	select {
+	case <-timerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("leader rerun timer did not start")
+	}
+	select {
+	case <-workStarted:
+	case <-time.After(time.Second):
+		t.Fatal("leader rerun did not reacquire a refill work slot")
+	}
+}
+
 func TestTenantPoolPendingResumeScanCooldownAfterEmptyResult(t *testing.T) {
 	s := &Server{}
 	now := time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
@@ -1281,6 +1344,165 @@ func TestAdminTenantPoolReplenishContinuesPastWatermarkToFillSlots(t *testing.T)
 			t.Fatalf("free slots = %d, want %d after refill", free, pool.Size)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestSharedTenantPoolLeaderReconcilerRefillsZeroInventory(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer poolManager.Close()
+	poolManager.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 100,
+		TokenSecret: make([]byte, 32)})
+	defer srv.Close()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{PoolID: "pool-leader-reconcile", OrganizationID: "org-leader-reconcile",
+		Size: 1, Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}
+	if err := metaStore.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	srv.reconcileSharedTenantPoolsWithCtx(ctx)
+	deadline := time.Now().Add(10 * time.Second)
+	for {
+		slots, countErr := metaStore.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
+		if countErr != nil {
+			t.Fatalf("count free slots: %v", countErr)
+		}
+		if slots == pool.Size {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("free slots = %d, want %d after leader reconcile", slots, pool.Size)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestLeaderTenantPoolReplenishmentDoesNotStartOnFollower(t *testing.T) {
+	mgr := leader.NewManager(nil)
+	srv := &Server{leader: mgr, tenantPoolReconcileSlots: make(chan struct{}, 1)}
+	srv.replenishTenantPoolLeaderAsync(context.Background(), &meta.TenantPool{
+		PoolID: "pool-follower", OrganizationID: "org-follower", Size: 1, Status: meta.TenantPoolActive,
+	}, tenant.CredentialProvisionRequest{})
+	value, ok := srv.tenantPoolReplenishJobs.Load("pool-follower")
+	if !ok {
+		t.Fatal("follower trigger did not initialize its local coalescing gate")
+	}
+	gate := value.(*tenantPoolWorkGate)
+	gate.mu.Lock()
+	running := gate.running
+	gate.mu.Unlock()
+	if running || len(srv.tenantPoolReconcileSlots) != 0 {
+		t.Fatalf("follower refill running=%v slots=%d, want no leader-owned work", running, len(srv.tenantPoolReconcileSlots))
+	}
+}
+
+func TestTenantPoolLeaderReconcileWorkersBoundConcurrency(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := &Server{forkWorkerCtx: ctx, tenantPoolReconcileSlots: make(chan struct{}, 1)}
+	firstStarted := make(chan struct{}, 1)
+	release := make(chan struct{})
+	if !srv.startTenantPoolLeaderReconcileWorker(ctx, func(context.Context) {
+		firstStarted <- struct{}{}
+		<-release
+	}) {
+		t.Fatal("first leader reconcile worker did not start")
+	}
+	<-firstStarted
+	secondStarted := make(chan struct{}, 1)
+	secondResult := make(chan bool, 1)
+	go func() {
+		secondResult <- srv.startTenantPoolLeaderReconcileWorker(ctx, func(context.Context) {
+			secondStarted <- struct{}{}
+		})
+	}()
+	select {
+	case result := <-secondResult:
+		t.Fatalf("second leader reconcile returned %v while the only slot was occupied", result)
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(release)
+	select {
+	case result := <-secondResult:
+		if !result {
+			t.Fatal("second leader reconcile did not start after a slot was released")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("second leader reconcile remained blocked after a slot was released")
+	}
+	<-secondStarted
+	srv.forkWorkerWG.Wait()
+}
+
+func TestManagedSharedDBStuckReconcilerFailsPoolAndPlacedTenant(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	ctx := context.Background()
+	now := time.Now().UTC()
+	logicalPool := &meta.TenantPool{PoolID: "logical-stuck", OrganizationID: "org-stuck", Size: 1,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}
+	if err := metaStore.CreateTenantPool(ctx, logicalPool); err != nil {
+		t.Fatalf("CreateTenantPool: %v", err)
+	}
+	spendingLimit := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-stuck", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	tenantID := "tenant-stuck-reconcile"
+	if err := metaStore.InsertTenant(ctx, &meta.Tenant{ID: tenantID, Status: meta.TenantPending,
+		Provider: tenant.ProviderTiDBCloudNative, DBPasswordCipher: []byte{}, SchemaVersion: 1,
+		CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatalf("InsertTenant: %v", err)
+	}
+	fsID, err := metaStore.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatalf("EnsureFsID: %v", err)
+	}
+	if err := metaStore.CompleteSharedTenantPoolMember(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared,
+		&meta.TenantPlacement{FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared},
+		&meta.TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: "org-stuck",
+			PoolID: logicalPool.PoolID, PoolStatus: meta.TenantPoolBindingFree}); err != nil {
+		t.Fatalf("CompleteSharedTenantPoolMember: %v", err)
+	}
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, now.Add(-20*time.Minute), dbID); err != nil {
+		t.Fatalf("age db pool: %v", err)
+	}
+
+	srv := &Server{meta: metaStore, managedSharedDBStuckTimeout: 15 * time.Minute}
+	srv.reconcileStuckManagedSharedDBPoolsWithCtx(ctx)
+	pool, err := metaStore.GetSharedDB(ctx, dbID)
+	if err != nil || pool.Status != meta.SharedDBStatusFailed {
+		t.Fatalf("pool after stuck reconcile = %+v, %v", pool, err)
+	}
+	gotTenant, err := metaStore.GetTenant(ctx, tenantID)
+	if err != nil || gotTenant.Status != meta.TenantFailed {
+		t.Fatalf("tenant after stuck reconcile = %+v, %v", gotTenant, err)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -599,6 +599,77 @@ func TestSharedTenantPoolRefillDoesNotOverfillAfterLogicalPoolShrink(t *testing.
 	}
 }
 
+func TestSharedTenantPoolWaveIgnoresOrphanPendingMembershipCapacity(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(poolManager.Close)
+	poolManager.SetMetaStore(metaStore)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	logicalPool := &meta.TenantPool{
+		PoolID: "pool-orphan-pending", OrganizationID: "org-orphan-pending", Size: 2,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := metaStore.CreateTenantPool(ctx, logicalPool); err != nil {
+		t.Fatalf("CreateTenantPool: %v", err)
+	}
+	prov := &fakeProvisioner{
+		provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		identityOrg: logicalPool.OrganizationID,
+	}
+	srv := NewWithConfig(Config{
+		Meta: metaStore, Pool: poolManager, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 1,
+		TokenSecret: make([]byte, 32), Leader: newFollowerLeaderManager(t, metaStore),
+	})
+	t.Cleanup(srv.Close)
+
+	const orphanTenantID = "tenant-orphan-pending-membership"
+	if err := srv.insertPendingPoolTenant(ctx, orphanTenantID, tenant.ProviderTiDBCloudNativeShared, now); err != nil {
+		t.Fatalf("insert orphan tenant: %v", err)
+	}
+	if err := metaStore.UpsertTenantPoolMembership(ctx, &meta.TenantPoolMembership{
+		TenantID: orphanTenantID, TiDBCloudOrganizationID: logicalPool.OrganizationID,
+		PoolID: logicalPool.PoolID, PoolStatus: meta.TenantPoolBindingFree,
+		CreatedAt: now, UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("insert orphan membership: %v", err)
+	}
+
+	results, err := srv.createFreeSharedPoolTenants(ctx, logicalPool.PoolID, logicalPool.Size,
+		tenant.CredentialProvisionRequest{}, nil)
+	if err != nil {
+		t.Fatalf("create valid shared wave: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("valid wave members = %d, want 2", len(results))
+	}
+	if got := prov.sharedPoolBatchMembers.Load(); got != 2 {
+		t.Fatalf("physical Cloud creates = %d, want 2", got)
+	}
+	var memberships int
+	if err := metaStore.DB().QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM tenant_pool_memberships WHERE pool_id = ?`, logicalPool.PoolID).Scan(&memberships); err != nil {
+		t.Fatal(err)
+	}
+	if memberships != 3 {
+		t.Fatalf("memberships = %d, want orphan plus two valid members", memberships)
+	}
+}
+
 func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1403,7 +1403,7 @@ func TestAdminTenantPoolReplenishSubmitsLargeRefillAsSingleWave(t *testing.T) {
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
 		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 100,
-		TokenSecret: make([]byte, 32)})
+		TokenSecret: make([]byte, 32), Leader: newFollowerLeaderManager(t, metaStore)})
 	defer srv.Close()
 	// Make the complete three-pool refill wave visible as one Cloud batch.
 	srv.managedSharedDBCloudBatchSize = 250
@@ -1582,7 +1582,6 @@ func TestSharedTenantPoolLeaderReconcilerRefillsZeroInventory(t *testing.T) {
 		t.Fatalf("create pool: %v", err)
 	}
 
-	srv.reconcileSharedTenantPoolsWithCtx(ctx)
 	deadline := time.Now().Add(10 * time.Second)
 	for {
 		slots, countErr := metaStore.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -399,6 +399,206 @@ func TestSharedTenantPoolRefillMakesWaveVisibleOnlyAfterMembershipReservation(t 
 	}
 }
 
+func TestSharedTenantPoolRefillDoesNotCommitAfterLogicalPoolDelete(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(poolManager.Close)
+	poolManager.SetMetaStore(metaStore)
+	ctx := context.Background()
+	logicalPool := &meta.TenantPool{PoolID: "pool-delete-during-wave", OrganizationID: "org-delete-during-wave",
+		Size: 2, Status: meta.TenantPoolActive, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
+	if err := metaStore.CreateTenantPool(ctx, logicalPool); err != nil {
+		t.Fatal(err)
+	}
+	batchStarted := make(chan struct{}, 1)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		sharedPoolBatchStarted: batchStarted}
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	srv := &Server{meta: metaStore, pool: poolManager, provisioner: prov,
+		defaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, sharedDBMaxTenants: 1,
+		managedSharedDBCloudBatchSize: 10, forkWorkerCtx: workerCtx, forkWorkerCancel: workerCancel}
+	t.Cleanup(srv.Close)
+
+	lockConn, err := metaStore.DB().Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lockConn.ExecContext(ctx, `LOCK TABLES tenant_quota_config WRITE`); err != nil {
+		_ = lockConn.Close()
+		t.Fatal(err)
+	}
+	locked := true
+	t.Cleanup(func() {
+		if locked {
+			_, _ = lockConn.ExecContext(context.Background(), `UNLOCK TABLES`)
+		}
+		_ = lockConn.Close()
+	})
+	waveDone := make(chan error, 1)
+	go func() {
+		_, createErr := srv.createFreeSharedPoolTenants(ctx, logicalPool.PoolID, logicalPool.Size,
+			tenant.CredentialProvisionRequest{}, nil)
+		waveDone <- createErr
+	}()
+	select {
+	case err := <-waveDone:
+		t.Fatalf("refill returned before quota lock was released: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := metaStore.UpdateTenantPoolStatus(ctx, logicalPool.PoolID, meta.TenantPoolDeleting); err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.DeleteTenantPoolAndDetachUsedMembers(ctx, logicalPool.PoolID); err != nil {
+		t.Fatalf("delete logical pool while refill is blocked: %v", err)
+	}
+	if _, err := lockConn.ExecContext(ctx, `UNLOCK TABLES`); err != nil {
+		t.Fatal(err)
+	}
+	locked = false
+	select {
+	case err := <-waveDone:
+		if err == nil {
+			t.Fatal("refill committed after logical pool deletion")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("refill did not stop after logical pool deletion")
+	}
+	select {
+	case <-batchStarted:
+		t.Fatal("Cloud batch started after logical pool deletion won")
+	default:
+	}
+	if _, err := metaStore.GetTenantPoolByID(ctx, logicalPool.PoolID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("logical pool after delete = %v, want not found", err)
+	}
+	var physicalRows, memberships int
+	if err := metaStore.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, logicalPool.OrganizationID).Scan(&physicalRows); err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM tenant_pool_memberships WHERE pool_id = ?`, logicalPool.PoolID).Scan(&memberships); err != nil {
+		t.Fatal(err)
+	}
+	if physicalRows != 0 || memberships != 0 {
+		t.Fatalf("durable refill residue after delete: physical=%d memberships=%d", physicalRows, memberships)
+	}
+}
+
+func TestSharedTenantPoolRefillDoesNotOverfillAfterLogicalPoolShrink(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(poolManager.Close)
+	poolManager.SetMetaStore(metaStore)
+	ctx := context.Background()
+	logicalPool := &meta.TenantPool{PoolID: "pool-shrink-during-wave", OrganizationID: "org-shrink-during-wave",
+		Size: 2, Status: meta.TenantPoolActive, CreatedAt: time.Now().UTC(), UpdatedAt: time.Now().UTC()}
+	if err := metaStore.CreateTenantPool(ctx, logicalPool); err != nil {
+		t.Fatal(err)
+	}
+	batchStarted := make(chan struct{}, 2)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		sharedPoolBatchStarted: batchStarted}
+	workerCtx, workerCancel := context.WithCancel(context.Background())
+	srv := &Server{meta: metaStore, pool: poolManager, provisioner: prov,
+		defaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, sharedDBMaxTenants: 1,
+		managedSharedDBCloudBatchSize: 10, forkWorkerCtx: workerCtx, forkWorkerCancel: workerCancel}
+	t.Cleanup(srv.Close)
+
+	lockConn, err := metaStore.DB().Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lockConn.ExecContext(ctx, `LOCK TABLES tenant_quota_config WRITE`); err != nil {
+		_ = lockConn.Close()
+		t.Fatal(err)
+	}
+	locked := true
+	t.Cleanup(func() {
+		if locked {
+			_, _ = lockConn.ExecContext(context.Background(), `UNLOCK TABLES`)
+		}
+		_ = lockConn.Close()
+	})
+	waveDone := make(chan error, 1)
+	go func() {
+		_, createErr := srv.createFreeSharedPoolTenants(ctx, logicalPool.PoolID, logicalPool.Size,
+			tenant.CredentialProvisionRequest{}, nil)
+		waveDone <- createErr
+	}()
+	select {
+	case err := <-waveDone:
+		t.Fatalf("refill returned before quota lock was released: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if err := metaStore.UpdateTenantPoolSize(ctx, logicalPool.PoolID, 1); err != nil {
+		t.Fatalf("shrink logical pool while refill is blocked: %v", err)
+	}
+	if _, err := lockConn.ExecContext(ctx, `UNLOCK TABLES`); err != nil {
+		t.Fatal(err)
+	}
+	locked = false
+	select {
+	case err := <-waveDone:
+		if err == nil {
+			t.Fatal("stale refill committed after logical pool shrink")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale refill did not stop after logical pool shrink")
+	}
+	select {
+	case <-batchStarted:
+		t.Fatal("Cloud batch started for stale oversized refill")
+	default:
+	}
+	gotPool, err := metaStore.GetTenantPoolByID(ctx, logicalPool.PoolID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPool.Size != 1 {
+		t.Fatalf("logical pool size = %d, want 1", gotPool.Size)
+	}
+	if free, err := metaStore.CountTenantPoolFreeSlots(ctx, logicalPool.OrganizationID); err != nil || free != 0 {
+		t.Fatalf("free slots after rejected stale refill = %d, err=%v", free, err)
+	}
+	if _, err := srv.createFreeSharedPoolTenants(ctx, logicalPool.PoolID, 1,
+		tenant.CredentialProvisionRequest{}, nil); err != nil {
+		t.Fatalf("correctly sized refill after shrink: %v", err)
+	}
+	select {
+	case <-batchStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Cloud batch did not start for correctly sized refill")
+	}
+	if free, err := metaStore.CountTenantPoolFreeSlots(ctx, logicalPool.OrganizationID); err != nil || free != 1 {
+		t.Fatalf("free slots after correctly sized refill = %d, err=%v", free, err)
+	}
+}
+
 func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -1468,6 +1668,75 @@ func TestAdminTenantPoolReplenishSubmitsLargeRefillAsSingleWave(t *testing.T) {
 	}
 	if got := prov.sharedPoolBatchMembers.Load(); got != 3 {
 		t.Fatalf("shared cloud batch members = %d, want 3 physical pools", got)
+	}
+}
+
+func TestManagedSharedDBCloudBatchRequestsAreGloballyBounded(t *testing.T) {
+	const wantMaxConcurrentBatches = 5
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(poolManager.Close)
+	poolManager.SetMetaStore(metaStore)
+	batchStarted := make(chan struct{}, 7)
+	batchRelease := make(chan struct{}, 7)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1",
+		sharedPoolBatchStarted: batchStarted, sharedPoolBatchRelease: batchRelease}
+	srv := &Server{meta: metaStore, pool: poolManager, provisioner: prov, sharedDBMaxTenants: 1,
+		managedSharedDBCloudBatchSize: 1}
+	ctx := context.Background()
+	cred := tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"}
+	dbIDs := make([]int64, 0, 7)
+	for range 7 {
+		row, err := srv.createManagedSharedDBPlan(ctx, "org-cloud-batch-bound", sharedDBProvisioningKey(cred))
+		if err != nil {
+			t.Fatal(err)
+		}
+		dbIDs = append(dbIDs, row.ID)
+	}
+	done := make(chan error, 1)
+	go func() {
+		_, createErr := srv.provisionManagedSharedDBPoolsBatchWithCredentials(ctx, dbIDs, cred)
+		done <- createErr
+	}()
+	for i := 0; i < wantMaxConcurrentBatches; i++ {
+		select {
+		case <-batchStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Cloud batch %d did not start", i+1)
+		}
+	}
+	select {
+	case <-batchStarted:
+		t.Fatalf("more than %d Cloud batch requests started concurrently", wantMaxConcurrentBatches)
+	case <-time.After(150 * time.Millisecond):
+	}
+	batchRelease <- struct{}{}
+	select {
+	case <-batchStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("next Cloud batch did not start after a request slot was released")
+	}
+	close(batchRelease)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("provision managed shared DB batches: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Cloud batch provisioning did not finish")
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -288,7 +288,7 @@ func TestSharedTenantPoolRefillPlansTenPoolsInOneBatch(t *testing.T) {
 	}
 }
 
-func TestSharedTenantPoolRefillStagesWholePhysicalWaveBeforePlacement(t *testing.T) {
+func TestSharedTenantPoolRefillMakesWaveVisibleOnlyAfterMembershipReservation(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -331,6 +331,7 @@ func TestSharedTenantPoolRefillStagesWholePhysicalWaveBeforePlacement(t *testing
 	}
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan error, 1)
+	finished := false
 	go func() {
 		_, err := srv.createFreeSharedPoolTenants(ctx, "pool-stage-wave", 6,
 			tenant.CredentialProvisionRequest{}, nil)
@@ -340,33 +341,61 @@ func TestSharedTenantPoolRefillStagesWholePhysicalWaveBeforePlacement(t *testing
 		cancel()
 		_, _ = lockConn.ExecContext(context.Background(), `UNLOCK TABLES`)
 		_ = lockConn.Close()
-		select {
-		case <-done:
-		case <-time.After(5 * time.Second):
-			t.Error("shared refill did not stop after releasing quota table lock")
+		if !finished {
+			select {
+			case <-done:
+			case <-time.After(5 * time.Second):
+				t.Error("shared refill did not stop after releasing quota table lock")
+			}
 		}
 		srv.Close()
 	})
 
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		var managedPools int
-		if err := metaStore.DB().QueryRowContext(context.Background(),
-			`SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, "org-stage-wave").Scan(&managedPools); err != nil {
-			t.Fatal(err)
-		}
-		if managedPools == 3 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("physical pools staged before placement = %d, want complete three-pool wave", managedPools)
-		}
-		time.Sleep(10 * time.Millisecond)
+	select {
+	case <-batchStarted:
+		t.Fatal("Cloud batch started before tenant membership reservations committed")
+	case <-time.After(100 * time.Millisecond):
+	}
+	if _, err := metaStore.FindSharedDBForAllocation(context.Background(), "org-stage-wave"); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("direct allocation saw refill-staged capacity before membership commit: %v", err)
+	}
+	if _, err := lockConn.ExecContext(context.Background(), `UNLOCK TABLES`); err != nil {
+		t.Fatal(err)
 	}
 	select {
 	case <-batchStarted:
-	case <-time.After(time.Second):
-		t.Fatal("Cloud batch did not start while tenant quota writes were still blocked")
+	case <-time.After(2 * time.Second):
+		t.Fatal("Cloud batch did not start after durable wave staging committed")
+	}
+	select {
+	case err := <-done:
+		finished = true
+		if err != nil {
+			t.Fatalf("createFreeSharedPoolTenants: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("shared refill did not finish after durable wave staging")
+	}
+	free, err := metaStore.CountTenantPoolFreeSlots(context.Background(), "org-stage-wave")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if free != 6 {
+		t.Fatalf("durably reserved free slots = %d, want 6", free)
+	}
+	if _, err := metaStore.FindSharedDBForAllocation(context.Background(), "org-stage-wave"); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("direct allocation saw capacity already reserved by the completed refill wave: %v", err)
+	}
+	active, err := metaStore.CountFreeTenantPoolBindings(context.Background(), "org-stage-wave")
+	if err != nil {
+		t.Fatal(err)
+	}
+	planned, err := metaStore.CountTenantPoolPlannedSlots(context.Background(), "org-stage-wave")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if active+planned != 6 {
+		t.Fatalf("active + planned slots after atomic wave commit = %d + %d, want 6", active, planned)
 	}
 }
 
@@ -418,52 +447,6 @@ func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T
 	}
 	if got := prov.iamCalls.Load(); got != 0 {
 		t.Fatalf("identity lookups = %d, want 0", got)
-	}
-}
-
-func TestSharedTenantPoolRefillLimitsPhysicalPartitionWorkersGlobally(t *testing.T) {
-	const wantConcurrency = 30
-	started := make(chan struct{}, 2*(wantConcurrency+1))
-	release := make(chan struct{})
-	done := make(chan []sharedPoolTenantCreateOutcome, 2)
-	globalSlots := make(chan struct{}, wantConcurrency)
-	for wave := 0; wave < 2; wave++ {
-		partitions := make([]sharedPoolTenantPartition, wantConcurrency+1)
-		for i := range partitions {
-			partitions[i] = sharedPoolTenantPartition{db: &meta.SharedDB{ID: int64(wave*100 + i + 1)}, tenantCount: 1}
-		}
-		go func() {
-			done <- runSharedPoolTenantPartitionWorkers(context.Background(), globalSlots, partitions, func(sharedPoolTenantPartition) sharedPoolTenantCreateOutcome {
-				started <- struct{}{}
-				<-release
-				return sharedPoolTenantCreateOutcome{}
-			})
-		}()
-	}
-	for i := 0; i < wantConcurrency; i++ {
-		select {
-		case <-started:
-		case <-time.After(500 * time.Millisecond):
-			close(release)
-			<-done
-			<-done
-			t.Fatalf("started %d/%d tenant workers before release", i, wantConcurrency)
-		}
-	}
-	select {
-	case <-started:
-		close(release)
-		<-done
-		<-done
-		t.Fatal("started a 31st tenant writer across concurrent refill waves")
-	case <-time.After(100 * time.Millisecond):
-	}
-	close(release)
-	for wave := 0; wave < 2; wave++ {
-		outcomes := <-done
-		if len(outcomes) != wantConcurrency+1 {
-			t.Fatalf("wave %d outcomes = %d, want %d", wave, len(outcomes), wantConcurrency+1)
-		}
 	}
 }
 
@@ -1605,7 +1588,7 @@ func TestSharedTenantPoolLeaderReconcilerRefillsZeroInventory(t *testing.T) {
 	}
 }
 
-func TestSharedTenantPoolRefillReplacesExpiredPlannedCapacity(t *testing.T) {
+func TestSharedTenantPoolRefillDoesNotReplaceRecoverablePlannedCapacity(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -1626,8 +1609,8 @@ func TestSharedTenantPoolRefillReplacesExpiredPlannedCapacity(t *testing.T) {
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
 		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 1,
-		ManagedSharedDBPlannedCapacityLease: time.Minute, TokenSecret: make([]byte, 32),
-		Leader: newFollowerLeaderManager(t, metaStore)})
+		TokenSecret: make([]byte, 32),
+		Leader:      newFollowerLeaderManager(t, metaStore)})
 	t.Cleanup(func() { srv.Close() })
 	ctx := context.Background()
 	now := time.Now().UTC()
@@ -1662,20 +1645,27 @@ func TestSharedTenantPoolRefillReplacesExpiredPlannedCapacity(t *testing.T) {
 		t.Fatalf("age planned pool: %v", err)
 	}
 
-	srv.replenishTenantPoolAsync(ctx, logicalPool, tenant.CredentialProvisionRequest{})
-	deadline := time.Now().Add(5 * time.Second)
-	for {
-		var physicalPools int
-		if err := metaStore.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, logicalPool.OrganizationID).Scan(&physicalPools); err != nil {
-			t.Fatalf("count physical pools: %v", err)
-		}
-		if physicalPools >= 2 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatalf("physical pools = %d, want replacement for expired planned capacity", physicalPools)
-		}
-		time.Sleep(10 * time.Millisecond)
+	srv.replenishTenantPool(ctx, logicalPool, tenant.CredentialProvisionRequest{})
+	var physicalPools int
+	if err := metaStore.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, logicalPool.OrganizationID).Scan(&physicalPools); err != nil {
+		t.Fatalf("count pending physical pools: %v", err)
+	}
+	if physicalPools != 1 {
+		t.Fatalf("pending recoverable physical pools = %d, want no replacement", physicalPools)
+	}
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET status = ?, updated_at = ? WHERE db_id = ?`,
+		meta.SharedDBStatusActive, now.Add(-20*time.Minute), dbID); err != nil {
+		t.Fatalf("activate and age physical pool: %v", err)
+	}
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE tenants SET status = ? WHERE id = ?`, meta.TenantProvisioning, tenantID); err != nil {
+		t.Fatalf("leave tenant activation pending: %v", err)
+	}
+	srv.replenishTenantPool(ctx, logicalPool, tenant.CredentialProvisionRequest{})
+	if err := metaStore.DB().QueryRowContext(ctx, `SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, logicalPool.OrganizationID).Scan(&physicalPools); err != nil {
+		t.Fatalf("count active physical pools: %v", err)
+	}
+	if physicalPools != 1 {
+		t.Fatalf("active pool with provisioning tenant produced %d physical pools, want no replacement", physicalPools)
 	}
 }
 
@@ -1899,6 +1889,57 @@ func TestManagedSharedDBStuckReconcilerFailsPoolAndPlacedTenant(t *testing.T) {
 	gotTenant, err := metaStore.GetTenant(ctx, tenantID)
 	if err != nil || gotTenant.Status != meta.TenantFailed {
 		t.Fatalf("tenant after stuck reconcile = %+v, %v", gotTenant, err)
+	}
+}
+
+func TestManagedSharedDBActiveTenantReconcilerFinalizesStrandedTenant(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	ctx := context.Background()
+	now := time.Now().UTC()
+	spendingLimit := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-active-recovery", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tenantID := "tenant-active-recovery"
+	if err := metaStore.InsertTenant(ctx, &meta.Tenant{ID: tenantID, Status: meta.TenantPending,
+		Provider: tenant.ProviderTiDBCloudNativeShared, DBPasswordCipher: []byte{}, SchemaVersion: 1,
+		CreatedAt: now, UpdatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	fsID, err := metaStore.EnsureFsID(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.CompleteSharedTenantPoolMember(ctx, tenantID, tenant.ProviderTiDBCloudNativeShared,
+		&meta.TenantPlacement{FsID: fsID, DbID: dbID, Placement: meta.PlacementShared, SchemaShape: meta.SchemaShapeShared},
+		&meta.TenantPoolMembership{TenantID: tenantID, TiDBCloudOrganizationID: "org-active-recovery",
+			PoolID: "logical-active-recovery", PoolStatus: meta.TenantPoolBindingFree}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET status = ? WHERE db_id = ?`, meta.SharedDBStatusActive, dbID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE tenants SET status = ? WHERE id = ?`, meta.TenantProvisioning, tenantID); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{meta: metaStore}
+	srv.resumeActiveManagedSharedDBTenantsWithCtx(ctx)
+	got, err := metaStore.GetTenant(ctx, tenantID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != meta.TenantActive {
+		t.Fatalf("stranded tenant status = %q, want active", got.Status)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -133,8 +133,9 @@ func TestTenantPoolClaimUsesNativeInventoryBeforeExternalSharedPool(t *testing.T
 }
 
 func TestTenantPoolClaimConsumesMixedInventoryInGlobalAgeOrder(t *testing.T) {
-	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.defaultTenantProvider = tenant.ProviderTiDBCloudNativeShared
+	rt := newQuotaRuntimeWithOptions(t, tenant.ProviderTiDBCloudNative, quotaRuntimeOptions{
+		defaultTenantProvider: tenant.ProviderTiDBCloudNativeShared,
+	})
 	ctx := context.Background()
 	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{
 		OrganizationID: "org-mixed-age", Role: tenant.TiDBCloudRoleProjectOwner,
@@ -636,8 +637,9 @@ func TestAdminTenantPoolCreateCleansPartialSharedMembersOnBatchFailure(t *testin
 }
 
 func TestDeleteFreeSharedPoolTenantSkipsPurgeWhenDBPoolIsUnready(t *testing.T) {
-	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	rt.server.defaultTenantProvider = tenant.ProviderTiDBCloudNativeShared
+	rt := newQuotaRuntimeWithOptions(t, tenant.ProviderTiDBCloudNative, quotaRuntimeOptions{
+		defaultTenantProvider: tenant.ProviderTiDBCloudNativeShared,
+	})
 	ctx := context.Background()
 	now := time.Now().UTC()
 	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
@@ -851,12 +853,14 @@ func TestTenantPoolMetadataResumePersistsAfterWaitDeadline(t *testing.T) {
 		tenantPoolMetadataResumeWaitTimeout = oldWaitTimeout
 	})
 
-	rt, schemaInitRecorder := newAdminTenantPoolRuntime(t)
-	waiter := &deadlineMetadataResumeProvisioner{
-		adminTenantPoolSchemaInitRecorder: schemaInitRecorder,
-		waitStarted:                       make(chan struct{}),
-	}
-	rt.server.provisioner = waiter
+	var waiter *deadlineMetadataResumeProvisioner
+	rt, schemaInitRecorder := newAdminTenantPoolRuntimeWithProvisioner(t, func(recorder *adminTenantPoolSchemaInitRecorder) tenant.Provisioner {
+		waiter = &deadlineMetadataResumeProvisioner{
+			adminTenantPoolSchemaInitRecorder: recorder,
+			waitStarted:                       make(chan struct{}),
+		}
+		return waiter
+	})
 
 	ctx := context.Background()
 	now := time.Now().UTC()
@@ -943,19 +947,20 @@ func TestTenantPoolMetadataResumePersistsReadyGroupBeforeSlowGroup(t *testing.T)
 		tenantPoolMetadataResumeGroupSize = oldGroupSize
 	})
 
-	rt, schemaInitRecorder := newAdminTenantPoolRuntime(t)
-	waiter := &groupStreamingMetadataResumeProvisioner{
-		adminTenantPoolSchemaInitRecorder: schemaInitRecorder,
-		slowTenantID:                      "pool-stream-resume-slow",
-		slowStarted:                       make(chan struct{}),
-		releaseSlow:                       make(chan struct{}),
-	}
+	var waiter *groupStreamingMetadataResumeProvisioner
+	rt, _ := newAdminTenantPoolRuntimeWithProvisioner(t, func(recorder *adminTenantPoolSchemaInitRecorder) tenant.Provisioner {
+		waiter = &groupStreamingMetadataResumeProvisioner{
+			adminTenantPoolSchemaInitRecorder: recorder,
+			slowTenantID:                      "pool-stream-resume-slow",
+			slowStarted:                       make(chan struct{}),
+			releaseSlow:                       make(chan struct{}),
+		}
+		return waiter
+	})
 	var releaseSlowOnce sync.Once
 	t.Cleanup(func() {
 		releaseSlowOnce.Do(func() { close(waiter.releaseSlow) })
 	})
-	rt.server.provisioner = waiter
-
 	ctx := context.Background()
 	now := time.Now().UTC()
 	if err := rt.meta.CreateTenantPool(ctx, &meta.TenantPool{
@@ -1700,6 +1705,62 @@ func TestManagedSharedDBStuckReconcilerFailsPoolAndPlacedTenant(t *testing.T) {
 	}
 }
 
+func TestManagedSharedDBStuckReconcilerSkipsPoolWithActiveRecoveryClaim(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	ctx := context.Background()
+	spendingLimit := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-stuck-active", ProvisioningKey: bytes.Repeat([]byte{8}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, time.Now().UTC().Add(-20*time.Minute), dbID); err != nil {
+		t.Fatalf("age db pool: %v", err)
+	}
+
+	srv := &Server{meta: metaStore, managedSharedDBStuckTimeout: 15 * time.Minute}
+	holderStarted := make(chan struct{})
+	releaseHolder := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- srv.withSharedDBPoolWorkLock(ctx, dbID, func(context.Context) error {
+			close(holderStarted)
+			<-releaseHolder
+			return nil
+		})
+	}()
+	<-holderStarted
+
+	srv.reconcileStuckManagedSharedDBPoolsWithCtx(ctx)
+	row, err := metaStore.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.Status != meta.SharedDBStatusPending {
+		t.Fatalf("busy recovery pool status = %q, want pending", row.Status)
+	}
+
+	close(releaseHolder)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("recovery claim holder: %v", err)
+	}
+	srv.reconcileStuckManagedSharedDBPoolsWithCtx(ctx)
+	row, err = metaStore.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.Status != meta.SharedDBStatusFailed {
+		t.Fatalf("idle stuck pool status = %q, want failed", row.Status)
+	}
+}
+
 func TestManagedSharedDBRefillCapsOneWaveAtFiftyPhysicalPools(t *testing.T) {
 	if got := managedSharedDBRefillTenantCount(10_000, 100, 50); got != 5_000 {
 		t.Fatalf("refill tenant count = %d, want capacity of 50 physical pools", got)
@@ -1824,10 +1885,19 @@ type adminTenantPoolSchemaInitRecorder struct {
 }
 
 func newAdminTenantPoolRuntime(t *testing.T) (*quotaRuntime, *adminTenantPoolSchemaInitRecorder) {
+	return newAdminTenantPoolRuntimeWithProvisioner(t, nil)
+}
+
+func newAdminTenantPoolRuntimeWithProvisioner(t *testing.T, wrap func(*adminTenantPoolSchemaInitRecorder) tenant.Provisioner) (*quotaRuntime, *adminTenantPoolSchemaInitRecorder) {
 	t.Helper()
-	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
-	recorder := &adminTenantPoolSchemaInitRecorder{quotaTestProvisioner: rt.prov}
-	rt.server.provisioner = recorder
+	var recorder *adminTenantPoolSchemaInitRecorder
+	rt := newQuotaRuntimeWithOptions(t, tenant.ProviderTiDBCloudNative, quotaRuntimeOptions{provisioner: func(prov *quotaTestProvisioner) tenant.Provisioner {
+		recorder = &adminTenantPoolSchemaInitRecorder{quotaTestProvisioner: prov}
+		if wrap != nil {
+			return wrap(recorder)
+		}
+		return recorder
+	}})
 	return rt, recorder
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -1169,6 +1169,56 @@ func TestTenantPoolReplenishmentRerunsCoalescedTriggerAfterWorkerFinishes(t *tes
 	}
 }
 
+func TestTenantPoolReplenishmentSchedulesCoalescedRerunWhenWorkStartFails(t *testing.T) {
+	s := &Server{}
+	pool := &meta.TenantPool{PoolID: "pool-work-start-failed", OrganizationID: "org-1", Size: 1}
+	timerStarts := 0
+	workStarter := func(context.Context, func(context.Context)) bool {
+		decision := s.requestTenantPoolReplenishmentAt(pool.PoolID, time.Now())
+		if decision.start || decision.scheduleAfter != 0 {
+			t.Fatalf("coalesced decision = %+v, want no immediate or delayed start", decision)
+		}
+		return false
+	}
+	timerStarter := func(context.Context, func(context.Context)) bool {
+		timerStarts++
+		return true
+	}
+
+	s.replenishTenantPoolAsyncWithStarters(context.Background(), pool, tenant.CredentialProvisionRequest{}, workStarter, timerStarter)
+
+	if timerStarts != 1 {
+		t.Fatalf("delayed rerun starts = %d, want 1 after work start failure", timerStarts)
+	}
+}
+
+func TestTenantPoolReplenishmentRetriesSchedulingWhenTimerStartFails(t *testing.T) {
+	s := &Server{}
+	pool := &meta.TenantPool{PoolID: "pool-timer-start-failed", OrganizationID: "org-1", Size: 1}
+	value, _ := s.tenantPoolReplenishJobs.LoadOrStore(pool.PoolID, &tenantPoolWorkGate{})
+	gate := value.(*tenantPoolWorkGate)
+	gate.mu.Lock()
+	gate.rerun = true
+	gate.nextAllowed = time.Now().Add(time.Minute)
+	gate.mu.Unlock()
+	timerStarts := 0
+	timerStarter := func(context.Context, func(context.Context)) bool {
+		timerStarts++
+		return false
+	}
+	workStarter := func(context.Context, func(context.Context)) bool {
+		t.Fatal("cooldown trigger unexpectedly started replenish work")
+		return false
+	}
+
+	s.replenishTenantPoolAsyncWithStarters(context.Background(), pool, tenant.CredentialProvisionRequest{}, workStarter, timerStarter)
+	s.replenishTenantPoolAsyncWithStarters(context.Background(), pool, tenant.CredentialProvisionRequest{}, workStarter, timerStarter)
+
+	if timerStarts != 2 {
+		t.Fatalf("timer start attempts = %d, want 2 after the first start failed", timerStarts)
+	}
+}
+
 func TestLeaderTenantPoolReplenishmentTimerDoesNotConsumeWorkSlot(t *testing.T) {
 	s := &Server{}
 	pool := &meta.TenantPool{PoolID: "pool-leader-rerun", OrganizationID: "org-leader-rerun", Size: 1}
@@ -1505,8 +1555,16 @@ func TestSharedTenantPoolLeaderReconcilerRefillsZeroInventory(t *testing.T) {
 }
 
 func TestLeaderTenantPoolReplenishmentDoesNotStartOnFollower(t *testing.T) {
-	mgr := leader.NewManager(nil)
-	srv := &Server{leader: mgr, tenantPoolReconcileSlots: make(chan struct{}, 1)}
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	mgr := leader.NewManager(metaStore.DB())
+	srv := &Server{
+		leader: mgr, tenantPoolReconcileSlots: make(chan struct{}, 1),
+		leaderWorkersStarted: true, leaderWorkerCtx: context.Background(),
+	}
 	srv.replenishTenantPoolLeaderAsync(context.Background(), &meta.TenantPool{
 		PoolID: "pool-follower", OrganizationID: "org-follower", Size: 1, Status: meta.TenantPoolActive,
 	}, tenant.CredentialProvisionRequest{})

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -199,10 +199,13 @@ func TestSharedTenantPoolRefillPlansTenPoolsInOneBatch(t *testing.T) {
 	defer poolManager.Close()
 	poolManager.SetMetaStore(metaStore)
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
-	secret := make([]byte, 32)
-	_, _ = rand.Read(secret)
-	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
-		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 1, TokenSecret: secret})
+	workerCtx, cancel := context.WithCancel(context.Background())
+	srv := &Server{
+		meta: metaStore, pool: poolManager, provisioner: prov,
+		defaultTenantProvider: tenant.ProviderTiDBCloudNativeShared,
+		sharedDBMaxTenants:    1, managedSharedDBCloudBatchSize: 10,
+		forkWorkerCtx: workerCtx, forkWorkerCancel: cancel,
+	}
 	defer srv.Close()
 	now := time.Now().UTC()
 	if err := metaStore.CreateTenantPool(context.Background(), &meta.TenantPool{PoolID: "pool-shared-10",
@@ -1180,7 +1183,7 @@ func TestAdminTenantPoolReplenishBatchesBelowFreeWatermark(t *testing.T) {
 	}
 }
 
-func TestAdminTenantPoolReplenishChunksLargeRefill(t *testing.T) {
+func TestAdminTenantPoolReplenishSubmitsLargeRefillAsSingleWave(t *testing.T) {
 	oldRetryWindow := schemaInitRetryWindow
 	schemaInitRetryWindow = 100 * time.Millisecond
 	t.Cleanup(func() { schemaInitRetryWindow = oldRetryWindow })
@@ -1206,8 +1209,7 @@ func TestAdminTenantPoolReplenishChunksLargeRefill(t *testing.T) {
 		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 100,
 		TokenSecret: make([]byte, 32)})
 	defer srv.Close()
-	// Make each refill batch visible as one cloud batch. The production default
-	// is smaller, but the physical pool count is independent of this test knob.
+	// Make the complete three-pool refill wave visible as one Cloud batch.
 	srv.managedSharedDBCloudBatchSize = 250
 	ctx := context.Background()
 	now := time.Now().UTC()
@@ -1253,11 +1255,11 @@ func TestAdminTenantPoolReplenishChunksLargeRefill(t *testing.T) {
 	})
 	deadline := time.Now().Add(10 * time.Second)
 	for {
-		if got := prov.sharedPoolBatchCalls.Load(); got >= 3 {
+		if got := prov.sharedPoolBatchCalls.Load(); got >= 1 {
 			break
 		}
 		if time.Now().After(deadline) {
-			t.Fatalf("shared cloud batch calls = %d, want three bounded refill batches", prov.sharedPoolBatchCalls.Load())
+			t.Fatalf("shared cloud batch calls = %d, want one complete refill wave", prov.sharedPoolBatchCalls.Load())
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
@@ -1274,6 +1276,12 @@ func TestAdminTenantPoolReplenishChunksLargeRefill(t *testing.T) {
 			t.Fatalf("free size = %d, want %d after refill", free, pool.Size)
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
+		t.Fatalf("shared cloud batch calls = %d, want 1", got)
+	}
+	if got := prov.sharedPoolBatchMembers.Load(); got != 3 {
+		t.Fatalf("shared cloud batch members = %d, want 3 physical pools", got)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -421,27 +421,31 @@ func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T
 	}
 }
 
-func TestSharedTenantPoolRefillLimitsPhysicalPartitionWorkersToThirty(t *testing.T) {
+func TestSharedTenantPoolRefillLimitsPhysicalPartitionWorkersGlobally(t *testing.T) {
 	const wantConcurrency = 30
-	started := make(chan struct{}, wantConcurrency+1)
+	started := make(chan struct{}, 2*(wantConcurrency+1))
 	release := make(chan struct{})
-	done := make(chan []sharedPoolTenantCreateOutcome, 1)
-	partitions := make([]sharedPoolTenantPartition, wantConcurrency+1)
-	for i := range partitions {
-		partitions[i] = sharedPoolTenantPartition{db: &meta.SharedDB{ID: int64(i + 1)}, tenantCount: 1}
+	done := make(chan []sharedPoolTenantCreateOutcome, 2)
+	globalSlots := make(chan struct{}, wantConcurrency)
+	for wave := 0; wave < 2; wave++ {
+		partitions := make([]sharedPoolTenantPartition, wantConcurrency+1)
+		for i := range partitions {
+			partitions[i] = sharedPoolTenantPartition{db: &meta.SharedDB{ID: int64(wave*100 + i + 1)}, tenantCount: 1}
+		}
+		go func() {
+			done <- runSharedPoolTenantPartitionWorkers(context.Background(), globalSlots, partitions, func(sharedPoolTenantPartition) sharedPoolTenantCreateOutcome {
+				started <- struct{}{}
+				<-release
+				return sharedPoolTenantCreateOutcome{}
+			})
+		}()
 	}
-	go func() {
-		done <- runSharedPoolTenantPartitionWorkers(context.Background(), partitions, func(sharedPoolTenantPartition) sharedPoolTenantCreateOutcome {
-			started <- struct{}{}
-			<-release
-			return sharedPoolTenantCreateOutcome{}
-		})
-	}()
 	for i := 0; i < wantConcurrency; i++ {
 		select {
 		case <-started:
 		case <-time.After(500 * time.Millisecond):
 			close(release)
+			<-done
 			<-done
 			t.Fatalf("started %d/%d tenant workers before release", i, wantConcurrency)
 		}
@@ -450,13 +454,16 @@ func TestSharedTenantPoolRefillLimitsPhysicalPartitionWorkersToThirty(t *testing
 	case <-started:
 		close(release)
 		<-done
-		t.Fatal("started a 31st tenant worker while 30 were still in flight")
+		<-done
+		t.Fatal("started a 31st tenant writer across concurrent refill waves")
 	case <-time.After(100 * time.Millisecond):
 	}
 	close(release)
-	outcomes := <-done
-	if len(outcomes) != wantConcurrency+1 {
-		t.Fatalf("outcomes = %d, want %d", len(outcomes), wantConcurrency+1)
+	for wave := 0; wave < 2; wave++ {
+		outcomes := <-done
+		if len(outcomes) != wantConcurrency+1 {
+			t.Fatalf("wave %d outcomes = %d, want %d", wave, len(outcomes), wantConcurrency+1)
+		}
 	}
 }
 
@@ -1698,6 +1705,14 @@ func TestTenantPoolLeaderReconcileWorkersQueueAndRestBetweenTasks(t *testing.T) 
 	defer cancel()
 	rest := 40 * time.Millisecond
 	srv := &Server{tenantPoolReconcileQueue: make(chan tenantPoolReconcileJob), tenantPoolReconcileWorkerRest: rest}
+	enqueue := func(fn func(context.Context)) bool {
+		select {
+		case srv.tenantPoolReconcileQueue <- tenantPoolReconcileJob{run: fn}:
+			return true
+		case <-ctx.Done():
+			return false
+		}
+	}
 	workerDone := make(chan struct{})
 	go func() {
 		defer close(workerDone)
@@ -1705,7 +1720,7 @@ func TestTenantPoolLeaderReconcileWorkersQueueAndRestBetweenTasks(t *testing.T) 
 	}()
 	firstStarted := make(chan struct{}, 1)
 	release := make(chan struct{})
-	if !srv.enqueueTenantPoolReconcileWork(ctx, func(context.Context) {
+	if !enqueue(func(context.Context) {
 		firstStarted <- struct{}{}
 		<-release
 	}) {
@@ -1715,7 +1730,7 @@ func TestTenantPoolLeaderReconcileWorkersQueueAndRestBetweenTasks(t *testing.T) 
 	secondStarted := make(chan struct{}, 1)
 	secondQueued := make(chan bool, 1)
 	go func() {
-		secondQueued <- srv.enqueueTenantPoolReconcileWork(ctx, func(context.Context) {
+		secondQueued <- enqueue(func(context.Context) {
 			secondStarted <- struct{}{}
 		})
 	}()
@@ -1745,32 +1760,91 @@ func TestTenantPoolLeaderReconcileWorkersQueueAndRestBetweenTasks(t *testing.T) 
 	}
 }
 
-func TestTenantPoolLeaderReconcileAllowsSamePoolAcrossScans(t *testing.T) {
-	srv := &Server{tenantPoolReconcileQueue: make(chan tenantPoolReconcileJob)}
-	pool := &meta.TenantPool{PoolID: "pool-repeated-scan", OrganizationID: "org-repeated-scan", Size: 100}
-	queued := make(chan bool, 2)
-	for range 2 {
-		go func() {
-			queued <- srv.enqueueTenantPoolLeaderReplenishment(context.Background(), pool, tenant.CredentialProvisionRequest{})
-		}()
+func TestTenantPoolLeaderReconcileCoalescesSamePoolIntoOneRerun(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srv := &Server{
+		tenantPoolReconcileQueue:      make(chan tenantPoolReconcileJob),
+		tenantPoolReconcileWorkerRest: 20 * time.Millisecond,
 	}
-	for range 2 {
-		select {
-		case job := <-srv.tenantPoolReconcileQueue:
-			if job.run == nil {
-				t.Fatal("queued leader refill has no work")
-			}
-		case <-time.After(time.Second):
-			t.Fatal("same pool was coalesced across leader scans")
+	workerDone := make(chan struct{})
+	go func() {
+		defer close(workerDone)
+		srv.runTenantPoolReconcileWorker(ctx)
+	}()
+
+	started := make(chan int, 2)
+	releaseFirst := make(chan struct{})
+	var attempts atomic.Int32
+	run := func(context.Context) {
+		attempt := int(attempts.Add(1))
+		started <- attempt
+		if attempt == 1 {
+			<-releaseFirst
 		}
 	}
-	for range 2 {
-		if ok := <-queued; !ok {
-			t.Fatal("same-pool leader refill was not queued")
+	if !srv.enqueueTenantPoolLeaderReconcile(ctx, "pool-repeated-scan", run) {
+		t.Fatal("initial leader reconcile task was not queued")
+	}
+	select {
+	case attempt := <-started:
+		if attempt != 1 {
+			t.Fatalf("first attempt = %d, want 1", attempt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("initial leader reconcile task did not start")
+	}
+
+	for i := 0; i < 3; i++ {
+		if !srv.enqueueTenantPoolLeaderReconcile(ctx, "pool-repeated-scan", run) {
+			t.Fatalf("coalesced trigger %d was rejected", i+1)
 		}
 	}
-	if _, ok := srv.tenantPoolReplenishJobs.Load(pool.PoolID); ok {
+	select {
+	case attempt := <-started:
+		t.Fatalf("attempt %d started while the first attempt was still running", attempt)
+	case <-time.After(30 * time.Millisecond):
+	}
+	close(releaseFirst)
+	select {
+	case attempt := <-started:
+		if attempt != 2 {
+			t.Fatalf("rerun attempt = %d, want 2", attempt)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("coalesced rerun did not start")
+	}
+	select {
+	case attempt := <-started:
+		t.Fatalf("unexpected extra coalesced attempt %d", attempt)
+	case <-time.After(50 * time.Millisecond):
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("leader reconcile attempts = %d, want 2", got)
+	}
+	if _, ok := srv.tenantPoolReplenishJobs.Load("pool-repeated-scan"); ok {
 		t.Fatal("leader refill unexpectedly used the request-side per-pool gate")
+	}
+
+	cancel()
+	select {
+	case <-workerDone:
+	case <-time.After(time.Second):
+		t.Fatal("tenant-pool reconcile worker did not stop")
+	}
+}
+
+func TestTenantPoolLeaderReconcileDoesNotRerunForDuplicateQueuedScan(t *testing.T) {
+	state := &tenantPoolLeaderReconcileState{}
+	if !state.request() {
+		t.Fatal("initial scan was not accepted")
+	}
+	if state.request() {
+		t.Fatal("duplicate queued scan was accepted as a second job")
+	}
+	state.start()
+	if state.next() {
+		t.Fatal("duplicate scan received before work started requested an unnecessary rerun")
 	}
 }
 

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -182,7 +182,6 @@ func (s *Server) handleAdminTenantCreate(w http.ResponseWriter, r *http.Request)
 		if res.Status == meta.TenantProvisioning {
 			s.startProvisionedTenantSchemaInit(r.Context(), res)
 		}
-		s.replenishTenantPoolAsync(r.Context(), pool, cred)
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusAccepted)
 		_ = json.NewEncoder(w).Encode(adminTenantCreateResponse{

--- a/pkg/server/fork_test.go
+++ b/pkg/server/fork_test.go
@@ -223,6 +223,10 @@ type forkCleanupTestRuntime struct {
 }
 
 func newForkCleanupTestRuntime(t *testing.T) *forkCleanupTestRuntime {
+	return newForkCleanupTestRuntimeWithProvisioner(t, nil)
+}
+
+func newForkCleanupTestRuntimeWithProvisioner(t *testing.T, override tenant.Provisioner) *forkCleanupTestRuntime {
 	t.Helper()
 	db := newTestDBInfo(t)
 	cleanupForkTestTables(t, db.Meta)
@@ -230,10 +234,12 @@ func newForkCleanupTestRuntime(t *testing.T) *forkCleanupTestRuntime {
 		defaultPublicKey:  "default-public",
 		defaultPrivateKey: "default-private",
 	}
-	server := NewWithConfig(Config{TokenSecret: []byte("ctx-fork-test-secret")})
-	server.meta = db.Meta
-	server.pool = db.Pool
-	server.provisioner = prov
+	configuredProvisioner := tenant.Provisioner(prov)
+	if override != nil {
+		configuredProvisioner = override
+	}
+	server := NewWithConfig(Config{Meta: db.Meta, Pool: db.Pool, Provisioner: configuredProvisioner,
+		TokenSecret: []byte("ctx-fork-test-secret")})
 	t.Cleanup(server.Close)
 	return &forkCleanupTestRuntime{server: server, meta: db.Meta, pool: db.Pool, prov: prov, dbHost: db.DBHost, dbPort: db.DBPort, dbUser: db.DBUser, dbPass: db.DBPass, dbName: db.DBName}
 }
@@ -793,8 +799,7 @@ func TestCleanupNativeFailedForkWithoutBranchIDDoesNotRequireCredentials(t *test
 }
 
 func TestCleanupBranchBackedForkWithoutProvisionerDoesNotMarkDeleted(t *testing.T) {
-	rt := newForkCleanupTestRuntime(t)
-	rt.server.provisioner = nonBranchOnlyProvisioner{}
+	rt := newForkCleanupTestRuntimeWithProvisioner(t, nonBranchOnlyProvisioner{})
 	rt.insertForkTenant(t, "fork-no-provisioner", meta.TenantDeleting, "branch-a")
 
 	rt.server.cleanupForkTenant(context.Background(), "fork-no-provisioner")

--- a/pkg/server/leader_lifecycle_test.go
+++ b/pkg/server/leader_lifecycle_test.go
@@ -314,3 +314,39 @@ func TestLeaderGatedWorkersOnLoseRacesOnLead(t *testing.T) {
 		srv.Close()
 	}
 }
+
+func TestStopLeaderWorkersDoesNotHoldLifecycleLockWhileWaiting(t *testing.T) {
+	mgr := leader.NewManager(nil, leader.WithDisabled())
+	mgr.Start(context.Background())
+	ctx, cancel := context.WithCancel(context.Background())
+	srv := &Server{
+		leader:               mgr,
+		leaderWorkersStarted: true,
+		leaderWorkerCtx:      ctx,
+		leaderWorkerCancel:   cancel,
+	}
+	srv.leaderWorkerWG.Add(1)
+	workerExiting := make(chan struct{})
+	go func() {
+		defer srv.leaderWorkerWG.Done()
+		<-ctx.Done()
+		close(workerExiting)
+		_ = srv.startManagedSharedDBWorker(ctx, func(context.Context) {})
+	}()
+
+	stopped := make(chan struct{})
+	go func() {
+		srv.stopLeaderWorkers()
+		close(stopped)
+	}()
+	select {
+	case <-workerExiting:
+	case <-time.After(time.Second):
+		t.Fatal("leader worker was not cancelled")
+	}
+	select {
+	case <-stopped:
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("stopLeaderWorkers deadlocked while an exiting worker checked leader admission")
+	}
+}

--- a/pkg/server/managed_shared_db_failed_cleanup.go
+++ b/pkg/server/managed_shared_db_failed_cleanup.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -66,22 +67,51 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 			}
 			continue
 		}
-		if current.Status != meta.SharedDBStatusFailed || current.TenantCount != 0 {
+		if current.Status != meta.SharedDBStatusFailed {
 			continue
 		}
-		clusterID := strings.TrimSpace(current.ClusterID)
-		clusterIDPersisted := clusterID != ""
-		var cred tenant.CredentialProvisionRequest
-		if !clusterIDPersisted {
+		if current.TenantCount != 0 {
+			repaired, repairErr := s.meta.RepairFailedSharedDBPoolTenantCountIfEmpty(ctx, row.ID)
+			if repairErr != nil {
+				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_count_repair_failed",
+					zap.Int64("db_pool_id", row.ID), zap.Int("tenant_count", current.TenantCount), zap.Error(repairErr))
+				continue
+			}
+			if !repaired {
+				continue
+			}
+			logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_count_repaired",
+				zap.Int64("db_pool_id", row.ID), zap.Int("previous_tenant_count", current.TenantCount))
+			current, loadErr = s.meta.GetSharedDB(ctx, row.ID)
+			if loadErr != nil || current.Status != meta.SharedDBStatusFailed || current.TenantCount != 0 {
+				if loadErr != nil && !errors.Is(loadErr, meta.ErrNotFound) {
+					logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_reload_failed", zap.Int64("db_pool_id", row.ID), zap.Error(loadErr))
+				}
+				continue
+			}
+		}
+		persistedClusterID := strings.TrimSpace(current.ClusterID)
+		cred, credErr := s.sharedDBCloudCredentials()
+		if credErr != nil {
+			logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_credentials_failed", zap.Int64("db_pool_id", row.ID), zap.Error(credErr))
+			continue
+		}
+		clusterIDs := make([]string, 0, 2)
+		if lister, ok := s.provisioner.(tenant.SharedDBPoolLister); ok {
+			discovered, discoverErr := lister.ListSharedDBPoolsWithCredentials(ctx, row.ID, row.UUID, cred)
+			if discoverErr != nil {
+				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_discovery_failed", zap.Int64("db_pool_id", row.ID), zap.Error(discoverErr))
+				continue
+			}
+			for _, info := range discovered {
+				if info != nil && strings.TrimSpace(info.ClusterID) != "" {
+					clusterIDs = append(clusterIDs, strings.TrimSpace(info.ClusterID))
+				}
+			}
+		} else if persistedClusterID == "" {
 			loader, ok := s.provisioner.(managedSharedDBPoolLoader)
 			if !ok {
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_discovery_unsupported", zap.Int64("db_pool_id", row.ID))
-				continue
-			}
-			var credErr error
-			cred, credErr = s.sharedDBCloudCredentials()
-			if credErr != nil {
-				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_credentials_failed", zap.Int64("db_pool_id", row.ID), zap.Error(credErr))
 				continue
 			}
 			discovered, discoverErr := loader.LoadSharedDBPoolWithCredentials(ctx, row.ID, row.UUID, "", cred)
@@ -89,34 +119,40 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_discovery_failed", zap.Int64("db_pool_id", row.ID), zap.Error(discoverErr))
 				continue
 			}
-			if discovered != nil {
-				clusterID = strings.TrimSpace(discovered.ClusterID)
-				if clusterID == "" {
-					logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_discovery_incomplete", zap.Int64("db_pool_id", row.ID))
-					continue
-				}
+			if discovered != nil && strings.TrimSpace(discovered.ClusterID) != "" {
+				clusterIDs = append(clusterIDs, strings.TrimSpace(discovered.ClusterID))
 			}
 		}
-		if clusterID != "" {
+		if persistedClusterID != "" {
+			clusterIDs = append(clusterIDs, persistedClusterID)
+		}
+		seenClusterIDs := make(map[string]struct{}, len(clusterIDs))
+		uniqueClusterIDs := clusterIDs[:0]
+		for _, clusterID := range clusterIDs {
+			if _, exists := seenClusterIDs[clusterID]; exists {
+				continue
+			}
+			seenClusterIDs[clusterID] = struct{}{}
+			uniqueClusterIDs = append(uniqueClusterIDs, clusterID)
+		}
+		if len(uniqueClusterIDs) > 0 {
 			deprovisioner, ok := s.provisioner.(tenant.CredentialDeprovisioner)
 			if !ok {
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_deprovision_unsupported", zap.Int64("db_pool_id", row.ID))
 				continue
 			}
-			if clusterIDPersisted {
-				var credErr error
-				cred, credErr = s.sharedDBCloudCredentials()
-				if credErr != nil {
-					logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_credentials_failed", zap.Int64("db_pool_id", row.ID), zap.Error(credErr))
-					continue
+			var deprovisionErr error
+			for _, clusterID := range uniqueClusterIDs {
+				if err := deprovisioner.DeprovisionWithCredentials(ctx, &tenant.ClusterInfo{ClusterID: clusterID}, cred); err != nil {
+					deprovisionErr = errors.Join(deprovisionErr, fmt.Errorf("cluster %s: %w", clusterID, err))
 				}
 			}
-			if deprovisionErr := deprovisioner.DeprovisionWithCredentials(ctx, &tenant.ClusterInfo{ClusterID: clusterID}, cred); deprovisionErr != nil {
+			if deprovisionErr != nil {
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_deprovision_failed", zap.Int64("db_pool_id", row.ID), zap.Error(deprovisionErr))
 				continue
 			}
-			if clusterIDPersisted {
-				cleared, clearErr := s.meta.ClearFailedSharedDBPoolClusterID(ctx, row.ID, clusterID)
+			if persistedClusterID != "" {
+				cleared, clearErr := s.meta.ClearFailedSharedDBPoolClusterID(ctx, row.ID, persistedClusterID)
 				if clearErr != nil || !cleared {
 					logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_clear_cluster_failed",
 						zap.Int64("db_pool_id", row.ID), zap.Bool("cleared", cleared), zap.Error(clearErr))

--- a/pkg/server/managed_shared_db_failed_cleanup.go
+++ b/pkg/server/managed_shared_db_failed_cleanup.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+	"go.uber.org/zap"
+)
+
+type managedSharedDBPoolLoader interface {
+	LoadSharedDBPoolWithCredentials(context.Context, int64, string, string, tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error)
+}
+
+// cleanupFailedManagedSharedDBPoolsWithCtx makes one bounded leader-only pass.
+// It reuses the existing failed shared-tenant cleanup state machine and does
+// not consume metadata, provisioning, or Cloud-create worker slots.
+func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
+	if s.meta == nil || s.pool == nil || s.provisioner == nil {
+		return
+	}
+	batchSize := s.managedSharedDBFailedCleanupBatchSize
+	if batchSize <= 0 {
+		batchSize = DefaultManagedSharedDBFailedCleanupBatchSize
+	}
+	rows, err := s.meta.ListSharedDBsByStatusAfter(ctx, meta.SharedDBStatusFailed, s.managedSharedDBFailedCleanupCursor, batchSize)
+	if err != nil {
+		logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_list_failed", zap.Error(err))
+		return
+	}
+	if len(rows) == 0 && s.managedSharedDBFailedCleanupCursor > 0 {
+		s.managedSharedDBFailedCleanupCursor = 0
+		rows, err = s.meta.ListSharedDBsByStatusAfter(ctx, meta.SharedDBStatusFailed, 0, batchSize)
+		if err != nil {
+			logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_list_failed", zap.Error(err))
+			return
+		}
+	}
+	if len(rows) == 0 {
+		return
+	}
+	s.managedSharedDBFailedCleanupCursor = rows[len(rows)-1].ID
+	cutoff := time.Now().UTC().Add(-tenantFailedCleanupRetryDelay)
+	for _, row := range rows {
+		candidates, listErr := s.meta.ListFailedSharedTenantCleanupCandidatesByDB(
+			ctx, row.ID, cutoff, tenantFailedCleanupSharedBatchSize)
+		if listErr != nil {
+			logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_tenant_list_failed",
+				zap.Int64("db_pool_id", row.ID), zap.Error(listErr))
+			continue
+		}
+		for i := range candidates {
+			if _, cleanupErr := s.cleanupFailedSharedTenant(ctx, row.TiDBCloudOrganizationID, cutoff, &candidates[i]); cleanupErr != nil {
+				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_tenant_failed",
+					zap.Int64("db_pool_id", row.ID), zap.String("tenant_id", candidates[i].ID), zap.Error(cleanupErr))
+			}
+		}
+		current, loadErr := s.meta.GetSharedDB(ctx, row.ID)
+		if loadErr != nil {
+			if !errors.Is(loadErr, meta.ErrNotFound) {
+				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_reload_failed", zap.Int64("db_pool_id", row.ID), zap.Error(loadErr))
+			}
+			continue
+		}
+		if current.Status != meta.SharedDBStatusFailed || current.TenantCount != 0 {
+			continue
+		}
+		clusterID := strings.TrimSpace(current.ClusterID)
+		clusterIDPersisted := clusterID != ""
+		var cred tenant.CredentialProvisionRequest
+		if !clusterIDPersisted {
+			loader, ok := s.provisioner.(managedSharedDBPoolLoader)
+			if !ok {
+				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_discovery_unsupported", zap.Int64("db_pool_id", row.ID))
+				continue
+			}
+			var credErr error
+			cred, credErr = s.sharedDBCloudCredentials()
+			if credErr != nil {
+				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_credentials_failed", zap.Int64("db_pool_id", row.ID), zap.Error(credErr))
+				continue
+			}
+			discovered, discoverErr := loader.LoadSharedDBPoolWithCredentials(ctx, row.ID, row.UUID, "", cred)
+			if discoverErr != nil {
+				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_discovery_failed", zap.Int64("db_pool_id", row.ID), zap.Error(discoverErr))
+				continue
+			}
+			if discovered != nil {
+				clusterID = strings.TrimSpace(discovered.ClusterID)
+				if clusterID == "" {
+					logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_discovery_incomplete", zap.Int64("db_pool_id", row.ID))
+					continue
+				}
+			}
+		}
+		if clusterID != "" {
+			deprovisioner, ok := s.provisioner.(tenant.CredentialDeprovisioner)
+			if !ok {
+				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_deprovision_unsupported", zap.Int64("db_pool_id", row.ID))
+				continue
+			}
+			if clusterIDPersisted {
+				var credErr error
+				cred, credErr = s.sharedDBCloudCredentials()
+				if credErr != nil {
+					logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_credentials_failed", zap.Int64("db_pool_id", row.ID), zap.Error(credErr))
+					continue
+				}
+			}
+			if deprovisionErr := deprovisioner.DeprovisionWithCredentials(ctx, &tenant.ClusterInfo{ClusterID: clusterID}, cred); deprovisionErr != nil {
+				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_deprovision_failed", zap.Int64("db_pool_id", row.ID), zap.Error(deprovisionErr))
+				continue
+			}
+			if clusterIDPersisted {
+				cleared, clearErr := s.meta.ClearFailedSharedDBPoolClusterID(ctx, row.ID, clusterID)
+				if clearErr != nil || !cleared {
+					logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_clear_cluster_failed",
+						zap.Int64("db_pool_id", row.ID), zap.Bool("cleared", cleared), zap.Error(clearErr))
+					continue
+				}
+			}
+		}
+		deleted, deleteErr := s.meta.DeleteFailedSharedDBPoolIfEmpty(ctx, row.ID)
+		if deleteErr != nil || !deleted {
+			logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_delete_failed",
+				zap.Int64("db_pool_id", row.ID), zap.Bool("deleted", deleted), zap.Error(deleteErr))
+			continue
+		}
+		logger.Info(ctx, "managed_shared_db_pool_failed_cleanup_done", zap.Int64("db_pool_id", row.ID), zap.String("db_pool_uuid", row.UUID))
+	}
+}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -1570,6 +1570,109 @@ func TestManagedSharedDBReservationKeepsOrganizationsParallel(t *testing.T) {
 	}
 }
 
+func TestManagedSharedDBReservationCoversPhysicalPlanningTransition(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	srv := &Server{meta: metaStore}
+	const organizationID = "org-reservation-planning"
+	const identity = "org:" + organizationID
+
+	holderStarted := make(chan struct{})
+	releaseHolder := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- metaStore.WithSharedDBAllocationLock(context.Background(), identity, func(context.Context) error {
+			close(holderStarted)
+			<-releaseHolder
+			return nil
+		})
+	}()
+	select {
+	case <-holderStarted:
+	case <-time.After(time.Second):
+		t.Fatal("physical planning lock holder did not start")
+	}
+	var releaseOnce sync.Once
+	releasePlanning := func() { releaseOnce.Do(func() { close(releaseHolder) }) }
+	defer func() {
+		releasePlanning()
+		select {
+		case err := <-holderDone:
+			if err != nil {
+				t.Errorf("release physical planning lock: %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Error("physical planning lock holder did not stop")
+		}
+	}()
+
+	firstReserveEntered := make(chan struct{})
+	firstDone := make(chan error, 1)
+	go func() {
+		_, _, err := srv.allocateManagedSharedDBForOrganization(context.Background(), organizationID,
+			tenant.CredentialProvisionRequest{}, func(*meta.SharedDB) error {
+				close(firstReserveEntered)
+				return nil
+			})
+		firstDone <- err
+	}()
+	deadline := time.Now().Add(time.Second)
+	for {
+		if _, waiting := srv.sharedDBAllocationLocks.Load(identity); waiting {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("first allocation did not reach physical planning")
+		}
+		time.Sleep(time.Millisecond)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	if _, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: organizationID, ProvisioningKey: bytes.Repeat([]byte{2}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	secondReserveEntered := make(chan struct{})
+	secondDone := make(chan error, 1)
+	go func() {
+		_, _, err := srv.allocateManagedSharedDBForOrganization(context.Background(), organizationID,
+			tenant.CredentialProvisionRequest{}, func(*meta.SharedDB) error {
+				close(secondReserveEntered)
+				return nil
+			})
+		secondDone <- err
+	}()
+	select {
+	case <-secondReserveEntered:
+		t.Error("same-organization reservation bypassed admission during physical planning")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	releasePlanning()
+	select {
+	case <-firstReserveEntered:
+	case <-time.After(time.Second):
+		t.Fatal("first reservation did not finish physical planning")
+	}
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first allocation: %v", err)
+	}
+	select {
+	case <-secondReserveEntered:
+	case <-time.After(time.Second):
+		t.Fatal("second reservation did not resume after physical planning")
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second allocation: %v", err)
+	}
+}
+
 func TestSharedDBAllocationLockWaitRespectsContextAndCleansUp(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -1359,7 +1359,7 @@ func TestManagedSharedDBContinuationKeepsRootAndSkipsSystemUser(t *testing.T) {
 	}
 }
 
-func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
+func TestManagedSharedDBBatchCreateSharesPerPoolOwnershipWithDirectEnsure(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -1758,12 +1758,11 @@ func TestEnsureManagedSharedDBPhysicalUsesPoolLockForKnownCluster(t *testing.T) 
 		t.Fatal(err)
 	}
 	srv := &Server{meta: metaStore, provisioner: &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}}
-	identity := fmt.Sprintf("org:org-known-cluster:db_pool:%d", dbID)
 	holderStarted := make(chan struct{})
 	releaseHolder := make(chan struct{})
 	holderDone := make(chan error, 1)
 	go func() {
-		holderDone <- srv.withSharedDBAllocationLock(context.Background(), identity, func(context.Context) error {
+		holderDone <- srv.withSharedDBPoolWorkLock(context.Background(), dbID, func(context.Context) error {
 			close(holderStarted)
 			<-releaseHolder
 			return nil
@@ -1803,8 +1802,8 @@ func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
 		t.Fatal(err)
 	}
 	spendingTarget := meta.MaxTiDBCloudSpendingLimit
-	dbIDs := make([]int64, 0, 101)
-	for i := 0; i < 101; i++ {
+	dbIDs := make([]int64, 0, 50)
+	for i := 0; i < 50; i++ {
 		dbID, createErr := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
 			TiDBCloudOrganizationID: "org-parallel-batches", ProvisioningKey: bytes.Repeat([]byte{3}, 32),
 			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
@@ -1815,9 +1814,9 @@ func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
 		}
 		dbIDs = append(dbIDs, dbID)
 	}
-	started := make(chan struct{}, 11)
+	started := make(chan struct{}, 5)
 	release := make(chan struct{})
-	requests := make(chan []tenant.SharedDBPoolCreateRequest, 11)
+	requests := make(chan []tenant.SharedDBPoolCreateRequest, 5)
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, identityOrg: "org-parallel-batches",
 		sharedPoolBatchStarted: started, sharedPoolBatchRelease: release, sharedPoolBatchRequests: requests}
 	srv := &Server{meta: metaStore, pool: pool, provisioner: prov,
@@ -1828,37 +1827,37 @@ func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
 		done <- batchErr
 	}()
 
-	for i := 0; i < 11; i++ {
+	for i := 0; i < 5; i++ {
 		select {
 		case <-started:
 		case <-time.After(500 * time.Millisecond):
 			close(release)
 			<-done
-			t.Fatalf("started %d/11 Cloud batch requests before release", i)
+			t.Fatalf("started %d/5 Cloud batch requests before release", i)
 		}
 	}
 	close(release)
 	if err := <-done; err != nil {
 		t.Fatalf("batch create: %v", err)
 	}
-	if got := prov.sharedPoolBatchCalls.Load(); got != 11 {
-		t.Fatalf("batch calls = %d, want 11", got)
+	if got := prov.sharedPoolBatchCalls.Load(); got != 5 {
+		t.Fatalf("batch calls = %d, want 5", got)
 	}
-	if got := prov.sharedPoolBatchMembers.Load(); got != 101 {
-		t.Fatalf("batch members = %d, want 101", got)
+	if got := prov.sharedPoolBatchMembers.Load(); got != 50 {
+		t.Fatalf("batch members = %d, want 50", got)
 	}
-	sizes := make([]int, 0, 11)
-	for i := 0; i < 11; i++ {
+	sizes := make([]int, 0, 5)
+	for i := 0; i < 5; i++ {
 		sizes = append(sizes, len(<-requests))
 	}
 	slices.Sort(sizes)
-	wantSizes := []int{1, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10}
+	wantSizes := []int{10, 10, 10, 10, 10}
 	if !slices.Equal(sizes, wantSizes) {
 		t.Fatalf("batch sizes = %v, want %v", sizes, wantSizes)
 	}
 }
 
-func TestManagedSharedDBBatchCreateLocksEachAllocationIdentityIndependently(t *testing.T) {
+func TestManagedSharedDBBatchCreateDoesNotWaitForCompletedPlanningLocks(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -1926,16 +1925,23 @@ func TestManagedSharedDBBatchCreateLocksEachAllocationIdentityIndependently(t *t
 			context.Background(), dbIDs, tenant.CredentialProvisionRequest{})
 		batchDone <- batchErr
 	}()
-	select {
-	case request := <-requests:
-		if len(request) != 1 || request[0].CustomerOrganizationID != testPools[1].organizationID {
-			t.Fatalf("first unlocked batch request = %+v, want only organization %q", request, testPools[1].organizationID)
+	startedOrganizations := make(map[string]bool, len(testPools))
+	for range testPools {
+		select {
+		case request := <-requests:
+			if len(request) != 1 {
+				close(releaseHolder)
+				<-holderDone
+				<-batchDone
+				t.Fatalf("batch request = %+v, want one physical pool", request)
+			}
+			startedOrganizations[request[0].CustomerOrganizationID] = true
+		case <-time.After(500 * time.Millisecond):
+			close(releaseHolder)
+			<-holderDone
+			<-batchDone
+			t.Fatal("Cloud create waited for an organization planning lock after its db_pool row existed")
 		}
-	case <-time.After(500 * time.Millisecond):
-		close(releaseHolder)
-		<-holderDone
-		<-batchDone
-		t.Fatal("unlocked organization did not start while the other allocation identity was locked")
 	}
 	close(releaseHolder)
 	if err := <-holderDone; err != nil {
@@ -1944,13 +1950,82 @@ func TestManagedSharedDBBatchCreateLocksEachAllocationIdentityIndependently(t *t
 	if err := <-batchDone; err != nil {
 		t.Fatalf("batch create: %v", err)
 	}
-	select {
-	case request := <-requests:
-		if len(request) != 1 || request[0].CustomerOrganizationID != testPools[0].organizationID {
-			t.Fatalf("blocked batch request = %+v, want only organization %q", request, testPools[0].organizationID)
+	for _, testPool := range testPools {
+		if !startedOrganizations[testPool.organizationID] {
+			t.Fatalf("organization %q Cloud create did not start while planning lock was held", testPool.organizationID)
 		}
-	default:
-		t.Fatal("blocked organization batch request was not issued after its allocation lock was released")
+	}
+}
+
+func TestManagedSharedDBBatchCreateRunsSameOrganizationPoolsConcurrently(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	const organizationID = "org-batch-parallel"
+	dbIDs := make([]int64, 0, 2)
+	for i := 0; i < 2; i++ {
+		dbID, createErr := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+			TiDBCloudOrganizationID: organizationID, ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+			PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+		})
+		if createErr != nil {
+			t.Fatal(createErr)
+		}
+		dbIDs = append(dbIDs, dbID)
+	}
+
+	started := make(chan struct{}, 2)
+	release := make(chan struct{})
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative,
+		sharedPoolBatchStarted: started, sharedPoolBatchRelease: release}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov,
+		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour), managedSharedDBCloudBatchSize: 10}
+	done := make(chan error, 2)
+	for _, dbID := range dbIDs {
+		go func() {
+			_, batchErr := srv.provisionManagedSharedDBPoolsBatchWithCredentials(
+				context.Background(), []int64{dbID}, tenant.CredentialProvisionRequest{})
+			done <- batchErr
+		}()
+	}
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("first same-organization Cloud create did not start")
+	}
+	secondStarted := false
+	select {
+	case <-started:
+		secondStarted = true
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(release)
+	for range dbIDs {
+		if batchErr := <-done; batchErr != nil {
+			t.Fatalf("batch create: %v", batchErr)
+		}
+	}
+	if !secondStarted {
+		t.Fatal("same-organization Cloud creates for different db pools were serialized")
 	}
 }
 
@@ -2042,7 +2117,7 @@ func TestManagedSharedDBBatchCreatePersistsResultsAfterInvalidEntry(t *testing.T
 		sharedPoolPartialErr: partialErr,
 	}
 	srv := &Server{meta: metaStore}
-	err = srv.provisionManagedSharedDBPoolsBatchChunkLocked(context.Background(), prov, requests, rows, tenant.CredentialProvisionRequest{})
+	err = srv.provisionManagedSharedDBPoolsBatchChunkClaimed(context.Background(), prov, requests, rows, tenant.CredentialProvisionRequest{})
 	if !errors.Is(err, partialErr) {
 		t.Fatalf("batch create error = %v, want partial cloud error", err)
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -1434,6 +1434,142 @@ func TestManagedSharedDBBatchCreateUsesAllocationLock(t *testing.T) {
 	}
 }
 
+func createActiveManagedSharedDBForAllocationTest(t *testing.T, metaStore *meta.Store, organizationID string) int64 {
+	t.Helper()
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: organizationID, ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := metaStore.DB().ExecContext(context.Background(), `UPDATE db_pool SET status = ?,
+		db_host = 'h', db_port = 4000, db_user = 'u', db_password = 'c', db_name = 'shared_db'
+		WHERE db_id = ?`, meta.SharedDBStatusActive, dbID); err != nil {
+		t.Fatal(err)
+	}
+	return dbID
+}
+
+func TestManagedSharedDBReservationSerializesSameOrganizationLocally(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	createActiveManagedSharedDBForAllocationTest(t, metaStore, "org-reservation-serial")
+	srv := &Server{meta: metaStore}
+
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+	go func() {
+		_, _, err := srv.allocateManagedSharedDBForOrganization(context.Background(), "org-reservation-serial",
+			tenant.CredentialProvisionRequest{}, func(*meta.SharedDB) error {
+				close(firstStarted)
+				<-releaseFirst
+				return nil
+			})
+		firstDone <- err
+	}()
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first reservation did not start")
+	}
+	go func() {
+		_, _, err := srv.allocateManagedSharedDBForOrganization(context.Background(), "org-reservation-serial",
+			tenant.CredentialProvisionRequest{}, func(*meta.SharedDB) error {
+				close(secondStarted)
+				return nil
+			})
+		secondDone <- err
+	}()
+	select {
+	case <-secondStarted:
+		t.Error("same-organization reservation entered concurrently")
+	case <-time.After(250 * time.Millisecond):
+	}
+	close(releaseFirst)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first reservation: %v", err)
+	}
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		t.Fatal("second reservation did not resume")
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second reservation: %v", err)
+	}
+	entries := 0
+	srv.sharedDBReservationLocks.Range(func(_, _ any) bool {
+		entries++
+		return true
+	})
+	if entries != 0 {
+		t.Fatalf("reservation lock entries after all users finished = %d, want 0", entries)
+	}
+}
+
+func TestManagedSharedDBReservationKeepsOrganizationsParallel(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	createActiveManagedSharedDBForAllocationTest(t, metaStore, "org-reservation-a")
+	createActiveManagedSharedDBForAllocationTest(t, metaStore, "org-reservation-b")
+	srv := &Server{meta: metaStore}
+
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	release := make(chan struct{})
+	firstDone := make(chan error, 1)
+	secondDone := make(chan error, 1)
+	go func() {
+		_, _, err := srv.allocateManagedSharedDBForOrganization(context.Background(), "org-reservation-a",
+			tenant.CredentialProvisionRequest{}, func(*meta.SharedDB) error {
+				close(firstStarted)
+				<-release
+				return nil
+			})
+		firstDone <- err
+	}()
+	select {
+	case <-firstStarted:
+	case <-time.After(time.Second):
+		t.Fatal("first organization reservation did not start")
+	}
+	go func() {
+		_, _, err := srv.allocateManagedSharedDBForOrganization(context.Background(), "org-reservation-b",
+			tenant.CredentialProvisionRequest{}, func(*meta.SharedDB) error {
+				close(secondStarted)
+				<-release
+				return nil
+			})
+		secondDone <- err
+	}()
+	select {
+	case <-secondStarted:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("different-organization reservation was serialized")
+	}
+	close(release)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first organization reservation: %v", err)
+	}
+	if err := <-secondDone; err != nil {
+		t.Fatalf("second organization reservation: %v", err)
+	}
+}
+
 func TestSharedDBAllocationLockWaitRespectsContextAndCleansUp(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -174,21 +174,28 @@ func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 	t.Cleanup(defaults.Close)
 	if defaults.managedSharedDBCloudBatchSize != 10 || defaults.managedSharedDBRefillPoolLimit != 50 ||
 		defaults.managedSharedDBMetadataWorkers != 15 || defaults.managedSharedDBMetadataBatchSize != 30 ||
-		defaults.managedSharedDBMetadataPollInterval != 15*time.Second || defaults.managedSharedDBProvisioningWorkers != 100 {
-		t.Fatalf("managed shared defaults = cloud_batch(%d) refill_pool_limit(%d) metadata(%d,%d,%s) provisioning(%d)",
+		defaults.managedSharedDBMetadataPollInterval != 15*time.Second || defaults.managedSharedDBProvisioningWorkers != 100 ||
+		defaults.tenantPoolReconcileInterval != 15*time.Second || defaults.managedSharedDBStuckTimeout != 15*time.Minute ||
+		defaults.tenantPoolReconcileWorkers != 10 || defaults.managedSharedDBFailedCleanupInterval != time.Minute || defaults.managedSharedDBFailedCleanupBatchSize != 5 {
+		t.Fatalf("managed shared defaults = cloud_batch(%d) refill_pool_limit(%d) metadata(%d,%d,%s) provisioning(%d) reconcile(%s) stuck(%s) failed_cleanup(%s,%d)",
 			defaults.managedSharedDBCloudBatchSize, defaults.managedSharedDBRefillPoolLimit,
 			defaults.managedSharedDBMetadataWorkers, defaults.managedSharedDBMetadataBatchSize, defaults.managedSharedDBMetadataPollInterval,
-			defaults.managedSharedDBProvisioningWorkers)
+			defaults.managedSharedDBProvisioningWorkers, defaults.tenantPoolReconcileInterval, defaults.managedSharedDBStuckTimeout,
+			defaults.managedSharedDBFailedCleanupInterval, defaults.managedSharedDBFailedCleanupBatchSize)
 	}
 	overrides := NewWithConfig(Config{
 		ManagedSharedDBCloudBatchSize: 3, ManagedSharedDBRefillPoolLimit: 12,
 		ManagedSharedDBMetadataWorkers: 5, ManagedSharedDBMetadataBatchSize: 6, ManagedSharedDBMetadataPollInterval: 7 * time.Second,
-		ManagedSharedDBProvisioningWorkers: 8,
+		ManagedSharedDBProvisioningWorkers: 8, TenantPoolReconcileInterval: 9 * time.Second, ManagedSharedDBStuckTimeout: 11 * time.Minute,
+		TenantPoolReconcileWorkers:           4,
+		ManagedSharedDBFailedCleanupInterval: 2 * time.Minute, ManagedSharedDBFailedCleanupBatchSize: 3,
 	})
 	t.Cleanup(overrides.Close)
 	if overrides.managedSharedDBCloudBatchSize != 3 || overrides.managedSharedDBRefillPoolLimit != 12 ||
 		overrides.managedSharedDBMetadataWorkers != 5 || overrides.managedSharedDBMetadataBatchSize != 6 ||
-		overrides.managedSharedDBMetadataPollInterval != 7*time.Second || overrides.managedSharedDBProvisioningWorkers != 8 {
+		overrides.managedSharedDBMetadataPollInterval != 7*time.Second || overrides.managedSharedDBProvisioningWorkers != 8 ||
+		overrides.tenantPoolReconcileInterval != 9*time.Second || overrides.tenantPoolReconcileWorkers != 4 || overrides.managedSharedDBStuckTimeout != 11*time.Minute ||
+		overrides.managedSharedDBFailedCleanupInterval != 2*time.Minute || overrides.managedSharedDBFailedCleanupBatchSize != 3 {
 		t.Fatalf("managed shared overrides were not retained")
 	}
 	capped := NewWithConfig(Config{ManagedSharedDBCloudBatchSize: 11, ManagedSharedDBMetadataWorkers: 16, ManagedSharedDBMetadataBatchSize: 31})
@@ -196,6 +203,42 @@ func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 	if capped.managedSharedDBCloudBatchSize != 10 || capped.managedSharedDBMetadataWorkers != 15 || capped.managedSharedDBMetadataBatchSize != 30 {
 		t.Fatalf("managed shared safety caps = cloud batch %d, metadata workers %d, metadata batch %d",
 			capped.managedSharedDBCloudBatchSize, capped.managedSharedDBMetadataWorkers, capped.managedSharedDBMetadataBatchSize)
+	}
+}
+
+func TestNextManagedSharedDBStatusPageAdvancesAndWrapsKeysetCursor(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	ctx := context.Background()
+	spendingLimit := meta.MaxTiDBCloudSpendingLimit
+	ids := make([]int64, 0, 3)
+	for i := 0; i < 3; i++ {
+		id, err := metaStore.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+			TiDBCloudOrganizationID: fmt.Sprintf("org-keyset-%d", i), ProvisioningKey: bytes.Repeat([]byte{byte(i + 1)}, 32),
+			CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+		})
+		if err != nil {
+			t.Fatalf("CreateManagedSharedDBPool %d: %v", i, err)
+		}
+		ids = append(ids, id)
+	}
+	srv := &Server{meta: metaStore}
+	var cursor int64
+	first, err := srv.nextManagedSharedDBStatusPage(ctx, meta.SharedDBStatusPending, &cursor, 2)
+	if err != nil || len(first) != 2 || first[0].ID != ids[0] || first[1].ID != ids[1] {
+		t.Fatalf("first page = %+v, cursor=%d, err=%v", first, cursor, err)
+	}
+	second, err := srv.nextManagedSharedDBStatusPage(ctx, meta.SharedDBStatusPending, &cursor, 2)
+	if err != nil || len(second) != 1 || second[0].ID != ids[2] {
+		t.Fatalf("second page = %+v, cursor=%d, err=%v", second, cursor, err)
+	}
+	third, err := srv.nextManagedSharedDBStatusPage(ctx, meta.SharedDBStatusPending, &cursor, 2)
+	if err != nil || len(third) != 2 || third[0].ID != ids[0] || third[1].ID != ids[1] {
+		t.Fatalf("wrapped page = %+v, cursor=%d, err=%v", third, cursor, err)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -172,35 +172,40 @@ func TestDefaultTenantProviderIsIndependentFromProvisionerType(t *testing.T) {
 func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 	defaults := NewWithConfig(Config{})
 	t.Cleanup(defaults.Close)
-	if defaults.managedSharedDBCloudBatchSize != 10 || defaults.managedSharedDBRefillPoolLimit != 50 ||
+	if defaults.managedSharedDBCloudBatchSize != 50 ||
 		defaults.managedSharedDBMetadataWorkers != 15 || defaults.managedSharedDBMetadataBatchSize != 30 ||
 		defaults.managedSharedDBMetadataPollInterval != 15*time.Second || defaults.managedSharedDBProvisioningWorkers != 100 ||
-		defaults.tenantPoolReconcileInterval != 15*time.Second || defaults.managedSharedDBStuckTimeout != 15*time.Minute ||
-		defaults.tenantPoolReconcileWorkers != 10 || defaults.managedSharedDBFailedCleanupInterval != time.Minute || defaults.managedSharedDBFailedCleanupBatchSize != 5 {
-		t.Fatalf("managed shared defaults = cloud_batch(%d) refill_pool_limit(%d) metadata(%d,%d,%s) provisioning(%d) reconcile(%s) stuck(%s) failed_cleanup(%s,%d)",
-			defaults.managedSharedDBCloudBatchSize, defaults.managedSharedDBRefillPoolLimit,
+		defaults.tenantPoolReconcileInterval != 5*time.Second || defaults.tenantPoolReconcileWorkerRest != 5*time.Second ||
+		defaults.managedSharedDBStuckTimeout != 15*time.Minute || defaults.tenantPoolReconcileWorkers != 15 ||
+		defaults.managedSharedDBPlannedCapacityLease != time.Minute || defaults.managedSharedDBFailedCleanupInterval != time.Minute || defaults.managedSharedDBFailedCleanupBatchSize != 5 {
+		t.Fatalf("managed shared defaults = cloud_batch(%d) metadata(%d,%d,%s) provisioning(%d) reconcile(%s,%d,%s) planned_lease(%s) stuck(%s) failed_cleanup(%s,%d)",
+			defaults.managedSharedDBCloudBatchSize,
 			defaults.managedSharedDBMetadataWorkers, defaults.managedSharedDBMetadataBatchSize, defaults.managedSharedDBMetadataPollInterval,
-			defaults.managedSharedDBProvisioningWorkers, defaults.tenantPoolReconcileInterval, defaults.managedSharedDBStuckTimeout,
+			defaults.managedSharedDBProvisioningWorkers, defaults.tenantPoolReconcileInterval, defaults.tenantPoolReconcileWorkers,
+			defaults.tenantPoolReconcileWorkerRest, defaults.managedSharedDBPlannedCapacityLease, defaults.managedSharedDBStuckTimeout,
 			defaults.managedSharedDBFailedCleanupInterval, defaults.managedSharedDBFailedCleanupBatchSize)
 	}
 	overrides := NewWithConfig(Config{
-		ManagedSharedDBCloudBatchSize: 3, ManagedSharedDBRefillPoolLimit: 12,
+		ManagedSharedDBCloudBatchSize:  12,
 		ManagedSharedDBMetadataWorkers: 5, ManagedSharedDBMetadataBatchSize: 6, ManagedSharedDBMetadataPollInterval: 7 * time.Second,
 		ManagedSharedDBProvisioningWorkers: 8, TenantPoolReconcileInterval: 9 * time.Second, ManagedSharedDBStuckTimeout: 11 * time.Minute,
-		TenantPoolReconcileWorkers:           4,
+		TenantPoolReconcileWorkers: 4, TenantPoolReconcileWorkerRest: 3 * time.Second,
+		ManagedSharedDBPlannedCapacityLease:  2 * time.Minute,
 		ManagedSharedDBFailedCleanupInterval: 2 * time.Minute, ManagedSharedDBFailedCleanupBatchSize: 3,
 	})
 	t.Cleanup(overrides.Close)
-	if overrides.managedSharedDBCloudBatchSize != 3 || overrides.managedSharedDBRefillPoolLimit != 12 ||
+	if overrides.managedSharedDBCloudBatchSize != 12 ||
 		overrides.managedSharedDBMetadataWorkers != 5 || overrides.managedSharedDBMetadataBatchSize != 6 ||
 		overrides.managedSharedDBMetadataPollInterval != 7*time.Second || overrides.managedSharedDBProvisioningWorkers != 8 ||
-		overrides.tenantPoolReconcileInterval != 9*time.Second || overrides.tenantPoolReconcileWorkers != 4 || overrides.managedSharedDBStuckTimeout != 11*time.Minute ||
+		overrides.tenantPoolReconcileInterval != 9*time.Second || overrides.tenantPoolReconcileWorkers != 4 ||
+		overrides.tenantPoolReconcileWorkerRest != 3*time.Second || overrides.managedSharedDBPlannedCapacityLease != 2*time.Minute ||
+		overrides.managedSharedDBStuckTimeout != 11*time.Minute ||
 		overrides.managedSharedDBFailedCleanupInterval != 2*time.Minute || overrides.managedSharedDBFailedCleanupBatchSize != 3 {
 		t.Fatalf("managed shared overrides were not retained")
 	}
-	capped := NewWithConfig(Config{ManagedSharedDBCloudBatchSize: 11, ManagedSharedDBMetadataWorkers: 16, ManagedSharedDBMetadataBatchSize: 31})
+	capped := NewWithConfig(Config{ManagedSharedDBCloudBatchSize: 75, ManagedSharedDBMetadataWorkers: 16, ManagedSharedDBMetadataBatchSize: 31})
 	t.Cleanup(capped.Close)
-	if capped.managedSharedDBCloudBatchSize != 10 || capped.managedSharedDBMetadataWorkers != 15 || capped.managedSharedDBMetadataBatchSize != 30 {
+	if capped.managedSharedDBCloudBatchSize != 75 || capped.managedSharedDBMetadataWorkers != 15 || capped.managedSharedDBMetadataBatchSize != 30 {
 		t.Fatalf("managed shared safety caps = cloud batch %d, metadata workers %d, metadata batch %d",
 			capped.managedSharedDBCloudBatchSize, capped.managedSharedDBMetadataWorkers, capped.managedSharedDBMetadataBatchSize)
 	}
@@ -275,6 +280,9 @@ func TestNextManagedSharedDBStatusPageAdvancesAndWrapsKeysetCursor(t *testing.T)
 	second, err := srv.nextManagedSharedDBStatusPage(ctx, meta.SharedDBStatusPending, &cursor, 2)
 	if err != nil || len(second) != 1 || second[0].ID != ids[2] {
 		t.Fatalf("second page = %+v, cursor=%d, err=%v", second, cursor, err)
+	}
+	if cursor != 0 {
+		t.Fatalf("cursor after short page = %d, want wrapped to zero", cursor)
 	}
 	third, err := srv.nextManagedSharedDBStatusPage(ctx, meta.SharedDBStatusPending, &cursor, 2)
 	if err != nil || len(third) != 2 || third[0].ID != ids[0] || third[1].ID != ids[1] {
@@ -515,6 +523,60 @@ func TestManagedSharedDBMetadataWorkerRefillsReadySlots(t *testing.T) {
 		if got.Status != meta.SharedDBStatusProvisioning {
 			t.Fatalf("db pool %d status = %q, want provisioning", row.ID, got.Status)
 		}
+	}
+}
+
+func TestManagedSharedDBMetadataWorkerHeartbeatsVisibleIncompletePool(t *testing.T) {
+	origWindow := schemaInitRetryWindow
+	schemaInitRetryWindow = 25 * time.Millisecond
+	t.Cleanup(func() { schemaInitRetryWindow = origWindow })
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-metadata-heartbeat", ProvisioningKey: bytes.Repeat([]byte{3}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+		PasswordCipher: []byte("cipher"), Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.UpdateManagedSharedDBPoolCloudResult(context.Background(), &meta.SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-metadata-heartbeat", ClusterID: "cluster-metadata-heartbeat",
+		PasswordCipher: []byte("cipher"), Name: "tidbcloud_fs",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	old := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Millisecond)
+	if _, err := metaStore.DB().ExecContext(context.Background(), `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, old, dbID); err != nil {
+		t.Fatal(err)
+	}
+	row, err := metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}
+	prov.sharedPoolBatchLoadFunc = func(requests []tenant.SharedDBPoolLoadRequest) ([]*tenant.SharedDBPoolInfo, error) {
+		return []*tenant.SharedDBPoolInfo{{DBPoolID: requests[0].DBPoolID, DBPoolUUID: requests[0].DBPoolUUID,
+			ClusterID: requests[0].ClusterID}}, nil
+	}
+	srv := &Server{meta: metaStore, provisioner: prov,
+		managedSharedDBMetadataWorkers: 1, managedSharedDBMetadataBatchSize: 1,
+		managedSharedDBMetadataPollInterval: 5 * time.Millisecond, managedSharedDBMetadataSlots: make(chan struct{}, 1)}
+	srv.pollManagedSharedDBMetadataWithReady(context.Background(), []*meta.SharedDB{row}, nil)
+	got, err := metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != meta.SharedDBStatusPending {
+		t.Fatalf("status = %q, want pending while endpoint metadata is incomplete", got.Status)
+	}
+	if !got.UpdatedAt.After(old) {
+		t.Fatalf("updated_at = %s, want heartbeat after %s", got.UpdatedAt, old)
 	}
 }
 
@@ -1166,6 +1228,46 @@ func TestManagedSharedDBContinuationRejectsProvisioningPoolWithoutConnectionMeta
 	}
 	if got := prov.sharedPoolWaitCalls.Load(); got != 0 {
 		t.Fatalf("shared metadata wait calls = %d, want 0", got)
+	}
+}
+
+func TestManagedSharedDBContinuationSkipsFailedPoolBeforeCloudCreate(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(pool.Close)
+	pool.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov, sharedDBMaxTenants: 100,
+		sharedDBSpendingLimit: meta.MaxTiDBCloudSpendingLimit}
+	row, err := srv.createManagedSharedDBPlan(context.Background(), "org-failed-continuation", bytes.Repeat([]byte{9}, 32))
+	if err != nil {
+		t.Fatalf("createManagedSharedDBPlan: %v", err)
+	}
+	if err := metaStore.MarkSharedDBPoolFailed(context.Background(), row.ID); err != nil {
+		t.Fatalf("MarkSharedDBPoolFailed: %v", err)
+	}
+	row, err = metaStore.GetSharedDB(context.Background(), row.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := srv.continueManagedSharedDBPoolLocked(context.Background(), row, tenant.CredentialProvisionRequest{}); err != nil {
+		t.Fatalf("continue failed pool: %v", err)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 0 {
+		t.Fatalf("shared batch calls = %d, want no Cloud create for failed pool", got)
 	}
 }
 
@@ -1821,7 +1923,7 @@ func TestEnsureManagedSharedDBPhysicalUsesPoolLockForKnownCluster(t *testing.T) 
 	}
 }
 
-func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
+func TestManagedSharedDBBatchCreateSubmitsFiftyPoolsInOneRequest(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -1854,34 +1956,32 @@ func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
 		}
 		dbIDs = append(dbIDs, dbID)
 	}
-	started := make(chan struct{}, 5)
+	started := make(chan struct{}, 1)
 	release := make(chan struct{})
-	requests := make(chan []tenant.SharedDBPoolCreateRequest, 5)
+	requests := make(chan []tenant.SharedDBPoolCreateRequest, 1)
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, identityOrg: "org-parallel-batches",
 		sharedPoolBatchStarted: started, sharedPoolBatchRelease: release, sharedPoolBatchRequests: requests}
 	srv := &Server{meta: metaStore, pool: pool, provisioner: prov,
-		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour), managedSharedDBCloudBatchSize: 10}
+		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour), managedSharedDBCloudBatchSize: 50}
 	done := make(chan error, 1)
 	go func() {
 		_, batchErr := srv.provisionManagedSharedDBPoolsBatch(context.Background(), dbIDs)
 		done <- batchErr
 	}()
 
-	for i := 0; i < 5; i++ {
-		select {
-		case <-started:
-		case <-time.After(500 * time.Millisecond):
-			close(release)
-			<-done
-			t.Fatalf("started %d/5 Cloud batch requests before release", i)
-		}
+	select {
+	case <-started:
+	case <-time.After(500 * time.Millisecond):
+		close(release)
+		<-done
+		t.Fatal("Cloud batch request did not start")
 	}
 	close(release)
 	if err := <-done; err != nil {
 		t.Fatalf("batch create: %v", err)
 	}
-	if got := prov.sharedPoolBatchCalls.Load(); got != 5 {
-		t.Fatalf("batch calls = %d, want 5", got)
+	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
+		t.Fatalf("batch calls = %d, want 1", got)
 	}
 	if got := prov.sharedPoolBatchMembers.Load(); got != 50 {
 		t.Fatalf("batch members = %d, want 50", got)
@@ -1889,14 +1989,8 @@ func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
 	if got := prov.sharedPoolBatchLoadCalls.Load(); got != 1 {
 		t.Fatalf("batch adoption list calls = %d, want 1 for the whole physical wave", got)
 	}
-	sizes := make([]int, 0, 5)
-	for i := 0; i < 5; i++ {
-		sizes = append(sizes, len(<-requests))
-	}
-	slices.Sort(sizes)
-	wantSizes := []int{10, 10, 10, 10, 10}
-	if !slices.Equal(sizes, wantSizes) {
-		t.Fatalf("batch sizes = %v, want %v", sizes, wantSizes)
+	if got := len(<-requests); got != 50 {
+		t.Fatalf("batch size = %d, want 50", got)
 	}
 }
 
@@ -2159,8 +2253,7 @@ func TestManagedSharedDBBatchCreateAdoptsExistingCloudPoolBeforeRetry(t *testing
 		}}, nil
 	}
 	srv := &Server{meta: metaStore, pool: pool, provisioner: prov,
-		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour), managedSharedDBCloudBatchSize: 10,
-		managedSharedDBRefillPoolLimit: 50}
+		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour), managedSharedDBCloudBatchSize: 50}
 	_, err = srv.provisionManagedSharedDBPoolsBatchWithCredentials(context.Background(), []int64{dbID}, tenant.CredentialProvisionRequest{})
 	if err != nil {
 		t.Fatalf("batch create adoption: %v", err)

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -206,6 +206,46 @@ func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 	}
 }
 
+func TestManagedSharedDBProvisioningWorkerLimitReservesMetaConnections(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int
+		maxOpen    int
+		want       int
+	}{
+		{name: "unlimited", configured: 100, maxOpen: 0, want: 100},
+		{name: "default meta pool", configured: 100, maxOpen: 100, want: 50},
+		{name: "configured below safe limit", configured: 8, maxOpen: 100, want: 8},
+		{name: "odd pool size", configured: 10, maxOpen: 3, want: 1},
+		{name: "no spare callback connection", configured: 1, maxOpen: 1, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := limitManagedSharedDBProvisioningWorkers(tt.configured, tt.maxOpen); got != tt.want {
+				t.Fatalf("worker limit = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestManagedSharedDBProvisioningSlotsUseEffectiveMetaConnectionBudget(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	metaStore.DB().SetMaxOpenConns(20)
+
+	srv := NewWithConfig(Config{Meta: metaStore, ManagedSharedDBProvisioningWorkers: 100})
+	t.Cleanup(srv.Close)
+	if got := srv.managedSharedDBProvisioningConcurrency; got != 10 {
+		t.Fatalf("effective provisioning concurrency = %d, want 10", got)
+	}
+	if got := cap(srv.managedSharedDBProvisioningSlots); got != 10 {
+		t.Fatalf("provisioning slot capacity = %d, want 10", got)
+	}
+}
+
 func TestNextManagedSharedDBStatusPageAdvancesAndWrapsKeysetCursor(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -1846,6 +1886,9 @@ func TestManagedSharedDBBatchCreateRunsAllChunksConcurrently(t *testing.T) {
 	if got := prov.sharedPoolBatchMembers.Load(); got != 50 {
 		t.Fatalf("batch members = %d, want 50", got)
 	}
+	if got := prov.sharedPoolBatchLoadCalls.Load(); got != 1 {
+		t.Fatalf("batch adoption list calls = %d, want 1 for the whole physical wave", got)
+	}
 	sizes := make([]int, 0, 5)
 	for i := 0; i < 5; i++ {
 		sizes = append(sizes, len(<-requests))
@@ -2069,6 +2112,71 @@ func TestManagedSharedDBBatchCreateReturnsTotalFailure(t *testing.T) {
 	_, err = srv.provisionManagedSharedDBPoolsBatch(context.Background(), []int64{dbID})
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("batch error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestManagedSharedDBBatchCreateAdoptsExistingCloudPoolBeforeRetry(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = metaStore.Close() }()
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	_, _ = rand.Read(master)
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	defer pool.Close()
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-adopt-before-retry", ProvisioningKey: bytes.Repeat([]byte{7}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+		PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	row, err := metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}
+	prov.sharedPoolBatchLoadFunc = func(requests []tenant.SharedDBPoolLoadRequest) ([]*tenant.SharedDBPoolInfo, error) {
+		if len(requests) != 1 || requests[0].DBPoolID != dbID || requests[0].DBPoolUUID != row.UUID || requests[0].ClusterID != "" {
+			t.Fatalf("adoption requests = %+v", requests)
+		}
+		return []*tenant.SharedDBPoolInfo{{
+			DBPoolID: dbID, DBPoolUUID: row.UUID, ClusterID: "cluster-adopted",
+			OrganizationID: "org-adopt-before-retry", DBName: "tidbcloud_fs",
+		}}, nil
+	}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: prov,
+		tidbCloudRBACCache: newTiDBCloudRBACCache(time.Hour), managedSharedDBCloudBatchSize: 10,
+		managedSharedDBRefillPoolLimit: 50}
+	_, err = srv.provisionManagedSharedDBPoolsBatchWithCredentials(context.Background(), []int64{dbID}, tenant.CredentialProvisionRequest{})
+	if err != nil {
+		t.Fatalf("batch create adoption: %v", err)
+	}
+	if got := prov.sharedPoolBatchLoadCalls.Load(); got != 1 {
+		t.Fatalf("batch adoption list calls = %d, want 1", got)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 0 {
+		t.Fatalf("Cloud create calls = %d, want 0 after adoption", got)
+	}
+	persisted, err := metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if persisted.ClusterID != "cluster-adopted" {
+		t.Fatalf("persisted cluster_id = %q, want cluster-adopted", persisted.ClusterID)
 	}
 }
 
@@ -4456,7 +4564,8 @@ func TestStartupResumesProvisioningTenantInit(t *testing.T) {
 	}
 
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBZero, cluster: &tenant.ClusterInfo{}}
-	_ = NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov, TokenSecret: []byte("abc")})
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov, TokenSecret: []byte("abc")})
+	defer srv.Close()
 
 	deadline := time.Now().Add(2 * time.Second)
 	for {
@@ -4521,7 +4630,8 @@ func TestStartupMarksPendingTenantFailed(t *testing.T) {
 	}
 
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBZero, cluster: &tenant.ClusterInfo{}}
-	_ = NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov, TokenSecret: []byte("abc")})
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov, TokenSecret: []byte("abc")})
+	defer srv.Close()
 
 	deadline := time.Now().Add(2 * time.Second)
 	for {
@@ -4587,7 +4697,7 @@ func TestStartupKeepsFreshPendingTenant(t *testing.T) {
 
 	prov := &fakeProvisioner{provider: tenant.ProviderTiDBZero, cluster: &tenant.ClusterInfo{}}
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: pool, Provisioner: prov, TokenSecret: []byte("abc")})
-	t.Cleanup(srv.Close)
+	defer srv.Close()
 
 	time.Sleep(100 * time.Millisecond)
 	row := metaStore.DB().QueryRow("SELECT status FROM tenants WHERE id = ?", tenantID)

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -177,12 +177,12 @@ func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 		defaults.managedSharedDBMetadataPollInterval != 15*time.Second || defaults.managedSharedDBProvisioningWorkers != 100 ||
 		defaults.tenantPoolReconcileInterval != 5*time.Second || defaults.tenantPoolReconcileWorkerRest != 5*time.Second ||
 		defaults.managedSharedDBStuckTimeout != 15*time.Minute || defaults.tenantPoolReconcileWorkers != 15 ||
-		defaults.managedSharedDBPlannedCapacityLease != time.Minute || defaults.managedSharedDBFailedCleanupInterval != time.Minute || defaults.managedSharedDBFailedCleanupBatchSize != 5 {
-		t.Fatalf("managed shared defaults = cloud_batch(%d) metadata(%d,%d,%s) provisioning(%d) reconcile(%s,%d,%s) planned_lease(%s) stuck(%s) failed_cleanup(%s,%d)",
+		defaults.managedSharedDBFailedCleanupInterval != time.Minute || defaults.managedSharedDBFailedCleanupBatchSize != 5 {
+		t.Fatalf("managed shared defaults = cloud_batch(%d) metadata(%d,%d,%s) provisioning(%d) reconcile(%s,%d,%s) stuck(%s) failed_cleanup(%s,%d)",
 			defaults.managedSharedDBCloudBatchSize,
 			defaults.managedSharedDBMetadataWorkers, defaults.managedSharedDBMetadataBatchSize, defaults.managedSharedDBMetadataPollInterval,
 			defaults.managedSharedDBProvisioningWorkers, defaults.tenantPoolReconcileInterval, defaults.tenantPoolReconcileWorkers,
-			defaults.tenantPoolReconcileWorkerRest, defaults.managedSharedDBPlannedCapacityLease, defaults.managedSharedDBStuckTimeout,
+			defaults.tenantPoolReconcileWorkerRest, defaults.managedSharedDBStuckTimeout,
 			defaults.managedSharedDBFailedCleanupInterval, defaults.managedSharedDBFailedCleanupBatchSize)
 	}
 	overrides := NewWithConfig(Config{
@@ -190,7 +190,6 @@ func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 		ManagedSharedDBMetadataWorkers: 5, ManagedSharedDBMetadataBatchSize: 6, ManagedSharedDBMetadataPollInterval: 7 * time.Second,
 		ManagedSharedDBProvisioningWorkers: 8, TenantPoolReconcileInterval: 9 * time.Second, ManagedSharedDBStuckTimeout: 11 * time.Minute,
 		TenantPoolReconcileWorkers: 4, TenantPoolReconcileWorkerRest: 3 * time.Second,
-		ManagedSharedDBPlannedCapacityLease:  2 * time.Minute,
 		ManagedSharedDBFailedCleanupInterval: 2 * time.Minute, ManagedSharedDBFailedCleanupBatchSize: 3,
 	})
 	t.Cleanup(overrides.Close)
@@ -198,7 +197,7 @@ func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 		overrides.managedSharedDBMetadataWorkers != 5 || overrides.managedSharedDBMetadataBatchSize != 6 ||
 		overrides.managedSharedDBMetadataPollInterval != 7*time.Second || overrides.managedSharedDBProvisioningWorkers != 8 ||
 		overrides.tenantPoolReconcileInterval != 9*time.Second || overrides.tenantPoolReconcileWorkers != 4 ||
-		overrides.tenantPoolReconcileWorkerRest != 3*time.Second || overrides.managedSharedDBPlannedCapacityLease != 2*time.Minute ||
+		overrides.tenantPoolReconcileWorkerRest != 3*time.Second ||
 		overrides.managedSharedDBStuckTimeout != 11*time.Minute ||
 		overrides.managedSharedDBFailedCleanupInterval != 2*time.Minute || overrides.managedSharedDBFailedCleanupBatchSize != 3 {
 		t.Fatalf("managed shared overrides were not retained")

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -325,13 +325,17 @@ func TestManagedSharedDBContinuationDoesNotStartOnFollower(t *testing.T) {
 func TestManagedSharedDBResumeLoopDoesNotOverlapPasses(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	started := make(chan struct{}, 2)
+	interval := 40 * time.Millisecond
+	started := make(chan time.Time, 2)
 	release := make(chan struct{}, 2)
+	completed := make(chan time.Time, 1)
 	done := make(chan struct{})
 	var running atomic.Int32
 	var maxRunning atomic.Int32
+	var attempts atomic.Int32
 	go func() {
-		runManagedSharedDBResumeLoop(ctx, 10*time.Millisecond, func(context.Context) {
+		runManagedSharedDBResumeLoop(ctx, interval, func(context.Context) {
+			attempt := attempts.Add(1)
 			current := running.Add(1)
 			for {
 				observed := maxRunning.Load()
@@ -339,8 +343,11 @@ func TestManagedSharedDBResumeLoopDoesNotOverlapPasses(t *testing.T) {
 					break
 				}
 			}
-			started <- struct{}{}
+			started <- time.Now()
 			<-release
+			if attempt == 1 {
+				completed <- time.Now()
+			}
 			running.Add(-1)
 		})
 		close(done)
@@ -350,15 +357,24 @@ func TestManagedSharedDBResumeLoopDoesNotOverlapPasses(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("initial managed shared DB resume pass did not start")
 	}
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(2 * interval)
 	select {
 	case <-started:
 		t.Fatal("managed shared DB resume loop started an overlapping pass")
 	default:
 	}
 	release <- struct{}{}
+	var firstCompletedAt time.Time
 	select {
-	case <-started:
+	case firstCompletedAt = <-completed:
+	case <-time.After(time.Second):
+		t.Fatal("initial managed shared DB resume pass did not complete")
+	}
+	select {
+	case secondStartedAt := <-started:
+		if elapsed := secondStartedAt.Sub(firstCompletedAt); elapsed < interval {
+			t.Fatalf("second resume pass started %s after completion, want at least %s", elapsed, interval)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("managed shared DB resume loop did not run after the first pass completed")
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -542,7 +542,7 @@ func TestManagedSharedDBMetadataWorkerRefillsReadySlots(t *testing.T) {
 	}
 }
 
-func TestManagedSharedDBMetadataWorkerHeartbeatsVisibleIncompletePool(t *testing.T) {
+func TestManagedSharedDBMetadataWorkerDoesNotKeepIncompletePoolAlive(t *testing.T) {
 	origWindow := schemaInitRetryWindow
 	schemaInitRetryWindow = 25 * time.Millisecond
 	t.Cleanup(func() { schemaInitRetryWindow = origWindow })
@@ -567,7 +567,7 @@ func TestManagedSharedDBMetadataWorkerHeartbeatsVisibleIncompletePool(t *testing
 	}); err != nil {
 		t.Fatal(err)
 	}
-	old := time.Now().UTC().Add(-10 * time.Minute).Truncate(time.Millisecond)
+	old := time.Now().UTC().Add(-20 * time.Minute).Truncate(time.Millisecond)
 	if _, err := metaStore.DB().ExecContext(context.Background(), `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, old, dbID); err != nil {
 		t.Fatal(err)
 	}
@@ -591,8 +591,17 @@ func TestManagedSharedDBMetadataWorkerHeartbeatsVisibleIncompletePool(t *testing
 	if got.Status != meta.SharedDBStatusPending {
 		t.Fatalf("status = %q, want pending while endpoint metadata is incomplete", got.Status)
 	}
-	if !got.UpdatedAt.After(old) {
-		t.Fatalf("updated_at = %s, want heartbeat after %s", got.UpdatedAt, old)
+	if !got.UpdatedAt.Equal(old) {
+		t.Fatalf("updated_at = %s, want unchanged incomplete-metadata timestamp %s", got.UpdatedAt, old)
+	}
+	srv.managedSharedDBStuckTimeout = 15 * time.Minute
+	srv.reconcileStuckManagedSharedDBPoolsWithCtx(context.Background())
+	got, err = metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Status != meta.SharedDBStatusFailed {
+		t.Fatalf("status after stuck reconciliation = %q, want failed", got.Status)
 	}
 }
 

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -66,6 +66,7 @@ type quotaTestProvisioner struct {
 	metadataBatchWaitHook       func(call int, clusters []*tenant.ClusterInfo)
 	metadataWaitErr             error
 	sharedPoolLoadFunc          func(int64, string, string) (*tenant.SharedDBPoolInfo, error)
+	sharedPoolListFunc          func(int64, string) ([]*tenant.SharedDBPoolInfo, error)
 	calls                       []string
 }
 
@@ -74,6 +75,20 @@ func (p *quotaTestProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context
 		return nil, nil
 	}
 	return p.sharedPoolLoadFunc(dbPoolID, dbPoolUUID, clusterID)
+}
+
+func (p *quotaTestProvisioner) ListSharedDBPoolsWithCredentials(_ context.Context, dbPoolID int64, dbPoolUUID string, _ tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+	if p.sharedPoolListFunc != nil {
+		return p.sharedPoolListFunc(dbPoolID, dbPoolUUID)
+	}
+	if p.sharedPoolLoadFunc == nil {
+		return nil, nil
+	}
+	row, err := p.sharedPoolLoadFunc(dbPoolID, dbPoolUUID, "")
+	if err != nil || row == nil {
+		return nil, err
+	}
+	return []*tenant.SharedDBPoolInfo{row}, nil
 }
 
 func (p *quotaTestProvisioner) recordCall(name string, req tenant.CredentialProvisionRequest, cluster *tenant.ClusterInfo, opts *tenant.QuotaUpdateOptions) {

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -65,7 +65,15 @@ type quotaTestProvisioner struct {
 	metadataBatchWaitCalls      atomic.Int32
 	metadataBatchWaitHook       func(call int, clusters []*tenant.ClusterInfo)
 	metadataWaitErr             error
+	sharedPoolLoadFunc          func(int64, string, string) (*tenant.SharedDBPoolInfo, error)
 	calls                       []string
+}
+
+func (p *quotaTestProvisioner) LoadSharedDBPoolWithCredentials(_ context.Context, dbPoolID int64, dbPoolUUID, clusterID string, _ tenant.CredentialProvisionRequest) (*tenant.SharedDBPoolInfo, error) {
+	if p.sharedPoolLoadFunc == nil {
+		return nil, nil
+	}
+	return p.sharedPoolLoadFunc(dbPoolID, dbPoolUUID, clusterID)
 }
 
 func (p *quotaTestProvisioner) recordCall(name string, req tenant.CredentialProvisionRequest, cluster *tenant.ClusterInfo, opts *tenant.QuotaUpdateOptions) {
@@ -2475,6 +2483,48 @@ func TestTenantPoolClaimMissTriggersPendingMetadataResume(t *testing.T) {
 		}
 		if time.Now().After(deadline) {
 			t.Fatalf("tenant after pending resume = status %s host %q user %q, metadata batch waits=%d", tnt.Status, tnt.DBHost, tnt.DBUser, rt.prov.metadataBatchWaitCalls.Load())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestTenantPoolClaimMissReplenishesZeroInventory(t *testing.T) {
+	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
+	oldRetryWindow := schemaInitRetryWindow
+	schemaInitRetryWindow = 100 * time.Millisecond
+	t.Cleanup(func() { schemaInitRetryWindow = oldRetryWindow })
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID: "pool-zero-inventory", OrganizationID: "org-1", Size: 1,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("create pool: %v", err)
+	}
+
+	res, gotPool, claimed, _, err := rt.server.claimAdminTenantFromPool(ctx, tenant.CredentialProvisionRequest{
+		PublicKey: "public-1", PrivateKey: "private-1",
+	}, nil)
+	if err != nil {
+		t.Fatalf("claim from empty pool: %v", err)
+	}
+	if claimed || res != nil || gotPool == nil || gotPool.PoolID != pool.PoolID {
+		t.Fatalf("claim result res=%+v pool=%+v claimed=%v, want pool miss", res, gotPool, claimed)
+	}
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		slots, countErr := rt.meta.CountTenantPoolFreeSlots(ctx, pool.OrganizationID)
+		if countErr != nil {
+			t.Fatalf("count free slots: %v", countErr)
+		}
+		if slots == pool.Size {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("durable free slots = %d, want %d after claim miss; batch calls=%d",
+				slots, pool.Size, rt.prov.batchPoolCalls.Load())
 		}
 		time.Sleep(10 * time.Millisecond)
 	}

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -384,7 +384,16 @@ func (p *tenantPoolNoListProvisioner) MarkClusterPoolFree(context.Context, *tena
 	return nil
 }
 
+type quotaRuntimeOptions struct {
+	defaultTenantProvider string
+	provisioner           func(*quotaTestProvisioner) tenant.Provisioner
+}
+
 func newQuotaRuntime(t *testing.T, provider string) *quotaRuntime {
+	return newQuotaRuntimeWithOptions(t, provider, quotaRuntimeOptions{})
+}
+
+func newQuotaRuntimeWithOptions(t *testing.T, provider string, opts quotaRuntimeOptions) *quotaRuntime {
 	t.Helper()
 	db := newTenantDeleteDBInfo(t)
 	testmysql.ResetMetaDB(t, db.Meta.DB())
@@ -452,7 +461,12 @@ func newQuotaRuntime(t *testing.T, provider string) *quotaRuntime {
 		t.Fatal(err)
 	}
 	prov := &quotaTestProvisioner{provider: provider}
-	server := NewWithConfig(Config{Meta: db.Meta, Pool: db.Pool, Provisioner: prov, TokenSecret: tokenSecret})
+	configuredProvisioner := tenant.Provisioner(prov)
+	if opts.provisioner != nil {
+		configuredProvisioner = opts.provisioner(prov)
+	}
+	server := NewWithConfig(Config{Meta: db.Meta, Pool: db.Pool, Provisioner: configuredProvisioner,
+		DefaultTenantProvider: opts.defaultTenantProvider, TokenSecret: tokenSecret})
 	t.Cleanup(server.Close)
 	return &quotaRuntime{meta: db.Meta, tenantID: tenantID, apiKey: apiKey, prov: prov, server: server}
 }
@@ -3352,7 +3366,6 @@ func TestProvisionClaimsFreePoolTenant(t *testing.T) {
 }
 
 func TestProvisionFallsBackWhenTenantPoolClaimCannotListManagedClusters(t *testing.T) {
-	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	prov := &tenantPoolNoListProvisioner{
 		fakeProvisioner: fakeProvisioner{
 			provider:      tenant.ProviderTiDBCloudNative,
@@ -3369,7 +3382,9 @@ func TestProvisionFallsBackWhenTenantPoolClaimCannotListManagedClusters(t *testi
 			},
 		},
 	}
-	rt.server.provisioner = prov
+	rt := newQuotaRuntimeWithOptions(t, tenant.ProviderTiDBCloudNative, quotaRuntimeOptions{
+		provisioner: func(*quotaTestProvisioner) tenant.Provisioner { return prov },
+	})
 
 	ts := httptest.NewServer(rt.server)
 	t.Cleanup(ts.Close)

--- a/pkg/server/quota_test.go
+++ b/pkg/server/quota_test.go
@@ -2786,6 +2786,207 @@ func TestAdminTenantPoolUpdateRejectsAboveMaxSize(t *testing.T) {
 	}
 }
 
+func TestAdminTenantPoolUpdateGrowsSharedPoolAtomically(t *testing.T) {
+	sharedProvisioner := &fakeProvisioner{
+		provider:      tenant.ProviderTiDBCloudNative,
+		cloudProvider: "aws",
+		region:        "us-east-1",
+		identityOrg:   "org-1",
+	}
+	rt := newQuotaRuntimeWithOptions(t, tenant.ProviderTiDBCloudNative, quotaRuntimeOptions{
+		defaultTenantProvider: tenant.ProviderTiDBCloudNativeShared,
+		provisioner: func(*quotaTestProvisioner) tenant.Provisioner {
+			return sharedProvisioner
+		},
+	})
+	rt.server.sharedDBMaxTenants = 1
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID: "pool-shared-grow", OrganizationID: "org-1", Size: 2,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("CreateTenantPool: %v", err)
+	}
+	if _, err := rt.server.createFreeSharedPoolTenants(ctx, pool.PoolID, pool.Size,
+		tenant.CredentialProvisionRequest{}, nil); err != nil {
+		t.Fatalf("seed shared tenant pool: %v", err)
+	}
+	baselineMembers := sharedProvisioner.sharedPoolBatchMembers.Load()
+
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	resp := patchJSON(t, ts.URL+"/v1/admin/tenant-pool", map[string]any{
+		"public_key": "public-1", "private_key": "private-1", "pool_size": 4,
+	}, "")
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want %d: %s", resp.StatusCode, http.StatusAccepted, body)
+	}
+	gotPool, err := rt.meta.GetTenantPoolByID(ctx, pool.PoolID)
+	if err != nil {
+		t.Fatalf("GetTenantPoolByID: %v", err)
+	}
+	if gotPool.Size != 4 {
+		t.Fatalf("pool size = %d, want 4", gotPool.Size)
+	}
+	if slots, err := rt.meta.CountTenantPoolFreeSlots(ctx, pool.OrganizationID); err != nil || slots != 4 {
+		t.Fatalf("durable slots = %d, err=%v, want 4", slots, err)
+	}
+	if added := sharedProvisioner.sharedPoolBatchMembers.Load() - baselineMembers; added != 2 {
+		t.Fatalf("additional physical Cloud creates = %d, want 2", added)
+	}
+}
+
+func TestAdminTenantPoolUpdateRejectsStaleSharedGrowWithoutWaveSideEffects(t *testing.T) {
+	sharedProvisioner := &fakeProvisioner{
+		provider:      tenant.ProviderTiDBCloudNative,
+		cloudProvider: "aws",
+		region:        "us-east-1",
+		identityOrg:   "org-1",
+	}
+	rt := newQuotaRuntimeWithOptions(t, tenant.ProviderTiDBCloudNative, quotaRuntimeOptions{
+		defaultTenantProvider: tenant.ProviderTiDBCloudNativeShared,
+		provisioner: func(*quotaTestProvisioner) tenant.Provisioner {
+			return sharedProvisioner
+		},
+	})
+	rt.server.sharedDBMaxTenants = 1
+	ctx := context.Background()
+	now := time.Now().UTC()
+	pool := &meta.TenantPool{
+		PoolID: "pool-shared-stale-grow", OrganizationID: "org-1", Size: 2,
+		Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now,
+	}
+	if err := rt.meta.CreateTenantPool(ctx, pool); err != nil {
+		t.Fatalf("CreateTenantPool: %v", err)
+	}
+	if _, err := rt.server.createFreeSharedPoolTenants(ctx, pool.PoolID, pool.Size,
+		tenant.CredentialProvisionRequest{}, nil); err != nil {
+		t.Fatalf("seed shared tenant pool: %v", err)
+	}
+
+	countRows := func(query string, args ...any) int {
+		t.Helper()
+		var count int
+		if err := rt.meta.DB().QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+			t.Fatalf("count rows: %v", err)
+		}
+		return count
+	}
+	baselinePhysical := countRows(`SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, pool.OrganizationID)
+	baselineTenants := countRows(`SELECT COUNT(*) FROM tenants`)
+	baselinePlacements := countRows(`SELECT COUNT(*) FROM tenant_placements`)
+	baselineMemberships := countRows(`SELECT COUNT(*) FROM tenant_pool_memberships WHERE pool_id = ?`, pool.PoolID)
+	baselineCloudCalls := sharedProvisioner.sharedPoolBatchCalls.Load()
+	baselineCloudMembers := sharedProvisioner.sharedPoolBatchMembers.Load()
+
+	lockConn, err := rt.meta.DB().Conn(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := lockConn.ExecContext(ctx, `LOCK TABLES tenant_quota_config WRITE`); err != nil {
+		_ = lockConn.Close()
+		t.Fatal(err)
+	}
+	locked := true
+	t.Cleanup(func() {
+		if locked {
+			_, _ = lockConn.ExecContext(context.Background(), `UNLOCK TABLES`)
+		}
+		_ = lockConn.Close()
+	})
+
+	ts := httptest.NewServer(rt.server)
+	t.Cleanup(ts.Close)
+	raw, err := json.Marshal(map[string]any{
+		"public_key": "public-1", "private_key": "private-1", "pool_size": 4,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest(http.MethodPatch, ts.URL+"/v1/admin/tenant-pool", bytes.NewReader(raw))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	type responseResult struct {
+		resp *http.Response
+		err  error
+	}
+	responseDone := make(chan responseResult, 1)
+	go func() {
+		resp, requestErr := http.DefaultClient.Do(req)
+		responseDone <- responseResult{resp: resp, err: requestErr}
+	}()
+	select {
+	case result := <-responseDone:
+		if result.resp != nil {
+			_ = result.resp.Body.Close()
+		}
+		t.Fatalf("PATCH returned before quota lock release: %v", result.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	if got := sharedProvisioner.sharedPoolBatchCalls.Load(); got != baselineCloudCalls {
+		t.Fatalf("Cloud calls while wave staging is blocked = %d, want %d", got, baselineCloudCalls)
+	}
+	if err := rt.meta.UpdateTenantPoolSize(ctx, pool.PoolID, 4); err != nil {
+		t.Fatalf("persist competing pool size: %v", err)
+	}
+	if _, err := lockConn.ExecContext(ctx, `UNLOCK TABLES`); err != nil {
+		t.Fatal(err)
+	}
+	locked = false
+
+	var result responseResult
+	select {
+	case result = <-responseDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("PATCH did not finish after quota lock release")
+	}
+	if result.err != nil {
+		t.Fatalf("PATCH request: %v", result.err)
+	}
+	defer func() { _ = result.resp.Body.Close() }()
+	body, err := io.ReadAll(result.resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d: %s", result.resp.StatusCode, http.StatusBadGateway, body)
+	}
+	gotPool, err := rt.meta.GetTenantPoolByID(ctx, pool.PoolID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPool.Size != 4 {
+		t.Fatalf("competing pool size = %d, want 4", gotPool.Size)
+	}
+	if got := countRows(`SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, pool.OrganizationID); got != baselinePhysical {
+		t.Fatalf("physical rows = %d, want baseline %d", got, baselinePhysical)
+	}
+	if got := countRows(`SELECT COUNT(*) FROM tenants`); got != baselineTenants {
+		t.Fatalf("tenant rows = %d, want baseline %d", got, baselineTenants)
+	}
+	if got := countRows(`SELECT COUNT(*) FROM tenant_placements`); got != baselinePlacements {
+		t.Fatalf("placement rows = %d, want baseline %d", got, baselinePlacements)
+	}
+	if got := countRows(`SELECT COUNT(*) FROM tenant_pool_memberships WHERE pool_id = ?`, pool.PoolID); got != baselineMemberships {
+		t.Fatalf("membership rows = %d, want baseline %d", got, baselineMemberships)
+	}
+	if got := sharedProvisioner.sharedPoolBatchCalls.Load(); got != baselineCloudCalls {
+		t.Fatalf("Cloud calls = %d, want baseline %d", got, baselineCloudCalls)
+	}
+	if got := sharedProvisioner.sharedPoolBatchMembers.Load(); got != baselineCloudMembers {
+		t.Fatalf("Cloud members = %d, want baseline %d", got, baselineCloudMembers)
+	}
+}
+
 func TestAdminTenantPoolCreateRejectsExistingIAMOrganizationPoolBeforeCloudCreate(t *testing.T) {
 	rt := newQuotaRuntime(t, tenant.ProviderTiDBCloudNative)
 	rt.prov.iamIdentities = []*tenant.TiDBCloudAPIKeyIdentity{{

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -220,6 +220,8 @@ type Server struct {
 	tenantPoolReconcileWorkers              int
 	tenantPoolReconcileQueue                chan tenantPoolReconcileJob
 	tenantPoolReconcileWorkerRest           time.Duration
+	tenantPoolLeaderReconcileJobs           sync.Map
+	sharedTenantPoolCreateSlots             chan struct{}
 	managedSharedDBPlannedCapacityLease     time.Duration
 	managedSharedDBStuckTimeout             time.Duration
 	managedSharedDBMetadataSlots            chan struct{}
@@ -540,6 +542,7 @@ func NewWithConfig(cfg Config) *Server {
 		tenantPoolReconcileWorkers:             tenantPoolReconcileWorkers,
 		tenantPoolReconcileQueue:               make(chan tenantPoolReconcileJob),
 		tenantPoolReconcileWorkerRest:          tenantPoolReconcileWorkerRest,
+		sharedTenantPoolCreateSlots:            make(chan struct{}, sharedTenantPoolCreateConcurrency),
 		managedSharedDBPlannedCapacityLease:    managedSharedDBPlannedCapacityLease,
 		managedSharedDBStuckTimeout:            managedSharedDBStuckTimeout,
 		managedSharedDBFailedCleanupInterval:   managedSharedDBFailedCleanupInterval,
@@ -981,16 +984,16 @@ func (s *Server) Close() {
 }
 
 func runManagedSharedDBResumeLoop(ctx context.Context, interval time.Duration, resume func(context.Context)) {
-	ticker := time.NewTicker(interval)
-	defer ticker.Stop()
-	resume(ctx)
 	for {
+		resume(ctx)
+		timer := time.NewTimer(interval)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return
-		case <-ticker.C:
-			resume(ctx)
+		case <-timer.C:
 		}
+		timer.Stop()
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -64,6 +64,14 @@ type Config struct {
 	ManagedSharedDBMetadataBatchSize    int
 	ManagedSharedDBMetadataPollInterval time.Duration
 	ManagedSharedDBProvisioningWorkers  int
+	// TenantPoolReconcileInterval drives the leader-only durable logical-pool
+	// scan. ManagedSharedDBStuckTimeout measures no-progress time in one physical
+	// pending/provisioning status. Failed cleanup has its own low-rate worker.
+	TenantPoolReconcileInterval           time.Duration
+	TenantPoolReconcileWorkers            int
+	ManagedSharedDBStuckTimeout           time.Duration
+	ManagedSharedDBFailedCleanupInterval  time.Duration
+	ManagedSharedDBFailedCleanupBatchSize int
 	// LegacyStarterProvisioner is only used for delete/fork compatibility on
 	// persisted tidb_cloud_starter tenants. New starter provisioning remains
 	// disabled and NormalizeProvider does not accept tidb_cloud_starter.
@@ -191,62 +199,73 @@ func (s *Server) provisionerForTenantProvider(provider string) tenant.Provisione
 }
 
 type Server struct {
-	fallback                            *backend.Dat9Backend
-	meta                                *meta.Store
-	pool                                *tenant.Pool
-	provisioner                         tenant.Provisioner
-	defaultTenantProvider               string
-	sharedDBMaxTenants                  int
-	sharedDBHardCapRatio                float64
-	sharedDBReopenRatio                 float64
-	sharedDBSpendingLimit               int64
-	managedSharedDBCloudBatchSize       int
-	managedSharedDBRefillPoolLimit      int
-	managedSharedDBMetadataWorkers      int
-	managedSharedDBMetadataBatchSize    int
-	managedSharedDBMetadataPollInterval time.Duration
-	managedSharedDBProvisioningWorkers  int
-	managedSharedDBMetadataSlots        chan struct{}
-	managedSharedDBProvisioningSlots    chan struct{}
-	managedSharedDBMetadataJobs         sync.Map
-	managedSharedDBProvisioningJobs     sync.Map
-	legacyStarterProvisioner            tenant.Provisioner
-	tokenSecret                         []byte
-	localTenantAPIKey                   string
-	vaultMK                             *vault.MasterKey
-	vaultIssuerURL                      string
-	publicURL                           string
-	maxUploadBytes                      int64
-	tenantPoolMaxSize                   int
-	tenantPoolRefillFreeRatio           float64
-	inlineThreshold                     int64
-	metrics                             *serverMetrics
-	logger                              *zap.Logger
-	mux                                 *http.ServeMux
-	events                              *eventBuses
-	tenantWorker                        *tenantWorkerManager
-	shardResolver                       *semanticShardResolver
-	journalCursorSecret                 []byte
-	objectGCWorker                      *objectGCWorker
-	slockOAuth                          SlockOAuthClient
-	tidbAutoEmbedding                   tenantAutoEmbeddingDefault
-	disableDBAutoEmbed                  bool
-	forkWorkerCtx                       context.Context
-	forkWorkerCancel                    context.CancelFunc
-	forkWorkerWG                        sync.WaitGroup
-	forkWorkerMu                        sync.Mutex
-	forkWorkerClosed                    bool
-	tenantPoolLocks                     sync.Map
-	tenantPoolReplenishJobs             sync.Map
-	tenantPoolCreateLocks               sync.Map
-	sharedDBAllocationLocks             sync.Map
-	tenantPoolResumeJobs                sync.Map
-	tenantPoolResumeScans               sync.Map
-	tenantFailedCleanupJobs             sync.Map
-	tenantFailedCleanupRunner           tenantFailedCleanupRunner
-	tidbCloudRBACCache                  *tidbCloudRBACCache
-	schemaInitErrors                    sync.Map
-	leader                              *leader.Manager
+	fallback              *backend.Dat9Backend
+	meta                  *meta.Store
+	pool                  *tenant.Pool
+	provisioner           tenant.Provisioner
+	defaultTenantProvider string
+	sharedDBMaxTenants    int
+	sharedDBHardCapRatio  float64
+	sharedDBReopenRatio   float64
+	sharedDBSpendingLimit int64
+
+	managedSharedDBCloudBatchSize           int
+	managedSharedDBRefillPoolLimit          int
+	managedSharedDBMetadataWorkers          int
+	managedSharedDBMetadataBatchSize        int
+	managedSharedDBMetadataPollInterval     time.Duration
+	managedSharedDBProvisioningWorkers      int
+	tenantPoolReconcileInterval             time.Duration
+	tenantPoolReconcileWorkers              int
+	tenantPoolReconcileSlots                chan struct{}
+	managedSharedDBStuckTimeout             time.Duration
+	managedSharedDBMetadataSlots            chan struct{}
+	managedSharedDBProvisioningSlots        chan struct{}
+	managedSharedDBMetadataJobs             sync.Map
+	managedSharedDBProvisioningJobs         sync.Map
+	managedSharedDBFailedCleanupBatchSize   int
+	managedSharedDBFailedCleanupInterval    time.Duration
+	managedSharedDBFailedCleanupCursor      int64
+	managedSharedDBPendingResumeCursor      int64
+	managedSharedDBProvisioningResumeCursor int64
+
+	legacyStarterProvisioner  tenant.Provisioner
+	tokenSecret               []byte
+	localTenantAPIKey         string
+	vaultMK                   *vault.MasterKey
+	vaultIssuerURL            string
+	publicURL                 string
+	maxUploadBytes            int64
+	tenantPoolMaxSize         int
+	tenantPoolRefillFreeRatio float64
+	inlineThreshold           int64
+	metrics                   *serverMetrics
+	logger                    *zap.Logger
+	mux                       *http.ServeMux
+	events                    *eventBuses
+	tenantWorker              *tenantWorkerManager
+	shardResolver             *semanticShardResolver
+	journalCursorSecret       []byte
+	objectGCWorker            *objectGCWorker
+	slockOAuth                SlockOAuthClient
+	tidbAutoEmbedding         tenantAutoEmbeddingDefault
+	disableDBAutoEmbed        bool
+	forkWorkerCtx             context.Context
+	forkWorkerCancel          context.CancelFunc
+	forkWorkerWG              sync.WaitGroup
+	forkWorkerMu              sync.Mutex
+	forkWorkerClosed          bool
+	tenantPoolLocks           sync.Map
+	tenantPoolReplenishJobs   sync.Map
+	tenantPoolCreateLocks     sync.Map
+	sharedDBAllocationLocks   sync.Map
+	tenantPoolResumeJobs      sync.Map
+	tenantPoolResumeScans     sync.Map
+	tenantFailedCleanupJobs   sync.Map
+	tenantFailedCleanupRunner tenantFailedCleanupRunner
+	tidbCloudRBACCache        *tidbCloudRBACCache
+	schemaInitErrors          sync.Map
+	leader                    *leader.Manager
 	// leaderWorkerCtx gates leader-only background schedulers. When leadership
 	// changes, this context is cancelled and recreated. Workers that use it
 	// (pending tenant reconciler, tenant delete cleanup, one-time resume tasks)
@@ -338,12 +357,17 @@ const DefaultSharedDBReopenRatio = 0.8
 const DefaultManagedSharedDBSpendingLimit = int64(1_000_000)
 
 const (
-	DefaultManagedSharedDBCloudBatchSize       = 10
-	DefaultManagedSharedDBRefillPoolLimit      = 50
-	DefaultManagedSharedDBMetadataWorkers      = 15
-	DefaultManagedSharedDBMetadataBatchSize    = 30
-	DefaultManagedSharedDBMetadataPollInterval = 15 * time.Second
-	DefaultManagedSharedDBProvisioningWorkers  = 100
+	DefaultManagedSharedDBCloudBatchSize         = 10
+	DefaultManagedSharedDBRefillPoolLimit        = 50
+	DefaultManagedSharedDBMetadataWorkers        = 15
+	DefaultManagedSharedDBMetadataBatchSize      = 30
+	DefaultManagedSharedDBMetadataPollInterval   = 15 * time.Second
+	DefaultManagedSharedDBProvisioningWorkers    = 100
+	DefaultTenantPoolReconcileInterval           = 15 * time.Second
+	DefaultTenantPoolReconcileWorkers            = 10
+	DefaultManagedSharedDBStuckTimeout           = 15 * time.Minute
+	DefaultManagedSharedDBFailedCleanupInterval  = time.Minute
+	DefaultManagedSharedDBFailedCleanupBatchSize = 5
 )
 
 // TenantStatusResponse is the JSON body of GET /v1/status. Fields are filled
@@ -451,43 +475,71 @@ func NewWithConfig(cfg Config) *Server {
 	if managedSharedDBProvisioningWorkers <= 0 {
 		managedSharedDBProvisioningWorkers = DefaultManagedSharedDBProvisioningWorkers
 	}
+	tenantPoolReconcileInterval := cfg.TenantPoolReconcileInterval
+	if tenantPoolReconcileInterval <= 0 {
+		tenantPoolReconcileInterval = DefaultTenantPoolReconcileInterval
+	}
+	tenantPoolReconcileWorkers := cfg.TenantPoolReconcileWorkers
+	if tenantPoolReconcileWorkers <= 0 {
+		tenantPoolReconcileWorkers = DefaultTenantPoolReconcileWorkers
+	}
+	managedSharedDBStuckTimeout := cfg.ManagedSharedDBStuckTimeout
+	if managedSharedDBStuckTimeout <= 0 {
+		managedSharedDBStuckTimeout = DefaultManagedSharedDBStuckTimeout
+	}
+	managedSharedDBFailedCleanupInterval := cfg.ManagedSharedDBFailedCleanupInterval
+	if managedSharedDBFailedCleanupInterval <= 0 {
+		managedSharedDBFailedCleanupInterval = DefaultManagedSharedDBFailedCleanupInterval
+	}
+	managedSharedDBFailedCleanupBatchSize := cfg.ManagedSharedDBFailedCleanupBatchSize
+	if managedSharedDBFailedCleanupBatchSize <= 0 {
+		managedSharedDBFailedCleanupBatchSize = DefaultManagedSharedDBFailedCleanupBatchSize
+	}
 	defaultTenantProvider := strings.TrimSpace(cfg.DefaultTenantProvider)
 	if defaultTenantProvider == "" && cfg.Provisioner != nil {
 		defaultTenantProvider = cfg.Provisioner.ProviderType()
 	}
 	forkWorkerCtx, forkWorkerCancel := context.WithCancel(context.Background())
 	s := &Server{
-		fallback:                            cfg.Backend,
-		meta:                                cfg.Meta,
-		pool:                                cfg.Pool,
-		tokenSecret:                         cfg.TokenSecret,
-		localTenantAPIKey:                   strings.TrimSpace(cfg.LocalTenantAPIKey),
-		vaultMK:                             vaultMK,
-		vaultIssuerURL:                      strings.TrimSpace(cfg.VaultIssuerURL),
-		publicURL:                           strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
-		provisioner:                         cfg.Provisioner,
-		defaultTenantProvider:               defaultTenantProvider,
-		sharedDBMaxTenants:                  cfg.SharedDBMaxTenants,
-		sharedDBHardCapRatio:                sharedDBHardCapRatio,
-		sharedDBReopenRatio:                 sharedDBReopenRatio,
-		sharedDBSpendingLimit:               sharedDBSpendingLimit,
-		managedSharedDBCloudBatchSize:       managedSharedDBCloudBatchSize,
-		managedSharedDBRefillPoolLimit:      managedSharedDBRefillPoolLimit,
-		managedSharedDBMetadataWorkers:      managedSharedDBMetadataWorkers,
-		managedSharedDBMetadataBatchSize:    managedSharedDBMetadataBatchSize,
-		managedSharedDBMetadataPollInterval: managedSharedDBMetadataPollInterval,
-		managedSharedDBProvisioningWorkers:  managedSharedDBProvisioningWorkers,
-		managedSharedDBMetadataSlots:        make(chan struct{}, managedSharedDBMetadataWorkers),
-		managedSharedDBProvisioningSlots:    make(chan struct{}, managedSharedDBProvisioningWorkers),
-		legacyStarterProvisioner:            cfg.LegacyStarterProvisioner,
-		maxUploadBytes:                      maxUpload,
-		tenantPoolMaxSize:                   tenantPoolMaxSize,
-		tenantPoolRefillFreeRatio:           tenantPoolRefillFreeRatio,
-		inlineThreshold:                     inlineThreshold,
-		metrics:                             newServerMetrics(),
-		logger:                              logger,
-		events:                              newEventBuses(),
-		slockOAuth:                          cfg.SlockOAuth,
+		fallback:              cfg.Backend,
+		meta:                  cfg.Meta,
+		pool:                  cfg.Pool,
+		tokenSecret:           cfg.TokenSecret,
+		localTenantAPIKey:     strings.TrimSpace(cfg.LocalTenantAPIKey),
+		vaultMK:               vaultMK,
+		vaultIssuerURL:        strings.TrimSpace(cfg.VaultIssuerURL),
+		publicURL:             strings.TrimRight(strings.TrimSpace(cfg.PublicURL), "/"),
+		provisioner:           cfg.Provisioner,
+		defaultTenantProvider: defaultTenantProvider,
+		sharedDBMaxTenants:    cfg.SharedDBMaxTenants,
+		sharedDBHardCapRatio:  sharedDBHardCapRatio,
+		sharedDBReopenRatio:   sharedDBReopenRatio,
+		sharedDBSpendingLimit: sharedDBSpendingLimit,
+
+		managedSharedDBCloudBatchSize:         managedSharedDBCloudBatchSize,
+		managedSharedDBRefillPoolLimit:        managedSharedDBRefillPoolLimit,
+		managedSharedDBMetadataWorkers:        managedSharedDBMetadataWorkers,
+		managedSharedDBMetadataBatchSize:      managedSharedDBMetadataBatchSize,
+		managedSharedDBMetadataPollInterval:   managedSharedDBMetadataPollInterval,
+		managedSharedDBProvisioningWorkers:    managedSharedDBProvisioningWorkers,
+		tenantPoolReconcileInterval:           tenantPoolReconcileInterval,
+		tenantPoolReconcileWorkers:            tenantPoolReconcileWorkers,
+		tenantPoolReconcileSlots:              make(chan struct{}, tenantPoolReconcileWorkers),
+		managedSharedDBStuckTimeout:           managedSharedDBStuckTimeout,
+		managedSharedDBFailedCleanupInterval:  managedSharedDBFailedCleanupInterval,
+		managedSharedDBFailedCleanupBatchSize: managedSharedDBFailedCleanupBatchSize,
+		managedSharedDBMetadataSlots:          make(chan struct{}, managedSharedDBMetadataWorkers),
+		managedSharedDBProvisioningSlots:      make(chan struct{}, managedSharedDBProvisioningWorkers),
+
+		legacyStarterProvisioner:  cfg.LegacyStarterProvisioner,
+		maxUploadBytes:            maxUpload,
+		tenantPoolMaxSize:         tenantPoolMaxSize,
+		tenantPoolRefillFreeRatio: tenantPoolRefillFreeRatio,
+		inlineThreshold:           inlineThreshold,
+		metrics:                   newServerMetrics(),
+		logger:                    logger,
+		events:                    newEventBuses(),
+		slockOAuth:                cfg.SlockOAuth,
 		tidbAutoEmbedding: tenantAutoEmbeddingDefault{
 			config:  defaultTiDBAutoEmbeddingConfig(cfg.TiDBAutoEmbeddingConfig),
 			apiKey:  strings.TrimSpace(cfg.TiDBAutoEmbeddingAPIKey),
@@ -954,6 +1006,15 @@ func (s *Server) startLeaderWorkers() {
 		}
 		startManagedSharedDBResumeLoop(s.resumePendingManagedSharedDBPoolsWithCtx)
 		startManagedSharedDBResumeLoop(s.resumeProvisioningManagedSharedDBPoolsWithCtx)
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			runManagedSharedDBResumeLoop(workerCtx, s.tenantPoolReconcileInterval, s.reconcileStuckManagedSharedDBPoolsWithCtx)
+		})
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			runManagedSharedDBResumeLoop(workerCtx, s.tenantPoolReconcileInterval, s.reconcileSharedTenantPoolsWithCtx)
+		})
+		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
+			runManagedSharedDBResumeLoop(workerCtx, s.managedSharedDBFailedCleanupInterval, s.cleanupFailedManagedSharedDBPoolsWithCtx)
+		})
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
 			s.resumeDeletingForkTenantsWithCtx(workerCtx)
 		})
@@ -4713,7 +4774,6 @@ func (s *Server) handleProvision(w http.ResponseWriter, r *http.Request) {
 			if res.Status == meta.TenantProvisioning {
 				s.startProvisionedTenantSchemaInit(r.Context(), res)
 			}
-			s.replenishTenantPoolAsync(r.Context(), pool, *credentialReq)
 			if quotaReq != nil && quotaReq.TiDBCloudSpendingLimit != nil {
 				metricEvent(r.Context(), "tenant_provision", "provider", provider, "quota", "create_time_spending_limit")
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -69,7 +69,6 @@ type Config struct {
 	TenantPoolReconcileInterval           time.Duration
 	TenantPoolReconcileWorkers            int
 	TenantPoolReconcileWorkerRest         time.Duration
-	ManagedSharedDBPlannedCapacityLease   time.Duration
 	ManagedSharedDBStuckTimeout           time.Duration
 	ManagedSharedDBFailedCleanupInterval  time.Duration
 	ManagedSharedDBFailedCleanupBatchSize int
@@ -221,8 +220,6 @@ type Server struct {
 	tenantPoolReconcileQueue                chan tenantPoolReconcileJob
 	tenantPoolReconcileWorkerRest           time.Duration
 	tenantPoolLeaderReconcileJobs           sync.Map
-	sharedTenantPoolCreateSlots             chan struct{}
-	managedSharedDBPlannedCapacityLease     time.Duration
 	managedSharedDBStuckTimeout             time.Duration
 	managedSharedDBMetadataSlots            chan struct{}
 	managedSharedDBProvisioningSlots        chan struct{}
@@ -233,6 +230,7 @@ type Server struct {
 	managedSharedDBFailedCleanupCursor      int64
 	managedSharedDBPendingResumeCursor      int64
 	managedSharedDBProvisioningResumeCursor int64
+	managedSharedDBActivationResumeCursor   int64
 
 	legacyStarterProvisioner  tenant.Provisioner
 	tokenSecret               []byte
@@ -372,7 +370,6 @@ const (
 	DefaultTenantPoolReconcileInterval           = 5 * time.Second
 	DefaultTenantPoolReconcileWorkers            = 15
 	DefaultTenantPoolReconcileWorkerRest         = 5 * time.Second
-	DefaultManagedSharedDBPlannedCapacityLease   = time.Minute
 	DefaultManagedSharedDBStuckTimeout           = 15 * time.Minute
 	DefaultManagedSharedDBFailedCleanupInterval  = time.Minute
 	DefaultManagedSharedDBFailedCleanupBatchSize = 5
@@ -495,10 +492,6 @@ func NewWithConfig(cfg Config) *Server {
 	if tenantPoolReconcileWorkerRest <= 0 {
 		tenantPoolReconcileWorkerRest = DefaultTenantPoolReconcileWorkerRest
 	}
-	managedSharedDBPlannedCapacityLease := cfg.ManagedSharedDBPlannedCapacityLease
-	if managedSharedDBPlannedCapacityLease <= 0 {
-		managedSharedDBPlannedCapacityLease = DefaultManagedSharedDBPlannedCapacityLease
-	}
 	managedSharedDBStuckTimeout := cfg.ManagedSharedDBStuckTimeout
 	if managedSharedDBStuckTimeout <= 0 {
 		managedSharedDBStuckTimeout = DefaultManagedSharedDBStuckTimeout
@@ -542,8 +535,6 @@ func NewWithConfig(cfg Config) *Server {
 		tenantPoolReconcileWorkers:             tenantPoolReconcileWorkers,
 		tenantPoolReconcileQueue:               make(chan tenantPoolReconcileJob),
 		tenantPoolReconcileWorkerRest:          tenantPoolReconcileWorkerRest,
-		sharedTenantPoolCreateSlots:            make(chan struct{}, sharedTenantPoolCreateConcurrency),
-		managedSharedDBPlannedCapacityLease:    managedSharedDBPlannedCapacityLease,
 		managedSharedDBStuckTimeout:            managedSharedDBStuckTimeout,
 		managedSharedDBFailedCleanupInterval:   managedSharedDBFailedCleanupInterval,
 		managedSharedDBFailedCleanupBatchSize:  managedSharedDBFailedCleanupBatchSize,
@@ -1048,6 +1039,7 @@ func (s *Server) startLeaderWorkers() {
 		}
 		startManagedSharedDBResumeLoop(s.resumePendingManagedSharedDBPoolsWithCtx)
 		startManagedSharedDBResumeLoop(s.resumeProvisioningManagedSharedDBPoolsWithCtx)
+		startManagedSharedDBResumeLoop(s.resumeActiveManagedSharedDBTenantsWithCtx)
 		for range s.tenantPoolReconcileWorkers {
 			s.startLeaderGoroutine(leaderCtx, s.runTenantPoolReconcileWorker)
 		}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -215,6 +215,7 @@ type Server struct {
 	managedSharedDBMetadataBatchSize        int
 	managedSharedDBMetadataPollInterval     time.Duration
 	managedSharedDBProvisioningWorkers      int
+	managedSharedDBProvisioningConcurrency  int
 	tenantPoolReconcileInterval             time.Duration
 	tenantPoolReconcileWorkers              int
 	tenantPoolReconcileSlots                chan struct{}
@@ -476,6 +477,11 @@ func NewWithConfig(cfg Config) *Server {
 	if managedSharedDBProvisioningWorkers <= 0 {
 		managedSharedDBProvisioningWorkers = DefaultManagedSharedDBProvisioningWorkers
 	}
+	managedSharedDBProvisioningConcurrency := managedSharedDBProvisioningWorkers
+	if cfg.Meta != nil && cfg.Meta.DB() != nil {
+		managedSharedDBProvisioningConcurrency = limitManagedSharedDBProvisioningWorkers(
+			managedSharedDBProvisioningWorkers, cfg.Meta.DB().Stats().MaxOpenConnections)
+	}
 	tenantPoolReconcileInterval := cfg.TenantPoolReconcileInterval
 	if tenantPoolReconcileInterval <= 0 {
 		tenantPoolReconcileInterval = DefaultTenantPoolReconcileInterval
@@ -517,20 +523,21 @@ func NewWithConfig(cfg Config) *Server {
 		sharedDBReopenRatio:   sharedDBReopenRatio,
 		sharedDBSpendingLimit: sharedDBSpendingLimit,
 
-		managedSharedDBCloudBatchSize:         managedSharedDBCloudBatchSize,
-		managedSharedDBRefillPoolLimit:        managedSharedDBRefillPoolLimit,
-		managedSharedDBMetadataWorkers:        managedSharedDBMetadataWorkers,
-		managedSharedDBMetadataBatchSize:      managedSharedDBMetadataBatchSize,
-		managedSharedDBMetadataPollInterval:   managedSharedDBMetadataPollInterval,
-		managedSharedDBProvisioningWorkers:    managedSharedDBProvisioningWorkers,
-		tenantPoolReconcileInterval:           tenantPoolReconcileInterval,
-		tenantPoolReconcileWorkers:            tenantPoolReconcileWorkers,
-		tenantPoolReconcileSlots:              make(chan struct{}, tenantPoolReconcileWorkers),
-		managedSharedDBStuckTimeout:           managedSharedDBStuckTimeout,
-		managedSharedDBFailedCleanupInterval:  managedSharedDBFailedCleanupInterval,
-		managedSharedDBFailedCleanupBatchSize: managedSharedDBFailedCleanupBatchSize,
-		managedSharedDBMetadataSlots:          make(chan struct{}, managedSharedDBMetadataWorkers),
-		managedSharedDBProvisioningSlots:      make(chan struct{}, managedSharedDBProvisioningWorkers),
+		managedSharedDBCloudBatchSize:          managedSharedDBCloudBatchSize,
+		managedSharedDBRefillPoolLimit:         managedSharedDBRefillPoolLimit,
+		managedSharedDBMetadataWorkers:         managedSharedDBMetadataWorkers,
+		managedSharedDBMetadataBatchSize:       managedSharedDBMetadataBatchSize,
+		managedSharedDBMetadataPollInterval:    managedSharedDBMetadataPollInterval,
+		managedSharedDBProvisioningWorkers:     managedSharedDBProvisioningWorkers,
+		managedSharedDBProvisioningConcurrency: managedSharedDBProvisioningConcurrency,
+		tenantPoolReconcileInterval:            tenantPoolReconcileInterval,
+		tenantPoolReconcileWorkers:             tenantPoolReconcileWorkers,
+		tenantPoolReconcileSlots:               make(chan struct{}, tenantPoolReconcileWorkers),
+		managedSharedDBStuckTimeout:            managedSharedDBStuckTimeout,
+		managedSharedDBFailedCleanupInterval:   managedSharedDBFailedCleanupInterval,
+		managedSharedDBFailedCleanupBatchSize:  managedSharedDBFailedCleanupBatchSize,
+		managedSharedDBMetadataSlots:           make(chan struct{}, managedSharedDBMetadataWorkers),
+		managedSharedDBProvisioningSlots:       make(chan struct{}, managedSharedDBProvisioningConcurrency),
 
 		legacyStarterProvisioner:  cfg.LegacyStarterProvisioner,
 		maxUploadBytes:            maxUpload,
@@ -736,6 +743,20 @@ func normalizeTenantPoolRefillFreeRatio(ratio float64) float64 {
 		return DefaultTenantPoolRefillFreeRatio
 	}
 	return ratio
+}
+
+// limitManagedSharedDBProvisioningWorkers reserves half of the metadb pool for
+// callback queries and unrelated control-plane traffic. Each active schema
+// worker holds one session connection for GET_LOCK while its callback performs
+// ordinary Store operations through another connection from the same pool.
+func limitManagedSharedDBProvisioningWorkers(configured, maxOpen int) int {
+	if configured <= 0 {
+		return 0
+	}
+	if maxOpen <= 0 {
+		return configured
+	}
+	return min(configured, maxOpen/2)
 }
 
 // insertTenantNotify records a best-effort unified outbox signal so other

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -210,6 +210,8 @@ type Server struct {
 	sharedDBSpendingLimit int64
 
 	managedSharedDBCloudBatchSize           int
+	managedSharedDBCloudBatchSlots          chan struct{}
+	managedSharedDBCloudBatchSlotsOnce      sync.Once
 	managedSharedDBMetadataWorkers          int
 	managedSharedDBMetadataBatchSize        int
 	managedSharedDBMetadataPollInterval     time.Duration
@@ -363,6 +365,7 @@ const DefaultManagedSharedDBSpendingLimit = int64(1_000_000)
 
 const (
 	DefaultManagedSharedDBCloudBatchSize         = 50
+	defaultManagedSharedDBCloudBatchConcurrency  = 5
 	DefaultManagedSharedDBMetadataWorkers        = 15
 	DefaultManagedSharedDBMetadataBatchSize      = 30
 	DefaultManagedSharedDBMetadataPollInterval   = 15 * time.Second

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -259,6 +259,7 @@ type Server struct {
 	tenantPoolReplenishJobs   sync.Map
 	tenantPoolCreateLocks     sync.Map
 	sharedDBAllocationLocks   sync.Map
+	sharedDBReservationLocks  sync.Map
 	tenantPoolResumeJobs      sync.Map
 	tenantPoolResumeScans     sync.Map
 	tenantFailedCleanupJobs   sync.Map

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -55,11 +55,10 @@ type Config struct {
 	SharedDBReopenRatio   float64
 	SharedDBSpendingLimit int64
 	// Managed shared-pool concurrency and polling controls. Zero values use
-	// the exported defaults below. CloudBatchSize, MetadataWorkers, and
-	// MetadataBatchSize are safety-capped at their defaults; RefillPoolLimit
-	// and ProvisioningWorkers accept larger configured values.
+	// the exported defaults below. MetadataWorkers and MetadataBatchSize are
+	// safety-capped at their defaults; CloudBatchSize and ProvisioningWorkers
+	// accept larger configured values.
 	ManagedSharedDBCloudBatchSize       int
-	ManagedSharedDBRefillPoolLimit      int
 	ManagedSharedDBMetadataWorkers      int
 	ManagedSharedDBMetadataBatchSize    int
 	ManagedSharedDBMetadataPollInterval time.Duration
@@ -69,6 +68,8 @@ type Config struct {
 	// pending/provisioning status. Failed cleanup has its own low-rate worker.
 	TenantPoolReconcileInterval           time.Duration
 	TenantPoolReconcileWorkers            int
+	TenantPoolReconcileWorkerRest         time.Duration
+	ManagedSharedDBPlannedCapacityLease   time.Duration
 	ManagedSharedDBStuckTimeout           time.Duration
 	ManagedSharedDBFailedCleanupInterval  time.Duration
 	ManagedSharedDBFailedCleanupBatchSize int
@@ -210,7 +211,6 @@ type Server struct {
 	sharedDBSpendingLimit int64
 
 	managedSharedDBCloudBatchSize           int
-	managedSharedDBRefillPoolLimit          int
 	managedSharedDBMetadataWorkers          int
 	managedSharedDBMetadataBatchSize        int
 	managedSharedDBMetadataPollInterval     time.Duration
@@ -218,7 +218,9 @@ type Server struct {
 	managedSharedDBProvisioningConcurrency  int
 	tenantPoolReconcileInterval             time.Duration
 	tenantPoolReconcileWorkers              int
-	tenantPoolReconcileSlots                chan struct{}
+	tenantPoolReconcileQueue                chan tenantPoolReconcileJob
+	tenantPoolReconcileWorkerRest           time.Duration
+	managedSharedDBPlannedCapacityLease     time.Duration
 	managedSharedDBStuckTimeout             time.Duration
 	managedSharedDBMetadataSlots            chan struct{}
 	managedSharedDBProvisioningSlots        chan struct{}
@@ -277,6 +279,7 @@ type Server struct {
 	leaderWorkerWG       sync.WaitGroup
 	leaderWorkerMu       sync.Mutex
 	leaderWorkersStarted bool
+	leaderWorkerStopDone chan struct{}
 	// replayWorker and expirySweepWorker are leader-gated central quota
 	// workers owned by the server (single callback owner). Started in
 	// startLeaderWorkers and stopped in stopLeaderWorkers so they follow
@@ -359,14 +362,15 @@ const DefaultSharedDBReopenRatio = 0.8
 const DefaultManagedSharedDBSpendingLimit = int64(1_000_000)
 
 const (
-	DefaultManagedSharedDBCloudBatchSize         = 10
-	DefaultManagedSharedDBRefillPoolLimit        = 50
+	DefaultManagedSharedDBCloudBatchSize         = 50
 	DefaultManagedSharedDBMetadataWorkers        = 15
 	DefaultManagedSharedDBMetadataBatchSize      = 30
 	DefaultManagedSharedDBMetadataPollInterval   = 15 * time.Second
 	DefaultManagedSharedDBProvisioningWorkers    = 100
-	DefaultTenantPoolReconcileInterval           = 15 * time.Second
-	DefaultTenantPoolReconcileWorkers            = 10
+	DefaultTenantPoolReconcileInterval           = 5 * time.Second
+	DefaultTenantPoolReconcileWorkers            = 15
+	DefaultTenantPoolReconcileWorkerRest         = 5 * time.Second
+	DefaultManagedSharedDBPlannedCapacityLease   = time.Minute
 	DefaultManagedSharedDBStuckTimeout           = 15 * time.Minute
 	DefaultManagedSharedDBFailedCleanupInterval  = time.Minute
 	DefaultManagedSharedDBFailedCleanupBatchSize = 5
@@ -454,11 +458,6 @@ func NewWithConfig(cfg Config) *Server {
 	if managedSharedDBCloudBatchSize <= 0 {
 		managedSharedDBCloudBatchSize = DefaultManagedSharedDBCloudBatchSize
 	}
-	managedSharedDBCloudBatchSize = min(managedSharedDBCloudBatchSize, DefaultManagedSharedDBCloudBatchSize)
-	managedSharedDBRefillPoolLimit := cfg.ManagedSharedDBRefillPoolLimit
-	if managedSharedDBRefillPoolLimit <= 0 {
-		managedSharedDBRefillPoolLimit = DefaultManagedSharedDBRefillPoolLimit
-	}
 	managedSharedDBMetadataWorkers := cfg.ManagedSharedDBMetadataWorkers
 	if managedSharedDBMetadataWorkers <= 0 {
 		managedSharedDBMetadataWorkers = DefaultManagedSharedDBMetadataWorkers
@@ -489,6 +488,14 @@ func NewWithConfig(cfg Config) *Server {
 	tenantPoolReconcileWorkers := cfg.TenantPoolReconcileWorkers
 	if tenantPoolReconcileWorkers <= 0 {
 		tenantPoolReconcileWorkers = DefaultTenantPoolReconcileWorkers
+	}
+	tenantPoolReconcileWorkerRest := cfg.TenantPoolReconcileWorkerRest
+	if tenantPoolReconcileWorkerRest <= 0 {
+		tenantPoolReconcileWorkerRest = DefaultTenantPoolReconcileWorkerRest
+	}
+	managedSharedDBPlannedCapacityLease := cfg.ManagedSharedDBPlannedCapacityLease
+	if managedSharedDBPlannedCapacityLease <= 0 {
+		managedSharedDBPlannedCapacityLease = DefaultManagedSharedDBPlannedCapacityLease
 	}
 	managedSharedDBStuckTimeout := cfg.ManagedSharedDBStuckTimeout
 	if managedSharedDBStuckTimeout <= 0 {
@@ -524,7 +531,6 @@ func NewWithConfig(cfg Config) *Server {
 		sharedDBSpendingLimit: sharedDBSpendingLimit,
 
 		managedSharedDBCloudBatchSize:          managedSharedDBCloudBatchSize,
-		managedSharedDBRefillPoolLimit:         managedSharedDBRefillPoolLimit,
 		managedSharedDBMetadataWorkers:         managedSharedDBMetadataWorkers,
 		managedSharedDBMetadataBatchSize:       managedSharedDBMetadataBatchSize,
 		managedSharedDBMetadataPollInterval:    managedSharedDBMetadataPollInterval,
@@ -532,7 +538,9 @@ func NewWithConfig(cfg Config) *Server {
 		managedSharedDBProvisioningConcurrency: managedSharedDBProvisioningConcurrency,
 		tenantPoolReconcileInterval:            tenantPoolReconcileInterval,
 		tenantPoolReconcileWorkers:             tenantPoolReconcileWorkers,
-		tenantPoolReconcileSlots:               make(chan struct{}, tenantPoolReconcileWorkers),
+		tenantPoolReconcileQueue:               make(chan tenantPoolReconcileJob),
+		tenantPoolReconcileWorkerRest:          tenantPoolReconcileWorkerRest,
+		managedSharedDBPlannedCapacityLease:    managedSharedDBPlannedCapacityLease,
 		managedSharedDBStuckTimeout:            managedSharedDBStuckTimeout,
 		managedSharedDBFailedCleanupInterval:   managedSharedDBFailedCleanupInterval,
 		managedSharedDBFailedCleanupBatchSize:  managedSharedDBFailedCleanupBatchSize,
@@ -996,11 +1004,20 @@ func runManagedSharedDBResumeLoop(ctx context.Context, interval time.Duration, r
 // running. The mutex is held for the entire transition so that a concurrent
 // stopLeaderWorkers observes the fully-started worker set (not a partial one).
 func (s *Server) startLeaderWorkers() {
-	s.leaderWorkerMu.Lock()
-	defer s.leaderWorkerMu.Unlock()
-	if s.leaderWorkersStarted {
-		return
+	for {
+		s.leaderWorkerMu.Lock()
+		if s.leaderWorkersStarted {
+			s.leaderWorkerMu.Unlock()
+			return
+		}
+		if stopDone := s.leaderWorkerStopDone; stopDone != nil {
+			s.leaderWorkerMu.Unlock()
+			<-stopDone
+			continue
+		}
+		break
 	}
+	defer s.leaderWorkerMu.Unlock()
 	s.leaderWorkersStarted = true
 	// Create a fresh leaderWorkerCtx for the fork-worker group and one-time
 	// resume tasks. These use leaderWorkerCtx (not forkWorkerCtx, which is
@@ -1028,6 +1045,9 @@ func (s *Server) startLeaderWorkers() {
 		}
 		startManagedSharedDBResumeLoop(s.resumePendingManagedSharedDBPoolsWithCtx)
 		startManagedSharedDBResumeLoop(s.resumeProvisioningManagedSharedDBPoolsWithCtx)
+		for range s.tenantPoolReconcileWorkers {
+			s.startLeaderGoroutine(leaderCtx, s.runTenantPoolReconcileWorker)
+		}
 		s.startLeaderGoroutine(leaderCtx, func(workerCtx context.Context) {
 			runManagedSharedDBResumeLoop(workerCtx, s.tenantPoolReconcileInterval, s.reconcileStuckManagedSharedDBPoolsWithCtx)
 		})
@@ -1198,27 +1218,33 @@ func (s *Server) cleanupTenantNotifyOutbox(ctx context.Context) {
 }
 
 // stopLeaderWorkers stops the background schedulers started by startLeaderWorkers.
-// Called when the pod loses leadership or the server shuts down. The whole stop
-// (including the worker Stop/wait calls and clearing the worker fields) is
-// serialized under leaderWorkerMu and guarded by leaderWorkersStarted, so
-// onLose (heartbeat goroutine), Close() (main goroutine), and a concurrent
-// startLeaderWorkers cannot interleave. Holding the mutex for the entire
-// transition guarantees a concurrent startLeaderWorkers observes the
-// fully-stopped state (leaderWorkersStarted == false) and does not leave
-// orphan workers that a stop already ran past.
+// Called when the pod loses leadership or the server shuts down. Lifecycle
+// state is detached under leaderWorkerMu, but cancellation and Wait happen
+// outside it so an exiting worker can safely check leader admission. A
+// concurrent start waits on leaderWorkerStopDone before creating a new worker
+// generation, so old teardown cannot stop newly-started singleton workers.
 func (s *Server) stopLeaderWorkers() {
 	s.leaderWorkerMu.Lock()
-	defer s.leaderWorkerMu.Unlock()
+	if stopDone := s.leaderWorkerStopDone; stopDone != nil {
+		s.leaderWorkerMu.Unlock()
+		<-stopDone
+		return
+	}
 	if !s.leaderWorkersStarted {
+		s.leaderWorkerMu.Unlock()
 		return
 	}
 	s.leaderWorkersStarted = false
+	stopDone := make(chan struct{})
+	s.leaderWorkerStopDone = stopDone
 	cancel := s.leaderWorkerCancel
 	s.leaderWorkerCancel = nil
+	s.leaderWorkerCtx = nil
 	replayWorker := s.replayWorker
 	s.replayWorker = nil
 	expirySweepWorker := s.expirySweepWorker
 	s.expirySweepWorker = nil
+	s.leaderWorkerMu.Unlock()
 
 	if cancel != nil {
 		cancel()
@@ -1243,6 +1269,12 @@ func (s *Server) stopLeaderWorkers() {
 	if s.objectGCWorker != nil {
 		s.objectGCWorker.Stop()
 	}
+	s.leaderWorkerMu.Lock()
+	if s.leaderWorkerStopDone == stopDone {
+		s.leaderWorkerStopDone = nil
+		close(stopDone)
+	}
+	s.leaderWorkerMu.Unlock()
 }
 
 // startLeaderGoroutine launches a goroutine that runs fn under the leader

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -637,6 +637,27 @@ func withManagedSharedDBMetadataRefillSlot(ctx context.Context, slot chan struct
 	return nil
 }
 
+func (s *Server) nextManagedSharedDBStatusPage(ctx context.Context, status string, cursor *int64, limit int) ([]*meta.SharedDB, error) {
+	if cursor == nil {
+		return nil, fmt.Errorf("shared db status cursor is required")
+	}
+	rows, err := s.meta.ListSharedDBsByStatusAfter(ctx, status, *cursor, limit)
+	if err != nil {
+		return nil, err
+	}
+	if len(rows) == 0 && *cursor > 0 {
+		*cursor = 0
+		rows, err = s.meta.ListSharedDBsByStatusAfter(ctx, status, 0, limit)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(rows) > 0 {
+		*cursor = rows[len(rows)-1].ID
+	}
+	return rows, nil
+}
+
 func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows []*meta.SharedDB, onReady func([]int64)) {
 	owned := make([]*meta.SharedDB, 0, len(rows))
 	for _, row := range rows {
@@ -682,6 +703,10 @@ func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows 
 	for _, row := range owned {
 		known[row.ID] = struct{}{}
 	}
+	var refillAfterID int64
+	for _, row := range owned {
+		refillAfterID = max(refillAfterID, row.ID)
+	}
 	var queueMu sync.Mutex
 	refillSlot := make(chan struct{}, 1)
 	takeLocked := func(limit int) []*meta.SharedDB {
@@ -714,7 +739,7 @@ func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows 
 			}
 			queueMu.Unlock()
 
-			fresh, listErr := s.meta.ListSharedDBsByStatus(ctx, meta.SharedDBStatusPending, 1000)
+			fresh, listErr := s.nextManagedSharedDBStatusPage(ctx, meta.SharedDBStatusPending, &refillAfterID, 1000)
 			if listErr != nil {
 				logger.Warn(ctx, "managed_shared_db_pool_metadata_refill_failed", zap.Error(listErr))
 			}
@@ -822,7 +847,7 @@ func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows 
 }
 
 func (s *Server) resumeProvisioningManagedSharedDBPoolsWithCtx(ctx context.Context) {
-	rows, err := s.meta.ListSharedDBsByStatus(ctx, meta.SharedDBStatusProvisioning, 1000)
+	rows, err := s.nextManagedSharedDBStatusPage(ctx, meta.SharedDBStatusProvisioning, &s.managedSharedDBProvisioningResumeCursor, 1000)
 	if err != nil {
 		logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.String("status", meta.SharedDBStatusProvisioning), zap.Error(err))
 		return
@@ -835,7 +860,7 @@ func (s *Server) resumeProvisioningManagedSharedDBPoolsWithCtx(ctx context.Conte
 }
 
 func (s *Server) resumePendingManagedSharedDBPoolsWithCtx(ctx context.Context) {
-	rows, err := s.meta.ListSharedDBsByStatus(ctx, meta.SharedDBStatusPending, 1000)
+	rows, err := s.nextManagedSharedDBStatusPage(ctx, meta.SharedDBStatusPending, &s.managedSharedDBPendingResumeCursor, 1000)
 	if err != nil {
 		logger.Warn(ctx, "managed_shared_db_pool_resume_list_failed", zap.String("status", meta.SharedDBStatusPending), zap.Error(err))
 		return

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -210,18 +210,29 @@ func generateManagedSharedDBRootPassword(length int) (string, error) {
 }
 
 func (s *Server) materializeSharedTenantQuota(ctx context.Context, tenantID string, opts provisionTenantOptions) error {
+	cfg, err := s.sharedTenantQuotaConfig(tenantID, opts)
+	if err != nil {
+		return err
+	}
+	if err := s.meta.SetQuotaConfig(ctx, cfg); err != nil {
+		return fmt.Errorf("materialize shared tenant quota: %w", err)
+	}
+	return nil
+}
+
+func (s *Server) sharedTenantQuotaConfig(tenantID string, opts provisionTenantOptions) (*meta.QuotaConfig, error) {
 	virtualLimit := s.sharedTenantVirtualSpendingLimit(opts)
 	var patch meta.QuotaConfigPatch
 	if opts.Quota != nil {
 		req := *opts.Quota
 		req.TenantID = tenantID
 		if err := s.validateQuotaSetRequest(req); err != nil {
-			return err
+			return nil, err
 		}
 		var err error
 		patch, err = quotaConfigPatchFromRequest(req)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 	cfg := &meta.QuotaConfig{
@@ -242,10 +253,7 @@ func (s *Server) materializeSharedTenantQuota(ctx context.Context, tenantID stri
 	if patch.MaxFileCount != nil {
 		cfg.MaxFileCount = *patch.MaxFileCount
 	}
-	if err := s.meta.SetQuotaConfig(ctx, cfg); err != nil {
-		return fmt.Errorf("materialize shared tenant quota: %w", err)
-	}
-	return nil
+	return cfg, nil
 }
 
 func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.CredentialProvisionRequest, reserve func(*meta.SharedDB) error) (sharedDB *meta.SharedDB, created bool, err error) {
@@ -927,6 +935,40 @@ func (s *Server) resumeProvisioningManagedSharedDBPoolsWithCtx(ctx context.Conte
 		ids = append(ids, row.ID)
 	}
 	s.runManagedSharedDBProvisioning(ctx, ids)
+}
+
+func (s *Server) resumeActiveManagedSharedDBTenantsWithCtx(ctx context.Context) {
+	rows, err := s.meta.ListActiveSharedDBsWithProvisioningTenantsAfter(ctx, s.managedSharedDBActivationResumeCursor, 1000)
+	if err != nil {
+		logger.Warn(ctx, "managed_shared_db_pool_activation_resume_list_failed", zap.Error(err))
+		return
+	}
+	if len(rows) == 0 && s.managedSharedDBActivationResumeCursor > 0 {
+		s.managedSharedDBActivationResumeCursor = 0
+		rows, err = s.meta.ListActiveSharedDBsWithProvisioningTenantsAfter(ctx, 0, 1000)
+		if err != nil {
+			logger.Warn(ctx, "managed_shared_db_pool_activation_resume_list_failed", zap.Error(err))
+			return
+		}
+	}
+	if len(rows) > 0 && len(rows) < 1000 {
+		s.managedSharedDBActivationResumeCursor = 0
+	} else if len(rows) > 0 {
+		s.managedSharedDBActivationResumeCursor = rows[len(rows)-1].ID
+	}
+	for _, row := range rows {
+		for {
+			activated, activateErr := s.meta.ActivateSharedTenantsBatch(ctx, row.ID, sharedTenantActivationBatchSize)
+			if activateErr != nil {
+				logger.Warn(ctx, "managed_shared_db_pool_activation_resume_failed",
+					zap.Int64("db_pool_id", row.ID), zap.String("db_pool_uuid", row.UUID), zap.Error(activateErr))
+				break
+			}
+			if activated < sharedTenantActivationBatchSize {
+				break
+			}
+		}
+	}
 }
 
 func (s *Server) resumePendingManagedSharedDBPoolsWithCtx(ctx context.Context) {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -858,7 +858,6 @@ func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows 
 				infos, loadErr := loader.BatchLoadSharedDBPoolsWithCredentials(ctx, requests, cred)
 				ready := make(map[int64]struct{}, len(infos))
 				readyIDs := make([]int64, 0, len(infos))
-				heartbeatIDs := make([]int64, 0, len(infos))
 				for _, info := range infos {
 					if info == nil {
 						continue
@@ -868,9 +867,9 @@ func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows 
 						continue
 					}
 					if strings.TrimSpace(info.Host) == "" || info.Port <= 0 || strings.TrimSpace(info.Username) == "" {
-						if strings.TrimSpace(info.ClusterID) != "" {
-							heartbeatIDs = append(heartbeatIDs, row.ID)
-						}
+						// Seeing the same incomplete Cloud object is not durable
+						// lifecycle progress. Preserve updated_at so the stuck
+						// watchdog can expire a pool whose metadata never becomes ready.
 						continue
 					}
 					name := info.DBName
@@ -883,12 +882,6 @@ func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows 
 					}
 					ready[row.ID] = struct{}{}
 					readyIDs = append(readyIDs, row.ID)
-				}
-				if len(heartbeatIDs) > 0 {
-					if err := s.meta.TouchManagedSharedDBPools(ctx, heartbeatIDs, meta.SharedDBStatusPending); err != nil {
-						logger.Warn(ctx, "managed_shared_db_pool_metadata_heartbeat_failed",
-							zap.Int("db_pool_count", len(heartbeatIDs)), zap.Error(err))
-					}
 				}
 				if loadErr != nil {
 					logger.Warn(ctx, "managed_shared_db_pool_metadata_retry", zap.Int("attempt", attempt), zap.Int("db_pool_count", len(group)), zap.Duration("retry_in", pollInterval), zap.Error(loadErr))

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -146,6 +146,16 @@ func (s *Server) withSharedDBAllocationLock(ctx context.Context, identity string
 	return s.meta.WithSharedDBAllocationLock(ctx, identity, fn)
 }
 
+func (s *Server) withSharedDBPoolWorkLock(ctx context.Context, dbID int64, fn func(context.Context) error) error {
+	identity := fmt.Sprintf("pool-work:%d", dbID)
+	localLock, err := acquireSharedDBLocalLock(ctx, &s.sharedDBAllocationLocks, identity)
+	if err != nil {
+		return err
+	}
+	defer releaseSharedDBLocalLock(&s.sharedDBAllocationLocks, identity, localLock, true)
+	return s.meta.WithSharedDBPoolWorkLock(ctx, dbID, fn)
+}
+
 func (s *Server) withSharedDBReservationLock(ctx context.Context, identity string, fn func() error) error {
 	localLock, err := acquireSharedDBLocalLock(ctx, &s.sharedDBReservationLocks, identity)
 	if err != nil {
@@ -941,12 +951,8 @@ func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64
 		if err != nil {
 			return err
 		}
-		identity := sharedDBAllocationIdentity(poolInfo.TiDBCloudOrganizationID, poolInfo.ProvisioningKey)
-		if strings.TrimSpace(poolInfo.ClusterID) != "" {
-			identity = fmt.Sprintf("%s:db_pool:%d", identity, poolInfo.ID)
-		}
 		restartWithOrganization := false
-		err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+		continuePool := func(lockCtx context.Context) error {
 			current, loadErr := s.meta.GetSharedDB(lockCtx, dbID)
 			if loadErr != nil {
 				return loadErr
@@ -956,7 +962,8 @@ func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64
 				return nil
 			}
 			return s.continueManagedSharedDBPoolLocked(lockCtx, current, cred)
-		})
+		}
+		err = s.withSharedDBPoolWorkLock(ctx, dbID, continuePool)
 		if err != nil {
 			return err
 		}
@@ -1069,13 +1076,9 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) 
 		if err != nil {
 			return nil, err
 		}
-		identity := sharedDBAllocationIdentity(poolInfo.TiDBCloudOrganizationID, poolInfo.ProvisioningKey)
-		if strings.TrimSpace(poolInfo.ClusterID) != "" {
-			identity = fmt.Sprintf("%s:db_pool:%d", identity, poolInfo.ID)
-		}
 		var result *meta.SharedDB
 		restartWithOrganization := false
-		err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+		ensurePool := func(lockCtx context.Context) error {
 			current, loadErr := s.meta.GetSharedDB(lockCtx, dbID)
 			if loadErr != nil {
 				return loadErr
@@ -1087,7 +1090,8 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) 
 			var ensureErr error
 			result, ensureErr = s.ensureManagedSharedDBPhysicalLocked(lockCtx, current, cred)
 			return ensureErr
-		})
+		}
+		err = s.withSharedDBPoolWorkLock(ctx, dbID, ensurePool)
 		if err != nil {
 			return nil, err
 		}
@@ -1098,11 +1102,10 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) 
 	return nil, fmt.Errorf("db pool %d allocation identity kept changing", dbID)
 }
 
-// continueManagedSharedDBPoolLocked keeps one durable allocation lock through
-// physical ensure, schema ensure, and activation. Pools with a known cluster
-// ID use a per-pool lock so metadata and schema work can advance concurrently;
-// pools without a cluster ID retain the organization lock to prevent duplicate
-// physical creation.
+// continueManagedSharedDBPoolLocked keeps one per-pool lock through physical
+// ensure, schema ensure, and activation. It is the same work lock used by the
+// batch create path, preventing duplicate physical creation and overlapping
+// schema attempts without serializing unrelated pools in one organization.
 func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo *meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
 	dbID := poolInfo.ID
 	var err error

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -93,19 +93,19 @@ func sharedDBAllocationIdentity(organizationID string, provisioningKey []byte) s
 	return fmt.Sprintf("credential:%x", provisioningKey)
 }
 
-type sharedDBAllocationLocalLock struct {
+type sharedDBLocalLock struct {
 	mu        sync.Mutex
 	semaphore chan struct{}
 	refs      int
 }
 
-func (s *Server) acquireSharedDBAllocationLocalLock(ctx context.Context, identity string) (*sharedDBAllocationLocalLock, error) {
+func acquireSharedDBLocalLock(ctx context.Context, locks *sync.Map, identity string) (*sharedDBLocalLock, error) {
 	for {
-		candidate := &sharedDBAllocationLocalLock{semaphore: make(chan struct{}, 1)}
-		value, _ := s.sharedDBAllocationLocks.LoadOrStore(identity, candidate)
-		localLock := value.(*sharedDBAllocationLocalLock)
+		candidate := &sharedDBLocalLock{semaphore: make(chan struct{}, 1)}
+		value, _ := locks.LoadOrStore(identity, candidate)
+		localLock := value.(*sharedDBLocalLock)
 		localLock.mu.Lock()
-		current, loaded := s.sharedDBAllocationLocks.Load(identity)
+		current, loaded := locks.Load(identity)
 		if !loaded || current != localLock {
 			localLock.mu.Unlock()
 			continue
@@ -117,31 +117,40 @@ func (s *Server) acquireSharedDBAllocationLocalLock(ctx context.Context, identit
 		case localLock.semaphore <- struct{}{}:
 			return localLock, nil
 		case <-ctx.Done():
-			s.releaseSharedDBAllocationLocalLock(identity, localLock, false)
+			releaseSharedDBLocalLock(locks, identity, localLock, false)
 			return nil, ctx.Err()
 		}
 	}
 }
 
-func (s *Server) releaseSharedDBAllocationLocalLock(identity string, localLock *sharedDBAllocationLocalLock, held bool) {
+func releaseSharedDBLocalLock(locks *sync.Map, identity string, localLock *sharedDBLocalLock, held bool) {
 	if held {
 		<-localLock.semaphore
 	}
 	localLock.mu.Lock()
 	localLock.refs--
 	if localLock.refs == 0 {
-		s.sharedDBAllocationLocks.CompareAndDelete(identity, localLock)
+		locks.CompareAndDelete(identity, localLock)
 	}
 	localLock.mu.Unlock()
 }
 
 func (s *Server) withSharedDBAllocationLock(ctx context.Context, identity string, fn func(context.Context) error) error {
-	localLock, err := s.acquireSharedDBAllocationLocalLock(ctx, identity)
+	localLock, err := acquireSharedDBLocalLock(ctx, &s.sharedDBAllocationLocks, identity)
 	if err != nil {
 		return err
 	}
-	defer s.releaseSharedDBAllocationLocalLock(identity, localLock, true)
+	defer releaseSharedDBLocalLock(&s.sharedDBAllocationLocks, identity, localLock, true)
 	return s.meta.WithSharedDBAllocationLock(ctx, identity, fn)
+}
+
+func (s *Server) withSharedDBReservationLock(ctx context.Context, identity string, fn func() error) error {
+	localLock, err := acquireSharedDBLocalLock(ctx, &s.sharedDBReservationLocks, identity)
+	if err != nil {
+		return err
+	}
+	defer releaseSharedDBLocalLock(&s.sharedDBReservationLocks, identity, localLock, true)
+	return fn()
 }
 
 func managedSharedDBDSN(info *meta.SharedDB, password string) string {
@@ -236,30 +245,42 @@ func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.Creden
 }
 
 func (s *Server) allocateManagedSharedDBForOrganization(ctx context.Context, organizationID string, cred tenant.CredentialProvisionRequest, reserve func(*meta.SharedDB) error) (sharedDB *meta.SharedDB, created bool, err error) {
-	// Capacity reservation is transactional in CompleteSharedTenant* and does
-	// not need the organization-wide planning lock. This fast path lets tenant
-	// pool refill consume existing capacity concurrently; the lock below is
-	// reserved for planning a new physical pool.
-	if reserve != nil {
-		for attempt := 0; attempt < 2; attempt++ {
-			candidate, findErr := s.meta.FindSharedDBForAllocation(ctx, organizationID)
-			if errors.Is(findErr, meta.ErrNotFound) {
-				break
-			}
-			if findErr != nil {
-				return nil, false, findErr
-			}
-			reserveErr := reserve(candidate)
-			if reserveErr == nil {
-				return candidate, false, nil
-			}
-			if !errors.Is(reserveErr, meta.ErrSharedDBCapacityExhausted) {
-				return nil, false, reserveErr
-			}
-		}
-	}
 	provisioningKey := sharedDBProvisioningKey(cred)
 	identity := sharedDBAllocationIdentity(organizationID, provisioningKey)
+	// Capacity reservation is transactional in CompleteSharedTenant* and does
+	// not need the cross-pod organization-wide planning lock. Serialize only
+	// this Pod's same-organization lookup plus reservation so a refill wave does
+	// not send every tenant worker into the same nearly-full db_pool row. Other
+	// organizations and Pods remain independent; the lock below is reserved for
+	// planning a new physical pool.
+	if reserve != nil {
+		var reserved *meta.SharedDB
+		if err := s.withSharedDBReservationLock(ctx, identity, func() error {
+			for attempt := 0; attempt < 2; attempt++ {
+				candidate, findErr := s.meta.FindSharedDBForAllocation(ctx, organizationID)
+				if errors.Is(findErr, meta.ErrNotFound) {
+					return nil
+				}
+				if findErr != nil {
+					return findErr
+				}
+				reserveErr := reserve(candidate)
+				if reserveErr == nil {
+					reserved = candidate
+					return nil
+				}
+				if !errors.Is(reserveErr, meta.ErrSharedDBCapacityExhausted) {
+					return reserveErr
+				}
+			}
+			return nil
+		}); err != nil {
+			return nil, false, err
+		}
+		if reserved != nil {
+			return reserved, false, nil
+		}
+	}
 	err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
 		for attempt := 0; attempt < 2; attempt++ {
 			candidate, findErr := s.meta.FindSharedDBForAllocation(lockCtx, organizationID)

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -257,6 +257,19 @@ func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.Creden
 }
 
 func (s *Server) createManagedSharedDBPlan(ctx context.Context, organizationID string, provisioningKey []byte) (*meta.SharedDB, error) {
+	row, err := s.newManagedSharedDBPlan(ctx, organizationID, provisioningKey)
+	if err != nil {
+		return nil, err
+	}
+	id, err := s.meta.CreateManagedSharedDBPool(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	row.ID = id
+	return row, nil
+}
+
+func (s *Server) newManagedSharedDBPlan(ctx context.Context, organizationID string, provisioningKey []byte) (*meta.SharedDB, error) {
 	maxTenants, fixedTarget := s.managedSharedDBPolicy()
 	cloudProvider, region := provisioningCloudRegion(s.provisioner)
 	rootPassword, err := generateManagedSharedDBRootPassword(24)
@@ -280,11 +293,6 @@ func (s *Server) createManagedSharedDBPlan(ctx context.Context, organizationID s
 		Name:                    s.defaultSharedDatabaseName(),
 		Status:                  meta.SharedDBStatusPending,
 	}
-	id, err := s.meta.CreateManagedSharedDBPool(ctx, row)
-	if err != nil {
-		return nil, err
-	}
-	row.ID = id
 	return row, nil
 }
 
@@ -706,7 +714,9 @@ func (s *Server) nextManagedSharedDBStatusPage(ctx context.Context, status strin
 			return nil, err
 		}
 	}
-	if len(rows) > 0 {
+	if len(rows) > 0 && len(rows) < limit {
+		*cursor = 0
+	} else if len(rows) > 0 {
 		*cursor = rows[len(rows)-1].ID
 	}
 	return rows, nil
@@ -848,12 +858,19 @@ func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows 
 				infos, loadErr := loader.BatchLoadSharedDBPoolsWithCredentials(ctx, requests, cred)
 				ready := make(map[int64]struct{}, len(infos))
 				readyIDs := make([]int64, 0, len(infos))
+				heartbeatIDs := make([]int64, 0, len(infos))
 				for _, info := range infos {
 					if info == nil {
 						continue
 					}
 					row := byID[info.DBPoolID]
-					if row == nil || strings.TrimSpace(info.Host) == "" || info.Port <= 0 || strings.TrimSpace(info.Username) == "" {
+					if row == nil {
+						continue
+					}
+					if strings.TrimSpace(info.Host) == "" || info.Port <= 0 || strings.TrimSpace(info.Username) == "" {
+						if strings.TrimSpace(info.ClusterID) != "" {
+							heartbeatIDs = append(heartbeatIDs, row.ID)
+						}
 						continue
 					}
 					name := info.DBName
@@ -866,6 +883,12 @@ func (s *Server) pollManagedSharedDBMetadataWithReady(ctx context.Context, rows 
 					}
 					ready[row.ID] = struct{}{}
 					readyIDs = append(readyIDs, row.ID)
+				}
+				if len(heartbeatIDs) > 0 {
+					if err := s.meta.TouchManagedSharedDBPools(ctx, heartbeatIDs, meta.SharedDBStatusPending); err != nil {
+						logger.Warn(ctx, "managed_shared_db_pool_metadata_heartbeat_failed",
+							zap.Int("db_pool_count", len(heartbeatIDs)), zap.Error(err))
+					}
 				}
 				if loadErr != nil {
 					logger.Warn(ctx, "managed_shared_db_pool_metadata_retry", zap.Int("attempt", attempt), zap.Int("db_pool_count", len(group)), zap.Duration("retry_in", pollInterval), zap.Error(loadErr))
@@ -995,6 +1018,13 @@ func (s *Server) ensureManagedSharedDBPhysicalLocked(ctx context.Context, poolIn
 	if poolInfo == nil {
 		return nil, fmt.Errorf("managed shared db pool is required")
 	}
+	switch poolInfo.Status {
+	case meta.SharedDBStatusFailed, meta.SharedDBStatusDraining:
+		return nil, fmt.Errorf("managed db pool %d is not creatable in status %q: %w", poolInfo.ID, poolInfo.Status, meta.ErrNotFound)
+	case meta.SharedDBStatusPending, meta.SharedDBStatusProvisioning, meta.SharedDBStatusActive:
+	default:
+		return nil, fmt.Errorf("managed db pool %d has unsupported status %q", poolInfo.ID, poolInfo.Status)
+	}
 	if poolInfo.ClusterID != "" && poolInfo.Host != "" && poolInfo.Port > 0 && poolInfo.User != "" {
 		return poolInfo, nil
 	}
@@ -1122,8 +1152,12 @@ func (s *Server) ensureManagedSharedDBPhysical(ctx context.Context, dbID int64) 
 func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo *meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
 	dbID := poolInfo.ID
 	var err error
-	if poolInfo.Status == meta.SharedDBStatusActive {
+	switch poolInfo.Status {
+	case meta.SharedDBStatusActive, meta.SharedDBStatusFailed, meta.SharedDBStatusDraining:
 		return nil
+	case meta.SharedDBStatusPending, meta.SharedDBStatusProvisioning:
+	default:
+		return fmt.Errorf("managed db pool %d has unsupported status %q", dbID, poolInfo.Status)
 	}
 	provisioner, ok := s.provisioner.(tenant.SharedDBPoolProvisioner)
 	if !ok {

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -492,9 +492,22 @@ func (s *Server) runManagedSharedDBProvisioning(ctx context.Context, dbIDs []int
 			s.managedSharedDBProvisioningJobs.Delete(dbID)
 		}
 	}()
-	workers := s.managedSharedDBProvisioningWorkers
+	workers := s.managedSharedDBProvisioningConcurrency
 	if workers <= 0 {
-		workers = DefaultManagedSharedDBProvisioningWorkers
+		if s.managedSharedDBProvisioningSlots != nil {
+			maxOpen := 0
+			if s.meta != nil && s.meta.DB() != nil {
+				maxOpen = s.meta.DB().Stats().MaxOpenConnections
+			}
+			logger.Error(ctx, "managed_shared_db_pool_provisioning_disabled",
+				zap.Int("configured_workers", s.managedSharedDBProvisioningWorkers),
+				zap.Int("meta_max_open_connections", maxOpen))
+			return
+		}
+		workers = s.managedSharedDBProvisioningWorkers
+		if workers <= 0 {
+			workers = DefaultManagedSharedDBProvisioningWorkers
+		}
 	}
 	failed := runManagedSharedDBProvisioningQueue(ctx, workers, s.managedSharedDBProvisioningSlots, owned,
 		schemaInitRetryWindow, schemaInitInitialBackoff, managedSharedDBProvisioningMaxBackoff,

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -247,99 +247,97 @@ func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.Creden
 func (s *Server) allocateManagedSharedDBForOrganization(ctx context.Context, organizationID string, cred tenant.CredentialProvisionRequest, reserve func(*meta.SharedDB) error) (sharedDB *meta.SharedDB, created bool, err error) {
 	provisioningKey := sharedDBProvisioningKey(cred)
 	identity := sharedDBAllocationIdentity(organizationID, provisioningKey)
-	// Capacity reservation is transactional in CompleteSharedTenant* and does
-	// not need the cross-pod organization-wide planning lock. Serialize only
-	// this Pod's same-organization lookup plus reservation so a refill wave does
-	// not send every tenant worker into the same nearly-full db_pool row. Other
-	// organizations and Pods remain independent; the lock below is reserved for
-	// planning a new physical pool.
-	if reserve != nil {
-		var reserved *meta.SharedDB
-		if err := s.withSharedDBReservationLock(ctx, identity, func() error {
+	planAndReserve := func() error {
+		return s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
 			for attempt := 0; attempt < 2; attempt++ {
-				candidate, findErr := s.meta.FindSharedDBForAllocation(ctx, organizationID)
-				if errors.Is(findErr, meta.ErrNotFound) {
+				candidate, findErr := s.meta.FindSharedDBForAllocation(lockCtx, organizationID)
+				if findErr == nil {
+					sharedDB = candidate
+				} else if !errors.Is(findErr, meta.ErrNotFound) {
+					return findErr
+				} else if organizationID != "" {
+					manual, manualErr := s.meta.FindSharedDBForOrg(lockCtx, organizationID)
+					if manualErr == nil && manual.SpendingLimit == nil {
+						sharedDB = manual
+					} else if manualErr != nil && !errors.Is(manualErr, meta.ErrNotFound) {
+						return manualErr
+					}
+				}
+				if sharedDB == nil {
+					maxTenants, fixedTarget := s.managedSharedDBPolicy()
+					cloudProvider, region := provisioningCloudRegion(s.provisioner)
+					rootPassword, passwordErr := generateManagedSharedDBRootPassword(24)
+					if passwordErr != nil {
+						return passwordErr
+					}
+					passwordCipher, encryptErr := s.pool.Encrypt(lockCtx, []byte(rootPassword))
+					if encryptErr != nil {
+						return fmt.Errorf("encrypt shared db root password: %w", encryptErr)
+					}
+					id, createErr := s.meta.CreateManagedSharedDBPool(lockCtx, &meta.SharedDB{
+						TiDBCloudOrganizationID: organizationID,
+						ProvisioningKey:         provisioningKey,
+						CloudProvider:           cloudProvider,
+						Region:                  region,
+						MaxTenants:              maxTenants,
+						SpendingLimit:           &fixedTarget,
+						PasswordCipher:          passwordCipher,
+						Name:                    s.defaultSharedDatabaseName(),
+					})
+					if createErr != nil {
+						return createErr
+					}
+					sharedDB, createErr = s.meta.GetSharedDB(lockCtx, id)
+					if createErr != nil {
+						return createErr
+					}
+					created = true
+				}
+				if reserve == nil {
 					return nil
 				}
-				if findErr != nil {
-					return findErr
-				}
-				reserveErr := reserve(candidate)
+				reserveErr := reserve(sharedDB)
 				if reserveErr == nil {
-					reserved = candidate
 					return nil
 				}
 				if !errors.Is(reserveErr, meta.ErrSharedDBCapacityExhausted) {
 					return reserveErr
 				}
+				sharedDB = nil
+				created = false
 			}
-			return nil
-		}); err != nil {
-			return nil, false, err
-		}
-		if reserved != nil {
-			return reserved, false, nil
-		}
+			return meta.ErrSharedDBCapacityExhausted
+		})
 	}
-	err = s.withSharedDBAllocationLock(ctx, identity, func(lockCtx context.Context) error {
+	if reserve == nil {
+		err = planAndReserve()
+		return sharedDB, created, err
+	}
+	// Capacity reservation is transactional in CompleteSharedTenant* and does
+	// not need a cross-pod lock while existing capacity is available. Serialize
+	// this Pod's complete same-organization lookup, optional physical planning,
+	// and reservation transition so a fast-path worker cannot steal a pool that
+	// another local worker just created but has not reserved yet. Different
+	// organizations and Pods remain independent.
+	err = s.withSharedDBReservationLock(ctx, identity, func() error {
 		for attempt := 0; attempt < 2; attempt++ {
-			candidate, findErr := s.meta.FindSharedDBForAllocation(lockCtx, organizationID)
-			if findErr == nil {
-				sharedDB = candidate
-			} else if !errors.Is(findErr, meta.ErrNotFound) {
+			candidate, findErr := s.meta.FindSharedDBForAllocation(ctx, organizationID)
+			if errors.Is(findErr, meta.ErrNotFound) {
+				break
+			}
+			if findErr != nil {
 				return findErr
-			} else if organizationID != "" {
-				manual, manualErr := s.meta.FindSharedDBForOrg(lockCtx, organizationID)
-				if manualErr == nil && manual.SpendingLimit == nil {
-					sharedDB = manual
-				} else if manualErr != nil && !errors.Is(manualErr, meta.ErrNotFound) {
-					return manualErr
-				}
 			}
-			if sharedDB == nil {
-				maxTenants, fixedTarget := s.managedSharedDBPolicy()
-				cloudProvider, region := provisioningCloudRegion(s.provisioner)
-				rootPassword, passwordErr := generateManagedSharedDBRootPassword(24)
-				if passwordErr != nil {
-					return passwordErr
-				}
-				passwordCipher, encryptErr := s.pool.Encrypt(lockCtx, []byte(rootPassword))
-				if encryptErr != nil {
-					return fmt.Errorf("encrypt shared db root password: %w", encryptErr)
-				}
-				id, createErr := s.meta.CreateManagedSharedDBPool(lockCtx, &meta.SharedDB{
-					TiDBCloudOrganizationID: organizationID,
-					ProvisioningKey:         provisioningKey,
-					CloudProvider:           cloudProvider,
-					Region:                  region,
-					MaxTenants:              maxTenants,
-					SpendingLimit:           &fixedTarget,
-					PasswordCipher:          passwordCipher,
-					Name:                    s.defaultSharedDatabaseName(),
-				})
-				if createErr != nil {
-					return createErr
-				}
-				sharedDB, createErr = s.meta.GetSharedDB(lockCtx, id)
-				if createErr != nil {
-					return createErr
-				}
-				created = true
-			}
-			if reserve == nil {
-				return nil
-			}
-			reserveErr := reserve(sharedDB)
+			reserveErr := reserve(candidate)
 			if reserveErr == nil {
+				sharedDB = candidate
 				return nil
 			}
 			if !errors.Is(reserveErr, meta.ErrSharedDBCapacityExhausted) {
 				return reserveErr
 			}
-			sharedDB = nil
-			created = false
 		}
-		return meta.ErrSharedDBCapacityExhausted
+		return planAndReserve()
 	})
 	return sharedDB, created, err
 }

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -12,6 +12,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/tenant"
@@ -244,6 +246,38 @@ func (s *Server) allocateManagedSharedDB(ctx context.Context, cred tenant.Creden
 	return s.allocateManagedSharedDBForOrganization(ctx, organizationID, cred, reserve)
 }
 
+func (s *Server) createManagedSharedDBPlan(ctx context.Context, organizationID string, provisioningKey []byte) (*meta.SharedDB, error) {
+	maxTenants, fixedTarget := s.managedSharedDBPolicy()
+	cloudProvider, region := provisioningCloudRegion(s.provisioner)
+	rootPassword, err := generateManagedSharedDBRootPassword(24)
+	if err != nil {
+		return nil, err
+	}
+	passwordCipher, err := s.pool.Encrypt(ctx, []byte(rootPassword))
+	if err != nil {
+		return nil, fmt.Errorf("encrypt shared db root password: %w", err)
+	}
+	row := &meta.SharedDB{
+		UUID:                    uuid.NewString(),
+		TiDBCloudOrganizationID: organizationID,
+		ProvisioningKey:         append([]byte(nil), provisioningKey...),
+		CloudProvider:           cloudProvider,
+		Region:                  region,
+		Role:                    meta.SharedDBRoleShared,
+		MaxTenants:              maxTenants,
+		SpendingLimit:           &fixedTarget,
+		PasswordCipher:          passwordCipher,
+		Name:                    s.defaultSharedDatabaseName(),
+		Status:                  meta.SharedDBStatusPending,
+	}
+	id, err := s.meta.CreateManagedSharedDBPool(ctx, row)
+	if err != nil {
+		return nil, err
+	}
+	row.ID = id
+	return row, nil
+}
+
 func (s *Server) allocateManagedSharedDBForOrganization(ctx context.Context, organizationID string, cred tenant.CredentialProvisionRequest, reserve func(*meta.SharedDB) error) (sharedDB *meta.SharedDB, created bool, err error) {
 	provisioningKey := sharedDBProvisioningKey(cred)
 	identity := sharedDBAllocationIdentity(organizationID, provisioningKey)
@@ -264,30 +298,8 @@ func (s *Server) allocateManagedSharedDBForOrganization(ctx context.Context, org
 					}
 				}
 				if sharedDB == nil {
-					maxTenants, fixedTarget := s.managedSharedDBPolicy()
-					cloudProvider, region := provisioningCloudRegion(s.provisioner)
-					rootPassword, passwordErr := generateManagedSharedDBRootPassword(24)
-					if passwordErr != nil {
-						return passwordErr
-					}
-					passwordCipher, encryptErr := s.pool.Encrypt(lockCtx, []byte(rootPassword))
-					if encryptErr != nil {
-						return fmt.Errorf("encrypt shared db root password: %w", encryptErr)
-					}
-					id, createErr := s.meta.CreateManagedSharedDBPool(lockCtx, &meta.SharedDB{
-						TiDBCloudOrganizationID: organizationID,
-						ProvisioningKey:         provisioningKey,
-						CloudProvider:           cloudProvider,
-						Region:                  region,
-						MaxTenants:              maxTenants,
-						SpendingLimit:           &fixedTarget,
-						PasswordCipher:          passwordCipher,
-						Name:                    s.defaultSharedDatabaseName(),
-					})
-					if createErr != nil {
-						return createErr
-					}
-					sharedDB, createErr = s.meta.GetSharedDB(lockCtx, id)
+					var createErr error
+					sharedDB, createErr = s.createManagedSharedDBPlan(lockCtx, organizationID, provisioningKey)
 					if createErr != nil {
 						return createErr
 					}

--- a/pkg/server/tenant_failed_cleanup_test.go
+++ b/pkg/server/tenant_failed_cleanup_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"errors"
@@ -386,6 +387,104 @@ func TestCleanupFailedOrganizationTenantsContinuesAcrossProviders(t *testing.T) 
 	assertSharedCleanupCompleted(t, rt, sharedID, fsID, dbID)
 	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
 		t.Fatalf("deprovision calls = %d, want native-only 1", got)
+	}
+}
+
+func TestCleanupFailedManagedSharedDBPoolsUsesDedicatedPhysicalPoolPass(t *testing.T) {
+	rt, _ := newFailedCleanupRuntimeWithoutWorkers(t)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	tenantID := insertFailedCleanupTenant(t, rt, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	fsID, dbID := setFailedCleanupSharedPlacement(t, rt, tenantID, false)
+	upsertFailedCleanupSharedMembership(t, rt, tenantID, "pool-shared-failed-physical", meta.TenantPoolBindingFree)
+	if _, err := rt.meta.DB().ExecContext(ctx, `UPDATE db_pool SET status = ?, cluster_id = ? WHERE db_id = ?`,
+		meta.SharedDBStatusFailed, "cluster-failed-physical", dbID); err != nil {
+		t.Fatalf("mark physical pool failed: %v", err)
+	}
+
+	rt.server.cleanupFailedManagedSharedDBPoolsWithCtx(ctx)
+	assertFailedCleanupTenantStatus(t, rt, tenantID, meta.TenantDeleted)
+	if _, err := rt.meta.GetTenantPlacement(ctx, fsID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("shared placement after cleanup error = %v, want ErrNotFound", err)
+	}
+	if _, err := rt.meta.GetTenantPoolMembership(ctx, tenantID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("shared membership after cleanup error = %v, want ErrNotFound", err)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("physical pool deprovision calls = %d, want 1", got)
+	}
+	if rt.prov.lastDeprovision == nil || rt.prov.lastDeprovision.ClusterID != "cluster-failed-physical" {
+		t.Fatalf("deprovisioned cluster = %+v", rt.prov.lastDeprovision)
+	}
+	if _, err := rt.meta.GetSharedDB(ctx, dbID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("GetSharedDB after cleanup error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCleanupFailedManagedSharedDBPoolsDeprovisionFailureRetainsFailedPool(t *testing.T) {
+	rt, _ := newFailedCleanupRuntimeWithoutWorkers(t)
+	ctx := context.Background()
+	old := time.Now().UTC().Add(-time.Hour)
+	tenantID := insertFailedCleanupTenant(t, rt, tenant.ProviderTiDBCloudNativeShared, "", "", old)
+	_, dbID := setFailedCleanupSharedPlacement(t, rt, tenantID, false)
+	upsertFailedCleanupSharedMembership(t, rt, tenantID, "pool-shared-failed-retry", meta.TenantPoolBindingFree)
+	if _, err := rt.meta.DB().ExecContext(ctx, `UPDATE db_pool SET status = ?, cluster_id = ? WHERE db_id = ?`,
+		meta.SharedDBStatusFailed, "cluster-failed-retry", dbID); err != nil {
+		t.Fatalf("mark physical pool failed: %v", err)
+	}
+	rt.prov.deprovisionErr = errors.New("cloud delete unavailable")
+
+	rt.server.cleanupFailedManagedSharedDBPoolsWithCtx(ctx)
+	pool, err := rt.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB after failed deprovision: %v", err)
+	}
+	if pool.Status != meta.SharedDBStatusFailed || pool.ClusterID != "cluster-failed-retry" || pool.TenantCount != 0 {
+		t.Fatalf("retained failed pool = %+v", pool)
+	}
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+}
+
+func TestCleanupFailedManagedSharedDBPoolsDiscoversUnpersistedCloudCluster(t *testing.T) {
+	rt, _ := newFailedCleanupRuntimeWithoutWorkers(t)
+	ctx := context.Background()
+	spendingLimit := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := rt.meta.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: failedCleanupTestOrganizationID,
+		ProvisioningKey:         bytes.Repeat([]byte{1}, 32),
+		CloudProvider:           "aws",
+		Region:                  "us-east-1",
+		MaxTenants:              100,
+		SpendingLimit:           &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	pool, err := rt.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if err := rt.meta.MarkSharedDBPoolFailed(ctx, dbID); err != nil {
+		t.Fatalf("MarkSharedDBPoolFailed: %v", err)
+	}
+	rt.prov.sharedPoolLoadFunc = func(gotDBID int64, gotUUID, gotClusterID string) (*tenant.SharedDBPoolInfo, error) {
+		if gotDBID != dbID || gotUUID != pool.UUID || gotClusterID != "" {
+			t.Fatalf("load request = (%d, %q, %q), want (%d, %q, empty)", gotDBID, gotUUID, gotClusterID, dbID, pool.UUID)
+		}
+		return &tenant.SharedDBPoolInfo{DBPoolID: dbID, DBPoolUUID: pool.UUID, ClusterID: "cluster-unpersisted"}, nil
+	}
+
+	rt.server.cleanupFailedManagedSharedDBPoolsWithCtx(ctx)
+	if got := rt.prov.deprovisionCalls.Load(); got != 1 {
+		t.Fatalf("deprovision calls = %d, want 1", got)
+	}
+	if rt.prov.lastDeprovision == nil || rt.prov.lastDeprovision.ClusterID != "cluster-unpersisted" {
+		t.Fatalf("deprovisioned cluster = %+v", rt.prov.lastDeprovision)
+	}
+	if _, err := rt.meta.GetSharedDB(ctx, dbID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("GetSharedDB after cleanup error = %v, want ErrNotFound", err)
 	}
 }
 

--- a/pkg/server/tenant_failed_cleanup_test.go
+++ b/pkg/server/tenant_failed_cleanup_test.go
@@ -488,6 +488,77 @@ func TestCleanupFailedManagedSharedDBPoolsDiscoversUnpersistedCloudCluster(t *te
 	}
 }
 
+func TestCleanupFailedManagedSharedDBPoolsRepairsPositiveTenantCountDrift(t *testing.T) {
+	rt, _ := newFailedCleanupRuntimeWithoutWorkers(t)
+	ctx := context.Background()
+	spendingLimit := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := rt.meta.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: failedCleanupTestOrganizationID,
+		ProvisioningKey:         bytes.Repeat([]byte{4}, 32),
+		CloudProvider:           "aws", Region: "us-east-1", MaxTenants: 100,
+		SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, `UPDATE db_pool SET status = ?, tenant_count = 7 WHERE db_id = ?`,
+		meta.SharedDBStatusFailed, dbID); err != nil {
+		t.Fatal(err)
+	}
+
+	rt.server.cleanupFailedManagedSharedDBPoolsWithCtx(ctx)
+	if _, err := rt.meta.GetSharedDB(ctx, dbID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("GetSharedDB after drift repair cleanup error = %v, want ErrNotFound", err)
+	}
+}
+
+func TestCleanupFailedManagedSharedDBPoolsDeletesEveryAmbiguousUUIDMatch(t *testing.T) {
+	rt, _ := newFailedCleanupRuntimeWithoutWorkers(t)
+	ctx := context.Background()
+	spendingLimit := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := rt.meta.CreateManagedSharedDBPool(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: failedCleanupTestOrganizationID,
+		ProvisioningKey:         bytes.Repeat([]byte{5}, 32),
+		CloudProvider:           "aws", Region: "us-east-1", MaxTenants: 100,
+		SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool, err := rt.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := rt.meta.MarkSharedDBPoolFailed(ctx, dbID); err != nil {
+		t.Fatal(err)
+	}
+	rt.prov.sharedPoolListFunc = func(gotDBID int64, gotUUID string) ([]*tenant.SharedDBPoolInfo, error) {
+		if gotDBID != dbID || gotUUID != pool.UUID {
+			t.Fatalf("list request = (%d,%q), want (%d,%q)", gotDBID, gotUUID, dbID, pool.UUID)
+		}
+		return []*tenant.SharedDBPoolInfo{
+			{DBPoolID: dbID, DBPoolUUID: pool.UUID, ClusterID: "cluster-duplicate-a"},
+			{DBPoolID: dbID, DBPoolUUID: pool.UUID, ClusterID: "cluster-duplicate-b"},
+		}, nil
+	}
+	seen := make(map[string]bool)
+	rt.prov.deprovisionHook = func(_ int, cluster *tenant.ClusterInfo) error {
+		seen[cluster.ClusterID] = true
+		return nil
+	}
+
+	rt.server.cleanupFailedManagedSharedDBPoolsWithCtx(ctx)
+	if got := rt.prov.deprovisionCalls.Load(); got != 2 {
+		t.Fatalf("deprovision calls = %d, want both ambiguous matches", got)
+	}
+	if !seen["cluster-duplicate-a"] || !seen["cluster-duplicate-b"] {
+		t.Fatalf("deprovisioned clusters = %v", seen)
+	}
+	if _, err := rt.meta.GetSharedDB(ctx, dbID); !errors.Is(err, meta.ErrNotFound) {
+		t.Fatalf("GetSharedDB after ambiguous cleanup error = %v, want ErrNotFound", err)
+	}
+}
+
 func TestCleanupFailedOrganizationTenantsSharedActiveDBPurgesScopedData(t *testing.T) {
 	rt, db := newFailedCleanupRuntimeWithoutWorkers(t)
 	ctx := context.Background()

--- a/pkg/server/tenant_pool_reconcile.go
+++ b/pkg/server/tenant_pool_reconcile.go
@@ -33,15 +33,23 @@ func (s *Server) reconcileStuckManagedSharedDBPoolsWithCtx(ctx context.Context) 
 				if row.UpdatedAt.After(cutoff) {
 					continue
 				}
-				failed, changed, failErr := s.meta.MarkStuckSharedDBPoolFailed(ctx, row.ID, status, cutoff)
-				if failErr != nil {
-					logger.Warn(ctx, "managed_shared_db_pool_stuck_fail_failed", zap.Int64("db_pool_id", row.ID), zap.String("status", status), zap.Error(failErr))
-					continue
-				}
-				if changed {
-					logger.Warn(ctx, "managed_shared_db_pool_stuck_failed", zap.Int64("db_pool_id", row.ID),
-						zap.String("db_pool_uuid", row.UUID), zap.String("status", status),
-						zap.Int("tenant_count", len(failed.TenantIDs)), zap.Duration("stuck_timeout", timeout))
+				claimErr := s.meta.WithSharedDBPoolWorkClaims(ctx, []int64{row.ID}, func(claimCtx context.Context, ownedIDs []int64) error {
+					if len(ownedIDs) == 0 {
+						return nil
+					}
+					failed, changed, failErr := s.meta.MarkStuckSharedDBPoolFailed(claimCtx, row.ID, status, cutoff)
+					if failErr != nil {
+						return failErr
+					}
+					if changed {
+						logger.Warn(claimCtx, "managed_shared_db_pool_stuck_failed", zap.Int64("db_pool_id", row.ID),
+							zap.String("db_pool_uuid", row.UUID), zap.String("status", status),
+							zap.Int("tenant_count", len(failed.TenantIDs)), zap.Duration("stuck_timeout", timeout))
+					}
+					return nil
+				})
+				if claimErr != nil {
+					logger.Warn(ctx, "managed_shared_db_pool_stuck_fail_failed", zap.Int64("db_pool_id", row.ID), zap.String("status", status), zap.Error(claimErr))
 				}
 			}
 			if len(rows) < tenantPoolReconcilePageSize {

--- a/pkg/server/tenant_pool_reconcile.go
+++ b/pkg/server/tenant_pool_reconcile.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"context"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+	"go.uber.org/zap"
+)
+
+const tenantPoolReconcilePageSize = 100
+
+func (s *Server) reconcileStuckManagedSharedDBPoolsWithCtx(ctx context.Context) {
+	if s.meta == nil {
+		return
+	}
+	timeout := s.managedSharedDBStuckTimeout
+	if timeout <= 0 {
+		timeout = DefaultManagedSharedDBStuckTimeout
+	}
+	cutoff := time.Now().UTC().Add(-timeout)
+	for _, status := range []string{meta.SharedDBStatusPending, meta.SharedDBStatusProvisioning} {
+		var afterID int64
+		for {
+			rows, err := s.meta.ListSharedDBsByStatusAfter(ctx, status, afterID, tenantPoolReconcilePageSize)
+			if err != nil {
+				logger.Warn(ctx, "managed_shared_db_pool_stuck_list_failed", zap.String("status", status), zap.Error(err))
+				break
+			}
+			for _, row := range rows {
+				if row.UpdatedAt.After(cutoff) {
+					continue
+				}
+				failed, changed, failErr := s.meta.MarkStuckSharedDBPoolFailed(ctx, row.ID, status, cutoff)
+				if failErr != nil {
+					logger.Warn(ctx, "managed_shared_db_pool_stuck_fail_failed", zap.Int64("db_pool_id", row.ID), zap.String("status", status), zap.Error(failErr))
+					continue
+				}
+				if changed {
+					logger.Warn(ctx, "managed_shared_db_pool_stuck_failed", zap.Int64("db_pool_id", row.ID),
+						zap.String("db_pool_uuid", row.UUID), zap.String("status", status),
+						zap.Int("tenant_count", len(failed.TenantIDs)), zap.Duration("stuck_timeout", timeout))
+				}
+			}
+			if len(rows) < tenantPoolReconcilePageSize {
+				break
+			}
+			afterID = rows[len(rows)-1].ID
+		}
+	}
+}
+
+// reconcileSharedTenantPoolsWithCtx scans durable logical pools and only
+// enqueues their existing asynchronous refill path. Capacity counts and Cloud
+// operations remain outside this leader scanner and outside claim requests.
+func (s *Server) reconcileSharedTenantPoolsWithCtx(ctx context.Context) {
+	if s.meta == nil || s.defaultTenantProvider != tenant.ProviderTiDBCloudNativeShared {
+		return
+	}
+	afterPoolID := ""
+	for {
+		pools, err := s.meta.ListTenantPoolsByStatusAfter(ctx, meta.TenantPoolActive, afterPoolID, tenantPoolReconcilePageSize)
+		if err != nil {
+			logger.Warn(ctx, "tenant_pool_reconcile_list_failed", zap.Error(err))
+			return
+		}
+		for _, pool := range pools {
+			s.replenishTenantPoolLeaderAsync(ctx, pool, tenant.CredentialProvisionRequest{})
+		}
+		if len(pools) < tenantPoolReconcilePageSize {
+			return
+		}
+		afterPoolID = pools[len(pools)-1].PoolID
+	}
+}
+
+func (s *Server) startTenantPoolLeaderReconcileWorker(ctx context.Context, fn func(context.Context)) bool {
+	if s.tenantPoolReconcileSlots == nil {
+		return false
+	}
+	select {
+	case s.tenantPoolReconcileSlots <- struct{}{}:
+	case <-ctx.Done():
+		return false
+	}
+	started := s.startManagedSharedDBWorker(ctx, func(workerCtx context.Context) {
+		defer func() { <-s.tenantPoolReconcileSlots }()
+		fn(workerCtx)
+	})
+	if !started {
+		<-s.tenantPoolReconcileSlots
+	}
+	return started
+}

--- a/pkg/server/tenant_pool_reconcile.go
+++ b/pkg/server/tenant_pool_reconcile.go
@@ -12,6 +12,10 @@ import (
 
 const tenantPoolReconcilePageSize = 100
 
+type tenantPoolReconcileJob struct {
+	run func(context.Context)
+}
+
 func (s *Server) reconcileStuckManagedSharedDBPoolsWithCtx(ctx context.Context) {
 	if s.meta == nil {
 		return
@@ -75,7 +79,9 @@ func (s *Server) reconcileSharedTenantPoolsWithCtx(ctx context.Context) {
 			return
 		}
 		for _, pool := range pools {
-			s.replenishTenantPoolLeaderAsync(ctx, pool, tenant.CredentialProvisionRequest{})
+			if !s.enqueueTenantPoolLeaderReplenishment(ctx, pool, tenant.CredentialProvisionRequest{}) {
+				return
+			}
 		}
 		if len(pools) < tenantPoolReconcilePageSize {
 			return
@@ -84,21 +90,40 @@ func (s *Server) reconcileSharedTenantPoolsWithCtx(ctx context.Context) {
 	}
 }
 
-func (s *Server) startTenantPoolLeaderReconcileWorker(ctx context.Context, fn func(context.Context)) bool {
-	if s.tenantPoolReconcileSlots == nil {
+func (s *Server) enqueueTenantPoolReconcileWork(ctx context.Context, fn func(context.Context)) bool {
+	if s.tenantPoolReconcileQueue == nil || fn == nil {
 		return false
 	}
 	select {
-	case s.tenantPoolReconcileSlots <- struct{}{}:
+	case s.tenantPoolReconcileQueue <- tenantPoolReconcileJob{run: fn}:
+		return true
 	case <-ctx.Done():
 		return false
 	}
-	started := s.startManagedSharedDBWorker(ctx, func(workerCtx context.Context) {
-		defer func() { <-s.tenantPoolReconcileSlots }()
-		fn(workerCtx)
-	})
-	if !started {
-		<-s.tenantPoolReconcileSlots
+}
+
+func (s *Server) runTenantPoolReconcileWorker(ctx context.Context) {
+	for {
+		var job tenantPoolReconcileJob
+		select {
+		case <-ctx.Done():
+			return
+		case job = <-s.tenantPoolReconcileQueue:
+		}
+		if job.run != nil {
+			job.run(ctx)
+		}
+		rest := s.tenantPoolReconcileWorkerRest
+		if rest <= 0 {
+			rest = DefaultTenantPoolReconcileWorkerRest
+		}
+		timer := time.NewTimer(rest)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+		timer.Stop()
 	}
-	return started
 }

--- a/pkg/server/tenant_pool_reconcile.go
+++ b/pkg/server/tenant_pool_reconcile.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"context"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
@@ -13,7 +15,58 @@ import (
 const tenantPoolReconcilePageSize = 100
 
 type tenantPoolReconcileJob struct {
-	run func(context.Context)
+	run   func(context.Context)
+	start func()
+	next  func() bool
+	abort func()
+}
+
+type tenantPoolLeaderReconcileState struct {
+	mu      sync.Mutex
+	queued  bool
+	running bool
+	rerun   bool
+}
+
+func (state *tenantPoolLeaderReconcileState) request() bool {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.queued {
+		return false
+	}
+	if state.running {
+		state.rerun = true
+		return false
+	}
+	state.queued = true
+	state.rerun = false
+	return true
+}
+
+func (state *tenantPoolLeaderReconcileState) start() {
+	state.mu.Lock()
+	state.queued = false
+	state.running = true
+	state.mu.Unlock()
+}
+
+func (state *tenantPoolLeaderReconcileState) next() bool {
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if state.rerun {
+		state.rerun = false
+		return true
+	}
+	state.running = false
+	return false
+}
+
+func (state *tenantPoolLeaderReconcileState) abort() {
+	state.mu.Lock()
+	state.queued = false
+	state.running = false
+	state.rerun = false
+	state.mu.Unlock()
 }
 
 func (s *Server) reconcileStuckManagedSharedDBPoolsWithCtx(ctx context.Context) {
@@ -90,14 +143,21 @@ func (s *Server) reconcileSharedTenantPoolsWithCtx(ctx context.Context) {
 	}
 }
 
-func (s *Server) enqueueTenantPoolReconcileWork(ctx context.Context, fn func(context.Context)) bool {
-	if s.tenantPoolReconcileQueue == nil || fn == nil {
+func (s *Server) enqueueTenantPoolLeaderReconcile(ctx context.Context, poolID string, run func(context.Context)) bool {
+	if s.tenantPoolReconcileQueue == nil || strings.TrimSpace(poolID) == "" || run == nil {
 		return false
 	}
+	value, _ := s.tenantPoolLeaderReconcileJobs.LoadOrStore(poolID, &tenantPoolLeaderReconcileState{})
+	state := value.(*tenantPoolLeaderReconcileState)
+	if !state.request() {
+		return true
+	}
+	job := tenantPoolReconcileJob{run: run, start: state.start, next: state.next, abort: state.abort}
 	select {
-	case s.tenantPoolReconcileQueue <- tenantPoolReconcileJob{run: fn}:
+	case s.tenantPoolReconcileQueue <- job:
 		return true
 	case <-ctx.Done():
+		state.abort()
 		return false
 	}
 }
@@ -110,20 +170,36 @@ func (s *Server) runTenantPoolReconcileWorker(ctx context.Context) {
 			return
 		case job = <-s.tenantPoolReconcileQueue:
 		}
-		if job.run != nil {
-			job.run(ctx)
-		}
-		rest := s.tenantPoolReconcileWorkerRest
-		if rest <= 0 {
-			rest = DefaultTenantPoolReconcileWorkerRest
-		}
-		timer := time.NewTimer(rest)
-		select {
-		case <-ctx.Done():
-			timer.Stop()
+		func() {
+			if job.start != nil {
+				job.start()
+			}
+			for {
+				if job.run != nil {
+					job.run(ctx)
+				}
+				rest := s.tenantPoolReconcileWorkerRest
+				if rest <= 0 {
+					rest = DefaultTenantPoolReconcileWorkerRest
+				}
+				timer := time.NewTimer(rest)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					if job.abort != nil {
+						job.abort()
+					}
+					return
+				case <-timer.C:
+				}
+				timer.Stop()
+				if job.next == nil || !job.next() {
+					return
+				}
+			}
+		}()
+		if ctx.Err() != nil {
 			return
-		case <-timer.C:
 		}
-		timer.Stop()
 	}
 }

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -124,6 +124,13 @@ type SharedDBPoolBatchLoader interface {
 	BatchLoadSharedDBPoolsWithCredentials(ctx context.Context, requests []SharedDBPoolLoadRequest, req CredentialProvisionRequest) ([]*SharedDBPoolInfo, error)
 }
 
+type SharedDBPoolLister interface {
+	// ListSharedDBPoolsWithCredentials returns every exact managed cluster
+	// carrying one durable DB-pool UUID. Cleanup uses it to converge duplicate
+	// Cloud resources instead of failing forever on ambiguity.
+	ListSharedDBPoolsWithCredentials(ctx context.Context, dbPoolID int64, dbPoolUUID string, req CredentialProvisionRequest) ([]*SharedDBPoolInfo, error)
+}
+
 type SharedDBPoolProvisioner interface {
 	Provisioner
 	// BatchProvisionSharedDBPoolsWithCredentials may return the successfully

--- a/pkg/tenant/provisioner.go
+++ b/pkg/tenant/provisioner.go
@@ -119,6 +119,8 @@ type SharedDBPoolLoadRequest struct {
 }
 
 type SharedDBPoolBatchLoader interface {
+	// BatchLoadSharedDBPoolsWithCredentials refreshes known cluster IDs and
+	// discovers requests without a cluster ID by their durable DB-pool UUID.
 	BatchLoadSharedDBPoolsWithCredentials(ctx context.Context, requests []SharedDBPoolLoadRequest, req CredentialProvisionRequest) ([]*SharedDBPoolInfo, error)
 }
 

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -717,6 +717,44 @@ func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoo
 	return p.sharedDBPoolInfoFromCluster(dbPoolID, wantUUID, &matches[0])
 }
 
+// ListSharedDBPoolsWithCredentials returns all exact managed label matches for
+// one durable pool UUID, including resources whose endpoint metadata is still
+// incomplete.
+func (p *Provisioner) ListSharedDBPoolsWithCredentials(ctx context.Context, dbPoolID int64, dbPoolUUID string, req tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
+	publicKey := strings.TrimSpace(req.PublicKey)
+	privateKey := strings.TrimSpace(req.PrivateKey)
+	if publicKey == "" || privateKey == "" {
+		return nil, tenant.ErrCredentialsRequired
+	}
+	if dbPoolID <= 0 {
+		return nil, fmt.Errorf("db pool id must be positive")
+	}
+	parsedUUID, err := uuid.Parse(strings.TrimSpace(dbPoolUUID))
+	if err != nil {
+		return nil, fmt.Errorf("db pool %d has invalid uuid %q: %w", dbPoolID, dbPoolUUID, err)
+	}
+	wantUUID := parsedUUID.String()
+	infos, err := p.listClusterInfosWithCredentials(ctx, publicKey, privateKey, nil, 100)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*tenant.SharedDBPoolInfo, 0)
+	for i := range infos {
+		if !strings.EqualFold(strings.TrimSpace(infos[i].Labels[Drive9DBPoolUUIDLabel]), wantUUID) ||
+			strings.TrimSpace(infos[i].Labels[Drive9ManagedLabel]) != "true" ||
+			strings.TrimSpace(infos[i].Labels[Drive9ProviderLabel]) != tenant.ProviderTiDBCloudNativeShared {
+			continue
+		}
+		row, convertErr := p.sharedDBPoolInfoFromCluster(dbPoolID, wantUUID, &infos[i])
+		if convertErr != nil {
+			return nil, convertErr
+		}
+		out = append(out, row)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ClusterID < out[j].ClusterID })
+	return out, nil
+}
+
 // BatchLoadSharedDBPoolsWithCredentials refreshes known managed clusters and
 // discovers requests without a cluster ID by durable DB-pool UUID. Incomplete
 // endpoint/user metadata is returned with empty connection fields so callers

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -717,10 +717,10 @@ func (p *Provisioner) LoadSharedDBPoolWithCredentials(ctx context.Context, dbPoo
 	return p.sharedDBPoolInfoFromCluster(dbPoolID, wantUUID, &matches[0])
 }
 
-// BatchLoadSharedDBPoolsWithCredentials refreshes multiple known managed
-// shared clusters with one TiDB Cloud list request. Incomplete endpoint/user
-// metadata is returned as an info with empty connection fields so callers can
-// keep the pool pending and poll it again later.
+// BatchLoadSharedDBPoolsWithCredentials refreshes known managed clusters and
+// discovers requests without a cluster ID by durable DB-pool UUID. Incomplete
+// endpoint/user metadata is returned with empty connection fields so callers
+// can keep the pool pending and poll it again later.
 func (p *Provisioner) BatchLoadSharedDBPoolsWithCredentials(ctx context.Context, requests []tenant.SharedDBPoolLoadRequest, req tenant.CredentialProvisionRequest) ([]*tenant.SharedDBPoolInfo, error) {
 	publicKey := strings.TrimSpace(req.PublicKey)
 	privateKey := strings.TrimSpace(req.PrivateKey)
@@ -730,8 +730,9 @@ func (p *Provisioner) BatchLoadSharedDBPoolsWithCredentials(ctx context.Context,
 	if len(requests) == 0 {
 		return nil, nil
 	}
-	targets := make(map[string]tenant.SharedDBPoolLoadRequest, len(requests))
+	targetsByUUID := make(map[string]tenant.SharedDBPoolLoadRequest, len(requests))
 	clusterIDs := make([]string, 0, len(requests))
+	discoverByUUID := false
 	for _, request := range requests {
 		if request.DBPoolID <= 0 {
 			return nil, fmt.Errorf("db pool id must be positive")
@@ -741,26 +742,57 @@ func (p *Provisioner) BatchLoadSharedDBPoolsWithCredentials(ctx context.Context,
 			return nil, fmt.Errorf("db pool %d has invalid uuid %q: %w", request.DBPoolID, request.DBPoolUUID, err)
 		}
 		clusterID := strings.TrimSpace(request.ClusterID)
-		if clusterID == "" {
-			return nil, fmt.Errorf("db pool %d cluster id is required", request.DBPoolID)
-		}
 		request.DBPoolUUID = parsedUUID.String()
 		request.ClusterID = clusterID
-		targets[clusterID] = request
+		if _, exists := targetsByUUID[request.DBPoolUUID]; exists {
+			return nil, fmt.Errorf("duplicate db pool uuid %s", request.DBPoolUUID)
+		}
+		targetsByUUID[request.DBPoolUUID] = request
+		if clusterID == "" {
+			discoverByUUID = true
+			continue
+		}
 		clusterIDs = append(clusterIDs, clusterID)
+	}
+	if discoverByUUID {
+		clusterIDs = nil
 	}
 	infos, err := p.listClusterInfosWithCredentials(ctx, publicKey, privateKey, clusterIDs, len(clusterIDs))
 	if err != nil {
 		return nil, err
 	}
-	out := make([]*tenant.SharedDBPoolInfo, 0, len(infos))
-	var partialErr error
+	infosByClusterID := make(map[string][]clusterInfo, len(infos))
+	infosByUUID := make(map[string][]clusterInfo, len(infos))
 	for i := range infos {
-		target, ok := targets[strings.TrimSpace(infos[i].ClusterID)]
-		if !ok {
+		clusterID := strings.TrimSpace(infos[i].ClusterID)
+		infosByClusterID[clusterID] = append(infosByClusterID[clusterID], infos[i])
+		if strings.TrimSpace(infos[i].Labels[Drive9ManagedLabel]) != "true" ||
+			strings.TrimSpace(infos[i].Labels[Drive9ProviderLabel]) != tenant.ProviderTiDBCloudNativeShared {
 			continue
 		}
-		result, convertErr := p.sharedDBPoolInfoFromCluster(target.DBPoolID, target.DBPoolUUID, &infos[i])
+		poolUUID, parseErr := uuid.Parse(strings.TrimSpace(infos[i].Labels[Drive9DBPoolUUIDLabel]))
+		if parseErr == nil {
+			infosByUUID[poolUUID.String()] = append(infosByUUID[poolUUID.String()], infos[i])
+		}
+	}
+	out := make([]*tenant.SharedDBPoolInfo, 0, len(requests))
+	var partialErr error
+	for _, target := range targetsByUUID {
+		var matches []clusterInfo
+		if clusterID := strings.TrimSpace(target.ClusterID); clusterID != "" {
+			matches = infosByClusterID[clusterID]
+		} else {
+			matches = infosByUUID[target.DBPoolUUID]
+		}
+		if len(matches) == 0 {
+			continue
+		}
+		if len(matches) != 1 {
+			partialErr = errors.Join(partialErr, fmt.Errorf("%w: found %d managed shared clusters for db pool %s",
+				tenant.ErrSharedDBPoolAmbiguous, len(matches), target.DBPoolUUID))
+			continue
+		}
+		result, convertErr := p.sharedDBPoolInfoFromCluster(target.DBPoolID, target.DBPoolUUID, &matches[0])
 		if convertErr != nil {
 			partialErr = errors.Join(partialErr, convertErr)
 			continue

--- a/pkg/tenant/tidbcloudnative/provisioner.go
+++ b/pkg/tenant/tidbcloudnative/provisioner.go
@@ -569,9 +569,6 @@ func (p *Provisioner) BatchProvisionSharedDBPoolsWithCredentials(ctx context.Con
 	if len(inputs) == 0 {
 		return []*tenant.SharedDBPoolInfo{}, nil
 	}
-	if len(inputs) > 10 {
-		return nil, fmt.Errorf("shared db pool batch size %d exceeds 10", len(inputs))
-	}
 	requests := make([]map[string]any, 0, len(inputs))
 	inputsByUUID := make(map[string]tenant.SharedDBPoolCreateRequest, len(inputs))
 	databaseNames := make(map[string]string, len(inputs))

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -1001,6 +1001,73 @@ func TestLoadSharedDBPoolWithoutClusterIDMatchesUUID(t *testing.T) {
 	}
 }
 
+func TestListSharedDBPoolsWithCredentialsReturnsAllExactManagedUUIDMatches(t *testing.T) {
+	const wantUUID = "22222222-2222-4222-8222-222222222222"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-shared-list-all", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodGet || r.URL.Path != "/v1beta1/clusters" {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"clusters": []map[string]any{
+			{
+				"clusterId": "cluster-z", "state": "CREATING",
+				"labels": map[string]string{
+					Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+					Drive9DBPoolUUIDLabel: wantUUID,
+				},
+			},
+			{
+				"clusterId": "cluster-a", "state": "ACTIVE", "userPrefix": "shared-user",
+				"endpoints": map[string]any{"public": map[string]any{"host": "shared.example", "port": 4000}},
+				"labels": map[string]string{
+					Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+					Drive9DBPoolUUIDLabel: wantUUID, TiDBCloudOrganizationLabel: "org-1",
+				},
+			},
+			{
+				"clusterId": "cluster-wrong-provider", "state": "ACTIVE",
+				"labels": map[string]string{
+					Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNative,
+					Drive9DBPoolUUIDLabel: wantUUID,
+				},
+			},
+			{
+				"clusterId": "cluster-other-uuid", "state": "ACTIVE",
+				"labels": map[string]string{
+					Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+					Drive9DBPoolUUIDLabel: "11111111-1111-4111-8111-111111111111",
+				},
+			},
+		}})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{apiURL: ts.URL, defaultDatabaseName: DefaultDatabaseName}
+	got, err := p.ListSharedDBPoolsWithCredentials(context.Background(), 41, wantUUID, tenant.CredentialProvisionRequest{
+		PublicKey: "public", PrivateKey: "private",
+	})
+	if err != nil {
+		t.Fatalf("ListSharedDBPoolsWithCredentials: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("shared DB pools = %#v, want two exact managed UUID matches", got)
+	}
+	if got[0].ClusterID != "cluster-a" || got[1].ClusterID != "cluster-z" {
+		t.Fatalf("sorted cluster IDs = %q, %q", got[0].ClusterID, got[1].ClusterID)
+	}
+	if got[0].DBPoolID != 41 || got[0].DBPoolUUID != wantUUID || got[1].DBPoolID != 41 || got[1].DBPoolUUID != wantUUID {
+		t.Fatalf("durable pool identity was not preserved: %#v", got)
+	}
+	if got[1].Host != "" || got[1].Port != 0 || got[1].Username != "" {
+		t.Fatalf("incomplete creating cluster unexpectedly has endpoint metadata: %#v", got[1])
+	}
+}
+
 func TestBatchLoadSharedDBPoolsUsesOneClusterListRequest(t *testing.T) {
 	const firstUUID = "11111111-1111-4111-8111-111111111111"
 	const secondUUID = "22222222-2222-4222-8222-222222222222"

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -868,6 +868,74 @@ func TestBatchProvisionSharedDBPoolsUsesPhysicalPoolIdentity(t *testing.T) {
 	}
 }
 
+func TestBatchProvisionSharedDBPoolsSendsFiftyPoolsInOneCloudRequest(t *testing.T) {
+	const batchSize = 50
+	inputs := make([]tenant.SharedDBPoolCreateRequest, 0, batchSize)
+	clusters := make([]map[string]any, 0, batchSize)
+	for i := range batchSize {
+		poolUUID := fmt.Sprintf("00000000-0000-4000-8000-%012d", i+1)
+		inputs = append(inputs, tenant.SharedDBPoolCreateRequest{
+			DBPoolID:               int64(i + 1),
+			DBPoolUUID:             poolUUID,
+			CustomerOrganizationID: fmt.Sprintf("customer-org-%d", i+1),
+			RootPassword:           fmt.Sprintf("durable-password-%d", i+1),
+			SpendingLimitMonthly:   1_000_000,
+		})
+		clusters = append(clusters, map[string]any{
+			"clusterId": fmt.Sprintf("cluster-%d", i+1),
+			"state":     "CREATING",
+			"labels": map[string]string{
+				TiDBCloudOrganizationLabel: "org-1",
+				Drive9DBPoolUUIDLabel:      poolUUID,
+			},
+		})
+	}
+
+	var cloudCalls atomic.Int32
+	var requestCount atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-shared-50", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		if r.Method != http.MethodPost || r.URL.Path != "/v1beta1/clusters:batchCreate" {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		cloudCalls.Add(1)
+		var body struct {
+			Requests []json.RawMessage `json:"requests"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		requestCount.Store(int32(len(body.Requests)))
+		_ = json.NewEncoder(w).Encode(map[string]any{"clusters": clusters})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{
+		apiURL: ts.URL, cloudProvider: "aws", region: "us-east-1",
+		defaultDatabaseName: DefaultDatabaseName,
+	}
+	got, err := p.BatchProvisionSharedDBPoolsWithCredentials(context.Background(), inputs,
+		tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	if err != nil {
+		t.Fatalf("BatchProvisionSharedDBPoolsWithCredentials: %v", err)
+	}
+	if calls := cloudCalls.Load(); calls != 1 {
+		t.Fatalf("authorized Cloud batch-create calls = %d, want 1", calls)
+	}
+	if count := requestCount.Load(); count != batchSize {
+		t.Fatalf("Cloud batch-create definitions = %d, want %d", count, batchSize)
+	}
+	if len(got) != batchSize {
+		t.Fatalf("shared pool results = %d, want %d", len(got), batchSize)
+	}
+}
+
 func TestBatchProvisionSharedDBPoolsRejectsMissingCustomerOrganizationBeforeRequest(t *testing.T) {
 	var calls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -183,7 +183,7 @@ func TestValidateSharedCredentialsUsesConfiguredKeyAtStartup(t *testing.T) {
 			defer ts.Close()
 
 			p := &Provisioner{
-				iamURL: ts.URL,
+				iamURL:                 ts.URL,
 				defaultSharedPublicKey: "SHAREDOWNER1", defaultSharedPrivateKey: "test-shared-private",
 			}
 			err := p.ValidateSharedCredentials(context.Background())
@@ -1046,6 +1046,49 @@ func TestBatchLoadSharedDBPoolsUsesOneClusterListRequest(t *testing.T) {
 	if len(got) != 2 || got[0].Host != "shared.example" || got[0].Port != 4000 || got[0].Username != "u1.root" ||
 		got[1].Host != "" || got[1].Port != 0 || got[1].Username != "" {
 		t.Fatalf("batch loaded shared pools = %+v", got)
+	}
+}
+
+func TestBatchLoadSharedDBPoolsDiscoversMissingClusterIDsByUUID(t *testing.T) {
+	const firstUUID = "11111111-1111-4111-8111-111111111111"
+	const secondUUID = "22222222-2222-4222-8222-222222222222"
+	var authorizedCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="nonce-shared-discover", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		authorizedCalls.Add(1)
+		if filter := r.URL.Query().Get("filter"); strings.Contains(filter, "clusterId =") {
+			http.Error(w, "discovery must list by managed labels, got filter: "+filter, http.StatusBadRequest)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"clusters": []map[string]any{
+			{"clusterId": "cluster-1", "state": "CREATING", "labels": map[string]string{
+				Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+				Drive9DBPoolUUIDLabel: firstUUID, TiDBCloudOrganizationLabel: "org-1"}},
+			{"clusterId": "cluster-2", "state": "CREATING", "labels": map[string]string{
+				Drive9ManagedLabel: "true", Drive9ProviderLabel: tenant.ProviderTiDBCloudNativeShared,
+				Drive9DBPoolUUIDLabel: secondUUID, TiDBCloudOrganizationLabel: "org-1"}},
+		}})
+	}))
+	defer ts.Close()
+
+	p := &Provisioner{apiURL: ts.URL}
+	got, err := p.BatchLoadSharedDBPoolsWithCredentials(context.Background(), []tenant.SharedDBPoolLoadRequest{
+		{DBPoolID: 1, DBPoolUUID: firstUUID},
+		{DBPoolID: 2, DBPoolUUID: secondUUID},
+	}, tenant.CredentialProvisionRequest{PublicKey: "public", PrivateKey: "private"})
+	if err != nil {
+		t.Fatalf("BatchLoadSharedDBPoolsWithCredentials: %v", err)
+	}
+	if authorizedCalls.Load() != 1 {
+		t.Fatalf("authorized list calls = %d, want 1", authorizedCalls.Load())
+	}
+	if len(got) != 2 || got[0].DBPoolID != 1 || got[0].ClusterID != "cluster-1" ||
+		got[1].DBPoolID != 2 || got[1].ClusterID != "cluster-2" {
+		t.Fatalf("discovered shared pools = %+v", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Move shared logical-pool bulk refill to the leader. Shared tenant requests claim existing inventory and retain the direct per-request fallback; native refill remains request-scoped because it needs the customer TiDB Cloud key.
- Scan active shared logical pools every 5 seconds by default and enqueue at most one task per pool per scan into 15 leader workers. Same-pool queued/running work is coalesced in memory; different pools remain parallel.
- Bound one refill attempt to one configurable Cloud batch request, defaulting to 50 physical TiDB clusters. Larger deficits converge through later durable scans.
- Keep Cloud work outside database locks. There is no tenant-pool MySQL named lock, distributed refill lock, or durable work queue; durable correctness comes from the atomic metadb wave transaction and a short logical-pool row ownership check inside that transaction.

## Durable refill ownership

- Atomically stage each refill wave in metadb before issuing the Cloud request. The transaction creates the physical `db_pool` rows together with all intended pending tenants, `fs_registry` rows, quota/profile rows, placements, free pool memberships, and accurate `db_pool.tenant_count` values.
- After independent tenant/quota/profile staging and before publishing placements/memberships, lock the logical pool row and revalidate its existence, active status, organization, current size, and current durable capacity. Delete or shrink winning first rolls back the complete wave, and Cloud creation never starts.
- For shared admin PATCH growth, pass an explicit expected-size/target-size contract into the same wave transaction. The transaction rejects a stale expected size, validates capacity against the target, and updates the logical size atomically with the reservations before Cloud starts.
- Validate every physical partition in a wave against the same logical pool and organization. Concurrent waves serialize only for the short ownership/capacity check; no lock is held across Cloud calls.
- Use batched multi-row SQL per physical partition instead of the previous per-tenant writer transactions. This removes the global 30-writer path and its hot `db_pool` row contention.
- A physical row is never visible without its intended logical reservations. Generic direct allocation therefore cannot steal refill-owned capacity; it can consume only a genuinely unreserved tail on the last partially-filled physical pool.
- A staging, ownership, or capacity error rolls back the entire wave, so no earlier empty physical pools or orphan pool memberships survive.
- Retry the complete atomic wave on bounded metadb lock conflicts, matching the established `fs_registry` allocation behavior.

## Authoritative capacity and recovery

- Count active claimable inventory separately from shared pending/provisioning planned inventory.
- Remove the independent one-minute planned-capacity lease and its environment setting. A pending/provisioning physical attempt continues to offset refill until the stuck watchdog atomically transitions the physical pool and its placed free tenants to `failed`.
- Late Cloud results cannot revive a terminal failed physical attempt. Only after the terminal transition removes the old capacity may a later refill scan create replacement capacity.
- Add a leader recovery scan for active physical pools with stranded provisioning tenants, covering a crash between physical activation and `ActivateSharedTenantsBatch` completion.
- Exclude native pending tenants from leader-owned shared planned capacity because the leader does not hold their request-scoped customer credential.

## Existing convergence hardening retained

- Metadata and provisioning keyset cursors wrap after a short page so continuous arrivals cannot starve older rows.
- Incomplete Cloud metadata does not heartbeat `db_pool.updated_at`; `pending` remains connection-metadata wait, `provisioning` remains shared schema initialization, and the 15-minute stuck timeout remains effective.
- Schema-provisioning concurrency is bounded by `min(configured workers, metadb MaxOpenConns / 2)` so advisory-lock sessions cannot exhaust the control-plane pool.
- Cloud batch-create requests use one server-global semaphore with a default maximum of 5 concurrent requests. The permit is released immediately when the Cloud request returns, before local result persistence.
- Failed cleanup reclaims stale deleting tenants, repairs positive `tenant_count` drift only when authoritative placements are empty, and removes all exact managed/shared UUID matches from Cloud before deleting the durable row.
- Leader loss cancels and waits outside `leaderWorkerMu`, avoiding shutdown deadlock while preventing overlapping leader generations.

## Default pipeline

```text
leader scan after each completed 5s interval
  -> one queued/running task per active logical pool
  -> 15 workers with queue backpressure and 5s worker rest
  -> exact active + non-terminal planned inventory check
  -> one metadb transaction reserves up to 50 physical pools and all logical members
  -> short logical-pool row lock + lifecycle/capacity revalidation
  -> one Cloud batch create request, globally bounded to 5 concurrent requests/server
  -> pending metadata workers pull connection readiness
  -> provisioning workers run shared schema init
  -> activate physical pools and placed tenants
  -> active-pool activation reconciler finalizes any stranded tenants
```

## Configuration

- `DRIVE9_TENANT_POOL_RECONCILE_INTERVAL` default `5s`
- `DRIVE9_TENANT_POOL_RECONCILE_WORKERS` default `15`
- `DRIVE9_TENANT_POOL_RECONCILE_WORKER_REST` default `5s`
- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE` default `50`
- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_WORKERS` default/max `15`
- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_BATCH_SIZE` default/max `30`
- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_METADATA_POLL_INTERVAL` default `15s`
- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_PROVISIONING_WORKERS` configured ceiling, additionally bounded by metadb `MaxOpenConns / 2`
- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_STUCK_TIMEOUT` default `15m`
- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_INTERVAL` default `1m`
- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_BATCH_SIZE` default `5`

## Upgrade notes

- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_REFILL_POOL_LIMIT` is intentionally removed without an alias. One logical-pool scan now stages at most one configurable Cloud batch and later scans converge any remaining deficit.
- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_PLANNED_CAPACITY_LEASE` is intentionally removed without an alias. The stuck watchdog is the single durable terminalization boundary for planned capacity.
- `DRIVE9_TIDBCLOUD_NATIVE_SHARED_CLOUD_BATCH_SIZE` is no longer clamped to 50; 50 is the default, while the server-global 5-request semaphore independently bounds concurrent Cloud pressure.
- The global 30 shared per-tenant writer limit and related runtime path are removed with the batched atomic wave implementation.

## Verification

- Red/green regressions for atomic shared PATCH grow, stale-grow rollback without Cloud or durable side effects, orphan planned-membership exclusion, delete-vs-blocked-wave, shrink-vs-blocked-wave, Cloud request concurrency, recoverable pending/provisioning capacity, active physical pools with stranded provisioning tenants, terminal failure fencing, and direct-allocation isolation during atomic wave staging.
- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/meta ./pkg/server ./pkg/tenant/tidbcloudnative -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test -race ./pkg/server ./pkg/meta ./pkg/tenant/tidbcloudnative -count=1`
- `GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint`
- `CGO_ENABLED=0 GOCACHE=/tmp/drive9-go-cache go build ./...`
- `git diff --check`

