### PR TITLE
fix(server): Retry-After on provisioning 503, 403 for failed tenants

### DIFF
--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -306,21 +306,21 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 
 		switch resolved.Tenant.Status {
 		case meta.TenantActive:
-	case meta.TenantPending:
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_pending", "tenant_id", resolved.Tenant.ID)...)
-		metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantPending))
-		errJSONRetryable(w, "tenant provisioning is pending")
-		return
-	case meta.TenantProvisioning:
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_provisioning", "tenant_id", resolved.Tenant.ID)...)
-		metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantProvisioning))
-		errJSONRetryable(w, "tenant is provisioning")
-		return
-	case meta.TenantFailed:
-		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_failed", "tenant_id", resolved.Tenant.ID)...)
-		metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantFailed))
-		errJSON(w, http.StatusForbidden, "tenant provisioning failed")
-		return
+		case meta.TenantPending:
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_pending", "tenant_id", resolved.Tenant.ID)...)
+			metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantPending))
+			errJSONRetryable(w, "tenant provisioning is pending")
+			return
+		case meta.TenantProvisioning:
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_provisioning", "tenant_id", resolved.Tenant.ID)...)
+			metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantProvisioning))
+			errJSONRetryable(w, "tenant is provisioning")
+			return
+		case meta.TenantFailed:
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_failed", "tenant_id", resolved.Tenant.ID)...)
+			metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantFailed))
+			errJSON(w, http.StatusForbidden, "tenant provisioning failed")
+			return
 		case meta.TenantSuspended, meta.TenantDeleting, meta.TenantDeleted:
 			pool.Invalidate(resolved.Tenant.ID)
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_blocked", "tenant_id", resolved.Tenant.ID, "status", resolved.Tenant.Status)...)

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -306,21 +306,21 @@ func tenantAuthMiddlewareWithFSScopeLoader(metaStore *meta.Store, pool *tenant.P
 
 		switch resolved.Tenant.Status {
 		case meta.TenantActive:
-		case meta.TenantPending:
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_pending", "tenant_id", resolved.Tenant.ID)...)
-			metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantPending))
-			errJSON(w, http.StatusServiceUnavailable, "tenant provisioning is pending")
-			return
-		case meta.TenantProvisioning:
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_provisioning", "tenant_id", resolved.Tenant.ID)...)
-			metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantProvisioning))
-			errJSON(w, http.StatusServiceUnavailable, "tenant is provisioning")
-			return
-		case meta.TenantFailed:
-			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_failed", "tenant_id", resolved.Tenant.ID)...)
-			metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantFailed))
-			errJSON(w, http.StatusServiceUnavailable, "tenant provisioning failed")
-			return
+	case meta.TenantPending:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_pending", "tenant_id", resolved.Tenant.ID)...)
+		metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantPending))
+		errJSONRetryable(w, "tenant provisioning is pending")
+		return
+	case meta.TenantProvisioning:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_provisioning", "tenant_id", resolved.Tenant.ID)...)
+		metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantProvisioning))
+		errJSONRetryable(w, "tenant is provisioning")
+		return
+	case meta.TenantFailed:
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_failed", "tenant_id", resolved.Tenant.ID)...)
+		metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantFailed))
+		errJSON(w, http.StatusForbidden, "tenant provisioning failed")
+		return
 		case meta.TenantSuspended, meta.TenantDeleting, meta.TenantDeleted:
 			pool.Invalidate(resolved.Tenant.ID)
 			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_blocked", "tenant_id", resolved.Tenant.ID, "status", resolved.Tenant.Status)...)
@@ -434,12 +434,12 @@ func handleDeleteNoAcquireAuth(w http.ResponseWriter, r *http.Request, pool *ten
 	case meta.TenantPending:
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_pending", "tenant_id", resolved.Tenant.ID)...)
 		metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantPending))
-		errJSON(w, http.StatusServiceUnavailable, "tenant provisioning is pending")
+		errJSONRetryable(w, "tenant provisioning is pending")
 		return
 	case meta.TenantProvisioning:
 		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "tenant_provisioning", "tenant_id", resolved.Tenant.ID)...)
 		metricEvent(r.Context(), "tenant_status", "status", string(meta.TenantProvisioning))
