### PR TITLE
feat: configure meta DB connection lifetimes

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -626,6 +626,8 @@ environment:
   DRIVE9_POOL_IDLE_REAP_INTERVAL  how often the idle reaper scans (default: 2m)
   DRIVE9_META_DB_MAX_OPEN_CONNS max open connections for the per-pod meta DB pool (default: 100)
   DRIVE9_META_DB_MAX_IDLE_CONNS max idle connections for the per-pod meta DB pool (default: 20)
+  DRIVE9_META_DB_CONN_MAX_LIFETIME maximum meta connection lifetime (default: 10m)
+  DRIVE9_META_DB_CONN_MAX_IDLE_TIME maximum meta connection idle time (default: 1m, 0s=disabled)
   DRIVE9_USER_DB_MAX_OPEN_CONNS max open connections for each cached tenant user DB pool (default: 6)
   DRIVE9_USER_DB_MAX_IDLE_CONNS max idle connections for each cached tenant user DB pool (default: 2)
   DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS max open connections for tenant schema-init DB pools (default: 8)

--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -626,7 +626,7 @@ environment:
   DRIVE9_POOL_IDLE_REAP_INTERVAL  how often the idle reaper scans (default: 2m)
   DRIVE9_META_DB_MAX_OPEN_CONNS max open connections for the per-pod meta DB pool (default: 100)
   DRIVE9_META_DB_MAX_IDLE_CONNS max idle connections for the per-pod meta DB pool (default: 20)
