### PR TITLE
feat(server): classify write client-cancel / deadline out of write_failed (task #198)

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2480,6 +2480,33 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 	})
 }
 
+const (
+	// writeResultClientCanceled is the low-cardinality metric result for a write
+	// whose backend error is a client-side cancellation (client closed the
+	// connection / cancelled the request context). It is deliberately NOT
+	// "ok"/"benign"/"info": a same-path supersede cancel can mask a lost update
+	// until durability is verified, so it is surfaced as needs-review, not
+	// silenced.
+	writeResultClientCanceled = "client_canceled"
+	// writeResultDeadlineExceeded is the metric result for a write whose backend
+	// error is a context deadline (distinct from a plain cancellation).
+	writeResultDeadlineExceeded = "deadline_exceeded"
+)
+
+// writeErrorTimingResult maps a write backend error to the server_write_timing
+// result label so timing rows are classified the same way as logs/metrics
+// (client_canceled / deadline_exceeded / error), instead of a generic "error".
+func writeErrorTimingResult(ctx context.Context, err error) string {
+	switch {
+	case isClientCanceled(ctx, err):
+		return writeResultClientCanceled
+	case errors.Is(err, context.DeadlineExceeded):
+		return writeResultDeadlineExceeded
+	default:
+		return "error"
+	}
+}
+
 func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string) {
 	timingEnabled := logger.BenchTimingLogEnabled()
 	var timingStart time.Time
@@ -2648,8 +2675,9 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		backendWriteDuration = time.Since(backendWriteStart)
 	}
 	if err != nil {
+		timingResult := writeErrorTimingResult(r.Context(), err)
 		if timingEnabled {
-			logServerWriteTiming(r.Context(), path, len(data), expectedRevision, 0, "error", bodyReadDuration, backendWriteDuration, responseDuration, time.Since(timingStart), err)
+			logServerWriteTiming(r.Context(), path, len(data), expectedRevision, 0, timingResult, bodyReadDuration, backendWriteDuration, responseDuration, time.Since(timingStart), err)
 		}
 		if errors.Is(err, backend.ErrUploadTooLarge) {
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_too_large_backend", "path", path, "error", err)...)
@@ -2671,6 +2699,25 @@ func (s *Server) handleWrite(w http.ResponseWriter, r *http.Request, path string
 		}
 		if errJSONInvalidRootDentry(w, err) {
 			metricEvent(r.Context(), "fs_write", "result", "error")
+			return
+		}
+		// Client-side cancellation and deadline are not server storage faults:
+		// classify them out of the generic Error-level write_failed so they stop
+		// polluting real storage-error alerts, while staying visible. A canceled
+		// write is warn + needs-review (NOT benign/info): a same-path supersede
+		// cancel could mask a lost update until durability is verified, so it must
+		// not be silenced. The response status is unchanged (backendErrorStatus
+		// already maps these to 499 / 504).
+		if isClientCanceled(r.Context(), err) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_client_canceled", "path", path, "error", err)...)
+			metricEvent(r.Context(), "fs_write", "result", writeResultClientCanceled)
+			errJSONInternalStorage(w, r, err)
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "write_deadline_exceeded", "path", path, "error", err)...)
+			metricEvent(r.Context(), "fs_write", "result", writeResultDeadlineExceeded)
+			errJSONInternalStorage(w, r, err)
 			return
 		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "write_failed", "path", path, "error", err)...)
@@ -3232,7 +3279,23 @@ func (s *Server) handleBatchWrite(w http.ResponseWriter, r *http.Request) {
 
 	backendResults, err := b.BatchWriteCtx(r.Context(), backendItems)
 	if err != nil {
+		// Same classification as handleWrite: client cancellation / deadline are
+		// not server storage faults, so keep them out of the Error-level
+		// batch_write_failed alert while staying visible (warn + needs-review).
+		if isClientCanceled(r.Context(), err) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_write_client_canceled", "error", err)...)
+			metricEvent(r.Context(), "fs_batch_write", "result", writeResultClientCanceled)
+			errJSONInternalStorage(w, r, err)
+			return
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "batch_write_deadline_exceeded", "error", err)...)
+			metricEvent(r.Context(), "fs_batch_write", "result", writeResultDeadlineExceeded)
+			errJSONInternalStorage(w, r, err)
+			return
+		}
 		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "batch_write_failed", "error", err)...)
+		metricEvent(r.Context(), "fs_batch_write", "result", "error")
 		errJSONInternalStorage(w, r, err)
 		return
 	}

