### PR TITLE
fix: open-unlink rmdir ENOTEMPTY and pjdfstest harness false fails

### DIFF
--- a/blackbox/harness/target.py
+++ b/blackbox/harness/target.py
@@ -173,10 +173,11 @@ class Drive9FuseTargetProvider:
         display = cmd if isinstance(cmd, str) else " ".join(cmd)
         start = time.monotonic()
         progress(f"command start: {safe_name} (timeout={timeout}s, logs={log_dir})")
-        # Truncate per invocation. Append mode caused modules that parse their
-        # own logs (e.g. community.pjdfstest) to pick up FAIL lines from older
-        # runs in the same work-dir even when the current prove exited 0.
-        with stdout.open("wb") as out, stderr.open("wb") as err:
+        # Append across invocations. Modules that parse their own logs (e.g.
+        # community.pjdfstest) locate the latest run via the per-invocation
+        # header line below; truncating here would overwrite earlier same-name
+        # logs (e.g. ltp_syscalls shard loops) that failure messages reference.
+        with stdout.open("ab") as out, stderr.open("ab") as err:
             out.write(f"# {utc_ts()} $ {display}\n".encode())
             out.flush()
             proc = subprocess.Popen(

--- a/blackbox/harness/target.py
+++ b/blackbox/harness/target.py
@@ -173,8 +173,11 @@ class Drive9FuseTargetProvider:
         display = cmd if isinstance(cmd, str) else " ".join(cmd)
         start = time.monotonic()
         progress(f"command start: {safe_name} (timeout={timeout}s, logs={log_dir})")
-        with stdout.open("ab") as out, stderr.open("ab") as err:
-            out.write(f"\n# {utc_ts()} $ {display}\n".encode())
+        # Truncate per invocation. Append mode caused modules that parse their
+        # own logs (e.g. community.pjdfstest) to pick up FAIL lines from older
+        # runs in the same work-dir even when the current prove exited 0.
+        with stdout.open("wb") as out, stderr.open("wb") as err:
+            out.write(f"# {utc_ts()} $ {display}\n".encode())
             out.flush()
             proc = subprocess.Popen(
                 cmd,

--- a/blackbox/harness/target.py
+++ b/blackbox/harness/target.py
@@ -180,15 +180,16 @@ class Drive9FuseTargetProvider:
         with stdout.open("ab") as out, stderr.open("ab") as err:
             # The header must begin on its own line (the pjdfstest parser
             # matches it at line starts); a previous command's output may not
-            # have ended with "\n".
+            # have ended with "\n". Fail closed if the boundary check itself
+            # cannot be verified, rather than appending an unanchored header.
             try:
                 if stdout.stat().st_size > 0:
                     with stdout.open("rb") as prev:
                         prev.seek(-1, os.SEEK_END)
                         if prev.read(1) != b"\n":
                             out.write(b"\n")
-            except OSError:
-                pass
+            except OSError as exc:
+                raise BlackboxError(f"cannot verify log header boundary in {stdout}: {exc}") from exc
             out.write(f"# {utc_ts()} $ {display}\n".encode())
             out.flush()
             proc = subprocess.Popen(

--- a/blackbox/harness/target.py
+++ b/blackbox/harness/target.py
@@ -178,6 +178,17 @@ class Drive9FuseTargetProvider:
         # header line below; truncating here would overwrite earlier same-name
         # logs (e.g. ltp_syscalls shard loops) that failure messages reference.
         with stdout.open("ab") as out, stderr.open("ab") as err:
+            # The header must begin on its own line (the pjdfstest parser
+            # matches it at line starts); a previous command's output may not
+            # have ended with "\n".
+            try:
+                if stdout.stat().st_size > 0:
+                    with stdout.open("rb") as prev:
+                        prev.seek(-1, os.SEEK_END)
+                        if prev.read(1) != b"\n":
+                            out.write(b"\n")
+            except OSError:
+                pass
             out.write(f"# {utc_ts()} $ {display}\n".encode())
             out.flush()
             proc = subprocess.Popen(

--- a/blackbox/harness/target.py
+++ b/blackbox/harness/target.py
@@ -178,20 +178,23 @@ class Drive9FuseTargetProvider:
         # header line below; truncating here would overwrite earlier same-name
         # logs (e.g. ltp_syscalls shard loops) that failure messages reference.
         with stdout.open("ab") as out, stderr.open("ab") as err:
-            # The header must begin on its own line (the pjdfstest parser
-            # matches it at line starts); a previous command's output may not
-            # have ended with "\n". Fail closed if the boundary check itself
-            # cannot be verified, rather than appending an unanchored header.
-            try:
-                if stdout.stat().st_size > 0:
-                    with stdout.open("rb") as prev:
-                        prev.seek(-1, os.SEEK_END)
-                        if prev.read(1) != b"\n":
-                            out.write(b"\n")
-            except OSError as exc:
-                raise BlackboxError(f"cannot verify log header boundary in {stdout}: {exc}") from exc
-            out.write(f"# {utc_ts()} $ {display}\n".encode())
-            out.flush()
+            # Each per-invocation header must begin on its own line (the
+            # pjdfstest parser matches headers at line starts in BOTH
+            # streams); a previous command's output may not have ended
+            # with "\n". Fail closed if the boundary check itself cannot
+            # be verified, rather than appending an unanchored header.
+            header = f"# {utc_ts()} $ {display}\n".encode()
+            for stream, log_path in ((out, stdout), (err, stderr)):
+                try:
+                    if log_path.stat().st_size > 0:
+                        with log_path.open("rb") as prev:
+                            prev.seek(-1, os.SEEK_END)
+                            if prev.read(1) != b"\n":
+                                stream.write(b"\n")
+                except OSError as exc:
+                    raise BlackboxError(f"cannot verify log header boundary in {log_path}: {exc}") from exc
+                stream.write(header)
+                stream.flush()
             proc = subprocess.Popen(
                 cmd,
                 cwd=str(cwd or REPO_ROOT),

--- a/blackbox/suites/community/pjdfstest/module.py
+++ b/blackbox/suites/community/pjdfstest/module.py
@@ -60,10 +60,11 @@ class CommunityPjdfstest(BaseModule):
                 env=env,
                 ok_codes=(0, 1, 124),
             )
-            combined = read_text(result.stdout) + "\n" + read_text(result.stderr)
+            stdout_text = read_text(result.stdout)
+            stderr_text = read_text(result.stderr)
             log = ctx.artifact_dir(self.id) / "pjdfstest.log"
-            log.write_text(combined, encoding="utf-8")
-            report = self.parse(combined, str(log), result.code)
+            log.write_text(stdout_text + "\n" + stderr_text, encoding="utf-8")
+            report = self.parse(stdout_text, stderr_text, str(log), result.code)
             write_json(ctx.result_dir / "pjdfstests.json", report)
             ctx.metric("community.pjdfstest.raw_pass_rate", float(report["raw_pass_rate"]), "ratio")
             if anomaly := report.get("anomaly"):
@@ -76,12 +77,21 @@ class CommunityPjdfstest(BaseModule):
         finally:
             ctx.target.unmount(handle)
 
-    def parse(self, text: str, log_path: str, rc: int) -> dict[str, Any]:
-        # If command logs were ever appended across runs, only score the latest
-        # prove invocation (header line written by target.run_cmd).
+    @staticmethod
+    def _latest_section(text: str) -> str:
+        # run_cmd writes a per-invocation header line to BOTH stdout and
+        # stderr; cut each stream at its own last header so stale sections
+        # from earlier invocations (in either stream) are never scored.
         headers = list(re.finditer(r"(?m)^# \d{4}-\d{2}-\d{2}T[^$]*\$ ", text))
         if headers:
-            text = text[headers[-1].start() :]
+            return text[headers[-1].start() :]
+        return text
+
+    def parse(self, stdout_text: str, stderr_text: str, log_path: str, rc: int) -> dict[str, Any]:
+        # Score the latest prove invocation only, per stream: appending the
+        # full stderr after the latest stdout section would count stale
+        # stderr summaries (e.g. an old "Failed: 1") against the latest run.
+        text = self._latest_section(stdout_text) + "\n" + self._latest_section(stderr_text)
         files_matches = list(re.finditer(r"Files=(\d+),\s*Tests=(\d+),", text))
         files_line = files_matches[-1] if files_matches else None
         total_files = int(files_line.group(1)) if files_line else 0

--- a/blackbox/suites/community/pjdfstest/module.py
+++ b/blackbox/suites/community/pjdfstest/module.py
@@ -66,6 +66,10 @@ class CommunityPjdfstest(BaseModule):
             report = self.parse(combined, str(log), result.code)
             write_json(ctx.result_dir / "pjdfstests.json", report)
             ctx.metric("community.pjdfstest.raw_pass_rate", float(report["raw_pass_rate"]), "ratio")
+            if anomaly := report.get("anomaly"):
+                raise BlackboxError(f"pjdfstest harness anomaly ({anomaly}); see {log}")
+            if report["total_cases"] <= 0:
+                raise BlackboxError(f"pjdfstest produced no test summary; see {log}")
             if report["failed_cases"] > 0:
                 raise BlackboxError(f"pjdfstest failures={report['failed_cases']}; see {log}")
             return report
@@ -99,15 +103,21 @@ class CommunityPjdfstest(BaseModule):
             # Ignore TAP TODO failures when counting raw not-ok lines.
             failed_cases = len(re.findall(r"(?m)^not ok\s+\d+(?!.*# TODO)", text))
             total_cases = failed_cases
-        # Trust prove's final Result line when present.
-        if re.search(r"(?m)^Result:\s*PASS\s*$", text) and rc == 0:
-            failed_cases = 0
-            failed_files = []
+        result_pass = re.search(r"(?m)^Result:\s*PASS\s*$", text) is not None
+        anomaly = ""
+        # Do not erase already-parsed failures just because prove printed
+        # Result: PASS — that hides parser/output inconsistencies (B2).
+        if result_pass and rc == 0 and failed_cases > 0:
+            anomaly = "result_pass_with_failed_summaries"
         if rc != 0 and failed_cases == 0:
             failed_cases = 1
             total_cases = max(total_cases, 1)
+        # No Files=/Tests= summary and no counted cases: fail-closed (B3).
+        # A successful run must produce a non-zero test count.
+        if total_cases == 0 and not anomaly:
+            anomaly = "no_test_summary"
         passed_cases = max(total_cases - failed_cases, 0)
-        return {
+        report: dict[str, Any] = {
             "schema": "drive9-fuse-pjdfstest/v2",
             "rc": rc,
             "log": log_path,
@@ -115,6 +125,10 @@ class CommunityPjdfstest(BaseModule):
             "total_cases": total_cases,
             "passed_cases": passed_cases,
             "failed_cases": failed_cases,
-            "raw_pass_rate": (passed_cases / total_cases) if total_cases else 1.0 if rc == 0 else 0.0,
+            # Zero-test runs report 0.0, never a fake perfect score.
+            "raw_pass_rate": (passed_cases / total_cases) if total_cases else 0.0,
             "failed_files": failed_files,
         }
+        if anomaly:
+            report["anomaly"] = anomaly
+        return report

--- a/blackbox/suites/community/pjdfstest/module.py
+++ b/blackbox/suites/community/pjdfstest/module.py
@@ -4,6 +4,7 @@ import os
 import re
 import shutil
 import subprocess
+from pathlib import Path
 from typing import Any
 
 from harness.core import BlackboxError, Context, write_json
@@ -21,6 +22,9 @@ class CommunityPjdfstest(BaseModule):
         ensure_pjdfstest(ctx)
 
     def run(self, ctx: Context) -> dict[str, Any]:
+        # Absolute path: Arch puts prove under /usr/bin/core_perl, which is off
+        # sudo's secure_path; bare "prove" fails with "command not found".
+        prove_bin = ctx.deps.ensure_prove()
         tests_dir, bin_path = ensure_pjdfstest(ctx)
         remote = ctx.target.remote_root(self.id)
         ctx.target.mkdir_remote(remote)
@@ -30,19 +34,24 @@ class CommunityPjdfstest(BaseModule):
             work_dir.mkdir(exist_ok=True)
             test_args = [str(tests_dir)]
             env = ctx.target.base_env()
-            env["PATH"] = f"{bin_path.parent}:{tests_dir.parent}:{env.get('PATH', '')}"
+            # Keep pjdfstest + prove dirs on PATH for prove-spawned .t scripts.
+            # sudo's secure_path often discards PATH even with -E, so when we
+            # elevate we re-inject PATH via `env` and invoke prove by absolute
+            # path (Arch: /usr/bin/core_perl/prove is off the default secure_path).
+            env["PATH"] = f"{bin_path.parent}:{tests_dir.parent}:{Path(prove_bin).parent}:{env.get('PATH', '')}"
             # pjdfstest exercises privileged operations (chown, chmod, utimens,
-            # etc.) that require root. When not root, elevate via sudo -E so
-            # the harness itself stays unprivileged. If sudo is unavailable or
-            # not passwordless, fail hard rather than running a degraded suite.
-            prove_cmd = ["prove", "--recurse", "--verbose", *test_args]
+            # etc.) that require root. When not root, elevate via passwordless
+            # sudo so the harness itself stays unprivileged. If sudo is
+            # unavailable or not passwordless, fail hard rather than running a
+            # degraded suite.
+            prove_cmd = [prove_bin, "--recurse", "--verbose", *test_args]
             if not ctx.capabilities.get("is_root"):
                 if not shutil.which("sudo"):
                     raise BlackboxError("pjdfstest requires root or passwordless sudo; sudo not found")
                 probe = subprocess.run(["sudo", "-n", "true"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
                 if probe.returncode != 0:
                     raise BlackboxError("pjdfstest requires root or passwordless sudo; sudo not available")
-                prove_cmd = ["sudo", "-E", *prove_cmd]
+                prove_cmd = ["sudo", "-n", "env", f"PATH={env['PATH']}", *prove_cmd]
             result = ctx.target.run_cmd(
                 "community-pjdfstest",
                 prove_cmd,
@@ -64,19 +73,36 @@ class CommunityPjdfstest(BaseModule):
             ctx.target.unmount(handle)
 
     def parse(self, text: str, log_path: str, rc: int) -> dict[str, Any]:
-        files_line = re.search(r"Files=(\d+),\s*Tests=(\d+),", text)
+        # If command logs were ever appended across runs, only score the latest
+        # prove invocation (header line written by target.run_cmd).
+        headers = list(re.finditer(r"(?m)^# \d{4}-\d{2}-\d{2}T[^$]*\$ ", text))
+        if headers:
+            text = text[headers[-1].start() :]
+        files_matches = list(re.finditer(r"Files=(\d+),\s*Tests=(\d+),", text))
+        files_line = files_matches[-1] if files_matches else None
         total_files = int(files_line.group(1)) if files_line else 0
         total_cases = int(files_line.group(2)) if files_line else 0
-        failed_file_re = re.compile(r"\S+/tests/(?P<rel>[^ ]+?\.t)\s+\(Wstat:\s*\d+\s+Tests:\s*(?P<tests>\d+)\s+Failed:\s*(?P<failed>\d+)\)")
+        # Only count summary lines with Failed: N (N > 0). The Test Summary
+        # Report may also list files with Failed: 0 (e.g. TODO passed).
+        failed_file_re = re.compile(
+            r"\S+/tests/(?P<rel>[^ ]+?\.t)\s+\(Wstat:\s*\d+\s+Tests:\s*(?P<tests>\d+)\s+Failed:\s*(?P<failed>[1-9]\d*)\)"
+        )
         failed_files = []
         for match in failed_file_re.finditer(text):
-            rel = match.group("rel")
-            failed = int(match.group("failed"))
-            failed_files.append({"path": rel, "tests": int(match.group("tests")), "failed": failed})
+            failed_files.append({
+                "path": match.group("rel"),
+                "tests": int(match.group("tests")),
+                "failed": int(match.group("failed")),
+            })
         failed_cases = sum(item["failed"] for item in failed_files)
         if total_cases == 0:
-            failed_cases = len(re.findall(r"^not ok\s+\d+", text, flags=re.MULTILINE))
+            # Ignore TAP TODO failures when counting raw not-ok lines.
+            failed_cases = len(re.findall(r"(?m)^not ok\s+\d+(?!.*# TODO)", text))
             total_cases = failed_cases
+        # Trust prove's final Result line when present.
+        if re.search(r"(?m)^Result:\s*PASS\s*$", text) and rc == 0:
+            failed_cases = 0
+            failed_files = []
         if rc != 0 and failed_cases == 0:
             failed_cases = 1
             total_cases = max(total_cases, 1)
@@ -89,6 +115,6 @@ class CommunityPjdfstest(BaseModule):
             "total_cases": total_cases,
             "passed_cases": passed_cases,
             "failed_cases": failed_cases,
-            "raw_pass_rate": (passed_cases / total_cases) if total_cases else 0.0,
+            "raw_pass_rate": (passed_cases / total_cases) if total_cases else 1.0 if rc == 0 else 0.0,
             "failed_files": failed_files,
         }

--- a/blackbox/suites/community/pjdfstest/test_parse.py
+++ b/blackbox/suites/community/pjdfstest/test_parse.py
@@ -1,0 +1,83 @@
+"""Unit tests for community.pjdfstest log parsing (no FUSE/mount required)."""
+
+from __future__ import annotations
+
+import unittest
+
+from suites.community.pjdfstest.module import CommunityPjdfstest
+
+
+class ParsePjdfstestLogTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.mod = CommunityPjdfstest()
+
+    def test_pass_run_with_summary(self) -> None:
+        text = """# 2026-07-26T15:03:18Z $ prove --recurse
+All tests successful.
+Test Summary Report
+-------------------
+/tmp/pjdfstest/tests/chown/00.t          (Wstat: 0 Tests: 1280 Failed: 0)
+  TODO passed:   1054, 1058
+Files=238, Tests=8798, 247 wallclock secs
+Result: PASS
+"""
+        report = self.mod.parse(text, "log", rc=0)
+        self.assertEqual(report["failed_cases"], 0)
+        self.assertEqual(report["total_cases"], 8798)
+        self.assertEqual(report["raw_pass_rate"], 1.0)
+        self.assertNotIn("anomaly", report)
+
+    def test_result_pass_with_failed_summaries_is_anomaly(self) -> None:
+        # B2: never erase parsed failures solely because Result: PASS is present.
+        text = """# 2026-07-26T15:03:18Z $ prove --recurse
+/tmp/pjdfstest/tests/unlink/14.t         (Wstat: 0 Tests: 10 Failed: 2)
+Files=1, Tests=10, 1 wallclock secs
+Result: PASS
+"""
+        report = self.mod.parse(text, "log", rc=0)
+        self.assertEqual(report["failed_cases"], 2)
+        self.assertEqual(report["total_cases"], 10)
+        self.assertEqual(report["anomaly"], "result_pass_with_failed_summaries")
+        self.assertLess(report["raw_pass_rate"], 1.0)
+
+    def test_zero_test_no_summary_is_anomaly(self) -> None:
+        # B3: empty/skipped prove output must not look like 100% conformance.
+        text = """# 2026-07-26T15:03:18Z $ prove --recurse
+"""
+        report = self.mod.parse(text, "log", rc=0)
+        self.assertEqual(report["total_cases"], 0)
+        self.assertEqual(report["failed_cases"], 0)
+        self.assertEqual(report["raw_pass_rate"], 0.0)
+        self.assertEqual(report["anomaly"], "no_test_summary")
+
+    def test_uses_latest_command_section_only(self) -> None:
+        text = """# 2026-07-26T12:16:21Z $ prove --recurse
+/tmp/pjdfstest/tests/unlink/14.t         (Wstat: 0 Tests: 7 Failed: 1)
+Files=238, Tests=8798, 245 wallclock secs
+Result: FAIL
+
+# 2026-07-26T15:03:18Z $ prove --recurse
+All tests successful.
+Files=238, Tests=8798, 247 wallclock secs
+Result: PASS
+"""
+        report = self.mod.parse(text, "log", rc=0)
+        self.assertEqual(report["failed_cases"], 0)
+        self.assertEqual(report["total_cases"], 8798)
+        self.assertNotIn("anomaly", report)
+
+    def test_real_fail_run(self) -> None:
+        text = """# 2026-07-26T12:16:21Z $ prove --recurse
+not ok 7 - tried 'rmdir x', expected 0, got ENOTEMPTY
+/tmp/pjdfstest/tests/unlink/14.t         (Wstat: 0 Tests: 7 Failed: 1)
+Files=238, Tests=8798, 245 wallclock secs
+Result: FAIL
+"""
+        report = self.mod.parse(text, "log", rc=1)
+        self.assertEqual(report["failed_cases"], 1)
+        self.assertEqual(report["failed_files"][0]["path"], "unlink/14.t")
+        self.assertNotIn("anomaly", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/blackbox/suites/community/pjdfstest/test_parse.py
+++ b/blackbox/suites/community/pjdfstest/test_parse.py
@@ -21,7 +21,7 @@ Test Summary Report
 Files=238, Tests=8798, 247 wallclock secs
 Result: PASS
 """
-        report = self.mod.parse(text, "log", rc=0)
+        report = self.mod.parse(text, "", "log", rc=0)
         self.assertEqual(report["failed_cases"], 0)
         self.assertEqual(report["total_cases"], 8798)
         self.assertEqual(report["raw_pass_rate"], 1.0)
@@ -34,7 +34,7 @@ Result: PASS
 Files=1, Tests=10, 1 wallclock secs
 Result: PASS
 """
-        report = self.mod.parse(text, "log", rc=0)
+        report = self.mod.parse(text, "", "log", rc=0)
         self.assertEqual(report["failed_cases"], 2)
         self.assertEqual(report["total_cases"], 10)
         self.assertEqual(report["anomaly"], "result_pass_with_failed_summaries")
@@ -44,7 +44,7 @@ Result: PASS
         # B3: empty/skipped prove output must not look like 100% conformance.
         text = """# 2026-07-26T15:03:18Z $ prove --recurse
 """
-        report = self.mod.parse(text, "log", rc=0)
+        report = self.mod.parse(text, "", "log", rc=0)
         self.assertEqual(report["total_cases"], 0)
         self.assertEqual(report["failed_cases"], 0)
         self.assertEqual(report["raw_pass_rate"], 0.0)
@@ -61,7 +61,7 @@ All tests successful.
 Files=238, Tests=8798, 247 wallclock secs
 Result: PASS
 """
-        report = self.mod.parse(text, "log", rc=0)
+        report = self.mod.parse(text, "", "log", rc=0)
         self.assertEqual(report["failed_cases"], 0)
         self.assertEqual(report["total_cases"], 8798)
         self.assertNotIn("anomaly", report)
@@ -73,10 +73,50 @@ not ok 7 - tried 'rmdir x', expected 0, got ENOTEMPTY
 Files=238, Tests=8798, 245 wallclock secs
 Result: FAIL
 """
-        report = self.mod.parse(text, "log", rc=1)
+        report = self.mod.parse(text, "", "log", rc=1)
         self.assertEqual(report["failed_cases"], 1)
         self.assertEqual(report["failed_files"][0]["path"], "unlink/14.t")
         self.assertNotIn("anomaly", report)
+
+
+    def test_stale_stderr_failure_not_scored_against_latest_pass(self) -> None:
+        # D: stale stderr from an earlier invocation must not be counted
+        # against the latest run — both streams carry per-invocation headers.
+        stdout = """# 2026-07-26T12:16:21Z $ prove --recurse
+/tmp/pjdfstest/tests/unlink/14.t         (Wstat: 0 Tests: 7 Failed: 1)
+Files=238, Tests=8798, 245 wallclock secs
+Result: FAIL
+
+# 2026-07-26T15:03:18Z $ prove --recurse
+All tests successful.
+Files=238, Tests=8798, 247 wallclock secs
+Result: PASS
+"""
+        stderr = """# 2026-07-26T12:16:21Z $ prove --recurse
+/tmp/pjdfstest/tests/unlink/14.t         (Wstat: 0 Tests: 7 Failed: 1)
+  Failed: 1/7 tests, 85.71% okay
+
+# 2026-07-26T15:03:18Z $ prove --recurse
+"""
+        report = self.mod.parse(stdout, stderr, "log", rc=0)
+        self.assertEqual(report["failed_cases"], 0)
+        self.assertEqual(report["total_cases"], 8798)
+        self.assertEqual(report["raw_pass_rate"], 1.0)
+        self.assertNotIn("anomaly", report)
+
+    def test_stderr_only_invocation_still_scored(self) -> None:
+        # TAP failures that appear on stderr of the LATEST invocation must
+        # still be counted.
+        stdout = """# 2026-07-26T15:03:18Z $ prove --recurse
+"""
+        stderr = """# 2026-07-26T15:03:18Z $ prove --recurse
+/tmp/pjdfstest/tests/unlink/14.t         (Wstat: 0 Tests: 7 Failed: 1)
+Files=238, Tests=8798, 245 wallclock secs
+Result: FAIL
+"""
+        report = self.mod.parse(stdout, stderr, "log", rc=1)
+        self.assertEqual(report["failed_cases"], 1)
+        self.assertEqual(report["total_cases"], 8798)
 
 
 if __name__ == "__main__":

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -94,7 +94,7 @@ type CommitQueue struct {
 	// back. When true, Enqueue returns errLayerRolledBack and commitOne
 	// skips tryAutoResolveConflict, going straight to terminal failure so
 	// pending writes are preserved as PendingConflict.
-	abandoned    bool
+	abandoned bool
 
 	// OnSuccess is called after successful upload with the committed
 	// revision. Used by dat9fs to seed readCache and update inode revision.
@@ -737,6 +737,79 @@ func (cq *CommitQueue) CancelPath(path string) {
 // pending entry moves to the content-addressed final path.
 func (cq *CommitQueue) CancelPathPreserveLocal(path string) {
 	cq.cancelPath(path, true)
+}
+
+// CancelPathIfInode cancels queued or in-flight uploads for path whose entries
+// were staged by the given inode, leaving entries owned by other inodes (e.g.
+// a replacement file that reused the pathname after an unlink) untouched.
+// Local shadow/index state is always preserved — the caller performs its own
+// generation-scoped cleanup.
+func (cq *CommitQueue) CancelPathIfInode(path string, ino uint64) {
+	if cq == nil || path == "" {
+		return
+	}
+	var cancels []context.CancelFunc
+	seen := make(map[*CommitEntry]struct{})
+	markCanceled := func(e *CommitEntry) {
+		if e == nil || e.Inode != ino {
+			return
+		}
+		e.canceled = true
+		cq.stopDelayedLocked(e)
+		if _, ok := seen[e]; ok {
+			return
+		}
+		seen[e] = struct{}{}
+		if e.cancelCommit != nil {
+			cancels = append(cancels, e.cancelCommit)
+		}
+		if e.cancelUpload != nil {
+			cancels = append(cancels, e.cancelUpload)
+		}
+	}
+
+	cq.mu.Lock()
+	if e, ok := cq.inFlight[path]; ok {
+		markCanceled(e)
+	}
+	if cq.queuedByPath != nil {
+		for e := range cq.queuedByPath[path] {
+			markCanceled(e)
+		}
+		if len(seen) > 0 {
+			remaining := cq.queue[:0]
+			for _, e := range cq.queue {
+				if _, drop := seen[e]; drop {
+					continue
+				}
+				remaining = append(remaining, e)
+			}
+			cq.queue = remaining
+			for e := range seen {
+				if set, ok := cq.queuedByPath[path]; ok {
+					delete(set, e)
+					if len(set) == 0 {
+						delete(cq.queuedByPath, path)
+					}
+				}
+			}
+		}
+	} else {
+		remaining := cq.queue[:0]
+		for _, e := range cq.queue {
+			if e.Path == path && e.Inode == ino {
+				markCanceled(e)
+				continue
+			}
+			remaining = append(remaining, e)
+		}
+		cq.queue = remaining
+	}
+	cq.mu.Unlock()
+
+	for _, cancel := range cancels {
+		cancel()
+	}
 }
 
 // CancelQueuedZeroTruncatePreserveLocal cancels queued, not in-flight,

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -6265,6 +6265,11 @@ func cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh *FileHandle) bool {
 // data. handles must be the exact set snapshotted before the mark pass;
 // handles released in between are skipped via the inode-index liveness check
 // in RelinkPath (their Release already ran the normal lifecycle).
+//
+// Only handle state is rolled back. No staging-store restore is needed:
+// Unlink defers every destructive Remove/CancelPath to the commit point
+// after a successful DELETE, so a failed DELETE leaves writeBack /
+// pendingIndex / shadowStore / queued commits untouched.
 func (fs *Dat9FS) unmarkOpenHandlesAfterFailedUnlink(p string, handles []*FileHandle) {
 	if fs.openHandles == nil || len(handles) == 0 {
 		return
@@ -6284,23 +6289,10 @@ func (fs *Dat9FS) unmarkOpenHandlesAfterFailedUnlink(p string, handles []*FileHa
 		fh.UnlinkedSize = 0
 		if gen := fh.UnlinkedShadowGen; gen != 0 && fs.shadowStore != nil {
 			fh.UnlinkedShadowGen = 0
-			if fh.ShadowSpill && fs.shadowStore.Unretire(gen, p) {
-				// The unlink-time Remove had retired the staged shadow; it is
-				// active again. Move the mark-time pin into the handle's own
-				// slot so Release unpins it exactly once.
-				if fh.ShadowPinned {
-					fs.shadowStore.Unpin(gen)
-				} else {
-					fh.ShadowGen = gen
-					fh.ShadowPinned = true
-				}
-			} else {
-				// Clean-handle read snapshot (or an already-replaced path):
-				// drop the mark-time pin.
-				fs.shadowStore.Unpin(gen)
-			}
-		} else {
-			fh.UnlinkedShadowGen = 0
+			// The mark-time pin is simply dropped: with the deferred commit
+			// point, the staged shadow was never removed or retired, so the
+			// handle keeps reading it by path like any normal handle.
+			fs.shadowStore.Unpin(gen)
 		}
 		fh.Unlock()
 	}
@@ -6441,6 +6433,13 @@ func (fs *Dat9FS) lockWritableRemoteCommitPath(p string) func() {
 			// would delete the newer writer's staged data after it stages — a
 			// silent data-loss bug. Canceling the old entry first ensures its
 			// cleanup runs (or has already run) before the new writer stages.
+			//
+			// The cancel is intentionally path-global (not inode-scoped): the
+			// stuck commit holds this path's PathLock, and Unlink takes the
+			// same lock unbounded, so no unlink+recreate can have completed
+			// while the commit is stuck — the path still belongs to the same
+			// live inode as this writer, and the cancel cannot hit a
+			// replacement file's staged state.
 			fs.debugf("lockWritableRemoteCommitPath: timeout (%s) waiting for %s, canceling in-flight and proceeding", timeout, p)
 			if fs.commitQueue != nil {
 				fs.commitQueue.CancelPath(p)
@@ -8021,10 +8020,10 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	//    window). Marking here is safe: a sync upload that PUTs after this
 	//    point records its committed revision while holding remoteCommitLock,
 	//    which the re-check below turns into a DELETE.
-	// 2. The drains below remove the path's staged shadow (directly or via
-	//    commitQueue CancelPath). Dirty ShadowSpill handles must pin their
-	//    shadow backing FIRST so those removals retire (fd preserved for
-	//    read-after-unlink) instead of deleting it.
+	// 2. The commit-point cleanup below removes the path's staged shadow
+	//    (directly or via commitQueue CancelPath). Dirty ShadowSpill handles
+	//    must pin their shadow backing FIRST so those removals retire (fd
+	//    preserved for read-after-unlink) instead of deleting it.
 	//
 	// snapshotRemote is always true here because pendingNew is not computed
 	// yet; for never-uploaded paths the remote snapshot read simply misses
@@ -8045,24 +8044,26 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		fs.debugf("unlink wait writeback start path=%s", childP)
 		fs.uploader.WaitPath(childP)
 		fs.debugDurationf(waitStart, 0, "unlink wait writeback done path=%s", childP)
-		// Check if the file was created locally and never uploaded.
+		// Check if the file was created locally and never uploaded. Read-only
+		// here: the destructive writeBack Remove is deferred to the commit
+		// point after a successful remote DELETE, so a failed DELETE leaves
+		// closed staged data intact for retry.
 		if meta, ok := fs.writeBack.GetMeta(childP); ok && meta.Kind == PendingNew {
 			pendingNew = true
 		}
-		// Remove pending cache entry to prevent future background uploads.
-		fs.writeBack.Remove(childP)
 	}
-	// Wait for any in-flight commitQueue upload and cancel it so the
-	// background commit cannot resurrect the deleted file.
+	// Wait for any in-flight commitQueue upload so the background commit
+	// cannot resurrect the deleted file. The destructive CancelPath is
+	// deferred to the commit point (see writeBack note above).
 	if fs.commitQueue != nil {
 		waitStart := time.Now()
 		fs.debugf("unlink wait commit start path=%s", childP)
 		fs.commitQueue.WaitPath(childP)
 		fs.debugDurationf(waitStart, 0, "unlink wait commit done path=%s", childP)
 
-		// Re-check pendingIndex after WaitPath but before CancelPath. On a
-		// successful commit, commitQueue removes pendingIndex before taking the
-		// entry out of inFlight/queue, so after WaitPath this distinguishes:
+		// Re-check pendingIndex after WaitPath. On a successful commit,
+		// commitQueue removes pendingIndex before taking the entry out of
+		// inFlight/queue, so after WaitPath this distinguishes:
 		// still PendingNew => never uploaded; missing => uploaded or remote file.
 		if fs.pendingIndex != nil {
 			if meta, ok := fs.pendingIndex.GetMeta(childP); ok {
@@ -8071,20 +8072,13 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 				pendingNew = false
 			}
 		}
-		fs.commitQueue.CancelPath(childP)
 	} else {
-		// Also check pendingIndex for the pending-new flag before clearing.
+		// Also check pendingIndex for the pending-new flag (read-only; the
+		// destructive Remove is deferred to the commit point).
 		if !pendingNew && fs.pendingIndex != nil {
 			if meta, ok := fs.pendingIndex.GetMeta(childP); ok && meta.Kind == PendingNew {
 				pendingNew = true
 			}
-		}
-		// Clean up shadow and pending index directly when no commit queue.
-		if fs.pendingIndex != nil {
-			fs.pendingIndex.Remove(childP)
-		}
-		if fs.shadowStore != nil {
-			fs.shadowStore.Remove(childP)
 		}
 	}
 
@@ -8101,9 +8095,9 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	// After waiting on remoteCommitLock, a concurrent sync Flush may have
 	// just uploaded and recorded a committed revision. That means the path
 	// exists remotely even if we earlier classified it as PendingNew.
-	// Do NOT clear pendingNew merely because we already removed our own
-	// writeBack/pendingIndex entries above — that would force a DELETE for
-	// true never-uploaded PendingNew files.
+	// Re-read the staging metadata under the lock for the same reason —
+	// all of this is read-only; the destructive cleanup happens only after
+	// the commit point below.
 	if fs.latestCommittedRevision(childP) > 0 {
 		pendingNew = false
 	}
@@ -8111,16 +8105,11 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		if meta, ok := fs.writeBack.GetMeta(childP); ok {
 			pendingNew = meta.Kind == PendingNew
 		}
-		fs.writeBack.Remove(childP)
 	}
 	if fs.pendingIndex != nil {
 		if meta, ok := fs.pendingIndex.GetMeta(childP); ok {
 			pendingNew = meta.Kind == PendingNew
 		}
-		fs.pendingIndex.Remove(childP)
-	}
-	if fs.shadowStore != nil {
-		fs.shadowStore.Remove(childP)
 	}
 
 	if !pendingNew {
@@ -8139,13 +8128,39 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 				// remotely, so the handles must not be treated as unlinked —
 				// otherwise their next Flush/Fsync/Release discards dirty
 				// data (silent data loss after a transient DELETE error).
+				// No staging-store rollback is needed: every destructive
+				// Remove/CancelPath is deferred to the commit point below,
+				// which a failed DELETE never reaches.
 				fs.unmarkOpenHandlesAfterFailedUnlink(childP, markedHandles)
 				status = httpToFuseStatus(err)
 				return status
 			}
 		}
 	}
-	// Release the per-path lock immediately after the remote DELETE: the B4
+
+	// Commit point passed (remote DELETE succeeded, or the path was never
+	// uploaded). NOW destroy the path's staged local state — write-back
+	// entry, queued commits, pending index, shadow — while still holding
+	// remoteCommitLock so no same-path producer (e.g. a commit-queue worker
+	// blocked on PathLock) can upload between the DELETE and this cleanup.
+	// Path-global removal is correct here: the name is being deleted, and a
+	// replacement create cannot start before Unlink returns (kernel parent
+	// serialization); straggler handles are marked unlinked in pass 2 below
+	// and their discard is ownership-scoped.
+	if fs.writeBack != nil {
+		fs.writeBack.Remove(childP)
+	}
+	if fs.commitQueue != nil {
+		fs.commitQueue.CancelPath(childP)
+	} else {
+		if fs.pendingIndex != nil {
+			fs.pendingIndex.Remove(childP)
+		}
+		if fs.shadowStore != nil {
+			fs.shadowStore.Remove(childP)
+		}
+	}
+	// Release the per-path lock immediately after the commit point: the B4
 	// invariant only covers remote commit producers, and the remaining
 	// handle/inode bookkeeping takes fh.mu (lock order is fh.mu →
 	// remoteCommitLock everywhere else).

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11484,6 +11484,15 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		return fs.flushGitHandleLockedWithPolicy(flushCtx, fh, fs.syncMode == SyncStrict)
 	}
 
+	// Unlink-while-open: never stage/enqueue/upload. Fsync can otherwise
+	// re-enter commitQueue after Unlink's ordered drain and resurrect the
+	// deleted path (write → unlink → fsync → close → rmdir ENOTEMPTY).
+	if fh.Unlinked {
+		phase = "unlinked-discard"
+		fs.discardUnlinkedHandleStateLocked(fh)
+		return gofuse.OK
+	}
+
 	// Interactive mode: Fsync = local durable only. Shadow file + journal
 	// ensure crash safety. Remote commit happens asynchronously.
 	requiresRemoteSync := isSQLitePersistentJournalPath(fh.Path)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7974,22 +7974,24 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	unlockRemoteCommit := fs.lockRemoteCommitPath(childP)
 	defer unlockRemoteCommit()
 
-	// A concurrent Flush may have finished under this lock and cleared
-	// pending-new staging while uploading the path. Recompute before DELETE.
+	// After waiting on remoteCommitLock, a concurrent sync Flush may have
+	// just uploaded and recorded a committed revision. That means the path
+	// exists remotely even if we earlier classified it as PendingNew.
+	// Do NOT clear pendingNew merely because we already removed our own
+	// writeBack/pendingIndex entries above — that would force a DELETE for
+	// true never-uploaded PendingNew files.
+	if fs.latestCommittedRevision(childP) > 0 {
+		pendingNew = false
+	}
 	if fs.writeBack != nil {
-		if meta, ok := fs.writeBack.GetMeta(childP); ok && meta.Kind == PendingNew {
-			pendingNew = true
-		} else if pendingNew {
-			// writeBack gone after a successful sync flush → must DELETE.
-			pendingNew = false
+		if meta, ok := fs.writeBack.GetMeta(childP); ok {
+			pendingNew = meta.Kind == PendingNew
 		}
 		fs.writeBack.Remove(childP)
 	}
 	if fs.pendingIndex != nil {
 		if meta, ok := fs.pendingIndex.GetMeta(childP); ok {
 			pendingNew = meta.Kind == PendingNew
-		} else if pendingNew {
-			pendingNew = false
 		}
 		fs.pendingIndex.Remove(childP)
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7963,6 +7963,40 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		}
 	}
 
+	// Serialize with synchronous Flush/Fsync handle uploads that hold the
+	// per-path remoteCommitLock across the network write while releasing
+	// fh.mu. Without this lock, Unlink can DELETE and return while an
+	// in-flight PUT still recreates the name (B4 / ENOTEMPTY class).
+	//
+	// Invariant: once Unlink returns OK, every remote commit producer for
+	// this path that started before or concurrently — including sync
+	// handle uploads — has finished, and Unlink's DELETE lands after them.
+	unlockRemoteCommit := fs.lockRemoteCommitPath(childP)
+	defer unlockRemoteCommit()
+
+	// A concurrent Flush may have finished under this lock and cleared
+	// pending-new staging while uploading the path. Recompute before DELETE.
+	if fs.writeBack != nil {
+		if meta, ok := fs.writeBack.GetMeta(childP); ok && meta.Kind == PendingNew {
+			pendingNew = true
+		} else if pendingNew {
+			// writeBack gone after a successful sync flush → must DELETE.
+			pendingNew = false
+		}
+		fs.writeBack.Remove(childP)
+	}
+	if fs.pendingIndex != nil {
+		if meta, ok := fs.pendingIndex.GetMeta(childP); ok {
+			pendingNew = meta.Kind == PendingNew
+		} else if pendingNew {
+			pendingNew = false
+		}
+		fs.pendingIndex.Remove(childP)
+	}
+	if fs.shadowStore != nil {
+		fs.shadowStore.Remove(childP)
+	}
+
 	if !pendingNew {
 		ctx, cf := fuseCtx(cancel)
 		defer cf()
@@ -11002,6 +11036,10 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 			log.Printf("sync handle shadowspill upload failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
+		if fh.Unlinked {
+			fs.discardUnlinkedHandleStateLocked(fh)
+			return gofuse.OK
+		}
 		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			log.Printf("sync handle shadowspill pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
@@ -12557,6 +12595,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			log.Printf("finish streaming failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
+		if fh.Unlinked {
+			phase = "unlinked-after-streaming"
+			fs.discardUnlinkedHandleStateLocked(fh)
+			return gofuse.OK
+		}
 		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			log.Printf("finish streaming pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
@@ -12625,6 +12668,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		if err != nil {
 			log.Printf("upload all parts failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
+		}
+		if fh.Unlinked {
+			phase = "unlinked-after-upload-all"
+			fs.discardUnlinkedHandleStateLocked(fh)
+			return gofuse.OK
 		}
 		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			log.Printf("upload all pending chmod failed for %s: %v", fh.Path, err)
@@ -12867,6 +12915,14 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	if err != nil {
 		log.Printf("flush upload failed for %s: %v", handlePath, err)
 		return httpToFuseStatus(err)
+	}
+	// If Unlink completed after we released remoteCommitLock (it serializes
+	// DELETE after our PUT via the same lock), the path is already deleted.
+	// Discard local staging and do not re-publish handle committed state.
+	if fh.Unlinked {
+		phase = "unlinked-after-upload"
+		fs.discardUnlinkedHandleStateLocked(fh)
+		return gofuse.OK
 	}
 	if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 		log.Printf("flush pending chmod failed for %s: %v", handlePath, err)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1224,7 +1224,10 @@ func (fs *Dat9FS) layerDirHasOpenChild(prefix string) bool {
 		}
 		fh.Lock()
 		path := fh.Path
-		unlinked := fh.UnlinkedData != nil
+		// fh.Unlinked is set by markOpenHandlesUnlinked for every open-unlinked
+		// handle. UnlinkedData alone is incomplete: dirty open-unlinked handles
+		// keep their Dirty buffer and may never populate UnlinkedData.
+		unlinked := fh.Unlinked || fh.UnlinkedData != nil
 		fh.Unlock()
 		if unlinked {
 			continue
@@ -1234,6 +1237,41 @@ func (fs *Dat9FS) layerDirHasOpenChild(prefix string) bool {
 		}
 	}
 	return false
+}
+
+// discardUnlinkedHandleStateLocked drops staged dirty/pending state for a
+// handle whose path was unlinked while open. Caller must hold fh.Lock.
+// Returning early from Flush/Release without this would re-stage write-back
+// and re-upload the file, leaving an orphan that makes parent rmdir ENOTEMPTY
+// (pjdfstest unlink/14.t).
+func (fs *Dat9FS) discardUnlinkedHandleStateLocked(fh *FileHandle) {
+	if fh == nil || !fh.Unlinked {
+		return
+	}
+	if fh.Dirty != nil {
+		fh.Dirty.ClearDirty()
+	}
+	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+	fh.DirtySeq = 0
+	fh.WriteBackSeq = 0
+	fh.ShadowCommitReady = false
+	fh.ShadowCommitSeq = 0
+	path := fh.Path
+	if path == "" {
+		return
+	}
+	if fs.debouncer != nil {
+		fs.debouncer.CancelNoWait(path)
+	}
+	if fs.writeBack != nil {
+		fs.writeBack.Remove(path)
+	}
+	if fs.pendingIndex != nil {
+		fs.pendingIndex.Remove(path)
+	}
+	if fs.commitQueue != nil {
+		fs.commitQueue.CancelPath(path)
+	}
 }
 
 func (fs *Dat9FS) lookupLayerNamespaceEntry(parentIno uint64, childP, name string, out *gofuse.EntryOut) (bool, gofuse.Status) {
@@ -10926,6 +10964,11 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 	if fh == nil || fh.Dirty == nil {
 		return gofuse.OK
 	}
+	if fh.Unlinked {
+		// Path was removed while open; never re-upload discarded content.
+		fs.discardUnlinkedHandleStateLocked(fh)
+		return gofuse.OK
+	}
 	if fs.clearStaleSQLitePersistentJournalEmptyCreateLocked(fh) {
 		return gofuse.OK
 	}
@@ -11139,6 +11182,15 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 		flushCtx, flushCancel := fuseCtxWithTimeout(cancel, gitCheckpointTimeout)
 		defer flushCancel()
 		return fs.flushGitHandleLockedWithPolicy(flushCtx, fh, fs.syncMode == SyncStrict)
+	}
+
+	// Unlink-while-open: never re-stage write-back or upload. Doing so
+	// resurrects the path after Unlink's remote DELETE and makes parent
+	// rmdir return ENOTEMPTY (pjdfstest unlink/14.t).
+	if fh.Unlinked {
+		phase = "unlinked-discard"
+		fs.discardUnlinkedHandleStateLocked(fh)
+		return gofuse.OK
 	}
 
 	if fh.Dirty != nil && fh.Dirty.HasDirtyParts() &&
@@ -11875,6 +11927,16 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 		phase = "cancel-debounce"
 		fs.debouncer.CancelNoWait(fh.Path)
 
+		// Unlink-while-open: discard dirty state and skip all remote uploads.
+		fh.Lock()
+		if fh.Unlinked {
+			phase = "unlinked-discard"
+			fs.discardUnlinkedHandleStateLocked(fh)
+			fh.Unlock()
+			return
+		}
+		fh.Unlock()
+
 		// close-sync is primarily enforced in Flush so close(2) can receive
 		// remote upload errors. Keep Release as a best-effort fallback for
 		// unusual flows where dirty staged state reaches Release directly.
@@ -12198,11 +12260,20 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 			return
 		}
 		// Skip the upload if the file has been unlinked since the debounce
-		// was scheduled. After Unlink, the inode is removed from the path
-		// map (RemoveLink). Without this check, the debounced callback
-		// would upload the file to the server after Unlink has already
-		// processed it, leaving a stale server-side file that causes
-		// rmdir to fail with ENOTEMPTY.
+		// was scheduled. RemoveLink (no open handles) drops the path map
+		// entry; RemoveLinkPreserve (open handles) keeps Path with
+		// Unlinked=true. Both must suppress re-upload — otherwise the
+		// debounced PUT resurrects a just-deleted path and parent rmdir
+		// fails with ENOTEMPTY (pjdfstest unlink/14.t).
+		if handle.Unlinked {
+			fs.discardUnlinkedHandleStateLocked(handle)
+			handle.Unlock()
+			return
+		}
+		if entry, ok := fs.inodes.GetEntry(ino); !ok || entry.Unlinked {
+			handle.Unlock()
+			return
+		}
 		if _, ok := fs.inodes.GetPath(ino); !ok {
 			handle.Unlock()
 			return
@@ -12357,6 +12428,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	}()
 	if fh.Dirty == nil {
 		phase = "no-dirty-buffer"
+		return gofuse.OK
+	}
+	if fh.Unlinked {
+		phase = "unlinked-discard"
+		fs.discardUnlinkedHandleStateLocked(fh)
 		return gofuse.OK
 	}
 	if fs.clearStaleSQLitePersistentJournalEmptyCreateLocked(fh) {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -6216,6 +6216,18 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		fh.Unlinked = true
 		if fh.Dirty != nil {
 			fh.UnlinkedSize = fh.Dirty.Size()
+			// Dirty ShadowSpill handles keep their authoritative data in the
+			// staged shadow, not in the Dirty buffer (parts were evicted).
+			// Pin that shadow as the handle's private read backing until
+			// Release: the unlink-time Remove then retires it (the fd stays
+			// readable via ReadAtGen) instead of deleting it, and a same-path
+			// replacement gets a fresh shadow file.
+			if fh.ShadowSpill && fh.UnlinkedShadowGen == 0 && fs.shadowStore != nil {
+				if gen, ok := fs.shadowStore.PinIfExists(p); ok {
+					fh.UnlinkedShadowGen = gen
+					fh.UnlinkedSnapshot = true
+				}
+			}
 		} else if snapshotOK {
 			if snapshotShadowGen != 0 && cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) {
 				fh.UnlinkedData = nil
@@ -6244,6 +6256,55 @@ func cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh *FileHandle) bool {
 		fh.UnlinkedData == nil &&
 		fh.UnlinkedShadowGen == 0 &&
 		!fh.UnlinkedSnapshot
+}
+
+// unmarkOpenHandlesAfterFailedUnlink rolls back markOpenHandlesUnlinked when
+// the remote DELETE fails: the directory entry still exists remotely, so the
+// handles must return to normal — otherwise every later Flush/Fsync/Release
+// takes the unlinked-discard branch and silently drops their dirty/staged
+// data. handles must be the exact set snapshotted before the mark pass;
+// handles released in between are skipped via the inode-index liveness check
+// in RelinkPath (their Release already ran the normal lifecycle).
+func (fs *Dat9FS) unmarkOpenHandlesAfterFailedUnlink(p string, handles []*FileHandle) {
+	if fs.openHandles == nil || len(handles) == 0 {
+		return
+	}
+	for _, fh := range handles {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		if !fh.Unlinked {
+			fh.Unlock()
+			continue
+		}
+		fh.Unlinked = false
+		fh.UnlinkedData = nil
+		fh.UnlinkedSnapshot = false
+		fh.UnlinkedSize = 0
+		if gen := fh.UnlinkedShadowGen; gen != 0 && fs.shadowStore != nil {
+			fh.UnlinkedShadowGen = 0
+			if fh.ShadowSpill && fs.shadowStore.Unretire(gen, p) {
+				// The unlink-time Remove had retired the staged shadow; it is
+				// active again. Move the mark-time pin into the handle's own
+				// slot so Release unpins it exactly once.
+				if fh.ShadowPinned {
+					fs.shadowStore.Unpin(gen)
+				} else {
+					fh.ShadowGen = gen
+					fh.ShadowPinned = true
+				}
+			} else {
+				// Clean-handle read snapshot (or an already-replaced path):
+				// drop the mark-time pin.
+				fs.shadowStore.Unpin(gen)
+			}
+		} else {
+			fh.UnlinkedShadowGen = 0
+		}
+		fh.Unlock()
+	}
+	fs.openHandles.RelinkPath(p, handles)
 }
 
 func (fs *Dat9FS) snapshotUnlinkedRemoteToShadow(ctx context.Context, p string, size int64, revision int64, pinCount int) (uint64, error) {
@@ -7943,6 +8004,40 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		status = httpToFuseStatus(err)
 		return status
 	}
+
+	// Pass 1: mark currently-open handles BEFORE the staging drains below and
+	// BEFORE acquiring remoteCommitLock.
+	//
+	// Two ordering constraints force this position:
+	//
+	// 1. markOpenHandlesUnlinked takes fh.mu per handle, and every other code
+	//    path acquires fh.mu before remoteCommitLock (Write, Flush, the
+	//    debounced callback — see the B13 note in flushHandleDebounced).
+	//    Running it while holding remoteCommitLock inverts that order: a
+	//    same-path flush holding fh.mu and waiting on remoteCommitLock would
+	//    deadlock with Unlink holding remoteCommitLock and waiting on fh.mu
+	//    (in practice the flush escapes via the 5s RemoteCommitWaitTimeout
+	//    and proceeds WITHOUT the lock, re-opening the B4 resurrection
+	//    window). Marking here is safe: a sync upload that PUTs after this
+	//    point records its committed revision while holding remoteCommitLock,
+	//    which the re-check below turns into a DELETE.
+	// 2. The drains below remove the path's staged shadow (directly or via
+	//    commitQueue CancelPath). Dirty ShadowSpill handles must pin their
+	//    shadow backing FIRST so those removals retire (fd preserved for
+	//    read-after-unlink) instead of deleting it.
+	//
+	// snapshotRemote is always true here because pendingNew is not computed
+	// yet; for never-uploaded paths the remote snapshot read simply misses
+	// and handles fall back to their dirty buffer / pinned shadow, matching
+	// the old pendingNew-branch behavior.
+	//
+	// Snapshot the handle set first so a failed remote DELETE can roll the
+	// marking back (the entry still exists remotely in that case).
+	markedHandles := fs.openHandles.SnapshotPath(childP)
+	markCtx, markCf := fuseCtx(cancel)
+	preserveOpen = fs.markOpenHandlesUnlinked(markCtx, childP, true)
+	markCf()
+
 	if fs.writeBack != nil && fs.uploader != nil {
 		// Wait for any in-flight upload to finish so it doesn't "revive"
 		// the file on the server after we delete it.
@@ -7993,21 +8088,6 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		}
 	}
 
-	// Pass 1: mark currently-open handles BEFORE acquiring remoteCommitLock.
-	// markOpenHandlesUnlinked takes fh.mu per handle, and every other code
-	// path acquires fh.mu before remoteCommitLock (Write, Flush, the debounced
-	// callback — see the B13 note in flushHandleDebounced). Running it while
-	// holding remoteCommitLock inverts that order: a same-path flush holding
-	// fh.mu and waiting on remoteCommitLock would deadlock with Unlink holding
-	// remoteCommitLock and waiting on fh.mu (in practice the flush escapes via
-	// the 5s RemoteCommitWaitTimeout and proceeds WITHOUT the lock, re-opening
-	// the B4 resurrection window). Marking here is safe: a sync upload that
-	// PUTs after this point records its committed revision while holding
-	// remoteCommitLock, which the re-check below turns into a DELETE.
-	markCtx, markCf := fuseCtx(cancel)
-	preserveOpen = fs.markOpenHandlesUnlinked(markCtx, childP, !pendingNew)
-	markCf()
-
 	// Serialize with synchronous Flush/Fsync handle uploads that hold the
 	// per-path remoteCommitLock across the network write while releasing
 	// fh.mu. Without this lock, Unlink can DELETE and return while an
@@ -8055,6 +8135,11 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		if err != nil {
 			if !isNotFoundErr(err) {
 				unlockRemoteCommit()
+				// Roll back pass-1 marking: the directory entry still exists
+				// remotely, so the handles must not be treated as unlinked —
+				// otherwise their next Flush/Fsync/Release discards dirty
+				// data (silent data loss after a transient DELETE error).
+				fs.unmarkOpenHandlesAfterFailedUnlink(childP, markedHandles)
 				status = httpToFuseStatus(err)
 				return status
 			}
@@ -10072,6 +10157,14 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 	if fh.ShadowSpill && fs.shadowStore != nil {
 		offset := int64(input.Offset)
 		size := fh.Dirty.Size()
+		// Open-unlinked handle: read from the pinned private backing (a
+		// retired shadow generation), never from the live path — that may
+		// belong to a same-path replacement or be already removed.
+		shadowGen := uint64(0)
+		if fh.Unlinked && fh.UnlinkedShadowGen != 0 {
+			shadowGen = fh.UnlinkedShadowGen
+			size = fh.UnlinkedSize
+		}
 		if offset >= size {
 			fh.Unlock()
 			source = "shadow-spill-eof"
@@ -10084,7 +10177,13 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		}
 		fh.Unlock()
 		result := make([]byte, end-offset)
-		n, err := fs.shadowStore.ReadAt(fh.Path, offset, result)
+		var n int
+		var err error
+		if shadowGen != 0 {
+			n, err = fs.shadowStore.ReadAtGen(shadowGen, offset, result)
+		} else {
+			n, err = fs.shadowStore.ReadAt(fh.Path, offset, result)
+		}
 		if err != nil && !errors.Is(err, io.EOF) {
 			source = "shadow-spill-error"
 			return nil, gofuse.EIO
@@ -11425,10 +11524,32 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			}
 			phase = "large-shadowspill-sync-upload"
 			expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+			handleIsNew := fh.IsNew
+			handlePath := fh.Path
+			// B4: serialize with Unlink's remote DELETE — hold the per-path
+			// remoteCommitLock across the network upload while releasing fh.mu,
+			// exactly like flushHandle Path 2. Without it Unlink can DELETE and
+			// return while this large-file PUT is still in flight.
+			unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
 			uploadStart := time.Now()
 			fs.debugf("flush shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 			fh.Unlock()
-			committedRev, err := uploadFromShadowRemoteWithRevision(uploadCtx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevision)
+			committedRev, err := uploadFromShadowRemoteWithRevision(uploadCtx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision)
+			// Record the committed revision while still holding remoteCommitLock
+			// so a waiting Unlink re-check observes the upload and issues a DELETE.
+			if err == nil && committedRev > 0 {
+				if handleIsNew {
+					fs.replaceCommittedRevision(handlePath, committedRev)
+				} else {
+					fs.recordCommittedRevision(handlePath, committedRev)
+				}
+			}
+			if err == nil && committedRev == 0 {
+				if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok && syntheticRev > 0 {
+					fs.recordCommittedRevision(handlePath, syntheticRev)
+				}
+			}
+			unlockRemoteCommit()
 			fh.Lock()
 			var uploadBytes uint64
 			if size > 0 {
@@ -11439,6 +11560,15 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			if err != nil {
 				log.Printf("flush: ShadowSpill sync upload failed for %s: %v", fh.Path, err)
 				return gofuse.EIO
+			}
+			// If Unlink completed while remoteCommitLock was released (it
+			// serializes DELETE after our PUT via the same lock), the path is
+			// already deleted. Discard local staging and do not re-publish
+			// handle committed state.
+			if fh.Unlinked {
+				phase = "unlinked-after-shadowspill-upload"
+				fs.discardUnlinkedHandleStateLocked(fh)
+				return gofuse.OK
 			}
 			if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 				log.Printf("flush: ShadowSpill pending chmod failed for %s: %v", fh.Path, err)
@@ -11690,10 +11820,32 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			return gofuse.OK
 		}
 		phase = "shadowspill-sync-upload"
+		handleIsNew := fh.IsNew
+		handlePath := fh.Path
+		// B4: serialize with Unlink's remote DELETE — hold the per-path
+		// remoteCommitLock across the network upload while releasing fh.mu,
+		// exactly like flushHandle Path 2. Without it Unlink can DELETE and
+		// return while this large-file PUT is still in flight.
+		unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
 		uploadStart := time.Now()
 		fs.debugf("fsync shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 		fh.Unlock()
-		committedRev, err := uploadFromShadowRemoteWithRevision(uploadCtx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevision)
+		committedRev, err := uploadFromShadowRemoteWithRevision(uploadCtx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision)
+		// Record the committed revision while still holding remoteCommitLock
+		// so a waiting Unlink re-check observes the upload and issues a DELETE.
+		if err == nil && committedRev > 0 {
+			if handleIsNew {
+				fs.replaceCommittedRevision(handlePath, committedRev)
+			} else {
+				fs.recordCommittedRevision(handlePath, committedRev)
+			}
+		}
+		if err == nil && committedRev == 0 {
+			if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok && syntheticRev > 0 {
+				fs.recordCommittedRevision(handlePath, syntheticRev)
+			}
+		}
+		unlockRemoteCommit()
 		fh.Lock()
 		var uploadBytes uint64
 		if size > 0 {
@@ -11704,6 +11856,15 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		if err != nil {
 			log.Printf("fsync: ShadowSpill sync upload failed for %s: %v", fh.Path, err)
 			return gofuse.EIO
+		}
+		// If Unlink completed while remoteCommitLock was released (it
+		// serializes DELETE after our PUT via the same lock), the path is
+		// already deleted. Discard local staging and do not re-publish
+		// handle committed state.
+		if fh.Unlinked {
+			phase = "unlinked-after-shadowspill-upload"
+			fs.discardUnlinkedHandleStateLocked(fh)
+			return gofuse.OK
 		}
 		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			log.Printf("fsync: ShadowSpill pending chmod failed for %s: %v", fh.Path, err)
@@ -12080,6 +12241,16 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			fh.Lock()
 			if lockWait := time.Since(lockStart); fs.debugEnabled() && lockWait >= fuseDebugSlowOpThreshold {
 				fs.debugf("release lock wait path=%s fh=%d ino=%d phase=%s wait=%s", fh.Path, input.Fh, fh.Ino, phase, lockWait)
+			}
+			// Unlink may have marked this handle between the earlier check
+			// and this lock acquisition; discard instead of enqueueing —
+			// the queued commit could land after Unlink's DELETE and
+			// resurrect the path (B4 class).
+			if fh.Unlinked {
+				phase = "unlinked-discard"
+				fs.discardUnlinkedHandleStateLocked(fh)
+				fh.Unlock()
+				return
 			}
 			fh.Dirty.ClearDirty()
 			fs.clearDirtySize(fh.Ino, fh.DirtySeq)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1244,10 +1244,20 @@ func (fs *Dat9FS) layerDirHasOpenChild(prefix string) bool {
 // Returning early from Flush/Release without this would re-stage write-back
 // and re-upload the file, leaving an orphan that makes parent rmdir ENOTEMPTY
 // (pjdfstest unlink/14.t).
+//
+// Path-keyed cleanup is strictly ownership-scoped: POSIX allows recreating
+// the pathname while the old unlinked fd is still open, and path-global
+// removes would then destroy the replacement file's staged state (B5). Each
+// store entry is removed only if it is still the exact generation/inode this
+// handle staged; anything newer belongs to a replacement and is left alone.
 func (fs *Dat9FS) discardUnlinkedHandleStateLocked(fh *FileHandle) {
 	if fh == nil || !fh.Unlinked {
 		return
 	}
+	// Release the staged same-path commit reservation, if this handle still
+	// owns one. Otherwise it would stay held until the final Release and
+	// block same-path create/write for RemoteCommitWaitTimeout.
+	fs.releaseHandleRemoteCommitPathLocked(fh)
 	if fh.Dirty != nil {
 		fh.Dirty.ClearDirty()
 	}
@@ -1261,16 +1271,22 @@ func (fs *Dat9FS) discardUnlinkedHandleStateLocked(fh *FileHandle) {
 		return
 	}
 	if fs.debouncer != nil {
-		fs.debouncer.CancelNoWait(path)
+		fs.debouncer.CancelNoWaitIfOwner(path, fh)
 	}
-	if fs.writeBack != nil {
-		fs.writeBack.Remove(path)
+	if fs.writeBack != nil && fh.WriteBackGen != 0 {
+		fs.writeBack.RemoveIfGeneration(path, fh.WriteBackGen)
 	}
-	if fs.pendingIndex != nil {
-		fs.pendingIndex.Remove(path)
+	if fs.pendingIndex != nil && fh.PendingIndexGen != 0 {
+		fs.pendingIndex.RemoveIfGeneration(path, fh.PendingIndexGen)
 	}
+	if fs.shadowStore != nil && fh.ShadowStageGen != 0 {
+		fs.shadowStore.RemoveIfGeneration(path, fh.ShadowStageGen)
+	}
+	fh.WriteBackGen = 0
+	fh.PendingIndexGen = 0
+	fh.ShadowStageGen = 0
 	if fs.commitQueue != nil {
-		fs.commitQueue.CancelPath(path)
+		fs.commitQueue.CancelPathIfInode(path, fh.Ino)
 	}
 }
 
@@ -3230,13 +3246,22 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 	}
 	mode, hasMode := fs.modeForPendingHandle(fh)
 	if fh.ShadowSpill {
-		if _, err := fs.pendingIndex.PutShadowSpillWithMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode); err != nil {
+		if gen, err := fs.pendingIndex.PutShadowSpillWithMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode); err != nil {
 			log.Printf("pending index put failed for %s: %v", fh.Path, err)
+		} else {
+			fh.PendingIndexGen = gen
 		}
 	} else {
-		if _, err := fs.pendingIndex.PutWithBaseRevAndMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode); err != nil {
+		if gen, err := fs.pendingIndex.PutWithBaseRevAndMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode); err != nil {
 			log.Printf("pending index put failed for %s: %v", fh.Path, err)
+		} else {
+			fh.PendingIndexGen = gen
 		}
+	}
+	// Record the staged shadow content generation so unlink-discard can scope
+	// its cleanup to this handle's staging generation.
+	if fs.shadowStore != nil {
+		fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(fh.Path)
 	}
 	return nil
 }
@@ -3322,7 +3347,7 @@ func (fs *Dat9FS) snapshotWriteBackLocked(fh *FileHandle) error {
 	data := fh.Dirty.bytesView()
 	bvDur := time.Since(bvStart)
 
-	timings, err := fs.writeBack.PutWithBaseRevAndModeTimings(
+	gen, timings, err := fs.writeBack.PutWithBaseRevAndModeTimings(
 		fh.Path,
 		data,
 		fh.Dirty.Size(),
@@ -3331,6 +3356,11 @@ func (fs *Dat9FS) snapshotWriteBackLocked(fh *FileHandle) error {
 		mode,
 		hasMode,
 	)
+	if err == nil {
+		// Record the staged generation so unlink-discard can remove only this
+		// handle's entry, never a fresher replacement at the same path.
+		fh.WriteBackGen = gen
+	}
 	if fs.perf != nil {
 		fs.perf.recordSnapshotWBSubPhases(bvDur, timings)
 	}
@@ -7963,6 +7993,21 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		}
 	}
 
+	// Pass 1: mark currently-open handles BEFORE acquiring remoteCommitLock.
+	// markOpenHandlesUnlinked takes fh.mu per handle, and every other code
+	// path acquires fh.mu before remoteCommitLock (Write, Flush, the debounced
+	// callback — see the B13 note in flushHandleDebounced). Running it while
+	// holding remoteCommitLock inverts that order: a same-path flush holding
+	// fh.mu and waiting on remoteCommitLock would deadlock with Unlink holding
+	// remoteCommitLock and waiting on fh.mu (in practice the flush escapes via
+	// the 5s RemoteCommitWaitTimeout and proceeds WITHOUT the lock, re-opening
+	// the B4 resurrection window). Marking here is safe: a sync upload that
+	// PUTs after this point records its committed revision while holding
+	// remoteCommitLock, which the re-check below turns into a DELETE.
+	markCtx, markCf := fuseCtx(cancel)
+	preserveOpen = fs.markOpenHandlesUnlinked(markCtx, childP, !pendingNew)
+	markCf()
+
 	// Serialize with synchronous Flush/Fsync handle uploads that hold the
 	// per-path remoteCommitLock across the network write while releasing
 	// fh.mu. Without this lock, Unlink can DELETE and return while an
@@ -7972,7 +8017,6 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	// this path that started before or concurrently — including sync
 	// handle uploads — has finished, and Unlink's DELETE lands after them.
 	unlockRemoteCommit := fs.lockRemoteCommitPath(childP)
-	defer unlockRemoteCommit()
 
 	// After waiting on remoteCommitLock, a concurrent sync Flush may have
 	// just uploaded and recorded a committed revision. That means the path
@@ -8000,24 +8044,34 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	}
 
 	if !pendingNew {
-		ctx, cf := fuseCtx(cancel)
-		defer cf()
-		preserveOpen = fs.markOpenHandlesUnlinked(ctx, childP, true)
-
 		// File existed on server (or unknown) — issue remote DELETE.
 		// Tolerate 404 in case it was already deleted.
+		ctx, cf := fuseCtx(cancel)
 		deleteStart := time.Now()
 		fs.debugf("unlink remote delete start path=%s", childP)
 		err := fs.deleteRemoteFileWithInterruptRecovery(ctx, childP)
+		cf()
 		fs.debugDurationf(deleteStart, 0, "unlink remote delete done path=%s err=%v", childP, err)
 		if err != nil {
 			if !isNotFoundErr(err) {
+				unlockRemoteCommit()
 				status = httpToFuseStatus(err)
 				return status
 			}
 		}
-	} else {
-		preserveOpen = fs.markOpenHandlesUnlinked(ctx, childP, false)
+	}
+	// Release the per-path lock immediately after the remote DELETE: the B4
+	// invariant only covers remote commit producers, and the remaining
+	// handle/inode bookkeeping takes fh.mu (lock order is fh.mu →
+	// remoteCommitLock everywhere else).
+	unlockRemoteCommit()
+
+	// Pass 2: handles that raced open between pass 1 and the DELETE escaped
+	// marking; mark them now (no remote snapshot — the path is already gone)
+	// so their Flush/Fsync/Release guards see fh.Unlinked and cannot
+	// resurrect the path.
+	if fs.markOpenHandlesUnlinked(ctx, childP, false) {
+		preserveOpen = true
 	}
 
 	if preserveOpen {
@@ -11098,7 +11152,9 @@ func (fs *Dat9FS) createEmptyHandleRemoteLocked(ctx context.Context, fh *FileHan
 		fs.inodes.UpdateSize(fh.Ino, 0)
 		fs.cacheFileForPath(fh.Path, 0, time.Now(), 0)
 		if fs.pendingIndex != nil {
-			_, _ = fs.pendingIndex.PutWithBaseRev(fh.Path, 0, fs.pendingKindForHandle(fh), expectedRevision)
+			if gen, putErr := fs.pendingIndex.PutWithBaseRev(fh.Path, 0, fs.pendingKindForHandle(fh), expectedRevision); putErr == nil {
+				fh.PendingIndexGen = gen
+			}
 		}
 		return gofuse.OK
 	}
@@ -11299,7 +11355,9 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 				} else {
 					fs.perf.recordFlushSnapshotWB(time.Since(snapWBStart2))
 					if fs.pendingIndex != nil {
-						_, _ = fs.pendingIndex.PutWithBaseRev(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev)
+						if gen, putErr := fs.pendingIndex.PutWithBaseRev(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev); putErr == nil {
+							fh.PendingIndexGen = gen
+						}
 					}
 					// Snapshot the dirty sequence at cache-write time so
 					// Release can detect whether new writes happened since.
@@ -11972,11 +12030,11 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			}
 			return
 		}
-		// Cancel any pending debounce for this path — Release always flushes immediately.
-		phase = "cancel-debounce"
-		fs.debouncer.CancelNoWait(fh.Path)
-
 		// Unlink-while-open: discard dirty state and skip all remote uploads.
+		// Checked BEFORE the path-global debounce cancel: for an unlinked
+		// handle the debounce entry (if any) is cancelled ownership-scoped
+		// inside the discard helper, so a replacement file that reused the
+		// pathname keeps its pending debounce.
 		fh.Lock()
 		if fh.Unlinked {
 			phase = "unlinked-discard"
@@ -11985,6 +12043,10 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			return
 		}
 		fh.Unlock()
+
+		// Cancel any pending debounce for this path — Release always flushes immediately.
+		phase = "cancel-debounce"
+		fs.debouncer.CancelNoWait(fh.Path)
 
 		// close-sync is primarily enforced in Flush so close(2) can receive
 		// remote upload errors. Keep Release as a best-effort fallback for
@@ -12302,7 +12364,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		}
 	}
 
-	fs.debouncer.Schedule(filePath, func() {
+	fs.debouncer.ScheduleWithOwner(filePath, handle, func() {
 		handle.Lock()
 		if handle.Dirty == nil || handle.DirtySeq != snapshotSeq {
 			handle.Unlock()
@@ -12530,8 +12592,10 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		}
 		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 		if fs.pendingIndex != nil {
-			if _, putErr := fs.pendingIndex.PutWithBaseRevAndMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode); putErr != nil {
+			if gen, putErr := fs.pendingIndex.PutWithBaseRevAndMode(fh.Path, size, fs.pendingKindForHandle(fh), fh.BaseRev, mode, hasMode); putErr != nil {
 				log.Printf("layer flush pending index update failed for %s: %v", fh.Path, putErr)
+			} else {
+				fh.PendingIndexGen = gen
 			}
 		}
 		return gofuse.OK

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -8071,6 +8071,11 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 			fs.unmarkOpenHandlesAfterFailedUnlink(childP, markedGitHandles)
 			return st
 		}
+		// Pass 2 (mirrors the remote-DELETE path): handles opened while the
+		// whiteout request was in flight escaped the first mark; mark them
+		// now so their later write/flush/release is suppressed too and the
+		// overlay entry cannot be upserted back over the whiteout.
+		fs.markOpenHandlesUnlinked(ctx, childP, false)
 		parentPath, _ := fs.inodes.GetPath(header.NodeId)
 		fs.dirCache.Remove(parentPath, name)
 		fs.touchDirectoryChangeTime(parentPath, time.Now())

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7978,6 +7978,13 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		}
 		ctx, cf := fuseCtx(cancel)
 		defer cf()
+		// Mark open handles BEFORE writing the whiteout so a flush/write on
+		// an anonymous git fd after unlink cannot upsert the overlay entry
+		// back over the whiteout — the same open-unlink invariant the
+		// remote-DELETE path enforces via markOpenHandlesUnlinked. The git
+		// unlink keeps its existing bookkeeping (no RemoveLinkPreserve;
+		// putGitWhiteout removes the inode entry as before).
+		fs.markOpenHandlesUnlinked(ctx, childP, false)
 		st := fs.putGitWhiteout(ctx, childP)
 		if st != gofuse.OK {
 			return st

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -6217,13 +6217,18 @@ func (fs *Dat9FS) hasOpenHandle(ino uint64, p string) bool {
 	return fs.openHandles.Has(ino, p)
 }
 
-func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapshotRemote bool) bool {
+// markOpenHandlesUnlinked marks every currently-open handle for p as unlinked
+// and detaches them from the path index. It returns the exact set of handles
+// it marked (for rollback on a failed remote DELETE/whiteout — a separate
+// pre-snapshot would race with handles opened in between) and whether that
+// set is non-empty.
+func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapshotRemote bool) (marked []*FileHandle, anyOpen bool) {
 	if fs.openHandles == nil || p == "" {
-		return false
+		return nil, false
 	}
 	handles := fs.openHandles.SnapshotPath(p)
 	if len(handles) == 0 {
-		return false
+		return nil, false
 	}
 
 	var size int64
@@ -6318,7 +6323,7 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		fh.Unlock()
 	}
 	fs.openHandles.UnlinkPath(p)
-	return true
+	return handles, true
 }
 
 func cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh *FileHandle) bool {
@@ -8025,7 +8030,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		if info.IsDir() {
 			return gofuse.Status(syscall.EISDIR)
 		}
-		preserveOpen := fs.markOpenHandlesUnlinked(ctx, childP, false)
+		_, preserveOpen := fs.markOpenHandlesUnlinked(ctx, childP, false)
 		if err := overlay.Remove(childP); err != nil {
 			return localErrToFuseStatus(err)
 		}
@@ -8056,10 +8061,14 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// back over the whiteout — the same open-unlink invariant the
 		// remote-DELETE path enforces via markOpenHandlesUnlinked. The git
 		// unlink keeps its existing bookkeeping (no RemoveLinkPreserve;
-		// putGitWhiteout removes the inode entry as before).
-		fs.markOpenHandlesUnlinked(ctx, childP, false)
+		// putGitWhiteout removes the inode entry as before). If the whiteout
+		// write fails, the directory entry still exists authoritatively, so
+		// the marking is rolled back — otherwise every later write/flush on
+		// those handles would keep being suppressed and silently drop data.
+		markedGitHandles, _ := fs.markOpenHandlesUnlinked(ctx, childP, false)
 		st := fs.putGitWhiteout(ctx, childP)
 		if st != gofuse.OK {
+			fs.unmarkOpenHandlesAfterFailedUnlink(childP, markedGitHandles)
 			return st
 		}
 		parentPath, _ := fs.inodes.GetPath(header.NodeId)
@@ -8110,12 +8119,13 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	// and handles fall back to their dirty buffer / pinned shadow, matching
 	// the old pendingNew-branch behavior.
 	//
-	// Snapshot the handle set first so a failed remote DELETE can roll the
-	// marking back (the entry still exists remotely in that case).
-	markedHandles := fs.openHandles.SnapshotPath(childP)
+	// The mark pass returns the exact handle set it marked, so a failed
+	// remote DELETE can roll precisely those handles back (the entry still
+	// exists remotely in that case).
 	markCtx, markCf := fuseCtx(cancel)
-	preserveOpen = fs.markOpenHandlesUnlinked(markCtx, childP, true)
+	markedHandles, markedAny := fs.markOpenHandlesUnlinked(markCtx, childP, true)
 	markCf()
+	preserveOpen = markedAny
 
 	if fs.writeBack != nil && fs.uploader != nil {
 		// Wait for any in-flight upload to finish so it doesn't "revive"
@@ -8250,7 +8260,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	// marking; mark them now (no remote snapshot — the path is already gone)
 	// so their Flush/Fsync/Release guards see fh.Unlinked and cannot
 	// resurrect the path.
-	if fs.markOpenHandlesUnlinked(ctx, childP, false) {
+	if _, anyOpen := fs.markOpenHandlesUnlinked(ctx, childP, false); anyOpen {
 		preserveOpen = true
 	}
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11033,6 +11033,14 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 	if fh == nil || fh.Dirty == nil || !fh.Dirty.HasDirtyParts() {
 		return gofuse.OK
 	}
+	if fh.Unlinked {
+		// Write-after-unlink on a write-sync handle: POSIX requires the write
+		// to succeed on the anonymous fd (the data is already in the Dirty
+		// buffer and remains readable), but it must NOT recreate the deleted
+		// pathname remotely. Flush/Fsync/Release discard staged state via the
+		// unlinked guards; the write-sync Write path must not upload either.
+		return gofuse.OK
+	}
 	if fs.layerEnabled() {
 		return fs.flushHandle(ctx, fh)
 	}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -20575,6 +20575,250 @@ func TestRmdirAfterOpenUnlinkDirtyFsync(t *testing.T) {
 	}
 }
 
+// TestOldUnlinkedHandleDiscardPreservesReplacementCommit is B5: POSIX allows
+// recreating a pathname while the old unlinked fd is still open. Flush/Release
+// on the old fd must clean up only its OWN staging generation — path-global
+// removes would cancel the replacement file's queued commit and lose its data.
+func TestOldUnlinkedHandleDiscardPreservesReplacementCommit(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		files    = map[string][]byte{}
+		dirs     = map[string]struct{}{"/": {}, "/dir": {}}
+		putCalls atomic.Int32
+	)
+	listDir := func(dir string) []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		var entries []map[string]any
+		for p, data := range files {
+			parent := path.Dir(p)
+			if parent == "." {
+				parent = "/"
+			}
+			if parent == dir {
+				entries = append(entries, map[string]any{"name": path.Base(p), "isDir": false, "size": len(data)})
+			}
+		}
+		return entries
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+		if p == "" {
+			p = "/"
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": listDir(p)})
+		case r.Method == http.MethodPost && r.URL.Query().Has("mkdir"):
+			mu.Lock()
+			dirs[p] = struct{}{}
+			delete(files, p)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPut || r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			files[p] = append([]byte(nil), body...)
+			delete(dirs, p)
+			mu.Unlock()
+			putCalls.Add(1)
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			delete(files, p)
+			delete(dirs, p)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead:
+			mu.Lock()
+			if data, ok := files[p]; ok {
+				w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if _, ok := dirs[p]; ok {
+				w.Header().Set("Content-Length", "0")
+				w.Header().Set("X-Dat9-IsDir", "true")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{SyncMode: SyncInteractive}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	wb, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.SetWriteBack(wb, nil)
+	cq := NewCommitQueue(fs.client, shadow, pending, nil, 1, 8)
+	fs.commitQueue = cq
+	defer cq.DrainAll()
+
+	var mkdirOut gofuse.EntryOut
+	if st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Mode:     0o755,
+	}, "dir", &mkdirOut); st != gofuse.OK {
+		t.Fatalf("Mkdir: %v", st)
+	}
+	dirIno := mkdirOut.NodeId
+
+	// Old handle: create + write + unlink while still open.
+	var oldCreate gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Flags:    uint32(syscall.O_RDWR),
+		Mode:     0o644,
+	}, "file.txt", &oldCreate); st != gofuse.OK {
+		t.Fatalf("Create old: %v", st)
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: oldCreate.NodeId},
+		Fh:       oldCreate.Fh,
+		Size:     uint32(len("old")),
+	}, []byte("old")); st != gofuse.OK {
+		t.Fatalf("Write old: %v", st)
+	}
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: dirIno}, "file.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+
+	// Replacement: recreate the same pathname while the old fd stays open,
+	// then fsync to stage + enqueue its commit.
+	var newCreate gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Flags:    uint32(syscall.O_RDWR),
+		Mode:     0o644,
+	}, "file.txt", &newCreate); st != gofuse.OK {
+		t.Fatalf("Create replacement: %v", st)
+	}
+	if newCreate.NodeId == oldCreate.NodeId {
+		t.Fatal("replacement reused the unlinked inode; test requires a fresh inode")
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: newCreate.NodeId},
+		Fh:       newCreate.Fh,
+		Size:     uint32(len("replacement")),
+	}, []byte("replacement")); st != gofuse.OK {
+		t.Fatalf("Write replacement: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: newCreate.NodeId},
+		Fh:       newCreate.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync replacement: %v", st)
+	}
+	if _, ok := pending.GetMeta("/dir/file.txt"); !ok {
+		t.Fatal("replacement pending entry missing after fsync")
+	}
+	if !shadow.Has("/dir/file.txt") {
+		t.Fatal("replacement shadow missing after fsync")
+	}
+	if !cq.HasPath("/dir/file.txt") {
+		t.Fatal("replacement commit missing after fsync")
+	}
+
+	// Flush + Release on the OLD unlinked fd must not touch the replacement's
+	// staged state (the B5 bug: path-global cleanup canceled it).
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: oldCreate.NodeId},
+		Fh:       oldCreate.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush old unlinked handle: %v", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: oldCreate.NodeId},
+		Fh:       oldCreate.Fh,
+	})
+
+	if _, ok := pending.GetMeta("/dir/file.txt"); !ok {
+		t.Fatal("old unlinked handle removed the replacement's pending entry")
+	}
+	if !shadow.Has("/dir/file.txt") {
+		t.Fatal("old unlinked handle removed the replacement's shadow")
+	}
+	if !cq.HasPath("/dir/file.txt") {
+		t.Fatal("old unlinked handle canceled the replacement's queued commit")
+	}
+
+	// Close the replacement and drain: its data must reach the remote.
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: newCreate.NodeId},
+		Fh:       newCreate.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush replacement: %v", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: newCreate.NodeId},
+		Fh:       newCreate.Fh,
+	})
+	cq.DrainAll()
+
+	mu.Lock()
+	data, ok := files["/dir/file.txt"]
+	mu.Unlock()
+	if !ok {
+		t.Fatal("replacement file never reached the remote backend")
+	}
+	if string(data) != "replacement" {
+		t.Fatalf("replacement remote content = %q, want %q", data, "replacement")
+	}
+	if got := putCalls.Load(); got == 0 {
+		t.Fatal("remote PUT calls = 0, want the replacement commit uploaded")
+	}
+}
+
+// TestDiscardUnlinkedHandleReleasesRemoteCommitLock: a handle that staged a
+// queued commit can still own the same-path commit reservation when it is
+// unlinked. The discard must release it, otherwise same-path create/write
+// blocks until the final Release (or RemoteCommitWaitTimeout).
+func TestDiscardUnlinkedHandleReleasesRemoteCommitLock(t *testing.T) {
+	fs := &Dat9FS{}
+	released := false
+	fh := &FileHandle{
+		Ino:                2,
+		Path:               "/dir/file.txt",
+		Unlinked:           true,
+		RemoteCommitUnlock: func() { released = true },
+	}
+	fh.Lock()
+	fs.discardUnlinkedHandleStateLocked(fh)
+	fh.Unlock()
+	if !released {
+		t.Fatal("discard did not release the handle-owned remote commit lock")
+	}
+	if fh.RemoteCommitUnlock != nil {
+		t.Fatal("fh.RemoteCommitUnlock not cleared by discard")
+	}
+}
+
 func TestRmdirRemoteDeleteDoesNotRetryRecreatedPathAfterInterrupt(t *testing.T) {
 	path := "/repo/emptydir"
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -20173,6 +20173,208 @@ func TestRmdirAfterOpenUnlinkDirtyFlush(t *testing.T) {
 	}
 }
 
+// TestConcurrentFlushDoesNotResurrectUnlinkedPath is B4: an in-flight
+// synchronous Flush that already passed pre-upload Unlinked checks must not
+// leave a resurrected name after concurrent Unlink returns. Unlink waits on
+// the same per-path remoteCommitLock held across the PUT.
+func TestConcurrentFlushDoesNotResurrectUnlinkedPath(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		files          = map[string][]byte{}
+		dirs           = map[string]struct{}{"/": {}, "/dir": {}}
+		putStarted     = make(chan struct{})
+		putRelease     = make(chan struct{})
+		putStartedOnce sync.Once
+		putCalls       atomic.Int32
+		delDir         atomic.Int32
+	)
+	listDir := func(dir string) []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		var entries []map[string]any
+		for p, data := range files {
+			parent := path.Dir(p)
+			if parent == "." {
+				parent = "/"
+			}
+			if parent == dir {
+				entries = append(entries, map[string]any{"name": path.Base(p), "isDir": false, "size": len(data)})
+			}
+		}
+		return entries
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+		if p == "" {
+			p = "/"
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": listDir(p)})
+		case r.Method == http.MethodPost && r.URL.Query().Has("mkdir"):
+			mu.Lock()
+			dirs[p] = struct{}{}
+			delete(files, p)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPut || r.Method == http.MethodPost:
+			// Block after the body is fully received so Flush is in-flight.
+			body, _ := io.ReadAll(r.Body)
+			putStartedOnce.Do(func() { close(putStarted) })
+			<-putRelease
+			mu.Lock()
+			files[p] = append([]byte(nil), body...)
+			delete(dirs, p)
+			mu.Unlock()
+			putCalls.Add(1)
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			if _, isDir := dirs[p]; isDir {
+				for child := range files {
+					if path.Dir(child) == p {
+						mu.Unlock()
+						http.Error(w, "directory not empty", http.StatusConflict)
+						return
+					}
+				}
+				delete(dirs, p)
+				delDir.Add(1)
+			} else {
+				delete(files, p)
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead:
+			mu.Lock()
+			if data, ok := files[p]; ok {
+				w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if _, ok := dirs[p]; ok {
+				w.Header().Set("Content-Length", "0")
+				w.Header().Set("X-Dat9-IsDir", "true")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var mkdirOut gofuse.EntryOut
+	if st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Mode:     0o755,
+	}, "dir", &mkdirOut); st != gofuse.OK {
+		t.Fatalf("Mkdir: %v", st)
+	}
+	dirIno := mkdirOut.NodeId
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Flags:    uint32(syscall.O_RDWR),
+		Mode:     0o644,
+	}, "file.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	// Force close-sync on this handle even if profile defaults differ.
+	if fh, ok := fs.fileHandles.Get(createOut.Fh); ok {
+		fh.WritePolicy = WritePolicyCloseSync
+	}
+	data := []byte("new")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(data)),
+	}, data); st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		flushDone <- fs.Flush(nil, &gofuse.FlushIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+
+	select {
+	case <-putStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for in-flight Flush PUT to start")
+	}
+
+	// Unlink must wait for the in-flight PUT (remoteCommitLock), then DELETE.
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: dirIno}, "file.txt")
+	}()
+
+	// Give Unlink a moment to reach remoteCommitLock wait if the race window
+	// is open; then release the PUT so Flush can finish and Unlink proceed.
+	time.Sleep(50 * time.Millisecond)
+	close(putRelease)
+
+	var unlinkSt, flushSt gofuse.Status
+	select {
+	case unlinkSt = <-unlinkDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for Unlink")
+	}
+	select {
+	case flushSt = <-flushDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for Flush")
+	}
+	if unlinkSt != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", unlinkSt)
+	}
+	if flushSt != gofuse.OK {
+		t.Fatalf("Flush status = %v, want OK", flushSt)
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+
+	mu.Lock()
+	_, exists := files["/dir/file.txt"]
+	mu.Unlock()
+	if exists {
+		t.Fatal("in-flight flush resurrected path after Unlink returned")
+	}
+	if got := putCalls.Load(); got != 1 {
+		// Exactly one PUT from the in-flight Flush; Unlink must not allow a second create.
+		t.Fatalf("remote PUT calls = %d, want 1", got)
+	}
+
+	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
+	if st != gofuse.OK {
+		t.Fatalf("Rmdir after concurrent flush+unlink = %v, want OK", st)
+	}
+	if got := delDir.Load(); got != 1 {
+		t.Fatalf("remote dir DELETE calls = %d, want 1", got)
+	}
+}
+
 // TestRmdirAfterOpenUnlinkDirtyFsync is the Fsync counterpart of
 // TestRmdirAfterOpenUnlinkDirtyFlush: write → unlink while open → fsync(fd)
 // must not re-stage/enqueue/upload the deleted path.

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -19980,6 +19980,203 @@ func TestRmdirSucceedsWithTombstoneFilteringStaleRemoteListing(t *testing.T) {
 	}
 }
 
