### PR TITLE
feat(cli): add fs setmeta command and show description in fs stat

### DIFF
--- a/cmd/drive9/cli/setmeta.go
+++ b/cmd/drive9/cli/setmeta.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/mem9-ai/drive9/pkg/backend"
+	"github.com/mem9-ai/drive9/pkg/client"
+)
+
+// SetMeta updates tags and/or description of an existing remote file without
+// rewriting its content.
+func SetMeta(c *client.Client, args []string) error {
+	authLocal, args, err := peelObjectAuth(args)
+	if err != nil {
+		return err
+	}
+	defer withObjectAuthLocal(authLocal)()
+
+	var tags map[string]string
+	tagsSet := false
+	clearTags := false
+	var description string
+	descriptionSet := false
+	clearDescription := false
+
+	var positional []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		switch {
+		case a == "--":
+			positional = append(positional, args[i+1:]...)
+			i = len(args)
+		case a == "--tag":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--tag requires argument")
+			}
+			i++
+			tags, err = parseAndMergeTag(tags, args[i])
+			if err != nil {
+				return err
+			}
+			tagsSet = true
+		case strings.HasPrefix(a, "--tag="):
+			tags, err = parseAndMergeTag(tags, strings.TrimPrefix(a, "--tag="))
+			if err != nil {
+				return err
+			}
+			tagsSet = true
+		case a == "--clear-tags":
+			clearTags = true
+		case a == "--description":
+			if i+1 >= len(args) {
+				return fmt.Errorf("--description requires argument")
+			}
+			i++
+			description = args[i]
+			descriptionSet = true
+		case strings.HasPrefix(a, "--description="):
+			description = strings.TrimPrefix(a, "--description=")
+			descriptionSet = true
+		case a == "--clear-description":
+			clearDescription = true
+		case strings.HasPrefix(a, "-"):
+			return fmt.Errorf("unknown flag %q", a)
+		default:
+			positional = append(positional, a)
+		}
+	}
+	if tagsSet && clearTags {
+		return fmt.Errorf("--tag and --clear-tags are mutually exclusive")
+	}
+	if descriptionSet && clearDescription {
+		return fmt.Errorf("--description and --clear-description are mutually exclusive")
+	}
+	if !tagsSet && !clearTags && !descriptionSet && !clearDescription {
+		return fmt.Errorf("usage: drive9 fs setmeta [--tag key=value]... [--clear-tags] [--description <text>] [--clear-description] <path>")
+	}
+	if len(positional) != 1 {
+		return fmt.Errorf("usage: drive9 fs setmeta [--tag key=value]... [--clear-tags] [--description <text>] [--clear-description] <path>")
+	}
+	if descriptionSet && utf8.RuneCountInString(description) > backend.MaxDescriptionLen {
+		return fmt.Errorf("description exceeds %d characters", backend.MaxDescriptionLen)
+	}
+
+	h, err := fsHandleForArg(c, positional[0])
+	if err != nil {
+		return err
+	}
+	if err := requireCapOnHandle(h, CapWrite, "setmeta"); err != nil {
+		return err
+	}
+	c, path := h.Client, h.Path
+
+	var opts client.SetMetadataOptions
+	if tagsSet || clearTags {
+		if tags == nil {
+			tags = map[string]string{}
+		}
+		opts.Tags = tags
+	}
+	if descriptionSet || clearDescription {
+		opts.Description = &description
+	}
+	return c.SetMetadata(path, opts)
+}

--- a/cmd/drive9/cli/setmeta.go
+++ b/cmd/drive9/cli/setmeta.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"unicode/utf8"
@@ -12,6 +13,7 @@ import (
 // SetMeta updates tags and/or description of an existing remote file without
 // rewriting its content.
 func SetMeta(c *client.Client, args []string) error {
+	const usage = "usage: drive9 fs setmeta [--tag key=value]... [--clear-tags] [--description <text>] [--clear-description] <path>"
 	authLocal, args, err := peelObjectAuth(args)
 	if err != nil {
 		return err
@@ -75,10 +77,10 @@ func SetMeta(c *client.Client, args []string) error {
 		return fmt.Errorf("--description and --clear-description are mutually exclusive")
 	}
 	if !tagsSet && !clearTags && !descriptionSet && !clearDescription {
-		return fmt.Errorf("usage: drive9 fs setmeta [--tag key=value]... [--clear-tags] [--description <text>] [--clear-description] <path>")
+		return errors.New(usage)
 	}
 	if len(positional) != 1 {
-		return fmt.Errorf("usage: drive9 fs setmeta [--tag key=value]... [--clear-tags] [--description <text>] [--clear-description] <path>")
+		return errors.New(usage)
 	}
 	if descriptionSet && utf8.RuneCountInString(description) > backend.MaxDescriptionLen {
 		return fmt.Errorf("description exceeds %d characters", backend.MaxDescriptionLen)
@@ -88,8 +90,18 @@ func SetMeta(c *client.Client, args []string) error {
 	if err != nil {
 		return err
 	}
-	if err := requireCapOnHandle(h, CapWrite, "setmeta"); err != nil {
-		return err
+	// Object backends advertise CapWrite but carry no drive9 client and have
+	// no file metadata; gate on the metadata caps so object URIs fail closed
+	// instead of dereferencing a nil client.
+	if tagsSet || clearTags {
+		if err := requireCapOnHandle(h, CapTags, "setmeta"); err != nil {
+			return err
+		}
+	}
+	if descriptionSet || clearDescription {
+		if err := requireCapOnHandle(h, CapDescription, "setmeta"); err != nil {
+			return err
+		}
 	}
 	c, path := h.Client, h.Path
 

--- a/cmd/drive9/cli/setmeta_test.go
+++ b/cmd/drive9/cli/setmeta_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mem9-ai/drive9/pkg/backend"
 	"github.com/mem9-ai/drive9/pkg/client"
 )
 
@@ -83,6 +84,69 @@ func TestSetMetaValidation(t *testing.T) {
 		if err := SetMeta(c, args); err == nil {
 			t.Fatalf("SetMeta(%v) succeeded, want error", args)
 		}
+	}
+}
+
+func TestSetMetaOmitsUnsetFields(t *testing.T) {
+	cases := []struct {
+		name        string
+		args        []string
+		wantTags    bool
+		wantDescKey bool
+	}{
+		{"description only omits tags", []string{"--description", "x", "/a.txt"}, false, true},
+		{"tags only omit description", []string{"--tag", "a=b", "/a.txt"}, true, false},
+		{"description= empty clears", []string{"--description=", "/a.txt"}, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotBody []byte
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				gotBody, _ = io.ReadAll(r.Body)
+				_, _ = w.Write([]byte(`{"status":"ok"}`))
+			}))
+			defer srv.Close()
+
+			c := client.New(srv.URL, "")
+			if err := SetMeta(c, tc.args); err != nil {
+				t.Fatalf("SetMeta: %v", err)
+			}
+			var body map[string]json.RawMessage
+			if err := json.Unmarshal(gotBody, &body); err != nil {
+				t.Fatalf("decode body: %v", err)
+			}
+			_, hasTags := body["tags"]
+			_, hasDesc := body["description"]
+			if hasTags != tc.wantTags || hasDesc != tc.wantDescKey {
+				t.Fatalf("body keys: tags=%v description=%v, want tags=%v description=%v (body %s)",
+					hasTags, hasDesc, tc.wantTags, tc.wantDescKey, gotBody)
+			}
+		})
+	}
+}
+
+// Object-store URIs have no drive9 client behind them; setmeta must fail
+// closed with an unsupported-capability error instead of panicking.
+func TestSetMetaRejectsObjectURI(t *testing.T) {
+	c := client.New("http://127.0.0.1:0", "")
+	err := SetMeta(c, []string{"--auth=local", "--tag", "a=b", "s3://bucket/key"})
+	if err == nil {
+		t.Fatal("SetMeta on s3:// URI succeeded, want fail-closed error")
+	}
+	if !strings.Contains(err.Error(), `backend "s3" does not support tags`) {
+		t.Fatalf("SetMeta on s3:// err = %v, want unsupported-tags error", err)
+	}
+	err = SetMeta(c, []string{"--auth=local", "--description", "x", "s3://bucket/key"})
+	if err == nil || !strings.Contains(err.Error(), `backend "s3" does not support description`) {
+		t.Fatalf("SetMeta --description on s3:// err = %v, want unsupported-description error", err)
+	}
+}
+
+func TestSetMetaDescriptionTooLong(t *testing.T) {
+	c := client.New("http://127.0.0.1:0", "")
+	long := strings.Repeat("x", backend.MaxDescriptionLen+1)
+	if err := SetMeta(c, []string{"--description", long, "/a.txt"}); err == nil {
+		t.Fatal("SetMeta with oversized description succeeded, want error")
 	}
 }
 

