### PR TITLE
fix(client-js): route small in-memory writes inline regardless of omitted size

### DIFF
--- a/clients/drive9-js/package.json
+++ b/clients/drive9-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drive9",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TypeScript SDK for drive9 — an agent-native filesystem with semantic search",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/clients/drive9-js/src/transfer.ts
+++ b/clients/drive9-js/src/transfer.ts
@@ -184,23 +184,35 @@ export async function writeStreamWithSummaryImpl(
   const started = new Date();
   const threshold = client["smallFileThreshold"];
   let data: Uint8Array;
+  let effectiveSize: number;
   if (stream instanceof Uint8Array) {
+    // The byte length is authoritative for an in-memory buffer, so ignore a
+    // missing/incorrect `size` argument: JS callers routinely omit it, and
+    // an `undefined` size otherwise fails every `size < threshold` check and
+    // silently routes a small file through multipart/S3 instead of inline.
     data = stream;
+    effectiveSize = data.length;
   } else {
+    if (typeof size !== "number" || !Number.isFinite(size) || size < 0) {
+      throw new Error(
+        `writeStreamWithSummary requires a finite non-negative size for a ReadableStream, got ${String(size)}`
+      );
+    }
     data = await streamToUint8Array(stream, size);
+    effectiveSize = data.length;
   }
-  if (size === 0 || size < threshold) {
+  if (effectiveSize === 0 || effectiveSize < threshold) {
     await client.write(path, data, opts);
-    return uploadSummary(path, size, "direct_put", started);
+    return uploadSummary(path, effectiveSize, "direct_put", started);
   }
   try {
     const plan = await writeStreamV2(client, path, data, opts);
-    return uploadSummary(path, size, "multipart_v2", started, plan.part_size, plan.total_parts, plan.total_parts);
+    return uploadSummary(path, effectiveSize, "multipart_v2", started, plan.part_size, plan.total_parts, plan.total_parts);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     if (msg.includes("v2 upload API not available")) {
       const plan = await writeStreamV1(client, path, data, opts);
-      return uploadSummary(path, size, "multipart_v1", started, plan.part_size, plan.parts.length, plan.parts.length);
+      return uploadSummary(path, effectiveSize, "multipart_v1", started, plan.part_size, plan.parts.length, plan.parts.length);
     } else {
       throw err;
     }

--- a/clients/drive9-js/tests/transfer.test.ts
+++ b/clients/drive9-js/tests/transfer.test.ts
@@ -46,6 +46,60 @@ describe("Transfer", () => {
     expect(initiateCalled).toBe(false);
   });
 
+  it("routes a small Uint8Array through direct PUT even when size is omitted", async () => {
+    // Regression: callers routinely omit the size argument for an in-memory
+    // buffer. An undefined size used to fail every `size < threshold` check
+    // and silently push a small file through multipart/S3 instead of inline.
+    let putCalled = false;
+    let initiateCalled = false;
+    server.use(
+      http.get("http://localhost:9009/v1/status", () => HttpResponse.json({ inline_threshold: 50000 })),
+      http.put("http://localhost:9009/v1/fs/no-size-small.bin", () => {
+        putCalled = true;
+        return HttpResponse.text("ok");
+      }),
+      http.post("http://localhost:9009/v2/uploads/initiate", () => {
+        initiateCalled = true;
+        return HttpResponse.text("unexpected multipart initiate", { status: 500 });
+      })
+    );
+    const client = new Client("http://localhost:9009", "test-key");
+    await client.warm();
+    const data = new TextEncoder().encode("x".repeat(7000));
+    // size argument intentionally omitted
+    const summary = await (client.writeStreamWithSummary as unknown as (
+      p: string,
+      s: Uint8Array
+    ) => Promise<{ mode: string; total_bytes: number }>)("/no-size-small.bin", data);
+    expect(summary.mode).toBe("direct_put");
+    expect(summary.total_bytes).toBe(7000);
+    expect(putCalled).toBe(true);
+    expect(initiateCalled).toBe(false);
+  });
+
+  it("throws for a ReadableStream with a missing or non-finite size", async () => {
+    const client = new Client("http://localhost:9009", "test-key");
+    const makeStream = () =>
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("tiny"));
+          controller.close();
+        },
+      });
+    await expect(
+      (client.writeStreamWithSummary as unknown as (p: string, s: ReadableStream<Uint8Array>) => Promise<unknown>)(
+        "/stream-no-size.bin",
+        makeStream()
+      )
+    ).rejects.toThrow(/finite non-negative size/);
+    await expect(
+      client.writeStreamWithSummary("/stream-nan-size.bin", makeStream(), Number.NaN)
+    ).rejects.toThrow(/finite non-negative size/);
+    await expect(
+      client.writeStreamWithSummary("/stream-neg-size.bin", makeStream(), -1)
+    ).rejects.toThrow(/finite non-negative size/);
+  });
+
   it("readStream handles 302 redirect", async () => {
     server.use(
       http.get("http://localhost:9009/v1/fs/large.bin", ({ request }) => {


### PR DESCRIPTION
## Problem

A user reported `writeStreamWithSummary` uploaded a **7KB file on a TiDB tenant to S3** instead of inlining it into TiDB (inline threshold default 50KB, so 7KB should inline).

## Root cause (client-side)

For an in-memory `Uint8Array`, the inline-vs-multipart decision used the caller-supplied `size` argument:

```ts
if (size === 0 || size < threshold) { /* inline direct PUT */ }
```

JS callers routinely omit `size` (`client.writeStreamWithSummary(path, bytes)`). An `undefined` size makes both checks false, so a small buffer silently fell through to the multipart (`writeStreamV2` → S3) path — even though `data.length` (the real 7000) was already in hand. Diagnosis by @adversary-1.

## Fix

- **Uint8Array**: effective size = `data.length` (authoritative); an omitted/incorrect `size` can no longer misroute a small file to S3.
- **ReadableStream**: require finite, non-negative `size`, fail fast otherwise.
- `UploadSummary.total_bytes` now always the effective size, never `undefined`.

Type signature still declares `size` (backward compatible); runtime now defends against omission.

## Regressions (per review gate)

- small Uint8Array with size omitted → `direct_put`, `total_bytes===7000`, no `/v2/uploads/initiate`.
- ReadableStream with missing/`NaN`/negative size → clear throw.

Full `npm run test` (69 passed), `npm run build`, `npm run lint` (`tsc --noEmit`) green.

## Note

Client-side cause only. A correct-explicit-size case still hitting S3 would be server-side (deployment `DRIVE9_INLINE_THRESHOLD` below file size, or tenant `provider` not `tidb_*` → `SmallInDB()=false`) — separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Uploads from in-memory data now calculate file size accurately, even when the size is omitted or incorrect.
  * Small in-memory uploads are correctly routed through direct upload.
  * Stream uploads now provide a clear validation error when the size is missing, negative, or not finite.
  * Upload metrics now report accurate byte counts.
* **Tests**
  * Added coverage to prevent regressions in direct-upload routing, size validation, and reported byte counts.
* **Chores**
  * Bumped the package version to **0.1.4**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->