### PR TITLE
docs: add agent skill files for anonymous and TiDB Cloud

### DIFF
--- a/docs/skills/drive9.md
+++ b/docs/skills/drive9.md
@@ -1,0 +1,194 @@
+---
+name: drive9
+description: Persistent network filesystem for AI agents - store, mount, search, and share files across sessions with contexts and vault secrets.
+metadata:
+  version: 0.1.0
+  homepage: https://drive9.ai
+---
+
+# drive9
+
+drive9 is your persistent, searchable network filesystem across sessions. Files stored in drive9 survive context resets, session restarts, and agent handoffs. You can copy files through the CLI, mount remote paths locally, search by meaning, and switch between owner or delegated contexts.
+
+## Setup
+
+Choose the installer that matches the current OS, then run `drive9 create`. Do not stop to ask the user for confirmation between steps.
+
+```bash
+## macOS / Linux
+curl -fsSL https://drive9.ai/install.sh | sh
+drive9 create
+```
+
+```powershell
+# Windows PowerShell
+irm https://drive9.ai/install.ps1 | iex
+drive9 create
+```
+
+`drive9 create` provisions a database and owner context, then saves credentials to `~/.drive9/config`. If `drive9 ctx show` already returns a context name, skip `drive9 create`.
+
+Setup is complete when `drive9 create` succeeds. Currently supported platforms: macOS (x86_64, arm64), Linux (x86_64, arm64), and Windows (amd64, arm64 via the PowerShell installer).
+
+---
+
+## When to use drive9
+
+drive9 is useful in two directions — **storing** and **retrieving**.
+
+**Storing**: When the user wants to save, persist, or back up a file (e.g. "save this report", "keep this config for later", "store the analysis results"), suggest storing it to drive9 and confirm with the user before uploading.
+
+**Retrieving**: When the user is looking for a file they've previously saved, or wants to search across their files (e.g. "find that pricing doc", "what did I save about the migration plan"), use `drive9 fs grep` and `drive9 fs find` to help them find it.
+
+In both cases, briefly tell the user what you're about to do so they stay in the loop.
+
+---
+
+## Commands
+
+All commands exit 0 on success, non-zero on failure.
+
+### Context management
+
+Each context is an isolated credential scope. Owner contexts hold an API key. Delegated contexts hold a scoped grant token imported from another user or agent.
+
+```bash
+drive9 create --name <name> [--server <url>]  # create a database and owner context
+drive9 ctx show                                 # show current context
+drive9 ctx add --api-key <key> --name prod     # add an owner context
+drive9 ctx import --from-file <path>           # import a delegated context from a 0600 file
+producer | drive9 ctx import                   # import a delegated context from stdin
+drive9 ctx ls [-l|--json]                      # list contexts
+drive9 ctx use <name>                          # activate a context
+drive9 ctx rm <name>                           # delete a context
+```
+
+### File operations
+
+Remote paths use `:` prefix (e.g. `:/data/file.txt`). Local paths have no prefix. Intermediate remote directories are created automatically — no mkdir needed.
+
+```bash
+# upload
+drive9 fs cp ./local.txt :/remote.txt
+drive9 fs cp - :/file.txt                  # from stdin
+drive9 fs cp --resume ./large.bin :/large.bin
+drive9 fs cp --append ./tail.log :/logs/app.log
+drive9 fs cp --tag topic=pricing --description "pricing plan" ./plan.md :/notes/plan.md
+
+# download
+drive9 fs cp :/remote.txt ./local.txt
+drive9 fs cp :/file.txt -                  # to stdout
+
+# server-side copy
+drive9 fs cp :/src.txt :/dst.txt
+
+# read / list / inspect
+drive9 fs cat :/path/to/file               # print content to stdout
+drive9 fs ls :/                            # list root
+drive9 fs ls :/path/                       # list subdirectory
+drive9 fs stat :/path/to/file              # metadata (size, type, mtime)
+
+# move / remove
+drive9 fs mv :/old.txt :/new.txt
+drive9 fs rm :/path/to/file
+
+# interactive shell
+drive9 fs sh
+```
+
+`drive9 fs cp` supports `--resume`, `--append`, repeated `--tag key=value`, and `--description <text>`. Tags and descriptions apply to local/stdin uploads. `--append` is for local-file-to-remote appends and cannot be combined with tags or descriptions.
+
+### Local mounts
+
+Mount the remote filesystem as a local directory. A mount binds to the context active at mount time; after changing contexts, unmount and mount again.
+
+```bash
+drive9 mount :/data ~/drive9-data
+drive9 umount ~/drive9
+```
+
+Vault secrets can also be mounted read-only:
+
+```bash
+drive9 mount vault ~/drive9-vault
+drive9 umount ~/drive9-vault
+```
+
+### Vault secrets
+
+Use `drive9 vault` for secret storage, scoped grants, and command execution with injected environment variables.
+
+```bash
+drive9 vault set aws AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=@/path/to/key
+drive9 vault get aws --json
+drive9 vault ls
+drive9 vault grant --agent alice --perm read --ttl 1h aws
+drive9 vault with /n/vault/aws -- env
+```
+
+### Search
+
+**grep** — semantic content search. Accepts natural language, not just exact strings. Runs vector similarity + BM25 + keyword matching in parallel.
+
+```bash
+drive9 fs grep "pricing strategy" /        # search all files
+drive9 fs grep "TODO" /projects/           # search within a directory
+```
+
+Output: one line per match — `<path>\t<score>` (tab-separated). Empty output means no matches.
+
+**find** — structural search by name, tag, date, or size. Flags combine with AND.
+
+```bash
+drive9 fs find / -name "*.md"
+drive9 fs find / -tag topic=pricing
+drive9 fs find / -newer 2026-03-01
+drive9 fs find / -older 2026-01-01
+drive9 fs find / -size +1048576
+drive9 fs find / -name "*.md" -newer 2026-03-01
+```
+
+Output: one path per line. Empty output means no matches.
+
+Use `grep` to find files by what they contain. Use `find` to find files by name, date, tag, or size.
+
+### Output formats
+
+| Command | Output |
+|---|---|
+| `fs ls` | one entry per line, directories end with `/` |
+| `fs ls -l` | tab-separated: `type  size  name` (type: `d` or `-`) |
+| `fs cat` | raw file content to stdout |
+| `fs stat` | key-value metadata; use `-o json` for JSON |
+| `fs grep` | tab-separated: `path  score` per match |
+| `fs find` | one path per line |
+
+---
+
+## Environment variables
+
+| Variable | Description | Default |
+|---|---|---|
+| `DRIVE9_SERVER` | Server URL | `https://api.drive9.ai` |
+| `DRIVE9_API_KEY` | Owner API key override | active owner context in `~/.drive9/config` |
+| `DRIVE9_VAULT_TOKEN` | Delegated token override | active delegated context in `~/.drive9/config` |
+
+---
+
+## Error handling
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `no current context` | No context created yet | Run `drive9 create` |
+| `context "X" not found` | Typo or deleted context | Run `drive9 ctx ls` to see available |
+| `provision failed` | Server unreachable or down | Check `DRIVE9_SERVER` env, network connectivity |
+| `401` / `403` | Invalid owner key or expired delegated token | Run `drive9 ctx ls` to verify, then `drive9 create`, `drive9 ctx add`, or `drive9 ctx import` |
+| `404` on file ops | File or path doesn't exist | Run `drive9 fs ls :/` to check what's there |
+| Non-zero exit, no output | Generic failure | Re-run with `DRIVE9_CLI_LOG_ENABLED=true` for debug logs |
+
+## Tips
+
+- Pipe content via stdin (`echo "..." | drive9 fs cp - :/path`) to avoid temp files.
+- Use `drive9 fs grep` for fuzzy/semantic queries — it understands meaning beyond exact match.
+- Separate projects get separate contexts via `drive9 create --name <name>`.
+- Use `drive9 --help` and `drive9 fs --help` to inspect the current CLI surface.

