### PR TITLE
fix: bound tenant metrics on successful control paths

### DIFF
--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -10,7 +10,7 @@ This dashboard set expects the `drive9_*` Prometheus namespace. The previous `da
 
 ## 1. Usage dashboard
 
-- `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, HTTP transport bytes, storage/media quota state, latency, and non-OK rates by TiDB Cloud org/tenant/surface/action. Use this to answer `who is using Drive9, how much, and through which workflows?`
+- `drive9-tenant-usage-dashboard.json`: first-stop dashboard for tenant-level product usage: active tenants, request frequency, in-flight requests, logical file reads/writes, storage/media quota state, latency, and non-OK rates by TiDB Cloud org/tenant/surface/action. Use this to answer `who is using Drive9, how much, and through which workflows?`
 
 Tenant usage metrics intentionally allow `tenant_id` and `tidbcloud_org_id` as Prometheus labels, but keep high-cardinality values out of labels: no path, file ID, upload ID, API key ID, raw URL, user agent, or trace ID. When a tenant has no TiDB Cloud org binding, or a hot path cannot safely resolve the binding without extra work, `tidbcloud_org_id` is reported as `guest`.
 
@@ -21,7 +21,6 @@ Tenant usage metrics intentionally allow `tenant_id` and `tidbcloud_org_id` as P
 - `drive9_tenant_requests_total`: request count by `tenant_id`, `tidbcloud_org_id`, `surface`, `action`, `result`, and `status_class`.
 - `drive9_tenant_request_duration_seconds`: request latency histogram by `surface` and `status_class`.
 - `drive9_tenant_inflight_requests`: current in-flight request gauge by `tenant_id`, `tidbcloud_org_id`, `surface`, and `action`.
-- `drive9_tenant_http_bytes_total`: HTTP transport bytes by `tenant_id`, `tidbcloud_org_id`, `surface`, and `direction=request|response`.
 - `drive9_tenant_file_bytes_total`: logical file bytes by `tenant_id`, `tidbcloud_org_id`, `surface`, `action`, and `direction=read|write`.
 - `drive9_tenant_storage_bytes`: opportunistically published quota storage gauge by `tenant_id`, `tidbcloud_org_id`, and `state=confirmed|reserved|limit`.
 - `drive9_tenant_media_files`: opportunistically published quota media-file gauge by `tenant_id`, `tidbcloud_org_id`, and `state=confirmed|limit`.

--- a/docs/grafana/README.md
+++ b/docs/grafana/README.md
@@ -18,10 +18,10 @@ Tenant usage metrics intentionally allow `tenant_id` and `tidbcloud_org_id` as P
 
 - `drive9_tenant_count`: tenant count by real tenant `status`.
 - `drive9_tenant_pool_bindings`: tenant-pool binding count by `pool_id`, `tidbcloud_org_id`, and binding `status=free|used`. The binding label is `status`, not `pool_status`.
-- `drive9_tenant_requests_total`: request count by `tenant_id`, `tidbcloud_org_id`, `surface`, `action`, `result`, and `status_class`.
+- `drive9_tenant_requests_total`: request count by `surface`, `action`, and `status_class`. It includes `tenant_id` and `tidbcloud_org_id` for data-plane surfaces and 4xx/5xx control-plane requests.
 - `drive9_tenant_request_duration_seconds`: request latency histogram by `surface` and `status_class`.
 - `drive9_tenant_inflight_requests`: current in-flight request gauge by `tenant_id`, `tidbcloud_org_id`, `surface`, and `action`.
-- `drive9_tenant_file_bytes_total`: logical file bytes by `tenant_id`, `tidbcloud_org_id`, `surface`, `action`, and `direction=read|write`.
+- `drive9_tenant_file_bytes_total`: logical file bytes by `tenant_id`, `tidbcloud_org_id`, and `direction=read|write`.
 - `drive9_tenant_storage_bytes`: opportunistically published quota storage gauge by `tenant_id`, `tidbcloud_org_id`, and `state=confirmed|reserved|limit`.
 - `drive9_tenant_media_files`: opportunistically published quota media-file gauge by `tenant_id`, `tidbcloud_org_id`, and `state=confirmed|limit`.
 

