### PR TITLE
feat: upload LayerFS objects directly to S3

### DIFF
--- a/cmd/drive9/cli/layer_test.go
+++ b/cmd/drive9/cli/layer_test.go
@@ -43,6 +43,7 @@ func TestUploadReaderToLayerUsesServerInlineThreshold(t *testing.T) {
 	defer srv.Close()
 
 	c := client.New(srv.URL, "")
+	c.Warm(context.Background())
 	err := uploadReaderToLayer(context.Background(), c, "layer-1", "/repo/a.bin", strings.NewReader("data"), 4, 0o644, true)
 	if err != nil {
 		t.Fatalf("uploadReaderToLayer: %v", err)
@@ -94,12 +95,70 @@ func TestUploadReaderToLayerUsesDirectUploadAboveServerThreshold(t *testing.T) {
 	defer api.Close()
 
 	c := client.New(api.URL, "")
+	c.Warm(context.Background())
 	err := uploadReaderToLayer(context.Background(), c, "layer-1", "/repo/a.bin", strings.NewReader("data"), 4, 0o644, true)
 	if err != nil {
 		t.Fatalf("uploadReaderToLayer: %v", err)
 	}
 	if uploaded != "data" || initiateCalls != 1 || entryCalls != 0 {
 		t.Fatalf("uploaded=%q initiateCalls=%d entryCalls=%d, want data, 1, 0", uploaded, initiateCalls, entryCalls)
+	}
+}
+
+func TestUploadReaderToLayerDoesNotFetchStatusOnHotPath(t *testing.T) {
+	var statusCalls, entryCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /v1/status":
+			statusCalls++
+			_, _ = io.WriteString(w, `{"inline_threshold":1}`)
+		case "HEAD /v1/fs/repo/a.bin":
+			http.NotFound(w, r)
+		case "POST /v1/layers/layer-1/entries":
+			entryCalls++
+			_ = json.NewEncoder(w).Encode(client.FSLayerEntry{Path: "/repo/a.bin"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	if err := uploadReaderToLayer(context.Background(), c, "layer-1", "/repo/a.bin", strings.NewReader("data"), 4, 0, false); err != nil {
+		t.Fatalf("uploadReaderToLayer: %v", err)
+	}
+	if statusCalls != 0 || entryCalls != 1 {
+		t.Fatalf("statusCalls=%d entryCalls=%d, want 0 and 1", statusCalls, entryCalls)
+	}
+}
+
+func TestUploadReaderToLayerCapsInlineEntrySize(t *testing.T) {
+	const size = int64(100 << 20)
+	var entryCalls, initiateCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "HEAD /v1/fs/repo/large.bin":
+			http.NotFound(w, r)
+		case "POST /v1/layers/layer-1/entries":
+			entryCalls++
+			http.Error(w, "unexpected inline upload", http.StatusInternalServerError)
+		case "POST /v1/layers/layer-1/uploads/initiate":
+			initiateCalls++
+			http.Error(w, "direct upload selected", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	c.SetSmallFileThresholdForTests(128 << 20)
+	err := uploadReaderToLayer(context.Background(), c, "layer-1", "/repo/large.bin", strings.NewReader("not consumed"), size, 0, false)
+	if err == nil || !strings.Contains(err.Error(), "direct upload selected") {
+		t.Fatalf("uploadReaderToLayer error = %v, want direct upload marker", err)
+	}
+	if entryCalls != 0 || initiateCalls != 1 {
+		t.Fatalf("entryCalls=%d initiateCalls=%d, want 0 and 1", entryCalls, initiateCalls)
 	}
 }
 

--- a/cmd/drive9/cli/layer_test.go
+++ b/cmd/drive9/cli/layer_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -12,6 +13,95 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/client"
 )
+
+func TestUploadReaderToLayerUsesServerInlineThreshold(t *testing.T) {
+	var statusCalls, entryCalls, initiateCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /v1/status":
+			statusCalls++
+			_, _ = io.WriteString(w, `{"inline_threshold":4}`)
+		case "HEAD /v1/fs/repo/a.bin":
+			http.NotFound(w, r)
+		case "POST /v1/layers/layer-1/entries":
+			entryCalls++
+			var req client.FSLayerEntryRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode layer entry: %v", err)
+			}
+			if string(req.Content) != "data" {
+				t.Errorf("inline content = %q, want data", req.Content)
+			}
+			_ = json.NewEncoder(w).Encode(client.FSLayerEntry{Path: req.Path})
+		case "POST /v1/layers/layer-1/uploads/initiate":
+			initiateCalls++
+			http.Error(w, "unexpected direct upload", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	err := uploadReaderToLayer(context.Background(), c, "layer-1", "/repo/a.bin", strings.NewReader("data"), 4, 0o644, true)
+	if err != nil {
+		t.Fatalf("uploadReaderToLayer: %v", err)
+	}
+	if statusCalls != 1 || entryCalls != 1 || initiateCalls != 0 {
+		t.Fatalf("statusCalls=%d entryCalls=%d initiateCalls=%d, want 1, 1, 0", statusCalls, entryCalls, initiateCalls)
+	}
+}
+
+func TestUploadReaderToLayerUsesDirectUploadAboveServerThreshold(t *testing.T) {
+	var uploaded string
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read S3 body: %v", err)
+		}
+		uploaded = string(data)
+		w.Header().Set("ETag", `"etag-1"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s3.Close()
+
+	var entryCalls, initiateCalls int
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method + " " + r.URL.Path {
+		case "GET /v1/status":
+			_, _ = io.WriteString(w, `{"inline_threshold":3}`)
+		case "HEAD /v1/fs/repo/a.bin":
+			http.NotFound(w, r)
+		case "POST /v1/layers/layer-1/entries":
+			entryCalls++
+			http.Error(w, "unexpected inline upload", http.StatusInternalServerError)
+		case "POST /v1/layers/layer-1/uploads/initiate":
+			initiateCalls++
+			w.WriteHeader(http.StatusAccepted)
+			_, _ = io.WriteString(w, `{"upload_id":"upload-1","part_size":4,"total_parts":1}`)
+		case "POST /v1/layers/layer-1/uploads/upload-1/presign-batch":
+			_ = json.NewEncoder(w).Encode(map[string]any{"parts": []map[string]any{{
+				"number": 1,
+				"url":    s3.URL,
+				"size":   4,
+			}}})
+		case "POST /v1/layers/layer-1/uploads/upload-1/complete":
+			_ = json.NewEncoder(w).Encode(client.FSLayerEntry{Path: "/repo/a.bin", StorageType: "s3"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	c := client.New(api.URL, "")
+	err := uploadReaderToLayer(context.Background(), c, "layer-1", "/repo/a.bin", strings.NewReader("data"), 4, 0o644, true)
+	if err != nil {
+		t.Fatalf("uploadReaderToLayer: %v", err)
+	}
+	if uploaded != "data" || initiateCalls != 1 || entryCalls != 0 {
+		t.Fatalf("uploaded=%q initiateCalls=%d entryCalls=%d, want data, 1, 0", uploaded, initiateCalls, entryCalls)
+	}
+}
 
 func TestLayerCreatePrintsLayerID(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/drive9/cli/layer_write.go
+++ b/cmd/drive9/cli/layer_write.go
@@ -11,8 +11,6 @@ import (
 	"github.com/mem9-ai/drive9/pkg/client"
 )
 
-const cliLayerInlineLimit = 96 << 20
-
 func layerBaseRevision(ctx context.Context, c *client.Client, remotePath string) (int64, error) {
 	stat, err := c.StatCtx(ctx, remotePath)
 	if client.IsNotFound(err) {
@@ -49,7 +47,11 @@ func uploadReaderToLayer(ctx context.Context, c *client.Client, layerRef, remote
 	if err != nil {
 		return err
 	}
-	if size <= cliLayerInlineLimit {
+	inlineLimit := c.SmallFileThreshold(ctx)
+	if inlineLimit <= 0 {
+		inlineLimit = client.DefaultSmallFileThreshold
+	}
+	if size <= inlineLimit {
 		data, err := io.ReadAll(r)
 		if err != nil {
 			return fmt.Errorf("read layer upload: %w", err)

--- a/cmd/drive9/cli/layer_write.go
+++ b/cmd/drive9/cli/layer_write.go
@@ -14,7 +14,7 @@ import (
 // Inline layer entries are JSON/base64 encoded and the server caps that
 // request body at 128 MiB. Leave room for the JSON envelope below the 96 MiB
 // raw-content boundary implied by base64 expansion.
-const cliLayerInlineLimit = 95 << 20
+const cliLayerInlineLimit = client.DefaultFSLayerInlineEntryBytes
 
 func layerBaseRevision(ctx context.Context, c *client.Client, remotePath string) (int64, error) {
 	stat, err := c.StatCtx(ctx, remotePath)

--- a/cmd/drive9/cli/layer_write.go
+++ b/cmd/drive9/cli/layer_write.go
@@ -11,6 +11,11 @@ import (
 	"github.com/mem9-ai/drive9/pkg/client"
 )
 
+// Inline layer entries are JSON/base64 encoded and the server caps that
+// request body at 128 MiB. Leave room for the JSON envelope below the 96 MiB
+// raw-content boundary implied by base64 expansion.
+const cliLayerInlineLimit = 95 << 20
+
 func layerBaseRevision(ctx context.Context, c *client.Client, remotePath string) (int64, error) {
 	stat, err := c.StatCtx(ctx, remotePath)
 	if client.IsNotFound(err) {
@@ -47,10 +52,11 @@ func uploadReaderToLayer(ctx context.Context, c *client.Client, layerRef, remote
 	if err != nil {
 		return err
 	}
-	inlineLimit := c.SmallFileThreshold(ctx)
+	inlineLimit := c.CachedSmallFileThreshold()
 	if inlineLimit <= 0 {
 		inlineLimit = client.DefaultSmallFileThreshold
 	}
+	inlineLimit = min(inlineLimit, cliLayerInlineLimit)
 	if size <= inlineLimit {
 		data, err := io.ReadAll(r)
 		if err != nil {

--- a/pkg/client/fs_layer.go
+++ b/pkg/client/fs_layer.go
@@ -319,6 +319,19 @@ func (c *Client) UploadFSLayerFile(ctx context.Context, layerID, path string, bo
 	if path == "" {
 		return nil, fmt.Errorf("path must not be empty")
 	}
+	if size > 0 {
+		plan, unavailable, err := c.initiateFSLayerUpload(ctx, layerID, path, size, baseRevision, mode, hasMode)
+		if err != nil {
+			return nil, err
+		}
+		if !unavailable {
+			return c.uploadFSLayerFileDirect(ctx, layerID, body, size, plan)
+		}
+	}
+	return c.uploadFSLayerFileLegacy(ctx, layerID, path, body, size, baseRevision, mode, hasMode)
+}
+
+func (c *Client) uploadFSLayerFileLegacy(ctx context.Context, layerID, path string, body io.Reader, size int64, baseRevision int64, mode uint32, hasMode bool) (*FSLayerEntry, error) {
 	q := url.Values{}
 	q.Set("path", path)
 	q.Set("size", fmt.Sprintf("%d", size))

--- a/pkg/client/fs_layer.go
+++ b/pkg/client/fs_layer.go
@@ -12,6 +12,11 @@ import (
 	"time"
 )
 
+// DefaultFSLayerInlineEntryBytes is the largest raw content payload that can
+// be sent in an inline LayerFS entry without exceeding the server's JSON body
+// limit after base64 encoding and envelope overhead.
+const DefaultFSLayerInlineEntryBytes int64 = 95 << 20
+
 type FSLayerCreateRequest struct {
 	LayerID        string            `json:"layer_id,omitempty"`
 	BaseRootPath   string            `json:"base_root_path"`

--- a/pkg/client/fs_layer_test.go
+++ b/pkg/client/fs_layer_test.go
@@ -4,11 +4,303 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 )
+
+func TestUploadFSLayerFileDirectMultipart(t *testing.T) {
+	const payload = "layer payload"
+	var uploaded strings.Builder
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || !strings.HasPrefix(r.URL.Path, "/part/") {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "" || r.Header.Get("X-Dat9-Actor") != "" {
+			t.Errorf("S3 received Drive9 credentials: Authorization=%q Actor=%q", r.Header.Get("Authorization"), r.Header.Get("X-Dat9-Actor"))
+		}
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read S3 part: %v", err)
+			http.Error(w, "read part", http.StatusInternalServerError)
+			return
+		}
+		uploaded.Write(data)
+		w.Header().Set("ETag", `"etag-`+strings.TrimPrefix(r.URL.Path, "/part/")+`"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s3.Close()
+
+	var presigned, completed bool
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer secret" || r.Header.Get("X-Dat9-Actor") != "actor-1" {
+			t.Errorf("Drive9 credentials: Authorization=%q Actor=%q", r.Header.Get("Authorization"), r.Header.Get("X-Dat9-Actor"))
+		}
+		switch r.Method + " " + r.URL.Path {
+		case "POST /v1/layers/layer-1/uploads/initiate":
+			var req struct {
+				Path         string `json:"path"`
+				TotalSize    int64  `json:"total_size"`
+				BaseRevision int64  `json:"base_revision"`
+				Mode         uint32 `json:"mode"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode initiate: %v", err)
+			}
+			if req.Path != "/repo/blob.bin" || req.TotalSize != int64(len(payload)) || req.BaseRevision != 7 || req.Mode != 0o640 {
+				t.Errorf("initiate request = %+v", req)
+			}
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(uploadPlanV2{
+				UploadID:   "upload-1",
+				PartSize:   5,
+				TotalParts: 3,
+			})
+		case "POST /v1/layers/layer-1/uploads/upload-1/presign-batch":
+			var req struct {
+				Parts []struct {
+					PartNumber int `json:"part_number"`
+				} `json:"parts"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode presign batch: %v", err)
+			}
+			if len(req.Parts) != 3 {
+				t.Errorf("presign parts = %+v, want three parts", req.Parts)
+				http.Error(w, "bad request", http.StatusBadRequest)
+				return
+			}
+			parts := make([]presignedPart, 0, len(req.Parts))
+			for _, requestedPart := range req.Parts {
+				partSize := int64(5)
+				if requestedPart.PartNumber == 3 {
+					partSize = 3
+				}
+				parts = append(parts, presignedPart{
+					Number: requestedPart.PartNumber,
+					URL:    s3.URL + "/part/" + string(rune('0'+requestedPart.PartNumber)),
+					Size:   partSize,
+				})
+			}
+			presigned = true
+			_ = json.NewEncoder(w).Encode(map[string]any{"parts": parts})
+		case "POST /v1/layers/layer-1/uploads/upload-1/complete":
+			var req struct {
+				Parts []completePart `json:"parts"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode complete: %v", err)
+			}
+			if len(req.Parts) != 3 || req.Parts[0].Number != 1 || req.Parts[2].ETag != `"etag-3"` {
+				t.Errorf("complete parts = %+v", req.Parts)
+			}
+			completed = true
+			_ = json.NewEncoder(w).Encode(FSLayerEntry{
+				LayerID:     "layer-1",
+				Path:        "/repo/blob.bin",
+				StorageType: "s3",
+				SizeBytes:   int64(len(payload)),
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	c := New(api.URL, "secret")
+	c.SetActor("actor-1")
+	entry, err := c.UploadFSLayerFile(context.Background(), "layer-1", "/repo/blob.bin", strings.NewReader(payload), int64(len(payload)), 7, 0o640, true)
+	if err != nil {
+		t.Fatalf("UploadFSLayerFile: %v", err)
+	}
+	if uploaded.String() != payload {
+		t.Fatalf("uploaded data = %q, want %q", uploaded.String(), payload)
+	}
+	if !presigned || !completed {
+		t.Fatalf("presigned=%v completed=%v, want both true", presigned, completed)
+	}
+	if entry.Path != "/repo/blob.bin" || entry.StorageType != "s3" {
+		t.Fatalf("entry = %+v", entry)
+	}
+}
+
+func TestUploadFSLayerFileFallsBackOnlyWhenInitiateIsUnavailable(t *testing.T) {
+	for _, status := range []int{http.StatusNotFound, http.StatusMethodNotAllowed} {
+		t.Run(http.StatusText(status), func(t *testing.T) {
+			var initiateCalls, legacyCalls int
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/v1/layers/layer-1/uploads/initiate":
+					initiateCalls++
+					w.WriteHeader(status)
+				case "/v1/layers/layer-1/objects":
+					legacyCalls++
+					data, _ := io.ReadAll(r.Body)
+					if string(data) != "payload" {
+						t.Errorf("legacy body = %q, want payload", data)
+					}
+					_ = json.NewEncoder(w).Encode(FSLayerEntry{Path: "/repo/a.bin"})
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer srv.Close()
+
+			c := New(srv.URL, "")
+			entry, err := c.UploadFSLayerFile(context.Background(), "layer-1", "/repo/a.bin", strings.NewReader("payload"), 7, 0, 0, false)
+			if err != nil {
+				t.Fatalf("UploadFSLayerFile: %v", err)
+			}
+			if entry.Path != "/repo/a.bin" || initiateCalls != 1 || legacyCalls != 1 {
+				t.Fatalf("entry=%+v initiateCalls=%d legacyCalls=%d", entry, initiateCalls, legacyCalls)
+			}
+		})
+	}
+}
+
+func TestUploadFSLayerFileDoesNotFallbackOnInitiateFailure(t *testing.T) {
+	var legacyCalls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/layers/layer-1/uploads/initiate":
+			http.Error(w, "unavailable", http.StatusInternalServerError)
+		case "/v1/layers/layer-1/objects":
+			legacyCalls++
+			_ = json.NewEncoder(w).Encode(FSLayerEntry{Path: "/repo/a.bin"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	_, err := c.UploadFSLayerFile(context.Background(), "layer-1", "/repo/a.bin", strings.NewReader("payload"), 7, 0, 0, false)
+	if err == nil {
+		t.Fatal("UploadFSLayerFile error = nil, want initiate failure")
+	}
+	if legacyCalls != 0 {
+		t.Fatalf("legacy calls = %d, want 0", legacyCalls)
+	}
+}
+
+func TestUploadFSLayerFileAbortsAfterPartFailureWithoutFallback(t *testing.T) {
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "S3 failure", http.StatusInternalServerError)
+	}))
+	defer s3.Close()
+
+	var abortCalls, legacyCalls int
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/layers/layer-1/uploads/initiate":
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(uploadPlanV2{UploadID: "upload-1", PartSize: 7, TotalParts: 1})
+		case "/v1/layers/layer-1/uploads/upload-1/presign-batch":
+			_ = json.NewEncoder(w).Encode(map[string]any{"parts": []presignedPart{{Number: 1, URL: s3.URL, Size: 7}}})
+		case "/v1/layers/layer-1/uploads/upload-1/abort":
+			abortCalls++
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		case "/v1/layers/layer-1/objects":
+			legacyCalls++
+			_ = json.NewEncoder(w).Encode(FSLayerEntry{Path: "/repo/a.bin"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	c := New(api.URL, "")
+	_, err := c.UploadFSLayerFile(context.Background(), "layer-1", "/repo/a.bin", strings.NewReader("payload"), 7, 0, 0, false)
+	if err == nil {
+		t.Fatal("UploadFSLayerFile error = nil, want part upload failure")
+	}
+	if abortCalls != 1 || legacyCalls != 0 {
+		t.Fatalf("abortCalls=%d legacyCalls=%d, want 1 and 0", abortCalls, legacyCalls)
+	}
+}
+
+func TestUploadFSLayerFileDoesNotFallbackOrAbortAfterCompleteStarts(t *testing.T) {
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("ETag", `"etag-1"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s3.Close()
+
+	var completeCalls, abortCalls, legacyCalls int
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/layers/layer-1/uploads/initiate":
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(uploadPlanV2{UploadID: "upload-1", PartSize: 7, TotalParts: 1})
+		case "/v1/layers/layer-1/uploads/upload-1/presign-batch":
+			_ = json.NewEncoder(w).Encode(map[string]any{"parts": []presignedPart{{Number: 1, URL: s3.URL, Size: 7}}})
+		case "/v1/layers/layer-1/uploads/upload-1/complete":
+			completeCalls++
+			conn, _, err := w.(http.Hijacker).Hijack()
+			if err != nil {
+				t.Errorf("hijack complete response: %v", err)
+				return
+			}
+			_ = conn.Close()
+		case "/v1/layers/layer-1/uploads/upload-1/abort":
+			abortCalls++
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+		case "/v1/layers/layer-1/objects":
+			legacyCalls++
+			_ = json.NewEncoder(w).Encode(FSLayerEntry{Path: "/repo/a.bin"})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	c := New(api.URL, "")
+	_, err := c.UploadFSLayerFile(context.Background(), "layer-1", "/repo/a.bin", strings.NewReader("payload"), 7, 0, 0, false)
+	if err == nil {
+		t.Fatal("UploadFSLayerFile error = nil, want ambiguous complete result")
+	}
+	if completeCalls != 1 || abortCalls != 0 || legacyCalls != 0 {
+		t.Fatalf("completeCalls=%d abortCalls=%d legacyCalls=%d, want 1, 0, 0", completeCalls, abortCalls, legacyCalls)
+	}
+}
+
+func TestReadFSLayerFileRedirectStripsCredentialsAcrossHosts(t *testing.T) {
+	var destinationAuthorization, destinationActor string
+	destination := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		destinationAuthorization = r.Header.Get("Authorization")
+		destinationActor = r.Header.Get("X-Dat9-Actor")
+		_, _ = io.WriteString(w, "payload")
+	}))
+	defer destination.Close()
+
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/layers/layer-1/objects" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Header.Get("Authorization") != "Bearer secret" || r.Header.Get("X-Dat9-Actor") != "actor-1" {
+			t.Errorf("source credentials: Authorization=%q Actor=%q", r.Header.Get("Authorization"), r.Header.Get("X-Dat9-Actor"))
+		}
+		http.Redirect(w, r, destination.URL+"/object", http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	c := New(source.URL, "secret")
+	c.SetActor("actor-1")
+	data, err := c.ReadFSLayerFile(context.Background(), "layer-1", "/repo/a.bin", nil)
+	if err != nil {
+		t.Fatalf("ReadFSLayerFile: %v", err)
+	}
+	if string(data) != "payload" {
+		t.Fatalf("data = %q, want payload", data)
+	}
+	if destinationAuthorization != "" || destinationActor != "" {
+		t.Fatalf("destination credentials: Authorization=%q Actor=%q, want empty", destinationAuthorization, destinationActor)
+	}
+}
 
 func TestCommitFSLayerReturnsConflictBody(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -47,6 +339,10 @@ func TestCommitFSLayerReturnsConflictBody(t *testing.T) {
 func TestFSLayerFileOperationsPreserveSpaceOnlyPath(t *testing.T) {
 	const path = "  "
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/uploads/initiate") {
+			http.NotFound(w, r)
+			return
+		}
 		if got := r.URL.Query().Get("path"); got != path {
 			t.Errorf("query path = %q, want %q", got, path)
 		}

--- a/pkg/client/fs_layer_test.go
+++ b/pkg/client/fs_layer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -21,6 +22,9 @@ func TestUploadFSLayerFileDirectMultipart(t *testing.T) {
 		}
 		if r.Header.Get("Authorization") != "" || r.Header.Get("X-Dat9-Actor") != "" {
 			t.Errorf("S3 received Drive9 credentials: Authorization=%q Actor=%q", r.Header.Get("Authorization"), r.Header.Get("X-Dat9-Actor"))
+		}
+		if r.Header.Get("X-Amz-Meta-Test") != "allowed" {
+			t.Errorf("S3 allowed presigned header = %q, want allowed", r.Header.Get("X-Amz-Meta-Test"))
 		}
 		data, err := io.ReadAll(r.Body)
 		if err != nil {
@@ -83,6 +87,11 @@ func TestUploadFSLayerFileDirectMultipart(t *testing.T) {
 					Number: requestedPart.PartNumber,
 					URL:    s3.URL + "/part/" + string(rune('0'+requestedPart.PartNumber)),
 					Size:   partSize,
+					Headers: map[string]string{
+						"authorization":   "Bearer leaked",
+						"x-dAt9-aCtOr":    "actor-leaked",
+						"X-Amz-Meta-Test": "allowed",
+					},
 				})
 			}
 			presigned = true
@@ -124,6 +133,120 @@ func TestUploadFSLayerFileDirectMultipart(t *testing.T) {
 	}
 	if entry.Path != "/repo/blob.bin" || entry.StorageType != "s3" {
 		t.Fatalf("entry = %+v", entry)
+	}
+}
+
+func TestPresignFSLayerUploadPartsAcceptsOutOfOrderResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/layers/layer-1/uploads/upload-1/presign-batch" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"parts": []presignedPart{
+			{Number: 3, URL: "https://s3.example/3", Size: 3},
+			{Number: 1, URL: "https://s3.example/1", Size: 5},
+			{Number: 2, URL: "https://s3.example/2", Size: 5},
+		}})
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	parts, err := c.presignFSLayerUploadParts(context.Background(), "layer-1", "upload-1", 1, 3, []int64{5, 5, 3})
+	if err != nil {
+		t.Fatalf("presignFSLayerUploadParts: %v", err)
+	}
+	if len(parts) != 3 || parts[0].Number != 1 || parts[1].Number != 2 || parts[2].Number != 3 {
+		t.Fatalf("parts = %+v, want part numbers [1 2 3]", parts)
+	}
+}
+
+func TestUploadFSLayerPartLimitsErrorBody(t *testing.T) {
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, strings.Repeat("x", 65<<10))
+	}))
+	defer s3.Close()
+
+	c := New("http://drive9.test", "")
+	_, err := c.uploadFSLayerPart(context.Background(), presignedPart{URL: s3.URL}, strings.NewReader("payload"), 7)
+	if err == nil {
+		t.Fatal("uploadFSLayerPart error = nil, want S3 error")
+	}
+	if len(err.Error()) > (64<<10)+32 {
+		t.Fatalf("uploadFSLayerPart error length = %d, want bounded S3 response", len(err.Error()))
+	}
+}
+
+func TestUploadFSLayerFileRePresignsExpiredPart(t *testing.T) {
+	const payload = "abcdefghij"
+	var part1Calls, part2Calls, presignCalls, abortCalls int
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		data, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read S3 body: %v", err)
+		}
+		switch r.URL.Path {
+		case "/part/1":
+			part1Calls++
+			if string(data) != "abcde" {
+				t.Errorf("S3 part 1 body = %q, want abcde", data)
+			}
+			w.Header().Set("ETag", `"etag-1"`)
+		case "/part/2":
+			part2Calls++
+			if string(data) != "fghij" {
+				t.Errorf("S3 part 2 body = %q, want fghij", data)
+			}
+			if part2Calls == 1 {
+				w.WriteHeader(http.StatusForbidden)
+				return
+			}
+			w.Header().Set("ETag", `"etag-2"`)
+		default:
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s3.Close()
+
+	api := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/layers/layer-1/uploads/initiate":
+			w.WriteHeader(http.StatusAccepted)
+			_ = json.NewEncoder(w).Encode(uploadPlanV2{UploadID: "upload-1", PartSize: 5, TotalParts: 2})
+		case "/v1/layers/layer-1/uploads/upload-1/presign-batch":
+			presignCalls++
+			var req struct {
+				Parts []struct {
+					PartNumber int `json:"part_number"`
+				} `json:"parts"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Errorf("decode presign request: %v", err)
+			}
+			presigned := make([]presignedPart, 0, len(req.Parts))
+			for _, requested := range req.Parts {
+				presigned = append(presigned, presignedPart{Number: requested.PartNumber, URL: fmt.Sprintf("%s/part/%d", s3.URL, requested.PartNumber), Size: 5})
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{"parts": presigned})
+		case "/v1/layers/layer-1/uploads/upload-1/complete":
+			_ = json.NewEncoder(w).Encode(FSLayerEntry{Path: "/repo/a.bin", StorageType: "s3"})
+		case "/v1/layers/layer-1/uploads/upload-1/abort":
+			abortCalls++
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer api.Close()
+
+	c := New(api.URL, "")
+	entry, err := c.UploadFSLayerFile(context.Background(), "layer-1", "/repo/a.bin", strings.NewReader(payload), int64(len(payload)), 0, 0, false)
+	if err != nil {
+		t.Fatalf("UploadFSLayerFile: %v", err)
+	}
+	if entry.StorageType != "s3" || part1Calls != 1 || part2Calls != 2 || presignCalls != 2 || abortCalls != 0 {
+		t.Fatalf("entry=%+v part1Calls=%d part2Calls=%d presignCalls=%d abortCalls=%d, want s3, 1, 2, 2, 0", entry, part1Calls, part2Calls, presignCalls, abortCalls)
 	}
 }
 

--- a/pkg/client/fs_layer_test.go
+++ b/pkg/client/fs_layer_test.go
@@ -12,6 +12,12 @@ import (
 	"testing"
 )
 
+func TestDefaultFSLayerInlineEntryBytes(t *testing.T) {
+	if got, want := DefaultFSLayerInlineEntryBytes, int64(95<<20); got != want {
+		t.Fatalf("DefaultFSLayerInlineEntryBytes = %d, want %d", got, want)
+	}
+}
+
 func TestUploadFSLayerFileDirectMultipart(t *testing.T) {
 	const payload = "layer payload"
 	var uploaded strings.Builder

--- a/pkg/client/fs_layer_transfer.go
+++ b/pkg/client/fs_layer_transfer.go
@@ -1,0 +1,241 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const fsLayerPresignBatchSize = 16
+
+type fsLayerUploadInitiateRequest struct {
+	Path         string `json:"path"`
+	TotalSize    int64  `json:"total_size"`
+	BaseRevision int64  `json:"base_revision,omitempty"`
+	Mode         uint32 `json:"mode,omitempty"`
+}
+
+func (c *Client) initiateFSLayerUpload(ctx context.Context, layerID, path string, size, baseRevision int64, mode uint32, hasMode bool) (*uploadPlanV2, bool, error) {
+	if baseRevision < 0 {
+		baseRevision = 0
+	}
+	if !hasMode {
+		mode = 0
+	}
+	body, err := json.Marshal(fsLayerUploadInitiateRequest{
+		Path:         path,
+		TotalSize:    size,
+		BaseRevision: baseRevision,
+		Mode:         mode & 0o777,
+	})
+	if err != nil {
+		return nil, false, err
+	}
+	u := c.baseURL + "/v1/layers/" + url.PathEscape(layerID) + "/uploads/initiate"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, false, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, false, fmt.Errorf("initiate fs layer upload: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
+		return nil, true, nil
+	}
+	if resp.StatusCode != http.StatusAccepted {
+		return nil, false, fmt.Errorf("initiate fs layer upload: %w", readError(resp))
+	}
+	var plan uploadPlanV2
+	if err := json.NewDecoder(resp.Body).Decode(&plan); err != nil {
+		return nil, false, fmt.Errorf("decode fs layer upload plan: %w", err)
+	}
+	if err := validateFSLayerUploadPlan(&plan, size); err != nil {
+		if plan.UploadID != "" {
+			c.abortFSLayerUploadBestEffort(ctx, layerID, plan.UploadID)
+		}
+		return nil, false, err
+	}
+	return &plan, false, nil
+}
+
+func validateFSLayerUploadPlan(plan *uploadPlanV2, size int64) error {
+	if plan.UploadID == "" {
+		return fmt.Errorf("invalid fs layer upload plan: upload_id is empty")
+	}
+	if plan.PartSize <= 0 {
+		return fmt.Errorf("invalid fs layer upload plan: part_size must be positive")
+	}
+	wantParts := (size-1)/plan.PartSize + 1
+	if plan.TotalParts <= 0 || int64(plan.TotalParts) != wantParts {
+		return fmt.Errorf("invalid fs layer upload plan: total_parts=%d, want %d", plan.TotalParts, wantParts)
+	}
+	return nil
+}
+
+func (c *Client) uploadFSLayerFileDirect(ctx context.Context, layerID string, body io.Reader, size int64, plan *uploadPlanV2) (*FSLayerEntry, error) {
+	parts := make([]completePart, 0, plan.TotalParts)
+	remaining := size
+	for start := 1; start <= plan.TotalParts; start += fsLayerPresignBatchSize {
+		end := min(start+fsLayerPresignBatchSize-1, plan.TotalParts)
+		expectedSizes := make([]int64, 0, end-start+1)
+		batchRemaining := remaining
+		for partNumber := start; partNumber <= end; partNumber++ {
+			partSize := min(plan.PartSize, batchRemaining)
+			expectedSizes = append(expectedSizes, partSize)
+			batchRemaining -= partSize
+		}
+		presigned, err := c.presignFSLayerUploadParts(ctx, layerID, plan.UploadID, start, end, expectedSizes)
+		if err != nil {
+			c.abortFSLayerUploadBestEffort(ctx, layerID, plan.UploadID)
+			return nil, err
+		}
+		for i, part := range presigned {
+			partNumber := start + i
+			partSize := expectedSizes[i]
+			etag, err := c.uploadFSLayerPart(ctx, part, body, partSize)
+			if err != nil {
+				c.abortFSLayerUploadBestEffort(ctx, layerID, plan.UploadID)
+				return nil, fmt.Errorf("upload fs layer part %d: %w", partNumber, err)
+			}
+			parts = append(parts, completePart{Number: partNumber, ETag: etag})
+			remaining -= partSize
+		}
+	}
+	return c.completeFSLayerUpload(ctx, layerID, plan.UploadID, parts)
+}
+
+func (c *Client) presignFSLayerUploadParts(ctx context.Context, layerID, uploadID string, start, end int, expectedSizes []int64) ([]presignedPart, error) {
+	entries := make([]struct {
+		PartNumber int `json:"part_number"`
+	}, 0, end-start+1)
+	for partNumber := start; partNumber <= end; partNumber++ {
+		entries = append(entries, struct {
+			PartNumber int `json:"part_number"`
+		}{PartNumber: partNumber})
+	}
+	body, err := json.Marshal(struct {
+		Parts []struct {
+			PartNumber int `json:"part_number"`
+		} `json:"parts"`
+	}{Parts: entries})
+	if err != nil {
+		return nil, err
+	}
+	u := c.fsLayerUploadURL(layerID, uploadID, "presign-batch")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("presign fs layer upload parts %d-%d: %w", start, end, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("presign fs layer upload parts %d-%d: %w", start, end, readError(resp))
+	}
+	var out struct {
+		Parts []presignedPart `json:"parts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode fs layer presign response: %w", err)
+	}
+	if len(out.Parts) != len(entries) {
+		return nil, fmt.Errorf("invalid fs layer presign response: got %d parts, want %d", len(out.Parts), len(entries))
+	}
+	for i, part := range out.Parts {
+		partNumber := start + i
+		if part.Number != partNumber || part.URL == "" || part.Size != expectedSizes[i] {
+			return nil, fmt.Errorf("invalid fs layer presign response for part %d", partNumber)
+		}
+	}
+	return out.Parts, nil
+}
+
+func (c *Client) uploadFSLayerPart(ctx context.Context, part presignedPart, body io.Reader, size int64) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, part.URL, io.LimitReader(body, size))
+	if err != nil {
+		return "", err
+	}
+	for key, value := range part.Headers {
+		if strings.EqualFold(key, "host") {
+			continue
+		}
+		req.Header.Set(key, value)
+	}
+	req.ContentLength = size
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode == http.StatusForbidden {
+		return "", errPresignExpired
+	}
+	if resp.StatusCode >= 300 {
+		responseBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(responseBody))
+	}
+	etag := resp.Header.Get("ETag")
+	if etag == "" {
+		return "", fmt.Errorf("S3 upload response omitted ETag")
+	}
+	return etag, nil
+}
+
+func (c *Client) completeFSLayerUpload(ctx context.Context, layerID, uploadID string, parts []completePart) (*FSLayerEntry, error) {
+	body, err := json.Marshal(struct {
+		Parts []completePart `json:"parts"`
+	}{Parts: parts})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.fsLayerUploadURL(layerID, uploadID, "complete"), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, markCommitAttempt(fmt.Errorf("complete fs layer upload: %w", err))
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, markCommitAttempt(fmt.Errorf("complete fs layer upload: %w", readError(resp)))
+	}
+	var entry FSLayerEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entry); err != nil {
+		return nil, markCommitAttempt(fmt.Errorf("decode completed fs layer entry: %w", err))
+	}
+	return &entry, nil
+}
+
+func (c *Client) abortFSLayerUploadBestEffort(parent context.Context, layerID, uploadID string) {
+	timeout := c.multipartAbortTimeout
+	if timeout <= 0 {
+		timeout = defaultMultipartAbortTimeout
+	}
+	ctx, cancel := newMultipartAbortContext(parent, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.fsLayerUploadURL(layerID, uploadID, "abort"), nil)
+	if err != nil {
+		return
+	}
+	resp, err := c.do(req)
+	if err == nil {
+		_ = resp.Body.Close()
+	}
+}
+
+func (c *Client) fsLayerUploadURL(layerID, uploadID, action string) string {
+	return c.baseURL + "/v1/layers/" + url.PathEscape(layerID) + "/uploads/" + url.PathEscape(uploadID) + "/" + action
+}