-		errJSON(w, http.StatusServiceUnavailable, "tenant is provisioning")
+		errJSONRetryable(w, "tenant is provisioning")
 		return
 	case meta.TenantSuspended:
 		pool.Invalidate(resolved.Tenant.ID)

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -935,3 +935,54 @@ func TestAuthForkDeleteSkipsPoolAcquire(t *testing.T) {
 		t.Fatalf("status=%d", resp.StatusCode)
 	}
 }
+
+func TestAuthTenantStatusResponses(t *testing.T) {
+	rt, cleanup := newAuthRuntime(t)
+	defer cleanup()
+
+	setStatus := func(status meta.TenantStatus) {
+		t.Helper()
+		if err := rt.meta.UpdateTenantStatus(context.Background(), rt.tenantID, status); err != nil {
+			t.Fatalf("set tenant status %s: %v", status, err)
+		}
+	}
+
+	h := tenantAuthMiddleware(rt.meta, rt.pool, rt.tokenSecret, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	cases := []struct {
+		name           string
+		method         string
+		path           string
+		status         meta.TenantStatus
+		wantCode       int
+		wantRetryAfter bool
+	}{
+		{"get pending is retryable", http.MethodGet, "/v1/fs/", meta.TenantPending, http.StatusServiceUnavailable, true},
+		{"get provisioning is retryable", http.MethodGet, "/v1/fs/", meta.TenantProvisioning, http.StatusServiceUnavailable, true},
+		{"get failed is forbidden", http.MethodGet, "/v1/fs/", meta.TenantFailed, http.StatusForbidden, false},
+		{"tenant delete pending is retryable", http.MethodDelete, "/v1/tenant", meta.TenantPending, http.StatusServiceUnavailable, true},
+		{"tenant delete provisioning is retryable", http.MethodDelete, "/v1/tenant", meta.TenantProvisioning, http.StatusServiceUnavailable, true},
+		{"tenant delete failed reaches handler", http.MethodDelete, "/v1/tenant", meta.TenantFailed, http.StatusNoContent, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setStatus(tc.status)
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			req.Header.Set("Authorization", "Bearer "+rt.token)
+			rr := httptest.NewRecorder()
+			h.ServeHTTP(rr, req)
+			if rr.Code != tc.wantCode {
+				t.Fatalf("status=%d want=%d body=%s", rr.Code, tc.wantCode, rr.Body.String())
+			}
+			retryAfter := rr.Header().Get("Retry-After")
+			if tc.wantRetryAfter && retryAfter == "" {
+				t.Fatal("missing Retry-After header")
+			}
+			if !tc.wantRetryAfter && retryAfter != "" {
+				t.Fatalf("unexpected Retry-After header: %q", retryAfter)
+			}
+		})
+	}
+}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6246,6 +6246,11 @@ func errJSON(w http.ResponseWriter, code int, msg string) {
 	_ = json.NewEncoder(w).Encode(map[string]string{"error": msg})
 }
 
+func errJSONRetryable(w http.ResponseWriter, msg string) {
+	w.Header().Set("Retry-After", "1")
+	errJSON(w, http.StatusServiceUnavailable, msg)
+}
+
 func errJSONInvalidRootDentry(w http.ResponseWriter, err error) bool {
 	if !errors.Is(err, datastore.ErrInvalidRootDentry) {
 		return false


### PR DESCRIPTION
## Why

- Tenant `pending`/`provisioning` responses return 503 with correct semantics (transient, retryable), but lack a `Retry-After` header, so clients cannot back off properly (as recommended in docs/design/agent-journal-design.md).
- Tenant `failed` is a persistent state; returning 503 (temporarily unavailable) is semantically inaccurate.

## Changes

- Add `errJSONRetryable`: 503 responses now consistently include `Retry-After: 1`.
- Both pending/provisioning branches in `auth.go` use `errJSONRetryable` (regular request path and `handleDeleteNoAcquireAuth`).
- `TenantFailed` now returns 403 instead of 503 (delete-tenant requests are unaffected; failed tenants are still allowed through that path).

## Test

- `make test TEST_PKGS='./pkg/server/...'` passes
- `make lint` reports 0 issues
