### PR TITLE
fix(fuse): route PATCH by server storage class, fall back to full upload on 400

### DIFF
--- a/.github/workflows/local-e2e.yml
+++ b/.github/workflows/local-e2e.yml
@@ -290,6 +290,10 @@ jobs:
           RUN_FUSE_POSIX_FSX: "0"
         run: bash e2e/fuse-release-gate.sh
 
+      - name: Run FUSE patch storage-class e2e
+        id: fuse-patch-storage-class
+        run: bash e2e/fuse-patch-storage-class.sh
+
       - name: Run Git operations smoke
         id: git-ops-smoke
         continue-on-error: true
@@ -427,6 +431,7 @@ jobs:
             echo "| CLI smoke | ${{ steps.cli-smoke.outcome || 'skipped' }} |"
             echo "| Layer FS smoke | ${{ steps.layer-fs-smoke.outcome || 'skipped' }} |"
             echo "| FUSE release gate | ${{ steps.fuse-smoke.outcome || 'skipped' }} |"
+            echo "| FUSE patch storage-class e2e | ${{ steps.fuse-patch-storage-class.outcome || 'skipped' }} |"
             echo "| Git operations smoke | ${{ steps.git-ops-smoke.outcome || 'skipped' }} |"
             echo "| Pack smoke | ${{ steps.pack-smoke.outcome || 'skipped' }} |"
             echo "| FUSE crash recovery e2e | ${{ steps.fuse-crash-recovery.outcome || 'skipped' }} |"
@@ -469,6 +474,7 @@ jobs:
             "cli-smoke": "${{ steps.cli-smoke.outcome }}",
             "layer-fs-smoke": "${{ steps.layer-fs-smoke.outcome }}",
             "fuse-smoke": "${{ steps.fuse-smoke.outcome }}",
+            "fuse-patch-storage-class": "${{ steps.fuse-patch-storage-class.outcome }}",
             "git-ops-smoke": "${{ steps.git-ops-smoke.outcome }}",
             "pack-smoke": "${{ steps.pack-smoke.outcome }}",
             "fuse-crash-recovery": "${{ steps.fuse-crash-recovery.outcome }}",

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -494,6 +494,28 @@ bash e2e/git-feature-smoke-test.sh
 POSIX pjdfstest lives in blackbox (`community.pjdfstest`), not under `e2e/`.
 
 
+### `fuse-patch-storage-class.sh`
+
+Host support: Linux and macOS only. This script needs real FUSE support and is
+targeted regression coverage for PATCH-vs-storage-class mismatches
+(`patch_unsupported_target`), not a general filesystem workload.
+
+1. Starts its own MySQL container and `drive9-server-local` with a high
+   `DRIVE9_INLINE_THRESHOLD`, seeds a file that lands inline (db9), then
+   restarts the server with a low threshold so the mount's cached threshold is
+   below the file size while the object stays db9-stored
+2. Mounts with `--mode=fuse --durability write-sync` and partially overwrites
+   the file at the same size
+3. Default `fixed` scenario: stat header advertises `db9`, zero PATCH attempts
+   (storage class seeded from the header), committed bytes correct, storage
+   healed to `s3`
+4. Manual cross-version scenarios: `SCENARIO=repro` replays the pre-fix EINVAL
+   loop with main-built binaries; `SCENARIO=fallback` runs the fixed client
+   against an old server binary (no storage-type header) and asserts exactly
+   one PATCH attempt before the full-upload fallback commits
+5. Override binaries with `DRIVE9_SERVER_BIN` / `DRIVE9_CLI_BIN`; default
+   binaries are built from the checkout when missing
+
 ### `fuse-release-gate.sh`
 
 1. Runs `fuse-smoke-test.sh` with `FUSE_STRICT_PREREQS=1`

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,6 +28,7 @@ including local single-tenant validation via `drive9-server-local`.
 | `git-ops-smoke-test.sh` | Lightweight local Git gate using a local bare fixture: native clone, `drive9 git clone --fast`, and `drive9 git clone --fast --blobless` across `coding-agent` and `portable` profiles, followed by edit/add/commit/stash, remount into a fresh local root, and Git state/content verification |
 | `fuse-crash-recovery-test.sh` | FUSE crash-recovery gate: fsync'd small files plus a large mid-upload ShadowSpill survive `kill -9` of the mount daemon, recovered commits converge remotely, unlinked files do not resurrect, and the journal WAL compacts after a clean remount |
 | `fuse-write-perf-budget-test.sh` | FUSE write-path perf budgets: fsync-heavy workload with deterministic op-count budgets (remote writes/stats/lists/mutations, commit retries/failures) plus an fsync latency ceiling, asserted from mount perf counters |
+| `fuse-patch-storage-class.sh` | PATCH-vs-storage-class mismatch (`patch_unsupported_target`) regression: seeds a db9-stored file above the restarted server's inline threshold, then partially overwrites it through a FUSE mount. Default `fixed` scenario asserts zero PATCH attempts, correct committed bytes, and storage heal to S3; `SCENARIO=repro`/`fallback` with `DRIVE9_SERVER_BIN`/`DRIVE9_CLI_BIN` overrides replay the pre-fix EINVAL loop and the old-server fallback locally |
 | `git-workspace-smoke-test.sh` | Git workspace fast-blobless clone with coding-agent local overlay, batched tracked-file edits, ignored local-only paths, `git add`/`commit`, `git apply`, and remount restore |
 | `posix-permission-smoke-test.sh` | POSIX permission coverage: API mkdir/chmod mode propagation, CLI `fs chmod`, FUSE `chmod`/`mkdir -m` with remote and local stat parity |
 | `native-smoke-test.sh` | TiDB Cloud Native tenant lifecycle: CLI provision with credentials, status poll, basic fs ops (mkdir/cp/cat/ls/rm), delete + verification, trap cleanup on failure |
@@ -42,7 +43,7 @@ without adding it to `.github/workflows/local-e2e.yml`.
 
 | Tier | Trigger | What runs |
 |------|---------|-----------|
-| PR gate | `pull_request` to `main` (local-e2e) | api, cli, layer-fs, fuse-release-gate (smoke + correctness + sqlite rollback), git-ops, portable pack/unpack, fuse-crash-recovery, fuse-write-perf-budget |
+| PR gate | `pull_request` to `main` (local-e2e) | api, cli, layer-fs, fuse-release-gate (smoke + correctness + sqlite rollback), fuse-patch-storage-class, git-ops, portable pack/unpack, fuse-crash-recovery, fuse-write-perf-budget |
 | Post-merge | `push` to `main` (local-e2e, coalesced via concurrency group) | PR gate + concurrency stress, POSIX/fsx, sqlite WAL/churn/concurrency, full `smoke-all.sh` (journal, posix-permission, git-workspace), git feature smoke |
 | Nightly | cron 20:17 UTC (local-e2e) | Post-merge set + FUSE performance baseline/archive/compare (compare is report-only; hosted-runner noise) |
 | Manual all | `e2e-all` workflow (`Run workflow` button) | Everything above via `run_all_e2e=1` |

