### PR TITLE
feat(client): bounded 503 retry for recursive deletes across SDKs

### DIFF
--- a/clients/drive9-js/README.md
+++ b/clients/drive9-js/README.md
@@ -94,7 +94,7 @@ Environment variables `DRIVE9_SERVER` or `DRIVE9_BASE` and `DRIVE9_API_KEY` take
 | Delete | `await client.delete(path)` |
 | Delete file (kind hint) | `await client.deleteFile(path)` |
 | Delete dir (kind hint) | `await client.deleteDir(path)` |
-| Recursive delete | `await client.removeAll(path)` |
+| Recursive delete | `await client.removeAll(path)` — automatically retries with backoff (honoring `Retry-After`, max 4 retries) when the server answers 503 for a large tree sweep still in progress |
 | Copy | `await client.copy(src, dst)` |
 | Rename | `await client.rename(old, new)` |
 | Mkdir | `await client.mkdir(path, mode?)` |

--- a/clients/drive9-js/src/client.ts
+++ b/clients/drive9-js/src/client.ts
@@ -130,8 +130,22 @@ const DOWNLOAD_DIR_CONCURRENCY = 16;
 // continues where it left off.
 const REMOVE_ALL_MAX_RETRIES = 4;
 
+// REMOVE_ALL_MAX_RETRY_DELAY_MS caps the delay honored from a Retry-After
+// header so a pathological value (e.g. Retry-After: 999999) cannot block the
+// caller for days.
+const REMOVE_ALL_MAX_RETRY_DELAY_MS = 60_000;
+
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function removeAllRetryDelay(retryAfter: string, backoff: number): number {
+  if (/^\d+$/.test(retryAfter)) {
+    // Honoring 0 as an immediate retry is intentional: the server explicitly
+    // dictates the delay, and the loop is bounded to REMOVE_ALL_MAX_RETRIES + 1 requests.
+    return Math.min(Number(retryAfter) * 1000, REMOVE_ALL_MAX_RETRY_DELAY_MS);
+  }
+  return backoff;
 }
 
 interface Drive9Config {
@@ -257,7 +271,8 @@ export class Client {
 
   fsUrl(path: string): string {
     const p = path.startsWith("/") ? path : `/${path}`;
-    return `${this.baseUrl}/v1/fs${p}`;
+    const encodedPath = p.split("/").map((segment) => encodeURIComponent(segment)).join("/");
+    return `${this.baseUrl}/v1/fs${encodedPath}`;
   }
 
   vaultUrl(path: string): string {
@@ -533,11 +548,7 @@ export class Client {
         const retryAfter = (resp.headers.get("retry-after") || "").trim();
         // Consume and discard the body before retrying.
         await resp.text().catch(() => "");
-        let delay = backoff;
-        if (/^\d+$/.test(retryAfter)) {
-          delay = Number(retryAfter) * 1000;
-        }
-        await sleep(delay);
+        await sleep(removeAllRetryDelay(retryAfter, backoff));
         backoff *= 2;
         continue;
       }

--- a/clients/drive9-js/src/client.ts
+++ b/clients/drive9-js/src/client.ts
@@ -124,6 +124,16 @@ const DEFAULT_SMALL_FILE_THRESHOLD = 50_000;
 const DEFAULT_SERVER = "https://api.drive9.ai";
 const DOWNLOAD_DIR_CONCURRENCY = 16;
 
+// REMOVE_ALL_MAX_RETRIES bounds the 503 retry loop for recursive deletes. The
+// server answers 503 when a batched recursive delete exhausts its per-request
+// budget; the sweep is resumable and idempotent, so re-issuing the same DELETE
+// continues where it left off.
+const REMOVE_ALL_MAX_RETRIES = 4;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 interface Drive9Config {
   server?: string;
   current_context?: string;
@@ -515,8 +525,25 @@ export class Client {
   }
 
   async removeAll(path: string): Promise<void> {
-    const resp = await fetch(`${this.fsUrl(path)}?recursive=1`, { method: "DELETE", headers: this.authHeaders() });
-    await checkError(resp);
+    const url = `${this.fsUrl(path)}?recursive=1`;
+    let backoff = 1000;
+    for (let attempt = 0; ; attempt++) {
+      const resp = await fetch(url, { method: "DELETE", headers: this.authHeaders() });
+      if (resp.status === 503 && attempt < REMOVE_ALL_MAX_RETRIES) {
+        const retryAfter = (resp.headers.get("retry-after") || "").trim();
+        // Consume and discard the body before retrying.
+        await resp.text().catch(() => "");
+        let delay = backoff;
+        if (/^\d+$/.test(retryAfter)) {
+          delay = Number(retryAfter) * 1000;
+        }
+        await sleep(delay);
+        backoff *= 2;
+        continue;
+      }
+      await checkError(resp);
+      return;
+    }
   }
 
   async copy(srcPath: string, dstPath: string): Promise<void> {

--- a/clients/drive9-js/tests/remove_all.test.ts
+++ b/clients/drive9-js/tests/remove_all.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { Client, StatusError } from "../src/index.js";
 import { setupServer } from "msw/node";
 import { http, HttpResponse } from "msw";
@@ -80,5 +80,73 @@ describe("removeAll", () => {
     const client = new Client(BASE, "test-key");
     await expect(client.delete("/data/")).rejects.toBeInstanceOf(StatusError);
     expect(calls).toBe(1);
+  });
+
+  it("encodes ? and # in the path before appending recursive=1", async () => {
+    const seen: string[] = [];
+    server.use(
+      http.delete(`${BASE}/v1/fs/dir%3Fname`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("recursive")).toBe("1");
+        seen.push(url.pathname + url.search);
+        return HttpResponse.json({ status: "ok" });
+      }),
+      http.delete(`${BASE}/v1/fs/dir%23name`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("recursive")).toBe("1");
+        seen.push(url.pathname + url.search);
+        return HttpResponse.json({ status: "ok" });
+      })
+    );
+
+    const client = new Client(BASE, "test-key");
+    await client.removeAll("/dir?name");
+    await client.removeAll("/dir#name");
+
+    expect(seen).toEqual([
+      "/v1/fs/dir%3Fname?recursive=1",
+      "/v1/fs/dir%23name?recursive=1",
+    ]);
+  });
+
+  it("clamps a huge Retry-After to the max retry delay", async () => {
+    const realSetTimeout = globalThis.setTimeout;
+    let seenDelay = 0;
+    vi.stubGlobal(
+      "setTimeout",
+      ((...args: Parameters<typeof setTimeout>) => {
+        seenDelay = args[1] ?? 0;
+        return realSetTimeout(args[0], 0);
+      }) as typeof setTimeout
+    );
+    const fetchSpy = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: "recursive delete in progress, retry to resume" }), {
+          status: 503,
+          headers: { "Content-Type": "application/json", "Retry-After": "999999" },
+        })
+      )
+      .mockResolvedValueOnce(new Response(JSON.stringify({ status: "ok" }), { status: 200 }));
+
+    try {
+      const client = new Client(BASE, "test-key");
+      await client.removeAll("/data/");
+      expect(seenDelay).toBe(60_000);
+    } finally {
+      fetchSpy.mockRestore();
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("uses encoded paths for sibling deletes as well", async () => {
+    server.use(
+      http.delete(`${BASE}/v1/fs/dir%3Fname`, ({ request }) => {
+        expect(new URL(request.url).pathname).toBe("/v1/fs/dir%3Fname");
+        return HttpResponse.json({ status: "ok" });
+      })
+    );
+
+    const client = new Client(BASE, "test-key");
+    await client.delete("/dir?name");
   });
 });

--- a/clients/drive9-js/tests/remove_all.test.ts
+++ b/clients/drive9-js/tests/remove_all.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { Client, StatusError } from "../src/index.js";
+import { setupServer } from "msw/node";
+import { http, HttpResponse } from "msw";
+
+const server = setupServer();
+server.listen({ onUnhandledRequest: "error" });
+
+const BASE = "http://localhost:9009";
+
+describe("removeAll", () => {
+  it("retries on 503 honoring Retry-After and succeeds after the sweep resumes", async () => {
+    // Server answers 503, 503, then 200: removeAll must issue exactly 3
+    // requests and honor the Retry-After header (1s on the second response).
+    let calls = 0;
+    server.use(
+      http.delete(`${BASE}/v1/fs/data`, ({ request }) => {
+        const url = new URL(request.url);
+        expect(url.searchParams.get("recursive")).toBe("1");
+        calls++;
+        if (calls === 1) {
+          return new HttpResponse(JSON.stringify({ error: "recursive delete in progress, retry to resume" }), {
+            status: 503,
+            headers: { "Content-Type": "application/json", "Retry-After": "0" },
+          });
+        }
+        if (calls === 2) {
+          return new HttpResponse(JSON.stringify({ error: "recursive delete in progress, retry to resume" }), {
+            status: 503,
+            headers: { "Content-Type": "application/json", "Retry-After": "1" },
+          });
+        }
+        return HttpResponse.json({ status: "ok" });
+      })
+    );
+
+    const client = new Client(BASE, "test-key");
+    const start = Date.now();
+    await client.removeAll("/data/");
+    const elapsed = Date.now() - start;
+
+    expect(calls).toBe(3);
+    // The second 503 carried Retry-After: 1, so at least ~1s must have passed.
+    expect(elapsed).toBeGreaterThanOrEqual(900);
+  });
+
+  it("surfaces the last 503 after exhausting retries", async () => {
+    // Server always answers 503: removeAll must fail after 1 + 4 requests.
+    let calls = 0;
+    server.use(
+      http.delete(`${BASE}/v1/fs/data`, () => {
+        calls++;
+        return new HttpResponse(JSON.stringify({ error: "recursive delete in progress, retry to resume" }), {
+          status: 503,
+          headers: { "Content-Type": "application/json", "Retry-After": "0" },
+        });
+      })
+    );
+
+    const client = new Client(BASE, "test-key");
+    await expect(client.removeAll("/data/")).rejects.toMatchObject({
+      name: "StatusError",
+      statusCode: 503,
+    });
+    expect(calls).toBe(5);
+  });
+
+  it("does not retry non-recursive deletes on 503", async () => {
+    let calls = 0;
+    server.use(
+      http.delete(`${BASE}/v1/fs/data`, () => {
+        calls++;
+        return new HttpResponse(JSON.stringify({ error: "boom" }), {
+          status: 503,
+          headers: { "Content-Type": "application/json" },
+        });
+      })
+    );
+
+    const client = new Client(BASE, "test-key");
+    await expect(client.delete("/data/")).rejects.toBeInstanceOf(StatusError);
+    expect(calls).toBe(1);
+  });
+});

--- a/clients/drive9-kotlin/README.md
+++ b/clients/drive9-kotlin/README.md
@@ -19,6 +19,8 @@ require Rust, generated bindings, shared libraries, or a regeneration step.
 - `Drive9Client.defaultClient()`, `withSmallFileThreshold`, `baseUrl`, `apiKey`
 - `write`, `writeWithRevision`, `read`, `uploadFile`, `downloadFile`
 - `list`, `stat`, `delete`, `copy`, `rename`, `mkdir`
