### PR TITLE
Optimize meta aggregation queries without new indexes

### DIFF
--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -1026,23 +1026,47 @@ func (s *Store) ListSharedDBs(ctx context.Context) (out []*SharedDB, err error) 
 // ListSharedDBPoolMetricSnapshots returns one snapshot per physical shared
 // database. It is intentionally a read-only aggregate used by the existing
 // tenant metrics pass; it does not reconcile or mutate capacity counters.
+// The query counts durable placements as an active baseline, then reclassifies
+// only non-active tenants. This keeps the common path index-only and avoids two
+// point lookups for every active placement.
+const listSharedDBPoolMetricSnapshotsSQL = `WITH non_active_tenant_states AS (
+	SELECT p.db_id, t.status AS tenant_status, COUNT(*) AS tenant_count
+		FROM tenants t FORCE INDEX (idx_tenant_status)
+		STRAIGHT_JOIN fs_registry f ON f.tenant_id = t.id
+		STRAIGHT_JOIN tenant_placements p ON p.fs_id = f.fs_id
+		WHERE t.status <> ?
+		GROUP BY p.db_id, t.status
+), tenant_state_deltas AS (
+	SELECT db_id, ? AS tenant_status, COUNT(*) AS tenant_count
+		FROM tenant_placements
+		GROUP BY db_id
+	UNION ALL
+	SELECT db_id, tenant_status, tenant_count
+		FROM non_active_tenant_states
+	UNION ALL
+	SELECT db_id, ? AS tenant_status, -SUM(tenant_count) AS tenant_count
+		FROM non_active_tenant_states
+		GROUP BY db_id
+), tenant_states AS (
+	SELECT db_id, tenant_status, SUM(tenant_count) AS tenant_count
+		FROM tenant_state_deltas
+		GROUP BY db_id, tenant_status
+		HAVING SUM(tenant_count) > 0
+)
+SELECT
+	d.db_id, d.uuid, COALESCE(d.org_id, ''), d.status, d.max_tenants, d.tenant_count, d.soft_cap_reached,
+	d.spending_limit,
+	COALESCE(tenant_states.tenant_status, ''), COALESCE(tenant_states.tenant_count, 0)
+	FROM db_pool d
+	LEFT JOIN tenant_states ON tenant_states.db_id = d.db_id
+	WHERE d.` + "`role`" + ` = ?
+	ORDER BY d.db_id, tenant_states.tenant_status`
+
 func (s *Store) ListSharedDBPoolMetricSnapshots(ctx context.Context) (out []SharedDBPoolMetricSnapshot, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "list_shared_db_pool_metric_snapshots", start, &err)
-	rows, err := s.db.QueryContext(ctx, `SELECT
-			d.db_id, d.uuid, COALESCE(d.org_id, ''), d.status, d.max_tenants, d.tenant_count, d.soft_cap_reached,
-			d.spending_limit,
-			COALESCE(states.tenant_status, ''), COALESCE(states.tenant_count, 0)
-		FROM db_pool d
-		LEFT JOIN (
-			SELECT p.db_id, t.status AS tenant_status, COUNT(*) AS tenant_count
-			FROM tenant_placements p
-			JOIN fs_registry f ON f.fs_id = p.fs_id
-			JOIN tenants t ON t.id = f.tenant_id
-			GROUP BY p.db_id, t.status
-		) states ON states.db_id = d.db_id
-		WHERE d.`+"`role`"+` = ?
-		ORDER BY d.db_id, states.tenant_status`, SharedDBRoleShared)
+	rows, err := s.db.QueryContext(ctx, listSharedDBPoolMetricSnapshotsSQL,
+		TenantActive, TenantActive, TenantActive, SharedDBRoleShared)
 	if err != nil {
 		return nil, fmt.Errorf("list shared db pool metric snapshots: %w", err)
 	}

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -2270,40 +2270,62 @@ func (s *Store) countFreeTenantPoolBindingsByStatus(ctx context.Context, organiz
 	return out, nil
 }
 