-  DRIVE9_META_DB_CONN_MAX_LIFETIME maximum meta connection lifetime (default: 10m)
+  DRIVE9_META_DB_CONN_MAX_LIFETIME maximum meta connection lifetime (default: 10m; non-positive/invalid values use default)
   DRIVE9_META_DB_CONN_MAX_IDLE_TIME maximum meta connection idle time (default: 1m, 0s=disabled)
   DRIVE9_USER_DB_MAX_OPEN_CONNS max open connections for each cached tenant user DB pool (default: 6)
   DRIVE9_USER_DB_MAX_IDLE_CONNS max idle connections for each cached tenant user DB pool (default: 2)

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -36,6 +36,7 @@ const (
 //
 // Supported role-specific env vars:
 //   - DRIVE9_META_DB_MAX_OPEN_CONNS / DRIVE9_META_DB_MAX_IDLE_CONNS
+//   - DRIVE9_META_DB_CONN_MAX_LIFETIME / DRIVE9_META_DB_CONN_MAX_IDLE_TIME
 //   - DRIVE9_USER_DB_MAX_OPEN_CONNS / DRIVE9_USER_DB_MAX_IDLE_CONNS
 //   - DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS / DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS
 //   - DRIVE9_SHARED_DB_MAX_OPEN_CONNS / DRIVE9_SHARED_DB_MAX_IDLE_CONNS
@@ -58,11 +59,11 @@ func ApplyPoolDefaults(db *sql.DB, role string) {
 
 func poolLifetime(role string) (time.Duration, time.Duration) {
 	lifetime, idleTime := defaultPoolLifetime(role)
-	if role != RoleShared {
+	if role != RoleMeta && role != RoleShared {
 		return lifetime, idleTime
 	}
-	return poolEnvDuration(role, "CONN_MAX_LIFETIME", lifetime),
-		poolEnvDuration(role, "CONN_MAX_IDLE_TIME", idleTime)
+	return poolEnvDuration(role, "CONN_MAX_LIFETIME", lifetime, false),
+		poolEnvDuration(role, "CONN_MAX_IDLE_TIME", idleTime, true)
 }
 
 func defaultPoolLifetime(role string) (time.Duration, time.Duration) {
@@ -102,7 +103,7 @@ func poolEnvInt(role, suffix string, def int) int {
 	return def
 }
 
-func poolEnvDuration(role, suffix string, def time.Duration) time.Duration {
+func poolEnvDuration(role, suffix string, def time.Duration, allowZero bool) time.Duration {
 	key := rolePoolEnvKey(role, suffix)
 	if key == "" {
 		return def
@@ -112,7 +113,7 @@ func poolEnvDuration(role, suffix string, def time.Duration) time.Duration {
 		return def
 	}
 	value, err := time.ParseDuration(raw)
-	if err != nil || value <= 0 {
+	if err != nil || value < 0 || value == 0 && !allowZero {
 		return def
 	}
 	return value

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -63,7 +63,7 @@ func poolLifetime(role string) (time.Duration, time.Duration) {
 		return lifetime, idleTime
 	}
 	return poolEnvDuration(role, "CONN_MAX_LIFETIME", lifetime, false),
-		poolEnvDuration(role, "CONN_MAX_IDLE_TIME", idleTime, true)
+		poolEnvDuration(role, "CONN_MAX_IDLE_TIME", idleTime, role == RoleMeta)
 }
 
 func defaultPoolLifetime(role string) (time.Duration, time.Duration) {

--- a/pkg/mysqlutil/pool_test.go
+++ b/pkg/mysqlutil/pool_test.go
@@ -112,6 +112,15 @@ func TestSharedPoolDurationEnv(t *testing.T) {
 	}
 }
 
+func TestSharedPoolDurationEnvRejectsZeroIdleTime(t *testing.T) {
+	t.Setenv("DRIVE9_SHARED_DB_CONN_MAX_IDLE_TIME", "0s")
+
+	_, idleTime := poolLifetime(RoleShared)
+	if idleTime != defaultSharedConnMaxIdleTime {
+		t.Fatalf("shared idle time = %s, want default %s", idleTime, defaultSharedConnMaxIdleTime)
+	}
+}
+
 func TestMetaPoolDurationEnvAllowsZeroIdleTime(t *testing.T) {
 	t.Setenv("DRIVE9_META_DB_CONN_MAX_LIFETIME", "1h")
 	t.Setenv("DRIVE9_META_DB_CONN_MAX_IDLE_TIME", "0s")
@@ -119,5 +128,15 @@ func TestMetaPoolDurationEnvAllowsZeroIdleTime(t *testing.T) {
 	lifetime, idleTime := poolLifetime(RoleMeta)
 	if lifetime != time.Hour || idleTime != 0 {
 		t.Fatalf("meta env durations = %s/%s, want 1h/0s", lifetime, idleTime)
+	}
+}
+
+func TestMetaPoolDurationEnvRejectsZeroLifetime(t *testing.T) {
+	t.Setenv("DRIVE9_META_DB_CONN_MAX_LIFETIME", "0s")
+	t.Setenv("DRIVE9_META_DB_CONN_MAX_IDLE_TIME", "0s")
+
+	lifetime, idleTime := poolLifetime(RoleMeta)
+	if lifetime != defaultMetaConnMaxLifetime || idleTime != 0 {
+		t.Fatalf("meta env durations = %s/%s, want default %s/0s", lifetime, idleTime, defaultMetaConnMaxLifetime)
 	}
 }

--- a/pkg/mysqlutil/pool_test.go
+++ b/pkg/mysqlutil/pool_test.go
@@ -111,3 +111,13 @@ func TestSharedPoolDurationEnv(t *testing.T) {
 		t.Fatalf("shared env durations = %s/%s, want 45m/12m", lifetime, idleTime)
 	}
 }
+
+func TestMetaPoolDurationEnvAllowsZeroIdleTime(t *testing.T) {
+	t.Setenv("DRIVE9_META_DB_CONN_MAX_LIFETIME", "1h")
+	t.Setenv("DRIVE9_META_DB_CONN_MAX_IDLE_TIME", "0s")
+
+	lifetime, idleTime := poolLifetime(RoleMeta)
+	if lifetime != time.Hour || idleTime != 0 {
+		t.Fatalf("meta env durations = %s/%s, want 1h/0s", lifetime, idleTime)
+	}
+}


### PR DESCRIPTION
## Summary
- expose meta DB connection max lifetime and max idle time through role-specific environment variables
- allow an explicit 0s max idle time for meta DB connections while preserving shared DB fallback behavior
- document lifetime fallback semantics and cover the requested 1h/0s plus zero-value boundaries

## Test plan
- [x] go test ./pkg/mysqlutil ./cmd/drive9-server -count=1
- [x] make build
- [x] make lint
- [x] git diff --check
- [ ] umask 022; make test (stopped while in progress to push the review fixes immediately as requested)