### PR TITLE
fix: isolate shared schema DB operations

### DIFF
--- a/pkg/metrics/db.go
+++ b/pkg/metrics/db.go
@@ -108,6 +108,14 @@ func RegisterSharedDBWithOrg(dbPoolUUID, tidbCloudOrgID string, db *sql.DB) {
 	registerDB("shared", "", dbPoolUUID, tidbCloudOrgID, db)
 }
 
+// RegisterSharedSchemaDBWithOrg registers the short-lived handle that applies
+// shared-schema bootstrap DDL. Its series exist only while a schema ensure is
+// running, which is the point: shared schema work stays separable from the
+// role="shared" data-plane series that latency and error-rate alerts read.
+func RegisterSharedSchemaDBWithOrg(dbPoolUUID, tidbCloudOrgID string, db *sql.DB) {
+	registerDB("shared_schema", "", dbPoolUUID, tidbCloudOrgID, db)
+}
+
 func registerDB(role, tenantID, dbPoolUUID, tidbCloudOrgID string, db *sql.DB) {
 	if db == nil {
 		return

--- a/pkg/mysqlutil/instrumented.go
+++ b/pkg/mysqlutil/instrumented.go
@@ -25,6 +25,15 @@ const (
 	// many tenants at once (fs_id row keys). Pool limits for this role must be
 	// sized for the whole cluster, not for one tenant.
 	RoleShared = "shared"
+	// RoleSharedSchema labels the short-lived handle that applies shared-schema
+	// bootstrap DDL to a physical shared DB, mirroring the RoleUser /
+	// RoleUserSchema split. Schema work — CREATE TABLE, ADD INDEX, contract
+	// repair, and the advisory lock that serializes them across pods — routinely
+	// blocks for seconds on TiDB, so it runs on its own handle instead of the
+	// RoleShared handle that serves tenant traffic. That keeps one cold pool
+	// open out of the shared data-plane latency series while leaving schema
+	// latency and failures observable under this role.
+	RoleSharedSchema = "shared_schema"
 )
 
 const (
@@ -49,6 +58,16 @@ func OpenInstrumentedForTenantWithOrg(ctx context.Context, dsn, role, tenantID, 
 func OpenInstrumentedForSharedDB(ctx context.Context, dsn, dbPoolUUID, tidbCloudOrgID string) (*sql.DB, error) {
 	return openInstrumented(ctx, dsn, RoleShared, func(db *sql.DB) {
 		metrics.RegisterSharedDBWithOrg(dbPoolUUID, tidbCloudOrgID, db)
+	})
+}
+
+// OpenInstrumentedForSharedSchemaDB opens the dedicated handle used to apply
+// shared-schema DDL to one physical shared DB. Callers close it as soon as the
+// schema ensure finishes; see RoleSharedSchema for why this work does not share
+// the data-plane handle.
+func OpenInstrumentedForSharedSchemaDB(ctx context.Context, dsn, dbPoolUUID, tidbCloudOrgID string) (*sql.DB, error) {
+	return openInstrumented(ctx, dsn, RoleSharedSchema, func(db *sql.DB) {
+		metrics.RegisterSharedSchemaDBWithOrg(dbPoolUUID, tidbCloudOrgID, db)
 	})
 }
 

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -21,7 +21,7 @@ const (
 	defaultUserSchemaConnMaxIdleTime = 20 * time.Second
 	defaultUserSchemaMaxOpenConns    = 8
 	defaultUserSchemaMaxIdleConns    = 2
-	// Shared-schema handles serve many tenants through one *sql.DB, so they
+	// Shared data-plane handles serve many tenants through one *sql.DB, so they
 	// get meta-like lifetimes and a much larger connection budget than
 	// per-tenant user pools.
 	defaultSharedConnMaxLifetime = 30 * time.Minute
@@ -35,6 +35,7 @@ const (
 	defaultSharedSchemaConnMaxIdleTime = 20 * time.Second
 	defaultSharedSchemaMaxOpenConns    = 12
 	defaultSharedSchemaMaxIdleConns    = 4
+	sharedSchemaMinOpenConns           = 2 // one pinned advisory-lock connection plus schema work
 )
 
 // ApplyPoolDefaults rotates and prunes idle connections before common LB/NAT
@@ -58,6 +59,9 @@ func ApplyPoolDefaults(db *sql.DB, role string) {
 	db.SetConnMaxIdleTime(idleTime)
 	maxOpen, maxIdle := defaultPoolLimits(role)
 	if v := poolEnvInt(role, "MAX_OPEN_CONNS", maxOpen); v > 0 {
+		if role == RoleSharedSchema && v < sharedSchemaMinOpenConns {
+			v = sharedSchemaMinOpenConns
+		}
 		db.SetMaxOpenConns(v)
 	}
 	if v := poolEnvInt(role, "MAX_IDLE_CONNS", maxIdle); v >= 0 {

--- a/pkg/mysqlutil/pool.go
+++ b/pkg/mysqlutil/pool.go
@@ -28,6 +28,13 @@ const (
 	defaultSharedConnMaxIdleTime = 5 * time.Minute
 	defaultSharedMaxOpenConns    = 300
 	defaultSharedMaxIdleConns    = 50
+	// Shared-schema handles live only for one schema ensure, so they get short
+	// lifetimes. The open budget covers the DDL fan-out (table groups) and the
+	// contract diff workers plus the connection that holds the advisory lock.
+	defaultSharedSchemaConnMaxLifetime = 3 * time.Minute
+	defaultSharedSchemaConnMaxIdleTime = 20 * time.Second
+	defaultSharedSchemaMaxOpenConns    = 12
+	defaultSharedSchemaMaxIdleConns    = 4
 )
 
 // ApplyPoolDefaults rotates and prunes idle connections before common LB/NAT
@@ -41,6 +48,7 @@ const (
 //   - DRIVE9_USER_SCHEMA_DB_MAX_OPEN_CONNS / DRIVE9_USER_SCHEMA_DB_MAX_IDLE_CONNS
 //   - DRIVE9_SHARED_DB_MAX_OPEN_CONNS / DRIVE9_SHARED_DB_MAX_IDLE_CONNS
 //   - DRIVE9_SHARED_DB_CONN_MAX_LIFETIME / DRIVE9_SHARED_DB_CONN_MAX_IDLE_TIME
+//   - DRIVE9_SHARED_SCHEMA_DB_MAX_OPEN_CONNS / DRIVE9_SHARED_SCHEMA_DB_MAX_IDLE_CONNS
 //
 // The limits apply to each *sql.DB pool. In a multi-pod deployment, size them
 // against TiDB max_connections and the expected number of active shared pools.
@@ -74,6 +82,8 @@ func defaultPoolLifetime(role string) (time.Duration, time.Duration) {
 		return defaultUserSchemaConnMaxLifetime, defaultUserSchemaConnMaxIdleTime
 	case RoleShared:
 		return defaultSharedConnMaxLifetime, defaultSharedConnMaxIdleTime
+	case RoleSharedSchema:
+		return defaultSharedSchemaConnMaxLifetime, defaultSharedSchemaConnMaxIdleTime
 	default:
 		return defaultMetaConnMaxLifetime, defaultMetaConnMaxIdleTime
 	}
@@ -89,6 +99,8 @@ func defaultPoolLimits(role string) (int, int) {
 		return defaultUserSchemaMaxOpenConns, defaultUserSchemaMaxIdleConns
 	case RoleShared:
 		return defaultSharedMaxOpenConns, defaultSharedMaxIdleConns
+	case RoleSharedSchema:
+		return defaultSharedSchemaMaxOpenConns, defaultSharedSchemaMaxIdleConns
 	default:
 		return 0, 0
 	}
@@ -129,6 +141,8 @@ func rolePoolEnvKey(role, suffix string) string {
 		return "DRIVE9_USER_SCHEMA_DB_" + suffix
 	case RoleShared:
 		return "DRIVE9_SHARED_DB_" + suffix
+	case RoleSharedSchema:
+		return "DRIVE9_SHARED_SCHEMA_DB_" + suffix
 	default:
 		return ""
 	}

--- a/pkg/mysqlutil/pool_test.go
+++ b/pkg/mysqlutil/pool_test.go
@@ -1,6 +1,7 @@
 package mysqlutil
 
 import (
+	"database/sql"
 	"testing"
 	"time"
 )
@@ -126,6 +127,20 @@ func TestSharedSchemaPoolEnvOverridesLimits(t *testing.T) {
 	t.Setenv("DRIVE9_SHARED_DB_MAX_OPEN_CONNS", "77")
 	if got := poolEnvInt(RoleSharedSchema, "MAX_OPEN_CONNS", defaultSharedSchemaMaxOpenConns); got != 3 {
 		t.Fatalf("shared schema max open after shared override = %d, want 3", got)
+	}
+}
+
+func TestSharedSchemaPoolRequiresTwoConnections(t *testing.T) {
+	t.Setenv("DRIVE9_SHARED_SCHEMA_DB_MAX_OPEN_CONNS", "1")
+	db, err := sql.Open("mysql", "")
+	if err != nil {
+		t.Fatalf("open sql db: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ApplyPoolDefaults(db, RoleSharedSchema)
+	if got := db.Stats().MaxOpenConnections; got != 2 {
+		t.Fatalf("shared schema max open = %d, want 2 to reserve one connection for the advisory lock", got)
 	}
 }
 

--- a/pkg/mysqlutil/pool_test.go
+++ b/pkg/mysqlutil/pool_test.go
@@ -101,6 +101,43 @@ func TestDefaultPoolLimits(t *testing.T) {
 	if maxOpen != 300 || maxIdle != 50 {
 		t.Fatalf("shared limits = %d/%d, want 300/50", maxOpen, maxIdle)
 	}
+
+	// The schema handle only serves one ensure at a time, so it must not claim a
+	// data-plane sized budget against the same physical DB.
+	maxOpen, maxIdle = defaultPoolLimits(RoleSharedSchema)
+	if maxOpen != defaultSharedSchemaMaxOpenConns {
+		t.Fatalf("shared schema max open = %d, want %d", maxOpen, defaultSharedSchemaMaxOpenConns)
+	}
+	if maxIdle != defaultSharedSchemaMaxIdleConns {
+		t.Fatalf("shared schema max idle = %d, want %d", maxIdle, defaultSharedSchemaMaxIdleConns)
+	}
+	if maxOpen >= defaultSharedMaxOpenConns {
+		t.Fatalf("shared schema max open = %d, want well under the shared budget %d", maxOpen, defaultSharedMaxOpenConns)
+	}
+}
+
+func TestSharedSchemaPoolEnvOverridesLimits(t *testing.T) {
+	t.Setenv("DRIVE9_SHARED_SCHEMA_DB_MAX_OPEN_CONNS", "3")
+
+	if got := poolEnvInt(RoleSharedSchema, "MAX_OPEN_CONNS", defaultSharedSchemaMaxOpenConns); got != 3 {
+		t.Fatalf("shared schema max open = %d, want 3", got)
+	}
+	// The shared data-plane knob must not bleed into the schema handle.
+	t.Setenv("DRIVE9_SHARED_DB_MAX_OPEN_CONNS", "77")
+	if got := poolEnvInt(RoleSharedSchema, "MAX_OPEN_CONNS", defaultSharedSchemaMaxOpenConns); got != 3 {
+		t.Fatalf("shared schema max open after shared override = %d, want 3", got)
+	}
+}
+
+func TestDefaultPoolLifetimeSharedSchemaIsShortLived(t *testing.T) {
+	lifetime, idleTime := defaultPoolLifetime(RoleSharedSchema)
+	if lifetime != defaultSharedSchemaConnMaxLifetime || idleTime != defaultSharedSchemaConnMaxIdleTime {
+		t.Fatalf("shared schema lifetimes = %v/%v, want %v/%v",
+			lifetime, idleTime, defaultSharedSchemaConnMaxLifetime, defaultSharedSchemaConnMaxIdleTime)
+	}
+	if lifetime >= defaultSharedConnMaxLifetime {
+		t.Fatalf("shared schema lifetime = %v, want shorter than the shared handle %v", lifetime, defaultSharedConnMaxLifetime)
+	}
 }
 
 func TestSharedPoolDurationEnv(t *testing.T) {

--- a/pkg/tenant/pool.go
+++ b/pkg/tenant/pool.go
@@ -1204,29 +1204,17 @@ func (p *Pool) sharedDBHandleWithSchemaLockWait(ctx context.Context, dbID int64,
 	// An empty TLSMode means a plain connection (local/self-hosted databases);
 	// shared DBs on TiDB Cloud are registered with tls=skip-verify or tls=true.
 	dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?%s", info.User, string(pass), info.Host, info.Port, info.Name, query)
+	// Bootstrap the schema before the data-plane handle exists, on a handle of
+	// its own, so multi-second DDL and lock waits never land in the
+	// role="shared" series that data-plane latency alerts read.
+	if info.SchemaVersion != schema.CurrentSharedTiDBSchemaVersion {
+		if err := p.ensureSharedDBSchemaOnce(ctx, dsn, info, dbID, waitForSchemaLock); err != nil {
+			return nil, fmt.Errorf("shared db %d: %w", dbID, err)
+		}
+	}
 	db, err := mysqlutil.OpenInstrumentedForSharedDB(ctx, dsn, info.UUID, info.TiDBCloudOrganizationID)
 	if err != nil {
 		return nil, fmt.Errorf("shared db %d: open: %w", dbID, err)
-	}
-	if info.SchemaVersion != schema.CurrentSharedTiDBSchemaVersion {
-		if err := withSharedDBSchemaAdvisoryLock(ctx, db, dbID, waitForSchemaLock, func(lockCtx context.Context) error {
-			// Another pod may have completed the migration between the initial
-			// metadata read and this lock acquisition.
-			current, err := p.metaStore.GetSharedDB(lockCtx, dbID)
-			if err != nil {
-				return err
-			}
-			if current.SchemaVersion == schema.CurrentSharedTiDBSchemaVersion {
-				return nil
-			}
-			if err := ensureSharedDBSchema(lockCtx, db); err != nil {
-				return fmt.Errorf("ensure schema: %w", err)
-			}
-			return p.metaStore.UpdateSharedDBSchemaVersion(lockCtx, dbID, schema.CurrentSharedTiDBSchemaVersion)
-		}); err != nil {
-			_ = mysqlutil.CloseInstrumented(db)
-			return nil, fmt.Errorf("shared db %d: %w", dbID, err)
-		}
 	}
 	p.sharedMu.Lock()
 	if p.sharedDBClosed {
@@ -1242,6 +1230,33 @@ func (p *Pool) sharedDBHandleWithSchemaLockWait(ctx context.Context, dbID int64,
 	lease := p.leaseSharedDBLocked(dbID, db)
 	p.sharedMu.Unlock()
 	return lease, nil
+}
+
+// ensureSharedDBSchemaOnce applies the checked-in shared schema through a
+// dedicated handle opened with mysqlutil.RoleSharedSchema and closes it before
+// the data-plane handle is opened. The advisory lock runs on the same handle, so
+// both the lock wait and the DDL are attributed to schema work.
+func (p *Pool) ensureSharedDBSchemaOnce(ctx context.Context, dsn string, info *meta.SharedDB, dbID int64, waitForSchemaLock bool) error {
+	schemaDB, err := schema.OpenSharedSchemaDB(ctx, dsn, info.UUID, info.TiDBCloudOrganizationID)
+	if err != nil {
+		return fmt.Errorf("open schema handle: %w", err)
+	}
+	defer func() { _ = mysqlutil.CloseInstrumented(schemaDB) }()
+	return withSharedDBSchemaAdvisoryLock(ctx, schemaDB, dbID, waitForSchemaLock, func(lockCtx context.Context) error {
+		// Another pod may have completed the migration between the initial
+		// metadata read and this lock acquisition.
+		current, err := p.metaStore.GetSharedDB(lockCtx, dbID)
+		if err != nil {
+			return err
+		}
+		if current.SchemaVersion == schema.CurrentSharedTiDBSchemaVersion {
+			return nil
+		}
+		if err := ensureSharedDBSchema(lockCtx, schemaDB); err != nil {
+			return fmt.Errorf("ensure schema: %w", err)
+		}
+		return p.metaStore.UpdateSharedDBSchemaVersion(lockCtx, dbID, schema.CurrentSharedTiDBSchemaVersion)
+	})
 }
 
 // EnsureSharedDBReady opens the shared physical DB through the normal cache

--- a/pkg/tenant/schema/shared.go
+++ b/pkg/tenant/schema/shared.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/mysqlutil"
 	"go.uber.org/zap"
 )
 
@@ -74,17 +75,29 @@ func SharedSchemaStatementsForDB(ctx context.Context, db *sql.DB) ([]string, err
 // TiDB Cloud features — plain TiDB without columnar support rejects them — so
 // their failures are tolerated with a warning instead of failing init.
 func InitSharedSchema(ctx context.Context, dsn string) error {
-	db, err := OpenTiDBSchemaDB(ctx, dsn)
+	db, err := OpenSharedSchemaDB(ctx, dsn, "", "")
 	if err != nil {
 		return err
 	}
-	defer func() { _ = closeTiDBSchemaDB(db) }()
+	defer func() { _ = mysqlutil.CloseInstrumented(db) }()
 	return EnsureSharedSchema(ctx, db)
+}
+
+// OpenSharedSchemaDB opens the dedicated shared-schema DDL handle for dsn. It
+// carries mysqlutil.RoleSharedSchema rather than the tenant RoleUserSchema, so
+// shared bootstrap work is attributable to the physical pool it targets.
+func OpenSharedSchemaDB(ctx context.Context, dsn, dbPoolUUID, tidbCloudOrgID string) (*sql.DB, error) {
+	if HasMultiStatements(dsn) {
+		return nil, fmt.Errorf("multiStatements is not allowed")
+	}
+	return mysqlutil.OpenInstrumentedForSharedSchemaDB(ctx, dsn, dbPoolUUID, tidbCloudOrgID)
 }
 
 // EnsureSharedSchema applies the shared schema through an already-open
 // physical DB handle. This is used by the shared connection cache so schema
 // comparison and initialization happen once at DB-pool open time.
+// Callers pass a handle opened with mysqlutil.RoleSharedSchema so this DDL is
+// observed apart from the role="shared" data-plane series.
 func EnsureSharedSchema(ctx context.Context, db *sql.DB) error {
 	stmts, err := SharedSchemaStatementsForDB(ctx, db)
 	if err != nil {

--- a/pkg/tenant/schema/shared_test.go
+++ b/pkg/tenant/schema/shared_test.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"net/http/httptest"
+	"strconv"
 	"strings"
 	"testing"
 
 	"github.com/mem9-ai/drive9/internal/schemaspec"
 	"github.com/mem9-ai/drive9/internal/testmysql"
+	"github.com/mem9-ai/drive9/pkg/metrics"
+	"github.com/mem9-ai/drive9/pkg/mysqlutil"
 )
 
 // sharedSchemaTables lists the 30 tables of the shared (multi-tenant) schema
@@ -206,6 +210,61 @@ func TestEnsureSharedSchemaValidatesFreshSchema(t *testing.T) {
 	if err := EnsureSharedSchema(context.Background(), db); err != nil {
 		t.Fatalf("EnsureSharedSchema fresh database: %v", err)
 	}
+}
+
+// TestEnsureSharedSchemaReportsSchemaRoleMetrics pins the alerting contract for
+// Drive9SharedDBOperationP99High: init-schema DDL targets the same physical
+// shared database that serves tenant traffic, and it once ran on the
+// role="shared" data-plane handle. It now gets a handle of its own, so the DDL
+// must be observed under the shared_schema role and leave the shared
+// data-plane latency series untouched.
+func TestEnsureSharedSchemaReportsSchemaRoleMetrics(t *testing.T) {
+	ctx := context.Background()
+	db, err := OpenSharedSchemaDB(ctx, testDSN, "pool-uuid-shared-schema-metrics", "org-shared-schema-metrics")
+	if err != nil {
+		t.Fatalf("open shared schema db: %v", err)
+	}
+	t.Cleanup(func() { _ = mysqlutil.CloseInstrumented(db) })
+	dropSharedSchemaTables(t, db)
+	t.Cleanup(func() { dropSharedSchemaTables(t, db) })
+
+	sharedBefore := dbOperationCount(t, "exec", mysqlutil.RoleShared)
+	schemaBefore := dbOperationCount(t, "exec", mysqlutil.RoleSharedSchema)
+
+	if err := EnsureSharedSchema(ctx, db); err != nil {
+		t.Fatalf("EnsureSharedSchema: %v", err)
+	}
+
+	if got := dbOperationCount(t, "exec", mysqlutil.RoleSharedSchema) - schemaBefore; got <= 0 {
+		t.Fatalf("shared_schema exec operations recorded = %v, want > 0", got)
+	}
+	if got := dbOperationCount(t, "exec", mysqlutil.RoleShared) - sharedBefore; got != 0 {
+		t.Fatalf("shared exec operations recorded during schema ensure = %v, want 0", got)
+	}
+}
+
+// dbOperationCount sums drive9_db_operations_total across every result label for
+// one operation/role pair.
+func dbOperationCount(t *testing.T, operation, role string) float64 {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	metrics.WritePrometheus(rec)
+	total := 0.0
+	for _, line := range strings.Split(rec.Body.String(), "\n") {
+		if !strings.HasPrefix(line, "drive9_db_operations_total{") {
+			continue
+		}
+		if !strings.Contains(line, `operation="`+operation+`"`) || !strings.Contains(line, `role="`+role+`"`) {
+			continue
+		}
+		fields := strings.Fields(line)
+		value, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		if err != nil {
+			t.Fatalf("parse metric line %q: %v", line, err)
+		}
+		total += value
+	}
+	return total
 }
 
 func dropSharedSchemaTables(t *testing.T, db interface {

--- a/pkg/tenant/schema/shared_test.go
+++ b/pkg/tenant/schema/shared_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"errors"
+	"fmt"
 	"net/http/httptest"
 	"strconv"
 	"strings"
@@ -243,6 +244,28 @@ func TestEnsureSharedSchemaReportsSchemaRoleMetrics(t *testing.T) {
 	}
 }
 
+func TestPrometheusSampleValueUsesTheSampleNotTimestampOrExemplar(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		line string
+		want float64
+	}{
+		{name: "plain", line: `drive9_db_operations_total{role="shared"} 3`, want: 3},
+		{name: "timestamp", line: `drive9_db_operations_total{role="shared"} 3 1722247200000`, want: 3},
+		{name: "exemplar", line: `drive9_db_operations_total{role="shared"} 3 # {trace_id="abc"} 1.5`, want: 3},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, err := prometheusSampleValue(test.line)
+			if err != nil {
+				t.Fatalf("prometheusSampleValue(%q): %v", test.line, err)
+			}
+			if got != test.want {
+				t.Fatalf("prometheusSampleValue(%q) = %v, want %v", test.line, got, test.want)
+			}
+		})
+	}
+}
+
 // dbOperationCount sums drive9_db_operations_total across every result label for
 // one operation/role pair.
 func dbOperationCount(t *testing.T, operation, role string) float64 {
@@ -257,14 +280,21 @@ func dbOperationCount(t *testing.T, operation, role string) float64 {
 		if !strings.Contains(line, `operation="`+operation+`"`) || !strings.Contains(line, `role="`+role+`"`) {
 			continue
 		}
-		fields := strings.Fields(line)
-		value, err := strconv.ParseFloat(fields[len(fields)-1], 64)
+		value, err := prometheusSampleValue(line)
 		if err != nil {
 			t.Fatalf("parse metric line %q: %v", line, err)
 		}
 		total += value
 	}
 	return total
+}
+
+func prometheusSampleValue(line string) (float64, error) {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0, fmt.Errorf("metric line has no sample value")
+	}
+	return strconv.ParseFloat(fields[1], 64)
 }
 
 func dropSharedSchemaTables(t *testing.T, db interface {


### PR DESCRIPTION
## Summary
- run shared schema DDL and advisory-lock waits on a short-lived `shared_schema` DB handle
- retain the long-lived `shared` handle exclusively for shared tenant data-plane traffic
- add role/pool-limit coverage and assert schema DDL does not enter the shared data-plane series

## Verification
- `make test TEST_PKGS="./pkg/mysqlutil/... ./pkg/metrics/... ./pkg/tenant/schema/... ./pkg/tenant/..."`
- `make lint`
- `make build-server`

No `docs/` files are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dedicated shared-schema database handling for schema initialization and migrations.
  * Added separate connection-pool settings and environment configuration for shared-schema operations.
  * Improved monitoring by reporting schema setup activity separately from regular database traffic.

* **Bug Fixes**
  * Prevented schema initialization waits and operations from being attributed to normal shared database activity.
  * Added safeguards against unsupported multi-statement connection configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->