### PR TITLE
feat: support ConfigMap-driven migration cutover

### DIFF
--- a/cmd/drive9-migration/main_test.go
+++ b/cmd/drive9-migration/main_test.go
@@ -143,6 +143,12 @@ func TestExecuteHelpAndPreflightFailure(t *testing.T) {
 	if code := execute([]string{"plan", "-f", "/config.yaml"}, io.Discard, io.Discard, deps); code != exitFailure {
 		t.Fatalf("preflight failure exit=%d", code)
 	}
+	deps.preflight = func(context.Context, *migration.Startup) (migration.PreflightResult, error) {
+		return migration.PreflightResult{}, errors.Join(migration.ErrPreflight, migration.ErrInvalidPhase)
+	}
+	if code := execute([]string{"run", "-f", "/config.yaml"}, io.Discard, io.Discard, deps); code != exitIllegalOperation {
+		t.Fatalf("illegal preflight phase exit=%d", code)
+	}
 }
 
 func TestExecuteUsesProvidedContextAndHelpDocumentsEveryCommand(t *testing.T) {

--- a/docs/design/drive9-migration-v1.md
+++ b/docs/design/drive9-migration-v1.md
@@ -120,7 +120,7 @@ Delete/Rename primitive is scope expansion.
 | `INV-03` | A Job never reads, verifies, mutates, or deletes business data outside its Target Prefix. |
 | `INV-04` | EBS remains Migration's authority through T2. The business remains EBS-primary for reads until the cutover fence is complete for every Job. |
 | `INV-05` | The only V1 phases are `SYNCING`, `DUAL_WRITE_REPAIRING`, and `CUTOVER_READY`. T1 is not a phase. |
-| `INV-06` | Phase changes are explicit. Conditions never advance a phase automatically. |
+| `INV-06` | Phase requests are explicit. A startup `CUTOVER_READY` request runs verification and the fence protocol; conditions never advance a phase by themselves. |
 | `INV-07` | From T0 onward, Migration never calls Drive9 Delete or Rename. |
 | `INV-08` | Create uses Must-Not-Exist/expected Revision 0. Update uses the exact observed positive Revision. A conflict never falls back to an unconditional write. |
 | `INV-09` | An incomplete source scan never implies deletion and never produces Delete work. |
@@ -200,7 +200,7 @@ entire Tenant/Space.
 
 ~~~text
 Operator-managed Kubernetes
-  ConfigMap snapshot + Secret Volume + DaemonSet rollout + kubectl exec
+  ConfigMap snapshot + Secret Volume + DaemonSet rollout + optional kubectl exec
                                    |
                                    v
                          drive9-migration
@@ -315,8 +315,11 @@ Configuration rules:
 
 1. ConfigMap changes are not hot-loaded. Every change requires a DaemonSet
    rollout restart.
-2. `phase` accepts only `SYNCING` or `DUAL_WRITE_REPAIRING`.
-   `CUTOVER_READY` is reachable only through the local fence command.
+2. `phase` accepts `SYNCING`, `DUAL_WRITE_REPAIRING`, or `CUTOVER_READY`.
+   `CUTOVER_READY` is a startup request, not proof that the actual phase has
+   changed. It requires an existing `DUAL_WRITE_REPAIRING` Checkpoint and runs a
+   new deep recovery, full verification, and the same fence protocol used by
+   `prepare-drive9-cutover`.
 3. By default, phase is read from the file named `phase` beside the `-f`
    configuration file. `DRIVE9_MIGRATION_PHASE` MAY replace that file at
    startup. Supplying both sources, or neither source, is an error. API keys
@@ -331,10 +334,14 @@ Configuration rules:
    and API-key values.
 8. A recovered Job whose static configuration or Source/Target identity differs
    from its Checkpoint fails closed.
-9. Repeating the current phase is idempotent. Requesting a phase lower than the
-   highest applied phase is rejected.
+9. Repeating the current phase is idempotent. Before fence intent, requesting a
+   phase lower than the highest applied phase is rejected. Fence state never
+   regresses, regardless of a later ConfigMap rollback.
 10. The shared ConfigMap phase is a batch-wide desired startup phase, but each
     Worker applies it independently during rollout.
+11. A configured `CUTOVER_READY` request does not directly update
+    `highest_phase`. Actual phase remains `DUAL_WRITE_REPAIRING` until durable
+    Fence Intent and Fence Complete succeed.
 
 ### 5.4 Credentials
 
@@ -403,17 +410,22 @@ startup
   |
   +-- configured DUAL_WRITE_REPAIRING --------> DUAL_WRITE_REPAIRING
                                                    |
-                                                   | prepare-drive9-cutover
+  +-- configured CUTOVER_READY --------------------+ startup recovery +
+                                                   | verify-full + fence
+                                                   |
+                                                   | or prepare-drive9-cutover
                                                    v
                                              CUTOVER_READY
 ~~~
 
 At startup, the Worker loads the minimal Checkpoint, validates monotonicity,
-then conditionally applies the configured non-regressing phase. It may report
-that actual phase while the mandatory deep recovery round is still running,
-but every convergence condition remains false until recovery succeeds.
+then conditionally applies the configured non-regressing phase. A configured
+`CUTOVER_READY` value is handled specially: the Checkpoint must already be at
+least `DUAL_WRITE_REPAIRING`; the Worker keeps that actual phase, completes deep
+recovery and a fresh full verification, and only then executes the fence
+protocol. Every convergence condition remains false until recovery succeeds.
 `ReadyForRollout` and `Attention` are not startup gates. There is no phase
-watcher and no automatic phase transition.
+watcher; ConfigMap changes require a rollout restart.
 
 If a durable fence intent exists, recovery may only finish fencing. It may not
 resume a writable phase.
@@ -460,7 +472,7 @@ Condition rules:
 | T0-T1 | Old Pods write EBS; new Pods write EBS and Drive9; EBS remains read authority | Complete the rolling business deployment | Fast rounds, grace, stable-source checks, conditional Create/Update; no Delete/Rename |
 | T1 | Every business Pod is externally confirmed dual-write | Record T1 outside Migration; invoke `verify-full` once per Job | Phase remains `DUAL_WRITE_REPAIRING`; serialize a full verification after the current fast Round |
 | T1-T2 | Business remains EBS-primary and dual-writes Drive9 | Observe per-Job status and diff; the external operator chooses duration and T2 | Continue fast repair after full verification |
-| T2 | Prepare Drive9-only writes | Invoke `prepare-drive9-cutover` per Job; wait until all Jobs are `CUTOVER_READY`; then switch the business | Permanently fence Migration writes |
+| T2 | Prepare Drive9-only writes | Set ConfigMap phase to `CUTOVER_READY` and rollout restart the Migration DaemonSet, or invoke `prepare-drive9-cutover` per Job; use the external kube plugin to wait until all Jobs are actually `CUTOVER_READY` with `fence_complete=true`; then switch the business | Run fresh startup recovery and verification for the ConfigMap path, then permanently fence Migration writes |
 
 Migration cannot detect whether all business Pods are dual-write, cannot select
 T1 or T2, and cannot aggregate a batch decision. DaemonSet rollout and per-Job
@@ -754,13 +766,23 @@ Execution:
 `full_verification.status` is one of `pending`, `running`, `passed`, or
 `failed` for the current process. An overlapping request is rejected and a
 duplicate call after completion returns the current result. Restart discards
-the request and result; after the mandatory startup recovery round, the
-operator must invoke `verify-full` again before cutover.
+the request and result. A normal `DUAL_WRITE_REPAIRING` restart requires the
+operator to invoke `verify-full` again; a configured `CUTOVER_READY` startup
+request runs a fresh verification automatically after deep recovery.
 
 A passed result covers data only through its completion time. It does not prove
 T1, encode an observation interval, or choose T2.
 
 ### 11.2 `prepare-drive9-cutover`
+
+The fence protocol has two triggers:
+
+1. `prepare-drive9-cutover` explicitly invokes it against the running Worker.
+2. A rollout with startup phase `CUTOVER_READY` first completes deep recovery
+   and a fresh full verification, then invokes the same protocol internally.
+
+The explicit command remains supported and idempotent after automatic
+completion.
 
 Per-Job preconditions:
 
@@ -770,7 +792,7 @@ Per-Job preconditions:
 4. Latest in-memory `full_verification.status=passed`.
 5. No newer full-verification request is pending, running, or failed.
 
-The command does not verify external T1, business Pod state, or any other Job.
+Neither trigger verifies external T1, business Pod state, or any other Job.
 Those are external batch-level gates.
 
 Protocol:
@@ -840,12 +862,16 @@ Worker from regressing phase or fence state.
 ### 12.3 Recovery rules
 
 1. Load and validate the minimal Checkpoint before any business-data mutation.
-2. Reject immutable identity/config mismatch and requested phase rollback.
+2. Reject immutable identity/config mismatch, requested phase rollback, and a
+   `CUTOVER_READY` request without an existing `DUAL_WRITE_REPAIRING`
+   Checkpoint.
 3. If fence intent exists, keep writes disabled and only finish persisting the
    complete fence.
-4. Otherwise enter the configured non-regressing phase with every condition
-   false and complete one deep full recovery round before normal or fast
-   rounds and before any convergence claim.
+4. Otherwise enter configured `SYNCING` or `DUAL_WRITE_REPAIRING` with every
+   condition false. For a configured `CUTOVER_READY` request, restore actual
+   `DUAL_WRITE_REPAIRING` without advancing the Checkpoint. Complete one deep
+   full recovery round before normal or fast rounds, automatic verification, or
+   any convergence claim.
    Recovery completion requires a complete source/target observation, not
    convergence; blockers or grace candidates remain visible and keep the
    applicable condition false.
@@ -854,9 +880,11 @@ Worker from regressing phase or fence state.
    mismatch follows the current phase's normal CAS rules.
 6. In `DUAL_WRITE_REPAIRING`, derive a new in-memory
    `repair_mtime_floor` from the recovery Round. Restart every grace interval.
-7. Discard an interrupted `verify-full`; the operator invokes it again after
-   recovery. Before fence intent, an interrupted cutover command is retried by
-   the operator. After fence intent, recovery may only complete fencing.
+7. Discard an interrupted `verify-full`. A normal dual-write restart requires
+   another operator request; a configured `CUTOVER_READY` startup reruns it
+   automatically. Before fence intent, an interrupted explicit cutover command
+   is retried by the operator. After fence intent, recovery may only complete
+   fencing.
 8. A Checkpoint or target ownership conflict indicates a duplicate/stale
    Worker and fails closed with `Attention=true`.
 
@@ -1091,11 +1119,15 @@ acceptance must prove the following behavior.
 16. UDS permissions, bounds, deadlines, streaming, serialization, schema, and
     exit codes are tested.
 17. `verify-full` is serialized, unfiltered by mtime, in-memory only, and does
-    not change phase; restart requires the operator to invoke it again.
-18. Fence failures before and after intent prove the irreversible recovery
+    not change phase; a configured `CUTOVER_READY` startup runs a fresh
+    verification after restart.
+18. ConfigMap cutover cannot create a fresh Job, skip `SYNCING`, or directly
+    persist actual `CUTOVER_READY`. Automatic and explicit triggers produce the
+    same fence.
+19. Fence failures before and after intent prove the irreversible recovery
     split; no post-intent write is possible.
-19. Keys and file contents are absent from every forbidden sink.
-20. Existing binaries build unchanged; `drive9-migration` builds with
+20. Keys and file contents are absent from every forbidden sink.
+21. Existing binaries build unchanged; `drive9-migration` builds with
     `CGO_ENABLED=0` for Linux AMD64 and ARM64.
 
 No acceptance test may claim strict consistency, No Extras, maximum RPO,
@@ -1147,9 +1179,9 @@ the V1 implementation contract:
 4. Actual file count, logical bytes, change rate, largest file, and small-file
    distribution for each EBS.
 5. Whether EBS serial/by-id is readable in the Worker environment.
-6. Operator Runbook integration for ConfigMap update, DaemonSet restart,
-   per-Job status, external T1 recording, `verify-full`, and
-   `prepare-drive9-cutover`.
+6. Operator Runbook integration for ConfigMap updates at T0 and T2, DaemonSet
+   restart, per-Job status, external T1 recording, `verify-full`, optional
+   `prepare-drive9-cutover`, and the kube plugin's all-Job T2 gate.
 7. Validation that the business writer normally changes at least one mtime or
    Source Version Token field for Create, Update, metadata change, atomic
    replace, and Rename.

--- a/docs/design/drive9-migration-v1.md
+++ b/docs/design/drive9-migration-v1.md
@@ -874,7 +874,9 @@ Worker from regressing phase or fence state.
    any convergence claim.
    Recovery completion requires a complete source/target observation, not
    convergence; blockers or grace candidates remain visible and keep the
-   applicable condition false.
+   applicable condition false. Retryable source changes, network failures,
+   HTTP 429 responses, and HTTP 5xx responses use the normal bounded backoff;
+   they do not terminate a configured cutover request before verification.
 5. A remote business write committed before process failure is rediscovered by
    the full target reread; a matching object is treated as converged and a
    mismatch follows the current phase's normal CAS rules.

--- a/docs/examples/drive9-migration/kubernetes.yaml
+++ b/docs/examples/drive9-migration/kubernetes.yaml
@@ -1,0 +1,150 @@
+# Single-PVC trial manifest. Apply it to the namespace that contains the PVC.
+# Replace the endpoint, volume ID, Node name, PVC name, and Owner API key.
+# Do not commit a real API key.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: drive9-migration
+data:
+  # Allowed startup requests: SYNCING, DUAL_WRITE_REPAIRING, CUTOVER_READY.
+  # Patch this value and rollout-restart the DaemonSet for each transition.
+  phase: SYNCING
+  config.yaml: |
+    version: v3
+    drive9:
+      endpoint: https://drive9.example.com
+    job_defaults:
+      sync:
+        grace_period: 60s
+      performance:
+        max_bytes_per_second: 104857600
+        small_file_workers: 8
+        large_file_workers: 2
+    spaces:
+      migration-target:
+        credential_ref: owner-api-key
+    jobs:
+      - volume_id: vol-00000000000000000
+        node_name: REPLACE_WITH_KUBERNETES_NODE_NAME
+        source:
+          type: ebs
+          root: /mnt/ebs/source
+        target:
+          space_ref: migration-target
+          prefix: /
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: drive9-migration-credentials
+type: Opaque
+stringData:
+  owner-api-key: REPLACE_WITH_DRIVE9_OWNER_API_KEY
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: drive9-migration
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: drive9-migration
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: drive9-migration
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      nodeSelector:
+        kubernetes.io/hostname: REPLACE_WITH_KUBERNETES_NODE_NAME
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: plan
+          image: ghcr.io/drive9-ai/drive9-migration:3a6d226
+          imagePullPolicy: IfNotPresent
+          args:
+            - plan
+            - -f
+            - /etc/drive9-migration/config.yaml
+          env:
+            - name: DRIVE9_MIGRATION_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+            - name: config
+              mountPath: /etc/drive9-migration
+              readOnly: true
+            - name: credentials
+              mountPath: /var/run/secrets/drive9-migration
+              readOnly: true
+            - name: source
+              mountPath: /mnt/ebs/source
+              readOnly: true
+      containers:
+        - name: worker
+          image: ghcr.io/drive9-ai/drive9-migration:3a6d226
+          imagePullPolicy: IfNotPresent
+          args:
+            - run
+            - -f
+            - /etc/drive9-migration/config.yaml
+          env:
+            - name: DRIVE9_MIGRATION_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsGroup: 0
+            runAsUser: 0
+          volumeMounts:
+            - name: config
+              mountPath: /etc/drive9-migration
+              readOnly: true
+            - name: credentials
+              mountPath: /var/run/secrets/drive9-migration
+              readOnly: true
+            - name: source
+              mountPath: /mnt/ebs/source
+              readOnly: true
+            - name: runtime
+              mountPath: /run/drive9-migration
+      terminationGracePeriodSeconds: 30
+      volumes:
+        - name: config
+          configMap:
+            name: drive9-migration
+        - name: credentials
+          secret:
+            secretName: drive9-migration-credentials
+            defaultMode: 0600
+        - name: source
+          persistentVolumeClaim:
+            claimName: replace-with-existing-ebs-pvc
+            readOnly: true
+        - name: runtime
+          emptyDir: {}

--- a/docs/examples/drive9-migration/kubernetes.yaml
+++ b/docs/examples/drive9-migration/kubernetes.yaml
@@ -1,6 +1,9 @@
 # Single-PVC trial manifest. Apply it to the namespace that contains the PVC.
 # Replace the endpoint, volume ID, Node name, PVC name, and Owner API key.
 # Do not commit a real API key.
+# The pinned 3a6d226 image supports the tested T0/T1 trial but predates
+# ConfigMap-driven CUTOVER_READY. Replace both image fields with a published
+# cutover-capable source tag before T2.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -45,10 +48,16 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: drive9-migration
+  labels:
+    app.kubernetes.io/name: drive9-migration
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/instance: single-pvc-trial
 spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: drive9-migration
+      app.kubernetes.io/component: worker
+      app.kubernetes.io/instance: single-pvc-trial
   updateStrategy:
     type: RollingUpdate
     rollingUpdate:
@@ -57,12 +66,16 @@ spec:
     metadata:
       labels:
         app.kubernetes.io/name: drive9-migration
+        app.kubernetes.io/component: worker
+        app.kubernetes.io/instance: single-pvc-trial
     spec:
       automountServiceAccountToken: false
       enableServiceLinks: false
       nodeSelector:
         kubernetes.io/hostname: REPLACE_WITH_KUBERNETES_NODE_NAME
       securityContext:
+        # Deliberately omit fsGroup: changing ownership on an existing Source
+        # PVC is outside the migration contract. See the Runbook root exception.
         seccompProfile:
           type: RuntimeDefault
       initContainers:
@@ -84,6 +97,8 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            # Restricted-root exception: required by the 0600 Secret and the
+            # customer-approved Source permissions; both mounts remain read-only.
             runAsGroup: 0
             runAsUser: 0
           volumeMounts:
@@ -97,7 +112,7 @@ spec:
               mountPath: /mnt/ebs/source
               readOnly: true
       containers:
-        - name: worker
+        - name: drive9-migration
           image: ghcr.io/drive9-ai/drive9-migration:3a6d226
           imagePullPolicy: IfNotPresent
           args:
@@ -119,6 +134,8 @@ spec:
               drop:
                 - ALL
             readOnlyRootFilesystem: true
+            # Restricted-root exception: required by the 0600 Secret and the
+            # customer-approved Source permissions; both mounts remain read-only.
             runAsGroup: 0
             runAsUser: 0
           volumeMounts:

--- a/docs/guides/drive9-migration-v1-runbook.md
+++ b/docs/guides/drive9-migration-v1-runbook.md
@@ -27,12 +27,7 @@ to:
 ghcr.io/drive9-ai/drive9-migration:<source-sha7>
 ```
 
-The workflow does not publish `latest`. Operators must use the immutable digest
-reported in the workflow summary:
-
-```text
-ghcr.io/drive9-ai/drive9-migration@sha256:<manifest-digest>
-```
+The workflow does not publish `latest`. Use the published commit tag directly.
 
 The `mem9-ai/drive9` repository must provide the Actions secrets
 `DRIVE9_AI_GHCR_USERNAME` and `DRIVE9_AI_GHCR_TOKEN`. The token must belong to an
@@ -46,9 +41,9 @@ visibility to Public. This is a one-time and irreversible visibility change.
 Afterward, verify from an environment that is not logged in to GHCR:
 
 ```bash
-docker pull ghcr.io/drive9-ai/drive9-migration@sha256:<manifest-digest>
+docker pull ghcr.io/drive9-ai/drive9-migration:<source-sha7>
 docker run --rm \
-  ghcr.io/drive9-ai/drive9-migration@sha256:<manifest-digest> --help
+  ghcr.io/drive9-ai/drive9-migration:<source-sha7> --help
 ```
 
 The image entrypoint is `drive9-migration`. A Worker container therefore uses
@@ -89,6 +84,39 @@ The `plan` JSON is the non-sensitive CSI handoff record: verify `volume_id`,
 identity, limits, target emptiness, and required capabilities. It never returns
 the API key.
 
+## Kubernetes single-PVC trial
+
+Use the [single-file Kubernetes manifest](../examples/drive9-migration/kubernetes.yaml)
+for one existing EBS PVC on one Node. Before applying it:
+
+1. Set the Drive9 endpoint and Owner API key for an empty test Space.
+2. Replace `volume_id` with the EBS PV's `.spec.csi.volumeHandle`.
+3. Set both `node_name` and `kubernetes.io/hostname` to the Node that owns the
+   PVC.
+4. Replace `claimName` with the existing PVC name. Apply every resource to that
+   PVC's namespace because Kubernetes does not allow cross-namespace PVC
+   mounts.
+5. Keep both PVC declarations read-only. The initContainer runs `plan`; the
+   Worker starts only when that preflight succeeds.
+
+Apply and inspect the trial with:
+
+```bash
+migration_namespace=<pvc-namespace>
+kubectl -n "$migration_namespace" apply \
+  -f docs/examples/drive9-migration/kubernetes.yaml
+kubectl -n "$migration_namespace" logs daemonset/drive9-migration -c plan
+kubectl -n "$migration_namespace" rollout status daemonset/drive9-migration
+kubectl -n "$migration_namespace" exec daemonset/drive9-migration \
+  -c worker -- \
+  /drive9-migration status --output json
+```
+
+The inline Secret is for a short-lived trial file only. For repeatable or
+production use, remove that Secret document and create the same
+`drive9-migration-credentials` Secret from a protected local file or secret
+manager. Never commit the populated manifest.
+
 ## SYNCING and rollout readiness
 
 Inspect each Job independently:
@@ -108,10 +136,30 @@ version. Change the selected phase source to `DUAL_WRITE_REPAIRING`, update the
 customer-owned ConfigMap if applicable, and rollout-restart the Migration
 DaemonSet. A mounted ConfigMap update alone does not change a running Worker.
 
+For the Kubernetes manifest above, run:
+
+```bash
+kubectl -n "$migration_namespace" patch configmap drive9-migration \
+  --type merge \
+  --patch '{"data":{"phase":"DUAL_WRITE_REPAIRING"}}'
+kubectl -n "$migration_namespace" rollout restart \
+  daemonset/drive9-migration
+kubectl -n "$migration_namespace" rollout status \
+  daemonset/drive9-migration
+kubectl -n "$migration_namespace" exec daemonset/drive9-migration \
+  -c worker -- \
+  /drive9-migration status --output json
+```
+
 After restart, require `recovery_complete=true` before using convergence
 claims. The Worker performs a new deep recovery round and derives a fresh
 in-memory repair mtime floor. Migration does not decide whether the business
 rollout has completed.
+
+In `DUAL_WRITE_REPAIRING`, automatic repair fails closed if an existing target
+mode differs from the Source mode, or if a newly discovered regular file does
+not use mode `0644`. Resolve such mode differences through the business
+dual-write path before cutover; do not force-clear Attention.
 
 ## T1: external rollout confirmation and full verification
 
@@ -123,16 +171,56 @@ drive9-migration verify-full
 drive9-migration status --output json
 ```
 
+From the Kubernetes Worker, run:
+
+```bash
+kubectl -n "$migration_namespace" exec daemonset/drive9-migration \
+  -c worker -- \
+  /drive9-migration verify-full
+kubectl -n "$migration_namespace" exec daemonset/drive9-migration \
+  -c worker -- \
+  /drive9-migration status --output json
+```
+
 The verification is process-local, scans every current Source path without an
-mtime filter, and does not trigger cutover. Restart clears it, so rerun it after
-any restart. Target-only residue is a warning and does not by itself fail
-one-way verification.
+mtime filter, and does not trigger cutover. A normal restart clears it and
+requires another explicit verification. A rollout configured with
+`phase: CUTOVER_READY` automatically runs a fresh verification after deep
+recovery. Target-only residue is a warning and does not by itself fail one-way
+verification.
 
 ## T2: irreversible cutover fence
 
-T2 remains a customer decision after business observation. Confirm every Job
-has a current passed full verification, no Attention condition, no grace or CAS
-retry work, and a converged latest round. Then invoke once per Job:
+T2 remains a customer decision after business observation. For Kubernetes,
+request it through the same ConfigMap and rollout mechanism used at T0:
+
+```bash
+kubectl -n "$migration_namespace" patch configmap drive9-migration \
+  --type merge \
+  --patch '{"data":{"phase":"CUTOVER_READY"}}'
+kubectl -n "$migration_namespace" rollout restart \
+  daemonset/drive9-migration
+kubectl -n "$migration_namespace" rollout status \
+  daemonset/drive9-migration
+```
+
+Each restarted Worker requires an existing `DUAL_WRITE_REPAIRING` Checkpoint,
+runs a new deep recovery and full verification, then executes the irreversible
+fence protocol. `kubectl rollout status` confirms only that the replacement
+Pods started; it is not the T2 completion gate. Use the kube plugin to require
+every declared Job to report both:
+
+```text
+phase=CUTOVER_READY
+fence_complete=true
+```
+
+Only after the aggregate check succeeds may the business switch to Drive9-only.
+Missing, duplicate, or unreachable Jobs fail that check closed.
+
+The existing explicit per-Job path remains available and idempotent. It requires
+a current passed full verification, a converged latest round, no Attention, and
+no grace, retry, pending, or in-flight repair work:
 
 ```text
 drive9-migration prepare-drive9-cutover

--- a/docs/guides/drive9-migration-v1-runbook.md
+++ b/docs/guides/drive9-migration-v1-runbook.md
@@ -29,6 +29,12 @@ ghcr.io/drive9-ai/drive9-migration:<source-sha7>
 
 The workflow does not publish `latest`. Use the published commit tag directly.
 
+The Kubernetes example remains pinned to `3a6d226` for its tested T0/T1 trial.
+That image predates ConfigMap-driven `CUTOVER_READY`. Before T2, replace both
+image fields with a published source tag that contains ConfigMap-driven cutover;
+otherwise the init container and Worker reject the requested phase. A failed
+rollout is never evidence that T2 completed.
+
 The `mem9-ai/drive9` repository must provide the Actions secrets
 `DRIVE9_AI_GHCR_USERNAME` and `DRIVE9_AI_GHCR_TOKEN`. The token must belong to an
 account authorized to publish packages in `drive9-ai` and needs only the GitHub
@@ -99,6 +105,22 @@ for one existing EBS PVC on one Node. Before applying it:
 5. Keep both PVC declarations read-only. The initContainer runs `plan`; the
    Worker starts only when that preflight succeeds.
 
+The example intentionally uses UID/GID 0 for both containers. This is a
+restricted migration exception: the projected credential is mode `0600`, and
+the existing Source may expose only customer-approved root-readable paths. The
+profile was exercised by the dev single-PVC trial with a read-only PVC,
+read-only root filesystem, no privilege escalation, all Linux capabilities
+dropped, and the runtime-default seccomp profile. It does not prove that every
+customer permission layout is readable.
+
+The example deliberately omits `fsGroup` because kubelet ownership adjustment
+could mutate an existing Source PVC. Before deployment, verify that UID 0 with
+no added capabilities can read every supported file and traverse every Source
+directory. If `plan` reports a Source read-access failure, stop and have the
+customer grant narrowly scoped read/traverse mode or ACL access. Do not
+recursively change Source ownership and do not add broad capabilities merely to
+make preflight pass.
+
 Apply and inspect the trial with:
 
 ```bash
@@ -108,7 +130,7 @@ kubectl -n "$migration_namespace" apply \
 kubectl -n "$migration_namespace" logs daemonset/drive9-migration -c plan
 kubectl -n "$migration_namespace" rollout status daemonset/drive9-migration
 kubectl -n "$migration_namespace" exec daemonset/drive9-migration \
-  -c worker -- \
+  -c drive9-migration -- \
   /drive9-migration status --output json
 ```
 
@@ -147,7 +169,7 @@ kubectl -n "$migration_namespace" rollout restart \
 kubectl -n "$migration_namespace" rollout status \
   daemonset/drive9-migration
 kubectl -n "$migration_namespace" exec daemonset/drive9-migration \
-  -c worker -- \
+  -c drive9-migration -- \
   /drive9-migration status --output json
 ```
 
@@ -175,10 +197,10 @@ From the Kubernetes Worker, run:
 
 ```bash
 kubectl -n "$migration_namespace" exec daemonset/drive9-migration \
-  -c worker -- \
+  -c drive9-migration -- \
   /drive9-migration verify-full
 kubectl -n "$migration_namespace" exec daemonset/drive9-migration \
-  -c worker -- \
+  -c drive9-migration -- \
   /drive9-migration status --output json
 ```
 
@@ -207,16 +229,49 @@ kubectl -n "$migration_namespace" rollout status \
 Each restarted Worker requires an existing `DUAL_WRITE_REPAIRING` Checkpoint,
 runs a new deep recovery and full verification, then executes the irreversible
 fence protocol. `kubectl rollout status` confirms only that the replacement
-Pods started; it is not the T2 completion gate. Use the kube plugin to require
-every declared Job to report both:
+Pods started; it is not the T2 completion gate.
 
-```text
-phase=CUTOVER_READY
-fence_complete=true
+The aggregate gate requires the released `kubectl-drive9-migration` client-side
+plugin, `jq` 1.6 or later, and `yq` v4. Install the platform plugin artifact as
+`kubectl-drive9-migration` on `PATH`, then confirm that
+`kubectl drive9 migration --help` succeeds. The manifest labels every Worker
+with batch `single-pvc-trial` and names its Worker container
+`drive9-migration`, which are required for plugin discovery.
+
+Run this exact gate. `yq` reads the complete declared Job ID set from the
+ConfigMap, the plugin queries every labeled observed Worker, and `jq` requires
+an exact unique ID-set match plus completed fencing:
+
+```bash
+(
+  set -euo pipefail
+  migration_batch=single-pvc-trial
+  expected_job_ids_json="$(
+    kubectl -n "$migration_namespace" get configmap drive9-migration \
+      -o jsonpath='{.data.config\.yaml}' | \
+      yq -o=json '.jobs | map(.volume_id)'
+  )"
+  kubectl drive9 migration status \
+    -n "$migration_namespace" \
+    --batch "$migration_batch" \
+    -o json | \
+    jq -e --argjson expected "$expected_job_ids_json" '
+      ([.jobs[].job_id] | sort) as $observed
+      | ($expected | sort) as $declared
+      | ($observed == $declared)
+        and (($observed | length) == ($observed | unique | length))
+        and all(.jobs[];
+          .status == "CUTOVER_READY"
+          and .worker_status.phase == "CUTOVER_READY"
+          and .worker_status.fence_complete == true)
+    '
+)
 ```
 
-Only after the aggregate check succeeds may the business switch to Drive9-only.
-Missing, duplicate, or unreachable Jobs fail that check closed.
+The subshell exits nonzero for a missing ConfigMap, missing or duplicate Job,
+unreachable Worker, plugin collection failure, ID-set mismatch, incomplete
+phase, or incomplete fence. If the plugin is not installed, T2 is blocked. Only
+after this command exits zero may the business switch to Drive9-only.
 
 The existing explicit per-Job path remains available and idempotent. It requires
 a current passed full verification, a converged latest round, no Attention, and

--- a/internal/migration/checkpoint.go
+++ b/internal/migration/checkpoint.go
@@ -239,7 +239,18 @@ func (s *CheckpointStore) Recover(ctx context.Context, startup *Startup) (*Recov
 	if err != nil {
 		return nil, err
 	}
-	if record.Revision == 0 {
+	cutoverRequested := startup.Phase == PhaseCutoverReady
+	if cutoverRequested {
+		if record.Revision == 0 {
+			return nil, fmt.Errorf("%w: CUTOVER_READY requires an existing DUAL_WRITE_REPAIRING checkpoint", ErrCheckpointMismatch)
+		}
+		if !sameCheckpointIdentity(record.Checkpoint, desired) {
+			return nil, fmt.Errorf("%w: immutable job identity", ErrCheckpointMismatch)
+		}
+		if phaseRank(record.Checkpoint.HighestPhase) < phaseRank(PhaseDualWriteRepairing) {
+			return nil, fmt.Errorf("%w: CUTOVER_READY requires an existing DUAL_WRITE_REPAIRING checkpoint", ErrCheckpointMismatch)
+		}
+	} else if record.Revision == 0 {
 		record, err = s.Update(ctx, CheckpointRecord{}, desired)
 		if err != nil {
 			return nil, err

--- a/internal/migration/checkpoint.go
+++ b/internal/migration/checkpoint.go
@@ -242,13 +242,13 @@ func (s *CheckpointStore) Recover(ctx context.Context, startup *Startup) (*Recov
 	cutoverRequested := startup.Phase == PhaseCutoverReady
 	if cutoverRequested {
 		if record.Revision == 0 {
-			return nil, fmt.Errorf("%w: CUTOVER_READY requires an existing DUAL_WRITE_REPAIRING checkpoint", ErrCheckpointMismatch)
+			return nil, fmt.Errorf("%w: %w: CUTOVER_READY requires an existing DUAL_WRITE_REPAIRING checkpoint", ErrInvalidPhase, ErrCheckpointMismatch)
 		}
 		if !sameCheckpointIdentity(record.Checkpoint, desired) {
 			return nil, fmt.Errorf("%w: immutable job identity", ErrCheckpointMismatch)
 		}
 		if phaseRank(record.Checkpoint.HighestPhase) < phaseRank(PhaseDualWriteRepairing) {
-			return nil, fmt.Errorf("%w: CUTOVER_READY requires an existing DUAL_WRITE_REPAIRING checkpoint", ErrCheckpointMismatch)
+			return nil, fmt.Errorf("%w: %w: CUTOVER_READY requires an existing DUAL_WRITE_REPAIRING checkpoint", ErrInvalidPhase, ErrCheckpointMismatch)
 		}
 	} else if record.Revision == 0 {
 		record, err = s.Update(ctx, CheckpointRecord{}, desired)

--- a/internal/migration/checkpoint_test.go
+++ b/internal/migration/checkpoint_test.go
@@ -164,7 +164,7 @@ func TestCheckpointPhaseAdvanceRejectsRollbackAndIdentityMismatch(t *testing.T) 
 func TestCheckpointCutoverRequestRequiresDualWriteAndDoesNotAdvanceActualPhase(t *testing.T) {
 	store, fake, startup := newCheckpointFixture(t)
 	startup.Phase = PhaseCutoverReady
-	if _, err := store.Recover(context.Background(), startup); !errors.Is(err, ErrCheckpointMismatch) {
+	if _, err := store.Recover(context.Background(), startup); !errors.Is(err, ErrCheckpointMismatch) || !errors.Is(err, ErrInvalidPhase) {
 		t.Fatalf("fresh cutover request error=%v", err)
 	}
 	fake.mu.Lock()
@@ -178,7 +178,7 @@ func TestCheckpointCutoverRequestRequiresDualWriteAndDoesNotAdvanceActualPhase(t
 		t.Fatal(err)
 	}
 	startup.Phase = PhaseCutoverReady
-	if _, err := store.Recover(context.Background(), startup); !errors.Is(err, ErrCheckpointMismatch) {
+	if _, err := store.Recover(context.Background(), startup); !errors.Is(err, ErrCheckpointMismatch) || !errors.Is(err, ErrInvalidPhase) {
 		t.Fatalf("SYNCING cutover request error=%v", err)
 	}
 

--- a/internal/migration/checkpoint_test.go
+++ b/internal/migration/checkpoint_test.go
@@ -161,6 +161,41 @@ func TestCheckpointPhaseAdvanceRejectsRollbackAndIdentityMismatch(t *testing.T) 
 	}
 }
 
+func TestCheckpointCutoverRequestRequiresDualWriteAndDoesNotAdvanceActualPhase(t *testing.T) {
+	store, fake, startup := newCheckpointFixture(t)
+	startup.Phase = PhaseCutoverReady
+	if _, err := store.Recover(context.Background(), startup); !errors.Is(err, ErrCheckpointMismatch) {
+		t.Fatalf("fresh cutover request error=%v", err)
+	}
+	fake.mu.Lock()
+	if fake.writes != 0 {
+		t.Fatalf("fresh cutover request wrote %d checkpoints", fake.writes)
+	}
+	fake.mu.Unlock()
+
+	startup.Phase = PhaseSyncing
+	if _, err := store.Recover(context.Background(), startup); err != nil {
+		t.Fatal(err)
+	}
+	startup.Phase = PhaseCutoverReady
+	if _, err := store.Recover(context.Background(), startup); !errors.Is(err, ErrCheckpointMismatch) {
+		t.Fatalf("SYNCING cutover request error=%v", err)
+	}
+
+	startup.Phase = PhaseDualWriteRepairing
+	if _, err := store.Recover(context.Background(), startup); err != nil {
+		t.Fatal(err)
+	}
+	startup.Phase = PhaseCutoverReady
+	recovery, err := store.Recover(context.Background(), startup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recovery.Record.Checkpoint.HighestPhase != PhaseDualWriteRepairing || recovery.State.Snapshot().Phase != PhaseDualWriteRepairing || !recovery.WritesAllowed || !recovery.DeepRecoveryRequired {
+		t.Fatalf("cutover request recovery=%+v", recovery)
+	}
+}
+
 func TestCheckpointStaleCASFailsClosed(t *testing.T) {
 	store, fake, startup := newCheckpointFixture(t)
 	recovery, err := store.Recover(context.Background(), startup)

--- a/internal/migration/config.go
+++ b/internal/migration/config.go
@@ -259,7 +259,7 @@ func ReadStartupPhase(configPath, environmentValue string, highestApplied Phase)
 		value = strings.TrimSpace(string(body))
 	}
 	desired := Phase(value)
-	if desired != PhaseSyncing && desired != PhaseDualWriteRepairing {
+	if desired != PhaseSyncing && desired != PhaseDualWriteRepairing && desired != PhaseCutoverReady {
 		return "", fmt.Errorf("%w: unsupported startup value %q", ErrInvalidPhase, value)
 	}
 	if highestApplied != "" && phaseRank(highestApplied) == 0 {

--- a/internal/migration/config_test.go
+++ b/internal/migration/config_test.go
@@ -145,6 +145,12 @@ func TestReadStartupPhaseSourcesAndRollback(t *testing.T) {
 	if phase, err := ReadStartupPhase(configPath, string(PhaseDualWriteRepairing), PhaseDualWriteRepairing); err != nil || phase != PhaseDualWriteRepairing {
 		t.Fatalf("idempotent phase=%q err=%v", phase, err)
 	}
+	if phase, err := ReadStartupPhase(configPath, string(PhaseCutoverReady), PhaseDualWriteRepairing); err != nil || phase != PhaseCutoverReady {
+		t.Fatalf("cutover request phase=%q err=%v", phase, err)
+	}
+	if phase, err := ReadStartupPhase(configPath, string(PhaseCutoverReady), PhaseCutoverReady); err != nil || phase != PhaseCutoverReady {
+		t.Fatalf("idempotent cutover request phase=%q err=%v", phase, err)
+	}
 }
 
 func TestCredentialSourceReloadsRotationAndDoesNotLeak(t *testing.T) {

--- a/internal/migration/fence_test.go
+++ b/internal/migration/fence_test.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -83,6 +85,63 @@ func TestCutoverFenceSuccessDuplicateAndRestart(t *testing.T) {
 	restarted, err := NewWorker(context.Background(), startup)
 	if err != nil || restarted.recovery.WritesAllowed || restarted.State().Phase != PhaseCutoverReady || !restarted.fenceComplete.Load() {
 		t.Fatalf("restart=%+v err=%v", restarted, err)
+	}
+}
+
+func TestConfigMapCutoverRequestRunsFreshVerificationAndFence(t *testing.T) {
+	_, startup, _, server := newFenceWorker(t)
+	defer server.Close()
+	startup.Phase = PhaseCutoverReady
+
+	worker, err := NewWorker(context.Background(), startup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := worker.statusOutput()
+	if before.StartupPhase != PhaseCutoverReady || before.Phase != PhaseDualWriteRepairing || before.RecoveryComplete || before.Verification.Status != "" || before.FenceIntent || before.FenceComplete {
+		t.Fatalf("pre-cutover status=%+v", before)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- worker.Run(ctx) }()
+	waitFor(t, worker.fenceComplete.Load)
+	after := worker.statusOutput()
+	if after.Phase != PhaseCutoverReady || after.StartupPhase != PhaseCutoverReady || after.Verification.Status != "passed" || !after.FenceIntent || !after.FenceComplete {
+		cancel()
+		<-done
+		t.Fatalf("automatic cutover status=%+v", after)
+	}
+	if _, err := worker.PrepareCutover(context.Background()); err != nil {
+		cancel()
+		<-done
+		t.Fatalf("manual cutover after automatic completion: %v", err)
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatalf("automatic cutover Worker error=%v", err)
+	}
+}
+
+func TestConfigMapCutoverRequestFailsClosedWhenFreshVerificationFails(t *testing.T) {
+	_, startup, _, server := newFenceWorker(t)
+	defer server.Close()
+	if err := os.WriteFile(filepath.Join(startup.Job.Source.Root, "unsafe-mode"), []byte("content"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	startup.Phase = PhaseCutoverReady
+
+	worker, err := NewWorker(context.Background(), startup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = worker.Run(context.Background())
+	if err == nil {
+		t.Fatal("automatic cutover succeeded after failed verification")
+	}
+	status := worker.statusOutput()
+	if status.Phase != PhaseDualWriteRepairing || status.Verification.Status != "failed" || status.FenceIntent || status.FenceComplete || !status.Conditions.Attention {
+		t.Fatalf("failed automatic cutover status=%+v error=%v", status, err)
 	}
 }
 

--- a/internal/migration/fence_test.go
+++ b/internal/migration/fence_test.go
@@ -13,8 +13,14 @@ import (
 )
 
 func newFenceWorker(t *testing.T) (*Worker, *Startup, *checkpointFake, *httptest.Server) {
+	worker, startup, checkpoint, _, server := newFenceWorkerWithTarget(t)
+	return worker, startup, checkpoint, server
+}
+
+func newFenceWorkerWithTarget(t *testing.T) (*Worker, *Startup, *checkpointFake, *memoryTarget, *httptest.Server) {
 	t.Helper()
-	backend := &workerServer{target: &memoryTarget{nodes: make(map[string]memoryTargetNode)}, checkpoint: &checkpointFake{}, caps: allWorkerCapabilities()}
+	target := &memoryTarget{nodes: make(map[string]memoryTargetNode)}
+	backend := &workerServer{target: target, checkpoint: &checkpointFake{}, caps: allWorkerCapabilities()}
 	server := httptest.NewServer(http.HandlerFunc(backend.handler))
 	startup := newWorkerStartup(t, t.TempDir(), server)
 	startup.Phase = PhaseDualWriteRepairing
@@ -31,7 +37,7 @@ func newFenceWorker(t *testing.T) (*Worker, *Startup, *checkpointFake, *httptest
 		server.Close()
 		t.Fatal(err)
 	}
-	return worker, startup, backend.checkpoint, server
+	return worker, startup, backend.checkpoint, target, server
 }
 
 func TestPrepareCutoverCancellationWhileWaitingForGateDoesNotFence(t *testing.T) {
@@ -120,6 +126,33 @@ func TestConfigMapCutoverRequestRunsFreshVerificationAndFence(t *testing.T) {
 	cancel()
 	if err := <-done; err != nil {
 		t.Fatalf("automatic cutover Worker error=%v", err)
+	}
+}
+
+func TestConfigMapCutoverRequestRetriesTransientRecoveryFailure(t *testing.T) {
+	_, startup, _, target, server := newFenceWorkerWithTarget(t)
+	defer server.Close()
+	startup.Phase = PhaseCutoverReady
+
+	worker, err := NewWorker(context.Background(), startup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	target.mu.Lock()
+	target.failListCount = 1
+	target.failListStatus = http.StatusServiceUnavailable
+	target.mu.Unlock()
+	retries := 0
+	worker.retryWait = func(context.Context, time.Duration) error {
+		retries++
+		return nil
+	}
+
+	if err := worker.runRequestedCutover(context.Background()); err != nil {
+		t.Fatalf("automatic cutover did not retry transient recovery failure: %v", err)
+	}
+	if retries != 1 || !worker.fenceComplete.Load() {
+		t.Fatalf("automatic cutover retries=%d status=%+v", retries, worker.statusOutput())
 	}
 }
 

--- a/internal/migration/handoff_test.go
+++ b/internal/migration/handoff_test.go
@@ -8,8 +8,9 @@ import (
 )
 
 const (
-	sampleConfigPath = "../../docs/examples/drive9-migration/config.yaml"
-	runbookPath      = "../../docs/guides/drive9-migration-v1-runbook.md"
+	sampleConfigPath     = "../../docs/examples/drive9-migration/config.yaml"
+	kubernetesSamplePath = "../../docs/examples/drive9-migration/kubernetes.yaml"
+	runbookPath          = "../../docs/guides/drive9-migration-v1-runbook.md"
 )
 
 func TestOperatorSampleSupportsBothLayoutsAndContainsNoCredential(t *testing.T) {
@@ -53,9 +54,32 @@ func TestPlanHandoffSchemaIsNonSensitiveAndRunbookCoversAcceptedWorkflow(t *test
 		t.Fatal(err)
 	}
 	text := string(runbook)
-	for _, required := range []string{"T0", "T1", "T2", "ConfigMap", "rollout-restart", "verify-full", "prepare-drive9-cutover", "post-T0", "residue", "metadata", "per Job", "residual ABA", "one mounted, read-only EBS Source per Job", "no rollback", "exact per-Job control directory"} {
+	for _, required := range []string{"T0", "T1", "T2", "ConfigMap", "rollout-restart", "verify-full", "prepare-drive9-cutover", "post-T0", "residue", "metadata", "per Job", "residual ABA", "one mounted, read-only EBS Source per Job", "no rollback", "exact per-Job control directory", "kubectl-drive9-migration", "expected_job_ids_json", ".worker_status.fence_complete == true", "fsGroup", "recursively change Source ownership"} {
 		if !strings.Contains(text, required) {
 			t.Fatalf("runbook omitted %q", required)
 		}
+	}
+}
+
+func TestKubernetesSampleMatchesPluginAndRestrictedRootContract(t *testing.T) {
+	body, err := os.ReadFile(kubernetesSamplePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(body)
+	for _, required := range []string{
+		"app.kubernetes.io/component: worker",
+		"app.kubernetes.io/instance: single-pvc-trial",
+		"- name: drive9-migration",
+		"allowPrivilegeEscalation: false",
+		"readOnlyRootFilesystem: true",
+		"capabilities:\n              drop:\n                - ALL",
+	} {
+		if !strings.Contains(text, required) {
+			t.Fatalf("Kubernetes sample omitted %q", required)
+		}
+	}
+	if strings.Count(text, "runAsUser: 0") != 2 || strings.Count(text, "runAsGroup: 0") != 2 {
+		t.Fatalf("Kubernetes sample must apply the documented root exception to plan and Worker")
 	}
 }

--- a/internal/migration/preflight.go
+++ b/internal/migration/preflight.go
@@ -192,6 +192,9 @@ func preflightWithProbe(ctx context.Context, startup *Startup, probe func(string
 			return PreflightResult{}, fmt.Errorf("%w: checkpoint: %w: requested phase rollback", ErrPreflight, ErrCheckpointMismatch)
 		}
 	}
+	if startup.Phase == PhaseCutoverReady && (!recoveryControlPresent || phaseRank(checkpoint.Checkpoint.HighestPhase) < phaseRank(PhaseDualWriteRepairing)) {
+		return PreflightResult{}, fmt.Errorf("%w: checkpoint: %w: CUTOVER_READY requires an existing DUAL_WRITE_REPAIRING checkpoint", ErrPreflight, ErrCheckpointMismatch)
+	}
 	entries, err := api.ListCtx(ctx, listPath(startup.Job.Target.Prefix))
 	if err != nil && !client.IsNotFound(err) {
 		return PreflightResult{}, fmt.Errorf("%w: target listing: %w", ErrPreflight, err)

--- a/internal/migration/preflight.go
+++ b/internal/migration/preflight.go
@@ -193,7 +193,7 @@ func preflightWithProbe(ctx context.Context, startup *Startup, probe func(string
 		}
 	}
 	if startup.Phase == PhaseCutoverReady && (!recoveryControlPresent || phaseRank(checkpoint.Checkpoint.HighestPhase) < phaseRank(PhaseDualWriteRepairing)) {
-		return PreflightResult{}, fmt.Errorf("%w: checkpoint: %w: CUTOVER_READY requires an existing DUAL_WRITE_REPAIRING checkpoint", ErrPreflight, ErrCheckpointMismatch)
+		return PreflightResult{}, fmt.Errorf("%w: %w: checkpoint: %w: CUTOVER_READY requires an existing DUAL_WRITE_REPAIRING checkpoint", ErrPreflight, ErrInvalidPhase, ErrCheckpointMismatch)
 	}
 	entries, err := api.ListCtx(ctx, listPath(startup.Job.Target.Prefix))
 	if err != nil && !client.IsNotFound(err) {

--- a/internal/migration/preflight_test.go
+++ b/internal/migration/preflight_test.go
@@ -421,7 +421,8 @@ func TestPreflightAllowsNonEmptyTargetOnlyForMatchingCheckpoint(t *testing.T) {
 	defer server.Close()
 
 	startup := preflightStartup(t, server.URL, root)
-	body, err := json.Marshal(checkpointFromStartup(startup))
+	checkpoint := checkpointFromStartup(startup)
+	body, err := json.Marshal(checkpoint)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -438,9 +439,21 @@ func TestPreflightAllowsNonEmptyTargetOnlyForMatchingCheckpoint(t *testing.T) {
 	if err != nil || result.TargetEmpty || !result.RecoveryControlPresent {
 		t.Fatalf("T0 rollout restart preflight=%+v err=%v", result, err)
 	}
+	startup.Phase = PhaseCutoverReady
+	if _, err := preflightWithVerifier(context.Background(), startup, func(string, string) (bool, error) { return true, nil }); !errors.Is(err, ErrPreflight) || !strings.Contains(err.Error(), "DUAL_WRITE_REPAIRING") {
+		t.Fatalf("cutover request from SYNCING error=%v", err)
+	}
+	checkpoint.HighestPhase = PhaseDualWriteRepairing
+	checkpointBody, err = json.Marshal(checkpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err = preflightWithVerifier(context.Background(), startup, func(string, string) (bool, error) { return true, nil })
+	if err != nil || result.TargetEmpty || !result.RecoveryControlPresent {
+		t.Fatalf("cutover rollout restart preflight=%+v err=%v", result, err)
+	}
 	startup.Phase = PhaseSyncing
 
-	checkpoint := checkpointFromStartup(startup)
 	checkpoint.ConfigHash = "other-config"
 	checkpointBody, err = json.Marshal(checkpoint)
 	if err != nil {

--- a/internal/migration/preflight_test.go
+++ b/internal/migration/preflight_test.go
@@ -440,7 +440,7 @@ func TestPreflightAllowsNonEmptyTargetOnlyForMatchingCheckpoint(t *testing.T) {
 		t.Fatalf("T0 rollout restart preflight=%+v err=%v", result, err)
 	}
 	startup.Phase = PhaseCutoverReady
-	if _, err := preflightWithVerifier(context.Background(), startup, func(string, string) (bool, error) { return true, nil }); !errors.Is(err, ErrPreflight) || !strings.Contains(err.Error(), "DUAL_WRITE_REPAIRING") {
+	if _, err := preflightWithVerifier(context.Background(), startup, func(string, string) (bool, error) { return true, nil }); !errors.Is(err, ErrPreflight) || !errors.Is(err, ErrInvalidPhase) || !strings.Contains(err.Error(), "DUAL_WRITE_REPAIRING") {
 		t.Fatalf("cutover request from SYNCING error=%v", err)
 	}
 	checkpoint.HighestPhase = PhaseDualWriteRepairing

--- a/internal/migration/worker.go
+++ b/internal/migration/worker.go
@@ -502,6 +502,16 @@ func (w *Worker) Run(ctx context.Context) error {
 		w.reporter.start(reporterCtx)
 		defer func() { cancel(); w.reporter.wait() }()
 	}
+	if w.startup != nil && w.startup.Phase == PhaseCutoverReady {
+		if err := w.runRequestedCutover(ctx); err != nil {
+			if ctx.Err() != nil {
+				return nil
+			}
+			return newWorkerRunError(err)
+		}
+		<-ctx.Done()
+		return nil
+	}
 	recovered := w.state.Snapshot().RecoveryComplete
 	attempt := 0
 	var blockedAt time.Time
@@ -557,6 +567,23 @@ func (w *Worker) Run(ctx context.Context) error {
 		case <-timer.C:
 		}
 	}
+}
+
+func (w *Worker) runRequestedCutover(ctx context.Context) error {
+	if err := w.controlGate.Acquire(ctx); err != nil {
+		return err
+	}
+	defer w.controlGate.Release()
+	if !w.state.Snapshot().RecoveryComplete {
+		if err := w.DeepRecovery(ctx); err != nil {
+			return err
+		}
+	}
+	if _, err := w.verifyFullLocked(ctx); err != nil {
+		return err
+	}
+	_, err := w.prepareCutoverLocked(ctx)
+	return err
 }
 
 type workerRunError struct {

--- a/internal/migration/worker.go
+++ b/internal/migration/worker.go
@@ -574,16 +574,46 @@ func (w *Worker) runRequestedCutover(ctx context.Context) error {
 		return err
 	}
 	defer w.controlGate.Release()
-	if !w.state.Snapshot().RecoveryComplete {
-		if err := w.DeepRecovery(ctx); err != nil {
-			return err
-		}
+	if err := w.recoverRequestedCutoverLocked(ctx); err != nil {
+		return err
 	}
 	if _, err := w.verifyFullLocked(ctx); err != nil {
 		return err
 	}
 	_, err := w.prepareCutoverLocked(ctx)
 	return err
+}
+
+func (w *Worker) recoverRequestedCutoverLocked(ctx context.Context) error {
+	attempt := 0
+	var blockedAt time.Time
+	for !w.state.Snapshot().RecoveryComplete {
+		err := w.DeepRecovery(ctx)
+		if err == nil {
+			return nil
+		}
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if isAuthError(err) {
+			if refreshErr := w.refreshClientLocked(ctx); refreshErr != nil {
+				w.state.SetAttention(true)
+			}
+		} else if !retryableWorkerError(err) {
+			w.state.SetAttention(true)
+			return err
+		}
+		if blockedAt.IsZero() {
+			blockedAt = w.clock()
+		} else if w.clock().Sub(blockedAt) >= attentionAfter {
+			w.state.SetAttention(true)
+		}
+		if err := w.waitForRetry(ctx, retryDelay(attempt, maxRetryDelay)); err != nil {
+			return err
+		}
+		attempt++
+	}
+	return nil
 }
 
 type workerRunError struct {


### PR DESCRIPTION
## What changed

1. Accept `CUTOVER_READY` as a desired startup phase from the Migration ConfigMap.
2. Require an existing `DUAL_WRITE_REPAIRING` checkpoint and keep the actual phase unchanged until fencing succeeds.
3. After a DaemonSet rollout, automatically run deep recovery, fresh full verification, and the existing irreversible fence protocol.
4. Preserve `prepare-drive9-cutover` as an idempotent manual trigger.
5. Add a single-PVC Kubernetes manifest and update the design and operator Runbook for ConfigMap-driven T2 and the external all-Job gate.

## Why

T0 and T2 can now use the same ConfigMap plus DaemonSet rollout workflow without weakening the existing cutover guarantees. `CUTOVER_READY` remains an observed result: failed verification cannot persist fence intent or actual cutover state.

## Validation

- `go test -count=1 ./cmd/drive9-migration ./internal/migration`
- `go test -race ./internal/migration -run 'Test(ConfigMapCutoverRequest|CutoverFenceSuccessDuplicateAndRestart|FenceRecoverySerializesWithControlCutover)'`
- `make build-migration`
- `make lint`
- `kubectl create --dry-run=client --validate=false -f docs/examples/drive9-migration/kubernetes.yaml -o name`
- All 8 Migration failpoint tests passed. The repository-wide failpoint runner subsequently reached unrelated `pkg/backend` tests and was blocked because local Docker/Podman was unavailable.

## Post-merge release step

Run the manually triggered `Publish migration image` workflow from the new `main` commit, then update customer-facing manifests and documentation to that public tag. The currently referenced `:3a6d226` image predates this ConfigMap cutover support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for startup-triggered migration cutover through configuration rollout or an explicit command.
  * Added a Kubernetes trial deployment with configurable migration settings, credentials, and restricted runtime access.
* **Bug Fixes**
  * Cutover now requires a valid recovery checkpoint and completed verification before fencing.
  * Unsafe or failed verification stops cutover without advancing migration state.
* **Documentation**
  * Expanded migration runbooks with Kubernetes procedures, rollout checks, recovery guidance, and cutover requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->