--- a/e2e/fuse-patch-storage-class.sh
+++ b/e2e/fuse-patch-storage-class.sh
@@ -1,0 +1,368 @@
+#!/usr/bin/env bash
+# e2e/fuse-patch-storage-class.sh — PATCH-vs-storage-class mismatch
+# (server-side patch_unsupported_target) reproduction and fix verification.
+#
+# Construction (no DB surgery): the server is first started with a HIGH
+# DRIVE9_INLINE_THRESHOLD so a 200KB seed file is stored inline (db9). The
+# server is then restarted against the same database with a LOW threshold, so
+# a freshly mounted client caches a threshold below the file size while the
+# object remains db9-stored. A partial overwrite at the same size then makes
+# the client's size heuristic select PATCH, which the server rejects with
+# 400 "file is not S3-stored".
+#
+# Scenarios (SCENARIO env, default "fixed"):
+#   repro    — pre-fix expectation: the mounted write/fsync fails with EINVAL,
+#              remote content is never committed, and every flush attempt logs
+#              patch_unsupported_target (use with main-built binaries).
+#   fallback — fixed client + OLD server (no X-Dat9-Storage-Type header):
+#              exactly one PATCH attempt, then a full-upload fallback commits
+#              the data and heals the object to S3.
+#   fixed    — fixed client + fixed server: the stat header seeds the storage
+#              class, so PATCH is never attempted and the write succeeds.
+#
+# Binaries default to the repo builds (bin/drive9-server-local, bin/drive9);
+# override with DRIVE9_SERVER_BIN / DRIVE9_CLI_BIN for cross-version runs.
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+SCENARIO="${SCENARIO:-fixed}"
+SERVER_BIN="${DRIVE9_SERVER_BIN:-$ROOT_DIR/bin/drive9-server-local}"
+CLI_BIN="${DRIVE9_CLI_BIN:-$ROOT_DIR/bin/drive9}"
+
+SEED_THRESHOLD="${SEED_THRESHOLD:-262144}"   # 256 KiB: seed file lands inline
+PATCH_THRESHOLD="${PATCH_THRESHOLD:-51200}"  # 50 KiB: below seed size
+SEED_SIZE="${SEED_SIZE:-204800}"             # 200 KiB
+WRITE_OFFSET="${WRITE_OFFSET:-65536}"
+WRITE_BYTES="${WRITE_BYTES:-4096}"
+
+DB_RUNTIME="${DRIVE9_LOCAL_E2E_DB_RUNTIME:-}"
+DB_IMAGE="${DRIVE9_LOCAL_E2E_DB_IMAGE:-mysql:8.4}"
+DB_NAME="${DRIVE9_LOCAL_E2E_DB_NAME:-drive9_local}"
+DB_PASSWORD="${DRIVE9_LOCAL_E2E_DB_PASSWORD:-drive9pass}"
+LOCAL_API_KEY="${DRIVE9_LOCAL_API_KEY:-local-dev-key}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-90}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-1}"
+MOUNT_READY_TIMEOUT_S="${MOUNT_READY_TIMEOUT_S:-20}"
+
+PASS=0
+FAIL=0
+DB_CONTAINER=""
+SERVER_PID=""
+MOUNT_POINT=""
+TMP_DIR="$(mktemp -d)"
+
+check() { # check <label> <expected> <actual>
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "PASS: $label"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL: $label (expected=$expected actual=$actual)"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+cleanup() {
+  local rc=$?
+  if [ -n "$MOUNT_POINT" ]; then
+    env HOME="$E2E_HOME" DRIVE9_SERVER="${PUBLIC_URL:-}" DRIVE9_API_KEY="$LOCAL_API_KEY" \
+      "$CLI_BIN" umount "$MOUNT_POINT" >/dev/null 2>&1 || umount "$MOUNT_POINT" >/dev/null 2>&1 || true
+  fi
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  if [ -n "$DB_CONTAINER" ]; then
+    "$DB_RUNTIME" rm -f "$DB_CONTAINER" >/dev/null 2>&1 || true
+  fi
+  if [ "$rc" -eq 0 ] && [ "$FAIL" -eq 0 ]; then
+    rm -rf "$TMP_DIR"
+  else
+    echo "Preserving artifacts at $TMP_DIR" >&2
+  fi
+  if [ "$FAIL" -gt 0 ]; then
+    exit 1
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+need_cmd() { command -v "$1" >/dev/null 2>&1 || { echo "missing required command: $1" >&2; exit 1; }; }
+
+pick_port() {
+  python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(("127.0.0.1", 0))
+print(s.getsockname()[1])
+s.close()
+PY
+}
+
+detect_runtime() {
+  if [ -n "$DB_RUNTIME" ]; then
+    need_cmd "$DB_RUNTIME"
+    return
+  fi
+  if command -v docker >/dev/null 2>&1; then DB_RUNTIME="docker"; return; fi
+  if command -v podman >/dev/null 2>&1; then DB_RUNTIME="podman"; return; fi
+  echo "docker or podman is required" >&2
+  exit 1
+}
+
+start_mysql() {
+  detect_runtime
+  DB_CONTAINER="drive9-patch-e2e-$(date +%s)-$$"
+  echo "Starting $DB_RUNTIME container $DB_CONTAINER"
+  "$DB_RUNTIME" run -d --name "$DB_CONTAINER" \
+    -e MYSQL_ROOT_PASSWORD="$DB_PASSWORD" \
+    -e MYSQL_DATABASE="$DB_NAME" \
+    -p 127.0.0.1::3306 "$DB_IMAGE" >/dev/null
+  local deadline port
+  deadline=$(($(date +%s) + POLL_TIMEOUT_S))
+  while :; do
+    port=$("$DB_RUNTIME" port "$DB_CONTAINER" 3306/tcp 2>/dev/null | awk -F: 'END{print $NF}')
+    [ -n "$port" ] && break
+    [ "$(date +%s)" -ge "$deadline" ] && { echo "timed out waiting for container port" >&2; exit 1; }
+    sleep "$POLL_INTERVAL_S"
+  done
+  while :; do
+    "$DB_RUNTIME" exec "$DB_CONTAINER" mysqladmin ping -uroot -p"$DB_PASSWORD" --silent >/dev/null 2>&1 && break
+    [ "$(date +%s)" -ge "$deadline" ] && { echo "timed out waiting for MySQL" >&2; exit 1; }
+    sleep "$POLL_INTERVAL_S"
+  done
+  # mysqladmin ping succeeds inside the container before the host-side port
+  # mapping serves real connections; wait until the mapped port completes a
+  # genuine MySQL handshake (server sends a greeting packet), not just a TCP
+  # accept that gets dropped during init.
+  while :; do
+    if python3 - "$port" <<'PY' >/dev/null 2>&1
+import socket, sys
+s = socket.create_connection(("127.0.0.1", int(sys.argv[1])), timeout=2)
+s.settimeout(3)
+data = s.recv(64)
+s.close()
+sys.exit(0 if len(data) > 4 else 1)
+PY
+    then
+      break
+    fi
+    [ "$(date +%s)" -ge "$deadline" ] && { echo "timed out waiting for MySQL handshake on port $port" >&2; exit 1; }
+    sleep "$POLL_INTERVAL_S"
+  done
+  DRIVE9_LOCAL_DSN="root:${DB_PASSWORD}@tcp(127.0.0.1:${port})/${DB_NAME}?parseTime=true"
+  export DRIVE9_LOCAL_DSN
+}
+
+wait_server() {
+  local deadline
+  deadline=$(($(date +%s) + POLL_TIMEOUT_S))
+  while :; do
+    if [ "$(curl -sS -o /dev/null -w '%{http_code}' "$PUBLIC_URL/healthz" 2>/dev/null || true)" = "200" ]; then
+      return
+    fi
+    if ! kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+      echo "drive9-server-local exited early; log tail:" >&2
+      tail -50 "$SERVER_LOG" >&2 || true
+      exit 1
+    fi
+    [ "$(date +%s)" -ge "$deadline" ] && { echo "timed out waiting for healthz" >&2; exit 1; }
+    sleep "$POLL_INTERVAL_S"
+  done
+}
+
+start_server() { # start_server <threshold> <init_schema>
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" >/dev/null 2>&1; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+  env \
+    DRIVE9_LISTEN_ADDR="$LISTEN_ADDR" \
+    DRIVE9_PUBLIC_URL="$PUBLIC_URL" \
+    DRIVE9_LOCAL_DSN="$DRIVE9_LOCAL_DSN" \
+    DRIVE9_LOCAL_INIT_SCHEMA="$2" \
+    DRIVE9_LOCAL_EMBEDDING_MODE=none \
+    DRIVE9_LOCAL_API_KEY="$LOCAL_API_KEY" \
+    DRIVE9_S3_DIR="$TMP_DIR/s3" \
+    DRIVE9_INLINE_THRESHOLD="$1" \
+    DRIVE9_LOG_LEVEL=warn \
+    "$SERVER_BIN" >>"$SERVER_LOG" 2>&1 &
+  SERVER_PID=$!
+  wait_server
+}
+
+is_mounted() {
+  # macOS reports the physical path (/private/var/...) while mktemp returns
+  # the /var/... symlink form; normalize both sides before comparing.
+  local mp="$1" phys
+  phys="$(cd "$(dirname "$mp")" 2>/dev/null && pwd -P)/$(basename "$mp")"
+  mount | awk -v mp="$mp" -v phys="$phys" '{for(i=1;i<=NF;i++) if($i=="on" && ($(i+1)==mp || $(i+1)==phys)) found=1} END{exit !found}'
+}
+
+wait_mount() {
+  local deadline
+  deadline=$(($(date +%s) + MOUNT_READY_TIMEOUT_S))
+  while :; do
+    if is_mounted "$MOUNT_POINT" && ls "$MOUNT_POINT" >/dev/null 2>&1; then
+      return
+    fi
+    [ "$(date +%s)" -ge "$deadline" ] && { echo "mount not ready at $MOUNT_POINT" >&2; exit 1; }
+    sleep 1
+  done
+}
+
+sha256_of() { shasum -a 256 "$1" | awk '{print $1}'; }
+
+need_cmd curl
+need_cmd python3
+need_cmd go
+need_cmd shasum
+
+# CI convenience: build the default binaries when absent. Explicitly overridden
+# binary paths must already exist.
+if [ -z "${DRIVE9_SERVER_BIN:-}" ] && [ ! -x "$SERVER_BIN" ]; then
+  echo "Building drive9-server-local"
+  make build-server-local
+fi
+if [ -z "${DRIVE9_CLI_BIN:-}" ] && [ ! -x "$CLI_BIN" ]; then
+  echo "Building drive9 CLI"
+  make build-cli
+fi
+need_cmd "$SERVER_BIN"
+need_cmd "$CLI_BIN"
+
+E2E_HOME="$TMP_DIR/home"
+mkdir -p "$E2E_HOME"
+
+start_mysql
+
+LISTEN_ADDR="127.0.0.1:$(pick_port)"
+PUBLIC_URL="http://${LISTEN_ADDR}"
+SERVER_LOG="$TMP_DIR/server.log"
+: >"$SERVER_LOG"
+
+REMOTE_PATH="/patch-e2e/seed.bin"
+SEED_FILE="$TMP_DIR/seed.bin"
+EXPECTED_FILE="$TMP_DIR/expected.bin"
+
+# Deterministic 200KB seed content.
+python3 - "$SEED_FILE" "$SEED_SIZE" <<'PY'
+import sys
+path, size = sys.argv[1], int(sys.argv[2])
+block = bytes(range(256)) * 1024
+with open(path, "wb") as f:
+    remaining = size
+    while remaining > 0:
+        chunk = block[: min(len(block), remaining)]
+        f.write(chunk)
+        remaining -= len(chunk)
+PY
+
+echo "=== phase 1: seed 200KB file with inline threshold $SEED_THRESHOLD (db9-stored)"
+start_server "$SEED_THRESHOLD" true
+code=$(curl -sS -o /dev/null -w '%{http_code}' -X PUT \
+  -H "Authorization: Bearer $LOCAL_API_KEY" \
+  --data-binary "@$SEED_FILE" \
+  "$PUBLIC_URL/v1/fs$REMOTE_PATH")
+check "seed PUT accepted" "200" "$code"
+
+seed_head=$(curl -sS -I -H "Authorization: Bearer $LOCAL_API_KEY" "$PUBLIC_URL/v1/fs$REMOTE_PATH")
+seed_storage=$(echo "$seed_head" | tr -d '\r' | grep -i '^x-dat9-storage-type:' | awk '{print $2}')
+if [ -n "$seed_storage" ]; then
+  check "seed file storage type advertised as db9" "db9" "$seed_storage"
+else
+  echo "INFO: server does not advertise X-Dat9-Storage-Type (old server binary)"
+fi
+
+echo "=== phase 2: restart server with inline threshold $PATCH_THRESHOLD"
+start_server "$PATCH_THRESHOLD" false
+PATCH_LOG_MARK=$(wc -l <"$SERVER_LOG" | tr -d ' ')
+
+echo "=== phase 3: mount with $(basename "$CLI_BIN") (durability=write-sync)"
+MOUNT_POINT="$TMP_DIR/mnt"
+mkdir -p "$MOUNT_POINT"
+env HOME="$E2E_HOME" DRIVE9_SERVER="$PUBLIC_URL" DRIVE9_API_KEY="$LOCAL_API_KEY" \
+  "$CLI_BIN" mount --mode=fuse --durability write-sync "$MOUNT_POINT" >"$TMP_DIR/mount.log" 2>&1 &
+wait_mount
+
+echo "=== phase 4: partial overwrite (${WRITE_BYTES}B @ ${WRITE_OFFSET}) + fsync"
+set +e
+write_err=$(python3 - "$MOUNT_POINT$REMOTE_PATH" "$WRITE_OFFSET" "$WRITE_BYTES" 2>&1 <<'PY'
+import os, sys
+path, offset, count = sys.argv[1], int(sys.argv[2]), int(sys.argv[3])
+payload = bytes((i * 7) % 256 for i in range(count))
+try:
+    fd = os.open(path, os.O_WRONLY)
+    try:
+        os.pwrite(fd, payload, offset)
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+except OSError as e:
+    print(f"errno={e.errno} ({e.strerror})")
+    sys.exit(1)
+PY
+)
+write_rc=$?
+set -e
+
+patch_count=$(tail -n +"$((PATCH_LOG_MARK + 1))" "$SERVER_LOG" | grep -c 'patch_unsupported_target' || true)
+
+case "$SCENARIO" in
+  repro)
+    check "mounted write fails pre-fix" "1" "$write_rc"
+    echo "INFO: write error: ${write_err:-none}"
+    if [ "$patch_count" -ge 1 ]; then
+      echo "PASS: server logged patch_unsupported_target ($patch_count time(s))"
+      PASS=$((PASS + 1))
+    else
+      echo "FAIL: expected patch_unsupported_target in server log"
+      FAIL=$((FAIL + 1))
+    fi
+    # The failed write must never have committed: remote content is the seed.
+    # GET follows redirects: S3-stored objects 302 to the (mock) S3 URL.
+  curl -sSL -H "Authorization: Bearer $LOCAL_API_KEY" "$PUBLIC_URL/v1/fs$REMOTE_PATH" -o "$TMP_DIR/remote.bin"
+    check "remote content unchanged (seed sha256)" "$(sha256_of "$SEED_FILE")" "$(sha256_of "$TMP_DIR/remote.bin")"
+    ;;
+  fallback)
+    check "mounted write succeeds via fallback" "0" "$write_rc"
+    echo "INFO: write error (want none): ${write_err:-none}"
+    check "exactly one PATCH attempt before fallback" "1" "$patch_count"
+    ;;
+  fixed)
+    check "mounted write succeeds" "0" "$write_rc"
+    echo "INFO: write error (want none): ${write_err:-none}"
+    check "no PATCH attempt (storage class seeded from header)" "0" "$patch_count"
+    ;;
+  *)
+    echo "unknown SCENARIO: $SCENARIO" >&2
+    exit 1
+    ;;
+esac
+
+if [ "$SCENARIO" != "repro" ]; then
+  # Expected content = seed with the overwritten block replaced.
+  python3 - "$SEED_FILE" "$EXPECTED_FILE" "$WRITE_OFFSET" "$WRITE_BYTES" <<'PY'
+import sys
+src, dst, offset, count = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+data = bytearray(open(src, "rb").read())
+data[offset:offset + count] = bytes((i * 7) % 256 for i in range(count))
+open(dst, "wb").write(data)
+PY
+  # GET follows redirects: S3-stored objects 302 to the (mock) S3 URL.
+  curl -sSL -H "Authorization: Bearer $LOCAL_API_KEY" "$PUBLIC_URL/v1/fs$REMOTE_PATH" -o "$TMP_DIR/remote.bin"
+  check "remote content matches expected post-write bytes" "$(sha256_of "$EXPECTED_FILE")" "$(sha256_of "$TMP_DIR/remote.bin")"
+
+  # The fallback uploaded 200KB >= the active threshold, healing the object to
+  # S3 when the server advertises storage type.
+  head_after=$(curl -sS -I -H "Authorization: Bearer $LOCAL_API_KEY" "$PUBLIC_URL/v1/fs$REMOTE_PATH")
+  storage_after=$(echo "$head_after" | tr -d '\r' | grep -i '^x-dat9-storage-type:' | awk '{print $2}')
+  if [ -n "$storage_after" ]; then
+    check "post-write storage type healed to s3" "s3" "$storage_after"
+  fi
+fi
+
+echo "=== done: $PASS passed, $FAIL failed (scenario=$SCENARIO)"

--- a/pkg/client/append.go
+++ b/pkg/client/append.go
@@ -181,7 +181,12 @@ func isClientNotFound(err error) bool {
 	return strings.HasPrefix(err.Error(), "not found: ")
 }
 
-func shouldRewriteAppend(err error) bool {
+// IsUnsupportedStorageTargetErr reports whether err is the server's 400
+// rejection of a partial-update operation (PATCH or append) because the
+// target file is not S3-stored (or S3 is not configured at all). Callers
+// should fall back to a full-content rewrite, which is valid for any storage
+// class.
+func IsUnsupportedStorageTargetErr(err error) bool {
 	var statusErr *StatusError
 	if !errors.As(err, &statusErr) {
 		return false
@@ -190,6 +195,19 @@ func shouldRewriteAppend(err error) bool {
 		return false
 	}
 	return strings.HasPrefix(statusErr.Message, "file is not S3-stored:") ||
-		strings.Contains(statusErr.Message, "S3 not configured") ||
-		strings.Contains(statusErr.Message, "unknown POST action")
+		strings.Contains(statusErr.Message, "S3 not configured")
+}
+
+func shouldRewriteAppend(err error) bool {
+	if IsUnsupportedStorageTargetErr(err) {
+		return true
+	}
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) {
+		return false
+	}
+	if statusErr.StatusCode != http.StatusBadRequest {
+		return false
+	}
+	return strings.Contains(statusErr.Message, "unknown POST action")
 }

--- a/pkg/client/append_test.go
+++ b/pkg/client/append_test.go
@@ -519,3 +519,64 @@ func TestAppendStreamRejectsOverlappingAppendPartWithoutReadURL(t *testing.T) {
 		t.Fatal("complete endpoint should not be called")
 	}
 }
