### PR TITLE
test(blackbox): force mdtest MPI off InfiniBand

### DIFF
--- a/.github/workflows/blackbox.yml
+++ b/.github/workflows/blackbox.yml
@@ -178,15 +178,28 @@ jobs:
           if [ -n "$suite_json" ]; then
             echo ""
             echo "=== Per-module results ==="
-            python3 -c '
+            python3 - "$suite_json" <<'PY'
           import json, sys
+
           with open(sys.argv[1]) as f:
               data = json.load(f)
           for r in data.get("records", []):
-              print(f"  {r[\"status\"]:4s}  {r[\"module\"]:40s}  {r.get(\"seconds\",0):.1f}s  {r.get(\"classification\",\"\")}")
+              status = str(r.get("status", ""))
+              module = str(r.get("module", ""))
+              seconds = float(r.get("seconds", 0) or 0)
+              classification = str(r.get("classification", ""))
+              print(f"  {status:4s}  {module:40s}  {seconds:.1f}s  {classification}")
           s = data.get("summary", {})
-          print(f"\nSummary: PASS={s.get(\"PASS\",0)} FAIL={s.get(\"FAIL\",0)} SKIP={s.get(\"SKIP\",0)} XFAIL={s.get(\"XFAIL\",0)} WARN={s.get(\"WARN\",0)}")
-          ' "$suite_json"
+          print(
+              "\nSummary: PASS={} FAIL={} SKIP={} XFAIL={} WARN={}".format(
+                  s.get("PASS", 0),
+                  s.get("FAIL", 0),
+                  s.get("SKIP", 0),
+                  s.get("XFAIL", 0),
+                  s.get("WARN", 0),
+              )
+          )
+          PY
           fi
 
       - name: Upload blackbox artifacts

--- a/blackbox/suites/community/README.md
+++ b/blackbox/suites/community/README.md
@@ -142,7 +142,9 @@ syscall coverage against a full LTP install.
 `community.mdtest` auto-fetches and builds IOR/mdtest when `mdtest` is not
 already available; IOR requires an MPI compiler, so with auto system-deps the
 harness installs `mpich`/`libmpich-dev` (Debian) or `openmpi` (Arch) when
-`mpicc` is missing. The IOR source is patched in-cache for newer compiler
+`mpicc` is missing. The run sets `UCX_TLS=tcp,sm,self` (and OpenMPI
+`btl=tcp,self`) so MPI_Init does not probe InfiniBand — GitHub-hosted
+runners have no IB and MPICH/UCX otherwise fails with `ibv_create_srq`. The IOR source is patched in-cache for newer compiler
 compatibility before building mdtest. `community.fsx` fetches and builds
 `secfs.test` to obtain the `fsx` binary, and patches `fsx.c` for glibc builds
 that already provide `strlcpy`/`strlcat` (common on Arch).

--- a/blackbox/suites/community/mdtest/module.py
+++ b/blackbox/suites/community/mdtest/module.py
@@ -20,7 +20,20 @@ class CommunityMdtest(BaseModule):
         handle = ctx.target.mount("community_mdtest", remote, profile="none")
         try:
             files = str(os.environ.get("MDTEST_FILES", "1000"))
-            result = ctx.target.run_cmd("community-mdtest", [mdtest, "-d", str(handle.mountpoint / "mdtest"), "-n", files, "-u", "-L", "-F"], timeout=int(os.environ.get("MDTEST_TIMEOUT_S", str(self.timeout))))
+            # IOR/mdtest always MPI_Init. MPICH's UCX netmod probes InfiniBand
+            # (ibv_create_srq) even for 1 rank; GitHub-hosted VMs have no IB
+            # and fail at init. Force TCP / shared-memory transports.
+            env = ctx.target.base_env()
+            env.setdefault("UCX_TLS", "tcp,sm,self")
+            env.setdefault("FI_PROVIDER", "tcp")
+            env.setdefault("OMPI_MCA_btl", "tcp,self")
+            env.setdefault("OMPI_MCA_pml", "ob1")
+            result = ctx.target.run_cmd(
+                "community-mdtest",
+                [mdtest, "-d", str(handle.mountpoint / "mdtest"), "-n", files, "-u", "-L", "-F"],
+                timeout=int(os.environ.get("MDTEST_TIMEOUT_S", str(self.timeout))),
+                env=env,
+            )
             if not result.ok:
                 raise BlackboxError(f"mdtest failed; see {result.stderr}")
             return {"files": int(files), "stdout": str(result.stdout)}


### PR DESCRIPTION
## Summary

`community.mdtest` failed on GitHub-hosted Ubuntu ([run 33147839279](https://github.com/mem9-ai/drive9/actions/runs/33147839279)):

```
UCX ERROR ibv_create_srq() failed: Operation not supported
MPI_Init failed ... ucx function returned with failed status
```

IOR/mdtest always calls `MPI_Init`. Apt MPICH's UCX netmod probes InfiniBand even for 1 rank; `ubuntu-latest` has no IB.

Default MPI transports to TCP / shared memory for the mdtest invocation (`UCX_TLS=tcp,sm,self`, `FI_PROVIDER=tcp`, OpenMPI `btl=tcp,self`). Existing `UCX_TLS` / `OMPI_MCA_*` in the environment still win.

## Test plan

- [ ] Re-run Blackbox `group=community` on `ubuntu-latest` and confirm `community.mdtest` gets past `MPI_Init`
- [ ] Orb Arch (OpenMPI, no IB required) still runs mdtest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mdtest reliability in environments without InfiniBand support.
  * Configured MPI workloads to use TCP and shared-memory transports, preventing initialization failures on hosted runners.
* **Documentation**
  * Added documentation describing the transport configuration and its compatibility rationale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->