### PR TITLE
fix: improve shared pool provisioning and capacity reuse

### DIFF
--- a/cmd/drive9-server/main.go
+++ b/cmd/drive9-server/main.go
@@ -699,7 +699,7 @@ environment:
   DRIVE9_TENANT_POOL_RECONCILE_INTERVAL leader logical-pool refill scan interval (default: 5s)
   DRIVE9_TENANT_POOL_RECONCILE_WORKERS concurrent queued leader logical-pool refill workers (default: 15)
   DRIVE9_TENANT_POOL_RECONCILE_WORKER_REST delay before a completed refill worker takes another task (default: 5s)
-  DRIVE9_TIDBCLOUD_NATIVE_SHARED_STUCK_TIMEOUT pending/provisioning no-progress timeout (default: 15m)
+  DRIVE9_TIDBCLOUD_NATIVE_SHARED_STUCK_TIMEOUT pending/provisioning no-progress timeout (default: 30m)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_INTERVAL failed physical-pool cleanup interval (default: 1m)
   DRIVE9_TIDBCLOUD_NATIVE_SHARED_FAILED_CLEANUP_BATCH_SIZE failed physical pools processed per cleanup pass (default: 5)
   DRIVE9_TIDBCLOUD_PRIVATE_ENDPOINT_HOST_MAP comma-separated public_host=private_host mappings (also accepts public_host:private_host);

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -295,8 +295,12 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 	if in.TiDBCloudOrganizationID == "" {
 		return fmt.Errorf("tidbcloud organization id is required")
 	}