+// Count raw durable bindings first, then subtract deleted-tenant cleanup debt by
+// driving from the selective tenant status index. Tenant rows are durable control-
+// plane records; production deletion marks them deleted instead of hard-deleting
+// them, so this avoids a tenant lookup for every live binding without counting debt.
+const countTenantPoolBindingsByStatusSQL = `WITH binding_deltas AS (
+	SELECT organization_id, pool_id, pool_status, COUNT(*) AS delta
+		FROM tenant_tidbcloud_org_bindings
+		WHERE pool_id <> ''
+		GROUP BY organization_id, pool_id, pool_status
+	UNION ALL
+	SELECT tidbcloud_organization_id AS organization_id, pool_id, pool_status, COUNT(*) AS delta
+		FROM tenant_pool_memberships
+		WHERE pool_id <> ''
+		GROUP BY tidbcloud_organization_id, pool_id, pool_status
+	UNION ALL
+	SELECT b.organization_id, b.pool_id, b.pool_status, -COUNT(*) AS delta
+		FROM tenants t
+		STRAIGHT_JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = t.id
+		WHERE t.status = ? AND b.pool_id <> ''
+		GROUP BY b.organization_id, b.pool_id, b.pool_status
+	UNION ALL
+	SELECT m.tidbcloud_organization_id AS organization_id, m.pool_id, m.pool_status, -COUNT(*) AS delta
+		FROM tenants t
+		STRAIGHT_JOIN tenant_pool_memberships m ON m.tenant_id = t.id
+		WHERE t.status = ? AND m.pool_id <> ''
+		GROUP BY m.tidbcloud_organization_id, m.pool_id, m.pool_status
+), binding_counts AS (
+	SELECT organization_id, pool_id, pool_status, SUM(delta) AS binding_count
+		FROM binding_deltas
+		GROUP BY organization_id, pool_id, pool_status
+)
+SELECT
+	p.pool_id,
+	p.organization_id,
+	statuses.pool_status,
+	COALESCE(binding_counts.binding_count, 0)
+	FROM tenant_tidbcloud_pools p
+	CROSS JOIN (
+		SELECT ? AS pool_status
+		UNION ALL
+		SELECT ? AS pool_status
+	) statuses
+	LEFT JOIN binding_counts
+		ON binding_counts.pool_id = p.pool_id
+		AND binding_counts.organization_id = p.organization_id
+		AND binding_counts.pool_status = statuses.pool_status
+	WHERE p.pool_id <> ''
+		AND p.organization_id IS NOT NULL
+		AND p.organization_id <> ''
+	ORDER BY p.pool_id, p.organization_id, statuses.pool_status`
+
 func (s *Store) CountTenantPoolBindingsByStatus(ctx context.Context) (out []TenantPoolBindingStatusCount, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "count_tidbcloud_pool_bindings_by_status", start, &err)
-	rows, err := s.db.QueryContext(ctx, `SELECT
-			p.pool_id,
-			p.organization_id,
-			statuses.pool_status,
-			/* Count only live tenant slots; deleted-tenant bindings are cleanup debt, not usable capacity. */
-			COUNT(t.id)
-		FROM tenant_tidbcloud_pools p
-		JOIN (
-			SELECT ? AS pool_status
-			UNION ALL
-			SELECT ? AS pool_status
-		) statuses
-		LEFT JOIN (
-			SELECT tenant_id, organization_id, pool_id, pool_status
-			FROM tenant_tidbcloud_org_bindings
-			UNION ALL
-			SELECT tenant_id, tidbcloud_organization_id AS organization_id, pool_id, pool_status
-			FROM tenant_pool_memberships
-		) b
-			ON b.pool_id = p.pool_id
-			AND b.organization_id = p.organization_id
-			AND b.pool_status = statuses.pool_status
-		LEFT JOIN tenants t
-			ON t.id = b.tenant_id
-			AND t.status <> ?
-		WHERE p.pool_id <> ''
-			AND p.organization_id IS NOT NULL
-			AND p.organization_id <> ''
-		GROUP BY p.pool_id, p.organization_id, statuses.pool_status
-		ORDER BY p.pool_id, p.organization_id, statuses.pool_status`,
-		TenantPoolBindingFree, TenantPoolBindingUsed, TenantDeleted)
+	rows, err := s.db.QueryContext(ctx, countTenantPoolBindingsByStatusSQL,
+		TenantDeleted, TenantDeleted, TenantPoolBindingFree, TenantPoolBindingUsed)
 	if err != nil {
 		return nil, fmt.Errorf("count tenant pool bindings by status query: %w", err)
 	}

