### PR TITLE
fix(cli): support mount path policy environment overrides

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -38,6 +38,10 @@ const (
 	defaultMountPerfCPUInterval        = 10 * time.Minute
 	defaultMountPerfHeapInterval       = 10 * time.Minute
 	envMountGVisorCompat               = "DRIVE9_MOUNT_GVISOR_COMPAT"
+	// EnvMountLocalOnlyPatterns adds newline-delimited local-only mount rules.
+	EnvMountLocalOnlyPatterns = "DRIVE9_MOUNT_LOCAL_ONLY_PATTERNS"
+	// EnvMountRemoteOnlyPatterns adds newline-delimited remote-only mount rules.
+	EnvMountRemoteOnlyPatterns = "DRIVE9_MOUNT_REMOTE_ONLY_PATTERNS"
 )
 
 var (
@@ -189,8 +193,8 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	var remoteOnlyPatterns stringListFlag
 	var unpackArchives stringListFlag
 	noAutoUnpack := fs.Bool("no-auto-unpack", false, "disable automatic profile pack restore before mounting")
-	fs.Var(&localOnlyPatterns, "local-only", "additional local-only path pattern for overlay routing (repeatable, e.g. **/node_modules/**)")
-	fs.Var(&remoteOnlyPatterns, "remote-only", "remote-persistent override path pattern for overlay routing (repeatable)")
+	fs.Var(&localOnlyPatterns, "local-only", "route matching paths to the local-only overlay; adds to profile rules; repeatable; env $DRIVE9_MOUNT_LOCAL_ONLY_PATTERNS uses one pattern per line")
+	fs.Var(&remoteOnlyPatterns, "remote-only", "force matching paths to remote-persistent storage; overrides local-only routing; repeatable; env $DRIVE9_MOUNT_REMOTE_ONLY_PATTERNS uses one pattern per line")
 	fs.Var(&unpackArchives, "unpack", "restore a drive9 pack archive into --local-root before mounting (repeatable)")
 	uploadConcurrency := fs.Int("upload-concurrency", 16, "maximum concurrent background uploads issued by FUSE")
 	dirCacheMaxEntries := fs.Int("dir-cache-max-entries", 200000, "maximum entries per directory in namespace cache before complete marking is disabled")
@@ -316,6 +320,25 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 		})
 	}
 
+	envLocalOnlyPatterns, err := consumeMountPolicyPatternsEnv(EnvMountLocalOnlyPatterns)
+	if err != nil {
+		return err
+	}
+	envRemoteOnlyPatterns, err := consumeMountPolicyPatternsEnv(EnvMountRemoteOnlyPatterns)
+	if err != nil {
+		return err
+	}
+	policyEnvArgs := make([]string, 0, 2*(len(envLocalOnlyPatterns)+len(envRemoteOnlyPatterns)))
+	for _, pattern := range envLocalOnlyPatterns {
+		policyEnvArgs = append(policyEnvArgs, "--local-only", pattern)
+	}
+	for _, pattern := range envRemoteOnlyPatterns {
+		policyEnvArgs = append(policyEnvArgs, "--remote-only", pattern)
+	}
+	// Snapshot environment-derived policy in argv so supervised restarts and
+	// later adoption keep the original mount contract without re-reading env.
+	originalArgs = append(policyEnvArgs, originalArgs...)
+
 	remoteRoot, err = mountpath.NormalizeRoot(remoteRoot)
 	if err != nil {
 		return fmt.Errorf("drive9 mount: %w", err)
@@ -434,8 +457,8 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 		}
 	}
 	*profile = profileCfg.Name
-	effectiveLocalOnlyPatterns := mergeProfileValues(profileCfg.LocalOnlyPatterns, localOnlyPatterns)
-	effectiveRemoteOnlyPatterns := mergeProfileValues(profileCfg.RemoteOnlyPatterns, remoteOnlyPatterns)
+	effectiveLocalOnlyPatterns := mergeProfileValues(profileCfg.LocalOnlyPatterns, envLocalOnlyPatterns, localOnlyPatterns)
+	effectiveRemoteOnlyPatterns := mergeProfileValues(profileCfg.RemoteOnlyPatterns, envRemoteOnlyPatterns, remoteOnlyPatterns)
 	effectivePackPaths := mergeProfileValues(profileCfg.PackPaths)
 	normalizedLocalRoot := strings.TrimSpace(*localRoot)
 	syncModeVal, writePolicyVal, err := parseFuseDurability(*durability)