-	if in.ClusterID == "" {
+	clusterID := strings.TrimSpace(in.ClusterID)
+	if clusterID == "" {
 		return fmt.Errorf("cluster id is required")
+	}
+	if clusterID != in.ClusterID {
+		return fmt.Errorf("cluster id must be an exact value")
 	}
 	if in.Port < 0 {
 		return fmt.Errorf("db port must not be negative")
@@ -345,7 +349,8 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 		// allocation identity cannot be reassigned underneath them. Connection
 		// metadata remains refreshable for endpoint and credential rotation.
 		if currentStatus == SharedDBStatusProvisioning &&
-			(currentOrganizationID != in.TiDBCloudOrganizationID || currentClusterID.String != in.ClusterID) {
+			((strings.TrimSpace(currentOrganizationID) != "" && currentOrganizationID != in.TiDBCloudOrganizationID) ||
+				(strings.TrimSpace(currentClusterID.String) != "" && currentClusterID.String != clusterID)) {
 			return fmt.Errorf("%w: db pool %d", ErrSharedDBPoolIdentityConflict, in.ID)
 		}
 		host := currentHost.String
@@ -369,7 +374,7 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 			name = in.Name
 		}
 		nextStatus := currentStatus
-		metadataReady := host != "" && port > 0 && user != "" && len(password) > 0 && name != ""
+		metadataReady := clusterID != "" && host != "" && port > 0 && user != "" && len(password) > 0 && name != ""
 		if currentStatus == SharedDBStatusPending && metadataReady {
 			nextStatus = SharedDBStatusProvisioning
 		}
@@ -380,7 +385,7 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 				db_name = COALESCE(?, db_name), db_tls = ?,
 				status_updated_at = CASE WHEN status <> ? THEN CURRENT_TIMESTAMP(3) ELSE status_updated_at END,
 				status = ?
-			WHERE db_id = ?`, in.TiDBCloudOrganizationID, in.ClusterID,
+			WHERE db_id = ?`, in.TiDBCloudOrganizationID, clusterID,
 			nullString(in.Host), nullInt(in.Port), nullString(in.User), nullBytes(in.PasswordCipher),
 			nullString(in.Name), in.TLSMode, nextStatus, nextStatus, in.ID); err != nil {
 			return fmt.Errorf("persist cloud result for db pool %d: %w", in.ID, err)

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -324,13 +324,14 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 	}
 	var advancedTenants []string
 	err = s.InTx(ctx, func(tx *sql.Tx) error {
-		var currentHost, currentUser, currentName sql.NullString
+		var currentOrganizationID string
+		var currentClusterID, currentHost, currentUser, currentName sql.NullString
 		var currentPort sql.NullInt64
 		var currentPassword []byte
 		var currentStatus string
-		if err := tx.QueryRowContext(ctx, `SELECT db_host, db_port, db_user, db_password, db_name, status
+		if err := tx.QueryRowContext(ctx, `SELECT org_id, cluster_id, db_host, db_port, db_user, db_password, db_name, status
 			FROM db_pool WHERE db_id = ? FOR UPDATE`, in.ID).
-			Scan(&currentHost, &currentPort, &currentUser, &currentPassword, &currentName, &currentStatus); err != nil {
+			Scan(&currentOrganizationID, &currentClusterID, &currentHost, &currentPort, &currentUser, &currentPassword, &currentName, &currentStatus); err != nil {
 			if errors.Is(err, sql.ErrNoRows) {
 				return ErrNotFound
 			}
@@ -338,6 +339,14 @@ func (s *Store) UpdateManagedSharedDBPoolCloudResult(ctx context.Context, in *Sh
 		}
 		if currentStatus != SharedDBStatusPending && currentStatus != SharedDBStatusProvisioning {
 			return ErrNotFound
+		}
+		// Once complete metadata advances the pool to provisioning, finishers may
+		// safely run without retaining this MetaDB row lock only if the Cloud
+		// allocation identity cannot be reassigned underneath them. Connection
+		// metadata remains refreshable for endpoint and credential rotation.
+		if currentStatus == SharedDBStatusProvisioning &&
+			(currentOrganizationID != in.TiDBCloudOrganizationID || currentClusterID.String != in.ClusterID) {
+			return fmt.Errorf("%w: db pool %d", ErrSharedDBPoolIdentityConflict, in.ID)
 		}
 		host := currentHost.String
 		if in.Host != "" {
@@ -521,7 +530,7 @@ func (s *Store) RefreshManagedSharedDBProvisioningProgress(ctx context.Context, 
 			return err
 		}
 		if status != SharedDBStatusProvisioning {
-			return ErrNotFound
+			return fmt.Errorf("%w: db pool %d has status %q", ErrSharedDBPoolNotProvisioning, dbID, status)
 		}
 	}
 	return nil

--- a/pkg/meta/db_pool.go
+++ b/pkg/meta/db_pool.go
@@ -494,6 +494,39 @@ func (s *Store) UpdateSharedDBSchemaVersion(ctx context.Context, dbID int64, ver
 	return nil
 }
 
+// RefreshManagedSharedDBProvisioningProgress keeps a long-running remote
+// schema operation visible to the stuck-pool watchdog without retaining a
+// MetaDB connection or advisory lock for the duration of the DDL.
+func (s *Store) RefreshManagedSharedDBProvisioningProgress(ctx context.Context, dbID int64) (err error) {
+	start := time.Now()
+	defer observeMeta(ctx, "refresh_managed_shared_db_provisioning_progress", start, &err)
+	if dbID <= 0 {
+		return fmt.Errorf("db_id must be positive")
+	}
+	res, err := s.db.ExecContext(ctx, `UPDATE db_pool SET updated_at = CURRENT_TIMESTAMP(3)
+		WHERE db_id = ? AND role = ? AND status = ?`, dbID, SharedDBRoleShared, SharedDBStatusProvisioning)
+	if err != nil {
+		return fmt.Errorf("refresh provisioning progress for db pool %d: %w", dbID, err)
+	}
+	affected, err := res.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("refresh provisioning progress rows affected for db pool %d: %w", dbID, err)
+	}
+	if affected == 0 {
+		var status string
+		if err := s.db.QueryRowContext(ctx, `SELECT status FROM db_pool WHERE db_id = ? AND role = ?`, dbID, SharedDBRoleShared).Scan(&status); err != nil {
+			if errors.Is(err, sql.ErrNoRows) {
+				return ErrNotFound
+			}
+			return err
+		}
+		if status != SharedDBStatusProvisioning {
+			return ErrNotFound
+		}
+	}
+	return nil
+}
+
 // ActivateSharedDBPool flips a managed pool to active only after the cloud
 // identity, connection fields, and shared schema version are complete.
 func (s *Store) ActivateSharedDBPool(ctx context.Context, dbID int64) (err error) {

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -731,7 +731,8 @@ func TestManagedSharedDBCloudResultRejectsIdentityChangeAfterProvisioning(t *tes
 		t.Fatalf("GetSharedDB after connection refresh: %v", err)
 	}
 	if got.TiDBCloudOrganizationID != ready.TiDBCloudOrganizationID || got.ClusterID != ready.ClusterID ||
-		got.Host != refreshed.Host || got.User != refreshed.User || !bytes.Equal(got.PasswordCipher, refreshed.PasswordCipher) {
+		got.Host != refreshed.Host || got.User != refreshed.User ||
+		!bytes.Equal(got.PasswordCipher, refreshed.PasswordCipher) || got.TLSMode != refreshed.TLSMode {
 		t.Fatalf("connection refresh = %+v, want stable identity with refreshed connection metadata", got)
 	}
 }

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -737,6 +737,68 @@ func TestManagedSharedDBCloudResultRejectsIdentityChangeAfterProvisioning(t *tes
 	}
 }
 
+func TestManagedSharedDBCloudResultRejectsBlankClusterIdentity(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-blank-cluster", ProvisioningKey: bytes.Repeat([]byte{3}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	err = s.UpdateManagedSharedDBPoolCloudResult(ctx, &SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-blank-cluster", ClusterID: "   ",
+		Host: "shared.example.com", Port: 4000, User: "root", PasswordCipher: []byte("cipher"),
+		Name: "tidbcloud_fs", TLSMode: "skip-verify",
+	})
+	if err == nil {
+		t.Fatal("blank cluster identity error = nil, want rejection")
+	}
+	got, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.Status != SharedDBStatusPending || got.ClusterID != "" {
+		t.Fatalf("pool after blank cluster identity = status %q cluster %q, want pending with no cluster", got.Status, got.ClusterID)
+	}
+}
+
+func TestManagedSharedDBCloudResultRepairsMissingProvisioningIdentity(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-repair-identity", ProvisioningKey: bytes.Repeat([]byte{4}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	ready := &SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-repair-identity", ClusterID: "cluster-repair-identity",
+		Host: "shared.example.com", Port: 4000, User: "root", PasswordCipher: []byte("cipher"),
+		Name: "tidbcloud_fs", TLSMode: "skip-verify",
+	}
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, ready); err != nil {
+		t.Fatalf("persist ready cloud result: %v", err)
+	}
+	if _, err := s.DB().ExecContext(ctx, `UPDATE db_pool SET cluster_id = NULL WHERE db_id = ?`, dbID); err != nil {
+		t.Fatalf("simulate legacy missing provisioning identity: %v", err)
+	}
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, ready); err != nil {
+		t.Fatalf("repair missing provisioning identity: %v", err)
+	}
+	got, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB: %v", err)
+	}
+	if got.Status != SharedDBStatusProvisioning || got.ClusterID != ready.ClusterID {
+		t.Fatalf("repaired pool = status %q cluster %q, want provisioning cluster %q", got.Status, got.ClusterID, ready.ClusterID)
+	}
+}
+
 func TestRefreshManagedSharedDBProvisioningProgressDistinguishesTerminalStatus(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/db_pool_test.go
+++ b/pkg/meta/db_pool_test.go
@@ -674,6 +674,102 @@ func TestManagedSharedDBUpdatedAtTracksProgressNotNoOpPolls(t *testing.T) {
 	}
 }
 
+func TestManagedSharedDBCloudResultRejectsIdentityChangeAfterProvisioning(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-identity", ProvisioningKey: bytes.Repeat([]byte{1}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	ready := &SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-identity", ClusterID: "cluster-identity",
+		Host: "shared.example.com", Port: 4000, User: "root", PasswordCipher: []byte("cipher"),
+		Name: "tidbcloud_fs", TLSMode: "skip-verify",
+	}
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, ready); err != nil {
+		t.Fatalf("persist ready cloud result: %v", err)
+	}
+
+	mutations := []struct {
+		name   string
+		mutate func(*SharedDB)
+	}{
+		{name: "organization", mutate: func(in *SharedDB) { in.TiDBCloudOrganizationID = "org-other" }},
+		{name: "cluster", mutate: func(in *SharedDB) { in.ClusterID = "cluster-other" }},
+	}
+	for _, tt := range mutations {
+		t.Run(tt.name, func(t *testing.T) {
+			changed := *ready
+			tt.mutate(&changed)
+			if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, &changed); !errors.Is(err, ErrSharedDBPoolIdentityConflict) {
+				t.Fatalf("identity mutation error = %v, want ErrSharedDBPoolIdentityConflict", err)
+			}
+			got, err := s.GetSharedDB(ctx, dbID)
+			if err != nil {
+				t.Fatalf("GetSharedDB: %v", err)
+			}
+			if got.TiDBCloudOrganizationID != ready.TiDBCloudOrganizationID || got.ClusterID != ready.ClusterID {
+				t.Fatalf("identity after rejected mutation = org %q cluster %q, want org %q cluster %q",
+					got.TiDBCloudOrganizationID, got.ClusterID, ready.TiDBCloudOrganizationID, ready.ClusterID)
+			}
+		})
+	}
+	refreshed := *ready
+	refreshed.Host = "rotated.example.com"
+	refreshed.User = "rotated.root"
+	refreshed.PasswordCipher = []byte("rotated-cipher")
+	refreshed.TLSMode = "true"
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, &refreshed); err != nil {
+		t.Fatalf("refresh connection metadata with stable identity: %v", err)
+	}
+	got, err := s.GetSharedDB(ctx, dbID)
+	if err != nil {
+		t.Fatalf("GetSharedDB after connection refresh: %v", err)
+	}
+	if got.TiDBCloudOrganizationID != ready.TiDBCloudOrganizationID || got.ClusterID != ready.ClusterID ||
+		got.Host != refreshed.Host || got.User != refreshed.User || !bytes.Equal(got.PasswordCipher, refreshed.PasswordCipher) {
+		t.Fatalf("connection refresh = %+v, want stable identity with refreshed connection metadata", got)
+	}
+}
+
+func TestRefreshManagedSharedDBProvisioningProgressDistinguishesTerminalStatus(t *testing.T) {
+	s := newControlStore(t)
+	ctx := context.Background()
+	spendingLimit := MaxTiDBCloudSpendingLimit
+	dbID, err := s.CreateManagedSharedDBPool(ctx, &SharedDB{
+		TiDBCloudOrganizationID: "org-heartbeat-status", ProvisioningKey: bytes.Repeat([]byte{2}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingLimit,
+	})
+	if err != nil {
+		t.Fatalf("CreateManagedSharedDBPool: %v", err)
+	}
+	if err := s.UpdateManagedSharedDBPoolCloudResult(ctx, &SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-heartbeat-status", ClusterID: "cluster-heartbeat-status",
+		Host: "shared.example.com", Port: 4000, User: "root", PasswordCipher: []byte("cipher"),
+		Name: "tidbcloud_fs", TLSMode: "skip-verify",
+	}); err != nil {
+		t.Fatalf("persist ready cloud result: %v", err)
+	}
+	if err := s.UpdateSharedDBSchemaVersion(ctx, dbID, 1); err != nil {
+		t.Fatalf("UpdateSharedDBSchemaVersion: %v", err)
+	}
+	if err := s.ActivateSharedDBPool(ctx, dbID); err != nil {
+		t.Fatalf("ActivateSharedDBPool: %v", err)
+	}
+
+	err = s.RefreshManagedSharedDBProvisioningProgress(ctx, dbID)
+	if !errors.Is(err, ErrSharedDBPoolNotProvisioning) || errors.Is(err, ErrNotFound) {
+		t.Fatalf("refresh active pool error = %v, want ErrSharedDBPoolNotProvisioning distinct from ErrNotFound", err)
+	}
+	if err := s.RefreshManagedSharedDBProvisioningProgress(ctx, dbID+1_000_000); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("refresh missing pool error = %v, want ErrNotFound", err)
+	}
+}
+
 func TestFinalizeFailedSharedDBPoolCleanupClearsCloudIdentityBeforeDelete(t *testing.T) {
 	s := newControlStore(t)
 	ctx := context.Background()

--- a/pkg/meta/meta.go
+++ b/pkg/meta/meta.go
@@ -21,12 +21,14 @@ import (
 )
 
 var (
-	ErrNotFound                 = errors.New("not found")
-	ErrDuplicate                = errors.New("duplicate entry")
-	ErrStorageQuotaExceeded     = errors.New("tenant storage quota exceeded")
-	ErrFileCountQuotaExceeded   = errors.New("tenant file count quota exceeded")
-	ErrReservationAlreadyExists = errors.New("upload reservation already exists")
-	ErrQuotaReservationBusy     = errors.New("quota reservation busy")
+	ErrNotFound                     = errors.New("not found")
+	ErrDuplicate                    = errors.New("duplicate entry")
+	ErrStorageQuotaExceeded         = errors.New("tenant storage quota exceeded")
+	ErrFileCountQuotaExceeded       = errors.New("tenant file count quota exceeded")
+	ErrReservationAlreadyExists     = errors.New("upload reservation already exists")
+	ErrQuotaReservationBusy         = errors.New("quota reservation busy")
+	ErrSharedDBPoolIdentityConflict = errors.New("shared db pool physical identity changed after provisioning started")
+	ErrSharedDBPoolNotProvisioning  = errors.New("shared db pool is not provisioning")
 )
 
 type TenantStatus string

--- a/pkg/meta/shared_pool_wave.go
+++ b/pkg/meta/shared_pool_wave.go
@@ -234,7 +234,9 @@ func lockManagedSharedDBPoolWaveCandidates(ctx context.Context, tx *sql.Tx, orga
 	// Acquire every reusable row for the organization in immutable primary-key
 	// order. Status can advance concurrently, so using it in the locking order
 	// can invert acquisition between overlapping refill waves. The result is
-	// sorted by readiness only after the complete stable lock set is held.
+	// sorted by readiness only after the complete stable lock set is held. This
+	// deliberately serializes same-organization refill waves for the duration
+	// of this short transaction; no Cloud or schema work runs while it is held.
 	rows, err := tx.QueryContext(ctx, lockManagedSharedDBPoolWaveCandidatesSQL, organizationID, SharedDBRoleShared,
 		SharedDBStatusActive, SharedDBStatusProvisioning, SharedDBStatusPending)
 	if err != nil {
@@ -500,6 +502,8 @@ func finalizeManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, sta
 		multiRowPlaceholders(len(staged.tenantIDs), 6), staged.membershipArgs...); err != nil {
 		return fmt.Errorf("insert wave memberships: %w", err)
 	}
+	// MySQL evaluates single-table SET assignments from left to right. Keep
+	// soft_cap_reached first so both calculations use the pre-increment count.
 	res, err := tx.ExecContext(ctx, `UPDATE db_pool
 		SET soft_cap_reached = CASE WHEN tenant_count + ? >= max_tenants THEN 1 ELSE 0 END,
 			tenant_count = tenant_count + ?

--- a/pkg/meta/shared_pool_wave.go
+++ b/pkg/meta/shared_pool_wave.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -144,7 +145,7 @@ func (s *Store) CreateManagedSharedDBPoolTenantWaveWithResize(ctx context.Contex
 		staged := make([]stagedManagedSharedDBPoolWavePlan, 0, len(prepared))
 		txErr := s.InTx(ctx, func(tx *sql.Tx) error {
 			memberOffset := 0
-			candidates, candidateErr := lockManagedSharedDBPoolWaveCandidates(ctx, tx, waveOrganizationID, len(waveMembers))
+			candidates, candidateErr := lockManagedSharedDBPoolWaveCandidates(ctx, tx, waveOrganizationID)
 			if candidateErr != nil {
 				return candidateErr
 			}
@@ -222,13 +223,20 @@ func (s *Store) CreateManagedSharedDBPoolTenantWaveWithResize(ctx context.Contex
 	return out, nil
 }
 
-func lockManagedSharedDBPoolWaveCandidates(ctx context.Context, tx *sql.Tx, organizationID string, limit int) ([]managedSharedDBPoolWaveCandidate, error) {
-	rows, err := tx.QueryContext(ctx, `SELECT db_id, status, max_tenants, tenant_count
+const lockManagedSharedDBPoolWaveCandidatesSQL = `SELECT db_id, status, max_tenants, tenant_count
 		FROM db_pool
 		WHERE org_id = ? AND role = ? AND status IN (?, ?, ?)
 			AND max_tenants > 0 AND soft_cap_reached = 0 AND tenant_count < max_tenants
-		ORDER BY CASE status WHEN 'active' THEN 0 WHEN 'provisioning' THEN 1 ELSE 2 END, db_id
-		LIMIT ? FOR UPDATE`, organizationID, SharedDBRoleShared, SharedDBStatusActive, SharedDBStatusProvisioning, SharedDBStatusPending, limit)
+		ORDER BY db_id
+		FOR UPDATE`
+
+func lockManagedSharedDBPoolWaveCandidates(ctx context.Context, tx *sql.Tx, organizationID string) ([]managedSharedDBPoolWaveCandidate, error) {
+	// Acquire every reusable row for the organization in immutable primary-key
+	// order. Status can advance concurrently, so using it in the locking order
+	// can invert acquisition between overlapping refill waves. The result is
+	// sorted by readiness only after the complete stable lock set is held.
+	rows, err := tx.QueryContext(ctx, lockManagedSharedDBPoolWaveCandidatesSQL, organizationID, SharedDBRoleShared,
+		SharedDBStatusActive, SharedDBStatusProvisioning, SharedDBStatusPending)
 	if err != nil {
 		return nil, fmt.Errorf("lock reusable managed shared DB pools: %w", err)
 	}
@@ -244,7 +252,30 @@ func lockManagedSharedDBPoolWaveCandidates(ctx context.Context, tx *sql.Tx, orga
 	if err := rows.Err(); err != nil {
 		return nil, err
 	}
+	sortManagedSharedDBPoolWaveCandidates(out)
 	return out, nil
+}
+
+func sortManagedSharedDBPoolWaveCandidates(candidates []managedSharedDBPoolWaveCandidate) {
+	statusRank := func(status string) int {
+		switch status {
+		case SharedDBStatusActive:
+			return 0
+		case SharedDBStatusProvisioning:
+			return 1
+		case SharedDBStatusPending:
+			return 2
+		default:
+			return 3
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		left, right := statusRank(candidates[i].status), statusRank(candidates[j].status)
+		if left != right {
+			return left < right
+		}
+		return candidates[i].dbID < candidates[j].dbID
+	})
 }
 
 func tenantStatusForSharedDBPoolWave(status string) (TenantStatus, error) {
@@ -470,8 +501,8 @@ func finalizeManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, sta
 		return fmt.Errorf("insert wave memberships: %w", err)
 	}
 	res, err := tx.ExecContext(ctx, `UPDATE db_pool
-		SET tenant_count = tenant_count + ?,
-			soft_cap_reached = CASE WHEN tenant_count + ? >= max_tenants THEN 1 ELSE 0 END
+		SET soft_cap_reached = CASE WHEN tenant_count + ? >= max_tenants THEN 1 ELSE 0 END,
+			tenant_count = tenant_count + ?
 		WHERE db_id = ? AND status = ? AND max_tenants > 0 AND soft_cap_reached = 0
 			AND tenant_count + ? <= max_tenants`,
 		len(staged.tenantIDs), len(staged.tenantIDs), staged.dbID, staged.dbStatus, len(staged.tenantIDs))

--- a/pkg/meta/shared_pool_wave.go
+++ b/pkg/meta/shared_pool_wave.go
@@ -25,11 +25,13 @@ type ManagedSharedDBPoolWavePlan struct {
 	Members []ManagedSharedDBPoolWaveMember
 }
 
-// ManagedSharedDBPoolWaveResult contains durable identifiers created for one
-// physical partition of a refill wave.
+// ManagedSharedDBPoolWaveResult contains one durable physical assignment for a
+// refill wave. Created reports whether the wave inserted the physical pool or
+// reused capacity from an existing row.
 type ManagedSharedDBPoolWaveResult struct {
 	DBID      int64
 	TenantIDs []string
+	Created   bool
 }
 
 // ManagedSharedDBPoolWaveResize atomically grows the logical tenant pool with
@@ -41,15 +43,24 @@ type ManagedSharedDBPoolWaveResize struct {
 }
 
 type preparedManagedSharedDBPoolWavePlan struct {
-	values  managedSharedDBInsertValues
-	members []ManagedSharedDBPoolWaveMember
+	values       managedSharedDBInsertValues
+	members      []ManagedSharedDBPoolWaveMember
+	tenantStatus TenantStatus
 }
 
 type stagedManagedSharedDBPoolWavePlan struct {
 	dbID           int64
+	dbStatus       string
 	tenantIDs      []string
 	placementArgs  []any
 	membershipArgs []any
+}
+
+type managedSharedDBPoolWaveCandidate struct {
+	dbID        int64
+	status      string
+	maxTenants  int
+	tenantCount int
 }
 
 func multiRowPlaceholders(rows, columns int) string {
@@ -57,10 +68,10 @@ func multiRowPlaceholders(rows, columns int) string {
 	return strings.TrimRight(strings.Repeat(row+",", rows), ",")
 }
 
-// CreateManagedSharedDBPoolTenantWave atomically creates each physical pool
-// together with all logical tenant reservations assigned to it. A direct
-// allocator therefore cannot observe refill-staged physical capacity before
-// tenant_count, placements, and pool memberships account for the wave.
+// CreateManagedSharedDBPoolTenantWave atomically fills existing physical pool
+// capacity before creating physical pools for any remaining logical tenant
+// reservations. A direct allocator therefore cannot observe refill-staged
+// capacity before tenant_count, placements, and memberships account for it.
 func (s *Store) CreateManagedSharedDBPoolTenantWave(ctx context.Context, plans []ManagedSharedDBPoolWavePlan) ([]ManagedSharedDBPoolWaveResult, error) {
 	return s.CreateManagedSharedDBPoolTenantWaveWithResize(ctx, plans, nil)
 }
@@ -74,6 +85,7 @@ func (s *Store) CreateManagedSharedDBPoolTenantWaveWithResize(ctx context.Contex
 		return nil, nil
 	}
 	prepared := make([]preparedManagedSharedDBPoolWavePlan, len(plans))
+	waveMembers := make([]ManagedSharedDBPoolWaveMember, 0)
 	seenTenants := make(map[string]struct{})
 	wavePoolID := ""
 	waveOrganizationID := ""
@@ -122,24 +134,68 @@ func (s *Store) CreateManagedSharedDBPoolTenantWaveWithResize(ctx context.Contex
 				return nil, fmt.Errorf("managed shared DB wave tenant %q has invalid auto-embedding profile", tenantID)
 			}
 		}
-		prepared[i] = preparedManagedSharedDBPoolWavePlan{values: values, members: plans[i].Members}
+		prepared[i] = preparedManagedSharedDBPoolWavePlan{values: values}
+		waveMembers = append(waveMembers, plans[i].Members...)
 		waveMemberCount += len(plans[i].Members)
 	}
 
 	err = withMetaLockConflictRetry(ctx, "create_managed_shared_db_pool_tenant_wave", func() error {
-		attemptOut := make([]ManagedSharedDBPoolWaveResult, len(prepared))
-		staged := make([]stagedManagedSharedDBPoolWavePlan, len(prepared))
+		attemptOut := make([]ManagedSharedDBPoolWaveResult, 0, len(prepared))
+		staged := make([]stagedManagedSharedDBPoolWavePlan, 0, len(prepared))
 		txErr := s.InTx(ctx, func(tx *sql.Tx) error {
+			memberOffset := 0
+			candidates, candidateErr := lockManagedSharedDBPoolWaveCandidates(ctx, tx, waveOrganizationID, len(waveMembers))
+			if candidateErr != nil {
+				return candidateErr
+			}
+			for _, candidate := range candidates {
+				if memberOffset >= len(waveMembers) {
+					break
+				}
+				assigned := min(candidate.maxTenants-candidate.tenantCount, len(waveMembers)-memberOffset)
+				if assigned <= 0 {
+					continue
+				}
+				tenantStatus, statusErr := tenantStatusForSharedDBPoolWave(candidate.status)
+				if statusErr != nil {
+					return statusErr
+				}
+				partition := preparedManagedSharedDBPoolWavePlan{
+					members:      waveMembers[memberOffset : memberOffset+assigned],
+					tenantStatus: tenantStatus,
+				}
+				stagedPartition, stageErr := stageManagedSharedDBPoolWaveMembers(ctx, tx, candidate.dbID, candidate.status, partition)
+				if stageErr != nil {
+					return fmt.Errorf("stage existing managed shared DB pool %d: %w", candidate.dbID, stageErr)
+				}
+				staged = append(staged, stagedPartition)
+				attemptOut = append(attemptOut, ManagedSharedDBPoolWaveResult{DBID: candidate.dbID, TenantIDs: stagedPartition.tenantIDs})
+				memberOffset += assigned
+			}
 			for i := range prepared {
-				dbID, insertErr := insertManagedSharedDBPool(ctx, tx, prepared[i].values)
+				if memberOffset >= len(waveMembers) {
+					break
+				}
+				assigned := min(prepared[i].values.maxTenants, len(waveMembers)-memberOffset)
+				partition := preparedManagedSharedDBPoolWavePlan{
+					values:       prepared[i].values,
+					members:      waveMembers[memberOffset : memberOffset+assigned],
+					tenantStatus: TenantPending,
+				}
+				dbID, insertErr := insertManagedSharedDBPool(ctx, tx, partition.values)
 				if insertErr != nil {
 					return insertErr
 				}
-				staged[i], insertErr = stageManagedSharedDBPoolWaveMembers(ctx, tx, dbID, prepared[i])
+				stagedPartition, insertErr := stageManagedSharedDBPoolWaveMembers(ctx, tx, dbID, SharedDBStatusPending, partition)
 				if insertErr != nil {
 					return fmt.Errorf("stage managed shared DB pool %d: %w", dbID, insertErr)
 				}
-				attemptOut[i] = ManagedSharedDBPoolWaveResult{DBID: dbID, TenantIDs: staged[i].tenantIDs}
+				staged = append(staged, stagedPartition)
+				attemptOut = append(attemptOut, ManagedSharedDBPoolWaveResult{DBID: dbID, TenantIDs: stagedPartition.tenantIDs, Created: true})
+				memberOffset += assigned
+			}
+			if memberOffset != len(waveMembers) {
+				return fmt.Errorf("managed shared DB wave assigned %d of %d members", memberOffset, len(waveMembers))
 			}
 			// Take logical-pool ownership only after the expensive independent
 			// tenant/quota/profile staging. If delete or shrink committed first,
@@ -166,7 +222,45 @@ func (s *Store) CreateManagedSharedDBPoolTenantWaveWithResize(ctx context.Contex
 	return out, nil
 }
 
-func stageManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID int64, plan preparedManagedSharedDBPoolWavePlan) (stagedManagedSharedDBPoolWavePlan, error) {
+func lockManagedSharedDBPoolWaveCandidates(ctx context.Context, tx *sql.Tx, organizationID string, limit int) ([]managedSharedDBPoolWaveCandidate, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT db_id, status, max_tenants, tenant_count
+		FROM db_pool
+		WHERE org_id = ? AND role = ? AND status IN (?, ?, ?)
+			AND max_tenants > 0 AND soft_cap_reached = 0 AND tenant_count < max_tenants
+		ORDER BY CASE status WHEN 'active' THEN 0 WHEN 'provisioning' THEN 1 ELSE 2 END, db_id
+		LIMIT ? FOR UPDATE`, organizationID, SharedDBRoleShared, SharedDBStatusActive, SharedDBStatusProvisioning, SharedDBStatusPending, limit)
+	if err != nil {
+		return nil, fmt.Errorf("lock reusable managed shared DB pools: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []managedSharedDBPoolWaveCandidate
+	for rows.Next() {
+		var candidate managedSharedDBPoolWaveCandidate
+		if err := rows.Scan(&candidate.dbID, &candidate.status, &candidate.maxTenants, &candidate.tenantCount); err != nil {
+			return nil, err
+		}
+		out = append(out, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func tenantStatusForSharedDBPoolWave(status string) (TenantStatus, error) {
+	switch status {
+	case SharedDBStatusActive:
+		return TenantActive, nil
+	case SharedDBStatusProvisioning:
+		return TenantProvisioning, nil
+	case SharedDBStatusPending:
+		return TenantPending, nil
+	default:
+		return "", fmt.Errorf("shared DB pool status %q is not reusable", status)
+	}
+}
+
+func stageManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID int64, dbStatus string, plan preparedManagedSharedDBPoolWavePlan) (stagedManagedSharedDBPoolWavePlan, error) {
 	now := time.Now().UTC()
 	tenantArgs := make([]any, 0, len(plan.members)*22)
 	tenantIDs := make([]string, 0, len(plan.members))
@@ -174,7 +268,7 @@ func stageManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID i
 		t := member.Tenant
 		tenantIDs = append(tenantIDs, t.ID)
 		tenantArgs = append(tenantArgs,
-			t.ID, t.Status, tenantKindForInsert(t), t.ParentTenantID, t.StorageNamespaceID,
+			t.ID, plan.tenantStatus, tenantKindForInsert(t), t.ParentTenantID, t.StorageNamespaceID,
 			t.DBHost, t.DBPort, t.DBUser, t.DBPasswordCipher, t.DBName, boolToInt(t.DBTLS),
 			t.Provider, nullStr(t.ClusterID), t.BranchID, nullStr(t.ClaimURL), t.ClaimExpiresAt, t.SchemaVersion,
 			tenantS3EncryptionModeForInsert(t), t.S3KMSKeyID, boolToInt(tenantS3BucketKeyEnabledForInsert(t)),
@@ -268,7 +362,7 @@ func stageManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, dbID i
 			return stagedManagedSharedDBPoolWavePlan{}, fmt.Errorf("insert wave auto-embedding profiles: %w", err)
 		}
 	}
-	return stagedManagedSharedDBPoolWavePlan{dbID: dbID, tenantIDs: tenantIDs,
+	return stagedManagedSharedDBPoolWavePlan{dbID: dbID, dbStatus: dbStatus, tenantIDs: tenantIDs,
 		placementArgs: placementArgs, membershipArgs: membershipArgs}, nil
 }
 
@@ -375,8 +469,12 @@ func finalizeManagedSharedDBPoolWaveMembers(ctx context.Context, tx *sql.Tx, sta
 		multiRowPlaceholders(len(staged.tenantIDs), 6), staged.membershipArgs...); err != nil {
 		return fmt.Errorf("insert wave memberships: %w", err)
 	}
-	res, err := tx.ExecContext(ctx, `UPDATE db_pool SET tenant_count = ?, soft_cap_reached = CASE WHEN ? >= max_tenants THEN 1 ELSE 0 END
-		WHERE db_id = ? AND status = ?`, len(staged.tenantIDs), len(staged.tenantIDs), staged.dbID, SharedDBStatusPending)
+	res, err := tx.ExecContext(ctx, `UPDATE db_pool
+		SET tenant_count = tenant_count + ?,
+			soft_cap_reached = CASE WHEN tenant_count + ? >= max_tenants THEN 1 ELSE 0 END
+		WHERE db_id = ? AND status = ? AND max_tenants > 0 AND soft_cap_reached = 0
+			AND tenant_count + ? <= max_tenants`,
+		len(staged.tenantIDs), len(staged.tenantIDs), staged.dbID, staged.dbStatus, len(staged.tenantIDs))
 	if err != nil {
 		return fmt.Errorf("reserve wave physical capacity: %w", err)
 	}

--- a/pkg/meta/shared_pool_wave_test.go
+++ b/pkg/meta/shared_pool_wave_test.go
@@ -1,0 +1,25 @@
+package meta
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestManagedSharedDBPoolWaveCandidateLockOrderIsStable(t *testing.T) {
+	if !strings.Contains(lockManagedSharedDBPoolWaveCandidatesSQL, "ORDER BY db_id\n\t\tFOR UPDATE") {
+		t.Fatalf("candidate lock query must acquire rows in stable db_id order: %s", lockManagedSharedDBPoolWaveCandidatesSQL)
+	}
+	if strings.Contains(lockManagedSharedDBPoolWaveCandidatesSQL, "ORDER BY CASE status") {
+		t.Fatalf("candidate lock query orders by mutable status: %s", lockManagedSharedDBPoolWaveCandidatesSQL)
+	}
+
+	candidates := []managedSharedDBPoolWaveCandidate{
+		{dbID: 1, status: SharedDBStatusPending},
+		{dbID: 2, status: SharedDBStatusActive},
+		{dbID: 3, status: SharedDBStatusProvisioning},
+	}
+	sortManagedSharedDBPoolWaveCandidates(candidates)
+	if candidates[0].dbID != 2 || candidates[1].dbID != 3 || candidates[2].dbID != 1 {
+		t.Fatalf("candidate preference order = %v, want active, provisioning, pending", candidates)
+	}
+}

--- a/pkg/server/admin_tenant_pool.go
+++ b/pkg/server/admin_tenant_pool.go
@@ -990,11 +990,16 @@ func (s *Server) createFreeSharedPoolTenantsWithResize(ctx context.Context, pool
 		return nil, err
 	}
 	continuationIDs := make([]int64, 0, len(partitions))
+	createIDs := make([]int64, 0, len(partitions))
 	for _, partition := range partitions {
 		continuationIDs = append(continuationIDs, partition.db.ID)
+		if partition.created {
+			createIDs = append(createIDs, partition.db.ID)
+		}
 	}
 	sort.Slice(continuationIDs, func(i, j int) bool { return continuationIDs[i] < continuationIDs[j] })
-	_, provisionErr := s.provisionManagedSharedDBPoolsBatchWithCredentials(ctx, continuationIDs, sharedCred)
+	sort.Slice(createIDs, func(i, j int) bool { return createIDs[i] < createIDs[j] })
+	_, provisionErr := s.provisionManagedSharedDBPoolsBatchWithCredentials(ctx, createIDs, sharedCred)
 	// The whole logical reservation wave is durable before Cloud creation
 	// starts, so allocators can only consume genuinely unreserved tail capacity.
 	s.scheduleManagedSharedDBContinuations(ctx, continuationIDs)
@@ -1035,17 +1040,17 @@ func (s *Server) createFreeSharedPoolTenantsWithResize(ctx context.Context, pool
 type sharedPoolTenantPartition struct {
 	db        *meta.SharedDB
 	tenantIDs []string
+	created   bool
 }
 
 func (s *Server) stageSharedPoolTenantWave(ctx context.Context, poolID, organizationID string, cred tenant.CredentialProvisionRequest, count int, quotaOpt *quotaRequest, resize *meta.ManagedSharedDBPoolWaveResize) ([]sharedPoolTenantPartition, error) {
 	if count <= 0 {
 		return nil, nil
 	}
-	// Refill deliberately stages dedicated physical capacity instead of
-	// reusing a globally visible oldest candidate. Otherwise multiple Pods can
-	// plan against the same capacity snapshot and recreate the hot-row storm
-	// this partitioned wave is meant to avoid. The caller already caps count by
-	// managedSharedDBCloudBatchSize, so lock-free over-creation stays bounded.
+	// The durable wave fills existing physical capacity before inserting a new
+	// db_pool row. Capacity selection and each per-DB tenant_count increment are
+	// batched under the same transaction as placements and memberships, avoiding
+	// both one-physical-DB-per-refill fragmentation and per-tenant hot-row writes.
 	remaining := count
 	provisioningKey := sharedDBProvisioningKey(cred)
 	maxTenants, _ := s.managedSharedDBPolicy()
@@ -1085,14 +1090,20 @@ func (s *Server) stageSharedPoolTenantWave(ctx context.Context, poolID, organiza
 		metrics.RecordSharedDBPoolWave(metrics.ResultForError(err), len(plans), count)
 		return nil, err
 	}
-	metrics.RecordSharedDBPoolWave("ok", len(created), count)
+	createdPhysical := 0
+	for _, result := range created {
+		if result.Created {
+			createdPhysical++
+		}
+	}
+	metrics.RecordSharedDBPoolWave("ok", createdPhysical, count)
 	partitions := make([]sharedPoolTenantPartition, 0, len(created))
 	for _, result := range created {
 		row, loadErr := s.meta.GetSharedDB(ctx, result.DBID)
 		if loadErr != nil {
 			return nil, loadErr
 		}
-		partitions = append(partitions, sharedPoolTenantPartition{db: row, tenantIDs: result.TenantIDs})
+		partitions = append(partitions, sharedPoolTenantPartition{db: row, tenantIDs: result.TenantIDs, created: result.Created})
 	}
 	return partitions, nil
 }

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -357,6 +357,25 @@ func TestSharedTenantPoolRefillReusesExistingPhysicalCapacity(t *testing.T) {
 		t.Fatalf("shared Cloud batch calls = %d, want 0 while existing capacity remains", got)
 	}
 
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET tenant_count = 93 WHERE db_id = ?`, dbID); err != nil {
+		t.Fatalf("move existing pool below capacity: %v", err)
+	}
+	results, err = srv.createFreeSharedPoolTenants(ctx, logicalPool.PoolID, 5, tenant.CredentialProvisionRequest{}, nil)
+	if err != nil {
+		t.Fatalf("createFreeSharedPoolTenants below capacity: %v", err)
+	}
+	var softCapReached bool
+	if err := metaStore.DB().QueryRowContext(ctx, `SELECT tenant_count, soft_cap_reached FROM db_pool WHERE db_id = ?`, dbID).
+		Scan(&tenantCount, &softCapReached); err != nil {
+		t.Fatalf("load remaining physical capacity: %v", err)
+	}
+	if tenantCount != 98 || softCapReached {
+		t.Fatalf("tenant count = %d, soft cap reached = %t, want 98 and false", tenantCount, softCapReached)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 0 {
+		t.Fatalf("shared Cloud batch calls = %d, want 0 before physical capacity is full", got)
+	}
+
 	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET tenant_count = 99 WHERE db_id = ?`, dbID); err != nil {
 		t.Fatalf("move existing pool near capacity: %v", err)
 	}
@@ -388,6 +407,45 @@ func TestSharedTenantPoolRefillReusesExistingPhysicalCapacity(t *testing.T) {
 	}
 	if got := prov.sharedPoolBatchMembers.Load(); got != 1 {
 		t.Fatalf("shared Cloud batch physical pools = %d, want 1 for the capacity remainder", got)
+	}
+
+	start := make(chan struct{})
+	errCh := make(chan error, 2)
+	var waveWG sync.WaitGroup
+	for i := 0; i < 2; i++ {
+		waveWG.Add(1)
+		go func() {
+			defer waveWG.Done()
+			<-start
+			waveResults, waveErr := srv.createFreeSharedPoolTenants(ctx, logicalPool.PoolID, 3, tenant.CredentialProvisionRequest{}, nil)
+			if waveErr == nil {
+				for _, result := range waveResults {
+					if result.Status != meta.TenantPending {
+						waveErr = fmt.Errorf("concurrent wave tenant %s status = %q, want pending", result.TenantID, result.Status)
+						break
+					}
+				}
+			}
+			errCh <- waveErr
+		}()
+	}
+	close(start)
+	waveWG.Wait()
+	close(errCh)
+	for waveErr := range errCh {
+		if waveErr != nil {
+			t.Fatalf("concurrent refill wave: %v", waveErr)
+		}
+	}
+	if err := metaStore.DB().QueryRowContext(ctx, `SELECT COUNT(*), COALESCE(SUM(tenant_count), 0)
+		FROM db_pool WHERE org_id = ?`, logicalPool.OrganizationID).Scan(&physicalPools, &tenantCount); err != nil {
+		t.Fatalf("load physical pool inventory after concurrent waves: %v", err)
+	}
+	if physicalPools != 2 || tenantCount != 108 {
+		t.Fatalf("physical pools = %d, tenant count = %d, want 2 and 108 after concurrent waves", physicalPools, tenantCount)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
+		t.Fatalf("shared Cloud batch calls = %d, want no extra create from concurrent reuse", got)
 	}
 }
 

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -360,7 +360,7 @@ func TestSharedTenantPoolRefillReusesExistingPhysicalCapacity(t *testing.T) {
 	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET tenant_count = 93 WHERE db_id = ?`, dbID); err != nil {
 		t.Fatalf("move existing pool below capacity: %v", err)
 	}
-	results, err = srv.createFreeSharedPoolTenants(ctx, logicalPool.PoolID, 5, tenant.CredentialProvisionRequest{}, nil)
+	_, err = srv.createFreeSharedPoolTenants(ctx, logicalPool.PoolID, 5, tenant.CredentialProvisionRequest{}, nil)
 	if err != nil {
 		t.Fatalf("createFreeSharedPoolTenants below capacity: %v", err)
 	}

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -288,6 +288,109 @@ func TestSharedTenantPoolRefillPlansTenPoolsInOneBatch(t *testing.T) {
 	}
 }
 
+func TestSharedTenantPoolRefillReusesExistingPhysicalCapacity(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	poolManager := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(poolManager.Close)
+	poolManager.SetMetaStore(metaStore)
+	prov := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative, cloudProvider: "aws", region: "us-east-1"}
+	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, SharedDBMaxTenants: 100,
+		TokenSecret: make([]byte, 32), Leader: newFollowerLeaderManager(t, metaStore)})
+	t.Cleanup(srv.Close)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	logicalPool := &meta.TenantPool{PoolID: "pool-reuse-existing", OrganizationID: "org-reuse-existing",
+		Size: 15, Status: meta.TenantPoolActive, CreatedAt: now, UpdatedAt: now}
+	if err := metaStore.CreateTenantPool(ctx, logicalPool); err != nil {
+		t.Fatalf("CreateTenantPool: %v", err)
+	}
+	passwordCipher, err := poolManager.Encrypt(ctx, []byte("shared-pass"))
+	if err != nil {
+		t.Fatalf("encrypt shared password: %v", err)
+	}
+	dbID, err := metaStore.RegisterSharedDB(ctx, &meta.SharedDB{
+		TiDBCloudOrganizationID: logicalPool.OrganizationID,
+		Host:                    "shared.example.com",
+		Port:                    4000,
+		User:                    "root",
+		PasswordCipher:          passwordCipher,
+		Name:                    "tidbcloud_fs",
+		MaxTenants:              100,
+	})
+	if err != nil {
+		t.Fatalf("RegisterSharedDB: %v", err)
+	}
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET tenant_count = 9 WHERE db_id = ?`, dbID); err != nil {
+		t.Fatalf("seed tenant_count: %v", err)
+	}
+
+	results, err := srv.createFreeSharedPoolTenants(ctx, logicalPool.PoolID, 1, tenant.CredentialProvisionRequest{}, nil)
+	if err != nil {
+		t.Fatalf("createFreeSharedPoolTenants: %v", err)
+	}
+	if len(results) != 1 || results[0].Status != meta.TenantActive {
+		t.Fatalf("results = %+v, want one active tenant", results)
+	}
+	var physicalPools, tenantCount int
+	if err := metaStore.DB().QueryRowContext(ctx, `SELECT COUNT(*), COALESCE(SUM(tenant_count), 0)
+		FROM db_pool WHERE org_id = ?`, logicalPool.OrganizationID).Scan(&physicalPools, &tenantCount); err != nil {
+		t.Fatalf("load physical pool inventory: %v", err)
+	}
+	if physicalPools != 1 || tenantCount != 10 {
+		t.Fatalf("physical pools = %d, tenant count = %d, want 1 and 10", physicalPools, tenantCount)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 0 {
+		t.Fatalf("shared Cloud batch calls = %d, want 0 while existing capacity remains", got)
+	}
+
+	if _, err := metaStore.DB().ExecContext(ctx, `UPDATE db_pool SET tenant_count = 99 WHERE db_id = ?`, dbID); err != nil {
+		t.Fatalf("move existing pool near capacity: %v", err)
+	}
+	results, err = srv.createFreeSharedPoolTenants(ctx, logicalPool.PoolID, 3, tenant.CredentialProvisionRequest{}, nil)
+	if err != nil {
+		t.Fatalf("createFreeSharedPoolTenants across capacity boundary: %v", err)
+	}
+	active, pending := 0, 0
+	for _, result := range results {
+		switch result.Status {
+		case meta.TenantActive:
+			active++
+		case meta.TenantPending:
+			pending++
+		}
+	}
+	if active != 1 || pending != 2 {
+		t.Fatalf("result statuses: active=%d pending=%d, want 1 and 2", active, pending)
+	}
+	if err := metaStore.DB().QueryRowContext(ctx, `SELECT COUNT(*), COALESCE(SUM(tenant_count), 0)
+		FROM db_pool WHERE org_id = ?`, logicalPool.OrganizationID).Scan(&physicalPools, &tenantCount); err != nil {
+		t.Fatalf("load physical pool inventory after spill: %v", err)
+	}
+	if physicalPools != 2 || tenantCount != 102 {
+		t.Fatalf("physical pools = %d, tenant count = %d, want 2 and 102", physicalPools, tenantCount)
+	}
+	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
+		t.Fatalf("shared Cloud batch calls = %d, want 1 for the capacity remainder", got)
+	}
+	if got := prov.sharedPoolBatchMembers.Load(); got != 1 {
+		t.Fatalf("shared Cloud batch physical pools = %d, want 1 for the capacity remainder", got)
+	}
+}
+
 func TestSharedTenantPoolRefillMakesWaveVisibleOnlyAfterMembershipReservation(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
@@ -721,7 +824,7 @@ func TestSharedTenantPoolRefillPlansWithServerOwnedSharedCredential(t *testing.T
 	}
 }
 
-func TestSharedTenantPoolRefillStagesDedicatedCapacityWithoutIdentityLookup(t *testing.T) {
+func TestSharedTenantPoolRefillReusesCapacityWithoutIdentityLookup(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -769,8 +872,8 @@ func TestSharedTenantPoolRefillStagesDedicatedCapacityWithoutIdentityLookup(t *t
 	if len(results) != 50 {
 		t.Fatalf("results = %d, want 50", len(results))
 	}
-	if got := prov.sharedPoolBatchCalls.Load(); got != 1 {
-		t.Fatalf("physical batch calls = %d, want one dedicated refill wave", got)
+	if got := prov.sharedPoolBatchCalls.Load(); got != 0 {
+		t.Fatalf("physical batch calls = %d, want no Cloud create while existing capacity remains", got)
 	}
 	if got := prov.iamCalls.Load(); got != 0 {
 		t.Fatalf("identity lookups = %d, want 0 when tenant pool organization is known", got)
@@ -784,8 +887,8 @@ func TestSharedTenantPoolRefillStagesDedicatedCapacityWithoutIdentityLookup(t *t
 		`SELECT COUNT(*) FROM db_pool WHERE org_id = ?`, "org-shared-existing").Scan(&physicalPoolCount); err != nil {
 		t.Fatal(err)
 	}
-	if existingTenantCount != 0 || physicalPoolCount != 2 {
-		t.Fatalf("existing tenant_count=%d physical pools=%d, want dedicated staged pool and untouched existing capacity",
+	if existingTenantCount != 50 || physicalPoolCount != 1 {
+		t.Fatalf("existing tenant_count=%d physical pools=%d, want reused existing capacity without a new pool",
 			existingTenantCount, physicalPoolCount)
 	}
 }

--- a/pkg/server/admin_tenant_pool_test.go
+++ b/pkg/server/admin_tenant_pool_test.go
@@ -825,7 +825,8 @@ func TestSharedTenantPoolDefensivelyReportsProvisioningWhenBatchMetadataComplete
 		t.Fatal(err)
 	}
 	srv := NewWithConfig(Config{Meta: metaStore, Pool: poolManager, Provisioner: prov,
-		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: secret})
+		DefaultTenantProvider: tenant.ProviderTiDBCloudNativeShared, TokenSecret: secret,
+		Leader: newFollowerLeaderManager(t, metaStore)})
 	defer srv.Close()
 	now := time.Now().UTC()
 	if err := metaStore.CreateTenantPool(context.Background(), &meta.TenantPool{

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -87,18 +87,46 @@ type fakeProvisioner struct {
 
 type blockingDatabaseEnsurer struct {
 	fakeProvisioner
-	started chan struct{}
-	release <-chan struct{}
+	started     chan struct{}
+	startedOnce sync.Once
+	release     <-chan struct{}
 }
 
 func (f *blockingDatabaseEnsurer) EnsureDatabase(ctx context.Context, _ string) error {
-	close(f.started)
+	f.startedOnce.Do(func() { close(f.started) })
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-f.release:
 		return errors.New("stop after provisioning heartbeat test")
 	}
+}
+
+func TestBlockingDatabaseEnsurerSignalsStartedOnceAcrossRetries(t *testing.T) {
+	started := make(chan struct{})
+	release := make(chan struct{})
+	close(release)
+	ensurer := &blockingDatabaseEnsurer{started: started, release: release}
+	for attempt := 0; attempt < 2; attempt++ {
+		if err := ensurer.EnsureDatabase(context.Background(), ""); err == nil {
+			t.Fatalf("EnsureDatabase attempt %d unexpectedly succeeded", attempt+1)
+		}
+	}
+	select {
+	case <-started:
+	default:
+		t.Fatal("EnsureDatabase did not signal started")
+	}
+}
+
+type countingEncryptor struct {
+	encrypt.Encryptor
+	decryptCalls atomic.Int32
+}
+
+func (e *countingEncryptor) Decrypt(ctx context.Context, ciphertext []byte) ([]byte, error) {
+	e.decryptCalls.Add(1)
+	return e.Encryptor.Decrypt(ctx, ciphertext)
 }
 
 type failingEncryptor struct {
@@ -241,6 +269,21 @@ func TestManagedSharedDBProvisioningSlotsIgnoreMetaConnectionBudget(t *testing.T
 	}
 	if got := cap(srv.managedSharedDBProvisioningSlots); got != 100 {
 		t.Fatalf("provisioning slot capacity = %d, want 100", got)
+	}
+}
+
+func TestManagedSharedDBProvisioningQueueErrorSkipsExpectedContention(t *testing.T) {
+	for _, err := range []error{
+		meta.ErrNotFound,
+		fmt.Errorf("target lock: %w", tenant.ErrSharedDBSchemaEnsureBusy),
+	} {
+		if got := managedSharedDBProvisioningQueueError(err); got != nil {
+			t.Fatalf("managedSharedDBProvisioningQueueError(%v) = %v, want nil", err, got)
+		}
+	}
+	wantErr := errors.New("schema apply failed")
+	if got := managedSharedDBProvisioningQueueError(wantErr); !errors.Is(got, wantErr) {
+		t.Fatalf("managedSharedDBProvisioningQueueError(%v) = %v, want original error", wantErr, got)
 	}
 }
 
@@ -2008,6 +2051,50 @@ func TestManagedSharedDBProvisioningDoesNotWaitForPoolWorkLock(t *testing.T) {
 	}
 	if !errors.Is(continuationErr, wantErr) {
 		t.Fatalf("provisioning continuation error = %v, want EnsureDatabase sentinel without waiting for pool-work lock", continuationErr)
+	}
+}
+
+func TestManagedSharedDBLockedContinuationDecryptsRootPasswordOnce(t *testing.T) {
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	localEncryptor, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passwordCipher, err := localEncryptor.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	countedEncryptor := &countingEncryptor{Encryptor: localEncryptor}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, countedEncryptor)
+	t.Cleanup(pool.Close)
+
+	wantErr := errors.New("stop after EnsureDatabase")
+	provisioner := &profileAwareFakeProvisioner{
+		fakeProvisioner: fakeProvisioner{provider: tenant.ProviderTiDBCloudNative},
+		ensureDBErr:     wantErr,
+	}
+	srv := &Server{pool: pool, provisioner: provisioner}
+	err = srv.continueManagedSharedDBPoolLocked(context.Background(), &meta.SharedDB{
+		ID:                      1,
+		UUID:                    "uuid",
+		TiDBCloudOrganizationID: "org",
+		ClusterID:               "cluster",
+		Host:                    "127.0.0.1",
+		Port:                    4000,
+		User:                    "prefix.root",
+		PasswordCipher:          passwordCipher,
+		Name:                    "tidbcloud_fs",
+		TLSMode:                 "true",
+		Status:                  meta.SharedDBStatusProvisioning,
+	}, tenant.CredentialProvisionRequest{})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("locked continuation error = %v, want %v", err, wantErr)
+	}
+	if got := countedEncryptor.decryptCalls.Load(); got != 1 {
+		t.Fatalf("root password decrypt calls = %d, want 1", got)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -210,29 +210,7 @@ func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 	}
 }
 
-func TestManagedSharedDBProvisioningWorkerLimitReservesMetaConnections(t *testing.T) {
-	tests := []struct {
-		name       string
-		configured int
-		maxOpen    int
-		want       int
-	}{
-		{name: "unlimited", configured: 100, maxOpen: 0, want: 100},
-		{name: "default meta pool", configured: 100, maxOpen: 100, want: 50},
-		{name: "configured below safe limit", configured: 8, maxOpen: 100, want: 8},
-		{name: "odd pool size", configured: 10, maxOpen: 3, want: 1},
-		{name: "no spare callback connection", configured: 1, maxOpen: 1, want: 0},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := limitManagedSharedDBProvisioningWorkers(tt.configured, tt.maxOpen); got != tt.want {
-				t.Fatalf("worker limit = %d, want %d", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestManagedSharedDBProvisioningSlotsUseEffectiveMetaConnectionBudget(t *testing.T) {
+func TestManagedSharedDBProvisioningSlotsIgnoreMetaConnectionBudget(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {
 		t.Fatal(err)
@@ -242,11 +220,11 @@ func TestManagedSharedDBProvisioningSlotsUseEffectiveMetaConnectionBudget(t *tes
 
 	srv := NewWithConfig(Config{Meta: metaStore, ManagedSharedDBProvisioningWorkers: 100})
 	t.Cleanup(srv.Close)
-	if got := srv.managedSharedDBProvisioningConcurrency; got != 10 {
-		t.Fatalf("effective provisioning concurrency = %d, want 10", got)
+	if got := srv.managedSharedDBProvisioningConcurrency; got != 100 {
+		t.Fatalf("effective provisioning concurrency = %d, want 100", got)
 	}
-	if got := cap(srv.managedSharedDBProvisioningSlots); got != 10 {
-		t.Fatalf("provisioning slot capacity = %d, want 10", got)
+	if got := cap(srv.managedSharedDBProvisioningSlots); got != 100 {
+		t.Fatalf("provisioning slot capacity = %d, want 100", got)
 	}
 }
 
@@ -1944,6 +1922,83 @@ func TestEnsureManagedSharedDBPhysicalUsesPoolLockForKnownCluster(t *testing.T) 
 	close(releaseHolder)
 	if err := <-holderDone; err != nil {
 		t.Fatalf("pool lock holder: %v", err)
+	}
+}
+
+func TestManagedSharedDBProvisioningDoesNotWaitForPoolWorkLock(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(pool.Close)
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-lock-free-provisioning", ProvisioningKey: bytes.Repeat([]byte{6}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+		PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.UpdateManagedSharedDBPoolCloudResult(context.Background(), &meta.SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-lock-free-provisioning", ClusterID: "cluster-lock-free-provisioning",
+		Host: "127.0.0.1", Port: 1, User: "prefix.root", PasswordCipher: passwordCipher,
+		Name: "tidbcloud_fs", TLSMode: "true",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{meta: metaStore, pool: pool, provisioner: &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}}
+	holderStarted := make(chan struct{})
+	releaseHolder := make(chan struct{})
+	holderDone := make(chan error, 1)
+	go func() {
+		holderDone <- srv.withSharedDBPoolWorkLock(context.Background(), dbID, func(context.Context) error {
+			close(holderStarted)
+			<-releaseHolder
+			return nil
+		})
+	}()
+	<-holderStarted
+
+	continuationDone := make(chan error, 1)
+	go func() {
+		continuationDone <- srv.continueManagedSharedDBPoolOnce(context.Background(), dbID)
+	}()
+	var continuationErr error
+	waitedForPoolLock := false
+	select {
+	case continuationErr = <-continuationDone:
+	case <-time.After(time.Second):
+		waitedForPoolLock = true
+	}
+	close(releaseHolder)
+	if err := <-holderDone; err != nil {
+		t.Fatalf("pool lock holder: %v", err)
+	}
+	if waitedForPoolLock {
+		continuationErr = <-continuationDone
+		t.Fatalf("provisioning continuation waited for the MetaDB pool-work lock: %v", continuationErr)
+	}
+	if continuationErr == nil {
+		t.Fatal("provisioning continuation unexpectedly connected to the invalid shared DB endpoint")
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -1981,7 +1981,12 @@ func TestManagedSharedDBProvisioningDoesNotWaitForPoolWorkLock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	srv := &Server{meta: metaStore, pool: pool, provisioner: &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}}
+	wantErr := errors.New("schema provisioning reached without waiting for MetaDB pool-work lock")
+	provisioner := &profileAwareFakeProvisioner{
+		fakeProvisioner: fakeProvisioner{provider: tenant.ProviderTiDBCloudNative},
+		ensureDBErr:     wantErr,
+	}
+	srv := &Server{meta: metaStore, pool: pool, provisioner: provisioner}
 	holderStarted := make(chan struct{})
 	releaseHolder := make(chan struct{})
 	holderDone := make(chan error, 1)
@@ -1994,27 +1999,50 @@ func TestManagedSharedDBProvisioningDoesNotWaitForPoolWorkLock(t *testing.T) {
 	}()
 	<-holderStarted
 
-	continuationDone := make(chan error, 1)
-	go func() {
-		continuationDone <- srv.continueManagedSharedDBPoolOnce(context.Background(), dbID)
-	}()
-	var continuationErr error
-	waitedForPoolLock := false
-	select {
-	case continuationErr = <-continuationDone:
-	case <-time.After(time.Second):
-		waitedForPoolLock = true
-	}
+	continuationCtx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	continuationErr := srv.continueManagedSharedDBPoolOnce(continuationCtx, dbID)
+	cancel()
 	close(releaseHolder)
 	if err := <-holderDone; err != nil {
 		t.Fatalf("pool lock holder: %v", err)
 	}
-	if waitedForPoolLock {
-		continuationErr = <-continuationDone
-		t.Fatalf("provisioning continuation waited for the MetaDB pool-work lock: %v", continuationErr)
+	if !errors.Is(continuationErr, wantErr) {
+		t.Fatalf("provisioning continuation error = %v, want EnsureDatabase sentinel without waiting for pool-work lock", continuationErr)
 	}
-	if continuationErr == nil {
-		t.Fatal("provisioning continuation unexpectedly connected to the invalid shared DB endpoint")
+}
+
+func TestManagedSharedDBProvisioningWorkerSkipsPendingCloudWork(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-provisioning-skips-pending",
+		ProvisioningKey:         bytes.Repeat([]byte{8}, 32),
+		CloudProvider:           "aws",
+		Region:                  "us-east-1",
+		MaxTenants:              100,
+		SpendingLimit:           &spendingTarget,
+		Name:                    "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	provisioner := &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative}
+	srv := &Server{meta: metaStore, provisioner: provisioner}
+
+	if err := srv.continueManagedSharedDBProvisioningOnce(context.Background(), dbID); err != nil {
+		t.Fatalf("provisioning-only continuation for pending row: %v", err)
+	}
+	if got := provisioner.iamCalls.Load(); got != 0 {
+		t.Fatalf("pending row IAM calls = %d, want 0", got)
+	}
+	if got := provisioner.sharedPoolBatchCalls.Load(); got != 0 {
+		t.Fatalf("pending row Cloud create calls = %d, want 0", got)
 	}
 }
 

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -2266,6 +2266,39 @@ func TestManagedSharedDBProvisioningHeartbeatFailureDoesNotCancelSchemaWork(t *t
 	}
 }
 
+func TestManagedSharedDBProvisioningHeartbeatDoesNotWarnAfterStatusAdvance(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-heartbeat-advanced", ProvisioningKey: bytes.Repeat([]byte{6}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := metaStore.DB().ExecContext(context.Background(), `UPDATE db_pool SET status = ? WHERE db_id = ?`, meta.SharedDBStatusActive, dbID); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &Server{meta: metaStore, managedSharedDBStuckTimeout: 40 * time.Millisecond}
+	core, observed := observer.New(zap.WarnLevel)
+	workCtx := logger.WithContext(context.Background(), zap.New(core))
+	if err := srv.withManagedSharedDBProvisioningHeartbeat(workCtx, dbID, func(context.Context) error {
+		time.Sleep(100 * time.Millisecond)
+		return nil
+	}); err != nil {
+		t.Fatalf("schema work after status advance: %v", err)
+	}
+	if got := observed.FilterMessage("managed_shared_db_pool_provisioning_heartbeat_failed").Len(); got != 0 {
+		t.Fatalf("heartbeat warnings after status advance = %d, want 0", got)
+	}
+}
+
 func TestManagedSharedDBBatchCreateSubmitsFiftyPoolsInOneRequest(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -2140,6 +2140,45 @@ func TestManagedSharedDBProvisioningHeartbeatPreventsStuckFailure(t *testing.T) 
 	}
 }
 
+func TestManagedSharedDBProvisioningHeartbeatFailureDoesNotCancelSchemaWork(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	srv := &Server{meta: metaStore, managedSharedDBStuckTimeout: 40 * time.Millisecond}
+	core, observed := observer.New(zap.WarnLevel)
+	workCtx := logger.WithContext(context.Background(), zap.New(core))
+	workFinished := false
+	err = srv.withManagedSharedDBProvisioningHeartbeat(workCtx, 999_999, func(schemaCtx context.Context) error {
+		deadline := time.NewTimer(time.Second)
+		defer deadline.Stop()
+		ticker := time.NewTicker(time.Millisecond)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-schemaCtx.Done():
+				return fmt.Errorf("schema work context canceled by heartbeat: %w", schemaCtx.Err())
+			case <-ticker.C:
+				if observed.FilterMessage("managed_shared_db_pool_provisioning_heartbeat_failed").Len() > 0 {
+					workFinished = true
+					return nil
+				}
+			case <-deadline.C:
+				return fmt.Errorf("heartbeat failure was not observed")
+			}
+		}
+	})
+	if err != nil {
+		t.Fatalf("schema work after heartbeat refresh failure: %v", err)
+	}
+	if !workFinished {
+		t.Fatal("schema work did not finish after heartbeat refresh failure")
+	}
+}
+
 func TestManagedSharedDBBatchCreateSubmitsFiftyPoolsInOneRequest(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -85,6 +85,22 @@ type fakeProvisioner struct {
 	sharedPoolWaitRelease       <-chan struct{}
 }
 
+type blockingDatabaseEnsurer struct {
+	fakeProvisioner
+	started chan struct{}
+	release <-chan struct{}
+}
+
+func (f *blockingDatabaseEnsurer) EnsureDatabase(ctx context.Context, _ string) error {
+	close(f.started)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-f.release:
+		return errors.New("stop after provisioning heartbeat test")
+	}
+}
+
 type failingEncryptor struct {
 	err error
 }
@@ -176,7 +192,7 @@ func TestManagedSharedDBWorkerConfigDefaultsAndOverrides(t *testing.T) {
 		defaults.managedSharedDBMetadataWorkers != 15 || defaults.managedSharedDBMetadataBatchSize != 30 ||
 		defaults.managedSharedDBMetadataPollInterval != 15*time.Second || defaults.managedSharedDBProvisioningWorkers != 100 ||
 		defaults.tenantPoolReconcileInterval != 5*time.Second || defaults.tenantPoolReconcileWorkerRest != 5*time.Second ||
-		defaults.managedSharedDBStuckTimeout != 15*time.Minute || defaults.tenantPoolReconcileWorkers != 15 ||
+		defaults.managedSharedDBStuckTimeout != 30*time.Minute || defaults.tenantPoolReconcileWorkers != 15 ||
 		defaults.managedSharedDBFailedCleanupInterval != time.Minute || defaults.managedSharedDBFailedCleanupBatchSize != 5 {
 		t.Fatalf("managed shared defaults = cloud_batch(%d) metadata(%d,%d,%s) provisioning(%d) reconcile(%s,%d,%s) stuck(%s) failed_cleanup(%s,%d)",
 			defaults.managedSharedDBCloudBatchSize,
@@ -1999,6 +2015,100 @@ func TestManagedSharedDBProvisioningDoesNotWaitForPoolWorkLock(t *testing.T) {
 	}
 	if continuationErr == nil {
 		t.Fatal("provisioning continuation unexpectedly connected to the invalid shared DB endpoint")
+	}
+}
+
+func TestManagedSharedDBProvisioningHeartbeatPreventsStuckFailure(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pool := tenant.NewPool(tenant.PoolConfig{S3Dir: mustTempDir(t), PublicURL: "http://localhost"}, enc)
+	t.Cleanup(pool.Close)
+	pool.SetMetaStore(metaStore)
+	passwordCipher, err := pool.Encrypt(context.Background(), []byte("root-pass"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	spendingTarget := meta.MaxTiDBCloudSpendingLimit
+	dbID, err := metaStore.CreateManagedSharedDBPool(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-provisioning-heartbeat", ProvisioningKey: bytes.Repeat([]byte{5}, 32),
+		CloudProvider: "aws", Region: "us-east-1", MaxTenants: 100, SpendingLimit: &spendingTarget,
+		PasswordCipher: passwordCipher, Name: "tidbcloud_fs",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := metaStore.UpdateManagedSharedDBPoolCloudResult(context.Background(), &meta.SharedDB{
+		ID: dbID, TiDBCloudOrganizationID: "org-provisioning-heartbeat", ClusterID: "cluster-provisioning-heartbeat",
+		Host: "127.0.0.1", Port: 1, User: "prefix.root", PasswordCipher: passwordCipher,
+		Name: "tidbcloud_fs", TLSMode: "true",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	staleAt := time.Now().UTC().Add(-time.Hour).Truncate(time.Millisecond)
+	if _, err := metaStore.DB().ExecContext(context.Background(), `UPDATE db_pool SET updated_at = ? WHERE db_id = ?`, staleAt, dbID); err != nil {
+		t.Fatal(err)
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	provisioner := &blockingDatabaseEnsurer{
+		fakeProvisioner: fakeProvisioner{provider: tenant.ProviderTiDBCloudNative},
+		started:         started,
+		release:         release,
+	}
+	const stuckTimeout = 120 * time.Millisecond
+	srv := &Server{
+		meta: metaStore, pool: pool, provisioner: provisioner,
+		managedSharedDBStuckTimeout: stuckTimeout,
+	}
+	continuationDone := make(chan error, 1)
+	go func() {
+		continuationDone <- srv.continueManagedSharedDBPoolOnce(context.Background(), dbID)
+	}()
+	<-started
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		row, err := metaStore.GetSharedDB(context.Background(), dbID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if row.UpdatedAt.After(staleAt) {
+			break
+		}
+		if time.Now().After(deadline) {
+			close(release)
+			<-continuationDone
+			t.Fatal("provisioning heartbeat did not refresh db_pool.updated_at")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	srv.reconcileStuckManagedSharedDBPoolsWithCtx(context.Background())
+	row, err := metaStore.GetSharedDB(context.Background(), dbID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if row.Status != meta.SharedDBStatusProvisioning {
+		t.Fatalf("actively provisioning pool status = %q, want provisioning", row.Status)
+	}
+
+	close(release)
+	if err := <-continuationDone; err == nil {
+		t.Fatal("provisioning continuation unexpectedly succeeded")
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -480,10 +480,6 @@ func NewWithConfig(cfg Config) *Server {
 		managedSharedDBProvisioningWorkers = DefaultManagedSharedDBProvisioningWorkers
 	}
 	managedSharedDBProvisioningConcurrency := managedSharedDBProvisioningWorkers
-	if cfg.Meta != nil && cfg.Meta.DB() != nil {
-		managedSharedDBProvisioningConcurrency = limitManagedSharedDBProvisioningWorkers(
-			managedSharedDBProvisioningWorkers, cfg.Meta.DB().Stats().MaxOpenConnections)
-	}
 	tenantPoolReconcileInterval := cfg.TenantPoolReconcileInterval
 	if tenantPoolReconcileInterval <= 0 {
 		tenantPoolReconcileInterval = DefaultTenantPoolReconcileInterval
@@ -749,20 +745,6 @@ func normalizeTenantPoolRefillFreeRatio(ratio float64) float64 {
 		return DefaultTenantPoolRefillFreeRatio
 	}
 	return ratio
-}
-
-// limitManagedSharedDBProvisioningWorkers reserves half of the metadb pool for
-// callback queries and unrelated control-plane traffic. Each active schema
-// worker holds one session connection for GET_LOCK while its callback performs
-// ordinary Store operations through another connection from the same pool.
-func limitManagedSharedDBProvisioningWorkers(configured, maxOpen int) int {
-	if configured <= 0 {
-		return 0
-	}
-	if maxOpen <= 0 {
-		return configured
-	}
-	return min(configured, maxOpen/2)
 }
 
 // insertTenantNotify records a best-effort unified outbox signal so other

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -373,7 +373,7 @@ const (
 	DefaultTenantPoolReconcileInterval           = 5 * time.Second
 	DefaultTenantPoolReconcileWorkers            = 15
 	DefaultTenantPoolReconcileWorkerRest         = 5 * time.Second
-	DefaultManagedSharedDBStuckTimeout           = 15 * time.Minute
+	DefaultManagedSharedDBStuckTimeout           = 30 * time.Minute
 	DefaultManagedSharedDBFailedCleanupInterval  = time.Minute
 	DefaultManagedSharedDBFailedCleanupBatchSize = 5
 )

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -1078,7 +1078,9 @@ func managedSharedDBConnectionMetadataComplete(poolInfo *meta.SharedDB) bool {
 // withManagedSharedDBProvisioningHeartbeat renews durable progress only when a
 // single remote provisioning attempt runs for a meaningful fraction of the
 // stuck timeout. Fast failures therefore remain eligible for normal stuck
-// cleanup instead of being kept alive by frequent retries.
+// cleanup instead of being kept alive by frequent retries. A heartbeat is
+// advisory: a transient MetaDB failure is logged but never cancels target-DB
+// schema work that is already in progress.
 func (s *Server) withManagedSharedDBProvisioningHeartbeat(ctx context.Context, dbID int64, fn func(context.Context) error) error {
 	timeout := s.managedSharedDBStuckTimeout
 	if timeout <= 0 {
@@ -1089,30 +1091,29 @@ func (s *Server) withManagedSharedDBProvisioningHeartbeat(ctx context.Context, d
 		interval = time.Millisecond
 	}
 	heartbeatCtx, cancel := context.WithCancel(ctx)
-	heartbeatDone := make(chan error, 1)
+	heartbeatDone := make(chan struct{})
 	go func() {
+		defer close(heartbeatDone)
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
 		for {
 			select {
 			case <-heartbeatCtx.Done():
-				heartbeatDone <- nil
 				return
 			case <-ticker.C:
 				if err := s.meta.RefreshManagedSharedDBProvisioningProgress(heartbeatCtx, dbID); err != nil {
-					heartbeatDone <- err
-					cancel()
-					return
+					if heartbeatCtx.Err() != nil {
+						return
+					}
+					logger.Warn(ctx, "managed_shared_db_pool_provisioning_heartbeat_failed",
+						zap.Int64("db_pool_id", dbID), zap.Error(err))
 				}
 			}
 		}
 	}()
-	workErr := fn(heartbeatCtx)
+	workErr := fn(ctx)
 	cancel()
-	heartbeatErr := <-heartbeatDone
-	if heartbeatErr != nil {
-		return errors.Join(workErr, fmt.Errorf("refresh managed shared db provisioning progress: %w", heartbeatErr))
-	}
+	<-heartbeatDone
 	return workErr
 }
 
@@ -1356,13 +1357,12 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 	return s.finishManagedSharedDBProvisioning(ctx, poolInfo, cred)
 }
 
-// finishManagedSharedDBProvisioning performs idempotent remote schema ensure
-// and activation after physical identity and connection metadata are durable.
-// It intentionally does not hold the MetaDB pool-work session lock: remote DDL
-// can take minutes, while leader-only consumption and per-process job dedup
-// prevent normal overlap and the operations below are safe to retry after a
-// leader handoff. A low-rate durable heartbeat prevents the stuck watchdog
-// from failing a pool while one of those long remote DDL operations is active.
+// finishManagedSharedDBProvisioning performs remote schema ensure and
+// activation after physical identity and connection metadata are durable. It
+// intentionally does not retain a MetaDB pool-work session across remote DDL;
+// the target TiDB advisory lock in EnsureSharedDBReady serializes schema work
+// across an overlapping leader handoff. A low-rate durable heartbeat prevents
+// the stuck watchdog from failing a pool while that work is active.
 func (s *Server) finishManagedSharedDBProvisioning(ctx context.Context, poolInfo *meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
 	if poolInfo == nil {
 		return fmt.Errorf("managed shared db pool is required")

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -524,11 +524,7 @@ func (s *Server) runManagedSharedDBProvisioning(ctx context.Context, dbIDs []int
 		schemaInitRetryWindow, schemaInitInitialBackoff, managedSharedDBProvisioningMaxBackoff,
 		managedSharedDBProvisioningCooldown,
 		func(jobCtx context.Context, dbID int64) error {
-			err := s.continueManagedSharedDBProvisioningOnce(jobCtx, dbID)
-			if errors.Is(err, meta.ErrNotFound) {
-				return nil
-			}
-			return err
+			return managedSharedDBProvisioningQueueError(s.continueManagedSharedDBProvisioningOnce(jobCtx, dbID))
 		}, func(dbID int64, attempt int, retryIn time.Duration, err error) {
 			logger.Warn(ctx, "managed_shared_db_pool_provisioning_retry", zap.Int64("db_pool_id", dbID),
 				zap.Int("attempt", attempt), zap.Duration("retry_in", retryIn), zap.Error(err))
@@ -536,6 +532,13 @@ func (s *Server) runManagedSharedDBProvisioning(ctx context.Context, dbIDs []int
 	for dbID, err := range failed {
 		logger.Warn(ctx, "managed_shared_db_pool_provisioning_failed", zap.Int64("db_pool_id", dbID), zap.Error(err))
 	}
+}
+
+func managedSharedDBProvisioningQueueError(err error) error {
+	if errors.Is(err, meta.ErrNotFound) || errors.Is(err, tenant.ErrSharedDBSchemaEnsureBusy) {
+		return nil
+	}
+	return err
 }
 
 // continueManagedSharedDBProvisioningOnce is the only operation run by the
@@ -1291,10 +1294,6 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 			return err
 		}
 	}
-	plainRootPassword, err := s.pool.Decrypt(ctx, poolInfo.PasswordCipher)
-	if err != nil {
-		return fmt.Errorf("decrypt shared db root password: %w", err)
-	}
 	needsMetadata := poolInfo.ClusterID == "" || poolInfo.Host == "" || poolInfo.Port <= 0 || poolInfo.User == ""
 	if poolInfo.Status == meta.SharedDBStatusProvisioning && needsMetadata {
 		return fmt.Errorf("provisioning db pool %d has incomplete connection metadata", dbID)
@@ -1316,6 +1315,10 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 		if result == nil {
 			if poolInfo.ClusterID != "" {
 				return fmt.Errorf("managed shared cluster %q was not found", poolInfo.ClusterID)
+			}
+			plainRootPassword, decryptErr := s.pool.Decrypt(ctx, poolInfo.PasswordCipher)
+			if decryptErr != nil {
+				return fmt.Errorf("decrypt shared db root password: %w", decryptErr)
 			}
 			results, createErr := provisioner.BatchProvisionSharedDBPoolsWithCredentials(ctx, []tenant.SharedDBPoolCreateRequest{{
 				DBPoolID: dbID, DBPoolUUID: poolInfo.UUID,

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -1022,6 +1022,14 @@ func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64
 		if err != nil {
 			return err
 		}
+		// Provisioning rows have already durably committed their physical
+		// identity and connection metadata. Schema ensure and activation are
+		// idempotent, so leader recovery can run them without holding a MetaDB
+		// session lock for the entire remote DDL operation. Pending rows still
+		// use the work lock below to prevent duplicate physical creation.
+		if poolInfo.Status == meta.SharedDBStatusProvisioning && managedSharedDBConnectionMetadataComplete(poolInfo) {
+			return s.finishManagedSharedDBProvisioning(ctx, poolInfo, cred)
+		}
 		restartWithOrganization := false
 		continuePool := func(lockCtx context.Context) error {
 			current, loadErr := s.meta.GetSharedDB(lockCtx, dbID)
@@ -1043,6 +1051,12 @@ func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64
 		}
 	}
 	return fmt.Errorf("db pool %d allocation identity kept changing", dbID)
+}
+
+func managedSharedDBConnectionMetadataComplete(poolInfo *meta.SharedDB) bool {
+	return poolInfo != nil && strings.TrimSpace(poolInfo.ClusterID) != "" && strings.TrimSpace(poolInfo.Host) != "" &&
+		poolInfo.Port > 0 && strings.TrimSpace(poolInfo.User) != "" && len(poolInfo.PasswordCipher) > 0 &&
+		strings.TrimSpace(poolInfo.Name) != ""
 }
 
 // ensureManagedSharedDBPhysicalLocked performs only the physical create/adopt
@@ -1279,6 +1293,30 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 		}
 	}
 	if poolInfo.Host == "" || poolInfo.Port <= 0 || poolInfo.User == "" || len(poolInfo.PasswordCipher) == 0 || poolInfo.Name == "" {
+		return fmt.Errorf("%w: db pool %d", errSharedDBConnectionMetadataNotReady, dbID)
+	}
+	return s.finishManagedSharedDBProvisioning(ctx, poolInfo, cred)
+}
+
+// finishManagedSharedDBProvisioning performs idempotent remote schema ensure
+// and activation after physical identity and connection metadata are durable.
+// It intentionally does not hold the MetaDB pool-work session lock: remote DDL
+// can take minutes, while leader-only consumption and per-process job dedup
+// prevent normal overlap and the operations below are safe to retry after a
+// leader handoff.
+func (s *Server) finishManagedSharedDBProvisioning(ctx context.Context, poolInfo *meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
+	if poolInfo == nil {
+		return fmt.Errorf("managed shared db pool is required")
+	}
+	dbID := poolInfo.ID
+	switch poolInfo.Status {
+	case meta.SharedDBStatusActive, meta.SharedDBStatusFailed, meta.SharedDBStatusDraining:
+		return nil
+	case meta.SharedDBStatusPending, meta.SharedDBStatusProvisioning:
+	default:
+		return fmt.Errorf("managed db pool %d has unsupported status %q", dbID, poolInfo.Status)
+	}
+	if !managedSharedDBConnectionMetadataComplete(poolInfo) {
 		return fmt.Errorf("%w: db pool %d", errSharedDBConnectionMetadataNotReady, dbID)
 	}
 	plain, err := s.pool.Decrypt(ctx, poolInfo.PasswordCipher)

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -511,13 +511,8 @@ func (s *Server) runManagedSharedDBProvisioning(ctx context.Context, dbIDs []int
 	workers := s.managedSharedDBProvisioningConcurrency
 	if workers <= 0 {
 		if s.managedSharedDBProvisioningSlots != nil {
-			maxOpen := 0
-			if s.meta != nil && s.meta.DB() != nil {
-				maxOpen = s.meta.DB().Stats().MaxOpenConnections
-			}
 			logger.Error(ctx, "managed_shared_db_pool_provisioning_disabled",
-				zap.Int("configured_workers", s.managedSharedDBProvisioningWorkers),
-				zap.Int("meta_max_open_connections", maxOpen))
+				zap.Int("configured_workers", s.managedSharedDBProvisioningWorkers))
 			return
 		}
 		workers = s.managedSharedDBProvisioningWorkers
@@ -529,7 +524,7 @@ func (s *Server) runManagedSharedDBProvisioning(ctx context.Context, dbIDs []int
 		schemaInitRetryWindow, schemaInitInitialBackoff, managedSharedDBProvisioningMaxBackoff,
 		managedSharedDBProvisioningCooldown,
 		func(jobCtx context.Context, dbID int64) error {
-			err := s.continueManagedSharedDBPoolOnce(jobCtx, dbID)
+			err := s.continueManagedSharedDBProvisioningOnce(jobCtx, dbID)
 			if errors.Is(err, meta.ErrNotFound) {
 				return nil
 			}
@@ -541,6 +536,27 @@ func (s *Server) runManagedSharedDBProvisioning(ctx context.Context, dbIDs []int
 	for dbID, err := range failed {
 		logger.Warn(ctx, "managed_shared_db_pool_provisioning_failed", zap.Int64("db_pool_id", dbID), zap.Error(err))
 	}
+}
+
+// continueManagedSharedDBProvisioningOnce is the only operation run by the
+// high-concurrency schema worker pool. Pending metadata and Cloud create work
+// stay in their separately bounded workers and never fall back to a MetaDB
+// pool-work session lock here.
+func (s *Server) continueManagedSharedDBProvisioningOnce(ctx context.Context, dbID int64) error {
+	poolInfo, err := s.meta.GetSharedDB(ctx, dbID)
+	if err != nil {
+		return err
+	}
+	if poolInfo.Status != meta.SharedDBStatusProvisioning {
+		logger.Debug(ctx, "managed_shared_db_pool_provisioning_skipped_status",
+			zap.Int64("db_pool_id", dbID), zap.String("status", poolInfo.Status))
+		return nil
+	}
+	cred, err := s.sharedDBCloudCredentials()
+	if err != nil {
+		return err
+	}
+	return s.finishManagedSharedDBProvisioning(ctx, poolInfo, cred)
 }
 
 type managedSharedDBProvisioningJob struct {
@@ -1243,7 +1259,11 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 	dbID := poolInfo.ID
 	var err error
 	switch poolInfo.Status {
-	case meta.SharedDBStatusActive, meta.SharedDBStatusFailed, meta.SharedDBStatusDraining:
+	case meta.SharedDBStatusActive:
+		return nil
+	case meta.SharedDBStatusFailed, meta.SharedDBStatusDraining:
+		logger.Debug(ctx, "managed_shared_db_pool_provisioning_terminal_status",
+			zap.Int64("db_pool_id", dbID), zap.String("status", poolInfo.Status))
 		return nil
 	case meta.SharedDBStatusPending, meta.SharedDBStatusProvisioning:
 	default:

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -1333,9 +1333,6 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 			return provisionErr
 		}
 	}
-	if poolInfo.Host == "" || poolInfo.Port <= 0 || poolInfo.User == "" || len(poolInfo.PasswordCipher) == 0 || poolInfo.Name == "" {
-		return fmt.Errorf("%w: db pool %d", errSharedDBConnectionMetadataNotReady, dbID)
-	}
 	return s.finishManagedSharedDBProvisioning(ctx, poolInfo, cred)
 }
 

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -1039,10 +1039,10 @@ func (s *Server) continueManagedSharedDBPoolOnce(ctx context.Context, dbID int64
 			return err
 		}
 		// Provisioning rows have already durably committed their physical
-		// identity and connection metadata. Schema ensure and activation are
-		// idempotent, so leader recovery can run them without holding a MetaDB
-		// session lock for the entire remote DDL operation. Pending rows still
-		// use the work lock below to prevent duplicate physical creation.
+		// identity and connection metadata. Schema ensure is serialized across
+		// pods by an advisory lock on the target TiDB, so leader recovery does
+		// not need to retain a MetaDB session across remote DDL. Pending rows
+		// still use the work lock below to prevent duplicate physical creation.
 		if poolInfo.Status == meta.SharedDBStatusProvisioning && managedSharedDBConnectionMetadataComplete(poolInfo) {
 			return s.finishManagedSharedDBProvisioning(ctx, poolInfo, cred)
 		}

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -1059,6 +1059,47 @@ func managedSharedDBConnectionMetadataComplete(poolInfo *meta.SharedDB) bool {
 		strings.TrimSpace(poolInfo.Name) != ""
 }
 
+// withManagedSharedDBProvisioningHeartbeat renews durable progress only when a
+// single remote provisioning attempt runs for a meaningful fraction of the
+// stuck timeout. Fast failures therefore remain eligible for normal stuck
+// cleanup instead of being kept alive by frequent retries.
+func (s *Server) withManagedSharedDBProvisioningHeartbeat(ctx context.Context, dbID int64, fn func(context.Context) error) error {
+	timeout := s.managedSharedDBStuckTimeout
+	if timeout <= 0 {
+		timeout = DefaultManagedSharedDBStuckTimeout
+	}
+	interval := timeout / 4
+	if interval <= 0 {
+		interval = time.Millisecond
+	}
+	heartbeatCtx, cancel := context.WithCancel(ctx)
+	heartbeatDone := make(chan error, 1)
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-heartbeatCtx.Done():
+				heartbeatDone <- nil
+				return
+			case <-ticker.C:
+				if err := s.meta.RefreshManagedSharedDBProvisioningProgress(heartbeatCtx, dbID); err != nil {
+					heartbeatDone <- err
+					cancel()
+					return
+				}
+			}
+		}
+	}()
+	workErr := fn(heartbeatCtx)
+	cancel()
+	heartbeatErr := <-heartbeatDone
+	if heartbeatErr != nil {
+		return errors.Join(workErr, fmt.Errorf("refresh managed shared db provisioning progress: %w", heartbeatErr))
+	}
+	return workErr
+}
+
 // ensureManagedSharedDBPhysicalLocked performs only the physical create/adopt
 // stage. It deliberately does not wait for endpoint readiness, system-user
 // setup, schema initialization, or activation so direct requests can fall back
@@ -1303,7 +1344,8 @@ func (s *Server) continueManagedSharedDBPoolLocked(ctx context.Context, poolInfo
 // It intentionally does not hold the MetaDB pool-work session lock: remote DDL
 // can take minutes, while leader-only consumption and per-process job dedup
 // prevent normal overlap and the operations below are safe to retry after a
-// leader handoff.
+// leader handoff. A low-rate durable heartbeat prevents the stuck watchdog
+// from failing a pool while one of those long remote DDL operations is active.
 func (s *Server) finishManagedSharedDBProvisioning(ctx context.Context, poolInfo *meta.SharedDB, cred tenant.CredentialProvisionRequest) error {
 	if poolInfo == nil {
 		return fmt.Errorf("managed shared db pool is required")
@@ -1324,26 +1366,31 @@ func (s *Server) finishManagedSharedDBProvisioning(ctx context.Context, poolInfo
 		return fmt.Errorf("decrypt shared db root password: %w", err)
 	}
 	dsn := managedSharedDBDSN(poolInfo, string(plain))
-	if ensurer, ok := s.provisioner.(tenantDatabaseEnsurer); ok {
-		if err := ensurer.EnsureDatabase(ctx, dsn); err != nil {
+	if err := s.withManagedSharedDBProvisioningHeartbeat(ctx, dbID, func(provisioningCtx context.Context) error {
+		if ensurer, ok := s.provisioner.(tenantDatabaseEnsurer); ok {
+			if err := ensurer.EnsureDatabase(provisioningCtx, dsn); err != nil {
+				return err
+			}
+		}
+		if err := s.pool.EnsureSharedDBReady(provisioningCtx, dbID); err != nil {
 			return err
 		}
-	}
-	if err := s.pool.EnsureSharedDBReady(ctx, dbID); err != nil {
-		return err
-	}
-	if updater, ok := s.provisioner.(tenant.QuotaUpdater); ok && poolInfo.SpendingLimit != nil {
-		_, patchErr := updater.UpdateQuota(ctx, &tenant.ClusterInfo{
-			ClusterID: poolInfo.ClusterID, OrganizationID: poolInfo.TiDBCloudOrganizationID,
-			Provider: tenant.ProviderTiDBCloudNative,
-		}, cred, tenant.QuotaUpdateOptions{TiDBCloudSpendingLimitMonthly: poolInfo.SpendingLimit})
-		if patchErr != nil {
-			logger.Warn(ctx, "managed_shared_db_spending_limit_sync_failed",
-				zap.Int64("db_pool_id", dbID),
-				zap.String("db_pool_uuid", poolInfo.UUID),
-				zap.String("tidbcloud_org_id", poolInfo.TiDBCloudOrganizationID),
-				zap.Error(patchErr))
+		if updater, ok := s.provisioner.(tenant.QuotaUpdater); ok && poolInfo.SpendingLimit != nil {
+			_, patchErr := updater.UpdateQuota(provisioningCtx, &tenant.ClusterInfo{
+				ClusterID: poolInfo.ClusterID, OrganizationID: poolInfo.TiDBCloudOrganizationID,
+				Provider: tenant.ProviderTiDBCloudNative,
+			}, cred, tenant.QuotaUpdateOptions{TiDBCloudSpendingLimitMonthly: poolInfo.SpendingLimit})
+			if patchErr != nil {
+				logger.Warn(provisioningCtx, "managed_shared_db_spending_limit_sync_failed",
+					zap.Int64("db_pool_id", dbID),
+					zap.String("db_pool_uuid", poolInfo.UUID),
+					zap.String("tidbcloud_org_id", poolInfo.TiDBCloudOrganizationID),
+					zap.Error(patchErr))
+			}
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	if err := s.meta.ActivateSharedDBPool(ctx, dbID); err != nil {
 		return err

--- a/pkg/server/shared_db_pool.go
+++ b/pkg/server/shared_db_pool.go
@@ -1108,6 +1108,11 @@ func (s *Server) withManagedSharedDBProvisioningHeartbeat(ctx context.Context, d
 					if heartbeatCtx.Err() != nil {
 						return
 					}
+					if errors.Is(err, meta.ErrSharedDBPoolNotProvisioning) {
+						logger.Debug(ctx, "managed_shared_db_pool_provisioning_heartbeat_stopped_status_advanced",
+							zap.Int64("db_pool_id", dbID), zap.Error(err))
+						return
+					}
 					logger.Warn(ctx, "managed_shared_db_pool_provisioning_heartbeat_failed",
 						zap.Int64("db_pool_id", dbID), zap.Error(err))
 				}

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -197,7 +197,10 @@ var (
 	defaultSharedDBHandleIdleTTL            = 30 * time.Minute
 )
 
-const sharedDBSchemaLockReleaseTimeout = 5 * time.Second
+const (
+	sharedDBSchemaLockReleaseTimeout        = 5 * time.Second
+	sharedDBSchemaForegroundLockWaitSeconds = 1
+)
 
 func ensureTiDBSchemaForEmbeddingMode(ctx context.Context, db *sql.DB, mode string, profile schema.TiDBAutoEmbeddingProfile) error {
 	tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
@@ -216,23 +219,43 @@ func ensureTiDBSchemaForEmbeddingMode(ctx context.Context, db *sql.DB, mode stri
 
 // withSharedDBSchemaAdvisoryLock serializes schema ensure on the target
 // physical DB itself. It does not retain a MetaDB connection, and distinct
-// db_pool rows use distinct lock names so their DDL remains concurrent.
-func withSharedDBSchemaAdvisoryLock(ctx context.Context, db *sql.DB, dbID int64, fn func(context.Context) error) (err error) {
+// db_pool rows use distinct lock names so their DDL remains concurrent. The
+// lock is session-owned; if that target connection is lost mid-DDL, TiDB
+// releases it and a later attempt can overlap the still-finishing statement.
+func withSharedDBSchemaAdvisoryLock(
+	ctx context.Context,
+	db *sql.DB,
+	dbID int64,
+	waitForLock bool,
+	fn func(context.Context) error,
+) (err error) {
 	conn, err := db.Conn(ctx)
 	if err != nil {
 		return err
 	}
 	defer func() { _ = conn.Close() }()
 	lockName := fmt.Sprintf("drive9:shared-schema:%d", dbID)
-	var acquired sql.NullInt64
-	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", lockName).Scan(&acquired); err != nil {
-		return fmt.Errorf("acquire shared schema advisory lock for db pool %d: %w", dbID, err)
+	waitSeconds := 0
+	if waitForLock {
+		waitSeconds = sharedDBSchemaForegroundLockWaitSeconds
 	}
-	if !acquired.Valid {
-		return fmt.Errorf("acquire shared schema advisory lock for db pool %d returned NULL", dbID)
-	}
-	if acquired.Int64 != 1 {
-		return fmt.Errorf("%w for db pool %d", errSharedDBSchemaEnsureBusy, dbID)
+	for {
+		var acquired sql.NullInt64
+		if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, ?)", lockName, waitSeconds).Scan(&acquired); err != nil {
+			return fmt.Errorf("acquire shared schema advisory lock for db pool %d: %w", dbID, err)
+		}
+		if !acquired.Valid {
+			return fmt.Errorf("acquire shared schema advisory lock for db pool %d returned NULL", dbID)
+		}
+		if acquired.Int64 == 1 {
+			break
+		}
+		if !waitForLock {
+			return fmt.Errorf("%w for db pool %d", errSharedDBSchemaEnsureBusy, dbID)
+		}
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("wait for shared schema advisory lock for db pool %d: %w", dbID, err)
+		}
 	}
 	defer func() {
 		releaseCtx, cancel := context.WithTimeout(context.Background(), sharedDBSchemaLockReleaseTimeout)
@@ -1094,6 +1117,10 @@ func (p *Pool) reapIdleSharedDBs(now time.Time) {
 // (db_pool.id), opening it on first use. An unreferenced handle remains warm
 // for defaultSharedDBHandleIdleTTL and is then closed by the existing reaper.
 func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) {
+	return p.sharedDBHandleWithSchemaLockWait(ctx, dbID, true)
+}
+
+func (p *Pool) sharedDBHandleWithSchemaLockWait(ctx context.Context, dbID int64, waitForSchemaLock bool) (*sql.DB, error) {
 	p.sharedMu.Lock()
 	if db, ok := p.sharedDBs[dbID]; ok {
 		p.sharedDBLastUsed[dbID] = time.Now()
@@ -1159,9 +1186,9 @@ func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) 
 		return nil, fmt.Errorf("shared db %d: open: %w", dbID, err)
 	}
 	if info.SchemaVersion != schema.CurrentSharedTiDBSchemaVersion {
-		if err := withSharedDBSchemaAdvisoryLock(ctx, db, dbID, func(lockCtx context.Context) error {
+		if err := withSharedDBSchemaAdvisoryLock(ctx, db, dbID, waitForSchemaLock, func(lockCtx context.Context) error {
 			// Another pod may have completed the migration between the initial
-			// metadata read and this non-blocking lock acquisition.
+			// metadata read and this lock acquisition.
 			current, err := p.metaStore.GetSharedDB(lockCtx, dbID)
 			if err != nil {
 				return err
@@ -1196,7 +1223,7 @@ func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) 
 // EnsureSharedDBReady opens the shared physical DB through the normal cache
 // path, which also compares and applies the checked-in shared schema version.
 func (p *Pool) EnsureSharedDBReady(ctx context.Context, dbID int64) error {
-	_, err := p.sharedDBHandle(ctx, dbID)
+	_, err := p.sharedDBHandleWithSchemaLockWait(ctx, dbID, false)
 	return err
 }
 

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -190,11 +190,14 @@ var (
 	ensureTiDBSchemaForAutoEmbeddingProfile = schema.EnsureTiDBSchemaForAutoEmbeddingProfile
 	ensureTiDBSchemaForFTSOnlyProfile       = schema.EnsureTiDBSchemaForFTSOnlyProfile
 	ensureSharedDBSchema                    = schema.EnsureSharedSchema
+	errSharedDBSchemaEnsureBusy             = errors.New("shared schema ensure already running")
 	defaultTenantPoolDrainTimeout           = 30 * time.Second
 	defaultTenantPoolMaxTenants             = 1024
 	defaultTenantPoolIdleReapInterval       = 2 * time.Minute
 	defaultSharedDBHandleIdleTTL            = 30 * time.Minute
 )
+
+const sharedDBSchemaLockReleaseTimeout = 5 * time.Second
 
 func ensureTiDBSchemaForEmbeddingMode(ctx context.Context, db *sql.DB, mode string, profile schema.TiDBAutoEmbeddingProfile) error {
 	tidbMode, err := TiDBEmbeddingModeForTenantMode(mode)
@@ -209,6 +212,42 @@ func ensureTiDBSchemaForEmbeddingMode(ctx context.Context, db *sql.DB, mode stri
 	default:
 		return schema.EnsureTiDBSchemaForEmbeddingModeProfile(ctx, db, tidbMode, profile)
 	}
+}
+
+// withSharedDBSchemaAdvisoryLock serializes schema ensure on the target
+// physical DB itself. It does not retain a MetaDB connection, and distinct
+// db_pool rows use distinct lock names so their DDL remains concurrent.
+func withSharedDBSchemaAdvisoryLock(ctx context.Context, db *sql.DB, dbID int64, fn func(context.Context) error) (err error) {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+	lockName := fmt.Sprintf("drive9:shared-schema:%d", dbID)
+	var acquired sql.NullInt64
+	if err := conn.QueryRowContext(ctx, "SELECT GET_LOCK(?, 0)", lockName).Scan(&acquired); err != nil {
+		return fmt.Errorf("acquire shared schema advisory lock for db pool %d: %w", dbID, err)
+	}
+	if !acquired.Valid {
+		return fmt.Errorf("acquire shared schema advisory lock for db pool %d returned NULL", dbID)
+	}
+	if acquired.Int64 != 1 {
+		return fmt.Errorf("%w for db pool %d", errSharedDBSchemaEnsureBusy, dbID)
+	}
+	defer func() {
+		releaseCtx, cancel := context.WithTimeout(context.Background(), sharedDBSchemaLockReleaseTimeout)
+		defer cancel()
+		var released sql.NullInt64
+		releaseErr := conn.QueryRowContext(releaseCtx, "SELECT RELEASE_LOCK(?)", lockName).Scan(&released)
+		if releaseErr != nil {
+			err = errors.Join(err, fmt.Errorf("release shared schema advisory lock for db pool %d: %w", dbID, releaseErr))
+			return
+		}
+		if !released.Valid || released.Int64 != 1 {
+			err = errors.Join(err, fmt.Errorf("shared schema advisory lock for db pool %d was not held by current connection", dbID))
+		}
+	}()
+	return fn(ctx)
 }
 
 func durationMs(d time.Duration) float64 {
@@ -1120,13 +1159,23 @@ func (p *Pool) sharedDBHandle(ctx context.Context, dbID int64) (*sql.DB, error) 
 		return nil, fmt.Errorf("shared db %d: open: %w", dbID, err)
 	}
 	if info.SchemaVersion != schema.CurrentSharedTiDBSchemaVersion {
-		if err := ensureSharedDBSchema(ctx, db); err != nil {
+		if err := withSharedDBSchemaAdvisoryLock(ctx, db, dbID, func(lockCtx context.Context) error {
+			// Another pod may have completed the migration between the initial
+			// metadata read and this non-blocking lock acquisition.
+			current, err := p.metaStore.GetSharedDB(lockCtx, dbID)
+			if err != nil {
+				return err
+			}
+			if current.SchemaVersion == schema.CurrentSharedTiDBSchemaVersion {
+				return nil
+			}
+			if err := ensureSharedDBSchema(lockCtx, db); err != nil {
+				return fmt.Errorf("ensure schema: %w", err)
+			}
+			return p.metaStore.UpdateSharedDBSchemaVersion(lockCtx, dbID, schema.CurrentSharedTiDBSchemaVersion)
+		}); err != nil {
 			_ = mysqlutil.CloseInstrumented(db)
-			return nil, fmt.Errorf("shared db %d: ensure schema: %w", dbID, err)
-		}
-		if err := p.metaStore.UpdateSharedDBSchemaVersion(ctx, dbID, schema.CurrentSharedTiDBSchemaVersion); err != nil {
-			_ = mysqlutil.CloseInstrumented(db)
-			return nil, fmt.Errorf("shared db %d: persist schema version: %w", dbID, err)
+			return nil, fmt.Errorf("shared db %d: %w", dbID, err)
 		}
 	}
 	p.sharedMu.Lock()

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -190,7 +190,7 @@ var (
 	ensureTiDBSchemaForAutoEmbeddingProfile = schema.EnsureTiDBSchemaForAutoEmbeddingProfile
 	ensureTiDBSchemaForFTSOnlyProfile       = schema.EnsureTiDBSchemaForFTSOnlyProfile
 	ensureSharedDBSchema                    = schema.EnsureSharedSchema
-	errSharedDBSchemaEnsureBusy             = errors.New("shared schema ensure already running")
+	ErrSharedDBSchemaEnsureBusy             = errors.New("shared schema ensure already running")
 	defaultTenantPoolDrainTimeout           = 30 * time.Second
 	defaultTenantPoolMaxTenants             = 1024
 	defaultTenantPoolIdleReapInterval       = 2 * time.Minute
@@ -251,7 +251,7 @@ func withSharedDBSchemaAdvisoryLock(
 			break
 		}
 		if !waitForLock {
-			return fmt.Errorf("%w for db pool %d", errSharedDBSchemaEnsureBusy, dbID)
+			return fmt.Errorf("%w for db pool %d", ErrSharedDBSchemaEnsureBusy, dbID)
 		}
 		if err := ctx.Err(); err != nil {
 			return fmt.Errorf("wait for shared schema advisory lock for db pool %d: %w", dbID, err)

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -235,6 +235,9 @@ func withSharedDBSchemaAdvisoryLock(
 	}
 	defer func() { _ = conn.Close() }()
 	lockName := fmt.Sprintf("drive9:shared-schema:%d", dbID)
+	// MySQL honors a zero GET_LOCK timeout as non-blocking. TiDB clamps its
+	// minimum timeout to one second, so the provisioning path is fail-fast but
+	// can wait for approximately one second when the same physical DB is busy.
 	waitSeconds := 0
 	if waitForLock {
 		waitSeconds = sharedDBSchemaForegroundLockWaitSeconds

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -435,6 +435,96 @@ func TestSharedDBSchemaIsCheckedLazilyAndRetriedAfterFailure(t *testing.T) {
 	}
 }
 
+func TestSharedDBSchemaEnsureUsesCrossPoolAdvisoryLock(t *testing.T) {
+	metaStore, err := meta.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = metaStore.Close() })
+	testmysql.ResetMetaDB(t, metaStore.DB())
+	dsnCfg, err := mysql.ParseDSN(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, portText, err := net.SplitHostPort(dsnCfg.Addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	master := make([]byte, 32)
+	if _, err := rand.Read(master); err != nil {
+		t.Fatal(err)
+	}
+	enc, err := encrypt.NewLocalAESEncryptor(master)
+	if err != nil {
+		t.Fatal(err)
+	}
+	passwordCipher, err := enc.Encrypt(context.Background(), []byte(dsnCfg.Passwd))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dbID, err := metaStore.RegisterSharedDB(context.Background(), &meta.SharedDB{
+		TiDBCloudOrganizationID: "org-schema-advisory-lock", Host: host, Port: port,
+		User: dsnCfg.User, PasswordCipher: passwordCipher, Name: dsnCfg.DBName,
+		MaxTenants: 100, Status: meta.SharedDBStatusActive,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstPool := NewPool(PoolConfig{}, enc)
+	firstPool.SetMetaStore(metaStore)
+	t.Cleanup(firstPool.Close)
+	secondPool := NewPool(PoolConfig{}, enc)
+	secondPool.SetMetaStore(metaStore)
+	t.Cleanup(secondPool.Close)
+
+	var ensureCalls atomic.Int32
+	firstEnsureStarted := make(chan struct{})
+	releaseFirstEnsure := make(chan struct{})
+	previousEnsure := ensureSharedDBSchema
+	ensureSharedDBSchema = func(ctx context.Context, db *sql.DB) error {
+		if ensureCalls.Add(1) == 1 {
+			close(firstEnsureStarted)
+			<-releaseFirstEnsure
+		}
+		return db.PingContext(ctx)
+	}
+	t.Cleanup(func() { ensureSharedDBSchema = previousEnsure })
+
+	firstDone := make(chan error, 1)
+	go func() { firstDone <- firstPool.EnsureSharedDBReady(context.Background(), dbID) }()
+	<-firstEnsureStarted
+	secondDone := make(chan error, 1)
+	go func() { secondDone <- secondPool.EnsureSharedDBReady(context.Background(), dbID) }()
+	var secondErr error
+	select {
+	case secondErr = <-secondDone:
+	case <-time.After(time.Second):
+		close(releaseFirstEnsure)
+		<-firstDone
+		t.Fatal("second shared schema ensure waited instead of returning a non-blocking lock conflict")
+	}
+	close(releaseFirstEnsure)
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first shared schema ensure: %v", err)
+	}
+	if !errors.Is(secondErr, errSharedDBSchemaEnsureBusy) {
+		t.Fatalf("second shared schema ensure error = %v, want non-blocking advisory lock conflict", secondErr)
+	}
+	if got := ensureCalls.Load(); got != 1 {
+		t.Fatalf("concurrent schema ensure calls = %d, want 1", got)
+	}
+	if err := secondPool.EnsureSharedDBReady(context.Background(), dbID); err != nil {
+		t.Fatalf("retry after first schema ensure completed: %v", err)
+	}
+	if got := ensureCalls.Load(); got != 1 {
+		t.Fatalf("schema ensure calls after current-version retry = %d, want 1", got)
+	}
+}
+
 func TestSharedDBColdOpensDoNotBlockDifferentDBPools(t *testing.T) {
 	metaStore, err := meta.Open(testDSN)
 	if err != nil {

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -484,6 +485,9 @@ func TestSharedDBSchemaEnsureUsesCrossPoolAdvisoryLock(t *testing.T) {
 	var ensureCalls atomic.Int32
 	firstEnsureStarted := make(chan struct{})
 	releaseFirstEnsure := make(chan struct{})
+	var releaseFirstEnsureOnce sync.Once
+	releaseFirst := func() { releaseFirstEnsureOnce.Do(func() { close(releaseFirstEnsure) }) }
+	t.Cleanup(releaseFirst)
 	previousEnsure := ensureSharedDBSchema
 	ensureSharedDBSchema = func(ctx context.Context, db *sql.DB) error {
 		if ensureCalls.Add(1) == 1 {
@@ -503,13 +507,9 @@ func TestSharedDBSchemaEnsureUsesCrossPoolAdvisoryLock(t *testing.T) {
 	select {
 	case secondErr = <-secondDone:
 	case <-time.After(time.Second):
-		close(releaseFirstEnsure)
+		releaseFirst()
 		<-firstDone
 		t.Fatal("second shared schema ensure waited instead of returning a non-blocking lock conflict")
-	}
-	close(releaseFirstEnsure)
-	if err := <-firstDone; err != nil {
-		t.Fatalf("first shared schema ensure: %v", err)
 	}
 	if !errors.Is(secondErr, errSharedDBSchemaEnsureBusy) {
 		t.Fatalf("second shared schema ensure error = %v, want non-blocking advisory lock conflict", secondErr)
@@ -517,11 +517,36 @@ func TestSharedDBSchemaEnsureUsesCrossPoolAdvisoryLock(t *testing.T) {
 	if got := ensureCalls.Load(); got != 1 {
 		t.Fatalf("concurrent schema ensure calls = %d, want 1", got)
 	}
-	if err := secondPool.EnsureSharedDBReady(context.Background(), dbID); err != nil {
-		t.Fatalf("retry after first schema ensure completed: %v", err)
+	waitCtx, cancelWait := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	_, waitErr := secondPool.sharedDBHandle(waitCtx, dbID)
+	cancelWait()
+	if !errors.Is(waitErr, context.DeadlineExceeded) {
+		t.Fatalf("foreground shared DB open deadline error = %v, want context deadline", waitErr)
+	}
+	foregroundDone := make(chan error, 1)
+	go func() {
+		_, err := secondPool.sharedDBHandle(context.Background(), dbID)
+		foregroundDone <- err
+	}()
+	select {
+	case err := <-foregroundDone:
+		t.Fatalf("foreground shared DB open returned before active schema ensure completed: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	releaseFirst()
+	if err := <-firstDone; err != nil {
+		t.Fatalf("first shared schema ensure: %v", err)
+	}
+	select {
+	case err := <-foregroundDone:
+		if err != nil {
+			t.Fatalf("foreground shared DB open after schema ensure: %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("foreground shared DB open did not resume after schema ensure completed")
 	}
 	if got := ensureCalls.Load(); got != 1 {
-		t.Fatalf("schema ensure calls after current-version retry = %d, want 1", got)
+		t.Fatalf("schema ensure calls after foreground current-version retry = %d, want 1", got)
 	}
 }
 

--- a/pkg/tenant/pool_test.go
+++ b/pkg/tenant/pool_test.go
@@ -487,8 +487,10 @@ func TestSharedDBSchemaEnsureUsesCrossPoolAdvisoryLock(t *testing.T) {
 	releaseFirstEnsure := make(chan struct{})
 	var releaseFirstEnsureOnce sync.Once
 	releaseFirst := func() { releaseFirstEnsureOnce.Do(func() { close(releaseFirstEnsure) }) }
-	t.Cleanup(releaseFirst)
 	previousEnsure := ensureSharedDBSchema
+	// Register the global-hook restore first so the later release-and-drain
+	// cleanup runs before it on every failure path.
+	t.Cleanup(func() { ensureSharedDBSchema = previousEnsure })
 	ensureSharedDBSchema = func(ctx context.Context, db *sql.DB) error {
 		if ensureCalls.Add(1) == 1 {
 			close(firstEnsureStarted)
@@ -496,10 +498,21 @@ func TestSharedDBSchemaEnsureUsesCrossPoolAdvisoryLock(t *testing.T) {
 		}
 		return db.PingContext(ctx)
 	}
-	t.Cleanup(func() { ensureSharedDBSchema = previousEnsure })
 
 	firstDone := make(chan error, 1)
-	go func() { firstDone <- firstPool.EnsureSharedDBReady(context.Background(), dbID) }()
+	firstExited := make(chan struct{})
+	t.Cleanup(func() {
+		releaseFirst()
+		select {
+		case <-firstExited:
+		case <-time.After(time.Second):
+			t.Error("first shared schema ensure did not exit during cleanup")
+		}
+	})
+	go func() {
+		defer close(firstExited)
+		firstDone <- firstPool.EnsureSharedDBReady(context.Background(), dbID)
+	}()
 	<-firstEnsureStarted
 	secondDone := make(chan error, 1)
 	go func() { secondDone <- secondPool.EnsureSharedDBReady(context.Background(), dbID) }()
@@ -511,7 +524,7 @@ func TestSharedDBSchemaEnsureUsesCrossPoolAdvisoryLock(t *testing.T) {
 		<-firstDone
 		t.Fatal("second shared schema ensure waited instead of returning a non-blocking lock conflict")
 	}
-	if !errors.Is(secondErr, errSharedDBSchemaEnsureBusy) {
+	if !errors.Is(secondErr, ErrSharedDBSchemaEnsureBusy) {
 		t.Fatalf("second shared schema ensure error = %v, want non-blocking advisory lock conflict", secondErr)
 	}
 	if got := ensureCalls.Load(); got != 1 {


### PR DESCRIPTION
## Summary

- use the configured shared schema-provisioning worker count directly instead of capping it at half of the MetaDB connection pool
- keep the high-concurrency worker pool provisioning-only; pending metadata and Cloud create/adoption remain in their separately bounded workers
- freeze non-empty Cloud organization and cluster identity once provisioning starts, while allowing missing legacy identity to be repaired and connection metadata to refresh
- avoid holding a MetaDB pool-work session lock across slow remote schema DDL
- serialize same-physical-DB schema ensure across pods with an advisory lock on the target TiDB; provisioning retries stay non-blocking while foreground cold-opens wait within their request context
- treat expected cross-pod schema-lock contention as a benign current-wave completion and retry from the next durable scan
- fill existing physical shared-DB capacity transactionally before creating any new physical DB for a logical-pool refill
- heartbeat durable provisioning progress for the stuck watchdog and raise the default no-progress timeout from 15 minutes to 30 minutes
- keep full schema ensure, schema-version persistence, DB activation, and tenant activation in the same completion boundary

## Why

Shared schema DDL executes on the physical shared DB, but the previous implementation held one MetaDB `GET_LOCK` session for the full remote DDL duration. With the default MetaDB pool of 100 connections, that reduced the configured 100 provisioning workers to 50. Slow FULLTEXT/VECTOR DDL therefore limited physical-pool activation throughput and caused claimable tenant inventory to oscillate to zero.

Rows selected by the provisioning queue already have durable physical identity and connection metadata. They now run only the schema-completion path and cannot fall back into pending metadata or Cloud-create work. Those earlier lifecycle stages retain their existing bounded workers and coordination. The transition to provisioning requires a non-blank cluster ID. Once a non-empty organization and cluster identity is durable, later metadata polls cannot reassign it; a malformed legacy provisioning row with missing identity can still be repaired. Endpoint and credential metadata remain refreshable.

To preserve cross-process exclusion during leader handoff, schema ensure acquires a session advisory lock on a dedicated connection to the target physical TiDB. The lock is scoped by `db_pool` ID, so independent physical DBs continue concurrently. Provisioning uses `GET_LOCK(..., 0)`: MySQL returns immediately, while TiDB clamps the timeout to its one-second minimum; duplicate durable work therefore fails fast, is treated as a benign completion of that queue wave, and retries through the next durable scan without warning/backoff churn. Foreground tenant cold-opens wait in one-second lock calls bounded by the request context, so an active tenant does not receive an opaque busy error during a schema-version migration. No MetaDB connection is retained across DDL. If the target TiDB session itself is lost mid-DDL, the advisory lock is released; this is the remaining narrow overlap window.

Long schema attempts refresh `db_pool.updated_at` after one quarter of the configured stuck timeout and at the same interval thereafter. Fast failures finish before the first heartbeat, so repeated quick failures cannot keep a genuinely stuck pool alive indefinitely. A transient heartbeat UPDATE failure is logged and retried on the next tick; it never cancels target-TiDB schema work already in progress. The default no-progress timeout is now 30 minutes to tolerate transient TiDB schema-init delays without discarding an already-created cluster.

Shared logical-pool refill now allocates each durable wave into existing `active`, `provisioning`, then `pending` physical DB capacity before inserting any new `db_pool` row. Candidate rows are locked in deterministic order inside the same transaction as tenant, placement, membership, quota, and embedding-profile staging; each physical DB receives one batched `tenant_count += assigned` update. Only the remainder after all reusable capacity is full produces new physical DBs and enters the Cloud-create batch. This prevents small periodic refill gaps from creating a succession of mostly empty physical clusters.

## Schema completeness

This does not activate a physical DB early. Mandatory tables, schema contract validation, all FULLTEXT/VECTOR DDL, schema-version persistence, physical DB activation, and tenant activation still complete in order before inventory becomes claimable.

A live dev TiDB probe also confirmed that these columnar indexes cannot be combined into one multi-schema `ALTER`: TiDB returns `ERROR 8200: Unsupported multi schema change for add columnar index`. The per-DB DDL sequence therefore remains unchanged; this PR increases concurrency across independent physical DBs.

## Verification

Current head `4dfa2ed9`:

- `go test ./pkg/server -run 'TestBlockingDatabaseEnsurerSignalsStartedOnceAcrossRetries|TestManagedSharedDBProvisioningQueueErrorSkipsExpectedContention|TestManagedSharedDBLockedContinuationDecryptsRootPasswordOnce|TestManagedSharedDBProvisioningHeartbeatFailureDoesNotCancelSchemaWork|TestManagedSharedDBProvisioningHeartbeatPreventsStuckFailure' -count=1`
- `go test ./pkg/tenant -run 'TestSharedDBSchemaEnsureUsesCrossPoolAdvisoryLock|TestSharedDBColdOpensDoNotBlockDifferentDBPools' -count=1`
- `go test -race ./pkg/tenant -run 'TestSharedDBSchemaEnsureUsesCrossPoolAdvisoryLock' -count=1`
- `git diff --check`
- `go test ./pkg/server -run 'TestSharedTenantPoolRefill|TestAdminTenantPoolReplenish(SubmitsLargeRefillAsSingleWave|ContinuesPastWatermarkToFillSlots)' -count=1`
- `go test ./pkg/meta -count=1`

Focused checks pass locally. Hosted checks for the current head are running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More aggressive reuse of existing shared database capacity during shared-tenant pool refills.
  * Shared DB schema ensure is now coordinated across instances to prevent conflicting schema/version updates.
* **Bug Fixes**
  * Increased default “stuck” detection timeout from 15 to 30 minutes (including the documented configuration default).
  * Managed shared DB provisioning now refreshes progress during long remote operations to reduce false failures.
  * Enforced identity consistency for managed shared DB pools and added clearer handling for non-provisioning states.
  * Provisioning concurrency now directly follows the configured worker limit.
* **Tests**
  * Expanded coverage for capacity reuse, shared-schema coordination, and managed shared DB provisioning/continuation behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->