--- a/docs/grafana/drive9-tenant-usage-dashboard.json
+++ b/docs/grafana/drive9-tenant-usage-dashboard.json
@@ -486,52 +486,6 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 20
-      },
-      "id": 10,
-      "options": {
-        "legend": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "displayMode": "table",
-          "placement": "bottom",
-          "showLegend": true
-        },
-        "tooltip": {
-          "mode": "multi",
-          "sort": "desc"
-        }
-      },
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "${datasource}"
-          },
-          "expr": "sum by (surface, direction) (rate(drive9_tenant_http_bytes_total{tidbcloud_org_id=~\"$org\",tenant_id=~\"$tenant\",surface=~\"$surface\"}[$__rate_interval]))",
-          "legendFormat": "{{surface}} {{direction}}",
-          "refId": "A"
-        }
-      ],
-      "title": "HTTP Transport Bytes",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "${datasource}"
-      },
-      "fieldConfig": {
-        "defaults": {
           "unit": "short"
         },
         "overrides": []

--- a/e2e/shared-smoke-test/cases/metrics-consistency.sh
+++ b/e2e/shared-smoke-test/cases/metrics-consistency.sh
@@ -5,11 +5,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
-metric_series_count() {
-  local text="$1" metric="$2"
-  printf '%s\n' "$text" | awk -v metric="$metric" '$0 ~ "^" metric "(\\{| )" { count++ } END { print count + 0 }'
-}
-
 metrics_has_tenant_labeled_control_success() {
   local text="$1"
   printf '%s\n' "$text" | grep -Eq '^drive9_tenant_requests_total\{[^}]*status_class="2xx"[^}]*surface="(provision|status|quota|tenant|tokens|vault|other)"[^}]*tenant_id='
@@ -39,15 +34,6 @@ TEXT="$(metrics_get)"
 if [ -z "$TEXT" ]; then
   skip_check "/metrics empty or not exposed"
 else
-	# Transport bytes are aggregate-only: request/response are the complete
-	# bounded label set. Control-plane 2xx request series are aggregate too;
-	# only data-plane traffic and 4xx/5xx retain tenant attribution.
-	http_bytes_series="$(metric_series_count "$TEXT" "drive9_tenant_http_bytes_total")"
-	if [ "$http_bytes_series" -le 2 ]; then
-		ok "tenant_http_bytes_total has at most request/response series ($http_bytes_series)"
-	else
-		fail "tenant_http_bytes_total has $http_bytes_series series; expected at most 2"
-	fi
 	if metrics_has_tenant_labeled_control_success "$TEXT"; then
 		fail "tenant_requests_total control-plane 2xx series unexpectedly carries tenant labels"
 	else

--- a/e2e/shared-smoke-test/cases/metrics-consistency.sh
+++ b/e2e/shared-smoke-test/cases/metrics-consistency.sh
@@ -5,6 +5,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 # shellcheck source=../lib.sh
 source "$SCRIPT_DIR/lib.sh"
 
+metric_series_count() {
+  local text="$1" metric="$2"
+  printf '%s\n' "$text" | awk -v metric="$metric" '$0 ~ "^" metric "(\\{| )" { count++ } END { print count + 0 }'
+}
+
+metrics_has_tenant_labeled_control_success() {
+  local text="$1"
+  printf '%s\n' "$text" | grep -Eq '^drive9_tenant_requests_total\{[^}]*status_class="2xx"[^}]*surface="(provision|status|quota|tenant|tokens|vault|other)"[^}]*tenant_id='
+}
+
 require_base
 require_cmds curl jq
 
@@ -29,6 +39,21 @@ TEXT="$(metrics_get)"
 if [ -z "$TEXT" ]; then
   skip_check "/metrics empty or not exposed"
 else
+	# Transport bytes are aggregate-only: request/response are the complete
+	# bounded label set. Control-plane 2xx request series are aggregate too;
+	# only data-plane traffic and 4xx/5xx retain tenant attribution.
+	http_bytes_series="$(metric_series_count "$TEXT" "drive9_tenant_http_bytes_total")"
+	if [ "$http_bytes_series" -le 2 ]; then
+		ok "tenant_http_bytes_total has at most request/response series ($http_bytes_series)"
+	else
+		fail "tenant_http_bytes_total has $http_bytes_series series; expected at most 2"
+	fi
+	if metrics_has_tenant_labeled_control_success "$TEXT"; then
+		fail "tenant_requests_total control-plane 2xx series unexpectedly carries tenant labels"
+	else
+		ok "tenant_requests_total control-plane 2xx series is aggregate-only"
+	fi
+
   if metrics_has_series "$TEXT" "drive9_shared_db_pool"; then
     ok "drive9_shared_db_pool_* series present"
   else

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -82,7 +82,7 @@ var fuseRemoteOperationBytes = fuseMeter.Int64Counter("drive9_fuse_remote_operat
 var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/tidbcloud_org/surface/action/status_class")
 var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_duration_seconds", "Tenant request duration histogram by surface/status_class", httpDurationBounds)
 var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/tidbcloud_org/surface")
-var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "Tenant-scoped HTTP transport bytes by tenant/tidbcloud_org/direction")
+var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "HTTP transport bytes by direction")
 var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/tidbcloud_org/direction")
 var tenantCount = tenantMeter.Float64Gauge("drive9_tenant_count", "Tenant count by status")
 var tenantStorageBytes = tenantMeter.Float64Gauge("drive9_tenant_storage_bytes", "Tenant storage bytes by tenant/tidbcloud_org/state")
@@ -392,6 +392,15 @@ func isOperationFailureResult(result string) bool {
 	}
 }
 
