### PR TITLE
fix: reduce metric cardinality and close observability gaps

### DIFF
--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -73,10 +73,11 @@ const (
 // allocation lives in pkg/meta; backend aliases let tenant write paths signal
 // work without importing the server package (which would be a cycle).
 const (
-	BackendWorkSSE            = meta.TenantNotifyWorkSSE            // wake local SSE bus
-	BackendWorkSemantic       = meta.TenantNotifyWorkSemantic       // kick semantic worker
-	BackendWorkFileGC         = meta.TenantNotifyWorkFileGC         // kick file GC worker
-	BackendWorkMetricsCleanup = meta.TenantNotifyWorkMetricsCleanup // reserved for lifecycle cleanup; backend does not emit it
+	BackendWorkSSE                = meta.TenantNotifyWorkSSE                // wake local SSE bus
+	BackendWorkSemantic           = meta.TenantNotifyWorkSemantic           // kick semantic worker
+	BackendWorkFileGC             = meta.TenantNotifyWorkFileGC             // kick file GC worker
+	BackendWorkMetricsCleanup     = meta.TenantNotifyWorkMetricsCleanup     // reserved for lifecycle cleanup; backend does not emit it
+	BackendWorkAPIKeyCacheCleanup = meta.TenantNotifyWorkAPIKeyCacheCleanup // reserved for auth-cache invalidation; backend does not emit it
 )
 
 // Dat9Backend implements filesystem.FileSystem with the inode model.

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -69,14 +69,14 @@ const (
 	symlinkContentType        = "application/x-symlink"
 )
 
-// Work mask constants for the unified tenant notify outbox. These mirror the
-// constants in pkg/server/work_mask.go but are defined here in the backend
-// package so the write path can signal which work types were enqueued without
-// importing the server package (which would be a circular dependency).
+// Work mask aliases for the unified tenant notify outbox. The persisted bit
+// allocation lives in pkg/meta; backend aliases let tenant write paths signal
+// work without importing the server package (which would be a cycle).
 const (
-	BackendWorkSSE      = 1 // wake local SSE bus
-	BackendWorkSemantic = 2 // kick semantic worker
-	BackendWorkFileGC   = 4 // kick file GC worker
+	BackendWorkSSE            = meta.TenantNotifyWorkSSE            // wake local SSE bus
+	BackendWorkSemantic       = meta.TenantNotifyWorkSemantic       // kick semantic worker
+	BackendWorkFileGC         = meta.TenantNotifyWorkFileGC         // kick file GC worker
+	BackendWorkMetricsCleanup = meta.TenantNotifyWorkMetricsCleanup // reserved for lifecycle cleanup; backend does not emit it
 )
 
 // Dat9Backend implements filesystem.FileSystem with the inode model.

--- a/pkg/backend/mutation_dispatcher.go
+++ b/pkg/backend/mutation_dispatcher.go
@@ -6,10 +6,12 @@ import (
 	"hash/fnv"
 	"sort"
 	"sync"
+	"time"
 
 	"go.uber.org/zap"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 const (
@@ -84,8 +86,9 @@ func StartMutationDispatcher() {
 	d := &mutationDispatcher{cancel: cancel}
 	for i := range d.shards {
 		d.shards[i] = make(chan quotaMutationItem, mutationDispatcherShardQueueSize)
+		metrics.RecordMutationDispatcherQueue(i, 0, mutationDispatcherShardQueueSize)
 		d.wg.Add(1)
-		go d.runShard(ctx, d.shards[i])
+		go d.runShard(ctx, i, d.shards[i])
 	}
 	mutationDispatcherInst = d
 }
@@ -119,7 +122,11 @@ func currentMutationDispatcher() *mutationDispatcher {
 // the intended backpressure point (callers hold mutationMu, so per-tenant
 // FIFO matches durable log_id order).
 func (d *mutationDispatcher) enqueue(item quotaMutationItem) {
-	d.shards[mutationDispatcherShardIndex(item.tenantID)] <- item
+	shard := int(mutationDispatcherShardIndex(item.tenantID))
+	start := time.Now()
+	d.shards[shard] <- item
+	metrics.RecordMutationDispatcherEnqueueBlocked(shard, time.Since(start))
+	metrics.RecordMutationDispatcherQueue(shard, len(d.shards[shard]), cap(d.shards[shard]))
 }
 
 func mutationDispatcherShardIndex(tenantID string) uint32 {
@@ -128,15 +135,18 @@ func mutationDispatcherShardIndex(tenantID string) uint32 {
 	return h.Sum32() % mutationDispatcherShards
 }
 
-func (d *mutationDispatcher) runShard(ctx context.Context, ch chan quotaMutationItem) {
+func (d *mutationDispatcher) runShard(ctx context.Context, shard int, ch chan quotaMutationItem) {
 	defer d.wg.Done()
 	for {
 		select {
 		case <-ctx.Done():
 			d.drainShard(ch)
+			metrics.RecordMutationDispatcherQueue(shard, 0, cap(ch))
 			return
 		case first := <-ch:
-			processMutationBatch(ctx, collectMutationBatch(ch, first))
+			batch := collectMutationBatch(ch, first)
+			metrics.RecordMutationDispatcherQueue(shard, len(ch), cap(ch))
+			processMutationBatch(ctx, batch)
 		}
 	}
 }
@@ -176,6 +186,7 @@ func collectMutationBatch(ch chan quotaMutationItem, first quotaMutationItem) []
 // only run on one underlying store; groups with a single item take the
 // legacy per-item path, larger groups share one transaction.
 func processMutationBatch(ctx context.Context, batch []quotaMutationItem) {
+	metrics.RecordMutationDispatcherBatch(len(batch), false)
 	groups := make([]mutationStoreGroup, 0, 1)
 	groupIndexByIdentity := make(map[any]int)
 	for i := range batch {
@@ -274,6 +285,7 @@ func processMutationStoreGroup(ctx context.Context, store MetaQuotaStore, items 
 	logger.Warn(ctx, "central_quota_mutation_batch_apply_failed",
 		zap.Int("batch_size", len(items)),
 		zap.Error(err))
+	metrics.RecordMutationDispatcherBatch(0, true)
 	for _, item := range items {
 		item.backend.applyQuotaMutation(ctx, item.mutationType, item.logID, item.pending, item.apply)
 		item.backend.mutationWG.Done()

--- a/pkg/backend/mutation_dispatcher_test.go
+++ b/pkg/backend/mutation_dispatcher_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -17,6 +18,9 @@ import (
 func TestMutationDispatcherAppliesAcrossTenantsPreservingOrder(t *testing.T) {
 	StartMutationDispatcher()
 	t.Cleanup(StopMutationDispatcher)
+	if metricsText := readBackendMetrics(); !strings.Contains(metricsText, `drive9_mutation_dispatcher_queue_capacity{shard="0"} 4096`) {
+		t.Fatalf("dispatcher queue capacity metric missing after start: %s", metricsText)
+	}
 
 	fake := newFakeMetaQuotaStore()
 	const tenantCount = 3
@@ -273,6 +277,10 @@ func TestMutationBatchPoisonItemFallsBackToPerItem(t *testing.T) {
 	}
 
 	processMutationBatch(context.Background(), items)
+	metricsText := readBackendMetrics()
+	if !strings.Contains(metricsText, "drive9_mutation_dispatcher_batch_fallback_total ") {
+		t.Fatalf("dispatcher fallback metric missing: %s", metricsText)
+	}
 
 	// The batch transaction aborted at the poison apply, so the batch mark
 	// was never attempted and every item went through the per-item path.

--- a/pkg/backend/mutation_replay.go
+++ b/pkg/backend/mutation_replay.go
@@ -223,8 +223,8 @@ func (w *MutationReplayWorker) recordPendingBacklog(ctx context.Context) {
 	for _, obs := range observations {
 		orgID := normalizeTenantMetricTiDBCloudOrgID(obs.TiDBCloudOrgID)
 		if previousOrgID, ok := w.observedBacklogTenants[obs.TenantID]; ok && previousOrgID != orgID {
-			metrics.RecordTenantGaugeWithOrg(obs.TenantID, previousOrgID, "mutation_replay", "pending_mutations", 0)
-			metrics.RecordTenantGaugeWithOrg(obs.TenantID, previousOrgID, "mutation_replay", "oldest_pending_age_seconds", 0)
+			metrics.DeleteTenantGaugeWithOrg(obs.TenantID, previousOrgID, "mutation_replay", "pending_mutations")
+			metrics.DeleteTenantGaugeWithOrg(obs.TenantID, previousOrgID, "mutation_replay", "oldest_pending_age_seconds")
 		}
 		current[obs.TenantID] = orgID
 		w.observedBacklogTenants[obs.TenantID] = orgID
@@ -235,8 +235,8 @@ func (w *MutationReplayWorker) recordPendingBacklog(ctx context.Context) {
 		if _, ok := current[tenantID]; ok {
 			continue
 		}
-		metrics.RecordTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "pending_mutations", 0)
-		metrics.RecordTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "oldest_pending_age_seconds", 0)
+		metrics.DeleteTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "pending_mutations")
+		metrics.DeleteTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "oldest_pending_age_seconds")
 		delete(w.observedBacklogTenants, tenantID)
 	}
 	metrics.RecordOperation("mutation_replay", "observe_pending", "ok", time.Since(start))
@@ -244,8 +244,8 @@ func (w *MutationReplayWorker) recordPendingBacklog(ctx context.Context) {
 
 func (w *MutationReplayWorker) clearPendingBacklogGauges() {
 	for tenantID, orgID := range w.observedBacklogTenants {
-		metrics.RecordTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "pending_mutations", 0)
-		metrics.RecordTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "oldest_pending_age_seconds", 0)
+		metrics.DeleteTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "pending_mutations")
+		metrics.DeleteTenantGaugeWithOrg(tenantID, orgID, "mutation_replay", "oldest_pending_age_seconds")
 		delete(w.observedBacklogTenants, tenantID)
 	}
 }

--- a/pkg/backend/mutation_replay_metrics_test.go
+++ b/pkg/backend/mutation_replay_metrics_test.go
@@ -35,11 +35,11 @@ func TestMutationReplayWorkerRecordsPendingBacklogGauges(t *testing.T) {
 	w.recordPendingBacklog(context.Background())
 
 	metricsText = readBackendMetrics()
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-backlog",tidbcloud_org_id="org-backlog"} 0`) {
-		t.Errorf("metrics did not clear pending mutation backlog gauge: %s", metricsText)
+	if strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-backlog",tidbcloud_org_id="org-backlog"}`) {
+		t.Errorf("healthy pending mutation backlog gauge was not deleted: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-backlog",tidbcloud_org_id="org-backlog"} 0`) {
-		t.Errorf("metrics did not clear oldest pending age gauge: %s", metricsText)
+	if strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-backlog",tidbcloud_org_id="org-backlog"}`) {
+		t.Errorf("healthy oldest pending age gauge was not deleted: %s", metricsText)
 	}
 }
 
@@ -55,8 +55,8 @@ func TestMutationReplayWorkerClearsPreviousOrganizationGauge(t *testing.T) {
 	w.recordPendingBacklog(context.Background())
 
 	metricsText := readBackendMetrics()
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-org-change",tidbcloud_org_id="guest"} 0`) {
-		t.Fatalf("previous guest backlog gauge was not cleared: %s", metricsText)
+	if strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-org-change",tidbcloud_org_id="guest"}`) {
+		t.Fatalf("previous guest backlog gauge was not deleted: %s", metricsText)
 	}
 	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-org-change",tidbcloud_org_id="org-current"} 1`) {
 		t.Fatalf("current org backlog gauge was not recorded: %s", metricsText)
@@ -75,11 +75,11 @@ func TestMutationReplayWorkerClearsPendingBacklogGaugesOnStop(t *testing.T) {
 	w.clearPendingBacklogGauges()
 
 	metricsText := readBackendMetrics()
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-stop",tidbcloud_org_id="guest"} 0`) {
-		t.Errorf("metrics did not clear pending mutation backlog gauge on stop: %s", metricsText)
+	if strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="pending_mutations",tenant_id="tenant-stop",tidbcloud_org_id="guest"}`) {
+		t.Errorf("metrics did not delete pending mutation backlog gauge on stop: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-stop",tidbcloud_org_id="guest"} 0`) {
-		t.Errorf("metrics did not clear oldest pending age gauge on stop: %s", metricsText)
+	if strings.Contains(metricsText, `drive9_service_gauge{component="mutation_replay",name="oldest_pending_age_seconds",tenant_id="tenant-stop",tidbcloud_org_id="guest"}`) {
+		t.Errorf("metrics did not delete oldest pending age gauge on stop: %s", metricsText)
 	}
 	if len(w.observedBacklogTenants) != 0 {
 		t.Errorf("observed backlog tenants = %d, want 0", len(w.observedBacklogTenants))

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -274,6 +274,7 @@ func recordTenantQuotaSnapshot(tenantID, tidbCloudOrgID string, usage *QuotaUsag
 	if tenantID == "" || usage == nil {
 		return
 	}
+	metrics.DeleteTenantQuotaSnapshot(tenantID)
 	metrics.RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, "confirmed", usage.StorageBytes)
 	metrics.RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, "reserved", usage.ReservedBytes)
 	metrics.RecordTenantMediaFilesWithOrg(tenantID, tidbCloudOrgID, "confirmed", usage.MediaFileCount)

--- a/pkg/backend/quota.go
+++ b/pkg/backend/quota.go
@@ -274,23 +274,18 @@ func recordTenantQuotaSnapshot(tenantID, tidbCloudOrgID string, usage *QuotaUsag
 	if tenantID == "" || usage == nil {
 		return
 	}
-	metrics.DeleteTenantQuotaSnapshot(tenantID)
-	metrics.RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, "confirmed", usage.StorageBytes)
-	metrics.RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, "reserved", usage.ReservedBytes)
-	metrics.RecordTenantMediaFilesWithOrg(tenantID, tidbCloudOrgID, "confirmed", usage.MediaFileCount)
-	metrics.RecordTenantVideoFilesWithOrg(tenantID, tidbCloudOrgID, "confirmed", usage.VideoFileCount)
-	if cfg == nil {
-		return
+	var storageLimit, mediaLimit, videoLimit int64
+	if cfg != nil {
+		storageLimit = cfg.MaxStorageBytes
+		mediaLimit = cfg.MaxMediaLLMFiles
+		videoLimit = cfg.MaxVideoLLMFiles
 	}
-	if cfg.MaxStorageBytes > 0 {
-		metrics.RecordTenantStorageBytesWithOrg(tenantID, tidbCloudOrgID, "limit", cfg.MaxStorageBytes)
-	}
-	if cfg.MaxMediaLLMFiles > 0 {
-		metrics.RecordTenantMediaFilesWithOrg(tenantID, tidbCloudOrgID, "limit", cfg.MaxMediaLLMFiles)
-	}
-	if cfg.MaxVideoLLMFiles > 0 {
-		metrics.RecordTenantVideoFilesWithOrg(tenantID, tidbCloudOrgID, "limit", cfg.MaxVideoLLMFiles)
-	}
+	metrics.ReplaceTenantQuotaSnapshotWithOrg(
+		tenantID, tidbCloudOrgID,
+		usage.StorageBytes, usage.ReservedBytes, usage.MediaFileCount, usage.VideoFileCount,
+		storageLimit, mediaLimit, videoLimit,
+		cfg != nil,
+	)
 }
 
 func quotaMediaDelta(oldIsMedia, newIsMedia bool) int64 {

--- a/pkg/backend/quota_metrics_test.go
+++ b/pkg/backend/quota_metrics_test.go
@@ -1,0 +1,40 @@
+package backend
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/metrics"
+)
+
+func TestRecordTenantQuotaSnapshotReplacesOldLimitsAndOrgLabels(t *testing.T) {
+	const tenantID = "tenant-quota-snapshot-replace"
+
+	recordTenantQuotaSnapshot(tenantID, "org-old", &QuotaUsageView{
+		StorageBytes: 10, MediaFileCount: 2, VideoFileCount: 1,
+	}, &QuotaConfigView{
+		MaxStorageBytes: 100, MaxMediaLLMFiles: 20, MaxVideoLLMFiles: 10,
+	})
+	recordTenantQuotaSnapshot(tenantID, "org-new", &QuotaUsageView{
+		StorageBytes: 11, MediaFileCount: 3, VideoFileCount: 2,
+	}, &QuotaConfigView{})
+
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	text := rec.Body.String()
+	for _, line := range strings.Split(text, "\n") {
+		if !strings.Contains(line, `tenant_id="`+tenantID+`"`) {
+			continue
+		}
+		if strings.Contains(line, `tidbcloud_org_id="org-old"`) {
+			t.Fatalf("old org quota series remains exported: %s", line)
+		}
+		if strings.Contains(line, `state="limit"`) {
+			t.Fatalf("removed quota limit remains exported: %s", line)
+		}
+	}
+	if !strings.Contains(text, `drive9_tenant_storage_bytes{state="confirmed",tenant_id="`+tenantID+`",tidbcloud_org_id="org-new"} 11.000000`) {
+		t.Fatalf("new quota usage snapshot missing:\n%s", text)
+	}
+}

--- a/pkg/backend/quota_metrics_test.go
+++ b/pkg/backend/quota_metrics_test.go
@@ -38,3 +38,31 @@ func TestRecordTenantQuotaSnapshotReplacesOldLimitsAndOrgLabels(t *testing.T) {
 		t.Fatalf("new quota usage snapshot missing:\n%s", text)
 	}
 }
+
+func TestRecordTenantQuotaSnapshotPreservesKnownLimitsWhenConfigUnavailable(t *testing.T) {
+	const (
+		tenantID = "tenant-quota-snapshot-config-unavailable"
+		orgID    = "org-quota-snapshot-config-unavailable"
+	)
+	recordTenantQuotaSnapshot(tenantID, orgID, &QuotaUsageView{
+		StorageBytes: 10, MediaFileCount: 2, VideoFileCount: 1,
+	}, &QuotaConfigView{
+		MaxStorageBytes: 100, MaxMediaLLMFiles: 20, MaxVideoLLMFiles: 10,
+	})
+	recordTenantQuotaSnapshot(tenantID, orgID, &QuotaUsageView{
+		StorageBytes: 11, MediaFileCount: 3, VideoFileCount: 2,
+	}, nil)
+
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	text := rec.Body.String()
+	for _, want := range []string{
+		`drive9_tenant_storage_bytes{state="limit",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 100.000000`,
+		`drive9_tenant_media_files{state="limit",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 20.000000`,
+		`drive9_tenant_video_files{state="limit",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 10.000000`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("known quota limit disappeared while config was unavailable; missing %q:\n%s", want, text)
+		}
+	}
+}

--- a/pkg/meta/api_key_cache.go
+++ b/pkg/meta/api_key_cache.go
@@ -143,6 +143,16 @@ func (c *apiKeyResolveCache) evictTenant(tenantID string) {
 	metrics.RecordAPIKeyResolveCacheEntries(entries)
 }
 
+// InvalidateAPIKeyResolveCacheForTenant drops all locally cached API-key
+// resolutions for tenantID. Lifecycle outbox consumers use this to invalidate
+// peer-pod caches after a deleting/deleted transition commits.
+func (s *Store) InvalidateAPIKeyResolveCacheForTenant(tenantID string) {
+	if s == nil || s.apiKeys == nil {
+		return
+	}
+	s.apiKeys.evictTenant(tenantID)
+}
+
 func (c *apiKeyResolveCache) deleteLocked(hash string) {
 	entry, ok := c.byHash[hash]
 	if !ok {

--- a/pkg/meta/api_key_cache.go
+++ b/pkg/meta/api_key_cache.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/mem9-ai/drive9/pkg/metrics"
@@ -53,9 +52,6 @@ type apiKeyResolveCache struct {
 	hashesByTenant map[string]map[string]struct{}
 
 	flight singleflight.Group
-
-	hits   atomic.Int64
-	misses atomic.Int64
 }
 
 func newAPIKeyResolveCache() *apiKeyResolveCache {
@@ -83,12 +79,10 @@ func apiKeyResolveCacheTTLFromEnv() time.Duration {
 func (c *apiKeyResolveCache) get(hash string) (*TenantWithAPIKey, bool) {
 	rec, ok := c.lookup(hash)
 	if !ok {
-		c.misses.Add(1)
-		metrics.RecordAPIKeyResolveCache("miss", c.entryCount())
+		metrics.RecordAPIKeyResolveCacheRequest("miss")
 		return nil, false
 	}
-	c.hits.Add(1)
-	metrics.RecordAPIKeyResolveCache("hit", c.entryCount())
+	metrics.RecordAPIKeyResolveCacheRequest("hit")
 	return rec, true
 }
 
@@ -97,11 +91,16 @@ func (c *apiKeyResolveCache) get(hash string) (*TenantWithAPIKey, bool) {
 func (c *apiKeyResolveCache) lookup(hash string) (*TenantWithAPIKey, bool) {
 	c.mu.Lock()
 	entry, ok := c.byHash[hash]
+	entriesAfterExpiry := -1
 	if ok && !time.Now().Before(entry.expiresAt) {
 		c.deleteLocked(hash)
+		entriesAfterExpiry = len(c.byHash)
 		ok = false
 	}
 	c.mu.Unlock()
+	if entriesAfterExpiry >= 0 {
+		metrics.RecordAPIKeyResolveCacheEntries(entriesAfterExpiry)
+	}
 	if !ok {
 		return nil, false
 	}
@@ -142,12 +141,6 @@ func (c *apiKeyResolveCache) evictTenant(tenantID string) {
 	entries := len(c.byHash)
 	c.mu.Unlock()
 	metrics.RecordAPIKeyResolveCacheEntries(entries)
-}
-
-func (c *apiKeyResolveCache) entryCount() int {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	return len(c.byHash)
 }
 
 func (c *apiKeyResolveCache) deleteLocked(hash string) {

--- a/pkg/meta/api_key_cache.go
+++ b/pkg/meta/api_key_cache.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/mem9-ai/drive9/pkg/metrics"
+
 	"golang.org/x/sync/singleflight"
 )
 
@@ -82,9 +84,11 @@ func (c *apiKeyResolveCache) get(hash string) (*TenantWithAPIKey, bool) {
 	rec, ok := c.lookup(hash)
 	if !ok {
 		c.misses.Add(1)
+		metrics.RecordAPIKeyResolveCache("miss", c.entryCount())
 		return nil, false
 	}
 	c.hits.Add(1)
+	metrics.RecordAPIKeyResolveCache("hit", c.entryCount())
 	return rec, true
 }
 
@@ -109,7 +113,6 @@ func (c *apiKeyResolveCache) lookup(hash string) (*TenantWithAPIKey, bool) {
 // its tenant so revocations can evict precisely.
 func (c *apiKeyResolveCache) fill(hash string, rec TenantWithAPIKey) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	if old, ok := c.byHash[hash]; ok {
 		c.removeTenantIndexLocked(old.rec.Tenant.ID, hash)
 	}
@@ -120,6 +123,9 @@ func (c *apiKeyResolveCache) fill(hash string, rec TenantWithAPIKey) {
 		c.hashesByTenant[rec.Tenant.ID] = set
 	}
 	set[hash] = struct{}{}
+	entries := len(c.byHash)
+	c.mu.Unlock()
+	metrics.RecordAPIKeyResolveCacheEntries(entries)
 }
 
 // evictTenant drops every cached hash known to belong to tenantID. Called
@@ -129,11 +135,19 @@ func (c *apiKeyResolveCache) fill(hash string, rec TenantWithAPIKey) {
 // are a no-op.
 func (c *apiKeyResolveCache) evictTenant(tenantID string) {
 	c.mu.Lock()
-	defer c.mu.Unlock()
 	for hash := range c.hashesByTenant[tenantID] {
 		delete(c.byHash, hash)
 	}
 	delete(c.hashesByTenant, tenantID)
+	entries := len(c.byHash)
+	c.mu.Unlock()
+	metrics.RecordAPIKeyResolveCacheEntries(entries)
+}
+
+func (c *apiKeyResolveCache) entryCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.byHash)
 }
 
 func (c *apiKeyResolveCache) deleteLocked(hash string) {

--- a/pkg/meta/api_key_cache.go
+++ b/pkg/meta/api_key_cache.go
@@ -13,11 +13,12 @@ import (
 
 // defaultAPIKeyResolveCacheTTL bounds how long a resolved API key entry may be
 // served from the in-process cache. Tenant-row and tenant_api_keys mutations
-// made through this Store evict the tenant's cached entries via the tenant
-// index; the TTL backstops changes made by other processes (each pod caches
-// independently) and the residual fill-after-evict race (a resolve reading
-// pre-mutation state concurrently with the mutation, then filling after the
-// eviction — that window has no version check and closes only at TTL expiry).
+// made through this Store evict the local tenant entries via the tenant index;
+// revocations also enqueue a durable cross-pod cache-cleanup signal. The TTL
+// backstops changes made by other processes and the residual fill-after-evict
+// race (a resolve reading pre-mutation state concurrently with the mutation,
+// then filling after the eviction — that window has no version check and closes
+// only at TTL expiry).
 const defaultAPIKeyResolveCacheTTL = 10 * time.Second
 
 // envAPIKeyResolveCacheTTLMS overrides defaultAPIKeyResolveCacheTTL (in

--- a/pkg/meta/api_key_cache_test.go
+++ b/pkg/meta/api_key_cache_test.go
@@ -168,6 +168,21 @@ func TestResolveByAPIKeyHashRevokeTenantAPIKeysEvictsCache(t *testing.T) {
 	}
 }
 
+func TestInvalidateAPIKeyResolveCacheForTenantEvictsCache(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	insertCacheTestTenant(t, s, "cache-t-invalidate")
+	insertCacheTestKey(t, s, "cache-t-invalidate", "cache-k-invalidate", "cache-hash-invalidate")
+	if _, err := s.ResolveByAPIKeyHash(ctx, "cache-hash-invalidate"); err != nil {
+		t.Fatal(err)
+	}
+
+	s.InvalidateAPIKeyResolveCacheForTenant("cache-t-invalidate")
+	if _, ok := s.apiKeys.lookup("cache-hash-invalidate"); ok {
+		t.Fatal("tenant API key remained cached after explicit invalidation")
+	}
+}
+
 func TestResolveByAPIKeyHashRevokeByIssuerEvictsCache(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/api_key_cache_test.go
+++ b/pkg/meta/api_key_cache_test.go
@@ -2,9 +2,37 @@ package meta
 
 import (
 	"context"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
+
+func TestAPIKeyResolveCacheExportsHitMissAndEntries(t *testing.T) {
+	c := newAPIKeyResolveCache()
+	if _, ok := c.get("metrics-miss"); ok {
+		t.Fatal("unexpected cache hit")
+	}
+	c.fill("metrics-hit", TenantWithAPIKey{Tenant: Tenant{ID: "cache-metrics-tenant"}})
+	if _, ok := c.get("metrics-hit"); !ok {
+		t.Fatal("expected cache hit")
+	}
+
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	text := rec.Body.String()
+	for _, want := range []string{
+		`drive9_api_key_resolve_cache_requests_total{result="miss"}`,
+		`drive9_api_key_resolve_cache_requests_total{result="hit"}`,
+		`drive9_api_key_resolve_cache_entries 1.000000`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing API key cache metric %q:\n%s", want, text)
+		}
+	}
+}
 
 func insertCacheTestTenant(t *testing.T, s *Store, tenantID string) {
 	t.Helper()

--- a/pkg/meta/api_key_cache_test.go
+++ b/pkg/meta/api_key_cache_test.go
@@ -81,8 +81,8 @@ func TestResolveByAPIKeyHashCachesWithinTTL(t *testing.T) {
 	if _, err := s.ResolveByAPIKeyHash(context.Background(), "cache-hash1"); err != nil {
 		t.Fatal(err)
 	}
-	if got := s.apiKeys.hits.Load(); got != 0 {
-		t.Fatalf("cache hits after first resolve = %d, want 0", got)
+	if _, ok := s.apiKeys.lookup("cache-hash1"); !ok {
+		t.Fatal("first resolve did not populate cache")
 	}
 	got, err := s.ResolveByAPIKeyHash(context.Background(), "cache-hash1")
 	if err != nil {
@@ -90,9 +90,6 @@ func TestResolveByAPIKeyHashCachesWithinTTL(t *testing.T) {
 	}
 	if got.Tenant.ID != "cache-t1" || got.APIKey.ID != "cache-k1" {
 		t.Fatalf("cached resolve = tenant %s key %s, want cache-t1/cache-k1", got.Tenant.ID, got.APIKey.ID)
-	}
-	if hits := s.apiKeys.hits.Load(); hits != 1 {
-		t.Fatalf("cache hits after second resolve = %d, want 1", hits)
 	}
 }
 
@@ -129,20 +126,15 @@ func TestResolveByAPIKeyHashRevokeAPIKeyEvictsCache(t *testing.T) {
 	if _, err := s.ResolveByAPIKeyHash(ctx, "cache-hash3"); err != nil {
 		t.Fatal(err)
 	}
-	if hits := s.apiKeys.hits.Load(); hits != 1 {
-		t.Fatalf("cache hits = %d, want 1", hits)
-	}
-
 	if err := s.RevokeAPIKey(ctx, "cache-t3", "cache-k3"); err != nil {
 		t.Fatal(err)
 	}
-	missesBefore := s.apiKeys.misses.Load()
+	if _, ok := s.apiKeys.lookup("cache-hash3"); ok {
+		t.Fatal("revoked API key remained cached")
+	}
 	revoked, err := s.ResolveByAPIKeyHash(ctx, "cache-hash3")
 	if err != nil {
 		t.Fatal(err)
-	}
-	if got := s.apiKeys.misses.Load(); got != missesBefore+1 {
-		t.Fatalf("cache misses after revoke = %d, want %d (entry evicted)", got, missesBefore+1)
 	}
 	if revoked.APIKey.Status != APIKeyRevoked {
 		t.Fatalf("revoked key status = %s, want %s", revoked.APIKey.Status, APIKeyRevoked)
@@ -161,20 +153,15 @@ func TestResolveByAPIKeyHashRevokeTenantAPIKeysEvictsCache(t *testing.T) {
 	if _, err := s.ResolveByAPIKeyHash(ctx, "cache-hash4"); err != nil {
 		t.Fatal(err)
 	}
-	if hits := s.apiKeys.hits.Load(); hits != 1 {
-		t.Fatalf("cache hits = %d, want 1", hits)
-	}
-
 	if err := s.RevokeTenantAPIKeys(ctx, "cache-t4"); err != nil {
 		t.Fatal(err)
 	}
-	missesBefore := s.apiKeys.misses.Load()
+	if _, ok := s.apiKeys.lookup("cache-hash4"); ok {
+		t.Fatal("tenant-revoked API key remained cached")
+	}
 	revoked, err := s.ResolveByAPIKeyHash(ctx, "cache-hash4")
 	if err != nil {
 		t.Fatal(err)
-	}
-	if got := s.apiKeys.misses.Load(); got != missesBefore+1 {
-		t.Fatalf("cache misses after RevokeTenantAPIKeys = %d, want %d", got, missesBefore+1)
 	}
 	if revoked.APIKey.Status != APIKeyRevoked {
 		t.Fatalf("tenant-revoked key status = %s, want %s", revoked.APIKey.Status, APIKeyRevoked)
@@ -198,20 +185,15 @@ func TestResolveByAPIKeyHashRevokeByIssuerEvictsCache(t *testing.T) {
 	if _, err := s.ResolveByAPIKeyHash(ctx, "cache-hash5"); err != nil {
 		t.Fatal(err)
 	}
-	if hits := s.apiKeys.hits.Load(); hits != 1 {
-		t.Fatalf("cache hits = %d, want 1", hits)
-	}
-
 	if err := s.RevokeAPIKeysByIssuer(ctx, "cache-t5", "slock", "subject-1", ""); err != nil {
 		t.Fatal(err)
 	}
-	missesBefore := s.apiKeys.misses.Load()
+	if _, ok := s.apiKeys.lookup("cache-hash5"); ok {
+		t.Fatal("issuer-revoked API key remained cached")
+	}
 	revoked, err := s.ResolveByAPIKeyHash(ctx, "cache-hash5")
 	if err != nil {
 		t.Fatal(err)
-	}
-	if got := s.apiKeys.misses.Load(); got != missesBefore+1 {
-		t.Fatalf("cache misses after issuer revoke = %d, want %d", got, missesBefore+1)
 	}
 	if revoked.APIKey.Status != APIKeyRevoked {
 		t.Fatalf("issuer-revoked key status = %s, want %s", revoked.APIKey.Status, APIKeyRevoked)
@@ -231,20 +213,15 @@ func TestResolveByAPIKeyHashTenantStatusUpdateEvictsCache(t *testing.T) {
 	if _, err := s.ResolveByAPIKeyHash(ctx, "cache-hash8"); err != nil {
 		t.Fatal(err)
 	}
-	if hits := s.apiKeys.hits.Load(); hits != 1 {
-		t.Fatalf("cache hits = %d, want 1", hits)
-	}
-
 	if err := s.UpdateTenantStatus(ctx, "cache-t8", TenantSuspended); err != nil {
 		t.Fatal(err)
 	}
-	missesBefore := s.apiKeys.misses.Load()
+	if _, ok := s.apiKeys.lookup("cache-hash8"); ok {
+		t.Fatal("tenant status update left stale API key resolution cached")
+	}
 	got, err := s.ResolveByAPIKeyHash(ctx, "cache-hash8")
 	if err != nil {
 		t.Fatal(err)
-	}
-	if got := s.apiKeys.misses.Load(); got != missesBefore+1 {
-		t.Fatalf("cache misses after status update = %d, want %d (entry evicted)", got, missesBefore+1)
 	}
 	if got.Tenant.Status != TenantSuspended {
 		t.Fatalf("tenant status after update = %s, want %s (no TTL wait)", got.Tenant.Status, TenantSuspended)
@@ -263,10 +240,6 @@ func TestResolveByAPIKeyHashDBCredentialUpdateEvictsCache(t *testing.T) {
 	if _, err := s.ResolveByAPIKeyHash(ctx, "cache-hash9"); err != nil {
 		t.Fatal(err)
 	}
-	if hits := s.apiKeys.hits.Load(); hits != 1 {
-		t.Fatalf("cache hits = %d, want 1", hits)
-	}
-
 	updated, err := s.UpdateTenantDBCredentialIf(ctx, "cache-t9", "root", "app_user", []byte("new-cipher"))
 	if err != nil {
 		t.Fatal(err)
@@ -274,13 +247,12 @@ func TestResolveByAPIKeyHashDBCredentialUpdateEvictsCache(t *testing.T) {
 	if !updated {
 		t.Fatal("UpdateTenantDBCredentialIf updated = false, want true")
 	}
-	missesBefore := s.apiKeys.misses.Load()
+	if _, ok := s.apiKeys.lookup("cache-hash9"); ok {
+		t.Fatal("credential update left stale API key resolution cached")
+	}
 	got, err := s.ResolveByAPIKeyHash(ctx, "cache-hash9")
 	if err != nil {
 		t.Fatal(err)
-	}
-	if got := s.apiKeys.misses.Load(); got != missesBefore+1 {
-		t.Fatalf("cache misses after credential update = %d, want %d (entry evicted)", got, missesBefore+1)
 	}
 	if got.Tenant.DBUser != "app_user" || string(got.Tenant.DBPasswordCipher) != "new-cipher" {
 		t.Fatalf("credentials after update = %q/%q, want app_user/new-cipher (no TTL wait)",
@@ -297,13 +269,12 @@ func TestResolveByAPIKeyHashTTLExpiryRefetches(t *testing.T) {
 	if _, err := s.ResolveByAPIKeyHash(context.Background(), "cache-hash6"); err != nil {
 		t.Fatal(err)
 	}
-	missesBefore := s.apiKeys.misses.Load()
 	time.Sleep(40 * time.Millisecond)
+	if _, ok := s.apiKeys.lookup("cache-hash6"); ok {
+		t.Fatal("expired API key resolution remained cached")
+	}
 	if _, err := s.ResolveByAPIKeyHash(context.Background(), "cache-hash6"); err != nil {
 		t.Fatal(err)
-	}
-	if got := s.apiKeys.misses.Load(); got != missesBefore+1 {
-		t.Fatalf("cache misses after TTL expiry = %d, want %d (entry re-fetched)", got, missesBefore+1)
 	}
 }
 
@@ -328,9 +299,6 @@ func TestResolveByAPIKeyHashCachedEntryIsIsolatedPerCaller(t *testing.T) {
 	again, err := s.ResolveByAPIKeyHash(context.Background(), "cache-hash7")
 	if err != nil {
 		t.Fatal(err)
-	}
-	if hits := s.apiKeys.hits.Load(); hits != 2 {
-		t.Fatalf("cache hits = %d, want 2", hits)
 	}
 	if string(again.APIKey.JWTCiphertext) != "jwt-cipher" {
 		t.Fatalf("cached jwt ciphertext mutated: %q", again.APIKey.JWTCiphertext)

--- a/pkg/meta/api_key_cache_test.go
+++ b/pkg/meta/api_key_cache_test.go
@@ -141,6 +141,69 @@ func TestResolveByAPIKeyHashRevokeAPIKeyEvictsCache(t *testing.T) {
 	}
 }
 
+func TestAPIKeyRevocationsWriteCacheCleanupOutbox(t *testing.T) {
+	tests := []struct {
+		name   string
+		revoke func(context.Context, *Store, string, string) error
+	}{
+		{
+			name: "single key",
+			revoke: func(ctx context.Context, s *Store, tenantID, keyID string) error {
+				return s.RevokeAPIKey(ctx, tenantID, keyID)
+			},
+		},
+		{
+			name: "all tenant keys",
+			revoke: func(ctx context.Context, s *Store, tenantID, _ string) error {
+				return s.RevokeTenantAPIKeys(ctx, tenantID)
+			},
+		},
+		{
+			name: "issuer keys",
+			revoke: func(ctx context.Context, s *Store, tenantID, _ string) error {
+				return s.RevokeAPIKeysByIssuer(ctx, tenantID, "slock", "subject-1", "")
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := newControlStore(t)
+			ctx := context.Background()
+			if _, err := s.DB().ExecContext(ctx, `DELETE FROM tenant_notify_outbox`); err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				_, _ = s.DB().ExecContext(context.Background(), `DELETE FROM tenant_notify_outbox`)
+			})
+			tenantID := "cache-outbox-" + strings.ReplaceAll(tt.name, " ", "-")
+			keyID := tenantID + "-key"
+			insertCacheTestTenant(t, s, tenantID)
+			insertCacheTestKey(t, s, tenantID, keyID, tenantID+"-hash")
+			if tt.name == "issuer keys" {
+				if _, err := s.DB().ExecContext(ctx, `UPDATE tenant_api_keys
+					SET issued_by_provider = 'slock', issued_by_subject_key = 'subject-1'
+					WHERE id = ?`, keyID); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := tt.revoke(ctx, s, tenantID, keyID); err != nil {
+				t.Fatal(err)
+			}
+			rows, err := s.ListTenantNotifySince(ctx, 0, 100)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, row := range rows {
+				if row.TenantID == tenantID && row.WorkMask&TenantNotifyWorkAPIKeyCacheCleanup != 0 {
+					return
+				}
+			}
+			t.Fatalf("missing durable API-key cache-cleanup outbox row for tenant %s: %+v", tenantID, rows)
+		})
+	}
+}
+
 func TestResolveByAPIKeyHashRevokeTenantAPIKeysEvictsCache(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -1616,7 +1616,7 @@ func (s *Store) FinalizeSharedTenantDeleteMetadata(ctx context.Context, tenantID
 		if _, err := tx.ExecContext(ctx, `DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?`, tenantID); err != nil {
 			return err
 		}
-		return nil
+		return insertTenantNotifyTx(ctx, tx, tenantID, TenantNotifyWorkMetricsCleanup)
 	})
 	if err != nil {
 		return err

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -175,6 +175,7 @@ type SharedDBPoolMetricSnapshot struct {
 	TenantCount             int
 	SoftCapReached          bool
 	SpendingLimit           *int64
+	UpdatedAt               time.Time
 	TenantStates            []SharedDBPoolTenantStateCount
 }
 
@@ -1055,7 +1056,7 @@ const listSharedDBPoolMetricSnapshotsSQL = `WITH non_active_tenant_states AS (
 )
 SELECT
 	d.db_id, d.uuid, COALESCE(d.org_id, ''), d.status, d.max_tenants, d.tenant_count, d.soft_cap_reached,
-	d.spending_limit,
+	d.spending_limit, d.updated_at,
 	COALESCE(tenant_states.tenant_status, ''), COALESCE(tenant_states.tenant_count, 0)
 	FROM db_pool d
 	LEFT JOIN tenant_states ON tenant_states.db_id = d.db_id
@@ -1078,16 +1079,17 @@ func (s *Store) ListSharedDBPoolMetricSnapshots(ctx context.Context) (out []Shar
 		var maxTenants, tenantCount int
 		var softCapReached bool
 		var spendingLimit sql.NullInt64
+		var updatedAt time.Time
 		var stateCount int64
 		if err := rows.Scan(&id, &dbPoolUUID, &organizationID, &status, &maxTenants, &tenantCount, &softCapReached,
-			&spendingLimit, &tenantStatus, &stateCount); err != nil {
+			&spendingLimit, &updatedAt, &tenantStatus, &stateCount); err != nil {
 			return nil, fmt.Errorf("scan shared db pool metric snapshot: %w", err)
 		}
 		index, ok := byID[id]
 		if !ok {
 			snapshot := SharedDBPoolMetricSnapshot{
 				ID: id, UUID: dbPoolUUID, TiDBCloudOrganizationID: organizationID, Status: status,
-				MaxTenants: maxTenants, TenantCount: tenantCount, SoftCapReached: softCapReached,
+				MaxTenants: maxTenants, TenantCount: tenantCount, SoftCapReached: softCapReached, UpdatedAt: updatedAt,
 			}
 			if spendingLimit.Valid {
 				value := spendingLimit.Int64

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -176,6 +176,7 @@ type SharedDBPoolMetricSnapshot struct {
 	SoftCapReached          bool
 	SpendingLimit           *int64
 	UpdatedAt               time.Time
+	StatusUpdatedAt         time.Time
 	TenantStates            []SharedDBPoolTenantStateCount
 }
 
@@ -367,10 +368,12 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 			SET org_id = ?, cluster_id = ?, provisioning_key = NULL,
 				db_host = COALESCE(?, db_host), db_port = COALESCE(?, db_port),
 				db_user = COALESCE(?, db_user), db_password = COALESCE(?, db_password),
-				db_name = COALESCE(?, db_name), db_tls = ?, status = ?
+				db_name = COALESCE(?, db_name), db_tls = ?,
+				status_updated_at = CASE WHEN status <> ? THEN CURRENT_TIMESTAMP(3) ELSE status_updated_at END,
+				status = ?
 			WHERE db_id = ?`, in.TiDBCloudOrganizationID, in.ClusterID,
 			nullString(in.Host), nullInt(in.Port), nullString(in.User), nullBytes(in.PasswordCipher),
-			nullString(in.Name), in.TLSMode, nextStatus, in.ID); err != nil {
+			nullString(in.Name), in.TLSMode, nextStatus, nextStatus, in.ID); err != nil {
 			return fmt.Errorf("persist cloud result for db pool %d: %w", in.ID, err)
 		}
 		if nextStatus == SharedDBStatusProvisioning && metadataReady {
@@ -499,7 +502,7 @@ func (s *Store) ActivateSharedDBPool(ctx context.Context, dbID int64) (err error
 	if dbID <= 0 {
 		return fmt.Errorf("db_id must be positive")
 	}
-	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?, status_updated_at = CURRENT_TIMESTAMP(3)
 		WHERE db_id = ? AND status = ? AND org_id IS NOT NULL AND cluster_id IS NOT NULL
 			AND db_host IS NOT NULL AND db_port IS NOT NULL AND db_user IS NOT NULL
 			AND db_password IS NOT NULL AND db_name IS NOT NULL AND schema_version > 0`,
@@ -528,7 +531,7 @@ func (s *Store) ActivateSharedDBPool(ctx context.Context, dbID int64) (err error
 }
 
 func (s *Store) MarkSharedDBPoolFailed(ctx context.Context, dbID int64) error {
-	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET status = ?, status_updated_at = CURRENT_TIMESTAMP(3)
 		WHERE db_id = ? AND status IN (?, ?) AND tenant_count = 0`,
 		SharedDBStatusFailed, dbID, SharedDBStatusPending, SharedDBStatusProvisioning)
 	if err != nil {
@@ -616,9 +619,9 @@ func (s *Store) MarkStuckSharedDBPoolFailed(ctx context.Context, dbID int64, exp
 			TenantFailed, now, dbID, tidbCloudNativeSharedProvider, TenantPending, TenantProvisioning); err != nil {
 			return fmt.Errorf("fail stuck shared tenants for db pool %d: %w", dbID, err)
 		}
-		res, err := tx.ExecContext(ctx, `UPDATE db_pool SET status = ?, updated_at = ?
+		res, err := tx.ExecContext(ctx, `UPDATE db_pool SET status = ?, status_updated_at = ?, updated_at = ?
 			WHERE db_id = ? AND role = ? AND status = ? AND updated_at <= ?`,
-			SharedDBStatusFailed, now, dbID, SharedDBRoleShared, expectedStatus, cutoff)
+			SharedDBStatusFailed, now, now, dbID, SharedDBRoleShared, expectedStatus, cutoff)
 		if err != nil {
 			return fmt.Errorf("fail stuck shared db pool %d: %w", dbID, err)
 		}
@@ -907,8 +910,10 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 			ORDER BY db_id LIMIT 1 FOR UPDATE`, organizationID, in.Host, in.Name, in.User).Scan(&dbID)
 		if err == nil {
 			if _, err := tx.ExecContext(ctx, `UPDATE db_pool
-				SET db_port = ?, db_password = ?, db_tls = ?, max_tenants = ?, status = ?
-				WHERE db_id = ?`, in.Port, in.PasswordCipher, in.TLSMode, in.MaxTenants, status, dbID); err != nil {
+				SET db_port = ?, db_password = ?, db_tls = ?, max_tenants = ?,
+					status_updated_at = CASE WHEN status <> ? THEN CURRENT_TIMESTAMP(3) ELSE status_updated_at END,
+					status = ?
+				WHERE db_id = ?`, in.Port, in.PasswordCipher, in.TLSMode, in.MaxTenants, status, status, dbID); err != nil {
 				return fmt.Errorf("update existing manual db_pool row: %w", err)
 			}
 			return nil
@@ -922,7 +927,9 @@ func (s *Store) RegisterSharedDB(ctx context.Context, in *SharedDB) (dbID int64,
 				"ON DUPLICATE KEY UPDATE org_id = VALUES(org_id), db_host = VALUES(db_host), "+
 				"db_port = VALUES(db_port), db_user = VALUES(db_user), db_name = VALUES(db_name), "+
 				"db_password = VALUES(db_password), db_tls = VALUES(db_tls), "+
-				"max_tenants = VALUES(max_tenants), status = VALUES(status)",
+				"max_tenants = VALUES(max_tenants), "+
+				"status_updated_at = CASE WHEN status <> VALUES(status) THEN CURRENT_TIMESTAMP(3) ELSE status_updated_at END, "+
+				"status = VALUES(status)",
 			poolUUID, organizationID, role, in.Host, in.Port, in.User, in.PasswordCipher, in.Name,
 			in.TLSMode, in.MaxTenants, status); err != nil {
 			return fmt.Errorf("upsert manual db_pool row: %w", err)
@@ -1056,7 +1063,7 @@ const listSharedDBPoolMetricSnapshotsSQL = `WITH non_active_tenant_states AS (
 )
 SELECT
 	d.db_id, d.uuid, COALESCE(d.org_id, ''), d.status, d.max_tenants, d.tenant_count, d.soft_cap_reached,
-	d.spending_limit, d.updated_at,
+	d.spending_limit, d.updated_at, d.status_updated_at,
 	COALESCE(tenant_states.tenant_status, ''), COALESCE(tenant_states.tenant_count, 0)
 	FROM db_pool d
 	LEFT JOIN tenant_states ON tenant_states.db_id = d.db_id
@@ -1079,17 +1086,17 @@ func (s *Store) ListSharedDBPoolMetricSnapshots(ctx context.Context) (out []Shar
 		var maxTenants, tenantCount int
 		var softCapReached bool
 		var spendingLimit sql.NullInt64
-		var updatedAt time.Time
+		var updatedAt, statusUpdatedAt time.Time
 		var stateCount int64
 		if err := rows.Scan(&id, &dbPoolUUID, &organizationID, &status, &maxTenants, &tenantCount, &softCapReached,
-			&spendingLimit, &updatedAt, &tenantStatus, &stateCount); err != nil {
+			&spendingLimit, &updatedAt, &statusUpdatedAt, &tenantStatus, &stateCount); err != nil {
 			return nil, fmt.Errorf("scan shared db pool metric snapshot: %w", err)
 		}
 		index, ok := byID[id]
 		if !ok {
 			snapshot := SharedDBPoolMetricSnapshot{
 				ID: id, UUID: dbPoolUUID, TiDBCloudOrganizationID: organizationID, Status: status,
-				MaxTenants: maxTenants, TenantCount: tenantCount, SoftCapReached: softCapReached, UpdatedAt: updatedAt,
+				MaxTenants: maxTenants, TenantCount: tenantCount, SoftCapReached: softCapReached, UpdatedAt: updatedAt, StatusUpdatedAt: statusUpdatedAt,
 			}
 			if spendingLimit.Valid {
 				value := spendingLimit.Int64

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -624,6 +624,10 @@ func TestManagedSharedDBUpdatedAtTracksProgressNotNoOpPolls(t *testing.T) {
 	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, partial); err != nil {
 		t.Fatalf("persist initial partial metadata: %v", err)
 	}
+	var initialStatusUpdatedAt time.Time
+	if err := s.DB().QueryRowContext(ctx, `SELECT status_updated_at FROM db_pool WHERE db_id = ?`, dbID).Scan(&initialStatusUpdatedAt); err != nil {
+		t.Fatalf("read initial status_updated_at: %v", err)
+	}
 	stuckAt := time.Now().UTC().Add(-20 * time.Minute).Truncate(time.Millisecond)
 	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, stuckAt, dbID); err != nil {
 		t.Fatalf("age pending pool: %v", err)
@@ -639,6 +643,13 @@ func TestManagedSharedDBUpdatedAtTracksProgressNotNoOpPolls(t *testing.T) {
 		t.Fatalf("no-op poll updated pool to status=%s updated_at=%s, want pending at %s",
 			unchanged.Status, unchanged.UpdatedAt, stuckAt)
 	}
+	var unchangedStatusUpdatedAt time.Time
+	if err := s.DB().QueryRowContext(ctx, `SELECT status_updated_at FROM db_pool WHERE db_id = ?`, dbID).Scan(&unchangedStatusUpdatedAt); err != nil {
+		t.Fatalf("read unchanged status_updated_at: %v", err)
+	}
+	if !unchangedStatusUpdatedAt.Equal(initialStatusUpdatedAt) {
+		t.Fatalf("no-op poll reset status_updated_at from %s to %s", initialStatusUpdatedAt, unchangedStatusUpdatedAt)
+	}
 	ready := *partial
 	ready.Host = "shared.example.com"
 	ready.Port = 4000
@@ -653,6 +664,13 @@ func TestManagedSharedDBUpdatedAtTracksProgressNotNoOpPolls(t *testing.T) {
 	if progressed.Status != SharedDBStatusProvisioning || !progressed.UpdatedAt.After(stuckAt) {
 		t.Fatalf("metadata progress left pool status=%s updated_at=%s, want provisioning after %s",
 			progressed.Status, progressed.UpdatedAt, stuckAt)
+	}
+	var progressedStatusUpdatedAt time.Time
+	if err := s.DB().QueryRowContext(ctx, `SELECT status_updated_at FROM db_pool WHERE db_id = ?`, dbID).Scan(&progressedStatusUpdatedAt); err != nil {
+		t.Fatalf("read progressed status_updated_at: %v", err)
+	}
+	if !progressedStatusUpdatedAt.After(initialStatusUpdatedAt) {
+		t.Fatalf("status transition did not advance status_updated_at: initial=%s progressed=%s", initialStatusUpdatedAt, progressedStatusUpdatedAt)
 	}
 }
 

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -3589,6 +3589,11 @@ func scanTenantBindingScanner(row tenantBindingScanner) (*TenantWithTiDBCloudOrg
 	return &rec, nil
 }
 
+// UpdateTenantStatus uses a per-tenant transaction for deleting/deleted
+// transitions so the status change and metrics-cleanup outbox row commit
+// atomically. Batch cleanup callers intentionally keep one transaction per
+// tenant: their loops include external cleanup work, and one large transaction
+// would extend lock lifetimes and couple otherwise independent tenant failures.
 func (s *Store) UpdateTenantStatus(ctx context.Context, id string, status TenantStatus) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "update_tenant_status", start, &err)
@@ -3645,6 +3650,10 @@ func (s *Store) UpdateTenantProvider(ctx context.Context, id, provider string) (
 	return nil
 }
 
+// UpdateTenantStatusIf has the same per-tenant transaction boundary as
+// UpdateTenantStatus when moving to deleting/deleted, while preserving the
+// conditional update and per-tenant failure isolation expected by cleanup
+// loops.
 func (s *Store) UpdateTenantStatusIf(ctx context.Context, id string, from, to TenantStatus) (updated bool, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "update_tenant_status_if", start, &err)

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -49,6 +49,7 @@ const (
 	TenantNotifyWorkSemantic
 	TenantNotifyWorkFileGC
 	TenantNotifyWorkMetricsCleanup
+	TenantNotifyWorkAPIKeyCacheCleanup
 )
 
 var allTenantStatuses = []TenantStatus{
@@ -3828,10 +3829,23 @@ func (s *Store) RevokeTenantAPIKeys(ctx context.Context, tenantID string) (err e
 	start := time.Now()
 	defer observeMeta(ctx, "revoke_tenant_api_keys", start, &err)
 	now := time.Now().UTC()
-	_, err = s.db.ExecContext(ctx, `UPDATE tenant_api_keys
-		SET status = ?, revoked_at = COALESCE(revoked_at, ?), updated_at = ?
-		WHERE tenant_id = ? AND status = ?`,
-		APIKeyRevoked, now, now, tenantID, APIKeyActive)
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `UPDATE tenant_api_keys
+			SET status = ?, revoked_at = COALESCE(revoked_at, ?), updated_at = ?
+			WHERE tenant_id = ? AND status = ?`,
+			APIKeyRevoked, now, now, tenantID, APIKeyActive)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return nil
+		}
+		return insertTenantNotifyTx(ctx, tx, tenantID, TenantNotifyWorkAPIKeyCacheCleanup)
+	})
 	if err != nil {
 		return err
 	}
@@ -3843,18 +3857,30 @@ func (s *Store) RevokeAPIKey(ctx context.Context, tenantID, apiKeyID string) (er
 	start := time.Now()
 	defer observeMeta(ctx, "revoke_api_key", start, &err)
 	now := time.Now().UTC()
-	res, err := s.db.ExecContext(ctx, `UPDATE tenant_api_keys
-		SET status = ?, revoked_at = COALESCE(revoked_at, ?), updated_at = ?
-		WHERE tenant_id = ? AND id = ? AND status = ?`,
-		APIKeyRevoked, now, now, tenantID, apiKeyID, APIKeyActive)
+	updated := false
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `UPDATE tenant_api_keys
+			SET status = ?, revoked_at = COALESCE(revoked_at, ?), updated_at = ?
+			WHERE tenant_id = ? AND id = ? AND status = ?`,
+			APIKeyRevoked, now, now, tenantID, apiKeyID, APIKeyActive)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		updated = n > 0
+		if !updated {
+			return nil
+		}
+		return insertTenantNotifyTx(ctx, tx, tenantID, TenantNotifyWorkAPIKeyCacheCleanup)
+	})
 	if err != nil {
 		return err
 	}
-	// Evict even when the row was already revoked (n == 0): a cached active
-	// entry would be stale in that case.
 	s.apiKeys.evictTenant(tenantID)
-	n, _ := res.RowsAffected()
-	if n == 0 {
+	if !updated {
 		return ErrNotFound
 	}
 	return nil
@@ -3864,11 +3890,24 @@ func (s *Store) RevokeAPIKeysByIssuer(ctx context.Context, tenantID, provider, s
 	start := time.Now()
 	defer observeMeta(ctx, "revoke_api_keys_by_issuer", start, &err)
 	now := time.Now().UTC()
-	_, err = s.db.ExecContext(ctx, `UPDATE tenant_api_keys
-		SET status = ?, revoked_at = COALESCE(revoked_at, ?), updated_at = ?
-		WHERE tenant_id = ? AND issued_by_provider = ? AND issued_by_subject_key = ? AND status = ?
-			AND (? = '' OR id <> ?)`,
-		APIKeyRevoked, now, now, tenantID, provider, subjectKey, APIKeyActive, exceptAPIKeyID, exceptAPIKeyID)
+	err = s.InTx(ctx, func(tx *sql.Tx) error {
+		res, err := tx.ExecContext(ctx, `UPDATE tenant_api_keys
+			SET status = ?, revoked_at = COALESCE(revoked_at, ?), updated_at = ?
+			WHERE tenant_id = ? AND issued_by_provider = ? AND issued_by_subject_key = ? AND status = ?
+				AND (? = '' OR id <> ?)`,
+			APIKeyRevoked, now, now, tenantID, provider, subjectKey, APIKeyActive, exceptAPIKeyID, exceptAPIKeyID)
+		if err != nil {
+			return err
+		}
+		n, err := res.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if n == 0 {
+			return nil
+		}
+		return insertTenantNotifyTx(ctx, tx, tenantID, TenantNotifyWorkAPIKeyCacheCleanup)
+	})
 	if err != nil {
 		return err
 	}
@@ -4828,7 +4867,8 @@ func (s *Store) DeleteSubscriptionsForStalePods(ctx context.Context) (n int64, e
 
 // TenantNotifyRow mirrors a row in tenant_notify_outbox. Each row is a
 // lightweight work signal: tenant_id identifies the tenant and work_mask is a
-// bitmask of work types to dispatch (SSE, semantic, file_gc, metrics cleanup).
+// bitmask of work types to dispatch (SSE, semantic, file_gc, metrics cleanup,
+// or API-key cache cleanup).
 type TenantNotifyRow struct {
 	ID             uint64
 	TenantID       string

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -468,6 +468,23 @@ func expandManagedDBPoolSchema(ctx context.Context, db *sql.DB) error {
 			return fmt.Errorf("add db_pool.soft_cap_reached: %w", err)
 		}
 	}
+	var statusUpdatedAtColumnExists int
+	if err := db.QueryRowContext(ctx, `SELECT COUNT(*)
+		FROM information_schema.columns
+		WHERE table_schema = DATABASE() AND table_name = 'db_pool' AND column_name = 'status_updated_at'`).Scan(&statusUpdatedAtColumnExists); err != nil {
+		return fmt.Errorf("inspect db_pool.status_updated_at: %w", err)
+	}
+	if statusUpdatedAtColumnExists == 0 {
+		if _, err := db.ExecContext(ctx, `ALTER TABLE db_pool ADD COLUMN status_updated_at DATETIME(3) NULL AFTER status`); err != nil {
+			return fmt.Errorf("add db_pool.status_updated_at: %w", err)
+		}
+		if _, err := db.ExecContext(ctx, `UPDATE db_pool SET status_updated_at = updated_at WHERE status_updated_at IS NULL`); err != nil {
+			return fmt.Errorf("backfill db_pool.status_updated_at: %w", err)
+		}
+		if _, err := db.ExecContext(ctx, `ALTER TABLE db_pool MODIFY COLUMN status_updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)`); err != nil {
+			return fmt.Errorf("make db_pool.status_updated_at non-null: %w", err)
+		}
+	}
 	// Only ever open the latch during migration. Do not clear a latched pool
 	// below the soft cap here; deletion owns the hysteresis transition.
 	if _, err := db.ExecContext(ctx, `UPDATE db_pool
@@ -788,6 +805,7 @@ func metaInitSchemaStatements() []string {
 			spending_limit BIGINT NULL,
 			schema_version INT UNSIGNED NOT NULL DEFAULT 0,
 			status       VARCHAR(20) NOT NULL DEFAULT 'active',
+			status_updated_at DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			created_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
 			updated_at   DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3) ON UPDATE CURRENT_TIMESTAMP(3),
 			UNIQUE INDEX uk_db_pool_uuid (uuid),

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -41,6 +41,16 @@ const (
 	TenantDeleted      TenantStatus = "deleted"
 )
 
+// Tenant notify work-mask bits are defined in the meta package because the
+// outbox is persisted here. Server and backend aliases reference these
+// constants instead of allocating bits independently.
+const (
+	TenantNotifyWorkSSE = 1 << iota
+	TenantNotifyWorkSemantic
+	TenantNotifyWorkFileGC
+	TenantNotifyWorkMetricsCleanup
+)
+
 var allTenantStatuses = []TenantStatus{
 	TenantPending,
 	TenantProvisioning,
@@ -2627,6 +2637,9 @@ func (s *Store) MarkFreeTenantPoolTenantDeleting(ctx context.Context, tenantID s
 		}
 		n, _ := res.RowsAffected()
 		updated = n > 0
+		if updated {
+			return insertTenantNotifyTx(ctx, tx, tenantID, TenantNotifyWorkMetricsCleanup)
+		}
 		return nil
 	})
 	if errors.Is(err, sql.ErrNoRows) {
@@ -3579,6 +3592,23 @@ func scanTenantBindingScanner(row tenantBindingScanner) (*TenantWithTiDBCloudOrg
 func (s *Store) UpdateTenantStatus(ctx context.Context, id string, status TenantStatus) (err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "update_tenant_status", start, &err)
+	if tenantStatusNeedsMetricsCleanup(status) {
+		err = s.InTx(ctx, func(tx *sql.Tx) error {
+			res, err := tx.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ? WHERE id = ?`, status, time.Now().UTC(), id)
+			if err != nil {
+				return err
+			}
+			if err := requireAffected(res); err != nil {
+				return err
+			}
+			return insertTenantNotifyTx(ctx, tx, id, TenantNotifyWorkMetricsCleanup)
+		})
+		if err != nil {
+			return err
+		}
+		s.apiKeys.evictTenant(id)
+		return nil
+	}
 	res, err := s.db.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ? WHERE id = ?`, status, time.Now().UTC(), id)
 	if err != nil {
 		return err
@@ -3589,6 +3619,10 @@ func (s *Store) UpdateTenantStatus(ctx context.Context, id string, status Tenant
 	}
 	s.apiKeys.evictTenant(id)
 	return nil
+}
+
+func tenantStatusNeedsMetricsCleanup(status TenantStatus) bool {
+	return status == TenantDeleting || status == TenantDeleted
 }
 
 // UpdateTenantProvider rewrites a tenant's persisted provider. It exists for
@@ -3614,6 +3648,28 @@ func (s *Store) UpdateTenantProvider(ctx context.Context, id, provider string) (
 func (s *Store) UpdateTenantStatusIf(ctx context.Context, id string, from, to TenantStatus) (updated bool, err error) {
 	start := time.Now()
 	defer observeMeta(ctx, "update_tenant_status_if", start, &err)
+	if tenantStatusNeedsMetricsCleanup(to) {
+		err = s.InTx(ctx, func(tx *sql.Tx) error {
+			res, err := tx.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ? WHERE id = ? AND status = ?`,
+				to, time.Now().UTC(), id, from)
+			if err != nil {
+				return err
+			}
+			n, _ := res.RowsAffected()
+			updated = n > 0
+			if !updated {
+				return nil
+			}
+			return insertTenantNotifyTx(ctx, tx, id, TenantNotifyWorkMetricsCleanup)
+		})
+		if err != nil {
+			return false, err
+		}
+		if updated {
+			s.apiKeys.evictTenant(id)
+		}
+		return updated, nil
+	}
 	res, err := s.db.ExecContext(ctx, `UPDATE tenants SET status = ?, updated_at = ? WHERE id = ? AND status = ?`,
 		to, time.Now().UTC(), id, from)
 	if err != nil {
@@ -4105,7 +4161,7 @@ func (s *Store) MarkTenantDeleted(ctx context.Context, tenantID string) (err err
 		if _, err := tx.ExecContext(ctx, `DELETE FROM tenant_tidbcloud_org_bindings WHERE tenant_id = ?`, tenantID); err != nil {
 			return err
 		}
-		return nil
+		return insertTenantNotifyTx(ctx, tx, tenantID, TenantNotifyWorkMetricsCleanup)
 	})
 	if err != nil {
 		return err
@@ -4168,7 +4224,7 @@ func (s *Store) FinalizeTenantDelete(ctx context.Context, tenantID, namespaceID 
 			WHERE f.tenant_id = ? AND p.status = ?`, tenantID, PlacementStatusDeleting); err != nil {
 			return err
 		}
-		return nil
+		return insertTenantNotifyTx(ctx, tx, tenantID, TenantNotifyWorkMetricsCleanup)
 	})
 	if err != nil {
 		return err
@@ -4745,7 +4801,7 @@ func (s *Store) DeleteSubscriptionsForStalePods(ctx context.Context) (n int64, e
 
 // TenantNotifyRow mirrors a row in tenant_notify_outbox. Each row is a
 // lightweight work signal: tenant_id identifies the tenant and work_mask is a
-// bitmask of work types to dispatch (SSE, semantic, file_gc, quota).
+// bitmask of work types to dispatch (SSE, semantic, file_gc, metrics cleanup).
 type TenantNotifyRow struct {
 	ID             uint64
 	TenantID       string
@@ -4762,6 +4818,13 @@ func (s *Store) InsertTenantNotify(ctx context.Context, tenantID string, workMas
 	start := time.Now()
 	defer observeMeta(ctx, "insert_tenant_notify", start, &err)
 	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO tenant_notify_outbox (tenant_id, work_mask) VALUES (?, ?)`,
+		tenantID, workMask)
+	return err
+}
+
+func insertTenantNotifyTx(ctx context.Context, tx *sql.Tx, tenantID string, workMask int) error {
+	_, err := tx.ExecContext(ctx,
 		`INSERT INTO tenant_notify_outbox (tenant_id, work_mask) VALUES (?, ?)`,
 		tenantID, workMask)
 	return err

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -788,6 +788,43 @@ func TestUpdateTenantStatus(t *testing.T) {
 	}
 }
 
+func TestUpdateTenantStatusDeletingWritesMetricsCleanupOutbox(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	const tenantID = "tenant-status-cleanup-outbox"
+	if err := s.InsertTenant(ctx, &Tenant{
+		ID:               tenantID,
+		Status:           TenantActive,
+		DBHost:           "127.0.0.1",
+		DBPort:           4000,
+		DBUser:           "root",
+		DBPasswordCipher: []byte("cipher"),
+		DBName:           "tenant_status_cleanup_outbox",
+		DBTLS:            true,
+		Provider:         "tidb_zero",
+		SchemaVersion:    1,
+		CreatedAt:        now,
+		UpdatedAt:        now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.UpdateTenantStatus(ctx, tenantID, TenantDeleting); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := s.ListTenantNotifySince(ctx, 0, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, row := range rows {
+		if row.TenantID == tenantID && row.WorkMask&TenantNotifyWorkMetricsCleanup != 0 {
+			return
+		}
+	}
+	t.Fatalf("missing durable metrics-cleanup outbox row for tenant %s: %+v", tenantID, rows)
+}
+
 func TestFinalizeTenantDeleteUpdatesJobNamespaceAndTenant(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()
@@ -936,12 +973,16 @@ func TestListTenantNotifySinceIncludesTiDBCloudOrgBinding(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(rows) != 1 {
-		t.Fatalf("notify row count = %d, want 1", len(rows))
+	for _, row := range rows {
+		if row.TenantID != tenantID {
+			continue
+		}
+		if row.TiDBCloudOrgID != "org-notify" {
+			t.Fatalf("notify row org = %q, want org-notify", row.TiDBCloudOrgID)
+		}
+		return
 	}
-	if rows[0].TiDBCloudOrgID != "org-notify" {
-		t.Fatalf("notify row org = %q, want org-notify", rows[0].TiDBCloudOrgID)
-	}
+	t.Fatalf("missing notify row for tenant %s: %+v", tenantID, rows)
 }
 
 func TestListTenantNotifySinceUsesSharedDBOrganization(t *testing.T) {

--- a/pkg/meta/meta_test.go
+++ b/pkg/meta/meta_test.go
@@ -1585,7 +1585,7 @@ func TestMetaSchemaSpecIncludesManagedSharedDBControlPlane(t *testing.T) {
 	for _, column := range []string{
 		"db_id", "uuid", "org_id", "cluster_id", "provisioning_key", "cloud_provider", "region",
 		"role", "db_host", "db_port", "db_user", "db_password", "db_name", "db_tls",
-		"max_tenants", "tenant_count", "soft_cap_reached", "spending_limit", "schema_version", "status",
+		"max_tenants", "tenant_count", "soft_cap_reached", "spending_limit", "schema_version", "status", "status_updated_at",
 		"created_at", "updated_at",
 	} {
 		if _, ok := dbPool.columns[column]; !ok {

--- a/pkg/meta/quota_setting_test.go
+++ b/pkg/meta/quota_setting_test.go
@@ -414,7 +414,7 @@ func TestRetryMetaLockConflictRetriesDeadlock(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	metrics.WritePrometheus(rec)
-	if !strings.Contains(rec.Body.String(), `drive9_service_operations_total{component="central_quota",operation="reserve_upload",result="lock_conflict_retry",tenant_id="tenant-retry-metric",tidbcloud_org_id="guest"} 2`) {
+	if !strings.Contains(rec.Body.String(), `drive9_service_operations_total{component="central_quota",operation="reserve_upload",result="lock_conflict_retry"} 2`) {
 		t.Fatalf("missing lock conflict retry metric:\n%s", rec.Body.String())
 	}
 }

--- a/pkg/meta/tenant_pool_failed_cleanup.go
+++ b/pkg/meta/tenant_pool_failed_cleanup.go
@@ -174,6 +174,9 @@ func (s *Store) MarkFailedNativeTenantDeleting(ctx context.Context, tenantID, or
 			return err
 		}
 		updated = affected == 1
+		if updated {
+			return insertTenantNotifyTx(ctx, tx, lockedTenantID, TenantNotifyWorkMetricsCleanup)
+		}
 		return nil
 	})
 	if errors.Is(err, sql.ErrNoRows) {
@@ -263,6 +266,9 @@ func (s *Store) MarkFailedSharedTenantDeleting(ctx context.Context, tenantID, or
 			return err
 		}
 		updated = affected == 1
+		if updated {
+			return insertTenantNotifyTx(ctx, tx, lockedTenantID, TenantNotifyWorkMetricsCleanup)
+		}
 		return nil
 	})
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/meta/tenant_pool_membership.go
+++ b/pkg/meta/tenant_pool_membership.go
@@ -251,6 +251,9 @@ func (s *Store) MarkFreeSharedTenantPoolTenantDeleting(ctx context.Context, tena
 		}
 		n, _ := res.RowsAffected()
 		updated = n == 1
+		if updated {
+			return insertTenantNotifyTx(ctx, tx, tenantID, TenantNotifyWorkMetricsCleanup)
+		}
 		return nil
 	})
 	if errors.Is(err, sql.ErrNoRows) {

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -358,6 +358,17 @@ func writeDBPrometheus(w http.ResponseWriter) {
 		poolTotals[key] = totals
 	}
 	keys := sortedDBMetricKeys(poolTotals)
+	tenantRoleTotals := make(map[string]dbPoolTotals)
+	for key, totals := range poolTotals {
+		if !key.hasTenantID() {
+			continue
+		}
+		aggregate := tenantRoleTotals[key.role]
+		aggregate.inUseConnections += totals.inUseConnections
+		aggregate.maxOpenConnections += totals.maxOpenConnections
+		tenantRoleTotals[key.role] = aggregate
+	}
+	tenantRoles := SortedKeys(tenantRoleTotals)
 
 	globalDB.mu.RLock()
 	probeByRole := make(map[string]dbProbeState, len(globalDB.probe))
@@ -407,7 +418,21 @@ func writeDBPrometheus(w http.ResponseWriter) {
 		labels := dbLabels(key)
 		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"open\"} %d\n", labels, totals.openConnections)
 		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"in_use\"} %d\n", labels, totals.inUseConnections)
+		if key.hasTenantID() {
+			continue
+		}
 		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"idle\"} %d\n", labels, totals.idleConnections)
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"max_open\"} %d\n", labels, totals.maxOpenConnections)
+	}
+	for _, role := range tenantRoles {
+		// Avoid duplicate role-only label sets if a caller registers both scoped
+		// and unscoped pools under the same role.
+		if _, exists := poolTotals[dbMetricKey{role: role}]; exists {
+			continue
+		}
+		totals := tenantRoleTotals[role]
+		labels := fmt.Sprintf("role=\"%s\"", EscapePromLabel(role))
+		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"in_use\"} %d\n", labels, totals.inUseConnections)
 		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"max_open\"} %d\n", labels, totals.maxOpenConnections)
 	}
 

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -368,6 +368,20 @@ func writeDBPrometheus(w http.ResponseWriter) {
 		aggregate.maxOpenConnections += totals.maxOpenConnections
 		tenantRoleTotals[key.role] = aggregate
 	}
+	// If a role has both scoped and unscoped pools, fold the unscoped pool's
+	// saturation totals into the same role-level aggregate. Emitting the
+	// unscoped key alone would hide tenant-scoped capacity while the pool is
+	// open (fork/delete paths are one such source of transient pools).
+	for key, totals := range poolTotals {
+		if key.hasTenantID() {
+			continue
+		}
+		if aggregate, ok := tenantRoleTotals[key.role]; ok {
+			aggregate.inUseConnections += totals.inUseConnections
+			aggregate.maxOpenConnections += totals.maxOpenConnections
+			tenantRoleTotals[key.role] = aggregate
+		}
+	}
 	tenantRoles := SortedKeys(tenantRoleTotals)
 
 	globalDB.mu.RLock()
@@ -412,6 +426,11 @@ func writeDBPrometheus(w http.ResponseWriter) {
 	_, _ = fmt.Fprintln(w, "# TYPE drive9_db_pool_connections gauge")
 	for _, key := range keys {
 		totals := poolTotals[key]
+		if !key.hasTenantID() {
+			if _, hasScopedPool := tenantRoleTotals[key.role]; hasScopedPool {
+				continue
+			}
+		}
 		if key.hasScopedIdentity() && totals.openConnections == 0 {
 			continue
 		}
@@ -425,12 +444,6 @@ func writeDBPrometheus(w http.ResponseWriter) {
 		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"max_open\"} %d\n", labels, totals.maxOpenConnections)
 	}
 	for _, role := range tenantRoles {
-		// Avoid duplicate role-only label sets if a caller registers both scoped
-		// and unscoped pools under the same role.
-		unscopedKey := (registeredDB{role: role}).metricKey()
-		if _, exists := poolTotals[unscopedKey]; exists {
-			continue
-		}
 		totals := tenantRoleTotals[role]
 		labels := fmt.Sprintf("role=\"%s\"", EscapePromLabel(role))
 		_, _ = fmt.Fprintf(w, "drive9_db_pool_connections{%s,state=\"in_use\"} %d\n", labels, totals.inUseConnections)

--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -427,7 +427,8 @@ func writeDBPrometheus(w http.ResponseWriter) {
 	for _, role := range tenantRoles {
 		// Avoid duplicate role-only label sets if a caller registers both scoped
 		// and unscoped pools under the same role.
-		if _, exists := poolTotals[dbMetricKey{role: role}]; exists {
+		unscopedKey := (registeredDB{role: role}).metricKey()
+		if _, exists := poolTotals[unscopedKey]; exists {
 			continue
 		}
 		totals := tenantRoleTotals[role]

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -237,6 +237,17 @@ func TestDBPoolConnectionsIncludesTenantPoolsWithOpenConnections(t *testing.T) {
 	if !strings.Contains(out, `drive9_db_pool_connections{role="user",tenant_id="`+tenantID+`",tidbcloud_org_id="guest",state="open"} 1`) {
 		t.Fatalf("expected tenant pool with open connections to emit pool connection series, got:\n%s", out)
 	}
+	if !strings.Contains(out, `drive9_db_pool_connections{role="user",tenant_id="`+tenantID+`",tidbcloud_org_id="guest",state="in_use"} 0`) {
+		t.Fatalf("expected tenant pool to retain in-use connection visibility, got:\n%s", out)
+	}
+	for _, state := range []string{"idle", "max_open"} {
+		if strings.Contains(out, `drive9_db_pool_connections{role="user",tenant_id="`+tenantID+`",tidbcloud_org_id="guest",state="`+state+`"}`) {
+			t.Fatalf("tenant pool unexpectedly exported per-tenant %s configuration series:\n%s", state, out)
+		}
+	}
+	if !strings.Contains(out, `drive9_db_pool_connections{role="user",state="max_open"} 1`) {
+		t.Fatalf("expected one role-level max_open series, got:\n%s", out)
+	}
 }
 
 func TestSharedDBPoolMetricsUseUUIDWithoutTenantLabel(t *testing.T) {

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -250,6 +250,32 @@ func TestDBPoolConnectionsIncludesTenantPoolsWithOpenConnections(t *testing.T) {
 	}
 }
 
+func TestDBPoolConnectionsDoesNotDuplicateRoleAggregateForMixedPools(t *testing.T) {
+	const role = "mixed-db-aggregate"
+	healthy := &atomic.Bool{}
+	healthy.Store(true)
+	unscoped := sql.OpenDB(fakeConnector{healthy: healthy})
+	tenantScoped := sql.OpenDB(fakeConnector{healthy: healthy})
+	unscoped.SetMaxOpenConns(2)
+	tenantScoped.SetMaxOpenConns(3)
+	t.Cleanup(func() {
+		UnregisterDB(unscoped)
+		UnregisterDB(tenantScoped)
+		_ = unscoped.Close()
+		_ = tenantScoped.Close()
+	})
+
+	RegisterDB(role, unscoped)
+	RegisterTenantDB(role, "mixed-db-aggregate-tenant", tenantScoped)
+	out := renderDB(t)
+	for _, state := range []string{"in_use", "max_open"} {
+		line := `drive9_db_pool_connections{role="` + role + `",state="` + state + `"}`
+		if got := strings.Count(out, line); got != 1 {
+			t.Fatalf("role aggregate %s count = %d, want 1:\n%s", state, got, out)
+		}
+	}
+}
+
 func TestSharedDBPoolMetricsUseUUIDWithoutTenantLabel(t *testing.T) {
 	const (
 		dbPoolUUID = "11111111-1111-4111-8111-111111111111"

--- a/pkg/metrics/db_test.go
+++ b/pkg/metrics/db_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
+	"fmt"
 	"net/http/httptest"
 	"strings"
 	"sync"
@@ -268,10 +269,16 @@ func TestDBPoolConnectionsDoesNotDuplicateRoleAggregateForMixedPools(t *testing.
 	RegisterDB(role, unscoped)
 	RegisterTenantDB(role, "mixed-db-aggregate-tenant", tenantScoped)
 	out := renderDB(t)
-	for _, state := range []string{"in_use", "max_open"} {
-		line := `drive9_db_pool_connections{role="` + role + `",state="` + state + `"}`
+	for _, tc := range []struct {
+		state string
+		value int
+	}{
+		{state: "in_use", value: 0},
+		{state: "max_open", value: 5},
+	} {
+		line := fmt.Sprintf(`drive9_db_pool_connections{role="%s",state="%s"} %d`, role, tc.state, tc.value)
 		if got := strings.Count(out, line); got != 1 {
-			t.Fatalf("role aggregate %s count = %d, want 1:\n%s", state, got, out)
+			t.Fatalf("role aggregate %s = %d occurrences, want one value %d:\n%s", tc.state, got, tc.value, out)
 		}
 	}
 }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -46,8 +46,10 @@ var sseMeter = globalMeterProvider.Meter("sse")
 var tenantMeter = globalMeterProvider.Meter("tenant")
 
 var serviceOperationsTotal = serviceMeter.Int64Counter("drive9_service_operations_total", "Service operations by component/operation/result")
+var tenantOperationFailuresTotal = serviceMeter.Int64Counter("drive9_tenant_operation_failures_total", "Tenant-scoped service operation failures by component/operation/result/tenant/tidbcloud_org")
 var serviceOperationDuration = serviceMeter.Float64Histogram("drive9_service_operation_duration_seconds", "Service operation duration histogram by component/operation/result", operationDurationBounds)
 var serviceGauge = serviceMeter.Float64Gauge("drive9_service_gauge", "Service gauges by component/name")
+var featureEnabled = serviceMeter.Float64Gauge("drive9_feature_enabled", "Configured Drive9 feature state")
 var tenantPoolMetadataResumeWaitTotal = serviceMeter.Int64Counter("drive9_tenant_pool_metadata_resume_wait_total", "Tenant pool metadata resume wait attempts by pool_id/organization_id/scope/result")
 var tenantPoolMetadataResumeWaitDuration = serviceMeter.Float64Histogram("drive9_tenant_pool_metadata_resume_wait_duration_seconds", "Tenant pool metadata resume wait duration by pool_id/organization_id/scope/result", tenantPoolMetadataResumeWaitDurationBounds)
 var tenantPoolCapacity = serviceMeter.Float64Gauge("drive9_tenant_pool_capacity", "Tenant pool capacity by pool_id/organization_id/state")
@@ -59,7 +61,7 @@ var sharedDBPoolSpendingLimit = serviceMeter.Float64Gauge("drive9_shared_db_pool
 var sharedDBPoolCacheHandles = serviceMeter.Float64Gauge("drive9_shared_db_pool_cache_handles", "Per-pod cached physical shared DB handles by tidbcloud_org_id/db_pool_id/db_pool_uuid")
 var sharedDBPoolCacheTenants = serviceMeter.Float64Gauge("drive9_shared_db_pool_cache_tenants", "Per-pod active tenant backend refs on a cached shared DB handle by tidbcloud_org_id/db_pool_id/db_pool_uuid")
 var tidbCloudRBACCacheRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_rbac_cache_requests_total", "TiDB Cloud API key to cluster RBAC cache requests by path/scope/result")
-var tidbCloudOpenAPIRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_openapi_requests_total", "TiDB Cloud OpenAPI requests by path/operation/result")
+var tidbCloudOpenAPIRequestsTotal = serviceMeter.Int64Counter("drive9_tidbcloud_openapi_requests_total", "TiDB Cloud OpenAPI requests by api/operation/result")
 var tidbCloudSpendingLimitSyncTotal = serviceMeter.Int64Counter("drive9_tidbcloud_spending_limit_sync_total", "TiDB Cloud spending limit local sync outcomes by source/result")
 var tidbCloudSpendingLimitMissingTotal = serviceMeter.Int64Counter("drive9_tidbcloud_spending_limit_missing_total", "TiDB Cloud spending limit missing local config observations by path")
 
@@ -77,11 +79,11 @@ var fuseRemoteOperationsTotal = fuseMeter.Int64Counter("drive9_fuse_remote_opera
 var fuseRemoteOperationDuration = fuseMeter.Float64Histogram("drive9_fuse_remote_operation_duration_seconds", "Remote FUSE operation duration histogram", operationDurationBounds)
 var fuseRemoteOperationBytes = fuseMeter.Int64Counter("drive9_fuse_remote_operation_bytes_total", "Bytes processed by remote FUSE operation/result")
 
-var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/tidbcloud_org/surface/action/result/status_class")
+var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/tidbcloud_org/surface/action/status_class")
 var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_duration_seconds", "Tenant request duration histogram by surface/status_class", httpDurationBounds)
-var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/tidbcloud_org/surface/action")
-var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/tidbcloud_org/surface/direction")
-var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/tidbcloud_org/surface/action/direction")
+var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/tidbcloud_org/surface")
+var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/tidbcloud_org/direction")
+var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/tidbcloud_org/direction")
 var tenantCount = tenantMeter.Float64Gauge("drive9_tenant_count", "Tenant count by status")
 var tenantStorageBytes = tenantMeter.Float64Gauge("drive9_tenant_storage_bytes", "Tenant storage bytes by tenant/tidbcloud_org/state")
 var tenantMediaFiles = tenantMeter.Float64Gauge("drive9_tenant_media_files", "Tenant media file count by tenant/tidbcloud_org/state")
@@ -102,13 +104,11 @@ var sseHeartbeatsSentTotal = sseMeter.Int64Counter("drive9_sse_heartbeats_sent_t
 // poll, latest, oldest) so DB pressure and table growth on the events path
 // are observable without direct DB access.
 var eventBusQueryDuration = serviceMeter.Float64Histogram("drive9_event_bus_query_duration_seconds", "Event-bus fs_events query duration by operation/result", eventBusQueryDurationBounds)
-var eventBusPollFailuresTotal = sseMeter.Int64Counter("drive9_event_bus_poll_failures_total", "Event-bus cross-pod poll query failures by tenant_id/tidbcloud_org_id")
-var eventBusPublishErrorsTotal = sseMeter.Int64Counter("drive9_event_bus_publish_errors_total", "Event-bus fs_events INSERT failures by tenant_id/tidbcloud_org_id")
 
 // fs_events table instruments. Compensates for the lack of direct TiDB
 // access: row count and prune volume are reported by the server itself.
 var fsEventsRows = sseMeter.Float64Gauge("drive9_fs_events_rows", "fs_events table row count by tenant_id/tidbcloud_org_id")
-var fsEventsPrunedTotal = sseMeter.Int64Counter("drive9_fs_events_pruned_total", "fs_events rows pruned by retention cleanup by tenant_id/tidbcloud_org_id")
+var fsEventsPrunedTotal = sseMeter.Int64Counter("drive9_fs_events_pruned_total", "fs_events rows pruned by retention cleanup")
 
 func RegisterModule(module string) {
 	globalRegistry.RegisterModule(module)
@@ -116,6 +116,14 @@ func RegisterModule(module string) {
 
 func SetModuleAvailability(module string, up bool) {
 	globalRegistry.SetModuleAvailability(module, up)
+}
+
+func SetFeatureEnabled(feature string, enabled bool) {
+	value := float64(0)
+	if enabled {
+		value = 1
+	}
+	featureEnabled.Set(value, Attr("feature", cleanMetricValue(feature, "unknown")))
 }
 
 func RecordOperation(component, operation, result string, d time.Duration) {
@@ -133,20 +141,17 @@ func RecordTenantOperationWithOrg(tenantID, tidbCloudOrgID, component, operation
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	RegisterModule(component)
-	baseAttrs := []Attribute{
+	attrs := []Attribute{
 		Attr("component", component),
 		Attr("operation", operation),
 		Attr("result", result),
 	}
-	counterAttrs := baseAttrs
-	if tenantID != "unknown" {
-		counterAttrs = append(counterAttrs, Attr("tenant_id", tenantID), Attr("tidbcloud_org_id", tidbCloudOrgID))
-	}
-	serviceOperationsTotal.Add(1, counterAttrs...)
+	serviceOperationsTotal.Add(1, attrs...)
+	recordTenantOperationFailure(tenantID, tidbCloudOrgID, result, attrs)
 	if d <= 0 {
 		return
 	}
-	serviceOperationDuration.Observe(d.Seconds(), baseAttrs...)
+	serviceOperationDuration.Observe(d.Seconds(), attrs...)
 }
 
 func RecordTenantPoolMetadataResumeWait(poolID, organizationID, scope, result string, d time.Duration) {
@@ -295,10 +300,10 @@ func RecordTiDBCloudRBACCacheRequest(path, scope, result string) {
 	)
 }
 
-func RecordTiDBCloudOpenAPIRequest(path, operation, result string) {
-	RegisterModule("tidbcloud_quota")
+func RecordTiDBCloudOpenAPIRequest(api, operation, result string) {
+	RegisterModule("tidbcloud_openapi")
 	tidbCloudOpenAPIRequestsTotal.Add(1,
-		Attr("path", cleanMetricValue(path, "unknown")),
+		Attr("api", cleanMetricValue(api, "unknown")),
 		Attr("operation", cleanMetricValue(operation, "unknown")),
 		Attr("result", cleanMetricValue(result, "unknown")),
 	)
@@ -359,10 +364,32 @@ func RecordTenantOperationCountWithOrg(tenantID, tidbCloudOrgID, component, oper
 		Attr("operation", operation),
 		Attr("result", result),
 	}
-	if tenantID != "unknown" {
-		attrs = append(attrs, Attr("tenant_id", tenantID), Attr("tidbcloud_org_id", tidbCloudOrgID))
-	}
 	serviceOperationsTotal.Add(1, attrs...)
+	recordTenantOperationFailure(tenantID, tidbCloudOrgID, result, attrs)
+}
+
+func recordTenantOperationFailure(tenantID, tidbCloudOrgID, result string, attrs []Attribute) {
+	if tenantID == "unknown" || !isOperationFailureResult(result) {
+		return
+	}
+	failureAttrs := append([]Attribute(nil), attrs...)
+	failureAttrs = append(failureAttrs,
+		Attr("tenant_id", tenantID),
+		Attr("tidbcloud_org_id", tidbCloudOrgID),
+	)
+	tenantOperationFailuresTotal.Add(1, failureAttrs...)
+}
+
+func isOperationFailureResult(result string) bool {
+	switch result {
+	case "error", "bad_conn", "deadline_exceeded", "failed",
+		"fail_open", "busy_fail_open",
+		"runtime_not_configured", "handler_missing", "unsupported",
+		"lease_lost", "dead_lettered":
+		return true
+	default:
+		return strings.HasSuffix(result, "_error")
+	}
 }
 
 func RecordGauge(component, name string, value float64) {
@@ -384,6 +411,19 @@ func RecordTenantGaugeWithOrg(tenantID, tidbCloudOrgID, component, name string, 
 		Attr("name", name),
 		Attr("tenant_id", tenantID),
 		Attr("tidbcloud_org_id", tidbCloudOrgID),
+	)
+}
+
+func DeleteTenantGauge(tenantID, component, name string) {
+	DeleteTenantGaugeWithOrg(tenantID, "", component, name)
+}
+
+func DeleteTenantGaugeWithOrg(tenantID, tidbCloudOrgID, component, name string) {
+	serviceGauge.Delete(
+		Attr("component", cleanMetricValue(component, "unknown")),
+		Attr("name", cleanMetricValue(name, "unknown")),
+		Attr("tenant_id", strings.TrimSpace(tenantID)),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 	)
 }
 
@@ -434,14 +474,13 @@ func RecordTenantRequestCountWithOrg(tenantID, tidbCloudOrgID, surface, action, 
 	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	surface = cleanMetricValue(surface, "other")
 	action = cleanMetricValue(action, "other")
-	result = cleanMetricValue(result, "unknown")
+	_ = result
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
 		Attr("tenant_id", tenantID),
 		Attr("tidbcloud_org_id", tidbCloudOrgID),
 		Attr("surface", surface),
 		Attr("action", action),
-		Attr("result", result),
 		Attr("status_class", statusClass(status)),
 	}
 	tenantRequestsTotal.Add(1, attrs...)
@@ -471,13 +510,22 @@ func RecordTenantEventWithOrg(tenantID, tidbCloudOrgID, event string, labels ...
 	attrs = append(attrs, Attr("event", cleanMetricValue(event, "unknown")))
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
-	if tenantID != "unknown" {
+	if tenantID != "unknown" && tenantAttributedBusinessEvent(event) {
 		attrs = append(attrs, Attr("tenant_id", tenantID), Attr("tidbcloud_org_id", tidbCloudOrgID))
 	}
 	for i := 0; i+1 < len(labels); i += 2 {
 		attrs = append(attrs, Attr(labels[i], labels[i+1]))
 	}
 	businessEventsTotal.Add(1, attrs...)
+}
+
+func tenantAttributedBusinessEvent(event string) bool {
+	switch event {
+	case "auth", "tenant_provision", "tenant_schema_init", "tenant_status":
+		return true
+	default:
+		return false
+	}
 }
 
 func RecordTenantRequest(tenantID, surface, action, result string, status int, d time.Duration) {
@@ -489,7 +537,7 @@ func RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, surface, action, resul
 	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	surface = cleanMetricValue(surface, "other")
 	action = cleanMetricValue(action, "other")
-	result = cleanMetricValue(result, "unknown")
+	_ = result
 	statusClass := "unknown"
 	if status > 0 {
 		statusClass = strconv.Itoa(status/100) + "xx"
@@ -500,7 +548,6 @@ func RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, surface, action, resul
 		Attr("tidbcloud_org_id", tidbCloudOrgID),
 		Attr("surface", surface),
 		Attr("action", action),
-		Attr("result", result),
 		Attr("status_class", statusClass),
 	}
 	tenantRequestsTotal.Add(1, attrs...)
@@ -518,7 +565,8 @@ func RecordTenantHTTPBytes(tenantID, surface, _, direction string, bytes int64) 
 }
 
 func RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, surface, _, direction string, bytes int64) {
-	recordTenantHTTPBytes(tenantID, tidbCloudOrgID, surface, direction, bytes)
+	_ = surface
+	recordTenantHTTPBytes(tenantID, tidbCloudOrgID, direction, bytes)
 }
 
 func RecordTenantFileBytes(tenantID, surface, action, direction string, bytes int64) {
@@ -526,7 +574,8 @@ func RecordTenantFileBytes(tenantID, surface, action, direction string, bytes in
 }
 
 func RecordTenantFileBytesWithOrg(tenantID, tidbCloudOrgID, surface, action, direction string, bytes int64) {
-	recordTenantBytes(tenantFileBytes, tenantID, tidbCloudOrgID, surface, action, direction, bytes)
+	_, _ = surface, action
+	recordTenantBytes(tenantFileBytes, tenantID, tidbCloudOrgID, direction, bytes)
 }
 
 func RecordTenantInFlight(tenantID, surface, action string, value float64) {
@@ -534,12 +583,12 @@ func RecordTenantInFlight(tenantID, surface, action string, value float64) {
 }
 
 func RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, surface, action string, value float64) {
+	_ = action
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
 		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("surface", cleanMetricValue(surface, "other")),
-		Attr("action", cleanMetricValue(action, "other")),
 	}
 	if value <= 0 {
 		tenantInflight.Delete(attrs...)
@@ -606,7 +655,31 @@ func RecordTenantVideoFilesWithOrg(tenantID, tidbCloudOrgID, state string, count
 	)
 }
 
-func recordTenantBytes(counter *Int64Counter, tenantID, tidbCloudOrgID, surface, action, direction string, bytes int64) {
+// DeleteTenantQuotaLimitsWithOrg removes the three optional quota-limit
+// series without touching current usage. Call it before exporting a fresh
+// snapshot so removed, zeroed, or relabeled limits cannot remain stale.
+func DeleteTenantQuotaLimitsWithOrg(tenantID, tidbCloudOrgID string) {
+	attrs := []Attribute{
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+		Attr("state", "limit"),
+	}
+	tenantStorageBytes.Delete(attrs...)
+	tenantMediaFiles.Delete(attrs...)
+	tenantVideoFiles.Delete(attrs...)
+}
+
+func DeleteTenantQuotaSnapshot(tenantID string) {
+	tenantID = cleanMetricValue(tenantID, "unknown")
+	if tenantID == "unknown" {
+		return
+	}
+	for _, name := range []string{tenantStorageBytes.name, tenantMediaFiles.name, tenantVideoFiles.name} {
+		globalRegistry.deleteGaugeByLabel(name, "tenant_id", tenantID)
+	}
+}
+
+func recordTenantBytes(counter *Int64Counter, tenantID, tidbCloudOrgID, direction string, bytes int64) {
 	if bytes <= 0 {
 		return
 	}
@@ -614,13 +687,11 @@ func recordTenantBytes(counter *Int64Counter, tenantID, tidbCloudOrgID, surface,
 	counter.Add(bytes,
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
 		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
-		Attr("surface", cleanMetricValue(surface, "other")),
-		Attr("action", cleanMetricValue(action, "other")),
 		Attr("direction", cleanMetricValue(direction, "unknown")),
 	)
 }
 
-func recordTenantHTTPBytes(tenantID, tidbCloudOrgID, surface, direction string, bytes int64) {
+func recordTenantHTTPBytes(tenantID, tidbCloudOrgID, direction string, bytes int64) {
 	if bytes <= 0 {
 		return
 	}
@@ -628,7 +699,6 @@ func recordTenantHTTPBytes(tenantID, tidbCloudOrgID, surface, direction string, 
 	tenantHTTPBytes.Add(bytes,
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
 		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
-		Attr("surface", cleanMetricValue(surface, "other")),
 		Attr("direction", cleanMetricValue(direction, "unknown")),
 	)
 }
@@ -696,14 +766,16 @@ func RecordSSEInFlight(tenantID string, count float64) {
 }
 
 func RecordSSEInFlightWithOrg(tenantID, tidbCloudOrgID string, count float64) {
-	if count < 0 {
-		count = 0
-	}
 	RegisterModule("sse")
-	sseInflight.Set(count,
+	attrs := []Attribute{
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
 		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
-	)
+	}
+	if count <= 0 {
+		sseInflight.Delete(attrs...)
+		return
+	}
+	sseInflight.Set(count, attrs...)
 }
 
 // RecordSSEPhase1 records the duration of the SSE Phase-1 replay/reset stage.
@@ -777,33 +849,6 @@ func RecordEventBusQuery(tenantID, operation, result string, d time.Duration) {
 	)
 }
 
-// RecordEventBusPollFailure records a cross-pod poll query failure (previously
-// only logged, not metriced).
-func RecordEventBusPollFailure(tenantID string) {
-	RecordEventBusPollFailureWithOrg(tenantID, "")
-}
-
-func RecordEventBusPollFailureWithOrg(tenantID, tidbCloudOrgID string) {
-	RegisterModule("sse")
-	eventBusPollFailuresTotal.Add(1,
-		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
-		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
-	)
-}
-
-// RecordEventBusPublishError records an fs_events INSERT failure.
-func RecordEventBusPublishError(tenantID string) {
-	RecordEventBusPublishErrorWithOrg(tenantID, "")
-}
-
-func RecordEventBusPublishErrorWithOrg(tenantID, tidbCloudOrgID string) {
-	RegisterModule("sse")
-	eventBusPublishErrorsTotal.Add(1,
-		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
-		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
-	)
-}
-
 // RecordFSEventsRows records the current fs_events row count for a tenant.
 // This compensates for the lack of direct TiDB access: the leader cleanup
 // goroutine samples the count and reports it here.
@@ -822,6 +867,13 @@ func RecordFSEventsRowsWithOrg(tenantID, tidbCloudOrgID string, count int64) {
 	)
 }
 
+func DeleteFSEventsRowsWithOrg(tenantID, tidbCloudOrgID string) {
+	fsEventsRows.Delete(
+		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+	)
+}
+
 // RecordFSEventsPruned records the number of fs_events rows deleted by
 // retention cleanup.
 func RecordFSEventsPruned(tenantID string, count int64) {
@@ -832,11 +884,9 @@ func RecordFSEventsPrunedWithOrg(tenantID, tidbCloudOrgID string, count int64) {
 	if count <= 0 {
 		return
 	}
+	_, _ = tenantID, tidbCloudOrgID
 	RegisterModule("sse")
-	fsEventsPrunedTotal.Add(count,
-		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
-		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
-	)
+	fsEventsPrunedTotal.Add(count)
 }
 
 func WritePrometheus(w http.ResponseWriter) {

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -655,27 +655,89 @@ func RecordTenantVideoFilesWithOrg(tenantID, tidbCloudOrgID, state string, count
 	)
 }
 
-// DeleteTenantQuotaLimitsWithOrg removes the three optional quota-limit
-// series without touching current usage. Call it before exporting a fresh
-// snapshot so removed, zeroed, or relabeled limits cannot remain stale.
-func DeleteTenantQuotaLimitsWithOrg(tenantID, tidbCloudOrgID string) {
-	attrs := []Attribute{
-		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
-		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
-		Attr("state", "limit"),
-	}
-	tenantStorageBytes.Delete(attrs...)
-	tenantMediaFiles.Delete(attrs...)
-	tenantVideoFiles.Delete(attrs...)
-}
-
-func DeleteTenantQuotaSnapshot(tenantID string) {
+// ReplaceTenantQuotaSnapshotWithOrg atomically replaces one tenant's quota
+// gauges under the registry lock. It performs only exact label lookups, so the
+// write path is O(1) in the number of tenants and a scrape cannot observe a
+// delete/re-add gap. When replaceLimits is false, the last known limits are
+// preserved while current usage is refreshed.
+func ReplaceTenantQuotaSnapshotWithOrg(
+	tenantID, tidbCloudOrgID string,
+	storageBytes, reservedBytes, mediaFiles, videoFiles int64,
+	storageLimitBytes, mediaLimitFiles, videoLimitFiles int64,
+	replaceLimits bool,
+) {
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	if tenantID == "unknown" {
 		return
 	}
-	for _, name := range []string{tenantStorageBytes.name, tenantMediaFiles.name, tenantVideoFiles.name} {
-		globalRegistry.deleteGaugeByLabel(name, "tenant_id", tenantID)
+	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
+	RegisterModule("tenant_usage")
+
+	globalRegistry.mu.Lock()
+	defer globalRegistry.mu.Unlock()
+	previous := globalRegistry.tenantQuotaSnapshots[tenantID]
+	if replaceLimits {
+		previous.storageLimitBytes = storageLimitBytes
+		previous.mediaLimitFiles = mediaLimitFiles
+		previous.videoLimitFiles = videoLimitFiles
+	}
+	if previous.orgID != "" && previous.orgID != tidbCloudOrgID {
+		deleteTenantQuotaSnapshotLabelsLocked(globalRegistry, tenantID, previous.orgID)
+	}
+	previous.orgID = tidbCloudOrgID
+	globalRegistry.tenantQuotaSnapshots[tenantID] = previous
+
+	setTenantQuotaGaugeLocked(globalRegistry, tenantStorageBytes.name, tenantID, tidbCloudOrgID, "confirmed", storageBytes)
+	setTenantQuotaGaugeLocked(globalRegistry, tenantStorageBytes.name, tenantID, tidbCloudOrgID, "reserved", reservedBytes)
+	setTenantQuotaGaugeLocked(globalRegistry, tenantMediaFiles.name, tenantID, tidbCloudOrgID, "confirmed", mediaFiles)
+	setTenantQuotaGaugeLocked(globalRegistry, tenantVideoFiles.name, tenantID, tidbCloudOrgID, "confirmed", videoFiles)
+	setOrDeleteTenantQuotaLimitLocked(globalRegistry, tenantStorageBytes.name, tenantID, tidbCloudOrgID, previous.storageLimitBytes)
+	setOrDeleteTenantQuotaLimitLocked(globalRegistry, tenantMediaFiles.name, tenantID, tidbCloudOrgID, previous.mediaLimitFiles)
+	setOrDeleteTenantQuotaLimitLocked(globalRegistry, tenantVideoFiles.name, tenantID, tidbCloudOrgID, previous.videoLimitFiles)
+}
+
+func setTenantQuotaGaugeLocked(r *Registry, name, tenantID, tidbCloudOrgID, state string, value int64) {
+	if value < 0 {
+		return
+	}
+	labels := labelsKey([]Attribute{
+		Attr("tenant_id", tenantID),
+		Attr("tidbcloud_org_id", tidbCloudOrgID),
+		Attr("state", state),
+	})
+	r.gauges[name].values[labels] = float64(value)
+}
+
+func setOrDeleteTenantQuotaLimitLocked(r *Registry, name, tenantID, tidbCloudOrgID string, value int64) {
+	labels := labelsKey([]Attribute{
+		Attr("tenant_id", tenantID),
+		Attr("tidbcloud_org_id", tidbCloudOrgID),
+		Attr("state", "limit"),
+	})
+	if value > 0 {
+		r.gauges[name].values[labels] = float64(value)
+		return
+	}
+	delete(r.gauges[name].values, labels)
+}
+
+func deleteTenantQuotaSnapshotLabelsLocked(r *Registry, tenantID, tidbCloudOrgID string) {
+	for _, metric := range []struct {
+		name   string
+		states []string
+	}{
+		{name: tenantStorageBytes.name, states: []string{"confirmed", "reserved", "limit"}},
+		{name: tenantMediaFiles.name, states: []string{"confirmed", "limit"}},
+		{name: tenantVideoFiles.name, states: []string{"confirmed", "limit"}},
+	} {
+		for _, state := range metric.states {
+			labels := labelsKey([]Attribute{
+				Attr("tenant_id", tenantID),
+				Attr("tidbcloud_org_id", tidbCloudOrgID),
+				Attr("state", state),
+			})
+			delete(r.gauges[metric.name].values, labels)
+		}
 	}
 }
 

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -465,16 +465,15 @@ func RecordHTTPRequestCount(method, route string, status int) {
 
 // RecordTenantRequestCount records only the tenant request counter, not the
 // duration histogram. Companion to RecordHTTPRequestCount for SSE routes.
-func RecordTenantRequestCount(tenantID, surface, action, result string, status int) {
-	RecordTenantRequestCountWithOrg(tenantID, "", surface, action, result, status)
+func RecordTenantRequestCount(tenantID, surface, action string, status int) {
+	RecordTenantRequestCountWithOrg(tenantID, "", surface, action, status)
 }
 
-func RecordTenantRequestCountWithOrg(tenantID, tidbCloudOrgID, surface, action, result string, status int) {
+func RecordTenantRequestCountWithOrg(tenantID, tidbCloudOrgID, surface, action string, status int) {
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	surface = cleanMetricValue(surface, "other")
 	action = cleanMetricValue(action, "other")
-	_ = result
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
 		Attr("tenant_id", tenantID),
@@ -528,16 +527,15 @@ func tenantAttributedBusinessEvent(event string) bool {
 	}
 }
 
-func RecordTenantRequest(tenantID, surface, action, result string, status int, d time.Duration) {
-	RecordTenantRequestWithOrg(tenantID, "", surface, action, result, status, d)
+func RecordTenantRequest(tenantID, surface, action string, status int, d time.Duration) {
+	RecordTenantRequestWithOrg(tenantID, "", surface, action, status, d)
 }
 
-func RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, surface, action, result string, status int, d time.Duration) {
+func RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, surface, action string, status int, d time.Duration) {
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	surface = cleanMetricValue(surface, "other")
 	action = cleanMetricValue(action, "other")
-	_ = result
 	statusClass := "unknown"
 	if status > 0 {
 		statusClass = strconv.Itoa(status/100) + "xx"
@@ -560,30 +558,27 @@ func RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, surface, action, resul
 	)
 }
 
-func RecordTenantHTTPBytes(tenantID, surface, _, direction string, bytes int64) {
-	RecordTenantHTTPBytesWithOrg(tenantID, "", surface, "", direction, bytes)
+func RecordTenantHTTPBytes(tenantID, direction string, bytes int64) {
+	RecordTenantHTTPBytesWithOrg(tenantID, "", direction, bytes)
 }
 
-func RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, surface, _, direction string, bytes int64) {
-	_ = surface
+func RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, direction string, bytes int64) {
 	recordTenantHTTPBytes(tenantID, tidbCloudOrgID, direction, bytes)
 }
 
-func RecordTenantFileBytes(tenantID, surface, action, direction string, bytes int64) {
-	RecordTenantFileBytesWithOrg(tenantID, "", surface, action, direction, bytes)
+func RecordTenantFileBytes(tenantID, direction string, bytes int64) {
+	RecordTenantFileBytesWithOrg(tenantID, "", direction, bytes)
 }
 
-func RecordTenantFileBytesWithOrg(tenantID, tidbCloudOrgID, surface, action, direction string, bytes int64) {
-	_, _ = surface, action
+func RecordTenantFileBytesWithOrg(tenantID, tidbCloudOrgID, direction string, bytes int64) {
 	recordTenantBytes(tenantFileBytes, tenantID, tidbCloudOrgID, direction, bytes)
 }
 
-func RecordTenantInFlight(tenantID, surface, action string, value float64) {
-	RecordTenantInFlightWithOrg(tenantID, "", surface, action, value)
+func RecordTenantInFlight(tenantID, surface string, value float64) {
+	RecordTenantInFlightWithOrg(tenantID, "", surface, value)
 }
 
-func RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, surface, action string, value float64) {
-	_ = action
+func RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, surface string, value float64) {
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
@@ -938,15 +933,10 @@ func DeleteFSEventsRowsWithOrg(tenantID, tidbCloudOrgID string) {
 
 // RecordFSEventsPruned records the number of fs_events rows deleted by
 // retention cleanup.
-func RecordFSEventsPruned(tenantID string, count int64) {
-	RecordFSEventsPrunedWithOrg(tenantID, "", count)
-}
-
-func RecordFSEventsPrunedWithOrg(tenantID, tidbCloudOrgID string, count int64) {
+func RecordFSEventsPruned(count int64) {
 	if count <= 0 {
 		return
 	}
-	_, _ = tenantID, tidbCloudOrgID
 	RegisterModule("sse")
 	fsEventsPrunedTotal.Add(count)
 }

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -269,21 +269,18 @@ func TestDeleteTenantGaugeAndSSEInFlightRemoveSeries(t *testing.T) {
 	}
 }
 
-func TestDeleteTenantQuotaLimitsRemovesOnlyLimitSeries(t *testing.T) {
+func TestReplaceTenantQuotaSnapshotRemovesOnlyAbsentLimitSeries(t *testing.T) {
 	const tenantID = "tenant-quota-limit-delete"
 	const orgID = "org-quota-limit-delete"
 
-	RecordTenantStorageBytesWithOrg(tenantID, orgID, "confirmed", 10)
-	RecordTenantStorageBytesWithOrg(tenantID, orgID, "limit", 100)
-	RecordTenantMediaFilesWithOrg(tenantID, orgID, "limit", 20)
-	RecordTenantVideoFilesWithOrg(tenantID, orgID, "limit", 30)
-	DeleteTenantQuotaLimitsWithOrg(tenantID, orgID)
+	ReplaceTenantQuotaSnapshotWithOrg(tenantID, orgID, 10, 1, 2, 3, 100, 20, 30, true)
+	ReplaceTenantQuotaSnapshotWithOrg(tenantID, orgID, 11, 1, 2, 3, 0, 0, 0, true)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
 	if !hasMetricLineWith(text, "drive9_tenant_storage_bytes", `tenant_id="`+tenantID+`"`, `state="confirmed"`) {
-		t.Fatalf("confirmed usage was deleted with limits:\n%s", text)
+		t.Fatalf("confirmed usage was deleted while limits were replaced:\n%s", text)
 	}
 	for _, metric := range []string{"drive9_tenant_storage_bytes", "drive9_tenant_media_files", "drive9_tenant_video_files"} {
 		if hasMetricLineWith(text, metric, `tenant_id="`+tenantID+`"`, `state="limit"`) {

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -128,7 +128,7 @@ func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 		action   = "request_duration_action"
 	)
 
-	RecordTenantRequestWithOrg(tenantID, "org-request-duration", surface, action, "ok", 201, time.Second)
+	RecordTenantRequestWithOrg(tenantID, "org-request-duration", surface, action, 201, time.Second)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
@@ -160,7 +160,7 @@ func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
 	const tenantID = "tenant-zero-request"
 
-	RecordTenantRequest(tenantID, "zero_surface", "zero_action", "ok", 200, 0)
+	RecordTenantRequest(tenantID, "zero_surface", "zero_action", 200, 0)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
@@ -232,7 +232,7 @@ func TestRecordTenantInFlightDeletesZeroValue(t *testing.T) {
 		action   = "inflight_delete_action"
 	)
 
-	RecordTenantInFlightWithOrg(tenantID, "org-inflight-delete", surface, action, 1)
+	RecordTenantInFlightWithOrg(tenantID, "org-inflight-delete", surface, 1)
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
@@ -240,7 +240,7 @@ func TestRecordTenantInFlightDeletesZeroValue(t *testing.T) {
 		t.Errorf("missing tenant in-flight gauge:\n%s", text)
 	}
 
-	RecordTenantInFlightWithOrg(tenantID, "org-inflight-delete", surface, action, 0)
+	RecordTenantInFlightWithOrg(tenantID, "org-inflight-delete", surface, 0)
 	rec = httptest.NewRecorder()
 	WritePrometheus(rec)
 	text = rec.Body.String()
@@ -297,9 +297,9 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 
 	RecordTenantGaugeWithOrg(tenantID, orgID, "component_org_label_test", "gauge", 1)
 	RecordTenantEventWithOrg(tenantID, orgID, "event_org_label_test", "result", "ok")
-	RecordTenantRequestCountWithOrg(tenantID, orgID, "surface_org_label_test", "action", "ok", 200)
-	RecordTenantHTTPBytesWithOrg(tenantID, orgID, "surface_org_label_test", "ignored", "request", 10)
-	RecordTenantFileBytesWithOrg(tenantID, orgID, "surface_org_label_test", "write", "out", 20)
+	RecordTenantRequestCountWithOrg(tenantID, orgID, "surface_org_label_test", "action", 200)
+	RecordTenantHTTPBytesWithOrg(tenantID, orgID, "request", 10)
+	RecordTenantFileBytesWithOrg(tenantID, orgID, "out", 20)
 	RecordTenantStorageBytesWithOrg(tenantID, orgID, "confirmed", 30)
 	RecordTenantMediaFilesWithOrg(tenantID, orgID, "confirmed", 40)
 	RecordTenantVideoFilesWithOrg(tenantID, orgID, "limit", 50)
@@ -309,7 +309,7 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 	RecordSSEResetSentWithOrg(tenantID, orgID, "seq_too_old")
 	RecordSSEHeartbeatSentWithOrg(tenantID, orgID)
 	RecordFSEventsRowsWithOrg(tenantID, orgID, 50)
-	RecordFSEventsPrunedWithOrg(tenantID, orgID, 60)
+	RecordFSEventsPruned(60)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
@@ -591,11 +591,11 @@ func TestDeleteTenantCounters(t *testing.T) {
 	const tidbCloudOrgID = "org-delete-counter"
 
 	RecordTenantOperationCountWithOrg(tenantID, tidbCloudOrgID, "cmp", "op", "ok")
-	RecordTenantRequestCountWithOrg(tenantID, tidbCloudOrgID, "api", "read", "ok", 200)
-	RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, "api", "", "upload", 1024)
+	RecordTenantRequestCountWithOrg(tenantID, tidbCloudOrgID, "api", "read", 200)
+	RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, "upload", 1024)
 	RecordSSEConnectionWithOrg(tenantID, tidbCloudOrgID, "mount", time.Second)
 	RecordSSEEventSentWithOrg(tenantID, tidbCloudOrgID, "write")
-	RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, "api", "read", 3)
+	RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, "api", 3)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -63,8 +63,14 @@ func TestRecordTenantOperationCountDoesNotRecordDuration(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-a",tidbcloud_org_id="org-counter-only"} 1`) {
-		t.Fatalf("missing counter-only operation total:\n%s", text)
+	if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok"} 1`) {
+		t.Fatalf("missing aggregate counter-only operation total:\n%s", text)
+	}
+	if hasMetricLineWith(text, "drive9_service_operations_total", `tenant_id="tenant-a"`) {
+		t.Fatalf("aggregate operation total unexpectedly carried tenant labels:\n%s", text)
+	}
+	if hasMetricLineWith(text, "drive9_tenant_operation_failures_total", `tenant_id="tenant-a"`) {
+		t.Fatalf("successful operation unexpectedly created a tenant failure series:\n%s", text)
 	}
 	if strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-a"}`) {
 		t.Fatalf("counter-only operation unexpectedly recorded a duration:\n%s", text)
@@ -80,7 +86,7 @@ func TestRecordTenantOperationZeroDurationDoesNotRecordDuration(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-zero",tidbcloud_org_id="org-zero-duration"} 1`) {
+	if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok"} 1`) {
 		t.Fatalf("missing zero-duration operation total:\n%s", text)
 	}
 	if strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="tenant-zero"}`) {
@@ -99,8 +105,11 @@ func TestRecordTenantOperationOmitsTenantFromDurationHistograms(t *testing.T) {
 			rec := httptest.NewRecorder()
 			WritePrometheus(rec)
 			text := rec.Body.String()
-			if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok",tenant_id="`+tenantID+`",tidbcloud_org_id="org-`+component+`"} 1`) {
-				t.Fatalf("missing tenant-scoped operation total:\n%s", text)
+			if !strings.Contains(text, `drive9_service_operations_total{component="`+component+`",operation="`+operation+`",result="ok"} 1`) {
+				t.Fatalf("missing aggregate operation total:\n%s", text)
+			}
+			if hasMetricLineWith(text, "drive9_service_operations_total", `tenant_id="`+tenantID+`"`) {
+				t.Fatalf("aggregate operation total unexpectedly carried tenant labels:\n%s", text)
 			}
 			if !strings.Contains(text, `drive9_service_operation_duration_seconds_count{component="`+component+`",operation="`+operation+`",result="ok"} 1`) {
 				t.Fatalf("missing tenant-omitted duration histogram:\n%s", text)
@@ -124,7 +133,7 @@ func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_requests_total{action="`+action+`",result="ok",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`",tidbcloud_org_id="org-request-duration"} 1`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="`+action+`",status_class="2xx",surface="`+surface+`",tenant_id="`+tenantID+`",tidbcloud_org_id="org-request-duration"} 1`) {
 		t.Errorf("missing tenant-scoped request total:\n%s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_count{status_class="2xx",surface="`+surface+`"} 1`) {
@@ -132,6 +141,9 @@ func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 	}
 	if hasMetricLineWith(text, "drive9_tenant_requests_total", `status="201"`) {
 		t.Errorf("tenant request total unexpectedly carried raw status label:\n%s", text)
+	}
+	if hasMetricLineWith(text, "drive9_tenant_requests_total", `result=`) {
+		t.Errorf("tenant request total unexpectedly carried derived result label:\n%s", text)
 	}
 	for _, unexpected := range []string{
 		`action="` + action + `"`,
@@ -153,7 +165,7 @@ func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_requests_total{action="zero_action",result="ok",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`",tidbcloud_org_id="guest"} 1`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="zero_action",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`",tidbcloud_org_id="guest"} 1`) {
 		t.Errorf("missing zero-duration tenant request total:\n%s", text)
 	}
 	if hasMetricLineWith(text, "drive9_tenant_request_duration_seconds_count", `surface="zero_surface"`) {
@@ -224,7 +236,7 @@ func TestRecordTenantInFlightDeletesZeroValue(t *testing.T) {
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_inflight_requests{action="`+action+`",surface="`+surface+`",tenant_id="`+tenantID+`",tidbcloud_org_id="org-inflight-delete"} 1.000000`) {
+	if !strings.Contains(text, `drive9_tenant_inflight_requests{surface="`+surface+`",tenant_id="`+tenantID+`",tidbcloud_org_id="org-inflight-delete"} 1.000000`) {
 		t.Errorf("missing tenant in-flight gauge:\n%s", text)
 	}
 
@@ -232,8 +244,51 @@ func TestRecordTenantInFlightDeletesZeroValue(t *testing.T) {
 	rec = httptest.NewRecorder()
 	WritePrometheus(rec)
 	text = rec.Body.String()
-	if strings.Contains(text, `drive9_tenant_inflight_requests{action="`+action+`",surface="`+surface+`",tenant_id="`+tenantID+`",tidbcloud_org_id="org-inflight-delete"}`) {
+	if strings.Contains(text, `drive9_tenant_inflight_requests{surface="`+surface+`",tenant_id="`+tenantID+`",tidbcloud_org_id="org-inflight-delete"}`) {
 		t.Errorf("tenant in-flight gauge should be deleted at zero:\n%s", text)
+	}
+}
+
+func TestDeleteTenantGaugeAndSSEInFlightRemoveSeries(t *testing.T) {
+	const tenantID = "tenant-gauge-delete"
+	const orgID = "org-gauge-delete"
+
+	RecordTenantGaugeWithOrg(tenantID, orgID, "semantic_worker", "queue_lag_seconds", 12)
+	RecordSSEInFlightWithOrg(tenantID, orgID, 2)
+	DeleteTenantGaugeWithOrg(tenantID, orgID, "semantic_worker", "queue_lag_seconds")
+	RecordSSEInFlightWithOrg(tenantID, orgID, 0)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if hasMetricLineWith(text, "drive9_service_gauge", `tenant_id="`+tenantID+`"`, `name="queue_lag_seconds"`) {
+		t.Fatalf("deleted tenant gauge remains exported:\n%s", text)
+	}
+	if hasMetricLineWith(text, "drive9_sse_inflight_connections", `tenant_id="`+tenantID+`"`) {
+		t.Fatalf("zero SSE in-flight series remains exported:\n%s", text)
+	}
+}
+
+func TestDeleteTenantQuotaLimitsRemovesOnlyLimitSeries(t *testing.T) {
+	const tenantID = "tenant-quota-limit-delete"
+	const orgID = "org-quota-limit-delete"
+
+	RecordTenantStorageBytesWithOrg(tenantID, orgID, "confirmed", 10)
+	RecordTenantStorageBytesWithOrg(tenantID, orgID, "limit", 100)
+	RecordTenantMediaFilesWithOrg(tenantID, orgID, "limit", 20)
+	RecordTenantVideoFilesWithOrg(tenantID, orgID, "limit", 30)
+	DeleteTenantQuotaLimitsWithOrg(tenantID, orgID)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !hasMetricLineWith(text, "drive9_tenant_storage_bytes", `tenant_id="`+tenantID+`"`, `state="confirmed"`) {
+		t.Fatalf("confirmed usage was deleted with limits:\n%s", text)
+	}
+	for _, metric := range []string{"drive9_tenant_storage_bytes", "drive9_tenant_media_files", "drive9_tenant_video_files"} {
+		if hasMetricLineWith(text, metric, `tenant_id="`+tenantID+`"`, `state="limit"`) {
+			t.Fatalf("stale limit remains for %s:\n%s", metric, text)
+		}
 	}
 }
 
@@ -256,8 +311,6 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 	RecordSSEEventSentWithOrg(tenantID, orgID, "write")
 	RecordSSEResetSentWithOrg(tenantID, orgID, "seq_too_old")
 	RecordSSEHeartbeatSentWithOrg(tenantID, orgID)
-	RecordEventBusPollFailureWithOrg(tenantID, orgID)
-	RecordEventBusPublishErrorWithOrg(tenantID, orgID)
 	RecordFSEventsRowsWithOrg(tenantID, orgID, 50)
 	RecordFSEventsPrunedWithOrg(tenantID, orgID, 60)
 
@@ -266,10 +319,10 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 	text := rec.Body.String()
 	for _, want := range []string{
 		`drive9_service_gauge{component="component_org_label_test",name="gauge",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1.000000`,
-		`drive9_business_events_total{event="event_org_label_test",result="ok",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
-		`drive9_tenant_requests_total{action="action",result="ok",status_class="2xx",surface="surface_org_label_test",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
-		`drive9_tenant_http_bytes_total{direction="request",surface="surface_org_label_test",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 10`,
-		`drive9_tenant_file_bytes_total{action="write",direction="out",surface="surface_org_label_test",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 20`,
+		`drive9_business_events_total{event="event_org_label_test",result="ok"} 1`,
+		`drive9_tenant_requests_total{action="action",status_class="2xx",surface="surface_org_label_test",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_tenant_http_bytes_total{direction="request",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 10`,
+		`drive9_tenant_file_bytes_total{direction="out",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 20`,
 		`drive9_tenant_storage_bytes{state="confirmed",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 30.000000`,
 		`drive9_tenant_media_files{state="confirmed",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 40.000000`,
 		`drive9_tenant_video_files{state="limit",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 50.000000`,
@@ -278,14 +331,78 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 		`drive9_sse_events_sent_total{op="write",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
 		`drive9_sse_resets_sent_total{reason="seq_too_old",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
 		`drive9_sse_heartbeats_sent_total{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
-		`drive9_event_bus_poll_failures_total{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
-		`drive9_event_bus_publish_errors_total{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
 		`drive9_fs_events_rows{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 50.000000`,
-		`drive9_fs_events_pruned_total{tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 60`,
+		`drive9_fs_events_pruned_total 60`,
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("missing org-scoped tenant metric %q:\n%s", want, text)
 		}
+	}
+}
+
+func TestDeleteFSEventsRowsRemovesHealthySeries(t *testing.T) {
+	const tenantID = "tenant-fs-events-rows-delete"
+	const orgID = "org-fs-events-rows-delete"
+	RecordFSEventsRowsWithOrg(tenantID, orgID, 12)
+	DeleteFSEventsRowsWithOrg(tenantID, orgID)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	if hasMetricLineWith(rec.Body.String(), "drive9_fs_events_rows", `tenant_id="`+tenantID+`"`) {
+		t.Fatalf("deleted fs_events row gauge remains exported:\n%s", rec.Body.String())
+	}
+}
+
+func TestTenantOperationFailuresUseSeparateFailureOnlyMetric(t *testing.T) {
+	const tenantID = "tenant-operation-failure-contract"
+	const orgID = "org-operation-failure-contract"
+
+	RecordTenantOperationCountWithOrg(tenantID, orgID, "contract", "work", "queued")
+	RecordTenantOperationCountWithOrg(tenantID, orgID, "contract", "work", "write_error")
+	RecordTenantOperationCountWithOrg(tenantID, orgID, "contract", "quota", "fail_open")
+	RecordTenantOperationCountWithOrg(tenantID, orgID, "contract", "extract", "runtime_not_configured")
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_service_operations_total{component="contract",operation="work",result="queued"} 1`) ||
+		!strings.Contains(text, `drive9_service_operations_total{component="contract",operation="work",result="write_error"} 1`) {
+		t.Fatalf("missing aggregate operation totals:\n%s", text)
+	}
+	if hasMetricLineWith(text, "drive9_service_operations_total", `tenant_id="`+tenantID+`"`) {
+		t.Fatalf("aggregate operation total carried tenant labels:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_tenant_operation_failures_total{component="contract",operation="work",result="write_error",tenant_id="`+tenantID+`",tidbcloud_org_id="`+orgID+`"} 1`) {
+		t.Fatalf("missing tenant failure attribution metric:\n%s", text)
+	}
+	for _, want := range []string{
+		`drive9_tenant_operation_failures_total{component="contract",operation="quota",result="fail_open",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_tenant_operation_failures_total{component="contract",operation="extract",result="runtime_not_configured",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing explicit tenant failure attribution %q:\n%s", want, text)
+		}
+	}
+	if hasMetricLineWith(text, "drive9_tenant_operation_failures_total", `result="queued"`) {
+		t.Fatalf("non-failure result created tenant failure series:\n%s", text)
+	}
+}
+
+func TestBusinessEventTenantLabelsAreLimitedToLifecycleEvents(t *testing.T) {
+	RecordTenantEventWithOrg("tenant-event-contract", "org-event-contract", "fs_write", "result", "ok")
+	RecordTenantEventWithOrg("tenant-event-contract", "org-event-contract", "tenant_provision", "provider", "local", "result", "ok")
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_business_events_total{event="fs_write",result="ok"} 1`) {
+		t.Fatalf("hot-path event was not aggregated:\n%s", text)
+	}
+	if hasMetricLineWith(text, "drive9_business_events_total", `event="fs_write"`, `tenant_id=`) {
+		t.Fatalf("hot-path event carried tenant labels:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_business_events_total{event="tenant_provision",provider="local",result="ok",tenant_id="tenant-event-contract",tidbcloud_org_id="org-event-contract"} 1`) {
+		t.Fatalf("lifecycle event lost tenant attribution:\n%s", text)
 	}
 }
 
@@ -429,7 +546,7 @@ func TestRecordTenantPoolBindingsIncludesPoolTiDBCloudOrgAndStatus(t *testing.T)
 
 func TestTiDBCloudQuotaMetricsOmitTenantID(t *testing.T) {
 	RecordTiDBCloudRBACCacheRequest("quota_get", "cluster", "hit")
-	RecordTiDBCloudOpenAPIRequest("admin_tenant_get", "list_managed_clusters", "ok")
+	RecordTiDBCloudOpenAPIRequest("cluster", "list_clusters", "ok")
 	RecordTiDBCloudSpendingLimitSync("quota_get", "updated")
 	RecordTiDBCloudSpendingLimitMissing("admin_tenant_list")
 
@@ -438,7 +555,7 @@ func TestTiDBCloudQuotaMetricsOmitTenantID(t *testing.T) {
 	text := rec.Body.String()
 	for _, want := range []string{
 		`drive9_tidbcloud_rbac_cache_requests_total{path="quota_get",result="hit",scope="cluster"} 1`,
-		`drive9_tidbcloud_openapi_requests_total{operation="list_managed_clusters",path="admin_tenant_get",result="ok"} 1`,
+		`drive9_tidbcloud_openapi_requests_total{api="cluster",operation="list_clusters",result="ok"} 1`,
 		`drive9_tidbcloud_spending_limit_sync_total{result="updated",source="quota_get"} 1`,
 		`drive9_tidbcloud_spending_limit_missing_total{path="admin_tenant_list"} 1`,
 	} {
@@ -449,6 +566,9 @@ func TestTiDBCloudQuotaMetricsOmitTenantID(t *testing.T) {
 	for _, line := range strings.Split(text, "\n") {
 		if strings.HasPrefix(line, "drive9_tidbcloud_") && strings.Contains(line, `tenant_id=`) {
 			t.Fatalf("TiDB Cloud quota metrics must not carry tenant_id:\n%s", text)
+		}
+		if strings.HasPrefix(line, "drive9_tidbcloud_openapi_requests_total") && strings.Contains(line, `path=`) {
+			t.Fatalf("TiDB Cloud OpenAPI metrics must use api, not path:\n%s", text)
 		}
 	}
 }

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -358,6 +358,21 @@ func (r *Registry) DeleteGaugesByLabel(labelKey, labelValue string) {
 	}
 }
 
+func (r *Registry) deleteGaugeByLabel(name, labelKey, labelValue string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	inst := r.gauges[name]
+	if inst == nil {
+		return
+	}
+	match := labelKey + `="` + EscapePromLabel(labelValue) + `"`
+	for labels := range inst.values {
+		if labelHasKeyValue(labels, match) {
+			delete(inst.values, labels)
+		}
+	}
+}
+
 func (r *Registry) observeHistogram(name, labels string, value float64) {
 	r.mu.Lock()
 	defer r.mu.Unlock()

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -81,6 +81,13 @@ type moduleState struct {
 	up           float64
 }
 
+type tenantQuotaSnapshotState struct {
+	orgID             string
+	storageLimitBytes int64
+	mediaLimitFiles   int64
+	videoLimitFiles   int64
+}
+
 type Registry struct {
 	mu sync.RWMutex
 
@@ -88,6 +95,8 @@ type Registry struct {
 	gauges     map[string]*gaugeInstrument
 	histograms map[string]*histogramInstrument
 	modules    map[string]moduleState
+
+	tenantQuotaSnapshots map[string]tenantQuotaSnapshotState
 }
 
 type MeterProvider struct {
@@ -116,10 +125,11 @@ type Float64Histogram struct {
 
 func NewRegistry() *Registry {
 	return &Registry{
-		counters:   map[string]*counterInstrument{},
-		gauges:     map[string]*gaugeInstrument{},
-		histograms: map[string]*histogramInstrument{},
-		modules:    map[string]moduleState{},
+		counters:             map[string]*counterInstrument{},
+		gauges:               map[string]*gaugeInstrument{},
+		histograms:           map[string]*histogramInstrument{},
+		modules:              map[string]moduleState{},
+		tenantQuotaSnapshots: map[string]tenantQuotaSnapshotState{},
 	}
 }
 
@@ -356,20 +366,8 @@ func (r *Registry) DeleteGaugesByLabel(labelKey, labelValue string) {
 			}
 		}
 	}
-}
-
-func (r *Registry) deleteGaugeByLabel(name, labelKey, labelValue string) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	inst := r.gauges[name]
-	if inst == nil {
-		return
-	}
-	match := labelKey + `="` + EscapePromLabel(labelValue) + `"`
-	for labels := range inst.values {
-		if labelHasKeyValue(labels, match) {
-			delete(inst.values, labels)
-		}
+	if labelKey == "tenant_id" {
+		delete(r.tenantQuotaSnapshots, labelValue)
 	}
 }
 

--- a/pkg/metrics/workers.go
+++ b/pkg/metrics/workers.go
@@ -5,7 +5,6 @@ import (
 	"time"
 )
 
-var queueDepthBounds = []float64{1, 4, 16, 64, 128, 256, 512, 1024, 2048, 3072, 4096}
 var batchSizeBounds = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1000}
 
 var mutationDispatcherQueueDepth = serviceMeter.Float64Gauge("drive9_mutation_dispatcher_queue_depth", "Queued central quota mutations by dispatcher shard")

--- a/pkg/metrics/workers.go
+++ b/pkg/metrics/workers.go
@@ -1,0 +1,145 @@
+package metrics
+
+import (
+	"strconv"
+	"time"
+)
+
+var queueDepthBounds = []float64{1, 4, 16, 64, 128, 256, 512, 1024, 2048, 3072, 4096}
+var batchSizeBounds = []float64{1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1000}
+
+var mutationDispatcherQueueDepth = serviceMeter.Float64Gauge("drive9_mutation_dispatcher_queue_depth", "Queued central quota mutations by dispatcher shard")
+var mutationDispatcherQueueCapacity = serviceMeter.Float64Gauge("drive9_mutation_dispatcher_queue_capacity", "Central quota mutation queue capacity by dispatcher shard")
+var mutationDispatcherEnqueueBlocked = serviceMeter.Float64Histogram("drive9_mutation_dispatcher_enqueue_blocked_seconds", "Time spent waiting to enqueue a central quota mutation by dispatcher shard", operationDurationBounds)
+var mutationDispatcherBatchSize = serviceMeter.Float64Histogram("drive9_mutation_dispatcher_batch_size", "Central quota mutations collected per dispatcher batch", batchSizeBounds)
+var mutationDispatcherBatchFallbackTotal = serviceMeter.Int64Counter("drive9_mutation_dispatcher_batch_fallback_total", "Central quota dispatcher batches that fell back to per-item transactions")
+
+var apiKeyResolveCacheRequestsTotal = serviceMeter.Int64Counter("drive9_api_key_resolve_cache_requests_total", "API key resolve cache requests by result")
+var apiKeyResolveCacheEntries = serviceMeter.Float64Gauge("drive9_api_key_resolve_cache_entries", "Current API key resolve cache entries")
+
+var notifyCoalescerFlushTotal = serviceMeter.Int64Counter("drive9_notify_coalescer_flush_total", "Tenant notify coalescer flushes by final result")
+var notifyCoalescerPerRowFallbackTotal = serviceMeter.Int64Counter("drive9_notify_coalescer_per_row_fallback_total", "Tenant notify coalescer per-row fallback inserts by result")
+var notifyCoalescerPending = serviceMeter.Float64Gauge("drive9_notify_coalescer_pending", "Tenant notify coalescer tenants awaiting flush")
+var notifyCoalescerBatchSize = serviceMeter.Float64Histogram("drive9_notify_coalescer_batch_size", "Tenants in a notify coalescer flush batch", batchSizeBounds)
+
+var tenantOutboxPollDuration = serviceMeter.Float64Histogram("drive9_tenant_outbox_poll_duration_seconds", "Tenant outbox poll cycle duration by result", operationDurationBounds)
+var tenantOutboxBatchSize = serviceMeter.Float64Histogram("drive9_tenant_outbox_batch_size", "Rows returned by a tenant outbox poll query", batchSizeBounds)
+var tenantOutboxBacklogOldestAge = serviceMeter.Float64Gauge("drive9_tenant_outbox_backlog_oldest_age_seconds", "Age of the oldest tenant outbox row while a backlog remains")
+var tenantOutboxFullBatchesTotal = serviceMeter.Int64Counter("drive9_tenant_outbox_full_batches_total", "Full tenant outbox batches requiring immediate drain")
+var tenantOutboxCursorFlushTotal = serviceMeter.Int64Counter("drive9_tenant_outbox_cursor_flush_total", "Tenant outbox cursor flushes by result")
+
+var sharedDBPoolStatusAge = serviceMeter.Float64Gauge("drive9_shared_db_pool_status_age_seconds", "Time a non-active shared DB pool has remained in its current status")
+var sharedDBPoolStuckMarkedFailedTotal = serviceMeter.Int64Counter("drive9_shared_db_pool_stuck_marked_failed_total", "Stuck shared DB pools marked failed by previous status")
+var sharedDBPoolWaveTotal = serviceMeter.Int64Counter("drive9_shared_db_pool_wave_total", "Managed shared DB pool reservation waves by result")
+var sharedDBPoolWavePhysicalPools = serviceMeter.Float64Histogram("drive9_shared_db_pool_wave_physical_pools", "Physical DB pools staged per managed shared-pool wave", batchSizeBounds)
+var sharedDBPoolWaveTenants = serviceMeter.Float64Histogram("drive9_shared_db_pool_wave_tenants", "Tenant slots staged per managed shared-pool wave", batchSizeBounds)
+var sharedDBPoolCleanupTotal = serviceMeter.Int64Counter("drive9_shared_db_pool_cleanup_total", "Failed managed shared DB pool cleanup steps by stage/result")
+
+func RecordMutationDispatcherQueue(shard, depth, capacity int) {
+	RegisterModule("mutation_dispatcher")
+	attrs := []Attribute{Attr("shard", strconv.Itoa(shard))}
+	mutationDispatcherQueueDepth.Set(float64(max(depth, 0)), attrs...)
+	mutationDispatcherQueueCapacity.Set(float64(max(capacity, 0)), attrs...)
+}
+
+func RecordMutationDispatcherEnqueueBlocked(shard int, d time.Duration) {
+	RegisterModule("mutation_dispatcher")
+	mutationDispatcherEnqueueBlocked.Observe(max(d.Seconds(), 0), Attr("shard", strconv.Itoa(shard)))
+}
+
+func RecordMutationDispatcherBatch(size int, fallback bool) {
+	RegisterModule("mutation_dispatcher")
+	if size > 0 {
+		mutationDispatcherBatchSize.Observe(float64(size))
+	}
+	if fallback {
+		mutationDispatcherBatchFallbackTotal.Add(1)
+	}
+}
+
+func RecordAPIKeyResolveCache(result string, entries int) {
+	RegisterModule("api_key_resolve_cache")
+	apiKeyResolveCacheRequestsTotal.Add(1, Attr("result", cleanMetricValue(result, "unknown")))
+	apiKeyResolveCacheEntries.Set(float64(max(entries, 0)))
+}
+
+func RecordAPIKeyResolveCacheEntries(entries int) {
+	RegisterModule("api_key_resolve_cache")
+	apiKeyResolveCacheEntries.Set(float64(max(entries, 0)))
+}
+
+func RecordNotifyCoalescerPending(pending int) {
+	RegisterModule("notify_coalescer")
+	notifyCoalescerPending.Set(float64(max(pending, 0)))
+}
+
+func RecordNotifyCoalescerFlush(result string, size int) {
+	RegisterModule("notify_coalescer")
+	notifyCoalescerFlushTotal.Add(1, Attr("result", cleanMetricValue(result, "unknown")))
+	if size > 0 {
+		notifyCoalescerBatchSize.Observe(float64(size))
+	}
+}
+
+func RecordNotifyCoalescerPerRowFallback(result string) {
+	RegisterModule("notify_coalescer")
+	notifyCoalescerPerRowFallbackTotal.Add(1, Attr("result", cleanMetricValue(result, "unknown")))
+}
+
+func RecordTenantOutboxPoll(result string, d time.Duration, size int, oldestAge time.Duration, full bool) {
+	RegisterModule("tenant_outbox_poller")
+	tenantOutboxPollDuration.Observe(max(d.Seconds(), 0), Attr("result", cleanMetricValue(result, "unknown")))
+	tenantOutboxBatchSize.Observe(float64(max(size, 0)))
+	if full {
+		tenantOutboxBacklogOldestAge.Set(max(oldestAge.Seconds(), 0))
+		tenantOutboxFullBatchesTotal.Add(1)
+	} else {
+		tenantOutboxBacklogOldestAge.Set(0)
+	}
+}
+
+func RecordTenantOutboxCursorFlush(result string) {
+	RegisterModule("tenant_outbox_poller")
+	tenantOutboxCursorFlushTotal.Add(1, Attr("result", cleanMetricValue(result, "unknown")))
+}
+
+func RecordSharedDBPoolStatusAge(tidbCloudOrgID, dbPoolUUID, status string, age time.Duration) {
+	RegisterModule("shared_db_pool")
+	sharedDBPoolStatusAge.Set(max(age.Seconds(), 0), sharedDBPoolStatusAgeAttrs(tidbCloudOrgID, dbPoolUUID, status)...)
+}
+
+func DeleteSharedDBPoolStatusAge(tidbCloudOrgID, dbPoolUUID, status string) {
+	sharedDBPoolStatusAge.Delete(sharedDBPoolStatusAgeAttrs(tidbCloudOrgID, dbPoolUUID, status)...)
+}
+
+func sharedDBPoolStatusAgeAttrs(tidbCloudOrgID, dbPoolUUID, status string) []Attribute {
+	return []Attribute{
+		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
+		Attr("db_pool_uuid", cleanMetricValue(dbPoolUUID, "unknown")),
+		Attr("status", cleanMetricValue(status, "unknown")),
+	}
+}
+
+func RecordSharedDBPoolStuckMarkedFailed(previousStatus string) {
+	RegisterModule("shared_db_pool")
+	sharedDBPoolStuckMarkedFailedTotal.Add(1, Attr("previous_status", cleanMetricValue(previousStatus, "unknown")))
+}
+
+func RecordSharedDBPoolWave(result string, physicalPools, tenants int) {
+	RegisterModule("shared_db_pool")
+	sharedDBPoolWaveTotal.Add(1, Attr("result", cleanMetricValue(result, "unknown")))
+	if physicalPools > 0 {
+		sharedDBPoolWavePhysicalPools.Observe(float64(physicalPools))
+	}
+	if tenants > 0 {
+		sharedDBPoolWaveTenants.Observe(float64(tenants))
+	}
+}
+
+func RecordSharedDBPoolCleanup(stage, result string) {
+	RegisterModule("shared_db_pool")
+	sharedDBPoolCleanupTotal.Add(1,
+		Attr("stage", cleanMetricValue(stage, "unknown")),
+		Attr("result", cleanMetricValue(result, "unknown")),
+	)
+}

--- a/pkg/metrics/workers.go
+++ b/pkg/metrics/workers.go
@@ -88,10 +88,10 @@ func RecordTenantOutboxPoll(result string, d time.Duration, size int, oldestAge 
 	RegisterModule("tenant_outbox_poller")
 	result = cleanMetricValue(result, "unknown")
 	tenantOutboxPollDuration.Observe(max(d.Seconds(), 0), Attr("result", result))
-	tenantOutboxBatchSize.Observe(float64(max(size, 0)))
 	if result != "ok" {
 		return
 	}
+	tenantOutboxBatchSize.Observe(float64(max(size, 0)))
 	if size > 0 {
 		tenantOutboxBacklogOldestAge.Set(max(oldestAge.Seconds(), 0))
 	} else {

--- a/pkg/metrics/workers.go
+++ b/pkg/metrics/workers.go
@@ -18,7 +18,7 @@ var apiKeyResolveCacheEntries = serviceMeter.Float64Gauge("drive9_api_key_resolv
 
 var notifyCoalescerFlushTotal = serviceMeter.Int64Counter("drive9_notify_coalescer_flush_total", "Tenant notify coalescer flushes by final result")
 var notifyCoalescerPerRowFallbackTotal = serviceMeter.Int64Counter("drive9_notify_coalescer_per_row_fallback_total", "Tenant notify coalescer per-row fallback inserts by result")
-var notifyCoalescerPending = serviceMeter.Float64Gauge("drive9_notify_coalescer_pending", "Tenant notify coalescer tenants awaiting flush")
+var notifyCoalescerPending = serviceMeter.Float64Gauge("drive9_notify_coalescer_pending", "Tenant notify coalescer tenants pending or awaiting durable flush")
 var notifyCoalescerBatchSize = serviceMeter.Float64Histogram("drive9_notify_coalescer_batch_size", "Tenants in a notify coalescer flush batch", batchSizeBounds)
 
 var tenantOutboxPollDuration = serviceMeter.Float64Histogram("drive9_tenant_outbox_poll_duration_seconds", "Tenant outbox poll cycle duration by result", operationDurationBounds)
@@ -56,10 +56,9 @@ func RecordMutationDispatcherBatch(size int, fallback bool) {
 	}
 }
 
-func RecordAPIKeyResolveCache(result string, entries int) {
+func RecordAPIKeyResolveCacheRequest(result string) {
 	RegisterModule("api_key_resolve_cache")
 	apiKeyResolveCacheRequestsTotal.Add(1, Attr("result", cleanMetricValue(result, "unknown")))
-	apiKeyResolveCacheEntries.Set(float64(max(entries, 0)))
 }
 
 func RecordAPIKeyResolveCacheEntries(entries int) {
@@ -87,13 +86,19 @@ func RecordNotifyCoalescerPerRowFallback(result string) {
 
 func RecordTenantOutboxPoll(result string, d time.Duration, size int, oldestAge time.Duration, full bool) {
 	RegisterModule("tenant_outbox_poller")
-	tenantOutboxPollDuration.Observe(max(d.Seconds(), 0), Attr("result", cleanMetricValue(result, "unknown")))
+	result = cleanMetricValue(result, "unknown")
+	tenantOutboxPollDuration.Observe(max(d.Seconds(), 0), Attr("result", result))
 	tenantOutboxBatchSize.Observe(float64(max(size, 0)))
-	if full {
+	if result != "ok" {
+		return
+	}
+	if size > 0 {
 		tenantOutboxBacklogOldestAge.Set(max(oldestAge.Seconds(), 0))
-		tenantOutboxFullBatchesTotal.Add(1)
 	} else {
 		tenantOutboxBacklogOldestAge.Set(0)
+	}
+	if full {
+		tenantOutboxFullBatchesTotal.Add(1)
 	}
 }
 

--- a/pkg/metrics/workers_test.go
+++ b/pkg/metrics/workers_test.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -74,36 +75,53 @@ func TestCriticalWorkerMetricsUseBoundedLabels(t *testing.T) {
 }
 
 func TestTenantOutboxBacklogAgeTracksObservedRowsAndSurvivesPollErrors(t *testing.T) {
-	RecordTenantOutboxPoll("ok", time.Millisecond, 1000, 2*time.Minute, true)
-	rec := httptest.NewRecorder()
-	WritePrometheus(rec)
-	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_batch_size_count 1`) {
-		t.Fatalf("successful poll did not observe one batch-size sample:\n%s", rec.Body.String())
+	histogramCount := func() float64 {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		WritePrometheus(rec)
+		for _, line := range strings.Split(rec.Body.String(), "\n") {
+			if !strings.HasPrefix(line, "drive9_tenant_outbox_batch_size_count ") {
+				continue
+			}
+			value, err := strconv.ParseFloat(strings.TrimPrefix(line, "drive9_tenant_outbox_batch_size_count "), 64)
+			if err != nil {
+				t.Fatalf("parse batch-size histogram count %q: %v", line, err)
+			}
+			return value
+		}
+		return 0
 	}
+	baseline := histogramCount()
+	RecordTenantOutboxPoll("ok", time.Millisecond, 1000, 2*time.Minute, true)
+	if got := histogramCount(); got != baseline+1 {
+		t.Fatalf("successful poll changed batch-size count from %v to %v, want %v", baseline, got, baseline+1)
+	}
+	afterSuccess := histogramCount()
 	RecordTenantOutboxPoll("error", time.Millisecond, 0, 0, false)
 
-	rec = httptest.NewRecorder()
-	WritePrometheus(rec)
-	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_batch_size_count 1`) {
-		t.Fatalf("error poll injected a zero batch-size sample:\n%s", rec.Body.String())
+	if got := histogramCount(); got != afterSuccess {
+		t.Fatalf("error poll changed batch-size count from %v to %v", afterSuccess, got)
 	}
-	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_backlog_oldest_age_seconds 120.000000`) {
-		t.Fatalf("poll error cleared last observed backlog age:\n%s", rec.Body.String())
+	if got := metricText(t); !strings.Contains(got, `drive9_tenant_outbox_backlog_oldest_age_seconds 120.000000`) {
+		t.Fatalf("poll error cleared last observed backlog age:\n%s", got)
 	}
 
 	RecordTenantOutboxPoll("ok", time.Millisecond, 1, 45*time.Second, false)
-	rec = httptest.NewRecorder()
-	WritePrometheus(rec)
-	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_backlog_oldest_age_seconds 45.000000`) {
-		t.Fatalf("non-full batch did not report its oldest row age:\n%s", rec.Body.String())
+	if got := metricText(t); !strings.Contains(got, `drive9_tenant_outbox_backlog_oldest_age_seconds 45.000000`) {
+		t.Fatalf("non-full batch did not report its oldest row age:\n%s", got)
 	}
 
 	RecordTenantOutboxPoll("ok", time.Millisecond, 0, 0, false)
-	rec = httptest.NewRecorder()
-	WritePrometheus(rec)
-	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_backlog_oldest_age_seconds 0.000000`) {
-		t.Fatalf("empty successful poll did not clear backlog age:\n%s", rec.Body.String())
+	if got := metricText(t); !strings.Contains(got, `drive9_tenant_outbox_backlog_oldest_age_seconds 0.000000`) {
+		t.Fatalf("empty successful poll did not clear backlog age:\n%s", got)
 	}
+}
+
+func metricText(t *testing.T) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	return rec.Body.String()
 }
 
 func TestAPIKeyResolveCacheRequestDoesNotRewriteEntryGauge(t *testing.T) {

--- a/pkg/metrics/workers_test.go
+++ b/pkg/metrics/workers_test.go
@@ -11,7 +11,8 @@ func TestCriticalWorkerMetricsUseBoundedLabels(t *testing.T) {
 	RecordMutationDispatcherQueue(2, 10, 4096)
 	RecordMutationDispatcherEnqueueBlocked(2, 25*time.Millisecond)
 	RecordMutationDispatcherBatch(17, true)
-	RecordAPIKeyResolveCache("hit", 8)
+	RecordAPIKeyResolveCacheEntries(8)
+	RecordAPIKeyResolveCacheRequest("hit")
 	RecordNotifyCoalescerPending(3)
 	RecordNotifyCoalescerFlush("retry_ok", 3)
 	RecordNotifyCoalescerPerRowFallback("error")
@@ -69,5 +70,45 @@ func TestCriticalWorkerMetricsUseBoundedLabels(t *testing.T) {
 				t.Errorf("bounded worker metric contains forbidden label %q: %s", forbidden, line)
 			}
 		}
+	}
+}
+
+func TestTenantOutboxBacklogAgeTracksObservedRowsAndSurvivesPollErrors(t *testing.T) {
+	RecordTenantOutboxPoll("ok", time.Millisecond, 1000, 2*time.Minute, true)
+	RecordTenantOutboxPoll("error", time.Millisecond, 0, 0, false)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_backlog_oldest_age_seconds 120.000000`) {
+		t.Fatalf("poll error cleared last observed backlog age:\n%s", rec.Body.String())
+	}
+
+	RecordTenantOutboxPoll("ok", time.Millisecond, 1, 45*time.Second, false)
+	rec = httptest.NewRecorder()
+	WritePrometheus(rec)
+	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_backlog_oldest_age_seconds 45.000000`) {
+		t.Fatalf("non-full batch did not report its oldest row age:\n%s", rec.Body.String())
+	}
+
+	RecordTenantOutboxPoll("ok", time.Millisecond, 0, 0, false)
+	rec = httptest.NewRecorder()
+	WritePrometheus(rec)
+	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_backlog_oldest_age_seconds 0.000000`) {
+		t.Fatalf("empty successful poll did not clear backlog age:\n%s", rec.Body.String())
+	}
+}
+
+func TestAPIKeyResolveCacheRequestDoesNotRewriteEntryGauge(t *testing.T) {
+	RecordAPIKeyResolveCacheEntries(7)
+	RecordAPIKeyResolveCacheRequest("hit")
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_api_key_resolve_cache_requests_total{result="hit"}`) {
+		t.Fatalf("missing API key cache request counter:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_api_key_resolve_cache_entries 7.000000`) {
+		t.Fatalf("request path rewrote API key cache entry gauge:\n%s", text)
 	}
 }

--- a/pkg/metrics/workers_test.go
+++ b/pkg/metrics/workers_test.go
@@ -1,0 +1,73 @@
+package metrics
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCriticalWorkerMetricsUseBoundedLabels(t *testing.T) {
+	RecordMutationDispatcherQueue(2, 10, 4096)
+	RecordMutationDispatcherEnqueueBlocked(2, 25*time.Millisecond)
+	RecordMutationDispatcherBatch(17, true)
+	RecordAPIKeyResolveCache("hit", 8)
+	RecordNotifyCoalescerPending(3)
+	RecordNotifyCoalescerFlush("retry_ok", 3)
+	RecordNotifyCoalescerPerRowFallback("error")
+	RecordTenantOutboxPoll("ok", 50*time.Millisecond, 1000, 12*time.Second, true)
+	RecordTenantOutboxCursorFlush("error")
+	RecordSharedDBPoolStatusAge("org-workers", "pool-workers", "pending", 15*time.Minute)
+	RecordSharedDBPoolStuckMarkedFailed("pending")
+	RecordSharedDBPoolWave("ok", 2, 40)
+	RecordSharedDBPoolCleanup("deprovision", "error")
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	for _, want := range []string{
+		`drive9_mutation_dispatcher_queue_depth{shard="2"} 10.000000`,
+		`drive9_mutation_dispatcher_queue_capacity{shard="2"} 4096.000000`,
+		`drive9_mutation_dispatcher_enqueue_blocked_seconds_count{shard="2"} 1`,
+		`drive9_mutation_dispatcher_batch_size_count 1`,
+		`drive9_mutation_dispatcher_batch_fallback_total 1`,
+		`drive9_api_key_resolve_cache_requests_total{result="hit"} 1`,
+		`drive9_api_key_resolve_cache_entries 8.000000`,
+		`drive9_notify_coalescer_pending 3.000000`,
+		`drive9_notify_coalescer_flush_total{result="retry_ok"} 1`,
+		`drive9_notify_coalescer_batch_size_count 1`,
+		`drive9_notify_coalescer_per_row_fallback_total{result="error"} 1`,
+		`drive9_tenant_outbox_poll_duration_seconds_count{result="ok"} 1`,
+		`drive9_tenant_outbox_batch_size_count 1`,
+		`drive9_tenant_outbox_backlog_oldest_age_seconds 12.000000`,
+		`drive9_tenant_outbox_full_batches_total 1`,
+		`drive9_tenant_outbox_cursor_flush_total{result="error"} 1`,
+		`drive9_shared_db_pool_status_age_seconds{db_pool_uuid="pool-workers",status="pending",tidbcloud_org_id="org-workers"} 900.000000`,
+		`drive9_shared_db_pool_stuck_marked_failed_total{previous_status="pending"} 1`,
+		`drive9_shared_db_pool_wave_total{result="ok"} 1`,
+		`drive9_shared_db_pool_wave_physical_pools_count 1`,
+		`drive9_shared_db_pool_wave_tenants_count 1`,
+		`drive9_shared_db_pool_cleanup_total{result="error",stage="deprovision"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("missing worker metric %q:\n%s", want, text)
+		}
+	}
+	for _, forbidden := range []string{`tenant_id=`, `db_pool_id=`} {
+		for _, line := range strings.Split(text, "\n") {
+			if !strings.HasPrefix(line, "drive9_mutation_dispatcher_") &&
+				!strings.HasPrefix(line, "drive9_api_key_resolve_cache_") &&
+				!strings.HasPrefix(line, "drive9_notify_coalescer_") &&
+				!strings.HasPrefix(line, "drive9_tenant_outbox_") &&
+				!strings.HasPrefix(line, "drive9_shared_db_pool_status_age_seconds") &&
+				!strings.HasPrefix(line, "drive9_shared_db_pool_stuck_marked_failed_total") &&
+				!strings.HasPrefix(line, "drive9_shared_db_pool_wave_") &&
+				!strings.HasPrefix(line, "drive9_shared_db_pool_cleanup_total") {
+				continue
+			}
+			if strings.Contains(line, forbidden) {
+				t.Errorf("bounded worker metric contains forbidden label %q: %s", forbidden, line)
+			}
+		}
+	}
+}

--- a/pkg/metrics/workers_test.go
+++ b/pkg/metrics/workers_test.go
@@ -75,10 +75,18 @@ func TestCriticalWorkerMetricsUseBoundedLabels(t *testing.T) {
 
 func TestTenantOutboxBacklogAgeTracksObservedRowsAndSurvivesPollErrors(t *testing.T) {
 	RecordTenantOutboxPoll("ok", time.Millisecond, 1000, 2*time.Minute, true)
-	RecordTenantOutboxPoll("error", time.Millisecond, 0, 0, false)
-
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
+	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_batch_size_count 1`) {
+		t.Fatalf("successful poll did not observe one batch-size sample:\n%s", rec.Body.String())
+	}
+	RecordTenantOutboxPoll("error", time.Millisecond, 0, 0, false)
+
+	rec = httptest.NewRecorder()
+	WritePrometheus(rec)
+	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_batch_size_count 1`) {
+		t.Fatalf("error poll injected a zero batch-size sample:\n%s", rec.Body.String())
+	}
 	if !strings.Contains(rec.Body.String(), `drive9_tenant_outbox_backlog_oldest_age_seconds 120.000000`) {
 		t.Fatalf("poll error cleared last observed backlog age:\n%s", rec.Body.String())
 	}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1737,7 +1737,7 @@ func (s *Server) cleanupPoolProvisionedClusters(ctx context.Context, clusters []
 			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_mark_deleted_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
 			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
 		} else {
-			s.broadcastTenantMetricsCleanup(tenantID)
+			s.clearLocalTenantMetrics(tenantID)
 		}
 	}
 }
@@ -1835,7 +1835,7 @@ func (s *Server) deleteNewestFreePoolTenants(ctx context.Context, poolID, organi
 				_ = s.meta.UpdateTenantStatus(context.Background(), t.ID, meta.TenantFailed)
 				return deleted, err
 			}
-			s.broadcastTenantMetricsCleanup(t.ID)
+			s.clearLocalTenantMetrics(t.ID)
 		}
 		deleted++
 		if !deleteAll {
@@ -1911,7 +1911,7 @@ func (s *Server) cleanupCreatedPoolTenants(ctx context.Context, results []*provi
 		if err := s.meta.MarkTenantDeleted(cleanupCtx, tenantID); err != nil {
 			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_mark_deleted_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
 		} else {
-			s.broadcastTenantMetricsCleanup(tenantID)
+			s.clearLocalTenantMetrics(tenantID)
 		}
 	}
 }

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -1082,8 +1082,10 @@ func (s *Server) stageSharedPoolTenantWave(ctx context.Context, poolID, organiza
 	}
 	created, err := s.meta.CreateManagedSharedDBPoolTenantWaveWithResize(ctx, plans, resize)
 	if err != nil {
+		metrics.RecordSharedDBPoolWave(metrics.ResultForError(err), len(plans), count)
 		return nil, err
 	}
+	metrics.RecordSharedDBPoolWave("ok", len(created), count)
 	partitions := make([]sharedPoolTenantPartition, 0, len(created))
 	for _, result := range created {
 		row, loadErr := s.meta.GetSharedDB(ctx, result.DBID)
@@ -1734,6 +1736,8 @@ func (s *Server) cleanupPoolProvisionedClusters(ctx context.Context, clusters []
 		if err := s.meta.MarkTenantDeleted(cleanupCtx, tenantID); err != nil {
 			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_mark_deleted_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
 			_ = s.meta.UpdateTenantStatus(context.Background(), tenantID, meta.TenantFailed)
+		} else {
+			s.broadcastTenantMetricsCleanup(tenantID)
 		}
 	}
 }
@@ -1831,6 +1835,7 @@ func (s *Server) deleteNewestFreePoolTenants(ctx context.Context, poolID, organi
 				_ = s.meta.UpdateTenantStatus(context.Background(), t.ID, meta.TenantFailed)
 				return deleted, err
 			}
+			s.broadcastTenantMetricsCleanup(t.ID)
 		}
 		deleted++
 		if !deleteAll {
@@ -1905,6 +1910,8 @@ func (s *Server) cleanupCreatedPoolTenants(ctx context.Context, results []*provi
 		_ = s.meta.RevokeTenantAPIKeys(cleanupCtx, tenantID)
 		if err := s.meta.MarkTenantDeleted(cleanupCtx, tenantID); err != nil {
 			logger.Warn(cleanupCtx, "admin_tenant_pool_cleanup_mark_deleted_failed", zap.String("tenant_id", tenantID), zap.String("reason", reason), zap.Error(err))
+		} else {
+			s.broadcastTenantMetricsCleanup(tenantID)
 		}
 	}
 }

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -380,6 +380,7 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 			return
 		}
 		if hasJob {
+			s.broadcastTenantMetricsCleanup(t.ID)
 			_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
 			writeJSON(w, http.StatusAccepted, adminTenantDeleteResponse{TenantID: t.ID, Status: string(meta.TenantDeleting)})
 			return

--- a/pkg/server/admin_tenants.go
+++ b/pkg/server/admin_tenants.go
@@ -380,7 +380,7 @@ func (s *Server) handleAdminTenantDelete(w http.ResponseWriter, r *http.Request,
 			return
 		}
 		if hasJob {
-			s.broadcastTenantMetricsCleanup(t.ID)
+			s.clearLocalTenantMetrics(t.ID)
 			_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
 			writeJSON(w, http.StatusAccepted, adminTenantDeleteResponse{TenantID: t.ID, Status: string(meta.TenantDeleting)})
 			return

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -255,8 +255,6 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			errJSON(w, http.StatusUnauthorized, "invalid API key")
 			return
 		}
-		setRequestMetricTenant(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID, resolved.Tenant.Provider, resolved.TiDBCloudOrgID, classifyTenantRequest(r))
-
 		if resolved.APIKey.Status != meta.APIKeyActive {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "auth_key_inactive", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "status", resolved.APIKey.Status)...)
 			metricEvent(r.Context(), "auth", "result", "key_inactive")
@@ -335,7 +333,6 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 			errJSON(w, http.StatusForbidden, "tenant is unavailable")
 			return
 		}
-
 		scopeKind := resolved.APIKey.ScopeKind
 		if scopeKind == "" {
 			scopeKind = meta.APIKeyScopeKindOwner
@@ -483,7 +480,7 @@ func handleDeleteNoAcquireAuth(w http.ResponseWriter, r *http.Request, pool *ten
 		ScopeKind:          scopeKind,
 		IsScoped:           isScoped,
 	}
-	setRequestMetricScope(r.Context(), scope, classifyTenantRequest(r))
+	setRequestMetricTenantForAuthStatus(r.Context(), scope.TenantID, scope.APIKeyID, scope.Provider, scope.TiDBCloudOrgID, resolved.Tenant.Status, classifyTenantRequest(r))
 	next.ServeHTTP(w, r.WithContext(withScope(r.Context(), scope)))
 }
 

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -618,11 +618,11 @@ func TestSharedTenantStatusLogsAndMetricsUseDBOrganization(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	metrics.WritePrometheus(recorder)
 	metricsText := recorder.Body.String()
-	wantMetric := `drive9_tenant_requests_total{action="get",result="ok",status_class="2xx",surface="status",tenant_id="` + rt.tenantID + `",tidbcloud_org_id="org-shared-status-output"}`
+	wantMetric := `drive9_tenant_requests_total{action="get",status_class="2xx",surface="status",tenant_id="` + rt.tenantID + `",tidbcloud_org_id="org-shared-status-output"}`
 	if !strings.Contains(metricsText, wantMetric) {
 		t.Fatalf("missing shared status request metric %q", wantMetric)
 	}
-	wrongMetric := `drive9_tenant_requests_total{action="get",result="ok",status_class="2xx",surface="status",tenant_id="` + rt.tenantID + `",tidbcloud_org_id="guest"}`
+	wrongMetric := `drive9_tenant_requests_total{action="get",status_class="2xx",surface="status",tenant_id="` + rt.tenantID + `",tidbcloud_org_id="guest"}`
 	if strings.Contains(metricsText, wrongMetric) {
 		t.Fatalf("shared status request metric used guest org %q", wrongMetric)
 	}

--- a/pkg/server/eventbus_test.go
+++ b/pkg/server/eventbus_test.go
@@ -81,8 +81,8 @@ func TestEventBusSetMetricOrgIDMovesInFlightGauge(t *testing.T) {
 	rec := httptest.NewRecorder()
 	metrics.WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_sse_inflight_connections{tenant_id="`+tenantID+`",tidbcloud_org_id="guest"} 0.000000`) {
-		t.Fatalf("old guest in-flight series was not zeroed:\n%s", text)
+	if strings.Contains(text, `drive9_sse_inflight_connections{tenant_id="`+tenantID+`",tidbcloud_org_id="guest"}`) {
+		t.Fatalf("old guest in-flight series was not deleted:\n%s", text)
 	}
 	if !strings.Contains(text, `drive9_sse_inflight_connections{tenant_id="`+tenantID+`",tidbcloud_org_id="org-eventbus-relabel"} 1.000000`) {
 		t.Fatalf("new org in-flight series was not recorded:\n%s", text)

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -644,7 +644,7 @@ func (s *Server) provisionForkTenantOnceWithCredentials(ctx context.Context, for
 	if err := s.finalizeTenantSchemaInit(ctx, forkID, dsn, forkTenant.Provider); err != nil {
 		return err
 	}
-	store, err := datastore.Open(dsn)
+	store, err := datastore.OpenForTenant(ctx, dsn, forkID)
 	if err != nil {
 		return err
 	}
@@ -1077,7 +1077,7 @@ func (s *Server) openTenantStore(ctx context.Context, t *meta.Tenant) (*datastor
 	if err != nil {
 		return nil, err
 	}
-	return datastore.Open(tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS, t.Provider))
+	return datastore.OpenForTenant(ctx, tenantDSN(t.DBUser, string(plain), t.DBHost, t.DBPort, t.DBName, t.DBTLS, t.Provider), t.ID)
 }
 
 func (s *Server) enqueueForkFileGCTaskRefs(ctx context.Context, t *meta.Tenant, store *datastore.Store) error {

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -1021,6 +1021,7 @@ func (s *Server) cleanupForkTenantOnce(ctx context.Context, tenantID string, cre
 			if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantDeleted); err != nil {
 				return fmt.Errorf("mark fork deleted: %w", err)
 			}
+			s.broadcastTenantMetricsCleanup(tenantID)
 		}
 		return nil
 	}
@@ -1056,6 +1057,7 @@ func (s *Server) cleanupForkTenantOnce(ctx context.Context, tenantID string, cre
 	if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantDeleted); err != nil {
 		return fmt.Errorf("mark fork deleted: %w", err)
 	}
+	s.broadcastTenantMetricsCleanup(tenantID)
 	return nil
 }
 
@@ -1066,6 +1068,7 @@ func (s *Server) cleanupFailedForkBranch(ctx context.Context, t *meta.Tenant, cr
 	if err := s.meta.UpdateTenantStatus(ctx, t.ID, meta.TenantDeleted); err != nil {
 		return fmt.Errorf("mark failed fork deleted: %w", err)
 	}
+	s.broadcastTenantMetricsCleanup(t.ID)
 	return nil
 }
 

--- a/pkg/server/fork.go
+++ b/pkg/server/fork.go
@@ -1021,7 +1021,7 @@ func (s *Server) cleanupForkTenantOnce(ctx context.Context, tenantID string, cre
 			if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantDeleted); err != nil {
 				return fmt.Errorf("mark fork deleted: %w", err)
 			}
-			s.broadcastTenantMetricsCleanup(tenantID)
+			s.clearLocalTenantMetrics(tenantID)
 		}
 		return nil
 	}
@@ -1057,7 +1057,7 @@ func (s *Server) cleanupForkTenantOnce(ctx context.Context, tenantID string, cre
 	if err := s.meta.UpdateTenantStatus(ctx, tenantID, meta.TenantDeleted); err != nil {
 		return fmt.Errorf("mark fork deleted: %w", err)
 	}
-	s.broadcastTenantMetricsCleanup(tenantID)
+	s.clearLocalTenantMetrics(tenantID)
 	return nil
 }
 
@@ -1068,7 +1068,7 @@ func (s *Server) cleanupFailedForkBranch(ctx context.Context, t *meta.Tenant, cr
 	if err := s.meta.UpdateTenantStatus(ctx, t.ID, meta.TenantDeleted); err != nil {
 		return fmt.Errorf("mark failed fork deleted: %w", err)
 	}
-	s.broadcastTenantMetricsCleanup(t.ID)
+	s.clearLocalTenantMetrics(t.ID)
 	return nil
 }
 

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -392,7 +392,8 @@ func (m *serverMetrics) adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, 
 }
 
 func tenantInFlightKey(tenantID, tidbCloudOrgID, surface, action string) string {
-	return tenantID + "\x00" + tidbCloudOrgID + "\x00" + surface + "\x00" + action
+	_ = action
+	return tenantID + "\x00" + tidbCloudOrgID + "\x00" + surface
 }
 
 type observedResponseWriter struct {

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -224,6 +224,17 @@ func setRequestMetricTenant(ctx context.Context, tenantID, apiKeyID, provider, t
 	}
 }
 
+// setRequestMetricTenantForAuthStatus scopes tenant request metrics only after
+// the auth path has established that the tenant is active. Rejected
+// deleting/deleted requests must not recreate series removed by lifecycle
+// cleanup outbox delivery.
+func setRequestMetricTenantForAuthStatus(ctx context.Context, tenantID, apiKeyID, provider, tidbCloudOrgID string, status meta.TenantStatus, class tenantRequestClass) {
+	if status != meta.TenantActive {
+		return
+	}
+	setRequestMetricTenant(ctx, tenantID, apiKeyID, provider, tidbCloudOrgID, class)
+}
+
 func requestMetricScope(ctx context.Context) (tenantID, apiKeyID, provider, tidbCloudOrgID string) {
 	state := requestMetricStateFromContext(ctx)
 	if state == nil {

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -184,29 +184,28 @@ func setRequestMetricTenant(ctx context.Context, tenantID, apiKeyID, provider, t
 		action = "other"
 	}
 
-	var oldTenantID, oldTiDBCloudOrgID, oldSurface, oldAction string
+	var oldTenantID, oldTiDBCloudOrgID, oldSurface string
 	var shouldMove bool
 	state.mu.Lock()
 	if state.tenantInFlight {
-		shouldMove = state.tenantID != tenantID || state.tidbCloudOrgID != tidbCloudOrgID || state.surface != surface || state.action != action
+		shouldMove = state.tenantID != tenantID || state.tidbCloudOrgID != tidbCloudOrgID || state.surface != surface
 		if shouldMove {
 			oldTenantID = state.tenantID
 			oldTiDBCloudOrgID = state.tidbCloudOrgID
 			oldSurface = state.surface
-			oldAction = state.action
 			state.tidbCloudOrgID = tidbCloudOrgID
 			state.surface = surface
-			state.action = action
 		}
 		state.tenantID = tenantID
 		state.tidbCloudOrgID = tidbCloudOrgID
 		state.apiKeyID = apiKeyID
 		state.provider = provider
+		state.action = action
 		state.mu.Unlock()
 		if shouldMove {
 			if m := metricsFromContext(ctx); m != nil {
-				m.adjustTenantInFlight(oldTenantID, oldTiDBCloudOrgID, oldSurface, oldAction, -1)
-				m.adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, action, 1)
+				m.adjustTenantInFlight(oldTenantID, oldTiDBCloudOrgID, oldSurface, -1)
+				m.adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, 1)
 			}
 		}
 		return
@@ -221,7 +220,7 @@ func setRequestMetricTenant(ctx context.Context, tenantID, apiKeyID, provider, t
 	state.mu.Unlock()
 
 	if m := metricsFromContext(ctx); m != nil {
-		m.adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, action, 1)
+		m.adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, 1)
 	}
 }
 
@@ -288,12 +287,11 @@ func finishRequestMetricTenant(ctx context.Context) {
 	tenantID := state.tenantID
 	tidbCloudOrgID := state.tidbCloudOrgID
 	surface := state.surface
-	action := state.action
 	state.tenantInFlight = false
 	state.mu.Unlock()
 
 	if m := metricsFromContext(ctx); m != nil {
-		m.adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, action, -1)
+		m.adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, -1)
 	}
 }
 
@@ -362,7 +360,7 @@ func (m *serverMetrics) adjustRouteInFlight(route string, delta int64) int64 {
 	return next
 }
 
-func (m *serverMetrics) adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, action string, delta int64) int64 {
+func (m *serverMetrics) adjustTenantInFlight(tenantID, tidbCloudOrgID, surface string, delta int64) int64 {
 	tenantID = strings.TrimSpace(tenantID)
 	if tenantID == "" {
 		return 0
@@ -372,27 +370,22 @@ func (m *serverMetrics) adjustTenantInFlight(tenantID, tidbCloudOrgID, surface, 
 	if surface == "" {
 		surface = "other"
 	}
-	action = strings.TrimSpace(action)
-	if action == "" {
-		action = "other"
-	}
-	key := tenantInFlightKey(tenantID, tidbCloudOrgID, surface, action)
+	key := tenantInFlightKey(tenantID, tidbCloudOrgID, surface)
 
 	m.tenantMu.Lock()
 	defer m.tenantMu.Unlock()
 	next := m.tenantInFlight[key] + delta
 	if next <= 0 {
 		delete(m.tenantInFlight, key)
-		metrics.RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, surface, action, 0)
+		metrics.RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, surface, 0)
 		return 0
 	}
 	m.tenantInFlight[key] = next
-	metrics.RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, surface, action, float64(next))
+	metrics.RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, surface, float64(next))
 	return next
 }
 
-func tenantInFlightKey(tenantID, tidbCloudOrgID, surface, action string) string {
-	_ = action
+func tenantInFlightKey(tenantID, tidbCloudOrgID, surface string) string {
 	return tenantID + "\x00" + tidbCloudOrgID + "\x00" + surface
 }
 
@@ -667,29 +660,6 @@ func classifyS3Action(r *http.Request) string {
 	return strings.ToLower(r.Method)
 }
 
-func tenantRequestResult(status int) string {
-	switch {
-	case status >= 200 && status < 400:
-		return "ok"
-	case status == http.StatusUnauthorized:
-		return "unauthorized"
-	case status == http.StatusForbidden:
-		return "denied"
-	case status == http.StatusNotFound:
-		return "not_found"
-	case status == http.StatusConflict:
-		return "conflict"
-	case status == http.StatusInsufficientStorage || status == http.StatusTooManyRequests:
-		return "quota_or_rate_limited"
-	case status >= 400 && status < 500:
-		return "client_error"
-	case status >= 500:
-		return "server_error"
-	default:
-		return "unknown"
-	}
-}
-
 func requestTenantID(r *http.Request) string {
 	tenantID, _, _, _ := requestMetricScope(r.Context())
 	if tenantID != "" {
@@ -726,12 +696,12 @@ func recordTenantHTTPRequest(r *http.Request, status int, d time.Duration, respo
 	if scopedClass, ok := requestMetricClass(r.Context()); ok {
 		class = scopedClass
 	}
-	metrics.RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, class.surface, class.action, tenantRequestResult(status), status, d)
+	metrics.RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, class.surface, class.action, status, d)
 	if r.ContentLength > 0 {
-		metrics.RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, class.surface, class.action, "request", r.ContentLength)
+		metrics.RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, "request", r.ContentLength)
 	}
 	if responseBytes > 0 {
-		metrics.RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, class.surface, class.action, "response", int64(responseBytes))
+		metrics.RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, "response", int64(responseBytes))
 	}
 }
 
@@ -740,7 +710,7 @@ func recordTenantFileBytes(ctx context.Context, surface, action, direction strin
 	if tenantID == "" || bytes <= 0 {
 		return
 	}
-	metrics.RecordTenantFileBytesWithOrg(tenantID, tidbCloudOrgID, surface, action, direction, bytes)
+	metrics.RecordTenantFileBytesWithOrg(tenantID, tidbCloudOrgID, direction, bytes)
 }
 
 func generateTraceID() string { return traceid.Generate() }

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -3,8 +3,13 @@ package server
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 func TestRequestRoute(t *testing.T) {
@@ -150,6 +155,34 @@ func TestSetRequestMetricTenantMovesInFlightLabel(t *testing.T) {
 	finishRequestMetricTenant(ctx)
 	if got := len(m.tenantInFlight); got != 0 {
 		t.Fatalf("tenant in-flight map size after finish = %d, want 0", got)
+	}
+}
+
+func TestSetRequestMetricTenantForAuthStatusOnlyScopesActiveTenants(t *testing.T) {
+	for _, status := range []meta.TenantStatus{meta.TenantDeleting, meta.TenantDeleted, meta.TenantSuspended} {
+		t.Run(string(status), func(t *testing.T) {
+			const tenantID = "tenant-auth-status-metrics"
+			metrics.DeleteTenantCounters(tenantID)
+			t.Cleanup(func() { metrics.DeleteTenantCounters(tenantID) })
+			ctx := withRequestMetricState(context.Background(), &requestMetricState{})
+			setRequestMetricTenantForAuthStatus(ctx, tenantID, "key", "db9", "org", status, tenantRequestClass{surface: "api", action: "read"})
+			if tenantID, _, _, _ := requestMetricScope(ctx); tenantID != "" {
+				t.Fatalf("tenant metric scope = %q for status %q, want empty", tenantID, status)
+			}
+			req := httptest.NewRequest(http.MethodGet, "http://example.test/v1/fs/stale", nil).WithContext(ctx)
+			recordTenantHTTPRequest(req, http.StatusForbidden, 0, 0)
+			recorder := httptest.NewRecorder()
+			metrics.WritePrometheus(recorder)
+			if strings.Contains(recorder.Body.String(), `tenant_id="`+tenantID+`"`) {
+				t.Fatalf("rejected %s request recreated tenant metrics:\n%s", status, recorder.Body.String())
+			}
+		})
+	}
+
+	ctx := withRequestMetricState(context.Background(), &requestMetricState{})
+	setRequestMetricTenantForAuthStatus(ctx, "tenant-active", "key", "db9", "org", meta.TenantActive, tenantRequestClass{surface: "api", action: "read"})
+	if tenantID, _, _, _ := requestMetricScope(ctx); tenantID != "tenant-active" {
+		t.Fatalf("tenant metric scope = %q, want tenant-active", tenantID)
 	}
 }
 

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -153,6 +153,22 @@ func TestSetRequestMetricTenantMovesInFlightLabel(t *testing.T) {
 	}
 }
 
+func TestAdjustTenantInFlightAggregatesActionsForSameSurface(t *testing.T) {
+	m := newServerMetrics()
+	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", "read", 1); got != 1 {
+		t.Fatalf("read increment = %d, want 1", got)
+	}
+	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", "write", 1); got != 2 {
+		t.Fatalf("write increment = %d, want aggregate 2", got)
+	}
+	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", "read", -1); got != 1 {
+		t.Fatalf("read decrement = %d, want aggregate 1", got)
+	}
+	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", "write", -1); got != 0 {
+		t.Fatalf("write decrement = %d, want 0", got)
+	}
+}
+
 func TestEventFieldsDoesNotDuplicateExplicitTiDBCloudOrgID(t *testing.T) {
 	ctx := withRequestMetricState(context.Background(), &requestMetricState{})
 	setRequestMetricTenant(ctx, "tenant-a", "", "", "org-request", tenantRequestClass{surface: "status", action: "get"})

--- a/pkg/server/instrumentation_test.go
+++ b/pkg/server/instrumentation_test.go
@@ -135,15 +135,15 @@ func TestSetRequestMetricTenantMovesInFlightLabel(t *testing.T) {
 	class := tenantRequestClass{surface: "object_store", action: "upload_part"}
 
 	setRequestMetricTenant(ctx, "local", "", "", "", class)
-	if got := m.tenantInFlight[tenantInFlightKey("local", defaultTenantMetricTiDBCloudOrgID, "object_store", "upload_part")]; got != 1 {
+	if got := m.tenantInFlight[tenantInFlightKey("local", defaultTenantMetricTiDBCloudOrgID, "object_store")]; got != 1 {
 		t.Fatalf("local in-flight = %d, want 1", got)
 	}
 
 	setRequestMetricTenant(ctx, "tenant-a", "", "", "org-a", class)
-	if got := m.tenantInFlight[tenantInFlightKey("local", defaultTenantMetricTiDBCloudOrgID, "object_store", "upload_part")]; got != 0 {
+	if got := m.tenantInFlight[tenantInFlightKey("local", defaultTenantMetricTiDBCloudOrgID, "object_store")]; got != 0 {
 		t.Fatalf("local in-flight after move = %d, want 0", got)
 	}
-	if got := m.tenantInFlight[tenantInFlightKey("tenant-a", "org-a", "object_store", "upload_part")]; got != 1 {
+	if got := m.tenantInFlight[tenantInFlightKey("tenant-a", "org-a", "object_store")]; got != 1 {
 		t.Fatalf("tenant-a in-flight = %d, want 1", got)
 	}
 
@@ -155,16 +155,16 @@ func TestSetRequestMetricTenantMovesInFlightLabel(t *testing.T) {
 
 func TestAdjustTenantInFlightAggregatesActionsForSameSurface(t *testing.T) {
 	m := newServerMetrics()
-	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", "read", 1); got != 1 {
+	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", 1); got != 1 {
 		t.Fatalf("read increment = %d, want 1", got)
 	}
-	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", "write", 1); got != 2 {
+	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", 1); got != 2 {
 		t.Fatalf("write increment = %d, want aggregate 2", got)
 	}
-	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", "read", -1); got != 1 {
+	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", -1); got != 1 {
 		t.Fatalf("read decrement = %d, want aggregate 1", got)
 	}
-	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", "write", -1); got != 0 {
+	if got := m.adjustTenantInFlight("tenant-inflight-actions", "org-inflight-actions", "fs", -1); got != 0 {
 		t.Fatalf("write decrement = %d, want 0", got)
 	}
 }

--- a/pkg/server/managed_shared_db_failed_cleanup.go
+++ b/pkg/server/managed_shared_db_failed_cleanup.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"go.uber.org/zap"
 )
@@ -30,6 +31,7 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 	}
 	rows, err := s.meta.ListSharedDBsByStatusAfter(ctx, meta.SharedDBStatusFailed, s.managedSharedDBFailedCleanupCursor, batchSize)
 	if err != nil {
+		metrics.RecordSharedDBPoolCleanup("list_pools", metrics.ResultForError(err))
 		logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_list_failed", zap.Error(err))
 		return
 	}
@@ -37,6 +39,7 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 		s.managedSharedDBFailedCleanupCursor = 0
 		rows, err = s.meta.ListSharedDBsByStatusAfter(ctx, meta.SharedDBStatusFailed, 0, batchSize)
 		if err != nil {
+			metrics.RecordSharedDBPoolCleanup("list_pools", metrics.ResultForError(err))
 			logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_list_failed", zap.Error(err))
 			return
 		}
@@ -50,18 +53,23 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 		candidates, listErr := s.meta.ListFailedSharedTenantCleanupCandidatesByDB(
 			ctx, row.ID, cutoff, tenantFailedCleanupSharedBatchSize)
 		if listErr != nil {
+			metrics.RecordSharedDBPoolCleanup("list_tenants", metrics.ResultForError(listErr))
 			logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_tenant_list_failed",
 				zap.Int64("db_pool_id", row.ID), zap.Error(listErr))
 			continue
 		}
 		for i := range candidates {
 			if _, cleanupErr := s.cleanupFailedSharedTenant(ctx, row.TiDBCloudOrganizationID, cutoff, &candidates[i]); cleanupErr != nil {
+				metrics.RecordSharedDBPoolCleanup("tenant", metrics.ResultForError(cleanupErr))
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_tenant_failed",
 					zap.Int64("db_pool_id", row.ID), zap.String("tenant_id", candidates[i].ID), zap.Error(cleanupErr))
+			} else {
+				metrics.RecordSharedDBPoolCleanup("tenant", "ok")
 			}
 		}
 		current, loadErr := s.meta.GetSharedDB(ctx, row.ID)
 		if loadErr != nil {
+			metrics.RecordSharedDBPoolCleanup("reload", metrics.ResultForError(loadErr))
 			if !errors.Is(loadErr, meta.ErrNotFound) {
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_reload_failed", zap.Int64("db_pool_id", row.ID), zap.Error(loadErr))
 			}
@@ -73,6 +81,7 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 		if current.TenantCount != 0 {
 			repaired, repairErr := s.meta.RepairFailedSharedDBPoolTenantCountIfEmpty(ctx, row.ID)
 			if repairErr != nil {
+				metrics.RecordSharedDBPoolCleanup("repair_count", metrics.ResultForError(repairErr))
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_count_repair_failed",
 					zap.Int64("db_pool_id", row.ID), zap.Int("tenant_count", current.TenantCount), zap.Error(repairErr))
 				continue
@@ -80,6 +89,7 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 			if !repaired {
 				continue
 			}
+			metrics.RecordSharedDBPoolCleanup("repair_count", "ok")
 			logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_count_repaired",
 				zap.Int64("db_pool_id", row.ID), zap.Int("previous_tenant_count", current.TenantCount))
 			current, loadErr = s.meta.GetSharedDB(ctx, row.ID)
@@ -93,6 +103,7 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 		persistedClusterID := strings.TrimSpace(current.ClusterID)
 		cred, credErr := s.sharedDBCloudCredentials()
 		if credErr != nil {
+			metrics.RecordSharedDBPoolCleanup("credentials", metrics.ResultForError(credErr))
 			logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_credentials_failed", zap.Int64("db_pool_id", row.ID), zap.Error(credErr))
 			continue
 		}
@@ -100,6 +111,7 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 		if lister, ok := s.provisioner.(tenant.SharedDBPoolLister); ok {
 			discovered, discoverErr := lister.ListSharedDBPoolsWithCredentials(ctx, row.ID, row.UUID, cred)
 			if discoverErr != nil {
+				metrics.RecordSharedDBPoolCleanup("discovery", metrics.ResultForError(discoverErr))
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_discovery_failed", zap.Int64("db_pool_id", row.ID), zap.Error(discoverErr))
 				continue
 			}
@@ -111,11 +123,13 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 		} else if persistedClusterID == "" {
 			loader, ok := s.provisioner.(managedSharedDBPoolLoader)
 			if !ok {
+				metrics.RecordSharedDBPoolCleanup("discovery", "unsupported")
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_discovery_unsupported", zap.Int64("db_pool_id", row.ID))
 				continue
 			}
 			discovered, discoverErr := loader.LoadSharedDBPoolWithCredentials(ctx, row.ID, row.UUID, "", cred)
 			if discoverErr != nil {
+				metrics.RecordSharedDBPoolCleanup("discovery", metrics.ResultForError(discoverErr))
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_discovery_failed", zap.Int64("db_pool_id", row.ID), zap.Error(discoverErr))
 				continue
 			}
@@ -138,6 +152,7 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 		if len(uniqueClusterIDs) > 0 {
 			deprovisioner, ok := s.provisioner.(tenant.CredentialDeprovisioner)
 			if !ok {
+				metrics.RecordSharedDBPoolCleanup("deprovision", "unsupported")
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_deprovision_unsupported", zap.Int64("db_pool_id", row.ID))
 				continue
 			}
@@ -148,24 +163,38 @@ func (s *Server) cleanupFailedManagedSharedDBPoolsWithCtx(ctx context.Context) {
 				}
 			}
 			if deprovisionErr != nil {
+				metrics.RecordSharedDBPoolCleanup("deprovision", metrics.ResultForError(deprovisionErr))
 				logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_deprovision_failed", zap.Int64("db_pool_id", row.ID), zap.Error(deprovisionErr))
 				continue
 			}
+			metrics.RecordSharedDBPoolCleanup("deprovision", "ok")
 			if persistedClusterID != "" {
 				cleared, clearErr := s.meta.ClearFailedSharedDBPoolClusterID(ctx, row.ID, persistedClusterID)
 				if clearErr != nil || !cleared {
+					result := metrics.ResultForError(clearErr)
+					if clearErr == nil {
+						result = "not_cleared"
+					}
+					metrics.RecordSharedDBPoolCleanup("clear_cluster", result)
 					logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_clear_cluster_failed",
 						zap.Int64("db_pool_id", row.ID), zap.Bool("cleared", cleared), zap.Error(clearErr))
 					continue
 				}
+				metrics.RecordSharedDBPoolCleanup("clear_cluster", "ok")
 			}
 		}
 		deleted, deleteErr := s.meta.DeleteFailedSharedDBPoolIfEmpty(ctx, row.ID)
 		if deleteErr != nil || !deleted {
+			result := metrics.ResultForError(deleteErr)
+			if deleteErr == nil {
+				result = "not_deleted"
+			}
+			metrics.RecordSharedDBPoolCleanup("delete_pool", result)
 			logger.Warn(ctx, "managed_shared_db_pool_failed_cleanup_delete_failed",
 				zap.Int64("db_pool_id", row.ID), zap.Bool("deleted", deleted), zap.Error(deleteErr))
 			continue
 		}
+		metrics.RecordSharedDBPoolCleanup("delete_pool", "ok")
 		logger.Info(ctx, "managed_shared_db_pool_failed_cleanup_done", zap.Int64("db_pool_id", row.ID), zap.String("db_pool_uuid", row.UUID))
 	}
 }

--- a/pkg/server/notify_coalescer.go
+++ b/pkg/server/notify_coalescer.go
@@ -37,7 +37,7 @@ const tenantNotifyFlushRetryBackoff = 100 * time.Millisecond
 //   - Poller cursor semantics (id > cursor ORDER BY id) are unaffected
 //     because each batch INSERT commits all of its rows atomically.
 //   - A failed flush retries the batch once, then falls back to independent
-//     per-row inserts; a row that still fails is logged and dropped. The
+//     per-row inserts; a row that still fails is logged and re-queued. The
 //     5-minute safety-net scan backstops only semantic/file_gc work — it
 //     never reads tenant_notify_outbox — so SSE cross-pod delivery relies on
 //     this retry → per-row fallback. Residual signal loss occurs only under
@@ -57,8 +57,10 @@ type tenantNotifyCoalescer struct {
 	// batch that will never flush.
 	stopped bool
 
-	mu      sync.Mutex
-	pending map[string]int // tenantID → OR-merged work_mask
+	flushMu  sync.Mutex // serializes periodic, shutdown, and test-triggered flushes
+	mu       sync.Mutex
+	pending  map[string]int // tenantID → OR-merged work_mask
+	inFlight map[string]int // batch swapped out but not yet durably inserted
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -98,7 +100,7 @@ func (c *tenantNotifyCoalescer) add(tenantID string, workMask int) {
 		return
 	}
 	c.pending[tenantID] |= workMask
-	pending := len(c.pending)
+	pending := c.pendingCountLocked()
 	c.mu.Unlock()
 	metrics.RecordNotifyCoalescerPending(pending)
 }
@@ -140,6 +142,8 @@ func (c *tenantNotifyCoalescer) stop() {
 // inserted individually, so a metadb hiccup degrades to roughly the
 // pre-coalescer per-event behavior instead of dropping the whole window.
 func (c *tenantNotifyCoalescer) flush(ctx context.Context) {
+	c.flushMu.Lock()
+	defer c.flushMu.Unlock()
 	c.mu.Lock()
 	if len(c.pending) == 0 {
 		c.mu.Unlock()
@@ -147,8 +151,10 @@ func (c *tenantNotifyCoalescer) flush(ctx context.Context) {
 	}
 	batch := c.pending
 	c.pending = make(map[string]int)
+	c.inFlight = batch
+	pending := c.pendingCountLocked()
 	c.mu.Unlock()
-	metrics.RecordNotifyCoalescerPending(0)
+	metrics.RecordNotifyCoalescerPending(pending)
 
 	entries := make([]meta.TenantNotifyEntry, 0, len(batch))
 	for tenantID, workMask := range batch {
@@ -156,6 +162,7 @@ func (c *tenantNotifyCoalescer) flush(ctx context.Context) {
 	}
 	if err := c.insertBatch(ctx, entries); err == nil {
 		metrics.RecordNotifyCoalescerFlush("ok", len(entries))
+		c.finishFlush(nil)
 		return
 	} else {
 		logger.Warn(ctx, "tenant_notify_coalescer_flush_failed",
@@ -165,10 +172,11 @@ func (c *tenantNotifyCoalescer) flush(ctx context.Context) {
 	select {
 	case <-ctx.Done():
 		// No room for the batch retry; go straight to per-row inserts (they
-		// fail fast on the cancelled context and are dropped per row).
+		// fail fast on the cancelled context and are re-queued per row).
 	case <-time.After(tenantNotifyFlushRetryBackoff):
 		if err := c.insertBatch(ctx, entries); err == nil {
 			metrics.RecordNotifyCoalescerFlush("retry_ok", len(entries))
+			c.finishFlush(nil)
 			return
 		} else {
 			logger.Warn(ctx, "tenant_notify_coalescer_flush_retry_failed",
@@ -177,15 +185,17 @@ func (c *tenantNotifyCoalescer) flush(ctx context.Context) {
 		}
 	}
 	metrics.RecordNotifyCoalescerFlush("fallback", len(entries))
-	c.insertPerRow(ctx, entries)
+	c.finishFlush(c.insertPerRow(ctx, entries))
 }
 
-// insertPerRow delivers each entry independently; a failing row is logged
-// and dropped without affecting the rest.
-func (c *tenantNotifyCoalescer) insertPerRow(ctx context.Context, entries []meta.TenantNotifyEntry) {
+// insertPerRow delivers each entry independently and returns rows that still
+// failed so the caller can merge them back into the next pending batch.
+func (c *tenantNotifyCoalescer) insertPerRow(ctx context.Context, entries []meta.TenantNotifyEntry) []meta.TenantNotifyEntry {
+	failed := make([]meta.TenantNotifyEntry, 0)
 	for _, e := range entries {
 		if err := c.insertSingle(ctx, e.TenantID, e.WorkMask); err != nil {
 			metrics.RecordNotifyCoalescerPerRowFallback("error")
+			failed = append(failed, e)
 			logger.Warn(ctx, "tenant_notify_coalescer_row_insert_failed",
 				zap.String("tenant_id", e.TenantID),
 				zap.Int("work_mask", e.WorkMask),
@@ -194,4 +204,26 @@ func (c *tenantNotifyCoalescer) insertPerRow(ctx context.Context, entries []meta
 			metrics.RecordNotifyCoalescerPerRowFallback("ok")
 		}
 	}
+	return failed
+}
+
+func (c *tenantNotifyCoalescer) finishFlush(failed []meta.TenantNotifyEntry) {
+	c.mu.Lock()
+	for _, e := range failed {
+		c.pending[e.TenantID] |= e.WorkMask
+	}
+	c.inFlight = nil
+	pending := c.pendingCountLocked()
+	c.mu.Unlock()
+	metrics.RecordNotifyCoalescerPending(pending)
+}
+
+func (c *tenantNotifyCoalescer) pendingCountLocked() int {
+	count := len(c.inFlight)
+	for tenantID := range c.pending {
+		if _, exists := c.inFlight[tenantID]; !exists {
+			count++
+		}
+	}
+	return count
 }

--- a/pkg/server/notify_coalescer.go
+++ b/pkg/server/notify_coalescer.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 // defaultTenantNotifyFlushInterval is how often the coalescer flushes merged
@@ -97,7 +98,9 @@ func (c *tenantNotifyCoalescer) add(tenantID string, workMask int) {
 		return
 	}
 	c.pending[tenantID] |= workMask
+	pending := len(c.pending)
 	c.mu.Unlock()
+	metrics.RecordNotifyCoalescerPending(pending)
 }
 
 func (c *tenantNotifyCoalescer) run(ctx context.Context) {
@@ -145,12 +148,14 @@ func (c *tenantNotifyCoalescer) flush(ctx context.Context) {
 	batch := c.pending
 	c.pending = make(map[string]int)
 	c.mu.Unlock()
+	metrics.RecordNotifyCoalescerPending(0)
 
 	entries := make([]meta.TenantNotifyEntry, 0, len(batch))
 	for tenantID, workMask := range batch {
 		entries = append(entries, meta.TenantNotifyEntry{TenantID: tenantID, WorkMask: workMask})
 	}
 	if err := c.insertBatch(ctx, entries); err == nil {
+		metrics.RecordNotifyCoalescerFlush("ok", len(entries))
 		return
 	} else {
 		logger.Warn(ctx, "tenant_notify_coalescer_flush_failed",
@@ -163,6 +168,7 @@ func (c *tenantNotifyCoalescer) flush(ctx context.Context) {
 		// fail fast on the cancelled context and are dropped per row).
 	case <-time.After(tenantNotifyFlushRetryBackoff):
 		if err := c.insertBatch(ctx, entries); err == nil {
+			metrics.RecordNotifyCoalescerFlush("retry_ok", len(entries))
 			return
 		} else {
 			logger.Warn(ctx, "tenant_notify_coalescer_flush_retry_failed",
@@ -170,6 +176,7 @@ func (c *tenantNotifyCoalescer) flush(ctx context.Context) {
 				zap.Error(err))
 		}
 	}
+	metrics.RecordNotifyCoalescerFlush("fallback", len(entries))
 	c.insertPerRow(ctx, entries)
 }
 
@@ -178,10 +185,13 @@ func (c *tenantNotifyCoalescer) flush(ctx context.Context) {
 func (c *tenantNotifyCoalescer) insertPerRow(ctx context.Context, entries []meta.TenantNotifyEntry) {
 	for _, e := range entries {
 		if err := c.insertSingle(ctx, e.TenantID, e.WorkMask); err != nil {
+			metrics.RecordNotifyCoalescerPerRowFallback("error")
 			logger.Warn(ctx, "tenant_notify_coalescer_row_insert_failed",
 				zap.String("tenant_id", e.TenantID),
 				zap.Int("work_mask", e.WorkMask),
 				zap.Error(err))
+		} else {
+			metrics.RecordNotifyCoalescerPerRowFallback("ok")
 		}
 	}
 }

--- a/pkg/server/notify_coalescer_test.go
+++ b/pkg/server/notify_coalescer_test.go
@@ -4,11 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 )
 
 type recordingNotifyInserter struct {
@@ -186,6 +189,19 @@ func TestTenantNotifyCoalescerFlushFailureFallsBackToPerRow(t *testing.T) {
 	}
 	if calls := rec.recorded(); len(calls) != 2 {
 		t.Fatalf("batch insert calls after fallback = %d, want 2 (dropped rows are not replayed)", len(calls))
+	}
+	metricRec := httptest.NewRecorder()
+	metrics.WritePrometheus(metricRec)
+	metricText := metricRec.Body.String()
+	for _, want := range []string{
+		`drive9_notify_coalescer_flush_total{result="fallback"}`,
+		`drive9_notify_coalescer_per_row_fallback_total{result="ok"}`,
+		`drive9_notify_coalescer_per_row_fallback_total{result="error"}`,
+		`drive9_notify_coalescer_pending 0.000000`,
+	} {
+		if !strings.Contains(metricText, want) {
+			t.Fatalf("missing notify coalescer metric %q: %s", want, metricText)
+		}
 	}
 }
 

--- a/pkg/server/notify_coalescer_test.go
+++ b/pkg/server/notify_coalescer_test.go
@@ -57,6 +57,17 @@ type flakyBatchInserter struct {
 	calls [][]meta.TenantNotifyEntry
 }
 
+type blockingBatchInserter struct {
+	started chan struct{}
+	release chan struct{}
+}
+
+func (b *blockingBatchInserter) insert(context.Context, []meta.TenantNotifyEntry) error {
+	close(b.started)
+	<-b.release
+	return nil
+}
+
 func (f *flakyBatchInserter) insert(ctx context.Context, entries []meta.TenantNotifyEntry) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -158,7 +169,7 @@ func TestTenantNotifyCoalescerFlushRetriesBatchOnce(t *testing.T) {
 }
 
 // The batch path fails twice: every entry is delivered through independent
-// per-row inserts, and a failing row is dropped without affecting the rest.
+// per-row inserts, and a failing row remains pending for the next flush.
 func TestTenantNotifyCoalescerFlushFailureFallsBackToPerRow(t *testing.T) {
 	rec := &recordingNotifyInserter{
 		err:       errors.New("meta down"),
@@ -169,8 +180,6 @@ func TestTenantNotifyCoalescerFlushFailureFallsBackToPerRow(t *testing.T) {
 	c.add("tenant-a", 1)
 	c.add("tenant-b", 2)
 	c.flush(context.Background()) // batch fails twice -> per-row fallback
-	rec.err = nil
-	c.flush(context.Background()) // nothing pending anymore
 
 	calls := rec.recorded()
 	if len(calls) != 2 {
@@ -187,9 +196,6 @@ func TestTenantNotifyCoalescerFlushFailureFallsBackToPerRow(t *testing.T) {
 	if got["tenant-a"] != 1 || got["tenant-b"] != 2 {
 		t.Fatalf("per-row entries = %v, want tenant-a=1 and tenant-b=2", got)
 	}
-	if calls := rec.recorded(); len(calls) != 2 {
-		t.Fatalf("batch insert calls after fallback = %d, want 2 (dropped rows are not replayed)", len(calls))
-	}
 	metricRec := httptest.NewRecorder()
 	metrics.WritePrometheus(metricRec)
 	metricText := metricRec.Body.String()
@@ -197,12 +203,46 @@ func TestTenantNotifyCoalescerFlushFailureFallsBackToPerRow(t *testing.T) {
 		`drive9_notify_coalescer_flush_total{result="fallback"}`,
 		`drive9_notify_coalescer_per_row_fallback_total{result="ok"}`,
 		`drive9_notify_coalescer_per_row_fallback_total{result="error"}`,
-		`drive9_notify_coalescer_pending 0.000000`,
+		`drive9_notify_coalescer_pending 1.000000`,
 	} {
 		if !strings.Contains(metricText, want) {
 			t.Fatalf("missing notify coalescer metric %q: %s", want, metricText)
 		}
 	}
+
+	rec.err = nil
+	rec.singleErr = nil
+	c.flush(context.Background())
+	calls = rec.recorded()
+	if len(calls) != 3 || len(calls[2]) != 1 || calls[2][0].TenantID != "tenant-b" || calls[2][0].WorkMask != 2 {
+		t.Fatalf("retried batch calls = %+v, want third batch with tenant-b mask 2", calls)
+	}
+	metricRec = httptest.NewRecorder()
+	metrics.WritePrometheus(metricRec)
+	if !strings.Contains(metricRec.Body.String(), `drive9_notify_coalescer_pending 0.000000`) {
+		t.Fatalf("pending gauge did not clear after retry success: %s", metricRec.Body.String())
+	}
+}
+
+func TestTenantNotifyCoalescerPendingIncludesInflightFlush(t *testing.T) {
+	blocker := &blockingBatchInserter{started: make(chan struct{}), release: make(chan struct{})}
+	rec := &recordingNotifyInserter{}
+	c := newTenantNotifyCoalescer(blocker.insert, rec.insertSingle, time.Minute)
+	c.add("tenant-inflight", 1)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c.flush(context.Background())
+	}()
+	<-blocker.started
+
+	metricRec := httptest.NewRecorder()
+	metrics.WritePrometheus(metricRec)
+	if !strings.Contains(metricRec.Body.String(), `drive9_notify_coalescer_pending 1.000000`) {
+		t.Fatalf("in-flight flush disappeared from pending gauge: %s", metricRec.Body.String())
+	}
+	close(blocker.release)
+	<-done
 }
 
 func TestTenantNotifyCoalescerStopFlushesPending(t *testing.T) {

--- a/pkg/server/quota.go
+++ b/pkg/server/quota.go
@@ -418,19 +418,15 @@ func (s *Server) applyQuotaSet(ctx context.Context, metricPath string, t *meta.T
 	}
 	cloudCfg, err := updater.MarkQuotaUpdateStarted(ctx, clusterInfoFromTenant(t), cred)
 	if err != nil {
-		metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "mark_quota_update_started", "error")
 		return err
 	}
-	metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "mark_quota_update_started", "ok")
 	if req.TiDBCloudSpendingLimit != nil {
 		updatedCloudCfg, err := updater.UpdateQuota(ctx, clusterInfoFromTenant(t), cred, tenant.QuotaUpdateOptions{
 			TiDBCloudSpendingLimitMonthly: req.TiDBCloudSpendingLimit,
 		})
 		if err != nil {
-			metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "update_quota", "error")
 			return err
 		}
-		metrics.RecordTiDBCloudOpenAPIRequest(metricPath, "update_quota", "ok")
 		if cloudCfg == nil {
 			cloudCfg = updatedCloudCfg
 		} else if updatedCloudCfg != nil && updatedCloudCfg.TiDBCloudSpendingLimitMonthly != nil {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -421,6 +421,7 @@ func NewWithConfig(cfg Config) *Server {
 	if logger == nil {
 		logger, _ = zap.NewProduction()
 	}
+	metrics.SetFeatureEnabled("vault", len(cfg.VaultMasterKey) > 0)
 	metrics.SetModuleAvailability("vault", false)
 	var vaultMK *vault.MasterKey
 	if len(cfg.VaultMasterKey) > 0 {
@@ -792,6 +793,18 @@ func (s *Server) insertTenantNotify(tenantID string, workMask int) {
 			zap.Int("work_mask", workMask),
 			zap.Error(err))
 	}
+}
+
+// broadcastTenantMetricsCleanup immediately clears this process and emits a
+// durable lifecycle signal so every pod clears historical tenant-scoped
+// series. Callers must invoke this only after a deleting/deleted transition or
+// cleanup job has been durably committed.
+func (s *Server) broadcastTenantMetricsCleanup(tenantID string) {
+	if tenantID == "" {
+		return
+	}
+	metrics.DeleteTenantCounters(tenantID)
+	s.insertTenantNotify(tenantID, WorkMetricsCleanup)
 }
 
 // startNotifyInfrastructure launches the unified tenant outbox components

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -795,11 +795,11 @@ func (s *Server) insertTenantNotify(tenantID string, workMask int) {
 	}
 }
 
-// broadcastTenantMetricsCleanup immediately clears this process after a
+// clearLocalTenantMetrics immediately clears this process after a
 // deleting/deleted lifecycle transition. The meta-store transition writes the
 // WorkMetricsCleanup outbox row in the same transaction, so this helper must
 // not enqueue a second best-effort signal through the coalescer.
-func (s *Server) broadcastTenantMetricsCleanup(tenantID string) {
+func (s *Server) clearLocalTenantMetrics(tenantID string) {
 	if tenantID == "" {
 		return
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2063,13 +2063,13 @@ func (s *Server) handleTenantStatus(w http.ResponseWriter, r *http.Request) {
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
-	setRequestMetricTenant(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID, resolved.Tenant.Provider, resolved.TiDBCloudOrgID, classifyTenantRequest(r))
 	if resolved.APIKey.Status != meta.APIKeyActive {
 		metricEvent(r.Context(), "auth", "result", "key_inactive")
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_status_key_inactive", "tenant_id", resolved.Tenant.ID, "api_key_id", resolved.APIKey.ID, "status", resolved.APIKey.Status)...)
 		errJSON(w, http.StatusUnauthorized, "invalid API key")
 		return
 	}
+	setRequestMetricTenantForAuthStatus(r.Context(), resolved.Tenant.ID, resolved.APIKey.ID, resolved.Tenant.Provider, resolved.TiDBCloudOrgID, resolved.Tenant.Status, classifyTenantRequest(r))
 	plain, err := poolDecryptToken(r.Context(), s.pool, resolved.APIKey.JWTCiphertext)
 	if err != nil {
 		metricEvent(r.Context(), "auth", "result", "decrypt_failed")

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -292,7 +292,7 @@ type Server struct {
 	// Unified tenant outbox components. The tenantOutboxPoller reads the
 	// central tenant_notify_outbox table (in the always-provisioned meta DB)
 	// on every pod and dispatches by work_mask: SSE bits wake the local bus;
-	// semantic/file_gc/quota bits kick the tenantWorker on the shard owner.
+	// semantic/file_gc bits kick the tenantWorker on the shard owner.
 	// The shardResolver determines shard ownership via jump consistent hashing
 	// over the active pod ring. The podRegistry maintains this pod's presence
 	// and subscriber set in the central DB. All run on every pod (not
@@ -795,25 +795,24 @@ func (s *Server) insertTenantNotify(tenantID string, workMask int) {
 	}
 }
 
-// broadcastTenantMetricsCleanup immediately clears this process and emits a
-// durable lifecycle signal so every pod clears historical tenant-scoped
-// series. Callers must invoke this only after a deleting/deleted transition or
-// cleanup job has been durably committed.
+// broadcastTenantMetricsCleanup immediately clears this process after a
+// deleting/deleted lifecycle transition. The meta-store transition writes the
+// WorkMetricsCleanup outbox row in the same transaction, so this helper must
+// not enqueue a second best-effort signal through the coalescer.
 func (s *Server) broadcastTenantMetricsCleanup(tenantID string) {
 	if tenantID == "" {
 		return
 	}
 	metrics.DeleteTenantCounters(tenantID)
-	s.insertTenantNotify(tenantID, WorkMetricsCleanup)
 }
 
 // startNotifyInfrastructure launches the unified tenant outbox components
 // that run on every pod (not leader-gated):
 //   - shardResolver: refreshes the active pod ring for jump-consistent-hash
-//     shard ownership of semantic/file_gc/quota work.
+//     shard ownership of semantic/file_gc work.
 //   - tenantOutboxPoller: reads the central tenant_notify_outbox table at
 //     200ms intervals and dispatches by work_mask (SSE → wake local bus;
-//     semantic/file_gc/quota → kick tenantWorker on shard owner).
+//     semantic/file_gc → kick tenantWorker on shard owner).
 //   - podRegistry: maintains this pod's presence in pod_registry and reports
 //     its SSE subscriber tenant set to pod_subscriptions.
 //

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -21,11 +21,34 @@ import (
 	"github.com/mem9-ai/drive9/pkg/client"
 	"github.com/mem9-ai/drive9/pkg/datastore"
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/pathutil"
 	"github.com/mem9-ai/drive9/pkg/s3client"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
+
+func TestVaultMetricsDistinguishDisabledInvalidAndAvailable(t *testing.T) {
+	assertMetric := func(want string) {
+		t.Helper()
+		rec := httptest.NewRecorder()
+		metrics.WritePrometheus(rec)
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("missing metric %q:\n%s", want, rec.Body.String())
+		}
+	}
+
+	_ = NewWithConfig(Config{})
+	assertMetric(`drive9_feature_enabled{feature="vault"} 0.000000`)
+
+	_ = NewWithConfig(Config{VaultMasterKey: []byte("invalid")})
+	assertMetric(`drive9_feature_enabled{feature="vault"} 1.000000`)
+	assertMetric(`drive9_module_up{module="vault"} 0.000000`)
+
+	_ = NewWithConfig(Config{VaultMasterKey: make([]byte, 32)})
+	assertMetric(`drive9_feature_enabled{feature="vault"} 1.000000`)
+	assertMetric(`drive9_module_up{module="vault"} 1.000000`)
+}
 
 func newTestServer(t *testing.T) *Server {
 	return newTestServerWithLogger(t, nil)
@@ -2302,32 +2325,35 @@ func TestMetricsEndpoint(t *testing.T) {
 	if !strings.Contains(text, `drive9_db_pool_registered{role="user"`) {
 		t.Fatalf("expected user db pool metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_requests_total{action="write",result="ok",status_class="2xx",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="write",status_class="2xx",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Errorf("expected tenant request usage metric in response: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_request_duration_seconds_bucket{status_class="2xx",surface="fs",le="0.1"}`) {
 		t.Errorf("expected tenant request duration usage metric in response: %s", text)
 	}
-	if strings.Contains(text, `drive9_tenant_inflight_requests{action="read",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
+	if strings.Contains(text, `drive9_tenant_inflight_requests{surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Errorf("completed tenant in-flight usage metric should be removed: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_http_bytes_total{direction="request",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
+	if !strings.Contains(text, `drive9_tenant_http_bytes_total{direction="request",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Errorf("expected tenant HTTP byte metric in response: %s", text)
 	}
 	if strings.Contains(text, `drive9_tenant_http_bytes_total{action="`) {
 		t.Errorf("tenant HTTP byte metric should not carry action: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="write",direction="write",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
+	if !strings.Contains(text, `drive9_tenant_file_bytes_total{direction="write",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Fatalf("expected tenant file write byte metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_file_bytes_total{action="read",direction="read",surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
+	if !strings.Contains(text, `drive9_tenant_file_bytes_total{direction="read",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Fatalf("expected tenant file read byte metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="fs_write",result="ok",tenant_id="local",tidbcloud_org_id="guest"}`) {
-		t.Fatalf("expected fs_write tenant event metric in response: %s", text)
+	if !strings.Contains(text, `drive9_business_events_total{event="fs_write",result="ok"}`) {
+		t.Fatalf("expected aggregate fs_write event metric in response: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="fs_read",result="ok",tenant_id="local",tidbcloud_org_id="guest"}`) {
-		t.Fatalf("expected fs_read tenant event metric in response: %s", text)
+	if !strings.Contains(text, `drive9_business_events_total{event="fs_read",result="ok"}`) {
+		t.Fatalf("expected aggregate fs_read event metric in response: %s", text)
+	}
+	if strings.Contains(text, `drive9_business_events_total{event="fs_write",result="ok",tenant_id=`) {
+		t.Fatalf("fs_write event metric unexpectedly carries tenant labels: %s", text)
 	}
 	if !strings.Contains(text, `drive9_business_events_total{event="tenant_provision",result="error"}`) {
 		t.Fatalf("expected tenant_provision error metric in response: %s", text)
@@ -2425,13 +2451,13 @@ func TestUploadActionMetrics(t *testing.T) {
 	body, _ := io.ReadAll(metricsResp.Body)
 	text := string(body)
 
-	if !strings.Contains(text, `drive9_business_events_total{event="upload_complete",result="error",tenant_id="local",tidbcloud_org_id="guest"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_complete",result="error"}`) {
 		t.Fatalf("expected upload_complete metric, got: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="upload_resume",result="error",tenant_id="local",tidbcloud_org_id="guest"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_resume",result="error"}`) {
 		t.Fatalf("expected upload_resume metric, got: %s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="upload_abort",result="error",tenant_id="local",tidbcloud_org_id="guest"}`) {
+	if !strings.Contains(text, `drive9_business_events_total{event="upload_abort",result="error"}`) {
 		t.Fatalf("expected upload_abort metric, got: %s", text)
 	}
 }

--- a/pkg/server/sse.go
+++ b/pkg/server/sse.go
@@ -237,7 +237,6 @@ func (s *Server) publishEvent(r *http.Request, path, op string) {
 				zap.String("op", op),
 				zap.Error(err))
 			metrics.RecordTenantOperationWithOrg(bus.tenantID, bus.TiDBCloudOrgID(), "event_bus", "publish", metrics.ResultForError(err), 0)
-			metrics.RecordEventBusPublishErrorWithOrg(bus.tenantID, bus.TiDBCloudOrgID())
 		}
 	}
 

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -94,6 +94,7 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if hasJob {
+			s.broadcastTenantMetricsCleanup(t.ID)
 			_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
 			writeTenantDeleteStatus(w, meta.TenantDeleting)
 			return
@@ -230,6 +231,7 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 		return
 	}
 	if deleteJobExists && placement != nil && placement.Status == meta.PlacementStatusDeleting {
+		s.broadcastTenantMetricsCleanup(t.ID)
 		_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
 		writeStatus(w, meta.TenantDeleting)
 		return
@@ -252,6 +254,7 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 				return
 			}
 			if markDeleted {
+				s.broadcastTenantMetricsCleanup(t.ID)
 				_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
 				writeTenantDeleteStatus(w, meta.TenantDeleted)
 				return
@@ -280,6 +283,7 @@ func (s *Server) enqueueTenantDeleteJob(ctx context.Context, t *meta.Tenant) (me
 		if err := s.meta.MarkTenantDeleted(ctx, t.ID); err != nil {
 			return "", err
 		}
+		s.broadcastTenantMetricsCleanup(t.ID)
 		return meta.TenantDeleted, nil
 	}
 	ns, err := s.meta.GetStorageNamespace(ctx, t.StorageNamespaceID)
@@ -298,6 +302,7 @@ func (s *Server) enqueueTenantDeleteJob(ctx context.Context, t *meta.Tenant) (me
 	}); err != nil {
 		return "", err
 	}
+	s.broadcastTenantMetricsCleanup(t.ID)
 	return meta.TenantDeleting, nil
 }
 
@@ -390,5 +395,9 @@ func (s *Server) processTenantDeleteJob(ctx context.Context, job meta.TenantDele
 	if err != nil {
 		return err
 	}
-	return s.meta.FinalizeTenantDelete(ctx, job.TenantID, job.NamespaceID, res.DeletedObjects, res.AbortedMultipartUploads)
+	if err := s.meta.FinalizeTenantDelete(ctx, job.TenantID, job.NamespaceID, res.DeletedObjects, res.AbortedMultipartUploads); err != nil {
+		return err
+	}
+	s.broadcastTenantMetricsCleanup(job.TenantID)
+	return nil
 }

--- a/pkg/server/tenant_delete.go
+++ b/pkg/server/tenant_delete.go
@@ -94,7 +94,7 @@ func (s *Server) handleTenantDelete(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if hasJob {
-			s.broadcastTenantMetricsCleanup(t.ID)
+			s.clearLocalTenantMetrics(t.ID)
 			_ = s.meta.RevokeTenantAPIKeys(r.Context(), t.ID)
 			writeTenantDeleteStatus(w, meta.TenantDeleting)
 			return
@@ -231,7 +231,7 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 		return
 	}
 	if deleteJobExists && placement != nil && placement.Status == meta.PlacementStatusDeleting {
-		s.broadcastTenantMetricsCleanup(t.ID)
+		s.clearLocalTenantMetrics(t.ID)
 		_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
 		writeStatus(w, meta.TenantDeleting)
 		return
@@ -254,7 +254,7 @@ func (s *Server) handleSharedTenantDeleteWithStatusWriter(
 				return
 			}
 			if markDeleted {
-				s.broadcastTenantMetricsCleanup(t.ID)
+				s.clearLocalTenantMetrics(t.ID)
 				_ = s.meta.RevokeTenantAPIKeys(ctx, t.ID)
 				writeTenantDeleteStatus(w, meta.TenantDeleted)
 				return
@@ -283,7 +283,7 @@ func (s *Server) enqueueTenantDeleteJob(ctx context.Context, t *meta.Tenant) (me
 		if err := s.meta.MarkTenantDeleted(ctx, t.ID); err != nil {
 			return "", err
 		}
-		s.broadcastTenantMetricsCleanup(t.ID)
+		s.clearLocalTenantMetrics(t.ID)
 		return meta.TenantDeleted, nil
 	}
 	ns, err := s.meta.GetStorageNamespace(ctx, t.StorageNamespaceID)
@@ -302,7 +302,7 @@ func (s *Server) enqueueTenantDeleteJob(ctx context.Context, t *meta.Tenant) (me
 	}); err != nil {
 		return "", err
 	}
-	s.broadcastTenantMetricsCleanup(t.ID)
+	s.clearLocalTenantMetrics(t.ID)
 	return meta.TenantDeleting, nil
 }
 
@@ -398,6 +398,6 @@ func (s *Server) processTenantDeleteJob(ctx context.Context, job meta.TenantDele
 	if err := s.meta.FinalizeTenantDelete(ctx, job.TenantID, job.NamespaceID, res.DeletedObjects, res.AbortedMultipartUploads); err != nil {
 		return err
 	}
-	s.broadcastTenantMetricsCleanup(job.TenantID)
+	s.clearLocalTenantMetrics(job.TenantID)
 	return nil
 }

--- a/pkg/server/tenant_delete_test.go
+++ b/pkg/server/tenant_delete_test.go
@@ -264,7 +264,25 @@ func TestTenantDeleteNativeSucceedsWithCredentials(t *testing.T) {
 	if rt.prov.lastDeprovision == nil || rt.prov.lastDeprovision.ClusterID != "cluster-delete-1" {
 		t.Fatalf("deprovision cluster = %+v", rt.prov.lastDeprovision)
 	}
+	assertTenantMetricsCleanupNotify(t, rt)
 	assertTenantDeletedAndKeysRevoked(t, rt)
+}
+
+func assertTenantMetricsCleanupNotify(t *testing.T, rt *tenantDeleteRuntime) {
+	t.Helper()
+	if rt.server.notifyCoalescer != nil {
+		rt.server.notifyCoalescer.flush(context.Background())
+	}
+	rows, err := rt.meta.ListTenantNotifySince(context.Background(), 0, 100)
+	if err != nil {
+		t.Fatalf("list tenant cleanup notifications: %v", err)
+	}
+	for _, row := range rows {
+		if row.TenantID == rt.tenantID && row.WorkMask&WorkMetricsCleanup != 0 {
+			return
+		}
+	}
+	t.Fatalf("tenant %s has no metrics-cleanup outbox notification: %+v", rt.tenantID, rows)
 }
 
 func TestTenantDeleteNativeUsesServerDefaultCredentials(t *testing.T) {

--- a/pkg/server/tenant_failed_cleanup.go
+++ b/pkg/server/tenant_failed_cleanup.go
@@ -271,6 +271,7 @@ func (s *Server) cleanupFailedNativeTenantWithDependencies(
 	if err := s.meta.MarkTenantDeleted(ctx, tenantID); err != nil {
 		return true, fmt.Errorf("finalize_metadata: %w", err)
 	}
+	s.broadcastTenantMetricsCleanup(tenantID)
 	logger.Info(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_candidate_done",
 		"organization_id", organizationID,
 		"tenant_id", tenantID,
@@ -351,6 +352,7 @@ func (s *Server) cleanupFailedSharedTenant(
 		ctx, tenantID, fsID, placement.DbID, s.sharedDBReopenRatio, true); err != nil {
 		return true, fmt.Errorf("finalize_metadata: %w", err)
 	}
+	s.broadcastTenantMetricsCleanup(tenantID)
 	if err := s.meta.RevokeTenantAPIKeys(ctx, tenantID); err != nil {
 		logger.Warn(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_revoke_keys_failed",
 			"organization_id", organizationID,

--- a/pkg/server/tenant_failed_cleanup.go
+++ b/pkg/server/tenant_failed_cleanup.go
@@ -271,7 +271,7 @@ func (s *Server) cleanupFailedNativeTenantWithDependencies(
 	if err := s.meta.MarkTenantDeleted(ctx, tenantID); err != nil {
 		return true, fmt.Errorf("finalize_metadata: %w", err)
 	}
-	s.broadcastTenantMetricsCleanup(tenantID)
+	s.clearLocalTenantMetrics(tenantID)
 	logger.Info(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_candidate_done",
 		"organization_id", organizationID,
 		"tenant_id", tenantID,
@@ -352,7 +352,7 @@ func (s *Server) cleanupFailedSharedTenant(
 		ctx, tenantID, fsID, placement.DbID, s.sharedDBReopenRatio, true); err != nil {
 		return true, fmt.Errorf("finalize_metadata: %w", err)
 	}
-	s.broadcastTenantMetricsCleanup(tenantID)
+	s.clearLocalTenantMetrics(tenantID)
 	if err := s.meta.RevokeTenantAPIKeys(ctx, tenantID); err != nil {
 		logger.Warn(ctx, "server_event", eventFields(ctx, "tenant_failed_cleanup_revoke_keys_failed",
 			"organization_id", organizationID,

--- a/pkg/server/tenant_metrics.go
+++ b/pkg/server/tenant_metrics.go
@@ -106,8 +106,8 @@ func (s *Server) observeSharedDBPoolMetrics(ctx context.Context) {
 		}
 		metrics.RecordSharedDBPoolTotal(orgID, snapshot.ID, snapshot.UUID, snapshot.Status, 1)
 		next[totalKey] = struct{}{}
-		if snapshot.Status != meta.SharedDBStatusActive && !snapshot.UpdatedAt.IsZero() {
-			age := time.Since(snapshot.UpdatedAt)
+		if snapshot.Status != meta.SharedDBStatusActive && !snapshot.StatusUpdatedAt.IsZero() {
+			age := time.Since(snapshot.StatusUpdatedAt)
 			if age < 0 {
 				age = 0
 			}

--- a/pkg/server/tenant_metrics.go
+++ b/pkg/server/tenant_metrics.go
@@ -18,10 +18,11 @@ type tenantPoolBindingMetricKey struct {
 }
 
 const (
-	sharedDBPoolMetricTotal    = "total"
-	sharedDBPoolMetricCapacity = "capacity"
-	sharedDBPoolMetricTenants  = "tenants"
-	sharedDBPoolMetricSpending = "spending_limit"
+	sharedDBPoolMetricTotal     = "total"
+	sharedDBPoolMetricCapacity  = "capacity"
+	sharedDBPoolMetricTenants   = "tenants"
+	sharedDBPoolMetricSpending  = "spending_limit"
+	sharedDBPoolMetricStatusAge = "status_age"
 )
 
 type sharedDBPoolMetricKey struct {
@@ -105,6 +106,17 @@ func (s *Server) observeSharedDBPoolMetrics(ctx context.Context) {
 		}
 		metrics.RecordSharedDBPoolTotal(orgID, snapshot.ID, snapshot.UUID, snapshot.Status, 1)
 		next[totalKey] = struct{}{}
+		if snapshot.Status != meta.SharedDBStatusActive && !snapshot.UpdatedAt.IsZero() {
+			age := time.Since(snapshot.UpdatedAt)
+			if age < 0 {
+				age = 0
+			}
+			metrics.RecordSharedDBPoolStatusAge(orgID, snapshot.UUID, snapshot.Status, age)
+			next[sharedDBPoolMetricKey{
+				kind: sharedDBPoolMetricStatusAge, dbPoolID: snapshot.ID, dbPoolUUID: snapshot.UUID,
+				tidbCloudOrgID: orgID, dimension: snapshot.Status,
+			}] = struct{}{}
+		}
 
 		free := int64(0)
 		if snapshot.MaxTenants > snapshot.TenantCount && !snapshot.SoftCapReached {
@@ -210,5 +222,7 @@ func deleteSharedDBPoolMetric(key sharedDBPoolMetricKey) {
 		metrics.DeleteSharedDBPoolTenants(key.tidbCloudOrgID, key.dbPoolID, key.dbPoolUUID, key.dimension)
 	case sharedDBPoolMetricSpending:
 		metrics.DeleteSharedDBPoolSpendingLimit(key.tidbCloudOrgID, key.dbPoolID, key.dbPoolUUID, key.dimension)
+	case sharedDBPoolMetricStatusAge:
+		metrics.DeleteSharedDBPoolStatusAge(key.tidbCloudOrgID, key.dbPoolUUID, key.dimension)
 	}
 }

--- a/pkg/server/tenant_metrics_test.go
+++ b/pkg/server/tenant_metrics_test.go
@@ -178,6 +178,9 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 	if err != nil {
 		t.Fatalf("CreateManagedSharedDBPool pending: %v", err)
 	}
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, time.Now().UTC().Add(-20*time.Minute), pendingDBID); err != nil {
+		t.Fatalf("age pending db pool: %v", err)
+	}
 
 	now := time.Now().UTC()
 	for _, tc := range []struct {
@@ -218,6 +221,7 @@ func TestObserveSharedDBPoolMetricsRecordsCapacityTenantsAndSpending(t *testing.
 	for _, want := range []string{
 		`drive9_shared_db_pool_total{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",status="active",tidbcloud_org_id="org-shared-db-metrics"} 1`,
 		`drive9_shared_db_pool_total{db_pool_id="` + pendingDBPoolID + `",db_pool_uuid="` + pendingPoolUUID + `",status="pending",tidbcloud_org_id="org-shared-db-metrics"} 1`,
+		`drive9_shared_db_pool_status_age_seconds{db_pool_uuid="` + pendingPoolUUID + `",status="pending",tidbcloud_org_id="org-shared-db-metrics"}`,
 		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="soft_max"} 5`,
 		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="hard_max"} 6`,
 		`drive9_shared_db_pool_capacity{db_pool_id="` + dbPoolID + `",db_pool_uuid="` + activePoolUUID + `",tidbcloud_org_id="org-shared-db-metrics",type="used"} 2`,

--- a/pkg/server/tenant_outbox_poller.go
+++ b/pkg/server/tenant_outbox_poller.go
@@ -212,6 +212,9 @@ func (p *tenantOutboxPoller) pollOnce(ctx context.Context) {
 
 // dispatch sends a single outbox row to the right consumer based on work_mask.
 func (p *tenantOutboxPoller) dispatch(ctx context.Context, row meta.TenantNotifyRow) {
+	if row.WorkMask&WorkAPIKeyCacheCleanup != 0 && p.metaStore != nil {
+		p.metaStore.InvalidateAPIKeyResolveCacheForTenant(row.TenantID)
+	}
 	if row.WorkMask&WorkMetricsCleanup != 0 {
 		metrics.DeleteTenantCounters(row.TenantID)
 		if p.metaStore != nil {

--- a/pkg/server/tenant_outbox_poller.go
+++ b/pkg/server/tenant_outbox_poller.go
@@ -214,6 +214,9 @@ func (p *tenantOutboxPoller) pollOnce(ctx context.Context) {
 func (p *tenantOutboxPoller) dispatch(ctx context.Context, row meta.TenantNotifyRow) {
 	if row.WorkMask&WorkMetricsCleanup != 0 {
 		metrics.DeleteTenantCounters(row.TenantID)
+		if p.metaStore != nil {
+			p.metaStore.InvalidateAPIKeyResolveCacheForTenant(row.TenantID)
+		}
 		if forgetter, ok := p.worker.(outboxTenantForgetter); ok {
 			forgetter.ForgetTenant(row.TenantID)
 		}

--- a/pkg/server/tenant_outbox_poller.go
+++ b/pkg/server/tenant_outbox_poller.go
@@ -19,6 +19,10 @@ type outboxKicker interface {
 	KickWithOrg(tenantID, tidbCloudOrgID string, workMask int)
 }
 
+type outboxTenantForgetter interface {
+	ForgetTenant(tenantID string)
+}
+
 const (
 	// defaultTenantOutboxPollInterval is the poller's tick interval. At 200ms,
 	// cross-pod work delivery is bounded to ~200ms. The target is the
@@ -39,6 +43,7 @@ const (
 // tenant_notify_outbox table (in the always-provisioned meta DB) and
 // dispatches work by work_mask:
 //   - SSE bit → wake the local EventBus (broadcast: all pods with subscribers)
+//   - Metrics cleanup bit → delete this pod's tenant-scoped metrics
 //   - Semantic/FileGC/Quota bits → kick the unified worker if this pod's shard
 //     resolver owns the tenant (sharded: shard owner only)
 //
@@ -170,8 +175,10 @@ func (p *tenantOutboxPoller) pollOnce(ctx context.Context) {
 		if ctx.Err() != nil {
 			return
 		}
+		pollStart := time.Now()
 		rows, err := p.metaStore.ListTenantNotifySince(ctx, p.lastID, tenantOutboxBatchSize)
 		if err != nil {
+			metrics.RecordTenantOutboxPoll(metrics.ResultForError(err), time.Since(pollStart), 0, 0, false)
 			logger.Warn(ctx, "tenant_outbox_poller_list_failed",
 				zap.Uint64("after_id", p.lastID),
 				zap.Error(err))
@@ -187,6 +194,14 @@ func (p *tenantOutboxPoller) pollOnce(ctx context.Context) {
 			p.dispatch(ctx, row)
 			p.lastID = row.ID
 		}
+		oldestAge := time.Duration(0)
+		if len(rows) > 0 {
+			oldestAge = time.Since(rows[0].CreatedAt)
+			if oldestAge < 0 {
+				oldestAge = 0
+			}
+		}
+		metrics.RecordTenantOutboxPoll("ok", time.Since(pollStart), len(rows), oldestAge, len(rows) == tenantOutboxBatchSize)
 		// If we got fewer rows than the batch size, we're caught up — wait for
 		// the next tick. Otherwise drain the remaining rows immediately.
 		if len(rows) < tenantOutboxBatchSize {
@@ -197,6 +212,12 @@ func (p *tenantOutboxPoller) pollOnce(ctx context.Context) {
 
 // dispatch sends a single outbox row to the right consumer based on work_mask.
 func (p *tenantOutboxPoller) dispatch(ctx context.Context, row meta.TenantNotifyRow) {
+	if row.WorkMask&WorkMetricsCleanup != 0 {
+		metrics.DeleteTenantCounters(row.TenantID)
+		if forgetter, ok := p.worker.(outboxTenantForgetter); ok {
+			forgetter.ForgetTenant(row.TenantID)
+		}
+	}
 	if row.WorkMask&WorkSSE != 0 {
 		// SSE is broadcast: wake any local bus with subscribers for this tenant.
 		// If no bus exists, skip — we never touch the tenant's TiDB.
@@ -227,11 +248,14 @@ func (p *tenantOutboxPoller) flushCursor(ctx context.Context) {
 		return
 	}
 	if err := p.metaStore.UpsertTenantOutboxCursor(ctx, p.podID, p.lastID); err != nil {
+		metrics.RecordTenantOutboxCursorFlush(metrics.ResultForError(err))
 		if ctx.Err() == nil {
 			logger.Warn(ctx, "tenant_outbox_poller_cursor_flush_failed",
 				zap.String("pod_id", p.podID),
 				zap.Uint64("cursor", p.lastID),
 				zap.Error(err))
 		}
+		return
 	}
+	metrics.RecordTenantOutboxCursorFlush("ok")
 }

--- a/pkg/server/tenant_outbox_poller_test.go
+++ b/pkg/server/tenant_outbox_poller_test.go
@@ -50,9 +50,12 @@ func TestTenantOutboxPollerPassesOrgToWorker(t *testing.T) {
 	}
 	recorder := httptest.NewRecorder()
 	metrics.WritePrometheus(recorder)
-	want := `drive9_service_operations_total{component="user_db_access",operation="outbox_dispatch_kick",result="ok",tenant_id="tenant-outbox-org-metric",tidbcloud_org_id="org-outbox-metric"}`
+	want := `drive9_service_operations_total{component="user_db_access",operation="outbox_dispatch_kick",result="ok"}`
 	if !strings.Contains(recorder.Body.String(), want) {
-		t.Fatalf("missing org-scoped outbox dispatch metric %q", want)
+		t.Fatalf("missing aggregate outbox dispatch metric %q", want)
+	}
+	if strings.Contains(recorder.Body.String(), `drive9_service_operations_total{component="user_db_access",operation="outbox_dispatch_kick",result="ok",tenant_id=`) {
+		t.Fatalf("successful outbox dispatch metric unexpectedly carries tenant labels: %s", recorder.Body.String())
 	}
 }
 
@@ -66,6 +69,34 @@ func TestTenantOutboxPollerSSEOnlyNoKick(t *testing.T) {
 	p.dispatch(context.Background(), row)
 	if len(k.kicks) != 0 {
 		t.Fatalf("SSE-only row should not kick worker, got %d kicks", len(k.kicks))
+	}
+}
+
+func TestTenantOutboxPollerMetricsCleanupIsBroadcast(t *testing.T) {
+	tenantID := "tenant-outbox-metrics-cleanup"
+	orgID := "org-outbox-metrics-cleanup"
+	metrics.RecordTenantOperationWithOrg(tenantID, orgID, "event_bus", "publish", "error", 0)
+	metrics.RecordTenantGaugeWithOrg(tenantID, orgID, "semantic_worker", "queue_lag_seconds", 10)
+
+	buses := newEventBuses()
+	k := &mockKicker{}
+	// A shard-rejected pod must still clean its local metric registry because
+	// cleanup is broadcast, unlike semantic and file-GC work.
+	p := newTenantOutboxPoller(nil, buses, k, func(string) bool { return false }, "pod1", 0, 0)
+	p.dispatch(context.Background(), meta.TenantNotifyRow{
+		ID:        1,
+		TenantID:  tenantID,
+		WorkMask:  WorkMetricsCleanup,
+		CreatedAt: time.Now(),
+	})
+
+	recorder := httptest.NewRecorder()
+	metrics.WritePrometheus(recorder)
+	if strings.Contains(recorder.Body.String(), tenantID) {
+		t.Fatalf("tenant metrics remain after broadcast cleanup: %s", recorder.Body.String())
+	}
+	if len(k.kicks) != 0 {
+		t.Fatalf("metrics cleanup should not kick sharded work, got %d kicks", len(k.kicks))
 	}
 }
 

--- a/pkg/server/tenant_outbox_poller_test.go
+++ b/pkg/server/tenant_outbox_poller_test.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
+	"github.com/mem9-ai/drive9/pkg/tenant"
+	"github.com/mem9-ai/drive9/pkg/tenant/token"
 )
 
 // mockKicker records kicks for deterministic testing of the poller.
@@ -97,6 +99,53 @@ func TestTenantOutboxPollerMetricsCleanupIsBroadcast(t *testing.T) {
 	}
 	if len(k.kicks) != 0 {
 		t.Fatalf("metrics cleanup should not kick sharded work, got %d kicks", len(k.kicks))
+	}
+}
+
+func TestTenantOutboxPollerAPIKeyCacheCleanupIsBroadcastWithoutDeletingMetrics(t *testing.T) {
+	rt := newTenantDeleteRuntime(t, tenant.ProviderTiDBZero, meta.APIKeyScopeKindOwner)
+	ctx := context.Background()
+	hash := token.HashToken(rt.apiKey)
+	resolved, err := rt.meta.ResolveByAPIKeyHash(ctx, hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved.APIKey.Status != meta.APIKeyActive {
+		t.Fatalf("initial API key status = %s, want %s", resolved.APIKey.Status, meta.APIKeyActive)
+	}
+	if _, err := rt.meta.DB().ExecContext(ctx, `UPDATE tenant_api_keys
+		SET status = ?, revoked_at = CURRENT_TIMESTAMP(3), updated_at = CURRENT_TIMESTAMP(3)
+		WHERE tenant_id = ?`, meta.APIKeyRevoked, rt.tenantID); err != nil {
+		t.Fatal(err)
+	}
+	stale, err := rt.meta.ResolveByAPIKeyHash(ctx, hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stale.APIKey.Status != meta.APIKeyActive {
+		t.Fatalf("pre-dispatch cached API key status = %s, want stale %s", stale.APIKey.Status, meta.APIKeyActive)
+	}
+
+	metrics.RecordTenantOperationWithOrg(rt.tenantID, "org-live", "event_bus", "publish", "error", 0)
+	p := newTenantOutboxPoller(rt.meta, newEventBuses(), &mockKicker{}, func(string) bool { return false }, "pod1", 0, 0)
+	p.dispatch(ctx, meta.TenantNotifyRow{
+		ID:        1,
+		TenantID:  rt.tenantID,
+		WorkMask:  WorkAPIKeyCacheCleanup,
+		CreatedAt: time.Now(),
+	})
+
+	refetched, err := rt.meta.ResolveByAPIKeyHash(ctx, hash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if refetched.APIKey.Status != meta.APIKeyRevoked {
+		t.Fatalf("post-dispatch API key status = %s, want %s", refetched.APIKey.Status, meta.APIKeyRevoked)
+	}
+	recorder := httptest.NewRecorder()
+	metrics.WritePrometheus(recorder)
+	if !strings.Contains(recorder.Body.String(), rt.tenantID) {
+		t.Fatalf("API-key-only cache cleanup deleted live tenant metrics: %s", recorder.Body.String())
 	}
 }
 

--- a/pkg/server/tenant_pool_reconcile.go
+++ b/pkg/server/tenant_pool_reconcile.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"go.uber.org/zap"
 )
@@ -99,6 +100,7 @@ func (s *Server) reconcileStuckManagedSharedDBPoolsWithCtx(ctx context.Context) 
 						return failErr
 					}
 					if changed {
+						metrics.RecordSharedDBPoolStuckMarkedFailed(status)
 						logger.Warn(claimCtx, "managed_shared_db_pool_stuck_failed", zap.Int64("db_pool_id", row.ID),
 							zap.String("db_pool_uuid", row.UUID), zap.String("status", status),
 							zap.Int("tenant_count", len(failed.TenantIDs)), zap.Duration("stuck_timeout", timeout))

--- a/pkg/server/tenant_worker.go
+++ b/pkg/server/tenant_worker.go
@@ -164,7 +164,8 @@ type tenantWorkerManager struct {
 
 	kicks chan kickMsg
 
-	lastMaintenance map[string]time.Time
+	lastMaintenance   map[string]time.Time
+	semanticMetricOrg map[string]string // tenantID -> org used by the last semantic gauge observation
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -214,6 +215,7 @@ func newTenantWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Store
 	m.inflight = make(map[string]int)
 	m.kickPending = make(map[string]pendingKick)
 	m.lastMaintenance = make(map[string]time.Time)
+	m.semanticMetricOrg = make(map[string]string)
 	m.kicks = make(chan kickMsg, tenantKickQueueCapacity)
 	return m
 }
@@ -269,6 +271,7 @@ func (m *tenantWorkerManager) ForgetTenant(tenantID string) {
 	m.mu.Lock()
 	delete(m.kickPending, tenantID)
 	delete(m.lastMaintenance, tenantID)
+	delete(m.semanticMetricOrg, tenantID)
 	m.mu.Unlock()
 }
 
@@ -341,10 +344,6 @@ func (m *tenantWorkerManager) Start(ctx context.Context) {
 	metrics.SetModuleAvailability("semantic_worker", true)
 	metrics.RecordGauge("semantic_worker", "workers", float64(m.opts.Workers))
 	metrics.RecordGauge("semantic_worker", "inflight", 0)
-	metrics.RecordGauge("semantic_worker", "queued", 0)
-	metrics.RecordGauge("semantic_worker", "processing", 0)
-	metrics.RecordGauge("semantic_worker", "dead_lettered", 0)
-	metrics.RecordGauge("semantic_worker", "queue_lag_seconds", 0)
 	for i := 0; i < m.opts.Workers; i++ {
 		m.wg.Add(1)
 		go m.workerLoop(workerCtx, i+1)
@@ -619,7 +618,23 @@ func (m *tenantWorkerManager) observeTenant(ctx context.Context, target *tenantT
 		}
 		return
 	}
-	recordSemanticWorkerObservation(target.tenantID, target.metricOrgID(), obs, now)
+	m.recordSemanticWorkerObservation(target.tenantID, target.metricOrgID(), obs, now)
+}
+
+func (m *tenantWorkerManager) recordSemanticWorkerObservation(tenantID, tidbCloudOrgID string, obs *datastore.SemanticTaskObservation, now time.Time) {
+	tidbCloudOrgID = normalizeTenantMetricTiDBCloudOrgID(tidbCloudOrgID)
+	m.mu.Lock()
+	previousOrgID := m.semanticMetricOrg[tenantID]
+	if m.semanticMetricOrg == nil {
+		m.semanticMetricOrg = make(map[string]string)
+	}
+	m.semanticMetricOrg[tenantID] = tidbCloudOrgID
+	m.mu.Unlock()
+	if previousOrgID != "" && previousOrgID != tidbCloudOrgID {
+		metrics.DeleteTenantGaugeWithOrg(tenantID, previousOrgID, "semantic_worker", "dead_lettered")
+		metrics.DeleteTenantGaugeWithOrg(tenantID, previousOrgID, "semantic_worker", "queue_lag_seconds")
+	}
+	recordSemanticWorkerObservation(tenantID, tidbCloudOrgID, obs, now)
 }
 
 func recordSemanticWorkerObservation(tenantID, tidbCloudOrgID string, obs *datastore.SemanticTaskObservation, now time.Time) {

--- a/pkg/server/tenant_worker.go
+++ b/pkg/server/tenant_worker.go
@@ -258,6 +258,20 @@ func (m *tenantWorkerManager) KickWithOrg(tenantID, tidbCloudOrgID string, workM
 	}
 }
 
+// ForgetTenant drops process-local scheduler bookkeeping after the tenant
+// lifecycle has durably entered deletion. A queued kick may still be present
+// in the channel, but processKicked will reject it against the persisted
+// non-active status and clear it again.
+func (m *tenantWorkerManager) ForgetTenant(tenantID string) {
+	if m == nil || tenantID == "" {
+		return
+	}
+	m.mu.Lock()
+	delete(m.kickPending, tenantID)
+	delete(m.lastMaintenance, tenantID)
+	m.mu.Unlock()
+}
+
 func mergeKickOrgID(current, next string) string {
 	next = strings.TrimSpace(next)
 	if next != "" {
@@ -574,15 +588,21 @@ func (m *tenantWorkerManager) piggybackMaintenance(ctx context.Context, target *
 	m.mu.Unlock()
 
 	// fs_events cleanup: prune rows older than fsEventsRetention.
-	if count, err := target.store.CountFSEvents(ctx); err == nil {
+	if count, err := target.store.CountFSEvents(ctx); err != nil {
+		metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "event_bus", "fs_events_count", metrics.ResultForError(err), 0)
+	} else if count > 0 {
 		metrics.RecordFSEventsRowsWithOrg(target.tenantID, target.metricOrgID(), count)
+	} else {
+		metrics.DeleteFSEventsRowsWithOrg(target.tenantID, target.metricOrgID())
 	}
 	if n, err := target.store.DeleteFSEventsBefore(ctx, now.Add(-fsEventsRetention)); err != nil {
+		metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "event_bus", "retention_sweep", metrics.ResultForError(err), 0)
 		if ctx.Err() == nil {
 			logger.Warn(ctx, "tenant_worker_fs_events_cleanup_failed",
 				zap.String("tenant_id", target.tenantID), zap.Error(err))
 		}
 	} else {
+		metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "event_bus", "retention_sweep", "ok", 0)
 		metrics.RecordFSEventsPrunedWithOrg(target.tenantID, target.metricOrgID(), n)
 	}
 
@@ -599,7 +619,18 @@ func (m *tenantWorkerManager) observeTenant(ctx context.Context, target *tenantT
 		}
 		return
 	}
-	metrics.RecordTenantGaugeWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "dead_lettered", float64(obs.DeadLettered))
+	recordSemanticWorkerObservation(target.tenantID, target.metricOrgID(), obs, now)
+}
+
+func recordSemanticWorkerObservation(tenantID, tidbCloudOrgID string, obs *datastore.SemanticTaskObservation, now time.Time) {
+	if obs == nil {
+		return
+	}
+	if obs.DeadLettered > 0 {
+		metrics.RecordTenantGaugeWithOrg(tenantID, tidbCloudOrgID, "semantic_worker", "dead_lettered", float64(obs.DeadLettered))
+	} else {
+		metrics.DeleteTenantGaugeWithOrg(tenantID, tidbCloudOrgID, "semantic_worker", "dead_lettered")
+	}
 	tenantLag := float64(0)
 	if obs.OldestClaimableAvailableAt != nil {
 		tenantLag = now.UTC().Sub(obs.OldestClaimableAvailableAt.UTC()).Seconds()
@@ -607,7 +638,11 @@ func (m *tenantWorkerManager) observeTenant(ctx context.Context, target *tenantT
 			tenantLag = 0
 		}
 	}
-	metrics.RecordTenantGaugeWithOrg(target.tenantID, target.metricOrgID(), "semantic_worker", "queue_lag_seconds", tenantLag)
+	if tenantLag > 0 {
+		metrics.RecordTenantGaugeWithOrg(tenantID, tidbCloudOrgID, "semantic_worker", "queue_lag_seconds", tenantLag)
+	} else {
+		metrics.DeleteTenantGaugeWithOrg(tenantID, tidbCloudOrgID, "semantic_worker", "queue_lag_seconds")
+	}
 }
 
 // kickRef resolves a kicked tenant ID to a schedulable ref, applying the same

--- a/pkg/server/tenant_worker.go
+++ b/pkg/server/tenant_worker.go
@@ -602,7 +602,7 @@ func (m *tenantWorkerManager) piggybackMaintenance(ctx context.Context, target *
 		}
 	} else {
 		metrics.RecordTenantOperationWithOrg(target.tenantID, target.metricOrgID(), "event_bus", "retention_sweep", "ok", 0)
-		metrics.RecordFSEventsPrunedWithOrg(target.tenantID, target.metricOrgID(), n)
+		metrics.RecordFSEventsPruned(n)
 	}
 
 	// Observation metrics: sample queue depth + dead-letter count.

--- a/pkg/server/tenant_worker_metrics_test.go
+++ b/pkg/server/tenant_worker_metrics_test.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/datastore"
+	"github.com/mem9-ai/drive9/pkg/metrics"
+)
+
+func TestRecordSemanticWorkerObservationExportsOnlyAbnormalState(t *testing.T) {
+	const tenantID = "tenant-semantic-observation-lifecycle"
+	const orgID = "org-semantic-observation-lifecycle"
+	now := time.Now().UTC()
+	oldest := now.Add(-10 * time.Minute)
+
+	recordSemanticWorkerObservation(tenantID, orgID, &datastore.SemanticTaskObservation{
+		DeadLettered: 2, OldestClaimableAvailableAt: &oldest,
+	}, now)
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_service_gauge{component="semantic_worker",name="dead_lettered",tenant_id="`+tenantID+`",tidbcloud_org_id="`+orgID+`"} 2`) {
+		t.Fatalf("dead-letter gauge missing in abnormal state:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_service_gauge{component="semantic_worker",name="queue_lag_seconds",tenant_id="`+tenantID+`",tidbcloud_org_id="`+orgID+`"} 600`) {
+		t.Fatalf("queue-lag gauge missing in abnormal state:\n%s", text)
+	}
+
+	recordSemanticWorkerObservation(tenantID, orgID, &datastore.SemanticTaskObservation{}, now)
+	rec = httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	text = rec.Body.String()
+	for _, name := range []string{"dead_lettered", "queue_lag_seconds"} {
+		if strings.Contains(text, `drive9_service_gauge{component="semantic_worker",name="`+name+`",tenant_id="`+tenantID+`"`) {
+			t.Fatalf("healthy semantic gauge %s remains exported:\n%s", name, text)
+		}
+	}
+}

--- a/pkg/server/tenant_worker_metrics_test.go
+++ b/pkg/server/tenant_worker_metrics_test.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -36,6 +37,55 @@ func TestRecordSemanticWorkerObservationExportsOnlyAbnormalState(t *testing.T) {
 	for _, name := range []string{"dead_lettered", "queue_lag_seconds"} {
 		if strings.Contains(text, `drive9_service_gauge{component="semantic_worker",name="`+name+`",tenant_id="`+tenantID+`"`) {
 			t.Fatalf("healthy semantic gauge %s remains exported:\n%s", name, text)
+		}
+	}
+}
+
+func TestTenantWorkerSemanticObservationDeletesPreviousOrgSeries(t *testing.T) {
+	const tenantID = "tenant-semantic-observation-org-change"
+	now := time.Now().UTC()
+	oldest := now.Add(-time.Minute)
+	m := &tenantWorkerManager{semanticMetricOrg: make(map[string]string)}
+	m.recordSemanticWorkerObservation(tenantID, "org-old", &datastore.SemanticTaskObservation{
+		DeadLettered: 1, OldestClaimableAvailableAt: &oldest,
+	}, now)
+	m.recordSemanticWorkerObservation(tenantID, "org-new", &datastore.SemanticTaskObservation{
+		DeadLettered: 2, OldestClaimableAvailableAt: &oldest,
+	}, now)
+
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	text := rec.Body.String()
+	if strings.Contains(text, `tenant_id="`+tenantID+`",tidbcloud_org_id="org-old"`) {
+		t.Fatalf("previous-org semantic gauge remains exported:\n%s", text)
+	}
+	if !strings.Contains(text, `component="semantic_worker",name="dead_lettered",tenant_id="`+tenantID+`",tidbcloud_org_id="org-new"`) {
+		t.Fatalf("new-org semantic gauge missing:\n%s", text)
+	}
+}
+
+func TestTenantWorkerStartDoesNotExportUnmaintainedGlobalQueueGauges(t *testing.T) {
+	for _, name := range []string{"queued", "processing", "dead_lettered", "queue_lag_seconds"} {
+		metrics.DeleteTenantGauge("", "semantic_worker", name)
+	}
+	m := &tenantWorkerManager{
+		opts:            TenantWorkerOptions{Workers: 1, PollInterval: time.Hour},
+		inflight:        make(map[string]int),
+		kickPending:     make(map[string]pendingKick),
+		lastMaintenance: make(map[string]time.Time),
+		kicks:           make(chan kickMsg, 1),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	m.Start(ctx)
+	defer m.Stop()
+
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	text := rec.Body.String()
+	for _, name := range []string{"queued", "processing", "dead_lettered", "queue_lag_seconds"} {
+		if strings.Contains(text, `drive9_service_gauge{component="semantic_worker",name="`+name+`",tenant_id=""`) {
+			t.Fatalf("unmaintained global semantic gauge %s was exported:\n%s", name, text)
 		}
 	}
 }

--- a/pkg/server/vault_read_test.go
+++ b/pkg/server/vault_read_test.go
@@ -363,8 +363,11 @@ func TestVaultMetricsExposed(t *testing.T) {
 	if !strings.Contains(metricsText, "drive9_module_up{module=\"vault\"} 1") {
 		t.Fatalf("metrics missing vault module availability: %s", metricsText)
 	}
-	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"vault\",operation=\"read_secret\",result=\"ok\",tenant_id=\"") {
+	if !strings.Contains(metricsText, "drive9_service_operations_total{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
 		t.Errorf("metrics missing vault service operation counter: %s", metricsText)
+	}
+	if strings.Contains(metricsText, "drive9_service_operations_total{component=\"vault\",operation=\"read_secret\",result=\"ok\",tenant_id=\"") {
+		t.Errorf("successful vault service operation counter should not carry tenant_id: %s", metricsText)
 	}
 	if !strings.Contains(metricsText, "drive9_service_operation_duration_seconds_count{component=\"vault\",operation=\"read_secret\",result=\"ok\"}") {
 		t.Errorf("metrics missing vault service duration histogram: %s", metricsText)

--- a/pkg/server/work_mask.go
+++ b/pkg/server/work_mask.go
@@ -7,6 +7,7 @@ import "github.com/mem9-ai/drive9/pkg/backend"
 //
 //	SSE bit  → wake local SSE bus (broadcast: all pods with subscribers)
 //	Semantic/GC/Quota bits → kick unified worker (sharded: shard owner only)
+//	Metrics cleanup bit → delete local tenant series (broadcast: every pod)
 //
 // These mirror the backend.Work* constants in pkg/backend/dat9.go. The
 // compile-time assertions below ensure the values stay in sync.
@@ -21,6 +22,10 @@ const (
 	// WorkFileGC (bit 2) kicks the unified worker to drain file_gc tasks.
 	// Sharded: only the shard-owner pod processes it.
 	WorkFileGC = 4
+	// WorkMetricsCleanup (bit 3) removes all tenant-scoped metric series from
+	// the local process. It is server-only because it is emitted by durable
+	// tenant lifecycle transitions, not by a tenant DB write path.
+	WorkMetricsCleanup = 8
 )
 
 // Compile-time assertions that the server-side work mask constants match the

--- a/pkg/server/work_mask.go
+++ b/pkg/server/work_mask.go
@@ -1,31 +1,34 @@
 package server
 
-import "github.com/mem9-ai/drive9/pkg/backend"
+import (
+	"github.com/mem9-ai/drive9/pkg/backend"
+	"github.com/mem9-ai/drive9/pkg/meta"
+)
 
 // Work mask constants for the unified tenant notify outbox. Each bit in
 // work_mask selects one work type. The poller dispatches by testing bits:
 //
 //	SSE bit  → wake local SSE bus (broadcast: all pods with subscribers)
-//	Semantic/GC/Quota bits → kick unified worker (sharded: shard owner only)
+//	Semantic/GC bits → kick unified worker (sharded: shard owner only)
 //	Metrics cleanup bit → delete local tenant series (broadcast: every pod)
 //
-// These mirror the backend.Work* constants in pkg/backend/dat9.go. The
-// compile-time assertions below ensure the values stay in sync.
+// The persisted allocation lives in pkg/meta. Backend and server aliases plus
+// the compile-time assertions below keep both producer paths in sync.
 const (
 	// WorkSSE (bit 0) wakes the local SSE EventBus so SSE handlers re-read
 	// fs_events. Broadcast to all pods (not sharded) — any pod with subscribers
 	// for the tenant must wake.
-	WorkSSE = 1
+	WorkSSE = meta.TenantNotifyWorkSSE
 	// WorkSemantic (bit 1) kicks the unified worker to drain semantic tasks
 	// for this tenant. Sharded: only the shard-owner pod processes it.
-	WorkSemantic = 2
+	WorkSemantic = meta.TenantNotifyWorkSemantic
 	// WorkFileGC (bit 2) kicks the unified worker to drain file_gc tasks.
 	// Sharded: only the shard-owner pod processes it.
-	WorkFileGC = 4
+	WorkFileGC = meta.TenantNotifyWorkFileGC
 	// WorkMetricsCleanup (bit 3) removes all tenant-scoped metric series from
 	// the local process. It is server-only because it is emitted by durable
 	// tenant lifecycle transitions, not by a tenant DB write path.
-	WorkMetricsCleanup = 8
+	WorkMetricsCleanup = meta.TenantNotifyWorkMetricsCleanup
 )
 
 // Compile-time assertions that the server-side work mask constants match the
@@ -35,4 +38,5 @@ var (
 	_ = [1]byte{}[backend.BackendWorkSSE^WorkSSE]
 	_ = [1]byte{}[backend.BackendWorkSemantic^WorkSemantic]
 	_ = [1]byte{}[backend.BackendWorkFileGC^WorkFileGC]
+	_ = [1]byte{}[backend.BackendWorkMetricsCleanup^WorkMetricsCleanup]
 )

--- a/pkg/server/work_mask.go
+++ b/pkg/server/work_mask.go
@@ -30,6 +30,10 @@ const (
 	// server-only because it is emitted by durable tenant lifecycle transitions,
 	// not by a tenant DB write path.
 	WorkMetricsCleanup = meta.TenantNotifyWorkMetricsCleanup
+	// WorkAPIKeyCacheCleanup (bit 4) invalidates locally cached API-key
+	// resolutions after a key revocation. It is broadcast to every pod but does
+	// not touch tenant metrics for live tenants.
+	WorkAPIKeyCacheCleanup = meta.TenantNotifyWorkAPIKeyCacheCleanup
 )
 
 // Compile-time assertions that the server-side work mask constants match the
@@ -40,4 +44,5 @@ var (
 	_ = [1]byte{}[backend.BackendWorkSemantic^WorkSemantic]
 	_ = [1]byte{}[backend.BackendWorkFileGC^WorkFileGC]
 	_ = [1]byte{}[backend.BackendWorkMetricsCleanup^WorkMetricsCleanup]
+	_ = [1]byte{}[backend.BackendWorkAPIKeyCacheCleanup^WorkAPIKeyCacheCleanup]
 )

--- a/pkg/server/work_mask.go
+++ b/pkg/server/work_mask.go
@@ -25,9 +25,10 @@ const (
 	// WorkFileGC (bit 2) kicks the unified worker to drain file_gc tasks.
 	// Sharded: only the shard-owner pod processes it.
 	WorkFileGC = meta.TenantNotifyWorkFileGC
-	// WorkMetricsCleanup (bit 3) removes all tenant-scoped metric series from
-	// the local process. It is server-only because it is emitted by durable
-	// tenant lifecycle transitions, not by a tenant DB write path.
+	// WorkMetricsCleanup (bit 3) removes all tenant-scoped metric series and
+	// invalidates the tenant API-key resolve cache in the local process. It is
+	// server-only because it is emitted by durable tenant lifecycle transitions,
+	// not by a tenant DB write path.
 	WorkMetricsCleanup = meta.TenantNotifyWorkMetricsCleanup
 )
 

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -1632,12 +1632,6 @@ func (p *Pool) closeEntry(e *entry) {
 		_ = e.store.Close()
 	}
 	p.releaseSharedDB(e.sharedDBID)
-	p.mu.Lock()
-	_, active := p.items[e.tenantID]
-	p.mu.Unlock()
-	if !active {
-		metrics.DeleteTenantCounters(e.tenantID)
-	}
 }
 
 type tenantPoolResult string

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -1187,6 +1187,29 @@ func TestIdleEviction(t *testing.T) {
 	}
 }
 
+func TestCloseEntryPreservesLiveTenantCounters(t *testing.T) {
+	const tenantID = "tenant-live-counter-close-entry"
+	metrics.DeleteTenantCounters(tenantID)
+	t.Cleanup(func() { metrics.DeleteTenantCounters(tenantID) })
+
+	metrics.RecordTenantRequestCountWithOrg(tenantID, "org-live-counter", "api", "read", 200)
+	assertTenantMetricPresent := func() {
+		t.Helper()
+		recorder := httptest.NewRecorder()
+		metrics.WritePrometheus(recorder)
+		if !strings.Contains(recorder.Body.String(), `drive9_tenant_requests_total{`) ||
+			!strings.Contains(recorder.Body.String(), `tenant_id="`+tenantID+`"`) {
+			t.Fatalf("live tenant counter disappeared from metrics:\n%s", recorder.Body.String())
+		}
+	}
+	assertTenantMetricPresent()
+
+	pool := NewPool(PoolConfig{}, nil)
+	pool.closeEntry(&entry{tenantID: tenantID})
+
+	assertTenantMetricPresent()
+}
+
 func TestIdleEvictionSkippedByRecentAcquire(t *testing.T) {
 	pool, tenant := newTestPoolAndTenantWithConfig(t, PoolConfig{
 		MaxTenants:       2,

--- a/pkg/tenant/tidbcloudnative/http_clusters_api.go
+++ b/pkg/tenant/tidbcloudnative/http_clusters_api.go
@@ -44,6 +44,7 @@ func (a *HTTPClustersAPI) CreateCluster(ctx context.Context, publicKey, privateK
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if !httpStatusOK(resp.StatusCode) {
+		recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationCreateCluster, resp.StatusCode, true)
 		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 		if readErr != nil {
 			return nil, readErr
@@ -52,9 +53,16 @@ func (a *HTTPClustersAPI) CreateCluster(ctx context.Context, publicKey, privateK
 	}
 	raw, readErr := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
 	if readErr != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationCreateCluster, tidbCloudResultProtocolError)
 		return nil, readErr
 	}
-	return parseClusterInfo(raw)
+	info, err := parseClusterInfo(raw)
+	if err != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationCreateCluster, tidbCloudResultProtocolError)
+		return nil, err
+	}
+	recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationCreateCluster, tidbCloudResultOK)
+	return info, nil
 }
 
 func (a *HTTPClustersAPI) BatchCreateClusters(ctx context.Context, publicKey, privateKey string, body []byte) ([]clusterInfo, error) {
@@ -67,6 +75,7 @@ func (a *HTTPClustersAPI) BatchCreateClusters(ctx context.Context, publicKey, pr
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if !httpStatusOK(resp.StatusCode) {
+		recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationBatchCreateClusters, resp.StatusCode, true)
 		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 		if readErr != nil {
 			return nil, readErr
@@ -75,12 +84,15 @@ func (a *HTTPClustersAPI) BatchCreateClusters(ctx context.Context, publicKey, pr
 	}
 	raw, err := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
 	if err != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationBatchCreateClusters, tidbCloudResultProtocolError)
 		return nil, err
 	}
 	var created clusterListResponse
 	if err := json.Unmarshal(raw, &created); err != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationBatchCreateClusters, tidbCloudResultProtocolError)
 		return nil, err
 	}
+	recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationBatchCreateClusters, tidbCloudResultOK)
 	return created.Clusters, nil
 }
 
@@ -99,6 +111,7 @@ func (a *HTTPClustersAPI) GetCluster(ctx context.Context, publicKey, privateKey,
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if !httpStatusOK(resp.StatusCode) {
+		recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationGetCluster, resp.StatusCode, true)
 		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 		if readErr != nil {
 			return nil, fmt.Errorf("read cluster get error body: %w", readErr)
@@ -107,15 +120,18 @@ func (a *HTTPClustersAPI) GetCluster(ctx context.Context, publicKey, privateKey,
 	}
 	raw, readErr := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
 	if readErr != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationGetCluster, tidbCloudResultProtocolError)
 		return nil, fmt.Errorf("read cluster body: %w", readErr)
 	}
 	info, err := parseClusterInfo(raw)
 	if err != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationGetCluster, tidbCloudResultProtocolError)
 		return nil, fmt.Errorf("parse cluster info: %w", err)
 	}
 	if info.Labels == nil {
 		info.Labels = make(map[string]string)
 	}
+	recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationGetCluster, tidbCloudResultOK)
 	return info, nil
 }
 
@@ -133,6 +149,7 @@ func (a *HTTPClustersAPI) ListClusters(ctx context.Context, publicKey, privateKe
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if !httpStatusOK(resp.StatusCode) {
+		recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationListClusters, resp.StatusCode, true)
 		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 		if readErr != nil {
 			return nil, "", fmt.Errorf("read cluster list error body: %w", readErr)
@@ -141,12 +158,15 @@ func (a *HTTPClustersAPI) ListClusters(ctx context.Context, publicKey, privateKe
 	}
 	raw, readErr := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
 	if readErr != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationListClusters, tidbCloudResultProtocolError)
 		return nil, "", fmt.Errorf("read cluster list body: %w", readErr)
 	}
 	list, err := parseClusterList(raw)
 	if err != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationListClusters, tidbCloudResultProtocolError)
 		return nil, "", fmt.Errorf("parse cluster list: %w", err)
 	}
+	recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationListClusters, tidbCloudResultOK)
 	return list.Clusters, strings.TrimSpace(list.NextPageToken), nil
 }
 
@@ -165,12 +185,14 @@ func (a *HTTPClustersAPI) PatchCluster(ctx context.Context, publicKey, privateKe
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if !httpStatusOK(resp.StatusCode) {
+		recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationUpdateCluster, resp.StatusCode, true)
 		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 		if readErr != nil {
 			return fmt.Errorf("read cluster patch error body: %w", readErr)
 		}
 		return newAPIStatusError("cluster patch", resp.StatusCode, sanitizeUpstreamBody(raw))
 	}
+	recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationUpdateCluster, tidbCloudResultOK)
 	return nil
 }
 
@@ -189,8 +211,10 @@ func (a *HTTPClustersAPI) DeleteCluster(ctx context.Context, publicKey, privateK
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationDeleteCluster, tidbCloudResultOK)
 		return nil
 	}
+	recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationDeleteCluster, resp.StatusCode, true)
 	raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 	if readErr != nil {
 		return readErr
@@ -209,6 +233,7 @@ func (a *HTTPClustersAPI) CreateBranch(ctx context.Context, publicKey, privateKe
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationCreateBranch, resp.StatusCode, true)
 		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 		if readErr != nil {
 			return nil, readErr
@@ -217,9 +242,16 @@ func (a *HTTPClustersAPI) CreateBranch(ctx context.Context, publicKey, privateKe
 	}
 	raw, readErr := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
 	if readErr != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationCreateBranch, tidbCloudResultProtocolError)
 		return nil, readErr
 	}
-	return parseBranchInfo(raw)
+	info, err := parseBranchInfo(raw)
+	if err != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationCreateBranch, tidbCloudResultProtocolError)
+		return nil, err
+	}
+	recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationCreateBranch, tidbCloudResultOK)
+	return info, nil
 }
 
 func (a *HTTPClustersAPI) GetBranch(ctx context.Context, publicKey, privateKey, clusterID, branchID string) (*branchInfo, error) {
@@ -233,6 +265,7 @@ func (a *HTTPClustersAPI) GetBranch(ctx context.Context, publicKey, privateKey, 
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
+		recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationGetBranch, resp.StatusCode, true)
 		raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 		if readErr != nil {
 			return nil, readErr
@@ -241,9 +274,16 @@ func (a *HTTPClustersAPI) GetBranch(ctx context.Context, publicKey, privateKey, 
 	}
 	raw, readErr := readUpstreamBody(resp.Body, upstreamClusterBodyLimit)
 	if readErr != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationGetBranch, tidbCloudResultProtocolError)
 		return nil, readErr
 	}
-	return parseBranchInfo(raw)
+	info, err := parseBranchInfo(raw)
+	if err != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationGetBranch, tidbCloudResultProtocolError)
+		return nil, err
+	}
+	recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationGetBranch, tidbCloudResultOK)
+	return info, nil
 }
 
 func (a *HTTPClustersAPI) DeleteBranch(ctx context.Context, publicKey, privateKey, clusterID, branchID string) error {
@@ -257,8 +297,10 @@ func (a *HTTPClustersAPI) DeleteBranch(ctx context.Context, publicKey, privateKe
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent || resp.StatusCode == http.StatusNotFound {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationDeleteBranch, tidbCloudResultOK)
 		return nil
 	}
+	recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationDeleteBranch, resp.StatusCode, true)
 	raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 	if readErr != nil {
 		return readErr
@@ -279,6 +321,7 @@ func (a *HTTPClustersAPI) ResolveAPIKey(ctx context.Context, publicKey, privateK
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if !httpStatusOK(resp.StatusCode) {
+		recordTiDBCloudHTTPResponse(tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, resp.StatusCode, true)
 		_, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 		if readErr != nil {
 			return nil, readErr
@@ -291,25 +334,33 @@ func (a *HTTPClustersAPI) ResolveAPIKey(ctx context.Context, publicKey, privateK
 		Role      string `json:"role"`
 	}
 	if err := json.NewDecoder(io.LimitReader(resp.Body, upstreamClusterBodyLimit)).Decode(&info); err != nil {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultProtocolError)
 		return nil, fmt.Errorf("decode IAM API key response: %w", err)
 	}
 	if strings.TrimSpace(info.AccessKey) != publicKey {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultProtocolError)
 		return nil, fmt.Errorf("IAM API key response does not match request credentials")
 	}
 	parts := strings.Split(strings.Trim(strings.TrimSpace(info.Name), "/"), "/")
 	if len(parts) < 2 || parts[0] != "orgs" || strings.TrimSpace(parts[1]) == "" {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultProtocolError)
 		return nil, fmt.Errorf("IAM API key response is missing organization")
 	}
 	role := strings.TrimSpace(info.Role)
 	if role != tenant.TiDBCloudRoleOrgOwner && role != tenant.TiDBCloudRoleProjectOwner {
+		recordTiDBCloudOpenAPIRequest(tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultProtocolError)
 		return nil, fmt.Errorf("%w: role %q; org:owner or project:owner is required", tenant.ErrTiDBCloudRoleInsufficient, role)
 	}
+	recordTiDBCloudOpenAPIRequest(tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultOK)
 	return &tenant.TiDBCloudAPIKeyIdentity{OrganizationID: strings.TrimSpace(parts[1]), Role: role}, nil
 }
 
 func (a *HTTPClustersAPI) doDigestAuthRequest(ctx context.Context, publicKey, privateKey, method, uri string, body []byte) (*http.Response, error) {
+	api := tidbCloudAPIForRequest(uri)
+	operation := tidbCloudOperationForRequest(method, uri)
 	req, err := http.NewRequestWithContext(ctx, method, uri, bytes.NewReader(body))
 	if err != nil {
+		recordTiDBCloudOpenAPIRequest(api, operation, tidbCloudResultProtocolError)
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
@@ -318,6 +369,7 @@ func (a *HTTPClustersAPI) doDigestAuthRequest(ctx context.Context, publicKey, pr
 	resp, err := a.client.Do(req)
 	if err != nil {
 		err = redactRequestError(err, uri)
+		recordTiDBCloudOpenAPIRequest(api, operation, tiDBCloudRequestErrorResult(err))
 		logger.Error(ctx, "tidbcloud_api_request",
 			zap.String("method", method),
 			zap.String("path", requestPath(uri)),
@@ -339,14 +391,17 @@ func (a *HTTPClustersAPI) doDigestAuthRequest(ctx context.Context, publicKey, pr
 	wwwAuth := resp.Header.Get("WWW-Authenticate")
 	nonce, realm, qop := parseDigestChallenge(wwwAuth)
 	if nonce == "" {
+		recordTiDBCloudOpenAPIRequest(api, operation, tidbCloudResultDigestError)
 		return nil, fmt.Errorf("invalid digest challenge")
 	}
 	auth, err := buildDigestAuth(publicKey, privateKey, method, uri, nonce, realm, qop)
 	if err != nil {
+		recordTiDBCloudOpenAPIRequest(api, operation, tidbCloudResultDigestError)
 		return nil, err
 	}
 	req2, err := http.NewRequestWithContext(ctx, method, uri, bytes.NewReader(body))
 	if err != nil {
+		recordTiDBCloudOpenAPIRequest(api, operation, tidbCloudResultProtocolError)
 		return nil, err
 	}
 	req2.Header.Set("Content-Type", "application/json")
@@ -355,6 +410,7 @@ func (a *HTTPClustersAPI) doDigestAuthRequest(ctx context.Context, publicKey, pr
 	resp2, err := a.client.Do(req2)
 	if err != nil {
 		err = redactRequestError(err, uri)
+		recordTiDBCloudOpenAPIRequest(api, operation, tiDBCloudRequestErrorResult(err))
 		logger.Error(ctx, "tidbcloud_api_request",
 			zap.String("method", method),
 			zap.String("path", requestPath(uri)),

--- a/pkg/tenant/tidbcloudnative/http_clusters_api.go
+++ b/pkg/tenant/tidbcloudnative/http_clusters_api.go
@@ -214,7 +214,7 @@ func (a *HTTPClustersAPI) DeleteCluster(ctx context.Context, publicKey, privateK
 		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationDeleteCluster, tidbCloudResultOK)
 		return nil
 	}
-	recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationDeleteCluster, resp.StatusCode, true)
+	recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationDeleteCluster, resp.StatusCode, false)
 	raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 	if readErr != nil {
 		return readErr
@@ -300,7 +300,7 @@ func (a *HTTPClustersAPI) DeleteBranch(ctx context.Context, publicKey, privateKe
 		recordTiDBCloudOpenAPIRequest(tidbCloudAPICluster, tidbCloudOperationDeleteBranch, tidbCloudResultOK)
 		return nil
 	}
-	recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationDeleteBranch, resp.StatusCode, true)
+	recordTiDBCloudHTTPResponse(tidbCloudAPICluster, tidbCloudOperationDeleteBranch, resp.StatusCode, false)
 	raw, readErr := readUpstreamBody(resp.Body, upstreamErrorBodyLimit+1)
 	if readErr != nil {
 		return readErr

--- a/pkg/tenant/tidbcloudnative/openapi_metrics.go
+++ b/pkg/tenant/tidbcloudnative/openapi_metrics.go
@@ -129,6 +129,9 @@ func tidbCloudOperationForRequest(method, uri string) string {
 			return tidbCloudOperationGetCluster
 		}
 	default:
+		// All production callers use one of the fixed IAM/cluster paths above;
+		// this bounded fallback is for malformed or newly introduced paths and
+		// must never be replaced with the raw URI as a metric label.
 		return "unknown"
 	}
 }

--- a/pkg/tenant/tidbcloudnative/openapi_metrics.go
+++ b/pkg/tenant/tidbcloudnative/openapi_metrics.go
@@ -14,7 +14,6 @@ import (
 const (
 	tidbCloudAPICluster = "cluster"
 	tidbCloudAPIIAM     = "iam"
-	tidbCloudAPIBilling = "billing"
 
 	tidbCloudOperationCreateCluster         = "create_cluster"
 	tidbCloudOperationBatchCreateClusters   = "batch_create_clusters"
@@ -26,7 +25,6 @@ const (
 	tidbCloudOperationGetBranch             = "get_branch"
 	tidbCloudOperationDeleteBranch          = "delete_branch"
 	tidbCloudOperationResolveAPIKeyIdentity = "resolve_api_key_identity"
-	tidbCloudOperationGetOrganizationPlan   = "get_organization_plan"
 
 	tidbCloudResultOK             = "ok"
 	tidbCloudResultClientError    = "client_error"

--- a/pkg/tenant/tidbcloudnative/openapi_metrics.go
+++ b/pkg/tenant/tidbcloudnative/openapi_metrics.go
@@ -1,0 +1,134 @@
+package tidbcloudnative
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/mem9-ai/drive9/pkg/metrics"
+)
+
+const (
+	tidbCloudAPICluster = "cluster"
+	tidbCloudAPIIAM     = "iam"
+	tidbCloudAPIBilling = "billing"
+
+	tidbCloudOperationCreateCluster         = "create_cluster"
+	tidbCloudOperationBatchCreateClusters   = "batch_create_clusters"
+	tidbCloudOperationGetCluster            = "get_cluster"
+	tidbCloudOperationListClusters          = "list_clusters"
+	tidbCloudOperationUpdateCluster         = "update_cluster"
+	tidbCloudOperationDeleteCluster         = "delete_cluster"
+	tidbCloudOperationCreateBranch          = "create_branch"
+	tidbCloudOperationGetBranch             = "get_branch"
+	tidbCloudOperationDeleteBranch          = "delete_branch"
+	tidbCloudOperationResolveAPIKeyIdentity = "resolve_api_key_identity"
+	tidbCloudOperationGetOrganizationPlan   = "get_organization_plan"
+
+	tidbCloudResultOK             = "ok"
+	tidbCloudResultClientError    = "client_error"
+	tidbCloudResultRateLimited    = "rate_limited"
+	tidbCloudResultUpstreamError  = "upstream_error"
+	tidbCloudResultProtocolError  = "protocol_error"
+	tidbCloudResultDigestError    = "digest_error"
+	tidbCloudResultTimeout        = "timeout"
+	tidbCloudResultTransportError = "transport_error"
+	tidbCloudResultCanceled       = "canceled"
+)
+
+func recordTiDBCloudOpenAPIRequest(api, operation, result string) {
+	if api == "" || operation == "" {
+		return
+	}
+	metrics.RecordTiDBCloudOpenAPIRequest(api, operation, result)
+}
+
+func recordTiDBCloudHTTPResponse(api, operation string, statusCode int, responseValid bool) {
+	recordTiDBCloudOpenAPIRequest(api, operation, tiDBCloudHTTPResult(statusCode, responseValid))
+}
+
+func tiDBCloudHTTPResult(statusCode int, responseValid bool) string {
+	if statusCode >= http.StatusOK && statusCode < http.StatusMultipleChoices {
+		if responseValid {
+			return tidbCloudResultOK
+		}
+		return tidbCloudResultProtocolError
+	}
+	if statusCode == http.StatusTooManyRequests {
+		return tidbCloudResultRateLimited
+	}
+	if statusCode >= http.StatusBadRequest && statusCode < http.StatusInternalServerError {
+		return tidbCloudResultClientError
+	}
+	if statusCode >= http.StatusInternalServerError && statusCode <= 599 {
+		return tidbCloudResultUpstreamError
+	}
+	return tidbCloudResultProtocolError
+}
+
+func tiDBCloudRequestErrorResult(err error) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return tidbCloudResultCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return tidbCloudResultTimeout
+	default:
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
+			return tidbCloudResultTimeout
+		}
+		return tidbCloudResultTransportError
+	}
+}
+
+func tidbCloudAPIForRequest(uri string) string {
+	if strings.Contains(uri, "/v1beta1/apikeys/") {
+		return tidbCloudAPIIAM
+	}
+	return tidbCloudAPICluster
+}
+
+func tidbCloudOperationForRequest(method, uri string) string {
+	path := uri
+	if parsed, err := url.Parse(uri); err == nil {
+		path = parsed.Path
+	}
+	switch {
+	case strings.HasSuffix(path, "/clusters:batchCreate"):
+		return tidbCloudOperationBatchCreateClusters
+	case strings.Contains(path, "/apikeys/"):
+		return tidbCloudOperationResolveAPIKeyIdentity
+	case strings.HasSuffix(path, "/v1beta1/clusters"):
+		if method == http.MethodGet {
+			return tidbCloudOperationListClusters
+		}
+		return tidbCloudOperationCreateCluster
+	case strings.Contains(path, "/branches/"):
+		switch method {
+		case http.MethodGet:
+			return tidbCloudOperationGetBranch
+		case http.MethodDelete:
+			return tidbCloudOperationDeleteBranch
+		default:
+			return tidbCloudOperationCreateBranch
+		}
+	case strings.HasSuffix(path, "/branches"):
+		return tidbCloudOperationCreateBranch
+	case strings.Contains(path, "/clusters/"):
+		switch method {
+		case http.MethodGet:
+			return tidbCloudOperationGetCluster
+		case http.MethodDelete:
+			return tidbCloudOperationDeleteCluster
+		case http.MethodPatch:
+			return tidbCloudOperationUpdateCluster
+		default:
+			return tidbCloudOperationGetCluster
+		}
+	default:
+		return "unknown"
+	}
+}

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -19,6 +20,7 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/traceid"
 )
@@ -27,6 +29,120 @@ type roundTripperFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
 	return f(req)
+}
+
+func tiDBCloudOpenAPIMetricValue(t *testing.T, api, operation, result string) float64 {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	prefix := fmt.Sprintf(`drive9_tidbcloud_openapi_requests_total{api=%q,operation=%q,result=%q} `, api, operation, result)
+	for _, line := range strings.Split(rec.Body.String(), "\n") {
+		if !strings.HasPrefix(line, prefix) {
+			continue
+		}
+		value, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimPrefix(line, prefix)), 64)
+		if err != nil {
+			t.Fatalf("parse metric line %q: %v", line, err)
+		}
+		return value
+	}
+	return 0
+}
+
+func TestTiDBCloudOpenAPIRequestErrorsAreClassified(t *testing.T) {
+	tests := []struct {
+		name       string
+		transport  http.RoundTripper
+		wantResult string
+	}{
+		{name: "digest challenge", transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusUnauthorized, Header: make(http.Header), Body: io.NopCloser(strings.NewReader(""))}, nil
+		}), wantResult: tidbCloudResultDigestError},
+		{name: "canceled", transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, context.Canceled
+		}), wantResult: tidbCloudResultCanceled},
+		{name: "timeout", transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, context.DeadlineExceeded
+		}), wantResult: tidbCloudResultTimeout},
+		{name: "transport", transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("network unavailable")
+		}), wantResult: tidbCloudResultTransportError},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			before := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tt.wantResult)
+			api := NewHTTPClustersAPI("", "https://iam.tidbapi.com", &http.Client{Transport: tt.transport})
+			if _, err := api.ResolveAPIKey(context.Background(), "METRICKEY1", "metric-private"); err == nil {
+				t.Fatal("expected request error")
+			}
+			after := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tt.wantResult)
+			if after != before+1 {
+				t.Fatalf("metric delta = %v, want 1", after-before)
+			}
+		})
+	}
+}
+
+func TestTiDBCloudOpenAPIDigestRetryRecordsOneLogicalRequest(t *testing.T) {
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if r.Header.Get("Authorization") == "" {
+			w.Header().Set("WWW-Authenticate", `Digest realm="tidbcloud", nonce="metric-nonce", qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"name": "orgs/123/projects/456/apiKeys/789", "accessKey": "METRICKEY2", "role": tenant.TiDBCloudRoleOrgOwner,
+		})
+	}))
+	defer ts.Close()
+
+	before := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultOK)
+	api := NewHTTPClustersAPI("", ts.URL, ts.Client())
+	if _, err := api.ResolveAPIKey(context.Background(), "METRICKEY2", "metric-private"); err != nil {
+		t.Fatal(err)
+	}
+	after := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultOK)
+	if calls.Load() != 2 || after != before+1 {
+		t.Fatalf("HTTP calls=%d metric delta=%v, want 2 calls and one logical request", calls.Load(), after-before)
+	}
+}
+
+func TestTiDBCloudOpenAPIProtocolFailureReplacesHTTPSuccess(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{not-json`)
+	}))
+	defer ts.Close()
+
+	beforeOK := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultOK)
+	beforeProtocol := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultProtocolError)
+	api := NewHTTPClustersAPI("", ts.URL, ts.Client())
+	if _, err := api.ResolveAPIKey(context.Background(), "METRICKEY3", "metric-private"); err == nil {
+		t.Fatal("ResolveAPIKey unexpectedly accepted a malformed response")
+	}
+	afterOK := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultOK)
+	afterProtocol := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPIIAM, tidbCloudOperationResolveAPIKeyIdentity, tidbCloudResultProtocolError)
+	if afterOK != beforeOK || afterProtocol != beforeProtocol+1 {
+		t.Fatalf("ok delta=%v protocol_error delta=%v, want 0 and 1", afterOK-beforeOK, afterProtocol-beforeProtocol)
+	}
+}
+
+func TestTiDBCloudOpenAPIClusterListWithoutQueryUsesListOperation(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"clusters":[]}`)
+	}))
+	defer ts.Close()
+	before := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPICluster, tidbCloudOperationListClusters, tidbCloudResultOK)
+	api := NewHTTPClustersAPI(ts.URL, "", ts.Client())
+	if _, _, err := api.ListClusters(context.Background(), "public", "private", nil); err != nil {
+		t.Fatal(err)
+	}
+	after := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPICluster, tidbCloudOperationListClusters, tidbCloudResultOK)
+	if after != before+1 {
+		t.Fatalf("list_clusters metric delta = %v, want 1", after-before)
+	}
 }
 
 func setRequiredNativeProvisionerEnv(t *testing.T) {

--- a/pkg/tenant/tidbcloudnative/provisioner_test.go
+++ b/pkg/tenant/tidbcloudnative/provisioner_test.go
@@ -129,6 +129,42 @@ func TestTiDBCloudOpenAPIProtocolFailureReplacesHTTPSuccess(t *testing.T) {
 	}
 }
 
+func TestTiDBCloudOpenAPIDeleteUnexpectedSuccessIsProtocolError(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(*HTTPClustersAPI) error
+		op   string
+	}{
+		{name: "cluster", call: func(api *HTTPClustersAPI) error {
+			return api.DeleteCluster(context.Background(), "public", "private", "cluster-202")
+		}, op: tidbCloudOperationDeleteCluster},
+		{name: "branch", call: func(api *HTTPClustersAPI) error {
+			return api.DeleteBranch(context.Background(), "public", "private", "cluster-202", "branch-202")
+		}, op: tidbCloudOperationDeleteBranch},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusAccepted,
+					Header:     make(http.Header),
+					Body:       io.NopCloser(strings.NewReader("accepted")),
+				}, nil
+			})}
+			beforeOK := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPICluster, tc.op, tidbCloudResultOK)
+			beforeProtocol := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPICluster, tc.op, tidbCloudResultProtocolError)
+			api := NewHTTPClustersAPI("https://cluster.tidbapi.com", "", client)
+			if err := tc.call(api); err == nil {
+				t.Fatal("unexpected 2xx delete response was accepted")
+			}
+			afterOK := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPICluster, tc.op, tidbCloudResultOK)
+			afterProtocol := tiDBCloudOpenAPIMetricValue(t, tidbCloudAPICluster, tc.op, tidbCloudResultProtocolError)
+			if afterOK != beforeOK || afterProtocol != beforeProtocol+1 {
+				t.Fatalf("ok delta=%v protocol_error delta=%v, want 0 and 1", afterOK-beforeOK, afterProtocol-beforeProtocol)
+			}
+		})
+	}
+}
+
 func TestTiDBCloudOpenAPIClusterListWithoutQueryUsesListOperation(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, `{"clusters":[]}`)


### PR DESCRIPTION
## Summary

- reduce high-cardinality tenant metric shapes and move per-tenant service attribution to a failure-only counter
- delete healthy or retired tenant gauge series, including cross-pod cleanup through the tenant notify outbox
- add bounded metrics for mutation dispatch, API key caching, notify coalescing, tenant outbox delivery, shared-pool convergence, and Vault feature state
- implement the TiDB Cloud OpenAPI api/operation/result contract directly in the HTTP producer, including digest retry, transport/status classification, idempotent delete, and protocol failures
- remove duplicate/dead event-bus counters and instrument the actual retention sweep path
- reduce per-tenant DB pool connection states while preserving role-level saturation capacity

## Alert consumers

The matching alert and rule-test changes were pushed to tidbcloud/runbooks#2688. They replace false-green SSE, extraction, semantic-worker, background-worker, and Vault expressions and add alerts for the new critical-path metrics.

## Validation so far

- focused metric contract, gauge lifecycle, dispatcher, cache, coalescer, outbox, shared-pool, Vault, deletion broadcast, and TiDB Cloud OpenAPI tests pass
- runbooks promtool rule tests pass
- full regression and lint will be run after PR creation, per requested sequencing; results will be added in a follow-up comment

## Scope notes

- no docs files are included
- this PR intentionally includes the TiDB Cloud OpenAPI metrics work previously carried by #785, so it does not depend on that PR merging first