+
+func TestIsUnsupportedStorageTargetErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"not s3 stored", &StatusError{StatusCode: http.StatusBadRequest, Message: "file is not S3-stored: /a.bin"}, true},
+		{"s3 not configured", &StatusError{StatusCode: http.StatusBadRequest, Message: "S3 not configured"}, true},
+		{"wrong status", &StatusError{StatusCode: http.StatusNotFound, Message: "file is not S3-stored: /a.bin"}, false},
+		{"unrelated 400", &StatusError{StatusCode: http.StatusBadRequest, Message: "bad request"}, false},
+		{"non status error", io.EOF, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsUnsupportedStorageTargetErr(tc.err); got != tc.want {
+				t.Fatalf("IsUnsupportedStorageTargetErr(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStatParsesStorageType(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/fs/s3.bin":
+			w.Header().Set("Content-Length", "200")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "7")
+			w.Header().Set("X-Dat9-Storage-Type", "s3")
+			w.WriteHeader(http.StatusOK)
+		case "/v1/fs/legacy.txt":
+			// Older server: no storage-type header.
+			w.Header().Set("Content-Length", "5")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "3")
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	s, err := c.StatCtx(context.Background(), "/s3.bin")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.StorageType != "s3" {
+		t.Fatalf("StorageType = %q, want s3", s.StorageType)
+	}
+
+	s, err = c.StatCtx(context.Background(), "/legacy.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.StorageType != "" {
+		t.Fatalf("StorageType = %q, want empty for legacy server", s.StorageType)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -197,6 +197,16 @@ type FileInfo struct {
 }
 
 // StatResult represents file metadata from HEAD.
+// Storage class values advertised by the server in the X-Dat9-Storage-Type
+// stat header. They mirror the datastore storage-type enum on the wire:
+// "db9" means the file content is stored inline in the database contents
+// table (regardless of the database product), "s3" means it lives in
+// object storage.
+const (
+	StorageTypeDB9 = "db9"
+	StorageTypeS3  = "s3"
+)
+
 type StatResult struct {
 	Size       int64
 	IsDir      bool
@@ -206,10 +216,10 @@ type StatResult struct {
 	HasMode    bool // true when the server returned a mode header (including 0)
 	ResourceID string
 	Nlink      uint32
-	// StorageType is the server-authoritative storage class ("db9" or "s3")
-	// from the X-Dat9-Storage-Type header. Empty when the server predates the
-	// header; callers must treat empty as "unknown" and fall back to local
-	// heuristics.
+	// StorageType is the server-authoritative storage class (StorageTypeDB9
+	// or StorageTypeS3) from the X-Dat9-Storage-Type header. Empty when the
+	// server predates the header; callers must treat empty as "unknown" and
+	// fall back to local heuristics.
 	StorageType string
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -206,6 +206,11 @@ type StatResult struct {
 	HasMode    bool // true when the server returned a mode header (including 0)
 	ResourceID string
 	Nlink      uint32
+	// StorageType is the server-authoritative storage class ("db9" or "s3")
+	// from the X-Dat9-Storage-Type header. Empty when the server predates the
+	// header; callers must treat empty as "unknown" and fall back to local
+	// heuristics.
+	StorageType string
 }
 
 // MaxBatchStatPaths is the maximum number of paths accepted by BatchStatCtx.
@@ -905,6 +910,7 @@ func (c *Client) StatCtx(ctx context.Context, path string) (*StatResult, error) 
 		}
 	}
 	s.ResourceID = resp.Header.Get("X-Dat9-Resource-ID")
+	s.StorageType = resp.Header.Get("X-Dat9-Storage-Type")
 	if nlink := resp.Header.Get("X-Dat9-Nlink"); nlink != "" {
 		if n, err := strconv.ParseUint(nlink, 10, 32); err == nil {
 			s.Nlink = uint32(n)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -197,14 +197,16 @@ type FileInfo struct {
 }
 
 // StatResult represents file metadata from HEAD.
-// Storage class values advertised by the server in the X-Dat9-Storage-Type
-// stat header. They mirror the datastore storage-type enum on the wire:
-// "db9" means the file content is stored inline in the database contents
-// table (regardless of the database product), "s3" means it lives in
-// object storage.
+// StorageType identifies the server-side storage class of a file's content,
+// as advertised in the X-Dat9-Storage-Type stat header. It mirrors the
+// datastore storage-type enum on the wire: "db9" means the file content is
+// stored inline in the database contents table (regardless of the database
+// product), "s3" means it lives in object storage.
+type StorageType string
+
 const (
-	StorageTypeDB9 = "db9"
-	StorageTypeS3  = "s3"
+	StorageTypeDB9 StorageType = "db9"
+	StorageTypeS3  StorageType = "s3"
 )
 
 type StatResult struct {
@@ -220,7 +222,7 @@ type StatResult struct {
 	// or StorageTypeS3) from the X-Dat9-Storage-Type header. Empty when the
 	// server predates the header; callers must treat empty as "unknown" and
 	// fall back to local heuristics.
-	StorageType string
+	StorageType StorageType
 }
 
 // MaxBatchStatPaths is the maximum number of paths accepted by BatchStatCtx.
@@ -920,7 +922,7 @@ func (c *Client) StatCtx(ctx context.Context, path string) (*StatResult, error) 
 		}
 	}
 	s.ResourceID = resp.Header.Get("X-Dat9-Resource-ID")
-	s.StorageType = resp.Header.Get("X-Dat9-Storage-Type")
+	s.StorageType = StorageType(resp.Header.Get("X-Dat9-Storage-Type"))
 	if nlink := resp.Header.Get("X-Dat9-Nlink"); nlink != "" {
 		if n, err := strconv.ParseUint(nlink, 10, 32); err == nil {
 			s.Nlink = uint32(n)

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1799,12 +1799,13 @@ func (s *Store) StatPathFallbackLite(ctx context.Context, primaryPath, fallbackP
 	defer observeStoreOp(ctx, "stat_path_fallback_lite", start, &err)
 
 	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
-		i.inode_id, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at
+		i.inode_id, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at, c.storage_type
 		FROM file_nodes fn
 		LEFT JOIN inodes i ON `+s.scope.AndOn(`COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'`, "i")+`
+		LEFT JOIN contents c ON `+s.scope.AndOn(`i.inode_id = c.inode_id`, "c")+`
 		WHERE `+s.andAsGrouped("fn", `(fn.path_hash = ? AND fn.path = ?) OR (fn.path_hash = ? AND fn.path = ?)`)+`
 		ORDER BY CASE WHEN fn.path = ? THEN 0 ELSE 1 END
-		LIMIT 1`, scopeWhereArgs(s.scope, 1, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)...)
+		LIMIT 1`, scopeWhereArgs(s.scope, 2, s.scope.Args(fileNodePathHash(primaryPath), primaryPath, fileNodePathHash(fallbackPath), fallbackPath, primaryPath)...)...)
 	out, err = scanNodeWithFileLite(row)
 	return out, err
 }
@@ -1815,11 +1816,12 @@ func (s *Store) StatLite(ctx context.Context, path string) (out *NodeWithFile, e
 	defer observeStoreOp(ctx, "stat_lite", start, &err)
 
 	row := s.db.QueryRowContext(ctx, `SELECT fn.node_id, fn.path, fn.parent_path, fn.name, fn.is_directory, fn.file_id, fn.created_at,
-		i.inode_id, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at
+		i.inode_id, i.size_bytes, i.revision, i.mode, i.status, i.created_at, i.confirmed_at, c.storage_type
 		FROM file_nodes fn
 		LEFT JOIN inodes i ON `+s.scope.AndOn(`COALESCE(fn.inode_id, fn.file_id) = i.inode_id AND i.status = 'CONFIRMED'`, "i")+`
+		LEFT JOIN contents c ON `+s.scope.AndOn(`i.inode_id = c.inode_id`, "c")+`
 		WHERE `+s.scope.AndAs("fn", `fn.path_hash = ? AND fn.path = ?`)+`
-		LIMIT 1`, scopeWhereArgs(s.scope, 1, s.scope.Args(fileNodePathHash(path), path)...)...)
+		LIMIT 1`, scopeWhereArgs(s.scope, 2, s.scope.Args(fileNodePathHash(path), path)...)...)
 	out, err = scanNodeWithFileLite(row)
 	return out, err
 }
@@ -2923,9 +2925,10 @@ func scanNodeWithFileLite(s scanner) (*NodeWithFile, error) {
 	var fMode sql.NullInt64
 	var fStatus sql.NullString
 	var fCreatedAt, fConfirmedAt sql.NullTime
+	var fStorageType sql.NullString
 
 	err := s.Scan(&n.NodeID, &n.Path, &n.ParentPath, &n.Name, &isDir, &nodeFileID, &nodeCreatedAt,
-		&fFileID, &fSizeBytes, &fRevision, &fMode, &fStatus, &fCreatedAt, &fConfirmedAt)
+		&fFileID, &fSizeBytes, &fRevision, &fMode, &fStatus, &fCreatedAt, &fConfirmedAt, &fStorageType)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil, ErrNotFound
@@ -2940,11 +2943,12 @@ func scanNodeWithFileLite(s scanner) (*NodeWithFile, error) {
 	nf := &NodeWithFile{Node: n}
 	if fFileID.Valid {
 		nf.File = &File{
-			FileID:    fFileID.String,
-			SizeBytes: fSizeBytes.Int64,
-			Revision:  fRevision.Int64,
-			Mode:      uint32(fMode.Int64),
-			Status:    FileStatus(fStatus.String),
+			FileID:      fFileID.String,
+			SizeBytes:   fSizeBytes.Int64,
+			Revision:    fRevision.Int64,
+			Mode:        uint32(fMode.Int64),
+			Status:      FileStatus(fStatus.String),
+			StorageType: StorageType(fStorageType.String),
 		}
 		if fCreatedAt.Valid {
 			nf.File.CreatedAt = fCreatedAt.Time.UTC()

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -289,8 +289,11 @@ func TestStatLite(t *testing.T) {
 	if nf.File.Description != "" {
 		t.Fatalf("Description should be empty in lite path, got %q", nf.File.Description)
 	}
-	if nf.File.StorageType != "" {
-		t.Fatalf("StorageType should be empty in lite path, got %q", nf.File.StorageType)
+	// StorageType IS fetched by the lite path: the server's HEAD handler
+	// advertises it as X-Dat9-Storage-Type so clients can route partial
+	// updates on fact instead of a size heuristic.
+	if nf.File.StorageType != StorageDB9 {
+		t.Fatalf("StorageType = %q, want %q", nf.File.StorageType, StorageDB9)
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -242,7 +242,7 @@ const (
 // inline-vs-S3 decision (shouldStoreInDB / IsLargeFile). Returns "" when the
 // negotiated threshold is unknown, in which case callers must keep the
 // previously known class rather than guessing.
-func (fs *Dat9FS) storageClassForCommittedSize(size int64) string {
+func (fs *Dat9FS) storageClassForCommittedSize(size int64) client.StorageType {
 	threshold := fs.negotiatedInlineThreshold()
 	if threshold <= 0 {
 		return ""
@@ -264,6 +264,29 @@ func (fs *Dat9FS) adoptCommittedStorageClassLocked(fh *FileHandle, committedSize
 	if class := fs.storageClassForCommittedSize(committedSize); class != "" {
 		fh.StorageClass = class
 	}
+}
+
+// materializeFullForUploadLocked ensures fh.Dirty can produce the complete
+// current file contents for a full upload (direct PUT or stream). Lazy
+// remote-backed parts are fetched via the buffer's LoadPart loader when
+// available. Returns false when the full contents cannot be reconstructed
+// without zero-filling untouched remote ranges — callers must then fail the
+// flush WITHOUT clearing dirty state. Eager bytesView() without this guard
+// uploads zeros for unloaded parts and silently corrupts the remote object
+// (e.g. an S3 object with a lazily loaded buffer routed to direct PUT after
+// the negotiated inline threshold was raised above the file size).
+func (fs *Dat9FS) materializeFullForUploadLocked(fh *FileHandle) bool {
+	if fh == nil || fh.Dirty == nil {
+		return false
+	}
+	if fh.Dirty.CanMaterializeFull() {
+		return true
+	}
+	if err := fh.Dirty.LoadMissingParts(); err != nil {
+		log.Printf("materialize full file for upload failed for %s: %v", fh.Path, err)
+		return false
+	}
+	return fh.Dirty.CanMaterializeFull()
 }
 
 // warmInlineThreshold triggers a one-shot /v1/status fetch via the client
@@ -3439,7 +3462,7 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 		dirtySeq     uint64
 		isNew        bool
 		zeroBase     bool
-		storageClass string
+		storageClass client.StorageType
 		shadowSource bool
 		canMemory    bool
 	}
@@ -10867,6 +10890,13 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 		canPatchExisting = false
 	}
 	if useDirectPUT || fh.OrigSize < threshold {
+		// Eager full-buffer materialization must prove no lazy remote-backed
+		// range is missing — bytesView() zero-fills unloaded parts and would
+		// silently corrupt the remote object (fetch them instead when the
+		// buffer has a loader; fail safe otherwise).
+		if !fs.materializeFullForUploadLocked(fh) {
+			return gofuse.EIO
+		}
 		data = fh.Dirty.bytesView()
 	}
 
@@ -12726,13 +12756,15 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	// (committedRev == 0) does not seed the read cache with full data.
 	var dataCopy []byte
 	if !usePatch {
-		// B12: For the WriteStreamConditional path (grown large file), check
-		// that all parts are loaded before materializing. Lazy-loaded existing
-		// files may have unloaded remote-backed parts; bytesView() would fill
-		// them with zeroes, overwriting remote data. Consistent with write-sync
-		// path's CanMaterializeFull() guard (line ~9971).
-		if !useDirectPUT && !fh.Dirty.CanMaterializeFull() {
-			log.Printf("flushHandle cannot materialize full file for %s (path2 growth)", fh.Path)
+		// B12: For full-upload paths (direct PUT and WriteStreamConditional),
+		// prove that all parts are loaded before materializing — or fetch the
+		// missing remote-backed parts via the lazy loader. Lazy-loaded
+		// existing files may have unloaded remote-backed parts; bytesView()
+		// would fill them with zeroes, overwriting remote data. This guard
+		// now covers the direct-PUT path as well (threshold raised above the
+		// file size after open), not just stream uploads.
+		if !fs.materializeFullForUploadLocked(fh) {
+			log.Printf("flushHandle cannot materialize full file for %s (path2)", fh.Path)
 			return gofuse.EIO
 		}
 		dataCopy = make([]byte, fh.Dirty.Size())

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -230,10 +230,11 @@ func (fs *Dat9FS) negotiatedInlineThreshold() int64 {
 }
 
 // Storage class values advertised by the server's X-Dat9-Storage-Type stat
-// header. They mirror the datastore storage-type enum values on the wire.
+// header. Aliased from pkg/client (the wire-protocol owner) so the FUSE
+// routing never defines its own copy of the protocol strings.
 const (
-	storageClassDB9 = "db9"
-	storageClassS3  = "s3"
+	storageClassDB9 = client.StorageTypeDB9
+	storageClassS3  = client.StorageTypeS3
 )
 
 // storageClassForCommittedSize derives the remote storage class produced by a

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -229,6 +229,42 @@ func (fs *Dat9FS) negotiatedInlineThreshold() int64 {
 	return 0
 }
 
+// Storage class values advertised by the server's X-Dat9-Storage-Type stat
+// header. They mirror the datastore storage-type enum values on the wire.
+const (
+	storageClassDB9 = "db9"
+	storageClassS3  = "s3"
+)
+
+// storageClassForCommittedSize derives the remote storage class produced by a
+// successful full-content commit of the given size, mirroring the server's
+// inline-vs-S3 decision (shouldStoreInDB / IsLargeFile). Returns "" when the
+// negotiated threshold is unknown, in which case callers must keep the
+// previously known class rather than guessing.
+func (fs *Dat9FS) storageClassForCommittedSize(size int64) string {
+	threshold := fs.negotiatedInlineThreshold()
+	if threshold <= 0 {
+		return ""
+	}
+	if size >= threshold {
+		return storageClassS3
+	}
+	return storageClassDB9
+}
+
+// adoptCommittedStorageClassLocked records the storage class implied by a
+// successful commit of committedSize. A no-op when the class cannot be
+// derived (unknown threshold), so a previously observed class is never
+// downgraded to "unknown".
+func (fs *Dat9FS) adoptCommittedStorageClassLocked(fh *FileHandle, committedSize int64) {
+	if fh == nil {
+		return
+	}
+	if class := fs.storageClassForCommittedSize(committedSize); class != "" {
+		fh.StorageClass = class
+	}
+}
+
 // warmInlineThreshold triggers a one-shot /v1/status fetch via the client
 // to populate the cached server inline_threshold. Idempotent and safe to
 // call from FUSE startup; failures (e.g. older server) cache as zero so
@@ -1683,6 +1719,7 @@ func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64
 	for _, fh := range matching {
 		var abortStreamer func()
 		fh.Lock()
+		fs.adoptCommittedStorageClassLocked(fh, truncateSize)
 		if shouldAdoptSingleHandlePathTruncate(fh, callerPID, len(matching)) {
 			var err error
 			abortStreamer, err = fs.truncateWritableHandleLocked(fh, truncateSize)
@@ -2053,6 +2090,7 @@ func (fs *Dat9FS) rebindCleanWriteBufferToRemoteLocked(fh *FileHandle, committed
 	next.sequential = true
 	fh.Dirty = next
 	fh.OrigSize = committedSize
+	fs.adoptCommittedStorageClassLocked(fh, committedSize)
 	clearReadTargetForLockedHandle(fh)
 
 	c := fs.client
@@ -2295,6 +2333,7 @@ func (fs *Dat9FS) markHandleRevisionOnlyLocked(fh *FileHandle, revision int64, s
 	fh.IsNew = false
 	fh.BaseRev = revision
 	fh.OrigSize = snapshotSize
+	fs.adoptCommittedStorageClassLocked(fh, snapshotSize)
 	fs.inodes.UpdateRevision(fh.Ino, revision)
 	fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, revision, fh, snapshotSize)
 	if fs.writeBack != nil {
@@ -2327,6 +2366,7 @@ func (fs *Dat9FS) markHandleRemoteCommittedLocked(fh *FileHandle, revision int64
 	if fh.Dirty != nil {
 		size := fh.Dirty.Size()
 		fh.OrigSize = size
+		fs.adoptCommittedStorageClassLocked(fh, size)
 		fs.inodes.UpdateSize(fh.Ino, size)
 	}
 	fs.refreshCommittedRevisionForOpenHandles(fh.Path, revision, fh)
@@ -2371,6 +2411,7 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 	}
 	fh.OrigSize = stat.Size
 	fh.BaseRev = stat.Revision
+	fh.StorageClass = stat.StorageType
 	if stat.Size == 0 {
 		return gofuse.OK
 	}
@@ -2545,6 +2586,9 @@ func (fs *Dat9FS) syncOpenHandlesAfterPathTruncate(ino uint64, newSize int64) {
 			fh.Unlock()
 			continue
 		}
+		// The path truncate committed a full re-upload of newSize remotely;
+		// the storage class follows from that size.
+		fs.adoptCommittedStorageClassLocked(fh, newSize)
 		curSize := fh.Dirty.Size()
 		if curSize != newSize {
 			if err := fh.Dirty.Truncate(newSize); err != nil {
@@ -3394,6 +3438,7 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 		dirtySeq     uint64
 		isNew        bool
 		zeroBase     bool
+		storageClass string
 		shadowSource bool
 		canMemory    bool
 	}
@@ -3422,6 +3467,7 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 			dirtySeq:     src.DirtySeq,
 			isNew:        src.IsNew,
 			zeroBase:     src.ZeroBase,
+			storageClass: src.StorageClass,
 			shadowSource: fs.shadowStore != nil && (src.ShadowReady || src.ShadowSpill),
 			canMemory:    src.Dirty.CanMaterializeFull(),
 		}
@@ -3468,6 +3514,7 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 				c.baseRev = c.src.BaseRev
 				c.isNew = c.src.IsNew
 				c.zeroBase = c.src.ZeroBase
+				c.storageClass = c.src.StorageClass
 				if size == 0 {
 					haveData = true
 				} else if c.src.Dirty.CanMaterializeFull() {
@@ -3497,8 +3544,10 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 		fh.BaseRev = c.baseRev
 		if c.isNew {
 			fh.OrigSize = 0
+			fh.StorageClass = ""
 		} else {
 			fh.OrigSize = c.origSize
+			fh.StorageClass = c.storageClass
 		}
 		fs.inodes.UpdateSize(fh.Ino, size)
 		if c.baseRev > 0 {
@@ -9733,6 +9782,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 				fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
 				if err == nil && stat != nil {
 					fh.BaseRev = stat.Revision
+					fh.StorageClass = stat.StorageType
 					fs.inodes.UpdateRevision(input.NodeId, stat.Revision)
 				}
 			}
@@ -10808,6 +10858,13 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 	threshold := fs.negotiatedInlineThreshold()
 	useDirectPUT := size == 0 || (threshold > 0 && size < threshold)
 	canPatchExisting := threshold > 0 && fh.OrigSize >= threshold && size <= fh.OrigSize
+	if fh.StorageClass == storageClassDB9 {
+		// Authoritative: the remote object is stored inline, so PATCH
+		// (S3 UploadPartCopy-based) is not applicable regardless of size.
+		// A known-S3 class needs no override: when OrigSize < threshold
+		// the direct-PUT / B11 growth guards already exclude PATCH.
+		canPatchExisting = false
+	}
 	if useDirectPUT || fh.OrigSize < threshold {
 		data = fh.Dirty.bytesView()
 	}
@@ -10864,6 +10921,31 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 			}
 			fs.perfRecordRemote(perfRemoteWrite, patchStart, err, patchBytes)
 			fs.debugDurationf(patchStart, 0, "write-sync patch done path=%s size=%d dirty_parts=%d err=%v", fh.Path, size, len(dirtyParts), err)
+			if err != nil && client.IsUnsupportedStorageTargetErr(err) {
+				// The server rejected the patch plan: the remote object is
+				// not S3-stored, so partial updates are unsupported for it.
+				// Record the observed class (this also prevents future
+				// flushes from re-selecting PATCH) and fall back to a full
+				// conditional upload, which is valid for any storage class.
+				fh.StorageClass = storageClassDB9
+				if !fh.Dirty.CanMaterializeFull() {
+					log.Printf("write-sync patch fallback cannot materialize full file for %s", fh.Path)
+					return gofuse.EIO
+				}
+				data = fh.Dirty.bytesView()
+				writeStart := time.Now()
+				fs.debugf("write-sync patch unsupported, full-upload fallback start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
+				err = fs.client.WriteStreamConditional(
+					ctx,
+					fs.remotePath(fh.Path),
+					bytes.NewReader(data),
+					size,
+					nil,
+					expectedRevision,
+				)
+				fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(len(data)))
+				fs.debugDurationf(writeStart, 0, "write-sync patch fallback done path=%s size=%d err=%v", fh.Path, size, err)
+			}
 		}
 	} else {
 		if data == nil && !fh.Dirty.CanMaterializeFull() {
@@ -10890,6 +10972,9 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 		log.Printf("write-sync upload failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}
+	// The commit is authoritative for the storage class: direct PUT lands
+	// inline, PATCH keeps S3, and a full upload re-splits by size.
+	fs.adoptCommittedStorageClassLocked(fh, size)
 	if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 		log.Printf("write-sync pending chmod failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
@@ -12603,6 +12688,12 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	// callback cannot construct correct content. Consistent with write-sync
 	// path's canPatchExisting guard (line ~9912).
 	usePatch := !useDirectPUT && threshold > 0 && handleOrigSize >= threshold && size <= handleOrigSize
+	if fh.StorageClass == storageClassDB9 {
+		// Authoritative: remote object is stored inline; PATCH requires S3.
+		// A known-S3 class needs no override: when OrigSize < threshold the
+		// direct-PUT / B11 growth guards already exclude PATCH.
+		usePatch = false
+	}
 
 	// Prepare patch snapshots while we still hold the lock.
 	var dirtyParts []int
@@ -12780,6 +12871,20 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	fs.debugDurationf(uploadStart, 0, "flushHandle path2 relock after upload path=%s size=%d err=%v", handlePath, size, err)
 
 	if err != nil {
+		if usePatch && client.IsUnsupportedStorageTargetErr(err) {
+			// The server rejected the patch plan: the remote object is not
+			// S3-stored. Record the observed class so this and future
+			// flushes route away from PATCH, then retry this flush as a
+			// full upload. Dirty state is untouched by the failed patch,
+			// and the recursion depth is bounded at 1: with StorageClass
+			// set to db9 the retry cannot re-enter the patch branch.
+			fh.StorageClass = storageClassDB9
+			if fh.Path == handlePath && fh.DirtySeq == handleDirtySeq {
+				fs.debugf("flushHandle patch unsupported target, retry as full upload path=%s size=%d", handlePath, size)
+				return fs.flushHandle(ctx, fh)
+			}
+			log.Printf("flush patch unsupported for %s; will full-upload on next flush (dirty state advanced during upload)", handlePath)
+		}
 		log.Printf("flush upload failed for %s: %v", handlePath, err)
 		return httpToFuseStatus(err)
 	}
@@ -12808,6 +12913,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	// must NOT be cleared — the old-path upload success does not satisfy
 	// the new path's flush obligation.
 	pathRetargeted := fh.Path != handlePath
+	if !pathRetargeted {
+		// The commit is authoritative for the storage class: direct PUT
+		// lands inline, PATCH keeps S3, and a full upload re-splits by size.
+		fs.adoptCommittedStorageClassLocked(fh, size)
+	}
 
 	// Only clear dirty state if no concurrent writes happened while the
 	// lock was released AND the handle was not retargeted. If DirtySeq

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -12290,6 +12290,17 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 	}
 
 	// Small file: schedule a deferred upload.
+	// The debounced callback commits the FULL buffer and clears dirty state
+	// on success, so this snapshot must meet the same materialization
+	// contract as every other full-upload path: bytesView() zero-fills
+	// unloaded lazy remote-backed parts, which would silently corrupt the
+	// remote object (e.g. an S3 object lazily opened while the server inline
+	// threshold sits above the buffer's part size). Fetch missing parts via
+	// the lazy loader, or fail EIO preserving dirty state.
+	if !fs.materializeFullForUploadLocked(fh) {
+		log.Printf("debounced flush cannot materialize full file for %s", fh.Path)
+		return gofuse.EIO
+	}
 	// Snapshot the data so the deferred upload sees a consistent copy.
 	snapshot := fh.Dirty.bytesView()
 	data := make([]byte, len(snapshot))

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -12290,6 +12290,16 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 	}
 
 	// Small file: schedule a deferred upload.
+	// Freeze the CAS base BEFORE any fetch/materialization. If a sibling
+	// commits while the lazy loader is fetching (which reads latest remote
+	// bytes), adopting the committed revision here would advance the base
+	// to the sibling's revision and let the deferred PUT silently splice
+	// this handle's older dirty bytes into the newer remote — the exact
+	// lost-update class the synchronous paths defend by capturing
+	// expectedRevision before materializing. With the base frozen first,
+	// the callback's revision re-check observes the sibling commit and
+	// skips the upload instead.
+	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 	// The debounced callback commits the FULL buffer and clears dirty state
 	// on success, so this snapshot must meet the same materialization
 	// contract as every other full-upload path: bytesView() zero-fills
@@ -12309,7 +12319,6 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 	ino := fh.Ino
 	handle := fh               // capture for goroutine
 	snapshotSeq := fh.DirtySeq // capture current dirty sequence
-	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 	// Snapshot the staging-store generations so the post-upload cleanup can be
 	// generation-guarded. A concurrent same-path write while the debounce is
 	// pending/in-flight would bump these generations, and removing the fresher

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -10959,7 +10959,10 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 				// flushes from re-selecting PATCH) and fall back to a full
 				// conditional upload, which is valid for any storage class.
 				fh.StorageClass = storageClassDB9
-				if !fh.Dirty.CanMaterializeFull() {
+				// Fetch missing lazy remote-backed parts when a loader is
+				// available (recoverable); fail EIO without clearing dirty
+				// state otherwise — never upload zero-filled ranges.
+				if !fs.materializeFullForUploadLocked(fh) {
 					log.Printf("write-sync patch fallback cannot materialize full file for %s", fh.Path)
 					return gofuse.EIO
 				}
@@ -10979,7 +10982,10 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 			}
 		}
 	} else {
-		if data == nil && !fh.Dirty.CanMaterializeFull() {
+		if data == nil && !fs.materializeFullForUploadLocked(fh) {
+			// Same fetch-or-fail contract as flushHandle: a lazily loaded
+			// existing file that grew beyond OrigSize is recoverable when a
+			// loader exists; otherwise fail without clearing dirty state.
 			log.Printf("write-sync cannot materialize full file for %s", fh.Path)
 			return gofuse.EIO
 		}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -16238,7 +16238,8 @@ func newPatchUnsupportedFakeServer(t *testing.T, path string, patchCount *atomic
 	return ts
 }
 
-func newLargeDirtyHandleForPatchTest(fs *Dat9FS, path string, origSize int64, writeSize int) *FileHandle {
+func newLargeDirtyHandleForPatchTest(t *testing.T, fs *Dat9FS, path string, origSize int64, writeSize int) *FileHandle {
+	t.Helper()
 	ino := fs.inodes.Lookup(path, false, 5, time.Now())
 	fs.inodes.UpdateRevision(ino, 5)
 	fh := &FileHandle{
@@ -16253,7 +16254,7 @@ func newLargeDirtyHandleForPatchTest(fs *Dat9FS, path string, origSize int64, wr
 		data[i] = byte(i)
 	}
 	if _, err := fh.Dirty.Write(0, data); err != nil {
-		panic(err)
+		t.Fatalf("seed dirty buffer: %v", err)
 	}
 	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
 	_ = fs.fileHandles.Allocate(fh)
@@ -16279,7 +16280,7 @@ func TestFlushHandle_Path2_PatchUnsupportedTargetFallsBackToFullUpload(t *testin
 	var threshold int64 = 100
 	fs.smallFileMax.Store(threshold)
 
-	fh := newLargeDirtyHandleForPatchTest(fs, path, 200, 120)
+	fh := newLargeDirtyHandleForPatchTest(t, fs, path, 200, 120)
 
 	fh.Lock()
 	st := fs.flushHandle(context.Background(), fh)
@@ -16320,7 +16321,7 @@ func TestFlushHandle_Path2_StorageClassDB9SkipsPatch(t *testing.T) {
 	var threshold int64 = 100
 	fs.smallFileMax.Store(threshold)
 
-	fh := newLargeDirtyHandleForPatchTest(fs, path, 200, 120)
+	fh := newLargeDirtyHandleForPatchTest(t, fs, path, 200, 120)
 	fh.StorageClass = storageClassDB9
 
 	fh.Lock()
@@ -16355,7 +16356,7 @@ func TestSyncWriteHandle_PatchUnsupportedTargetFallsBackToFullUpload(t *testing.
 	var threshold int64 = 100
 	fs.smallFileMax.Store(threshold)
 
-	fh := newLargeDirtyHandleForPatchTest(fs, path, 200, 120)
+	fh := newLargeDirtyHandleForPatchTest(t, fs, path, 200, 120)
 
 	fh.Lock()
 	st := fs.syncWriteHandleToRemoteLocked(context.Background(), fh)
@@ -16409,6 +16410,415 @@ func TestPreloadWritableHandleSeedsStorageClass(t *testing.T) {
 	}
 	if fh.OrigSize != 200 || fh.BaseRev != 3 {
 		t.Fatalf("OrigSize/BaseRev = %d/%d, want 200/3", fh.OrigSize, fh.BaseRev)
+	}
+}
+
+// flushBothWays runs a handle flush through both full-upload entry points:
+// flushHandle (non-layer Path 2) and the write-sync path.
+func flushBothWays(t *testing.T) []struct {
+	name string
+	run  func(*Dat9FS, *FileHandle) gofuse.Status
+} {
+	t.Helper()
+	return []struct {
+		name string
+		run  func(*Dat9FS, *FileHandle) gofuse.Status
+	}{
+		{
+			name: "flushHandle",
+			run: func(fs *Dat9FS, fh *FileHandle) gofuse.Status {
+				fh.Lock()
+				defer fh.Unlock()
+				return fs.flushHandle(context.Background(), fh)
+			},
+		},
+		{
+			name: "write-sync",
+			run: func(fs *Dat9FS, fh *FileHandle) gofuse.Status {
+				fh.Lock()
+				defer fh.Unlock()
+				return fs.syncWriteHandleToRemoteLocked(context.Background(), fh)
+			},
+		},
+	}
+}
+
+// newLazyTwoPartHandle builds a handle whose dirty buffer simulates a
+// lazily loaded existing 512-byte S3 object with 256-byte parts: only the
+// modified part is loaded. origPart returns the canned original content of
+// 1-based part pn; withLoader=false leaves the buffer without a lazy
+// loader (CanMaterializeFull false and no way to refetch).
+func newLazyTwoPartHandle(t *testing.T, fs *Dat9FS, path string, withLoader bool, loadCalls *atomic.Int32) (fh *FileHandle, orig [2][]byte) {
+	t.Helper()
+	ino := fs.inodes.Lookup(path, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	for p := range orig {
+		orig[p] = make([]byte, 256)
+		for i := range orig[p] {
+			orig[p][i] = byte(0xA0 + p*0x10 + i%16)
+		}
+	}
+
+	wb := NewWriteBuffer(path, maxPreloadSize, 256)
+	wb.remoteSize = 512
+	wb.totalSize = 512
+	if withLoader {
+		wb.LoadPart = func(partNum int) ([]byte, error) {
+			loadCalls.Add(1)
+			return append([]byte(nil), orig[partNum-1]...), nil
+		}
+	}
+
+	fh = &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    wb,
+		BaseRev:  5,
+		OrigSize: 512,
+	}
+	// Modify only the first 4 bytes (loads part 1; part 2 stays unloaded).
+	if _, err := wb.Write(0, []byte("WXYZ")); err != nil {
+		t.Fatalf("seed dirty buffer: %v", err)
+	}
+	if wb.CanMaterializeFull() {
+		t.Fatal("expected CanMaterializeFull() = false for lazy two-part buffer")
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, wb.Size())
+	_ = fs.fileHandles.Allocate(fh)
+	return fh, orig
+}
+
+// TestFlushDirectPUTLazyBufferFetchesMissingParts is the qiffang blocker
+// regression: an existing S3 object with a lazily loaded buffer is routed
+// to direct PUT after the negotiated inline threshold is raised above the
+// file size. Only one part is modified. The flush must fetch the unloaded
+// remote-backed part (never upload zero-filled ranges), and the committed
+// bytes must preserve the untouched original content.
+func TestFlushDirectPUTLazyBufferFetchesMissingParts(t *testing.T) {
+	for _, tc := range flushBothWays(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			var loadCalls atomic.Int32
+			var gotBody []byte
+			var gotExpectedRev string
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPut && r.URL.Path == "/v1/fs/lazy-raised-threshold.dat" {
+					gotExpectedRev = r.Header.Get("X-Dat9-Expected-Revision")
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("read PUT body: %v", err)
+					}
+					gotBody = body
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{"revision": 42})
+					return
+				}
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+			// Threshold raised above the file size (512 < 51200): the flush
+			// routes to direct PUT even though the object is S3-stored.
+			fs.smallFileMax.Store(51200)
+
+			path := "/lazy-raised-threshold.dat"
+			fh, orig := newLazyTwoPartHandle(t, fs, path, true, &loadCalls)
+
+			if st := tc.run(fs, fh); st != gofuse.OK {
+				t.Fatalf("flush status = %v, want OK (missing parts must be fetched, not zero-filled)", st)
+			}
+			if loadCalls.Load() == 0 {
+				t.Fatal("expected lazy loader to be called for the unloaded part")
+			}
+			if gotExpectedRev != "5" {
+				t.Fatalf("direct PUT X-Dat9-Expected-Revision = %q, want 5 (CAS must be preserved)", gotExpectedRev)
+			}
+			if int64(len(gotBody)) != 512 {
+				t.Fatalf("direct PUT body size = %d, want 512", len(gotBody))
+			}
+			want := make([]byte, 512)
+			copy(want, orig[0])
+			copy(want[256:], orig[1])
+			copy(want[:4], "WXYZ")
+			if !bytes.Equal(gotBody, want) {
+				t.Fatal("direct PUT body mismatch: untouched remote-backed range was not preserved")
+			}
+			if fh.DirtySeq != 0 {
+				t.Fatalf("DirtySeq = %d, want 0 after successful upload", fh.DirtySeq)
+			}
+		})
+	}
+}
+
+// TestFlushDirectPUTLazyBufferNoLoaderReturnsEIO covers the fail-safe half
+// of the qiffang blocker: without a lazy loader, a direct-PUT flush of a
+// buffer that cannot materialize must fail with EIO and preserve dirty
+// state, never uploading zero-filled ranges.
+func TestFlushDirectPUTLazyBufferNoLoaderReturnsEIO(t *testing.T) {
+	for _, tc := range flushBothWays(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			var serverHit atomic.Bool
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				serverHit.Store(true)
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			fs.smallFileMax.Store(51200)
+
+			path := "/lazy-no-loader.dat"
+			fh, _ := newLazyTwoPartHandle(t, fs, path, false, nil)
+			dirtySeqBefore := fh.DirtySeq
+
+			if st := tc.run(fs, fh); st != gofuse.EIO {
+				t.Fatalf("flush status = %v, want EIO (must not upload zero-filled ranges)", st)
+			}
+			if serverHit.Load() {
+				t.Fatal("server received an upload request — must fail before materializing")
+			}
+			if fh.DirtySeq != dirtySeqBefore {
+				t.Fatalf("DirtySeq = %d, want %d preserved after EIO", fh.DirtySeq, dirtySeqBefore)
+			}
+		})
+	}
+}
+
+// patchFallbackV2Fake is a PATCH-rejecting fake server that runs the real
+// v2 multipart protocol for the fallback full upload, recording the
+// expected_revision from the initiate request and the uploaded part bytes.
+type patchFallbackV2Fake struct {
+	t *testing.T
+
+	server       *httptest.Server
+	patchCount   atomic.Int32
+	gotExpected  atomic.Int64
+	gotUpload    atomic.Bool
+	gotBody      []byte
+	conflictMode atomic.Bool // when true, initiate responds 409
+}
+
+func newPatchFallbackV2Fake(t *testing.T, path string) *patchFallbackV2Fake {
+	t.Helper()
+	f := &patchFallbackV2Fake{t: t}
+	f.gotExpected.Store(-1)
+	f.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPatch:
+			f.patchCount.Add(1)
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "file is not S3-stored: " + path})
+
+		case r.Method == http.MethodPut && strings.HasPrefix(r.URL.Path, "/v1/fs/"):
+			// Fallback full rewrite via direct PUT (size below the client's
+			// cached upload threshold): CAS travels in the header.
+			if f.conflictMode.Load() {
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "revision conflict"})
+				return
+			}
+			if rev, err := strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64); err == nil {
+				f.gotExpected.Store(rev)
+			}
+			f.gotUpload.Store(true)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read direct PUT body: %v", err)
+			}
+			f.gotBody = body
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"revision": 42})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/initiate":
+			if f.conflictMode.Load() {
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "revision conflict"})
+				return
+			}
+			var req struct {
+				ExpectedRevision *int64 `json:"expected_revision"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode initiate: %v", err)
+			}
+			if req.ExpectedRevision != nil {
+				f.gotExpected.Store(*req.ExpectedRevision)
+			}
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"upload_id":   "upload-1",
+				"key":         "object-key",
+				"part_size":   int64(s3client.PartSize),
+				"total_parts": 1,
+			})
+
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/upload-1/presign-batch":
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"parts": []map[string]any{
+					{"number": 1, "url": f.server.URL + "/s3/upload-1/1", "size": 120},
+				},
+			})
+
+		case r.Method == http.MethodPut && r.URL.Path == "/s3/upload-1/1":
+			f.gotUpload.Store(true)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read part body: %v", err)
+			}
+			f.gotBody = body
+			w.Header().Set("ETag", "etag-1")
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == http.MethodPost && r.URL.Path == "/v2/uploads/upload-1/complete":
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(f.server.Close)
+	return f
+}
+
+// TestFlushPatchFallbackCarriesExpectedRevision is the qiffang #199 CAS
+// regression: after PATCH is rejected with "file is not S3-stored", the
+// fallback full rewrite must remain revision-conditional (expected_revision
+// carries the handle BaseRev) and must upload the complete buffer content.
+func TestFlushPatchFallbackCarriesExpectedRevision(t *testing.T) {
+	for _, tc := range flushBothWays(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			path := "/fallback-cas.dat"
+			fake := newPatchFallbackV2Fake(t, path)
+
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(fake.server.URL), opts)
+			fs.smallFileMax.Store(100)
+
+			fh := newLargeDirtyHandleForPatchTest(t, fs, path, 200, 120)
+
+			if st := tc.run(fs, fh); st != gofuse.OK {
+				t.Fatalf("flush status = %v, want OK (fallback full upload)", st)
+			}
+			if got := fake.patchCount.Load(); got != 1 {
+				t.Fatalf("PATCH attempts = %d, want exactly 1", got)
+			}
+			if got := fake.gotExpected.Load(); got != 5 {
+				t.Fatalf("fallback initiate expected_revision = %d, want 5 (BaseRev CAS)", got)
+			}
+			if !fake.gotUpload.Load() {
+				t.Fatal("expected fallback part upload")
+			}
+			if int64(len(fake.gotBody)) != 120 {
+				t.Fatalf("fallback uploaded %d bytes, want 120", len(fake.gotBody))
+			}
+			if fh.DirtySeq != 0 {
+				t.Fatalf("DirtySeq = %d, want 0 after successful fallback", fh.DirtySeq)
+			}
+		})
+	}
+}
+
+// TestFlushPatchFallbackConflictPreservesDirty is the qiffang #199
+// conflict regression: when the fallback full rewrite loses the CAS race
+// (409 revision conflict), the flush must fail without clearing dirty
+// state, while the observed storage class still heals future routing away
+// from PATCH.
+func TestFlushPatchFallbackConflictPreservesDirty(t *testing.T) {
+	for _, tc := range flushBothWays(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			path := "/fallback-conflict.dat"
+			fake := newPatchFallbackV2Fake(t, path)
+			fake.conflictMode.Store(true)
+
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(fake.server.URL), opts)
+			fs.smallFileMax.Store(100)
+
+			fh := newLargeDirtyHandleForPatchTest(t, fs, path, 200, 120)
+			dirtySeqBefore := fh.DirtySeq
+
+			if st := tc.run(fs, fh); st == gofuse.OK {
+				t.Fatal("flush status = OK, want error on 409 revision conflict")
+			}
+			if got := fake.patchCount.Load(); got != 1 {
+				t.Fatalf("PATCH attempts = %d, want exactly 1", got)
+			}
+			if fake.gotUpload.Load() {
+				t.Fatal("part upload attempted despite initiate conflict")
+			}
+			if fh.DirtySeq != dirtySeqBefore {
+				t.Fatalf("DirtySeq = %d, want %d preserved after conflict", fh.DirtySeq, dirtySeqBefore)
+			}
+			if fh.StorageClass != storageClassDB9 {
+				t.Fatalf("StorageClass = %q, want %q (routing must heal away from PATCH)", fh.StorageClass, storageClassDB9)
+			}
+		})
+	}
+}
+
+// TestFlushPatchFallbackLazyBufferFailsWithoutUpload is the qiffang #199
+// non-materialization regression: after a rejected PATCH, a lazy buffer
+// that cannot materialize the full file must fail with EIO — never issue a
+// full upload with zero-filled ranges, never clear dirty state — while the
+// observed storage class still heals future routing away from PATCH.
+func TestFlushPatchFallbackLazyBufferFailsWithoutUpload(t *testing.T) {
+	for _, tc := range flushBothWays(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			var patchCount atomic.Int32
+			var uploadHit atomic.Bool
+
+			path := "/fallback-lazy.dat"
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodPatch:
+					patchCount.Add(1)
+					_, _ = io.ReadAll(r.Body)
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "file is not S3-stored: " + path})
+				default:
+					uploadHit.Store(true)
+					w.WriteHeader(http.StatusOK)
+				}
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			fs.smallFileMax.Store(100)
+
+			fh, _ := newLazyTwoPartHandle(t, fs, path, false, nil)
+			dirtySeqBefore := fh.DirtySeq
+
+			if st := tc.run(fs, fh); st != gofuse.EIO {
+				t.Fatalf("flush status = %v, want EIO (must not upload zero-filled ranges)", st)
+			}
+			if got := patchCount.Load(); got != 1 {
+				t.Fatalf("PATCH attempts = %d, want exactly 1", got)
+			}
+			if uploadHit.Load() {
+				t.Fatal("full upload attempted for non-materializable buffer — must fail instead")
+			}
+			if fh.DirtySeq != dirtySeqBefore {
+				t.Fatalf("DirtySeq = %d, want %d preserved after EIO", fh.DirtySeq, dirtySeqBefore)
+			}
+			if fh.StorageClass != storageClassDB9 {
+				t.Fatalf("StorageClass = %q, want %q (routing must heal away from PATCH)", fh.StorageClass, storageClassDB9)
+			}
+		})
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -16213,6 +16213,205 @@ func TestFlushHandle_Path2_GrowthBypassesPatch(t *testing.T) {
 	}
 }
 
