### PR TITLE
fix: make Tencent CAM credential refresh resilient

### DIFF
--- a/pkg/s3client/tencent.go
+++ b/pkg/s3client/tencent.go
@@ -3,8 +3,10 @@ package s3client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"strings"
@@ -16,6 +18,19 @@ import (
 )
 
 const camMetaBase = "http://metadata.tencentyun.com/latest/meta-data/cam/security-credentials/"
+
+var ErrCAMMetadataUnavailable = errors.New("cam metadata temporarily unavailable")
+
+const (
+	camMetadataRequestTimeout = 2 * time.Second
+	camMetadataMaxAttempts    = 3
+	camMetadataRetryBackoff   = 100 * time.Millisecond
+	camCredentialRefreshAhead = 5 * time.Minute
+	camCredentialFallbackMin  = time.Minute
+
+	camMetadataListRolesOperation      = "cam_metadata_list_roles"
+	camMetadataGetCredentialsOperation = "cam_metadata_get_credentials"
+)
 
 func isTencentEndpoint(endpoint string) bool {
 	if len(endpoint) == 0 {
@@ -50,61 +65,92 @@ func tencentSecretKey() string {
 }
 
 type camProvider struct {
-	mu        sync.Mutex
-	cached    aws.Credentials
-	expiresAt time.Time
-	client    *http.Client
+	mu           sync.Mutex
+	cached       aws.Credentials
+	expiresAt    time.Time
+	client       *http.Client
+	metadataURL  string
+	maxAttempts  int
+	retryBackoff time.Duration
+	refreshAhead time.Duration
+	fallbackMin  time.Duration
+	keepExpiry   bool
 }
 
 func newCAMProvider() *camProvider {
 	return &camProvider{
-		client: &http.Client{Timeout: 5 * time.Second},
+		client:       &http.Client{Timeout: camMetadataRequestTimeout},
+		metadataURL:  camMetaBase,
+		maxAttempts:  camMetadataMaxAttempts,
+		retryBackoff: camMetadataRetryBackoff,
+		refreshAhead: camCredentialRefreshAhead,
+		fallbackMin:  camCredentialFallbackMin,
 	}
+}
+
+func newCAMCredentialsProvider(provider *camProvider, refreshAhead time.Duration) *aws.CredentialsCache {
+	return aws.NewCredentialsCache(provider, func(options *aws.CredentialsCacheOptions) {
+		options.ExpiryWindow = refreshAhead
+	})
 }
 
 func (p *camProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if time.Now().Before(p.expiresAt.Add(-5 * time.Minute)) {
+	now := time.Now()
+	if now.Before(p.expiresAt.Add(-p.refreshAhead)) {
+		p.keepExpiry = false
 		return p.cached, nil
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, camMetaBase, nil)
+	creds, expiry, err := p.retrieveFresh(ctx)
 	if err != nil {
-		return aws.Credentials{}, fmt.Errorf("cam: create list roles request: %w", err)
+		if errors.Is(err, ErrCAMMetadataUnavailable) &&
+			p.cached.AccessKeyID != "" &&
+			time.Now().Before(p.expiresAt.Add(-p.fallbackMin)) {
+			p.keepExpiry = true
+			return p.cached, nil
+		}
+		p.keepExpiry = false
+		return aws.Credentials{}, err
 	}
-	resp, err := p.client.Do(req)
+	p.cached = creds
+	p.expiresAt = expiry
+	p.keepExpiry = false
+	return p.cached, nil
+}
+
+func (p *camProvider) AdjustExpiresBy(creds aws.Credentials, duration time.Duration) (aws.Credentials, error) {
+	p.mu.Lock()
+	keepExpiry := p.keepExpiry
+	p.keepExpiry = false
+	p.mu.Unlock()
+	if keepExpiry || !creds.CanExpire {
+		return creds, nil
+	}
+	creds.Expires = creds.Expires.Add(duration)
+	return creds, nil
+}
+
+func (p *camProvider) retrieveFresh(ctx context.Context) (aws.Credentials, time.Time, error) {
+	listStart := time.Now()
+	body, err := p.fetchMetadata(ctx, p.metadataURL, "cam: list roles")
 	if err != nil {
-		return aws.Credentials{}, fmt.Errorf("cam: list roles: %w", err)
-	}
-	body, err := io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	if err != nil {
-		return aws.Credentials{}, fmt.Errorf("cam: read list roles response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return aws.Credentials{}, fmt.Errorf("cam: list roles: status %d", resp.StatusCode)
+		recordS3Operation(camMetadataListRolesOperation, camMetadataResult(err), listStart)
+		return aws.Credentials{}, time.Time{}, err
 	}
 	roleName := strings.TrimSpace(string(body))
 	if roleName == "" {
-		return aws.Credentials{}, fmt.Errorf("cam: no role bound to instance")
+		recordS3Operation(camMetadataListRolesOperation, "role_missing", listStart)
+		return aws.Credentials{}, time.Time{}, fmt.Errorf("cam: no role bound to instance")
 	}
+	recordS3Operation(camMetadataListRolesOperation, "ok", listStart)
 
-	req, err = http.NewRequestWithContext(ctx, http.MethodGet, camMetaBase+roleName, nil)
+	credentialsStart := time.Now()
+	body, err = p.fetchMetadata(ctx, p.metadataURL+roleName, fmt.Sprintf("cam: get credentials for %s", roleName))
 	if err != nil {
-		return aws.Credentials{}, fmt.Errorf("cam: create get credentials request: %w", err)
-	}
-	resp, err = p.client.Do(req)
-	if err != nil {
-		return aws.Credentials{}, fmt.Errorf("cam: get credentials for %s: %w", roleName, err)
-	}
-	body, err = io.ReadAll(resp.Body)
-	_ = resp.Body.Close()
-	if err != nil {
-		return aws.Credentials{}, fmt.Errorf("cam: read get credentials response: %w", err)
-	}
-	if resp.StatusCode != http.StatusOK {
-		return aws.Credentials{}, fmt.Errorf("cam: get credentials: status %d", resp.StatusCode)
+		recordS3Operation(camMetadataGetCredentialsOperation, camMetadataResult(err), credentialsStart)
+		return aws.Credentials{}, time.Time{}, err
 	}
 
 	var creds struct {
@@ -114,24 +160,137 @@ func (p *camProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 		Expiration   string `json:"Expiration"`
 	}
 	if err := json.Unmarshal(body, &creds); err != nil {
-		return aws.Credentials{}, fmt.Errorf("cam: parse credentials: %w", err)
+		recordS3Operation(camMetadataGetCredentialsOperation, "invalid_response", credentialsStart)
+		return aws.Credentials{}, time.Time{}, fmt.Errorf("cam: parse credentials: %w", err)
+	}
+	if creds.TmpSecretId == "" || creds.TmpSecretKey == "" {
+		recordS3Operation(camMetadataGetCredentialsOperation, "invalid_response", credentialsStart)
+		return aws.Credentials{}, time.Time{}, fmt.Errorf("cam: credentials response is missing access key fields")
 	}
 
 	expiry, err := time.Parse(time.RFC3339, creds.Expiration)
 	if err != nil {
-		return aws.Credentials{}, fmt.Errorf("cam: parse expiration %q: %w", creds.Expiration, err)
+		recordS3Operation(camMetadataGetCredentialsOperation, "invalid_response", credentialsStart)
+		return aws.Credentials{}, time.Time{}, fmt.Errorf("cam: parse expiration %q: %w", creds.Expiration, err)
 	}
+	recordS3Operation(camMetadataGetCredentialsOperation, "ok", credentialsStart)
 
-	p.cached = aws.Credentials{
+	return aws.Credentials{
 		AccessKeyID:     creds.TmpSecretId,
 		SecretAccessKey: creds.TmpSecretKey,
 		SessionToken:    creds.Token,
 		Source:          "TencentCAMRole",
 		CanExpire:       true,
 		Expires:         expiry,
+	}, expiry, nil
+}
+
+func (p *camProvider) fetchMetadata(ctx context.Context, url, operation string) ([]byte, error) {
+	attempts := p.maxAttempts
+	if attempts < 1 {
+		attempts = 1
 	}
-	p.expiresAt = expiry
-	return p.cached, nil
+	var lastErr error
+	lastRetryable := false
+	for attempt := 1; attempt <= attempts; attempt++ {
+		body, retryable, err := p.fetchMetadataOnce(ctx, url, operation)
+		if err == nil {
+			return body, nil
+		}
+		lastErr = err
+		lastRetryable = retryable
+		if !retryable || attempt == attempts {
+			break
+		}
+		if err := waitForCAMRetry(ctx, p.retryBackoff*time.Duration(attempt)); err != nil {
+			return nil, fmt.Errorf("%s: %w", operation, err)
+		}
+	}
+	if lastRetryable {
+		return nil, &camMetadataUnavailableError{err: lastErr}
+	}
+	return nil, lastErr
+}
+
+func (p *camProvider) fetchMetadataOnce(ctx context.Context, url, operation string) ([]byte, bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, false, fmt.Errorf("%s: create request: %w", operation, err)
+	}
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, ctx.Err() == nil, fmt.Errorf("%s: %w", operation, err)
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if readErr != nil {
+		return nil, ctx.Err() == nil, fmt.Errorf("%s: read response: %w", operation, readErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		retryable := resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= http.StatusInternalServerError
+		return nil, retryable, fmt.Errorf("%s: %w", operation, &camMetadataStatusError{statusCode: resp.StatusCode})
+	}
+	return body, false, nil
+}
+
+type camMetadataStatusError struct {
+	statusCode int
+}
+
+func (e *camMetadataStatusError) Error() string {
+	return fmt.Sprintf("metadata status %d", e.statusCode)
+}
+
+type camMetadataUnavailableError struct {
+	err error
+}
+
+func (e *camMetadataUnavailableError) Error() string {
+	return e.err.Error()
+}
+
+func (e *camMetadataUnavailableError) Unwrap() error {
+	return e.err
+}
+
+func (e *camMetadataUnavailableError) Is(target error) bool {
+	return target == ErrCAMMetadataUnavailable
+}
+
+func camMetadataResult(err error) string {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return "timeout"
+	}
+	var networkErr net.Error
+	if errors.As(err, &networkErr) && networkErr.Timeout() {
+		return "timeout"
+	}
+	var statusErr *camMetadataStatusError
+	if errors.As(err, &statusErr) {
+		switch {
+		case statusErr.statusCode == http.StatusTooManyRequests:
+			return "throttled"
+		case statusErr.statusCode >= http.StatusInternalServerError:
+			return "server_error"
+		default:
+			return "rejected"
+		}
+	}
+	return "unavailable"
+}
+
+func waitForCAMRetry(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }
 
 func credentialsForTencent(cfg AWSConfig) (aws.CredentialsProvider, error) {
@@ -148,7 +307,8 @@ func credentialsForTencent(cfg AWSConfig) (aws.CredentialsProvider, error) {
 		}
 		return credentials.NewStaticCredentialsProvider(accessKeyID, secretAccessKey, sessionToken), nil
 	}
-	return newCAMProvider(), nil
+	provider := newCAMProvider()
+	return newCAMCredentialsProvider(provider, provider.refreshAhead), nil
 }
 
 func newTencent(ctx context.Context, cfg AWSConfig) (*AWSS3Client, error) {

--- a/pkg/s3client/tencent.go
+++ b/pkg/s3client/tencent.go
@@ -65,16 +65,16 @@ func tencentSecretKey() string {
 }
 
 type camProvider struct {
-	mu           sync.Mutex
-	cached       aws.Credentials
-	expiresAt    time.Time
-	client       *http.Client
-	metadataURL  string
-	maxAttempts  int
-	retryBackoff time.Duration
-	refreshAhead time.Duration
-	fallbackMin  time.Duration
-	keepExpiry   bool
+	mu             sync.Mutex
+	cached         aws.Credentials
+	expiresAt      time.Time
+	client         *http.Client
+	metadataURL    string
+	maxAttempts    int
+	retryBackoff   time.Duration
+	refreshAhead   time.Duration
+	fallbackMin    time.Duration
+	fallbackResult bool
 }
 
 func newCAMProvider() *camProvider {
@@ -99,7 +99,7 @@ func (p *camProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 	defer p.mu.Unlock()
 	now := time.Now()
 	if now.Before(p.expiresAt.Add(-p.refreshAhead)) {
-		p.keepExpiry = false
+		p.fallbackResult = false
 		return p.cached, nil
 	}
 
@@ -108,24 +108,28 @@ func (p *camProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
 		if errors.Is(err, ErrCAMMetadataUnavailable) &&
 			p.cached.AccessKeyID != "" &&
 			time.Now().Before(p.expiresAt.Add(-p.fallbackMin)) {
-			p.keepExpiry = true
+			p.fallbackResult = true
 			return p.cached, nil
 		}
-		p.keepExpiry = false
+		p.fallbackResult = false
 		return aws.Credentials{}, err
 	}
 	p.cached = creds
 	p.expiresAt = expiry
-	p.keepExpiry = false
+	p.fallbackResult = false
 	return p.cached, nil
 }
 
 func (p *camProvider) AdjustExpiresBy(creds aws.Credentials, duration time.Duration) (aws.Credentials, error) {
 	p.mu.Lock()
-	keepExpiry := p.keepExpiry
-	p.keepExpiry = false
+	fallbackResult := p.fallbackResult
+	p.fallbackResult = false
 	p.mu.Unlock()
-	if keepExpiry || !creds.CanExpire {
+	if !creds.CanExpire {
+		return creds, nil
+	}
+	if fallbackResult {
+		creds.Expires = creds.Expires.Add(-p.fallbackMin)
 		return creds, nil
 	}
 	creds.Expires = creds.Expires.Add(duration)

--- a/pkg/s3client/tencent_test.go
+++ b/pkg/s3client/tencent_test.go
@@ -110,7 +110,7 @@ func TestCAMProviderFallsBackToSafelyUnexpiredCredentials(t *testing.T) {
 	}
 }
 
-func TestCAMCredentialsCacheFallbackPreservesActualExpiry(t *testing.T) {
+func TestCAMCredentialsCacheFallbackStopsBeforeSafetyMargin(t *testing.T) {
 	expiry := time.Now().Add(10 * time.Minute)
 	var metadataCalls atomic.Int32
 	var metadataUnavailable atomic.Bool
@@ -149,8 +149,8 @@ func TestCAMCredentialsCacheFallbackPreservesActualExpiry(t *testing.T) {
 	if creds.AccessKeyID != "tmp-id" {
 		t.Fatalf("fallback AccessKeyID = %q, want tmp-id", creds.AccessKeyID)
 	}
-	if !creds.Expires.Equal(expiry) {
-		t.Fatalf("fallback expiry = %v, want actual expiry %v", creds.Expires, expiry)
+	if want := expiry.Add(-provider.fallbackMin); !creds.Expires.Equal(want) {
+		t.Fatalf("fallback expiry = %v, want safety cutoff %v", creds.Expires, want)
 	}
 	callsAfterFallback := metadataCalls.Load()
 	if _, err := credentials.Retrieve(context.Background()); err != nil {

--- a/pkg/s3client/tencent_test.go
+++ b/pkg/s3client/tencent_test.go
@@ -1,0 +1,315 @@
+package s3client
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+func camCredentialsJSON(expiry time.Time) string {
+	return `{"TmpSecretId":"tmp-id","TmpSecretKey":"tmp-key","Token":"tmp-token","Expiration":"` + expiry.UTC().Format(time.RFC3339Nano) + `"}`
+}
+
+func newTestCAMProvider(server *httptest.Server) *camProvider {
+	provider := newCAMProvider()
+	provider.client = &http.Client{Timeout: 20 * time.Millisecond}
+	provider.metadataURL = server.URL + "/security-credentials/"
+	provider.maxAttempts = 2
+	provider.retryBackoff = 0
+	return provider
+}
+
+func isCAMRoleListRequest(req *http.Request) bool {
+	return strings.HasSuffix(req.URL.Path, "/security-credentials/")
+}
+
+func TestCAMProviderRetrievesCredentials(t *testing.T) {
+	expiry := time.Now().Add(time.Hour).UTC().Truncate(time.Second)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if isCAMRoleListRequest(req) {
+			_, _ = w.Write([]byte("drive9-cos-role"))
+			return
+		}
+		_, _ = w.Write([]byte(camCredentialsJSON(expiry)))
+	}))
+	defer server.Close()
+	provider := newTestCAMProvider(server)
+
+	creds, err := provider.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("Retrieve() error = %v", err)
+	}
+	if creds.AccessKeyID != "tmp-id" || creds.SecretAccessKey != "tmp-key" || creds.SessionToken != "tmp-token" {
+		t.Fatalf("Retrieve() credentials = %#v", creds)
+	}
+	if !creds.Expires.Equal(expiry) {
+		t.Fatalf("Retrieve() expiry = %v, want %v", creds.Expires, expiry)
+	}
+}
+
+func TestCAMProviderRetriesTransientCredentialTimeout(t *testing.T) {
+	expiry := time.Now().Add(time.Hour)
+	var credentialCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if isCAMRoleListRequest(req) {
+			_, _ = w.Write([]byte("drive9-cos-role"))
+			return
+		}
+		if credentialCalls.Add(1) == 1 {
+			<-req.Context().Done()
+			return
+		}
+		_, _ = w.Write([]byte(camCredentialsJSON(expiry)))
+	}))
+	defer server.Close()
+	provider := newTestCAMProvider(server)
+
+	creds, err := provider.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("Retrieve() error = %v", err)
+	}
+	if creds.AccessKeyID != "tmp-id" {
+		t.Fatalf("Retrieve() AccessKeyID = %q, want tmp-id", creds.AccessKeyID)
+	}
+	if got := credentialCalls.Load(); got != 2 {
+		t.Fatalf("credential metadata calls = %d, want 2", got)
+	}
+}
+
+func TestCAMProviderFallsBackToSafelyUnexpiredCredentials(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	defer server.Close()
+	oldCreds := aws.Credentials{
+		AccessKeyID:     "old-id",
+		SecretAccessKey: "old-key",
+		SessionToken:    "old-token",
+		Source:          "TencentCAMRole",
+		CanExpire:       true,
+		Expires:         time.Now().Add(2 * time.Minute),
+	}
+	provider := newTestCAMProvider(server)
+	provider.cached = oldCreds
+	provider.expiresAt = oldCreds.Expires
+
+	creds, err := provider.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("Retrieve() error = %v", err)
+	}
+	if creds.AccessKeyID != oldCreds.AccessKeyID {
+		t.Fatalf("Retrieve() AccessKeyID = %q, want %q", creds.AccessKeyID, oldCreds.AccessKeyID)
+	}
+}
+
+func TestCAMCredentialsCacheFallbackPreservesActualExpiry(t *testing.T) {
+	expiry := time.Now().Add(10 * time.Minute)
+	var metadataCalls atomic.Int32
+	var metadataUnavailable atomic.Bool
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		metadataCalls.Add(1)
+		if metadataUnavailable.Load() {
+			<-req.Context().Done()
+			return
+		}
+		if isCAMRoleListRequest(req) {
+			_, _ = w.Write([]byte("drive9-cos-role"))
+			return
+		}
+		_, _ = w.Write([]byte(camCredentialsJSON(expiry)))
+	}))
+	defer server.Close()
+	provider := newTestCAMProvider(server)
+	provider.client.Timeout = 20 * time.Millisecond
+	provider.maxAttempts = 1
+	credentials := newCAMCredentialsProvider(provider, provider.refreshAhead)
+
+	initialCreds, err := credentials.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("initial Retrieve() error = %v", err)
+	}
+	if want := expiry.Add(-provider.refreshAhead); !initialCreds.Expires.Equal(want) {
+		t.Fatalf("initial expiry = %v, want early refresh at %v", initialCreds.Expires, want)
+	}
+	metadataUnavailable.Store(true)
+	provider.refreshAhead = 11 * time.Minute
+	credentials.Invalidate()
+	creds, err := credentials.Retrieve(context.Background())
+	if err != nil {
+		t.Fatalf("fallback Retrieve() error = %v", err)
+	}
+	if creds.AccessKeyID != "tmp-id" {
+		t.Fatalf("fallback AccessKeyID = %q, want tmp-id", creds.AccessKeyID)
+	}
+	if !creds.Expires.Equal(expiry) {
+		t.Fatalf("fallback expiry = %v, want actual expiry %v", creds.Expires, expiry)
+	}
+	callsAfterFallback := metadataCalls.Load()
+	if _, err := credentials.Retrieve(context.Background()); err != nil {
+		t.Fatalf("cached fallback Retrieve() error = %v", err)
+	}
+	if got := metadataCalls.Load(); got != callsAfterFallback {
+		t.Fatalf("metadata calls after cached fallback = %d, want %d", got, callsAfterFallback)
+	}
+}
+
+func TestCAMProviderRejectsNearExpiryFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	defer server.Close()
+	provider := newTestCAMProvider(server)
+	provider.cached = aws.Credentials{AccessKeyID: "near-expiry-id"}
+	provider.expiresAt = time.Now().Add(camCredentialFallbackMin / 2)
+
+	creds, err := provider.Retrieve(context.Background())
+	if err == nil {
+		t.Fatal("Retrieve() error = nil, want metadata timeout")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Retrieve() error = %v, want deadline exceeded", err)
+	}
+	if !errors.Is(err, ErrCAMMetadataUnavailable) {
+		t.Fatalf("Retrieve() error = %v, want CAM metadata unavailable", err)
+	}
+	if creds.AccessKeyID != "" {
+		t.Fatalf("Retrieve() AccessKeyID = %q, want empty", creds.AccessKeyID)
+	}
+}
+
+func TestCAMProviderRejectsExpiredFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		<-req.Context().Done()
+	}))
+	defer server.Close()
+	provider := newTestCAMProvider(server)
+	provider.cached = aws.Credentials{AccessKeyID: "expired-id"}
+	provider.expiresAt = time.Now().Add(-time.Second)
+
+	creds, err := provider.Retrieve(context.Background())
+	if err == nil {
+		t.Fatal("Retrieve() error = nil, want metadata timeout")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Retrieve() error = %v, want deadline exceeded", err)
+	}
+	if !errors.Is(err, ErrCAMMetadataUnavailable) {
+		t.Fatalf("Retrieve() error = %v, want CAM metadata unavailable", err)
+	}
+	if creds.AccessKeyID != "" {
+		t.Fatalf("Retrieve() AccessKeyID = %q, want empty", creds.AccessKeyID)
+	}
+}
+
+func TestCAMProviderDoesNotRetryPermanentMetadataStatus(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		calls.Add(1)
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer server.Close()
+	provider := newTestCAMProvider(server)
+	provider.cached = aws.Credentials{AccessKeyID: "old-id"}
+	provider.expiresAt = time.Now().Add(2 * time.Minute)
+
+	creds, err := provider.Retrieve(context.Background())
+	if err == nil {
+		t.Fatal("Retrieve() error = nil, want status error")
+	}
+	if creds.AccessKeyID != "" {
+		t.Fatalf("Retrieve() AccessKeyID = %q, want no fallback", creds.AccessKeyID)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("metadata calls = %d, want 1", got)
+	}
+}
+
+func TestCAMProviderDeduplicatesConcurrentRefresh(t *testing.T) {
+	expiry := time.Now().Add(time.Hour)
+	var listCalls atomic.Int32
+	var credentialCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		if isCAMRoleListRequest(req) {
+			listCalls.Add(1)
+			_, _ = w.Write([]byte("drive9-cos-role"))
+			return
+		}
+		credentialCalls.Add(1)
+		_, _ = w.Write([]byte(camCredentialsJSON(expiry)))
+	}))
+	defer server.Close()
+	provider := newTestCAMProvider(server)
+
+	const callers = 8
+	start := make(chan struct{})
+	errCh := make(chan error, callers)
+	var waitGroup sync.WaitGroup
+	for range callers {
+		waitGroup.Add(1)
+		go func() {
+			defer waitGroup.Done()
+			<-start
+			_, err := provider.Retrieve(context.Background())
+			errCh <- err
+		}()
+	}
+	close(start)
+	waitGroup.Wait()
+	close(errCh)
+	for err := range errCh {
+		if err != nil {
+			t.Fatalf("concurrent Retrieve() error = %v", err)
+		}
+	}
+	if got := listCalls.Load(); got != 1 {
+		t.Fatalf("role-list metadata calls = %d, want 1", got)
+	}
+	if got := credentialCalls.Load(); got != 1 {
+		t.Fatalf("credential metadata calls = %d, want 1", got)
+	}
+}
+
+func TestCAMMetadataResult(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{name: "timeout", err: &camMetadataUnavailableError{err: context.DeadlineExceeded}, want: "timeout"},
+		{name: "throttled", err: &camMetadataStatusError{statusCode: http.StatusTooManyRequests}, want: "throttled"},
+		{name: "server error", err: &camMetadataStatusError{statusCode: http.StatusBadGateway}, want: "server_error"},
+		{name: "rejected", err: &camMetadataStatusError{statusCode: http.StatusNotFound}, want: "rejected"},
+		{name: "unavailable", err: errors.New("connection reset"), want: "unavailable"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := camMetadataResult(test.err); got != test.want {
+				t.Fatalf("camMetadataResult() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestCredentialsForTencentWrapsCAMProviderWithCache(t *testing.T) {
+	t.Setenv("TENCENTCLOUD_SECRET_ID", "")
+	t.Setenv("TENCENTCLOUD_SECRETID", "")
+	t.Setenv("TENCENTCLOUD_SECRET_KEY", "")
+	t.Setenv("TENCENTCLOUD_SECRETKEY", "")
+	t.Setenv("TENCENTCLOUD_SECURITY_TOKEN", "")
+
+	provider, err := credentialsForTencent(AWSConfig{})
+	if err != nil {
+		t.Fatalf("credentialsForTencent() error = %v", err)
+	}
+	if _, ok := provider.(*aws.CredentialsCache); !ok {
+		t.Fatalf("credentialsForTencent() provider = %T, want *aws.CredentialsCache", provider)
+	}
+}

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
+	"github.com/mem9-ai/drive9/pkg/s3client"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/tenant/token"
 	"github.com/mem9-ai/drive9/pkg/tenantctx"
@@ -100,6 +101,9 @@ func backendErrorStatus(ctx context.Context, err error) int {
 	if isClientCanceled(ctx, err) {
 		return statusClientClosedRequest
 	}
+	if errors.Is(err, s3client.ErrCAMMetadataUnavailable) {
+		return http.StatusServiceUnavailable
+	}
 	if errors.Is(err, context.DeadlineExceeded) {
 		return http.StatusGatewayTimeout
 	}
@@ -116,7 +120,12 @@ func backendErrorStatus(ctx context.Context, err error) int {
 }
 
 func writeBackendError(w http.ResponseWriter, r *http.Request, err error) {
-	errJSON(w, backendErrorStatus(r.Context(), err), sanitizeClientError(err))
+	status := backendErrorStatus(r.Context(), err)
+	if status == http.StatusServiceUnavailable {
+		errJSONRetryable(w, sanitizeClientError(err))
+		return
+	}
+	errJSON(w, status, sanitizeClientError(err))
 }
 
 func ScopeFromContext(ctx context.Context) *TenantScope {

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mem9-ai/drive9/pkg/logger"
 	"github.com/mem9-ai/drive9/pkg/meta"
 	"github.com/mem9-ai/drive9/pkg/metrics"
+	"github.com/mem9-ai/drive9/pkg/s3client"
 	"github.com/mem9-ai/drive9/pkg/tenant"
 	"github.com/mem9-ai/drive9/pkg/tenant/token"
 	"go.uber.org/zap"
@@ -846,6 +847,11 @@ func TestBackendErrorStatus(t *testing.T) {
 			want: http.StatusGatewayTimeout,
 		},
 		{
+			name: "cam metadata unavailable",
+			err:  fmt.Errorf("%w: metadata timeout", s3client.ErrCAMMetadataUnavailable),
+			want: http.StatusServiceUnavailable,
+		},
+		{
 			name: "tidb quota error 1105",
 			err:  fmt.Errorf("open db: Error 1105 (HY000): Due to the usage quota being exhausted"),
 			want: http.StatusPaymentRequired,
@@ -903,6 +909,22 @@ func TestBackendErrorStatus(t *testing.T) {
 				t.Errorf("backendErrorStatus() = %d, want %d", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestWriteBackendErrorCAMMetadataUnavailableIsRetryable(t *testing.T) {
+	recorder := httptest.NewRecorder()
+	request := httptest.NewRequest(http.MethodGet, "/v1/fs/file", nil)
+	writeBackendError(recorder, request, fmt.Errorf("%w: metadata timeout", s3client.ErrCAMMetadataUnavailable))
+
+	if recorder.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want %d", recorder.Code, http.StatusServiceUnavailable)
+	}
+	if retryAfter := recorder.Header().Get("Retry-After"); retryAfter == "" {
+		t.Fatal("Retry-After header is missing")
+	}
+	if body := recorder.Body.String(); !strings.Contains(body, `"error":"backend unavailable"`) {
+		t.Fatalf("body = %q, want sanitized backend error", body)
 	}
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -6295,7 +6295,12 @@ func errJSONInvalidRootDentry(w http.ResponseWriter, err error) bool {
 const internalStorageErrorMessage = "storage backend unavailable; contact support"
 
 func errJSONInternalStorage(w http.ResponseWriter, r *http.Request, err error) {
-	errJSON(w, backendErrorStatus(r.Context(), err), internalStorageErrorMessage)
+	status := backendErrorStatus(r.Context(), err)
+	if status == http.StatusServiceUnavailable {
+		errJSONRetryable(w, internalStorageErrorMessage)
+		return
+	}
+	errJSON(w, status, internalStorageErrorMessage)
 }
 
 func (s *Server) handleSQL(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- retry Tencent CAM metadata timeouts, 429 responses, and 5xx responses with bounded per-request deadlines and backoff
- refresh credentials five minutes early, deduplicate concurrent refreshes, and fall back only to credentials with at least one minute of real validity remaining
- expose exhausted transient CAM metadata failures as retryable HTTP 503 responses with `Retry-After`, while keeping client errors sanitized
- add separate CAM role-list and credential-fetch operation results so metadata failures are distinguishable from COS data-plane failures

## Tests

- `go test ./pkg/s3client -count=1`
- `go test -race ./pkg/s3client -run 'TestCAM|TestCredentialsForTencentWrapsCAMProviderWithCache' -count=1`
- `go test -c ./pkg/server -o /tmp/drive9-server-cam.test`
- `make lint`
- `git diff --check`

Focused `pkg/server` execution is blocked on this workstation because its `TestMain` requires unavailable rootless Docker/testcontainers; the package and tests compile successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability**
  * Improved Tencent CAM credential retrieval with configurable metadata endpoints, retries, timeouts, and response validation.
  * Safely reuses valid cached credentials during temporary metadata outages while preserving expiration handling.
  * Prevents duplicate credential refreshes during concurrent requests.

* **Bug Fixes**
  * Temporary credential-service outages now return HTTP 503 responses with retry guidance.
  * Improved handling distinguishes temporary failures from permanent metadata errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->