+// TestRmdirAfterOpenUnlinkDirtyFlush mirrors pjdfstest unlink/14.t:
+// create dir, create file, write while open, unlink while still open (dirty),
+// close (Flush/Release), then rmdir the parent. Flush must not re-upload the
+// unlinked dirty buffer — that would leave an orphan remote file and make
+// rmdir return ENOTEMPTY.
+func TestRmdirAfterOpenUnlinkDirtyFlush(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		files    = map[string][]byte{}
+		dirs     = map[string]struct{}{"/": {}, "/dir": {}}
+		putCalls atomic.Int32
+		delFile  atomic.Int32
+		delDir   atomic.Int32
+	)
+	listDir := func(dir string) []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		prefix := dir
+		if !strings.HasSuffix(prefix, "/") {
+			prefix += "/"
+		}
+		var entries []map[string]any
+		for p := range dirs {
+			if p == "/" || p == dir {
+				continue
+			}
+			parent := path.Dir(p)
+			if parent == "." {
+				parent = "/"
+			}
+			if parent == dir {
+				entries = append(entries, map[string]any{"name": path.Base(p), "isDir": true, "size": 0})
+			}
+		}
+		for p, data := range files {
+			parent := path.Dir(p)
+			if parent == "." {
+				parent = "/"
+			}
+			if parent == dir {
+				entries = append(entries, map[string]any{"name": path.Base(p), "isDir": false, "size": len(data)})
+			}
+		}
+		return entries
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+		if p == "" {
+			p = "/"
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": listDir(p)})
+		case r.Method == http.MethodPost && r.URL.Query().Has("mkdir"):
+			mu.Lock()
+			dirs[p] = struct{}{}
+			delete(files, p)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPut || r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			files[p] = append([]byte(nil), body...)
+			delete(dirs, p)
+			mu.Unlock()
+			putCalls.Add(1)
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			_, isDir := dirs[p]
+			_, isFile := files[p]
+			if isDir {
+				// ENOTEMPTY if any direct child remains.
+				for child := range files {
+					if path.Dir(child) == p || (p == "/" && strings.Count(child, "/") == 1) {
+						mu.Unlock()
+						http.Error(w, "directory not empty", http.StatusConflict)
+						return
+					}
+				}
+				for child := range dirs {
+					if child != p && path.Dir(child) == p {
+						mu.Unlock()
+						http.Error(w, "directory not empty", http.StatusConflict)
+						return
+					}
+				}
+				delete(dirs, p)
+				delDir.Add(1)
+			} else if isFile {
+				delete(files, p)
+				delFile.Add(1)
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead:
+			mu.Lock()
+			if data, ok := files[p]; ok {
+				w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if _, ok := dirs[p]; ok {
+				w.Header().Set("Content-Length", "0")
+				w.Header().Set("X-Dat9-IsDir", "true")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	// Enable write-back so Flush can re-stage after Unlink (the bug path).
+	wb, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.SetWriteBack(wb, nil)
+
+	var mkdirOut gofuse.EntryOut
+	if st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Mode:     0o755,
+	}, "dir", &mkdirOut); st != gofuse.OK {
+		t.Fatalf("Mkdir: %v", st)
+	}
+	dirIno := mkdirOut.NodeId
+
+	// Create + write while open (dirty, never remotely durable yet).
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Flags:    uint32(syscall.O_RDWR),
+		Mode:     0o644,
+	}, "file.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	data := []byte("Hello,_World!")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(data)),
+	}, data); st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+
+	// Unlink while still open (same as pjdfstest open:write:unlink:pread).
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: dirIno}, "file.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+
+	// Close path: Flush then Release must not resurrect the file remotely.
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush after unlink: %v", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+
+	if got := putCalls.Load(); got != 0 {
+		t.Fatalf("remote PUT after open-unlink close = %d, want 0 (must not re-upload)", got)
+	}
+	mu.Lock()
+	if _, ok := files["/dir/file.txt"]; ok {
+		mu.Unlock()
+		t.Fatal("remote still has /dir/file.txt after open-unlink close")
+	}
+	mu.Unlock()
+
+	// Parent rmdir must succeed (pjdfstest unlink/14.t assertion 7).
+	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
+	if st != gofuse.OK {
+		t.Fatalf("Rmdir after open-unlink = %v, want OK", st)
+	}
+	if got := delDir.Load(); got != 1 {
+		t.Fatalf("remote dir DELETE calls = %d, want 1", got)
+	}
+}
+
 func TestRmdirRemoteDeleteDoesNotRetryRecreatedPathAfterInterrupt(t *testing.T) {
 	path := "/repo/emptydir"
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -20585,6 +20585,9 @@ func TestOldUnlinkedHandleDiscardPreservesReplacementCommit(t *testing.T) {
 		files    = map[string][]byte{}
 		dirs     = map[string]struct{}{"/": {}, "/dir": {}}
 		putCalls atomic.Int32
+		// allowPUT gates the replacement's remote upload so the assertions on
+		// staged state are deterministic regardless of worker timing.
+		allowPUT = make(chan struct{})
 	)
 	listDir := func(dir string) []map[string]any {
 		mu.Lock()
@@ -20618,6 +20621,7 @@ func TestOldUnlinkedHandleDiscardPreservesReplacementCommit(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case r.Method == http.MethodPut || r.Method == http.MethodPost:
 			body, _ := io.ReadAll(r.Body)
+			<-allowPUT
 			mu.Lock()
 			files[p] = append([]byte(nil), body...)
 			delete(dirs, p)
@@ -20710,7 +20714,10 @@ func TestOldUnlinkedHandleDiscardPreservesReplacementCommit(t *testing.T) {
 	}
 
 	// Replacement: recreate the same pathname while the old fd stays open,
-	// then fsync to stage + enqueue its commit.
+	// then fsync to stage + enqueue its commit. The server PUT is gated on
+	// allowPUT below, so the queued commit cannot land remotely before the
+	// assertions — whether the worker is still queued or already blocked in
+	// the PUT, pending/shadow/queue state stays observable.
 	var newCreate gofuse.CreateOut
 	if st := fs.Create(nil, &gofuse.CreateIn{
 		InHeader: gofuse.InHeader{NodeId: dirIno},
@@ -20768,7 +20775,9 @@ func TestOldUnlinkedHandleDiscardPreservesReplacementCommit(t *testing.T) {
 		t.Fatal("old unlinked handle canceled the replacement's queued commit")
 	}
 
-	// Close the replacement and drain: its data must reach the remote.
+	// Close the replacement and drain: its data must reach the remote. Open
+	// the server PUT gate first so the queued commit can proceed.
+	close(allowPUT)
 	if st := fs.Flush(nil, &gofuse.FlushIn{
 		InHeader: gofuse.InHeader{NodeId: newCreate.NodeId},
 		Fh:       newCreate.Fh,
@@ -20816,6 +20825,712 @@ func TestDiscardUnlinkedHandleReleasesRemoteCommitLock(t *testing.T) {
 	}
 	if fh.RemoteCommitUnlock != nil {
 		t.Fatal("fh.RemoteCommitUnlock not cleared by discard")
+	}
+}
+
+// TestUnlinkDeleteFailureRollsBackOpenHandleMarks: when the remote DELETE
+// fails (non-404), Unlink must roll back the pass-1 unlinked marking so the
+// still-open dirty handle is NOT treated as removed — otherwise its next
+// Flush/Release discards live data (silent data loss after an unlink that
+// returned an error).
+func TestUnlinkDeleteFailureRollsBackOpenHandleMarks(t *testing.T) {
+	var (
+		mu           sync.Mutex
+		files        = map[string][]byte{}
+		dirs         = map[string]struct{}{"/": {}, "/dir": {}}
+		putCalls     atomic.Int32
+		failNextFile atomic.Bool
+	)
+	failNextFile.Store(true)
+	listDir := func(dir string) []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		var entries []map[string]any
+		for p, data := range files {
+			parent := path.Dir(p)
+			if parent == "." {
+				parent = "/"
+			}
+			if parent == dir {
+				entries = append(entries, map[string]any{"name": path.Base(p), "isDir": false, "size": len(data)})
+			}
+		}
+		return entries
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+		if p == "" {
+			p = "/"
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": listDir(p)})
+		case r.Method == http.MethodGet:
+			mu.Lock()
+			if data, ok := files[p]; ok {
+				mu.Unlock()
+				w.Header().Set("X-Dat9-Revision", "1")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(data)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Query().Has("mkdir"):
+			mu.Lock()
+			dirs[p] = struct{}{}
+			delete(files, p)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPut || r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			files[p] = append([]byte(nil), body...)
+			delete(dirs, p)
+			mu.Unlock()
+			putCalls.Add(1)
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete:
+			if _, isDir := dirs[p]; !isDir && failNextFile.CompareAndSwap(true, false) {
+				// Transient failure on the first file DELETE.
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			delete(files, p)
+			delete(dirs, p)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead:
+			mu.Lock()
+			if data, ok := files[p]; ok {
+				w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if _, ok := dirs[p]; ok {
+				w.Header().Set("Content-Length", "0")
+				w.Header().Set("X-Dat9-IsDir", "true")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var mkdirOut gofuse.EntryOut
+	if st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Mode:     0o755,
+	}, "dir", &mkdirOut); st != gofuse.OK {
+		t.Fatalf("Mkdir: %v", st)
+	}
+	dirIno := mkdirOut.NodeId
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Flags:    uint32(syscall.O_RDWR),
+		Mode:     0o644,
+	}, "file.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	v1 := []byte("uploaded-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1: %v", st)
+	}
+	// Upload v1 so the path exists remotely and Unlink must issue a DELETE.
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush v1: %v", st)
+	}
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("remote PUT for v1 = %d, want 1", got)
+	}
+	data := []byte("must-survive-failed-unlink")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(data)),
+	}, data); st != gofuse.OK {
+		t.Fatalf("Write v2: %v", st)
+	}
+
+	// First Unlink: the remote DELETE fails with 500. Unlink must report the
+	// error AND leave the handle in a normal (not unlinked) state.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: dirIno}, "file.txt"); st == gofuse.OK {
+		t.Fatal("Unlink unexpectedly succeeded despite remote DELETE 500")
+	}
+
+	// Flush must upload the dirty buffer (close-sync), NOT discard it as if
+	// the path had been unlinked.
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush after failed unlink: %v", st)
+	}
+	if got := putCalls.Load(); got != 2 {
+		t.Fatalf("remote PUT after failed unlink = %d, want 2 (dirty data must be preserved)", got)
+	}
+	mu.Lock()
+	gotData, ok := files["/dir/file.txt"]
+	mu.Unlock()
+	if !ok || string(gotData) != string(data) {
+		t.Fatalf("remote content after failed unlink = %q, %v — want %q", gotData, ok, data)
+	}
+
+	// The handle is still fully readable.
+	read := make([]byte, len(data))
+	rs, rst := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Offset:   0,
+		Size:     uint32(len(data)),
+	}, read)
+	if rst != gofuse.OK {
+		t.Fatalf("Read after failed unlink: %v", rst)
+	}
+	br, _ := rs.Bytes(read)
+	if string(br) != string(data) {
+		t.Fatalf("Read after failed unlink = %q, want %q", br, data)
+	}
+
+	// Second Unlink now succeeds; the close path then discards normally and
+	// rmdir works.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: dirIno}, "file.txt"); st != gofuse.OK {
+		t.Fatalf("second Unlink: %v", st)
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush after real unlink: %v", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+	if st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir"); st != gofuse.OK {
+		t.Fatalf("Rmdir after successful unlink = %v, want OK", st)
+	}
+}
+
+// TestConcurrentStrictShadowSpillFsyncDoesNotResurrectUnlinkedPath is the
+// large-file sibling of TestConcurrentFlushDoesNotResurrectUnlinkedPath: the
+// strict ShadowSpill Fsync upload must hold remoteCommitLock across the
+// network write so Unlink's DELETE lands after it (B4 class).
+func TestConcurrentStrictShadowSpillFsyncDoesNotResurrectUnlinkedPath(t *testing.T) {
+	filePath := "/dir/file.txt"
+	data := bytes.Repeat([]byte("strict-shadowspill-0123456789\n"), 128)
+
+	var (
+		mu             sync.Mutex
+		files          = map[string][]byte{}
+		dirs           = map[string]struct{}{"/": {}, "/dir": {}}
+		uploads        = map[string][]byte{}
+		nextUploadID   int
+		putStarted     = make(chan struct{})
+		putRelease     = make(chan struct{})
+		putStartedOnce sync.Once
+		delDir         atomic.Int32
+	)
+	listDir := func(dir string) []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		var entries []map[string]any
+		for p, d := range files {
+			parent := path.Dir(p)
+			if parent == "." {
+				parent = "/"
+			}
+			if parent == dir {
+				entries = append(entries, map[string]any{"name": path.Base(p), "isDir": false, "size": len(d)})
+			}
+		}
+		return entries
+	}
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": listDir(p)})
+		case r.Method == http.MethodPost && r.URL.Query().Has("mkdir"):
+			mu.Lock()
+			dirs[p] = struct{}{}
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/initiate":
+			var req struct {
+				Path      string `json:"path"`
+				TotalSize int64  `json:"total_size"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			nextUploadID++
+			uploadID := fmt.Sprintf("upload-%d", nextUploadID)
+			uploads[uploadID] = nil
+			mu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"upload_id":   uploadID,
+				"key":         "object-key",
+				"part_size":   req.TotalSize,
+				"total_parts": 1,
+			})
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/uploads/") && strings.HasSuffix(r.URL.Path, "/presign-batch"):
+			uploadID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v2/uploads/"), "/presign-batch")
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"parts": []map[string]any{{
+					"number": 1,
+					"url":    ts.URL + "/s3/" + uploadID + "/1",
+					"size":   len(data),
+				}},
+			})
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/s3/"):
+			uploadID := strings.Split(strings.TrimPrefix(r.URL.Path, "/s3/"), "/")[0]
+			body, _ := io.ReadAll(r.Body)
+			putStartedOnce.Do(func() { close(putStarted) })
+			<-putRelease
+			mu.Lock()
+			uploads[uploadID] = append([]byte(nil), body...)
+			mu.Unlock()
+			w.Header().Set("ETag", "etag-1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/uploads/") && strings.HasSuffix(r.URL.Path, "/complete"):
+			uploadID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v2/uploads/"), "/complete")
+			mu.Lock()
+			body := uploads[uploadID]
+			files[filePath] = append([]byte(nil), body...)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			if _, isDir := dirs[p]; isDir {
+				for child := range files {
+					if path.Dir(child) == p {
+						mu.Unlock()
+						http.Error(w, "directory not empty", http.StatusConflict)
+						return
+					}
+				}
+				delete(dirs, p)
+				delDir.Add(1)
+			} else {
+				delete(files, p)
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead:
+			mu.Lock()
+			if d, ok := files[p]; ok {
+				w.Header().Set("Content-Length", strconv.Itoa(len(d)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if _, ok := dirs[p]; ok {
+				w.Header().Set("Content-Length", "0")
+				w.Header().Set("X-Dat9-IsDir", "true")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0, SyncMode: SyncStrict}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	var mkdirOut gofuse.EntryOut
+	if st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Mode:     0o755,
+	}, "dir", &mkdirOut); st != gofuse.OK {
+		t.Fatalf("Mkdir: %v", st)
+	}
+	dirIno := mkdirOut.NodeId
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Flags:    uint32(syscall.O_RDWR),
+		Mode:     0o644,
+	}, "file.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(data)),
+	}, data); st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	spill := fh.ShadowSpill
+	fh.Unlock()
+	if !spill {
+		t.Fatal("handle is not ShadowSpill; test setup broken")
+	}
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	select {
+	case <-putStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for in-flight strict ShadowSpill upload")
+	}
+
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: dirIno}, "file.txt")
+	}()
+	time.Sleep(50 * time.Millisecond)
+	close(putRelease)
+
+	var unlinkSt, fsyncSt gofuse.Status
+	select {
+	case unlinkSt = <-unlinkDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for Unlink (lock-order inversion?)")
+	}
+	select {
+	case fsyncSt = <-fsyncDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for Fsync")
+	}
+	if unlinkSt != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", unlinkSt)
+	}
+	if fsyncSt != gofuse.OK {
+		t.Fatalf("Fsync status = %v, want OK", fsyncSt)
+	}
+
+	mu.Lock()
+	_, exists := files[filePath]
+	mu.Unlock()
+	if exists {
+		t.Fatal("in-flight strict ShadowSpill upload resurrected path after Unlink returned")
+	}
+	if st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir"); st != gofuse.OK {
+		t.Fatalf("Rmdir after concurrent strict ShadowSpill fsync+unlink = %v, want OK", st)
+	}
+	if got := delDir.Load(); got != 1 {
+		t.Fatalf("remote dir DELETE calls = %d, want 1", got)
+	}
+}
+
+// TestOpenUnlinkedShadowSpillReadSurvivesFlushAndReplacement: a dirty
+// ShadowSpill handle's authoritative data lives in the staged shadow, not the
+// Dirty buffer. After unlink-while-open, Flush/Fsync must not destroy that
+// backing — reads from the still-open fd must return the original bytes until
+// final Release, even after a same-path replacement stages its own shadow.
+func TestOpenUnlinkedShadowSpillReadSurvivesFlushAndReplacement(t *testing.T) {
+	type uploadState struct {
+		path string
+		size int64
+		body []byte
+	}
+	var (
+		mu           sync.Mutex
+		files        = map[string][]byte{}
+		dirs         = map[string]struct{}{"/": {}, "/dir": {}}
+		uploads      = map[string]uploadState{}
+		nextUploadID int
+	)
+	listDir := func(dir string) []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		var entries []map[string]any
+		for p, d := range files {
+			if path.Dir(p) == dir {
+				entries = append(entries, map[string]any{"name": path.Base(p), "isDir": false, "size": len(d)})
+			}
+		}
+		return entries
+	}
+	var ts *httptest.Server
+	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+		if p == "" {
+			p = "/"
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": listDir(p)})
+		case r.Method == http.MethodPost && r.URL.Query().Has("mkdir"):
+			mu.Lock()
+			dirs[p] = struct{}{}
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/initiate":
+			var req struct {
+				Path      string `json:"path"`
+				TotalSize int64  `json:"total_size"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			nextUploadID++
+			uploadID := fmt.Sprintf("upload-%d", nextUploadID)
+			uploads[uploadID] = uploadState{path: req.Path, size: req.TotalSize}
+			mu.Unlock()
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"upload_id":   uploadID,
+				"key":         "object-key",
+				"part_size":   req.TotalSize,
+				"total_parts": 1,
+			})
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/uploads/") && strings.HasSuffix(r.URL.Path, "/presign-batch"):
+			uploadID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v2/uploads/"), "/presign-batch")
+			mu.Lock()
+			st0 := uploads[uploadID]
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"parts": []map[string]any{{
+					"number": 1,
+					"url":    ts.URL + "/s3/" + uploadID + "/1",
+					"size":   st0.size,
+				}},
+			})
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/s3/"):
+			uploadID := strings.Split(strings.TrimPrefix(r.URL.Path, "/s3/"), "/")[0]
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			st0 := uploads[uploadID]
+			st0.body = append([]byte(nil), body...)
+			uploads[uploadID] = st0
+			mu.Unlock()
+			w.Header().Set("ETag", "etag-1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v2/uploads/") && strings.HasSuffix(r.URL.Path, "/complete"):
+			uploadID := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/v2/uploads/"), "/complete")
+			mu.Lock()
+			st0 := uploads[uploadID]
+			files[st0.path] = append([]byte(nil), st0.body...)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+		case r.Method == http.MethodPut || r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			files[p] = append([]byte(nil), body...)
+			mu.Unlock()
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			delete(files, p)
+			delete(dirs, p)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead:
+			mu.Lock()
+			if d, ok := files[p]; ok {
+				w.Header().Set("Content-Length", strconv.Itoa(len(d)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if _, ok := dirs[p]; ok {
+				w.Header().Set("Content-Length", "0")
+				w.Header().Set("X-Dat9-IsDir", "true")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{SyncMode: SyncInteractive, FlushDebounce: time.Hour}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	var mkdirOut gofuse.EntryOut
+	if st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Mode:     0o755,
+	}, "dir", &mkdirOut); st != gofuse.OK {
+		t.Fatalf("Mkdir: %v", st)
+	}
+	dirIno := mkdirOut.NodeId
+
+	oldData := bytes.Repeat([]byte("old-shadowspill-backing-0123456789\n"), 96)
+	var oldCreate gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Flags:    uint32(syscall.O_RDWR),
+		Mode:     0o644,
+	}, "file.txt", &oldCreate); st != gofuse.OK {
+		t.Fatalf("Create old: %v", st)
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: oldCreate.NodeId},
+		Fh:       oldCreate.Fh,
+		Size:     uint32(len(oldData)),
+	}, oldData); st != gofuse.OK {
+		t.Fatalf("Write old: %v", st)
+	}
+	oldFh, ok := fs.fileHandles.Get(oldCreate.Fh)
+	if !ok {
+		t.Fatal("old handle missing")
+	}
+	oldFh.Lock()
+	if !oldFh.ShadowSpill {
+		oldFh.Unlock()
+		t.Fatal("old handle is not ShadowSpill; test setup broken")
+	}
+	oldFh.Unlock()
+
+	// Unlink while the ShadowSpill fd stays open.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: dirIno}, "file.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+	// Flush must discard staged state but PRESERVE the fd's read backing.
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: oldCreate.NodeId},
+		Fh:       oldCreate.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush old unlinked handle: %v", st)
+	}
+
+	readOld := func() string {
+		buf := make([]byte, len(oldData))
+		rs, rst := fs.Read(nil, &gofuse.ReadIn{
+			InHeader: gofuse.InHeader{NodeId: oldCreate.NodeId},
+			Fh:       oldCreate.Fh,
+			Offset:   0,
+			Size:     uint32(len(oldData)),
+		}, buf)
+		if rst != gofuse.OK {
+			t.Fatalf("Read old unlinked ShadowSpill fd: %v", rst)
+		}
+		br, _ := rs.Bytes(buf)
+		return string(br)
+	}
+	if got := readOld(); got != string(oldData) {
+		t.Fatalf("Read after unlinked Flush = %.40q..., want original ShadowSpill bytes", got)
+	}
+
+	// Recreate the pathname and stage a replacement shadow; the old fd's
+	// reads must still return the OLD content (no aliasing).
+	var newCreate gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Flags:    uint32(syscall.O_RDWR),
+		Mode:     0o644,
+	}, "file.txt", &newCreate); st != gofuse.OK {
+		t.Fatalf("Create replacement: %v", st)
+	}
+	newData := bytes.Repeat([]byte("replacement-9876543210\n"), 128)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: newCreate.NodeId},
+		Fh:       newCreate.Fh,
+		Size:     uint32(len(newData)),
+	}, newData); st != gofuse.OK {
+		t.Fatalf("Write replacement: %v", st)
+	}
+	// The replacement's spill staged its own shadow at the same path. The old
+	// fd's reads must still return the OLD content (no aliasing).
+	if got := readOld(); got != string(oldData) {
+		t.Fatalf("Read after replacement staged = %.40q..., want original ShadowSpill bytes", got)
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: oldCreate.NodeId},
+		Fh:       oldCreate.Fh,
+	})
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: newCreate.NodeId},
+		Fh:       newCreate.Fh,
+	})
+
+	// The replacement's own lifecycle is undisturbed by the old fd's discard.
+	mu.Lock()
+	remoteData, remoteOK := files["/dir/file.txt"]
+	mu.Unlock()
+	if !remoteOK || string(remoteData) != string(newData) {
+		t.Fatalf("replacement remote content = %.40q..., %v — want the replacement bytes", remoteData, remoteOK)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -20173,6 +20173,206 @@ func TestRmdirAfterOpenUnlinkDirtyFlush(t *testing.T) {
 	}
 }
 