+func tenantAttributedSurface(surface, statusClass string) bool {
+	switch surface {
+	case "fs", "upload", "object_store", "sql", "events", "journal", "git_workspace":
+		return true
+	default:
+		return statusClass == "4xx" || statusClass == "5xx"
+	}
+}
+
 func RecordGauge(component, name string, value float64) {
 	RecordTenantGauge("", component, name, value)
 }
@@ -463,7 +472,7 @@ func RecordHTTPRequestCount(method, route string, status int) {
 	)
 }
 
-// RecordTenantRequestCount records only the tenant request counter, not the
+// RecordTenantRequestCount records only the request counter, not the
 // duration histogram. Companion to RecordHTTPRequestCount for SSE routes.
 func RecordTenantRequestCount(tenantID, surface, action string, status int) {
 	RecordTenantRequestCountWithOrg(tenantID, "", surface, action, status)
@@ -474,13 +483,15 @@ func RecordTenantRequestCountWithOrg(tenantID, tidbCloudOrgID, surface, action s
 	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
 	surface = cleanMetricValue(surface, "other")
 	action = cleanMetricValue(action, "other")
+	statusClass := statusClass(status)
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
-		Attr("tenant_id", tenantID),
-		Attr("tidbcloud_org_id", tidbCloudOrgID),
 		Attr("surface", surface),
 		Attr("action", action),
-		Attr("status_class", statusClass(status)),
+		Attr("status_class", statusClass),
+	}
+	if tenantAttributedSurface(surface, statusClass) {
+		attrs = append(attrs, Attr("tenant_id", tenantID), Attr("tidbcloud_org_id", tidbCloudOrgID))
 	}
 	tenantRequestsTotal.Add(1, attrs...)
 }