--- a/pkg/client/fs_layer_transfer.go
+++ b/pkg/client/fs_layer_transfer.go
@@ -12,8 +12,7 @@ import (
 )
 
 const (
-	fsLayerPresignBatchSize  = 16
-	fsLayerMaxErrorBodyBytes = 64 << 10
+	fsLayerPresignBatchSize = 16
 )
 
 type fsLayerUploadInitiateRequest struct {
@@ -207,7 +206,7 @@ func (c *Client) uploadFSLayerPart(ctx context.Context, part presignedPart, body
 		return "", errPresignExpired
 	}
 	if resp.StatusCode >= 300 {
-		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, fsLayerMaxErrorBodyBytes))
+		responseBody := readPresignedErrorBody(resp)
 		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(responseBody))
 	}
 	etag := resp.Header.Get("ETag")

--- a/pkg/client/fs_layer_transfer.go
+++ b/pkg/client/fs_layer_transfer.go
@@ -4,14 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 )
 
-const fsLayerPresignBatchSize = 16
+const (
+	fsLayerPresignBatchSize  = 16
+	fsLayerMaxErrorBodyBytes = 64 << 10
+)
 
 type fsLayerUploadInitiateRequest struct {
 	Path         string `json:"path"`
@@ -83,6 +86,7 @@ func validateFSLayerUploadPlan(plan *uploadPlanV2, size int64) error {
 func (c *Client) uploadFSLayerFileDirect(ctx context.Context, layerID string, body io.Reader, size int64, plan *uploadPlanV2) (*FSLayerEntry, error) {
 	parts := make([]completePart, 0, plan.TotalParts)
 	remaining := size
+	seeker, seekable := body.(io.Seeker)
 	for start := 1; start <= plan.TotalParts; start += fsLayerPresignBatchSize {
 		end := min(start+fsLayerPresignBatchSize-1, plan.TotalParts)
 		expectedSizes := make([]int64, 0, end-start+1)
@@ -100,7 +104,24 @@ func (c *Client) uploadFSLayerFileDirect(ctx context.Context, layerID string, bo
 		for i, part := range presigned {
 			partNumber := start + i
 			partSize := expectedSizes[i]
+			partOffset, canRetry := int64(0), false
+			if seekable {
+				partOffset, err = seeker.Seek(0, io.SeekCurrent)
+				canRetry = err == nil
+			}
 			etag, err := c.uploadFSLayerPart(ctx, part, body, partSize)
+			if errors.Is(err, errPresignExpired) && canRetry {
+				if _, seekErr := seeker.Seek(partOffset, io.SeekStart); seekErr != nil {
+					err = fmt.Errorf("rewind fs layer part %d: %w", partNumber, seekErr)
+				} else {
+					fresh, presignErr := c.presignFSLayerUploadParts(ctx, layerID, plan.UploadID, partNumber, partNumber, []int64{partSize})
+					if presignErr != nil {
+						err = fmt.Errorf("re-presign fs layer part %d: %w", partNumber, presignErr)
+					} else {
+						etag, err = c.uploadFSLayerPart(ctx, fresh[0], body, partSize)
+					}
+				}
+			}
 			if err != nil {
 				c.abortFSLayerUploadBestEffort(ctx, layerID, plan.UploadID)
 				return nil, fmt.Errorf("upload fs layer part %d: %w", partNumber, err)
@@ -152,13 +173,17 @@ func (c *Client) presignFSLayerUploadParts(ctx context.Context, layerID, uploadI
 	if len(out.Parts) != len(entries) {
 		return nil, fmt.Errorf("invalid fs layer presign response: got %d parts, want %d", len(out.Parts), len(entries))
 	}
-	for i, part := range out.Parts {
-		partNumber := start + i
-		if part.Number != partNumber || part.URL == "" || part.Size != expectedSizes[i] {
-			return nil, fmt.Errorf("invalid fs layer presign response for part %d", partNumber)
+	ordered := make([]presignedPart, len(out.Parts))
+	seen := make([]bool, len(out.Parts))
+	for _, part := range out.Parts {
+		index := part.Number - start
+		if index < 0 || index >= len(ordered) || seen[index] || part.URL == "" || part.Size != expectedSizes[index] {
+			return nil, fmt.Errorf("invalid fs layer presign response for part %d", part.Number)
 		}
+		ordered[index] = part
+		seen[index] = true
 	}
-	return out.Parts, nil
+	return ordered, nil
 }
 
 func (c *Client) uploadFSLayerPart(ctx context.Context, part presignedPart, body io.Reader, size int64) (string, error) {
@@ -167,7 +192,7 @@ func (c *Client) uploadFSLayerPart(ctx context.Context, part presignedPart, body
 		return "", err
 	}
 	for key, value := range part.Headers {
-		if strings.EqualFold(key, "host") {
+		if isForbiddenPresignedHeader(key) {
 			continue
 		}
 		req.Header.Set(key, value)
@@ -182,7 +207,7 @@ func (c *Client) uploadFSLayerPart(ctx context.Context, part presignedPart, body
 		return "", errPresignExpired
 	}
 	if resp.StatusCode >= 300 {
-		responseBody, _ := io.ReadAll(resp.Body)
+		responseBody, _ := io.ReadAll(io.LimitReader(resp.Body, fsLayerMaxErrorBodyBytes))
 		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(responseBody))
 	}
 	etag := resp.Header.Get("ETag")

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -221,7 +221,7 @@ func (c *Client) uploadPatchPart(ctx context.Context, part *PatchPartURL, readPa
 	}
 	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body := readPresignedErrorBody(resp)
 		return fmt.Errorf("upload part: HTTP %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"sync"
 )
 
@@ -171,7 +170,7 @@ func (c *Client) uploadPatchPart(ctx context.Context, part *PatchPartURL, readPa
 		}
 		// AWS presigned URLs with Range require the matching Range header.
 		for k, v := range part.ReadHeaders {
-			if !strings.EqualFold(k, "host") {
+			if !isForbiddenPresignedHeader(k) {
 				req.Header.Set(k, v)
 			}
 		}
@@ -203,7 +202,7 @@ func (c *Client) uploadPatchPart(ctx context.Context, part *PatchPartURL, readPa
 		return err
 	}
 	for k, v := range part.Headers {
-		if strings.EqualFold(k, "host") {
+		if isForbiddenPresignedHeader(k) {
 			continue
 		}
 		req.Header.Set(k, v)

--- a/pkg/client/patch_test.go
+++ b/pkg/client/patch_test.go
@@ -47,17 +47,29 @@ func TestPatchFileSendsExplicitPartSize(t *testing.T) {
 				UploadID: "patch-123",
 				PartSize: 6,
 				UploadParts: []*PatchPartURL{{
-					Number:      2,
-					URL:         fmt.Sprintf("http://%s/upload/2", r.Host),
-					Size:        6,
-					Headers:     map[string]string{"X-Upload-Token": "upload-token"},
-					ReadURL:     fmt.Sprintf("http://%s/read/2", r.Host),
-					ReadHeaders: map[string]string{"Range": "bytes=6-11"},
+					Number: 2,
+					URL:    fmt.Sprintf("http://%s/upload/2", r.Host),
+					Size:   6,
+					Headers: map[string]string{
+						"X-Upload-Token": "upload-token",
+						"authorization":  "Bearer leaked",
+						"x-dAt9-aCtOr":   "actor-leaked",
+					},
+					ReadURL: fmt.Sprintf("http://%s/read/2", r.Host),
+					ReadHeaders: map[string]string{
+						"Range":         "bytes=6-11",
+						"Authorization": "Bearer leaked",
+						"X-Dat9-Actor":  "actor-leaked",
+					},
 				}},
 				CopiedParts: []int{1},
 			})
 
 		case r.Method == http.MethodGet && r.URL.Path == "/read/2":
+			if r.Header.Get("Authorization") != "" || r.Header.Get("X-Dat9-Actor") != "" {
+				http.Error(w, "read target received Drive9 credentials", http.StatusBadRequest)
+				return
+			}
 			if got := r.Header.Get("Range"); got != "bytes=6-11" {
 				http.Error(w, "missing range header", http.StatusBadRequest)
 				return
@@ -65,6 +77,10 @@ func TestPatchFileSendsExplicitPartSize(t *testing.T) {
 			_, _ = w.Write([]byte("orig!!"))
 
 		case r.Method == http.MethodPut && r.URL.Path == "/upload/2":
+			if r.Header.Get("Authorization") != "" || r.Header.Get("X-Dat9-Actor") != "" {
+				http.Error(w, "upload target received Drive9 credentials", http.StatusBadRequest)
+				return
+			}
 			if got := r.Header.Get("X-Upload-Token"); got != "upload-token" {
 				http.Error(w, "missing upload token", http.StatusBadRequest)
 				return

--- a/pkg/client/patch_test.go
+++ b/pkg/client/patch_test.go
@@ -405,3 +405,22 @@ func TestPatchUploadRespectsPresignedChecksumHeader(t *testing.T) {
 		})
 	}
 }
+
+func TestPatchUploadPartLimitsErrorBody(t *testing.T) {
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, strings.Repeat("x", 65<<10))
+	}))
+	defer s3.Close()
+
+	c := New("http://drive9.test", "")
+	err := c.uploadPatchPart(context.Background(), &PatchPartURL{Number: 1, URL: s3.URL, Size: 7}, func(int, int64, []byte) ([]byte, error) {
+		return []byte("payload"), nil
+	})
+	if err == nil {
+		t.Fatal("uploadPatchPart error = nil, want S3 error")
+	}
+	if len(err.Error()) > (64<<10)+64 {
+		t.Fatalf("uploadPatchPart error length = %d, want bounded S3 response", len(err.Error()))
+	}
+}

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -229,6 +229,12 @@ func uploadParallelism(partSize int64) int {
 	return min(byMemory, uploadMaxConcurrency)
 }
 
+func isForbiddenPresignedHeader(key string) bool {
+	return strings.EqualFold(key, "host") ||
+		strings.EqualFold(key, "authorization") ||
+		strings.EqualFold(key, "x-dat9-actor")
+}
+
 func boundedUploadParallelism(partSize int64, partCount int) int {
 	parallelism := uploadParallelism(partSize)
 	if partCount > 0 && parallelism > partCount {
@@ -879,7 +885,7 @@ func (c *Client) uploadOnePart(ctx context.Context, part PartURL, data []byte) (
 		return "", err
 	}
 	for k, v := range part.Headers {
-		if strings.EqualFold(k, "host") {
+		if isForbiddenPresignedHeader(k) {
 			continue
 		}
 		req.Header.Set(k, v)
@@ -1203,7 +1209,7 @@ func (c *Client) uploadOnePartV2(ctx context.Context, part presignedPart, data [
 		return "", err
 	}
 	for k, v := range part.Headers {
-		if strings.EqualFold(k, "host") {
+		if isForbiddenPresignedHeader(k) {
 			continue
 		}
 		req.Header.Set(k, v)

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -88,6 +88,13 @@ type ProgressFunc func(partNumber, totalParts int, bytesUploaded int64)
 // no server value has been negotiated.
 const DefaultSmallFileThreshold = 50_000
 
+const maxPresignedErrorBodyBytes = 64 << 10
+
+func readPresignedErrorBody(resp *http.Response) []byte {
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, maxPresignedErrorBodyBytes))
+	return body
+}
+
 // uploadThreshold returns the cutoff between direct PUT and V2 multipart
 // upload. Resolution order:
 //  1. Per-Client override (c.smallFileThreshold > 0): used as-is. Tests pin
@@ -900,7 +907,7 @@ func (c *Client) uploadOnePart(ctx context.Context, part PartURL, data []byte) (
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body := readPresignedErrorBody(resp)
 		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -1226,7 +1233,7 @@ func (c *Client) uploadOnePartV2(ctx context.Context, part presignedPart, data [
 		return "", errPresignExpired
 	}
 	if resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body := readPresignedErrorBody(resp)
 		return "", fmt.Errorf("HTTP %d: %s", resp.StatusCode, string(body))
 	}
 

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -966,6 +966,44 @@ func TestPresignedUploadsStripDrive9Credentials(t *testing.T) {
 	}
 }
 
+func TestPresignedPartErrorsLimitBody(t *testing.T) {
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, strings.Repeat("x", 65<<10))
+	}))
+	defer s3.Close()
+
+	for _, tc := range []struct {
+		name   string
+		upload func() error
+	}{
+		{
+			name: "v1",
+			upload: func() error {
+				_, err := (&Client{httpClient: http.DefaultClient}).uploadOnePart(context.Background(), PartURL{URL: s3.URL}, []byte("payload"))
+				return err
+			},
+		},
+		{
+			name: "v2",
+			upload: func() error {
+				_, err := (&Client{httpClient: http.DefaultClient}).uploadOnePartV2(context.Background(), presignedPart{URL: s3.URL}, []byte("payload"))
+				return err
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.upload()
+			if err == nil {
+				t.Fatal("upload error = nil, want S3 error")
+			}
+			if len(err.Error()) > (64<<10)+32 {
+				t.Fatalf("upload error length = %d, want bounded S3 response", len(err.Error()))
+			}
+		})
+	}
+}
+
 func TestWriteStreamV2RePresignsExpiredPart(t *testing.T) {
 	var expiredUploads atomic.Int32
 	var freshUploads atomic.Int32

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -934,6 +934,38 @@ func TestWriteStreamV2MultiPartUsesPlanPartSize(t *testing.T) {
 	}
 }
 
+func TestPresignedUploadsStripDrive9Credentials(t *testing.T) {
+	var requests int
+	s3 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if r.Header.Get("Authorization") != "" || r.Header.Get("X-Dat9-Actor") != "" {
+			t.Errorf("S3 received Drive9 credentials: Authorization=%q Actor=%q", r.Header.Get("Authorization"), r.Header.Get("X-Dat9-Actor"))
+		}
+		if r.Header.Get("X-Amz-Meta-Test") != "allowed" {
+			t.Errorf("S3 allowed presigned header = %q, want allowed", r.Header.Get("X-Amz-Meta-Test"))
+		}
+		w.Header().Set("ETag", `"etag-1"`)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s3.Close()
+
+	headers := map[string]string{
+		"authorization":   "Bearer leaked",
+		"x-dAt9-aCtOr":    "actor-leaked",
+		"X-Amz-Meta-Test": "allowed",
+	}
+	c := New("http://drive9.test", "")
+	if _, err := c.uploadOnePart(context.Background(), PartURL{URL: s3.URL, Headers: headers}, []byte("v1")); err != nil {
+		t.Fatalf("uploadOnePart: %v", err)
+	}
+	if _, err := c.uploadOnePartV2(context.Background(), presignedPart{URL: s3.URL, Headers: headers}, []byte("v2")); err != nil {
+		t.Fatalf("uploadOnePartV2: %v", err)
+	}
+	if requests != 2 {
+		t.Fatalf("S3 requests = %d, want 2", requests)
+	}
+}
+
 func TestWriteStreamV2RePresignsExpiredPart(t *testing.T) {
 	var expiredUploads atomic.Int32
 	var freshUploads atomic.Int32

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -19,7 +19,7 @@ import (
 var errCommitPostUpload = errors.New("commit post-upload step failed")
 
 const (
-	maxInlineLayerEntryBytes     = 96 << 20
+	maxInlineLayerEntryBytes     = client.DefaultFSLayerInlineEntryBytes
 	zeroTruncateCommitQueueDelay = 50 * time.Millisecond
 	defaultCommitBatchMaxItems   = 64
 	defaultCommitBatchMaxBytes   = client.MaxBatchWriteBytes

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -709,6 +709,10 @@ func TestCommitQueueLayerUploadAcceptsShadowSpillWithoutBaseWrite(t *testing.T) 
 	var gotBody []byte
 	var putCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPost && r.URL.Path == "/v1/layers/layer-1/uploads/initiate" {
+			http.NotFound(w, r)
+			return
+		}
 		if r.Method == http.MethodPut {
 			putCalls.Add(1)
 			w.WriteHeader(http.StatusInternalServerError)

--- a/pkg/fuse/mount_layer_test.go
+++ b/pkg/fuse/mount_layer_test.go
@@ -1183,6 +1183,8 @@ func TestLayerSetAttrLargeTruncateUploadsLayerObjectFromShadow(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/layers/layer-1/uploads/initiate":
+			http.NotFound(w, r)
 		case r.Method == http.MethodPost && r.URL.Path == "/v1/layers/layer-1/objects":
 			uploadCalls++
 			if got := r.URL.Query().Get("path"); got != remotePath {


### PR DESCRIPTION
## Summary

- transparently upgrade `Client.UploadFSLayerFile` to the LayerFS direct multipart API introduced by tidbcloud/fs#69
- preserve old-server compatibility by falling back to `/objects` only when initiate returns 404 or 405, before the upload body is consumed
- stream parts directly to presigned S3 URLs, batch presign requests, and abort incomplete sessions without retrying through the legacy write path
- use the server-advertised `inline_threshold` for CLI LayerFS writes, with the historical 50 KB value only when an older server does not advertise one
- keep LayerFS reads on `/objects` and cover cross-host 307 credential stripping

## Correctness boundaries

- failures from initiate other than 404/405 never fall back
- failures after part upload begins trigger best-effort abort and never fall back
- once complete is attempted, ambiguous results are returned to the caller without abort or a second legacy upload
- Drive9 authorization and actor headers are never sent to presigned S3 endpoints
- the public `UploadFSLayerFile` signature is unchanged, so CLI, FUSE, and SDK callers share the same implementation

## Verification

- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/client ./cmd/drive9/cli ./pkg/fuse -count=1`
- `GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint` (`0 issues`)
- `GOCACHE=/tmp/drive9-go-cache make build`
- `git diff --check origin/main...HEAD`

The full `GOCACHE=/tmp/drive9-go-cache make test` run completed but was not clean because five unrelated `internal/migration` timing/filesystem-metadata tests failed: `TestScannerStableReadRejectsTokenChangeWithUnchangedMtime`, `TestScannerRejectsDirectoryMutationAfterEnumeration`, `TestVerifyFullRetriesMoreThanFourSourceChanges`, `TestDualTokenChangeRestartsGraceAndCASConflictRetries`, and `TestDualChangedTokenRemainsPendingAfterUnstableRead`. This PR does not modify `internal/migration`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multipart uploads for filesystem layers, including upload planning, presigned parts, completion, retries, and failure recovery.
  - Large files now use direct multipart uploads when supported, while smaller files use inline uploads based on the server-provided threshold.
  - Added fallback to the legacy upload path when multipart uploads are unavailable.

- **Bug Fixes**
  - Improved handling of expired links, incomplete upload plans, redirects, and upload failures.
  - Presigned requests no longer expose Drive9 credentials.
  - Error responses are safely size-limited.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->