### PR TITLE
feat: add Drive9 migration kubectl status plugin

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -16,16 +16,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ github.sha }}
 
-      - name: Checkout agfs dependency
-        run: |
-          git clone --depth 1 https://github.com/c4pt0r/agfs ../agfs
-
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version-file: go.mod
           cache: true

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -40,10 +40,16 @@ jobs:
         run: |
           make build-cli-release DIST_DIR=dist VERSION="${{ env.VERSION }}" CLI_TARGETS="linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64"
 
+      - name: Build migration kubectl plugin for all platforms
+        run: |
+          make build-migration-kube-plugin-release DIST_DIR=dist VERSION="${{ env.VERSION }}" KUBE_PLUGIN_TARGETS="linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64"
+
       - name: Verify Windows artifacts
         run: |
           test -f dist/drive9-windows-amd64.exe
           test -f dist/drive9-windows-arm64.exe
+          test -f dist/kubectl-drive9-migration-windows-amd64.exe
+          test -f dist/kubectl-drive9-migration-windows-arm64.exe
 
       - name: Ensure version file
         run: |
@@ -59,6 +65,6 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add site/releases/
           git diff --cached --quiet && echo "No changes to commit" && exit 0
-          git commit -m "release: drive9 CLI ${{ env.VERSION }}"
+          git commit -m "release: drive9 CLIs ${{ env.VERSION }}"
           git pull --rebase
           git push

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ GOARCH ?= $(HOST_GOARCH)
 APP_NAME ?= drive9-server
 CLI_NAME ?= drive9
 MIGRATION_NAME ?= drive9-migration
+KUBE_PLUGIN_NAME ?= kubectl-drive9-migration
 LOCAL_SERVER_NAME ?= drive9-server-local
 
 BIN_DIR ?= bin
@@ -23,6 +24,7 @@ DIST_DIR ?= dist
 SERVER_BIN ?= $(BIN_DIR)/$(APP_NAME)
 CLI_BIN ?= $(BIN_DIR)/$(CLI_NAME)
 MIGRATION_BIN ?= $(BIN_DIR)/$(MIGRATION_NAME)
+KUBE_PLUGIN_BIN ?= $(BIN_DIR)/$(KUBE_PLUGIN_NAME)
 LOCAL_SERVER_BIN ?= $(BIN_DIR)/$(LOCAL_SERVER_NAME)
 
 VERSION ?=
@@ -32,6 +34,7 @@ BUILD_TIME ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 
 CLI_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64
 MIGRATION_TARGETS ?= linux/amd64 linux/arm64
+KUBE_PLUGIN_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
 GOLANGCI_LINT_BIN ?= $(BIN_DIR)/golangci-lint