--- a/pkg/meta/meta_query_plan_test.go
+++ b/pkg/meta/meta_query_plan_test.go
@@ -1,0 +1,58 @@
+package meta
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCountTenantPoolBindingsByStatusSQLAggregatesBeforeTenantLookup(t *testing.T) {
+	for _, fragment := range []string{
+		"FROM tenant_tidbcloud_org_bindings\n\t\tWHERE pool_id <> ''\n\t\tGROUP BY organization_id, pool_id, pool_status",
+		"FROM tenant_pool_memberships\n\t\tWHERE pool_id <> ''\n\t\tGROUP BY tidbcloud_organization_id, pool_id, pool_status",
+		"FROM tenants t\n\t\tSTRAIGHT_JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = t.id",
+		"FROM tenants t\n\t\tSTRAIGHT_JOIN tenant_pool_memberships m ON m.tenant_id = t.id",
+	} {
+		if !strings.Contains(countTenantPoolBindingsByStatusSQL, fragment) {
+			t.Fatalf("optimized pool binding count query missing %q:\n%s", fragment, countTenantPoolBindingsByStatusSQL)
+		}
+	}
+	if strings.Contains(countTenantPoolBindingsByStatusSQL, "LEFT JOIN tenants t") {
+		t.Fatalf("pool binding count query still looks up every tenant row:\n%s", countTenantPoolBindingsByStatusSQL)
+	}
+}
+
+func TestListSharedDBPoolMetricSnapshotsSQLReclassifiesOnlyNonActiveTenants(t *testing.T) {
+	for _, fragment := range []string{
+		"FROM tenants t FORCE INDEX (idx_tenant_status)",
+		"STRAIGHT_JOIN fs_registry f ON f.tenant_id = t.id",
+		"STRAIGHT_JOIN tenant_placements p ON p.fs_id = f.fs_id",
+		"WHERE t.status <> ?",
+		"SELECT db_id, ? AS tenant_status, COUNT(*) AS tenant_count\n\t\tFROM tenant_placements\n\t\tGROUP BY db_id",
+		"SELECT db_id, ? AS tenant_status, -SUM(tenant_count) AS tenant_count",
+	} {
+		if !strings.Contains(listSharedDBPoolMetricSnapshotsSQL, fragment) {
+			t.Fatalf("optimized shared DB snapshot query missing %q:\n%s", fragment, listSharedDBPoolMetricSnapshotsSQL)
+		}
+	}
+	if strings.Contains(listSharedDBPoolMetricSnapshotsSQL, "FROM tenant_placements p\n\t\t\tJOIN fs_registry") {
+		t.Fatalf("shared DB snapshot query still looks up every placement's tenant:\n%s", listSharedDBPoolMetricSnapshotsSQL)
+	}
+}
+
+func TestObservePendingMutationsSQLAggregatesBeforeOrganizationLookups(t *testing.T) {
+	for _, fragment := range []string{
+		"WITH pending_mutations AS (",
+		"SELECT tenant_id, COUNT(*) AS pending_count, MIN(created_at) AS oldest_created_at",
+		"FROM quota_mutation_log FORCE INDEX (idx_pending_tenant_age)",
+		"WHERE status = 'pending'\n\t\tGROUP BY tenant_id",
+		"pending.pending_count, pending.oldest_created_at",
+		"FROM pending_mutations pending\n\tLEFT JOIN tenants t ON t.id = pending.tenant_id",
+	} {
+		if !strings.Contains(observePendingMutationsSQL, fragment) {
+			t.Fatalf("optimized pending mutation query missing %q:\n%s", fragment, observePendingMutationsSQL)
+		}
+	}
+	if strings.Contains(observePendingMutationsSQL, "COUNT(*), MIN(q.created_at)") {
+		t.Fatalf("pending mutation query still joins metadata before aggregation:\n%s", observePendingMutationsSQL)
+	}
+}

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1006,9 +1006,19 @@ func TestObservePendingMutationsUsesSharedDBOrganization(t *testing.T) {
 	}
 	tenantID := "mutation-observe-shared-tenant"
 	insertSharedTenantPlacementForOrgTest(t, s, tenantID, "org-mutation-observe-shared")