+// TestRmdirAfterOpenUnlinkDirtyFsync is the Fsync counterpart of
+// TestRmdirAfterOpenUnlinkDirtyFlush: write → unlink while open → fsync(fd)
+// must not re-stage/enqueue/upload the deleted path.
+func TestRmdirAfterOpenUnlinkDirtyFsync(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		files    = map[string][]byte{}
+		dirs     = map[string]struct{}{"/": {}, "/dir": {}}
+		putCalls atomic.Int32
+		delDir   atomic.Int32
+	)
+	listDir := func(dir string) []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		var entries []map[string]any
+		for p := range dirs {
+			if p == "/" || p == dir {
+				continue
+			}
+			parent := path.Dir(p)
+			if parent == "." {
+				parent = "/"
+			}
+			if parent == dir {
+				entries = append(entries, map[string]any{"name": path.Base(p), "isDir": true, "size": 0})
+			}
+		}
+		for p, data := range files {
+			parent := path.Dir(p)
+			if parent == "." {
+				parent = "/"
+			}
+			if parent == dir {
+				entries = append(entries, map[string]any{"name": path.Base(p), "isDir": false, "size": len(data)})
+			}
+		}
+		return entries
+	}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+		if p == "" {
+			p = "/"
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": listDir(p)})
+		case r.Method == http.MethodPost && r.URL.Query().Has("mkdir"):
+			mu.Lock()
+			dirs[p] = struct{}{}
+			delete(files, p)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPut || r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			files[p] = append([]byte(nil), body...)
+			delete(dirs, p)
+			mu.Unlock()
+			putCalls.Add(1)
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			_, isDir := dirs[p]
+			if isDir {
+				for child := range files {
+					if path.Dir(child) == p {
+						mu.Unlock()
+						http.Error(w, "directory not empty", http.StatusConflict)
+						return
+					}
+				}
+				delete(dirs, p)
+				delDir.Add(1)
+			} else {
+				delete(files, p)
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead:
+			mu.Lock()
+			if data, ok := files[p]; ok {
+				w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if _, ok := dirs[p]; ok {
+				w.Header().Set("Content-Length", "0")
+				w.Header().Set("X-Dat9-IsDir", "true")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{SyncMode: SyncInteractive}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	wb, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.SetWriteBack(wb, nil)
+	// Minimal commit queue so interactive Fsync can enqueue if the unlinked
+	// guard is missing (the bug path under review).
+	cq := NewCommitQueue(fs.client, shadow, pending, nil, 1, 8)
+	fs.commitQueue = cq
+	defer cq.DrainAll()
+
+	var mkdirOut gofuse.EntryOut
+	if st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Mode:     0o755,
+	}, "dir", &mkdirOut); st != gofuse.OK {
+		t.Fatalf("Mkdir: %v", st)
+	}
+	dirIno := mkdirOut.NodeId
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Flags:    uint32(syscall.O_RDWR),
+		Mode:     0o644,
+	}, "file.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	data := []byte("Hello,_World!")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(data)),
+	}, data); st != gofuse.OK {
+		t.Fatalf("Write: %v", st)
+	}
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: dirIno}, "file.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+
+	// Fsync after dirty open-unlink must discard, not re-enqueue.
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync after unlink: %v", st)
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush after unlink: %v", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+
+	if got := putCalls.Load(); got != 0 {
+		t.Fatalf("remote PUT after open-unlink fsync = %d, want 0", got)
+	}
+	if _, ok := pending.GetMeta("/dir/file.txt"); ok {
+		t.Fatal("pendingIndex still has /dir/file.txt after open-unlink fsync")
+	}
+	mu.Lock()
+	if _, ok := files["/dir/file.txt"]; ok {
+		mu.Unlock()
+		t.Fatal("remote still has /dir/file.txt after open-unlink fsync")
+	}
+	mu.Unlock()
+
+	st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir")
+	if st != gofuse.OK {
+		t.Fatalf("Rmdir after open-unlink fsync = %v, want OK", st)
+	}
+	if got := delDir.Load(); got != 1 {
+		t.Fatalf("remote dir DELETE calls = %d, want 1", got)
+	}
+}
+
 func TestRmdirRemoteDeleteDoesNotRetryRecreatedPathAfterInterrupt(t *testing.T) {
 	path := "/repo/emptydir"
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -21151,6 +21151,211 @@ func TestUnlinkDeleteFailurePreservesClosedPendingState(t *testing.T) {
 	}
 }
 
