### PR TITLE
fix: restore Windows CLI release build

### DIFF
--- a/.github/workflows/code-ci.yml
+++ b/.github/workflows/code-ci.yml
@@ -56,3 +56,6 @@ jobs:
 
       - name: Build (server and cli)
         run: make build
+
+      - name: Build Windows CLI
+        run: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -o /tmp/drive9-windows-amd64.exe ./cmd/drive9

--- a/cmd/drive9/cli/mount_credentials.go
+++ b/cmd/drive9/cli/mount_credentials.go
@@ -1,0 +1,42 @@
+package cli
+
+import "os"
+
+// withEnsureCredentialEnv temporarily installs stored mount credentials into
+// the process environment for a mount operation.
+func withEnsureCredentialEnv(server, apiKey, token string, fn func() error) error {
+	if server == "" && apiKey == "" && token == "" {
+		return fn()
+	}
+	type snap struct {
+		key string
+		val string
+		ok  bool
+	}
+	keys := []string{EnvServer, EnvAPIKey, EnvVaultToken}
+	prev := make([]snap, 0, len(keys))
+	for _, k := range keys {
+		v, ok := os.LookupEnv(k)
+		prev = append(prev, snap{key: k, val: v, ok: ok})
+	}
+	defer func() {
+		for _, s := range prev {
+			if s.ok {
+				_ = os.Setenv(s.key, s.val)
+			} else {
+				_ = os.Unsetenv(s.key)
+			}
+		}
+	}()
+	if server != "" {
+		_ = os.Setenv(EnvServer, server)
+	}
+	if token != "" {
+		_ = os.Setenv(EnvVaultToken, token)
+		_ = os.Unsetenv(EnvAPIKey)
+	} else if apiKey != "" {
+		_ = os.Setenv(EnvAPIKey, apiKey)
+		_ = os.Unsetenv(EnvVaultToken)
+	}
+	return fn()
+}

--- a/cmd/drive9/cli/mount_supervise.go
+++ b/cmd/drive9/cli/mount_supervise.go
@@ -489,45 +489,6 @@ func argsHasFlag(args []string, name string) bool {
 	return false
 }
 
-// withEnsureCredentialEnv temporarily installs stored mount credentials into
-// the process environment for remount (needed for vault tokens which have no flag).
-func withEnsureCredentialEnv(server, apiKey, token string, fn func() error) error {
-	if server == "" && apiKey == "" && token == "" {
-		return fn()
-	}
-	type snap struct {
-		key string
-		val string
-		ok  bool
-	}
-	keys := []string{EnvServer, EnvAPIKey, EnvVaultToken}
-	prev := make([]snap, 0, len(keys))
-	for _, k := range keys {
-		v, ok := os.LookupEnv(k)
-		prev = append(prev, snap{key: k, val: v, ok: ok})
-	}
-	defer func() {
-		for _, s := range prev {
-			if s.ok {
-				_ = os.Setenv(s.key, s.val)
-			} else {
-				_ = os.Unsetenv(s.key)
-			}
-		}
-	}()
-	if server != "" {
-		_ = os.Setenv(EnvServer, server)
-	}
-	if token != "" {
-		_ = os.Setenv(EnvVaultToken, token)
-		_ = os.Unsetenv(EnvAPIKey)
-	} else if apiKey != "" {
-		_ = os.Setenv(EnvAPIKey, apiKey)
-		_ = os.Unsetenv(EnvVaultToken)
-	}
-	return fn()
-}
-
 func stripEnsureBlockingFlags(args []string) []string {
 	out := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {


### PR DESCRIPTION
## Summary

- move `withEnsureCredentialEnv` out of the Unix-only mount supervision file
- make the credential environment wrapper available to Windows CLI builds without changing its behavior
- fix the Windows cross-build failure from [release run 32922898362](https://github.com/mem9-ai/drive9/actions/runs/32922898362/job/98039827621)

## Validation

- `go test ./cmd/drive9/cli -count=1`
- `go vet ./cmd/drive9/cli`
- `make build-cli-release DIST_DIR=/private/tmp/drive9-cli-release-test VERSION=dev CLI_TARGETS="linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mount operations now reliably apply the configured server and mount credentials.
  * Credential environment settings are preserved and restored after mounting.
  * Token credentials take precedence over API keys, while alternate credential values are cleared to prevent conflicts.
  * Remount and adoption operations no longer unexpectedly alter existing credential settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->