-	if _, err := s.InsertMutationLog(ctx, &MutationLogEntry{
+	oldest := time.Now().UTC().Add(-5 * time.Minute)
+	firstID, err := s.InsertMutationLog(ctx, &MutationLogEntry{
 		TenantID: tenantID, MutationType: "file_delete", MutationData: []byte(`{"file_id":"f1"}`),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.InsertMutationLog(ctx, &MutationLogEntry{
+		TenantID: tenantID, MutationType: "file_delete", MutationData: []byte(`{"file_id":"f2"}`),
 	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE quota_mutation_log SET created_at = ? WHERE id = ?`, oldest, firstID); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1020,6 +1030,12 @@ func TestObservePendingMutationsUsesSharedDBOrganization(t *testing.T) {
 		if row.TenantID == tenantID {
 			if row.TiDBCloudOrgID != "org-mutation-observe-shared" {
 				t.Fatalf("mutation observation org = %q, want org-mutation-observe-shared", row.TiDBCloudOrgID)
+			}
+			if row.PendingCount != 2 {
+				t.Fatalf("mutation observation pending count = %d, want 2", row.PendingCount)
+			}
+			if row.OldestPendingAgeSeconds < 4*60 || row.OldestPendingAgeSeconds > 6*60 {
+				t.Fatalf("mutation observation oldest age = %.3fs, want about 5m", row.OldestPendingAgeSeconds)
 			}
 			return
 		}
@@ -2147,6 +2163,26 @@ func TestCountTenantPoolBindingsByStatusGroupsByPoolOrganizationAndStatus(t *tes
 			t.Fatalf("upsert binding %s: %v", tc.tenantID, err)
 		}
 	}
+	for _, tc := range []struct {
+		tenantID string
+		status   TenantStatus
+		pool     TenantPoolBindingStatus
+	}{
+		{tenantID: "binding-counts-shared-free", status: TenantActive, pool: TenantPoolBindingFree},
+		{tenantID: "binding-counts-shared-deleted", status: TenantDeleted, pool: TenantPoolBindingUsed},
+	} {
+		insertTenantForPoolMembershipTest(t, s, tc.tenantID, tc.status, now)
+		if err := s.UpsertTenantPoolMembership(ctx, &TenantPoolMembership{
+			TenantID:                tc.tenantID,
+			TiDBCloudOrganizationID: "org-binding-counts-a",
+			PoolID:                  "pool-binding-counts-a",
+			PoolStatus:              tc.pool,
+			CreatedAt:               now,
+			UpdatedAt:               now,
+		}); err != nil {
+			t.Fatalf("upsert shared membership %s: %v", tc.tenantID, err)
+		}
+	}
 
 	counts, err := s.CountTenantPoolBindingsByStatus(ctx)
 	if err != nil {
@@ -2157,7 +2193,7 @@ func TestCountTenantPoolBindingsByStatusGroupsByPoolOrganizationAndStatus(t *tes
 		got[count.PoolID+"|"+count.OrganizationID+"|"+string(count.Status)] = count.Count
 	}
 	want := map[string]int64{
-		"pool-binding-counts-a|org-binding-counts-a|free":         2,
+		"pool-binding-counts-a|org-binding-counts-a|free":         3,
 		"pool-binding-counts-a|org-binding-counts-a|used":         1,
 		"pool-binding-counts-empty|org-binding-counts-empty|free": 0,
 		"pool-binding-counts-empty|org-binding-counts-empty|used": 0,

--- a/pkg/meta/quota.go
+++ b/pkg/meta/quota.go
@@ -1368,25 +1368,32 @@ func (s *Store) ListPendingMutations(ctx context.Context, minAge time.Duration, 
 	return entries, rows.Err()
 }
 
+// Aggregate the mutation log before resolving tenant organization metadata so
+// each pending tenant, rather than each pending mutation, performs the joins.
+const observePendingMutationsSQL = `WITH pending_mutations AS (
+	SELECT tenant_id, COUNT(*) AS pending_count, MIN(created_at) AS oldest_created_at
+		FROM quota_mutation_log FORCE INDEX (idx_pending_tenant_age)
+		WHERE status = 'pending'
+		GROUP BY tenant_id
+)
+SELECT pending.tenant_id,
+	COALESCE(CASE WHEN t.provider = ? THEN d.org_id ELSE b.organization_id END, ''),
+	pending.pending_count, pending.oldest_created_at
+	FROM pending_mutations pending
+	LEFT JOIN tenants t ON t.id = pending.tenant_id
+	LEFT JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = pending.tenant_id
+	LEFT JOIN fs_registry f ON f.tenant_id = pending.tenant_id
+	LEFT JOIN tenant_placements p ON p.fs_id = f.fs_id
+	LEFT JOIN db_pool d ON d.db_id = p.db_id
+	ORDER BY pending.tenant_id`
+
 // ObservePendingMutations returns per-tenant pending mutation backlog and age.
 func (s *Store) ObservePendingMutations(ctx context.Context) ([]MutationBacklogObservation, error) {
 	start := time.Now()
 	var err error
 	defer observeMeta(ctx, "observe_pending_mutations", start, &err)
 
-	rows, err := s.db.QueryContext(ctx,
-		`SELECT q.tenant_id,
-		        COALESCE(CASE WHEN t.provider = ? THEN d.org_id ELSE b.organization_id END, ''),
-		        COUNT(*), MIN(q.created_at)
-		 FROM quota_mutation_log q FORCE INDEX (idx_pending_tenant_age)
-		 LEFT JOIN tenants t ON t.id = q.tenant_id
-		 LEFT JOIN tenant_tidbcloud_org_bindings b ON b.tenant_id = q.tenant_id
-		 LEFT JOIN fs_registry f ON f.tenant_id = q.tenant_id
-		 LEFT JOIN tenant_placements p ON p.fs_id = f.fs_id
-		 LEFT JOIN db_pool d ON d.db_id = p.db_id
-		 WHERE q.status = 'pending'
-		 GROUP BY q.tenant_id, t.provider, d.org_id, b.organization_id
-		 ORDER BY q.tenant_id`, tidbCloudNativeSharedProvider)
+	rows, err := s.db.QueryContext(ctx, observePendingMutationsSQL, tidbCloudNativeSharedProvider)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- pre-aggregate native/shared tenant-pool bindings and subtract deleted-tenant cleanup debt instead of looking up every bound tenant
- count shared placements as an active baseline and reclassify only non-active tenants, avoiding two point lookups per active placement
- aggregate pending quota mutations per tenant before resolving organization metadata
- add query-shape regressions and result coverage for native/shared/deleted bindings, tenant states, and mutation backlog count/age/org
- no schema or index changes

## Tencent dev evidence

Read-only EXPLAIN ANALYZE on guarded Tencent dev (`cls-9rse7rff-100049824031-context-default`, `drive9-tidbcloud/drive9-server`, `env=dev`):

| Query | Before | Optimized |
| --- | ---: | ---: |
| tenant pool binding counts | 5.991s | 0.843s |
| shared DB pool metric snapshots | 5.101s | 0.211s |
| pending mutation backlog | 1.758s paired baseline | 1.435s paired / 0.486s final run |

The final mutation run processed 54,408 pending rows, aggregated them into 10,495 tenant lookups, and remained sensitive to database cache/load.

## Test plan

- `go test ./pkg/meta -count=1 -timeout 5m`
- focused server metric tests for tenant-pool binding and shared DB pool collectors
- `make lint`
- `make build-server`
- `git diff --check`
- read-only Tencent dev EXPLAIN ANALYZE

## Out of scope

- retention for the approximately 212M-row `quota_mutation_log`
- transaction/lock-wait investigation for `tenant_file_meta ... FOR UPDATE`
- deployment or environment mutation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy of shared database pool tenant metrics, including tenant-state counts and status changes.
  - Corrected pool binding counts for shared and deleted tenants.
  - Improved pending mutation reporting with more accurate counts and oldest pending age information.

- **Performance**
  - Optimized metric, binding, and mutation queries to aggregate data more efficiently, improving responsiveness for larger environments.

- **Tests**
  - Added coverage to verify query efficiency and shared-database monitoring results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->