### PR TITLE
fix(fuse): close git open-unlink straddle race at handle registration

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -10029,7 +10029,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		if st := fs.prepareGitOpenHandle(ctx, fh, input.Flags); st != gofuse.OK {
 			return st
 		}
-		out.Fh = fs.allocateFileHandle(fh)
+		out.Fh = fs.allocateGitWorkspaceFileHandle(fh, rt, rel)
 		out.OpenFlags = gitWorkspaceOpenFlags(rt, rel, input.Flags)
 		return gofuse.OK
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -10029,7 +10029,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 		if st := fs.prepareGitOpenHandle(ctx, fh, input.Flags); st != gofuse.OK {
 			return st
 		}
-		out.Fh = fs.allocateGitWorkspaceFileHandle(fh, rt, rel)
+		out.Fh = fs.allocateGitWorkspaceFileHandle(ctx, fh, rt, rel)
 		out.OpenFlags = gitWorkspaceOpenFlags(rt, rel, input.Flags)
 		return gofuse.OK
 	}

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -3576,7 +3576,10 @@ func (fs *Dat9FS) applyGitOverlayMirrorEntryUnlessWhiteout(fh *FileHandle, size 
 		fh.Unlinked = true
 		return
 	}
-	fs.rememberPendingGitOverlayEntry(fh.GitWorkspaceID, entry)
+	// Capture the pending seq so registration-time whiteout adoption can drop
+	// only THIS handle's stale pending entry — a legitimate same-path
+	// recreate re-remembers the path with a newer seq and must survive.
+	fh.GitPendingMirrorSeq = fs.rememberPendingGitOverlayEntry(fh.GitWorkspaceID, entry)
 }
 
 func (fs *Dat9FS) rememberPendingGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) uint64 {
@@ -4109,9 +4112,15 @@ func (fs *Dat9FS) gitCreateHandle(ctx context.Context, localPath string, flags u
 	if hasMode {
 		fs.setPendingModeLocked(fh, mode, 0)
 	}
+	// Apply the create's mirror entry BEFORE creating the dirty mirror file:
+	// a straddled open adopting the unlinked state removes the stale mirror
+	// pathname while the whiteout is still authoritative
+	// (removeGitDirtyMirrorIfWhiteout, under rt.mu). Applying first orders
+	// this create against that cleanup — the cleanup either sees this upsert
+	// (and skips the removal) or runs before this mirror exists.
+	fs.applyGitOverlayMirrorEntry(fh, 0)
 	if file, ok := fs.openGitDirtyMirrorFile(rt, rel, flags|uint32(syscall.O_TRUNC), nil); ok {
 		fh.LocalFile = file
-		fs.applyGitOverlayMirrorEntry(fh, 0)
 	}
 	fh.DirtySeq = fs.markDirtySize(ino, 0)
 	return fh, entry, gofuse.OK
@@ -4150,11 +4159,29 @@ func (fs *Dat9FS) prepareGitOpenHandle(ctx context.Context, fh *FileHandle, flag
 	}
 	accMode := flags & syscall.O_ACCMODE
 	if accMode != syscall.O_WRONLY && accMode != syscall.O_RDWR {
-		// Read-only opens do not preload. Stash the observed overlay content
-		// so a whiteout racing the rest of this open can still give the
-		// registered handle an anonymous-fd read backing instead of EOF.
-		if overlaySeen && overlayObserved.Op != "whiteout" && len(overlayObserved.Content) > 0 {
+		// Read-only opens stay preload-free for clean-tree files, but an
+		// overlay-backed fd must never be stranded without a read backing: if
+		// a whiteout races the rest of this open, registration adopts the
+		// unlinked state and Read must still serve the pre-unlink bytes — or
+		// the open must fail rather than succeed and read EOF.
+		switch {
+		case overlaySeen && overlayObserved.Op == "whiteout":
+			// The name is already gone; a stale kernel dentry can still
+			// reach here. Fail fast instead of registering an fd with no
+			// backing.
+			return gofuse.ENOENT
+		case overlaySeen && len(overlayObserved.Content) > 0:
 			fh.GitOpenSnapshot = overlayObserved.Content
+		case overlaySeen && overlayObserved.SizeBytes > 0:
+			// Metadata-only entry (list responses may omit content). Fetch
+			// the bytes now: read-through never caches the response back
+			// over a whiteout, and if the whiteout won first the read fails
+			// and the open fails fast instead of succeeding with no backing.
+			data, err := fs.readGitOverlayFile(ctx, rt, fh.Path, rel, overlayObserved, 0, -1)
+			if err != nil {
+				return gitReadErrToFuseStatus(err)
+			}
+			fh.GitOpenSnapshot = data
 		}
 		return gofuse.OK
 	}
@@ -4220,43 +4247,78 @@ func (fs *Dat9FS) prepareGitOpenHandle(ctx context.Context, fh *FileHandle, flag
 // or the re-check runs after the whiteout was applied and marks it here. The
 // handle keeps POSIX anonymous-fd semantics: reads/writes stay local, and the
 // fh.Unlinked guards suppress any mirror/flush that would upsert over the
-// whiteout.
-//
-// Adopting the unlinked state also requires three cleanups, which run right
-// after the critical section (the whiteout is already authoritative, so they
-// cannot be raced into validity):
-//
-//  1. Any pending overlay upsert this open's dirty mirror registered is
-//     dropped: a whiteout landing between the mirror's whiteout-checked
-//     apply and its rememberPendingGitOverlayEntry would otherwise leave a
-//     stale pending upsert that mergePendingGitOverlayEntries replays over
-//     the server whiteout on the next refresh. A pending upsert coexisting
-//     with an authoritative whiteout for the same path is stale by
-//     definition — a legitimate recreate applies its own overlay entry,
-//     which would have made the re-check above see an upsert instead.
-//  2. The dirty-mirror pathname is removed (mirroring putGitWhiteout):
-//     otherwise a later same-path recreate/refresh would prefer the stale
-//     anonymous mirror bytes over the replacement content. The open fd keeps
-//     working as the handle's anonymous backing.
-//  3. A read-only handle gets an anonymous-fd read backing
-//     (preserveGitUnlinkedReadBacking) so Read keeps serving pre-unlink
-//     contents instead of EOF.
+// whiteout. cleanupGitWhiteoutAdoption then finishes the adoption (see its
+// contract).
 func (fs *Dat9FS) allocateGitWorkspaceFileHandle(ctx context.Context, fh *FileHandle, rt *gitWorkspaceRuntime, rel string) uint64 {
 	fhID := fs.fileHandles.Allocate(fh)
+	if fs.registerGitWorkspaceHandle(fh, rt, rel) {
+		fs.cleanupGitWhiteoutAdoption(ctx, fh, rt, rel)
+	}
+	return fhID
+}
+
+// registerGitWorkspaceHandle adds fh to openHandles, atomically adopting the
+// unlinked state when a whiteout raced the open. Reports whether the unlinked
+// state was adopted and cleanupGitWhiteoutAdoption must run.
+func (fs *Dat9FS) registerGitWorkspaceHandle(fh *FileHandle, rt *gitWorkspaceRuntime, rel string) bool {
 	fs.openHandles.mu.Lock()
+	defer fs.openHandles.mu.Unlock()
 	marked := false
 	if e, ok := rt.overlayEntry(rel); ok && e.Op == "whiteout" {
 		fh.Unlinked = true
 		marked = true
 	}
 	fs.openHandles.addLocked(fh)
-	fs.openHandles.mu.Unlock()
-	if marked {
-		fs.forgetPendingGitOverlayEntry(fh.GitWorkspaceID, rel, 0)
-		fs.removeGitDirtyMirror(rt, rel)
-		fs.preserveGitUnlinkedReadBacking(ctx, fh, rt, rel)
+	return marked
+}
+
+// cleanupGitWhiteoutAdoption finishes adopting the unlinked state for a
+// handle registered after a whiteout. Every step is ownership-scoped so a
+// legitimate same-path recreate that landed after the registration re-check
+// cannot lose its own state to the straddled handle's cleanup:
+//
+//  1. Only THIS handle's pending mirror upsert is dropped (seq-scoped): a
+//     whiteout landing between the mirror's whiteout-checked apply and its
+//     rememberPendingGitOverlayEntry leaves a stale pending upsert that
+//     mergePendingGitOverlayEntries would replay over the server whiteout on
+//     the next refresh. A recreate re-remembers the path with a newer seq,
+//     so its entry survives.
+//  2. The dirty-mirror pathname is removed only while the whiteout is still
+//     authoritative (atomically under rt.mu): a recreate applies its overlay
+//     entry before creating its mirror, so it either flips the check to its
+//     upsert (removal skipped) or creates its mirror after the removal.
+//     Without this a later same-path recreate/refresh would prefer the stale
+//     anonymous mirror bytes over the replacement content. The open fd keeps
+//     working as the handle's anonymous backing.
+//  3. A read-only handle gets an anonymous-fd read backing
+//     (preserveGitUnlinkedReadBacking) so Read keeps serving pre-unlink
+//     contents instead of EOF.
+func (fs *Dat9FS) cleanupGitWhiteoutAdoption(ctx context.Context, fh *FileHandle, rt *gitWorkspaceRuntime, rel string) {
+	if fh.GitPendingMirrorSeq != 0 {
+		fs.forgetPendingGitOverlayEntry(fh.GitWorkspaceID, rel, fh.GitPendingMirrorSeq)
 	}
-	return fhID
+	fs.removeGitDirtyMirrorIfWhiteout(rt, rel)
+	fs.preserveGitUnlinkedReadBacking(ctx, fh, rt, rel)
+}
+
+// removeGitDirtyMirrorIfWhiteout unlinks the dirty-mirror pathname for rel
+// only while the overlay whiteout is still authoritative, holding rt.mu
+// across the check and the unlink. A legitimate same-path recreate applies
+// its overlay entry (under rt.mu via applyGitOverlayEntry/its callers) before
+// creating its mirror, so it either flips the check to its upsert — and the
+// mirror is left alone — or creates its mirror after this removal.
+func (fs *Dat9FS) removeGitDirtyMirrorIfWhiteout(rt *gitWorkspaceRuntime, rel string) {
+	if rt == nil || rel == "" {
+		return
+	}
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	if e, ok := rt.overlay[rel]; !ok || e.Op != "whiteout" {
+		return
+	}
+	if mirrorPath, ok := fs.gitWorkspaceDirtyMirrorPath(rt, rel); ok {
+		_ = os.Remove(mirrorPath)
+	}
 }
 
 // preserveGitUnlinkedReadBacking gives a read-only handle that adopted the

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -1433,7 +1433,13 @@ func (fs *Dat9FS) readGitOverlayFile(ctx context.Context, rt *gitWorkspaceRuntim
 			return nil, err
 		}
 		e = *loaded
-		fs.applyGitOverlayEntry(rt.workspace.WorkspaceID, e)
+		// The response may be a pre-whiteout snapshot (the GET raced an
+		// unlink's whiteout commit). Never cache it back over an authoritative
+		// whiteout — that would resurrect the deleted name locally and
+		// mislead the open registration check. The fetched bytes are still
+		// served to this reader: an open that raced the unlink keeps its
+		// anonymous-fd reads.
+		_, _ = fs.applyGitOverlayEntryUnlessWhiteout(rt.workspace.WorkspaceID, e)
 	}
 	if e.Op == "whiteout" {
 		return nil, os.ErrNotExist
@@ -1449,7 +1455,7 @@ func (fs *Dat9FS) readGitOverlayFile(ctx context.Context, rt *gitWorkspaceRuntim
 	}
 	if e.SizeBytes != int64(len(e.Content)) {
 		e.SizeBytes = int64(len(e.Content))
-		fs.applyGitOverlayEntry(rt.workspace.WorkspaceID, e)
+		_, _ = fs.applyGitOverlayEntryUnlessWhiteout(rt.workspace.WorkspaceID, e)
 	}
 	if ino, ok := fs.inodes.GetInode(localPath); ok {
 		fs.inodes.UpdateSize(ino, int64(len(e.Content)))
@@ -3477,6 +3483,40 @@ func (fs *Dat9FS) applyGitOverlayEntry(workspaceID string, entry client.GitOverl
 	}
 }
 
+// applyGitOverlayEntryUnlessWhiteout mirrors entry into the live overlay only
+// when no whiteout has become authoritative for the path in the meantime; the
+// check and the update share one rt.mu critical section so a racing
+// putGitWhiteout either lands first (and wins) or lands after (and
+// overwrites). It is for unsynchronized local overlay mutations — read-through
+// caching and open-time dirty-mirror upserts — that race an unlink's
+// whiteout. Server-ordered writes must keep using applyGitOverlayEntry via
+// putGitOverlayWithPolicy: overwriting the whiteout there is exactly how a
+// name is recreated after unlink.
+//
+// blockedByWhiteout reports that a whiteout is currently authoritative and the
+// entry was dropped; applied reports the entry was stored.
+func (fs *Dat9FS) applyGitOverlayEntryUnlessWhiteout(workspaceID string, entry client.GitOverlayEntry) (applied, blockedByWhiteout bool) {
+	if fs == nil || fs.git == nil {
+		return false, false
+	}
+	fs.git.mu.Lock()
+	defer fs.git.mu.Unlock()
+	for _, rt := range fs.git.workspaces {
+		if rt == nil || rt.workspace.WorkspaceID != workspaceID {
+			continue
+		}
+		rt.mu.Lock()
+		if current, ok := rt.overlay[entry.Path]; ok && current.Op == "whiteout" {
+			rt.mu.Unlock()
+			return false, true
+		}
+		rt.overlay[entry.Path] = entry
+		rt.mu.Unlock()
+		return true, false
+	}
+	return false, false
+}
+
 func (fs *Dat9FS) applyGitOverlayMirrorEntry(fh *FileHandle, size int64) {
 	if fs == nil || fh == nil || fh.Layer != PathLayerGitWorkspace || fh.GitWorkspaceID == "" || fh.GitRelPath == "" {
 		return
@@ -3502,6 +3542,41 @@ func (fs *Dat9FS) applyGitOverlayMirrorEntry(fh *FileHandle, size int64) {
 	}
 	fs.rememberPendingGitOverlayEntry(fh.GitWorkspaceID, entry)
 	fs.applyGitOverlayEntry(fh.GitWorkspaceID, entry)
+}
+
+// applyGitOverlayMirrorEntryUnlessWhiteout is the open-time variant of
+// applyGitOverlayMirrorEntry. prepareGitOpenHandle runs before the handle is
+// registered, so neither the fh.Unlinked guard above nor the unlink's marking
+// passes can protect it from a whiteout racing the open. Here the whiteout
+// check and the overlay update are atomic with putGitWhiteout's
+// applyGitOverlayEntry; when the whiteout wins, the handle adopts the
+// unlinked state instead of resurrecting the name — the same outcome the
+// registration-time check in allocateGitWorkspaceFileHandle produces.
+// gitCreateHandle keeps applyGitOverlayMirrorEntry because Create must be
+// able to overwrite a whiteout (that is how a name is recreated).
+func (fs *Dat9FS) applyGitOverlayMirrorEntryUnlessWhiteout(fh *FileHandle, size int64) {
+	if fs == nil || fh == nil || fh.Layer != PathLayerGitWorkspace || fh.GitWorkspaceID == "" || fh.GitRelPath == "" {
+		return
+	}
+	if fh.Unlinked {
+		return
+	}
+	entry := client.GitOverlayEntry{
+		WorkspaceID:    fh.GitWorkspaceID,
+		Path:           fh.GitRelPath,
+		Op:             "upsert",
+		Kind:           fh.GitKind,
+		Mode:           gitModeForHandle(fh),
+		SizeBytes:      size,
+		BaseObjectSHA:  fh.GitBaseObjectSHA,
+		ChecksumSHA256: "",
+		UpdatedAt:      time.Now(),
+	}
+	if _, blocked := fs.applyGitOverlayEntryUnlessWhiteout(fh.GitWorkspaceID, entry); blocked {
+		fh.Unlinked = true
+		return
+	}
+	fs.rememberPendingGitOverlayEntry(fh.GitWorkspaceID, entry)
 }
 
 func (fs *Dat9FS) rememberPendingGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) uint64 {
@@ -4082,7 +4157,7 @@ func (fs *Dat9FS) prepareGitOpenHandle(ctx context.Context, fh *FileHandle, flag
 		fs.inodes.UpdateSize(fh.Ino, 0)
 		if file, ok := fs.openGitDirtyMirrorFile(rt, rel, flags, nil); ok {
 			fh.LocalFile = file
-			fs.applyGitOverlayMirrorEntry(fh, 0)
+			fs.applyGitOverlayMirrorEntryUnlessWhiteout(fh, 0)
 			return gofuse.OK
 		}
 		return gofuse.OK
@@ -4121,6 +4196,30 @@ func (fs *Dat9FS) prepareGitOpenHandle(ctx context.Context, fh *FileHandle, flag
 	}
 	fh.Dirty.ClearDirty()
 	return gofuse.OK
+}
+
+// allocateGitWorkspaceFileHandle registers fh and, atomically with the
+// registration, adopts the unlinked state when a whiteout raced the open.
+//
+// prepareGitOpenHandle reads the overlay before the handle is visible to
+// anyone, so an unlink's whiteout can land after that read but before the
+// handle reaches openHandles — escaping both the unlink's pre-whiteout mark
+// and its post-commit pass. Re-checking the overlay and adding the handle
+// under one openHandles critical section closes the window: either the Add
+// precedes the post-commit pass's snapshot (and that pass marks the handle),
+// or the re-check runs after the whiteout was applied and marks it here. The
+// handle keeps POSIX anonymous-fd semantics: reads/writes stay local, and the
+// fh.Unlinked guards suppress any mirror/flush that would upsert over the
+// whiteout.
+func (fs *Dat9FS) allocateGitWorkspaceFileHandle(fh *FileHandle, rt *gitWorkspaceRuntime, rel string) uint64 {
+	fhID := fs.fileHandles.Allocate(fh)
+	fs.openHandles.mu.Lock()
+	if e, ok := rt.overlayEntry(rel); ok && e.Op == "whiteout" {
+		fh.Unlinked = true
+	}
+	fs.openHandles.addLocked(fh)
+	fs.openHandles.mu.Unlock()
+	return fhID
 }
 
 func (fs *Dat9FS) openGitDirtyMirrorFile(rt *gitWorkspaceRuntime, rel string, flags uint32, initial []byte) (*os.File, bool) {

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -4126,10 +4126,14 @@ func (fs *Dat9FS) prepareGitOpenHandle(ctx context.Context, fh *FileHandle, flag
 	fh.GitWorkspaceID = rt.workspace.WorkspaceID
 	fh.GitRelPath = rel
 	fh.GitKind = "file"
+	var overlayObserved client.GitOverlayEntry
+	overlaySeen := false
 	if e, ok := rt.overlayEntry(rel); ok {
 		fh.GitKind = e.Kind
 		fh.GitMode = e.Mode
 		fh.GitBaseObjectSHA = e.BaseObjectSHA
+		overlayObserved = e
+		overlaySeen = true
 	} else if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
 		if n, ok := rt.localHeadNode(rel); ok {
 			fh.GitKind = n.Kind
@@ -4146,6 +4150,12 @@ func (fs *Dat9FS) prepareGitOpenHandle(ctx context.Context, fh *FileHandle, flag
 	}
 	accMode := flags & syscall.O_ACCMODE
 	if accMode != syscall.O_WRONLY && accMode != syscall.O_RDWR {
+		// Read-only opens do not preload. Stash the observed overlay content
+		// so a whiteout racing the rest of this open can still give the
+		// registered handle an anonymous-fd read backing instead of EOF.
+		if overlaySeen && overlayObserved.Op != "whiteout" && len(overlayObserved.Content) > 0 {
+			fh.GitOpenSnapshot = overlayObserved.Content
+		}
 		return gofuse.OK
 	}
 
@@ -4211,15 +4221,82 @@ func (fs *Dat9FS) prepareGitOpenHandle(ctx context.Context, fh *FileHandle, flag
 // handle keeps POSIX anonymous-fd semantics: reads/writes stay local, and the
 // fh.Unlinked guards suppress any mirror/flush that would upsert over the
 // whiteout.
-func (fs *Dat9FS) allocateGitWorkspaceFileHandle(fh *FileHandle, rt *gitWorkspaceRuntime, rel string) uint64 {
+//
+// Adopting the unlinked state also requires three cleanups, which run right
+// after the critical section (the whiteout is already authoritative, so they
+// cannot be raced into validity):
+//
+//  1. Any pending overlay upsert this open's dirty mirror registered is
+//     dropped: a whiteout landing between the mirror's whiteout-checked
+//     apply and its rememberPendingGitOverlayEntry would otherwise leave a
+//     stale pending upsert that mergePendingGitOverlayEntries replays over
+//     the server whiteout on the next refresh. A pending upsert coexisting
+//     with an authoritative whiteout for the same path is stale by
+//     definition — a legitimate recreate applies its own overlay entry,
+//     which would have made the re-check above see an upsert instead.
+//  2. The dirty-mirror pathname is removed (mirroring putGitWhiteout):
+//     otherwise a later same-path recreate/refresh would prefer the stale
+//     anonymous mirror bytes over the replacement content. The open fd keeps
+//     working as the handle's anonymous backing.
+//  3. A read-only handle gets an anonymous-fd read backing
+//     (preserveGitUnlinkedReadBacking) so Read keeps serving pre-unlink
+//     contents instead of EOF.
+func (fs *Dat9FS) allocateGitWorkspaceFileHandle(ctx context.Context, fh *FileHandle, rt *gitWorkspaceRuntime, rel string) uint64 {
 	fhID := fs.fileHandles.Allocate(fh)
 	fs.openHandles.mu.Lock()
+	marked := false
 	if e, ok := rt.overlayEntry(rel); ok && e.Op == "whiteout" {
 		fh.Unlinked = true
+		marked = true
 	}
 	fs.openHandles.addLocked(fh)
 	fs.openHandles.mu.Unlock()
+	if marked {
+		fs.forgetPendingGitOverlayEntry(fh.GitWorkspaceID, rel, 0)
+		fs.removeGitDirtyMirror(rt, rel)
+		fs.preserveGitUnlinkedReadBacking(ctx, fh, rt, rel)
+	}
 	return fhID
+}
+
+// preserveGitUnlinkedReadBacking gives a read-only handle that adopted the
+// unlinked state at registration an anonymous-fd read backing, so Read keeps
+// serving the pre-unlink contents instead of EOF. Writable handles already
+// have one (the Dirty buffer or the dirty-mirror fd) and are skipped. The
+// snapshot comes from the overlay content the open observed in
+// prepareGitOpenHandle, falling back to the clean tree — object packs are
+// content-addressed and unaffected by the whiteout. Content that was never
+// fetched locally (metadata-only overlay entry) is unreachable once the
+// whiteout is authoritative; the handle keeps the pre-existing EOF behavior
+// for that residual case.
+func (fs *Dat9FS) preserveGitUnlinkedReadBacking(ctx context.Context, fh *FileHandle, rt *gitWorkspaceRuntime, rel string) {
+	if fh == nil || rt == nil || rel == "" || fh.Dirty != nil || fh.LocalFile != nil {
+		return
+	}
+	snapshot := fh.GitOpenSnapshot
+	if snapshot == nil {
+		var n client.GitTreeNode
+		found := false
+		if localTree, _ := fs.ensureGitLocalHeadTree(ctx, rt); localTree {
+			n, found = rt.localHeadNode(rel)
+		} else {
+			n, found = rt.cleanNode(rel)
+		}
+		if found && n.Kind != "dir" && n.Kind != "submodule" {
+			if data, err := fs.readGitCleanFile(ctx, rt, fh.Path, rel, n, 0, -1); err == nil &&
+				int64(len(data)) <= maxPathTruncateInMemoryBytes {
+				snapshot = data
+			}
+		}
+	}
+	if len(snapshot) == 0 {
+		return
+	}
+	fh.Lock()
+	fh.UnlinkedData = snapshot
+	fh.UnlinkedSize = int64(len(snapshot))
+	fh.UnlinkedSnapshot = true
+	fh.Unlock()
 }
 
 func (fs *Dat9FS) openGitDirtyMirrorFile(rt *gitWorkspaceRuntime, rel string, flags uint32, initial []byte) (*os.File, bool) {

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -4575,6 +4575,132 @@ func TestApplyGitOverlayMirrorEntryUnlessWhiteout(t *testing.T) {
 	}
 }
 
+// TestGitWorkspaceOpenSpanningWhiteoutCommitMarkedUnlinked replays the exact
+// straddling schedule reproduced on the PR #804 base in
+// https://github.com/mem9-ai/drive9/issues/817#issuecomment-5138095001:
+// the whiteout POST is parked FIRST, then the open's overlay GET snapshots
+// the old upsert and parks, then the whiteout commits and Unlink returns,
+// and only then does the open resume and register. On the base this produced
+// a registered handle with Unlinked == false whose write/flush flipped the
+// fixture overlay from whiteout back to upsert; here the handle must adopt
+// the unlinked state and the whiteout must survive.
+func TestGitWorkspaceOpenSpanningWhiteoutCommitMarkedUnlinked(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	fixture.mu.Lock()
+	fixture.overlay["sync.txt"] = client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "sync.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+		SizeBytes:   8,
+		// No inline content: the open's read-through does a single-entry GET,
+		// which is the park point below.
+	}
+	fixture.mu.Unlock()
+
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+
+	postWait := make(chan struct{})
+	postEntered := make(chan struct{})
+	getWait := make(chan struct{})
+	getEntered := make(chan struct{})
+	fixture.mu.Lock()
+	fixture.overlayPostWait = postWait
+	fixture.overlayPostEntered = postEntered
+	fixture.overlayGetWait = getWait
+	fixture.overlayGetEntered = getEntered
+	fixture.overlayGetFillContent = true
+	fixture.mu.Unlock()
+
+	// Step 1: start the whiteout unlink and park its overlay POST.
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt")
+	}()
+	select {
+	case <-postEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("whiteout POST never parked")
+	}
+
+	// Step 2: start the open; its overlay GET snapshots the old upsert (the
+	// whiteout has not committed yet) and parks before handle registration.
+	openDone := make(chan gofuse.Status, 1)
+	var openOut gofuse.OpenOut
+	go func() {
+		openDone <- fs.Open(nil, &gofuse.OpenIn{
+			InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+			Flags:    uint32(syscall.O_RDWR),
+		}, &openOut)
+	}()
+	select {
+	case <-getEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("overlay GET never parked")
+	}
+
+	// Step 3: release the whiteout and let the unlink finish — pass 1 already
+	// ran before the POST, and the post-commit pass still finds no handle.
+	close(postWait)
+	if st := <-unlinkDone; st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+
+	// Step 4: release the stale snapshot; the open resumes and registers.
+	close(getWait)
+	if st := <-openDone; st != gofuse.OK {
+		t.Fatalf("Open spanning whiteout status = %v, want OK (anonymous fd)", st)
+	}
+
+	// The straddling open adopted the unlinked state at registration.
+	fh, ok := fs.fileHandles.Get(openOut.Fh)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	unlinked := fh.Unlinked
+	fh.Unlock()
+	if !unlinked {
+		t.Fatal("handle registered after spanning the whiteout has Unlinked == false")
+	}
+
+	// Write/flush through the handle must not flip the committed whiteout
+	// back to an upsert.
+	v2 := []byte("git-v2-must-stay-local")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Fh:       openOut.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write after unlink on straddled handle = %v, want OK", st)
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{Fh: openOut.Fh}); st != gofuse.OK {
+		t.Fatalf("Flush after unlink on straddled handle = %v, want OK", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: openOut.Fh})
+
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	puts := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if puts != 1 {
+		t.Fatalf("overlay puts = %d, want 1 (whiteout only) — straddled handle resurrected the entry", puts)
+	}
+	if !ok || entry.Op != "whiteout" {
+		t.Fatalf("remote overlay entry = %+v, %v — want whiteout preserved", entry, ok)
+	}
+}
+
 // TestPrepareGitOpenHandleTruncOnWhiteoutAdoptsUnlinked: an O_TRUNC open whose
 // dirty-mirror upsert races a committed whiteout must lose against the
 // whiteout (adopting the unlinked state) instead of upserting the name back

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -4561,7 +4561,8 @@ func TestApplyGitOverlayMirrorEntryUnlessWhiteout(t *testing.T) {
 		t.Fatal("blocked mirror left a pending overlay entry")
 	}
 
-	// A live upsert: the mirror entry applies and is remembered as pending.
+	// A live upsert: the mirror entry applies and is remembered as pending,
+	// with the seq captured for ownership-scoped cleanup.
 	live := newGitHandle("live.txt")
 	fs.applyGitOverlayMirrorEntryUnlessWhiteout(live, 5)
 	if live.Unlinked {
@@ -4572,6 +4573,9 @@ func TestApplyGitOverlayMirrorEntryUnlessWhiteout(t *testing.T) {
 	}
 	if !pendingHas("live.txt") {
 		t.Fatal("mirror entry not remembered as pending")
+	}
+	if live.GitPendingMirrorSeq == 0 {
+		t.Fatal("mirror pending seq not captured on the handle")
 	}
 }
 
@@ -4805,15 +4809,17 @@ func TestGitWorkspaceRegistrationDropsStalePendingMirrorEntry(t *testing.T) {
 		Kind:        "file",
 	})
 	// ...and only then does the mirror's pending registration run — stale.
-	fs.rememberPendingGitOverlayEntry("ws1", upsert)
+	staleSeq := fs.rememberPendingGitOverlayEntry("ws1", upsert)
 
-	// Registration marks the straddled handle and must drop the stale pending.
+	// Registration marks the straddled handle and must drop the stale pending
+	// (seq-scoped to this handle's own mirror entry).
 	fh := &FileHandle{
-		Path:           "/repo/race.txt",
-		Layer:          PathLayerGitWorkspace,
-		GitWorkspaceID: "ws1",
-		GitRelPath:     "race.txt",
-		GitKind:        "file",
+		Path:                "/repo/race.txt",
+		Layer:               PathLayerGitWorkspace,
+		GitWorkspaceID:      "ws1",
+		GitRelPath:          "race.txt",
+		GitKind:             "file",
+		GitPendingMirrorSeq: staleSeq,
 	}
 	fs.allocateGitWorkspaceFileHandle(context.Background(), fh, rt, "race.txt")
 	if !fh.Unlinked {
@@ -4996,4 +5002,201 @@ func TestGitWorkspaceStraddledOpenRemovesStaleDirtyMirror(t *testing.T) {
 		t.Fatalf("read replacement = %q, want %q; stale trunc mirror shadowed recreated path", got, replacement)
 	}
 	fs.Release(nil, &gofuse.ReleaseIn{Fh: fhID})
+}
+
+// TestGitWorkspaceReadonlyOpenStraddlingWhiteoutReadsMetadataOnlyContent: a
+// read-only open of a metadata-only overlay entry (list responses may omit
+// content) whose read-through GET snapshots the pre-whiteout state must still
+// serve the pre-unlink bytes after registration adopts the unlinked state —
+// not EOF. prepareGitOpenHandle fetches the bytes up front for exactly this
+// case; the fixture parks the GET so the whiteout commits mid-open.
+func TestGitWorkspaceReadonlyOpenStraddlingWhiteoutReadsMetadataOnlyContent(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	want := bytes.Repeat([]byte{0x5a}, 7)
+	fixture.mu.Lock()
+	fixture.overlay["meta.txt"] = client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "meta.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+		SizeBytes:   int64(len(want)),
+		// No inline content: metadata-only — the open's read-through does a
+		// single-entry GET, which is the park point below.
+	}
+	fixture.mu.Unlock()
+
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "meta.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+
+	getWait := make(chan struct{})
+	getEntered := make(chan struct{})
+	fixture.mu.Lock()
+	fixture.overlayGetWait = getWait
+	fixture.overlayGetEntered = getEntered
+	fixture.overlayGetFillContent = true
+	fixture.mu.Unlock()
+
+	openDone := make(chan gofuse.Status, 1)
+	var openOut gofuse.OpenOut
+	go func() {
+		openDone <- fs.Open(nil, &gofuse.OpenIn{
+			InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+			Flags:    uint32(syscall.O_RDONLY),
+		}, &openOut)
+	}()
+	select {
+	case <-getEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("overlay GET never parked")
+	}
+
+	// Commit the whiteout while the open's read-through is parked on its
+	// pre-whiteout snapshot, then let the open resume and register.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "meta.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	close(getWait)
+	if st := <-openDone; st != gofuse.OK {
+		t.Fatalf("Open straddling whiteout status = %v, want OK (anonymous fd)", st)
+	}
+
+	fh, ok := fs.fileHandles.Get(openOut.Fh)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	unlinked := fh.Unlinked
+	fh.Unlock()
+	if !unlinked {
+		t.Fatal("read-only straddled handle not marked unlinked")
+	}
+
+	// The anonymous fd serves the pre-unlink bytes, not EOF.
+	buf := make([]byte, len(want))
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Fh:       openOut.Fh,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read on unlinked read-only handle = %v, want OK", st)
+	}
+	data, code := result.Bytes(buf)
+	if code != gofuse.OK {
+		t.Fatalf("Read result bytes = %v, want OK", code)
+	}
+	if !bytes.Equal(data, want) {
+		t.Fatalf("read content = %q, want %q", data, want)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: openOut.Fh})
+}
+
+// TestGitWorkspaceStraddleAdoptionPreservesSamePathRecreate: the adoption
+// cleanup that runs after the registration re-check must be ownership-scoped.
+// A legitimate same-path recreate that lands between the re-check and the
+// cleanup applies its own overlay upsert (with a newer pending seq) and then
+// creates its dirty mirror; the straddled handle's cleanup must drop only its
+// own stale pending entry and must not remove the recreate's mirror.
+func TestGitWorkspaceStraddleAdoptionPreservesSamePathRecreate(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+
+	rt, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/recreate.txt")
+	if !ok {
+		t.Fatal("workspace ws1 not loaded")
+	}
+
+	// The straddler's open-time mirror applied and remembered its upsert while
+	// no whiteout existed yet.
+	straddler := &FileHandle{
+		Path:           "/repo/recreate.txt",
+		Layer:          PathLayerGitWorkspace,
+		GitWorkspaceID: "ws1",
+		GitRelPath:     "recreate.txt",
+		GitKind:        "file",
+	}
+	fs.applyGitOverlayMirrorEntryUnlessWhiteout(straddler, 0)
+	if straddler.GitPendingMirrorSeq == 0 {
+		t.Fatal("mirror pending seq not captured on the straddler")
+	}
+
+	// The whiteout's sync commit lands (forget pending, then apply).
+	fs.forgetPendingGitOverlayEntry("ws1", "recreate.txt", 0)
+	fs.applyGitOverlayEntry("ws1", client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "recreate.txt",
+		Op:          "whiteout",
+		Kind:        "file",
+	})
+	// The straggling pending registration runs after it — stale.
+	fs.rememberPendingGitOverlayEntry("ws1", client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "recreate.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+	})
+
+	// The registration re-check sees the whiteout and marks the straddler.
+	if !fs.registerGitWorkspaceHandle(straddler, rt, "recreate.txt") {
+		t.Fatal("straddler not marked unlinked at registration")
+	}
+
+	// A legitimate recreate lands BEFORE the adoption cleanup: its overlay
+	// upsert first (newer pending seq), then its dirty mirror.
+	replacement := []byte("replacement")
+	recreate := &FileHandle{
+		Path:           "/repo/recreate.txt",
+		Layer:          PathLayerGitWorkspace,
+		GitWorkspaceID: "ws1",
+		GitRelPath:     "recreate.txt",
+		GitKind:        "file",
+	}
+	fs.applyGitOverlayMirrorEntry(recreate, int64(len(replacement)))
+	mirrorFile, ok := fs.openGitDirtyMirrorFile(rt, "recreate.txt", uint32(syscall.O_RDWR), replacement)
+	if !ok {
+		t.Fatal("recreate dirty mirror not created")
+	}
+	defer func() { _ = mirrorFile.Close() }()
+	mirrorPath, ok := fs.gitWorkspaceDirtyMirrorPath(rt, "recreate.txt")
+	if !ok {
+		t.Fatal("dirty mirror path unavailable")
+	}
+
+	// The straddler's late cleanup must not delete the recreate's state.
+	fs.cleanupGitWhiteoutAdoption(context.Background(), straddler, rt, "recreate.txt")
+
+	// The pending entry that owns the path must be the recreate's upsert (the
+	// straddler's stale size-0 entry is dropped seq-scoped; the recreate's
+	// newer-seq entry survives).
+	fs.gitOverlayMu.Lock()
+	pending, hasPending := fs.gitOverlayPending["ws1"]["recreate.txt"]
+	fs.gitOverlayMu.Unlock()
+	if !hasPending {
+		t.Fatal("adoption cleanup deleted the recreate's pending entry")
+	}
+	if pending.entry.Op != "upsert" || pending.entry.SizeBytes != int64(len(replacement)) {
+		t.Fatalf("pending entry after cleanup = %+v — want recreate upsert (size %d)", pending.entry, len(replacement))
+	}
+	entry, found := rt.overlayEntry("recreate.txt")
+	if !found || entry.Op != "upsert" || entry.SizeBytes != int64(len(replacement)) {
+		t.Fatalf("overlay after cleanup = %+v, %v — want recreate upsert preserved", entry, found)
+	}
+	mirrorData, err := os.ReadFile(mirrorPath)
+	if err != nil {
+		t.Fatalf("recreate dirty mirror removed by adoption cleanup: %v", err)
+	}
+	if !bytes.Equal(mirrorData, replacement) {
+		t.Fatalf("recreate dirty mirror content = %q, want %q", mirrorData, replacement)
+	}
 }

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -4763,3 +4763,237 @@ func TestPrepareGitOpenHandleTruncOnWhiteoutAdoptsUnlinked(t *testing.T) {
 		t.Fatal("blocked mirror left a pending overlay entry")
 	}
 }
+
+// TestGitWorkspaceRegistrationDropsStalePendingMirrorEntry replays the
+// pending-map gap from the adversarial review: the open-time mirror applies
+// its upsert, the whiteout's sync commit (forget pending, then apply) lands
+// before the mirror's pending registration runs, and the stale pending upsert
+// would be replayed by mergePendingGitOverlayEntries over the server whiteout
+// on the next refresh. Registration-time adoption of the unlinked state must
+// drop it.
+func TestGitWorkspaceRegistrationDropsStalePendingMirrorEntry(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+
+	rt, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/race.txt")
+	if !ok {
+		t.Fatal("workspace ws1 not loaded")
+	}
+
+	// The open-time mirror applies its upsert while no whiteout exists yet.
+	upsert := client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "race.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+	}
+	applied, blocked := fs.applyGitOverlayEntryUnlessWhiteout("ws1", upsert)
+	if !applied || blocked {
+		t.Fatalf("mirror apply = %v, blocked %v — want applied", applied, blocked)
+	}
+	// The parked gap: the whiteout's sync commit (forget pending, then apply)
+	// lands between the mirror's whiteout-checked apply and its pending
+	// registration...
+	fs.forgetPendingGitOverlayEntry("ws1", "race.txt", 0)
+	fs.applyGitOverlayEntry("ws1", client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "race.txt",
+		Op:          "whiteout",
+		Kind:        "file",
+	})
+	// ...and only then does the mirror's pending registration run — stale.
+	fs.rememberPendingGitOverlayEntry("ws1", upsert)
+
+	// Registration marks the straddled handle and must drop the stale pending.
+	fh := &FileHandle{
+		Path:           "/repo/race.txt",
+		Layer:          PathLayerGitWorkspace,
+		GitWorkspaceID: "ws1",
+		GitRelPath:     "race.txt",
+		GitKind:        "file",
+	}
+	fs.allocateGitWorkspaceFileHandle(context.Background(), fh, rt, "race.txt")
+	if !fh.Unlinked {
+		t.Fatal("handle not marked unlinked at registration")
+	}
+	fs.gitOverlayMu.Lock()
+	_, pending := fs.gitOverlayPending["ws1"]["race.txt"]
+	fs.gitOverlayMu.Unlock()
+	if pending {
+		t.Fatal("stale pending mirror upsert survived registration")
+	}
+
+	// A workspace refresh merging pending entries over the server state must
+	// keep the authoritative whiteout.
+	serverOverlay := map[string]client.GitOverlayEntry{
+		"race.txt": {WorkspaceID: "ws1", Path: "race.txt", Op: "whiteout", Kind: "file"},
+	}
+	fs.mergePendingGitOverlayEntries("ws1", serverOverlay)
+	if got := serverOverlay["race.txt"].Op; got != "whiteout" {
+		t.Fatalf("merged overlay op = %q, want whiteout; stale mirror pending resurrected path", got)
+	}
+}
+
+// TestGitWorkspaceReadonlyOpenStraddlingWhiteoutReadsPreUnlinkContent: a
+// read-only open whose registration adopts the unlinked state must keep
+// serving the pre-unlink contents (POSIX anonymous-fd reads), not EOF.
+// Read-only opens do not preload, so the registration-time backing comes from
+// the overlay content the open observed in prepareGitOpenHandle.
+func TestGitWorkspaceReadonlyOpenStraddlingWhiteoutReadsPreUnlinkContent(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	content := []byte("read-only-before-unlink")
+	fixture.mu.Lock()
+	fixture.overlay["ro.txt"] = client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "ro.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+		SizeBytes:   int64(len(content)),
+		Content:     content,
+	}
+	fixture.mu.Unlock()
+
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "ro.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+
+	// Model the straddle deterministically at the prepare/register boundary:
+	// prepare (read-only — stashes the observed overlay content), the
+	// whiteout commits, then registration adopts the unlinked state.
+	fh := &FileHandle{
+		Ino:         lookupOut.NodeId,
+		Path:        "/repo/ro.txt",
+		Flags:       uint32(syscall.O_RDONLY),
+		WritePolicy: WritePolicyWriteSync,
+	}
+	if st := fs.prepareGitOpenHandle(context.Background(), fh, fh.Flags); st != gofuse.OK {
+		t.Fatalf("prepareGitOpenHandle status = %v, want OK", st)
+	}
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "ro.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	rt, rel, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/ro.txt")
+	if !ok {
+		t.Fatal("workspace missing after unlink")
+	}
+	fhID := fs.allocateGitWorkspaceFileHandle(context.Background(), fh, rt, rel)
+	if !fh.Unlinked {
+		t.Fatal("read-only straddled handle not marked unlinked")
+	}
+
+	// The anonymous fd keeps serving the pre-unlink contents.
+	buf := make([]byte, len(content))
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Fh:       fhID,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read on unlinked read-only handle = %v, want OK", st)
+	}
+	data, code := result.Bytes(buf)
+	if code != gofuse.OK {
+		t.Fatalf("Read result bytes = %v, want OK", code)
+	}
+	if !bytes.Equal(data, content) {
+		t.Fatalf("read content = %q, want %q", data, content)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: fhID})
+}
+
+// TestGitWorkspaceStraddledOpenRemovesStaleDirtyMirror: when the whiteout
+// wins against an open-time dirty mirror, the mirror pathname must be removed
+// (the open fd stays as the anonymous backing). Otherwise a later same-path
+// replacement is shadowed by the stale mirror — readGitDirtyMirror is
+// consulted before the overlay entry.
+func TestGitWorkspaceStraddledOpenRemovesStaleDirtyMirror(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	fixture.mu.Lock()
+	fixture.overlay["trunc.txt"] = client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "trunc.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+		SizeBytes:   4,
+		Content:     []byte("data"),
+	}
+	fixture.mu.Unlock()
+
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "trunc.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "trunc.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+
+	// O_TRUNC prepare after the whiteout: the mirror file is created, the
+	// mirror upsert loses against the whiteout, the handle adopts unlinked.
+	fh := &FileHandle{
+		Ino:         lookupOut.NodeId,
+		Path:        "/repo/trunc.txt",
+		Flags:       uint32(syscall.O_TRUNC | syscall.O_RDWR),
+		WritePolicy: WritePolicyWriteSync,
+	}
+	if st := fs.prepareGitOpenHandle(context.Background(), fh, fh.Flags); st != gofuse.OK {
+		t.Fatalf("prepareGitOpenHandle status = %v, want OK", st)
+	}
+	if !fh.Unlinked {
+		t.Fatal("O_TRUNC open over a whiteout not marked unlinked")
+	}
+	rt, rel, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/trunc.txt")
+	if !ok {
+		t.Fatal("workspace missing after unlink")
+	}
+	mirrorPath, ok := fs.gitWorkspaceDirtyMirrorPath(rt, rel)
+	if !ok {
+		t.Fatal("dirty mirror path unavailable")
+	}
+	if _, err := os.Stat(mirrorPath); err != nil {
+		t.Fatalf("dirty mirror missing before registration: %v", err)
+	}
+
+	// Registration removes the mirror pathname; the open fd remains the
+	// handle's anonymous backing.
+	fhID := fs.allocateGitWorkspaceFileHandle(context.Background(), fh, rt, rel)
+	if _, err := os.Stat(mirrorPath); !os.IsNotExist(err) {
+		t.Fatalf("dirty mirror pathname survived registration: err=%v", err)
+	}
+
+	// A legitimate same-path replacement must serve its own bytes, not the
+	// stale anonymous mirror's.
+	replacement := []byte("replacement")
+	fs.applyGitOverlayEntry("ws1", client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "trunc.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+		SizeBytes:   int64(len(replacement)),
+		Content:     replacement,
+	})
+	got, err := fs.readGitFile(context.Background(), "/repo/trunc.txt", 0, -1)
+	if err != nil {
+		t.Fatalf("readGitFile replacement: %v", err)
+	}
+	if !bytes.Equal(got, replacement) {
+		t.Fatalf("read replacement = %q, want %q; stale trunc mirror shadowed recreated path", got, replacement)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: fhID})
+}

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -37,22 +37,32 @@ type gitWorkspaceFixture struct {
 	// overlayPostWait, so tests can open files while a whiteout is in flight.
 	overlayPostEntered     chan struct{}
 	overlayPostEnteredOnce sync.Once
-	objectPacks            map[string]client.GitObjectPack
-	state                  []byte
-	stateStorage           string
-	gitStatePuts           int
-	mode                   string
-	headCommit             string
-	deleted                bool
-	listRequests           int
-	server                 *httptest.Server
-	repoURL                string
-	treeNodes              []client.GitTreeNode
-	readmeObjectSHA        string
-	readmeSize             int64
-	failTree               bool
-	failOverlay            bool
-	failOverlayPut         bool
+	// overlayGetWait/overlayGetEntered park single-entry overlay GETs the same
+	// way, so tests can race an open's read-through against a whiteout.
+	overlayGetWait        chan struct{}
+	overlayGetEntered     chan struct{}
+	overlayGetEnteredOnce sync.Once
+	// overlayGetFillContent makes single-entry GETs synthesize deterministic
+	// content for entries seeded with a size but no inline content (modelling
+	// metadata-only list responses). Off by default so the missing-content
+	// error path stays testable.
+	overlayGetFillContent bool
+	objectPacks           map[string]client.GitObjectPack
+	state                 []byte
+	stateStorage          string
+	gitStatePuts          int
+	mode                  string
+	headCommit            string
+	deleted               bool
+	listRequests          int
+	server                *httptest.Server
+	repoURL               string
+	treeNodes             []client.GitTreeNode
+	readmeObjectSHA       string
+	readmeSize            int64
+	failTree              bool
+	failOverlay           bool
+	failOverlayPut        bool
 }
 
 type gitStateOnlyFixture struct {
@@ -357,18 +367,37 @@ func (f *gitWorkspaceFixture) handleOverlay(w http.ResponseWriter, r *http.Reque
 	switch r.Method {
 	case http.MethodGet:
 		f.mu.Lock()
-		defer f.mu.Unlock()
 		if f.failOverlay {
+			f.mu.Unlock()
 			w.WriteHeader(http.StatusInternalServerError)
 			_ = json.NewEncoder(w).Encode(map[string]string{"error": "overlay unavailable"})
 			return
 		}
 		if p := r.URL.Query().Get("path"); p != "" {
+			// Snapshot the entry and the gate channels BEFORE parking: a test
+			// that parks the GET models a response read before a concurrent
+			// whiteout committed and delayed on the wire.
 			entry, ok := f.overlay[p]
+			wait := f.overlayGetWait
+			entered := f.overlayGetEntered
+			fill := f.overlayGetFillContent
+			f.mu.Unlock()
 			if !ok {
 				w.WriteHeader(http.StatusNotFound)
 				_ = json.NewEncoder(w).Encode(map[string]string{"error": "not found"})
 				return
+			}
+			// Single-entry GETs carry the content even when list responses
+			// were metadata-only; entries seeded without content get
+			// deterministic bytes of their declared size.
+			if fill && len(entry.Content) == 0 && entry.SizeBytes > 0 {
+				entry.Content = bytes.Repeat([]byte{0x5a}, int(entry.SizeBytes))
+			}
+			if wait != nil {
+				if entered != nil {
+					f.overlayGetEnteredOnce.Do(func() { close(entered) })
+				}
+				<-wait
 			}
 			_ = json.NewEncoder(w).Encode(entry)
 			return
@@ -377,6 +406,7 @@ func (f *gitWorkspaceFixture) handleOverlay(w http.ResponseWriter, r *http.Reque
 		for _, entry := range f.overlay {
 			entries = append(entries, entry)
 		}
+		f.mu.Unlock()
 		_ = json.NewEncoder(w).Encode(map[string]any{"entries": entries})
 	case http.MethodPost, http.MethodPut:
 		var req client.GitOverlayEntryRequest
@@ -4331,5 +4361,279 @@ func TestGitWorkspaceUnlinkMarksHandlesOpenedDuringWhiteout(t *testing.T) {
 	}
 	if !ok || entry.Op != "whiteout" {
 		t.Fatalf("overlay entry = %+v, %v — want whiteout preserved", entry, ok)
+	}
+}
+
+// TestGitWorkspaceOpenStraddlingWhiteoutMarkedUnlinked: an Open whose overlay
+// read snapshots the pre-whiteout state, but whose handle registers only after
+// the unlink's whiteout and post-commit pass have both completed, must still
+// adopt the unlinked state at registration. Otherwise the handle escapes every
+// marking pass and a later write/flush upserts over the whiteout,
+// resurrecting the deleted name. Here the fixture parks the open's
+// single-entry overlay GET with a pre-whiteout snapshot already taken, the
+// unlink then commits the whiteout and finishes, and the open resumes after.
+func TestGitWorkspaceOpenStraddlingWhiteoutMarkedUnlinked(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	staleContent := bytes.Repeat([]byte{0x5a}, 8)
+	fixture.mu.Lock()
+	fixture.overlay["straddle.txt"] = client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "straddle.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+		SizeBytes:   int64(len(staleContent)),
+		// No inline content: the open's read-through does a single-entry GET,
+		// which is the park point below.
+	}
+	fixture.mu.Unlock()
+
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "straddle.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+
+	getWait := make(chan struct{})
+	getEntered := make(chan struct{})
+	fixture.mu.Lock()
+	fixture.overlayGetWait = getWait
+	fixture.overlayGetEntered = getEntered
+	fixture.overlayGetFillContent = true
+	fixture.mu.Unlock()
+
+	openDone := make(chan gofuse.Status, 1)
+	var openOut gofuse.OpenOut
+	go func() {
+		openDone <- fs.Open(nil, &gofuse.OpenIn{
+			InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+			Flags:    uint32(syscall.O_RDWR),
+		}, &openOut)
+	}()
+	select {
+	case <-getEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("overlay GET never parked")
+	}
+
+	// Commit the whiteout while the open's read is still parked on its
+	// pre-whiteout snapshot. Both marking passes find no handle for the path.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "straddle.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	close(getWait)
+	if st := <-openDone; st != gofuse.OK {
+		t.Fatalf("Open straddling whiteout status = %v, want OK (anonymous fd)", st)
+	}
+
+	// The straddling open adopted the unlinked state at registration.
+	fh, ok := fs.fileHandles.Get(openOut.Fh)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	unlinked := fh.Unlinked
+	fh.Unlock()
+	if !unlinked {
+		t.Fatal("straddling open handle not marked unlinked at registration")
+	}
+
+	// The stale GET snapshot must not have resurrected the name in the local
+	// overlay either.
+	rt, rel, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/straddle.txt")
+	if !ok {
+		t.Fatal("workspace missing after unlink")
+	}
+	if entry, found := rt.overlayEntry(rel); !found || entry.Op != "whiteout" {
+		t.Fatalf("local overlay entry = %+v, %v — want whiteout preserved", entry, found)
+	}
+
+	// Anonymous-fd reads still serve the pre-unlink content.
+	buf := make([]byte, len(staleContent))
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Fh:       openOut.Fh,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read on unlinked straddled handle = %v, want OK", st)
+	}
+	data, code := result.Bytes(buf)
+	if code != gofuse.OK {
+		t.Fatalf("Read result bytes = %v, want OK", code)
+	}
+	if !bytes.Equal(data, staleContent) {
+		t.Fatalf("Read content = %q, want pre-unlink %q", data, staleContent)
+	}
+
+	// Nothing the handle does may republish the name.
+	v2 := []byte("git-v2-must-stay-local")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Fh:       openOut.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write after unlink on straddled handle = %v, want OK", st)
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{Fh: openOut.Fh}); st != gofuse.OK {
+		t.Fatalf("Flush after unlink on straddled handle = %v, want OK", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: openOut.Fh})
+
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["straddle.txt"]
+	puts := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if puts != 1 {
+		t.Fatalf("overlay puts = %d, want 1 (whiteout only) — straddled handle resurrected the entry", puts)
+	}
+	if !ok || entry.Op != "whiteout" {
+		t.Fatalf("remote overlay entry = %+v, %v — want whiteout preserved", entry, ok)
+	}
+	if entry, found := rt.overlayEntry(rel); !found || entry.Op != "whiteout" {
+		t.Fatalf("local overlay entry after writes = %+v, %v — want whiteout preserved", entry, found)
+	}
+}
+
+// TestApplyGitOverlayMirrorEntryUnlessWhiteout covers the open-time mirror
+// primitive directly: prepareGitOpenHandle applies the O_TRUNC dirty-mirror
+// upsert before the handle is registered, so it must lose atomically against
+// an authoritative whiteout (and adopt the unlinked state) instead of
+// upserting over it.
+func TestApplyGitOverlayMirrorEntryUnlessWhiteout(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+
+	// Force the workspace runtime to load before applying overlay entries.
+	if _, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/seed"); !ok {
+		t.Fatal("workspace ws1 not loaded")
+	}
+
+	newGitHandle := func(rel string) *FileHandle {
+		return &FileHandle{
+			Path:           "/repo/" + rel,
+			Layer:          PathLayerGitWorkspace,
+			GitWorkspaceID: "ws1",
+			GitRelPath:     rel,
+			GitKind:        "file",
+		}
+	}
+	pendingHas := func(rel string) bool {
+		fs.gitOverlayMu.Lock()
+		defer fs.gitOverlayMu.Unlock()
+		_, ok := fs.gitOverlayPending["ws1"][rel]
+		return ok
+	}
+	overlayOp := func(rel string) (string, bool) {
+		rt, relPath, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/"+rel)
+		if !ok {
+			return "", false
+		}
+		entry, found := rt.overlayEntry(relPath)
+		return entry.Op, found
+	}
+
+	// A whiteout already authoritative for the path: the mirror upsert is
+	// dropped, nothing is remembered as pending, and the handle adopts the
+	// unlinked state.
+	fs.applyGitOverlayEntry("ws1", client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "gone.txt",
+		Op:          "whiteout",
+		Kind:        "file",
+	})
+	blocked := newGitHandle("gone.txt")
+	fs.applyGitOverlayMirrorEntryUnlessWhiteout(blocked, 0)
+	if !blocked.Unlinked {
+		t.Fatal("handle mirroring over a whiteout not marked unlinked")
+	}
+	if op, found := overlayOp("gone.txt"); !found || op != "whiteout" {
+		t.Fatalf("overlay after blocked mirror = %q, %v — want whiteout preserved", op, found)
+	}
+	if pendingHas("gone.txt") {
+		t.Fatal("blocked mirror left a pending overlay entry")
+	}
+
+	// A live upsert: the mirror entry applies and is remembered as pending.
+	live := newGitHandle("live.txt")
+	fs.applyGitOverlayMirrorEntryUnlessWhiteout(live, 5)
+	if live.Unlinked {
+		t.Fatal("handle on a live path wrongly marked unlinked")
+	}
+	if op, found := overlayOp("live.txt"); !found || op != "upsert" {
+		t.Fatalf("overlay after mirror = %q, %v — want upsert", op, found)
+	}
+	if !pendingHas("live.txt") {
+		t.Fatal("mirror entry not remembered as pending")
+	}
+}
+
+// TestPrepareGitOpenHandleTruncOnWhiteoutAdoptsUnlinked: an O_TRUNC open whose
+// dirty-mirror upsert races a committed whiteout must lose against the
+// whiteout (adopting the unlinked state) instead of upserting the name back
+// into the live overlay. prepareGitOpenHandle runs before handle
+// registration, so neither the unlink's marking passes nor the fh.Unlinked
+// guard in applyGitOverlayMirrorEntry can cover it.
+func TestPrepareGitOpenHandleTruncOnWhiteoutAdoptsUnlinked(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	fixture.mu.Lock()
+	fixture.overlay["trunc.txt"] = client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "trunc.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+		SizeBytes:   4,
+		Content:     []byte("data"),
+	}
+	fixture.mu.Unlock()
+
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyWriteSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "trunc.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup status = %v, want OK", st)
+	}
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "trunc.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+
+	// Model the straddle at the prepare level: the whiteout is committed
+	// before the O_TRUNC dirty-mirror upsert runs.
+	fh := &FileHandle{
+		Ino:         lookupOut.NodeId,
+		Path:        "/repo/trunc.txt",
+		Flags:       uint32(syscall.O_TRUNC | syscall.O_RDWR),
+		WritePolicy: WritePolicyWriteSync,
+	}
+	if st := fs.prepareGitOpenHandle(context.Background(), fh, fh.Flags); st != gofuse.OK {
+		t.Fatalf("prepareGitOpenHandle status = %v, want OK (anonymous fd)", st)
+	}
+	if !fh.Unlinked {
+		t.Fatal("O_TRUNC open over a whiteout not marked unlinked")
+	}
+	rt, rel, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/trunc.txt")
+	if !ok {
+		t.Fatal("workspace missing after unlink")
+	}
+	if entry, found := rt.overlayEntry(rel); !found || entry.Op != "whiteout" {
+		t.Fatalf("local overlay entry = %+v, %v — want whiteout preserved (mirror resurrected it)", entry, found)
+	}
+	fs.gitOverlayMu.Lock()
+	_, pending := fs.gitOverlayPending["ws1"]["trunc.txt"]
+	fs.gitOverlayMu.Unlock()
+	if pending {
+		t.Fatal("blocked mirror left a pending overlay entry")
 	}
 }

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -45,6 +45,12 @@ type FileHandle struct {
 	GitKind           string
 	GitMode           string
 	GitBaseObjectSHA  string
+	// GitOpenSnapshot is the overlay entry content observed by a read-only
+	// prepareGitOpenHandle. It exists so a whiteout racing the rest of the
+	// open can still give the registered handle an anonymous-fd read backing
+	// (see preserveGitUnlinkedReadBacking); nil for writable opens (they
+	// preload into Dirty / the dirty mirror) and for metadata-only entries.
+	GitOpenSnapshot   []byte
 	PendingMode       uint32 // mode change deferred because a dirty handle was open
 	HasPendingMode    bool   // true when PendingMode should be applied on Release
 	PendingModeGen    uint64 // generation for PendingMode, used to avoid clearing newer chmods

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -45,23 +45,31 @@ type FileHandle struct {
 	GitKind           string
 	GitMode           string
 	GitBaseObjectSHA  string
-	// GitOpenSnapshot is the overlay entry content observed by a read-only
-	// prepareGitOpenHandle. It exists so a whiteout racing the rest of the
-	// open can still give the registered handle an anonymous-fd read backing
-	// (see preserveGitUnlinkedReadBacking); nil for writable opens (they
-	// preload into Dirty / the dirty mirror) and for metadata-only entries.
-	GitOpenSnapshot   []byte
-	PendingMode       uint32 // mode change deferred because a dirty handle was open
-	HasPendingMode    bool   // true when PendingMode should be applied on Release
-	PendingModeGen    uint64 // generation for PendingMode, used to avoid clearing newer chmods
-	PreviousMode      uint32 // mode before PendingMode was set (for rollback on flush failure)
-	HasPreviousMode   bool   // true when previous mode state was snapshotted
-	PreviousModeKnown bool   // true when PreviousMode was authoritative
-	Unlinked          bool   // true after the directory entry was removed while this handle stayed open
-	UnlinkedSnapshot  bool   // true when UnlinkedData is an authoritative read snapshot
-	UnlinkedData      []byte // read-only snapshot for open-but-unlinked remote files
-	UnlinkedShadowGen uint64 // generation pin for large open-unlink snapshots stored in ShadowStore
-	UnlinkedSize      int64
+	// GitOpenSnapshot is the overlay entry content observed (or fetched, for
+	// metadata-only entries) by a read-only prepareGitOpenHandle. It exists
+	// so a whiteout racing the rest of the open can still give the registered
+	// handle an anonymous-fd read backing (see
+	// preserveGitUnlinkedReadBacking); nil for writable opens (they preload
+	// into Dirty / the dirty mirror) and for clean-tree files (their
+	// content-addressed backing is whiteout-immune).
+	GitOpenSnapshot []byte
+	// GitPendingMirrorSeq is the pending-map sequence of this handle's
+	// open-time dirty-mirror upsert (0 = none). Registration-time whiteout
+	// adoption uses it to drop only THIS handle's stale pending entry — a
+	// legitimate same-path recreate re-remembers the path with a newer seq
+	// and must survive the cleanup.
+	GitPendingMirrorSeq uint64
+	PendingMode         uint32 // mode change deferred because a dirty handle was open
+	HasPendingMode      bool   // true when PendingMode should be applied on Release
+	PendingModeGen      uint64 // generation for PendingMode, used to avoid clearing newer chmods
+	PreviousMode        uint32 // mode before PendingMode was set (for rollback on flush failure)
+	HasPreviousMode     bool   // true when previous mode state was snapshotted
+	PreviousModeKnown   bool   // true when PreviousMode was authoritative
+	Unlinked            bool   // true after the directory entry was removed while this handle stayed open
+	UnlinkedSnapshot    bool   // true when UnlinkedData is an authoritative read snapshot
+	UnlinkedData        []byte // read-only snapshot for open-but-unlinked remote files
+	UnlinkedShadowGen   uint64 // generation pin for large open-unlink snapshots stored in ShadowStore
+	UnlinkedSize        int64
 	// Staging generations recorded when this handle staged path-keyed state.
 	// discardUnlinkedHandleStateLocked uses them for ownership-scoped cleanup:
 	// after a pathname is unlinked and recreated, path-global removes would

--- a/pkg/fuse/open_handles.go
+++ b/pkg/fuse/open_handles.go
@@ -29,6 +29,13 @@ func (idx *OpenHandleIndex) Add(fh *FileHandle) {
 	}
 	idx.mu.Lock()
 	defer idx.mu.Unlock()
+	idx.addLocked(fh)
+}
+
+// addLocked inserts fh into the indexes; the caller must hold idx.mu. It
+// exists so a registration can be made atomic with another check (see
+// allocateGitWorkspaceFileHandle).
+func (idx *OpenHandleIndex) addLocked(fh *FileHandle) {
 	addHandleToSet(idx.byInode, fh.Ino, fh)
 	addHandleToSet(idx.byPath, fh.Path, fh)
 	idx.pathByHandle[fh] = fh.Path


### PR DESCRIPTION
## Summary

Closes the residual git-workspace open-unlink race tracked in #817 (follow-up to #804).

A git `Open` prepares its handle **before** registering it in `openHandles`. An unlink's whiteout can therefore commit after `prepareGitOpenHandle` read the overlay but before the handle is visible to either marking pass. The escaped handle (`fh.Unlinked=false`) could then upsert over the whiteout on a later write/flush and resurrect the deleted name.

Three cooperating changes close the window end to end:

1. **Registration-time whiteout check, atomic with registration** — `allocateGitWorkspaceFileHandle` re-checks the overlay and adds the handle under a single `openHandles` critical section. Either the Add precedes the unlink's post-commit `SnapshotPath` (and that pass marks the handle), or the re-check runs after the whiteout was applied (and the handle adopts `fh.Unlinked=true` itself). The open still succeeds with POSIX anonymous-fd semantics: reads/writes stay local, and the existing `fh.Unlinked` guards in `flushGitHandleLockedWithPolicy` / `flushGitLocalFileHandleLockedWithPolicy` / `applyGitOverlayMirrorEntry` suppress any republish.
2. **Stale read-through caching no longer clobbers a whiteout** — `readGitOverlayFile`'s single-entry GET can return a pre-whiteout snapshot. It is now cached via `applyGitOverlayEntryUnlessWhiteout` (check-and-set under one `rt.mu` section, atomic against `putGitWhiteout`'s apply), so the local overlay keeps the whiteout and the registration check above isn't misled. The fetched bytes are still served to the racing reader.
3. **O_TRUNC open-time mirror loses atomically against a whiteout** — `prepareGitOpenHandle`'s dirty-mirror upsert runs before registration, so the `fh.Unlinked` guard in `applyGitOverlayMirrorEntry` can't cover it. The new `applyGitOverlayMirrorEntryUnlessWhiteout` variant drops the upsert (and marks the handle unlinked) when a whiteout is authoritative. `gitCreateHandle` keeps the unconditional variant because Create must overwrite whiteouts to recreate a name.

`markOpenHandlesUnlinked` semantics, failed-whiteout rollback, unlinked LocalFile mirror suppression, and pass-2 marking from #804 are unchanged.

## Tests

- `TestGitWorkspaceOpenStraddlingWhiteoutMarkedUnlinked` — the exact #817 timeline: fixture parks the open's overlay GET with a pre-whiteout snapshot already taken, unlink commits the whiteout and finishes both marking passes, the open resumes, and the resulting handle provably cannot resurrect the path (no new overlay PUTs, whiteout preserved locally and remotely, anonymous-fd reads still serve pre-unlink content).
- `TestPrepareGitOpenHandleTruncOnWhiteoutAdoptsUnlinked` — prepare-level O_TRUNC-over-whiteout coverage.
- `TestApplyGitOverlayMirrorEntryUnlessWhiteout` — the mirror primitive directly.
- Negative controls: each of the three fixes was individually reverted and the corresponding test fails (e.g. reverting the read-through guard alone makes the registration check miss, because the stale snapshot had resurrected the local overlay entry first).
- Full `pkg/fuse` suite green except `TestShouldContinueAfterWaitMountPermissionErrorWhenProbePasses/Fails`, which fail identically on unmodified `origin/main` (environmental).
- `go test -race` on the new and neighboring unlink tests, `golangci-lint run pkg/fuse/...` → 0 issues.

Fixes #817


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Git workspace file handling during concurrent overlay updates.
  * Prevented deleted files from being unexpectedly recreated after whiteouts.
  * Ensured open handles correctly reflect files removed during concurrent operations.
  * Improved consistency for reads, writes, truncation, and unlink operations racing with deletions.
  * Preserved access to content that was opened before a concurrent deletion.
  * Removed stale file state so subsequent operations reflect the latest workspace contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->