### PR TITLE
feat: support EBS subpath migration jobs

### DIFF
--- a/.github/workflows/publish-migration-image.yml
+++ b/.github/workflows/publish-migration-image.yml
@@ -21,14 +21,6 @@ jobs:
       build_time: ${{ steps.metadata.outputs.build_time }}
       trace_tag: ${{ steps.metadata.outputs.trace_tag }}
     steps:
-      - name: Require the main branch
-        shell: bash
-        run: |
-          if [[ "$GITHUB_REF" != "refs/heads/main" ]]; then
-            echo "Migration images may only be published from main" >&2
-            exit 1
-          fi
-
       - name: Resolve image metadata
         id: metadata
         shell: bash
@@ -200,6 +192,7 @@ jobs:
         run: |
           {
             printf '### Published Drive9 Migration image\n\n'
+            printf -- "- Source ref: \`%s\`\n" "$GITHUB_REF_NAME"
             printf -- "- Source commit: \`%s\`\n" "$GITHUB_SHA"
             printf -- "- Tag: \`%s:%s\`\n" "$IMAGE" "$TRACE_TAG"
             printf -- "- Digest: \`%s\`\n" "$DIGEST"

--- a/cmd/drive9-migration/main.go
+++ b/cmd/drive9-migration/main.go
@@ -27,9 +27,9 @@ type dependencies struct {
 	ctx            context.Context
 	getenv         func(string) string
 	credentialRoot string
-	load           func(string, string, string, string, migration.Phase) (*migration.Startup, error)
-	preflight      func(context.Context, *migration.Startup) (migration.PreflightResult, error)
-	start          func(context.Context, *migration.Startup) error
+	load           func(string, string, string, string, migration.Phase) (*migration.RuntimeStartup, error)
+	plan           func(context.Context, *migration.RuntimeStartup) (migration.PlanResult, error)
+	start          func(context.Context, *migration.RuntimeStartup) error
 	control        func(context.Context, controlRequest) error
 }
 
@@ -40,9 +40,9 @@ func main() {
 		ctx:            ctx,
 		getenv:         os.Getenv,
 		credentialRoot: migration.DefaultCredentialRoot,
-		load:           migration.LoadStartup,
-		preflight:      migration.Preflight,
-		start:          migration.RunWorker,
+		load:           migration.LoadRuntimeStartup,
+		plan:           migration.Plan,
+		start:          migration.RunManager,
 		control: func(ctx context.Context, request controlRequest) error {
 			return migration.Control(ctx, migration.DefaultControlSocket, request, os.Stdout)
 		},
@@ -79,10 +79,10 @@ func execute(args []string, stdout, stderr io.Writer, deps dependencies) int {
 			err = deps.control(ctx, request)
 		}
 	case "verify-full", "prepare-drive9-cutover":
-		if len(args) != 1 {
-			err = fmt.Errorf("%s accepts no arguments", args[0])
-		} else {
-			err = deps.control(ctx, controlRequest{Command: args[0]})
+		var request controlRequest
+		request, err = parseJobMutation(args[0], args[1:], stderr)
+		if err == nil {
+			err = deps.control(ctx, request)
 		}
 	default:
 		err = fmt.Errorf("unknown command %q", args[0])
@@ -124,50 +124,65 @@ func executeStartupCommand(ctx context.Context, command string, args []string, s
 	if err != nil {
 		return err
 	}
-	result, err := deps.preflight(ctx, startup)
-	if err != nil {
-		return err
-	}
 	if command == "run" {
 		return deps.start(ctx, startup)
 	}
-	return json.NewEncoder(stdout).Encode(result)
+	result, planErr := deps.plan(ctx, startup)
+	if err := json.NewEncoder(stdout).Encode(result); err != nil {
+		return err
+	}
+	return planErr
 }
 
 func parseStatus(args []string, stderr io.Writer) (controlRequest, error) {
 	flags := flag.NewFlagSet("status", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	output := flags.String("output", "", "output format")
+	jobID := flags.String("job-id", "", "Job ID filter")
 	if err := flags.Parse(args); err != nil {
 		return controlRequest{}, err
 	}
 	if flags.NArg() != 0 || *output != "json" {
 		return controlRequest{}, errors.New("status requires --output json")
 	}
-	return controlRequest{Command: "status", Output: *output}, nil
+	return controlRequest{Command: "status", JobID: *jobID, Output: *output}, nil
 }
 
 func parseDiff(args []string, stderr io.Writer) (controlRequest, error) {
 	flags := flag.NewFlagSet("diff", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	output := flags.String("output", "", "output format")
+	jobID := flags.String("job-id", "", "Job ID")
 	typeFilter := flags.String("type", "", "finding type")
 	limit := flags.Int("limit", 0, "maximum findings; zero is unlimited")
 	if err := flags.Parse(args); err != nil {
 		return controlRequest{}, err
 	}
-	if flags.NArg() != 0 || *output != "jsonl" || *limit < 0 {
-		return controlRequest{}, errors.New("diff requires --output jsonl and a non-negative --limit")
+	if flags.NArg() != 0 || *jobID == "" || *output != "jsonl" || *limit < 0 {
+		return controlRequest{}, errors.New("diff requires --job-id, --output jsonl, and a non-negative --limit")
 	}
-	return controlRequest{Command: "diff", Output: *output, Type: *typeFilter, Limit: *limit}, nil
+	return controlRequest{Command: "diff", JobID: *jobID, Output: *output, Type: *typeFilter, Limit: *limit}, nil
+}
+
+func parseJobMutation(command string, args []string, stderr io.Writer) (controlRequest, error) {
+	flags := flag.NewFlagSet(command, flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	jobID := flags.String("job-id", "", "Job ID")
+	if err := flags.Parse(args); err != nil {
+		return controlRequest{}, err
+	}
+	if flags.NArg() != 0 || *jobID == "" {
+		return controlRequest{}, fmt.Errorf("%s requires --job-id", command)
+	}
+	return controlRequest{Command: command, JobID: *jobID}, nil
 }
 
 func writeUsage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "usage: drive9-migration <plan|run|status|diff|verify-full|prepare-drive9-cutover> [options]")
-	_, _ = fmt.Fprintln(w, "  plan -f <config.yaml>                 validate one local Job and print its non-sensitive mapping")
-	_, _ = fmt.Fprintln(w, "  run -f <config.yaml>                  run one foreground Worker")
-	_, _ = fmt.Fprintln(w, "  status --output json                  print process-local status")
-	_, _ = fmt.Fprintln(w, "  diff --output jsonl [--type T] [--limit N]")
-	_, _ = fmt.Fprintln(w, "  verify-full                           run serialized in-memory full verification")
-	_, _ = fmt.Fprintln(w, "  prepare-drive9-cutover                write the irreversible cutover fence")
+	_, _ = fmt.Fprintln(w, "  plan -f <config.yaml>                 validate all Jobs for one local EBS")
+	_, _ = fmt.Fprintln(w, "  run -f <config.yaml>                  run all Jobs for one local EBS")
+	_, _ = fmt.Fprintln(w, "  status [--job-id ID] --output json    print process-local status")
+	_, _ = fmt.Fprintln(w, "  diff --job-id ID --output jsonl [--type T] [--limit N]")
+	_, _ = fmt.Fprintln(w, "  verify-full --job-id ID               run full verification for one Job")
+	_, _ = fmt.Fprintln(w, "  prepare-drive9-cutover --job-id ID    fence one Job")
 }

--- a/cmd/drive9-migration/main_test.go
+++ b/cmd/drive9-migration/main_test.go
@@ -26,20 +26,20 @@ func testDependencies(t *testing.T) (dependencies, *[]string) {
 			}
 		},
 		credentialRoot: "/secret-root",
-		load: func(configPath, nodeName, phase, secretRoot string, highest migration.Phase) (*migration.Startup, error) {
+		load: func(configPath, nodeName, phase, secretRoot string, highest migration.Phase) (*migration.RuntimeStartup, error) {
 			calls = append(calls, "load:"+configPath+":"+nodeName+":"+phase+":"+secretRoot+":"+string(highest))
-			return &migration.Startup{Job: migration.Job{VolumeID: "vol-001"}, Phase: migration.PhaseSyncing, ConfigHash: "hash"}, nil
+			return &migration.RuntimeStartup{Source: migration.EBSSourceConfig{VolumeID: "vol-001"}, Phase: migration.PhaseSyncing}, nil
 		},
-		preflight: func(context.Context, *migration.Startup) (migration.PreflightResult, error) {
-			calls = append(calls, "preflight")
-			return migration.PreflightResult{VolumeID: "vol-001", RequiredCapabilities: true}, nil
+		plan: func(context.Context, *migration.RuntimeStartup) (migration.PlanResult, error) {
+			calls = append(calls, "plan")
+			return migration.PlanResult{VolumeID: "vol-001"}, nil
 		},
-		start: func(context.Context, *migration.Startup) error {
+		start: func(context.Context, *migration.RuntimeStartup) error {
 			calls = append(calls, "run")
 			return nil
 		},
 		control: func(_ context.Context, request controlRequest) error {
-			calls = append(calls, "control:"+request.Command+":"+request.Output+":"+request.Type)
+			calls = append(calls, "control:"+request.Command+":"+request.JobID+":"+request.Output+":"+request.Type)
 			return nil
 		},
 	}, &calls
@@ -53,10 +53,10 @@ func TestExecuteDispatchesSixCommands(t *testing.T) {
 	}{
 		{name: "plan", args: []string{"plan", "-f", "/config.yaml"}, wantCall: "load:/config.yaml:node-a:SYNCING:/secret-root:"},
 		{name: "run", args: []string{"run", "-f", "/config.yaml"}, wantCall: "run"},
-		{name: "status", args: []string{"status", "--output", "json"}, wantCall: "control:status:json:"},
-		{name: "diff", args: []string{"diff", "--type", "content", "--limit", "10", "--output", "jsonl"}, wantCall: "control:diff:jsonl:content"},
-		{name: "verify", args: []string{"verify-full"}, wantCall: "control:verify-full::"},
-		{name: "cutover", args: []string{"prepare-drive9-cutover"}, wantCall: "control:prepare-drive9-cutover::"},
+		{name: "status", args: []string{"status", "--output", "json"}, wantCall: "control:status::json:"},
+		{name: "diff", args: []string{"diff", "--job-id", "job-a", "--type", "content", "--limit", "10", "--output", "jsonl"}, wantCall: "control:diff:job-a:jsonl:content"},
+		{name: "verify", args: []string{"verify-full", "--job-id", "job-a"}, wantCall: "control:verify-full:job-a::"},
+		{name: "cutover", args: []string{"prepare-drive9-cutover", "--job-id", "job-a"}, wantCall: "control:prepare-drive9-cutover:job-a::"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			deps, calls := testDependencies(t)
@@ -67,8 +67,8 @@ func TestExecuteDispatchesSixCommands(t *testing.T) {
 			if !containsCall(*calls, tc.wantCall) {
 				t.Fatalf("calls=%v, want %q", *calls, tc.wantCall)
 			}
-			if (tc.name == "plan" || tc.name == "run") && !containsCall(*calls, "preflight") {
-				t.Fatalf("calls=%v, startup command skipped preflight", *calls)
+			if tc.name == "plan" && !containsCall(*calls, "plan") {
+				t.Fatalf("calls=%v, plan command skipped planning", *calls)
 			}
 			if strings.Contains(stdout.String(), "secret") {
 				t.Fatalf("stdout leaked secret: %q", stdout.String())
@@ -97,13 +97,15 @@ func TestExecuteExitCodes(t *testing.T) {
 		{name: "unknown command", args: []string{"unknown"}, want: exitFailure},
 		{name: "invalid phase", args: []string{"plan", "-f", "/config.yaml"}, err: migration.ErrInvalidPhase, want: exitIllegalOperation},
 		{name: "configuration", args: []string{"plan", "-f", "/config.yaml"}, err: errors.New("bad config"), want: exitFailure},
-		{name: "illegal action", args: []string{"verify-full"}, err: migration.ErrIllegalAction, want: exitIllegalOperation},
+		{name: "illegal action", args: []string{"verify-full", "--job-id", "job-a"}, err: migration.ErrIllegalAction, want: exitIllegalOperation},
 		{name: "socket unavailable", args: []string{"status", "--output", "json"}, err: migration.ErrControlUnavailable, want: exitControlUnavailable},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			deps, _ := testDependencies(t)
 			if len(tc.args) > 0 && (tc.args[0] == "plan" || tc.args[0] == "run") {
-				deps.load = func(string, string, string, string, migration.Phase) (*migration.Startup, error) { return nil, tc.err }
+				deps.load = func(string, string, string, string, migration.Phase) (*migration.RuntimeStartup, error) {
+					return nil, tc.err
+				}
 			} else if tc.err != nil {
 				deps.control = func(context.Context, controlRequest) error { return tc.err }
 			}
@@ -120,10 +122,10 @@ func TestExecuteRejectsInvalidCommandOptions(t *testing.T) {
 		{"plan"},
 		{"run", "-f", "config", "extra"},
 		{"status", "--output", "yaml"},
-		{"diff", "--output", "json"},
-		{"diff", "--output", "jsonl", "--limit", "-1"},
-		{"verify-full", "extra"},
-		{"prepare-drive9-cutover", "extra"},
+		{"diff", "--job-id", "job-a", "--output", "json"},
+		{"diff", "--job-id", "job-a", "--output", "jsonl", "--limit", "-1"},
+		{"verify-full"},
+		{"prepare-drive9-cutover"},
 	} {
 		if code := execute(args, io.Discard, io.Discard, deps); code != exitFailure {
 			t.Fatalf("args=%v exit=%d", args, code)
@@ -131,23 +133,23 @@ func TestExecuteRejectsInvalidCommandOptions(t *testing.T) {
 	}
 }
 
-func TestExecuteHelpAndPreflightFailure(t *testing.T) {
+func TestExecuteHelpAndPlanFailure(t *testing.T) {
 	deps, _ := testDependencies(t)
 	var output bytes.Buffer
 	if code := execute([]string{"--help"}, &output, io.Discard, deps); code != exitSuccess || !strings.Contains(output.String(), "drive9-migration") {
 		t.Fatalf("help exit=%d output=%q", code, output.String())
 	}
-	deps.preflight = func(context.Context, *migration.Startup) (migration.PreflightResult, error) {
-		return migration.PreflightResult{}, migration.ErrPreflight
+	deps.plan = func(context.Context, *migration.RuntimeStartup) (migration.PlanResult, error) {
+		return migration.PlanResult{VolumeID: "vol-001"}, migration.ErrPlanFailed
 	}
 	if code := execute([]string{"plan", "-f", "/config.yaml"}, io.Discard, io.Discard, deps); code != exitFailure {
-		t.Fatalf("preflight failure exit=%d", code)
+		t.Fatalf("plan failure exit=%d", code)
 	}
-	deps.preflight = func(context.Context, *migration.Startup) (migration.PreflightResult, error) {
-		return migration.PreflightResult{}, errors.Join(migration.ErrPreflight, migration.ErrInvalidPhase)
+	deps.load = func(string, string, string, string, migration.Phase) (*migration.RuntimeStartup, error) {
+		return nil, errors.Join(migration.ErrPreflight, migration.ErrInvalidPhase)
 	}
 	if code := execute([]string{"run", "-f", "/config.yaml"}, io.Discard, io.Discard, deps); code != exitIllegalOperation {
-		t.Fatalf("illegal preflight phase exit=%d", code)
+		t.Fatalf("illegal startup phase exit=%d", code)
 	}
 }
 

--- a/cmd/kubectl-drive9-migration/main_test.go
+++ b/cmd/kubectl-drive9-migration/main_test.go
@@ -105,11 +105,15 @@ func podJSON(namespace, name, batch, phase string) map[string]any {
 
 func statusJSON(t *testing.T, volumeID, phase string, conditions map[string]bool) []byte {
 	t.Helper()
-	body, err := json.Marshal(map[string]any{
+	job := map[string]any{
+		"job_id":            volumeID,
 		"volume_id":         volumeID,
 		"node_name":         "node-a",
+		"ebs_root":          "/ebs",
+		"subpath":           "/data",
 		"space_ref":         "space-a",
 		"prefix":            "/data",
+		"runtime_state":     "RUNNING",
 		"phase":             phase,
 		"startup_phase":     phase,
 		"recovery_complete": true,
@@ -127,6 +131,12 @@ func statusJSON(t *testing.T, volumeID, phase string, conditions map[string]bool
 		"full_verification": map[string]any{"status": "pending"},
 		"fence_intent":      phase == "CUTOVER_READY",
 		"fence_complete":    phase == "CUTOVER_READY",
+	}
+	body, err := json.Marshal(map[string]any{
+		"volume_id": volumeID,
+		"node_name": "node-a",
+		"ebs_root":  "/ebs",
+		"jobs":      []any{job},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/kubectl-drive9-migration/render.go
+++ b/cmd/kubectl-drive9-migration/render.go
@@ -33,14 +33,14 @@ func renderTable(output io.Writer, wide bool, jobs []jobResult, batches []batchS
 	table := tabwriter.NewWriter(output, 0, 4, 2, ' ', 0)
 	showBatch := shouldShowBatch(jobs)
 	if wide {
-		if _, err := fmt.Fprintln(table, "NAMESPACE\tBATCH\tJOB\tPHASE\tSTATUS\tROUND\tFILES\tDIFF\tRETRY\tVERIFY\tNODE\tPOD\tSPACE\tPREFIX\tCAND_MTIME\tCAND_SOURCE_TOKEN_CHANGED\tCAND_NEW_PATH\tCAND_FILTERED\tPENDING\tIN_FLIGHT\tERROR"); err != nil {
+		if _, err := fmt.Fprintln(table, "NAMESPACE\tBATCH\tJOB\tVOLUME\tPHASE\tSTATUS\tROUND\tFILES\tDIFF\tRETRY\tVERIFY\tNODE\tPOD\tSPACE\tPREFIX\tCAND_MTIME\tCAND_SOURCE_TOKEN_CHANGED\tCAND_NEW_PATH\tCAND_FILTERED\tPENDING\tIN_FLIGHT\tERROR"); err != nil {
 			return err
 		}
 		for _, job := range jobs {
 			status := job.parsed
 			candidateMtime, candidateSourceToken, candidateNewPath, candidateFiltered := candidateCounts(status)
-			if _, err := fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-				valueOrDash(job.Namespace), valueOrDash(job.Batch), valueOrDash(job.JobID), valueOrDash(job.Phase),
+			if _, err := fmt.Fprintf(table, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				valueOrDash(job.Namespace), valueOrDash(job.Batch), valueOrDash(job.JobID), valueOrDash(job.VolumeID), valueOrDash(job.Phase),
 				job.DisplayStatus, roundDisplay(status), sourceCount(status), findingCount(status), retryCount(status),
 				verificationDisplay(status), valueOrDash(job.Node), valueOrDash(job.Pod), spaceRef(status), prefix(status),
 				candidateMtime, candidateSourceToken, candidateNewPath, candidateFiltered,

--- a/cmd/kubectl-drive9-migration/render_test.go
+++ b/cmd/kubectl-drive9-migration/render_test.go
@@ -10,8 +10,9 @@ import (
 
 func renderedJob(namespace, batch, pod, volumeID string) jobResult {
 	status := &workerStatus{
-		VolumeID: volumeID, NodeName: "node-a", SpaceRef: "space-a", Prefix: "/data",
-		Phase: "SYNCING", StartupPhase: "SYNCING", SourceCount: 42,
+		JobID: "job-" + volumeID, VolumeID: volumeID, NodeName: "node-a", SpaceRef: "space-a", Prefix: "/data",
+		RuntimeState: "RUNNING",
+		Phase:        "SYNCING", StartupPhase: "SYNCING", SourceCount: 42,
 		Conditions: workerConditions{ReadyForRollout: true},
 		CandidateCounts: workerCandidates{
 			Mtime: 3, SourceTokenChanged: 5, NewPath: 7, Filtered: 11,
@@ -24,7 +25,7 @@ func renderedJob(namespace, batch, pod, volumeID string) jobResult {
 	}
 	return jobResult{
 		Namespace: namespace, Batch: batch, Pod: pod, Node: "node-a", PodPhase: "Running",
-		JobID: volumeID, Phase: "SYNCING", DisplayStatus: "READY_FOR_ROLLOUT",
+		JobID: status.JobID, VolumeID: volumeID, Phase: "SYNCING", DisplayStatus: "READY_FOR_ROLLOUT",
 		Worker: json.RawMessage(`{"volume_id":"` + volumeID + `","future_field":true}`),
 		parsed: status,
 	}

--- a/cmd/kubectl-drive9-migration/status.go
+++ b/cmd/kubectl-drive9-migration/status.go
@@ -25,7 +25,7 @@ func collectStatus(ctx context.Context, opts options, deps dependencies) ([]jobR
 		return nil, nil, false, errors.New("no Drive9 Migration Worker Pods matched the requested scope")
 	}
 
-	jobs := make([]jobResult, len(pods.Items))
+	podJobs := make([][]jobResult, len(pods.Items))
 	execIndexes := make([]int, 0, len(pods.Items))
 	for i := range pods.Items {
 		item := &pods.Items[i]
@@ -33,7 +33,7 @@ func collectStatus(ctx context.Context, opts options, deps dependencies) ([]jobR
 		if batch == "" {
 			batch = missingBatch
 		}
-		jobs[i] = jobResult{
+		base := jobResult{
 			Namespace: item.Metadata.Namespace,
 			Batch:     batch,
 			Pod:       item.Metadata.Name,
@@ -42,20 +42,21 @@ func collectStatus(ctx context.Context, opts options, deps dependencies) ([]jobR
 		}
 		switch {
 		case item.Metadata.Name == "" || item.Metadata.Namespace == "":
-			markCollectionFailure(&jobs[i], "UNAVAILABLE", "Pod identity is incomplete")
+			markCollectionFailure(&base, "UNAVAILABLE", "Pod identity is incomplete")
 		case item.Metadata.DeletionTimestamp != nil:
-			markCollectionFailure(&jobs[i], "TERMINATING", "Pod is terminating")
+			markCollectionFailure(&base, "TERMINATING", "Pod is terminating")
 		case item.Status.Phase != "Running":
 			phase := strings.ToUpper(item.Status.Phase)
 			if phase == "" {
 				phase = "UNKNOWN"
 			}
-			markCollectionFailure(&jobs[i], "POD_"+phase, "Pod phase is "+emptyAsUnknown(item.Status.Phase))
+			markCollectionFailure(&base, "POD_"+phase, "Pod phase is "+emptyAsUnknown(item.Status.Phase))
 		case !hasContainer(*item, workerContainer):
-			markCollectionFailure(&jobs[i], "UNAVAILABLE", "Pod has no drive9-migration container")
+			markCollectionFailure(&base, "UNAVAILABLE", "Pod has no drive9-migration container")
 		default:
 			execIndexes = append(execIndexes, i)
 		}
+		podJobs[i] = []jobResult{base}
 	}
 
 	semaphore := make(chan struct{}, deps.concurrency)
@@ -69,19 +70,24 @@ func collectStatus(ctx context.Context, opts options, deps dependencies) ([]jobR
 			case semaphore <- struct{}{}:
 				defer func() { <-semaphore }()
 			case <-ctx.Done():
-				markCollectionFailure(&jobs[index], "UNAVAILABLE", normalizeMessage(ctx.Err().Error()))
+				markCollectionFailure(&podJobs[index][0], "UNAVAILABLE", normalizeMessage(ctx.Err().Error()))
 				return
 			}
-			queryWorker(ctx, opts, deps, &jobs[index])
+			podJobs[index] = queryWorker(ctx, opts, deps, podJobs[index][0])
 		}()
 	}
 	wait.Wait()
 
+	jobs := make([]jobResult, 0, len(pods.Items))
+	for _, results := range podJobs {
+		jobs = append(jobs, results...)
+	}
 	for i := range jobs {
 		if jobs[i].parsed == nil {
 			continue
 		}
-		jobs[i].JobID = jobs[i].parsed.VolumeID
+		jobs[i].JobID = jobs[i].parsed.JobID
+		jobs[i].VolumeID = jobs[i].parsed.VolumeID
 		jobs[i].Phase = jobs[i].parsed.Phase
 		if jobs[i].Batch == missingBatch {
 			markCollectionFailure(&jobs[i], "UNAVAILABLE", "Pod is missing "+instanceLabel)
@@ -134,63 +140,115 @@ func kubectlGlobalArgs(opts options) []string {
 	return args
 }
 
-func queryWorker(parent context.Context, opts options, deps dependencies, job *jobResult) {
+func queryWorker(parent context.Context, opts options, deps dependencies, base jobResult) []jobResult {
 	ctx, cancel := context.WithTimeout(parent, deps.execTimeout)
 	defer cancel()
-	result := deps.run(ctx, "kubectl", execWorkerArgs(opts, *job)...)
+	result := deps.run(ctx, "kubectl", execWorkerArgs(opts, base)...)
 	if result.err != nil {
-		markCollectionFailure(job, "UNAVAILABLE", commandError(result, ctx.Err()))
-		return
+		markCollectionFailure(&base, "UNAVAILABLE", commandError(result, ctx.Err()))
+		return []jobResult{base}
 	}
-	status, raw, err := decodeWorkerStatus(result.stdout)
+	_, statuses, err := decodeWorkerStatus(result.stdout)
 	if err != nil {
-		markCollectionFailure(job, "UNAVAILABLE", "invalid Worker status: "+err.Error())
-		return
+		markCollectionFailure(&base, "UNAVAILABLE", "invalid Worker status: "+err.Error())
+		return []jobResult{base}
 	}
-	job.parsed = &status
-	job.Worker = raw
+	jobs := make([]jobResult, 0, len(statuses))
+	for i := range statuses {
+		job := base
+		job.parsed = &statuses[i].status
+		job.Worker = statuses[i].raw
+		jobs = append(jobs, job)
+	}
+	return jobs
 }
 
-func decodeWorkerStatus(body []byte) (workerStatus, json.RawMessage, error) {
+type decodedWorkerStatus struct {
+	status workerStatus
+	raw    json.RawMessage
+}
+
+func decodeWorkerStatus(body []byte) (workerStatusEnvelope, []decodedWorkerStatus, error) {
 	trimmed := bytes.TrimSpace(body)
 	var fields map[string]json.RawMessage
 	if err := decodeOneJSON(trimmed, &fields); err != nil {
-		return workerStatus{}, nil, err
+		return workerStatusEnvelope{}, nil, err
 	}
-	for _, name := range []string{"volume_id", "phase", "startup_phase", "conditions", "fence_intent", "fence_complete"} {
+	for _, name := range []string{"volume_id", "node_name", "ebs_root", "jobs"} {
 		if _, ok := fields[name]; !ok {
-			return workerStatus{}, nil, fmt.Errorf("missing %s", name)
+			return workerStatusEnvelope{}, nil, fmt.Errorf("missing %s", name)
+		}
+	}
+	var envelope workerStatusEnvelope
+	if err := json.Unmarshal(trimmed, &envelope); err != nil {
+		return workerStatusEnvelope{}, nil, err
+	}
+	if envelope.VolumeID == "" || envelope.NodeName == "" || envelope.EBSRoot == "" || len(envelope.Jobs) == 0 {
+		return workerStatusEnvelope{}, nil, errors.New("invalid EBS status identity")
+	}
+	decoded := make([]decodedWorkerStatus, 0, len(envelope.Jobs))
+	for _, raw := range envelope.Jobs {
+		status, err := decodeJobStatus(raw)
+		if err != nil {
+			return workerStatusEnvelope{}, nil, err
+		}
+		if status.VolumeID != envelope.VolumeID || status.NodeName != envelope.NodeName {
+			return workerStatusEnvelope{}, nil, fmt.Errorf("job %q EBS identity mismatch", status.JobID)
+		}
+		decoded = append(decoded, decodedWorkerStatus{status: status, raw: append(json.RawMessage(nil), raw...)})
+	}
+	return envelope, decoded, nil
+}
+
+func decodeJobStatus(raw json.RawMessage) (workerStatus, error) {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &fields); err != nil {
+		return workerStatus{}, err
+	}
+	for _, name := range []string{"job_id", "volume_id", "node_name", "runtime_state", "startup_phase"} {
+		if _, ok := fields[name]; !ok {
+			return workerStatus{}, fmt.Errorf("missing Jobs[].%s", name)
+		}
+	}
+	var status workerStatus
+	if err := json.Unmarshal(raw, &status); err != nil {
+		return workerStatus{}, err
+	}
+	if status.JobID == "" || status.VolumeID == "" {
+		return workerStatus{}, errors.New("empty Job identity")
+	}
+	if status.RuntimeState != "INITIALIZING" && status.RuntimeState != "RETRYING" && status.RuntimeState != "RUNNING" && status.RuntimeState != "STOPPED" {
+		return workerStatus{}, fmt.Errorf("invalid runtime_state %q", status.RuntimeState)
+	}
+	if !validPhase(status.StartupPhase) {
+		return workerStatus{}, fmt.Errorf("invalid startup_phase %q", status.StartupPhase)
+	}
+	if status.RuntimeState != "RUNNING" {
+		return status, nil
+	}
+	for _, name := range []string{"phase", "conditions", "fence_intent", "fence_complete"} {
+		if _, ok := fields[name]; !ok {
+			return workerStatus{}, fmt.Errorf("missing Jobs[].%s", name)
 		}
 	}
 	for _, name := range []string{"fence_intent", "fence_complete"} {
-		if err := validateBooleanField(fields, name, name); err != nil {
-			return workerStatus{}, nil, err
+		if err := validateBooleanField(fields, name, "Jobs[]."+name); err != nil {
+			return workerStatus{}, err
 		}
 	}
 	var conditionFields map[string]json.RawMessage
 	if err := json.Unmarshal(fields["conditions"], &conditionFields); err != nil {
-		return workerStatus{}, nil, fmt.Errorf("decode conditions: %w", err)
+		return workerStatus{}, fmt.Errorf("decode conditions: %w", err)
 	}
 	for _, name := range []string{"ready_for_rollout", "current_converged", "attention"} {
-		if err := validateBooleanField(conditionFields, name, "conditions."+name); err != nil {
-			return workerStatus{}, nil, err
+		if err := validateBooleanField(conditionFields, name, "Jobs[].conditions."+name); err != nil {
+			return workerStatus{}, err
 		}
 	}
-	var status workerStatus
-	if err := json.Unmarshal(trimmed, &status); err != nil {
-		return workerStatus{}, nil, err
-	}
-	if status.VolumeID == "" {
-		return workerStatus{}, nil, errors.New("empty volume_id")
-	}
 	if !validPhase(status.Phase) {
-		return workerStatus{}, nil, fmt.Errorf("invalid phase %q", status.Phase)
+		return workerStatus{}, fmt.Errorf("invalid phase %q", status.Phase)
 	}
-	if !validPhase(status.StartupPhase) {
-		return workerStatus{}, nil, fmt.Errorf("invalid startup_phase %q", status.StartupPhase)
-	}
-	raw := append(json.RawMessage(nil), trimmed...)
-	return status, raw, nil
+	return status, nil
 }
 
 func validateBooleanField(fields map[string]json.RawMessage, name, path string) error {
@@ -237,6 +295,10 @@ func hasContainer(item pod, name string) bool {
 
 func deriveJobStatus(status workerStatus) string {
 	switch {
+	case status.RuntimeState == "RETRYING" || status.RuntimeState == "STOPPED":
+		return "ATTENTION"
+	case status.RuntimeState == "INITIALIZING":
+		return "INITIALIZING"
 	case status.Conditions.Attention:
 		return "ATTENTION"
 	case status.Phase == "CUTOVER_READY" && status.FenceComplete:
@@ -310,6 +372,7 @@ func summarizeBatches(jobs []jobResult) []batchSummary {
 
 func deriveBatchStatus(jobs []jobResult) string {
 	phases := make(map[string]struct{})
+	initializing := false
 	for _, job := range jobs {
 		switch job.DisplayStatus {
 		case "UNAVAILABLE", "DUPLICATE", "ATTENTION", "TERMINATING":
@@ -318,7 +381,14 @@ func deriveBatchStatus(jobs []jobResult) string {
 		if strings.HasPrefix(job.DisplayStatus, "POD_") || job.Batch == missingBatch || job.parsed == nil {
 			return "NEEDS_ATTENTION"
 		}
+		if job.DisplayStatus == "INITIALIZING" {
+			initializing = true
+			continue
+		}
 		phases[job.Phase] = struct{}{}
+	}
+	if initializing {
+		return "SYNCING"
 	}
 	if len(phases) != 1 {
 		return "MIXED_PHASE"

--- a/cmd/kubectl-drive9-migration/status.go
+++ b/cmd/kubectl-drive9-migration/status.go
@@ -387,6 +387,9 @@ func deriveBatchStatus(jobs []jobResult) string {
 		}
 		phases[job.Phase] = struct{}{}
 	}
+	if len(phases) > 1 {
+		return "MIXED_PHASE"
+	}
 	if initializing {
 		return "SYNCING"
 	}

--- a/cmd/kubectl-drive9-migration/status_test.go
+++ b/cmd/kubectl-drive9-migration/status_test.go
@@ -140,6 +140,18 @@ func batchJob(pod, phase, display string) jobResult {
 	}
 }
 
+func initializingBatchJob(pod string) jobResult {
+	status := &workerStatus{
+		JobID: "job-" + pod, VolumeID: "vol-" + pod,
+		RuntimeState: "INITIALIZING", StartupPhase: "SYNCING",
+	}
+	return jobResult{
+		Namespace: "migration", Batch: "batch-a", Pod: pod,
+		JobID: status.JobID, VolumeID: status.VolumeID,
+		DisplayStatus: "INITIALIZING", parsed: status,
+	}
+}
+
 func TestDeriveBatchStatus(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -151,6 +163,19 @@ func TestDeriveBatchStatus(t *testing.T) {
 			batchJob("a", "SYNCING", "SYNCING"),
 			batchJob("b", "DUAL_WRITE_REPAIRING", "REPAIRING"),
 		}, want: "MIXED_PHASE"},
+		{name: "initializing preserves mixed phase", jobs: []jobResult{
+			initializingBatchJob("initializing"),
+			batchJob("a", "SYNCING", "SYNCING"),
+			batchJob("b", "DUAL_WRITE_REPAIRING", "REPAIRING"),
+		}, want: "MIXED_PHASE"},
+		{name: "all initializing", jobs: []jobResult{
+			initializingBatchJob("a"),
+			initializingBatchJob("b"),
+		}, want: "SYNCING"},
+		{name: "initializing with one observed phase", jobs: []jobResult{
+			initializingBatchJob("initializing"),
+			batchJob("a", "DUAL_WRITE_REPAIRING", "REPAIRING"),
+		}, want: "SYNCING"},
 		{name: "syncing", jobs: []jobResult{
 			batchJob("a", "SYNCING", "READY_FOR_ROLLOUT"),
 			batchJob("b", "SYNCING", "SYNCING"),

--- a/cmd/kubectl-drive9-migration/status_test.go
+++ b/cmd/kubectl-drive9-migration/status_test.go
@@ -19,7 +19,8 @@ func mutateStatusJSON(t *testing.T, mutate func(map[string]any)) []byte {
 	}), &document); err != nil {
 		t.Fatal(err)
 	}
-	mutate(document)
+	jobs := document["jobs"].([]any)
+	mutate(jobs[0].(map[string]any))
 	body, err := json.Marshal(document)
 	if err != nil {
 		t.Fatal(err)
@@ -31,12 +32,12 @@ func TestDecodeWorkerStatusValidation(t *testing.T) {
 	withFutureField := mutateStatusJSON(t, func(document map[string]any) {
 		document["future_field"] = map[string]any{"kept": true}
 	})
-	status, raw, err := decodeWorkerStatus(withFutureField)
+	envelope, statuses, err := decodeWorkerStatus(withFutureField)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if status.VolumeID != "vol-001" || !strings.Contains(string(raw), "future_field") {
-		t.Fatalf("status=%+v raw=%s", status, raw)
+	if envelope.VolumeID != "vol-001" || len(statuses) != 1 || !strings.Contains(string(statuses[0].raw), "future_field") {
+		t.Fatalf("envelope=%+v statuses=%+v", envelope, statuses)
 	}
 
 	for _, tc := range []struct {
@@ -51,19 +52,19 @@ func TestDecodeWorkerStatusValidation(t *testing.T) {
 		}), []byte("\n{}")...), want: "trailing JSON"},
 		{name: "missing identity", body: mutateStatusJSON(t, func(document map[string]any) {
 			delete(document, "volume_id")
-		}), want: "missing volume_id"},
+		}), want: "missing Jobs[].volume_id"},
 		{name: "empty identity", body: mutateStatusJSON(t, func(document map[string]any) {
 			document["volume_id"] = ""
-		}), want: "empty volume_id"},
+		}), want: "empty Job identity"},
 		{name: "invalid phase", body: mutateStatusJSON(t, func(document map[string]any) {
 			document["phase"] = "UNKNOWN"
 		}), want: "invalid phase"},
 		{name: "missing condition", body: mutateStatusJSON(t, func(document map[string]any) {
 			delete(document["conditions"].(map[string]any), "attention")
-		}), want: "missing conditions.attention"},
+		}), want: "missing Jobs[].conditions.attention"},
 		{name: "missing fence", body: mutateStatusJSON(t, func(document map[string]any) {
 			delete(document, "fence_complete")
-		}), want: "missing fence_complete"},
+		}), want: "missing Jobs[].fence_complete"},
 		{name: "null fence", body: mutateStatusJSON(t, func(document map[string]any) {
 			document["fence_complete"] = nil
 		}), want: "fence_complete must be a boolean"},
@@ -84,13 +85,19 @@ func TestDecodeWorkerStatusValidation(t *testing.T) {
 }
 
 func TestDeriveJobStatus(t *testing.T) {
-	base := workerStatus{Phase: "SYNCING", StartupPhase: "SYNCING"}
+	base := workerStatus{RuntimeState: "RUNNING", Phase: "SYNCING", StartupPhase: "SYNCING"}
 	for _, tc := range []struct {
 		name   string
 		mutate func(*workerStatus)
 		want   string
 	}{
 		{name: "syncing", want: "SYNCING"},
+		{name: "initializing", mutate: func(status *workerStatus) {
+			status.RuntimeState, status.Phase = "INITIALIZING", ""
+		}, want: "INITIALIZING"},
+		{name: "retrying", mutate: func(status *workerStatus) {
+			status.RuntimeState, status.Phase = "RETRYING", ""
+		}, want: "ATTENTION"},
 		{name: "ready for rollout", mutate: func(status *workerStatus) {
 			status.Conditions.ReadyForRollout = true
 		}, want: "READY_FOR_ROLLOUT"},
@@ -126,9 +133,9 @@ func TestDeriveJobStatus(t *testing.T) {
 }
 
 func batchJob(pod, phase, display string) jobResult {
-	status := &workerStatus{VolumeID: "vol-" + pod, Phase: phase, StartupPhase: phase}
+	status := &workerStatus{JobID: "job-" + pod, VolumeID: "vol-" + pod, RuntimeState: "RUNNING", Phase: phase, StartupPhase: phase}
 	return jobResult{
-		Namespace: "migration", Batch: "batch-a", Pod: pod, JobID: status.VolumeID,
+		Namespace: "migration", Batch: "batch-a", Pod: pod, JobID: status.JobID, VolumeID: status.VolumeID,
 		Phase: phase, DisplayStatus: display, parsed: status,
 	}
 }
@@ -186,6 +193,47 @@ func TestSummarizeBatchesCountsCollectionFailuresAsUnavailable(t *testing.T) {
 	summary := summaries[0]
 	if summary.Available != 2 || summary.Attention != 1 || summary.Unavailable != 1 {
 		t.Fatalf("summary=%+v", summary)
+	}
+}
+
+func TestCollectStatusExpandsOnePodIntoMultipleJobs(t *testing.T) {
+	var document map[string]any
+	if err := json.Unmarshal(statusJSON(t, "vol-001", "SYNCING", map[string]bool{
+		"ready_for_rollout": false, "current_converged": false, "attention": false,
+	}), &document); err != nil {
+		t.Fatal(err)
+	}
+	first := document["jobs"].([]any)[0].(map[string]any)
+	first["job_id"], first["subpath"] = "job-a", "/A"
+	body, err := json.Marshal(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var second map[string]any
+	if err := json.Unmarshal(body, &second); err != nil {
+		t.Fatal(err)
+	}
+	second["job_id"], second["subpath"] = "job-b", "/B"
+	document["jobs"] = []any{first, second}
+	status, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fake := &fakeKubectl{
+		podList: podListJSON(t, podJSON("migration", "worker-a", "batch-a", "Running")),
+		statuses: map[string][]byte{
+			"migration/worker-a": status,
+		},
+	}
+	jobs, batches, partial, err := collectStatus(context.Background(), options{}, normalizeDependencies(testDeps(fake)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if partial || len(jobs) != 2 || len(batches) != 1 || batches[0].ObservedJobs != 2 {
+		t.Fatalf("partial=%v jobs=%+v batches=%+v", partial, jobs, batches)
+	}
+	if jobs[0].JobID != "job-a" || jobs[1].JobID != "job-b" || jobs[0].VolumeID != "vol-001" || jobs[0].Pod != jobs[1].Pod {
+		t.Fatalf("expanded jobs=%+v", jobs)
 	}
 }
 

--- a/cmd/kubectl-drive9-migration/types.go
+++ b/cmd/kubectl-drive9-migration/types.go
@@ -48,11 +48,17 @@ type podStatus struct {
 }
 
 type workerStatus struct {
+	JobID            string             `json:"job_id"`
 	VolumeID         string             `json:"volume_id"`
 	NodeName         string             `json:"node_name,omitempty"`
+	EBSRoot          string             `json:"ebs_root,omitempty"`
+	Subpath          string             `json:"subpath,omitempty"`
 	SpaceRef         string             `json:"space_ref,omitempty"`
 	Prefix           string             `json:"prefix,omitempty"`
-	Phase            string             `json:"phase"`
+	RuntimeState     string             `json:"runtime_state"`
+	RuntimeAttempts  int                `json:"runtime_attempts,omitempty"`
+	RuntimeError     string             `json:"runtime_error,omitempty"`
+	Phase            string             `json:"phase,omitempty"`
 	StartupPhase     string             `json:"startup_phase"`
 	RecoveryComplete bool               `json:"recovery_complete"`
 	Round            workerRound        `json:"round"`
@@ -69,6 +75,13 @@ type workerStatus struct {
 	FenceIntent      bool               `json:"fence_intent"`
 	FenceComplete    bool               `json:"fence_complete"`
 	AttentionReason  string             `json:"attention_reason,omitempty"`
+}
+
+type workerStatusEnvelope struct {
+	VolumeID string            `json:"volume_id"`
+	NodeName string            `json:"node_name"`
+	EBSRoot  string            `json:"ebs_root"`
+	Jobs     []json.RawMessage `json:"jobs"`
 }
 
 type workerRound struct {
@@ -109,6 +122,7 @@ type jobResult struct {
 	Node          string          `json:"node,omitempty"`
 	PodPhase      string          `json:"pod_phase,omitempty"`
 	JobID         string          `json:"job_id,omitempty"`
+	VolumeID      string          `json:"volume_id,omitempty"`
 	Phase         string          `json:"phase,omitempty"`
 	DisplayStatus string          `json:"status"`
 	Error         string          `json:"error,omitempty"`

--- a/docs/design/drive9-migration-v1.md
+++ b/docs/design/drive9-migration-v1.md
@@ -131,6 +131,7 @@ Delete/Rename primitive is scope expansion.
 | `INV-14` | Post-T0 verification is one-way coverage: every current EBS path must match Drive9; target-only residue is a warning, not a failure by itself. |
 | `INV-15` | Jobs are independent. Partial batch progress never rolls back a successful Job. |
 | `INV-16` | Migration reuses `pkg/client` transfer, fresh Multipart, filesystem, and CAS code. It never resumes or adopts a prior Multipart session, shells out to `drive9 cp`, or reimplements the upload protocol. |
+| `INV-17` | Before Worker fan-out, every configured credential resolves an authenticated `tenant_id`; target Prefix overlap is evaluated by that actual Tenant/Space identity. |
 
 ## 3. Domain model and target mapping
 
@@ -179,7 +180,8 @@ Prefix rules:
 
 1. Paths MUST use Drive9 absolute, UTF-8, NFC-normalized path semantics.
 2. Backslashes, `.`, and `..` segments are invalid.
-3. Two Jobs in one Space MUST NOT use equal or ancestor/descendant Prefixes.
+3. Two Jobs whose credentials authenticate to one Space MUST NOT use equal or
+   ancestor/descendant Prefixes, even when their `credential_ref` values differ.
 4. If two or more Jobs share a Space, no Job may target `/`.
 5. A first run requires an absent or empty business Target Prefix. A restart
    may continue only when the remote Checkpoint identifies the same Job and
@@ -347,6 +349,8 @@ Configuration rules:
 11. A configured `CUTOVER_READY` request does not directly update
     `highest_phase`. Actual phase remains `DUAL_WRITE_REPAIRING` until durable
     Fence Intent and Fence Complete succeed.
+12. Authenticated target identity does not add a ConfigMap field and is excluded
+    from `config_hash` and Checkpoint v2.
 
 ### 5.4 Credentials
 
@@ -361,7 +365,8 @@ Rules:
 1. The Secret Volume is read-only and MUST NOT use `subPath`, so kubelet can
    update projected files.
 2. The Worker reloads the current Job's key after file change or authentication
-   failure.
+   failure, but publishes the replacement client only when `/v1/status` returns
+   the same process-lifetime `tenant_id`.
 3. A batch Secret may contain multiple keys. Every DaemonSet Pod can
    technically read all mounted keys; V1 accepts this because the Worker is
    trusted.
@@ -383,7 +388,16 @@ Job:
 2. Resolve exactly one EBS Source for `DRIVE9_MIGRATION_NODE_NAME`, then resolve
    every nested Job and reject duplicate Job identity or overlapping subpaths.
 3. Normalize and validate every subpath and Space/Prefix mapping, including
-   cross-Job overlap and the control Prefix carve-out.
+   definite same-credential overlap and the control Prefix carve-out.
+
+Before any Worker fan-out, a read-only batch safety gate authenticates every
+Space referenced by the complete configuration, including Jobs assigned to
+other nodes. It resolves `/v1/status.tenant_id`, groups Jobs by
+`(endpoint, tenant_id)`, and rejects equal or ancestor/descendant Prefixes in
+one actual Tenant/Space. An unresolved credential, missing `tenant_id`, or
+overlap prevents every Worker from starting because the unknown destination
+cannot be proven disjoint. Each selected local Job freezes its accepted
+`tenant_id` only for the process lifetime.
 
 Dynamic probes cover every Job beneath the selected local EBS Source. `plan`
 runs them sequentially; `run` initializes and retries them independently:
@@ -913,6 +927,7 @@ Migration adapter before any Worker task consumes Drive9 APIs.
 | Conditional upload | Preserve Revision 0 create and exact positive-Revision update; no unconditional fallback |
 | Fresh upload | Carry the whole checksum through a new V1/V2 conditional Multipart completion; Migration does not call Resume |
 | Capabilities | Expose bounded Migration-required checksum read/complete capabilities |
+| Target identity | Authenticated `GET /v1/status` returns a stable non-empty `tenant_id`; distinct valid keys for one tenant return the same value |
 | Event endpoint | Owner-authenticated `POST /v1/migration/events` with bounded JSON; Server derives Tenant identity from the authenticated Owner API key |
 | Event storage | One structured log and low-cardinality metrics only; no database table |
 
@@ -920,10 +935,10 @@ Required data capabilities are fail-fast preflight gates. Event availability is
 reported separately and is optional for data correctness.
 
 The external Server repository owns and freezes exact capability names,
-request-model names, payload-size constant, and wire behavior. The current
-CLI/Worker plan owns only the matching `pkg/client` adapter described above.
-It MUST NOT guess names, duplicate Server wire structs in the Worker, or add a
-new Server Wire Contract.
+`tenant_id`, request-model names, payload-size constant, and wire behavior. The
+Server identity prerequisite is tracked by `tidbcloud/fs#104`; this repository
+owns only the matching `pkg/client` adapter and MUST NOT duplicate Server wire
+structs in the Worker.
 
 The event endpoint rejects scoped tokens in production deployments. Production
 requests use tenant authentication, and caller-supplied checksums and Migration
@@ -1096,6 +1111,8 @@ acceptance must prove the following behavior.
 9. Production Server mode validates the configured Owner API key before
    accepting events or caller-supplied checksums. Local/fallback mode is
    test-only and excluded from this production acceptance requirement.
+10. Authenticated status returns a stable non-empty `tenant_id`; missing or
+    malformed identity remains distinguishable from transport and auth errors.
 
 ### 19.2 Migration CLI and Worker
 
@@ -1143,6 +1160,11 @@ acceptance must prove the following behavior.
 22. Keys and file contents are absent from every forbidden sink.
 23. Existing binaries build unchanged; `drive9-migration` builds with
     `CGO_ENABLED=0` for Linux AMD64 and ARM64.
+24. Different credential references resolving to one `tenant_id` reject equal
+    or ancestor/descendant Prefixes before Worker fan-out; disjoint Prefixes in
+    that tenant and identical Prefixes in distinct tenants pass.
+25. Credential refresh cannot atomically swap a client that resolves to another
+    tenant.
 
 No acceptance test may claim strict consistency, No Extras, maximum RPO,
 undetectable-ABA safety, automatic rollback, or cross-Job atomicity.
@@ -1177,9 +1199,10 @@ moves.
 
 The CLI/Worker delivery may modify `pkg/client` only for the Migration Contract
 listed in section 13 and accepted by its Client prerequisite task. It must not
-modify Server or datastore/backend code. Any required new Server Wire Contract
-is a `SERVER_BLOCKER`; do not hide it in the current repository. Do not
-introduce a public Migration SDK or a generalized reconciliation framework.
+modify Server or datastore/backend code. `/v1/status.tenant_id` is the accepted
+external prerequisite tracked by `tidbcloud/fs#104`; any additional Server Wire
+Contract is a `SERVER_BLOCKER`. Do not introduce a public Migration SDK or a
+generalized reconciliation framework.
 
 ## 21. Deployment inputs, not design gaps
 

--- a/docs/design/drive9-migration-v1.md
+++ b/docs/design/drive9-migration-v1.md
@@ -56,14 +56,14 @@ switches to Drive9-only writes.
 | Area | V1 contract |
 | --- | --- |
 | Source | One EBS filesystem already mounted as a local directory on an eligible EKS node |
-| Job | One EBS Source Root to one Drive9 `(Space, Prefix)` |
+| Job | One configured EBS subpath Source Root to one Drive9 `(Space, Prefix)` |
 | Parallelism | Multiple independent Jobs may run concurrently |
 | Target layouts | One EBS per Space, or multiple EBS Jobs in one Space under disjoint Prefixes |
 | Synchronization | Repeated full namespace rounds, incremental convergence, complete deep recovery after restart, and fresh conditional uploads |
 | Handoff | `SYNCING -> DUAL_WRITE_REPAIRING -> CUTOVER_READY` |
 | Verification | EBS-to-Drive9 one-way coverage using whole-file SHA-256 and supported metadata |
 | Runtime control | Startup configuration plus local single-Job Unix socket commands |
-| Deployment assumption | Existing Kubernetes operations manage a DaemonSet; one eligible node, one EBS, one Worker, one Job |
+| Deployment assumption | Existing Kubernetes operations manage a DaemonSet; one eligible node, one EBS, one Worker process, multiple independent Jobs |
 | CSI | Reuse the existing CSI driver and its Secret/`remote-root`/RWX behavior without code changes |
 
 ### 1.2 Explicitly out of scope
@@ -139,8 +139,10 @@ Delete/Rename primitive is scope expansion.
 | Term | Definition |
 | --- | --- |
 | Job | The smallest state, recovery, rate-limit, verification, and fence unit |
-| `job_id` | Stable V1 Job identifier; exactly equal to `volume_id` |
-| `volume_id` | AWS EBS volume ID in `vol-xxxx` form; no separate Job ID is configured |
+| `job_id` | Stable, explicit V1 Job identifier for one EBS subpath mapping |
+| `volume_id` | AWS EBS volume ID in `vol-xxxx` form; multiple Jobs may share it |
+| EBS Root | The mounted EBS directory selected for one Worker process |
+| Subpath | Absolute logical path beneath EBS Root; configured subpaths are disjoint |
 | Source Root | The mounted EBS directory included in the migration |
 | Space | Configuration reference to one Drive9 Tenant filesystem |
 | Prefix | The Job-owned business path inside a Space; not an authorization boundary |
@@ -153,7 +155,7 @@ Delete/Rename primitive is scope expansion.
 
 ### 3.2 Path mapping
 
-For a source entry `sourceRoot/relative/path`:
+For a source entry `ebsRoot/subpath/relative/path`:
 
 ~~~text
 target path = normalize(target Prefix + relative/path)
@@ -222,15 +224,16 @@ Operator-managed Kubernetes
 Runtime boundaries:
 
 1. `drive9-migration run` is a foreground Worker process.
-2. A Worker selects exactly one declared Job using
+2. A Worker process selects exactly one declared EBS Source using
    `DRIVE9_MIGRATION_NODE_NAME`, populated from `spec.nodeName` through the
-   Downward API. `volume_id`, not `node_name`, is the stable Job identity.
+   Downward API, then starts every nested subpath Job. `job_id` is the stable
+   Job identity; `volume_id` groups Jobs by EBS.
 3. The Worker does not call the Kubernetes API and needs no Migration-specific
    RBAC.
 4. The Worker exposes no network listener. Local commands use one mode-0600
    Unix Domain Socket with bounded JSON, deadlines, and serialized mutations.
-5. One Worker owns one Job. Internal small-file, large-file, and Multipart work
-   may be concurrent.
+5. One Worker process owns multiple independent Job Workers. Each Job's internal
+   small-file, large-file, and Multipart work may be concurrent.
 6. V1 has no SQLite, local database, or PVC requirement. Per-round, per-path,
    finding, verification, and upload state lives only in process memory.
 7. The remote Checkpoint contains only immutable identity and non-regressible
@@ -246,22 +249,23 @@ Runtime boundaries:
 ~~~bash
 drive9-migration plan -f /etc/drive9-migration/config.yaml
 drive9-migration run -f /etc/drive9-migration/config.yaml
-drive9-migration status --output json
-drive9-migration diff [--type <type>] [--limit <n>] --output jsonl
-drive9-migration verify-full
-drive9-migration prepare-drive9-cutover
+drive9-migration status [--job-id <id>] --output json
+drive9-migration diff --job-id <id> [--type <type>] [--limit <n>] --output jsonl
+drive9-migration verify-full --job-id <id>
+drive9-migration prepare-drive9-cutover --job-id <id>
 ~~~
 
 | Command | Contract |
 | --- | --- |
-| `plan` | Read-only batch-static validation plus dynamic preflight for the selected local Job; no Drive9 business-data mutation |
-| `run` | Start the foreground Worker for the Job selected on this node |
-| `status` | Query current local Job state and summaries; differences still return success |
+| `plan` | Read-only static validation plus sequential dynamic preflight for every Job in the selected EBS; no Drive9 business-data mutation |
+| `run` | Start one foreground process supervising every Job in the selected EBS |
+| `status` | Query all current local Job states or filter one Job; differences still return success |
 | `diff` | Stream detailed findings as JSONL |
 | `verify-full` | Run one in-memory full verification inside `DUAL_WRITE_REPAIRING`; phase does not change |
 | `prepare-drive9-cutover` | Execute the irreversible per-Job fence protocol |
 
-The four local commands do not accept `job_id` because one Pod contains one Job.
+Job-specific `diff`, `verify-full`, and `prepare-drive9-cutover` require an exact
+`job_id`. `status` accepts an optional Job filter. No mutation-all command exists.
 
 ### 5.2 Exit codes
 
@@ -284,7 +288,7 @@ metadata:
 data:
   phase: SYNCING
   config.yaml: |
-    version: v3
+    version: v4
     drive9:
       endpoint: https://drive9.example.com
     job_defaults:
@@ -297,19 +301,20 @@ data:
     spaces:
       space-001:
         credential_ref: space-001-key
-    jobs:
+    ebs_sources:
       - volume_id: vol-001
         node_name: ip-10-0-1-10
-        source:
-          type: ebs
-          root: /ebs/xxxx
-        target:
-          space_ref: space-001
-          prefix: /
+        root: /ebs/xxxx
+        jobs:
+          - job_id: vol-001-user-a
+            subpath: /A
+            target:
+              space_ref: space-001
+              prefix: /
 ~~~
 
-Shared-Space Jobs use the same schema and distinct Prefixes such as
-`/vol-001` and `/vol-002`.
+Additional Jobs use distinct, non-overlapping EBS subpaths and may target
+different Spaces or disjoint Prefixes in one Space.
 
 Configuration rules:
 
@@ -329,9 +334,9 @@ Configuration rules:
    and is immutable while a Job runs.
 6. `max_bytes_per_second` is the total upload limit for each Job, not each
    internal worker and not the batch.
-7. `config_hash` covers the parsed static Source, Target, endpoint,
-   `space_ref -> credential_ref` mapping, and `job_defaults`. It excludes phase
-   and API-key values.
+7. `config_hash` covers `job_id`, `volume_id`, EBS Root, subpath, parsed static
+   Source/Target, endpoint, `space_ref -> credential_ref` mapping, and
+   `job_defaults`. It excludes node assignment, phase, and API-key values.
 8. A recovered Job whose static configuration or Source/Target identity differs
    from its Checkpoint fails closed.
 9. Repeating the current phase is idempotent. Before fence intent, requesting a
@@ -373,16 +378,15 @@ trusted as a startup authorization.
 Batch-static checks use only configuration and therefore cover every declared
 Job:
 
-1. Strictly decode schema version v3 and reject unknown fields, duplicate IDs,
-   malformed `volume_id` values, unsupported Source types, and per-Job default
-   overrides.
-2. Resolve exactly one Job for `DRIVE9_MIGRATION_NODE_NAME` and reject duplicate
-   active Job identity.
-3. Normalize and validate every Space/Prefix mapping, including cross-Job
-   overlap and the control Prefix carve-out.
+1. Strictly decode schema version v4 and reject v3, unknown fields, duplicate
+   IDs, malformed `volume_id` or `job_id` values, and per-Job default overrides.
+2. Resolve exactly one EBS Source for `DRIVE9_MIGRATION_NODE_NAME`, then resolve
+   every nested Job and reject duplicate Job identity or overlapping subpaths.
+3. Normalize and validate every subpath and Space/Prefix mapping, including
+   cross-Job overlap and the control Prefix carve-out.
 
-Dynamic probes cover only the selected local Job because a Worker cannot access
-another node's EBS:
+Dynamic probes cover every Job beneath the selected local EBS Source. `plan`
+runs them sequentially; `run` initializes and retries them independently:
 
 1. Validate Source Root existence, traversal, and read access.
 2. Verify EBS serial or `/dev/disk/by-id` against `volume_id` when available.
@@ -394,7 +398,8 @@ another node's EBS:
 5. Confirm first-run Target Prefix emptiness or valid same-Job recovery state.
 6. Count source entries and logical bytes and report the observed namespace
    size. `plan` does not retain that inventory after returning.
-7. Emit the selected Job's non-sensitive CSI handoff mapping.
+7. Emit every selected Job's non-sensitive CSI handoff mapping and retain
+   partial plan results.
 
 Batch readiness is external: the Kubernetes operations layer runs this dynamic
 preflight on every eligible node and aggregates the per-Job results.
@@ -846,10 +851,10 @@ Each Job owns one conditionally updated control record beneath:
 /.drive9-migration/jobs/<job-id>/
 ~~~
 
-The Checkpoint contains only:
+The strict checkpoint schema is v2; checkpoint v1 is rejected. It contains only:
 
-1. Stable Job identity and immutable `config_hash`, Source, Target, Space, and
-   Prefix identity.
+1. Stable `job_id`, EBS `volume_id`, EBS Root, subpath, and immutable
+   `config_hash`, Source, Target, Space, and Prefix identity.
 2. Highest applied phase.
 3. Irreversible fence intent.
 4. Complete write fence.
@@ -932,9 +937,11 @@ new token type or Prefix scope is added.
 
 ### 14.1 `status`
 
-`status --output json` returns current facts for one Job:
+`status --output json` returns one EBS envelope containing every configured Job;
+`--job-id` filters it to one item. A Job item includes:
 
-1. Actual phase and startup-configured phase.
+1. Runtime state (`INITIALIZING`, `RETRYING`, `RUNNING`, or `STOPPED`), actual
+   phase when available, and startup-configured phase.
 2. `ReadyForRollout`, `CurrentConverged`, and `Attention` with reasons.
 3. Fence intent and complete-fence state.
 4. Current in-memory `repair_mtime_floor`, startup recovery state, and latest
@@ -950,9 +957,9 @@ contain the full path list.
 
 ### 14.2 `diff`
 
-`diff --output jsonl` streams detailed findings through the local UDS. It is the
-explicit interface for per-path diagnosis. Reads may run concurrently; state
-mutations are serialized.
+`diff --job-id <id> --output jsonl` streams detailed findings through the local
+UDS. It is the explicit interface for per-path diagnosis. Reads may run
+concurrently; state mutations are serialized per Job.
 
 ### 14.3 Post-grace CAS events
 
@@ -986,7 +993,7 @@ volume, node, Pod, tenant, and Space MUST NOT be metric labels.
 
 ## 15. Concurrency, rate, and capacity
 
-1. One Worker process owns one Job.
+1. One Worker process owns one selected EBS and supervises all configured Jobs.
 2. Small-file, large-file, and Multipart workers share one Job-level byte token
    bucket.
 3. `max_bytes_per_second` is the aggregate upload ceiling for that Job.
@@ -1092,8 +1099,9 @@ acceptance must prove the following behavior.
 
 ### 19.2 Migration CLI and Worker
 
-1. Strict config parsing, one-Job node selection, phase-source exclusivity,
-   phase rollback rejection, and Secret rotation are tested.
+1. Strict v4 config parsing, one-EBS node selection, nested Job resolution,
+   phase-source exclusivity, phase rollback rejection, and Secret rotation are
+   tested.
 2. Preflight is read-only and rejects every invalid mapping before Drive9
    business mutation.
 3. EBS fixtures cover all supported and blocked object/metadata cases.
@@ -1128,8 +1136,12 @@ acceptance must prove the following behavior.
     same fence.
 19. Fence failures before and after intent prove the irreversible recovery
     split; no post-intent write is possible.
-20. Keys and file contents are absent from every forbidden sink.
-21. Existing binaries build unchanged; `drive9-migration` builds with
+20. One transiently failing Job retries without cancelling healthy siblings;
+    one permanently stopped Job remains visible in process status.
+21. Job-specific controls require an exact `job_id`, and no mutation-all command
+    is exposed.
+22. Keys and file contents are absent from every forbidden sink.
+23. Existing binaries build unchanged; `drive9-migration` builds with
     `CGO_ENABLED=0` for Linux AMD64 and ARM64.
 
 No acceptance test may claim strict consistency, No Extras, maximum RPO,

--- a/docs/examples/drive9-migration/config.yaml
+++ b/docs/examples/drive9-migration/config.yaml
@@ -1,4 +1,4 @@
-version: v3
+version: v4
 drive9:
   endpoint: https://drive9.example.com
 job_defaults:
@@ -9,32 +9,29 @@ job_defaults:
     small_file_workers: 8
     large_file_workers: 2
 spaces:
-  volume-a:
-    credential_ref: volume-a-owner-key
-  shared:
-    credential_ref: shared-owner-key
-jobs:
+  user-a:
+    credential_ref: user-a-owner-key
+  user-b:
+    credential_ref: user-b-owner-key
+  user-c:
+    credential_ref: user-c-owner-key
+ebs_sources:
   - volume_id: vol-0a
     node_name: migration-node-a
-    source:
-      type: ebs
-      root: /mnt/ebs/vol-0a
-    target:
-      space_ref: volume-a
-      prefix: /
-  - volume_id: vol-0b
-    node_name: migration-node-b
-    source:
-      type: ebs
-      root: /mnt/ebs/vol-0b
-    target:
-      space_ref: shared
-      prefix: /vol-0b
-  - volume_id: vol-0c
-    node_name: migration-node-c
-    source:
-      type: ebs
-      root: /mnt/ebs/vol-0c
-    target:
-      space_ref: shared
-      prefix: /vol-0c
+    root: /mnt/ebs/vol-0a
+    jobs:
+      - job_id: vol-0a-user-a
+        subpath: /A
+        target:
+          space_ref: user-a
+          prefix: /
+      - job_id: vol-0a-user-b
+        subpath: /B
+        target:
+          space_ref: user-b
+          prefix: /
+      - job_id: vol-0a-user-c
+        subpath: /C
+        target:
+          space_ref: user-c
+          prefix: /

--- a/docs/examples/drive9-migration/kubernetes.yaml
+++ b/docs/examples/drive9-migration/kubernetes.yaml
@@ -1,9 +1,7 @@
 # Single-PVC trial manifest. Apply it to the namespace that contains the PVC.
 # Replace the endpoint, volume ID, Node name, PVC name, and Owner API key.
 # Do not commit a real API key.
-# The pinned 3a6d226 image supports the tested T0/T1 trial but predates
-# ConfigMap-driven CUTOVER_READY. Replace both image fields with a published
-# cutover-capable source tag before T2.
+# Replace both image fields with one published v4-capable source tag.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,7 +11,7 @@ data:
   # Patch this value and rollout-restart the DaemonSet for each transition.
   phase: SYNCING
   config.yaml: |
-    version: v3
+    version: v4
     drive9:
       endpoint: https://drive9.example.com
     job_defaults:
@@ -24,17 +22,25 @@ data:
         small_file_workers: 8
         large_file_workers: 2
     spaces:
-      migration-target:
-        credential_ref: owner-api-key
-    jobs:
+      user-a:
+        credential_ref: user-a-owner-api-key
+      user-b:
+        credential_ref: user-b-owner-api-key
+    ebs_sources:
       - volume_id: vol-00000000000000000
         node_name: REPLACE_WITH_KUBERNETES_NODE_NAME
-        source:
-          type: ebs
-          root: /mnt/ebs/source
-        target:
-          space_ref: migration-target
-          prefix: /
+        root: /mnt/ebs/source
+        jobs:
+          - job_id: vol-00000000000000000-user-a
+            subpath: /A
+            target:
+              space_ref: user-a
+              prefix: /
+          - job_id: vol-00000000000000000-user-b
+            subpath: /B
+            target:
+              space_ref: user-b
+              prefix: /
 ---
 apiVersion: v1
 kind: Secret
@@ -42,7 +48,8 @@ metadata:
   name: drive9-migration-credentials
 type: Opaque
 stringData:
-  owner-api-key: REPLACE_WITH_DRIVE9_OWNER_API_KEY
+  user-a-owner-api-key: REPLACE_WITH_USER_A_DRIVE9_OWNER_API_KEY
+  user-b-owner-api-key: REPLACE_WITH_USER_B_DRIVE9_OWNER_API_KEY
 ---
 apiVersion: apps/v1
 kind: DaemonSet
@@ -80,7 +87,7 @@ spec:
           type: RuntimeDefault
       initContainers:
         - name: plan
-          image: ghcr.io/drive9-ai/drive9-migration:3a6d226
+          image: ghcr.io/drive9-ai/drive9-migration:REPLACE_WITH_V4_SOURCE_TAG
           imagePullPolicy: IfNotPresent
           args:
             - plan
@@ -113,7 +120,7 @@ spec:
               readOnly: true
       containers:
         - name: drive9-migration
-          image: ghcr.io/drive9-ai/drive9-migration:3a6d226
+          image: ghcr.io/drive9-ai/drive9-migration:REPLACE_WITH_V4_SOURCE_TAG
           imagePullPolicy: IfNotPresent
           args:
             - run

--- a/docs/guides/drive9-migration-v1-runbook.md
+++ b/docs/guides/drive9-migration-v1-runbook.md
@@ -6,16 +6,19 @@ title: Drive9 Migration V1 Operator Runbook
 
 ## Safety boundary
 
-Drive9 Migration V1 moves one mounted, read-only EBS Source per Job to one
-Drive9 Space/Prefix. It has no rollback or unfence. After T0 it never propagates
-Delete or Rename, so old target paths can remain as non-blocking residue.
+Drive9 Migration V1 moves configured subpaths from one mounted, read-only EBS
+Source into independent Drive9 Space/Prefix Jobs. It has no rollback or unfence.
+After T0 it never propagates Delete or Rename, so old target paths can remain as
+non-blocking residue.
 
 The prominent V1 limits are post-T0 residue, metadata loss, per-Job throttling,
-residual ABA risk, one Source per Job, and no rollback. V1 preserves supported
-path, link, content, and `mode & 0777` semantics. It does not preserve UID/GID,
+residual ABA risk, one subpath Source Root per Job, and no rollback. V1
+preserves supported path, link, content, and `mode & 0777` semantics. It does
+not preserve UID/GID,
 timestamps, xattrs, ACLs, special bits, or sparse layout. Revision reuse after
 delete/recreate retains a residual ABA overwrite risk. Throttling is per Job,
-not batch-wide, and Jobs have no cross-Job transaction.
+not EBS-wide, and Jobs have no cross-Job transaction. With N active Jobs, the
+process may use up to N times the configured per-Job bandwidth and worker count.
 
 ## Public container image
 
@@ -29,11 +32,10 @@ ghcr.io/drive9-ai/drive9-migration:<source-sha7>
 
 The workflow does not publish `latest`. Use the published commit tag directly.
 
-The Kubernetes example remains pinned to `3a6d226` for its tested T0/T1 trial.
-That image predates ConfigMap-driven `CUTOVER_READY`. Before T2, replace both
-image fields with a published source tag that contains ConfigMap-driven cutover;
-otherwise the init container and Worker reject the requested phase. A failed
-rollout is never evidence that T2 completed.
+The Kubernetes example uses `REPLACE_WITH_V4_SOURCE_TAG`. Replace both image
+fields with the same published source tag containing the strict v4 subpath
+contract. A v3 binary rejects the v4 example, and a failed rollout is never
+evidence that T2 completed.
 
 The `mem9-ai/drive9` repository must provide the Actions secrets
 `DRIVE9_AI_GHCR_USERNAME` and `DRIVE9_AI_GHCR_TOKEN`. The token must belong to an
@@ -59,43 +61,52 @@ described below remain required.
 ## Inputs and handoff mapping
 
 Use [the sample configuration](../examples/drive9-migration/config.yaml) as the
-strict `version: v3` shape. Every node name must select exactly one Job. The
+strict `version: v4` shape. Every node name selects exactly one EBS Source, and
+one process runs all Jobs nested beneath that Source. v3 configuration and
+checkpoint v1 are not accepted or converted. The
 credential reference is only a Secret-volume filename; the API key itself must
 exist only in the read-only Secret volume at
 `/var/run/secrets/drive9-migration/<credential_ref>`.
 
-The sample demonstrates both accepted CSI handoff layouts:
+The sample demonstrates one EBS with three customer subpath mappings:
 
-| EBS Source | Drive9 target | Layout |
+| EBS subpath | Drive9 target | Job ID |
 | --- | --- | --- |
-| `/mnt/ebs/vol-0a` | Space `volume-a`, Prefix `/` | One EBS per Space |
-| `/mnt/ebs/vol-0b` | Space `shared`, Prefix `/vol-0b` | Shared Space, disjoint Prefix |
-| `/mnt/ebs/vol-0c` | Space `shared`, Prefix `/vol-0c` | Shared Space, disjoint Prefix |
+| `/mnt/ebs/vol-0a/A` | Space `user-a`, Prefix `/` | `vol-0a-user-a` |
+| `/mnt/ebs/vol-0a/B` | Space `user-b`, Prefix `/` | `vol-0a-user-b` |
+| `/mnt/ebs/vol-0a/C` | Space `user-c`, Prefix `/` | `vol-0a-user-c` |
+
+Subpath names are not copied into target paths. Configured subpaths must be
+disjoint; unconfigured EBS paths are ignored. A subpath root must be a real
+directory on the EBS device. Hardlinks spanning different subpath Jobs become
+independent target files.
 
 Set `DRIVE9_MIGRATION_NODE_NAME` to the local node name. Supply the phase from
 exactly one source: a sibling `phase` file beside `config.yaml`, or the accepted
 `DRIVE9_MIGRATION_PHASE` fallback. Never place a key in config, argv, or an
 environment variable.
 
-Before starting a Job, mount its EBS Source read-only, provision the referenced
-Secret file with mode `0600`, write `SYNCING` to the phase source, and run:
+Before starting the process, mount its EBS Source read-only, provision every
+referenced Secret file with mode `0600`, write `SYNCING` to the phase source,
+and run:
 
 ```text
 drive9-migration plan -f /etc/drive9-migration/config.yaml
 drive9-migration run -f /etc/drive9-migration/config.yaml
 ```
 
-The `plan` JSON is the non-sensitive CSI handoff record: verify `volume_id`,
-`node_name`, `source_root`, `space_ref`, `prefix`, `credential_ref`, source
-identity, limits, target emptiness, and required capabilities. It never returns
-the API key.
+The `plan` JSON is the non-sensitive CSI handoff record: verify `job_id`,
+`volume_id`, `node_name`, `ebs_root`, `subpath`, `source_root`, `space_ref`,
+`prefix`, `credential_ref`, source identity, limits, target emptiness, and
+required capabilities for every Job. It never returns an API key. Plan retains
+all Job results and exits nonzero if any Job fails.
 
 ## Kubernetes single-PVC trial
 
 Use the [single-file Kubernetes manifest](../examples/drive9-migration/kubernetes.yaml)
 for one existing EBS PVC on one Node. Before applying it:
 
-1. Set the Drive9 endpoint and Owner API key for an empty test Space.
+1. Set the Drive9 endpoint and one Owner API key for each empty test Space.
 2. Replace `volume_id` with the EBS PV's `.spec.csi.volumeHandle`.
 3. Set both `node_name` and `kubernetes.io/hostname` to the Node that owns the
    PVC.
@@ -227,7 +238,7 @@ Inspect each Job independently:
 
 ```text
 drive9-migration status --output json
-drive9-migration diff --output jsonl
+drive9-migration diff --job-id <job-id> --output jsonl
 ```
 
 Proceed only when the latest complete round reports `ready_for_rollout=true`,
@@ -271,8 +282,8 @@ T1 is an external customer signal that every business Pod runs the dual-write
 version; it is not a Migration phase. For every Job, invoke:
 
 ```text
-drive9-migration verify-full
-drive9-migration status --output json
+drive9-migration verify-full --job-id <job-id>
+drive9-migration status --job-id <job-id> --output json
 ```
 
 From the Kubernetes Worker, run:
@@ -280,7 +291,7 @@ From the Kubernetes Worker, run:
 ```bash
 kubectl -n "$migration_namespace" exec daemonset/drive9-migration \
   -c drive9-migration -- \
-  /drive9-migration verify-full
+  /drive9-migration verify-full --job-id <job-id>
 kubectl -n "$migration_namespace" exec daemonset/drive9-migration \
   -c drive9-migration -- \
   /drive9-migration status --output json
@@ -331,7 +342,7 @@ an exact unique ID-set match plus completed fencing:
   expected_job_ids_json="$(
     kubectl -n "$migration_namespace" get configmap drive9-migration \
       -o jsonpath='{.data.config\.yaml}' | \
-      yq -o=json '.jobs | map(.volume_id)'
+      yq -o=json '[.ebs_sources[].jobs[].job_id]'
   )"
   kubectl drive9 migration status \
     -n "$migration_namespace" \
@@ -360,8 +371,8 @@ a current passed full verification, a converged latest round, no Attention, and
 no grace, retry, pending, or in-flight repair work:
 
 ```text
-drive9-migration prepare-drive9-cutover
-drive9-migration status --output json
+drive9-migration prepare-drive9-cutover --job-id <job-id>
+drive9-migration status --job-id <job-id> --output json
 ```
 
 The Worker drains in-flight Migration work, persists Fence Intent, completes
@@ -372,7 +383,7 @@ rollback, phase regression, or unfence.
 ## Retained control data
 
 V1 has no automatic cleanup or cleanup command. Keep
-`/.drive9-migration/jobs/<volume_id>/` while fence recovery might be needed.
+`/.drive9-migration/jobs/<job_id>/` while fence recovery might be needed.
 Manual deletion is allowed only after every Job is `CUTOVER_READY`, the
 Migration Worker has been permanently removed or disabled, and recovery data
 is no longer needed. Use approved Drive9 administration tooling and target only

--- a/docs/guides/drive9-migration-v1-runbook.md
+++ b/docs/guides/drive9-migration-v1-runbook.md
@@ -23,14 +23,19 @@ process may use up to N times the configured per-Job bandwidth and worker count.
 ## Public container image
 
 The manually triggered `publish-migration-image.yml` workflow builds Linux
-AMD64 and ARM64 images from `main` and publishes one multi-architecture manifest
-to:
+AMD64 and ARM64 images from the selected repository branch and publishes one
+multi-architecture manifest to:
 
 ```text
 ghcr.io/drive9-ai/drive9-migration:<source-sha7>
 ```
 
-The workflow does not publish `latest`. Use the published commit tag directly.
+The workflow does not publish `latest`. It reports the source ref and commit;
+use the published commit tag directly. Non-main publication is intended for
+explicitly selected development and E2E refs.
+
+Dispatch only a trusted repository ref: the workflow executes that ref's
+workflow and Dockerfile while using a GHCR write credential.
 
 The Kubernetes example uses `REPLACE_WITH_V4_SOURCE_TAG`. Replace both image
 fields with the same published source tag containing the strict v4 subpath

--- a/docs/guides/drive9-migration-v1-runbook.md
+++ b/docs/guides/drive9-migration-v1-runbook.md
@@ -73,6 +73,14 @@ credential reference is only a Secret-volume filename; the API key itself must
 exist only in the read-only Secret volume at
 `/var/run/secrets/drive9-migration/<credential_ref>`.
 
+The ConfigMap does not contain `tenant_id`. At each `plan` and `run` startup,
+Migration authenticates every configured credential against `/v1/status`,
+resolves its actual `tenant_id`, and rejects overlapping Prefixes across
+different credential filenames that reach the same Tenant/Space. Every
+configured credential must resolve before any Worker starts. After that
+batch safety gate succeeds, Job initialization and runtime failures remain per
+Job.
+
 The sample demonstrates one EBS with three customer subpath mappings:
 
 | EBS subpath | Drive9 target | Job ID |
@@ -105,6 +113,11 @@ The `plan` JSON is the non-sensitive CSI handoff record: verify `job_id`,
 `prefix`, `credential_ref`, source identity, limits, target emptiness, and
 required capabilities for every Job. It never returns an API key. Plan retains
 all Job results and exits nonzero if any Job fails.
+
+An older Server that omits `/v1/status.tenant_id` is unsupported for this v4
+multi-Job flow. Credential rotation is accepted only when the replacement key
+returns the same process-lifetime `tenant_id`; a different tenant fails the Job
+closed before the client is swapped.
 
 ## Kubernetes single-PVC trial
 

--- a/docs/plans/2026-08-10-drive9-migration-kubectl-plugin-design.md
+++ b/docs/plans/2026-08-10-drive9-migration-kubectl-plugin-design.md
@@ -29,8 +29,9 @@ batch-aware and does not introduce a Kubernetes or Drive9 control plane.
    a selected namespace, or all namespaces.
 2. Optionally select one migration batch through
    `app.kubernetes.io/instance`.
-3. Query each existing Worker through bounded concurrent `kubectl exec` calls to
-   its existing local `status --output json` command.
+3. Query each existing Worker Pod through bounded concurrent `kubectl exec`
+   calls to its local `status --output json` command and expand the returned EBS
+   envelope into one row per Job.
 4. Render deterministic `table`, `wide`, and aggregate `json` output.
 5. Derive a concise per-Job display status and one observed-status summary per
    `(namespace, batch)`.
@@ -48,7 +49,7 @@ batch-aware and does not introduce a Kubernetes or Drive9 control plane.
 3. Watch mode, TUI, Web UI, history, persistence, alerting, or notifications.
 4. CRDs, Controllers, Operators, Services, network APIs, Kubernetes Conditions,
    or new RBAC resources.
-5. Changes to the Worker status wire contract or the Worker image.
+5. Additional Worker status mutations or Worker-image lifecycle management.
 6. Krew publication or a separate plugin distribution service.
 
 ### 2.3 Accepted completeness boundary
@@ -72,8 +73,8 @@ metadata:
 
 `app.kubernetes.io/instance` is the customer-selected migration batch name.
 The Worker container name is `drive9-migration`. The plugin does not require a
-per-Job label because `volume_id` is returned by the Worker status payload at
-`internal/migration/control.go:79`.
+per-Job label because every nested status item returns explicit `job_id` and
+`volume_id` fields from `internal/migration/control.go`.
 
 The fixed discovery selector is:
 
@@ -117,13 +118,14 @@ kubectl-drive9-migration
   -> validate labels and Kubernetes Pod state
   -> at most 8 concurrent kubectl exec calls
        /drive9-migration status --output json
-  -> validate and parse the Worker payload
+  -> validate and parse the multi-Job EBS Worker payload
+  -> expand one Pod into Job rows
   -> derive per-Job display states and batch summaries
   -> stable sort
   -> render table, wide, or JSON
 ```
 
-Every exec has a 10-second timeout. Commands are executed with argument arrays,
+Every Pod exec has a 10-second timeout. Commands are executed with argument arrays,
 never through a shell. The plugin uses a small injected command function for
 unit tests, following the existing CLI dependency-injection pattern at
 `cmd/drive9-migration/main.go:26`; it does not introduce a general command
@@ -132,7 +134,7 @@ runner interface.
 ## 6. Display-state derivation
 
 Kubernetes availability is evaluated before Worker state. After all responses
-are collected, duplicate `(namespace, batch, volume_id)` results are marked as
+are collected, duplicate `(namespace, batch, job_id)` results are marked as
 ambiguous.
 
 | Display status | Derivation |
@@ -218,7 +220,7 @@ not replace external T1 confirmation.
 ## 11. Acceptance criteria
 
 1. Zero-argument status discovers all correctly labeled Worker Pods in the
-   current kubectl namespace and renders one row per Pod.
+   current kubectl namespace and renders one row per reported Job.
 2. Namespace, all-namespace, batch, context, kubeconfig, and output flags produce
    the exact child kubectl arguments required by this design.
 3. No more than eight exec calls run concurrently, and one hung Pod is cancelled

--- a/examples/go-sdk-cookbook/cookbook_test.go
+++ b/examples/go-sdk-cookbook/cookbook_test.go
@@ -197,6 +197,11 @@ func ExampleClient_migrationContract() {
 	ctx := context.Background()
 	c := drive9.New("https://drive9.example.com", "owner-api-key")
 
+	tenantID, err := c.GetMigrationTenantID(ctx)
+	if err != nil || tenantID == "" {
+		return
+	}
+
 	capabilities, err := c.GetMigrationCapabilities(ctx)
 	if err != nil ||
 		!capabilities.ChecksumRead ||
@@ -798,6 +803,7 @@ var coveredClientMethods = map[string]bool{
 	// Migration V1 client contract.
 	"BatchStatWithOptionsCtx":                               true,
 	"GetMigrationCapabilities":                              true,
+	"GetMigrationTenantID":                                  true,
 	"PostMigrationEvent":                                    true,
 	"WriteStreamConditionalWithChecksum":                    true,
 	"WriteStreamConditionalWithChecksumAndPreCompleteCheck": true,

--- a/internal/migration/checkpoint.go
+++ b/internal/migration/checkpoint.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"path/filepath"
 
 	"github.com/mem9-ai/drive9/pkg/client"
 )
 
 const (
-	CheckpointVersion  = "v1"
+	CheckpointVersion  = "v2"
 	maxCheckpointBytes = 64 << 10
 )
 
@@ -27,6 +28,8 @@ type Checkpoint struct {
 	JobID         string `json:"job_id"`
 	ConfigHash    string `json:"config_hash"`
 	VolumeID      string `json:"volume_id"`
+	EBSRoot       string `json:"ebs_root"`
+	SourceSubpath string `json:"source_subpath"`
 	SourceRoot    string `json:"source_root"`
 	Endpoint      string `json:"endpoint"`
 	SpaceRef      string `json:"space_ref"`
@@ -61,7 +64,7 @@ func NewCheckpointStore(api *client.Client) *CheckpointStore {
 }
 
 func CheckpointPath(jobID string) (string, error) {
-	if !volumeIDPattern.MatchString(jobID) {
+	if err := validateJobID(jobID); err != nil {
 		return "", fmt.Errorf("invalid checkpoint job ID")
 	}
 	return ControlPrefix + "/jobs/" + jobID + "/checkpoint.json", nil
@@ -69,8 +72,9 @@ func CheckpointPath(jobID string) (string, error) {
 
 func checkpointFromStartup(startup *Startup) Checkpoint {
 	return Checkpoint{
-		Version: CheckpointVersion, JobID: startup.Job.VolumeID,
+		Version: CheckpointVersion, JobID: startup.Job.JobID,
 		ConfigHash: startup.ConfigHash, VolumeID: startup.Job.VolumeID,
+		EBSRoot: startup.Job.EBSRoot, SourceSubpath: startup.Job.Subpath,
 		SourceRoot: startup.Job.Source.Root, Endpoint: startup.Config.Drive9.Endpoint,
 		SpaceRef: startup.Job.Target.SpaceRef, Prefix: startup.Job.Target.Prefix,
 		CredentialRef: startup.Space.CredentialRef, HighestPhase: startup.Phase,
@@ -143,8 +147,11 @@ func decodeCheckpoint(body []byte) (Checkpoint, error) {
 }
 
 func validateCheckpoint(checkpoint Checkpoint) error {
-	if checkpoint.Version != CheckpointVersion || !volumeIDPattern.MatchString(checkpoint.JobID) || checkpoint.JobID != checkpoint.VolumeID || checkpoint.ConfigHash == "" || checkpoint.SourceRoot == "" || checkpoint.Endpoint == "" || checkpoint.SpaceRef == "" || checkpoint.Prefix == "" || checkpoint.CredentialRef == "" {
+	if checkpoint.Version != CheckpointVersion || validateJobID(checkpoint.JobID) != nil || !volumeIDPattern.MatchString(checkpoint.VolumeID) || checkpoint.ConfigHash == "" || checkpoint.EBSRoot == "" || checkpoint.SourceSubpath == "" || checkpoint.SourceRoot == "" || checkpoint.Endpoint == "" || checkpoint.SpaceRef == "" || checkpoint.Prefix == "" || checkpoint.CredentialRef == "" {
 		return fmt.Errorf("%w: incomplete immutable identity", ErrCheckpointMismatch)
+	}
+	if validateSourceSubpath(checkpoint.SourceSubpath) != nil || !filepath.IsAbs(checkpoint.EBSRoot) || filepath.Clean(checkpoint.EBSRoot) != checkpoint.EBSRoot || checkpoint.SourceRoot != effectiveSourceRoot(checkpoint.EBSRoot, checkpoint.SourceSubpath) {
+		return fmt.Errorf("%w: invalid source identity", ErrCheckpointMismatch)
 	}
 	if phaseRank(checkpoint.HighestPhase) == 0 || (checkpoint.FenceIntent && phaseRank(checkpoint.HighestPhase) < phaseRank(PhaseDualWriteRepairing)) || (checkpoint.HighestPhase == PhaseCutoverReady && !checkpoint.FenceComplete) || (checkpoint.FenceComplete && (!checkpoint.FenceIntent || checkpoint.HighestPhase != PhaseCutoverReady)) {
 		return fmt.Errorf("%w: invalid phase or fence state", ErrCheckpointMismatch)
@@ -153,7 +160,7 @@ func validateCheckpoint(checkpoint Checkpoint) error {
 }
 
 func sameCheckpointIdentity(left, right Checkpoint) bool {
-	return left.Version == right.Version && left.JobID == right.JobID && left.ConfigHash == right.ConfigHash && left.VolumeID == right.VolumeID && left.SourceRoot == right.SourceRoot && left.Endpoint == right.Endpoint && left.SpaceRef == right.SpaceRef && left.Prefix == right.Prefix && left.CredentialRef == right.CredentialRef
+	return left.Version == right.Version && left.JobID == right.JobID && left.ConfigHash == right.ConfigHash && left.VolumeID == right.VolumeID && left.EBSRoot == right.EBSRoot && left.SourceSubpath == right.SourceSubpath && left.SourceRoot == right.SourceRoot && left.Endpoint == right.Endpoint && left.SpaceRef == right.SpaceRef && left.Prefix == right.Prefix && left.CredentialRef == right.CredentialRef
 }
 
 func validateCheckpointTransition(current, next Checkpoint, creating bool) error {

--- a/internal/migration/checkpoint_test.go
+++ b/internal/migration/checkpoint_test.go
@@ -20,6 +20,7 @@ import (
 
 type checkpointFake struct {
 	mu             sync.Mutex
+	jobID          string
 	revision       int64
 	body           []byte
 	failCAS        bool
@@ -40,7 +41,11 @@ func (f *checkpointFake) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		return
 	}
-	if r.URL.Path != "/v1/fs/.drive9-migration/jobs/vol-001/checkpoint.json" {
+	jobID := f.jobID
+	if jobID == "" {
+		jobID = "vol-001"
+	}
+	if r.URL.Path != "/v1/fs/.drive9-migration/jobs/"+jobID+"/checkpoint.json" {
 		if r.Method == http.MethodHead && f.dirConflict {
 			w.Header().Set("X-Dat9-IsDir", strconv.FormatBool(f.dirIsDir))
 			w.Header().Set("X-Dat9-Revision", "1")
@@ -88,14 +93,15 @@ func (f *checkpointFake) serveHTTP(w http.ResponseWriter, r *http.Request) {
 
 func newCheckpointFixture(t *testing.T) (*CheckpointStore, *checkpointFake, *Startup) {
 	t.Helper()
-	fake := &checkpointFake{}
+	fake := &checkpointFake{jobID: "vol-001-user-a"}
 	server := httptest.NewServer(http.HandlerFunc(fake.serveHTTP))
 	t.Cleanup(server.Close)
 	startup := &Startup{
 		Config: &Config{Drive9: Drive9Config{Endpoint: server.URL}},
 		Job: Job{
-			VolumeID: "vol-001", NodeName: "node-a",
-			Source: SourceConfig{Type: "ebs", Root: "/ebs/001"},
+			JobID: "vol-001-user-a", VolumeID: "vol-001", NodeName: "node-a",
+			EBSRoot: "/ebs/001", Subpath: "/A",
+			Source: SourceConfig{Type: "ebs", Root: "/ebs/001/A"},
 			Target: TargetConfig{SpaceRef: "space-001", Prefix: "/data"},
 		},
 		Space: SpaceConfig{CredentialRef: "space-001-key"}, Phase: PhaseSyncing, ConfigHash: "config-hash",
@@ -281,9 +287,9 @@ func TestCheckpointRejectsForbiddenTransitionAndCorruptPayload(t *testing.T) {
 		t.Fatalf("complete-without-intent error=%v", err)
 	}
 	fake.mu.Lock()
-	fake.body = []byte(`{"version":"v1","job_id":"vol-001","unknown":true}`)
+	fake.body = []byte(`{"version":"v1","job_id":"vol-001-user-a","unknown":true}`)
 	fake.mu.Unlock()
-	if _, err := store.Load(context.Background(), "vol-001"); err == nil {
+	if _, err := store.Load(context.Background(), "vol-001-user-a"); err == nil {
 		t.Fatal("unknown checkpoint field accepted")
 	}
 }
@@ -302,7 +308,7 @@ func TestCheckpointStrictPathDecodeAndShapeValidation(t *testing.T) {
 		t.Fatalf("trailing error=%v", err)
 	}
 	for _, mutate := range []func(*Checkpoint){
-		func(value *Checkpoint) { value.Version = "v2" },
+		func(value *Checkpoint) { value.Version = "v1" },
 		func(value *Checkpoint) { value.ConfigHash = "" },
 		func(value *Checkpoint) { value.HighestPhase = "UNKNOWN" },
 		func(value *Checkpoint) { value.FenceIntent = true },
@@ -353,7 +359,7 @@ func TestCheckpointLoadRejectsUnstableAndOversizedReads(t *testing.T) {
 			}))
 			defer server.Close()
 			store := NewCheckpointStore(driveclient.New(server.URL, ""))
-			if _, err := store.Load(context.Background(), "vol-001"); !errors.Is(err, tc.want) {
+			if _, err := store.Load(context.Background(), "vol-001-user-a"); !errors.Is(err, tc.want) {
 				t.Fatalf("load error=%v, want %v", err, tc.want)
 			}
 			if got := reads.Load(); got != tc.wantReads {

--- a/internal/migration/config.go
+++ b/internal/migration/config.go
@@ -1,4 +1,4 @@
-// Package migration implements the single-Job Drive9 Migration V1 worker.
+// Package migration implements Drive9 Migration V1 EBS subpath workers.
 package migration
 
 import (
@@ -16,11 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mem9-ai/drive9/pkg/pathutil"
 	"gopkg.in/yaml.v3"
 )
 
 const (
-	ConfigVersion               = "v3"
+	ConfigVersion               = "v4"
 	DefaultGracePeriod          = time.Minute
 	DefaultCredentialRoot       = "/var/run/secrets/drive9-migration"
 	MigrationNodeNameEnv        = "DRIVE9_MIGRATION_NODE_NAME"
@@ -33,6 +34,7 @@ const (
 var (
 	volumeIDPattern      = regexp.MustCompile(`^vol-[0-9a-f]+$`)
 	credentialRefPattern = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]*$`)
+	jobIDPattern         = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$`)
 	// ErrInvalidPhase classifies illegal, ambiguous, or regressive startup phases.
 	ErrInvalidPhase = errors.New("invalid migration phase")
 	// ErrIllegalAction classifies a phase-incompatible control operation.
@@ -88,24 +90,43 @@ type TargetConfig struct {
 	Prefix   string `yaml:"prefix" json:"prefix"`
 }
 
-// Job is one stable EBS volume to Drive9 Space/Prefix mapping.
-type Job struct {
-	VolumeID string       `yaml:"volume_id" json:"volume_id"`
-	NodeName string       `yaml:"node_name" json:"node_name"`
-	Source   SourceConfig `yaml:"source" json:"source"`
-	Target   TargetConfig `yaml:"target" json:"target"`
+// JobConfig is one configured EBS subpath to Drive9 target mapping.
+type JobConfig struct {
+	JobID   string       `yaml:"job_id" json:"job_id"`
+	Subpath string       `yaml:"subpath" json:"subpath"`
+	Target  TargetConfig `yaml:"target" json:"target"`
 }
 
-// Config is the strict version-v3 static startup configuration.
+// EBSSourceConfig groups all independent Jobs beneath one mounted EBS root.
+type EBSSourceConfig struct {
+	VolumeID string      `yaml:"volume_id" json:"volume_id"`
+	NodeName string      `yaml:"node_name" json:"node_name"`
+	Root     string      `yaml:"root" json:"root"`
+	Jobs     []JobConfig `yaml:"jobs" json:"jobs"`
+}
+
+// Job is one resolved EBS subpath to Drive9 Space/Prefix mapping.
+type Job struct {
+	JobID    string       `json:"job_id"`
+	VolumeID string       `json:"volume_id"`
+	NodeName string       `json:"node_name"`
+	EBSRoot  string       `json:"ebs_root"`
+	Subpath  string       `json:"subpath"`
+	Source   SourceConfig `json:"source"`
+	Target   TargetConfig `json:"target"`
+}
+
+// Config is the strict version-v4 static startup configuration.
 type Config struct {
 	Version     string                 `yaml:"version" json:"version"`
 	Drive9      Drive9Config           `yaml:"drive9" json:"drive9"`
 	JobDefaults JobDefaults            `yaml:"job_defaults" json:"job_defaults"`
 	Spaces      map[string]SpaceConfig `yaml:"spaces" json:"spaces"`
-	Jobs        []Job                  `yaml:"jobs" json:"jobs"`
+	EBSSources  []EBSSourceConfig      `yaml:"ebs_sources" json:"ebs_sources"`
+	Jobs        []Job                  `yaml:"-" json:"-"`
 }
 
-// LoadConfig decodes exactly one bounded YAML document and validates V3 fields.
+// LoadConfig decodes exactly one bounded YAML document and validates V4 fields.
 func LoadConfig(configPath string) (*Config, error) {
 	file, err := os.Open(configPath)
 	if err != nil {
@@ -159,8 +180,8 @@ func (c *Config) validate() error {
 	if performance.MaxBytesPerSecond <= 0 || performance.SmallFileWorkers <= 0 || performance.LargeFileWorkers <= 0 {
 		return fmt.Errorf("job performance limits and worker counts must be positive")
 	}
-	if len(c.Spaces) == 0 || len(c.Jobs) == 0 {
-		return fmt.Errorf("config must declare at least one Space and Job")
+	if len(c.Spaces) == 0 || len(c.EBSSources) == 0 {
+		return fmt.Errorf("config must declare at least one Space and EBS source")
 	}
 	for name, space := range c.Spaces {
 		if name == "" {
@@ -170,51 +191,124 @@ func (c *Config) validate() error {
 			return fmt.Errorf("space %q: %w", name, err)
 		}
 	}
-	seenVolumes := make(map[string]struct{}, len(c.Jobs))
-	for i := range c.Jobs {
-		job := &c.Jobs[i]
-		if !volumeIDPattern.MatchString(job.VolumeID) {
-			return fmt.Errorf("job %d has invalid volume_id", i)
+	seenVolumes := make(map[string]struct{}, len(c.EBSSources))
+	seenNodes := make(map[string]struct{}, len(c.EBSSources))
+	seenJobs := make(map[string]struct{})
+	resolved := make([]Job, 0)
+	for sourceIndex := range c.EBSSources {
+		source := &c.EBSSources[sourceIndex]
+		if !volumeIDPattern.MatchString(source.VolumeID) {
+			return fmt.Errorf("EBS source %d has invalid volume_id", sourceIndex)
 		}
-		if _, exists := seenVolumes[job.VolumeID]; exists {
-			return fmt.Errorf("duplicate volume_id %q", job.VolumeID)
+		if _, exists := seenVolumes[source.VolumeID]; exists {
+			return fmt.Errorf("duplicate volume_id %q", source.VolumeID)
 		}
-		seenVolumes[job.VolumeID] = struct{}{}
-		if job.NodeName == "" {
-			return fmt.Errorf("job %q has empty node_name", job.VolumeID)
+		seenVolumes[source.VolumeID] = struct{}{}
+		if source.NodeName == "" {
+			return fmt.Errorf("EBS source %q has empty node_name", source.VolumeID)
 		}
-		if job.Source.Type != "ebs" || !filepath.IsAbs(job.Source.Root) || filepath.Clean(job.Source.Root) != job.Source.Root {
-			return fmt.Errorf("job %q requires a clean absolute EBS source root", job.VolumeID)
+		if _, exists := seenNodes[source.NodeName]; exists {
+			return fmt.Errorf("duplicate node_name %q", source.NodeName)
 		}
-		if _, ok := c.Spaces[job.Target.SpaceRef]; !ok {
-			return fmt.Errorf("job %q references unknown Space %q", job.VolumeID, job.Target.SpaceRef)
+		seenNodes[source.NodeName] = struct{}{}
+		if !filepath.IsAbs(source.Root) || filepath.Clean(source.Root) != source.Root {
+			return fmt.Errorf("EBS source %q requires a clean absolute root", source.VolumeID)
 		}
-		if !strings.HasPrefix(job.Target.Prefix, "/") || path.Clean(job.Target.Prefix) != job.Target.Prefix {
-			return fmt.Errorf("job %q requires a clean absolute target prefix", job.VolumeID)
+		if len(source.Jobs) == 0 {
+			return fmt.Errorf("EBS source %q must declare at least one Job", source.VolumeID)
 		}
+		for jobIndex := range source.Jobs {
+			configured := &source.Jobs[jobIndex]
+			if err := validateJobID(configured.JobID); err != nil {
+				return fmt.Errorf("EBS source %q Job %d: %w", source.VolumeID, jobIndex, err)
+			}
+			if _, exists := seenJobs[configured.JobID]; exists {
+				return fmt.Errorf("duplicate job_id %q", configured.JobID)
+			}
+			seenJobs[configured.JobID] = struct{}{}
+			if err := validateSourceSubpath(configured.Subpath); err != nil {
+				return fmt.Errorf("job %q: %w", configured.JobID, err)
+			}
+			if _, ok := c.Spaces[configured.Target.SpaceRef]; !ok {
+				return fmt.Errorf("job %q references unknown Space %q", configured.JobID, configured.Target.SpaceRef)
+			}
+			if !strings.HasPrefix(configured.Target.Prefix, "/") || path.Clean(configured.Target.Prefix) != configured.Target.Prefix {
+				return fmt.Errorf("job %q requires a clean absolute target prefix", configured.JobID)
+			}
+			for prior := range jobIndex {
+				if prefixesOverlap(source.Jobs[prior].Subpath, configured.Subpath) {
+					return fmt.Errorf("EBS source %q has overlapping source subpaths %q and %q", source.VolumeID, source.Jobs[prior].Subpath, configured.Subpath)
+				}
+			}
+			resolved = append(resolved, resolveJob(*source, *configured))
+		}
+	}
+	c.Jobs = resolved
+	return nil
+}
+
+func validateJobID(jobID string) error {
+	if !jobIDPattern.MatchString(jobID) || jobID == "." || jobID == ".." {
+		return fmt.Errorf("invalid job_id")
 	}
 	return nil
 }
 
-// SelectJob resolves exactly one Job assigned to nodeName.
-func (c *Config) SelectJob(nodeName string) (Job, error) {
-	if nodeName == "" {
-		return Job{}, fmt.Errorf("%s is required", MigrationNodeNameEnv)
+func validateSourceSubpath(subpath string) error {
+	canonical, err := pathutil.Canonicalize(subpath)
+	if err != nil || canonical != subpath {
+		return fmt.Errorf("requires an absolute clean UTF-8 NFC subpath")
 	}
-	var selected *Job
-	for i := range c.Jobs {
-		if c.Jobs[i].NodeName != nodeName {
+	return nil
+}
+
+func effectiveSourceRoot(root, subpath string) string {
+	if subpath == "/" {
+		return root
+	}
+	return filepath.Join(root, filepath.FromSlash(strings.TrimPrefix(subpath, "/")))
+}
+
+func resolveJob(source EBSSourceConfig, configured JobConfig) Job {
+	return Job{
+		JobID: configured.JobID, VolumeID: source.VolumeID, NodeName: source.NodeName,
+		EBSRoot: source.Root, Subpath: configured.Subpath,
+		Source: SourceConfig{Type: "ebs", Root: effectiveSourceRoot(source.Root, configured.Subpath)},
+		Target: configured.Target,
+	}
+}
+
+// SelectSource resolves exactly one EBS Source assigned to nodeName.
+func (c *Config) SelectSource(nodeName string) (EBSSourceConfig, error) {
+	if nodeName == "" {
+		return EBSSourceConfig{}, fmt.Errorf("%s is required", MigrationNodeNameEnv)
+	}
+	var selected *EBSSourceConfig
+	for i := range c.EBSSources {
+		if c.EBSSources[i].NodeName != nodeName {
 			continue
 		}
 		if selected != nil {
-			return Job{}, fmt.Errorf("node %q resolves more than one Job", nodeName)
+			return EBSSourceConfig{}, fmt.Errorf("node %q resolves more than one EBS source", nodeName)
 		}
-		selected = &c.Jobs[i]
+		selected = &c.EBSSources[i]
 	}
 	if selected == nil {
-		return Job{}, fmt.Errorf("node %q resolves no Job", nodeName)
+		return EBSSourceConfig{}, fmt.Errorf("node %q resolves no EBS source", nodeName)
 	}
 	return *selected, nil
+}
+
+// SelectJob retains the single-Job helper for Job-local tests and callers.
+func (c *Config) SelectJob(nodeName string) (Job, error) {
+	source, err := c.SelectSource(nodeName)
+	if err != nil {
+		return Job{}, err
+	}
+	if len(source.Jobs) != 1 {
+		return Job{}, fmt.Errorf("node %q resolves %d Jobs", nodeName, len(source.Jobs))
+	}
+	return resolveJob(source, source.Jobs[0]), nil
 }
 
 // Phase is the non-regressible per-Job migration phase.
@@ -316,6 +410,14 @@ type Startup struct {
 	mountProbe     sourceMountProbe
 }
 
+// RuntimeStartup is the secret-free startup snapshot for one EBS process.
+type RuntimeStartup struct {
+	Config *Config         `json:"config"`
+	Source EBSSourceConfig `json:"source"`
+	Phase  Phase           `json:"phase"`
+	Jobs   []*Startup      `json:"jobs"`
+}
+
 // ConfigHash hashes only one Job's normalized immutable configuration.
 func ConfigHash(cfg *Config, job Job) (string, error) {
 	space, ok := cfg.Spaces[job.Target.SpaceRef]
@@ -323,7 +425,10 @@ func ConfigHash(cfg *Config, job Job) (string, error) {
 		return "", fmt.Errorf("config hash references unknown Space %q", job.Target.SpaceRef)
 	}
 	type stableJob struct {
+		JobID    string       `json:"job_id"`
 		VolumeID string       `json:"volume_id"`
+		EBSRoot  string       `json:"ebs_root"`
+		Subpath  string       `json:"subpath"`
 		Source   SourceConfig `json:"source"`
 		Target   TargetConfig `json:"target"`
 	}
@@ -335,7 +440,10 @@ func ConfigHash(cfg *Config, job Job) (string, error) {
 		Space       SpaceConfig  `json:"space"`
 	}{
 		Version: cfg.Version, Drive9: cfg.Drive9, JobDefaults: cfg.JobDefaults,
-		Job:   stableJob{VolumeID: job.VolumeID, Source: job.Source, Target: job.Target},
+		Job: stableJob{
+			JobID: job.JobID, VolumeID: job.VolumeID, EBSRoot: job.EBSRoot,
+			Subpath: job.Subpath, Source: job.Source, Target: job.Target,
+		},
 		Space: space,
 	})
 	if err != nil {
@@ -345,13 +453,13 @@ func ConfigHash(cfg *Config, job Job) (string, error) {
 	return hex.EncodeToString(sum[:]), nil
 }
 
-// LoadStartup resolves and validates one local Job without retaining its key.
-func LoadStartup(configPath, nodeName, environmentPhase, credentialRoot string, highestApplied Phase) (*Startup, error) {
+// LoadRuntimeStartup resolves all Jobs for one local EBS without retaining keys.
+func LoadRuntimeStartup(configPath, nodeName, environmentPhase, credentialRoot string, highestApplied Phase) (*RuntimeStartup, error) {
 	cfg, err := LoadConfig(configPath)
 	if err != nil {
 		return nil, err
 	}
-	job, err := cfg.SelectJob(nodeName)
+	source, err := cfg.SelectSource(nodeName)
 	if err != nil {
 		return nil, err
 	}
@@ -359,17 +467,38 @@ func LoadStartup(configPath, nodeName, environmentPhase, credentialRoot string, 
 	if err != nil {
 		return nil, err
 	}
-	space := cfg.Spaces[job.Target.SpaceRef]
-	credential, err := NewCredentialSource(credentialRoot, space.CredentialRef)
-	if err != nil {
-		return nil, fmt.Errorf("resolve credential: %w", err)
+	runtime := &RuntimeStartup{Config: cfg, Source: source, Phase: phase, Jobs: make([]*Startup, 0, len(source.Jobs))}
+	for _, configured := range source.Jobs {
+		job := resolveJob(source, configured)
+		space := cfg.Spaces[job.Target.SpaceRef]
+		credential, err := NewCredentialSource(credentialRoot, space.CredentialRef)
+		if err != nil {
+			return nil, fmt.Errorf("resolve credential for Job %q: %w", job.JobID, err)
+		}
+		hash, err := ConfigHash(cfg, job)
+		if err != nil {
+			return nil, err
+		}
+		runtime.Jobs = append(runtime.Jobs, &Startup{
+			Config: cfg, Job: job, Space: space, Phase: phase,
+			ConfigHash: hash, Credential: credential,
+		})
 	}
-	if _, err := credential.Read(); err != nil {
+	return runtime, nil
+}
+
+// LoadStartup resolves one local Job for Job-local tests and callers.
+func LoadStartup(configPath, nodeName, environmentPhase, credentialRoot string, highestApplied Phase) (*Startup, error) {
+	runtime, err := LoadRuntimeStartup(configPath, nodeName, environmentPhase, credentialRoot, highestApplied)
+	if err != nil {
 		return nil, err
 	}
-	hash, err := ConfigHash(cfg, job)
-	if err != nil {
+	if len(runtime.Jobs) != 1 {
+		return nil, fmt.Errorf("node %q resolves %d Jobs", nodeName, len(runtime.Jobs))
+	}
+	startup := runtime.Jobs[0]
+	if _, err := startup.Credential.Read(); err != nil {
 		return nil, err
 	}
-	return &Startup{Config: cfg, Job: job, Space: space, Phase: phase, ConfigHash: hash, Credential: credential}, nil
+	return startup, nil
 }

--- a/internal/migration/config.go
+++ b/internal/migration/config.go
@@ -400,22 +400,24 @@ func (s CredentialSource) Read() (string, error) {
 
 // Startup is a secret-free immutable startup snapshot plus a reloadable source.
 type Startup struct {
-	Config         *Config          `json:"config"`
-	Job            Job              `json:"job"`
-	Space          SpaceConfig      `json:"space"`
-	Phase          Phase            `json:"phase"`
-	ConfigHash     string           `json:"config_hash"`
-	Credential     CredentialSource `json:"-"`
-	acceptedSource sourceMountIdentity
-	mountProbe     sourceMountProbe
+	Config           *Config          `json:"config"`
+	Job              Job              `json:"job"`
+	Space            SpaceConfig      `json:"space"`
+	Phase            Phase            `json:"phase"`
+	ConfigHash       string           `json:"config_hash"`
+	Credential       CredentialSource `json:"-"`
+	acceptedTenantID string
+	acceptedSource   sourceMountIdentity
+	mountProbe       sourceMountProbe
 }
 
 // RuntimeStartup is the secret-free startup snapshot for one EBS process.
 type RuntimeStartup struct {
-	Config *Config         `json:"config"`
-	Source EBSSourceConfig `json:"source"`
-	Phase  Phase           `json:"phase"`
-	Jobs   []*Startup      `json:"jobs"`
+	Config            *Config         `json:"config"`
+	Source            EBSSourceConfig `json:"source"`
+	Phase             Phase           `json:"phase"`
+	Jobs              []*Startup      `json:"jobs"`
+	targetCredentials map[string]CredentialSource
 }
 
 // ConfigHash hashes only one Job's normalized immutable configuration.
@@ -467,14 +469,26 @@ func LoadRuntimeStartup(configPath, nodeName, environmentPhase, credentialRoot s
 	if err != nil {
 		return nil, err
 	}
-	runtime := &RuntimeStartup{Config: cfg, Source: source, Phase: phase, Jobs: make([]*Startup, 0, len(source.Jobs))}
+	runtime := &RuntimeStartup{
+		Config: cfg, Source: source, Phase: phase, Jobs: make([]*Startup, 0, len(source.Jobs)),
+		targetCredentials: make(map[string]CredentialSource),
+	}
+	for _, job := range cfg.Jobs {
+		spaceRef := job.Target.SpaceRef
+		if _, exists := runtime.targetCredentials[spaceRef]; exists {
+			continue
+		}
+		space := cfg.Spaces[spaceRef]
+		credential, err := NewCredentialSource(credentialRoot, space.CredentialRef)
+		if err != nil {
+			return nil, fmt.Errorf("resolve credential for Space %q: %w", spaceRef, err)
+		}
+		runtime.targetCredentials[spaceRef] = credential
+	}
 	for _, configured := range source.Jobs {
 		job := resolveJob(source, configured)
 		space := cfg.Spaces[job.Target.SpaceRef]
-		credential, err := NewCredentialSource(credentialRoot, space.CredentialRef)
-		if err != nil {
-			return nil, fmt.Errorf("resolve credential for Job %q: %w", job.JobID, err)
-		}
+		credential := runtime.targetCredentials[job.Target.SpaceRef]
 		hash, err := ConfigHash(cfg, job)
 		if err != nil {
 			return nil, err

--- a/internal/migration/config_test.go
+++ b/internal/migration/config_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 )
 
-const validConfigYAML = `version: v3
+const validConfigYAML = `version: v4
 drive9:
   endpoint: https://drive9.example.com
 job_defaults:
@@ -23,15 +23,16 @@ job_defaults:
 spaces:
   space-001:
     credential_ref: space-001-key
-jobs:
+ebs_sources:
   - volume_id: vol-001
     node_name: node-a
-    source:
-      type: ebs
-      root: /ebs/001
-    target:
-      space_ref: space-001
-      prefix: /
+    root: /ebs/001
+    jobs:
+      - job_id: vol-001
+        subpath: /
+        target:
+          space_ref: space-001
+          prefix: /
 `
 
 func writeConfig(t *testing.T, body string) string {
@@ -49,7 +50,7 @@ func TestLoadConfigStrictAndDefaults(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if cfg.Version != "v3" || cfg.Drive9.Endpoint != "https://drive9.example.com" {
+	if cfg.Version != "v4" || cfg.Drive9.Endpoint != "https://drive9.example.com" {
 		t.Fatalf("config = %+v", cfg)
 	}
 	if time.Duration(cfg.JobDefaults.Sync.GracePeriod) != time.Minute {
@@ -67,9 +68,9 @@ func TestLoadConfigRejectsMalformedUnknownAndUnsupportedFields(t *testing.T) {
 	}{
 		{name: "malformed", body: "version: ["},
 		{name: "unknown top level", body: validConfigYAML + "extra: true\n"},
-		{name: "per-job override", body: strings.Replace(validConfigYAML, "    target:\n", "    grace_period: 30s\n    target:\n", 1)},
-		{name: "wrong version", body: strings.Replace(validConfigYAML, "version: v3", "version: v2", 1)},
-		{name: "multiple documents", body: validConfigYAML + "---\nversion: v3\n"},
+		{name: "per-job override", body: strings.Replace(validConfigYAML, "        target:\n", "        grace_period: 30s\n        target:\n", 1)},
+		{name: "wrong version", body: strings.Replace(validConfigYAML, "version: v4", "version: v2", 1)},
+		{name: "multiple documents", body: validConfigYAML + "---\nversion: v4\n"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if _, err := LoadConfig(writeConfig(t, tc.body)); err == nil {
@@ -82,8 +83,11 @@ func TestLoadConfigRejectsMalformedUnknownAndUnsupportedFields(t *testing.T) {
 func TestLoadConfigRejectsDuplicateAndInvalidJobIdentity(t *testing.T) {
 	duplicate := validConfigYAML + `  - volume_id: vol-001
     node_name: node-b
-    source: {type: ebs, root: /ebs/002}
-    target: {space_ref: space-001, prefix: /other}
+    root: /ebs/002
+    jobs:
+      - job_id: vol-001-other
+        subpath: /
+        target: {space_ref: space-001, prefix: /other}
 `
 	if _, err := LoadConfig(writeConfig(t, duplicate)); err == nil || !strings.Contains(err.Error(), "duplicate volume_id") {
 		t.Fatalf("duplicate error = %v", err)
@@ -96,21 +100,19 @@ func TestLoadConfigRejectsDuplicateAndInvalidJobIdentity(t *testing.T) {
 	}
 }
 
-func TestSelectJobRequiresExactlyOneNodeMatch(t *testing.T) {
+func TestSelectSourceRequiresExactlyOneNodeMatch(t *testing.T) {
 	cfg, err := LoadConfig(writeConfig(t, validConfigYAML))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := cfg.SelectJob("missing"); err == nil {
+	if _, err := cfg.SelectSource("missing"); err == nil {
 		t.Fatal("missing node match accepted")
 	}
-	cfg.Jobs = append(cfg.Jobs, Job{
-		VolumeID: "vol-002",
-		NodeName: "node-a",
-		Source:   SourceConfig{Type: "ebs", Root: "/ebs/002"},
-		Target:   TargetConfig{SpaceRef: "space-001", Prefix: "/other"},
+	cfg.EBSSources = append(cfg.EBSSources, EBSSourceConfig{
+		VolumeID: "vol-002", NodeName: "node-a", Root: "/ebs/002",
+		Jobs: []JobConfig{{JobID: "vol-002-root", Subpath: "/", Target: TargetConfig{SpaceRef: "space-001", Prefix: "/other"}}},
 	})
-	if _, err := cfg.SelectJob("node-a"); err == nil {
+	if _, err := cfg.SelectSource("node-a"); err == nil {
 		t.Fatal("multiple node matches accepted")
 	}
 }
@@ -221,8 +223,11 @@ func TestLoadStartupHashExcludesPhaseAndSecret(t *testing.T) {
 func TestConfigHashCoversOnlySelectedEffectiveJob(t *testing.T) {
 	extraJob := `  - volume_id: vol-002
     node_name: node-b
-    source: {type: ebs, root: /ebs/002}
-    target: {space_ref: space-001, prefix: /other}
+    root: /ebs/002
+    jobs:
+      - job_id: vol-002-root
+        subpath: /
+        target: {space_ref: space-001, prefix: /other}
 `
 	first, err := LoadConfig(writeConfig(t, validConfigYAML+extraJob))
 	if err != nil {

--- a/internal/migration/config_v4_test.go
+++ b/internal/migration/config_v4_test.go
@@ -91,6 +91,9 @@ func TestLoadRuntimeStartupResolvesEverySubpathWithoutReadingCredentials(t *test
 	if len(runtime.Jobs) != 2 {
 		t.Fatalf("Jobs=%d", len(runtime.Jobs))
 	}
+	if len(runtime.targetCredentials) != 2 {
+		t.Fatalf("target credentials=%d, want 2", len(runtime.targetCredentials))
+	}
 	for index, expected := range []struct {
 		jobID   string
 		subpath string
@@ -100,6 +103,33 @@ func TestLoadRuntimeStartupResolvesEverySubpathWithoutReadingCredentials(t *test
 		if job.JobID != expected.jobID || job.Subpath != expected.subpath || job.EBSRoot != "/ebs/001" || job.Source.Root != filepath.Clean(expected.root) {
 			t.Fatalf("Job %d=%+v", index, job)
 		}
+		if runtime.Jobs[index].Credential.path != runtime.targetCredentials[job.Target.SpaceRef].path {
+			t.Fatalf("Job %d credential does not reuse complete target mapping", index)
+		}
+	}
+}
+
+func TestLoadRuntimeStartupRetainsCredentialsForOtherConfiguredSources(t *testing.T) {
+	body := strings.Replace(validV4ConfigYAML, "ebs_sources:\n", "  space-c:\n    credential_ref: space-c-key\nebs_sources:\n", 1)
+	body += `  - volume_id: vol-002
+    node_name: node-b
+    root: /ebs/002
+    jobs:
+      - job_id: vol-002-user-c
+        subpath: /C
+        target:
+          space_ref: space-c
+          prefix: /
+`
+	runtime, err := LoadRuntimeStartup(writeConfig(t, body), "node-a", string(PhaseSyncing), t.TempDir(), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runtime.Jobs) != 2 || len(runtime.targetCredentials) != 3 {
+		t.Fatalf("local Jobs=%d target credentials=%d", len(runtime.Jobs), len(runtime.targetCredentials))
+	}
+	if filepath.Base(runtime.targetCredentials["space-c"].path) != "space-c-key" {
+		t.Fatalf("other-source credential=%q", runtime.targetCredentials["space-c"].path)
 	}
 }
 

--- a/internal/migration/config_v4_test.go
+++ b/internal/migration/config_v4_test.go
@@ -1,0 +1,130 @@
+package migration
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const validV4ConfigYAML = `version: v4
+drive9:
+  endpoint: https://drive9.example.com
+job_defaults:
+  sync:
+    grace_period: 60s
+  performance:
+    max_bytes_per_second: 1024
+    small_file_workers: 2
+    large_file_workers: 1
+spaces:
+  space-a:
+    credential_ref: space-a-key
+  space-b:
+    credential_ref: space-b-key
+ebs_sources:
+  - volume_id: vol-001
+    node_name: node-a
+    root: /ebs/001
+    jobs:
+      - job_id: vol-001-user-a
+        subpath: /A
+        target:
+          space_ref: space-a
+          prefix: /
+      - job_id: vol-001-user-b
+        subpath: /B
+        target:
+          space_ref: space-b
+          prefix: /
+`
+
+func TestLoadConfigAcceptsV4EBSSubpathMappings(t *testing.T) {
+	cfg, err := LoadConfig(writeConfig(t, validV4ConfigYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Version != "v4" {
+		t.Fatalf("version = %q, want v4", cfg.Version)
+	}
+}
+
+func TestLoadConfigRejectsV3(t *testing.T) {
+	body := strings.Replace(validConfigYAML, "version: v4", "version: v3", 1)
+	if _, err := LoadConfig(writeConfig(t, body)); err == nil || !strings.Contains(err.Error(), `config version must be "v4"`) {
+		t.Fatalf("v3 error = %v", err)
+	}
+}
+
+func TestLoadConfigRejectsOverlappingV4Subpaths(t *testing.T) {
+	body := strings.Replace(validV4ConfigYAML, "        subpath: /B", "        subpath: /A/child", 1)
+	if _, err := LoadConfig(writeConfig(t, body)); err == nil || !strings.Contains(err.Error(), "overlapping source subpaths") {
+		t.Fatalf("overlap error = %v", err)
+	}
+}
+
+func TestLoadConfigRejectsInvalidV4JobIdentityAndSubpath(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{name: "duplicate Job ID", body: strings.Replace(validV4ConfigYAML, "job_id: vol-001-user-b", "job_id: vol-001-user-a", 1)},
+		{name: "unsafe Job ID", body: strings.Replace(validV4ConfigYAML, "job_id: vol-001-user-a", "job_id: ../user-a", 1)},
+		{name: "relative subpath", body: strings.Replace(validV4ConfigYAML, "subpath: /A", "subpath: A", 1)},
+		{name: "traversing subpath", body: strings.Replace(validV4ConfigYAML, "subpath: /A", "subpath: /A/../B", 1)},
+		{name: "backslash subpath", body: strings.Replace(validV4ConfigYAML, "subpath: /A", `subpath: /A\\B`, 1)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := LoadConfig(writeConfig(t, tc.body)); err == nil {
+				t.Fatal("invalid v4 mapping accepted")
+			}
+		})
+	}
+}
+
+func TestLoadRuntimeStartupResolvesEverySubpathWithoutReadingCredentials(t *testing.T) {
+	runtime, err := LoadRuntimeStartup(
+		writeConfig(t, validV4ConfigYAML), "node-a", string(PhaseSyncing), t.TempDir(), "",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runtime.Jobs) != 2 {
+		t.Fatalf("Jobs=%d", len(runtime.Jobs))
+	}
+	for index, expected := range []struct {
+		jobID   string
+		subpath string
+		root    string
+	}{{"vol-001-user-a", "/A", "/ebs/001/A"}, {"vol-001-user-b", "/B", "/ebs/001/B"}} {
+		job := runtime.Jobs[index].Job
+		if job.JobID != expected.jobID || job.Subpath != expected.subpath || job.EBSRoot != "/ebs/001" || job.Source.Root != filepath.Clean(expected.root) {
+			t.Fatalf("Job %d=%+v", index, job)
+		}
+	}
+}
+
+func TestConfigHashCoversJobIDAndSubpath(t *testing.T) {
+	cfg, err := LoadConfig(writeConfig(t, validV4ConfigYAML))
+	if err != nil {
+		t.Fatal(err)
+	}
+	job := cfg.Jobs[0]
+	original, err := ConfigHash(cfg, job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job.JobID = "replacement-job"
+	changedID, err := ConfigHash(cfg, job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	job = cfg.Jobs[0]
+	job.Subpath, job.Source.Root = "/replacement", "/ebs/001/replacement"
+	changedSubpath, err := ConfigHash(cfg, job)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if original == changedID || original == changedSubpath {
+		t.Fatalf("hashes original=%s id=%s subpath=%s", original, changedID, changedSubpath)
+	}
+}

--- a/internal/migration/control.go
+++ b/internal/migration/control.go
@@ -27,6 +27,7 @@ var controlIODeadline = 5 * time.Second
 
 type ControlRequest struct {
 	Command string `json:"command"`
+	JobID   string `json:"job_id,omitempty"`
 	Output  string `json:"output,omitempty"`
 	Type    string `json:"type,omitempty"`
 	Limit   int    `json:"limit,omitempty"`
@@ -77,12 +78,18 @@ func (g *serialGate) Release() {
 }
 
 type StatusOutput struct {
+	JobID            string              `json:"job_id,omitempty"`
 	VolumeID         string              `json:"volume_id,omitempty"`
 	NodeName         string              `json:"node_name,omitempty"`
+	EBSRoot          string              `json:"ebs_root,omitempty"`
+	Subpath          string              `json:"subpath,omitempty"`
 	SpaceRef         string              `json:"space_ref,omitempty"`
 	Prefix           string              `json:"prefix,omitempty"`
 	CredentialRef    string              `json:"credential_ref,omitempty"`
-	Phase            Phase               `json:"phase"`
+	RuntimeState     RuntimeState        `json:"runtime_state,omitempty"`
+	RuntimeAttempts  int                 `json:"runtime_attempts,omitempty"`
+	RuntimeError     string              `json:"runtime_error,omitempty"`
+	Phase            Phase               `json:"phase,omitempty"`
 	StartupPhase     Phase               `json:"startup_phase"`
 	RecoveryComplete bool                `json:"recovery_complete"`
 	Current          RoundStatus         `json:"round"`
@@ -103,16 +110,28 @@ type StatusOutput struct {
 	AttentionReason  string              `json:"attention_reason,omitempty"`
 }
 
+type EBSStatusOutput struct {
+	VolumeID string         `json:"volume_id"`
+	NodeName string         `json:"node_name"`
+	EBSRoot  string         `json:"ebs_root"`
+	Jobs     []StatusOutput `json:"jobs"`
+}
+
+type controlTarget interface {
+	prepareControl(context.Context, ControlRequest) (func(), error)
+	handlePreparedControl(context.Context, io.Writer, ControlRequest) error
+}
+
 type controlServer struct {
 	ctx      context.Context
 	listener net.Listener
 	path     string
-	worker   *Worker
+	target   controlTarget
 	once     sync.Once
 	wait     sync.WaitGroup
 }
 
-func startControl(ctx context.Context, path string, worker *Worker) (*controlServer, error) {
+func startControl(ctx context.Context, path string, target controlTarget) (*controlServer, error) {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return nil, err
 	}
@@ -124,7 +143,7 @@ func startControl(ctx context.Context, path string, worker *Worker) (*controlSer
 		_ = listener.Close()
 		return nil, err
 	}
-	server := &controlServer{ctx: ctx, listener: listener, path: path, worker: worker}
+	server := &controlServer{ctx: ctx, listener: listener, path: path, target: target}
 	server.wait.Add(1)
 	go server.serve()
 	go func() { <-ctx.Done(); server.close() }()
@@ -195,17 +214,19 @@ func (s *controlServer) handle(conn net.Conn) {
 			_, _ = conn.Read(extra[:])
 			cancelWait()
 		}()
-		if err := s.worker.controlGate.Acquire(waitCtx); err != nil {
+		release, err := s.target.prepareControl(waitCtx, request)
+		if err != nil {
 			cancelWait()
+			_ = writeControlTerminal(output, request.Command, err)
 			return
 		}
 		cancelWait()
-		defer s.worker.controlGate.Release()
+		defer release()
 		if err := writeControlFrame(output, controlFrame{Type: controlFrameAccepted, Command: request.Command}); err != nil {
 			return
 		}
 	}
-	err = s.worker.handleControlLocked(s.ctx, output, request)
+	err = s.target.handlePreparedControl(s.ctx, output, request)
 	_ = writeControlTerminal(output, request.Command, err)
 }
 
@@ -226,6 +247,107 @@ func (s *controlServer) close() {
 		s.wait.Wait()
 		_ = os.Remove(s.path)
 	})
+}
+
+func (w *Worker) prepareControl(ctx context.Context, request ControlRequest) (func(), error) {
+	if !isControlMutation(request.Command) {
+		return func() {}, nil
+	}
+	if err := w.controlGate.Acquire(ctx); err != nil {
+		return nil, err
+	}
+	return w.controlGate.Release, nil
+}
+
+func (w *Worker) handlePreparedControl(ctx context.Context, output io.Writer, request ControlRequest) error {
+	return w.handleControlLocked(ctx, output, request)
+}
+
+func (m *Manager) prepareControl(ctx context.Context, request ControlRequest) (func(), error) {
+	if !isControlMutation(request.Command) {
+		return func() {}, nil
+	}
+	if request.JobID == "" {
+		return nil, ErrIllegalAction
+	}
+	snapshot, ok := m.snapshot(request.JobID)
+	if !ok || snapshot.Worker == nil || snapshot.State != RuntimeRunning {
+		return nil, ErrIllegalAction
+	}
+	if err := snapshot.Worker.controlGate.Acquire(ctx); err != nil {
+		return nil, err
+	}
+	current, ok := m.snapshot(request.JobID)
+	if !ok || current.Worker != snapshot.Worker || current.State != RuntimeRunning {
+		snapshot.Worker.controlGate.Release()
+		return nil, ErrIllegalAction
+	}
+	return snapshot.Worker.controlGate.Release, nil
+}
+
+func (m *Manager) handlePreparedControl(ctx context.Context, output io.Writer, request ControlRequest) error {
+	if request.Command == "status" {
+		if request.Output != "json" {
+			return ErrIllegalAction
+		}
+		status, err := m.statusOutput(request.JobID)
+		if err != nil {
+			return err
+		}
+		return json.NewEncoder(output).Encode(status)
+	}
+	if request.JobID == "" {
+		return ErrIllegalAction
+	}
+	snapshot, ok := m.snapshot(request.JobID)
+	if !ok || snapshot.Worker == nil || snapshot.State != RuntimeRunning {
+		return ErrIllegalAction
+	}
+	return snapshot.Worker.handleControlLocked(ctx, output, request)
+}
+
+func (m *Manager) statusOutput(jobID string) (EBSStatusOutput, error) {
+	snapshots, err := m.snapshots(jobID)
+	if err != nil {
+		return EBSStatusOutput{}, err
+	}
+	status := EBSStatusOutput{
+		VolumeID: m.startup.Source.VolumeID, NodeName: m.startup.Source.NodeName,
+		EBSRoot: m.startup.Source.Root, Jobs: make([]StatusOutput, 0, len(snapshots)),
+	}
+	for _, snapshot := range snapshots {
+		var job StatusOutput
+		if snapshot.Worker != nil {
+			job = snapshot.Worker.statusOutput()
+		} else {
+			job = startupStatusOutput(snapshot.Startup)
+		}
+		job.RuntimeState = snapshot.State
+		job.RuntimeAttempts = snapshot.Attempts
+		job.RuntimeError = snapshot.Error
+		if snapshot.Error != "" {
+			job.AttentionReason = snapshot.Error
+		}
+		status.Jobs = append(status.Jobs, job)
+	}
+	return status, nil
+}
+
+func startupStatusOutput(startup *Startup) StatusOutput {
+	status := StatusOutput{Findings: make(map[FindingKind]int)}
+	if startup == nil {
+		return status
+	}
+	status.JobID = startup.Job.JobID
+	status.VolumeID = startup.Job.VolumeID
+	status.NodeName = startup.Job.NodeName
+	status.EBSRoot = startup.Job.EBSRoot
+	status.Subpath = startup.Job.Subpath
+	status.SpaceRef = startup.Job.Target.SpaceRef
+	status.Prefix = startup.Job.Target.Prefix
+	status.CredentialRef = startup.Space.CredentialRef
+	status.StartupPhase = startup.Phase
+	return status
 }
 
 func (w *Worker) handleControl(ctx context.Context, output io.Writer, request ControlRequest) error {
@@ -287,9 +409,12 @@ func (w *Worker) statusOutput() StatusOutput {
 	snapshot := w.state.Snapshot()
 	status := StatusOutput{Phase: snapshot.Phase, StartupPhase: snapshot.Phase, RecoveryComplete: snapshot.RecoveryComplete, Current: snapshot.Current, Conditions: snapshot.Conditions, RepairMtimeFloor: snapshot.RepairMtimeFloor, CandidateCounts: snapshot.CandidateCounts, GraceCandidates: len(snapshot.Grace), CASRetry: len(snapshot.Retry), Backlog: len(snapshot.Retry), PendingRepairs: snapshot.PendingRepairs, InFlight: snapshot.ActiveOperations, Verification: snapshot.Verification, Findings: make(map[FindingKind]int)}
 	if w.startup != nil {
+		status.JobID = w.startup.Job.JobID
 		status.StartupPhase = w.startup.Phase
 		status.VolumeID = w.startup.Job.VolumeID
 		status.NodeName = w.startup.Job.NodeName
+		status.EBSRoot = w.startup.Job.EBSRoot
+		status.Subpath = w.startup.Job.Subpath
 		status.SpaceRef = w.startup.Job.Target.SpaceRef
 		status.Prefix = w.startup.Job.Target.Prefix
 		status.CredentialRef = w.startup.Space.CredentialRef
@@ -402,11 +527,11 @@ func Control(ctx context.Context, socket string, request ControlRequest, output 
 				}
 				accepted = true
 			case controlFrameTerminal:
-				if isControlMutation(request.Command) && !accepted {
-					return errors.New("mutation terminated before acceptance")
-				}
 				if !frame.OK {
 					return controlFrameError(frame)
+				}
+				if isControlMutation(request.Command) && !accepted {
+					return errors.New("mutation succeeded before acceptance")
 				}
 				if frame.Error != "" || frame.Code != 0 || !validControlPayloadCount(request.Command, payloads) {
 					return errors.New("invalid successful control terminal")
@@ -461,14 +586,30 @@ func decodeControlJSON(body []byte, destination any) error {
 func validateControlPayload(command string, body []byte) error {
 	switch command {
 	case "status":
+		var fields map[string]json.RawMessage
+		if err := decodeControlJSON(body, &fields); err != nil {
+			return fmt.Errorf("invalid status response: %w", err)
+		}
+		if _, ok := fields["jobs"]; ok {
+			status := &EBSStatusOutput{}
+			if err := decodeControlJSON(body, status); err != nil {
+				return fmt.Errorf("invalid EBS status response: %w", err)
+			}
+			if status.VolumeID == "" || status.NodeName == "" || status.EBSRoot == "" || len(status.Jobs) == 0 {
+				return errors.New("invalid EBS status identity")
+			}
+			for _, job := range status.Jobs {
+				if err := validateStatusOutput(job); err != nil {
+					return err
+				}
+			}
+			return nil
+		}
 		status := &StatusOutput{}
 		if err := decodeControlJSON(body, status); err != nil {
 			return fmt.Errorf("invalid status response: %w", err)
 		}
-		if phaseRank(status.Phase) == 0 || phaseRank(status.StartupPhase) == 0 {
-			return errors.New("invalid status phase")
-		}
-		return nil
+		return validateStatusOutput(*status)
 	case "diff":
 		finding := &Finding{}
 		if err := decodeControlJSON(body, finding); err != nil {
@@ -499,6 +640,22 @@ func validateControlPayload(command string, body []byte) error {
 	default:
 		return ErrIllegalAction
 	}
+}
+
+func validateStatusOutput(status StatusOutput) error {
+	if status.RuntimeState != "" && status.RuntimeState != RuntimeInitializing && status.RuntimeState != RuntimeRetrying && status.RuntimeState != RuntimeRunning && status.RuntimeState != RuntimeStopped {
+		return errors.New("invalid runtime state")
+	}
+	if status.RuntimeState == RuntimeInitializing || status.RuntimeState == RuntimeRetrying || status.RuntimeState == RuntimeStopped {
+		if status.JobID == "" || phaseRank(status.StartupPhase) == 0 {
+			return errors.New("invalid startup-only status")
+		}
+		return nil
+	}
+	if phaseRank(status.Phase) == 0 || phaseRank(status.StartupPhase) == 0 {
+		return errors.New("invalid status phase")
+	}
+	return nil
 }
 
 func validControlPayloadCount(command string, count int) bool {

--- a/internal/migration/handoff_test.go
+++ b/internal/migration/handoff_test.go
@@ -13,7 +13,7 @@ const (
 	runbookPath          = "../../docs/guides/drive9-migration-v1-runbook.md"
 )
 
-func TestOperatorSampleSupportsBothLayoutsAndContainsNoCredential(t *testing.T) {
+func TestOperatorSampleSupportsEBSSubpathMappingsAndContainsNoCredential(t *testing.T) {
 	cfg, err := LoadConfig(sampleConfigPath)
 	if err != nil {
 		t.Fatal(err)
@@ -21,7 +21,7 @@ func TestOperatorSampleSupportsBothLayoutsAndContainsNoCredential(t *testing.T) 
 	if err := ValidateMappings(cfg); err != nil {
 		t.Fatal(err)
 	}
-	if len(cfg.Jobs) != 3 || cfg.Jobs[0].Target.Prefix != "/" || cfg.Jobs[1].Target.SpaceRef != cfg.Jobs[2].Target.SpaceRef || cfg.Jobs[1].Target.Prefix == cfg.Jobs[2].Target.Prefix {
+	if len(cfg.EBSSources) != 1 || len(cfg.Jobs) != 3 || cfg.Jobs[0].VolumeID != cfg.Jobs[2].VolumeID || cfg.Jobs[0].Subpath == cfg.Jobs[1].Subpath || cfg.Jobs[0].Target.SpaceRef == cfg.Jobs[1].Target.SpaceRef {
 		t.Fatalf("sample mappings=%+v", cfg.Jobs)
 	}
 	body, err := os.ReadFile(sampleConfigPath)
@@ -36,12 +36,12 @@ func TestOperatorSampleSupportsBothLayoutsAndContainsNoCredential(t *testing.T) 
 }
 
 func TestPlanHandoffSchemaIsNonSensitiveAndRunbookCoversAcceptedWorkflow(t *testing.T) {
-	result := PreflightResult{VolumeID: "vol-0b", NodeName: "migration-node-b", SourceRoot: "/mnt/ebs/vol-0b", SpaceRef: "shared", Prefix: "/vol-0b", CredentialRef: "shared-owner-key", RequiredCapabilities: true}
+	result := PreflightResult{JobID: "vol-0a-user-a", VolumeID: "vol-0a", NodeName: "migration-node-a", EBSRoot: "/mnt/ebs/vol-0a", Subpath: "/A", SourceRoot: "/mnt/ebs/vol-0a/A", SpaceRef: "user-a", Prefix: "/", CredentialRef: "user-a-owner-key", RequiredCapabilities: true}
 	body, err := json.Marshal(result)
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, field := range []string{"volume_id", "node_name", "source_root", "space_ref", "prefix", "credential_ref", "required_capabilities"} {
+	for _, field := range []string{"job_id", "volume_id", "node_name", "ebs_root", "subpath", "source_root", "space_ref", "prefix", "credential_ref", "required_capabilities"} {
 		if !strings.Contains(string(body), `"`+field+`"`) {
 			t.Fatalf("plan handoff omitted %q: %s", field, body)
 		}
@@ -54,7 +54,7 @@ func TestPlanHandoffSchemaIsNonSensitiveAndRunbookCoversAcceptedWorkflow(t *test
 		t.Fatal(err)
 	}
 	text := string(runbook)
-	for _, required := range []string{"T0", "T1", "T2", "ConfigMap", "rollout-restart", "verify-full", "prepare-drive9-cutover", "post-T0", "residue", "metadata", "per Job", "residual ABA", "one mounted, read-only EBS Source per Job", "no rollback", "exact per-Job control directory", "kubectl-drive9-migration", "expected_job_ids_json", ".worker_status.fence_complete == true", "fsGroup", "recursively change Source ownership"} {
+	for _, required := range []string{"T0", "T1", "T2", "ConfigMap", "rollout-restart", "verify-full", "prepare-drive9-cutover", "post-T0", "residue", "metadata", "per Job", "residual ABA", "configured subpaths from one mounted, read-only EBS", "version: v4", "checkpoint v1", "no rollback", "exact per-Job control directory", "kubectl-drive9-migration", "expected_job_ids_json", ".worker_status.fence_complete == true", "fsGroup", "recursively change Source ownership"} {
 		if !strings.Contains(text, required) {
 			t.Fatalf("runbook omitted %q", required)
 		}

--- a/internal/migration/handoff_test.go
+++ b/internal/migration/handoff_test.go
@@ -54,7 +54,7 @@ func TestPlanHandoffSchemaIsNonSensitiveAndRunbookCoversAcceptedWorkflow(t *test
 		t.Fatal(err)
 	}
 	text := string(runbook)
-	for _, required := range []string{"T0", "T1", "T2", "ConfigMap", "rollout-restart", "verify-full", "prepare-drive9-cutover", "post-T0", "residue", "metadata", "per Job", "residual ABA", "configured subpaths from one mounted, read-only EBS", "version: v4", "checkpoint v1", "no rollback", "exact per-Job control directory", "kubectl-drive9-migration", "expected_job_ids_json", ".worker_status.fence_complete == true", "fsGroup", "recursively change Source ownership"} {
+	for _, required := range []string{"T0", "T1", "T2", "ConfigMap", "rollout-restart", "verify-full", "prepare-drive9-cutover", "post-T0", "residue", "metadata", "per Job", "residual ABA", "configured subpaths from one mounted, read-only EBS", "version: v4", "checkpoint v1", "no rollback", "exact per-Job control directory", "kubectl-drive9-migration", "expected_job_ids_json", ".worker_status.fence_complete == true", "fsGroup", "recursively change Source ownership", "/v1/status.tenant_id", "does not contain `tenant_id`", "batch safety gate", "process-lifetime `tenant_id`"} {
 		if !strings.Contains(text, required) {
 			t.Fatalf("runbook omitted %q", required)
 		}

--- a/internal/migration/manager.go
+++ b/internal/migration/manager.go
@@ -65,8 +65,11 @@ func newManagerWithDependencies(startup *RuntimeStartup, deps managerDependencie
 	if startup == nil || startup.Config == nil || len(startup.Jobs) == 0 {
 		return nil, errors.New("Manager requires runtime startup configuration")
 	}
+	if err := ValidateMappings(startup.Config); err != nil {
+		return nil, fmt.Errorf("Manager static mapping: %w", err)
+	}
 	if deps.preflight == nil {
-		deps.preflight = Preflight
+		deps.preflight = preflightJob
 	}
 	if deps.newWorker == nil {
 		deps.newWorker = NewWorker

--- a/internal/migration/manager.go
+++ b/internal/migration/manager.go
@@ -43,10 +43,11 @@ type jobRuntimeSnapshot struct {
 }
 
 type managerDependencies struct {
-	preflight func(context.Context, *Startup) (PreflightResult, error)
-	newWorker func(context.Context, *Startup) (*Worker, error)
-	runWorker func(context.Context, *Worker) error
-	wait      func(context.Context, time.Duration) error
+	validateTargets func(context.Context, *RuntimeStartup) error
+	preflight       func(context.Context, *Startup) (PreflightResult, error)
+	newWorker       func(context.Context, *Startup) (*Worker, error)
+	runWorker       func(context.Context, *Worker) error
+	wait            func(context.Context, time.Duration) error
 }
 
 // Manager supervises independent Job Workers for one selected EBS process.
@@ -70,6 +71,9 @@ func newManagerWithDependencies(startup *RuntimeStartup, deps managerDependencie
 	}
 	if deps.preflight == nil {
 		deps.preflight = preflightJob
+	}
+	if deps.validateTargets == nil {
+		deps.validateTargets = validateAuthenticatedTargets
 	}
 	if deps.newWorker == nil {
 		deps.newWorker = NewWorker
@@ -98,6 +102,9 @@ func newManagerWithDependencies(startup *RuntimeStartup, deps managerDependencie
 }
 
 func (m *Manager) Run(ctx context.Context) error {
+	if err := m.deps.validateTargets(ctx, m.startup); err != nil {
+		return err
+	}
 	var wait sync.WaitGroup
 	for _, jobID := range m.order {
 		slot := m.jobs[jobID]

--- a/internal/migration/manager.go
+++ b/internal/migration/manager.go
@@ -1,0 +1,263 @@
+package migration
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/client"
+)
+
+type RuntimeState string
+
+const (
+	RuntimeInitializing RuntimeState = "INITIALIZING"
+	RuntimeRetrying     RuntimeState = "RETRYING"
+	RuntimeRunning      RuntimeState = "RUNNING"
+	RuntimeStopped      RuntimeState = "STOPPED"
+)
+
+const maximumRuntimeErrorBytes = 512
+
+type jobRuntimeSlot struct {
+	mu       sync.RWMutex
+	startup  *Startup
+	state    RuntimeState
+	worker   *Worker
+	attempts int
+	err      string
+}
+
+type jobRuntimeSnapshot struct {
+	Startup  *Startup
+	State    RuntimeState
+	Worker   *Worker
+	Attempts int
+	Error    string
+}
+
+type managerDependencies struct {
+	preflight func(context.Context, *Startup) (PreflightResult, error)
+	newWorker func(context.Context, *Startup) (*Worker, error)
+	runWorker func(context.Context, *Worker) error
+	wait      func(context.Context, time.Duration) error
+}
+
+// Manager supervises independent Job Workers for one selected EBS process.
+type Manager struct {
+	startup *RuntimeStartup
+	jobs    map[string]*jobRuntimeSlot
+	order   []string
+	deps    managerDependencies
+}
+
+func NewManager(startup *RuntimeStartup) (*Manager, error) {
+	return newManagerWithDependencies(startup, managerDependencies{})
+}
+
+func newManagerWithDependencies(startup *RuntimeStartup, deps managerDependencies) (*Manager, error) {
+	if startup == nil || startup.Config == nil || len(startup.Jobs) == 0 {
+		return nil, errors.New("Manager requires runtime startup configuration")
+	}
+	if deps.preflight == nil {
+		deps.preflight = Preflight
+	}
+	if deps.newWorker == nil {
+		deps.newWorker = NewWorker
+	}
+	if deps.runWorker == nil {
+		deps.runWorker = func(ctx context.Context, worker *Worker) error { return worker.Run(ctx) }
+	}
+	if deps.wait == nil {
+		deps.wait = waitForManagerRetry
+	}
+	manager := &Manager{
+		startup: startup, jobs: make(map[string]*jobRuntimeSlot, len(startup.Jobs)),
+		order: make([]string, 0, len(startup.Jobs)), deps: deps,
+	}
+	for _, job := range startup.Jobs {
+		if job == nil || validateJobID(job.Job.JobID) != nil {
+			return nil, errors.New("Manager requires valid Job startup identity")
+		}
+		if _, exists := manager.jobs[job.Job.JobID]; exists {
+			return nil, errors.New("Manager requires unique Job IDs")
+		}
+		manager.jobs[job.Job.JobID] = &jobRuntimeSlot{startup: job, state: RuntimeInitializing}
+		manager.order = append(manager.order, job.Job.JobID)
+	}
+	return manager, nil
+}
+
+func (m *Manager) Run(ctx context.Context) error {
+	var wait sync.WaitGroup
+	for _, jobID := range m.order {
+		slot := m.jobs[jobID]
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			m.runJob(ctx, slot)
+		}()
+	}
+	<-ctx.Done()
+	wait.Wait()
+	return nil
+}
+
+func (m *Manager) runJob(ctx context.Context, slot *jobRuntimeSlot) {
+	attempt := 0
+	for {
+		slot.setInitializing(attempt)
+		if _, err := m.deps.preflight(ctx, slot.startup); err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			if !retryableInitializationError(err) {
+				slot.stop(err)
+				return
+			}
+			slot.setRetrying(attempt+1, err)
+			if err := m.deps.wait(ctx, retryDelay(attempt, maxRetryDelay)); err != nil {
+				return
+			}
+			attempt++
+			continue
+		}
+		worker, err := m.deps.newWorker(ctx, slot.startup)
+		if err != nil {
+			if ctx.Err() != nil {
+				return
+			}
+			if !retryableInitializationError(err) {
+				slot.stop(err)
+				return
+			}
+			slot.setRetrying(attempt+1, err)
+			if err := m.deps.wait(ctx, retryDelay(attempt, maxRetryDelay)); err != nil {
+				return
+			}
+			attempt++
+			continue
+		}
+		slot.run(worker)
+		if err := m.deps.runWorker(ctx, worker); err != nil && ctx.Err() == nil {
+			slot.stop(err)
+		}
+		return
+	}
+}
+
+func (s *jobRuntimeSlot) setInitializing(attempts int) {
+	s.mu.Lock()
+	s.state, s.worker, s.attempts, s.err = RuntimeInitializing, nil, attempts, ""
+	s.mu.Unlock()
+}
+
+func (s *jobRuntimeSlot) setRetrying(attempts int, err error) {
+	s.mu.Lock()
+	s.state, s.worker, s.attempts, s.err = RuntimeRetrying, nil, attempts, boundedRuntimeError(err)
+	s.mu.Unlock()
+}
+
+func (s *jobRuntimeSlot) run(worker *Worker) {
+	s.mu.Lock()
+	s.state, s.worker, s.err = RuntimeRunning, worker, ""
+	s.mu.Unlock()
+}
+
+func (s *jobRuntimeSlot) stop(err error) {
+	s.mu.Lock()
+	s.state, s.worker, s.err = RuntimeStopped, nil, boundedRuntimeError(err)
+	s.mu.Unlock()
+}
+
+func (s *jobRuntimeSlot) snapshot() jobRuntimeSnapshot {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return jobRuntimeSnapshot{Startup: s.startup, State: s.state, Worker: s.worker, Attempts: s.attempts, Error: s.err}
+}
+
+func (m *Manager) snapshot(jobID string) (jobRuntimeSnapshot, bool) {
+	slot, ok := m.jobs[jobID]
+	if !ok {
+		return jobRuntimeSnapshot{}, false
+	}
+	return slot.snapshot(), true
+}
+
+func (m *Manager) snapshots(jobID string) ([]jobRuntimeSnapshot, error) {
+	if jobID != "" {
+		snapshot, ok := m.snapshot(jobID)
+		if !ok {
+			return nil, ErrIllegalAction
+		}
+		return []jobRuntimeSnapshot{snapshot}, nil
+	}
+	result := make([]jobRuntimeSnapshot, 0, len(m.order))
+	for _, id := range m.order {
+		result = append(result, m.jobs[id].snapshot())
+	}
+	return result, nil
+}
+
+func retryableInitializationError(err error) bool {
+	if isAuthError(err) || retryableWorkerError(err) || errors.Is(err, fs.ErrPermission) {
+		return true
+	}
+	var status *client.StatusError
+	if errors.As(err, &status) {
+		return status.StatusCode == http.StatusTooManyRequests || status.StatusCode >= 500
+	}
+	var network net.Error
+	return errors.As(err, &network)
+}
+
+func waitForManagerRetry(ctx context.Context, delay time.Duration) error {
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}
+
+func boundedRuntimeError(err error) string {
+	if err == nil {
+		return ""
+	}
+	message := err.Error()
+	var status *client.StatusError
+	if errors.As(err, &status) {
+		message = fmt.Sprintf("drive9 request failed: HTTP %d", status.StatusCode)
+	}
+	message = strings.Join(strings.Fields(message), " ")
+	runes := []rune(message)
+	if len(runes) <= maximumRuntimeErrorBytes {
+		return message
+	}
+	return string(runes[:maximumRuntimeErrorBytes])
+}
+
+func RunManager(ctx context.Context, startup *RuntimeStartup) error {
+	return RunManagerAt(ctx, startup, DefaultControlSocket)
+}
+
+func RunManagerAt(ctx context.Context, startup *RuntimeStartup, socket string) error {
+	manager, err := NewManager(startup)
+	if err != nil {
+		return err
+	}
+	control, err := startControl(ctx, socket, manager)
+	if err != nil {
+		return err
+	}
+	defer control.close()
+	return manager.Run(ctx)
+}

--- a/internal/migration/manager_test.go
+++ b/internal/migration/manager_test.go
@@ -74,6 +74,31 @@ func TestManagerValidatesSharedMappingsBeforeJobLoops(t *testing.T) {
 	}
 }
 
+func TestManagerAuthenticatedTargetGateFailsBeforeJobLoops(t *testing.T) {
+	gateErr := errors.New("authenticated target overlap")
+	var preflightCalls, workerCalls int
+	manager, err := newManagerWithDependencies(testRuntimeStartup("job-a", "job-b"), managerDependencies{
+		validateTargets: func(context.Context, *RuntimeStartup) error { return gateErr },
+		preflight: func(context.Context, *Startup) (PreflightResult, error) {
+			preflightCalls++
+			return PreflightResult{}, nil
+		},
+		newWorker: func(context.Context, *Startup) (*Worker, error) {
+			workerCalls++
+			return &Worker{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manager.Run(context.Background()); !errors.Is(err, gateErr) {
+		t.Fatalf("manager error = %v, want target gate error", err)
+	}
+	if preflightCalls != 0 || workerCalls != 0 {
+		t.Fatalf("target gate failure reached preflight=%d worker=%d", preflightCalls, workerCalls)
+	}
+}
+
 func TestManagerRetriesOneJobWithoutBlockingSibling(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -81,6 +106,7 @@ func TestManagerRetriesOneJobWithoutBlockingSibling(t *testing.T) {
 	calls := make(map[string]int)
 	running := make(chan string, 2)
 	manager, err := newManagerWithDependencies(testRuntimeStartup("job-a", "job-b"), managerDependencies{
+		validateTargets: func(context.Context, *RuntimeStartup) error { return nil },
 		preflight: func(_ context.Context, startup *Startup) (PreflightResult, error) {
 			mu.Lock()
 			calls[startup.Job.JobID]++
@@ -132,6 +158,7 @@ func TestManagerPermanentFailureStopsOnlyOneJob(t *testing.T) {
 	failed := make(chan struct{}, 1)
 	running := make(chan struct{}, 1)
 	manager, err := newManagerWithDependencies(testRuntimeStartup("job-a", "job-b"), managerDependencies{
+		validateTargets: func(context.Context, *RuntimeStartup) error { return nil },
 		preflight: func(_ context.Context, startup *Startup) (PreflightResult, error) {
 			if startup.Job.JobID == "job-a" {
 				failed <- struct{}{}

--- a/internal/migration/manager_test.go
+++ b/internal/migration/manager_test.go
@@ -15,7 +15,28 @@ import (
 )
 
 func testRuntimeStartup(jobIDs ...string) *RuntimeStartup {
-	config := &Config{Version: ConfigVersion}
+	configuredJobs := make([]JobConfig, 0, len(jobIDs))
+	spaces := make(map[string]SpaceConfig, len(jobIDs))
+	for _, jobID := range jobIDs {
+		configuredJobs = append(configuredJobs, JobConfig{
+			JobID: jobID, Subpath: "/" + jobID,
+			Target: TargetConfig{SpaceRef: jobID, Prefix: "/"},
+		})
+		spaces[jobID] = SpaceConfig{CredentialRef: jobID + "-key"}
+	}
+	config := &Config{
+		Version: ConfigVersion, Drive9: Drive9Config{Endpoint: "https://drive9.example.com"},
+		JobDefaults: JobDefaults{
+			Sync: SyncDefaults{GracePeriod: Duration(DefaultGracePeriod)},
+			Performance: PerformanceDefaults{
+				MaxBytesPerSecond: 1024, SmallFileWorkers: 1, LargeFileWorkers: 1,
+			},
+		},
+		Spaces: spaces,
+		EBSSources: []EBSSourceConfig{{
+			VolumeID: "vol-001", NodeName: "node-a", Root: "/ebs", Jobs: configuredJobs,
+		}},
+	}
 	runtime := &RuntimeStartup{
 		Config: config, Source: EBSSourceConfig{VolumeID: "vol-001", NodeName: "node-a", Root: "/ebs"},
 		Phase: PhaseSyncing,
@@ -23,11 +44,34 @@ func testRuntimeStartup(jobIDs ...string) *RuntimeStartup {
 	for _, jobID := range jobIDs {
 		runtime.Jobs = append(runtime.Jobs, &Startup{
 			Config: config,
-			Job:    Job{JobID: jobID, VolumeID: "vol-001", NodeName: "node-a", EBSRoot: "/ebs", Subpath: "/" + jobID, Source: SourceConfig{Type: "ebs", Root: "/ebs/" + jobID}},
-			Phase:  PhaseSyncing,
+			Job: Job{
+				JobID: jobID, VolumeID: "vol-001", NodeName: "node-a", EBSRoot: "/ebs",
+				Subpath: "/" + jobID, Source: SourceConfig{Type: "ebs", Root: "/ebs/" + jobID},
+				Target: TargetConfig{SpaceRef: jobID, Prefix: "/"},
+			},
+			Space: spaces[jobID],
+			Phase: PhaseSyncing,
 		})
 	}
 	return runtime
+}
+
+func TestManagerValidatesSharedMappingsBeforeJobLoops(t *testing.T) {
+	runtime := testRuntimeStartup("job-a", "job-b")
+	runtime.Config.EBSSources[0].Jobs[1].Target.Prefix = ControlPrefix + "/unsafe"
+	preflightCalls := 0
+	manager, err := newManagerWithDependencies(runtime, managerDependencies{
+		preflight: func(context.Context, *Startup) (PreflightResult, error) {
+			preflightCalls++
+			return PreflightResult{}, nil
+		},
+	})
+	if err == nil || manager != nil {
+		t.Fatalf("invalid shared mapping manager=%+v error=%v", manager, err)
+	}
+	if preflightCalls != 0 {
+		t.Fatalf("preflight calls=%d, want 0", preflightCalls)
+	}
 }
 
 func TestManagerRetriesOneJobWithoutBlockingSibling(t *testing.T) {

--- a/internal/migration/manager_test.go
+++ b/internal/migration/manager_test.go
@@ -1,0 +1,217 @@
+package migration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/mem9-ai/drive9/pkg/client"
+)
+
+func testRuntimeStartup(jobIDs ...string) *RuntimeStartup {
+	config := &Config{Version: ConfigVersion}
+	runtime := &RuntimeStartup{
+		Config: config, Source: EBSSourceConfig{VolumeID: "vol-001", NodeName: "node-a", Root: "/ebs"},
+		Phase: PhaseSyncing,
+	}
+	for _, jobID := range jobIDs {
+		runtime.Jobs = append(runtime.Jobs, &Startup{
+			Config: config,
+			Job:    Job{JobID: jobID, VolumeID: "vol-001", NodeName: "node-a", EBSRoot: "/ebs", Subpath: "/" + jobID, Source: SourceConfig{Type: "ebs", Root: "/ebs/" + jobID}},
+			Phase:  PhaseSyncing,
+		})
+	}
+	return runtime
+}
+
+func TestManagerRetriesOneJobWithoutBlockingSibling(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var mu sync.Mutex
+	calls := make(map[string]int)
+	running := make(chan string, 2)
+	manager, err := newManagerWithDependencies(testRuntimeStartup("job-a", "job-b"), managerDependencies{
+		preflight: func(_ context.Context, startup *Startup) (PreflightResult, error) {
+			mu.Lock()
+			calls[startup.Job.JobID]++
+			attempt := calls[startup.Job.JobID]
+			mu.Unlock()
+			if startup.Job.JobID == "job-a" && attempt == 1 {
+				return PreflightResult{}, &client.StatusError{StatusCode: http.StatusServiceUnavailable}
+			}
+			return PreflightResult{}, nil
+		},
+		newWorker: func(_ context.Context, startup *Startup) (*Worker, error) {
+			return &Worker{startup: startup}, nil
+		},
+		runWorker: func(ctx context.Context, worker *Worker) error {
+			running <- worker.startup.Job.JobID
+			<-ctx.Done()
+			return nil
+		},
+		wait: func(context.Context, time.Duration) error { return nil },
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- manager.Run(ctx) }()
+	seen := map[string]bool{}
+	for len(seen) < 2 {
+		select {
+		case jobID := <-running:
+			seen[jobID] = true
+		case <-time.After(time.Second):
+			t.Fatalf("running Jobs=%v", seen)
+		}
+	}
+	mu.Lock()
+	if calls["job-a"] != 2 || calls["job-b"] != 1 {
+		t.Fatalf("preflight calls=%v", calls)
+	}
+	mu.Unlock()
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestManagerPermanentFailureStopsOnlyOneJob(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	failed := make(chan struct{}, 1)
+	running := make(chan struct{}, 1)
+	manager, err := newManagerWithDependencies(testRuntimeStartup("job-a", "job-b"), managerDependencies{
+		preflight: func(_ context.Context, startup *Startup) (PreflightResult, error) {
+			if startup.Job.JobID == "job-a" {
+				failed <- struct{}{}
+				return PreflightResult{}, ErrCheckpointMismatch
+			}
+			return PreflightResult{}, nil
+		},
+		newWorker: func(_ context.Context, startup *Startup) (*Worker, error) {
+			return &Worker{startup: startup}, nil
+		},
+		runWorker: func(ctx context.Context, _ *Worker) error {
+			running <- struct{}{}
+			<-ctx.Done()
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- manager.Run(ctx) }()
+	select {
+	case <-failed:
+	case <-time.After(time.Second):
+		t.Fatal("failing Job did not run preflight")
+	}
+	select {
+	case <-running:
+	case <-time.After(time.Second):
+		t.Fatal("healthy sibling did not run")
+	}
+	deadline := time.Now().Add(time.Second)
+	for {
+		snapshot, ok := manager.snapshot("job-a")
+		if ok && snapshot.State == RuntimeStopped {
+			if !strings.Contains(snapshot.Error, ErrCheckpointMismatch.Error()) {
+				t.Fatalf("stopped snapshot=%+v", snapshot)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("job-a snapshot=%+v", snapshot)
+		}
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestManagerControlReportsStartupOnlyJobsAndRejectsUnscopedMutation(t *testing.T) {
+	manager, err := NewManager(testRuntimeStartup("job-a", "job-b"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	socket := testControlSocket(t)
+	server, err := startControl(ctx, socket, manager)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer server.close()
+	var output bytes.Buffer
+	if err := Control(ctx, socket, ControlRequest{Command: "status", Output: "json"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	var status EBSStatusOutput
+	if err := json.Unmarshal(output.Bytes(), &status); err != nil {
+		t.Fatal(err)
+	}
+	if status.VolumeID != "vol-001" || len(status.Jobs) != 2 {
+		t.Fatalf("status=%+v", status)
+	}
+	for _, job := range status.Jobs {
+		if job.RuntimeState != RuntimeInitializing || job.Phase != "" || job.StartupPhase != PhaseSyncing {
+			t.Fatalf("startup-only Job=%+v", job)
+		}
+	}
+	output.Reset()
+	if err := Control(ctx, socket, ControlRequest{Command: "status", JobID: "job-a", Output: "json"}, &output); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(output.Bytes(), &status); err != nil || len(status.Jobs) != 1 || status.Jobs[0].JobID != "job-a" {
+		t.Fatalf("filtered status=%+v err=%v", status, err)
+	}
+	if err := Control(ctx, socket, ControlRequest{Command: "verify-full"}, &bytes.Buffer{}); !errors.Is(err, ErrIllegalAction) {
+		t.Fatalf("unscoped mutation error=%v", err)
+	}
+}
+
+func TestManagerMutationGatesAreIndependentPerJob(t *testing.T) {
+	manager, err := NewManager(testRuntimeStartup("job-a", "job-b"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, jobID := range []string{"job-a", "job-b"} {
+		slot := manager.jobs[jobID]
+		slot.run(&Worker{startup: slot.startup})
+	}
+	releaseA, err := manager.prepareControl(context.Background(), ControlRequest{Command: "verify-full", JobID: "job-a"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer releaseA()
+	releaseB, err := manager.prepareControl(context.Background(), ControlRequest{Command: "verify-full", JobID: "job-b"})
+	if err != nil {
+		t.Fatalf("Job B was blocked by Job A: %v", err)
+	}
+	releaseB()
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if _, err := manager.prepareControl(ctx, ControlRequest{Command: "verify-full", JobID: "job-a"}); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("second Job A mutation error=%v", err)
+	}
+}
+
+func TestBoundedRuntimeErrorRedactsHTTPBodyAndPreservesUTF8(t *testing.T) {
+	message := boundedRuntimeError(&client.StatusError{StatusCode: http.StatusServiceUnavailable, Message: "secret response body"})
+	if message != "drive9 request failed: HTTP 503" {
+		t.Fatalf("HTTP error=%q", message)
+	}
+	message = boundedRuntimeError(errors.New(strings.Repeat("界", maximumRuntimeErrorBytes+1)))
+	if len([]rune(message)) != maximumRuntimeErrorBytes || !strings.HasSuffix(message, "界") {
+		t.Fatalf("bounded UTF-8 error has %d runes", len([]rune(message)))
+	}
+}

--- a/internal/migration/preflight.go
+++ b/internal/migration/preflight.go
@@ -14,8 +14,9 @@ import (
 const ControlPrefix = "/.drive9-migration"
 
 var (
-	ErrPreflight  = errors.New("migration preflight failed")
-	ErrPlanFailed = errors.New("migration plan has failed Jobs")
+	ErrPreflight              = errors.New("migration preflight failed")
+	ErrPlanFailed             = errors.New("migration plan has failed Jobs")
+	ErrTargetIdentityMismatch = errors.New("authenticated target identity mismatch")
 )
 
 type PreflightResult struct {
@@ -76,6 +77,15 @@ func Plan(ctx context.Context, startup *RuntimeStartup) (PlanResult, error) {
 	if err := ValidateMappings(startup.Config); err != nil {
 		return result, fmt.Errorf("%w: static mapping: %v", ErrPreflight, err)
 	}
+	if err := validateAuthenticatedTargets(ctx, startup); err != nil {
+		message := boundedRuntimeError(err)
+		for _, job := range startup.Jobs {
+			result.Jobs = append(result.Jobs, PlanJobResult{
+				JobID: job.Job.JobID, Subpath: job.Job.Subpath, Target: job.Job.Target, Error: message,
+			})
+		}
+		return result, ErrPlanFailed
+	}
 	if _, err := sourceMountProbeFor(startup.Jobs[0])(startup.Source.Root, startup.Source.VolumeID); err != nil {
 		message := boundedRuntimeError(err)
 		for _, job := range startup.Jobs {
@@ -101,6 +111,67 @@ func Plan(ctx context.Context, startup *RuntimeStartup) (PlanResult, error) {
 		return result, ErrPlanFailed
 	}
 	return result, nil
+}
+
+func validateAuthenticatedTargets(ctx context.Context, startup *RuntimeStartup) error {
+	if startup == nil || startup.Config == nil {
+		return fmt.Errorf("%w: missing runtime startup", ErrPreflight)
+	}
+	if err := ValidateMappings(startup.Config); err != nil {
+		return fmt.Errorf("%w: static mapping: %v", ErrPreflight, err)
+	}
+	resolved := make(map[string]string, len(startup.targetCredentials))
+	for _, job := range startup.Config.Jobs {
+		spaceRef := job.Target.SpaceRef
+		if _, exists := resolved[spaceRef]; exists {
+			continue
+		}
+		credential, exists := startup.targetCredentials[spaceRef]
+		if !exists {
+			return fmt.Errorf("%w: missing credential source for Space %q", ErrPreflight, spaceRef)
+		}
+		key, _, err := credential.readStable()
+		if err != nil {
+			return fmt.Errorf("%w: credential for Space %q: %w", ErrPreflight, spaceRef, err)
+		}
+		tenantID, err := client.New(startup.Config.Drive9.Endpoint, key).GetMigrationTenantID(ctx)
+		if err != nil {
+			return fmt.Errorf("%w: target identity for Space %q: %w", ErrPreflight, spaceRef, err)
+		}
+		resolved[spaceRef] = tenantID
+	}
+
+	byTarget := make(map[string][]string)
+	targetOrder := make([]string, 0, len(resolved))
+	for _, job := range startup.Config.Jobs {
+		tenantID, exists := resolved[job.Target.SpaceRef]
+		if !exists {
+			return fmt.Errorf("%w: unresolved target identity for Space %q", ErrPreflight, job.Target.SpaceRef)
+		}
+		identity := startup.Config.Drive9.Endpoint + "\x00" + tenantID
+		if _, exists := byTarget[identity]; !exists {
+			targetOrder = append(targetOrder, identity)
+		}
+		byTarget[identity] = append(byTarget[identity], job.Target.Prefix)
+	}
+	for _, identity := range targetOrder {
+		prefixes := byTarget[identity]
+		for index, left := range prefixes {
+			if left == "/" && len(prefixes) > 1 {
+				return fmt.Errorf("%w: authenticated target root prefix cannot be shared", ErrPreflight)
+			}
+			for _, right := range prefixes[index+1:] {
+				if prefixesOverlap(left, right) {
+					return fmt.Errorf("%w: authenticated target has overlapping prefixes %q and %q", ErrPreflight, left, right)
+				}
+			}
+		}
+	}
+
+	for _, job := range startup.Jobs {
+		job.acceptedTenantID = resolved[job.Job.Target.SpaceRef]
+	}
+	return nil
 }
 
 // ValidateMappings checks the complete batch before any selected-Job probe.
@@ -238,6 +309,9 @@ func preflightWithProbeValidation(ctx context.Context, startup *Startup, probe f
 	if missing != "" {
 		return PreflightResult{}, fmt.Errorf("%w: required capability %s is unavailable", ErrPreflight, missing)
 	}
+	if err := verifyAuthenticatedTenant(ctx, api, startup); err != nil {
+		return PreflightResult{}, fmt.Errorf("%w: %w", ErrPreflight, err)
+	}
 	maxUploadBytes, inlineThreshold := api.MaxUploadBytes(ctx), api.CachedSmallFileThreshold()
 	distribution, err := fileDistribution(scan, maxUploadBytes, inlineThreshold)
 	if err != nil {
@@ -290,6 +364,23 @@ func preflightWithProbeValidation(ctx context.Context, startup *Startup, probe f
 		MaxUploadBytes: maxUploadBytes, InlineThreshold: inlineThreshold,
 		TargetEmpty: targetEmpty, RecoveryControlPresent: recoveryControlPresent,
 	}, nil
+}
+
+func verifyAuthenticatedTenant(ctx context.Context, api *client.Client, startup *Startup) error {
+	if api == nil || startup == nil {
+		return fmt.Errorf("%w: missing target identity input", ErrTargetIdentityMismatch)
+	}
+	if startup.acceptedTenantID == "" {
+		return fmt.Errorf("%w: batch gate did not accept a tenant", ErrTargetIdentityMismatch)
+	}
+	tenantID, err := api.GetMigrationTenantID(ctx)
+	if err != nil {
+		return fmt.Errorf("target identity: %w", err)
+	}
+	if tenantID != startup.acceptedTenantID {
+		return fmt.Errorf("%w: credential resolved to another tenant", ErrTargetIdentityMismatch)
+	}
+	return nil
 }
 
 func verifySourceReadAccess(ctx context.Context, scanner *Scanner, scan ScanResult) error {

--- a/internal/migration/preflight.go
+++ b/internal/migration/preflight.go
@@ -13,11 +13,17 @@ import (
 
 const ControlPrefix = "/.drive9-migration"
 
-var ErrPreflight = errors.New("migration preflight failed")
+var (
+	ErrPreflight  = errors.New("migration preflight failed")
+	ErrPlanFailed = errors.New("migration plan has failed Jobs")
+)
 
 type PreflightResult struct {
+	JobID                   string  `json:"job_id"`
 	VolumeID                string  `json:"volume_id"`
 	NodeName                string  `json:"node_name"`
+	EBSRoot                 string  `json:"ebs_root"`
+	Subpath                 string  `json:"subpath"`
 	SourceRoot              string  `json:"source_root"`
 	SpaceRef                string  `json:"space_ref"`
 	Prefix                  string  `json:"prefix"`
@@ -43,6 +49,60 @@ type PreflightResult struct {
 	RecoveryControlPresent  bool    `json:"recovery_control_present"`
 }
 
+type PlanJobResult struct {
+	JobID   string           `json:"job_id"`
+	Subpath string           `json:"subpath"`
+	Target  TargetConfig     `json:"target"`
+	Result  *PreflightResult `json:"result,omitempty"`
+	Error   string           `json:"error,omitempty"`
+}
+
+type PlanResult struct {
+	VolumeID string          `json:"volume_id"`
+	NodeName string          `json:"node_name"`
+	EBSRoot  string          `json:"ebs_root"`
+	Jobs     []PlanJobResult `json:"jobs"`
+}
+
+// Plan checks every configured Job for one selected EBS and retains partial results.
+func Plan(ctx context.Context, startup *RuntimeStartup) (PlanResult, error) {
+	if startup == nil || startup.Config == nil || len(startup.Jobs) == 0 {
+		return PlanResult{}, fmt.Errorf("%w: missing runtime startup", ErrPreflight)
+	}
+	result := PlanResult{
+		VolumeID: startup.Source.VolumeID, NodeName: startup.Source.NodeName,
+		EBSRoot: startup.Source.Root, Jobs: make([]PlanJobResult, 0, len(startup.Jobs)),
+	}
+	if err := ValidateMappings(startup.Config); err != nil {
+		return result, fmt.Errorf("%w: static mapping: %v", ErrPreflight, err)
+	}
+	if _, err := sourceMountProbeFor(startup.Jobs[0])(startup.Source.Root, startup.Source.VolumeID); err != nil {
+		message := boundedRuntimeError(err)
+		for _, job := range startup.Jobs {
+			result.Jobs = append(result.Jobs, PlanJobResult{
+				JobID: job.Job.JobID, Subpath: job.Job.Subpath, Target: job.Job.Target, Error: message,
+			})
+		}
+		return result, ErrPlanFailed
+	}
+	failed := false
+	for _, job := range startup.Jobs {
+		planned := PlanJobResult{JobID: job.Job.JobID, Subpath: job.Job.Subpath, Target: job.Job.Target}
+		preflight, err := Preflight(ctx, job)
+		if err != nil {
+			planned.Error = boundedRuntimeError(err)
+			failed = true
+		} else {
+			planned.Result = &preflight
+		}
+		result.Jobs = append(result.Jobs, planned)
+	}
+	if failed {
+		return result, ErrPlanFailed
+	}
+	return result, nil
+}
+
 // ValidateMappings checks the complete batch before any selected-Job probe.
 func ValidateMappings(cfg *Config) error {
 	if cfg == nil {
@@ -52,12 +112,7 @@ func ValidateMappings(cfg *Config) error {
 		return err
 	}
 	byCredential := make(map[string][]string)
-	nodes := make(map[string]struct{})
 	for _, job := range cfg.Jobs {
-		if _, exists := nodes[job.NodeName]; exists {
-			return fmt.Errorf("duplicate node_name %q", job.NodeName)
-		}
-		nodes[job.NodeName] = struct{}{}
 		prefix, err := validateTargetPrefix(job.Target.Prefix)
 		if err != nil {
 			return fmt.Errorf("job %q: %w", job.VolumeID, err)
@@ -123,7 +178,7 @@ func preflightWithProbe(ctx context.Context, startup *Startup, probe func(string
 	if err := ValidateMappings(startup.Config); err != nil {
 		return PreflightResult{}, fmt.Errorf("%w: static mapping: %v", ErrPreflight, err)
 	}
-	initialMountIdentity, err := probe(startup.Job.Source.Root, startup.Job.VolumeID)
+	initialMountIdentity, err := observeJobSource(startup, probe)
 	if err != nil {
 		return PreflightResult{}, fmt.Errorf("%w: initial volume identity: %w", ErrPreflight, err)
 	}
@@ -153,7 +208,7 @@ func preflightWithProbe(ctx context.Context, startup *Startup, probe func(string
 			}
 		}
 	}
-	mountIdentity, err := probe(startup.Job.Source.Root, startup.Job.VolumeID)
+	mountIdentity, err := observeJobSource(startup, probe)
 	if err != nil {
 		return PreflightResult{}, fmt.Errorf("%w: final volume identity: %w", ErrPreflight, err)
 	}
@@ -178,7 +233,7 @@ func preflightWithProbe(ctx context.Context, startup *Startup, probe func(string
 	if err != nil {
 		return PreflightResult{}, fmt.Errorf("%w: %w", ErrPreflight, err)
 	}
-	checkpoint, err := NewCheckpointStore(api).Load(ctx, startup.Job.VolumeID)
+	checkpoint, err := NewCheckpointStore(api).Load(ctx, startup.Job.JobID)
 	if err != nil {
 		return PreflightResult{}, fmt.Errorf("%w: checkpoint: %w", ErrPreflight, err)
 	}
@@ -211,7 +266,8 @@ func preflightWithProbe(ctx context.Context, startup *Startup, probe func(string
 	}
 	startup.acceptedSource = initialMountIdentity
 	return PreflightResult{
-		VolumeID: startup.Job.VolumeID, NodeName: startup.Job.NodeName,
+		JobID: startup.Job.JobID, VolumeID: startup.Job.VolumeID, NodeName: startup.Job.NodeName,
+		EBSRoot: startup.Job.EBSRoot, Subpath: startup.Job.Subpath,
 		SourceRoot: startup.Job.Source.Root, SpaceRef: startup.Job.Target.SpaceRef,
 		Prefix: startup.Job.Target.Prefix, CredentialRef: startup.Space.CredentialRef,
 		ConfigHash: startup.ConfigHash, ControlPrefix: ControlPrefix,

--- a/internal/migration/preflight.go
+++ b/internal/migration/preflight.go
@@ -88,7 +88,7 @@ func Plan(ctx context.Context, startup *RuntimeStartup) (PlanResult, error) {
 	failed := false
 	for _, job := range startup.Jobs {
 		planned := PlanJobResult{JobID: job.Job.JobID, Subpath: job.Job.Subpath, Target: job.Job.Target}
-		preflight, err := Preflight(ctx, job)
+		preflight, err := preflightJob(ctx, job)
 		if err != nil {
 			planned.Error = boundedRuntimeError(err)
 			failed = true
@@ -155,6 +155,10 @@ func Preflight(ctx context.Context, startup *Startup) (PreflightResult, error) {
 	return preflightWithProbe(ctx, startup, sourceMountProbeFor(startup), nil)
 }
 
+func preflightJob(ctx context.Context, startup *Startup) (PreflightResult, error) {
+	return preflightWithProbeValidation(ctx, startup, sourceMountProbeFor(startup), nil, false)
+}
+
 func preflightWithVerifier(ctx context.Context, startup *Startup, verifyVolume func(string, string) (bool, error)) (PreflightResult, error) {
 	return preflightWithChecks(ctx, startup, verifyVolume, nil)
 }
@@ -172,11 +176,17 @@ func preflightWithChecks(ctx context.Context, startup *Startup, verifyVolume fun
 }
 
 func preflightWithProbe(ctx context.Context, startup *Startup, probe func(string, string) (sourceMountIdentity, error), openFile func(*os.Root, string) (*os.File, error)) (PreflightResult, error) {
+	return preflightWithProbeValidation(ctx, startup, probe, openFile, true)
+}
+
+func preflightWithProbeValidation(ctx context.Context, startup *Startup, probe func(string, string) (sourceMountIdentity, error), openFile func(*os.Root, string) (*os.File, error), validateMappings bool) (PreflightResult, error) {
 	if startup == nil || startup.Config == nil {
 		return PreflightResult{}, fmt.Errorf("%w: missing startup snapshot", ErrPreflight)
 	}
-	if err := ValidateMappings(startup.Config); err != nil {
-		return PreflightResult{}, fmt.Errorf("%w: static mapping: %v", ErrPreflight, err)
+	if validateMappings {
+		if err := ValidateMappings(startup.Config); err != nil {
+			return PreflightResult{}, fmt.Errorf("%w: static mapping: %v", ErrPreflight, err)
+		}
 	}
 	initialMountIdentity, err := observeJobSource(startup, probe)
 	if err != nil {

--- a/internal/migration/preflight_test.go
+++ b/internal/migration/preflight_test.go
@@ -15,26 +15,38 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/client"
 	"golang.org/x/sys/unix"
+	"gopkg.in/yaml.v3"
 )
 
 func mappingConfig(t *testing.T, jobs string) *Config {
 	t.Helper()
-	body := strings.Replace(validConfigYAML, `jobs:
-  - volume_id: vol-001
-    node_name: node-a
-    source:
-      type: ebs
-      root: /ebs/001
-    target:
-      space_ref: space-001
-      prefix: /
-`, "jobs:\n"+jobs, 1)
-	if body == validConfigYAML {
-		t.Fatal("jobs block was not replaced; validConfigYAML drifted")
+	var legacy []struct {
+		VolumeID string       `yaml:"volume_id"`
+		NodeName string       `yaml:"node_name"`
+		Source   SourceConfig `yaml:"source"`
+		Target   TargetConfig `yaml:"target"`
 	}
-	cfg, err := LoadConfig(writeConfig(t, body))
-	if err != nil {
+	if err := yaml.Unmarshal([]byte(jobs), &legacy); err != nil {
 		t.Fatal(err)
+	}
+	cfg := &Config{
+		Version: ConfigVersion, Drive9: Drive9Config{Endpoint: "https://drive9.example.com"},
+		JobDefaults: JobDefaults{
+			Sync: SyncDefaults{GracePeriod: Duration(DefaultGracePeriod)},
+			Performance: PerformanceDefaults{
+				MaxBytesPerSecond: 1024, SmallFileWorkers: 2, LargeFileWorkers: 1,
+			},
+		},
+		Spaces:     map[string]SpaceConfig{"space-001": {CredentialRef: "space-001-key"}},
+		EBSSources: make([]EBSSourceConfig, 0, len(legacy)),
+	}
+	for _, job := range legacy {
+		cfg.EBSSources = append(cfg.EBSSources, EBSSourceConfig{
+			VolumeID: job.VolumeID, NodeName: job.NodeName, Root: job.Source.Root,
+			Jobs: []JobConfig{{
+				JobID: job.VolumeID + "-root", Subpath: "/", Target: job.Target,
+			}},
+		})
 	}
 	return cfg
 }
@@ -141,7 +153,7 @@ func TestValidateMappingsUsesCredentialMappingForSpaceAliases(t *testing.T) {
     target: {space_ref: space-001, prefix: /other}
 `)
 		cfg.Spaces["alias"] = SpaceConfig{CredentialRef: aliasCredential}
-		cfg.Jobs[1].Target = TargetConfig{SpaceRef: "alias", Prefix: aliasPrefix}
+		cfg.EBSSources[1].Jobs[0].Target = TargetConfig{SpaceRef: "alias", Prefix: aliasPrefix}
 		return cfg
 	}
 
@@ -535,9 +547,12 @@ func TestPreflightStaticMappingFailsBeforeRemoteCall(t *testing.T) {
 	}))
 	defer srv.Close()
 	startup := preflightStartup(t, srv.URL, root)
-	startup.Config.Jobs = append(startup.Config.Jobs, Job{
-		VolumeID: "vol-002", NodeName: "node-b", Source: SourceConfig{Type: "ebs", Root: "/ebs/002"},
-		Target: TargetConfig{SpaceRef: "space-001", Prefix: "/sub"},
+	startup.Config.EBSSources = append(startup.Config.EBSSources, EBSSourceConfig{
+		VolumeID: "vol-002", NodeName: "node-a", Root: "/ebs/002",
+		Jobs: []JobConfig{{
+			JobID: "vol-002-root", Subpath: "/",
+			Target: TargetConfig{SpaceRef: "space-001", Prefix: "/sub"},
+		}},
 	})
 	_, err := Preflight(context.Background(), startup)
 	if !errors.Is(err, ErrPreflight) || hits.Load() != 0 {
@@ -569,5 +584,50 @@ func TestPreflightPreservesOldServerAndTypedClientErrors(t *testing.T) {
 				t.Fatalf("typed error=%T %v", err, err)
 			}
 		})
+	}
+}
+
+func TestPlanRetainsAllJobResultsOnPartialFailure(t *testing.T) {
+	root := t.TempDir()
+	for _, subpath := range []string{"A", "B"} {
+		if err := os.Mkdir(filepath.Join(root, subpath), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, subpath, "file"), []byte(subpath), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.URL.Path == "/v1/status":
+			_, _ = w.Write([]byte(`{"max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
+		case r.Method == http.MethodHead && strings.HasSuffix(r.URL.Path, "/checkpoint.json"):
+			http.NotFound(w, r)
+		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []client.FileInfo{{Name: ".drive9-migration", IsDir: true}}})
+		default:
+			http.Error(w, "unexpected", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+	body := strings.Replace(validV4ConfigYAML, "https://drive9.example.com", server.URL, 1)
+	body = strings.Replace(body, "/ebs/001", root, 1)
+	secretRoot := t.TempDir()
+	if err := os.WriteFile(filepath.Join(secretRoot, "space-a-key"), []byte("owner-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	runtime, err := LoadRuntimeStartup(writeConfig(t, body), "node-a", string(PhaseSyncing), secretRoot, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, job := range runtime.Jobs {
+		job.mountProbe = testMountedSourceProbe
+	}
+	result, err := Plan(context.Background(), runtime)
+	if !errors.Is(err, ErrPlanFailed) {
+		t.Fatalf("plan error=%v", err)
+	}
+	if len(result.Jobs) != 2 || result.Jobs[0].Result == nil || result.Jobs[0].Error != "" || result.Jobs[1].Result != nil || result.Jobs[1].Error == "" {
+		t.Fatalf("plan=%+v", result)
 	}
 }

--- a/internal/migration/preflight_test.go
+++ b/internal/migration/preflight_test.go
@@ -169,6 +169,142 @@ func TestValidateMappingsUsesCredentialMappingForSpaceAliases(t *testing.T) {
 	}
 }
 
+func TestValidateAuthenticatedTargetsUsesTenantIdentity(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		tenantA     string
+		tenantB     string
+		prefixA     string
+		prefixB     string
+		wantErr     bool
+		crossSource bool
+	}{
+		{name: "same tenant equal", tenantA: "tenant-1", tenantB: "tenant-1", prefixA: "/team", prefixB: "/team", wantErr: true},
+		{name: "same tenant ancestor", tenantA: "tenant-1", tenantB: "tenant-1", prefixA: "/team", prefixB: "/team/sub", wantErr: true},
+		{name: "same tenant segment distinct", tenantA: "tenant-1", tenantB: "tenant-1", prefixA: "/team", prefixB: "/team-2"},
+		{name: "different tenants equal", tenantA: "tenant-1", tenantB: "tenant-2", prefixA: "/team", prefixB: "/team"},
+		{name: "cross source overlap", tenantA: "tenant-1", tenantB: "tenant-1", prefixA: "/team", prefixB: "/team/sub", wantErr: true, crossSource: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			runtime, closeServer := authenticatedTargetRuntime(t, tc.tenantA, tc.tenantB, tc.prefixA, tc.prefixB, tc.crossSource)
+			defer closeServer()
+
+			err := validateAuthenticatedTargets(context.Background(), runtime)
+			if tc.wantErr && err == nil {
+				t.Fatal("overlapping authenticated targets were accepted")
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatal(err)
+			}
+			if !tc.wantErr {
+				if runtime.Jobs[0].acceptedTenantID != tc.tenantA {
+					t.Fatalf("accepted tenant ID = %q, want %q", runtime.Jobs[0].acceptedTenantID, tc.tenantA)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAuthenticatedTargetsRejectsMissingTenantIdentity(t *testing.T) {
+	runtime, closeServer := authenticatedTargetRuntime(t, "", "tenant-2", "/a", "/b", false)
+	defer closeServer()
+
+	err := validateAuthenticatedTargets(context.Background(), runtime)
+	if !errors.Is(err, client.ErrMigrationUnsupported) {
+		t.Fatalf("error = %v, want ErrMigrationUnsupported", err)
+	}
+	for _, job := range runtime.Jobs {
+		if job.acceptedTenantID != "" {
+			t.Fatalf("partially accepted tenant identity for %s", job.Job.JobID)
+		}
+	}
+}
+
+func TestPlanAuthenticatedTargetGateFailureMarksEverySelectedJob(t *testing.T) {
+	runtime, closeServer := authenticatedTargetRuntime(t, "tenant-1", "tenant-1", "/team", "/team/sub", false)
+	defer closeServer()
+	root := t.TempDir()
+	runtime.Source.Root = root
+	runtime.Config.EBSSources[0].Root = root
+	for _, job := range runtime.Jobs {
+		if err := os.Mkdir(filepath.Join(root, strings.TrimPrefix(job.Job.Subpath, "/")), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		job.Job.EBSRoot = root
+		job.Job.Source.Root = effectiveSourceRoot(root, job.Job.Subpath)
+		job.mountProbe = testMountedSourceProbe
+	}
+
+	result, err := Plan(context.Background(), runtime)
+	if !errors.Is(err, ErrPlanFailed) || len(result.Jobs) != 2 {
+		t.Fatalf("plan error = %v, result = %+v", err, result)
+	}
+	for _, job := range result.Jobs {
+		if job.Result != nil || !strings.Contains(job.Error, "overlapping prefixes") {
+			t.Fatalf("plan Job = %+v", job)
+		}
+	}
+}
+
+func authenticatedTargetRuntime(t *testing.T, tenantA, tenantB, prefixA, prefixB string, crossSource bool) (*RuntimeStartup, func()) {
+	t.Helper()
+	tenantByAuth := map[string]string{"Bearer key-a": tenantA, "Bearer key-b": tenantB}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/status" {
+			http.NotFound(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"tenant_id": tenantByAuth[r.Header.Get("Authorization")]})
+	}))
+	secretRoot := t.TempDir()
+	for name, key := range map[string]string{"key-a-file": "key-a\n", "key-b-file": "key-b\n"} {
+		if err := os.WriteFile(filepath.Join(secretRoot, name), []byte(key), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	spaces := map[string]SpaceConfig{
+		"space-a": {CredentialRef: "key-a-file"},
+		"space-b": {CredentialRef: "key-b-file"},
+	}
+	jobsA := []JobConfig{
+		{JobID: "job-a", Subpath: "/A", Target: TargetConfig{SpaceRef: "space-a", Prefix: prefixA}},
+	}
+	sources := []EBSSourceConfig{{VolumeID: "vol-001", NodeName: "node-a", Root: "/ebs/a", Jobs: jobsA}}
+	if crossSource {
+		sources = append(sources, EBSSourceConfig{VolumeID: "vol-002", NodeName: "node-b", Root: "/ebs/b", Jobs: []JobConfig{
+			{JobID: "job-b", Subpath: "/B", Target: TargetConfig{SpaceRef: "space-b", Prefix: prefixB}},
+		}})
+	} else {
+		sources[0].Jobs = append(sources[0].Jobs, JobConfig{
+			JobID: "job-b", Subpath: "/B", Target: TargetConfig{SpaceRef: "space-b", Prefix: prefixB},
+		})
+	}
+	cfg := &Config{
+		Version: ConfigVersion, Drive9: Drive9Config{Endpoint: server.URL},
+		JobDefaults: JobDefaults{
+			Sync:        SyncDefaults{GracePeriod: Duration(DefaultGracePeriod)},
+			Performance: PerformanceDefaults{MaxBytesPerSecond: 1024, SmallFileWorkers: 1, LargeFileWorkers: 1},
+		},
+		Spaces: spaces, EBSSources: sources,
+	}
+	if err := cfg.validate(); err != nil {
+		t.Fatal(err)
+	}
+	runtime := &RuntimeStartup{Config: cfg, Source: sources[0], Phase: PhaseSyncing, targetCredentials: make(map[string]CredentialSource)}
+	for spaceRef, space := range spaces {
+		credential, err := NewCredentialSource(secretRoot, space.CredentialRef)
+		if err != nil {
+			t.Fatal(err)
+		}
+		runtime.targetCredentials[spaceRef] = credential
+	}
+	for _, configured := range sources[0].Jobs {
+		job := resolveJob(sources[0], configured)
+		runtime.Jobs = append(runtime.Jobs, &Startup{Config: cfg, Job: job, Space: spaces[job.Target.SpaceRef], Phase: PhaseSyncing})
+	}
+	return runtime, server.Close
+}
+
 func TestValidateTargetPrefixUsesDrive9PathRules(t *testing.T) {
 	for _, prefix := range []string{"/bad\\path", "/bad\x01path", "/dot/../path"} {
 		if _, err := validateTargetPrefix(prefix); err == nil {
@@ -212,6 +348,7 @@ func preflightStartup(t *testing.T, endpoint, root string) *Startup {
 	if err != nil {
 		t.Fatal(err)
 	}
+	startup.acceptedTenantID = "tenant-a"
 	startup.mountProbe = testMountedSourceProbe
 	return startup
 }
@@ -230,7 +367,7 @@ func TestPreflightChecksSelectedSourceClientCapabilitiesAndEmptyTarget(t *testin
 		switch {
 		case r.Method == http.MethodGet && r.URL.Path == "/v1/status":
 			statusHits.Add(1)
-			_, _ = w.Write([]byte(`{"max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true,"event_ingest":false}}`))
+			_, _ = w.Write([]byte(`{"tenant_id":"tenant-a","max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true,"event_ingest":false}}`))
 		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
 			listHits.Add(1)
 			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []client.FileInfo{{Name: ".drive9-migration", IsDir: true}}})
@@ -262,6 +399,51 @@ func TestPreflightChecksSelectedSourceClientCapabilitiesAndEmptyTarget(t *testin
 	}
 }
 
+func TestPreflightRejectsAuthenticatedTenantMismatchBeforeTargetAccess(t *testing.T) {
+	root := t.TempDir()
+	var targetHits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/status" {
+			_, _ = w.Write([]byte(`{"tenant_id":"tenant-b","max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
+			return
+		}
+		targetHits.Add(1)
+		http.Error(w, "unexpected target access", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	startup := preflightStartup(t, server.URL, root)
+	startup.acceptedTenantID = "tenant-a"
+	_, err := Preflight(context.Background(), startup)
+	if !errors.Is(err, ErrTargetIdentityMismatch) {
+		t.Fatalf("error = %v, want ErrTargetIdentityMismatch", err)
+	}
+	if targetHits.Load() != 0 {
+		t.Fatalf("tenant mismatch made %d target requests", targetHits.Load())
+	}
+}
+
+func TestPreflightRequiresBatchAcceptedTenantIdentity(t *testing.T) {
+	root := t.TempDir()
+	var targetHits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/status" {
+			_, _ = w.Write([]byte(`{"tenant_id":"tenant-a","max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
+			return
+		}
+		targetHits.Add(1)
+		http.Error(w, "unexpected target access", http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	startup := preflightStartup(t, server.URL, root)
+	startup.acceptedTenantID = ""
+	_, err := Preflight(context.Background(), startup)
+	if !errors.Is(err, ErrTargetIdentityMismatch) || targetHits.Load() != 0 {
+		t.Fatalf("error = %v, target hits = %d", err, targetHits.Load())
+	}
+}
+
 func TestPreflightSourceIdentityIsRequiredByWorkerConstruction(t *testing.T) {
 	parent := t.TempDir()
 	root := filepath.Join(parent, "source")
@@ -271,7 +453,7 @@ func TestPreflightSourceIdentityIsRequiredByWorkerConstruction(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/status":
-			_, _ = w.Write([]byte(`{"max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
+			_, _ = w.Write([]byte(`{"tenant_id":"tenant-a","max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
 		case r.Method == http.MethodHead && strings.HasSuffix(r.URL.Path, "/checkpoint.json"):
 			http.NotFound(w, r)
 		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
@@ -306,7 +488,7 @@ func TestPreflightRejectsSourceIdentityChangeDuringValidation(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/status":
-			_, _ = w.Write([]byte(`{"max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
+			_, _ = w.Write([]byte(`{"tenant_id":"tenant-a","max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
 		case r.Method == http.MethodHead && strings.HasSuffix(r.URL.Path, "/checkpoint.json"):
 			http.NotFound(w, r)
 		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
@@ -349,7 +531,7 @@ func TestPreflightRejectsUnreadableAndOversizedRegularFiles(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		remoteHits.Add(1)
 		if r.URL.Path == "/v1/status" {
-			_, _ = w.Write([]byte(`{"max_upload_bytes":2,"inline_threshold":1,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
+			_, _ = w.Write([]byte(`{"tenant_id":"tenant-a","max_upload_bytes":2,"inline_threshold":1,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
 			return
 		}
 		http.Error(w, "unexpected", http.StatusInternalServerError)
@@ -418,7 +600,7 @@ func TestPreflightAllowsNonEmptyTargetOnlyForMatchingCheckpoint(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/status":
-			_, _ = w.Write([]byte(`{"max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
+			_, _ = w.Write([]byte(`{"tenant_id":"tenant-a","max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
 		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
 			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []client.FileInfo{{Name: "business", IsDir: false}, {Name: ".drive9-migration", IsDir: true}}})
 		case r.URL.Path == "/v1/fs/.drive9-migration/jobs/vol-001/checkpoint.json" && r.Method == http.MethodHead:
@@ -487,7 +669,7 @@ func TestPreflightRequiredCapabilitiesFailClosedAndEventIsOptional(t *testing.T)
 			caps[missing] = false
 			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if r.URL.Path == "/v1/status" {
-					_ = json.NewEncoder(w).Encode(map[string]any{"max_upload_bytes": 10, "inline_threshold": 5, "migration_capabilities": caps})
+					_ = json.NewEncoder(w).Encode(map[string]any{"tenant_id": "tenant-a", "max_upload_bytes": 10, "inline_threshold": 5, "migration_capabilities": caps})
 					return
 				}
 				t.Error("target listing reached with missing required capability")
@@ -511,7 +693,7 @@ func TestPreflightRejectsBusinessTargetAndRootControlCollision(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		hits.Add(1)
 		if r.URL.Path == "/v1/status" {
-			_, _ = w.Write([]byte(`{"max_upload_bytes":10,"inline_threshold":5,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
+			_, _ = w.Write([]byte(`{"tenant_id":"tenant-a","max_upload_bytes":10,"inline_threshold":5,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
 			return
 		}
 		if r.Method == http.MethodHead && strings.HasSuffix(r.URL.Path, "/checkpoint.json") {
@@ -600,10 +782,24 @@ func TestPlanRetainsAllJobResultsOnPartialFailure(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
 		case r.URL.Path == "/v1/status":
-			_, _ = w.Write([]byte(`{"max_upload_bytes":1048576,"inline_threshold":1024,"migration_capabilities":{"checksum_read":true,"checksum_complete":true,"conditional_create":true,"conditional_update":true}}`))
+			tenantID := "tenant-a"
+			if r.Header.Get("Authorization") == "Bearer owner-key-b" {
+				tenantID = "tenant-b"
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"tenant_id": tenantID, "max_upload_bytes": 1048576, "inline_threshold": 1024,
+				"migration_capabilities": map[string]bool{
+					"checksum_read": true, "checksum_complete": true,
+					"conditional_create": true, "conditional_update": true,
+				},
+			})
 		case r.Method == http.MethodHead && strings.HasSuffix(r.URL.Path, "/checkpoint.json"):
 			http.NotFound(w, r)
 		case r.Method == http.MethodGet && r.URL.Query().Get("list") == "1":
+			if r.Header.Get("Authorization") == "Bearer owner-key-b" {
+				http.Error(w, "forbidden", http.StatusForbidden)
+				return
+			}
 			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []client.FileInfo{{Name: ".drive9-migration", IsDir: true}}})
 		default:
 			http.Error(w, "unexpected", http.StatusMethodNotAllowed)
@@ -614,6 +810,9 @@ func TestPlanRetainsAllJobResultsOnPartialFailure(t *testing.T) {
 	body = strings.Replace(body, "/ebs/001", root, 1)
 	secretRoot := t.TempDir()
 	if err := os.WriteFile(filepath.Join(secretRoot, "space-a-key"), []byte("owner-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(secretRoot, "space-b-key"), []byte("owner-key-b\n"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 	runtime, err := LoadRuntimeStartup(writeConfig(t, body), "node-a", string(PhaseSyncing), secretRoot, "")

--- a/internal/migration/reporter_test.go
+++ b/internal/migration/reporter_test.go
@@ -103,7 +103,10 @@ func TestDualCASReportsExactlyOneLogicalEventAndNeverBlocksRepair(t *testing.T) 
 			now := time.Now()
 			worker, server := newDualWorker(t, root, target, time.Minute, &now)
 			defer server.Close()
-			worker.startup = &Startup{Job: Job{VolumeID: "vol-001", NodeName: "node", Target: TargetConfig{SpaceRef: "space", Prefix: "/data"}}}
+			worker.startup = &Startup{
+				Job:              Job{VolumeID: "vol-001", NodeName: "node", Target: TargetConfig{SpaceRef: "space", Prefix: "/data"}},
+				acceptedTenantID: "tenant-a",
+			}
 			worker.reporter = newEventReporter(worker.api, 4)
 			worker.apply.onCAS = worker.reportCAS
 			ctx, cancel := context.WithCancel(context.Background())
@@ -134,7 +137,7 @@ func TestDualCASReportsExactlyOneLogicalEventAndNeverBlocksRepair(t *testing.T) 
 			target.mu.Lock()
 			events := append([]client.MigrationEvent(nil), target.events...)
 			target.mu.Unlock()
-			if len(events) == 0 || events[0].CASAttempt != 1 || events[0].Phase != string(PhaseDualWriteRepairing) || events[0].SourceVersionToken == "" || events[0].Operation != "create" || events[0].SourceChecksumSHA256 == "" || events[0].ErrorClass != "none" {
+			if len(events) == 0 || events[0].CASAttempt != 1 || events[0].Phase != string(PhaseDualWriteRepairing) || events[0].SpaceID != "tenant-a" || events[0].SourceVersionToken == "" || events[0].Operation != "create" || events[0].SourceChecksumSHA256 == "" || events[0].ErrorClass != "none" {
 				t.Fatalf("events=%+v", events)
 			}
 			for _, event := range events[1:] {

--- a/internal/migration/runtime_identity.go
+++ b/internal/migration/runtime_identity.go
@@ -31,6 +31,57 @@ func sourceMountProbeFor(startup *Startup) sourceMountProbe {
 	return observeMountedSource
 }
 
+func observeJobSource(startup *Startup, probe sourceMountProbe) (sourceMountIdentity, error) {
+	if startup == nil {
+		return sourceMountIdentity{}, errors.New("missing startup")
+	}
+	ebsRoot := startup.Job.EBSRoot
+	if ebsRoot == "" {
+		ebsRoot = startup.Job.Source.Root
+	}
+	ebsIdentity, err := probe(ebsRoot, startup.Job.VolumeID)
+	if err != nil {
+		return sourceMountIdentity{}, err
+	}
+	if ebsRoot == startup.Job.Source.Root {
+		return ebsIdentity, nil
+	}
+	sourceIdentity, err := observeSubpathRoot(ebsRoot, startup.Job.Source.Root)
+	if err != nil {
+		return sourceMountIdentity{}, err
+	}
+	if sourceIdentity.Device != ebsIdentity.Device {
+		return sourceMountIdentity{}, fmt.Errorf("%w: source subpath is on another device", ErrSourceMountChanged)
+	}
+	sourceIdentity.VolumeSerial = ebsIdentity.VolumeSerial
+	sourceIdentity.VolumeIdentityVerified = ebsIdentity.VolumeIdentityVerified
+	return sourceIdentity, nil
+}
+
+func observeSubpathRoot(ebsRoot, sourceRoot string) (sourceMountIdentity, error) {
+	relative, err := filepath.Rel(ebsRoot, sourceRoot)
+	if err != nil || relative == ".." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+		return sourceMountIdentity{}, fmt.Errorf("%w: source subpath escapes EBS root", ErrSourceMountChanged)
+	}
+	root, err := os.OpenRoot(ebsRoot)
+	if err != nil {
+		return sourceMountIdentity{}, fmt.Errorf("open EBS root: %w", err)
+	}
+	defer func() { _ = root.Close() }()
+	info, err := root.Lstat(relative)
+	if err != nil {
+		return sourceMountIdentity{}, fmt.Errorf("lstat source subpath root: %w", err)
+	}
+	if !info.IsDir() {
+		return sourceMountIdentity{}, errors.New("source subpath root is not a directory")
+	}
+	identity, err := defaultFileIdentity(sourceRoot, info)
+	if err != nil {
+		return sourceMountIdentity{}, fmt.Errorf("source subpath root identity: %w", err)
+	}
+	return sourceMountIdentity{Device: identity.version.Device, Inode: identity.version.Inode}, nil
+}
+
 func observeSourceRoot(root string) (sourceMountIdentity, error) {
 	info, err := os.Lstat(root)
 	if err != nil {

--- a/internal/migration/runtime_identity_test.go
+++ b/internal/migration/runtime_identity_test.go
@@ -2,6 +2,8 @@ package migration
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -47,6 +49,50 @@ func TestExtractEBSVolumeIDRequiresExactToken(t *testing.T) {
 		if got := extractEBSVolumeID(tc.serial); got != tc.want {
 			t.Fatalf("extractEBSVolumeID(%q)=%q, want %q", tc.serial, got, tc.want)
 		}
+	}
+}
+
+func TestObserveJobSourceUsesRealSubpathDirectoryAndRejectsSymlinkRoot(t *testing.T) {
+	ebsRoot := t.TempDir()
+	subpath := filepath.Join(ebsRoot, "A")
+	if err := os.Mkdir(subpath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	startup := &Startup{Job: Job{
+		VolumeID: "vol-001", EBSRoot: ebsRoot, Subpath: "/A",
+		Source: SourceConfig{Type: "ebs", Root: subpath},
+	}}
+	identity, err := observeJobSource(startup, testMountedSourceProbe)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want, err := observeSourceRoot(subpath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if identity.Device != want.Device || identity.Inode != want.Inode {
+		t.Fatalf("identity=%+v want=%+v", identity, want)
+	}
+	symlink := filepath.Join(ebsRoot, "link")
+	if err := os.Symlink(subpath, symlink); err != nil {
+		t.Fatal(err)
+	}
+	startup.Job.Subpath, startup.Job.Source.Root = "/link", symlink
+	if _, err := observeJobSource(startup, testMountedSourceProbe); err == nil {
+		t.Fatal("symlink subpath root accepted")
+	}
+	outside := t.TempDir()
+	if err := os.Mkdir(filepath.Join(outside, "nested"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ancestor := filepath.Join(ebsRoot, "ancestor")
+	if err := os.Symlink(outside, ancestor); err != nil {
+		t.Fatal(err)
+	}
+	startup.Job.Subpath = "/ancestor/nested"
+	startup.Job.Source.Root = filepath.Join(ancestor, "nested")
+	if _, err := observeJobSource(startup, testMountedSourceProbe); err == nil {
+		t.Fatal("ancestor symlink escape accepted")
 	}
 }
 

--- a/internal/migration/worker.go
+++ b/internal/migration/worker.go
@@ -137,6 +137,9 @@ func (w *Worker) refreshClientLocked(ctx context.Context) error {
 	if missing := missingCapabilities(caps); missing != "" {
 		return fmt.Errorf("required capability %s is unavailable", missing)
 	}
+	if err := verifyAuthenticatedTenant(ctx, api, w.startup); err != nil {
+		return err
+	}
 	inventory, err := NewTargetScanner(api, w.startup.Job.Target.Prefix)
 	if err != nil {
 		return err
@@ -637,6 +640,8 @@ func newWorkerRunError(err error) error {
 		result.class, result.cause = "unsafe_source", ErrUnsafeSourcePath
 	case errors.Is(err, ErrCheckpointMismatch):
 		result.class, result.cause = "checkpoint_mismatch", ErrCheckpointMismatch
+	case errors.Is(err, ErrTargetIdentityMismatch):
+		result.class, result.cause = "target_identity_mismatch", ErrTargetIdentityMismatch
 	}
 	return result
 }
@@ -662,10 +667,11 @@ func (w *Worker) reportCAS(source SourceEntry, target *client.StatResult, expect
 		result, class = "failure", classifyRetry(err)
 	}
 	attempt := w.eventID.Add(1)
+	spaceID := w.startup.acceptedTenantID
 	event := client.MigrationEvent{
 		EventID: fmt.Sprintf("%s-%d-%d", eventContext.RoundID, attempt, now.UnixNano()), EmittedAt: now.UTC().Format(time.RFC3339Nano),
 		Phase: string(eventContext.Phase), RoundID: eventContext.RoundID, CASAttempt: attempt, FirstSeenAt: firstSeen.UTC().Format(time.RFC3339Nano), GraceSeconds: int64(w.graceWindow().Seconds()),
-		JobID: w.startup.Job.JobID, VolumeID: w.startup.Job.VolumeID, NodeName: w.startup.Job.NodeName, SpaceID: w.startup.Job.Target.SpaceRef,
+		JobID: w.startup.Job.JobID, VolumeID: w.startup.Job.VolumeID, NodeName: w.startup.Job.NodeName, SpaceID: spaceID,
 		SourcePath: source.Path, TargetPath: targetRemotePath(w.startup.Job.Target.Prefix, source.Path, false), SourceVersionToken: token,
 		Size: source.Version.Size, Mtime: source.Version.MtimeNS, SourceChecksumSHA256: source.ChecksumSHA256, ExpectedRevision: expected,
 		Operation: "update", Result: result, ErrorClass: class, LatencyMS: time.Since(started).Milliseconds(),

--- a/internal/migration/worker.go
+++ b/internal/migration/worker.go
@@ -63,7 +63,7 @@ func NewWorker(ctx context.Context, startup *Startup) (*Worker, error) {
 	if err != nil {
 		return nil, err
 	}
-	observedSource, err := sourceMountProbeFor(startup)(startup.Job.Source.Root, startup.Job.VolumeID)
+	observedSource, err := observeJobSource(startup, sourceMountProbeFor(startup))
 	if err != nil {
 		return nil, fmt.Errorf("observe mounted source: %w", err)
 	}
@@ -145,7 +145,7 @@ func (w *Worker) refreshClientLocked(ctx context.Context) error {
 		api: api, inventory: inventory, checkpoint: NewCheckpointStore(api), eventIngest: caps.EventIngest,
 	}
 	if w.recovery != nil {
-		observed, loadErr := candidate.checkpoint.Load(ctx, w.startup.Job.VolumeID)
+		observed, loadErr := candidate.checkpoint.Load(ctx, w.startup.Job.JobID)
 		if loadErr != nil {
 			return fmt.Errorf("validate refreshed credential checkpoint: %w", loadErr)
 		}
@@ -215,7 +215,7 @@ func (w *Worker) validateSourceMount() error {
 		err      error
 	)
 	if w.startup != nil && w.startup.Job.Source.Root != "" {
-		observed, err = sourceMountProbeFor(w.startup)(w.startup.Job.Source.Root, w.startup.Job.VolumeID)
+		observed, err = observeJobSource(w.startup, sourceMountProbeFor(w.startup))
 	} else if w.scanner != nil {
 		observed, err = observeSourceRoot(w.scanner.root)
 	} else {
@@ -260,7 +260,7 @@ func (w *Worker) validateRemoteCheckpoint(ctx context.Context) error {
 	if w.startup == nil || w.recovery == nil || w.checkpoint == nil {
 		return nil
 	}
-	observed, err := w.checkpoint.Load(ctx, w.startup.Job.VolumeID)
+	observed, err := w.checkpoint.Load(ctx, w.startup.Job.JobID)
 	if err != nil {
 		return err
 	}
@@ -665,7 +665,7 @@ func (w *Worker) reportCAS(source SourceEntry, target *client.StatResult, expect
 	event := client.MigrationEvent{
 		EventID: fmt.Sprintf("%s-%d-%d", eventContext.RoundID, attempt, now.UnixNano()), EmittedAt: now.UTC().Format(time.RFC3339Nano),
 		Phase: string(eventContext.Phase), RoundID: eventContext.RoundID, CASAttempt: attempt, FirstSeenAt: firstSeen.UTC().Format(time.RFC3339Nano), GraceSeconds: int64(w.graceWindow().Seconds()),
-		JobID: w.startup.Job.VolumeID, VolumeID: w.startup.Job.VolumeID, NodeName: w.startup.Job.NodeName, SpaceID: w.startup.Job.Target.SpaceRef,
+		JobID: w.startup.Job.JobID, VolumeID: w.startup.Job.VolumeID, NodeName: w.startup.Job.NodeName, SpaceID: w.startup.Job.Target.SpaceRef,
 		SourcePath: source.Path, TargetPath: targetRemotePath(w.startup.Job.Target.Prefix, source.Path, false), SourceVersionToken: token,
 		Size: source.Version.Size, Mtime: source.Version.MtimeNS, SourceChecksumSHA256: source.ChecksumSHA256, ExpectedRevision: expected,
 		Operation: "update", Result: result, ErrorClass: class, LatencyMS: time.Since(started).Milliseconds(),

--- a/internal/migration/worker_test.go
+++ b/internal/migration/worker_test.go
@@ -57,6 +57,7 @@ type workerServer struct {
 	target           *memoryTarget
 	checkpoint       *checkpointFake
 	checkpointByAuth map[string]*checkpointFake
+	tenantByAuth     map[string]string
 	rejectAuth       map[string]bool
 	rejectStatus     int
 	onReject         func()
@@ -157,7 +158,12 @@ func (s *workerServer) handler(w http.ResponseWriter, r *http.Request) {
 	}
 	switch {
 	case r.URL.Path == "/v1/status":
+		tenantID := "tenant-a"
+		if candidate := s.tenantByAuth[authorization]; candidate != "" {
+			tenantID = candidate
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
+			"tenant_id":        tenantID,
 			"max_upload_bytes": 1 << 20, "inline_threshold": 1 << 10,
 			"migration_capabilities": s.caps,
 		})
@@ -505,7 +511,7 @@ func newWorkerStartup(t *testing.T, root string, server *httptest.Server) *Start
 	}
 	return &Startup{
 		Config: config, Job: job, Space: config.Spaces["space"], Phase: PhaseSyncing,
-		ConfigHash: hash, Credential: credential, mountProbe: testMountedSourceProbe,
+		ConfigHash: hash, Credential: credential, acceptedTenantID: "tenant-a", mountProbe: testMountedSourceProbe,
 	}
 }
 
@@ -715,6 +721,11 @@ func TestNewWorkerBuildsRuntimeAndReloadsCredential(t *testing.T) {
 	if _, err := NewWorker(context.Background(), nil); err == nil {
 		t.Fatal("nil startup accepted")
 	}
+	startup.acceptedTenantID = ""
+	if _, err := NewWorker(context.Background(), startup); !errors.Is(err, ErrTargetIdentityMismatch) {
+		t.Fatalf("empty accepted tenant error = %v", err)
+	}
+	startup.acceptedTenantID = "tenant-a"
 	backend.caps.ConditionalUpdate = false
 	if _, err := NewWorker(context.Background(), startup); err == nil {
 		t.Fatal("missing capability accepted")
@@ -1090,6 +1101,38 @@ func TestCredentialRefreshValidatesCheckpointBeforeAtomicSwap(t *testing.T) {
 	}
 	if worker.api != oldAPI || worker.inventory != oldInventory || worker.checkpoint != oldCheckpoint || worker.apply != oldApply {
 		t.Fatal("identity mismatch partially replaced the active runtime")
+	}
+}
+
+func TestCredentialRefreshRejectsAuthenticatedTenantMismatchBeforeAtomicSwap(t *testing.T) {
+	root := t.TempDir()
+	backend := &workerServer{
+		target: &memoryTarget{nodes: make(map[string]memoryTargetNode)}, checkpoint: &checkpointFake{},
+		tenantByAuth: map[string]string{"Bearer wrong-tenant-key": "tenant-b"}, caps: allWorkerCapabilities(),
+	}
+	server := httptest.NewServer(http.HandlerFunc(backend.handler))
+	defer server.Close()
+	startup := newWorkerStartup(t, root, server)
+	worker, err := NewWorker(context.Background(), startup)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldAPI, oldInventory, oldCheckpoint, oldApply := worker.api, worker.inventory, worker.checkpoint, worker.apply
+	if err := os.WriteFile(startup.Credential.path, []byte("wrong-tenant-key\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := worker.refreshClient(context.Background()); !errors.Is(err, ErrTargetIdentityMismatch) {
+		t.Fatalf("wrong-tenant refresh error = %v", err)
+	}
+	if worker.api != oldAPI || worker.inventory != oldInventory || worker.checkpoint != oldCheckpoint || worker.apply != oldApply {
+		t.Fatal("tenant mismatch partially replaced the active runtime")
+	}
+}
+
+func TestWorkerRunErrorClassifiesTargetIdentityMismatch(t *testing.T) {
+	err := newWorkerRunError(fmt.Errorf("refresh: %w", ErrTargetIdentityMismatch))
+	if !errors.Is(err, ErrTargetIdentityMismatch) || !strings.Contains(err.Error(), "target_identity_mismatch") {
+		t.Fatalf("classified error = %v", err)
 	}
 }
 

--- a/internal/migration/worker_test.go
+++ b/internal/migration/worker_test.go
@@ -494,7 +494,10 @@ func newWorkerStartup(t *testing.T, root string, server *httptest.Server) *Start
 		},
 		Spaces: map[string]SpaceConfig{"space": {CredentialRef: "owner-key"}},
 	}
-	job := Job{VolumeID: "vol-001", NodeName: "node", Source: SourceConfig{Type: "ebs", Root: root}, Target: TargetConfig{SpaceRef: "space", Prefix: "/data"}}
+	configured := JobConfig{JobID: "vol-001", Subpath: "/", Target: TargetConfig{SpaceRef: "space", Prefix: "/data"}}
+	source := EBSSourceConfig{VolumeID: "vol-001", NodeName: "node", Root: root, Jobs: []JobConfig{configured}}
+	config.EBSSources = []EBSSourceConfig{source}
+	job := resolveJob(source, configured)
 	config.Jobs = []Job{job}
 	hash, err := ConfigHash(config, job)
 	if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -51,6 +51,7 @@ type Client struct {
 // Forward-compatible: unknown fields decode-and-ignore cleanly.
 type tenantStatusResponse struct {
 	Status                string                 `json:"status"`
+	TenantID              string                 `json:"tenant_id,omitempty"`
 	MaxUploadBytes        int64                  `json:"max_upload_bytes"`
 	InlineThreshold       int64                  `json:"inline_threshold,omitempty"`
 	MigrationCapabilities *MigrationCapabilities `json:"migration_capabilities,omitempty"`
@@ -601,6 +602,18 @@ func (c *Client) GetMigrationCapabilities(ctx context.Context) (MigrationCapabil
 		return MigrationCapabilities{}, fmt.Errorf("%w: status omitted migration_capabilities", ErrMigrationUnsupported)
 	}
 	return *body.MigrationCapabilities, nil
+}
+
+// GetMigrationTenantID returns the stable identity of the authenticated target.
+func (c *Client) GetMigrationTenantID(ctx context.Context) (string, error) {
+	body, err := c.tenantStatus(ctx)
+	if err != nil {
+		return "", fmt.Errorf("fetch migration tenant identity: %w", err)
+	}
+	if body.TenantID == "" || strings.TrimSpace(body.TenantID) != body.TenantID {
+		return "", fmt.Errorf("%w: status omitted a valid tenant_id", ErrMigrationUnsupported)
+	}
+	return body.TenantID, nil
 }
 
 // PostMigrationEvent sends one diagnostic event to the optional Server

--- a/pkg/client/migration_contract_test.go
+++ b/pkg/client/migration_contract_test.go
@@ -201,6 +201,81 @@ func TestMigrationCapabilityOldServerIsRecognizablyUnsupported(t *testing.T) {
 	}
 }
 
+func TestMigrationTenantIdentityContract(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		body        string
+		want        string
+		unsupported bool
+		wantError   bool
+	}{
+		{name: "present", body: `{"tenant_id":"tenant-a","unknown":"ignored"}`, want: "tenant-a"},
+		{name: "missing", body: `{"status":"active"}`, unsupported: true},
+		{name: "empty", body: `{"tenant_id":""}`, unsupported: true},
+		{name: "whitespace padded", body: `{"tenant_id":" tenant-a "}`, unsupported: true},
+		{name: "malformed", body: `{"tenant_id":42}`, wantError: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tc.body))
+			}))
+			defer srv.Close()
+
+			got, err := New(srv.URL, "").GetMigrationTenantID(context.Background())
+			switch {
+			case tc.unsupported && !errors.Is(err, ErrMigrationUnsupported):
+				t.Fatalf("error = %v, want ErrMigrationUnsupported", err)
+			case tc.wantError && err == nil:
+				t.Fatal("error = nil, want decode error")
+			case !tc.unsupported && !tc.wantError && err != nil:
+				t.Fatal(err)
+			case err == nil && got != tc.want:
+				t.Fatalf("tenant ID = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestMigrationTenantIdentitySharesStatusCacheWithCapabilities(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		_, _ = w.Write([]byte(`{"tenant_id":"tenant-a","max_upload_bytes":1048576,"inline_threshold":7,"migration_capabilities":{"checksum_read":true}}`))
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "")
+	tenantID, err := client.GetMigrationTenantID(context.Background())
+	if err != nil || tenantID != "tenant-a" {
+		t.Fatalf("tenant ID = %q, error = %v", tenantID, err)
+	}
+	caps, err := client.GetMigrationCapabilities(context.Background())
+	if err != nil || !caps.ChecksumRead || hits.Load() != 1 {
+		t.Fatalf("capabilities = %+v, hits = %d, error = %v", caps, hits.Load(), err)
+	}
+}
+
+func TestMigrationTenantIdentityStatusFailureRetries(t *testing.T) {
+	var hits atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if hits.Add(1) == 1 {
+			http.Error(w, "temporary", http.StatusServiceUnavailable)
+			return
+		}
+		_, _ = w.Write([]byte(`{"tenant_id":"tenant-a"}`))
+	}))
+	defer srv.Close()
+
+	client := New(srv.URL, "")
+	if _, err := client.GetMigrationTenantID(context.Background()); err == nil {
+		t.Fatal("status failure error = nil")
+	}
+	tenantID, err := client.GetMigrationTenantID(context.Background())
+	if err != nil || tenantID != "tenant-a" || hits.Load() != 2 {
+		t.Fatalf("tenant ID = %q, hits = %d, error = %v", tenantID, hits.Load(), err)
+	}
+}
+
 func TestMigrationCapabilityStatusErrorsAreTypedAndRetryable(t *testing.T) {
 	for _, status := range []int{
 		http.StatusUnauthorized,

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -4098,7 +4098,8 @@ func createGitRepoWithReadme(t *testing.T, content []byte) string {
 
 func runFuseTestGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
-	cmd := exec.Command("git", args...)
+	gitArgs := append([]string{"-c", "maintenance.auto=false"}, args...)
+	cmd := exec.Command("git", gitArgs...)
 	if dir != "" {
 		cmd.Dir = dir
 	}

--- a/pkg/server/provision_test.go
+++ b/pkg/server/provision_test.go
@@ -2783,12 +2783,12 @@ func TestInitTenantSchemaAsyncRecordsOrgScopedEvent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	srv := NewWithConfig(Config{
-		Meta:        metaStore,
-		Pool:        db.Pool,
-		Provisioner: &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative},
-	})
-	defer srv.Close()
+	srv := &Server{
+		meta:        metaStore,
+		pool:        db.Pool,
+		provisioner: &fakeProvisioner{provider: tenant.ProviderTiDBCloudNative},
+		metrics:     newServerMetrics(),
+	}
 	dsn := tenantDSN(db.DBUser, db.DBPass, db.DBHost, db.DBPort, db.DBName, false, tenant.ProviderTiDBCloudNative)
 	srv.initTenantSchemaAsync(context.Background(), tenantID, dsn, tenant.ProviderTiDBCloudNative, func(context.Context, string) error {
 		return nil


### PR DESCRIPTION
## Summary

- replace the migration config with a strict v4 `ebs_sources` schema that maps disjoint EBS subpaths to independent Drive9 Space/Prefix Jobs
- run all Jobs for one selected EBS in a single process while keeping checkpoint, retry, status, verification, fencing, credentials, and rate limits per Job
- separate `job_id` from `volume_id`, introduce checkpoint v2, and confine subpath resolution through `os.Root`
- route local control operations by `--job-id` and expand one Worker Pod into multiple rows in the kubectl migration plugin
- update migration examples, design, runbook, and allow manual migration-image publication from trusted non-main refs

## Compatibility

- config v3 is rejected; only v4 is accepted
- checkpoint v1 is rejected; checkpoint v2 records explicit Job and EBS/subpath identity
- business cutover remains externally controlled; no batch cutover state machine or shared rate limiter is added

## Validation

- `go test ./internal/migration ./cmd/drive9-migration ./cmd/kubectl-drive9-migration`
- `go test -race ./internal/migration ./cmd/drive9-migration ./cmd/kubectl-drive9-migration`
- golangci-lint v2.5.0 built with Go 1.25.1: 0 issues
- `make build-migration`
- `make build-migration-kube-plugin`
- `git diff --check`

Repository-wide `make test` was attempted. Migration and other non-container packages passed; unrelated suites requiring Docker/Podman could not start locally, and existing FUSE commit-queue tests hit the host 10% free-space safety threshold.

## Dev EKS E2E

GitHub Actions image run: https://github.com/mem9-ai/drive9/actions/runs/32836766245

Immutable image:

`ghcr.io/drive9-ai/drive9-migration@sha256:42085747fab6d3d32907734c307774c1670cc41f023622b8058f8f6b16e7821b`

Validated in context `dev-drive9-eks-ap-southeast-1`, namespace `drive9-migration-smoke`:

- one gp3 EBS volume with `/A`, `/B`, and `/C` mapped to three separate disposable Drive9 spaces
- plan returned three successful Job mappings
- all three Jobs reached `RUNNING`, `recovery_complete=true`, and `ready_for_rollout=true`
- each target contained only its own marker; nine cross-target and ignored-path assertions returned 404
- an A-only incremental file synchronized only to Space A
- DaemonSet restart recovered all three Jobs from matching checkpoint v2 records
- kubectl plugin expanded one Pod into three `READY_FOR_ROLLOUT` Job rows
- no cutover or irreversible fence was invoked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for multiple migration jobs per EBS source.
  * Added job-specific status, filtering, verification, and cutover controls.
  * Added runtime states, retries, and per-job failure isolation.
  * Expanded status output with job, volume, subpath, attempt, and error details.
  * Added authenticated tenant validation and a `VOLUME` column to wide output.

* **Documentation**
  * Updated configuration examples and runbooks for schema v4 and job-scoped operations.

* **Bug Fixes**
  * Improved status parsing and source, checkpoint, and target identity validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->