+// newPatchUnsupportedFakeServer returns a test server whose storage semantics
+// reject PATCH with the production "file is not S3-stored" 400 (the file is
+// db9-stored despite its size), while accepting full uploads.
+func newPatchUnsupportedFakeServer(t *testing.T, path string, patchCount *atomic.Int32, fullUpload *atomic.Bool) *httptest.Server {
+	t.Helper()
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPatch:
+			patchCount.Add(1)
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "file is not S3-stored: " + path})
+		case http.MethodPut, http.MethodPost:
+			fullUpload.Store(true)
+			_, _ = io.ReadAll(r.Body)
+			w.WriteHeader(http.StatusOK)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"status": "ok"})
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func newLargeDirtyHandleForPatchTest(fs *Dat9FS, path string, origSize int64, writeSize int) *FileHandle {
+	ino := fs.inodes.Lookup(path, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    NewWriteBuffer(path, maxPreloadSize, 0),
+		BaseRev:  5,
+		OrigSize: origSize,
+	}
+	data := make([]byte, writeSize)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	if _, err := fh.Dirty.Write(0, data); err != nil {
+		panic(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	_ = fs.fileHandles.Allocate(fh)
+	return fh
+}
+
+// TestFlushHandle_Path2_PatchUnsupportedTargetFallsBackToFullUpload is the
+// scenario-B regression test: the size heuristic selects PATCH
+// (OrigSize >= threshold, size <= OrigSize) but the server stores the object
+// inline and rejects PATCH with 400. The flush must fall back to a full
+// upload (no EINVAL, dirty cleared, exactly one PATCH attempt), and the
+// committed upload re-derives the storage class from the uploaded size.
+func TestFlushHandle_Path2_PatchUnsupportedTargetFallsBackToFullUpload(t *testing.T) {
+	var patchCount atomic.Int32
+	var fullUpload atomic.Bool
+	path := "/patch-unsupported.dat"
+	ts := newPatchUnsupportedFakeServer(t, path, &patchCount, &fullUpload)
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var threshold int64 = 100
+	fs.smallFileMax.Store(threshold)
+
+	fh := newLargeDirtyHandleForPatchTest(fs, path, 200, 120)
+
+	fh.Lock()
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+
+	if st != gofuse.OK {
+		t.Fatalf("flushHandle status = %v, want OK (PATCH 400 must fall back to full upload, not EINVAL)", st)
+	}
+	if got := patchCount.Load(); got != 1 {
+		t.Fatalf("PATCH attempts = %d, want exactly 1 (no retry loop)", got)
+	}
+	if !fullUpload.Load() {
+		t.Fatal("expected full-upload fallback after PATCH 400")
+	}
+	if fh.DirtySeq != 0 {
+		t.Fatalf("DirtySeq = %d, want 0 after successful fallback upload", fh.DirtySeq)
+	}
+	// The fallback uploaded 120 bytes >= threshold, which the server stores
+	// as S3 — the committed state heals the storage class.
+	if fh.StorageClass != storageClassS3 {
+		t.Fatalf("StorageClass = %q, want %q after healing full upload", fh.StorageClass, storageClassS3)
+	}
+}
+
+// TestFlushHandle_Path2_StorageClassDB9SkipsPatch verifies that a known
+// db9 storage class routes the flush directly to a full upload even when
+// the size heuristic (OrigSize >= threshold) would select PATCH.
+func TestFlushHandle_Path2_StorageClassDB9SkipsPatch(t *testing.T) {
+	var patchCount atomic.Int32
+	var fullUpload atomic.Bool
+	path := "/patch-known-db9.dat"
+	ts := newPatchUnsupportedFakeServer(t, path, &patchCount, &fullUpload)
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var threshold int64 = 100
+	fs.smallFileMax.Store(threshold)
+
+	fh := newLargeDirtyHandleForPatchTest(fs, path, 200, 120)
+	fh.StorageClass = storageClassDB9
+
+	fh.Lock()
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+
+	if st != gofuse.OK {
+		t.Fatalf("flushHandle status = %v, want OK", st)
+	}
+	if got := patchCount.Load(); got != 0 {
+		t.Fatalf("PATCH attempts = %d, want 0 (known db9 class must bypass PATCH)", got)
+	}
+	if !fullUpload.Load() {
+		t.Fatal("expected full upload for known db9 storage class")
+	}
+}
+
+// TestSyncWriteHandle_PatchUnsupportedTargetFallsBackToFullUpload covers the
+// write-sync flush path (syncWriteHandleToRemoteLocked): same scenario-B
+// setup, and the PATCH 400 must inline-fallback to a full upload within the
+// same flush.
+func TestSyncWriteHandle_PatchUnsupportedTargetFallsBackToFullUpload(t *testing.T) {
+	var patchCount atomic.Int32
+	var fullUpload atomic.Bool
+	path := "/patch-unsupported-ws.dat"
+	ts := newPatchUnsupportedFakeServer(t, path, &patchCount, &fullUpload)
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	var threshold int64 = 100
+	fs.smallFileMax.Store(threshold)
+
+	fh := newLargeDirtyHandleForPatchTest(fs, path, 200, 120)
+
+	fh.Lock()
+	st := fs.syncWriteHandleToRemoteLocked(context.Background(), fh)
+	fh.Unlock()
+
+	if st != gofuse.OK {
+		t.Fatalf("syncWriteHandleToRemoteLocked status = %v, want OK (PATCH 400 must fall back to full upload)", st)
+	}
+	if got := patchCount.Load(); got != 1 {
+		t.Fatalf("PATCH attempts = %d, want exactly 1 (no retry loop)", got)
+	}
+	if !fullUpload.Load() {
+		t.Fatal("expected full-upload fallback after PATCH 400")
+	}
+	if fh.DirtySeq != 0 {
+		t.Fatalf("DirtySeq = %d, want 0 after successful fallback upload", fh.DirtySeq)
+	}
+}
+
+// TestPreloadWritableHandleSeedsStorageClass verifies that the stat response
+// storage-type header seeds the handle's storage class at preload time.
+func TestPreloadWritableHandleSeedsStorageClass(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodHead && r.URL.Path == "/v1/fs/seed.txt" {
+			w.Header().Set("Content-Length", "200")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "3")
+			w.Header().Set("X-Dat9-Storage-Type", "db9")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup("/seed.txt", false, 200, time.Now())
+	fh := &FileHandle{
+		Ino:   ino,
+		Path:  "/seed.txt",
+		Dirty: NewWriteBuffer("/seed.txt", maxPreloadSize, 0),
+	}
+	if st := fs.preloadWritableHandle(context.Background(), fh); st != gofuse.OK {
+		t.Fatalf("preloadWritableHandle status = %v, want OK", st)
+	}
+	if fh.StorageClass != storageClassDB9 {
+		t.Fatalf("StorageClass = %q, want %q seeded from stat header", fh.StorageClass, storageClassDB9)
+	}
+	if fh.OrigSize != 200 || fh.BaseRev != 3 {
+		t.Fatalf("OrigSize/BaseRev = %d/%d, want 200/3", fh.OrigSize, fh.BaseRev)
+	}
+}
+
 // TestFlushHandle_Path2_SyntheticRevRecordedBeforeUnlock verifies that when
 // a Path 2 flush succeeds without the server returning a committed revision
 // (e.g. PatchFile / WriteStreamConditional), the synthetic revision

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -17032,6 +17032,105 @@ func TestFlushPatchFallbackLazyFetchNewerRevisionConflicts(t *testing.T) {
 	}
 }
 
+// TestFlushHandleDebouncedLazyBufferFetchesMissingParts covers the debounced
+// upload entry point (qiffang adversary-1 update): a lazy multi-part
+// existing file below the inline threshold must fetch the untouched part
+// before the deferred snapshot, so the debounced callback uploads the
+// complete original content instead of zero-filled ranges.
+func TestFlushHandleDebouncedLazyBufferFetchesMissingParts(t *testing.T) {
+	var loadCalls atomic.Int32
+	var gotBody []byte
+	var gotExpectedRev string
+
+	path := "/debounced-lazy.dat"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			gotExpectedRev = r.Header.Get("X-Dat9-Expected-Revision")
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read PUT body: %v", err)
+			}
+			gotBody = body
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"revision": 42})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	// Small-file debounce route: size (512) < inlineThreshold (50KB default).
+	fs.debouncer = newFlushDebouncer(50 * time.Millisecond)
+
+	fh, orig := newLazyTwoPartHandle(t, fs, path, true, &loadCalls)
+
+	fh.Lock()
+	st := fs.flushHandleDebounced(context.Background(), fh, false)
+	fh.Unlock()
+	if st != gofuse.OK {
+		t.Fatalf("flushHandleDebounced status = %v, want OK (schedule)", st)
+	}
+	fs.debouncer.FlushAll()
+
+	if loadCalls.Load() == 0 {
+		t.Fatal("expected lazy loader to fetch the untouched part before snapshot")
+	}
+	if gotExpectedRev != "5" {
+		t.Fatalf("debounced PUT X-Dat9-Expected-Revision = %q, want 5 (BaseRev CAS)", gotExpectedRev)
+	}
+	want := make([]byte, 512)
+	copy(want, orig[0])
+	copy(want[256:], orig[1])
+	copy(want[:4], "WXYZ")
+	if !bytes.Equal(gotBody, want) {
+		t.Fatal("debounced upload body mismatch: untouched remote-backed range was zero-filled")
+	}
+	if fh.Dirty.HasDirtyParts() {
+		t.Fatal("dirty parts remain after successful debounced upload")
+	}
+}
+
+// TestFlushHandleDebouncedLazyBufferNoLoaderReturnsEIO covers the fail-safe
+// half for the debounced path: without a lazy loader, the debounce decision
+// must fail EIO synchronously without scheduling an upload and without
+// clearing dirty state.
+func TestFlushHandleDebouncedLazyBufferNoLoaderReturnsEIO(t *testing.T) {
+	var serverHit atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.debouncer = newFlushDebouncer(50 * time.Millisecond)
+
+	path := "/debounced-lazy-no-loader.dat"
+	fh, _ := newLazyTwoPartHandle(t, fs, path, false, nil)
+	dirtySeqBefore := fh.DirtySeq
+
+	fh.Lock()
+	st := fs.flushHandleDebounced(context.Background(), fh, false)
+	fh.Unlock()
+	if st != gofuse.EIO {
+		t.Fatalf("flushHandleDebounced status = %v, want EIO (must not snapshot zero-filled ranges)", st)
+	}
+	fs.debouncer.FlushAll()
+	if serverHit.Load() {
+		t.Fatal("server received an upload request — must fail before scheduling")
+	}
+	if fh.DirtySeq != dirtySeqBefore {
+		t.Fatalf("DirtySeq = %d, want %d preserved after EIO", fh.DirtySeq, dirtySeqBefore)
+	}
+}
+
 // TestFlushHandle_Path2_SyntheticRevRecordedBeforeUnlock verifies that when
 // a Path 2 flush succeeds without the server returning a committed revision
 // (e.g. PatchFile / WriteStreamConditional), the synthetic revision

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -17131,6 +17131,84 @@ func TestFlushHandleDebouncedLazyBufferNoLoaderReturnsEIO(t *testing.T) {
 	}
 }
 