--- a/docs/skills/tidbcloud-aws-ap-southeast-1.md
+++ b/docs/skills/tidbcloud-aws-ap-southeast-1.md
@@ -1,0 +1,336 @@
+---
+name: drive9
+description: Persistent network filesystem for TiDB Cloud users — store, mount, search, and share workspace files across sessions and sandboxes.
+metadata:
+  version: 0.1.0
+---
+
+# drive9
+
+drive9 is a persistent workspace for sandboxes and agents. Files survive context resets, session restarts, and agent handoffs. The default workflow is to mount a remote path as a local folder and use ordinary tools (`vim`, `code`, `git`, `python`). You can also operate on remote files directly with `drive9 fs`.
+
+This skill is for **TiDB Cloud** users. Every `drive9 create` and `drive9 ctx add` must pass the Drive9 server URL. `drive9 create` must also pass the user's TiDB Cloud API public key (AK) and private key (SK).
+
+## Setup
+
+Do not run `drive9 create` with no flags. Collect the user's TiDB Cloud **public key** and **private key** first. If either key is missing, ask for both and wait. Do not invent keys, and do not echo them back after the command runs.
+
+The server URL is required on create (and on `ctx add`). Always pass:
+
+```text
+https://aws-ap-southeast-1.drive9.ai/
+```
+
+If `drive9 ctx show` already returns a context name, skip `drive9 create`.
+
+Otherwise install the CLI (macOS / Linux), then create a workspace:
+
+```bash
+curl -fsSL https://drive9.ai/install.sh | sh
+
+drive9 create --server https://aws-ap-southeast-1.drive9.ai/ \
+    --tidbcloud-public-key <public-key> \
+    --tidbcloud-private-key <private-key>
+```
+
+Do not stop to ask for confirmation between install and create once both keys are available.
+
+`drive9 create` provisions a workspace and saves credentials to `~/.drive9/config`. Then activate the new context and mount it:
+
+```bash
+drive9 ctx use <CTX_ID>
+drive9 fs mkdir :/my-project
+drive9 mount :/my-project ./workspace
+```
+
+`./workspace` is now backed by drive9. Use it like any local folder:
+
+```bash
+echo "hello drive9" > ./workspace/hello.txt
+cat ./workspace/hello.txt
+cp ./report.pdf ./workspace/
+git clone https://github.com/your/repo ./workspace/repo
+```
+
+Unmount when done:
+
+```bash
+drive9 umount ./workspace
+```
+
+Setup is complete when `drive9 create` succeeds and `drive9 ctx show` returns a context name.
+
+---
+
+## When to use drive9
+
+drive9 is useful in two directions — **storing** and **retrieving**. Prefer the mount as the working directory.
+
+**Storing**: When the user wants to save, persist, or back up a file (e.g. "save this report", "keep this config for later"), write it into the mounted workspace or `drive9 fs cp` it to a remote path. Confirm with the user before uploading.
+
+**Retrieving**: When the user is looking for a file they previously saved (e.g. "find that pricing doc", "what did I save about the migration plan"), look in the mount or use `drive9 fs grep` / `drive9 fs find`.
+
+**Isolated edits**: When an agent or sandbox should try changes without touching the shared workspace, create a layer, mount it, then `commit` or `rollback`.
+
+In all cases, briefly tell the user what you're about to do.
+
+---
+
+## Commands
+
+All commands exit 0 on success, non-zero on failure. Remote paths start with `:/` — that is the drive9 root.
+
+### Context management
+
+Each context is an isolated credential scope. Owner contexts hold an API key.
+
+```bash
+drive9 create --server https://aws-ap-southeast-1.drive9.ai/ \
+    --tidbcloud-public-key <public-key> \
+    --tidbcloud-private-key <private-key>
+drive9 ctx show
+drive9 ctx ls
+drive9 ctx use <name>
+drive9 ctx rm <name>
+```
+
+`drive9 create` may take `--name <name>`. Never omit `--server`, `--tidbcloud-public-key`, or `--tidbcloud-private-key`.
+
+### Sharing a workspace
+
+The same workspace can be mounted from another sandbox, another machine, or by a teammate. Share the Drive9 API key (the key stored in the owner context, not the TiDB Cloud keys). On the other side:
+
+```bash
+drive9 ctx add --name shared --server https://aws-ap-southeast-1.drive9.ai/ --api-key "THE_API_KEY"
+drive9 ctx use shared
+drive9 mount :/my-project ./workspace
+```
+
+`--server` is required on `ctx add`. Files written by one sandbox are immediately available to the next.
+
+### Local mounts
+
+```bash
+drive9 mount :/my-project ./workspace
+drive9 umount ./workspace
+```
+
+The remote path `:/my-project` must already exist. Create it with `drive9 fs mkdir :/my-project`.
+
+After mounting, the directory behaves like a local folder. Verify with ordinary tools:
+
+```bash
+ls ./workspace
+df -h ./workspace
+```
+
+A mount binds to the context active at mount time. After `drive9 ctx use`, unmount and mount again.
+
+### Layer operations
+
+A layer is a writable overlay on a drive9 path. The base stays unchanged while you work. `commit` applies the overlay back to the base; `rollback` discards it.
+
+**Create a layer and mount it**
+
+```bash
+drive9 fs layer create :/my-project --name fix-auth
+drive9 mount --mode=fuse --layer fix-auth :/my-project ./attempt
+```
+
+`./attempt` behaves like a local folder. Reads fall through to the base; writes stay in the layer until you commit. `--layer` requires FUSE (`--mode=fuse`). You can create more than one layer on the same base and mount each in its own directory.
+
+**Inspect**
+
+```bash
+drive9 fs layer list
+drive9 fs layer status fix-auth
+drive9 fs layer diff fix-auth
+```
+
+Refer to a layer by id, name, or tag (for example `tag:agent=a`).
+
+**Checkpoint**
+
+```bash
+drive9 fs layer checkpoint fix-auth --label tests-pass
+```
+
+A checkpoint is a restore point. Remount a checkpoint as a read-only view:
+
+```bash
+drive9 mount --mode=fuse --layer fix-auth --checkpoint <checkpoint-id> :/my-project ./restore
+```
+
+**Commit or roll back**
+
+```bash
+drive9 fs layer commit fix-auth
+drive9 fs layer rollback fix-auth
+```
+
+Commit is all-or-nothing. If the base changed while the layer was open, the layer becomes `conflicted` and stays available for review — it is not overwritten or discarded.
+
+| Command | Description |
+|---|---|
+| `drive9 fs layer create :/path --name NAME` | Create a layer on a base path |
+| `drive9 fs layer list` | List layers |
+| `drive9 fs layer status NAME` | Show state, base, and durable seq |
+| `drive9 fs layer diff NAME` | List overlay entries (add / modify / delete) |
+| `drive9 fs layer checkpoint NAME --label LABEL` | Record a restore point |
+| `drive9 fs layer commit NAME` | Apply the layer to the base |
+| `drive9 fs layer rollback NAME` | Discard the layer |
+
+#### Next release — copy-on-write fork
+
+The next CLI version adds copy-on-write fork. Fork creates a child layer from an existing layer without copying files, so two attempts can share work so far and then diverge. Do not run these commands until that CLI is installed.
+
+```bash
+drive9 fs layer fork fix-auth --name fix-auth-b
+drive9 fs layer fork fix-auth --name restore-view --checkpoint <checkpoint-id>
+drive9 mount --mode=fuse --layer fix-auth-b :/my-project ./attempt-b
+drive9 fs layer chain fix-auth-b
+drive9 fs layer delete fix-auth-b
+drive9 fs layer delete fix-auth --cascade
+```
+
+`fork` pins the child to the parent's current tip, or to a checkpoint if you pass `--checkpoint`. Reads walk the child, then the parent at that pin, then the base. `commit` on any layer still writes the effective view to the base, not into the parent. `delete --cascade` abandons a parent and its descendants together.
+
+### File operations
+
+Operate on remote files directly, without mounting.
+
+**Browse and read**
+
+| Command | Description |
+|---|---|
+| `drive9 fs ls :/path` | List directory contents |
+| `drive9 fs ls -l :/path` | List with size and timestamp |
+| `drive9 fs cat :/path/file.txt` | Print file contents |
+| `drive9 fs stat :/path/file.txt` | Show file metadata |
+
+**Upload and download**
+
+| Command | Description |
+|---|---|
+| `drive9 fs cp local.txt :/remote.txt` | Upload a file |
+| `drive9 fs cp :/remote.txt ./local.txt` | Download a file |
+| `drive9 fs cp :/remote.txt -` | Download to stdout |
+
+**Organize**
+
+| Command | Description |
+|---|---|
+| `drive9 fs mkdir :/new-dir` | Create a directory |
+| `drive9 fs mv :/old :/new` | Move or rename |
+| `drive9 fs rm :/file` | Delete a file |
+| `drive9 fs rm -r :/dir` | Delete a directory |
+
+**Search**
+
+| Command | Description |
+|---|---|
+| `drive9 fs grep "keyword" :/` | Search file contents |
+| `drive9 fs grep "keyword" :/docs` | Search within a directory |
+| `drive9 fs find :/ -name "*.md"` | Find files by name |
+| `drive9 fs find :/ -newer 2026-01-01` | Find files modified after a date |
+| `drive9 fs find :/ -size +1000000` | Find files larger than 1MB |
+
+Use `grep` to find files by what they contain. Use `find` to find files by name, date, or size.
+
+### Git operations
+
+Drive9 provides a Git-aware fast clone for repositories inside a mounted drive:
+
+```bash
+drive9 git clone --fast <repo-url> <mounted-path>
+```
+
+Fast clone does not materialize every clean working-tree file as normal drive9 file rows. Instead, drive9 records the repository `HEAD` tree as a Git workspace manifest, keeps `.git` in the local overlay, and exposes the working tree through the FUSE Git workspace layer. This makes large repositories much faster to clone while preserving normal Git and file operations after mount.
+
+By default, `--fast` uses a full local Git object database:
+
+```bash
+drive9 git clone --fast https://github.com/org/repo.git <mountpoint>/repo
+```
+
+Use `--blobless` when initial clone latency and network transfer matter more than having all blobs locally immediately:
+
+```bash
+drive9 git clone --fast --blobless https://github.com/org/repo.git <mountpoint>/repo
+```
+
+`--blobless` uses Git partial clone (`--filter=blob:none`). Drive9 registers the HEAD tree immediately, then hydrates clean blob content later. Hydration runs in the background by default; use `--hydrate=sync` to wait before returning, or `drive9 git hydrate` to hydrate an existing blobless workspace.
+
+```bash
+drive9 git clone --fast --blobless --hydrate=sync https://github.com/org/repo.git <mountpoint>/repo
+drive9 git hydrate <mountpoint>/repo
+```
+
+Rule of thumb: use plain `--fast` for better local Git performance after clone; use `--fast --blobless` for faster startup and lower initial data transfer.
+
+---
+
+## Platform notes
+
+### macOS
+
+drive9 auto-detects the mount backend:
+
+- **FUSE** (recommended) — full POSIX filesystem semantics. Supports `git`, `symlink`, file locking, and all standard development tools. Requires [macFUSE](https://osxfuse.github.io/):
+
+```bash
+brew install --cask macfuse
+```
+
+Allow the system extension in **System Settings → Privacy & Security**, then restart.
+
+- **WebDAV** (fallback) — used automatically when macFUSE is not installed. Built into macOS, zero dependencies. Sufficient for basic file read/write, but does not support symlinks, file locking, or some `git` operations.
+
+For development workflows, install macFUSE. Layer mounts (`--layer`) require FUSE (`--mode=fuse`).
+
+### Linux
+
+FUSE is pre-installed on most Linux distributions, including E2B sandboxes and cloud VMs.
+
+Verify:
+
+```bash
+ls /dev/fuse
+```
+
+If `/dev/fuse` exists, you're ready. No additional setup needed.
+
+---
+
+## Environment variables
+
+| Variable | Description |
+|---|---|
+| `DRIVE9_SERVER` | Does not replace `--server` on `create` / `ctx add`. Always pass `--server https://aws-ap-southeast-1.drive9.ai/` on those commands. |
+| `DRIVE9_API_KEY` | Owner API key override; otherwise the active owner context in `~/.drive9/config` |
+
+---
+
+## Error handling
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| `no current context` | No context created yet | Run `drive9 create` with `--server` and both TiDB Cloud keys |
+| `context "X" not found` | Typo or deleted context | Run `drive9 ctx ls` to see available names |
+| `provision failed` | Server unreachable, wrong URL, or bad keys | Confirm `--server https://aws-ap-southeast-1.drive9.ai/` and both keys |
+| `401` / `403` | Invalid owner API key | Run `drive9 ctx ls` to verify, then `drive9 create` or `drive9 ctx add` with `--server` |
+| `404` on file ops / remote directory not found | Path does not exist | Create it first: `drive9 fs mkdir :/name` |
+| `Permission denied` on mount | Wrong or missing context | Run `drive9 ctx` / `drive9 ctx show` |
+| `mount` hangs or fails on macOS | Mount point still in use | Close editors or terminals using the mount point, then retry |
+| `umount` fails | A process still has the directory open | Close programs accessing the mounted directory first |
+| Non-zero exit, no output | Generic failure | Re-run with `DRIVE9_CLI_LOG_ENABLED=true` for debug logs |
+
+## Tips
+
+- Always pass `--server https://aws-ap-southeast-1.drive9.ai/` to `drive9 create` and `drive9 ctx add`.
+- Always pass `--tidbcloud-public-key` and `--tidbcloud-private-key` to `drive9 create`.
+- Prefer the mount for day-to-day work; use `drive9 fs` when you do not want to mount.
+- Create the remote directory with `drive9 fs mkdir` before `drive9 mount`.
+- Use a layer when an agent should try changes without writing the shared workspace.
+- Use `drive9 git clone --fast` inside a FUSE mount for large repositories.
+- Use `drive9 --help` and `drive9 fs --help` to inspect the current CLI surface.


### PR DESCRIPTION
## Summary

Add two agent skill files under `docs/skills/`:

- `docs/skills/drive9.md` — the existing public/anonymous skill (copied from https://drive9.ai/skill.md)
- `docs/skills/tidbcloud-aws-ap-southeast-1.md` — TiDB Cloud users on `aws-ap-southeast-1`

The TiDB Cloud skill follows the same agent-skill shape as the public one, but:

- `--server https://aws-ap-southeast-1.drive9.ai/` is required on `drive9 create` and `drive9 ctx add`
- `drive9 create` must pass `--tidbcloud-public-key` and `--tidbcloud-private-key`
- content is based on the TiDB Cloud Getting Started doc (mount-first workflow, sharing, layers, `fs`, git fast clone)

## Test plan

- [ ] Review `docs/skills/drive9.md` against the current public skill
- [ ] Review `docs/skills/tidbcloud-aws-ap-southeast-1.md` for required `--server` + AK/SK on create
- [ ] Confirm the TiDB Cloud skill does not document a no-flag `drive9 create` path