@@ -942,6 +965,8 @@ func applyScrubbedMountEnv(scrubbed []string) {
 		EnvVaultToken,
 		EnvTiDBCloudPublicKey,
 		EnvTiDBCloudPrivateKey,
+		EnvMountLocalOnlyPatterns,
+		EnvMountRemoteOnlyPatterns,
 	} {
 		_ = os.Unsetenv(key)
 	}
@@ -1198,7 +1223,9 @@ func mountBackgroundEnv(environ []string, req mountBackgroundRequest) []string {
 			strings.HasPrefix(kv, EnvAPIKey+"=") ||
 			strings.HasPrefix(kv, EnvVaultToken+"=") ||
 			strings.HasPrefix(kv, EnvTiDBCloudPublicKey+"=") ||
-			strings.HasPrefix(kv, EnvTiDBCloudPrivateKey+"=") {
+			strings.HasPrefix(kv, EnvTiDBCloudPrivateKey+"=") ||
+			strings.HasPrefix(kv, EnvMountLocalOnlyPatterns+"=") ||
+			strings.HasPrefix(kv, EnvMountRemoteOnlyPatterns+"=") {
 			continue
 		}
 		out = append(out, kv)
@@ -1595,6 +1622,32 @@ func validateMountPolicyPatterns(patternGroups ...[]string) error {
 		}
 	}
 	return nil
+}
+
+func consumeMountPolicyPatternsEnv(name string) ([]string, error) {
+	raw, ok := os.LookupEnv(name)
+	if !ok {
+		return nil, nil
+	}
+	_ = os.Unsetenv(name)
+
+	patterns := make([]string, 0)
+	seen := make(map[string]struct{})
+	for lineNo, line := range strings.Split(raw, "\n") {
+		pattern := strings.TrimSpace(line)
+		if pattern == "" {
+			continue
+		}
+		if err := validateMountPolicyPatterns([]string{pattern}); err != nil {
+			return nil, fmt.Errorf("%s line %d: %w", name, lineNo+1, err)
+		}
+		if _, ok := seen[pattern]; ok {
+			continue
+		}
+		seen[pattern] = struct{}{}
+		patterns = append(patterns, pattern)
+	}
+	return patterns, nil
 }
 
 type stringListFlag []string

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -641,7 +641,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 			})
 		}
 		return startMountBackground(mountBackgroundRequest{
-			Args:       append([]string(nil), args...),
+			Args:       append([]string(nil), originalArgs...),
 			MountPoint: mountPoint,
 			Server:     serverVal,
 			APIKey:     apiKeyVal,

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -328,12 +328,12 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	if err != nil {
 		return err
 	}
-	policyEnvArgs := make([]string, 0, 2*(len(envLocalOnlyPatterns)+len(envRemoteOnlyPatterns)))
+	policyEnvArgs := make([]string, 0, len(envLocalOnlyPatterns)+len(envRemoteOnlyPatterns))
 	for _, pattern := range envLocalOnlyPatterns {
-		policyEnvArgs = append(policyEnvArgs, "--local-only", pattern)
+		policyEnvArgs = append(policyEnvArgs, "--local-only="+pattern)
 	}
 	for _, pattern := range envRemoteOnlyPatterns {
-		policyEnvArgs = append(policyEnvArgs, "--remote-only", pattern)
+		policyEnvArgs = append(policyEnvArgs, "--remote-only="+pattern)
 	}
 	// Snapshot environment-derived policy in argv so supervised restarts and
 	// later adoption keep the original mount contract without re-reading env.

--- a/cmd/drive9/cli/mount_supervise_test.go
+++ b/cmd/drive9/cli/mount_supervise_test.go
@@ -110,6 +110,8 @@ func TestApplyScrubbedMountEnvUnsetsOmitted(t *testing.T) {
 	t.Setenv(EnvAPIKey, "old")
 	t.Setenv(EnvServer, "https://old")
 	t.Setenv(EnvVaultToken, "old-tok")
+	t.Setenv(EnvMountLocalOnlyPatterns, "**/.cache/**")
+	t.Setenv(EnvMountRemoteOnlyPatterns, "**/tmp/**")
 	scrubbed := mountBackgroundEnv(os.Environ(), mountBackgroundRequest{
 		Server: "https://s",
 		APIKey: "new",
@@ -129,6 +131,12 @@ func TestApplyScrubbedMountEnvUnsetsOmitted(t *testing.T) {
 	}
 	if _, ok := os.LookupEnv(EnvVaultToken); ok {
 		t.Fatal("vault token should be unset when using api key snapshot")
+	}
+	if _, ok := os.LookupEnv(EnvMountLocalOnlyPatterns); ok {
+		t.Fatalf("%s should be unset after policy snapshot", EnvMountLocalOnlyPatterns)
+	}
+	if _, ok := os.LookupEnv(EnvMountRemoteOnlyPatterns); ok {
+		t.Fatalf("%s should be unset after policy snapshot", EnvMountRemoteOnlyPatterns)
 	}
 }
 

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -1129,6 +1129,8 @@ func TestMountBackgroundEnvSnapshotsCredentials(t *testing.T) {
 		EnvVaultToken + "=old-token",
 		EnvTiDBCloudPublicKey + "=tidb-public",
 		EnvTiDBCloudPrivateKey + "=tidb-private",
+		EnvMountLocalOnlyPatterns + "=**/.cache/**",
+		EnvMountRemoteOnlyPatterns + "=**/tmp/**",
 	}, mountBackgroundRequest{
 		Server: "https://drive9.example",
 		Token:  "jwt-token",
@@ -1148,6 +1150,31 @@ func TestWorkerArgsForSupervisePreservesGVisorCompat(t *testing.T) {
 	got := workerArgsForSupervise([]string{"--gvisor-compat=false", "/mnt/drive9"})
 	if !containsString(got, "--gvisor-compat=false") {
 		t.Fatalf("worker args = %v, want explicit gVisor compatibility flag", got)
+	}
+}
+
+func TestConsumeMountPolicyPatternsEnv(t *testing.T) {
+	t.Setenv(EnvMountRemoteOnlyPatterns, " **/tmp/** \r\n\n**/.tmp/**\n**/tmp/**\n**/with space/** ")
+
+	got, err := consumeMountPolicyPatternsEnv(EnvMountRemoteOnlyPatterns)
+	if err != nil {
+		t.Fatalf("consumeMountPolicyPatternsEnv: %v", err)
+	}
+	want := []string{"**/tmp/**", "**/.tmp/**", "**/with space/**"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("patterns = %v, want %v", got, want)
+	}
+	if _, ok := os.LookupEnv(EnvMountRemoteOnlyPatterns); ok {
+		t.Fatalf("%s should be consumed", EnvMountRemoteOnlyPatterns)
+	}
+}
+
+func TestConsumeMountPolicyPatternsEnvReportsVariableAndLine(t *testing.T) {
+	t.Setenv(EnvMountRemoteOnlyPatterns, "**/tmp/**\n**/../bad/**")
+
+	_, err := consumeMountPolicyPatternsEnv(EnvMountRemoteOnlyPatterns)
+	if err == nil || !strings.Contains(err.Error(), EnvMountRemoteOnlyPatterns+" line 2") || !strings.Contains(err.Error(), `".." segment`) {
+		t.Fatalf("error = %v, want variable, line, and invalid segment", err)
 	}
 }
 
@@ -2519,6 +2546,87 @@ func TestMountCmdCodingAgentProfilePassesPolicyOptions(t *testing.T) {
 	}
 	if !reflect.DeepEqual(got.RemoteOnlyPatterns, []string{"**/node_modules/keep/**"}) {
 		t.Fatalf("RemoteOnlyPatterns = %v", got.RemoteOnlyPatterns)
+	}
+}
+
+func TestMountCmdCodingAgentProfileMergesPolicyEnvironment(t *testing.T) {
+	oldMountFuse := mountFuse
+	t.Cleanup(func() { mountFuse = oldMountFuse })
+
+	t.Setenv(EnvMountLocalOnlyPatterns, "**/.agent-cache/**\n**/.shared/**")
+	t.Setenv(EnvMountRemoteOnlyPatterns, "**/tmp/**\n**/.shared/**")
+	var got *mountFuseOptions
+	mountFuse = func(opts *mountFuseOptions) error {
+		copied := *opts
+		got = &copied
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--foreground",
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--profile", "coding-agent",
+		"--local-root", t.TempDir(),
+		"--local-only", "**/.cli-cache/**",
+		"--remote-only", "**/uploads/**",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	if got == nil {
+		t.Fatal("mountFuse was not called")
+	}
+	wantLocal := mergeProfileValues(
+		builtinCodingAgentLocalOnlyPatterns(),
+		[]string{"**/.agent-cache/**", "**/.shared/**", "**/.cli-cache/**"},
+	)
+	if !reflect.DeepEqual(got.LocalOnlyPatterns, wantLocal) {
+		t.Fatalf("LocalOnlyPatterns = %v, want %v", got.LocalOnlyPatterns, wantLocal)
+	}
+	wantRemote := []string{"**/tmp/**", "**/.shared/**", "**/uploads/**"}
+	if !reflect.DeepEqual(got.RemoteOnlyPatterns, wantRemote) {
+		t.Fatalf("RemoteOnlyPatterns = %v, want %v", got.RemoteOnlyPatterns, wantRemote)
+	}
+}
+
+func TestMountCmdMaterializesPolicyEnvironmentInSupervisedArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("supervised mounts are disabled on Windows")
+	}
+	oldStartSupervised := startMountSupervisedBackground
+	oldMountFuse := mountFuse
+	t.Cleanup(func() {
+		startMountSupervisedBackground = oldStartSupervised
+		mountFuse = oldMountFuse
+	})
+
+	t.Setenv(EnvMountRemoteOnlyPatterns, "**/tmp/**\n**/.tmp/**")
+	var got mountSuperviseStartRequest
+	startMountSupervisedBackground = func(req mountSuperviseStartRequest) error {
+		got = req
+		return nil
+	}
+	mountFuse = func(*mountFuseOptions) error {
+		t.Fatal("mountFuse should not run in-process")
+		return nil
+	}
+
+	err := MountCmd([]string{
+		"--mode", "fuse",
+		"--server", "https://drive9.example",
+		"--api-key", "sk-test",
+		"--profile", "coding-agent",
+		t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("MountCmd: %v", err)
+	}
+	wantPrefix := []string{"--remote-only", "**/tmp/**", "--remote-only", "**/.tmp/**"}
+	if len(got.OriginalArgs) < len(wantPrefix) || !reflect.DeepEqual(got.OriginalArgs[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("OriginalArgs = %v, want policy prefix %v", got.OriginalArgs, wantPrefix)
 	}
 }
 

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -955,6 +955,7 @@ func TestMountCmdNoSuperviseUsesLegacyBackground(t *testing.T) {
 		mountFuse = oldMountFuse
 	})
 
+	t.Setenv(EnvMountRemoteOnlyPatterns, "**/tmp/**\n**/.tmp/**")
 	var got mountBackgroundRequest
 	startMountBackground = func(req mountBackgroundRequest) error {
 		got = req
@@ -975,7 +976,8 @@ func TestMountCmdNoSuperviseUsesLegacyBackground(t *testing.T) {
 		"--no-supervise",
 		"--server", "https://drive9.example",
 		"--api-key", "sk-test",
-		"--profile", "interactive",
+		"--profile", "coding-agent",
+		"--local-root", t.TempDir(),
 		mountPoint,
 	})
 	if err != nil {
@@ -983,6 +985,10 @@ func TestMountCmdNoSuperviseUsesLegacyBackground(t *testing.T) {
 	}
 	if got.MountPoint != mountPoint {
 		t.Fatalf("MountPoint = %q, want %q", got.MountPoint, mountPoint)
+	}
+	wantPrefix := []string{"--remote-only", "**/tmp/**", "--remote-only", "**/.tmp/**"}
+	if len(got.Args) < len(wantPrefix) || !reflect.DeepEqual(got.Args[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("Args = %v, want policy prefix %v", got.Args, wantPrefix)
 	}
 }
 

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -955,7 +955,8 @@ func TestMountCmdNoSuperviseUsesLegacyBackground(t *testing.T) {
 		mountFuse = oldMountFuse
 	})
 
-	t.Setenv(EnvMountRemoteOnlyPatterns, "**/tmp/**\n**/.tmp/**")
+	t.Setenv(EnvMountLocalOnlyPatterns, "--api-key")
+	t.Setenv(EnvMountRemoteOnlyPatterns, "**/tmp/**")
 	var got mountBackgroundRequest
 	startMountBackground = func(req mountBackgroundRequest) error {
 		got = req
@@ -986,9 +987,12 @@ func TestMountCmdNoSuperviseUsesLegacyBackground(t *testing.T) {
 	if got.MountPoint != mountPoint {
 		t.Fatalf("MountPoint = %q, want %q", got.MountPoint, mountPoint)
 	}
-	wantPrefix := []string{"--remote-only", "**/tmp/**", "--remote-only", "**/.tmp/**"}
+	wantPrefix := []string{"--local-only=--api-key", "--remote-only=**/tmp/**"}
 	if len(got.Args) < len(wantPrefix) || !reflect.DeepEqual(got.Args[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("Args = %v, want policy prefix %v", got.Args, wantPrefix)
+	}
+	if childArgs := foregroundMountCommandArgs(got.Args); !containsString(childArgs, "--local-only=--api-key") {
+		t.Fatalf("foreground args = %v, want flag-like policy pattern preserved", childArgs)
 	}
 }
 
@@ -2609,7 +2613,7 @@ func TestMountCmdMaterializesPolicyEnvironmentInSupervisedArgs(t *testing.T) {
 		mountFuse = oldMountFuse
 	})
 
-	t.Setenv(EnvMountRemoteOnlyPatterns, "**/tmp/**\n**/.tmp/**")
+	t.Setenv(EnvMountRemoteOnlyPatterns, "**/tmp/**\n--foreground")
 	var got mountSuperviseStartRequest
 	startMountSupervisedBackground = func(req mountSuperviseStartRequest) error {
 		got = req
@@ -2630,9 +2634,12 @@ func TestMountCmdMaterializesPolicyEnvironmentInSupervisedArgs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MountCmd: %v", err)
 	}
-	wantPrefix := []string{"--remote-only", "**/tmp/**", "--remote-only", "**/.tmp/**"}
+	wantPrefix := []string{"--remote-only=**/tmp/**", "--remote-only=--foreground"}
 	if len(got.OriginalArgs) < len(wantPrefix) || !reflect.DeepEqual(got.OriginalArgs[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("OriginalArgs = %v, want policy prefix %v", got.OriginalArgs, wantPrefix)
+	}
+	if workerArgs := workerArgsForSupervise(got.OriginalArgs); !containsString(workerArgs, "--remote-only=--foreground") {
+		t.Fatalf("worker args = %v, want flag-like policy pattern preserved", workerArgs)
 	}
 }
 

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -772,8 +772,8 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 				{Title: "Overlay profiles", Flags: []visualHelpFlag{
 					{Name: "--profile NAME", Desc: "mount profile: coding-agent, portable, none, interactive, or a custom profile file"},
 					{Name: "--local-root DIR", Desc: "local-only overlay storage root; auto-generated for overlay profiles"},
-					{Name: "--local-only PATTERN", Desc: "additional local-only path pattern; repeatable"},
-					{Name: "--remote-only PATTERN", Desc: "remote-persistent override path pattern; repeatable"},
+					{Name: "--local-only PATTERN", Desc: "add a local-only rule; repeatable; env DRIVE9_MOUNT_LOCAL_ONLY_PATTERNS is newline-delimited"},
+					{Name: "--remote-only PATTERN", Desc: "force remote-persistent routing over local rules; repeatable; env DRIVE9_MOUNT_REMOTE_ONLY_PATTERNS is newline-delimited"},
 					{Name: "--unpack :/archive.tar.gz", Desc: "restore a drive9 pack archive into local-root before mounting; repeatable"},
 					{Name: "--no-auto-unpack", Desc: "disable automatic profile pack restore before mounting"},
 				}},
@@ -805,6 +805,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 				{Command: "drive9 mount :/ ./mnt", Desc: "supervised background mount (default)"},
 				{Command: "drive9 mount --supervise-foreground :/ ./mnt", Desc: "block as supervisor (sandbox entrypoint)"},
 				{Command: "drive9 mount --profile coding-agent :/workspace ./mnt", Desc: "profile mount"},
+				{Command: "DRIVE9_MOUNT_REMOTE_ONLY_PATTERNS='**/tmp/**' drive9 mount :/workspace ./mnt", Desc: "keep tmp paths remote-persistent"},
 				{Command: "drive9 mount --layer layer_123 --checkpoint cp_456 :/team ./mnt", Desc: "restore a layer checkpoint before mounting"},
 				{Command: "drive9 mount --perf-dir ./perf --foreground :/ ./mnt", Desc: "foreground worker only with profiling outputs"},
 			},

--- a/pkg/fuse/local_policy_test.go
+++ b/pkg/fuse/local_policy_test.go
@@ -42,6 +42,17 @@ func TestLocalPolicyRemoteOnlyOverridesLocalOnly(t *testing.T) {
 	}
 }
 
+func TestLocalPolicyRemoteOnlyOverridesBuiltinTmpRule(t *testing.T) {
+	policy := NewLocalPolicy(MountProfileCodingAgent, nil, []string{"**/tmp/**"})
+
+	if got := policy.Classify("/repo/tmp/object.blob"); got != PathLayerRemotePersistent {
+		t.Fatalf("tmp object policy = %s, want remote persistent", got)
+	}
+	if got := policy.Classify("/repo/blobs/aa/object.blob"); got != PathLayerRemotePersistent {
+		t.Fatalf("blob object policy = %s, want remote persistent", got)
+	}
+}
+
 func TestLocalPolicyDisabledForOrdinaryMount(t *testing.T) {
 	policy := NewLocalPolicy("", nil, nil)
 	if policy.Enabled() {


### PR DESCRIPTION
## Summary

- add newline-delimited `DRIVE9_MOUNT_LOCAL_ONLY_PATTERNS` and `DRIVE9_MOUNT_REMOTE_ONLY_PATTERNS` inputs
- merge environment patterns with profile rules and repeatable CLI flags
- snapshot environment-derived rules into supervised mount argv so restarts and adoption preserve the original policy
- clarify that `--remote-only` overrides local-only routing and add the `tmp` override example

## Problem

The default `coding-agent` profile classifies `**/tmp/**` as local-only. Renaming a temporary file from `tmp/**` into a remote-persistent path such as `blobs/**` therefore crosses backing layers and returns `EXDEV`.

This change keeps the built-in profile unchanged while giving callers an agent-legible way to force selected paths back to remote-persistent storage. Values use one pattern per line, are trimmed, deduplicated, validated with variable and line diagnostics, and follow the existing remote-over-local precedence.

Example:

```bash
export DRIVE9_MOUNT_REMOTE_ONLY_PATTERNS=$'**/tmp/**\n**/.tmp/**'
drive9 mount :/workspace /mnt/drive9
```

## Validation

- `go test ./cmd/drive9/cli ./cmd/drive9 -count=1`
- `go test ./pkg/fuse -run 'TestLocalPolicy(RemoteOnlyOverridesBuiltinTmpRule|RemoteOnlyOverridesLocalOnly)$' -count=1`
- `go vet ./cmd/drive9/cli ./pkg/fuse ./cmd/drive9`
- `git diff --check`

Local full-package FUSE validation was attempted, but the host had approximately 0.5% free disk space, below the suite's 10% write-back threshold, so unrelated quota tests returned `ENOSPC`. Local `make lint` was also blocked because the repository-pinned golangci-lint binary was built with Go 1.24.6 while this module targets Go 1.25.1.

## Follow-up

CSI propagation is intentionally deferred to [drive9-ai/k8s-csi#36](https://github.com/drive9-ai/k8s-csi/issues/36).

Closes #859

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-variable support for configuring local-only and remote-only mount path patterns.
  * Patterns are validated, deduplicated, and applied to foreground, background, and supervised mounts.
  * Remote-only rules can override built-in local-only rules where applicable.

* **Documentation**
  * Updated mount help text with environment-variable details and usage examples.

* **Bug Fixes**
  * Prevented mount policy environment variables from leaking into child processes after being consumed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->