### PR TITLE
fix(fuse): snapshot write-back from authoritative shadow; fetch lazy layer buffers

### DIFF
--- a/e2e/suite-manifest.json
+++ b/e2e/suite-manifest.json
@@ -5,25 +5,36 @@
       "title": "API smoke",
       "product_area": "api",
       "product_promise": "HTTP API works end to end",
-      "owner_hint": "api"
+      "owner_hint": "api",
+      "failure_class": "correctness"
     },
     "cli-smoke": {
       "title": "CLI smoke",
       "product_area": "cli",
       "product_promise": "drive9 CLI works end to end",
-      "owner_hint": "cli"
+      "owner_hint": "cli",
+      "failure_class": "correctness"
     },
     "layer-fs-smoke": {
       "title": "Layer FS smoke",
       "product_area": "filesystem",
       "product_promise": "layered filesystem reads/writes are correct",
-      "owner_hint": "fs"
+      "owner_hint": "fs",
+      "failure_class": "correctness"
     },
     "fuse-smoke": {
       "title": "FUSE release gate",
       "product_area": "fuse",
       "product_promise": "FUSE mount works for release",
-      "owner_hint": "fs"
+      "owner_hint": "fs",
+      "failure_class": "correctness"
+    },
+    "fuse-patch-storage-class": {
+      "title": "FUSE patch storage-class e2e",
+      "product_area": "fuse",
+      "product_promise": "FUSE partial updates route by storage class and recover from unsupported PATCH targets",
+      "owner_hint": "fs",
+      "failure_class": "correctness"
     },
     "git-ops-smoke": {
       "title": "Git operations smoke",
@@ -36,7 +47,8 @@
       "title": "Pack smoke",
       "product_area": "portability",
       "product_promise": "portable pack/unpack round-trips losslessly",
-      "owner_hint": "fs"
+      "owner_hint": "fs",
+      "failure_class": "correctness"
     },
     "fuse-crash-recovery": {
       "title": "FUSE crash recovery e2e",
@@ -77,7 +89,8 @@
       "title": "Full smoke-all suite",
       "product_area": "platform",
       "product_promise": "the full smoke suite passes",
-      "owner_hint": "platform"
+      "owner_hint": "platform",
+      "failure_class": "correctness"
     },
     "git-feature-smoke": {
       "title": "Git feature smoke",

--- a/internal/e2ereport/manifest_sync_test.go
+++ b/internal/e2ereport/manifest_sync_test.go
@@ -1,0 +1,57 @@
+package e2ereport
+
+import (
+	"os"
+	"regexp"
+	"testing"
+)
+
+// TestSuiteManifestCoversWorkflowOutcomes pins the sync contract between
+// .github/workflows/local-e2e.yml and e2e/suite-manifest.json: every suite id
+// the workflow emits into /tmp/e2e-outcomes.json must carry product metadata,
+// and a failure outcome for it must synthesize a classified failure through
+// the real aggregator path. Without this, a newly added step id silently
+// degrades to class=unknown / promise=- / owner=- in nightly owner routing.
+func TestSuiteManifestCoversWorkflowOutcomes(t *testing.T) {
+	workflow, err := os.ReadFile("../../.github/workflows/local-e2e.yml")
+	if err != nil {
+		t.Fatalf("read workflow: %v", err)
+	}
+	manifestData, err := os.ReadFile("../../e2e/suite-manifest.json")
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	manifest, err := LoadManifest(manifestData)
+	if err != nil {
+		t.Fatalf("load manifest: %v", err)
+	}
+
+	idRe := regexp.MustCompile(`"([a-z0-9_-]+)": "\$\{\{ steps\.[a-z0-9_-]+\.outcome \}\}"`)
+	ids := idRe.FindAllStringSubmatch(string(workflow), -1)
+	if len(ids) == 0 {
+		t.Fatal("no step outcome ids found in workflow — extraction pattern broken?")
+	}
+
+	for _, match := range ids {
+		id := match[1]
+		meta, ok := manifest.Suites[id]
+		if !ok {
+			t.Errorf("workflow outcome id %q missing from e2e/suite-manifest.json", id)
+			continue
+		}
+		if meta.ProductPromise == "" || meta.OwnerHint == "" {
+			t.Errorf("manifest entry %q lacks product_promise/owner_hint: %+v", id, meta)
+		}
+
+		// A failure outcome for this suite must synthesize a fully classified
+		// failure through the real aggregator path.
+		summaries := SynthesizeSummaries(manifest, TierNightly, map[string]string{id: "failure"}, nil)
+		if len(summaries) != 1 {
+			t.Fatalf("synthesize %q: got %d summaries, want 1", id, len(summaries))
+		}
+		s := summaries[0]
+		if s.ProductPromise == "" || s.OwnerHint == "" || s.FailureClass == FailureNone || s.FailureClass == FailureUnknown {
+			t.Errorf("synthesized failure for %q is not fully classified: %+v", id, s)
+		}
+	}
+}

--- a/pkg/datastore/fs_layer.go
+++ b/pkg/datastore/fs_layer.go
@@ -588,6 +588,31 @@ func (s *Store) UpsertFSLayerEntry(ctx context.Context, entry *FSLayerEntry) err
 	if err := validateFSLayerEntryWithinBaseRoot(entry, baseRoot); err != nil {
 		return err
 	}
+	// Synchronous base-revision CAS for file content upserts. Without this
+	// gate, an upsert based on a stale base revision is persisted silently
+	// (e.g. a FUSE lazy flush that fetched retained parts after a sibling
+	// commit): the spliced bytes enter the layer, the writer's dirty state
+	// is cleared, and the mismatch only surfaces at layer-commit preflight —
+	// escalating the whole layer to Conflicted. Reject here, while the
+	// writer can still retry. base_revision <= 0 means "no base claim"
+	// (new or layer-local file) and skips the check, matching the commit
+	// preflight's semantics.
+	if entry.Op == FSLayerEntryOpUpsert && entry.Kind == FSLayerEntryKindFile && entry.BaseRevision > 0 {
+		bn, statErr := s.StatTx(ctx, tx, entry.Path)
+		if errors.Is(statErr, ErrNotFound) {
+			return fmt.Errorf("%w: base file %s missing for base_revision=%d", ErrRevisionConflict, entry.Path, entry.BaseRevision)
+		}
+		if statErr != nil {
+			return fmt.Errorf("stat base file for layer upsert %s: %w", entry.Path, statErr)
+		}
+		var currentRev int64
+		if bn.File != nil {
+			currentRev = bn.File.Revision
+		}
+		if bn.File == nil || currentRev != entry.BaseRevision {
+			return fmt.Errorf("%w: base revision changed for %s (current=%d, want=%d)", ErrRevisionConflict, entry.Path, currentRev, entry.BaseRevision)
+		}
+	}
 	if entry.EntrySeq <= 0 {
 		var seq sql.NullInt64
 		if err := tx.QueryRowContext(ctx, `SELECT MAX(entry_seq) FROM fs_layer_entries WHERE `+s.scope.And(`layer_id = ?`), s.scope.Args(entry.LayerID)...).Scan(&seq); err != nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3350,29 +3350,32 @@ func (fs *Dat9FS) snapshotWriteBackLocked(fh *FileHandle) error {
 
 	bvStart := time.Now()
 	var data []byte
-	if !fh.Dirty.CanMaterializeFull() {
-		// The buffer has parts that are not loaded (evicted under spill or
-		// never lazily loaded): bytesView() would zero-fill those ranges and
-		// the write-back cache would persist corrupted bytes. ShadowSpill and
-		// ShadowReady handles write through to the shadow store on every
-		// write, so the shadow holds the authoritative full content —
-		// snapshot from there. Any other non-materializable buffer has no
-		// authoritative secondary source: fail instead of zero-filling, and
-		// let the caller fall back to a guarded synchronous upload.
-		if fh.ShadowReady && fs.shadowStore != nil && fs.shadowStore.Has(fh.Path) {
-			shadowData, err := fs.shadowStore.ReadAll(fh.Path)
-			if err != nil {
-				return err
-			}
-			if size := fh.Dirty.Size(); int64(len(shadowData)) != size {
-				// Writes hit the shadow first and truncates are mirrored, so
-				// sizes must agree; treat any divergence as unsafe to stage.
-				return fmt.Errorf("shadow size %d != dirty size %d for %s", len(shadowData), size, fh.Path)
-			}
-			data = shadowData
-		} else {
-			return syscall.ENOTSUP
+	// ShadowSpill handles write through to the shadow store on every write,
+	// so the shadow — never the possibly evicted buffer — is the
+	// authoritative full content. Snapshot from it unconditionally: for
+	// newly created spill files CanMaterializeFull is vacuously true
+	// (remoteSize == 0) even after OnPartFull evicted part bytes from
+	// memory, and bytesView() would zero-fill those ranges.
+	// For non-spill buffers the shadow read is only needed when the buffer
+	// cannot materialize; any other non-materializable buffer has no
+	// authoritative secondary source and fails ENOTSUP instead of
+	// zero-filling, letting the caller fall back to a guarded upload.
+	fromShadow := fh.ShadowReady && fs.shadowStore != nil && fs.shadowStore.Has(fh.Path) &&
+		(fh.ShadowSpill || !fh.Dirty.CanMaterializeFull())
+	switch {
+	case fromShadow:
+		shadowData, err := fs.shadowStore.ReadAll(fh.Path)
+		if err != nil {
+			return err
 		}
+		if size := fh.Dirty.Size(); int64(len(shadowData)) != size {
+			// Writes hit the shadow first and truncates are mirrored, so
+			// sizes must agree; treat any divergence as unsafe to stage.
+			return fmt.Errorf("shadow size %d != dirty size %d for %s", len(shadowData), size, fh.Path)
+		}
+		data = shadowData
+	case !fh.Dirty.CanMaterializeFull():
+		return syscall.ENOTSUP
 	}
 	if data == nil {
 		data = fh.Dirty.bytesView()
@@ -11339,11 +11342,20 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 					} else {
 						phase = "small-snapshot-writeback"
 						snapWBStart := time.Now()
-						if err := fs.snapshotWriteBackLocked(fh); err != nil && fs.writeBack != nil {
+						// Advance WriteBackSeq only when the snapshot actually
+						// landed: the sequence gates the writeBack cache as an
+						// upload/read source, so claiming freshness after a
+						// skipped/failed snapshot could serve a stale .dat as
+						// current. On failure the next Flush/Release re-attempts
+						// the snapshot or falls back to the synchronous flush —
+						// the staged shadow + pendingIndex already carry the
+						// durable commit path.
+						if err := fs.snapshotWriteBackLocked(fh); err != nil {
 							log.Printf("writeback snapshot failed for %s: %v", fh.Path, err)
+						} else {
+							fh.WriteBackSeq = fh.DirtySeq
 						}
 						fs.perf.recordFlushSnapshotWB(time.Since(snapWBStart))
-						fh.WriteBackSeq = fh.DirtySeq
 						return gofuse.OK
 					}
 				}
@@ -11485,10 +11497,13 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 					log.Printf("flush: shadow stage failed for %s (size=%d): %v, falling through to sync upload", fh.Path, fh.Dirty.Size(), err)
 				} else {
 					phase = "large-snapshot-writeback"
-					if err := fs.snapshotWriteBackLocked(fh); err != nil && fs.writeBack != nil {
+					if err := fs.snapshotWriteBackLocked(fh); err != nil {
 						log.Printf("flush: writeback snapshot failed for %s: %v", fh.Path, err)
+					} else {
+						// See the small-snapshot-writeback path: only claim a
+						// current cache when the snapshot actually landed.
+						fh.WriteBackSeq = fh.DirtySeq
 					}
-					fh.WriteBackSeq = fh.DirtySeq
 					// If a streaming upload was already in flight, abandon it:
 					// the CommitQueue (driven by Release via the cache fast
 					// path) will read from the shadow file instead. Without
@@ -11651,10 +11666,13 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 					}
 				} else {
 					fs.releaseHandleRemoteCommitPathLocked(fh)
-					if err := fs.snapshotWriteBackLocked(fh); err != nil && fs.writeBack != nil {
+					if err := fs.snapshotWriteBackLocked(fh); err != nil {
 						log.Printf("fsync writeback snapshot failed for %s: %v", fh.Path, err)
+					} else {
+						// See the small-snapshot-writeback path: only claim a
+						// current cache when the snapshot actually landed.
+						fh.WriteBackSeq = fh.DirtySeq
 					}
-					fh.WriteBackSeq = fh.DirtySeq
 				}
 				return gofuse.OK
 			}
@@ -12539,6 +12557,14 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 
 	size := fh.Dirty.Size()
 	if fs.layerEnabled() {
+		// Freeze the upsert base BEFORE any lazy fetch. The layer branch
+		// deliberately reads the un-adopted BaseRev (expectedRevisionForHandle,
+		// not the Locked variant) and holds fh.mu for the whole branch, so a
+		// sibling commit mid-fetch cannot advance the base — the layer upsert
+		// always goes out with base M and the server-side CAS is the backstop
+		// against splicing older dirty bytes into a newer remote. Keep this
+		// capture ahead of materializeFullForUploadLocked.
+		expectedRevision := expectedRevisionForHandle(fh)
 		if fh.ShadowSpill || (fh.Streamer != nil && fh.Streamer.Started()) || !fs.materializeFullForUploadLocked(fh) {
 			if fh.ShadowSpill {
 				if err := fs.commitLayerShadowLocked(ctx, fh, true); err != nil {
@@ -12552,7 +12578,6 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		}
 		data := fh.Dirty.bytesView()
 		mode, hasMode := fs.modeForPendingHandle(fh)
-		expectedRevision := expectedRevisionForHandle(fh)
 		if err := fs.upsertLayerFile(ctx, fh.Path, data, expectedRevision, mode, hasMode); err != nil {
 			log.Printf("layer flush failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3349,7 +3349,34 @@ func (fs *Dat9FS) snapshotWriteBackLocked(fh *FileHandle) error {
 	mode, hasMode := fs.modeForPendingHandle(fh)
 
 	bvStart := time.Now()
-	data := fh.Dirty.bytesView()
+	var data []byte
+	if !fh.Dirty.CanMaterializeFull() {
+		// The buffer has parts that are not loaded (evicted under spill or
+		// never lazily loaded): bytesView() would zero-fill those ranges and
+		// the write-back cache would persist corrupted bytes. ShadowSpill and
+		// ShadowReady handles write through to the shadow store on every
+		// write, so the shadow holds the authoritative full content —
+		// snapshot from there. Any other non-materializable buffer has no
+		// authoritative secondary source: fail instead of zero-filling, and
+		// let the caller fall back to a guarded synchronous upload.
+		if fh.ShadowReady && fs.shadowStore != nil && fs.shadowStore.Has(fh.Path) {
+			shadowData, err := fs.shadowStore.ReadAll(fh.Path)
+			if err != nil {
+				return err
+			}
+			if size := fh.Dirty.Size(); int64(len(shadowData)) != size {
+				// Writes hit the shadow first and truncates are mirrored, so
+				// sizes must agree; treat any divergence as unsafe to stage.
+				return fmt.Errorf("shadow size %d != dirty size %d for %s", len(shadowData), size, fh.Path)
+			}
+			data = shadowData
+		} else {
+			return syscall.ENOTSUP
+		}
+	}
+	if data == nil {
+		data = fh.Dirty.bytesView()
+	}
 	bvDur := time.Since(bvStart)
 
 	timings, err := fs.writeBack.PutWithBaseRevAndModeTimings(
@@ -12512,7 +12539,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 
 	size := fh.Dirty.Size()
 	if fs.layerEnabled() {
-		if fh.ShadowSpill || (fh.Streamer != nil && fh.Streamer.Started()) || !fh.Dirty.CanMaterializeFull() {
+		if fh.ShadowSpill || (fh.Streamer != nil && fh.Streamer.Started()) || !fs.materializeFullForUploadLocked(fh) {
 			if fh.ShadowSpill {
 				if err := fs.commitLayerShadowLocked(ctx, fh, true); err != nil {
 					log.Printf("layer shadowspill flush failed for %s: %v", fh.Path, err)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -17209,6 +17209,147 @@ func TestFlushHandleDebouncedLazyFetchNewerRevisionSkipsUpload(t *testing.T) {
 	}
 }
 
+// TestFlushHandleLayerLazyBufferFetchesAndUpserts covers issue #815 path A:
+// in layer mode, an ordinary handle with a lazily loaded buffer must fetch
+// the missing remote-backed parts (pinned loader) and upsert the complete
+// file into the layer, instead of failing EIO and dropping the edit on
+// Release.
+func TestFlushHandleLayerLazyBufferFetchesAndUpserts(t *testing.T) {
+	var loadCalls atomic.Int32
+	var gotContent []byte
+	var gotBaseRevision int64
+
+	path := "/layer-lazy.dat"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/layers/layer_815/entries" {
+			var req struct {
+				Path         string `json:"path"`
+				Content      []byte `json:"content"`
+				BaseRevision int64  `json:"base_revision"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode layer entry: %v", err)
+			}
+			gotContent = req.Content
+			gotBaseRevision = req.BaseRevision
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"id": "entry-1", "path": req.Path})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{LayerRef: "layer_815"}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	fh, orig := newLazyTwoPartHandle(t, fs, path, true, &loadCalls)
+
+	fh.Lock()
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+
+	if st != gofuse.OK {
+		t.Fatalf("layer flush status = %v, want OK (lazy buffer must be fetched, not EIO)", st)
+	}
+	if loadCalls.Load() == 0 {
+		t.Fatal("expected lazy loader to fetch the untouched part before layer upsert")
+	}
+	want := make([]byte, 512)
+	copy(want, orig[0])
+	copy(want[256:], orig[1])
+	copy(want[:4], "WXYZ")
+	if !bytes.Equal(gotContent, want) {
+		t.Fatal("layer entry content mismatch: untouched remote-backed range not preserved")
+	}
+	if gotBaseRevision != 5 {
+		t.Fatalf("layer entry base_revision = %d, want 5 (pinned base revision)", gotBaseRevision)
+	}
+	if fh.Dirty.HasDirtyParts() {
+		t.Fatal("dirty parts remain after successful layer flush")
+	}
+}
+
+// TestSnapshotWriteBackShadowSpillUsesAuthoritativeShadow covers issue #815
+// path B: for a ShadowSpill handle with evicted parts, the write-back
+// snapshot must come from the shadow store (the authoritative write-through
+// copy), never from bytesView() which zero-fills evicted ranges.
+func TestSnapshotWriteBackShadowSpillUsesAuthoritativeShadow(t *testing.T) {
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wbCache, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.writeBack = wbCache
+
+	const baseRev int64 = 7
+	path := "/spill-wb.bin"
+
+	// The authoritative content lives in the shadow (every real Write hits
+	// the shadow first). Include the sparse edit so the expected snapshot
+	// matches the handle's current dirty state.
+	full := make([]byte, 512)
+	for i := range full {
+		full[i] = byte(i % 251)
+	}
+	copy(full[:4], "WXYZ")
+	if err := shadow.WriteFull(path, full, baseRev); err != nil {
+		t.Fatal(err)
+	}
+
+	// Dirty buffer simulating spill eviction: part 0 loaded+dirty, part 1
+	// evicted after spill — CanMaterializeFull() is false, and bytesView()
+	// would zero-fill the second half.
+	wb := NewWriteBuffer(path, maxPreloadSize, 256)
+	wb.remoteSize = 512
+	wb.totalSize = 512
+	if _, err := wb.Write(0, []byte("WXYZ")); err != nil {
+		t.Fatal(err)
+	}
+	wb.EvictPart(1)
+	if wb.CanMaterializeFull() {
+		t.Fatal("expected CanMaterializeFull() = false for spill-evicted buffer")
+	}
+
+	fh := &FileHandle{
+		Ino:         42,
+		Path:        path,
+		Dirty:       wb,
+		BaseRev:     baseRev,
+		ShadowReady: true,
+		ShadowSpill: true,
+		WritePolicy: WritePolicyWriteBack,
+	}
+	fh.DirtySeq = fs.markDirtySize(42, 512)
+
+	if err := fs.snapshotWriteBackLocked(fh); err != nil {
+		t.Fatalf("snapshotWriteBackLocked: %v", err)
+	}
+	got, ok := wbCache.Get(path)
+	if !ok {
+		t.Fatal("write-back cache has no staged content after snapshot")
+	}
+	if !bytes.Equal(got, full) {
+		t.Fatal("write-back snapshot mismatch — must come from the authoritative shadow, not zero-filled bytesView")
+	}
+}
+
 // TestFlushHandle_Path2_SyntheticRevRecordedBeforeUnlock verifies that when
 // a Path 2 flush succeeds without the server returning a committed revision
 // (e.g. PatchFile / WriteStreamConditional), the synthetic revision

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -17350,6 +17350,177 @@ func TestSnapshotWriteBackShadowSpillUsesAuthoritativeShadow(t *testing.T) {
 	}
 }
 
+// TestSnapshotWriteBackNewShadowSpillFileUsesShadow covers the #816
+// follow-up blocker: a NEW ShadowSpill file has remoteSize == 0, so
+// CanMaterializeFull() is vacuously true even after OnPartFull evicted a
+// full part from memory. The write-back snapshot must still come from the
+// authoritative shadow, not zero-filled bytesView().
+func TestSnapshotWriteBackNewShadowSpillFileUsesShadow(t *testing.T) {
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wbCache, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.writeBack = wbCache
+
+	path := "/spill-new-wb.bin"
+	// Two full parts of content, authoritative in the shadow (write-through).
+	full := make([]byte, 512)
+	for i := range full {
+		full[i] = byte(i % 239)
+	}
+	if err := shadow.WriteFull(path, full, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	// New-file dirty buffer: remoteSize stays 0, both parts written, then
+	// part 0 is evicted (spill). CanMaterializeFull() remains true because
+	// the covered remote prefix is empty — exactly the gap the old
+	// condition missed.
+	wb := NewWriteBuffer(path, maxPreloadSize, 256)
+	if _, err := wb.Write(0, full); err != nil {
+		t.Fatal(err)
+	}
+	wb.EvictPart(0)
+	if !wb.CanMaterializeFull() {
+		t.Fatal("test premise broken: new-file buffer must report CanMaterializeFull() = true")
+	}
+
+	fh := &FileHandle{
+		Ino:         42,
+		Path:        path,
+		Dirty:       wb,
+		IsNew:       true,
+		ShadowReady: true,
+		ShadowSpill: true,
+		WritePolicy: WritePolicyWriteBack,
+	}
+	fh.DirtySeq = fs.markDirtySize(42, 512)
+
+	if err := fs.snapshotWriteBackLocked(fh); err != nil {
+		t.Fatalf("snapshotWriteBackLocked: %v", err)
+	}
+	got, ok := wbCache.Get(path)
+	if !ok {
+		t.Fatal("write-back cache has no staged content after snapshot")
+	}
+	if !bytes.Equal(got, full) {
+		t.Fatal("write-back snapshot mismatch for new spill file — must come from the authoritative shadow, not zero-filled bytesView")
+	}
+}
+
+// TestFlushHandleLayerLazyFetchNewerRevisionConflicts is the layer-mode
+// cross-revision gate demanded on #816: while the lazy loader fetches a
+// missing part (observing newer remote bytes), a sibling commit is recorded.
+// The layer upsert must still go out with the frozen base revision M (never
+// the sibling's newer revision), the server-side CAS rejects it, and dirty
+// state is preserved — no splice of newer retained bytes into the older base.
+func TestFlushHandleLayerLazyFetchNewerRevisionConflicts(t *testing.T) {
+	var loadCalls atomic.Int32
+	var upsertSeen atomic.Bool
+	var gotBaseRevision atomic.Int64
+
+	path := "/layer-splice.dat"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/layers/layer_815/entries" {
+			var req struct {
+				BaseRevision int64 `json:"base_revision"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode layer entry: %v", err)
+			}
+			upsertSeen.Store(true)
+			gotBaseRevision.Store(req.BaseRevision)
+			// Remote has advanced to revision 9: base 5 must lose the CAS race.
+			w.WriteHeader(http.StatusConflict)
+			_ = json.NewEncoder(w).Encode(map[string]string{"error": "revision conflict"})
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.String())
+		w.WriteHeader(http.StatusMethodNotAllowed)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{LayerRef: "layer_815"}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	ino := fs.inodes.Lookup(path, false, 5, time.Now())
+	fs.inodes.UpdateRevision(ino, 5)
+
+	orig := make([][]byte, 2)
+	for p := range orig {
+		orig[p] = make([]byte, 256)
+		for i := range orig[p] {
+			orig[p][i] = byte(0xA0 + p*0x10 + i%16)
+		}
+	}
+
+	wb := NewWriteBuffer(path, maxPreloadSize, 256)
+	wb.remoteSize = 512
+	wb.totalSize = 512
+	// The sibling's rev-9 commit is recorded exactly when the flush fetches
+	// the missing part 2 — the ordering hazard this test pins. Part 1 loads
+	// earlier during the seeding Write and does not record.
+	wb.LoadPart = func(partNum int) ([]byte, error) {
+		loadCalls.Add(1)
+		if partNum == 2 {
+			fs.recordCommittedRevision(path, 9)
+		}
+		return append([]byte(nil), orig[partNum-1]...), nil
+	}
+
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    wb,
+		BaseRev:  5,
+		OrigSize: 512,
+	}
+	if _, err := wb.Write(0, []byte("WXYZ")); err != nil {
+		t.Fatalf("seed dirty buffer: %v", err)
+	}
+	if wb.CanMaterializeFull() {
+		t.Fatal("expected CanMaterializeFull() = false for lazy two-part buffer")
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, wb.Size())
+	_ = fs.fileHandles.Allocate(fh)
+
+	fh.Lock()
+	st := fs.flushHandle(context.Background(), fh)
+	fh.Unlock()
+
+	if st == gofuse.OK {
+		t.Fatal("layer flush status = OK, want CAS rejection — base must stay at M and lose to the newer remote")
+	}
+	if !upsertSeen.Load() {
+		t.Fatal("expected a layer upsert attempt with the frozen base revision")
+	}
+	if got := gotBaseRevision.Load(); got != 5 {
+		t.Fatalf("layer entry base_revision = %d, want 5 (frozen base M, never the sibling's newer revision)", got)
+	}
+	if loadCalls.Load() == 0 {
+		t.Fatal("expected the lazy loader to fetch the retained range from latest remote")
+	}
+	if !fh.Dirty.HasDirtyParts() {
+		t.Fatal("dirty state cleared — must be preserved after CAS rejection")
+	}
+}
+
 // TestFlushHandle_Path2_SyntheticRevRecordedBeforeUnlock verifies that when
 // a Path 2 flush succeeds without the server returning a committed revision
 // (e.g. PatchFile / WriteStreamConditional), the synthetic revision

--- a/pkg/server/fs_layer.go
+++ b/pkg/server/fs_layer.go
@@ -1674,6 +1674,10 @@ func writeFSLayerStoreError(w http.ResponseWriter, r *http.Request, err error) {
 		errJSON(w, http.StatusNotFound, "not found")
 		return
 	}
+	if errors.Is(err, datastore.ErrRevisionConflict) {
+		errJSON(w, http.StatusConflict, err.Error())
+		return
+	}
 	if errors.Is(err, datastore.ErrFSLayerRefAmbiguous) {
 		errJSON(w, http.StatusConflict, err.Error())
 		return

--- a/pkg/server/fs_layer_test.go
+++ b/pkg/server/fs_layer_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
@@ -901,5 +903,61 @@ func TestValidateFSLayerCommitSnapshotsRejectsIncomplete(t *testing.T) {
 	}})
 	if err == nil {
 		t.Fatal("validateFSLayerCommitSnapshots succeeded, want error")
+	}
+}
+
+func TestFSLayerEntryUpsertBaseRevisionCAS(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	putBase := func(body string) {
+		req, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/base.txt", strings.NewReader(body))
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("write base: %d", resp.StatusCode)
+		}
+	}
+	upsertEntry := func(baseRevision int64) int {
+		payload := fmt.Sprintf(`{"path":"/base.txt","op":"upsert","kind":"file","base_revision":%d,"content":"bGF5ZXIgZGF0YQ=="}`, baseRevision)
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/layers/layer-cas/entries", strings.NewReader(payload))
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	putBase("v1")
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/layers", strings.NewReader(`{"layer_id":"layer-cas","base_root_path":"/"}`))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("layer create: %d", resp.StatusCode)
+	}
+
+	// Upsert against the current base revision is accepted.
+	if code := upsertEntry(1); code != http.StatusOK {
+		t.Fatalf("upsert with current base revision: %d, want 200", code)
+	}
+
+	// Base moves to revision 2; the stale base_revision=1 upsert must be
+	// rejected synchronously (no silent splice into the layer).
+	putBase("v2")
+	if code := upsertEntry(1); code != http.StatusConflict {
+		t.Fatalf("upsert with stale base revision: %d, want 409", code)
+	}
+
+	// The fresh base revision is accepted again.
+	if code := upsertEntry(2); code != http.StatusOK {
+		t.Fatalf("upsert with fresh base revision: %d, want 200", code)
 	}
 }


### PR DESCRIPTION
## Background

Follow-up to #812 (merged). Fixes #815 — the two lazy-buffer zero-fill hazards qiffang identified in the write-back / shadow / layer durability subsystem, deliberately split out of #812 — and closes the `suite-manifest.json` metadata gap from his last #812 review.

## Changes

**Path B — ShadowSpill writeBack snapshot zero-fill (`snapshotWriteBackLocked`)**
- Previously, `ShadowReady`/`IsNew` handles were exempt from the `CanMaterializeFull` check and the snapshot came from `fh.Dirty.bytesView()`. For a spill-evicted buffer this zero-filled evicted ranges into the write-back cache — poisoning subsequent reads and any read-modify-write or commit-fallback that consumed the staged snapshot — while the authoritative bytes sat in the shadow store.
- Now: when the buffer cannot materialize and `ShadowReady` with a shadow present, the snapshot reads `shadowStore.ReadAll` (ShadowSpill/ShadowReady handles write through to the shadow on every write, so it is the authoritative full content). Any other non-materializable buffer fails `ENOTSUP` instead of zero-filling, letting the caller fall back to a guarded synchronous upload. A shadow/dirty size divergence fails the snapshot instead of staging suspect bytes.

**Path A — layer-mode lazy handle flush (`flushHandle` layer branch)**
- Previously returned `EIO` for `!CanMaterializeFull()` without a fetch attempt, so a recoverable lazy sparse edit failed at flush and was dropped on Release.
- Now runs `materializeFullForUploadLocked`: fetches missing remote-backed parts via the pinned lazy loader (or `EIO` when truly unmaterializable, unchanged) before upserting the complete layer entry.

**e2e metadata gap from #812's last review**
- `fuse-patch-storage-class` added to `e2e/suite-manifest.json`, and `failure_class: correctness` backfilled for the six suites that lacked one (`api-smoke`, `cli-smoke`, `layer-fs-smoke`, `fuse-smoke`, `pack-smoke`, `smoke-all`) — the aggregator previously synthesized `class=unknown` for them too.
- New sync regression `internal/e2ereport/manifest_sync_test.go`: every suite id emitted into `local-e2e.yml`'s outcomes JSON must exist in the manifest with `product_promise`/`owner_hint`, and a failure outcome must synthesize a fully classified failure through the real `SynthesizeSummaries` path. Verified end-to-end with `cmd/e2e-aggregate` (the new suite now reports `class=correctness, promise=…, owner=fs`).

## Regressions

- `TestFlushHandleLayerLazyBufferFetchesAndUpserts` — layer mode, lazy two-part buffer with loader: untouched part fetched, inline layer entry content byte-exact, `base_revision` pinned, dirty cleared. Fails against the old EIO branch.
- `TestSnapshotWriteBackShadowSpillUsesAuthoritativeShadow` — spill-evicted buffer: staged write-back content equals the authoritative shadow bytes, not a zero-filled `bytesView()`. Fails against the old snapshot path.

`make lint` 0 issues; gofmt clean; full `pkg/fuse` + `pkg/client` + `internal/e2ereport` suites pass (the two `TestShouldContinueAfterWaitMountPermissionError*` failures reproduce on clean main on macOS — pre-existing portability gap, unrelated).

Fixes #815


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented stale file updates from overwriting newer revisions.
  * Improved write-back handling for large and remotely backed files, preserving complete file contents.
  * Ensured revision conflicts return a clear `409 Conflict` response.
  * Preserved pending changes when uploads encounter revision conflicts.

* **Tests**
  * Added coverage for revision conflicts, lazy-loaded file updates, write-back snapshots, and end-to-end outcome classification.
  * Updated test metadata to consistently classify suite failures and identify ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->