+// TestFlushHandleDebouncedLazyFetchNewerRevisionSkipsUpload is the
+// discriminating cross-revision regression for the debounced path (qiffang
+// adversary-1): the CAS base must be frozen BEFORE the lazy fetch. A
+// sibling commit (recorded during the fetch) must make the deferred
+// callback skip the upload — never PUT with the newer revision over this
+// handle's older dirty bytes, and never clear dirty state.
+func TestFlushHandleDebouncedLazyFetchNewerRevisionSkipsUpload(t *testing.T) {
+	var serverHit atomic.Bool
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverHit.Store(true)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.debouncer = newFlushDebouncer(50 * time.Millisecond)
+
+	path := "/debounced-splice.dat"
+	ino := fs.inodes.Lookup(path, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	orig := make([][]byte, 2)
+	for p := range orig {
+		orig[p] = make([]byte, 256)
+		for i := range orig[p] {
+			orig[p][i] = byte(0xA0 + p*0x10 + i%16)
+		}
+	}
+
+	wb := NewWriteBuffer(path, maxPreloadSize, 256)
+	wb.remoteSize = 512
+	wb.totalSize = 512
+	// The loader observes the latest remote AND records the sibling's rev-9
+	// commit mid-fetch — the ordering hazard this test pins. Only the flush
+	// fetches part 2; part 1 loads during the seeding Write below, so the
+	// commit must be recorded exactly when part 2 is requested.
+	wb.LoadPart = func(partNum int) ([]byte, error) {
+		if partNum == 2 {
+			fs.recordCommittedRevision(path, 9)
+		}
+		return append([]byte(nil), orig[partNum-1]...), nil
+	}
+
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    wb,
+		BaseRev:  5,
+		OrigSize: 512,
+	}
+	if _, err := wb.Write(0, []byte("WXYZ")); err != nil {
+		t.Fatalf("seed dirty buffer: %v", err)
+	}
+	if wb.CanMaterializeFull() {
+		t.Fatal("expected CanMaterializeFull() = false for lazy two-part buffer")
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, wb.Size())
+	_ = fs.fileHandles.Allocate(fh)
+
+	fh.Lock()
+	st := fs.flushHandleDebounced(context.Background(), fh, false)
+	fh.Unlock()
+	if st != gofuse.OK {
+		t.Fatalf("flushHandleDebounced status = %v, want OK (schedule)", st)
+	}
+	fs.debouncer.FlushAll()
+
+	if serverHit.Load() {
+		t.Fatal("debounced callback uploaded — sibling commit during fetch must skip the PUT (splice)")
+	}
+	if !fh.Dirty.HasDirtyParts() {
+		t.Fatal("dirty state cleared — must be preserved when the callback skips")
+	}
+}
+
 // TestFlushHandle_Path2_SyntheticRevRecordedBeforeUnlock verifies that when
 // a Path 2 flush succeeds without the server returning a committed revision
 // (e.g. PatchFile / WriteStreamConditional), the synthetic revision

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -16822,6 +16822,216 @@ func TestFlushPatchFallbackLazyBufferFailsWithoutUpload(t *testing.T) {
 	}
 }
 
