### PR TITLE
feat: add tenant extract config SDK and CLI support

### DIFF
--- a/cmd/drive9/cli/admin.go
+++ b/cmd/drive9/cli/admin.go
@@ -47,6 +47,8 @@ func adminTenant(args []string) error {
 		return adminTenantDelete(args[1:])
 	case "set-quota":
 		return quotaSet(args[1:])
+	case "extract-config":
+		return adminTenantExtractConfig(args[1:])
 	case "pool":
 		return adminTenantPool(args[1:])
 	default:
@@ -736,6 +738,7 @@ commands:
   tenant get --tenant-id ID         show one tenant and quota
   tenant delete --tenant-id ID      delete one tenant
   tenant set-quota --tenant-id ID   set quota for one tenant
+  tenant extract-config <get|set>   get or update media extract config
   pool <command> [flags]            manage the tenant pool
 
 global admin flags:
@@ -780,11 +783,12 @@ commands:
   get --tenant-id ID               show one tenant and quota
   delete --tenant-id ID            delete one tenant
   set-quota --tenant-id ID         set quota for one tenant
+  extract-config <get|set>         get or update media extract config
 
 flags:
   --server URL                     server URL (default: active context server)
   --region-code CODE               TiDBCloud Mode region code; ignored when --server is set
-  --tenant-id ID                   drive9 tenant id for get/delete/set-quota
+  --tenant-id ID                   drive9 tenant id for get/delete/set-quota/extract-config
   --tidbcloud-public-key KEY       TiDB Cloud public key
   --tidbcloud-private-key KEY      TiDB Cloud private key
   --max-storage-size Mi            set-quota: max confirmed+reserved storage size in Mi

--- a/cmd/drive9/cli/admin_extract_config.go
+++ b/cmd/drive9/cli/admin_extract_config.go
@@ -31,25 +31,24 @@ func adminTenantExtractConfig(args []string) error {
 }
 
 type adminTenantExtractConfigFlags struct {
-	serverFlag       string
-	serverGiven      bool
-	regionCodeFlag   string
-	regionCodeGiven  bool
-	tenantID         string
-	tenantIDGiven    bool
-	mediaType        string
-	mediaTypeGiven   bool
-	publicKeyFlag    string
-	publicKeyGiven   bool
-	privateKeyFlag   string
-	privateKeyGiven  bool
-	asJSON           bool
-	enabled          *bool
-	apiBase          *string
-	apiKey           *string
-	model            *string
-	prompt           *string
-	configFieldCount int
+	serverFlag      string
+	serverGiven     bool
+	regionCodeFlag  string
+	regionCodeGiven bool
+	tenantID        string
+	tenantIDGiven   bool
+	mediaType       string
+	mediaTypeGiven  bool
+	publicKeyFlag   string
+	publicKeyGiven  bool
+	privateKeyFlag  string
+	privateKeyGiven bool
+	asJSON          bool
+	enabled         *bool
+	apiBase         *string
+	apiKey          *string
+	model           *string
+	prompt          *string
 }
 
 func parseAdminTenantExtractConfigFlags(args []string, usage string, allowConfig bool) (adminTenantExtractConfigFlags, error) {
@@ -110,7 +109,6 @@ func parseAdminTenantExtractConfigFlags(args []string, usage string, allowConfig
 				return flags, err
 			}
 			flags.enabled, i = &parsed, next
-			flags.configFieldCount++
 		case "--api-base":
 			if !allowConfig {
 				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
@@ -120,7 +118,6 @@ func parseAdminTenantExtractConfigFlags(args []string, usage string, allowConfig
 				return flags, err
 			}
 			flags.apiBase, i = &value, next
-			flags.configFieldCount++
 		case "--api-key":
 			if !allowConfig {
 				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
@@ -130,7 +127,6 @@ func parseAdminTenantExtractConfigFlags(args []string, usage string, allowConfig
 				return flags, err
 			}
 			flags.apiKey, i = &value, next
-			flags.configFieldCount++
 		case "--model":
 			if !allowConfig {
 				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
@@ -140,7 +136,6 @@ func parseAdminTenantExtractConfigFlags(args []string, usage string, allowConfig
 				return flags, err
 			}
 			flags.model, i = &value, next
-			flags.configFieldCount++
 		case "--prompt":
 			if !allowConfig {
 				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
@@ -150,7 +145,6 @@ func parseAdminTenantExtractConfigFlags(args []string, usage string, allowConfig
 				return flags, err
 			}
 			flags.prompt, i = &value, next
-			flags.configFieldCount++
 		default:
 			return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
 		}
@@ -181,7 +175,7 @@ func parseAdminTenantExtractConfigFlags(args []string, usage string, allowConfig
 	}
 	flags.tenantID = strings.TrimSpace(flags.tenantID)
 	flags.mediaType = strings.TrimSpace(flags.mediaType)
-	if allowConfig && flags.configFieldCount == 0 {
+	if allowConfig && flags.enabled == nil && flags.apiBase == nil && flags.apiKey == nil && flags.model == nil && flags.prompt == nil {
 		return flags, fmt.Errorf("at least one extract config field is required")
 	}
 	return flags, nil
@@ -205,17 +199,9 @@ func parseAdminExtractBool(value string) (bool, error) {
 	}
 }
 
-func (f adminTenantExtractConfigFlags) client(server string) *client.Client {
-	return client.New(server, "")
-}
-
-func (f adminTenantExtractConfigFlags) credentials() (string, string) {
-	return adminTiDBCloudKeys(f.publicKeyFlag, f.privateKeyFlag)
-}
-
 func (f adminTenantExtractConfigFlags) requestIdentity() (client.QuotaRequest, error) {
-	publicKey, privateKey := f.credentials()
-	return quotaRequest(strings.TrimSpace(f.tenantID), publicKey, privateKey)
+	publicKey, privateKey := adminTiDBCloudKeys(f.publicKeyFlag, f.privateKeyFlag)
+	return quotaRequest(f.tenantID, publicKey, privateKey)
 }
 
 func (f adminTenantExtractConfigFlags) server() (string, error) {
@@ -239,8 +225,8 @@ func adminTenantExtractConfigGet(args []string) error {
 	if err != nil {
 		return err
 	}
-	out, err := flags.client(server).AdminGetTenantExtractConfig(context.Background(), client.AdminTenantExtractConfigGetRequest{
-		TenantID: identity.TenantID, MediaType: client.ExtractMediaType(strings.TrimSpace(flags.mediaType)), PublicKey: identity.PublicKey, PrivateKey: identity.PrivateKey,
+	out, err := client.New(server, "").AdminGetTenantExtractConfig(context.Background(), client.AdminTenantExtractConfigGetRequest{
+		TenantID: identity.TenantID, MediaType: client.ExtractMediaType(flags.mediaType), PublicKey: identity.PublicKey, PrivateKey: identity.PrivateKey,
 	})
 	if err != nil {
 		return quotaAPIError("get tenant extract config", err)
@@ -264,8 +250,8 @@ func adminTenantExtractConfigSet(args []string) error {
 	if err != nil {
 		return err
 	}
-	out, err := flags.client(server).AdminSetTenantExtractConfig(context.Background(), client.AdminTenantExtractConfigSetRequest{
-		TenantID: identity.TenantID, MediaType: client.ExtractMediaType(strings.TrimSpace(flags.mediaType)), PublicKey: identity.PublicKey, PrivateKey: identity.PrivateKey,
+	out, err := client.New(server, "").AdminSetTenantExtractConfig(context.Background(), client.AdminTenantExtractConfigSetRequest{
+		TenantID: identity.TenantID, MediaType: client.ExtractMediaType(flags.mediaType), PublicKey: identity.PublicKey, PrivateKey: identity.PrivateKey,
 		Enabled: flags.enabled, APIBase: flags.apiBase, APIKey: flags.apiKey, Model: flags.model, Prompt: flags.prompt,
 	})
 	if err != nil {
@@ -278,6 +264,7 @@ func printAdminTenantExtractConfigResponse(out *client.AdminTenantExtractConfig,
 	if out == nil {
 		return fmt.Errorf("tenant extract config response is empty")
 	}
+	out = redactAdminTenantExtractConfig(out)
 	if asJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -287,6 +274,48 @@ func printAdminTenantExtractConfigResponse(out *client.AdminTenantExtractConfig,
 	_, _ = fmt.Fprintln(w, "MEDIA_TYPE\tENABLED\tSOURCE\tAPI_BASE\tAPI_KEY\tMODEL\tPROMPT\tUPDATED_AT")
 	_, _ = fmt.Fprintf(w, "%s\t%t\t%s\t%s\t%s\t%s\t%s\t%s\n", mediaType, out.Enabled, emptyAsDash(out.Source), optionalExtractString(out.APIBase), optionalExtractString(out.APIKey), optionalExtractString(out.Model), optionalExtractString(out.Prompt), optionalExtractTime(out.UpdatedAt))
 	return w.Flush()
+}
+
+func redactAdminTenantExtractConfig(out *client.AdminTenantExtractConfig) *client.AdminTenantExtractConfig {
+	redacted := *out
+	if out.APIKey != nil {
+		apiKey := redactProviderAPIKey(*out.APIKey)
+		redacted.APIKey = &apiKey
+	}
+	return &redacted
+}
+
+func redactProviderAPIKey(apiKey string) string {
+	if apiKey == "" {
+		return apiKey
+	}
+	runes := []rune(apiKey)
+	if isMaskedProviderAPIKey(runes) {
+		return apiKey
+	}
+	if len(runes) <= 4 {
+		return "********"
+	}
+	return string(runes[:4]) + "********"
+}
+
+func isMaskedProviderAPIKey(runes []rune) bool {
+	firstMask := -1
+	for i, r := range runes {
+		if r == '*' {
+			firstMask = i
+			break
+		}
+	}
+	if firstMask < 0 || firstMask > 4 {
+		return false
+	}
+	for _, r := range runes[firstMask:] {
+		if r != '*' {
+			return false
+		}
+	}
+	return true
 }
 
 func optionalExtractString(value *string) string {
@@ -321,9 +350,9 @@ common flags:
 
 set flags:
   --enabled true|false             enable or disable this media type
-  --api-base URL                   provider base URL
-  --api-key KEY                    provider API key (sensitive)
-  --model MODEL                    provider model name
+  --api-base URL                   provider base URL; non-empty when enabling
+  --api-key KEY                    provider API key; non-empty when enabling (sensitive)
+  --model MODEL                    provider model name; non-empty when enabling
   --prompt TEXT                    custom extraction prompt; empty clears the override`
 }
 
@@ -354,9 +383,9 @@ flags:
   --tenant-id ID                   required
   --media-type TYPE                required
   --enabled true|false
-  --api-base URL
-  --api-key KEY                    sensitive
-  --model MODEL
+  --api-base URL                   non-empty when enabling
+  --api-key KEY                    non-empty when enabling (sensitive)
+  --model MODEL                    non-empty when enabling
   --prompt TEXT                    empty clears the custom prompt
   --tidbcloud-public-key KEY
   --tidbcloud-private-key KEY

--- a/cmd/drive9/cli/admin_extract_config.go
+++ b/cmd/drive9/cli/admin_extract_config.go
@@ -1,0 +1,349 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/mem9-ai/drive9/pkg/client"
+)
+
+func adminTenantExtractConfig(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("%s", adminTenantExtractConfigUsage())
+	}
+	switch args[0] {
+	case "-h", "-help", "--help", "help":
+		_, _ = fmt.Fprintln(os.Stdout, adminTenantExtractConfigUsage())
+		return nil
+	case "get":
+		return adminTenantExtractConfigGet(args[1:])
+	case "set":
+		return adminTenantExtractConfigSet(args[1:])
+	default:
+		return fmt.Errorf("unknown admin tenant extract-config command %q\n%s", args[0], adminTenantExtractConfigUsage())
+	}
+}
+
+type adminTenantExtractConfigFlags struct {
+	serverFlag       string
+	serverGiven      bool
+	regionCodeFlag   string
+	regionCodeGiven  bool
+	tenantID         string
+	tenantIDGiven    bool
+	mediaType        string
+	mediaTypeGiven   bool
+	publicKeyFlag    string
+	publicKeyGiven   bool
+	privateKeyFlag   string
+	privateKeyGiven  bool
+	asJSON           bool
+	enabled          *bool
+	apiBase          *string
+	apiKey           *string
+	model            *string
+	prompt           *string
+	configFieldCount int
+}
+
+func parseAdminTenantExtractConfigFlags(args []string, usage string, allowConfig bool) (adminTenantExtractConfigFlags, error) {
+	var flags adminTenantExtractConfigFlags
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-h", "-help", "--help", "help":
+			_, _ = fmt.Fprintln(os.Stdout, usage)
+			return flags, errHelpRequested{}
+		case "--server":
+			value, next, err := nextAdminExtractFlag(args, i, "--server")
+			if err != nil {
+				return flags, err
+			}
+			flags.serverFlag, flags.serverGiven, i = value, true, next
+		case "--region-code":
+			value, next, err := nextAdminExtractFlag(args, i, "--region-code")
+			if err != nil {
+				return flags, err
+			}
+			flags.regionCodeFlag, flags.regionCodeGiven, i = value, true, next
+		case "--tenant-id":
+			value, next, err := nextAdminExtractFlag(args, i, "--tenant-id")
+			if err != nil {
+				return flags, err
+			}
+			flags.tenantID, flags.tenantIDGiven, i = value, true, next
+		case "--media-type":
+			value, next, err := nextAdminExtractFlag(args, i, "--media-type")
+			if err != nil {
+				return flags, err
+			}
+			flags.mediaType, flags.mediaTypeGiven, i = value, true, next
+		case "--tidbcloud-public-key":
+			value, next, err := nextAdminExtractFlag(args, i, "--tidbcloud-public-key")
+			if err != nil {
+				return flags, err
+			}
+			flags.publicKeyFlag, flags.publicKeyGiven, i = value, true, next
+		case "--tidbcloud-private-key":
+			value, next, err := nextAdminExtractFlag(args, i, "--tidbcloud-private-key")
+			if err != nil {
+				return flags, err
+			}
+			flags.privateKeyFlag, flags.privateKeyGiven, i = value, true, next
+		case "--json":
+			flags.asJSON = true
+		case "--enabled":
+			if !allowConfig {
+				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+			}
+			value, next, err := nextAdminExtractFlag(args, i, "--enabled")
+			if err != nil {
+				return flags, err
+			}
+			parsed, err := parseAdminExtractBool(value)
+			if err != nil {
+				return flags, err
+			}
+			flags.enabled, i = &parsed, next
+			flags.configFieldCount++
+		case "--api-base":
+			if !allowConfig {
+				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+			}
+			value, next, err := nextAdminExtractFlag(args, i, "--api-base")
+			if err != nil {
+				return flags, err
+			}
+			flags.apiBase, i = &value, next
+			flags.configFieldCount++
+		case "--api-key":
+			if !allowConfig {
+				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+			}
+			value, next, err := nextAdminExtractFlag(args, i, "--api-key")
+			if err != nil {
+				return flags, err
+			}
+			flags.apiKey, i = &value, next
+			flags.configFieldCount++
+		case "--model":
+			if !allowConfig {
+				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+			}
+			value, next, err := nextAdminExtractFlag(args, i, "--model")
+			if err != nil {
+				return flags, err
+			}
+			flags.model, i = &value, next
+			flags.configFieldCount++
+		case "--prompt":
+			if !allowConfig {
+				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+			}
+			value, next, err := nextAdminExtractFlag(args, i, "--prompt")
+			if err != nil {
+				return flags, err
+			}
+			flags.prompt, i = &value, next
+			flags.configFieldCount++
+		default:
+			return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+		}
+	}
+	if err := rejectEmptyFlag("server", strings.TrimSpace(flags.serverFlag), flags.serverGiven); err != nil {
+		return flags, err
+	}
+	if err := rejectEmptyFlag("region-code", strings.TrimSpace(flags.regionCodeFlag), flags.regionCodeGiven); err != nil {
+		return flags, err
+	}
+	if err := rejectEmptyFlag("tenant-id", strings.TrimSpace(flags.tenantID), flags.tenantIDGiven); err != nil {
+		return flags, err
+	}
+	if err := rejectEmptyFlag("media-type", strings.TrimSpace(flags.mediaType), flags.mediaTypeGiven); err != nil {
+		return flags, err
+	}
+	if err := rejectEmptyFlag("tidbcloud-public-key", strings.TrimSpace(flags.publicKeyFlag), flags.publicKeyGiven); err != nil {
+		return flags, err
+	}
+	if err := rejectEmptyFlag("tidbcloud-private-key", strings.TrimSpace(flags.privateKeyFlag), flags.privateKeyGiven); err != nil {
+		return flags, err
+	}
+	if strings.TrimSpace(flags.tenantID) == "" {
+		return flags, fmt.Errorf("--tenant-id is required")
+	}
+	if strings.TrimSpace(flags.mediaType) == "" {
+		return flags, fmt.Errorf("--media-type is required")
+	}
+	flags.tenantID = strings.TrimSpace(flags.tenantID)
+	flags.mediaType = strings.TrimSpace(flags.mediaType)
+	if allowConfig && flags.configFieldCount == 0 {
+		return flags, fmt.Errorf("at least one extract config field is required")
+	}
+	return flags, nil
+}
+
+func nextAdminExtractFlag(args []string, index int, name string) (string, int, error) {
+	if index+1 >= len(args) {
+		return "", index, fmt.Errorf("%s requires an argument", name)
+	}
+	return args[index+1], index + 1, nil
+}
+
+func parseAdminExtractBool(value string) (bool, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("--enabled must be true or false")
+	}
+}
+
+func (f adminTenantExtractConfigFlags) client(server string) *client.Client {
+	return client.New(server, "")
+}
+
+func (f adminTenantExtractConfigFlags) credentials() (string, string) {
+	return adminTiDBCloudKeys(f.publicKeyFlag, f.privateKeyFlag)
+}
+
+func (f adminTenantExtractConfigFlags) requestIdentity() (client.QuotaRequest, error) {
+	publicKey, privateKey := f.credentials()
+	return quotaRequest(strings.TrimSpace(f.tenantID), publicKey, privateKey)
+}
+
+func (f adminTenantExtractConfigFlags) server() (string, error) {
+	r := ResolveCredentials()
+	return quotaServer(f.serverFlag, f.regionCodeFlag, r.Server, true)
+}
+
+func adminTenantExtractConfigGet(args []string) error {
+	flags, err := parseAdminTenantExtractConfigFlags(args, adminTenantExtractConfigGetUsage(), false)
+	if err != nil {
+		if errors.Is(err, errHelpRequested{}) {
+			return nil
+		}
+		return err
+	}
+	server, err := flags.server()
+	if err != nil {
+		return err
+	}
+	identity, err := flags.requestIdentity()
+	if err != nil {
+		return err
+	}
+	out, err := flags.client(server).AdminGetTenantExtractConfig(context.Background(), client.AdminTenantExtractConfigGetRequest{
+		TenantID: identity.TenantID, MediaType: client.ExtractMediaType(strings.TrimSpace(flags.mediaType)), PublicKey: identity.PublicKey, PrivateKey: identity.PrivateKey,
+	})
+	if err != nil {
+		return quotaAPIError("get tenant extract config", err)
+	}
+	return printAdminTenantExtractConfigResponse(out, flags.mediaType, flags.asJSON)
+}
+
+func adminTenantExtractConfigSet(args []string) error {
+	flags, err := parseAdminTenantExtractConfigFlags(args, adminTenantExtractConfigSetUsage(), true)
+	if err != nil {
+		if errors.Is(err, errHelpRequested{}) {
+			return nil
+		}
+		return err
+	}
+	server, err := flags.server()
+	if err != nil {
+		return err
+	}
+	identity, err := flags.requestIdentity()
+	if err != nil {
+		return err
+	}
+	out, err := flags.client(server).AdminSetTenantExtractConfig(context.Background(), client.AdminTenantExtractConfigSetRequest{
+		TenantID: identity.TenantID, MediaType: client.ExtractMediaType(strings.TrimSpace(flags.mediaType)), PublicKey: identity.PublicKey, PrivateKey: identity.PrivateKey,
+		Enabled: flags.enabled, APIBase: flags.apiBase, APIKey: flags.apiKey, Model: flags.model, Prompt: flags.prompt,
+	})
+	if err != nil {
+		return quotaAPIError("set tenant extract config", err)
+	}
+	return printAdminTenantExtractConfigResponse(out, flags.mediaType, flags.asJSON)
+}
+
+func printAdminTenantExtractConfigResponse(out *client.AdminTenantExtractConfig, mediaType string, asJSON bool) error {
+	if out == nil {
+		return fmt.Errorf("tenant extract config response is empty")
+	}
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "MEDIA_TYPE\tENABLED\tSOURCE\tAPI_BASE\tAPI_KEY\tMODEL\tPROMPT\tUPDATED_AT")
+	_, _ = fmt.Fprintf(w, "%s\t%t\t%s\t%s\t%s\t%s\t%s\t%s\n", mediaType, out.Enabled, emptyAsDash(out.Source), emptyAsDash(out.APIBase), emptyAsDash(out.APIKey), emptyAsDash(out.Model), emptyAsDash(out.Prompt), emptyAsDash(out.UpdatedAt))
+	return w.Flush()
+}
+
+func adminTenantExtractConfigUsage() string {
+	return `usage: drive9 admin tenant extract-config <get|set> [flags]
+
+commands:
+  get [flags]                       show one tenant's extract config
+  set [flags]                       partially update one tenant's extract config
+
+common flags:
+  --server URL                     server URL (default: active context server)
+  --region-code CODE               region code; ignored when --server is set
+  --tenant-id ID                   drive9 tenant id
+  --media-type TYPE                extract media type (image, audio, video, text, or a future type)
+  --tidbcloud-public-key KEY       TiDB Cloud public key
+  --tidbcloud-private-key KEY      TiDB Cloud private key
+  --json                           output result as JSON
+
+set flags:
+  --enabled true|false             enable or disable this media type
+  --api-base URL                   provider base URL
+  --api-key KEY                    provider API key (sensitive)
+  --model MODEL                    provider model name
+  --prompt TEXT                    custom extraction prompt; empty clears the override`
+}
+
+func adminTenantExtractConfigGetUsage() string {
+	return `usage: drive9 admin tenant extract-config get [flags]
+
+show one tenant's effective extract configuration.
+
+flags:
+  --server URL
+  --region-code CODE
+  --tenant-id ID                   required
+  --media-type TYPE                required
+  --tidbcloud-public-key KEY
+  --tidbcloud-private-key KEY
+  --json                           output result as JSON`
+}
+
+func adminTenantExtractConfigSetUsage() string {
+	return `usage: drive9 admin tenant extract-config set [flags]
+
+partially update one tenant's extract configuration. At least one config field
+is required; provider completeness and live validation are performed by the server.
+
+flags:
+  --server URL
+  --region-code CODE
+  --tenant-id ID                   required
+  --media-type TYPE                required
+  --enabled true|false
+  --api-base URL
+  --api-key KEY                    sensitive
+  --model MODEL
+  --prompt TEXT                    empty clears the custom prompt
+  --tidbcloud-public-key KEY
+  --tidbcloud-private-key KEY
+  --json                           output result as JSON`
+}

--- a/cmd/drive9/cli/admin_extract_config.go
+++ b/cmd/drive9/cli/admin_extract_config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	"github.com/mem9-ai/drive9/pkg/client"
 )
@@ -284,8 +285,22 @@ func printAdminTenantExtractConfigResponse(out *client.AdminTenantExtractConfig,
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
 	_, _ = fmt.Fprintln(w, "MEDIA_TYPE\tENABLED\tSOURCE\tAPI_BASE\tAPI_KEY\tMODEL\tPROMPT\tUPDATED_AT")
-	_, _ = fmt.Fprintf(w, "%s\t%t\t%s\t%s\t%s\t%s\t%s\t%s\n", mediaType, out.Enabled, emptyAsDash(out.Source), emptyAsDash(out.APIBase), emptyAsDash(out.APIKey), emptyAsDash(out.Model), emptyAsDash(out.Prompt), emptyAsDash(out.UpdatedAt))
+	_, _ = fmt.Fprintf(w, "%s\t%t\t%s\t%s\t%s\t%s\t%s\t%s\n", mediaType, out.Enabled, emptyAsDash(out.Source), optionalExtractString(out.APIBase), optionalExtractString(out.APIKey), optionalExtractString(out.Model), optionalExtractString(out.Prompt), optionalExtractTime(out.UpdatedAt))
 	return w.Flush()
+}
+
+func optionalExtractString(value *string) string {
+	if value == nil {
+		return "-"
+	}
+	return emptyAsDash(*value)
+}
+
+func optionalExtractTime(value *time.Time) string {
+	if value == nil || value.IsZero() {
+		return "-"
+	}
+	return value.Format(time.RFC3339)
 }
 
 func adminTenantExtractConfigUsage() string {

--- a/cmd/drive9/cli/admin_extract_config_test.go
+++ b/cmd/drive9/cli/admin_extract_config_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/client"
 )
 
 func TestAdminTenantExtractConfigHelp(t *testing.T) {
@@ -34,6 +36,8 @@ func TestAdminTenantExtractConfigHelp(t *testing.T) {
 		"--api-key KEY",
 		"--model MODEL",
 		"--prompt TEXT",
+		"non-empty when enabling",
+		"empty clears",
 	} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("help missing %q:\n%s", want, stdout)
@@ -55,7 +59,7 @@ func TestAdminTenantExtractConfigGetPrintsTableAndHeaders(t *testing.T) {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"enabled":    true,
 			"api_base":   "https://provider.example.com",
-			"api_key":    "prov********",
+			"api_key":    "plain-provider-key",
 			"model":      "audio-model",
 			"prompt":     "extract audio",
 			"source":     "custom",
@@ -77,13 +81,76 @@ func TestAdminTenantExtractConfigGetPrintsTableAndHeaders(t *testing.T) {
 	if err != nil {
 		t.Fatalf("get: %v", err)
 	}
-	for _, want := range []string{"MEDIA_TYPE", "ENABLED", "SOURCE", "API_BASE", "API_KEY", "MODEL", "PROMPT", "UPDATED_AT", "audio", "true", "custom", "prov********"} {
+	if strings.Contains(stdout, "plain-provider-key") {
+		t.Fatal("table output leaked the provider API key")
+	}
+	for _, want := range []string{"MEDIA_TYPE", "ENABLED", "SOURCE", "API_BASE", "API_KEY", "MODEL", "PROMPT", "UPDATED_AT", "audio", "true", "custom", "plai********"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("output missing %q:\n%s", want, stdout)
 		}
 	}
-	if strings.Contains(stdout, "provider-secret") {
-		t.Fatalf("output leaked provider key: %s", stdout)
+}
+
+func TestAdminTenantExtractConfigGetRedactsPlaintextAPIKeyInJSON(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled": true,
+			"api_key": "plain-provider-key",
+			"source":  "custom",
+		})
+	}))
+	defer srv.Close()
+
+	stdout, err := captureStdoutE(t, func() error {
+		return Admin([]string{
+			"tenant", "extract-config", "get",
+			"--server", srv.URL,
+			"--tenant-id", "tenant-1",
+			"--media-type", "future-media",
+			"--tidbcloud-public-key", "public-1",
+			"--tidbcloud-private-key", "private-1",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if strings.Contains(stdout, "plain-provider-key") {
+		t.Fatal("JSON output leaked the provider API key")
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("decode JSON output: %v", err)
+	}
+	if out["api_key"] != "plai********" {
+		t.Fatalf("api_key = %q, want redacted value", out["api_key"])
+	}
+}
+
+func TestRedactAdminTenantExtractConfigCopiesResponseAndKeepsMaskedKey(t *testing.T) {
+	plaintext := "plain-provider-key"
+	original := &client.AdminTenantExtractConfig{APIKey: &plaintext}
+	redacted := redactAdminTenantExtractConfig(original)
+	if original.APIKey == nil || *original.APIKey != "plain-provider-key" {
+		t.Fatal("redaction modified the SDK response")
+	}
+	if redacted == original || redacted.APIKey == original.APIKey || redacted.APIKey == nil || *redacted.APIKey != "plai********" {
+		t.Fatalf("redacted response = %#v", redacted)
+	}
+
+	alreadyMasked := "prov****"
+	masked := redactAdminTenantExtractConfig(&client.AdminTenantExtractConfig{APIKey: &alreadyMasked})
+	if masked.APIKey == nil || *masked.APIKey != alreadyMasked {
+		t.Fatalf("already-masked API key = %q", optionalExtractString(masked.APIKey))
+	}
+
+	embeddedAsterisk := "ab*c-remaining-value"
+	masked = redactAdminTenantExtractConfig(&client.AdminTenantExtractConfig{APIKey: &embeddedAsterisk})
+	if masked.APIKey == nil || *masked.APIKey != "ab*c********" {
+		t.Fatal("an embedded asterisk incorrectly bypassed redaction")
 	}
 }
 
@@ -129,7 +196,7 @@ func TestAdminTenantExtractConfigSetPreservesExplicitFields(t *testing.T) {
 		t.Fatalf("body = %#v, want explicit false and empty prompt", gotBody)
 	}
 	if strings.Contains(stdout, "provider-secret") {
-		t.Fatalf("output leaked provider key: %s", stdout)
+		t.Fatal("output leaked the provider API key")
 	}
 	var out map[string]any
 	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
@@ -223,7 +290,10 @@ func TestAdminTenantExtractConfigSetErrorDoesNotPrintProviderSecret(t *testing.T
 			"--tidbcloud-private-key", "private-1",
 		})
 	})
-	if err == nil || strings.Contains(err.Error(), "provider-secret") || strings.Contains(errOutput, "provider-secret") {
-		t.Fatalf("error/output leaked provider secret: err=%v output=%q", err, errOutput)
+	if err == nil {
+		t.Fatal("set error = nil")
+	}
+	if strings.Contains(err.Error(), "provider-secret") || strings.Contains(errOutput, "provider-secret") {
+		t.Fatal("error or output leaked the provider API key")
 	}
 }

--- a/cmd/drive9/cli/admin_extract_config_test.go
+++ b/cmd/drive9/cli/admin_extract_config_test.go
@@ -1,0 +1,229 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAdminTenantExtractConfigHelp(t *testing.T) {
+	tenantHelp, err := captureStdoutE(t, func() error {
+		return Admin([]string{"tenant", "--help"})
+	})
+	if err != nil {
+		t.Fatalf("tenant help: %v", err)
+	}
+	if !strings.Contains(tenantHelp, "extract-config <get|set>") {
+		t.Fatalf("tenant help missing extract-config command:\n%s", tenantHelp)
+	}
+
+	stdout, err := captureStdoutE(t, func() error {
+		return Admin([]string{"tenant", "extract-config", "--help"})
+	})
+	if err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	for _, want := range []string{
+		"usage: drive9 admin tenant extract-config <get|set>",
+		"--tenant-id ID",
+		"--media-type TYPE",
+		"--api-base URL",
+		"--api-key KEY",
+		"--model MODEL",
+		"--prompt TEXT",
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("help missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestAdminTenantExtractConfigGetPrintsTableAndHeaders(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/admin/tenants/tenant-1/extract-config/audio" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
+			t.Fatalf("missing TiDB Cloud headers")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":    true,
+			"api_base":   "https://provider.example.com",
+			"api_key":    "prov********",
+			"model":      "audio-model",
+			"prompt":     "extract audio",
+			"source":     "custom",
+			"updated_at": "2026-08-21T01:02:03Z",
+		})
+	}))
+	defer srv.Close()
+
+	stdout, err := captureStdoutE(t, func() error {
+		return Admin([]string{
+			"tenant", "extract-config", "get",
+			"--server", srv.URL,
+			"--tenant-id", "tenant-1",
+			"--media-type", "audio",
+			"--tidbcloud-public-key", "public-1",
+			"--tidbcloud-private-key", "private-1",
+		})
+	})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	for _, want := range []string{"MEDIA_TYPE", "ENABLED", "SOURCE", "API_BASE", "API_KEY", "MODEL", "PROMPT", "UPDATED_AT", "audio", "true", "custom", "prov********"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("output missing %q:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "provider-secret") {
+		t.Fatalf("output leaked provider key: %s", stdout)
+	}
+}
+
+func TestAdminTenantExtractConfigSetPreservesExplicitFields(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/admin/tenants/tenant-1/extract-config/image" {
+			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
+			t.Fatalf("missing TiDB Cloud headers")
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled": false,
+			"source":  "custom",
+		})
+	}))
+	defer srv.Close()
+
+	stdout, err := captureStdoutE(t, func() error {
+		return Admin([]string{
+			"tenant", "extract-config", "set",
+			"--server", srv.URL,
+			"--tenant-id", "tenant-1",
+			"--media-type", "image",
+			"--enabled", "false",
+			"--prompt", "",
+			"--tidbcloud-public-key", "public-1",
+			"--tidbcloud-private-key", "private-1",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if gotBody["enabled"] != false || gotBody["prompt"] != "" || len(gotBody) != 2 {
+		t.Fatalf("body = %#v, want explicit false and empty prompt", gotBody)
+	}
+	if strings.Contains(stdout, "provider-secret") {
+		t.Fatalf("output leaked provider key: %s", stdout)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("decode JSON output: %v\n%s", err, stdout)
+	}
+	if out["enabled"] != false || out["source"] != "custom" {
+		t.Fatalf("JSON output = %#v", out)
+	}
+}
+
+func TestAdminTenantExtractConfigSetFullProviderBody(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":  true,
+			"api_base": "https://provider.example.com",
+			"api_key":  "prov********",
+			"model":    "vision-model",
+			"source":   "custom",
+		})
+	}))
+	defer srv.Close()
+
+	_, err := captureStdoutE(t, func() error {
+		return Admin([]string{
+			"tenant", "extract-config", "set",
+			"--server", srv.URL,
+			"--tenant-id", "tenant-1",
+			"--media-type", "image",
+			"--enabled", "true",
+			"--api-base", "https://provider.example.com",
+			"--api-key", "provider-secret",
+			"--model", "vision-model",
+			"--tidbcloud-public-key", "public-1",
+			"--tidbcloud-private-key", "private-1",
+			"--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if gotBody["enabled"] != true || gotBody["api_base"] != "https://provider.example.com" || gotBody["api_key"] != "provider-secret" || gotBody["model"] != "vision-model" || len(gotBody) != 4 {
+		t.Fatalf("body = %#v", gotBody)
+	}
+}
+
+func TestAdminTenantExtractConfigRejectsMissingOrInvalidFlags(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	for _, args := range [][]string{
+		{"tenant", "extract-config", "get", "--server", "https://drive9.example.com", "--media-type", "image"},
+		{"tenant", "extract-config", "get", "--server", "https://drive9.example.com", "--tenant-id", "tenant-1"},
+		{"tenant", "extract-config", "get", "--server", "https://drive9.example.com", "--tenant-id", "tenant-1", "--media-type", "image"},
+		{"tenant", "extract-config", "set", "--server", "https://drive9.example.com", "--tenant-id", "tenant-1", "--media-type", "image", "--enabled", "maybe"},
+		{"tenant", "extract-config", "set", "--server", "https://drive9.example.com", "--tenant-id", "tenant-1", "--media-type", "image"},
+	} {
+		if _, err := captureStdoutE(t, func() error { return Admin(args) }); err == nil {
+			t.Fatalf("Admin(%v) error = nil", args)
+		}
+	}
+}
+
+func TestAdminTenantExtractConfigSetErrorDoesNotPrintProviderSecret(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"provider validation failed"}`)
+	}))
+	defer srv.Close()
+
+	errOutput, err := captureStdoutE(t, func() error {
+		return Admin([]string{
+			"tenant", "extract-config", "set",
+			"--server", srv.URL,
+			"--tenant-id", "tenant-1",
+			"--media-type", "image",
+			"--enabled", "true",
+			"--api-base", "https://provider.example.com",
+			"--api-key", "provider-secret",
+			"--model", "vision-model",
+			"--tidbcloud-public-key", "public-1",
+			"--tidbcloud-private-key", "private-1",
+		})
+	})
+	if err == nil || strings.Contains(err.Error(), "provider-secret") || strings.Contains(errOutput, "provider-secret") {
+		t.Fatalf("error/output leaked provider secret: err=%v output=%q", err, errOutput)
+	}
+}

--- a/cmd/drive9/cli/admin_extract_config_test.go
+++ b/cmd/drive9/cli/admin_extract_config_test.go
@@ -47,10 +47,10 @@ func TestAdminTenantExtractConfigGetPrintsTableAndHeaders(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet || r.URL.Path != "/v1/admin/tenants/tenant-1/extract-config/audio" {
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
-			t.Fatalf("missing TiDB Cloud headers")
+			t.Errorf("missing TiDB Cloud headers")
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"enabled":    true,
@@ -94,13 +94,13 @@ func TestAdminTenantExtractConfigSetPreservesExplicitFields(t *testing.T) {
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut || r.URL.Path != "/v1/admin/tenants/tenant-1/extract-config/image" {
-			t.Fatalf("unexpected request %s %s", r.Method, r.URL.Path)
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
 		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
-			t.Fatalf("missing TiDB Cloud headers")
+			t.Errorf("missing TiDB Cloud headers")
 		}
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			t.Fatalf("decode body: %v", err)
+			t.Errorf("decode body: %v", err)
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"enabled": false,
@@ -147,7 +147,7 @@ func TestAdminTenantExtractConfigSetFullProviderBody(t *testing.T) {
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			t.Fatalf("decode body: %v", err)
+			t.Errorf("decode body: %v", err)
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"enabled":  true,

--- a/examples/go-sdk-cookbook/cookbook_test.go
+++ b/examples/go-sdk-cookbook/cookbook_test.go
@@ -379,6 +379,18 @@ func ExampleClient_quota() {
 		TiDBCloudSpendingLimit: &spendingLimit,
 	})
 
+	enabled := true
+	prompt := "extract structured attributes"
+	_, _ = credentialClient.AdminGetTenantExtractConfig(ctx, drive9.AdminTenantExtractConfigGetRequest{
+		TenantID: tenantID, MediaType: drive9.ExtractMediaTypeImage,
+		PublicKey: tidbCloudPublicKey, PrivateKey: tidbCloudPrivateKey,
+	})
+	_, _ = credentialClient.AdminSetTenantExtractConfig(ctx, drive9.AdminTenantExtractConfigSetRequest{
+		TenantID: tenantID, MediaType: drive9.ExtractMediaTypeImage,
+		PublicKey: tidbCloudPublicKey, PrivateKey: tidbCloudPrivateKey,
+		Enabled: &enabled, Prompt: &prompt,
+	})
+
 	poolSize := 10
 	_, _ = credentialClient.AdminCreateTenantPool(ctx, drive9.AdminTenantPoolRequest{
 		PublicKey:  tidbCloudPublicKey,
@@ -586,6 +598,8 @@ var coveredClientMethods = map[string]bool{
 	"AdminGetTenantPool":                   true,
 	"AdminListTenants":                     true,
 	"AdminSetTenantQuota":                  true,
+	"AdminGetTenantExtractConfig":          true,
+	"AdminSetTenantExtractConfig":          true,
 	"AdminUpdateTenantPool":                true,
 	"AppendJournalEntries":                 true,
 	"AppendStream":                         true,

--- a/pkg/client/admin_extract_config.go
+++ b/pkg/client/admin_extract_config.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 )
 
 // ExtractMediaType identifies the media-specific extraction configuration.
@@ -23,13 +24,13 @@ const (
 // AdminTenantExtractConfig is the effective extraction configuration returned
 // by the admin API. APIKey is masked by the server.
 type AdminTenantExtractConfig struct {
-	Enabled   bool   `json:"enabled"`
-	APIBase   string `json:"api_base,omitempty"`
-	APIKey    string `json:"api_key,omitempty"`
-	Model     string `json:"model,omitempty"`
-	Prompt    string `json:"prompt,omitempty"`
-	Source    string `json:"source"`
-	UpdatedAt string `json:"updated_at,omitempty"`
+	Enabled   bool       `json:"enabled"`
+	APIBase   *string    `json:"api_base,omitempty"`
+	APIKey    *string    `json:"api_key,omitempty"`
+	Model     *string    `json:"model,omitempty"`
+	Prompt    *string    `json:"prompt,omitempty"`
+	Source    string     `json:"source"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
 }
 
 // AdminTenantExtractConfigGetRequest identifies a tenant and media type for
@@ -91,13 +92,15 @@ func (c *Client) AdminSetTenantExtractConfig(ctx context.Context, update AdminTe
 }
 
 func adminTenantExtractConfigPath(tenantID string, mediaType ExtractMediaType) (string, error) {
-	if strings.TrimSpace(tenantID) == "" {
+	tenantID = strings.TrimSpace(tenantID)
+	mediaTypeValue := strings.TrimSpace(string(mediaType))
+	if tenantID == "" {
 		return "", fmt.Errorf("tenant ID is required")
 	}
-	if strings.TrimSpace(string(mediaType)) == "" {
+	if mediaTypeValue == "" {
 		return "", fmt.Errorf("media type is required")
 	}
-	return "/v1/admin/tenants/" + url.PathEscape(tenantID) + "/extract-config/" + url.PathEscape(string(mediaType)), nil
+	return "/v1/admin/tenants/" + url.PathEscape(tenantID) + "/extract-config/" + url.PathEscape(mediaTypeValue), nil
 }
 
 func (c *Client) doAdminTenantExtractConfig(req *http.Request, operation string) (*AdminTenantExtractConfig, error) {

--- a/pkg/client/admin_extract_config.go
+++ b/pkg/client/admin_extract_config.go
@@ -1,0 +1,117 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// ExtractMediaType identifies the media-specific extraction configuration.
+type ExtractMediaType string
+
+const (
+	ExtractMediaTypeImage ExtractMediaType = "image"
+	ExtractMediaTypeAudio ExtractMediaType = "audio"
+	ExtractMediaTypeVideo ExtractMediaType = "video"
+	ExtractMediaTypeText  ExtractMediaType = "text"
+)
+
+// AdminTenantExtractConfig is the effective extraction configuration returned
+// by the admin API. APIKey is masked by the server.
+type AdminTenantExtractConfig struct {
+	Enabled   bool   `json:"enabled"`
+	APIBase   string `json:"api_base,omitempty"`
+	APIKey    string `json:"api_key,omitempty"`
+	Model     string `json:"model,omitempty"`
+	Prompt    string `json:"prompt,omitempty"`
+	Source    string `json:"source"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// AdminTenantExtractConfigGetRequest identifies a tenant and media type for
+// extract-config lookup.
+type AdminTenantExtractConfigGetRequest struct {
+	TenantID   string
+	MediaType  ExtractMediaType
+	PublicKey  string
+	PrivateKey string
+}
+
+// AdminTenantExtractConfigSetRequest updates a tenant extract config. Nil
+// config fields are omitted so partial updates preserve existing values.
+type AdminTenantExtractConfigSetRequest struct {
+	TenantID   string           `json:"-"`
+	MediaType  ExtractMediaType `json:"-"`
+	PublicKey  string           `json:"-"`
+	PrivateKey string           `json:"-"`
+	Enabled    *bool            `json:"enabled,omitempty"`
+	APIBase    *string          `json:"api_base,omitempty"`
+	APIKey     *string          `json:"api_key,omitempty"`
+	Model      *string          `json:"model,omitempty"`
+	Prompt     *string          `json:"prompt,omitempty"`
+}
+
+// AdminGetTenantExtractConfig returns the effective extract configuration for
+// one tenant and media type.
+func (c *Client) AdminGetTenantExtractConfig(ctx context.Context, query AdminTenantExtractConfigGetRequest) (*AdminTenantExtractConfig, error) {
+	path, err := adminTenantExtractConfigPath(query.TenantID, query.MediaType)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create admin tenant extract config get request: %w", err)
+	}
+	setQuotaHeaders(req, query.PublicKey, query.PrivateKey)
+	return c.doAdminTenantExtractConfig(req, "get")
+}
+
+// AdminSetTenantExtractConfig updates the extract configuration for one tenant
+// and media type.
+func (c *Client) AdminSetTenantExtractConfig(ctx context.Context, update AdminTenantExtractConfigSetRequest) (*AdminTenantExtractConfig, error) {
+	path, err := adminTenantExtractConfigPath(update.TenantID, update.MediaType)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(update)
+	if err != nil {
+		return nil, fmt.Errorf("marshal admin tenant extract config set request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+path, bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("create admin tenant extract config set request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	setQuotaHeaders(req, update.PublicKey, update.PrivateKey)
+	return c.doAdminTenantExtractConfig(req, "set")
+}
+
+func adminTenantExtractConfigPath(tenantID string, mediaType ExtractMediaType) (string, error) {
+	if strings.TrimSpace(tenantID) == "" {
+		return "", fmt.Errorf("tenant ID is required")
+	}
+	if strings.TrimSpace(string(mediaType)) == "" {
+		return "", fmt.Errorf("media type is required")
+	}
+	return "/v1/admin/tenants/" + url.PathEscape(tenantID) + "/extract-config/" + url.PathEscape(string(mediaType)), nil
+}
+
+func (c *Client) doAdminTenantExtractConfig(req *http.Request, operation string) (*AdminTenantExtractConfig, error) {
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("admin tenant extract config %s request: %w", operation, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var out AdminTenantExtractConfig
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode admin tenant extract config %s response: %w", operation, err)
+	}
+	return &out, nil
+}

--- a/pkg/client/admin_extract_config.go
+++ b/pkg/client/admin_extract_config.go
@@ -56,6 +56,14 @@ type AdminTenantExtractConfigSetRequest struct {
 	Prompt     *string          `json:"prompt,omitempty"`
 }
 
+type adminTenantExtractConfigSetBody struct {
+	Enabled *bool   `json:"enabled,omitempty"`
+	APIBase *string `json:"api_base,omitempty"`
+	APIKey  *string `json:"api_key,omitempty"`
+	Model   *string `json:"model,omitempty"`
+	Prompt  *string `json:"prompt,omitempty"`
+}
+
 // AdminGetTenantExtractConfig returns the effective extract configuration for
 // one tenant and media type.
 func (c *Client) AdminGetTenantExtractConfig(ctx context.Context, query AdminTenantExtractConfigGetRequest) (*AdminTenantExtractConfig, error) {
@@ -78,7 +86,13 @@ func (c *Client) AdminSetTenantExtractConfig(ctx context.Context, update AdminTe
 	if err != nil {
 		return nil, err
 	}
-	raw, err := json.Marshal(update)
+	raw, err := json.Marshal(adminTenantExtractConfigSetBody{
+		Enabled: update.Enabled,
+		APIBase: update.APIBase,
+		APIKey:  update.APIKey,
+		Model:   update.Model,
+		Prompt:  update.Prompt,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal admin tenant extract config set request: %w", err)
 	}

--- a/pkg/client/admin_extract_config_test.go
+++ b/pkg/client/admin_extract_config_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 )
 
 func TestAdminGetTenantExtractConfigSendsHeadersAndDecodesResponse(t *testing.T) {
@@ -17,7 +18,7 @@ func TestAdminGetTenantExtractConfigSendsHeadersAndDecodesResponse(t *testing.T)
 	var gotPrivateKey string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodGet {
-			t.Fatalf("method = %s, want GET", r.Method)
+			t.Errorf("method = %s, want GET", r.Method)
 		}
 		gotEscapedPath = r.URL.EscapedPath()
 		gotPublicKey = r.Header.Get("X-TiDBCloud-Public-Key")
@@ -35,8 +36,8 @@ func TestAdminGetTenantExtractConfigSendsHeadersAndDecodesResponse(t *testing.T)
 	defer srv.Close()
 
 	out, err := New(srv.URL, "").AdminGetTenantExtractConfig(context.Background(), AdminTenantExtractConfigGetRequest{
-		TenantID:   "tenant/1",
-		MediaType:  ExtractMediaType("future/type"),
+		TenantID:   " tenant/1 ",
+		MediaType:  ExtractMediaType(" future/type "),
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 	})
@@ -49,7 +50,11 @@ func TestAdminGetTenantExtractConfigSendsHeadersAndDecodesResponse(t *testing.T)
 	if gotPublicKey != "public-1" || gotPrivateKey != "private-1" {
 		t.Fatalf("credentials public=%q private=%q", gotPublicKey, gotPrivateKey)
 	}
-	if !out.Enabled || out.Source != "custom" || out.APIBase != "https://provider.example.com" || out.APIKey != "sk-a********" || out.Model != "vision-model" || out.Prompt != "custom prompt" || out.UpdatedAt != "2026-08-21T01:02:03Z" {
+	updatedAt, err := time.Parse(time.RFC3339, "2026-08-21T01:02:03Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.APIBase == nil || *out.APIBase != "https://provider.example.com" || out.APIKey == nil || *out.APIKey != "sk-a********" || out.Model == nil || *out.Model != "vision-model" || out.Prompt == nil || *out.Prompt != "custom prompt" || out.UpdatedAt == nil || !out.UpdatedAt.Equal(updatedAt) || !out.Enabled || out.Source != "custom" {
 		t.Fatalf("response = %#v", out)
 	}
 }
@@ -62,16 +67,16 @@ func TestAdminSetTenantExtractConfigPreservesPartialFieldPresence(t *testing.T) 
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
-			t.Fatalf("method = %s, want PUT", r.Method)
+			t.Errorf("method = %s, want PUT", r.Method)
 		}
 		if r.URL.Path != "/v1/admin/tenants/tenant-1/extract-config/audio" {
-			t.Fatalf("path = %q", r.URL.Path)
+			t.Errorf("path = %q", r.URL.Path)
 		}
 		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
-			t.Fatalf("missing TiDB Cloud credential headers")
+			t.Errorf("missing TiDB Cloud credential headers")
 		}
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
-			t.Fatalf("decode request body: %v", err)
+			t.Errorf("decode request body: %v", err)
 		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"enabled": false,
@@ -113,6 +118,28 @@ func TestAdminTenantExtractConfigRejectsEmptyIdentity(t *testing.T) {
 	}
 	if _, err := c.AdminGetTenantExtractConfig(context.Background(), AdminTenantExtractConfigGetRequest{TenantID: "tenant-1"}); err == nil {
 		t.Fatal("empty media type error = nil")
+	}
+}
+
+func TestAdminTenantExtractConfigPreservesOptionalResponsePresence(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"enabled":false,"api_base":"","prompt":"","source":"none"}`))
+	}))
+	defer srv.Close()
+
+	out, err := New(srv.URL, "").AdminGetTenantExtractConfig(context.Background(), AdminTenantExtractConfigGetRequest{
+		TenantID: "tenant-1", MediaType: ExtractMediaTypeImage,
+	})
+	if err != nil {
+		t.Fatalf("AdminGetTenantExtractConfig: %v", err)
+	}
+	if out.APIBase == nil || *out.APIBase != "" || out.Prompt == nil || *out.Prompt != "" {
+		t.Fatalf("explicit empty values lost: %#v", out)
+	}
+	if out.APIKey != nil || out.Model != nil || out.UpdatedAt != nil {
+		t.Fatalf("absent values decoded as present: %#v", out)
 	}
 }
 

--- a/pkg/client/admin_extract_config_test.go
+++ b/pkg/client/admin_extract_config_test.go
@@ -1,0 +1,136 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAdminGetTenantExtractConfigSendsHeadersAndDecodesResponse(t *testing.T) {
+	t.Parallel()
+
+	var gotEscapedPath string
+	var gotPublicKey string
+	var gotPrivateKey string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Fatalf("method = %s, want GET", r.Method)
+		}
+		gotEscapedPath = r.URL.EscapedPath()
+		gotPublicKey = r.Header.Get("X-TiDBCloud-Public-Key")
+		gotPrivateKey = r.Header.Get("X-TiDBCloud-Private-Key")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":    true,
+			"api_base":   "https://provider.example.com",
+			"api_key":    "sk-a********",
+			"model":      "vision-model",
+			"prompt":     "custom prompt",
+			"source":     "custom",
+			"updated_at": "2026-08-21T01:02:03Z",
+		})
+	}))
+	defer srv.Close()
+
+	out, err := New(srv.URL, "").AdminGetTenantExtractConfig(context.Background(), AdminTenantExtractConfigGetRequest{
+		TenantID:   "tenant/1",
+		MediaType:  ExtractMediaType("future/type"),
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+	})
+	if err != nil {
+		t.Fatalf("AdminGetTenantExtractConfig: %v", err)
+	}
+	if gotEscapedPath != "/v1/admin/tenants/tenant%2F1/extract-config/future%2Ftype" {
+		t.Fatalf("escaped path = %q", gotEscapedPath)
+	}
+	if gotPublicKey != "public-1" || gotPrivateKey != "private-1" {
+		t.Fatalf("credentials public=%q private=%q", gotPublicKey, gotPrivateKey)
+	}
+	if !out.Enabled || out.Source != "custom" || out.APIBase != "https://provider.example.com" || out.APIKey != "sk-a********" || out.Model != "vision-model" || out.Prompt != "custom prompt" || out.UpdatedAt != "2026-08-21T01:02:03Z" {
+		t.Fatalf("response = %#v", out)
+	}
+}
+
+func TestAdminSetTenantExtractConfigPreservesPartialFieldPresence(t *testing.T) {
+	t.Parallel()
+
+	enabled := false
+	prompt := ""
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			t.Fatalf("method = %s, want PUT", r.Method)
+		}
+		if r.URL.Path != "/v1/admin/tenants/tenant-1/extract-config/audio" {
+			t.Fatalf("path = %q", r.URL.Path)
+		}
+		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
+			t.Fatalf("missing TiDB Cloud credential headers")
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Fatalf("decode request body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled": false,
+			"source":  "custom",
+		})
+	}))
+	defer srv.Close()
+
+	out, err := New(srv.URL, "").AdminSetTenantExtractConfig(context.Background(), AdminTenantExtractConfigSetRequest{
+		TenantID:   "tenant-1",
+		MediaType:  ExtractMediaTypeAudio,
+		PublicKey:  "public-1",
+		PrivateKey: "private-1",
+		Enabled:    &enabled,
+		Prompt:     &prompt,
+	})
+	if err != nil {
+		t.Fatalf("AdminSetTenantExtractConfig: %v", err)
+	}
+	if len(gotBody) != 2 || gotBody["enabled"] != false || gotBody["prompt"] != "" {
+		t.Fatalf("request body = %#v, want explicit false and empty prompt only", gotBody)
+	}
+	for _, omitted := range []string{"api_base", "api_key", "model", "tenant_id", "media_type", "public_key", "private_key"} {
+		if _, ok := gotBody[omitted]; ok {
+			t.Fatalf("request body unexpectedly contains %q: %#v", omitted, gotBody)
+		}
+	}
+	if out.Enabled || out.Source != "custom" {
+		t.Fatalf("response = %#v", out)
+	}
+}
+
+func TestAdminTenantExtractConfigRejectsEmptyIdentity(t *testing.T) {
+	t.Parallel()
+
+	c := New("https://drive9.example.com", "")
+	if _, err := c.AdminGetTenantExtractConfig(context.Background(), AdminTenantExtractConfigGetRequest{MediaType: ExtractMediaTypeImage}); err == nil {
+		t.Fatal("empty tenant ID error = nil")
+	}
+	if _, err := c.AdminGetTenantExtractConfig(context.Background(), AdminTenantExtractConfigGetRequest{TenantID: "tenant-1"}); err == nil {
+		t.Fatal("empty media type error = nil")
+	}
+}
+
+func TestAdminGetTenantExtractConfigReturnsStatusError(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"media type is not supported"}`))
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "").AdminGetTenantExtractConfig(context.Background(), AdminTenantExtractConfigGetRequest{
+		TenantID:  "tenant-1",
+		MediaType: ExtractMediaTypeVideo,
+	})
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) || statusErr.StatusCode != http.StatusBadRequest || statusErr.Message != "media type is not supported" {
+		t.Fatalf("error = %#v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- add generic media-type Go SDK methods for tenant extract-config GET and partial PUT
- add `drive9 admin tenant extract-config get|set` with existing TiDB Cloud admin credential and endpoint resolution
- preserve omitted fields, explicit `false`, and explicit empty prompt values while leaving provider validation to the server

## Testing

- `GOCACHE=/tmp/drive9-go-cache go test ./pkg/client ./cmd/drive9/cli -count=1`
- `GOCACHE=/tmp/drive9-go-cache go test ./cmd/drive9 -count=1`
- `GOCACHE=/tmp/drive9-go-cache go build ./cmd/drive9`
- `GOCACHE=/tmp/drive9-go-cache GOLANGCI_LINT_CACHE=/tmp/drive9-golangci-cache make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `admin tenant extract-config` command with `get` and `set` operations.
  * Supports image, audio, video, and text extraction settings.
  * Includes partial updates, credential and server options, validation, and table or JSON output.
  * Added SDK cookbook examples for retrieving and updating extraction settings.

* **Bug Fixes**
  * Improved handling of escaped identifiers, optional fields, timestamps, and API errors.
  * Added safeguards to prevent provider API keys from appearing in output or error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->