### PR TITLE
feat: defer quota counter updates to transaction end and skip no-op file meta upserts

### DIFF
--- a/pkg/backend/llm_usage_test.go
+++ b/pkg/backend/llm_usage_test.go
@@ -40,8 +40,8 @@ func (m *mockQuotaStore) EnsureQuotaUsageRow(_ context.Context, _ string) error 
 func (m *mockQuotaStore) IncrStorageBytes(_ context.Context, _ string, _ int64) error   { return nil }
 func (m *mockQuotaStore) IncrReservedBytes(_ context.Context, _ string, _ int64) error  { return nil }
 func (m *mockQuotaStore) IncrFileCount(_ context.Context, _ string, _ int64) error      { return nil }
-func (m *mockQuotaStore) IncrMediaFileCount(_ context.Context, _ string, _ int64) error  { return nil }
-func (m *mockQuotaStore) IncrVideoFileCount(_ context.Context, _ string, _ int64) error  { return nil }
+func (m *mockQuotaStore) IncrMediaFileCount(_ context.Context, _ string, _ int64) error { return nil }
+func (m *mockQuotaStore) IncrVideoFileCount(_ context.Context, _ string, _ int64) error { return nil }
 func (m *mockQuotaStore) TransferReservedToConfirmed(_ context.Context, _ string, _, _ int64) error {
 	return nil
 }
