### PR TITLE
fix: build migration image for target architecture

### DIFF
--- a/Dockerfile.migration
+++ b/Dockerfile.migration
@@ -2,8 +2,8 @@
 
 FROM --platform=$BUILDPLATFORM golang:1.25.1-bookworm AS builder
 
-ARG TARGETOS=linux
-ARG TARGETARCH=amd64
+ARG TARGETOS
+ARG TARGETARCH
 ARG VERSION=dev
 ARG GIT_HASH=unknown
 ARG GIT_BRANCH=unknown


### PR DESCRIPTION
## Summary

- Let BuildKit inject `TARGETOS` and `TARGETARCH` for the selected image platform.
- Ensure the ARM64 migration image contains an ARM64 binary.

## Root cause

`Dockerfile.migration` redeclared the automatic platform arguments with `amd64` defaults. The ARM64 build therefore compiled `drive9-migration` with `GOARCH=amd64`, and its native ARM64 smoke test failed with `exec format error`.

Failed run: https://github.com/mem9-ai/drive9/actions/runs/31374218634/job/93409753462

## Validation

- Built `drive9-migration` with `GOOS=linux GOARCH=arm64`.
- Confirmed the binary is a statically linked ARM aarch64 ELF.
- Confirmed Go build metadata reports `GOOS=linux` and `GOARCH=arm64`.
- `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration container builds by correctly honoring the target operating system and architecture supplied by the build environment.
  * Prevented builds from defaulting unexpectedly to Linux AMD64.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->