### PR TITLE
feat(client): reject invalid fs paths client-side with actionable hints

### DIFF
--- a/pkg/client/append.go
+++ b/pkg/client/append.go
@@ -109,7 +109,11 @@ func (c *Client) initiateAppend(ctx context.Context, path string, appendSize int
 		return nil, fmt.Errorf("marshal append request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path)+"?append", bytes.NewReader(body))
+	reqURL, err := c.url(path)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?append", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/append.go
+++ b/pkg/client/append.go
@@ -109,11 +109,7 @@ func (c *Client) initiateAppend(ctx context.Context, path string, appendSize int
 		return nil, fmt.Errorf("marshal append request: %w", err)
 	}
 
-	reqURL, err := c.url(path)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?append", bytes.NewReader(body))
+	req, err := c.newFSRequest(ctx, http.MethodPost, path, "?append", bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/append_log.go
+++ b/pkg/client/append_log.go
@@ -42,7 +42,11 @@ func (c *Client) AppendLog(ctx context.Context, path string, tail io.Reader, tai
 		tail = bytes.NewReader(nil)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path)+"?append-log", tail)
+	reqURL, err := c.url(path)
+	if err != nil {
+		return AppendLogResult{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?append-log", tail)
 	if err != nil {
 		return AppendLogResult{}, err
 	}
@@ -96,7 +100,11 @@ func (c *Client) WriteServerStreamConditional(ctx context.Context, path string, 
 		body = bytes.NewReader(nil)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(path), body)
+	reqURL, err := c.url(path)
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, body)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/client/append_log.go
+++ b/pkg/client/append_log.go
@@ -42,11 +42,7 @@ func (c *Client) AppendLog(ctx context.Context, path string, tail io.Reader, tai
 		tail = bytes.NewReader(nil)
 	}
 
-	reqURL, err := c.url(path)
-	if err != nil {
-		return AppendLogResult{}, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?append-log", tail)
+	req, err := c.newFSRequest(ctx, http.MethodPost, path, "?append-log", tail)
 	if err != nil {
 		return AppendLogResult{}, err
 	}
@@ -100,11 +96,7 @@ func (c *Client) WriteServerStreamConditional(ctx context.Context, path string, 
 		body = bytes.NewReader(nil)
 	}
 
-	reqURL, err := c.url(path)
-	if err != nil {
-		return 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, body)
+	req, err := c.newFSRequest(ctx, http.MethodPut, path, "", body)
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -410,11 +410,16 @@ type StatMetadataResult struct {
 
 var errStatMetadataCompatFallback = errors.New("stat metadata fallback to legacy HEAD")
 
-func (c *Client) url(path string) string {
+// url builds the /v1/fs request URL for path, rejecting paths the server
+// would refuse with HTTP 400 so callers fail fast client-side.
+func (c *Client) url(path string) (string, error) {
+	if err := validateFSPath(path); err != nil {
+		return "", err
+	}
 	if !strings.HasPrefix(path, "/") {
 		path = "/" + path
 	}
-	return c.baseURL + "/v1/fs" + escapeFSPath(path)
+	return c.baseURL + "/v1/fs" + escapeFSPath(path), nil
 }
 
 func escapeFSPath(path string) string {
@@ -741,7 +746,11 @@ func (c *Client) CreateFile(path string) (int64, error) {
 // CreateFileCtx creates an empty file with context support and returns the
 // committed file revision when the server reports it.
 func (c *Client) CreateFileCtx(ctx context.Context, path string) (int64, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path)+"?create=1", nil)
+	reqURL, err := c.url(path)
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?create=1", nil)
 	if err != nil {
 		return 0, err
 	}
@@ -776,7 +785,11 @@ func (c *Client) SymlinkCtx(ctx context.Context, target, linkPath string) error 
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(linkPath)+"?symlink=1", bytes.NewReader(body))
+	reqURL, err := c.url(linkPath)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?symlink=1", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -799,7 +812,14 @@ func (c *Client) Hardlink(srcPath, dstPath string) error {
 
 // HardlinkCtx creates a hard link with context support.
 func (c *Client) HardlinkCtx(ctx context.Context, srcPath, dstPath string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(dstPath)+"?hardlink=1", nil)
+	if err := validateFSPath(srcPath); err != nil {
+		return err
+	}
+	reqURL, err := c.url(dstPath)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?hardlink=1", nil)
 	if err != nil {
 		return err
 	}
@@ -816,7 +836,11 @@ func (c *Client) HardlinkCtx(ctx context.Context, srcPath, dstPath string) error
 }
 
 func (c *Client) writeCtxConditionalFull(ctx context.Context, path string, data []byte, expectedRevision int64, tags map[string]string, description string) (int64, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(path), bytes.NewReader(data))
+	reqURL, err := c.url(path)
+	if err != nil {
+		return 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(data))
 	if err != nil {
 		return 0, err
 	}
@@ -863,7 +887,11 @@ func (c *Client) Read(path string) ([]byte, error) {
 
 // ReadCtx downloads a file's content with context support.
 func (c *Client) ReadCtx(ctx context.Context, path string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(path), nil)
+	reqURL, err := c.url(path)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -901,7 +929,11 @@ func (c *Client) List(path string) ([]FileInfo, error) {
 // ListCtx returns the entries in a directory with context support.
 func (c *Client) ListCtx(ctx context.Context, path string) ([]FileInfo, error) {
 	// Use an explicit value to avoid intermediaries dropping bare "?list".
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(path)+"?list=1", nil)
+	reqURL, err := c.url(path)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL+"?list=1", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -938,6 +970,11 @@ func (c *Client) BatchStatWithOptionsCtx(ctx context.Context, paths []string, op
 	}
 	if len(paths) > MaxBatchStatPaths {
 		return nil, fmt.Errorf("batch stat: %d paths exceeds limit of %d", len(paths), MaxBatchStatPaths)
+	}
+	for _, p := range paths {
+		if err := validateFSPath(p); err != nil {
+			return nil, err
+		}
 	}
 	body, err := json.Marshal(struct {
 		Paths           []string `json:"paths"`
@@ -982,6 +1019,11 @@ func (c *Client) BatchReadSmallCtx(ctx context.Context, paths []string, maxBytes
 	}
 	if len(paths) > MaxBatchReadSmallPaths {
 		return nil, fmt.Errorf("batch read-small: %d paths exceeds limit of %d", len(paths), MaxBatchReadSmallPaths)
+	}
+	for _, p := range paths {
+		if err := validateFSPath(p); err != nil {
+			return nil, err
+		}
 	}
 	body, err := json.Marshal(struct {
 		Paths    []string `json:"paths"`
@@ -1034,6 +1076,9 @@ func (c *Client) BatchWriteCtx(ctx context.Context, items []BatchWriteItem) ([]B
 	}
 	var total int64
 	for _, item := range items {
+		if err := validateFSPath(item.Path); err != nil {
+			return nil, err
+		}
 		total += int64(len(item.Data))
 		if total > MaxBatchWriteBytes {
 			return nil, fmt.Errorf("batch write: %d bytes exceeds limit of %d", total, MaxBatchWriteBytes)
@@ -1089,7 +1134,11 @@ func (c *Client) Stat(path string) (*StatResult, error) {
 // StatCtx is the context-aware form of the lightweight HEAD-based Stat
 // interface. Use StatMetadataCompatCtx when enriched metadata is required.
 func (c *Client) StatCtx(ctx context.Context, path string) (*StatResult, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, c.url(path), nil)
+	reqURL, err := c.url(path)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, reqURL, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1141,7 +1190,11 @@ func (c *Client) StatMetadata(path string) (*StatMetadataResult, error) {
 
 // StatMetadataCtx returns enriched metadata for a path with context support.
 func (c *Client) StatMetadataCtx(ctx context.Context, path string) (*StatMetadataResult, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(path)+"?stat=1", nil)
+	reqURL, err := c.url(path)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL+"?stat=1", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1297,7 +1350,10 @@ func removeAllRetryDelay(retryAfter string, backoff time.Duration) time.Duration
 }
 
 func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kind string) error {
-	requestURL := c.url(path)
+	requestURL, err := c.url(path)
+	if err != nil {
+		return err
+	}
 	if recursive {
 		// Use an explicit value to avoid intermediaries dropping bare "?recursive".
 		requestURL += "?recursive=1"
@@ -1349,7 +1405,14 @@ func (c *Client) Copy(srcPath, dstPath string) error {
 // tree copy). The non-Ctx Copy delegates here so both paths share
 // the same request shape.
 func (c *Client) CopyCtx(ctx context.Context, srcPath, dstPath string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(dstPath)+"?copy", nil)
+	if err := validateFSPath(srcPath); err != nil {
+		return err
+	}
+	reqURL, err := c.url(dstPath)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?copy", nil)
 	if err != nil {
 		return err
 	}
@@ -1372,7 +1435,14 @@ func (c *Client) Rename(oldPath, newPath string) error {
 
 // RenameCtx moves/renames a file or directory with context support.
 func (c *Client) RenameCtx(ctx context.Context, oldPath, newPath string) error {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(newPath)+"?rename", nil)
+	if err := validateFSPath(oldPath); err != nil {
+		return err
+	}
+	reqURL, err := c.url(newPath)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?rename", nil)
 	if err != nil {
 		return err
 	}
@@ -1395,7 +1465,11 @@ func (c *Client) Mkdir(path string) error {
 
 // MkdirCtx creates a directory with context support.
 func (c *Client) MkdirCtx(ctx context.Context, path string, mode uint32) error {
-	urlStr := c.url(path) + "?mkdir"
+	urlStr, err := c.url(path)
+	if err != nil {
+		return err
+	}
+	urlStr += "?mkdir"
 	if mode != 0o755 {
 		urlStr += "&mode=" + strconv.FormatUint(uint64(mode), 10)
 	}
@@ -1425,7 +1499,11 @@ func (c *Client) ChmodCtx(ctx context.Context, path string, mode uint32) error {
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path)+"?chmod", bytes.NewReader(body))
+	reqURL, err := c.url(path)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?chmod", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -1499,7 +1577,11 @@ func (c *Client) Grep(query, pathPrefix string, limit int) ([]SearchResult, erro
 }
 
 func (c *Client) GrepWithLayer(query, pathPrefix string, limit int, layerRef string) ([]SearchResult, error) {
-	u := c.url(pathPrefix) + "?grep=" + url.QueryEscape(query)
+	u, err := c.url(pathPrefix)
+	if err != nil {
+		return nil, err
+	}
+	u += "?grep=" + url.QueryEscape(query)
 	if limit > 0 {
 		u += "&limit=" + strconv.Itoa(limit)
 	}
@@ -1527,7 +1609,11 @@ func (c *Client) GrepWithLayer(query, pathPrefix string, limit int, layerRef str
 
 func (c *Client) Find(pathPrefix string, params url.Values) ([]SearchResult, error) {
 	params.Set("find", "")
-	u := c.url(pathPrefix) + "?" + params.Encode()
+	u, err := c.url(pathPrefix)
+	if err != nil {
+		return nil, err
+	}
+	u += "?" + params.Encode()
 	req, err := http.NewRequest(http.MethodGet, u, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -424,6 +424,17 @@ func (c *Client) url(path string) (string, error) {
 	return c.baseURL + "/v1/fs" + escapeFSPath(path), nil
 }
 
+// newFSRequest builds an HTTP request for the /v1/fs endpoint, rejecting
+// paths the server would refuse with HTTP 400 so callers fail fast
+// client-side. rawQuery includes the leading "?" or is empty.
+func (c *Client) newFSRequest(ctx context.Context, method, path, rawQuery string, body io.Reader) (*http.Request, error) {
+	reqURL, err := c.url(path)
+	if err != nil {
+		return nil, err
+	}
+	return http.NewRequestWithContext(ctx, method, reqURL+rawQuery, body)
+}
+
 func escapeFSPath(path string) string {
 	// Escape each path byte that is unsafe in an HTTP request target while
 	// retaining separators so the server receives the original path shape.
@@ -748,11 +759,7 @@ func (c *Client) CreateFile(path string) (int64, error) {
 // CreateFileCtx creates an empty file with context support and returns the
 // committed file revision when the server reports it.
 func (c *Client) CreateFileCtx(ctx context.Context, path string) (int64, error) {
-	reqURL, err := c.url(path)
-	if err != nil {
-		return 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?create=1", nil)
+	req, err := c.newFSRequest(ctx, http.MethodPost, path, "?create=1", nil)
 	if err != nil {
 		return 0, err
 	}
@@ -787,11 +794,7 @@ func (c *Client) SymlinkCtx(ctx context.Context, target, linkPath string) error 
 	if err != nil {
 		return err
 	}
-	reqURL, err := c.url(linkPath)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?symlink=1", bytes.NewReader(body))
+	req, err := c.newFSRequest(ctx, http.MethodPost, linkPath, "?symlink=1", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -817,11 +820,7 @@ func (c *Client) HardlinkCtx(ctx context.Context, srcPath, dstPath string) error
 	if err := validateFSPath(srcPath); err != nil {
 		return err
 	}
-	reqURL, err := c.url(dstPath)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?hardlink=1", nil)
+	req, err := c.newFSRequest(ctx, http.MethodPost, dstPath, "?hardlink=1", nil)
 	if err != nil {
 		return err
 	}
@@ -838,11 +837,7 @@ func (c *Client) HardlinkCtx(ctx context.Context, srcPath, dstPath string) error
 }
 
 func (c *Client) writeCtxConditionalFull(ctx context.Context, path string, data []byte, expectedRevision int64, tags map[string]string, description string) (int64, error) {
-	reqURL, err := c.url(path)
-	if err != nil {
-		return 0, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, bytes.NewReader(data))
+	req, err := c.newFSRequest(ctx, http.MethodPut, path, "", bytes.NewReader(data))
 	if err != nil {
 		return 0, err
 	}
@@ -889,11 +884,7 @@ func (c *Client) Read(path string) ([]byte, error) {
 
 // ReadCtx downloads a file's content with context support.
 func (c *Client) ReadCtx(ctx context.Context, path string) ([]byte, error) {
-	reqURL, err := c.url(path)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := c.newFSRequest(ctx, http.MethodGet, path, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -931,11 +922,7 @@ func (c *Client) List(path string) ([]FileInfo, error) {
 // ListCtx returns the entries in a directory with context support.
 func (c *Client) ListCtx(ctx context.Context, path string) ([]FileInfo, error) {
 	// Use an explicit value to avoid intermediaries dropping bare "?list".
-	reqURL, err := c.url(path)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL+"?list=1", nil)
+	req, err := c.newFSRequest(ctx, http.MethodGet, path, "?list=1", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1142,11 +1129,7 @@ func (c *Client) Stat(path string) (*StatResult, error) {
 // StatCtx is the context-aware form of the lightweight HEAD-based Stat
 // interface. Use StatMetadataCompatCtx when enriched metadata is required.
 func (c *Client) StatCtx(ctx context.Context, path string) (*StatResult, error) {
-	reqURL, err := c.url(path)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, reqURL, nil)
+	req, err := c.newFSRequest(ctx, http.MethodHead, path, "", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1198,11 +1181,7 @@ func (c *Client) StatMetadata(path string) (*StatMetadataResult, error) {
 
 // StatMetadataCtx returns enriched metadata for a path with context support.
 func (c *Client) StatMetadataCtx(ctx context.Context, path string) (*StatMetadataResult, error) {
-	reqURL, err := c.url(path)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL+"?stat=1", nil)
+	req, err := c.newFSRequest(ctx, http.MethodGet, path, "?stat=1", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1358,20 +1337,17 @@ func removeAllRetryDelay(retryAfter string, backoff time.Duration) time.Duration
 }
 
 func (c *Client) deleteCtx(ctx context.Context, path string, recursive bool, kind string) error {
-	requestURL, err := c.url(path)
-	if err != nil {
-		return err
-	}
+	// Use an explicit value to avoid intermediaries dropping bare "?recursive".
+	var rawQuery string
 	if recursive {
-		// Use an explicit value to avoid intermediaries dropping bare "?recursive".
-		requestURL += "?recursive=1"
+		rawQuery = "?recursive=1"
 	} else if kind != "" {
-		requestURL += "?kind=" + url.QueryEscape(kind)
+		rawQuery = "?kind=" + url.QueryEscape(kind)
 	}
 
 	backoff := time.Second
 	for attempt := 0; ; attempt++ {
-		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, requestURL, nil)
+		req, err := c.newFSRequest(ctx, http.MethodDelete, path, rawQuery, nil)
 		if err != nil {
 			return err
 		}
@@ -1416,11 +1392,7 @@ func (c *Client) CopyCtx(ctx context.Context, srcPath, dstPath string) error {
 	if err := validateFSPath(srcPath); err != nil {
 		return err
 	}
-	reqURL, err := c.url(dstPath)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?copy", nil)
+	req, err := c.newFSRequest(ctx, http.MethodPost, dstPath, "?copy", nil)
 	if err != nil {
 		return err
 	}
@@ -1446,11 +1418,7 @@ func (c *Client) RenameCtx(ctx context.Context, oldPath, newPath string) error {
 	if err := validateFSPath(oldPath); err != nil {
 		return err
 	}
-	reqURL, err := c.url(newPath)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?rename", nil)
+	req, err := c.newFSRequest(ctx, http.MethodPost, newPath, "?rename", nil)
 	if err != nil {
 		return err
 	}
@@ -1473,15 +1441,11 @@ func (c *Client) Mkdir(path string) error {
 
 // MkdirCtx creates a directory with context support.
 func (c *Client) MkdirCtx(ctx context.Context, path string, mode uint32) error {
-	urlStr, err := c.url(path)
-	if err != nil {
-		return err
-	}
-	urlStr += "?mkdir"
+	rawQuery := "?mkdir"
 	if mode != 0o755 {
-		urlStr += "&mode=" + strconv.FormatUint(uint64(mode), 10)
+		rawQuery += "&mode=" + strconv.FormatUint(uint64(mode), 10)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, urlStr, nil)
+	req, err := c.newFSRequest(ctx, http.MethodPost, path, rawQuery, nil)
 	if err != nil {
 		return err
 	}
@@ -1507,11 +1471,7 @@ func (c *Client) ChmodCtx(ctx context.Context, path string, mode uint32) error {
 	if err != nil {
 		return err
 	}
-	reqURL, err := c.url(path)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?chmod", bytes.NewReader(body))
+	req, err := c.newFSRequest(ctx, http.MethodPost, path, "?chmod", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}
@@ -1585,18 +1545,14 @@ func (c *Client) Grep(query, pathPrefix string, limit int) ([]SearchResult, erro
 }
 
 func (c *Client) GrepWithLayer(query, pathPrefix string, limit int, layerRef string) ([]SearchResult, error) {
-	u, err := c.url(pathPrefix)
-	if err != nil {
-		return nil, err
-	}
-	u += "?grep=" + url.QueryEscape(query)
+	rawQuery := "?grep=" + url.QueryEscape(query)
 	if limit > 0 {
-		u += "&limit=" + strconv.Itoa(limit)
+		rawQuery += "&limit=" + strconv.Itoa(limit)
 	}
 	if strings.TrimSpace(layerRef) != "" {
-		u += "&layer=" + url.QueryEscape(strings.TrimSpace(layerRef))
+		rawQuery += "&layer=" + url.QueryEscape(strings.TrimSpace(layerRef))
 	}
-	req, err := http.NewRequest(http.MethodGet, u, nil)
+	req, err := c.newFSRequest(context.Background(), http.MethodGet, pathPrefix, rawQuery, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1617,12 +1573,7 @@ func (c *Client) GrepWithLayer(query, pathPrefix string, limit int, layerRef str
 
 func (c *Client) Find(pathPrefix string, params url.Values) ([]SearchResult, error) {
 	params.Set("find", "")
-	u, err := c.url(pathPrefix)
-	if err != nil {
-		return nil, err
-	}
-	u += "?" + params.Encode()
-	req, err := http.NewRequest(http.MethodGet, u, nil)
+	req, err := c.newFSRequest(context.Background(), http.MethodGet, pathPrefix, "?"+params.Encode(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -354,8 +354,10 @@ func (r BatchStatResult) OK() bool {
 
 // BatchReadSmallResult is one per-path result from BatchReadSmallCtx.
 //
-// Data is JSON base64-encoded on the wire. Missing, invalid, directory, and
-// too-large paths are reported as per-path errors.
+// Data is JSON base64-encoded on the wire. Missing, directory, and too-large
+// paths are reported as per-path errors. (Paths the server would reject with
+// HTTP 400 never reach the wire: client-side validation fails the whole
+// BatchReadSmallCtx call first.)
 type BatchReadSmallResult struct {
 	Path     string `json:"path"`
 	Status   int    `json:"status"`
@@ -958,7 +960,9 @@ func (c *Client) ListCtx(ctx context.Context, path string) ([]FileInfo, error) {
 //
 // Transport/request errors fail the method. Per-path stat errors are returned
 // inside the corresponding BatchStatResult so one missing path does not fail
-// the whole batch.
+// the whole batch. A path that fails client-side validation (anything the
+// server would reject with HTTP 400, e.g. backslashes or ".." segments)
+// fails the whole call before any request is sent.
 func (c *Client) BatchStatCtx(ctx context.Context, paths []string) ([]BatchStatResult, error) {
 	return c.BatchStatWithOptionsCtx(ctx, paths, BatchStatOptions{})
 }
@@ -1012,7 +1016,9 @@ func (c *Client) BatchStatWithOptionsCtx(ctx context.Context, paths []string, op
 //
 // Transport/request errors fail the method. Per-path read errors are returned
 // inside the corresponding BatchReadSmallResult so one missing or too-large
-// path does not fail the whole batch.
+// path does not fail the whole batch. A path that fails client-side validation
+// (anything the server would reject with HTTP 400, e.g. backslashes or ".."
+// segments) fails the whole call before any request is sent.
 func (c *Client) BatchReadSmallCtx(ctx context.Context, paths []string, maxBytes int64) ([]BatchReadSmallResult, error) {
 	if len(paths) == 0 {
 		return []BatchReadSmallResult{}, nil
@@ -1066,7 +1072,9 @@ func (c *Client) BatchReadSmallCtx(ctx context.Context, paths []string, maxBytes
 //
 // Transport/request errors fail the method. Per-path write errors are returned
 // inside the corresponding BatchWriteResult so one conflict does not fail the
-// whole batch.
+// whole batch. A path that fails client-side validation (anything the server
+// would reject with HTTP 400, e.g. backslashes or ".." segments) fails the
+// whole call before any request is sent.
 func (c *Client) BatchWriteCtx(ctx context.Context, items []BatchWriteItem) ([]BatchWriteResult, error) {
 	if len(items) == 0 {
 		return []BatchWriteResult{}, nil

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -85,7 +85,11 @@ func (c *Client) PatchFile(ctx context.Context, path string, newSize int64, dirt
 		return fmt.Errorf("marshal patch request: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, c.url(path), bytes.NewReader(reqBody))
+	reqURL, err := c.url(path)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, reqURL, bytes.NewReader(reqBody))
 	if err != nil {
 		return err
 	}

--- a/pkg/client/patch.go
+++ b/pkg/client/patch.go
@@ -85,11 +85,7 @@ func (c *Client) PatchFile(ctx context.Context, path string, newSize int64, dirt
 		return fmt.Errorf("marshal patch request: %w", err)
 	}
 
-	reqURL, err := c.url(path)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, reqURL, bytes.NewReader(reqBody))
+	req, err := c.newFSRequest(ctx, http.MethodPatch, path, "", bytes.NewReader(reqBody))
 	if err != nil {
 		return err
 	}

--- a/pkg/client/path.go
+++ b/pkg/client/path.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/mem9-ai/drive9/pkg/pathutil"
+)
+
+// windowsDriveSegment matches a Windows drive-letter prefix ("C:\" or "D:/")
+// at the start of the path or at the start of any path segment. The segment
+// form catches the observed failure mode where a client joins a Windows local
+// absolute path onto a drive9 directory, e.g. "/remote/dir/C:\stock".
+var windowsDriveSegment = regexp.MustCompile(`(?:^|/)[A-Za-z]:[\\/]`)
+
+// validateFSPath rejects paths the server would refuse with HTTP 400 so the
+// caller fails fast with an actionable message instead of a server round
+// trip. Validation only: the server remains the canonicalization authority,
+// and the original path is sent unchanged when valid.
+func validateFSPath(path string) error {
+	if _, err := pathutil.Canonicalize(path); err != nil {
+		return fmt.Errorf("invalid drive9 path %q: %v%s", path, err, windowsPathHint(path))
+	}
+	return nil
+}
+
+// windowsPathHint returns actionable guidance when an invalid path looks like
+// it came from a Windows local filesystem.
+func windowsPathHint(path string) string {
+	switch {
+	case windowsDriveSegment.MatchString(path):
+		return "; path looks like a Windows local path — drive9 paths are absolute POSIX paths with no drive letter; strip the drive prefix and convert separators (e.g. filepath.ToSlash) before calling"
+	case strings.ContainsRune(path, '\\'):
+		return "; drive9 paths use forward slashes — convert Windows-style separators (e.g. filepath.ToSlash) before calling"
+	default:
+		return ""
+	}
+}

--- a/pkg/client/path.go
+++ b/pkg/client/path.go
@@ -20,7 +20,7 @@ var windowsDriveSegment = regexp.MustCompile(`(?:^|/)[A-Za-z]:[\\/]`)
 // and the original path is sent unchanged when valid.
 func validateFSPath(path string) error {
 	if _, err := pathutil.Canonicalize(path); err != nil {
-		return fmt.Errorf("invalid drive9 path %q: %v%s", path, err, windowsPathHint(path))
+		return fmt.Errorf("invalid drive9 path %q: %w%s", path, err, windowsPathHint(path))
 	}
 	return nil
 }

--- a/pkg/client/path.go
+++ b/pkg/client/path.go
@@ -30,7 +30,7 @@ func validateFSPath(path string) error {
 func windowsPathHint(path string) string {
 	switch {
 	case windowsDriveSegment.MatchString(path):
-		return "; path looks like a Windows local path — drive9 paths are absolute POSIX paths with no drive letter; strip the drive prefix and convert separators (e.g. filepath.ToSlash) before calling"
+		return "; path looks like a Windows local path — drive9 paths are absolute POSIX paths with no drive letter; remove the Windows drive segment (e.g. `C:\\`) and convert separators with filepath.ToSlash before calling"
 	case strings.ContainsRune(path, '\\'):
 		return "; drive9 paths use forward slashes — convert Windows-style separators (e.g. filepath.ToSlash) before calling"
 	default:

--- a/pkg/client/path_test.go
+++ b/pkg/client/path_test.go
@@ -44,12 +44,13 @@ func TestValidateFSPath(t *testing.T) {
 			err := validateFSPath(tc.path)
 			if tc.wantSub == "" {
 				if err != nil {
-					t.Fatalf("validateFSPath(%q) = %v, want nil", tc.path, err)
+					t.Errorf("validateFSPath(%q) = %v, want nil", tc.path, err)
 				}
 				return
 			}
 			if err == nil {
-				t.Fatalf("validateFSPath(%q) = nil, want error containing %q", tc.path, tc.wantSub)
+				t.Errorf("validateFSPath(%q) = nil, want error containing %q", tc.path, tc.wantSub)
+				return
 			}
 			if !strings.Contains(err.Error(), "invalid drive9 path") {
 				t.Errorf("error = %v, want invalid drive9 path prefix", err)
@@ -112,6 +113,6 @@ func TestFSMethodsRejectWindowsPathBeforeRequest(t *testing.T) {
 		}
 	}
 	if called.Load() {
-		t.Fatal("server was called despite client-side path validation")
+		t.Error("server was called despite client-side path validation")
 	}
 }

--- a/pkg/client/path_test.go
+++ b/pkg/client/path_test.go
@@ -1,0 +1,117 @@
+//go:build !integration
+
+package client
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+func TestValidateFSPath(t *testing.T) {
+	valid := []string{
+		"/",
+		"",
+		"/ok.txt",
+		"/dir/sub dir/文件.txt",
+		"relative/ok.txt", // server roots it; client only rejects what the server would
+		"/trailing-slash-dir/",
+	}
+	for _, p := range valid {
+		if err := validateFSPath(p); err != nil {
+			t.Errorf("validateFSPath(%q) = %v, want nil", p, err)
+		}
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		wantSub  string
+		wantHint string
+	}{
+		{name: "windows drive absolute", path: `C:\股票工具`, wantSub: "path contains backslash", wantHint: "Windows local path"},
+		{name: "embedded windows drive segment", path: `/个股回测工具/C:\股票工具`, wantSub: "path contains backslash", wantHint: "Windows local path"},
+		{name: "windows forward-slash drive", path: `D:/股票工具/x`, wantSub: "", wantHint: ""}, // valid POSIX path; no rejection
+		{name: "bare backslash", path: `/dir/sub\name`, wantSub: "path contains backslash", wantHint: "forward slashes"},
+		{name: "dot dot", path: "/dir/../escape", wantSub: `".." segment`, wantHint: ""},
+		{name: "nul", path: "/dir/\x00x", wantSub: "NUL", wantHint: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateFSPath(tc.path)
+			if tc.wantSub == "" {
+				if err != nil {
+					t.Fatalf("validateFSPath(%q) = %v, want nil", tc.path, err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateFSPath(%q) = nil, want error containing %q", tc.path, tc.wantSub)
+			}
+			if !strings.Contains(err.Error(), "invalid drive9 path") {
+				t.Errorf("error = %v, want invalid drive9 path prefix", err)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("error = %v, want containing %q", err, tc.wantSub)
+			}
+			if tc.wantHint != "" && !strings.Contains(err.Error(), tc.wantHint) {
+				t.Errorf("error = %v, want hint containing %q", err, tc.wantHint)
+			}
+		})
+	}
+}
+
+func TestFSMethodsRejectWindowsPathBeforeRequest(t *testing.T) {
+	var called atomic.Bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called.Store(true)
+	}))
+	defer ts.Close()
+	c := New(ts.URL, "")
+
+	ctx := context.Background()
+	// Shape observed in production: a Windows local absolute path joined
+	// onto a drive9 directory as a path segment.
+	bad := `/个股回测工具/C:\股票工具`
+	checks := map[string]func() error{
+		"Mkdir":       func() error { return c.MkdirCtx(ctx, bad, 0o755) },
+		"Write":       func() error { return c.WriteCtx(ctx, bad, []byte("x")) },
+		"Read":        func() error { _, err := c.ReadCtx(ctx, bad); return err },
+		"List":        func() error { _, err := c.ListCtx(ctx, bad); return err },
+		"Stat":        func() error { _, err := c.StatCtx(ctx, bad); return err },
+		"Delete":      func() error { return c.DeleteCtx(ctx, bad) },
+		"RenameSrc":   func() error { return c.RenameCtx(ctx, bad, "/ok") },
+		"RenameDst":   func() error { return c.RenameCtx(ctx, "/ok", bad) },
+		"CopySrc":     func() error { return c.CopyCtx(ctx, bad, "/ok") },
+		"CopyDst":     func() error { return c.CopyCtx(ctx, "/ok", bad) },
+		"HardlinkSrc": func() error { return c.HardlinkCtx(ctx, bad, "/ok") },
+		"BatchStat":   func() error { _, err := c.BatchStatCtx(ctx, []string{"/ok", bad}); return err },
+		"BatchReadSmall": func() error {
+			_, err := c.BatchReadSmallCtx(ctx, []string{bad}, 16)
+			return err
+		},
+		"BatchWrite": func() error {
+			_, err := c.BatchWriteCtx(ctx, []BatchWriteItem{{Path: bad, Data: []byte("x")}})
+			return err
+		},
+	}
+	for name, fn := range checks {
+		err := fn()
+		if err == nil {
+			t.Errorf("%s: error = nil, want invalid path error", name)
+			continue
+		}
+		if !strings.Contains(err.Error(), "invalid drive9 path") {
+			t.Errorf("%s: error = %v, want invalid drive9 path", name, err)
+		}
+		if !strings.Contains(err.Error(), "Windows local path") {
+			t.Errorf("%s: error = %v, want Windows hint", name, err)
+		}
+	}
+	if called.Load() {
+		t.Fatal("server was called despite client-side path validation")
+	}
+}

--- a/pkg/client/path_test.go
+++ b/pkg/client/path_test.go
@@ -120,6 +120,9 @@ func TestFSMethodsRejectWindowsPathBeforeRequest(t *testing.T) {
 		"ResumeUpload": func() error {
 			return c.ResumeUpload(ctx, bad, bytes.NewReader([]byte("x")), 1<<20, nil)
 		},
+		"WriteMultipartStream": func() error {
+			return c.WriteMultipartStreamConditional(ctx, bad, bytes.NewReader([]byte("x")), 1<<20, nil, 1)
+		},
 		"StreamWriter": func() error { return sw.WritePart(ctx, 1, []byte("x")) },
 		"BatchStat":    func() error { _, err := c.BatchStatCtx(ctx, []string{"/ok", bad}); return err },
 		"BatchReadSmall": func() error {

--- a/pkg/client/path_test.go
+++ b/pkg/client/path_test.go
@@ -101,6 +101,17 @@ func TestFSMethodsRejectWindowsPathBeforeRequest(t *testing.T) {
 		"AppendStream": func() error {
 			return c.AppendStream(ctx, bad, strings.NewReader("x"), 1, nil)
 		},
+		"AppendLog": func() error {
+			_, err := c.AppendLog(ctx, bad, strings.NewReader("x"), 1, 0, 0)
+			return err
+		},
+		"WriteServerStream": func() error {
+			_, err := c.WriteServerStreamConditional(ctx, bad, strings.NewReader("x"), 1, 0)
+			return err
+		},
+		"SetMetadata": func() error {
+			return c.SetMetadataCtx(ctx, bad, SetMetadataOptions{Tags: map[string]string{"k": "v"}})
+		},
 		// Large size forces the multipart upload session path; validation
 		// must fire before the /v1/status threshold fetch and checksum work.
 		"WriteStream": func() error {

--- a/pkg/client/path_test.go
+++ b/pkg/client/path_test.go
@@ -3,9 +3,11 @@
 package client
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -77,6 +79,7 @@ func TestFSMethodsRejectWindowsPathBeforeRequest(t *testing.T) {
 	// Shape observed in production: a Windows local absolute path joined
 	// onto a drive9 directory as a path segment.
 	bad := `/个股回测工具/C:\股票工具`
+	sw := c.NewStreamWriter(ctx, bad, 1024)
 	checks := map[string]func() error{
 		"Mkdir":       func() error { return c.MkdirCtx(ctx, bad, 0o755) },
 		"Write":       func() error { return c.WriteCtx(ctx, bad, []byte("x")) },
@@ -89,7 +92,25 @@ func TestFSMethodsRejectWindowsPathBeforeRequest(t *testing.T) {
 		"CopySrc":     func() error { return c.CopyCtx(ctx, bad, "/ok") },
 		"CopyDst":     func() error { return c.CopyCtx(ctx, "/ok", bad) },
 		"HardlinkSrc": func() error { return c.HardlinkCtx(ctx, bad, "/ok") },
-		"BatchStat":   func() error { _, err := c.BatchStatCtx(ctx, []string{"/ok", bad}); return err },
+		"Symlink":     func() error { return c.SymlinkCtx(ctx, "/target", bad) },
+		"Chmod":       func() error { return c.ChmodCtx(ctx, bad, 0o600) },
+		"CreateFile":  func() error { _, err := c.CreateFileCtx(ctx, bad); return err },
+		"Grep":        func() error { _, err := c.Grep("q", bad, 0); return err },
+		"Find":        func() error { _, err := c.Find(bad, url.Values{}); return err },
+		"PatchFile":   func() error { return c.PatchFile(ctx, bad, 0, nil, nil, nil) },
+		"AppendStream": func() error {
+			return c.AppendStream(ctx, bad, strings.NewReader("x"), 1, nil)
+		},
+		// Large size forces the multipart upload session path; validation
+		// must fire before the /v1/status threshold fetch and checksum work.
+		"WriteStream": func() error {
+			return c.WriteStream(ctx, bad, bytes.NewReader([]byte("x")), 1<<20, nil)
+		},
+		"ResumeUpload": func() error {
+			return c.ResumeUpload(ctx, bad, bytes.NewReader([]byte("x")), 1<<20, nil)
+		},
+		"StreamWriter": func() error { return sw.WritePart(ctx, 1, []byte("x")) },
+		"BatchStat":    func() error { _, err := c.BatchStatCtx(ctx, []string{"/ok", bad}); return err },
 		"BatchReadSmall": func() error {
 			_, err := c.BatchReadSmallCtx(ctx, []string{bad}, 16)
 			return err

--- a/pkg/client/setmeta.go
+++ b/pkg/client/setmeta.go
@@ -48,11 +48,7 @@ func (c *Client) SetMetadataCtx(ctx context.Context, path string, opts SetMetada
 	if err != nil {
 		return err
 	}
-	reqURL, err := c.url(path)
-	if err != nil {
-		return err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?setmeta=1", bytes.NewReader(body))
+	req, err := c.newFSRequest(ctx, http.MethodPost, path, "?setmeta=1", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/pkg/client/setmeta.go
+++ b/pkg/client/setmeta.go
@@ -48,7 +48,11 @@ func (c *Client) SetMetadataCtx(ctx context.Context, path string, opts SetMetada
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path)+"?setmeta=1", bytes.NewReader(body))
+	reqURL, err := c.url(path)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, reqURL+"?setmeta=1", bytes.NewReader(body))
 	if err != nil {
 		return err
 	}

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -754,7 +754,11 @@ func (c *Client) initiateUploadByBody(ctx context.Context, path string, size int
 }
 
 func (c *Client) initiateUploadLegacy(ctx context.Context, path string, size int64, checksums []string, expectedRevision int64, description string) (UploadPlan, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.url(path), http.NoBody)
+	reqURL, err := c.url(path)
+	if err != nil {
+		return UploadPlan{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, http.NoBody)
 	if err != nil {
 		return UploadPlan{}, err
 	}
@@ -1390,7 +1394,11 @@ func (c *Client) readWithoutRedirect(ctx context.Context, path, rangeHeader stri
 		return http.ErrUseLastResponse
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url(path), nil)
+	reqURL, err := c.url(path)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -450,6 +450,11 @@ func (c *Client) writeStreamConditionalWithSummary(ctx context.Context, path str
 }
 
 func (c *Client) writeStreamConditionalWithSummaryAndPreCompleteCheck(ctx context.Context, path string, r io.Reader, size int64, progress ProgressFunc, expectedRevision int64, tags map[string]string, description, checksumSHA256 string, preCompleteCheck func() error) (*UploadSummary, error) {
+	// Validate before the threshold fetch and any checksum work so a bad
+	// path fails fast without a round trip or wasted CPU.
+	if err := validateFSPath(path); err != nil {
+		return nil, err
+	}
 	if err := validateWholeChecksumSHA256(checksumSHA256); err != nil {
 		return nil, err
 	}
@@ -722,6 +727,9 @@ func (c *Client) initiateUpload(ctx context.Context, path string, size int64, ch
 }
 
 func (c *Client) initiateUploadByBody(ctx context.Context, path string, size int64, checksums []string, expectedRevision int64, description string) (UploadPlan, *http.Response, error) {
+	if err := validateFSPath(path); err != nil {
+		return UploadPlan{}, nil, err
+	}
 	body, err := json.Marshal(uploadInitiateRequest{
 		Path:             path,
 		TotalSize:        size,
@@ -974,6 +982,9 @@ func (c *Client) completeUploadWithOptions(ctx context.Context, uploadID string,
 // initiateUploadV2 calls POST /v2/uploads/initiate.
 // Returns errV2NotAvailable if the server responds with 404.
 func (c *Client) initiateUploadV2(ctx context.Context, path string, size int64, expectedRevision int64, description string) (*uploadPlanV2, error) {
+	if err := validateFSPath(path); err != nil {
+		return nil, err
+	}
 	body, err := json.Marshal(struct {
 		Path             string `json:"path"`
 		TotalSize        int64  `json:"total_size"`
@@ -1891,6 +1902,11 @@ func (c *Client) ResumeUploadWithSummary(ctx context.Context, path string, r io.
 // the resulting revision on completion, and returns coarse-grained phase
 // timings for the completed resume flow.
 func (c *Client) ResumeUploadWithSummaryAndTags(ctx context.Context, path string, r io.ReaderAt, totalSize int64, progress ProgressFunc, tags map[string]string) (*UploadSummary, error) {
+	// Validate before the upload query and checksum computation so a bad
+	// path fails fast without a round trip or wasted CPU.
+	if err := validateFSPath(path); err != nil {
+		return nil, err
+	}
 	// Resume also applies tags only during complete, so validate here before we
 	// query/resume/upload additional parts.
 	if err := validateTags(tags); err != nil {
@@ -1959,6 +1975,9 @@ func (c *Client) ResumeUploadWithSummaryAndTags(ctx context.Context, path string
 
 // queryUpload finds an active upload for the given path.
 func (c *Client) queryUpload(ctx context.Context, path string) (*UploadMeta, error) {
+	if err := validateFSPath(path); err != nil {
+		return nil, err
+	}
 	query := url.Values{}
 	query.Set("path", path)
 	query.Set("status", "UPLOADING")

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -429,6 +429,9 @@ func (c *Client) writeStreamConditionalWithChecksumAndPreCompleteCheck(ctx conte
 // therefore cannot use the direct-PUT path, which materializes the full reader
 // into memory before sending.
 func (c *Client) WriteMultipartStreamConditional(ctx context.Context, path string, ra io.ReaderAt, size int64, progress ProgressFunc, expectedRevision int64) error {
+	if err := validateFSPath(path); err != nil {
+		return err
+	}
 	if size <= 0 {
 		return fmt.Errorf("multipart upload requires positive size")
 	}
@@ -762,11 +765,7 @@ func (c *Client) initiateUploadByBody(ctx context.Context, path string, size int
 }
 
 func (c *Client) initiateUploadLegacy(ctx context.Context, path string, size int64, checksums []string, expectedRevision int64, description string) (UploadPlan, error) {
-	reqURL, err := c.url(path)
-	if err != nil {
-		return UploadPlan{}, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPut, reqURL, http.NoBody)
+	req, err := c.newFSRequest(ctx, http.MethodPut, path, "", http.NoBody)
 	if err != nil {
 		return UploadPlan{}, err
 	}
@@ -1405,11 +1404,7 @@ func (c *Client) readWithoutRedirect(ctx context.Context, path, rangeHeader stri
 		return http.ErrUseLastResponse
 	}
 
-	reqURL, err := c.url(path)
-	if err != nil {
-		return nil, err
-	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
+	req, err := c.newFSRequest(ctx, http.MethodGet, path, "", nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Motivation

Alert `Drive9FSInvalidPathRejectedTenant` fired for a tenant whose custom client kept sending Windows local paths as drive9 path segments (`.../个股回测工具/C:\股票工具`, `.../D:\股票工具` — 50 mkdir rejections in the alert window, all `path contains backslash`, single API key). The server-side 400 is correct behavior and stays untouched — but every bad request burned a round trip and paged on-call before the tenant could self-diagnose.

## What changed

The Go SDK now fails fast on paths the server would reject with HTTP 400:

- **`pkg/client/path.go` (new)**: `validateFSPath` runs the same `pathutil.Canonicalize` rules the server enforces (wrapped with `%w` for `errors.Is`/`As`). `windowsPathHint` detects a Windows drive-letter segment (at the start *or* embedded mid-path, which is the observed join bug) and appends actionable guidance: strip the drive prefix, convert separators with `filepath.ToSlash`.
- **`/v1/fs` URL paths**: `c.url()` — the single choke point — now returns `(string, error)` and validates; all call sites in `client.go`/`append.go`/`patch.go`/`transfer.go` updated.
- **Header/body-carried paths**: `RenameCtx`/`CopyCtx`/`HardlinkCtx` source paths, and every path in `BatchStat`/`BatchReadSmall`/`BatchWrite` request bodies.
- **Upload-session paths** (bypass `c.url()` — path travels in JSON body or query param): `initiateUploadByBody` (`/v1/uploads/initiate`), `initiateUploadV2` (`/v2/uploads/initiate`, also covers `StreamWriter`), and `queryUpload` (`GET /v1/uploads?path=`). The `WriteStream*`/`ResumeUpload*` funnels validate up front, so a bad path fails before the `/v1/status` threshold fetch and before v1 part-checksum CPU work.

Deliberately out of scope: server validation stays strict (silent rewriting would introduce canonicalization ambiguity — backslash is a legal POSIX filename byte); symlink targets are not pre-validated (relative targets are legal); layer-API query-param paths unchanged; `BatchWrite` keeps accepting trailing-slash/root items client-side (server reports those per-path).

## Contract note: batch methods

`BatchStatCtx`/`BatchReadSmallCtx`/`BatchWriteCtx` previously sent all paths and reported invalid ones per-path. Now a path that fails client-side validation fails the **whole call** before any request is sent (per-path results now only cover server-side per-path failures). Method docs and the `BatchReadSmallResult` comment are updated accordingly.

## User-facing result

CLI commands need no changes — they all route through `pkg/client`, so users now see e.g.:

```
invalid drive9 path "/个股回测工具/C:\股票工具": path contains backslash; path looks like a Windows local path — drive9 paths are absolute POSIX paths with no drive letter; strip the drive prefix and convert separators (e.g. filepath.ToSlash) before calling
```

instead of a server round trip ending in HTTP 400.

## Test plan

- `pkg/client/path_test.go` (new): table-driven `validateFSPath` cases (drive-letter at start, embedded segment, bare backslash, `..`, NUL, plus valid control cases) and a fail-fast test covering 25 SDK methods — including `WriteStream` (multipart size), `ResumeUpload`, and `StreamWriter.WritePart` — asserting **zero HTTP requests** are made and the Windows hint is present.
- `make test TEST_PKGS='./pkg/client/...'` — full suite passes
- `make test TEST_PKGS='./cmd/...'` — CLI suite passes
- `make lint` — 0 issues


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid filesystem paths are now rejected on the client before requests are sent.
  - Improved handling of URL resolution errors across file operations.
  - Range reads now handle partial-content responses and empty ranges more reliably.
  - Upload and transfer operations validate paths before performing network or processing work.
- **Tests**
  - Added coverage confirming invalid paths are rejected without contacting the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->