### PR TITLE
feat: add embedding config SDK, CLI, and hosted E2E

### DIFF
--- a/.github/workflows/code-ci.yml
+++ b/.github/workflows/code-ci.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Test hosted config smoke guards
+        run: bash scripts/test-hosted-config-smoke-guards.sh
+
       - name: Checkout agfs dependency
         run: |
           git clone --depth 1 https://github.com/c4pt0r/agfs ../agfs

--- a/cmd/drive9/cli/admin.go
+++ b/cmd/drive9/cli/admin.go
@@ -51,6 +51,8 @@ func adminTenant(args []string) error {
 		return quotaSet(args[1:])
 	case "extract-config":
 		return adminTenantExtractConfig(args[1:])
+	case "embedding-config":
+		return adminTenantEmbeddingConfig(args[1:])
 	case "object-namespace":
 		return adminTenantObjectNamespace(args[1:])
 	case "pool":
@@ -679,6 +681,7 @@ commands:
   tenant delete --tenant-id ID      delete one tenant
   tenant set-quota --tenant-id ID   set quota for one tenant
   tenant extract-config <get|set>   get or update media extract config
+  tenant embedding-config <get|set>  get or replace embedding config
   tenant object-namespace <get|set|clear>  bind a customer object prefix id
   object-backend <add|get|ls|update|rm>  org object-store credentials
   pool <command> [flags]            manage the tenant pool
@@ -734,12 +737,13 @@ commands:
   delete --tenant-id ID            delete one tenant
   set-quota --tenant-id ID         set quota for one tenant
   extract-config <get|set>         get or update media extract config
+  embedding-config <get|set>       get or replace embedding config
   object-namespace <get|set|clear> bind customer object prefix id
 
 flags:
   --server URL                     server URL (default: active context server)
   --region-code CODE               TiDBCloud Mode region code; ignored when --server is set
-  --tenant-id ID                   drive9 tenant id for get/delete/set-quota/extract-config/object-namespace
+  --tenant-id ID                   drive9 tenant id for get/delete/set-quota/extract-config/embedding-config/object-namespace
   --tidbcloud-public-key KEY       TiDB Cloud public key
   --tidbcloud-private-key KEY      TiDB Cloud private key
   --max-storage-size Mi            set-quota: max confirmed+reserved storage size in Mi

--- a/cmd/drive9/cli/admin_embedding_config.go
+++ b/cmd/drive9/cli/admin_embedding_config.go
@@ -1,0 +1,298 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/mem9-ai/drive9/pkg/client"
+)
+
+func adminTenantEmbeddingConfig(args []string) error {
+	if len(args) == 0 {
+		return fmt.Errorf("%s", adminTenantEmbeddingConfigUsage())
+	}
+	switch args[0] {
+	case "-h", "-help", "--help", "help":
+		_, _ = fmt.Fprintln(os.Stdout, adminTenantEmbeddingConfigUsage())
+		return nil
+	case "get":
+		return adminTenantEmbeddingConfigGet(args[1:])
+	case "set":
+		return adminTenantEmbeddingConfigSet(args[1:])
+	default:
+		return fmt.Errorf("unknown admin tenant embedding-config command %q\n%s", args[0], adminTenantEmbeddingConfigUsage())
+	}
+}
+
+type adminTenantEmbeddingConfigFlags struct {
+	serverFlag      string
+	serverGiven     bool
+	regionCodeFlag  string
+	regionCodeGiven bool
+	tenantID        string
+	tenantIDGiven   bool
+	publicKeyFlag   string
+	publicKeyGiven  bool
+	privateKeyFlag  string
+	privateKeyGiven bool
+	asJSON          bool
+	enabled         *bool
+	apiBase         *string
+	apiKey          *string
+	model           *string
+}
+
+func parseAdminTenantEmbeddingConfigFlags(args []string, usage string, allowConfig bool) (adminTenantEmbeddingConfigFlags, error) {
+	var flags adminTenantEmbeddingConfigFlags
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "-h", "-help", "--help", "help":
+			_, _ = fmt.Fprintln(os.Stdout, usage)
+			return flags, errHelpRequested{}
+		case "--server":
+			value, next, err := nextAdminExtractFlag(args, i, "--server")
+			if err != nil {
+				return flags, err
+			}
+			flags.serverFlag, flags.serverGiven, i = value, true, next
+		case "--region-code":
+			value, next, err := nextAdminExtractFlag(args, i, "--region-code")
+			if err != nil {
+				return flags, err
+			}
+			flags.regionCodeFlag, flags.regionCodeGiven, i = value, true, next
+		case "--tenant-id":
+			value, next, err := nextAdminExtractFlag(args, i, "--tenant-id")
+			if err != nil {
+				return flags, err
+			}
+			flags.tenantID, flags.tenantIDGiven, i = value, true, next
+		case "--tidbcloud-public-key":
+			value, next, err := nextAdminExtractFlag(args, i, "--tidbcloud-public-key")
+			if err != nil {
+				return flags, err
+			}
+			flags.publicKeyFlag, flags.publicKeyGiven, i = value, true, next
+		case "--tidbcloud-private-key":
+			value, next, err := nextAdminExtractFlag(args, i, "--tidbcloud-private-key")
+			if err != nil {
+				return flags, err
+			}
+			flags.privateKeyFlag, flags.privateKeyGiven, i = value, true, next
+		case "--json":
+			flags.asJSON = true
+		case "--enabled":
+			if !allowConfig {
+				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+			}
+			value, next, err := nextAdminExtractFlag(args, i, "--enabled")
+			if err != nil {
+				return flags, err
+			}
+			parsed, err := parseAdminExtractBool(value)
+			if err != nil {
+				return flags, err
+			}
+			flags.enabled, i = &parsed, next
+		case "--api-base", "--api-key", "--model":
+			if !allowConfig {
+				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+			}
+			name := args[i]
+			value, next, err := nextAdminExtractFlag(args, i, name)
+			if err != nil {
+				return flags, err
+			}
+			switch name {
+			case "--api-base":
+				flags.apiBase = &value
+			case "--api-key":
+				flags.apiKey = &value
+			case "--model":
+				flags.model = &value
+			}
+			i = next
+		default:
+			return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+		}
+	}
+	if err := rejectEmptyFlag("server", strings.TrimSpace(flags.serverFlag), flags.serverGiven); err != nil {
+		return flags, err
+	}
+	if err := rejectEmptyFlag("region-code", strings.TrimSpace(flags.regionCodeFlag), flags.regionCodeGiven); err != nil {
+		return flags, err
+	}
+	if err := rejectEmptyFlag("tenant-id", strings.TrimSpace(flags.tenantID), flags.tenantIDGiven); err != nil {
+		return flags, err
+	}
+	if err := rejectEmptyFlag("tidbcloud-public-key", strings.TrimSpace(flags.publicKeyFlag), flags.publicKeyGiven); err != nil {
+		return flags, err
+	}
+	if err := rejectEmptyFlag("tidbcloud-private-key", strings.TrimSpace(flags.privateKeyFlag), flags.privateKeyGiven); err != nil {
+		return flags, err
+	}
+	flags.tenantID = strings.TrimSpace(flags.tenantID)
+	if flags.tenantID == "" {
+		return flags, fmt.Errorf("--tenant-id is required")
+	}
+	if !allowConfig {
+		return flags, nil
+	}
+	if flags.enabled == nil {
+		return flags, fmt.Errorf("--enabled is required")
+	}
+	if *flags.enabled {
+		if flags.apiBase == nil || flags.apiKey == nil || flags.model == nil {
+			return flags, fmt.Errorf("--api-base, --api-key, and --model are required when enabling")
+		}
+		if strings.TrimSpace(*flags.apiBase) == "" || strings.TrimSpace(*flags.apiKey) == "" || strings.TrimSpace(*flags.model) == "" {
+			return flags, fmt.Errorf("--api-base, --api-key, and --model must not be empty when enabling")
+		}
+		return flags, nil
+	}
+	if flags.apiBase != nil || flags.apiKey != nil || flags.model != nil {
+		return flags, fmt.Errorf("--api-base, --api-key, and --model must be omitted when disabling")
+	}
+	return flags, nil
+}
+
+func (f adminTenantEmbeddingConfigFlags) requestIdentity() (client.QuotaRequest, error) {
+	publicKey, privateKey := adminTiDBCloudKeys(f.publicKeyFlag, f.privateKeyFlag)
+	return quotaRequest(f.tenantID, publicKey, privateKey)
+}
+
+func (f adminTenantEmbeddingConfigFlags) server() (string, error) {
+	r := ResolveCredentials()
+	return quotaServer(f.serverFlag, f.regionCodeFlag, r.Server, true)
+}
+
+func adminTenantEmbeddingConfigGet(args []string) error {
+	flags, err := parseAdminTenantEmbeddingConfigFlags(args, adminTenantEmbeddingConfigGetUsage(), false)
+	if err != nil {
+		if errors.Is(err, errHelpRequested{}) {
+			return nil
+		}
+		return err
+	}
+	server, err := flags.server()
+	if err != nil {
+		return err
+	}
+	identity, err := flags.requestIdentity()
+	if err != nil {
+		return err
+	}
+	out, err := client.New(server, "").AdminGetTenantEmbeddingConfig(context.Background(), client.AdminTenantEmbeddingConfigGetRequest{
+		TenantID: identity.TenantID, PublicKey: identity.PublicKey, PrivateKey: identity.PrivateKey,
+	})
+	if err != nil {
+		return quotaAPIError("get tenant embedding config", err)
+	}
+	return printAdminTenantEmbeddingConfigResponse(out, flags.asJSON)
+}
+
+func adminTenantEmbeddingConfigSet(args []string) error {
+	flags, err := parseAdminTenantEmbeddingConfigFlags(args, adminTenantEmbeddingConfigSetUsage(), true)
+	if err != nil {
+		if errors.Is(err, errHelpRequested{}) {
+			return nil
+		}
+		return err
+	}
+	server, err := flags.server()
+	if err != nil {
+		return err
+	}
+	identity, err := flags.requestIdentity()
+	if err != nil {
+		return err
+	}
+	out, err := client.New(server, "").AdminSetTenantEmbeddingConfig(context.Background(), client.AdminTenantEmbeddingConfigSetRequest{
+		TenantID: identity.TenantID, PublicKey: identity.PublicKey, PrivateKey: identity.PrivateKey,
+		Enabled: *flags.enabled, APIBase: flags.apiBase, APIKey: flags.apiKey, Model: flags.model,
+	})
+	if err != nil {
+		return quotaAPIError("set tenant embedding config", err)
+	}
+	return printAdminTenantEmbeddingConfigResponse(out, flags.asJSON)
+}
+
+func printAdminTenantEmbeddingConfigResponse(out *client.AdminTenantEmbeddingConfig, asJSON bool) error {
+	if out == nil {
+		return fmt.Errorf("tenant embedding config response is empty")
+	}
+	redacted := *out
+	if out.APIKey != nil {
+		apiKey := redactProviderAPIKey(*out.APIKey)
+		redacted.APIKey = &apiKey
+	}
+	if asJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(&redacted)
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
+	_, _ = fmt.Fprintln(w, "ENABLED\tSOURCE\tAPI_BASE\tAPI_KEY\tMODEL\tGENERATION\tUPDATED_AT")
+	_, _ = fmt.Fprintf(w, "%t\t%s\t%s\t%s\t%s\t%s\t%s\n", redacted.Enabled, emptyAsDash(redacted.Source), optionalExtractString(redacted.APIBase), optionalExtractString(redacted.APIKey), optionalExtractString(redacted.Model), optionalEmbeddingGeneration(redacted.Generation), optionalExtractTime(redacted.UpdatedAt))
+	return w.Flush()
+}
+
+func optionalEmbeddingGeneration(generation uint64) string {
+	if generation == 0 {
+		return "-"
+	}
+	return fmt.Sprintf("%d", generation)
+}
+
+func adminTenantEmbeddingConfigUsage() string {
+	return `usage: drive9 admin tenant embedding-config <get|set> [flags]
+
+commands:
+  get [flags]                       show one tenant's embedding config
+  set [flags]                       replace one tenant's embedding config
+
+set is a full replacement. --enabled is required. Enabling also requires
+--api-base, --api-key, and --model; disabling requires them to be omitted.
+
+set flags:
+  --enabled true|false
+  --api-base URL
+  --api-key KEY
+  --model MODEL`
+}
+
+func adminTenantEmbeddingConfigGetUsage() string {
+	return `usage: drive9 admin tenant embedding-config get [flags]
+
+flags:
+  --server URL
+  --region-code CODE
+  --tenant-id ID                   required
+  --tidbcloud-public-key KEY
+  --tidbcloud-private-key KEY
+  --json                           output result as JSON`
+}
+
+func adminTenantEmbeddingConfigSetUsage() string {
+	return `usage: drive9 admin tenant embedding-config set [flags]
+
+replace one tenant's embedding configuration. This is a full replacement;
+provider completeness and live validation are performed by the server.
+
+flags:
+  --server URL
+  --region-code CODE
+  --tenant-id ID                   required
+  --enabled true|false             required
+  --api-base URL                   required when enabling; omit when disabling
+  --api-key KEY                    required when enabling; omit when disabling (sensitive)
+  --model MODEL                    required when enabling; omit when disabling
+  --tidbcloud-public-key KEY
+  --tidbcloud-private-key KEY
+  --json                           output result as JSON`
+}

--- a/cmd/drive9/cli/admin_embedding_config.go
+++ b/cmd/drive9/cli/admin_embedding_config.go
@@ -187,9 +187,10 @@ func adminTenantEmbeddingConfigGet(args []string) error {
 	if err != nil {
 		return err
 	}
-	out, err := client.New(server, "").AdminGetTenantEmbeddingConfig(context.Background(), client.AdminTenantEmbeddingConfigGetRequest{
-		TenantID: identity.TenantID, PublicKey: identity.PublicKey, PrivateKey: identity.PrivateKey,
-	})
+	out, err := client.New(server, "").AdminGetTenantEmbeddingConfig(
+		context.Background(),
+		client.AdminTenantEmbeddingConfigGetRequest(identity),
+	)
 	if err != nil {
 		return quotaAPIError("get tenant embedding config", err)
 	}

--- a/cmd/drive9/cli/admin_embedding_config_test.go
+++ b/cmd/drive9/cli/admin_embedding_config_test.go
@@ -1,0 +1,146 @@
+package cli
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestAdminTenantEmbeddingConfigHelp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	tenantHelp, err := captureStdoutE(t, func() error { return Admin([]string{"tenant", "--help"}) })
+	if err != nil {
+		t.Fatalf("tenant help: %v", err)
+	}
+	if !strings.Contains(tenantHelp, "embedding-config <get|set>") {
+		t.Fatalf("tenant help missing embedding-config command:\n%s", tenantHelp)
+	}
+
+	stdout, err := captureStdoutE(t, func() error { return Admin([]string{"tenant", "embedding-config", "--help"}) })
+	if err != nil {
+		t.Fatalf("embedding config help: %v", err)
+	}
+	for _, want := range []string{"embedding-config <get|set>", "--enabled true|false", "--api-base URL", "--api-key KEY", "--model MODEL", "full replacement"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("help missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestAdminTenantEmbeddingConfigGetPrintsTableAndRedactsKey(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/admin/tenants/tenant-1/embedding-config" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
+			t.Errorf("missing TiDB Cloud headers")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled": true, "api_base": "https://provider.example.com/v1", "api_key": "plain-provider-key",
+			"model": "embedding-model", "source": "custom", "generation": 4, "updated_at": "2026-08-28T01:02:03Z",
+		})
+	}))
+	defer srv.Close()
+
+	stdout, err := captureStdoutE(t, func() error {
+		return Admin([]string{
+			"tenant", "embedding-config", "get", "--server", srv.URL, "--tenant-id", "tenant-1",
+			"--tidbcloud-public-key", "public-1", "--tidbcloud-private-key", "private-1",
+		})
+	})
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if strings.Contains(stdout, "plain-provider-key") {
+		t.Fatal("table output leaked provider API key")
+	}
+	for _, want := range []string{"ENABLED", "SOURCE", "API_BASE", "API_KEY", "MODEL", "GENERATION", "UPDATED_AT", "true", "custom", "plai********", "embedding-model", "4"} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("output missing %q:\n%s", want, stdout)
+		}
+	}
+}
+
+func TestAdminTenantEmbeddingConfigSetEnabledSendsCompleteBody(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/admin/tenants/tenant-1/embedding-config" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"enabled": true, "api_key": "prov********", "source": "custom"})
+	}))
+	defer srv.Close()
+
+	stdout, err := captureStdoutE(t, func() error {
+		return Admin([]string{
+			"tenant", "embedding-config", "set", "--server", srv.URL, "--tenant-id", "tenant-1", "--enabled", "true",
+			"--api-base", "https://provider.example.com/v1", "--api-key", "provider-secret", "--model", "embedding-model",
+			"--tidbcloud-public-key", "public-1", "--tidbcloud-private-key", "private-1", "--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if len(gotBody) != 4 || gotBody["enabled"] != true || gotBody["api_base"] != "https://provider.example.com/v1" || gotBody["api_key"] != "provider-secret" || gotBody["model"] != "embedding-model" {
+		t.Fatalf("request body = %#v", gotBody)
+	}
+	if strings.Contains(stdout, "provider-secret") {
+		t.Fatal("JSON output leaked provider API key")
+	}
+}
+
+func TestAdminTenantEmbeddingConfigSetDisabledSendsEnabledOnly(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"enabled": false, "source": "custom"})
+	}))
+	defer srv.Close()
+
+	_, err := captureStdoutE(t, func() error {
+		return Admin([]string{
+			"tenant", "embedding-config", "set", "--server", srv.URL, "--tenant-id", "tenant-1", "--enabled", "false",
+			"--tidbcloud-public-key", "public-1", "--tidbcloud-private-key", "private-1", "--json",
+		})
+	})
+	if err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if len(gotBody) != 1 || gotBody["enabled"] != false {
+		t.Fatalf("request body = %#v, want enabled=false only", gotBody)
+	}
+}
+
+func TestAdminTenantEmbeddingConfigRejectsInvalidReplacementFlags(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	clearProvisionEnv(t)
+
+	for _, args := range [][]string{
+		{"tenant", "embedding-config", "get", "--server", "https://drive9.example.com"},
+		{"tenant", "embedding-config", "set", "--server", "https://drive9.example.com", "--tenant-id", "tenant-1"},
+		{"tenant", "embedding-config", "set", "--server", "https://drive9.example.com", "--tenant-id", "tenant-1", "--enabled", "true", "--api-base", "https://provider.example.com", "--api-key", "key"},
+		{"tenant", "embedding-config", "set", "--server", "https://drive9.example.com", "--tenant-id", "tenant-1", "--enabled", "false", "--model", "model"},
+	} {
+		if _, err := captureStdoutE(t, func() error { return Admin(args) }); err == nil {
+			t.Fatalf("Admin(%v) error = nil", args)
+		}
+	}
+}

