### PR TITLE
fix: map non-empty directory delete to HTTP 409

### DIFF
--- a/pkg/backend/dat9_test.go
+++ b/pkg/backend/dat9_test.go
@@ -556,6 +556,25 @@ func TestRemoveFileAndDirCtxUseTypedPaths(t *testing.T) {
 	}
 }
 
+func TestRemoveNonEmptyDirectoryReturnsErrDirectoryNotEmpty(t *testing.T) {
+	b := newTestBackend(t)
+	ctx := context.Background()
+
+	if err := b.Mkdir("/tree", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.Write("/tree/child.txt", []byte("data"), 0, filesystem.WriteFlagCreate); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := b.RemoveCtx(ctx, "/tree/"); !errors.Is(err, datastore.ErrDirectoryNotEmpty) {
+		t.Fatalf("RemoveCtx non-empty dir err = %v, want ErrDirectoryNotEmpty", err)
+	}
+	if err := b.RemoveDirCtx(ctx, "/tree/"); !errors.Is(err, datastore.ErrDirectoryNotEmpty) {
+		t.Fatalf("RemoveDirCtx non-empty dir err = %v, want ErrDirectoryNotEmpty", err)
+	}
+}
+
 func TestRemoveAll(t *testing.T) {
 	b := newTestBackend(t)
 	if err := b.Mkdir("/data", 0o755); err != nil {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -26,6 +26,7 @@ var (
 	ErrUploadNotActive         = errors.New("upload is not in UPLOADING state")
 	ErrUploadExpired           = errors.New("upload has expired")
 	ErrPathConflict            = errors.New("path already exists")
+	ErrDirectoryNotEmpty       = errors.New("directory not empty")
 	ErrInvalidLinkTarget       = errors.New("invalid link target")
 	ErrInvalidRootDentry       = errors.New("root path is implicit and cannot be mutated as a file node")
 	ErrUploadConflict          = errors.New("active upload already exists for this path")
@@ -382,7 +383,7 @@ func (s *Store) DeleteEmptyDir(ctx context.Context, path string) (err error) {
 		return err
 	}
 	if hasChildren {
-		return fmt.Errorf("directory not empty: %s", path)
+		return fmt.Errorf("%w: %s", ErrDirectoryNotEmpty, path)
 	}
 	res, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+s.scope.And(`path_hash = ? AND path = ? AND is_directory = 1`),
 		s.scope.Args(fileNodePathHash(path), path)...)
@@ -3115,6 +3116,7 @@ func storeOpResultForError(err error) string {
 	case errors.Is(err, ErrNotFound):
 		return "not_found"
 	case errors.Is(err, ErrPathConflict),
+		errors.Is(err, ErrDirectoryNotEmpty),
 		errors.Is(err, ErrRevisionConflict),
 		errors.Is(err, ErrUploadConflict),
 		errors.Is(err, ErrUploadNotActive),

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -61,6 +61,8 @@ func TestStoreOpResultForErrorClassifiesExpectedConflicts(t *testing.T) {
 		{name: "nil", err: nil, want: "ok"},
 		{name: "not found", err: ErrNotFound, want: "not_found"},
 		{name: "path conflict", err: ErrPathConflict, want: "conflict"},
+		{name: "directory not empty", err: ErrDirectoryNotEmpty, want: "conflict"},
+		{name: "directory not empty wrapped", err: fmt.Errorf("%w: /dir/", ErrDirectoryNotEmpty), want: "conflict"},
 		{name: "revision conflict", err: ErrRevisionConflict, want: "conflict"},
 		{name: "upload conflict", err: ErrUploadConflict, want: "conflict"},
 		{name: "upload not active", err: ErrUploadNotActive, want: "conflict"},

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3960,8 +3960,12 @@ func httpToFuseStatus(err error) gofuse.Status {
 		case http.StatusNotFound:
 			return gofuse.ENOENT
 		case http.StatusConflict:
-			if strings.Contains(strings.ToLower(se.Message), "revision conflict") {
+			lower := strings.ToLower(se.Message)
+			if strings.Contains(lower, "revision conflict") {
 				return gofuse.EIO
+			}
+			if strings.Contains(lower, "directory not empty") {
+				return gofuse.Status(syscall.ENOTEMPTY)
 			}
 			return gofuse.Status(syscall.EEXIST)
 		case http.StatusForbidden:
@@ -3991,6 +3995,8 @@ func httpToFuseStatus(err error) gofuse.Status {
 	switch {
 	case strings.Contains(lowerMsg, "not found") || strings.Contains(msg, "HTTP 404"):
 		return gofuse.ENOENT
+	case strings.Contains(lowerMsg, "directory not empty"):
+		return gofuse.Status(syscall.ENOTEMPTY)
 	case strings.Contains(lowerMsg, "already exists") || strings.Contains(msg, "HTTP 409"):
 		return gofuse.Status(syscall.EEXIST)
 	case strings.Contains(msg, "HTTP 403"):

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -7582,6 +7582,16 @@ func TestHTTPToFuseStatus_MapsConflictToEEXIST(t *testing.T) {
 	}
 }
 
+func TestHTTPToFuseStatus_MapsDirectoryNotEmptyToENOTEMPTY(t *testing.T) {
+	want := gofuse.Status(syscall.ENOTEMPTY)
+	if got := httpToFuseStatus(&client.StatusError{StatusCode: http.StatusConflict, Message: "directory not empty: /dir/"}); got != want {
+		t.Fatalf("status error 409 directory not empty = %v, want %v", got, want)
+	}
+	if got := httpToFuseStatus(fmt.Errorf("directory not empty: /dir/")); got != want {
+		t.Fatalf("string directory not empty = %v, want %v", got, want)
+	}
+}
+
 func TestHTTPToFuseStatus_PreservesRevisionConflictAsEIO(t *testing.T) {
 	if got := httpToFuseStatus(&client.StatusError{StatusCode: http.StatusConflict, Message: "revision conflict"}); got != gofuse.EIO {
 		t.Fatalf("revision conflict status = %v, want %v", got, gofuse.EIO)

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/go-sql-driver/mysql"
 	"github.com/mem9-ai/drive9/pkg/backend"
+	"github.com/mem9-ai/drive9/pkg/datastore"
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
@@ -83,6 +84,9 @@ func sanitizeClientError(err error) string {
 	if err == nil {
 		return "backend unavailable"
 	}
+	if errors.Is(err, datastore.ErrDirectoryNotEmpty) {
+		return err.Error()
+	}
 	if isQuotaError(err) {
 		return "tenant usage quota exceeded"
 	}
@@ -98,6 +102,9 @@ func backendErrorStatus(ctx context.Context, err error) int {
 	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return http.StatusGatewayTimeout
+	}
+	if errors.Is(err, datastore.ErrDirectoryNotEmpty) {
+		return http.StatusConflict
 	}
 	if isQuotaError(err) {
 		return http.StatusPaymentRequired

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/go-sql-driver/mysql"
+	"github.com/mem9-ai/drive9/pkg/datastore"
 	"github.com/mem9-ai/drive9/pkg/encrypt"
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
@@ -821,6 +822,14 @@ func TestSanitizeClientError_Fallback(t *testing.T) {
 	}
 }
 
+func TestSanitizeClientError_DirectoryNotEmpty(t *testing.T) {
+	err := fmt.Errorf("%w: /projects/a/b/", datastore.ErrDirectoryNotEmpty)
+	got := sanitizeClientError(err)
+	if got != err.Error() {
+		t.Fatalf("got %q, want %q", got, err.Error())
+	}
+}
+
 func TestBackendErrorStatus(t *testing.T) {
 	tests := []struct {
 		name string
@@ -856,6 +865,16 @@ func TestBackendErrorStatus(t *testing.T) {
 			name: "schema migration error",
 			err:  fmt.Errorf("migrate split tables: Error 1146: Table doesn't exist"),
 			want: http.StatusBadGateway,
+		},
+		{
+			name: "directory not empty",
+			err:  datastore.ErrDirectoryNotEmpty,
+			want: http.StatusConflict,
+		},
+		{
+			name: "directory not empty wrapped",
+			err:  fmt.Errorf("%w: /projects/a/b/", datastore.ErrDirectoryNotEmpty),
+			want: http.StatusConflict,
 		},
 		{
 			name: "unknown error",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3421,6 +3421,13 @@ func (s *Server) handleDelete(w http.ResponseWriter, r *http.Request, path strin
 			errJSON(w, http.StatusNotFound, err.Error())
 			return
 		}
+		if errors.Is(err, datastore.ErrDirectoryNotEmpty) {
+			// Non-recursive rmdir of a non-empty directory is an expected
+			// client conflict (POSIX ENOTEMPTY), not a server fault.
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "delete_not_empty", "path", path, "recursive", recursive, "kind", kind, "error", err)...)
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
 		if errJSONInvalidRootDentry(w, err) {
 			return
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1560,6 +1560,72 @@ func TestDelete(t *testing.T) {
 	}
 }
 
+func TestDeleteNonEmptyDirectoryReturnsConflict(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/nonempty?mkdir", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mkdir status = %d, want 200", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/nonempty/child.txt", strings.NewReader("data"))
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("write status = %d, want 200", resp.StatusCode)
+	}
+
+	// Non-recursive delete of a non-empty directory is an expected client
+	// conflict (POSIX ENOTEMPTY), not a 5xx server fault.
+	for _, rawQuery := range []string{"", "kind=dir"} {
+		req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/v1/fs/nonempty?"+rawQuery, nil)
+		resp, err = http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		body, _ := io.ReadAll(resp.Body)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusConflict {
+			t.Fatalf("delete non-empty dir (?%s) status = %d, want 409, body=%s", rawQuery, resp.StatusCode, body)
+		}
+		if !strings.Contains(string(body), "directory not empty") {
+			t.Fatalf("delete non-empty dir (?%s) body = %s, want directory not empty", rawQuery, body)
+		}
+	}
+
+	// Still present after conflict.
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/nonempty/", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("dir still present status = %d, want 200", resp.StatusCode)
+	}
+
+	// Recursive delete succeeds.
+	req, _ = http.NewRequest(http.MethodDelete, ts.URL+"/v1/fs/nonempty?recursive", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("recursive delete status = %d, want 200", resp.StatusCode)
+	}
+}
+
 func TestDeleteKindHint(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)


### PR DESCRIPTION
## Summary

- Non-recursive `DELETE /v1/fs/*` on a non-empty directory used to surface as **HTTP 500**, which tripped `Drive9RouteHTTPErrorRateCritical` (seen on tencentcloud-ap-beijing when a client cleaned a `smali_out` tree without `?recursive`).
- Introduce `datastore.ErrDirectoryNotEmpty` and map it to **HTTP 409 Conflict** (client conflict / POSIX `ENOTEMPTY`), with warn-level logging instead of error.
- Classify the error as a datastore `conflict` result (warn, not error metrics/logs).
- FUSE maps `409` + `directory not empty` to `ENOTEMPTY` instead of `EEXIST`.

## Test plan

- [x] `go test ./pkg/server/ -run 'TestBackendErrorStatus|TestSanitizeClientError_DirectoryNotEmpty|TestDeleteNonEmptyDirectoryReturnsConflict|TestDeleteKindHint|TestDelete$'`
- [x] `go test ./pkg/backend/ -run 'TestRemoveNonEmptyDirectoryReturnsErrDirectoryNotEmpty|TestRemoveFileAndDirCtxUseTypedPaths'`
- [x] `go test ./pkg/fuse/ -run 'TestHTTPToFuseStatus_MapsDirectoryNotEmptyToENOTEMPTY|TestHTTPToFuseStatus_MapsConflictToEEXIST|TestHTTPToFuseStatus_PreservesRevisionConflictAsEIO'`
- [ ] CI green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Deleting a non-empty directory now returns a clear `409 Conflict` response.
  - Directory contents are preserved when deletion is rejected.
  - Recursive deletion continues to remove non-empty directories successfully.
  - Filesystem clients now receive the appropriate “directory not empty” error status.
  - Error messages are preserved and reported clearly across API and filesystem operations.

- **Tests**
  - Added coverage for backend, API, authentication, and filesystem handling of non-empty directory deletion conflicts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->