### PR TITLE
feat(datastore): batched post-order recursive directory delete

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,19 @@ embedding. Override any var before running.
 
 ---
 
+## Feature flags
+
+- `DRIVE9_RECURSIVE_DELETE_BATCHED=1` — batched post-order recursive directory delete
+  (fast path single transaction for small trees, bounded per-batch sweep otherwise).
+  Unset/empty keeps the legacy single-transaction delete. See
+  `docs/design/recursive-delete-batched-design.md`.
+- `DRIVE9_DELETE_RECONCILE_REPAIR=1` — lets the periodic per-tenant orphan
+  reconciliation (`Store.ReconcileDeleteOrphans`, piggybacked on tenant maintenance)
+  repair broken-chain dentries / stranded inodes. Default is dry-run (audit only).
+
+
+---
+
 ## Project layout
 
 ```

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -70,6 +70,10 @@ bash e2e/fuse-correctness-workload.sh
 # Bounded FUSE concurrency stress workload
 bash e2e/fuse-concurrency-stress.sh
 
+# Batched recursive-delete stress workload (requires a server with
+# DRIVE9_RECURSIVE_DELETE_BATCHED=1 to exercise the batched sweep)
+bash e2e/fuse-recursive-delete-stress.sh
+
 # Opt-in FUSE performance baseline metrics workload
 bash e2e/fuse-performance-baseline.sh
 
@@ -408,6 +412,38 @@ deterministic writable concurrency coverage, not a Git or cross-mount workload.
 8. Preserve run root, mount log, expected/actual manifests, and reader error log
    on failure
 
+### `fuse-recursive-delete-stress.sh`
+
+Host support: Linux and macOS only. This script needs real FUSE support and is
+stress coverage for the batched recursive directory delete redesign
+(`docs/design/recursive-delete-batched-design.md`, server flag
+`DRIVE9_RECURSIVE_DELETE_BATCHED`). The server must run with the flag enabled
+to exercise the batched sweep; against a legacy-flag server this suite is the
+regression detector for the single-transaction failure modes. Trees are built
+through the FUSE mount; deletes go through `drive9 fs rm -r`
+(`DELETE /v1/fs/{path}?recursive`, the batched-sweep entry point). Manual-only
+in CI (see `e2e/README.md` "CI automation tiers") until the flag flips on.
+
+1. Provision tenant unless `DRIVE9_API_KEY` is already set
+2. Prepare `drive9` CLI binary (build local or download official release)
+3. Mount a fresh writable namespace through real FUSE
+4. Scenario A: build a large tree (default 2000 files / 50 subdirs) through the
+   mount, run `rm -r` on it while a background writer keeps writing a sibling
+   tree; assert `rm -r` succeeds, reports no lock-wait/deadlock errors, the
+   tree is absent remotely, and the sibling tree matches an exact sha256
+   manifest (mount + remote snapshot)
+5. Scenario B: start `rm -r` on a large tree, SIGKILL the CLI mid-sweep, then
+   retry `rm -r`; assert the retry succeeds (or the first pass already
+   finished) and the tree converges to fully removed remotely with no residue
+6. Scenario C: `mkdir` at the same path racing an in-flight `rm -r`, then
+   write a new file set at the recreated path; assert the raced `rm -r`
+   succeeds and the new tree is intact (exact manifest via mount + remote
+   snapshot, so no old content survives and no new content is swept)
+7. Unmount, copy sibling and recreated trees back through the CLI, and verify
+   the remote snapshots match the expected manifests
+8. Preserve run root, mount log, manifests, and rm/sibling-writer logs on
+   failure
+
 ### `fuse-performance-baseline.sh`
 
 Host support: Linux and macOS only. This script needs real FUSE support and is
@@ -616,8 +652,8 @@ See `e2e/shared-smoke-test/README.md`.
 | `RUN_LARGE_FILE` | `1` | `api-smoke-test.sh` |
 | `LARGE_FILE_MB` | `100` | `api-smoke-test.sh` |
 | `BATCH_SMALL_FILE_COUNT` | `10` | `api-smoke-test.sh` |
-| `REQUEST_MAX_RETRIES` | `8` | `api-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
-| `REQUEST_RETRY_SLEEP_S` | `2` | `api-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
+| `REQUEST_MAX_RETRIES` | `8` | `api-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh`, `fuse-recursive-delete-stress.sh` |
+| `REQUEST_RETRY_SLEEP_S` | `2` | `api-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh`, `fuse-recursive-delete-stress.sh` |
 | `RUN_UPLOAD_LIMIT_BOUNDARY` | `1` (defaults to `0` when `DRIVE9_API_KEY` is set) | `api-smoke-test.sh` |
 | `UPLOAD_LIMIT_BYTES` | `10737418240` | `api-smoke-test.sh` |
 | `RUN_SEMANTIC_CHECKS` | `1` | `api-smoke-test.sh` |
@@ -634,16 +670,16 @@ See `e2e/shared-smoke-test/README.md`.
 | `RUN_CLI_FORK_CHECKS` | `1` (auto-skip when `/v1/fork` is unavailable) | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_TIMEOUT_S` | `90` | `cli-smoke-test.sh` |
 | `CLI_SEMANTIC_INTERVAL_S` | `3` | `cli-smoke-test.sh` |