@@ -509,7 +520,7 @@ func RecordTenantEventWithOrg(tenantID, tidbCloudOrgID, event string, labels ...
 	attrs = append(attrs, Attr("event", cleanMetricValue(event, "unknown")))
 	tenantID = cleanMetricValue(tenantID, "unknown")
 	tidbCloudOrgID = cleanTiDBCloudOrgID(tidbCloudOrgID)
-	if tenantID != "unknown" && tenantAttributedBusinessEvent(event) {
+	if tenantID != "unknown" && tenantAttributedBusinessEvent(event, metricLabelValue(labels, "result")) {
 		attrs = append(attrs, Attr("tenant_id", tenantID), Attr("tidbcloud_org_id", tidbCloudOrgID))
 	}
 	for i := 0; i+1 < len(labels); i += 2 {
@@ -518,13 +529,17 @@ func RecordTenantEventWithOrg(tenantID, tidbCloudOrgID, event string, labels ...
 	businessEventsTotal.Add(1, attrs...)
 }
 
-func tenantAttributedBusinessEvent(event string) bool {
-	switch event {
-	case "auth", "tenant_provision", "tenant_schema_init", "tenant_status":
-		return true
-	default:
-		return false
+func tenantAttributedBusinessEvent(event, result string) bool {
+	return event == "tenant_provision" && isOperationFailureResult(result)
+}
+
+func metricLabelValue(labels []string, key string) string {
+	for i := 0; i+1 < len(labels); i += 2 {
+		if labels[i] == key {
+			return cleanMetricValue(labels[i+1], "unknown")
+		}
 	}
+	return "unknown"
 }
 
 func RecordTenantRequest(tenantID, surface, action string, status int, d time.Duration) {
@@ -542,11 +557,12 @@ func RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, surface, action string
 	}
 	RegisterModule("tenant_usage")
 	attrs := []Attribute{
-		Attr("tenant_id", tenantID),
-		Attr("tidbcloud_org_id", tidbCloudOrgID),
 		Attr("surface", surface),
 		Attr("action", action),
 		Attr("status_class", statusClass),
+	}
+	if tenantAttributedSurface(surface, statusClass) {
+		attrs = append(attrs, Attr("tenant_id", tenantID), Attr("tidbcloud_org_id", tidbCloudOrgID))
 	}
 	tenantRequestsTotal.Add(1, attrs...)
 	if d <= 0 {
@@ -558,12 +574,8 @@ func RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, surface, action string
 	)
 }
 
-func RecordTenantHTTPBytes(tenantID, direction string, bytes int64) {
-	RecordTenantHTTPBytesWithOrg(tenantID, "", direction, bytes)
-}
-
-func RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, direction string, bytes int64) {
-	recordTenantHTTPBytes(tenantID, tidbCloudOrgID, direction, bytes)
+func RecordTenantHTTPBytes(direction string, bytes int64) {
+	recordTenantHTTPBytes(direction, bytes)
 }
 
 func RecordTenantFileBytes(tenantID, direction string, bytes int64) {
@@ -748,14 +760,12 @@ func recordTenantBytes(counter *Int64Counter, tenantID, tidbCloudOrgID, directio
 	)
 }
 
-func recordTenantHTTPBytes(tenantID, tidbCloudOrgID, direction string, bytes int64) {
+func recordTenantHTTPBytes(direction string, bytes int64) {
 	if bytes <= 0 {
 		return
 	}
 	RegisterModule("tenant_usage")
 	tenantHTTPBytes.Add(bytes,
-		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
-		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
 		Attr("direction", cleanMetricValue(direction, "unknown")),
 	)
 }

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -530,7 +530,14 @@ func RecordTenantEventWithOrg(tenantID, tidbCloudOrgID, event string, labels ...
 }
 
 func tenantAttributedBusinessEvent(event, result string) bool {
-	return event == "tenant_provision" && isOperationFailureResult(result)
+	switch event {
+	case "tenant_provision":
+		return isOperationFailureResult(result)
+	case "auth", "tenant_schema_init", "tenant_status":
+		return true
+	default:
+		return false
+	}
 }
 
 func metricLabelValue(labels []string, key string) string {

--- a/pkg/metrics/operations.go
+++ b/pkg/metrics/operations.go
@@ -82,7 +82,6 @@ var fuseRemoteOperationBytes = fuseMeter.Int64Counter("drive9_fuse_remote_operat
 var tenantRequestsTotal = tenantMeter.Int64Counter("drive9_tenant_requests_total", "Tenant-scoped requests by tenant/tidbcloud_org/surface/action/status_class")
 var tenantRequestDuration = tenantMeter.Float64Histogram("drive9_tenant_request_duration_seconds", "Tenant request duration histogram by surface/status_class", httpDurationBounds)
 var tenantInflight = tenantMeter.Float64Gauge("drive9_tenant_inflight_requests", "Current in-flight tenant-scoped requests by tenant/tidbcloud_org/surface")
-var tenantHTTPBytes = tenantMeter.Int64Counter("drive9_tenant_http_bytes_total", "HTTP transport bytes by direction")
 var tenantFileBytes = tenantMeter.Int64Counter("drive9_tenant_file_bytes_total", "Tenant-scoped logical file bytes by tenant/tidbcloud_org/direction")
 var tenantCount = tenantMeter.Float64Gauge("drive9_tenant_count", "Tenant count by status")
 var tenantStorageBytes = tenantMeter.Float64Gauge("drive9_tenant_storage_bytes", "Tenant storage bytes by tenant/tidbcloud_org/state")
@@ -581,10 +580,6 @@ func RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, surface, action string
 	)
 }
 
-func RecordTenantHTTPBytes(direction string, bytes int64) {
-	recordTenantHTTPBytes(direction, bytes)
-}
-
 func RecordTenantFileBytes(tenantID, direction string, bytes int64) {
 	RecordTenantFileBytesWithOrg(tenantID, "", direction, bytes)
 }
@@ -763,16 +758,6 @@ func recordTenantBytes(counter *Int64Counter, tenantID, tidbCloudOrgID, directio
 	counter.Add(bytes,
 		Attr("tenant_id", cleanMetricValue(tenantID, "unknown")),
 		Attr("tidbcloud_org_id", cleanTiDBCloudOrgID(tidbCloudOrgID)),
-		Attr("direction", cleanMetricValue(direction, "unknown")),
-	)
-}
-
-func recordTenantHTTPBytes(direction string, bytes int64) {
-	if bytes <= 0 {
-		return
-	}
-	RegisterModule("tenant_usage")
-	tenantHTTPBytes.Add(bytes,
 		Attr("direction", cleanMetricValue(direction, "unknown")),
 	)
 }

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -299,7 +299,6 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 	RecordTenantGaugeWithOrg(tenantID, orgID, "component_org_label_test", "gauge", 1)
 	RecordTenantEventWithOrg(tenantID, orgID, "event_org_label_test", "result", "ok")
 	RecordTenantRequestCountWithOrg(tenantID, orgID, "fs", "action", 200)
-	RecordTenantHTTPBytes("request", 10)
 	RecordTenantFileBytesWithOrg(tenantID, orgID, "out", 20)
 	RecordTenantStorageBytesWithOrg(tenantID, orgID, "confirmed", 30)
 	RecordTenantMediaFilesWithOrg(tenantID, orgID, "confirmed", 40)
@@ -319,7 +318,6 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 		`drive9_service_gauge{component="component_org_label_test",name="gauge",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1.000000`,
 		`drive9_business_events_total{event="event_org_label_test",result="ok"} 1`,
 		`drive9_tenant_requests_total{action="action",status_class="2xx",surface="fs",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
-		`drive9_tenant_http_bytes_total{direction="request"} 10`,
 		`drive9_tenant_file_bytes_total{direction="out",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 20`,
 		`drive9_tenant_storage_bytes{state="confirmed",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 30.000000`,
 		`drive9_tenant_media_files{state="confirmed",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 40.000000`,
@@ -628,7 +626,6 @@ func TestDeleteTenantCounters(t *testing.T) {
 
 	RecordTenantOperationCountWithOrg(tenantID, tidbCloudOrgID, "cmp", "op", "ok")
 	RecordTenantRequestCountWithOrg(tenantID, tidbCloudOrgID, "api", "read", 200)
-	RecordTenantHTTPBytes("upload", 1024)
 	RecordSSEConnectionWithOrg(tenantID, tidbCloudOrgID, "mount", time.Second)
 	RecordSSEEventSentWithOrg(tenantID, tidbCloudOrgID, "write")
 	RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, "api", 3)
@@ -649,7 +646,6 @@ func TestDeleteTenantCounters(t *testing.T) {
 	counterNames := []string{
 		"drive9_service_operations_total",
 		"drive9_tenant_requests_total",
-		"drive9_tenant_http_bytes_total",
 		"drive9_sse_connections_total",
 		"drive9_sse_events_sent_total",
 	}

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -5,6 +5,7 @@ import (
 	"database/sql/driver"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
@@ -124,7 +125,7 @@ func TestRecordTenantOperationOmitsTenantFromDurationHistograms(t *testing.T) {
 func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 	const (
 		tenantID = "tenant-request-duration-omit"
-		surface  = "request_duration_surface"
+		surface  = "fs"
 		action   = "request_duration_action"
 	)
 
@@ -160,15 +161,15 @@ func TestRecordTenantRequestOmitsHighCardinalityLabels(t *testing.T) {
 func TestRecordTenantRequestZeroDurationDoesNotRecordDuration(t *testing.T) {
 	const tenantID = "tenant-zero-request"
 
-	RecordTenantRequest(tenantID, "zero_surface", "zero_action", 200, 0)
+	RecordTenantRequest(tenantID, "object_store", "zero_action", 200, 0)
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
 	text := rec.Body.String()
-	if !strings.Contains(text, `drive9_tenant_requests_total{action="zero_action",status_class="2xx",surface="zero_surface",tenant_id="`+tenantID+`",tidbcloud_org_id="guest"} 1`) {
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="zero_action",status_class="2xx",surface="object_store",tenant_id="`+tenantID+`",tidbcloud_org_id="guest"} 1`) {
 		t.Errorf("missing zero-duration tenant request total:\n%s", text)
 	}
-	if hasMetricLineWith(text, "drive9_tenant_request_duration_seconds_count", `surface="zero_surface"`) {
+	if hasMetricLineWith(text, "drive9_tenant_request_duration_seconds_count", `surface="object_store"`, `status_class="2xx"`) {
 		t.Errorf("zero-duration tenant request unexpectedly recorded a duration:\n%s", text)
 	}
 }
@@ -297,8 +298,8 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 
 	RecordTenantGaugeWithOrg(tenantID, orgID, "component_org_label_test", "gauge", 1)
 	RecordTenantEventWithOrg(tenantID, orgID, "event_org_label_test", "result", "ok")
-	RecordTenantRequestCountWithOrg(tenantID, orgID, "surface_org_label_test", "action", 200)
-	RecordTenantHTTPBytesWithOrg(tenantID, orgID, "request", 10)
+	RecordTenantRequestCountWithOrg(tenantID, orgID, "fs", "action", 200)
+	RecordTenantHTTPBytes("request", 10)
 	RecordTenantFileBytesWithOrg(tenantID, orgID, "out", 20)
 	RecordTenantStorageBytesWithOrg(tenantID, orgID, "confirmed", 30)
 	RecordTenantMediaFilesWithOrg(tenantID, orgID, "confirmed", 40)
@@ -317,8 +318,8 @@ func TestTenantIDMetricsIncludeTiDBCloudOrgID(t *testing.T) {
 	for _, want := range []string{
 		`drive9_service_gauge{component="component_org_label_test",name="gauge",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1.000000`,
 		`drive9_business_events_total{event="event_org_label_test",result="ok"} 1`,
-		`drive9_tenant_requests_total{action="action",status_class="2xx",surface="surface_org_label_test",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
-		`drive9_tenant_http_bytes_total{direction="request",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 10`,
+		`drive9_tenant_requests_total{action="action",status_class="2xx",surface="fs",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 1`,
+		`drive9_tenant_http_bytes_total{direction="request"} 10`,
 		`drive9_tenant_file_bytes_total{direction="out",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 20`,
 		`drive9_tenant_storage_bytes{state="confirmed",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 30.000000`,
 		`drive9_tenant_media_files{state="confirmed",tenant_id="` + tenantID + `",tidbcloud_org_id="` + orgID + `"} 40.000000`,
@@ -385,9 +386,10 @@ func TestTenantOperationFailuresUseSeparateFailureOnlyMetric(t *testing.T) {
 	}
 }
 
-func TestBusinessEventTenantLabelsAreLimitedToLifecycleEvents(t *testing.T) {
+func TestBusinessEventTenantLabelsAreLimitedToFailures(t *testing.T) {
 	RecordTenantEventWithOrg("tenant-event-contract", "org-event-contract", "fs_write", "result", "ok")
-	RecordTenantEventWithOrg("tenant-event-contract", "org-event-contract", "tenant_provision", "provider", "local", "result", "ok")
+	RecordTenantEventWithOrg("tenant-event-contract", "org-event-contract", "tenant_provision", "provider", "local", "result", "accepted")
+	RecordTenantEventWithOrg("tenant-event-contract", "org-event-contract", "tenant_provision", "provider", "local", "result", "cluster_error")
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
@@ -398,8 +400,38 @@ func TestBusinessEventTenantLabelsAreLimitedToLifecycleEvents(t *testing.T) {
 	if hasMetricLineWith(text, "drive9_business_events_total", `event="fs_write"`, `tenant_id=`) {
 		t.Fatalf("hot-path event carried tenant labels:\n%s", text)
 	}
-	if !strings.Contains(text, `drive9_business_events_total{event="tenant_provision",provider="local",result="ok",tenant_id="tenant-event-contract",tidbcloud_org_id="org-event-contract"} 1`) {
-		t.Fatalf("lifecycle event lost tenant attribution:\n%s", text)
+	if !strings.Contains(text, `drive9_business_events_total{event="tenant_provision",provider="local",result="accepted"} 1`) {
+		t.Fatalf("successful provisioning event was not aggregated:\n%s", text)
+	}
+	if hasMetricLineWith(text, "drive9_business_events_total", `event="tenant_provision"`, `result="accepted"`, `tenant_id=`) {
+		t.Fatalf("successful provisioning event carried tenant labels:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_business_events_total{event="tenant_provision",provider="local",result="cluster_error",tenant_id="tenant-event-contract",tidbcloud_org_id="org-event-contract"} 1`) {
+		t.Fatalf("failed provisioning event lost tenant attribution:\n%s", text)
+	}
+}
+
+func TestTenantRequestTenantLabelsAreLimitedToDataPlaneAndErrors(t *testing.T) {
+	RecordTenantRequestWithOrg("tenant-request-contract", "org-request-contract", "provision", "post", http.StatusAccepted, time.Second)
+	RecordTenantRequestWithOrg("tenant-request-contract", "org-request-contract", "provision", "post", http.StatusBadRequest, time.Second)
+	RecordTenantRequestWithOrg("tenant-request-contract", "org-request-contract", "fs", "write", http.StatusAccepted, time.Second)
+
+	rec := httptest.NewRecorder()
+	WritePrometheus(rec)
+	text := rec.Body.String()
+	if !strings.Contains(text, `drive9_tenant_requests_total{action="post",status_class="2xx",surface="provision"} 1`) {
+		t.Fatalf("successful control-plane request was not aggregated:\n%s", text)
+	}
+	if hasMetricLineWith(text, "drive9_tenant_requests_total", `surface="provision"`, `status_class="2xx"`, `tenant_id=`) {
+		t.Fatalf("successful control-plane request carried tenant labels:\n%s", text)
+	}
+	for _, want := range []string{
+		`drive9_tenant_requests_total{action="post",status_class="4xx",surface="provision",tenant_id="tenant-request-contract",tidbcloud_org_id="org-request-contract"} 1`,
+		`drive9_tenant_requests_total{action="write",status_class="2xx",surface="fs",tenant_id="tenant-request-contract",tidbcloud_org_id="org-request-contract"} 1`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing tenant-scoped request metric %q:\n%s", want, text)
+		}
 	}
 }
 
@@ -592,7 +624,7 @@ func TestDeleteTenantCounters(t *testing.T) {
 
 	RecordTenantOperationCountWithOrg(tenantID, tidbCloudOrgID, "cmp", "op", "ok")
 	RecordTenantRequestCountWithOrg(tenantID, tidbCloudOrgID, "api", "read", 200)
-	RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, "upload", 1024)
+	RecordTenantHTTPBytes("upload", 1024)
 	RecordSSEConnectionWithOrg(tenantID, tidbCloudOrgID, "mount", time.Second)
 	RecordSSEEventSentWithOrg(tenantID, tidbCloudOrgID, "write")
 	RecordTenantInFlightWithOrg(tenantID, tidbCloudOrgID, "api", 3)

--- a/pkg/metrics/operations_test.go
+++ b/pkg/metrics/operations_test.go
@@ -390,6 +390,7 @@ func TestBusinessEventTenantLabelsAreLimitedToFailures(t *testing.T) {
 	RecordTenantEventWithOrg("tenant-event-contract", "org-event-contract", "fs_write", "result", "ok")
 	RecordTenantEventWithOrg("tenant-event-contract", "org-event-contract", "tenant_provision", "provider", "local", "result", "accepted")
 	RecordTenantEventWithOrg("tenant-event-contract", "org-event-contract", "tenant_provision", "provider", "local", "result", "cluster_error")
+	RecordTenantEventWithOrg("tenant-event-contract", "org-event-contract", "tenant_schema_init", "provider", "local", "result", "error")
 
 	rec := httptest.NewRecorder()
 	WritePrometheus(rec)
@@ -408,6 +409,9 @@ func TestBusinessEventTenantLabelsAreLimitedToFailures(t *testing.T) {
 	}
 	if !strings.Contains(text, `drive9_business_events_total{event="tenant_provision",provider="local",result="cluster_error",tenant_id="tenant-event-contract",tidbcloud_org_id="org-event-contract"} 1`) {
 		t.Fatalf("failed provisioning event lost tenant attribution:\n%s", text)
+	}
+	if !strings.Contains(text, `drive9_business_events_total{event="tenant_schema_init",provider="local",result="error",tenant_id="tenant-event-contract",tidbcloud_org_id="org-event-contract"} 1`) {
+		t.Fatalf("schema-init event lost tenant attribution:\n%s", text)
 	}
 }
 

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -618,13 +618,12 @@ func TestSharedTenantStatusLogsAndMetricsUseDBOrganization(t *testing.T) {
 	recorder := httptest.NewRecorder()
 	metrics.WritePrometheus(recorder)
 	metricsText := recorder.Body.String()
-	wantMetric := `drive9_tenant_requests_total{action="get",status_class="2xx",surface="status",tenant_id="` + rt.tenantID + `",tidbcloud_org_id="org-shared-status-output"}`
+	wantMetric := `drive9_tenant_requests_total{action="get",status_class="2xx",surface="status"}`
 	if !strings.Contains(metricsText, wantMetric) {
-		t.Fatalf("missing shared status request metric %q", wantMetric)
+		t.Fatalf("missing aggregated status request metric %q", wantMetric)
 	}
-	wrongMetric := `drive9_tenant_requests_total{action="get",status_class="2xx",surface="status",tenant_id="` + rt.tenantID + `",tidbcloud_org_id="guest"}`
-	if strings.Contains(metricsText, wrongMetric) {
-		t.Fatalf("shared status request metric used guest org %q", wrongMetric)
+	if strings.Contains(metricsText, `drive9_tenant_requests_total{action="get",status_class="2xx",surface="status",tenant_id=`) {
+		t.Fatalf("successful status request metric unexpectedly carried tenant labels")
 	}
 }
 

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -709,10 +709,10 @@ func recordTenantHTTPRequest(r *http.Request, status int, d time.Duration, respo
 	}
 	metrics.RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, class.surface, class.action, status, d)
 	if r.ContentLength > 0 {
-		metrics.RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, "request", r.ContentLength)
+		metrics.RecordTenantHTTPBytes("request", r.ContentLength)
 	}
 	if responseBytes > 0 {
-		metrics.RecordTenantHTTPBytesWithOrg(tenantID, tidbCloudOrgID, "response", int64(responseBytes))
+		metrics.RecordTenantHTTPBytes("response", int64(responseBytes))
 	}
 }
 

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -708,12 +708,6 @@ func recordTenantHTTPRequest(r *http.Request, status int, d time.Duration, respo
 		class = scopedClass
 	}
 	metrics.RecordTenantRequestWithOrg(tenantID, tidbCloudOrgID, class.surface, class.action, status, d)
-	if r.ContentLength > 0 {
-		metrics.RecordTenantHTTPBytes("request", r.ContentLength)
-	}
-	if responseBytes > 0 {
-		metrics.RecordTenantHTTPBytes("response", int64(responseBytes))
-	}
 }
 
 func recordTenantFileBytes(ctx context.Context, surface, action, direction string, bytes int64) {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2334,11 +2334,8 @@ func TestMetricsEndpoint(t *testing.T) {
 	if strings.Contains(text, `drive9_tenant_inflight_requests{surface="fs",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Errorf("completed tenant in-flight usage metric should be removed: %s", text)
 	}
-	if !strings.Contains(text, `drive9_tenant_http_bytes_total{direction="request",tenant_id="local",tidbcloud_org_id="guest"}`) {
-		t.Errorf("expected tenant HTTP byte metric in response: %s", text)
-	}
-	if strings.Contains(text, `drive9_tenant_http_bytes_total{action="`) {
-		t.Errorf("tenant HTTP byte metric should not carry action: %s", text)
+	if strings.Contains(text, "drive9_tenant_http_bytes_total") {
+		t.Errorf("HTTP transport byte metric should not be exported: %s", text)
 	}
 	if !strings.Contains(text, `drive9_tenant_file_bytes_total{direction="write",tenant_id="local",tidbcloud_org_id="guest"}`) {
 		t.Fatalf("expected tenant file write byte metric in response: %s", text)

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -1327,7 +1327,7 @@ func TestCloseEntryPreservesLiveTenantCounters(t *testing.T) {
 	metrics.DeleteTenantCounters(tenantID)
 	t.Cleanup(func() { metrics.DeleteTenantCounters(tenantID) })
 
-	metrics.RecordTenantRequestCountWithOrg(tenantID, "org-live-counter", "api", "read", 200)
+	metrics.RecordTenantRequestCountWithOrg(tenantID, "org-live-counter", "fs", "read", 200)
 	assertTenantMetricPresent := func() {
 		t.Helper()
 		recorder := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- aggregate tenant HTTP transport bytes by direction only
- retain tenant attribution for provisioning failures and control-plane 4xx/5xx, while aggregating successful control-plane requests
- add metric contract tests and shared-smoke metric-shape guards

## Validation
- go test ./pkg/metrics ./pkg/server -count=1
- go test ./... -run ^ -count=1
- bash -n e2e/shared-smoke-test/cases/metrics-consistency.sh
- make lint
- make build-server
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Metrics**
  * Reduced metric label cardinality across tenant request, HTTP byte, and business-event series.
  * Tenant/org labels are now limited to applicable data-plane and failure scenarios; control-plane success requests are aggregated without tenant labels.
  * Removed the tenant HTTP transport bytes metric from exported output and dashboard documentation.
* **Bug Fixes**
  * Added/strengthened consistency checks to prevent unexpected high-cardinality or tenant-labeled series.
* **Documentation**
  * Updated Grafana tenant-usage dashboard and tenant metrics contract.
* **Tests**
  * Updated and added assertions in unit, server, auth, and e2e smoke tests to match the new metric semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->