### PR TITLE
fix(fuse): refresh gVisor directory snapshots

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ KUBE_PLUGIN_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows
 
 GOLANGCI_LINT_VERSION ?= v2.5.0
 GOLANGCI_LINT_BIN ?= $(BIN_DIR)/golangci-lint
+GOLANGCI_LINT_GO_VERSION ?= $(shell $(GO) env GOVERSION)
 
 IMAGE_REPO ?= drive9-server
 IMAGE_TAG ?= latest
@@ -106,7 +107,7 @@ install-lint:
 	@if [ ! -x "$(GOLANGCI_LINT_BIN)" ]; then \
 		echo "Installing golangci-lint $(GOLANGCI_LINT_VERSION) to $(BIN_DIR)..."; \
 		mkdir -p "$(BIN_DIR)"; \
-		GOBIN="$(BIN_DIR_ABS)" $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
+		GOTOOLCHAIN="$(GOLANGCI_LINT_GO_VERSION)" GOBIN="$(BIN_DIR_ABS)" $(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION); \
 	else \
 		echo "golangci-lint already installed at $(GOLANGCI_LINT_BIN)"; \
 	fi

--- a/cmd/drive9/cli/fuse_bridge.go
+++ b/cmd/drive9/cli/fuse_bridge.go
@@ -72,6 +72,7 @@ type mountFuseOptions struct {
 	ParallelReadBlockSize   int64
 	SyncRead                bool
 	DirectMountStrict       bool
+	GVisorCompat            bool
 	AllowOther              bool
 	ReadOnly                bool
 	Debug                   bool

--- a/cmd/drive9/cli/fuse_bridge_supported.go
+++ b/cmd/drive9/cli/fuse_bridge_supported.go
@@ -65,6 +65,7 @@ func mountFuseImpl(opts *mountFuseOptions) error {
 		ParallelReadBlockSize:   opts.ParallelReadBlockSize,
 		SyncRead:                opts.SyncRead,
 		DirectMountStrict:       opts.DirectMountStrict,
+		GVisorCompat:            opts.GVisorCompat,
 		AllowOther:              opts.AllowOther,
 		ReadOnly:                opts.ReadOnly,
 		Debug:                   opts.Debug,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -37,6 +37,7 @@ const (
 	defaultMountPerfCPUDuration        = 30 * time.Second
 	defaultMountPerfCPUInterval        = 10 * time.Minute
 	defaultMountPerfHeapInterval       = 10 * time.Minute
+	envMountGVisorCompat               = "DRIVE9_MOUNT_GVISOR_COMPAT"
 )
 
 var (
@@ -171,6 +172,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	parallelReadBlockSize := fs.Int64("parallel-read-block-size-mb", defaultFuseParallelReadBlockSizeMB, "block size in MB for parallel large-file reads")
 	syncRead := fs.Bool("fuse-sync-read", false, "disable kernel async read dispatch; at most one read in flight per file handle")
 	directMountStrict := fs.Bool("direct-mount-strict", false, "Linux only: mount directly with mount(2) and do not fall back to fusermount")
+	gvisorCompat := fs.Bool("gvisor-compat", false, "enable gVisor-specific FUSE compatibility behavior (default from $DRIVE9_MOUNT_GVISOR_COMPAT)")
 	legacyDirStatFallback := fs.Bool("legacy-dir-stat-fallback", false, "on Lookup stat 404, list parent to support legacy servers without directory stat")
 	readDirPrefetch := fs.Bool("readdir-prefetch", false, "prefetch small files after directory reads into the read cache")
 	prefetchMaxFiles := fs.Int("readdir-prefetch-max-files", 32, "maximum small files prefetched per directory read")
@@ -219,6 +221,12 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
+	if !flagProvided(fs, "gvisor-compat") {
+		*gvisorCompat, err = mountGVisorCompatFromEnv()
+		if err != nil {
+			return err
+		}
+	}
 
 	// Parse positional args: 1-arg = mountpoint; 2-arg = remote mountpoint.
 	var remoteRoot, mountPoint string
@@ -252,6 +260,9 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	}
 
 	if objectLoc != nil {
+		if *gvisorCompat {
+			return fmt.Errorf("drive9 mount: --gvisor-compat is only supported with Drive9 FUSE mounts")
+		}
 		if err := validateObjectMount(runtime.GOOS, *mode, *layerRef, *checkpointRef, *profile); err != nil {
 			return err
 		}
@@ -483,6 +494,9 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	if resolved == MountModeWebDAV && *readOnly {
 		return fmt.Errorf("drive9 mount: --read-only is not supported with WebDAV mode")
 	}
+	if resolved == MountModeWebDAV && *gvisorCompat {
+		return fmt.Errorf("drive9 mount: --gvisor-compat is only supported with --mode=fuse")
+	}
 	if resolved == MountModeWebDAV && trustProcessLocalEventsGiven {
 		return fmt.Errorf("drive9 mount: --trust-process-local-events is only supported with --mode=fuse")
 	}
@@ -548,6 +562,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 			PackPaths:          append([]string(nil), effectivePackPaths...),
 			ReadOnly:           *readOnly,
 			Debug:              *debug,
+			GVisorCompat:       *gvisorCompat,
 		})
 	}
 