--- a/pkg/server/write_error_classification_test.go
+++ b/pkg/server/write_error_classification_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/backend"
+)
+
+// TestWriteErrorTimingResultClassification locks the write-error classification
+// used by handleWrite / batch_write for logs, metrics, and server_write_timing:
+// a client-cancelled write and a deadline-exceeded write are classified OUT of
+// the generic "error" bucket (so they stop polluting real storage-error
+// alerts), and they are classified DISTINCTLY from each other. Everything else
+// stays "error". (task #198 gate: adversary-1 pts 1/3/7, adversary-2 gate test.)
+func TestWriteErrorTimingResultClassification(t *testing.T) {
+	bg := context.Background()
+
+	// A context that is itself cancelled (models the client closing the
+	// connection so the inbound request ctx is Done) even when the returned err
+	// is a wrapped/opaque cancellation.
+	canceledCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cases := []struct {
+		name string
+		ctx  context.Context
+		err  error
+		want string
+	}{
+		{"plain canceled", bg, context.Canceled, writeResultClientCanceled},
+		{"wrapped canceled", bg, fmt.Errorf("backend put: %w", context.Canceled), writeResultClientCanceled},
+		{"canceled via ctx only", canceledCtx, errors.New("connection reset"), writeResultClientCanceled},
+		{"plain deadline", bg, context.DeadlineExceeded, writeResultDeadlineExceeded},
+		{"wrapped deadline", bg, fmt.Errorf("backend put: %w", context.DeadlineExceeded), writeResultDeadlineExceeded},
+		{"real storage error", bg, errors.New("s3: internal error"), "error"},
+		{"sentinel upload too large", bg, backend.ErrUploadTooLarge, "error"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := writeErrorTimingResult(tc.ctx, tc.err); got != tc.want {
+				t.Fatalf("writeErrorTimingResult = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestWriteCanceledIsNotErrorBucket enforces adversary-1 pt 7: a client-cancelled
+// write must NOT be classified as the generic "error" (Error-level write_failed)
+// bucket, and cancellation must be classified separately from deadline.
+func TestWriteCanceledIsNotErrorBucket(t *testing.T) {
+	if writeResultClientCanceled == "error" {
+		t.Fatal("client-canceled must not reuse the generic 'error' result (would keep polluting Error-level write_failed alerts)")
+	}
+	if writeResultClientCanceled == writeResultDeadlineExceeded {
+		t.Fatal("client-canceled and deadline-exceeded must be classified distinctly")
+	}
+}
+
+// TestWriteCanceledResultIsNeedsReviewNotBenign is the safety gate (adversary-2):
+// the client-canceled classification MUST NOT be downgraded to a benign/ok/info
+// label. A same-path supersede cancel can mask a lost update until durability is
+// verified, so it must remain a needs-review signal. This test fails loudly if a
+// future change silences it.
+func TestWriteCanceledResultIsNeedsReviewNotBenign(t *testing.T) {
+	forbidden := map[string]bool{"ok": true, "benign": true, "info": true, "success": true, "": true}
+	if forbidden[writeResultClientCanceled] {
+		t.Fatalf("writeResultClientCanceled = %q must express needs-review, not a benign/ok/info label", writeResultClientCanceled)
+	}
+	if forbidden[writeResultDeadlineExceeded] {
+		t.Fatalf("writeResultDeadlineExceeded = %q must not be a benign/ok/info label", writeResultDeadlineExceeded)
+	}
+}


### PR DESCRIPTION
## What

Server `write_failed` "context canceled" logs are **client-side cancellations**, not server storage faults — e.g. FUSE writeback same-path supersede cancelling an in-flight commit (`lockWritableRemoteCommitPath` → `CancelPath` after `RemoteCommitWaitTimeout`), or a FUSE op INTERRUPT/unmount cancelling a sync upload. They were logged at **Error** level as generic `write_failed` + metric `result="error"`, polluting real storage-error alerts and hiding the true client-cancel rate.

This classifies the `handleWrite` / `batch_write` backend error into three buckets for **logs, metrics, and `server_write_timing.result`**:
- `context.Canceled` → warn `write_client_canceled`, result `client_canceled`
- `context.DeadlineExceeded` → warn `write_deadline_exceeded`, result `deadline_exceeded`
- other → unchanged: Error-level `write_failed`, result `error`

## Why needs-review, not benign

The `client_canceled` classification is deliberately **needs-review, NOT benign/ok/info**: a same-path supersede cancel can mask a lost update until the durability/inversion question is resolved, so it stays visible (warn + a dedicated low-cardinality metric label) and must not be silenced. A test (`TestWriteCanceledResultIsNeedsReviewNotBenign`) fails loudly if a future change downgrades it.

## Constraints honored (task #198 gate)

- User-visible API/status contract **unchanged** — `backendErrorStatus` already maps canceled→499 / deadline→504; this is log/metric/timing only.
- Metric labels stay **low-cardinality** (`result` only; no path/tenant_id/api_key_id).
- Scope limited to `handleWrite` (2676) + `batch_write` (3282); no other handlers.
- `handlePatch` / `patch_unsupported_target` is **out of scope** (task #199) — the FUSE `PatchFile` path has no rewrite fallback and is a separate storage-class mismatch; this PR does NOT reuse that (incorrect) "transparently benign" premise.

## Tests

`pkg/server/write_error_classification_test.go`:
- `writeErrorTimingResult` table: plain/wrapped `context.Canceled`, cancel-via-ctx-only, plain/wrapped `context.DeadlineExceeded`, real storage error, sentinel → correct bucket.
- `context.Canceled` is NOT the generic `error` bucket and is distinct from deadline.
- Safety gate: `client_canceled` / `deadline_exceeded` must not be a benign/ok/info label.

Note: `pkg/server` `TestMain` starts a MySQL testcontainer, so these run in CI (not locally without Docker). `go vet ./pkg/server/` + gofmt clean locally.

Investigation & acceptance gate: task #198 (adversary-1) + adversary-2. Related: #199 (patch_unsupported / dev2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved write-operation error reporting by distinguishing client cancellations and request timeouts from other storage failures.
  * Added clearer warning logs and metrics for canceled and timed-out writes, including batch writes.
  * Preserved generic error handling for unrelated storage failures.

* **Tests**
  * Added coverage for canceled, timed-out, wrapped, and generic write errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->