### PR TITLE
fix(fuse): fence writeback generations

### DIFF
--- a/e2e/fuse-supervision-test.sh
+++ b/e2e/fuse-supervision-test.sh
@@ -36,6 +36,7 @@ NO_RESTART_OBSERVE_S="${NO_RESTART_OBSERVE_S:-12}"
 FUSE_PROBE_TIMEOUT_S="${FUSE_PROBE_TIMEOUT_S:-10}"
 # close-sync write+read can exceed 10s under CI load; keep mountpoint/health shorter.
 FUSE_IO_PROBE_TIMEOUT_S="${FUSE_IO_PROBE_TIMEOUT_S:-30}"
+CACHE_PROBE_TIMEOUT_S="${CACHE_PROBE_TIMEOUT_S:-90}"
 FUSE_MOUNT_ROOT="${FUSE_MOUNT_ROOT:-/tmp}"
 FUSE_STRICT_PREREQS="${FUSE_STRICT_PREREQS:-0}"
 FUSE_UMOUNT_TIMEOUT="${FUSE_UMOUNT_TIMEOUT:-45s}"
@@ -166,6 +167,82 @@ probe_mount_io() {
     got="$(tr -d "\n" <"$f" 2>/dev/null || true)"
     [ "$got" = "$marker" ]
   ' _ "$marker" "$f"
+}
+
+probe_cache_invalidation_io() {
+  local marker="$1"
+  local dir="$MOUNT_POINT/cache-invalidation-$marker"
+  with_timeout "$CACHE_PROBE_TIMEOUT_S" bash -c '
+    set -euo pipefail
+    marker="$1"
+    dir="$2"
+    mkdir -p "$dir"
+
+    # O_TRUNC / shell-redirection path: the immediate close-to-open read must
+    # not observe the transient 0-byte truncate image or older kernel pages.
+    f="$dir/o-trunc.txt"
+    printf "seed-%s\n" "$marker" >"$f"
+    for i in 1 2 3; do
+      want="o-trunc-${marker}-${i}"
+      printf "%s\n" "$want" >"$f"
+      got="$(tr -d "\n" <"$f")"
+      [ "$got" = "$want" ]
+    done
+
+    # SetAttr truncate path: exercise truncate(2) separately from open(O_TRUNC),
+    # then write final bytes and immediately reopen/read.
+    python3 - "$dir/setattr.txt" "$marker" <<'"'"'PY'"'"'
+import os
+import pathlib
+import sys
+
+p = pathlib.Path(sys.argv[1])
+marker = sys.argv[2]
+p.write_text(f"seed-setattr-{marker}\n")
+os.truncate(p, 0)
+want = f"setattr-{marker}\n"
+p.write_text(want)
+got = p.read_text()
+if got != want:
+    raise SystemExit(f"setattr truncate read {got!r}, want {want!r}")
+PY
+
+    # Rename, unlink, recreate: any short-window cache-bypass state must be
+    # scoped to the inode/generation, not just the path string.
+    src="$dir/rename-src.txt"
+    dst="$dir/recreate.txt"
+    printf "old-%s\n" "$marker" >"$dst"
+    printf "renamed-%s\n" "$marker" >"$src"
+    mv -f "$src" "$dst"
+    got="$(tr -d "\n" <"$dst")"
+    [ "$got" = "renamed-${marker}" ]
+    rm -f "$dst"
+    printf "recreated-%s\n" "$marker" >"$dst"
+    got="$(tr -d "\n" <"$dst")"
+    [ "$got" = "recreated-${marker}" ]
+
+    # Concurrent close/read shape: the writer close/release window must not let
+    # an immediate reader see an older same-path dirty sibling or a 0-byte
+    # truncate shadow.
+    python3 - "$dir/concurrent.txt" "$marker" <<'"'"'PY'"'"'
+import pathlib
+import sys
+import threading
+
+p = pathlib.Path(sys.argv[1])
+marker = sys.argv[2]
+for i in range(8):
+    want = f"concurrent-{marker}-{i}\n"
+    def writer():
+        p.write_text(want)
+    t = threading.Thread(target=writer)
+    t.start()
+    t.join()
+    got = p.read_text()
+    if got != want:
+        raise SystemExit(f"concurrent read {got!r}, want {want!r}")
+PY
+  ' _ "$marker" "$dir"
 }
 
 mount_status_json() {
@@ -395,6 +472,7 @@ require_cmd curl
 require_cmd jq
 require_cmd go
 require_cmd make
+require_cmd python3
 
 if [ "$(uname -s)" != "Linux" ] && [ "$(uname -s)" != "Darwin" ]; then
   skip_or_fail "unsupported OS for this workload"
@@ -589,6 +667,12 @@ check_cmd "mount status reports supervised" \
 check_cmd "mount status reports healthy" \
   bash -c 'printf "%s" "$1" | jq -e ".healthy == true" >/dev/null' _ "$STATUS_JSON"
 check_cmd "initial IO through supervised mount" probe_mount_io "before-crash"
+check_cmd "initial close-sync cache invalidation IO" probe_cache_invalidation_io "before-crash"
+CACHE_FRESH_REL="cache-invalidation-fresh.txt"
+CACHE_FRESH_WANT="fresh-cache-boundary-$RUN_ID"
+check_cmd "seed fresh-mount cache probe" \
+  bash -c 'printf "%s\n" "$2" >"$1"' _ \
+  "$MOUNT_POINT/$CACHE_FRESH_REL" "$CACHE_FRESH_WANT"
 check_cmd "resolved worker pid before kill" test -n "${WORKER_PID:-}"
 check_cmd "resolved supervisor pid before kill" test -n "${SUPERVISOR_PID:-}"
 if [ -z "${WORKER_PID:-}" ] || [ -z "${SUPERVISOR_PID:-}" ]; then
@@ -607,6 +691,7 @@ echo "INFO post-heal status: $STATUS_JSON"
 # Settle briefly: status can still show "starting" for a moment after heal.
 sleep 1
 check_cmd "post-heal IO works" wait_healthy_io "after-heal"
+check_cmd "post-heal close-sync cache invalidation IO" probe_cache_invalidation_io "after-heal"
 check_cmd "post-heal health ok" drive9 mount health "$MOUNT_POINT"
 
 HEALED_SUPERVISOR="$(supervisor_pid_from_status)"
@@ -650,6 +735,10 @@ echo "[8] remount after umount (stop token must not stick)"
 if start_supervised_mount; then
   check_eq "remount after umount ready" "true" "true"
   check_cmd "IO works on remount" probe_mount_io "after-remount"
+  check_cmd "fresh mount reads seeded cache probe bytes" \
+    bash -c 'got="$(tr -d "\n" <"$1")"; [ "$got" = "$2" ]' _ \
+    "$MOUNT_POINT/$CACHE_FRESH_REL" "$CACHE_FRESH_WANT"
+  check_cmd "remount close-sync cache invalidation IO" probe_cache_invalidation_io "after-remount"
 else
   check_eq "remount after umount ready" "false" "true"
   cat "$MOUNT_LOG" >&2 || true

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -661,7 +661,14 @@ func (cq *CommitQueue) RecoverPending() {
 			PendingIndexGen:   meta.Generation,
 		}
 		if cq.shadows != nil {
-			entry.ShadowGen = cq.shadows.ActiveGeneration(path)
+			entry.ShadowGen = cq.shadows.EnsureActiveGeneration(path, meta.BaseRev)
+			if entry.ShadowGen == 0 {
+				safeLogPrintf("commit queue: skipping recovered pending entry for %s (shadow generation unavailable)", path)
+				if _, err := cq.index.MarkConflictIfGeneration(path, meta.Generation); err != nil {
+					safeLogPrintf("commit queue: mark recovered pending conflict failed for %s: %v", path, err)
+				}
+				continue
+			}
 		}
 		if err := cq.Enqueue(entry); err != nil {
 			safeLogPrintf("commit queue: recover enqueue failed for %s: %v", path, err)
@@ -1989,15 +1996,11 @@ func (cq *CommitQueue) onCommitSuccessWithOptions(entry *CommitEntry, expectedRe
 	if cq.shadows != nil && cq.layerRefSnapshot() == "" {
 		if entry.ShadowGen != 0 {
 			cq.shadows.RemoveIfGeneration(entry.Path, entry.ShadowGen)
-		} else {
-			cq.shadows.Remove(entry.Path)
 		}
 	}
 	if cq.index != nil && cq.layerRefSnapshot() == "" {
 		if entry.PendingIndexGen != 0 {
 			cq.index.RemoveIfGeneration(entry.Path, entry.PendingIndexGen)
-		} else {
-			cq.index.Remove(entry.Path)
 		}
 	}
 	if cq.index != nil && cq.layerRefSnapshot() != "" {
@@ -2310,8 +2313,14 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 		cq.onCommitTerminalFailure(entry)
 		return
 	}
-	defer release()
-	defer func() { _ = fd.Close() }()
+	defer func() {
+		if fd != nil {
+			_ = fd.Close()
+		}
+		if release != nil {
+			release()
+		}
+	}()
 	if stat.Size != localSize {
 		safeLogPrintf("commit queue: ShadowSpill conflict for %s is genuine (local %d bytes vs server %d bytes), terminal failure", entry.Path, localSize, stat.Size)
 		cq.onCommitTerminalFailure(entry)
@@ -2362,6 +2371,12 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 	}
 
 	safeLogPrintf("commit queue: auto-resolved ShadowSpill conflict for %s (idempotent, %d bytes match server rev %d)", entry.Path, localSize, stat.Revision)
+	// onCommitSuccess removes the shadow generation. Release the OpenIfGeneration
+	// path lock first to avoid self-deadlock on generation-scoped cleanup.
+	_ = fd.Close()
+	fd = nil
+	release()
+	release = nil
 	if err := cq.onCommitSuccess(entry, stat.Revision, stat.Revision); err != nil {
 		cq.onCommitPostUploadFailure(entry, err)
 	}

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -17,6 +17,7 @@ import (
 )
 
 var errCommitPostUpload = errors.New("commit post-upload step failed")
+var errCommitPayloadStale = errors.New("commit payload generation is stale")
 
 const (
 	maxInlineLayerEntryBytes     = client.DefaultFSLayerInlineEntryBytes
@@ -57,10 +58,57 @@ type CommitEntry struct {
 	Mode                 uint32
 	HasMode              bool
 	CoalesceZeroTruncate bool
-	dispatched           bool
-	canceled             bool
-	cancelCommit         context.CancelFunc
-	cancelUpload         context.CancelFunc
+	// PayloadBaseRev is the revision that the local bytes were derived from.
+	// It is intentionally separate from BaseRev (the CAS revision sent to the
+	// server): a stale writeback entry must never pair rev2-era bytes with a
+	// later BaseRev just because a sibling handle committed rev3.
+	PayloadBaseRev    int64
+	PayloadBaseRevSet bool
+	// ShadowGen and PendingIndexGen bind this entry to the exact path-local
+	// staging generations that existed when the entry was enqueued. Upload and
+	// cleanup use these tokens so a later same-path write cannot swap in newer
+	// shadow bytes or have its pending metadata removed by an older entry.
+	ShadowGen       uint64
+	PendingIndexGen uint64
+	DirtySeq        uint64
+	WriteBackSeq    uint64
+	WriteBackGen    uint64
+	// DurableWatermarkRev is the newest revision that Dat9FS knows was already
+	// made durable (for example by a strict fsync). Entries whose payload was
+	// based on an older revision are stale and must fail instead of overwriting
+	// that watermark through Release/CommitQueue.
+	DurableWatermarkRev int64
+	// DisableAutoResolveLWW forces conflicts for fenced entries to stay
+	// terminal. Re-basing old bytes with a new BaseRev is exactly the silent
+	// rollback class this fence prevents.
+	DisableAutoResolveLWW bool
+	dispatched            bool
+	canceled              bool
+	cancelCommit          context.CancelFunc
+	cancelUpload          context.CancelFunc
+	payload               []byte
+	payloadBound          bool
+}
+
+func (entry *CommitEntry) payloadBaseRevision() int64 {
+	if entry == nil {
+		return 0
+	}
+	if entry.PayloadBaseRevSet {
+		return entry.PayloadBaseRev
+	}
+	return entry.BaseRev
+}
+
+func (entry *CommitEntry) bindPayload(data []byte) []byte {
+	if entry == nil {
+		return data
+	}
+	if !entry.payloadBound {
+		entry.payload = append([]byte(nil), data...)
+		entry.payloadBound = true
+	}
+	return entry.payload
 }
 
 // CommitSuccessFunc is called after a commit queue entry is successfully
@@ -598,13 +646,19 @@ func (cq *CommitQueue) RecoverPending() {
 			}
 		}
 		entry := &CommitEntry{
-			Path:        path,
-			BaseRev:     meta.BaseRev,
-			Size:        size,
-			Kind:        meta.Kind,
-			ShadowSpill: meta.ShadowSpill,
-			Mode:        meta.Mode,
-			HasMode:     meta.HasMode,
+			Path:              path,
+			BaseRev:           meta.BaseRev,
+			Size:              size,
+			Kind:              meta.Kind,
+			ShadowSpill:       meta.ShadowSpill,
+			Mode:              meta.Mode,
+			HasMode:           meta.HasMode,
+			PayloadBaseRev:    meta.BaseRev,
+			PayloadBaseRevSet: true,
+			PendingIndexGen:   meta.Generation,
+		}
+		if cq.shadows != nil {
+			entry.ShadowGen = cq.shadows.ActiveGeneration(path)
 		}
 		if err := cq.Enqueue(entry); err != nil {
 			safeLogPrintf("commit queue: recover enqueue failed for %s: %v", path, err)
@@ -1208,6 +1262,12 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 			safeLogPrintf("commit queue: entry for %s was canceled during upload", entry.Path)
 			return
 		}
+		if errors.Is(err, errCommitPayloadStale) {
+			safeLogPrintf("commit queue: stale payload rejected for %s: %v", entry.Path, err)
+			cq.onCommitTerminalFailure(entry)
+			unlockPath()
+			return
+		}
 		if errors.Is(err, client.ErrConflict) {
 			// When the layer was rolled back, the 409 is a state conflict
 			// (not a revision conflict); skip the Stat/HEAD auto-resolve
@@ -1218,6 +1278,12 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 			cq.mu.Unlock()
 			if abandoned {
 				safeLogPrintf("commit queue: layer abandoned, terminal failure for %s", entry.Path)
+				cq.onCommitTerminalFailure(entry)
+				unlockPath()
+				return
+			}
+			if entry.DisableAutoResolveLWW {
+				safeLogPrintf("commit queue: fenced conflict for %s at base revision %d, keeping terminal", entry.Path, entry.BaseRev)
 				cq.onCommitTerminalFailure(entry)
 				unlockPath()
 				return
@@ -1371,6 +1437,21 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 	remoteItems, err := cq.prepareBatchWriteItems(entries)
 	if err != nil {
 		cancel()
+		if errors.Is(err, errCommitPayloadStale) {
+			for _, entry := range entries {
+				if entry == nil {
+					continue
+				}
+				if errors.Is(cq.validateEntryPayloadFresh(entry), errCommitPayloadStale) {
+					safeLogPrintf("commit queue: stale batched payload rejected for %s: %v", entry.Path, err)
+					cq.onCommitTerminalFailure(entry)
+					cq.endInFlight(entry)
+					continue
+				}
+				cq.fallbackBatchEntries([]*CommitEntry{entry})
+			}
+			return
+		}
 		cq.fallbackBatchEntries(entries)
 		return
 	}
@@ -1423,7 +1504,18 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 			continue
 		}
 		resultErr := batchWriteResultError(result)
+		if errors.Is(resultErr, errCommitPayloadStale) {
+			cq.onCommitTerminalFailure(entry)
+			cq.endInFlight(entry)
+			continue
+		}
 		if errors.Is(resultErr, client.ErrConflict) {
+			if entry.DisableAutoResolveLWW {
+				safeLogPrintf("commit queue: fenced batch conflict for %s at base revision %d, keeping terminal", entry.Path, entry.BaseRev)
+				cq.onCommitTerminalFailure(entry)
+				cq.endInFlight(entry)
+				continue
+			}
 			safeLogPrintf("commit queue: batch conflict committing %s at base revision %d, attempting auto-resolve", entry.Path, entry.BaseRev)
 			cq.tryAutoResolveConflict(entryCtx, entry)
 			cq.endInFlight(entry)
@@ -1438,7 +1530,7 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 func (cq *CommitQueue) prepareBatchWriteItems(entries []*CommitEntry) ([]client.BatchWriteItem, error) {
 	items := make([]client.BatchWriteItem, len(entries))
 	for i, entry := range entries {
-		data, err := cq.shadows.ReadAll(entry.Path)
+		data, err := cq.readEntryPayload(entry)
 		if err != nil {
 			return nil, fmt.Errorf("read shadow %s: %w", entry.Path, err)
 		}
@@ -1511,6 +1603,44 @@ func sleepWithCancel(ctx context.Context, delay time.Duration) bool {
 	case <-ctx.Done():
 		return false
 	}
+}
+
+func (cq *CommitQueue) validateEntryPayloadFresh(entry *CommitEntry) error {
+	if entry == nil {
+		return nil
+	}
+	payloadBaseRev := entry.payloadBaseRevision()
+	if entry.DurableWatermarkRev > 0 && payloadBaseRev >= 0 && payloadBaseRev < entry.DurableWatermarkRev {
+		return fmt.Errorf("%w: %s payload base rev %d is older than durable watermark rev %d",
+			errCommitPayloadStale, entry.Path, payloadBaseRev, entry.DurableWatermarkRev)
+	}
+	if entry.ShadowGen != 0 && cq != nil && cq.shadows != nil {
+		if activeGen := cq.shadows.ActiveGeneration(entry.Path); activeGen != entry.ShadowGen {
+			return fmt.Errorf("%w: %s shadow generation changed from %d to %d",
+				errCommitPayloadStale, entry.Path, entry.ShadowGen, activeGen)
+		}
+	}
+	return nil
+}
+
+func (cq *CommitQueue) readEntryPayload(entry *CommitEntry) ([]byte, error) {
+	if entry == nil {
+		return nil, fmt.Errorf("nil commit entry")
+	}
+	if err := cq.validateEntryPayloadFresh(entry); err != nil {
+		return nil, err
+	}
+	if entry.payloadBound {
+		return entry.payload, nil
+	}
+	if cq == nil || cq.shadows == nil {
+		return nil, fmt.Errorf("no shadow store")
+	}
+	data, err := cq.shadows.ReadAllIfGeneration(entry.Path, entry.ShadowGen)
+	if err != nil {
+		return nil, err
+	}
+	return entry.bindPayload(data), nil
 }
 
 func (cq *CommitQueue) entryUploadContext(parent context.Context, entry *CommitEntry, timeout time.Duration) (context.Context, context.CancelFunc, bool) {
@@ -1592,12 +1722,15 @@ func (cq *CommitQueue) uploadEntry(ctx context.Context, entry *CommitEntry) (int
 	if layerRef != "" {
 		return cq.uploadLayerEntry(ctx, layerRef, entry, apiPath, expectedRevision)
 	}
+	if err := cq.validateEntryPayloadFresh(entry); err != nil {
+		return 0, err
+	}
 
 	// ShadowSpill entries: stream directly from shadow file to avoid loading
 	// multi-GiB files into memory. Uses io.SectionReader over the shadow fd.
 	if entry.ShadowSpill {
 		start := time.Now()
-		committedRev, err := uploadFromShadowRemoteWithRevision(ctx, cq.client, cq.shadows, entry.Path, apiPath, expectedRevision)
+		committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(ctx, cq.client, cq.shadows, entry.Path, apiPath, expectedRevision, entry.ShadowGen)
 		if cq.perf != nil {
 			var bytes uint64
 			if entry.Size > 0 {
@@ -1609,7 +1742,7 @@ func (cq *CommitQueue) uploadEntry(ctx context.Context, entry *CommitEntry) (int
 	}
 
 	// Non-ShadowSpill: read full content into memory.
-	data, err := cq.shadows.ReadAll(entry.Path)
+	data, err := cq.readEntryPayload(entry)
 	if err != nil {
 		return 0, fmt.Errorf("read shadow: %w", err)
 	}
@@ -1642,11 +1775,15 @@ func (cq *CommitQueue) uploadEntry(ctx context.Context, entry *CommitEntry) (int
 }
 
 func (cq *CommitQueue) uploadLayerEntry(ctx context.Context, layerRef string, entry *CommitEntry, apiPath string, expectedRevision int64) (int64, error) {
+	if err := cq.validateEntryPayloadFresh(entry); err != nil {
+		return 0, err
+	}
 	if entry.Size > maxInlineLayerEntryBytes || entry.ShadowSpill {
-		fd, actualSize, err := cq.shadows.Open(entry.Path)
+		fd, actualSize, release, err := cq.shadows.OpenIfGeneration(entry.Path, entry.ShadowGen)
 		if err != nil {
 			return 0, fmt.Errorf("open shadow stream: %w", err)
 		}
+		defer release()
 		defer func() { _ = fd.Close() }()
 		if entry.Size != actualSize {
 			return 0, fmt.Errorf("layer entry %s size mismatch: metadata=%d actual=%d", entry.Path, entry.Size, actualSize)
@@ -1658,7 +1795,7 @@ func (cq *CommitQueue) uploadLayerEntry(ctx context.Context, layerRef string, en
 		}
 		return 0, err
 	}
-	data, err := cq.shadows.ReadAll(entry.Path)
+	data, err := cq.readEntryPayload(entry)
 	if err != nil {
 		return 0, fmt.Errorf("read shadow: %w", err)
 	}
@@ -1815,10 +1952,18 @@ func (cq *CommitQueue) onCommitSuccessWithOptions(entry *CommitEntry, expectedRe
 	// the local metadata source, and shadowStore remains the local data source
 	// for large files that are not admitted to readCache.
 	if cq.shadows != nil && cq.layerRefSnapshot() == "" {
-		cq.shadows.Remove(entry.Path)
+		if entry.ShadowGen != 0 {
+			cq.shadows.RemoveIfGeneration(entry.Path, entry.ShadowGen)
+		} else {
+			cq.shadows.Remove(entry.Path)
+		}
 	}
 	if cq.index != nil && cq.layerRefSnapshot() == "" {
-		cq.index.Remove(entry.Path)
+		if entry.PendingIndexGen != 0 {
+			cq.index.RemoveIfGeneration(entry.Path, entry.PendingIndexGen)
+		} else {
+			cq.index.Remove(entry.Path)
+		}
 	}
 	if cq.index != nil && cq.layerRefSnapshot() != "" {
 		if err := cq.index.MarkCommitted(entry.Path, committedRev); err != nil {
@@ -1880,13 +2025,18 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 	}
 
 	// Read local shadow content.
-	localData, err := cq.shadows.ReadAll(entry.Path)
+	localData, err := cq.readEntryPayload(entry)
 	if err != nil {
 		// Shadow may have been removed by a concurrent CancelPath/CancelPrefix
 		// (Unlink/Rmdir). Treat as canceled rather than a true conflict.
 		if cq.isEntryCanceled(entry) {
 			cq.removeFromQueue(entry)
 			safeLogPrintf("commit queue: auto-resolve skipped for %s (canceled mid-read)", entry.Path)
+			return
+		}
+		if errors.Is(err, errCommitPayloadStale) {
+			safeLogPrintf("commit queue: auto-resolve rejected stale payload for %s: %v", entry.Path, err)
+			cq.onCommitTerminalFailure(entry)
 			return
 		}
 		safeLogPrintf("commit queue: auto-resolve failed for %s: read shadow: %v", entry.Path, err)
@@ -1980,6 +2130,11 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 	}
 
 	// Branch 2: LWW — re-upload local shadow with new base revision.
+	if entry.DisableAutoResolveLWW {
+		safeLogPrintf("commit queue: fenced conflict for %s will not LWW-rebase payload from base rev %d onto server rev %d", entry.Path, entry.payloadBaseRevision(), serverRev)
+		cq.onCommitTerminalFailure(entry)
+		return
+	}
 	// Re-check cancelation before the potentially expensive upload.
 	if cq.isEntryCanceled(entry) {
 		cq.removeFromQueue(entry)
@@ -2030,6 +2185,11 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 		cq.onCommitTerminalFailure(entry)
 		return
 	}
+	if err := cq.validateEntryPayloadFresh(entry); err != nil {
+		safeLogPrintf("commit queue: ShadowSpill stale payload rejected for %s: %v", entry.Path, err)
+		cq.onCommitTerminalFailure(entry)
+		return
+	}
 	apiPath := cq.remotePath(entry.Path)
 
 	statCtx, statCancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -2059,7 +2219,7 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 				return
 			}
 			uploadStart := time.Now()
-			committedRev, uploadErr := uploadFromShadowRemoteWithRevision(uploadCtx, cq.client, cq.shadows, entry.Path, apiPath, 0)
+			committedRev, uploadErr := uploadFromShadowRemoteWithRevisionAndGeneration(uploadCtx, cq.client, cq.shadows, entry.Path, apiPath, 0, entry.ShadowGen)
 			uploadCancel()
 			if cq.perf != nil {
 				var bytes uint64
@@ -2089,18 +2249,24 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 		return
 	}
 
-	localSize := cq.shadows.Size(entry.Path)
-	if localSize < 0 {
+	fd, localSize, release, err := cq.shadows.OpenIfGeneration(entry.Path, entry.ShadowGen)
+	if err != nil {
 		// Shadow gone — likely canceled by a concurrent Unlink/Rmdir.
 		if cq.isEntryCanceled(entry) {
 			cq.removeFromQueue(entry)
 			safeLogPrintf("commit queue: ShadowSpill auto-resolve skipped for %s (canceled)", entry.Path)
 			return
 		}
-		safeLogPrintf("commit queue: ShadowSpill auto-resolve failed for %s: shadow missing", entry.Path)
+		if errors.Is(err, errCommitPayloadStale) {
+			safeLogPrintf("commit queue: ShadowSpill auto-resolve rejected stale payload for %s: %v", entry.Path, err)
+		} else {
+			safeLogPrintf("commit queue: ShadowSpill auto-resolve failed for %s: open shadow: %v", entry.Path, err)
+		}
 		cq.onCommitTerminalFailure(entry)
 		return
 	}
+	defer release()
+	defer func() { _ = fd.Close() }()
 	if stat.Size != localSize {
 		safeLogPrintf("commit queue: ShadowSpill conflict for %s is genuine (local %d bytes vs server %d bytes), terminal failure", entry.Path, localSize, stat.Size)
 		cq.onCommitTerminalFailure(entry)
@@ -2132,7 +2298,7 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 			cq.onCommitTerminalFailure(entry)
 			return
 		}
-		ln, err := cq.shadows.ReadAt(entry.Path, off, buf[:n])
+		ln, err := fd.ReadAt(buf[:n], off)
 		if err != nil || int64(ln) != n {
 			if cq.isEntryCanceled(entry) {
 				cq.removeFromQueue(entry)
@@ -2177,7 +2343,19 @@ func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry) {
 	// The conflict marker MUST be durable before we journal or dequeue;
 	// otherwise a restart could re-enqueue the same upload.
 	if cq.index != nil {
-		if err := cq.index.MarkConflict(entry.Path); err != nil {
+		if entry.PendingIndexGen != 0 {
+			marked, err := cq.index.MarkConflictIfGeneration(entry.Path, entry.PendingIndexGen)
+			if err != nil {
+				safeLogPrintf("commit queue: failed to mark conflict for %s: %v (entry remains queued)", entry.Path, err)
+				cq.removeFromQueue(entry)
+				return
+			}
+			if !marked {
+				safeLogPrintf("commit queue: stale terminal failure for %s skipped conflict marker; newer pending generation exists", entry.Path)
+				cq.removeFromQueue(entry)
+				return
+			}
+		} else if err := cq.index.MarkConflict(entry.Path); err != nil {
 			// Conflict marker not durable — leave the entry queued so
 			// RecoverPending can retry on next startup rather than
 			// silently dropping it.

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -70,8 +70,6 @@ type CommitEntry struct {
 	// shadow bytes or have its pending metadata removed by an older entry.
 	ShadowGen       uint64
 	PendingIndexGen uint64
-	DirtySeq        uint64
-	WriteBackSeq    uint64
 	WriteBackGen    uint64
 	// DurableWatermarkRev is the newest revision that Dat9FS knows was already
 	// made durable (for example by a strict fsync). Entries whose payload was
@@ -153,6 +151,11 @@ type CommitQueue struct {
 	// PathLock serializes upload and cleanup against Dat9FS same-path shadow
 	// mutations. When unset, the queue still serializes same-path entries.
 	PathLock func(path string) func()
+	// DurableWatermark returns the latest path revision that Dat9FS has
+	// observed as committed/durable. It is consulted while the path lock is
+	// held so an entry that was fresh at enqueue time cannot LWW-rebase stale
+	// payload bytes after a sibling strict fsync advances the same path.
+	DurableWatermark func(path string) int64
 
 	// workCh dispatches entries to upload workers. The buffer is always
 	// larger than maxPending so Enqueue never blocks.
@@ -1288,6 +1291,12 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 				unlockPath()
 				return
 			}
+			if err := cq.validateEntryPayloadFresh(entry); err != nil {
+				safeLogPrintf("commit queue: conflict auto-resolve rejected stale payload for %s: %v", entry.Path, err)
+				cq.onCommitTerminalFailure(entry)
+				unlockPath()
+				return
+			}
 			safeLogPrintf("commit queue: conflict committing %s at base revision %d, attempting auto-resolve", entry.Path, entry.BaseRev)
 			cq.tryAutoResolveConflict(entryCtx, entry)
 			unlockPath()
@@ -1434,8 +1443,10 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 		entry.cancelUpload = cancel
 	}
 	cq.mu.Unlock()
+	unlockPaths := cq.lockBatchPaths(entries)
 	remoteItems, err := cq.prepareBatchWriteItems(entries)
 	if err != nil {
+		unlockPaths()
 		cancel()
 		if errors.Is(err, errCommitPayloadStale) {
 			for _, entry := range entries {
@@ -1456,7 +1467,6 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 		return
 	}
 
-	unlockPaths := cq.lockBatchPaths(entries)
 	start := time.Now()
 	results, err := cq.client.BatchWriteCtx(ctx, remoteItems)
 	if cq.perf != nil {
@@ -1504,20 +1514,25 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 			continue
 		}
 		resultErr := batchWriteResultError(result)
-		if errors.Is(resultErr, errCommitPayloadStale) {
-			cq.onCommitTerminalFailure(entry)
-			cq.endInFlight(entry)
-			continue
-		}
 		if errors.Is(resultErr, client.ErrConflict) {
+			unlockPath := cq.lockPath(entry.Path)
 			if entry.DisableAutoResolveLWW {
 				safeLogPrintf("commit queue: fenced batch conflict for %s at base revision %d, keeping terminal", entry.Path, entry.BaseRev)
 				cq.onCommitTerminalFailure(entry)
+				unlockPath()
+				cq.endInFlight(entry)
+				continue
+			}
+			if err := cq.validateEntryPayloadFresh(entry); err != nil {
+				safeLogPrintf("commit queue: batch conflict auto-resolve rejected stale payload for %s: %v", entry.Path, err)
+				cq.onCommitTerminalFailure(entry)
+				unlockPath()
 				cq.endInFlight(entry)
 				continue
 			}
 			safeLogPrintf("commit queue: batch conflict committing %s at base revision %d, attempting auto-resolve", entry.Path, entry.BaseRev)
 			cq.tryAutoResolveConflict(entryCtx, entry)
+			unlockPath()
 			cq.endInFlight(entry)
 			continue
 		}
@@ -1610,9 +1625,11 @@ func (cq *CommitQueue) validateEntryPayloadFresh(entry *CommitEntry) error {
 		return nil
 	}
 	payloadBaseRev := entry.payloadBaseRevision()
-	if entry.DurableWatermarkRev > 0 && payloadBaseRev >= 0 && payloadBaseRev < entry.DurableWatermarkRev {
+	watermark := cq.effectiveDurableWatermark(entry)
+	if watermark > 0 && payloadBaseRev >= 0 && payloadBaseRev < watermark {
+		entry.DisableAutoResolveLWW = true
 		return fmt.Errorf("%w: %s payload base rev %d is older than durable watermark rev %d",
-			errCommitPayloadStale, entry.Path, payloadBaseRev, entry.DurableWatermarkRev)
+			errCommitPayloadStale, entry.Path, payloadBaseRev, watermark)
 	}
 	if entry.ShadowGen != 0 && cq != nil && cq.shadows != nil {
 		if activeGen := cq.shadows.ActiveGeneration(entry.Path); activeGen != entry.ShadowGen {
@@ -1621,6 +1638,24 @@ func (cq *CommitQueue) validateEntryPayloadFresh(entry *CommitEntry) error {
 		}
 	}
 	return nil
+}
+
+// effectiveDurableWatermark returns the freshest known durable revision for
+// entry.Path, combining the enqueue-time fence stored on the entry with the
+// live filesystem tracker. It also writes the live watermark back to the entry
+// so later conflict handling cannot auto-resolve with a stale snapshot.
+func (cq *CommitQueue) effectiveDurableWatermark(entry *CommitEntry) int64 {
+	if entry == nil {
+		return 0
+	}
+	watermark := entry.DurableWatermarkRev
+	if cq != nil && cq.DurableWatermark != nil {
+		if live := cq.DurableWatermark(entry.Path); live > watermark {
+			watermark = live
+			entry.DurableWatermarkRev = live
+		}
+	}
+	return watermark
 }
 
 func (cq *CommitQueue) readEntryPayload(entry *CommitEntry) ([]byte, error) {
@@ -2132,6 +2167,16 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 	// Branch 2: LWW — re-upload local shadow with new base revision.
 	if entry.DisableAutoResolveLWW {
 		safeLogPrintf("commit queue: fenced conflict for %s will not LWW-rebase payload from base rev %d onto server rev %d", entry.Path, entry.payloadBaseRevision(), serverRev)
+		cq.onCommitTerminalFailure(entry)
+		return
+	}
+	if entry.PayloadBaseRevSet && entry.payloadBaseRevision() < serverRev {
+		safeLogPrintf("commit queue: refusing LWW rebase for %s: payload base rev %d is older than server rev %d", entry.Path, entry.payloadBaseRevision(), serverRev)
+		cq.onCommitTerminalFailure(entry)
+		return
+	}
+	if err := cq.validateEntryPayloadFresh(entry); err != nil {
+		safeLogPrintf("commit queue: auto-resolve rejected stale payload for %s before LWW: %v", entry.Path, err)
 		cq.onCommitTerminalFailure(entry)
 		return
 	}

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -164,6 +164,162 @@ func TestCommitQueueBatchWriteUsesBatchEndpoint(t *testing.T) {
 	}
 }
 
+func TestCommitQueueBatchWriteValidatesPayloadUnderPathLocks(t *testing.T) {
+	var batchCalls atomic.Int32
+	var putACalls atomic.Int32
+	var putBCalls atomic.Int32
+	var putBBody []byte
+	var handlerMu sync.Mutex
+	var handlerErr error
+	recordHandlerErr := func(err error) {
+		handlerMu.Lock()
+		defer handlerMu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/v1/status":
+			_ = json.NewEncoder(w).Encode(map[string]any{"inline_threshold": 50000})
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/fs:batch-write":
+			batchCalls.Add(1)
+			http.Error(w, "stale batch must be filtered before BatchWriteCtx", http.StatusInternalServerError)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs/a.txt":
+			putACalls.Add(1)
+			http.Error(w, "stale /a.txt must not fall back to single PUT", http.StatusInternalServerError)
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs/b.txt":
+			putBCalls.Add(1)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				recordHandlerErr(fmt.Errorf("read b.txt body: %w", err))
+				http.Error(w, "read b body", http.StatusInternalServerError)
+				return
+			}
+			if r.Header.Get("X-Dat9-Expected-Revision") != "0" {
+				recordHandlerErr(fmt.Errorf("b.txt expected revision = %q, want create revision 0", r.Header.Get("X-Dat9-Expected-Revision")))
+				http.Error(w, "unexpected b expected revision", http.StatusInternalServerError)
+				return
+			}
+			handlerMu.Lock()
+			putBBody = append([]byte(nil), body...)
+			handlerMu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"ok","revision":1}`))
+		default:
+			recordHandlerErr(fmt.Errorf("unexpected request: %s %s", r.Method, r.URL.String()))
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull("/a.txt", []byte("stale-a"), 2); err != nil {
+		t.Fatal(err)
+	}
+	oldAShadowGen := shadow.ActiveGeneration("/a.txt")
+	oldAPendingGen, err := pending.PutWithBaseRev("/a.txt", int64(len("stale-a")), PendingOverwrite, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull("/b.txt", []byte("fresh-b"), 0); err != nil {
+		t.Fatal(err)
+	}
+	bShadowGen := shadow.ActiveGeneration("/b.txt")
+	bPendingGen, err := pending.PutWithBaseRev("/b.txt", int64(len("fresh-b")), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.Warm(context.Background())
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.ConfigureBatchWrite(10*time.Millisecond, 64, client.MaxBatchWriteBytes)
+	var restageOnce sync.Once
+	cq.PathLock = func(path string) func() {
+		if path == "/a.txt" {
+			restageOnce.Do(func() {
+				if err := shadow.WriteFull("/a.txt", []byte("fresh-a"), 3); err != nil {
+					recordHandlerErr(fmt.Errorf("restage a shadow: %w", err))
+					return
+				}
+				if _, err := pending.PutWithBaseRev("/a.txt", int64(len("fresh-a")), PendingOverwrite, 3); err != nil {
+					recordHandlerErr(fmt.Errorf("restage a pending: %w", err))
+					return
+				}
+			})
+		}
+		return func() {}
+	}
+
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              "/a.txt",
+		BaseRev:           2,
+		PayloadBaseRev:    2,
+		PayloadBaseRevSet: true,
+		Size:              int64(len("stale-a")),
+		Kind:              PendingOverwrite,
+		ShadowGen:         oldAShadowGen,
+		PendingIndexGen:   oldAPendingGen,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              "/b.txt",
+		BaseRev:           0,
+		PayloadBaseRev:    0,
+		PayloadBaseRevSet: true,
+		Size:              int64(len("fresh-b")),
+		Kind:              PendingNew,
+		ShadowGen:         bShadowGen,
+		PendingIndexGen:   bPendingGen,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if got := batchCalls.Load(); got != 0 {
+		t.Fatalf("batch calls = %d, want 0; stale item must be omitted before BatchWriteCtx", got)
+	}
+	if got := putACalls.Load(); got != 0 {
+		t.Fatalf("a.txt PUT calls = %d, want 0; stale item must not fallback-upload", got)
+	}
+	if got := putBCalls.Load(); got != 1 {
+		t.Fatalf("b.txt PUT calls = %d, want 1 fallback commit for fresh batch member", got)
+	}
+	handlerMu.Lock()
+	gotPutBBody := append([]byte(nil), putBBody...)
+	err = handlerErr
+	handlerMu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(gotPutBBody) != "fresh-b" {
+		t.Fatalf("b.txt PUT body = %q, want fresh-b", gotPutBBody)
+	}
+	meta, ok := pending.GetMeta("/a.txt")
+	if !ok {
+		t.Fatal("newer a.txt pending entry should survive stale batch entry")
+	}
+	if meta.Generation == oldAPendingGen || meta.Kind == PendingConflict || meta.BaseRev != 3 {
+		t.Fatalf("a.txt pending meta = %+v, want newer non-conflict base rev 3", meta)
+	}
+	if data, err := shadow.ReadAll("/a.txt"); err != nil || string(data) != "fresh-a" {
+		t.Fatalf("a.txt shadow = %q err=%v, want fresh-a", data, err)
+	}
+	if pending.HasPending("/b.txt") || shadow.Has("/b.txt") {
+		t.Fatal("b.txt staging should be cleaned after fallback commit")
+	}
+}
+
 func TestCommitQueueBatchWriteFallsBackWhenUnsupported(t *testing.T) {
 	var batchCalls atomic.Int32
 	var putCalls atomic.Int32

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -18,6 +18,19 @@ import (
 	"github.com/mem9-ai/drive9/pkg/client"
 )
 
+func attachTestStagingGens(shadow *ShadowStore, pending *PendingIndex, entry *CommitEntry) *CommitEntry {
+	if entry == nil {
+		return nil
+	}
+	if shadow != nil && entry.ShadowGen == 0 {
+		entry.ShadowGen = shadow.ActiveGeneration(entry.Path)
+	}
+	if pending != nil && entry.PendingIndexGen == 0 {
+		entry.PendingIndexGen = pending.Generation(entry.Path)
+	}
+	return entry
+}
+
 func TestCommitQueueConditionalCommitSuccess(t *testing.T) {
 	var gotExpected string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -41,7 +54,9 @@ func TestCommitQueueConditionalCommitSuccess(t *testing.T) {
 	if err := shadow.WriteFull("/ok.txt", []byte("data"), 7); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := pending.PutWithBaseRev("/ok.txt", 4, PendingOverwrite, 7); err != nil {
+	shadowGen := shadow.ActiveGeneration("/ok.txt")
+	pendingGen, err := pending.PutWithBaseRev("/ok.txt", 4, PendingOverwrite, 7)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -54,10 +69,12 @@ func TestCommitQueueConditionalCommitSuccess(t *testing.T) {
 		successRev = committedRev
 	}
 	if err := cq.Enqueue(&CommitEntry{
-		Path:    "/ok.txt",
-		BaseRev: 7,
-		Size:    4,
-		Kind:    PendingOverwrite,
+		Path:            "/ok.txt",
+		BaseRev:         7,
+		Size:            4,
+		Kind:            PendingOverwrite,
+		ShadowGen:       shadowGen,
+		PendingIndexGen: pendingGen,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -126,23 +143,27 @@ func TestCommitQueueBatchWriteUsesBatchEndpoint(t *testing.T) {
 	if err := shadow.WriteFull("/a.txt", []byte("a"), 0); err != nil {
 		t.Fatal(err)
 	}
+	aShadowGen := shadow.ActiveGeneration("/a.txt")
 	if err := shadow.WriteFull("/b.txt", []byte("b"), 0); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := pending.PutWithBaseRev("/a.txt", 1, PendingNew, 0); err != nil {
+	bShadowGen := shadow.ActiveGeneration("/b.txt")
+	aPendingGen, err := pending.PutWithBaseRev("/a.txt", 1, PendingNew, 0)
+	if err != nil {
 		t.Fatal(err)
 	}
-	if _, err := pending.PutWithBaseRev("/b.txt", 1, PendingNew, 0); err != nil {
+	bPendingGen, err := pending.PutWithBaseRev("/b.txt", 1, PendingNew, 0)
+	if err != nil {
 		t.Fatal(err)
 	}
 	c := newTestClient(ts.URL)
 	c.Warm(context.Background())
 	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
 	cq.ConfigureBatchWrite(10*time.Millisecond, 64, client.MaxBatchWriteBytes)
-	if err := cq.Enqueue(&CommitEntry{Path: "/a.txt", Size: 1, Kind: PendingNew}); err != nil {
+	if err := cq.Enqueue(&CommitEntry{Path: "/a.txt", Size: 1, Kind: PendingNew, ShadowGen: aShadowGen, PendingIndexGen: aPendingGen}); err != nil {
 		t.Fatal(err)
 	}
-	if err := cq.Enqueue(&CommitEntry{Path: "/b.txt", Size: 1, Kind: PendingNew}); err != nil {
+	if err := cq.Enqueue(&CommitEntry{Path: "/b.txt", Size: 1, Kind: PendingNew, ShadowGen: bShadowGen, PendingIndexGen: bPendingGen}); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -350,22 +371,30 @@ func TestCommitQueueBatchWriteFallsBackWhenUnsupported(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	type stagingGen struct {
+		shadow  uint64
+		pending uint64
+	}
+	gens := make(map[string]stagingGen)
 	for _, path := range []string{"/a.txt", "/b.txt"} {
 		if err := shadow.WriteFull(path, []byte("x"), 0); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := pending.PutWithBaseRev(path, 1, PendingNew, 0); err != nil {
+		shadowGen := shadow.ActiveGeneration(path)
+		pendingGen, err := pending.PutWithBaseRev(path, 1, PendingNew, 0)
+		if err != nil {
 			t.Fatal(err)
 		}
+		gens[path] = stagingGen{shadow: shadowGen, pending: pendingGen}
 	}
 	c := newTestClient(ts.URL)
 	c.Warm(context.Background())
 	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
 	cq.ConfigureBatchWrite(10*time.Millisecond, 64, client.MaxBatchWriteBytes)
-	if err := cq.Enqueue(&CommitEntry{Path: "/a.txt", Size: 1, Kind: PendingNew}); err != nil {
+	if err := cq.Enqueue(&CommitEntry{Path: "/a.txt", Size: 1, Kind: PendingNew, ShadowGen: gens["/a.txt"].shadow, PendingIndexGen: gens["/a.txt"].pending}); err != nil {
 		t.Fatal(err)
 	}
-	if err := cq.Enqueue(&CommitEntry{Path: "/b.txt", Size: 1, Kind: PendingNew}); err != nil {
+	if err := cq.Enqueue(&CommitEntry{Path: "/b.txt", Size: 1, Kind: PendingNew, ShadowGen: gens["/b.txt"].shadow, PendingIndexGen: gens["/b.txt"].pending}); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -419,22 +448,30 @@ func TestCommitQueueBatchWriteFallsBackPerItemFailure(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	type stagingGen struct {
+		shadow  uint64
+		pending uint64
+	}
+	gens := make(map[string]stagingGen)
 	for _, path := range []string{"/a.txt", "/b.txt"} {
 		if err := shadow.WriteFull(path, []byte("x"), 0); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := pending.PutWithBaseRev(path, 1, PendingNew, 0); err != nil {
+		shadowGen := shadow.ActiveGeneration(path)
+		pendingGen, err := pending.PutWithBaseRev(path, 1, PendingNew, 0)
+		if err != nil {
 			t.Fatal(err)
 		}
+		gens[path] = stagingGen{shadow: shadowGen, pending: pendingGen}
 	}
 	c := newTestClient(ts.URL)
 	c.Warm(context.Background())
 	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
 	cq.ConfigureBatchWrite(10*time.Millisecond, 64, client.MaxBatchWriteBytes)
-	if err := cq.Enqueue(&CommitEntry{Path: "/a.txt", Size: 1, Kind: PendingNew}); err != nil {
+	if err := cq.Enqueue(&CommitEntry{Path: "/a.txt", Size: 1, Kind: PendingNew, ShadowGen: gens["/a.txt"].shadow, PendingIndexGen: gens["/a.txt"].pending}); err != nil {
 		t.Fatal(err)
 	}
-	if err := cq.Enqueue(&CommitEntry{Path: "/b.txt", Size: 1, Kind: PendingNew}); err != nil {
+	if err := cq.Enqueue(&CommitEntry{Path: "/b.txt", Size: 1, Kind: PendingNew, ShadowGen: gens["/b.txt"].shadow, PendingIndexGen: gens["/b.txt"].pending}); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -992,13 +1029,13 @@ func TestCommitQueueSkipsDefaultModeForPendingNew(t *testing.T) {
 	}
 
 	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:    "/plain.txt",
 		Size:    4,
 		Kind:    PendingNew,
 		Mode:    defaultRegularFileMode,
 		HasMode: true,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -1062,13 +1099,13 @@ func TestCommitQueueRetriesPostUploadChmodNotFound(t *testing.T) {
 	}
 
 	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:    "/exec-retry.sh",
 		Size:    4,
 		Kind:    PendingNew,
 		Mode:    0o755,
 		HasMode: true,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -1252,7 +1289,7 @@ func TestCommitQueueCancelPathDoesNotPoisonFutureSamePath(t *testing.T) {
 	if _, err := pending.PutWithBaseRev(path, int64(len(newData)), PendingNew, 0); err != nil {
 		t.Fatal(err)
 	}
-	newEntry := &CommitEntry{Path: path, Size: int64(len(newData)), Kind: PendingNew}
+	newEntry := attachTestStagingGens(shadow, pending, &CommitEntry{Path: path, Size: int64(len(newData)), Kind: PendingNew})
 	if cq.isEntryCanceled(newEntry) {
 		t.Fatal("new entry for same path must not inherit old cancellation")
 	}
@@ -1419,12 +1456,12 @@ func TestCommitQueueDirectPutRouting(t *testing.T) {
 		}
 
 		cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
-		if err := cq.Enqueue(&CommitEntry{
+		if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 			Path:    "/small.bin",
 			BaseRev: 5,
 			Size:    int64(len(data)),
 			Kind:    PendingOverwrite,
-		}); err != nil {
+		})); err != nil {
 			t.Fatal(err)
 		}
 		cq.DrainAll()
@@ -1622,12 +1659,12 @@ func TestCommitQueueAutoResolveLWW(t *testing.T) {
 		}
 		successRev = committedRev
 	}
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:    "/lww.txt",
 		BaseRev: 5,
 		Size:    12,
 		Kind:    PendingOverwrite,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -1699,12 +1736,12 @@ func TestCommitQueueAutoResolveIdempotent(t *testing.T) {
 		}
 		successRev = committedRev
 	}
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:    "/idem.txt",
 		BaseRev: 5,
 		Size:    int64(len(sameContent)),
 		Kind:    PendingOverwrite,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -1968,13 +2005,13 @@ func TestCommitQueueShadowSpillUpload(t *testing.T) {
 		}
 		successRev = committedRev
 	}
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:        "/big.bin",
 		BaseRev:     12,
 		Size:        int64(len(data)),
 		Kind:        PendingOverwrite,
 		ShadowSpill: true,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -2043,7 +2080,9 @@ func TestCommitQueueShadowSpillSmallFileDirectPUTCleansState(t *testing.T) {
 	if err := shadow.WriteFull(path, data, 12); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := pending.PutShadowSpill(path, int64(len(data)), PendingOverwrite, 12); err != nil {
+	shadowGen := shadow.ActiveGeneration(path)
+	pendingGen, err := pending.PutShadowSpill(path, int64(len(data)), PendingOverwrite, 12)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -2055,11 +2094,13 @@ func TestCommitQueueShadowSpillSmallFileDirectPUTCleansState(t *testing.T) {
 		successRev = committedRev
 	}
 	if err := cq.Enqueue(&CommitEntry{
-		Path:        path,
-		BaseRev:     12,
-		Size:        int64(len(data)),
-		Kind:        PendingOverwrite,
-		ShadowSpill: true,
+		Path:            path,
+		BaseRev:         12,
+		Size:            int64(len(data)),
+		Kind:            PendingOverwrite,
+		ShadowSpill:     true,
+		ShadowGen:       shadowGen,
+		PendingIndexGen: pendingGen,
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -2183,14 +2224,14 @@ func TestCommitQueueMultipartCreateInfersRevisionForOpenHandle(t *testing.T) {
 	fhID := fs.allocateFileHandle(fh)
 	defer fs.deleteFileHandle(fhID, fh)
 
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:        path,
 		Inode:       ino,
 		BaseRev:     0,
 		Size:        int64(len(data)),
 		Kind:        PendingNew,
 		ShadowSpill: true,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -2328,13 +2369,13 @@ func TestCommitQueueShadowSpillConflictIdempotent(t *testing.T) {
 	}
 
 	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:        "/big.bin",
 		BaseRev:     5,
 		Size:        int64(len(data)),
 		Kind:        PendingOverwrite,
 		ShadowSpill: true,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -2402,12 +2443,12 @@ func TestCommitQueueAutoResolveNotFoundRetriesAsCreate(t *testing.T) {
 	cq.OnSuccess = func(entry *CommitEntry, committedRev int64) {
 		successRev = committedRev
 	}
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:    "/recovered.txt",
 		BaseRev: 0,
 		Size:    14,
 		Kind:    PendingNew,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -2514,13 +2555,13 @@ func TestCommitQueueShadowSpillConflictNotFoundRetriesAsCreate(t *testing.T) {
 	cq.OnSuccess = func(entry *CommitEntry, committedRev int64) {
 		successRev = committedRev
 	}
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:        "/recovered-spill.bin",
 		BaseRev:     0,
 		Size:        int64(len(data)),
 		Kind:        PendingNew,
 		ShadowSpill: true,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -2737,6 +2778,169 @@ func TestCommitQueueRecoverPendingUsesShadowSize(t *testing.T) {
 	}
 	if pending.HasPending("/stale.bin") {
 		t.Error("pending entry not cleaned up after recovered commit")
+	}
+}
+
+func TestCommitQueueRecoverPendingBindsGenerationAndPreservesNewerRestage(t *testing.T) {
+	const path = "/recover-restage.db"
+	oldPayload := []byte("recovered old payload")
+	freshPayload := []byte("newer restaged payload")
+	var remoteCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteCalls.Add(1)
+		http.Error(w, "stale recovered payload must be rejected before remote I/O", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	shadowDir := t.TempDir()
+	pendingDir := t.TempDir()
+
+	shadow1, err := NewShadowStore(shadowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pending1, err := NewPendingIndex(pendingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow1.WriteFull(path, oldPayload, 5); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending1.PutWithBaseRev(path, int64(len(oldPayload)), PendingOverwrite, 5); err != nil {
+		t.Fatal(err)
+	}
+	shadow1.Close()
+
+	shadow2, err := NewShadowStore(shadowDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow2.Close()
+	if err := shadow2.RecoverFromDisk(); err != nil {
+		t.Fatal(err)
+	}
+	pending2, err := NewPendingIndex(pendingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pending2.RecoverFromDisk(); err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(50000)
+	cq := NewCommitQueue(c, shadow2, pending2, nil, 1, 8)
+	lockEntered := make(chan struct{})
+	releaseLock := make(chan struct{})
+	var enterOnce sync.Once
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() { close(releaseLock) })
+	}
+	defer release()
+	cq.PathLock = func(p string) func() {
+		if p == path {
+			enterOnce.Do(func() {
+				close(lockEntered)
+				<-releaseLock
+			})
+		}
+		return func() {}
+	}
+	cq.RecoverPending()
+	select {
+	case <-lockEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("recovered commit did not enter path lock")
+	}
+	if gen := shadow2.ActiveGeneration(path); gen == 0 {
+		t.Fatal("RecoverPending did not mint a shadow generation for recovered payload")
+	}
+
+	if err := shadow2.WriteFull(path, freshPayload, 6); err != nil {
+		t.Fatal(err)
+	}
+	freshShadowGen := shadow2.ActiveGeneration(path)
+	freshPendingGen, err := pending2.PutWithBaseRev(path, int64(len(freshPayload)), PendingOverwrite, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	release()
+	cq.DrainAll()
+
+	if got := remoteCalls.Load(); got != 0 {
+		t.Fatalf("remote requests = %d, want 0; stale recovered generation must fail locally", got)
+	}
+	meta, ok := pending2.GetMeta(path)
+	if !ok {
+		t.Fatal("newer restaged pending generation was removed")
+	}
+	if meta.Generation != freshPendingGen || meta.Kind == PendingConflict {
+		t.Fatalf("pending meta = %+v, want fresh generation %d and not conflict", meta, freshPendingGen)
+	}
+	data, err := shadow2.ReadAll(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(freshPayload) {
+		t.Fatalf("shadow data = %q, want fresh restaged payload", data)
+	}
+	if got := shadow2.ActiveGeneration(path); got != freshShadowGen {
+		t.Fatalf("shadow generation = %d, want fresh generation %d", got, freshShadowGen)
+	}
+}
+
+func TestCommitQueueGenZeroSuccessCleanupPreservesStaging(t *testing.T) {
+	const path = "/gen-zero-cleanup.db"
+	payload := []byte("fresh staged payload")
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(path, payload, 6); err != nil {
+		t.Fatal(err)
+	}
+	shadowGen := shadow.ActiveGeneration(path)
+	pendingGen, err := pending.PutWithBaseRev(path, int64(len(payload)), PendingOverwrite, 6)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient("http://localhost"), shadow, pending, nil, 1, 8)
+	defer cq.DrainAll()
+	if err := cq.onCommitSuccessWithOptions(&CommitEntry{
+		Path:         path,
+		BaseRev:      5,
+		Size:         int64(len(payload)),
+		Kind:         PendingOverwrite,
+		ShadowGen:    0,
+		WriteBackGen: 0,
+	}, 5, 6, false); err != nil {
+		t.Fatal(err)
+	}
+
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("gen-0 success cleanup removed pending state")
+	}
+	if meta.Generation != pendingGen {
+		t.Fatalf("pending generation = %d, want %d", meta.Generation, pendingGen)
+	}
+	data, err := shadow.ReadAll(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(payload) {
+		t.Fatalf("shadow data = %q, want staged payload", data)
+	}
+	if got := shadow.ActiveGeneration(path); got != shadowGen {
+		t.Fatalf("shadow generation = %d, want %d", got, shadowGen)
 	}
 }
 
@@ -3065,7 +3269,7 @@ func TestCommitQueueDelayedZeroTruncateTimerDispatches(t *testing.T) {
 	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	cq.zeroTruncateDelay = 20 * time.Millisecond
 	defer cq.DrainAll()
-	if err := cq.Enqueue(&CommitEntry{Path: "/standalone.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}); err != nil {
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{Path: "/standalone.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true})); err != nil {
 		t.Fatal(err)
 	}
 	select {
@@ -3355,7 +3559,7 @@ func TestCommitQueueDrainAllForcesDelayedZeroTruncate(t *testing.T) {
 
 	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
 	cq.zeroTruncateDelay = time.Hour
-	if err := cq.Enqueue(&CommitEntry{Path: "/drain.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true}); err != nil {
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{Path: "/drain.txt", Size: 0, Kind: PendingOverwrite, BaseRev: 7, CoalesceZeroTruncate: true})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1429,6 +1429,35 @@ func (fs *Dat9FS) removeHandleStagingLocked(fh *FileHandle) {
 	fh.ShadowStageGen = 0
 }
 
+// removeShadowPendingStagingGenerationLocked cleans up only the shadow and
+// pending-index generations captured by an upload owner. It deliberately avoids
+// path-wide removal so an older Flush/Fsync/Release cannot delete a newer
+// same-path generation staged while the older upload was in flight.
+func (fs *Dat9FS) removeShadowPendingStagingGenerationLocked(fh *FileHandle, localPath string, shadowGen, pendingIndexGen uint64) {
+	if fs == nil || localPath == "" {
+		return
+	}
+	if fs.pendingIndex != nil && pendingIndexGen != 0 {
+		fs.pendingIndex.RemoveIfGeneration(localPath, pendingIndexGen)
+	}
+	if fs.shadowStore != nil && shadowGen != 0 {
+		fs.shadowStore.RemoveIfGeneration(localPath, shadowGen)
+	}
+	if fh == nil || fh.Path != localPath {
+		return
+	}
+	if pendingIndexGen != 0 && (fh.PendingIndexGen == 0 || fh.PendingIndexGen == pendingIndexGen) {
+		fh.PendingIndexGen = 0
+	}
+	if shadowGen != 0 && (fh.ShadowStageGen == 0 || fh.ShadowStageGen == shadowGen) {
+		fh.ShadowStageGen = 0
+		fh.ShadowReady = false
+		fh.ShadowSpill = false
+		fh.ShadowCommitReady = false
+		fh.ShadowCommitSeq = 0
+	}
+}
+
 func (fs *Dat9FS) lookupLayerNamespaceEntry(parentIno uint64, childP, name string, out *gofuse.EntryOut) (bool, gofuse.Status) {
 	if fs == nil || !fs.layerEnabled() {
 		return false, gofuse.OK
@@ -3444,8 +3473,6 @@ func (fs *Dat9FS) bindCommitEntryToHandleLocked(entry *CommitEntry, fh *FileHand
 	}
 	entry.PayloadBaseRev = payloadBaseRev
 	entry.PayloadBaseRevSet = true
-	entry.DirtySeq = fh.DirtySeq
-	entry.WriteBackSeq = fh.WriteBackSeq
 	entry.WriteBackGen = fh.WriteBackGen
 	entry.ShadowGen = fh.ShadowStageGen
 	if entry.ShadowGen == 0 && fs.shadowStore != nil {
@@ -11768,6 +11795,10 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		if shadowGen == 0 {
 			shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
 		}
+		pendingIndexGen := fh.PendingIndexGen
+		if pendingIndexGen == 0 && fs.pendingIndex != nil {
+			pendingIndexGen = fs.pendingIndex.Generation(fh.Path)
+		}
 		uploadStart := time.Now()
 		fs.debugf("sync handle shadowspill upload start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
 		fh.Unlock()
@@ -11804,16 +11835,7 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		} else {
 			fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
 			fs.finalizeHandleFlushLocked(fh, expectedRevision)
-			if fs.shadowStore != nil {
-				fs.shadowStore.Remove(fh.Path)
-				fh.ShadowReady = false
-				fh.ShadowSpill = false
-				fh.ShadowCommitReady = false
-				fh.ShadowCommitSeq = 0
-			}
-			if fs.pendingIndex != nil {
-				fs.pendingIndex.Remove(fh.Path)
-			}
+			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, shadowGen, pendingIndexGen)
 		}
 		fs.inodes.UpdateSize(fh.Ino, size)
 		fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
@@ -12131,6 +12153,10 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			if shadowGen == 0 {
 				shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
 			}
+			pendingIndexGen := fh.PendingIndexGen
+			if pendingIndexGen == 0 && fs.pendingIndex != nil {
+				pendingIndexGen = fs.pendingIndex.Generation(fh.Path)
+			}
 			// B4: serialize with Unlink's remote DELETE — hold the per-path
 			// remoteCommitLock across the network upload while releasing fh.mu,
 			// exactly like flushHandle Path 2. Without it Unlink can DELETE and
@@ -12196,16 +12222,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			fs.inodes.UpdateSize(fh.Ino, size)
 			fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 			fs.finalizeHandleFlushLocked(fh, expectedRevision)
-			if fs.shadowStore != nil {
-				fs.shadowStore.Remove(fh.Path)
-				fh.ShadowReady = false
-				fh.ShadowSpill = false
-				fh.ShadowCommitReady = false
-				fh.ShadowCommitSeq = 0
-			}
-			if fs.pendingIndex != nil {
-				fs.pendingIndex.Remove(fh.Path)
-			}
+			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, shadowGen, pendingIndexGen)
 			return gofuse.OK
 		}
 
@@ -12437,6 +12454,10 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		if shadowGen == 0 {
 			shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
 		}
+		pendingIndexGen := fh.PendingIndexGen
+		if pendingIndexGen == 0 && fs.pendingIndex != nil {
+			pendingIndexGen = fs.pendingIndex.Generation(fh.Path)
+		}
 		// B4: serialize with Unlink's remote DELETE — hold the per-path
 		// remoteCommitLock across the network upload while releasing fh.mu,
 		// exactly like flushHandle Path 2. Without it Unlink can DELETE and
@@ -12501,16 +12522,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
 			fs.finalizeHandleFlushLocked(fh, expectedRevision)
 			fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
-			if fs.shadowStore != nil {
-				fs.shadowStore.Remove(fh.Path)
-				fh.ShadowReady = false
-				fh.ShadowSpill = false
-				fh.ShadowCommitReady = false
-				fh.ShadowCommitSeq = 0
-			}
-			if fs.pendingIndex != nil {
-				fs.pendingIndex.Remove(fh.Path)
-			}
+			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, shadowGen, pendingIndexGen)
 		}
 		fs.inodes.UpdateSize(fh.Ino, size)
 		return gofuse.OK
@@ -12560,6 +12572,11 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 				fh.Dirty.ClearDirty()
 				fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 			}
+			// Keep DirtySeq as an open-handle lifetime fence after a strict
+			// fsync. The buffer may still contain the pre-fsync image, so this
+			// handle must not adopt a sibling's newer BaseRev until it is
+			// reloaded or closed; otherwise old bytes could be paired with a
+			// newer CAS base.
 			fh.WriteBackSeq = 0
 			return gofuse.OK
 		}
@@ -12590,6 +12607,10 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 			fh.WriteBackSeq = 0
 		}
+		// Keep DirtySeq as an open-handle lifetime fence after a strict
+		// fsync. The writeback snapshot has been committed, but the handle's
+		// in-memory image is not proven rebased to any later sibling
+		// revision, so adoption remains disabled until reload/close.
 		if committedRev > 0 {
 			fs.markHandleRemoteCommittedLocked(fh, committedRev)
 		} else {
@@ -12941,16 +12962,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 							} else {
 								fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
 								fs.finalizeHandleFlushLocked(fh, expectedRevision)
-								if fs.shadowStore != nil {
-									fs.shadowStore.Remove(fh.Path)
-									fh.ShadowReady = false
-									fh.ShadowSpill = false
-									fh.ShadowCommitReady = false
-									fh.ShadowCommitSeq = 0
-								}
-								if fs.pendingIndex != nil {
-									fs.pendingIndex.Remove(fh.Path)
-								}
+								fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, entry.ShadowGen, entry.PendingIndexGen)
 							}
 							fs.inodes.UpdateSize(fh.Ino, size)
 						}
@@ -13473,6 +13485,14 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 
 		// Collect dirty parts that need re-upload (back-written after eviction)
 		dirtyParts := fh.Dirty.DirtyStreamedParts()
+		shadowGen := fh.ShadowStageGen
+		if shadowGen == 0 && fs.shadowStore != nil {
+			shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
+		}
+		pendingIndexGen := fh.PendingIndexGen
+		if pendingIndexGen == 0 && fs.pendingIndex != nil {
+			pendingIndexGen = fs.pendingIndex.Generation(fh.Path)
+		}
 
 		streamer := fh.Streamer
 		streamer.RefreshExpectedRevision(expectedRevision)
@@ -13522,12 +13542,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 		// Remove stale shadow so subsequent read-only opens don't serve
 		// the empty placeholder created at Create/Open time.
-		if fs.shadowStore != nil {
-			fs.shadowStore.Remove(fh.Path)
-		}
-		if fs.pendingIndex != nil {
-			fs.pendingIndex.Remove(fh.Path)
-		}
+		fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, shadowGen, pendingIndexGen)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 		// Local flush — kernel receives the Flush reply with status.
 		// No notifyInode needed; kernel will refresh attrs on next access.
@@ -13548,6 +13563,14 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 				copy(cp, src)
 				partSnapshots[pn] = cp
 			}
+		}
+		shadowGen := fh.ShadowStageGen
+		if shadowGen == 0 && fs.shadowStore != nil {
+			shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
+		}
+		pendingIndexGen := fh.PendingIndexGen
+		if pendingIndexGen == 0 && fs.pendingIndex != nil {
+			pendingIndexGen = fs.pendingIndex.Generation(fh.Path)
 		}
 
 		streamer := fh.Streamer
@@ -13595,12 +13618,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.inodes.UpdateSize(fh.Ino, size)
 		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 		// Remove stale shadow (same reason as Path 1a above).
-		if fs.shadowStore != nil {
-			fs.shadowStore.Remove(fh.Path)
-		}
-		if fs.pendingIndex != nil {
-			fs.pendingIndex.Remove(fh.Path)
-		}
+		fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, shadowGen, pendingIndexGen)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 		// Local flush — kernel receives the Flush reply with status.
 		// No notifyInode needed; kernel will refresh attrs on next access.

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -55,18 +55,21 @@ type Dat9FS struct {
 	// stream is current, revision-bound file stat hits are enabled only when
 	// MountOptions.TrustLocalEvents explicitly allows process-local SSE
 	// freshness for this deployment.
-	statCacheUnverified atomic.Bool
-	readSlots           chan struct{}
-	dirtyMu             sync.Mutex
-	dirtyInodes         map[uint64]dirtyInodeState
-	dirtySeq            uint64
-	modeSeq             atomic.Uint64
-	specialMu           sync.RWMutex
-	specialByPath       map[string]uint64
-	uid                 uint32
-	gid                 uint32
-	opts                *MountOptions
-	debouncer           *flushDebouncer
+	statCacheUnverified  atomic.Bool
+	readSlots            chan struct{}
+	dirtyMu              sync.Mutex
+	dirtyInodes          map[uint64]dirtyInodeState
+	dirtySeq             uint64
+	kernelCacheBypassMu  sync.Mutex
+	kernelCacheBypass    map[uint64]kernelCacheBypassMarker
+	kernelCacheBypassSeq uint64
+	modeSeq              atomic.Uint64
+	specialMu            sync.RWMutex
+	specialByPath        map[string]uint64
+	uid                  uint32
+	gid                  uint32
+	opts                 *MountOptions
+	debouncer            *flushDebouncer
 
 	// Write-back cache: Flush writes small files to local disk, Release
 	// triggers async upload. Nil when CacheDir is not configured.
@@ -312,6 +315,16 @@ type dirtyInodeState struct {
 	seq  uint64
 }
 
+type kernelCacheBypassMarker struct {
+	ino        uint64
+	path       string
+	generation uint64
+	revision   int64
+	size       int64
+	reason     string
+	expiresAt  time.Time
+}
+
 type layerSymlinkState struct {
 	Target string
 	Mode   uint32
@@ -333,6 +346,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		dirCache:          NewNamespaceCache(opts.DirTTL, opts.NegativeEntryTTL, dirCacheMaxEntriesOrDefault(opts.DirCacheMaxEntries)),
 		readSlots:         make(chan struct{}, readConcurrencyOrDefault(opts.ReadConcurrency)),
 		dirtyInodes:       make(map[uint64]dirtyInodeState),
+		kernelCacheBypass: make(map[uint64]kernelCacheBypassMarker),
 		specialByPath:     make(map[string]uint64),
 		uid:               uint32(os.Getuid()),
 		gid:               uint32(os.Getgid()),
@@ -403,6 +417,7 @@ const (
 	sqliteSidecarDirtyWaitInterval = time.Millisecond
 	samePathDirtyWaitTimeout       = 250 * time.Millisecond
 	samePathDirtyWaitInterval      = time.Millisecond
+	kernelCacheBypassFallbackTTL   = 2 * time.Second
 
 	// namespaceMutationRetryTimeout bounds detached retries for idempotent-ish
 	// namespace mutations after a FUSE interrupt or transient backend error.
@@ -1667,14 +1682,6 @@ func remoteOpenFlagsForHandle(fh *FileHandle) uint32 {
 	if fh.ShadowPinned || fh.ShadowReady || fh.ShadowSpill {
 		return gofuse.FOPEN_DIRECT_IO
 	}
-	if fh.Dirty == nil && (fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync) {
-		// close-sync/write-sync are close-to-open durability barriers. On
-		// Linux, a previous O_TRUNC writer can leave a stale 0-byte page/attr
-		// cache view even after the remote commit succeeds; make clean sync-mode
-		// readers enter userspace so they can observe the freshly committed
-		// read cache/remote revision instead of a kernel-side stale view.
-		return gofuse.FOPEN_DIRECT_IO
-	}
 	if fh.Dirty != nil {
 		if fh.Flags&syscall.O_TRUNC != 0 || fh.OrigSize >= smallFileShadowThreshold {
 			return gofuse.FOPEN_DIRECT_IO
@@ -1682,6 +1689,84 @@ func remoteOpenFlagsForHandle(fh *FileHandle) uint32 {
 		return gofuse.FOPEN_KEEP_CACHE
 	}
 	return gofuse.FOPEN_KEEP_CACHE
+}
+
+func (fs *Dat9FS) openFlagsForHandle(fh *FileHandle) uint32 {
+	flags := remoteOpenFlagsForHandle(fh)
+	if flags != gofuse.FOPEN_KEEP_CACHE || fh == nil || fh.Dirty != nil {
+		return flags
+	}
+	if fs.kernelCacheBypassActive(fh) {
+		return gofuse.FOPEN_DIRECT_IO
+	}
+	return flags
+}
+
+func (fs *Dat9FS) armKernelCacheBypass(ino uint64, localPath string, revision, size int64, reason string) uint64 {
+	if fs == nil || ino == 0 {
+		return 0
+	}
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	if fs.kernelCacheBypass == nil {
+		fs.kernelCacheBypass = make(map[uint64]kernelCacheBypassMarker)
+	}
+	fs.kernelCacheBypassSeq++
+	gen := fs.kernelCacheBypassSeq
+	fs.kernelCacheBypass[ino] = kernelCacheBypassMarker{
+		ino:        ino,
+		path:       localPath,
+		generation: gen,
+		revision:   revision,
+		size:       size,
+		reason:     reason,
+		expiresAt:  time.Now().Add(kernelCacheBypassFallbackTTL),
+	}
+	fs.debugf("kernel cache bypass armed path=%s ino=%d gen=%d rev=%d size=%d reason=%s", localPath, ino, gen, revision, size, reason)
+	return gen
+}
+
+func (fs *Dat9FS) clearKernelCacheBypassGeneration(ino, generation uint64) {
+	if fs == nil || ino == 0 || generation == 0 {
+		return
+	}
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	marker, ok := fs.kernelCacheBypass[ino]
+	if !ok || marker.generation != generation {
+		return
+	}
+	delete(fs.kernelCacheBypass, ino)
+	fs.debugf("kernel cache bypass cleared path=%s ino=%d gen=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.generation, marker.revision, marker.size, marker.reason)
+}
+
+func (fs *Dat9FS) kernelCacheBypassActive(fh *FileHandle) bool {
+	if fs == nil || fh == nil || fh.Ino == 0 {
+		return false
+	}
+	now := time.Now()
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	marker, ok := fs.kernelCacheBypass[fh.Ino]
+	if !ok {
+		return false
+	}
+	if !marker.expiresAt.IsZero() && now.After(marker.expiresAt) {
+		delete(fs.kernelCacheBypass, fh.Ino)
+		fs.debugf("kernel cache bypass expired path=%s ino=%d gen=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.generation, marker.revision, marker.size, marker.reason)
+		return false
+	}
+	return marker.ino == fh.Ino
+}
+
+func (fs *Dat9FS) finishSyncCommitKernelCacheBoundary(ino uint64, localPath string, revision, size int64) {
+	if fs == nil || ino == 0 {
+		return
+	}
+	gen := fs.armKernelCacheBypass(ino, localPath, revision, size, "sync-commit")
+	if fs.notifyInodeSync(ino) {
+		fs.clearKernelCacheBypassGeneration(ino, gen)
+	}
 }
 
 func (fs *Dat9FS) localEntry(localPath string, info os.FileInfo, incrementLookup bool) (*InodeEntry, gofuse.Status) {
@@ -6397,12 +6482,13 @@ func (fs *Dat9FS) notifyEntry(parentIno uint64, name string) {
 // invalidation form, while off=0/len=0 invalidates cached data. A data-only
 // invalidation can leave a just-truncated 0-byte i_size cached across a later
 // close-sync remote commit, making immediate close-to-open reads observe EOF.
-func (fs *Dat9FS) invalidateInodeKernelCaches(ino uint64) {
+func (fs *Dat9FS) invalidateInodeKernelCaches(ino uint64) bool {
 	if fs.server == nil {
-		return
+		return false
 	}
-	_ = fs.server.InodeNotify(ino, -1, 0)
-	_ = fs.server.InodeNotify(ino, 0, 0)
+	attrErr := fs.server.InodeNotify(ino, -1, 0)
+	dataErr := fs.server.InodeNotify(ino, 0, 0)
+	return attrErr == gofuse.OK && dataErr == gofuse.OK
 }
 
 // notifyInode tells the kernel to invalidate cached attributes and data
@@ -6419,7 +6505,7 @@ func (fs *Dat9FS) notifyInode(ino uint64) {
 	fs.notifyWg.Add(1)
 	go func() {
 		defer fs.notifyWg.Done()
-		fs.invalidateInodeKernelCaches(ino)
+		_ = fs.invalidateInodeKernelCaches(ino)
 	}()
 }
 
@@ -6429,12 +6515,12 @@ func (fs *Dat9FS) notifyInode(ino uint64) {
 // remote commits are close-to-open barriers: the next opener may otherwise
 // observe stale size/page-cache state even though the remote commit has
 // completed.
-func (fs *Dat9FS) notifyInodeSync(ino uint64) {
+func (fs *Dat9FS) notifyInodeSync(ino uint64) bool {
 	fs.notifyCount.Add(1)
 	if fs.perf != nil {
 		fs.perf.notifyInode.add(1)
 	}
-	fs.invalidateInodeKernelCaches(ino)
+	return fs.invalidateInodeKernelCaches(ino)
 }
 
 func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name string, out *gofuse.EntryOut) (status gofuse.Status) {
@@ -7902,6 +7988,9 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 			truncMtime := time.Now()
 			entry.Mtime = truncMtime
 			fs.inodes.UpdateMtime(input.NodeId, truncMtime)
+		}
+		if sizeChanged {
+			fs.armKernelCacheBypass(input.NodeId, entry.Path, entry.Revision, newSize, "setattr-size")
 		}
 		// Kernel already receives updated attrs via the SetAttr reply —
 		// no need for an explicit notifyInode here.
@@ -10513,7 +10602,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 
 	fh.DirtySeq = fs.markDirtySize(ino, 0)
 	out.Fh = fs.allocateFileHandle(fh)
-	out.OpenFlags = remoteOpenFlagsForHandle(fh)
+	out.OpenFlags = fs.openFlagsForHandle(fh)
 	fs.fillEntryOut(entry, &out.EntryOut)
 
 	parentPath, _ := fs.inodes.GetPath(input.NodeId)
@@ -10696,7 +10785,8 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			// open/00.t test 43). Use a synchronous InodeNotify (not the
 			// async notifyInode goroutine) to guarantee the cache is
 			// invalidated before Open returns to the kernel.
-			fs.invalidateInodeKernelCaches(input.NodeId)
+			_ = fs.invalidateInodeKernelCaches(input.NodeId)
+			fs.armKernelCacheBypass(input.NodeId, p, fh.BaseRev, 0, "open-truncate")
 			if fh.WritePolicy != WritePolicyWriteSync && fs.shadowStore != nil && fs.pendingIndex != nil {
 				if err := fs.shadowStore.WriteFull(p, nil, fh.BaseRev); err != nil {
 					safeLogPrintf("shadow reset failed for truncate-open %s: %v", p, err)
@@ -10751,7 +10841,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 	}
 
 	out.Fh = fs.allocateFileHandle(fh)
-	out.OpenFlags = remoteOpenFlagsForHandle(fh)
+	out.OpenFlags = fs.openFlagsForHandle(fh)
 	fs.debugf("open path=%s fh=%d ino=%d flags=0x%x open_flags=%d dirty=%t prefetch=%t orig_size=%d base_rev=%d shadow_ready=%t shadow_spill=%t write_policy=%s", p, out.Fh, fh.Ino, input.Flags, out.OpenFlags, fh.Dirty != nil, fh.Prefetch != nil, fh.OrigSize, fh.BaseRev, fh.ShadowReady, fh.ShadowSpill, fh.WritePolicy)
 	return gofuse.OK
 }
@@ -11710,6 +11800,9 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 	}
 	fh.DirtySeq = fs.markDirtySize(fh.Ino, fh.Dirty.Size())
 	fs.inodes.UpdateSize(fh.Ino, fh.Dirty.Size())
+	if fh.Flags&syscall.O_TRUNC != 0 {
+		fs.armKernelCacheBypass(fh.Ino, fh.Path, fh.BaseRev, fh.Dirty.Size(), "truncate-write")
+	}
 	if fh.WritePolicy == WritePolicyWriteSync {
 		size := fh.Dirty.Size()
 		writeCtx, writeCancel := fuseCtxWithTimeout(cancel, releaseTimeout(size))
@@ -11958,7 +12051,7 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 		// handle was opened O_TRUNC + FOPEN_DIRECT_IO, invalidate kernel
 		// size/data state immediately so the next read cannot observe the
 		// truncation's stale 0-byte view.
-		fs.notifyInodeSync(fh.Ino)
+		fs.finishSyncCommitKernelCacheBoundary(fh.Ino, fh.Path, committedRev, size)
 	}
 	return gofuse.OK
 }
@@ -12039,7 +12132,7 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		fs.inodes.UpdateSize(fh.Ino, size)
 		fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
 		if fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync {
-			fs.notifyInodeSync(fh.Ino)
+			fs.finishSyncCommitKernelCacheBoundary(fh.Ino, fh.Path, committedRev, size)
 		}
 		return gofuse.OK
 	}
@@ -12067,6 +12160,9 @@ func (fs *Dat9FS) createEmptyHandleRemoteLocked(ctx context.Context, fh *FileHan
 		fs.readCache.Put(fh.Path, nil, 0)
 		fs.inodes.UpdateSize(fh.Ino, 0)
 		fs.cacheFileForPath(fh.Path, 0, time.Now(), 0)
+		if fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync {
+			fs.finishSyncCommitKernelCacheBoundary(fh.Ino, fh.Path, 0, 0)
+		}
 		if fs.pendingIndex != nil {
 			if gen, putErr := fs.pendingIndex.PutWithBaseRev(fh.Path, 0, fs.pendingKindForHandle(fh), expectedRevision); putErr == nil {
 				fh.PendingIndexGen = gen
@@ -12116,6 +12212,9 @@ func (fs *Dat9FS) createEmptyHandleRemoteLocked(ctx context.Context, fh *FileHan
 	fh.ShadowCommitSeq = 0
 	fh.ShadowStageGen = 0
 	fh.PendingIndexGen = 0
+	if fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync {
+		fs.finishSyncCommitKernelCacheBoundary(fh.Ino, fh.Path, committedRev, 0)
+	}
 	return gofuse.OK
 }
 
@@ -13741,7 +13840,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 		if fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync {
-			fs.notifyInodeSync(fh.Ino)
+			if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok {
+				fs.finishSyncCommitKernelCacheBoundary(fh.Ino, fh.Path, syntheticRev, size)
+			} else {
+				fs.finishSyncCommitKernelCacheBoundary(fh.Ino, fh.Path, 0, size)
+			}
 		}
 		return gofuse.OK
 	}
@@ -13811,7 +13914,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 		if fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync {
-			fs.notifyInodeSync(fh.Ino)
+			if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok {
+				fs.finishSyncCommitKernelCacheBoundary(fh.Ino, fh.Path, syntheticRev, size)
+			} else {
+				fs.finishSyncCommitKernelCacheBoundary(fh.Ino, fh.Path, 0, size)
+			}
 		}
 		return gofuse.OK
 	}
@@ -14217,7 +14324,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		// the just-committed bytes live only in userspace/remote caches. Invalidate
 		// synchronously before returning Flush so an immediate close-to-open read
 		// cannot serve stale/empty data from the kernel cache.
-		fs.notifyInodeSync(handleIno)
+		fs.finishSyncCommitKernelCacheBoundary(handleIno, handlePath, committedBarrierRev, publishSize)
 	}
 	// Local flush — kernel receives the Flush reply with status. Most paths do
 	// not need notifyInode/notifyEntry because userspace caches are updated

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -10524,6 +10524,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 					safeLogPrintf("shadow reset failed for truncate-open %s: %v", p, err)
 				} else {
 					fh.ShadowReady = true
+					fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(p)
 					// Pin shadow so commit queue cleanup doesn't delete it while
 					// this handle is reading.
 					fh.ShadowGen = fs.shadowStore.Pin(p)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1392,37 +1392,24 @@ func (fs *Dat9FS) discardUnlinkedHandleStateLocked(fh *FileHandle) {
 // handle close/release from deleting a fresher same-path write that appeared
 // after the stale handle captured its snapshot.
 //
-// Some legacy/setup paths create staging before the handle has recorded a
-// generation (for example an empty create shadow). For those, only fall back to
-// path-wide cleanup when no other open handle still has pending state for this
-// path; otherwise leaking stale staging is safer than deleting another handle's
-// data.
+// Handles without recorded generations deliberately do not fall back to
+// path-wide cleanup. CommitQueue can own path-keyed staging after clearing a
+// handle's generation fields, and a gen-0 path-wide Remove could delete that
+// queued payload. Leaking ambiguous legacy staging is safer than deleting a
+// newer same-path generation.
 func (fs *Dat9FS) removeHandleStagingLocked(fh *FileHandle) {
 	if fs == nil || fh == nil || fh.Path == "" {
 		return
 	}
 	path := fh.Path
-	ownedOrUncontended := !fs.hasOtherPendingOpenHandleState(path, fh)
-	if fs.writeBack != nil {
-		if fh.WriteBackGen != 0 {
-			fs.writeBack.RemoveIfGeneration(path, fh.WriteBackGen)
-		} else if ownedOrUncontended {
-			fs.writeBack.Remove(path)
-		}
+	if fs.writeBack != nil && fh.WriteBackGen != 0 {
+		fs.writeBack.RemoveIfGeneration(path, fh.WriteBackGen)
 	}
-	if fs.pendingIndex != nil {
-		if fh.PendingIndexGen != 0 {
-			fs.pendingIndex.RemoveIfGeneration(path, fh.PendingIndexGen)
-		} else if ownedOrUncontended {
-			fs.pendingIndex.Remove(path)
-		}
+	if fs.pendingIndex != nil && fh.PendingIndexGen != 0 {
+		fs.pendingIndex.RemoveIfGeneration(path, fh.PendingIndexGen)
 	}
-	if fs.shadowStore != nil {
-		if fh.ShadowStageGen != 0 {
-			fs.shadowStore.RemoveIfGeneration(path, fh.ShadowStageGen)
-		} else if ownedOrUncontended {
-			fs.shadowStore.Remove(path)
-		}
+	if fs.shadowStore != nil && fh.ShadowStageGen != 0 {
+		fs.shadowStore.RemoveIfGeneration(path, fh.ShadowStageGen)
 	}
 	fh.WriteBackGen = 0
 	fh.PendingIndexGen = 0
@@ -1844,8 +1831,10 @@ func (fs *Dat9FS) truncateWritableHandleLocked(fh *FileHandle, newSize int64) (f
 				safeLogPrintf("shadow truncate failed for %s: %v", fh.Path, err)
 				fs.shadowStore.Remove(fh.Path)
 				fh.ShadowReady = false
+				fh.ShadowStageGen = 0
 			} else {
 				fh.ShadowReady = true
+				fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(fh.Path)
 			}
 		}
 	}
@@ -2176,6 +2165,9 @@ func (fs *Dat9FS) canRemoveActiveStaleShadowForCleanRefreshLocked(fh *FileHandle
 	if fs.hasPendingLocalStateExceptShadow(fh.Path) {
 		return false
 	}
+	if fs.hasQueuedCommit(fh.Path) {
+		return false
+	}
 	if fs.hasOtherPendingOpenHandleState(fh.Path, fh) {
 		return false
 	}
@@ -2504,6 +2496,7 @@ func (fs *Dat9FS) adoptCommittedRevisionLocked(fh *FileHandle) {
 		return
 	}
 	advanced := revision > fh.BaseRev
+	committedSize := fs.committedHandleSizeLocked(fh)
 	if advanced {
 		if !fs.handleCanAdoptCommittedRevisionLocked(fh) {
 			return
@@ -2513,16 +2506,18 @@ func (fs *Dat9FS) adoptCommittedRevisionLocked(fh *FileHandle) {
 		if fh.Streamer != nil {
 			fh.Streamer.RefreshExpectedRevision(expectedRevisionForHandle(fh))
 		}
+		// A clean writable handle may still hold a WriteBuffer image from its
+		// previous BaseRev. Rebind it when lazily adopting a sibling revision so a
+		// future write cannot pair old cached bytes with the newer CAS base.
+		if fh.Dirty != nil {
+			fs.rebindCleanWriteBufferToRemoteLocked(fh, committedSize)
+		}
 	}
-	if fs.clearRemovedCommittedShadowLocked(fh, revision, fs.committedHandleSizeLocked(fh), false) {
+	if fs.clearRemovedCommittedShadowLocked(fh, revision, committedSize, false) {
 		return
 	}
 	if advanced && fh.ShadowReady && fs.shadowStore != nil {
-		size := int64(0)
-		if fh.Dirty != nil {
-			size = fh.Dirty.Size()
-		}
-		if err := fs.shadowStore.Ensure(fh.Path, size, revision); err != nil {
+		if err := fs.shadowStore.Ensure(fh.Path, committedSize, revision); err != nil {
 			safeLogPrintf("shadow base revision adopt failed for %s: %v", fh.Path, err)
 		}
 	}
@@ -2598,6 +2593,21 @@ func (fs *Dat9FS) seedReadCacheFromShadowLocked(path string, size int64, revisio
 		return
 	}
 	fs.readCache.PutOwned(path, data, revision)
+}
+
+func (fs *Dat9FS) seedReadCacheFromShadowGenerationLocked(path string, size int64, revision int64, shadowGen uint64) bool {
+	if fs == nil || fs.shadowStore == nil || fs.readCache == nil || revision <= 0 || shadowGen == 0 {
+		return false
+	}
+	if size > fs.readCache.MaxFileSize() {
+		return false
+	}
+	data, err := fs.shadowStore.ReadAllIfGeneration(path, shadowGen)
+	if err != nil {
+		return false
+	}
+	fs.readCache.PutOwned(path, data, revision)
+	return true
 }
 
 func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gofuse.Status {
@@ -3473,15 +3483,10 @@ func (fs *Dat9FS) bindCommitEntryToHandleLocked(entry *CommitEntry, fh *FileHand
 	}
 	entry.PayloadBaseRev = payloadBaseRev
 	entry.PayloadBaseRevSet = true
-	entry.WriteBackGen = fh.WriteBackGen
-	entry.ShadowGen = fh.ShadowStageGen
-	if entry.ShadowGen == 0 && fs.shadowStore != nil {
-		entry.ShadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
-	}
-	entry.PendingIndexGen = fh.PendingIndexGen
-	if entry.PendingIndexGen == 0 && fs.pendingIndex != nil {
-		entry.PendingIndexGen = fs.pendingIndex.Generation(fh.Path)
-	}
+	gens := fs.captureHandleStagingGensLocked(fh)
+	entry.WriteBackGen = gens.WriteBackGen
+	entry.ShadowGen = gens.ShadowGen
+	entry.PendingIndexGen = gens.PendingIndexGen
 	if watermark := fs.latestCommittedRevision(fh.Path); watermark > payloadBaseRev && payloadBaseRev >= 0 {
 		entry.DurableWatermarkRev = watermark
 		entry.DisableAutoResolveLWW = true
@@ -10318,6 +10323,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 		} else {
 			fh.ShadowReady = true
 			fh.ShadowSpill = true
+			fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(childP)
 		}
 	}
 
@@ -11464,6 +11470,9 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 		shadowStart := time.Now()
 		unlockShadowWrite := fs.lockHandleRemoteCommitPathLocked(fh)
 		_, err := fs.shadowStore.WriteAt(fh.Path, writeOffset, data, fh.BaseRev)
+		if err == nil {
+			fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(fh.Path)
+		}
 		unlockShadowWrite()
 		if err != nil {
 			if errors.Is(err, syscall.ENOSPC) {
@@ -11494,6 +11503,9 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 		shadowStart := time.Now()
 		unlockShadowWrite := fs.lockHandleRemoteCommitPathLocked(fh)
 		_, err := fs.shadowStore.WriteAt(fh.Path, writeOffset, data, fh.BaseRev)
+		if err == nil {
+			fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(fh.Path)
+		}
 		unlockShadowWrite()
 		if err != nil {
 			if errors.Is(err, syscall.ENOSPC) {
@@ -11503,6 +11515,7 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 			safeLogPrintf("shadow write-through failed for %s: %v", fh.Path, err)
 			fs.shadowStore.Remove(fh.Path)
 			fh.ShadowReady = false
+			fh.ShadowStageGen = 0
 			source = "shadow-through-error"
 		} else {
 			source = "shadow-through"
@@ -11566,6 +11579,7 @@ func (fs *Dat9FS) restoreFailedWriteSyncLocked(fh *FileHandle, snapshot *writeBu
 		fh.ShadowSpill = false
 		fh.ShadowCommitReady = false
 		fh.ShadowCommitSeq = 0
+		fh.ShadowStageGen = 0
 	}
 }
 
@@ -11791,18 +11805,11 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
 		defer unlockRemoteCommit()
 		expectedRevision := fs.expectedRevisionForHandleLocked(fh)
-		shadowGen := fh.ShadowStageGen
-		if shadowGen == 0 {
-			shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
-		}
-		pendingIndexGen := fh.PendingIndexGen
-		if pendingIndexGen == 0 && fs.pendingIndex != nil {
-			pendingIndexGen = fs.pendingIndex.Generation(fh.Path)
-		}
+		stagingGens := fs.captureHandleStagingGensLocked(fh)
 		uploadStart := time.Now()
 		fs.debugf("sync handle shadowspill upload start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
 		fh.Unlock()
-		committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevision, shadowGen)
+		committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevision, stagingGens.ShadowGen)
 		fh.Lock()
 		var uploadBytes uint64
 		if size > 0 {
@@ -11829,13 +11836,17 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		fh.ShadowCommitSeq = 0
 		clearReadTargetForLockedHandle(fh)
 		if committedRev > 0 {
-			fs.clearReadTargetsForPathExcept(fh.Path, fh)
-			fs.seedReadCacheFromShadowLocked(fh.Path, size, committedRev)
+			if fs.seedReadCacheFromShadowGenerationLocked(fh.Path, size, committedRev, stagingGens.ShadowGen) {
+				fs.clearReadTargetsForPathExcept(fh.Path, fh)
+			} else {
+				fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
+			}
 			fs.markHandleRemoteCommittedLocked(fh, committedRev)
+			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 		} else {
 			fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
 			fs.finalizeHandleFlushLocked(fh, expectedRevision)
-			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, shadowGen, pendingIndexGen)
+			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 		}
 		fs.inodes.UpdateSize(fh.Ino, size)
 		fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
@@ -11847,6 +11858,7 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 
 func (fs *Dat9FS) createEmptyHandleRemoteLocked(ctx context.Context, fh *FileHandle) gofuse.Status {
 	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+	stagingGens := fs.captureHandleStagingGensLocked(fh)
 	if fs.layerEnabled() {
 		if err := fs.upsertLayerFile(ctx, fh.Path, nil, expectedRevision, 0, false); err != nil {
 			safeLogPrintf("sync empty layer create failed for %s: %v", fh.Path, err)
@@ -11906,16 +11918,13 @@ func (fs *Dat9FS) createEmptyHandleRemoteLocked(ctx context.Context, fh *FileHan
 	}
 	fs.inodes.UpdateSize(fh.Ino, 0)
 	fs.cacheFileForPath(fh.Path, 0, time.Now(), committedRev)
-	if fs.shadowStore != nil {
-		fs.shadowStore.Remove(fh.Path)
-		fh.ShadowReady = false
-		fh.ShadowSpill = false
-		fh.ShadowCommitReady = false
-		fh.ShadowCommitSeq = 0
-	}
-	if fs.pendingIndex != nil {
-		fs.pendingIndex.Remove(fh.Path)
-	}
+	fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
+	fh.ShadowReady = false
+	fh.ShadowSpill = false
+	fh.ShadowCommitReady = false
+	fh.ShadowCommitSeq = 0
+	fh.ShadowStageGen = 0
+	fh.PendingIndexGen = 0
 	return gofuse.OK
 }
 
@@ -12149,14 +12158,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 			handleIsNew := fh.IsNew
 			handlePath := fh.Path
-			shadowGen := fh.ShadowStageGen
-			if shadowGen == 0 {
-				shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
-			}
-			pendingIndexGen := fh.PendingIndexGen
-			if pendingIndexGen == 0 && fs.pendingIndex != nil {
-				pendingIndexGen = fs.pendingIndex.Generation(fh.Path)
-			}
+			stagingGens := fs.captureHandleStagingGensLocked(fh)
 			// B4: serialize with Unlink's remote DELETE — hold the per-path
 			// remoteCommitLock across the network upload while releasing fh.mu,
 			// exactly like flushHandle Path 2. Without it Unlink can DELETE and
@@ -12165,7 +12167,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			uploadStart := time.Now()
 			fs.debugf("flush shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 			fh.Unlock()
-			committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(uploadCtx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision, shadowGen)
+			committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(uploadCtx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision, stagingGens.ShadowGen)
 			// Record the committed revision while still holding remoteCommitLock
 			// so a waiting Unlink re-check observes the upload and issues a DELETE.
 			if err == nil && committedRev > 0 {
@@ -12210,9 +12212,13 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			fh.DirtySeq = 0
 			if committedRev > 0 {
 				clearReadTargetForLockedHandle(fh)
-				fs.clearReadTargetsForPathExcept(fh.Path, fh)
-				fs.seedReadCacheFromShadowLocked(fh.Path, size, committedRev)
+				if fs.seedReadCacheFromShadowGenerationLocked(fh.Path, size, committedRev, stagingGens.ShadowGen) {
+					fs.clearReadTargetsForPathExcept(fh.Path, fh)
+				} else {
+					fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
+				}
 				fs.markHandleRemoteCommittedLocked(fh, committedRev)
+				fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 				fs.inodes.UpdateSize(fh.Ino, size)
 				fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
 				return gofuse.OK
@@ -12222,7 +12228,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			fs.inodes.UpdateSize(fh.Ino, size)
 			fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 			fs.finalizeHandleFlushLocked(fh, expectedRevision)
-			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, shadowGen, pendingIndexGen)
+			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 			return gofuse.OK
 		}
 
@@ -12450,14 +12456,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		phase = "shadowspill-sync-upload"
 		handleIsNew := fh.IsNew
 		handlePath := fh.Path
-		shadowGen := fh.ShadowStageGen
-		if shadowGen == 0 {
-			shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
-		}
-		pendingIndexGen := fh.PendingIndexGen
-		if pendingIndexGen == 0 && fs.pendingIndex != nil {
-			pendingIndexGen = fs.pendingIndex.Generation(fh.Path)
-		}
+		stagingGens := fs.captureHandleStagingGensLocked(fh)
 		// B4: serialize with Unlink's remote DELETE — hold the per-path
 		// remoteCommitLock across the network upload while releasing fh.mu,
 		// exactly like flushHandle Path 2. Without it Unlink can DELETE and
@@ -12466,7 +12465,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		uploadStart := time.Now()
 		fs.debugf("fsync shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 		fh.Unlock()
-		committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(uploadCtx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision, shadowGen)
+		committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(uploadCtx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision, stagingGens.ShadowGen)
 		// Record the committed revision while still holding remoteCommitLock
 		// so a waiting Unlink re-check observes the upload and issues a DELETE.
 		if err == nil && committedRev > 0 {
@@ -12513,16 +12512,20 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		}
 		if committedRev > 0 {
 			clearReadTargetForLockedHandle(fh)
-			fs.clearReadTargetsForPathExcept(fh.Path, fh)
-			fs.seedReadCacheFromShadowLocked(fh.Path, size, committedRev)
+			if fs.seedReadCacheFromShadowGenerationLocked(fh.Path, size, committedRev, stagingGens.ShadowGen) {
+				fs.clearReadTargetsForPathExcept(fh.Path, fh)
+			} else {
+				fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
+			}
 			fs.markHandleRemoteCommittedLocked(fh, committedRev)
+			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 			fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
 		} else {
 			clearReadTargetForLockedHandle(fh)
 			fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
 			fs.finalizeHandleFlushLocked(fh, expectedRevision)
 			fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
-			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, shadowGen, pendingIndexGen)
+			fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 		}
 		fs.inodes.UpdateSize(fh.Ino, size)
 		return gofuse.OK
@@ -12571,12 +12574,11 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 			if fh.Dirty != nil {
 				fh.Dirty.ClearDirty()
 				fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+				fh.DirtySeq = 0
 			}
-			// Keep DirtySeq as an open-handle lifetime fence after a strict
-			// fsync. The buffer may still contain the pre-fsync image, so this
-			// handle must not adopt a sibling's newer BaseRev until it is
-			// reloaded or closed; otherwise old bytes could be paired with a
-			// newer CAS base.
+			// The handle is now clean. Future sibling-revision adoption will rebind
+			// the writable buffer to the adopted revision before any new write can
+			// use the updated BaseRev.
 			fh.WriteBackSeq = 0
 			return gofuse.OK
 		}
@@ -12605,12 +12607,12 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		if fh.Dirty != nil {
 			fh.Dirty.ClearDirty()
 			fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+			fh.DirtySeq = 0
 			fh.WriteBackSeq = 0
 		}
-		// Keep DirtySeq as an open-handle lifetime fence after a strict
-		// fsync. The writeback snapshot has been committed, but the handle's
-		// in-memory image is not proven rebased to any later sibling
-		// revision, so adoption remains disabled until reload/close.
+		// The handle is now clean. Future sibling-revision adoption will rebind
+		// the writable buffer to the adopted revision before any new write can
+		// use the updated BaseRev.
 		if committedRev > 0 {
 			fs.markHandleRemoteCommittedLocked(fh, committedRev)
 		} else {
@@ -12957,8 +12959,13 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 						} else {
 							clearReadTargetForLockedHandle(fh)
 							if committedRev > 0 {
-								fs.clearReadTargetsForPathExcept(fh.Path, fh)
+								if fs.seedReadCacheFromShadowGenerationLocked(fh.Path, size, committedRev, entry.ShadowGen) {
+									fs.clearReadTargetsForPathExcept(fh.Path, fh)
+								} else {
+									fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
+								}
 								fs.markHandleRemoteCommittedLocked(fh, committedRev)
+								fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, entry.ShadowGen, entry.PendingIndexGen)
 							} else {
 								fs.invalidateReadCacheAndTargetsExcept(fh.Path, fh)
 								fs.finalizeHandleFlushLocked(fh, expectedRevision)
@@ -13485,14 +13492,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 
 		// Collect dirty parts that need re-upload (back-written after eviction)
 		dirtyParts := fh.Dirty.DirtyStreamedParts()
-		shadowGen := fh.ShadowStageGen
-		if shadowGen == 0 && fs.shadowStore != nil {
-			shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
-		}
-		pendingIndexGen := fh.PendingIndexGen
-		if pendingIndexGen == 0 && fs.pendingIndex != nil {
-			pendingIndexGen = fs.pendingIndex.Generation(fh.Path)
-		}
+		stagingGens := fs.captureHandleStagingGensLocked(fh)
 
 		streamer := fh.Streamer
 		streamer.RefreshExpectedRevision(expectedRevision)
@@ -13542,7 +13542,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 		// Remove stale shadow so subsequent read-only opens don't serve
 		// the empty placeholder created at Create/Open time.
-		fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, shadowGen, pendingIndexGen)
+		fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 		// Local flush — kernel receives the Flush reply with status.
 		// No notifyInode needed; kernel will refresh attrs on next access.
@@ -13564,14 +13564,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 				partSnapshots[pn] = cp
 			}
 		}
-		shadowGen := fh.ShadowStageGen
-		if shadowGen == 0 && fs.shadowStore != nil {
-			shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
-		}
-		pendingIndexGen := fh.PendingIndexGen
-		if pendingIndexGen == 0 && fs.pendingIndex != nil {
-			pendingIndexGen = fs.pendingIndex.Generation(fh.Path)
-		}
+		stagingGens := fs.captureHandleStagingGensLocked(fh)
 
 		streamer := fh.Streamer
 		streamer.RefreshExpectedRevision(expectedRevision)
@@ -13618,7 +13611,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		fs.inodes.UpdateSize(fh.Ino, size)
 		fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 		// Remove stale shadow (same reason as Path 1a above).
-		fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, shadowGen, pendingIndexGen)
+		fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
 		// Local flush — kernel receives the Flush reply with status.
 		// No notifyInode needed; kernel will refresh attrs on next access.
@@ -14258,6 +14251,22 @@ func (fs *Dat9FS) readCommitEntryPayloadForCache(entry *CommitEntry) ([]byte, er
 		return nil, err
 	}
 	return data, nil
+}
+
+// captureHandleStagingGensLocked returns only the generations explicitly owned
+// by fh. It intentionally does not fall back to ActiveGeneration(path): handles
+// with zero generation fields may be racing with CommitQueue-owned staging, and
+// using the path's current generation would let an older handle clean up or bind
+// a newer payload it did not create.
+func (fs *Dat9FS) captureHandleStagingGensLocked(fh *FileHandle) StagingGens {
+	if fs == nil || fh == nil {
+		return StagingGens{}
+	}
+	return StagingGens{
+		WriteBackGen:    fh.WriteBackGen,
+		PendingIndexGen: fh.PendingIndexGen,
+		ShadowGen:       fh.ShadowStageGen,
+	}
 }
 
 // snapshotStagingGens captures the pendingIndex and shadowStore content

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -5814,6 +5814,20 @@ func (fs *Dat9FS) cacheNegativePath(p string) {
 	fs.dirCache.MarkNegative(parentPath, name)
 }
 
+func (fs *Dat9FS) cacheRemoteNotFoundPath(p string) {
+	if fs == nil || p == "/" || isLockFilePath(p) {
+		return
+	}
+	// A remote-confirmed ENOENT starts a fresh path incarnation. Any
+	// committed-revision watermark from a prior incarnation must not fence a
+	// later PendingNew recreate before the request reaches the server. Older
+	// dirty payloads are still fenced by their own generation/base-revision
+	// checks; this only clears the path epoch after the mount has observed that
+	// the remote object no longer exists.
+	fs.forgetCommittedRevision(p)
+	fs.cacheNegativePath(p)
+}
+
 func (fs *Dat9FS) hasNegativePathCache(p string) bool {
 	if fs == nil || fs.dirCache == nil || p == "/" {
 		return false
@@ -6368,6 +6382,11 @@ func (fs *Dat9FS) lookupFromDirCache(parentPath, childP, name string, out *gofus
 				fs.perf.namespaceSessionMiss.add(1)
 			}
 		}
+		// Returning ENOENT from namespace cache means this mount currently
+		// observes the path as absent. Do not let a committed-revision watermark
+		// from a previous incarnation make a later same-name PendingNew look
+		// stale before it reaches the server.
+		fs.forgetCommittedRevision(childP)
 		out.NodeId = 0
 		out.SetEntryTimeout(fs.negativeEntryTTL(childP))
 		return true, gofuse.ENOENT
@@ -6666,7 +6685,7 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 				if !fs.lockMountViewRead(listGeneration) {
 					return gofuse.Status(syscall.EAGAIN)
 				}
-				fs.cacheNegativePath(childP)
+				fs.cacheRemoteNotFoundPath(childP)
 				out.NodeId = 0
 				out.SetEntryTimeout(fs.negativeEntryTTL(childP))
 				fs.mountViewMu.RUnlock()
@@ -6702,7 +6721,7 @@ func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		if !fs.lockMountViewRead(statGeneration) {
 			return gofuse.Status(syscall.EAGAIN)
 		}
-		fs.cacheNegativePath(childP)
+		fs.cacheRemoteNotFoundPath(childP)
 		out.NodeId = 0
 		out.SetEntryTimeout(fs.negativeEntryTTL(childP))
 		fs.mountViewMu.RUnlock()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -397,6 +397,8 @@ const (
 
 	sqliteSidecarDirtyWaitTimeout  = 250 * time.Millisecond
 	sqliteSidecarDirtyWaitInterval = time.Millisecond
+	samePathDirtyWaitTimeout       = 250 * time.Millisecond
+	samePathDirtyWaitInterval      = time.Millisecond
 
 	// namespaceMutationRetryTimeout bounds detached retries for idempotent-ish
 	// namespace mutations after a FUSE interrupt or transient backend error.
@@ -3895,7 +3897,8 @@ func (fs *Dat9FS) readSamePathDirtyHandle(path string, skip *FileHandle, offset 
 	if isSQLitePersistentJournalPath(path) {
 		return nil, 0, false, gofuse.OK
 	}
-	return fs.readSamePathDirtyHandleAllowJournals(path, skip, offset, reqSize)
+	data, n, ok, st, _ := fs.readSamePathDirtyHandleAllowJournalsOnce(path, skip, offset, reqSize)
+	return data, n, ok, st
 }
 
 func (fs *Dat9FS) readSQLitePersistentJournalDirtyRange(path string, skip *FileHandle, offset int64, reqSize uint32) ([]byte, int, bool, gofuse.Status) {
@@ -4029,9 +4032,9 @@ func (fs *Dat9FS) readSQLitePersistentJournalVisibleRange(path string, skip *Fil
 	return nil, 0, false, gofuse.OK, ""
 }
 
-func (fs *Dat9FS) readSamePathDirtyHandleAllowJournals(path string, skip *FileHandle, offset int64, reqSize uint32) ([]byte, int, bool, gofuse.Status) {
+func (fs *Dat9FS) readSamePathDirtyHandleAllowJournalsOnce(path string, skip *FileHandle, offset int64, reqSize uint32) ([]byte, int, bool, gofuse.Status, bool) {
 	if fs == nil || fs.openHandles == nil || path == "" || reqSize == 0 {
-		return nil, 0, false, gofuse.OK
+		return nil, 0, false, gofuse.OK, false
 	}
 
 	type candidate struct {
@@ -4042,11 +4045,13 @@ func (fs *Dat9FS) readSamePathDirtyHandleAllowJournals(path string, skip *FileHa
 restartLoop:
 	for {
 		var candidates []candidate
+		pending := false
 		for _, src := range fs.openHandles.SnapshotPath(path) {
 			if src == nil || src == skip {
 				continue
 			}
 			if !src.TryLock() {
+				pending = true
 				continue
 			}
 			if src.Dirty != nil && src.DirtySeq > 0 {
@@ -4070,12 +4075,13 @@ restartLoop:
 			}
 			if src.DirtySeq != c.dirtySeq {
 				src.Unlock()
+				pending = true
 				continue restartLoop
 			}
 			size := src.Dirty.Size()
 			if offset >= size {
 				src.Unlock()
-				return nil, 0, true, gofuse.OK
+				return nil, 0, true, gofuse.OK, false
 			}
 			end := offset + int64(reqSize)
 			if end > size {
@@ -4083,7 +4089,7 @@ restartLoop:
 			}
 			if end <= offset {
 				src.Unlock()
-				return nil, 0, true, gofuse.OK
+				return nil, 0, true, gofuse.OK, false
 			}
 			buf := make([]byte, end-offset)
 
@@ -4092,9 +4098,10 @@ restartLoop:
 				n, err := fs.shadowStore.ReadAt(path, offset, buf)
 				if err != nil && !errors.Is(err, io.EOF) {
 					fs.debugf("read same-path shadow miss path=%s off=%d req=%d err=%v", path, offset, reqSize, err)
+					pending = true
 					continue
 				}
-				return buf[:n], n, true, gofuse.OK
+				return buf[:n], n, true, gofuse.OK, false
 			}
 
 			ps := src.Dirty.PartSize()
@@ -4111,6 +4118,7 @@ restartLoop:
 			}
 			if touchesEvicted {
 				src.Unlock()
+				pending = true
 				continue
 			}
 			for p := firstPart; p <= lastPart; p++ {
@@ -4118,16 +4126,36 @@ restartLoop:
 					if err := src.Dirty.EnsureLoaded(p); err != nil {
 						src.Unlock()
 						fs.debugf("read same-path dirty incomplete path=%s part=%d err=%v", path, p, err)
+						pending = true
 						continue candidateLoop
 					}
 				}
 			}
 			src.Dirty.ReadAt(offset, buf)
 			src.Unlock()
-			return buf, len(buf), true, gofuse.OK
+			return buf, len(buf), true, gofuse.OK, false
 		}
-		return nil, 0, false, gofuse.OK
+		return nil, 0, false, gofuse.OK, pending
 	}
+}
+
+func (fs *Dat9FS) readSamePathDirtyHandleVisibleRange(path string, skip *FileHandle, offset int64, reqSize uint32) ([]byte, int, bool, gofuse.Status, string) {
+	deadline := time.Now().Add(samePathDirtyWaitTimeout)
+	for {
+		data, n, ok, st, pending := fs.readSamePathDirtyHandleAllowJournalsOnce(path, skip, offset, reqSize)
+		if ok || st != gofuse.OK {
+			return data, n, ok, st, "same-path-dirty"
+		}
+		if !pending {
+			break
+		}
+		if time.Now().After(deadline) {
+			fs.debugf("read same-path dirty wait expired path=%s off=%d req=%d", path, offset, reqSize)
+			break
+		}
+		time.Sleep(samePathDirtyWaitInterval)
+	}
+	return nil, 0, false, gofuse.OK, ""
 }
 
 func (fs *Dat9FS) readSQLitePersistentJournalCommittedCache(path string, fallbackRevision int64, offset int64, reqSize uint32) ([]byte, int, bool) {
@@ -11003,14 +11031,30 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		return gofuse.ReadResultData(data), gofuse.OK
 	}
 
-	if fh.Dirty == nil && isSQLiteVisibleSamePathDirtyPath(fh.Path) {
-		if data, n, ok, st := fs.readSamePathDirtyHandle(fh.Path, fh, int64(input.Offset), input.Size); ok {
-			source = "same-path-dirty"
-			bytesRead = n
-			if st != gofuse.OK {
-				return nil, st
+	if fh.Dirty == nil && !isSQLitePersistentJournalPath(fh.Path) {
+		if fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync {
+			// A close-sync/write-sync writer can still be in userspace Release
+			// after close(2) returns to the caller. Preserve same-mount
+			// close-to-open visibility by reading from that open dirty handle
+			// instead of racing the remote object, which may temporarily hold
+			// the preceding O_TRUNC image.
+			if data, n, ok, st, src := fs.readSamePathDirtyHandleVisibleRange(fh.Path, fh, int64(input.Offset), input.Size); ok || st != gofuse.OK {
+				source = src
+				bytesRead = n
+				if st != gofuse.OK {
+					return nil, st
+				}
+				return gofuse.ReadResultData(data), gofuse.OK
 			}
-			return gofuse.ReadResultData(data), gofuse.OK
+		} else if isSQLiteVisibleSamePathDirtyPath(fh.Path) {
+			if data, n, ok, st := fs.readSamePathDirtyHandle(fh.Path, fh, int64(input.Offset), input.Size); ok || st != gofuse.OK {
+				source = "same-path-dirty"
+				bytesRead = n
+				if st != gofuse.OK {
+					return nil, st
+				}
+				return gofuse.ReadResultData(data), gofuse.OK
+			}
 		}
 	}
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1966,6 +1966,8 @@ func (fs *Dat9FS) updateOpenHandleBaseRevision(remotePath string, revision int64
 			}
 			if err := fs.shadowStore.Ensure(fh.Path, size, revision); err != nil {
 				safeLogPrintf("shadow base revision refresh failed for %s: %v", fh.Path, err)
+			} else {
+				fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(fh.Path)
 			}
 		}
 		fh.Unlock()
@@ -2566,6 +2568,8 @@ func (fs *Dat9FS) adoptCommittedRevisionLocked(fh *FileHandle) {
 	if advanced && fh.ShadowReady && fs.shadowStore != nil {
 		if err := fs.shadowStore.Ensure(fh.Path, committedSize, revision); err != nil {
 			safeLogPrintf("shadow base revision adopt failed for %s: %v", fh.Path, err)
+		} else {
+			fh.ShadowStageGen = fs.shadowStore.ActiveGeneration(fh.Path)
 		}
 	}
 }
@@ -3395,6 +3399,11 @@ func (fs *Dat9FS) stagePathTruncateToZeroLocked(ctx context.Context, entry *Inod
 	if !fs.canStagePathTruncateToZero(entry) {
 		return gofuse.Status(syscall.ENOTSUP)
 	}
+	// SetAttr holds this path's remoteCommitLock before reaching
+	// applyRemoteTruncate. Keep this helper non-reentrant: it stages,
+	// optionally falls back to a synchronous upload, and cleans up while the
+	// caller-held lock excludes same-path writers from publishing a newer
+	// generation between those steps.
 	expectedRevision := entry.Revision
 	mode := uint32(0)
 	hasMode := false
@@ -3402,17 +3411,25 @@ func (fs *Dat9FS) stagePathTruncateToZeroLocked(ctx context.Context, entry *Inod
 		mode = entry.Mode & 0o777
 		hasMode = mode != defaultRegularFileMode
 	}
+
 	if err := fs.shadowStore.WriteFull(entry.Path, nil, expectedRevision); err != nil {
 		safeLogPrintf("path truncate shadow stage failed for %s: %v", entry.Path, err)
 		return gofuse.EIO
 	}
+	shadowGen := fs.shadowStore.ActiveGeneration(entry.Path)
+	cleanupStaging := func() {
+		if shadowGen != 0 {
+			fs.shadowStore.RemoveIfGeneration(entry.Path, shadowGen)
+		}
+	}
 	if err := fs.shadowStore.Sync(entry.Path); err != nil {
-		fs.shadowStore.Remove(entry.Path)
+		cleanupStaging()
 		safeLogPrintf("path truncate shadow sync failed for %s: %v", entry.Path, err)
 		return gofuse.EIO
 	}
-	if _, err := fs.pendingIndex.PutWithBaseRevAndMode(entry.Path, 0, PendingOverwrite, expectedRevision, mode, hasMode); err != nil {
-		fs.shadowStore.Remove(entry.Path)
+	pendingGen, err := fs.pendingIndex.PutWithBaseRevAndMode(entry.Path, 0, PendingOverwrite, expectedRevision, mode, hasMode)
+	if err != nil {
+		cleanupStaging()
 		safeLogPrintf("path truncate pending index update failed for %s: %v", entry.Path, err)
 		return gofuse.EIO
 	}
@@ -3428,11 +3445,19 @@ func (fs *Dat9FS) stagePathTruncateToZeroLocked(ctx context.Context, entry *Inod
 		CoalesceZeroTruncate: true,
 	}
 	fs.bindCommitEntryToPath(commit, entry.Path, expectedRevision)
+	commit.ShadowGen = shadowGen
+	commit.PendingIndexGen = pendingGen
+	cleanupCommitStaging := func() {
+		fs.removeShadowPendingStagingGenerationLocked(nil, entry.Path, commit.ShadowGen, commit.PendingIndexGen)
+	}
 	if err := fs.commitQueue.Enqueue(commit); err != nil {
 		safeLogPrintf("path truncate async enqueue failed for %s: %v, falling back to sync commit", entry.Path, err)
 		if commitErr := fs.commitQueue.commitNowPathLocked(ctx, commit); commitErr != nil {
-			fs.pendingIndex.Remove(entry.Path)
-			fs.shadowStore.Remove(entry.Path)
+			if errors.Is(commitErr, errCommitPayloadStale) {
+				fs.commitQueue.onCommitTerminalFailure(commit)
+			} else {
+				cleanupCommitStaging()
+			}
 			safeLogPrintf("path truncate sync fallback failed for %s: %v", entry.Path, commitErr)
 			return httpToFuseStatus(commitErr)
 		}
@@ -3679,7 +3704,16 @@ func (fs *Dat9FS) loadWritableHandleFromShadowLocked(fh *FileHandle, meta *Write
 		return syscall.ENOENT
 	}
 
-	data, err := fs.shadowStore.ReadAll(fh.Path)
+	shadowGen := fs.shadowStore.ActiveGeneration(fh.Path)
+	var (
+		data []byte
+		err  error
+	)
+	if shadowGen != 0 {
+		data, err = fs.shadowStore.ReadAllIfGeneration(fh.Path, shadowGen)
+	} else {
+		data, err = fs.shadowStore.ReadAll(fh.Path)
+	}
 	if err != nil {
 		return err
 	}
@@ -3701,6 +3735,8 @@ func (fs *Dat9FS) loadWritableHandleFromShadowLocked(fh *FileHandle, meta *Write
 
 	fh.Dirty = wb
 	fh.ShadowReady = true
+	fh.ShadowStageGen = shadowGen
+	fh.PendingIndexGen = meta.Generation
 	fh.IsNew = meta.Kind == PendingNew
 	fh.ZeroBase = zeroOverwrite
 	fh.OrigSize = meta.Size
@@ -3738,6 +3774,7 @@ func (fs *Dat9FS) loadWritableHandleFromWriteBackLocked(fh *FileHandle) bool {
 	}
 
 	fh.IsNew = meta.Kind == PendingNew
+	fh.WriteBackGen = meta.Generation
 	fh.OrigSize = int64(len(data))
 	if meta.BaseRev > 0 {
 		fh.BaseRev = meta.BaseRev
@@ -3762,16 +3799,19 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 	}
 
 	type candidate struct {
-		src          *FileHandle
-		size         int64
-		origSize     int64
-		baseRev      int64
-		dirtySeq     uint64
-		isNew        bool
-		zeroBase     bool
-		storageClass client.StorageType
-		shadowSource bool
-		canMemory    bool
+		src             *FileHandle
+		size            int64
+		origSize        int64
+		baseRev         int64
+		dirtySeq        uint64
+		isNew           bool
+		zeroBase        bool
+		storageClass    client.StorageType
+		shadowSource    bool
+		canMemory       bool
+		writeBackGen    uint64
+		pendingIndexGen uint64
+		shadowStageGen  uint64
 	}
 
 	var candidates []candidate
@@ -3791,16 +3831,19 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 			continue
 		}
 		c := candidate{
-			src:          src,
-			size:         src.Dirty.Size(),
-			origSize:     src.OrigSize,
-			baseRev:      src.BaseRev,
-			dirtySeq:     src.DirtySeq,
-			isNew:        src.IsNew,
-			zeroBase:     src.ZeroBase,
-			storageClass: src.StorageClass,
-			shadowSource: fs.shadowStore != nil && (src.ShadowReady || src.ShadowSpill),
-			canMemory:    src.Dirty.CanMaterializeFull(),
+			src:             src,
+			size:            src.Dirty.Size(),
+			origSize:        src.OrigSize,
+			baseRev:         src.BaseRev,
+			dirtySeq:        src.DirtySeq,
+			isNew:           src.IsNew,
+			zeroBase:        src.ZeroBase,
+			storageClass:    src.StorageClass,
+			shadowSource:    fs.shadowStore != nil && (src.ShadowReady || src.ShadowSpill),
+			canMemory:       src.Dirty.CanMaterializeFull(),
+			writeBackGen:    src.WriteBackGen,
+			pendingIndexGen: src.PendingIndexGen,
+			shadowStageGen:  src.ShadowStageGen,
 		}
 		src.Unlock()
 		candidates = append(candidates, c)
@@ -3828,7 +3871,11 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 		// dirty buffer may have evicted parts and would materialize zeros.
 		if !haveData && c.shadowSource {
 			var err error
-			data, err = fs.shadowStore.ReadAll(fh.Path)
+			if c.shadowStageGen != 0 {
+				data, err = fs.shadowStore.ReadAllIfGeneration(fh.Path, c.shadowStageGen)
+			} else {
+				data, err = fs.shadowStore.ReadAll(fh.Path)
+			}
 			if err != nil {
 				safeLogPrintf("open-handle preload shadow read failed for %s: %v", fh.Path, err)
 			} else {
@@ -3870,6 +3917,12 @@ func (fs *Dat9FS) loadWritableHandleFromOpenHandleLocked(fh *FileHandle) bool {
 			continue
 		}
 		fh.Dirty.ClearDirty()
+		fh.WriteBackGen = c.writeBackGen
+		fh.PendingIndexGen = c.pendingIndexGen
+		if c.shadowSource {
+			fh.ShadowReady = true
+			fh.ShadowStageGen = c.shadowStageGen
+		}
 		fh.IsNew = c.isNew
 		fh.ZeroBase = c.zeroBase || (c.isNew && c.baseRev == 0)
 		fh.BaseRev = c.baseRev
@@ -3977,13 +4030,18 @@ restartLoop:
 		sort.SliceStable(candidates, func(i, j int) bool {
 			return candidates[i].dirtySeq > candidates[j].dirtySeq
 		})
+		if len(candidates) > 0 && testHookAfterSamePathDirtyHandleScan != nil {
+			testHookAfterSamePathDirtyHandleScan(path)
+		}
+		if pending {
+			return nil, 0, false, gofuse.OK, true
+		}
 
 	candidateLoop:
 		for _, c := range candidates {
 			src := c.fh
 			if !src.TryLock() {
-				pending = true
-				continue
+				return nil, 0, false, gofuse.OK, true
 			}
 			if src.Dirty == nil || src.DirtySeq == 0 {
 				src.Unlock()
@@ -4103,13 +4161,15 @@ restartLoop:
 		if len(candidates) > 0 && testHookAfterSamePathDirtyHandleScan != nil {
 			testHookAfterSamePathDirtyHandleScan(path)
 		}
+		if pending {
+			return nil, 0, false, gofuse.OK, true
+		}
 
 	candidateLoop:
 		for _, c := range candidates {
 			src := c.fh
 			if !src.TryLock() {
-				pending = true
-				continue
+				return nil, 0, false, gofuse.OK, true
 			}
 			if src.Dirty == nil || src.DirtySeq == 0 {
 				src.Unlock()
@@ -13437,6 +13497,11 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 
 		if handle.Dirty != nil && handle.DirtySeq == snapshotSeq {
 			handle.Dirty.ClearDirty()
+			fs.clearDirtySize(handle.Ino, snapshotSeq)
+			handle.DirtySeq = 0
+			if handle.WriteBackSeq == snapshotSeq {
+				handle.WriteBackSeq = 0
+			}
 		}
 		handle.Unlock()
 		if committedRev > 0 {
@@ -13675,8 +13740,9 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		// the empty placeholder created at Create/Open time.
 		fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
-		// Local flush — kernel receives the Flush reply with status.
-		// No notifyInode needed; kernel will refresh attrs on next access.
+		if fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync {
+			fs.notifyInodeSync(fh.Ino)
+		}
 		return gofuse.OK
 	}
 
@@ -13744,8 +13810,9 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		// Remove stale shadow (same reason as Path 1a above).
 		fs.removeShadowPendingStagingGenerationLocked(fh, fh.Path, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 		fs.finalizeHandleFlushLocked(fh, expectedRevision)
-		// Local flush — kernel receives the Flush reply with status.
-		// No notifyInode needed; kernel will refresh attrs on next access.
+		if fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync {
+			fs.notifyInodeSync(fh.Ino)
+		}
 		return gofuse.OK
 	}
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -25,6 +25,10 @@ import (
 	"github.com/mem9-ai/drive9/pkg/s3client"
 )
 
+// testHookAfterSamePathDirtyHandleScan lets race-focused unit tests lock a
+// candidate after discovery but before the second TryLock in candidateLoop.
+var testHookAfterSamePathDirtyHandleScan func(path string)
+
 // Dat9FS implements the go-fuse RawFileSystem interface, bridging FUSE
 // operations to the dat9 HTTP API via the Go SDK client.
 type Dat9FS struct {
@@ -3978,6 +3982,7 @@ restartLoop:
 		for _, c := range candidates {
 			src := c.fh
 			if !src.TryLock() {
+				pending = true
 				continue
 			}
 			if src.Dirty == nil || src.DirtySeq == 0 {
@@ -4095,11 +4100,15 @@ restartLoop:
 		sort.SliceStable(candidates, func(i, j int) bool {
 			return candidates[i].dirtySeq > candidates[j].dirtySeq
 		})
+		if len(candidates) > 0 && testHookAfterSamePathDirtyHandleScan != nil {
+			testHookAfterSamePathDirtyHandleScan(path)
+		}
 
 	candidateLoop:
 		for _, c := range candidates {
 			src := c.fh
 			if !src.TryLock() {
+				pending = true
 				continue
 			}
 			if src.Dirty == nil || src.DirtySeq == 0 {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -5815,16 +5815,20 @@ func (fs *Dat9FS) cacheNegativePath(p string) {
 }
 
 func (fs *Dat9FS) cacheRemoteNotFoundPath(p string) {
-	if fs == nil || p == "/" || isLockFilePath(p) {
+	if fs == nil || p == "/" {
 		return
 	}
 	// A remote-confirmed ENOENT starts a fresh path incarnation. Any
-	// committed-revision watermark from a prior incarnation must not fence a
-	// later PendingNew recreate before the request reaches the server. Older
-	// dirty payloads are still fenced by their own generation/base-revision
-	// checks; this only clears the path epoch after the mount has observed that
-	// the remote object no longer exists.
-	fs.forgetCommittedRevision(p)
+	// committed-revision watermark from a prior incarnation (including child
+	// paths if the missing entry used to be a directory) must not fence a later
+	// PendingNew recreate before the request reaches the server. Older dirty
+	// payloads are still fenced by their own generation/base-revision checks;
+	// this only clears the path epoch after the mount has observed that the
+	// remote object no longer exists.
+	fs.forgetCommittedRevisionPrefix(p)
+	// Lock files intentionally bypass namespace negative caching so high-churn
+	// lock create/delete/recreate probes always revalidate remotely. Keep that
+	// cache policy separate from the incarnation/watermark reset above.
 	fs.cacheNegativePath(p)
 }
 
@@ -6383,10 +6387,11 @@ func (fs *Dat9FS) lookupFromDirCache(parentPath, childP, name string, out *gofus
 			}
 		}
 		// Returning ENOENT from namespace cache means this mount currently
-		// observes the path as absent. Do not let a committed-revision watermark
-		// from a previous incarnation make a later same-name PendingNew look
-		// stale before it reaches the server.
-		fs.forgetCommittedRevision(childP)
+		// observes the path as absent. Do not let committed-revision watermarks
+		// from a previous incarnation (including children if this used to be a
+		// directory) make later same-name PendingNew payloads look stale before
+		// they reach the server.
+		fs.forgetCommittedRevisionPrefix(childP)
 		out.NodeId = 0
 		out.SetEntryTimeout(fs.negativeEntryTTL(childP))
 		return true, gofuse.ENOENT

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1628,6 +1628,14 @@ func remoteOpenFlagsForHandle(fh *FileHandle) uint32 {
 	if fh.ShadowPinned || fh.ShadowReady || fh.ShadowSpill {
 		return gofuse.FOPEN_DIRECT_IO
 	}
+	if fh.Dirty == nil && (fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync) {
+		// close-sync/write-sync are close-to-open durability barriers. On
+		// Linux, a previous O_TRUNC writer can leave a stale 0-byte page/attr
+		// cache view even after the remote commit succeeds; make clean sync-mode
+		// readers enter userspace so they can observe the freshly committed
+		// read cache/remote revision instead of a kernel-side stale view.
+		return gofuse.FOPEN_DIRECT_IO
+	}
 	if fh.Dirty != nil {
 		if fh.Flags&syscall.O_TRUNC != 0 || fh.OrigSize >= smallFileShadowThreshold {
 			return gofuse.FOPEN_DIRECT_IO

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2101,15 +2101,58 @@ func (fs *Dat9FS) handleCanAdoptCommittedRevisionLocked(fh *FileHandle) bool {
 	}
 	// A dirty handle's bytes were prepared against its current BaseRev.
 	// Advancing only the revision token after a sibling commit would create
-	// the silent-rollback shape: old payload + new CAS base. SQLite sidecar
-	// journals keep their historical same-mount adoption path only while they
-	// are still pure in-memory buffers; once they have path-keyed staging in
-	// shadow/writeBack/pendingIndex, the generation checks above fence them
-	// like any other dirty payload.
-	if !isSQLitePersistentJournalPath(fh.Path) && (fh.DirtySeq != 0 || (fh.Dirty != nil && fh.Dirty.HasDirtyParts())) {
+	// the silent-rollback shape: old payload + new CAS base. This applies to
+	// SQLite sidecar journals too: before staging, a dirty app.db-wal handle
+	// is still old WAL payload and must not silently become "based on" a newer
+	// sibling checkpoint revision.
+	if fh.DirtySeq != 0 || (fh.Dirty != nil && fh.Dirty.HasDirtyParts()) {
 		return false
 	}
 	return true
+}
+
+func (fs *Dat9FS) sqlitePersistentJournalCanAdoptForImmediateRemoteSyncLocked(fh *FileHandle) bool {
+	if fs == nil || fh == nil || !isSQLitePersistentJournalPath(fh.Path) {
+		return false
+	}
+	if fh.Dirty == nil || (fh.DirtySeq == 0 && !fh.Dirty.HasDirtyParts()) {
+		return false
+	}
+	if fh.WriteBackSeq != 0 || fh.WriteBackGen != 0 || fh.ShadowCommitReady || fh.ShadowCommitSeq != 0 {
+		return false
+	}
+	if fh.ShadowReady || fh.ShadowSpill {
+		return false
+	}
+	if fs.pendingIndex != nil && fh.PendingIndexGen != 0 && fs.pendingIndex.Generation(fh.Path) == fh.PendingIndexGen {
+		return false
+	}
+	if fs.shadowStore != nil && fh.ShadowStageGen != 0 && fs.shadowStore.ActiveGeneration(fh.Path) == fh.ShadowStageGen {
+		return false
+	}
+	return true
+}
+
+// adoptCommittedRevisionForSQLitePersistentJournalRemoteSyncLocked is the only
+// dirty SQLite sidecar revision-adopt path. It is used immediately before a
+// synchronous remote upload while the caller serializes same-path commits with
+// remoteCommitLock. It must not be used by staging/writeback paths: staged
+// CommitEntry payloads need their original payload/base generation preserved so
+// an old app.db-wal/app.db-journal snapshot cannot be paired with a newer CAS
+// BaseRev after another handle made a checkpoint durable.
+func (fs *Dat9FS) adoptCommittedRevisionForSQLitePersistentJournalRemoteSyncLocked(fh *FileHandle) {
+	if !fs.sqlitePersistentJournalCanAdoptForImmediateRemoteSyncLocked(fh) {
+		return
+	}
+	revision := fs.latestCommittedRevision(fh.Path)
+	if revision <= 0 || revision <= fh.BaseRev {
+		return
+	}
+	fh.IsNew = false
+	fh.BaseRev = revision
+	if fh.Streamer != nil {
+		fh.Streamer.RefreshExpectedRevision(expectedRevisionForHandle(fh))
+	}
 }
 
 func (fs *Dat9FS) refreshCleanCommittedRevisionForHandleLocked(fh *FileHandle) bool {
@@ -13445,6 +13488,8 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			unlockRemoteCommit()
 		}
 	}()
+
+	fs.adoptCommittedRevisionForSQLitePersistentJournalRemoteSyncLocked(fh)
 
 	var err error
 	// Path 1a: Streaming mode — parts were submitted during Write() and are

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -6290,8 +6290,22 @@ func (fs *Dat9FS) notifyEntry(parentIno uint64, name string) {
 	}()
 }
 
+// invalidateInodeKernelCaches asks the kernel to drop both inode attributes
+// (notably i_size) and cached file data. Linux treats off=-1 as the attribute
+// invalidation form, while off=0/len=0 invalidates cached data. A data-only
+// invalidation can leave a just-truncated 0-byte i_size cached across a later
+// close-sync remote commit, making immediate close-to-open reads observe EOF.
+func (fs *Dat9FS) invalidateInodeKernelCaches(ino uint64) {
+	if fs.server == nil {
+		return
+	}
+	_ = fs.server.InodeNotify(ino, -1, 0)
+	_ = fs.server.InodeNotify(ino, 0, 0)
+}
+
 // notifyInode tells the kernel to invalidate cached attributes and data
-// for an inode. off=0, sz=0 means invalidate all cached data.
+// for an inode. The notification is asynchronous to avoid re-entry deadlocks
+// from mutation handlers.
 func (fs *Dat9FS) notifyInode(ino uint64) {
 	fs.notifyCount.Add(1)
 	if fs.perf != nil {
@@ -6303,7 +6317,7 @@ func (fs *Dat9FS) notifyInode(ino uint64) {
 	fs.notifyWg.Add(1)
 	go func() {
 		defer fs.notifyWg.Done()
-		_ = fs.server.InodeNotify(ino, 0, 0)
+		fs.invalidateInodeKernelCaches(ino)
 	}()
 }
 
@@ -6318,10 +6332,7 @@ func (fs *Dat9FS) notifyInodeSync(ino uint64) {
 	if fs.perf != nil {
 		fs.perf.notifyInode.add(1)
 	}
-	if fs.server == nil {
-		return
-	}
-	_ = fs.server.InodeNotify(ino, 0, 0)
+	fs.invalidateInodeKernelCaches(ino)
 }
 
 func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name string, out *gofuse.EntryOut) (status gofuse.Status) {
@@ -7533,6 +7544,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 	if !ok {
 		return gofuse.ENOENT
 	}
+	sizeChanged := false
 	ctx, cf := fuseCtx(cancel)
 	defer cf()
 	if entryIsMetadataOnlySpecial(entry) {
@@ -7610,6 +7622,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 			fs.inodes.UpdateSize(input.NodeId, int64(input.Size))
 			if entry.Size != oldSize {
 				metadataChanged = true
+				sizeChanged = true
 			}
 		}
 		info, err := overlay.Lstat(entry.Path)
@@ -7625,7 +7638,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 			fs.cacheEntryForPath(entry.Path, entry)
 		}
 		fs.fillAttr(entry, &out.Attr)
-		out.SetTimeout(fs.opts.AttrTTL)
+		fs.setAttrOutTimeout(out, sizeChanged)
 		return gofuse.OK
 	}
 	if _, rel, ok := fs.gitWorkspaceForPath(ctx, entry.Path); ok && rel != "" {
@@ -7777,6 +7790,7 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 		fs.inodes.UpdateSize(input.NodeId, newSize)
 		if newSize != oldSize {
 			metadataChanged = true
+			sizeChanged = true
 			// POSIX: truncation updates mtime (not just ctime). The trailing
 			// metadataChanged block only updates ctime, so update mtime
 			// explicitly here. Without this, open(O_TRUNC) — which the
@@ -7798,8 +7812,19 @@ func (fs *Dat9FS) SetAttr(cancel <-chan struct{}, input *gofuse.SetAttrIn, out *
 		fs.cacheEntryForPath(entry.Path, entry)
 	}
 	fs.fillAttr(entry, &out.Attr)
-	out.SetTimeout(fs.opts.AttrTTL)
+	fs.setAttrOutTimeout(out, sizeChanged)
 	return gofuse.OK
+}
+
+func (fs *Dat9FS) setAttrOutTimeout(out *gofuse.AttrOut, sizeChanged bool) {
+	if sizeChanged {
+		// Size-changing SetAttr can be an intermediate truncate from shell
+		// redirection before the writer's close-sync commit publishes the final
+		// bytes. Do not let the kernel cache that transient i_size.
+		out.SetTimeout(0)
+		return
+	}
+	out.SetTimeout(fs.opts.AttrTTL)
 }
 
 func (fs *Dat9FS) Readlink(cancel <-chan struct{}, header *gofuse.InHeader) (out []byte, status gofuse.Status) {
@@ -10569,9 +10594,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			// open/00.t test 43). Use a synchronous InodeNotify (not the
 			// async notifyInode goroutine) to guarantee the cache is
 			// invalidated before Open returns to the kernel.
-			if fs.server != nil {
-				_ = fs.server.InodeNotify(input.NodeId, 0, 0)
-			}
+			fs.invalidateInodeKernelCaches(input.NodeId)
 			if fh.WritePolicy != WritePolicyWriteSync && fs.shadowStore != nil && fs.pendingIndex != nil {
 				if err := fs.shadowStore.WriteFull(p, nil, fh.BaseRev); err != nil {
 					safeLogPrintf("shadow reset failed for truncate-open %s: %v", p, err)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2111,50 +2111,6 @@ func (fs *Dat9FS) handleCanAdoptCommittedRevisionLocked(fh *FileHandle) bool {
 	return true
 }
 
-func (fs *Dat9FS) sqlitePersistentJournalCanAdoptForImmediateRemoteSyncLocked(fh *FileHandle) bool {
-	if fs == nil || fh == nil || !isSQLitePersistentJournalPath(fh.Path) {
-		return false
-	}
-	if fh.Dirty == nil || (fh.DirtySeq == 0 && !fh.Dirty.HasDirtyParts()) {
-		return false
-	}
-	if fh.WriteBackSeq != 0 || fh.WriteBackGen != 0 || fh.ShadowCommitReady || fh.ShadowCommitSeq != 0 {
-		return false
-	}
-	if fh.ShadowReady || fh.ShadowSpill {
-		return false
-	}
-	if fs.pendingIndex != nil && fh.PendingIndexGen != 0 && fs.pendingIndex.Generation(fh.Path) == fh.PendingIndexGen {
-		return false
-	}
-	if fs.shadowStore != nil && fh.ShadowStageGen != 0 && fs.shadowStore.ActiveGeneration(fh.Path) == fh.ShadowStageGen {
-		return false
-	}
-	return true
-}
-
-// adoptCommittedRevisionForSQLitePersistentJournalRemoteSyncLocked is the only
-// dirty SQLite sidecar revision-adopt path. It is used immediately before a
-// synchronous remote upload while the caller serializes same-path commits with
-// remoteCommitLock. It must not be used by staging/writeback paths: staged
-// CommitEntry payloads need their original payload/base generation preserved so
-// an old app.db-wal/app.db-journal snapshot cannot be paired with a newer CAS
-// BaseRev after another handle made a checkpoint durable.
-func (fs *Dat9FS) adoptCommittedRevisionForSQLitePersistentJournalRemoteSyncLocked(fh *FileHandle) {
-	if !fs.sqlitePersistentJournalCanAdoptForImmediateRemoteSyncLocked(fh) {
-		return
-	}
-	revision := fs.latestCommittedRevision(fh.Path)
-	if revision <= 0 || revision <= fh.BaseRev {
-		return
-	}
-	fh.IsNew = false
-	fh.BaseRev = revision
-	if fh.Streamer != nil {
-		fh.Streamer.RefreshExpectedRevision(expectedRevisionForHandle(fh))
-	}
-}
-
 func (fs *Dat9FS) refreshCleanCommittedRevisionForHandleLocked(fh *FileHandle) bool {
 	if fs == nil || fh == nil || fh.Dirty == nil || !fs.handleCanAdoptCommittedRevisionLocked(fh) {
 		return false
@@ -13488,8 +13444,6 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			unlockRemoteCommit()
 		}
 	}()
-
-	fs.adoptCommittedRevisionForSQLitePersistentJournalRemoteSyncLocked(fh)
 
 	var err error
 	// Path 1a: Streaming mode — parts were submitted during Write() and are

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1447,6 +1447,39 @@ func (fs *Dat9FS) removeShadowPendingStagingGenerationLocked(fh *FileHandle, loc
 	}
 }
 
+// removeSupersededZeroTruncateStagingLocked retires a path-level zero-byte
+// truncate shadow after a later same-path remote commit has durably published
+// non-empty bytes. This is intentionally narrower than path-wide cleanup: it
+// only removes the currently active 0-byte shadow/pending generation when that
+// staging is based on a revision older than the just-committed revision. The
+// caller must hold the path's remoteCommitLock so no same-path writer can stage
+// newer bytes between the generation checks and the removals.
+func (fs *Dat9FS) removeSupersededZeroTruncateStagingLocked(localPath string, committedRev, uploadedSize int64) {
+	if fs == nil || localPath == "" || committedRev <= 0 || uploadedSize <= 0 || fs.shadowStore == nil {
+		return
+	}
+	shadowGen := fs.shadowStore.ActiveGeneration(localPath)
+	if shadowGen == 0 {
+		return
+	}
+	if fs.shadowStore.Size(localPath) != 0 {
+		return
+	}
+	shadowBaseRev := fs.shadowStore.BaseRev(localPath)
+	if shadowBaseRev >= committedRev {
+		return
+	}
+	if fs.pendingIndex != nil {
+		if meta, ok := fs.pendingIndex.GetMeta(localPath); ok {
+			if meta.Kind != PendingOverwrite || meta.Size != 0 || meta.BaseRev >= committedRev {
+				return
+			}
+			fs.pendingIndex.RemoveIfGeneration(localPath, meta.Generation)
+		}
+	}
+	fs.shadowStore.RemoveIfGeneration(localPath, shadowGen)
+}
+
 func (fs *Dat9FS) lookupLayerNamespaceEntry(parentIno uint64, childP, name string, out *gofuse.EntryOut) (bool, gofuse.Status) {
 	if fs == nil || !fs.layerEnabled() {
 		return false, gofuse.OK
@@ -13718,6 +13751,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	handleOrigSize := fh.OrigSize
 	handleDirtyPartSize := fh.Dirty.PartSize()
 	handleFullRangeLoaded := writeBufferHasLoadedFullRange(fh.Dirty)
+	stagingGens := fs.captureHandleStagingGensLocked(fh)
 	var committedRev int64
 
 	// Use the negotiated server threshold (not the heuristic-only inline
@@ -13892,6 +13926,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	// will see the updated revision via adoptCommittedRevisionLocked.
 	// This must happen before releasing remoteCommitLock to prevent a
 	// same-path flush from snapshotting a stale expectedRevision.
+	committedBarrierRev := committedRev
 	if err == nil && committedRev > 0 {
 		if handleIsNew {
 			fs.replaceCommittedRevision(handlePath, committedRev)
@@ -13908,7 +13943,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	if err == nil && committedRev == 0 {
 		if syntheticRev, ok := committedRevisionFromExpectedRevision(expectedRevision); ok && syntheticRev > 0 {
 			fs.recordCommittedRevision(handlePath, syntheticRev)
+			committedBarrierRev = syntheticRev
 		}
+	}
+	if err == nil {
+		fs.removeSupersededZeroTruncateStagingLocked(handlePath, committedBarrierRev, size)
 	}
 
 	// Release remoteCommitLock AFTER upload + revision recording but
@@ -14083,6 +14122,16 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 				fs.inodes.UpdateMtime(handleIno, commitTime)
 			}
 		}
+	}
+	if !pathRetargeted {
+		// Open(O_TRUNC) and other truncate-first flows may leave a 0-byte shadow
+		// pinned for this writer while the close-sync small-write path uploads the
+		// final bytes directly to the remote server. Retire only the exact staging
+		// generations captured from this handle; otherwise an immediate reader can
+		// pin the stale truncate shadow and observe EOF even though the remote commit
+		// has completed. Generation guards preserve the writeback fence invariant: a
+		// stale handle must never delete a newer same-path payload.
+		fs.removeShadowPendingStagingGenerationLocked(fh, handlePath, stagingGens.ShadowGen, stagingGens.PendingIndexGen)
 	}
 	if !pathRetargeted && fh.DirtySeq == 0 &&
 		(fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync) {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2581,20 +2581,6 @@ func (fs *Dat9FS) markHandleRemoteCommittedLocked(fh *FileHandle, revision int64
 	fh.ShadowCommitSeq = 0
 }
 
-func (fs *Dat9FS) seedReadCacheFromShadowLocked(path string, size int64, revision int64) {
-	if fs == nil || fs.shadowStore == nil || fs.readCache == nil || revision <= 0 {
-		return
-	}
-	if size > fs.readCache.MaxFileSize() {
-		return
-	}
-	data, err := fs.shadowStore.ReadAll(path)
-	if err != nil {
-		return
-	}
-	fs.readCache.PutOwned(path, data, revision)
-}
-
 func (fs *Dat9FS) seedReadCacheFromShadowGenerationLocked(path string, size int64, revision int64, shadowGen uint64) bool {
 	if fs == nil || fs.shadowStore == nil || fs.readCache == nil || revision <= 0 || shadowGen == 0 {
 		return false

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -929,16 +929,19 @@ func (fs *Dat9FS) commitLayerShadowLocked(ctx context.Context, fh *FileHandle, s
 		size = fh.Dirty.Size()
 	}
 	mode, hasMode := fs.modeForPendingHandle(fh)
+	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+	payloadBaseRev := fh.BaseRev
 	entry := &CommitEntry{
 		Path:        fh.Path,
 		Inode:       fh.Ino,
-		BaseRev:     fh.BaseRev,
+		BaseRev:     expectedRevision,
 		Size:        size,
 		Kind:        fs.pendingKindForHandle(fh),
 		ShadowSpill: shadowSpill,
 		Mode:        mode,
 		HasMode:     hasMode,
 	}
+	fs.bindCommitEntryToHandleLocked(entry, fh, payloadBaseRev)
 	fh.Unlock()
 	err := fs.commitQueue.CommitNow(ctx, entry)
 	fh.Lock()
@@ -1379,6 +1382,51 @@ func (fs *Dat9FS) discardUnlinkedHandleStateLocked(fh *FileHandle) {
 	if fs.commitQueue != nil {
 		fs.commitQueue.CancelPathIfInode(path, fh.Ino)
 	}
+}
+
+// removeHandleStagingLocked removes path-keyed staging state owned by fh.
+// Caller must hold fh.mu.
+//
+// The primary path is generation-scoped: a handle may only remove the exact
+// writeBack/pendingIndex/shadow generations it staged. This prevents a stale
+// handle close/release from deleting a fresher same-path write that appeared
+// after the stale handle captured its snapshot.
+//
+// Some legacy/setup paths create staging before the handle has recorded a
+// generation (for example an empty create shadow). For those, only fall back to
+// path-wide cleanup when no other open handle still has pending state for this
+// path; otherwise leaking stale staging is safer than deleting another handle's
+// data.
+func (fs *Dat9FS) removeHandleStagingLocked(fh *FileHandle) {
+	if fs == nil || fh == nil || fh.Path == "" {
+		return
+	}
+	path := fh.Path
+	ownedOrUncontended := !fs.hasOtherPendingOpenHandleState(path, fh)
+	if fs.writeBack != nil {
+		if fh.WriteBackGen != 0 {
+			fs.writeBack.RemoveIfGeneration(path, fh.WriteBackGen)
+		} else if ownedOrUncontended {
+			fs.writeBack.Remove(path)
+		}
+	}
+	if fs.pendingIndex != nil {
+		if fh.PendingIndexGen != 0 {
+			fs.pendingIndex.RemoveIfGeneration(path, fh.PendingIndexGen)
+		} else if ownedOrUncontended {
+			fs.pendingIndex.Remove(path)
+		}
+	}
+	if fs.shadowStore != nil {
+		if fh.ShadowStageGen != 0 {
+			fs.shadowStore.RemoveIfGeneration(path, fh.ShadowStageGen)
+		} else if ownedOrUncontended {
+			fs.shadowStore.Remove(path)
+		}
+	}
+	fh.WriteBackGen = 0
+	fh.PendingIndexGen = 0
+	fh.ShadowStageGen = 0
 }
 
 func (fs *Dat9FS) lookupLayerNamespaceEntry(parentIno uint64, childP, name string, out *gofuse.EntryOut) (bool, gofuse.Status) {
@@ -1990,8 +2038,8 @@ func (fs *Dat9FS) refreshCommittedRevisionForOpenHandles(path string, revision i
 		if !fh.TryLock() {
 			continue
 		}
-		if fh.Dirty != nil {
-			cleanBuffer := fh.DirtySeq == 0 && !fh.Dirty.HasDirtyParts()
+		if fs.handleCanAdoptCommittedRevisionLocked(fh) {
+			cleanBuffer := fh.Dirty != nil
 			fh.IsNew = false
 			fh.BaseRev = revision
 			if fh.Streamer != nil {
@@ -2023,8 +2071,8 @@ func (fs *Dat9FS) refreshCommittedRevisionForOpenHandlesWithSize(path string, re
 		if !fh.TryLock() {
 			continue
 		}
-		if fh.Dirty != nil {
-			cleanBuffer := fh.DirtySeq == 0 && !fh.Dirty.HasDirtyParts()
+		if fs.handleCanAdoptCommittedRevisionLocked(fh) {
+			cleanBuffer := fh.Dirty != nil
 			fh.IsNew = false
 			fh.BaseRev = revision
 			if fh.Streamer != nil {
@@ -2038,8 +2086,34 @@ func (fs *Dat9FS) refreshCommittedRevisionForOpenHandlesWithSize(path string, re
 	}
 }
 
+func (fs *Dat9FS) handleCanAdoptCommittedRevisionLocked(fh *FileHandle) bool {
+	if fh == nil {
+		return false
+	}
+	if fh.WriteBackSeq != 0 || fh.ShadowCommitReady || fh.ShadowCommitSeq != 0 {
+		return false
+	}
+	if fs != nil && fh.PendingIndexGen != 0 && fs.pendingIndex != nil && fs.pendingIndex.Generation(fh.Path) == fh.PendingIndexGen {
+		return false
+	}
+	if fs != nil && fh.ShadowStageGen != 0 && fs.shadowStore != nil && fs.shadowStore.ActiveGeneration(fh.Path) == fh.ShadowStageGen {
+		return false
+	}
+	// A dirty handle's bytes were prepared against its current BaseRev.
+	// Advancing only the revision token after a sibling commit would create
+	// the silent-rollback shape: old payload + new CAS base. SQLite sidecar
+	// journals keep their historical same-mount adoption path only while they
+	// are still pure in-memory buffers; once they have path-keyed staging in
+	// shadow/writeBack/pendingIndex, the generation checks above fence them
+	// like any other dirty payload.
+	if !isSQLitePersistentJournalPath(fh.Path) && (fh.DirtySeq != 0 || (fh.Dirty != nil && fh.Dirty.HasDirtyParts())) {
+		return false
+	}
+	return true
+}
+
 func (fs *Dat9FS) refreshCleanCommittedRevisionForHandleLocked(fh *FileHandle) bool {
-	if fs == nil || fh == nil || fh.Dirty == nil || fh.DirtySeq != 0 || fh.Dirty.HasDirtyParts() {
+	if fs == nil || fh == nil || fh.Dirty == nil || !fs.handleCanAdoptCommittedRevisionLocked(fh) {
 		return false
 	}
 	revision := fs.latestCommittedRevision(fh.Path)
@@ -2403,6 +2477,9 @@ func (fs *Dat9FS) adoptCommittedRevisionLocked(fh *FileHandle) {
 	}
 	advanced := revision > fh.BaseRev
 	if advanced {
+		if !fs.handleCanAdoptCommittedRevisionLocked(fh) {
+			return
+		}
 		fh.IsNew = false
 		fh.BaseRev = revision
 		if fh.Streamer != nil {
@@ -2445,15 +2522,7 @@ func (fs *Dat9FS) markHandleRevisionOnlyLocked(fh *FileHandle, revision int64, s
 	fs.adoptCommittedStorageClassLocked(fh, snapshotSize)
 	fs.inodes.UpdateRevision(fh.Ino, revision)
 	fs.refreshCommittedRevisionForOpenHandlesWithSize(fh.Path, revision, fh, snapshotSize)
-	if fs.writeBack != nil {
-		fs.writeBack.Remove(fh.Path)
-	}
-	if fs.shadowStore != nil {
-		fs.shadowStore.Remove(fh.Path)
-	}
-	if fs.pendingIndex != nil {
-		fs.pendingIndex.Remove(fh.Path)
-	}
+	fs.removeHandleStagingLocked(fh)
 	fh.ShadowReady = false
 	fh.ShadowSpill = false
 	fh.ShadowCommitReady = false
@@ -2482,15 +2551,7 @@ func (fs *Dat9FS) markHandleRemoteCommittedLocked(fh *FileHandle, revision int64
 	if fh.ZeroBase && fh.Dirty != nil && fh.Dirty.Size() > 0 {
 		fh.ZeroBase = false
 	}
-	if fs.writeBack != nil {
-		fs.writeBack.Remove(fh.Path)
-	}
-	if fs.shadowStore != nil {
-		fs.shadowStore.Remove(fh.Path)
-	}
-	if fs.pendingIndex != nil {
-		fs.pendingIndex.Remove(fh.Path)
-	}
+	fs.removeHandleStagingLocked(fh)
 	fh.ShadowReady = false
 	fh.ShadowSpill = false
 	fh.ShadowCommitReady = false
@@ -3295,6 +3356,7 @@ func (fs *Dat9FS) stagePathTruncateToZeroLocked(ctx context.Context, entry *Inod
 		HasMode:              hasMode,
 		CoalesceZeroTruncate: true,
 	}
+	fs.bindCommitEntryToPath(commit, entry.Path, expectedRevision)
 	if err := fs.commitQueue.Enqueue(commit); err != nil {
 		safeLogPrintf("path truncate async enqueue failed for %s: %v, falling back to sync commit", entry.Path, err)
 		if commitErr := fs.commitQueue.commitNowPathLocked(ctx, commit); commitErr != nil {
@@ -3377,6 +3439,47 @@ func (fs *Dat9FS) stageShadowForQueuedCommitLocked(fh *FileHandle, durable bool)
 	return err
 }
 
+func (fs *Dat9FS) bindCommitEntryToHandleLocked(entry *CommitEntry, fh *FileHandle, payloadBaseRev int64) {
+	if fs == nil || entry == nil || fh == nil {
+		return
+	}
+	entry.PayloadBaseRev = payloadBaseRev
+	entry.PayloadBaseRevSet = true
+	entry.DirtySeq = fh.DirtySeq
+	entry.WriteBackSeq = fh.WriteBackSeq
+	entry.WriteBackGen = fh.WriteBackGen
+	entry.ShadowGen = fh.ShadowStageGen
+	if entry.ShadowGen == 0 && fs.shadowStore != nil {
+		entry.ShadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
+	}
+	entry.PendingIndexGen = fh.PendingIndexGen
+	if entry.PendingIndexGen == 0 && fs.pendingIndex != nil {
+		entry.PendingIndexGen = fs.pendingIndex.Generation(fh.Path)
+	}
+	if watermark := fs.latestCommittedRevision(fh.Path); watermark > payloadBaseRev && payloadBaseRev >= 0 {
+		entry.DurableWatermarkRev = watermark
+		entry.DisableAutoResolveLWW = true
+	}
+}
+
+func (fs *Dat9FS) bindCommitEntryToPath(entry *CommitEntry, remotePath string, payloadBaseRev int64) {
+	if fs == nil || entry == nil || remotePath == "" {
+		return
+	}
+	entry.PayloadBaseRev = payloadBaseRev
+	entry.PayloadBaseRevSet = true
+	if fs.shadowStore != nil {
+		entry.ShadowGen = fs.shadowStore.ActiveGeneration(remotePath)
+	}
+	if fs.pendingIndex != nil {
+		entry.PendingIndexGen = fs.pendingIndex.Generation(remotePath)
+	}
+	if watermark := fs.latestCommittedRevision(remotePath); watermark > payloadBaseRev && payloadBaseRev >= 0 {
+		entry.DurableWatermarkRev = watermark
+		entry.DisableAutoResolveLWW = true
+	}
+}
+
 func (fs *Dat9FS) enqueueStagedShadowCommitLocked(fh *FileHandle) error {
 	if fs == nil || fh == nil || fh.Dirty == nil || fs.commitQueue == nil || fs.shadowStore == nil || !fs.shadowStore.Has(fh.Path) {
 		return syscall.ENOTSUP
@@ -3384,6 +3487,7 @@ func (fs *Dat9FS) enqueueStagedShadowCommitLocked(fh *FileHandle) error {
 	size := fh.Dirty.Size()
 	mode, hasMode := fs.modeForPendingHandle(fh)
 	expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+	payloadBaseRev := fh.BaseRev
 	entry := &CommitEntry{
 		Path:        fh.Path,
 		Inode:       fh.Ino,
@@ -3394,6 +3498,7 @@ func (fs *Dat9FS) enqueueStagedShadowCommitLocked(fh *FileHandle) error {
 		Mode:        mode,
 		HasMode:     hasMode,
 	}
+	fs.bindCommitEntryToHandleLocked(entry, fh, payloadBaseRev)
 	if err := fs.commitQueue.Enqueue(entry); err != nil {
 		return err
 	}
@@ -3403,9 +3508,18 @@ func (fs *Dat9FS) enqueueStagedShadowCommitLocked(fh *FileHandle) error {
 	fh.WriteBackSeq = 0
 	fh.ShadowCommitReady = false
 	fh.ShadowCommitSeq = 0
-	if fs.writeBack != nil {
-		fs.writeBack.Remove(fh.Path)
+	// The commit queue now owns fh.PendingIndexGen/fh.ShadowStageGen via the
+	// CommitEntry. Do not remove those path-keyed records here: the async
+	// worker still needs the shadow payload and will clean both records with
+	// generation guards after upload (or keep/mark them on terminal failure).
+	// Only clear this handle's writeBack snapshot, which is no longer needed
+	// once the staged shadow commit is queued.
+	if fs.writeBack != nil && fh.WriteBackGen != 0 {
+		fs.writeBack.RemoveIfGeneration(fh.Path, fh.WriteBackGen)
 	}
+	fh.WriteBackGen = 0
+	fh.PendingIndexGen = 0
+	fh.ShadowStageGen = 0
 	if hasMode {
 		clearPendingModeLocked(fh)
 		fh.Unlock()
@@ -8894,6 +9008,7 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 			Mode:        meta.Mode,
 			HasMode:     meta.HasMode,
 		}
+		fs.bindCommitEntryToPath(entry, newP, meta.BaseRev)
 		if isGitLooseObjectFinalPath(newP) {
 			// Git treats a successful tmp_obj_* -> <sha> rename as making the
 			// object database complete. Do not acknowledge that rename while the
@@ -11650,10 +11765,14 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
 		defer unlockRemoteCommit()
 		expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+		shadowGen := fh.ShadowStageGen
+		if shadowGen == 0 {
+			shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
+		}
 		uploadStart := time.Now()
 		fs.debugf("sync handle shadowspill upload start path=%s size=%d expected_rev=%d", fh.Path, size, expectedRevision)
 		fh.Unlock()
-		committedRev, err := uploadFromShadowRemoteWithRevision(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevision)
+		committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(ctx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevision, shadowGen)
 		fh.Lock()
 		var uploadBytes uint64
 		if size > 0 {
@@ -12009,6 +12128,10 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			expectedRevision := fs.expectedRevisionForHandleLocked(fh)
 			handleIsNew := fh.IsNew
 			handlePath := fh.Path
+			shadowGen := fh.ShadowStageGen
+			if shadowGen == 0 {
+				shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
+			}
 			// B4: serialize with Unlink's remote DELETE — hold the per-path
 			// remoteCommitLock across the network upload while releasing fh.mu,
 			// exactly like flushHandle Path 2. Without it Unlink can DELETE and
@@ -12017,7 +12140,7 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			uploadStart := time.Now()
 			fs.debugf("flush shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 			fh.Unlock()
-			committedRev, err := uploadFromShadowRemoteWithRevision(uploadCtx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision)
+			committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(uploadCtx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision, shadowGen)
 			// Record the committed revision while still holding remoteCommitLock
 			// so a waiting Unlink re-check observes the upload and issues a DELETE.
 			if err == nil && committedRev > 0 {
@@ -12311,6 +12434,10 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		phase = "shadowspill-sync-upload"
 		handleIsNew := fh.IsNew
 		handlePath := fh.Path
+		shadowGen := fh.ShadowStageGen
+		if shadowGen == 0 {
+			shadowGen = fs.shadowStore.ActiveGeneration(fh.Path)
+		}
 		// B4: serialize with Unlink's remote DELETE — hold the per-path
 		// remoteCommitLock across the network upload while releasing fh.mu,
 		// exactly like flushHandle Path 2. Without it Unlink can DELETE and
@@ -12319,7 +12446,7 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		uploadStart := time.Now()
 		fs.debugf("fsync shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
 		fh.Unlock()
-		committedRev, err := uploadFromShadowRemoteWithRevision(uploadCtx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision)
+		committedRev, err := uploadFromShadowRemoteWithRevisionAndGeneration(uploadCtx, fs.client, fs.shadowStore, handlePath, fs.remotePath(handlePath), expectedRevision, shadowGen)
 		// Record the committed revision while still holding remoteCommitLock
 		// so a waiting Unlink re-check observes the upload and issues a DELETE.
 		if err == nil && committedRev > 0 {
@@ -12406,15 +12533,18 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 				return gofuse.EIO
 			}
 			mode, hasMode := fs.modeForPendingHandle(fh)
+			expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+			payloadBaseRev := fh.BaseRev
 			entry := &CommitEntry{
 				Path:    fh.Path,
 				Inode:   fh.Ino,
-				BaseRev: fh.BaseRev,
+				BaseRev: expectedRevision,
 				Size:    size,
 				Kind:    fs.pendingKindForHandle(fh),
 				Mode:    mode,
 				HasMode: hasMode,
 			}
+			fs.bindCommitEntryToHandleLocked(entry, fh, payloadBaseRev)
 			uploadStart := time.Now()
 			fs.debugf("fsync layer upload start path=%s", fh.Path)
 			err := fs.commitQueue.CommitNow(ctx, entry)
@@ -12471,7 +12601,10 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 	} else if fs.writeBack != nil && fh.WriteBackSeq != 0 && fh.WriteBackSeq != fh.DirtySeq {
 		// Snapshot is stale — discard it so we don't upload old data.
 		phase = "writeback-stale"
-		fs.writeBack.Remove(fh.Path)
+		if fh.WriteBackGen != 0 {
+			fs.writeBack.RemoveIfGeneration(fh.Path, fh.WriteBackGen)
+		}
+		fh.WriteBackGen = 0
 		fh.WriteBackSeq = 0
 	}
 
@@ -12741,17 +12874,10 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				fh.Unlock()
 				return
 			}
-			fh.Dirty.ClearDirty()
-			fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 			size := fh.Dirty.Size()
-			fh.DirtySeq = 0
-			fh.ShadowCommitReady = false
-			fh.ShadowCommitSeq = 0
 			mode, hasMode := fs.modeForPendingHandle(fh)
 			expectedRevision := fs.expectedRevisionForHandleLocked(fh)
-			unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
-			fh.Unlock()
-
+			payloadBaseRev := fh.BaseRev
 			entry := &CommitEntry{
 				Path:        fh.Path,
 				Inode:       fh.Ino,
@@ -12765,6 +12891,15 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			if fh.IsNew {
 				entry.Kind = PendingNew
 			}
+			fs.bindCommitEntryToHandleLocked(entry, fh, payloadBaseRev)
+			fh.Dirty.ClearDirty()
+			fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+			fh.DirtySeq = 0
+			fh.ShadowCommitReady = false
+			fh.ShadowCommitSeq = 0
+			unlockRemoteCommit := fs.takeHandleRemoteCommitPathLocked(fh)
+			fh.Unlock()
+
 			enqueueStart := time.Now()
 			fs.debugf("release commit enqueue start path=%s size=%d shadow_spill=true", fh.Path, size)
 			err := fs.commitQueue.Enqueue(entry)
@@ -12782,7 +12917,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 					phase = "shadowspill-sync-upload"
 					uploadStart := time.Now()
 					fs.debugf("release shadowspill upload start path=%s size=%d timeout=%s", fh.Path, size, releaseTimeout(size))
-					committedRev, uploadErr := uploadFromShadowRemoteWithRevision(uploadCtx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevision)
+					committedRev, uploadErr := uploadFromShadowRemoteWithRevisionAndGeneration(uploadCtx, fs.client, fs.shadowStore, fh.Path, fs.remotePath(fh.Path), expectedRevision, entry.ShadowGen)
 					var uploadBytes uint64
 					if size > 0 {
 						uploadBytes = uint64(size)
@@ -12870,6 +13005,21 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				phase = "writeback-cache-release"
 				mode, hasMode := fs.modeForPendingHandle(fh)
 				expectedRevision := fs.expectedRevisionForHandleLocked(fh)
+				payloadBaseRev := fh.BaseRev
+				size := fh.Dirty.Size()
+				entry := &CommitEntry{
+					Path:    fh.Path,
+					Inode:   fh.Ino,
+					BaseRev: expectedRevision,
+					Size:    size,
+					Kind:    PendingOverwrite,
+					Mode:    mode,
+					HasMode: hasMode,
+				}
+				if fh.IsNew {
+					entry.Kind = PendingNew
+				}
+				fs.bindCommitEntryToHandleLocked(entry, fh, payloadBaseRev)
 				fh.Dirty.ClearDirty()
 				fs.clearDirtySize(fh.Ino, fh.DirtySeq)
 				fh.DirtySeq = 0
@@ -12884,18 +13034,6 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 				// Enqueue to CommitQueue if available (P1), otherwise
 				// use the legacy uploader.
 				if useCommitQueue {
-					entry := &CommitEntry{
-						Path:    fh.Path,
-						Inode:   fh.Ino,
-						BaseRev: expectedRevision,
-						Size:    fh.Dirty.Size(),
-						Kind:    PendingOverwrite,
-						Mode:    mode,
-						HasMode: hasMode,
-					}
-					if fh.IsNew {
-						entry.Kind = PendingNew
-					}
 					enqueueStart := time.Now()
 					fs.debugf("release commit enqueue start path=%s size=%d shadow_spill=false", fh.Path, entry.Size)
 					err := fs.commitQueue.Enqueue(entry)
@@ -12913,7 +13051,9 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 						// CommitQueue owns the upload via shadow; remove the
 						// writeBack .dat/.meta snapshot so it doesn't leak or
 						// serve stale data to Lookup/Read.
-						fs.writeBack.Remove(fh.Path)
+						if entry.WriteBackGen != 0 {
+							fs.writeBack.RemoveIfGeneration(fh.Path, entry.WriteBackGen)
+						}
 					}
 					unlockRemoteCommit()
 				} else {
@@ -12932,7 +13072,7 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 
 				// Invalidate caches so subsequent reads see fresh data.
 				fs.invalidateReadCacheAndTargets(fh.Path)
-				fs.cacheFileForPath(fh.Path, fh.Dirty.Size(), time.Now(), 0)
+				fs.cacheFileForPath(fh.Path, size, time.Now(), 0)
 				// Local release — kernel already knows about this close.
 				// No notifyInode needed; userspace caches are invalidated above.
 				return
@@ -12940,7 +13080,10 @@ func (fs *Dat9FS) Release(cancel <-chan struct{}, input *gofuse.ReleaseIn) {
 			// Stale cache — remove it, fall through to sync upload.
 			if fh.WriteBackSeq != 0 {
 				fs.debugf("release stale writeback remove path=%s writeback_seq=%d dirty_seq=%d", fh.Path, fh.WriteBackSeq, fh.DirtySeq)
-				fs.writeBack.Remove(fh.Path)
+				if fh.WriteBackGen != 0 {
+					fs.writeBack.RemoveIfGeneration(fh.Path, fh.WriteBackGen)
+				}
+				fh.WriteBackGen = 0
 				fh.WriteBackSeq = 0
 			}
 			fh.Unlock()
@@ -13094,6 +13237,13 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 			unlockRemoteCommit()
 			handle.Unlock()
 			return
+		}
+		if expectedRevision >= 0 {
+			if latest := fs.latestCommittedRevision(filePath); latest > expectedRevision {
+				unlockRemoteCommit()
+				handle.Unlock()
+				return
+			}
 		}
 
 		dCtx, dCf := context.WithTimeout(context.Background(), fuseTimeout)
@@ -14023,7 +14173,7 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 	if fs.layerEnabled() {
 		fs.clearReadTargetsForPath(entry.Path)
 		if fs.shadowStore != nil && entry.Size <= fs.readCache.MaxFileSize() {
-			if data, err := fs.shadowStore.ReadAll(entry.Path); err == nil {
+			if data, err := fs.readCommitEntryPayloadForCache(entry); err == nil {
 				fs.readCache.PutOwned(entry.Path, data, 0)
 			}
 		}
@@ -14048,7 +14198,7 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 		// Seed readCache from shadow data before the shadow file is removed.
 		// Only attempt for files under the readCache size limit.
 		if entry.Size <= fs.readCache.MaxFileSize() && fs.shadowStore != nil {
-			if data, err := fs.shadowStore.ReadAll(entry.Path); err == nil {
+			if data, err := fs.readCommitEntryPayloadForCache(entry); err == nil {
 				fs.readCache.PutOwned(entry.Path, data, committedRev)
 			}
 		}
@@ -14074,6 +14224,23 @@ func (fs *Dat9FS) onCommitQueueSuccess(entry *CommitEntry, committedRev int64) {
 		}
 		fs.cacheFileForPath(entry.Path, entry.Size, time.Now(), 0)
 	}
+}
+
+func (fs *Dat9FS) readCommitEntryPayloadForCache(entry *CommitEntry) ([]byte, error) {
+	if fs == nil || entry == nil {
+		return nil, fmt.Errorf("nil commit cache payload")
+	}
+	if entry.payloadBound {
+		return append([]byte(nil), entry.payload...), nil
+	}
+	if fs.shadowStore == nil {
+		return nil, fmt.Errorf("missing shadow store")
+	}
+	data, err := fs.shadowStore.ReadAllIfGeneration(entry.Path, entry.ShadowGen)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
 }
 
 // snapshotStagingGens captures the pendingIndex and shadowStore content

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -6271,6 +6271,23 @@ func (fs *Dat9FS) notifyInode(ino uint64) {
 	}()
 }
 
+// notifyInodeSync invalidates cached inode attrs/data before returning to the
+// kernel. Most local mutations must use notifyInode's asynchronous path to
+// avoid go-fuse worker-pool re-entry deadlocks, but close-sync/write-sync
+// remote commits are close-to-open barriers: the next opener may otherwise
+// observe stale size/page-cache state even though the remote commit has
+// completed.
+func (fs *Dat9FS) notifyInodeSync(ino uint64) {
+	fs.notifyCount.Add(1)
+	if fs.perf != nil {
+		fs.perf.notifyInode.add(1)
+	}
+	if fs.server == nil {
+		return
+	}
+	_ = fs.server.InodeNotify(ino, 0, 0)
+}
+
 func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name string, out *gofuse.EntryOut) (status gofuse.Status) {
 	perfStart := fs.perfStart()
 	defer func() { fs.perfRecordFuse(perfFuseLookup, perfStart, status, 0) }()
@@ -11759,6 +11776,13 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 	}
 	fs.inodes.UpdateSize(fh.Ino, size)
 	fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
+	if fh.WritePolicy == WritePolicyWriteSync {
+		// write-sync completes the remote commit before Write returns. If this
+		// handle was opened O_TRUNC + FOPEN_DIRECT_IO, invalidate kernel
+		// size/data state immediately so the next read cannot observe the
+		// truncation's stale 0-byte view.
+		fs.notifyInodeSync(fh.Ino)
+	}
 	return gofuse.OK
 }
 
@@ -11837,6 +11861,9 @@ func (fs *Dat9FS) syncHandleToRemoteLocked(ctx context.Context, fh *FileHandle) 
 		}
 		fs.inodes.UpdateSize(fh.Ino, size)
 		fs.cacheFileForPath(fh.Path, size, time.Now(), committedRev)
+		if fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync {
+			fs.notifyInodeSync(fh.Ino)
+		}
 		return gofuse.OK
 	}
 
@@ -13982,9 +14009,20 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 			}
 		}
 	}
-	// Local flush — kernel receives the Flush reply with status.
-	// No notifyInode/notifyEntry needed; userspace caches are updated
-	// above and kernel will refresh attrs on next getattr/lookup.
+	if !pathRetargeted && fh.DirtySeq == 0 &&
+		(fh.WritePolicy == WritePolicyCloseSync || fh.WritePolicy == WritePolicyWriteSync) {
+		// close-sync/write-sync are remote durability barriers. The writer may
+		// have been opened with O_TRUNC + FOPEN_DIRECT_IO, so Linux can retain a
+		// kernel-side size/page-cache view from the truncation (0 bytes) while
+		// the just-committed bytes live only in userspace/remote caches. Invalidate
+		// synchronously before returning Flush so an immediate close-to-open read
+		// cannot serve stale/empty data from the kernel cache.
+		fs.notifyInodeSync(handleIno)
+	}
+	// Local flush — kernel receives the Flush reply with status. Most paths do
+	// not need notifyInode/notifyEntry because userspace caches are updated
+	// above and kernel will refresh attrs on next getattr/lookup. Synchronous
+	// close-sync/write-sync uploads are the exception handled just above.
 	return gofuse.OK
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14696,6 +14696,7 @@ func TestFlushHandle_StartedSQLiteJournalStreamerKeepsStaleBaseRev(t *testing.T)
 	var gotExpected atomic.Int64
 	gotExpected.Store(-999)
 	var initiateCalls atomic.Int32
+	var handlerErrors testErrorRecorder
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost || r.URL.Path != "/v2/uploads/initiate" {
 			http.NotFound(w, r)
@@ -14708,13 +14709,19 @@ func TestFlushHandle_StartedSQLiteJournalStreamerKeepsStaleBaseRev(t *testing.T)
 			ExpectedRevision *int64 `json:"expected_revision"`
 		}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			t.Fatalf("decode initiate request: %v", err)
+			handlerErrors.Recordf("decode initiate request: %v", err)
+			http.Error(w, "bad initiate request", http.StatusBadRequest)
+			return
 		}
 		if req.Path != "/stream.db-wal" {
-			t.Fatalf("initiate path = %q, want /stream.db-wal", req.Path)
+			handlerErrors.Recordf("initiate path = %q, want /stream.db-wal", req.Path)
+			http.Error(w, "unexpected initiate path", http.StatusInternalServerError)
+			return
 		}
 		if req.TotalSize != int64(len(data)) {
-			t.Fatalf("initiate total size = %d, want %d", req.TotalSize, len(data))
+			handlerErrors.Recordf("initiate total size = %d, want %d", req.TotalSize, len(data))
+			http.Error(w, "unexpected initiate size", http.StatusInternalServerError)
+			return
 		}
 		if req.ExpectedRevision != nil {
 			gotExpected.Store(*req.ExpectedRevision)
@@ -14723,7 +14730,8 @@ func TestFlushHandle_StartedSQLiteJournalStreamerKeepsStaleBaseRev(t *testing.T)
 			http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
 			return
 		}
-		t.Fatal("stale SQLite journal streamer unexpectedly adopted rev8")
+		handlerErrors.Recordf("stale SQLite journal streamer unexpectedly adopted rev8")
+		http.Error(w, "stale SQLite journal streamer unexpectedly adopted latest revision", http.StatusInternalServerError)
 	}))
 	defer ts.Close()
 
@@ -14764,6 +14772,7 @@ func TestFlushHandle_StartedSQLiteJournalStreamerKeepsStaleBaseRev(t *testing.T)
 	if fh.BaseRev != 7 {
 		t.Fatalf("fh.BaseRev = %d, want 7", fh.BaseRev)
 	}
+	handlerErrors.Check(t)
 }
 
 func TestTruncateWritableHandleLockedZeroResetsStreamingStateBeforeContinuedWrite(t *testing.T) {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -8083,6 +8083,30 @@ func TestOpenWritableSQLiteUsesDirectIO(t *testing.T) {
 	}
 }
 
+func TestOpenReadOnlySyncDurabilityUsesDirectIO(t *testing.T) {
+	for _, policy := range []WritePolicy{WritePolicyCloseSync, WritePolicyWriteSync} {
+		t.Run(string(policy), func(t *testing.T) {
+			opts := &MountOptions{}
+			opts.setDefaults()
+			opts.WritePolicy = policy
+			fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+			ino := fs.inodes.Lookup("/sync-visible.txt", false, 17, time.Now())
+
+			var out gofuse.OpenOut
+			st := fs.Open(nil, &gofuse.OpenIn{
+				InHeader: gofuse.InHeader{NodeId: ino},
+				Flags:    uint32(syscall.O_RDONLY),
+			}, &out)
+			if st != gofuse.OK {
+				t.Fatalf("Open status = %v, want OK", st)
+			}
+			if out.OpenFlags != gofuse.FOPEN_DIRECT_IO {
+				t.Fatalf("open flags = %d, want FOPEN_DIRECT_IO for %s close-to-open coherence", out.OpenFlags, policy)
+			}
+		})
+	}
+}
+
 func TestOpenReadOnlyCacheableFileSkipsPrefetcher(t *testing.T) {
 	size := int64(defaultReadCacheMaxFileSize)
 	fs, ino, cleanup := newTestDat9FS(t, size, func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3353,15 +3353,21 @@ func TestFlushSmallNewFileRefreshesSiblingHandleRevision(t *testing.T) {
 	if st := fs.Flush(nil, &gofuse.FlushIn{InHeader: gofuse.InHeader{NodeId: ino}, Fh: fh1ID}); st != gofuse.OK {
 		t.Fatalf("first Flush status = %v, want OK", st)
 	}
-	if fh2.IsNew {
-		t.Fatal("second handle should no longer be create-if-absent after sibling commit")
+	if !fh2.IsNew {
+		t.Fatal("dirty sibling handle adopted committed revision before its remote-sync boundary")
 	}
-	if fh2.BaseRev != 1 {
-		t.Fatalf("second handle BaseRev = %d, want 1", fh2.BaseRev)
+	if fh2.BaseRev != 0 {
+		t.Fatalf("second handle BaseRev before flush = %d, want 0", fh2.BaseRev)
 	}
 
 	if st := fs.Flush(nil, &gofuse.FlushIn{InHeader: gofuse.InHeader{NodeId: ino}, Fh: fh2ID}); st != gofuse.OK {
 		t.Fatalf("second Flush status = %v, want OK", st)
+	}
+	if fh2.IsNew {
+		t.Fatal("second handle should no longer be create-if-absent after its remote-sync flush")
+	}
+	if fh2.BaseRev != 2 {
+		t.Fatalf("second handle BaseRev after flush = %d, want 2", fh2.BaseRev)
 	}
 
 	mu.Lock()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -12318,6 +12318,106 @@ func TestReadCloseSyncSamePathDirtyWriterWaitsForLockedHandle(t *testing.T) {
 	}
 }
 
+func TestReadCloseSyncSamePathDirtyWriterWaitsForCandidateLoopLockedHandle(t *testing.T) {
+	var remoteReads atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteReads.Add(1)
+		http.Error(w, "remote should not be consulted while a scanned same-path dirty writer is locked", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	const filePath = "/supervise-probe.txt"
+	want := []byte("after-heal-candidate-loop")
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	writer := &FileHandle{
+		Ino:         ino,
+		Path:        filePath,
+		WritePolicy: WritePolicyCloseSync,
+		Dirty:       fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+	}
+	if _, err := writer.Dirty.Write(0, want); err != nil {
+		t.Fatal(err)
+	}
+	writer.DirtySeq = fs.markDirtySize(ino, int64(len(want)))
+	fs.openHandles.Add(writer)
+
+	lockedInCandidateWindow := make(chan struct{})
+	releaseLockedWriter := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWriter := func() {
+		releaseOnce.Do(func() {
+			close(releaseLockedWriter)
+		})
+	}
+	t.Cleanup(func() {
+		testHookAfterSamePathDirtyHandleScan = nil
+		releaseWriter()
+	})
+
+	var hookOnce sync.Once
+	testHookAfterSamePathDirtyHandleScan = func(path string) {
+		if path != filePath {
+			return
+		}
+		hookOnce.Do(func() {
+			writer.Lock()
+			close(lockedInCandidateWindow)
+			go func() {
+				<-releaseLockedWriter
+				writer.Unlock()
+			}()
+		})
+	}
+
+	reader := &FileHandle{Ino: ino, Path: filePath, WritePolicy: WritePolicyCloseSync}
+	readerID := fs.allocateFileHandle(reader)
+	defer fs.deleteFileHandle(readerID, reader)
+
+	type readResult struct {
+		data []byte
+		st   gofuse.Status
+		err  error
+	}
+	done := make(chan readResult, 1)
+	go func() {
+		got, st, err := readDat9FSTestRange(fs, ino, readerID, 0, len(want))
+		done <- readResult{data: got, st: st, err: err}
+	}()
+
+	select {
+	case <-lockedInCandidateWindow:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for same-path dirty candidate-loop lock window")
+	}
+	time.Sleep(10 * time.Millisecond)
+	if gotRemote := remoteReads.Load(); gotRemote != 0 {
+		t.Fatalf("remote reads while candidate lock was pending = %d, want 0", gotRemote)
+	}
+	releaseWriter()
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatal(res.err)
+		}
+		if res.st != gofuse.OK {
+			t.Fatalf("Read status = %v, want OK", res.st)
+		}
+		if !bytes.Equal(res.data, want) {
+			t.Fatalf("read bytes = %q, want %q", res.data, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for close-sync same-path dirty read")
+	}
+	if gotRemote := remoteReads.Load(); gotRemote != 0 {
+		t.Fatalf("remote reads = %d, want 0", gotRemote)
+	}
+}
+
 func TestReadSQLiteSamePathDirtyShadowEOFIsShortRead(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "remote should not be consulted for same-mount sqlite shadow data", http.StatusInternalServerError)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -9925,6 +9925,132 @@ func TestOpenWritablePreloadChoosesNewestOpenHandle(t *testing.T) {
 	}
 }
 
+func TestLoadWritableHandleFromShadowBindsStagingGenerations(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	const filePath = "/shadow-adopt.txt"
+	data := []byte("pending shadow bytes")
+	if err := shadow.WriteFull(filePath, data, 7); err != nil {
+		t.Fatal(err)
+	}
+	shadowGen := shadow.ActiveGeneration(filePath)
+	pendingGen, err := pending.PutWithBaseRev(filePath, int64(len(data)), PendingOverwrite, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	meta, ok := pending.GetMeta(filePath)
+	if !ok {
+		t.Fatal("pending metadata missing")
+	}
+
+	ino := fs.inodes.Lookup(filePath, false, int64(len(data)), time.Now())
+	target := &FileHandle{
+		Ino:   ino,
+		Path:  filePath,
+		Dirty: fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+	}
+	if err := fs.loadWritableHandleFromShadowLocked(target, meta); err != nil {
+		t.Fatalf("loadWritableHandleFromShadowLocked: %v", err)
+	}
+	if got := target.ShadowStageGen; got != shadowGen {
+		t.Fatalf("ShadowStageGen = %d, want %d", got, shadowGen)
+	}
+	if got := target.PendingIndexGen; got != pendingGen {
+		t.Fatalf("PendingIndexGen = %d, want %d", got, pendingGen)
+	}
+	if got := target.BaseRev; got != 7 {
+		t.Fatalf("BaseRev = %d, want 7", got)
+	}
+	if got := target.Dirty.Bytes(); !bytes.Equal(got, data) {
+		t.Fatalf("dirty bytes = %q, want %q", got, data)
+	}
+}
+
+func TestLoadWritableHandleFromOpenHandleCopiesStagingGenerations(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	const filePath = "/open-shadow-adopt.txt"
+	data := []byte("source shadow bytes")
+	if err := shadow.WriteFull(filePath, data, 3); err != nil {
+		t.Fatal(err)
+	}
+	shadowGen := shadow.ActiveGeneration(filePath)
+	pendingGen, err := pending.PutWithBaseRev(filePath, int64(len(data)), PendingOverwrite, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ino := fs.inodes.Lookup(filePath, false, int64(len(data)), time.Now())
+	source := &FileHandle{
+		Ino:             ino,
+		Path:            filePath,
+		Dirty:           fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+		BaseRev:         3,
+		OrigSize:        int64(len(data)),
+		ShadowReady:     true,
+		ShadowStageGen:  shadowGen,
+		PendingIndexGen: pendingGen,
+		WriteBackGen:    44,
+	}
+	if _, err := source.Dirty.Write(0, data); err != nil {
+		t.Fatal(err)
+	}
+	source.DirtySeq = fs.markDirtySize(ino, source.Dirty.Size())
+	fs.openHandles.Add(source)
+
+	target := &FileHandle{
+		Ino:   ino,
+		Path:  filePath,
+		Dirty: fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+	}
+	if !fs.loadWritableHandleFromOpenHandleLocked(target) {
+		t.Fatal("loadWritableHandleFromOpenHandleLocked returned false")
+	}
+	if !target.ShadowReady {
+		t.Fatal("target did not preserve shadow-backed source state")
+	}
+	if got := target.ShadowStageGen; got != shadowGen {
+		t.Fatalf("ShadowStageGen = %d, want %d", got, shadowGen)
+	}
+	if got := target.PendingIndexGen; got != pendingGen {
+		t.Fatalf("PendingIndexGen = %d, want %d", got, pendingGen)
+	}
+	if got := target.WriteBackGen; got != uint64(44) {
+		t.Fatalf("WriteBackGen = %d, want 44", got)
+	}
+	if got := target.Dirty.Bytes(); !bytes.Equal(got, data) {
+		t.Fatalf("dirty bytes = %q, want %q", got, data)
+	}
+}
+
 func TestOpenWritablePreloadSkipsCleanSiblingReboundToNewRevision(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
@@ -12418,6 +12544,219 @@ func TestReadCloseSyncSamePathDirtyWriterWaitsForCandidateLoopLockedHandle(t *te
 	}
 }
 
+func TestReadCloseSyncSamePathNewestLockedCandidateBlocksOlderDirtySibling(t *testing.T) {
+	var remoteReads atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteReads.Add(1)
+		http.Error(w, "remote should not be consulted while newest same-path dirty writer is locked", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	const filePath = "/supervise-probe.txt"
+	olderData := []byte("older-dirty-candidate")
+	newestData := []byte("newest-dirty-candidate")
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	older := &FileHandle{
+		Ino:         ino,
+		Path:        filePath,
+		WritePolicy: WritePolicyCloseSync,
+		Dirty:       fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+	}
+	if _, err := older.Dirty.Write(0, olderData); err != nil {
+		t.Fatal(err)
+	}
+	older.DirtySeq = fs.markDirtySize(ino, int64(len(olderData)))
+	fs.openHandles.Add(older)
+
+	newest := &FileHandle{
+		Ino:         ino,
+		Path:        filePath,
+		WritePolicy: WritePolicyCloseSync,
+		Dirty:       fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+	}
+	if _, err := newest.Dirty.Write(0, newestData); err != nil {
+		t.Fatal(err)
+	}
+	newest.DirtySeq = fs.markDirtySize(ino, int64(len(newestData)))
+	fs.openHandles.Add(newest)
+
+	lockedInCandidateWindow := make(chan struct{})
+	releaseLockedWriter := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWriter := func() {
+		releaseOnce.Do(func() {
+			close(releaseLockedWriter)
+		})
+	}
+	t.Cleanup(func() {
+		testHookAfterSamePathDirtyHandleScan = nil
+		releaseWriter()
+	})
+
+	var hookOnce sync.Once
+	testHookAfterSamePathDirtyHandleScan = func(path string) {
+		if path != filePath {
+			return
+		}
+		hookOnce.Do(func() {
+			newest.Lock()
+			close(lockedInCandidateWindow)
+			go func() {
+				<-releaseLockedWriter
+				newest.Unlock()
+			}()
+		})
+	}
+
+	reader := &FileHandle{Ino: ino, Path: filePath, WritePolicy: WritePolicyCloseSync}
+	readerID := fs.allocateFileHandle(reader)
+	defer fs.deleteFileHandle(readerID, reader)
+
+	type readResult struct {
+		data []byte
+		st   gofuse.Status
+		err  error
+	}
+	done := make(chan readResult, 1)
+	go func() {
+		got, st, err := readDat9FSTestRange(fs, ino, readerID, 0, len(newestData))
+		done <- readResult{data: got, st: st, err: err}
+	}()
+
+	select {
+	case <-lockedInCandidateWindow:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for newest same-path dirty candidate lock window")
+	}
+	select {
+	case res := <-done:
+		t.Fatalf("read completed while newest dirty candidate was locked: data=%q status=%v err=%v", res.data, res.st, res.err)
+	case <-time.After(10 * time.Millisecond):
+	}
+	if gotRemote := remoteReads.Load(); gotRemote != 0 {
+		t.Fatalf("remote reads while newest candidate lock was pending = %d, want 0", gotRemote)
+	}
+	releaseWriter()
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatal(res.err)
+		}
+		if res.st != gofuse.OK {
+			t.Fatalf("Read status = %v, want OK", res.st)
+		}
+		if !bytes.Equal(res.data, newestData) {
+			t.Fatalf("read bytes = %q, want newest %q", res.data, newestData)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for close-sync same-path dirty read")
+	}
+}
+
+func TestReadSQLiteSidecarNewestLockedCandidateBlocksOlderDirtySibling(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+
+	const filePath = "/app.db-wal"
+	olderData := []byte("older-wal-frame")
+	newestData := []byte("newest-wal-data")
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	older := &FileHandle{
+		Ino:   ino,
+		Path:  filePath,
+		Dirty: fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+	}
+	if _, err := older.Dirty.Write(0, olderData); err != nil {
+		t.Fatal(err)
+	}
+	older.DirtySeq = fs.markDirtySize(ino, int64(len(olderData)))
+	fs.openHandles.Add(older)
+
+	newest := &FileHandle{
+		Ino:   ino,
+		Path:  filePath,
+		Dirty: fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+	}
+	if _, err := newest.Dirty.Write(0, newestData); err != nil {
+		t.Fatal(err)
+	}
+	newest.DirtySeq = fs.markDirtySize(ino, int64(len(newestData)))
+	fs.openHandles.Add(newest)
+
+	lockedInCandidateWindow := make(chan struct{})
+	releaseLockedWriter := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseWriter := func() {
+		releaseOnce.Do(func() {
+			close(releaseLockedWriter)
+		})
+	}
+	t.Cleanup(func() {
+		testHookAfterSamePathDirtyHandleScan = nil
+		releaseWriter()
+	})
+
+	var hookOnce sync.Once
+	testHookAfterSamePathDirtyHandleScan = func(path string) {
+		if path != filePath {
+			return
+		}
+		hookOnce.Do(func() {
+			newest.Lock()
+			close(lockedInCandidateWindow)
+			go func() {
+				<-releaseLockedWriter
+				newest.Unlock()
+			}()
+		})
+	}
+
+	type readResult struct {
+		data []byte
+		n    int
+		ok   bool
+		st   gofuse.Status
+	}
+	done := make(chan readResult, 1)
+	go func() {
+		got, n, ok, st, _ := fs.readSQLitePersistentJournalVisibleRange(filePath, nil, 0, 0, uint32(len(newestData)))
+		done <- readResult{data: got, n: n, ok: ok, st: st}
+	}()
+
+	select {
+	case <-lockedInCandidateWindow:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for newest sqlite sidecar dirty candidate lock window")
+	}
+	select {
+	case res := <-done:
+		t.Fatalf("sqlite sidecar read completed while newest dirty candidate was locked: data=%q n=%d ok=%t status=%v", res.data, res.n, res.ok, res.st)
+	case <-time.After(10 * time.Millisecond):
+	}
+	releaseWriter()
+
+	select {
+	case res := <-done:
+		if res.st != gofuse.OK {
+			t.Fatalf("Read status = %v, want OK", res.st)
+		}
+		if !res.ok {
+			t.Fatal("sqlite sidecar dirty reader should return newest bytes after lock releases")
+		}
+		if !bytes.Equal(res.data, newestData) {
+			t.Fatalf("read bytes = %q, want newest %q", res.data, newestData)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for sqlite sidecar dirty read")
+	}
+}
+
 func TestReadSQLiteSamePathDirtyShadowEOFIsShortRead(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "remote should not be consulted for same-mount sqlite shadow data", http.StatusInternalServerError)
@@ -14262,6 +14601,77 @@ func TestSetAttr_WriteBackStrictPathTruncateStagesAndReturnsBeforeRemoteCommit(t
 	}
 	close(releasePut)
 	cq.DrainAll()
+}
+
+func TestSetAttr_WriteBackPathTruncateSyncFallbackMarksStaleConflict(t *testing.T) {
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	c := newTestClient("http://127.0.0.1")
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = &CommitQueue{
+		maxPending:       0,
+		client:           c,
+		shadows:          shadow,
+		index:            pending,
+		queue:            []*CommitEntry{},
+		queuedByPath:     map[string]map[*CommitEntry]struct{}{},
+		inFlight:         map[string]*CommitEntry{},
+		delayed:          map[*CommitEntry]*time.Timer{},
+		workCh:           make(chan *CommitEntry, 1),
+		DurableWatermark: fs.latestCommittedRevision,
+	}
+
+	const filePath = "/stale-truncate.txt"
+	ino := fs.inodes.Lookup(filePath, false, 4096, time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+	fs.recordCommittedRevision(filePath, 2)
+	entry, ok := fs.inodes.GetEntry(ino)
+	if !ok {
+		t.Fatal("inode entry missing")
+	}
+	entry.Revision = 1
+
+	unlockRemoteCommit := fs.lockRemoteCommitPath(filePath)
+	st := fs.stagePathTruncateToZeroLocked(context.Background(), entry, ino)
+	unlockRemoteCommit()
+	if st == gofuse.OK {
+		t.Fatal("stale path truncate fallback unexpectedly succeeded")
+	}
+	meta, ok := pending.GetMeta(filePath)
+	if !ok {
+		t.Fatal("stale truncate pending metadata should be preserved as a conflict")
+	}
+	if meta.Kind != PendingConflict {
+		t.Fatalf("pending kind = %v, want PendingConflict", meta.Kind)
+	}
+	if meta.BaseRev != 1 {
+		t.Fatalf("pending base revision = %d, want 1", meta.BaseRev)
+	}
+	if meta.Size != 0 {
+		t.Fatalf("pending size = %d, want 0", meta.Size)
+	}
+	if !shadow.Has(filePath) {
+		t.Fatal("stale truncate shadow should be preserved for manual recovery")
+	}
+	data, err := shadow.ReadAll(filePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("stale truncate shadow length = %d, want 0", len(data))
+	}
 }
 
 func TestOpenTruncateCancelsQueuedPathTruncateWithoutCancelingInFlight(t *testing.T) {
@@ -20806,12 +21216,12 @@ func TestRenamePendingNewCommitUsesRemoteRenameWhenCanceledUploadBecameVisible(t
 	oldIno := fs.inodes.Lookup(oldP, false, int64(len(data)), time.Now())
 	dirIno := fs.inodes.Lookup("/repo/.git", true, 0, time.Now())
 
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:  oldP,
 		Inode: oldIno,
 		Size:  int64(len(data)),
 		Kind:  PendingNew,
-	}); err != nil {
+	})); err != nil {
 		t.Fatalf("enqueue old temp upload: %v", err)
 	}
 
@@ -25723,6 +26133,20 @@ func TestDebouncedFlushRemovesPendingIndexAfterUpload(t *testing.T) {
 	// The shadowStore entry should be removed.
 	if shadow.Has(filePath) {
 		t.Fatal("shadowStore should be removed after debounced upload")
+	}
+	fh.Lock()
+	dirtySeq := fh.DirtySeq
+	writeBackSeq := fh.WriteBackSeq
+	dirtyParts := fh.Dirty != nil && fh.Dirty.HasDirtyParts()
+	fh.Unlock()
+	if dirtySeq != 0 {
+		t.Fatalf("DirtySeq after debounced upload = %d, want 0", dirtySeq)
+	}
+	if writeBackSeq != 0 {
+		t.Fatalf("WriteBackSeq after debounced upload = %d, want 0", writeBackSeq)
+	}
+	if dirtyParts {
+		t.Fatal("dirty parts should be clear after debounced upload")
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -12207,6 +12207,117 @@ func TestReadSQLiteSamePathDirtyHandleSkipsIncompleteCandidate(t *testing.T) {
 	}
 }
 
+func TestReadCloseSyncSamePathDirtyWriterUsesDirtyBuffer(t *testing.T) {
+	var remoteReads atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteReads.Add(1)
+		http.Error(w, "remote should not be consulted while a same-path close-sync writer is dirty", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	const filePath = "/supervise-probe.txt"
+	want := []byte("before-crash")
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	writer := &FileHandle{
+		Ino:         ino,
+		Path:        filePath,
+		WritePolicy: WritePolicyCloseSync,
+		Dirty:       fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+	}
+	if _, err := writer.Dirty.Write(0, want); err != nil {
+		t.Fatal(err)
+	}
+	writer.DirtySeq = fs.markDirtySize(ino, int64(len(want)))
+	fs.openHandles.Add(writer)
+
+	reader := &FileHandle{Ino: ino, Path: filePath, WritePolicy: WritePolicyCloseSync}
+	readerID := fs.allocateFileHandle(reader)
+	defer fs.deleteFileHandle(readerID, reader)
+
+	got, st, err := readDat9FSTestRange(fs, ino, readerID, 0, len(want))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st != gofuse.OK {
+		t.Fatalf("Read status = %v, want OK", st)
+	}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("read bytes = %q, want %q", got, want)
+	}
+	if gotRemote := remoteReads.Load(); gotRemote != 0 {
+		t.Fatalf("remote reads = %d, want 0", gotRemote)
+	}
+}
+
+func TestReadCloseSyncSamePathDirtyWriterWaitsForLockedHandle(t *testing.T) {
+	var remoteReads atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		remoteReads.Add(1)
+		http.Error(w, "remote should not be consulted while waiting for same-path dirty writer", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+	const filePath = "/supervise-probe.txt"
+	want := []byte("after-heal")
+	ino := fs.inodes.Lookup(filePath, false, 0, time.Now())
+	writer := &FileHandle{
+		Ino:         ino,
+		Path:        filePath,
+		WritePolicy: WritePolicyCloseSync,
+		Dirty:       fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+	}
+	if _, err := writer.Dirty.Write(0, want); err != nil {
+		t.Fatal(err)
+	}
+	writer.DirtySeq = fs.markDirtySize(ino, int64(len(want)))
+	fs.openHandles.Add(writer)
+	writer.Lock()
+
+	reader := &FileHandle{Ino: ino, Path: filePath, WritePolicy: WritePolicyCloseSync}
+	readerID := fs.allocateFileHandle(reader)
+	defer fs.deleteFileHandle(readerID, reader)
+
+	type readResult struct {
+		data []byte
+		st   gofuse.Status
+		err  error
+	}
+	done := make(chan readResult, 1)
+	go func() {
+		got, st, err := readDat9FSTestRange(fs, ino, readerID, 0, len(want))
+		done <- readResult{data: got, st: st, err: err}
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	writer.Unlock()
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatal(res.err)
+		}
+		if res.st != gofuse.OK {
+			t.Fatalf("Read status = %v, want OK", res.st)
+		}
+		if !bytes.Equal(res.data, want) {
+			t.Fatalf("read bytes = %q, want %q", res.data, want)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for close-sync same-path dirty read")
+	}
+	if gotRemote := remoteReads.Load(); gotRemote != 0 {
+		t.Fatalf("remote reads = %d, want 0", gotRemote)
+	}
+}
+
 func TestReadSQLiteSamePathDirtyShadowEOFIsShortRead(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "remote should not be consulted for same-mount sqlite shadow data", http.StatusInternalServerError)

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -12895,6 +12895,9 @@ func TestSetAttr_MtimeUpdate(t *testing.T) {
 	if out.Mtime != uint64(mtime.Unix()) {
 		t.Fatalf("out.Mtime = %d, want %d", out.Mtime, mtime.Unix())
 	}
+	if got := out.Timeout(); got != fs.opts.AttrTTL {
+		t.Fatalf("attr timeout = %v, want %v", got, fs.opts.AttrTTL)
+	}
 }
 
 func TestSetAttr_MtimeNow(t *testing.T) {
@@ -13244,6 +13247,78 @@ func TestSetAttr_TruncateWithoutHandleRefreshesRevision(t *testing.T) {
 	}
 	if fh.BaseRev != 2 {
 		t.Fatalf("open base revision = %d, want 2", fh.BaseRev)
+	}
+}
+
+func TestSetAttr_SizeChangeDisablesAttrCache(t *testing.T) {
+	var (
+		mu       sync.Mutex
+		revision int64 = 1
+		content        = bytes.Repeat([]byte{0x41}, 42)
+		recorder testErrorRecorder
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			mu.Lock()
+			defer mu.Unlock()
+			w.Header().Set("Content-Length", strconv.FormatInt(int64(len(content)), 10))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(revision, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPut:
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				recorder.Recordf("read truncate body: %v", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			if len(body) != 0 {
+				recorder.Recordf("truncate body len = %d, want 0", len(body))
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			content = append(content[:0], body...)
+			revision = 2
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			http.NotFound(w, r)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{AttrTTL: time.Minute}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup("/file.bin", false, 42, time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+
+	var out gofuse.AttrOut
+	st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: ino},
+			Valid:    gofuse.FATTR_SIZE,
+			Size:     0,
+		},
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("SetAttr status = %v, want OK", st)
+	}
+	recorder.Check(t)
+	if got := out.Timeout(); got != 0 {
+		t.Fatalf("attr timeout after size change = %v, want 0", got)
+	}
+	if out.Size != 0 {
+		t.Fatalf("out.Size = %d, want 0", out.Size)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -5978,6 +5978,7 @@ func TestLookupUsesDirCacheNegativeEntryWithoutRemoteStat(t *testing.T) {
 	opts.setDefaults()
 	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	fs.dirCache.Put("/", []CachedFileInfo{{Name: "other.txt", Size: 1}})
+	fs.recordCommittedRevision("/missing.txt", 7)
 
 	var out gofuse.EntryOut
 	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "missing.txt", &out)
@@ -5989,6 +5990,9 @@ func TestLookupUsesDirCacheNegativeEntryWithoutRemoteStat(t *testing.T) {
 	}
 	if out.NodeId != 0 {
 		t.Fatalf("negative lookup NodeId = %d, want 0", out.NodeId)
+	}
+	if got := fs.latestCommittedRevision("/missing.txt"); got != 0 {
+		t.Fatalf("committed revision after cached ENOENT = %d, want 0", got)
 	}
 }
 
@@ -6047,6 +6051,167 @@ func TestLookupStatNotFoundSeedsShortNegativeNamespaceCache(t *testing.T) {
 	}
 	if got := headCalls.Load(); got != 1 {
 		t.Fatalf("HEAD calls = %d, want 1", got)
+	}
+}
+
+func TestLookupRemoteNotFoundClearsCommittedRevisionForPendingNewRecreate(t *testing.T) {
+	const filePath = "/recreate.txt"
+	newData := []byte("new incarnation")
+	staleData := []byte("old payload")
+
+	var (
+		mu          sync.Mutex
+		rec         testErrorRecorder
+		putBodies   [][]byte
+		putExpected []string
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			if r.URL.Path != "/v1/fs"+filePath {
+				rec.Recordf("HEAD path = %s, want /v1/fs%s", r.URL.Path, filePath)
+				http.Error(w, "bad path", http.StatusBadRequest)
+				return
+			}
+			// Simulate another client deleting a file this mount previously knew
+			// at rev 7. Lookup has now authoritatively observed a new empty
+			// incarnation slot for this path.
+			http.Error(w, "not found", http.StatusNotFound)
+		case http.MethodPut:
+			if r.URL.Path != "/v1/fs"+filePath {
+				rec.Recordf("PUT path = %s, want /v1/fs%s", r.URL.Path, filePath)
+				http.Error(w, "bad path", http.StatusBadRequest)
+				return
+			}
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				rec.Recordf("read PUT body: %v", err)
+				http.Error(w, "read body", http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			putBodies = append(putBodies, append([]byte(nil), body...))
+			putExpected = append(putExpected, r.Header.Get("X-Dat9-Expected-Revision"))
+			mu.Unlock()
+			if r.Header.Get("X-Dat9-Expected-Revision") != "0" {
+				http.Error(w, "revision conflict", http.StatusConflict)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(8)})
+		default:
+			rec.Recordf("unexpected method %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+		}
+	}))
+	defer ts.Close()
+	defer rec.Check(t)
+
+	opts := &MountOptions{SyncMode: SyncInteractive, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.PathLock = fs.lockRemoteCommitPath
+	cq.DurableWatermark = fs.latestCommittedRevision
+	cq.OnSuccess = fs.onCommitQueueSuccess
+	cq.OnCleanup = fs.onCommitQueueCleanup
+	fs.commitQueue = cq
+	defer cq.DrainAll()
+
+	fs.recordCommittedRevision(filePath, 7)
+	var lookupOut gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "recreate.txt", &lookupOut)
+	if st != gofuse.ENOENT {
+		t.Fatalf("Lookup status = %v, want ENOENT", st)
+	}
+	if got := fs.latestCommittedRevision(filePath); got != 0 {
+		t.Fatalf("committed revision after remote ENOENT = %d, want 0", got)
+	}
+	if !fs.hasNegativePathCache(filePath) {
+		t.Fatal("remote ENOENT did not seed negative lookup cache")
+	}
+
+	if err := shadow.WriteFull(filePath, newData, 0); err != nil {
+		t.Fatal(err)
+	}
+	pendingGen, err := pending.PutWithBaseRev(filePath, int64(len(newData)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ino := fs.inodes.Lookup(filePath, false, int64(len(newData)), time.Now())
+	entry := &CommitEntry{
+		Path:            filePath,
+		Inode:           ino,
+		BaseRev:         0,
+		Size:            int64(len(newData)),
+		Kind:            PendingNew,
+		PendingIndexGen: pendingGen,
+	}
+	fs.bindCommitEntryToPath(entry, filePath, 0)
+	if entry.DurableWatermarkRev != 0 {
+		t.Fatalf("recreate entry durable watermark = %d, want 0 after remote ENOENT", entry.DurableWatermarkRev)
+	}
+	if err := cq.CommitNow(context.Background(), entry); err != nil {
+		t.Fatalf("PendingNew recreate commit: %v", err)
+	}
+
+	mu.Lock()
+	gotExpected := append([]string(nil), putExpected...)
+	gotBodies := append([][]byte(nil), putBodies...)
+	mu.Unlock()
+	if len(gotExpected) != 1 || gotExpected[0] != "0" {
+		t.Fatalf("PUT expected revisions = %v, want [0]", gotExpected)
+	}
+	if len(gotBodies) != 1 || !bytes.Equal(gotBodies[0], newData) {
+		t.Fatalf("PUT bodies = %q, want %q", gotBodies, newData)
+	}
+	if got := fs.latestCommittedRevision(filePath); got != 8 {
+		t.Fatalf("committed revision after recreate = %d, want 8", got)
+	}
+
+	// The new-incarnation fix must not relax the old-payload fence: once the
+	// recreate is durable at rev 8, rev-0 payload cannot be paired with a newer
+	// BaseRev and overwrite it as another revision.
+	if err := shadow.WriteFull(filePath, staleData, 0); err != nil {
+		t.Fatal(err)
+	}
+	stalePendingGen, err := pending.PutWithBaseRev(filePath, int64(len(staleData)), PendingOverwrite, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	staleEntry := &CommitEntry{
+		Path:            filePath,
+		Inode:           ino,
+		BaseRev:         8,
+		Size:            int64(len(staleData)),
+		Kind:            PendingOverwrite,
+		PendingIndexGen: stalePendingGen,
+	}
+	fs.bindCommitEntryToPath(staleEntry, filePath, 0)
+	if staleEntry.DurableWatermarkRev != 8 {
+		t.Fatalf("stale entry durable watermark = %d, want 8", staleEntry.DurableWatermarkRev)
+	}
+	if err := cq.CommitNow(context.Background(), staleEntry); !errors.Is(err, errCommitPayloadStale) {
+		t.Fatalf("stale payload commit error = %v, want errCommitPayloadStale", err)
+	}
+	mu.Lock()
+	gotPutCount := len(putExpected)
+	mu.Unlock()
+	if gotPutCount != 1 {
+		t.Fatalf("PUT calls after stale payload = %d, want 1", gotPutCount)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -20100,12 +20100,12 @@ func TestRenamePendingNewCommitSyncCommitsGitLooseObjectFinalPath(t *testing.T) 
 	oldIno := fs.inodes.Lookup(oldP, false, int64(len(data)), time.Now())
 	dirIno := fs.inodes.Lookup("/repo/.git/objects/70", true, 0, time.Now())
 
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:  oldP,
 		Inode: oldIno,
 		Size:  int64(len(data)),
 		Kind:  PendingNew,
-	}); err != nil {
+	})); err != nil {
 		t.Fatalf("enqueue old temp upload: %v", err)
 	}
 	select {
@@ -20352,12 +20352,12 @@ func TestRenamePendingNewCommitFallsBackWhenFinalTargetExists(t *testing.T) {
 	dirIno := fs.inodes.Lookup("/repo/.git", true, 0, time.Now())
 	fs.inodes.Lookup(newP, false, 36, time.Now())
 
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:  oldP,
 		Inode: oldIno,
 		Size:  int64(len(data)),
 		Kind:  PendingNew,
-	}); err != nil {
+	})); err != nil {
 		t.Fatalf("enqueue old temp upload: %v", err)
 	}
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -6055,9 +6055,25 @@ func TestLookupStatNotFoundSeedsShortNegativeNamespaceCache(t *testing.T) {
 }
 
 func TestLookupRemoteNotFoundClearsCommittedRevisionForPendingNewRecreate(t *testing.T) {
-	const filePath = "/recreate.txt"
+	for _, tc := range []struct {
+		name              string
+		filePath          string
+		wantNegativeCache bool
+	}{
+		{name: "regular-file", filePath: "/recreate.txt", wantNegativeCache: true},
+		{name: "lock-file", filePath: "/config.lock", wantNegativeCache: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			testRemoteNotFoundClearsCommittedRevisionForPendingNewRecreate(t, tc.filePath, tc.wantNegativeCache)
+		})
+	}
+}
+
+func testRemoteNotFoundClearsCommittedRevisionForPendingNewRecreate(t *testing.T, filePath string, wantNegativeCache bool) {
+	t.Helper()
 	newData := []byte("new incarnation")
 	staleData := []byte("old payload")
+	lookupName := path.Base(filePath)
 
 	var (
 		mu          sync.Mutex
@@ -6075,7 +6091,8 @@ func TestLookupRemoteNotFoundClearsCommittedRevisionForPendingNewRecreate(t *tes
 			}
 			// Simulate another client deleting a file this mount previously knew
 			// at rev 7. Lookup has now authoritatively observed a new empty
-			// incarnation slot for this path.
+			// incarnation slot for this path. Lock files must clear the watermark
+			// too even though they intentionally skip negative dir-cache entries.
 			http.Error(w, "not found", http.StatusNotFound)
 		case http.MethodPut:
 			if r.URL.Path != "/v1/fs"+filePath {
@@ -6133,15 +6150,15 @@ func TestLookupRemoteNotFoundClearsCommittedRevisionForPendingNewRecreate(t *tes
 
 	fs.recordCommittedRevision(filePath, 7)
 	var lookupOut gofuse.EntryOut
-	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, "recreate.txt", &lookupOut)
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, lookupName, &lookupOut)
 	if st != gofuse.ENOENT {
 		t.Fatalf("Lookup status = %v, want ENOENT", st)
 	}
 	if got := fs.latestCommittedRevision(filePath); got != 0 {
 		t.Fatalf("committed revision after remote ENOENT = %d, want 0", got)
 	}
-	if !fs.hasNegativePathCache(filePath) {
-		t.Fatal("remote ENOENT did not seed negative lookup cache")
+	if got := fs.hasNegativePathCache(filePath); got != wantNegativeCache {
+		t.Fatalf("negative cache after remote ENOENT = %v, want %v", got, wantNegativeCache)
 	}
 
 	if err := shadow.WriteFull(filePath, newData, 0); err != nil {
@@ -6215,6 +6232,44 @@ func TestLookupRemoteNotFoundClearsCommittedRevisionForPendingNewRecreate(t *tes
 	}
 }
 
+func TestLookupRemoteDirectoryNotFoundClearsCommittedRevisionPrefix(t *testing.T) {
+	const dirPath = "/gone-dir"
+	var rec testErrorRecorder
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodHead {
+			rec.Recordf("method = %s, want HEAD", r.Method)
+			http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+			return
+		}
+		if r.URL.Path != "/v1/fs"+dirPath {
+			rec.Recordf("HEAD path = %s, want /v1/fs%s", r.URL.Path, dirPath)
+			http.Error(w, "bad path", http.StatusBadRequest)
+			return
+		}
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	defer ts.Close()
+	defer rec.Check(t)
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.recordCommittedRevision(dirPath, 7)
+	fs.recordCommittedRevision(dirPath+"/file.txt", 8)
+
+	var out gofuse.EntryOut
+	st := fs.Lookup(nil, &gofuse.InHeader{NodeId: 1}, path.Base(dirPath), &out)
+	if st != gofuse.ENOENT {
+		t.Fatalf("Lookup status = %v, want ENOENT", st)
+	}
+	if got := fs.latestCommittedRevision(dirPath); got != 0 {
+		t.Fatalf("directory committed revision after remote ENOENT = %d, want 0", got)
+	}
+	if got := fs.latestCommittedRevision(dirPath + "/file.txt"); got != 0 {
+		t.Fatalf("child committed revision after remote directory ENOENT = %d, want 0", got)
+	}
+}
+
 func TestLookupLockFileStatNotFoundDoesNotSeedNamespaceNegative(t *testing.T) {
 	var headCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -6229,6 +6284,7 @@ func TestLookupLockFileStatNotFoundDoesNotSeedNamespaceNegative(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
 	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.recordCommittedRevision("/config.lock", 7)
 
 	for range 2 {
 		var out gofuse.EntryOut
@@ -6239,6 +6295,9 @@ func TestLookupLockFileStatNotFoundDoesNotSeedNamespaceNegative(t *testing.T) {
 	}
 	if got := headCalls.Load(); got != 2 {
 		t.Fatalf("HEAD calls = %d, want 2", got)
+	}
+	if got := fs.latestCommittedRevision("/config.lock"); got != 0 {
+		t.Fatalf("lock committed revision after remote ENOENT = %d, want 0", got)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -14468,6 +14468,9 @@ func TestStageShadowReadyNonSpillRewritesShadowWithDirtyBuffer(t *testing.T) {
 	if err := fs.stageShadowForQueuedCommitLocked(fh, true); err != nil {
 		t.Fatal(err)
 	}
+	if fh.ShadowStageGen == 0 {
+		t.Fatal("staged shadow rewrite lost shadow staging generation")
+	}
 	defer fs.releaseHandleRemoteCommitPathLocked(fh)
 
 	got, err := shadow.ReadAll(path)
@@ -14526,6 +14529,9 @@ func TestOpenTruncateResetShadowStagesDirtyBuffer(t *testing.T) {
 	if !fh.ShadowReady {
 		t.Fatal("truncate-open did not reset shadow")
 	}
+	if fh.ShadowStageGen == 0 {
+		t.Fatal("truncate-open reset shadow did not record staging generation")
+	}
 	if fh.ShadowSpill {
 		t.Fatal("truncate-open shadow must stay dirty-buffer backed, not ShadowSpill")
 	}
@@ -14540,6 +14546,9 @@ func TestOpenTruncateResetShadowStagesDirtyBuffer(t *testing.T) {
 	}
 	if err := fs.stageShadowForQueuedCommitLocked(fh, true); err != nil {
 		t.Fatal(err)
+	}
+	if fh.ShadowStageGen == 0 {
+		t.Fatal("staged truncate-open rewrite lost shadow staging generation")
 	}
 	defer fs.releaseHandleRemoteCommitPathLocked(fh)
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -3268,7 +3268,7 @@ func TestFlushNewLargeWriteStreamCarriesCreateIfAbsentRevision(t *testing.T) {
 	}
 }
 
-func TestFlushSmallNewFileRefreshesSiblingHandleRevision(t *testing.T) {
+func TestFlushSmallNewSQLiteJournalDirtySiblingKeepsOriginalBaseRev(t *testing.T) {
 	const filePath = "/sqlite/workload.db-journal"
 
 	var (
@@ -3360,14 +3360,14 @@ func TestFlushSmallNewFileRefreshesSiblingHandleRevision(t *testing.T) {
 		t.Fatalf("second handle BaseRev before flush = %d, want 0", fh2.BaseRev)
 	}
 
-	if st := fs.Flush(nil, &gofuse.FlushIn{InHeader: gofuse.InHeader{NodeId: ino}, Fh: fh2ID}); st != gofuse.OK {
-		t.Fatalf("second Flush status = %v, want OK", st)
+	if st := fs.Flush(nil, &gofuse.FlushIn{InHeader: gofuse.InHeader{NodeId: ino}, Fh: fh2ID}); st == gofuse.OK {
+		t.Fatal("second Flush status = OK, want CAS conflict for stale dirty journal payload")
 	}
-	if fh2.IsNew {
-		t.Fatal("second handle should no longer be create-if-absent after its remote-sync flush")
+	if !fh2.IsNew {
+		t.Fatal("second dirty sibling handle adopted committed revision after failed stale flush")
 	}
-	if fh2.BaseRev != 2 {
-		t.Fatalf("second handle BaseRev after flush = %d, want 2", fh2.BaseRev)
+	if fh2.BaseRev != 0 {
+		t.Fatalf("second handle BaseRev after failed flush = %d, want 0", fh2.BaseRev)
 	}
 
 	mu.Lock()
@@ -3375,14 +3375,14 @@ func TestFlushSmallNewFileRefreshesSiblingHandleRevision(t *testing.T) {
 	if serverErr != nil {
 		t.Fatal(serverErr)
 	}
-	if !reflect.DeepEqual(expected, []int64{0, 1}) {
-		t.Fatalf("expected revisions = %v, want [0 1]", expected)
+	if !reflect.DeepEqual(expected, []int64{0, 0}) {
+		t.Fatalf("expected revisions = %v, want [0 0]", expected)
 	}
-	if revision != 2 {
-		t.Fatalf("server revision = %d, want 2", revision)
+	if revision != 1 {
+		t.Fatalf("server revision = %d, want 1", revision)
 	}
-	if string(content) != "second" {
-		t.Fatalf("server content = %q, want second", content)
+	if string(content) != "first" {
+		t.Fatalf("server content = %q, want first", content)
 	}
 }
 
@@ -14641,7 +14641,7 @@ func TestFlushHandle_UsesCommittedRevisionWithoutPostFlushStat(t *testing.T) {
 	}
 }
 
-func TestFlushHandle_AdoptsSameMountCommittedRevision(t *testing.T) {
+func TestFlushHandle_RejectsStaleSQLiteJournalDirtyPayloadAfterSameMountCommit(t *testing.T) {
 	var gotExpected string
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
@@ -14680,35 +14680,66 @@ func TestFlushHandle_AdoptsSameMountCommittedRevision(t *testing.T) {
 	fh.Lock()
 	st := fs.flushHandle(context.Background(), fh)
 	fh.Unlock()
-	if st != gofuse.OK {
-		t.Fatalf("flushHandle status = %v, want OK", st)
+	if st == gofuse.OK {
+		t.Fatal("flushHandle status = OK, want CAS conflict for stale dirty journal payload")
 	}
-	if gotExpected != "8" {
-		t.Fatalf("X-Dat9-Expected-Revision = %q, want 8", gotExpected)
+	if gotExpected != "7" {
+		t.Fatalf("X-Dat9-Expected-Revision = %q, want 7", gotExpected)
 	}
-	if fh.BaseRev != 9 {
-		t.Fatalf("fh.BaseRev = %d, want 9", fh.BaseRev)
+	if fh.BaseRev != 7 {
+		t.Fatalf("fh.BaseRev = %d, want 7", fh.BaseRev)
 	}
 }
 
-func TestFlushHandle_RefreshesStartedStreamerRevision(t *testing.T) {
+func TestFlushHandle_StartedSQLiteJournalStreamerKeepsStaleBaseRev(t *testing.T) {
 	data := bytes.Repeat([]byte("x"), s3client.PartSize+32)
-	expectedRevision := int64(8)
-	rec := newMultipartUploadRecorder(t, "/stream.db-wal", int64(len(data)), &expectedRevision)
+	var gotExpected atomic.Int64
+	gotExpected.Store(-999)
+	var initiateCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.Path != "/v2/uploads/initiate" {
+			http.NotFound(w, r)
+			return
+		}
+		initiateCalls.Add(1)
+		var req struct {
+			Path             string `json:"path"`
+			TotalSize        int64  `json:"total_size"`
+			ExpectedRevision *int64 `json:"expected_revision"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("decode initiate request: %v", err)
+		}
+		if req.Path != "/stream.db-wal" {
+			t.Fatalf("initiate path = %q, want /stream.db-wal", req.Path)
+		}
+		if req.TotalSize != int64(len(data)) {
+			t.Fatalf("initiate total size = %d, want %d", req.TotalSize, len(data))
+		}
+		if req.ExpectedRevision != nil {
+			gotExpected.Store(*req.ExpectedRevision)
+		}
+		if req.ExpectedRevision == nil || *req.ExpectedRevision != 8 {
+			http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+			return
+		}
+		t.Fatal("stale SQLite journal streamer unexpectedly adopted rev8")
+	}))
+	defer ts.Close()
 
 	opts := &MountOptions{}
 	opts.setDefaults()
-	fs := NewDat9FS(rec.client(), opts)
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
 	ino := fs.inodes.Lookup("/stream.db-wal", false, int64(len(data)), time.Now())
 	fs.inodes.UpdateRevision(ino, 7)
-	fs.recordCommittedRevision("/stream.db-wal", expectedRevision)
+	fs.recordCommittedRevision("/stream.db-wal", 8)
 
 	fh := &FileHandle{
 		Ino:      ino,
 		Path:     "/stream.db-wal",
 		Dirty:    NewWriteBuffer("/stream.db-wal", maxPreloadSize, 0),
 		BaseRev:  7,
-		Streamer: NewStreamUploader(rec.client(), "/stream.db-wal", 7),
+		Streamer: NewStreamUploader(newTestClient(ts.URL), "/stream.db-wal", 7),
 	}
 	if _, err := fh.Dirty.Write(0, data); err != nil {
 		t.Fatal(err)
@@ -14721,14 +14752,17 @@ func TestFlushHandle_RefreshesStartedStreamerRevision(t *testing.T) {
 	fh.Lock()
 	st := fs.flushHandle(context.Background(), fh)
 	fh.Unlock()
-	if st != gofuse.OK {
-		t.Fatalf("flushHandle status = %v, want OK", st)
+	if st == gofuse.OK {
+		t.Fatal("flushHandle status = OK, want CAS conflict for stale SQLite journal streamer payload")
 	}
-	if got := rec.initiateCalls.Load(); got != 1 {
+	if got := initiateCalls.Load(); got != 1 {
 		t.Fatalf("initiate calls = %d, want 1", got)
 	}
-	if fh.BaseRev != expectedRevision+1 {
-		t.Fatalf("fh.BaseRev = %d, want %d", fh.BaseRev, expectedRevision+1)
+	if got := gotExpected.Load(); got != 7 {
+		t.Fatalf("initiate expected revision = %d, want 7", got)
+	}
+	if fh.BaseRev != 7 {
+		t.Fatalf("fh.BaseRev = %d, want 7", fh.BaseRev)
 	}
 }
 
@@ -14933,13 +14967,15 @@ func TestAdoptPathTruncateZeroResetsStartedStreamerBeforeFlush(t *testing.T) {
 	}
 }
 
-func TestFlushHandle_SerializesSamePathRemoteCommits(t *testing.T) {
+func TestFlushHandle_SerializesSamePathSQLiteJournalCommitsWithoutAdoptingStalePayload(t *testing.T) {
 	var (
 		mu         sync.Mutex
 		revision   int64 = 7
 		handlerErr error
 		putCalls   atomic.Int32
 		inFlight   atomic.Int32
+		okFlushes  atomic.Int32
+		badFlushes atomic.Int32
 		gotHeaders []string
 	)
 	recordHandlerErr := func(err error) {
@@ -15004,9 +15040,10 @@ func TestFlushHandle_SerializesSamePathRemoteCommits(t *testing.T) {
 			fh.Lock()
 			st := fs.flushHandle(context.Background(), fh)
 			fh.Unlock()
-			if st != gofuse.OK {
-				errCh <- fmt.Errorf("flushHandle status = %v, want OK", st)
-				return
+			if st == gofuse.OK {
+				okFlushes.Add(1)
+			} else {
+				badFlushes.Add(1)
 			}
 			errCh <- nil
 		}(fh)
@@ -15020,6 +15057,12 @@ func TestFlushHandle_SerializesSamePathRemoteCommits(t *testing.T) {
 	if got := putCalls.Load(); got != 2 {
 		t.Fatalf("PUT calls = %d, want 2", got)
 	}
+	if got := okFlushes.Load(); got != 1 {
+		t.Fatalf("successful flushes = %d, want 1", got)
+	}
+	if got := badFlushes.Load(); got != 1 {
+		t.Fatalf("failed stale flushes = %d, want 1", got)
+	}
 	mu.Lock()
 	err := handlerErr
 	headers := append([]string(nil), gotHeaders...)
@@ -15028,14 +15071,14 @@ func TestFlushHandle_SerializesSamePathRemoteCommits(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(headers) != 2 || headers[0] != "7" || headers[1] != "8" {
-		t.Fatalf("expected revision headers = %v, want [7 8]", headers)
+	if len(headers) != 2 || headers[0] != "7" || headers[1] != "7" {
+		t.Fatalf("expected revision headers = %v, want [7 7]", headers)
 	}
-	if finalRevision != 9 {
-		t.Fatalf("server revision = %d, want 9", finalRevision)
+	if finalRevision != 8 {
+		t.Fatalf("server revision = %d, want 8", finalRevision)
 	}
-	if got := fs.latestCommittedRevision("/wal.db-wal"); got != 9 {
-		t.Fatalf("latest committed revision = %d, want 9", got)
+	if got := fs.latestCommittedRevision("/wal.db-wal"); got != 8 {
+		t.Fatalf("latest committed revision = %d, want 8", got)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -8083,7 +8083,7 @@ func TestOpenWritableSQLiteUsesDirectIO(t *testing.T) {
 	}
 }
 
-func TestOpenReadOnlySyncDurabilityUsesDirectIO(t *testing.T) {
+func TestOpenReadOnlySyncDurabilityKeepsCacheWithoutBypassMarker(t *testing.T) {
 	for _, policy := range []WritePolicy{WritePolicyCloseSync, WritePolicyWriteSync} {
 		t.Run(string(policy), func(t *testing.T) {
 			opts := &MountOptions{}
@@ -8100,11 +8100,151 @@ func TestOpenReadOnlySyncDurabilityUsesDirectIO(t *testing.T) {
 			if st != gofuse.OK {
 				t.Fatalf("Open status = %v, want OK", st)
 			}
-			if out.OpenFlags != gofuse.FOPEN_DIRECT_IO {
-				t.Fatalf("open flags = %d, want FOPEN_DIRECT_IO for %s close-to-open coherence", out.OpenFlags, policy)
+			if out.OpenFlags != gofuse.FOPEN_KEEP_CACHE {
+				t.Fatalf("open flags = %d, want FOPEN_KEEP_CACHE for clean %s reader", out.OpenFlags, policy)
 			}
 		})
 	}
+}
+
+func TestOpenReadOnlySyncDurabilityBypassMarkerUsesDirectIO(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.WritePolicy = WritePolicyCloseSync
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+
+	markedIno := fs.inodes.Lookup("/sync-visible.txt", false, 17, time.Now())
+	fs.inodes.UpdateRevision(markedIno, 7)
+	otherIno := fs.inodes.Lookup("/other.txt", false, 11, time.Now())
+	fs.inodes.UpdateRevision(otherIno, 3)
+
+	fs.armKernelCacheBypass(markedIno, "/sync-visible.txt", 7, 17, "test")
+
+	var markedOut gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: markedIno},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &markedOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open marked status = %v, want OK", st)
+	}
+	if markedOut.OpenFlags != gofuse.FOPEN_DIRECT_IO {
+		t.Fatalf("marked open flags = %d, want FOPEN_DIRECT_IO", markedOut.OpenFlags)
+	}
+
+	var otherOut gofuse.OpenOut
+	st = fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: otherIno},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &otherOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open other status = %v, want OK", st)
+	}
+	if otherOut.OpenFlags != gofuse.FOPEN_KEEP_CACHE {
+		t.Fatalf("other open flags = %d, want FOPEN_KEEP_CACHE", otherOut.OpenFlags)
+	}
+}
+
+func TestKernelCacheBypassMarkerIsInodeScopedAcrossRecreate(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.WritePolicy = WritePolicyCloseSync
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+
+	oldIno := fs.inodes.Lookup("/recreate.txt", false, 0, time.Now())
+	fs.armKernelCacheBypass(oldIno, "/recreate.txt", 1, 0, "test")
+	fs.inodes.Remove("/recreate.txt")
+
+	newIno := fs.inodes.Lookup("/recreate.txt", false, 19, time.Now())
+	if newIno == oldIno {
+		t.Fatalf("recreated inode = %d, want a different inode", newIno)
+	}
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: newIno},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open recreated status = %v, want OK", st)
+	}
+	if out.OpenFlags != gofuse.FOPEN_KEEP_CACHE {
+		t.Fatalf("recreated open flags = %d, want FOPEN_KEEP_CACHE", out.OpenFlags)
+	}
+}
+
+func TestKernelCacheBypassMarkerFollowsRenamedInode(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.WritePolicy = WritePolicyCloseSync
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+
+	ino := fs.inodes.Lookup("/old.txt", false, 5, time.Now())
+	fs.armKernelCacheBypass(ino, "/old.txt", 2, 5, "test")
+	fs.inodes.Rename("/old.txt", "/new.txt")
+
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open renamed status = %v, want OK", st)
+	}
+	if out.OpenFlags != gofuse.FOPEN_DIRECT_IO {
+		t.Fatalf("renamed open flags = %d, want FOPEN_DIRECT_IO for same inode marker", out.OpenFlags)
+	}
+}
+
+func TestSyncCommitNotifyFailureLeavesPerInodeBypass(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.WritePolicy = WritePolicyCloseSync
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+
+	ino := fs.inodes.Lookup("/notify-fallback.txt", false, 21, time.Now())
+	fs.inodes.UpdateRevision(ino, 9)
+	fs.finishSyncCommitKernelCacheBoundary(ino, "/notify-fallback.txt", 9, 21)
+
+	if !fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/notify-fallback.txt"}) {
+		t.Fatal("notify failure did not leave per-inode bypass marker active")
+	}
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	if out.OpenFlags != gofuse.FOPEN_DIRECT_IO {
+		t.Fatalf("open flags = %d, want FOPEN_DIRECT_IO while notify fallback is active", out.OpenFlags)
+	}
+}
+
+func TestKernelCacheBypassMarkerExpiresAndClearsByGeneration(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.WritePolicy = WritePolicyCloseSync
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+
+	ino := fs.inodes.Lookup("/short-window.txt", false, 8, time.Now())
+	oldGen := fs.armKernelCacheBypass(ino, "/short-window.txt", 1, 8, "old")
+	newGen := fs.armKernelCacheBypass(ino, "/short-window.txt", 2, 8, "new")
+	fs.clearKernelCacheBypassGeneration(ino, oldGen)
+	if !fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/short-window.txt"}) {
+		t.Fatal("clearing an older generation removed the active marker")
+	}
+
+	fs.kernelCacheBypassMu.Lock()
+	marker := fs.kernelCacheBypass[ino]
+	marker.expiresAt = time.Now().Add(-time.Second)
+	fs.kernelCacheBypass[ino] = marker
+	fs.kernelCacheBypassMu.Unlock()
+
+	if fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/short-window.txt"}) {
+		t.Fatal("expired marker stayed active")
+	}
+	fs.clearKernelCacheBypassGeneration(ino, newGen)
 }
 
 func TestOpenReadOnlyCacheableFileSkipsPrefetcher(t *testing.T) {
@@ -25874,6 +26014,9 @@ func TestSetAttr_NoKernelNotify(t *testing.T) {
 	after := fs.notifyCount.Load()
 	if delta := after - before; delta != 0 {
 		t.Fatalf("SetAttr produced %d kernel notify calls, want 0", delta)
+	}
+	if !fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/trunc.txt"}) {
+		t.Fatal("SetAttr size change did not arm per-inode cache bypass marker")
 	}
 }
 

--- a/pkg/fuse/mount.go
+++ b/pkg/fuse/mount.go
@@ -530,6 +530,7 @@ func Mount(opts *MountOptions) (err error) {
 				cq.OnSuccess = dat9fs.onCommitQueueSuccess
 				cq.OnCleanup = dat9fs.onCommitQueueCleanup
 				cq.PathLock = dat9fs.lockRemoteCommitPath
+				cq.DurableWatermark = dat9fs.latestCommittedRevision
 				if opts.WritePolicy == WritePolicyWriteBack && opts.WriteBackBatchWindow > 0 {
 					cq.ConfigureBatchWrite(opts.WriteBackBatchWindow, opts.WriteBackBatchMaxFiles, opts.WriteBackBatchMaxBytes)
 				}

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -564,6 +564,50 @@ func (idx *PendingIndex) MarkConflict(remotePath string) error {
 	return nil
 }
 
+// MarkConflictIfGeneration is MarkConflict scoped to a specific pending-entry
+// generation. It returns false without touching disk or memory when a newer
+// same-path Put has already replaced the entry, so a stale commit failure does
+// not poison fresher pending data.
+func (idx *PendingIndex) MarkConflictIfGeneration(remotePath string, expectedGen uint64) (bool, error) {
+	if expectedGen == 0 {
+		return true, idx.MarkConflict(remotePath)
+	}
+	pl := idx.acquirePathLock(remotePath)
+	defer idx.releasePathLock(remotePath, pl)
+
+	idx.mu.RLock()
+	meta, ok := idx.items[remotePath]
+	if !ok {
+		idx.mu.RUnlock()
+		return true, nil
+	}
+	if meta.Generation != expectedGen {
+		idx.mu.RUnlock()
+		return false, nil
+	}
+	conflicted := *meta
+	conflicted.Kind = PendingConflict
+	idx.mu.RUnlock()
+
+	metaBytes, err := json.Marshal(&conflicted)
+	if err != nil {
+		return false, fmt.Errorf("pending index marshal conflict: %w", err)
+	}
+	metaPath := filepath.Join(idx.dir, hashPath(remotePath)+".meta")
+	if err := atomicWrite(metaPath, metaBytes); err != nil {
+		return false, fmt.Errorf("pending index write conflict: %w", err)
+	}
+
+	idx.mu.Lock()
+	if m, exists := idx.items[remotePath]; exists && m.Generation == expectedGen {
+		m.Kind = PendingConflict
+		idx.mu.Unlock()
+		return true, nil
+	}
+	idx.mu.Unlock()
+	return false, nil
+}
+
 // Count returns the number of pending entries.
 func (idx *PendingIndex) Count() int {
 	idx.mu.RLock()

--- a/pkg/fuse/remote_upload.go
+++ b/pkg/fuse/remote_upload.go
@@ -28,27 +28,32 @@ func uploadBufferedRemoteFileWithRevision(ctx context.Context, c *client.Client,
 // the entire file into memory. localPath identifies the shadow entry;
 // remotePath is the API destination (may differ when using RemoteRoot).
 func uploadFromShadowRemoteWithRevision(ctx context.Context, c *client.Client, shadows *ShadowStore, localPath, remotePath string, expectedRevision int64) (int64, error) {
+	return uploadFromShadowRemoteWithRevisionAndGeneration(ctx, c, shadows, localPath, remotePath, expectedRevision, 0)
+}
+
+func uploadFromShadowRemoteWithRevisionAndGeneration(ctx context.Context, c *client.Client, shadows *ShadowStore, localPath, remotePath string, expectedRevision int64, expectedGen uint64) (int64, error) {
 	// Sync shadow to disk before uploading to ensure all data is durable.
-	if err := shadows.Sync(localPath); err != nil {
+	if err := shadows.SyncIfGeneration(localPath, expectedGen); err != nil {
 		return 0, err
 	}
-	size := shadows.Size(localPath)
-	if size < 0 {
-		return 0, io.ErrUnexpectedEOF
+	fd, size, release, err := shadows.OpenIfGeneration(localPath, expectedGen)
+	if err != nil {
+		return 0, err
 	}
+	defer release()
+	defer func() { _ = fd.Close() }()
 	if size == 0 {
 		return c.WriteCtxConditionalWithRevision(ctx, remotePath, nil, expectedRevision)
 	}
 	threshold := c.CachedSmallFileThreshold()
 	if threshold > 0 && size < threshold {
-		data, err := shadows.ReadAll(localPath)
-		if err != nil {
+		data := make([]byte, size)
+		if _, err := fd.ReadAt(data, 0); err != nil {
 			return 0, err
 		}
 		return c.WriteCtxConditionalWithRevision(ctx, remotePath, data, expectedRevision)
 	}
-	ra := &shadowReaderAt{store: shadows, path: localPath}
-	sr := io.NewSectionReader(ra, 0, size)
+	sr := io.NewSectionReader(fd, 0, size)
 	if err := c.WriteMultipartStreamConditional(ctx, remotePath, sr, size, nil, expectedRevision); err != nil {
 		return 0, err
 	}

--- a/pkg/fuse/remote_upload_test.go
+++ b/pkg/fuse/remote_upload_test.go
@@ -377,12 +377,12 @@ func TestCommitQueueLargeOverwriteUsesMultipartUpload(t *testing.T) {
 	}
 
 	cq := NewCommitQueue(rec.client(), shadow, pending, nil, 1, 8)
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:    remotePath,
 		BaseRev: expectedRevision,
 		Size:    int64(len(data)),
 		Kind:    PendingOverwrite,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()
@@ -496,12 +496,12 @@ func TestCommitQueueMapsRemoteRoot(t *testing.T) {
 	}
 
 	cq := NewCommitQueue(rec.client(), shadow, pending, nil, 1, 8, "/remote")
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:    localPath,
 		BaseRev: expectedRevision,
 		Size:    int64(len(data)),
 		Kind:    PendingOverwrite,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 	cq.DrainAll()

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -1305,6 +1305,54 @@ func (s *ShadowStore) ActiveGeneration(remotePath string) uint64 {
 	return s.writeGen[remotePath]
 }
 
+// EnsureActiveGeneration loads the active shadow for remotePath, including a
+// hash-keyed shadow recovered from disk, and returns a nonzero content
+// generation for it. Recovered shadows start without memory-only writeGen
+// state; CommitQueue must mint one before binding a recovered CommitEntry so
+// later uploads and cleanup remain generation-scoped instead of path-wide.
+func (s *ShadowStore) EnsureActiveGeneration(remotePath string, baseRev int64) uint64 {
+	if s == nil || remotePath == "" {
+		return 0
+	}
+	pl := s.acquirePathLock(remotePath)
+	defer s.releasePathLock(remotePath, pl)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	sf, ok := s.files[remotePath]
+	if !ok {
+		hashKey := "__hash:" + hashPath(remotePath)
+		if recovered, recoveredOK := s.files[hashKey]; recoveredOK {
+			sf = recovered
+			delete(s.files, hashKey)
+			s.files[remotePath] = sf
+		} else {
+			fd, err := os.OpenFile(s.shadowPath(remotePath), os.O_RDWR, 0o644)
+			if err != nil {
+				return 0
+			}
+			fi, err := fd.Stat()
+			if err != nil {
+				_ = fd.Close()
+				return 0
+			}
+			sf = &ShadowFile{fd: fd, size: fi.Size()}
+			s.files[remotePath] = sf
+		}
+	}
+	if sf == nil {
+		return 0
+	}
+	if baseRev != 0 {
+		sf.baseRev = baseRev
+	}
+	if gen := s.writeGen[remotePath]; gen != 0 {
+		return gen
+	}
+	return s.bumpWriteGenLocked(remotePath)
+}
+
 // bumpWriteGenLocked increments the content generation for remotePath. Called
 // under s.mu on every mutating write so ActiveGeneration reflects the latest
 // write. Returns the new generation.

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -902,6 +902,70 @@ func (s *ShadowStore) ReadAll(remotePath string) ([]byte, error) {
 	return os.ReadFile(sp)
 }
 
+// ReadAllIfGeneration reads the active shadow only if its current content
+// generation still matches expectedGen. Generation 0 preserves the historical
+// path-based fallback for recovered legacy entries that were created before
+// CommitEntry carried generation tokens.
+func (s *ShadowStore) ReadAllIfGeneration(remotePath string, expectedGen uint64) ([]byte, error) {
+	if expectedGen == 0 {
+		return s.ReadAll(remotePath)
+	}
+	if s == nil {
+		return nil, fmt.Errorf("nil shadow store")
+	}
+	pl := s.acquirePathLock(remotePath)
+	defer s.releasePathLock(remotePath, pl)
+
+	s.mu.RLock()
+	if s.writeGen[remotePath] != expectedGen {
+		s.mu.RUnlock()
+		return nil, fmt.Errorf("%w: shadow %s generation changed", errCommitPayloadStale, remotePath)
+	}
+	sf, ok := s.files[remotePath]
+	if !ok {
+		s.mu.RUnlock()
+		return nil, fmt.Errorf("%w: shadow %s generation not active", errCommitPayloadStale, remotePath)
+	}
+	data := make([]byte, sf.size)
+	_, err := sf.fd.ReadAt(data, 0)
+	s.mu.RUnlock()
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+// SyncIfGeneration fsyncs the active shadow only if its current content
+// generation still matches expectedGen. Generation 0 preserves the historical
+// path-based fallback for recovered legacy entries.
+func (s *ShadowStore) SyncIfGeneration(remotePath string, expectedGen uint64) error {
+	if s == nil {
+		return fmt.Errorf("nil shadow store")
+	}
+	if expectedGen == 0 {
+		return s.Sync(remotePath)
+	}
+	pl := s.acquirePathLock(remotePath)
+	defer s.releasePathLock(remotePath, pl)
+
+	s.mu.RLock()
+	if s.writeGen[remotePath] != expectedGen {
+		s.mu.RUnlock()
+		return fmt.Errorf("%w: shadow %s generation changed", errCommitPayloadStale, remotePath)
+	}
+	sf, ok := s.files[remotePath]
+	if !ok {
+		s.mu.RUnlock()
+		return fmt.Errorf("%w: shadow %s generation not active", errCommitPayloadStale, remotePath)
+	}
+	err := sf.fd.Sync()
+	s.mu.RUnlock()
+	if err != nil {
+		return fmt.Errorf("shadow sync: %w", err)
+	}
+	return nil
+}
+
 // Open opens the current shadow file for remotePath for streaming reads.
 // The caller owns the returned file descriptor.
 func (s *ShadowStore) Open(remotePath string) (*os.File, int64, error) {
@@ -930,6 +994,49 @@ func (s *ShadowStore) Open(remotePath string) (*os.File, int64, error) {
 		return nil, 0, fmt.Errorf("shadow stream stat: %w", err)
 	}
 	return fd, fi.Size(), nil
+}
+
+// OpenIfGeneration opens a streaming fd for the active shadow only if its
+// current content generation still matches expectedGen. The returned release
+// function must be called after the upload/streaming read is done. For a
+// nonzero generation it holds the path-local shadow lock for the caller, so the
+// opened fd cannot observe concurrent same-path shadow mutations while it is
+// being streamed to a remote commit.
+func (s *ShadowStore) OpenIfGeneration(remotePath string, expectedGen uint64) (*os.File, int64, func(), error) {
+	if expectedGen == 0 {
+		fd, size, err := s.Open(remotePath)
+		return fd, size, func() {}, err
+	}
+	if s == nil {
+		return nil, 0, func() {}, fmt.Errorf("nil shadow store")
+	}
+	pl := s.acquirePathLock(remotePath)
+	release := func() {
+		s.releasePathLock(remotePath, pl)
+	}
+
+	s.mu.RLock()
+	if s.writeGen[remotePath] != expectedGen {
+		s.mu.RUnlock()
+		release()
+		return nil, 0, func() {}, fmt.Errorf("%w: shadow %s generation changed", errCommitPayloadStale, remotePath)
+	}
+	sf, ok := s.files[remotePath]
+	if !ok {
+		s.mu.RUnlock()
+		release()
+		return nil, 0, func() {}, fmt.Errorf("%w: shadow %s generation not active", errCommitPayloadStale, remotePath)
+	}
+	size := sf.size
+	sp := s.shadowPath(remotePath)
+	s.mu.RUnlock()
+
+	fd, err := os.Open(sp)
+	if err != nil {
+		release()
+		return nil, 0, func() {}, fmt.Errorf("shadow open stream: %w", err)
+	}
+	return fd, size, release, nil
 }
 
 // Size returns the size of a shadow file, or -1 if not found.

--- a/pkg/fuse/shadow.go
+++ b/pkg/fuse/shadow.go
@@ -1344,11 +1344,11 @@ func (s *ShadowStore) EnsureActiveGeneration(remotePath string, baseRev int64) u
 	if sf == nil {
 		return 0
 	}
-	if baseRev != 0 {
-		sf.baseRev = baseRev
-	}
 	if gen := s.writeGen[remotePath]; gen != 0 {
 		return gen
+	}
+	if baseRev != 0 {
+		sf.baseRev = baseRev
 	}
 	return s.bumpWriteGenLocked(remotePath)
 }

--- a/pkg/fuse/shadow_test.go
+++ b/pkg/fuse/shadow_test.go
@@ -1421,6 +1421,46 @@ func TestShadowStoreRemoveIfGenerationRaceStaleVsNewerWrite(t *testing.T) {
 	}
 }
 
+func TestShadowStoreEnsureActiveGenerationKeepsExistingBaseRevision(t *testing.T) {
+	dir := t.TempDir()
+	ss, err := NewShadowStore(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ss.Close()
+
+	const path = "/base-rev.txt"
+	if err := ss.WriteFull(path, []byte("payload"), 7); err != nil {
+		t.Fatal(err)
+	}
+	gen := ss.ActiveGeneration(path)
+	if gen == 0 {
+		t.Fatal("expected nonzero active generation")
+	}
+	if got := ss.BaseRev(path); got != 7 {
+		t.Fatalf("initial base revision = %d, want 7", got)
+	}
+
+	if gotGen := ss.EnsureActiveGeneration(path, 9); gotGen != gen {
+		t.Fatalf("EnsureActiveGeneration returned gen %d, want existing gen %d", gotGen, gen)
+	}
+	if got := ss.BaseRev(path); got != 7 {
+		t.Fatalf("base revision after EnsureActiveGeneration = %d, want existing 7", got)
+	}
+
+	const recoveredPath = "/recovered-base-rev.txt"
+	if err := os.WriteFile(ss.shadowPath(recoveredPath), []byte("recovered"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	recoveredGen := ss.EnsureActiveGeneration(recoveredPath, 11)
+	if recoveredGen == 0 {
+		t.Fatal("expected recovered shadow to get an active generation")
+	}
+	if got := ss.BaseRev(recoveredPath); got != 11 {
+		t.Fatalf("recovered base revision = %d, want 11", got)
+	}
+}
+
 // TestShadowStoreRemoveIfGenerationWriteFullRaceConsistency races replacement
 // WriteFulls against a stale-generation removal and asserts that whenever an
 // active shadow generation exists, its disk file is present and readable.

--- a/pkg/fuse/stream_upload.go
+++ b/pkg/fuse/stream_upload.go
@@ -65,9 +65,11 @@ func (su *StreamUploader) Started() bool {
 }
 
 // RefreshExpectedRevision updates the conditional revision used for future
-// upload initiation while the remote upload has not started yet. SubmitPart
-// only buffers bytes locally for a later FinishStreaming call, so pending
-// buffered parts can still safely adopt a newer same-mount committed revision.
+// upload initiation while the remote upload has not started yet. Callers must
+// only use it after proving the buffered payload is compatible with the newer
+// revision; dirty SQLite sidecar payloads keep their original base so server
+// CAS can reject stale WAL/journal bytes instead of accepting old content as a
+// newer revision.
 func (su *StreamUploader) RefreshExpectedRevision(revision int64) bool {
 	if revision < 0 {
 		return false

--- a/pkg/fuse/writeback_generation_fence_test.go
+++ b/pkg/fuse/writeback_generation_fence_test.go
@@ -1421,3 +1421,148 @@ func TestShadowSpillSyncCleanupKeepsNewerGeneration(t *testing.T) {
 	}
 	handlerErrors.Check(t)
 }
+
+func TestRemoveHandleStagingWithoutGenerationPreservesQueueOwnedStaging(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+	writeBack, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.writeBack = writeBack
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	const path = "/queued.db"
+	payload := []byte("queue-owned generation")
+	writeBackGen, _, err := writeBack.PutWithBaseRevAndModeTimings(path, payload, int64(len(payload)), PendingOverwrite, 3, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(path, payload, 3); err != nil {
+		t.Fatal(err)
+	}
+	shadowGen := shadow.ActiveGeneration(path)
+	pendingGen, err := pending.PutWithBaseRev(path, int64(len(payload)), PendingOverwrite, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// This mirrors the queue-owned state after a CommitEntry has taken over and
+	// the producing handle's generation fields have been cleared. A later gen-0
+	// handle cleanup must not path-wide delete that queued payload.
+	fs.removeHandleStagingLocked(&FileHandle{Path: path})
+
+	wbMeta, ok := writeBack.GetMeta(path)
+	if !ok {
+		t.Fatal("queue-owned writeback entry was removed by gen-0 handle cleanup")
+	}
+	if wbMeta.Generation != writeBackGen {
+		t.Fatalf("writeback generation = %d, want %d", wbMeta.Generation, writeBackGen)
+	}
+	pendingMeta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("queue-owned pending entry was removed by gen-0 handle cleanup")
+	}
+	if pendingMeta.Generation != pendingGen {
+		t.Fatalf("pending generation = %d, want %d", pendingMeta.Generation, pendingGen)
+	}
+	data, err := shadow.ReadAll(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(payload) {
+		t.Fatalf("shadow data = %q, want queue-owned payload", data)
+	}
+	if got := shadow.ActiveGeneration(path); got != shadowGen {
+		t.Fatalf("shadow generation = %d, want %d", got, shadowGen)
+	}
+}
+
+func TestShadowSpillDirectPUTCleanupKeepsNewerGeneration(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	const path = "/small.db-wal"
+	oldPayload := []byte("old checkpoint A")
+	freshPayload := []byte("fresh checkpoint B")
+	if err := shadow.WriteFull(path, oldPayload, 2); err != nil {
+		t.Fatal(err)
+	}
+	oldShadowGen := shadow.ActiveGeneration(path)
+	oldPendingGen, err := pending.PutShadowSpill(path, int64(len(oldPayload)), PendingOverwrite, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Path:              path,
+		ShadowReady:       true,
+		ShadowSpill:       true,
+		ShadowCommitReady: true,
+		ShadowStageGen:    oldShadowGen,
+		PendingIndexGen:   oldPendingGen,
+	}
+
+	if err := shadow.WriteFull(path, freshPayload, 3); err != nil {
+		t.Fatal(err)
+	}
+	freshShadowGen := shadow.ActiveGeneration(path)
+	freshPendingGen, err := pending.PutShadowSpill(path, int64(len(freshPayload)), PendingOverwrite, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the direct-PUT ShadowSpill success tail after H1 uploaded gen 1
+	// but H2 staged gen 2 before H1's cleanup. The cache seed must not live-read
+	// gen 2 as if it were H1's uploaded payload, and cleanup must only target
+	// H1's captured generations.
+	if fs.seedReadCacheFromShadowGenerationLocked(path, int64(len(oldPayload)), 4, oldShadowGen) {
+		t.Fatal("stale direct-PUT success tail seeded read cache from newer shadow generation")
+	}
+	fs.markHandleRemoteCommittedLocked(fh, 4)
+	fs.removeShadowPendingStagingGenerationLocked(fh, path, oldShadowGen, oldPendingGen)
+
+	if cached, ok := fs.readCache.Get(path, 4); ok {
+		t.Fatalf("read cache contains %q for rev4; stale success tail must not cache a live newer generation", cached)
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("newer pending generation was removed by stale direct-PUT cleanup")
+	}
+	if meta.Generation != freshPendingGen {
+		t.Fatalf("pending generation = %d, want fresh generation %d", meta.Generation, freshPendingGen)
+	}
+	data, err := shadow.ReadAll(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(freshPayload) {
+		t.Fatalf("shadow data = %q, want fresh payload", data)
+	}
+	if got := shadow.ActiveGeneration(path); got != freshShadowGen {
+		t.Fatalf("shadow generation = %d, want fresh generation %d", got, freshShadowGen)
+	}
+}

--- a/pkg/fuse/writeback_generation_fence_test.go
+++ b/pkg/fuse/writeback_generation_fence_test.go
@@ -1,0 +1,847 @@
+package fuse
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
+)
+
+func sqliteCheckpointImages(t *testing.T) ([]byte, []byte) {
+	t.Helper()
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skipf("python3 not available for sqlite checkpoint fixture: %v", err)
+	}
+	dir := t.TempDir()
+	db := filepath.Join(dir, "app.db")
+	checkpointA := filepath.Join(dir, "checkpoint-a.db")
+	checkpointB := filepath.Join(dir, "checkpoint-b.db")
+	script := `
+import os, shutil, sqlite3, sys
+db, checkpoint_a, checkpoint_b = sys.argv[1:]
+for p in [db, db + "-wal", db + "-shm", db + "-journal", checkpoint_a, checkpoint_b]:
+    try:
+        os.remove(p)
+    except FileNotFoundError:
+        pass
+conn = sqlite3.connect(db)
+mode = conn.execute("PRAGMA journal_mode=WAL").fetchone()[0].lower()
+if mode != "wal":
+    raise RuntimeError(f"journal_mode={mode}")
+conn.execute("PRAGMA synchronous=FULL")
+conn.execute("PRAGMA wal_autocheckpoint=0")
+conn.execute("PRAGMA mmap_size=0")
+conn.execute("CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT)")
+for i in range(1, 6):
+    conn.execute("INSERT INTO t(v) VALUES (?)", (f"v{i}",))
+    conn.commit()
+busy, log, checkpointed = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+if busy != 0:
+    raise RuntimeError(f"checkpoint A busy: {(busy, log, checkpointed)}")
+if conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] != 5:
+    raise RuntimeError("checkpoint A row count mismatch")
+shutil.copyfile(db, checkpoint_a)
+for i in range(6, 13):
+    conn.execute("INSERT INTO t(v) VALUES (?)", (f"v{i}",))
+    conn.commit()
+busy, log, checkpointed = conn.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+if busy != 0:
+    raise RuntimeError(f"checkpoint B busy: {(busy, log, checkpointed)}")
+if conn.execute("PRAGMA integrity_check").fetchone()[0] != "ok":
+    raise RuntimeError("checkpoint B integrity_check failed")
+if conn.execute("SELECT COUNT(*) FROM t").fetchone()[0] != 12:
+    raise RuntimeError("checkpoint B row count mismatch")
+conn.close()
+shutil.copyfile(db, checkpoint_b)
+`
+	cmd := exec.Command(python, "-c", script, db, checkpointA, checkpointB)
+	cmd.Env = append(os.Environ(), "PYTHONDONTWRITEBYTECODE=1")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sqlite checkpoint fixture failed: %v\n%s", err, out)
+	}
+	a, err := os.ReadFile(checkpointA)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := os.ReadFile(checkpointB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return a, b
+}
+
+func sqliteRowCountFromImage(t *testing.T, image []byte) int {
+	t.Helper()
+	python, err := exec.LookPath("python3")
+	if err != nil {
+		t.Skipf("python3 not available for sqlite image validation: %v", err)
+	}
+	db := filepath.Join(t.TempDir(), "fresh.db")
+	if err := os.WriteFile(db, image, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	script := `
+import sqlite3, sys
+conn = sqlite3.connect(f"file:{sys.argv[1]}?mode=ro", uri=True)
+integrity = conn.execute("PRAGMA integrity_check").fetchone()[0]
+count = conn.execute("SELECT COUNT(*) FROM t").fetchone()[0]
+conn.close()
+print(integrity)
+print(count)
+`
+	out, err := exec.Command(python, "-c", script, db).CombinedOutput()
+	if err != nil {
+		t.Fatalf("sqlite image validation failed: %v\n%s", err, out)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) != 2 || lines[0] != "ok" {
+		t.Fatalf("sqlite image validation output = %q, want integrity ok + row count", out)
+	}
+	var rows int
+	if _, err := fmt.Sscanf(lines[1], "%d", &rows); err != nil {
+		t.Fatalf("parse row count %q: %v", lines[1], err)
+	}
+	return rows
+}
+
+type casFileServer struct {
+	t    *testing.T
+	path string
+
+	mu       sync.Mutex
+	revision int64
+	body     []byte
+	puts     []casFilePut
+}
+
+type casFilePut struct {
+	expected string
+	revision int64
+	body     []byte
+}
+
+func newCASFileServer(t *testing.T, path string, revision int64, body []byte) (*casFileServer, *httptest.Server) {
+	t.Helper()
+	s := &casFileServer{
+		t:        t,
+		path:     path,
+		revision: revision,
+		body:     append([]byte(nil), body...),
+	}
+	ts := httptest.NewServer(http.HandlerFunc(s.serveHTTP))
+	return s, ts
+}
+
+func (s *casFileServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/v1/fs"+s.path {
+		http.NotFound(w, r)
+		return
+	}
+	switch r.Method {
+	case http.MethodPut:
+		expected := r.Header.Get("X-Dat9-Expected-Revision")
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		wantExpected := fmt.Sprintf("%d", s.revision)
+		if expected != wantExpected {
+			http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+			return
+		}
+		s.revision++
+		s.body = append([]byte(nil), body...)
+		s.puts = append(s.puts, casFilePut{
+			expected: expected,
+			revision: s.revision,
+			body:     append([]byte(nil), body...),
+		})
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": s.revision})
+	case http.MethodHead:
+		s.mu.Lock()
+		revision := s.revision
+		size := len(s.body)
+		s.mu.Unlock()
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", size))
+		w.Header().Set("X-Dat9-IsDir", "false")
+		w.Header().Set("X-Dat9-Revision", fmt.Sprintf("%d", revision))
+		w.WriteHeader(http.StatusOK)
+	case http.MethodGet:
+		s.mu.Lock()
+		body := append([]byte(nil), s.body...)
+		s.mu.Unlock()
+		_, _ = w.Write(body)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *casFileServer) snapshot() (int64, []byte, []casFilePut) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	puts := make([]casFilePut, len(s.puts))
+	copy(puts, s.puts)
+	return s.revision, append([]byte(nil), s.body...), puts
+}
+
+func TestDirtySiblingKeepsOriginalBaseRevAfterCommittedRevisionAdvances(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*FileHandle)
+	}{
+		{
+			name: "dirty-buffer",
+		},
+		{
+			name: "writeback-snapshot",
+			configure: func(fh *FileHandle) {
+				fh.WriteBackSeq = fh.DirtySeq
+			},
+		},
+		{
+			name: "shadow-commit-ready",
+			configure: func(fh *FileHandle) {
+				fh.ShadowCommitReady = true
+				fh.ShadowCommitSeq = fh.DirtySeq
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient("http://localhost"), opts)
+
+			const filePath = "/workload.db"
+			ino := fs.inodes.Lookup(filePath, false, 8192, time.Now())
+			fs.inodes.UpdateRevision(ino, 2)
+
+			stale := &FileHandle{
+				Ino:      ino,
+				Path:     filePath,
+				Dirty:    fs.newWriteBuffer(filePath, maxPreloadSize, 0),
+				OrigSize: 8192,
+				BaseRev:  2,
+			}
+			if _, err := stale.Dirty.Write(0, []byte("checkpoint-A")); err != nil {
+				t.Fatal(err)
+			}
+			stale.DirtySeq = fs.markDirtySize(ino, stale.Dirty.Size())
+			if tc.configure != nil {
+				tc.configure(stale)
+			}
+			fs.openHandles.Add(stale)
+
+			fs.refreshCommittedRevisionForOpenHandles(filePath, 3, nil)
+
+			if stale.BaseRev != 2 {
+				t.Fatalf("dirty sibling BaseRev advanced to %d; want original 2 so stale content cannot be paired with rev3", stale.BaseRev)
+			}
+
+			stale.Lock()
+			got := fs.expectedRevisionForHandleLocked(stale)
+			stale.Unlock()
+			if got != 2 {
+				t.Fatalf("expected revision for dirty sibling = %d, want 2", got)
+			}
+		})
+	}
+}
+
+func TestCommitQueueRejectsPayloadOlderThanDurableWatermark(t *testing.T) {
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		putCalls.Add(1)
+		http.Error(w, "stale payload must not reach server", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const path = "/repro.db"
+	oldMain := []byte("sqlite-main: checkpoint A has 5 rows")
+	if err := shadow.WriteFull(path, oldMain, 2); err != nil {
+		t.Fatal(err)
+	}
+	shadowGen := shadow.ActiveGeneration(path)
+	pendingGen, err := pending.PutWithBaseRev(path, int64(len(oldMain)), PendingOverwrite, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(50000)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	entry := &CommitEntry{
+		Path:                  path,
+		BaseRev:               3,
+		PayloadBaseRev:        2,
+		PayloadBaseRevSet:     true,
+		Size:                  int64(len(oldMain)),
+		Kind:                  PendingOverwrite,
+		ShadowGen:             shadowGen,
+		PendingIndexGen:       pendingGen,
+		DurableWatermarkRev:   3,
+		DisableAutoResolveLWW: true,
+	}
+
+	err = cq.CommitNow(context.Background(), entry)
+	if !errors.Is(err, errCommitPayloadStale) {
+		t.Fatalf("CommitNow err = %v, want errCommitPayloadStale", err)
+	}
+	if got := putCalls.Load(); got != 0 {
+		t.Fatalf("server saw %d uploads; stale checkpoint-A payload must not be PUT after checkpoint-B watermark", got)
+	}
+	if data, err := shadow.ReadAll(path); err != nil || string(data) != string(oldMain) {
+		t.Fatalf("shadow changed after rejected stale payload: data=%q err=%v", data, err)
+	}
+}
+
+func TestSQLiteCheckpointABStaleHandleCannotOverwriteDurableMainDB(t *testing.T) {
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		putCalls.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		t.Fatalf("stale checkpoint-A payload reached server: expected_rev=%q body=%q", r.Header.Get("X-Dat9-Expected-Revision"), body)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.client.SetSmallFileThresholdForTests(50000)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	fs.commitQueue = NewCommitQueue(fs.client, shadow, pending, nil, 1, 8)
+
+	const path = "/app-v2-dev.db"
+	checkpointA := []byte("main.db checkpoint A: 5 rows")
+	ino := fs.inodes.Lookup(path, false, int64(len(checkpointA)), time.Now())
+	fs.inodes.UpdateRevision(ino, 2)
+	fs.recordCommittedRevision(path, 2)
+
+	stale := &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    fs.newWriteBuffer(path, maxPreloadSize, 0),
+		OrigSize: int64(len(checkpointA)),
+		BaseRev:  2,
+	}
+	if _, err := stale.Dirty.Write(0, checkpointA); err != nil {
+		t.Fatal(err)
+	}
+	stale.DirtySeq = fs.markDirtySize(ino, stale.Dirty.Size())
+	if err := fs.shadowStore.WriteFull(path, checkpointA, stale.BaseRev); err != nil {
+		t.Fatal(err)
+	}
+	stale.ShadowStageGen = fs.shadowStore.ActiveGeneration(path)
+	stale.PendingIndexGen, err = fs.pendingIndex.PutWithBaseRev(path, int64(len(checkpointA)), PendingOverwrite, stale.BaseRev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.openHandles.Add(stale)
+
+	// Checkpoint B has already reached the authoritative server as rev3.
+	// The stale handle must keep its rev2 payload base and be fenced before a
+	// close/release path can upload checkpoint A as a new rev4.
+	fs.recordCommittedRevision(path, 3)
+	fs.inodes.UpdateRevision(ino, 3)
+	fs.refreshCommittedRevisionForOpenHandles(path, 3, nil)
+	if stale.BaseRev != 2 {
+		t.Fatalf("stale main.db handle BaseRev = %d, want 2", stale.BaseRev)
+	}
+
+	stale.Lock()
+	expectedRev := fs.expectedRevisionForHandleLocked(stale)
+	entry := &CommitEntry{
+		Path:    path,
+		Inode:   ino,
+		BaseRev: expectedRev,
+		Size:    stale.Dirty.Size(),
+		Kind:    PendingOverwrite,
+	}
+	fs.bindCommitEntryToHandleLocked(entry, stale, stale.BaseRev)
+	stale.Unlock()
+
+	if err := fs.commitQueue.CommitNow(context.Background(), entry); !errors.Is(err, errCommitPayloadStale) {
+		t.Fatalf("CommitNow err = %v, want errCommitPayloadStale", err)
+	}
+	if got := putCalls.Load(); got != 0 {
+		t.Fatalf("server saw %d uploads; stale checkpoint-A must not become a newer revision after checkpoint-B", got)
+	}
+}
+
+func TestSQLiteCheckpointABStaleHandleReleaseFreshRemoteKeepsCheckpointB(t *testing.T) {
+	checkpointA, checkpointB := sqliteCheckpointImages(t)
+	if rows := sqliteRowCountFromImage(t, checkpointA); rows != 5 {
+		t.Fatalf("checkpoint A rows = %d, want 5", rows)
+	}
+	if rows := sqliteRowCountFromImage(t, checkpointB); rows != 12 {
+		t.Fatalf("checkpoint B rows = %d, want 12", rows)
+	}
+
+	const path = "/app-v2-dev.db"
+	server, ts := newCASFileServer(t, path, 2, checkpointA)
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0, SyncMode: SyncStrict, WritePolicy: WritePolicyWriteBack}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.client.SetSmallFileThresholdForTests(1 << 20)
+	writeBack, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	uploader := NewWriteBackUploader(fs.client, writeBack, 1)
+	defer uploader.DrainAll()
+	fs.SetWriteBack(writeBack, uploader)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(fs.client, shadow, pending, nil, 1, 8)
+	defer cq.DrainAll()
+	fs.commitQueue = cq
+
+	ino := fs.inodes.Lookup(path, false, int64(len(checkpointA)), time.Now())
+	fs.inodes.UpdateRevision(ino, 2)
+	fs.recordCommittedRevision(path, 2)
+
+	// H-A: a stale main.db handle has checkpoint-A bytes staged in the
+	// writeback/shadow stores. This is the Release/CommitQueue side of the
+	// production incident, but the bytes are real sqlite3 checkpoint output.
+	stale := &FileHandle{
+		Ino:         ino,
+		Path:        path,
+		Dirty:       fs.newWriteBuffer(path, maxPreloadSize, 0),
+		OrigSize:    int64(len(checkpointA)),
+		BaseRev:     2,
+		WritePolicy: WritePolicyWriteBack,
+	}
+	if _, err := stale.Dirty.Write(0, checkpointA); err != nil {
+		t.Fatal(err)
+	}
+	stale.DirtySeq = fs.markDirtySize(ino, stale.Dirty.Size())
+	stale.Lock()
+	if err := fs.stageShadowLocked(stale, true); err != nil {
+		stale.Unlock()
+		t.Fatal(err)
+	}
+	if err := fs.snapshotWriteBackLocked(stale); err != nil {
+		stale.Unlock()
+		t.Fatal(err)
+	}
+	stale.WriteBackSeq = stale.DirtySeq
+	stale.Unlock()
+	staleID := fs.allocateFileHandle(stale)
+
+	// H-B: checkpoint B writes the real 12-row sqlite image and strict fsyncs
+	// it to the server. This must become the durable watermark for /app.db.
+	newer := &FileHandle{
+		Ino:         ino,
+		Path:        path,
+		Dirty:       fs.newWriteBuffer(path, maxPreloadSize, 0),
+		OrigSize:    int64(len(checkpointA)),
+		BaseRev:     2,
+		WritePolicy: WritePolicyWriteBack,
+	}
+	if _, err := newer.Dirty.Write(0, checkpointB); err != nil {
+		t.Fatal(err)
+	}
+	newer.DirtySeq = fs.markDirtySize(ino, newer.Dirty.Size())
+	newerID := fs.allocateFileHandle(newer)
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: ino}, Fh: newerID}); st != gofuse.OK {
+		t.Fatalf("checkpoint B Fsync status = %v, want OK", st)
+	}
+	rev, body, puts := server.snapshot()
+	if rev != 3 {
+		t.Fatalf("server revision after checkpoint B = %d, want 3", rev)
+	}
+	if rows := sqliteRowCountFromImage(t, body); rows != 12 {
+		t.Fatalf("server rows after checkpoint B fsync = %d, want 12", rows)
+	}
+	if len(puts) != 1 || puts[0].expected != "2" {
+		t.Fatalf("checkpoint B PUT history = %+v, want one PUT expected rev2", puts)
+	}
+	if stale.BaseRev != 2 {
+		t.Fatalf("stale main.db BaseRev = %d, want 2 after checkpoint B watermark", stale.BaseRev)
+	}
+
+	// Closing the stale H-A handle exercises the real FUSE Release
+	// writeback-cache path. The queued entry is based on rev2 payload under a
+	// rev3 durable watermark, so it must be fenced before it can upload A as
+	// rev4. A fresh remote snapshot must still be the 12-row checkpoint B.
+	fs.Release(nil, &gofuse.ReleaseIn{InHeader: gofuse.InHeader{NodeId: ino}, Fh: staleID})
+	cq.DrainAll()
+	rev, body, puts = server.snapshot()
+	if rev != 3 {
+		t.Fatalf("server revision after stale Release = %d, want 3 (no old checkpoint-A rev4)", rev)
+	}
+	if len(puts) != 1 {
+		t.Fatalf("server PUTs after stale Release = %d, want only checkpoint B PUT", len(puts))
+	}
+	if rows := sqliteRowCountFromImage(t, body); rows != 12 {
+		t.Fatalf("fresh remote sqlite rows after stale Release = %d, want 12", rows)
+	}
+	if meta, ok := pending.GetMeta(path); !ok || meta.Kind != PendingConflict {
+		t.Fatalf("stale checkpoint-A pending meta = %+v ok=%t, want preserved conflict", meta, ok)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{InHeader: gofuse.InHeader{NodeId: ino}, Fh: newerID})
+}
+
+func TestSQLitePersistentJournalStagedDirtyHandleCannotAdoptCommittedRevision(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	const path = "/app.db-wal"
+	ino := fs.inodes.Lookup(path, false, 32, time.Now())
+	fs.inodes.UpdateRevision(ino, 2)
+	fs.recordCommittedRevision(path, 2)
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    fs.newWriteBuffer(path, maxPreloadSize, 0),
+		OrigSize: 32,
+		BaseRev:  2,
+	}
+	if _, err := fh.Dirty.Write(0, []byte("non-empty wal frame payload")); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	fh.Lock()
+	if err := fs.stageShadowLocked(fh, true); err != nil {
+		fh.Unlock()
+		t.Fatal(err)
+	}
+	fh.Unlock()
+	fs.openHandles.Add(fh)
+
+	fs.recordCommittedRevision(path, 3)
+	fs.refreshCommittedRevisionForOpenHandles(path, 3, nil)
+
+	if fh.BaseRev != 2 {
+		t.Fatalf("staged dirty journal BaseRev = %d, want 2; path-keyed sidecar staging must not adopt a newer CAS base", fh.BaseRev)
+	}
+	fh.Lock()
+	entry := &CommitEntry{Path: path, Inode: ino, BaseRev: fs.expectedRevisionForHandleLocked(fh), Size: fh.Dirty.Size(), Kind: PendingOverwrite}
+	fs.bindCommitEntryToHandleLocked(entry, fh, fh.BaseRev)
+	fh.Unlock()
+	if entry.PayloadBaseRev != 2 || !entry.PayloadBaseRevSet {
+		t.Fatalf("journal entry payload base = %d set=%t, want rev2 binding", entry.PayloadBaseRev, entry.PayloadBaseRevSet)
+	}
+	if entry.DurableWatermarkRev != 3 || !entry.DisableAutoResolveLWW {
+		t.Fatalf("journal entry watermark = %d disable_lww=%t, want rev3 fence", entry.DurableWatermarkRev, entry.DisableAutoResolveLWW)
+	}
+}
+
+func TestReleaseWriteBackCleanupKeepsNewerGeneration(t *testing.T) {
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			putCalls.Add(1)
+			http.Error(w, "stale release entry must be rejected before upload", http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	writeBack, err := NewWriteBackCache(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	uploader := NewWriteBackUploader(fs.client, writeBack, 0)
+	fs.SetWriteBack(writeBack, uploader)
+	defer uploader.DrainAll()
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(fs.client, shadow, pending, nil, 1, 8, fs.remoteRoot())
+	cq.PathLock = fs.lockRemoteCommitPath
+	cq.OnSuccess = fs.onCommitQueueSuccess
+	cq.OnCleanup = fs.onCommitQueueCleanup
+	fs.commitQueue = cq
+	defer cq.DrainAll()
+
+	const path = "/same-path.db"
+	oldPayload := []byte("old")
+	newPayload := []byte("new")
+
+	ino := fs.inodes.Lookup(path, false, int64(len(oldPayload)), time.Now())
+	fs.inodes.UpdateRevision(ino, 2)
+	fs.recordCommittedRevision(path, 2)
+	fh := &FileHandle{
+		Ino:      ino,
+		Path:     path,
+		Dirty:    fs.newWriteBuffer(path, maxPreloadSize, 0),
+		BaseRev:  2,
+		OrigSize: int64(len(oldPayload)),
+	}
+	if _, err := fh.Dirty.Write(0, oldPayload); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	fh.Lock()
+	if err := fs.stageShadowLocked(fh, true); err != nil {
+		fh.Unlock()
+		t.Fatal(err)
+	}
+	fh.Unlock()
+
+	oldGen, _, err := writeBack.PutWithBaseRevAndModeTimings(path, oldPayload, int64(len(oldPayload)), PendingOverwrite, 2, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fh.WriteBackGen = oldGen
+	fh.WriteBackSeq = fh.DirtySeq
+
+	fs.recordCommittedRevision(path, 3)
+	fhID := fs.allocateFileHandle(fh)
+
+	newGen, _, err := writeBack.PutWithBaseRevAndModeTimings(path, newPayload, int64(len(newPayload)), PendingOverwrite, 3, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if newGen == oldGen {
+		t.Fatal("writeBack generation did not advance")
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       fhID,
+	})
+	cq.DrainAll()
+
+	meta, ok := writeBack.GetMeta(path)
+	if !ok {
+		t.Fatal("newer writeBack generation was removed by stale cleanup")
+	}
+	if meta.Generation != newGen {
+		t.Fatalf("writeBack generation = %d, want newer generation %d", meta.Generation, newGen)
+	}
+	if got := putCalls.Load(); got != 0 {
+		t.Fatalf("server saw %d uploads; stale release entry must be rejected before upload", got)
+	}
+}
+
+func TestCommitQueueStaleGenerationCannotPoisonNewerPendingEntry(t *testing.T) {
+	var putCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		putCalls.Add(1)
+		http.Error(w, "stale generation must not upload", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const path = "/same-path.db"
+	oldPayload := []byte("old handle payload")
+	freshPayload := []byte("fresh handle payload")
+	if err := shadow.WriteFull(path, oldPayload, 2); err != nil {
+		t.Fatal(err)
+	}
+	oldShadowGen := shadow.ActiveGeneration(path)
+	oldPendingGen, err := pending.PutWithBaseRev(path, int64(len(oldPayload)), PendingOverwrite, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := shadow.WriteFull(path, freshPayload, 3); err != nil {
+		t.Fatal(err)
+	}
+	freshPendingGen, err := pending.PutWithBaseRev(path, int64(len(freshPayload)), PendingOverwrite, 3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(50000)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              path,
+		BaseRev:           2,
+		PayloadBaseRev:    2,
+		PayloadBaseRevSet: true,
+		Size:              int64(len(oldPayload)),
+		Kind:              PendingOverwrite,
+		ShadowGen:         oldShadowGen,
+		PendingIndexGen:   oldPendingGen,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if got := putCalls.Load(); got != 0 {
+		t.Fatalf("server saw %d uploads; stale generation must be rejected locally", got)
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("newer pending entry was removed by stale commit failure")
+	}
+	if meta.Generation != freshPendingGen {
+		t.Fatalf("pending generation = %d, want newer generation %d", meta.Generation, freshPendingGen)
+	}
+	if meta.Kind == PendingConflict {
+		t.Fatal("newer pending entry was incorrectly marked conflicted by stale commit failure")
+	}
+	data, err := shadow.ReadAll(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(freshPayload) {
+		t.Fatalf("shadow data = %q, want fresh payload", data)
+	}
+}
+
+func TestCommitQueueFencedConflictDoesNotLWWRebaseOldPayload(t *testing.T) {
+	var putCalls atomic.Int32
+	var headCalls atomic.Int32
+	var getCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodHead:
+			headCalls.Add(1)
+			http.Error(w, "fenced conflict must not auto-resolve", http.StatusInternalServerError)
+		case http.MethodGet:
+			getCalls.Add(1)
+			http.Error(w, "fenced conflict must not read for LWW", http.StatusInternalServerError)
+		default:
+			putCalls.Add(1)
+			body, _ := io.ReadAll(r.Body)
+			if r.Header.Get("X-Dat9-Expected-Revision") != "2" {
+				t.Fatalf("unexpected expected revision %q body=%q", r.Header.Get("X-Dat9-Expected-Revision"), body)
+			}
+			http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+		}
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const path = "/checkpoint.db"
+	oldPayload := []byte("checkpoint A: 5 rows")
+	if err := shadow.WriteFull(path, oldPayload, 2); err != nil {
+		t.Fatal(err)
+	}
+	shadowGen := shadow.ActiveGeneration(path)
+	pendingGen, err := pending.PutWithBaseRev(path, int64(len(oldPayload)), PendingOverwrite, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(50000)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:                  path,
+		BaseRev:               2,
+		PayloadBaseRev:        2,
+		PayloadBaseRevSet:     true,
+		Size:                  int64(len(oldPayload)),
+		Kind:                  PendingOverwrite,
+		ShadowGen:             shadowGen,
+		PendingIndexGen:       pendingGen,
+		DisableAutoResolveLWW: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want exactly initial conflicting upload", got)
+	}
+	if got := headCalls.Load(); got != 0 {
+		t.Fatalf("HEAD calls = %d, want 0; fenced entry must not enter auto-resolve", got)
+	}
+	if got := getCalls.Load(); got != 0 {
+		t.Fatalf("GET calls = %d, want 0; fenced entry must not read for LWW", got)
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending entry should remain for manual recovery after fenced conflict")
+	}
+	if meta.Kind != PendingConflict {
+		t.Fatalf("pending kind = %v, want PendingConflict", meta.Kind)
+	}
+}

--- a/pkg/fuse/writeback_generation_fence_test.go
+++ b/pkg/fuse/writeback_generation_fence_test.go
@@ -740,6 +740,110 @@ func TestSQLitePersistentJournalUnstagedShadowSpillCannotAdoptDuringStaging(t *t
 	}
 }
 
+func TestSQLitePersistentJournalImmediateRemoteSyncCannotAdoptStalePayload(t *testing.T) {
+	for _, path := range []string{"/app.db-wal", "/app.db-journal"} {
+		t.Run(path, func(t *testing.T) {
+			var (
+				mu       sync.Mutex
+				revision int64 = 3
+				body           = []byte("rev3 sqlite sidecar bytes")
+				attempts []struct {
+					expected string
+					body     []byte
+				}
+			)
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPut || r.URL.Path != "/v1/fs"+path {
+					http.NotFound(w, r)
+					return
+				}
+				data, err := io.ReadAll(r.Body)
+				if err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+					return
+				}
+				mu.Lock()
+				defer mu.Unlock()
+				expected := r.Header.Get("X-Dat9-Expected-Revision")
+				attempts = append(attempts, struct {
+					expected string
+					body     []byte
+				}{expected: expected, body: append([]byte(nil), data...)})
+				if expected != fmt.Sprintf("%d", revision) {
+					http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+					return
+				}
+				revision++
+				body = append([]byte(nil), data...)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": revision})
+			}))
+			defer ts.Close()
+
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient(ts.URL), opts)
+
+			ino := fs.inodes.Lookup(path, false, int64(len(body)), time.Now())
+			fs.inodes.UpdateRevision(ino, 2)
+			// A newer same-path sidecar revision has already become durable
+			// in this mount, but this handle still owns rev2-era dirty bytes.
+			// Immediate remote-sync must let the server CAS reject that stale
+			// payload instead of swapping in the newer BaseRev and accepting it
+			// as rev4.
+			fs.recordCommittedRevision(path, 3)
+
+			oldPayload := []byte("rev2 stale sqlite sidecar bytes")
+			fh := &FileHandle{
+				Ino:      ino,
+				Path:     path,
+				Dirty:    fs.newWriteBuffer(path, maxPreloadSize, 0),
+				OrigSize: int64(len(oldPayload)),
+				BaseRev:  2,
+			}
+			if _, err := fh.Dirty.Write(0, oldPayload); err != nil {
+				t.Fatal(err)
+			}
+			fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+
+			fh.Lock()
+			st := fs.flushHandle(context.Background(), fh)
+			fh.Unlock()
+			if st == gofuse.OK {
+				t.Fatal("stale SQLite sidecar remote-sync unexpectedly succeeded")
+			}
+			if fh.BaseRev != 2 {
+				t.Fatalf("stale SQLite sidecar BaseRev = %d, want 2", fh.BaseRev)
+			}
+
+			mu.Lock()
+			finalRev := revision
+			finalBody := append([]byte(nil), body...)
+			gotAttempts := append([]struct {
+				expected string
+				body     []byte
+			}(nil), attempts...)
+			mu.Unlock()
+
+			if finalRev != 3 {
+				t.Fatalf("server revision = %d, want 3; stale payload must not be accepted as rev4", finalRev)
+			}
+			if string(finalBody) != "rev3 sqlite sidecar bytes" {
+				t.Fatalf("server body = %q, want rev3 bytes", finalBody)
+			}
+			if len(gotAttempts) != 1 {
+				t.Fatalf("PUT attempts = %d, want 1", len(gotAttempts))
+			}
+			if gotAttempts[0].expected != "2" {
+				t.Fatalf("PUT expected revision = %q, want stale base rev 2", gotAttempts[0].expected)
+			}
+			if string(gotAttempts[0].body) != string(oldPayload) {
+				t.Fatalf("PUT body = %q, want stale payload attempt for CAS rejection", gotAttempts[0].body)
+			}
+		})
+	}
+}
+
 func TestReleaseWriteBackCleanupKeepsNewerGeneration(t *testing.T) {
 	var putCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fuse/writeback_generation_fence_test.go
+++ b/pkg/fuse/writeback_generation_fence_test.go
@@ -325,10 +325,20 @@ func TestCommitQueueRejectsPayloadOlderThanDurableWatermark(t *testing.T) {
 
 func TestSQLiteCheckpointABStaleHandleCannotOverwriteDurableMainDB(t *testing.T) {
 	var putCalls atomic.Int32
+	var handlerMu sync.Mutex
+	var handlerErr error
+	recordHandlerErr := func(err error) {
+		handlerMu.Lock()
+		defer handlerMu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		putCalls.Add(1)
 		body, _ := io.ReadAll(r.Body)
-		t.Fatalf("stale checkpoint-A payload reached server: expected_rev=%q body=%q", r.Header.Get("X-Dat9-Expected-Revision"), body)
+		recordHandlerErr(fmt.Errorf("stale checkpoint-A payload reached server: expected_rev=%q body=%q", r.Header.Get("X-Dat9-Expected-Revision"), body))
+		http.Error(w, "stale payload reached server", http.StatusInternalServerError)
 	}))
 	defer ts.Close()
 
@@ -403,6 +413,12 @@ func TestSQLiteCheckpointABStaleHandleCannotOverwriteDurableMainDB(t *testing.T)
 	}
 	if got := putCalls.Load(); got != 0 {
 		t.Fatalf("server saw %d uploads; stale checkpoint-A must not become a newer revision after checkpoint-B", got)
+	}
+	handlerMu.Lock()
+	err = handlerErr
+	handlerMu.Unlock()
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 
@@ -1026,6 +1042,15 @@ func TestCommitQueueFencedConflictDoesNotLWWRebaseOldPayload(t *testing.T) {
 	var putCalls atomic.Int32
 	var headCalls atomic.Int32
 	var getCalls atomic.Int32
+	var handlerMu sync.Mutex
+	var handlerErr error
+	recordHandlerErr := func(err error) {
+		handlerMu.Lock()
+		defer handlerMu.Unlock()
+		if handlerErr == nil {
+			handlerErr = err
+		}
+	}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodHead:
@@ -1038,7 +1063,9 @@ func TestCommitQueueFencedConflictDoesNotLWWRebaseOldPayload(t *testing.T) {
 			putCalls.Add(1)
 			body, _ := io.ReadAll(r.Body)
 			if r.Header.Get("X-Dat9-Expected-Revision") != "2" {
-				t.Fatalf("unexpected expected revision %q body=%q", r.Header.Get("X-Dat9-Expected-Revision"), body)
+				recordHandlerErr(fmt.Errorf("unexpected expected revision %q body=%q", r.Header.Get("X-Dat9-Expected-Revision"), body))
+				http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+				return
 			}
 			http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
 		}
@@ -1100,4 +1127,297 @@ func TestCommitQueueFencedConflictDoesNotLWWRebaseOldPayload(t *testing.T) {
 	if meta.Kind != PendingConflict {
 		t.Fatalf("pending kind = %v, want PendingConflict", meta.Kind)
 	}
+	handlerMu.Lock()
+	err = handlerErr
+	handlerMu.Unlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCommitQueueLiveDurableWatermarkRejectsEntryThatBecameStaleAfterEnqueue(t *testing.T) {
+	var requestCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCalls.Add(1)
+		http.Error(w, "stale payload must be rejected before remote I/O", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const path = "/checkpoint.db"
+	oldPayload := []byte("checkpoint A")
+	if err := shadow.WriteFull(path, oldPayload, 2); err != nil {
+		t.Fatal(err)
+	}
+	shadowGen := shadow.ActiveGeneration(path)
+	pendingGen, err := pending.PutWithBaseRev(path, int64(len(oldPayload)), PendingOverwrite, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	var liveWatermark atomic.Int64
+	lockEntered := make(chan struct{})
+	releaseLock := make(chan struct{})
+	var enterOnce sync.Once
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseLock)
+		})
+	}
+	defer release()
+	cq.DurableWatermark = func(string) int64 {
+		return liveWatermark.Load()
+	}
+	cq.PathLock = func(string) func() {
+		enterOnce.Do(func() {
+			close(lockEntered)
+			<-releaseLock
+		})
+		return func() {}
+	}
+
+	entry := &CommitEntry{
+		Path:              path,
+		BaseRev:           2,
+		PayloadBaseRev:    2,
+		PayloadBaseRevSet: true,
+		Size:              int64(len(oldPayload)),
+		Kind:              PendingOverwrite,
+		ShadowGen:         shadowGen,
+		PendingIndexGen:   pendingGen,
+	}
+	if err := cq.Enqueue(entry); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-lockEntered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("commit worker did not enter path lock")
+	}
+
+	// Simulate a sibling strict fsync making checkpoint B durable after this
+	// entry was already enqueued but before it dispatches its payload.
+	liveWatermark.Store(3)
+	release()
+	cq.DrainAll()
+
+	if got := requestCalls.Load(); got != 0 {
+		t.Fatalf("remote requests = %d, want 0; stale payload must be fenced at dispatch", got)
+	}
+	if entry.DurableWatermarkRev != 3 || !entry.DisableAutoResolveLWW {
+		t.Fatalf("entry watermark/lww = %d/%t, want 3/true", entry.DurableWatermarkRev, entry.DisableAutoResolveLWW)
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending stale entry should remain for manual recovery")
+	}
+	if meta.Kind != PendingConflict {
+		t.Fatalf("pending kind = %v, want PendingConflict", meta.Kind)
+	}
+}
+
+func TestCommitQueueRefusesLWWWhenPayloadBaseOlderThanServerRevision(t *testing.T) {
+	const path = "/checkpoint.db"
+	oldPayload := []byte("checkpoint A: 5 rows")
+	freshPayload := []byte("checkpoint B: 12 rows")
+	server, ts := newCASFileServer(t, path, 3, freshPayload)
+	defer ts.Close()
+
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(path, oldPayload, 2); err != nil {
+		t.Fatal(err)
+	}
+	shadowGen := shadow.ActiveGeneration(path)
+	pendingGen, err := pending.PutWithBaseRev(path, int64(len(oldPayload)), PendingOverwrite, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(50000)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              path,
+		BaseRev:           2,
+		PayloadBaseRev:    2,
+		PayloadBaseRevSet: true,
+		Size:              int64(len(oldPayload)),
+		Kind:              PendingOverwrite,
+		ShadowGen:         shadowGen,
+		PendingIndexGen:   pendingGen,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	rev, body, puts := server.snapshot()
+	if rev != 3 {
+		t.Fatalf("server revision = %d, want 3; stale payload must not LWW into rev4", rev)
+	}
+	if string(body) != string(freshPayload) {
+		t.Fatalf("server body = %q, want checkpoint B payload", body)
+	}
+	if len(puts) != 0 {
+		t.Fatalf("successful PUT history = %+v, want no stale LWW write", puts)
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending entry should remain for manual recovery")
+	}
+	if meta.Kind != PendingConflict {
+		t.Fatalf("pending kind = %v, want PendingConflict", meta.Kind)
+	}
+}
+
+func TestShadowSpillSyncCleanupKeepsNewerGeneration(t *testing.T) {
+	const path = "/large.db-wal"
+	freshPayload := []byte("checkpoint B fresh shadow generation")
+	var putCalls atomic.Int32
+	var putMu sync.Mutex
+	var gotBody []byte
+	var handlerErrors testErrorRecorder
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/v1/fs"+path {
+			http.NotFound(w, r)
+			return
+		}
+		putCalls.Add(1)
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			handlerErrors.Recordf("read PUT body: %v", err)
+			http.Error(w, "read body", http.StatusInternalServerError)
+			return
+		}
+		if r.Header.Get("X-Dat9-Expected-Revision") != "3" {
+			handlerErrors.Recordf("expected revision = %q, want 3", r.Header.Get("X-Dat9-Expected-Revision"))
+			http.Error(w, `{"error":"revision conflict"}`, http.StatusConflict)
+			return
+		}
+		if string(body) != string(freshPayload) {
+			handlerErrors.Recordf("PUT body = %q, want fresh payload", body)
+			http.Error(w, "stale shadow payload", http.StatusInternalServerError)
+			return
+		}
+		putMu.Lock()
+		gotBody = append([]byte(nil), body...)
+		putMu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":4}`))
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	oldPayload := []byte("checkpoint A old shadow generation")
+	if err := shadow.WriteFull(path, oldPayload, 2); err != nil {
+		t.Fatal(err)
+	}
+	oldShadowGen := shadow.ActiveGeneration(path)
+	oldPendingGen, err := pending.PutShadowSpillWithMode(path, int64(len(oldPayload)), PendingOverwrite, 2, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Path:              path,
+		ShadowReady:       true,
+		ShadowSpill:       true,
+		ShadowCommitReady: true,
+		ShadowStageGen:    oldShadowGen,
+		PendingIndexGen:   oldPendingGen,
+	}
+
+	// H2 stages a newer generation after H1's upload has returned but before
+	// H1 runs cleanup. H1 must not path-wide delete H2's only staged copy.
+	if err := shadow.WriteFull(path, freshPayload, 3); err != nil {
+		t.Fatal(err)
+	}
+	freshShadowGen := shadow.ActiveGeneration(path)
+	freshPendingGen, err := pending.PutShadowSpillWithMode(path, int64(len(freshPayload)), PendingOverwrite, 3, 0, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fs.removeShadowPendingStagingGenerationLocked(fh, path, oldShadowGen, oldPendingGen)
+
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("newer pending generation was removed by stale cleanup")
+	}
+	if meta.Generation != freshPendingGen {
+		t.Fatalf("pending generation = %d, want fresh generation %d", meta.Generation, freshPendingGen)
+	}
+	data, err := shadow.ReadAll(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != string(freshPayload) {
+		t.Fatalf("shadow data after cleanup = %q, want fresh payload", data)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(50000)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              path,
+		BaseRev:           3,
+		PayloadBaseRev:    3,
+		PayloadBaseRevSet: true,
+		Size:              int64(len(freshPayload)),
+		Kind:              PendingOverwrite,
+		ShadowSpill:       true,
+		ShadowGen:         freshShadowGen,
+		PendingIndexGen:   freshPendingGen,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+
+	if got := putCalls.Load(); got != 1 {
+		t.Fatalf("PUT calls = %d, want fresh generation commit", got)
+	}
+	putMu.Lock()
+	committedBody := append([]byte(nil), gotBody...)
+	putMu.Unlock()
+	if string(committedBody) != string(freshPayload) {
+		t.Fatalf("committed body = %q, want fresh payload", committedBody)
+	}
+	if pending.HasPending(path) {
+		t.Fatal("pending entry should be removed after fresh generation commit")
+	}
+	if shadow.Has(path) {
+		t.Fatal("shadow entry should be removed after fresh generation commit")
+	}
+	handlerErrors.Check(t)
 }

--- a/pkg/fuse/writeback_generation_fence_test.go
+++ b/pkg/fuse/writeback_generation_fence_test.go
@@ -588,6 +588,158 @@ func TestSQLitePersistentJournalStagedDirtyHandleCannotAdoptCommittedRevision(t 
 	}
 }
 
+func TestSQLitePersistentJournalUnstagedDirtyHandleCannotAdoptDuringStaging(t *testing.T) {
+	for _, path := range []string{"/app.db-wal", "/app.db-journal"} {
+		t.Run(path, func(t *testing.T) {
+			opts := &MountOptions{}
+			opts.setDefaults()
+			fs := NewDat9FS(newTestClient("http://localhost"), opts)
+			shadow, err := NewShadowStore(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer shadow.Close()
+			pending, err := NewPendingIndex(t.TempDir())
+			if err != nil {
+				t.Fatal(err)
+			}
+			fs.shadowStore = shadow
+			fs.pendingIndex = pending
+
+			ino := fs.inodes.Lookup(path, false, 32, time.Now())
+			fs.inodes.UpdateRevision(ino, 2)
+			fs.recordCommittedRevision(path, 2)
+			fh := &FileHandle{
+				Ino:      ino,
+				Path:     path,
+				Dirty:    fs.newWriteBuffer(path, maxPreloadSize, 0),
+				OrigSize: 32,
+				BaseRev:  2,
+			}
+			oldPayload := []byte("old sqlite sidecar payload")
+			if _, err := fh.Dirty.Write(0, oldPayload); err != nil {
+				t.Fatal(err)
+			}
+			fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+			fs.openHandles.Add(fh)
+
+			// This is the pre-staging race from the production RCA: a sibling
+			// has already made rev3 durable, but this sidecar handle still
+			// carries rev2-era dirty bytes and has not recorded ShadowStageGen or
+			// PendingIndexGen yet. Neither the sibling-revision refresh nor
+			// stageShadowLocked may adopt rev3 before staging those bytes.
+			fs.recordCommittedRevision(path, 3)
+			fs.refreshCommittedRevisionForOpenHandles(path, 3, nil)
+			if fh.BaseRev != 2 {
+				t.Fatalf("unstaged dirty journal BaseRev = %d after sibling refresh, want 2", fh.BaseRev)
+			}
+			fh.Lock()
+			if err := fs.stageShadowLocked(fh, true); err != nil {
+				fh.Unlock()
+				t.Fatal(err)
+			}
+			fh.Unlock()
+
+			if fh.BaseRev != 2 {
+				t.Fatalf("unstaged dirty journal BaseRev = %d, want 2 after stageShadowLocked", fh.BaseRev)
+			}
+			if got := shadow.BaseRev(path); got != 2 {
+				t.Fatalf("shadow base rev = %d, want 2", got)
+			}
+			meta, ok := pending.GetMeta(path)
+			if !ok {
+				t.Fatal("pending meta missing after staging")
+			}
+			if meta.BaseRev != 2 {
+				t.Fatalf("pending base rev = %d, want 2", meta.BaseRev)
+			}
+			fh.Lock()
+			entry := &CommitEntry{Path: path, Inode: ino, BaseRev: fs.expectedRevisionForHandleLocked(fh), Size: fh.Dirty.Size(), Kind: PendingOverwrite}
+			fs.bindCommitEntryToHandleLocked(entry, fh, fh.BaseRev)
+			fh.Unlock()
+			if entry.PayloadBaseRev != 2 || !entry.PayloadBaseRevSet {
+				t.Fatalf("entry payload base = %d set=%t, want rev2", entry.PayloadBaseRev, entry.PayloadBaseRevSet)
+			}
+			if entry.DurableWatermarkRev != 3 || !entry.DisableAutoResolveLWW {
+				t.Fatalf("entry watermark = %d disable_lww=%t, want rev3 fence", entry.DurableWatermarkRev, entry.DisableAutoResolveLWW)
+			}
+		})
+	}
+}
+
+func TestSQLitePersistentJournalUnstagedShadowSpillCannotAdoptDuringStaging(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	const path = "/app.db-wal"
+	ino := fs.inodes.Lookup(path, false, 0, time.Now())
+	fs.inodes.UpdateRevision(ino, 2)
+	fs.recordCommittedRevision(path, 2)
+	oldPayload := []byte("old sqlite wal shadowspill payload")
+	if err := shadow.WriteFull(path, oldPayload, 2); err != nil {
+		t.Fatal(err)
+	}
+	fh := &FileHandle{
+		Ino:         ino,
+		Path:        path,
+		Dirty:       fs.newWriteBuffer(path, maxPreloadSize, 0),
+		OrigSize:    int64(len(oldPayload)),
+		BaseRev:     2,
+		ShadowReady: true,
+		ShadowSpill: true,
+	}
+	if _, err := fh.Dirty.Write(0, oldPayload); err != nil {
+		t.Fatal(err)
+	}
+	fh.DirtySeq = fs.markDirtySize(ino, fh.Dirty.Size())
+	fs.openHandles.Add(fh)
+
+	fs.recordCommittedRevision(path, 3)
+	fs.refreshCommittedRevisionForOpenHandles(path, 3, nil)
+	if fh.BaseRev != 2 {
+		t.Fatalf("unstaged ShadowSpill journal BaseRev = %d after sibling refresh, want 2", fh.BaseRev)
+	}
+	fh.Lock()
+	if err := fs.stageShadowLocked(fh, true); err != nil {
+		fh.Unlock()
+		t.Fatal(err)
+	}
+	fh.Unlock()
+
+	if fh.BaseRev != 2 {
+		t.Fatalf("unstaged ShadowSpill journal BaseRev = %d, want 2 after stageShadowLocked", fh.BaseRev)
+	}
+	if got := shadow.BaseRev(path); got != 2 {
+		t.Fatalf("shadow base rev = %d, want 2", got)
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending meta missing after ShadowSpill staging")
+	}
+	if meta.BaseRev != 2 || !meta.ShadowSpill {
+		t.Fatalf("pending meta base/shadowspill = %d/%t, want 2/true", meta.BaseRev, meta.ShadowSpill)
+	}
+	fh.Lock()
+	entry := &CommitEntry{Path: path, Inode: ino, BaseRev: fs.expectedRevisionForHandleLocked(fh), Size: fh.Dirty.Size(), Kind: PendingOverwrite, ShadowSpill: true}
+	fs.bindCommitEntryToHandleLocked(entry, fh, fh.BaseRev)
+	fh.Unlock()
+	if entry.PayloadBaseRev != 2 || entry.DurableWatermarkRev != 3 || !entry.DisableAutoResolveLWW {
+		t.Fatalf("entry payload/watermark/lww = %d/%d/%t, want 2/3/true", entry.PayloadBaseRev, entry.DurableWatermarkRev, entry.DisableAutoResolveLWW)
+	}
+}
+
 func TestReleaseWriteBackCleanupKeepsNewerGeneration(t *testing.T) {
 	var putCalls atomic.Int32
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -4764,13 +4764,13 @@ func TestUnlink_PendingNewCommitQueueUploadedDeletesRemote(t *testing.T) {
 	fs.commitQueue = cq
 	fs.inodes.Lookup(p, false, int64(len(data)), time.Now())
 
-	if err := cq.Enqueue(&CommitEntry{
+	if err := cq.Enqueue(attachTestStagingGens(shadow, pending, &CommitEntry{
 		Path:    p,
 		Inode:   2,
 		Size:    int64(len(data)),
 		Kind:    PendingNew,
 		BaseRev: 0,
-	}); err != nil {
+	})); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -1379,6 +1379,9 @@ func TestCloseSyncOpenTruncateOverwriteReadSeesLatestBytes(t *testing.T) {
 	if st != gofuse.OK {
 		t.Fatalf("Open read before writer Release status = %v, want OK", st)
 	}
+	if readBeforeReleaseOut.OpenFlags != gofuse.FOPEN_DIRECT_IO {
+		t.Fatalf("Open read before writer Release flags = %d, want FOPEN_DIRECT_IO while per-inode bypass fallback is active", readBeforeReleaseOut.OpenFlags)
+	}
 	bufBeforeRelease := make([]byte, 64)
 	resultBeforeRelease, st := fs.Read(nil, &gofuse.ReadIn{
 		InHeader: gofuse.InHeader{NodeId: ino},
@@ -1410,6 +1413,9 @@ func TestCloseSyncOpenTruncateOverwriteReadSeesLatestBytes(t *testing.T) {
 	}, &readOut)
 	if st != gofuse.OK {
 		t.Fatalf("Open read status = %v, want OK", st)
+	}
+	if readOut.OpenFlags != gofuse.FOPEN_DIRECT_IO {
+		t.Fatalf("Open read flags = %d, want FOPEN_DIRECT_IO while per-inode bypass fallback is active", readOut.OpenFlags)
 	}
 	buf := make([]byte, 64)
 	result, st := fs.Read(nil, &gofuse.ReadIn{
@@ -1542,6 +1548,9 @@ func TestCloseSyncFlushSupersedesPathZeroShadowBeforeRelease(t *testing.T) {
 	}, &readOut)
 	if st != gofuse.OK {
 		t.Fatalf("Open read status = %v, want OK", st)
+	}
+	if readOut.OpenFlags != gofuse.FOPEN_DIRECT_IO {
+		t.Fatalf("Open read flags = %d, want FOPEN_DIRECT_IO while per-inode bypass fallback is active", readOut.OpenFlags)
 	}
 	buf := make([]byte, 64)
 	result, st := fs.Read(nil, &gofuse.ReadIn{

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -1363,6 +1363,41 @@ func TestCloseSyncOpenTruncateOverwriteReadSeesLatestBytes(t *testing.T) {
 	if got := fs.notifyCount.Load() - beforeFlushNotify; got != 1 {
 		t.Fatalf("close-sync truncate overwrite flush sent %d inode invalidations, want 1", got)
 	}
+	if shadow.Has(path) {
+		t.Fatal("close-sync truncate overwrite flush left stale 0-byte shadow active")
+	}
+
+	// FUSE Release is best-effort/asynchronous from the kernel's perspective.
+	// close-sync visibility must therefore be satisfied by Flush itself: an
+	// immediate close-to-open reader must not pin the writer's O_TRUNC shadow
+	// and observe EOF before Release runs.
+	var readBeforeReleaseOut gofuse.OpenOut
+	st = fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &readBeforeReleaseOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open read before writer Release status = %v, want OK", st)
+	}
+	bufBeforeRelease := make([]byte, 64)
+	resultBeforeRelease, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       readBeforeReleaseOut.Fh,
+		Offset:   0,
+		Size:     uint32(len(bufBeforeRelease)),
+	}, bufBeforeRelease)
+	if st != gofuse.OK {
+		t.Fatalf("Read before writer Release status = %v, want OK", st)
+	}
+	gotBeforeRelease, _ := resultBeforeRelease.Bytes(bufBeforeRelease)
+	if !bytes.Equal(gotBeforeRelease, updated) {
+		t.Fatalf("Read before writer Release = %q, want %q", gotBeforeRelease, updated)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       readBeforeReleaseOut.Fh,
+	})
+
 	fs.Release(nil, &gofuse.ReleaseIn{
 		InHeader: gofuse.InHeader{NodeId: ino},
 		Fh:       writeOut.Fh,
@@ -1390,6 +1425,147 @@ func TestCloseSyncOpenTruncateOverwriteReadSeesLatestBytes(t *testing.T) {
 	if !bytes.Equal(got, updated) {
 		t.Fatalf("Read = %q, want %q", got, updated)
 	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if puts != 1 {
+		t.Fatalf("PUT calls = %d, want 1", puts)
+	}
+	if !bytes.Equal(content, updated) || rev != 2 {
+		t.Fatalf("server content/rev = %q/%d, want %q/2", content, rev, updated)
+	}
+}
+
+func TestCloseSyncFlushSupersedesPathZeroShadowBeforeRelease(t *testing.T) {
+	const path = "/supervise-probe.txt"
+	initial := []byte("ready\n")
+	updated := []byte("after-heal\n")
+
+	var (
+		mu      sync.Mutex
+		content       = append([]byte(nil), initial...)
+		rev     int64 = 1
+		puts    int
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			_, _ = w.Write(content)
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			if got := r.Header.Get("X-Dat9-Expected-Revision"); got != "1" {
+				t.Errorf("expected revision header = %q, want 1", got)
+			}
+			puts++
+			rev++
+			content = append(content[:0], body...)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": rev})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	opts := &MountOptions{FlushDebounce: 0, SyncMode: SyncStrict, WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	// Model a path-based truncate-to-zero staging record that is not owned by
+	// this writer handle (ShadowStageGen remains 0 on the handle). This is the
+	// FUSE supervision shape behind `printf > file`: a later close-sync write
+	// publishes final bytes directly, and the immediate reader must not pin the
+	// stale zero-byte shadow and observe EOF.
+	if err := shadow.WriteFull(path, nil, 1); err != nil {
+		t.Fatal(err)
+	}
+	if got := shadow.Size(path); got != 0 {
+		t.Fatalf("seeded shadow size = %d, want 0", got)
+	}
+
+	ino := fs.inodes.Lookup(path, false, int64(len(initial)), time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+	fs.inodes.UpdateSize(ino, int64(len(initial)))
+
+	var writeOut gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_WRONLY),
+	}, &writeOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open write status = %v, want OK", st)
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       writeOut.Fh,
+		Offset:   0,
+	}, updated); st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       writeOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush status = %v, want OK", st)
+	}
+	if shadow.Has(path) {
+		t.Fatal("close-sync flush left stale path-level zero-byte shadow active")
+	}
+
+	var readOut gofuse.OpenOut
+	st = fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &readOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open read status = %v, want OK", st)
+	}
+	buf := make([]byte, 64)
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       readOut.Fh,
+		Offset:   0,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read status = %v, want OK", st)
+	}
+	got, _ := result.Bytes(buf)
+	if !bytes.Equal(got, updated) {
+		t.Fatalf("Read = %q, want %q", got, updated)
+	}
+
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       readOut.Fh,
+	})
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       writeOut.Fh,
+	})
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -1276,6 +1276,127 @@ func TestFlush_CloseSyncUploadsBeforeReturning(t *testing.T) {
 	}
 }
 
+func TestCloseSyncOpenTruncateOverwriteReadSeesLatestBytes(t *testing.T) {
+	const path = "/supervise-probe.txt"
+	initial := []byte("ready\n")
+	updated := []byte("before-crash\n")
+
+	var (
+		mu      sync.Mutex
+		content       = append([]byte(nil), initial...)
+		rev     int64 = 1
+		puts    int
+	)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.Method {
+		case http.MethodHead:
+			w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			w.WriteHeader(http.StatusOK)
+		case http.MethodGet:
+			w.Header().Set("Content-Length", strconv.Itoa(len(content)))
+			w.Header().Set("X-Dat9-IsDir", "false")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			_, _ = w.Write(content)
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			if got := r.Header.Get("X-Dat9-Expected-Revision"); got != "1" {
+				t.Errorf("expected revision header = %q, want 1", got)
+			}
+			puts++
+			rev++
+			content = append(content[:0], body...)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": rev})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1024)
+	opts := &MountOptions{FlushDebounce: 0, SyncMode: SyncStrict, WritePolicy: WritePolicyCloseSync}
+	opts.setDefaults()
+	fs := NewDat9FS(c, opts)
+	shadow, err := NewShadowStore(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	ino := fs.inodes.Lookup(path, false, int64(len(initial)), time.Now())
+	fs.inodes.UpdateRevision(ino, 1)
+	fs.inodes.UpdateSize(ino, int64(len(initial)))
+
+	var writeOut gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_WRONLY | syscall.O_TRUNC),
+	}, &writeOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open truncate status = %v, want OK", st)
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       writeOut.Fh,
+		Offset:   0,
+	}, updated); st != gofuse.OK {
+		t.Fatalf("Write status = %v, want OK", st)
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       writeOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Flush status = %v, want OK", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       writeOut.Fh,
+	})
+
+	var readOut gofuse.OpenOut
+	st = fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &readOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open read status = %v, want OK", st)
+	}
+	buf := make([]byte, 64)
+	result, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Fh:       readOut.Fh,
+		Offset:   0,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read status = %v, want OK", st)
+	}
+	got, _ := result.Bytes(buf)
+	if !bytes.Equal(got, updated) {
+		t.Fatalf("Read = %q, want %q", got, updated)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if puts != 1 {
+		t.Fatalf("PUT calls = %d, want 1", puts)
+	}
+	if !bytes.Equal(content, updated) || rev != 2 {
+		t.Fatalf("server content/rev = %q/%d, want %q/2", content, rev, updated)
+	}
+}
+
 func TestWriteSyncUploadsBeforeWriteReturns(t *testing.T) {
 	var putCalls atomic.Int32
 	var uploaded []byte

--- a/pkg/fuse/writeback_test.go
+++ b/pkg/fuse/writeback_test.go
@@ -1353,11 +1353,15 @@ func TestCloseSyncOpenTruncateOverwriteReadSeesLatestBytes(t *testing.T) {
 	}, updated); st != gofuse.OK {
 		t.Fatalf("Write status = %v, want OK", st)
 	}
+	beforeFlushNotify := fs.notifyCount.Load()
 	if st := fs.Flush(nil, &gofuse.FlushIn{
 		InHeader: gofuse.InHeader{NodeId: ino},
 		Fh:       writeOut.Fh,
 	}); st != gofuse.OK {
 		t.Fatalf("Flush status = %v, want OK", st)
+	}
+	if got := fs.notifyCount.Load() - beforeFlushNotify; got != 1 {
+		t.Fatalf("close-sync truncate overwrite flush sent %d inode invalidations, want 1", got)
 	}
 	fs.Release(nil, &gofuse.ReleaseIn{
 		InHeader: gofuse.InHeader{NodeId: ino},


### PR DESCRIPTION
## Summary
- prevent dirty writeback handles from adopting a newer BaseRev without proving payload generation matches
- bind CommitQueue entries to writeback generation and add durable watermark/fence checks
- block stale SQLite sidecar immediate remote-sync payloads from overwriting newer revisions

## Tests
- go test ./pkg/fuse -run 'WritebackGeneration|SQLite|CommitQueue'
- race subset for writeback generation fence
- pkg/fuse full suite passes except known local mount_wait environment skips/failures

## Scope
This fixes the correctness blocker where old SQLite sidecar/WAL payload could be committed with a fresh BaseRev and overwrite a newer revision. It does not claim to fix the separate SQLite WAL O(n²) fsync write-amplification performance issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented outdated file changes from overwriting newer committed content.
  - Stale uploads now fail with a conflict instead of being silently accepted.
  - Improved handling of simultaneous edits, streamed uploads, SQLite journal changes, and delayed write-back operations.
  - Prevented conflict resolution from automatically favoring outdated data.
  - Preserved newer changes during temporary staging cleanup.
  - Improved read consistency after synchronous writes and closes.

- **Reliability**
  - Enhanced batched, recovered, and shadow-backed upload consistency.
  - Added safeguards to ensure uploaded content matches the latest staged version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->