--- a/cmd/drive9/cli/setmeta_test.go
+++ b/cmd/drive9/cli/setmeta_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/drive9/pkg/client"
+)
+
+func TestSetMetaSendsTagsAndDescription(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		gotBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","revision":3}`))
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	if err := SetMeta(c, []string{"--tag", "owner=alice", "--tag=env=prod", "--description", "hello", "/a.txt"}); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/fs/a.txt" || gotQuery != "setmeta=1" {
+		t.Fatalf("request = %s %s?%s, want POST /v1/fs/a.txt?setmeta=1", gotMethod, gotPath, gotQuery)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(gotBody, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	tags, ok := body["tags"].(map[string]any)
+	if !ok || tags["owner"] != "alice" || tags["env"] != "prod" {
+		t.Fatalf("body tags = %v", body["tags"])
+	}
+	if body["description"] != "hello" {
+		t.Fatalf("body description = %v", body["description"])
+	}
+}
+
+func TestSetMetaClearSendsEmptyValues(t *testing.T) {
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	if err := SetMeta(c, []string{"--clear-tags", "--clear-description", "/a.txt"}); err != nil {
+		t.Fatalf("SetMeta: %v", err)
+	}
+	var body map[string]json.RawMessage
+	if err := json.Unmarshal(gotBody, &body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if string(body["tags"]) != `{}` {
+		t.Fatalf("tags = %s, want {}", body["tags"])
+	}
+	if string(body["description"]) != `""` {
+		t.Fatalf("description = %s, want empty string", body["description"])
+	}
+}
+
+func TestSetMetaValidation(t *testing.T) {
+	c := client.New("http://127.0.0.1:0", "")
+	cases := [][]string{
+		{"/a.txt"},               // nothing to update
+		{"--tag", "owner=alice"}, // missing path
+		{"--tag", "owner=alice", "--clear-tags", "/a"}, // conflicting tag flags
+		{"--description", "x", "--clear-description", "/a"},
+		{"--tag", "bad", "/a.txt"},                 // missing '='
+		{"--tag", "a=b", "--tag", "a=c", "/a.txt"}, // duplicate key
+		{"--bogus", "/a.txt"},
+	}
+	for _, args := range cases {
+		if err := SetMeta(c, args); err == nil {
+			t.Fatalf("SetMeta(%v) succeeded, want error", args)
+		}
+	}
+}
+
+func TestSetMetaServerErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"not found"}`))
+	}))
+	defer srv.Close()
+
+	c := client.New(srv.URL, "")
+	err := SetMeta(c, []string{"--tag", "a=b", "/missing.txt"})
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Fatalf("SetMeta err = %v, want not found", err)
+	}
+}

--- a/cmd/drive9/cli/stat.go
+++ b/cmd/drive9/cli/stat.go
@@ -107,6 +107,9 @@ func Stat(c *client.Client, args []string) error {
 	}
 	fmt.Printf("content_type: %s\n", m.ContentType)
 	fmt.Printf("semantic_text: %s\n", m.SemanticText)
+	if m.Description != "" {
+		fmt.Printf("description: %s\n", m.Description)
+	}
 	if m.Degraded {
 		fmt.Printf("degraded: true\n")
 	}

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -364,6 +364,8 @@ func runFS(args []string) {
 		err = cli.Mkdir(c, rest)
 	case "chmod":
 		err = cli.Chmod(c, rest)
+	case "setmeta":
+		err = cli.SetMeta(c, rest)
 	case "symlink":
 		err = cli.Symlink(c, rest)
 	case "hardlink":
@@ -499,6 +501,14 @@ commands:
   mv <old> <new>      rename/move
   mkdir <path>        create directory (parents auto-created)
   chmod <mode> <path>  change file permissions (octal, e.g. 644)
+  setmeta [flags] <path>
+                       update tags/description without re-uploading
+    --tag <key=value>  replace the tag set (repeatable)
+    --clear-tags       remove all user tags
+    --description <text>
+                       set file description
+    --clear-description
+                       remove the description
   symlink <target> <link>
                        create symbolic link
   hardlink <target> <link>

--- a/cmd/drive9/visual_help.go
+++ b/cmd/drive9/visual_help.go
@@ -546,6 +546,7 @@ func drive9VisualHelpCommands() []visualHelpCommand {
 					{Name: "mv <old> <new>", Desc: "rename or move a path"},
 					{Name: "mkdir <path>", Desc: "create a directory; parents are auto-created"},
 					{Name: "chmod <mode> <path>", Desc: "change permissions with octal mode, e.g. 644"},
+					{Name: "setmeta [flags] <path>", Desc: "update tags/description without re-uploading (--tag k=v, --clear-tags, --description, --clear-description)"},
 					{Name: "symlink <target> <link>", Desc: "create a symbolic link"},
 					{Name: "hardlink <target> <link>", Desc: "create a hard link"},
 					{Name: "rm [-r|--recursive] <path>", Desc: "remove a file or directory tree"},

--- a/examples/go-sdk-cookbook/cookbook_test.go
+++ b/examples/go-sdk-cookbook/cookbook_test.go
@@ -54,6 +54,7 @@ func ExampleClient_constructionStatusAndRawRequests() {
 func ExampleClient_filesystemCRUDAndMetadata() {
 	ctx := context.Background()
 	c := drive9.New("https://drive9.example.com", "api-key")
+	desc := "updated description"
 
 	_ = c.Mkdir("/workspace")
 	_ = c.MkdirCtx(ctx, "/workspace/", 0o755)
@@ -102,6 +103,8 @@ func ExampleClient_filesystemCRUDAndMetadata() {
 	_ = c.HardlinkCtx(ctx, "/workspace/a.txt", "/workspace/a-hardlink-ctx.txt")
 	_ = c.Chmod("/workspace/a.txt", 0o640)
 	_ = c.ChmodCtx(ctx, "/workspace/a.txt", 0o644)
+	_ = c.SetMetadata("/workspace/a.txt", drive9.SetMetadataOptions{Tags: map[string]string{"owner": "alice"}})
+	_ = c.SetMetadataCtx(ctx, "/workspace/a.txt", drive9.SetMetadataOptions{Description: &desc})
 
 	_, _ = c.SQL("select path, size_bytes from files limit 10")
 	_, _ = c.Grep("deployment checklist", "/workspace/", 20)
@@ -776,6 +779,8 @@ var coveredClientMethods = map[string]bool{
 	"SQL":                                  true,
 	"SearchJournal":                        true,
 	"SetActor":                             true,
+	"SetMetadata":                          true,
+	"SetMetadataCtx":                       true,
 	"SetQuota":                             true,
 	"SetSmallFileThresholdForTests":        true,
 	"SmallFileThreshold":                   true,

--- a/pkg/backend/semantic_tasks.go
+++ b/pkg/backend/semantic_tasks.go
@@ -141,6 +141,17 @@ func newEmbedTask(taskID, fileID string, revision int64, now time.Time) *semanti
 	}
 }
 
+// forceRequeueEmbedTaskTx guarantees a queued embed task for the current
+// revision, re-queuing terminal rows in place and resetting rows being
+// processed under an active lease (clearing the receipt fails the in-flight
+// owner's lease fence). Metadata-only updates (setmeta) change the
+// description without bumping the revision, so neither the terminal-row
+// dedupe of plain enqueue nor the active-lease exemption of ensure can
+// apply: both would leave the new description without an embedding.
+func (b *Dat9Backend) forceRequeueEmbedTaskTx(tx *sql.Tx, fileID string, revision int64) (bool, error) {
+	return b.store.ForceRequeueSemanticTaskTx(tx, newEmbedTask(b.genID(), fileID, revision, time.Now().UTC()))
+}
+
 func newImgExtractTask(taskID, fileID string, revision int64, path, contentType string, now time.Time) (*semantic.Task, error) {
 	now = now.UTC()
 	payload := semantic.ImgExtractTaskPayload{Path: path, ContentType: contentType}

--- a/pkg/backend/setmeta.go
+++ b/pkg/backend/setmeta.go
@@ -1,0 +1,127 @@
+package backend
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/pingcap/failpoint"
+
+	"github.com/mem9-ai/drive9/pkg/datastore"
+	"github.com/mem9-ai/drive9/pkg/pathutil"
+)
+
+// setmetaAfterResolveFailpoint gates the window between path→inode
+// resolution and the metadata transaction so tests can deterministically
+// delete+recreate the dentry in between.
+const setmetaAfterResolveFailpoint = "setmetaAfterResolve"
+
+// ErrSetMetadataOnDirectory is returned when file metadata (tags/description)
+// is set on a directory. Only regular files carry tags and descriptions.
+var ErrSetMetadataOnDirectory = errors.New("cannot set file metadata on a directory")
+
+// FileMetadataUpdate describes a metadata-only update of an existing file.
+// A nil Tags map leaves the tag set unchanged; a non-nil map (including an
+// empty one) replaces all tags (this store has no tag provenance column, so
+// the replace covers every tag row, matching upload-time semantics). A nil
+// Description leaves the description unchanged; a non-nil pointer sets it
+// (empty string clears).
+type FileMetadataUpdate struct {
+	Tags        map[string]string
+	Description *string
+}
+
+// SetFileMetadataCtx updates tags and/or description of an existing file
+// without rewriting its content. The file revision is left unchanged; a
+// description change re-triggers description embedding (app-managed mode
+// force-requeues a semantic task pinned to the current revision;
+// auto-embedding mode lets the database derive the new vector). It returns
+// the current revision.
+func (b *Dat9Backend) SetFileMetadataCtx(ctx context.Context, path string, upd FileMetadataUpdate) (revision int64, err error) {
+	start := time.Now()
+	defer func() { observeBackend(ctx, b.tenantID, b.tidbCloudOrgID, "set_metadata", err, start) }()
+
+	path, err = pathutil.Canonicalize(path)
+	if err != nil {
+		return 0, err
+	}
+	if path == "/" {
+		return 0, datastore.ErrInvalidRootDentry
+	}
+	resolvedPath, node, err := b.resolveNodePath(ctx, path)
+	if err != nil {
+		return 0, err
+	}
+	if node.IsDirectory {
+		return 0, ErrSetMetadataOnDirectory
+	}
+	fileID := node.InodeID
+	if fileID == "" {
+		fileID = node.FileID
+	}
+	if fileID == "" {
+		return 0, datastore.ErrNotFound
+	}
+	failpoint.InjectCall(setmetaAfterResolveFailpoint, resolvedPath)
+
+	enqueued := false
+	err = b.store.InTx(ctx, func(tx *sql.Tx) error {
+		// Fence the path→inode resolution (which happened outside this
+		// transaction): if the dentry was deleted or recreated meanwhile it
+		// now points at a different (or no) identity, and the metadata must
+		// not land on the replacement inode.
+		liveID, err := b.store.LockDentryFileIDTx(tx, resolvedPath)
+		if err != nil {
+			return err
+		}
+		if liveID != fileID {
+			return datastore.ErrRevisionConflict
+		}
+		rev, err := b.store.LockConfirmedFileRevisionTx(tx, fileID)
+		if err != nil {
+			return err
+		}
+		revision = rev
+		if upd.Tags != nil {
+			if err := b.store.ReplaceFileTagsTx(tx, fileID, upd.Tags); err != nil {
+				return err
+			}
+		}
+		if upd.Description != nil {
+			if b.UsesDatabaseAutoEmbedding() {
+				// The database owns vector state; updating the description
+				// re-derives the generated column. No embed task.
+				if err := b.store.UpdateFileDescriptionAutoEmbeddingTx(tx, fileID, *upd.Description); err != nil {
+					return err
+				}
+				return nil
+			}
+			// Lock-order contract with the embed writeback path: the task row
+			// is taken before the semantic row. The revision is intentionally
+			// unchanged, so a previously completed or in-flight embed task
+			// for this revision may already exist; force-requeue re-queues
+			// such rows in place and invalidates any in-flight owner's lease
+			// (plain enqueue would dedupe terminal rows away, ensure would
+			// leave active leases alone).
+			if b.shouldEnqueueEmbedForRevision(resolvedPath, "", "", *upd.Description) {
+				created, err := b.forceRequeueEmbedTaskTx(tx, fileID, rev)
+				if err != nil {
+					return err
+				}
+				enqueued = created
+			}
+			if err := b.store.UpdateFileDescriptionTx(tx, fileID, *upd.Description); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	if enqueued {
+		b.notifyWorkEnqueued(BackendWorkSemantic)
+	}
+	return revision, nil
+}

--- a/pkg/backend/setmeta_failpoint_test.go
+++ b/pkg/backend/setmeta_failpoint_test.go
@@ -1,0 +1,116 @@
+//go:build failpoint
+
+package backend
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/failpoint"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+
+	"github.com/mem9-ai/drive9/pkg/datastore"
+)
+
+// TestSetFileMetadataRejectsDeleteRecreateRace pins the dentry fence: when the
+// path is deleted and recreated between path→inode resolution and the
+// metadata transaction, setmeta must fail with ErrRevisionConflict and must
+// not mutate the replacement inode.
+func TestSetFileMetadataRejectsDeleteRecreateRace(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{AppSemanticTasksEnabled: true})
+	ctx := context.Background()
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(ctx, "/race.txt", []byte("old"), 0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1,
+		map[string]string{"owner": "old"}, "old description"); err != nil {
+		t.Fatal(err)
+	}
+	oldNode, err := b.Store().GetNode(ctx, "/race.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var fired atomic.Bool
+	if err := failpoint.EnableCall("github.com/mem9-ai/drive9/pkg/backend/setmetaAfterResolve", func(path string) {
+		if path != "/race.txt" || !fired.CompareAndSwap(false, true) {
+			return
+		}
+		if _, err := b.Store().DeleteFileWithRefCheck(ctx, "/race.txt"); err != nil {
+			t.Errorf("race delete: %v", err)
+			return
+		}
+		now := time.Now().UTC()
+		if err := b.Store().InsertFile(ctx, &datastore.File{
+			FileID: "f-race-new", StorageType: datastore.StorageDB9, StorageRef: "inline",
+			Revision: 1, Status: datastore.StatusConfirmed, Description: "replacement description",
+			CreatedAt: now, ConfirmedAt: &now,
+		}); err != nil {
+			t.Errorf("race recreate file: %v", err)
+			return
+		}
+		if err := b.Store().InsertNode(ctx, &datastore.FileNode{
+			NodeID: "n-race-new", Path: "/race.txt", ParentPath: "/", Name: "race.txt",
+			FileID: "f-race-new", CreatedAt: now,
+		}); err != nil {
+			t.Errorf("race recreate node: %v", err)
+		}
+	}); err != nil {
+		t.Fatalf("enable failpoint: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = failpoint.Disable("github.com/mem9-ai/drive9/pkg/backend/setmetaAfterResolve")
+	})
+
+	_, err = b.SetFileMetadataCtx(ctx, "/race.txt", FileMetadataUpdate{
+		Tags:        map[string]string{"owner": "attacker"},
+		Description: setMetaStringPtr("attacker description"),
+	})
+	if !errors.Is(err, datastore.ErrRevisionConflict) {
+		t.Fatalf("setmeta after delete+recreate err = %v, want ErrRevisionConflict", err)
+	}
+	if !fired.Load() {
+		t.Fatal("failpoint did not fire")
+	}
+
+	// The replacement inode is untouched: no user tags, original description.
+	tags, err := b.Store().GetFileTags(ctx, "f-race-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 0 {
+		t.Fatalf("replacement inode tags = %+v, want none", tags)
+	}
+	sem, err := b.Store().GetSemantic(ctx, "f-race-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sem.Description != "replacement description" {
+		t.Fatalf("replacement description = %q, want unchanged", sem.Description)
+	}
+
+	// The old (deleted) inode was not tagged either.
+	tags, err = b.Store().GetFileTags(ctx, oldNode.FileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 0 {
+		t.Fatalf("old inode tags = %+v, want none", tags)
+	}
+
+	// A retry against the live dentry succeeds on the replacement inode.
+	if _, err := b.SetFileMetadataCtx(ctx, "/race.txt", FileMetadataUpdate{
+		Tags: map[string]string{"owner": "alice"},
+	}); err != nil {
+		t.Fatalf("setmeta retry: %v", err)
+	}
+	tags, err = b.Store().GetFileTags(ctx, "f-race-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tags["owner"] != "alice" {
+		t.Fatalf("replacement inode tags after retry = %+v, want owner=alice", tags)
+	}
+}

--- a/pkg/backend/setmeta_test.go
+++ b/pkg/backend/setmeta_test.go
@@ -1,0 +1,226 @@
+package backend
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+
+	"github.com/mem9-ai/drive9/pkg/datastore"
+	"github.com/mem9-ai/drive9/pkg/semantic"
+)
+
+func setMetaStringPtr(s string) *string { return &s }
+
+// setMetaClaimableEmbedTask returns the claimable embed task, or nil when no
+// claimable task exists. The claim timestamp is nudged forward because TiDB
+// DATETIME(3) rounds available_at up to the next millisecond, which can
+// otherwise land just after time.Now().
+func setMetaClaimableEmbedTask(t *testing.T, b *Dat9Backend, now time.Time) *semantic.Task {
+	t.Helper()
+	task, found, err := b.Store().ClaimSemanticTask(context.Background(), now.Add(time.Second), time.Minute, semantic.TaskTypeEmbed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !found {
+		return nil
+	}
+	return task
+}
+
+// A description-only setmeta must re-queue the embed task for the current
+// revision even when a terminal (acked) task row for that revision already
+// exists: EnqueueSemanticTask would dedupe it away, ForceRequeueSemanticTask
+// re-queues it in place.
+func TestSetFileMetadataRequeuesCompletedEmbedTask(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{AppSemanticTasksEnabled: true})
+	ctx := context.Background()
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(ctx, "/d.txt", []byte("body"), 0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1, nil, "old description"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the worker completing the embed task for revision 1.
+	task := setMetaClaimableEmbedTask(t, b, time.Now().UTC())
+	if task == nil || task.ResourceVersion != 1 {
+		t.Fatalf("initial embed task = %+v, want queued task at revision 1", task)
+	}
+	if err := b.Store().AckSemanticTask(ctx, task.TaskID, task.Receipt); err != nil {
+		t.Fatal(err)
+	}
+
+	rev, err := b.SetFileMetadataCtx(ctx, "/d.txt", FileMetadataUpdate{Description: setMetaStringPtr("new description")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rev != 1 {
+		t.Fatalf("setmeta revision = %d, want unchanged 1", rev)
+	}
+
+	// The terminal row was re-queued for the same revision.
+	requeued := setMetaClaimableEmbedTask(t, b, time.Now().UTC())
+	if requeued == nil {
+		t.Fatal("embed task was not re-queued after description setmeta")
+	}
+	if requeued.ResourceID != task.ResourceID || requeued.ResourceVersion != 1 {
+		t.Fatalf("requeued task = %+v, want same file at revision 1", requeued)
+	}
+
+	// The stale description embedding state was cleared.
+	node, err := b.Store().GetNode(ctx, "/d.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sem, err := b.Store().GetSemantic(ctx, node.FileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sem.Description != "new description" {
+		t.Fatalf("description = %q, want %q", sem.Description, "new description")
+	}
+	if sem.DescriptionEmbeddingRevision != nil {
+		t.Fatalf("description_embedding_revision = %v, want cleared", *sem.DescriptionEmbeddingRevision)
+	}
+}
+
+// A tags-only setmeta must not touch the description or enqueue embed work.
+func TestSetFileMetadataTagsOnlyEnqueuesNothing(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{AppSemanticTasksEnabled: true})
+	ctx := context.Background()
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(ctx, "/t.txt", []byte("body"), 0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1, nil, "kept description"); err != nil {
+		t.Fatal(err)
+	}
+	// Drain the initial embed task so any new enqueue is observable.
+	task := setMetaClaimableEmbedTask(t, b, time.Now().UTC())
+	if task == nil {
+		t.Fatal("initial embed task missing")
+	}
+	if err := b.Store().AckSemanticTask(ctx, task.TaskID, task.Receipt); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := b.SetFileMetadataCtx(ctx, "/t.txt", FileMetadataUpdate{Tags: map[string]string{"owner": "alice"}}); err != nil {
+		t.Fatal(err)
+	}
+	if task := setMetaClaimableEmbedTask(t, b, time.Now().UTC()); task != nil {
+		t.Fatalf("tags-only setmeta enqueued embed task %+v", task)
+	}
+
+	node, err := b.Store().GetNode(ctx, "/t.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sem, err := b.Store().GetSemantic(ctx, node.FileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sem.Description != "kept description" {
+		t.Fatalf("description = %q, want unchanged", sem.Description)
+	}
+	tags, err := b.Store().GetFileTags(ctx, node.FileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 1 || tags["owner"] != "alice" {
+		t.Fatalf("tags = %+v, want owner=alice", tags)
+	}
+}
+
+// Clearing the description clears the embedding state and does not enqueue
+// new embed work.
+func TestSetFileMetadataClearDescriptionEnqueuesNothing(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{AppSemanticTasksEnabled: true})
+	ctx := context.Background()
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(ctx, "/c.txt", []byte("body"), 0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1, nil, "doomed description"); err != nil {
+		t.Fatal(err)
+	}
+	task := setMetaClaimableEmbedTask(t, b, time.Now().UTC())
+	if task == nil {
+		t.Fatal("initial embed task missing")
+	}
+	if err := b.Store().AckSemanticTask(ctx, task.TaskID, task.Receipt); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := b.SetFileMetadataCtx(ctx, "/c.txt", FileMetadataUpdate{Description: setMetaStringPtr("")}); err != nil {
+		t.Fatal(err)
+	}
+	if task := setMetaClaimableEmbedTask(t, b, time.Now().UTC()); task != nil {
+		t.Fatalf("clear-description setmeta enqueued embed task %+v", task)
+	}
+
+	node, err := b.Store().GetNode(ctx, "/c.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sem, err := b.Store().GetSemantic(ctx, node.FileID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sem.Description != "" || sem.DescriptionEmbeddingRevision != nil {
+		t.Fatalf("semantic = %+v, want cleared description and embedding state", sem)
+	}
+}
+
+// A description setmeta while the embed task is being processed must
+// invalidate the in-flight lease and leave the task queued again, so the new
+// description is embedded even when the old worker already wrote its vector
+// and is about to ack.
+func TestSetFileMetadataForceRequeuesInFlightEmbedTask(t *testing.T) {
+	b := newTestBackendWithOptions(t, Options{AppSemanticTasksEnabled: true})
+	ctx := context.Background()
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(ctx, "/inflight.txt", []byte("body"), 0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1, nil, "old description"); err != nil {
+		t.Fatal(err)
+	}
+	task := setMetaClaimableEmbedTask(t, b, time.Now().UTC())
+	if task == nil {
+		t.Fatal("initial embed task missing")
+	}
+	// The task is now processing under an active lease (claim held).
+
+	if _, err := b.SetFileMetadataCtx(ctx, "/inflight.txt", FileMetadataUpdate{Description: setMetaStringPtr("new description")}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The in-flight owner's lease is invalidated: ack with the old receipt
+	// must not complete the row.
+	if err := b.Store().AckSemanticTask(ctx, task.TaskID, task.Receipt); err == nil {
+		t.Fatal("ack with invalidated receipt succeeded, want error")
+	}
+	// The row is claimable again for the same revision.
+	requeued := setMetaClaimableEmbedTask(t, b, time.Now().UTC())
+	if requeued == nil {
+		t.Fatal("in-flight embed task was not re-queued after description setmeta")
+	}
+	if requeued.ResourceVersion != 1 || requeued.Receipt == task.Receipt {
+		t.Fatalf("requeued task = %+v, want revision 1 under a fresh lease", requeued)
+	}
+}
+
+func TestSetFileMetadataErrors(t *testing.T) {
+	b := newTestBackend(t)
+	ctx := context.Background()
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(ctx, "/f.txt", []byte("body"), 0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.SetFileMetadataCtx(ctx, "/missing.txt", FileMetadataUpdate{Tags: map[string]string{"a": "b"}}); !errors.Is(err, datastore.ErrNotFound) {
+		t.Fatalf("missing file err = %v, want ErrNotFound", err)
+	}
+	if _, err := b.SetFileMetadataCtx(ctx, "/", FileMetadataUpdate{Tags: map[string]string{"a": "b"}}); !errors.Is(err, datastore.ErrInvalidRootDentry) {
+		t.Fatalf("root err = %v, want ErrInvalidRootDentry", err)
+	}
+	if err := b.Store().InsertNode(ctx, &datastore.FileNode{
+		NodeID: "n-dir", Path: "/dir", ParentPath: "/", Name: "dir", IsDirectory: true, CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := b.SetFileMetadataCtx(ctx, "/dir", FileMetadataUpdate{Tags: map[string]string{"a": "b"}}); !errors.Is(err, ErrSetMetadataOnDirectory) {
+		t.Fatalf("directory err = %v, want ErrSetMetadataOnDirectory", err)
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -384,6 +384,7 @@ type StatMetadataResult struct {
 	Mtime        *int64            `json:"mtime,omitempty"` // Unix seconds when known
 	ContentType  string            `json:"content_type"`
 	SemanticText string            `json:"semantic_text"`
+	Description  string            `json:"description"`
 	Tags         map[string]string `json:"tags"`
 	Degraded     bool              `json:"degraded,omitempty"`
 }

--- a/pkg/client/setmeta.go
+++ b/pkg/client/setmeta.go
@@ -1,0 +1,65 @@
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// SetMetadataOptions selects which file metadata fields to update. A nil
+// Tags map leaves the tag set unchanged; a non-nil map (including an empty
+// one) replaces the user-owned tag set. A nil Description leaves the
+// description unchanged; a non-nil pointer sets it (empty string clears).
+type SetMetadataOptions struct {
+	Tags        map[string]string
+	Description *string
+}
+
+// setMetadataRequest is the wire body for POST /v1/fs/{path}?setmeta=1.
+// Pointer fields distinguish "absent" (leave unchanged) from "present"
+// (replace/clear).
+type setMetadataRequest struct {
+	Tags        *map[string]string `json:"tags,omitempty"`
+	Description *string            `json:"description,omitempty"`
+}
+
+// SetMetadata updates tags and/or description of an existing file without
+// rewriting its content.
+func (c *Client) SetMetadata(path string, opts SetMetadataOptions) error {
+	return c.SetMetadataCtx(context.Background(), path, opts)
+}
+
+// SetMetadataCtx updates tags and/or description of an existing file with
+// context support.
+func (c *Client) SetMetadataCtx(ctx context.Context, path string, opts SetMetadataOptions) error {
+	if opts.Tags == nil && opts.Description == nil {
+		return fmt.Errorf("setmeta: nothing to update")
+	}
+	if err := validateTags(opts.Tags); err != nil {
+		return err
+	}
+	reqBody := setMetadataRequest{Description: opts.Description}
+	if opts.Tags != nil {
+		reqBody.Tags = &opts.Tags
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url(path)+"?setmeta=1", bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return readError(resp)
+	}
+	return nil
+}

--- a/pkg/datastore/embedding_writeback.go
+++ b/pkg/datastore/embedding_writeback.go
@@ -46,6 +46,20 @@ func (s *Store) UpdateFileEmbedding(ctx context.Context, fileID string, revision
 
 // UpdateFileDescriptionEmbedding conditionally writes a description embedding for the current file revision.
 func (s *Store) UpdateFileDescriptionEmbedding(ctx context.Context, fileID string, revision int64, vector []float32) (updated bool, err error) {
+	return s.updateFileDescriptionEmbedding(ctx, fileID, revision, "", false, vector)
+}
+
+// UpdateFileDescriptionEmbeddingIfText conditionally writes a description
+// embedding only while the stored description still matches
+// expectedDescription (the text that was sent to the embedding provider).
+// Description can change without a revision bump (setmeta), so the text
+// predicate is what prevents an in-flight embed task from stamping a vector
+// for a stale description.
+func (s *Store) UpdateFileDescriptionEmbeddingIfText(ctx context.Context, fileID string, revision int64, expectedDescription string, vector []float32) (updated bool, err error) {
+	return s.updateFileDescriptionEmbedding(ctx, fileID, revision, expectedDescription, true, vector)
+}
+
+func (s *Store) updateFileDescriptionEmbedding(ctx context.Context, fileID string, revision int64, expectedDescription string, checkText bool, vector []float32) (updated bool, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "update_file_description_embedding", start, &err)
 
@@ -53,25 +67,40 @@ func (s *Store) UpdateFileDescriptionEmbedding(ctx context.Context, fileID strin
 		return false, fmt.Errorf("embedding vector is required")
 	}
 	if s.useLegacyFiles {
-		res, err := s.db.ExecContext(ctx, `UPDATE files SET description_embedding = ?, description_embedding_revision = ?
-			WHERE file_id = ? AND revision = ? AND status = 'CONFIRMED'`,
-			embedding.FormatVector(vector), revision, fileID, revision)
+		query := `UPDATE files SET description_embedding = ?, description_embedding_revision = ?
+			WHERE file_id = ? AND revision = ? AND status = 'CONFIRMED'`
+		args := []any{embedding.FormatVector(vector), revision, fileID, revision}
+		if checkText {
+			query += ` AND description <=> ?`
+			args = append(args, nullStr(expectedDescription))
+		}
+		res, err := s.db.ExecContext(ctx, query, args...)
 		if err != nil {
 			return false, err
 		}
 		rowsAffected, _ := res.RowsAffected()
 		// Always attempt semantic update regardless of legacy rowsAffected.
-		if _, err := s.db.ExecContext(ctx, `UPDATE semantic SET description_embedding = ?, description_embedding_revision = ?
-			WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND revision = ? AND status = 'CONFIRMED'`)+`)`),
-			append([]any{embedding.FormatVector(vector), revision}, append(s.scope.Args(fileID), s.scope.Args(fileID, revision)...)...)...); err != nil {
+		semQuery := `UPDATE semantic SET description_embedding = ?, description_embedding_revision = ?
+			WHERE ` + s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND revision = ? AND status = 'CONFIRMED'`)+`)`)
+		semArgs := append([]any{embedding.FormatVector(vector), revision}, append(s.scope.Args(fileID), s.scope.Args(fileID, revision)...)...)
+		if checkText {
+			semQuery += ` AND description <=> ?`
+			semArgs = append(semArgs, nullStr(expectedDescription))
+		}
+		if _, err := s.db.ExecContext(ctx, semQuery, semArgs...); err != nil {
 			return false, fmt.Errorf("update semantic description_embedding: %w", err)
 		}
 		return rowsAffected > 0, nil
 	}
 	// New tenant without legacy files: write directly to semantic.
