### PR TITLE
fix: support 64-byte layer identifiers

### DIFF
--- a/docs/design/layered-filesystem-v1-design.md
+++ b/docs/design/layered-filesystem-v1-design.md
@@ -236,6 +236,10 @@ fs_layer_checkpoints
 fs_layer_tags
 ```
 
+`layer_id` and `checkpoint_id` are UTF-8 strings limited to 64 bytes. A
+`layer_id` must not contain `:` because event IDs use `:` as their structural
+separator. Invalid identifiers are client errors and return HTTP 400.
+
 ### fs_layers
 
 `fs_layers` represents one agent session:
@@ -343,6 +347,9 @@ after_json
 idempotency_key
 created_at
 ```
+
+`event_id` is `VARCHAR(128)` so the longest valid 64-byte `layer_id` plus the
+rollback marker and sequence suffix always fits.
 
 ### fs_layer_checkpoints
 

--- a/pkg/datastore/fs_layer.go
+++ b/pkg/datastore/fs_layer.go
@@ -18,6 +18,7 @@ type FSLayerEntryKind string
 
 var ErrFSLayerRefAmbiguous = errors.New("fs layer ref is ambiguous")
 var ErrFSLayerStateConflict = errors.New("fs layer state conflict")
+var ErrFSLayerInvalidArgument = errors.New("invalid fs layer argument")
 
 const (
 	FSLayerStateActive     FSLayerState = "active"
@@ -41,6 +42,9 @@ const (
 	FSLayerEntryKindFile    FSLayerEntryKind = "file"
 	FSLayerEntryKindDir     FSLayerEntryKind = "dir"
 	FSLayerEntryKindSymlink FSLayerEntryKind = "symlink"
+
+	FSLayerIDMaxBytes           = 64
+	FSLayerCheckpointIDMaxBytes = 64
 
 	// fsLayerEventOpRollback is the synthetic event op emitted into
 	// fs_layer_events when a layer is rolled back. It lets mounted FUSE
@@ -117,19 +121,13 @@ func (s *Store) CreateFSLayer(ctx context.Context, layer *FSLayer) error {
 	}
 	layer.LayerID = strings.TrimSpace(layer.LayerID)
 	if layer.LayerID == "" {
-		return fmt.Errorf("fs layer id is required")
+		return fmt.Errorf("%w: layer_id is required", ErrFSLayerInvalidArgument)
 	}
-	// fs_layer_events.event_id is VARCHAR(64) PRIMARY KEY. Normal upsert
-	// event_ids use "<layerID>:<seq>"; rollback event_ids use
-	// "<layerID>:rollback:<seq>" (9 chars longer). A layer_id near 64
-	// chars would overflow the PK on rollback, and a layer_id containing
-	// ":" could collide with another layer's rollback event_id. Reject
-	// both here so all event_id formats always fit the schema.
-	if len(layer.LayerID) > 50 {
-		return fmt.Errorf("fs layer id too long (%d chars, max 50)", len(layer.LayerID))
+	if len(layer.LayerID) > FSLayerIDMaxBytes {
+		return fmt.Errorf("%w: layer_id exceeds %d bytes", ErrFSLayerInvalidArgument, FSLayerIDMaxBytes)
 	}
 	if strings.Contains(layer.LayerID, ":") {
-		return fmt.Errorf("fs layer id must not contain \":\"")
+		return fmt.Errorf("%w: layer_id must not contain \":\"", ErrFSLayerInvalidArgument)
 	}
 	root, err := pathutil.CanonicalizeDir(layer.BaseRootPath)
 	if err != nil {
@@ -752,10 +750,13 @@ func (s *Store) CreateFSLayerCheckpoint(ctx context.Context, checkpoint *FSLayer
 	checkpoint.CheckpointID = strings.TrimSpace(checkpoint.CheckpointID)
 	checkpoint.LayerID = strings.TrimSpace(checkpoint.LayerID)
 	if checkpoint.CheckpointID == "" {
-		return fmt.Errorf("fs layer checkpoint id is required")
+		return fmt.Errorf("%w: checkpoint_id is required", ErrFSLayerInvalidArgument)
+	}
+	if len(checkpoint.CheckpointID) > FSLayerCheckpointIDMaxBytes {
+		return fmt.Errorf("%w: checkpoint_id exceeds %d bytes", ErrFSLayerInvalidArgument, FSLayerCheckpointIDMaxBytes)
 	}
 	if checkpoint.LayerID == "" {
-		return fmt.Errorf("fs layer id is required")
+		return fmt.Errorf("%w: layer_id is required", ErrFSLayerInvalidArgument)
 	}
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {

--- a/pkg/datastore/fs_layer_test.go
+++ b/pkg/datastore/fs_layer_test.go
@@ -4,8 +4,67 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 	"testing"
 )
+
+func TestFSLayerIdentifierBoundaries(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+
+	for i, size := range []int{49, 50, 51, FSLayerIDMaxBytes} {
+		layerID := strings.Repeat(string(rune('a'+i)), size)
+		if err := s.CreateFSLayer(ctx, &FSLayer{LayerID: layerID, BaseRootPath: "/repo"}); err != nil {
+			t.Fatalf("CreateFSLayer %d bytes: %v", size, err)
+		}
+		if err := s.RollbackFSLayer(ctx, layerID); err != nil {
+			t.Fatalf("RollbackFSLayer %d bytes: %v", size, err)
+		}
+		events, err := s.ListFSLayerEvents(ctx, layerID, 0, 10)
+		if err != nil {
+			t.Fatalf("ListFSLayerEvents %d bytes: %v", size, err)
+		}
+		if len(events) != 1 || events[0].EventID != fmt.Sprintf("%s:rollback:1", layerID) {
+			t.Fatalf("events for %d-byte layer = %+v", size, events)
+		}
+	}
+
+	for _, layerID := range []string{
+		strings.Repeat("z", FSLayerIDMaxBytes+1),
+		strings.Repeat("界", 22),
+		"layer:invalid",
+	} {
+		err := s.CreateFSLayer(ctx, &FSLayer{LayerID: layerID, BaseRootPath: "/repo"})
+		if !errors.Is(err, ErrFSLayerInvalidArgument) {
+			t.Fatalf("CreateFSLayer %q err=%v, want ErrFSLayerInvalidArgument", layerID, err)
+		}
+	}
+}
+
+func TestFSLayerCheckpointIdentifierBoundaries(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	if err := s.CreateFSLayer(ctx, &FSLayer{LayerID: "layer-checkpoint-boundary", BaseRootPath: "/repo"}); err != nil {
+		t.Fatalf("CreateFSLayer: %v", err)
+	}
+
+	checkpointID := strings.Repeat("c", FSLayerCheckpointIDMaxBytes)
+	if err := s.CreateFSLayerCheckpoint(ctx, &FSLayerCheckpoint{
+		CheckpointID: checkpointID,
+		LayerID:      "layer-checkpoint-boundary",
+	}); err != nil {
+		t.Fatalf("CreateFSLayerCheckpoint %d bytes: %v", FSLayerCheckpointIDMaxBytes, err)
+	}
+
+	err := s.CreateFSLayerCheckpoint(ctx, &FSLayerCheckpoint{
+		CheckpointID: strings.Repeat("c", FSLayerCheckpointIDMaxBytes+1),
+		LayerID:      "layer-checkpoint-boundary",
+	})
+	if !errors.Is(err, ErrFSLayerInvalidArgument) {
+		t.Fatalf("CreateFSLayerCheckpoint oversized err=%v, want ErrFSLayerInvalidArgument", err)
+	}
+}
 
 func TestFSLayerRoundTripAndState(t *testing.T) {
 	s := newTestStore(t)

--- a/pkg/server/fs_layer.go
+++ b/pkg/server/fs_layer.go
@@ -1656,6 +1656,10 @@ func applyFSLayerEntryMode(ctx context.Context, b *backendpkg.Dat9Backend, path 
 }
 
 func writeFSLayerStoreError(w http.ResponseWriter, r *http.Request, err error) {
+	if errors.Is(err, datastore.ErrFSLayerInvalidArgument) {
+		errJSON(w, http.StatusBadRequest, err.Error())
+		return
+	}
 	if errors.Is(err, datastore.ErrNotFound) {
 		errJSON(w, http.StatusNotFound, "not found")
 		return

--- a/pkg/server/fs_layer_test.go
+++ b/pkg/server/fs_layer_test.go
@@ -47,6 +47,77 @@ func TestFSLayerRenameTargetPreservesSpaces(t *testing.T) {
 	}
 }
 
+func TestFSLayerAPIIdentifierBoundaries(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	ctx := context.Background()
+	c := client.New(ts.URL, "")
+	for i, size := range []int{49, 50, 51, datastore.FSLayerIDMaxBytes} {
+		layerID := strings.Repeat(string(rune('a'+i)), size)
+		layer, err := c.CreateFSLayer(ctx, client.FSLayerCreateRequest{
+			LayerID:      layerID,
+			BaseRootPath: "/repo",
+		})
+		if err != nil {
+			t.Fatalf("CreateFSLayer %d bytes: %v", size, err)
+		}
+		if layer.LayerID != layerID {
+			t.Fatalf("CreateFSLayer %d bytes returned id=%q", size, layer.LayerID)
+		}
+	}
+
+	auto, err := c.CreateFSLayer(ctx, client.FSLayerCreateRequest{BaseRootPath: "/repo"})
+	if err != nil {
+		t.Fatalf("CreateFSLayer generated id: %v", err)
+	}
+	if auto.LayerID == "" || len(auto.LayerID) > datastore.FSLayerIDMaxBytes {
+		t.Fatalf("generated layer id = %q", auto.LayerID)
+	}
+
+	for _, tt := range []struct {
+		name    string
+		layerID string
+		message string
+	}{
+		{name: "oversized", layerID: strings.Repeat("z", datastore.FSLayerIDMaxBytes+1), message: "layer_id exceeds 64 bytes"},
+		{name: "colon", layerID: "layer:invalid", message: `layer_id must not contain ":"`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := c.CreateFSLayer(ctx, client.FSLayerCreateRequest{LayerID: tt.layerID, BaseRootPath: "/repo"})
+			var statusErr *client.StatusError
+			if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusBadRequest {
+				t.Fatalf("CreateFSLayer err=%v, want HTTP 400", err)
+			}
+			if !strings.Contains(statusErr.Message, tt.message) {
+				t.Fatalf("CreateFSLayer message=%q, want %q", statusErr.Message, tt.message)
+			}
+		})
+	}
+
+	if _, err := c.CreateFSLayer(ctx, client.FSLayerCreateRequest{
+		LayerID:      "layer-checkpoint-boundary",
+		BaseRootPath: "/repo",
+	}); err != nil {
+		t.Fatalf("CreateFSLayer checkpoint boundary: %v", err)
+	}
+	checkpointID := strings.Repeat("c", datastore.FSLayerCheckpointIDMaxBytes)
+	if _, err := c.CheckpointFSLayer(ctx, "layer-checkpoint-boundary", client.FSLayerCheckpointRequest{CheckpointID: checkpointID}); err != nil {
+		t.Fatalf("CheckpointFSLayer %d bytes: %v", datastore.FSLayerCheckpointIDMaxBytes, err)
+	}
+	_, err = c.CheckpointFSLayer(ctx, "layer-checkpoint-boundary", client.FSLayerCheckpointRequest{
+		CheckpointID: strings.Repeat("c", datastore.FSLayerCheckpointIDMaxBytes+1),
+	})
+	var statusErr *client.StatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("CheckpointFSLayer oversized err=%v, want HTTP 400", err)
+	}
+	if !strings.Contains(statusErr.Message, "checkpoint_id exceeds 64 bytes") {
+		t.Fatalf("CheckpointFSLayer message=%q", statusErr.Message)
+	}
+}
+
 func TestFSLayerObjectPathPreservesTrailingControlWhitespace(t *testing.T) {
 	s := newTestServer(t)
 	ts := httptest.NewServer(s)

--- a/pkg/tenant/schema/fs_layer.go
+++ b/pkg/tenant/schema/fs_layer.go
@@ -63,7 +63,7 @@ func FSLayerTiDBSchemaStatements() []string {
 		`CREATE INDEX idx_fs_layer_entries_op ON fs_layer_entries(layer_id, op)`,
 
 		`CREATE TABLE IF NOT EXISTS fs_layer_events (
-			event_id        VARCHAR(64) PRIMARY KEY,
+			event_id        VARCHAR(128) NOT NULL,
 			layer_id        VARCHAR(64) NOT NULL,
 			seq             BIGINT NOT NULL,
 			actor_id        VARCHAR(255) NOT NULL DEFAULT '',
@@ -72,7 +72,8 @@ func FSLayerTiDBSchemaStatements() []string {
 			before_json     JSON,
 			after_json      JSON,
 			idempotency_key VARCHAR(255) NOT NULL DEFAULT '',
-			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3)
+			created_at      DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+			PRIMARY KEY (event_id)
 		)`,
 		`CREATE UNIQUE INDEX uk_fs_layer_events_seq ON fs_layer_events(layer_id, seq)`,
 		`CREATE INDEX idx_fs_layer_events_created ON fs_layer_events(layer_id, created_at)`,
@@ -150,7 +151,7 @@ func FSLayerDB9SchemaStatements() []string {
 		`CREATE INDEX IF NOT EXISTS idx_fs_layer_entries_op ON fs_layer_entries(layer_id, op)`,
 
 		`CREATE TABLE IF NOT EXISTS fs_layer_events (
-			event_id        VARCHAR(64) PRIMARY KEY,
+			event_id        VARCHAR(128) NOT NULL,
 			layer_id        VARCHAR(64) NOT NULL,
 			seq             BIGINT NOT NULL,
 			actor_id        VARCHAR(255) NOT NULL DEFAULT '',
@@ -159,8 +160,10 @@ func FSLayerDB9SchemaStatements() []string {
 			before_json     JSONB,
 			after_json      JSONB,
 			idempotency_key VARCHAR(255) NOT NULL DEFAULT '',
-			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+			created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+			PRIMARY KEY (event_id)
 		)`,
+		`ALTER TABLE IF EXISTS fs_layer_events ALTER COLUMN event_id TYPE VARCHAR(128)`,
 		`CREATE UNIQUE INDEX IF NOT EXISTS uk_fs_layer_events_seq ON fs_layer_events(layer_id, seq)`,
 		`CREATE INDEX IF NOT EXISTS idx_fs_layer_events_created ON fs_layer_events(layer_id, created_at)`,
 

--- a/pkg/tenant/schema/fs_layer_test.go
+++ b/pkg/tenant/schema/fs_layer_test.go
@@ -1,0 +1,52 @@
+package schema
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestFSLayerEventIDSchemaAndTiDBWideningRepair(t *testing.T) {
+	spec, err := tidbSchemaSpecFromStatements(FSLayerTiDBSchemaStatements())
+	if err != nil {
+		t.Fatalf("tidbSchemaSpecFromStatements: %v", err)
+	}
+	table := mustTableSpecFromSchemaSpec(t, spec, "fs_layer_events")
+	eventID := table.columns["event_id"]
+	if eventID.columnType != "varchar(128)" {
+		t.Fatalf("event_id column type=%q, want varchar(128)", eventID.columnType)
+	}
+	if eventID.modifySQL != "ALTER TABLE fs_layer_events MODIFY COLUMN event_id VARCHAR(128) NOT NULL" {
+		t.Fatalf("event_id modify SQL=%q", eventID.modifySQL)
+	}
+
+	diffs := []tidbSchemaDiff{{
+		kind:       tidbSchemaDiffColumnType,
+		tableName:  "fs_layer_events",
+		columnName: "event_id",
+		repairSQL:  eventID.modifySQL,
+	}}
+	repairs := plannedTiDBSchemaRepairs(diffs)
+	if len(repairs) != 1 || repairs[0] != eventID.modifySQL {
+		t.Fatalf("planned repairs=%#v, want event_id widening", repairs)
+	}
+}
+
+func TestFSLayerDB9SchemaIncludesEventIDWideningMigration(t *testing.T) {
+	var createFound bool
+	var migrationFound bool
+	for _, statement := range FSLayerDB9SchemaStatements() {
+		normalized := normalizeSQLFragment(statement)
+		if strings.HasPrefix(normalized, "create table if not exists fs_layer_events ") && strings.Contains(normalized, "event_id varchar(128) not null") {
+			createFound = true
+		}
+		if normalized == "alter table if exists fs_layer_events alter column event_id type varchar(128)" {
+			migrationFound = true
+		}
+	}
+	if !createFound {
+		t.Fatal("db9 fs_layer_events create statement does not use VARCHAR(128)")
+	}
+	if !migrationFound {
+		t.Fatal("db9 schema does not widen existing fs_layer_events.event_id")
+	}
+}

--- a/pkg/tenant/schema/tidb_auto.go
+++ b/pkg/tenant/schema/tidb_auto.go
@@ -2891,6 +2891,8 @@ func isSafeModifyColumnRepairSQL(diff tidbSchemaDiff) bool {
 		return n == "alter table uploads modify column target_path text not null"
 	case "fs_events.path":
 		return n == "alter table fs_events modify column path text not null"
+	case "fs_layer_events.event_id":
+		return n == "alter table fs_layer_events modify column event_id varchar(128) not null"
 	default:
 		return false
 	}


### PR DESCRIPTION
## Summary
- define the LayerFS `layer_id` and `checkpoint_id` contract as 64 UTF-8 bytes
- widen derived layer event IDs to `VARCHAR(128)` with TiDB/db9 migration coverage
- return HTTP 400 for oversized or structurally invalid identifiers instead of `500 backend unavailable`

## Validation
- `make lint`
- `go build ./...`
- `go vet ./pkg/datastore ./pkg/server ./pkg/tenant/schema ./cmd/drive9-server ./cmd/drive9-server-local`
- focused and full LayerFS datastore/server tests against a fresh local MySQL 8.4 instance
- full `pkg/tenant/schema` tests
- schema parser/planner regression plus direct old-`VARCHAR(64)` widening probe
- `git diff --check`

## Boundaries covered
- auto-generated, 49B, 50B, 51B, and 64B layer IDs succeed
- 65B and `:`-containing layer IDs return HTTP 400
- 64B checkpoint IDs succeed; 65B returns HTTP 400
- a 64B layer can emit its rollback event without overflowing `event_id`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Layer and checkpoint identifiers now support up to 64 UTF-8 bytes.
  * Added validation for required identifiers and disallowed characters.

* **Bug Fixes**
  * Invalid identifiers now return clear HTTP 400 errors.
  * Expanded event ID storage to support longer layer and rollback identifiers.
  * Added safe database schema migration support for existing installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->