-| `CLI_SOURCE` | `build` (`build` or `official`) | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
-| `CLI_RELEASE_BASE_URL` | `https://drive9.ai/releases` | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
-| `CLI_RELEASE_VERSION` | *(latest)* | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
-| `MOUNT_READY_TIMEOUT_S` | `20` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
-| `MOUNT_READY_INTERVAL_S` | `1` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
-| `FUSE_MOUNT_ROOT` | `/tmp` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
+| `CLI_SOURCE` | `build` (`build` or `official`) | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh`, `fuse-recursive-delete-stress.sh` |
+| `CLI_RELEASE_BASE_URL` | `https://drive9.ai/releases` | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh`, `fuse-recursive-delete-stress.sh` |
+| `CLI_RELEASE_VERSION` | *(latest)* | `cli-smoke-test.sh`, `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh`, `fuse-recursive-delete-stress.sh` |
+| `MOUNT_READY_TIMEOUT_S` | `20` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh`, `fuse-recursive-delete-stress.sh` |
+| `MOUNT_READY_INTERVAL_S` | `1` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh`, `fuse-recursive-delete-stress.sh` |
+| `FUSE_MOUNT_ROOT` | `/tmp` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh`, `fuse-recursive-delete-stress.sh` |
 | `CLI_MAX_RETRIES` | `8` | `fuse-smoke-test.sh` |
 | `CLI_RETRY_SLEEP_S` | `2` | `fuse-smoke-test.sh` |
-| `FUSE_STRICT_PREREQS` | `0` (`1` in release gate) | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
-| `FUSE_UMOUNT_TIMEOUT` | `60s` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh` |
+| `FUSE_STRICT_PREREQS` | `0` (`1` in release gate) | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh`, `fuse-recursive-delete-stress.sh` |
+| `FUSE_UMOUNT_TIMEOUT` | `60s` | `fuse-smoke-test.sh`, `fuse-correctness-workload.sh`, `fuse-sqlite-correctness.sh`, `fuse-concurrency-stress.sh`, `fuse-performance-baseline.sh`, `fuse-recursive-delete-stress.sh` |
 | `FUSE_CORRECTNESS_LARGE_MB` | `9` | `fuse-correctness-workload.sh` |
 | `FUSE_CORRECTNESS_KEEP_ARTIFACTS` | `0` | `fuse-correctness-workload.sh` |
 | `RUN_FUSE_ALL_WORKLOADS` | `0` | `fuse-release-gate.sh` |
@@ -663,6 +699,17 @@ See `e2e/shared-smoke-test/README.md`.
 | `FUSE_CONCURRENCY_PAYLOAD_KB` | `32` | `fuse-concurrency-stress.sh` |
 | `FUSE_CONCURRENCY_TIMEOUT_S` | `120` | `fuse-concurrency-stress.sh` |
 | `FUSE_CONCURRENCY_KEEP_ARTIFACTS` | `0` | `fuse-concurrency-stress.sh` |
+| `FUSE_RDEL_FILES` | `2000` | `fuse-recursive-delete-stress.sh` |
+| `FUSE_RDEL_SUBDIRS` | `50` | `fuse-recursive-delete-stress.sh` |
+| `FUSE_RDEL_PAYLOAD_KB` | `4` | `fuse-recursive-delete-stress.sh` |
+| `FUSE_RDEL_RACE_FILES` | `64` | `fuse-recursive-delete-stress.sh` |
+| `FUSE_RDEL_SIBLING_BASE_FILES` | `16` | `fuse-recursive-delete-stress.sh` |
+| `FUSE_RDEL_SIBLING_MAX_WRITES` | `4000` | `fuse-recursive-delete-stress.sh` |
+| `FUSE_RDEL_KILL_AFTER_S` | `2` | `fuse-recursive-delete-stress.sh` |
+| `FUSE_RDEL_BUILD_TIMEOUT_S` | `600` | `fuse-recursive-delete-stress.sh` |
+| `FUSE_RDEL_SWEEP_TIMEOUT_S` | `180` | `fuse-recursive-delete-stress.sh` |
+| `FUSE_RDEL_KEEP_ARTIFACTS` | `0` | `fuse-recursive-delete-stress.sh` |
+| `FUSE_RDEL_ARTIFACT_DIR` | - | `fuse-recursive-delete-stress.sh` |
 | `RUN_FUSE_CONCURRENCY_STRESS` | `0` | `fuse-release-gate.sh` |
 | `RUN_FUSE_POSIX_FSX` | `0` | `fuse-release-gate.sh` |
 | `RUN_FUSE_PERFORMANCE_BASELINE` | `0` | `fuse-release-gate.sh` |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -21,6 +21,7 @@ including local single-tenant validation via `drive9-server-local`.
 | `fuse-correctness-workload.sh` | Real read-only FUSE workload over a manifest fixture: `find`, `grep`, `stat`, `cat`, `sha256`, symlink, hardlink, unicode/space paths, empty files, binary files, and 8MiB+ files |
 | `fuse-sqlite-correctness.sh` | Real writable FUSE SQLite correctness workload with rollback-journal mode, `PRAGMA integrity_check`, unmount/remount parity, and remote snapshot verification; set `RUN_FUSE_SQLITE_WAL=1` for WAL, `RUN_FUSE_SQLITE_CHURN=1` for repeated large-DB rewrite churn, and `RUN_FUSE_SQLITE_CONCURRENCY=1` for the bounded readers/writer detector |
 | `fuse-concurrency-stress.sh` | Real writable FUSE concurrency workload with parallel writers/readers, atomic rename, unlink churn, open-handle rename reads, and deterministic final manifest checks |
+| `fuse-recursive-delete-stress.sh` | Batched recursive-delete stress (`DRIVE9_RECURSIVE_DELETE_BATCHED`): large-tree `rm -r` under concurrent sibling writes with exact sha256 sibling manifest and no lock-wait errors, `rm -r` killed mid-sweep then retried to full removal, and same-path `mkdir`/rewrite racing the sweep with the new tree verified intact (mount + remote snapshot) |
 | `fuse-posix-fsx-gate.sh` | Opt-in JuiceFS-style POSIX/fsx subset over real writable FUSE: deterministic random write/read/truncate, atomic rename replacement, unlink-open reads, directory fsync, final model hash, unmount, and remote snapshot parity |
 | `fuse-performance-baseline.sh` | Opt-in real writable FUSE baseline that records small-file, large-file, repeated large-read, and SQLite transaction/read metrics as JSON artifacts without hardcoded throughput thresholds; SQLite reads verify stored row payload bytes against row checksums |
 | `fuse-release-gate.sh` | Strict FUSE release/CI gate with hard prereq failures, small-repo git clone/status/log, durable umount/remount, mount-log audit, manifest-based FUSE correctness workload, and SQLite rollback-journal correctness; set `RUN_FUSE_ALL_WORKLOADS=1` to add all optional release-gate workloads, `RUN_FUSE_SQLITE_CORRECTNESS=0` to skip SQLite temporarily, `RUN_FUSE_CONCURRENCY_STRESS=1` to add bounded concurrency stress, `RUN_FUSE_POSIX_FSX=1` to add the POSIX/fsx subset, and `RUN_FUSE_PERFORMANCE_BASELINE=1` to add performance metrics |
@@ -47,7 +48,7 @@ without adding it to `.github/workflows/local-e2e.yml`.
 | Post-merge | `push` to `main` (local-e2e, coalesced via concurrency group) | PR gate + concurrency stress, POSIX/fsx, sqlite WAL/churn/concurrency, full `smoke-all.sh` (journal, posix-permission, git-workspace), git feature smoke |
 | Nightly | cron 20:17 UTC (local-e2e) | Post-merge set + FUSE performance baseline/archive/compare (compare is report-only; hosted-runner noise) |
 | Manual all | `e2e-all` workflow (`Run workflow` button) | Everything above via `run_all_e2e=1` |
-| Manual only | not wired, run by hand | `description-smoke-test.sh` (Docker + Ollama/stub embedder), `native-smoke-test.sh` (TiDB Cloud Native — requires credentials), `local-smoke.sh` (`make e2e-local` wrapper) |
+| Manual only | not wired, run by hand | `description-smoke-test.sh` (Docker + Ollama/stub embedder), `native-smoke-test.sh` (TiDB Cloud Native — requires credentials), `local-smoke.sh` (`make e2e-local` wrapper), `fuse-recursive-delete-stress.sh` (requires a server started with `DRIVE9_RECURSIVE_DELETE_BATCHED=1`; the flag is off by default during soak, so no CI deployment exercises it — wire into `local-e2e.yml` when the flag flips on) |
 
 Scheduled and post-merge failures auto-file/append to a `ci-e2e-failure`
 GitHub issue, since GitHub only notifies the workflow author otherwise.
@@ -136,6 +137,11 @@ bash e2e/fuse-sqlite-correctness.sh
 
 # Bounded concurrency stress on a real writable FUSE mount.
 bash e2e/fuse-concurrency-stress.sh
+
+# Batched recursive-delete stress on a real writable FUSE mount. Requires the
+# server to run with DRIVE9_RECURSIVE_DELETE_BATCHED=1 to exercise the batched
+# sweep; see the manual-only note under "CI automation tiers".
+bash e2e/fuse-recursive-delete-stress.sh
 
 # JuiceFS-style POSIX/fsx subset on a real writable FUSE mount.
 bash e2e/fuse-posix-fsx-gate.sh

--- a/e2e/fuse-recursive-delete-stress.sh
+++ b/e2e/fuse-recursive-delete-stress.sh
@@ -1,0 +1,824 @@
+#!/usr/bin/env bash
+# Deterministic Drive9 FUSE recursive-delete stress workload.
+#
+# Covers the batched recursive directory delete redesign
+# (docs/design/recursive-delete-batched-design.md, server flag
+# DRIVE9_RECURSIVE_DELETE_BATCHED):
+#   a. rm -r of a large tree (default 2000 files / 50 subdirs) built through a
+#      real FUSE mount while a background writer keeps writing a sibling tree;
+#      asserts rm -r succeeds, reports no lock-wait/deadlock errors, and the
+#      sibling data stays intact (exact sha256 manifest, mount + remote).
+#   b. rm -r killed (SIGKILL) mid-sweep, then retried; asserts the retry
+#      resumes the server-side sweep and the tree converges to fully removed.
+#   c. mkdir at the same path racing an in-flight rm -r, then a new tree
+#      written at the recreated path; asserts the new tree is complete and no
+#      old content survives (path-recreation generation case).
+#
+# Deletes go through `drive9 fs rm -r` (DELETE /v1/fs/{path}?recursive), which
+# is the entry point of the batched server-side sweep; fixture trees and
+# sibling writes go through the FUSE mount. To exercise the batched
+# implementation the server must run with DRIVE9_RECURSIVE_DELETE_BATCHED=1;
+# against a legacy server this suite is the regression detector for the
+# single-transaction failure modes (lock-wait timeouts on large trees).
+
+set -euo pipefail
+
+BASE="${DRIVE9_BASE:-http://127.0.0.1:9009}"
+DRIVE9_API_KEY="${DRIVE9_API_KEY:-}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-120}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+MOUNT_READY_TIMEOUT_S="${MOUNT_READY_TIMEOUT_S:-20}"
+MOUNT_READY_INTERVAL_S="${MOUNT_READY_INTERVAL_S:-1}"
+FUSE_MOUNT_ROOT="${FUSE_MOUNT_ROOT:-/tmp}"
+FUSE_STRICT_PREREQS="${FUSE_STRICT_PREREQS:-0}"
+FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-60s}"
+FUSE_RDEL_KEEP_ARTIFACTS="${FUSE_RDEL_KEEP_ARTIFACTS:-0}"
+FUSE_RDEL_ARTIFACT_DIR="${FUSE_RDEL_ARTIFACT_DIR:-}"
+FUSE_RDEL_FILES="${FUSE_RDEL_FILES:-2000}"
+FUSE_RDEL_SUBDIRS="${FUSE_RDEL_SUBDIRS:-50}"
+FUSE_RDEL_PAYLOAD_KB="${FUSE_RDEL_PAYLOAD_KB:-4}"
+FUSE_RDEL_RACE_FILES="${FUSE_RDEL_RACE_FILES:-64}"
+FUSE_RDEL_SIBLING_BASE_FILES="${FUSE_RDEL_SIBLING_BASE_FILES:-16}"
+FUSE_RDEL_SIBLING_MAX_WRITES="${FUSE_RDEL_SIBLING_MAX_WRITES:-4000}"
+FUSE_RDEL_KILL_AFTER_S="${FUSE_RDEL_KILL_AFTER_S:-2}"
+FUSE_RDEL_BUILD_TIMEOUT_S="${FUSE_RDEL_BUILD_TIMEOUT_S:-600}"
+FUSE_RDEL_SWEEP_TIMEOUT_S="${FUSE_RDEL_SWEEP_TIMEOUT_S:-180}"
+CLI_SOURCE="${CLI_SOURCE:-build}"
+CLI_RELEASE_BASE_URL="${CLI_RELEASE_BASE_URL:-https://drive9.ai/releases}"
+CLI_RELEASE_VERSION="${CLI_RELEASE_VERSION:-}"
+REQUEST_MAX_RETRIES="${REQUEST_MAX_RETRIES:-8}"
+REQUEST_RETRY_SLEEP_S="${REQUEST_RETRY_SLEEP_S:-2}"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+check_eq() {
+  local desc="$1" got="$2" want="$3"
+  TOTAL=$((TOTAL + 1))
+  if [ "$got" = "$want" ]; then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    echo "  want: $want"
+    echo "  got:  $got"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+check_cmd() {
+  local desc="$1"
+  shift
+  TOTAL=$((TOTAL + 1))
+  if "$@"; then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+require_cmd() {
+  local name="$1"
+  TOTAL=$((TOTAL + 1))
+  if command -v "$name" >/dev/null 2>&1; then
+    echo "PASS $name is available"
+    PASS=$((PASS + 1))
+    return 0
+  fi
+  echo "FAIL $name is available" >&2
+  FAIL=$((FAIL + 1))
+  exit 1
+}
+
+skip() {
+  echo "SKIP $*"
+  exit 0
+}
+
+skip_or_fail() {
+  if [ "$FUSE_STRICT_PREREQS" = "1" ]; then
+    echo "FAIL $*" >&2
+    exit 1
+  fi
+  skip "$@"
+}
+
+detect_release_target() {
+  case "$(uname -s)" in
+    Linux) CLI_RELEASE_OS="linux" ;;
+    Darwin) CLI_RELEASE_OS="darwin" ;;
+    *)
+      echo "unsupported OS for official CLI download: $(uname -s)" >&2
+      return 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64|amd64) CLI_RELEASE_ARCH="amd64" ;;
+    aarch64|arm64) CLI_RELEASE_ARCH="arm64" ;;
+    *)
+      echo "unsupported architecture for official CLI download: $(uname -m)" >&2
+      return 1
+      ;;
+  esac
+}
+
+download_official_cli() {
+  local target_version="$CLI_RELEASE_VERSION"
+  local unversioned_url versioned_url download_url
+  detect_release_target || return 1
+  unversioned_url="$CLI_RELEASE_BASE_URL/drive9-$CLI_RELEASE_OS-$CLI_RELEASE_ARCH"
+  if [ -z "$target_version" ]; then
+    target_version=$(curl -fsSL "$CLI_RELEASE_BASE_URL/version" 2>/dev/null | tr -d '[:space:]' || true)
+  fi
+  download_url="$unversioned_url"
+  if [ -n "$target_version" ]; then
+    versioned_url="$CLI_RELEASE_BASE_URL/drive9-$target_version-$CLI_RELEASE_OS-$CLI_RELEASE_ARCH"
+    if curl -fsI "$versioned_url" >/dev/null 2>&1; then
+      download_url="$versioned_url"
+    fi
+  fi
+  curl -fsSL "$download_url" -o "$CLI_BIN"
+  chmod +x "$CLI_BIN"
+  local actual_version
+  actual_version="$($CLI_BIN --version 2>/dev/null | awk '{print $2}')"
+  if [ -n "$CLI_RELEASE_VERSION" ] && [ "$actual_version" != "$CLI_RELEASE_VERSION" ]; then
+    echo "downloaded version mismatch: expected=$CLI_RELEASE_VERSION actual=$actual_version" >&2
+    return 1
+  fi
+  echo "downloaded official drive9 $actual_version for $CLI_RELEASE_OS/$CLI_RELEASE_ARCH" >&2
+}
+
+prepare_cli_binary() {
+  CLI_BIN="$(mktemp)"
+  case "$CLI_SOURCE" in
+    build)
+      make build-cli CLI_BIN="$CLI_BIN"
+      ;;
+    official)
+      download_official_cli
+      ;;
+    *)
+      echo "invalid CLI_SOURCE: $CLI_SOURCE (expected build|official)" >&2
+      return 1
+      ;;
+  esac
+}
+
+is_mounted() {
+  local mount_point="$1"
+  local physical_mount_point
+  physical_mount_point="$(cd "$(dirname "$mount_point")" 2>/dev/null && pwd -P)/$(basename "$mount_point")"
+  if command -v mountpoint >/dev/null 2>&1; then
+    mountpoint -q "$mount_point"
+    return
+  fi
+  mount | awk -v mp="$mount_point" -v pmp="$physical_mount_point" '{for(i=1;i<=NF;i++) if($i=="on" && ($(i+1)==mp || $(i+1)==pmp)) found=1} END{exit !found}'
+}
+
+wait_mount_state() {
+  local expect="$1"
+  local deadline=$(( $(date +%s) + MOUNT_READY_TIMEOUT_S ))
+  while :; do
+    if [ "$expect" = "mounted" ] && is_mounted "$MOUNT_POINT"; then
+      return 0
+    fi
+    if [ "$expect" = "unmounted" ] && ! is_mounted "$MOUNT_POINT"; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep "$MOUNT_READY_INTERVAL_S"
+  done
+}
+
+start_mount() {
+  {
+    echo "=== drive9 recursive-delete stress mount start time=$(date -u '+%Y-%m-%dT%H:%M:%SZ') ==="
+    echo "root_remote=$ROOT_REMOTE"
+  } >>"$MOUNT_LOG"
+  drive9 mount "$MOUNT_POINT" >>"$MOUNT_LOG" 2>&1 &
+  MOUNT_PID="$!"
+
+  if wait_mount_state mounted; then
+    return 0
+  fi
+  cat "$MOUNT_LOG" >&2 || true
+  return 1
+}
+
+stop_mount() {
+  set +e
+  if [ -n "${MOUNT_POINT:-}" ] && is_mounted "$MOUNT_POINT"; then
+    drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT" >/dev/null 2>&1 || true
+    wait_mount_state unmounted >/dev/null 2>&1 || true
+  fi
+  if [ -n "${MOUNT_PID:-}" ] && kill -0 "$MOUNT_PID" >/dev/null 2>&1; then
+    kill "$MOUNT_PID" >/dev/null 2>&1 || true
+    wait "$MOUNT_PID" >/dev/null 2>&1 || true
+  fi
+  MOUNT_PID=""
+  set -e
+}
+
+unmount_mount() {
+  if is_mounted "$MOUNT_POINT"; then
+    drive9 umount --timeout "$FUSE_UMOUNT_TIMEOUT" "$MOUNT_POINT"
+  fi
+  wait_mount_state unmounted
+  if [ -n "${MOUNT_PID:-}" ]; then
+    set +e
+    wait "$MOUNT_PID" >/dev/null 2>&1
+    MOUNT_PID=""
+    set -e
+  fi
+}
+
+curl_body_code() {
+  local method="$1"
+  local url="$2"
+  local auth="${3:-}"
+
+  local attempt=1
+  while :; do
+    local body_file code rc
+    body_file="$(mktemp)"
+    set +e
+    if [ -n "$auth" ]; then
+      code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" -H "Authorization: Bearer $auth" "$url")
+      rc=$?
+    else
+      code=$(curl -sS -o "$body_file" -w "%{http_code}" -X "$method" "$url")
+      rc=$?
+    fi
+    set -e
+    if [ "$rc" -ne 0 ]; then
+      code="000"
+    fi
+
+    if { [ "$rc" -eq 0 ] && [ "$code" != "429" ] && [ "$code" != "403" ]; } || [ "$attempt" -ge "$REQUEST_MAX_RETRIES" ]; then
+      cat "$body_file"
+      echo
+      echo "__HTTP__${code}"
+      rm -f "$body_file"
+      return "$rc"
+    fi
+
+    rm -f "$body_file"
+    attempt=$((attempt + 1))
+    sleep "$REQUEST_RETRY_SLEEP_S"
+  done
+}
+
+http_code() { printf '%s' "$1" | awk -F'__HTTP__' 'NF>1{print $2}' | tr -d '\n'; }
+json_body() { printf '%s' "$1" | sed '/__HTTP__/d'; }
+
+drive9_retry() {
+  local attempt=1
+  local out rc
+  while :; do
+    set +e
+    out=$(drive9 "$@" 2>&1)
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+      printf '%s' "$out"
+      return 0
+    fi
+    if [ "$attempt" -lt "$REQUEST_MAX_RETRIES" ] && [[ "$out" == *"Too Many Requests"* || "$out" == *"HTTP 429"* || "$out" == *"HTTP 403"* || "$out" == *"403 Forbidden"* ]]; then
+      attempt=$((attempt + 1))
+      sleep "$REQUEST_RETRY_SLEEP_S"
+      continue
+    fi
+    printf '%s\n' "$out" >&2
+    return "$rc"
+  done
+}
+
+# wait_remote_absent polls the list endpoint until the path returns 404,
+# i.e. the recursive sweep has fully converged remotely.
+wait_remote_absent() {
+  local remote="$1"
+  local deadline=$(( $(date +%s) + FUSE_RDEL_SWEEP_TIMEOUT_S ))
+  while :; do
+    local resp code
+    resp=$(curl_body_code GET "$BASE/v1/fs$remote/?list" "$API_KEY")
+    code=$(http_code "$resp")
+    if [ "$code" = "404" ]; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      echo "remote path still present after ${FUSE_RDEL_SWEEP_TIMEOUT_S}s: $remote (last HTTP $code)" >&2
+      return 1
+    fi
+    sleep "$POLL_INTERVAL_S"
+  done
+}
+
+wait_for_file() {
+  local path="$1"
+  local deadline=$(( $(date +%s) + FUSE_RDEL_BUILD_TIMEOUT_S ))
+  while :; do
+    if [ -f "$path" ]; then
+      return 0
+    fi
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+# build_tree creates FUSE_RDEL_FILES fsync'd files spread over
+# FUSE_RDEL_SUBDIRS subdirectories under $1 through the mount. Content is a
+# deterministic function of the relative path.
+build_tree() {
+  python3 - "$1" "$FUSE_RDEL_FILES" "$FUSE_RDEL_SUBDIRS" "$FUSE_RDEL_PAYLOAD_KB" <<'PY'
+import hashlib
+import os
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+root, files, subdirs, payload_kb = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), int(sys.argv[4])
+
+
+def payload(rel):
+    header = f"drive9-rdel path={rel}\n".encode()
+    seed = hashlib.sha256(header).digest()
+    body = bytearray()
+    target = payload_kb * 1024
+    counter = 0
+    while len(body) < target:
+        body.extend(hashlib.sha256(seed + counter.to_bytes(8, "big")).digest())
+        counter += 1
+    return header + bytes(body[:target]) + b"\nEND\n"
+
+
+def write_one(index):
+    rel = f"sub-{index % subdirs:03d}/file-{index:05d}.txt"
+    path = os.path.join(root, rel)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    data = payload(rel)
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o644)
+    try:
+        off = 0
+        while off < len(data):
+            off += os.write(fd, data[off:])
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+
+
+os.makedirs(root, exist_ok=True)
+with ThreadPoolExecutor(max_workers=8) as pool:
+    for _ in pool.map(write_one, range(files)):
+        pass
+PY
+}
+
+# start_sibling_writer seeds the sibling tree, touches the ready file, then
+# keeps writing deterministic live files (recording an exact sha256 manifest)
+# until the stop file appears.
+start_sibling_writer() {
+  python3 - "$SIBLING_MOUNT" "$SIBLING_MANIFEST" "$READY_FILE" "$STOP_FILE" \
+    "$FUSE_RDEL_PAYLOAD_KB" "$FUSE_RDEL_SIBLING_BASE_FILES" "$FUSE_RDEL_SIBLING_MAX_WRITES" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+root, manifest_path, ready_file, stop_file = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+payload_kb, base_files, max_writes = int(sys.argv[5]), int(sys.argv[6]), int(sys.argv[7])
+manifest = {}
+
+
+def payload(rel):
+    header = f"drive9-rdel-sibling path={rel}\n".encode()
+    seed = hashlib.sha256(header).digest()
+    body = bytearray()
+    target = payload_kb * 1024
+    counter = 0
+    while len(body) < target:
+        body.extend(hashlib.sha256(seed + counter.to_bytes(8, "big")).digest())
+        counter += 1
+    return header + bytes(body[:target]) + b"\nEND\n"
+
+
+def write_fsync(rel):
+    path = os.path.join(root, rel)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    data = payload(rel)
+    fd = os.open(path, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o644)
+    try:
+        off = 0
+        while off < len(data):
+            off += os.write(fd, data[off:])
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    manifest[rel] = {"size": len(data), "sha256": hashlib.sha256(data).hexdigest()}
+
+
+def flush_manifest():
+    tmp = manifest_path + ".tmp"
+    with open(tmp, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2, sort_keys=True)
+        f.write("\n")
+    os.replace(tmp, manifest_path)
+
+
+for i in range(base_files):
+    write_fsync(f"base/base-{i:03d}.txt")
+flush_manifest()
+with open(ready_file, "w", encoding="utf-8") as f:
+    f.write("ready\n")
+
+written = 0
+while written < max_writes and not os.path.exists(stop_file):
+    write_fsync(f"live/live-{written:05d}.txt")
+    flush_manifest()
+    written += 1
+flush_manifest()
+print(f"sibling writer done: base={base_files} live={written}")
+PY
+}
+
+# write_race_new_tree writes the new deterministic file set at the recreated
+# same-path directory and records its expected manifest.
+write_race_new_tree() {
+  python3 - "$RACE_MOUNT_TARGET" "$RACE_NEW_MANIFEST" "$FUSE_RDEL_RACE_FILES" "$FUSE_RDEL_PAYLOAD_KB" <<'PY'
+import hashlib
+import json
+import os
+import sys
+
+root, manifest_path, files, payload_kb = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+manifest = {}
+
+
+def payload(rel):
+    header = f"drive9-rdel-race-new path={rel}\n".encode()
+    seed = hashlib.sha256(header).digest()
+    body = bytearray()
+    target = payload_kb * 1024
+    counter = 0
+    while len(body) < target:
+        body.extend(hashlib.sha256(seed + counter.to_bytes(8, "big")).digest())
+        counter += 1
+    return header + bytes(body[:target]) + b"\nEND\n"
+
+
+os.makedirs(root, exist_ok=True)
+for i in range(files):
+    rel = f"new-{i:04d}.txt"
+    data = payload(rel)
+    fd = os.open(os.path.join(root, rel), os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o644)
+    try:
+        off = 0
+        while off < len(data):
+            off += os.write(fd, data[off:])
+        os.fsync(fd)
+    finally:
+        os.close(fd)
+    manifest[rel] = {"size": len(data), "sha256": hashlib.sha256(data).hexdigest()}
+
+with open(manifest_path, "w", encoding="utf-8") as f:
+    json.dump(manifest, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+# verify_manifest_dir fails unless the directory tree at $2 exactly matches the
+# expected sha256 manifest at $3 (no missing, extra, or mismatched files).
+verify_manifest_dir() {
+  local desc="$1"
+  local root="$2"
+  local expected="$3"
+  local actual="$4"
+  TOTAL=$((TOTAL + 1))
+  if python3 - "$root" "$expected" "$actual" <<'PY'
+import hashlib
+import json
+import os
+import sys
+root = os.path.abspath(sys.argv[1])
+expected_path = sys.argv[2]
+actual_path = sys.argv[3]
+with open(expected_path, encoding="utf-8") as f:
+    expected = json.load(f)
+actual = {}
+for current_root, dirs, files in os.walk(root):
+    dirs[:] = [d for d in dirs if d != ".go-fuse-epoll-hack"]
+    for name in files:
+        path = os.path.join(current_root, name)
+        rel = os.path.relpath(path, root)
+        if rel == ".go-fuse-epoll-hack" or rel.endswith("/.go-fuse-epoll-hack"):
+            continue
+        with open(path, "rb") as f:
+            data = f.read()
+        actual[rel] = {"size": len(data), "sha256": hashlib.sha256(data).hexdigest()}
+with open(actual_path, "w", encoding="utf-8") as f:
+    json.dump(actual, f, indent=2, sort_keys=True)
+    f.write("\n")
+if actual != expected:
+    print("manifest mismatch", file=sys.stderr)
+    print("missing:", sorted(set(expected) - set(actual))[:20], file=sys.stderr)
+    print("extra:", sorted(set(actual) - set(expected))[:20], file=sys.stderr)
+    mismatched = sorted(rel for rel in set(expected) & set(actual) if expected[rel] != actual[rel])
+    print("mismatched:", mismatched[:20], file=sys.stderr)
+    raise SystemExit(1)
+PY
+  then
+    echo "PASS $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "FAIL $desc"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== drive9 FUSE recursive-delete stress ==="
+echo "BASE=$BASE"
+echo "CLI_SOURCE=$CLI_SOURCE"
+echo "FUSE_STRICT_PREREQS=$FUSE_STRICT_PREREQS"
+echo "FUSE_RDEL_FILES=$FUSE_RDEL_FILES"
+echo "FUSE_RDEL_SUBDIRS=$FUSE_RDEL_SUBDIRS"
+echo "FUSE_RDEL_PAYLOAD_KB=$FUSE_RDEL_PAYLOAD_KB"
+echo "FUSE_RDEL_RACE_FILES=$FUSE_RDEL_RACE_FILES"
+echo "FUSE_RDEL_SIBLING_BASE_FILES=$FUSE_RDEL_SIBLING_BASE_FILES"
+echo "FUSE_RDEL_SIBLING_MAX_WRITES=$FUSE_RDEL_SIBLING_MAX_WRITES"
+echo "FUSE_RDEL_KILL_AFTER_S=$FUSE_RDEL_KILL_AFTER_S"
+echo "FUSE_RDEL_SWEEP_TIMEOUT_S=$FUSE_RDEL_SWEEP_TIMEOUT_S"
+
+require_cmd curl
+require_cmd jq
+require_cmd python3
+if [ "$CLI_SOURCE" = "build" ]; then
+  require_cmd go
+fi
+
+if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
+  skip_or_fail "unsupported OS for this workload"
+fi
+
+if [ "$(uname -s)" = "Linux" ]; then
+  if ! command -v fusermount >/dev/null 2>&1 && ! command -v fusermount3 >/dev/null 2>&1; then
+    skip_or_fail "fusermount/fusermount3 is required for Linux FUSE unmount"
+  fi
+  if [ ! -e /dev/fuse ]; then
+    skip_or_fail "/dev/fuse not available"
+  fi
+fi
+
+if [ "$FUSE_RDEL_FILES" -lt 1 ] || [ "$FUSE_RDEL_SUBDIRS" -lt 1 ] || [ "$FUSE_RDEL_RACE_FILES" -lt 1 ]; then
+  echo "invalid recursive-delete settings: files/subdirs/race-files must be >= 1" >&2
+  exit 1
+fi
+
+if [ "$FUSE_RDEL_PAYLOAD_KB" -lt 1 ]; then
+  echo "invalid FUSE_RDEL_PAYLOAD_KB: must be >= 1" >&2
+  exit 1
+fi
+
+echo "[1] provision tenant"
+if [ -n "$DRIVE9_API_KEY" ]; then
+  API_KEY="$DRIVE9_API_KEY"
+  check_eq "use provided DRIVE9_API_KEY" "true" "true"
+else
+  resp=$(curl_body_code POST "$BASE/v1/provision")
+  code=$(http_code "$resp")
+  body=$(json_body "$resp")
+  check_eq "POST /v1/provision returns 202" "$code" "202"
+  API_KEY=$(printf '%s' "$body" | jq -r '.api_key // empty')
+  check_cmd "provision returns api_key" test -n "$API_KEY"
+fi
+
+echo "[2] wait tenant active"
+deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+state=""
+while :; do
+  sresp=$(curl_body_code GET "$BASE/v1/status" "$API_KEY")
+  scode=$(http_code "$sresp")
+  sbody=$(json_body "$sresp")
+  state=$(printf '%s' "$sbody" | jq -r '.status // empty')
+  echo "status=${scode}:${state}"
+  if [ "$scode" = "200" ] && [ "$state" = "active" ]; then
+    break
+  fi
+  if [ "$(date +%s)" -ge "$deadline" ]; then
+    break
+  fi
+  sleep "$POLL_INTERVAL_S"
+done
+check_eq "tenant becomes active" "$state" "active"
+
+echo "[3] prepare drive9 cli"
+prepare_cli_binary
+check_cmd "drive9 binary ready" test -x "$CLI_BIN"
+
+# HOME is overridden so a pre-existing ~/.drive9 context cannot shadow
+# DRIVE9_SERVER (context server takes precedence over the env var).
+drive9() {
+  HOME="$CTX_HOME" DRIVE9_SERVER="$BASE" DRIVE9_API_KEY="$API_KEY" "$CLI_BIN" "$@"
+}
+
+TS="$(date +%s)"
+if [ -n "$FUSE_RDEL_ARTIFACT_DIR" ]; then
+  mkdir -p "$FUSE_RDEL_ARTIFACT_DIR"
+  RUN_ROOT="$(mktemp -d "$FUSE_RDEL_ARTIFACT_DIR/drive9-fuse-rdel-${TS}.XXXXXX")"
+else
+  RUN_ROOT="$(mktemp -d "$FUSE_MOUNT_ROOT/drive9-fuse-rdel-${TS}.XXXXXX")"
+fi
+RUN_ID="$(basename "$RUN_ROOT")"
+MOUNT_POINT="$RUN_ROOT/mount"
+MOUNT_LOG="$RUN_ROOT/mount.log"
+CTX_HOME="$RUN_ROOT/ctx-home"
+REMOTE_SNAPSHOT="$RUN_ROOT/remote-snapshot"
+ROOT_REL="$RUN_ID"
+ROOT_REMOTE="/$ROOT_REL"
+WORK_MOUNT="$MOUNT_POINT/$ROOT_REL/work"
+WORK_REMOTE="$ROOT_REMOTE/work"
+MOUNT_PID=""
+
+mkdir -p "$MOUNT_POINT" "$CTX_HOME"
+: > "$MOUNT_LOG"
+
+cleanup() {
+  local rc=$?
+  stop_mount
+  if [ -n "${CLI_BIN:-}" ]; then
+    rm -f "$CLI_BIN"
+  fi
+  if [ "$rc" -eq 0 ] && [ "$FAIL" -eq 0 ] && [ "$FUSE_RDEL_KEEP_ARTIFACTS" != "1" ]; then
+    rm -rf "$RUN_ROOT"
+  else
+    echo "Artifacts preserved at $RUN_ROOT"
+    echo "Mount log: $MOUNT_LOG"
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+echo "[4] create remote root"
+drive9_retry fs mkdir "$ROOT_REMOTE" >/dev/null
+check_eq "remote recursive-delete root" "$ROOT_REMOTE" "$ROOT_REMOTE"
+
+echo "[5] mount writable namespace"
+if start_mount; then
+  check_eq "recursive-delete mount is mounted" "true" "true"
+else
+  check_eq "recursive-delete mount is mounted" "false" "true"
+  exit 1
+fi
+
+echo "[6] scenario A: rm -r of large tree with concurrent sibling writes"
+SIBLING_MOUNT="$WORK_MOUNT/stress/sibling"
+SIBLING_MANIFEST="$RUN_ROOT/sibling-manifest.json"
+READY_FILE="$RUN_ROOT/sibling.ready"
+STOP_FILE="$RUN_ROOT/sibling.stop"
+RM_STRESS_LOG="$RUN_ROOT/rm-stress.log"
+: >"$RM_STRESS_LOG"
+
+check_cmd "stress target tree built through mount" build_tree "$WORK_MOUNT/stress/target"
+
+start_sibling_writer >>"$RUN_ROOT/sibling-writer.log" 2>&1 &
+WRITER_PID=$!
+check_cmd "sibling writer seeded base files" wait_for_file "$READY_FILE"
+
+set +e
+rm_out=$(drive9_retry fs rm -r "$WORK_REMOTE/stress/target" 2>&1)
+rm_rc=$?
+set -e
+printf '%s\n' "$rm_out" >>"$RM_STRESS_LOG"
+check_eq "rm -r of large tree succeeds under sibling write load" "$rm_rc" "0"
+lock_hits=$(grep -Eic 'lock[ -]?wait|error 1205|deadlock' "$RM_STRESS_LOG" || true)
+check_eq "rm -r reported no lock-wait/deadlock errors" "$lock_hits" "0"
+check_cmd "deleted stress tree absent remotely" wait_remote_absent "$WORK_REMOTE/stress/target"
+
+touch "$STOP_FILE"
+set +e
+wait "$WRITER_PID"
+writer_rc=$?
+set -e
+check_eq "background sibling writer exited cleanly" "$writer_rc" "0"
+verify_manifest_dir "sibling tree intact through mount (exact manifest)" "$SIBLING_MOUNT" "$SIBLING_MANIFEST" "$RUN_ROOT/sibling-actual-mounted.json"
+
+echo "[7] scenario B: rm -r killed mid-sweep, retry resumes to completion"
+RM_RETRY_LOG="$RUN_ROOT/rm-retry.log"
+: >"$RM_RETRY_LOG"
+
+check_cmd "retry target tree built through mount" build_tree "$WORK_MOUNT/retry/target"
+
+set +e
+drive9 fs rm -r "$WORK_REMOTE/retry/target" >>"$RM_RETRY_LOG" 2>&1 &
+RM_PID=$!
+sleep "$FUSE_RDEL_KILL_AFTER_S"
+killed=0
+if kill -0 "$RM_PID" 2>/dev/null; then
+  kill -9 "$RM_PID" 2>/dev/null && killed=1
+fi
+wait "$RM_PID" 2>/dev/null
+set -e
+if [ "$killed" = "1" ]; then
+  echo "INFO killed first rm -r mid-sweep (kill -9 of CLI cancels the request)"
+else
+  echo "INFO first rm -r finished before the kill landed; resume path not exercised (raise FUSE_RDEL_FILES or lower FUSE_RDEL_KILL_AFTER_S)"
+fi
+
+set +e
+retry_out=$(drive9_retry fs rm -r "$WORK_REMOTE/retry/target" 2>&1)
+retry_rc=$?
+set -e
+printf '%s\n' "$retry_out" >>"$RM_RETRY_LOG"
+if [ "$retry_rc" -ne 0 ]; then
+  # Tolerate "already gone": the first pass may have completed server-side
+  # before the kill landed, in which case the retry sees a 404.
+  if wait_remote_absent "$WORK_REMOTE/retry/target"; then
+    check_eq "retry rm -r (first pass already removed the tree)" "0" "0"
+  else
+    check_eq "retry rm -r succeeds" "$retry_rc" "0"
+  fi
+else
+  check_eq "retry rm -r succeeds" "0" "0"
+fi
+check_cmd "retry target fully removed remotely (no residue)" wait_remote_absent "$WORK_REMOTE/retry/target"
+lock_hits=$(grep -Eic 'lock[ -]?wait|error 1205|deadlock' "$RM_RETRY_LOG" || true)
+check_eq "retry rm -r reported no lock-wait/deadlock errors" "$lock_hits" "0"
+
+echo "[8] scenario C: mkdir at the same path racing an in-flight rm -r"
+RACE_MOUNT_TARGET="$WORK_MOUNT/race/target"
+RACE_NEW_MANIFEST="$RUN_ROOT/race-new-manifest.json"
+RM_RACE_LOG="$RUN_ROOT/rm-race.log"
+: >"$RM_RACE_LOG"
+
+check_cmd "race target tree built through mount" build_tree "$RACE_MOUNT_TARGET"
+
+set +e
+drive9_retry fs rm -r "$WORK_REMOTE/race/target" >>"$RM_RACE_LOG" 2>&1 &
+RM_PID=$!
+set -e
+
+# Race: recreate the directory through the mount as soon as the sweep drops
+# the old root dentry (root-last ordering means this lands at/just after the
+# end of the sweep).
+race_mkdir_ok=0
+race_deadline=$(( $(date +%s) + FUSE_RDEL_SWEEP_TIMEOUT_S ))
+while :; do
+  if mkdir "$RACE_MOUNT_TARGET" 2>/dev/null; then
+    race_mkdir_ok=1
+    break
+  fi
+  if ! kill -0 "$RM_PID" 2>/dev/null; then
+    if mkdir "$RACE_MOUNT_TARGET" 2>/dev/null; then
+      race_mkdir_ok=1
+    fi
+    break
+  fi
+  if [ "$(date +%s)" -ge "$race_deadline" ]; then
+    break
+  fi
+  sleep 0.05
+done
+
+# Write the new tree immediately so early files can land while the sweep is
+# still finishing; the sweep must never delete the recreated tree.
+check_cmd "new tree written at recreated same-path directory" write_race_new_tree
+
+set +e
+wait "$RM_PID"
+race_rm_rc=$?
+set -e
+check_eq "raced rm -r completed successfully" "$race_rm_rc" "0"
+check_eq "same-path mkdir succeeded during/after rm -r" "$race_mkdir_ok" "1"
+lock_hits=$(grep -Eic 'lock[ -]?wait|error 1205|deadlock' "$RM_RACE_LOG" || true)
+check_eq "raced rm -r reported no lock-wait/deadlock errors" "$lock_hits" "0"
+verify_manifest_dir "recreated same-path tree intact through mount (new files only)" "$RACE_MOUNT_TARGET" "$RACE_NEW_MANIFEST" "$RUN_ROOT/race-actual-mounted.json"
+
+echo "[9] unmount and verify remote persistence"
+check_cmd "unmount recursive-delete stress mount" unmount_mount
+MOUNT_PID=""
+mkdir -p "$REMOTE_SNAPSHOT"
+drive9_retry fs cp -r ":$WORK_REMOTE/stress/sibling" "$REMOTE_SNAPSHOT" >/dev/null
+if [ -d "$REMOTE_SNAPSHOT/sibling" ]; then
+  SIBLING_SNAP="$REMOTE_SNAPSHOT/sibling"
+else
+  SIBLING_SNAP="$REMOTE_SNAPSHOT"
+fi
+verify_manifest_dir "remote sibling snapshot matches mounted manifest" "$SIBLING_SNAP" "$SIBLING_MANIFEST" "$RUN_ROOT/sibling-actual-remote.json"
+drive9_retry fs cp -r ":$WORK_REMOTE/race/target" "$REMOTE_SNAPSHOT" >/dev/null
+if [ -d "$REMOTE_SNAPSHOT/target" ]; then
+  RACE_SNAP="$REMOTE_SNAPSHOT/target"
+else
+  RACE_SNAP="$REMOTE_SNAPSHOT"
+fi
+verify_manifest_dir "remote same-path snapshot matches new-tree manifest" "$RACE_SNAP" "$RACE_NEW_MANIFEST" "$RUN_ROOT/race-actual-remote.json"
+
+echo "[10] cleanup remote fixture"
+drive9_retry fs rm -r "$ROOT_REMOTE" >/dev/null || true
+
+echo "RESULT: $PASS/$TOTAL passed, $FAIL failed"
+exit "$FAIL"

--- a/pkg/backend/dat9.go
+++ b/pkg/backend/dat9.go
@@ -567,8 +567,11 @@ func (b *Dat9Backend) RemoveAllCtx(ctx context.Context, path string) (err error)
 		}
 		return err
 	}
-	_, err = b.store.DeleteDirRecursive(ctx, path)
-	if err == nil {
+	summary, err := b.store.DeleteDirRecursive(ctx, path)
+	// Kick the GC worker even when the sweep ended in a retryable error
+	// (ErrDeleteIncomplete / ErrDirectoryNotEmpty): batches committed before
+	// the error may already have enqueued GC tasks.
+	if summary != nil && summary.OrphansEnqueued > 0 {
 		b.notifyWorkEnqueued(BackendWorkFileGC)
 	}
 	return err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1069,9 +1069,19 @@ func (c *Client) RemoveAll(path string) error {
 // RemoveAllCtx removes a file or directory tree recursively with context support.
 // It forwards to deleteCtx with recursive=true, so regular files use Delete
 // semantics and missing paths return the same 404 *StatusError as RemoveAll.
+// A large tree delete may exceed the server's per-request budget; the server
+// then answers 503 and RemoveAllCtx retries with backoff (honoring Retry-After,
+// at most removeAllMaxRetries times). Retrying is safe: the server-side sweep
+// is resumable and idempotent, so a repeated DELETE continues it.
 func (c *Client) RemoveAllCtx(ctx context.Context, path string) error {
 	return c.deleteCtx(ctx, path, true, "")
 }
+
+// removeAllMaxRetries bounds the 503 retry loop for recursive deletes. The
+// server answers 503 (ErrDeleteIncomplete) when a batched recursive delete
+// exhausts its transaction/time budget; the sweep is resumable and idempotent,
+// so re-issuing the same DELETE continues where it left off.
+const removeAllMaxRetries = 4
 
 func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kind string) error {
 	requestURL := c.url(path)
@@ -1082,19 +1092,40 @@ func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kin
 		requestURL += "?kind=" + url.QueryEscape(kind)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
-	if err != nil {
-		return err
+	backoff := time.Second
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := c.do(req)
+		if err != nil {
+			return err
+		}
+		if recursive && resp.StatusCode == http.StatusServiceUnavailable && attempt < removeAllMaxRetries {
+			retryAfter := resp.Header.Get("Retry-After")
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			delay := backoff
+			if secs, perr := strconv.Atoi(strings.TrimSpace(retryAfter)); perr == nil && secs >= 0 {
+				delay = time.Duration(secs) * time.Second
+			}
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+			backoff *= 2
+			continue
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode >= 300 {
+			return readError(resp)
+		}
+		return nil
 	}
-	resp, err := c.do(req)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode >= 300 {
-		return readError(resp)
-	}
-	return nil
 }
 
 // Copy performs a server-side zero-copy (same file_id, new path).

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1080,7 +1080,10 @@ func (c *Client) RemoveAllCtx(ctx context.Context, path string) error {
 // removeAllMaxRetries bounds the 503 retry loop for recursive deletes. The
 // server answers 503 (ErrDeleteIncomplete) when a batched recursive delete
 // exhausts its transaction/time budget; the sweep is resumable and idempotent,
-// so re-issuing the same DELETE continues where it left off.
+// so re-issuing the same DELETE continues where it left off. Note this only
+// helps when the server's budget trips before the gateway/client deadline —
+// a huge tree can still be cut off by an upstream timeout first (the async
+// delete follow-up covers that case).
 const removeAllMaxRetries = 4
 
 func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kind string) error {

--- a/pkg/client/delete_retry_test.go
+++ b/pkg/client/delete_retry_test.go
@@ -1,0 +1,72 @@
+//go:build !integration
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestRemoveAllRetriesOn503 verifies the bounded retry loop around recursive
+// deletes: two 503 responses (honoring Retry-After) followed by a 200 must
+// surface as success, with exactly three requests issued.
+func TestRemoveAllRetriesOn503(t *testing.T) {
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || !strings.Contains(r.URL.RawQuery, "recursive=1") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		switch n := calls.Add(1); n {
+		case 1:
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable)
+		case 2:
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusServiceUnavailable)
+		default:
+			_, _ = fmt.Fprint(w, `{"status":"ok"}`)
+		}
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	if err := c.RemoveAll("/data/"); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("requests = %d, want 3", got)
+	}
+}
+
+// TestRemoveAllRetryLimitExceeded verifies the retry loop is bounded: a server
+// that keeps answering 503 must surface the last 503 as an error after
+// 1 + removeAllMaxRetries requests.
+func TestRemoveAllRetryLimitExceeded(t *testing.T) {
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprint(w, `{"error":"recursive delete in progress, retry to resume"}`)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	err := c.RemoveAll("/data/")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	var se *StatusError
+	if !errors.As(err, &se) || se.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("error = %v, want 503 *StatusError", err)
+	}
+	if got, want := calls.Load(), int32(1+removeAllMaxRetries); got != want {
+		t.Fatalf("requests = %d, want %d", got, want)
+	}
+}

--- a/pkg/datastore/delete_reconcile.go
+++ b/pkg/datastore/delete_reconcile.go
@@ -52,6 +52,12 @@ var deleteReconcileMaxScanRows = 200_000
 // It is in-worker state, not durable: a pod restart re-covers earlier rows,
 // which is acceptable for an audit/repair backstop whose repairs themselves
 // persist. A nil state is equivalent to a fresh one (tests, one-shot runs).
+//
+// Cursors advance in node_id / inode_id sort order: rows created behind the
+// cursor are seen by the current pass, rows created ahead of it wait for the
+// next full pass. This is eventual coverage, not real-time auditing. If a
+// repair fails mid-page, the cursor rolls back to the page start so the next
+// round retries that page.
 type DeleteReconcileState struct {
 	DentryCursor string
 	InodeCursor  string
@@ -130,6 +136,7 @@ func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchS
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		pageStart := state.DentryCursor
 		rows, err := s.db.QueryContext(ctx, `SELECT node_id, path, parent_path, COALESCE(file_id, ''), is_directory
 			FROM file_nodes WHERE `+s.scope.And(`node_id > ?`)+` ORDER BY node_id LIMIT ?`,
 			s.scope.Args(state.DentryCursor, batchSize)...)
@@ -186,6 +193,10 @@ func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchS
 			for _, c := range broken {
 				repaired, err := s.repairBrokenDentry(ctx, c)
 				if err != nil {
+					// Roll the cursor back to the page start so the next
+					// round retries this page's remaining repairs instead
+					// of skipping them until the next full pass.
+					state.DentryCursor = pageStart
 					return err
 				}
 				if repaired {
@@ -344,6 +355,7 @@ func (s *Store) reconcileStrandedInodes(ctx context.Context, dryRun bool, batchS
 		if err := ctx.Err(); err != nil {
 			return err
 		}
+		pageStart := state.InodeCursor
 		// Candidate set: CONFIRMED inodes joined to contents (a directory
 		// inode has no contents row, so the join excludes them), with no
 		// file_nodes reference via either column (file dentries reference
@@ -388,6 +400,10 @@ func (s *Store) reconcileStrandedInodes(ctx context.Context, dryRun bool, batchS
 			for _, id := range page {
 				repaired, err := s.repairStrandedInode(ctx, id)
 				if err != nil {
+					// Roll the cursor back to the page start so the next
+					// round retries this page's remaining repairs instead
+					// of skipping them until the next full pass.
+					state.InodeCursor = pageStart
 					return err
 				}
 				if repaired {

--- a/pkg/datastore/delete_reconcile.go
+++ b/pkg/datastore/delete_reconcile.go
@@ -41,8 +41,21 @@ const DefaultDeleteReconcileBatchSize = 500
 // deleteReconcileMaxScanRows bounds the rows one reconciliation round scans
 // per table, so a hot tenant cannot turn a 10-minute piggyback round into an
 // hours-long scan. Repair progress persists across rounds (repaired rows
-// disappear), so capping a round is safe; dry-run simply re-audits.
-const deleteReconcileMaxScanRows = 200_000
+// disappear), so capping a round is safe; dry-run simply re-audits. A
+// package-level variable so tests can shrink it.
+var deleteReconcileMaxScanRows = 200_000
+
+// DeleteReconcileState carries the scan cursors between reconciliation
+// rounds. The per-tenant worker holds one instance per tenant (alongside its
+// other throttle state), so a round that hits deleteReconcileMaxScanRows
+// resumes where it stopped instead of re-auditing the same prefix forever.
+// It is in-worker state, not durable: a pod restart re-covers earlier rows,
+// which is acceptable for an audit/repair backstop whose repairs themselves
+// persist. A nil state is equivalent to a fresh one (tests, one-shot runs).
+type DeleteReconcileState struct {
+	DentryCursor string
+	InodeCursor  string
+}
 
 // DeleteReconcileReport summarizes one reconciliation round.
 type DeleteReconcileReport struct {
@@ -69,20 +82,25 @@ func DeleteReconcileRepairEnabled() bool {
 // ReconcileDeleteOrphans runs one reconciliation round over this tenant's
 // store: a schema-agnostic broken-chain dentry scan, plus a stranded file
 // inode scan on split-schema stores (skipped when HasLegacyFiles is true).
-// In dry-run mode candidates are only counted and logged.
-func (s *Store) ReconcileDeleteOrphans(ctx context.Context, dryRun bool, batchSize int) (report *DeleteReconcileReport, err error) {
+// In dry-run mode candidates are only counted and logged. state carries the
+// scan cursors between rounds (nil = fresh); a round that completes a full
+// pass resets its cursor so the next round starts over.
+func (s *Store) ReconcileDeleteOrphans(ctx context.Context, dryRun bool, batchSize int, state *DeleteReconcileState) (report *DeleteReconcileReport, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "delete_reconcile", start, &err)
 
 	if batchSize <= 0 {
 		batchSize = DefaultDeleteReconcileBatchSize
 	}
+	if state == nil {
+		state = &DeleteReconcileState{}
+	}
 	report = &DeleteReconcileReport{}
-	if err := s.reconcileBrokenDentries(ctx, dryRun, batchSize, report); err != nil {
+	if err := s.reconcileBrokenDentries(ctx, dryRun, batchSize, state, report); err != nil {
 		return report, err
 	}
 	if !s.useLegacyFiles {
-		if err := s.reconcileStrandedInodes(ctx, dryRun, batchSize, report); err != nil {
+		if err := s.reconcileStrandedInodes(ctx, dryRun, batchSize, state, report); err != nil {
 			return report, err
 		}
 	}
@@ -106,8 +124,7 @@ type reconcileDentryCandidate struct {
 	isDir      bool
 }
 
-func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchSize int, report *DeleteReconcileReport) error {
-	cursor := ""
+func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchSize int, state *DeleteReconcileState, report *DeleteReconcileReport) error {
 	scannedTotal := 0
 	for {
 		if err := ctx.Err(); err != nil {
@@ -115,7 +132,7 @@ func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchS
 		}
 		rows, err := s.db.QueryContext(ctx, `SELECT node_id, path, parent_path, COALESCE(file_id, ''), is_directory
 			FROM file_nodes WHERE `+s.scope.And(`node_id > ?`)+` ORDER BY node_id LIMIT ?`,
-			s.scope.Args(cursor, batchSize)...)
+			s.scope.Args(state.DentryCursor, batchSize)...)
 		if err != nil {
 			return err
 		}
@@ -130,7 +147,7 @@ func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchS
 			}
 			c.isDir = isDir != 0
 			scanned++
-			cursor = c.nodeID
+			state.DentryCursor = c.nodeID
 			// Top-level rows are always valid: the root is implicit and has
 			// no file_nodes row, so a parent lookup would always miss.
 			if c.parentPath == "/" {
@@ -177,9 +194,13 @@ func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchS
 			}
 		}
 		if scanned < batchSize {
+			// Full pass completed: restart from the beginning next round.
+			state.DentryCursor = ""
 			return nil
 		}
 		if scannedTotal >= deleteReconcileMaxScanRows {
+			// Capped round: keep the cursor in state so the next round
+			// resumes here instead of re-auditing the same prefix.
 			logger.Info(ctx, "delete_reconcile_scan_capped",
 				zap.Int("scanned_rows", scannedTotal))
 			return nil
@@ -188,43 +209,56 @@ func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchS
 }
 
 // reconcileExistingParentDirs returns the set of parent paths that exist as
-// directory dentries, using one (path_hash, path) row-constructor IN query
-// per chunk instead of a point check per candidate row.
+// directory dentries. It queries path_hash IN (...) (an index-friendly form
+// on both MySQL and TiDB) and filters the exact path match in memory, instead
+// of a point check per candidate row.
 func (s *Store) reconcileExistingParentDirs(ctx context.Context, parentPaths []string) (map[string]bool, error) {
 	existing := make(map[string]bool, len(parentPaths))
-	seen := make(map[string]bool, len(parentPaths))
-	uniq := make([]string, 0, len(parentPaths))
+	hashToPaths := make(map[string][]string, len(parentPaths))
 	for _, p := range parentPaths {
-		if !seen[p] {
-			seen[p] = true
-			uniq = append(uniq, p)
+		h := fileNodePathHash(p)
+		if len(hashToPaths[h]) == 0 {
+			hashToPaths[h] = []string{p}
+			continue
+		}
+		dup := false
+		for _, q := range hashToPaths[h] {
+			if q == p {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			hashToPaths[h] = append(hashToPaths[h], p)
 		}
 	}
-	for start := 0; start < len(uniq); start += DefaultDeleteReconcileBatchSize {
+	hashes := make([]string, 0, len(hashToPaths))
+	for h := range hashToPaths {
+		hashes = append(hashes, h)
+	}
+	for start := 0; start < len(hashes); start += DefaultDeleteReconcileBatchSize {
 		end := start + DefaultDeleteReconcileBatchSize
-		if end > len(uniq) {
-			end = len(uniq)
+		if end > len(hashes) {
+			end = len(hashes)
 		}
-		chunk := uniq[start:end]
-		tuples := make([]string, 0, len(chunk))
-		args := make([]any, 0, len(chunk)*2)
-		for _, p := range chunk {
-			tuples = append(tuples, "(?, ?)")
-			args = append(args, fileNodePathHash(p), p)
-		}
-		rows, err := s.db.QueryContext(ctx, `SELECT path FROM file_nodes WHERE `+
-			s.scope.And(`(path_hash, path) IN (`+strings.Join(tuples, ",")+`) AND is_directory = 1`),
-			s.scope.Args(args...)...)
+		chunk := hashes[start:end]
+		rows, err := s.db.QueryContext(ctx, `SELECT path_hash, path FROM file_nodes WHERE `+
+			s.scope.And(`path_hash IN (`+questionPlaceholders(len(chunk))+`) AND is_directory = 1`),
+			s.scope.Args(stringsToAny(chunk)...)...)
 		if err != nil {
 			return nil, err
 		}
 		for rows.Next() {
-			var p string
-			if err := rows.Scan(&p); err != nil {
+			var h, p string
+			if err := rows.Scan(&h, &p); err != nil {
 				_ = rows.Close()
 				return nil, err
 			}
-			existing[p] = true
+			for _, q := range hashToPaths[h] {
+				if q == p {
+					existing[p] = true
+				}
+			}
 		}
 		if err := rows.Err(); err != nil {
 			_ = rows.Close()
@@ -304,8 +338,7 @@ func (s *Store) repairBrokenDentry(ctx context.Context, c reconcileDentryCandida
 
 // --- stranded file inodes (split schema only) ---
 
-func (s *Store) reconcileStrandedInodes(ctx context.Context, dryRun bool, batchSize int, report *DeleteReconcileReport) error {
-	cursor := ""
+func (s *Store) reconcileStrandedInodes(ctx context.Context, dryRun bool, batchSize int, state *DeleteReconcileState, report *DeleteReconcileReport) error {
 	scannedTotal := 0
 	for {
 		if err := ctx.Err(); err != nil {
@@ -318,7 +351,7 @@ func (s *Store) reconcileStrandedInodes(ctx context.Context, dryRun bool, batchS
 		// file_gc_tasks row.
 		args := s.scope.Args()                 // i
 		args = append(args, s.scope.Args()...) // c
-		args = append(args, cursor)            // i.inode_id > ?
+		args = append(args, state.InodeCursor) // i.inode_id > ?
 		args = append(args, s.scope.Args()...) // fn
 		args = append(args, s.scope.Args()...) // g
 		args = append(args, batchSize)         // LIMIT
@@ -363,15 +396,19 @@ func (s *Store) reconcileStrandedInodes(ctx context.Context, dryRun bool, batchS
 			}
 		}
 		if len(page) < batchSize {
+			// Full pass completed: restart from the beginning next round.
+			state.InodeCursor = ""
 			return nil
 		}
 		scannedTotal += len(page)
+		state.InodeCursor = page[len(page)-1]
 		if scannedTotal >= deleteReconcileMaxScanRows {
+			// Capped round: keep the cursor in state so the next round
+			// resumes here instead of re-auditing the same prefix.
 			logger.Info(ctx, "delete_reconcile_scan_capped",
 				zap.Int("scanned_rows", scannedTotal))
 			return nil
 		}
-		cursor = page[len(page)-1]
 	}
 }
 

--- a/pkg/datastore/delete_reconcile.go
+++ b/pkg/datastore/delete_reconcile.go
@@ -1,0 +1,459 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"os"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+)
+
+// Orphan reconciliation sweep, per
+// docs/design/recursive-delete-batched-design.md §4.2.1. The batched
+// recursive delete (delete_recursive.go) has a single-statement residual race
+// window at the commit boundary that can orphan a row; this sweep is the
+// backstop that detects and repairs those orphans. It runs in dry-run
+// (audit-only) mode by default and repairs only when
+// DRIVE9_DELETE_RECONCILE_REPAIR is set.
+//
+// Safety rules that must not be weakened:
+//
+//   - A file_nodes row with parent_path == "/" is ALWAYS valid and is skipped
+//     without any lookup: the root is implicit, there is no file_nodes row
+//     for "/", so a parent point-check for a top-level row always misses.
+//   - A non-top-level parent must exist AND be a directory
+//     (is_directory = 1); existence alone is not sufficient.
+//   - Repair locks the candidate row (SELECT ... FOR UPDATE) and re-runs the
+//     parent/reference checks as current reads in the same transaction before
+//     deleting anything; the scan itself is a snapshot read.
+//   - The stranded-inode scan covers file inodes only: the contents JOIN
+//     excludes directory inodes, whose leak is a deliberate Non-goal.
+
+// DefaultDeleteReconcileBatchSize bounds the rows scanned per page when the
+// caller does not specify a batch size.
+const DefaultDeleteReconcileBatchSize = 500
+
+// DeleteReconcileReport summarizes one reconciliation round.
+type DeleteReconcileReport struct {
+	// BrokenDentries counts scan-time broken-chain dentry candidates.
+	BrokenDentries int64
+	// StrandedInodes counts scan-time stranded file inode candidates
+	// (split schema only; always 0 on legacy-files stores).
+	StrandedInodes int64
+	// Repaired counts rows actually repaired; always 0 in dry-run mode.
+	Repaired int64
+}
+
+// DeleteReconcileRepairEnabled reports whether reconciliation runs in repair
+// mode. Read per call so tests and operators can toggle it without a restart.
+func DeleteReconcileRepairEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("DRIVE9_DELETE_RECONCILE_REPAIR"))) {
+	case "1", "true", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// ReconcileDeleteOrphans runs one reconciliation round over this tenant's
+// store: a schema-agnostic broken-chain dentry scan, plus a stranded file
+// inode scan on split-schema stores (skipped when HasLegacyFiles is true).
+// In dry-run mode candidates are only counted and logged.
+func (s *Store) ReconcileDeleteOrphans(ctx context.Context, dryRun bool, batchSize int) (report *DeleteReconcileReport, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "delete_reconcile", start, &err)
+
+	if batchSize <= 0 {
+		batchSize = DefaultDeleteReconcileBatchSize
+	}
+	report = &DeleteReconcileReport{}
+	if err := s.reconcileBrokenDentries(ctx, dryRun, batchSize, report); err != nil {
+		return report, err
+	}
+	if !s.useLegacyFiles {
+		if err := s.reconcileStrandedInodes(ctx, dryRun, batchSize, report); err != nil {
+			return report, err
+		}
+	}
+	logger.Info(ctx, "delete_reconcile_round",
+		zap.Bool("dry_run", dryRun),
+		zap.Int64("broken_dentries", report.BrokenDentries),
+		zap.Int64("stranded_inodes", report.StrandedInodes),
+		zap.Int64("repaired", report.Repaired))
+	return report, nil
+}
+
+// --- broken-chain dentries ---
+
+// reconcileDentryCandidate is a file_nodes row whose parent chain was broken
+// at scan time.
+type reconcileDentryCandidate struct {
+	nodeID     string
+	path       string
+	parentPath string
+	fileID     string
+	isDir      bool
+}
+
+func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchSize int, report *DeleteReconcileReport) error {
+	cursor := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		rows, err := s.db.QueryContext(ctx, `SELECT node_id, path, parent_path, COALESCE(file_id, ''), is_directory
+			FROM file_nodes WHERE `+s.scope.And(`node_id > ?`)+` ORDER BY node_id LIMIT ?`,
+			s.scope.Args(cursor, batchSize)...)
+		if err != nil {
+			return err
+		}
+		var page []reconcileDentryCandidate
+		scanned := 0
+		for rows.Next() {
+			var c reconcileDentryCandidate
+			var isDir int
+			if err := rows.Scan(&c.nodeID, &c.path, &c.parentPath, &c.fileID, &isDir); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			c.isDir = isDir != 0
+			scanned++
+			cursor = c.nodeID
+			// Top-level rows are always valid: the root is implicit and has
+			// no file_nodes row, so a parent lookup would always miss.
+			if c.parentPath == "/" {
+				continue
+			}
+			page = append(page, c)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+
+		// Classify the whole page (snapshot point-checks) before repairing,
+		// so a repair cannot reclassify an unscanned sibling in this round.
+		var broken []reconcileDentryCandidate
+		for _, c := range page {
+			ok, err := s.reconcileParentDirExists(ctx, c.parentPath)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				broken = append(broken, c)
+			}
+		}
+		report.BrokenDentries += int64(len(broken))
+		if !dryRun {
+			for _, c := range broken {
+				repaired, err := s.repairBrokenDentry(ctx, c)
+				if err != nil {
+					return err
+				}
+				if repaired {
+					report.Repaired++
+				}
+			}
+		}
+		if scanned < batchSize {
+			return nil
+		}
+	}
+}
+
+// reconcileParentDirExists is the snapshot parent check: the parent must
+// exist and be a directory.
+func (s *Store) reconcileParentDirExists(ctx context.Context, parentPath string) (bool, error) {
+	var one int
+	err := s.db.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE `+
+		s.scope.And(`path_hash = ? AND path = ? AND is_directory = 1`),
+		s.scope.Args(fileNodePathHash(parentPath), parentPath)...).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// reconcileParentDirExistsTx is the same check as a current read inside a
+// repair transaction.
+func (s *Store) reconcileParentDirExistsTx(ctx context.Context, tx *sql.Tx, parentPath string) (bool, error) {
+	var one int
+	err := tx.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE `+
+		s.scope.And(`path_hash = ? AND path = ? AND is_directory = 1`),
+		s.scope.Args(fileNodePathHash(parentPath), parentPath)...).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// repairBrokenDentry repairs one broken-chain candidate in its own small
+// transaction: lock the row by node_id, re-run the parent check as a current
+// read, and only then delete the dentry and run the orphan pipeline for its
+// file_id. repaired=false means the row was already gone or its parent
+// reappeared (the chain was mid-EnsureParentDirsTx when scanned).
+func (s *Store) repairBrokenDentry(ctx context.Context, c reconcileDentryCandidate) (repaired bool, err error) {
+	err = s.reconcileWithRetry(ctx, func(tx *sql.Tx) error {
+		repaired = false
+		var parentPath, fileID string
+		var isDir int
+		err := tx.QueryRowContext(ctx, `SELECT parent_path, COALESCE(file_id, ''), is_directory
+			FROM file_nodes WHERE `+s.scope.And(`node_id = ?`)+` FOR UPDATE`,
+			s.scope.Args(c.nodeID)...).Scan(&parentPath, &fileID, &isDir)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil // already gone (concurrent delete): idempotent no-op
+		}
+		if err != nil {
+			return err
+		}
+		if parentPath == "/" {
+			return nil // top-level row: never broken
+		}
+		ok, err := s.reconcileParentDirExistsTx(ctx, tx, parentPath)
+		if err != nil {
+			return err
+		}
+		if ok {
+			return nil // parent reappeared since the snapshot scan
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+
+			s.scope.And(`node_id = ?`), s.scope.Args(c.nodeID)...); err != nil {
+			return err
+		}
+		repaired = true
+		logger.Info(ctx, "delete_reconcile_dentry_repaired",
+			zap.String("node_id", c.nodeID),
+			zap.String("path", c.path),
+			zap.String("parent_path", parentPath),
+			zap.Bool("is_directory", isDir != 0))
+		if isDir == 0 && fileID != "" {
+			if _, err := s.processOrphansTx(ctx, tx, []string{fileID}); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	return repaired, err
+}
+
+// --- stranded file inodes (split schema only) ---
+
+func (s *Store) reconcileStrandedInodes(ctx context.Context, dryRun bool, batchSize int, report *DeleteReconcileReport) error {
+	cursor := ""
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		// Candidate set: CONFIRMED inodes joined to contents (a directory
+		// inode has no contents row, so the join excludes them), with no
+		// file_nodes reference via either column (file dentries reference
+		// through file_id, directory dentries through inode_id) and no
+		// file_gc_tasks row.
+		args := s.scope.Args()                 // i
+		args = append(args, s.scope.Args()...) // c
+		args = append(args, cursor)            // i.inode_id > ?
+		args = append(args, s.scope.Args()...) // fn
+		args = append(args, s.scope.Args()...) // g
+		args = append(args, batchSize)         // LIMIT
+		rows, err := s.db.QueryContext(ctx, `SELECT i.inode_id FROM inodes i
+			JOIN contents c ON c.inode_id = i.inode_id
+			WHERE `+s.scope.AndAs("i", s.scope.AndAs("c", `i.status = 'CONFIRMED' AND i.inode_id > ?`))+`
+			  AND NOT EXISTS (SELECT 1 FROM file_nodes fn WHERE `+
+			s.scope.AndAs("fn", `(fn.file_id = i.inode_id OR fn.inode_id = i.inode_id)`)+`)
+			  AND NOT EXISTS (SELECT 1 FROM file_gc_tasks g WHERE `+
+			s.scope.AndAs("g", `(g.file_id = i.inode_id OR g.inode_id = i.inode_id)`)+`)
+			ORDER BY i.inode_id LIMIT ?`, args...)
+		if err != nil {
+			return err
+		}
+		var page []string
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				_ = rows.Close()
+				return err
+			}
+			page = append(page, id)
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return err
+		}
+		if err := rows.Close(); err != nil {
+			return err
+		}
+
+		report.StrandedInodes += int64(len(page))
+		if !dryRun {
+			for _, id := range page {
+				repaired, err := s.repairStrandedInode(ctx, id)
+				if err != nil {
+					return err
+				}
+				if repaired {
+					report.Repaired++
+				}
+			}
+		}
+		if len(page) < batchSize {
+			return nil
+		}
+		cursor = page[len(page)-1]
+	}
+}
+
+// repairStrandedInode repairs one stranded file inode in its own small
+// transaction: lock the inode, re-run the reference checks as current reads,
+// then mark it DELETED, drop its tags, and enqueue the GC task.
+func (s *Store) repairStrandedInode(ctx context.Context, inodeID string) (repaired bool, err error) {
+	err = s.reconcileWithRetry(ctx, func(tx *sql.Tx) error {
+		repaired = false
+		var status string
+		err := tx.QueryRowContext(ctx, `SELECT status FROM inodes WHERE `+
+			s.scope.And(`inode_id = ?`)+` FOR UPDATE`,
+			s.scope.Args(inodeID)...).Scan(&status)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if FileStatus(status) != StatusConfirmed {
+			return nil
+		}
+		// Fetch the contents row (also the directory-inode exclusion: a
+		// directory inode has no contents row) to build the GC task.
+		var sizeBytes int64
+		var storageType, storageRef, contentType sql.NullString
+		err = tx.QueryRowContext(ctx, `SELECT i.size_bytes, c.storage_type, c.storage_ref, c.content_type
+			FROM inodes i JOIN contents c ON c.inode_id = i.inode_id
+			WHERE `+s.scope.AndAs("i", s.scope.AndAs("c", `i.inode_id = ?`)),
+			scopeWhereArgs(s.scope, 2, s.scope.Args(inodeID)...)...).Scan(
+			&sizeBytes, &storageType, &storageRef, &contentType)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil // no contents row: directory inode — Non-goal, leave it
+		}
+		if err != nil {
+			return err
+		}
+		f := &File{
+			FileID:      inodeID,
+			StorageType: StorageType(storageType.String),
+			StorageRef:  storageRef.String,
+			ContentType: contentType.String,
+			SizeBytes:   sizeBytes,
+			Status:      StatusDeleted,
+		}
+		// Current-read re-checks under the inode lock.
+		referenced, err := s.reconcileInodeReferencedTx(ctx, tx, inodeID)
+		if err != nil {
+			return err
+		}
+		if referenced {
+			return nil
+		}
+		hasTask, err := s.reconcileInodeHasGCTaskTx(ctx, tx, inodeID)
+		if err != nil {
+			return err
+		}
+		if hasTask {
+			return nil // the GC worker already owns it
+		}
+		if _, err := tx.ExecContext(ctx, `UPDATE inodes SET status = 'DELETED' WHERE `+
+			s.scope.And(`inode_id = ?`), s.scope.Args(inodeID)...); err != nil {
+			return err
+		}
+		if err := s.deleteFileTagsByIDsTx(ctx, tx, []string{inodeID}); err != nil {
+			return err
+		}
+		task, err := NewFileGCTaskFromFile(f, time.Now().UTC())
+		if err != nil {
+			return err
+		}
+		if _, err := s.enqueueFileGCTasksTx(tx, []*FileGCTask{task}); err != nil {
+			return err
+		}
+		repaired = true
+		logger.Info(ctx, "delete_reconcile_inode_repaired", zap.String("inode_id", inodeID))
+		return nil
+	})
+	return repaired, err
+}
+
+// reconcileInodeReferencedTx reports whether any file_nodes row references
+// the inode via either column (current read).
+func (s *Store) reconcileInodeReferencedTx(ctx context.Context, tx *sql.Tx, inodeID string) (bool, error) {
+	var one int
+	err := tx.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE `+
+		s.scope.And(`file_id = ? OR inode_id = ?`)+` LIMIT 1`,
+		s.scope.Args(inodeID, inodeID)...).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// reconcileInodeHasGCTaskTx reports whether a file_gc_tasks row already
+// exists for the inode (current read).
+func (s *Store) reconcileInodeHasGCTaskTx(ctx context.Context, tx *sql.Tx, inodeID string) (bool, error) {
+	var one int
+	err := tx.QueryRowContext(ctx, `SELECT 1 FROM file_gc_tasks WHERE `+
+		s.scope.And(`file_id = ? OR inode_id = ?`)+` LIMIT 1`,
+		s.scope.Args(inodeID, inodeID)...).Scan(&one)
+	if errors.Is(err, sql.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// reconcileWithRetry runs fn in a transaction, retrying deadlock/lock-wait
+// failures with backoff, mirroring the sweep's withBatchRetry.
+func (s *Store) reconcileWithRetry(ctx context.Context, fn func(tx *sql.Tx) error) error {
+	for attempt := 0; ; attempt++ {
+		tx, err := s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		fnErr := fn(tx)
+		if fnErr != nil {
+			_ = tx.Rollback()
+			if isRetryableTxnError(fnErr) && attempt < deleteDirBatchRetries {
+				if !sleepWithContext(ctx, time.Duration(50*(1<<attempt))*time.Millisecond) {
+					return ctx.Err()
+				}
+				continue
+			}
+			return fnErr
+		}
+		if err := tx.Commit(); err != nil {
+			if isRetryableTxnError(err) && attempt < deleteDirBatchRetries {
+				if !sleepWithContext(ctx, time.Duration(50*(1<<attempt))*time.Millisecond) {
+					return ctx.Err()
+				}
+				continue
+			}
+			return err
+		}
+		return nil
+	}
+}

--- a/pkg/datastore/delete_reconcile.go
+++ b/pkg/datastore/delete_reconcile.go
@@ -38,6 +38,12 @@ import (
 // caller does not specify a batch size.
 const DefaultDeleteReconcileBatchSize = 500
 
+// deleteReconcileMaxScanRows bounds the rows one reconciliation round scans
+// per table, so a hot tenant cannot turn a 10-minute piggyback round into an
+// hours-long scan. Repair progress persists across rounds (repaired rows
+// disappear), so capping a round is safe; dry-run simply re-audits.
+const deleteReconcileMaxScanRows = 200_000
+
 // DeleteReconcileReport summarizes one reconciliation round.
 type DeleteReconcileReport struct {
 	// BrokenDentries counts scan-time broken-chain dentry candidates.
@@ -102,6 +108,7 @@ type reconcileDentryCandidate struct {
 
 func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchSize int, report *DeleteReconcileReport) error {
 	cursor := ""
+	scannedTotal := 0
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -138,16 +145,22 @@ func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchS
 		if err := rows.Close(); err != nil {
 			return err
 		}
+		scannedTotal += scanned
 
-		// Classify the whole page (snapshot point-checks) before repairing,
-		// so a repair cannot reclassify an unscanned sibling in this round.
+		// Classify the whole page (one batched snapshot check) before
+		// repairing, so a repair cannot reclassify an unscanned sibling in
+		// this round.
+		parentPaths := make([]string, 0, len(page))
+		for _, c := range page {
+			parentPaths = append(parentPaths, c.parentPath)
+		}
+		existing, err := s.reconcileExistingParentDirs(ctx, parentPaths)
+		if err != nil {
+			return err
+		}
 		var broken []reconcileDentryCandidate
 		for _, c := range page {
-			ok, err := s.reconcileParentDirExists(ctx, c.parentPath)
-			if err != nil {
-				return err
-			}
-			if !ok {
+			if !existing[c.parentPath] {
 				broken = append(broken, c)
 			}
 		}
@@ -166,23 +179,62 @@ func (s *Store) reconcileBrokenDentries(ctx context.Context, dryRun bool, batchS
 		if scanned < batchSize {
 			return nil
 		}
+		if scannedTotal >= deleteReconcileMaxScanRows {
+			logger.Info(ctx, "delete_reconcile_scan_capped",
+				zap.Int("scanned_rows", scannedTotal))
+			return nil
+		}
 	}
 }
 
-// reconcileParentDirExists is the snapshot parent check: the parent must
-// exist and be a directory.
-func (s *Store) reconcileParentDirExists(ctx context.Context, parentPath string) (bool, error) {
-	var one int
-	err := s.db.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE `+
-		s.scope.And(`path_hash = ? AND path = ? AND is_directory = 1`),
-		s.scope.Args(fileNodePathHash(parentPath), parentPath)...).Scan(&one)
-	if errors.Is(err, sql.ErrNoRows) {
-		return false, nil
+// reconcileExistingParentDirs returns the set of parent paths that exist as
+// directory dentries, using one (path_hash, path) row-constructor IN query
+// per chunk instead of a point check per candidate row.
+func (s *Store) reconcileExistingParentDirs(ctx context.Context, parentPaths []string) (map[string]bool, error) {
+	existing := make(map[string]bool, len(parentPaths))
+	seen := make(map[string]bool, len(parentPaths))
+	uniq := make([]string, 0, len(parentPaths))
+	for _, p := range parentPaths {
+		if !seen[p] {
+			seen[p] = true
+			uniq = append(uniq, p)
+		}
 	}
-	if err != nil {
-		return false, err
+	for start := 0; start < len(uniq); start += DefaultDeleteReconcileBatchSize {
+		end := start + DefaultDeleteReconcileBatchSize
+		if end > len(uniq) {
+			end = len(uniq)
+		}
+		chunk := uniq[start:end]
+		tuples := make([]string, 0, len(chunk))
+		args := make([]any, 0, len(chunk)*2)
+		for _, p := range chunk {
+			tuples = append(tuples, "(?, ?)")
+			args = append(args, fileNodePathHash(p), p)
+		}
+		rows, err := s.db.QueryContext(ctx, `SELECT path FROM file_nodes WHERE `+
+			s.scope.And(`(path_hash, path) IN (`+strings.Join(tuples, ",")+`) AND is_directory = 1`),
+			s.scope.Args(args...)...)
+		if err != nil {
+			return nil, err
+		}
+		for rows.Next() {
+			var p string
+			if err := rows.Scan(&p); err != nil {
+				_ = rows.Close()
+				return nil, err
+			}
+			existing[p] = true
+		}
+		if err := rows.Err(); err != nil {
+			_ = rows.Close()
+			return nil, err
+		}
+		if err := rows.Close(); err != nil {
+			return nil, err
+		}
 	}
-	return true, nil
+	return existing, nil
 }
 
 // reconcileParentDirExistsTx is the same check as a current read inside a
@@ -254,6 +306,7 @@ func (s *Store) repairBrokenDentry(ctx context.Context, c reconcileDentryCandida
 
 func (s *Store) reconcileStrandedInodes(ctx context.Context, dryRun bool, batchSize int, report *DeleteReconcileReport) error {
 	cursor := ""
+	scannedTotal := 0
 	for {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -312,6 +365,12 @@ func (s *Store) reconcileStrandedInodes(ctx context.Context, dryRun bool, batchS
 		if len(page) < batchSize {
 			return nil
 		}
+		scannedTotal += len(page)
+		if scannedTotal >= deleteReconcileMaxScanRows {
+			logger.Info(ctx, "delete_reconcile_scan_capped",
+				zap.Int("scanned_rows", scannedTotal))
+			return nil
+		}
 		cursor = page[len(page)-1]
 	}
 }
@@ -342,7 +401,7 @@ func (s *Store) repairStrandedInode(ctx context.Context, inodeID string) (repair
 		err = tx.QueryRowContext(ctx, `SELECT i.size_bytes, c.storage_type, c.storage_ref, c.content_type
 			FROM inodes i JOIN contents c ON c.inode_id = i.inode_id
 			WHERE `+s.scope.AndAs("i", s.scope.AndAs("c", `i.inode_id = ?`)),
-			scopeWhereArgs(s.scope, 2, s.scope.Args(inodeID)...)...).Scan(
+			scopeWhereArgs(s.scope, 2, inodeID)...).Scan(
 			&sizeBytes, &storageType, &storageRef, &contentType)
 		if errors.Is(err, sql.ErrNoRows) {
 			return nil // no contents row: directory inode — Non-goal, leave it
@@ -399,7 +458,7 @@ func (s *Store) repairStrandedInode(ctx context.Context, inodeID string) (repair
 func (s *Store) reconcileInodeReferencedTx(ctx context.Context, tx *sql.Tx, inodeID string) (bool, error) {
 	var one int
 	err := tx.QueryRowContext(ctx, `SELECT 1 FROM file_nodes WHERE `+
-		s.scope.And(`file_id = ? OR inode_id = ?`)+` LIMIT 1`,
+		s.scope.And(`(file_id = ? OR inode_id = ?)`)+` LIMIT 1`,
 		s.scope.Args(inodeID, inodeID)...).Scan(&one)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil
@@ -415,7 +474,7 @@ func (s *Store) reconcileInodeReferencedTx(ctx context.Context, tx *sql.Tx, inod
 func (s *Store) reconcileInodeHasGCTaskTx(ctx context.Context, tx *sql.Tx, inodeID string) (bool, error) {
 	var one int
 	err := tx.QueryRowContext(ctx, `SELECT 1 FROM file_gc_tasks WHERE `+
-		s.scope.And(`file_id = ? OR inode_id = ?`)+` LIMIT 1`,
+		s.scope.And(`(file_id = ? OR inode_id = ?)`)+` LIMIT 1`,
 		s.scope.Args(inodeID, inodeID)...).Scan(&one)
 	if errors.Is(err, sql.ErrNoRows) {
 		return false, nil

--- a/pkg/datastore/delete_reconcile_test.go
+++ b/pkg/datastore/delete_reconcile_test.go
@@ -1,0 +1,332 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/internal/testmysql"
+)
+
+// newSplitOnlyTestStore returns a store whose database has no legacy `files`
+// table, so the stranded-inode scan (split schema only) runs.
+func newSplitOnlyTestStore(t *testing.T) *Store {
+	t.Helper()
+	initDatastoreSchema(t, testDSN)
+	db, err := sql.Open("mysql", testDSN)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if _, err := db.Exec(`DROP TABLE IF EXISTS files`); err != nil {
+		_ = db.Close()
+		t.Fatalf("drop files: %v", err)
+	}
+	testmysql.ResetDBWithoutFiles(t, db)
+	_ = db.Close()
+
+	s, err := Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.HasLegacyFiles() {
+		_ = s.Close()
+		t.Fatal("expected split-only store, got legacy files")
+	}
+	t.Cleanup(func() { _ = s.Close() })
+	return s
+}
+
+func reconcilePlantFile(t *testing.T, s *Store, fileID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := s.InsertFile(context.Background(), &File{
+		FileID:      fileID,
+		StorageType: StorageDB9,
+		StorageRef:  "/blobs/" + fileID,
+		SizeBytes:   4,
+		Revision:    1,
+		Status:      StatusConfirmed,
+		CreatedAt:   now,
+		ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func reconcilePlantDir(t *testing.T, s *Store, nodeID, path, parentPath, inodeID string) {
+	t.Helper()
+	now := time.Now().UTC()
+	if err := s.InsertInode(context.Background(), &Inode{
+		InodeID:   inodeID,
+		Revision:  1,
+		Mode:      0o755,
+		Status:    StatusConfirmed,
+		CreatedAt: now,
+		Mtime:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(context.Background(), &FileNode{
+		NodeID:      nodeID,
+		Path:        path,
+		ParentPath:  parentPath,
+		Name:        baseName(path),
+		IsDirectory: true,
+		InodeID:     inodeID,
+		CreatedAt:   now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func reconcilePlantFileNode(t *testing.T, s *Store, nodeID, path, parentPath, fileID string) {
+	t.Helper()
+	if err := s.InsertNode(context.Background(), &FileNode{
+		NodeID:     nodeID,
+		Path:       path,
+		ParentPath: parentPath,
+		Name:       baseName(path),
+		FileID:     fileID,
+		CreatedAt:  time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func reconcileNodeExists(t *testing.T, s *Store, path string) bool {
+	t.Helper()
+	exists, err := s.NodeExists(context.Background(), path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return exists
+}
+
+func reconcileInodeStatus(t *testing.T, s *Store, inodeID string) string {
+	t.Helper()
+	var status string
+	if err := s.DB().QueryRowContext(context.Background(),
+		`SELECT status FROM inodes WHERE inode_id = ?`, inodeID).Scan(&status); err != nil {
+		t.Fatal(err)
+	}
+	return status
+}
+
+func reconcileGCTaskCount(t *testing.T, s *Store, fileID string) int {
+	t.Helper()
+	var n int
+	if err := s.DB().QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM file_gc_tasks WHERE file_id = ?`, fileID).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	return n
+}
+
+// Regression red line: top-level rows (parent_path == "/") must never be
+// classified as broken — the implicit root has no file_nodes row.
+func TestReconcileDeleteOrphansRepairsOnlyBrokenDentry(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	// Normal top-level file and directory.
+	reconcilePlantFile(t, s, "f-top")
+	reconcilePlantFileNode(t, s, "n-top", "/top.txt", "/", "f-top")
+	reconcilePlantDir(t, s, "n-topdir", "/dir/", "/", "d-top")
+
+	// A genuinely broken dentry: parent /ghost/ does not exist.
+	reconcilePlantFile(t, s, "f-orphan")
+	reconcilePlantFileNode(t, s, "n-orphan", "/ghost/a.txt", "/ghost/", "f-orphan")
+
+	report, err := s.ReconcileDeleteOrphans(ctx, false, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.BrokenDentries != 1 || report.Repaired != 1 {
+		t.Fatalf("report = %+v, want BrokenDentries=1 Repaired=1", report)
+	}
+
+	// Top-level rows untouched (zero false positives).
+	if !reconcileNodeExists(t, s, "/top.txt") {
+		t.Fatal("top-level file /top.txt was wrongly removed")
+	}
+	if !reconcileNodeExists(t, s, "/dir/") {
+		t.Fatal("top-level dir /dir/ was wrongly removed")
+	}
+	if got := reconcileInodeStatus(t, s, "f-top"); got != string(StatusConfirmed) {
+		t.Fatalf("f-top status = %s, want CONFIRMED", got)
+	}
+	if n := reconcileGCTaskCount(t, s, "f-top"); n != 0 {
+		t.Fatalf("f-top gc tasks = %d, want 0", n)
+	}
+
+	// Broken dentry repaired: node gone, file DELETED, GC task enqueued.
+	if reconcileNodeExists(t, s, "/ghost/a.txt") {
+		t.Fatal("broken dentry /ghost/a.txt still present")
+	}
+	if got := reconcileInodeStatus(t, s, "f-orphan"); got != string(StatusDeleted) {
+		t.Fatalf("f-orphan status = %s, want DELETED", got)
+	}
+	if n := reconcileGCTaskCount(t, s, "f-orphan"); n != 1 {
+		t.Fatalf("f-orphan gc tasks = %d, want 1", n)
+	}
+}
+
+// A broken-chain directory with an intact subtree converges over multiple
+// rounds: round 1 repairs only the directory's own dentry, later rounds pick
+// up the children stranded one level down.
+func TestReconcileDeleteOrphansBrokenDirMultiRound(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	reconcilePlantDir(t, s, "n-sub", "/ghost/sub/", "/ghost/", "d-sub")
+	reconcilePlantFile(t, s, "f-1")
+	reconcilePlantFileNode(t, s, "n-f1", "/ghost/sub/f.txt", "/ghost/sub/", "f-1")
+	reconcilePlantDir(t, s, "n-inner", "/ghost/sub/inner/", "/ghost/sub/", "d-inner")
+	reconcilePlantFile(t, s, "f-2")
+	reconcilePlantFileNode(t, s, "n-f2", "/ghost/sub/inner/g.txt", "/ghost/sub/inner/", "f-2")
+
+	// Round 1: only the top broken dentry is repaired; the children's chains
+	// were intact at scan time.
+	report, err := s.ReconcileDeleteOrphans(ctx, false, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Repaired != 1 {
+		t.Fatalf("round 1 repaired = %d, want 1", report.Repaired)
+	}
+	if reconcileNodeExists(t, s, "/ghost/sub/") {
+		t.Fatal("round 1: /ghost/sub/ still present")
+	}
+	if !reconcileNodeExists(t, s, "/ghost/sub/f.txt") || !reconcileNodeExists(t, s, "/ghost/sub/inner/") {
+		t.Fatal("round 1 repaired children whose chains were intact at scan time")
+	}
+
+	// Later rounds converge: every descendant is repaired, files get GC tasks.
+	converged := false
+	for round := 2; round <= 6; round++ {
+		report, err := s.ReconcileDeleteOrphans(ctx, false, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if report.BrokenDentries == 0 && report.StrandedInodes == 0 {
+			converged = true
+			break
+		}
+	}
+	if !converged {
+		t.Fatal("reconciliation did not converge within 5 follow-up rounds")
+	}
+	for _, p := range []string{"/ghost/sub/f.txt", "/ghost/sub/inner/", "/ghost/sub/inner/g.txt"} {
+		if reconcileNodeExists(t, s, p) {
+			t.Fatalf("node %s still present after convergence", p)
+		}
+	}
+	for _, id := range []string{"f-1", "f-2"} {
+		if got := reconcileInodeStatus(t, s, id); got != string(StatusDeleted) {
+			t.Fatalf("%s status = %s, want DELETED", id, got)
+		}
+		if n := reconcileGCTaskCount(t, s, id); n != 1 {
+			t.Fatalf("%s gc tasks = %d, want 1", id, n)
+		}
+	}
+}
+
+func TestReconcileDeleteOrphansStrandedInode(t *testing.T) {
+	s := newSplitOnlyTestStore(t)
+	ctx := context.Background()
+
+	// CONFIRMED inode + contents, no file_nodes reference.
+	reconcilePlantFile(t, s, "f-stray")
+
+	report, err := s.ReconcileDeleteOrphans(ctx, false, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.StrandedInodes != 1 || report.Repaired != 1 {
+		t.Fatalf("report = %+v, want StrandedInodes=1 Repaired=1", report)
+	}
+	if got := reconcileInodeStatus(t, s, "f-stray"); got != string(StatusDeleted) {
+		t.Fatalf("f-stray status = %s, want DELETED", got)
+	}
+	if n := reconcileGCTaskCount(t, s, "f-stray"); n != 1 {
+		t.Fatalf("f-stray gc tasks = %d, want 1", n)
+	}
+}
+
+// Directory inodes (inodes row, no contents row) are a deliberate Non-goal:
+// the sweep must leave them alone.
+func TestReconcileDeleteOrphansIgnoresDirectoryInode(t *testing.T) {
+	s := newSplitOnlyTestStore(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC()
+	if err := s.InsertInode(ctx, &Inode{
+		InodeID:   "d-stray",
+		Revision:  1,
+		Mode:      0o755,
+		Status:    StatusConfirmed,
+		CreatedAt: now,
+		Mtime:     now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := s.ReconcileDeleteOrphans(ctx, false, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.StrandedInodes != 0 || report.Repaired != 0 {
+		t.Fatalf("report = %+v, want zero hits for directory inode", report)
+	}
+	if got := reconcileInodeStatus(t, s, "d-stray"); got != string(StatusConfirmed) {
+		t.Fatalf("d-stray status = %s, want CONFIRMED (untouched)", got)
+	}
+	if n := reconcileGCTaskCount(t, s, "d-stray"); n != 0 {
+		t.Fatalf("d-stray gc tasks = %d, want 0", n)
+	}
+}
+
+func TestReconcileDeleteOrphansDryRun(t *testing.T) {
+	s := newSplitOnlyTestStore(t)
+	ctx := context.Background()
+
+	reconcilePlantFile(t, s, "f-orphan")
+	reconcilePlantFileNode(t, s, "n-orphan", "/ghost/a.txt", "/ghost/", "f-orphan")
+	reconcilePlantFile(t, s, "f-stray")
+
+	report, err := s.ReconcileDeleteOrphans(ctx, true, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.BrokenDentries != 1 || report.StrandedInodes != 1 || report.Repaired != 0 {
+		t.Fatalf("report = %+v, want BrokenDentries=1 StrandedInodes=1 Repaired=0", report)
+	}
+
+	// Dry-run must not modify anything.
+	if !reconcileNodeExists(t, s, "/ghost/a.txt") {
+		t.Fatal("dry-run removed the broken dentry")
+	}
+	if got := reconcileInodeStatus(t, s, "f-orphan"); got != string(StatusConfirmed) {
+		t.Fatalf("f-orphan status = %s, want CONFIRMED", got)
+	}
+	if got := reconcileInodeStatus(t, s, "f-stray"); got != string(StatusConfirmed) {
+		t.Fatalf("f-stray status = %s, want CONFIRMED", got)
+	}
+	if n := reconcileGCTaskCount(t, s, "f-orphan"); n != 0 {
+		t.Fatalf("f-orphan gc tasks = %d, want 0", n)
+	}
+	if n := reconcileGCTaskCount(t, s, "f-stray"); n != 0 {
+		t.Fatalf("f-stray gc tasks = %d, want 0", n)
+	}
+}
+
+func TestDeleteReconcileRepairEnabled(t *testing.T) {
+	if DeleteReconcileRepairEnabled() {
+		t.Fatal("repair mode enabled without env var")
+	}
+	t.Setenv("DRIVE9_DELETE_RECONCILE_REPAIR", "1")
+	if !DeleteReconcileRepairEnabled() {
+		t.Fatal("repair mode disabled with DRIVE9_DELETE_RECONCILE_REPAIR=1")
+	}
+}

--- a/pkg/datastore/delete_reconcile_test.go
+++ b/pkg/datastore/delete_reconcile_test.go
@@ -330,3 +330,77 @@ func TestDeleteReconcileRepairEnabled(t *testing.T) {
 		t.Fatal("repair mode disabled with DRIVE9_DELETE_RECONCILE_REPAIR=1")
 	}
 }
+
+// TestReconcileStrandedInodeSharedScopeIsolation is the regression test for
+// the ungrouped-OR bug in the repair re-checks: under shared schema,
+// `fs_id = ? AND file_id = ? OR inode_id = ?` lets the inode_id branch escape
+// the fs_id conjunct, so a *different tenant's* file_nodes/file_gc_tasks row
+// with the same ID would make the repair wrongly conclude "still referenced"
+// and skip the stranded inode forever. Both re-checks must group the OR.
+func TestReconcileStrandedInodeSharedScopeIsolation(t *testing.T) {
+	installSharedCoreFSNoLegacy(t)
+	ctx := context.Background()
+	const fsA, fsB int64 = 4600001, 4600002
+	storeA := newSharedStore(t, fsA)
+	storeB := newSharedStore(t, fsB)
+	now := time.Now()
+
+	// Two stranded CONFIRMED file inodes for tenant A: no file_nodes row, no
+	// GC task.
+	for _, id := range []string{"shared-stray-1", "shared-stray-2"} {
+		if err := storeA.InsertFile(ctx, &File{
+			FileID: id, StorageType: StorageDB9, StorageRef: "inline:" + id,
+			SizeBytes: 1, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+		}); err != nil {
+			t.Fatalf("InsertFile %s: %v", id, err)
+		}
+	}
+
+	// Tenant B references the same IDs — a file_nodes row for one, a GC task
+	// for the other. Neither must affect A's reconciliation.
+	if _, err := storeB.DB().Exec(`INSERT INTO file_nodes
+		(fs_id, node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, created_at)
+		VALUES (?, ?, ?, ?, '/', ?, 'b.txt', 0, 'shared-stray-1', ?)`,
+		fsB, "shared-b-node-1", "/b.txt", fileNodePathHash("/b.txt"), fileNodePathHash("/"), now); err != nil {
+		t.Fatalf("insert B file_nodes row: %v", err)
+	}
+	if _, err := storeB.EnqueueFileGCTaskTx(storeB.DB(), &FileGCTask{
+		FileID: "shared-stray-2", StorageType: StorageDB9, StorageRef: "inline:b",
+	}); err != nil {
+		t.Fatalf("insert B gc task: %v", err)
+	}
+
+	report, err := storeA.ReconcileDeleteOrphans(ctx, false, 0)
+	if err != nil {
+		t.Fatalf("ReconcileDeleteOrphans: %v", err)
+	}
+	if report.StrandedInodes != 2 || report.Repaired != 2 {
+		t.Fatalf("report = %+v, want 2 stranded inodes and 2 repairs", report)
+	}
+	for _, id := range []string{"shared-stray-1", "shared-stray-2"} {
+		var status string
+		if err := storeA.DB().QueryRow(`SELECT status FROM inodes WHERE fs_id = ? AND inode_id = ?`,
+			fsA, id).Scan(&status); err != nil {
+			t.Fatalf("read inode %s: %v", id, err)
+		}
+		if status != string(StatusDeleted) {
+			t.Fatalf("inode %s status = %s, want DELETED", id, status)
+		}
+		if _, err := storeA.GetFileGCTaskByFileID(ctx, id); err != nil {
+			t.Fatalf("gc task for %s: %v", id, err)
+		}
+	}
+
+	// Tenant B's rows are untouched.
+	var bNodes int
+	if err := storeB.DB().QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE fs_id = ? AND file_id = ?`,
+		fsB, "shared-stray-1").Scan(&bNodes); err != nil {
+		t.Fatal(err)
+	}
+	if bNodes != 1 {
+		t.Fatalf("tenant B file_nodes row count = %d, want 1", bNodes)
+	}
+	if _, err := storeB.GetFileGCTaskByFileID(ctx, "shared-stray-2"); err != nil {
+		t.Fatalf("tenant B gc task should survive: %v", err)
+	}
+}

--- a/pkg/datastore/delete_reconcile_test.go
+++ b/pkg/datastore/delete_reconcile_test.go
@@ -479,3 +479,75 @@ func TestReconcileCappedRoundResumesFromCursor(t *testing.T) {
 		t.Fatalf("broken dentry across rounds = %d, want 1", found)
 	}
 }
+
+// TestReconcileCappedRoundRepairResumes is the repair-mode counterpart of
+// TestReconcileCappedRoundResumesFromCursor: repairs made by earlier rounds
+// persist, later rounds resume from the cursor, and no row is repaired twice.
+func TestReconcileCappedRoundRepairResumes(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	oldMax := deleteReconcileMaxScanRows
+	deleteReconcileMaxScanRows = 10
+	t.Cleanup(func() { deleteReconcileMaxScanRows = oldMax })
+
+	if err := s.InsertNode(ctx, &FileNode{NodeID: "rcap-d", Path: "/rcap/", ParentPath: "/", Name: "rcap", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 25; i++ {
+		name := fmt.Sprintf("f%02d.txt", i)
+		if err := s.InsertNode(ctx, &FileNode{
+			NodeID: fmt.Sprintf("rcap-n%02d", i), Path: "/rcap/" + name, ParentPath: "/rcap/", Name: name, CreatedAt: now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Two broken-chain dentries, sorting before and after the /rcap/ rows.
+	insertBroken := func(nodeID, path string) {
+		t.Helper()
+		if _, err := s.DB().Exec(`INSERT INTO file_nodes (node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, created_at)
+			VALUES (?, ?, ?, '/gone/', ?, ?, 0, '', ?)`,
+			nodeID, path, fileNodePathHash(path), fileNodePathHash("/gone/"), baseName(path), now); err != nil {
+			t.Fatalf("insert broken dentry %s: %v", nodeID, err)
+		}
+	}
+	insertBroken("aaa-broken", "/gone/aaa.txt")
+	insertBroken("zzz-broken", "/gone/zzz.txt")
+
+	state := &DeleteReconcileState{}
+	var totalRepaired int64
+	for i := 0; i < 12; i++ {
+		r, err := s.ReconcileDeleteOrphans(ctx, false, 10, state)
+		if err != nil {
+			t.Fatal(err)
+		}
+		totalRepaired += r.Repaired
+		if state.DentryCursor == "" {
+			break
+		}
+	}
+	if state.DentryCursor != "" {
+		t.Fatal("expected a full pass to complete within the round budget")
+	}
+	if totalRepaired != 2 {
+		t.Fatalf("repaired = %d, want 2 (no double-repair, no skipped page)", totalRepaired)
+	}
+	for _, nodeID := range []string{"aaa-broken", "zzz-broken"} {
+		var n int
+		if err := s.DB().QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE node_id = ?`, nodeID).Scan(&n); err != nil {
+			t.Fatal(err)
+		}
+		if n != 0 {
+			t.Fatalf("broken dentry %s still present", nodeID)
+		}
+	}
+	// The healthy tree was not touched.
+	var healthy int
+	if err := s.DB().QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE parent_path = '/rcap/'`).Scan(&healthy); err != nil {
+		t.Fatal(err)
+	}
+	if healthy != 25 {
+		t.Fatalf("healthy rows = %d, want 25", healthy)
+	}
+}

--- a/pkg/datastore/delete_reconcile_test.go
+++ b/pkg/datastore/delete_reconcile_test.go
@@ -3,6 +3,7 @@ package datastore
 import (
 	"context"
 	"database/sql"
+	"fmt"
 	"testing"
 	"time"
 
@@ -138,7 +139,7 @@ func TestReconcileDeleteOrphansRepairsOnlyBrokenDentry(t *testing.T) {
 	reconcilePlantFile(t, s, "f-orphan")
 	reconcilePlantFileNode(t, s, "n-orphan", "/ghost/a.txt", "/ghost/", "f-orphan")
 
-	report, err := s.ReconcileDeleteOrphans(ctx, false, 100)
+	report, err := s.ReconcileDeleteOrphans(ctx, false, 100, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -188,7 +189,7 @@ func TestReconcileDeleteOrphansBrokenDirMultiRound(t *testing.T) {
 
 	// Round 1: only the top broken dentry is repaired; the children's chains
 	// were intact at scan time.
-	report, err := s.ReconcileDeleteOrphans(ctx, false, 100)
+	report, err := s.ReconcileDeleteOrphans(ctx, false, 100, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -205,7 +206,7 @@ func TestReconcileDeleteOrphansBrokenDirMultiRound(t *testing.T) {
 	// Later rounds converge: every descendant is repaired, files get GC tasks.
 	converged := false
 	for round := 2; round <= 6; round++ {
-		report, err := s.ReconcileDeleteOrphans(ctx, false, 100)
+		report, err := s.ReconcileDeleteOrphans(ctx, false, 100, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -239,7 +240,7 @@ func TestReconcileDeleteOrphansStrandedInode(t *testing.T) {
 	// CONFIRMED inode + contents, no file_nodes reference.
 	reconcilePlantFile(t, s, "f-stray")
 
-	report, err := s.ReconcileDeleteOrphans(ctx, false, 100)
+	report, err := s.ReconcileDeleteOrphans(ctx, false, 100, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -272,7 +273,7 @@ func TestReconcileDeleteOrphansIgnoresDirectoryInode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	report, err := s.ReconcileDeleteOrphans(ctx, false, 100)
+	report, err := s.ReconcileDeleteOrphans(ctx, false, 100, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -295,7 +296,7 @@ func TestReconcileDeleteOrphansDryRun(t *testing.T) {
 	reconcilePlantFileNode(t, s, "n-orphan", "/ghost/a.txt", "/ghost/", "f-orphan")
 	reconcilePlantFile(t, s, "f-stray")
 
-	report, err := s.ReconcileDeleteOrphans(ctx, true, 100)
+	report, err := s.ReconcileDeleteOrphans(ctx, true, 100, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -370,7 +371,7 @@ func TestReconcileStrandedInodeSharedScopeIsolation(t *testing.T) {
 		t.Fatalf("insert B gc task: %v", err)
 	}
 
-	report, err := storeA.ReconcileDeleteOrphans(ctx, false, 0)
+	report, err := storeA.ReconcileDeleteOrphans(ctx, false, 0, nil)
 	if err != nil {
 		t.Fatalf("ReconcileDeleteOrphans: %v", err)
 	}
@@ -402,5 +403,79 @@ func TestReconcileStrandedInodeSharedScopeIsolation(t *testing.T) {
 	}
 	if _, err := storeB.GetFileGCTaskByFileID(ctx, "shared-stray-2"); err != nil {
 		t.Fatalf("tenant B gc task should survive: %v", err)
+	}
+}
+
+// TestReconcileCappedRoundResumesFromCursor pins the checkpoint behavior:
+// when a round hits deleteReconcileMaxScanRows, the next round must resume
+// from the stored cursor instead of re-auditing the same prefix — otherwise
+// tenants larger than the cap would never have their tail rows audited
+// (dry-run would report a false "no orphans" signal forever).
+func TestReconcileCappedRoundResumesFromCursor(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now()
+
+	oldMax := deleteReconcileMaxScanRows
+	deleteReconcileMaxScanRows = 10
+	t.Cleanup(func() { deleteReconcileMaxScanRows = oldMax })
+
+	// A real directory with 25 files: 26 scanned rows, none top-level except
+	// the directory itself (parent_path "/"), so the cap trips on page 1.
+	if err := s.InsertNode(ctx, &FileNode{NodeID: "cap-d", Path: "/cap/", ParentPath: "/", Name: "cap", IsDirectory: true, CreatedAt: now}); err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 25; i++ {
+		name := fmt.Sprintf("f%02d.txt", i)
+		if err := s.InsertNode(ctx, &FileNode{
+			NodeID: fmt.Sprintf("cap-n%02d", i), Path: "/cap/" + name, ParentPath: "/cap/", Name: name, CreatedAt: now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// A broken-chain dentry whose node_id sorts AFTER all the rows above:
+	// the first capped round must not see it, a later round must.
+	if _, err := s.DB().Exec(`INSERT INTO file_nodes (node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, created_at)
+		VALUES ('zzz-broken', '/gone/x.txt', ?, '/gone/', ?, 'x.txt', 0, '', ?)`,
+		fileNodePathHash("/gone/x.txt"), fileNodePathHash("/gone/"), now); err != nil {
+		t.Fatalf("insert broken dentry: %v", err)
+	}
+
+	state := &DeleteReconcileState{}
+	report1, err := s.ReconcileDeleteOrphans(ctx, true, 10, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report1.BrokenDentries != 0 {
+		t.Fatalf("round 1 should not reach the tail row, got %d broken", report1.BrokenDentries)
+	}
+	if state.DentryCursor == "" {
+		t.Fatal("capped round must keep the cursor for the next round")
+	}
+	firstCursor := state.DentryCursor
+
+	report2, err := s.ReconcileDeleteOrphans(ctx, true, 10, state)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.DentryCursor == firstCursor {
+		t.Fatal("round 2 must advance the cursor, not restart from the prefix")
+	}
+
+	// Keep rounding until the full pass completes: the tail broken dentry is
+	// found and the cursor resets for the next full pass.
+	found := report2.BrokenDentries
+	for i := 0; i < 10 && state.DentryCursor != ""; i++ {
+		r, err := s.ReconcileDeleteOrphans(ctx, true, 10, state)
+		if err != nil {
+			t.Fatal(err)
+		}
+		found += r.BrokenDentries
+	}
+	if state.DentryCursor != "" {
+		t.Fatal("cursor must reset after a full pass completes")
+	}
+	if found != 1 {
+		t.Fatalf("broken dentry across rounds = %d, want 1", found)
 	}
 }

--- a/pkg/datastore/delete_recursive.go
+++ b/pkg/datastore/delete_recursive.go
@@ -1,0 +1,756 @@
+package datastore
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/pingcap/failpoint"
+
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/metrics"
+)
+
+// Batched recursive directory delete, per
+// docs/design/recursive-delete-batched-design.md. Enabled with
+// DRIVE9_RECURSIVE_DELETE_BATCHED; when unset the legacy single-transaction
+// implementation runs unchanged.
+//
+// Invariants (see the design doc §4.2):
+//
+//	I1  a directory dentry is deleted only in a transaction that verified it
+//	    childless, with a post-DELETE re-check in the same transaction;
+//	I2  the root dentry is deleted last — while it exists it pins the path
+//	    against recreation (idx_path uniqueness);
+//	I3  orphan/GC decisions derive only from rows deleted in the same
+//	    transaction;
+//	I4  a directory that was non-empty at first visit is re-evaluated for
+//	    unlinking after it drains (post-order lift);
+//	I5  a drain batch that deleted zero rows breaks out — batch fullness is
+//	    never a progress signal.
+
+// errDirDeleteRaced marks a batch/lift whose post-DELETE re-check found new
+// children: the transaction must roll back and the directory be revisited.
+var errDirDeleteRaced = errors.New("directory delete raced with concurrent create")
+
+// DeleteDirRecursiveSummary reports the outcome of a recursive delete.
+type DeleteDirRecursiveSummary struct {
+	NodesDeleted    int64
+	OrphansEnqueued int64
+	TxCount         int64
+}
+
+// recursiveDeleteBatchedEnabled reports whether the batched implementation is
+// enabled. Read per call so tests and operators can toggle it without a
+// restart.
+func recursiveDeleteBatchedEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("DRIVE9_RECURSIVE_DELETE_BATCHED"))) {
+	case "1", "true", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+// DeleteDirRecursive deletes dirPath and its whole subtree. With the batched
+// flag enabled, small trees are deleted in one atomic transaction (fast path)
+// and large trees in bounded per-batch transactions (post-order sweep);
+// success means the root dentry is gone. Without the flag, the legacy
+// single-transaction behavior applies.
+func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out *DeleteDirRecursiveSummary, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "delete_dir_recursive", start, &err)
+
+	if recursiveDeleteBatchedEnabled() {
+		return s.deleteDirRecursiveBatched(ctx, dirPath)
+	}
+	return s.deleteDirRecursiveLegacy(ctx, dirPath)
+}
+
+const (
+	// deleteDirEstimateMaxDirs bounds the counting walk used to derive the
+	// transaction budget.
+	deleteDirEstimateMaxDirs = 100_000
+)
+
+// Tunables are package-level variables so tests can shrink them.
+var (
+	// deleteDirSweepBatchSize bounds the rows touched by one sweep
+	// transaction.
+	deleteDirSweepBatchSize = deleteFileIDBatchSize
+	// deleteDirMaxDuration bounds one recursive delete call; the sweep is
+	// resumable, so a bounded caller may simply retry.
+	deleteDirMaxDuration = 5 * time.Minute
+	// deleteDirRootAttempts bounds root-dentry retries against racing
+	// concurrent writers before ErrDirectoryNotEmpty is returned.
+	deleteDirRootAttempts = 5
+	// deleteDirBatchRetries bounds deadlock/lock-wait retries per batch
+	// transaction.
+	deleteDirBatchRetries = 3
+	// deleteDirMaxBatchesCap caps the derived transaction budget.
+	deleteDirMaxBatchesCap = int64(1_000_000)
+)
+
+func isLockWaitTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "Lock wait timeout exceeded")
+}
+
+func isRetryableTxnError(err error) bool {
+	return isDeadlock(err) || isLockWaitTimeout(err)
+}
+
+// deleteChildRow is one file_nodes row selected during a drain batch.
+type deleteChildRow struct {
+	nodeID string
+	path   string
+	fileID string
+	isDir  bool
+}
+
+// dirDeleteQueue is a LIFO stack of directory paths with set dedup, giving a
+// naturally post-order-ish traversal (deep directories are processed before
+// their ancestors).
+type dirDeleteQueue struct {
+	stack []string
+	in    map[string]bool
+}
+
+func newDirDeleteQueue() *dirDeleteQueue { return &dirDeleteQueue{in: make(map[string]bool)} }
+
+func (q *dirDeleteQueue) push(p string) {
+	if p == "" || q.in[p] {
+		return
+	}
+	q.in[p] = true
+	q.stack = append(q.stack, p)
+}
+
+func (q *dirDeleteQueue) pop() (string, bool) {
+	if len(q.stack) == 0 {
+		return "", false
+	}
+	p := q.stack[len(q.stack)-1]
+	q.stack = q.stack[:len(q.stack)-1]
+	delete(q.in, p)
+	return p, true
+}
+
+func (q *dirDeleteQueue) empty() bool { return len(q.stack) == 0 }
+
+// AbortUploadsByTargetPrefix best-effort aborts active uploads whose target
+// path lies under dirPath, so their finalize cannot materialize nodes inside
+// a tree being deleted. uploads has no target_path prefix index, so this is a
+// bounded scan of the tenant's active uploads.
+func (s *Store) AbortUploadsByTargetPrefix(ctx context.Context, dirPath string) (n int64, err error) {
+	start := time.Now()
+	defer observeStoreOp(ctx, "abort_uploads_by_target_prefix", start, &err)
+
+	where, args := pathPrefixPredicate("target_path", dirPath)
+	res, err := s.db.ExecContext(ctx, `UPDATE uploads SET status = 'ABORTED', updated_at = ?
+		WHERE `+s.scope.And(`status IN ('INITIATED', 'UPLOADING') AND `+where),
+		append([]any{time.Now().UTC()}, s.scope.Args(args...)...)...)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
+// deleteDirRecursiveBatched implements the flag-on path: fast path for small
+// trees, post-order batched sweep otherwise.
+func (s *Store) deleteDirRecursiveBatched(ctx context.Context, dirPath string) (*DeleteDirRecursiveSummary, error) {
+	if dirPath == "/" {
+		return nil, ErrInvalidRootDentry
+	}
+
+	// Step 0: best-effort abort of in-flight uploads into the subtree.
+	if n, err := s.AbortUploadsByTargetPrefix(ctx, dirPath); err != nil {
+		logger.Warn(ctx, "delete_dir_recursive_abort_uploads_failed", zap.String("path", dirPath), zap.Error(err))
+	} else if n > 0 {
+		logger.Info(ctx, "delete_dir_recursive_abort_uploads", zap.String("path", dirPath), zap.Int64("aborted", n))
+	}
+
+	// The root dentry must exist (I2 pins the path for the whole operation).
+	if _, err := s.lookupDirNodeID(ctx, dirPath); err != nil {
+		return nil, err
+	}
+
+	// Step 1: fast path — the whole subtree in one transaction.
+	summary, done, err := s.deleteDirFastPath(ctx, dirPath)
+	if err != nil {
+		return nil, err
+	}
+	if done {
+		logger.Info(ctx, "delete_dir_recursive_done",
+			zap.String("path", dirPath), zap.String("mode", "fast_path"),
+			zap.Int64("nodes_deleted", summary.NodesDeleted),
+			zap.Int64("orphans_enqueued", summary.OrphansEnqueued),
+			zap.Int64("tx_count", summary.TxCount))
+		return summary, nil
+	}
+	summary = &DeleteDirRecursiveSummary{}
+
+	// Budget derived from the (walkable) subtree estimate: deep chains cost
+	// ~2 transactions per directory, wide dirs ~1 per batch of files.
+	files, dirs := s.estimateSubtreeSize(ctx, dirPath)
+	maxBatches := int64(32) + 8*(files/int64(deleteDirSweepBatchSize)+dirs+1)
+	if maxBatches > deleteDirMaxBatchesCap {
+		maxBatches = deleteDirMaxBatchesCap
+	}
+
+	sw := &dirSweeper{
+		s:          s,
+		root:       dirPath,
+		queue:      newDirDeleteQueue(),
+		maxBatches: maxBatches,
+		deadline:   time.Now().Add(deleteDirMaxDuration),
+		summary:    summary,
+	}
+
+	// Steps 2+3: sweep, then delete the root last; a non-empty root means
+	// concurrent writers raced us — re-seed and go again, bounded.
+	for attempt := 0; ; attempt++ {
+		sw.queue.push(dirPath)
+		if err := sw.sweep(ctx); err != nil {
+			return sw.summary, err
+		}
+		failpoint.InjectCall("deleteDirBeforeRootDelete", dirPath, attempt)
+		err := s.DeleteEmptyDir(ctx, dirPath)
+		if err == nil || errors.Is(err, ErrNotFound) {
+			// ErrNotFound: a concurrent delete removed the root — the goal
+			// state is reached either way.
+			logger.Info(ctx, "delete_dir_recursive_done",
+				zap.String("path", dirPath), zap.String("mode", "sweep"),
+				zap.Int64("nodes_deleted", sw.summary.NodesDeleted),
+				zap.Int64("orphans_enqueued", sw.summary.OrphansEnqueued),
+				zap.Int64("tx_count", sw.summary.TxCount))
+			return sw.summary, nil
+		}
+		if !errors.Is(err, ErrDirectoryNotEmpty) {
+			return sw.summary, err
+		}
+		if attempt+1 >= deleteDirRootAttempts {
+			return sw.summary, fmt.Errorf("%w: %s", ErrDirectoryNotEmpty, dirPath)
+		}
+	}
+}
+
+// lookupDirNodeID returns the root directory's node_id, or ErrNotFound.
+func (s *Store) lookupDirNodeID(ctx context.Context, dirPath string) (string, error) {
+	var nodeID string
+	err := s.db.QueryRowContext(ctx, `SELECT node_id FROM file_nodes WHERE `+
+		s.scope.And(`path_hash = ? AND path = ? AND is_directory = 1`),
+		s.scope.Args(fileNodePathHash(dirPath), dirPath)...).Scan(&nodeID)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", ErrNotFound
+	}
+	if err != nil {
+		return "", err
+	}
+	return nodeID, nil
+}
+
+// estimateSubtreeSize counts files and directories under dirPath with an
+// indexed per-directory COUNT walk. The walk is bounded by
+// deleteDirEstimateMaxDirs; a partial estimate still yields a safe budget.
+func (s *Store) estimateSubtreeSize(ctx context.Context, dirPath string) (files, dirs int64) {
+	queue := []string{dirPath}
+	for len(queue) > 0 && dirs < deleteDirEstimateMaxDirs {
+		parent := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		var total, dirCount int64
+		err := s.db.QueryRowContext(ctx, `SELECT COUNT(*), COALESCE(SUM(is_directory), 0) FROM file_nodes
+			WHERE `+s.scope.And(`parent_path_hash = ? AND parent_path = ?`),
+			s.scope.Args(fileNodePathHash(parent), parent)...).Scan(&total, &dirCount)
+		if err != nil {
+			return files, dirs
+		}
+		files += total - dirCount
+		dirs += dirCount
+		// Enqueue child directories by name page to avoid unbounded memory.
+		offset := ""
+		for {
+			rows, err := s.db.QueryContext(ctx, `SELECT path FROM file_nodes
+				WHERE `+s.scope.And(`parent_path_hash = ? AND parent_path = ? AND is_directory = 1 AND name > ?`)+`
+				ORDER BY name LIMIT 1000`,
+				s.scope.Args(fileNodePathHash(parent), parent, offset)...)
+			if err != nil {
+				return files, dirs
+			}
+			n := 0
+			for rows.Next() {
+				var p string
+				if err := rows.Scan(&p); err != nil {
+					_ = rows.Close()
+					return files, dirs
+				}
+				queue = append(queue, p)
+				offset = baseName(p)
+				n++
+			}
+			_ = rows.Close()
+			if n < 1000 {
+				break
+			}
+		}
+	}
+	return files, dirs
+}
+
+// --- fast path ---
+
+// deleteDirFastPath attempts the whole subtree in a single transaction when
+// it enumerates to at most deleteDirSweepBatchSize nodes. done=false means the
+// caller should continue with the batched sweep.
+func (s *Store) deleteDirFastPath(ctx context.Context, dirPath string) (summary *DeleteDirRecursiveSummary, done bool, err error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, false, err
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// Bounded BFS enumeration, children locked FOR UPDATE as we go.
+	var nodes []deleteChildRow
+	queue := []string{dirPath}
+	for len(queue) > 0 {
+		parent := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		remaining := deleteDirSweepBatchSize - len(nodes) + 1
+		rows, err := s.selectChildrenForUpdateTx(ctx, tx, parent, remaining)
+		if err != nil {
+			return nil, false, err
+		}
+		for _, r := range rows {
+			if r.isDir {
+				queue = append(queue, r.path)
+			}
+		}
+		nodes = append(nodes, rows...)
+		if len(nodes) > deleteDirSweepBatchSize {
+			return nil, false, nil // overflow → sweep
+		}
+	}
+
+	// Children before parents: directory paths end in '/', so a deeper path
+	// always sorts after its ancestors.
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].path > nodes[j].path })
+
+	var fileIDs []string
+	for start := 0; start < len(nodes); start += deleteFileIDBatchSize {
+		end := start + deleteFileIDBatchSize
+		if end > len(nodes) {
+			end = len(nodes)
+		}
+		batch := nodes[start:end]
+		ids := make([]any, 0, len(batch))
+		for _, n := range batch {
+			ids = append(ids, n.nodeID)
+			if !n.isDir && n.fileID != "" {
+				fileIDs = append(fileIDs, n.fileID)
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+
+			s.scope.And(`node_id IN (`+questionPlaceholders(len(batch))+`)`),
+			s.scope.Args(ids...)...); err != nil {
+			return nil, false, err
+		}
+	}
+
+	orphans, err := s.processOrphansTx(ctx, tx, fileIDs)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Root last (I2), with a post-DELETE re-check (I1).
+	if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+
+		s.scope.And(`path_hash = ? AND path = ? AND is_directory = 1`),
+		s.scope.Args(fileNodePathHash(dirPath), dirPath)...); err != nil {
+		return nil, false, err
+	}
+	hasChildren, err := s.dirHasChildrenTx(ctx, tx, dirPath)
+	if err != nil {
+		return nil, false, err
+	}
+	if hasChildren {
+		return nil, false, nil // raced with a concurrent create → sweep
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, false, err
+	}
+	return &DeleteDirRecursiveSummary{
+		NodesDeleted:    int64(len(nodes)) + 1,
+		OrphansEnqueued: orphans,
+		TxCount:         1,
+	}, true, nil
+}
+
+// --- batched sweep ---
+
+type dirSweeper struct {
+	s          *Store
+	root       string
+	queue      *dirDeleteQueue
+	maxBatches int64
+	deadline   time.Time
+	summary    *DeleteDirRecursiveSummary
+}
+
+func (sw *dirSweeper) checkBudget(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if sw.summary.TxCount >= sw.maxBatches || time.Now().After(sw.deadline) {
+		return fmt.Errorf("%w: %s (tx=%d)", ErrDeleteIncomplete, sw.root, sw.summary.TxCount)
+	}
+	return nil
+}
+
+// sweep drains the work queue in bounded per-batch transactions.
+func (sw *dirSweeper) sweep(ctx context.Context) error {
+	for !sw.queue.empty() {
+		parent, _ := sw.queue.pop()
+
+		// Drain this directory in batches.
+		raced := false
+		for {
+			if err := sw.checkBudget(ctx); err != nil {
+				return err
+			}
+			failpoint.InjectCall("drainBatchBeforeSelect", parent)
+			out, err := sw.runDrainBatch(ctx, parent)
+			if errors.Is(err, errDirDeleteRaced) {
+				// Post-DELETE re-check failed: revisit the raced subdir and
+				// this parent promptly (I1); skip the lift this round.
+				sw.queue.push(parent)
+				sw.queue.push(out.racedDir)
+				raced = true
+				break
+			}
+			if err != nil {
+				return err
+			}
+			sw.summary.NodesDeleted += out.deleted
+			sw.summary.OrphansEnqueued += out.orphans
+			for _, sub := range out.subdirs {
+				sw.queue.push(sub)
+			}
+			if out.deleted == 0 {
+				break // I5: nothing deletable at this level — descend first
+			}
+			if out.rows < int64(deleteDirSweepBatchSize) {
+				break // level drained
+			}
+		}
+
+		// Post-order lift (I4): delete the drained directory's own dentry.
+		// The root is owned by the caller's DeleteEmptyDir step.
+		if raced || parent == sw.root {
+			continue
+		}
+		if err := sw.checkBudget(ctx); err != nil {
+			return err
+		}
+		lifted, err := sw.runLift(ctx, parent)
+		if err != nil {
+			return err
+		}
+		if lifted {
+			sw.summary.NodesDeleted++
+			sw.queue.push(parentPath(parent))
+		}
+	}
+	return nil
+}
+
+type drainOutcome struct {
+	rows     int64
+	deleted  int64
+	orphans  int64
+	fileIDs  []string
+	subdirs  []string
+	racedDir string
+}
+
+// runDrainBatch executes one drain batch transaction with bounded retries on
+// deadlock/lock-wait.
+func (sw *dirSweeper) runDrainBatch(ctx context.Context, parent string) (*drainOutcome, error) {
+	var out *drainOutcome
+	err := sw.withBatchRetry(ctx, "delete_dir_recursive_batch", func(tx *sql.Tx) error {
+		var err error
+		out, err = sw.s.drainChildrenBatchTx(ctx, tx, parent)
+		return err
+	})
+	if err != nil {
+		if out == nil {
+			out = &drainOutcome{}
+		}
+		return out, err
+	}
+	sw.summary.TxCount++
+	return out, nil
+}
+
+// runLift executes one post-order lift transaction. lifted=true means the
+// dentry was deleted and the parent should be revisited. A non-empty or
+// already-gone directory is a committed no-op (idempotent).
+func (sw *dirSweeper) runLift(ctx context.Context, dirPath string) (lifted bool, err error) {
+	err = sw.withBatchRetry(ctx, "delete_dir_recursive_lift", func(tx *sql.Tx) error {
+		lifted = false
+		failpoint.InjectCall("liftBeforePathLookup", dirPath)
+		var nodeID string
+		err := tx.QueryRowContext(ctx, `SELECT node_id FROM file_nodes WHERE `+
+			sw.s.scope.And(`path_hash = ? AND path = ? AND is_directory = 1`)+` FOR UPDATE`,
+			sw.s.scope.Args(fileNodePathHash(dirPath), dirPath)...).Scan(&nodeID)
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil // already gone (concurrent rmdir): idempotent success
+		}
+		if err != nil {
+			return err
+		}
+		has, err := sw.s.dirHasChildrenTx(ctx, tx, dirPath)
+		if err != nil {
+			return err
+		}
+		if has {
+			return nil // legit children queued below, or racing creates
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+
+			sw.s.scope.And(`node_id = ?`), sw.s.scope.Args(nodeID)...); err != nil {
+			return err
+		}
+		still, err := sw.s.dirHasChildrenTx(ctx, tx, dirPath)
+		if err != nil {
+			return err
+		}
+		if still {
+			return errDirDeleteRaced // rollback; step-3 re-seed rediscovers it
+		}
+		lifted = true
+		return nil
+	})
+	if errors.Is(err, errDirDeleteRaced) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	sw.summary.TxCount++
+	return lifted, nil
+}
+
+// withBatchRetry runs fn in a transaction, retrying deadlock/lock-wait
+// failures with backoff. errDirDeleteRaced and other errors propagate without
+// retry.
+func (sw *dirSweeper) withBatchRetry(ctx context.Context, op string, fn func(tx *sql.Tx) error) (err error) {
+	start := time.Now()
+	defer func() {
+		result := "ok"
+		if err != nil {
+			result = "error"
+			if errors.Is(err, errDirDeleteRaced) {
+				result = "raced"
+			}
+		}
+		metrics.RecordOperation("datastore", op, result, time.Since(start))
+	}()
+
+	for attempt := 0; ; attempt++ {
+		tx, err := sw.s.db.BeginTx(ctx, nil)
+		if err != nil {
+			return err
+		}
+		fnErr := fn(tx)
+		if fnErr == nil {
+			fnErr = deleteDirBatchFailpointError(op)
+		}
+		if fnErr != nil {
+			_ = tx.Rollback()
+			if isRetryableTxnError(fnErr) && attempt < deleteDirBatchRetries {
+				metrics.RecordOperation("datastore", op+"_retry", "retryable", 0)
+				if !sleepWithContext(ctx, time.Duration(50*(1<<attempt))*time.Millisecond) {
+					return ctx.Err()
+				}
+				continue
+			}
+			return fnErr
+		}
+		if err := tx.Commit(); err != nil {
+			if isRetryableTxnError(err) && attempt < deleteDirBatchRetries {
+				metrics.RecordOperation("datastore", op+"_retry", "retryable", 0)
+				if !sleepWithContext(ctx, time.Duration(50*(1<<attempt))*time.Millisecond) {
+					return ctx.Err()
+				}
+				continue
+			}
+			return err
+		}
+		return nil
+	}
+}
+
+func sleepWithContext(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+// errDeleteDirBatchInjected is the synthetic deadlock returned by
+// deleteDirBatchFailpointError when its failpoint is armed; the message keeps
+// isRetryableTxnError true so the batch retry path is exercised.
+var errDeleteDirBatchInjected = errors.New("injected failpoint: Deadlock found when trying to get lock; try restarting transaction")
+
+// deleteDirBatchFailpointError lets failpoint tests inject one synthetic
+// retryable error per batch operation (op). It is a no-op unless the
+// failpoint is armed: the failpoint.Inject marker compiles to an empty call
+// until failpoint-ctl rewrites it, so normal runs see exactly the
+// non-instrumented behavior.
+func deleteDirBatchFailpointError(op string) error {
+	var injected error
+	failpoint.Inject("deleteDirBatchError", func(val failpoint.Value) {
+		if name, ok := val.(string); ok && name == op {
+			injected = errDeleteDirBatchInjected
+		}
+	})
+	return injected
+}
+
+// selectChildrenForUpdateTx selects up to limit children of parent, locking
+// them FOR UPDATE. The (parent_path_hash, name) index makes this a bounded
+// range scan.
+func (s *Store) selectChildrenForUpdateTx(ctx context.Context, tx *sql.Tx, parent string, limit int) ([]deleteChildRow, error) {
+	rows, err := tx.QueryContext(ctx, `SELECT node_id, path, COALESCE(file_id, ''), is_directory FROM file_nodes
+		WHERE `+s.scope.And(`parent_path_hash = ? AND parent_path = ?`)+`
+		ORDER BY name LIMIT ? FOR UPDATE`,
+		s.scope.Args(fileNodePathHash(parent), parent, limit)...)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rows.Close() }()
+	var out []deleteChildRow
+	for rows.Next() {
+		var r deleteChildRow
+		var isDir int
+		if err := rows.Scan(&r.nodeID, &r.path, &r.fileID, &isDir); err != nil {
+			return nil, err
+		}
+		r.isDir = isDir != 0
+		out = append(out, r)
+	}
+	return out, rows.Err()
+}
+
+// drainChildrenBatchTx processes one batch of parent's children: files are
+// deleted and fed to the orphan pipeline (I3), empty directories are deleted
+// with a post-DELETE re-check (I1), non-empty directories are queued for
+// descent.
+func (s *Store) drainChildrenBatchTx(ctx context.Context, tx *sql.Tx, parent string) (*drainOutcome, error) {
+	rows, err := s.selectChildrenForUpdateTx(ctx, tx, parent, deleteDirSweepBatchSize)
+	if err != nil {
+		return nil, err
+	}
+	failpoint.InjectCall("drainChildrenBatchAfterSelect", parent)
+	out := &drainOutcome{rows: int64(len(rows))}
+	for _, r := range rows {
+		if !r.isDir {
+			if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+
+				s.scope.And(`node_id = ?`), s.scope.Args(r.nodeID)...); err != nil {
+				return nil, err
+			}
+			out.deleted++
+			if r.fileID != "" {
+				out.fileIDs = append(out.fileIDs, r.fileID)
+			}
+			continue
+		}
+		has, err := s.dirHasChildrenTx(ctx, tx, r.path)
+		if err != nil {
+			return nil, err
+		}
+		if has {
+			out.subdirs = append(out.subdirs, r.path)
+			continue
+		}
+		if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+
+			s.scope.And(`node_id = ?`), s.scope.Args(r.nodeID)...); err != nil {
+			return nil, err
+		}
+		out.deleted++
+		failpoint.InjectCall("drainEmptyDirBeforeRecheck", r.path)
+		still, err := s.dirHasChildrenTx(ctx, tx, r.path)
+		if err != nil {
+			return nil, err
+		}
+		if still {
+			out.racedDir = r.path
+			return out, errDirDeleteRaced
+		}
+	}
+	orphans, err := s.processOrphansTx(ctx, tx, out.fileIDs)
+	if err != nil {
+		return nil, err
+	}
+	out.orphans = orphans
+	return out, nil
+}
+
+// processOrphansTx runs the orphan pipeline for file IDs whose dentries were
+// deleted in this transaction: lock the inodes, keep only IDs with no
+// remaining file_nodes reference, mark them DELETED, drop their tags, and
+// enqueue batched GC tasks.
+func (s *Store) processOrphansTx(ctx context.Context, tx *sql.Tx, fileIDs []string) (int64, error) {
+	if len(fileIDs) == 0 {
+		return 0, nil
+	}
+	sort.Strings(fileIDs)
+	deduped := fileIDs[:0]
+	for i, id := range fileIDs {
+		if i == 0 || id != fileIDs[i-1] {
+			deduped = append(deduped, id)
+		}
+	}
+	if err := s.lockFileIDsForDeleteTx(ctx, tx, deduped); err != nil {
+		return 0, err
+	}
+	orphaned, err := s.scanOrphanedFilesByIDTx(ctx, tx, deduped)
+	if err != nil {
+		return 0, err
+	}
+	if len(orphaned) == 0 {
+		return 0, nil
+	}
+	orphanIDs := make([]string, 0, len(orphaned))
+	for _, f := range orphaned {
+		orphanIDs = append(orphanIDs, f.FileID)
+	}
+	if err := s.markFilesDeletedTx(ctx, tx, orphanIDs); err != nil {
+		return 0, err
+	}
+	if err := s.deleteFileTagsByIDsTx(ctx, tx, orphanIDs); err != nil {
+		return 0, err
+	}
+	now := time.Now().UTC()
+	tasks := make([]*FileGCTask, 0, len(orphaned))
+	for _, f := range orphaned {
+		task, err := NewFileGCTaskFromFile(f, now)
+		if err != nil {
+			return 0, err
+		}
+		tasks = append(tasks, task)
+	}
+	return s.enqueueFileGCTasksTx(tx, tasks)
+}

--- a/pkg/datastore/delete_recursive.go
+++ b/pkg/datastore/delete_recursive.go
@@ -76,8 +76,9 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out *De
 
 const (
 	// deleteDirEstimateMaxDirs bounds the counting walk used to derive the
-	// transaction budget.
-	deleteDirEstimateMaxDirs = 100_000
+	// transaction budget. Deliberately small: the budget only needs to be
+	// sufficient, not exact — maxDuration is the hard backstop.
+	deleteDirEstimateMaxDirs = 10_000
 )
 
 // Tunables are package-level variables so tests can shrink them.
@@ -150,7 +151,10 @@ func (q *dirDeleteQueue) empty() bool { return len(q.stack) == 0 }
 // AbortUploadsByTargetPrefix best-effort aborts active uploads whose target
 // path lies under dirPath, so their finalize cannot materialize nodes inside
 // a tree being deleted. uploads has no target_path prefix index, so this is a
-// bounded scan of the tenant's active uploads.
+// bounded scan of the tenant's active uploads. Note this only marks the
+// metadata rows ABORTED (which blocks finalize); the S3 multipart sessions
+// themselves are left to the usual lifecycle/abort sweeper, as the store
+// layer has no S3 client.
 func (s *Store) AbortUploadsByTargetPrefix(ctx context.Context, dirPath string) (n int64, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "abort_uploads_by_target_prefix", start, &err)
@@ -260,9 +264,13 @@ func (s *Store) lookupDirNodeID(ctx context.Context, dirPath string) (string, er
 }
 
 // estimateSubtreeSize counts files and directories under dirPath with an
-// indexed per-directory COUNT walk. The walk is bounded by
-// deleteDirEstimateMaxDirs; a partial estimate still yields a safe budget.
+// indexed per-directory COUNT walk, bounding the walk at
+// deleteDirEstimateMaxDirs directories. The estimate only feeds the
+// transaction budget, so it errs on the generous side: any query failure
+// returns the walk cap (budget then saturates at deleteDirMaxBatchesCap and
+// maxDuration remains the real backstop).
 func (s *Store) estimateSubtreeSize(ctx context.Context, dirPath string) (files, dirs int64) {
+	generous := func() (int64, int64) { return files, deleteDirEstimateMaxDirs }
 	queue := []string{dirPath}
 	for len(queue) > 0 && dirs < deleteDirEstimateMaxDirs {
 		parent := queue[len(queue)-1]
@@ -272,7 +280,7 @@ func (s *Store) estimateSubtreeSize(ctx context.Context, dirPath string) (files,
 			WHERE `+s.scope.And(`parent_path_hash = ? AND parent_path = ?`),
 			s.scope.Args(fileNodePathHash(parent), parent)...).Scan(&total, &dirCount)
 		if err != nil {
-			return files, dirs
+			return generous()
 		}
 		files += total - dirCount
 		dirs += dirCount
@@ -284,14 +292,14 @@ func (s *Store) estimateSubtreeSize(ctx context.Context, dirPath string) (files,
 				ORDER BY name LIMIT 1000`,
 				s.scope.Args(fileNodePathHash(parent), parent, offset)...)
 			if err != nil {
-				return files, dirs
+				return generous()
 			}
 			n := 0
 			for rows.Next() {
 				var p string
 				if err := rows.Scan(&p); err != nil {
 					_ = rows.Close()
-					return files, dirs
+					return generous()
 				}
 				queue = append(queue, p)
 				offset = baseName(p)

--- a/pkg/datastore/delete_recursive_failpoint_test.go
+++ b/pkg/datastore/delete_recursive_failpoint_test.go
@@ -1,0 +1,578 @@
+//go:build failpoint
+
+package datastore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/failpoint"
+)
+
+// Deterministic race tests for the batched recursive directory delete
+// (docs/design/recursive-delete-batched-design.md §6). The injection points
+// live in delete_recursive.go and are failpoint markers: with the tree not
+// rewritten by failpoint-ctl they are empty no-op calls, so failpoint-off
+// behavior is identical to the non-instrumented code. Every callback is
+// scoped narrowly (path/op match + fire-once) and paired with a
+// t.Cleanup Disable. Synchronization uses channels, never sleeps.
+//
+// Engine note: tests run against MySQL 8 (REPEATABLE READ) via
+// testcontainers. Unlike TiDB, InnoDB takes gap locks on the drain batch's
+// locking reads, so a concurrent create into a directory whose drain
+// transaction is open is serialized behind that transaction's commit. Where
+// that changes the observable interleaving versus TiDB, the test says so and
+// asserts the MySQL-deterministic outcome.
+
+const (
+	fpDrainAfterSelect      = "github.com/mem9-ai/drive9/pkg/datastore/drainChildrenBatchAfterSelect"
+	fpDrainBeforeSelect     = "github.com/mem9-ai/drive9/pkg/datastore/drainBatchBeforeSelect"
+	fpEmptyDirBeforeRecheck = "github.com/mem9-ai/drive9/pkg/datastore/drainEmptyDirBeforeRecheck"
+	fpLiftBeforePathLookup  = "github.com/mem9-ai/drive9/pkg/datastore/liftBeforePathLookup"
+	fpBeforeRootDelete      = "github.com/mem9-ai/drive9/pkg/datastore/deleteDirBeforeRootDelete"
+	fpBatchError            = "github.com/mem9-ai/drive9/pkg/datastore/deleteDirBatchError"
+)
+
+// enableCallFailpoint registers fn for the InjectCall failpoint and disarms
+// it on test cleanup.
+func enableCallFailpoint(t *testing.T, fp string, fn any) {
+	t.Helper()
+	if err := failpoint.EnableCall(fp, fn); err != nil {
+		t.Fatalf("enable failpoint %s: %v", fp, err)
+	}
+	t.Cleanup(func() {
+		_ = failpoint.Disable(fp)
+	})
+}
+
+// insertConfirmedFileE is insertConfirmedFile with an error return, for use
+// inside failpoint callbacks and helper goroutines where t.Fatal is illegal.
+func insertConfirmedFileE(s *Store, fileID string) error {
+	now := time.Now().UTC()
+	return s.InsertFile(context.Background(), &File{
+		FileID: fileID, StorageType: StorageDB9, StorageRef: "/blobs/" + fileID,
+		SizeBytes: 1, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+	})
+}
+
+// createFileViaRealPath creates one file dentry through the real create path
+// (EnsureParentDirsTx + InsertNodeTx) in a single transaction, mirroring how
+// backend creates land nodes.
+func createFileViaRealPath(s *Store, path, fileID string) error {
+	ctx := context.Background()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := s.EnsureParentDirsTx(tx, path, func() string { return deterministicNodeID(path) }); err != nil {
+		return fmt.Errorf("ensure parents %s: %w", path, err)
+	}
+	if err := s.InsertNodeTx(tx, fileTestNode(path, fileID, time.Now())); err != nil {
+		return fmt.Errorf("insert node %s: %w", path, err)
+	}
+	return tx.Commit()
+}
+
+// ensureParentsOnly runs only the EnsureParentDirsTx half of the create path,
+// committing whatever parent dentries it (re)creates.
+func ensureParentsOnly(s *Store, path string) error {
+	ctx := context.Background()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := s.EnsureParentDirsTx(tx, path, func() string { return deterministicNodeID(path) }); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+// insertNodeOnly runs only the InsertNodeTx half of the create path (a bare
+// INSERT, no parent-existence check — see store.go InsertNodeTx).
+func insertNodeOnly(s *Store, path, fileID string) error {
+	ctx := context.Background()
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = tx.Rollback() }()
+	if err := s.InsertNodeTx(tx, fileTestNode(path, fileID, time.Now())); err != nil {
+		return err
+	}
+	return tx.Commit()
+}
+
+func inodeStatus(t *testing.T, s *Store, id string) string {
+	t.Helper()
+	var status string
+	if err := s.db.QueryRow(`SELECT status FROM inodes WHERE inode_id = ?`, id).Scan(&status); err != nil {
+		t.Fatalf("inode status for %q: %v", id, err)
+	}
+	return status
+}
+
+func countAllGCTasks(t *testing.T, s *Store) int64 {
+	t.Helper()
+	var n int64
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM file_gc_tasks`).Scan(&n); err != nil {
+		t.Fatalf("count gc tasks: %v", err)
+	}
+	return n
+}
+
+// bulkFixtureTree inserts count files (f%03d naming) with confirmed inodes
+// directly under dir and returns their file IDs.
+func bulkFixtureTree(t *testing.T, s *Store, dir string, count int) []string {
+	t.Helper()
+	now := time.Now()
+	nodes := []*FileNode{dirTestNode(dir, now)}
+	fileIDs := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		fid := fmt.Sprintf("%sf%03d", dir[1:len(dir)-1], i)
+		fileIDs = append(fileIDs, fid)
+		insertConfirmedFile(t, s, fid, now)
+		nodes = append(nodes, fileTestNode(fmt.Sprintf("%sf%03d.txt", dir, i), fid, now))
+	}
+	bulkInsertNodes(t, s, nodes...)
+	return fileIDs
+}
+
+// TestDeleteDirBatchedTOCTOUCreateConverges injects a create through the real
+// create path while a drain batch of the target directory holds its
+// SELECT ... FOR UPDATE locks. The racing file sorts after every fixture
+// file, so on MySQL its INSERT does not touch the paused batch's locked gap
+// and commits mid-sweep; a later batch of the same drain loop must pick it up
+// (the loop always re-selects the first N current names). The red line: no
+// blob leak (inode DELETED + GC task) and no invisible orphan.
+func TestDeleteDirBatchedTOCTOUCreateConverges(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	setDeleteDirTunables(t, 20, deleteDirMaxDuration)
+	s := newTestStore(t)
+
+	bulkFixtureTree(t, s, "/r/", 65)
+
+	hit := make(chan struct{})
+	release := make(chan struct{})
+	var fired atomic.Bool
+	enableCallFailpoint(t, fpDrainAfterSelect, func(parent string) {
+		if parent != "/r/" || !fired.CompareAndSwap(false, true) {
+			return
+		}
+		close(hit)
+		<-release
+	})
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		_, err := s.DeleteDirRecursive(context.Background(), "/r/")
+		deleteDone <- err
+	}()
+
+	select {
+	case <-hit:
+	case <-time.After(30 * time.Second):
+		close(release)
+		t.Fatal("drain batch failpoint never fired")
+	}
+
+	// Create while the first drain batch of /r/ is paused with locks held.
+	insertConfirmedFile(t, s, "f-race", time.Now())
+	createDone := make(chan error, 1)
+	go func() { createDone <- createFileViaRealPath(s, "/r/zzz-race.txt", "f-race") }()
+	select {
+	case err := <-createDone:
+		if err != nil {
+			close(release)
+			t.Fatalf("racing create: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		close(release)
+		t.Fatal("racing create blocked behind the drain batch (gap-lock analysis broke)")
+	}
+	close(release)
+
+	if err := <-deleteDone; err != nil {
+		t.Fatalf("DeleteDirRecursive: %v", err)
+	}
+
+	// The racing file was swept by a later drain batch: dentry gone, inode
+	// marked DELETED, exactly one GC task — no blob leak, no orphan.
+	assertNodeGone(t, s, "/r/zzz-race.txt")
+	assertNodeGone(t, s, "/r/")
+	if n := countNodesLike(t, s, "/r/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /r/, want 0", n)
+	}
+	if n := countGCTasks(t, s, "f-race"); n != 1 {
+		t.Fatalf("gc tasks for f-race = %d, want 1", n)
+	}
+	if st := inodeStatus(t, s, "f-race"); st != string(StatusDeleted) {
+		t.Fatalf("inode f-race status = %q, want DELETED (blob leak otherwise)", st)
+	}
+	if n := countAllGCTasks(t, s); n != 66 {
+		t.Fatalf("total gc tasks = %d, want 66 (65 fixture + 1 racing)", n)
+	}
+}
+
+// TestDeleteDirBatchedEmptyDirDeleteRace injects a create between an empty
+// directory's dentry DELETE and the post-DELETE re-check inside the same
+// drain batch. On MySQL the racing INSERT blocks on the drain transaction's
+// gap lock and commits right after the batch — the design's acknowledged
+// residual window (§4.2 "Residual window"; on TiDB the insert lands before
+// the re-check and rolls the batch back instead). The test pins that window
+// deterministically and asserts the companion reconciliation sweep (§4.2.1)
+// detects and repairs the orphan: no lasting invisible orphan, no blob leak.
+func TestDeleteDirBatchedEmptyDirDeleteRace(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	t.Setenv("DRIVE9_DELETE_RECONCILE_REPAIR", "1")
+	setDeleteDirTunables(t, 20, deleteDirMaxDuration)
+	s := newTestStore(t)
+
+	// 25 loose files force the sweep; /e/sub/ (empty) sorts last, so the
+	// second drain batch of /e/ deletes its dentry. Both directory dentries
+	// carry an inode_id like real directories: without it the racing
+	// create's EnsureParentDirsTx would backfill inode_id with an UPDATE
+	// that blocks on the paused batch's locks, deadlocking the test.
+	now := time.Now()
+	rootDir := dirTestNode("/e/", now)
+	rootDir.InodeID = "inode-e"
+	subDir := dirTestNode("/e/sub/", now)
+	subDir.InodeID = "inode-e-sub"
+	nodes := []*FileNode{rootDir, subDir}
+	for i := 0; i < 25; i++ {
+		fid := fmt.Sprintf("ef%03d", i)
+		insertConfirmedFile(t, s, fid, now)
+		nodes = append(nodes, fileTestNode(fmt.Sprintf("/e/f%03d.txt", i), fid, now))
+	}
+	bulkInsertNodes(t, s, nodes...)
+
+	hit := make(chan struct{})
+	release := make(chan struct{})
+	var fired atomic.Bool
+	enableCallFailpoint(t, fpEmptyDirBeforeRecheck, func(dirPath string) {
+		if dirPath != "/e/sub/" || !fired.CompareAndSwap(false, true) {
+			return
+		}
+		close(hit)
+		<-release
+	})
+
+	deleteDone := make(chan error, 1)
+	go func() {
+		_, err := s.DeleteDirRecursive(context.Background(), "/e/")
+		deleteDone <- err
+	}()
+
+	select {
+	case <-hit:
+	case <-time.After(30 * time.Second):
+		close(release)
+		t.Fatal("empty-dir recheck failpoint never fired")
+	}
+
+	// The dentry DELETE is uncommitted, so the real create path still sees
+	// /e/sub/ alive and does not recreate it. The bare INSERT then lands
+	// after the batch commits (gap lock), leaving a broken-chain row.
+	insertConfirmedFile(t, s, "f-race2", now)
+	if err := ensureParentsOnly(s, "/e/sub/zzz-new.txt"); err != nil {
+		close(release)
+		t.Fatalf("ensure parents: %v", err)
+	}
+	insertDone := make(chan error, 1)
+	go func() { insertDone <- insertNodeOnly(s, "/e/sub/zzz-new.txt", "f-race2") }()
+	close(release)
+
+	if err := <-deleteDone; err != nil {
+		t.Fatalf("DeleteDirRecursive: %v", err)
+	}
+	select {
+	case err := <-insertDone:
+		if err != nil {
+			t.Fatalf("racing insert: %v", err)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("racing insert still blocked after the delete returned")
+	}
+
+	// Residual window state: the row exists but its parent chain is broken,
+	// and no GC task covers it yet.
+	assertNodeAlive(t, s, "/e/sub/zzz-new.txt")
+	assertNodeGone(t, s, "/e/sub/")
+	assertNodeGone(t, s, "/e/")
+	if n := countGCTasks(t, s, "f-race2"); n != 0 {
+		t.Fatalf("gc tasks for f-race2 = %d, want 0 before reconciliation", n)
+	}
+
+	// The reconciliation sweep (repair mode) must remove the broken-chain
+	// dentry and run the orphan pipeline for its file.
+	report, err := s.ReconcileDeleteOrphans(context.Background(), false, 100)
+	if err != nil {
+		t.Fatalf("ReconcileDeleteOrphans: %v", err)
+	}
+	if report.BrokenDentries != 1 || report.Repaired != 1 {
+		t.Fatalf("reconcile report = %+v, want exactly 1 broken dentry repaired", report)
+	}
+	assertNodeGone(t, s, "/e/sub/zzz-new.txt")
+	if n := countNodesLike(t, s, "/e/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /e/ after reconcile, want 0", n)
+	}
+	if n := countGCTasks(t, s, "f-race2"); n != 1 {
+		t.Fatalf("gc tasks for f-race2 = %d, want 1 after reconcile", n)
+	}
+	if st := inodeStatus(t, s, "f-race2"); st != string(StatusDeleted) {
+		t.Fatalf("inode f-race2 status = %q, want DELETED", st)
+	}
+	if n := countAllGCTasks(t, s); n != 26 {
+		t.Fatalf("total gc tasks = %d, want 26 (25 fixture + 1 racing)", n)
+	}
+}
+
+// TestDeleteDirBatchedLiftIdempotent races a plain rmdir (DeleteEmptyDir)
+// against the post-order lift of an already-drained subdirectory: the lift's
+// path lookup must treat the missing dentry as idempotent success and the
+// overall delete must complete.
+func TestDeleteDirBatchedLiftIdempotent(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	setDeleteDirTunables(t, 20, deleteDirMaxDuration)
+	s := newTestStore(t)
+	now := time.Now()
+
+	// /l/sub/ holds 25 files: the fast path overflows, the sweep drains
+	// /l/sub/ in two batches, then lifts /l/sub/.
+	fileIDs := bulkFixtureTree(t, s, "/l/sub/", 25)
+	bulkInsertNodes(t, s, dirTestNode("/l/", now))
+
+	hit := make(chan struct{})
+	release := make(chan struct{})
+	var fired atomic.Bool
+	enableCallFailpoint(t, fpLiftBeforePathLookup, func(dirPath string) {
+		if dirPath != "/l/sub/" || !fired.CompareAndSwap(false, true) {
+			return
+		}
+		close(hit)
+		<-release
+	})
+
+	deleteDone := make(chan error, 1)
+	var summary *DeleteDirRecursiveSummary
+	go func() {
+		var err error
+		summary, err = s.DeleteDirRecursive(context.Background(), "/l/")
+		deleteDone <- err
+	}()
+
+	select {
+	case <-hit:
+	case <-time.After(30 * time.Second):
+		close(release)
+		t.Fatal("lift failpoint never fired")
+	}
+
+	// The lift transaction has begun but holds no locks yet (the failpoint
+	// fires before its path lookup), so this rmdir commits immediately.
+	if err := s.DeleteEmptyDir(context.Background(), "/l/sub/"); err != nil {
+		close(release)
+		t.Fatalf("concurrent rmdir: %v", err)
+	}
+	close(release)
+
+	if err := <-deleteDone; err != nil {
+		t.Fatalf("DeleteDirRecursive: %v", err)
+	}
+	if summary.NodesDeleted != 25 {
+		t.Fatalf("summary.NodesDeleted = %d, want 25 (lift counted no already-gone dentry)", summary.NodesDeleted)
+	}
+	if n := countNodesLike(t, s, "/l/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /l/, want 0", n)
+	}
+	assertNodeGone(t, s, "/l/")
+	for _, fid := range fileIDs {
+		if n := countGCTasks(t, s, fid); n != 1 {
+			t.Fatalf("gc tasks for %s = %d, want 1", fid, n)
+		}
+	}
+}
+
+// TestDeleteDirBatchedErrorOnPartial arms a writer that keeps the root
+// non-empty before every root-delete attempt: with root attempts bounded to
+// 2 the delete must return ErrDirectoryNotEmpty (never a partial success),
+// and a later call after the writer stops must complete the delete.
+func TestDeleteDirBatchedErrorOnPartial(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	setDeleteDirTunables(t, 20, deleteDirMaxDuration)
+	oldAttempts := deleteDirRootAttempts
+	deleteDirRootAttempts = 2
+	t.Cleanup(func() { deleteDirRootAttempts = oldAttempts })
+	s := newTestStore(t)
+
+	bulkFixtureTree(t, s, "/w/", 25)
+
+	var writerErr error
+	var created []string
+	enableCallFailpoint(t, fpBeforeRootDelete, func(dirPath string, attempt int) {
+		if dirPath != "/w/" {
+			return
+		}
+		// Runs outside any sweep transaction (no locks held), so a
+		// synchronous create through the real path is safe here.
+		fid := fmt.Sprintf("f-writer-%d", attempt)
+		p := fmt.Sprintf("/w/zz-writer-%d.txt", attempt)
+		if err := insertConfirmedFileE(s, fid); err != nil {
+			writerErr = err
+			return
+		}
+		if err := createFileViaRealPath(s, p, fid); err != nil {
+			writerErr = err
+			return
+		}
+		created = append(created, p)
+	})
+
+	_, err := s.DeleteDirRecursive(context.Background(), "/w/")
+	if !errors.Is(err, ErrDirectoryNotEmpty) {
+		t.Fatalf("DeleteDirRecursive err = %v, want ErrDirectoryNotEmpty", err)
+	}
+	if writerErr != nil {
+		t.Fatalf("writer: %v", writerErr)
+	}
+	if len(created) != 2 {
+		t.Fatalf("writer created %d files, want 2 (one per root attempt)", len(created))
+	}
+
+	// Stop the writer: a fresh call resumes and completes the delete.
+	if err := failpoint.Disable(fpBeforeRootDelete); err != nil {
+		t.Fatalf("disable failpoint: %v", err)
+	}
+	if _, err := s.DeleteDirRecursive(context.Background(), "/w/"); err != nil {
+		t.Fatalf("second DeleteDirRecursive: %v", err)
+	}
+	if n := countNodesLike(t, s, "/w/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /w/, want 0", n)
+	}
+	assertNodeGone(t, s, "/w/")
+	if n := countAllGCTasks(t, s); n != 27 {
+		t.Fatalf("total gc tasks = %d, want 27 (25 fixture + 2 writer)", n)
+	}
+}
+
+// TestDeleteDirBatchedRenameOutMidSweep renames a subdirectory out of the
+// target tree while the delete is in flight (sweep entered, root dentry
+// pinned, before the first drain batch). The moved subtree must survive
+// intact — the sweep deletes only rows it currently selects by node_id, so it
+// can never follow stale paths — and must not enqueue GC for moved files.
+//
+// The rename runs synchronously inside the failpoint callback: no sweep
+// transaction is open at this point, so RenameDir's unindexed
+// `path LIKE ... FOR UPDATE` scan (design §2.2) cannot deadlock against the
+// sweep. Pausing later — inside a drain batch — would deadlock the test,
+// because that scan would block on the paused batch's locks.
+func TestDeleteDirBatchedRenameOutMidSweep(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	setDeleteDirTunables(t, 20, deleteDirMaxDuration)
+	s := newTestStore(t)
+	now := time.Now()
+
+	looseIDs := bulkFixtureTree(t, s, "/r/", 25)
+	var subIDs []string
+	subNodes := []*FileNode{dirTestNode("/r/sub/", now)}
+	for i := 0; i < 10; i++ {
+		fid := fmt.Sprintf("sub-f%02d", i)
+		subIDs = append(subIDs, fid)
+		insertConfirmedFile(t, s, fid, now)
+		subNodes = append(subNodes, fileTestNode(fmt.Sprintf("/r/sub/s%02d.txt", i), fid, now))
+	}
+	bulkInsertNodes(t, s, subNodes...)
+
+	var renameErr error
+	var renamed int64
+	var fired atomic.Bool
+	enableCallFailpoint(t, fpDrainBeforeSelect, func(parent string) {
+		if parent != "/r/" || !fired.CompareAndSwap(false, true) {
+			return
+		}
+		renamed, renameErr = s.RenameDir(context.Background(), "/r/sub/", "/outside/")
+	})
+
+	if _, err := s.DeleteDirRecursive(context.Background(), "/r/"); err != nil {
+		t.Fatalf("DeleteDirRecursive: %v", err)
+	}
+	if !fired.Load() {
+		t.Fatal("drain-before-select failpoint never fired")
+	}
+	if renameErr != nil {
+		t.Fatalf("RenameDir: %v", renameErr)
+	}
+	if renamed != 11 {
+		t.Fatalf("RenameDir moved %d rows, want 11 (dentry + 10 files)", renamed)
+	}
+
+	// The in-tree portion is fully gone.
+	if n := countNodesLike(t, s, "/r/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /r/, want 0", n)
+	}
+	assertNodeGone(t, s, "/r/")
+
+	// The renamed-away copy is intact, with no stray GC for its files.
+	assertNodeAlive(t, s, "/outside/")
+	for i, fid := range subIDs {
+		assertNodeAlive(t, s, fmt.Sprintf("/outside/s%02d.txt", i))
+		if n := countGCTasks(t, s, fid); n != 0 {
+			t.Fatalf("gc tasks for moved file %s = %d, want 0", fid, n)
+		}
+		if st := inodeStatus(t, s, fid); st != string(StatusConfirmed) {
+			t.Fatalf("inode %s status = %q, want CONFIRMED", fid, st)
+		}
+	}
+	for _, fid := range looseIDs {
+		if n := countGCTasks(t, s, fid); n != 1 {
+			t.Fatalf("gc tasks for %s = %d, want 1", fid, n)
+		}
+	}
+}
+
+// TestDeleteDirBatchedPerBatchRetry injects synthetic deadlock errors into
+// the first two drain-batch attempts and asserts the bounded per-batch retry
+// absorbs them: the delete completes and only committed batches count toward
+// the transaction budget.
+func TestDeleteDirBatchedPerBatchRetry(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	setDeleteDirTunables(t, 20, deleteDirMaxDuration)
+	s := newTestStore(t)
+
+	fileIDs := bulkFixtureTree(t, s, "/b/", 25)
+
+	// Two one-shot injected deadlocks, scoped to drain batches (not lifts).
+	if err := failpoint.Enable(fpBatchError, `2*return("delete_dir_recursive_batch")`); err != nil {
+		t.Fatalf("enable failpoint %s: %v", fpBatchError, err)
+	}
+	t.Cleanup(func() {
+		_ = failpoint.Disable(fpBatchError)
+	})
+
+	summary, err := s.DeleteDirRecursive(context.Background(), "/b/")
+	if err != nil {
+		t.Fatalf("DeleteDirRecursive: %v (retry must absorb the injected deadlocks)", err)
+	}
+	// 25 files / batch 20 = 2 committed drain batches; retried (rolled-back)
+	// attempts must not count.
+	if summary.TxCount != 2 {
+		t.Fatalf("summary.TxCount = %d, want 2 committed batches (retries not counted)", summary.TxCount)
+	}
+	if summary.NodesDeleted != 25 {
+		t.Fatalf("summary.NodesDeleted = %d, want 25", summary.NodesDeleted)
+	}
+	if n := countNodesLike(t, s, "/b/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /b/, want 0", n)
+	}
+	assertNodeGone(t, s, "/b/")
+	for _, fid := range fileIDs {
+		if n := countGCTasks(t, s, fid); n != 1 {
+			t.Fatalf("gc tasks for %s = %d, want 1", fid, n)
+		}
+	}
+}

--- a/pkg/datastore/delete_recursive_failpoint_test.go
+++ b/pkg/datastore/delete_recursive_failpoint_test.go
@@ -310,7 +310,7 @@ func TestDeleteDirBatchedEmptyDirDeleteRace(t *testing.T) {
 
 	// The reconciliation sweep (repair mode) must remove the broken-chain
 	// dentry and run the orphan pipeline for its file.
-	report, err := s.ReconcileDeleteOrphans(context.Background(), false, 100)
+	report, err := s.ReconcileDeleteOrphans(context.Background(), false, 100, nil)
 	if err != nil {
 		t.Fatalf("ReconcileDeleteOrphans: %v", err)
 	}

--- a/pkg/datastore/delete_recursive_test.go
+++ b/pkg/datastore/delete_recursive_test.go
@@ -1,0 +1,448 @@
+package datastore
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Tests for the batched recursive directory delete
+// (docs/design/recursive-delete-batched-design.md §4.2/§6). All tests run with
+// DRIVE9_RECURSIVE_DELETE_BATCHED=1 except the legacy smoke test.
+
+// setDeleteDirTunables overrides the batched-delete tunables for one test and
+// restores them on cleanup.
+func setDeleteDirTunables(t *testing.T, batchSize int, maxDuration time.Duration) {
+	t.Helper()
+	oldBatch, oldDuration := deleteDirSweepBatchSize, deleteDirMaxDuration
+	deleteDirSweepBatchSize = batchSize
+	deleteDirMaxDuration = maxDuration
+	t.Cleanup(func() {
+		deleteDirSweepBatchSize = oldBatch
+		deleteDirMaxDuration = oldDuration
+	})
+}
+
+// dirTestNode builds a directory dentry for path (must end in '/').
+func dirTestNode(path string, now time.Time) *FileNode {
+	return &FileNode{
+		NodeID:      "n" + fileNodePathHash(path)[:20],
+		Path:        path,
+		ParentPath:  parentPath(path),
+		Name:        baseName(path),
+		IsDirectory: true,
+		CreatedAt:   now,
+	}
+}
+
+// fileTestNode builds a file dentry for path (no trailing '/') backed by fileID.
+func fileTestNode(path, fileID string, now time.Time) *FileNode {
+	return &FileNode{
+		NodeID:     "n" + fileNodePathHash(path)[:20],
+		Path:       path,
+		ParentPath: parentPath(path),
+		Name:       baseName(path),
+		FileID:     fileID,
+		CreatedAt:  now,
+	}
+}
+
+// bulkInsertNodes inserts dentries directly, bypassing per-row InsertNode so
+// large/deep fixture trees stay fast.
+func bulkInsertNodes(t *testing.T, s *Store, nodes ...*FileNode) {
+	t.Helper()
+	const cols = `node_id, path, path_hash, parent_path, parent_path_hash, name, is_directory, file_id, inode_id, created_at`
+	for start := 0; start < len(nodes); start += 200 {
+		end := min(start+200, len(nodes))
+		var sb strings.Builder
+		sb.WriteString(`INSERT INTO file_nodes (` + s.scope.InsCols(cols) + `) VALUES `)
+		var args []any
+		for i, n := range nodes[start:end] {
+			if i > 0 {
+				sb.WriteString(", ")
+			}
+			sb.WriteString("(" + s.scope.InsVals("?, ?, ?, ?, ?, ?, ?, ?, ?, ?") + ")")
+			args = append(args, s.scope.Args(n.NodeID, n.Path, fileNodePathHash(n.Path), n.ParentPath,
+				fileNodePathHash(n.ParentPath), n.Name, n.IsDirectory, nullStr(n.FileID), nullStr(n.InodeID),
+				n.CreatedAt.UTC())...)
+		}
+		if _, err := s.db.Exec(sb.String(), args...); err != nil {
+			t.Fatalf("bulk insert nodes: %v", err)
+		}
+	}
+}
+
+// insertConfirmedFile inserts one CONFIRMED db9-backed file identity.
+func insertConfirmedFile(t *testing.T, s *Store, fileID string, now time.Time) {
+	t.Helper()
+	if err := s.InsertFile(context.Background(), &File{
+		FileID: fileID, StorageType: StorageDB9, StorageRef: "/blobs/" + fileID,
+		SizeBytes: 1, Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatalf("InsertFile %s: %v", fileID, err)
+	}
+}
+
+func assertNodeGone(t *testing.T, s *Store, path string) {
+	t.Helper()
+	if _, err := s.GetNode(context.Background(), path); !errors.Is(err, ErrNotFound) {
+		t.Errorf("GetNode(%q) err = %v, want ErrNotFound", path, err)
+	}
+}
+
+func assertNodeAlive(t *testing.T, s *Store, path string) {
+	t.Helper()
+	if _, err := s.GetNode(context.Background(), path); err != nil {
+		t.Errorf("GetNode(%q) err = %v, want alive", path, err)
+	}
+}
+
+// countNodesLike counts file_nodes rows whose path matches a SQL LIKE pattern
+// (test fixture paths are chosen free of LIKE metacharacters where a plain
+// pattern is used).
+func countNodesLike(t *testing.T, s *Store, pattern string) int64 {
+	t.Helper()
+	var n int64
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE path LIKE ?`, pattern).Scan(&n); err != nil {
+		t.Fatalf("count nodes like %q: %v", pattern, err)
+	}
+	return n
+}
+
+func countDirNodesLike(t *testing.T, s *Store, pattern string) int64 {
+	t.Helper()
+	var n int64
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM file_nodes WHERE is_directory = 1 AND path LIKE ?`, pattern).Scan(&n); err != nil {
+		t.Fatalf("count dir nodes like %q: %v", pattern, err)
+	}
+	return n
+}
+
+func countGCTasks(t *testing.T, s *Store, fileID string) int64 {
+	t.Helper()
+	var n int64
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM file_gc_tasks WHERE file_id = ?`, fileID).Scan(&n); err != nil {
+		t.Fatalf("count gc tasks for %q: %v", fileID, err)
+	}
+	return n
+}
+
+func TestDeleteDirBatchedSmallTreeFastPath(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	s := newTestStore(t)
+	now := time.Now()
+
+	insertConfirmedFile(t, s, "f1", now)
+	insertConfirmedFile(t, s, "f2", now)
+	bulkInsertNodes(t, s,
+		dirTestNode("/data/", now),
+		dirTestNode("/data/sub/", now),
+		fileTestNode("/data/a.txt", "f1", now),
+		fileTestNode("/data/sub/b.txt", "f2", now),
+	)
+
+	summary, err := s.DeleteDirRecursive(context.Background(), "/data/")
+	if err != nil {
+		t.Fatalf("DeleteDirRecursive: %v", err)
+	}
+	if summary.TxCount != 1 {
+		t.Fatalf("summary.TxCount = %d, want 1 (fast path single transaction)", summary.TxCount)
+	}
+	if summary.NodesDeleted != 4 || summary.OrphansEnqueued != 2 {
+		t.Fatalf("summary = %+v, want 4 nodes deleted and 2 orphans", summary)
+	}
+	for _, p := range []string{"/data/", "/data/sub/", "/data/a.txt", "/data/sub/b.txt"} {
+		assertNodeGone(t, s, p)
+	}
+	for _, fid := range []string{"f1", "f2"} {
+		task, err := s.GetFileGCTaskByFileID(context.Background(), fid)
+		if err != nil {
+			t.Fatalf("get gc task %s: %v", fid, err)
+		}
+		if task.Status != FileGCTaskQueued || task.StorageRef != "/blobs/"+fid {
+			t.Fatalf("unexpected gc task for %s: %+v", fid, task)
+		}
+	}
+}
+
+func TestDeleteDirBatchedDeepTreePostOrder(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	setDeleteDirTunables(t, 20, deleteDirMaxDuration)
+	s := newTestStore(t)
+	now := time.Now()
+
+	// Depth-3 tree whose intermediate directories are non-empty at first
+	// visit; 26 subtree nodes overflows batch=20 so the sweep (not the fast
+	// path) handles it. The post-order lift (I4) must remove every directory
+	// dentry.
+	nodes := []*FileNode{dirTestNode("/d/", now), dirTestNode("/d/a/", now), dirTestNode("/d/a/b/", now)}
+	var fileIDs []string
+	for i, dir := range []string{"/d/", "/d/a/", "/d/a/b/"} {
+		for j := 0; j < 8; j++ {
+			fid := fmt.Sprintf("f-%d-%d", i, j)
+			fileIDs = append(fileIDs, fid)
+			insertConfirmedFile(t, s, fid, now)
+			nodes = append(nodes, fileTestNode(fmt.Sprintf("%sfile-%d.txt", dir, j), fid, now))
+		}
+	}
+	bulkInsertNodes(t, s, nodes...)
+
+	if _, err := s.DeleteDirRecursive(context.Background(), "/d/"); err != nil {
+		t.Fatalf("DeleteDirRecursive: %v", err)
+	}
+	// Regression red line: zero directory dentries left under /d/.
+	if n := countDirNodesLike(t, s, "/d/%"); n != 0 {
+		t.Fatalf("%d directory dentries remain under /d/, want 0 (post-order lift)", n)
+	}
+	if n := countNodesLike(t, s, "/d/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /d/, want 0", n)
+	}
+	assertNodeGone(t, s, "/d/")
+	for _, fid := range fileIDs {
+		if n := countGCTasks(t, s, fid); n != 1 {
+			t.Fatalf("gc tasks for %s = %d, want 1", fid, n)
+		}
+	}
+}
+
+func TestDeleteDirBatchedDrainLivelock(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	setDeleteDirTunables(t, 20, deleteDirMaxDuration)
+	s := newTestStore(t)
+	now := time.Now()
+
+	// 45 non-empty subdirectories (> 2x batch size): a drain batch of /w/
+	// deletes zero rows, so a "batch full means progress" loop would spin
+	// forever (I5 regression).
+	nodes := []*FileNode{dirTestNode("/w/", now)}
+	for i := 0; i < 45; i++ {
+		dir := fmt.Sprintf("/w/w%02d/", i)
+		fid := fmt.Sprintf("f-%02d", i)
+		insertConfirmedFile(t, s, fid, now)
+		nodes = append(nodes, dirTestNode(dir, now), fileTestNode(dir+"x.txt", fid, now))
+	}
+	bulkInsertNodes(t, s, nodes...)
+
+	if _, err := s.DeleteDirRecursive(context.Background(), "/w/"); err != nil {
+		t.Fatalf("DeleteDirRecursive: %v (must not return ErrDeleteIncomplete)", err)
+	}
+	if n := countNodesLike(t, s, "/w/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /w/, want 0", n)
+	}
+	assertNodeGone(t, s, "/w/")
+}
+
+func TestDeleteDirBatchedDeepChain(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	setDeleteDirTunables(t, 20, deleteDirMaxDuration)
+	s := newTestStore(t)
+	now := time.Now()
+
+	// 100-level single-child chain: ~2 transactions per directory, so a
+	// budget derived from file counts alone would abort with
+	// ErrDeleteIncomplete (regression for enumeration-derived budget).
+	insertConfirmedFile(t, s, "f-leaf", now)
+	nodes := []*FileNode{dirTestNode("/c0/", now)}
+	prefix := "/c0/"
+	for i := 1; i < 100; i++ {
+		p := fmt.Sprintf("%sc%d/", prefix, i)
+		nodes = append(nodes, dirTestNode(p, now))
+		prefix = p
+	}
+	nodes = append(nodes, fileTestNode(prefix+"file.txt", "f-leaf", now))
+	bulkInsertNodes(t, s, nodes...)
+
+	if _, err := s.DeleteDirRecursive(context.Background(), "/c0/"); err != nil {
+		t.Fatalf("DeleteDirRecursive: %v (must not return ErrDeleteIncomplete)", err)
+	}
+	if n := countNodesLike(t, s, "/c0/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /c0/, want 0", n)
+	}
+	assertNodeGone(t, s, "/c0/")
+	if n := countGCTasks(t, s, "f-leaf"); n != 1 {
+		t.Fatalf("gc tasks for f-leaf = %d, want 1", n)
+	}
+}
+
+func TestDeleteDirBatchedResume(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	// 1ns max duration makes the sweep abort at its first budget check.
+	setDeleteDirTunables(t, 20, time.Nanosecond)
+	s := newTestStore(t)
+	now := time.Now()
+
+	nodes := []*FileNode{dirTestNode("/r/", now)}
+	var fileIDs []string
+	for i := 0; i < 30; i++ {
+		fid := fmt.Sprintf("f-%02d", i)
+		fileIDs = append(fileIDs, fid)
+		insertConfirmedFile(t, s, fid, now)
+		nodes = append(nodes, fileTestNode(fmt.Sprintf("/r/f%02d.txt", i), fid, now))
+	}
+	bulkInsertNodes(t, s, nodes...)
+
+	_, err := s.DeleteDirRecursive(context.Background(), "/r/")
+	if !errors.Is(err, ErrDeleteIncomplete) && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
+		t.Fatalf("first DeleteDirRecursive err = %v, want ErrDeleteIncomplete or context error", err)
+	}
+
+	// Resume: restore a generous duration and re-call the same entry point.
+	// (deleteDirMaxDuration still holds the 1ns override here, so set the
+	// default explicitly.)
+	setDeleteDirTunables(t, 20, 5*time.Minute)
+	if _, err := s.DeleteDirRecursive(context.Background(), "/r/"); err != nil {
+		t.Fatalf("resumed DeleteDirRecursive: %v", err)
+	}
+	if n := countNodesLike(t, s, "/r/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /r/ after resume, want 0", n)
+	}
+	assertNodeGone(t, s, "/r/")
+	for _, fid := range fileIDs {
+		if n := countGCTasks(t, s, fid); n != 1 {
+			t.Fatalf("gc tasks for %s = %d, want exactly 1 (idempotent re-run)", fid, n)
+		}
+	}
+}
+
+func TestDeleteDirBatchedWideDirectory(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	setDeleteDirTunables(t, 20, deleteDirMaxDuration)
+	s := newTestStore(t)
+	now := time.Now()
+
+	nodes := []*FileNode{dirTestNode("/wide/", now)}
+	for i := 0; i < 100; i++ {
+		fid := fmt.Sprintf("f-%03d", i)
+		insertConfirmedFile(t, s, fid, now)
+		nodes = append(nodes, fileTestNode(fmt.Sprintf("/wide/f%03d.txt", i), fid, now))
+	}
+	bulkInsertNodes(t, s, nodes...)
+
+	if _, err := s.DeleteDirRecursive(context.Background(), "/wide/"); err != nil {
+		t.Fatalf("DeleteDirRecursive: %v", err)
+	}
+	if n := countNodesLike(t, s, "/wide/%"); n != 0 {
+		t.Fatalf("%d nodes remain under /wide/, want 0", n)
+	}
+	assertNodeGone(t, s, "/wide/")
+	var gcTotal int64
+	if err := s.db.QueryRow(`SELECT COUNT(*) FROM file_gc_tasks`).Scan(&gcTotal); err != nil {
+		t.Fatalf("count gc tasks: %v", err)
+	}
+	if gcTotal != 100 {
+		t.Fatalf("gc tasks = %d, want 100", gcTotal)
+	}
+}
+
+func TestDeleteDirBatchedHardlink(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	s := newTestStore(t)
+	now := time.Now()
+
+	insertConfirmedFile(t, s, "f1", now)
+	bulkInsertNodes(t, s,
+		dirTestNode("/del/", now),
+		dirTestNode("/keep/", now),
+		fileTestNode("/del/link.txt", "f1", now),
+		fileTestNode("/keep/link.txt", "f1", now),
+	)
+
+	summary, err := s.DeleteDirRecursive(context.Background(), "/del/")
+	if err != nil {
+		t.Fatalf("DeleteDirRecursive /del/: %v", err)
+	}
+	if summary.OrphansEnqueued != 0 {
+		t.Fatalf("orphans enqueued = %d, want 0 (f1 still referenced by /keep/)", summary.OrphansEnqueued)
+	}
+	if _, err := s.GetFileGCTaskByFileID(context.Background(), "f1"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("gc task for f1 after first delete: err = %v, want ErrNotFound", err)
+	}
+	assertNodeAlive(t, s, "/keep/")
+	assertNodeAlive(t, s, "/keep/link.txt")
+
+	summary, err = s.DeleteDirRecursive(context.Background(), "/keep/")
+	if err != nil {
+		t.Fatalf("DeleteDirRecursive /keep/: %v", err)
+	}
+	if summary.OrphansEnqueued != 1 {
+		t.Fatalf("orphans enqueued = %d, want 1 (last reference removed)", summary.OrphansEnqueued)
+	}
+	if n := countGCTasks(t, s, "f1"); n != 1 {
+		t.Fatalf("gc tasks for f1 = %d, want 1 after last link deleted", n)
+	}
+}
+
+func TestDeleteDirBatchedLikeMetachars(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	s := newTestStore(t)
+	now := time.Now()
+
+	insertConfirmedFile(t, s, "f1", now)
+	insertConfirmedFile(t, s, "f2", now)
+	bulkInsertNodes(t, s,
+		dirTestNode("/a_b/", now),
+		dirTestNode("/axb/", now),
+		fileTestNode("/a_b/a.txt", "f1", now),
+		fileTestNode("/axb/b.txt", "f2", now),
+	)
+
+	if _, err := s.DeleteDirRecursive(context.Background(), "/a_b/"); err != nil {
+		t.Fatalf("DeleteDirRecursive /a_b/: %v", err)
+	}
+	assertNodeGone(t, s, "/a_b/")
+	assertNodeGone(t, s, "/a_b/a.txt")
+	// '_' is a LIKE single-character wildcard: an unescaped prefix match
+	// would also delete /axb/ (regression for design §2.2).
+	assertNodeAlive(t, s, "/axb/")
+	assertNodeAlive(t, s, "/axb/b.txt")
+	if n := countGCTasks(t, s, "f1"); n != 1 {
+		t.Fatalf("gc tasks for f1 = %d, want 1", n)
+	}
+	if _, err := s.GetFileGCTaskByFileID(context.Background(), "f2"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("gc task for f2: err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeleteDirBatchedRootNotFound(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "1")
+	s := newTestStore(t)
+
+	_, err := s.DeleteDirRecursive(context.Background(), "/missing/")
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("DeleteDirRecursive err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDeleteDirBatchedLegacyFlagOff(t *testing.T) {
+	t.Setenv("DRIVE9_RECURSIVE_DELETE_BATCHED", "0")
+	s := newTestStore(t)
+	now := time.Now()
+
+	insertConfirmedFile(t, s, "f1", now)
+	insertConfirmedFile(t, s, "f2", now)
+	bulkInsertNodes(t, s,
+		dirTestNode("/data/", now),
+		dirTestNode("/data/sub/", now),
+		fileTestNode("/data/a.txt", "f1", now),
+		fileTestNode("/data/sub/b.txt", "f2", now),
+	)
+
+	summary, err := s.DeleteDirRecursive(context.Background(), "/data/")
+	if err != nil {
+		t.Fatalf("DeleteDirRecursive (legacy): %v", err)
+	}
+	if summary.NodesDeleted != 4 || summary.OrphansEnqueued != 2 {
+		t.Fatalf("summary = %+v, want 4 nodes deleted and 2 orphans", summary)
+	}
+	for _, p := range []string{"/data/", "/data/sub/", "/data/a.txt", "/data/sub/b.txt"} {
+		assertNodeGone(t, s, p)
+	}
+	for _, fid := range []string{"f1", "f2"} {
+		if n := countGCTasks(t, s, fid); n != 1 {
+			t.Fatalf("gc tasks for %s = %d, want 1", fid, n)
+		}
+	}
+}

--- a/pkg/datastore/file_gc_tasks.go
+++ b/pkg/datastore/file_gc_tasks.go
@@ -420,9 +420,12 @@ func normalizeFileGCTask(task *FileGCTask, now time.Time) {
 }
 
 // enqueueFileGCTasksTx inserts many queued tasks in chunked multi-row
-// INSERT IGNORE statements, giving the same duplicate-is-no-op semantics as
+// statements, giving the same duplicate-is-no-op semantics as
 // enqueueFileGCTask (file IDs are never reused; hardlink batches may repeat a
-// file_id). It returns the number of tasks actually inserted.
+// file_id). ON DUPLICATE KEY UPDATE (not INSERT IGNORE) is deliberate: only
+// unique-key conflicts are swallowed, while real errors (bad types, length,
+// constraints) still fail the batch instead of silently dropping GC tasks.
+// It returns the number of tasks actually inserted.
 func (s *Store) enqueueFileGCTasksTx(db execer, tasks []*FileGCTask) (int64, error) {
 	var inserted int64
 	now := time.Now().UTC()
@@ -452,16 +455,19 @@ func (s *Store) enqueueFileGCTasksTx(db execer, tasks []*FileGCTask) (int64, err
 				task.AvailableAt.UTC(), nullStr(task.LastError), task.CreatedAt.UTC(),
 				task.UpdatedAt.UTC(), nilTime(task.CompletedAt))...)
 		}
-		res, err := db.Exec(`INSERT IGNORE INTO file_gc_tasks
+		res, err := db.Exec(`INSERT INTO file_gc_tasks
 			(`+s.scope.InsCols(`task_id, file_id, storage_type, storage_ref, size_bytes, content_type,
 			 status, attempt_count, max_attempts, receipt, leased_at, lease_until,
 			 available_at, last_error, created_at, updated_at, completed_at`)+`)
-			VALUES `+strings.Join(values, `,`), args...)
+			VALUES `+strings.Join(values, `,`)+`
+			ON DUPLICATE KEY UPDATE task_id = task_id`, args...)
 		if err != nil {
 			return inserted, err
 		}
 		n, _ := res.RowsAffected()
-		inserted += n
+		// MySQL counts a duplicate-key no-op update as 2 affected rows; only
+		// count real inserts.
+		inserted += min(n, int64(len(batch)))
 	}
 	return inserted, nil
 }

--- a/pkg/datastore/file_gc_tasks.go
+++ b/pkg/datastore/file_gc_tasks.go
@@ -374,44 +374,20 @@ func (s *Store) enqueueFileGCTask(db execer, task *FileGCTask) (bool, error) {
 	if task == nil {
 		return false, fmt.Errorf("file gc task is required")
 	}
-	if strings.TrimSpace(task.TaskID) == "" {
-		task.TaskID = task.FileID
-	}
 	if strings.TrimSpace(task.FileID) == "" {
 		return false, fmt.Errorf("file_id is required")
 	}
-	now := time.Now().UTC()
-	status := task.Status
-	if status == "" {
-		status = FileGCTaskQueued
-	}
-	maxAttempts := task.MaxAttempts
-	if maxAttempts <= 0 {
-		maxAttempts = defaultFileGCMaxAttempts
-	}
-	availableAt := task.AvailableAt
-	if availableAt.IsZero() {
-		availableAt = now
-	}
-	createdAt := task.CreatedAt
-	if createdAt.IsZero() {
-		createdAt = now
-	}
-	updatedAt := task.UpdatedAt
-	if updatedAt.IsZero() {
-		updatedAt = createdAt
-	}
-
+	normalizeFileGCTask(task, time.Now().UTC())
 	_, err := db.Exec(`INSERT INTO file_gc_tasks
 		(`+s.scope.InsCols(`task_id, file_id, storage_type, storage_ref, size_bytes, content_type,
 		 status, attempt_count, max_attempts, receipt, leased_at, lease_until,
 		 available_at, last_error, created_at, updated_at, completed_at`)+`)
 		VALUES (`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`,
 		s.scope.Args(task.TaskID, task.FileID, task.StorageType, task.StorageRef, task.SizeBytes,
-			nullStr(task.ContentType), status, task.AttemptCount, maxAttempts,
+			nullStr(task.ContentType), task.Status, task.AttemptCount, task.MaxAttempts,
 			nullStr(task.Receipt), nilTime(task.LeasedAt), nilTime(task.LeaseUntil),
-			availableAt.UTC(), nullStr(task.LastError), createdAt.UTC(),
-			updatedAt.UTC(), nilTime(task.CompletedAt))...)
+			task.AvailableAt.UTC(), nullStr(task.LastError), task.CreatedAt.UTC(),
+			task.UpdatedAt.UTC(), nilTime(task.CompletedAt))...)
 	if err == nil {
 		return true, nil
 	}
@@ -419,6 +395,75 @@ func (s *Store) enqueueFileGCTask(db execer, task *FileGCTask) (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+// normalizeFileGCTask applies the defaulting rules of enqueueFileGCTask.
+func normalizeFileGCTask(task *FileGCTask, now time.Time) {
+	if strings.TrimSpace(task.TaskID) == "" {
+		task.TaskID = task.FileID
+	}
+	if task.Status == "" {
+		task.Status = FileGCTaskQueued
+	}
+	if task.MaxAttempts <= 0 {
+		task.MaxAttempts = defaultFileGCMaxAttempts
+	}
+	if task.AvailableAt.IsZero() {
+		task.AvailableAt = now
+	}
+	if task.CreatedAt.IsZero() {
+		task.CreatedAt = now
+	}
+	if task.UpdatedAt.IsZero() {
+		task.UpdatedAt = task.CreatedAt
+	}
+}
+
+// enqueueFileGCTasksTx inserts many queued tasks in chunked multi-row
+// INSERT IGNORE statements, giving the same duplicate-is-no-op semantics as
+// enqueueFileGCTask (file IDs are never reused; hardlink batches may repeat a
+// file_id). It returns the number of tasks actually inserted.
+func (s *Store) enqueueFileGCTasksTx(db execer, tasks []*FileGCTask) (int64, error) {
+	var inserted int64
+	now := time.Now().UTC()
+	for start := 0; start < len(tasks); start += deleteFileIDBatchSize {
+		end := start + deleteFileIDBatchSize
+		if end > len(tasks) {
+			end = len(tasks)
+		}
+		batch := tasks[start:end]
+		if len(batch) == 0 {
+			continue
+		}
+		values := make([]string, 0, len(batch))
+		args := make([]any, 0, len(batch)*18)
+		for _, task := range batch {
+			if task == nil {
+				return inserted, fmt.Errorf("file gc task is required")
+			}
+			if strings.TrimSpace(task.FileID) == "" {
+				return inserted, fmt.Errorf("file_id is required")
+			}
+			normalizeFileGCTask(task, now)
+			values = append(values, `(`+s.scope.InsVals(`?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?`)+`)`)
+			args = append(args, s.scope.Args(task.TaskID, task.FileID, task.StorageType, task.StorageRef, task.SizeBytes,
+				nullStr(task.ContentType), task.Status, task.AttemptCount, task.MaxAttempts,
+				nullStr(task.Receipt), nilTime(task.LeasedAt), nilTime(task.LeaseUntil),
+				task.AvailableAt.UTC(), nullStr(task.LastError), task.CreatedAt.UTC(),
+				task.UpdatedAt.UTC(), nilTime(task.CompletedAt))...)
+		}
+		res, err := db.Exec(`INSERT IGNORE INTO file_gc_tasks
+			(`+s.scope.InsCols(`task_id, file_id, storage_type, storage_ref, size_bytes, content_type,
+			 status, attempt_count, max_attempts, receipt, leased_at, lease_until,
+			 available_at, last_error, created_at, updated_at, completed_at`)+`)
+			VALUES `+strings.Join(values, `,`), args...)
+		if err != nil {
+			return inserted, err
+		}
+		n, _ := res.RowsAffected()
+		inserted += n
+	}
+	return inserted, nil
 }
 
 func (s *Store) fileGCTaskLeaseError(ctx context.Context, taskID string) error {

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -37,6 +37,10 @@ var (
 	ErrJournalPayloadTooLarge  = errors.New("journal payload too large")
 	ErrRevisionConflict        = errors.New("revision conflict")
 	ErrFileGCTaskLeaseMismatch = errors.New("file gc task lease mismatch")
+	// ErrDeleteIncomplete marks a bounded recursive delete that exhausted its
+	// transaction/time budget before finishing. The operation is resumable:
+	// callers may retry the same request to continue.
+	ErrDeleteIncomplete = errors.New("recursive delete incomplete, retry to resume")
 )
 
 type StorageType string
@@ -367,7 +371,9 @@ func (s *Store) DeleteNode(ctx context.Context, path string) (err error) {
 	return nil
 }
 
-// DeleteEmptyDir atomically checks a directory is empty and deletes it.
+// DeleteEmptyDir atomically checks a directory is empty and deletes it. The
+// post-DELETE re-check closes the TiDB no-gap-lock window where a concurrent
+// create commits a child between the emptiness check and the delete.
 func (s *Store) DeleteEmptyDir(ctx context.Context, path string) (err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "delete_empty_dir", start, &err)
@@ -393,6 +399,13 @@ func (s *Store) DeleteEmptyDir(ctx context.Context, path string) (err error) {
 	n, _ := res.RowsAffected()
 	if n == 0 {
 		return ErrNotFound
+	}
+	stillHasChildren, err := s.dirHasChildrenTx(ctx, tx, path)
+	if err != nil {
+		return err
+	}
+	if stillHasChildren {
+		return fmt.Errorf("%w: %s", ErrDirectoryNotEmpty, path)
 	}
 	err = tx.Commit()
 	return err
@@ -2014,10 +2027,11 @@ func (s *Store) DeleteFileWithRefCheck(ctx context.Context, path string) (out *F
 	return out, nil
 }
 
-func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*File, err error) {
-	start := time.Now()
-	defer observeStoreOp(ctx, "delete_dir_recursive", start, &err)
-
+// deleteDirRecursiveLegacy is the pre-flag implementation: the whole subtree
+// in one unbounded transaction. Kept as the default while
+// DRIVE9_RECURSIVE_DELETE_BATCHED soaks; see
+// docs/design/recursive-delete-batched-design.md.
+func (s *Store) deleteDirRecursiveLegacy(ctx context.Context, dirPath string) (out *DeleteDirRecursiveSummary, err error) {
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		return nil, err
@@ -2044,10 +2058,12 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 		return nil, err
 	}
 
-	if _, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+s.andAsGrouped("", `path = ? OR path LIKE ?`),
-		s.scope.Args(dirPath, dirPath+"%")...); err != nil {
+	delRes, err := tx.ExecContext(ctx, `DELETE FROM file_nodes WHERE `+s.andAsGrouped("", `path = ? OR path LIKE ?`),
+		s.scope.Args(dirPath, dirPath+"%")...)
+	if err != nil {
 		return nil, err
 	}
+	nodesDeleted, _ := delRes.RowsAffected()
 
 	orphaned, err := s.scanOrphanedFilesByIDTx(ctx, tx, fileIDs)
 	if err != nil {
@@ -2064,21 +2080,27 @@ func (s *Store) DeleteDirRecursive(ctx context.Context, dirPath string) (out []*
 		return nil, err
 	}
 
+	tasks := make([]*FileGCTask, 0, len(orphaned))
 	for _, f := range orphaned {
 		task, err := NewFileGCTaskFromFile(f, time.Now().UTC())
 		if err != nil {
 			return nil, err
 		}
-		if _, err := s.EnqueueFileGCTaskTx(tx, task); err != nil {
-			return nil, err
-		}
+		tasks = append(tasks, task)
+	}
+	enqueued, err := s.enqueueFileGCTasksTx(tx, tasks)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := tx.Commit(); err != nil {
 		return nil, err
 	}
-	out = orphaned
-	return out, nil
+	return &DeleteDirRecursiveSummary{
+		NodesDeleted:    nodesDeleted,
+		OrphansEnqueued: enqueued,
+		TxCount:         1,
+	}, nil
 }
 
 type deleteCandidate struct {

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -998,14 +998,13 @@ func TestDeleteDirRecursive(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	orphaned, err := s.DeleteDirRecursive(context.Background(), "/data/")
+	summary, err := s.DeleteDirRecursive(context.Background(), "/data/")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(orphaned) != 1 || orphaned[0].FileID != "f2" {
-		t.Fatalf("expected 1 orphaned (f2), got %d", len(orphaned))
+	if summary.NodesDeleted != 3 || summary.OrphansEnqueued != 1 {
+		t.Fatalf("summary = %+v, want 3 nodes deleted and 1 orphan (f2)", summary)
 	}
-	requireEmbeddingRevision(t, orphaned[0].EmbeddingRevision, 23)
 	if _, err := s.GetFileGCTaskByFileID(context.Background(), "f1"); err != ErrNotFound {
 		t.Fatalf("expected no gc task for shared f1, got %v", err)
 	}
@@ -1051,12 +1050,12 @@ func TestDeleteDirRecursiveDoesNotDeleteSiblingPrefix(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	orphaned, err := s.DeleteDirRecursive(context.Background(), "/data/")
+	summary, err := s.DeleteDirRecursive(context.Background(), "/data/")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(orphaned) != 1 || orphaned[0].FileID != "f1" {
-		t.Fatalf("orphaned = %+v, want only f1", orphaned)
+	if summary.OrphansEnqueued != 1 {
+		t.Fatalf("summary = %+v, want 1 orphan (f1)", summary)
 	}
 	if _, err := s.GetNode(context.Background(), "/data-other/"); err != nil {
 		t.Fatalf("sibling directory should survive: %v", err)

--- a/pkg/server/auth.go
+++ b/pkg/server/auth.go
@@ -87,6 +87,9 @@ func sanitizeClientError(err error) string {
 	if errors.Is(err, datastore.ErrDirectoryNotEmpty) {
 		return err.Error()
 	}
+	if errors.Is(err, datastore.ErrDeleteIncomplete) {
+		return "recursive delete in progress, retry to resume"
+	}
 	if isQuotaError(err) {
 		return "tenant usage quota exceeded"
 	}
@@ -103,6 +106,9 @@ func backendErrorStatus(ctx context.Context, err error) int {
 	if errors.Is(err, context.DeadlineExceeded) {
 		return http.StatusGatewayTimeout
 	}
+	if errors.Is(err, datastore.ErrDeleteIncomplete) {
+		return http.StatusServiceUnavailable
+	}
 	if errors.Is(err, datastore.ErrDirectoryNotEmpty) {
 		return http.StatusConflict
 	}
@@ -116,6 +122,11 @@ func backendErrorStatus(ctx context.Context, err error) int {
 }
 
 func writeBackendError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, datastore.ErrDeleteIncomplete) {
+		// A bounded recursive delete ran out of budget; it is resumable, so tell
+		// the client when to re-issue the same request to continue the sweep.
+		w.Header().Set("Retry-After", "2")
+	}
 	errJSON(w, backendErrorStatus(r.Context(), err), sanitizeClientError(err))
 }
 

--- a/pkg/server/auth_test.go
+++ b/pkg/server/auth_test.go
@@ -833,6 +833,30 @@ func TestSanitizeClientError_DirectoryNotEmpty(t *testing.T) {
 	}
 }
 
+func TestSanitizeClientError_DeleteIncomplete(t *testing.T) {
+	err := fmt.Errorf("%w: /projects/a/ (tx=12)", datastore.ErrDeleteIncomplete)
+	got := sanitizeClientError(err)
+	if got != "recursive delete in progress, retry to resume" {
+		t.Fatalf("got %q, want %q", got, "recursive delete in progress, retry to resume")
+	}
+}
+
+func TestWriteBackendError_DeleteIncomplete(t *testing.T) {
+	err := fmt.Errorf("%w: /projects/a/ (tx=12)", datastore.ErrDeleteIncomplete)
+	req := httptest.NewRequest(http.MethodDelete, "/v1/fs/projects/a/?recursive=1", nil)
+	rr := httptest.NewRecorder()
+	writeBackendError(rr, req, err)
+	if rr.Code != http.StatusServiceUnavailable {
+		t.Fatalf("status=%d, want %d", rr.Code, http.StatusServiceUnavailable)
+	}
+	if got := rr.Header().Get("Retry-After"); got != "2" {
+		t.Fatalf("Retry-After = %q, want %q", got, "2")
+	}
+	if body := rr.Body.String(); !strings.Contains(body, "recursive delete in progress, retry to resume") {
+		t.Fatalf("body = %q, want sanitized retry message", body)
+	}
+}
+
 func TestBackendErrorStatus(t *testing.T) {
 	tests := []struct {
 		name string
@@ -878,6 +902,16 @@ func TestBackendErrorStatus(t *testing.T) {
 			name: "directory not empty wrapped",
 			err:  fmt.Errorf("%w: /projects/a/b/", datastore.ErrDirectoryNotEmpty),
 			want: http.StatusConflict,
+		},
+		{
+			name: "delete incomplete",
+			err:  datastore.ErrDeleteIncomplete,
+			want: http.StatusServiceUnavailable,
+		},
+		{
+			name: "delete incomplete wrapped",
+			err:  fmt.Errorf("%w: /projects/a/ (tx=12)", datastore.ErrDeleteIncomplete),
+			want: http.StatusServiceUnavailable,
 		},
 		{
 			name: "unknown error",

--- a/pkg/server/tenant_worker.go
+++ b/pkg/server/tenant_worker.go
@@ -652,8 +652,13 @@ func (m *tenantWorkerManager) piggybackMaintenance(ctx context.Context, target *
 	}
 
 	// Delete-orphan reconciliation (§4.2.1): one throttled round per tenant,
-	// dry-run unless DRIVE9_DELETE_RECONCILE_REPAIR is set.
-	m.reconcileDeleteOrphans(ctx, target)	// Observation metrics: sample queue depth + dead-letter count.
+	// dry-run unless DRIVE9_DELETE_RECONCILE_REPAIR is set. The scan cursor is
+	// held per tenant in this manager (in-memory): a pod restart or shard
+	// owner change re-covers earlier rows — repairs persist, so this only
+	// delays tail coverage for very large tenants, it never loses repairs.
+	m.reconcileDeleteOrphans(ctx, target)
+
+	// Observation metrics: sample queue depth + dead-letter count.
 	m.observeTenant(ctx, target, now)
 }
 

--- a/pkg/server/tenant_worker.go
+++ b/pkg/server/tenant_worker.go
@@ -50,6 +50,12 @@ const (
 	defaultTenantMaintenanceInterval = 5 * time.Minute
 )
 
+// tenantDeleteReconcileInterval is the throttle interval for the per-tenant
+// delete-orphan reconciliation round (design doc
+// recursive-delete-batched-design.md §4.2.1). A package-level variable so
+// tests can shrink it.
+var tenantDeleteReconcileInterval = 10 * time.Minute
+
 var tenantWorkerUsesTiDBAutoEmbedding = tenant.UsesTiDBAutoEmbedding
 
 var tenantWorkerAllowedEmbedTaskTypes = []semantic.TaskType{semantic.TaskTypeEmbed}
@@ -178,7 +184,8 @@ type tenantWorkerManager struct {
 	kicks chan kickMsg
 
 	lastMaintenance   map[string]time.Time
-	semanticMetricOrg map[string]string // tenantID -> org used by the last semantic gauge observation
+	lastReconcile     map[string]time.Time // tenantID -> last delete-orphan reconciliation round
+	semanticMetricOrg map[string]string    // tenantID -> org used by the last semantic gauge observation
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -228,6 +235,7 @@ func newTenantWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Store
 	m.inflight = make(map[string]int)
 	m.kickPending = make(map[string]pendingKick)
 	m.lastMaintenance = make(map[string]time.Time)
+	m.lastReconcile = make(map[string]time.Time)
 	m.semanticMetricOrg = make(map[string]string)
 	m.kicks = make(chan kickMsg, tenantKickQueueCapacity)
 	return m
@@ -284,6 +292,7 @@ func (m *tenantWorkerManager) ForgetTenant(tenantID string) {
 	m.mu.Lock()
 	delete(m.kickPending, tenantID)
 	delete(m.lastMaintenance, tenantID)
+	delete(m.lastReconcile, tenantID)
 	delete(m.semanticMetricOrg, tenantID)
 	m.mu.Unlock()
 }
@@ -639,8 +648,54 @@ func (m *tenantWorkerManager) piggybackMaintenance(ctx context.Context, target *
 		}
 	}
 
+	// Delete-orphan reconciliation (§4.2.1): one throttled round per tenant,
+	// dry-run unless DRIVE9_DELETE_RECONCILE_REPAIR is set.
+	m.reconcileDeleteOrphans(ctx, target)
+
 	// Observation metrics: sample queue depth + dead-letter count.
 	m.observeTenant(ctx, target, now)
+}
+
+// reconcileDeleteOrphans runs one delete-orphan reconciliation round for the
+// tenant, throttled to once per tenantDeleteReconcileInterval. Like the rest
+// of piggyback maintenance it only fires for already-warm (kick-driven)
+// tenants — it never wakes a cold tenant.
+func (m *tenantWorkerManager) reconcileDeleteOrphans(ctx context.Context, target *tenantTarget) {
+	if ctx.Err() != nil {
+		return
+	}
+	now := time.Now()
+	m.mu.Lock()
+	if m.lastReconcile == nil {
+		m.lastReconcile = make(map[string]time.Time)
+	}
+	last := m.lastReconcile[target.tenantID]
+	if now.Sub(last) < tenantDeleteReconcileInterval {
+		m.mu.Unlock()
+		return
+	}
+	m.lastReconcile[target.tenantID] = now
+	m.mu.Unlock()
+
+	dryRun := !datastore.DeleteReconcileRepairEnabled()
+	report, err := target.store.ReconcileDeleteOrphans(ctx, dryRun, 0)
+	if err != nil {
+		if !isContextDoneErr(err) {
+			logger.Warn(ctx, "tenant_worker_delete_reconcile_failed",
+				zap.String("tenant_id", target.tenantID),
+				zap.Bool("dry_run", dryRun),
+				zap.Error(err))
+		}
+		return
+	}
+	if report.BrokenDentries > 0 || report.StrandedInodes > 0 {
+		logger.Info(ctx, "tenant_worker_delete_reconcile_candidates",
+			zap.String("tenant_id", target.tenantID),
+			zap.Bool("dry_run", dryRun),
+			zap.Int64("broken_dentries", report.BrokenDentries),
+			zap.Int64("stranded_inodes", report.StrandedInodes),
+			zap.Int64("repaired", report.Repaired))
+	}
 }
 
 func (m *tenantWorkerManager) observeTenant(ctx context.Context, target *tenantTarget, now time.Time) {

--- a/pkg/server/tenant_worker.go
+++ b/pkg/server/tenant_worker.go
@@ -185,7 +185,8 @@ type tenantWorkerManager struct {
 
 	lastMaintenance   map[string]time.Time
 	lastReconcile     map[string]time.Time // tenantID -> last delete-orphan reconciliation round
-	semanticMetricOrg map[string]string    // tenantID -> org used by the last semantic gauge observation
+	reconcileState    map[string]*datastore.DeleteReconcileState
+	semanticMetricOrg map[string]string // tenantID -> org used by the last semantic gauge observation
 
 	cancel context.CancelFunc
 	wg     sync.WaitGroup
@@ -236,6 +237,7 @@ func newTenantWorkerManager(fallback *backend.Dat9Backend, metaStore *meta.Store
 	m.kickPending = make(map[string]pendingKick)
 	m.lastMaintenance = make(map[string]time.Time)
 	m.lastReconcile = make(map[string]time.Time)
+	m.reconcileState = make(map[string]*datastore.DeleteReconcileState)
 	m.semanticMetricOrg = make(map[string]string)
 	m.kicks = make(chan kickMsg, tenantKickQueueCapacity)
 	return m
@@ -293,6 +295,7 @@ func (m *tenantWorkerManager) ForgetTenant(tenantID string) {
 	delete(m.kickPending, tenantID)
 	delete(m.lastMaintenance, tenantID)
 	delete(m.lastReconcile, tenantID)
+	delete(m.reconcileState, tenantID)
 	delete(m.semanticMetricOrg, tenantID)
 	m.mu.Unlock()
 }
@@ -650,9 +653,7 @@ func (m *tenantWorkerManager) piggybackMaintenance(ctx context.Context, target *
 
 	// Delete-orphan reconciliation (§4.2.1): one throttled round per tenant,
 	// dry-run unless DRIVE9_DELETE_RECONCILE_REPAIR is set.
-	m.reconcileDeleteOrphans(ctx, target)
-
-	// Observation metrics: sample queue depth + dead-letter count.
+	m.reconcileDeleteOrphans(ctx, target)	// Observation metrics: sample queue depth + dead-letter count.
 	m.observeTenant(ctx, target, now)
 }
 
@@ -669,16 +670,24 @@ func (m *tenantWorkerManager) reconcileDeleteOrphans(ctx context.Context, target
 	if m.lastReconcile == nil {
 		m.lastReconcile = make(map[string]time.Time)
 	}
+	if m.reconcileState == nil {
+		m.reconcileState = make(map[string]*datastore.DeleteReconcileState)
+	}
 	last := m.lastReconcile[target.tenantID]
 	if now.Sub(last) < tenantDeleteReconcileInterval {
 		m.mu.Unlock()
 		return
 	}
 	m.lastReconcile[target.tenantID] = now
+	state := m.reconcileState[target.tenantID]
+	if state == nil {
+		state = &datastore.DeleteReconcileState{}
+		m.reconcileState[target.tenantID] = state
+	}
 	m.mu.Unlock()
 
 	dryRun := !datastore.DeleteReconcileRepairEnabled()
-	report, err := target.store.ReconcileDeleteOrphans(ctx, dryRun, 0)
+	report, err := target.store.ReconcileDeleteOrphans(ctx, dryRun, 0, state)
 	if err != nil {
 		if !isContextDoneErr(err) {
 			logger.Warn(ctx, "tenant_worker_delete_reconcile_failed",


### PR DESCRIPTION
# Batched, race-aware recursive directory delete

## Problem

`Store.DeleteDirRecursive` deleted an entire subtree in **one synchronous transaction**: an unindexed `path = ? OR path LIKE ?` scan (twice — `file_nodes.path` has no index), a whole-subtree `FOR UPDATE` lock held to commit, and one `INSERT` round trip per file into `file_gc_tasks`. On large trees this hit TiDB transaction-size limits, caused lock-wait timeouts (1205) for concurrent writers, and tripped generic latency/5xx alerts. It also had two latent correctness bugs: an unescaped LIKE pattern (`_`/`%` in directory names over-match siblings) and a snapshot-read/current-read TOCTOU that could leak blobs.

## What changes

The batched post-order delete **replaces** the legacy single-transaction implementation (no rollout flag — it is the default and only behavior):

- **Fast path** — subtrees that enumerate to ≤ one batch are still deleted in a single atomic transaction, children post-order, root dentry last, with a post-DELETE childless re-check.
- **Post-order batched sweep** — larger trees are drained in bounded per-batch transactions via the `(parent_path_hash, name)` index (no `path LIKE` scans). Safety invariants:
  - **I1** a directory dentry is deleted only in a transaction that verified it childless, with a post-DELETE re-check (TiDB has no gap locks);
  - **I2** the root dentry is deleted last — while it exists, `idx_path` uniqueness pins the path against recreation by `EnsureParentDirsTx` (no generation confusion, no fake 404 on retry);
  - **I3** orphan/GC decisions derive only from rows deleted in the same transaction (TOCTOU closed);
  - **I4** directories non-empty at first visit are revisited for unlinking after they drain (post-order lift);
  - **I5** a batch that deleted zero rows breaks out — batch fullness is never a progress signal.
- **Budgets** — per-call budget counts *committed* transactions (derived from the subtree estimate, so deep directory chains are not truncated), plus `maxDuration`/ctx; exhaustion returns `ErrDeleteIncomplete` (retryable), never a partial success. Success means the root is gone.
- **Batched GC enqueue** — `file_gc_tasks` inserts become chunked multi-row `ON DUPLICATE KEY UPDATE` (was one round trip per file); real constraint errors still fail the batch.
- **In-flight uploads** into the subtree are marked `ABORTED` best-effort so finalize cannot materialize nodes mid-sweep.
- **`DeleteEmptyDir`** gains the post-DELETE re-check (also covers plain `rmdir`).
- **Orphan reconciliation** (`Store.ReconcileDeleteOrphans`) — the required backstop for the residual commit-boundary window: broken-chain dentry scan (implicit-root aware; parent must be a directory; batched `path_hash IN` checks) + stranded file-inode scan (split schema only; directory inodes excluded via the `contents` join). Repair locks and re-checks before deleting; per-round scan is capped with a cursor held per tenant by the worker (in-memory checkpoint; repairs persist, restarts only re-cover; a failed page repair rolls the cursor back to the page start). Runs in **dry-run** mode by default; `DRIVE9_DELETE_RECONCILE_REPAIR=1` enables repair. Wired into per-tenant piggyback maintenance (10 min throttle, warm tenants only).
- **Server/SDK** — `ErrDeleteIncomplete` → 503 + `Retry-After`; the Go SDK retries recursive deletes on 503 with bounded backoff (safe: the sweep is resumable and idempotent). The backend kicks the file-GC worker whenever orphans were enqueued, including partial sweeps.

## Semantics change

Large-directory deletes are no longer atomic: while the sweep runs, the root still resolves and `ls` shows a gradually emptying directory (POSIX `rm -r`-like). Client disconnects roll back at most one batch; retries resume.

## Testing

- Unit: fast path, deep-tree post-order (zero residual dentries), I5 livelock regression, deep-chain budget, resume idempotency, wide directories, hardlinks, LIKE metacharacters, default-path smoke.
- Failpoint suite: TOCTOU create convergence, empty-dir residual window (pinned, with reconcile backstop asserted), lift idempotency vs concurrent rmdir, error-on-partial, rename-out mid-sweep, per-batch deadlock retry.
- Reconciliation: implicit-root zero-top-level-hits red line, multi-round convergence, directory-inode exclusion, dry-run, two-tenant shared-scope isolation (grouped-OR regression), capped-round cursor resume (dry-run + repair).
- Server/SDK: 503 + `Retry-After` mapping, bounded SDK retry.
- E2E: `e2e/fuse-recursive-delete-stress.sh` (sibling writers, kill-and-resume, same-path mkdir race) — manual-only for now.
- `make lint` clean; `pkg/datastore`, `pkg/server`, `pkg/client`, `pkg/backend` full suites pass (MySQL testcontainers); failpoint suite passes.

## Rollout

1. Deploy: batched delete is live by default; reconciliation runs dry-run — watch `delete_reconcile` logs.
2. Flip `DRIVE9_DELETE_RECONCILE_REPAIR=1` after the dry-run report is reviewed.