-	res, err := s.db.ExecContext(ctx, `UPDATE semantic SET description_embedding = ?, description_embedding_revision = ?
-		WHERE `+s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND revision = ? AND status = 'CONFIRMED'`)+`)`),
-		append([]any{embedding.FormatVector(vector), revision}, append(s.scope.Args(fileID), s.scope.Args(fileID, revision)...)...)...)
+	query := `UPDATE semantic SET description_embedding = ?, description_embedding_revision = ?
+		WHERE ` + s.scope.And(`inode_id = ? AND EXISTS (SELECT 1 FROM inodes WHERE `+s.scope.And(`inode_id = ? AND revision = ? AND status = 'CONFIRMED'`)+`)`)
+	args := append([]any{embedding.FormatVector(vector), revision}, append(s.scope.Args(fileID), s.scope.Args(fileID, revision)...)...)
+	if checkText {
+		query += ` AND description <=> ?`
+		args = append(args, nullStr(expectedDescription))
+	}
+	res, err := s.db.ExecContext(ctx, query, args...)
 	if err != nil {
 		return false, fmt.Errorf("update semantic description_embedding: %w", err)
 	}

--- a/pkg/datastore/embedding_writeback_test.go
+++ b/pkg/datastore/embedding_writeback_test.go
@@ -11,6 +11,52 @@ import (
 	"github.com/mem9-ai/drive9/pkg/tenant/schema"
 )
 
+func TestUpdateFileDescriptionEmbeddingIfText(t *testing.T) {
+	s := newTestStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := s.InsertFile(ctx, &File{
+		FileID: "f-desc-text", StorageType: StorageDB9, StorageRef: "/blobs/f-desc-text",
+		Revision: 1, Status: StatusConfirmed, Description: "old description",
+		CreatedAt: now, ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Matching text writes.
+	updated, err := s.UpdateFileDescriptionEmbeddingIfText(ctx, "f-desc-text", 1, "old description", testEmbeddingVector(0.4))
+	if err != nil || !updated {
+		t.Fatalf("matching writeback updated=%v err=%v", updated, err)
+	}
+
+	// Simulate setmeta changing the description without a revision bump.
+	if err := s.InTx(ctx, func(tx *sql.Tx) error {
+		return s.UpdateFileDescriptionTx(tx, "f-desc-text", "new description")
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stale text is skipped and does not overwrite the cleared state.
+	updated, err = s.UpdateFileDescriptionEmbeddingIfText(ctx, "f-desc-text", 1, "old description", testEmbeddingVector(0.5))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if updated {
+		t.Fatal("stale description writeback succeeded")
+	}
+	file := mustFile(t, s, "f-desc-text")
+	if file.Description != "new description" || file.DescriptionEmbeddingRevision != nil {
+		t.Fatalf("file description=%q description_embedding_revision=%v, want new description and no embedding",
+			file.Description, file.DescriptionEmbeddingRevision)
+	}
+
+	// Fresh text writes again.
+	updated, err = s.UpdateFileDescriptionEmbeddingIfText(ctx, "f-desc-text", 1, "new description", testEmbeddingVector(0.6))
+	if err != nil || !updated {
+		t.Fatalf("fresh writeback updated=%v err=%v", updated, err)
+	}
+}
+
 func TestUpdateFileEmbedding(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now().UTC()

--- a/pkg/datastore/semantic.go
+++ b/pkg/datastore/semantic.go
@@ -65,6 +65,65 @@ func (s *Store) updateSemanticNoEmbedTx(db execer, inodeID string, contentText, 
 	return err
 }
 
+// LockConfirmedFileRevisionTx locks the confirmed inode row for fileID inside
+// an existing transaction and returns its current revision.
+func (s *Store) LockConfirmedFileRevisionTx(db execer, fileID string) (int64, error) {
+	var rev int64
+	if err := db.QueryRow(`SELECT revision FROM inodes WHERE `+s.scope.And(`inode_id = ? AND status = 'CONFIRMED'`)+` FOR UPDATE`, s.scope.Args(fileID)...).Scan(&rev); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return 0, ErrNotFound
+		}
+		return 0, fmt.Errorf("read current revision: %w", err)
+	}
+	return rev, nil
+}
+
+// UpdateFileDescriptionTx updates only the description of a confirmed file,
+// clearing the description embedding so app-managed semantic processing
+// recomputes it. Callers that serialize against concurrent content writes
+// must hold the inode lock (LockConfirmedFileRevisionTx) first.
+func (s *Store) UpdateFileDescriptionTx(db execer, fileID, description string) error {
+	return s.updateFileDescriptionTx(db, fileID, description, false)
+}
+
+// UpdateFileDescriptionAutoEmbeddingTx updates only the description of a
+// confirmed file without touching vector columns. Auto-embedding mode relies
+// on the database to derive vectors from description. Callers that serialize
+// against concurrent content writes must hold the inode lock
+// (LockConfirmedFileRevisionTx) first.
+func (s *Store) UpdateFileDescriptionAutoEmbeddingTx(db execer, fileID, description string) error {
+	return s.updateFileDescriptionTx(db, fileID, description, true)
+}
+
+func (s *Store) updateFileDescriptionTx(db execer, fileID, description string, autoEmbedding bool) error {
+	if s.useLegacyFiles {
+		query := `UPDATE files SET description = ?`
+		if !autoEmbedding {
+			query += `, description_embedding = NULL, description_embedding_revision = NULL`
+		}
+		query += ` WHERE file_id = ?`
+		if _, err := db.Exec(query, nullStr(description), fileID); err != nil {
+			return err
+		}
+	}
+	if autoEmbedding {
+		if _, err := db.Exec(`UPDATE semantic SET description = ?
+			WHERE `+s.scope.And(`inode_id = ?`),
+			append([]any{nullStr(description)}, s.scope.Args(fileID)...)...); err != nil {
+			return err
+		}
+		return nil
+	}
+	if _, err := db.Exec(`UPDATE semantic SET
+		description = ?,
+		description_embedding = NULL, description_embedding_revision = NULL
+		WHERE `+s.scope.And(`inode_id = ?`),
+		append([]any{nullStr(description)}, s.scope.Args(fileID)...)...); err != nil {
+		return err
+	}
+	return nil
+}
+
 func scanSemantic(row *sql.Row) (*Semantic, error) {
 	var sem Semantic
 	var contentText, description sql.NullString

--- a/pkg/datastore/semantic_tasks.go
+++ b/pkg/datastore/semantic_tasks.go
@@ -177,7 +177,22 @@ func (s *Store) enqueueSemanticTask(db execer, task *semantic.Task) (bool, error
 	return false, err
 }
 
+// ForceRequeueSemanticTaskTx is EnsureSemanticTaskQueuedTx except that a row
+// being processed under an active lease is also reset to queued: clearing the
+// receipt invalidates the in-flight owner's lease fence, so its
+// writeback/ack/retry become no-ops and the queued row re-processes with
+// fresh state. Used by metadata-only updates (setmeta) that change the
+// description without bumping the revision, where the revision check alone
+// cannot invalidate in-flight embed work.
+func (s *Store) ForceRequeueSemanticTaskTx(tx *sql.Tx, task *semantic.Task) (bool, error) {
+	return s.ensureSemanticTaskQueuedTxForce(tx, task, true)
+}
+
 func (s *Store) ensureSemanticTaskQueuedTx(tx *sql.Tx, task *semantic.Task) (bool, error) {
+	return s.ensureSemanticTaskQueuedTxForce(tx, task, false)
+}
+
+func (s *Store) ensureSemanticTaskQueuedTxForce(tx *sql.Tx, task *semantic.Task, force bool) (bool, error) {
 	if task == nil {
 		return false, fmt.Errorf("semantic task is required")
 	}
@@ -200,7 +215,7 @@ func (s *Store) ensureSemanticTaskQueuedTx(tx *sql.Tx, task *semantic.Task) (boo
 	if err != nil {
 		return false, err
 	}
-	if existing.Status == semantic.TaskProcessing && existing.LeaseUntil != nil && existing.LeaseUntil.After(now) {
+	if !force && existing.Status == semantic.TaskProcessing && existing.LeaseUntil != nil && existing.LeaseUntil.After(now) {
 		return false, nil
 	}
 

--- a/pkg/datastore/store.go
+++ b/pkg/datastore/store.go
@@ -1740,6 +1740,28 @@ func (s *Store) StatTx(ctx context.Context, db execer, path string) (out *NodeWi
 	return scanNodeWithFileWithBlob(row)
 }
 
+// LockDentryFileIDTx locks the file_nodes row for path inside an existing
+// transaction and returns the dentry's current file identity
+// (COALESCE(inode_id, file_id)). It returns ErrNotFound when the dentry does
+// not exist. Callers use it to fence path→inode resolution races: a dentry
+// deleted and recreated after resolution points at a different identity.
+func (s *Store) LockDentryFileIDTx(db execer, path string) (string, error) {
+	var id sql.NullString
+	err := db.QueryRow(`SELECT COALESCE(inode_id, file_id) FROM file_nodes WHERE `+
+		s.scope.And(`path_hash = ? AND path = ?`)+` FOR UPDATE`,
+		s.scope.Args(fileNodePathHash(path), path)...).Scan(&id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return "", ErrNotFound
+		}
+		return "", err
+	}
+	if !id.Valid || id.String == "" {
+		return "", ErrNotFound
+	}
+	return id.String, nil
+}
+
 func (s *Store) StatPathFallback(ctx context.Context, primaryPath, fallbackPath string) (out *NodeWithFile, err error) {
 	start := time.Now()
 	defer observeStoreOp(ctx, "stat_path_fallback", start, &err)

--- a/pkg/datastore/store_test.go
+++ b/pkg/datastore/store_test.go
@@ -705,6 +705,103 @@ func TestReplaceFileTagsTxAndGetFileTags(t *testing.T) {
 	}
 }
 
+func TestUpdateFileDescriptionTxClearsDescriptionEmbedding(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now().UTC()
+	if err := s.InsertFile(context.Background(), &File{
+		FileID: "f-desc", StorageType: StorageDB9, StorageRef: "/blobs/f-desc",
+		Revision: 2, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+		Description: "old description",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	updated, err := s.UpdateFileDescriptionEmbedding(context.Background(), "f-desc", 2, testEmbeddingVector(0.1, 0.2, 0.3))
+	if err != nil || !updated {
+		t.Fatalf("seed description embedding: updated=%v err=%v", updated, err)
+	}
+
+	if err := s.InTx(context.Background(), func(tx *sql.Tx) error {
+		if _, err := s.LockConfirmedFileRevisionTx(tx, "f-desc"); err != nil {
+			return err
+		}
+		return s.UpdateFileDescriptionTx(tx, "f-desc", "new description")
+	}); err != nil {
+		t.Fatalf("UpdateFileDescriptionTx: %v", err)
+	}
+
+	sem, err := s.GetSemantic(context.Background(), "f-desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sem.Description != "new description" {
+		t.Fatalf("description = %q, want %q", sem.Description, "new description")
+	}
+	if sem.DescriptionEmbeddingRevision != nil {
+		t.Fatalf("description_embedding_revision = %v, want cleared", *sem.DescriptionEmbeddingRevision)
+	}
+	if got := mustFile(t, s, "f-desc").Revision; got != 2 {
+		t.Fatalf("revision = %d, want unchanged 2", got)
+	}
+
+	// Clearing the description stores NULL.
+	if err := s.InTx(context.Background(), func(tx *sql.Tx) error {
+		return s.UpdateFileDescriptionTx(tx, "f-desc", "")
+	}); err != nil {
+		t.Fatalf("UpdateFileDescriptionTx(clear): %v", err)
+	}
+	sem, err = s.GetSemantic(context.Background(), "f-desc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sem.Description != "" {
+		t.Fatalf("description after clear = %q, want empty", sem.Description)
+	}
+
+	// Unknown file is reported by the revision lock.
+	if err := s.InTx(context.Background(), func(tx *sql.Tx) error {
+		_, err := s.LockConfirmedFileRevisionTx(tx, "f-missing")
+		return err
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("LockConfirmedFileRevisionTx(missing) err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestLockDentryFileIDTx(t *testing.T) {
+	s := newTestStore(t)
+	now := time.Now()
+	if err := s.InsertFile(context.Background(), &File{
+		FileID: "f-dentry", StorageType: StorageDB9, StorageRef: "inline",
+		Revision: 1, Status: StatusConfirmed, CreatedAt: now, ConfirmedAt: &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := s.InsertNode(context.Background(), &FileNode{
+		NodeID: "n-dentry", Path: "/dentry.txt", ParentPath: "/", Name: "dentry.txt",
+		FileID: "f-dentry", CreatedAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var id string
+	if err := s.InTx(context.Background(), func(tx *sql.Tx) error {
+		var err error
+		id, err = s.LockDentryFileIDTx(tx, "/dentry.txt")
+		return err
+	}); err != nil {
+		t.Fatalf("LockDentryFileIDTx: %v", err)
+	}
+	if id != "f-dentry" {
+		t.Fatalf("dentry identity = %q, want f-dentry", id)
+	}
+
+	if err := s.InTx(context.Background(), func(tx *sql.Tx) error {
+		_, err := s.LockDentryFileIDTx(tx, "/missing.txt")
+		return err
+	}); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("LockDentryFileIDTx(missing) err = %v, want ErrNotFound", err)
+	}
+}
+
 func TestReplaceFileTagsByPrefixTxPreservesOtherTags(t *testing.T) {
 	s := newTestStore(t)
 	now := time.Now()

--- a/pkg/server/fs_authorization_test.go
+++ b/pkg/server/fs_authorization_test.go
@@ -650,6 +650,7 @@ func TestC2aDispatcherWriteSideAllowed(t *testing.T) {
 			{http.MethodPost, "rename=1"},
 			{http.MethodPost, "mkdir=1"},
 			{http.MethodPost, "mkdir=1&mode=755"},
+			{http.MethodPost, "setmeta=1"},
 			{http.MethodPost, "create=1"},
 			{http.MethodPost, "symlink=1"},
 		}

--- a/pkg/server/fs_setmeta.go
+++ b/pkg/server/fs_setmeta.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"unicode/utf8"
+
+	"github.com/mem9-ai/drive9/pkg/backend"
+	"github.com/mem9-ai/drive9/pkg/datastore"
+	"github.com/mem9-ai/drive9/pkg/logger"
+	"github.com/mem9-ai/drive9/pkg/tagutil"
+)
+
+// maxSetMetaBodyBytes caps the setmeta request body. The payload is a small
+// JSON object ({tags, description}); even a large tag map with maximum-length
+// keys/values and a maximum-length description stays well under this limit.
+const maxSetMetaBodyBytes = 1 << 20
+
+type setFileMetadataRequest struct {
+	// Tags replaces the tag set when present (null/absent leaves tags
+	// unchanged; an empty object clears all tags).
+	Tags map[string]string `json:"tags"`
+	// Description sets the description when present (null/absent leaves it
+	// unchanged; an empty string clears it).
+	Description *string `json:"description"`
+}
+
+func (s *Server) handleSetMeta(w http.ResponseWriter, r *http.Request, path string) {
+	if !authorizeFS(w, r, FSOpWrite, path) {
+		return
+	}
+	b := backendFromRequest(r)
+	if b == nil {
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "setmeta_missing_scope", "path", path)...)
+		errJSON(w, http.StatusUnauthorized, "missing tenant scope")
+		return
+	}
+	var req setFileMetadataRequest
+	if err := json.NewDecoder(http.MaxBytesReader(w, r.Body, maxSetMetaBodyBytes)).Decode(&req); err != nil {
+		var maxErr *http.MaxBytesError
+		if errors.As(err, &maxErr) {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "setmeta_body_too_large", "path", path, "max", maxSetMetaBodyBytes)...)
+			errJSON(w, http.StatusRequestEntityTooLarge, "request body too large")
+			return
+		}
+		logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "setmeta_bad_body", "path", path, "error", err)...)
+		errJSON(w, http.StatusBadRequest, "invalid request body: "+err.Error())
+		return
+	}
+	if req.Tags == nil && req.Description == nil {
+		errJSON(w, http.StatusBadRequest, "nothing to update: provide tags and/or description")
+		return
+	}
+	if req.Tags != nil {
+		if err := tagutil.ValidateMap(req.Tags); err != nil {
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "setmeta_invalid_tags", "path", path, "error", err)...)
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+	}
+	if req.Description != nil && utf8.RuneCountInString(*req.Description) > backend.MaxDescriptionLen {
+		errJSON(w, http.StatusBadRequest, fmt.Sprintf("description exceeds %d characters", backend.MaxDescriptionLen))
+		return
+	}
+	revision, err := b.SetFileMetadataCtx(r.Context(), path, backend.FileMetadataUpdate{Tags: req.Tags, Description: req.Description})
+	if err != nil {
+		if errors.Is(err, datastore.ErrNotFound) {
+			errJSON(w, http.StatusNotFound, "not found")
+			return
+		}
+		if errors.Is(err, datastore.ErrRevisionConflict) {
+			// The dentry was delete+recreated between path resolution and the
+			// update transaction; the client can retry against the new file.
+			logger.Warn(r.Context(), "server_event", eventFields(r.Context(), "setmeta_revision_conflict", "path", path, "detail", err.Error())...)
+			errJSON(w, http.StatusConflict, err.Error())
+			return
+		}
+		if errors.Is(err, backend.ErrSetMetadataOnDirectory) {
+			errJSON(w, http.StatusBadRequest, err.Error())
+			return
+		}
+		if errJSONInvalidRootDentry(w, err) {
+			return
+		}
+		logger.Error(r.Context(), "server_event", eventFields(r.Context(), "setmeta_failed", "path", path, "error", err)...)
+		writeBackendError(w, r, err)
+		return
+	}
+	logger.Info(r.Context(), "server_event", eventFields(r.Context(), "setmeta_ok", "path", path)...)
+	s.publishEvent(r, path, "setmeta")
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": revision})
+}

--- a/pkg/server/fs_setmeta_failpoint_test.go
+++ b/pkg/server/fs_setmeta_failpoint_test.go
@@ -1,0 +1,122 @@
+//go:build failpoint
+
+package server
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pingcap/failpoint"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+
+	"github.com/mem9-ai/drive9/internal/testtidb"
+	"github.com/mem9-ai/drive9/pkg/backend"
+	"github.com/mem9-ai/drive9/pkg/datastore"
+	"github.com/mem9-ai/drive9/pkg/s3client"
+)
+
+// TestSetMetaDeleteRecreateRaceReturnsConflict pins the public API behavior of
+// the dentry fence: a delete+recreate between path resolution and the
+// metadata transaction yields HTTP 409 (not 500), and the replacement inode
+// keeps its own metadata.
+func TestSetMetaDeleteRecreateRaceReturnsConflict(t *testing.T) {
+	s3Dir, err := os.MkdirTemp("", "dat9-srv-s3-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
+	initServerTenantSchema(t, testDSN)
+	store, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testtidb.ResetDB(t, store.DB())
+	t.Cleanup(func() { _ = store.Close() })
+	s3c, err := s3client.NewLocal(s3Dir, "/s3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := backend.NewWithS3(store, s3c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewWithConfig(Config{Backend: b})
+	t.Cleanup(func() { s.Close() })
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	ctx := context.Background()
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(ctx, "/race.txt", []byte("old"), 0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1,
+		map[string]string{"owner": "old"}, "old description"); err != nil {
+		t.Fatal(err)
+	}
+
+	var fired atomic.Bool
+	if err := failpoint.EnableCall("github.com/mem9-ai/drive9/pkg/backend/setmetaAfterResolve", func(path string) {
+		if path != "/race.txt" || !fired.CompareAndSwap(false, true) {
+			return
+		}
+		if _, err := store.DeleteFileWithRefCheck(ctx, "/race.txt"); err != nil {
+			t.Errorf("race delete: %v", err)
+			return
+		}
+		now := time.Now().UTC()
+		if err := store.InsertFile(ctx, &datastore.File{
+			FileID: "f-race-new", StorageType: datastore.StorageDB9, StorageRef: "inline",
+			Revision: 1, Status: datastore.StatusConfirmed, Description: "replacement description",
+			CreatedAt: now, ConfirmedAt: &now,
+		}); err != nil {
+			t.Errorf("race recreate file: %v", err)
+			return
+		}
+		if err := store.InsertNode(ctx, &datastore.FileNode{
+			NodeID: "n-race-new", Path: "/race.txt", ParentPath: "/", Name: "race.txt",
+			FileID: "f-race-new", CreatedAt: now,
+		}); err != nil {
+			t.Errorf("race recreate node: %v", err)
+		}
+	}); err != nil {
+		t.Fatalf("enable failpoint: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = failpoint.Disable("github.com/mem9-ai/drive9/pkg/backend/setmetaAfterResolve")
+	})
+
+	req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/race.txt?setmeta=1",
+		strings.NewReader(`{"tags":{"owner":"attacker"},"description":"attacker description"}`))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusConflict {
+		t.Fatalf("setmeta after delete+recreate: status = %d, want 409", resp.StatusCode)
+	}
+	if !fired.Load() {
+		t.Fatal("failpoint did not fire")
+	}
+
+	tags, err := store.GetFileTags(ctx, "f-race-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tags) != 0 {
+		t.Fatalf("replacement inode tags = %+v, want none", tags)
+	}
+	sem, err := store.GetSemantic(ctx, "f-race-new")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sem.Description != "replacement description" {
+		t.Fatalf("replacement description = %q, want unchanged", sem.Description)
+	}
+}

--- a/pkg/server/fs_setmeta_test.go
+++ b/pkg/server/fs_setmeta_test.go
@@ -1,0 +1,234 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/c4pt0r/agfs/agfs-server/pkg/filesystem"
+
+	"github.com/mem9-ai/drive9/internal/testtidb"
+	"github.com/mem9-ai/drive9/pkg/backend"
+	"github.com/mem9-ai/drive9/pkg/datastore"
+	"github.com/mem9-ai/drive9/pkg/s3client"
+)
+
+func setMetaRequest(t *testing.T, ts *httptest.Server, path, body string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs"+path+"?setmeta=1", strings.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resp
+}
+
+type setMetaStatResponse struct {
+	Revision    int64             `json:"revision"`
+	Description string            `json:"description"`
+	Tags        map[string]string `json:"tags"`
+}
+
+func statMetadata(t *testing.T, ts *httptest.Server, path string) setMetaStatResponse {
+	t.Helper()
+	resp, err := http.Get(ts.URL + "/v1/fs" + path + "?stat=1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("stat metadata: %d", resp.StatusCode)
+	}
+	var out setMetaStatResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode metadata: %v", err)
+	}
+	return out
+}
+
+func TestSetMetaUpdateTagsAndDescription(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	writeReq, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/meta.txt", strings.NewReader("hello metadata"))
+	writeReq.Header.Add("X-Dat9-Tag", "owner=alice")
+	writeReq.Header.Add("X-Dat9-Description", "initial description")
+	writeResp, err := http.DefaultClient.Do(writeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = writeResp.Body.Close()
+	if writeResp.StatusCode != http.StatusOK {
+		t.Fatalf("write: %d", writeResp.StatusCode)
+	}
+
+	before := statMetadata(t, ts, "/meta.txt")
+	if before.Tags["owner"] != "alice" || before.Description != "initial description" {
+		t.Fatalf("unexpected initial metadata: %+v", before)
+	}
+
+	// Replace tags only; description must stay unchanged.
+	resp := setMetaRequest(t, ts, "/meta.txt", `{"tags":{"owner":"bob","env":"prod"}}`)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("setmeta tags: %d", resp.StatusCode)
+	}
+	after := statMetadata(t, ts, "/meta.txt")
+	if len(after.Tags) != 2 || after.Tags["owner"] != "bob" || after.Tags["env"] != "prod" {
+		t.Fatalf("tags after setmeta: %+v", after.Tags)
+	}
+	if after.Description != "initial description" {
+		t.Fatalf("description changed unexpectedly: %q", after.Description)
+	}
+	if after.Revision != before.Revision {
+		t.Fatalf("revision bumped by setmeta: %d -> %d", before.Revision, after.Revision)
+	}
+
+	// Update description only; tags must stay unchanged.
+	resp = setMetaRequest(t, ts, "/meta.txt", `{"description":"updated description"}`)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("setmeta description: %d", resp.StatusCode)
+	}
+	after = statMetadata(t, ts, "/meta.txt")
+	if after.Description != "updated description" {
+		t.Fatalf("description after setmeta: %q", after.Description)
+	}
+	if len(after.Tags) != 2 || after.Tags["owner"] != "bob" {
+		t.Fatalf("tags changed unexpectedly: %+v", after.Tags)
+	}
+
+	// Clear both.
+	resp = setMetaRequest(t, ts, "/meta.txt", `{"tags":{},"description":""}`)
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("setmeta clear: %d", resp.StatusCode)
+	}
+	after = statMetadata(t, ts, "/meta.txt")
+	if len(after.Tags) != 0 {
+		t.Fatalf("tags after clear: %+v", after.Tags)
+	}
+	if after.Description != "" {
+		t.Fatalf("description after clear: %q", after.Description)
+	}
+}
+
+func TestSetMetaErrors(t *testing.T) {
+	s := newTestServer(t)
+	ts := httptest.NewServer(s)
+	defer ts.Close()
+
+	writeReq, _ := http.NewRequest(http.MethodPut, ts.URL+"/v1/fs/exists.txt", strings.NewReader("data"))
+	writeResp, err := http.DefaultClient.Do(writeReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = writeResp.Body.Close()
+	if writeResp.StatusCode != http.StatusOK {
+		t.Fatalf("write: %d", writeResp.StatusCode)
+	}
+
+	mkdirReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/fs/dir?mkdir=1", nil)
+	mkdirResp, err := http.DefaultClient.Do(mkdirReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = mkdirResp.Body.Close()
+	if mkdirResp.StatusCode != http.StatusOK {
+		t.Fatalf("mkdir: %d", mkdirResp.StatusCode)
+	}
+
+	cases := []struct {
+		name string
+		path string
+		body string
+		want int
+	}{
+		{"not found", "/missing.txt", `{"tags":{"a":"b"}}`, http.StatusNotFound},
+		{"empty update", "/exists.txt", `{}`, http.StatusBadRequest},
+		{"invalid tag", "/exists.txt", `{"tags":{"a=b":"v"}}`, http.StatusBadRequest},
+		{"invalid body", "/exists.txt", `not-json`, http.StatusBadRequest},
+		{"directory", "/dir", `{"tags":{"a":"b"}}`, http.StatusBadRequest},
+		{"description too long", "/exists.txt", `{"description":"` + strings.Repeat("x", backend.MaxDescriptionLen+1) + `"}`, http.StatusBadRequest},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := setMetaRequest(t, ts, tc.path, tc.body)
+			_ = resp.Body.Close()
+			if resp.StatusCode != tc.want {
+				t.Fatalf("setmeta %s: status = %d, want %d", tc.name, resp.StatusCode, tc.want)
+			}
+		})
+	}
+
+	t.Run("body too large", func(t *testing.T) {
+		resp := setMetaRequest(t, ts, "/exists.txt", `{"description":"`+strings.Repeat("x", maxSetMetaBodyBytes)+`"}`)
+		_ = resp.Body.Close()
+		if resp.StatusCode != http.StatusRequestEntityTooLarge {
+			t.Fatalf("setmeta oversized body: status = %d, want 413", resp.StatusCode)
+		}
+	})
+}
+
+// Scoped tokens may setmeta only within their write-scoped zones.
+func TestSetMetaScopedTokenZones(t *testing.T) {
+	s3Dir, err := os.MkdirTemp("", "dat9-srv-s3-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(s3Dir) })
+	initServerTenantSchema(t, testDSN)
+	store, err := datastore.Open(testDSN)
+	if err != nil {
+		t.Fatal(err)
+	}
+	testtidb.ResetDB(t, store.DB())
+	t.Cleanup(func() { _ = store.Close() })
+	s3c, err := s3client.NewLocal(s3Dir, "/s3")
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := backend.NewWithS3(store, s3c)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := NewWithConfig(Config{Backend: b})
+	t.Cleanup(func() { s.Close() })
+
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(context.Background(), "/allowed/f.txt", []byte("data"), 0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := b.WriteCtxIfRevisionWithTagsResult(context.Background(), "/denied/f.txt", []byte("data"), 0,
+		filesystem.WriteFlagCreate|filesystem.WriteFlagTruncate, -1, nil, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	scope := &TenantScope{
+		IsScoped: true,
+		Backend:  b,
+		FSScopes: []FSScope{{Prefix: "/allowed", Ops: map[FSOp]bool{FSOpRead: true, FSOpWrite: true}}},
+	}
+	doSetMeta := func(path string) int {
+		r := httptest.NewRequest(http.MethodPost, "/v1/fs"+path+"?setmeta=1", strings.NewReader(`{"tags":{"a":"b"}}`))
+		r = r.WithContext(withScope(r.Context(), scope))
+		w := httptest.NewRecorder()
+		s.handleSetMeta(w, r, path)
+		return w.Result().StatusCode
+	}
+	if got := doSetMeta("/allowed/f.txt"); got != http.StatusOK {
+		t.Fatalf("in-zone setmeta status = %d, want 200", got)
+	}
+	if got := doSetMeta("/denied/f.txt"); got != http.StatusForbidden {
+		t.Fatalf("out-of-zone setmeta status = %d, want 403", got)
+	}
+}

--- a/pkg/server/instrumentation.go
+++ b/pkg/server/instrumentation.go
@@ -596,7 +596,8 @@ func classifyFSAction(r *http.Request) string {
 		return "delete"
 	case http.MethodPost:
 		q := r.URL.Query()
-		for _, key := range []string{"append", "copy", "rename", "mkdir", "chmod", "create", "symlink", "hardlink"} {
+		// Keep the key set and order in sync with handleFS's POST dispatcher.
+		for _, key := range []string{"append", "copy", "rename", "mkdir", "chmod", "setmeta", "create", "symlink", "hardlink"} {
 			if q.Has(key) {
 				return key
 			}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1810,7 +1810,7 @@ func isScopedFSPostQueryAllowed(q url.Values) bool {
 	// no selector = deny (no handler matches the dispatcher's else branch
 	// for scoped tokens — that's "unknown POST action" which is a 400 for
 	// owner today, and we don't want to silently widen for scoped).
-	selectors := []string{"append", "copy", "rename", "mkdir", "chmod", "create", "symlink", "hardlink"}
+	selectors := []string{"append", "copy", "rename", "mkdir", "chmod", "setmeta", "create", "symlink", "hardlink"}
 	selectorCount := 0
 	var selectorKey string
 	for _, k := range selectors {
@@ -1844,6 +1844,10 @@ func isScopedFSPostQueryAllowed(q url.Values) bool {
 		// the dispatcher gate makes the policy decision explicit at the
 		// allowlist boundary.
 		return false
+	case "setmeta":
+		// handleSetMeta reads only ?setmeta; tags/description are in the
+		// JSON body.
+		return queryKeysSubsetOf(q, []string{"setmeta"})
 	case "create":
 		// handleCreate reads only ?create.
 		return queryKeysSubsetOf(q, []string{"create"})
@@ -2117,6 +2121,8 @@ func (s *Server) handleFS(w http.ResponseWriter, r *http.Request) {
 			s.handleMkdir(w, r, path)
 		} else if r.URL.Query().Has("chmod") {
 			s.handleChmod(w, r, path)
+		} else if r.URL.Query().Has("setmeta") {
+			s.handleSetMeta(w, r, path)
 		} else if r.URL.Query().Has("create") {
 			s.handleCreate(w, r, path)
 		} else if r.URL.Query().Has("symlink") {
@@ -2308,6 +2314,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 			Mtime        *int64            `json:"mtime,omitempty"`
 			ContentType  string            `json:"content_type"`
 			SemanticText string            `json:"semantic_text"`
+			Description  string            `json:"description"`
 			Tags         map[string]string `json:"tags"`
 		}{
 			IsDir: true,
@@ -2336,6 +2343,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 	var mtime *int64
 	var contentType string
 	var semanticText string
+	var description string
 	resourceID := nf.Node.NodeID
 	nlink, err := nodeLinkCount(r.Context(), b, nf)
 	if err != nil {
@@ -2356,6 +2364,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 		}
 		contentType = nf.File.ContentType
 		semanticText = nf.File.ContentText
+		description = nf.File.Description
 
 		tags, err = b.Store().GetFileTags(r.Context(), nf.File.FileID)
 		if err != nil {
@@ -2380,6 +2389,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 		Mtime        *int64            `json:"mtime,omitempty"`
 		ContentType  string            `json:"content_type"`
 		SemanticText string            `json:"semantic_text"`
+		Description  string            `json:"description"`
 		Tags         map[string]string `json:"tags"`
 	}{
 		Size:         size,
@@ -2390,6 +2400,7 @@ func (s *Server) handleStatMetadata(w http.ResponseWriter, r *http.Request, path
 		Mtime:        mtime,
 		ContentType:  contentType,
 		SemanticText: semanticText,
+		Description:  description,
 		Tags:         tags,
 	})
 }

--- a/pkg/server/tenant_worker_semantic.go
+++ b/pkg/server/tenant_worker_semantic.go
@@ -450,6 +450,7 @@ func (m *tenantWorkerManager) processEmbedTask(ctx context.Context, store *datas
 		}
 	}
 
+	descChanged := false
 	if strings.TrimSpace(file.Description) != "" {
 		vecDesc, err := m.embedder.EmbedText(ctx, file.Description)
 		if err != nil {
@@ -458,12 +459,20 @@ func (m *tenantWorkerManager) processEmbedTask(ctx context.Context, store *datas
 		if len(vecDesc) == 0 {
 			return semanticTaskOutcome{action: semanticTaskActionRetry, result: "embed_desc_empty", message: "embed description returned empty vector"}
 		}
-		descUpdated, err = store.UpdateFileDescriptionEmbedding(ctx, task.ResourceID, task.ResourceVersion, vecDesc)
+		descUpdated, err = store.UpdateFileDescriptionEmbeddingIfText(ctx, task.ResourceID, task.ResourceVersion, file.Description, vecDesc)
 		if err != nil {
 			return semanticTaskOutcome{action: semanticTaskActionRetry, result: "writeback_desc_error", message: fmt.Sprintf("write description embedding: %v", err)}
 		}
+		// setmeta changes the description without bumping the revision, so the
+		// revision check above cannot catch a description that changed while
+		// this task was in flight; the writeback text predicate does. Retry to
+		// converge on the new description.
+		descChanged = !descUpdated
 	}
 
+	if descChanged {
+		return semanticTaskOutcome{action: semanticTaskActionRetry, result: "description_changed", message: "description changed during embedding"}
+	}
 	if !contentUpdated && !descUpdated {
 		return semanticTaskOutcome{action: semanticTaskActionAck, result: "obsolete", message: "conditional_write_miss"}
 	}


### PR DESCRIPTION
## What

Add `drive9 fs setmeta` so tags and description can be updated at any time, not only at upload. Backed by the new server endpoint `POST /v1/fs/{path}?setmeta=1` (tidbcloud/fs#125).

```bash
drive9 fs setmeta :/path --tag owner=bob --tag env=prod      # replace user tag set
drive9 fs setmeta :/path --description "new desc"           # set description
drive9 fs setmeta :/path --clear-tags --clear-description    # clear both
```

## Details

- `pkg/client.SetMetadata(ctx, path, SetMetadataOptions)`: nil `Tags` / nil `Description` leave the field unchanged; empty map / empty string clear it (pointer fields on the wire distinguish absent from empty).
- Tag flags reuse `cp`'s `parseAndMergeTag` validation (key=value, dup-key rejection, tagutil rules); `--tag` vs `--clear-tags` and `--description` vs `--clear-description` are mutually exclusive; at least one operation is required.
- Capability check uses `CapWrite` (metadata write); no layer support (layer entries don't have file tag parity yet).
- `fs stat` now prints `description:` (text output, when non-empty) and includes `description` in `-o json`, matching the server's enriched stat.
- Registered in `runFS`, `fsUsage`, and visual help.

## Tests

- `cmd/drive9/cli/setmeta_test.go` (httptest): wire format (POST /v1/fs/{path}?setmeta=1 JSON body), clear semantics (`tags:{}`, `description:""`), flag validation matrix, server error propagation.
- `go build ./...`, `go test ./cmd/drive9/... ./pkg/client/`, `make lint` all clean.
- End-to-end smoke against a local drive9-server (tidbcloud/fs feat/setmeta) + TiDB: upload with `--tag`/`--description` → `fs setmeta` replace/clear → `fs stat` read-back; revision unchanged throughout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `drive9 fs setmeta` command to update file tags and descriptions without re-uploading content.
  * Supports replacing or clearing tags and descriptions with validation and clear error messages.
  * File status output now includes descriptions when available.
  * Added SDK and API support for updating file metadata.
* **Documentation**
  * Updated filesystem and visual help with `setmeta` usage and options.
  * Added metadata update examples to the Go SDK cookbook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->