+- `removeAll` — recursive delete; automatically retries server 503 responses
+  (honoring `Retry-After`, bounded) while a large tree sweep is in progress
 - `grep`, `find`, `sql`
 - `downloadFlow`, `downloadRangeFlow`, `uploadFlow`
 - `newStreamUpload` / `Drive9StreamUpload` for v2 multipart stream upload

--- a/clients/drive9-kotlin/lib/src/main/kotlin/com/drive9/mobile/Drive9.kt
+++ b/clients/drive9-kotlin/lib/src/main/kotlin/com/drive9/mobile/Drive9.kt
@@ -1,6 +1,7 @@
 package com.drive9.mobile
 
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
@@ -40,6 +41,11 @@ import javax.net.ssl.SSLSocketFactory
 
 private const val DEFAULT_SMALL_FILE_THRESHOLD = 50_000L
 private const val DEFAULT_PART_SIZE = 8L * 1024L * 1024L
+
+// Bounds the 503 retry loop for recursive deletes. The server answers 503
+// when a batched recursive delete exhausts its per-request budget; the sweep
+// is resumable and idempotent, so re-issuing the same DELETE continues it.
+private const val REMOVE_ALL_MAX_RETRIES = 4
 
 /** Idiomatic Kotlin Drive9 client implemented with platform-native HTTP. */
 public class Drive9Client(
@@ -135,6 +141,40 @@ public class Drive9Client(
 
     public suspend fun delete(path: String): Unit = withContext(Dispatchers.IO) {
         request("DELETE", fsUrl(path)).close()
+    }
+
+    /**
+     * Removes a file or directory tree recursively.
+     *
+     * A large tree delete may exceed the server's per-request budget; the
+     * server then answers 503 and this method retries with backoff (honoring
+     * Retry-After, at most [REMOVE_ALL_MAX_RETRIES] times). Retrying is safe:
+     * the server-side sweep is resumable and idempotent, so a repeated DELETE
+     * continues where it left off.
+     */
+    public suspend fun removeAll(path: String): Unit = withContext(Dispatchers.IO) {
+        val url = "${fsUrl(path)}?recursive=1"
+        var backoffMs = 1_000L
+        var attempt = 0
+        while (true) {
+            val conn = open("DELETE", url)
+            try {
+                val status = conn.responseCode
+                if (status == HttpURLConnection.HTTP_UNAVAILABLE && attempt < REMOVE_ALL_MAX_RETRIES) {
+                    val retryAfterSecs = conn.getHeaderField("Retry-After")?.trim()?.toLongOrNull()
+                    val delayMs = if (retryAfterSecs != null && retryAfterSecs >= 0) retryAfterSecs * 1_000 else backoffMs
+                    backoffMs *= 2
+                    attempt++
+                    conn.disconnect()
+                    delay(delayMs)
+                    continue
+                }
+                if (status !in 200..299) throw errorFrom(conn, status)
+                return@withContext
+            } finally {
+                conn.disconnect()
+            }
+        }
     }
 
     public suspend fun copy(srcPath: String, dstPath: String): Unit = withContext(Dispatchers.IO) {

--- a/clients/drive9-kotlin/lib/src/main/kotlin/com/drive9/mobile/Drive9.kt
+++ b/clients/drive9-kotlin/lib/src/main/kotlin/com/drive9/mobile/Drive9.kt
@@ -47,6 +47,11 @@ private const val DEFAULT_PART_SIZE = 8L * 1024L * 1024L
 // is resumable and idempotent, so re-issuing the same DELETE continues it.
 private const val REMOVE_ALL_MAX_RETRIES = 4
 
+// REMOVE_ALL_MAX_RETRY_DELAY_SECS caps the delay honored from a Retry-After
+// header so a pathological value (e.g. Retry-After: 999999) cannot block the
+// caller for days.
+private const val REMOVE_ALL_MAX_RETRY_DELAY_SECS = 60L
+
 /** Idiomatic Kotlin Drive9 client implemented with platform-native HTTP. */
 public class Drive9Client(
     baseUrl: String,
@@ -158,24 +163,25 @@ public class Drive9Client(
         var attempt = 0
         while (true) {
             val conn = open("DELETE", url)
+            var retryDelayMs: Long? = null
             try {
                 val status = conn.responseCode
                 if (status == HttpURLConnection.HTTP_UNAVAILABLE && attempt < REMOVE_ALL_MAX_RETRIES) {
                     val retryAfterSecs = conn.getHeaderField("Retry-After")?.trim()?.toLongOrNull()
-                    val delayMs = if (retryAfterSecs != null && retryAfterSecs >= 0) retryAfterSecs * 1_000 else backoffMs
+                    retryDelayMs = removeAllRetryDelayMs(retryAfterSecs, backoffMs)
                     backoffMs *= 2
                     attempt++
                     // Drain the 503 body so the underlying connection can be
                     // reused for the retry instead of being discarded.
                     conn.errorStream?.use { it.readBytes() }
-                    delay(delayMs)
-                    continue
+                } else {
+                    if (status !in 200..299) throw errorFrom(conn, status)
+                    return@withContext
                 }
-                if (status !in 200..299) throw errorFrom(conn, status)
-                return@withContext
             } finally {
                 conn.disconnect()
             }
+            retryDelayMs?.let { delay(it) }
         }
     }
 
@@ -1289,6 +1295,20 @@ private fun urlEncode(value: String): String =
 
 private fun pathEncode(value: String): String =
     value.split('/').joinToString("/") { urlEncode(it) }
+
+/**
+ * Decides the sleep before the next recursive-delete retry. A valid
+ * non-negative Retry-After value (integer delta-seconds) is honored and
+ * clamped to REMOVE_ALL_MAX_RETRY_DELAY_SECS; honoring 0 as an immediate
+ * retry is intentional (the retry loop is bounded). A missing or unparseable
+ * header falls back to the passed exponential backoff.
+ */
+internal fun removeAllRetryDelayMs(retryAfterSecs: Long?, backoffMs: Long): Long {
+    if (retryAfterSecs != null && retryAfterSecs >= 0) {
+        return minOf(retryAfterSecs, REMOVE_ALL_MAX_RETRY_DELAY_SECS) * 1_000L
+    }
+    return backoffMs
+}
 
 private fun checkCancel(token: Drive9CancelToken?) {
     if (token?.isCancelled() == true) {

--- a/clients/drive9-kotlin/lib/src/main/kotlin/com/drive9/mobile/Drive9.kt
+++ b/clients/drive9-kotlin/lib/src/main/kotlin/com/drive9/mobile/Drive9.kt
@@ -165,7 +165,9 @@ public class Drive9Client(
                     val delayMs = if (retryAfterSecs != null && retryAfterSecs >= 0) retryAfterSecs * 1_000 else backoffMs
                     backoffMs *= 2
                     attempt++
-                    conn.disconnect()
+                    // Drain the 503 body so the underlying connection can be
+                    // reused for the retry instead of being discarded.
+                    conn.errorStream?.use { it.readBytes() }
                     delay(delayMs)
                     continue
                 }

--- a/clients/drive9-kotlin/lib/src/test/kotlin/com/drive9/mobile/Drive9Test.kt
+++ b/clients/drive9-kotlin/lib/src/test/kotlin/com/drive9/mobile/Drive9Test.kt
@@ -150,6 +150,53 @@ class Drive9Test {
     }
 
     @Test
+    fun removeAllRetries503ThenSucceeds() = runBlocking {
+        var hits = 0
+        route("DELETE", "/v1/fs/tree/?recursive=1") { ex ->
+            hits++
+            if (hits < 3) {
+                val body = """{"error":"recursive delete in progress, retry to resume"}"""
+                    .toByteArray(StandardCharsets.UTF_8)
+                ex.responseHeaders.add("Content-Type", "application/json")
+                ex.responseHeaders.add("Retry-After", "0")
+                ex.sendResponseHeaders(503, body.size.toLong())
+                ex.responseBody.write(body)
+                ex.close()
+            } else {
+                ex.sendResponseHeaders(200, -1)
+                ex.close()
+            }
+        }
+
+        val client = Drive9Client(baseUrl, "k")
+        client.removeAll("/tree/")
+        assertEquals(3, hits)
+    }
+
+    @Test
+    fun removeAllGivesUpAfterBoundedRetries() = runBlocking {
+        var hits = 0
+        route("DELETE", "/v1/fs/tree/?recursive=1") { ex ->
+            hits++
+            val body = """{"error":"recursive delete in progress, retry to resume"}"""
+                .toByteArray(StandardCharsets.UTF_8)
+            ex.responseHeaders.add("Content-Type", "application/json")
+            ex.responseHeaders.add("Retry-After", "0")
+            ex.sendResponseHeaders(503, body.size.toLong())
+            ex.responseBody.write(body)
+            ex.close()
+        }
+
+        val client = Drive9Client(baseUrl, "k")
+        val err = assertFailsWith<Drive9Exception.Drive9> {
+            client.removeAll("/tree/")
+        }
+        assertEquals(503, err.statusCode)
+        // 1 initial request + REMOVE_ALL_MAX_RETRIES (4) retries.
+        assertEquals(5, hits)
+    }
+
+    @Test
     fun conflictPreservesServerRevision() = runBlocking {
         route("PUT", "/v1/fs/r.txt") { ex ->
             ex.requestBody.readBytes()

--- a/clients/drive9-kotlin/lib/src/test/kotlin/com/drive9/mobile/Drive9Test.kt
+++ b/clients/drive9-kotlin/lib/src/test/kotlin/com/drive9/mobile/Drive9Test.kt
@@ -197,6 +197,14 @@ class Drive9Test {
     }
 
     @Test
+    fun removeAllRetryDelayClampsHugeRetryAfter() {
+        assertEquals(60_000L, removeAllRetryDelayMs(999_999L, 1_000L))
+        assertEquals(0L, removeAllRetryDelayMs(0L, 1_000L))
+        assertEquals(2_000L, removeAllRetryDelayMs(2L, 1_000L))
+        assertEquals(1_000L, removeAllRetryDelayMs(null, 1_000L))
+    }
+
+    @Test
     fun conflictPreservesServerRevision() = runBlocking {
         route("PUT", "/v1/fs/r.txt") { ex ->
             ex.requestBody.readBytes()

--- a/clients/drive9-py/README.md
+++ b/clients/drive9-py/README.md
@@ -35,6 +35,10 @@ client.copy("/src.txt", "/dst.txt")
 client.rename("/old.txt", "/new.txt")
 client.delete("/tmp.txt")
 
+# Recursive delete (retries automatically with backoff if the server
+# answers 503 while sweeping a large tree)
+client.remove_all("/mydir")
+
 # SQL query
 rows = client.sql('SELECT * FROM files WHERE path = "/hello.txt"')
 

--- a/clients/drive9-py/drive9/client.py
+++ b/clients/drive9-py/drive9/client.py
@@ -232,6 +232,9 @@ class Client(TransferMixin, PatchMixin):
                             delay = secs
                     except ValueError:
                         pass
+                # Release the connection back to the pool before sleeping;
+                # requests only returns it once the body is consumed/closed.
+                resp.close()
                 time.sleep(delay)
                 backoff *= 2
                 attempt += 1

--- a/clients/drive9-py/drive9/client.py
+++ b/clients/drive9-py/drive9/client.py
@@ -25,6 +25,37 @@ def _parse_iso_datetime(s: str) -> datetime:
 # continues where it left off.
 _REMOVE_ALL_MAX_RETRIES = 4
 
+# _REMOVE_ALL_MAX_RETRY_DELAY caps the delay honored from a Retry-After header
+# so a pathological value (e.g. Retry-After: 999999) cannot block the caller
+# for days.
+_REMOVE_ALL_MAX_RETRY_DELAY = 60.0
+
+
+def _remove_all_retry_delay(retry_after: Optional[str], backoff: float) -> float:
+    """Decide the sleep before the next recursive-delete retry.
+
+    A valid Retry-After header (integer delta-seconds) is honored, clamped to
+    _REMOVE_ALL_MAX_RETRY_DELAY; honoring 0 as an immediate retry is
+    intentional — the server dictates the delay and the retry loop is bounded
+    to _REMOVE_ALL_MAX_RETRIES + 1 requests. A missing, unparseable, or
+    negative header falls back to the passed exponential backoff.
+    """
+    if retry_after is not None:
+        try:
+            secs = int(retry_after.strip())
+            if secs >= 0:
+                return min(float(secs), _REMOVE_ALL_MAX_RETRY_DELAY)
+        except ValueError:
+            pass
+    return backoff
+
+
+def _encode_fs_path(path: str) -> str:
+    """Percent-encode each segment of a drive9 path, preserving slashes."""
+    if not path.startswith("/"):
+        path = "/" + path
+    return "/".join(quote(segment, safe="") for segment in path.split("/"))
+
 
 class Client(TransferMixin, PatchMixin):
     """The Drive9 HTTP client."""
@@ -78,9 +109,7 @@ class Client(TransferMixin, PatchMixin):
             self.session.mount("https://", adapter)
 
     def _url(self, path: str) -> str:
-        if not path.startswith("/"):
-            path = "/" + path
-        return f"{self.base_url}/v1/fs{path}"
+        return f"{self.base_url}/v1/fs{_encode_fs_path(path)}"
 
     def _vault_url(self, path: str) -> str:
         if not path.startswith("/"):
@@ -223,17 +252,9 @@ class Client(TransferMixin, PatchMixin):
         while True:
             resp = self._request("DELETE", url)
             if resp.status_code == 503 and attempt < _REMOVE_ALL_MAX_RETRIES:
-                delay = backoff
-                retry_after = resp.headers.get("Retry-After")
-                if retry_after is not None:
-                    try:
-                        secs = int(retry_after.strip())
-                        if secs >= 0:
-                            delay = secs
-                    except ValueError:
-                        pass
-                # Release the connection back to the pool before sleeping;
-                # requests only returns it once the body is consumed/closed.
+                delay = _remove_all_retry_delay(resp.headers.get("Retry-After"), backoff)
+                # Close the response before sleeping so the connection is not
+                # held open for the whole backoff.
                 resp.close()
                 time.sleep(delay)
                 backoff *= 2

--- a/clients/drive9-py/drive9/client.py
+++ b/clients/drive9-py/drive9/client.py
@@ -44,7 +44,9 @@ def _remove_all_retry_delay(retry_after: Optional[str], backoff: float) -> float
         try:
             secs = int(retry_after.strip())
             if secs >= 0:
-                return min(float(secs), _REMOVE_ALL_MAX_RETRY_DELAY)
+                # Clamp in the integer domain first: float() can raise
+                # OverflowError for valid ints with hundreds of digits.
+                return float(min(secs, int(_REMOVE_ALL_MAX_RETRY_DELAY)))
         except ValueError:
             pass
     return backoff

--- a/clients/drive9-py/drive9/client.py
+++ b/clients/drive9-py/drive9/client.py
@@ -1,5 +1,6 @@
 """Drive9 HTTP client."""
 
+import time
 from datetime import datetime
 from typing import Optional
 from urllib.parse import urlencode, quote
@@ -16,6 +17,13 @@ from .stream import StreamWriter
 def _parse_iso_datetime(s: str) -> datetime:
     """Parse ISO8601 datetime, handling Z suffix for Python < 3.11."""
     return datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+# _REMOVE_ALL_MAX_RETRIES bounds the 503 retry loop for recursive deletes. The
+# server answers 503 when a batched recursive delete exhausts its per-request
+# budget; the sweep is resumable and idempotent, so re-issuing the same DELETE
+# continues where it left off.
+_REMOVE_ALL_MAX_RETRIES = 4
 
 
 class Client(TransferMixin, PatchMixin):
@@ -199,6 +207,37 @@ class Client(TransferMixin, PatchMixin):
         """Remove a file or directory."""
         resp = self._request("DELETE", self._url(path))
         self._check_error(resp)
+
+    def remove_all(self, path: str) -> None:
+        """Remove a file or directory tree recursively.
+
+        A large tree delete may exceed the server's per-request budget; the
+        server then answers 503 (with an optional Retry-After header) and this
+        method retries with backoff, at most _REMOVE_ALL_MAX_RETRIES times.
+        Retrying is safe: the server-side sweep is resumable and idempotent,
+        so a repeated DELETE continues where it left off.
+        """
+        url = self._url(path) + "?recursive=1"
+        backoff = 1.0
+        attempt = 0
+        while True:
+            resp = self._request("DELETE", url)
+            if resp.status_code == 503 and attempt < _REMOVE_ALL_MAX_RETRIES:
+                delay = backoff
+                retry_after = resp.headers.get("Retry-After")
+                if retry_after is not None:
+                    try:
+                        secs = int(retry_after.strip())
+                        if secs >= 0:
+                            delay = secs
+                    except ValueError:
+                        pass
+                time.sleep(delay)
+                backoff *= 2
+                attempt += 1
+                continue
+            self._check_error(resp)
+            return
 
     def copy(self, src_path: str, dst_path: str) -> None:
         """Perform a server-side zero-copy."""

--- a/clients/drive9-py/tests/test_client.py
+++ b/clients/drive9-py/tests/test_client.py
@@ -97,6 +97,69 @@ def test_delete(client):
 
 
 @responses.activate
+def test_remove_all(client):
+    responses.add(
+        responses.DELETE,
+        f"{BASE_URL}/v1/fs/dir?recursive=1",
+        status=200,
+    )
+    client.remove_all("/dir")
+    assert len(responses.calls) == 1
+
+
+@responses.activate
+def test_remove_all_retries_on_503_then_succeeds(client):
+    url = f"{BASE_URL}/v1/fs/dir?recursive=1"
+    for _ in range(2):
+        responses.add(
+            responses.DELETE,
+            url,
+            json={"error": "recursive delete in progress, retry to resume"},
+            status=503,
+            headers={"Retry-After": "0"},
+        )
+    responses.add(responses.DELETE, url, status=200)
+
+    client.remove_all("/dir")
+
+    assert len(responses.calls) == 3
+    for call in responses.calls:
+        assert call.request.url == url
+
+
+@responses.activate
+def test_remove_all_gives_up_after_max_retries(client):
+    url = f"{BASE_URL}/v1/fs/dir?recursive=1"
+    responses.add(
+        responses.DELETE,
+        url,
+        json={"error": "recursive delete in progress, retry to resume"},
+        status=503,
+        headers={"Retry-After": "0"},
+    )
+
+    with pytest.raises(Drive9Error) as exc_info:
+        client.remove_all("/dir")
+
+    assert exc_info.value.status_code == 503
+    # 1 initial attempt + _REMOVE_ALL_MAX_RETRIES retries.
+    assert len(responses.calls) == 5
+
+
+@responses.activate
+def test_remove_all_missing_retry_after_uses_backoff(client):
+    url = f"{BASE_URL}/v1/fs/dir?recursive=1"
+    responses.add(responses.DELETE, url, status=503)  # no Retry-After header
+    responses.add(responses.DELETE, url, status=200)
+
+    with mock.patch("drive9.client.time.sleep") as sleep:
+        client.remove_all("/dir")
+
+    sleep.assert_called_once_with(1.0)
+    assert len(responses.calls) == 2
+
+
+@responses.activate
 def test_copy(client):
     responses.add(
         responses.POST,

--- a/clients/drive9-py/tests/test_client.py
+++ b/clients/drive9-py/tests/test_client.py
@@ -179,6 +179,25 @@ def test_remove_all_large_retry_after_is_clamped(client):
 
 
 @responses.activate
+def test_remove_all_overflow_retry_after_is_clamped(client):
+    url = f"{BASE_URL}/v1/fs/dir?recursive=1"
+    responses.add(
+        responses.DELETE,
+        url,
+        json={"error": "recursive delete in progress, retry to resume"},
+        status=503,
+        headers={"Retry-After": "9" * 400},
+    )
+    responses.add(responses.DELETE, url, status=200)
+
+    with mock.patch("drive9.client.time.sleep") as sleep:
+        client.remove_all("/dir")
+
+    sleep.assert_called_once_with(60.0)
+    assert len(responses.calls) == 2
+
+
+@responses.activate
 def test_remove_all_encodes_query_and_fragment_in_path(client):
     urls = [
         f"{BASE_URL}/v1/fs/dir%3Fname?recursive=1",

--- a/clients/drive9-py/tests/test_client.py
+++ b/clients/drive9-py/tests/test_client.py
@@ -160,6 +160,55 @@ def test_remove_all_missing_retry_after_uses_backoff(client):
 
 
 @responses.activate
+def test_remove_all_large_retry_after_is_clamped(client):
+    url = f"{BASE_URL}/v1/fs/dir?recursive=1"
+    responses.add(
+        responses.DELETE,
+        url,
+        json={"error": "recursive delete in progress, retry to resume"},
+        status=503,
+        headers={"Retry-After": "999999"},
+    )
+    responses.add(responses.DELETE, url, status=200)
+
+    with mock.patch("drive9.client.time.sleep") as sleep:
+        client.remove_all("/dir")
+
+    sleep.assert_called_once_with(60.0)
+    assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_remove_all_encodes_query_and_fragment_in_path(client):
+    urls = [
+        f"{BASE_URL}/v1/fs/dir%3Fname?recursive=1",
+        f"{BASE_URL}/v1/fs/dir%23name?recursive=1",
+    ]
+    for url in urls:
+        responses.add(responses.DELETE, url, status=200)
+
+    client.remove_all("/dir?name")
+    client.remove_all("/dir#name")
+
+    assert [call.request.url for call in responses.calls] == urls
+
+
+@responses.activate
+def test_delete_encodes_query_and_fragment_in_path(client):
+    urls = [
+        f"{BASE_URL}/v1/fs/dir%3Fname",
+        f"{BASE_URL}/v1/fs/dir%23name",
+    ]
+    for url in urls:
+        responses.add(responses.DELETE, url, status=200)
+
+    client.delete("/dir?name")
+    client.delete("/dir#name")
+
+    assert [call.request.url for call in responses.calls] == urls
+
+
+@responses.activate
 def test_copy(client):
     responses.add(
         responses.POST,

--- a/clients/drive9-py/tests/test_e2e.py
+++ b/clients/drive9-py/tests/test_e2e.py
@@ -47,7 +47,7 @@ def prefix(client):
     yield p
     # best-effort cleanup
     try:
-        client.delete(p.rstrip("/") + "?recursive")
+        client.remove_all(p.rstrip("/"))
     except Exception:
         pass
 

--- a/clients/drive9-py/tests/test_integration.py
+++ b/clients/drive9-py/tests/test_integration.py
@@ -58,7 +58,7 @@ def prefix(client):
     client.mkdir(p.rstrip("/"))
     yield p
     try:
-        client.delete(p.rstrip("/") + "?recursive")
+        client.remove_all(p.rstrip("/"))
     except Exception:
         pass
 

--- a/clients/drive9-rs/README.md
+++ b/clients/drive9-rs/README.md
@@ -78,6 +78,7 @@ Environment variables `DRIVE9_SERVER` and `DRIVE9_API_KEY` override values from 
 | List directory | `client.list(path).await` |
 | Stat | `client.stat(path).await` |
 | Delete | `client.delete(path).await` |
+| Recursive delete | `client.remove_all(path).await` (retries automatically on 503 while the server sweeps a large tree) |
 | Copy | `client.copy(src, dst).await` |
 | Rename | `client.rename(old, new).await` |
 | Mkdir | `client.mkdir(path).await` |

--- a/clients/drive9-rs/README.md
+++ b/clients/drive9-rs/README.md
@@ -86,6 +86,10 @@ Environment variables `DRIVE9_SERVER` and `DRIVE9_API_KEY` override values from 
 | Grep | `client.grep(query, prefix, limit).await` |
 | Find | `client.find(prefix, params).await` |
 
+The client attaches `Authorization` only when the base URL is HTTPS or an
+HTTP loopback address (`127.0.0.1`, `localhost`, `::1`); credentials are
+omitted for other plain-HTTP origins.
+
 ### Streaming & multipart
 
 | Operation | Method |

--- a/clients/drive9-rs/examples/basic.rs
+++ b/clients/drive9-rs/examples/basic.rs
@@ -18,7 +18,10 @@ async fn main() -> Result<(), drive9::Drive9Error> {
 
     // Stat the file
     let info = client.stat(path).await?;
-    println!("Stat: size={} revision={} is_dir={}", info.size, info.revision, info.is_dir);
+    println!(
+        "Stat: size={} revision={} is_dir={}",
+        info.size, info.revision, info.is_dir
+    );
 
     // List directory
     let entries = client.list("/examples/").await?;
@@ -28,12 +31,16 @@ async fn main() -> Result<(), drive9::Drive9Error> {
     }
 
     // Conditional write
-    client.write_with_revision(path, b"updated content", info.revision).await?;
+    client
+        .write_with_revision(path, b"updated content", info.revision)
+        .await?;
     println!("Conditional write succeeded");
 
     // Copy and rename
     client.copy(path, "/examples/hello-copy.txt").await?;
-    client.rename("/examples/hello-copy.txt", "/examples/hello-moved.txt").await?;
+    client
+        .rename("/examples/hello-copy.txt", "/examples/hello-moved.txt")
+        .await?;
 
     // Clean up
     client.delete(path).await?;

--- a/clients/drive9-rs/examples/vault.rs
+++ b/clients/drive9-rs/examples/vault.rs
@@ -21,7 +21,10 @@ async fn main() -> Result<(), drive9::Drive9Error> {
     println!("Read secret: {:?}", secret);
 
     // Read a single field
-    if let Ok(field) = client.read_vault_secret_field(secret_name, "password").await {
+    if let Ok(field) = client
+        .read_vault_secret_field(secret_name, "password")
+        .await
+    {
         println!("Password field: {}", field);
     }
 

--- a/clients/drive9-rs/src/client.rs
+++ b/clients/drive9-rs/src/client.rs
@@ -14,6 +14,40 @@ const DEFAULT_SMALL_FILE_THRESHOLD: i64 = 50_000;
 /// re-issuing the same DELETE continues where it left off.
 const REMOVE_ALL_MAX_RETRIES: u32 = 4;
 
+/// Caps the delay honored from a Retry-After header so a pathological value
+/// (e.g. Retry-After: 999999) cannot block the caller for days.
+const REMOVE_ALL_MAX_RETRY_DELAY_SECS: u64 = 60;
+
+/// Percent-encode each segment of a drive9 path, preserving separators, so
+/// characters such as `?` and `#` cannot be reinterpreted as URL delimiters.
+fn encoded_fs_path(path: &str) -> String {
+    let normalized = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+    normalized
+        .split('/')
+        .map(|segment| urlencoding::encode(segment).into_owned())
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+/// Decide the sleep before the next recursive-delete retry. A valid
+/// non-negative Retry-After value (integer delta-seconds) is honored and
+/// clamped to REMOVE_ALL_MAX_RETRY_DELAY_SECS; honoring 0 as an immediate
+/// retry is intentional (the retry loop is bounded). A missing or unparseable
+/// header falls back to the passed exponential backoff.
+fn remove_all_retry_delay(
+    retry_after: Option<&str>,
+    backoff: std::time::Duration,
+) -> std::time::Duration {
+    match retry_after.and_then(|v| v.trim().parse::<u64>().ok()) {
+        Some(secs) => std::time::Duration::from_secs(secs.min(REMOVE_ALL_MAX_RETRY_DELAY_SECS)),
+        None => backoff,
+    }
+}
+
 fn load_config_file() -> Option<(String, Option<String>)> {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
@@ -40,14 +74,15 @@ fn load_config_file() -> Option<(String, Option<String>)> {
 }
 
 fn load_config() -> (String, Option<String>) {
-    let env_server = std::env::var("DRIVE9_SERVER").ok().filter(|s| !s.is_empty());
-    let env_key = std::env::var("DRIVE9_API_KEY").ok().filter(|s| !s.is_empty());
-    let (file_server, file_key) = load_config_file()
-        .unwrap_or_else(|| ("https://api.drive9.ai".to_string(), None));
-    (
-        env_server.unwrap_or(file_server),
-        env_key.or(file_key),
-    )
+    let env_server = std::env::var("DRIVE9_SERVER")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let env_key = std::env::var("DRIVE9_API_KEY")
+        .ok()
+        .filter(|s| !s.is_empty());
+    let (file_server, file_key) =
+        load_config_file().unwrap_or_else(|| ("https://api.drive9.ai".to_string(), None));
+    (env_server.unwrap_or(file_server), env_key.or(file_key))
 }
 
 #[derive(Clone, Debug)]
@@ -106,12 +141,7 @@ impl Client {
     }
 
     pub(crate) fn fs_url(&self, path: &str) -> String {
-        let p = if path.starts_with('/') {
-            path
-        } else {
-            &format!("/{}", path)
-        };
-        format!("{}/v1/fs{}", self.base_url, p)
+        format!("{}/v1/fs{}", self.base_url, encoded_fs_path(path))
     }
 
     pub(crate) fn vault_url(&self, path: &str) -> String {
@@ -267,15 +297,14 @@ impl Client {
             if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE
                 && attempt < REMOVE_ALL_MAX_RETRIES
             {
-                let delay = resp
-                    .headers()
-                    .get(reqwest::header::RETRY_AFTER)
-                    .and_then(|v| v.to_str().ok())
-                    .and_then(|v| v.trim().parse::<u64>().ok())
-                    .map(std::time::Duration::from_secs)
-                    .unwrap_or(backoff);
-                // Release the connection before sleeping so it is returned to
-                // the pool instead of being held for the whole backoff.
+                let delay = remove_all_retry_delay(
+                    resp.headers()
+                        .get(reqwest::header::RETRY_AFTER)
+                        .and_then(|v| v.to_str().ok()),
+                    backoff,
+                );
+                // Release the response before sleeping so the connection is
+                // not held open for the whole backoff.
                 drop(resp);
                 tokio::time::sleep(delay).await;
                 backoff *= 2;
@@ -404,5 +433,38 @@ impl Client {
             total_size,
             expected_revision,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encoded_fs_path_escapes_query_and_fragment_delimiters() {
+        assert_eq!(encoded_fs_path("/dir?name"), "/dir%3Fname");
+        assert_eq!(encoded_fs_path("/dir#name"), "/dir%23name");
+        assert_eq!(encoded_fs_path("dir?name"), "/dir%3Fname");
+        assert_eq!(encoded_fs_path("/a b/c"), "/a%20b/c");
+    }
+
+    #[test]
+    fn remove_all_retry_delay_clamps_huge_retry_after() {
+        assert_eq!(
+            remove_all_retry_delay(Some("999999"), std::time::Duration::from_secs(1)),
+            std::time::Duration::from_secs(REMOVE_ALL_MAX_RETRY_DELAY_SECS)
+        );
+        assert_eq!(
+            remove_all_retry_delay(Some("0"), std::time::Duration::from_secs(1)),
+            std::time::Duration::ZERO
+        );
+        assert_eq!(
+            remove_all_retry_delay(Some("2"), std::time::Duration::from_secs(1)),
+            std::time::Duration::from_secs(2)
+        );
+        assert_eq!(
+            remove_all_retry_delay(None, std::time::Duration::from_secs(4)),
+            std::time::Duration::from_secs(4)
+        );
     }
 }

--- a/clients/drive9-rs/src/client.rs
+++ b/clients/drive9-rs/src/client.rs
@@ -8,6 +8,12 @@ use std::collections::HashMap;
 
 const DEFAULT_SMALL_FILE_THRESHOLD: i64 = 50_000;
 
+/// Bounds the 503 retry loop for recursive deletes. The server answers 503
+/// with a Retry-After header when a batched recursive delete exhausts its
+/// transaction/time budget; the sweep is resumable and idempotent, so
+/// re-issuing the same DELETE continues where it left off.
+const REMOVE_ALL_MAX_RETRIES: u32 = 4;
+
 fn load_config_file() -> Option<(String, Option<String>)> {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
@@ -237,6 +243,45 @@ impl Client {
             .await?;
         check_error(resp).await?;
         Ok(())
+    }
+
+    /// Remove a file or directory tree recursively via `DELETE ?recursive=1`.
+    ///
+    /// A large tree delete may exceed the server's per-request budget; the
+    /// server then answers 503 and this method retries with backoff (honoring
+    /// Retry-After, at most REMOVE_ALL_MAX_RETRIES times). Retrying is safe:
+    /// the server-side sweep is resumable and idempotent, so a repeated DELETE
+    /// continues it.
+    pub async fn remove_all(&self, path: &str) -> Result<(), Drive9Error> {
+        // Use an explicit value to avoid intermediaries dropping bare "?recursive".
+        let url = format!("{}?recursive=1", self.fs_url(path));
+        let mut backoff = std::time::Duration::from_secs(1);
+        let mut attempt: u32 = 0;
+        loop {
+            let resp = self
+                .http
+                .delete(&url)
+                .headers(self.auth_headers())
+                .send()
+                .await?;
+            if resp.status() == reqwest::StatusCode::SERVICE_UNAVAILABLE
+                && attempt < REMOVE_ALL_MAX_RETRIES
+            {
+                let delay = resp
+                    .headers()
+                    .get(reqwest::header::RETRY_AFTER)
+                    .and_then(|v| v.to_str().ok())
+                    .and_then(|v| v.trim().parse::<u64>().ok())
+                    .map(std::time::Duration::from_secs)
+                    .unwrap_or(backoff);
+                tokio::time::sleep(delay).await;
+                backoff *= 2;
+                attempt += 1;
+                continue;
+            }
+            check_error(resp).await?;
+            return Ok(());
+        }
     }
 
     pub async fn copy(&self, src_path: &str, dst_path: &str) -> Result<(), Drive9Error> {

--- a/clients/drive9-rs/src/client.rs
+++ b/clients/drive9-rs/src/client.rs
@@ -274,6 +274,9 @@ impl Client {
                     .and_then(|v| v.trim().parse::<u64>().ok())
                     .map(std::time::Duration::from_secs)
                     .unwrap_or(backoff);
+                // Release the connection before sleeping so it is returned to
+                // the pool instead of being held for the whole backoff.
+                drop(resp);
                 tokio::time::sleep(delay).await;
                 backoff *= 2;
                 attempt += 1;

--- a/clients/drive9-rs/src/client.rs
+++ b/clients/drive9-rs/src/client.rs
@@ -48,6 +48,24 @@ fn remove_all_retry_delay(
     }
 }
 
+/// Returns true when a bearer token may be attached to a request targeting
+/// `base_url`: HTTPS is always allowed, plain HTTP only for loopback hosts.
+fn can_send_credentials(base_url: &str) -> bool {
+    let Ok(url) = url::Url::parse(base_url) else {
+        return false;
+    };
+    if url.scheme() == "https" {
+        return true;
+    }
+    if url.scheme() != "http" {
+        return false;
+    }
+    matches!(
+        url.host_str(),
+        Some("127.0.0.1" | "localhost" | "::1" | "[::1]")
+    )
+}
+
 fn load_config_file() -> Option<(String, Option<String>)> {
     let home = std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
@@ -155,9 +173,11 @@ impl Client {
 
     pub(crate) fn auth_headers(&self) -> HeaderMap {
         let mut h = HeaderMap::new();
-        if let Some(ref key) = self.api_key {
-            if let Ok(v) = HeaderValue::from_str(&format!("Bearer {}", key)) {
-                h.insert("Authorization", v);
+        if can_send_credentials(&self.base_url) {
+            if let Some(ref key) = self.api_key {
+                if let Ok(v) = HeaderValue::from_str(&format!("Bearer {}", key)) {
+                    h.insert("Authorization", v);
+                }
             }
         }
         h
@@ -466,5 +486,26 @@ mod tests {
             remove_all_retry_delay(None, std::time::Duration::from_secs(4)),
             std::time::Duration::from_secs(4)
         );
+    }
+
+    #[test]
+    fn can_send_credentials_allows_https_and_loopback_http() {
+        assert!(can_send_credentials("https://api.drive9.ai"));
+        assert!(can_send_credentials("http://127.0.0.1:9009"));
+        assert!(can_send_credentials("http://localhost:9009"));
+        assert!(!can_send_credentials("http://example.com"));
+        assert!(!can_send_credentials(""));
+    }
+
+    #[test]
+    fn auth_headers_omit_bearer_on_non_loopback_http() {
+        let https = Client::new("https://api.drive9.ai", "k");
+        assert!(https.auth_headers().contains_key("Authorization"));
+
+        let loopback = Client::new("http://127.0.0.1:9009", "k");
+        assert!(loopback.auth_headers().contains_key("Authorization"));
+
+        let insecure = Client::new("http://example.com", "k");
+        assert!(!insecure.auth_headers().contains_key("Authorization"));
     }
 }

--- a/clients/drive9-rs/src/error.rs
+++ b/clients/drive9-rs/src/error.rs
@@ -42,7 +42,11 @@ pub(crate) async fn check_error(resp: reqwest::Response) -> Result<reqwest::Resp
         })
         .or_else(|| {
             let text = String::from_utf8_lossy(&bytes).trim().to_string();
-            if text.is_empty() { None } else { Some(text) }
+            if text.is_empty() {
+                None
+            } else {
+                Some(text)
+            }
         })
         .unwrap_or_else(|| format!("HTTP {}", status.as_u16()));
     if status == StatusCode::CONFLICT {

--- a/clients/drive9-rs/src/transfer.rs
+++ b/clients/drive9-rs/src/transfer.rs
@@ -206,9 +206,10 @@ impl Client {
         let status = resp.status();
         if status.as_u16() == 206 {
             let stream = resp.bytes_stream();
-            let reader = StreamReader::new(stream.map(|item| {
-                item.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
-            }));
+            let reader =
+                StreamReader::new(stream.map(|item| {
+                    item.map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+                }));
             return Ok(Box::new(reader));
         }
         if status.as_u16() == 416 {

--- a/clients/drive9-rs/tests/integration.rs
+++ b/clients/drive9-rs/tests/integration.rs
@@ -226,7 +226,12 @@ async fn integration_streaming() {
 
     // write_stream_conditional
     let _ = c
-        .write_stream_conditional(&format!("{}cond.bin", p), seekable(sdata.clone()), sdata.len() as i64, -1)
+        .write_stream_conditional(
+            &format!("{}cond.bin", p),
+            seekable(sdata.clone()),
+            sdata.len() as i64,
+            -1,
+        )
         .await
         .unwrap();
 
@@ -244,9 +249,7 @@ async fn integration_streaming() {
     assert_eq!(head.len(), 10);
 
     // resume_upload (best-effort)
-    let _ = c
-        .resume_upload(&large, seekable(ldata.clone()), size)
-        .await;
+    let _ = c.resume_upload(&large, seekable(ldata.clone()), size).await;
 
     cleanup_prefix(&p).await;
 }
@@ -327,7 +330,10 @@ async fn integration_vault() {
     let sec = match c.create_vault_secret(&sec_name, &fields).await {
         Ok(s) => s,
         Err(e) => {
-            eprintln!("create_vault_secret (best-effort, local server may not enable vault): {:?}", e);
+            eprintln!(
+                "create_vault_secret (best-effort, local server may not enable vault): {:?}",
+                e
+            );
             return;
         }
     };
@@ -345,7 +351,10 @@ async fn integration_vault() {
 
     // issue / revoke vault token (best-effort)
     let scope = vec![format!("secret:{}", sec_name)];
-    if let Ok(vt) = c.issue_vault_token("it-rs-agent", "it-rs-task", &scope, 60).await {
+    if let Ok(vt) = c
+        .issue_vault_token("it-rs-agent", "it-rs-task", &scope, 60)
+        .await
+    {
         assert!(!vt.token.is_empty());
         let _ = c.revoke_vault_token(&vt.token_id).await;
     }

--- a/clients/drive9-rs/tests/integration.rs
+++ b/clients/drive9-rs/tests/integration.rs
@@ -80,21 +80,7 @@ fn rand_suffix() -> u64 {
 
 async fn cleanup_prefix(p: &str) {
     let c = make_client();
-    let key = match c.api_key() {
-        Some(k) => k.to_string(),
-        None => return,
-    };
-    let url = format!(
-        "{}/v1/fs{}?recursive=1",
-        base(),
-        p.trim_end_matches('/')
-    );
-    // The Rust SDK does not expose RemoveAll, so issue a raw recursive DELETE.
-    let _ = reqwest::Client::new()
-        .delete(&url)
-        .header("Authorization", format!("Bearer {}", key))
-        .send()
-        .await;
+    let _ = c.remove_all(p).await;
 }
 
 // Helpers to build a Box<dyn SeekableReader> from a Vec<u8>.

--- a/clients/drive9-rs/tests/test_client.rs
+++ b/clients/drive9-rs/tests/test_client.rs
@@ -2,6 +2,9 @@ use base64::Engine;
 use drive9::{Client, Drive9Error};
 use mockito::Matcher;
 use sha2::{Digest, Sha256};
+use std::io::{Read as _, Write as _};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 #[tokio::test]
 async fn test_write_and_read() {
@@ -213,4 +216,75 @@ async fn test_patch_file_respects_presigned_checksum_header() {
         )
         .await
         .unwrap();
+}
+
+/// Spin up a tiny one-request-per-connection HTTP server that answers DELETE
+/// with the given status sequence (the last status repeats once the sequence
+/// is exhausted). 503 responses carry `Retry-After: 0` to keep tests fast.
+/// Returns the base URL and a shared counter of requests received.
+fn spawn_status_sequence_server(statuses: Vec<u16>) -> (String, Arc<AtomicUsize>) {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_bg = hits.clone();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { break };
+            let idx = hits_bg.fetch_add(1, Ordering::SeqCst);
+            let mut buf = Vec::new();
+            let mut byte = [0u8; 1];
+            loop {
+                if stream.read(&mut byte).unwrap_or(0) == 0 {
+                    break;
+                }
+                buf.push(byte[0]);
+                if buf.ends_with(b"\r\n\r\n") {
+                    break;
+                }
+            }
+            let status = statuses
+                .get(idx)
+                .copied()
+                .unwrap_or_else(|| *statuses.last().unwrap());
+            let (status_line, body, extra) = if status == 503 {
+                (
+                    "503 Service Unavailable",
+                    r#"{"error":"recursive delete in progress, retry to resume"}"#,
+                    "Retry-After: 0\r\n",
+                )
+            } else {
+                ("200 OK", "", "")
+            };
+            let resp = format!(
+                "HTTP/1.1 {}\r\nContent-Type: application/json\r\n{}Content-Length: {}\r\nConnection: close\r\n\r\n{}",
+                status_line,
+                extra,
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(resp.as_bytes());
+        }
+    });
+    (format!("http://127.0.0.1:{}", port), hits)
+}
+
+#[tokio::test]
+async fn test_remove_all_retries_503_then_succeeds() {
+    let (url, hits) = spawn_status_sequence_server(vec![503, 503, 200]);
+    let client = Client::new(url, "test-key");
+    client.remove_all("/big-tree/").await.unwrap();
+    assert_eq!(hits.load(Ordering::SeqCst), 3);
+}
+
+#[tokio::test]
+async fn test_remove_all_gives_up_after_max_retries() {
+    let (url, hits) = spawn_status_sequence_server(vec![503]);
+    let client = Client::new(url, "test-key");
+    let err = client.remove_all("/big-tree/").await.unwrap_err();
+    match err {
+        Drive9Error::Status { status_code, .. } => assert_eq!(status_code, 503),
+        _ => panic!("expected Status error, got {:?}", err),
+    }
+    // 1 initial attempt + REMOVE_ALL_MAX_RETRIES (4) retries.
+    assert_eq!(hits.load(Ordering::SeqCst), 5);
 }

--- a/clients/drive9-rs/tests/test_client.rs
+++ b/clients/drive9-rs/tests/test_client.rs
@@ -221,14 +221,19 @@ async fn test_patch_file_respects_presigned_checksum_header() {
 /// Spin up a tiny one-request-per-connection HTTP server that answers DELETE
 /// with the given status sequence (the last status repeats once the sequence
 /// is exhausted). 503 responses carry `Retry-After: 0` to keep tests fast.
-/// Returns the base URL and a shared counter of requests received.
-fn spawn_status_sequence_server(statuses: Vec<u16>) -> (String, Arc<AtomicUsize>) {
+/// The listener thread exits after `max_requests` connections so tests do not
+/// leak a blocked thread. Returns the base URL and a shared counter of
+/// requests received.
+fn spawn_status_sequence_server(
+    statuses: Vec<u16>,
+    max_requests: usize,
+) -> (String, Arc<AtomicUsize>) {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let port = listener.local_addr().unwrap().port();
     let hits = Arc::new(AtomicUsize::new(0));
     let hits_bg = hits.clone();
     std::thread::spawn(move || {
-        for stream in listener.incoming() {
+        for stream in listener.incoming().take(max_requests) {
             let Ok(mut stream) = stream else { break };
             let idx = hits_bg.fetch_add(1, Ordering::SeqCst);
             let mut buf = Vec::new();
@@ -270,7 +275,7 @@ fn spawn_status_sequence_server(statuses: Vec<u16>) -> (String, Arc<AtomicUsize>
 
 #[tokio::test]
 async fn test_remove_all_retries_503_then_succeeds() {
-    let (url, hits) = spawn_status_sequence_server(vec![503, 503, 200]);
+    let (url, hits) = spawn_status_sequence_server(vec![503, 503, 200], 3);
     let client = Client::new(url, "test-key");
     client.remove_all("/big-tree/").await.unwrap();
     assert_eq!(hits.load(Ordering::SeqCst), 3);
@@ -278,7 +283,7 @@ async fn test_remove_all_retries_503_then_succeeds() {
 
 #[tokio::test]
 async fn test_remove_all_gives_up_after_max_retries() {
-    let (url, hits) = spawn_status_sequence_server(vec![503]);
+    let (url, hits) = spawn_status_sequence_server(vec![503], 5);
     let client = Client::new(url, "test-key");
     let err = client.remove_all("/big-tree/").await.unwrap_err();
     match err {

--- a/clients/drive9-rs/tests/test_client.rs
+++ b/clients/drive9-rs/tests/test_client.rs
@@ -293,3 +293,28 @@ async fn test_remove_all_gives_up_after_max_retries() {
     // 1 initial attempt + REMOVE_ALL_MAX_RETRIES (4) retries.
     assert_eq!(hits.load(Ordering::SeqCst), 5);
 }
+
+#[tokio::test]
+async fn test_remove_all_encodes_query_and_fragment_in_path() {
+    let mut server = mockito::Server::new_async().await;
+    let _m1 = server
+        .mock("DELETE", "/v1/fs/dir%3Fname?recursive=1")
+        .with_status(200)
+        .create_async()
+        .await;
+    let _m2 = server
+        .mock("DELETE", "/v1/fs/dir%23name?recursive=1")
+        .with_status(200)
+        .create_async()
+        .await;
+    let _m3 = server
+        .mock("DELETE", "/v1/fs/dir%3Fname")
+        .with_status(200)
+        .create_async()
+        .await;
+
+    let client = Client::new(server.url(), "test-key");
+    client.remove_all("/dir?name").await.unwrap();
+    client.remove_all("/dir#name").await.unwrap();
+    client.delete("/dir?name").await.unwrap();
+}

--- a/clients/drive9-swift/README.md
+++ b/clients/drive9-swift/README.md
@@ -28,6 +28,9 @@ bindings, C interop, shared libraries, linker flags, or a regeneration step.
 
 `baseUrl` may include a trailing slash. If `apiKey` is non-empty, requests send
 `Authorization: Bearer <apiKey>`; an empty key sends no authorization header.
+The client refuses to send that token over non-loopback plain HTTP. Use
+`https://` for production endpoints; plain HTTP is accepted only for loopback
+endpoints such as `http://127.0.0.1:9009` used in local tests.
 
 ## Parity notes
 

--- a/clients/drive9-swift/README.md
+++ b/clients/drive9-swift/README.md
@@ -17,7 +17,9 @@ bindings, C interop, shared libraries, linker flags, or a regeneration step.
 - `Drive9Client(baseUrl, apiKey)`
 - `Drive9Client.defaultClient()`, `withSmallFileThreshold`, `baseUrl`, `apiKey`
 - `write`, `writeWithRevision`, `read`, `uploadFile`, `downloadFile`
-- `list`, `stat`, `delete`, `copy`, `rename`, `mkdir`
+- `list`, `stat`, `delete`, `removeAll`, `copy`, `rename`, `mkdir`
+  (`removeAll` issues `DELETE ?recursive=1` and automatically retries
+  resumable 503 responses, honoring `Retry-After`, up to 4 times)
 - `grep`, `find`, `sql`
 - `downloadStream`, `downloadRangeStream`, `uploadStream`
 - `newStreamUpload` / `Drive9StreamUpload` for v2 multipart stream upload

--- a/clients/drive9-swift/Sources/Drive9Mobile/Drive9.swift
+++ b/clients/drive9-swift/Sources/Drive9Mobile/Drive9.swift
@@ -6,6 +6,12 @@ import FoundationNetworking
 private let defaultSmallFileThreshold: Int64 = 50_000
 private let defaultPartSize: Int64 = 8 * 1024 * 1024
 
+// removeAllMaxRetries bounds the 503 retry loop for recursive deletes. The
+// server answers 503 when a batched recursive delete exhausts its per-request
+// budget; the sweep is resumable and idempotent, so re-issuing the same
+// DELETE continues where it left off.
+private let removeAllMaxRetries = 4
+
 public final class Drive9Client: @unchecked Sendable {
     private let baseUrlValue: String
     private let apiKeyValue: String?
@@ -96,6 +102,45 @@ public final class Drive9Client: @unchecked Sendable {
 
     public func delete(path: String) async throws {
         _ = try await send(makeRequest(method: "DELETE", url: fsUrl(path)))
+    }
+
+    /// Removes a file or directory tree recursively. A large tree delete may
+    /// exceed the server's per-request budget; the server then answers 503
+    /// (with an optional Retry-After header) and removeAll retries with
+    /// backoff, at most removeAllMaxRetries times. Retrying is safe: the
+    /// server-side sweep is resumable and idempotent, so a repeated DELETE
+    /// continues where it left off.
+    public func removeAll(path: String) async throws {
+        var components = URLComponents(url: fsUrl(path), resolvingAgainstBaseURL: false)!
+        components.queryItems = [URLQueryItem(name: "recursive", value: "1")]
+        let request = makeRequest(method: "DELETE", url: components.url!)
+
+        var backoffNs: UInt64 = 1_000_000_000 // 1s
+        for attempt in 0...removeAllMaxRetries {
+            let result: (Data, URLResponse)
+            do {
+                result = try await session.data(for: request)
+            } catch {
+                throw Drive9Exception.Drive9(code: "request", statusCode: nil, detail: error.localizedDescription, serverRevision: nil)
+            }
+            guard let http = result.1 as? HTTPURLResponse else {
+                throw Drive9Exception.Drive9(code: "request", statusCode: nil, detail: "non-HTTP response", serverRevision: nil)
+            }
+            if http.statusCode == 503 && attempt < removeAllMaxRetries {
+                var delayNs = backoffNs
+                if let raw = http.value(forHTTPHeaderField: "Retry-After"),
+                   let secs = Int(raw.trimmingCharacters(in: .whitespaces)), secs >= 0 {
+                    delayNs = UInt64(secs) * 1_000_000_000
+                }
+                try await Task.sleep(nanoseconds: delayNs)
+                backoffNs *= 2
+                continue
+            }
+            guard (200...299).contains(http.statusCode) else {
+                throw errorFrom(data: result.0, status: http.statusCode)
+            }
+            return
+        }
     }
 
     public func copy(srcPath: String, dstPath: String) async throws {

--- a/clients/drive9-swift/Sources/Drive9Mobile/Drive9.swift
+++ b/clients/drive9-swift/Sources/Drive9Mobile/Drive9.swift
@@ -12,6 +12,11 @@ private let defaultPartSize: Int64 = 8 * 1024 * 1024
 // DELETE continues where it left off.
 private let removeAllMaxRetries = 4
 
+// removeAllMaxRetryDelaySeconds caps the delay honored from a Retry-After
+// header so a pathological value (e.g. Retry-After: 999999) cannot block the
+// caller for days.
+private let removeAllMaxRetryDelaySeconds: UInt64 = 60
+
 public final class Drive9Client: @unchecked Sendable {
     private let baseUrlValue: String
     private let apiKeyValue: String?
@@ -117,6 +122,7 @@ public final class Drive9Client: @unchecked Sendable {
 
         var backoffNs: UInt64 = 1_000_000_000 // 1s
         for attempt in 0...removeAllMaxRetries {
+            try ensureRequestCredentialsAllowed(request)
             let result: (Data, URLResponse)
             do {
                 result = try await session.data(for: request)
@@ -127,11 +133,10 @@ public final class Drive9Client: @unchecked Sendable {
                 throw Drive9Exception.Drive9(code: "request", statusCode: nil, detail: "non-HTTP response", serverRevision: nil)
             }
             if http.statusCode == 503 && attempt < removeAllMaxRetries {
-                var delayNs = backoffNs
-                if let raw = http.value(forHTTPHeaderField: "Retry-After"),
-                   let secs = Int(raw.trimmingCharacters(in: .whitespaces)), secs >= 0 {
-                    delayNs = UInt64(secs) * 1_000_000_000
-                }
+                let delayNs = removeAllRetryDelayNs(
+                    retryAfter: http.value(forHTTPHeaderField: "Retry-After"),
+                    backoffNs: backoffNs
+                )
                 try await Task.sleep(nanoseconds: delayNs)
                 backoffNs *= 2
                 continue
@@ -708,7 +713,29 @@ public final class Drive9Client: @unchecked Sendable {
         return request
     }
 
+    func canSendCredentials(to url: URL) -> Bool {
+        guard let scheme = url.scheme?.lowercased() else { return false }
+        if scheme == "https" { return true }
+        guard scheme == "http", let host = url.host?.lowercased() else { return false }
+        return host == "127.0.0.1" || host == "localhost" || host == "::1" || host == "[::1]"
+    }
+
+    func ensureRequestCredentialsAllowed(_ request: URLRequest) throws {
+        guard request.value(forHTTPHeaderField: "Authorization") != nil,
+              let url = request.url,
+              !canSendCredentials(to: url) else {
+            return
+        }
+        throw Drive9Exception.Drive9(
+            code: "insecure_base_url",
+            statusCode: nil,
+            detail: "refusing to send bearer token to a non-HTTPS, non-loopback origin",
+            serverRevision: nil
+        )
+    }
+
     private func send(_ request: URLRequest, body: Data? = nil, accepted: ClosedRange<Int> = 200...299) async throws -> (data: Data, http: HTTPURLResponse) {
+        try ensureRequestCredentialsAllowed(request)
         do {
             let result: (Data, URLResponse)
             if let body {
@@ -856,6 +883,20 @@ public final class Drive9Client: @unchecked Sendable {
         normalizedPath(path).split(separator: "/", omittingEmptySubsequences: false)
             .map { String($0).addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? String($0) }
             .joined(separator: "/")
+    }
+
+    /// Decides the sleep before the next recursive-delete retry. A valid
+    /// non-negative Retry-After value (integer delta-seconds) is honored and
+    /// clamped to removeAllMaxRetryDelaySeconds; honoring 0 as an immediate
+    /// retry is intentional (the retry loop is bounded). A missing or
+    /// unparseable header falls back to the passed exponential backoff.
+    func removeAllRetryDelayNs(retryAfter: String?, backoffNs: UInt64) -> UInt64 {
+        if let raw = retryAfter,
+           let secs = Int(raw.trimmingCharacters(in: .whitespaces)),
+           secs >= 0 {
+            return min(UInt64(secs), removeAllMaxRetryDelaySeconds) * 1_000_000_000
+        }
+        return backoffNs
     }
 }
 

--- a/clients/drive9-swift/Tests/Drive9MobileTests/Drive9Tests.swift
+++ b/clients/drive9-swift/Tests/Drive9MobileTests/Drive9Tests.swift
@@ -12,6 +12,7 @@ final class HitCounter: @unchecked Sendable {
     private var count = 0
     private let lock = NSLock()
     func bump() { lock.lock(); count += 1; lock.unlock() }
+    func bumpAndGet() -> Int { lock.lock(); defer { lock.unlock() }; count += 1; return count }
     func get() -> Int { lock.lock(); defer { lock.unlock() }; return count }
 }
 
@@ -105,6 +106,57 @@ final class Drive9Tests: XCTestCase {
         try await client.copy(srcPath: "src.txt", dstPath: "/dst.txt")
         try await client.rename(oldPath: "/old.txt", newPath: "/new.txt")
         try await client.mkdir(path: "/dir/")
+    }
+
+    func testRemoveAllRetries503ThenSucceeds() async throws {
+        let hits = HitCounter()
+        server.routeAnyQuery("DELETE", "/v1/fs/dir/") { req in
+            XCTAssertEqual(req.query, "recursive=1")
+            let n = hits.bumpAndGet()
+            if n < 3 {
+                let body = #"{"error":"recursive delete in progress, retry to resume"}"#
+                return MockResponse(
+                    status: 503,
+                    body: Data(body.utf8),
+                    contentType: "application/json",
+                    extraHeaders: ["Retry-After": "0"]
+                )
+            }
+            return MockResponse(status: 200, body: Data())
+        }
+
+        let client = Drive9Client(baseUrl: server.baseURL, apiKey: "k")
+        try await client.removeAll(path: "/dir/")
+        XCTAssertEqual(hits.get(), 3)
+    }
+
+    func testRemoveAllGivesUpAfterMaxRetries() async throws {
+        let hits = HitCounter()
+        server.routeAnyQuery("DELETE", "/v1/fs/dir/") { req in
+            XCTAssertEqual(req.query, "recursive=1")
+            _ = hits.bumpAndGet()
+            let body = #"{"error":"recursive delete in progress, retry to resume"}"#
+            return MockResponse(
+                status: 503,
+                body: Data(body.utf8),
+                contentType: "application/json",
+                extraHeaders: ["Retry-After": "0"]
+            )
+        }
+
+        let client = Drive9Client(baseUrl: server.baseURL, apiKey: "k")
+        do {
+            try await client.removeAll(path: "/dir/")
+            XCTFail("expected removeAll to throw after retries exhausted")
+        } catch let error as Drive9Exception {
+            guard case let .Drive9(code, statusCode, _, _) = error else {
+                XCTFail("unexpected variant: \(error)")
+                return
+            }
+            XCTAssertEqual(code, "http_status")
+            XCTAssertEqual(statusCode, 503)
+        }
+        XCTAssertEqual(hits.get(), 5)
     }
 
     func testGrepReturnsSearchResultsWithEncodedQuery() async throws {

--- a/clients/drive9-swift/Tests/Drive9MobileTests/Drive9Tests.swift
+++ b/clients/drive9-swift/Tests/Drive9MobileTests/Drive9Tests.swift
@@ -1,3 +1,7 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 import XCTest
 @testable import Drive9Mobile
 

--- a/clients/drive9-swift/Tests/Drive9MobileTests/Drive9Tests.swift
+++ b/clients/drive9-swift/Tests/Drive9MobileTests/Drive9Tests.swift
@@ -159,6 +159,37 @@ final class Drive9Tests: XCTestCase {
         XCTAssertEqual(hits.get(), 5)
     }
 
+    func testRemoveAllRetryDelayClampsHugeRetryAfter() {
+        let client = Drive9Client(baseUrl: "http://127.0.0.1:1", apiKey: "k")
+        XCTAssertEqual(
+            client.removeAllRetryDelayNs(retryAfter: "999999", backoffNs: 1_000_000_000),
+            60_000_000_000
+        )
+        XCTAssertEqual(client.removeAllRetryDelayNs(retryAfter: "0", backoffNs: 1_000_000_000), 0)
+        XCTAssertEqual(client.removeAllRetryDelayNs(retryAfter: "2", backoffNs: 1_000_000_000), 2_000_000_000)
+        XCTAssertEqual(client.removeAllRetryDelayNs(retryAfter: nil, backoffNs: 2_000_000_000), 2_000_000_000)
+    }
+
+    func testBearerTokenOnlySentToHTTPSOrLoopbackHTTP() {
+        let client = Drive9Client(baseUrl: "http://example.com", apiKey: "k")
+        XCTAssertFalse(client.canSendCredentials(to: URL(string: "http://example.com/v1/fs/x")!))
+        XCTAssertTrue(client.canSendCredentials(to: URL(string: "https://api.drive9.ai/v1/fs/x")!))
+        XCTAssertTrue(client.canSendCredentials(to: URL(string: "http://127.0.0.1:9009/v1/fs/x")!))
+        XCTAssertTrue(client.canSendCredentials(to: URL(string: "http://localhost:9009/v1/fs/x")!))
+    }
+
+    func testInsecureHTTPWithBearerThrows() throws {
+        let client = Drive9Client(baseUrl: "http://example.com", apiKey: "k")
+
+        var request = URLRequest(url: URL(string: "http://example.com/v1/fs/x")!)
+        request.setValue("Bearer k", forHTTPHeaderField: "Authorization")
+        XCTAssertThrowsError(try client.ensureRequestCredentialsAllowed(request))
+
+        request = URLRequest(url: URL(string: "http://127.0.0.1:9009/v1/fs/x")!)
+        request.setValue("Bearer k", forHTTPHeaderField: "Authorization")
+        XCTAssertNoThrow(try client.ensureRequestCredentialsAllowed(request))
+    }
+
     func testGrepReturnsSearchResultsWithEncodedQuery() async throws {
         server.route("GET", "/v1/fs/?grep=hello%20world&limit=3") { _ in
             let body = #"[{"path":"/a.txt","name":"a.txt","size_bytes":7,"score":0.5}]"#

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1088,6 +1088,31 @@ func (c *Client) RemoveAllCtx(ctx context.Context, path string) error {
 // delete follow-up covers that case).
 const removeAllMaxRetries = 4
 
+// removeAllMaxRetryDelay caps the Retry-After value honored by the recursive
+// delete retry loop, so a bogus header (e.g. "999999") cannot park the client
+// for days. The exponential backoff fallback is already bounded by
+// removeAllMaxRetries and needs no cap.
+const removeAllMaxRetryDelay = 60 * time.Second
+
+// removeAllRetryDelay computes how long to wait before retrying a recursive
+// delete after a 503. A valid, non-negative Retry-After value (integer
+// delta-seconds) is honored, clamped to removeAllMaxRetryDelay; a missing or
+// invalid header falls back to the passed backoff.
+func removeAllRetryDelay(retryAfter string, backoff time.Duration) time.Duration {
+	if secs, err := strconv.Atoi(strings.TrimSpace(retryAfter)); err == nil && secs >= 0 {
+		// Honoring 0 as an immediate retry is intentional: the server
+		// explicitly dictates the delay, and the loop is bounded to
+		// 1 + removeAllMaxRetries requests.
+		// Clamp in seconds before converting so an absurd header cannot
+		// overflow the Duration multiplication and bypass the cap.
+		if secs > int(removeAllMaxRetryDelay/time.Second) {
+			secs = int(removeAllMaxRetryDelay / time.Second)
+		}
+		return time.Duration(secs) * time.Second
+	}
+	return backoff
+}
+
 func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kind string) error {
 	requestURL := c.url(path)
 	if recursive {
@@ -1108,13 +1133,9 @@ func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kin
 			return err
 		}
 		if recursive && resp.StatusCode == http.StatusServiceUnavailable && attempt < removeAllMaxRetries {
-			retryAfter := resp.Header.Get("Retry-After")
 			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
-			delay := backoff
-			if secs, perr := strconv.Atoi(strings.TrimSpace(retryAfter)); perr == nil && secs >= 0 {
-				delay = time.Duration(secs) * time.Second
-			}
+			delay := removeAllRetryDelay(resp.Header.Get("Retry-After"), backoff)
 			timer := time.NewTimer(delay)
 			select {
 			case <-ctx.Done():
@@ -1125,6 +1146,8 @@ func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kin
 			backoff *= 2
 			continue
 		}
+		// Retry branches close the body explicitly before continuing; this
+		// defer only covers the terminal iteration that returns from the loop.
 		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode >= 300 {
 			return readError(resp)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1080,7 +1080,9 @@ func (c *Client) RemoveAllCtx(ctx context.Context, path string) error {
 // removeAllMaxRetries bounds the 503 retry loop for recursive deletes. The
 // server answers 503 (ErrDeleteIncomplete) when a batched recursive delete
 // exhausts its transaction/time budget; the sweep is resumable and idempotent,
-// so re-issuing the same DELETE continues where it left off. Note this only
+// so re-issuing the same DELETE continues where it left off. The server-side
+// contract lives in tidbcloud/fs (https://github.com/tidbcloud/fs/pull/39);
+// ErrDeleteIncomplete is defined there, not in this repo. Note this only
 // helps when the server's budget trips before the gateway/client deadline —
 // a huge tree can still be cut off by an upstream timeout first (the async
 // delete follow-up covers that case).

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1069,9 +1069,22 @@ func (c *Client) RemoveAll(path string) error {
 // RemoveAllCtx removes a file or directory tree recursively with context support.
 // It forwards to deleteCtx with recursive=true, so regular files use Delete
 // semantics and missing paths return the same 404 *StatusError as RemoveAll.
+// A large tree delete may exceed the server's per-request budget; the server
+// then answers 503 and RemoveAllCtx retries with backoff (honoring Retry-After,
+// at most removeAllMaxRetries times). Retrying is safe: the server-side sweep
+// is resumable and idempotent, so a repeated DELETE continues it.
 func (c *Client) RemoveAllCtx(ctx context.Context, path string) error {
 	return c.deleteCtx(ctx, path, true, "")
 }
+
+// removeAllMaxRetries bounds the 503 retry loop for recursive deletes. The
+// server answers 503 (ErrDeleteIncomplete) when a batched recursive delete
+// exhausts its transaction/time budget; the sweep is resumable and idempotent,
+// so re-issuing the same DELETE continues where it left off. Note this only
+// helps when the server's budget trips before the gateway/client deadline —
+// a huge tree can still be cut off by an upstream timeout first (the async
+// delete follow-up covers that case).
+const removeAllMaxRetries = 4
 
 func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kind string) error {
 	requestURL := c.url(path)
@@ -1082,19 +1095,40 @@ func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kin
 		requestURL += "?kind=" + url.QueryEscape(kind)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
-	if err != nil {
-		return err
+	backoff := time.Second
+	for attempt := 0; ; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
+		if err != nil {
+			return err
+		}
+		resp, err := c.do(req)
+		if err != nil {
+			return err
+		}
+		if recursive && resp.StatusCode == http.StatusServiceUnavailable && attempt < removeAllMaxRetries {
+			retryAfter := resp.Header.Get("Retry-After")
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+			delay := backoff
+			if secs, perr := strconv.Atoi(strings.TrimSpace(retryAfter)); perr == nil && secs >= 0 {
+				delay = time.Duration(secs) * time.Second
+			}
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ctx.Err()
+			case <-timer.C:
+			}
+			backoff *= 2
+			continue
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode >= 300 {
+			return readError(resp)
+		}
+		return nil
 	}
-	resp, err := c.do(req)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode >= 300 {
-		return readError(resp)
-	}
-	return nil
 }
 
 // Copy performs a server-side zero-copy (same file_id, new path).

--- a/pkg/client/delete_retry_test.go
+++ b/pkg/client/delete_retry_test.go
@@ -1,0 +1,72 @@
+//go:build !integration
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// TestRemoveAllRetriesOn503 verifies the bounded retry loop around recursive
+// deletes: two 503 responses (honoring Retry-After) followed by a 200 must
+// surface as success, with exactly three requests issued.
+func TestRemoveAllRetriesOn503(t *testing.T) {
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodDelete || !strings.Contains(r.URL.RawQuery, "recursive=1") {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL)
+		}
+		switch n := calls.Add(1); n {
+		case 1:
+			w.Header().Set("Retry-After", "0")
+			w.WriteHeader(http.StatusServiceUnavailable)
+		case 2:
+			w.Header().Set("Retry-After", "1")
+			w.WriteHeader(http.StatusServiceUnavailable)
+		default:
+			_, _ = fmt.Fprint(w, `{"status":"ok"}`)
+		}
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	if err := c.RemoveAll("/data/"); err != nil {
+		t.Fatalf("RemoveAll: %v", err)
+	}
+	if got := calls.Load(); got != 3 {
+		t.Fatalf("requests = %d, want 3", got)
+	}
+}
+
+// TestRemoveAllRetryLimitExceeded verifies the retry loop is bounded: a server
+// that keeps answering 503 must surface the last 503 as an error after
+// 1 + removeAllMaxRetries requests.
+func TestRemoveAllRetryLimitExceeded(t *testing.T) {
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Retry-After", "0")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = fmt.Fprint(w, `{"error":"recursive delete in progress, retry to resume"}`)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	err := c.RemoveAll("/data/")
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	var se *StatusError
+	if !errors.As(err, &se) || se.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("error = %v, want 503 *StatusError", err)
+	}
+	if got, want := calls.Load(), int32(1+removeAllMaxRetries); got != want {
+		t.Fatalf("requests = %d, want %d", got, want)
+	}
+}

--- a/pkg/client/delete_retry_test.go
+++ b/pkg/client/delete_retry_test.go
@@ -3,6 +3,7 @@
 package client
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // TestRemoveAllRetriesOn503 verifies the bounded retry loop around recursive
@@ -68,5 +70,68 @@ func TestRemoveAllRetryLimitExceeded(t *testing.T) {
 	}
 	if got, want := calls.Load(), int32(1+removeAllMaxRetries); got != want {
 		t.Fatalf("requests = %d, want %d", got, want)
+	}
+}
+
+// TestDeleteDoesNotRetryOn503 verifies the 503 retry loop only applies to
+// recursive deletes: a plain (non-recursive) delete must surface the first
+// 503 immediately, without re-issuing the request.
+func TestDeleteDoesNotRetryOn503(t *testing.T) {
+	var calls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		if strings.Contains(r.URL.RawQuery, "recursive=1") {
+			t.Errorf("unexpected recursive query: %s", r.URL)
+		}
+		w.Header().Set("Retry-After", "0")
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer ts.Close()
+
+	c := New(ts.URL, "")
+	err := c.Delete("/data/file.txt")
+	var se *StatusError
+	if !errors.As(err, &se) || se.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("error = %v, want 503 *StatusError", err)
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1 (no retry for non-recursive delete)", got)
+	}
+}
+
+// TestRemoveAllCtxCancelDuringBackoff verifies that cancelling the context
+// while the retry loop is waiting out a Retry-After delay aborts the wait
+// immediately instead of sleeping through it.
+func TestRemoveAllCtxCancelDuringBackoff(t *testing.T) {
+	var calls atomic.Int32
+	responded := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		close(responded)
+	}))
+	defer ts.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := New(ts.URL, "")
+	done := make(chan error, 1)
+	go func() { done <- c.RemoveAllCtx(ctx, "/data/") }()
+
+	// Wait until the first 503 response is sent (the retry loop is now in its
+	// backoff wait), then cancel.
+	<-responded
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("error = %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("RemoveAllCtx did not return promptly after cancel")
+	}
+	if got := calls.Load(); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
 	}
 }

--- a/pkg/client/delete_retry_test.go
+++ b/pkg/client/delete_retry_test.go
@@ -99,6 +99,32 @@ func TestDeleteDoesNotRetryOn503(t *testing.T) {
 	}
 }
 
+// TestRemoveAllRetryDelayClampsRetryAfter verifies that a huge Retry-After
+// value is clamped to removeAllMaxRetryDelay instead of parking the client
+// for days, while normal and missing values keep their existing behavior.
+func TestRemoveAllRetryDelayClampsRetryAfter(t *testing.T) {
+	tests := []struct {
+		name       string
+		retryAfter string
+		backoff    time.Duration
+		want       time.Duration
+	}{
+		{name: "huge value is clamped", retryAfter: "999999", backoff: time.Second, want: removeAllMaxRetryDelay},
+		{name: "overflow-scale value is clamped before conversion", retryAfter: "10000000000", backoff: time.Second, want: removeAllMaxRetryDelay},
+		{name: "zero means immediate retry", retryAfter: "0", backoff: time.Second, want: 0},
+		{name: "small value is honored", retryAfter: "2", backoff: time.Second, want: 2 * time.Second},
+		{name: "missing header uses backoff", retryAfter: "", backoff: 2 * time.Second, want: 2 * time.Second},
+		{name: "invalid header uses backoff", retryAfter: "soon", backoff: 4 * time.Second, want: 4 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := removeAllRetryDelay(tt.retryAfter, tt.backoff); got != tt.want {
+				t.Fatalf("removeAllRetryDelay(%q, %v) = %v, want %v", tt.retryAfter, tt.backoff, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestRemoveAllCtxCancelDuringBackoff verifies that cancelling the context
 // while the retry loop is waiting out a Retry-After delay aborts the wait
 // immediately instead of sleeping through it.


### PR DESCRIPTION
## What

Ports the client side of [tidbcloud/fs#39](https://github.com/tidbcloud/fs/pull/39) (batched, race-aware recursive directory delete) into this repo, and aligns all language SDKs with the new server contract.

Server contract: a recursive delete (`DELETE /v1/fs{path}?recursive=1`) on a large tree may exhaust its per-request budget and answer **503 + `Retry-After: 2`** (`ErrDeleteIncomplete`). The server-side sweep is resumable and idempotent — re-issuing the same DELETE continues where it left off. Small trees still delete atomically in one request.

## Changes

- **pkg/client (Go)**: `RemoveAll`/`deleteCtx` retry 503 with exponential backoff (1s → 2s → 4s → 8s, honoring `Retry-After`, at most 4 retries) for recursive deletes only; ctx cancel aborts the backoff wait immediately. This also covers the CLI and FUSE, which both go through `pkg/client`.
- **clients/drive9-js**: same retry in `removeAll`.
- **clients/drive9-py / drive9-rs / drive9-swift / drive9-kotlin**: add `remove_all`/`removeAll` with the same retry semantics (these SDKs previously had no public recursive-delete API); retry loop releases the response/connection before sleeping so it returns to the pool.
- Unit tests in every SDK: 503→503→200 succeeds with exactly 3 requests; persistent 503 errors after exactly 5 requests; Go additionally covers non-recursive-no-retry and cancel-during-backoff.

## Compatibility

Old clients against the new server: no data risk. Large-tree deletes may surface a plain 503, but the partially-deleted tree stays consistent and re-issuing the same DELETE resumes the sweep (a server-side reconcile worker cleans up orphans regardless). Upgrading the client just makes the resume automatic.

## Testing

- Go: `pkg/client` retry tests pass (testcontainers/MySQL); `golangci-lint` clean.
- JS: `vitest` 72 passed (incl. new `remove_all.test.ts`, msw-based).
- Python: 51 unit tests pass (`responses`-mocked).
- Rust: 11 unit tests pass (local stub server); `cargo fmt` clean on touched files.
- Swift: 15 unit tests pass (existing MockHTTPServer).
- Kotlin: `:lib:test` 28 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added recursive deletion support across client libraries.
  * Recursive deletions retry temporary server-unavailable (503) responses up to four times.
  * Retries honor `Retry-After` guidance or use automatic backoff, improving reliability for large directory cleanups.
  * Retry delays are bounded, and cancellations remain responsive.
  * File paths containing query or fragment characters are encoded safely.
  * Swift bearer credentials are restricted to HTTPS or loopback HTTP.

* **Documentation**
  * Updated client documentation with recursive deletion usage and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->