--- a/cmd/drive9/cli/admin_embedding_config_test.go
+++ b/cmd/drive9/cli/admin_embedding_config_test.go
@@ -77,6 +77,9 @@ func TestAdminTenantEmbeddingConfigSetEnabledSendsCompleteBody(t *testing.T) {
 		if r.Method != http.MethodPut || r.URL.Path != "/v1/admin/tenants/tenant-1/embedding-config" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
+		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
+			t.Errorf("missing TiDB Cloud headers")
+		}
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Errorf("decode body: %v", err)
 		}
@@ -108,6 +111,12 @@ func TestAdminTenantEmbeddingConfigSetDisabledSendsEnabledOnly(t *testing.T) {
 
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/admin/tenants/tenant-1/embedding-config" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
+			t.Errorf("missing TiDB Cloud headers")
+		}
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Errorf("decode body: %v", err)
 		}

--- a/cmd/drive9/cli/admin_extract_config.go
+++ b/cmd/drive9/cli/admin_extract_config.go
@@ -48,6 +48,7 @@ type adminTenantExtractConfigFlags struct {
 	apiBase         *string
 	apiKey          *string
 	model           *string
+	protocol        *string
 	prompt          *string
 }
 
@@ -136,6 +137,15 @@ func parseAdminTenantExtractConfigFlags(args []string, usage string, allowConfig
 				return flags, err
 			}
 			flags.model, i = &value, next