@@ -53,7 +56,7 @@ BUILDINFO_LDFLAGS = -X github.com/mem9-ai/drive9/pkg/buildinfo.Version=$(if $(VE
 	-X github.com/mem9-ai/drive9/pkg/buildinfo.GitBranch=$(GIT_BRANCH) \
 	-X github.com/mem9-ai/drive9/pkg/buildinfo.BuildTime=$(BUILD_TIME)
 
-.PHONY: mod test test-failpoint test-podman fmt lint install-lint build build-server build-server-local build-cli build-cli-release build-migration build-migration-release run-server-local e2e-local sdk-integration-tests docker-build docker-build-migration docker-push-migration-multi
+.PHONY: mod test test-failpoint test-podman fmt lint install-lint build build-server build-server-local build-cli build-cli-release build-migration build-migration-release build-migration-kube-plugin build-migration-kube-plugin-release run-server-local e2e-local sdk-integration-tests docker-build docker-build-migration docker-push-migration-multi
 
 mod:
 	$(GO) mod tidy
@@ -147,6 +150,10 @@ build-migration:
 	mkdir -p $(dir $(MIGRATION_BIN))
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -ldflags "$(BUILDINFO_LDFLAGS)" -o $(MIGRATION_BIN) ./cmd/drive9-migration
 
+build-migration-kube-plugin:
+	mkdir -p $(dir $(KUBE_PLUGIN_BIN))
+	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) $(GO) build -ldflags "$(BUILDINFO_LDFLAGS)" -o $(KUBE_PLUGIN_BIN) ./cmd/kubectl-drive9-migration
+
 build-migration-release:
 	@set -euo pipefail; \
 	mkdir -p $(DIST_DIR); \
@@ -158,6 +165,22 @@ build-migration-release:
 		$(MAKE) --no-print-directory build-migration GOOS="$$os" GOARCH="$$arch" MIGRATION_BIN="$$out" VERSION="$(VERSION)"; \
 	done; \
 	cd $(DIST_DIR) && sha256sum $(MIGRATION_NAME)-* > migration-checksums.txt
+
+build-migration-kube-plugin-release:
+	@set -euo pipefail; \
+	mkdir -p $(DIST_DIR); \
+	for target in $(KUBE_PLUGIN_TARGETS); do \
+		os="$${target%/*}"; \
+		arch="$${target#*/}"; \
+		ext=""; \
+		if [ "$$os" = "windows" ]; then \
+			ext=".exe"; \
+		fi; \
+		out="$(DIST_DIR)/$(KUBE_PLUGIN_NAME)-$${os}-$${arch}$$ext"; \
+		echo "Building $$(basename "$$out")..."; \
+		$(MAKE) --no-print-directory build-migration-kube-plugin GOOS="$$os" GOARCH="$$arch" KUBE_PLUGIN_BIN="$$out" VERSION="$(VERSION)"; \
+	done; \
+	cd $(DIST_DIR) && sha256sum $(KUBE_PLUGIN_NAME)-* > migration-kube-plugin-checksums.txt
 
 build-cli-release:
 	@set -euo pipefail; \

--- a/cmd/kubectl-drive9-migration/main.go
+++ b/cmd/kubectl-drive9-migration/main.go
@@ -1,0 +1,173 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"os/signal"
+	"regexp"
+	"syscall"
+	"time"
+)
+
+const (
+	exitSuccess = 0
+	exitFailure = 1
+	exitUsage   = 2
+)
+
+var batchLabelPattern = regexp.MustCompile(`^[A-Za-z0-9](?:[A-Za-z0-9_.-]{0,61}[A-Za-z0-9])?$`)
+
+type options struct {
+	namespace     string
+	allNamespaces bool
+	batch         string
+	contextName   string
+	kubeconfig    string
+	output        string
+}
+
+type commandResult struct {
+	stdout []byte
+	stderr []byte
+	err    error
+}
+
+type dependencies struct {
+	ctx         context.Context
+	now         func() time.Time
+	run         func(context.Context, string, ...string) commandResult
+	execTimeout time.Duration
+	concurrency int
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	os.Exit(execute(os.Args[1:], os.Stdout, os.Stderr, dependencies{
+		ctx:         ctx,
+		now:         time.Now,
+		run:         runCommand,
+		execTimeout: defaultExecTimeout,
+		concurrency: maxConcurrentExec,
+	}))
+}
+
+func execute(args []string, stdout, stderr io.Writer, deps dependencies) int {
+	if len(args) == 1 && (args[0] == "-h" || args[0] == "--help") {
+		writeUsage(stdout)
+		return exitSuccess
+	}
+	if len(args) == 0 {
+		writeUsage(stderr)
+		return exitUsage
+	}
+	if args[0] != "status" {
+		_, _ = fmt.Fprintf(stderr, "unknown command %q\n", args[0])
+		writeUsage(stderr)
+		return exitUsage
+	}
+
+	opts, err := parseStatusOptions(args[1:])
+	if errors.Is(err, flag.ErrHelp) {
+		writeUsage(stdout)
+		return exitSuccess
+	}
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return exitUsage
+	}
+	deps = normalizeDependencies(deps)
+	jobs, batches, partial, err := collectStatus(deps.ctx, opts, deps)
+	if err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return exitFailure
+	}
+	if err := renderStatus(stdout, opts, deps.now().UTC(), jobs, batches); err != nil {
+		_, _ = fmt.Fprintln(stderr, err)
+		return exitFailure
+	}
+	if partial {
+		return exitFailure
+	}
+	return exitSuccess
+}
+
+func normalizeDependencies(deps dependencies) dependencies {
+	if deps.ctx == nil {
+		deps.ctx = context.Background()
+	}
+	if deps.now == nil {
+		deps.now = time.Now
+	}
+	if deps.run == nil {
+		deps.run = runCommand
+	}
+	if deps.execTimeout <= 0 {
+		deps.execTimeout = defaultExecTimeout
+	}
+	if deps.concurrency <= 0 {
+		deps.concurrency = maxConcurrentExec
+	} else if deps.concurrency > maxConcurrentExec {
+		deps.concurrency = maxConcurrentExec
+	}
+	return deps
+}
+
+func parseStatusOptions(args []string) (options, error) {
+	opts := options{output: "table"}
+	flags := flag.NewFlagSet("status", flag.ContinueOnError)
+	flags.SetOutput(io.Discard)
+	flags.Usage = func() {}
+	flags.StringVar(&opts.namespace, "namespace", "", "Kubernetes namespace")
+	flags.StringVar(&opts.namespace, "n", "", "Kubernetes namespace")
+	flags.BoolVar(&opts.allNamespaces, "all-namespaces", false, "query all namespaces")
+	flags.BoolVar(&opts.allNamespaces, "A", false, "query all namespaces")
+	flags.StringVar(&opts.batch, "batch", "", "migration batch label")
+	flags.StringVar(&opts.contextName, "context", "", "kubectl context")
+	flags.StringVar(&opts.kubeconfig, "kubeconfig", "", "path to kubeconfig")
+	flags.StringVar(&opts.output, "output", "table", "output format: table, wide, or json")
+	flags.StringVar(&opts.output, "o", "table", "output format: table, wide, or json")
+	if err := flags.Parse(args); err != nil {
+		return options{}, err
+	}
+	if flags.NArg() != 0 {
+		return options{}, errors.New("status accepts no positional arguments")
+	}
+	if opts.namespace != "" && opts.allNamespaces {
+		return options{}, errors.New("--namespace and --all-namespaces are mutually exclusive")
+	}
+	switch opts.output {
+	case "table", "wide", "json":
+	default:
+		return options{}, fmt.Errorf("unsupported output format %q", opts.output)
+	}
+	if opts.batch != "" && !batchLabelPattern.MatchString(opts.batch) {
+		return options{}, errors.New("--batch must be a valid non-empty Kubernetes label value")
+	}
+	return opts, nil
+}
+
+func runCommand(ctx context.Context, name string, args ...string) commandResult {
+	cmd := exec.CommandContext(ctx, name, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return commandResult{stdout: stdout.Bytes(), stderr: stderr.Bytes(), err: err}
+}
+
+func writeUsage(output io.Writer) {
+	_, _ = fmt.Fprintln(output, "usage: kubectl drive9 migration status [options]")
+	_, _ = fmt.Fprintln(output, "  -n, --namespace NAME       query one namespace")
+	_, _ = fmt.Fprintln(output, "  -A, --all-namespaces       query all namespaces")
+	_, _ = fmt.Fprintln(output, "      --batch NAME           select one migration batch")
+	_, _ = fmt.Fprintln(output, "      --context NAME         use a kubectl context")
+	_, _ = fmt.Fprintln(output, "      --kubeconfig PATH      use a kubeconfig file")
+	_, _ = fmt.Fprintln(output, "  -o, --output FORMAT        table (default), wide, or json")
+}

--- a/cmd/kubectl-drive9-migration/main.go
+++ b/cmd/kubectl-drive9-migration/main.go
@@ -1,3 +1,5 @@
+// Command kubectl-drive9-migration implements the read-only kubectl plugin for
+// aggregating Drive9 Migration Worker status.
 package main
 
 import (

--- a/cmd/kubectl-drive9-migration/main_test.go
+++ b/cmd/kubectl-drive9-migration/main_test.go
@@ -1,0 +1,305 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+type recordedCall struct {
+	name string
+	args []string
+}
+
+type fakeKubectl struct {
+	mu       sync.Mutex
+	calls    []recordedCall
+	podList  []byte
+	statuses map[string][]byte
+	errors   map[string]commandResult
+}
+
+func (f *fakeKubectl) run(_ context.Context, name string, args ...string) commandResult {
+	f.mu.Lock()
+	f.calls = append(f.calls, recordedCall{name: name, args: append([]string(nil), args...)})
+	f.mu.Unlock()
+
+	if len(args) > 0 && containsArg(args, "get") {
+		return commandResult{stdout: f.podList}
+	}
+	pod := argAfter(args, "--namespace") + "/" + argBefore(args, "--container")
+	if result, ok := f.errors[pod]; ok {
+		return result
+	}
+	return commandResult{stdout: f.statuses[pod]}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, arg := range args {
+		if arg == want {
+			return true
+		}
+	}
+	return false
+}
+
+func argAfter(args []string, want string) string {
+	for i := range args {
+		if args[i] == want && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func argBefore(args []string, want string) string {
+	for i := range args {
+		if args[i] == want && i > 0 {
+			return args[i-1]
+		}
+	}
+	return ""
+}
+
+func podListJSON(t *testing.T, pods ...map[string]any) []byte {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"apiVersion": "v1",
+		"kind":       "PodList",
+		"items":      pods,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func podJSON(namespace, name, batch, phase string) map[string]any {
+	labels := map[string]string{
+		"app.kubernetes.io/name":      "drive9-migration",
+		"app.kubernetes.io/component": "worker",
+	}
+	if batch != "" {
+		labels["app.kubernetes.io/instance"] = batch
+	}
+	return map[string]any{
+		"metadata": map[string]any{
+			"namespace": namespace,
+			"name":      name,
+			"labels":    labels,
+		},
+		"spec": map[string]any{
+			"nodeName":   "node-a",
+			"containers": []map[string]string{{"name": workerContainer}},
+		},
+		"status": map[string]string{"phase": phase},
+	}
+}
+
+func statusJSON(t *testing.T, volumeID, phase string, conditions map[string]bool) []byte {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"volume_id":         volumeID,
+		"node_name":         "node-a",
+		"space_ref":         "space-a",
+		"prefix":            "/data",
+		"phase":             phase,
+		"startup_phase":     phase,
+		"recovery_complete": true,
+		"round": map[string]any{
+			"id":              "round-1",
+			"mode":            "full",
+			"scan_complete":   true,
+			"round_converged": true,
+			"completed_at":    "2026-08-10T02:00:00Z",
+		},
+		"conditions":        conditions,
+		"source_count":      42,
+		"finding_counts":    map[string]int{},
+		"backlog":           0,
+		"full_verification": map[string]any{"status": "pending"},
+		"fence_intent":      phase == "CUTOVER_READY",
+		"fence_complete":    phase == "CUTOVER_READY",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func testDeps(fake *fakeKubectl) dependencies {
+	return dependencies{
+		ctx:         context.Background(),
+		now:         func() time.Time { return time.Date(2026, 8, 10, 3, 0, 0, 0, time.UTC) },
+		run:         fake.run,
+		execTimeout: time.Second,
+		concurrency: maxConcurrentExec,
+	}
+}
+
+func TestExecuteBuildsKubectlArguments(t *testing.T) {
+	fake := &fakeKubectl{
+		podList: podListJSON(t, podJSON("migration", "worker-a", "batch-a", "Running")),
+		statuses: map[string][]byte{
+			"migration/worker-a": statusJSON(t, "vol-001", "SYNCING", map[string]bool{
+				"ready_for_rollout": true, "current_converged": false, "attention": false,
+			}),
+		},
+	}
+	var stdout, stderr bytes.Buffer
+	args := []string{
+		"status", "--namespace", "migration", "--batch", "batch-a",
+		"--context", "prod", "--kubeconfig", "/tmp/kubeconfig",
+	}
+	if code := execute(args, &stdout, &stderr, testDeps(fake)); code != exitSuccess {
+		t.Fatalf("exit=%d stderr=%q", code, stderr.String())
+	}
+
+	want := []recordedCall{
+		{name: "kubectl", args: []string{
+			"--kubeconfig", "/tmp/kubeconfig", "--context", "prod",
+			"get", "pods", "--namespace", "migration",
+			"--selector", fixedSelector + ",app.kubernetes.io/instance=batch-a",
+			"--output", "json",
+		}},
+		{name: "kubectl", args: []string{
+			"--kubeconfig", "/tmp/kubeconfig", "--context", "prod",
+			"exec", "--namespace", "migration", "worker-a",
+			"--container", workerContainer, "--",
+			workerBinary, "status", "--output", "json",
+		}},
+	}
+	if !reflect.DeepEqual(fake.calls, want) {
+		t.Fatalf("calls=%#v\nwant=%#v", fake.calls, want)
+	}
+	if !strings.Contains(stdout.String(), "vol-001") || !strings.Contains(stdout.String(), "READY_FOR_ROLLOUT") {
+		t.Fatalf("stdout=%q", stdout.String())
+	}
+}
+
+func TestExecuteScopeArguments(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "current namespace",
+			args: []string{"status"},
+			want: []string{"get", "pods", "--selector", fixedSelector, "--output", "json"},
+		},
+		{
+			name: "all namespaces",
+			args: []string{"status", "--all-namespaces"},
+			want: []string{"get", "pods", "--all-namespaces", "--selector", fixedSelector, "--output", "json"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &fakeKubectl{podList: podListJSON(t), statuses: map[string][]byte{}}
+			if code := execute(tc.args, io.Discard, io.Discard, testDeps(fake)); code != exitFailure {
+				t.Fatalf("exit=%d, want %d for zero Pods", code, exitFailure)
+			}
+			if len(fake.calls) != 1 || !reflect.DeepEqual(fake.calls[0].args, tc.want) {
+				t.Fatalf("calls=%#v want args=%#v", fake.calls, tc.want)
+			}
+		})
+	}
+}
+
+func TestExecuteArgumentErrorsAndHelp(t *testing.T) {
+	fake := &fakeKubectl{}
+	deps := testDeps(fake)
+	for _, args := range [][]string{
+		{},
+		{"unknown"},
+		{"status", "--namespace", "a", "--all-namespaces"},
+		{"status", "--output", "yaml"},
+		{"status", "--batch", "bad,batch"},
+		{"status", "extra"},
+	} {
+		if code := execute(args, io.Discard, io.Discard, deps); code != exitUsage {
+			t.Fatalf("args=%v exit=%d, want %d", args, code, exitUsage)
+		}
+	}
+	var help bytes.Buffer
+	if code := execute([]string{"--help"}, &help, io.Discard, deps); code != exitSuccess {
+		t.Fatalf("help exit=%d", code)
+	}
+	if !strings.Contains(help.String(), "kubectl drive9 migration status") {
+		t.Fatalf("help=%q", help.String())
+	}
+	if len(fake.calls) != 0 {
+		t.Fatalf("invalid commands invoked kubectl: %#v", fake.calls)
+	}
+
+	var parseError bytes.Buffer
+	if code := execute([]string{"status", "--bogus"}, io.Discard, &parseError, deps); code != exitUsage {
+		t.Fatalf("unknown flag exit=%d", code)
+	}
+	if got := strings.Count(parseError.String(), "flag provided but not defined"); got != 1 {
+		t.Fatalf("unknown flag error count=%d, stderr=%q", got, parseError.String())
+	}
+}
+
+func TestExecuteAttentionIsSuccessfulButPendingIsPartial(t *testing.T) {
+	attention := &fakeKubectl{
+		podList: podListJSON(t, podJSON("migration", "worker-a", "batch-a", "Running")),
+		statuses: map[string][]byte{
+			"migration/worker-a": statusJSON(t, "vol-001", "SYNCING", map[string]bool{
+				"ready_for_rollout": false, "current_converged": false, "attention": true,
+			}),
+		},
+	}
+	var output bytes.Buffer
+	if code := execute([]string{"status"}, &output, io.Discard, testDeps(attention)); code != exitSuccess {
+		t.Fatalf("attention exit=%d output=%q", code, output.String())
+	}
+	if !strings.Contains(output.String(), "ATTENTION") {
+		t.Fatalf("attention output=%q", output.String())
+	}
+
+	pending := &fakeKubectl{
+		podList:  podListJSON(t, podJSON("migration", "worker-b", "batch-a", "Pending")),
+		statuses: map[string][]byte{},
+	}
+	output.Reset()
+	if code := execute([]string{"status"}, &output, io.Discard, testDeps(pending)); code != exitFailure {
+		t.Fatalf("pending exit=%d output=%q", code, output.String())
+	}
+	if !strings.Contains(output.String(), "POD_PENDING") {
+		t.Fatalf("pending output=%q", output.String())
+	}
+}
+
+func TestExecutePreservesSuccessWhenOneExecFails(t *testing.T) {
+	fake := &fakeKubectl{
+		podList: podListJSON(t,
+			podJSON("migration", "worker-a", "batch-a", "Running"),
+			podJSON("migration", "worker-b", "batch-a", "Running"),
+		),
+		statuses: map[string][]byte{
+			"migration/worker-a": statusJSON(t, "vol-001", "SYNCING", map[string]bool{
+				"ready_for_rollout": true, "current_converged": false, "attention": false,
+			}),
+		},
+		errors: map[string]commandResult{
+			"migration/worker-b": {stderr: []byte("pods/exec is forbidden\n"), err: errors.New("exit 1")},
+		},
+	}
+	var output bytes.Buffer
+	if code := execute([]string{"status"}, &output, io.Discard, testDeps(fake)); code != exitFailure {
+		t.Fatalf("exit=%d output=%q", code, output.String())
+	}
+	for _, want := range []string{"vol-001", "READY_FOR_ROLLOUT", "worker-b", "UNAVAILABLE"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("partial output omitted %q: %s", want, output.String())
+		}
+	}
+}

--- a/cmd/kubectl-drive9-migration/render.go
+++ b/cmd/kubectl-drive9-migration/render.go
@@ -33,15 +33,17 @@ func renderTable(output io.Writer, wide bool, jobs []jobResult, batches []batchS
 	table := tabwriter.NewWriter(output, 0, 4, 2, ' ', 0)
 	showBatch := shouldShowBatch(jobs)
 	if wide {
-		if _, err := fmt.Fprintln(table, "NAMESPACE\tBATCH\tJOB\tPHASE\tSTATUS\tROUND\tFILES\tDIFF\tRETRY\tVERIFY\tNODE\tPOD\tSPACE\tPREFIX\tPENDING\tIN_FLIGHT\tERROR"); err != nil {
+		if _, err := fmt.Fprintln(table, "NAMESPACE\tBATCH\tJOB\tPHASE\tSTATUS\tROUND\tFILES\tDIFF\tRETRY\tVERIFY\tNODE\tPOD\tSPACE\tPREFIX\tCAND_MTIME\tCAND_SOURCE_TOKEN_CHANGED\tCAND_NEW_PATH\tCAND_FILTERED\tPENDING\tIN_FLIGHT\tERROR"); err != nil {
 			return err
 		}
 		for _, job := range jobs {
 			status := job.parsed
-			if _, err := fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			candidateMtime, candidateSourceToken, candidateNewPath, candidateFiltered := candidateCounts(status)
+			if _, err := fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
 				valueOrDash(job.Namespace), valueOrDash(job.Batch), valueOrDash(job.JobID), valueOrDash(job.Phase),
 				job.DisplayStatus, roundDisplay(status), sourceCount(status), findingCount(status), retryCount(status),
 				verificationDisplay(status), valueOrDash(job.Node), valueOrDash(job.Pod), spaceRef(status), prefix(status),
+				candidateMtime, candidateSourceToken, candidateNewPath, candidateFiltered,
 				pendingRepairs(status), inFlight(status), valueOrDash(job.Error)); err != nil {
 				return err
 			}
@@ -165,6 +167,16 @@ func prefix(status *workerStatus) string {
 		return "-"
 	}
 	return valueOrDash(status.Prefix)
+}
+
+func candidateCounts(status *workerStatus) (string, string, string, string) {
+	if status == nil {
+		return "-", "-", "-", "-"
+	}
+	return strconv.Itoa(status.CandidateCounts.Mtime),
+		strconv.Itoa(status.CandidateCounts.SourceTokenChanged),
+		strconv.Itoa(status.CandidateCounts.NewPath),
+		strconv.Itoa(status.CandidateCounts.Filtered)
 }
 
 func pendingRepairs(status *workerStatus) string {

--- a/cmd/kubectl-drive9-migration/render.go
+++ b/cmd/kubectl-drive9-migration/render.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+)
+
+func renderStatus(output io.Writer, opts options, generatedAt time.Time, jobs []jobResult, batches []batchSummary) error {
+	if opts.output == "json" {
+		encoder := json.NewEncoder(output)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(aggregateOutput{
+			GeneratedAt: generatedAt,
+			Scope: queryScope{
+				Namespace:     opts.namespace,
+				AllNamespaces: opts.allNamespaces,
+				Batch:         opts.batch,
+				Context:       opts.contextName,
+			},
+			Batches: batches,
+			Jobs:    jobs,
+		})
+	}
+	return renderTable(output, opts.output == "wide", jobs, batches)
+}
+
+func renderTable(output io.Writer, wide bool, jobs []jobResult, batches []batchSummary) error {
+	table := tabwriter.NewWriter(output, 0, 4, 2, ' ', 0)
+	showBatch := shouldShowBatch(jobs)
+	if wide {
+		if _, err := fmt.Fprintln(table, "NAMESPACE\tBATCH\tJOB\tPHASE\tSTATUS\tROUND\tFILES\tDIFF\tRETRY\tVERIFY\tNODE\tPOD\tSPACE\tPREFIX\tPENDING\tIN_FLIGHT\tERROR"); err != nil {
+			return err
+		}
+		for _, job := range jobs {
+			status := job.parsed
+			if _, err := fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				valueOrDash(job.Namespace), valueOrDash(job.Batch), valueOrDash(job.JobID), valueOrDash(job.Phase),
+				job.DisplayStatus, roundDisplay(status), sourceCount(status), findingCount(status), retryCount(status),
+				verificationDisplay(status), valueOrDash(job.Node), valueOrDash(job.Pod), spaceRef(status), prefix(status),
+				pendingRepairs(status), inFlight(status), valueOrDash(job.Error)); err != nil {
+				return err
+			}
+		}
+	} else {
+		headers := make([]string, 0, 10)
+		if showBatch {
+			headers = append(headers, "BATCH")
+		}
+		headers = append(headers, "JOB", "PHASE", "STATUS", "ROUND", "FILES", "DIFF", "RETRY", "VERIFY", "POD")
+		if _, err := fmt.Fprintln(table, strings.Join(headers, "\t")); err != nil {
+			return err
+		}
+		for _, job := range jobs {
+			fields := make([]string, 0, 10)
+			if showBatch {
+				fields = append(fields, valueOrDash(job.Batch))
+			}
+			status := job.parsed
+			fields = append(fields,
+				valueOrDash(job.JobID), valueOrDash(job.Phase), job.DisplayStatus,
+				roundDisplay(status), sourceCount(status), findingCount(status), retryCount(status),
+				verificationDisplay(status), valueOrDash(job.Pod),
+			)
+			if _, err := fmt.Fprintln(table, strings.Join(fields, "\t")); err != nil {
+				return err
+			}
+		}
+	}
+	if err := table.Flush(); err != nil {
+		return err
+	}
+	if len(batches) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(output); err != nil {
+		return err
+	}
+	for _, summary := range batches {
+		name := summary.Batch
+		if summary.Namespace != "" {
+			name = summary.Namespace + "/" + name
+		}
+		if _, err := fmt.Fprintf(output,
+			"Batch %s: %s - observed %d jobs, %d available, %d attention, %d unavailable\n",
+			name, summary.Status, summary.ObservedJobs, summary.Available, summary.Attention, summary.Unavailable,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func shouldShowBatch(jobs []jobResult) bool {
+	batches := make(map[string]struct{})
+	for _, job := range jobs {
+		batches[job.Namespace+"\x00"+job.Batch] = struct{}{}
+	}
+	return len(batches) != 1 || (len(jobs) > 0 && jobs[0].Batch == missingBatch)
+}
+
+func roundDisplay(status *workerStatus) string {
+	if status == nil || status.Round.Mode == "" {
+		return "-"
+	}
+	suffix := ""
+	switch {
+	case status.Round.FailureClass != "":
+		suffix = "/failed"
+	case !status.Round.CompletedAt.IsZero() && status.Round.Converged:
+		suffix = "/ok"
+	case !status.Round.CompletedAt.IsZero():
+		suffix = "/complete"
+	case !status.Round.StartedAt.IsZero() || status.Round.ID != "":
+		suffix = "/running"
+	}
+	return string(status.Round.Mode) + suffix
+}
+
+func sourceCount(status *workerStatus) string {
+	if status == nil {
+		return "-"
+	}
+	return strconv.Itoa(status.SourceCount)
+}
+
+func findingCount(status *workerStatus) string {
+	if status == nil {
+		return "-"
+	}
+	total := 0
+	for _, count := range status.FindingCounts {
+		total += count
+	}
+	return strconv.Itoa(total)
+}
+
+func retryCount(status *workerStatus) string {
+	if status == nil {
+		return "-"
+	}
+	return strconv.Itoa(status.Backlog)
+}
+
+func verificationDisplay(status *workerStatus) string {
+	if status == nil || status.Verification.Status == "" {
+		return "-"
+	}
+	return strings.ToUpper(status.Verification.Status)
+}
+
+func spaceRef(status *workerStatus) string {
+	if status == nil {
+		return "-"
+	}
+	return valueOrDash(status.SpaceRef)
+}
+
+func prefix(status *workerStatus) string {
+	if status == nil {
+		return "-"
+	}
+	return valueOrDash(status.Prefix)
+}
+
+func pendingRepairs(status *workerStatus) string {
+	if status == nil {
+		return "-"
+	}
+	return strconv.Itoa(status.PendingRepairs)
+}
+
+func inFlight(status *workerStatus) string {
+	if status == nil {
+		return "-"
+	}
+	return strconv.Itoa(status.InFlight)
+}
+
+func valueOrDash(value string) string {
+	if value == "" {
+		return "-"
+	}
+	return value
+}

--- a/cmd/kubectl-drive9-migration/render_test.go
+++ b/cmd/kubectl-drive9-migration/render_test.go
@@ -13,6 +13,9 @@ func renderedJob(namespace, batch, pod, volumeID string) jobResult {
 		VolumeID: volumeID, NodeName: "node-a", SpaceRef: "space-a", Prefix: "/data",
 		Phase: "SYNCING", StartupPhase: "SYNCING", SourceCount: 42,
 		Conditions: workerConditions{ReadyForRollout: true},
+		CandidateCounts: workerCandidates{
+			Mtime: 3, SourceTokenChanged: 5, NewPath: 7, Filtered: 11,
+		},
 		Round: workerRound{
 			ID: "round-1", Mode: "full", CompletedAt: time.Date(2026, 8, 10, 2, 0, 0, 0, time.UTC),
 			ScanComplete: true, Converged: true,
@@ -69,7 +72,11 @@ func TestRenderWideIncludesOperationalDetails(t *testing.T) {
 	if err := renderStatus(&output, options{output: "wide"}, time.Now(), []jobResult{job}, summarizeBatches([]jobResult{job})); err != nil {
 		t.Fatal(err)
 	}
-	for _, want := range []string{"NAMESPACE", "NODE", "SPACE", "PREFIX", "IN_FLIGHT", "migration", "node-a", "space-a", "/data", "bounded detail"} {
+	for _, want := range []string{
+		"NAMESPACE", "NODE", "SPACE", "PREFIX", "CAND_MTIME", "CAND_SOURCE_TOKEN_CHANGED",
+		"CAND_NEW_PATH", "CAND_FILTERED", "IN_FLIGHT", "migration", "node-a",
+		"space-a", "/data", "3", "5", "7", "11", "bounded detail",
+	} {
 		if !strings.Contains(output.String(), want) {
 			t.Fatalf("wide output omitted %q:\n%s", want, output.String())
 		}

--- a/cmd/kubectl-drive9-migration/render_test.go
+++ b/cmd/kubectl-drive9-migration/render_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func renderedJob(namespace, batch, pod, volumeID string) jobResult {
+	status := &workerStatus{
+		VolumeID: volumeID, NodeName: "node-a", SpaceRef: "space-a", Prefix: "/data",
+		Phase: "SYNCING", StartupPhase: "SYNCING", SourceCount: 42,
+		Conditions: workerConditions{ReadyForRollout: true},
+		Round: workerRound{
+			ID: "round-1", Mode: "full", CompletedAt: time.Date(2026, 8, 10, 2, 0, 0, 0, time.UTC),
+			ScanComplete: true, Converged: true,
+		},
+		Verification: workerVerification{Status: "pending"},
+	}
+	return jobResult{
+		Namespace: namespace, Batch: batch, Pod: pod, Node: "node-a", PodPhase: "Running",
+		JobID: volumeID, Phase: "SYNCING", DisplayStatus: "READY_FOR_ROLLOUT",
+		Worker: json.RawMessage(`{"volume_id":"` + volumeID + `","future_field":true}`),
+		parsed: status,
+	}
+}
+
+func TestRenderCompactTableAndSummaries(t *testing.T) {
+	jobs := []jobResult{
+		renderedJob("migration", "batch-a", "worker-b", "vol-002"),
+		renderedJob("migration", "batch-a", "worker-a", "vol-001"),
+	}
+	sortJobs(jobs)
+	batches := summarizeBatches(jobs)
+	var output bytes.Buffer
+	if err := renderStatus(&output, options{output: "table"}, time.Now(), jobs, batches); err != nil {
+		t.Fatal(err)
+	}
+	text := output.String()
+	if !strings.HasPrefix(text, "JOB") || strings.HasPrefix(text, "BATCH") {
+		t.Fatalf("single-batch header=%q", strings.SplitN(text, "\n", 2)[0])
+	}
+	if strings.Index(text, "vol-001") > strings.Index(text, "vol-002") {
+		t.Fatalf("rows are not sorted: %s", text)
+	}
+	for _, want := range []string{"READY_FOR_ROLLOUT", "full/ok", "42", "Batch migration/batch-a: READY_FOR_ROLLOUT", "observed 2 jobs"} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("output omitted %q:\n%s", want, text)
+		}
+	}
+
+	jobs = append(jobs, renderedJob("migration", "batch-b", "worker-c", "vol-003"))
+	sortJobs(jobs)
+	output.Reset()
+	if err := renderStatus(&output, options{output: "table"}, time.Now(), jobs, summarizeBatches(jobs)); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(output.String(), "BATCH") {
+		t.Fatalf("multi-batch output omitted BATCH: %s", output.String())
+	}
+}
+
+func TestRenderWideIncludesOperationalDetails(t *testing.T) {
+	job := renderedJob("migration", "batch-a", "worker-a", "vol-001")
+	job.Error = "bounded detail"
+	var output bytes.Buffer
+	if err := renderStatus(&output, options{output: "wide"}, time.Now(), []jobResult{job}, summarizeBatches([]jobResult{job})); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"NAMESPACE", "NODE", "SPACE", "PREFIX", "IN_FLIGHT", "migration", "node-a", "space-a", "/data", "bounded detail"} {
+		if !strings.Contains(output.String(), want) {
+			t.Fatalf("wide output omitted %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestRenderJSONPreservesRawWorkerAndOmitsKubeconfig(t *testing.T) {
+	generatedAt := time.Date(2026, 8, 10, 3, 0, 0, 0, time.UTC)
+	job := renderedJob("migration", "batch-a", "worker-a", "vol-001")
+	var output bytes.Buffer
+	opts := options{
+		output: "json", namespace: "migration", batch: "batch-a", contextName: "prod",
+		kubeconfig: "/secret/kubeconfig",
+	}
+	if err := renderStatus(&output, opts, generatedAt, []jobResult{job}, summarizeBatches([]jobResult{job})); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(output.String(), "/secret/kubeconfig") {
+		t.Fatalf("JSON leaked kubeconfig path: %s", output.String())
+	}
+	var aggregate aggregateOutput
+	if err := json.Unmarshal(output.Bytes(), &aggregate); err != nil {
+		t.Fatal(err)
+	}
+	if !aggregate.GeneratedAt.Equal(generatedAt) || aggregate.Scope.Context != "prod" || len(aggregate.Jobs) != 1 {
+		t.Fatalf("aggregate=%+v", aggregate)
+	}
+	if !strings.Contains(string(aggregate.Jobs[0].Worker), "future_field") {
+		t.Fatalf("raw Worker payload not preserved: %s", aggregate.Jobs[0].Worker)
+	}
+}

--- a/cmd/kubectl-drive9-migration/status.go
+++ b/cmd/kubectl-drive9-migration/status.go
@@ -288,7 +288,7 @@ func summarizeBatches(jobs []jobResult) []batchSummary {
 			Status:       deriveBatchStatus(group),
 		}
 		for _, job := range group {
-			if job.parsed != nil {
+			if !job.collectionFailed {
 				summary.Available++
 			} else {
 				summary.Unavailable++

--- a/cmd/kubectl-drive9-migration/status.go
+++ b/cmd/kubectl-drive9-migration/status.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+	"sync"
+)
+
+func collectStatus(ctx context.Context, opts options, deps dependencies) ([]jobResult, []batchSummary, bool, error) {
+	listed := deps.run(ctx, "kubectl", getPodsArgs(opts)...)
+	if listed.err != nil {
+		return nil, nil, false, fmt.Errorf("list Drive9 Migration Worker Pods: %s", commandError(listed, ctx.Err()))
+	}
+	var pods podList
+	if err := decodeOneJSON(listed.stdout, &pods); err != nil {
+		return nil, nil, false, fmt.Errorf("decode kubectl Pod list: %w", err)
+	}
+	if len(pods.Items) == 0 {
+		return nil, nil, false, errors.New("no Drive9 Migration Worker Pods matched the requested scope")
+	}
+
+	jobs := make([]jobResult, len(pods.Items))
+	execIndexes := make([]int, 0, len(pods.Items))
+	for i := range pods.Items {
+		item := &pods.Items[i]
+		batch := item.Metadata.Labels[instanceLabel]
+		if batch == "" {
+			batch = missingBatch
+		}
+		jobs[i] = jobResult{
+			Namespace: item.Metadata.Namespace,
+			Batch:     batch,
+			Pod:       item.Metadata.Name,
+			Node:      item.Spec.NodeName,
+			PodPhase:  item.Status.Phase,
+		}
+		switch {
+		case item.Metadata.Name == "" || item.Metadata.Namespace == "":
+			markCollectionFailure(&jobs[i], "UNAVAILABLE", "Pod identity is incomplete")
+		case item.Metadata.DeletionTimestamp != nil:
+			markCollectionFailure(&jobs[i], "TERMINATING", "Pod is terminating")
+		case item.Status.Phase != "Running":
+			phase := strings.ToUpper(item.Status.Phase)
+			if phase == "" {
+				phase = "UNKNOWN"
+			}
+			markCollectionFailure(&jobs[i], "POD_"+phase, "Pod phase is "+emptyAsUnknown(item.Status.Phase))
+		case !hasContainer(*item, workerContainer):
+			markCollectionFailure(&jobs[i], "UNAVAILABLE", "Pod has no drive9-migration container")
+		default:
+			execIndexes = append(execIndexes, i)
+		}
+	}
+
+	semaphore := make(chan struct{}, deps.concurrency)
+	var wait sync.WaitGroup
+	for _, index := range execIndexes {
+		index := index
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			select {
+			case semaphore <- struct{}{}:
+				defer func() { <-semaphore }()
+			case <-ctx.Done():
+				markCollectionFailure(&jobs[index], "UNAVAILABLE", normalizeMessage(ctx.Err().Error()))
+				return
+			}
+			queryWorker(ctx, opts, deps, &jobs[index])
+		}()
+	}
+	wait.Wait()
+
+	for i := range jobs {
+		if jobs[i].parsed == nil {
+			continue
+		}
+		jobs[i].JobID = jobs[i].parsed.VolumeID
+		jobs[i].Phase = jobs[i].parsed.Phase
+		if jobs[i].Batch == missingBatch {
+			markCollectionFailure(&jobs[i], "UNAVAILABLE", "Pod is missing "+instanceLabel)
+			continue
+		}
+		jobs[i].DisplayStatus = deriveJobStatus(*jobs[i].parsed)
+	}
+	markDuplicates(jobs)
+	sortJobs(jobs)
+	batches := summarizeBatches(jobs)
+	partial := false
+	for i := range jobs {
+		partial = partial || jobs[i].collectionFailed
+	}
+	return jobs, batches, partial, nil
+}
+
+func getPodsArgs(opts options) []string {
+	args := kubectlGlobalArgs(opts)
+	args = append(args, "get", "pods")
+	if opts.namespace != "" {
+		args = append(args, "--namespace", opts.namespace)
+	} else if opts.allNamespaces {
+		args = append(args, "--all-namespaces")
+	}
+	selector := fixedSelector
+	if opts.batch != "" {
+		selector += "," + instanceLabel + "=" + opts.batch
+	}
+	return append(args, "--selector", selector, "--output", "json")
+}
+
+func execWorkerArgs(opts options, job jobResult) []string {
+	args := kubectlGlobalArgs(opts)
+	return append(args,
+		"exec", "--namespace", job.Namespace, job.Pod,
+		"--container", workerContainer, "--",
+		workerBinary, "status", "--output", "json",
+	)
+}
+
+func kubectlGlobalArgs(opts options) []string {
+	args := make([]string, 0, 4)
+	if opts.kubeconfig != "" {
+		args = append(args, "--kubeconfig", opts.kubeconfig)
+	}
+	if opts.contextName != "" {
+		args = append(args, "--context", opts.contextName)
+	}
+	return args
+}
+
+func queryWorker(parent context.Context, opts options, deps dependencies, job *jobResult) {
+	ctx, cancel := context.WithTimeout(parent, deps.execTimeout)
+	defer cancel()
+	result := deps.run(ctx, "kubectl", execWorkerArgs(opts, *job)...)
+	if result.err != nil {
+		markCollectionFailure(job, "UNAVAILABLE", commandError(result, ctx.Err()))
+		return
+	}
+	status, raw, err := decodeWorkerStatus(result.stdout)
+	if err != nil {
+		markCollectionFailure(job, "UNAVAILABLE", "invalid Worker status: "+err.Error())
+		return
+	}
+	job.parsed = &status
+	job.Worker = raw
+}
+
+func decodeWorkerStatus(body []byte) (workerStatus, json.RawMessage, error) {
+	trimmed := bytes.TrimSpace(body)
+	var fields map[string]json.RawMessage
+	if err := decodeOneJSON(trimmed, &fields); err != nil {
+		return workerStatus{}, nil, err
+	}
+	for _, name := range []string{"volume_id", "phase", "startup_phase", "conditions", "fence_intent", "fence_complete"} {
+		if _, ok := fields[name]; !ok {
+			return workerStatus{}, nil, fmt.Errorf("missing %s", name)
+		}
+	}
+	for _, name := range []string{"fence_intent", "fence_complete"} {
+		if err := validateBooleanField(fields, name, name); err != nil {
+			return workerStatus{}, nil, err
+		}
+	}
+	var conditionFields map[string]json.RawMessage
+	if err := json.Unmarshal(fields["conditions"], &conditionFields); err != nil {
+		return workerStatus{}, nil, fmt.Errorf("decode conditions: %w", err)
+	}
+	for _, name := range []string{"ready_for_rollout", "current_converged", "attention"} {
+		if err := validateBooleanField(conditionFields, name, "conditions."+name); err != nil {
+			return workerStatus{}, nil, err
+		}
+	}
+	var status workerStatus
+	if err := json.Unmarshal(trimmed, &status); err != nil {
+		return workerStatus{}, nil, err
+	}
+	if status.VolumeID == "" {
+		return workerStatus{}, nil, errors.New("empty volume_id")
+	}
+	if !validPhase(status.Phase) {
+		return workerStatus{}, nil, fmt.Errorf("invalid phase %q", status.Phase)
+	}
+	if !validPhase(status.StartupPhase) {
+		return workerStatus{}, nil, fmt.Errorf("invalid startup_phase %q", status.StartupPhase)
+	}
+	raw := append(json.RawMessage(nil), trimmed...)
+	return status, raw, nil
+}
+
+func validateBooleanField(fields map[string]json.RawMessage, name, path string) error {
+	raw, ok := fields[name]
+	if !ok {
+		return fmt.Errorf("missing %s", path)
+	}
+	var value *bool
+	if err := json.Unmarshal(raw, &value); err != nil {
+		return fmt.Errorf("decode %s: %w", path, err)
+	}
+	if value == nil {
+		return fmt.Errorf("%s must be a boolean", path)
+	}
+	return nil
+}
+
+func decodeOneJSON(body []byte, destination any) error {
+	decoder := json.NewDecoder(bytes.NewReader(body))
+	if err := decoder.Decode(destination); err != nil {
+		return err
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return errors.New("trailing JSON data")
+		}
+		return err
+	}
+	return nil
+}
+
+func validPhase(phase string) bool {
+	return phase == "SYNCING" || phase == "DUAL_WRITE_REPAIRING" || phase == "CUTOVER_READY"
+}
+
+func hasContainer(item pod, name string) bool {
+	for _, container := range item.Spec.Containers {
+		if container.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func deriveJobStatus(status workerStatus) string {
+	switch {
+	case status.Conditions.Attention:
+		return "ATTENTION"
+	case status.Phase == "CUTOVER_READY" && status.FenceComplete:
+		return "CUTOVER_READY"
+	case status.Phase == "CUTOVER_READY":
+		return "ATTENTION"
+	case status.Conditions.ReadyForRollout:
+		return "READY_FOR_ROLLOUT"
+	case status.Conditions.CurrentConverged:
+		return "CONVERGED"
+	case status.Phase == "DUAL_WRITE_REPAIRING":
+		return "REPAIRING"
+	default:
+		return "SYNCING"
+	}
+}
+
+func markDuplicates(jobs []jobResult) {
+	indexes := make(map[string][]int)
+	for i := range jobs {
+		if jobs[i].parsed == nil || jobs[i].Batch == missingBatch {
+			continue
+		}
+		key := jobs[i].Namespace + "\x00" + jobs[i].Batch + "\x00" + jobs[i].JobID
+		indexes[key] = append(indexes[key], i)
+	}
+	for _, duplicates := range indexes {
+		if len(duplicates) < 2 {
+			continue
+		}
+		for _, index := range duplicates {
+			markCollectionFailure(&jobs[index], "DUPLICATE", "multiple Pods report this Job identity")
+		}
+	}
+}
+
+func summarizeBatches(jobs []jobResult) []batchSummary {
+	grouped := make(map[string][]jobResult)
+	for _, job := range jobs {
+		key := job.Namespace + "\x00" + job.Batch
+		grouped[key] = append(grouped[key], job)
+	}
+	summaries := make([]batchSummary, 0, len(grouped))
+	for _, group := range grouped {
+		summary := batchSummary{
+			Namespace:    group[0].Namespace,
+			Batch:        group[0].Batch,
+			ObservedJobs: len(group),
+			Status:       deriveBatchStatus(group),
+		}
+		for _, job := range group {
+			if job.parsed != nil {
+				summary.Available++
+			} else {
+				summary.Unavailable++
+			}
+			if job.DisplayStatus == "ATTENTION" {
+				summary.Attention++
+			}
+		}
+		summaries = append(summaries, summary)
+	}
+	sort.Slice(summaries, func(i, j int) bool {
+		if summaries[i].Namespace != summaries[j].Namespace {
+			return summaries[i].Namespace < summaries[j].Namespace
+		}
+		return summaries[i].Batch < summaries[j].Batch
+	})
+	return summaries
+}
+
+func deriveBatchStatus(jobs []jobResult) string {
+	phases := make(map[string]struct{})
+	for _, job := range jobs {
+		switch job.DisplayStatus {
+		case "UNAVAILABLE", "DUPLICATE", "ATTENTION", "TERMINATING":
+			return "NEEDS_ATTENTION"
+		}
+		if strings.HasPrefix(job.DisplayStatus, "POD_") || job.Batch == missingBatch || job.parsed == nil {
+			return "NEEDS_ATTENTION"
+		}
+		phases[job.Phase] = struct{}{}
+	}
+	if len(phases) != 1 {
+		return "MIXED_PHASE"
+	}
+	for phase := range phases {
+		switch phase {
+		case "CUTOVER_READY":
+			return "CUTOVER_READY"
+		case "DUAL_WRITE_REPAIRING":
+			for _, job := range jobs {
+				if job.DisplayStatus != "CONVERGED" {
+					return "REPAIRING"
+				}
+			}
+			return "CONVERGED"
+		case "SYNCING":
+			for _, job := range jobs {
+				if job.DisplayStatus != "READY_FOR_ROLLOUT" {
+					return "SYNCING"
+				}
+			}
+			return "READY_FOR_ROLLOUT"
+		default:
+			return "NEEDS_ATTENTION"
+		}
+	}
+	return "NEEDS_ATTENTION"
+}
+
+func sortJobs(jobs []jobResult) {
+	sort.SliceStable(jobs, func(i, j int) bool {
+		left, right := jobs[i], jobs[j]
+		if left.Namespace != right.Namespace {
+			return left.Namespace < right.Namespace
+		}
+		if left.Batch != right.Batch {
+			return left.Batch < right.Batch
+		}
+		if left.JobID != right.JobID {
+			return left.JobID < right.JobID
+		}
+		return left.Pod < right.Pod
+	})
+}
+
+func markCollectionFailure(job *jobResult, status, message string) {
+	job.DisplayStatus = status
+	job.collectionFailed = true
+	message = normalizeMessage(message)
+	if job.Error == "" {
+		job.Error = message
+	} else if message != "" && !strings.Contains(job.Error, message) {
+		job.Error = normalizeMessage(job.Error + "; " + message)
+	}
+}
+
+func commandError(result commandResult, contextErr error) string {
+	if contextErr != nil {
+		return normalizeMessage(contextErr.Error())
+	}
+	if message := normalizeMessage(string(result.stderr)); message != "" {
+		return message
+	}
+	if result.err != nil {
+		return normalizeMessage(result.err.Error())
+	}
+	return "kubectl command failed"
+}
+
+func normalizeMessage(message string) string {
+	message = strings.Join(strings.Fields(message), " ")
+	runes := []rune(message)
+	if len(runes) > maxErrorLength {
+		message = string(runes[:maxErrorLength])
+	}
+	return message
+}
+
+func emptyAsUnknown(value string) string {
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}

--- a/cmd/kubectl-drive9-migration/status_test.go
+++ b/cmd/kubectl-drive9-migration/status_test.go
@@ -173,6 +173,22 @@ func TestDeriveBatchStatus(t *testing.T) {
 	}
 }
 
+func TestSummarizeBatchesCountsCollectionFailuresAsUnavailable(t *testing.T) {
+	available := batchJob("available", "SYNCING", "SYNCING")
+	attention := batchJob("attention", "SYNCING", "ATTENTION")
+	unavailable := batchJob("duplicate", "SYNCING", "DUPLICATE")
+	unavailable.collectionFailed = true
+
+	summaries := summarizeBatches([]jobResult{available, attention, unavailable})
+	if len(summaries) != 1 {
+		t.Fatalf("summaries=%+v", summaries)
+	}
+	summary := summaries[0]
+	if summary.Available != 2 || summary.Attention != 1 || summary.Unavailable != 1 {
+		t.Fatalf("summary=%+v", summary)
+	}
+}
+
 func TestCollectStatusPreservesFailuresAndDetectsDuplicates(t *testing.T) {
 	fake := &fakeKubectl{
 		podList: podListJSON(t,
@@ -200,6 +216,16 @@ func TestCollectStatusPreservesFailuresAndDetectsDuplicates(t *testing.T) {
 	}
 	if !partial || len(jobs) != 4 || len(batches) != 2 {
 		t.Fatalf("partial=%v jobs=%d batches=%+v", partial, len(jobs), batches)
+	}
+	byBatch := make(map[string]batchSummary)
+	for _, batch := range batches {
+		byBatch[batch.Batch] = batch
+	}
+	if batch := byBatch["batch-a"]; batch.Available != 0 || batch.Unavailable != 3 {
+		t.Fatalf("duplicate batch summary=%+v", batch)
+	}
+	if batch := byBatch[missingBatch]; batch.Available != 0 || batch.Unavailable != 1 {
+		t.Fatalf("missing-label batch summary=%+v", batch)
 	}
 	byPod := make(map[string]jobResult)
 	for _, job := range jobs {

--- a/cmd/kubectl-drive9-migration/status_test.go
+++ b/cmd/kubectl-drive9-migration/status_test.go
@@ -1,0 +1,351 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func mutateStatusJSON(t *testing.T, mutate func(map[string]any)) []byte {
+	t.Helper()
+	var document map[string]any
+	if err := json.Unmarshal(statusJSON(t, "vol-001", "SYNCING", map[string]bool{
+		"ready_for_rollout": false, "current_converged": false, "attention": false,
+	}), &document); err != nil {
+		t.Fatal(err)
+	}
+	mutate(document)
+	body, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return body
+}
+
+func TestDecodeWorkerStatusValidation(t *testing.T) {
+	withFutureField := mutateStatusJSON(t, func(document map[string]any) {
+		document["future_field"] = map[string]any{"kept": true}
+	})
+	status, raw, err := decodeWorkerStatus(withFutureField)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.VolumeID != "vol-001" || !strings.Contains(string(raw), "future_field") {
+		t.Fatalf("status=%+v raw=%s", status, raw)
+	}
+
+	for _, tc := range []struct {
+		name string
+		body []byte
+		want string
+	}{
+		{name: "empty", body: nil, want: "EOF"},
+		{name: "malformed", body: []byte("{"), want: "unexpected EOF"},
+		{name: "trailing", body: append(statusJSON(t, "vol-001", "SYNCING", map[string]bool{
+			"ready_for_rollout": false, "current_converged": false, "attention": false,
+		}), []byte("\n{}")...), want: "trailing JSON"},
+		{name: "missing identity", body: mutateStatusJSON(t, func(document map[string]any) {
+			delete(document, "volume_id")
+		}), want: "missing volume_id"},
+		{name: "empty identity", body: mutateStatusJSON(t, func(document map[string]any) {
+			document["volume_id"] = ""
+		}), want: "empty volume_id"},
+		{name: "invalid phase", body: mutateStatusJSON(t, func(document map[string]any) {
+			document["phase"] = "UNKNOWN"
+		}), want: "invalid phase"},
+		{name: "missing condition", body: mutateStatusJSON(t, func(document map[string]any) {
+			delete(document["conditions"].(map[string]any), "attention")
+		}), want: "missing conditions.attention"},
+		{name: "missing fence", body: mutateStatusJSON(t, func(document map[string]any) {
+			delete(document, "fence_complete")
+		}), want: "missing fence_complete"},
+		{name: "null fence", body: mutateStatusJSON(t, func(document map[string]any) {
+			document["fence_complete"] = nil
+		}), want: "fence_complete must be a boolean"},
+		{name: "null condition", body: mutateStatusJSON(t, func(document map[string]any) {
+			document["conditions"].(map[string]any)["attention"] = nil
+		}), want: "conditions.attention must be a boolean"},
+		{name: "wrong fence type", body: mutateStatusJSON(t, func(document map[string]any) {
+			document["fence_complete"] = "false"
+		}), want: "cannot unmarshal string"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := decodeWorkerStatus(tc.body)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error=%v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestDeriveJobStatus(t *testing.T) {
+	base := workerStatus{Phase: "SYNCING", StartupPhase: "SYNCING"}
+	for _, tc := range []struct {
+		name   string
+		mutate func(*workerStatus)
+		want   string
+	}{
+		{name: "syncing", want: "SYNCING"},
+		{name: "ready for rollout", mutate: func(status *workerStatus) {
+			status.Conditions.ReadyForRollout = true
+		}, want: "READY_FOR_ROLLOUT"},
+		{name: "repairing", mutate: func(status *workerStatus) {
+			status.Phase, status.StartupPhase = "DUAL_WRITE_REPAIRING", "DUAL_WRITE_REPAIRING"
+		}, want: "REPAIRING"},
+		{name: "converged", mutate: func(status *workerStatus) {
+			status.Phase, status.StartupPhase = "DUAL_WRITE_REPAIRING", "DUAL_WRITE_REPAIRING"
+			status.Conditions.CurrentConverged = true
+		}, want: "CONVERGED"},
+		{name: "attention wins", mutate: func(status *workerStatus) {
+			status.Conditions.ReadyForRollout = true
+			status.Conditions.Attention = true
+		}, want: "ATTENTION"},
+		{name: "cutover", mutate: func(status *workerStatus) {
+			status.Phase, status.StartupPhase = "CUTOVER_READY", "DUAL_WRITE_REPAIRING"
+			status.FenceComplete = true
+		}, want: "CUTOVER_READY"},
+		{name: "incomplete fence", mutate: func(status *workerStatus) {
+			status.Phase, status.StartupPhase = "CUTOVER_READY", "DUAL_WRITE_REPAIRING"
+		}, want: "ATTENTION"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			status := base
+			if tc.mutate != nil {
+				tc.mutate(&status)
+			}
+			if got := deriveJobStatus(status); got != tc.want {
+				t.Fatalf("status=%s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func batchJob(pod, phase, display string) jobResult {
+	status := &workerStatus{VolumeID: "vol-" + pod, Phase: phase, StartupPhase: phase}
+	return jobResult{
+		Namespace: "migration", Batch: "batch-a", Pod: pod, JobID: status.VolumeID,
+		Phase: phase, DisplayStatus: display, parsed: status,
+	}
+}
+
+func TestDeriveBatchStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		jobs []jobResult
+		want string
+	}{
+		{name: "needs attention", jobs: []jobResult{batchJob("a", "SYNCING", "ATTENTION")}, want: "NEEDS_ATTENTION"},
+		{name: "mixed phase", jobs: []jobResult{
+			batchJob("a", "SYNCING", "SYNCING"),
+			batchJob("b", "DUAL_WRITE_REPAIRING", "REPAIRING"),
+		}, want: "MIXED_PHASE"},
+		{name: "syncing", jobs: []jobResult{
+			batchJob("a", "SYNCING", "READY_FOR_ROLLOUT"),
+			batchJob("b", "SYNCING", "SYNCING"),
+		}, want: "SYNCING"},
+		{name: "ready", jobs: []jobResult{
+			batchJob("a", "SYNCING", "READY_FOR_ROLLOUT"),
+			batchJob("b", "SYNCING", "READY_FOR_ROLLOUT"),
+		}, want: "READY_FOR_ROLLOUT"},
+		{name: "repairing", jobs: []jobResult{
+			batchJob("a", "DUAL_WRITE_REPAIRING", "CONVERGED"),
+			batchJob("b", "DUAL_WRITE_REPAIRING", "REPAIRING"),
+		}, want: "REPAIRING"},
+		{name: "converged", jobs: []jobResult{
+			batchJob("a", "DUAL_WRITE_REPAIRING", "CONVERGED"),
+			batchJob("b", "DUAL_WRITE_REPAIRING", "CONVERGED"),
+		}, want: "CONVERGED"},
+		{name: "cutover", jobs: []jobResult{
+			batchJob("a", "CUTOVER_READY", "CUTOVER_READY"),
+			batchJob("b", "CUTOVER_READY", "CUTOVER_READY"),
+		}, want: "CUTOVER_READY"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deriveBatchStatus(tc.jobs); got != tc.want {
+				t.Fatalf("status=%s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCollectStatusPreservesFailuresAndDetectsDuplicates(t *testing.T) {
+	fake := &fakeKubectl{
+		podList: podListJSON(t,
+			podJSON("migration", "worker-a", "batch-a", "Running"),
+			podJSON("migration", "worker-b", "batch-a", "Running"),
+			podJSON("migration", "worker-c", "batch-a", "Pending"),
+			podJSON("migration", "worker-d", "", "Running"),
+		),
+		statuses: map[string][]byte{
+			"migration/worker-a": statusJSON(t, "vol-001", "SYNCING", map[string]bool{
+				"ready_for_rollout": true, "current_converged": false, "attention": false,
+			}),
+			"migration/worker-b": statusJSON(t, "vol-001", "SYNCING", map[string]bool{
+				"ready_for_rollout": true, "current_converged": false, "attention": false,
+			}),
+			"migration/worker-d": statusJSON(t, "vol-004", "SYNCING", map[string]bool{
+				"ready_for_rollout": false, "current_converged": false, "attention": false,
+			}),
+		},
+	}
+	deps := normalizeDependencies(testDeps(fake))
+	jobs, batches, partial, err := collectStatus(context.Background(), options{}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !partial || len(jobs) != 4 || len(batches) != 2 {
+		t.Fatalf("partial=%v jobs=%d batches=%+v", partial, len(jobs), batches)
+	}
+	byPod := make(map[string]jobResult)
+	for _, job := range jobs {
+		byPod[job.Pod] = job
+	}
+	for _, pod := range []string{"worker-a", "worker-b"} {
+		if byPod[pod].DisplayStatus != "DUPLICATE" {
+			t.Fatalf("%s status=%s", pod, byPod[pod].DisplayStatus)
+		}
+	}
+	if byPod["worker-c"].DisplayStatus != "POD_PENDING" {
+		t.Fatalf("pending=%+v", byPod["worker-c"])
+	}
+	if byPod["worker-d"].DisplayStatus != "UNAVAILABLE" || byPod["worker-d"].Batch != missingBatch {
+		t.Fatalf("missing label=%+v", byPod["worker-d"])
+	}
+}
+
+func TestCollectStatusPreservesNonRunningAndInvalidPods(t *testing.T) {
+	failed := podJSON("migration", "worker-failed", "batch-a", "Failed")
+	succeeded := podJSON("migration", "worker-succeeded", "batch-a", "Succeeded")
+	terminating := podJSON("migration", "worker-terminating", "batch-a", "Running")
+	terminating["metadata"].(map[string]any)["deletionTimestamp"] = "2026-08-10T03:00:00Z"
+	wrongContainer := podJSON("migration", "worker-wrong-container", "batch-a", "Running")
+	wrongContainer["spec"].(map[string]any)["containers"] = []map[string]string{{"name": "sidecar"}}
+	fake := &fakeKubectl{
+		podList:  podListJSON(t, failed, succeeded, terminating, wrongContainer),
+		statuses: map[string][]byte{},
+	}
+	deps := normalizeDependencies(testDeps(fake))
+	jobs, _, partial, err := collectStatus(context.Background(), options{}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !partial || len(fake.calls) != 1 {
+		t.Fatalf("partial=%v calls=%#v", partial, fake.calls)
+	}
+	byPod := make(map[string]string)
+	for _, job := range jobs {
+		byPod[job.Pod] = job.DisplayStatus
+	}
+	want := map[string]string{
+		"worker-failed":          "POD_FAILED",
+		"worker-succeeded":       "POD_SUCCEEDED",
+		"worker-terminating":     "TERMINATING",
+		"worker-wrong-container": "UNAVAILABLE",
+	}
+	for pod, status := range want {
+		if byPod[pod] != status {
+			t.Fatalf("%s status=%q, want %q", pod, byPod[pod], status)
+		}
+	}
+}
+
+func TestCollectStatusCapsConcurrency(t *testing.T) {
+	pods := make([]map[string]any, 0, 12)
+	statuses := make(map[string][]byte)
+	for i := 0; i < 12; i++ {
+		pod := fmt.Sprintf("worker-%02d", i)
+		pods = append(pods, podJSON("migration", pod, "batch-a", "Running"))
+		statuses[pod] = statusJSON(t, fmt.Sprintf("vol-%03d", i), "SYNCING", map[string]bool{
+			"ready_for_rollout": false, "current_converged": false, "attention": false,
+		})
+	}
+	started := make(chan struct{}, len(pods))
+	release := make(chan struct{})
+	var active, maximum atomic.Int32
+	run := func(ctx context.Context, _ string, args ...string) commandResult {
+		if containsArg(args, "get") {
+			return commandResult{stdout: podListJSON(t, pods...)}
+		}
+		current := active.Add(1)
+		defer active.Add(-1)
+		for {
+			prior := maximum.Load()
+			if current <= prior || maximum.CompareAndSwap(prior, current) {
+				break
+			}
+		}
+		started <- struct{}{}
+		select {
+		case <-release:
+			return commandResult{stdout: statuses[argBefore(args, "--container")]}
+		case <-ctx.Done():
+			return commandResult{err: ctx.Err()}
+		}
+	}
+	deps := normalizeDependencies(dependencies{
+		ctx: context.Background(), run: run, execTimeout: time.Second, concurrency: 99,
+		now: time.Now,
+	})
+	type outcome struct {
+		jobs    []jobResult
+		partial bool
+		err     error
+	}
+	done := make(chan outcome, 1)
+	go func() {
+		jobs, _, partial, err := collectStatus(context.Background(), options{}, deps)
+		done <- outcome{jobs: jobs, partial: partial, err: err}
+	}()
+	for i := 0; i < maxConcurrentExec; i++ {
+		<-started
+	}
+	select {
+	case <-started:
+		t.Fatal("more than eight exec calls started before a slot was released")
+	default:
+	}
+	close(release)
+	result := <-done
+	if result.err != nil || result.partial || len(result.jobs) != len(pods) {
+		t.Fatalf("result=%+v", result)
+	}
+	if maximum.Load() != maxConcurrentExec {
+		t.Fatalf("maximum concurrency=%d, want %d", maximum.Load(), maxConcurrentExec)
+	}
+}
+
+func TestCollectStatusTimesOutOneWorker(t *testing.T) {
+	run := func(ctx context.Context, _ string, args ...string) commandResult {
+		if containsArg(args, "get") {
+			return commandResult{stdout: podListJSON(t, podJSON("migration", "worker-a", "batch-a", "Running"))}
+		}
+		<-ctx.Done()
+		return commandResult{err: errors.New("child stopped")}
+	}
+	deps := normalizeDependencies(dependencies{
+		ctx: context.Background(), run: run, execTimeout: 10 * time.Millisecond,
+		concurrency: maxConcurrentExec, now: time.Now,
+	})
+	jobs, _, partial, err := collectStatus(context.Background(), options{}, deps)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !partial || len(jobs) != 1 || jobs[0].DisplayStatus != "UNAVAILABLE" {
+		t.Fatalf("partial=%v jobs=%+v", partial, jobs)
+	}
+	if !strings.Contains(jobs[0].Error, "deadline exceeded") {
+		t.Fatalf("error=%q", jobs[0].Error)
+	}
+}
+
+func TestNormalizeMessageIsSingleLineAndBounded(t *testing.T) {
+	message := normalizeMessage(" first\nsecond\t" + strings.Repeat("x", maxErrorLength+20))
+	if strings.ContainsAny(message, "\n\t") || len([]rune(message)) != maxErrorLength {
+		t.Fatalf("message length=%d value=%q", len([]rune(message)), message)
+	}
+}

--- a/cmd/kubectl-drive9-migration/types.go
+++ b/cmd/kubectl-drive9-migration/types.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const (
+	fixedSelector     = "app.kubernetes.io/name=drive9-migration,app.kubernetes.io/component=worker"
+	instanceLabel     = "app.kubernetes.io/instance"
+	workerContainer   = "drive9-migration"
+	workerBinary      = "/drive9-migration"
+	missingBatch      = "<missing>"
+	maxConcurrentExec = 8
+	maxErrorLength    = 512
+)
+
+const defaultExecTimeout = 10 * time.Second
+
+type podList struct {
+	Items []pod `json:"items"`
+}
+
+type pod struct {
+	Metadata podMetadata `json:"metadata"`
+	Spec     podSpec     `json:"spec"`
+	Status   podStatus   `json:"status"`
+}
+
+type podMetadata struct {
+	Name              string            `json:"name"`
+	Namespace         string            `json:"namespace"`
+	Labels            map[string]string `json:"labels"`
+	DeletionTimestamp *string           `json:"deletionTimestamp"`
+}
+
+type podSpec struct {
+	NodeName   string         `json:"nodeName"`
+	Containers []podContainer `json:"containers"`
+}
+
+type podContainer struct {
+	Name string `json:"name"`
+}
+
+type podStatus struct {
+	Phase string `json:"phase"`
+}
+
+type workerStatus struct {
+	VolumeID         string             `json:"volume_id"`
+	NodeName         string             `json:"node_name,omitempty"`
+	SpaceRef         string             `json:"space_ref,omitempty"`
+	Prefix           string             `json:"prefix,omitempty"`
+	Phase            string             `json:"phase"`
+	StartupPhase     string             `json:"startup_phase"`
+	RecoveryComplete bool               `json:"recovery_complete"`
+	Round            workerRound        `json:"round"`
+	Conditions       workerConditions   `json:"conditions"`
+	SourceCount      int                `json:"source_count"`
+	CandidateCounts  workerCandidates   `json:"candidate_counts"`
+	FindingCounts    map[string]int     `json:"finding_counts"`
+	GraceCandidates  int                `json:"grace_candidates"`
+	CASRetry         int                `json:"cas_retry"`
+	Backlog          int                `json:"backlog"`
+	PendingRepairs   int                `json:"pending_repairs"`
+	InFlight         int                `json:"in_flight"`
+	Verification     workerVerification `json:"full_verification"`
+	FenceIntent      bool               `json:"fence_intent"`
+	FenceComplete    bool               `json:"fence_complete"`
+	AttentionReason  string             `json:"attention_reason,omitempty"`
+}
+
+type workerRound struct {
+	ID           string    `json:"id,omitempty"`
+	Mode         string    `json:"mode,omitempty"`
+	StartedAt    time.Time `json:"started_at,omitempty"`
+	CompletedAt  time.Time `json:"completed_at,omitempty"`
+	ScanComplete bool      `json:"scan_complete"`
+	Converged    bool      `json:"round_converged"`
+	FailureClass string    `json:"failure_class,omitempty"`
+}
+
+type workerConditions struct {
+	ReadyForRollout  bool `json:"ready_for_rollout"`
+	CurrentConverged bool `json:"current_converged"`
+	Attention        bool `json:"attention"`
+}
+
+type workerCandidates struct {
+	Mtime              int `json:"mtime"`
+	SourceTokenChanged int `json:"source_token_changed"`
+	NewPath            int `json:"new_path"`
+	Filtered           int `json:"filtered"`
+}
+
+type workerVerification struct {
+	Status        string    `json:"status,omitempty"`
+	RequestedAt   time.Time `json:"requested_at,omitempty"`
+	CompletedAt   time.Time `json:"completed_at,omitempty"`
+	SourceCount   int64     `json:"source_count"`
+	MismatchCount int64     `json:"mismatch_count"`
+}
+
+type jobResult struct {
+	Namespace     string          `json:"namespace"`
+	Batch         string          `json:"batch"`
+	Pod           string          `json:"pod"`
+	Node          string          `json:"node,omitempty"`
+	PodPhase      string          `json:"pod_phase,omitempty"`
+	JobID         string          `json:"job_id,omitempty"`
+	Phase         string          `json:"phase,omitempty"`
+	DisplayStatus string          `json:"status"`
+	Error         string          `json:"error,omitempty"`
+	Worker        json.RawMessage `json:"worker_status,omitempty"`
+
+	parsed           *workerStatus
+	collectionFailed bool
+}
+
+type batchSummary struct {
+	Namespace    string `json:"namespace"`
+	Batch        string `json:"batch"`
+	Status       string `json:"status"`
+	ObservedJobs int    `json:"observed_jobs"`
+	Available    int    `json:"available_jobs"`
+	Attention    int    `json:"attention_jobs"`
+	Unavailable  int    `json:"unavailable_jobs"`
+}
+
+type queryScope struct {
+	Namespace     string `json:"namespace,omitempty"`
+	AllNamespaces bool   `json:"all_namespaces"`
+	Batch         string `json:"batch,omitempty"`
+	Context       string `json:"context,omitempty"`
+}
+
+type aggregateOutput struct {
+	GeneratedAt time.Time      `json:"generated_at"`
+	Scope       queryScope     `json:"scope"`
+	Batches     []batchSummary `json:"batches"`
+	Jobs        []jobResult    `json:"jobs"`
+}

--- a/docs/guides/drive9-migration-v1-runbook.md
+++ b/docs/guides/drive9-migration-v1-runbook.md
@@ -139,6 +139,50 @@ production use, remove that Secret document and create the same
 `drive9-migration-credentials` Secret from a protected local file or secret
 manager. Never commit the populated manifest.
 
+## Aggregate status with the kubectl plugin
+
+Label the Migration DaemonSet and its Pod template so the client-side plugin can
+discover Workers. Use one instance value for one customer migration batch:
+
+```yaml
+metadata:
+  labels:
+    app.kubernetes.io/name: drive9-migration
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/instance: customer-a-20260810
+```
+
+The Worker container name must be `drive9-migration`. Download the plugin
+artifact for the operator's platform, rename it to
+`kubectl-drive9-migration` (`kubectl-drive9-migration.exe` on Windows), make it
+executable where applicable, and place it on `PATH`. Confirm discovery with:
+
+```bash
+kubectl plugin list
+```
+
+The zero-argument command queries all labeled Workers in the current namespace:
+
+```bash
+kubectl drive9 migration status
+kubectl drive9 migration status --batch customer-a-20260810
+kubectl drive9 migration status -n migration-system
+kubectl drive9 migration status -A
+kubectl drive9 migration status -o wide
+kubectl drive9 migration status -o json
+```
+
+The plugin uses the operator's existing kubectl context and Pod list/exec
+permissions. It does not read the Migration ConfigMap or Secret and does not add
+RBAC. Each summary deliberately says `observed N jobs`: a Job with no Pod is not
+discoverable. Pending, Failed, Terminating, unreachable, and duplicate observed
+Pods remain visible and make the command exit nonzero. Attention and incomplete
+migration remain status facts and do not make an otherwise complete query fail.
+
+An observed `CUTOVER_READY` summary does not prove that every configured Job was
+discovered, does not prove external T1, and does not authorize the business
+switch. The T1 and T2 gates below remain authoritative.
+
 ## SYNCING and rollout readiness
 
 Inspect each Job independently:

--- a/docs/guides/drive9-migration-v1-runbook.md
+++ b/docs/guides/drive9-migration-v1-runbook.md
@@ -150,12 +150,50 @@ metadata:
     app.kubernetes.io/name: drive9-migration
     app.kubernetes.io/component: worker
     app.kubernetes.io/instance: customer-a-20260810
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: drive9-migration
+        app.kubernetes.io/component: worker
+        app.kubernetes.io/instance: customer-a-20260810
 ```
 
 The Worker container name must be `drive9-migration`. Download the plugin
-artifact for the operator's platform, rename it to
-`kubectl-drive9-migration` (`kubectl-drive9-migration.exe` on Windows), make it
-executable where applicable, and place it on `PATH`. Confirm discovery with:
+artifact for the operator's platform together with
+`migration-kube-plugin-checksums.txt`. Verify the downloaded artifact before
+installing it. For Linux:
+
+```bash
+plugin_artifact=kubectl-drive9-migration-linux-amd64
+grep " $plugin_artifact$" migration-kube-plugin-checksums.txt |
+  sha256sum --check
+```
+
+For macOS:
+
+```bash
+plugin_artifact=kubectl-drive9-migration-darwin-arm64
+grep " $plugin_artifact$" migration-kube-plugin-checksums.txt |
+  shasum --algorithm 256 --check
+```
+
+For Windows PowerShell:
+
+```powershell
+$artifact = "kubectl-drive9-migration-windows-amd64.exe"
+$line = Get-Content migration-kube-plugin-checksums.txt |
+  Where-Object { $_ -match "  $([regex]::Escape($artifact))$" }
+if (-not $line) { throw "checksum entry not found" }
+$expected = ($line -split '\s+')[0].ToLowerInvariant()
+$actual = (Get-FileHash -Algorithm SHA256 $artifact).Hash.ToLowerInvariant()
+if ($actual -ne $expected) { throw "checksum mismatch" }
+```
+
+Choose the artifact name matching the operator's architecture. After successful
+verification, rename it to `kubectl-drive9-migration`
+(`kubectl-drive9-migration.exe` on Windows), make it executable where
+applicable, and place it on `PATH`. Confirm discovery with:
 
 ```bash
 kubectl plugin list

--- a/docs/plans/2026-08-10-drive9-migration-kubectl-plugin-design.md
+++ b/docs/plans/2026-08-10-drive9-migration-kubectl-plugin-design.md
@@ -137,10 +137,11 @@ ambiguous.
 
 | Display status | Derivation |
 | --- | --- |
-| `POD_PENDING`, `POD_FAILED`, `TERMINATING` | Kubernetes Pod cannot provide a current Worker result |
+| `POD_<PHASE>` | Any non-`Running` Kubernetes Pod, including `POD_PENDING`, `POD_FAILED`, and `POD_SUCCEEDED` |
+| `TERMINATING` | Kubernetes Pod has a deletion timestamp |
 | `UNAVAILABLE` | Exec failed, timed out, or returned invalid JSON |
 | `DUPLICATE` | More than one observed Pod reports the same Job identity in one batch |
-| `ATTENTION` | `conditions.attention=true` |
+| `ATTENTION` | `conditions.attention=true`, or actual phase is `CUTOVER_READY` while the fence is incomplete |
 | `CUTOVER_READY` | Actual phase is `CUTOVER_READY` and the fence is complete |
 | `READY_FOR_ROLLOUT` | `conditions.ready_for_rollout=true` |
 | `CONVERGED` | `conditions.current_converged=true` |

--- a/docs/plans/2026-08-10-drive9-migration-kubectl-plugin-design.md
+++ b/docs/plans/2026-08-10-drive9-migration-kubectl-plugin-design.md
@@ -1,0 +1,243 @@
+---
+title: Drive9 Migration kubectl Plugin Design
+status: accepted
+accepted_at: 2026-08-10
+scope_class: medium
+production_net_loc: 850-1050
+---
+
+# Drive9 Migration kubectl plugin design
+
+## 1. Objective
+
+Deliver a client-side `kubectl` plugin that discovers existing Drive9 Migration
+Worker Pods and presents one customer-readable, read-only view of their Job
+status. The zero-argument happy path is:
+
+```bash
+kubectl drive9 migration status
+```
+
+The plugin aggregates only observed Pods. It does not make the Migration Worker
+batch-aware and does not introduce a Kubernetes or Drive9 control plane.
+
+## 2. Scope baseline
+
+### 2.1 In scope
+
+1. Discover Worker Pods through a fixed label contract in the current namespace,
+   a selected namespace, or all namespaces.
+2. Optionally select one migration batch through
+   `app.kubernetes.io/instance`.
+3. Query each existing Worker through bounded concurrent `kubectl exec` calls to
+   its existing local `status --output json` command.
+4. Render deterministic `table`, `wide`, and aggregate `json` output.
+5. Derive a concise per-Job display status and one observed-status summary per
+   `(namespace, batch)`.
+6. Preserve partial results when one or more Pods are unavailable.
+7. Build customer-side binaries for Linux, macOS, and Windows on AMD64 and
+   ARM64, using the existing CLI release path.
+8. Document labels, installation, commands, output semantics, and the observed
+   Pod limitation.
+
+### 2.2 Explicitly deferred or out of scope
+
+1. Reading Migration ConfigMaps or discovering Jobs for which no Pod exists.
+2. `diff`, `verify-full`, `prepare-drive9-cutover`, or any other mutating or
+   per-path operation.
+3. Watch mode, TUI, Web UI, history, persistence, alerting, or notifications.
+4. CRDs, Controllers, Operators, Services, network APIs, Kubernetes Conditions,
+   or new RBAC resources.
+5. Changes to the Worker status wire contract or the Worker image.
+6. Krew publication or a separate plugin distribution service.
+
+### 2.3 Accepted completeness boundary
+
+The plugin cannot know the configured number of Jobs without reading the
+ConfigMap. Every summary therefore says `observed N jobs`; it must never claim
+that all configured Jobs were discovered. A Pod that does not exist is invisible.
+A matching Pending, Failed, Terminating, or unreachable Pod remains visible.
+
+## 3. Kubernetes resource contract
+
+The DaemonSet and its Pod template carry these labels:
+
+```yaml
+metadata:
+  labels:
+    app.kubernetes.io/name: drive9-migration
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/instance: customer-a-20260810
+```
+
+`app.kubernetes.io/instance` is the customer-selected migration batch name.
+The Worker container name is `drive9-migration`. The plugin does not require a
+per-Job label because `volume_id` is returned by the Worker status payload at
+`internal/migration/control.go:79`.
+
+The fixed discovery selector is:
+
+```text
+app.kubernetes.io/name=drive9-migration,app.kubernetes.io/component=worker
+```
+
+`--batch NAME` adds an exact
+`app.kubernetes.io/instance=NAME` requirement. Without `--batch`, all matching
+instances in scope are displayed and summarized separately. Missing instance
+labels are reported as a contract error rather than silently excluded.
+
+## 4. CLI contract
+
+The binary name `kubectl-drive9-migration` exposes the nested kubectl command
+`kubectl drive9 migration`.
+
+```bash
+kubectl drive9 migration status
+kubectl drive9 migration status --batch customer-a-20260810
+kubectl drive9 migration status -n migration-system
+kubectl drive9 migration status -A
+kubectl drive9 migration status -o table
+kubectl drive9 migration status -o wide
+kubectl drive9 migration status -o json
+```
+
+The plugin accepts `--context` and `--kubeconfig` and forwards them to every
+child `kubectl` invocation. `-n/--namespace` and `-A/--all-namespaces` are
+mutually exclusive. `table` is the default output.
+
+## 5. Runtime architecture and data flow
+
+The implementation is a CGO-free Go binary that invokes the user's existing
+`kubectl`. It does not import `client-go` or implement the Kubernetes exec
+transport.
+
+```text
+kubectl-drive9-migration
+  -> kubectl get pods -l <fixed selector> -o json
+  -> validate labels and Kubernetes Pod state
+  -> at most 8 concurrent kubectl exec calls
+       /drive9-migration status --output json
+  -> validate and parse the Worker payload
+  -> derive per-Job display states and batch summaries
+  -> stable sort
+  -> render table, wide, or JSON
+```
+
+Every exec has a 10-second timeout. Commands are executed with argument arrays,
+never through a shell. The plugin uses a small injected command function for
+unit tests, following the existing CLI dependency-injection pattern at
+`cmd/drive9-migration/main.go:26`; it does not introduce a general command
+runner interface.
+
+## 6. Display-state derivation
+
+Kubernetes availability is evaluated before Worker state. After all responses
+are collected, duplicate `(namespace, batch, volume_id)` results are marked as
+ambiguous.
+
+| Display status | Derivation |
+| --- | --- |
+| `POD_PENDING`, `POD_FAILED`, `TERMINATING` | Kubernetes Pod cannot provide a current Worker result |
+| `UNAVAILABLE` | Exec failed, timed out, or returned invalid JSON |
+| `DUPLICATE` | More than one observed Pod reports the same Job identity in one batch |
+| `ATTENTION` | `conditions.attention=true` |
+| `CUTOVER_READY` | Actual phase is `CUTOVER_READY` and the fence is complete |
+| `READY_FOR_ROLLOUT` | `conditions.ready_for_rollout=true` |
+| `CONVERGED` | `conditions.current_converged=true` |
+| `REPAIRING` | Actual phase is `DUAL_WRITE_REPAIRING` and is not converged |
+| `SYNCING` | Actual phase is `SYNCING` and is not ready for rollout |
+
+The batch summary precedence is:
+
+```text
+NEEDS_ATTENTION > MIXED_PHASE > CUTOVER_READY > CONVERGED
+                > READY_FOR_ROLLOUT > REPAIRING > SYNCING
+```
+
+`CUTOVER_READY` describes only all observed Jobs. It does not prove external T1,
+authorize a business switch, or change the Runbook safety boundary documented at
+`docs/design/drive9-migration-v1.md:454`.
+
+## 7. Output contract
+
+Default table columns are `BATCH`, `JOB`, `PHASE`, `STATUS`, `ROUND`, `FILES`,
+`DIFF`, `RETRY`, `VERIFY`, and `POD`. When only one batch is present, the
+renderer may omit `BATCH`. Wide output also includes namespace, node, target
+Space/Prefix, candidate counts, pending/in-flight work, and a bounded error
+message.
+
+JSON output contains:
+
+1. Generation time and effective query scope.
+2. One batch summary per `(namespace, instance)`.
+3. One item per observed Pod with Kubernetes identity, derived status, an
+   optional bounded error, and the validated raw Worker status object.
+
+Items and summaries are sorted by namespace, batch, Job ID, and Pod name. New
+Worker fields remain available in the raw JSON object without changing table
+rendering.
+
+## 8. Errors and exit codes
+
+| Code | Meaning |
+| ---: | --- |
+| `0` | Pod discovery and every applicable Worker query succeeded; migration progress, differences, mixed phase, and Attention remain status facts |
+| `1` | No matching Pod, Kubernetes discovery failure, partial/unavailable result, invalid labels, invalid Worker payload, or duplicate Job identity |
+| `2` | Invalid CLI arguments |
+
+Partial result failures still render every successfully collected Job. Stderr
+from `kubectl` is normalized to one bounded message and cannot replace structured
+stdout. Cancellation stops outstanding child processes.
+
+## 9. Security and compatibility
+
+1. The plugin reads no Drive9 key or Migration Secret.
+2. It inherits the user's existing kubectl authentication and requires only the
+   permissions already needed for Pod list and Pod exec.
+3. Kubeconfig contents, environment values, and raw child commands are not
+   logged.
+4. The Worker status contract already excludes API keys and file contents at
+   `docs/design/drive9-migration-v1.md:918`.
+5. The table intentionally excludes `credential_ref`; JSON preserves the
+   existing non-secret Worker payload.
+6. Unknown additive Worker JSON fields are accepted for forward compatibility;
+   required identity, phase, conditions, and fence fields are validated.
+
+## 10. Build, release, and documentation
+
+Add dedicated local and six-platform release targets beside the existing CLI
+targets at `Makefile:142`. Extend `.github/workflows/release-cli.yml` to build
+and copy plugin artifacts through the existing release directory. Actual release
+execution remains a separately authorized external action.
+
+Update `docs/guides/drive9-migration-v1-runbook.md` with the label contract,
+installation name, commands, output scope, and the rule that this display does
+not replace external T1 confirmation.
+
+## 11. Acceptance criteria
+
+1. Zero-argument status discovers all correctly labeled Worker Pods in the
+   current kubectl namespace and renders one row per Pod.
+2. Namespace, all-namespace, batch, context, kubeconfig, and output flags produce
+   the exact child kubectl arguments required by this design.
+3. No more than eight exec calls run concurrently, and one hung Pod is cancelled
+   after 10 seconds without losing other results.
+4. Every display and batch state in Sections 6 and 8 is covered by deterministic
+   unit tests.
+5. Pending, Failed, Terminating, missing-label, timeout, malformed-output, and
+   duplicate-Job cases remain visible and return code 1.
+6. Attention or incomplete migration with otherwise successful queries returns
+   code 0, matching the single-Job status behavior at
+   `cmd/drive9-migration/main.go:69`.
+7. Linux, macOS, and Windows AMD64/ARM64 artifacts build with `CGO_ENABLED=0`.
+8. Existing Worker and drive9 test suites remain unchanged and passing.
+
+## 12. Effort boundary
+
+Expected production implementation is `~850-1050 LoC`, Medium, excluding tests,
+generated artifacts, release boilerplate, and documentation. Reading ConfigMaps,
+adding mutations, adding a watcher, or introducing `client-go` is scope expansion
+and requires a new design decision. The post-implementation estimate is higher
+than the initial estimate because the accepted behavior requires cross-platform
+Pod and Worker wire DTOs, strict partial-result validation, and three renderers;
+the owned surfaces and scope class are unchanged.


### PR DESCRIPTION
## Summary

1. Add the client-side `kubectl drive9 migration status` plugin, discovering Migration Worker Pods through the fixed label contract.
2. Aggregate deterministic per-Job and observed batch states with bounded concurrent Pod exec, partial-result handling, and table, wide, and JSON output.
3. Add CGO-free Linux, macOS, and Windows AMD64/ARM64 release builds plus design and Runbook documentation.

## Testing

1. `go test -cover ./cmd/kubectl-drive9-migration ./cmd/drive9-migration ./internal/migration` (plugin coverage: 85.6%)
2. `go test -race ./cmd/kubectl-drive9-migration`
3. `go vet ./cmd/kubectl-drive9-migration`
4. `make lint`
5. `make build-migration-kube-plugin`
6. `make build-migration-kube-plugin-release DIST_DIR=<temporary-directory>` with checksum verification for all six artifacts

## Known environment limitation

`make test` was attempted, but MySQL-backed packages could not start because neither Podman nor Docker was reachable, while existing FUSE tests rejected the workspace free-disk ratio. The focused plugin and Migration suites passed independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the read-only `kubectl drive9 migration status` command for monitoring migration progress across Kubernetes workloads.
  * Supports namespace, batch, context, kubeconfig, and output-format options.
  * Added compact, wide, and JSON output with job details, batch summaries, errors, and progress indicators.
  * Reports partial results when individual workloads cannot be queried.
  * Added cross-platform plugin builds for Linux, macOS, and Windows, including release packaging and checksums.
* **Documentation**
  * Added installation, configuration, usage, permissions, and troubleshooting guidance for the plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->