### PR TITLE
fix(fuse): handle gVisor writeback ordering and interrupts

### DIFF
--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -477,6 +477,14 @@ func (cq *CommitQueue) PendingStats() (count int, bytes int64) {
 		count++
 		bytes += e.Size
 	}
+	for e := range cq.immediate {
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		count++
+		bytes += e.Size
+	}
 	return
 }
 
@@ -530,12 +538,26 @@ func (cq *CommitQueue) snapshotLocked() CommitQueueSnapshot {
 		snap.Pending++
 		snap.Bytes += e.Size
 	}
+	for e := range cq.immediate {
+		if e == nil {
+			continue
+		}
+		if snap.FirstPath == "" {
+			snap.FirstPath = e.Path
+		}
+		if _, ok := seen[e]; ok {
+			continue
+		}
+		seen[e] = struct{}{}
+		snap.Pending++
+		snap.Bytes += e.Size
+	}
 	for e := range cq.delayed {
 		if e != nil && snap.FirstPath == "" {
 			snap.FirstPath = e.Path
 		}
 	}
-	snap.InFlight = len(cq.inFlight)
+	snap.InFlight = len(cq.inFlight) + len(cq.immediate)
 	snap.Delayed = len(cq.delayed)
 	if cq.index != nil {
 		var firstConflictPath string
@@ -709,8 +731,9 @@ func (cq *CommitQueue) WaitPath(path string) {
 		cq.forceDelayedPathLocked(path)
 		_, inflight := cq.inFlight[path]
 		queued := cq.hasQueuedPathLocked(path)
+		immediate := cq.hasImmediatePathLocked(path)
 		cq.mu.Unlock()
-		if !inflight && !queued {
+		if !inflight && !queued && !immediate {
 			return
 		}
 		time.Sleep(50 * time.Millisecond)
@@ -725,8 +748,9 @@ func (cq *CommitQueue) WaitPathTimeout(path string, pollInterval time.Duration) 
 	cq.forceDelayedPathLocked(path)
 	_, inflight := cq.inFlight[path]
 	queued := cq.hasQueuedPathLocked(path)
+	immediate := cq.hasImmediatePathLocked(path)
 	cq.mu.Unlock()
-	if !inflight && !queued {
+	if !inflight && !queued && !immediate {
 		return true
 	}
 	time.Sleep(pollInterval)
@@ -743,7 +767,25 @@ func (cq *CommitQueue) HasPath(path string) bool {
 	if _, inflight := cq.inFlight[path]; inflight {
 		return true
 	}
-	return cq.hasQueuedPathLocked(path)
+	return cq.hasQueuedPathLocked(path) || cq.hasImmediatePathLocked(path)
+}
+
+func (cq *CommitQueue) hasImmediatePathLocked(path string) bool {
+	for entry := range cq.immediate {
+		if entry != nil && entry.Path == path {
+			return true
+		}
+	}
+	return false
+}
+
+func (cq *CommitQueue) hasImmediatePrefixLocked(prefix string) bool {
+	for entry := range cq.immediate {
+		if entry != nil && strings.HasPrefix(entry.Path, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (cq *CommitQueue) mutationSeqForPath(path string) uint64 {
@@ -755,6 +797,11 @@ func (cq *CommitQueue) mutationSeqForPath(path string) uint64 {
 	var seq uint64
 	if entry := cq.inFlight[path]; entry != nil && entry.MutationSeq > seq {
 		seq = entry.MutationSeq
+	}
+	for entry := range cq.immediate {
+		if entry != nil && entry.Path == path && entry.MutationSeq > seq {
+			seq = entry.MutationSeq
+		}
 	}
 	for entry := range cq.queuedByPath[path] {
 		if entry != nil && entry.MutationSeq > seq {
@@ -823,6 +870,9 @@ func (cq *CommitQueue) WaitPrefix(prefix string) {
 				}
 			}
 		}
+		if !found {
+			found = cq.hasImmediatePrefixLocked(prefix)
+		}
 		cq.mu.Unlock()
 		if !found {
 			return
@@ -854,6 +904,9 @@ func (cq *CommitQueue) WaitPrefixTimeout(prefix string, timeout time.Duration) b
 					break
 				}
 			}
+		}
+		if !found {
+			found = cq.hasImmediatePrefixLocked(prefix)
 		}
 		cq.mu.Unlock()
 		if !found {
@@ -915,6 +968,11 @@ func (cq *CommitQueue) CancelPathIfInode(path string, ino uint64) {
 	if e, ok := cq.inFlight[path]; ok {
 		markCanceled(e)
 	}
+	for e := range cq.immediate {
+		if e != nil && e.Path == path {
+			markCanceled(e)
+		}
+	}
 	if cq.queuedByPath != nil {
 		for e := range cq.queuedByPath[path] {
 			markCanceled(e)
@@ -964,7 +1022,7 @@ func (cq *CommitQueue) CancelQueuedZeroTruncatePreserveLocal(path string) bool {
 	}
 	cq.mu.Lock()
 	defer cq.mu.Unlock()
-	if cq.inFlight[path] != nil {
+	if cq.inFlight[path] != nil || cq.hasImmediatePathLocked(path) {
 		return false
 	}
 	otherQueued := false
@@ -1013,6 +1071,11 @@ func (cq *CommitQueue) cancelPath(path string, preserveLocal bool) {
 	cq.mu.Lock()
 	if e, ok := cq.inFlight[path]; ok {
 		markCanceled(e)
+	}
+	for e := range cq.immediate {
+		if e != nil && e.Path == path {
+			markCanceled(e)
+		}
 	}
 	if cq.queuedByPath != nil {
 		for e := range cq.queuedByPath[path] {
@@ -1102,6 +1165,12 @@ func (cq *CommitQueue) CancelPrefix(prefix string) {
 		if strings.HasPrefix(p, prefix) {
 			markCanceled(e)
 			cancelled = append(cancelled, p)
+		}
+	}
+	for e := range cq.immediate {
+		if e != nil && strings.HasPrefix(e.Path, prefix) {
+			markCanceled(e)
+			cancelled = append(cancelled, e.Path)
 		}
 	}
 	for _, e := range cq.queue {
@@ -1916,6 +1985,10 @@ func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEnt
 }
 
 func (cq *CommitQueue) commitNowClaimedPathLocked(ctx context.Context, entry *CommitEntry) error {
+	if cq.isEntryCanceled(entry) {
+		cq.discardEntry(entry)
+		return nil
+	}
 	if cq.discardSupersededEntry(entry) {
 		return nil
 	}
@@ -1925,6 +1998,10 @@ func (cq *CommitQueue) commitNowClaimedPathLocked(ctx context.Context, entry *Co
 			cq.perf.commitFailure.add(1)
 		}
 		return err
+	}
+	if cq.isEntryCanceled(entry) {
+		cq.discardEntry(entry)
+		return nil
 	}
 	if err := cq.onCommitSuccess(entry, entry.BaseRev, committedRev); err != nil {
 		if cq.perf != nil {
@@ -1943,6 +2020,7 @@ func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *
 		cq.mu.Lock()
 		newer := false
 		older := false
+		skipQueuedAliases := pathLocked && cq.inFlight[entry.Path] != nil
 		for _, active := range cq.inFlight {
 			if active == nil || active.canceled || active == entry || (pathLocked && active.Path == entry.Path) || active.Inode != entry.Inode || active.MutationSeq == 0 {
 				continue
@@ -1964,7 +2042,7 @@ func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *
 			}
 		}
 		for _, queued := range cq.queue {
-			if queued == nil || queued.canceled || queued == entry || (pathLocked && queued.Path == entry.Path) || queued.Inode != entry.Inode || queued.MutationSeq == 0 {
+			if queued == nil || queued.canceled || queued == entry || (pathLocked && queued.Path == entry.Path) || skipQueuedAliases || queued.Inode != entry.Inode || queued.MutationSeq == 0 {
 				continue
 			}
 			if queued.MutationSeq > entry.MutationSeq {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1546,9 +1546,9 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 	}
 	cq.mu.Unlock()
 	cancel()
-	unlockPaths()
 
 	if err != nil {
+		unlockPaths()
 		if isBatchWriteUnsupported(err) {
 			cq.ConfigureBatchWrite(0, 0, 0)
 		}
@@ -1557,10 +1557,16 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 		return
 	}
 	if len(results) != len(entries) {
+		unlockPaths()
 		safeLogPrintf("commit queue: batch write returned %d results for %d entries, falling back to single commits", len(results), len(entries))
 		cq.fallbackBatchEntries(entries)
 		return
 	}
+	type failedBatchEntry struct {
+		entry *CommitEntry
+		err   error
+	}
+	failed := make([]failedBatchEntry, 0)
 	for i, result := range results {
 		entry := entries[i]
 		if cq.isEntryCanceled(entry) {
@@ -1578,6 +1584,12 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 			continue
 		}
 		resultErr := batchWriteResultError(result)
+		failed = append(failed, failedBatchEntry{entry: entry, err: resultErr})
+	}
+	unlockPaths()
+	for _, failure := range failed {
+		entry := failure.entry
+		resultErr := failure.err
 		if errors.Is(resultErr, client.ErrConflict) {
 			unlockPath := cq.lockPath(entry.Path)
 			if entry.DisableAutoResolveLWW {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -119,6 +119,10 @@ type CommitSuccessFunc func(entry *CommitEntry, committedRev int64)
 // state has been removed but before the queue entry is dequeued.
 type CommitCleanupFunc func(entry *CommitEntry)
 
+// CommitSupersededFunc reports whether a queued live-handle snapshot has been
+// overtaken by a newer mutation and must not reach remote storage.
+type CommitSupersededFunc func(entry *CommitEntry) bool
+
 // CommitQueue manages ordered background remote commits with baseRev tracking.
 // It provides backpressure when the queue exceeds maxPending items.
 type CommitQueue struct {
@@ -148,6 +152,14 @@ type CommitQueue struct {
 
 	// OnCleanup is called after local commit state has been removed.
 	OnCleanup CommitCleanupFunc
+
+	// OnDiscard is called after a superseded entry's owned staging and queue
+	// state have been removed without publishing commit success.
+	OnDiscard CommitCleanupFunc
+
+	// IsSuperseded is an optional upload-boundary guard. Sequence-zero path and
+	// recovery entries remain unfiltered by the Dat9FS implementation.
+	IsSuperseded CommitSupersededFunc
 
 	// PathLock serializes upload and cleanup against Dat9FS same-path shadow
 	// mutations. When unset, the queue still serializes same-path entries.
@@ -1072,6 +1084,24 @@ func (cq *CommitQueue) isEntryCanceled(entry *CommitEntry) bool {
 	return entry.canceled
 }
 
+func (cq *CommitQueue) discardSupersededEntry(entry *CommitEntry) bool {
+	if cq == nil || entry == nil || cq.IsSuperseded == nil || !cq.IsSuperseded(entry) {
+		return false
+	}
+	if cq.index != nil && entry.PendingIndexGen != 0 {
+		cq.index.RemoveIfGeneration(entry.Path, entry.PendingIndexGen)
+	}
+	if cq.shadows != nil && entry.ShadowGen != 0 {
+		cq.shadows.RemoveIfGeneration(entry.Path, entry.ShadowGen)
+	}
+	cq.removeFromQueue(entry)
+	if cq.OnDiscard != nil {
+		cq.OnDiscard(entry)
+	}
+	safeLogPrintf("commit queue: discarded superseded entry for %s (inode=%d seq=%d)", entry.Path, entry.Inode, entry.MutationSeq)
+	return true
+}
+
 func (cq *CommitQueue) worker() {
 	defer cq.wg.Done()
 	for entry := range cq.workCh {
@@ -1238,6 +1268,10 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 		cq.mu.Unlock()
 
 		unlockPath := cq.lockPath(entry.Path)
+		if cq.discardSupersededEntry(entry) {
+			unlockPath()
+			return
+		}
 		committedRev, err := cq.uploadEntry(ctx, entry)
 		cq.mu.Lock()
 		entry.cancelUpload = nil
@@ -1419,15 +1453,16 @@ func (cq *CommitQueue) batchWriteEligible(entry *CommitEntry) bool {
 }
 
 func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
+	allEntries := append([]*CommitEntry(nil), entries...)
 	entryCtx, entryCancel := context.WithCancel(context.Background())
 	cq.mu.Lock()
-	for _, entry := range entries {
+	for _, entry := range allEntries {
 		entry.cancelCommit = entryCancel
 	}
 	cq.mu.Unlock()
 	defer func() {
 		cq.mu.Lock()
-		for _, entry := range entries {
+		for _, entry := range allEntries {
 			entry.cancelCommit = nil
 			entry.cancelUpload = nil
 		}
@@ -1452,6 +1487,27 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 	}
 	cq.mu.Unlock()
 	unlockPaths := cq.lockBatchPaths(entries)
+	active := entries[:0]
+	for _, entry := range entries {
+		if cq.discardSupersededEntry(entry) {
+			cq.endInFlight(entry)
+			continue
+		}
+		active = append(active, entry)
+	}
+	entries = active
+	if len(entries) == 0 {
+		cancel()
+		unlockPaths()
+		return
+	}
+	if len(entries) == 1 {
+		cancel()
+		unlockPaths()
+		cq.fallbackBatchEntries(entries)
+		return
+	}
+
 	remoteItems, err := cq.prepareBatchWriteItems(entries)
 	if err != nil {
 		unlockPaths()
@@ -1721,6 +1777,9 @@ func (cq *CommitQueue) CommitNow(ctx context.Context, entry *CommitEntry) error 
 }
 
 func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEntry) error {
+	if cq.discardSupersededEntry(entry) {
+		return nil
+	}
 	committedRev, err := cq.uploadEntry(ctx, entry)
 	if err != nil {
 		if cq.perf != nil {
@@ -2033,6 +2092,9 @@ func (cq *CommitQueue) onCommitSuccessWithOptions(entry *CommitEntry, expectedRe
 // This covers ~80% of agent conflict scenarios (whole-file overwrites) without
 // requiring 3-way merge. Max 1 retry to avoid write amplification.
 func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *CommitEntry) {
+	if cq.discardSupersededEntry(entry) {
+		return
+	}
 	// Bail early if the file was deleted locally while queued.
 	if cq.isEntryCanceled(entry) {
 		cq.removeFromQueue(entry)
@@ -2182,6 +2244,9 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 	if err := cq.validateEntryPayloadFresh(entry); err != nil {
 		safeLogPrintf("commit queue: auto-resolve rejected stale payload for %s before LWW: %v", entry.Path, err)
 		cq.onCommitTerminalFailure(entry)
+		return
+	}
+	if cq.discardSupersededEntry(entry) {
 		return
 	}
 	// Re-check cancelation before the potentially expensive upload.

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -735,6 +735,24 @@ func (cq *CommitQueue) HasPath(path string) bool {
 	return cq.hasQueuedPathLocked(path)
 }
 
+func (cq *CommitQueue) mutationSeqForPath(path string) uint64 {
+	if cq == nil || path == "" {
+		return 0
+	}
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	var seq uint64
+	if entry := cq.inFlight[path]; entry != nil && entry.MutationSeq > seq {
+		seq = entry.MutationSeq
+	}
+	for entry := range cq.queuedByPath[path] {
+		if entry != nil && entry.MutationSeq > seq {
+			seq = entry.MutationSeq
+		}
+	}
+	return seq
+}
+
 // WaitPrefix blocks until all in-flight or queued commits under the given
 // prefix complete. Used by Rename to wait for descendant commits.
 func (cq *CommitQueue) WaitPrefix(prefix string) {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1957,11 +1957,8 @@ func (cq *CommitQueue) entryUploadContext(parent context.Context, entry *CommitE
 // by workers. It is used as a fallback when the async queue rejects an entry
 // after local state has already moved to the final path.
 func (cq *CommitQueue) CommitNow(ctx context.Context, entry *CommitEntry) error {
-	cq.mu.Lock()
-	abandoned := cq.abandoned
-	cq.mu.Unlock()
-	if abandoned {
-		return errLayerRolledBack
+	if err := cq.rejectAbandonedLayer(); err != nil {
+		return err
 	}
 	release, discard, err := cq.beginImmediateMutationCommit(ctx, entry, false)
 	if err != nil {
@@ -1979,7 +1976,20 @@ func (cq *CommitQueue) CommitNow(ctx context.Context, entry *CommitEntry) error 
 	return cq.commitNowClaimedPathLocked(ctx, entry)
 }
 
+func (cq *CommitQueue) rejectAbandonedLayer() error {
+	cq.mu.Lock()
+	abandoned := cq.abandoned
+	cq.mu.Unlock()
+	if abandoned {
+		return errLayerRolledBack
+	}
+	return nil
+}
+
 func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEntry) error {
+	if err := cq.rejectAbandonedLayer(); err != nil {
+		return err
+	}
 	release, discard, err := cq.beginImmediateMutationCommit(ctx, entry, true)
 	if err != nil {
 		return err

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1220,6 +1220,16 @@ func (cq *CommitQueue) isEntryCanceled(entry *CommitEntry) bool {
 	return entry.canceled
 }
 
+func (cq *CommitQueue) isCanceledImmediateEntry(entry *CommitEntry) bool {
+	if cq == nil || entry == nil || !cq.serializeMutationInodes {
+		return false
+	}
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	_, immediate := cq.immediate[entry]
+	return immediate && entry.canceled
+}
+
 func (cq *CommitQueue) discardSupersededEntry(entry *CommitEntry) bool {
 	if cq == nil || entry == nil || cq.IsSuperseded == nil || !cq.IsSuperseded(entry) {
 		return false
@@ -1985,8 +1995,8 @@ func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEnt
 }
 
 func (cq *CommitQueue) commitNowClaimedPathLocked(ctx context.Context, entry *CommitEntry) error {
-	if cq.isEntryCanceled(entry) {
-		cq.discardEntry(entry)
+	if cq.isCanceledImmediateEntry(entry) {
+		cq.removeFromQueue(entry)
 		return nil
 	}
 	if cq.discardSupersededEntry(entry) {
@@ -1999,8 +2009,8 @@ func (cq *CommitQueue) commitNowClaimedPathLocked(ctx context.Context, entry *Co
 		}
 		return err
 	}
-	if cq.isEntryCanceled(entry) {
-		cq.discardEntry(entry)
+	if cq.isCanceledImmediateEntry(entry) {
+		cq.removeFromQueue(entry)
 		return nil
 	}
 	if err := cq.onCommitSuccess(entry, entry.BaseRev, committedRev); err != nil {
@@ -2020,7 +2030,7 @@ func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *
 		cq.mu.Lock()
 		newer := false
 		older := false
-		skipQueuedAliases := pathLocked && cq.inFlight[entry.Path] != nil
+		samePathWorker := pathLocked && cq.inFlight[entry.Path] != nil
 		for _, active := range cq.inFlight {
 			if active == nil || active.canceled || active == entry || (pathLocked && active.Path == entry.Path) || active.Inode != entry.Inode || active.MutationSeq == 0 {
 				continue
@@ -2042,7 +2052,10 @@ func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *
 			}
 		}
 		for _, queued := range cq.queue {
-			if queued == nil || queued.canceled || queued == entry || (pathLocked && queued.Path == entry.Path) || skipQueuedAliases || queued.Inode != entry.Inode || queued.MutationSeq == 0 {
+			if queued == nil || queued.canceled || queued == entry || (pathLocked && queued.Path == entry.Path) || queued.Inode != entry.Inode || queued.MutationSeq == 0 {
+				continue
+			}
+			if samePathWorker && queued.MutationSeq < entry.MutationSeq {
 				continue
 			}
 			if queued.MutationSeq > entry.MutationSeq {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -85,6 +85,7 @@ type CommitEntry struct {
 	canceled              bool
 	cancelCommit          context.CancelFunc
 	cancelUpload          context.CancelFunc
+	mutationPublished     bool
 	payload               []byte
 	payloadBound          bool
 }

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -166,6 +166,10 @@ type CommitQueue struct {
 	// recovery entries remain unfiltered by the Dat9FS implementation.
 	IsSuperseded CommitSupersededFunc
 
+	// serializeMutationInodes extends queue dispatch ordering across hardlink
+	// aliases for live-handle mutations. It is enabled only for gVisor mounts.
+	serializeMutationInodes bool
+
 	// PathLock serializes upload and cleanup against Dat9FS same-path shadow
 	// mutations. When unset, the queue still serializes same-path entries.
 	PathLock func(path string) func()
@@ -767,6 +771,19 @@ func (cq *CommitQueue) hasNewerMutation(path string, ino, seq uint64) bool {
 	newer := func(entry *CommitEntry) bool {
 		return entry != nil && !entry.canceled && entry.Inode == ino && entry.MutationSeq > seq
 	}
+	if cq.serializeMutationInodes {
+		for _, entry := range cq.inFlight {
+			if newer(entry) {
+				return true
+			}
+		}
+		for _, entry := range cq.queue {
+			if newer(entry) {
+				return true
+			}
+		}
+		return false
+	}
 	if newer(cq.inFlight[path]) {
 		return true
 	}
@@ -1190,8 +1207,7 @@ func (cq *CommitQueue) beginInFlight(entry *CommitEntry) bool {
 		if cq.inFlight == nil {
 			cq.inFlight = make(map[string]*CommitEntry)
 		}
-		oldest := cq.oldestQueuedForPathLocked(entry.Path)
-		if cq.inFlight[entry.Path] == nil && (oldest == nil || oldest == entry) {
+		if cq.canBeginInFlightLocked(entry) {
 			cq.inFlight[entry.Path] = entry
 			cq.mu.Unlock()
 			return true
@@ -1213,11 +1229,34 @@ func (cq *CommitQueue) tryBeginInFlight(entry *CommitEntry) bool {
 	if cq.inFlight == nil {
 		cq.inFlight = make(map[string]*CommitEntry)
 	}
-	oldest := cq.oldestQueuedForPathLocked(entry.Path)
-	if cq.inFlight[entry.Path] != nil || (oldest != nil && oldest != entry) {
+	if !cq.canBeginInFlightLocked(entry) {
 		return false
 	}
 	cq.inFlight[entry.Path] = entry
+	return true
+}
+
+func (cq *CommitQueue) canBeginInFlightLocked(entry *CommitEntry) bool {
+	if cq == nil || entry == nil || cq.inFlight[entry.Path] != nil {
+		return false
+	}
+	if oldest := cq.oldestQueuedForPathLocked(entry.Path); oldest != nil && oldest != entry {
+		return false
+	}
+	if !cq.serializeMutationInodes || entry.Inode == 0 || entry.MutationSeq == 0 {
+		return true
+	}
+	for _, active := range cq.inFlight {
+		if active != nil && active != entry && active.Inode == entry.Inode && active.MutationSeq != 0 {
+			return false
+		}
+	}
+	for _, queued := range cq.queue {
+		if queued == nil || queued.canceled || queued.Inode != entry.Inode || queued.MutationSeq == 0 {
+			continue
+		}
+		return queued == entry
+	}
 	return true
 }
 

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -757,6 +757,26 @@ func (cq *CommitQueue) mutationSeqForPath(path string) uint64 {
 	return seq
 }
 
+func (cq *CommitQueue) hasNewerMutation(path string, ino, seq uint64) bool {
+	if cq == nil || path == "" || ino == 0 || seq == 0 {
+		return false
+	}
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	newer := func(entry *CommitEntry) bool {
+		return entry != nil && !entry.canceled && entry.Inode == ino && entry.MutationSeq > seq
+	}
+	if newer(cq.inFlight[path]) {
+		return true
+	}
+	for entry := range cq.queuedByPath[path] {
+		if newer(entry) {
+			return true
+		}
+	}
+	return false
+}
+
 // WaitPrefix blocks until all in-flight or queued commits under the given
 // prefix complete. Used by Rename to wait for descendant commits.
 func (cq *CommitQueue) WaitPrefix(prefix string) {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -150,6 +150,10 @@ type CommitQueue struct {
 	// revision. Used by dat9fs to seed readCache and update inode revision.
 	OnSuccess CommitSuccessFunc
 
+	// OnUploaded is called at the data-commit boundary before fallible mode,
+	// journal, or cleanup bookkeeping.
+	OnUploaded CommitSuccessFunc
+
 	// OnCleanup is called after local commit state has been removed.
 	OnCleanup CommitCleanupFunc
 
@@ -2026,6 +2030,9 @@ func (cq *CommitQueue) onCommitSuccessWithOptions(entry *CommitEntry, expectedRe
 	layerRef := cq.layerRefSnapshot()
 	if layerRef == "" {
 		committedRev = committedRevisionForExpectedRevision(expectedRevision, committedRev)
+	}
+	if cq.OnUploaded != nil {
+		cq.OnUploaded(entry, committedRev)
 	}
 
 	if layerRef == "" && !remoteModeAlreadyApplied && shouldApplyRemoteMode(entry.Kind, entry.HasMode, entry.Mode) {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1148,6 +1148,14 @@ func (cq *CommitQueue) discardSupersededEntry(entry *CommitEntry) bool {
 	if cq == nil || entry == nil || cq.IsSuperseded == nil || !cq.IsSuperseded(entry) {
 		return false
 	}
+	cq.discardEntry(entry)
+	return true
+}
+
+func (cq *CommitQueue) discardEntry(entry *CommitEntry) {
+	if cq == nil || entry == nil {
+		return
+	}
 	if cq.index != nil && entry.PendingIndexGen != 0 {
 		cq.index.RemoveIfGeneration(entry.Path, entry.PendingIndexGen)
 	}
@@ -1159,7 +1167,6 @@ func (cq *CommitQueue) discardSupersededEntry(entry *CommitEntry) bool {
 		cq.OnDiscard(entry)
 	}
 	safeLogPrintf("commit queue: discarded superseded entry for %s (inode=%d seq=%d)", entry.Path, entry.Inode, entry.MutationSeq)
-	return true
 }
 
 func (cq *CommitQueue) worker() {
@@ -1871,6 +1878,17 @@ func (cq *CommitQueue) CommitNow(ctx context.Context, entry *CommitEntry) error 
 }
 
 func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEntry) error {
+	release, discard, err := cq.beginImmediateMutationCommit(ctx, entry)
+	if err != nil {
+		return err
+	}
+	if discard {
+		cq.discardEntry(entry)
+		return nil
+	}
+	if release != nil {
+		defer release()
+	}
 	if cq.discardSupersededEntry(entry) {
 		return nil
 	}
@@ -1888,6 +1906,52 @@ func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEnt
 		return err
 	}
 	return nil
+}
+
+func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *CommitEntry) (func(), bool, error) {
+	if cq == nil || entry == nil || !cq.serializeMutationInodes || entry.Inode == 0 || entry.MutationSeq == 0 {
+		return nil, false, nil
+	}
+	for {
+		cq.mu.Lock()
+		newer := false
+		older := false
+		for _, active := range cq.inFlight {
+			if active == nil || active == entry || active.Path == entry.Path || active.Inode != entry.Inode || active.MutationSeq == 0 {
+				continue
+			}
+			if active.MutationSeq > entry.MutationSeq {
+				newer = true
+			} else if active.MutationSeq < entry.MutationSeq {
+				older = true
+			}
+		}
+		for _, queued := range cq.queue {
+			if queued == nil || queued.canceled || queued == entry || queued.Path == entry.Path || queued.Inode != entry.Inode || queued.MutationSeq == 0 {
+				continue
+			}
+			if queued.MutationSeq > entry.MutationSeq {
+				newer = true
+			} else if queued.MutationSeq < entry.MutationSeq {
+				older = true
+			}
+		}
+		if newer {
+			cq.mu.Unlock()
+			return nil, true, nil
+		}
+		if !older && cq.inFlight[entry.Path] == nil {
+			cq.inFlight[entry.Path] = entry
+			cq.mu.Unlock()
+			return func() { cq.endInFlight(entry) }, false, nil
+		}
+		cq.mu.Unlock()
+		select {
+		case <-ctx.Done():
+			return nil, false, ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
 }
 
 func committedRevisionForExpectedRevision(expectedRevision, committedRev int64) int64 {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -51,6 +51,7 @@ func (cq *CommitQueue) directPutThreshold() int64 {
 type CommitEntry struct {
 	Path                 string
 	Inode                uint64
+	MutationSeq          uint64
 	BaseRev              int64 // revision when we started editing
 	Size                 int64
 	Kind                 PendingKind

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -130,7 +130,8 @@ type CommitQueue struct {
 	mu           sync.Mutex
 	queue        []*CommitEntry
 	queuedByPath map[string]map[*CommitEntry]struct{}
-	inFlight     map[string]*CommitEntry // paths currently being processed by workers
+	inFlight     map[string]*CommitEntry   // paths currently being processed by workers
+	immediate    map[*CommitEntry]struct{} // synchronous gVisor commits participating in inode ordering
 	delayed      map[*CommitEntry]*time.Timer
 	maxPending   int
 	client       *client.Client
@@ -216,6 +217,7 @@ func NewCommitQueue(c *client.Client, shadows *ShadowStore, index *PendingIndex,
 		index:             index,
 		journal:           journal,
 		inFlight:          make(map[string]*CommitEntry),
+		immediate:         make(map[*CommitEntry]struct{}),
 		queuedByPath:      make(map[string]map[*CommitEntry]struct{}),
 		delayed:           make(map[*CommitEntry]*time.Timer),
 		workCh:            make(chan *CommitEntry, bufSize),
@@ -777,6 +779,11 @@ func (cq *CommitQueue) hasNewerMutation(path string, ino, seq uint64) bool {
 				return true
 			}
 		}
+		for entry := range cq.immediate {
+			if newer(entry) {
+				return true
+			}
+		}
 		for _, entry := range cq.queue {
 			if newer(entry) {
 				return true
@@ -1255,6 +1262,11 @@ func (cq *CommitQueue) canBeginInFlightLocked(entry *CommitEntry) bool {
 	}
 	for _, active := range cq.inFlight {
 		if active != nil && active != entry && active.Inode == entry.Inode && active.MutationSeq != 0 {
+			return false
+		}
+	}
+	for active := range cq.immediate {
+		if active != nil && !active.canceled && active != entry && active.Inode == entry.Inode && active.MutationSeq != 0 {
 			return false
 		}
 	}
@@ -1872,13 +1884,7 @@ func (cq *CommitQueue) CommitNow(ctx context.Context, entry *CommitEntry) error 
 	if abandoned {
 		return errLayerRolledBack
 	}
-	unlockPath := cq.lockPath(entry.Path)
-	defer unlockPath()
-	return cq.commitNowPathLocked(ctx, entry)
-}
-
-func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEntry) error {
-	release, discard, err := cq.beginImmediateMutationCommit(ctx, entry)
+	release, discard, err := cq.beginImmediateMutationCommit(ctx, entry, false)
 	if err != nil {
 		return err
 	}
@@ -1889,6 +1895,27 @@ func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEnt
 	if release != nil {
 		defer release()
 	}
+	unlockPath := cq.lockPath(entry.Path)
+	defer unlockPath()
+	return cq.commitNowClaimedPathLocked(ctx, entry)
+}
+
+func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEntry) error {
+	release, discard, err := cq.beginImmediateMutationCommit(ctx, entry, true)
+	if err != nil {
+		return err
+	}
+	if discard {
+		cq.discardEntry(entry)
+		return nil
+	}
+	if release != nil {
+		defer release()
+	}
+	return cq.commitNowClaimedPathLocked(ctx, entry)
+}
+
+func (cq *CommitQueue) commitNowClaimedPathLocked(ctx context.Context, entry *CommitEntry) error {
 	if cq.discardSupersededEntry(entry) {
 		return nil
 	}
@@ -1908,7 +1935,7 @@ func (cq *CommitQueue) commitNowPathLocked(ctx context.Context, entry *CommitEnt
 	return nil
 }
 
-func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *CommitEntry) (func(), bool, error) {
+func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *CommitEntry, pathLocked bool) (func(), bool, error) {
 	if cq == nil || entry == nil || !cq.serializeMutationInodes || entry.Inode == 0 || entry.MutationSeq == 0 {
 		return nil, false, nil
 	}
@@ -1917,7 +1944,17 @@ func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *
 		newer := false
 		older := false
 		for _, active := range cq.inFlight {
-			if active == nil || active == entry || active.Path == entry.Path || active.Inode != entry.Inode || active.MutationSeq == 0 {
+			if active == nil || active.canceled || active == entry || (pathLocked && active.Path == entry.Path) || active.Inode != entry.Inode || active.MutationSeq == 0 {
+				continue
+			}
+			if active.MutationSeq > entry.MutationSeq {
+				newer = true
+			} else if active.MutationSeq < entry.MutationSeq {
+				older = true
+			}
+		}
+		for active := range cq.immediate {
+			if active == nil || active.canceled || active == entry || (pathLocked && active.Path == entry.Path) || active.Inode != entry.Inode || active.MutationSeq == 0 {
 				continue
 			}
 			if active.MutationSeq > entry.MutationSeq {
@@ -1927,7 +1964,7 @@ func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *
 			}
 		}
 		for _, queued := range cq.queue {
-			if queued == nil || queued.canceled || queued == entry || queued.Path == entry.Path || queued.Inode != entry.Inode || queued.MutationSeq == 0 {
+			if queued == nil || queued.canceled || queued == entry || (pathLocked && queued.Path == entry.Path) || queued.Inode != entry.Inode || queued.MutationSeq == 0 {
 				continue
 			}
 			if queued.MutationSeq > entry.MutationSeq {
@@ -1940,10 +1977,13 @@ func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *
 			cq.mu.Unlock()
 			return nil, true, nil
 		}
-		if !older && cq.inFlight[entry.Path] == nil {
-			cq.inFlight[entry.Path] = entry
+		if !older && (pathLocked || cq.inFlight[entry.Path] == nil) {
+			if cq.immediate == nil {
+				cq.immediate = make(map[*CommitEntry]struct{})
+			}
+			cq.immediate[entry] = struct{}{}
 			cq.mu.Unlock()
-			return func() { cq.endInFlight(entry) }, false, nil
+			return func() { cq.endImmediate(entry) }, false, nil
 		}
 		cq.mu.Unlock()
 		select {
@@ -1952,6 +1992,15 @@ func (cq *CommitQueue) beginImmediateMutationCommit(ctx context.Context, entry *
 		case <-time.After(50 * time.Millisecond):
 		}
 	}
+}
+
+func (cq *CommitQueue) endImmediate(entry *CommitEntry) {
+	if cq == nil || entry == nil {
+		return
+	}
+	cq.mu.Lock()
+	delete(cq.immediate, entry)
+	cq.mu.Unlock()
 }
 
 func committedRevisionForExpectedRevision(expectedRevision, committedRev int64) int64 {

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -749,6 +749,22 @@ func TestCommitQueueCommitNowHoldsPathLockThroughSuccessCleanup(t *testing.T) {
 	}
 }
 
+func TestCommitQueueCommitNowRejectsAbandonedLayer(t *testing.T) {
+	cq := &CommitQueue{abandoned: true}
+	entry := &CommitEntry{Path: "/rolled-back.txt"}
+
+	for name, commit := range map[string]func(context.Context, *CommitEntry) error{
+		"CommitNow":           cq.CommitNow,
+		"commitNowPathLocked": cq.commitNowPathLocked,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := commit(context.Background(), entry); err != errLayerRolledBack {
+				t.Fatalf("%s error = %v, want errLayerRolledBack", name, err)
+			}
+		})
+	}
+}
+
 func TestCommitQueueAppliesModeAfterUpload(t *testing.T) {
 	var putCalls atomic.Int32
 	var chmodCalls atomic.Int32

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -322,6 +322,7 @@ type dirtyInodeState struct {
 
 type inodeMutationState struct {
 	latestSeq         uint64
+	stagedSeq         uint64
 	committedSeq      uint64
 	committedRevision int64
 	committedSize     int64
@@ -1890,6 +1891,19 @@ func (fs *Dat9FS) clearDirtySize(ino uint64, seq uint64) {
 	}
 }
 
+func (fs *Dat9FS) recordStagedMutation(ino, seq uint64) {
+	if !fs.gvisorCompatibilityEnabled() || ino == 0 || seq == 0 {
+		return
+	}
+	fs.dirtyMu.Lock()
+	state := fs.mutationInodes[ino]
+	if seq > state.stagedSeq {
+		state.stagedSeq = seq
+	}
+	fs.mutationInodes[ino] = state
+	fs.dirtyMu.Unlock()
+}
+
 func (fs *Dat9FS) gvisorCompatibilityEnabled() bool {
 	return fs != nil && fs.opts != nil && fs.opts.GVisorCompat
 }
@@ -1919,6 +1933,20 @@ func (fs *Dat9FS) recordCommittedMutation(ino uint64, seq uint64, revision int64
 	fs.dirtyMu.Unlock()
 }
 
+func (fs *Dat9FS) resolveCommittedMutationRevision(localPath string, committedRev, expectedRevision int64) int64 {
+	if committedRev > 0 {
+		return committedRev
+	}
+	if revision, ok := committedRevisionFromExpectedRevision(expectedRevision); ok && revision > 0 {
+		return revision
+	}
+	stat, err := fs.remotePathStatDetached(localPath)
+	if err == nil && stat != nil && stat.Revision > 0 {
+		return stat.Revision
+	}
+	return 0
+}
+
 func (fs *Dat9FS) committedMutation(ino uint64) (inodeMutationState, bool) {
 	if !fs.gvisorCompatibilityEnabled() || ino == 0 {
 		return inodeMutationState{}, false
@@ -1940,7 +1968,7 @@ func (fs *Dat9FS) commitEntrySuperseded(entry *CommitEntry) bool {
 	if !ok {
 		return false
 	}
-	return entry.MutationSeq < state.latestSeq || entry.MutationSeq <= state.committedSeq
+	return entry.MutationSeq < state.stagedSeq || entry.MutationSeq <= state.committedSeq
 }
 
 // discardSupersededMutationLocked turns a handle snapshot that is no newer
@@ -1951,11 +1979,12 @@ func (fs *Dat9FS) discardSupersededMutationLocked(fh *FileHandle) bool {
 		return false
 	}
 	state, ok := fs.committedMutation(fh.Ino)
-	if !ok || fh.DirtySeq > state.committedSeq {
+	if !ok || state.committedRevision <= 0 || fh.DirtySeq > state.committedSeq {
 		return false
 	}
 
 	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+	fs.removeHandleOwnedStagingLocked(fh)
 	if fh.Dirty != nil {
 		fh.Dirty.ClearDirty()
 	}
@@ -3685,6 +3714,9 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 	// its cleanup to this handle's staging generation.
 	if fs.shadowStore != nil {
 		fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(fh.Path)
+	}
+	if durable {
+		fs.recordStagedMutation(fh.Ino, fh.DirtySeq)
 	}
 	return nil
 }
@@ -9716,10 +9748,10 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 	}
 
 	renameCtx, renameCancel := fs.namespaceMutationCommitContext(ctx)
+	defer renameCancel()
 	renameErr := fs.renameRemoteWithTransientRetry(renameCtx, oldP, newP)
-	renameCancel()
 	if renameErr != nil {
-		if handled, st := fs.renameRemoteFileToMissingTargetFallback(ctx, input, oldInfo, newInfo, renameErr); handled {
+		if handled, st := fs.renameRemoteFileToMissingTargetFallback(renameCtx, input, oldInfo, newInfo, renameErr); handled {
 			return st
 		}
 		return httpToFuseStatus(renameErr)
@@ -12630,6 +12662,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			}
 			phase = "large-shadowspill-sync-upload"
 			expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+			mutationSeq := fh.DirtySeq
 			handleIsNew := fh.IsNew
 			handlePath := fh.Path
 			stagingGens := fs.captureHandleStagingGensLocked(fh)
@@ -12667,6 +12700,11 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			if err != nil {
 				safeLogPrintf("flush: ShadowSpill sync upload failed for %s: %v", fh.Path, err)
 				return gofuse.EIO
+			}
+			mutationRevision := fs.resolveCommittedMutationRevision(fh.Path, committedRev, expectedRevision)
+			fs.recordCommittedMutation(fh.Ino, mutationSeq, mutationRevision, size)
+			if mutationRevision > 0 {
+				fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, mutationRevision, fh, size)
 			}
 			// If Unlink completed while remoteCommitLock was released (it
 			// serializes DELETE after our PUT via the same lock), the path is
@@ -13075,6 +13113,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		}
 
 		expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+		mutationSeq := fh.DirtySeq
 		uploadStart := time.Now()
 		fs.debugf("fsync writeback upload start path=%s", fh.Path)
 		committedRev, err := fs.uploader.UploadSyncWithRevision(ctx, fh.Path)
@@ -13082,6 +13121,11 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		if err != nil {
 			safeLogPrintf("fsync writeback upload failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
+		}
+		mutationRevision := fs.resolveCommittedMutationRevision(fh.Path, committedRev, expectedRevision)
+		fs.recordCommittedMutation(fh.Ino, mutationSeq, mutationRevision, size)
+		if mutationRevision > 0 {
+			fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, mutationRevision, fh, size)
 		}
 		if fh.HasPendingMode {
 			ino := fh.Ino
@@ -14771,6 +14815,7 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 		return
 	}
 	if !fs.layerEnabled() {
+		committedRev = fs.resolveCommittedMutationRevision(entry.Path, committedRev, entry.BaseRev)
 		fs.recordCommittedMutation(entry.Inode, entry.MutationSeq, committedRev, entry.Size)
 	}
 	if fs.layerEnabled() {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -8888,7 +8888,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// whiteout request was in flight escaped the first mark; mark them
 		// now so their later write/flush/release is suppressed too and the
 		// overlay entry cannot be upserted back over the whiteout.
-		fs.markOpenHandlesUnlinked(ctx, childP, false)
+		_, _, _ = fs.markOpenHandlesUnlinked(ctx, childP, false)
 		parentPath, _ := fs.inodes.GetPath(header.NodeId)
 		fs.dirCache.Remove(parentPath, name)
 		fs.touchDirectoryChangeTime(parentPath, time.Now())
@@ -12406,14 +12406,13 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 
 	size := fh.Dirty.Size()
 	if fh.ShadowSpill && fs.shadowStore != nil {
-		mutationSeq := fh.DirtySeq
 		unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
 		defer unlockRemoteCommit()
 		if fs.discardSupersededMutationLocked(fh) {
 			fs.removeHandleOwnedStagingLocked(fh)
 			return gofuse.OK
 		}
-		mutationSeq = fh.DirtySeq
+		mutationSeq := fh.DirtySeq
 		expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 		stagingGens := fs.captureHandleStagingGensLocked(fh)
 		uploadStart := time.Now()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -9634,16 +9634,21 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 			entry.ShadowGen = fs.shadowStore.ActiveGeneration(newP)
 		}
 		fs.bindCommitEntryToPath(entry, newP, meta.BaseRev)
+		commitPendingRenameNow := func() error {
+			commitCtx, commitCancel := fs.namespaceMutationCommitContext(ctx)
+			defer commitCancel()
+			return fs.commitQueue.commitNowPathLocked(commitCtx, entry)
+		}
 		if isGitLooseObjectFinalPath(newP) {
 			// Git treats a successful tmp_obj_* -> <sha> rename as making the
 			// object database complete. Do not acknowledge that rename while the
 			// content-addressed object is only queued for best-effort upload.
-			if commitErr := fs.commitQueue.commitNowPathLocked(ctx, entry); commitErr != nil {
+			if commitErr := commitPendingRenameNow(); commitErr != nil {
 				return pendingRenameHandled, fmt.Errorf("sync commit git loose object rename %s: %w", newP, commitErr)
 			}
 		} else if err := fs.commitQueue.Enqueue(entry); err != nil {
 			safeLogPrintf("rename: enqueue pending-new commit for %s failed, falling back to sync commit: %v", newP, err)
-			if commitErr := fs.commitQueue.commitNowPathLocked(ctx, entry); commitErr != nil {
+			if commitErr := commitPendingRenameNow(); commitErr != nil {
 				return pendingRenameHandled, fmt.Errorf("sync commit pending-new rename %s: %w", newP, commitErr)
 			}
 		}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3711,6 +3711,10 @@ func (fs *Dat9FS) stageShadowForQueuedCommitLocked(fh *FileHandle, durable bool)
 	acquired := fh != nil && fh.RemoteCommitUnlock == nil
 	if fh != nil {
 		_ = fs.lockHandleRemoteCommitPathLocked(fh)
+		if fs.gvisorCompatibilityEnabled() && fs.commitQueue != nil && fs.commitQueue.hasNewerMutation(fh.Path, fh.Ino, fh.DirtySeq) {
+			fs.releaseHandleRemoteCommitPathLocked(fh)
+			return syscall.EAGAIN
+		}
 		if fs.discardSupersededMutationLocked(fh) {
 			fs.removeHandleOwnedStagingLocked(fh)
 			fs.releaseHandleRemoteCommitPathLocked(fh)
@@ -12625,6 +12629,9 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 					stageStart := time.Now()
 					fs.debugf("flush stage shadow start path=%s size=%d durable=true", fh.Path, size)
 					err := fs.stageShadowForQueuedCommitLocked(fh, true)
+					if errors.Is(err, syscall.EAGAIN) {
+						return gofuse.EAGAIN
+					}
 					stageDur := time.Since(stageStart)
 					fs.debugDurationf(stageStart, 0, "flush stage shadow done path=%s size=%d err=%v", fh.Path, size, err)
 					fs.perf.recordFlushStageShadow(stageDur)
@@ -12702,6 +12709,9 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			stageStart := time.Now()
 			fs.debugf("flush shadowspill stage start path=%s size=%d durable=true", fh.Path, size)
 			err := fs.stageShadowForQueuedCommitLocked(fh, true)
+			if errors.Is(err, syscall.EAGAIN) {
+				return gofuse.EAGAIN
+			}
 			largeStageDur := time.Since(stageStart)
 			fs.debugDurationf(stageStart, 0, "flush shadowspill stage done path=%s size=%d err=%v", fh.Path, size, err)
 			fs.perf.recordFlushStageShadow(largeStageDur)
@@ -12826,6 +12836,9 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 				stageStart := time.Now()
 				fs.debugf("flush stage shadow start path=%s size=%d durable=true", fh.Path, size)
 				err := fs.stageShadowForQueuedCommitLocked(fh, true)
+				if errors.Is(err, syscall.EAGAIN) {
+					return gofuse.EAGAIN
+				}
 				fs.debugDurationf(stageStart, 0, "flush stage shadow done path=%s size=%d err=%v", fh.Path, size, err)
 				if err != nil {
 					safeLogPrintf("flush: shadow stage failed for %s (size=%d): %v, falling through to sync upload", fh.Path, fh.Dirty.Size(), err)
@@ -12960,6 +12973,9 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			phase = "interactive-shadowspill-stage"
 			stageStart := time.Now()
 			err := fs.stageShadowForQueuedCommitLocked(fh, true)
+			if errors.Is(err, syscall.EAGAIN) {
+				return gofuse.EAGAIN
+			}
 			fs.debugDurationf(stageStart, 0, "fsync shadowspill stage done path=%s err=%v", fh.Path, err)
 			if err == nil {
 				if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {
@@ -12997,6 +13013,9 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			phase = "interactive-stage"
 			stageStart := time.Now()
 			err := fs.stageShadowForQueuedCommitLocked(fh, true)
+			if errors.Is(err, syscall.EAGAIN) {
+				return gofuse.EAGAIN
+			}
 			fs.debugDurationf(stageStart, 0, "fsync stage done path=%s err=%v", fh.Path, err)
 			if err == nil {
 				if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1966,8 +1966,19 @@ func (fs *Dat9FS) discardSupersededMutationLocked(fh *FileHandle) bool {
 		return false
 	}
 	state, ok := fs.committedMutation(fh.Ino)
-	if !ok || state.committedRevision <= 0 || fh.DirtySeq > state.committedSeq {
+	if !ok || fh.DirtySeq > state.committedSeq || state.committedRevision <= 0 && !fs.layerEnabled() {
 		return false
+	}
+	var layerData []byte
+	if state.committedRevision <= 0 && fs.layerEnabled() {
+		if fs.shadowStore == nil {
+			return false
+		}
+		var err error
+		layerData, err = fs.shadowStore.ReadAll(fh.Path)
+		if err != nil || int64(len(layerData)) != state.committedSize {
+			return false
+		}
 	}
 
 	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
@@ -1991,8 +2002,18 @@ func (fs *Dat9FS) discardSupersededMutationLocked(fh *FileHandle) bool {
 		}
 	}
 	fs.inodes.UpdateSize(fh.Ino, state.committedSize)
-	if fh.Dirty != nil && state.committedRevision > 0 {
-		fs.rebindCleanWriteBufferToRemoteLocked(fh, state.committedSize)
+	if fh.Dirty != nil {
+		if state.committedRevision > 0 {
+			fs.rebindCleanWriteBufferToRemoteLocked(fh, state.committedSize)
+		} else {
+			next := fs.newWriteBuffer(fh.Path, maxPreloadSize, fh.Dirty.PartSize())
+			if len(layerData) > 0 {
+				_, _ = next.Write(0, layerData)
+			}
+			next.ClearDirty()
+			fh.Dirty = next
+			fh.OrigSize = state.committedSize
+		}
 	}
 	clearReadTargetForLockedHandle(fh)
 	return true
@@ -14107,6 +14128,13 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 
 	size := fh.Dirty.Size()
 	if fs.layerEnabled() {
+		unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
+		defer unlockRemoteCommit()
+		if fs.discardSupersededMutationLocked(fh) {
+			fs.removeHandleOwnedStagingLocked(fh)
+			phase = "superseded-layer-mutation"
+			return gofuse.OK
+		}
 		// Freeze the upsert base BEFORE any lazy fetch. The layer branch
 		// deliberately reads the un-adopted BaseRev (expectedRevisionForHandle,
 		// not the Locked variant) and holds fh.mu for the whole branch, so a
@@ -14132,6 +14160,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			safeLogPrintf("layer flush failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
+		fs.recordCommittedMutation(fh.Ino, fh.DirtySeq, expectedRevision, size)
 		if fh.Dirty != nil {
 			fh.Dirty.ClearDirty()
 		}
@@ -15036,10 +15065,15 @@ func (fs *Dat9FS) captureHandleStagingGensLocked(fh *FileHandle) StagingGens {
 }
 
 func (fs *Dat9FS) onCommitQueueUploaded(entry *CommitEntry, committedRev int64) {
-	if fs == nil || entry == nil || fs.layerEnabled() {
+	if fs == nil || entry == nil {
 		return
 	}
 	if entry.mutationPublished {
+		return
+	}
+	if fs.layerEnabled() {
+		entry.mutationPublished = true
+		fs.recordCommittedMutation(entry.Inode, entry.MutationSeq, entry.BaseRev, entry.Size)
 		return
 	}
 	committedRev = fs.resolveCommittedMutationRevision(entry.Path, committedRev, entry.BaseRev)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1970,13 +1970,10 @@ func (fs *Dat9FS) discardSupersededMutationLocked(fh *FileHandle) bool {
 		return false
 	}
 	var layerData []byte
-	if state.committedRevision <= 0 && fs.layerEnabled() {
-		if fs.shadowStore == nil {
-			return false
-		}
-		var err error
-		layerData, err = fs.shadowStore.ReadAll(fh.Path)
-		if err != nil || int64(len(layerData)) != state.committedSize {
+	if fs.layerEnabled() {
+		var ok bool
+		layerData, ok = fs.readCommittedLayerData(fh.Path, state.committedSize)
+		if !ok {
 			return false
 		}
 	}
@@ -2003,9 +2000,7 @@ func (fs *Dat9FS) discardSupersededMutationLocked(fh *FileHandle) bool {
 	}
 	fs.inodes.UpdateSize(fh.Ino, state.committedSize)
 	if fh.Dirty != nil {
-		if state.committedRevision > 0 {
-			fs.rebindCleanWriteBufferToRemoteLocked(fh, state.committedSize)
-		} else {
+		if fs.layerEnabled() {
 			next := fs.newWriteBuffer(fh.Path, maxPreloadSize, fh.Dirty.PartSize())
 			if len(layerData) > 0 {
 				_, _ = next.Write(0, layerData)
@@ -2013,10 +2008,35 @@ func (fs *Dat9FS) discardSupersededMutationLocked(fh *FileHandle) bool {
 			next.ClearDirty()
 			fh.Dirty = next
 			fh.OrigSize = state.committedSize
+		} else if state.committedRevision > 0 {
+			fs.rebindCleanWriteBufferToRemoteLocked(fh, state.committedSize)
 		}
 	}
 	clearReadTargetForLockedHandle(fh)
 	return true
+}
+
+func (fs *Dat9FS) readCommittedLayerData(localPath string, size int64) ([]byte, bool) {
+	if fs == nil || !fs.layerEnabled() || size < 0 {
+		return nil, false
+	}
+	if fs.shadowStore != nil && fs.shadowStore.Has(localPath) {
+		if data, err := fs.shadowStore.ReadAll(localPath); err == nil && int64(len(data)) == size {
+			return data, true
+		}
+	}
+	if fs.readCache != nil {
+		if data, ok := fs.readCache.Get(localPath, 0); ok && int64(len(data)) == size {
+			return cloneBytes(data), true
+		}
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), fuseTimeout)
+	defer cancel()
+	data, err := fs.client.ReadFSLayerFile(ctx, fs.layerRef(), fs.remotePath(localPath), nil)
+	if err != nil || int64(len(data)) != size {
+		return nil, false
+	}
+	return data, true
 }
 
 func (fs *Dat9FS) removeHandleOwnedStagingLocked(fh *FileHandle) {
@@ -7030,7 +7050,7 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 					safeLogPrintf("open-unlink large snapshot failed for %s: %v", p, err)
 				}
 			}
-			if needsSnapshot && !snapshotOK {
+			if needsSnapshot && !snapshotOK && fs.gvisorCompatibilityEnabled() {
 				if snapshotErr == nil {
 					snapshotErr = syscall.EIO
 				}
@@ -13768,6 +13788,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 						if fs.layerEnabled() {
 							flushStatus = gofuse.EIO
 							safeLogPrintf("release: layer commitQueue enqueue failed for %s: %v", fh.Path, err)
+							unlockRemoteCommit()
 							return
 						}
 						if fs.gvisorCompatibilityEnabled() {
@@ -13777,6 +13798,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 							if commitErr != nil {
 								flushStatus = httpToFuseStatus(commitErr)
 								safeLogPrintf("release: synchronous sequence-preserving fallback failed for %s: %v", fh.Path, commitErr)
+								unlockRemoteCommit()
 								return
 							}
 							fs.writeBack.Remove(fh.Path)
@@ -14175,7 +14197,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			safeLogPrintf("layer flush failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
-		fs.recordCommittedMutation(fh.Ino, fh.DirtySeq, expectedRevision, size)
+		fs.recordCommittedMutation(fh.Ino, fh.DirtySeq, 0, size)
 		if fh.Dirty != nil {
 			fh.Dirty.ClearDirty()
 		}
@@ -14987,9 +15009,6 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 		return
 	}
 	fs.onCommitQueueUploaded(entry, committedRev)
-	if !fs.layerEnabled() {
-		committedRev = fs.resolveCommittedMutationRevision(entry.Path, committedRev, entry.BaseRev)
-	}
 	if fs.layerEnabled() {
 		fs.clearReadTargetsForPath(entry.Path)
 		if fs.shadowStore != nil && entry.Size <= fs.readCache.MaxFileSize() {
@@ -15080,7 +15099,7 @@ func (fs *Dat9FS) captureHandleStagingGensLocked(fh *FileHandle) StagingGens {
 }
 
 func (fs *Dat9FS) onCommitQueueUploaded(entry *CommitEntry, committedRev int64) {
-	if fs == nil || entry == nil {
+	if fs == nil || entry == nil || !fs.gvisorCompatibilityEnabled() {
 		return
 	}
 	if entry.mutationPublished {
@@ -15088,7 +15107,7 @@ func (fs *Dat9FS) onCommitQueueUploaded(entry *CommitEntry, committedRev int64) 
 	}
 	if fs.layerEnabled() {
 		entry.mutationPublished = true
-		fs.recordCommittedMutation(entry.Inode, entry.MutationSeq, entry.BaseRev, entry.Size)
+		fs.recordCommittedMutation(entry.Inode, entry.MutationSeq, 0, entry.Size)
 		return
 	}
 	committedRev = fs.resolveCommittedMutationRevision(entry.Path, committedRev, entry.BaseRev)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -964,7 +964,7 @@ func (fs *Dat9FS) commitLayerShadowLocked(ctx context.Context, fh *FileHandle, s
 		return fmt.Errorf("missing shadow for %s", fh.Path)
 	}
 	gvisorCompat := fs.gvisorCompatibilityEnabled()
-	pathLocked = pathLocked || gvisorCompat && fh.RemoteCommitUnlock != nil
+	pathLocked = pathLocked || fh.RemoteCommitUnlock != nil
 	handlePath := fh.Path
 	handleIno := fh.Ino
 	mutationSeq := fh.DirtySeq

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -963,6 +963,7 @@ func (fs *Dat9FS) commitLayerShadowLocked(ctx context.Context, fh *FileHandle, s
 	if fs.shadowStore == nil || !fs.shadowStore.Has(fh.Path) {
 		return fmt.Errorf("missing shadow for %s", fh.Path)
 	}
+	pathLocked = pathLocked || fh.RemoteCommitUnlock != nil
 	size := int64(0)
 	if fh.Dirty != nil {
 		size = fh.Dirty.Size()
@@ -12411,19 +12412,36 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 
 	size := fh.Dirty.Size()
 	if fh.ShadowSpill && fs.shadowStore != nil {
+		handlePath := fh.Path
+		handleIno := fh.Ino
+		mutationSeq := fh.DirtySeq
 		unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
-		defer unlockRemoteCommit()
+		remoteCommitReleased := false
+		defer func() {
+			if !remoteCommitReleased {
+				unlockRemoteCommit()
+			}
+		}()
 		if fs.discardSupersededMutationLocked(fh) {
 			fs.removeHandleOwnedStagingLocked(fh)
 			return gofuse.OK
 		}
-		mutationSeq := fh.DirtySeq
 		expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 		stagingGens := fs.captureHandleStagingGensLocked(fh)
 		uploadStart := time.Now()
 		fs.debugf("sync handle shadowspill upload start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
 		fh.Unlock()
-		committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevision, stagingGens.ShadowGen)
+		committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(ctx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision, stagingGens.ShadowGen)
+		var committedMutationRev int64
+		if err == nil {
+			committedMutationRev = fs.resolveCommittedMutationRevision(handlePath, committedRev, expectedRevision)
+			fs.recordCommittedMutation(handleIno, mutationSeq, committedMutationRev, size)
+			if committedMutationRev > 0 {
+				fs.refreshCommittedRevisionForOpenHandlesWithSize(handlePath, committedMutationRev, fh, size)
+			}
+		}
+		unlockRemoteCommit()
+		remoteCommitReleased = true
 		fh.Lock()
 		var uploadBytes uint64
 		if size > 0 {
@@ -12439,14 +12457,15 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 			fs.discardUnlinkedHandleStateLocked(fh)
 			return gofuse.OK
 		}
-		committedMutationRev := fs.resolveCommittedMutationRevision(fh.Path, committedRev, expectedRevision)
-		fs.recordCommittedMutation(fh.Ino, mutationSeq, committedMutationRev, size)
-		if committedMutationRev > 0 {
-			fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, committedMutationRev, fh, size)
+		if fh.Path != handlePath || fh.DirtySeq != mutationSeq {
+			return gofuse.OK
 		}
 		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			safeLogPrintf("sync handle shadowspill pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
+		}
+		if fh.Path != handlePath || fh.DirtySeq != mutationSeq {
+			return gofuse.OK
 		}
 		fh.Dirty.ClearDirty()
 		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
@@ -14297,6 +14316,9 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		perfUploadStart := fs.perfStart()
 		err = streamer.FinishStreaming(ctx, size,
 			lastPartNum, lastCp, dirtyParts)
+		recordMutationBeforeFenceRelease()
+		unlockRemoteCommit()
+		remoteCommitReleased = true
 		fh.Lock()
 		var perfUploadBytes uint64
 		if size > 0 {
@@ -14314,9 +14336,15 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			fs.discardUnlinkedHandleStateLocked(fh)
 			return gofuse.OK
 		}
+		if fh.Path != mutationPath || fh.DirtySeq != mutationSeq {
+			return gofuse.OK
+		}
 		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			safeLogPrintf("finish streaming pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
+		}
+		if fh.Path != mutationPath || fh.DirtySeq != mutationSeq {
+			return gofuse.OK
 		}
 
 		sidecarRevision := sqliteCommittedRevision(0, expectedRevision)
@@ -14372,6 +14400,9 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fh.Unlock()
 		perfUploadStart := fs.perfStart()
 		err = streamer.UploadAll(ctx, size, partSnapshots)
+		recordMutationBeforeFenceRelease()
+		unlockRemoteCommit()
+		remoteCommitReleased = true
 		fh.Lock()
 		var perfUploadBytes uint64
 		if size > 0 {
@@ -14389,9 +14420,15 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			fs.discardUnlinkedHandleStateLocked(fh)
 			return gofuse.OK
 		}
+		if fh.Path != mutationPath || fh.DirtySeq != mutationSeq {
+			return gofuse.OK
+		}
 		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			safeLogPrintf("upload all pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
+		}
+		if fh.Path != mutationPath || fh.DirtySeq != mutationSeq {
+			return gofuse.OK
 		}
 
 		sidecarRevision := sqliteCommittedRevision(0, expectedRevision)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -15039,7 +15039,14 @@ func (fs *Dat9FS) onCommitQueueUploaded(entry *CommitEntry, committedRev int64) 
 	if fs == nil || entry == nil || fs.layerEnabled() {
 		return
 	}
+	if entry.mutationPublished {
+		return
+	}
 	committedRev = fs.resolveCommittedMutationRevision(entry.Path, committedRev, entry.BaseRev)
+	if committedRev <= 0 {
+		return
+	}
+	entry.mutationPublished = true
 	fs.recordCommittedMutation(entry.Inode, entry.MutationSeq, committedRev, entry.Size)
 	if committedRev > 0 {
 		fs.refreshCommittedRevisionForOpenHandlesWithSize(entry.Path, committedRev, nil, entry.Size)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -9831,7 +9831,10 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 		return st
 	}
 	if oldInfo.special {
-		return fs.renameMetadataOnlySpecial(ctx, input, oldP, newP, newInfo)
+		specialRenameCtx, specialRenameCancel := fs.namespaceMutationCommitContext(ctx)
+		st := fs.renameMetadataOnlySpecial(specialRenameCtx, input, oldP, newP, newInfo)
+		specialRenameCancel()
+		return st
 	}
 
 	pendingRename, err := fs.renamePendingNewCommit(ctx, input, oldP, newP)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7393,8 +7393,20 @@ func (fs *Dat9FS) openHandleEntry(p string) (*InodeEntry, bool) {
 	return nil, false
 }
 
+func (fs *Dat9FS) inodeHasPendingMutationState(ino uint64, fallbackPath string, includeFallbackQueue bool) bool {
+	if entry, ok := fs.inodes.GetEntry(ino); ok && entry != nil {
+		for alias := range entry.Paths {
+			if fs.hasPendingLocalState(alias) || (alias != fallbackPath || includeFallbackQueue) && fs.hasQueuedCommit(alias) {
+				return true
+			}
+		}
+		return false
+	}
+	return fs.hasPendingLocalState(fallbackPath) || includeFallbackQueue && fs.hasQueuedCommit(fallbackPath)
+}
+
 func (fs *Dat9FS) cleanupReleasedInode(ino uint64, p string) {
-	if fs.hasOpenHandle(ino, p) || fs.hasPendingLocalState(p) || fs.hasQueuedCommit(p) {
+	if fs.hasOpenHandle(ino, p) || fs.inodeHasPendingMutationState(ino, p, true) {
 		return
 	}
 	fs.forgetMutationState(ino)
@@ -7405,7 +7417,7 @@ func (fs *Dat9FS) cleanupReleasedInode(ino uint64, p string) {
 }
 
 func (fs *Dat9FS) cleanupCommittedInode(ino uint64, p string) {
-	if fs.hasOpenHandle(ino, p) || fs.hasPendingLocalState(p) {
+	if fs.hasOpenHandle(ino, p) || fs.inodeHasPendingMutationState(ino, p, false) {
 		return
 	}
 	fs.forgetMutationState(ino)
@@ -12208,17 +12220,17 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 	// The commit is authoritative for the storage class: direct PUT lands
 	// inline, PATCH keeps S3, and a full upload re-splits by size.
 	fs.adoptCommittedStorageClassLocked(fh, size)
+	sidecarRevision := fs.resolveCommittedMutationRevision(fh.Path, committedRev, expectedRevision)
+	fs.recordCommittedMutation(fh.Ino, mutationSeq, sidecarRevision, size)
+	if sidecarRevision > 0 {
+		fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, sidecarRevision, fh, size)
+	}
 	if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 		safeLogPrintf("write-sync pending chmod failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}
 
-	sidecarRevision := sqliteCommittedRevision(committedRev, expectedRevision)
 	sidecarCached := fs.cacheCommittedSQLitePersistentJournalLocked(fh, sidecarRevision)
-	fs.recordCommittedMutation(fh.Ino, mutationSeq, sidecarRevision, size)
-	if fs.gvisorCompatibilityEnabled() && sidecarRevision > 0 {
-		fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, sidecarRevision, fh, size)
-	}
 	fh.Dirty.ClearDirty()
 	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 	fh.DirtySeq = 0
@@ -12985,6 +12997,8 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		handleIsNew := fh.IsNew
 		handlePath := fh.Path
 		stagingGens := fs.captureHandleStagingGensLocked(fh)
+		handleIno := fh.Ino
+		mutationSeq := fh.DirtySeq
 		// B4: serialize with Unlink's remote DELETE — hold the per-path
 		// remoteCommitLock across the network upload while releasing fh.mu,
 		// exactly like flushHandle Path 2. Without it Unlink can DELETE and
@@ -13006,6 +13020,13 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		if err == nil && committedRev == 0 {
 			if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok && syntheticRev > 0 {
 				fs.recordCommittedRevision(handlePath, syntheticRev)
+			}
+		}
+		if err == nil {
+			mutationRevision := fs.resolveCommittedMutationRevision(handlePath, committedRev, expectedRevision)
+			fs.recordCommittedMutation(handleIno, mutationSeq, mutationRevision, size)
+			if mutationRevision > 0 {
+				fs.refreshCommittedRevisionForOpenHandlesWithSize(handlePath, mutationRevision, fh, size)
 			}
 		}
 		unlockRemoteCommit()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1987,7 +1987,7 @@ func (fs *Dat9FS) discardSupersededMutationLocked(fh *FileHandle) bool {
 		fh.BaseRev = state.committedRevision
 		fs.inodes.UpdateRevision(fh.Ino, state.committedRevision)
 		if fh.Streamer != nil {
-			fh.Streamer.RefreshExpectedRevision(expectedRevisionForHandle(fh))
+			fh.Streamer.ResetForNextWrite(expectedRevisionForHandle(fh))
 		}
 	}
 	fs.inodes.UpdateSize(fh.Ino, state.committedSize)
@@ -9472,9 +9472,37 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 
 	unlockRemoteCommit := func() {}
 	if fs.commitQueue != nil {
-		unlockRemoteCommit = fs.lockWritableRemoteCommitPath(newP)
+		first, second := oldP, newP
+		if second < first {
+			first, second = second, first
+		}
+		unlockFirst := fs.lockWritableRemoteCommitPath(first)
+		if first == second {
+			unlockRemoteCommit = unlockFirst
+		} else {
+			unlockSecond := fs.lockWritableRemoteCommitPath(second)
+			unlockRemoteCommit = func() {
+				unlockSecond()
+				unlockFirst()
+			}
+		}
 	}
 	defer unlockRemoteCommit()
+	if fs.shadowStore != nil {
+		shadowGen := fs.shadowStore.ActiveGeneration(oldP)
+		for _, fh := range fs.openHandles.SnapshotPath(oldP) {
+			if fh == nil {
+				continue
+			}
+			fh.Lock()
+			if shadowGen != 0 && fh.ShadowStageGen == shadowGen {
+				mutationSeq = fh.ShadowStageSeq
+				fh.Unlock()
+				break
+			}
+			fh.Unlock()
+		}
+	}
 
 	if fs.layerEnabled() && fs.shadowStore != nil && !fs.shadowStore.Has(oldP) {
 		return pendingRenameRemoteFallback, nil
@@ -12321,6 +12349,11 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		mutationSeq := fh.DirtySeq
 		unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
 		defer unlockRemoteCommit()
+		if fs.discardSupersededMutationLocked(fh) {
+			fs.removeHandleOwnedStagingLocked(fh)
+			return gofuse.OK
+		}
+		mutationSeq = fh.DirtySeq
 		expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 		stagingGens := fs.captureHandleStagingGensLocked(fh)
 		uploadStart := time.Now()
@@ -13558,6 +13591,11 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 					} else {
 						fallbackCommittedRev = committedRev
 						fh.Lock()
+						mutationRevision := fs.resolveCommittedMutationRevision(fh.Path, committedRev, expectedRevision)
+						fs.recordCommittedMutation(fh.Ino, mutationSeq, mutationRevision, size)
+						if mutationRevision > 0 {
+							fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, mutationRevision, fh, size)
+						}
 						if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 							flushStatus = httpToFuseStatus(err)
 							preservePendingModeOnReleaseFailure = true
@@ -13902,6 +13940,11 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 			safeLogPrintf("debounced flush failed for %s: %v", filePath, err)
 			return
 		}
+		mutationRevision := fs.resolveCommittedMutationRevision(filePath, committedRev, expectedRevision)
+		fs.recordCommittedMutation(ino, snapshotSeq, mutationRevision, int64(len(data)))
+		if mutationRevision > 0 {
+			fs.refreshCommittedRevisionForOpenHandlesWithSize(filePath, mutationRevision, handle, int64(len(data)))
+		}
 		modeCtx, modeCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		modeErr := fs.applyPendingModeForHandleLocked(modeCtx, handle)
 		modeCancel()
@@ -13915,7 +13958,6 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		// with Path 2's approach (lines 11754-11770).
 		if committedRev > 0 {
 			fs.recordCommittedRevision(filePath, committedRev)
-			fs.recordCommittedMutation(ino, snapshotSeq, committedRev, int64(len(data)))
 			handle.IsNew = false
 			handle.BaseRev = committedRev
 			fs.inodes.UpdateSize(ino, int64(len(data)))
@@ -13926,9 +13968,6 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 				handle.ZeroBase = false
 			}
 		} else {
-			if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok {
-				fs.recordCommittedMutation(ino, snapshotSeq, syntheticRev, int64(len(data)))
-			}
 			fs.finalizeHandleFlushLocked(handle, expectedRevision)
 		}
 		// Release remoteCommitLock after recording revision, before
@@ -14884,9 +14923,9 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 	if entry == nil {
 		return
 	}
+	fs.onCommitQueueUploaded(entry, committedRev)
 	if !fs.layerEnabled() {
 		committedRev = fs.resolveCommittedMutationRevision(entry.Path, committedRev, entry.BaseRev)
-		fs.recordCommittedMutation(entry.Inode, entry.MutationSeq, committedRev, entry.Size)
 	}
 	if fs.layerEnabled() {
 		fs.clearReadTargetsForPath(entry.Path)
@@ -14974,6 +15013,17 @@ func (fs *Dat9FS) captureHandleStagingGensLocked(fh *FileHandle) StagingGens {
 		WriteBackGen:    fh.WriteBackGen,
 		PendingIndexGen: fh.PendingIndexGen,
 		ShadowGen:       fh.ShadowStageGen,
+	}
+}
+
+func (fs *Dat9FS) onCommitQueueUploaded(entry *CommitEntry, committedRev int64) {
+	if fs == nil || entry == nil || fs.layerEnabled() {
+		return
+	}
+	committedRev = fs.resolveCommittedMutationRevision(entry.Path, committedRev, entry.BaseRev)
+	fs.recordCommittedMutation(entry.Inode, entry.MutationSeq, committedRev, entry.Size)
+	if committedRev > 0 {
+		fs.refreshCommittedRevisionForOpenHandlesWithSize(entry.Path, committedRev, nil, entry.Size)
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -12313,14 +12313,14 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 			fs.discardUnlinkedHandleStateLocked(fh)
 			return gofuse.OK
 		}
+		committedMutationRev := fs.resolveCommittedMutationRevision(fh.Path, committedRev, expectedRevision)
+		fs.recordCommittedMutation(fh.Ino, mutationSeq, committedMutationRev, size)
+		if committedMutationRev > 0 {
+			fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, committedMutationRev, fh, size)
+		}
 		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			safeLogPrintf("sync handle shadowspill pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
-		}
-		committedMutationRev := sqliteCommittedRevision(committedRev, expectedRevision)
-		fs.recordCommittedMutation(fh.Ino, mutationSeq, committedMutationRev, size)
-		if fs.gvisorCompatibilityEnabled() && committedMutationRev > 0 {
-			fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, committedMutationRev, fh, size)
 		}
 		fh.Dirty.ClearDirty()
 		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
@@ -12399,16 +12399,15 @@ func (fs *Dat9FS) createEmptyHandleRemoteLocked(ctx context.Context, fh *FileHan
 		safeLogPrintf("sync empty create failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}
+	committedMutationRev := fs.resolveCommittedMutationRevision(fh.Path, committedRev, expectedRevision)
+	fs.recordCommittedMutation(fh.Ino, mutationSeq, committedMutationRev, 0)
+	if committedMutationRev > 0 {
+		fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, committedMutationRev, fh, 0)
+	}
 	if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 		safeLogPrintf("sync empty create pending chmod failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
 	}
-	committedMutationRev := sqliteCommittedRevision(committedRev, expectedRevision)
-	fs.recordCommittedMutation(fh.Ino, mutationSeq, committedMutationRev, 0)
-	if fs.gvisorCompatibilityEnabled() && committedMutationRev > 0 {
-		fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, committedMutationRev, fh, 0)
-	}
-
 	if fh.DirtySeq != 0 {
 		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 		fh.DirtySeq = 0
@@ -13643,9 +13642,21 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 							safeLogPrintf("release: layer commitQueue enqueue failed for %s: %v", fh.Path, err)
 							return
 						}
-						// Backpressure — fall back to legacy uploader.
-						fs.debugf("release uploader submit fallback path=%s", fh.Path)
-						fs.uploader.Submit(fh.Path)
+						if fs.gvisorCompatibilityEnabled() {
+							uploadCtx, uploadCancel := context.WithTimeout(context.Background(), releaseTimeout(commitSize))
+							commitErr := fs.commitQueue.commitNowPathLocked(uploadCtx, entry)
+							uploadCancel()
+							if commitErr != nil {
+								flushStatus = httpToFuseStatus(commitErr)
+								safeLogPrintf("release: synchronous sequence-preserving fallback failed for %s: %v", fh.Path, commitErr)
+								return
+							}
+							fs.writeBack.Remove(fh.Path)
+						} else {
+							// Preserve the legacy non-gVisor backpressure behavior.
+							fs.debugf("release uploader submit fallback path=%s", fh.Path)
+							fs.uploader.Submit(fh.Path)
+						}
 					} else {
 						// CommitQueue owns the upload via shadow; remove the
 						// writeBack .dat/.meta snapshot so it doesn't leak or

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -59,6 +59,7 @@ type Dat9FS struct {
 	readSlots           chan struct{}
 	dirtyMu             sync.Mutex
 	dirtyInodes         map[uint64]dirtyInodeState
+	mutationInodes      map[uint64]inodeMutationState
 	dirtySeq            uint64
 	kernelCacheBypassMu sync.Mutex
 	kernelCacheBypass   map[uint64]kernelCacheBypassMarker
@@ -319,6 +320,13 @@ type dirtyInodeState struct {
 	seq  uint64
 }
 
+type inodeMutationState struct {
+	latestSeq         uint64
+	committedSeq      uint64
+	committedRevision int64
+	committedSize     int64
+}
+
 type layerSymlinkState struct {
 	Target string
 	Mode   uint32
@@ -528,6 +536,23 @@ func fuseCtxWithTimeout(cancel <-chan struct{}, timeout time.Duration) (context.
 func detachedSharedReadCtx(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if timeout <= 0 {
 		timeout = fuseTimeout
+	}
+	return context.WithTimeout(context.WithoutCancel(parent), timeout)
+}
+
+func (fs *Dat9FS) namespaceMutationCommitContext(parent context.Context) (context.Context, context.CancelFunc) {
+	if !fs.gvisorCompatibilityEnabled() {
+		return parent, func() {}
+	}
+	timeout := fuseTimeout
+	if deadline, ok := parent.Deadline(); ok {
+		remaining := time.Until(deadline)
+		if remaining < timeout {
+			timeout = remaining
+		}
+	}
+	if timeout <= 0 {
+		timeout = time.Nanosecond
 	}
 	return context.WithTimeout(context.WithoutCancel(parent), timeout)
 }
@@ -948,6 +973,7 @@ func (fs *Dat9FS) commitLayerShadowLocked(ctx context.Context, fh *FileHandle, s
 	entry := &CommitEntry{
 		Path:        fh.Path,
 		Inode:       fh.Ino,
+		MutationSeq: fh.DirtySeq,
 		BaseRev:     expectedRevision,
 		Size:        size,
 		Kind:        fs.pendingKindForHandle(fh),
@@ -1839,6 +1865,14 @@ func (fs *Dat9FS) markDirtySize(ino uint64, size int64) uint64 {
 	fs.dirtySeq++
 	seq := fs.dirtySeq
 	fs.dirtyInodes[ino] = dirtyInodeState{size: size, seq: seq}
+	if fs.gvisorCompatibilityEnabled() {
+		if fs.mutationInodes == nil {
+			fs.mutationInodes = make(map[uint64]inodeMutationState)
+		}
+		state := fs.mutationInodes[ino]
+		state.latestSeq = seq
+		fs.mutationInodes[ino] = state
+	}
 	return seq
 }
 
@@ -1854,6 +1888,94 @@ func (fs *Dat9FS) clearDirtySize(ino uint64, seq uint64) {
 	if ok && state.seq == seq {
 		delete(fs.dirtyInodes, ino)
 	}
+}
+
+func (fs *Dat9FS) gvisorCompatibilityEnabled() bool {
+	return fs != nil && fs.opts != nil && fs.opts.GVisorCompat
+}
+
+func (fs *Dat9FS) recordCommittedMutation(ino uint64, seq uint64, revision int64, size int64) {
+	if !fs.gvisorCompatibilityEnabled() || ino == 0 || seq == 0 {
+		return
+	}
+
+	fs.dirtyMu.Lock()
+	if fs.mutationInodes == nil {
+		fs.mutationInodes = make(map[uint64]inodeMutationState)
+	}
+	state := fs.mutationInodes[ino]
+	if seq >= state.committedSeq {
+		state.committedSeq = seq
+		state.committedRevision = revision
+		state.committedSize = size
+	}
+	if seq > state.latestSeq {
+		state.latestSeq = seq
+	}
+	fs.mutationInodes[ino] = state
+	if dirty, ok := fs.dirtyInodes[ino]; ok && dirty.seq <= state.committedSeq {
+		delete(fs.dirtyInodes, ino)
+	}
+	fs.dirtyMu.Unlock()
+}
+
+func (fs *Dat9FS) committedMutation(ino uint64) (inodeMutationState, bool) {
+	if !fs.gvisorCompatibilityEnabled() || ino == 0 {
+		return inodeMutationState{}, false
+	}
+
+	fs.dirtyMu.Lock()
+	state, ok := fs.mutationInodes[ino]
+	fs.dirtyMu.Unlock()
+	return state, ok && state.committedSeq != 0
+}
+
+// discardSupersededMutationLocked turns a handle snapshot that is no newer
+// than the committed inode watermark into a clean view of the committed file.
+// Caller must hold fh.mu. Shared path-keyed staging is intentionally untouched.
+func (fs *Dat9FS) discardSupersededMutationLocked(fh *FileHandle) bool {
+	if fh == nil || fh.DirtySeq == 0 {
+		return false
+	}
+	state, ok := fs.committedMutation(fh.Ino)
+	if !ok || fh.DirtySeq > state.committedSeq {
+		return false
+	}
+
+	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+	if fh.Dirty != nil {
+		fh.Dirty.ClearDirty()
+	}
+	fh.DirtySeq = 0
+	fh.WriteBackSeq = 0
+	fh.ShadowReady = false
+	fh.ShadowSpill = false
+	fh.ShadowCommitReady = false
+	fh.ShadowCommitSeq = 0
+	fh.ZeroBase = false
+	fh.IsNew = false
+	if state.committedRevision > 0 {
+		fh.BaseRev = state.committedRevision
+		fs.inodes.UpdateRevision(fh.Ino, state.committedRevision)
+		if fh.Streamer != nil {
+			fh.Streamer.RefreshExpectedRevision(expectedRevisionForHandle(fh))
+		}
+	}
+	fs.inodes.UpdateSize(fh.Ino, state.committedSize)
+	if fh.Dirty != nil && state.committedRevision > 0 {
+		fs.rebindCleanWriteBufferToRemoteLocked(fh, state.committedSize)
+	}
+	clearReadTargetForLockedHandle(fh)
+	return true
+}
+
+func (fs *Dat9FS) forgetMutationState(ino uint64) {
+	if ino == 0 {
+		return
+	}
+	fs.dirtyMu.Lock()
+	delete(fs.mutationInodes, ino)
+	fs.dirtyMu.Unlock()
 }
 
 func shouldRefreshHandleAfterPathTruncate(fh *FileHandle) bool {
@@ -2116,6 +2238,7 @@ func (fs *Dat9FS) refreshCommittedRevisionForOpenHandles(path string, revision i
 		if !fh.TryLock() {
 			continue
 		}
+		fs.discardSupersededMutationLocked(fh)
 		if fs.handleCanAdoptCommittedRevisionLocked(fh) {
 			cleanBuffer := fh.Dirty != nil
 			fh.IsNew = false
@@ -2149,6 +2272,7 @@ func (fs *Dat9FS) refreshCommittedRevisionForOpenHandlesWithSize(path string, re
 		if !fh.TryLock() {
 			continue
 		}
+		fs.discardSupersededMutationLocked(fh)
 		if fs.handleCanAdoptCommittedRevisionLocked(fh) {
 			cleanBuffer := fh.Dirty != nil
 			fh.IsNew = false
@@ -3591,6 +3715,7 @@ func (fs *Dat9FS) enqueueStagedShadowCommitLocked(fh *FileHandle) error {
 	entry := &CommitEntry{
 		Path:        fh.Path,
 		Inode:       fh.Ino,
+		MutationSeq: fh.DirtySeq,
 		BaseRev:     expectedRevision,
 		Size:        size,
 		Kind:        fs.pendingKindForHandle(fh),
@@ -4823,8 +4948,9 @@ func (fs *Dat9FS) snapshotOpenHandlesForPath(ctx context.Context, localPath stri
 		return nil
 	}
 	type candidate struct {
-		fh   *FileHandle
-		size int64
+		fh       *FileHandle
+		size     int64
+		revision int64
 	}
 	var candidates []candidate
 	for _, fh := range fs.openHandles.SnapshotPath(localPath) {
@@ -4832,6 +4958,13 @@ func (fs *Dat9FS) snapshotOpenHandlesForPath(ctx context.Context, localPath stri
 			continue
 		}
 		inodeSize := fs.inodeSnapshotSize(fh.Ino)
+		inodeRevision := int64(0)
+		if fs.gvisorCompatibilityEnabled() {
+			entry, ok := fs.inodes.GetEntry(fh.Ino)
+			if ok && entry != nil {
+				inodeRevision = entry.Revision
+			}
+		}
 		fh.Lock()
 		handlePath := fh.Path
 		size, eligible := unlinkSnapshotSizeLocked(fh, inodeSize)
@@ -4840,22 +4973,27 @@ func (fs *Dat9FS) snapshotOpenHandlesForPath(ctx context.Context, localPath stri
 		if !eligible || handlePath != localPath || size < 0 || size > maxPathTruncateInMemoryBytes {
 			continue
 		}
-		candidates = append(candidates, candidate{fh: fh, size: size})
+		candidates = append(candidates, candidate{fh: fh, size: size, revision: inodeRevision})
 	}
 	if len(candidates) == 0 {
 		return nil
 	}
 
-	snapshots := make(map[int64][]byte)
+	type snapshotKey struct {
+		size     int64
+		revision int64
+	}
+	snapshots := make(map[snapshotKey][]byte)
 	for _, cand := range candidates {
-		data, ok := snapshots[cand.size]
+		key := snapshotKey{size: cand.size, revision: cand.revision}
+		data, ok := snapshots[key]
 		if !ok {
 			var err error
-			data, err = fs.readOpenHandleSnapshot(ctx, localPath, cand.size)
+			data, err = fs.readOpenHandleSnapshot(ctx, localPath, cand.size, cand.revision)
 			if err != nil {
 				return err
 			}
-			snapshots[cand.size] = data
+			snapshots[key] = data
 		}
 
 		inodeSize := fs.inodeSnapshotSize(cand.fh.Ino)
@@ -4870,7 +5008,7 @@ func (fs *Dat9FS) snapshotOpenHandlesForPath(ctx context.Context, localPath stri
 	return nil
 }
 
-func (fs *Dat9FS) readOpenHandleSnapshot(ctx context.Context, localPath string, size int64) ([]byte, error) {
+func (fs *Dat9FS) readOpenHandleSnapshot(ctx context.Context, localPath string, size int64, revision int64) ([]byte, error) {
 	if size < 0 || size > maxPathTruncateInMemoryBytes {
 		return nil, fmt.Errorf("open-handle snapshot size out of range for %s: %d", localPath, size)
 	}
@@ -4884,6 +5022,11 @@ func (fs *Dat9FS) readOpenHandleSnapshot(ctx context.Context, localPath string, 
 	}
 	if fs.writeBack != nil {
 		if data, ok := fs.writeBack.getView(localPath); ok {
+			return cloneBytes(data), nil
+		}
+	}
+	if fs.gvisorCompatibilityEnabled() && fs.readCache != nil && revision > 0 {
+		if data, ok := fs.readCache.Get(localPath, revision); ok && int64(len(data)) == size {
 			return cloneBytes(data), nil
 		}
 	}
@@ -7177,6 +7320,7 @@ func (fs *Dat9FS) cleanupReleasedInode(ino uint64, p string) {
 	if fs.hasOpenHandle(ino, p) || fs.hasPendingLocalState(p) || fs.hasQueuedCommit(p) {
 		return
 	}
+	fs.forgetMutationState(ino)
 	// Concurrent Release/commit cleanup for the same path is safe here:
 	// RemoveFileIfUnreferenced holds the inode map lock and is idempotent when
 	// another goroutine already removed the forgotten regular-file mapping.
@@ -7187,6 +7331,7 @@ func (fs *Dat9FS) cleanupCommittedInode(ino uint64, p string) {
 	if fs.hasOpenHandle(ino, p) || fs.hasPendingLocalState(p) {
 		return
 	}
+	fs.forgetMutationState(ino)
 	fs.inodes.RemoveFileIfUnreferenced(ino)
 }
 
@@ -7902,6 +8047,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 			if ok && fh.Dirty != nil {
 				var abortStreamer func()
 				fh.Lock()
+				fs.discardSupersededMutationLocked(fh)
 				var err error
 				abortStreamer, err = fs.truncateWritableHandleLocked(fh, newSize)
 				if err != nil {
@@ -8733,11 +8879,15 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	if !pendingNew {
 		// File existed on server (or unknown) — issue remote DELETE.
 		// Tolerate 404 in case it was already deleted.
-		ctx, cf := fuseCtx(cancel)
+		deleteCtx, deleteCancel := fuseCtx(cancel)
+		if fs.gvisorCompatibilityEnabled() {
+			deleteCancel()
+			deleteCtx, deleteCancel = fs.namespaceMutationCommitContext(ctx)
+		}
 		deleteStart := time.Now()
 		fs.debugf("unlink remote delete start path=%s", childP)
-		err := fs.deleteRemoteFileWithInterruptRecovery(ctx, childP)
-		cf()
+		err := fs.deleteRemoteFileWithInterruptRecovery(deleteCtx, childP)
+		deleteCancel()
 		fs.debugDurationf(deleteStart, 0, "unlink remote delete done path=%s err=%v", childP, err)
 		if err != nil {
 			if !isNotFoundErr(err) {
@@ -9194,7 +9344,10 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 			return pendingRenameHandled, oldExistsErr
 		}
 		if oldExistsRemote {
-			if err := fs.renameRemoteWithTransientRetry(ctx, oldP, newP); err != nil {
+			renameCtx, renameCancel := fs.namespaceMutationCommitContext(ctx)
+			err := fs.renameRemoteWithTransientRetry(renameCtx, oldP, newP)
+			renameCancel()
+			if err != nil {
 				return pendingRenameHandled, err
 			}
 			if fs.shadowStore != nil {
@@ -9517,11 +9670,14 @@ func (fs *Dat9FS) Rename(cancel <-chan struct{}, input *gofuse.RenameIn, oldName
 		}
 	}
 
-	if err := fs.renameRemoteWithTransientRetry(ctx, oldP, newP); err != nil {
-		if handled, st := fs.renameRemoteFileToMissingTargetFallback(ctx, input, oldInfo, newInfo, err); handled {
+	renameCtx, renameCancel := fs.namespaceMutationCommitContext(ctx)
+	renameErr := fs.renameRemoteWithTransientRetry(renameCtx, oldP, newP)
+	renameCancel()
+	if renameErr != nil {
+		if handled, st := fs.renameRemoteFileToMissingTargetFallback(ctx, input, oldInfo, newInfo, renameErr); handled {
 			return st
 		}
-		return httpToFuseStatus(err)
+		return httpToFuseStatus(renameErr)
 	}
 	if pendingRename == pendingRenameRemoteFallbackCleanupOld {
 		if fs.shadowStore != nil {
@@ -11671,6 +11827,7 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 
 	unlockRemoteCommit := fs.lockHandleRemoteCommitPathLocked(fh)
 	defer unlockRemoteCommit()
+	fs.discardSupersededMutationLocked(fh)
 	fs.adoptCommittedRevisionLocked(fh)
 
 	if fh.Dirty == nil {
@@ -11831,6 +11988,7 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 	}
 
 	size := fh.Dirty.Size()
+	mutationSeq := fh.DirtySeq
 	unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
 	defer unlockRemoteCommit()
 	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
@@ -11980,6 +12138,10 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 
 	sidecarRevision := sqliteCommittedRevision(committedRev, expectedRevision)
 	sidecarCached := fs.cacheCommittedSQLitePersistentJournalLocked(fh, sidecarRevision)
+	fs.recordCommittedMutation(fh.Ino, mutationSeq, sidecarRevision, size)
+	if fs.gvisorCompatibilityEnabled() && sidecarRevision > 0 {
+		fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, sidecarRevision, fh, size)
+	}
 	fh.Dirty.ClearDirty()
 	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 	fh.DirtySeq = 0
@@ -12036,6 +12198,7 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 
 	size := fh.Dirty.Size()
 	if fh.ShadowSpill && fs.shadowStore != nil {
+		mutationSeq := fh.DirtySeq
 		unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
 		defer unlockRemoteCommit()
 		expectedRevision := fs.expectedRevisionForHandleLocked(fh)
@@ -12062,6 +12225,11 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			safeLogPrintf("sync handle shadowspill pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
+		}
+		committedMutationRev := sqliteCommittedRevision(committedRev, expectedRevision)
+		fs.recordCommittedMutation(fh.Ino, mutationSeq, committedMutationRev, size)
+		if fs.gvisorCompatibilityEnabled() && committedMutationRev > 0 {
+			fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, committedMutationRev, fh, size)
 		}
 		fh.Dirty.ClearDirty()
 		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
@@ -12124,6 +12292,7 @@ func (fs *Dat9FS) createEmptyHandleRemoteLocked(ctx context.Context, fh *FileHan
 		return gofuse.OK
 	}
 
+	mutationSeq := fh.DirtySeq
 	unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
 	defer unlockRemoteCommit()
 	writeStart := time.Now()
@@ -12142,6 +12311,11 @@ func (fs *Dat9FS) createEmptyHandleRemoteLocked(ctx context.Context, fh *FileHan
 	if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 		safeLogPrintf("sync empty create pending chmod failed for %s: %v", fh.Path, err)
 		return httpToFuseStatus(err)
+	}
+	committedMutationRev := sqliteCommittedRevision(committedRev, expectedRevision)
+	fs.recordCommittedMutation(fh.Ino, mutationSeq, committedMutationRev, 0)
+	if fs.gvisorCompatibilityEnabled() && committedMutationRev > 0 {
+		fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, committedMutationRev, fh, 0)
 	}
 
 	if fh.DirtySeq != 0 {
@@ -12251,6 +12425,10 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 	if fh.Unlinked {
 		phase = "unlinked-discard"
 		fs.discardUnlinkedHandleStateLocked(fh)
+		return gofuse.OK
+	}
+	if fs.discardSupersededMutationLocked(fh) {
+		phase = "superseded-mutation"
 		return gofuse.OK
 	}
 
@@ -12594,6 +12772,10 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		fs.discardUnlinkedHandleStateLocked(fh)
 		return gofuse.OK
 	}
+	if fs.discardSupersededMutationLocked(fh) {
+		phase = "superseded-mutation"
+		return gofuse.OK
+	}
 
 	// Interactive mode: Fsync = local durable only. Shadow file + journal
 	// ensure crash safety. Remote commit happens asynchronously.
@@ -12793,13 +12975,14 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 			payloadBaseRev := fh.BaseRev
 			entry := &CommitEntry{
-				Path:    fh.Path,
-				Inode:   fh.Ino,
-				BaseRev: expectedRevision,
-				Size:    size,
-				Kind:    fs.pendingKindForHandle(fh),
-				Mode:    mode,
-				HasMode: hasMode,
+				Path:        fh.Path,
+				Inode:       fh.Ino,
+				MutationSeq: fh.DirtySeq,
+				BaseRev:     expectedRevision,
+				Size:        size,
+				Kind:        fs.pendingKindForHandle(fh),
+				Mode:        mode,
+				HasMode:     hasMode,
 			}
 			fs.bindCommitEntryToHandleLocked(entry, fh, payloadBaseRev)
 			uploadStart := time.Now()
@@ -13090,6 +13273,11 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			fh.Unlock()
 			return
 		}
+		if fs.discardSupersededMutationLocked(fh) {
+			phase = "superseded-mutation"
+			fh.Unlock()
+			return
+		}
 		fh.Unlock()
 
 		// Cancel any pending debounce for this path — Release always flushes immediately.
@@ -13139,6 +13327,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				fh.Unlock()
 				return
 			}
+			mutationSeq := fh.DirtySeq
 			size := fh.Dirty.Size()
 			mode, hasMode := fs.modeForPendingHandle(fh)
 			expectedRevision := fs.expectedRevisionForHandleLocked(fh)
@@ -13146,6 +13335,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			entry := &CommitEntry{
 				Path:        fh.Path,
 				Inode:       fh.Ino,
+				MutationSeq: mutationSeq,
 				BaseRev:     expectedRevision,
 				Size:        size,
 				Kind:        PendingOverwrite,
@@ -13269,13 +13459,14 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				payloadBaseRev := fh.BaseRev
 				size := fh.Dirty.Size()
 				entry := &CommitEntry{
-					Path:    fh.Path,
-					Inode:   fh.Ino,
-					BaseRev: expectedRevision,
-					Size:    size,
-					Kind:    PendingOverwrite,
-					Mode:    mode,
-					HasMode: hasMode,
+					Path:        fh.Path,
+					Inode:       fh.Ino,
+					MutationSeq: fh.DirtySeq,
+					BaseRev:     expectedRevision,
+					Size:        size,
+					Kind:        PendingOverwrite,
+					Mode:        mode,
+					HasMode:     hasMode,
 				}
 				if fh.IsNew {
 					entry.Kind = PendingNew
@@ -13531,6 +13722,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		// with Path 2's approach (lines 11754-11770).
 		if committedRev > 0 {
 			fs.recordCommittedRevision(filePath, committedRev)
+			fs.recordCommittedMutation(ino, snapshotSeq, committedRev, int64(len(data)))
 			handle.IsNew = false
 			handle.BaseRev = committedRev
 			fs.inodes.UpdateSize(ino, int64(len(data)))
@@ -13541,6 +13733,9 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 				handle.ZeroBase = false
 			}
 		} else {
+			if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok {
+				fs.recordCommittedMutation(ino, snapshotSeq, syntheticRev, int64(len(data)))
+			}
 			fs.finalizeHandleFlushLocked(handle, expectedRevision)
 		}
 		// Release remoteCommitLock after recording revision, before
@@ -13642,6 +13837,10 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.discardUnlinkedHandleStateLocked(fh)
 		return gofuse.OK
 	}
+	if fs.discardSupersededMutationLocked(fh) {
+		phase = "superseded-mutation"
+		return gofuse.OK
+	}
 	if fs.clearStaleSQLitePersistentJournalEmptyCreateLocked(fh) {
 		phase = "stale-sqlite-sidecar-empty-create"
 		return gofuse.OK
@@ -13650,6 +13849,20 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		phase = "no-dirty-parts"
 		return gofuse.OK
 	}
+	mutationPath := fh.Path
+	mutationIno := fh.Ino
+	mutationSeq := fh.DirtySeq
+	mutationSize := fh.Dirty.Size()
+	defer func() {
+		if !fs.gvisorCompatibilityEnabled() || status != gofuse.OK || fs.layerEnabled() || mutationSeq == 0 || fh.Path != mutationPath {
+			return
+		}
+		revision := fs.latestCommittedRevision(mutationPath)
+		fs.recordCommittedMutation(mutationIno, mutationSeq, revision, mutationSize)
+		if revision > 0 {
+			fs.refreshCommittedRevisionForOpenHandlesWithSize(mutationPath, revision, fh, mutationSize)
+		}
+	}()
 
 	size := fh.Dirty.Size()
 	if fs.layerEnabled() {
@@ -14466,6 +14679,9 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 	}
 	if entry == nil {
 		return
+	}
+	if !fs.layerEnabled() {
+		fs.recordCommittedMutation(entry.Inode, entry.MutationSeq, committedRev, entry.Size)
 	}
 	if fs.layerEnabled() {
 		fs.clearReadTargetsForPath(entry.Path)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -956,7 +956,7 @@ func (fs *Dat9FS) upsertLayerRename(ctx context.Context, oldLocalPath, newLocalP
 	return nil
 }
 
-func (fs *Dat9FS) commitLayerShadowLocked(ctx context.Context, fh *FileHandle, shadowSpill bool) error {
+func (fs *Dat9FS) commitLayerShadowLocked(ctx context.Context, fh *FileHandle, shadowSpill, pathLocked bool) error {
 	if fs.commitQueue == nil {
 		return fmt.Errorf("missing commit queue")
 	}
@@ -983,7 +983,12 @@ func (fs *Dat9FS) commitLayerShadowLocked(ctx context.Context, fh *FileHandle, s
 	}
 	fs.bindCommitEntryToHandleLocked(entry, fh, payloadBaseRev)
 	fh.Unlock()
-	err := fs.commitQueue.CommitNow(ctx, entry)
+	var err error
+	if pathLocked {
+		err = fs.commitQueue.commitNowPathLocked(ctx, entry)
+	} else {
+		err = fs.commitQueue.CommitNow(ctx, entry)
+	}
 	fh.Lock()
 	if err != nil {
 		return err
@@ -12792,7 +12797,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 				phase = "large-shadowspill-layer-sync-upload"
 				uploadStart := time.Now()
 				fs.debugf("flush layer shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
-				err := fs.commitLayerShadowLocked(uploadCtx, fh, true)
+				err := fs.commitLayerShadowLocked(uploadCtx, fh, true, false)
 				fs.debugDurationf(uploadStart, 0, "flush layer shadowspill upload done path=%s size=%d err=%v", fh.Path, size, err)
 				if err != nil {
 					safeLogPrintf("flush: layer ShadowSpill sync upload failed for %s: %v", fh.Path, err)
@@ -13121,7 +13126,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			phase = "shadowspill-layer-sync-upload"
 			uploadStart := time.Now()
 			fs.debugf("fsync layer shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
-			err := fs.commitLayerShadowLocked(uploadCtx, fh, true)
+			err := fs.commitLayerShadowLocked(uploadCtx, fh, true, false)
 			fs.debugDurationf(uploadStart, 0, "fsync layer shadowspill upload done path=%s size=%d err=%v", fh.Path, size, err)
 			if err != nil {
 				safeLogPrintf("fsync: layer ShadowSpill sync upload failed for %s: %v", fh.Path, err)
@@ -14181,7 +14186,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		expectedRevision := expectedRevisionForHandle(fh)
 		if fh.ShadowSpill || (fh.Streamer != nil && fh.Streamer.Started()) || !fs.materializeFullForUploadLocked(fh) {
 			if fh.ShadowSpill {
-				if err := fs.commitLayerShadowLocked(ctx, fh, true); err != nil {
+				if err := fs.commitLayerShadowLocked(ctx, fh, true, true); err != nil {
 					safeLogPrintf("layer shadowspill flush failed for %s: %v", fh.Path, err)
 					return httpToFuseStatus(err)
 				}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -322,7 +322,6 @@ type dirtyInodeState struct {
 
 type inodeMutationState struct {
 	latestSeq         uint64
-	stagedSeq         uint64
 	committedSeq      uint64
 	committedRevision int64
 	committedSize     int64
@@ -1891,19 +1890,6 @@ func (fs *Dat9FS) clearDirtySize(ino uint64, seq uint64) {
 	}
 }
 
-func (fs *Dat9FS) recordStagedMutation(ino, seq uint64) {
-	if !fs.gvisorCompatibilityEnabled() || ino == 0 || seq == 0 {
-		return
-	}
-	fs.dirtyMu.Lock()
-	state := fs.mutationInodes[ino]
-	if seq > state.stagedSeq {
-		state.stagedSeq = seq
-	}
-	fs.mutationInodes[ino] = state
-	fs.dirtyMu.Unlock()
-}
-
 func (fs *Dat9FS) gvisorCompatibilityEnabled() bool {
 	return fs != nil && fs.opts != nil && fs.opts.GVisorCompat
 }
@@ -1968,7 +1954,7 @@ func (fs *Dat9FS) commitEntrySuperseded(entry *CommitEntry) bool {
 	if !ok {
 		return false
 	}
-	return entry.MutationSeq < state.stagedSeq || entry.MutationSeq <= state.committedSeq
+	return entry.MutationSeq <= state.committedSeq
 }
 
 // discardSupersededMutationLocked turns a handle snapshot that is no newer
@@ -3714,9 +3700,6 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 	// its cleanup to this handle's staging generation.
 	if fs.shadowStore != nil {
 		fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(fh.Path)
-	}
-	if durable {
-		fs.recordStagedMutation(fh.Ino, fh.DirtySeq)
 	}
 	return nil
 }
@@ -9388,6 +9371,20 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 	if !ok || meta.Kind != PendingNew {
 		return pendingRenameNotApplicable, nil
 	}
+	mutationSeq := uint64(0)
+	if fs.commitQueue != nil {
+		mutationSeq = fs.commitQueue.mutationSeqForPath(oldP)
+	}
+	for _, fh := range fs.openHandles.SnapshotPath(oldP) {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		if fh.DirtySeq > mutationSeq {
+			mutationSeq = fh.DirtySeq
+		}
+		fh.Unlock()
+	}
 
 	// Only use the local fast path when the final path is truly absent.
 	// Git lockfile replacement (for example config.lock -> config) must keep
@@ -9480,14 +9477,19 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 	if fs.commitQueue != nil {
 		ino, _ := fs.inodes.GetInode(newP)
 		entry := &CommitEntry{
-			Path:        newP,
-			Inode:       ino,
-			BaseRev:     meta.BaseRev,
-			Size:        meta.Size,
-			Kind:        meta.Kind,
-			ShadowSpill: meta.ShadowSpill,
-			Mode:        meta.Mode,
-			HasMode:     meta.HasMode,
+			Path:            newP,
+			Inode:           ino,
+			MutationSeq:     mutationSeq,
+			PendingIndexGen: fs.pendingIndex.Generation(newP),
+			BaseRev:         meta.BaseRev,
+			Size:            meta.Size,
+			Kind:            meta.Kind,
+			ShadowSpill:     meta.ShadowSpill,
+			Mode:            meta.Mode,
+			HasMode:         meta.HasMode,
+		}
+		if fs.shadowStore != nil {
+			entry.ShadowGen = fs.shadowStore.ActiveGeneration(newP)
 		}
 		fs.bindCommitEntryToPath(entry, newP, meta.BaseRev)
 		if isGitLooseObjectFinalPath(newP) {
@@ -14066,12 +14068,13 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		phase = "superseded-after-commit-fence"
 		return gofuse.OK
 	}
+	mutationExpectedRevision := fs.expectedRevisionForHandleLocked(fh)
 	mutationRecorded := false
 	recordMutationBeforeFenceRelease := func() {
-		if mutationRecorded || !fs.gvisorCompatibilityEnabled() || status != gofuse.OK || err != nil || mutationSeq == 0 || fh.Unlinked || fh.Path != mutationPath {
+		if mutationRecorded || !fs.gvisorCompatibilityEnabled() || err != nil || mutationSeq == 0 || fh.Unlinked || fh.Path != mutationPath {
 			return
 		}
-		revision := fs.latestCommittedRevision(mutationPath)
+		revision := fs.resolveCommittedMutationRevision(mutationPath, fs.latestCommittedRevision(mutationPath), mutationExpectedRevision)
 		fs.recordCommittedMutation(mutationIno, mutationSeq, revision, mutationSize)
 		if revision > 0 {
 			fs.refreshCommittedRevisionForOpenHandlesWithSize(mutationPath, revision, fh, mutationSize)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1419,6 +1419,7 @@ func (fs *Dat9FS) discardUnlinkedHandleStateLocked(fh *FileHandle) {
 	fh.WriteBackGen = 0
 	fh.PendingIndexGen = 0
 	fh.ShadowStageGen = 0
+	fh.ShadowStageSeq = 0
 	if fs.commitQueue != nil {
 		fs.commitQueue.CancelPathIfInode(path, fh.Ino)
 	}
@@ -2013,6 +2014,7 @@ func (fs *Dat9FS) removeHandleOwnedStagingLocked(fh *FileHandle) {
 	fh.WriteBackGen = 0
 	fh.PendingIndexGen = 0
 	fh.ShadowStageGen = 0
+	fh.ShadowStageSeq = 0
 }
 
 func (fs *Dat9FS) forgetMutationState(ino uint64) {
@@ -3700,6 +3702,7 @@ func (fs *Dat9FS) stageShadowLocked(fh *FileHandle, durable bool) error {
 	// its cleanup to this handle's staging generation.
 	if fs.shadowStore != nil {
 		fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(fh.Path)
+		fh.ShadowStageSeq = fh.DirtySeq
 	}
 	return nil
 }
@@ -6923,13 +6926,13 @@ func (fs *Dat9FS) hasOpenHandle(ino uint64, p string) bool {
 // it marked (for rollback on a failed remote DELETE/whiteout — a separate
 // pre-snapshot would race with handles opened in between) and whether that
 // set is non-empty.
-func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapshotRemote bool) (marked []*FileHandle, anyOpen bool) {
+func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapshotRemote bool) (marked []*FileHandle, anyOpen bool, snapshotErr error) {
 	if fs.openHandles == nil || p == "" {
-		return nil, false
+		return nil, false, nil
 	}
 	handles := fs.openHandles.SnapshotPath(p)
 	if len(handles) == 0 {
-		return nil, false
+		return nil, false, nil
 	}
 
 	var size int64
@@ -6970,8 +6973,10 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 					snapshotOK = true
 				} else if err == nil {
 					err = io.ErrUnexpectedEOF
+					snapshotErr = err
 					safeLogPrintf("open-unlink snapshot short read for %s: got=%d want=%d", p, len(data), size)
 				} else {
+					snapshotErr = err
 					safeLogPrintf("open-unlink snapshot failed for %s: %v", p, err)
 				}
 				fs.perfRecordRemote(perfRemoteRead, readStart, err, uint64(len(data)))
@@ -6981,8 +6986,15 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 					snapshotShadowGen = gen
 					snapshotOK = true
 				} else {
+					snapshotErr = err
 					safeLogPrintf("open-unlink large snapshot failed for %s: %v", p, err)
 				}
+			}
+			if needsSnapshot && !snapshotOK {
+				if snapshotErr == nil {
+					snapshotErr = syscall.EIO
+				}
+				return nil, false, snapshotErr
 			}
 		}
 	}
@@ -7024,7 +7036,7 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		fh.Unlock()
 	}
 	fs.openHandles.UnlinkPath(p)
-	return handles, true
+	return handles, true, nil
 }
 
 func cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh *FileHandle) bool {
@@ -8771,7 +8783,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		if info.IsDir() {
 			return gofuse.Status(syscall.EISDIR)
 		}
-		_, preserveOpen := fs.markOpenHandlesUnlinked(ctx, childP, false)
+		_, preserveOpen, _ := fs.markOpenHandlesUnlinked(ctx, childP, false)
 		if err := overlay.Remove(childP); err != nil {
 			return localErrToFuseStatus(err)
 		}
@@ -8806,7 +8818,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// write fails, the directory entry still exists authoritatively, so
 		// the marking is rolled back — otherwise every later write/flush on
 		// those handles would keep being suppressed and silently drop data.
-		markedGitHandles, _ := fs.markOpenHandlesUnlinked(ctx, childP, false)
+		markedGitHandles, _, _ := fs.markOpenHandlesUnlinked(ctx, childP, false)
 		st := fs.putGitWhiteout(ctx, childP)
 		if st != gofuse.OK {
 			fs.unmarkOpenHandlesAfterFailedUnlink(childP, markedGitHandles)
@@ -8869,8 +8881,16 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	// remote DELETE can roll precisely those handles back (the entry still
 	// exists remotely in that case).
 	markCtx, markCf := fuseCtx(cancel)
-	markedHandles, markedAny := fs.markOpenHandlesUnlinked(markCtx, childP, true)
+	if fs.gvisorCompatibilityEnabled() {
+		markCf()
+		markCtx, markCf = fs.namespaceMutationCommitContext(ctx)
+	}
+	markedHandles, markedAny, markErr := fs.markOpenHandlesUnlinked(markCtx, childP, true)
 	markCf()
+	if markErr != nil {
+		status = httpToFuseStatus(markErr)
+		return status
+	}
 	preserveOpen = markedAny
 
 	if fs.writeBack != nil && fs.uploader != nil {
@@ -9010,7 +9030,7 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	// marking; mark them now (no remote snapshot — the path is already gone)
 	// so their Flush/Fsync/Release guards see fh.Unlinked and cannot
 	// resurrect the path.
-	if _, anyOpen := fs.markOpenHandlesUnlinked(ctx, childP, false); anyOpen {
+	if _, anyOpen, _ := fs.markOpenHandlesUnlinked(ctx, childP, false); anyOpen {
 		preserveOpen = true
 	}
 
@@ -9375,15 +9395,20 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 	if fs.commitQueue != nil {
 		mutationSeq = fs.commitQueue.mutationSeqForPath(oldP)
 	}
-	for _, fh := range fs.openHandles.SnapshotPath(oldP) {
-		if fh == nil {
-			continue
+	if mutationSeq == 0 && fs.shadowStore != nil {
+		shadowGen := fs.shadowStore.ActiveGeneration(oldP)
+		for _, fh := range fs.openHandles.SnapshotPath(oldP) {
+			if fh == nil {
+				continue
+			}
+			fh.Lock()
+			if shadowGen != 0 && fh.ShadowStageGen == shadowGen {
+				mutationSeq = fh.ShadowStageSeq
+				fh.Unlock()
+				break
+			}
+			fh.Unlock()
 		}
-		fh.Lock()
-		if fh.DirtySeq > mutationSeq {
-			mutationSeq = fh.DirtySeq
-		}
-		fh.Unlock()
 	}
 
 	// Only use the local fast path when the final path is truly absent.

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -963,7 +963,11 @@ func (fs *Dat9FS) commitLayerShadowLocked(ctx context.Context, fh *FileHandle, s
 	if fs.shadowStore == nil || !fs.shadowStore.Has(fh.Path) {
 		return fmt.Errorf("missing shadow for %s", fh.Path)
 	}
-	pathLocked = pathLocked || fh.RemoteCommitUnlock != nil
+	gvisorCompat := fs.gvisorCompatibilityEnabled()
+	pathLocked = pathLocked || gvisorCompat && fh.RemoteCommitUnlock != nil
+	handlePath := fh.Path
+	handleIno := fh.Ino
+	mutationSeq := fh.DirtySeq
 	size := int64(0)
 	if fh.Dirty != nil {
 		size = fh.Dirty.Size()
@@ -994,13 +998,20 @@ func (fs *Dat9FS) commitLayerShadowLocked(ctx context.Context, fh *FileHandle, s
 	if err != nil {
 		return err
 	}
+	if gvisorCompat && (fh.Unlinked || fh.Path != handlePath || fh.DirtySeq != mutationSeq) {
+		return nil
+	}
 	if hasMode {
 		fs.clearPendingModeForInodeGeneration(fh.Ino, fh, mode&0o777, fh.PendingModeGen)
 		clearPendingModeLocked(fh)
 	}
 	if fh.Dirty != nil {
 		fh.Dirty.ClearDirty()
-		fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+		if gvisorCompat {
+			fs.clearDirtySize(handleIno, mutationSeq)
+		} else {
+			fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+		}
 		fh.DirtySeq = 0
 	}
 	fh.WriteBackSeq = 0
@@ -14264,7 +14275,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	mutationExpectedRevision := fs.expectedRevisionForHandleLocked(fh)
 	mutationRecorded := false
 	recordMutationBeforeFenceRelease := func() {
-		if mutationRecorded || !fs.gvisorCompatibilityEnabled() || err != nil || mutationSeq == 0 || fh.Unlinked || fh.Path != mutationPath {
+		if mutationRecorded || !fs.gvisorCompatibilityEnabled() || err != nil || mutationSeq == 0 {
 			return
 		}
 		revision := fs.resolveCommittedMutationRevision(mutationPath, fs.latestCommittedRevision(mutationPath), mutationExpectedRevision)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -29,6 +29,11 @@ import (
 // candidate after discovery but before the second TryLock in candidateLoop.
 var testHookAfterSamePathDirtyHandleScan func(path string)
 
+// testHookBeforeGVisorShadowSpillFlushFence lets race-focused unit tests pause
+// a gVisor ShadowSpill Flush after its initial supersession check but before it
+// acquires the same-path remote commit fence.
+var testHookBeforeGVisorShadowSpillFlushFence func(path string)
+
 // Dat9FS implements the go-fuse RawFileSystem interface, bridging FUSE
 // operations to the dat9 HTTP API via the Go SDK client.
 type Dat9FS struct {
@@ -12843,16 +12848,35 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 				return gofuse.OK
 			}
 			phase = "large-shadowspill-sync-upload"
+			gvisorCompat := fs.gvisorCompatibilityEnabled()
 			expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 			mutationSeq := fh.DirtySeq
 			handleIsNew := fh.IsNew
 			handlePath := fh.Path
+			handleIno := fh.Ino
 			stagingGens := fs.captureHandleStagingGensLocked(fh)
 			// B4: serialize with Unlink's remote DELETE — hold the per-path
 			// remoteCommitLock across the network upload while releasing fh.mu,
 			// exactly like flushHandle Path 2. Without it Unlink can DELETE and
 			// return while this large-file PUT is still in flight.
+			if gvisorCompat && testHookBeforeGVisorShadowSpillFlushFence != nil {
+				testHookBeforeGVisorShadowSpillFlushFence(fh.Path)
+			}
 			unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
+			if gvisorCompat && fs.discardSupersededMutationLocked(fh) {
+				fs.removeHandleOwnedStagingLocked(fh)
+				unlockRemoteCommit()
+				phase = "superseded-after-commit-fence"
+				return gofuse.OK
+			}
+			if gvisorCompat {
+				expectedRevision = fs.expectedRevisionForHandleLocked(fh)
+				mutationSeq = fh.DirtySeq
+				handleIsNew = fh.IsNew
+				handlePath = fh.Path
+				handleIno = fh.Ino
+				stagingGens = fs.captureHandleStagingGensLocked(fh)
+			}
 			uploadStart := time.Now()
 			fs.debugf("flush shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 			fh.Unlock()
@@ -12871,6 +12895,14 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 					fs.recordCommittedRevision(handlePath, syntheticRev)
 				}
 			}
+			var mutationRevision int64
+			if err == nil && gvisorCompat {
+				mutationRevision = fs.resolveCommittedMutationRevision(handlePath, committedRev, expectedRevision)
+				fs.recordCommittedMutation(handleIno, mutationSeq, mutationRevision, size)
+				if mutationRevision > 0 {
+					fs.refreshCommittedRevisionForOpenHandlesWithSize(handlePath, mutationRevision, fh, size)
+				}
+			}
 			unlockRemoteCommit()
 			fh.Lock()
 			var uploadBytes uint64
@@ -12883,10 +12915,11 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 				safeLogPrintf("flush: ShadowSpill sync upload failed for %s: %v", fh.Path, err)
 				return gofuse.EIO
 			}
-			mutationRevision := fs.resolveCommittedMutationRevision(fh.Path, committedRev, expectedRevision)
-			fs.recordCommittedMutation(fh.Ino, mutationSeq, mutationRevision, size)
-			if mutationRevision > 0 {
-				fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, mutationRevision, fh, size)
+			if !gvisorCompat {
+				mutationRevision = fs.resolveCommittedMutationRevision(fh.Path, committedRev, expectedRevision)
+				if mutationRevision > 0 {
+					fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, mutationRevision, fh, size)
+				}
 			}
 			// If Unlink completed while remoteCommitLock was released (it
 			// serializes DELETE after our PUT via the same lock), the path is
@@ -12897,12 +12930,22 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 				fs.discardUnlinkedHandleStateLocked(fh)
 				return gofuse.OK
 			}
+			if gvisorCompat && (fh.Path != handlePath || fh.DirtySeq != mutationSeq) {
+				return gofuse.OK
+			}
 			if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 				safeLogPrintf("flush: ShadowSpill pending chmod failed for %s: %v", fh.Path, err)
 				return httpToFuseStatus(err)
 			}
+			if gvisorCompat && (fh.Path != handlePath || fh.DirtySeq != mutationSeq) {
+				return gofuse.OK
+			}
 			fh.Dirty.ClearDirty()
-			fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+			if gvisorCompat {
+				fs.clearDirtySize(handleIno, mutationSeq)
+			} else {
+				fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+			}
 			fh.DirtySeq = 0
 			if committedRev > 0 {
 				clearReadTargetForLockedHandle(fh)
@@ -13172,6 +13215,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			return gofuse.OK
 		}
 		phase = "shadowspill-sync-upload"
+		gvisorCompat := fs.gvisorCompatibilityEnabled()
 		handleIsNew := fh.IsNew
 		handlePath := fh.Path
 		stagingGens := fs.captureHandleStagingGensLocked(fh)
@@ -13235,13 +13279,23 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			fs.discardUnlinkedHandleStateLocked(fh)
 			return gofuse.OK
 		}
+		if gvisorCompat && (fh.Path != handlePath || fh.DirtySeq != mutationSeq) {
+			return gofuse.OK
+		}
 		if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {
 			safeLogPrintf("fsync: ShadowSpill pending chmod failed for %s: %v", fh.Path, err)
 			return httpToFuseStatus(err)
 		}
+		if gvisorCompat && (fh.Path != handlePath || fh.DirtySeq != mutationSeq) {
+			return gofuse.OK
+		}
 		if fh.Dirty != nil {
 			fh.Dirty.ClearDirty()
-			fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+			if gvisorCompat {
+				fs.clearDirtySize(handleIno, mutationSeq)
+			} else {
+				fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+			}
 			fh.DirtySeq = 0
 		}
 		if committedRev > 0 {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1930,6 +1930,19 @@ func (fs *Dat9FS) committedMutation(ino uint64) (inodeMutationState, bool) {
 	return state, ok && state.committedSeq != 0
 }
 
+func (fs *Dat9FS) commitEntrySuperseded(entry *CommitEntry) bool {
+	if !fs.gvisorCompatibilityEnabled() || entry == nil || entry.Inode == 0 || entry.MutationSeq == 0 {
+		return false
+	}
+	fs.dirtyMu.Lock()
+	state, ok := fs.mutationInodes[entry.Inode]
+	fs.dirtyMu.Unlock()
+	if !ok {
+		return false
+	}
+	return entry.MutationSeq < state.latestSeq || entry.MutationSeq <= state.committedSeq
+}
+
 // discardSupersededMutationLocked turns a handle snapshot that is no newer
 // than the committed inode watermark into a clean view of the committed file.
 // Caller must hold fh.mu. Shared path-keyed staging is intentionally untouched.
@@ -1967,6 +1980,24 @@ func (fs *Dat9FS) discardSupersededMutationLocked(fh *FileHandle) bool {
 	}
 	clearReadTargetForLockedHandle(fh)
 	return true
+}
+
+func (fs *Dat9FS) removeHandleOwnedStagingLocked(fh *FileHandle) {
+	if fh == nil || fh.Path == "" {
+		return
+	}
+	if fs.writeBack != nil && fh.WriteBackGen != 0 {
+		fs.writeBack.RemoveIfGeneration(fh.Path, fh.WriteBackGen)
+	}
+	if fs.pendingIndex != nil && fh.PendingIndexGen != 0 {
+		fs.pendingIndex.RemoveIfGeneration(fh.Path, fh.PendingIndexGen)
+	}
+	if fs.shadowStore != nil && fh.ShadowStageGen != 0 {
+		fs.shadowStore.RemoveIfGeneration(fh.Path, fh.ShadowStageGen)
+	}
+	fh.WriteBackGen = 0
+	fh.PendingIndexGen = 0
+	fh.ShadowStageGen = 0
 }
 
 func (fs *Dat9FS) forgetMutationState(ino uint64) {
@@ -3662,6 +3693,11 @@ func (fs *Dat9FS) stageShadowForQueuedCommitLocked(fh *FileHandle, durable bool)
 	acquired := fh != nil && fh.RemoteCommitUnlock == nil
 	if fh != nil {
 		_ = fs.lockHandleRemoteCommitPathLocked(fh)
+		if fs.discardSupersededMutationLocked(fh) {
+			fs.removeHandleOwnedStagingLocked(fh)
+			fs.releaseHandleRemoteCommitPathLocked(fh)
+			return nil
+		}
 	}
 	err := fs.stageShadowLocked(fh, durable)
 	if err != nil && acquired {
@@ -3705,7 +3741,14 @@ func (fs *Dat9FS) bindCommitEntryToPath(entry *CommitEntry, remotePath string, p
 }
 
 func (fs *Dat9FS) enqueueStagedShadowCommitLocked(fh *FileHandle) error {
-	if fs == nil || fh == nil || fh.Dirty == nil || fs.commitQueue == nil || fs.shadowStore == nil || !fs.shadowStore.Has(fh.Path) {
+	if fs == nil || fh == nil || fh.Dirty == nil || fs.commitQueue == nil || fs.shadowStore == nil {
+		return syscall.ENOTSUP
+	}
+	if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {
+		fs.releaseHandleRemoteCommitPathLocked(fh)
+		return nil
+	}
+	if !fs.shadowStore.Has(fh.Path) {
 		return syscall.ENOTSUP
 	}
 	size := fh.Dirty.Size()
@@ -3713,15 +3756,17 @@ func (fs *Dat9FS) enqueueStagedShadowCommitLocked(fh *FileHandle) error {
 	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 	payloadBaseRev := fh.BaseRev
 	entry := &CommitEntry{
-		Path:        fh.Path,
-		Inode:       fh.Ino,
-		MutationSeq: fh.DirtySeq,
-		BaseRev:     expectedRevision,
-		Size:        size,
-		Kind:        fs.pendingKindForHandle(fh),
-		ShadowSpill: fh.ShadowSpill,
-		Mode:        mode,
-		HasMode:     hasMode,
+		Path:            fh.Path,
+		Inode:           fh.Ino,
+		MutationSeq:     fh.DirtySeq,
+		PendingIndexGen: fh.PendingIndexGen,
+		ShadowGen:       fh.ShadowStageGen,
+		BaseRev:         expectedRevision,
+		Size:            size,
+		Kind:            fs.pendingKindForHandle(fh),
+		ShadowSpill:     fh.ShadowSpill,
+		Mode:            mode,
+		HasMode:         hasMode,
 	}
 	fs.bindCommitEntryToHandleLocked(entry, fh, payloadBaseRev)
 	if err := fs.commitQueue.Enqueue(entry); err != nil {
@@ -12479,6 +12524,10 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 					if err != nil {
 						safeLogPrintf("shadow stage failed for %s: %v, falling through", fh.Path, err)
 					} else {
+						if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {
+							phase = "superseded-after-commit-fence"
+							return gofuse.OK
+						}
 						phase = "small-snapshot-writeback"
 						snapWBStart := time.Now()
 						// Advance WriteBackSeq only when the snapshot actually
@@ -12552,6 +12601,10 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			if err != nil {
 				safeLogPrintf("flush: shadow stage failed for ShadowSpill %s (size=%d): %v, falling through to sync upload", fh.Path, fh.Dirty.Size(), err)
 			} else {
+				if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {
+					phase = "superseded-after-commit-fence"
+					return gofuse.OK
+				}
 				fh.ShadowCommitReady = true
 				fh.ShadowCommitSeq = fh.DirtySeq
 				return gofuse.OK
@@ -12664,6 +12717,10 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 				if err != nil {
 					safeLogPrintf("flush: shadow stage failed for %s (size=%d): %v, falling through to sync upload", fh.Path, fh.Dirty.Size(), err)
 				} else {
+					if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {
+						phase = "superseded-after-commit-fence"
+						return gofuse.OK
+					}
 					phase = "large-snapshot-writeback"
 					if err := fs.snapshotWriteBackLocked(fh); err != nil {
 						safeLogPrintf("flush: writeback snapshot failed for %s: %v", fh.Path, err)
@@ -12792,6 +12849,10 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			err := fs.stageShadowForQueuedCommitLocked(fh, true)
 			fs.debugDurationf(stageStart, 0, "fsync shadowspill stage done path=%s err=%v", fh.Path, err)
 			if err == nil {
+				if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {
+					phase = "superseded-after-commit-fence"
+					return gofuse.OK
+				}
 				// Journal before enqueue: the async commit appends a
 				// JournalCommit marker, which must get a higher Seq than
 				// this fsync frame or replay resurrects a committed path.
@@ -12825,6 +12886,10 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			err := fs.stageShadowForQueuedCommitLocked(fh, true)
 			fs.debugDurationf(stageStart, 0, "fsync stage done path=%s err=%v", fh.Path, err)
 			if err == nil {
+				if fh.DirtySeq == 0 || !fh.Dirty.HasDirtyParts() {
+					phase = "superseded-after-commit-fence"
+					return gofuse.OK
+				}
 				// Journal before enqueue: the async commit appends a
 				// JournalCommit marker, which must get a higher Seq than
 				// this fsync frame or replay resurrects a committed path.
@@ -13327,6 +13392,14 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				fh.Unlock()
 				return
 			}
+			unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
+			if fs.discardSupersededMutationLocked(fh) {
+				fs.removeHandleOwnedStagingLocked(fh)
+				unlockRemoteCommit()
+				fh.Unlock()
+				phase = "superseded-after-commit-fence"
+				return
+			}
 			mutationSeq := fh.DirtySeq
 			size := fh.Dirty.Size()
 			mode, hasMode := fs.modeForPendingHandle(fh)
@@ -13352,7 +13425,6 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			fh.DirtySeq = 0
 			fh.ShadowCommitReady = false
 			fh.ShadowCommitSeq = 0
-			unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
 			fh.Unlock()
 
 			enqueueStart := time.Now()
@@ -13454,16 +13526,29 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			fs.debugf("release writeback check path=%s streamer_active=%t writeback_seq=%d dirty_seq=%d can_use_cache=%t", fh.Path, streamerActive, fh.WriteBackSeq, fh.DirtySeq, canUseCache)
 			if canUseCache {
 				phase = "writeback-cache-release"
+				useCommitQueue := fs.commitQueue != nil && fs.shadowStore != nil && fs.shadowStore.Has(fh.Path)
+				var unlockRemoteCommit func()
+				if useCommitQueue {
+					unlockRemoteCommit = fs.takeHandleRemoteCommitPathLocked(fh)
+					if fs.discardSupersededMutationLocked(fh) {
+						fs.removeHandleOwnedStagingLocked(fh)
+						unlockRemoteCommit()
+						fh.Unlock()
+						phase = "superseded-after-commit-fence"
+						return
+					}
+				}
 				mode, hasMode := fs.modeForPendingHandle(fh)
 				expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+				mutationSeq := fh.DirtySeq
+				commitSize := fh.Dirty.Size()
 				payloadBaseRev := fh.BaseRev
-				size := fh.Dirty.Size()
 				entry := &CommitEntry{
 					Path:        fh.Path,
 					Inode:       fh.Ino,
-					MutationSeq: fh.DirtySeq,
+					MutationSeq: mutationSeq,
 					BaseRev:     expectedRevision,
-					Size:        size,
+					Size:        commitSize,
 					Kind:        PendingOverwrite,
 					Mode:        mode,
 					HasMode:     hasMode,
@@ -13476,11 +13561,6 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 				fh.DirtySeq = 0
 				fh.WriteBackSeq = 0
-				useCommitQueue := fs.commitQueue != nil && fs.shadowStore != nil && fs.shadowStore.Has(fh.Path)
-				var unlockRemoteCommit func()
-				if useCommitQueue {
-					unlockRemoteCommit = fs.takeHandleRemoteCommitPathLocked(fh)
-				}
 				fh.Unlock()
 
 				// Enqueue to CommitQueue if available (P1), otherwise
@@ -13524,7 +13604,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 
 				// Invalidate caches so subsequent reads see fresh data.
 				fs.invalidateReadCacheAndTargets(fh.Path)
-				fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
+				fs.cacheFileForPath(fh.Path, commitSize, time.Now(), 0)
 				// Local release — kernel already knows about this close.
 				// No notifyInode needed; userspace caches are invalidated above.
 				return
@@ -13853,16 +13933,6 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	mutationIno := fh.Ino
 	mutationSeq := fh.DirtySeq
 	mutationSize := fh.Dirty.Size()
-	defer func() {
-		if !fs.gvisorCompatibilityEnabled() || status != gofuse.OK || fs.layerEnabled() || mutationSeq == 0 || fh.Path != mutationPath {
-			return
-		}
-		revision := fs.latestCommittedRevision(mutationPath)
-		fs.recordCommittedMutation(mutationIno, mutationSeq, revision, mutationSize)
-		if revision > 0 {
-			fs.refreshCommittedRevisionForOpenHandlesWithSize(mutationPath, revision, fh, mutationSize)
-		}
-	}()
 
 	size := fh.Dirty.Size()
 	if fs.layerEnabled() {
@@ -13926,6 +13996,25 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	}()
 
 	var err error
+	if fs.discardSupersededMutationLocked(fh) {
+		fs.removeHandleOwnedStagingLocked(fh)
+		phase = "superseded-after-commit-fence"
+		return gofuse.OK
+	}
+	mutationRecorded := false
+	recordMutationBeforeFenceRelease := func() {
+		if mutationRecorded || !fs.gvisorCompatibilityEnabled() || status != gofuse.OK || err != nil || mutationSeq == 0 || fh.Unlinked || fh.Path != mutationPath {
+			return
+		}
+		revision := fs.latestCommittedRevision(mutationPath)
+		fs.recordCommittedMutation(mutationIno, mutationSeq, revision, mutationSize)
+		if revision > 0 {
+			fs.refreshCommittedRevisionForOpenHandlesWithSize(mutationPath, revision, fh, mutationSize)
+		}
+		mutationRecorded = true
+	}
+	defer recordMutationBeforeFenceRelease()
+
 	// Path 1a: Streaming mode — parts were submitted during Write() and are
 	// buffered in the StreamUploader's pendingParts. We must finalize via
 	// FinishStreaming (which initiates the server upload with the actual total
@@ -14298,6 +14387,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	if err == nil {
 		fs.removeSupersededZeroTruncateStagingLocked(handlePath, committedBarrierRev, size)
 	}
+	recordMutationBeforeFenceRelease()
 
 	// Release remoteCommitLock AFTER upload + revision recording but
 	// BEFORE re-acquiring fh.mu. This preserves same-path serialization
@@ -14832,6 +14922,13 @@ func (fs *Dat9FS) onCommitQueueCleanup(entry *CommitEntry) {
 		return
 	}
 	fs.clearRemovedCommittedShadowForOpenHandles(entry.Path, fs.latestCommittedRevision(entry.Path), entry.Size)
+	fs.cleanupCommittedInode(entry.Inode, entry.Path)
+}
+
+func (fs *Dat9FS) onCommitQueueDiscard(entry *CommitEntry) {
+	if entry == nil || entry.Inode == 0 {
+		return
+	}
 	fs.cleanupCommittedInode(entry.Inode, entry.Path)
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -12043,7 +12043,11 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 		}
 		if st != gofuse.OK {
 			if fh.Layer != PathLayerGitWorkspace {
-				fs.restoreFailedWriteSyncLocked(fh, writeSyncSnapshot)
+				if state, ok := fs.committedMutation(fh.Ino); ok && fh.DirtySeq != 0 && fh.DirtySeq <= state.committedSeq {
+					fs.discardSupersededMutationLocked(fh)
+				} else {
+					fs.restoreFailedWriteSyncLocked(fh, writeSyncSnapshot)
+				}
 			}
 			return 0, st
 		}
@@ -13004,7 +13008,6 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 	// ShadowSpill strict: synchronous streaming upload from shadow.
 	if fh.ShadowSpill && fs.shadowStore != nil {
 		size := fh.Dirty.Size()
-		expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 		uploadCtx, uploadCancel := fuseCtxWithTimeout(cancel, releaseTimeout(size))
 		defer uploadCancel()
 		if fs.layerEnabled() {
@@ -13024,12 +13027,19 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		handlePath := fh.Path
 		stagingGens := fs.captureHandleStagingGensLocked(fh)
 		handleIno := fh.Ino
-		mutationSeq := fh.DirtySeq
 		// B4: serialize with Unlink's remote DELETE — hold the per-path
 		// remoteCommitLock across the network upload while releasing fh.mu,
 		// exactly like flushHandle Path 2. Without it Unlink can DELETE and
 		// return while this large-file PUT is still in flight.
 		unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
+		if fs.discardSupersededMutationLocked(fh) {
+			fs.removeHandleOwnedStagingLocked(fh)
+			unlockRemoteCommit()
+			phase = "superseded-after-commit-fence"
+			return gofuse.OK
+		}
+		expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+		mutationSeq := fh.DirtySeq
 		uploadStart := time.Now()
 		fs.debugf("fsync shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 		fh.Unlock()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -5009,6 +5009,20 @@ func (fs *Dat9FS) inodeSnapshotSize(ino uint64) int64 {
 	return entry.Size
 }
 
+func (fs *Dat9FS) committedOpenHandleSnapshotState(ino uint64, localPath string, size, revision int64) (int64, int64) {
+	if !fs.gvisorCompatibilityEnabled() {
+		return size, revision
+	}
+	if state, ok := fs.committedMutation(ino); ok && state.committedRevision > revision {
+		size = state.committedSize
+		revision = state.committedRevision
+	}
+	if committedRevision := fs.latestCommittedRevision(localPath); committedRevision > revision {
+		revision = committedRevision
+	}
+	return size, revision
+}
+
 func (fs *Dat9FS) snapshotOpenHandlesBeforeUnlink(ctx context.Context, localPath string) error {
 	return fs.snapshotOpenHandlesForPath(ctx, localPath, nil)
 }
@@ -5061,6 +5075,7 @@ func (fs *Dat9FS) snapshotOpenHandlesForPath(ctx context.Context, localPath stri
 		if !eligible || handlePath != localPath || size < 0 || size > maxPathTruncateInMemoryBytes {
 			continue
 		}
+		size, inodeRevision = fs.committedOpenHandleSnapshotState(fh.Ino, localPath, size, inodeRevision)
 		candidates = append(candidates, candidate{fh: fh, size: size, revision: inodeRevision})
 	}
 	if len(candidates) == 0 {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -8923,8 +8923,15 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	if fs.debouncer != nil {
 		fs.debouncer.Cancel(childP)
 	}
-	if err := fs.snapshotOpenHandlesBeforeUnlink(ctx, childP); err != nil {
-		status = httpToFuseStatus(err)
+	snapshotCtx := ctx
+	snapshotCancel := func() {}
+	if fs.gvisorCompatibilityEnabled() {
+		snapshotCtx, snapshotCancel = fs.namespaceMutationCommitContext(ctx)
+	}
+	snapshotErr := fs.snapshotOpenHandlesBeforeUnlink(snapshotCtx, childP)
+	snapshotCancel()
+	if snapshotErr != nil {
+		status = httpToFuseStatus(snapshotErr)
 		return status
 	}
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -25812,7 +25812,7 @@ func TestReadOpenHandleSnapshotRetriesTransientRangeRead(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
 	defer cancel()
 
-	got, err := fs.readOpenHandleSnapshot(ctx, "/snapshot.bin", int64(len(data)))
+	got, err := fs.readOpenHandleSnapshot(ctx, "/snapshot.bin", int64(len(data)), 0)
 	if err != nil {
 		t.Fatalf("readOpenHandleSnapshot: %v", err)
 	}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -16885,6 +16885,179 @@ func TestFlushHandle_Path2_NoDeadlockWithConcurrentWrite(t *testing.T) {
 	_ = fhID // keep allocated for the duration of the test
 }
 
+func TestSyncHandleShadowSpillConcurrentWritePreservesDirtyState(t *testing.T) {
+	const filePath = "/shadowspill-concurrent.txt"
+	original := []byte("original shadow data")
+	updated := []byte("updated shadow data")
+	uploadStarted := make(chan struct{})
+	uploadResume := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+			return
+		}
+		_, _ = io.ReadAll(r.Body)
+		close(uploadStarted)
+		<-uploadResume
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	fs.shadowStore = shadow
+	ino := fs.inodes.Lookup(filePath, false, int64(len(original)), time.Now())
+	dirty := NewWriteBuffer(filePath, maxPreloadSize, 0)
+	if _, err := dirty.Write(0, original); err != nil {
+		t.Fatal(err)
+	}
+	dirty.maxSize = streamingWriteMaxSize
+	if err := shadow.WriteFull(filePath, original, 0); err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Ino:         ino,
+		Path:        filePath,
+		Dirty:       dirty,
+		DirtySeq:    fs.markDirtySize(ino, int64(len(original))),
+		ShadowSpill: true,
+		ShadowReady: true,
+		IsNew:       true,
+	}
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.syncHandleToRemoteLocked(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("shadowspill upload did not start")
+	}
+	writeDone := make(chan error, 1)
+	go func() {
+		fh.Lock()
+		unlockRemoteCommit := fs.lockHandleRemoteCommitPathLocked(fh)
+		_, err := fh.Dirty.Write(0, updated)
+		if err == nil {
+			fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+		}
+		unlockRemoteCommit()
+		fh.Unlock()
+		writeDone <- err
+	}()
+	close(uploadResume)
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("syncHandleToRemoteLocked status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("syncHandleToRemoteLocked deadlocked with concurrent Write")
+	}
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatalf("concurrent Write failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent Write did not complete")
+	}
+	fh.Lock()
+	dirtySeq := fh.DirtySeq
+	hasDirty := fh.Dirty.HasDirtyParts()
+	fh.Unlock()
+	if dirtySeq == 0 || !hasDirty {
+		t.Fatalf("concurrent shadowspill write was cleared: seq=%d dirty=%t", dirtySeq, hasDirty)
+	}
+}
+
+func TestFlushHandleUploadAllConcurrentWritePreservesDirtyState(t *testing.T) {
+	const filePath = "/uploadall-concurrent.txt"
+	data := bytes.Repeat([]byte("a"), int(DefaultPartSize)+1024)
+	updated := []byte("updated after uploadall snapshot")
+	expectedRevision := int64(0)
+	rec := newMultipartUploadRecorder(t, filePath, int64(len(data)), &expectedRevision)
+	rec.completeStarted = make(chan struct{})
+	rec.allowComplete = make(chan struct{})
+	var allowCompleteOnce sync.Once
+	t.Cleanup(func() { allowCompleteOnce.Do(func() { close(rec.allowComplete) }) })
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(rec.client(), opts)
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	dirty := fs.newWriteBuffer(filePath, maxPreloadSize, 0)
+	if _, err := dirty.Write(0, data); err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     filePath,
+		Dirty:    dirty,
+		DirtySeq: fs.markDirtySize(ino, int64(len(data))),
+		Streamer: NewStreamUploader(rec.client(), filePath, expectedRevision),
+		IsNew:    true,
+	}
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		fh.Lock()
+		st := fs.flushHandle(context.Background(), fh)
+		fh.Unlock()
+		flushDone <- st
+	}()
+	select {
+	case <-rec.completeStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("UploadAll did not reach complete")
+	}
+	writeDone := make(chan error, 1)
+	go func() {
+		fh.Lock()
+		unlockRemoteCommit := fs.lockHandleRemoteCommitPathLocked(fh)
+		_, err := fh.Dirty.Write(0, updated)
+		if err == nil {
+			fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+		}
+		unlockRemoteCommit()
+		fh.Unlock()
+		writeDone <- err
+	}()
+	allowCompleteOnce.Do(func() { close(rec.allowComplete) })
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("flushHandle status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("UploadAll flush deadlocked with concurrent Write")
+	}
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatalf("concurrent Write failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent Write did not complete")
+	}
+	fh.Lock()
+	dirtySeq := fh.DirtySeq
+	hasDirty := fh.Dirty.HasDirtyParts()
+	fh.Unlock()
+	if dirtySeq == 0 || !hasDirty {
+		t.Fatalf("concurrent UploadAll write was cleared: seq=%d dirty=%t", dirtySeq, hasDirty)
+	}
+}
+
 // TestFlushHandle_Path2_RenameRetargetDuringUpload verifies that when
 // retargetOpenHandlesForRename changes fh.Path while a Path 2 upload is
 // in-flight, the committed revision is NOT misattributed to the new path.

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -2592,6 +2592,12 @@ func TestGVisorCompatWriteBackRequiresCommitQueue(t *testing.T) {
 			want:        true,
 		},
 		{
+			name:      "gvisor default writeback legacy fallback rejected",
+			gvisor:    true,
+			writeBack: true,
+			want:      true,
+		},
+		{
 			name:        "gvisor writeback queue available",
 			gvisor:      true,
 			writePolicy: WritePolicyWriteBack,
@@ -2769,5 +2775,153 @@ func TestGVisorCompatDisabledRenameMetadataOnlySpecialTargetDeleteRemainsInterru
 	}
 	if got := deleteCalls.Load(); got != 1 {
 		t.Fatalf("target DELETE calls = %d, want 1", got)
+	}
+}
+
+func TestGVisorCompatPendingNewGitRenameSyncCommitSurvivesInterrupt(t *testing.T) {
+	testGVisorCompatPendingNewRenameSyncCommitInterrupt(t, true, true, false, gofuse.OK)
+}
+
+func TestGVisorCompatPendingNewRenameQueueFallbackSyncCommitSurvivesInterrupt(t *testing.T) {
+	testGVisorCompatPendingNewRenameSyncCommitInterrupt(t, true, false, true, gofuse.OK)
+}
+
+func TestGVisorCompatDisabledPendingNewGitRenameSyncCommitRemainsInterruptible(t *testing.T) {
+	testGVisorCompatPendingNewRenameSyncCommitInterrupt(t, false, true, false, gofuse.EAGAIN)
+}
+
+func testGVisorCompatPendingNewRenameSyncCommitInterrupt(t *testing.T, gvisorCompat, gitLooseObject, queueStopped bool, wantStatus gofuse.Status) {
+	t.Helper()
+	oldP := "/repo/.git/objects/70/tmp_obj_interrupt"
+	newP := "/repo/.git/objects/70/24234d93f61104585962ac664bc5a7ed1d241d"
+	oldName := "tmp_obj_interrupt"
+	newName := "24234d93f61104585962ac664bc5a7ed1d241d"
+	parentPath := "/repo/.git/objects/70"
+	if !gitLooseObject {
+		oldP = "/repo/tmp_obj_interrupt"
+		newP = "/repo/final-object"
+		oldName = "tmp_obj_interrupt"
+		newName = "final-object"
+		parentPath = "/repo"
+	}
+	data := []byte("loose object final commit")
+	putStarted := make(chan struct{})
+	putCanceled := make(chan struct{})
+	allowPut := make(chan struct{})
+	var (
+		putCalls   atomic.Int32
+		closeAllow sync.Once
+	)
+	t.Cleanup(func() { closeAllow.Do(func() { close(allowPut) }) })
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && (r.URL.Path == "/v1/fs"+oldP || r.URL.Path == "/v1/fs"+newP):
+			http.NotFound(w, r)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+newP:
+			if putCalls.Add(1) != 1 {
+				http.Error(w, "unexpected retry", http.StatusInternalServerError)
+				return
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if string(body) != string(data) {
+				http.Error(w, "unexpected final upload body", http.StatusBadRequest)
+				return
+			}
+			close(putStarted)
+			select {
+			case <-r.Context().Done():
+				close(putCanceled)
+				return
+			case <-allowPut:
+				_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+			}
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.String(), http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: gvisorCompat}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), -1, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 16)
+	defer cq.DrainAll()
+	if queueStopped {
+		cq.DrainAll()
+	}
+	fs.commitQueue = cq
+
+	if err := shadow.WriteFull(oldP, data, 0); err != nil {
+		t.Fatalf("WriteFull old shadow: %v", err)
+	}
+	if _, err := pending.PutWithBaseRev(oldP, int64(len(data)), PendingNew, 0); err != nil {
+		t.Fatalf("PutWithBaseRev old pending: %v", err)
+	}
+	fs.inodes.Lookup(oldP, false, int64(len(data)), time.Now())
+	dirIno := fs.inodes.Lookup(parentPath, true, 0, time.Now())
+
+	cancel := make(chan struct{})
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		done <- fs.Rename(cancel, &gofuse.RenameIn{
+			InHeader: gofuse.InHeader{NodeId: dirIno},
+			Newdir:   dirIno,
+		}, oldName, newName)
+	}()
+	select {
+	case <-putStarted:
+		close(cancel)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for final-path PUT")
+	}
+	if gvisorCompat {
+		select {
+		case <-putCanceled:
+			// The final status assertion exposes an interruptible commit context.
+		case <-time.After(100 * time.Millisecond):
+			closeAllow.Do(func() { close(allowPut) })
+		}
+	} else {
+		select {
+		case <-putCanceled:
+		case <-time.After(5 * time.Second):
+			t.Fatal("non-gVisor final-path PUT was not canceled")
+		}
+	}
+	select {
+	case st := <-done:
+		if st != wantStatus {
+			t.Fatalf("Rename status = %v, want %v", st, wantStatus)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Rename did not finish")
+	}
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("final-path PUTs = %d, want 1", got)
+	}
+	if gvisorCompat {
+		if pending.HasPending(newP) {
+			t.Fatal("final path remained pending after detached commit")
+		}
+		if shadow.Has(newP) {
+			t.Fatal("final shadow remained after detached commit")
+		}
 	}
 }

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -812,6 +812,197 @@ func TestGVisorCompatLayerDiscardRebindsCommittedShadow(t *testing.T) {
 	}
 }
 
+func TestGVisorCompatLayerQueueUploadRebindsExistingFileFromShadow(t *testing.T) {
+	const filePath = "/layer-existing.txt"
+	committed := []byte("layer committed content")
+	opts := &MountOptions{GVisorCompat: true, LayerRef: "layer-test"}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	fs.shadowStore = shadow
+	ino := fs.inodes.Lookup(filePath, false, int64(len(committed)), time.Now())
+	fs.inodes.UpdateRevision(ino, 7)
+	_, stale := newGVisorMutationHandle(t, fs, filePath, ino)
+	if err := shadow.WriteFull(filePath, committed, 7); err != nil {
+		t.Fatal(err)
+	}
+	newerSeq := fs.markDirtySize(ino, int64(len(committed)))
+	fs.onCommitQueueUploaded(&CommitEntry{
+		Path:        filePath,
+		Inode:       ino,
+		MutationSeq: newerSeq,
+		BaseRev:     7,
+		Size:        int64(len(committed)),
+	}, 0)
+
+	stale.Lock()
+	discarded := fs.discardSupersededMutationLocked(stale)
+	got := stale.Dirty.Bytes()
+	stale.Unlock()
+	if !discarded {
+		t.Fatal("layer sibling was not discarded")
+	}
+	if !bytes.Equal(got, committed) {
+		t.Fatalf("layer rebound content = %q, want %q", got, committed)
+	}
+}
+
+func TestGVisorCompatMarkOpenHandlesUnlinkedSnapshotFailureIsGated(t *testing.T) {
+	const filePath = "/snapshot-failure.txt"
+	for _, tc := range []struct {
+		name         string
+		gvisorCompat bool
+		wantErr      bool
+		wantMarked   bool
+	}{
+		{name: "disabled", wantMarked: true},
+		{name: "enabled", gvisorCompat: true, wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				http.Error(w, "snapshot read failed", http.StatusInternalServerError)
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{GVisorCompat: tc.gvisorCompat}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			ino := fs.inodes.Lookup(filePath, false, 4, time.Now())
+			fh := &FileHandle{Ino: ino, Path: filePath}
+			fs.allocateFileHandle(fh)
+
+			marked, anyOpen, err := fs.markOpenHandlesUnlinked(context.Background(), filePath, true)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("markOpenHandlesUnlinked error = %v, want error=%t", err, tc.wantErr)
+			}
+			if anyOpen != tc.wantMarked || len(marked) != map[bool]int{false: 0, true: 1}[tc.wantMarked] {
+				t.Fatalf("marked/anyOpen = %d/%t, want %t", len(marked), anyOpen, tc.wantMarked)
+			}
+			fh.Lock()
+			gotUnlinked := fh.Unlinked
+			fh.Unlock()
+			if gotUnlinked != tc.wantMarked {
+				t.Fatalf("handle unlinked = %t, want %t", gotUnlinked, tc.wantMarked)
+			}
+		})
+	}
+}
+
+func TestGVisorCompatCommitNowOrdersHardlinkAliasesByInode(t *testing.T) {
+	const ino = uint64(42)
+	older := &CommitEntry{Path: "/alias-b", Inode: ino, MutationSeq: 1}
+	newer := &CommitEntry{Path: "/alias-a", Inode: ino, MutationSeq: 2}
+	cq := &CommitQueue{
+		queue:                   []*CommitEntry{older},
+		queuedByPath:            map[string]map[*CommitEntry]struct{}{older.Path: {older: {}}},
+		inFlight:                map[string]*CommitEntry{older.Path: older},
+		serializeMutationInodes: true,
+	}
+
+	type result struct {
+		release func()
+		discard bool
+		err     error
+	}
+	done := make(chan result, 1)
+	go func() {
+		release, discard, err := cq.beginImmediateMutationCommit(context.Background(), newer)
+		done <- result{release: release, discard: discard, err: err}
+	}()
+	select {
+	case got := <-done:
+		t.Fatalf("newer immediate commit started before older alias drained: %+v", got)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cq.mu.Lock()
+	delete(cq.inFlight, older.Path)
+	cq.queue = nil
+	cq.queuedByPath = map[string]map[*CommitEntry]struct{}{}
+	cq.mu.Unlock()
+
+	select {
+	case got := <-done:
+		if got.err != nil || got.discard || got.release == nil {
+			t.Fatalf("newer immediate result = %+v, want acquired release", got)
+		}
+		got.release()
+	case <-time.After(time.Second):
+		t.Fatal("newer immediate commit did not resume after older alias drained")
+	}
+
+	cq = &CommitQueue{
+		queue:                   []*CommitEntry{newer},
+		queuedByPath:            map[string]map[*CommitEntry]struct{}{newer.Path: {newer: {}}},
+		inFlight:                make(map[string]*CommitEntry),
+		serializeMutationInodes: true,
+	}
+	release, discard, err := cq.beginImmediateMutationCommit(context.Background(), older)
+	if err != nil || !discard || release != nil {
+		t.Fatalf("older immediate result = release:%v discard:%t err:%v, want discarded", release != nil, discard, err)
+	}
+}
+
+func TestGVisorCompatReleaseFallbackUnlocksCommitPath(t *testing.T) {
+	const filePath = "/release-fallback.txt"
+	opts := &MountOptions{GVisorCompat: true, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	c := newTestClient("http://127.0.0.1")
+	fs := NewDat9FS(c, opts)
+	cache, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	uploader := NewWriteBackUploader(c, cache, 1)
+	t.Cleanup(uploader.DrainAll)
+	fs.SetWriteBack(cache, uploader)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull(filePath, []byte("data"), 0); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	t.Cleanup(cq.DrainAll)
+	cq.mu.Lock()
+	cq.maxPending = 0
+	cq.mu.Unlock()
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = cq
+
+	ino := fs.inodes.Lookup(filePath, false, 4, time.Now())
+	dirty := fs.newWriteBuffer(filePath, maxPreloadSize, 0)
+	if _, err := dirty.Write(0, []byte("data")); err != nil {
+		t.Fatal(err)
+	}
+	var unlocks atomic.Int32
+	fh := &FileHandle{
+		Ino:                ino,
+		Path:               filePath,
+		Dirty:              dirty,
+		DirtySeq:           1,
+		WriteBackSeq:       1,
+		RemoteCommitUnlock: func() { unlocks.Add(1) },
+	}
+	fhID := fs.allocateFileHandle(fh)
+
+	fs.Release(nil, &gofuse.ReleaseIn{InHeader: gofuse.InHeader{NodeId: ino}, Fh: fhID})
+	if got := unlocks.Load(); got != 1 {
+		t.Fatalf("commit-path unlock calls = %d, want 1 after fallback failure", got)
+	}
+}
+
 func TestGVisorCompatQueueSuccessSynthesizesUnknownRevision(t *testing.T) {
 	const filePath = "/unknown-revision.txt"
 	opts := &MountOptions{GVisorCompat: true}
@@ -823,6 +1014,29 @@ func TestGVisorCompatQueueSuccessSynthesizesUnknownRevision(t *testing.T) {
 	state, ok := fs.committedMutation(ino)
 	if !ok || state.committedRevision != 1 {
 		t.Fatalf("committed mutation state = %+v, %t; want synthesized revision 1", state, ok)
+	}
+}
+
+func TestGVisorCompatDisabledQueueUploadDoesNotSynthesizeRevision(t *testing.T) {
+	const filePath = "/disabled-unknown-revision.txt"
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	ino := fs.inodes.Lookup(filePath, false, 11, time.Now())
+	fh := &FileHandle{
+		Ino:     ino,
+		Path:    filePath,
+		Dirty:   fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+		BaseRev: 0,
+	}
+	fs.allocateFileHandle(fh)
+	fs.onCommitQueueUploaded(&CommitEntry{Path: filePath, Inode: ino, MutationSeq: 1, Size: 11, Kind: PendingNew}, 0)
+
+	fh.Lock()
+	gotRevision := fh.BaseRev
+	fh.Unlock()
+	if gotRevision != 0 {
+		t.Fatalf("non-gVisor queue upload synthesized handle revision %d, want 0", gotRevision)
 	}
 }
 

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -984,6 +984,25 @@ func TestGVisorCompatPathLockedImmediateCommitDoesNotWaitForSamePathWorker(t *te
 	}
 }
 
+func TestGVisorCompatPathLockedImmediateCommitDiscardsForNewerQueuedAlias(t *testing.T) {
+	const ino = uint64(42)
+	worker := &CommitEntry{Path: "/same-path", Inode: ino, MutationSeq: 1}
+	entry := &CommitEntry{Path: "/same-path", Inode: ino, MutationSeq: 2}
+	newerAlias := &CommitEntry{Path: "/alias-path", Inode: ino, MutationSeq: 3}
+	cq := &CommitQueue{
+		inFlight:                map[string]*CommitEntry{worker.Path: worker},
+		queue:                   []*CommitEntry{newerAlias},
+		queuedByPath:            map[string]map[*CommitEntry]struct{}{newerAlias.Path: {newerAlias: {}}},
+		immediate:               make(map[*CommitEntry]struct{}),
+		serializeMutationInodes: true,
+	}
+
+	release, discard, err := cq.beginImmediateMutationCommit(context.Background(), entry, true)
+	if err != nil || !discard || release != nil {
+		t.Fatalf("path-locked immediate result = release:%t discard:%t err:%v, want discarded by newer alias", release != nil, discard, err)
+	}
+}
+
 func TestGVisorCompatImmediateCommitOccupiesPathAndCanBeCanceled(t *testing.T) {
 	const filePath = "/immediate.txt"
 	entry := &CommitEntry{Path: filePath, Inode: 42, MutationSeq: 1}
@@ -1016,6 +1035,55 @@ func TestGVisorCompatImmediateCommitOccupiesPathAndCanBeCanceled(t *testing.T) {
 	release()
 	if cq.HasPath(filePath) {
 		t.Fatal("released immediate commit remained visible to HasPath")
+	}
+}
+
+func TestGVisorCompatImmediateCancelPreservesLocalStaging(t *testing.T) {
+	const filePath = "/immediate-preserve.txt"
+	data := []byte("preserve this staged content")
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull(filePath, data, 0); err != nil {
+		t.Fatal(err)
+	}
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	pendingGen, err := pending.PutWithBaseRev(filePath, int64(len(data)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cq := NewCommitQueue(newTestClient("http://127.0.0.1"), shadow, pending, nil, 1, 8)
+	cq.serializeMutationInodes = true
+	defer cq.DrainAll()
+	entry := &CommitEntry{
+		Path:            filePath,
+		Inode:           42,
+		MutationSeq:     1,
+		PendingIndexGen: pendingGen,
+		ShadowGen:       shadow.ActiveGeneration(filePath),
+		Size:            int64(len(data)),
+		Kind:            PendingNew,
+	}
+	release, discard, err := cq.beginImmediateMutationCommit(context.Background(), entry, false)
+	if err != nil || discard || release == nil {
+		t.Fatalf("begin immediate = release:%t discard:%t err:%v", release != nil, discard, err)
+	}
+	defer release()
+
+	cq.CancelPathPreserveLocal(filePath)
+	if err := cq.commitNowClaimedPathLocked(context.Background(), entry); err != nil {
+		t.Fatalf("commit canceled immediate entry: %v", err)
+	}
+	if !shadow.Has(filePath) {
+		t.Fatal("CancelPathPreserveLocal removed the immediate entry shadow")
+	}
+	if !pending.HasPending(filePath) {
+		t.Fatal("CancelPathPreserveLocal removed the immediate entry pending state")
 	}
 }
 
@@ -1086,6 +1154,118 @@ func TestGVisorCompatLayerShadowCommitDoesNotRelockPathFence(t *testing.T) {
 	}
 	if got := pathLockCalls.Load(); got != 0 {
 		t.Fatalf("path fence locks = %d, want 0 while already held", got)
+	}
+}
+
+func TestGVisorCompatLayerShadowCommitPreservesConcurrentWrite(t *testing.T) {
+	const filePath = "/layer-shadow-concurrent.txt"
+	original := []byte("original layer shadow data")
+	updated := []byte("updated after layer commit started")
+	uploadStarted := make(chan struct{})
+	allowUpload := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/layers/layer-test/entries" {
+			http.Error(w, "unexpected request "+r.Method+" "+r.URL.Path, http.StatusInternalServerError)
+			return
+		}
+		close(uploadStarted)
+		<-allowUpload
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"layer_id": "layer-test", "path": filePath, "op": "upsert", "kind": "file"})
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true, LayerRef: "layer-test"}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(filePath, original, 0); err != nil {
+		t.Fatal(err)
+	}
+	pendingGen, err := pending.PutWithBaseRev(filePath, int64(len(original)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.SetLayerRef("layer-test")
+	cq.serializeMutationInodes = true
+	defer cq.DrainAll()
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = cq
+	ino := fs.inodes.Lookup(filePath, false, int64(len(original)), time.Now())
+	dirty := fs.newWriteBuffer(filePath, maxPreloadSize, 0)
+	if _, err := dirty.Write(0, original); err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Ino:                ino,
+		Path:               filePath,
+		Dirty:              dirty,
+		DirtySeq:           fs.markDirtySize(ino, int64(len(original))),
+		ShadowSpill:        true,
+		ShadowStageGen:     shadow.ActiveGeneration(filePath),
+		PendingIndexGen:    pendingGen,
+		IsNew:              true,
+		RemoteCommitUnlock: func() {},
+	}
+	commitDone := make(chan error, 1)
+	go func() {
+		fh.Lock()
+		err := fs.commitLayerShadowLocked(context.Background(), fh, false, false)
+		fh.Unlock()
+		commitDone <- err
+	}()
+	select {
+	case <-uploadStarted:
+	case err := <-commitDone:
+		t.Fatalf("layer commit ended before upload started: %v", err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("layer commit did not start")
+	}
+	writeDone := make(chan error, 1)
+	go func() {
+		fh.Lock()
+		unlockRemoteCommit := fs.lockHandleRemoteCommitPathLocked(fh)
+		_, err := fh.Dirty.Write(0, updated)
+		if err == nil {
+			fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+		}
+		unlockRemoteCommit()
+		fh.Unlock()
+		writeDone <- err
+	}()
+	select {
+	case err := <-writeDone:
+		if err != nil {
+			t.Fatalf("concurrent Write failed: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent Write did not complete")
+	}
+	close(allowUpload)
+	select {
+	case err := <-commitDone:
+		if err != nil {
+			t.Fatalf("commitLayerShadowLocked: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("layer commit did not complete")
+	}
+	fh.Lock()
+	dirtySeq := fh.DirtySeq
+	hasDirty := fh.Dirty.HasDirtyParts()
+	fh.Unlock()
+	if dirtySeq == 0 || !hasDirty {
+		t.Fatalf("concurrent layer write was cleared: seq=%d dirty=%t", dirtySeq, hasDirty)
 	}
 }
 

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -951,9 +951,11 @@ func TestGVisorCompatPathLockedImmediateCommitDoesNotWaitForSamePathWorker(t *te
 	const ino = uint64(42)
 	older := &CommitEntry{Path: "/same-path", Inode: ino, MutationSeq: 1}
 	newer := &CommitEntry{Path: "/same-path", Inode: ino, MutationSeq: 2}
+	queuedAlias := &CommitEntry{Path: "/alias-path", Inode: ino, MutationSeq: 1}
 	cq := &CommitQueue{
 		inFlight:                map[string]*CommitEntry{older.Path: older},
-		queuedByPath:            make(map[string]map[*CommitEntry]struct{}),
+		queue:                   []*CommitEntry{queuedAlias},
+		queuedByPath:            map[string]map[*CommitEntry]struct{}{queuedAlias.Path: {queuedAlias: {}}},
 		immediate:               make(map[*CommitEntry]struct{}),
 		serializeMutationInodes: true,
 	}
@@ -979,6 +981,41 @@ func TestGVisorCompatPathLockedImmediateCommitDoesNotWaitForSamePathWorker(t *te
 		got.release()
 	case <-time.After(time.Second):
 		t.Fatal("path-locked immediate commit waited for same-path in-flight worker")
+	}
+}
+
+func TestGVisorCompatImmediateCommitOccupiesPathAndCanBeCanceled(t *testing.T) {
+	const filePath = "/immediate.txt"
+	entry := &CommitEntry{Path: filePath, Inode: 42, MutationSeq: 1}
+	cq := &CommitQueue{
+		inFlight:                make(map[string]*CommitEntry),
+		queuedByPath:            make(map[string]map[*CommitEntry]struct{}),
+		immediate:               make(map[*CommitEntry]struct{}),
+		serializeMutationInodes: true,
+	}
+	release, discard, err := cq.beginImmediateMutationCommit(context.Background(), entry, false)
+	if err != nil || discard || release == nil {
+		t.Fatalf("begin immediate = release:%t discard:%t err:%v", release != nil, discard, err)
+	}
+	if !cq.HasPath(filePath) {
+		t.Fatal("immediate commit was invisible to HasPath")
+	}
+	if cq.WaitPathTimeout(filePath, 0) {
+		t.Fatal("immediate commit was invisible to WaitPathTimeout")
+	}
+	if cq.WaitPrefixTimeout("/", 0) {
+		t.Fatal("immediate commit was invisible to WaitPrefixTimeout")
+	}
+	if snap := cq.Snapshot(); snap.InFlight != 1 || snap.Pending != 1 {
+		t.Fatalf("immediate commit snapshot = %+v, want one in-flight pending entry", snap)
+	}
+	cq.CancelPath(filePath)
+	if !entry.canceled {
+		t.Fatal("CancelPath did not mark immediate commit canceled")
+	}
+	release()
+	if cq.HasPath(filePath) {
+		t.Fatal("released immediate commit remained visible to HasPath")
 	}
 }
 
@@ -1672,7 +1709,10 @@ func TestGVisorCompatUnlinkKeepsRemoteMutationAliveAfterInterrupt(t *testing.T) 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodDelete:
-			deleteCalls.Add(1)
+			if deleteCalls.Add(1) != 1 {
+				http.Error(w, "unexpected retry", http.StatusInternalServerError)
+				return
+			}
 			close(deleteStarted)
 			select {
 			case <-r.Context().Done():

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -319,7 +319,7 @@ func TestGVisorCompatCommitQueueSkipsSupersededEntryBeforeUpload(t *testing.T) {
 	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
 	staleSeq := fs.markDirtySize(ino, int64(len("stale")))
 	newerSeq := fs.markDirtySize(ino, int64(len("newer")))
-	fs.recordStagedMutation(ino, newerSeq)
+	fs.recordCommittedMutation(ino, newerSeq, 1, int64(len("newer")))
 	if err := shadow.WriteFull(filePath, []byte("stale"), 0); err != nil {
 		t.Fatal(err)
 	}
@@ -390,7 +390,7 @@ func TestGVisorCompatSupersededEntryDoesNotRemoveNewerStaging(t *testing.T) {
 	}
 
 	newerSeq := fs.markDirtySize(ino, int64(len("newer")))
-	fs.recordStagedMutation(ino, newerSeq)
+	fs.recordCommittedMutation(ino, newerSeq, 1, int64(len("newer")))
 	if err := shadow.WriteFull(filePath, []byte("newer"), 0); err != nil {
 		t.Fatal(err)
 	}
@@ -500,7 +500,7 @@ func TestGVisorCompatCommitQueueSkipsEntrySupersededBeforeLWW(t *testing.T) {
 		t.Fatal("timed out waiting for conflict read")
 	}
 	newerSeq := fs.markDirtySize(ino, int64(len("latest local")))
-	fs.recordStagedMutation(ino, newerSeq)
+	fs.recordCommittedMutation(ino, newerSeq, 2, int64(len("latest local")))
 	releaseOnce.Do(func() { close(releaseRead) })
 	waitCtx, waitCancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer waitCancel()
@@ -555,7 +555,7 @@ func TestGVisorCompatCommitQueueFiltersSupersededBatchEntry(t *testing.T) {
 	staleIno := fs.inodes.Lookup(stalePath, false, 5, time.Now())
 	staleSeq := fs.markDirtySize(staleIno, 5)
 	newerSeq := fs.markDirtySize(staleIno, 6)
-	fs.recordStagedMutation(staleIno, newerSeq)
+	fs.recordCommittedMutation(staleIno, newerSeq, 1, 6)
 	validIno := fs.inodes.Lookup(validPath, false, 5, time.Now())
 	validSeq := fs.markDirtySize(validIno, 5)
 	if err := shadow.WriteFull(stalePath, []byte("stale"), 0); err != nil {
@@ -684,15 +684,10 @@ func TestGVisorCompatUnstagedWriteDoesNotSupersedeDurableEntry(t *testing.T) {
 	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
 	ino := fs.inodes.Lookup("/durable-before-private.txt", false, 0, time.Now())
 	durableSeq := fs.markDirtySize(ino, 7)
-	fs.recordStagedMutation(ino, durableSeq)
-	newerSeq := fs.markDirtySize(ino, 8)
+	fs.markDirtySize(ino, 8)
 	entry := &CommitEntry{Inode: ino, MutationSeq: durableSeq}
 	if fs.commitEntrySuperseded(entry) {
 		t.Fatal("unstaged private write superseded an older durable entry")
-	}
-	fs.recordStagedMutation(ino, newerSeq)
-	if !fs.commitEntrySuperseded(entry) {
-		t.Fatal("newer durable staging did not supersede the older entry")
 	}
 }
 

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -2301,5 +2302,275 @@ func TestGVisorCompatOpenHandleSnapshotRejectsRevisionBehindCommittedFrontier(t 
 	}
 	if got := getCalls.Load(); got != 1 {
 		t.Fatalf("remote GET calls = %d, want 1 after rejecting stale cache", got)
+	}
+}
+
+func TestGVisorCompatShadowSpillFlushPreservesConcurrentWrite(t *testing.T) {
+	testGVisorCompatShadowSpillSyncCommitPreservesConcurrentWrite(t, func(fs *Dat9FS, ino, fhID uint64) gofuse.Status {
+		return fs.Flush(nil, &gofuse.FlushIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+		})
+	})
+}
+
+func TestGVisorCompatShadowSpillFsyncPreservesConcurrentWrite(t *testing.T) {
+	testGVisorCompatShadowSpillSyncCommitPreservesConcurrentWrite(t, func(fs *Dat9FS, ino, fhID uint64) gofuse.Status {
+		return fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+		})
+	})
+}
+
+func testGVisorCompatShadowSpillSyncCommitPreservesConcurrentWrite(t *testing.T, commit func(*Dat9FS, uint64, uint64) gofuse.Status) {
+	t.Helper()
+	const filePath = "/shadowspill-sync-concurrent-write.bin"
+	original := bytes.Repeat([]byte("a"), writeBackThreshold)
+	updated := []byte("newer write after old shadow upload")
+	uploadStarted := make(chan struct{})
+	allowUpload := make(chan struct{})
+	var (
+		uploadMu sync.Mutex
+		uploaded []byte
+		putCalls atomic.Int32
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			_, _ = w.Write(original)
+			return
+		case http.MethodPut:
+		default:
+			http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		uploadMu.Lock()
+		uploaded = append(uploaded[:0], body...)
+		putCall := putCalls.Add(1)
+		uploadMu.Unlock()
+		if putCall == 1 {
+			close(uploadStarted)
+			<-allowUpload
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int64{"revision": int64(putCall)})
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{
+		GVisorCompat: true,
+		SyncMode:     SyncStrict,
+		WritePolicy:  WritePolicyWriteBack,
+	}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(int64(writeBackThreshold + 1))
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	fs.shadowStore = shadow
+
+	ino := fs.inodes.Lookup(filePath, false, int64(len(original)), time.Now())
+	dirty := fs.newWriteBuffer(filePath, maxPreloadSize, 0)
+	if _, err := dirty.Write(0, original); err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(filePath, original, 0); err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Ino:            ino,
+		Path:           filePath,
+		Dirty:          dirty,
+		DirtySeq:       fs.markDirtySize(ino, int64(len(original))),
+		ShadowReady:    true,
+		ShadowSpill:    true,
+		ShadowStageGen: shadow.ActiveGeneration(filePath),
+		IsNew:          true,
+		WritePolicy:    WritePolicyWriteBack,
+	}
+	fhID := fs.allocateFileHandle(fh)
+
+	commitDone := make(chan gofuse.Status, 1)
+	go func() {
+		commitDone <- commit(fs, ino, fhID)
+	}()
+	select {
+	case <-uploadStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("old shadow upload did not start")
+	}
+
+	writeDone := make(chan gofuse.Status, 1)
+	go func() {
+		_, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+			Offset:   0,
+			Size:     uint32(len(updated)),
+		}, updated)
+		writeDone <- st
+	}()
+
+	// Flush/Fsync has released fh.mu for the upload. Wait until Write holds
+	// it while blocked on the still-held path fence, then release the upload.
+	deadline := time.Now().Add(5 * time.Second)
+	for fh.TryLock() {
+		fh.Unlock()
+		if time.Now().After(deadline) {
+			t.Fatal("concurrent Write did not acquire fh.mu")
+		}
+		runtime.Gosched()
+	}
+	close(allowUpload)
+
+	select {
+	case st := <-writeDone:
+		if st != gofuse.OK {
+			t.Fatalf("concurrent Write status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("concurrent Write did not finish")
+	}
+	select {
+	case st := <-commitDone:
+		if st != gofuse.OK {
+			t.Fatalf("sync commit status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("sync commit did not finish")
+	}
+
+	uploadMu.Lock()
+	firstUpload := append([]byte(nil), uploaded...)
+	uploadMu.Unlock()
+	if !bytes.Equal(firstUpload, original) {
+		t.Fatal("old sync commit did not upload its captured shadow snapshot")
+	}
+	fh.Lock()
+	dirtySeq := fh.DirtySeq
+	hasDirty := fh.Dirty != nil && fh.Dirty.HasDirtyParts()
+	fh.Unlock()
+	if dirtySeq == 0 || !hasDirty {
+		t.Fatalf("concurrent Write was cleared: dirty_seq=%d dirty=%t", dirtySeq, hasDirty)
+	}
+
+	if st := commit(fs, ino, fhID); st != gofuse.OK {
+		t.Fatalf("next sync commit status = %v, want OK", st)
+	}
+	wantRemote := append([]byte(nil), original...)
+	copy(wantRemote, updated)
+	uploadMu.Lock()
+	gotRemote := append([]byte(nil), uploaded...)
+	uploadMu.Unlock()
+	if !bytes.Equal(gotRemote, wantRemote) {
+		t.Fatalf("next sync commit body = %q, want updated dirty buffer", gotRemote[:len(updated)])
+	}
+}
+
+func TestGVisorCompatShadowSpillFlushRechecksSupersessionAfterFence(t *testing.T) {
+	const filePath = "/shadowspill-stale-after-fence.bin"
+	stale := bytes.Repeat([]byte("s"), writeBackThreshold)
+	newer := []byte("newer committed sibling data")
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+			return
+		}
+		putCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 2})
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{
+		GVisorCompat: true,
+		SyncMode:     SyncStrict,
+		WritePolicy:  WritePolicyWriteBack,
+	}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(int64(writeBackThreshold + 1))
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	fs.shadowStore = shadow
+
+	ino := fs.inodes.Lookup(filePath, false, int64(len(stale)), time.Now())
+	dirty := fs.newWriteBuffer(filePath, maxPreloadSize, 0)
+	if _, err := dirty.Write(0, stale); err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(filePath, stale, 0); err != nil {
+		t.Fatal(err)
+	}
+	staleSeq := fs.markDirtySize(ino, int64(len(stale)))
+	fh := &FileHandle{
+		Ino:            ino,
+		Path:           filePath,
+		Dirty:          dirty,
+		DirtySeq:       staleSeq,
+		ShadowReady:    true,
+		ShadowSpill:    true,
+		ShadowStageGen: shadow.ActiveGeneration(filePath),
+		IsNew:          true,
+		WritePolicy:    WritePolicyWriteBack,
+	}
+	fhID := fs.allocateFileHandle(fh)
+
+	reachedFence := make(chan struct{})
+	allowFence := make(chan struct{})
+	previousHook := testHookBeforeGVisorShadowSpillFlushFence
+	testHookBeforeGVisorShadowSpillFlushFence = func(path string) {
+		if path != filePath {
+			return
+		}
+		close(reachedFence)
+		<-allowFence
+	}
+	t.Cleanup(func() {
+		testHookBeforeGVisorShadowSpillFlushFence = previousHook
+	})
+
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		flushDone <- fs.Flush(nil, &gofuse.FlushIn{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Fh:       fhID,
+		})
+	}()
+	select {
+	case <-reachedFence:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Flush did not reach the post-check, pre-fence boundary")
+	}
+
+	newerSeq := fs.markDirtySize(ino, int64(len(newer)))
+	fs.recordCommittedMutation(ino, newerSeq, 1, int64(len(newer)))
+	close(allowFence)
+
+	select {
+	case st := <-flushDone:
+		if st != gofuse.OK {
+			t.Fatalf("stale Flush status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale Flush did not finish")
+	}
+	if got := putCalls.Load(); got != 0 {
+		t.Fatalf("stale Flush remote PUTs = %d, want 0", got)
 	}
 }

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -318,7 +318,8 @@ func TestGVisorCompatCommitQueueSkipsSupersededEntryBeforeUpload(t *testing.T) {
 
 	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
 	staleSeq := fs.markDirtySize(ino, int64(len("stale")))
-	fs.markDirtySize(ino, int64(len("newer")))
+	newerSeq := fs.markDirtySize(ino, int64(len("newer")))
+	fs.recordStagedMutation(ino, newerSeq)
 	if err := shadow.WriteFull(filePath, []byte("stale"), 0); err != nil {
 		t.Fatal(err)
 	}
@@ -388,7 +389,8 @@ func TestGVisorCompatSupersededEntryDoesNotRemoveNewerStaging(t *testing.T) {
 		Kind:            PendingNew,
 	}
 
-	fs.markDirtySize(ino, int64(len("newer")))
+	newerSeq := fs.markDirtySize(ino, int64(len("newer")))
+	fs.recordStagedMutation(ino, newerSeq)
 	if err := shadow.WriteFull(filePath, []byte("newer"), 0); err != nil {
 		t.Fatal(err)
 	}
@@ -497,7 +499,8 @@ func TestGVisorCompatCommitQueueSkipsEntrySupersededBeforeLWW(t *testing.T) {
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for conflict read")
 	}
-	fs.markDirtySize(ino, int64(len("latest local")))
+	newerSeq := fs.markDirtySize(ino, int64(len("latest local")))
+	fs.recordStagedMutation(ino, newerSeq)
 	releaseOnce.Do(func() { close(releaseRead) })
 	waitCtx, waitCancel := context.WithTimeout(context.Background(), 3*time.Second)
 	defer waitCancel()
@@ -551,7 +554,8 @@ func TestGVisorCompatCommitQueueFiltersSupersededBatchEntry(t *testing.T) {
 
 	staleIno := fs.inodes.Lookup(stalePath, false, 5, time.Now())
 	staleSeq := fs.markDirtySize(staleIno, 5)
-	fs.markDirtySize(staleIno, 6)
+	newerSeq := fs.markDirtySize(staleIno, 6)
+	fs.recordStagedMutation(staleIno, newerSeq)
 	validIno := fs.inodes.Lookup(validPath, false, 5, time.Now())
 	validSeq := fs.markDirtySize(validIno, 5)
 	if err := shadow.WriteFull(stalePath, []byte("stale"), 0); err != nil {
@@ -671,6 +675,78 @@ func TestGVisorCompatDisabledCommitQueueDoesNotFilterMutationSequence(t *testing
 	}
 	if got := putCalls.Load(); got != 1 {
 		t.Fatalf("PUT calls = %d, want 1 with GVisorCompat disabled", got)
+	}
+}
+
+func TestGVisorCompatUnstagedWriteDoesNotSupersedeDurableEntry(t *testing.T) {
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	ino := fs.inodes.Lookup("/durable-before-private.txt", false, 0, time.Now())
+	durableSeq := fs.markDirtySize(ino, 7)
+	fs.recordStagedMutation(ino, durableSeq)
+	newerSeq := fs.markDirtySize(ino, 8)
+	entry := &CommitEntry{Inode: ino, MutationSeq: durableSeq}
+	if fs.commitEntrySuperseded(entry) {
+		t.Fatal("unstaged private write superseded an older durable entry")
+	}
+	fs.recordStagedMutation(ino, newerSeq)
+	if !fs.commitEntrySuperseded(entry) {
+		t.Fatal("newer durable staging did not supersede the older entry")
+	}
+}
+
+func TestGVisorCompatDiscardSupersededMutationRemovesOwnedStaging(t *testing.T) {
+	const filePath = "/owned-staging.txt"
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	_, stale := newGVisorMutationHandle(t, fs, filePath, ino)
+	if err := shadow.WriteFull(filePath, nil, 0); err != nil {
+		t.Fatal(err)
+	}
+	pendingGen, err := pending.PutWithBaseRev(filePath, 0, PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	stale.ShadowStageGen = shadow.ActiveGeneration(filePath)
+	stale.PendingIndexGen = pendingGen
+	newerSeq := fs.markDirtySize(ino, 9)
+	fs.recordCommittedMutation(ino, newerSeq, 1, 9)
+	stale.Lock()
+	discarded := fs.discardSupersededMutationLocked(stale)
+	stale.Unlock()
+	if !discarded {
+		t.Fatal("stale mutation was not discarded")
+	}
+	if shadow.Has(filePath) || pending.HasPending(filePath) {
+		t.Fatal("discarded handle left generation-owned staging behind")
+	}
+}
+
+func TestGVisorCompatQueueSuccessSynthesizesUnknownRevision(t *testing.T) {
+	const filePath = "/unknown-revision.txt"
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	ino := fs.inodes.Lookup(filePath, false, 11, time.Now())
+	seq := fs.markDirtySize(ino, 11)
+	fs.onCommitQueueSuccess(&CommitEntry{Path: filePath, Inode: ino, MutationSeq: seq, Size: 11, Kind: PendingNew}, 0)
+	state, ok := fs.committedMutation(ino)
+	if !ok || state.committedRevision != 1 {
+		t.Fatalf("committed mutation state = %+v, %t; want synthesized revision 1", state, ok)
 	}
 }
 

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -1,0 +1,777 @@
+package fuse
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+)
+
+func newGVisorMutationHandle(t *testing.T, fs *Dat9FS, path string, ino uint64) (uint64, *FileHandle) {
+	t.Helper()
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    fs.newWriteBuffer(path, maxPreloadSize, 0),
+		IsNew:    true,
+		ZeroBase: true,
+	}
+	if err := fh.Dirty.Truncate(0); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, 0)
+	return fs.allocateFileHandle(fh), fh
+}
+
+func TestGVisorCompatReleaseDiscardsSupersededCrossHandleTruncate(t *testing.T) {
+	want := []byte("newer content from the create handle")
+
+	var (
+		mu       sync.Mutex
+		remote   []byte
+		revision int64
+		putCount int
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		switch r.Method {
+		case http.MethodPut:
+			expected, err := strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64)
+			if err != nil {
+				t.Errorf("parse expected revision: %v", err)
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			if expected != revision {
+				t.Errorf("expected revision = %d, remote revision = %d", expected, revision)
+				http.Error(w, "revision conflict", http.StatusConflict)
+				return
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Errorf("read PUT body: %v", err)
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			remote = append(remote[:0], body...)
+			revision++
+			putCount++
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": revision})
+		case http.MethodHead:
+			if revision == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			w.Header().Set("Content-Length", strconv.Itoa(len(remote)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(revision, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			_, _ = w.Write(remote)
+		default:
+			http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{
+		GVisorCompat: true,
+		SyncMode:     SyncInteractive,
+		WritePolicy:  WritePolicyWriteBack,
+	}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+
+	var created gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT | syscall.O_EXCL),
+		Mode:     defaultRegularFileMode,
+	}, "SKILL.md", &created); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+
+	var opened gofuse.OpenOut
+	if st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: created.NodeId},
+		Flags:    uint32(syscall.O_WRONLY),
+	}, &opened); st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+
+	var attrOut gofuse.AttrOut
+	if st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: created.NodeId},
+			Valid:    gofuse.FATTR_SIZE | gofuse.FATTR_FH,
+			Fh:       opened.Fh,
+			Size:     0,
+		},
+	}, &attrOut); st != gofuse.OK {
+		t.Fatalf("SetAttr(B) status = %v, want OK", st)
+	}
+
+	if n, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: created.NodeId},
+		Fh:       created.Fh,
+		Offset:   0,
+	}, want); st != gofuse.OK || int(n) != len(want) {
+		t.Fatalf("Write(A) = %d, %v; want %d, OK", n, st, len(want))
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: created.NodeId},
+		Fh:       created.Fh,
+	})
+
+	var gotAttr gofuse.AttrOut
+	if st := fs.GetAttr(nil, &gofuse.GetAttrIn{
+		InHeader: gofuse.InHeader{NodeId: created.NodeId},
+	}, &gotAttr); st != gofuse.OK {
+		t.Fatalf("GetAttr after Release(A) status = %v, want OK", st)
+	}
+	if got := int64(gotAttr.Size); got != int64(len(want)) {
+		t.Fatalf("GetAttr size after Release(A) = %d, want %d", got, len(want))
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: created.NodeId},
+		Fh:       opened.Fh,
+	})
+
+	mu.Lock()
+	gotRemote := append([]byte(nil), remote...)
+	gotRevision := revision
+	gotPutCount := putCount
+	mu.Unlock()
+	if gotPutCount != 1 {
+		t.Fatalf("remote PUT count = %d, want 1", gotPutCount)
+	}
+	if gotRevision != 1 {
+		t.Fatalf("remote revision = %d, want 1", gotRevision)
+	}
+	if string(gotRemote) != string(want) {
+		t.Fatalf("remote content = %q, want %q", gotRemote, want)
+	}
+}
+
+func TestGVisorCompatSameHandleTruncateThenWriteRemainsCorrect(t *testing.T) {
+	want := []byte("same handle content")
+	var (
+		mu       sync.Mutex
+		putCount int
+		putBody  []byte
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("read PUT body: %v", err)
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		mu.Lock()
+		putCount++
+		putBody = append(putBody[:0], body...)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{
+		GVisorCompat: true,
+		SyncMode:     SyncInteractive,
+		WritePolicy:  WritePolicyWriteBack,
+	}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+
+	var created gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT | syscall.O_EXCL),
+		Mode:     defaultRegularFileMode,
+	}, "same-handle.txt", &created); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	var out gofuse.AttrOut
+	if st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: created.NodeId},
+			Valid:    gofuse.FATTR_SIZE | gofuse.FATTR_FH,
+			Fh:       created.Fh,
+			Size:     0,
+		},
+	}, &out); st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+	if n, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: created.NodeId},
+		Fh:       created.Fh,
+	}, want); st != gofuse.OK || int(n) != len(want) {
+		t.Fatalf("Write = %d, %v; want %d, OK", n, st, len(want))
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: created.NodeId},
+		Fh:       created.Fh,
+	})
+
+	mu.Lock()
+	defer mu.Unlock()
+	if putCount != 1 || !bytes.Equal(putBody, want) {
+		t.Fatalf("remote PUTs/body = %d/%q, want 1/%q", putCount, putBody, want)
+	}
+}
+
+func TestGVisorCompatCommittedMutationSupersedesSiblingAndAllowsNewWrite(t *testing.T) {
+	const filePath = "/file.bin"
+	committed := []byte("committed")
+	fs, ino, closeServer := newTestDat9FS(t, int64(len(committed)), func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(committed)
+	})
+	defer closeServer()
+	fs.opts.GVisorCompat = true
+	fhID, sibling := newGVisorMutationHandle(t, fs, filePath, ino)
+
+	newerSeq := fs.markDirtySize(ino, int64(len(committed)))
+	fs.onCommitQueueSuccess(&CommitEntry{
+		Path:        filePath,
+		Inode:       ino,
+		MutationSeq: newerSeq,
+		Size:        int64(len(committed)),
+		Kind:        PendingNew,
+	}, 1)
+
+	sibling.Lock()
+	if sibling.DirtySeq != 0 || sibling.Dirty.HasDirtyParts() {
+		t.Fatalf("superseded sibling remains dirty: seq=%d dirty=%t", sibling.DirtySeq, sibling.Dirty.HasDirtyParts())
+	}
+	if sibling.BaseRev != 1 || sibling.Dirty.Size() != int64(len(committed)) || sibling.Dirty.maxSize < int64(len(committed)) {
+		t.Fatalf("superseded sibling base/size/max = %d/%d/%d, want 1/%d/>=%d", sibling.BaseRev, sibling.Dirty.Size(), sibling.Dirty.maxSize, len(committed), len(committed))
+	}
+	sibling.Unlock()
+
+	later := []byte("later")
+	if n, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       fhID,
+		Offset:   0,
+	}, later); st != gofuse.OK || int(n) != len(later) {
+		t.Fatalf("later Write = %d, %v; want %d, OK", n, st, len(later))
+	}
+	sibling.Lock()
+	if sibling.DirtySeq <= newerSeq {
+		t.Fatalf("later DirtySeq = %d, want > committed %d", sibling.DirtySeq, newerSeq)
+	}
+	if got := sibling.Dirty.Bytes()[:len(later)]; !bytes.Equal(got, later) {
+		t.Fatalf("later dirty prefix = %q, want %q", got, later)
+	}
+	sibling.Unlock()
+}
+
+func TestGVisorCompatCommittedMutationAllowsLaterExplicitTruncate(t *testing.T) {
+	const filePath = "/later-truncate.txt"
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	fhID, sibling := newGVisorMutationHandle(t, fs, filePath, ino)
+
+	newerSeq := fs.markDirtySize(ino, int64(len("committed")))
+	fs.onCommitQueueSuccess(&CommitEntry{
+		Path:        filePath,
+		Inode:       ino,
+		MutationSeq: newerSeq,
+		Size:        int64(len("committed")),
+		Kind:        PendingNew,
+	}, 1)
+
+	var out gofuse.AttrOut
+	if st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_SIZE | gofuse.FATTR_FH,
+			Fh:       fhID,
+			Size:     0,
+		},
+	}, &out); st != gofuse.OK {
+		t.Fatalf("later SetAttr status = %v, want OK", st)
+	}
+	sibling.Lock()
+	defer sibling.Unlock()
+	if sibling.DirtySeq <= newerSeq {
+		t.Fatalf("truncate DirtySeq = %d, want > committed %d", sibling.DirtySeq, newerSeq)
+	}
+	if sibling.Dirty.Size() != 0 || !sibling.Dirty.HasDirtyParts() {
+		t.Fatalf("later truncate state = size:%d dirty:%t, want size:0 dirty:true", sibling.Dirty.Size(), sibling.Dirty.HasDirtyParts())
+	}
+	if fs.discardSupersededMutationLocked(sibling) {
+		t.Fatal("genuinely later truncate was incorrectly superseded")
+	}
+}
+
+func TestGVisorCompatDisabledDoesNotSupersedeSiblingMutation(t *testing.T) {
+	const filePath = "/disabled.txt"
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	_, sibling := newGVisorMutationHandle(t, fs, filePath, ino)
+	staleSeq := sibling.DirtySeq
+	newerSeq := fs.markDirtySize(ino, 9)
+
+	fs.onCommitQueueSuccess(&CommitEntry{
+		Path:        filePath,
+		Inode:       ino,
+		MutationSeq: newerSeq,
+		Size:        9,
+		Kind:        PendingNew,
+	}, 1)
+
+	sibling.Lock()
+	defer sibling.Unlock()
+	if sibling.DirtySeq != staleSeq || !sibling.Dirty.HasDirtyParts() {
+		t.Fatalf("disabled sibling changed: seq=%d dirty=%t, want seq=%d dirty=true", sibling.DirtySeq, sibling.Dirty.HasDirtyParts(), staleSeq)
+	}
+}
+
+func TestGVisorCompatRenamePreflightRetriesInterruptedTargetStat(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		targetExists bool
+	}{
+		{name: "missing target"},
+		{name: "existing target", targetExists: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			firstStarted := make(chan struct{})
+			var headCalls atomic.Int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodHead || r.URL.Path != "/v1/fs/dst" {
+					http.Error(w, "unexpected request", http.StatusInternalServerError)
+					return
+				}
+				if headCalls.Add(1) == 1 {
+					close(firstStarted)
+					<-r.Context().Done()
+					return
+				}
+				if !tc.targetExists {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Length", "3")
+				w.Header().Set("X-Dat9-IsDir", "false")
+				w.Header().Set("X-Dat9-Revision", "4")
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{GVisorCompat: true, LookupRetryCount: 1, LookupRetryTimeout: time.Second}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			fs.inodes.Lookup("/src", false, 3, time.Now())
+
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan struct {
+				info renamePathInfo
+				st   gofuse.Status
+			}, 1)
+			go func() {
+				_, target, st := fs.renamePreflight(ctx, &gofuse.RenameIn{
+					InHeader: gofuse.InHeader{NodeId: 1},
+					Newdir:   1,
+				}, "/src", "/dst")
+				done <- struct {
+					info renamePathInfo
+					st   gofuse.Status
+				}{info: target, st: st}
+			}()
+
+			select {
+			case <-firstStarted:
+				cancel()
+			case <-time.After(time.Second):
+				t.Fatal("timed out waiting for initial target stat")
+			}
+			select {
+			case result := <-done:
+				if result.st != gofuse.OK {
+					t.Fatalf("renamePreflight status = %v, want OK", result.st)
+				}
+				if result.info.exists != tc.targetExists {
+					t.Fatalf("target exists = %t, want %t", result.info.exists, tc.targetExists)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("renamePreflight timed out")
+			}
+			if got := headCalls.Load(); got != 2 {
+				t.Fatalf("target HEAD calls = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestGVisorCompatRenamePreflightUsesNegativeTargetCache(t *testing.T) {
+	var remoteCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "target stat should use negative cache", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.inodes.Lookup("/src", false, 3, time.Now())
+	fs.cacheNegativePath("/dst")
+
+	_, target, st := fs.renamePreflight(context.Background(), &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Newdir:   1,
+	}, "/src", "/dst")
+	if st != gofuse.OK {
+		t.Fatalf("renamePreflight status = %v, want OK", st)
+	}
+	if target.exists {
+		t.Fatal("negative cached target unexpectedly exists")
+	}
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote calls = %d, want 0", got)
+	}
+}
+
+func TestGVisorCompatDisabledRenamePreflightDoesNotRetryInterrupt(t *testing.T) {
+	firstStarted := make(chan struct{})
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		headCalls.Add(1)
+		close(firstStarted)
+		<-r.Context().Done()
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{LookupRetryCount: 1, LookupRetryTimeout: time.Second}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.inodes.Lookup("/src", false, 3, time.Now())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		_, _, st := fs.renamePreflight(ctx, &gofuse.RenameIn{
+			InHeader: gofuse.InHeader{NodeId: 1},
+			Newdir:   1,
+		}, "/src", "/dst")
+		done <- st
+	}()
+	select {
+	case <-firstStarted:
+		cancel()
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for target stat")
+	}
+	select {
+	case st := <-done:
+		if st != gofuse.EAGAIN {
+			t.Fatalf("renamePreflight status = %v, want EAGAIN", st)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("renamePreflight timed out")
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("target HEAD calls = %d, want 1", got)
+	}
+}
+
+func TestGVisorCompatRenamePreflightRejectsRetryAfterMountViewReset(t *testing.T) {
+	firstStarted := make(chan struct{})
+	retryStarted := make(chan struct{})
+	allowRetry := make(chan struct{})
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch headCalls.Add(1) {
+		case 1:
+			close(firstStarted)
+			<-r.Context().Done()
+		case 2:
+			close(retryStarted)
+			<-allowRetry
+			http.NotFound(w, r)
+		default:
+			http.Error(w, "unexpected retry", http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true, LookupRetryCount: 1, LookupRetryTimeout: time.Second}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.inodes.Lookup("/src", false, 3, time.Now())
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		_, _, st := fs.renamePreflight(ctx, &gofuse.RenameIn{
+			InHeader: gofuse.InHeader{NodeId: 1},
+			Newdir:   1,
+		}, "/src", "/dst")
+		done <- st
+	}()
+
+	select {
+	case <-firstStarted:
+		cancel()
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for initial target stat")
+	}
+	select {
+	case <-retryStarted:
+		fs.resetMountView()
+		close(allowRetry)
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for detached retry")
+	}
+	select {
+	case st := <-done:
+		if st != gofuse.EAGAIN {
+			t.Fatalf("renamePreflight status = %v, want EAGAIN", st)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("renamePreflight timed out after mount reset")
+	}
+	if got := headCalls.Load(); got != 2 {
+		t.Fatalf("target HEAD calls = %d, want 2", got)
+	}
+}
+
+func TestGVisorCompatUnlinkKeepsRemoteMutationAliveAfterInterrupt(t *testing.T) {
+	const filePath = "/dir/file.txt"
+	deleteStarted := make(chan struct{})
+	deleteCanceled := make(chan struct{})
+	allowDelete := make(chan struct{})
+	var (
+		deleteCalls atomic.Int32
+		closeAllow  sync.Once
+	)
+	t.Cleanup(func() { closeAllow.Do(func() { close(allowDelete) }) })
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodDelete:
+			deleteCalls.Add(1)
+			close(deleteStarted)
+			select {
+			case <-r.Context().Done():
+				close(deleteCanceled)
+				return
+			case <-allowDelete:
+				_ = json.NewEncoder(w).Encode(map[string]string{"status": "ok"})
+			}
+		case http.MethodHead:
+			w.Header().Set("Content-Length", "4")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	parentIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+	fs.inodes.Lookup(filePath, false, 4, time.Now())
+	cancel := make(chan struct{})
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		done <- fs.Unlink(cancel, &gofuse.InHeader{NodeId: parentIno}, "file.txt")
+	}()
+
+	select {
+	case <-deleteStarted:
+		close(cancel)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for remote DELETE")
+	}
+	select {
+	case <-deleteCanceled:
+		// Current behavior: the assertion below will expose EAGAIN.
+	case <-time.After(100 * time.Millisecond):
+		closeAllow.Do(func() { close(allowDelete) })
+	}
+	select {
+	case st := <-done:
+		if st != gofuse.OK {
+			t.Fatalf("Unlink status = %v, want OK", st)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Unlink timed out")
+	}
+	if got := deleteCalls.Load(); got != 1 {
+		t.Fatalf("DELETE calls = %d, want 1", got)
+	}
+	if _, ok := fs.inodes.GetInode(filePath); ok {
+		t.Fatal("successful unlink kept the local path")
+	}
+}
+
+func TestGVisorCompatRenameKeepsRemoteMutationAliveAfterInterrupt(t *testing.T) {
+	renameStarted := make(chan struct{})
+	renameCanceled := make(chan struct{})
+	allowRename := make(chan struct{})
+	var (
+		renameCalls atomic.Int32
+		closeAllow  sync.Once
+	)
+	t.Cleanup(func() { closeAllow.Do(func() { close(allowRename) }) })
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs/dst" && r.URL.RawQuery == "rename":
+			if renameCalls.Add(1) == 1 {
+				close(renameStarted)
+				select {
+				case <-r.Context().Done():
+					close(renameCanceled)
+					return
+				case <-allowRename:
+					w.WriteHeader(http.StatusOK)
+					return
+				}
+			}
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs/dst":
+			http.NotFound(w, r)
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs/src":
+			w.Header().Set("Content-Length", "3")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		default:
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.inodes.Lookup("/src", false, 3, time.Now())
+	fs.cacheNegativePath("/dst")
+	cancel := make(chan struct{})
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		done <- fs.Rename(cancel, &gofuse.RenameIn{
+			InHeader: gofuse.InHeader{NodeId: 1},
+			Newdir:   1,
+		}, "src", "dst")
+	}()
+
+	select {
+	case <-renameStarted:
+		close(cancel)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for remote rename")
+	}
+	select {
+	case <-renameCanceled:
+		// The request must remain live in compatibility mode; count catches retry.
+	case <-time.After(100 * time.Millisecond):
+		closeAllow.Do(func() { close(allowRename) })
+	}
+	select {
+	case st := <-done:
+		if st != gofuse.OK {
+			t.Fatalf("Rename status = %v, want OK", st)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("Rename timed out")
+	}
+	if got := renameCalls.Load(); got != 1 {
+		t.Fatalf("remote rename calls = %d, want 1", got)
+	}
+	if _, ok := fs.inodes.GetInode("/dst"); !ok {
+		t.Fatal("successful rename did not install target inode")
+	}
+}
+
+func TestGVisorCompatOpenHandleSnapshotUsesRevisionMatchingReadCache(t *testing.T) {
+	const (
+		filePath = "/cached-snapshot.txt"
+		revision = int64(7)
+	)
+	data := []byte("cached snapshot bytes")
+	for _, tc := range []struct {
+		name         string
+		gvisorCompat bool
+		cacheRev     int64
+		wantGets     int32
+	}{
+		{name: "enabled matching revision", gvisorCompat: true, cacheRev: revision, wantGets: 0},
+		{name: "enabled stale revision", gvisorCompat: true, cacheRev: revision - 1, wantGets: 1},
+		{name: "disabled matching revision", cacheRev: revision, wantGets: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var getCalls atomic.Int32
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+					return
+				}
+				getCalls.Add(1)
+				_, _ = w.Write(data)
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{GVisorCompat: tc.gvisorCompat}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			ino := fs.inodes.Lookup(filePath, false, int64(len(data)), time.Now())
+			fs.inodes.UpdateRevision(ino, revision)
+			fs.readCache.Put(filePath, data, tc.cacheRev)
+			fh := &FileHandle{
+				Ino:      ino,
+				Path:     filePath,
+				Dirty:    fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+				OrigSize: int64(len(data)),
+				BaseRev:  revision,
+			}
+			fs.allocateFileHandle(fh)
+
+			if err := fs.snapshotOpenHandlesBeforeUnlink(context.Background(), filePath); err != nil {
+				t.Fatalf("snapshotOpenHandlesBeforeUnlink: %v", err)
+			}
+			fh.Lock()
+			gotSnapshot := append([]byte(nil), fh.UnlinkedData...)
+			fh.Unlock()
+			if !bytes.Equal(gotSnapshot, data) {
+				t.Fatalf("snapshot = %q, want %q", gotSnapshot, data)
+			}
+			if got := getCalls.Load(); got != tc.wantGets {
+				t.Fatalf("remote GET calls = %d, want %d", got, tc.wantGets)
+			}
+		})
+	}
+}

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -355,6 +355,56 @@ func TestGVisorCompatCommitQueueSkipsSupersededEntryBeforeUpload(t *testing.T) {
 	}
 }
 
+func TestGVisorCompatCommitQueueOrdersHardlinkAliasesByInode(t *testing.T) {
+	const ino = uint64(42)
+	older := &CommitEntry{Path: "/alias-b", Inode: ino, MutationSeq: 1}
+	newer := &CommitEntry{Path: "/alias-a", Inode: ino, MutationSeq: 2}
+
+	cq := &CommitQueue{
+		queue:                   []*CommitEntry{newer, older},
+		queuedByPath:            map[string]map[*CommitEntry]struct{}{newer.Path: {newer: {}}, older.Path: {older: {}}},
+		inFlight:                map[string]*CommitEntry{newer.Path: newer},
+		serializeMutationInodes: true,
+	}
+	if !cq.hasNewerMutation(older.Path, ino, older.MutationSeq) {
+		t.Fatal("newer queued hardlink alias was not visible to stale staging")
+	}
+	if cq.tryBeginInFlight(older) {
+		t.Fatal("hardlink alias upload began while the same inode was already in flight")
+	}
+
+	cq = &CommitQueue{
+		queue:                   []*CommitEntry{older, newer},
+		queuedByPath:            map[string]map[*CommitEntry]struct{}{newer.Path: {newer: {}}, older.Path: {older: {}}},
+		inFlight:                make(map[string]*CommitEntry),
+		serializeMutationInodes: true,
+	}
+	if cq.tryBeginInFlight(newer) {
+		t.Fatal("newer hardlink alias bypassed the older queued inode mutation")
+	}
+	if !cq.tryBeginInFlight(older) {
+		t.Fatal("oldest queued inode mutation did not begin")
+	}
+}
+
+func TestGVisorCompatDisabledCommitQueueDoesNotOrderHardlinkAliases(t *testing.T) {
+	const ino = uint64(42)
+	older := &CommitEntry{Path: "/alias-b", Inode: ino, MutationSeq: 1}
+	newer := &CommitEntry{Path: "/alias-a", Inode: ino, MutationSeq: 2}
+	cq := &CommitQueue{
+		queue:        []*CommitEntry{newer, older},
+		queuedByPath: map[string]map[*CommitEntry]struct{}{newer.Path: {newer: {}}, older.Path: {older: {}}},
+		inFlight:     map[string]*CommitEntry{newer.Path: newer},
+	}
+
+	if cq.hasNewerMutation(older.Path, ino, older.MutationSeq) {
+		t.Fatal("disabled compatibility mode inspected another hardlink path")
+	}
+	if !cq.tryBeginInFlight(older) {
+		t.Fatal("disabled compatibility mode serialized hardlink aliases")
+	}
+}
+
 func TestGVisorCompatSupersededEntryDoesNotRemoveNewerStaging(t *testing.T) {
 	const filePath = "/superseded-generation.txt"
 	opts := &MountOptions{GVisorCompat: true}
@@ -1498,5 +1548,56 @@ func TestGVisorCompatOpenHandleSnapshotUsesRevisionMatchingReadCache(t *testing.
 				t.Fatalf("remote GET calls = %d, want %d", got, tc.wantGets)
 			}
 		})
+	}
+}
+
+func TestGVisorCompatOpenHandleSnapshotRejectsRevisionBehindCommittedFrontier(t *testing.T) {
+	const (
+		filePath          = "/committed-frontier-snapshot.txt"
+		inodeRevision     = int64(1)
+		committedRevision = int64(2)
+	)
+	oldData := []byte("old bytes")
+	newData := []byte("new bytes")
+	var getCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+			return
+		}
+		getCalls.Add(1)
+		_, _ = w.Write(newData)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup(filePath, false, int64(len(oldData)), time.Now())
+	fs.inodes.UpdateRevision(ino, inodeRevision)
+	fs.readCache.Put(filePath, oldData, inodeRevision)
+	seq := fs.markDirtySize(ino, int64(len(newData)))
+	fs.recordCommittedRevision(filePath, committedRevision)
+	fs.recordCommittedMutation(ino, seq, committedRevision, int64(len(newData)))
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     filePath,
+		Dirty:    fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+		OrigSize: int64(len(oldData)),
+		BaseRev:  inodeRevision,
+	}
+	fs.allocateFileHandle(fh)
+
+	if err := fs.snapshotOpenHandlesBeforeUnlink(context.Background(), filePath); err != nil {
+		t.Fatalf("snapshotOpenHandlesBeforeUnlink: %v", err)
+	}
+	fh.Lock()
+	got := append([]byte(nil), fh.UnlinkedData...)
+	fh.Unlock()
+	if !bytes.Equal(got, newData) {
+		t.Fatalf("snapshot = %q, want latest committed %q", got, newData)
+	}
+	if got := getCalls.Load(); got != 1 {
+		t.Fatalf("remote GET calls = %d, want 1 after rejecting stale cache", got)
 	}
 }

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -910,7 +910,7 @@ func TestGVisorCompatCommitNowOrdersHardlinkAliasesByInode(t *testing.T) {
 	}
 	done := make(chan result, 1)
 	go func() {
-		release, discard, err := cq.beginImmediateMutationCommit(context.Background(), newer)
+		release, discard, err := cq.beginImmediateMutationCommit(context.Background(), newer, false)
 		done <- result{release: release, discard: discard, err: err}
 	}()
 	select {
@@ -941,9 +941,114 @@ func TestGVisorCompatCommitNowOrdersHardlinkAliasesByInode(t *testing.T) {
 		inFlight:                make(map[string]*CommitEntry),
 		serializeMutationInodes: true,
 	}
-	release, discard, err := cq.beginImmediateMutationCommit(context.Background(), older)
+	release, discard, err := cq.beginImmediateMutationCommit(context.Background(), older, false)
 	if err != nil || !discard || release != nil {
 		t.Fatalf("older immediate result = release:%v discard:%t err:%v, want discarded", release != nil, discard, err)
+	}
+}
+
+func TestGVisorCompatPathLockedImmediateCommitDoesNotWaitForSamePathWorker(t *testing.T) {
+	const ino = uint64(42)
+	older := &CommitEntry{Path: "/same-path", Inode: ino, MutationSeq: 1}
+	newer := &CommitEntry{Path: "/same-path", Inode: ino, MutationSeq: 2}
+	cq := &CommitQueue{
+		inFlight:                map[string]*CommitEntry{older.Path: older},
+		queuedByPath:            make(map[string]map[*CommitEntry]struct{}),
+		immediate:               make(map[*CommitEntry]struct{}),
+		serializeMutationInodes: true,
+	}
+
+	done := make(chan struct {
+		release func()
+		discard bool
+		err     error
+	}, 1)
+	go func() {
+		release, discard, err := cq.beginImmediateMutationCommit(context.Background(), newer, true)
+		done <- struct {
+			release func()
+			discard bool
+			err     error
+		}{release: release, discard: discard, err: err}
+	}()
+	select {
+	case got := <-done:
+		if got.err != nil || got.discard || got.release == nil {
+			t.Fatalf("path-locked immediate result = %+v, want acquired release", got)
+		}
+		got.release()
+	case <-time.After(time.Second):
+		t.Fatal("path-locked immediate commit waited for same-path in-flight worker")
+	}
+}
+
+func TestGVisorCompatLayerShadowCommitDoesNotRelockPathFence(t *testing.T) {
+	const filePath = "/layer-shadow.txt"
+	data := []byte("layer shadow data")
+	var pathLockCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/layers/layer-test/entries" {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"layer_id": "layer-test", "path": filePath, "op": "upsert", "kind": "file"})
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true, LayerRef: "layer-test"}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(filePath, data, 0); err != nil {
+		t.Fatal(err)
+	}
+	pendingGen, err := pending.PutWithBaseRev(filePath, int64(len(data)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	cq.SetLayerRef("layer-test")
+	cq.serializeMutationInodes = true
+	cq.PathLock = func(string) func() {
+		pathLockCalls.Add(1)
+		return func() {}
+	}
+	defer cq.DrainAll()
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = cq
+	ino := fs.inodes.Lookup(filePath, false, int64(len(data)), time.Now())
+	dirty := fs.newWriteBuffer(filePath, maxPreloadSize, 0)
+	if _, err := dirty.Write(0, data); err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Ino:             ino,
+		Path:            filePath,
+		Dirty:           dirty,
+		DirtySeq:        fs.markDirtySize(ino, int64(len(data))),
+		ShadowSpill:     true,
+		ShadowStageGen:  shadow.ActiveGeneration(filePath),
+		PendingIndexGen: pendingGen,
+		IsNew:           true,
+	}
+	fh.Lock()
+	err = fs.commitLayerShadowLocked(context.Background(), fh, false, true)
+	fh.Unlock()
+	if err != nil {
+		t.Fatalf("commitLayerShadowLocked: %v", err)
+	}
+	if got := pathLockCalls.Load(); got != 0 {
+		t.Fatalf("path fence locks = %d, want 0 while already held", got)
 	}
 }
 

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -1157,6 +1157,65 @@ func TestGVisorCompatLayerShadowCommitDoesNotRelockPathFence(t *testing.T) {
 	}
 }
 
+func TestLayerShadowCommitDoesNotRelockInheritedFence(t *testing.T) {
+	const filePath = "/layer-shadow-inherited-fence.txt"
+	data := []byte("layer shadow data")
+	var pathLockCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v1/layers/layer-test/entries" {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"layer_id": "layer-test", "path": filePath, "op": "upsert", "kind": "file"})
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{LayerRef: "layer-test"}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	if err := shadow.WriteFull(filePath, data, 0); err != nil {
+		t.Fatal(err)
+	}
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, nil, nil, 1, 8)
+	cq.SetLayerRef("layer-test")
+	cq.PathLock = func(string) func() {
+		pathLockCalls.Add(1)
+		return func() {}
+	}
+	defer cq.DrainAll()
+	fs.shadowStore = shadow
+	fs.commitQueue = cq
+	ino := fs.inodes.Lookup(filePath, false, int64(len(data)), time.Now())
+	dirty := fs.newWriteBuffer(filePath, maxPreloadSize, 0)
+	if _, err := dirty.Write(0, data); err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Ino:                ino,
+		Path:               filePath,
+		Dirty:              dirty,
+		ShadowSpill:        true,
+		ShadowStageGen:     shadow.ActiveGeneration(filePath),
+		IsNew:              true,
+		RemoteCommitUnlock: func() {},
+	}
+	fh.Lock()
+	err = fs.commitLayerShadowLocked(context.Background(), fh, false, false)
+	fh.Unlock()
+	if err != nil {
+		t.Fatalf("commitLayerShadowLocked: %v", err)
+	}
+	if got := pathLockCalls.Load(); got != 0 {
+		t.Fatalf("path fence locks = %d, want 0 while inherited fence is held", got)
+	}
+}
+
 func TestGVisorCompatLayerShadowCommitPreservesConcurrentWrite(t *testing.T) {
 	const filePath = "/layer-shadow-concurrent.txt"
 	original := []byte("original layer shadow data")

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -170,6 +170,510 @@ func TestGVisorCompatReleaseDiscardsSupersededCrossHandleTruncate(t *testing.T) 
 	}
 }
 
+func TestGVisorCompatStageAfterCommitFenceDiscardsSupersededHandle(t *testing.T) {
+	const filePath = "/commit-fence.txt"
+	newer := []byte("newer committed content")
+	putStarted := make(chan struct{})
+	releasePut := make(chan struct{})
+	var releaseOnce sync.Once
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/fs"+filePath {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		if !bytes.Equal(body, newer) {
+			t.Errorf("PUT body = %q, want %q", body, newer)
+		}
+		close(putStarted)
+		<-releasePut
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true, SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.PathLock = fs.lockRemoteCommitPath
+	cq.OnSuccess = fs.onCommitQueueSuccess
+	cq.OnCleanup = fs.onCommitQueueCleanup
+	fs.commitQueue = cq
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releasePut) })
+		cq.DrainAll()
+	})
+
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	_, stale := newGVisorMutationHandle(t, fs, filePath, ino)
+	newerSeq := fs.markDirtySize(ino, int64(len(newer)))
+	if err := shadow.WriteFull(filePath, newer, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(filePath, int64(len(newer)), PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:        filePath,
+		Inode:       ino,
+		MutationSeq: newerSeq,
+		Size:        int64(len(newer)),
+		Kind:        PendingNew,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-putStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for newer upload")
+	}
+
+	staleLocked := make(chan struct{})
+	stageDone := make(chan error, 1)
+	go func() {
+		stale.Lock()
+		close(staleLocked)
+		err := fs.stageShadowForQueuedCommitLocked(stale, true)
+		stale.Unlock()
+		stageDone <- err
+	}()
+	<-staleLocked
+	releaseOnce.Do(func() { close(releasePut) })
+
+	select {
+	case err := <-stageDone:
+		if err != nil {
+			t.Fatalf("stage stale handle: %v", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("stale handle did not resume after newer commit")
+	}
+
+	stale.Lock()
+	defer stale.Unlock()
+	if stale.DirtySeq != 0 || stale.Dirty.HasDirtyParts() {
+		t.Fatalf("stale handle remains dirty after commit-fence wait: seq=%d dirty=%t", stale.DirtySeq, stale.Dirty.HasDirtyParts())
+	}
+	if stale.BaseRev != 1 || stale.Dirty.Size() != int64(len(newer)) {
+		t.Fatalf("stale handle base/size = %d/%d, want 1/%d", stale.BaseRev, stale.Dirty.Size(), len(newer))
+	}
+	if shadow.Has(filePath) {
+		staged, err := shadow.ReadAll(filePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(staged, newer) {
+			t.Fatalf("superseded handle replaced newer shadow with %q", staged)
+		}
+	}
+}
+
+func TestGVisorCompatCommitQueueSkipsSupersededEntryBeforeUpload(t *testing.T) {
+	const filePath = "/superseded-before-upload.txt"
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			putCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+			return
+		}
+		http.Error(w, "unexpected request", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	staleSeq := fs.markDirtySize(ino, int64(len("stale")))
+	fs.markDirtySize(ino, int64(len("newer")))
+	if err := shadow.WriteFull(filePath, []byte("stale"), 0); err != nil {
+		t.Fatal(err)
+	}
+	pendingGen, err := pending.PutWithBaseRev(filePath, int64(len("stale")), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.IsSuperseded = fs.commitEntrySuperseded
+	defer cq.DrainAll()
+	if err := cq.Enqueue(&CommitEntry{
+		Path:            filePath,
+		Inode:           ino,
+		MutationSeq:     staleSeq,
+		PendingIndexGen: pendingGen,
+		ShadowGen:       shadow.ActiveGeneration(filePath),
+		Size:            int64(len("stale")),
+		Kind:            PendingNew,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer waitCancel()
+	if err := cq.WaitIdle(waitCtx); err != nil {
+		t.Fatal(err)
+	}
+	if got := putCalls.Load(); got != 0 {
+		t.Fatalf("PUT calls = %d, want 0", got)
+	}
+	if shadow.Has(filePath) || pending.HasPending(filePath) {
+		t.Fatal("superseded entry staging was not removed")
+	}
+}
+
+func TestGVisorCompatSupersededEntryDoesNotRemoveNewerStaging(t *testing.T) {
+	const filePath = "/superseded-generation.txt"
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	staleSeq := fs.markDirtySize(ino, int64(len("stale")))
+	if err := shadow.WriteFull(filePath, []byte("stale"), 0); err != nil {
+		t.Fatal(err)
+	}
+	stalePendingGen, err := pending.PutWithBaseRev(filePath, int64(len("stale")), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry := &CommitEntry{
+		Path:            filePath,
+		Inode:           ino,
+		MutationSeq:     staleSeq,
+		PendingIndexGen: stalePendingGen,
+		ShadowGen:       shadow.ActiveGeneration(filePath),
+		Size:            int64(len("stale")),
+		Kind:            PendingNew,
+	}
+
+	fs.markDirtySize(ino, int64(len("newer")))
+	if err := shadow.WriteFull(filePath, []byte("newer"), 0); err != nil {
+		t.Fatal(err)
+	}
+	newPendingGen, err := pending.PutWithBaseRev(filePath, int64(len("newer")), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient("http://127.0.0.1"), shadow, pending, nil, 1, 8)
+	cq.IsSuperseded = fs.commitEntrySuperseded
+	defer cq.DrainAll()
+	if err := cq.CommitNow(context.Background(), entry); err != nil {
+		t.Fatal(err)
+	}
+	got, err := shadow.ReadAll(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(got, []byte("newer")) {
+		t.Fatalf("shadow content = %q, want newer", got)
+	}
+	if gotGen := pending.Generation(filePath); gotGen != newPendingGen {
+		t.Fatalf("pending generation = %d, want newer generation %d", gotGen, newPendingGen)
+	}
+}
+
+func TestGVisorCompatCommitQueueSkipsEntrySupersededBeforeLWW(t *testing.T) {
+	const filePath = "/superseded-before-lww.txt"
+	localData := []byte("stale local")
+	remoteData := []byte("newer remote")
+	readStarted := make(chan struct{})
+	releaseRead := make(chan struct{})
+	var releaseOnce sync.Once
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodPut:
+			if putCalls.Add(1) == 1 {
+				http.Error(w, "revision conflict", http.StatusConflict)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 3})
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(remoteData)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "2")
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			close(readStarted)
+			<-releaseRead
+			_, _ = w.Write(remoteData)
+		default:
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ino := fs.inodes.Lookup(filePath, false, int64(len(localData)), time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+	seq := fs.markDirtySize(ino, int64(len(localData)))
+	if err := shadow.WriteFull(filePath, localData, 1); err != nil {
+		t.Fatal(err)
+	}
+	pendingGen, err := pending.PutWithBaseRev(filePath, int64(len(localData)), PendingOverwrite, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.IsSuperseded = fs.commitEntrySuperseded
+	t.Cleanup(func() {
+		releaseOnce.Do(func() { close(releaseRead) })
+		cq.DrainAll()
+	})
+	if err := cq.Enqueue(&CommitEntry{
+		Path:            filePath,
+		Inode:           ino,
+		MutationSeq:     seq,
+		PendingIndexGen: pendingGen,
+		ShadowGen:       shadow.ActiveGeneration(filePath),
+		BaseRev:         1,
+		Size:            int64(len(localData)),
+		Kind:            PendingOverwrite,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-readStarted:
+	case <-time.After(3 * time.Second):
+		t.Fatal("timed out waiting for conflict read")
+	}
+	fs.markDirtySize(ino, int64(len("latest local")))
+	releaseOnce.Do(func() { close(releaseRead) })
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer waitCancel()
+	if err := cq.WaitIdle(waitCtx); err != nil {
+		t.Fatal(err)
+	}
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want only initial conflicting PUT", got)
+	}
+	if shadow.Has(filePath) || pending.HasPending(filePath) {
+		t.Fatal("superseded LWW entry staging was not removed")
+	}
+}
+
+func TestGVisorCompatCommitQueueFiltersSupersededBatchEntry(t *testing.T) {
+	const (
+		stalePath = "/batch-stale.txt"
+		validPath = "/batch-valid.txt"
+	)
+	var batchCalls atomic.Int32
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-write":
+			batchCalls.Add(1)
+			http.Error(w, "superseded entry must be filtered before batching", http.StatusInternalServerError)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+validPath:
+			putCalls.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+		default:
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	staleIno := fs.inodes.Lookup(stalePath, false, 5, time.Now())
+	staleSeq := fs.markDirtySize(staleIno, 5)
+	fs.markDirtySize(staleIno, 6)
+	validIno := fs.inodes.Lookup(validPath, false, 5, time.Now())
+	validSeq := fs.markDirtySize(validIno, 5)
+	if err := shadow.WriteFull(stalePath, []byte("stale"), 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(validPath, []byte("valid"), 0); err != nil {
+		t.Fatal(err)
+	}
+	stalePendingGen, err := pending.PutWithBaseRev(stalePath, 5, PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	validPendingGen, err := pending.PutWithBaseRev(validPath, 5, PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.IsSuperseded = fs.commitEntrySuperseded
+	cq.ConfigureBatchWrite(20*time.Millisecond, 8, 1<<20)
+	defer cq.DrainAll()
+	if err := cq.Enqueue(&CommitEntry{
+		Path:            stalePath,
+		Inode:           staleIno,
+		MutationSeq:     staleSeq,
+		PendingIndexGen: stalePendingGen,
+		ShadowGen:       shadow.ActiveGeneration(stalePath),
+		Size:            5,
+		Kind:            PendingNew,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:            validPath,
+		Inode:           validIno,
+		MutationSeq:     validSeq,
+		PendingIndexGen: validPendingGen,
+		ShadowGen:       shadow.ActiveGeneration(validPath),
+		Size:            5,
+		Kind:            PendingNew,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer waitCancel()
+	if err := cq.WaitIdle(waitCtx); err != nil {
+		t.Fatal(err)
+	}
+	if got := batchCalls.Load(); got != 0 {
+		t.Fatalf("batch calls = %d, want 0 after filtering to one entry", got)
+	}
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("valid PUT calls = %d, want 1", got)
+	}
+	if shadow.Has(stalePath) || pending.HasPending(stalePath) {
+		t.Fatal("superseded batch staging was not removed")
+	}
+}
+
+func TestGVisorCompatDisabledCommitQueueDoesNotFilterMutationSequence(t *testing.T) {
+	const filePath = "/disabled-sequence-filter.txt"
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		putCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(filePath, []byte("stale"), 0); err != nil {
+		t.Fatal(err)
+	}
+	pendingGen, err := pending.PutWithBaseRev(filePath, 5, PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ino := fs.inodes.Lookup(filePath, false, 5, time.Now())
+	staleSeq := fs.markDirtySize(ino, 5)
+	fs.markDirtySize(ino, 6)
+
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.IsSuperseded = fs.commitEntrySuperseded
+	defer cq.DrainAll()
+	if err := cq.Enqueue(&CommitEntry{
+		Path:            filePath,
+		Inode:           ino,
+		MutationSeq:     staleSeq,
+		PendingIndexGen: pendingGen,
+		ShadowGen:       shadow.ActiveGeneration(filePath),
+		Size:            5,
+		Kind:            PendingNew,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitCtx, waitCancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer waitCancel()
+	if err := cq.WaitIdle(waitCtx); err != nil {
+		t.Fatal(err)
+	}
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want 1 with GVisorCompat disabled", got)
+	}
+}
+
 func TestGVisorCompatSameHandleTruncateThenWriteRemainsCorrect(t *testing.T) {
 	want := []byte("same handle content")
 	var (
@@ -459,6 +963,125 @@ func TestGVisorCompatRenamePreflightUsesNegativeTargetCache(t *testing.T) {
 	}
 	if got := remoteCalls.Load(); got != 0 {
 		t.Fatalf("remote calls = %d, want 0", got)
+	}
+}
+
+func TestGVisorCompatRenamePreflightRevalidatesNegativeTargetInStickyDirectory(t *testing.T) {
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead || r.URL.Path != "/v1/fs/dst" {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		headCalls.Add(1)
+		w.Header().Set("Content-Length", "1")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", "1")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.uid = 0
+	fs.gid = 0
+	fs.inodes.UpdateMode(1, uint32(syscall.S_IFDIR)|0o1777)
+	fs.inodes.UpdateOwner(1, 0, 0, true, true)
+	srcIno := fs.inodes.Lookup("/src", false, 3, time.Now())
+	fs.inodes.UpdateMode(srcIno, uint32(syscall.S_IFREG)|0o644)
+	fs.inodes.UpdateOwner(srcIno, 65534, 65534, true, true)
+	fs.cacheNegativePath("/dst")
+
+	_, target, st := fs.renamePreflight(context.Background(), &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{
+			NodeId: 1,
+			Caller: gofuse.Caller{Owner: gofuse.Owner{Uid: 65534, Gid: 65534}},
+		},
+		Newdir: 1,
+	}, "/src", "/dst")
+	if st != gofuse.EPERM {
+		t.Fatalf("renamePreflight status = %v, want EPERM", st)
+	}
+	if !target.exists {
+		t.Fatal("revalidated target unexpectedly missing")
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("target HEAD calls = %d, want 1", got)
+	}
+}
+
+func TestGVisorCompatRenamePreflightRevalidatesNegativeTargetForDirectorySource(t *testing.T) {
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead || r.URL.Path != "/v1/fs/dst" {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		headCalls.Add(1)
+		w.Header().Set("Content-Length", "1")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", "1")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	srcIno := fs.inodes.Lookup("/src", true, 0, time.Now())
+	fs.inodes.UpdateMode(srcIno, uint32(syscall.S_IFDIR)|0o755)
+	fs.cacheNegativePath("/dst")
+
+	_, target, st := fs.renamePreflight(context.Background(), &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Newdir:   1,
+	}, "/src", "/dst")
+	if st != gofuse.Status(syscall.ENOTDIR) {
+		t.Fatalf("renamePreflight status = %v, want ENOTDIR", st)
+	}
+	if !target.exists {
+		t.Fatal("revalidated target unexpectedly missing")
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("target HEAD calls = %d, want 1", got)
+	}
+}
+
+func TestGVisorCompatRenamePreflightRevalidatesNegativeTargetForSpecialSource(t *testing.T) {
+	var headCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead || r.URL.Path != "/v1/fs/dst" {
+			http.Error(w, "unexpected request", http.StatusInternalServerError)
+			return
+		}
+		headCalls.Add(1)
+		w.Header().Set("Content-Length", "1")
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", "1")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	srcIno := fs.inodes.Lookup("/src", false, 0, time.Now())
+	fs.inodes.UpdateMode(srcIno, uint32(syscall.S_IFIFO)|0o644)
+	fs.cacheNegativePath("/dst")
+
+	_, target, st := fs.renamePreflight(context.Background(), &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Newdir:   1,
+	}, "/src", "/dst")
+	if st != gofuse.OK {
+		t.Fatalf("renamePreflight status = %v, want OK", st)
+	}
+	if !target.exists {
+		t.Fatal("revalidated target unexpectedly missing")
+	}
+	if got := headCalls.Load(); got != 1 {
+		t.Fatalf("target HEAD calls = %d, want 1", got)
 	}
 }
 

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -731,6 +731,37 @@ func TestGVisorCompatDiscardSupersededMutationRemovesOwnedStaging(t *testing.T) 
 	}
 }
 
+func TestGVisorCompatLayerDiscardRebindsCommittedShadow(t *testing.T) {
+	const filePath = "/layer-file.txt"
+	want := []byte("layer committed content")
+	opts := &MountOptions{GVisorCompat: true, LayerRef: "layer-test"}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1"), opts)
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	fs.shadowStore = shadow
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	_, stale := newGVisorMutationHandle(t, fs, filePath, ino)
+	if err := shadow.WriteFull(filePath, want, 0); err != nil {
+		t.Fatal(err)
+	}
+	newerSeq := fs.markDirtySize(ino, int64(len(want)))
+	fs.recordCommittedMutation(ino, newerSeq, 0, int64(len(want)))
+	stale.Lock()
+	discarded := fs.discardSupersededMutationLocked(stale)
+	got := stale.Dirty.Bytes()
+	stale.Unlock()
+	if !discarded {
+		t.Fatal("layer sibling was not discarded")
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("layer rebound content = %q, want %q", got, want)
+	}
+}
+
 func TestGVisorCompatQueueSuccessSynthesizesUnknownRevision(t *testing.T) {
 	const filePath = "/unknown-revision.txt"
 	opts := &MountOptions{GVisorCompat: true}

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -2574,3 +2574,200 @@ func TestGVisorCompatShadowSpillFlushRechecksSupersessionAfterFence(t *testing.T
 		t.Fatalf("stale Flush remote PUTs = %d, want 0", got)
 	}
 }
+
+func TestGVisorCompatWriteBackRequiresCommitQueue(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		gvisor      bool
+		writePolicy WritePolicy
+		writeBack   bool
+		commitQueue bool
+		want        bool
+	}{
+		{
+			name:        "gvisor writeback legacy fallback rejected",
+			gvisor:      true,
+			writePolicy: WritePolicyWriteBack,
+			writeBack:   true,
+			want:        true,
+		},
+		{
+			name:        "gvisor writeback queue available",
+			gvisor:      true,
+			writePolicy: WritePolicyWriteBack,
+			writeBack:   true,
+			commitQueue: true,
+		},
+		{
+			name:        "non gvisor legacy fallback preserved",
+			writePolicy: WritePolicyWriteBack,
+			writeBack:   true,
+		},
+		{
+			name:        "gvisor close sync has no legacy uploader path",
+			gvisor:      true,
+			writePolicy: WritePolicyCloseSync,
+			writeBack:   true,
+		},
+		{
+			name:        "gvisor without writeback cache",
+			gvisor:      true,
+			writePolicy: WritePolicyWriteBack,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &MountOptions{GVisorCompat: tc.gvisor, WritePolicy: tc.writePolicy}
+			opts.setDefaults()
+			var writeBack *WriteBackCache
+			if tc.writeBack {
+				writeBack = &WriteBackCache{}
+			}
+			var commitQueue *CommitQueue
+			if tc.commitQueue {
+				commitQueue = &CommitQueue{}
+			}
+			if got := gvisorWriteBackRequiresCommitQueue(opts, writeBack, commitQueue); got != tc.want {
+				t.Fatalf("gvisorWriteBackRequiresCommitQueue = %t, want %t", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGVisorCompatRenameMetadataOnlySpecialTargetDeleteSurvivesInterrupt(t *testing.T) {
+	deleteStarted := make(chan struct{})
+	deleteCanceled := make(chan struct{})
+	allowDelete := make(chan struct{})
+	var (
+		deleteCalls atomic.Int32
+		closeAllow  sync.Once
+	)
+	t.Cleanup(func() { closeAllow.Do(func() { close(allowDelete) }) })
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs/pipe":
+			http.NotFound(w, r)
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs/target":
+			w.Header().Set("Content-Length", "1")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/fs/target":
+			if deleteCalls.Add(1) != 1 {
+				http.Error(w, "unexpected retry", http.StatusInternalServerError)
+				return
+			}
+			close(deleteStarted)
+			select {
+			case <-r.Context().Done():
+				close(deleteCanceled)
+				return
+			case <-allowDelete:
+				w.WriteHeader(http.StatusNoContent)
+			}
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.String(), http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{GVisorCompat: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	var out gofuse.EntryOut
+	if st := fs.Mknod(nil, &gofuse.MknodIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Mode:     uint32(syscall.S_IFIFO) | 0o644,
+	}, "pipe", &out); st != gofuse.OK {
+		t.Fatalf("Mknod status = %v, want OK", st)
+	}
+
+	cancel := make(chan struct{})
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		done <- fs.Rename(cancel, &gofuse.RenameIn{InHeader: gofuse.InHeader{NodeId: 1}, Newdir: 1}, "pipe", "target")
+	}()
+	select {
+	case <-deleteStarted:
+		close(cancel)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for target DELETE")
+	}
+	select {
+	case <-deleteCanceled:
+		// The final status assertion exposes an interruptible mutation context.
+	case <-time.After(100 * time.Millisecond):
+		closeAllow.Do(func() { close(allowDelete) })
+	}
+	select {
+	case st := <-done:
+		if st != gofuse.OK {
+			t.Fatalf("Rename status = %v, want OK", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Rename did not finish")
+	}
+	if got := deleteCalls.Load(); got != 1 {
+		t.Fatalf("target DELETE calls = %d, want 1", got)
+	}
+	if _, ok := fs.specialNodeEntry("/target"); !ok {
+		t.Fatal("special source was not renamed to target")
+	}
+}
+
+func TestGVisorCompatDisabledRenameMetadataOnlySpecialTargetDeleteRemainsInterruptible(t *testing.T) {
+	deleteStarted := make(chan struct{})
+	var deleteCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs/pipe":
+			http.NotFound(w, r)
+		case r.Method == http.MethodHead && r.URL.Path == "/v1/fs/target":
+			w.Header().Set("Content-Length", "1")
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", "1")
+			w.WriteHeader(http.StatusOK)
+		case r.Method == http.MethodDelete && r.URL.Path == "/v1/fs/target":
+			deleteCalls.Add(1)
+			close(deleteStarted)
+			<-r.Context().Done()
+		default:
+			http.Error(w, "unexpected "+r.Method+" "+r.URL.String(), http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	var out gofuse.EntryOut
+	if st := fs.Mknod(nil, &gofuse.MknodIn{
+		InHeader: gofuse.InHeader{NodeId: 1},
+		Mode:     uint32(syscall.S_IFIFO) | 0o644,
+	}, "pipe", &out); st != gofuse.OK {
+		t.Fatalf("Mknod status = %v, want OK", st)
+	}
+
+	cancel := make(chan struct{})
+	done := make(chan gofuse.Status, 1)
+	go func() {
+		done <- fs.Rename(cancel, &gofuse.RenameIn{InHeader: gofuse.InHeader{NodeId: 1}, Newdir: 1}, "pipe", "target")
+	}()
+	select {
+	case <-deleteStarted:
+		close(cancel)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for target DELETE")
+	}
+	select {
+	case st := <-done:
+		if st != gofuse.EAGAIN {
+			t.Fatalf("Rename status = %v, want EAGAIN", st)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Rename did not return after interrupt")
+	}
+	if got := deleteCalls.Load(); got != 1 {
+		t.Fatalf("target DELETE calls = %d, want 1", got)
+	}
+}

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -1934,6 +1934,110 @@ func TestGVisorCompatRenamePreflightRejectsRetryAfterMountViewReset(t *testing.T
 	}
 }
 
+func TestGVisorCompatUnlinkSnapshotSurvivesInterrupt(t *testing.T) {
+	const filePath = "/dir/snapshot.txt"
+	data := []byte("open handle snapshot")
+	for _, tc := range []struct {
+		name         string
+		gvisorCompat bool
+		wantStatus   gofuse.Status
+		wantDeletes  int32
+	}{
+		{name: "gvisor", gvisorCompat: true, wantStatus: gofuse.OK, wantDeletes: 1},
+		{name: "disabled", wantStatus: gofuse.EAGAIN},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshotStarted := make(chan struct{})
+			snapshotCanceled := make(chan struct{})
+			allowSnapshot := make(chan struct{})
+			var (
+				snapshotCalls atomic.Int32
+				deleteCalls   atomic.Int32
+				allowOnce     sync.Once
+			)
+			t.Cleanup(func() { allowOnce.Do(func() { close(allowSnapshot) }) })
+
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					if snapshotCalls.Add(1) != 1 {
+						http.Error(w, "unexpected snapshot retry", http.StatusInternalServerError)
+						return
+					}
+					close(snapshotStarted)
+					select {
+					case <-r.Context().Done():
+						close(snapshotCanceled)
+						return
+					case <-allowSnapshot:
+						_, _ = w.Write(data)
+					}
+				case http.MethodDelete:
+					deleteCalls.Add(1)
+					w.WriteHeader(http.StatusOK)
+				default:
+					http.Error(w, "unexpected request", http.StatusMethodNotAllowed)
+				}
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{GVisorCompat: tc.gvisorCompat}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+			parentIno := fs.inodes.Lookup("/dir", true, 0, time.Now())
+			ino := fs.inodes.Lookup(filePath, false, int64(len(data)), time.Now())
+			fs.inodes.UpdateRevision(ino, 1)
+			fs.allocateFileHandle(&FileHandle{
+				Ino:      ino,
+				Path:     filePath,
+				Dirty:    fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+				OrigSize: int64(len(data)),
+				BaseRev:  1,
+			})
+
+			cancel := make(chan struct{})
+			done := make(chan gofuse.Status, 1)
+			go func() {
+				done <- fs.Unlink(cancel, &gofuse.InHeader{NodeId: parentIno}, "snapshot.txt")
+			}()
+
+			select {
+			case <-snapshotStarted:
+				close(cancel)
+			case <-time.After(time.Second):
+				t.Fatal("snapshot GET did not start")
+			}
+
+			if tc.gvisorCompat {
+				select {
+				case <-snapshotCanceled:
+					t.Fatal("gVisor snapshot GET was canceled by the FUSE request")
+				case <-time.After(100 * time.Millisecond):
+					allowOnce.Do(func() { close(allowSnapshot) })
+				}
+			} else {
+				select {
+				case <-snapshotCanceled:
+				case <-time.After(time.Second):
+					t.Fatal("disabled snapshot GET was not canceled")
+				}
+			}
+
+			select {
+			case st := <-done:
+				if st != tc.wantStatus {
+					t.Fatalf("Unlink status = %v, want %v", st, tc.wantStatus)
+				}
+			case <-time.After(3 * time.Second):
+				t.Fatal("Unlink timed out")
+			}
+			if got := deleteCalls.Load(); got != tc.wantDeletes {
+				t.Fatalf("DELETE calls = %d, want %d", got, tc.wantDeletes)
+			}
+		})
+	}
+}
+
 func TestGVisorCompatUnlinkKeepsRemoteMutationAliveAfterInterrupt(t *testing.T) {
 	const filePath = "/dir/file.txt"
 	deleteStarted := make(chan struct{})

--- a/pkg/fuse/gvisor_compat_test.go
+++ b/pkg/fuse/gvisor_compat_test.go
@@ -1008,11 +1008,11 @@ func TestGVisorCompatRenamePreflightRetriesInterruptedTargetStat(t *testing.T) {
 	}
 }
 
-func TestGVisorCompatRenamePreflightUsesNegativeTargetCache(t *testing.T) {
+func TestGVisorCompatRenamePreflightRevalidatesNegativeTargetCache(t *testing.T) {
 	var remoteCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		remoteCalls.Add(1)
-		http.Error(w, "target stat should use negative cache", http.StatusInternalServerError)
+		http.NotFound(w, r)
 	}))
 	defer ts.Close()
 
@@ -1032,8 +1032,8 @@ func TestGVisorCompatRenamePreflightUsesNegativeTargetCache(t *testing.T) {
 	if target.exists {
 		t.Fatal("negative cached target unexpectedly exists")
 	}
-	if got := remoteCalls.Load(); got != 0 {
-		t.Fatalf("remote calls = %d, want 0", got)
+	if got := remoteCalls.Load(); got != 1 {
+		t.Fatalf("remote calls = %d, want 1", got)
 	}
 }
 

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -81,6 +81,7 @@ type FileHandle struct {
 	WriteBackGen       uint64 // writeBack generation staged by this handle (0 = none)
 	PendingIndexGen    uint64 // pendingIndex generation staged by this handle (0 = none)
 	ShadowStageGen     uint64 // shadowStore content generation staged by this handle (0 = none)
+	ShadowStageSeq     uint64 // DirtySeq represented by ShadowStageGen
 	RemoteCommitUnlock func() // held same-path commit lock while local shadow state is reserved
 	mu                 sync.Mutex
 }

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -529,6 +529,8 @@ func Mount(opts *MountOptions) (err error) {
 				cq.SetPerfCounters(dat9fs.perf)
 				cq.OnSuccess = dat9fs.onCommitQueueSuccess
 				cq.OnCleanup = dat9fs.onCommitQueueCleanup
+				cq.OnDiscard = dat9fs.onCommitQueueDiscard
+				cq.IsSuperseded = dat9fs.commitEntrySuperseded
 				cq.PathLock = dat9fs.lockRemoteCommitPath
 				cq.DurableWatermark = dat9fs.latestCommittedRevision
 				if opts.WritePolicy == WritePolicyWriteBack && opts.WriteBackBatchWindow > 0 {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -532,6 +532,7 @@ func Mount(opts *MountOptions) (err error) {
 				cq.OnCleanup = dat9fs.onCommitQueueCleanup
 				cq.OnDiscard = dat9fs.onCommitQueueDiscard
 				cq.IsSuperseded = dat9fs.commitEntrySuperseded
+				cq.serializeMutationInodes = opts.GVisorCompat
 				cq.PathLock = dat9fs.lockRemoteCommitPath
 				cq.DurableWatermark = dat9fs.latestCommittedRevision
 				if opts.WritePolicy == WritePolicyWriteBack && opts.WriteBackBatchWindow > 0 {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -103,6 +103,14 @@ type MountOptions struct {
 
 const defaultUploadConcurrency = 16
 
+// gvisorWriteBackRequiresCommitQueue rejects the legacy write-back uploader
+// path for gVisor-compatible write-back mounts. That uploader persists only
+// path-owned metadata, so it cannot enforce the inode mutation ordering that
+// GVisorCompat requires.
+func gvisorWriteBackRequiresCommitQueue(opts *MountOptions, writeBack *WriteBackCache, commitQueue *CommitQueue) bool {
+	return opts != nil && opts.GVisorCompat && opts.WritePolicy == WritePolicyWriteBack && writeBack != nil && commitQueue == nil
+}
+
 func (o *MountOptions) setDefaults() {
 	// Apply profile defaults before generic defaults so profile-specific
 	// zero-value options can take effect while explicit non-zero values win.
@@ -547,6 +555,15 @@ func Mount(opts *MountOptions) (err error) {
 					layerEventWatcherStop = StartLayerEventWatcher(dat9fs, c, opts, shadowStore, pendingIdx)
 				}
 				dat9fs.commitQueue = cq
+			}
+			if gvisorWriteBackRequiresCommitQueue(opts, wbCache, dat9fs.commitQueue) {
+				if journal != nil {
+					_ = journal.Close()
+				}
+				if shadowStore != nil {
+					shadowStore.Close()
+				}
+				return errors.New("mount: gvisor compat write-back requires pending index and shadow store")
 			}
 
 			if wbCache != nil {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -108,7 +108,14 @@ const defaultUploadConcurrency = 16
 // path-owned metadata, so it cannot enforce the inode mutation ordering that
 // GVisorCompat requires.
 func gvisorWriteBackRequiresCommitQueue(opts *MountOptions, writeBack *WriteBackCache, commitQueue *CommitQueue) bool {
-	return opts != nil && opts.GVisorCompat && opts.WritePolicy == WritePolicyWriteBack && writeBack != nil && commitQueue == nil
+	if opts == nil {
+		return false
+	}
+	policy := opts.WritePolicy
+	if policy == "" {
+		policy = WritePolicyWriteBack
+	}
+	return opts.GVisorCompat && policy == WritePolicyWriteBack && writeBack != nil && commitQueue == nil
 }
 
 func (o *MountOptions) setDefaults() {

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -528,6 +528,7 @@ func Mount(opts *MountOptions) (err error) {
 				cq.SetLayerRef(opts.LayerRef)
 				cq.SetPerfCounters(dat9fs.perf)
 				cq.OnSuccess = dat9fs.onCommitQueueSuccess
+				cq.OnUploaded = dat9fs.onCommitQueueUploaded
 				cq.OnCleanup = dat9fs.onCommitQueueCleanup
 				cq.OnDiscard = dat9fs.onCommitQueueDiscard
 				cq.IsSuperseded = dat9fs.commitEntrySuperseded

--- a/pkg/fuse/remote_upload_test.go
+++ b/pkg/fuse/remote_upload_test.go
@@ -31,6 +31,8 @@ type multipartUploadRecorder struct {
 	statCalls        atomic.Int32
 	s3PutCalls       atomic.Int32
 	directFilePuts   atomic.Int32
+	completeStarted  chan struct{}
+	allowComplete    chan struct{}
 	mu               sync.Mutex
 	gotUploadedBytes int64
 }
@@ -190,6 +192,10 @@ func newMultipartUploadRecorder(t *testing.T, wantPath string, wantSize int64, w
 				if part.Number != wantNumber || part.ETag != "etag-1" {
 					t.Fatalf("complete part[%d] = %+v, want number=%d etag=etag-1", i, part, wantNumber)
 				}
+			}
+			if rec.completeStarted != nil {
+				close(rec.completeStarted)
+				<-rec.allowComplete
 			}
 			w.WriteHeader(http.StatusOK)
 			return

--- a/pkg/fuse/rename_posix.go
+++ b/pkg/fuse/rename_posix.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+
 	"github.com/mem9-ai/drive9/pkg/client"
 )
 
@@ -97,7 +98,7 @@ func (fs *Dat9FS) renamePreflight(ctx context.Context, input *gofuse.RenameIn, o
 	}
 
 	newInfo := renamePathInfo{path: newP}
-	if !fs.gvisorCompatibilityEnabled() || !fs.hasNegativePathCache(newP) {
+	if !fs.canUseNegativeRenameTarget(oldInfo, newParentInfo, newP) {
 		newInfo, err = fs.renamePathInfo(ctx, newP)
 		if err != nil {
 			return oldInfo, newInfo, httpToFuseStatus(err)
@@ -125,6 +126,16 @@ func (fs *Dat9FS) renamePreflight(ctx context.Context, input *gofuse.RenameIn, o
 	}
 
 	return oldInfo, newInfo, gofuse.OK
+}
+
+func (fs *Dat9FS) canUseNegativeRenameTarget(oldInfo, newParentInfo renamePathInfo, newP string) bool {
+	if !fs.gvisorCompatibilityEnabled() || !fs.hasNegativePathCache(newP) {
+		return false
+	}
+	if oldInfo.isDir || oldInfo.special {
+		return false
+	}
+	return newParentInfo.modeOrDefault()&stickyPermissionBit == 0
 }
 
 func (fs *Dat9FS) renameCheckParentAccess(caller gofuse.Owner, parent renamePathInfo) gofuse.Status {

--- a/pkg/fuse/rename_posix.go
+++ b/pkg/fuse/rename_posix.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+	"github.com/mem9-ai/drive9/pkg/client"
 )
 
 const stickyPermissionBit uint32 = 0o1000
@@ -95,9 +96,12 @@ func (fs *Dat9FS) renamePreflight(ctx context.Context, input *gofuse.RenameIn, o
 		return oldInfo, renamePathInfo{}, st
 	}
 
-	newInfo, err := fs.renamePathInfo(ctx, newP)
-	if err != nil {
-		return oldInfo, newInfo, httpToFuseStatus(err)
+	newInfo := renamePathInfo{path: newP}
+	if !fs.gvisorCompatibilityEnabled() || !fs.hasNegativePathCache(newP) {
+		newInfo, err = fs.renamePathInfo(ctx, newP)
+		if err != nil {
+			return oldInfo, newInfo, httpToFuseStatus(err)
+		}
 	}
 
 	if newInfo.exists {
@@ -186,9 +190,7 @@ func (fs *Dat9FS) renamePathInfo(ctx context.Context, p string) (renamePathInfo,
 		return renameInfoFromEntry(p, entry, false), nil
 	}
 
-	statStart := fs.perfStart()
-	stat, err := fs.client.StatCtx(ctx, fs.remotePath(p))
-	fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
+	stat, err := fs.renameStatWithTransientRetry(ctx, p)
 	if err != nil {
 		if isNotFoundErr(err) {
 			return info, nil
@@ -211,6 +213,49 @@ func (fs *Dat9FS) renamePathInfo(ctx context.Context, p string) (renamePathInfo,
 		return info, syscall.EIO
 	}
 	return renameInfoFromEntry(p, entry, false), nil
+}
+
+func (fs *Dat9FS) renameStatWithTransientRetry(ctx context.Context, p string) (*client.StatResult, error) {
+	gvisorCompat := fs.gvisorCompatibilityEnabled()
+	generation := fs.mountViewGeneration.Load()
+	statPath := func(statCtx context.Context) (*client.StatResult, error) {
+		statStart := fs.perfStart()
+		stat, err := fs.client.StatCtx(statCtx, fs.remotePath(p))
+		fs.perfRecordRemote(perfRemoteStat, statStart, err, 0)
+		return stat, err
+	}
+	viewCurrent := func() bool {
+		return fs.mountViewGeneration.Load() == generation
+	}
+
+	stat, err := statPath(ctx)
+	if gvisorCompat && !viewCurrent() {
+		return nil, context.Canceled
+	}
+	if err == nil || isNotFoundErr(err) || !gvisorCompat || !isTransientLookupErr(err) {
+		return stat, err
+	}
+
+	lastErr := err
+	for range fs.lookupStatRetryCount() {
+		if !viewCurrent() {
+			return nil, context.Canceled
+		}
+		retryCtx, retryCancel := context.WithTimeout(context.WithoutCancel(ctx), fs.lookupStatRetryTimeout())
+		stat, err = statPath(retryCtx)
+		retryCancel()
+		if !viewCurrent() {
+			return nil, context.Canceled
+		}
+		if err == nil || isNotFoundErr(err) {
+			return stat, err
+		}
+		if !isTransientLookupErr(err) {
+			return nil, err
+		}
+		lastErr = err
+	}
+	return nil, lastErr
 }
 
 func renameInfoFromEntry(p string, entry *InodeEntry, special bool) renamePathInfo {

--- a/pkg/fuse/rename_posix.go
+++ b/pkg/fuse/rename_posix.go
@@ -97,12 +97,9 @@ func (fs *Dat9FS) renamePreflight(ctx context.Context, input *gofuse.RenameIn, o
 		return oldInfo, renamePathInfo{}, st
 	}
 
-	newInfo := renamePathInfo{path: newP}
-	if !fs.canUseNegativeRenameTarget(oldInfo, newParentInfo, newP) {
-		newInfo, err = fs.renamePathInfo(ctx, newP)
-		if err != nil {
-			return oldInfo, newInfo, httpToFuseStatus(err)
-		}
+	newInfo, err := fs.renamePathInfo(ctx, newP)
+	if err != nil {
+		return oldInfo, newInfo, httpToFuseStatus(err)
 	}
 
 	if newInfo.exists {
@@ -126,16 +123,6 @@ func (fs *Dat9FS) renamePreflight(ctx context.Context, input *gofuse.RenameIn, o
 	}
 
 	return oldInfo, newInfo, gofuse.OK
-}
-
-func (fs *Dat9FS) canUseNegativeRenameTarget(oldInfo, newParentInfo renamePathInfo, newP string) bool {
-	if !fs.gvisorCompatibilityEnabled() || !fs.hasNegativePathCache(newP) {
-		return false
-	}
-	if oldInfo.isDir || oldInfo.special {
-		return false
-	}
-	return newParentInfo.modeOrDefault()&stickyPermissionBit == 0
 }
 
 func (fs *Dat9FS) renameCheckParentAccess(caller gofuse.Owner, parent renamePathInfo) gofuse.Status {


### PR DESCRIPTION
## Summary

1. Preserve gVisor cross-handle mutation ordering by carrying mutation sequences through commit entries and discarding superseded dirty snapshots.
2. Recover interrupted rename preflight metadata reads and keep committed rename/unlink requests alive after later FUSE interrupts.
3. Reuse revision-matching read-cache snapshots for open-handle preservation.
4. Gate all new behavior behind GVisorCompat so non-gVisor mounts retain existing semantics.

Closes #877
Closes #878

## Testing

1. Focused gVisor and existing rename/unlink interruption tests pass.
2. TestGVisorCompat tests pass for 10 consecutive runs.
3. Focused race tests pass.
4. make lint passes with 0 issues.
5. gofmt and git diff --check pass.

## Not run

1. Live Kubernetes gVisor E2E reproduction.
2. Full repository test suite; validation was intentionally scoped to affected tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gVisor-compatible handling of concurrent writes, truncates, and committed changes across open file handles.
  * Prevented superseded mutations from being staged, flushed, or uploaded.
  * Preserved remote mutations during interrupted unlink and rename operations.
  * Improved rename reliability with transient retries and negative-cache revalidation.
  * Ensured open-handle snapshots use the correct revision and read-cache state.
  * Improved commit reliability under backpressure and unknown remote revisions.

* **Tests**
  * Added comprehensive coverage for mutation ordering, commit filtering, interrupted namespace operations, cache behavior, and revision consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->