+// TestWriteSyncWriteAfterUnlinkDoesNotResurrectPath: POSIX permits writing to
+// an anonymous (unlinked) fd, and the write must succeed and stay readable —
+// but on a write-sync (O_SYNC/O_DSYNC / WritePolicyWriteSync) handle it must
+// NOT upload, or the deleted pathname is recreated and parent rmdir fails
+// with ENOTEMPTY again.
+func TestWriteSyncWriteAfterUnlinkDoesNotResurrectPath(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		files    = map[string][]byte{}
+		dirs     = map[string]struct{}{"/": {}, "/dir": {}}
+		putCalls atomic.Int32
+		delDir   atomic.Int32
+	)
+	listDir := func(dir string) []map[string]any {
+		mu.Lock()
+		defer mu.Unlock()
+		var entries []map[string]any
+		for p, data := range files {
+			parent := path.Dir(p)
+			if parent == "." {
+				parent = "/"
+			}
+			if parent == dir {
+				entries = append(entries, map[string]any{"name": path.Base(p), "isDir": false, "size": len(data)})
+			}
+		}
+		return entries
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+		if p == "" {
+			p = "/"
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": listDir(p)})
+		case r.Method == http.MethodGet:
+			mu.Lock()
+			if data, ok := files[p]; ok {
+				mu.Unlock()
+				w.Header().Set("X-Dat9-Revision", "1")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(data)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		case r.Method == http.MethodPost && r.URL.Query().Has("mkdir"):
+			mu.Lock()
+			dirs[p] = struct{}{}
+			delete(files, p)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodPut || r.Method == http.MethodPost:
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			files[p] = append([]byte(nil), body...)
+			delete(dirs, p)
+			mu.Unlock()
+			putCalls.Add(1)
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			if _, isDir := dirs[p]; isDir {
+				for child := range files {
+					if path.Dir(child) == p {
+						mu.Unlock()
+						http.Error(w, "directory not empty", http.StatusConflict)
+						return
+					}
+				}
+				delete(dirs, p)
+				delDir.Add(1)
+			} else {
+				delete(files, p)
+			}
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead:
+			mu.Lock()
+			if data, ok := files[p]; ok {
+				w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			if _, ok := dirs[p]; ok {
+				w.Header().Set("Content-Length", "0")
+				w.Header().Set("X-Dat9-IsDir", "true")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var mkdirOut gofuse.EntryOut
+	if st := fs.Mkdir(nil, &gofuse.MkdirIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Mode:     0o755,
+	}, "dir", &mkdirOut); st != gofuse.OK {
+		t.Fatalf("Mkdir: %v", st)
+	}
+	dirIno := mkdirOut.NodeId
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Flags:    uint32(syscall.O_RDWR),
+		Mode:     0o644,
+	}, "file.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	// Force write-sync (O_SYNC-like) policy on this handle.
+	if fh, ok := fs.fileHandles.Get(createOut.Fh); ok {
+		fh.WritePolicy = WritePolicyWriteSync
+	}
+
+	v1 := []byte("v1-synced")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1: %v", st)
+	}
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("write-sync Write v1: remote PUT = %d, want 1 (write-sync uploads eagerly)", got)
+	}
+
+	// Unlink while the write-sync fd stays open.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: dirIno}, "file.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+
+	// Write-after-unlink must succeed (anonymous fd) but perform NO remote
+	// create/update for the deleted path.
+	v2 := []byte("v2-must-stay-local")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write after unlink: %v", st)
+	}
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("write-after-unlink issued a remote upload (PUT = %d, want still 1)", got)
+	}
+
+	// Anonymous-fd semantics: the write landed in the fd's Dirty buffer and
+	// stays readable there. (Read-path merging of the mark-time remote
+	// snapshot vs post-unlink writes is a separate pre-existing question.)
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	buf := make([]byte, len(v2))
+	nRead := fh.Dirty.ReadAt(0, buf)
+	fh.Unlock()
+	if nRead != len(v2) || string(buf) != string(v2) {
+		t.Fatalf("Dirty buffer content after write-after-unlink = %q (n=%d), want %q", buf[:nRead], nRead, v2)
+	}
+
+	// Close path: discard only, still no upload.
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush: %v", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("close after write-after-unlink issued a remote upload (PUT = %d, want still 1)", got)
+	}
+	mu.Lock()
+	_, exists := files["/dir/file.txt"]
+	mu.Unlock()
+	if exists {
+		t.Fatal("write-after-unlink resurrected the deleted path remotely")
+	}
+	if st := fs.Rmdir(nil, &gofuse.InHeader{NodeId: 1}, "dir"); st != gofuse.OK {
+		t.Fatalf("Rmdir after write-sync write-after-unlink = %v, want OK", st)
+	}
+	if got := delDir.Load(); got != 1 {
+		t.Fatalf("remote dir DELETE calls = %d, want 1", got)
+	}
+}
+
 // TestConcurrentStrictShadowSpillFsyncDoesNotResurrectUnlinkedPath is the
 // large-file sibling of TestConcurrentFlushDoesNotResurrectUnlinkedPath: the
 // strict ShadowSpill Fsync upload must hold remoteCommitLock across the

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -19997,10 +19997,6 @@ func TestRmdirAfterOpenUnlinkDirtyFlush(t *testing.T) {
 	listDir := func(dir string) []map[string]any {
 		mu.Lock()
 		defer mu.Unlock()
-		prefix := dir
-		if !strings.HasSuffix(prefix, "/") {
-			prefix += "/"
-		}
 		var entries []map[string]any
 		for p := range dirs {
 			if p == "/" || p == dir {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -21200,6 +21200,9 @@ func TestConcurrentFlushDoesNotResurrectUnlinkedPath(t *testing.T) {
 		return entries
 	}
 
+	// abort unblocks request gates if the test fails early, so ts.Close()
+	// cannot hang on a parked handler.
+	abort := make(chan struct{})
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
 		if p == "" {
@@ -21218,7 +21221,12 @@ func TestConcurrentFlushDoesNotResurrectUnlinkedPath(t *testing.T) {
 			// Block after the body is fully received so Flush is in-flight.
 			body, _ := io.ReadAll(r.Body)
 			putStartedOnce.Do(func() { close(putStarted) })
-			<-putRelease
+			select {
+			case <-putRelease:
+			case <-abort:
+				http.Error(w, "test aborted", http.StatusInternalServerError)
+				return
+			}
 			mu.Lock()
 			files[p] = append([]byte(nil), body...)
 			delete(dirs, p)
@@ -21268,6 +21276,7 @@ func TestConcurrentFlushDoesNotResurrectUnlinkedPath(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
+	defer func() { close(abort) }()
 
 	opts := &MountOptions{WritePolicy: WritePolicyCloseSync}
 	opts.setDefaults()
@@ -21584,6 +21593,9 @@ func TestOldUnlinkedHandleDiscardPreservesReplacementCommit(t *testing.T) {
 		// allowPUT gates the replacement's remote upload so the assertions on
 		// staged state are deterministic regardless of worker timing.
 		allowPUT = make(chan struct{})
+		// abort unblocks the gate if the test fails early, so ts.Close()
+		// cannot hang on a parked handler.
+		abort = make(chan struct{})
 	)
 	listDir := func(dir string) []map[string]any {
 		mu.Lock()
@@ -21617,7 +21629,12 @@ func TestOldUnlinkedHandleDiscardPreservesReplacementCommit(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		case r.Method == http.MethodPut || r.Method == http.MethodPost:
 			body, _ := io.ReadAll(r.Body)
-			<-allowPUT
+			select {
+			case <-allowPUT:
+			case <-abort:
+				http.Error(w, "test aborted", http.StatusInternalServerError)
+				return
+			}
 			mu.Lock()
 			files[p] = append([]byte(nil), body...)
 			delete(dirs, p)
@@ -21656,6 +21673,7 @@ func TestOldUnlinkedHandleDiscardPreservesReplacementCommit(t *testing.T) {
 		}
 	}))
 	defer ts.Close()
+	defer func() { close(abort) }()
 
 	opts := &MountOptions{SyncMode: SyncInteractive}
 	opts.setDefaults()
@@ -22370,6 +22388,9 @@ func TestConcurrentStrictShadowSpillFsyncDoesNotResurrectUnlinkedPath(t *testing
 		putRelease     = make(chan struct{})
 		putStartedOnce sync.Once
 		delDir         atomic.Int32
+		// abort unblocks the request gate if the test fails early, so
+		// ts.Close() cannot hang on a parked handler.
+		abort = make(chan struct{})
 	)
 	listDir := func(dir string) []map[string]any {
 		mu.Lock()
@@ -22431,7 +22452,12 @@ func TestConcurrentStrictShadowSpillFsyncDoesNotResurrectUnlinkedPath(t *testing
 			uploadID := strings.Split(strings.TrimPrefix(r.URL.Path, "/s3/"), "/")[0]
 			body, _ := io.ReadAll(r.Body)
 			putStartedOnce.Do(func() { close(putStarted) })
-			<-putRelease
+			select {
+			case <-putRelease:
+			case <-abort:
+				http.Error(w, "test aborted", http.StatusInternalServerError)
+				return
+			}
 			mu.Lock()
 			uploads[uploadID] = append([]byte(nil), body...)
 			mu.Unlock()
@@ -22487,6 +22513,7 @@ func TestConcurrentStrictShadowSpillFsyncDoesNotResurrectUnlinkedPath(t *testing
 		}
 	}))
 	defer ts.Close()
+	defer func() { close(abort) }()
 
 	opts := &MountOptions{FlushDebounce: 0, SyncMode: SyncStrict}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -21036,6 +21036,121 @@ func TestUnlinkDeleteFailureRollsBackOpenHandleMarks(t *testing.T) {
 	}
 }
 
+// TestUnlinkDeleteFailurePreservesClosedPendingState: a failed remote DELETE
+// must not destroy closed staged state (no live handle) — a POSIX unlink that
+// fails leaves the namespace entry in place, so an already-accepted local
+// PendingOverwrite whose only copy lives in the staging stores must remain
+// recoverable. Regression for the commit-point deferral in Unlink.
+func TestUnlinkDeleteFailurePreservesClosedPendingState(t *testing.T) {
+	const filePath = "/file.txt"
+	staged := []byte("newer-local-overwrite")
+
+	var (
+		mu       sync.Mutex
+		files    = map[string][]byte{filePath: []byte("remote-v1")}
+		headHits atomic.Int32
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+		if p == "" {
+			p = "/"
+		}
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+		case r.Method == http.MethodGet:
+			mu.Lock()
+			if data, ok := files[p]; ok {
+				mu.Unlock()
+				w.Header().Set("X-Dat9-Revision", "1")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write(data)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		case r.Method == http.MethodDelete:
+			// Transient failure — the unlink does not happen remotely.
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		case r.Method == http.MethodHead:
+			headHits.Add(1)
+			mu.Lock()
+			if data, ok := files[p]; ok {
+				w.Header().Set("Content-Length", strconv.Itoa(len(data)))
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "1")
+				mu.Unlock()
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+			mu.Unlock()
+			http.NotFound(w, r)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{SyncMode: SyncInteractive}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	wb, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.SetWriteBack(wb, nil)
+
+	// Seed a CLOSED staged overwrite for the remote file (no live handle):
+	// shadow bytes + pending index + write-back entry at remote base rev 1.
+	if err := shadow.WriteFull(filePath, staged, 1); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(filePath, int64(len(staged)), PendingOverwrite, 1); err != nil {
+		t.Fatal(err)
+	}
+	if err := wb.PutWithBaseRevAndMode(filePath, staged, int64(len(staged)), PendingOverwrite, 1, 0, false); err != nil {
+		t.Fatal(err)
+	}
+	// The inode must exist for the unlink path resolution.
+	fs.inodes.Lookup(filePath, false, int64(len(files[filePath])), time.Now())
+
+	// Unlink fails (DELETE 500) and must leave every staged copy intact.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, "file.txt"); st == gofuse.OK {
+		t.Fatal("Unlink unexpectedly succeeded despite remote DELETE 500")
+	}
+
+	if meta, ok := pending.GetMeta(filePath); !ok || meta.Kind != PendingOverwrite {
+		t.Fatalf("pendingIndex entry lost after failed unlink (ok=%v)", ok)
+	}
+	if !shadow.Has(filePath) {
+		t.Fatal("shadow backing lost after failed unlink")
+	}
+	if data, err := shadow.ReadAll(filePath); err != nil || string(data) != string(staged) {
+		t.Fatalf("shadow content after failed unlink = %q, %v — want staged bytes", data, err)
+	}
+	if meta, ok := wb.GetMeta(filePath); !ok || meta.Kind != PendingOverwrite {
+		t.Fatalf("writeBack entry lost after failed unlink (ok=%v)", ok)
+	}
+	// Remote file untouched: HEAD still sees it.
+	mu.Lock()
+	_, remoteOK := files[filePath]
+	mu.Unlock()
+	if !remoteOK {
+		t.Fatal("remote file must still exist after failed DELETE")
+	}
+}
+
 // TestConcurrentStrictShadowSpillFsyncDoesNotResurrectUnlinkedPath is the
 // large-file sibling of TestConcurrentFlushDoesNotResurrectUnlinkedPath: the
 // strict ShadowSpill Fsync upload must hold remoteCommitLock across the

--- a/pkg/fuse/debounce.go
+++ b/pkg/fuse/debounce.go
@@ -30,6 +30,7 @@ type flushDebouncer struct {
 type pendingFlush struct {
 	timer    *time.Timer
 	uploadFn func()
+	owner    any // scheduling owner (e.g. *FileHandle); used by CancelNoWaitIfOwner
 	done     chan struct{}
 	once     sync.Once
 }
@@ -60,6 +61,14 @@ func newFlushDebouncer(delay time.Duration) *flushDebouncer {
 // the timer callback will not run a second concurrent callback for the same
 // path — it waits for the existing inflight to drain first.
 func (d *flushDebouncer) Schedule(path string, uploadFn func()) {
+	d.ScheduleWithOwner(path, nil, uploadFn)
+}
+
+// ScheduleWithOwner is Schedule with an explicit owner token (typically a
+// *FileHandle) so that CancelNoWaitIfOwner can cancel only entries owned by a
+// specific handle — path-global cancels would otherwise kill a replacement
+// file's pending debounce after unlink + pathname reuse.
+func (d *flushDebouncer) ScheduleWithOwner(path string, owner any, uploadFn func()) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
@@ -69,7 +78,7 @@ func (d *flushDebouncer) Schedule(path string, uploadFn func()) {
 		delete(d.pending, path)
 	}
 
-	pf := &pendingFlush{uploadFn: uploadFn, done: make(chan struct{})}
+	pf := &pendingFlush{uploadFn: uploadFn, owner: owner, done: make(chan struct{})}
 	pf.timer = time.AfterFunc(d.delay, func() {
 		d.runCallback(path, pf)
 	})
@@ -150,6 +159,21 @@ func (d *flushDebouncer) CancelNoWait(path string) {
 	d.mu.Lock()
 	pf, ok := d.pending[path]
 	if ok {
+		pf.timer.Stop()
+		pf.finish()
+		delete(d.pending, path)
+	}
+	d.mu.Unlock()
+}
+
+// CancelNoWaitIfOwner is like CancelNoWait but only cancels when the pending
+// entry was scheduled by owner. Used by unlink-while-open discard so an old
+// unlinked handle cannot cancel a debounce scheduled by a replacement file
+// that reused the pathname.
+func (d *flushDebouncer) CancelNoWaitIfOwner(path string, owner any) {
+	d.mu.Lock()
+	pf, ok := d.pending[path]
+	if ok && pf.owner == owner {
 		pf.timer.Stop()
 		pf.finish()
 		delete(d.pending, path)

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2443,6 +2443,31 @@ func TestFlushDebouncer_Cancel(t *testing.T) {
 	}
 }
 
+func TestFlushDebouncer_CancelNoWaitIfOwner(t *testing.T) {
+	d := newFlushDebouncer(20 * time.Millisecond)
+	ownerA := &struct{}{}
+	ownerB := &struct{}{}
+
+	// A non-owner cancel must leave the pending entry alone.
+	fired := make(chan string, 1)
+	d.ScheduleWithOwner("/a", ownerA, func() { fired <- "/a" })
+	d.CancelNoWaitIfOwner("/a", ownerB)
+	select {
+	case <-fired:
+	case <-time.After(time.Second):
+		t.Fatal("non-owner CancelNoWaitIfOwner stopped the debounce")
+	}
+
+	// An owner cancel stops the pending entry.
+	d.ScheduleWithOwner("/a", ownerA, func() { fired <- "/a2" })
+	d.CancelNoWaitIfOwner("/a", ownerA)
+	select {
+	case p := <-fired:
+		t.Fatalf("owner CancelNoWaitIfOwner did not stop the debounce (fired %q)", p)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
 func TestFlushDebouncer_FlushAll(t *testing.T) {
 	d := newFlushDebouncer(10 * time.Second) // long delay — won't fire naturally
 	results := make(map[string]bool)

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2445,8 +2445,10 @@ func TestFlushDebouncer_Cancel(t *testing.T) {
 
 func TestFlushDebouncer_CancelNoWaitIfOwner(t *testing.T) {
 	d := newFlushDebouncer(20 * time.Millisecond)
-	ownerA := &struct{}{}
-	ownerB := &struct{}{}
+	// Distinct non-zero-size owner tokens: pointers to zero-size values may
+	// share an address (runtime.zerobase) and compare equal.
+	ownerA := &FileHandle{Ino: 101}
+	ownerB := &FileHandle{Ino: 102}
 
 	// A non-owner cancel must leave the pending entry alone.
 	fired := make(chan string, 1)

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -3766,6 +3766,16 @@ func (fs *Dat9FS) flushGitLocalFileHandleLockedWithPolicy(ctx context.Context, f
 	if fh == nil || fh.Layer != PathLayerGitWorkspace || fh.LocalFile == nil {
 		return gofuse.OK
 	}
+	if fh.Unlinked {
+		// Open-unlink: the gitEntry unlink path marked this handle when it
+		// wrote the whiteout. Suppress the overlay upsert so the whiteout is
+		// not shadowed by a recreate from the anonymous fd. The fd's data
+		// stays in LocalFile untouched for reads (POSIX write/read
+		// after-unlink) — unlike Flush/Release on remote-DELETE handles,
+		// nothing is discarded here because a write-sync Write also routes
+		// through this function and its bytes must remain readable.
+		return gofuse.OK
+	}
 	if fh.DirtySeq == 0 && !fh.HasPendingMode {
 		return gofuse.OK
 	}
@@ -3805,6 +3815,15 @@ func (fs *Dat9FS) flushGitLocalFileHandleLockedWithPolicy(ctx context.Context, f
 
 func (fs *Dat9FS) flushGitHandleLockedWithPolicy(ctx context.Context, fh *FileHandle, forceSync bool) gofuse.Status {
 	if fh == nil || fh.Layer != PathLayerGitWorkspace {
+		return gofuse.OK
+	}
+	if fh.Unlinked {
+		// Open-unlink: suppress the overlay upsert — the whiteout written by
+		// the gitEntry unlink path must not be shadowed by a recreate from
+		// the anonymous fd. Its data stays in the Dirty buffer / LocalFile
+		// for reads (POSIX write/read-after-unlink); nothing is discarded
+		// here because write-sync Writes also route through this function
+		// and their bytes must remain readable.
 		return gofuse.OK
 	}
 	if fh.LocalFile != nil {

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -3481,6 +3481,14 @@ func (fs *Dat9FS) applyGitOverlayMirrorEntry(fh *FileHandle, size int64) {
 	if fs == nil || fh == nil || fh.Layer != PathLayerGitWorkspace || fh.GitWorkspaceID == "" || fh.GitRelPath == "" {
 		return
 	}
+	if fh.Unlinked {
+		// Open-unlink: the whiteout written by the gitEntry unlink path must
+		// stay authoritative in the live overlay and the pending map. An
+		// upsert mirror here would resurrect the deleted name in lookups,
+		// readdir and reads on the active mount even though the remote PUT
+		// is already suppressed by the git flush guards.
+		return
+	}
 	entry := client.GitOverlayEntry{
 		WorkspaceID:    fh.GitWorkspaceID,
 		Path:           fh.GitRelPath,

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -48,6 +48,7 @@ type gitWorkspaceFixture struct {
 	readmeSize      int64
 	failTree        bool
 	failOverlay     bool
+	failOverlayPut  bool
 }
 
 type gitStateOnlyFixture struct {
@@ -380,6 +381,12 @@ func (f *gitWorkspaceFixture) handleOverlay(w http.ResponseWriter, r *http.Reque
 			return
 		}
 		f.mu.Lock()
+		if f.failOverlayPut {
+			f.mu.Unlock()
+			w.WriteHeader(http.StatusInternalServerError)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "overlay put unavailable"})
+			return
+		}
 		wait := f.overlayPostWait
 		f.mu.Unlock()
 		if wait != nil {
@@ -4107,5 +4114,103 @@ func TestGitWorkspaceWriteSyncWriteAfterUnlinkDoesNotResurrectOverlay(t *testing
 	}
 	if !ok || entry.Op != "whiteout" {
 		t.Fatalf("overlay entry after write-after-unlink = %+v, %v — want whiteout preserved", entry, ok)
+	}
+
+	// Live mount state: the whiteout must stay authoritative — lookups and
+	// gitEntry report the name absent, and no pending upsert mirrors it back.
+	if ge, handled := fs.gitEntry(context.Background(), "/repo/sync.txt", false); !handled || ge != nil {
+		t.Fatalf("gitEntry after write-after-unlink = %+v, handled=%v — want whiteout (nil entry)", ge, handled)
+	}
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt", &lookupOut); st != gofuse.ENOENT {
+		t.Fatalf("Lookup after write-after-unlink = %v, want ENOENT", st)
+	}
+	fs.gitOverlayMu.Lock()
+	var pendingUpsert any
+	if byPath := fs.gitOverlayPending["ws1"]; byPath != nil {
+		if pe, ok := byPath["sync.txt"]; ok {
+			pendingUpsert = pe.entry
+		}
+	}
+	fs.gitOverlayMu.Unlock()
+	if pendingUpsert != nil {
+		t.Fatalf("pending overlay upsert for unlinked path = %+v", pendingUpsert)
+	}
+}
+
+// TestGitWorkspaceUnlinkWhiteoutFailureRollsBackHandleMarks: when the git
+// whiteout write fails, Unlink must roll the open-handle marking back — the
+// entry still exists authoritatively, so handles must not stay unlinked and
+// their later writes must publish normally.
+func TestGitWorkspaceUnlinkWhiteoutFailureRollsBackHandleMarks(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+
+	// Whiteout write fails → Unlink must error AND roll the marking back.
+	fixture.mu.Lock()
+	fixture.failOverlayPut = true
+	fixture.mu.Unlock()
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st == gofuse.OK {
+		t.Fatal("Unlink unexpectedly succeeded despite failing whiteout")
+	}
+	fixture.mu.Lock()
+	fixture.failOverlayPut = false
+	fixture.mu.Unlock()
+
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	unlinked := fh.Unlinked
+	fh.Unlock()
+	if unlinked {
+		t.Fatal("handle left marked unlinked after failed whiteout")
+	}
+	if got := len(fs.openHandles.SnapshotPath("/repo/sync.txt")); got != 1 {
+		t.Fatalf("openHandles path index after rollback = %d handles, want 1 relinked", got)
+	}
+
+	// The handle publishes normally again.
+	v2 := []byte("git-v2-published")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write after failed whiteout status = %v, want OK", st)
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	fixture.mu.Unlock()
+	if !ok || entry.Op != "upsert" || string(entry.Content) != string(v2) {
+		t.Fatalf("overlay after failed whiteout + rewrite = %+v, %v — want upsert with v2 content", entry, ok)
+	}
+
+	// Path remains linked.
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup after failed whiteout = %v, want OK", st)
 	}
 }

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -33,22 +33,26 @@ type gitWorkspaceFixture struct {
 	overlay         map[string]client.GitOverlayEntry
 	overlayPuts     int
 	overlayPostWait chan struct{}
-	objectPacks     map[string]client.GitObjectPack
-	state           []byte
-	stateStorage    string
-	gitStatePuts    int
-	mode            string
-	headCommit      string
-	deleted         bool
-	listRequests    int
-	server          *httptest.Server
-	repoURL         string
-	treeNodes       []client.GitTreeNode
-	readmeObjectSHA string
-	readmeSize      int64
-	failTree        bool
-	failOverlay     bool
-	failOverlayPut  bool
+	// overlayPostEntered is closed when a POST first parks on
+	// overlayPostWait, so tests can open files while a whiteout is in flight.
+	overlayPostEntered     chan struct{}
+	overlayPostEnteredOnce sync.Once
+	objectPacks            map[string]client.GitObjectPack
+	state                  []byte
+	stateStorage           string
+	gitStatePuts           int
+	mode                   string
+	headCommit             string
+	deleted                bool
+	listRequests           int
+	server                 *httptest.Server
+	repoURL                string
+	treeNodes              []client.GitTreeNode
+	readmeObjectSHA        string
+	readmeSize             int64
+	failTree               bool
+	failOverlay            bool
+	failOverlayPut         bool
 }
 
 type gitStateOnlyFixture struct {
@@ -388,8 +392,12 @@ func (f *gitWorkspaceFixture) handleOverlay(w http.ResponseWriter, r *http.Reque
 			return
 		}
 		wait := f.overlayPostWait
+		entered := f.overlayPostEntered
 		f.mu.Unlock()
 		if wait != nil {
+			if entered != nil {
+				f.overlayPostEnteredOnce.Do(func() { close(entered) })
+			}
 			<-wait
 		}
 		entry := client.GitOverlayEntry{
@@ -4212,5 +4220,116 @@ func TestGitWorkspaceUnlinkWhiteoutFailureRollsBackHandleMarks(t *testing.T) {
 	var lookupOut gofuse.EntryOut
 	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt", &lookupOut); st != gofuse.OK {
 		t.Fatalf("Lookup after failed whiteout = %v, want OK", st)
+	}
+}
+
+// TestGitWorkspaceUnlinkMarksHandlesOpenedDuringWhiteout: a handle opened
+// while the git whiteout request is in flight must be marked by the
+// post-commit pass — otherwise its later write/flush would upsert the overlay
+// entry back over the whiteout (the remote-DELETE path has the same second
+// mark pass).
+func TestGitWorkspaceUnlinkMarksHandlesOpenedDuringWhiteout(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+
+	// Park the whiteout POST; open a SECOND writable handle while it is in
+	// flight (after the unlink's first mark pass, before the whiteout lands).
+	postWait := make(chan struct{})
+	postEntered := make(chan struct{})
+	fixture.mu.Lock()
+	fixture.overlayPostWait = postWait
+	fixture.overlayPostEntered = postEntered
+	fixture.mu.Unlock()
+
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt")
+	}()
+	select {
+	case <-postEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("whiteout POST never parked")
+	}
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup during in-flight whiteout = %v, want OK (name still present)", st)
+	}
+	var open2 gofuse.OpenOut
+	if st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Flags:    uint32(syscall.O_RDWR),
+	}, &open2); st != gofuse.OK {
+		t.Fatalf("Open second handle during in-flight whiteout = %v, want OK", st)
+	}
+
+	close(postWait)
+	if st := <-unlinkDone; st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+
+	// Both handles must be marked unlinked now — the first by pass 1, the
+	// second by the post-commit pass.
+	for _, fhID := range []uint64{createOut.Fh, open2.Fh} {
+		fh, ok := fs.fileHandles.Get(fhID)
+		if !ok {
+			t.Fatalf("handle %d missing", fhID)
+		}
+		fh.Lock()
+		unlinked := fh.Unlinked
+		fh.Unlock()
+		if !unlinked {
+			t.Fatalf("handle %d not marked unlinked after whiteout (pass-2 gap)", fhID)
+		}
+	}
+
+	// Neither handle may upsert on write/flush/release.
+	fixture.mu.Lock()
+	putsAfterWhiteout := fixture.overlayPuts
+	fixture.mu.Unlock()
+	v2 := []byte("git-v2-must-stay-local")
+	for _, fhID := range []uint64{createOut.Fh, open2.Fh} {
+		if _, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+			Fh:       fhID,
+			Size:     uint32(len(v2)),
+		}, v2); st != gofuse.OK {
+			t.Fatalf("Write after unlink on handle %d = %v, want OK", fhID, st)
+		}
+		if st := fs.Flush(nil, &gofuse.FlushIn{Fh: fhID}); st != gofuse.OK {
+			t.Fatalf("Flush after unlink on handle %d = %v, want OK", fhID, st)
+		}
+		fs.Release(nil, &gofuse.ReleaseIn{Fh: fhID})
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	putsFinal := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if putsFinal != putsAfterWhiteout {
+		t.Fatalf("overlay puts after whiteout = %d, after writes = %d — handle opened during whiteout resurrected the entry", putsAfterWhiteout, putsFinal)
+	}
+	if !ok || entry.Op != "whiteout" {
+		t.Fatalf("overlay entry = %+v, %v — want whiteout preserved", entry, ok)
 	}
 }

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -3980,3 +3980,132 @@ func TestEnsureGitWorkspacesRecordsRefreshPerfCounters(t *testing.T) {
 		t.Fatalf("git_workspace_forced_refresh after force = %d, want 1", got)
 	}
 }
+
+// TestGitWorkspaceWriteSyncWriteAfterUnlinkDoesNotResurrectOverlay covers the
+// git quadrant of the open-unlink invariant: a write-sync git handle unlinked
+// while open must accept further writes on the anonymous fd, but neither the
+// write nor Flush/Release may upsert the overlay entry back over the whiteout.
+func TestGitWorkspaceWriteSyncWriteAfterUnlinkDoesNotResurrectOverlay(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	fixture.mu.Unlock()
+	if !ok || entry.Op != "upsert" {
+		t.Fatalf("overlay entry after v1 write = %+v, %v — want upsert", entry, ok)
+	}
+
+	// Unlink while the write-sync git fd stays open: overlay becomes a
+	// whiteout, and the handle must be marked unlinked.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	fixture.mu.Lock()
+	entry, ok = fixture.overlay["sync.txt"]
+	putsAfterWhiteout := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if !ok || entry.Op != "whiteout" {
+		t.Fatalf("overlay entry after unlink = %+v, %v — want whiteout", entry, ok)
+	}
+	if fh, ok := fs.fileHandles.Get(createOut.Fh); !ok {
+		t.Fatal("handle missing")
+	} else {
+		fh.Lock()
+		unlinked := fh.Unlinked
+		fh.Unlock()
+		if !unlinked {
+			t.Fatal("git handle not marked unlinked by gitEntry unlink path")
+		}
+	}
+
+	// Write-after-unlink must succeed (anonymous fd) but NOT upsert.
+	v2 := []byte("git-v2-must-stay-local")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write after unlink status = %v, want OK", st)
+	}
+	// Anonymous-fd semantics: the post-unlink write stays readable from the
+	// fd's own backing (LocalFile for checked-out git handles, otherwise the
+	// Dirty buffer).
+	if fh, ok := fs.fileHandles.Get(createOut.Fh); ok {
+		fh.Lock()
+		localName := ""
+		if fh.LocalFile != nil {
+			localName = fh.LocalFile.Name()
+		}
+		dirty := fh.Dirty
+		fh.Unlock()
+		if localName != "" {
+			// The whiteout removed the dirty-mirror NAME, but the open
+			// *os.File keeps the inode alive — read via the fd itself.
+			fh.Lock()
+			buf := make([]byte, len(v2))
+			n, err := fh.LocalFile.ReadAt(buf, 0)
+			fh.Unlock()
+			if err != nil && n == 0 {
+				t.Fatalf("read unlinked git LocalFile fd: %v", err)
+			}
+			if string(buf[:n]) != string(v2) {
+				t.Fatalf("LocalFile fd content = %q, want %q", buf[:n], v2)
+			}
+		} else {
+			if dirty == nil {
+				t.Fatal("no readable backing on unlinked git handle")
+			}
+			buf := make([]byte, len(v2))
+			n := dirty.ReadAt(0, buf)
+			if n != len(v2) || string(buf) != string(v2) {
+				t.Fatalf("Dirty buffer content = %q (n=%d), want %q", buf[:n], n, v2)
+			}
+		}
+	} else {
+		t.Fatal("handle missing before close")
+	}
+
+	// Flush and Release must not upsert either.
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush after unlink status = %v, want OK", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	})
+
+	fixture.mu.Lock()
+	entry, ok = fixture.overlay["sync.txt"]
+	putsFinal := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if putsFinal != putsAfterWhiteout {
+		t.Fatalf("overlay puts after whiteout = %d, after write/flush/release = %d — unlinked git handle resurrected the entry", putsAfterWhiteout, putsFinal)
+	}
+	if !ok || entry.Op != "whiteout" {
+		t.Fatalf("overlay entry after write-after-unlink = %+v, %v — want whiteout preserved", entry, ok)
+	}
+}

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -11,45 +11,54 @@ import (
 // FileHandle represents an open file in the FUSE filesystem.
 // WriteBuffer is defined in write.go and supports offset-based writes.
 type FileHandle struct {
-	Ino                uint64
-	Path               string
-	Layer              PathLayer
-	LocalFile          *os.File
-	Flags              uint32          // O_RDONLY, O_WRONLY, O_RDWR, O_APPEND, etc.
-	OpenPID            uint32          // PID that opened the handle, when supplied by the kernel
-	Dirty              *WriteBuffer    // write buffer, nil for read-only opens
-	DirtySeq           uint64          // monotonic sequence for authoritative dirty-size tracking
-	WriteBackSeq       uint64          // DirtySeq at time of write-back cache snapshot (0 = no snapshot)
-	OrigSize           int64           // original file size at open time (for patch detection)
-	BaseRev            int64           // server revision at open time (for conflict detection)
-	ZeroBase           bool            // true when the handle has adopted an explicit empty-file baseline
-	IsNew              bool            // true if created via Create() (no prior remote existence)
-	ShadowReady        bool            // true when the local shadow file is a safe full snapshot
-	ShadowSpill        bool            // true when shadow is the authoritative data source (large IsNew/ZeroBase files)
-	ShadowCommitReady  bool            // true when ShadowSpill Flush has staged shadow for async commit
-	ShadowCommitSeq    uint64          // DirtySeq captured when ShadowCommitReady was staged
-	ShadowPinned       bool            // true when this handle has pinned the shadow (must Unpin on Release)
-	ShadowGen          uint64          // generation token from Pin/PinIfExists (passed to Unpin)
-	Streamer           *StreamUploader // nil for small files / read-only; manages background part uploads
-	Prefetch           *Prefetcher     // nil for writable handles; sequential read prefetcher
-	ReadTarget         *client.ReadTarget
-	WritePolicy        WritePolicy // per-handle remote durability policy chosen at open/create
-	GitWorkspaceID     string      // set for handles served by the git workspace layer
-	GitRelPath         string
-	GitKind            string
-	GitMode            string
-	GitBaseObjectSHA   string
-	PendingMode        uint32 // mode change deferred because a dirty handle was open
-	HasPendingMode     bool   // true when PendingMode should be applied on Release
-	PendingModeGen     uint64 // generation for PendingMode, used to avoid clearing newer chmods
-	PreviousMode       uint32 // mode before PendingMode was set (for rollback on flush failure)
-	HasPreviousMode    bool   // true when previous mode state was snapshotted
-	PreviousModeKnown  bool   // true when PreviousMode was authoritative
-	Unlinked           bool   // true after the directory entry was removed while this handle stayed open
-	UnlinkedSnapshot   bool   // true when UnlinkedData is an authoritative read snapshot
-	UnlinkedData       []byte // read-only snapshot for open-but-unlinked remote files
-	UnlinkedShadowGen  uint64 // generation pin for large open-unlink snapshots stored in ShadowStore
-	UnlinkedSize       int64
+	Ino               uint64
+	Path              string
+	Layer             PathLayer
+	LocalFile         *os.File
+	Flags             uint32          // O_RDONLY, O_WRONLY, O_RDWR, O_APPEND, etc.
+	OpenPID           uint32          // PID that opened the handle, when supplied by the kernel
+	Dirty             *WriteBuffer    // write buffer, nil for read-only opens
+	DirtySeq          uint64          // monotonic sequence for authoritative dirty-size tracking
+	WriteBackSeq      uint64          // DirtySeq at time of write-back cache snapshot (0 = no snapshot)
+	OrigSize          int64           // original file size at open time (for patch detection)
+	BaseRev           int64           // server revision at open time (for conflict detection)
+	ZeroBase          bool            // true when the handle has adopted an explicit empty-file baseline
+	IsNew             bool            // true if created via Create() (no prior remote existence)
+	ShadowReady       bool            // true when the local shadow file is a safe full snapshot
+	ShadowSpill       bool            // true when shadow is the authoritative data source (large IsNew/ZeroBase files)
+	ShadowCommitReady bool            // true when ShadowSpill Flush has staged shadow for async commit
+	ShadowCommitSeq   uint64          // DirtySeq captured when ShadowCommitReady was staged
+	ShadowPinned      bool            // true when this handle has pinned the shadow (must Unpin on Release)
+	ShadowGen         uint64          // generation token from Pin/PinIfExists (passed to Unpin)
+	Streamer          *StreamUploader // nil for small files / read-only; manages background part uploads
+	Prefetch          *Prefetcher     // nil for writable handles; sequential read prefetcher
+	ReadTarget        *client.ReadTarget
+	WritePolicy       WritePolicy // per-handle remote durability policy chosen at open/create
+	GitWorkspaceID    string      // set for handles served by the git workspace layer
+	GitRelPath        string
+	GitKind           string
+	GitMode           string
+	GitBaseObjectSHA  string
+	PendingMode       uint32 // mode change deferred because a dirty handle was open
+	HasPendingMode    bool   // true when PendingMode should be applied on Release
+	PendingModeGen    uint64 // generation for PendingMode, used to avoid clearing newer chmods
+	PreviousMode      uint32 // mode before PendingMode was set (for rollback on flush failure)
+	HasPreviousMode   bool   // true when previous mode state was snapshotted
+	PreviousModeKnown bool   // true when PreviousMode was authoritative
+	Unlinked          bool   // true after the directory entry was removed while this handle stayed open
+	UnlinkedSnapshot  bool   // true when UnlinkedData is an authoritative read snapshot
+	UnlinkedData      []byte // read-only snapshot for open-but-unlinked remote files
+	UnlinkedShadowGen uint64 // generation pin for large open-unlink snapshots stored in ShadowStore
+	UnlinkedSize      int64
+	// Staging generations recorded when this handle staged path-keyed state.
+	// discardUnlinkedHandleStateLocked uses them for ownership-scoped cleanup:
+	// after a pathname is unlinked and recreated, path-global removes would
+	// destroy the replacement file's staged state, so only store generations
+	// this handle actually created may be removed (gens are monotonic per
+	// store, so a stale value simply never matches).
+	WriteBackGen       uint64 // writeBack generation staged by this handle (0 = none)
+	PendingIndexGen    uint64 // pendingIndex generation staged by this handle (0 = none)
+	ShadowStageGen     uint64 // shadowStore content generation staged by this handle (0 = none)
 	RemoteCommitUnlock func() // held same-path commit lock while local shadow state is reserved
 	mu                 sync.Mutex
 }

--- a/pkg/fuse/open_handles.go
+++ b/pkg/fuse/open_handles.go
@@ -70,6 +70,32 @@ func (idx *OpenHandleIndex) UnlinkPath(p string) {
 	delete(idx.byPath, p)
 }
 
+// RelinkPath re-attaches handles to the path index, reversing UnlinkPath.
+// Used to roll back a failed Unlink. Handles that are no longer open (absent
+// from the inode index, e.g. released in between) are skipped.
+func (idx *OpenHandleIndex) RelinkPath(p string, handles []*FileHandle) {
+	if idx == nil || p == "" {
+		return
+	}
+	idx.mu.Lock()
+	defer idx.mu.Unlock()
+
+	for _, fh := range handles {
+		if fh == nil {
+			continue
+		}
+		set, ok := idx.byInode[fh.Ino]
+		if !ok {
+			continue
+		}
+		if _, ok := set[fh]; !ok {
+			continue
+		}
+		addHandleToSet(idx.byPath, p, fh)
+		idx.pathByHandle[fh] = p
+	}
+}
+
 // Has reports whether any open handle matches ino or p.
 // When both are supplied this intentionally uses OR semantics to preserve the
 // old conservative inode/path checks from the pre-index table scan.

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -76,10 +76,19 @@ func (idx *PendingIndex) acquireTwoPathLocks(a, b string) (pla, plb *pendingPath
 }
 
 func (idx *PendingIndex) releaseTwoPathLocks(a, b string, pla, plb *pendingPathLock) {
-	if plb != nil {
-		idx.releasePathLock(b, plb)
+	// Release against the same SORTED names used by acquireTwoPathLocks:
+	// pla protects the lexicographically smaller path, plb the larger one.
+	// Releasing against the original unsorted names crosses the lock/path
+	// pairing for reverse-ordered renames and can delete a live lock's map
+	// entry, splitting one path into two mutexes.
+	first, second := a, b
+	if second < first {
+		first, second = second, first
 	}
-	idx.releasePathLock(a, pla)
+	if plb != nil {
+		idx.releasePathLock(second, plb)
+	}
+	idx.releasePathLock(first, pla)
 }
 
 // NewPendingIndex creates a PendingIndex backed by the given directory.

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -14,11 +14,72 @@ import (
 // PendingIndex is an in-memory authoritative index for pending file metadata.
 // All metadata reads are served from memory (O(1), no disk I/O, no JSON parse).
 // Disk writes happen on Put/Remove/Rename for durability and crash recovery.
+//
+// Concurrency: mutating operations hold a per-path lock across both the disk
+// write and the in-memory publish/removal, so a same-path Put and a
+// generation-checked RemoveIfGeneration cannot interleave disk state — e.g. a
+// replacement Put's new .meta must never be deleted by a stale owner's
+// remove that already passed its generation check in memory.
 type PendingIndex struct {
-	mu      sync.RWMutex
-	items   map[string]*WriteBackMeta // path → metadata
-	dir     string                    // directory for .meta persistence
-	nextGen atomic.Uint64
+	mu        sync.RWMutex
+	items     map[string]*WriteBackMeta // path → metadata
+	dir       string                    // directory for .meta persistence
+	nextGen   atomic.Uint64
+	pathLocks map[string]*pendingPathLock
+}
+
+// pendingPathLock is a refcounted per-path mutex, mirroring WriteBackCache's
+// pathLockEntry. Lock order: path lock (outer) → idx.mu (inner).
+type pendingPathLock struct {
+	mu      sync.Mutex
+	waiters int
+}
+
+func (idx *PendingIndex) acquirePathLock(remotePath string) *pendingPathLock {
+	idx.mu.Lock()
+	pl, ok := idx.pathLocks[remotePath]
+	if !ok {
+		pl = &pendingPathLock{}
+		idx.pathLocks[remotePath] = pl
+	}
+	pl.waiters++
+	idx.mu.Unlock()
+
+	pl.mu.Lock()
+	return pl
+}
+
+func (idx *PendingIndex) releasePathLock(remotePath string, pl *pendingPathLock) {
+	idx.mu.Lock()
+	pl.waiters--
+	if pl.waiters == 0 {
+		delete(idx.pathLocks, remotePath)
+	}
+	idx.mu.Unlock()
+	pl.mu.Unlock()
+}
+
+// acquireTwoPathLocks locks both paths in a stable (lexicographic) order so
+// rename operations cannot deadlock against each other.
+func (idx *PendingIndex) acquireTwoPathLocks(a, b string) (pla, plb *pendingPathLock) {
+	if a == b {
+		pla = idx.acquirePathLock(a)
+		return pla, nil
+	}
+	first, second := a, b
+	if second < first {
+		first, second = second, first
+	}
+	pla = idx.acquirePathLock(first)
+	plb = idx.acquirePathLock(second)
+	return pla, plb
+}
+
+func (idx *PendingIndex) releaseTwoPathLocks(a, b string, pla, plb *pendingPathLock) {
+	if plb != nil {
+		idx.releasePathLock(b, plb)
+	}
+	idx.releasePathLock(a, pla)
 }
 
 // NewPendingIndex creates a PendingIndex backed by the given directory.
@@ -28,8 +89,9 @@ func NewPendingIndex(dir string) (*PendingIndex, error) {
 		return nil, fmt.Errorf("pending index dir: %w", err)
 	}
 	idx := &PendingIndex{
-		items: make(map[string]*WriteBackMeta),
-		dir:   dir,
+		items:     make(map[string]*WriteBackMeta),
+		dir:       dir,
+		pathLocks: make(map[string]*pendingPathLock),
 	}
 	return idx, nil
 }
@@ -102,6 +164,12 @@ func (idx *PendingIndex) PutShadowSpillWithMode(remotePath string, size int64, k
 }
 
 func (idx *PendingIndex) putInternal(remotePath string, size int64, kind PendingKind, baseRev int64, shadowSpill bool, mode uint32, hasMode bool) (uint64, error) {
+	// Hold the per-path lock across the disk write AND the in-memory publish
+	// so a generation-checked removal of a stale entry cannot delete this
+	// fresh .meta after already passing its in-memory check.
+	pl := idx.acquirePathLock(remotePath)
+	defer idx.releasePathLock(remotePath, pl)
+
 	gen := idx.nextGen.Add(1)
 	meta := &WriteBackMeta{
 		Path:        remotePath,
@@ -156,23 +224,31 @@ func (idx *PendingIndex) HasPending(remotePath string) bool {
 
 // Remove deletes metadata for the given path from memory and disk.
 func (idx *PendingIndex) Remove(remotePath string) {
+	pl := idx.acquirePathLock(remotePath)
 	idx.mu.Lock()
 	delete(idx.items, remotePath)
 	idx.mu.Unlock()
 
 	metaPath := filepath.Join(idx.dir, hashPath(remotePath)+".meta")
 	_ = os.Remove(metaPath)
+	idx.releasePathLock(remotePath, pl)
 }
 
 // RemoveIfGeneration atomically checks that the current generation matches
 // expectedGen before removing the entry. Returns true if the entry was
 // removed. This prevents a stale upload from removing a fresher pending entry
 // that was created (via a newer Put) while the old upload was in flight.
+//
+// The per-path lock is held across the generation check, the map removal AND
+// the disk .meta removal, so a concurrent same-path Put cannot publish its new
+// generation in between and have its fresh .meta deleted by this stale remove.
 func (idx *PendingIndex) RemoveIfGeneration(remotePath string, expectedGen uint64) bool {
+	pl := idx.acquirePathLock(remotePath)
 	idx.mu.Lock()
 	meta, ok := idx.items[remotePath]
 	if !ok || meta.Generation != expectedGen {
 		idx.mu.Unlock()
+		idx.releasePathLock(remotePath, pl)
 		return false
 	}
 	delete(idx.items, remotePath)
@@ -180,6 +256,7 @@ func (idx *PendingIndex) RemoveIfGeneration(remotePath string, expectedGen uint6
 
 	metaPath := filepath.Join(idx.dir, hashPath(remotePath)+".meta")
 	_ = os.Remove(metaPath)
+	idx.releasePathLock(remotePath, pl)
 	return true
 }
 
@@ -197,6 +274,9 @@ func (idx *PendingIndex) Generation(remotePath string) uint64 {
 // RenamePending atomically moves a pending entry from oldPath to newPath.
 // Returns true if there was a pending entry to rename.
 func (idx *PendingIndex) RenamePending(oldPath, newPath string) bool {
+	pla, plb := idx.acquireTwoPathLocks(oldPath, newPath)
+	defer idx.releaseTwoPathLocks(oldPath, newPath, pla, plb)
+
 	idx.mu.RLock()
 	meta, ok := idx.items[oldPath]
 	if !ok {
@@ -246,6 +326,9 @@ func (idx *PendingIndex) RenamePending(oldPath, newPath string) bool {
 // (with nil error) when there is no pending entry for oldPath, and a non-nil
 // error when persisting the prepared meta fails.
 func (idx *PendingIndex) PrepareRename(oldPath, newPath string) (*WriteBackMeta, error) {
+	pla, plb := idx.acquireTwoPathLocks(oldPath, newPath)
+	defer idx.releaseTwoPathLocks(oldPath, newPath, pla, plb)
+
 	idx.mu.RLock()
 	meta, ok := idx.items[oldPath]
 	if !ok {
@@ -281,6 +364,9 @@ func (idx *PendingIndex) PrepareRename(oldPath, newPath string) (*WriteBackMeta,
 // file has moved: newPath becomes authoritative in memory, oldPath is removed
 // from memory and disk.
 func (idx *PendingIndex) CommitRename(oldPath string, newMeta *WriteBackMeta) {
+	pla, plb := idx.acquireTwoPathLocks(oldPath, newMeta.Path)
+	defer idx.releaseTwoPathLocks(oldPath, newMeta.Path, pla, plb)
+
 	idx.mu.Lock()
 	delete(idx.items, oldPath)
 	idx.items[newMeta.Path] = newMeta
@@ -293,6 +379,9 @@ func (idx *PendingIndex) CommitRename(oldPath string, newMeta *WriteBackMeta) {
 // for newPath. It refuses to touch disk when newPath is live in memory, so an
 // unrelated pending entry at the target path cannot be destroyed.
 func (idx *PendingIndex) AbortRename(newPath string) {
+	pl := idx.acquirePathLock(newPath)
+	defer idx.releasePathLock(newPath, pl)
+
 	idx.mu.RLock()
 	_, live := idx.items[newPath]
 	idx.mu.RUnlock()
@@ -366,6 +455,9 @@ func (idx *PendingIndex) UpdateSize(remotePath string, size int64) {
 
 // UpdateMode updates the pending mode metadata for an existing entry.
 func (idx *PendingIndex) UpdateMode(remotePath string, mode uint32) error {
+	pl := idx.acquirePathLock(remotePath)
+	defer idx.releasePathLock(remotePath, pl)
+
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 
@@ -394,6 +486,9 @@ func (idx *PendingIndex) UpdateMode(remotePath string, mode uint32) error {
 // MarkCommitted keeps the pending entry as a local overlay data source but no
 // longer treats it as never-persisted new data.
 func (idx *PendingIndex) MarkCommitted(remotePath string, committedRev int64) error {
+	pl := idx.acquirePathLock(remotePath)
+	defer idx.releasePathLock(remotePath, pl)
+
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
 
@@ -427,6 +522,9 @@ func (idx *PendingIndex) MarkCommitted(remotePath string, committedRev int64) er
 // The in-memory state is only updated after the disk write succeeds to
 // ensure crash recovery sees a consistent view.
 func (idx *PendingIndex) MarkConflict(remotePath string) error {
+	pl := idx.acquirePathLock(remotePath)
+	defer idx.releasePathLock(remotePath, pl)
+
 	idx.mu.RLock()
 	meta, ok := idx.items[remotePath]
 	if !ok {

--- a/pkg/fuse/pending_index_test.go
+++ b/pkg/fuse/pending_index_test.go
@@ -1,8 +1,10 @@
 package fuse
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 )
 
@@ -345,5 +347,82 @@ func TestPendingIndexAbortRename(t *testing.T) {
 	}
 	if !recovered2.HasPending("/live.txt") {
 		t.Error("AbortRename deleted a live entry's meta")
+	}
+}
+
+// TestPendingIndexRemoveIfGenerationPutRaceConsistency races replacement Puts
+// against stale-generation removals and asserts the crash-durability invariant
+// at the end: recovery from disk must see exactly the live in-memory entries.
+// Without per-path serialization, a stale RemoveIfGeneration can delete the
+// replacement's fresh .meta after the replacement already passed the in-memory
+// generation check (disk lost while memory looks correct).
+func TestPendingIndexRemoveIfGenerationPutRaceConsistency(t *testing.T) {
+	dir := t.TempDir()
+	idx, err := NewPendingIndex(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	const p = "/race/file.txt"
+
+	// Seed the stale generation the remover will target.
+	staleGen, err := idx.Put(p, 1, PendingNew)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const racers = 8
+	const rounds = 100
+	var wg sync.WaitGroup
+	// Remover: repeatedly try to remove the ORIGINAL generation. Only the
+	// first attempt can succeed; later ones must be no-ops because any
+	// present entry is a fresher replacement generation.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			idx.RemoveIfGeneration(p, staleGen)
+		}
+	}()
+	// Replacers: keep publishing newer generations.
+	for r := 0; r < racers; r++ {
+		wg.Add(1)
+		go func(r int) {
+			defer wg.Done()
+			for i := 0; i < rounds; i++ {
+				if _, err := idx.Put(p, int64(r*rounds+i+2), PendingNew); err != nil {
+					t.Errorf("put: %v", err)
+					return
+				}
+			}
+		}(r)
+	}
+	wg.Wait()
+
+	// Invariant: whatever is in memory must be exactly what is on disk.
+	live, liveOK := idx.GetMeta(p)
+	diskRaw, diskErr := os.ReadFile(filepath.Join(dir, hashPath(p)+".meta"))
+	if liveOK {
+		if diskErr != nil {
+			t.Fatalf("live entry gen=%d present but .meta missing on disk: %v", live.Generation, diskErr)
+		}
+		var diskMeta WriteBackMeta
+		if err := json.Unmarshal(diskRaw, &diskMeta); err != nil {
+			t.Fatalf("decode .meta: %v", err)
+		}
+		if diskMeta.Generation != live.Generation {
+			t.Fatalf("memory gen=%d but disk gen=%d — stale remove deleted replacement .meta", live.Generation, diskMeta.Generation)
+		}
+	}
+	// Full recovery must reproduce the live view.
+	idx2, err := NewPendingIndex(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := idx2.RecoverFromDisk(); err != nil {
+		t.Fatal(err)
+	}
+	_, recOK := idx2.GetMeta(p)
+	if liveOK != recOK {
+		t.Fatalf("recovery mismatch: live=%v recovered=%v", liveOK, recOK)
 	}
 }

--- a/pkg/fuse/pending_index_test.go
+++ b/pkg/fuse/pending_index_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestPendingIndexPutGetRemove(t *testing.T) {
@@ -425,4 +426,82 @@ func TestPendingIndexRemoveIfGenerationPutRaceConsistency(t *testing.T) {
 	if liveOK != recOK {
 		t.Fatalf("recovery mismatch: live=%v recovered=%v", liveOK, recOK)
 	}
+}
+
+// TestPendingIndexTwoPathLocksReverseOrder proves that a reverse-lexicographic
+// acquire/release pair cannot split one path into two live mutexes: a waiter
+// on the smaller path must hold the SAME lock instance that a later acquirer
+// blocks on. Regression for the crossed lock/path pairing in
+// releaseTwoPathLocks.
+func TestPendingIndexTwoPathLocksReverseOrder(t *testing.T) {
+	idx, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pla, plb := idx.acquireTwoPathLocks("/z", "/a")
+
+	// Register a waiter on "/a" (the lexicographically smaller path, held
+	// via pla).
+	waiterHeld := make(chan *pendingPathLock, 1)
+	waiterDone := make(chan struct{})
+	go func() {
+		defer close(waiterDone)
+		pl := idx.acquirePathLock("/a")
+		waiterHeld <- pl
+		// Hold the lock briefly; a second acquirer must not enter meanwhile.
+		time.Sleep(150 * time.Millisecond)
+		idx.releasePathLock("/a", pl)
+	}()
+	// Wait until the waiter is queued on the /a lock.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		idx.mu.Lock()
+		pl, ok := idx.pathLocks["/a"]
+		waiters := 0
+		if ok {
+			waiters = pl.waiters
+		}
+		idx.mu.Unlock()
+		if ok && waiters >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("waiter never queued on /a path lock")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	// Release the pair in the original (unsorted) order. With the crossed
+	// release the /a map entry would be deleted here, letting a second
+	// acquirer create a fresh mutex and enter concurrently with the waiter.
+	idx.releaseTwoPathLocks("/z", "/a", pla, plb)
+
+	var waiterLock *pendingPathLock
+	select {
+	case waiterLock = <-waiterHeld:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter did not acquire /a lock after pair release")
+	}
+
+	// While the waiter holds /a, a new acquirer must block.
+	secondAcquired := make(chan struct{})
+	go func() {
+		pl := idx.acquirePathLock("/a")
+		close(secondAcquired)
+		idx.releasePathLock("/a", pl)
+	}()
+	select {
+	case <-secondAcquired:
+		t.Fatal("second acquirer entered /a while the waiter still held it — path split into two locks")
+	case <-time.After(50 * time.Millisecond):
+		// Expected: still blocked.
+	}
+	<-waiterDone
+	select {
+	case <-secondAcquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second acquirer never entered /a after waiter released")
+	}
+	_ = waiterLock
 }

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -131,6 +131,8 @@ func (s *ShadowStore) releasePathLock(remotePath string, pl *shadowPathLock) {
 
 // acquireTwoPathLocks locks both paths in a stable (lexicographic) order so
 // Rename cannot deadlock against a concurrent opposite-direction Rename.
+// The returned locks correspond to the SORTED names: pla protects first,
+// plb protects second.
 func (s *ShadowStore) acquireTwoPathLocks(a, b string) (pla, plb *shadowPathLock) {
 	if a == b {
 		pla = s.acquirePathLock(a)
@@ -146,10 +148,19 @@ func (s *ShadowStore) acquireTwoPathLocks(a, b string) (pla, plb *shadowPathLock
 }
 
 func (s *ShadowStore) releaseTwoPathLocks(a, b string, pla, plb *shadowPathLock) {
-	if plb != nil {
-		s.releasePathLock(b, plb)
+	// Release against the same SORTED names used by acquireTwoPathLocks:
+	// pla protects the lexicographically smaller path, plb the larger one.
+	// Releasing against the original unsorted names crosses the lock/path
+	// pairing for reverse-ordered renames and can delete a live lock's map
+	// entry, splitting one path into two mutexes.
+	first, second := a, b
+	if second < first {
+		first, second = second, first
 	}
-	s.releasePathLock(a, pla)
+	if plb != nil {
+		s.releasePathLock(second, plb)
+	}
+	s.releasePathLock(first, pla)
 }
 
 // NewShadowStore creates a ShadowStore rooted at dir.
@@ -1175,48 +1186,6 @@ func (s *ShadowStore) RemoveIfGeneration(remotePath string, expectedGen uint64) 
 	}
 	s.runRemoveCleanup(cleanup)
 	s.releasePathLock(remotePath, pl)
-	return true
-}
-
-// Unretire moves a retired shadow generation back to the active map for
-// remotePath, renaming its disk file back. Used to roll back a failed Unlink:
-// the shadow was retired by the unlink-time Remove but the remote DELETE
-// failed, so the still-open handle's backing must become the live shadow
-// again. Returns false if the generation is not retired or the path already
-// has an active shadow (e.g. a replacement was created in between — rolling
-// back then would destroy it).
-func (s *ShadowStore) Unretire(gen uint64, remotePath string) bool {
-	if gen == 0 {
-		return false
-	}
-	pl := s.acquirePathLock(remotePath)
-	defer s.releasePathLock(remotePath, pl)
-
-	s.mu.Lock()
-	rt, ok := s.retired[gen]
-	if !ok {
-		s.mu.Unlock()
-		return false
-	}
-	if _, exists := s.files[remotePath]; exists {
-		s.mu.Unlock()
-		return false
-	}
-	delete(s.retired, gen)
-	sf := &ShadowFile{fd: rt.fd, size: rt.size}
-	s.files[remotePath] = sf
-	s.active[remotePath] = gen
-	s.genFile[gen] = sf
-	s.bumpWriteGenLocked(remotePath)
-	s.mu.Unlock()
-
-	if err := os.Rename(rt.diskPath, s.shadowPath(remotePath)); err != nil {
-		// The retired file is missing (e.g. swept after a crash): keep the
-		// maps consistent — the fd remains readable, so in-memory state and
-		// Has()/ReadAt() still work for the handle's lifetime.
-		_ = err
-	}
-	s.pendingBytes.Add(rt.size)
 	return true
 }
 

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -91,6 +91,65 @@ type ShadowStore struct {
 	cachedFreeBytes  atomic.Int64 // cached Statfs free bytes (Bavail*Bsize)
 	cachedTotalBytes atomic.Int64 // cached Statfs total bytes (Blocks*Bsize)
 
+	// pathLocks serializes all disk+memory mutations per remote path, so a
+	// generation-checked removal (RemoveIfGeneration) cannot delete or retire
+	// the on-disk shadow of a fresher same-path write that already passed the
+	// in-memory generation check. Lock order: path lock (outer) → s.mu (inner).
+	pathLocks map[string]*shadowPathLock
+}
+
+// shadowPathLock is a refcounted per-path mutex, mirroring WriteBackCache's
+// pathLockEntry.
+type shadowPathLock struct {
+	mu      sync.Mutex
+	waiters int
+}
+
+func (s *ShadowStore) acquirePathLock(remotePath string) *shadowPathLock {
+	s.mu.Lock()
+	pl, ok := s.pathLocks[remotePath]
+	if !ok {
+		pl = &shadowPathLock{}
+		s.pathLocks[remotePath] = pl
+	}
+	pl.waiters++
+	s.mu.Unlock()
+
+	pl.mu.Lock()
+	return pl
+}
+
+func (s *ShadowStore) releasePathLock(remotePath string, pl *shadowPathLock) {
+	s.mu.Lock()
+	pl.waiters--
+	if pl.waiters == 0 {
+		delete(s.pathLocks, remotePath)
+	}
+	s.mu.Unlock()
+	pl.mu.Unlock()
+}
+
+// acquireTwoPathLocks locks both paths in a stable (lexicographic) order so
+// Rename cannot deadlock against a concurrent opposite-direction Rename.
+func (s *ShadowStore) acquireTwoPathLocks(a, b string) (pla, plb *shadowPathLock) {
+	if a == b {
+		pla = s.acquirePathLock(a)
+		return pla, nil
+	}
+	first, second := a, b
+	if second < first {
+		first, second = second, first
+	}
+	pla = s.acquirePathLock(first)
+	plb = s.acquirePathLock(second)
+	return pla, plb
+}
+
+func (s *ShadowStore) releaseTwoPathLocks(a, b string, pla, plb *shadowPathLock) {
+	if plb != nil {
+		s.releasePathLock(b, plb)
+	}
+	s.releasePathLock(a, pla)
 }
 
 // NewShadowStore creates a ShadowStore rooted at dir.
@@ -126,6 +185,7 @@ func NewShadowStoreWithQuota(dir string, freeRatio float64, maxBytes int64) (*Sh
 		writeGen:            make(map[string]uint64),
 		writeCacheFreeRatio: freeRatio,
 		writeCacheMaxBytes:  maxBytes,
+		pathLocks:           make(map[string]*shadowPathLock),
 	}
 	return ss, nil
 }
@@ -310,6 +370,9 @@ func (s *ShadowStore) ensureShadowFile(remotePath string, baseRev int64) (*Shado
 // This is used to establish a local writable source of truth for new or
 // truncating handles before any user writes arrive.
 func (s *ShadowStore) Ensure(remotePath string, size int64, baseRev int64) error {
+	pl := s.acquirePathLock(remotePath)
+	defer s.releasePathLock(remotePath, pl)
+
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
 		return err
@@ -341,6 +404,9 @@ func (s *ShadowStore) Ensure(remotePath string, size int64, baseRev int64) error
 // WriteAt writes user data directly into the shadow file without syncing.
 // The caller decides when the shadow needs durable persistence.
 func (s *ShadowStore) WriteAt(remotePath string, offset int64, data []byte, baseRev int64) (int, error) {
+	pl := s.acquirePathLock(remotePath)
+	defer s.releasePathLock(remotePath, pl)
+
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
 		return 0, err
@@ -398,6 +464,9 @@ func (s *ShadowStore) WriteAt(remotePath string, offset int64, data []byte, base
 // WriteFull replaces the shadow contents with a full snapshot.
 // Returns ENOSPC if the write would breach disk protection limits.
 func (s *ShadowStore) WriteFull(remotePath string, data []byte, baseRev int64) error {
+	pl := s.acquirePathLock(remotePath)
+	defer s.releasePathLock(remotePath, pl)
+
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
 		return err
@@ -527,6 +596,9 @@ func (s *ShadowStore) checkFreeRatioThrottled(requiredBytes int64) error {
 // perform the actual fd.ReadAt call under RLock, so no concurrent reader
 // can be using the old fd when WriteStream releases Lock.
 func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64) (int64, error) {
+	pl := s.acquirePathLock(remotePath)
+	defer s.releasePathLock(remotePath, pl)
+
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
 		return 0, err
@@ -594,6 +666,9 @@ func (s *ShadowStore) WriteStream(remotePath string, r io.Reader, baseRev int64)
 // Truncate updates the shadow file length without syncing it.
 // Returns ENOSPC if the growth would breach disk protection limits.
 func (s *ShadowStore) Truncate(remotePath string, size int64, baseRev int64) error {
+	pl := s.acquirePathLock(remotePath)
+	defer s.releasePathLock(remotePath, pl)
+
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
 		return err
@@ -638,6 +713,9 @@ func (s *ShadowStore) Sync(remotePath string) error {
 // Each dirty part is written at its correct offset via pwrite.
 // This avoids full-file materialization — cost is O(dirty_parts) syscalls.
 func (s *ShadowStore) WriteExtents(remotePath string, wb *WriteBuffer, baseRev int64) error {
+	pl := s.acquirePathLock(remotePath)
+	defer s.releasePathLock(remotePath, pl)
+
 	sf, err := s.ensureShadowFile(remotePath, baseRev)
 	if err != nil {
 		return err
@@ -1057,14 +1135,21 @@ func (s *ShadowStore) runRemoveCleanup(cleanup shadowRemoveCleanup) {
 // pins, the shadow is "retired" — removed from the active files map so new
 // writers get a fresh shadow, but kept alive for existing readers until the
 // last Unpin.
+//
+// The per-path lock is held across map removal AND disk cleanup so a
+// concurrent same-path write cannot open/reuse the shared disk path in
+// between.
 func (s *ShadowStore) Remove(remotePath string) {
+	pl := s.acquirePathLock(remotePath)
 	s.mu.Lock()
 	cleanup, ok := s.removeCoreLocked(remotePath, 0)
 	s.mu.Unlock()
 	if !ok {
+		s.releasePathLock(remotePath, pl)
 		return
 	}
 	s.runRemoveCleanup(cleanup)
+	s.releasePathLock(remotePath, pl)
 }
 
 // RemoveIfGeneration removes the shadow file for remotePath only if its current
@@ -1074,14 +1159,64 @@ func (s *ShadowStore) Remove(remotePath string) {
 // between the check and the actual removal. Returns true only if the entry was
 // removed. This prevents a stale upload from removing a fresher shadow that
 // was written while the old upload was in flight.
+//
+// The per-path lock is additionally held across the disk cleanup (retire
+// rename or immediate remove), closing the window where a replacement write
+// could create its new shadow at the shared disk path after the in-memory
+// check but before the stale cleanup removed/renamed it.
 func (s *ShadowStore) RemoveIfGeneration(remotePath string, expectedGen uint64) bool {
+	pl := s.acquirePathLock(remotePath)
 	s.mu.Lock()
 	cleanup, ok := s.removeCoreLocked(remotePath, expectedGen)
 	s.mu.Unlock()
 	if !ok {
+		s.releasePathLock(remotePath, pl)
 		return false
 	}
 	s.runRemoveCleanup(cleanup)
+	s.releasePathLock(remotePath, pl)
+	return true
+}
+
+// Unretire moves a retired shadow generation back to the active map for
+// remotePath, renaming its disk file back. Used to roll back a failed Unlink:
+// the shadow was retired by the unlink-time Remove but the remote DELETE
+// failed, so the still-open handle's backing must become the live shadow
+// again. Returns false if the generation is not retired or the path already
+// has an active shadow (e.g. a replacement was created in between — rolling
+// back then would destroy it).
+func (s *ShadowStore) Unretire(gen uint64, remotePath string) bool {
+	if gen == 0 {
+		return false
+	}
+	pl := s.acquirePathLock(remotePath)
+	defer s.releasePathLock(remotePath, pl)
+
+	s.mu.Lock()
+	rt, ok := s.retired[gen]
+	if !ok {
+		s.mu.Unlock()
+		return false
+	}
+	if _, exists := s.files[remotePath]; exists {
+		s.mu.Unlock()
+		return false
+	}
+	delete(s.retired, gen)
+	sf := &ShadowFile{fd: rt.fd, size: rt.size}
+	s.files[remotePath] = sf
+	s.active[remotePath] = gen
+	s.genFile[gen] = sf
+	s.bumpWriteGenLocked(remotePath)
+	s.mu.Unlock()
+
+	if err := os.Rename(rt.diskPath, s.shadowPath(remotePath)); err != nil {
+		// The retired file is missing (e.g. swept after a crash): keep the
+		// maps consistent — the fd remains readable, so in-memory state and
+		// Has()/ReadAt() still work for the handle's lifetime.
+		_ = err
+	}
+	s.pendingBytes.Add(rt.size)
 	return true
 }
 
@@ -1109,6 +1244,9 @@ func (s *ShadowStore) bumpWriteGenLocked(remotePath string) uint64 {
 // pendingBytes (the replacement shadow's disk file is overwritten by the
 // os.Rename).
 func (s *ShadowStore) Rename(oldPath, newPath string) bool {
+	pla, plb := s.acquireTwoPathLocks(oldPath, newPath)
+	defer s.releaseTwoPathLocks(oldPath, newPath, pla, plb)
+
 	s.mu.Lock()
 
 	sf, ok := s.files[oldPath]

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"sync"
 	"syscall"
 	"testing"
 	"time"
@@ -1417,5 +1418,120 @@ func TestShadowStoreRemoveIfGenerationRaceStaleVsNewerWrite(t *testing.T) {
 	}
 	if !bytes.Equal(got, newest) {
 		t.Fatalf("content = %q, want %q (newer content must survive)", got, newest)
+	}
+}
+
+// TestShadowStoreUnretire covers the rollback primitive: a pinned shadow that
+// was retired by Remove must become the live shadow again after Unretire,
+// unless the path has already been re-created by a replacement write.
+func TestShadowStoreUnretire(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+	const p = "/dir/file.txt"
+
+	if err := ss.WriteFull(p, []byte("v1"), 0); err != nil {
+		t.Fatal(err)
+	}
+	gen := ss.Pin(p)
+	if gen == 0 {
+		t.Fatal("pin returned 0")
+	}
+	ss.Remove(p) // retires because refs > 0
+	if ss.Has(p) {
+		t.Fatal("shadow still active after retire")
+	}
+
+	// Unretire restores the live shadow with its content.
+	if !ss.Unretire(gen, p) {
+		t.Fatal("Unretire returned false")
+	}
+	if !ss.Has(p) {
+		t.Fatal("shadow not active after Unretire")
+	}
+	data, err := ss.ReadAll(p)
+	if err != nil || string(data) != "v1" {
+		t.Fatalf("ReadAll after Unretire = %q, %v — want v1", data, err)
+	}
+	ss.Unpin(gen)
+
+	// A replacement at the same path must block Unretire of the old generation.
+	if err := ss.WriteFull(p, []byte("v2"), 0); err != nil {
+		t.Fatal(err)
+	}
+	gen2 := ss.Pin(p)
+	ss.Remove(p) // retires v2 generation... actually retires current active
+	if ss.Has(p) {
+		t.Fatal("shadow still active after second retire")
+	}
+	if err := ss.WriteFull(p, []byte("replacement"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if ss.Unretire(gen2, p) {
+		t.Fatal("Unretire must refuse when the path has an active replacement shadow")
+	}
+	data, err = ss.ReadAll(p)
+	if err != nil || string(data) != "replacement" {
+		t.Fatalf("ReadAll after refused Unretire = %q, %v — want replacement", data, err)
+	}
+	ss.Unpin(gen2)
+}
+
+// TestShadowStoreRemoveIfGenerationWriteFullRaceConsistency races replacement
+// WriteFulls against a stale-generation removal and asserts that whenever an
+// active shadow generation exists, its disk file is present and readable.
+// Without per-path serialization, the stale remove can delete/rename the
+// replacement's fresh shadow after the in-memory generation check passed.
+func TestShadowStoreRemoveIfGenerationWriteFullRaceConsistency(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+	const p = "/race/file.txt"
+
+	if err := ss.WriteFull(p, []byte("stale"), 0); err != nil {
+		t.Fatal(err)
+	}
+	staleGen := ss.ActiveGeneration(p)
+	if staleGen == 0 {
+		t.Fatal("no active generation after WriteFull")
+	}
+
+	const racers = 8
+	const rounds = 100
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < rounds; i++ {
+			ss.RemoveIfGeneration(p, staleGen)
+		}
+	}()
+	for r := 0; r < racers; r++ {
+		wg.Add(1)
+		go func(r int) {
+			defer wg.Done()
+			for i := 0; i < rounds; i++ {
+				if err := ss.WriteFull(p, []byte("gen"), 0); err != nil {
+					t.Errorf("WriteFull: %v", err)
+					return
+				}
+			}
+		}(r)
+	}
+	wg.Wait()
+
+	if gen := ss.ActiveGeneration(p); gen != 0 {
+		if _, err := ss.ReadAll(p); err != nil {
+			t.Fatalf("active generation %d present but shadow unreadable: %v", gen, err)
+		}
+		if _, err := os.Stat(ss.shadowPath(p)); err != nil {
+			t.Fatalf("active generation %d present but disk file missing: %v", gen, err)
+		}
 	}
 }

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -1421,65 +1421,6 @@ func TestShadowStoreRemoveIfGenerationRaceStaleVsNewerWrite(t *testing.T) {
 	}
 }
 
-// TestShadowStoreUnretire covers the rollback primitive: a pinned shadow that
-// was retired by Remove must become the live shadow again after Unretire,
-// unless the path has already been re-created by a replacement write.
-func TestShadowStoreUnretire(t *testing.T) {
-	dir := t.TempDir()
-	ss, err := NewShadowStore(dir)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer ss.Close()
-	const p = "/dir/file.txt"
-
-	if err := ss.WriteFull(p, []byte("v1"), 0); err != nil {
-		t.Fatal(err)
-	}
-	gen := ss.Pin(p)
-	if gen == 0 {
-		t.Fatal("pin returned 0")
-	}
-	ss.Remove(p) // retires because refs > 0
-	if ss.Has(p) {
-		t.Fatal("shadow still active after retire")
-	}
-
-	// Unretire restores the live shadow with its content.
-	if !ss.Unretire(gen, p) {
-		t.Fatal("Unretire returned false")
-	}
-	if !ss.Has(p) {
-		t.Fatal("shadow not active after Unretire")
-	}
-	data, err := ss.ReadAll(p)
-	if err != nil || string(data) != "v1" {
-		t.Fatalf("ReadAll after Unretire = %q, %v — want v1", data, err)
-	}
-	ss.Unpin(gen)
-
-	// A replacement at the same path must block Unretire of the old generation.
-	if err := ss.WriteFull(p, []byte("v2"), 0); err != nil {
-		t.Fatal(err)
-	}
-	gen2 := ss.Pin(p)
-	ss.Remove(p) // retires v2 generation... actually retires current active
-	if ss.Has(p) {
-		t.Fatal("shadow still active after second retire")
-	}
-	if err := ss.WriteFull(p, []byte("replacement"), 0); err != nil {
-		t.Fatal(err)
-	}
-	if ss.Unretire(gen2, p) {
-		t.Fatal("Unretire must refuse when the path has an active replacement shadow")
-	}
-	data, err = ss.ReadAll(p)
-	if err != nil || string(data) != "replacement" {
-		t.Fatalf("ReadAll after refused Unretire = %q, %v — want replacement", data, err)
-	}
-	ss.Unpin(gen2)
-}
-
 // TestShadowStoreRemoveIfGenerationWriteFullRaceConsistency races replacement
 // WriteFulls against a stale-generation removal and asserts that whenever an
 // active shadow generation exists, its disk file is present and readable.
@@ -1533,5 +1474,71 @@ func TestShadowStoreRemoveIfGenerationWriteFullRaceConsistency(t *testing.T) {
 		if _, err := os.Stat(ss.shadowPath(p)); err != nil {
 			t.Fatalf("active generation %d present but disk file missing: %v", gen, err)
 		}
+	}
+}
+
+// TestShadowStoreTwoPathLocksReverseOrder is the ShadowStore counterpart of
+// TestPendingIndexTwoPathLocksReverseOrder: a reverse-lexicographic
+// acquire/release pair must not split one path into two live mutexes.
+func TestShadowStoreTwoPathLocksReverseOrder(t *testing.T) {
+	ss, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	pla, plb := ss.acquireTwoPathLocks("/z", "/a")
+
+	waiterHeld := make(chan *shadowPathLock, 1)
+	waiterDone := make(chan struct{})
+	go func() {
+		defer close(waiterDone)
+		pl := ss.acquirePathLock("/a")
+		waiterHeld <- pl
+		time.Sleep(150 * time.Millisecond)
+		ss.releasePathLock("/a", pl)
+	}()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		ss.mu.Lock()
+		pl, ok := ss.pathLocks["/a"]
+		waiters := 0
+		if ok {
+			waiters = pl.waiters
+		}
+		ss.mu.Unlock()
+		if ok && waiters >= 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("waiter never queued on /a path lock")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	ss.releaseTwoPathLocks("/z", "/a", pla, plb)
+
+	select {
+	case <-waiterHeld:
+	case <-time.After(2 * time.Second):
+		t.Fatal("waiter did not acquire /a lock after pair release")
+	}
+
+	secondAcquired := make(chan struct{})
+	go func() {
+		pl := ss.acquirePathLock("/a")
+		close(secondAcquired)
+		ss.releasePathLock("/a", pl)
+	}()
+	select {
+	case <-secondAcquired:
+		t.Fatal("second acquirer entered /a while the waiter still held it — path split into two locks")
+	case <-time.After(50 * time.Millisecond):
+	}
+	<-waiterDone
+	select {
+	case <-secondAcquired:
+	case <-time.After(2 * time.Second):
+		t.Fatal("second acquirer never entered /a after waiter released")
 	}
 }

--- a/pkg/fuse/writeback.go
+++ b/pkg/fuse/writeback.go
@@ -239,17 +239,20 @@ type WriteBackPutTimings struct {
 // PutWithBaseRevAndMode is like PutWithBaseRev, but also persists the file
 // permission bits that should be applied once the pending data is remote.
 func (c *WriteBackCache) PutWithBaseRevAndMode(remotePath string, data []byte, size int64, kind PendingKind, baseRev int64, mode uint32, hasMode bool) error {
-	_, err := c.PutWithBaseRevAndModeTimings(remotePath, data, size, kind, baseRev, mode, hasMode)
+	_, _, err := c.PutWithBaseRevAndModeTimings(remotePath, data, size, kind, baseRev, mode, hasMode)
 	return err
 }
 
 // PutWithBaseRevAndModeTimings is like PutWithBaseRevAndMode but also returns
-// sub-phase timings for diagnostic instrumentation.
+// the allocated store generation and sub-phase timings for diagnostic
+// instrumentation. The generation lets callers perform ownership-scoped
+// cleanup later (RemoveIfGeneration) so a stale owner never removes a fresher
+// same-path entry.
 //
 // File I/O (.dat/.meta atomicWrite) runs outside the global WriteBackCache.mu,
 // serialized per-path by a per-path lock. The global lock is only held briefly
 // to allocate the generation, compute file paths, and publish in-memory state.
-func (c *WriteBackCache) PutWithBaseRevAndModeTimings(remotePath string, data []byte, size int64, kind PendingKind, baseRev int64, mode uint32, hasMode bool) (WriteBackPutTimings, error) {
+func (c *WriteBackCache) PutWithBaseRevAndModeTimings(remotePath string, data []byte, size int64, kind PendingKind, baseRev int64, mode uint32, hasMode bool) (uint64, WriteBackPutTimings, error) {
 	var t WriteBackPutTimings
 
 	// Phase 1: acquire per-path lock (serializes same-path Put/Remove/etc.)
@@ -267,7 +270,7 @@ func (c *WriteBackCache) PutWithBaseRevAndModeTimings(remotePath string, data []
 	datStart := time.Now()
 	if err := atomicWrite(datPath, data); err != nil {
 		c.releasePathLock(remotePath, pl)
-		return t, fmt.Errorf("writeback put data: %w", err)
+		return 0, t, fmt.Errorf("writeback put data: %w", err)
 	}
 	t.DatWrite = time.Since(datStart)
 
@@ -286,14 +289,14 @@ func (c *WriteBackCache) PutWithBaseRevAndModeTimings(remotePath string, data []
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {
 		c.releasePathLock(remotePath, pl)
-		return t, fmt.Errorf("writeback marshal meta: %w", err)
+		return 0, t, fmt.Errorf("writeback marshal meta: %w", err)
 	}
 	metaStart := time.Now()
 	if err := atomicWrite(metaPath, metaBytes); err != nil {
 		// Best-effort cleanup of the .dat file if meta write fails.
 		_ = os.Remove(datPath)
 		c.releasePathLock(remotePath, pl)
-		return t, fmt.Errorf("writeback put meta: %w", err)
+		return 0, t, fmt.Errorf("writeback put meta: %w", err)
 	}
 	t.MetaWrite = time.Since(metaStart)
 
@@ -305,7 +308,7 @@ func (c *WriteBackCache) PutWithBaseRevAndModeTimings(remotePath string, data []
 	c.mu.Unlock()
 
 	c.releasePathLock(remotePath, pl)
-	return t, nil
+	return gen, t, nil
 }
 
 // Get reads the cached data for remotePath. Returns nil, false if not cached.


### PR DESCRIPTION
## Summary

- **FUSE:** Fix `rmdir` returning `ENOTEMPTY` after unlink-while-open with dirty write buffers (pjdfstest `unlink/14.t`). Flush/Release/debounce could re-stage write-back and re-upload a just-deleted path; discard unlinked handle state instead, and treat `fh.Unlinked` in open-child checks.
- **Blackbox `community.pjdfstest`:** Use absolute `prove` path under sudo (Arch `/usr/bin/core_perl` is off `secure_path`), re-inject `PATH` via `env`, truncate per-command logs, and parse only the latest prove section so reused work-dirs do not treat prior FAIL lines as product regressions.

## Context

On Orb Arch blackbox community runs, `community.pjdfstest` failed with:

1. `sudo: prove: command not found` (harness env)
2. Then `unlink/14.t` test 7: `rmdir` expected 0, got `ENOTEMPTY` after open+write+unlink
3. After the product fix, prove reported `Result: PASS` but the module still failed because command logs were appended across runs and the parser scored an old `Failed: 1` line

## Test plan

- [x] `go test ./pkg/fuse/ -run 'TestRmdirAfterOpenUnlinkDirtyFlush|TestRmdir|TestUnlink|TestFlush' -count=1`
- [x] `TestRmdirAfterOpenUnlinkDirtyFlush` (new regression)
- [x] Parse unit check on appended PASS logs → `failed_cases == 0`
- [x] Orb: `python blackbox/run.py --module community.pjdfstest --bin ./bin/drive9 --work-dir ./tmp` → prove `Result: PASS` / exit 0 after rebuild with FUSE fix
- [ ] CI `make lint` / package tests on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented deleted/unlinked paths from being restored by consistently treating unlinked open handles as authoritative across flush, fsync, release, and deferred upload/commit flows.
  * Improved unlink and remote-delete handling to avoid server-side path recreation and to roll back state when deletes fail.
  * Ensured git workspace flush doesn’t resurrect overlays for write-sync handles left open after unlink.

* **Tests**
  * Expanded FUSE regression coverage for unlink/rmdir ordering, rollback behavior, and concurrency “no resurrection” scenarios.
  * Added unit tests for pjdfstest log parsing/anomaly detection and improved robustness of parsing-based metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->