### PR TITLE
fix: project fs_id in shared SKIP LOCKED claim queries (TiDB planner workaround)

### DIFF
--- a/pkg/datastore/file_gc_tasks.go
+++ b/pkg/datastore/file_gc_tasks.go
@@ -144,15 +144,20 @@ func (s *Store) ClaimFileGCTask(ctx context.Context, now time.Time, leaseDuratio
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	row := tx.QueryRowContext(ctx, `SELECT task_id, file_id, storage_type, storage_ref,
+	// SelCols adds the fs_id projection in shared shape to work around the
+	// TiDB FOR UPDATE SKIP LOCKED planner bug that rejects WHERE predicates
+	// over unprojected columns (see Scope.SelCols).
+	row := tx.QueryRowContext(ctx, `SELECT `+s.scope.SelCols(`task_id, file_id, storage_type, storage_ref,
 		size_bytes, content_type, status, attempt_count, max_attempts, receipt,
-		leased_at, lease_until, available_at, last_error, created_at, updated_at, completed_at
+		leased_at, lease_until, available_at, last_error, created_at, updated_at, completed_at`)+`
 		FROM file_gc_tasks
 		WHERE `+s.scope.And(`status = ? AND available_at <= ?`)+`
 		ORDER BY available_at, created_at, task_id
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED`, s.scope.Args(FileGCTaskQueued, now)...)
-	task, err := scanFileGCTask(row)
+	// The claim query projects fs_id first in shared shape (workaround for
+	// the TiDB SKIP LOCKED planner bug; see Scope.SelCols); withFsID skips it.
+	task, err := scanFileGCTask(row, s.scope.Shared())
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil, false, nil
@@ -282,7 +287,7 @@ func (s *Store) RecoverExpiredFileGCTasks(ctx context.Context, now time.Time, li
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	query := `SELECT task_id FROM file_gc_tasks
+	query := `SELECT ` + s.scope.SelCols(`task_id`) + ` FROM file_gc_tasks
 		WHERE ` + s.scope.And(`status = ? AND lease_until IS NOT NULL AND lease_until < ?`) + `
 		ORDER BY lease_until, created_at, task_id`
 	args := s.scope.Args(FileGCTaskProcessing, now)
@@ -299,8 +304,15 @@ func (s *Store) RecoverExpiredFileGCTasks(ctx context.Context, now time.Time, li
 
 	var taskIDs []string
 	for rows.Next() {
+		// Shared shape projects fs_id first (workaround for the TiDB SKIP
+		// LOCKED planner bug; see Scope.SelCols); scan and discard it.
+		var fsID int64
 		var taskID string
-		if err := rows.Scan(&taskID); err != nil {
+		if s.scope.Shared() {
+			if err := rows.Scan(&fsID, &taskID); err != nil {
+				return 0, err
+			}
+		} else if err := rows.Scan(&taskID); err != nil {
 			return 0, err
 		}
 		taskIDs = append(taskIDs, taskID)
@@ -421,14 +433,23 @@ func (s *Store) fileGCTaskLeaseError(ctx context.Context, taskID string) error {
 	return ErrFileGCTaskLeaseMismatch
 }
 
-func scanFileGCTask(s scanner) (*FileGCTask, error) {
+func scanFileGCTask(s scanner, withFsID ...bool) (*FileGCTask, error) {
 	var task FileGCTask
 	var contentType, receipt, lastError sql.NullString
 	var leasedAt, leaseUntil, completedAt sql.NullTime
-	err := s.Scan(&task.TaskID, &task.FileID, &task.StorageType, &task.StorageRef,
+	// withFsID[0] is set by the SKIP LOCKED claim paths: in shared shape those
+	// queries project fs_id first (workaround for the TiDB SKIP LOCKED
+	// planner bug; see Scope.SelCols), so scan and discard the leading column.
+	dest := make([]any, 0, 18)
+	if len(withFsID) > 0 && withFsID[0] {
+		var fsID int64
+		dest = append(dest, &fsID)
+	}
+	dest = append(dest, &task.TaskID, &task.FileID, &task.StorageType, &task.StorageRef,
 		&task.SizeBytes, &contentType, &task.Status, &task.AttemptCount,
 		&task.MaxAttempts, &receipt, &leasedAt, &leaseUntil, &task.AvailableAt,
 		&lastError, &task.CreatedAt, &task.UpdatedAt, &completedAt)
+	err := s.Scan(dest...)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound

--- a/pkg/datastore/scope.go
+++ b/pkg/datastore/scope.go
@@ -122,6 +122,25 @@ func (s Scope) InsVals(vals string) string {
 	return vals
 }
 
+// SelCols prefixes a SELECT column list with "fs_id, " in shared shape and
+// returns it unchanged in standalone shape. It exists ONLY to work around a
+// TiDB planner bug: with FOR UPDATE SKIP LOCKED, TiDB builds the table
+// schema from the projection only, so a WHERE predicate over an unprojected
+// column is rejected with planner error "Can't find column" — even though
+// the SQL is perfectly valid (it works on MySQL, PostgreSQL, and on TiDB
+// itself with plain FOR UPDATE). Observed on v8.5.3-serverless
+// (2026-06-25 build). Projecting fs_id avoids the bug; callers must scan
+// the extra leading column and may discard it. This can be reverted once
+// upstream fixes the planner. Use it only where the fs_id predicate is
+// present (i.e. queries built with And/Args), otherwise the extra
+// projection is wasted bytes on the wire.
+func (s Scope) SelCols(cols string) string {
+	if s.shared {
+		return "fs_id, " + cols
+	}
+	return cols
+}
+
 // tenantCol returns the tenant-discriminator column name for journal/vault
 // tables under this Store's schema shape.
 func (s *Store) tenantCol() string { return s.scope.TenantCol() }

--- a/pkg/datastore/scope_test.go
+++ b/pkg/datastore/scope_test.go
@@ -1,0 +1,13 @@
+package datastore
+
+import "testing"
+
+func TestScopeSelCols(t *testing.T) {
+	t.Helper()
+	if got := SharedScope(42).SelCols("task_id"); got != "fs_id, task_id" {
+		t.Fatalf("shared SelCols = %q, want %q", got, "fs_id, task_id")
+	}
+	if got := StandaloneScope(42).SelCols("task_id"); got != "task_id" {
+		t.Fatalf("standalone SelCols = %q, want %q", got, "task_id")
+	}
+}

--- a/pkg/datastore/semantic_tasks.go
+++ b/pkg/datastore/semantic_tasks.go
@@ -259,7 +259,9 @@ func (s *Store) claimSemanticTask(ctx context.Context, now time.Time, leaseDurat
 
 	query, args := s.claimSemanticTaskQuery(now, normalizedTypes)
 	row := tx.QueryRowContext(ctx, query, args...)
-	task, scanErr := scanSemanticTask(row)
+	// The claim query projects fs_id first in shared shape (workaround for
+	// the TiDB SKIP LOCKED planner bug; see Scope.SelCols); withFsID skips it.
+	task, scanErr := scanSemanticTask(row, s.scope.Shared())
 	if scanErr != nil {
 		if errors.Is(scanErr, semantic.ErrTaskNotFound) {
 			return nil, false, nil
@@ -319,9 +321,12 @@ func normalizeClaimTaskTypes(taskTypes []semantic.TaskType) ([]semantic.TaskType
 }
 
 func (s *Store) claimSemanticTaskQuery(now time.Time, taskTypes []semantic.TaskType) (string, []any) {
-	query := `SELECT task_id, task_type, resource_id, resource_version, status,
+	// SelCols adds the fs_id projection in shared shape to work around the
+	// TiDB FOR UPDATE SKIP LOCKED planner bug that rejects WHERE predicates
+	// over unprojected columns (see Scope.SelCols).
+	query := `SELECT ` + s.scope.SelCols(`task_id, task_type, resource_id, resource_version, status,
 		attempt_count, max_attempts, receipt, leased_at, lease_until, available_at,
-		payload_json, last_error, created_at, updated_at, completed_at
+		payload_json, last_error, created_at, updated_at, completed_at`) + `
 		FROM semantic_tasks
 		WHERE ` + s.scope.And(`status = ?`)
 	args := s.scope.Args(semantic.TaskQueued)
@@ -508,7 +513,7 @@ func (s *Store) RecoverExpiredSemanticTasks(ctx context.Context, now time.Time, 
 	}
 	defer func() { _ = tx.Rollback() }()
 
-	query := `SELECT task_id FROM semantic_tasks
+	query := `SELECT ` + s.scope.SelCols(`task_id`) + ` FROM semantic_tasks
 		WHERE ` + s.scope.And(`status = ? AND lease_until IS NOT NULL AND lease_until < ?`) + `
 		ORDER BY lease_until, created_at, task_id`
 	args := s.scope.Args(semantic.TaskProcessing, now)
@@ -525,8 +530,15 @@ func (s *Store) RecoverExpiredSemanticTasks(ctx context.Context, now time.Time, 
 
 	var taskIDs []string
 	for rows.Next() {
+		// Shared shape projects fs_id first (workaround for the TiDB SKIP
+		// LOCKED planner bug; see Scope.SelCols); scan and discard it.
+		var fsID int64
 		var taskID string
-		if err := rows.Scan(&taskID); err != nil {
+		if s.scope.Shared() {
+			if err := rows.Scan(&fsID, &taskID); err != nil {
+				return 0, err
+			}
+		} else if err := rows.Scan(&taskID); err != nil {
 			return 0, err
 		}
 		taskIDs = append(taskIDs, taskID)
@@ -596,15 +608,24 @@ func semanticTaskLeaseNow() time.Time {
 	return now
 }
 
-func scanSemanticTask(s scanner) (*semantic.Task, error) {
+func scanSemanticTask(s scanner, withFsID ...bool) (*semantic.Task, error) {
 	var task semantic.Task
 	var receipt, lastError sql.NullString
 	var leasedAt, leaseUntil, completedAt sql.NullTime
 	var payload []byte
-	err := s.Scan(&task.TaskID, &task.TaskType, &task.ResourceID, &task.ResourceVersion,
+	// withFsID[0] is set by the SKIP LOCKED claim paths: in shared shape those
+	// queries project fs_id first (workaround for the TiDB SKIP LOCKED
+	// planner bug; see Scope.SelCols), so scan and discard the leading column.
+	dest := make([]any, 0, 17)
+	if len(withFsID) > 0 && withFsID[0] {
+		var fsID int64
+		dest = append(dest, &fsID)
+	}
+	dest = append(dest, &task.TaskID, &task.TaskType, &task.ResourceID, &task.ResourceVersion,
 		&task.Status, &task.AttemptCount, &task.MaxAttempts, &receipt, &leasedAt,
 		&leaseUntil, &task.AvailableAt, &payload, &lastError, &task.CreatedAt,
 		&task.UpdatedAt, &completedAt)
+	err := s.Scan(dest...)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, semantic.ErrTaskNotFound


### PR DESCRIPTION
## Why

Since the shared-table rollout, `tenant_worker` claim loops against shared task tables fail every claim with:

```
Error 1105 (HY000): Can't find column tidbcloud_fs.semantic_tasks.fs_id in schema Column: [tidbcloud_fs.semantic_tasks.task_id]
```

Verified against a live shared DB (`tidbcloud_fs`, TiDB `v8.5.3-serverless`, 2026-06-25 build): the table **has** `fs_id` (`PRIMARY KEY (fs_id, task_id) CLUSTERED`), and the failure is specific to `FOR UPDATE SKIP LOCKED` — the TiDB planner builds the table schema from the SELECT projection only, so a `WHERE` predicate over an unprojected column is rejected. Plain `SELECT` and plain `FOR UPDATE` are unaffected, and MySQL parses all shapes. Reproduced on an empty table (plan-time error):

| shape | result |
|---|---|
| `SELECT task_id ... FOR UPDATE` | ok |
| `SELECT task_id ... FOR UPDATE SKIP LOCKED` | Can't find column |
| `SELECT fs_id, task_id ... FOR UPDATE SKIP LOCKED` | **ok** |
| `SELECT * ... FOR UPDATE SKIP LOCKED` | ok |

## Change

Project `fs_id` in the four `FOR UPDATE SKIP LOCKED` claim queries, **shared shape only** — standalone tenant DBs have no `fs_id` column, so the projection must not be added there:

- New `Scope.SelCols` (mirrors `InsCols`): prefixes the SELECT column list with `fs_id, ` only when the store addresses a shared-schema DB, next to a comment documenting the TiDB planner behavior it works around.
- Applied to `ClaimSemanticTask` / `RecoverExpiredSemanticTasks` / `ClaimFileGCTask` / `RecoverExpiredFileGCTasks`; the leading column is scanned and discarded (`withFsID` on the two scan helpers + an explicit leading scan in the two recover loops).
- Plain `FOR UPDATE` sites (task dedup, lease checks) are untouched — they are not affected by the bug.

Claim semantics (WHERE / ORDER / LIMIT / locking) are unchanged; the only difference on the wire is one extra returned column.

## Test plan

- `go build ./...`, `make lint` → 0 issues.
- `make test TEST_PKGS='./pkg/datastore/...'` → all green, including the shared-schema suites exercising claim + recover against real MySQL.
- New `TestScopeSelCols` pins shared vs standalone projection.
- Verified end-to-end on a live TiDB `v8.5.3-serverless` shared DB that the new shapes parse under `FOR UPDATE SKIP LOCKED`.

Follow-up (outside this PR): report the planner bug upstream with the minimal repro (`SELECT task_id FROM semantic_tasks WHERE fs_id = ? FOR UPDATE SKIP LOCKED`); this projection change can be revisited once a fixed TiDB ships.