@@ -51,8 +51,8 @@ func (m *mockQuotaStore) AtomicReserveAndInsertUpload(_ context.Context, _ *Uplo
 func (m *mockQuotaStore) IncrStorageBytesTx(_ *sql.Tx, _ string, _ int64) error   { return nil }
 func (m *mockQuotaStore) IncrReservedBytesTx(_ *sql.Tx, _ string, _ int64) error  { return nil }
 func (m *mockQuotaStore) IncrFileCountTx(_ *sql.Tx, _ string, _ int64) error      { return nil }
-func (m *mockQuotaStore) IncrMediaFileCountTx(_ *sql.Tx, _ string, _ int64) error  { return nil }
-func (m *mockQuotaStore) IncrVideoFileCountTx(_ *sql.Tx, _ string, _ int64) error  { return nil }
+func (m *mockQuotaStore) IncrMediaFileCountTx(_ *sql.Tx, _ string, _ int64) error { return nil }
+func (m *mockQuotaStore) IncrVideoFileCountTx(_ *sql.Tx, _ string, _ int64) error { return nil }
 func (m *mockQuotaStore) TransferReservedToConfirmedTx(_ *sql.Tx, _ string, _, _ int64) error {
 	return nil
 }

--- a/pkg/backend/llm_usage_test.go
+++ b/pkg/backend/llm_usage_test.go
@@ -56,6 +56,9 @@ func (m *mockQuotaStore) IncrVideoFileCountTx(_ *sql.Tx, _ string, _ int64) erro
 func (m *mockQuotaStore) TransferReservedToConfirmedTx(_ *sql.Tx, _ string, _, _ int64) error {
 	return nil
 }
+func (m *mockQuotaStore) IncrQuotaUsageCountersTx(_ *sql.Tx, _ string, _, _, _, _ int64) error {
+	return nil
+}
 
 func (m *mockQuotaStore) UpsertFileMeta(_ context.Context, _ *FileMetaView) error { return nil }
 func (m *mockQuotaStore) GetFileMeta(_ context.Context, _, _ string) (*FileMetaView, error) {

--- a/pkg/backend/mutation_dispatcher.go
+++ b/pkg/backend/mutation_dispatcher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"hash/fnv"
+	"sort"
 	"sync"
 
 	"go.uber.org/zap"
@@ -43,7 +44,7 @@ type quotaMutationItem struct {
 	mutationType   string
 	logID          int64
 	pending        quotaPendingDeltas
-	apply          func(context.Context, *sql.Tx) error
+	apply          func(context.Context, *sql.Tx) (quotaCounterDeltas, error)
 	// raw is a pre-built closure submitted through the legacy enqueueMutation
 	// API (unit tests). Raw items bypass batching and run one by one.
 	raw func(context.Context)
@@ -213,6 +214,16 @@ type mutationStoreGroup struct {
 // per-tenant FIFO is guaranteed by mutationMu plus one shard per tenant),
 // then one batch mark.
 //
+// Applies return their tenant_quota_usage counter deltas instead of
+// executing them inline; the runner aggregates them per tenant (items are
+// cross-tenant) and flushes them after the last apply in SORTED tenant_id
+// order — a deterministic global lock order so two pods' batch transactions
+// cannot deadlock each other by locking the per-tenant hot rows in different
+// orders. Deferring the counter updates to the end of the tx ("hot row
+// last") shrinks the lock-hold window on the single per-tenant
+// tenant_quota_usage row from the whole batch to just before commit, and N
+// mutations for one tenant collapse into one UPDATE.
+//
 // On any failure — including InnoDB killing the batch as a cross-pod
 // deadlock victim (two pods' batch transactions lock tenant_file_meta rows
 // in different orders) or the batch mark detecting an already-applied row —
@@ -232,8 +243,23 @@ func processMutationStoreGroup(ctx context.Context, store MetaQuotaStore, items 
 		ids[i] = item.logID
 	}
 	err := store.InTx(ctx, func(tx *sql.Tx) error {
+		deltasByTenant := make(map[string]quotaCounterDeltas)
 		for _, item := range items {
-			if err := item.apply(ctx, tx); err != nil {
+			deltas, err := item.apply(ctx, tx)
+			if err != nil {
+				return err
+			}
+			agg := deltasByTenant[item.tenantID]
+			agg.add(deltas)
+			deltasByTenant[item.tenantID] = agg
+		}
+		tenantIDs := make([]string, 0, len(deltasByTenant))
+		for tenantID := range deltasByTenant {
+			tenantIDs = append(tenantIDs, tenantID)
+		}
+		sort.Strings(tenantIDs)
+		for _, tenantID := range tenantIDs {
+			if err := applyQuotaCounterDeltasTx(store, tx, tenantID, deltasByTenant[tenantID]); err != nil {
 				return err
 			}
 		}

--- a/pkg/backend/mutation_dispatcher_test.go
+++ b/pkg/backend/mutation_dispatcher_test.go
@@ -37,11 +37,11 @@ func TestMutationDispatcherAppliesAcrossTenantsPreservingOrder(t *testing.T) {
 			tenantID := b.TenantID()
 			err := b.logAndEnqueueMutation(context.Background(), "file_create",
 				fileCreateMutationData{FileID: fmt.Sprintf("file-%d", n), SizeBytes: 1},
-				quotaPendingDeltas{}, func(context.Context, *sql.Tx) error {
+				quotaPendingDeltas{}, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) {
 					orderMu.Lock()
 					appliedOrder[tenantID] = append(appliedOrder[tenantID], n)
 					orderMu.Unlock()
-					return nil
+					return quotaCounterDeltas{}, nil
 				})
 			if err != nil {
 				t.Fatal(err)
@@ -97,11 +97,11 @@ func TestMutationBatchSingleTxForSameStore(t *testing.T) {
 		tenantID := fmt.Sprintf("batch-tenant-%d", i)
 		b := &Dat9Backend{}
 		b.SetMetaQuotaStore(context.Background(), tenantID, fake)
-		items = append(items, newDispatcherTestItem(t, b, fake, func(context.Context, *sql.Tx) error {
+		items = append(items, newDispatcherTestItem(t, b, fake, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) {
 			orderMu.Lock()
 			received = append(received, tenantID)
 			orderMu.Unlock()
-			return nil
+			return quotaCounterDeltas{}, nil
 		}))
 	}
 
@@ -141,10 +141,10 @@ func TestMutationBatchGroupsByStore(t *testing.T) {
 	bB.SetMetaQuotaStore(context.Background(), "store-b-tenant", fakeB)
 
 	items := []quotaMutationItem{
-		newDispatcherTestItem(t, bA, fakeA, func(context.Context, *sql.Tx) error { return nil }),
-		newDispatcherTestItem(t, bB, fakeB, func(context.Context, *sql.Tx) error { return nil }),
-		newDispatcherTestItem(t, bA, fakeA, func(context.Context, *sql.Tx) error { return nil }),
-		newDispatcherTestItem(t, bB, fakeB, func(context.Context, *sql.Tx) error { return nil }),
+		newDispatcherTestItem(t, bA, fakeA, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return quotaCounterDeltas{}, nil }),
+		newDispatcherTestItem(t, bB, fakeB, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return quotaCounterDeltas{}, nil }),
+		newDispatcherTestItem(t, bA, fakeA, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return quotaCounterDeltas{}, nil }),
+		newDispatcherTestItem(t, bB, fakeB, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return quotaCounterDeltas{}, nil }),
 	}
 
 	processMutationBatch(context.Background(), items)
@@ -189,8 +189,8 @@ func TestMutationBatchGroupsByStoreIdentity(t *testing.T) {
 	bB.SetMetaQuotaStore(context.Background(), "identity-tenant-b", storeB)
 
 	items := []quotaMutationItem{
-		newDispatcherTestItem(t, bA, storeA, func(context.Context, *sql.Tx) error { return nil }),
-		newDispatcherTestItem(t, bB, storeB, func(context.Context, *sql.Tx) error { return nil }),
+		newDispatcherTestItem(t, bA, storeA, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return quotaCounterDeltas{}, nil }),
+		newDispatcherTestItem(t, bB, storeB, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return quotaCounterDeltas{}, nil }),
 	}
 
 	processMutationBatch(context.Background(), items)
@@ -222,8 +222,8 @@ func TestMutationBatchAlreadyAppliedMarkFallsBackToPerItem(t *testing.T) {
 	b2.SetMetaQuotaStore(context.Background(), "aa-tenant-2", fake)
 
 	items := []quotaMutationItem{
-		newDispatcherTestItem(t, b1, fake, func(context.Context, *sql.Tx) error { return nil }),
-		newDispatcherTestItem(t, b2, fake, func(context.Context, *sql.Tx) error { return nil }),
+		newDispatcherTestItem(t, b1, fake, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return quotaCounterDeltas{}, nil }),
+		newDispatcherTestItem(t, b2, fake, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return quotaCounterDeltas{}, nil }),
 	}
 	// Pre-apply the first item outside the dispatcher so the batch mark fails
 	// with an already-applied-wrapping error on the whole batch.
@@ -265,10 +265,10 @@ func TestMutationBatchPoisonItemFallsBackToPerItem(t *testing.T) {
 	good2 := &Dat9Backend{}
 	good2.SetMetaQuotaStore(context.Background(), "good-tenant-2", fake)
 
-	goodApply := func(context.Context, *sql.Tx) error { return nil }
+	goodApply := func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return quotaCounterDeltas{}, nil }
 	items := []quotaMutationItem{
 		newDispatcherTestItem(t, good1, fake, goodApply),
-		newDispatcherTestItem(t, poison, fake, func(context.Context, *sql.Tx) error { return poisonErr }),
+		newDispatcherTestItem(t, poison, fake, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return quotaCounterDeltas{}, poisonErr }),
 		newDispatcherTestItem(t, good2, fake, goodApply),
 	}
 
@@ -307,9 +307,9 @@ func TestEnqueueMutationItemInlineWhenDispatcherNotStarted(t *testing.T) {
 	var applied atomic.Int64
 	err := b.logAndEnqueueMutation(context.Background(), "file_create",
 		fileCreateMutationData{FileID: "inline-file", SizeBytes: 1},
-		quotaPendingDeltas{}, func(context.Context, *sql.Tx) error {
+		quotaPendingDeltas{}, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) {
 			applied.Add(1)
-			return nil
+			return quotaCounterDeltas{}, nil
 		})
 	if err != nil {
 		t.Fatal(err)
@@ -330,7 +330,7 @@ func TestEnqueueMutationItemInlineWhenDispatcherNotStarted(t *testing.T) {
 // newDispatcherTestItem durably logs a mutation through the backend and
 // builds the dispatcher item exactly the way logAndEnqueueMutation does,
 // including the mutationWG slot the worker releases after processing.
-func newDispatcherTestItem(t *testing.T, b *Dat9Backend, store MetaQuotaStore, apply func(context.Context, *sql.Tx) error) quotaMutationItem {
+func newDispatcherTestItem(t *testing.T, b *Dat9Backend, store MetaQuotaStore, apply func(context.Context, *sql.Tx) (quotaCounterDeltas, error)) quotaMutationItem {
 	t.Helper()
 	logID, err := b.logQuotaMutation(context.Background(), "file_create", fileCreateMutationData{FileID: "f", SizeBytes: 1})
 	if err != nil {

--- a/pkg/backend/mutation_hot_row_last_test.go
+++ b/pkg/backend/mutation_hot_row_last_test.go
@@ -1,0 +1,182 @@
+package backend
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestMutationBatchAggregatesCounterDeltasSortedByTenant drives a cross-tenant
+// batch (3 mutations for one tenant, 1 for another) and asserts the "hot row
+// last" contract: the runner flushes exactly one IncrQuotaUsageCountersTx per
+// tenant, in sorted tenant_id order (deterministic cross-pod lock order),
+// with the per-item deltas correctly summed.
+func TestMutationBatchAggregatesCounterDeltasSortedByTenant(t *testing.T) {
+	fake := newFakeMetaQuotaStore()
+
+	bA := &Dat9Backend{}
+	bA.SetMetaQuotaStore(context.Background(), "agg-tenant-a", fake)
+	bB := &Dat9Backend{}
+	bB.SetMetaQuotaStore(context.Background(), "agg-tenant-b", fake)
+
+	fixedDeltas := func(d quotaCounterDeltas) func(context.Context, *sql.Tx) (quotaCounterDeltas, error) {
+		return func(context.Context, *sql.Tx) (quotaCounterDeltas, error) { return d, nil }
+	}
+	items := []quotaMutationItem{
+		newDispatcherTestItem(t, bA, fake, fixedDeltas(quotaCounterDeltas{storageBytes: 10, fileCount: 1})),
+		newDispatcherTestItem(t, bB, fake, fixedDeltas(quotaCounterDeltas{storageBytes: 7, fileCount: 1})),
+		newDispatcherTestItem(t, bA, fake, fixedDeltas(quotaCounterDeltas{storageBytes: 20})),
+		newDispatcherTestItem(t, bA, fake, fixedDeltas(quotaCounterDeltas{storageBytes: 5, mediaFileCount: 1, reservedBytes: -3})),
+	}
+
+	processMutationBatch(context.Background(), items)
+
+	// processMutationBatch is synchronous, so the fake state is stable here.
+	want := []incrQuotaUsageCountersCall{
+		{tenantID: "agg-tenant-a", storageDelta: 35, fileDelta: 1, mediaDelta: 1, reservedDelta: -3},
+		{tenantID: "agg-tenant-b", storageDelta: 7, fileDelta: 1},
+	}
+	if len(fake.incrQuotaUsageCountersCalls) != len(want) {
+		t.Fatalf("counter flush calls = %v, want %v", fake.incrQuotaUsageCountersCalls, want)
+	}
+	for i, w := range want {
+		if got := fake.incrQuotaUsageCountersCalls[i]; got != w {
+			t.Fatalf("counter flush call %d = %+v, want %+v (sorted tenant order, summed deltas)", i, got, w)
+		}
+	}
+	for _, item := range items {
+		if got := fake.mutationStatus(item.logID); got != "applied" {
+			t.Fatalf("mutation %d status = %q, want applied", item.logID, got)
+		}
+	}
+}
+
+// TestMutationBatchCreateThenOverwriteSumsDeltas proves the in-tx read-your-
+// writes property of delta aggregation: create(file,100) followed by
+// overwrite(file,100→150) in ONE batch must sum to storage_bytes +150 and
+// file_count +1, because the overwrite's GetFileMetaForUpdateTx sees the
+// create's in-tx upsert.
+func TestMutationBatchCreateThenOverwriteSumsDeltas(t *testing.T) {
+	fake := newFakeMetaQuotaStore()
+	b := &Dat9Backend{}
+	b.SetMetaQuotaStore(context.Background(), "hot-tenant", fake)
+
+	items := []quotaMutationItem{
+		newDispatcherTestItem(t, b, fake, func(ctx context.Context, tx *sql.Tx) (quotaCounterDeltas, error) {
+			return applyCentralFileCreateTx(fake, tx, "hot-tenant", fileCreateMutationData{FileID: "f1", SizeBytes: 100})
+		}),
+		newDispatcherTestItem(t, b, fake, func(ctx context.Context, tx *sql.Tx) (quotaCounterDeltas, error) {
+			return applyCentralFileOverwriteTx(fake, tx, "hot-tenant", fileOverwriteMutationData{
+				FileID: "f1", OldSizeBytes: 100, NewSizeBytes: 150,
+			})
+		}),
+	}
+
+	processMutationBatch(context.Background(), items)
+
+	if len(fake.incrQuotaUsageCountersCalls) != 1 {
+		t.Fatalf("counter flush calls = %v, want exactly 1 for a single-tenant batch", fake.incrQuotaUsageCountersCalls)
+	}
+	got := fake.incrQuotaUsageCountersCalls[0]
+	want := incrQuotaUsageCountersCall{tenantID: "hot-tenant", storageDelta: 150, fileDelta: 1}
+	if got != want {
+		t.Fatalf("counter flush = %+v, want %+v (create +100 then overwrite +50)", got, want)
+	}
+	fm, err := fake.GetFileMeta(context.Background(), "hot-tenant", "f1")
+	if err != nil {
+		t.Fatalf("get file meta: %v", err)
+	}
+	if fm.SizeBytes != 150 {
+		t.Fatalf("file meta size = %d, want 150 after in-tx create+overwrite", fm.SizeBytes)
+	}
+	for _, item := range items {
+		if got := fake.mutationStatus(item.logID); got != "applied" {
+			t.Fatalf("mutation %d status = %q, want applied", item.logID, got)
+		}
+	}
+}
+
+// TestMutationBatchNoOpOverwriteSkipsUpsertAndCounters covers the no-op skip:
+// an overwrite whose new size/isMedia already match the shadow row must not
+// upsert tenant_file_meta and must produce zero counter deltas — while the
+// mutation is still marked applied.
+func TestMutationBatchNoOpOverwriteSkipsUpsertAndCounters(t *testing.T) {
+	fake := newFakeMetaQuotaStore()
+	b := &Dat9Backend{}
+	b.SetMetaQuotaStore(context.Background(), "noop-tenant", fake)
+	if err := fake.UpsertFileMeta(context.Background(), &FileMetaView{
+		TenantID: "noop-tenant", FileID: "f1", SizeBytes: 100, IsMedia: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	noopOverwrite := func(context.Context, *sql.Tx) (quotaCounterDeltas, error) {
+		return applyCentralFileOverwriteTx(fake, nil, "noop-tenant", fileOverwriteMutationData{
+			FileID: "f1", OldSizeBytes: 100, OldIsMedia: true, NewSizeBytes: 100, NewIsMedia: true,
+		})
+	}
+	items := []quotaMutationItem{
+		newDispatcherTestItem(t, b, fake, noopOverwrite),
+		newDispatcherTestItem(t, b, fake, noopOverwrite),
+	}
+
+	processMutationBatch(context.Background(), items)
+
+	if fake.upsertFileMetaCalls != 0 {
+		t.Fatalf("UpsertFileMetaTx calls = %d, want 0 (identical size/isMedia must skip the upsert)", fake.upsertFileMetaCalls)
+	}
+	if len(fake.incrQuotaUsageCountersCalls) != 0 {
+		t.Fatalf("counter flush calls = %v, want none (no-op mutations produce zero deltas)", fake.incrQuotaUsageCountersCalls)
+	}
+	for _, item := range items {
+		if got := fake.mutationStatus(item.logID); got != "applied" {
+			t.Fatalf("mutation %d status = %q, want applied (no-op mutations are still marked)", item.logID, got)
+		}
+	}
+	// The shadow row is untouched.
+	fm, err := fake.GetFileMeta(context.Background(), "noop-tenant", "f1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fm.SizeBytes != 100 || !fm.IsMedia {
+		t.Fatalf("file meta = %+v, want unchanged {100 true}", fm)
+	}
+}
+
+// TestInlineApplyFlushesCountersBeforeMark covers the per-item path
+// (dispatcher not running): the apply's counter deltas must be flushed in
+// one statement BEFORE MarkMutationAppliedTx, inside the same transaction.
+func TestInlineApplyFlushesCountersBeforeMark(t *testing.T) {
+	if currentMutationDispatcher() != nil {
+		t.Skip("mutation dispatcher is running (leaked by another test)")
+	}
+	fake := newFakeMetaQuotaStore()
+	b := &Dat9Backend{}
+	b.SetMetaQuotaStore(context.Background(), "inline-deltas-tenant", fake)
+
+	err := b.logAndEnqueueMutation(context.Background(), "file_create",
+		fileCreateMutationData{FileID: "f1", SizeBytes: 64, IsMedia: true},
+		quotaPendingDeltas{storageDelta: 64, fileDelta: 1, mediaDelta: 1},
+		func(ctx context.Context, tx *sql.Tx) (quotaCounterDeltas, error) {
+			return applyCentralFileCreateTx(fake, tx, "inline-deltas-tenant",
+				fileCreateMutationData{FileID: "f1", SizeBytes: 64, IsMedia: true})
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Inline apply is synchronous: the counter flush must precede the mark.
+	if got := fake.counterMarkEvents; len(got) != 2 || got[0] != "counters" || got[1] != "mark" {
+		t.Fatalf("counter/mark events = %v, want [counters mark]", got)
+	}
+	usage, err := fake.GetQuotaUsage(context.Background(), "inline-deltas-tenant")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.StorageBytes != 64 || usage.FileCount != 1 || usage.MediaFileCount != 1 {
+		t.Fatalf("usage = %+v, want storage=64 file=1 media=1", usage)
+	}
+	if got := fake.mutations[len(fake.mutations)-1].status; got != "applied" {
+		t.Fatalf("mutation status = %q, want applied", got)
+	}
+}

--- a/pkg/backend/mutation_replay.go
+++ b/pkg/backend/mutation_replay.go
@@ -252,64 +252,64 @@ func (w *MutationReplayWorker) clearPendingBacklogGauges() {
 
 func (w *MutationReplayWorker) replayOne(ctx context.Context, entry MutationLogView) error {
 	return w.store.InTx(ctx, func(tx *sql.Tx) error {
-		if err := w.applyMutation(ctx, tx, entry); err != nil {
+		deltas, err := w.applyMutation(ctx, tx, entry)
+		if err != nil {
+			return err
+		}
+		// Flush the counter deltas before the mark so the tenant_quota_usage
+		// hot row is touched once, at the end of the tx ("hot row last").
+		if err := applyQuotaCounterDeltasTx(w.store, tx, entry.TenantID, deltas); err != nil {
 			return err
 		}
 		return w.store.MarkMutationAppliedTx(tx, entry.ID)
 	})
 }
 
-func (w *MutationReplayWorker) applyMutation(ctx context.Context, tx *sql.Tx, entry MutationLogView) error {
+func (w *MutationReplayWorker) applyMutation(ctx context.Context, tx *sql.Tx, entry MutationLogView) (quotaCounterDeltas, error) {
 	return applyCentralQuotaMutationTx(ctx, w.store, tx, entry.TenantID, entry.MutationType, entry.MutationData, entry.ID)
 }
 
-func applyCentralQuotaMutationTx(ctx context.Context, store MetaQuotaStore, tx *sql.Tx, tenantID, mutationType string, mutationData json.RawMessage, logID int64) error {
+func applyCentralQuotaMutationTx(ctx context.Context, store MetaQuotaStore, tx *sql.Tx, tenantID, mutationType string, mutationData json.RawMessage, logID int64) (quotaCounterDeltas, error) {
 	switch mutationType {
 	case "file_create":
 		var data fileCreateMutationData
 		if err := json.Unmarshal(mutationData, &data); err != nil {
-			return err
+			return quotaCounterDeltas{}, err
 		}
 		return applyCentralFileCreateTx(store, tx, tenantID, data)
 
 	case "file_overwrite":
 		var data fileOverwriteMutationData
 		if err := json.Unmarshal(mutationData, &data); err != nil {
-			return err
+			return quotaCounterDeltas{}, err
 		}
 		return applyCentralFileOverwriteTx(store, tx, tenantID, data)
 
 	case "file_delete":
 		var data fileDeleteMutationData
 		if err := json.Unmarshal(mutationData, &data); err != nil {
-			return err
+			return quotaCounterDeltas{}, err
 		}
 		deleted, err := store.DeleteFileMetaIfExistsTx(tx, tenantID, data.FileID)
 		if err != nil {
-			return err
+			return quotaCounterDeltas{}, err
 		}
 		if !deleted {
-			return nil
+			return quotaCounterDeltas{}, nil
 		}
-		if data.SizeBytes != 0 {
-			if err := store.IncrStorageBytesTx(tx, tenantID, -data.SizeBytes); err != nil {
-				return err
-			}
-		}
-		if err := store.IncrFileCountTx(tx, tenantID, -1); err != nil {
-			return err
+		deltas := quotaCounterDeltas{
+			storageBytes: -data.SizeBytes,
+			fileCount:    -1,
 		}
 		if data.IsMedia {
-			if err := store.IncrMediaFileCountTx(tx, tenantID, -1); err != nil {
-				return err
-			}
+			deltas.mediaFileCount = -1
 		}
-		return nil
+		return deltas, nil
 
 	case "upload_complete":
 		var data uploadCompleteMutationData
 		if err := json.Unmarshal(mutationData, &data); err != nil {
-			return err
+			return quotaCounterDeltas{}, err
 		}
 		// Real shared helper — same body as the inline fast path in
 		// completeUploadReservation. MarkMutationAppliedTx stays with the
@@ -321,8 +321,11 @@ func applyCentralQuotaMutationTx(ctx context.Context, store MetaQuotaStore, tx *
 	case "llm_cost_record":
 		var data llmCostMutationData
 		if err := json.Unmarshal(mutationData, &data); err != nil {
-			return err
+			return quotaCounterDeltas{}, err
 		}
+		// LLM cost writes go to tenant_llm_usage and tenant_monthly_llm_cost
+		// — different tables than the tenant_quota_usage hot row, and rare —
+		// so they stay inline and this apply returns zero counter deltas.
 		if err := store.InsertCentralLLMUsageTx(tx, &LLMUsageView{
 			TenantID:       tenantID,
 			TaskType:       data.TaskType,
@@ -331,15 +334,18 @@ func applyCentralQuotaMutationTx(ctx context.Context, store MetaQuotaStore, tx *
 			RawUnits:       data.RawUnits,
 			RawUnitType:    data.RawUnitType,
 		}); err != nil {
-			return err
+			return quotaCounterDeltas{}, err
 		}
-		return store.IncrMonthlyLLMCostTx(tx, tenantID, data.CostMillicents)
+		if err := store.IncrMonthlyLLMCostTx(tx, tenantID, data.CostMillicents); err != nil {
+			return quotaCounterDeltas{}, err
+		}
+		return quotaCounterDeltas{}, nil
 
 	default:
 		logger.Warn(context.Background(), "mutation_replay_unknown_type",
 			zap.String("tenant_id", tenantID),
 			zap.String("mutation_type", mutationType),
 			zap.Int64("log_id", logID))
-		return nil // skip unknown types gracefully
+		return quotaCounterDeltas{}, nil // skip unknown types gracefully
 	}
 }

--- a/pkg/backend/quota_migration_test.go
+++ b/pkg/backend/quota_migration_test.go
@@ -29,27 +29,40 @@ type fakeMutationRecord struct {
 	createdAt      time.Time
 }
 
+// incrQuotaUsageCountersCall records one non-no-op IncrQuotaUsageCountersTx
+// call for batch counter-aggregation assertions.
+type incrQuotaUsageCountersCall struct {
+	tenantID      string
+	storageDelta  int64
+	fileDelta     int64
+	mediaDelta    int64
+	reservedDelta int64
+}
+
 type fakeMetaQuotaStore struct {
-	mu                      sync.Mutex
-	usage                   map[string]*QuotaUsageView
-	config                  map[string]*QuotaConfigView
-	fileMeta                map[string]*FileMetaView
-	reservations            map[string]*UploadReservationView
-	monthly                 map[string]int64
-	llmUsage                []LLMUsageView
-	objectGCCandidates      []meta.ObjectGCCandidateInput
-	mutations               []fakeMutationRecord
-	nextID                  int64
-	markAppliedCalls        int // Finding B invariant: count MarkMutationAppliedTx calls (pre-guard, on-entry)
-	markBatchAppliedCalls   int // count MarkMutationsAppliedTx (dispatcher batch) calls
-	observePendingCalls     int
-	monthlyCostErr          error
-	insertMutationErr       error
-	objectGCCandidateErr    error
-	insertReservationErr    error // injected into AtomicReserveAndInsertUpload to simulate INSERT failure inside the tx
-	getReservationErr       error // injected into GetUploadReservation to simulate transient DB error
-	inTxHook                func(context.Context) error
-	alreadyAppliedOnMarkErr map[int64]bool
+	mu                          sync.Mutex
+	usage                       map[string]*QuotaUsageView
+	config                      map[string]*QuotaConfigView
+	fileMeta                    map[string]*FileMetaView
+	reservations                map[string]*UploadReservationView
+	monthly                     map[string]int64
+	llmUsage                    []LLMUsageView
+	objectGCCandidates          []meta.ObjectGCCandidateInput
+	mutations                   []fakeMutationRecord
+	nextID                      int64
+	markAppliedCalls            int // Finding B invariant: count MarkMutationAppliedTx calls (pre-guard, on-entry)
+	markBatchAppliedCalls       int // count MarkMutationsAppliedTx (dispatcher batch) calls
+	observePendingCalls         int
+	upsertFileMetaCalls         int // count UpsertFileMetaTx calls (no-op-skip assertions)
+	incrQuotaUsageCountersCalls []incrQuotaUsageCountersCall
+	counterMarkEvents           []string // "counters" / "mark" ordering probe for hot-row-last assertions
+	monthlyCostErr              error
+	insertMutationErr           error
+	objectGCCandidateErr        error
+	insertReservationErr        error // injected into AtomicReserveAndInsertUpload to simulate INSERT failure inside the tx
+	getReservationErr           error // injected into GetUploadReservation to simulate transient DB error
+	inTxHook                    func(context.Context) error
+	alreadyAppliedOnMarkErr     map[int64]bool
 }
 
 func (f *fakeMetaQuotaStore) EnqueueObjectGCCandidate(_ context.Context, c *meta.ObjectGCCandidateInput) error {
@@ -199,6 +212,30 @@ func (f *fakeMetaQuotaStore) TransferReservedToConfirmedTx(tx *sql.Tx, tenantID 
 	return f.TransferReservedToConfirmed(context.Background(), tenantID, reservedDelta, storageDelta)
 }
 
+// IncrQuotaUsageCountersTx mirrors the real Store contract: one combined
+// counter update, skipping entirely (no recorded call) on all-zero deltas.
+func (f *fakeMetaQuotaStore) IncrQuotaUsageCountersTx(tx *sql.Tx, tenantID string, storageDelta, fileDelta, mediaDelta, reservedDelta int64) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if storageDelta == 0 && fileDelta == 0 && mediaDelta == 0 && reservedDelta == 0 {
+		return nil
+	}
+	f.incrQuotaUsageCountersCalls = append(f.incrQuotaUsageCountersCalls, incrQuotaUsageCountersCall{
+		tenantID:      tenantID,
+		storageDelta:  storageDelta,
+		fileDelta:     fileDelta,
+		mediaDelta:    mediaDelta,
+		reservedDelta: reservedDelta,
+	})
+	f.counterMarkEvents = append(f.counterMarkEvents, "counters")
+	u := f.ensureUsageLocked(tenantID)
+	u.StorageBytes += storageDelta
+	u.FileCount += fileDelta
+	u.MediaFileCount += mediaDelta
+	u.ReservedBytes += reservedDelta
+	return nil
+}
+
 // AtomicReserveAndInsertUpload models the real Store contract: claim
 // reserved_bytes and insert the reservation row inside a single (fake) tx.
 // If either step fails the state is fully rolled back — reserved_bytes is
@@ -246,7 +283,12 @@ func (f *fakeMetaQuotaStore) UpsertFileMeta(ctx context.Context, fm *FileMetaVie
 }
 
 func (f *fakeMetaQuotaStore) UpsertFileMetaTx(tx *sql.Tx, fm *FileMetaView) error {
-	return f.UpsertFileMeta(context.Background(), fm)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.upsertFileMetaCalls++
+	cp := *fm
+	f.fileMeta[metaKey(fm.TenantID, fm.FileID)] = &cp
+	return nil
 }
 
 func (f *fakeMetaQuotaStore) GetFileMeta(ctx context.Context, tenantID, fileID string) (*FileMetaView, error) {
@@ -498,6 +540,7 @@ func (f *fakeMetaQuotaStore) MarkMutationAppliedTx(tx *sql.Tx, id int64) error {
 	// MarkAppliedCalledExactlyOnce test even when the second call is a silent
 	// no-op on an already-applied row.
 	f.markAppliedCalls++
+	f.counterMarkEvents = append(f.counterMarkEvents, "mark")
 	for i := range f.mutations {
 		if f.mutations[i].id == id {
 			if f.alreadyAppliedOnMarkErr[id] {
@@ -818,8 +861,8 @@ func TestCentralQuotaPendingDeltaRetainedThenExpiresAfterInlineApplyFailure(t *t
 	}, quotaPendingDeltas{
 		storageDelta: 128,
 		fileDelta:    1,
-	}, func(context.Context, *sql.Tx) error {
-		return applyErr
+	}, func(context.Context, *sql.Tx) (quotaCounterDeltas, error) {
+		return quotaCounterDeltas{}, applyErr
 	}); err != nil {
 		t.Fatalf("log and enqueue mutation: %v", err)
 	}

--- a/pkg/backend/quota_mutation.go
+++ b/pkg/backend/quota_mutation.go
@@ -46,6 +46,37 @@ type llmCostMutationData struct {
 
 const postCommitQuotaMutationTimeout = 30 * time.Second
 
+// quotaCounterDeltas accumulates the tenant_quota_usage counter adjustments
+// produced by one mutation apply. Applies RETURN their deltas instead of
+// executing the per-counter Incr*Tx statements inline; the transaction owner
+// (dispatcher batch runner, per-item applyQuotaMutation, or replayOne)
+// aggregates them per tenant and flushes them at the END of the transaction
+// via IncrQuotaUsageCountersTx — "hot row last" — so the single per-tenant
+// tenant_quota_usage row is locked only just before commit instead of from
+// the first mutation apply to commit, and N mutations for one tenant
+// collapse into one UPDATE.
+type quotaCounterDeltas struct {
+	storageBytes   int64
+	fileCount      int64
+	mediaFileCount int64
+	reservedBytes  int64
+}
+
+func (d *quotaCounterDeltas) add(o quotaCounterDeltas) {
+	d.storageBytes += o.storageBytes
+	d.fileCount += o.fileCount
+	d.mediaFileCount += o.mediaFileCount
+	d.reservedBytes += o.reservedBytes
+}
+
+// applyQuotaCounterDeltasTx flushes one tenant's aggregated counter deltas at
+// the end of a mutation transaction. IncrQuotaUsageCountersTx is a no-op on
+// all-zero deltas, so callers may invoke this unconditionally.
+func applyQuotaCounterDeltasTx(store MetaQuotaStore, tx *sql.Tx, tenantID string, deltas quotaCounterDeltas) error {
+	return store.IncrQuotaUsageCountersTx(tx, tenantID,
+		deltas.storageBytes, deltas.fileCount, deltas.mediaFileCount, deltas.reservedBytes)
+}
+
 // PostCommitQuotaMutationError reports that the user-visible file mutation has
 // already committed, but the central quota handoff failed afterward.
 type PostCommitQuotaMutationError struct {
@@ -111,9 +142,17 @@ func (b *Dat9Backend) logQuotaMutation(ctx context.Context, mutationType string,
 // applyQuotaMutation applies a previously-logged mutation and marks it as
 // applied. This is the async-safe half of the split mutation path — if it
 // fails or never runs, MutationReplayWorker picks up the pending log entry.
-func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType string, logID int64, pending quotaPendingDeltas, apply func(context.Context, *sql.Tx) error) {
+// The apply returns its tenant_quota_usage counter deltas instead of
+// executing them inline; they are flushed in one statement right before the
+// mark ("hot row last"), keeping the semantics identical from the caller's
+// perspective while shrinking the hot-row lock window to just before commit.
+func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType string, logID int64, pending quotaPendingDeltas, apply func(context.Context, *sql.Tx) (quotaCounterDeltas, error)) {
 	if err := b.metaStore.InTx(ctx, func(tx *sql.Tx) error {
-		if err := apply(ctx, tx); err != nil {
+		deltas, err := apply(ctx, tx)
+		if err != nil {
+			return err
+		}
+		if err := applyQuotaCounterDeltasTx(b.metaStore, tx, b.tenantID, deltas); err != nil {
 			return err
 		}
 		return b.metaStore.MarkMutationAppliedTx(tx, logID)
@@ -149,7 +188,7 @@ func (b *Dat9Backend) applyQuotaMutation(ctx context.Context, mutationType strin
 // pending (unapplied) entries in (tenant_id, id) order, which handles
 // crash recovery. Cross-pod last-writer divergence on file_meta requires
 // operational reconciliation from tenant file metadata.
-func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType string, payload any, pending quotaPendingDeltas, apply func(context.Context, *sql.Tx) error) error {
+func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType string, payload any, pending quotaPendingDeltas, apply func(context.Context, *sql.Tx) (quotaCounterDeltas, error)) error {
 	if b.metaStore == nil || b.tenantID == "" {
 		return nil
 	}
@@ -182,19 +221,34 @@ func (b *Dat9Backend) logAndEnqueueMutation(ctx context.Context, mutationType st
 	return nil
 }
 
-func applyCentralFileStateTx(store MetaQuotaStore, tx *sql.Tx, tenantID, fileID string, sizeBytes int64, isMedia bool) error {
+// applyCentralFileStateTx applies a create/overwrite shadow-state mutation:
+// read the current tenant_file_meta row (FOR UPDATE), upsert it, and RETURN
+// the resulting tenant_quota_usage counter deltas for the caller to flush at
+// the end of the transaction ("hot row last" — see quotaCounterDeltas).
+func applyCentralFileStateTx(store MetaQuotaStore, tx *sql.Tx, tenantID, fileID string, sizeBytes int64, isMedia bool) (quotaCounterDeltas, error) {
 	oldSize := int64(0)
 	oldIsMedia := false
 	oldExists := false
 	old, err := store.GetFileMetaForUpdateTx(tx, tenantID, fileID)
 	if err != nil {
 		if !errors.Is(err, meta.ErrNotFound) {
-			return err
+			return quotaCounterDeltas{}, err
 		}
 	} else if old != nil {
 		oldExists = true
 		oldSize = old.SizeBytes
 		oldIsMedia = old.IsMedia
+	}
+	// No-op fast path: the shadow row already matches the new state, so the
+	// upsert would write identical values. Skipping it is safe because
+	// UpsertFileMetaTx only maintains size_bytes/is_media (no updated_at
+	// upkeep) and nothing consumes tenant_file_meta.updated_at for
+	// correctness — file GC settlement keys off HasPendingFileMutation plus
+	// size/isMedia. This avoids a useless write for the overwhelming
+	// majority of mutations (same-size overwrites). The mutation itself is
+	// still marked applied by the caller.
+	if oldExists && oldSize == sizeBytes && oldIsMedia == isMedia {
+		return quotaCounterDeltas{}, nil
 	}
 	if err := store.UpsertFileMetaTx(tx, &FileMetaView{
 		TenantID:  tenantID,
@@ -202,33 +256,23 @@ func applyCentralFileStateTx(store MetaQuotaStore, tx *sql.Tx, tenantID, fileID 
 		SizeBytes: sizeBytes,
 		IsMedia:   isMedia,
 	}); err != nil {
-		return err
+		return quotaCounterDeltas{}, err
 	}
-	storageDelta := sizeBytes - oldSize
-	if storageDelta != 0 {
-		if err := store.IncrStorageBytesTx(tx, tenantID, storageDelta); err != nil {
-			return err
-		}
+	deltas := quotaCounterDeltas{
+		storageBytes:   sizeBytes - oldSize,
+		mediaFileCount: quotaMediaDelta(oldIsMedia, isMedia),
 	}
 	if !oldExists {
-		if err := store.IncrFileCountTx(tx, tenantID, 1); err != nil {
-			return err
-		}
+		deltas.fileCount = 1
 	}
-	mediaDelta := quotaMediaDelta(oldIsMedia, isMedia)
-	if mediaDelta != 0 {
-		if err := store.IncrMediaFileCountTx(tx, tenantID, mediaDelta); err != nil {
-			return err
-		}
-	}
-	return nil
+	return deltas, nil
 }
 
-func applyCentralFileCreateTx(store MetaQuotaStore, tx *sql.Tx, tenantID string, data fileCreateMutationData) error {
+func applyCentralFileCreateTx(store MetaQuotaStore, tx *sql.Tx, tenantID string, data fileCreateMutationData) (quotaCounterDeltas, error) {
 	return applyCentralFileStateTx(store, tx, tenantID, data.FileID, data.SizeBytes, data.IsMedia)
 }
 
-func applyCentralFileOverwriteTx(store MetaQuotaStore, tx *sql.Tx, tenantID string, data fileOverwriteMutationData) error {
+func applyCentralFileOverwriteTx(store MetaQuotaStore, tx *sql.Tx, tenantID string, data fileOverwriteMutationData) (quotaCounterDeltas, error) {
 	return applyCentralFileStateTx(store, tx, tenantID, data.FileID, data.NewSizeBytes, data.NewIsMedia)
 }
 
@@ -247,7 +291,7 @@ func (b *Dat9Backend) recordCentralFileCreateMutation(ctx context.Context, fileI
 		storageDelta: sizeBytes,
 		fileDelta:    1,
 		mediaDelta:   mediaDelta,
-	}, func(applyCtx context.Context, tx *sql.Tx) error {
+	}, func(applyCtx context.Context, tx *sql.Tx) (quotaCounterDeltas, error) {
 		return applyCentralFileCreateTx(b.metaStore, tx, b.tenantID, data)
 	})
 }
@@ -265,7 +309,7 @@ func (b *Dat9Backend) recordCentralFileOverwriteMutation(ctx context.Context, fi
 	return b.logAndEnqueueMutation(ctx, "file_overwrite", data, quotaPendingDeltas{
 		storageDelta: newSize - oldSize,
 		mediaDelta:   quotaMediaDelta(oldIsMedia, newIsMedia),
-	}, func(applyCtx context.Context, tx *sql.Tx) error {
+	}, func(applyCtx context.Context, tx *sql.Tx) (quotaCounterDeltas, error) {
 		return applyCentralFileOverwriteTx(b.metaStore, tx, b.tenantID, data)
 	})
 }
@@ -277,7 +321,10 @@ func (b *Dat9Backend) syncCentralLLMCostRecord(ctx context.Context, taskType, ta
 		CostMillicents: costMillicents,
 		RawUnits:       rawUnits,
 		RawUnitType:    rawUnitType,
-	}, quotaPendingDeltas{}, func(applyCtx context.Context, tx *sql.Tx) error {
+	}, quotaPendingDeltas{}, func(applyCtx context.Context, tx *sql.Tx) (quotaCounterDeltas, error) {
+		// LLM cost writes go to tenant_llm_usage and tenant_monthly_llm_cost
+		// — different tables than the tenant_quota_usage hot row, and rare —
+		// so they stay inline and this apply returns zero counter deltas.
 		if err := b.metaStore.InsertCentralLLMUsageTx(tx, &LLMUsageView{
 			TenantID:       b.tenantID,
 			TaskType:       taskType,
@@ -286,8 +333,11 @@ func (b *Dat9Backend) syncCentralLLMCostRecord(ctx context.Context, taskType, ta
 			RawUnits:       rawUnits,
 			RawUnitType:    rawUnitType,
 		}); err != nil {
-			return err
+			return quotaCounterDeltas{}, err
 		}
-		return b.metaStore.IncrMonthlyLLMCostTx(tx, b.tenantID, costMillicents)
+		if err := b.metaStore.IncrMonthlyLLMCostTx(tx, b.tenantID, costMillicents); err != nil {
+			return quotaCounterDeltas{}, err
+		}
+		return quotaCounterDeltas{}, nil
 	})
 }

--- a/pkg/backend/quota_store.go
+++ b/pkg/backend/quota_store.go
@@ -39,6 +39,11 @@ type MetaQuotaStore interface {
 	IncrMediaFileCountTx(tx *sql.Tx, tenantID string, delta int64) error
 	IncrVideoFileCountTx(tx *sql.Tx, tenantID string, delta int64) error
 	TransferReservedToConfirmedTx(tx *sql.Tx, tenantID string, reservedDelta, storageDelta int64) error
+	// IncrQuotaUsageCountersTx applies all four counter deltas with one
+	// UPDATE on tenant_quota_usage. The batched mutation apply paths call
+	// it once per tenant at the end of the transaction ("hot row last")
+	// instead of touching the single per-tenant hot row from every apply.
+	IncrQuotaUsageCountersTx(tx *sql.Tx, tenantID string, storageDelta, fileDelta, mediaDelta, reservedDelta int64) error
 
 	// File meta (server-authored shadow state)
 	UpsertFileMeta(ctx context.Context, fm *FileMetaView) error

--- a/pkg/backend/round_a_review_test.go
+++ b/pkg/backend/round_a_review_test.go
@@ -653,7 +653,7 @@ func TestRoundA_Fix4_CompleteUpload_MarkAppliedCalledExactlyOnce(t *testing.T) {
 		if err != nil {
 			t.Fatalf("insert: %v", err)
 		}
-		if err := applyUploadCompleteTx(context.Background(), fake, nil, "tenant-a", uploadCompleteMutationData{
+		if _, err := applyUploadCompleteTx(context.Background(), fake, nil, "tenant-a", uploadCompleteMutationData{
 			UploadID:     "u1",
 			FileID:       "file-1",
 			NewSizeBytes: 40,

--- a/pkg/backend/upload_reservation.go
+++ b/pkg/backend/upload_reservation.go
@@ -230,7 +230,7 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 		NewSizeBytes:  newSizeBytes,
 		NewIsMedia:    newIsMedia,
 	}
-	return b.logAndEnqueueMutation(ctx, "upload_complete", data, quotaPendingDeltas{}, func(applyCtx context.Context, tx *sql.Tx) error {
+	return b.logAndEnqueueMutation(ctx, "upload_complete", data, quotaPendingDeltas{}, func(applyCtx context.Context, tx *sql.Tx) (quotaCounterDeltas, error) {
 		return applyUploadCompleteTx(applyCtx, b.metaStore, tx, b.tenantID, data)
 	})
 }
@@ -274,7 +274,13 @@ func (b *Dat9Backend) completeUploadReservation(ctx context.Context, uploadID st
 // replay path calls it inside replayOne. Keeping the mark-applied call out
 // of this helper prevents a double-mark rollback trap if any future caller
 // also marks applied in the outer tx.
-func applyUploadCompleteTx(ctx context.Context, store MetaQuotaStore, tx *sql.Tx, tenantID string, data uploadCompleteMutationData) error {
+//
+// Counter updates are NOT executed inline: the reservation settle and the
+// file_meta upsert stay inline, but every tenant_quota_usage adjustment
+// (including the reserved_bytes decrement of the reserved→storage transfer)
+// is returned as quotaCounterDeltas for the caller to flush at the end of
+// the transaction ("hot row last" — see quotaCounterDeltas).
+func applyUploadCompleteTx(ctx context.Context, store MetaQuotaStore, tx *sql.Tx, tenantID string, data uploadCompleteMutationData) (quotaCounterDeltas, error) {
 	mediaDelta := int64(0)
 	switch {
 	case !data.OldIsMedia && data.NewIsMedia:
@@ -286,7 +292,7 @@ func applyUploadCompleteTx(ctx context.Context, store MetaQuotaStore, tx *sql.Tx
 	var oldMeta *FileMetaView
 	if old, err := store.GetFileMetaForUpdateTx(tx, tenantID, data.FileID); err != nil {
 		if !errors.Is(err, meta.ErrNotFound) {
-			return err
+			return quotaCounterDeltas{}, err
 		}
 	} else if old != nil {
 		oldExists = true
@@ -294,46 +300,33 @@ func applyUploadCompleteTx(ctx context.Context, store MetaQuotaStore, tx *sql.Tx
 	}
 	settled, reservedFileCountDelta, err := store.SettleActiveReservationTx(ctx, tx, tenantID, data.UploadID, "completed")
 	if err != nil {
-		return err
+		return quotaCounterDeltas{}, err
 	}
 	if !settled && oldMeta != nil && oldMeta.SizeBytes == data.NewSizeBytes && oldMeta.IsMedia == data.NewIsMedia {
-		return nil
+		return quotaCounterDeltas{}, nil
 	}
+	var deltas quotaCounterDeltas
 	if settled {
-		if err := store.TransferReservedToConfirmedTx(tx, tenantID, -data.ReservedBytes, data.ReservedBytes); err != nil {
-			return err
-		}
+		// Transfer reserved → storage as returned counter deltas.
+		deltas.reservedBytes -= data.ReservedBytes
+		deltas.storageBytes += data.ReservedBytes
 	} else {
 		// settled=false: fail-open initiate / already-settled / expiry sweep
 		// race. reserved_bytes is already balanced; charge storage directly.
-		if data.NewSizeBytes != 0 {
-			if err := store.IncrStorageBytesTx(tx, tenantID, data.NewSizeBytes); err != nil {
-				return err
-			}
-		}
+		deltas.storageBytes += data.NewSizeBytes
 	}
-	if data.OldSizeBytes != 0 {
-		if err := store.IncrStorageBytesTx(tx, tenantID, -data.OldSizeBytes); err != nil {
-			return err
-		}
-	}
+	deltas.storageBytes -= data.OldSizeBytes
 	if err := store.UpsertFileMetaTx(tx, &FileMetaView{
 		TenantID:  tenantID,
 		FileID:    data.FileID,
 		SizeBytes: data.NewSizeBytes,
 		IsMedia:   data.NewIsMedia,
 	}); err != nil {
-		return err
+		return quotaCounterDeltas{}, err
 	}
 	if !oldExists && (!settled || reservedFileCountDelta <= 0) {
-		if err := store.IncrFileCountTx(tx, tenantID, 1); err != nil {
-			return err
-		}
+		deltas.fileCount = 1
 	}
-	if mediaDelta != 0 {
-		if err := store.IncrMediaFileCountTx(tx, tenantID, mediaDelta); err != nil {
-			return err
-		}
-	}
-	return nil
+	deltas.mediaFileCount = mediaDelta
+	return deltas, nil
 }

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -664,6 +664,34 @@ func (s *Store) TransferReservedToConfirmedTx(tx *sql.Tx, tenantID string, reser
 	return ensureRowsAffected(res, tenantID)
 }
 
+// IncrQuotaUsageCountersTx atomically adjusts all four quota usage counters
+// with a single UPDATE inside a transaction. It mirrors the per-counter
+// Incr*Tx semantics exactly (plain additive deltas, no clamping, and the
+// tenant row must already exist), but collapses what used to be one
+// statement per touched counter into one statement for the whole batch.
+// The batched mutation apply paths call this at the END of their
+// transaction ("hot row last") so the per-tenant tenant_quota_usage row is
+// locked only just before commit instead of from the first mutation apply.
+// It is a no-op when every delta is zero, so callers may invoke it
+// unconditionally.
+func (s *Store) IncrQuotaUsageCountersTx(tx *sql.Tx, tenantID string, storageDelta, fileDelta, mediaDelta, reservedDelta int64) error {
+	if storageDelta == 0 && fileDelta == 0 && mediaDelta == 0 && reservedDelta == 0 {
+		return nil
+	}
+	res, err := tx.Exec(
+		`UPDATE tenant_quota_usage
+		 SET storage_bytes = storage_bytes + ?,
+		     file_count = file_count + ?,
+		     media_file_count = media_file_count + ?,
+		     reserved_bytes = reserved_bytes + ?
+		 WHERE tenant_id = ?`,
+		storageDelta, fileDelta, mediaDelta, reservedDelta, tenantID)
+	if err != nil {
+		return err
+	}
+	return ensureRowsAffected(res, tenantID)
+}
+
 // defaultMaxStorageBytes is the fallback limit when no per-tenant config row exists.
 var defaultMaxStorageBytes atomic.Int64
 var defaultMaxFileSizeBytes atomic.Int64

--- a/pkg/meta/quota_counters_test.go
+++ b/pkg/meta/quota_counters_test.go
@@ -1,0 +1,74 @@
+package meta
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+)
+
+// TestIncrQuotaUsageCountersTx covers the combined counter update used by the
+// batched "hot row last" mutation apply paths: all four counters move with
+// one statement, all-zero deltas are a no-op (even for a tenant without a
+// usage row), and a non-zero delta against a missing row errors exactly like
+// the per-counter Incr*Tx methods (ensureRowsAffected).
+func TestIncrQuotaUsageCountersTx(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+
+	if err := s.EnsureQuotaUsageRow(ctx, "tenant-counters"); err != nil {
+		t.Fatal(err)
+	}
+	// Seed non-zero counters so negative deltas are observable too.
+	if err := s.IncrStorageBytes(ctx, "tenant-counters", 100); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.IncrReservedBytes(ctx, "tenant-counters", 40); err != nil {
+		t.Fatal(err)
+	}
+
+	err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.IncrQuotaUsageCountersTx(tx, "tenant-counters", 50, 2, 1, -40)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage, err := s.GetQuotaUsage(ctx, "tenant-counters")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.StorageBytes != 150 || usage.FileCount != 2 || usage.MediaFileCount != 1 || usage.ReservedBytes != 0 {
+		t.Fatalf("usage = %+v, want storage=150 file=2 media=1 reserved=0", usage)
+	}
+
+	// All-zero deltas are a no-op: counters unchanged, and no error even for
+	// a tenant whose usage row does not exist (no statement is executed).
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.IncrQuotaUsageCountersTx(tx, "tenant-counters", 0, 0, 0, 0)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.IncrQuotaUsageCountersTx(tx, "tenant-without-usage-row", 0, 0, 0, 0)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	usage, err = s.GetQuotaUsage(ctx, "tenant-counters")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if usage.StorageBytes != 150 || usage.FileCount != 2 || usage.MediaFileCount != 1 || usage.ReservedBytes != 0 {
+		t.Fatalf("usage after zero-delta no-op = %+v, want unchanged", usage)
+	}
+
+	// A non-zero delta against a missing usage row errors like the
+	// per-counter Incr*Tx methods do.
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.IncrQuotaUsageCountersTx(tx, "tenant-without-usage-row", 1, 0, 0, 0)
+	})
+	if err == nil || !strings.Contains(err.Error(), "tenant_quota_usage row missing") {
+		t.Fatalf("err = %v, want tenant_quota_usage row missing", err)
+	}
+}

--- a/pkg/tenant/quota_adapter.go
+++ b/pkg/tenant/quota_adapter.go
@@ -125,6 +125,10 @@ func (a *metaQuotaAdapter) TransferReservedToConfirmedTx(tx *sql.Tx, tenantID st
 	return a.s.TransferReservedToConfirmedTx(tx, tenantID, reservedDelta, storageDelta)
 }
 
+func (a *metaQuotaAdapter) IncrQuotaUsageCountersTx(tx *sql.Tx, tenantID string, storageDelta, fileDelta, mediaDelta, reservedDelta int64) error {
+	return a.s.IncrQuotaUsageCountersTx(tx, tenantID, storageDelta, fileDelta, mediaDelta, reservedDelta)
+}
+
 // AtomicReserveAndInsertUpload is the preferred single-transaction API for the
 // upload-initiate path. See meta.Store.AtomicReserveAndInsertUpload for
 // invariants. Translates meta sentinels to backend sentinels for the caller.


### PR DESCRIPTION
## Why

Follow-up to #792. After deploying it and re-running the stress workload, DBBrain shows the commit-rate problem is solved (transactions −78%, commit latency 19ms → 6.5ms), but two new facts surfaced in the quota accounting chain:

1. **Row-lock contention exploded on the quota hot rows.** `SELECT ... tenant_file_meta FOR UPDATE` lock wait went 452s → 8,408s/12h; `INSERT IGNORE tenant_quota_usage` accumulated 8,152s of lock wait on only 553k execs (~15ms avg); `UPDATE tenant_quota_usage` 5,360s on 246k execs (~22ms avg). Cause: batched apply transactions (up to 128 items) hold every touched row from first apply to commit, and every mutation touches the single per-tenant `tenant_quota_usage` row — two pods' batches over the same tenant set are almost guaranteed to intersect (birthday paradox), so cross-pod lock waits are amplified by batch length.
2. **99%+ of mutations are quota-neutral.** Only 246k of 41.5M file mutations actually changed `storage_bytes` — the rest are same-size overwrites that still pay a `FOR UPDATE` read + an identical-value upsert per mutation.

## Changes

**Hot row last.** Apply closures now *return* their `tenant_quota_usage` counter deltas instead of executing the per-counter `Incr*Tx` inline. Each transaction owner flushes them at the END of the transaction:

- dispatcher batch runner: aggregates per tenant across the (cross-tenant) batch and flushes in **sorted tenant_id order** (deterministic global lock order against cross-pod deadlocks), before `MarkMutationsAppliedTx`;
- per-item path (`applyQuotaMutation`) and `replayOne`: flush right before the mark, same transaction.

The hot row is now locked only just before commit instead of for the whole batch, and N mutations for one tenant collapse into a single `UPDATE tenant_quota_usage` via the new `IncrQuotaUsageCountersTx` (same additive + row-exists semantics as the per-counter methods; no-op when all deltas are zero — matching the old per-counter conditionals).

**No-op skip.** `applyCentralFileStateTx` already reads the shadow row `FOR UPDATE`; when it exists with identical `size_bytes`/`is_media`, the upsert is skipped entirely (the mutation is still marked applied). Safe because `UpsertFileMetaTx` maintains only those two columns and nothing consumes `tenant_file_meta.updated_at` for correctness (file GC settlement keys off `HasPendingFileMutation` + size/isMedia). `applyUploadCompleteTx` keeps its pre-existing identical-meta early return; the settled-branch reserved→storage transfer is preserved exactly (verified `TransferReservedToConfirmedTx` has no extra guard clause).

Semantics preserved: exactly-once marking (`status='pending'` + affected-rows check), in-tx read-your-writes for create→overwrite on the same file, per-tenant FIFO, failure fallback to the legacy per-item path, and the pending-delta admission estimates are all unchanged.

## Expected effect (same workload)

- `tenant_quota_usage` lock-hold per batch: from ~whole-batch (tens of ms) to just-before-commit — the three lock-wait hot spots should drop by roughly an order of magnitude.
- Usage counter statements: from up to 3 per mutation to ~1 per tenant per batch.
- `tenant_file_meta` upserts: −~40M/12h (no-op overwrites skipped).
- Combined with #792 this should bring metadb statement volume down another ~40% and eliminate the lock-wait tail.

## Test plan

- New backend tests: per-tenant aggregation with sorted flush order; create→overwrite delta composition; no-op overwrite skips upsert+counters but still marks applied; inline path flushes before mark.
- New meta test: `IncrQuotaUsageCountersTx` counter moves + zero-delta no-op.
- `make lint` 0 issues; `make test` green across pkg/meta, pkg/backend, pkg/server, pkg/tenant.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quota accounting for file creation, overwrites, deletions, and completed uploads.
  * Quota usage updates are now applied consistently and atomically, reducing inconsistent counter states.
  * No-op file updates no longer create unnecessary metadata or quota changes.
  * Mutation replay and batch processing now preserve correct ordering between quota updates and completion status.
* **Tests**
  * Added coverage for aggregated quota updates, transactional behavior, upload reservations, and no-op operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->