+// TestFlushPatchFallbackLazyBufferFetchesAndRecovers covers the recoverable
+// half of the lazy-buffer fallback gate (qiffang P1): with a lazy loader
+// available, a rejected PATCH must fetch the untouched remote-backed part
+// and complete the revision-conditional full upload — not return EIO.
+func TestFlushPatchFallbackLazyBufferFetchesAndRecovers(t *testing.T) {
+	for _, tc := range flushBothWays(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			var patchCount atomic.Int32
+			var loadCalls atomic.Int32
+			var gotBody []byte
+			var gotExpectedRev string
+
+			path := "/fallback-lazy-recover.dat"
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodPatch:
+					patchCount.Add(1)
+					_, _ = io.ReadAll(r.Body)
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "file is not S3-stored: " + path})
+				case http.MethodPut:
+					gotExpectedRev = r.Header.Get("X-Dat9-Expected-Revision")
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("read PUT body: %v", err)
+					}
+					gotBody = body
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{"revision": 42})
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			fs.smallFileMax.Store(100)
+
+			fh, orig := newLazyTwoPartHandle(t, fs, path, true, &loadCalls)
+
+			if st := tc.run(fs, fh); st != gofuse.OK {
+				t.Fatalf("flush status = %v, want OK (loader makes the lazy fallback recoverable)", st)
+			}
+			if got := patchCount.Load(); got != 1 {
+				t.Fatalf("PATCH attempts = %d, want exactly 1", got)
+			}
+			if loadCalls.Load() == 0 {
+				t.Fatal("expected lazy loader to fetch the untouched part during fallback")
+			}
+			if gotExpectedRev != "5" {
+				t.Fatalf("fallback X-Dat9-Expected-Revision = %q, want 5 (BaseRev CAS)", gotExpectedRev)
+			}
+			want := make([]byte, 512)
+			copy(want, orig[0])
+			copy(want[256:], orig[1])
+			copy(want[:4], "WXYZ")
+			if !bytes.Equal(gotBody, want) {
+				t.Fatal("fallback body mismatch: untouched remote-backed range was not preserved")
+			}
+			if fh.DirtySeq != 0 {
+				t.Fatalf("DirtySeq = %d, want 0 after successful fallback", fh.DirtySeq)
+			}
+		})
+	}
+}
+
+// TestFlushGrowthLazyBufferFetchesMissingParts covers the write-sync stream
+// branch fetch gap (qiffang P1): a lazily loaded existing file that grows
+// beyond OrigSize must fetch unloaded remote-backed parts and complete the
+// full upload on both flush paths, instead of returning EIO.
+func TestFlushGrowthLazyBufferFetchesMissingParts(t *testing.T) {
+	for _, tc := range flushBothWays(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			var loadCalls atomic.Int32
+			var gotBody []byte
+			var gotExpectedRev string
+
+			path := "/growth-lazy-fetch.dat"
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method == http.MethodPut {
+					gotExpectedRev = r.Header.Get("X-Dat9-Expected-Revision")
+					body, err := io.ReadAll(r.Body)
+					if err != nil {
+						t.Errorf("read PUT body: %v", err)
+					}
+					gotBody = body
+					w.Header().Set("Content-Type", "application/json")
+					_ = json.NewEncoder(w).Encode(map[string]any{"revision": 42})
+					return
+				}
+				t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+				w.WriteHeader(http.StatusMethodNotAllowed)
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			fs.smallFileMax.Store(100)
+
+			fh, orig := newLazyTwoPartHandle(t, fs, path, true, &loadCalls)
+			// Grow beyond OrigSize: append 88 bytes at the end (size 512->600).
+			appendData := make([]byte, 88)
+			for i := range appendData {
+				appendData[i] = byte(i + 1)
+			}
+			if _, err := fh.Dirty.Write(512, appendData); err != nil {
+				t.Fatalf("append: %v", err)
+			}
+			fh.DirtySeq = fs.markDirtySize(fh.Ino, fh.Dirty.Size())
+
+			if st := tc.run(fs, fh); st != gofuse.OK {
+				t.Fatalf("flush status = %v, want OK (growth with loader must fetch, not EIO)", st)
+			}
+			if loadCalls.Load() == 0 {
+				t.Fatal("expected lazy loader to fetch the untouched part before growth upload")
+			}
+			if gotExpectedRev != "5" {
+				t.Fatalf("upload X-Dat9-Expected-Revision = %q, want 5 (BaseRev CAS)", gotExpectedRev)
+			}
+			want := make([]byte, 600)
+			copy(want, orig[0])
+			copy(want[256:], orig[1])
+			copy(want[:4], "WXYZ")
+			copy(want[512:], appendData)
+			if !bytes.Equal(gotBody, want) {
+				t.Fatal("growth upload body mismatch: untouched remote-backed range not preserved")
+			}
+			if fh.DirtySeq != 0 {
+				t.Fatalf("DirtySeq = %d, want 0 after successful upload", fh.DirtySeq)
+			}
+		})
+	}
+}
+
+// TestFlushPatchFallbackLazyFetchNewerRevisionConflicts is the discriminating
+// cross-revision regression for the splice gate: the lazy loader reads the
+// retained range from the LATEST remote (revision N) while the dirty handle
+// still uploads with expected revision M<N. The CAS must reject the upload
+// with 409, dirty state must be preserved, and remote N must not be
+// overwritten — no splice of newer fetched bytes into an older base.
+func TestFlushPatchFallbackLazyFetchNewerRevisionConflicts(t *testing.T) {
+	for _, tc := range flushBothWays(t) {
+		t.Run(tc.name, func(t *testing.T) {
+			var patchCount atomic.Int32
+			var loadCalls atomic.Int32
+			var gotExpectedRev string
+			var commitAccepted atomic.Bool
+
+			path := "/fallback-splice.dat"
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodPatch:
+					patchCount.Add(1)
+					_, _ = io.ReadAll(r.Body)
+					w.WriteHeader(http.StatusBadRequest)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "file is not S3-stored: " + path})
+				case http.MethodPut:
+					// The remote has advanced to revision 9 since the handle
+					// opened at revision 5: any write conditioned on 5 must
+					// lose the CAS race. Never accept the commit.
+					gotExpectedRev = r.Header.Get("X-Dat9-Expected-Revision")
+					_, _ = io.ReadAll(r.Body)
+					w.WriteHeader(http.StatusConflict)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "revision conflict"})
+				default:
+					t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			fs.smallFileMax.Store(100)
+
+			// The loader serves the latest (revision-9) remote bytes; the
+			// handle's BaseRev stays at 5.
+			fh, _ := newLazyTwoPartHandle(t, fs, path, true, &loadCalls)
+			dirtySeqBefore := fh.DirtySeq
+
+			if st := tc.run(fs, fh); st == gofuse.OK {
+				t.Fatal("flush status = OK, want CAS rejection (409) — fetched newer bytes must not splice into the older base")
+			}
+			if commitAccepted.Load() {
+				t.Fatal("remote accepted a commit — remote revision N must not be overwritten")
+			}
+			if loadCalls.Load() == 0 {
+				t.Fatal("expected the lazy loader to fetch the retained range from latest remote")
+			}
+			if gotExpectedRev != "5" {
+				t.Fatalf("upload X-Dat9-Expected-Revision = %q, want 5 (handle still uploads with base revision M)", gotExpectedRev)
+			}
+			if got := patchCount.Load(); got != 1 {
+				t.Fatalf("PATCH attempts = %d, want exactly 1", got)
+			}
+			if fh.DirtySeq != dirtySeqBefore {
+				t.Fatalf("DirtySeq = %d, want %d preserved after CAS rejection", fh.DirtySeq, dirtySeqBefore)
+			}
+			if fh.StorageClass != storageClassDB9 {
+				t.Fatalf("StorageClass = %q, want %q (routing must heal away from PATCH)", fh.StorageClass, storageClassDB9)
+			}
+		})
+	}
+}
+
 // TestFlushHandle_Path2_SyntheticRevRecordedBeforeUnlock verifies that when
 // a Path 2 flush succeeds without the server returning a committed revision
 // (e.g. PatchFile / WriteStreamConditional), the synthetic revision

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -27,7 +27,7 @@ type FileHandle struct {
 	// the server's X-Dat9-Storage-Type stat header when available, updated
 	// after local commits and after a PATCH rejection. Write routing prefers
 	// it over the OrigSize size-heuristic when known.
-	StorageClass       string
+	StorageClass       client.StorageType
 	ZeroBase           bool            // true when the handle has adopted an explicit empty-file baseline
 	IsNew              bool            // true if created via Create() (no prior remote existence)
 	ShadowReady        bool            // true when the local shadow file is a safe full snapshot

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -11,17 +11,23 @@ import (
 // FileHandle represents an open file in the FUSE filesystem.
 // WriteBuffer is defined in write.go and supports offset-based writes.
 type FileHandle struct {
-	Ino                uint64
-	Path               string
-	Layer              PathLayer
-	LocalFile          *os.File
-	Flags              uint32          // O_RDONLY, O_WRONLY, O_RDWR, O_APPEND, etc.
-	OpenPID            uint32          // PID that opened the handle, when supplied by the kernel
-	Dirty              *WriteBuffer    // write buffer, nil for read-only opens
-	DirtySeq           uint64          // monotonic sequence for authoritative dirty-size tracking
-	WriteBackSeq       uint64          // DirtySeq at time of write-back cache snapshot (0 = no snapshot)
-	OrigSize           int64           // original file size at open time (for patch detection)
-	BaseRev            int64           // server revision at open time (for conflict detection)
+	Ino          uint64
+	Path         string
+	Layer        PathLayer
+	LocalFile    *os.File
+	Flags        uint32       // O_RDONLY, O_WRONLY, O_RDWR, O_APPEND, etc.
+	OpenPID      uint32       // PID that opened the handle, when supplied by the kernel
+	Dirty        *WriteBuffer // write buffer, nil for read-only opens
+	DirtySeq     uint64       // monotonic sequence for authoritative dirty-size tracking
+	WriteBackSeq uint64       // DirtySeq at time of write-back cache snapshot (0 = no snapshot)
+	OrigSize     int64        // original file size at open time (for patch detection)
+	BaseRev      int64        // server revision at open time (for conflict detection)
+	// StorageClass is the cached view of the remote object's storage class
+	// (storageClassDB9 / storageClassS3, empty = unknown). It is seeded from
+	// the server's X-Dat9-Storage-Type stat header when available, updated
+	// after local commits and after a PATCH rejection. Write routing prefers
+	// it over the OrigSize size-heuristic when known.
+	StorageClass       string
 	ZeroBase           bool            // true when the handle has adopted an explicit empty-file baseline
 	IsNew              bool            // true if created via Create() (no prior remote existence)
 	ShadowReady        bool            // true when the local shadow file is a safe full snapshot

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -1,6 +1,7 @@
 package fuse
 
 import (
+	"fmt"
 	"log"
 	"syscall"
 )
@@ -844,6 +845,46 @@ func (wb *WriteBuffer) CanMaterializeFull() bool {
 		}
 	}
 	return true
+}
+
+// LoadMissingParts force-loads every unloaded part of the retained remote
+// prefix via the configured LoadPart loader, so Bytes()/bytesView can
+// reconstruct the complete current contents. It is a no-op when the buffer
+// has no remote-backed ranges and never marks parts dirty. Returns an error
+// when a required part cannot be loaded — no loader configured, load
+// failure, or a part evicted after streaming upload (its original bytes are
+// no longer available) — leaving previously loaded parts untouched.
+func (wb *WriteBuffer) LoadMissingParts() error {
+	if wb.smallFileData != nil {
+		return nil
+	}
+	covered := wb.remoteSize
+	if wb.totalSize < covered {
+		covered = wb.totalSize
+	}
+	if covered <= 0 {
+		return nil
+	}
+
+	numParts := int((covered + wb.partSize - 1) / wb.partSize)
+	for idx := 0; idx < numParts; idx++ {
+		if wb.IsPartLoaded(idx) {
+			continue
+		}
+		if wb.uploadedParts != nil && wb.uploadedParts[idx] {
+			return fmt.Errorf("part %d was evicted after streaming upload and cannot be refetched", idx+1)
+		}
+		if wb.LoadPart == nil {
+			return fmt.Errorf("part %d is not loaded and no lazy part loader is configured", idx+1)
+		}
+		data, err := wb.LoadPart(idx + 1) // 1-based
+		if err != nil {
+			return fmt.Errorf("load part %d: %w", idx+1, err)
+		}
+		wb.parts[idx] = data
+		wb.curMemory += int64(len(data))
+	}
+	return nil
 }
 
 // Reset clears the buffer, releasing the underlying memory.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3484,6 +3484,12 @@ func (s *Server) handleStat(w http.ResponseWriter, r *http.Request, path string)
 	}
 	if nf.File != nil {
 		w.Header().Set("X-Dat9-Revision", strconv.FormatInt(nf.File.Revision, 10))
+		// Advertise the authoritative storage class so clients (notably FUSE
+		// write-sync) can route PATCH vs full-upload on fact instead of a
+		// size-based heuristic. Older clients simply ignore the header.
+		if nf.File.StorageType != "" {
+			w.Header().Set("X-Dat9-Storage-Type", string(nf.File.StorageType))
+		}
 		if nf.File.ConfirmedAt != nil {
 			w.Header().Set("X-Dat9-Mtime", strconv.FormatInt(nf.File.ConfirmedAt.Unix(), 10))
 		} else {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -493,6 +493,39 @@ func TestStat(t *testing.T) {
 	if resp.Header.Get("X-Dat9-IsDir") != "false" {
 		t.Errorf("expected X-Dat9-IsDir false, got %s", resp.Header.Get("X-Dat9-IsDir"))
 	}
+	if got := resp.Header.Get("X-Dat9-Storage-Type"); got != "db9" {
+		t.Errorf("expected X-Dat9-Storage-Type db9 for small inline file, got %q", got)
+	}
+}
+
+func TestStatStorageTypeHeader(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	// Directory stat must not carry a storage type.
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/dir?mkdir", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("mkdir: %d", resp.StatusCode)
+	}
+
+	req, _ = http.NewRequest(http.MethodHead, ts.URL+"/v1/fs/dir", nil)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stat dir: %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Dat9-Storage-Type"); got != "" {
+		t.Errorf("expected no X-Dat9-Storage-Type for directory, got %q", got)
+	}
 }
 
 func TestBatchStatReturnsPerPathResults(t *testing.T) {


### PR DESCRIPTION
## Background

The server log keeps filling with `patch_unsupported_target`. Root cause: FUSE selects PATCH purely from a client-side size heuristic (`OrigSize >= cached inline threshold && newSize <= OrigSize`). Whenever the heuristic disagrees with the server-side storage class — a db9-stored object at size >= threshold, caused by inline-threshold changes, a stale mount-cached threshold, pre-#728 clients, or out-of-band writes — the server rejects PATCH with 400, FUSE returns EINVAL and retains dirty state. Every retry repeats the same doomed PATCH: an infinite failure loop that spams the log and makes the file unflushable. #728 fixed the same-handle truncate source of this mismatch; this PR closes the remaining class with two coexisting layers.

## Changes

**Fact-based routing layer (server + client + FUSE cache)**
- `handleStat` HEAD responses now advertise `X-Dat9-Storage-Type`; the lite stat queries fetch `storage_type` via the contents join (blob/text/description still skipped).
- `pkg/client` parses it into `StatResult.StorageType` (empty = unknown / older server) and exports `IsUnsupportedStorageTargetErr` (`shouldRewriteAppend` refactored on top of it).
- `FileHandle.StorageClass` caches the remote storage class: seeded from stat responses on the writable-open path, copied from sibling handles on preload, re-derived from committed size after successful local commits, and propagated to same-path handles after truncate commits.
- Both PATCH call sites (`flushHandle` Path 2, `syncWriteHandleToRemoteLocked`) bypass PATCH when the class is known db9; when the class is unknown the existing size heuristic applies unchanged, so behavior against older servers is identical. Zero extra requests on common paths — the header piggybacks on HEADs the client already issues.

**Self-healing fallback layer (no more EINVAL loops)**
- On a PATCH 400 (`file is not S3-stored` / `S3 not configured`), the flush records the observed class and falls back to a full conditional upload on the spot: inline in the write-sync path (fh.mu held throughout), and via a depth-bounded `flushHandle` retry in the non-layer path (commit lock already released, DirtySeq verified unchanged).
- After the fallback, the commit re-derives the class from the uploaded size: a file that crossed the threshold heals to S3 permanently; under server/client threshold skew the steady state degrades to at most one wasted PATCH per flush instead of an infinite EINVAL loop.

## Compatibility

- Old client + new server: the new header is ignored; behavior unchanged (the old-client loop still exists and only converges by upgrading).
- New client + old server: no header → class unknown → original heuristic plus the 400 fallback; the loop is eliminated.

## Tests

- server: HEAD returns `db9` for inline files, no header for directories.
- client: `StorageType` parsing (including absence on legacy servers); `IsUnsupportedStorageTargetErr` table test.
- datastore: lite stat contract updated (now returns `storage_type`).
- fuse: scenario-B regression for both flush paths (PATCH 400 → full upload, exactly one PATCH attempt, dirty cleared), known-db9 class skips PATCH, stat header seeds the handle class.

`make lint` reports 0 issues; full test suites of `pkg/datastore`, `pkg/server`, `pkg/client`, `pkg/fuse` pass (the two `TestShouldContinueAfterWaitMountPermissionError*` failures in pkg/fuse reproduce on a clean main checkout — pre-existing environment issue, unrelated to this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authoritative storage-class discovery via `X-Dat9-Storage-Type`, propagated through stat results, client metadata, and FUSE write handling (including “healing” after successful writes).

* **Bug Fixes**
  * Improved robustness when PATCH is rejected for unsupported storage targets: reliably falls back to full uploads while preserving dirty/CAS behavior.
  * Ensured safe full-materialization for lazy remote-backed data during truncate/refresh, commit, sync-write, and debounced flushes.

* **Tests**
  * Expanded unit tests for storage-type parsing and unsupported-target detection, plus new FUSE and e2e regression coverage for PATCH fallback/healing.

* **Chores**
  * Added CI and documentation updates for the new e2e suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## End-to-end verification (`e2e/fuse-patch-storage-class.sh`, wired as a PR gate in `local-e2e.yml`)

The mismatch is constructed without DB surgery: the server starts with a high `DRIVE9_INLINE_THRESHOLD` so a 200KB seed file is stored inline (db9), then restarts against the same database with a low threshold, so a freshly mounted client's cached threshold sits below the file size while the object remains db9-stored. A partial same-size overwrite through a write-sync FUSE mount then exercises exactly the production mismatch.

Locally verified matrix (macOS + macFUSE):

| Scenario | Server | Client (mount) | Result |
| --- | --- | --- | --- |
| `repro` | main `80ed57b` | main `80ed57b` | write fails `EINVAL`, `patch_unsupported_target` logged, remote content never committed — the bug reproduces |
| `fallback` | main `80ed57b` (no header) | this branch | write succeeds, exactly one PATCH attempt, full-upload fallback commits correct bytes |
| `fixed` | this branch | this branch | HEAD advertises `db9`, zero PATCH attempts, bytes correct, storage healed to `s3` |

The default `fixed` scenario runs in CI on this checkout; `repro`/`fallback` are manual cross-version replays via `DRIVE9_SERVER_BIN` / `DRIVE9_CLI_BIN` overrides (documented in `e2e/README.md` and `e2e/AGENTS.md`).