+		case "--protocol":
+			if !allowConfig {
+				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
+			}
+			value, next, err := nextAdminExtractFlag(args, i, "--protocol")
+			if err != nil {
+				return flags, err
+			}
+			flags.protocol, i = &value, next
 		case "--prompt":
 			if !allowConfig {
 				return flags, fmt.Errorf("unknown flag %q\n%s", args[i], usage)
@@ -175,7 +185,7 @@ func parseAdminTenantExtractConfigFlags(args []string, usage string, allowConfig
 	}
 	flags.tenantID = strings.TrimSpace(flags.tenantID)
 	flags.mediaType = strings.TrimSpace(flags.mediaType)
-	if allowConfig && flags.enabled == nil && flags.apiBase == nil && flags.apiKey == nil && flags.model == nil && flags.prompt == nil {
+	if allowConfig && flags.enabled == nil && flags.apiBase == nil && flags.apiKey == nil && flags.model == nil && flags.protocol == nil && flags.prompt == nil {
 		return flags, fmt.Errorf("at least one extract config field is required")
 	}
 	return flags, nil
@@ -252,7 +262,7 @@ func adminTenantExtractConfigSet(args []string) error {
 	}
 	out, err := client.New(server, "").AdminSetTenantExtractConfig(context.Background(), client.AdminTenantExtractConfigSetRequest{
 		TenantID: identity.TenantID, MediaType: client.ExtractMediaType(flags.mediaType), PublicKey: identity.PublicKey, PrivateKey: identity.PrivateKey,
-		Enabled: flags.enabled, APIBase: flags.apiBase, APIKey: flags.apiKey, Model: flags.model, Prompt: flags.prompt,
+		Enabled: flags.enabled, APIBase: flags.apiBase, APIKey: flags.apiKey, Model: flags.model, Protocol: flags.protocol, Prompt: flags.prompt,
 	})
 	if err != nil {
 		return quotaAPIError("set tenant extract config", err)
@@ -271,8 +281,8 @@ func printAdminTenantExtractConfigResponse(out *client.AdminTenantExtractConfig,
 		return enc.Encode(out)
 	}
 	w := tabwriter.NewWriter(os.Stdout, 0, 4, 2, ' ', 0)
-	_, _ = fmt.Fprintln(w, "MEDIA_TYPE\tENABLED\tSOURCE\tAPI_BASE\tAPI_KEY\tMODEL\tPROMPT\tUPDATED_AT")
-	_, _ = fmt.Fprintf(w, "%s\t%t\t%s\t%s\t%s\t%s\t%s\t%s\n", mediaType, out.Enabled, emptyAsDash(out.Source), optionalExtractString(out.APIBase), optionalExtractString(out.APIKey), optionalExtractString(out.Model), optionalExtractString(out.Prompt), optionalExtractTime(out.UpdatedAt))
+	_, _ = fmt.Fprintln(w, "MEDIA_TYPE\tENABLED\tSOURCE\tAPI_BASE\tAPI_KEY\tMODEL\tPROTOCOL\tPROMPT\tUPDATED_AT")
+	_, _ = fmt.Fprintf(w, "%s\t%t\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n", mediaType, out.Enabled, emptyAsDash(out.Source), optionalExtractString(out.APIBase), optionalExtractString(out.APIKey), optionalExtractString(out.Model), optionalExtractString(out.Protocol), optionalExtractString(out.Prompt), optionalExtractTime(out.UpdatedAt))
 	return w.Flush()
 }
 
@@ -353,6 +363,7 @@ set flags:
   --api-base URL                   provider base URL; non-empty when enabling
   --api-key KEY                    provider API key; non-empty when enabling (sensitive)
   --model MODEL                    provider model name; non-empty when enabling
+  --protocol PROTOCOL             provider wire protocol (default: openai)
   --prompt TEXT                    custom extraction prompt; empty clears the override`
 }
 
@@ -386,6 +397,7 @@ flags:
   --api-base URL                   non-empty when enabling
   --api-key KEY                    non-empty when enabling (sensitive)
   --model MODEL                    non-empty when enabling
+  --protocol PROTOCOL             provider wire protocol (openai or qwen-asr for audio)
   --prompt TEXT                    empty clears the custom prompt
   --tidbcloud-public-key KEY
   --tidbcloud-private-key KEY

--- a/cmd/drive9/cli/admin_extract_config_test.go
+++ b/cmd/drive9/cli/admin_extract_config_test.go
@@ -35,6 +35,7 @@ func TestAdminTenantExtractConfigHelp(t *testing.T) {
 		"--api-base URL",
 		"--api-key KEY",
 		"--model MODEL",
+		"--protocol PROTOCOL",
 		"--prompt TEXT",
 		"non-empty when enabling",
 		"empty clears",
@@ -61,6 +62,7 @@ func TestAdminTenantExtractConfigGetPrintsTableAndHeaders(t *testing.T) {
 			"api_base":   "https://provider.example.com",
 			"api_key":    "plain-provider-key",
 			"model":      "audio-model",
+			"protocol":   "qwen-asr",
 			"prompt":     "extract audio",
 			"source":     "custom",
 			"updated_at": "2026-08-21T01:02:03Z",
@@ -84,7 +86,7 @@ func TestAdminTenantExtractConfigGetPrintsTableAndHeaders(t *testing.T) {
 	if strings.Contains(stdout, "plain-provider-key") {
 		t.Fatal("table output leaked the provider API key")
 	}
-	for _, want := range []string{"MEDIA_TYPE", "ENABLED", "SOURCE", "API_BASE", "API_KEY", "MODEL", "PROMPT", "UPDATED_AT", "audio", "true", "custom", "plai********"} {
+	for _, want := range []string{"MEDIA_TYPE", "ENABLED", "SOURCE", "API_BASE", "API_KEY", "MODEL", "PROTOCOL", "PROMPT", "UPDATED_AT", "audio", "true", "custom", "qwen-asr", "plai********"} {
 		if !strings.Contains(stdout, want) {
 			t.Fatalf("output missing %q:\n%s", want, stdout)
 		}
@@ -236,6 +238,7 @@ func TestAdminTenantExtractConfigSetFullProviderBody(t *testing.T) {
 			"--api-base", "https://provider.example.com",
 			"--api-key", "provider-secret",
 			"--model", "vision-model",
+			"--protocol", "openai",
 			"--tidbcloud-public-key", "public-1",
 			"--tidbcloud-private-key", "private-1",
 			"--json",
@@ -244,7 +247,7 @@ func TestAdminTenantExtractConfigSetFullProviderBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("set: %v", err)
 	}
-	if gotBody["enabled"] != true || gotBody["api_base"] != "https://provider.example.com" || gotBody["api_key"] != "provider-secret" || gotBody["model"] != "vision-model" || len(gotBody) != 4 {
+	if gotBody["enabled"] != true || gotBody["api_base"] != "https://provider.example.com" || gotBody["api_key"] != "provider-secret" || gotBody["model"] != "vision-model" || gotBody["protocol"] != "openai" || len(gotBody) != 5 {
 		t.Fatalf("body = %#v", gotBody)
 	}
 }

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -147,6 +147,19 @@ export DRIVE9_E2E_IMAGE_EXTRACT_API_BASE="https://..."
 export DRIVE9_E2E_IMAGE_EXTRACT_API_KEY="..."
 export DRIVE9_E2E_IMAGE_EXTRACT_MODEL="..."
 bash e2e/image-extract-config-smoke-test.sh
+
+# Tenant video-extract config smoke. Manual-only and skip-if-env-missing.
+export DRIVE9_E2E_VIDEO_EXTRACT_API_BASE="https://..."
+export DRIVE9_E2E_VIDEO_EXTRACT_API_KEY="..."
+export DRIVE9_E2E_VIDEO_EXTRACT_MODEL="..."
+export DRIVE9_E2E_VIDEO_FIXTURE_PATH="/path/to/fixture.mp4"
+bash e2e/video-extract-config-smoke-test.sh
+
+# Tenant embedding config/processing smoke. Model output must be 1024 dimensions.
+export DRIVE9_E2E_EMBED_API_BASE="https://..."
+export DRIVE9_E2E_EMBED_API_KEY="..."
+export DRIVE9_E2E_EMBED_MODEL="..."
+bash e2e/embedding-config-smoke-test.sh
 ```
 
 #### Existing-tenant regression
@@ -640,6 +653,30 @@ suite: local image extract is env-only and does not validate tenant config.
 7. Disable config (`enabled:false` clears provider fields); upload a second image and require empty semantic text/tags for `DISABLED_EXTRACT_WAIT_S`
 8. Exit trap disables config, deletes the test tree, then `DELETE /v1/admin/tenants/{id}`
 
+### `video-extract-config-smoke-test.sh`
+
+Manual-only: hosted control-plane credentials, a billable OpenAI-compatible
+vision provider, and a caller-provided MP4. Not wired into CI; skips before any
+HTTP request when a required variable is missing.
+
+1. Provision a disposable tenant and wait for `active`
+2. PUT a custom video config with `protocol:openai`; verify masked provider output
+3. Upload the MP4 and poll `?stat` until model-derived `semantic_text` is written
+4. Disable the config, upload the MP4 again, and assert no extracted text appears
+5. Exit trap disables config, deletes the test tree, and deletes the tenant
+
+### `embedding-config-smoke-test.sh`
+
+Manual-only: hosted control-plane credentials plus a billable OpenAI-compatible
+embedding provider returning exactly 1024 dimensions. Not wired into CI; skips
+before any HTTP request when a required variable is missing.
+
+1. Provision a disposable tenant and wait for `active`; reject database-auto mode
+2. Reject an invalid key and unreachable API base, verifying config is unchanged
+3. PUT a valid custom config and verify masked provider output and generation
+4. Upload target/distractor text and poll a vocabulary-disjoint query for the target
+5. Disable the config; exit trap deletes the test tree and tenant
+
 ### `native-smoke-test.sh`
 
 Manual-only: requires TiDB Cloud API credentials. Not wired into CI.
@@ -673,7 +710,7 @@ Manual-only: requires TiDB Cloud API credentials. Not wired into CI.
 | `DRIVE9_API_KEY` | - | `cli-smoke-test.sh` (optional; when set, skip provision and reuse the tenant) |
 | `DRIVE9_API_KEY` | - | `fuse-smoke-test.sh` (optional; skip provision when set) |
 | `DRIVE9_API_KEY` | - | `posix-permission-smoke-test.sh` (optional; skip provision when set) |
-| `POLL_TIMEOUT_S` | `300` (api smoke), `600` (image-extract), `120` (other smoke) | polling scripts |
+| `POLL_TIMEOUT_S` | `300` (api smoke), `600` (hosted config smokes), `120` (other smoke) | polling scripts |
 | `POLL_INTERVAL_S` | `5` | polling scripts |
 | `RUN_LARGE_FILE` | `1` | `api-smoke-test.sh` |
 | `LARGE_FILE_MB` | `100` | `api-smoke-test.sh` |
@@ -764,15 +801,27 @@ Manual-only: requires TiDB Cloud API credentials. Not wired into CI.
 | `GIT_FEATURE_TIMEOUT_S` | `240` | `git-feature-smoke-test.sh` |
 | `GIT_FEATURE_RUN_OVERSIZED` | `1` | `git-feature-smoke-test.sh` |
 | `GIT_WORKSPACE_HYDRATE` | `sync` | `git-workspace-smoke-test.sh` |
-| `DRIVE9_TIDBCLOUD_PUBLIC_KEY` | *(required)* | `native-smoke-test.sh`, `image-extract-config-smoke-test.sh` |
-| `DRIVE9_TIDBCLOUD_PRIVATE_KEY` | *(required)* | `native-smoke-test.sh`, `image-extract-config-smoke-test.sh` |
+| `DRIVE9_TIDBCLOUD_PUBLIC_KEY` | *(required)* | `native-smoke-test.sh`, hosted config smoke tests |
+| `DRIVE9_TIDBCLOUD_PRIVATE_KEY` | *(required)* | `native-smoke-test.sh`, hosted config smoke tests |
 | `DRIVE9_E2E_IMAGE_EXTRACT_API_BASE` | *(required)* | `image-extract-config-smoke-test.sh` |
 | `DRIVE9_E2E_IMAGE_EXTRACT_API_KEY` | *(required)* | `image-extract-config-smoke-test.sh` |
 | `DRIVE9_E2E_IMAGE_EXTRACT_MODEL` | *(required)* | `image-extract-config-smoke-test.sh` |
 | `DRIVE9_E2E_UNREACHABLE_API_BASE` | `https://example.com:81/v1` | `image-extract-config-smoke-test.sh` |
 | `IMAGE_EXTRACT_TIMEOUT_S` | `180` | `image-extract-config-smoke-test.sh` |
 | `IMAGE_EXTRACT_INTERVAL_S` | `3` | `image-extract-config-smoke-test.sh` |
-| `DISABLED_EXTRACT_WAIT_S` | `30` | `image-extract-config-smoke-test.sh` |
+| `DISABLED_EXTRACT_WAIT_S` | `30` | image/video extract config smoke tests |
+| `DRIVE9_E2E_VIDEO_EXTRACT_API_BASE` | *(required)* | `video-extract-config-smoke-test.sh` |
+| `DRIVE9_E2E_VIDEO_EXTRACT_API_KEY` | *(required)* | `video-extract-config-smoke-test.sh` |
+| `DRIVE9_E2E_VIDEO_EXTRACT_MODEL` | *(required)* | `video-extract-config-smoke-test.sh` |
+| `DRIVE9_E2E_VIDEO_FIXTURE_PATH` | *(required MP4)* | `video-extract-config-smoke-test.sh` |
+| `VIDEO_EXTRACT_TIMEOUT_S` | `600` | `video-extract-config-smoke-test.sh` |
+| `VIDEO_EXTRACT_INTERVAL_S` | `5` | `video-extract-config-smoke-test.sh` |
+| `DRIVE9_E2E_EMBED_API_BASE` | *(required)* | `embedding-config-smoke-test.sh` |
+| `DRIVE9_E2E_EMBED_API_KEY` | *(required)* | `embedding-config-smoke-test.sh` |
+| `DRIVE9_E2E_EMBED_MODEL` | *(required, 1024 dimensions)* | `embedding-config-smoke-test.sh` |
+| `EMBED_TIMEOUT_S` | `180` | `embedding-config-smoke-test.sh` |
+| `EMBED_INTERVAL_S` | `3` | `embedding-config-smoke-test.sh` |
+| `EMBED_CONFIG_PROPAGATION_WAIT_S` | `2` | `embedding-config-smoke-test.sh` |
 | `SKIP_CLEANUP` | `0` | `native-smoke-test.sh` |
 
 ## Conventions

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -650,7 +650,7 @@ suite: local image extract is env-only and does not validate tenant config.
 
 1. `POST /v1/provision` with control-plane keys; capture `tenant_id` / `api_key`
 2. Poll `GET /v1/status` until `active`
-3. `GET /v1/admin/tenants/{id}/extract-config/image` — new tenant source is `none` or `default`
+3. `GET /v1/admin/tenants/{id}/extract-config/image` — require new tenant source `none` (a process default would make provider usage ambiguous)
 4. Invalid provider API key → 400, config unchanged; unreachable API base → 502/504, config unchanged
 5. Valid custom config PUT — provider validated, response/GET mask the API key
 6. Upload `e2e/fixtures/cat03.jpg`; poll `?stat` until `tags.e2e_marker` appears; `find` by that tag

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -149,13 +149,17 @@ export DRIVE9_E2E_IMAGE_EXTRACT_MODEL="..."
 bash e2e/image-extract-config-smoke-test.sh
 
 # Tenant video-extract config smoke. Manual-only and skip-if-env-missing.
+export DRIVE9_BASE="https://..."
 export DRIVE9_E2E_VIDEO_EXTRACT_API_BASE="https://..."
 export DRIVE9_E2E_VIDEO_EXTRACT_API_KEY="..."
 export DRIVE9_E2E_VIDEO_EXTRACT_MODEL="..."
 export DRIVE9_E2E_VIDEO_FIXTURE_PATH="/path/to/fixture.mp4"
+# The MP4 must visibly contain this marker; the script does not put it in the prompt.
+export DRIVE9_E2E_VIDEO_EXPECTED_MARKER="..."
 bash e2e/video-extract-config-smoke-test.sh
 
 # Tenant embedding config/processing smoke. Model output must be 1024 dimensions.
+export DRIVE9_BASE="https://..."
 export DRIVE9_E2E_EMBED_API_BASE="https://..."
 export DRIVE9_E2E_EMBED_API_KEY="..."
 export DRIVE9_E2E_EMBED_MODEL="..."
@@ -661,7 +665,7 @@ HTTP request when a required variable is missing.
 
 1. Provision a disposable tenant and wait for `active`
 2. PUT a custom video config with `protocol:openai`; verify masked provider output
-3. Upload the MP4 and poll `?stat` until model-derived `semantic_text` is written
+3. Upload the MP4 and poll `?stat` until model-derived `semantic_text` containing the fixture's expected marker is written
 4. Disable the config, upload the MP4 again, and assert no extracted text appears
 5. Exit trap disables config, deletes the test tree, and deletes the tenant
 
@@ -671,7 +675,7 @@ Manual-only: hosted control-plane credentials plus a billable OpenAI-compatible
 embedding provider returning exactly 1024 dimensions. Not wired into CI; skips
 before any HTTP request when a required variable is missing.
 
-1. Provision a disposable tenant and wait for `active`; reject database-auto mode
+1. Provision a disposable tenant and wait for `active`; require `source=none` and reject database-auto mode
 2. Reject an invalid key and unreachable API base, verifying config is unchanged
 3. PUT a valid custom config and verify masked provider output and generation
 4. Upload target/distractor text and poll a vocabulary-disjoint query for the target
@@ -814,6 +818,7 @@ Manual-only: requires TiDB Cloud API credentials. Not wired into CI.
 | `DRIVE9_E2E_VIDEO_EXTRACT_API_KEY` | *(required)* | `video-extract-config-smoke-test.sh` |
 | `DRIVE9_E2E_VIDEO_EXTRACT_MODEL` | *(required)* | `video-extract-config-smoke-test.sh` |
 | `DRIVE9_E2E_VIDEO_FIXTURE_PATH` | *(required MP4)* | `video-extract-config-smoke-test.sh` |
+| `DRIVE9_E2E_VIDEO_EXPECTED_MARKER` | *(required visible fixture fact)* | `video-extract-config-smoke-test.sh` |
 | `VIDEO_EXTRACT_TIMEOUT_S` | `600` | `video-extract-config-smoke-test.sh` |
 | `VIDEO_EXTRACT_INTERVAL_S` | `5` | `video-extract-config-smoke-test.sh` |
 | `DRIVE9_E2E_EMBED_API_BASE` | *(required)* | `embedding-config-smoke-test.sh` |

--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -28,17 +28,19 @@ Use a hosted deployment by default. For local development on this machine, use
 Current dev deployments:
 
 ```bash
-# Dev
+# Dev (HTTP only; never use for credential-bearing hosted config smokes)
 export DRIVE9_BASE="http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com"
 
-# Dev (tidbcloud-native)
+# Dev, tidbcloud-native (HTTP only; same restriction)
 export DRIVE9_BASE="http://k8s-drive9ti-drive9se-b6bbe5ba6e-cee81207452d1185.elb.ap-southeast-1.amazonaws.com"
 
 # Prod
 export DRIVE9_BASE="https://api.drive9.ai"
 ```
 
-Use the dev value unless the environment owner announces a new endpoint.
+Use the dev values only for scripts that do not send control-plane or provider
+credentials. Image/video extract-config and embedding-config smokes require an
+explicit HTTPS endpoint.
 
 #### Run smoke scripts
 
@@ -150,6 +152,8 @@ bash e2e/image-extract-config-smoke-test.sh
 
 # Tenant video-extract config smoke. Manual-only and skip-if-env-missing.
 export DRIVE9_BASE="https://..."
+export DRIVE9_TIDBCLOUD_PUBLIC_KEY="..."
+export DRIVE9_TIDBCLOUD_PRIVATE_KEY="..."
 export DRIVE9_E2E_VIDEO_EXTRACT_API_BASE="https://..."
 export DRIVE9_E2E_VIDEO_EXTRACT_API_KEY="..."
 export DRIVE9_E2E_VIDEO_EXTRACT_MODEL="..."
@@ -160,6 +164,8 @@ bash e2e/video-extract-config-smoke-test.sh
 
 # Tenant embedding config/processing smoke. Model output must be 1024 dimensions.
 export DRIVE9_BASE="https://..."
+export DRIVE9_TIDBCLOUD_PUBLIC_KEY="..."
+export DRIVE9_TIDBCLOUD_PRIVATE_KEY="..."
 export DRIVE9_E2E_EMBED_API_BASE="https://..."
 export DRIVE9_E2E_EMBED_API_KEY="..."
 export DRIVE9_E2E_EMBED_MODEL="..."
@@ -664,8 +670,8 @@ vision provider, and a caller-provided MP4. Not wired into CI; skips before any
 HTTP request when a required variable is missing.
 
 1. Provision a disposable tenant and wait for `active`
-2. PUT a custom video config with `protocol:openai`; verify masked provider output
-3. Upload the MP4 and poll `?stat` until model-derived `semantic_text` containing the fixture's expected marker is written
+2. Require initial config `source=none`, then PUT a custom video config with `protocol:openai`; verify masked provider output
+3. Reject a marker present in the prompt; upload the MP4 via multipart and poll `?stat` until model-derived `semantic_text` containing the fixture's expected marker is written
 4. Disable the config, upload the MP4 again, and assert no extracted text appears
 5. Exit trap disables config, deletes the test tree, and deletes the tenant
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -37,6 +37,8 @@ including local validation via `drive9-server` with `DRIVE9_TENANT_PROVIDER=loca
 | `tokens-smoke-test.sh` | `/v1/tokens` management: dispatcher, scoped lifecycle/refresh, pseudoroot projected listing and hidden siblings, scoped gate, control-plane generate/list/status (needs `provider=local` mock IAM). Off in default `smoke-all.sh`; set `RUN_TOKENS_SMOKE=1` |
 | `sse-retention-smoke-test.sh` | SSE `/v1/events` initial sync, live `file_changed` delivery + cursor replay, >1000-event backlog drain; optional long-window replay and short-retention sweep (`SSE_SWEEP_TEST=1`). Off in default `smoke-all.sh`; set `RUN_SSE_SMOKE=1` |
 | `image-extract-config-smoke-test.sh` | Opt-in hosted HTTP test: provision a disposable tenant, validate tenant image-extract config (reject invalid key / unreachable base, persist a masked custom config), upload an image, assert a generated attribute tag via stat/find, disable the config, and delete the tenant. Manual-only: needs control-plane keys and a billable vision provider |
+| `video-extract-config-smoke-test.sh` | Opt-in hosted HTTP test: provision a disposable tenant, persist an OpenAI-protocol video config, upload a caller-provided MP4, assert worker-generated semantic text, disable extraction, and verify a later upload stays unprocessed. Manual-only: needs control-plane keys, a billable vision provider, and an MP4 fixture |
+| `embedding-config-smoke-test.sh` | Opt-in hosted HTTP test: provision a disposable tenant, reject invalid/unreachable providers without persistence, persist a masked custom embedding config, upload target/distractor text, and assert semantic recall through the app-managed embedding worker. Manual-only: needs control-plane keys and a billable 1024-dimension embedding provider |
 | `object-auth-smoke-test.sh` | Manual `--auth=server` STS mint: admin object-backend add/get/update, tenant object-namespace, then `fs cp/ls/cat` against a real bucket without `--auth=local`, plus outside-namespace deny. Not wired into CI/local-e2e; skip-if-env-missing. Needs tidbcloud-native plus a dedicated test bucket |
 | `object-auth-s3-hosted-test.sh` | Manual hosted S3 `--auth=server` coverage: two-tenant `cust` vs `cust-evil` isolation (CLI + STS ListBucket), fail-closed mint, tenant key cannot register backends, read-only vs write mint, drive9↔S3 copy, object FUSE mount, and in-place STS refresh with `DRIVE9_OBJECT_SESSION_REFRESH_*_LEAD`. Same credentials as `object-auth-smoke-test.sh` |
 | `object-auth-cos-hosted-test.sh` | Same 44-check hosted coverage as S3, against Tencent COS (`tccli`). Needs a dedicated test bucket + CAM user; never point at prod COS. Set `DRIVE9_E2E_OBJECT_REGION` and `DRIVE9_E2E_OBJECT_ACCOUNT_ID` (APPID) |
@@ -56,7 +58,7 @@ without adding it to `.github/workflows/local-e2e.yml`.
 | Post-merge | `push` to `main` (local-e2e, coalesced via concurrency group) | PR gate + concurrency stress, POSIX/fsx, sqlite WAL/churn/concurrency, `smoke-all.sh` extras (journal, posix-permission, git-workspace), git feature smoke |
 | Nightly | cron 20:17 UTC (local-e2e) | Post-merge set + FUSE performance baseline/archive/compare (compare is report-only; hosted-runner noise) |
 | Manual all | Local E2E `workflow_dispatch` with `run_all_e2e=1` | Everything above |
-| Manual only | not wired, run by hand | `description-smoke-test.sh` (Docker + Ollama/stub embedder), `native-smoke-test.sh` (TiDB Cloud Native — requires credentials), `image-extract-config-smoke-test.sh` (hosted control-plane + billable vision provider), `object-auth-smoke-test.sh` (tidbcloud-native + real object-store STS mint; `--auth=server` cannot run in local-e2e), `object-auth-s3-hosted-test.sh` / `object-auth-cos-hosted-test.sh` / `object-auth-tos-hosted-test.sh` (hosted S3/COS/TOS isolation/mount/refresh; same reason) |
+| Manual only | not wired, run by hand | `description-smoke-test.sh` (Docker + Ollama/stub embedder), `native-smoke-test.sh` (TiDB Cloud Native — requires credentials), `image-extract-config-smoke-test.sh` / `video-extract-config-smoke-test.sh` (hosted control-plane + billable vision provider), `embedding-config-smoke-test.sh` (hosted control-plane + billable embedding provider), `object-auth-smoke-test.sh` (tidbcloud-native + real object-store STS mint; `--auth=server` cannot run in local-e2e), `object-auth-s3-hosted-test.sh` / `object-auth-cos-hosted-test.sh` / `object-auth-tos-hosted-test.sh` (hosted S3/COS/TOS isolation/mount/refresh; same reason) |
 
 Scheduled and post-merge failures auto-file/append to a `ci-e2e-failure`
 GitHub issue, since GitHub only notifies the workflow author otherwise.
@@ -214,6 +216,19 @@ export DRIVE9_E2E_IMAGE_EXTRACT_API_KEY="..."
 export DRIVE9_E2E_IMAGE_EXTRACT_MODEL="..."
 bash e2e/image-extract-config-smoke-test.sh
 
+# Tenant video-extract config + worker smoke. The fixture must be an MP4.
+export DRIVE9_E2E_VIDEO_EXTRACT_API_BASE="https://..."
+export DRIVE9_E2E_VIDEO_EXTRACT_API_KEY="..."
+export DRIVE9_E2E_VIDEO_EXTRACT_MODEL="..."
+export DRIVE9_E2E_VIDEO_FIXTURE_PATH="/path/to/fixture.mp4"
+bash e2e/video-extract-config-smoke-test.sh
+
+# Tenant embedding-config + worker/query smoke. The model must return 1024 dimensions.
+export DRIVE9_E2E_EMBED_API_BASE="https://..."
+export DRIVE9_E2E_EMBED_API_KEY="..."
+export DRIVE9_E2E_EMBED_MODEL="..."
+bash e2e/embedding-config-smoke-test.sh
+
 bash e2e/smoke-all.sh
 
 # Skip FUSE-related suites.
@@ -303,6 +318,18 @@ Useful knobs for existing-tenant runs:
   and an unreachable API base are rejected without changing the tenant's
   config. Override `DRIVE9_E2E_UNREACHABLE_API_BASE` only when the default
   public, closed-port endpoint is unsuitable.
+- `video-extract-config-smoke-test.sh` requires a caller-provided MP4 through
+  `DRIVE9_E2E_VIDEO_FIXTURE_PATH`. It sets `protocol:openai`, validates masked
+  config output, polls `semantic_text` for model-derived visual output, then
+  disables the config and verifies that a subsequent upload remains empty.
+- `embedding-config-smoke-test.sh` requires an OpenAI-compatible model that
+  returns exactly 1024 dimensions. It can configure shared or native
+  `fts_only` tenants; database auto-embedding tenants are rejected explicitly.
+  After PUT it waits two seconds by default for cross-Pod config invalidation
+  (`EMBED_CONFIG_PROPAGATION_WAIT_S`) before uploading the test documents.
+  The semantic query deliberately avoids the target text's vocabulary so a
+  successful match exercises vector generation and query embedding rather
+  than plain FTS.
 - Tenant readiness is checked through `GET /v1/status`.
 - `api-smoke-test.sh` defaults `POLL_TIMEOUT_S` to 300s because schema initialization can exceed 120s in some regions.
 - File operations use `/v1/fs/*` and include nested directory coverage.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -37,8 +37,8 @@ including local validation via `drive9-server` with `DRIVE9_TENANT_PROVIDER=loca
 | `tokens-smoke-test.sh` | `/v1/tokens` management: dispatcher, scoped lifecycle/refresh, pseudoroot projected listing and hidden siblings, scoped gate, control-plane generate/list/status (needs `provider=local` mock IAM). Off in default `smoke-all.sh`; set `RUN_TOKENS_SMOKE=1` |
 | `sse-retention-smoke-test.sh` | SSE `/v1/events` initial sync, live `file_changed` delivery + cursor replay, >1000-event backlog drain; optional long-window replay and short-retention sweep (`SSE_SWEEP_TEST=1`). Off in default `smoke-all.sh`; set `RUN_SSE_SMOKE=1` |
 | `image-extract-config-smoke-test.sh` | Opt-in hosted HTTP test: provision a disposable tenant, validate tenant image-extract config (reject invalid key / unreachable base, persist a masked custom config), upload an image, assert a generated attribute tag via stat/find, disable the config, and delete the tenant. Manual-only: needs control-plane keys and a billable vision provider |
-| `video-extract-config-smoke-test.sh` | Opt-in hosted HTTP test: provision a disposable tenant, persist an OpenAI-protocol video config, upload a caller-provided MP4, assert worker-generated semantic text, disable extraction, and verify a later upload stays unprocessed. Manual-only: needs control-plane keys, a billable vision provider, and an MP4 fixture |
-| `embedding-config-smoke-test.sh` | Opt-in hosted HTTP test: provision a disposable tenant, reject invalid/unreachable providers without persistence, persist a masked custom embedding config, upload target/distractor text, and assert semantic recall through the app-managed embedding worker. Manual-only: needs control-plane keys and a billable 1024-dimension embedding provider |
+| `video-extract-config-smoke-test.sh` | Opt-in hosted HTTPS test: provision a disposable tenant, persist an OpenAI-protocol video config, upload a caller-provided MP4 with a fixture-visible expected marker, assert worker-generated semantic text, disable extraction, and verify a later upload stays unprocessed. Manual-only: needs control-plane keys, a billable vision provider, and an MP4 fixture |
+| `embedding-config-smoke-test.sh` | Opt-in hosted HTTPS test: require no process-default embedding provider, provision a disposable tenant, reject invalid/unreachable providers without persistence, persist a masked custom embedding config, upload target/distractor text, and assert semantic recall through the app-managed embedding worker. Manual-only: needs control-plane keys and a billable 1024-dimension embedding provider |
 | `object-auth-smoke-test.sh` | Manual `--auth=server` STS mint: admin object-backend add/get/update, tenant object-namespace, then `fs cp/ls/cat` against a real bucket without `--auth=local`, plus outside-namespace deny. Not wired into CI/local-e2e; skip-if-env-missing. Needs tidbcloud-native plus a dedicated test bucket |
 | `object-auth-s3-hosted-test.sh` | Manual hosted S3 `--auth=server` coverage: two-tenant `cust` vs `cust-evil` isolation (CLI + STS ListBucket), fail-closed mint, tenant key cannot register backends, read-only vs write mint, drive9↔S3 copy, object FUSE mount, and in-place STS refresh with `DRIVE9_OBJECT_SESSION_REFRESH_*_LEAD`. Same credentials as `object-auth-smoke-test.sh` |
 | `object-auth-cos-hosted-test.sh` | Same 44-check hosted coverage as S3, against Tencent COS (`tccli`). Needs a dedicated test bucket + CAM user; never point at prod COS. Set `DRIVE9_E2E_OBJECT_REGION` and `DRIVE9_E2E_OBJECT_ACCOUNT_ID` (APPID) |
@@ -217,13 +217,17 @@ export DRIVE9_E2E_IMAGE_EXTRACT_MODEL="..."
 bash e2e/image-extract-config-smoke-test.sh
 
 # Tenant video-extract config + worker smoke. The fixture must be an MP4.
+export DRIVE9_BASE="https://..."
 export DRIVE9_E2E_VIDEO_EXTRACT_API_BASE="https://..."
 export DRIVE9_E2E_VIDEO_EXTRACT_API_KEY="..."
 export DRIVE9_E2E_VIDEO_EXTRACT_MODEL="..."
 export DRIVE9_E2E_VIDEO_FIXTURE_PATH="/path/to/fixture.mp4"
+# The fixture must visibly contain this marker; it is not included in the prompt.
+export DRIVE9_E2E_VIDEO_EXPECTED_MARKER="..."
 bash e2e/video-extract-config-smoke-test.sh
 
 # Tenant embedding-config + worker/query smoke. The model must return 1024 dimensions.
+export DRIVE9_BASE="https://..."
 export DRIVE9_E2E_EMBED_API_BASE="https://..."
 export DRIVE9_E2E_EMBED_API_KEY="..."
 export DRIVE9_E2E_EMBED_MODEL="..."
@@ -319,11 +323,15 @@ Useful knobs for existing-tenant runs:
   config. Override `DRIVE9_E2E_UNREACHABLE_API_BASE` only when the default
   public, closed-port endpoint is unsuitable.
 - `video-extract-config-smoke-test.sh` requires a caller-provided MP4 through
-  `DRIVE9_E2E_VIDEO_FIXTURE_PATH`. It sets `protocol:openai`, validates masked
-  config output, polls `semantic_text` for model-derived visual output, then
-  disables the config and verifies that a subsequent upload remains empty.
+  `DRIVE9_E2E_VIDEO_FIXTURE_PATH` and a visible fixture fact through
+  `DRIVE9_E2E_VIDEO_EXPECTED_MARKER`. It requires an explicit HTTPS
+  `DRIVE9_BASE`, sets `protocol:openai`, validates masked config output, polls
+  `semantic_text` for model-derived visual output containing that fixture fact,
+  then disables the config and verifies that a subsequent upload remains empty.
 - `embedding-config-smoke-test.sh` requires an OpenAI-compatible model that
-  returns exactly 1024 dimensions. It can configure shared or native
+  returns exactly 1024 dimensions, an explicit HTTPS `DRIVE9_BASE`, and an
+  initial `source=none` config so the smoke proves the persisted tenant config
+  is used rather than a process default. It can configure shared or native
   `fts_only` tenants; database auto-embedding tenants are rejected explicitly.
   After PUT it waits two seconds by default for cross-Pod config invalidation
   (`EMBED_CONFIG_PROPAGATION_WAIT_S`) before uploading the test documents.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -36,7 +36,7 @@ including local validation via `drive9-server` with `DRIVE9_TENANT_PROVIDER=loca
 | `posix-permission-smoke-test.sh` | POSIX permission coverage: API mkdir/chmod mode propagation, CLI `fs chmod`, FUSE `chmod`/`mkdir -m` with remote and local stat parity |
 | `tokens-smoke-test.sh` | `/v1/tokens` management: dispatcher, scoped lifecycle/refresh, pseudoroot projected listing and hidden siblings, scoped gate, control-plane generate/list/status (needs `provider=local` mock IAM). Off in default `smoke-all.sh`; set `RUN_TOKENS_SMOKE=1` |
 | `sse-retention-smoke-test.sh` | SSE `/v1/events` initial sync, live `file_changed` delivery + cursor replay, >1000-event backlog drain; optional long-window replay and short-retention sweep (`SSE_SWEEP_TEST=1`). Off in default `smoke-all.sh`; set `RUN_SSE_SMOKE=1` |
-| `image-extract-config-smoke-test.sh` | Opt-in hosted HTTP test: provision a disposable tenant, validate tenant image-extract config (reject invalid key / unreachable base, persist a masked custom config), upload an image, assert a generated attribute tag via stat/find, disable the config, and delete the tenant. Manual-only: needs control-plane keys and a billable vision provider |
+| `image-extract-config-smoke-test.sh` | Opt-in hosted HTTPS test: require no process-default image provider, provision a disposable tenant, validate tenant image-extract config (reject invalid key / unreachable base, persist a masked custom config), upload an image, assert a generated attribute tag via stat/find, disable the config, and delete the tenant. Manual-only: needs control-plane keys and a billable vision provider |
 | `video-extract-config-smoke-test.sh` | Opt-in hosted HTTPS test: provision a disposable tenant, persist an OpenAI-protocol video config, upload a caller-provided MP4 with a fixture-visible expected marker, assert worker-generated semantic text, disable extraction, and verify a later upload stays unprocessed. Manual-only: needs control-plane keys, a billable vision provider, and an MP4 fixture |
 | `embedding-config-smoke-test.sh` | Opt-in hosted HTTPS test: require no process-default embedding provider, provision a disposable tenant, reject invalid/unreachable providers without persistence, persist a masked custom embedding config, upload target/distractor text, and assert semantic recall through the app-managed embedding worker. Manual-only: needs control-plane keys and a billable 1024-dimension embedding provider |
 | `object-auth-smoke-test.sh` | Manual `--auth=server` STS mint: admin object-backend add/get/update, tenant object-namespace, then `fs cp/ls/cat` against a real bucket without `--auth=local`, plus outside-namespace deny. Not wired into CI/local-e2e; skip-if-env-missing. Needs tidbcloud-native plus a dedicated test bucket |
@@ -304,7 +304,8 @@ Useful knobs for existing-tenant runs:
 - `api-smoke-test.sh` expects `POST /v1/provision` to return `tenant_id`, `api_key`, and `status`.
 - `image-extract-config-smoke-test.sh` always provisions a disposable tenant
   with `DRIVE9_TIDBCLOUD_PUBLIC_KEY` / `DRIVE9_TIDBCLOUD_PRIVATE_KEY`. Provider
-  configuration requires `DRIVE9_E2E_IMAGE_EXTRACT_API_BASE`,
+  configuration requires an explicit HTTPS `DRIVE9_BASE` and
+  `DRIVE9_E2E_IMAGE_EXTRACT_API_BASE`,
   `DRIVE9_E2E_IMAGE_EXTRACT_API_KEY`, and `DRIVE9_E2E_IMAGE_EXTRACT_MODEL`.
   The config PUT performs a real validation request before storing the config,
   and the uploaded fixture causes a second provider request in the image
@@ -312,7 +313,9 @@ Useful knobs for existing-tenant runs:
   a short lowercase English noun chosen by the model from the image. The test
   never prints either private key. Exit trap disables the custom config first,
   then removes the test file tree and deletes the tenant. `POLL_TIMEOUT_S`
-  controls tenant readiness (default `600`); `IMAGE_EXTRACT_TIMEOUT_S` and
+  controls tenant readiness (default `600`); the initial config must report
+  `source=none` so the smoke cannot pass through a process default.
+  `IMAGE_EXTRACT_TIMEOUT_S` and
   `IMAGE_EXTRACT_INTERVAL_S` control tag polling (defaults `180` and `3`).
   After the positive path, the test disables the custom config, uploads a new
   image, and requires its semantic text and tags to stay empty for

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -101,15 +101,19 @@ Use a hosted deployment by default. For local development on this machine, use
 #### Deployment endpoints
 
 ```bash
-# Dev
+# Dev (HTTP only; never use for credential-bearing hosted config smokes)
 export DRIVE9_BASE="http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com"
 
-# Dev (tidbcloud-native)
+# Dev, tidbcloud-native (HTTP only; same restriction)
 export DRIVE9_BASE="http://k8s-drive9ti-drive9se-b6bbe5ba6e-cee81207452d1185.elb.ap-southeast-1.amazonaws.com"
 
 # Prod
 export DRIVE9_BASE="https://api.drive9.ai"
 ```
+
+The hosted image/video extract-config and embedding-config smokes send
+control-plane and provider credentials, so they require an explicit HTTPS
+endpoint and reject both HTTP dev endpoints above.
 
 #### Run smoke scripts
 
@@ -218,6 +222,8 @@ bash e2e/image-extract-config-smoke-test.sh
 
 # Tenant video-extract config + worker smoke. The fixture must be an MP4.
 export DRIVE9_BASE="https://..."
+export DRIVE9_TIDBCLOUD_PUBLIC_KEY="..."
+export DRIVE9_TIDBCLOUD_PRIVATE_KEY="..."
 export DRIVE9_E2E_VIDEO_EXTRACT_API_BASE="https://..."
 export DRIVE9_E2E_VIDEO_EXTRACT_API_KEY="..."
 export DRIVE9_E2E_VIDEO_EXTRACT_MODEL="..."
@@ -228,6 +234,8 @@ bash e2e/video-extract-config-smoke-test.sh
 
 # Tenant embedding-config + worker/query smoke. The model must return 1024 dimensions.
 export DRIVE9_BASE="https://..."
+export DRIVE9_TIDBCLOUD_PUBLIC_KEY="..."
+export DRIVE9_TIDBCLOUD_PRIVATE_KEY="..."
 export DRIVE9_E2E_EMBED_API_BASE="https://..."
 export DRIVE9_E2E_EMBED_API_KEY="..."
 export DRIVE9_E2E_EMBED_MODEL="..."
@@ -328,9 +336,11 @@ Useful knobs for existing-tenant runs:
 - `video-extract-config-smoke-test.sh` requires a caller-provided MP4 through
   `DRIVE9_E2E_VIDEO_FIXTURE_PATH` and a visible fixture fact through
   `DRIVE9_E2E_VIDEO_EXPECTED_MARKER`. It requires an explicit HTTPS
-  `DRIVE9_BASE`, sets `protocol:openai`, validates masked config output, polls
-  `semantic_text` for model-derived visual output containing that fixture fact,
-  then disables the config and verifies that a subsequent upload remains empty.
+  `DRIVE9_BASE` and initial `source=none`, rejects a marker already present in
+  its prompt, sets `protocol:openai`, validates masked config output, uploads by
+  the multipart protocol, polls `semantic_text` for model-derived visual output
+  containing that fixture fact, then disables the config and verifies that a
+  subsequent upload remains empty.
 - `embedding-config-smoke-test.sh` requires an OpenAI-compatible model that
   returns exactly 1024 dimensions, an explicit HTTPS `DRIVE9_BASE`, and an
   initial `source=none` config so the smoke proves the persisted tenant config

--- a/e2e/embedding-config-smoke-test.sh
+++ b/e2e/embedding-config-smoke-test.sh
@@ -53,6 +53,8 @@ die() {
   exit 1
 }
 
+[[ "$BASE" == https://* ]] || die "DRIVE9_BASE must use https:// for hosted embedding config smoke"
+
 for command in curl jq; do
   command -v "$command" >/dev/null || die "$command is required"
 done
@@ -207,7 +209,8 @@ before_body="$(json_body "$before_response")"
 [ "$before_code" = "200" ] || http_failure "initial embedding config GET" "$before_code" "$before_body"
 before_source="$(printf '%s' "$before_body" | jq -r '.source // empty')"
 case "$before_source" in
-  none|default) ;;
+  none) ;;
+  default) die "tenant has a process default embedding provider; hosted embedding-config smoke requires source=none to prove tenant config usage" ;;
   database_auto) die "tenant uses database auto-embedding; hosted embedding-config smoke requires shared or native fts_only mode" ;;
   *) die "new tenant unexpectedly has embedding config source ${before_source:-unknown}" ;;
 esac

--- a/e2e/embedding-config-smoke-test.sh
+++ b/e2e/embedding-config-smoke-test.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# Live tenant embedding-config and semantic processing smoke test.
+#
+# Manual-only: provisions and deletes a real tenant and calls a billable
+# OpenAI-compatible 1024-dimension embedding provider. Missing configuration
+# skips the suite before any HTTP request is made.
+
+set -euo pipefail
+
+required_env=(
+  DRIVE9_BASE
+  DRIVE9_TIDBCLOUD_PUBLIC_KEY
+  DRIVE9_TIDBCLOUD_PRIVATE_KEY
+  DRIVE9_E2E_EMBED_API_BASE
+  DRIVE9_E2E_EMBED_API_KEY
+  DRIVE9_E2E_EMBED_MODEL
+)
+missing_env=()
+for name in "${required_env[@]}"; do
+  if [ -z "${!name:-}" ]; then
+    missing_env+=("$name")
+  fi
+done
+if [ "${#missing_env[@]}" -gt 0 ]; then
+  printf 'SKIP: embedding config smoke requires: %s\n' "${missing_env[*]}"
+  exit 0
+fi
+
+BASE="${DRIVE9_BASE%/}"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-600}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+EMBED_TIMEOUT_S="${EMBED_TIMEOUT_S:-180}"
+EMBED_INTERVAL_S="${EMBED_INTERVAL_S:-3}"
+EMBED_CONFIG_PROPAGATION_WAIT_S="${EMBED_CONFIG_PROPAGATION_WAIT_S:-2}"
+CURL_CONNECT_TIMEOUT_S="${CURL_CONNECT_TIMEOUT_S:-10}"
+CURL_MAX_TIME_S="${CURL_MAX_TIME_S:-120}"
+UNREACHABLE_API_BASE="${DRIVE9_E2E_UNREACHABLE_API_BASE:-https://example.com:81/v1}"
+
+ROOT_PATH="embedding-e2e"
+TARGET_PATH="$ROOT_PATH/target.txt"
+DISTRACTOR_PATH="$ROOT_PATH/distractor.txt"
+TARGET_TEXT="A veterinarian carefully treats an injured kitten inside a quiet clinic."
+DISTRACTOR_TEXT="A cargo ship carries steel containers across the open ocean."
+SEMANTIC_QUERY="animal doctor caring for a wounded feline"
+
+TENANT_ID=""
+OWNER_API_KEY=""
+CONFIG_ENABLED=0
+TREE_CREATED=0
+
+die() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for command in curl jq; do
+  command -v "$command" >/dev/null || die "$command is required"
+done
+
+curl_response() {
+  local method="$1"
+  local url="$2"
+  local auth="$3"
+  shift 3
+
+  local body_file
+  body_file="$(mktemp)"
+  local args=(
+    --connect-timeout "$CURL_CONNECT_TIMEOUT_S"
+    --max-time "$CURL_MAX_TIME_S"
+    -sS -o "$body_file" -w '%{http_code}' -X "$method"
+  )
+  case "$auth" in
+    control-plane)
+      args+=(
+        -H "X-TiDBCloud-Public-Key: $DRIVE9_TIDBCLOUD_PUBLIC_KEY"
+        -H "X-TiDBCloud-Private-Key: $DRIVE9_TIDBCLOUD_PRIVATE_KEY"
+      )
+      ;;
+    owner)
+      args+=(-H "Authorization: Bearer ${OWNER_API_KEY}")
+      ;;
+    *)
+      rm -f "$body_file"
+      die "unknown authentication mode: $auth"
+      ;;
+  esac
+
+  local code
+  if ! code="$(curl "${args[@]}" "$@" "$url")"; then
+    rm -f "$body_file"
+    return 1
+  fi
+  cat "$body_file"
+  printf '\n__HTTP__%s\n' "$code"
+  rm -f "$body_file"
+}
+
+http_code() {
+  printf '%s' "$1" | awk -F'__HTTP__' 'NF > 1 {print $2}' | tr -d '\n'
+}
+
+json_body() {
+  printf '%s' "$1" | sed '/__HTTP__/d'
+}
+
+http_failure() {
+  local action="$1"
+  local code="$2"
+  local body="$3"
+  local reason
+  reason="$(printf '%s' "$body" | jq -r '.error // empty' 2>/dev/null || true)"
+  if [ -n "$reason" ]; then
+    die "$action returned HTTP $code: $reason"
+  fi
+  die "$action returned HTTP $code"
+}
+
+assert_config_unchanged() {
+  local label="$1"
+  local response code body canonical
+  response="$(curl_response GET "$config_url" control-plane)" || die "$label config verification GET failed"
+  code="$(http_code "$response")"
+  body="$(json_body "$response")"
+  [ "$code" = "200" ] || http_failure "$label config verification GET" "$code" "$body"
+  canonical="$(printf '%s' "$body" | jq -S -c .)" || die "$label config verification returned invalid JSON"
+  [ "$canonical" = "$before_canonical" ] || die "$label candidate changed the persisted config"
+}
+
+cleanup() {
+  local status=$?
+  local cleanup_failed=0
+  trap - EXIT
+  set +e
+
+  if [ "$CONFIG_ENABLED" -eq 1 ] && [ -n "$TENANT_ID" ]; then
+    local disable_response disable_code
+    disable_response="$(printf '%s' '{"enabled":false}' | curl_response PUT "$BASE/v1/admin/tenants/$TENANT_ID/embedding-config" control-plane -H 'Content-Type: application/json' --data-binary @-)"
+    disable_code="$(http_code "$disable_response")"
+    if [ "$disable_code" != "200" ]; then
+      printf 'CLEANUP FAIL: disabling embedding config returned HTTP %s\n' "$disable_code" >&2
+      cleanup_failed=1
+    fi
+  fi
+
+  if [ "$TREE_CREATED" -eq 1 ] && [ -n "$OWNER_API_KEY" ]; then
+    local tree_response tree_code
+    tree_response="$(curl_response DELETE "$BASE/v1/fs/$ROOT_PATH?recursive" owner)"
+    tree_code="$(http_code "$tree_response")"
+    if [ "$tree_code" != "200" ]; then
+      printf 'CLEANUP FAIL: deleting test tree returned HTTP %s\n' "$tree_code" >&2
+      cleanup_failed=1
+    fi
+  fi
+
+  if [ -n "$TENANT_ID" ]; then
+    local tenant_response tenant_code
+    tenant_response="$(curl_response DELETE "$BASE/v1/admin/tenants/$TENANT_ID" control-plane)"
+    tenant_code="$(http_code "$tenant_response")"
+    if [ "$tenant_code" != "202" ] && [ "$tenant_code" != "200" ]; then
+      printf 'CLEANUP FAIL: deleting tenant %s returned HTTP %s\n' "$TENANT_ID" "$tenant_code" >&2
+      cleanup_failed=1
+    fi
+  fi
+
+  if [ "$status" -eq 0 ] && [ "$cleanup_failed" -ne 0 ]; then
+    status=1
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+printf '=== tenant embedding config smoke ===\n'
+printf 'Base URL: %s\n' "$BASE"
+printf 'Target text: %s\n' "$TARGET_TEXT"
+printf 'Semantic query: %s\n' "$SEMANTIC_QUERY"
+
+provision_response="$(curl_response POST "$BASE/v1/provision" control-plane)" || die "tenant provision request failed"
+provision_code="$(http_code "$provision_response")"
+provision_body="$(json_body "$provision_response")"
+[ "$provision_code" = "202" ] || http_failure "tenant provision" "$provision_code" "$provision_body"
+TENANT_ID="$(printf '%s' "$provision_body" | jq -r '.tenant_id // empty')"
+OWNER_API_KEY="$(printf '%s' "$provision_body" | jq -r '.api_key // empty')"
+[ -n "$TENANT_ID" ] || die "tenant provision response omitted tenant_id"
+[ -n "$OWNER_API_KEY" ] || die "tenant provision response omitted api_key"
+printf 'PASS: provisioned disposable tenant %s\n' "$TENANT_ID"
+
+deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+last_status=""
+while :; do
+  status_response="$(curl_response GET "$BASE/v1/status" owner)" || die "tenant status request failed"
+  status_code="$(http_code "$status_response")"
+  status_body="$(json_body "$status_response")"
+  if [ "$status_code" = "200" ]; then
+    last_status="$(printf '%s' "$status_body" | jq -r '.status // empty')"
+    [ "$last_status" = "active" ] && break
+  fi
+  [ "$(date +%s)" -lt "$deadline" ] || die "tenant did not become active within ${POLL_TIMEOUT_S}s (last status: ${last_status:-unknown})"
+  sleep "$POLL_INTERVAL_S"
+done
+printf 'PASS: tenant became active\n'
+
+config_url="$BASE/v1/admin/tenants/$TENANT_ID/embedding-config"
+before_response="$(curl_response GET "$config_url" control-plane)" || die "initial embedding config request failed"
+before_code="$(http_code "$before_response")"
+before_body="$(json_body "$before_response")"
+[ "$before_code" = "200" ] || http_failure "initial embedding config GET" "$before_code" "$before_body"
+before_source="$(printf '%s' "$before_body" | jq -r '.source // empty')"
+case "$before_source" in
+  none|default) ;;
+  database_auto) die "tenant uses database auto-embedding; hosted embedding-config smoke requires shared or native fts_only mode" ;;
+  *) die "new tenant unexpectedly has embedding config source ${before_source:-unknown}" ;;
+esac
+before_canonical="$(printf '%s' "$before_body" | jq -S -c .)" || die "initial embedding config GET returned invalid JSON"
+
+invalid_key_response="$(
+  jq -nc --arg api_base "$DRIVE9_E2E_EMBED_API_BASE" --arg model "$DRIVE9_E2E_EMBED_MODEL" '{enabled:true, api_base:$api_base, api_key:"drive9-e2e-invalid-provider-key", model:$model}' |
+    curl_response PUT "$config_url" control-plane -H 'Content-Type: application/json' --data-binary @-
+)" || die "invalid API key embedding config PUT request failed"
+invalid_key_code="$(http_code "$invalid_key_response")"
+invalid_key_body="$(json_body "$invalid_key_response")"
+[ "$invalid_key_code" = "400" ] || http_failure "invalid API key embedding config PUT (expected HTTP 400)" "$invalid_key_code" "$invalid_key_body"
+invalid_key_error="$(printf '%s' "$invalid_key_body" | jq -r '.error // empty')"
+[[ "$invalid_key_error" == "embedding provider validation failed: "* ]] || die "invalid API key embedding config PUT returned an unexpected error"
+assert_config_unchanged "invalid API key"
+printf 'PASS: invalid embedding provider key was rejected without persistence\n'
+
+unreachable_response="$(
+  jq -nc --arg api_base "$UNREACHABLE_API_BASE" --arg api_key "$DRIVE9_E2E_EMBED_API_KEY" --arg model "$DRIVE9_E2E_EMBED_MODEL" '{enabled:true, api_base:$api_base, api_key:$api_key, model:$model}' |
+    curl_response PUT "$config_url" control-plane -H 'Content-Type: application/json' --data-binary @-
+)" || die "unreachable embedding provider config PUT request failed"
+unreachable_code="$(http_code "$unreachable_response")"
+unreachable_body="$(json_body "$unreachable_response")"
+if [ "$unreachable_code" != "502" ] && [ "$unreachable_code" != "504" ]; then
+  http_failure "unreachable embedding provider config PUT (expected HTTP 502 or 504)" "$unreachable_code" "$unreachable_body"
+fi
+assert_config_unchanged "unreachable API base"
+printf 'PASS: unreachable embedding provider was rejected without persistence\n'
+
+config_response="$(
+  jq -nc '{enabled:true, api_base:env.DRIVE9_E2E_EMBED_API_BASE, api_key:env.DRIVE9_E2E_EMBED_API_KEY, model:env.DRIVE9_E2E_EMBED_MODEL}' |
+    curl_response PUT "$config_url" control-plane -H 'Content-Type: application/json' --data-binary @-
+)" || die "embedding config PUT request failed"
+config_code="$(http_code "$config_response")"
+config_body="$(json_body "$config_response")"
+[ "$config_code" = "200" ] || http_failure "embedding config PUT/provider validation" "$config_code" "$config_body"
+CONFIG_ENABLED=1
+if ! printf '%s' "$config_body" | jq -e '
+  .enabled == true and .source == "custom" and (.generation | type == "number" and . > 0) and
+  .api_base == env.DRIVE9_E2E_EMBED_API_BASE and .model == env.DRIVE9_E2E_EMBED_MODEL and
+  (.api_key | type == "string" and contains("*") and . != env.DRIVE9_E2E_EMBED_API_KEY)
+' >/dev/null; then
+  die "embedding config response did not return the expected masked custom config"
+fi
+printf 'PASS: embedding provider validated and custom config is masked\n'
+
+# Config invalidation is synchronous on the serving pod and propagated to
+# other pods by the metadb outbox. Allow that bounded broadcast to settle
+# before the upload decides whether to enqueue app-managed embedding work.
+sleep "$EMBED_CONFIG_PROPAGATION_WAIT_S"
+
+mkdir_response="$(curl_response POST "$BASE/v1/fs/$ROOT_PATH?mkdir" owner)" || die "test directory creation failed"
+mkdir_code="$(http_code "$mkdir_response")"
+mkdir_body="$(json_body "$mkdir_response")"
+[ "$mkdir_code" = "200" ] || http_failure "test directory creation" "$mkdir_code" "$mkdir_body"
+TREE_CREATED=1
+
+target_response="$(curl_response PUT "$BASE/v1/fs/$TARGET_PATH" owner -H 'Content-Type: text/plain' --data-binary "$TARGET_TEXT")" || die "semantic target upload failed"
+target_code="$(http_code "$target_response")"
+target_body="$(json_body "$target_response")"
+[ "$target_code" = "200" ] || http_failure "semantic target upload" "$target_code" "$target_body"
+distractor_response="$(curl_response PUT "$BASE/v1/fs/$DISTRACTOR_PATH" owner -H 'Content-Type: text/plain' --data-binary "$DISTRACTOR_TEXT")" || die "semantic distractor upload failed"
+distractor_code="$(http_code "$distractor_response")"
+distractor_body="$(json_body "$distractor_response")"
+[ "$distractor_code" = "200" ] || http_failure "semantic distractor upload" "$distractor_code" "$distractor_body"
+printf 'PASS: uploaded semantic target and distractor\n'
+
+embed_deadline=$(( $(date +%s) + EMBED_TIMEOUT_S ))
+found="false"
+while :; do
+  grep_response="$(curl_response GET "$BASE/v1/fs/$ROOT_PATH" owner --get --data-urlencode "grep=$SEMANTIC_QUERY" --data-urlencode 'limit=20')" || die "semantic grep request failed"
+  grep_code="$(http_code "$grep_response")"
+  grep_body="$(json_body "$grep_response")"
+  if [ "$grep_code" = "200" ] && printf '%s' "$grep_body" | jq -e --arg path "/$TARGET_PATH" '
+    type == "array" and any(.[]; (.path == $path) or ((.path // "") | endswith($path)))
+  ' >/dev/null 2>&1; then
+    found="true"
+    break
+  fi
+  [ "$(date +%s)" -lt "$embed_deadline" ] || break
+  sleep "$EMBED_INTERVAL_S"
+done
+[ "$found" = "true" ] || die "semantic query did not find the target within ${EMBED_TIMEOUT_S}s"
+printf 'PASS: app-managed embedding worker and semantic query found the target\n'
+printf '%s\n' '--- semantic grep result ---'
+printf '%s' "$grep_body" | jq .
+
+disable_response="$(printf '%s' '{"enabled":false}' | curl_response PUT "$config_url" control-plane -H 'Content-Type: application/json' --data-binary @-)" || die "embedding config disable request failed"
+disable_code="$(http_code "$disable_response")"
+disable_body="$(json_body "$disable_response")"
+[ "$disable_code" = "200" ] || http_failure "embedding config disable" "$disable_code" "$disable_body"
+if ! printf '%s' "$disable_body" | jq -e '.enabled == false and .source == "custom" and (.api_base // "") == "" and (.api_key // "") == "" and (.model // "") == ""' >/dev/null; then
+  die "embedding config disable response did not return a cleared custom config"
+fi
+CONFIG_ENABLED=0
+printf 'PASS: embedding config disabled cleanly\n'

--- a/e2e/image-extract-config-smoke-test.sh
+++ b/e2e/image-extract-config-smoke-test.sh
@@ -61,6 +61,8 @@ die() {
   exit 1
 }
 
+[[ "$BASE" == https://* ]] || die "DRIVE9_BASE must use https:// for hosted image extract smoke"
+
 for command in curl jq; do
   command -v "$command" >/dev/null || die "$command is required"
 done
@@ -223,7 +225,8 @@ before_body="$(json_body "$before_response")"
 [ "$before_code" = "200" ] || http_failure "initial extract config GET" "$before_code" "$before_body"
 before_source="$(printf '%s' "$before_body" | jq -r '.source // empty')"
 case "$before_source" in
-  none|default) ;;
+  none) ;;
+  default) die "tenant has a process default image provider; hosted image-extract smoke requires source=none to prove tenant config usage" ;;
   *) die "new tenant unexpectedly has extract config source ${before_source:-unknown}" ;;
 esac
 before_canonical="$(printf '%s' "$before_body" | jq -S -c .)" || die "initial extract config GET returned invalid JSON"

--- a/e2e/video-extract-config-smoke-test.sh
+++ b/e2e/video-extract-config-smoke-test.sh
@@ -8,12 +8,14 @@
 set -euo pipefail
 
 required_env=(
+  DRIVE9_BASE
   DRIVE9_TIDBCLOUD_PUBLIC_KEY
   DRIVE9_TIDBCLOUD_PRIVATE_KEY
   DRIVE9_E2E_VIDEO_EXTRACT_API_BASE
   DRIVE9_E2E_VIDEO_EXTRACT_API_KEY
   DRIVE9_E2E_VIDEO_EXTRACT_MODEL
   DRIVE9_E2E_VIDEO_FIXTURE_PATH
+  DRIVE9_E2E_VIDEO_EXPECTED_MARKER
 )
 missing_env=()
 for name in "${required_env[@]}"; do
@@ -26,7 +28,7 @@ if [ "${#missing_env[@]}" -gt 0 ]; then
   exit 0
 fi
 
-BASE="${DRIVE9_BASE:-http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com}"
+BASE="${DRIVE9_BASE}"
 BASE="${BASE%/}"
 VIDEO_FIXTURE="$DRIVE9_E2E_VIDEO_FIXTURE_PATH"
 POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-600}"
@@ -40,7 +42,7 @@ CURL_MAX_TIME_S="${CURL_MAX_TIME_S:-180}"
 ROOT_PATH="video-extract-e2e"
 VIDEO_PATH="$ROOT_PATH/fixture.mp4"
 DISABLED_VIDEO_PATH="$ROOT_PATH/disabled.mp4"
-MARKER="drive9_video_e2e"
+MARKER="$DRIVE9_E2E_VIDEO_EXPECTED_MARKER"
 
 TENANT_ID=""
 OWNER_API_KEY=""
@@ -51,6 +53,8 @@ die() {
   printf 'FAIL: %s\n' "$*" >&2
   exit 1
 }
+
+[[ "$BASE" == https://* ]] || die "DRIVE9_BASE must use https:// for hosted video extract smoke"
 
 for command in curl jq; do
   command -v "$command" >/dev/null || die "$command is required"
@@ -194,13 +198,13 @@ printf 'PASS: tenant became active\n'
 
 config_url="$BASE/v1/admin/tenants/$TENANT_ID/extract-config/video"
 config_response="$(
-  jq -nc --arg marker "$MARKER" '{
+  jq -nc '{
     enabled: true,
     api_base: env.DRIVE9_E2E_VIDEO_EXTRACT_API_BASE,
     api_key: env.DRIVE9_E2E_VIDEO_EXTRACT_API_KEY,
     model: env.DRIVE9_E2E_VIDEO_EXTRACT_MODEL,
     protocol: "openai",
-    prompt: ("Describe the actual visible content across the supplied video frames in one concise English sentence. Include the exact token " + $marker + " in the sentence. Do not invent details.")
+    prompt: "Describe the actual visible content across the supplied video frames in one concise English sentence. Do not invent details."
   }' |
     curl_response PUT "$config_url" control-plane -H 'Content-Type: application/json' --data-binary @-
 )" || die "video extract config PUT request failed"

--- a/e2e/video-extract-config-smoke-test.sh
+++ b/e2e/video-extract-config-smoke-test.sh
@@ -8,7 +8,6 @@
 set -euo pipefail
 
 required_env=(
-  DRIVE9_BASE
   DRIVE9_TIDBCLOUD_PUBLIC_KEY
   DRIVE9_TIDBCLOUD_PRIVATE_KEY
   DRIVE9_E2E_VIDEO_EXTRACT_API_BASE
@@ -27,7 +26,8 @@ if [ "${#missing_env[@]}" -gt 0 ]; then
   exit 0
 fi
 
-BASE="${DRIVE9_BASE%/}"
+BASE="${DRIVE9_BASE:-http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com}"
+BASE="${BASE%/}"
 VIDEO_FIXTURE="$DRIVE9_E2E_VIDEO_FIXTURE_PATH"
 POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-600}"
 POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"

--- a/e2e/video-extract-config-smoke-test.sh
+++ b/e2e/video-extract-config-smoke-test.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# Live tenant video-extract config and worker smoke test.
+#
+# Manual-only: provisions and deletes a real tenant, uploads a caller-provided
+# MP4, and calls a billable OpenAI-compatible vision provider. Missing
+# configuration skips the suite before any HTTP request is made.
+
+set -euo pipefail
+
+required_env=(
+  DRIVE9_BASE
+  DRIVE9_TIDBCLOUD_PUBLIC_KEY
+  DRIVE9_TIDBCLOUD_PRIVATE_KEY
+  DRIVE9_E2E_VIDEO_EXTRACT_API_BASE
+  DRIVE9_E2E_VIDEO_EXTRACT_API_KEY
+  DRIVE9_E2E_VIDEO_EXTRACT_MODEL
+  DRIVE9_E2E_VIDEO_FIXTURE_PATH
+)
+missing_env=()
+for name in "${required_env[@]}"; do
+  if [ -z "${!name:-}" ]; then
+    missing_env+=("$name")
+  fi
+done
+if [ "${#missing_env[@]}" -gt 0 ]; then
+  printf 'SKIP: video extract config smoke requires: %s\n' "${missing_env[*]}"
+  exit 0
+fi
+
+BASE="${DRIVE9_BASE%/}"
+VIDEO_FIXTURE="$DRIVE9_E2E_VIDEO_FIXTURE_PATH"
+POLL_TIMEOUT_S="${POLL_TIMEOUT_S:-600}"
+POLL_INTERVAL_S="${POLL_INTERVAL_S:-5}"
+VIDEO_EXTRACT_TIMEOUT_S="${VIDEO_EXTRACT_TIMEOUT_S:-600}"
+VIDEO_EXTRACT_INTERVAL_S="${VIDEO_EXTRACT_INTERVAL_S:-5}"
+DISABLED_EXTRACT_WAIT_S="${DISABLED_EXTRACT_WAIT_S:-30}"
+CURL_CONNECT_TIMEOUT_S="${CURL_CONNECT_TIMEOUT_S:-10}"
+CURL_MAX_TIME_S="${CURL_MAX_TIME_S:-180}"
+
+ROOT_PATH="video-extract-e2e"
+VIDEO_PATH="$ROOT_PATH/fixture.mp4"
+DISABLED_VIDEO_PATH="$ROOT_PATH/disabled.mp4"
+MARKER="drive9_video_e2e"
+
+TENANT_ID=""
+OWNER_API_KEY=""
+CONFIG_ENABLED=0
+TREE_CREATED=0
+
+die() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+for command in curl jq; do
+  command -v "$command" >/dev/null || die "$command is required"
+done
+[ -s "$VIDEO_FIXTURE" ] || die "video fixture not found or empty: $VIDEO_FIXTURE"
+
+curl_response() {
+  local method="$1"
+  local url="$2"
+  local auth="$3"
+  shift 3
+
+  local body_file
+  body_file="$(mktemp)"
+  local args=(
+    --connect-timeout "$CURL_CONNECT_TIMEOUT_S"
+    --max-time "$CURL_MAX_TIME_S"
+    -sS -o "$body_file" -w '%{http_code}' -X "$method"
+  )
+  case "$auth" in
+    control-plane)
+      args+=(
+        -H "X-TiDBCloud-Public-Key: $DRIVE9_TIDBCLOUD_PUBLIC_KEY"
+        -H "X-TiDBCloud-Private-Key: $DRIVE9_TIDBCLOUD_PRIVATE_KEY"
+      )
+      ;;
+    owner)
+      args+=(-H "Authorization: Bearer ${OWNER_API_KEY}")
+      ;;
+    *)
+      rm -f "$body_file"
+      die "unknown authentication mode: $auth"
+      ;;
+  esac
+
+  local code
+  if ! code="$(curl "${args[@]}" "$@" "$url")"; then
+    rm -f "$body_file"
+    return 1
+  fi
+  cat "$body_file"
+  printf '\n__HTTP__%s\n' "$code"
+  rm -f "$body_file"
+}
+
+http_code() {
+  printf '%s' "$1" | awk -F'__HTTP__' 'NF > 1 {print $2}' | tr -d '\n'
+}
+
+json_body() {
+  printf '%s' "$1" | sed '/__HTTP__/d'
+}
+
+http_failure() {
+  local action="$1"
+  local code="$2"
+  local body="$3"
+  local reason
+  reason="$(printf '%s' "$body" | jq -r '.error // empty' 2>/dev/null || true)"
+  if [ -n "$reason" ]; then
+    die "$action returned HTTP $code: $reason"
+  fi
+  die "$action returned HTTP $code"
+}
+
+cleanup() {
+  local status=$?
+  local cleanup_failed=0
+  trap - EXIT
+  set +e
+
+  if [ "$CONFIG_ENABLED" -eq 1 ] && [ -n "$TENANT_ID" ]; then
+    local disable_response disable_code
+    disable_response="$(
+      printf '%s' '{"enabled":false}' |
+        curl_response PUT "$BASE/v1/admin/tenants/$TENANT_ID/extract-config/video" control-plane \
+          -H 'Content-Type: application/json' --data-binary @-
+    )"
+    disable_code="$(http_code "$disable_response")"
+    if [ "$disable_code" != "200" ]; then
+      printf 'CLEANUP FAIL: disabling video extract config returned HTTP %s\n' "$disable_code" >&2
+      cleanup_failed=1
+    fi
+  fi
+
+  if [ "$TREE_CREATED" -eq 1 ] && [ -n "$OWNER_API_KEY" ]; then
+    local tree_response tree_code
+    tree_response="$(curl_response DELETE "$BASE/v1/fs/$ROOT_PATH?recursive" owner)"
+    tree_code="$(http_code "$tree_response")"
+    if [ "$tree_code" != "200" ]; then
+      printf 'CLEANUP FAIL: deleting test tree returned HTTP %s\n' "$tree_code" >&2
+      cleanup_failed=1
+    fi
+  fi
+
+  if [ -n "$TENANT_ID" ]; then
+    local tenant_response tenant_code
+    tenant_response="$(curl_response DELETE "$BASE/v1/admin/tenants/$TENANT_ID" control-plane)"
+    tenant_code="$(http_code "$tenant_response")"
+    if [ "$tenant_code" != "202" ] && [ "$tenant_code" != "200" ]; then
+      printf 'CLEANUP FAIL: deleting tenant %s returned HTTP %s\n' "$TENANT_ID" "$tenant_code" >&2
+      cleanup_failed=1
+    fi
+  fi
+
+  if [ "$status" -eq 0 ] && [ "$cleanup_failed" -ne 0 ]; then
+    status=1
+  fi
+  exit "$status"
+}
+trap cleanup EXIT
+
+printf '=== tenant video extract config smoke ===\n'
+printf 'Base URL: %s\n' "$BASE"
+printf 'Video fixture: %s\n' "$VIDEO_FIXTURE"
+
+provision_response="$(curl_response POST "$BASE/v1/provision" control-plane)" || die "tenant provision request failed"
+provision_code="$(http_code "$provision_response")"
+provision_body="$(json_body "$provision_response")"
+[ "$provision_code" = "202" ] || http_failure "tenant provision" "$provision_code" "$provision_body"
+TENANT_ID="$(printf '%s' "$provision_body" | jq -r '.tenant_id // empty')"
+OWNER_API_KEY="$(printf '%s' "$provision_body" | jq -r '.api_key // empty')"
+[ -n "$TENANT_ID" ] || die "tenant provision response omitted tenant_id"
+[ -n "$OWNER_API_KEY" ] || die "tenant provision response omitted api_key"
+printf 'PASS: provisioned disposable tenant %s\n' "$TENANT_ID"
+
+deadline=$(( $(date +%s) + POLL_TIMEOUT_S ))
+last_status=""
+while :; do
+  status_response="$(curl_response GET "$BASE/v1/status" owner)" || die "tenant status request failed"
+  status_code="$(http_code "$status_response")"
+  status_body="$(json_body "$status_response")"
+  if [ "$status_code" = "200" ]; then
+    last_status="$(printf '%s' "$status_body" | jq -r '.status // empty')"
+    [ "$last_status" = "active" ] && break
+  fi
+  [ "$(date +%s)" -lt "$deadline" ] || die "tenant did not become active within ${POLL_TIMEOUT_S}s (last status: ${last_status:-unknown})"
+  sleep "$POLL_INTERVAL_S"
+done
+printf 'PASS: tenant became active\n'
+
+config_url="$BASE/v1/admin/tenants/$TENANT_ID/extract-config/video"
+config_response="$(
+  jq -nc --arg marker "$MARKER" '{
+    enabled: true,
+    api_base: env.DRIVE9_E2E_VIDEO_EXTRACT_API_BASE,
+    api_key: env.DRIVE9_E2E_VIDEO_EXTRACT_API_KEY,
+    model: env.DRIVE9_E2E_VIDEO_EXTRACT_MODEL,
+    protocol: "openai",
+    prompt: ("Describe the actual visible content across the supplied video frames in one concise English sentence. Include the exact token " + $marker + " in the sentence. Do not invent details.")
+  }' |
+    curl_response PUT "$config_url" control-plane -H 'Content-Type: application/json' --data-binary @-
+)" || die "video extract config PUT request failed"
+config_code="$(http_code "$config_response")"
+config_body="$(json_body "$config_response")"
+[ "$config_code" = "200" ] || http_failure "video extract config PUT/provider validation" "$config_code" "$config_body"
+CONFIG_ENABLED=1
+if ! printf '%s' "$config_body" | jq -e '
+  .enabled == true and .source == "custom" and .protocol == "openai" and
+  .api_base == env.DRIVE9_E2E_VIDEO_EXTRACT_API_BASE and
+  .model == env.DRIVE9_E2E_VIDEO_EXTRACT_MODEL and
+  (.api_key | type == "string" and contains("*") and . != env.DRIVE9_E2E_VIDEO_EXTRACT_API_KEY)
+' >/dev/null; then
+  die "video extract config response did not return the expected masked custom config"
+fi
+printf 'PASS: provider validated and custom video config is masked\n'
+
+mkdir_response="$(curl_response POST "$BASE/v1/fs/$ROOT_PATH?mkdir" owner)" || die "test directory creation failed"
+mkdir_code="$(http_code "$mkdir_response")"
+mkdir_body="$(json_body "$mkdir_response")"
+[ "$mkdir_code" = "200" ] || http_failure "test directory creation" "$mkdir_code" "$mkdir_body"
+TREE_CREATED=1
+
+upload_response="$(curl_response PUT "$BASE/v1/fs/$VIDEO_PATH" owner -H 'Content-Type: video/mp4' --data-binary "@$VIDEO_FIXTURE")" || die "video upload request failed"
+upload_code="$(http_code "$upload_response")"
+upload_body="$(json_body "$upload_response")"
+[ "$upload_code" = "200" ] || http_failure "video upload" "$upload_code" "$upload_body"
+printf 'PASS: uploaded video fixture\n'
+
+extract_deadline=$(( $(date +%s) + VIDEO_EXTRACT_TIMEOUT_S ))
+semantic_text=""
+while :; do
+  stat_response="$(curl_response GET "$BASE/v1/fs/$VIDEO_PATH?stat" owner)" || die "video stat request failed"
+  stat_code="$(http_code "$stat_response")"
+  stat_body="$(json_body "$stat_response")"
+  if [ "$stat_code" = "200" ]; then
+    semantic_text="$(printf '%s' "$stat_body" | jq -r '.semantic_text // empty')"
+    if [[ "$semantic_text" == *"$MARKER"* ]] && [ "${#semantic_text}" -gt "${#MARKER}" ]; then
+      break
+    fi
+  fi
+  [ "$(date +%s)" -lt "$extract_deadline" ] || die "video semantic text did not appear within ${VIDEO_EXTRACT_TIMEOUT_S}s"
+  sleep "$VIDEO_EXTRACT_INTERVAL_S"
+done
+printf 'PASS: video worker wrote model-derived semantic text\n'
+printf '%s\n%s\n' '--- video semantic_text ---' "$semantic_text"
+
+disable_response="$(printf '%s' '{"enabled":false}' | curl_response PUT "$config_url" control-plane -H 'Content-Type: application/json' --data-binary @-)" || die "video extract config disable request failed"
+disable_code="$(http_code "$disable_response")"
+disable_body="$(json_body "$disable_response")"
+[ "$disable_code" = "200" ] || http_failure "video extract config disable" "$disable_code" "$disable_body"
+if ! printf '%s' "$disable_body" | jq -e '.enabled == false and .source == "custom"' >/dev/null; then
+  die "video extract config disable response was unexpected"
+fi
+CONFIG_ENABLED=0
+
+disabled_upload_response="$(curl_response PUT "$BASE/v1/fs/$DISABLED_VIDEO_PATH" owner -H 'Content-Type: video/mp4' --data-binary "@$VIDEO_FIXTURE")" || die "disabled video upload request failed"
+disabled_upload_code="$(http_code "$disabled_upload_response")"
+disabled_upload_body="$(json_body "$disabled_upload_response")"
+[ "$disabled_upload_code" = "200" ] || http_failure "disabled video upload" "$disabled_upload_code" "$disabled_upload_body"
+
+disabled_deadline=$(( $(date +%s) + DISABLED_EXTRACT_WAIT_S ))
+while :; do
+  disabled_stat_response="$(curl_response GET "$BASE/v1/fs/$DISABLED_VIDEO_PATH?stat" owner)" || die "disabled video stat request failed"
+  disabled_stat_code="$(http_code "$disabled_stat_response")"
+  disabled_stat_body="$(json_body "$disabled_stat_response")"
+  [ "$disabled_stat_code" = "200" ] || http_failure "disabled video stat" "$disabled_stat_code" "$disabled_stat_body"
+  [ -z "$(printf '%s' "$disabled_stat_body" | jq -r '.semantic_text // empty')" ] || die "disabled video unexpectedly received extracted text"
+  [ "$(date +%s)" -ge "$disabled_deadline" ] && break
+  sleep "$VIDEO_EXTRACT_INTERVAL_S"
+done
+printf 'PASS: disabled video config produced no extracted text for %ss\n' "$DISABLED_EXTRACT_WAIT_S"

--- a/e2e/video-extract-config-smoke-test.sh
+++ b/e2e/video-extract-config-smoke-test.sh
@@ -56,7 +56,7 @@ die() {
 
 [[ "$BASE" == https://* ]] || die "DRIVE9_BASE must use https:// for hosted video extract smoke"
 
-for command in curl jq; do
+for command in curl jq python3; do
   command -v "$command" >/dev/null || die "$command is required"
 done
 [ -s "$VIDEO_FIXTURE" ] || die "video fixture not found or empty: $VIDEO_FIXTURE"
@@ -118,6 +118,68 @@ http_failure() {
     die "$action returned HTTP $code: $reason"
   fi
   die "$action returned HTTP $code"
+}
+
+upload_video_fixture() {
+  local remote_path="$1"
+  local response code body upload_id plan_file complete_response complete_code complete_body
+
+  response="$(curl_response PUT "$BASE/v1/fs/$remote_path" owner \
+    -H 'Content-Type: video/mp4' \
+    -H "X-Dat9-Part-Checksums: $VIDEO_PART_CHECKSUMS" \
+    --data-binary "@$VIDEO_FIXTURE")" || die "video upload request failed"
+  code="$(http_code "$response")"
+  body="$(json_body "$response")"
+  if [ "$code" = "200" ]; then
+    return 0
+  fi
+  [ "$code" = "202" ] || http_failure "video upload" "$code" "$body"
+
+  upload_id="$(printf '%s' "$body" | jq -r '.upload_id // empty')"
+  [ -n "$upload_id" ] || die "video upload response omitted upload_id"
+  plan_file="$(mktemp)"
+  printf '%s' "$body" >"$plan_file"
+  if ! python3 - "$plan_file" "$VIDEO_FIXTURE" <<'PY'
+import json
+import sys
+import urllib.request
+
+plan_path, file_path = sys.argv[1], sys.argv[2]
+with open(plan_path, "r", encoding="utf-8") as f:
+    plan = json.load(f)
+
+parts = plan.get("parts", [])
+if not parts:
+    raise SystemExit("video upload plan has no parts")
+with open(file_path, "rb") as data_file:
+    for idx, part in enumerate(parts, 1):
+        size = int(part["size"])
+        data = data_file.read(size)
+        if len(data) != size:
+            raise SystemExit(f"short read for part {idx}: got {len(data)} expected {size}")
+        req = urllib.request.Request(part["url"], data=data, method="PUT")
+        req.add_header("Content-Length", str(size))
+        for key, value in (part.get("headers") or {}).items():
+            req.add_header(key, value)
+        if part.get("checksum_crc32c"):
+            req.add_header("x-amz-checksum-crc32c", part["checksum_crc32c"])
+        elif part.get("checksum_sha256"):
+            req.add_header("x-amz-checksum-sha256", part["checksum_sha256"])
+        with urllib.request.urlopen(req, timeout=300) as resp:
+            if getattr(resp, "status", 200) >= 300:
+                raise SystemExit(f"part {idx} failed: HTTP {resp.status}")
+PY
+  then
+    rm -f "$plan_file"
+    die "video multipart part upload failed"
+  fi
+  rm -f "$plan_file"
+
+  complete_response="$(curl_response POST "$BASE/v1/uploads/$upload_id/complete" owner)" || die "video upload complete request failed"
+  complete_code="$(http_code "$complete_response")"
+  complete_body="$(json_body "$complete_response")"
+  [ "$complete_code" = "200" ] || http_failure "video upload complete" "$complete_code" "$complete_body"
+  [ "$(printf '%s' "$complete_body" | jq -r '.status // empty')" = "ok" ] || die "video upload complete response was unexpected"
 }
 
 cleanup() {
@@ -228,10 +290,36 @@ mkdir_body="$(json_body "$mkdir_response")"
 [ "$mkdir_code" = "200" ] || http_failure "test directory creation" "$mkdir_code" "$mkdir_body"
 TREE_CREATED=1
 
-upload_response="$(curl_response PUT "$BASE/v1/fs/$VIDEO_PATH" owner -H 'Content-Type: video/mp4' --data-binary "@$VIDEO_FIXTURE")" || die "video upload request failed"
-upload_code="$(http_code "$upload_response")"
-upload_body="$(json_body "$upload_response")"
-[ "$upload_code" = "200" ] || http_failure "video upload" "$upload_code" "$upload_body"
+VIDEO_PART_CHECKSUMS="$(python3 - "$VIDEO_FIXTURE" <<'PY'
+import base64
+import struct
+import sys
+
+def _crc32c_table():
+    poly = 0x82F63B78
+    table = []
+    for i in range(256):
+        crc = i
+        for _ in range(8):
+            crc = (crc >> 1) ^ poly if crc & 1 else crc >> 1
+        table.append(crc)
+    return table
+
+table = _crc32c_table()
+part_size = 8 * 1024 * 1024
+checksums = []
+with open(sys.argv[1], "rb") as f:
+    while chunk := f.read(part_size):
+        crc = 0xFFFFFFFF
+        for byte in chunk:
+            crc = table[(crc ^ byte) & 0xFF] ^ (crc >> 8)
+        crc ^= 0xFFFFFFFF
+        checksums.append(base64.b64encode(struct.pack(">I", crc)).decode())
+print(",".join(checksums))
+PY
+)" || die "video checksum calculation failed"
+
+upload_video_fixture "$VIDEO_PATH"
 printf 'PASS: uploaded video fixture\n'
 
 extract_deadline=$(( $(date +%s) + VIDEO_EXTRACT_TIMEOUT_S ))
@@ -261,10 +349,7 @@ if ! printf '%s' "$disable_body" | jq -e '.enabled == false and .source == "cust
 fi
 CONFIG_ENABLED=0
 
-disabled_upload_response="$(curl_response PUT "$BASE/v1/fs/$DISABLED_VIDEO_PATH" owner -H 'Content-Type: video/mp4' --data-binary "@$VIDEO_FIXTURE")" || die "disabled video upload request failed"
-disabled_upload_code="$(http_code "$disabled_upload_response")"
-disabled_upload_body="$(json_body "$disabled_upload_response")"
-[ "$disabled_upload_code" = "200" ] || http_failure "disabled video upload" "$disabled_upload_code" "$disabled_upload_body"
+upload_video_fixture "$DISABLED_VIDEO_PATH"
 
 disabled_deadline=$(( $(date +%s) + DISABLED_EXTRACT_WAIT_S ))
 while :; do

--- a/e2e/video-extract-config-smoke-test.sh
+++ b/e2e/video-extract-config-smoke-test.sh
@@ -43,6 +43,7 @@ ROOT_PATH="video-extract-e2e"
 VIDEO_PATH="$ROOT_PATH/fixture.mp4"
 DISABLED_VIDEO_PATH="$ROOT_PATH/disabled.mp4"
 MARKER="$DRIVE9_E2E_VIDEO_EXPECTED_MARKER"
+VIDEO_PROMPT="Describe the actual visible content across the supplied video frames in one concise English sentence. Do not invent details."
 
 TENANT_ID=""
 OWNER_API_KEY=""
@@ -55,6 +56,7 @@ die() {
 }
 
 [[ "$BASE" == https://* ]] || die "DRIVE9_BASE must use https:// for hosted video extract smoke"
+[[ "${VIDEO_PROMPT,,}" != *"${MARKER,,}"* ]] || die "DRIVE9_E2E_VIDEO_EXPECTED_MARKER must not appear in the video prompt"
 
 for command in curl jq python3; do
   command -v "$command" >/dev/null || die "$command is required"
@@ -124,16 +126,14 @@ upload_video_fixture() {
   local remote_path="$1"
   local response code body upload_id plan_file complete_response complete_code complete_body
 
-  response="$(curl_response PUT "$BASE/v1/fs/$remote_path" owner \
-    -H 'Content-Type: video/mp4' \
-    -H "X-Dat9-Part-Checksums: $VIDEO_PART_CHECKSUMS" \
-    --data-binary "@$VIDEO_FIXTURE")" || die "video upload request failed"
+  response="$(
+    jq -nc --arg path "/$remote_path" --argjson total_size "$VIDEO_BYTES" --arg checksums "$VIDEO_PART_CHECKSUMS" \
+      '{path:$path,total_size:$total_size,part_checksums:($checksums|split(","))}' |
+      curl_response POST "$BASE/v1/uploads/initiate" owner -H 'Content-Type: application/json' --data-binary @-
+  )" || die "video multipart initiate request failed"
   code="$(http_code "$response")"
   body="$(json_body "$response")"
-  if [ "$code" = "200" ]; then
-    return 0
-  fi
-  [ "$code" = "202" ] || http_failure "video upload" "$code" "$body"
+  [ "$code" = "202" ] || http_failure "video multipart initiate" "$code" "$body"
 
   upload_id="$(printf '%s' "$body" | jq -r '.upload_id // empty')"
   [ -n "$upload_id" ] || die "video upload response omitted upload_id"
@@ -259,14 +259,25 @@ done
 printf 'PASS: tenant became active\n'
 
 config_url="$BASE/v1/admin/tenants/$TENANT_ID/extract-config/video"
+before_response="$(curl_response GET "$config_url" control-plane)" || die "initial video extract config request failed"
+before_code="$(http_code "$before_response")"
+before_body="$(json_body "$before_response")"
+[ "$before_code" = "200" ] || http_failure "initial video extract config GET" "$before_code" "$before_body"
+before_source="$(printf '%s' "$before_body" | jq -r '.source // empty')"
+case "$before_source" in
+  none) ;;
+  default) die "tenant has a process default video provider; hosted video-extract smoke requires source=none to prove tenant config usage" ;;
+  *) die "new tenant unexpectedly has video extract config source ${before_source:-unknown}" ;;
+esac
+
 config_response="$(
-  jq -nc '{
+  jq -nc --arg prompt "$VIDEO_PROMPT" '{
     enabled: true,
     api_base: env.DRIVE9_E2E_VIDEO_EXTRACT_API_BASE,
     api_key: env.DRIVE9_E2E_VIDEO_EXTRACT_API_KEY,
     model: env.DRIVE9_E2E_VIDEO_EXTRACT_MODEL,
     protocol: "openai",
-    prompt: "Describe the actual visible content across the supplied video frames in one concise English sentence. Do not invent details."
+    prompt: $prompt
   }' |
     curl_response PUT "$config_url" control-plane -H 'Content-Type: application/json' --data-binary @-
 )" || die "video extract config PUT request failed"
@@ -318,6 +329,7 @@ with open(sys.argv[1], "rb") as f:
 print(",".join(checksums))
 PY
 )" || die "video checksum calculation failed"
+VIDEO_BYTES="$(wc -c <"$VIDEO_FIXTURE" | tr -d '[:space:]')"
 
 upload_video_fixture "$VIDEO_PATH"
 printf 'PASS: uploaded video fixture\n'

--- a/e2e/video-extract-config-smoke-test.sh
+++ b/e2e/video-extract-config-smoke-test.sh
@@ -56,7 +56,9 @@ die() {
 }
 
 [[ "$BASE" == https://* ]] || die "DRIVE9_BASE must use https:// for hosted video extract smoke"
-[[ "${VIDEO_PROMPT,,}" != *"${MARKER,,}"* ]] || die "DRIVE9_E2E_VIDEO_EXPECTED_MARKER must not appear in the video prompt"
+shopt -s nocasematch
+[[ "$VIDEO_PROMPT" != *"$MARKER"* ]] || die "DRIVE9_E2E_VIDEO_EXPECTED_MARKER must not appear in the video prompt"
+shopt -u nocasematch
 
 for command in curl jq python3; do
   command -v "$command" >/dev/null || die "$command is required"

--- a/examples/go-sdk-cookbook/cookbook_test.go
+++ b/examples/go-sdk-cookbook/cookbook_test.go
@@ -393,6 +393,16 @@ func ExampleClient_quota() {
 			Enabled: &enabled, Prompt: &prompt,
 		})
 	}
+	_, _ = credentialClient.AdminGetTenantEmbeddingConfig(ctx, drive9.AdminTenantEmbeddingConfigGetRequest{
+		TenantID: tenantID, PublicKey: tidbCloudPublicKey, PrivateKey: tidbCloudPrivateKey,
+	})
+	embedAPIBase := "https://embedding.example.com/v1"
+	embedAPIKey := "embedding-provider-key"
+	embedModel := "embedding-model"
+	_, _ = credentialClient.AdminSetTenantEmbeddingConfig(ctx, drive9.AdminTenantEmbeddingConfigSetRequest{
+		TenantID: tenantID, PublicKey: tidbCloudPublicKey, PrivateKey: tidbCloudPrivateKey,
+		Enabled: true, APIBase: &embedAPIBase, APIKey: &embedAPIKey, Model: &embedModel,
+	})
 	_, _ = credentialClient.AdminSetTenantQuota(ctx, drive9.QuotaSetRequest{
 		TenantID:               tenantID,
 		PublicKey:              tidbCloudPublicKey,
@@ -637,11 +647,13 @@ var coveredClientMethods = map[string]bool{
 	"AdminDeleteTenant":                    true,
 	"AdminDeleteTenantPool":                true,
 	"AdminGetTenant":                       true,
+	"AdminGetTenantEmbeddingConfig":        true,
 	"AdminGetTenantPool":                   true,
 	"AdminListTenants":                     true,
 	"AdminSetTenantQuota":                  true,
 	"AdminGetTenantExtractConfig":          true,
 	"AdminSetTenantExtractConfig":          true,
+	"AdminSetTenantEmbeddingConfig":        true,
 	"AdminClearObjectNamespace":            true,
 	"AdminCreateObjectBackend":             true,
 	"AdminDeleteObjectBackend":             true,

--- a/pkg/client/admin_embedding_config.go
+++ b/pkg/client/admin_embedding_config.go
@@ -42,13 +42,6 @@ type AdminTenantEmbeddingConfigSetRequest struct {
 	Model      *string `json:"model,omitempty"`
 }
 
-type adminTenantEmbeddingConfigSetBody struct {
-	Enabled bool    `json:"enabled"`
-	APIBase *string `json:"api_base,omitempty"`
-	APIKey  *string `json:"api_key,omitempty"`
-	Model   *string `json:"model,omitempty"`
-}
-
 // AdminGetTenantEmbeddingConfig returns the effective embedding configuration
 // for one tenant.
 func (c *Client) AdminGetTenantEmbeddingConfig(ctx context.Context, query AdminTenantEmbeddingConfigGetRequest) (*AdminTenantEmbeddingConfig, error) {
@@ -70,12 +63,7 @@ func (c *Client) AdminSetTenantEmbeddingConfig(ctx context.Context, update Admin
 	if err != nil {
 		return nil, err
 	}
-	raw, err := json.Marshal(adminTenantEmbeddingConfigSetBody{
-		Enabled: update.Enabled,
-		APIBase: update.APIBase,
-		APIKey:  update.APIKey,
-		Model:   update.Model,
-	})
+	raw, err := json.Marshal(update)
 	if err != nil {
 		return nil, fmt.Errorf("marshal admin tenant embedding config set request: %w", err)
 	}
@@ -97,6 +85,7 @@ func adminTenantEmbeddingConfigPath(tenantID string) (string, error) {
 }
 
 func (c *Client) doAdminTenantEmbeddingConfig(req *http.Request, operation string) (*AdminTenantEmbeddingConfig, error) {
+	// Admin control-plane requests use TiDB Cloud headers; c.do would also attach the tenant Bearer credential.
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("admin tenant embedding config %s request: %w", operation, err)

--- a/pkg/client/admin_embedding_config.go
+++ b/pkg/client/admin_embedding_config.go
@@ -97,7 +97,7 @@ func adminTenantEmbeddingConfigPath(tenantID string) (string, error) {
 }
 
 func (c *Client) doAdminTenantEmbeddingConfig(req *http.Request, operation string) (*AdminTenantEmbeddingConfig, error) {
-	resp, err := c.do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("admin tenant embedding config %s request: %w", operation, err)
 	}

--- a/pkg/client/admin_embedding_config.go
+++ b/pkg/client/admin_embedding_config.go
@@ -1,0 +1,113 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// AdminTenantEmbeddingConfig is the effective embedding configuration returned
+// by the admin API. APIKey is masked by the server.
+type AdminTenantEmbeddingConfig struct {
+	Enabled    bool       `json:"enabled"`
+	APIBase    *string    `json:"api_base,omitempty"`
+	APIKey     *string    `json:"api_key,omitempty"`
+	Model      *string    `json:"model,omitempty"`
+	Source     string     `json:"source"`
+	Generation uint64     `json:"generation,omitempty"`
+	UpdatedAt  *time.Time `json:"updated_at,omitempty"`
+}
+
+// AdminTenantEmbeddingConfigGetRequest identifies a tenant for embedding-config lookup.
+type AdminTenantEmbeddingConfigGetRequest struct {
+	TenantID   string
+	PublicKey  string
+	PrivateKey string
+}
+
+// AdminTenantEmbeddingConfigSetRequest replaces a tenant embedding config.
+// Provider fields must be present when enabling and omitted when disabling.
+type AdminTenantEmbeddingConfigSetRequest struct {
+	TenantID   string  `json:"-"`
+	PublicKey  string  `json:"-"`
+	PrivateKey string  `json:"-"`
+	Enabled    bool    `json:"enabled"`
+	APIBase    *string `json:"api_base,omitempty"`
+	APIKey     *string `json:"api_key,omitempty"`
+	Model      *string `json:"model,omitempty"`
+}
+
+type adminTenantEmbeddingConfigSetBody struct {
+	Enabled bool    `json:"enabled"`
+	APIBase *string `json:"api_base,omitempty"`
+	APIKey  *string `json:"api_key,omitempty"`
+	Model   *string `json:"model,omitempty"`
+}
+
+// AdminGetTenantEmbeddingConfig returns the effective embedding configuration
+// for one tenant.
+func (c *Client) AdminGetTenantEmbeddingConfig(ctx context.Context, query AdminTenantEmbeddingConfigGetRequest) (*AdminTenantEmbeddingConfig, error) {
+	path, err := adminTenantEmbeddingConfigPath(query.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create admin tenant embedding config get request: %w", err)
+	}
+	setQuotaHeaders(req, query.PublicKey, query.PrivateKey)
+	return c.doAdminTenantEmbeddingConfig(req, "get")
+}
+
+// AdminSetTenantEmbeddingConfig replaces the embedding configuration for one tenant.
+func (c *Client) AdminSetTenantEmbeddingConfig(ctx context.Context, update AdminTenantEmbeddingConfigSetRequest) (*AdminTenantEmbeddingConfig, error) {
+	path, err := adminTenantEmbeddingConfigPath(update.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	raw, err := json.Marshal(adminTenantEmbeddingConfigSetBody{
+		Enabled: update.Enabled,
+		APIBase: update.APIBase,
+		APIKey:  update.APIKey,
+		Model:   update.Model,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal admin tenant embedding config set request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, c.baseURL+path, bytes.NewReader(raw))
+	if err != nil {
+		return nil, fmt.Errorf("create admin tenant embedding config set request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	setQuotaHeaders(req, update.PublicKey, update.PrivateKey)
+	return c.doAdminTenantEmbeddingConfig(req, "set")
+}
+
+func adminTenantEmbeddingConfigPath(tenantID string) (string, error) {
+	tenantID = strings.TrimSpace(tenantID)
+	if tenantID == "" {
+		return "", fmt.Errorf("tenant ID is required")
+	}
+	return "/v1/admin/tenants/" + url.PathEscape(tenantID) + "/embedding-config", nil
+}
+
+func (c *Client) doAdminTenantEmbeddingConfig(req *http.Request, operation string) (*AdminTenantEmbeddingConfig, error) {
+	resp, err := c.do(req)
+	if err != nil {
+		return nil, fmt.Errorf("admin tenant embedding config %s request: %w", operation, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return nil, readError(resp)
+	}
+	var out AdminTenantEmbeddingConfig
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode admin tenant embedding config %s response: %w", operation, err)
+	}
+	return &out, nil
+}

--- a/pkg/client/admin_embedding_config_test.go
+++ b/pkg/client/admin_embedding_config_test.go
@@ -21,6 +21,9 @@ func TestAdminGetTenantEmbeddingConfigSendsHeadersAndDecodesResponse(t *testing.
 		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
 			t.Errorf("missing TiDB Cloud credential headers")
 		}
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("Authorization = %q, want empty", got)
+		}
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"enabled":    true,
 			"api_base":   "https://provider.example.com/v1",
@@ -33,7 +36,7 @@ func TestAdminGetTenantEmbeddingConfigSendsHeadersAndDecodesResponse(t *testing.
 	}))
 	defer srv.Close()
 
-	out, err := New(srv.URL, "").AdminGetTenantEmbeddingConfig(context.Background(), AdminTenantEmbeddingConfigGetRequest{
+	out, err := New(srv.URL, "tenant-api-key").AdminGetTenantEmbeddingConfig(context.Background(), AdminTenantEmbeddingConfigGetRequest{
 		TenantID: " tenant/1 ", PublicKey: "public-1", PrivateKey: "private-1",
 	})
 	if err != nil {
@@ -62,6 +65,9 @@ func TestAdminSetTenantEmbeddingConfigSendsFullReplacement(t *testing.T) {
 		if r.Method != http.MethodPut || r.URL.Path != "/v1/admin/tenants/tenant-1/embedding-config" {
 			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
 		}
+		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
+			t.Errorf("missing TiDB Cloud credential headers")
+		}
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Errorf("decode body: %v", err)
 		}
@@ -89,6 +95,12 @@ func TestAdminSetTenantEmbeddingConfigDisableOmitsProviderFields(t *testing.T) {
 
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/admin/tenants/tenant-1/embedding-config" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
+			t.Errorf("missing TiDB Cloud credential headers")
+		}
 		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
 			t.Errorf("decode body: %v", err)
 		}
@@ -97,7 +109,7 @@ func TestAdminSetTenantEmbeddingConfigDisableOmitsProviderFields(t *testing.T) {
 	defer srv.Close()
 
 	_, err := New(srv.URL, "").AdminSetTenantEmbeddingConfig(context.Background(), AdminTenantEmbeddingConfigSetRequest{
-		TenantID: "tenant-1", Enabled: false,
+		TenantID: "tenant-1", PublicKey: "public-1", PrivateKey: "private-1", Enabled: false,
 	})
 	if err != nil {
 		t.Fatalf("AdminSetTenantEmbeddingConfig: %v", err)

--- a/pkg/client/admin_embedding_config_test.go
+++ b/pkg/client/admin_embedding_config_test.go
@@ -1,0 +1,120 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestAdminGetTenantEmbeddingConfigSendsHeadersAndDecodesResponse(t *testing.T) {
+	t.Parallel()
+
+	var gotEscapedPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("method = %s, want GET", r.Method)
+		}
+		gotEscapedPath = r.URL.EscapedPath()
+		if r.Header.Get("X-TiDBCloud-Public-Key") != "public-1" || r.Header.Get("X-TiDBCloud-Private-Key") != "private-1" {
+			t.Errorf("missing TiDB Cloud credential headers")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"enabled":    true,
+			"api_base":   "https://provider.example.com/v1",
+			"api_key":    "sk-a********",
+			"model":      "embedding-model",
+			"source":     "custom",
+			"generation": 3,
+			"updated_at": "2026-08-28T01:02:03Z",
+		})
+	}))
+	defer srv.Close()
+
+	out, err := New(srv.URL, "").AdminGetTenantEmbeddingConfig(context.Background(), AdminTenantEmbeddingConfigGetRequest{
+		TenantID: " tenant/1 ", PublicKey: "public-1", PrivateKey: "private-1",
+	})
+	if err != nil {
+		t.Fatalf("AdminGetTenantEmbeddingConfig: %v", err)
+	}
+	if gotEscapedPath != "/v1/admin/tenants/tenant%2F1/embedding-config" {
+		t.Fatalf("escaped path = %q", gotEscapedPath)
+	}
+	updatedAt, err := time.Parse(time.RFC3339, "2026-08-28T01:02:03Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !out.Enabled || out.APIBase == nil || *out.APIBase != "https://provider.example.com/v1" || out.APIKey == nil || *out.APIKey != "sk-a********" || out.Model == nil || *out.Model != "embedding-model" || out.Source != "custom" || out.Generation != 3 || out.UpdatedAt == nil || !out.UpdatedAt.Equal(updatedAt) {
+		t.Fatalf("response = %#v", out)
+	}
+}
+
+func TestAdminSetTenantEmbeddingConfigSendsFullReplacement(t *testing.T) {
+	t.Parallel()
+
+	apiBase := "https://provider.example.com/v1"
+	apiKey := "provider-secret"
+	model := "embedding-model"
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/admin/tenants/tenant-1/embedding-config" {
+			t.Errorf("unexpected request %s %s", r.Method, r.URL.Path)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"enabled": true, "source": "custom", "generation": 2})
+	}))
+	defer srv.Close()
+
+	out, err := New(srv.URL, "").AdminSetTenantEmbeddingConfig(context.Background(), AdminTenantEmbeddingConfigSetRequest{
+		TenantID: "tenant-1", PublicKey: "public-1", PrivateKey: "private-1", Enabled: true,
+		APIBase: &apiBase, APIKey: &apiKey, Model: &model,
+	})
+	if err != nil {
+		t.Fatalf("AdminSetTenantEmbeddingConfig: %v", err)
+	}
+	if len(gotBody) != 4 || gotBody["enabled"] != true || gotBody["api_base"] != apiBase || gotBody["api_key"] != apiKey || gotBody["model"] != model {
+		t.Fatalf("request body = %#v", gotBody)
+	}
+	if !out.Enabled || out.Source != "custom" || out.Generation != 2 {
+		t.Fatalf("response = %#v", out)
+	}
+}
+
+func TestAdminSetTenantEmbeddingConfigDisableOmitsProviderFields(t *testing.T) {
+	t.Parallel()
+
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{"enabled": false, "source": "custom"})
+	}))
+	defer srv.Close()
+
+	_, err := New(srv.URL, "").AdminSetTenantEmbeddingConfig(context.Background(), AdminTenantEmbeddingConfigSetRequest{
+		TenantID: "tenant-1", Enabled: false,
+	})
+	if err != nil {
+		t.Fatalf("AdminSetTenantEmbeddingConfig: %v", err)
+	}
+	if len(gotBody) != 1 || gotBody["enabled"] != false {
+		t.Fatalf("request body = %#v, want enabled=false only", gotBody)
+	}
+}
+
+func TestAdminTenantEmbeddingConfigRejectsEmptyTenantID(t *testing.T) {
+	t.Parallel()
+
+	c := New("https://drive9.example.com", "")
+	if _, err := c.AdminGetTenantEmbeddingConfig(context.Background(), AdminTenantEmbeddingConfigGetRequest{}); err == nil {
+		t.Fatal("get empty tenant ID error = nil")
+	}
+	if _, err := c.AdminSetTenantEmbeddingConfig(context.Background(), AdminTenantEmbeddingConfigSetRequest{}); err == nil {
+		t.Fatal("set empty tenant ID error = nil")
+	}
+}

--- a/pkg/client/admin_extract_config.go
+++ b/pkg/client/admin_extract_config.go
@@ -28,6 +28,7 @@ type AdminTenantExtractConfig struct {
 	APIBase   *string    `json:"api_base,omitempty"`
 	APIKey    *string    `json:"api_key,omitempty"`
 	Model     *string    `json:"model,omitempty"`
+	Protocol  *string    `json:"protocol,omitempty"`
 	Prompt    *string    `json:"prompt,omitempty"`
 	Source    string     `json:"source"`
 	UpdatedAt *time.Time `json:"updated_at,omitempty"`
@@ -53,15 +54,17 @@ type AdminTenantExtractConfigSetRequest struct {
 	APIBase    *string          `json:"api_base,omitempty"`
 	APIKey     *string          `json:"api_key,omitempty"`
 	Model      *string          `json:"model,omitempty"`
+	Protocol   *string          `json:"protocol,omitempty"`
 	Prompt     *string          `json:"prompt,omitempty"`
 }
 
 type adminTenantExtractConfigSetBody struct {
-	Enabled *bool   `json:"enabled,omitempty"`
-	APIBase *string `json:"api_base,omitempty"`
-	APIKey  *string `json:"api_key,omitempty"`
-	Model   *string `json:"model,omitempty"`
-	Prompt  *string `json:"prompt,omitempty"`
+	Enabled  *bool   `json:"enabled,omitempty"`
+	APIBase  *string `json:"api_base,omitempty"`
+	APIKey   *string `json:"api_key,omitempty"`
+	Model    *string `json:"model,omitempty"`
+	Protocol *string `json:"protocol,omitempty"`
+	Prompt   *string `json:"prompt,omitempty"`
 }
 
 // AdminGetTenantExtractConfig returns the effective extract configuration for
@@ -87,11 +90,12 @@ func (c *Client) AdminSetTenantExtractConfig(ctx context.Context, update AdminTe
 		return nil, err
 	}
 	raw, err := json.Marshal(adminTenantExtractConfigSetBody{
-		Enabled: update.Enabled,
-		APIBase: update.APIBase,
-		APIKey:  update.APIKey,
-		Model:   update.Model,
-		Prompt:  update.Prompt,
+		Enabled:  update.Enabled,
+		APIBase:  update.APIBase,
+		APIKey:   update.APIKey,
+		Model:    update.Model,
+		Protocol: update.Protocol,
+		Prompt:   update.Prompt,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshal admin tenant extract config set request: %w", err)

--- a/pkg/client/admin_extract_config_test.go
+++ b/pkg/client/admin_extract_config_test.go
@@ -28,6 +28,7 @@ func TestAdminGetTenantExtractConfigSendsHeadersAndDecodesResponse(t *testing.T)
 			"api_base":   "https://provider.example.com",
 			"api_key":    "sk-a********",
 			"model":      "vision-model",
+			"protocol":   "openai",
 			"prompt":     "custom prompt",
 			"source":     "custom",
 			"updated_at": "2026-08-21T01:02:03Z",
@@ -54,7 +55,7 @@ func TestAdminGetTenantExtractConfigSendsHeadersAndDecodesResponse(t *testing.T)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if out.APIBase == nil || *out.APIBase != "https://provider.example.com" || out.APIKey == nil || *out.APIKey != "sk-a********" || out.Model == nil || *out.Model != "vision-model" || out.Prompt == nil || *out.Prompt != "custom prompt" || out.UpdatedAt == nil || !out.UpdatedAt.Equal(updatedAt) || !out.Enabled || out.Source != "custom" {
+	if out.APIBase == nil || *out.APIBase != "https://provider.example.com" || out.APIKey == nil || *out.APIKey != "sk-a********" || out.Model == nil || *out.Model != "vision-model" || out.Protocol == nil || *out.Protocol != "openai" || out.Prompt == nil || *out.Prompt != "custom prompt" || out.UpdatedAt == nil || !out.UpdatedAt.Equal(updatedAt) || !out.Enabled || out.Source != "custom" {
 		t.Fatalf("response = %#v", out)
 	}
 }
@@ -64,6 +65,7 @@ func TestAdminSetTenantExtractConfigPreservesPartialFieldPresence(t *testing.T) 
 
 	enabled := false
 	prompt := ""
+	protocol := "qwen-asr"
 	var gotBody map[string]any
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPut {
@@ -91,13 +93,14 @@ func TestAdminSetTenantExtractConfigPreservesPartialFieldPresence(t *testing.T) 
 		PublicKey:  "public-1",
 		PrivateKey: "private-1",
 		Enabled:    &enabled,
+		Protocol:   &protocol,
 		Prompt:     &prompt,
 	})
 	if err != nil {
 		t.Fatalf("AdminSetTenantExtractConfig: %v", err)
 	}
-	if len(gotBody) != 2 || gotBody["enabled"] != false || gotBody["prompt"] != "" {
-		t.Fatalf("request body = %#v, want explicit false and empty prompt only", gotBody)
+	if len(gotBody) != 3 || gotBody["enabled"] != false || gotBody["protocol"] != "qwen-asr" || gotBody["prompt"] != "" {
+		t.Fatalf("request body = %#v, want explicit false, protocol, and empty prompt only", gotBody)
 	}
 	for _, omitted := range []string{"api_base", "api_key", "model", "tenant_id", "media_type", "public_key", "private_key"} {
 		if _, ok := gotBody[omitted]; ok {
@@ -138,7 +141,7 @@ func TestAdminTenantExtractConfigPreservesOptionalResponsePresence(t *testing.T)
 	if out.APIBase == nil || *out.APIBase != "" || out.Prompt == nil || *out.Prompt != "" {
 		t.Fatalf("explicit empty values lost: %#v", out)
 	}
-	if out.APIKey != nil || out.Model != nil || out.UpdatedAt != nil {
+	if out.APIKey != nil || out.Model != nil || out.Protocol != nil || out.UpdatedAt != nil {
 		t.Fatalf("absent values decoded as present: %#v", out)
 	}
 }

--- a/scripts/test-hosted-config-smoke-guards.sh
+++ b/scripts/test-hosted-config-smoke-guards.sh
@@ -14,6 +14,14 @@ printf '%s\n' \
   'exit 99' >"$FAKE_BIN/curl"
 chmod +x "$FAKE_BIN/curl"
 
+fail_with_output() {
+  local output_file="$1"
+  shift
+  [ ! -f "$output_file" ] || cat "$output_file" >&2
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
 common_env=(
   "PATH=$FAKE_BIN:$PATH"
   "CURL_CALLED_FILE=$CURL_CALLED_FILE"
@@ -46,46 +54,40 @@ for script in "${scripts[@]}"; do
     rm -f "$CURL_CALLED_FILE"
     output_file="$FAKE_BIN/output"
     if env "${common_env[@]}" DRIVE9_BASE="$base" bash "$REPO_ROOT/$script" >"$output_file" 2>&1; then
-      printf 'FAIL: %s accepted insecure DRIVE9_BASE=%s\n' "$script" "$base" >&2
-      exit 1
+      fail_with_output "$output_file" "$script accepted insecure DRIVE9_BASE=$base"
     fi
     grep -q 'DRIVE9_BASE must use https://' "$output_file" || {
-      printf 'FAIL: %s did not report the HTTPS requirement\n' "$script" >&2
-      exit 1
+      fail_with_output "$output_file" "$script did not report the HTTPS requirement"
     }
     [ ! -e "$CURL_CALLED_FILE" ] || {
-      printf 'FAIL: %s called curl for insecure DRIVE9_BASE=%s\n' "$script" "$base" >&2
-      exit 1
+      fail_with_output "$output_file" "$script called curl for insecure DRIVE9_BASE=$base"
     }
   done
 
   rm -f "$CURL_CALLED_FILE"
   output_file="$FAKE_BIN/output"
-  env -u DRIVE9_BASE "${common_env[@]}" bash "$REPO_ROOT/$script" >"$output_file" 2>&1
+  if ! env -u DRIVE9_BASE "${common_env[@]}" bash "$REPO_ROOT/$script" >"$output_file" 2>&1; then
+    fail_with_output "$output_file" "$script did not skip successfully when DRIVE9_BASE was absent"
+  fi
   grep -q '^SKIP:' "$output_file" || {
-    printf 'FAIL: %s did not skip when DRIVE9_BASE was absent\n' "$script" >&2
-    exit 1
+    fail_with_output "$output_file" "$script did not report SKIP when DRIVE9_BASE was absent"
   }
   [ ! -e "$CURL_CALLED_FILE" ] || {
-    printf 'FAIL: %s called curl when DRIVE9_BASE was absent\n' "$script" >&2
-    exit 1
+    fail_with_output "$output_file" "$script called curl when DRIVE9_BASE was absent"
   }
 done
 
 rm -f "$CURL_CALLED_FILE"
 output_file="$FAKE_BIN/output"
-if env "${common_env[@]}" DRIVE9_BASE=https://drive9.invalid DRIVE9_E2E_VIDEO_EXPECTED_MARKER=video \
+if env "${common_env[@]}" DRIVE9_BASE=https://drive9.invalid DRIVE9_E2E_VIDEO_EXPECTED_MARKER=ViDeO \
   bash "$REPO_ROOT/e2e/video-extract-config-smoke-test.sh" >"$output_file" 2>&1; then
-  printf 'FAIL: video smoke accepted a marker present in its prompt\n' >&2
-  exit 1
+  fail_with_output "$output_file" "video smoke accepted a marker present in its prompt"
 fi
 grep -q 'must not appear in the video prompt' "$output_file" || {
-  printf 'FAIL: video smoke did not report the marker/prompt conflict\n' >&2
-  exit 1
+  fail_with_output "$output_file" "video smoke did not report the marker/prompt conflict"
 }
 [ ! -e "$CURL_CALLED_FILE" ] || {
-  printf 'FAIL: video smoke called curl for a marker/prompt conflict\n' >&2
-  exit 1
+  fail_with_output "$output_file" "video smoke called curl for a marker/prompt conflict"
 }
 
 printf 'PASS: hosted config smoke guards fail closed without network access\n'

--- a/scripts/test-hosted-config-smoke-guards.sh
+++ b/scripts/test-hosted-config-smoke-guards.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# Regression checks for credential-bearing hosted smoke preconditions.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+FAKE_BIN="$(mktemp -d)"
+CURL_CALLED_FILE="$FAKE_BIN/curl-called"
+trap 'rm -rf "$FAKE_BIN"' EXIT
+
+printf '%s\n' \
+  '#!/usr/bin/env bash' \
+  ': >"${CURL_CALLED_FILE:?}"' \
+  'exit 99' >"$FAKE_BIN/curl"
+chmod +x "$FAKE_BIN/curl"
+
+common_env=(
+  "PATH=$FAKE_BIN:$PATH"
+  "CURL_CALLED_FILE=$CURL_CALLED_FILE"
+  DRIVE9_TIDBCLOUD_PUBLIC_KEY=dummy-public
+  DRIVE9_TIDBCLOUD_PRIVATE_KEY=dummy-private
+  DRIVE9_E2E_IMAGE_EXTRACT_API_BASE=https://provider.invalid/v1
+  DRIVE9_E2E_IMAGE_EXTRACT_API_KEY=dummy-image-key
+  DRIVE9_E2E_IMAGE_EXTRACT_MODEL=dummy-image-model
+  DRIVE9_E2E_VIDEO_EXTRACT_API_BASE=https://provider.invalid/v1
+  DRIVE9_E2E_VIDEO_EXTRACT_API_KEY=dummy-video-key
+  DRIVE9_E2E_VIDEO_EXTRACT_MODEL=dummy-video-model
+  DRIVE9_E2E_VIDEO_FIXTURE_PATH=/fixture-not-read-before-base-validation.mp4
+  DRIVE9_E2E_VIDEO_EXPECTED_MARKER=fixture-specific-marker
+  DRIVE9_E2E_EMBED_API_BASE=https://provider.invalid/v1
+  DRIVE9_E2E_EMBED_API_KEY=dummy-embed-key
+  DRIVE9_E2E_EMBED_MODEL=dummy-embed-model
+)
+scripts=(
+  e2e/image-extract-config-smoke-test.sh
+  e2e/video-extract-config-smoke-test.sh
+  e2e/embedding-config-smoke-test.sh
+)
+http_bases=(
+  http://127.0.0.1:9
+  http://k8s-dat9-dat9serv-d5e02e7d07-1645488597.ap-southeast-1.elb.amazonaws.com
+)
+
+for script in "${scripts[@]}"; do
+  for base in "${http_bases[@]}"; do
+    rm -f "$CURL_CALLED_FILE"
+    output_file="$FAKE_BIN/output"
+    if env "${common_env[@]}" DRIVE9_BASE="$base" bash "$REPO_ROOT/$script" >"$output_file" 2>&1; then
+      printf 'FAIL: %s accepted insecure DRIVE9_BASE=%s\n' "$script" "$base" >&2
+      exit 1
+    fi
+    grep -q 'DRIVE9_BASE must use https://' "$output_file" || {
+      printf 'FAIL: %s did not report the HTTPS requirement\n' "$script" >&2
+      exit 1
+    }
+    [ ! -e "$CURL_CALLED_FILE" ] || {
+      printf 'FAIL: %s called curl for insecure DRIVE9_BASE=%s\n' "$script" "$base" >&2
+      exit 1
+    }
+  done
+
+  rm -f "$CURL_CALLED_FILE"
+  output_file="$FAKE_BIN/output"
+  env -u DRIVE9_BASE "${common_env[@]}" bash "$REPO_ROOT/$script" >"$output_file" 2>&1
+  grep -q '^SKIP:' "$output_file" || {
+    printf 'FAIL: %s did not skip when DRIVE9_BASE was absent\n' "$script" >&2
+    exit 1
+  }
+  [ ! -e "$CURL_CALLED_FILE" ] || {
+    printf 'FAIL: %s called curl when DRIVE9_BASE was absent\n' "$script" >&2
+    exit 1
+  }
+done
+
+rm -f "$CURL_CALLED_FILE"
+output_file="$FAKE_BIN/output"
+if env "${common_env[@]}" DRIVE9_BASE=https://drive9.invalid DRIVE9_E2E_VIDEO_EXPECTED_MARKER=video \
+  bash "$REPO_ROOT/e2e/video-extract-config-smoke-test.sh" >"$output_file" 2>&1; then
+  printf 'FAIL: video smoke accepted a marker present in its prompt\n' >&2
+  exit 1
+fi
+grep -q 'must not appear in the video prompt' "$output_file" || {
+  printf 'FAIL: video smoke did not report the marker/prompt conflict\n' >&2
+  exit 1
+}
+[ ! -e "$CURL_CALLED_FILE" ] || {
+  printf 'FAIL: video smoke called curl for a marker/prompt conflict\n' >&2
+  exit 1
+}
+
+printf 'PASS: hosted config smoke guards fail closed without network access\n'


### PR DESCRIPTION
## Summary

- add typed Go SDK GET/PUT support for tenant `embedding-config`
- add `drive9 admin tenant embedding-config get|set` with full-replacement validation and API-key redaction
- expose extract provider `protocol` through the existing Go SDK and CLI
- add manual-only hosted video extraction and embedding processing E2E scripts
- document required provider variables, the MP4 fixture, and the fixed 1024-dimension embedding contract

## Verification

- `go test ./pkg/client -run 'TestAdmin.*Tenant(Extract|Embedding)Config' -count=1`\n- `go test ./cmd/drive9/cli -run 'TestAdminTenant(Extract|Embedding)Config' -count=1`\n- `bash -n e2e/video-extract-config-smoke-test.sh e2e/embedding-config-smoke-test.sh`\n- verified both hosted scripts skip before network access when required environment variables are absent\n- `gofmt -l` on changed Go files and `git diff --check`\n\nThe billable hosted provider paths were not executed locally; they remain manual-only and require control-plane credentials, provider credentials, and an MP4 fixture for the video suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added administrative commands and SDK support to view and update tenant embedding configurations.
  * Added protocol selection for tenant video extract configurations.
  * Sensitive provider API keys are masked in displayed results.
  * Configuration changes validate required and incompatible options.

* **Documentation**
  * Updated command help and end-to-end testing guidance for embedding and video extraction.

* **Tests**
  * Expanded coverage for configuration operations, validation, secure HTTPS endpoints, masking, and smoke-test workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->