@@ -677,6 +692,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 			PackPaths:          append([]string(nil), effectivePackPaths...),
 			ReadOnly:           *readOnly,
 			Debug:              *debug,
+			GVisorCompat:       *gvisorCompat,
 		})
 	}
 
@@ -728,6 +744,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 		ParallelReadBlockSize:   *parallelReadBlockSize << 20,
 		SyncRead:                *syncRead,
 		DirectMountStrict:       *directMountStrict,
+		GVisorCompat:            *gvisorCompat,
 		AllowOther:              *allowOther,
 		ReadOnly:                *readOnly,
 		Debug:                   *debug,
@@ -1602,6 +1619,21 @@ func durationFlagValue(fs *flag.FlagSet, name string, value time.Duration) time.
 		return value
 	}
 	return 0
+}
+
+func mountGVisorCompatFromEnv() (bool, error) {
+	raw, ok := os.LookupEnv(envMountGVisorCompat)
+	if !ok {
+		return false, nil
+	}
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "true":
+		return true, nil
+	case "false":
+		return false, nil
+	default:
+		return false, fmt.Errorf("drive9 mount: %s must be true or false, got %q", envMountGVisorCompat, raw)
+	}
 }
 
 func readCacheTTLFlagValue(given bool, value time.Duration) (time.Duration, error) {

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -221,7 +221,8 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
-	if !flagProvided(fs, "gvisor-compat") {
+	gvisorCompatGiven := flagProvided(fs, "gvisor-compat")
+	if !gvisorCompatGiven {
 		*gvisorCompat, err = mountGVisorCompatFromEnv()
 		if err != nil {
 			return err
@@ -260,7 +261,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	}
 
 	if objectLoc != nil {
-		if *gvisorCompat {
+		if gvisorCompatGiven && *gvisorCompat {
 			return fmt.Errorf("drive9 mount: --gvisor-compat is only supported with Drive9 FUSE mounts")
 		}
 		if err := validateObjectMount(runtime.GOOS, *mode, *layerRef, *checkpointRef, *profile); err != nil {
@@ -494,7 +495,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	if resolved == MountModeWebDAV && *readOnly {
 		return fmt.Errorf("drive9 mount: --read-only is not supported with WebDAV mode")
 	}
-	if resolved == MountModeWebDAV && *gvisorCompat {
+	if resolved == MountModeWebDAV && gvisorCompatGiven && *gvisorCompat {
 		return fmt.Errorf("drive9 mount: --gvisor-compat is only supported with --mode=fuse")
 	}
 	if resolved == MountModeWebDAV && trustProcessLocalEventsGiven {

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -1293,6 +1293,56 @@ func TestMountCmdRejectsGVisorCompatForNonFUSEMounts(t *testing.T) {
 	}
 }
 
+func TestMountCmdIgnoresGVisorCompatEnvironmentForNonFUSEMounts(t *testing.T) {
+	t.Setenv(envMountGVisorCompat, "true")
+
+	t.Run("WebDAV", func(t *testing.T) {
+		err := MountCmd([]string{
+			"--foreground",
+			"--mode", "webdav",
+			"--trust-process-local-events",
+			t.TempDir(),
+		})
+		if err == nil {
+			t.Fatal("MountCmd error = nil, want WebDAV option error")
+		}
+		if strings.Contains(err.Error(), "--gvisor-compat") {
+			t.Fatalf("MountCmd error = %q, ambient gVisor compatibility must be ignored", err)
+		}
+		if !strings.Contains(err.Error(), "--trust-process-local-events") {
+			t.Fatalf("MountCmd error = %q, want WebDAV option error", err)
+		}
+	})
+
+	t.Run("object", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("object mounts are unsupported on Windows")
+		}
+		oldMountObjectStore := mountObjectStore
+		t.Cleanup(func() { mountObjectStore = oldMountObjectStore })
+		called := false
+		mountObjectStore = func(*Location, string, string, bool, bool, bool, bool) error {
+			called = true
+			return nil
+		}
+		t.Setenv("HOME", t.TempDir())
+		t.Setenv(EnvServer, "https://drive9.example")
+		t.Setenv(EnvAPIKey, "sk-test")
+
+		if err := MountCmd([]string{
+			"--foreground",
+			"--mode", "fuse",
+			"s3://bucket/prefix/",
+			t.TempDir(),
+		}); err != nil {
+			t.Fatalf("MountCmd: %v", err)
+		}
+		if !called {
+			t.Fatal("mountObjectStore was not called")
+		}
+	})
+}
+
 func TestMountCmdRejectsInvalidGVisorCompatEnvironment(t *testing.T) {
 	t.Setenv(envMountGVisorCompat, "enabled")
 	err := MountCmd([]string{"--foreground", "--mode", "fuse", t.TempDir()})

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -1043,6 +1043,11 @@ func TestForegroundMountCommandArgs(t *testing.T) {
 			want: []string{"mount", "--foreground", "--direct-mount-strict", "/mnt/drive9"},
 		},
 		{
+			name: "fs preserve gvisor compatibility",
+			in:   []string{"--gvisor-compat=false", "/mnt/drive9"},
+			want: []string{"mount", "--foreground", "--gvisor-compat=false", "/mnt/drive9"},
+		},
+		{
 			name: "vault",
 			in:   []string{"vault", "--dir-ttl", "1s", "/mnt/vault"},
 			want: []string{"mount", "vault", "--foreground", "--dir-ttl", "1s", "/mnt/vault"},
@@ -1118,6 +1123,7 @@ func TestWaitForBackgroundMountReadyStopsChildOnStateReadError(t *testing.T) {
 func TestMountBackgroundEnvSnapshotsCredentials(t *testing.T) {
 	got := mountBackgroundEnv([]string{
 		"PATH=/bin",
+		envMountGVisorCompat + "=true",
 		EnvServer + "=https://old.example",
 		EnvAPIKey + "=old-key",
 		EnvVaultToken + "=old-token",
@@ -1129,11 +1135,19 @@ func TestMountBackgroundEnvSnapshotsCredentials(t *testing.T) {
 	})
 	want := []string{
 		"PATH=/bin",
+		envMountGVisorCompat + "=true",
 		EnvServer + "=https://drive9.example",
 		EnvVaultToken + "=jwt-token",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("env = %v, want %v", got, want)
+	}
+}
+
+func TestWorkerArgsForSupervisePreservesGVisorCompat(t *testing.T) {
+	got := workerArgsForSupervise([]string{"--gvisor-compat=false", "/mnt/drive9"})
+	if !containsString(got, "--gvisor-compat=false") {
+		t.Fatalf("worker args = %v, want explicit gVisor compatibility flag", got)
 	}
 }
 
@@ -1197,6 +1211,96 @@ func TestMountCmdLeavesLegacyDirStatFallbackDisabledByDefault(t *testing.T) {
 	}
 	if got.LegacyDirStatFallback {
 		t.Fatal("LegacyDirStatFallback = true, want false")
+	}
+}
+
+func TestMountCmdResolvesGVisorCompat(t *testing.T) {
+	tests := []struct {
+		name     string
+		env      string
+		unsetEnv bool
+		args     []string
+		want     bool
+	}{
+		{name: "disabled by default", unsetEnv: true, want: false},
+		{name: "enabled by environment", env: "true", want: true},
+		{name: "flag enables over environment", env: "false", args: []string{"--gvisor-compat"}, want: true},
+		{name: "explicit flag disables over environment", env: "true", args: []string{"--gvisor-compat=false"}, want: false},
+		{name: "explicit flag overrides invalid environment", env: "invalid", args: []string{"--gvisor-compat=false"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.unsetEnv {
+				t.Setenv(envMountGVisorCompat, "temporary")
+				if err := os.Unsetenv(envMountGVisorCompat); err != nil {
+					t.Fatalf("unset %s: %v", envMountGVisorCompat, err)
+				}
+			} else {
+				t.Setenv(envMountGVisorCompat, tt.env)
+			}
+			oldMountFuse := mountFuse
+			t.Cleanup(func() { mountFuse = oldMountFuse })
+
+			var got *mountFuseOptions
+			mountFuse = func(opts *mountFuseOptions) error {
+				copied := *opts
+				got = &copied
+				return nil
+			}
+
+			args := []string{
+				"--foreground",
+				"--mode", "fuse",
+				"--server", "https://drive9.example",
+				"--api-key", "sk-test",
+			}
+			args = append(args, tt.args...)
+			args = append(args, t.TempDir())
+			if err := MountCmd(args); err != nil {
+				t.Fatalf("MountCmd: %v", err)
+			}
+			if got == nil {
+				t.Fatal("mountFuse was not called")
+			}
+			if got.GVisorCompat != tt.want {
+				t.Fatalf("GVisorCompat = %t, want %t", got.GVisorCompat, tt.want)
+			}
+		})
+	}
+}
+
+func TestMountCmdRejectsGVisorCompatForNonFUSEMounts(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "WebDAV", args: []string{"--foreground", "--mode", "webdav", "--gvisor-compat"}},
+		{name: "object", args: []string{"--foreground", "--gvisor-compat", "s3://bucket/prefix/"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := append(append([]string(nil), tt.args...), t.TempDir())
+			err := MountCmd(args)
+			if err == nil {
+				t.Fatal("MountCmd error = nil, want unsupported compatibility-mode error")
+			}
+			if !strings.Contains(err.Error(), "--gvisor-compat") || !strings.Contains(err.Error(), "only supported") {
+				t.Fatalf("MountCmd error = %q, want gVisor compatibility scope error", err)
+			}
+		})
+	}
+}
+
+func TestMountCmdRejectsInvalidGVisorCompatEnvironment(t *testing.T) {
+	t.Setenv(envMountGVisorCompat, "enabled")
+	err := MountCmd([]string{"--foreground", "--mode", "fuse", t.TempDir()})
+	if err == nil {
+		t.Fatal("MountCmd error = nil, want invalid environment error")
+	}
+	if !strings.Contains(err.Error(), envMountGVisorCompat) {
+		t.Fatalf("MountCmd error = %q, want %s", err, envMountGVisorCompat)
 	}
 }
 

--- a/pkg/fuse/auth_reset_test.go
+++ b/pkg/fuse/auth_reset_test.go
@@ -301,7 +301,7 @@ func TestDirectoryListDiscardedWhenMountViewResetsInFlight(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		_, _, err := fs.loadDirHandleEntries(context.Background(), dh)
+		_, _, err := fs.loadDirHandleEntries(context.Background(), dh, false)
 		done <- err
 	}()
 	<-listStarted
@@ -405,14 +405,14 @@ func TestEmptyDirectoryHandleRemainsLoaded(t *testing.T) {
 	fs := NewDat9FS(client.NewWithToken(ts.URL, "scoped"), opts)
 	dh := &DirHandle{Ino: 1, Path: "/", entriesGeneration: fs.mountViewGeneration.Load()}
 
-	if entries, _, err := fs.loadDirHandleEntries(context.Background(), dh); err != nil || len(entries) != 0 {
+	if entries, _, err := fs.loadDirHandleEntries(context.Background(), dh, false); err != nil || len(entries) != 0 {
 		t.Fatalf("first load = %#v, %v; want empty loaded directory", entries, err)
 	}
 	if dh.Entries == nil {
 		t.Fatal("empty directory handle was not marked loaded")
 	}
 	fs.dirCache.Invalidate("/")
-	if entries, _, err := fs.loadDirHandleEntries(context.Background(), dh); err != nil || len(entries) != 0 {
+	if entries, _, err := fs.loadDirHandleEntries(context.Background(), dh, false); err != nil || len(entries) != 0 {
 		t.Fatalf("second load = %#v, %v; want cached empty directory", entries, err)
 	}
 	if got := listCalls.Load(); got != 1 {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -9306,10 +9306,12 @@ func (fs *Dat9FS) ReadDir(cancel <-chan struct{}, input *gofuse.ReadIn, out *gof
 	if !ok {
 		return gofuse.ENOENT
 	}
-	dh.readMu.Lock()
-	defer dh.readMu.Unlock()
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
+	if !dh.lockRead(ctx) {
+		return gofuse.EINTR
+	}
+	defer dh.unlockRead()
 	fs.observePathPolicyWithContext(ctx, dh.Path)
 
 	entries, generation, err := fs.loadDirHandleEntries(ctx, dh, fs.opts.GVisorCompat && input.Offset == 0)
@@ -9362,10 +9364,12 @@ func (fs *Dat9FS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out 
 	if !ok {
 		return gofuse.ENOENT
 	}
-	dh.readMu.Lock()
-	defer dh.readMu.Unlock()
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
+	if !dh.lockRead(ctx) {
+		return gofuse.EINTR
+	}
+	defer dh.unlockRead()
 	fs.observePathPolicyWithContext(ctx, dh.Path)
 
 	entries, generation, err := fs.loadDirHandleEntries(ctx, dh, fs.opts.GVisorCompat && input.Offset == 0)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -9256,10 +9256,13 @@ func (fs *Dat9FS) OpenDir(cancel <-chan struct{}, input *gofuse.OpenIn, out *gof
 	return gofuse.OK
 }
 
-func (fs *Dat9FS) loadDirHandleEntries(ctx context.Context, dh *DirHandle) ([]DirEntry, uint64, error) {
+func (fs *Dat9FS) loadDirHandleEntries(ctx context.Context, dh *DirHandle, refresh bool) ([]DirEntry, uint64, error) {
 	dh.mu.Lock()
 	generation := fs.mountViewGeneration.Load()
-	if dh.entriesGeneration == generation && dh.Entries != nil {
+	// gVisor directfs rewinds and reuses one host directory FD. Treat its
+	// offset-zero request as a new enumeration sequence, while preserving the
+	// current snapshot for nonzero pagination and for all other callers.
+	if !refresh && dh.entriesGeneration == generation && dh.Entries != nil {
 		entries := cloneLoadedDirEntries(dh.Entries)
 		dh.mu.Unlock()
 		return entries, generation, nil
@@ -9307,7 +9310,7 @@ func (fs *Dat9FS) ReadDir(cancel <-chan struct{}, input *gofuse.ReadIn, out *gof
 	defer cf()
 	fs.observePathPolicyWithContext(ctx, dh.Path)
 
-	entries, generation, err := fs.loadDirHandleEntries(ctx, dh)
+	entries, generation, err := fs.loadDirHandleEntries(ctx, dh, fs.opts.GVisorCompat && input.Offset == 0)
 	if err != nil {
 		safeLogPrintf("list dir failed for %s: %v", dh.Path, err)
 		return listDirErrToFuseStatus(err)
@@ -9361,7 +9364,7 @@ func (fs *Dat9FS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out 
 	defer cf()
 	fs.observePathPolicyWithContext(ctx, dh.Path)
 
-	entries, generation, err := fs.loadDirHandleEntries(ctx, dh)
+	entries, generation, err := fs.loadDirHandleEntries(ctx, dh, fs.opts.GVisorCompat && input.Offset == 0)
 	if err != nil {
 		safeLogPrintf("list dir plus failed for %s: %v", dh.Path, err)
 		return listDirErrToFuseStatus(err)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -9306,6 +9306,8 @@ func (fs *Dat9FS) ReadDir(cancel <-chan struct{}, input *gofuse.ReadIn, out *gof
 	if !ok {
 		return gofuse.ENOENT
 	}
+	dh.readMu.Lock()
+	defer dh.readMu.Unlock()
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
 	fs.observePathPolicyWithContext(ctx, dh.Path)
@@ -9360,6 +9362,8 @@ func (fs *Dat9FS) ReadDirPlus(cancel <-chan struct{}, input *gofuse.ReadIn, out 
 	if !ok {
 		return gofuse.ENOENT
 	}
+	dh.readMu.Lock()
+	defer dh.readMu.Unlock()
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
 	fs.observePathPolicyWithContext(ctx, dh.Path)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -6461,6 +6461,120 @@ func TestReadDirEmitsDotAndDotDot(t *testing.T) {
 	}
 }
 
+func TestReadDirGVisorCompatControlsOffsetZeroRefresh(t *testing.T) {
+	tests := []struct {
+		name         string
+		gvisorCompat bool
+		want         []string
+	}{
+		{name: "disabled", want: []string{".", "..", "before.txt"}},
+		{name: "enabled", gvisorCompat: true, want: []string{".", "..", "before.txt", "after.txt"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &MountOptions{GVisorCompat: tt.gvisorCompat}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient("http://localhost"), opts)
+			dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+			fs.dirCache.Put("/dir", []CachedFileInfo{{Name: "before.txt"}})
+			dh := &DirHandle{Ino: dirIno, Path: "/dir"}
+			fh := fs.dirHandles.Allocate(dh)
+
+			read := func() []string {
+				out := gofuse.NewDirEntryList(make([]byte, 4096), 0)
+				if st := fs.ReadDir(nil, &gofuse.ReadIn{
+					InHeader: gofuse.InHeader{NodeId: dirIno},
+					Fh:       fh,
+					Offset:   0,
+					Size:     4096,
+				}, out); st != gofuse.OK {
+					t.Fatalf("ReadDir status = %v, want OK", st)
+				}
+				return parseDirEntryNames(t, out)
+			}
+
+			if got := read(); !reflect.DeepEqual(got, []string{".", "..", "before.txt"}) {
+				t.Fatalf("first ReadDir = %v, want [. .. before.txt]", got)
+			}
+			fs.dirCache.Upsert("/dir", CachedFileInfo{Name: "after.txt"})
+			if got := read(); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("second ReadDir = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReadDirGVisorCompatKeepsSnapshotForNonzeroOffset(t *testing.T) {
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+	fs.dirCache.Put("/dir", []CachedFileInfo{{Name: "before.txt"}})
+	dh := &DirHandle{Ino: dirIno, Path: "/dir"}
+	fh := fs.dirHandles.Allocate(dh)
+
+	first := gofuse.NewDirEntryList(make([]byte, 4096), 0)
+	if st := fs.ReadDir(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Fh:       fh,
+		Offset:   0,
+		Size:     4096,
+	}, first); st != gofuse.OK {
+		t.Fatalf("initial ReadDir status = %v, want OK", st)
+	}
+
+	fs.dirCache.Upsert("/dir", CachedFileInfo{Name: "after.txt"})
+	continued := gofuse.NewDirEntryList(make([]byte, 4096), 2)
+	if st := fs.ReadDir(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Fh:       fh,
+		Offset:   2,
+		Size:     4096,
+	}, continued); st != gofuse.OK {
+		t.Fatalf("continued ReadDir status = %v, want OK", st)
+	}
+	if got, want := parseDirEntryNames(t, continued), []string{"before.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("continued ReadDir = %v, want %v", got, want)
+	}
+}
+
+func TestReadDirPlusGVisorCompatRefreshesOffsetZero(t *testing.T) {
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+	fs.dirCache.Put("/dir", []CachedFileInfo{{Name: "before.txt"}})
+	dh := &DirHandle{Ino: dirIno, Path: "/dir"}
+	fh := fs.dirHandles.Allocate(dh)
+
+	read := func() {
+		out := gofuse.NewDirEntryList(make([]byte, 4096), 0)
+		if st := fs.ReadDirPlus(nil, &gofuse.ReadIn{
+			InHeader: gofuse.InHeader{NodeId: dirIno},
+			Fh:       fh,
+			Offset:   0,
+			Size:     4096,
+		}, out); st != gofuse.OK {
+			t.Fatalf("ReadDirPlus status = %v, want OK", st)
+		}
+	}
+
+	read()
+	fs.dirCache.Upsert("/dir", CachedFileInfo{Name: "after.txt"})
+	read()
+
+	dh.mu.Lock()
+	defer dh.mu.Unlock()
+	got := make([]string, 0, len(dh.Entries))
+	for _, entry := range dh.Entries {
+		got = append(got, entry.Name)
+	}
+	if want := []string{"before.txt", "after.txt"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("directory snapshot = %v, want %v", got, want)
+	}
+}
+
 // TestReadDirEmitsDotAndDotDotAtRoot verifies ".." at the root resolves to the
 // root inode itself rather than a missing parent.
 func TestReadDirEmitsDotAndDotDotAtRoot(t *testing.T) {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -6620,6 +6620,83 @@ func TestReadDirSerializesConcurrentRequestsPerHandle(t *testing.T) {
 	}
 }
 
+func TestReadDirCanceledWhileWaitingForHandle(t *testing.T) {
+	for _, readDirPlus := range []bool{false, true} {
+		name := "ReadDir"
+		if readDirPlus {
+			name = "ReadDirPlus"
+		}
+		t.Run(name, func(t *testing.T) {
+			listStarted := make(chan struct{})
+			releaseList := make(chan struct{})
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				close(listStarted)
+				<-releaseList
+				_, _ = w.Write([]byte(`{"entries":[]}`))
+			}))
+			defer ts.Close()
+			t.Cleanup(func() {
+				select {
+				case <-releaseList:
+				default:
+					close(releaseList)
+				}
+			})
+
+			opts := &MountOptions{GVisorCompat: true}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+			dh := &DirHandle{Ino: dirIno, Path: "/dir"}
+			fh := fs.dirHandles.Allocate(dh)
+			read := func(cancel <-chan struct{}) gofuse.Status {
+				input := &gofuse.ReadIn{
+					InHeader: gofuse.InHeader{NodeId: dirIno},
+					Fh:       fh,
+					Offset:   0,
+					Size:     4096,
+				}
+				out := gofuse.NewDirEntryList(make([]byte, 4096), 0)
+				if readDirPlus {
+					return fs.ReadDirPlus(cancel, input, out)
+				}
+				return fs.ReadDir(cancel, input, out)
+			}
+
+			firstDone := make(chan gofuse.Status, 1)
+			go func() { firstDone <- read(nil) }()
+			<-listStarted
+
+			cancel := make(chan struct{})
+			secondStarted := make(chan struct{})
+			secondDone := make(chan gofuse.Status, 1)
+			go func() {
+				close(secondStarted)
+				secondDone <- read(cancel)
+			}()
+			<-secondStarted
+			close(cancel)
+
+			select {
+			case st := <-secondDone:
+				if st != gofuse.EINTR {
+					t.Fatalf("canceled directory request status = %v, want EINTR", st)
+				}
+			case <-time.After(200 * time.Millisecond):
+				close(releaseList)
+				<-firstDone
+				<-secondDone
+				t.Fatal("canceled directory request stayed blocked on the handle")
+			}
+
+			close(releaseList)
+			if st := <-firstDone; st != gofuse.OK {
+				t.Fatalf("first directory request status = %v, want OK", st)
+			}
+		})
+	}
+}
+
 func TestReadDirPlusGVisorCompatKeepsSnapshotForNonzeroOffset(t *testing.T) {
 	opts := &MountOptions{GVisorCompat: true}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -6539,6 +6539,124 @@ func TestReadDirGVisorCompatKeepsSnapshotForNonzeroOffset(t *testing.T) {
 	}
 }
 
+func TestReadDirSerializesConcurrentRequestsPerHandle(t *testing.T) {
+	for _, readDirPlus := range []bool{false, true} {
+		name := "ReadDir"
+		if readDirPlus {
+			name = "ReadDirPlus"
+		}
+		t.Run(name, func(t *testing.T) {
+			firstListStarted := make(chan struct{})
+			secondListStarted := make(chan struct{})
+			releaseFirstList := make(chan struct{})
+			var listCalls atomic.Int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				switch listCalls.Add(1) {
+				case 1:
+					close(firstListStarted)
+					<-releaseFirstList
+				case 2:
+					close(secondListStarted)
+				}
+				_, _ = w.Write([]byte(`{"entries":[]}`))
+			}))
+			defer ts.Close()
+			t.Cleanup(func() {
+				select {
+				case <-releaseFirstList:
+				default:
+					close(releaseFirstList)
+				}
+			})
+
+			opts := &MountOptions{GVisorCompat: true}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+			dh := &DirHandle{Ino: dirIno, Path: "/dir"}
+			fh := fs.dirHandles.Allocate(dh)
+			read := func() gofuse.Status {
+				input := &gofuse.ReadIn{
+					InHeader: gofuse.InHeader{NodeId: dirIno},
+					Fh:       fh,
+					Offset:   0,
+					Size:     4096,
+				}
+				out := gofuse.NewDirEntryList(make([]byte, 4096), 0)
+				if readDirPlus {
+					return fs.ReadDirPlus(nil, input, out)
+				}
+				return fs.ReadDir(nil, input, out)
+			}
+
+			firstDone := make(chan gofuse.Status, 1)
+			go func() { firstDone <- read() }()
+			<-firstListStarted
+			secondCallStarted := make(chan struct{})
+			secondDone := make(chan gofuse.Status, 1)
+			go func() {
+				close(secondCallStarted)
+				secondDone <- read()
+			}()
+			<-secondCallStarted
+
+			select {
+			case <-secondListStarted:
+				close(releaseFirstList)
+				<-firstDone
+				<-secondDone
+				t.Fatal("second directory request overlapped the first on one handle")
+			case <-time.After(200 * time.Millisecond):
+			}
+
+			close(releaseFirstList)
+			if st := <-firstDone; st != gofuse.OK {
+				t.Fatalf("first directory request status = %v, want OK", st)
+			}
+			if st := <-secondDone; st != gofuse.OK {
+				t.Fatalf("second directory request status = %v, want OK", st)
+			}
+		})
+	}
+}
+
+func TestReadDirPlusGVisorCompatKeepsSnapshotForNonzeroOffset(t *testing.T) {
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	dirIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+	fs.dirCache.Put("/dir", []CachedFileInfo{{Name: "before.txt"}})
+	dh := &DirHandle{Ino: dirIno, Path: "/dir"}
+	fh := fs.dirHandles.Allocate(dh)
+
+	first := gofuse.NewDirEntryList(make([]byte, 4096), 0)
+	if st := fs.ReadDirPlus(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Fh:       fh,
+		Offset:   0,
+		Size:     4096,
+	}, first); st != gofuse.OK {
+		t.Fatalf("initial ReadDirPlus status = %v, want OK", st)
+	}
+
+	fs.dirCache.Upsert("/dir", CachedFileInfo{Name: "after.txt"})
+	continued := gofuse.NewDirEntryList(make([]byte, 4096), 2)
+	if st := fs.ReadDirPlus(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Fh:       fh,
+		Offset:   2,
+		Size:     4096,
+	}, continued); st != gofuse.OK {
+		t.Fatalf("continued ReadDirPlus status = %v, want OK", st)
+	}
+
+	dh.mu.Lock()
+	defer dh.mu.Unlock()
+	if got := len(dh.Entries); got != 1 || dh.Entries[0].Name != "before.txt" {
+		t.Fatalf("continued snapshot = %+v, want only before.txt", dh.Entries)
+	}
+}
+
 func TestReadDirPlusGVisorCompatRefreshesOffsetZero(t *testing.T) {
 	opts := &MountOptions{GVisorCompat: true}
 	opts.setDefaults()

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -127,6 +127,7 @@ func (fh *FileHandle) LockWithTimeout(timeout time.Duration) bool {
 
 // DirHandle represents an open directory in the FUSE filesystem.
 type DirHandle struct {
+	readMu            sync.Mutex // serializes directory reads for this handle
 	mu                sync.Mutex
 	Ino               uint64
 	Path              string

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -130,7 +130,7 @@ type DirHandle struct {
 	mu                sync.Mutex
 	Ino               uint64
 	Path              string
-	Entries           []DirEntry // guarded by mu; cached directory entries for ReadDir
+	Entries           []DirEntry // guarded by mu; stable snapshot for one directory enumeration sequence
 	entriesGeneration uint64
 }
 

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -1,6 +1,7 @@
 package fuse
 
 import (
+	"context"
 	"os"
 	"sync"
 	"time"
@@ -127,12 +128,37 @@ func (fh *FileHandle) LockWithTimeout(timeout time.Duration) bool {
 
 // DirHandle represents an open directory in the FUSE filesystem.
 type DirHandle struct {
-	readMu            sync.Mutex // serializes directory reads for this handle
+	readOnce          sync.Once
+	readToken         chan struct{}
 	mu                sync.Mutex
 	Ino               uint64
 	Path              string
 	Entries           []DirEntry // guarded by mu; stable snapshot for one directory enumeration sequence
 	entriesGeneration uint64
+}
+
+func (dh *DirHandle) lockRead(ctx context.Context) bool {
+	dh.readOnce.Do(func() {
+		dh.readToken = make(chan struct{}, 1)
+		dh.readToken <- struct{}{}
+	})
+	if ctx.Err() != nil {
+		return false
+	}
+	select {
+	case <-ctx.Done():
+		return false
+	case <-dh.readToken:
+		if ctx.Err() != nil {
+			dh.readToken <- struct{}{}
+			return false
+		}
+		return true
+	}
+}
+
+func (dh *DirHandle) unlockRead() {
+	dh.readToken <- struct{}{}
 }
 
 // DirEntry is a simplified directory entry for FUSE readdir.

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -72,6 +72,7 @@ type MountOptions struct {
 	ParallelReadBlockSize   int64         // block size for parallel large-file reads in bytes (default 1MiB)
 	SyncRead                bool          // disable kernel async read dispatch; at most one read in flight per file handle
 	DirectMountStrict       bool          // Linux only: mount with mount(2) and do not fall back to fusermount
+	GVisorCompat            bool          // enable gVisor-specific FUSE compatibility behavior
 	LookupRetryCount        int           // detached retries after transient Lookup/GetAttr stat failures (default 2)
 	LookupRetryTimeout      time.Duration // timeout per detached stat retry after interrupt/transient errors (default 250ms)
 	LegacyDirStatFallback   bool          // on Lookup stat 404, list parent to support legacy servers without directory stat


### PR DESCRIPTION
## Summary

- add opt-in gVisor FUSE compatibility through --gvisor-compat and DRIVE9_MOUNT_GVISOR_COMPAT
- rebuild directory-handle snapshots for offset-zero ReadDir and ReadDirPlus requests only in compatibility mode
- serialize directory reads per handle so concurrent refreshes cannot publish out of order
- preserve nonzero-offset pagination snapshots for both ReadDir and ReadDirPlus
- ignore ambient compatibility configuration for object and WebDAV mounts while rejecting explicit unsupported flags
- install the pinned golangci-lint with the Go toolchain selected by this module

## Scope and follow-up

The compatibility behavior is intentionally opt-in for a bounded rollout. This PR is related to #860 but does not auto-close it. CSI forwarding of DRIVE9_MOUNT_GVISOR_COMPAT is tracked by https://github.com/drive9-ai/k8s-csi/issues/35 and should land in the same release train before closing #860.

## Validation

- Code CI passed
- Local E2E passed
- make lint (0 issues)
- go test ./cmd/drive9/cli -count=1
- targeted pkg/fuse directory, pagination, mount-reset, and stale-inode tests
- targeted CLI and FUSE race-detector tests, including concurrent per-handle directory reads
- go vet ./cmd/drive9/cli ./pkg/fuse
- go build ./cmd/drive9
- git diff --check
- real dev EKS gVisor directfs validation passed on ARM64: 9P with cache=remote_revalidating and directfs, offset-zero readdir observed the new file, stat/read agreed, and recursive-copy enumeration refreshed

## Local limitation

The complete pkg/fuse suite was attempted locally but unrelated write-back tests rejected writes because the host volume had less than the required 10% free space. The affected directory tests pass normally and under the race detector; CI ran the complete suite on its clean runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added gVisor-compatible FUSE mounting through the `--gvisor-compat` option and `DRIVE9_MOUNT_GVISOR_COMPAT` environment variable.
  - Restricted this option to Drive9 FUSE mounts.
  - Improved directory enumeration for gVisor compatibility, including refreshed offset-zero reads and reliable concurrent access.

- **Bug Fixes**
  - Preserved directory snapshots during paginated, nonzero-offset reads.

- **Tests**
  - Added coverage for option precedence, validation, argument propagation, directory refresh, and concurrent directory access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->