### PR TITLE
fix(fuse): keep sync cache bypass through ttl

### DIFF
--- a/e2e/fuse-supervision-test.sh
+++ b/e2e/fuse-supervision-test.sh
@@ -247,9 +247,10 @@ for i in range(8):
         raise SystemExit(f"concurrent read {got!r}, want {want!r}")
 PY
 
-    # Short-window recovery: after the 2s per-inode bypass TTL expires, ordinary
-    # clean reads must still see committed bytes. This catches designs that only
-    # work while every clean reader is forced through DIRECT_IO.
+    # Short-window liveness canary: kernelCacheBypassFallbackTTL is 2s, so sleep
+    # 3s before checking post-TTL reads still see committed bytes. Content
+    # assertions here cannot prove the reader used KEEP_CACHE rather than
+    # DIRECT_IO forever; unit open-flag tests enforce that policy boundary.
     sleep 3
     got="$(tr -d "\n" <"$f")"
     [ "$got" = "o-trunc-${marker}-3" ]

--- a/e2e/fuse-supervision-test.sh
+++ b/e2e/fuse-supervision-test.sh
@@ -177,6 +177,8 @@ probe_cache_invalidation_io() {
     marker="$1"
     dir="$2"
     mkdir -p "$dir"
+    unrelated="$dir/unrelated.txt"
+    printf "unrelated-%s\n" "$marker" >"$unrelated"
 
     # O_TRUNC / shell-redirection path: the immediate close-to-open read must
     # not observe the transient 0-byte truncate image or older kernel pages.
@@ -188,6 +190,8 @@ probe_cache_invalidation_io() {
       got="$(tr -d "\n" <"$f")"
       [ "$got" = "$want" ]
     done
+    got="$(tr -d "\n" <"$unrelated")"
+    [ "$got" = "unrelated-${marker}" ]
 
     # SetAttr truncate path: exercise truncate(2) separately from open(O_TRUNC),
     # then write final bytes and immediately reopen/read.
@@ -242,6 +246,17 @@ for i in range(8):
     if got != want:
         raise SystemExit(f"concurrent read {got!r}, want {want!r}")
 PY
+
+    # Short-window recovery: after the 2s per-inode bypass TTL expires, ordinary
+    # clean reads must still see committed bytes. This catches designs that only
+    # work while every clean reader is forced through DIRECT_IO.
+    sleep 3
+    got="$(tr -d "\n" <"$f")"
+    [ "$got" = "o-trunc-${marker}-3" ]
+    got="$(tr -d "\n" <"$dst")"
+    [ "$got" = "recreated-${marker}" ]
+    got="$(tr -d "\n" <"$unrelated")"
+    [ "$got" = "unrelated-${marker}" ]
   ' _ "$marker" "$dir"
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -29,10 +29,6 @@ import (
 // candidate after discovery but before the second TryLock in candidateLoop.
 var testHookAfterSamePathDirtyHandleScan func(path string)
 
-// testHookNotifyInodeSync lets cache-boundary tests observe the production
-// synchronous notify path without mounting a real FUSE server.
-var testHookNotifyInodeSync func(ino uint64)
-
 // Dat9FS implements the go-fuse RawFileSystem interface, bridging FUSE
 // operations to the dat9 HTTP API via the Go SDK client.
 type Dat9FS struct {
@@ -323,15 +319,6 @@ type dirtyInodeState struct {
 	seq  uint64
 }
 
-type kernelCacheBypassMarker struct {
-	ino       uint64
-	path      string
-	revision  int64
-	size      int64
-	reason    string
-	expiresAt time.Time
-}
-
 type layerSymlinkState struct {
 	Target string
 	Mode   uint32
@@ -424,7 +411,6 @@ const (
 	sqliteSidecarDirtyWaitInterval = time.Millisecond
 	samePathDirtyWaitTimeout       = 250 * time.Millisecond
 	samePathDirtyWaitInterval      = time.Millisecond
-	kernelCacheBypassFallbackTTL   = 2 * time.Second
 
 	// namespaceMutationRetryTimeout bounds detached retries for idempotent-ish
 	// namespace mutations after a FUSE interrupt or transient backend error.
@@ -1707,168 +1693,6 @@ func (fs *Dat9FS) openFlagsForHandle(fh *FileHandle) uint32 {
 		return gofuse.FOPEN_DIRECT_IO
 	}
 	return flags
-}
-
-// armKernelCacheBypass records a short-lived per-inode cache-bypass marker for
-// close-to-open readers that must not trust stale kernel pages immediately
-// after a truncate-first sync commit.
-func (fs *Dat9FS) armKernelCacheBypass(ino uint64, localPath string, revision, size int64, reason string) {
-	fs.armKernelCacheBypassUntil(ino, localPath, revision, size, reason, time.Now().Add(kernelCacheBypassFallbackTTL))
-}
-
-// armKernelCacheBypassUntil is the testable form of armKernelCacheBypass with
-// an explicit expiry. Re-arming markers uses one coalesced mount-level sweeper
-// rather than one timer per commit or inode.
-func (fs *Dat9FS) armKernelCacheBypassUntil(ino uint64, localPath string, revision, size int64, reason string, expiresAt time.Time) {
-	if fs == nil || ino == 0 {
-		return
-	}
-	fs.kernelCacheBypassMu.Lock()
-	defer fs.kernelCacheBypassMu.Unlock()
-	if fs.kernelCacheBypass == nil {
-		fs.kernelCacheBypass = make(map[uint64]kernelCacheBypassMarker)
-	}
-	fs.kernelCacheBypass[ino] = kernelCacheBypassMarker{
-		ino:       ino,
-		path:      localPath,
-		revision:  revision,
-		size:      size,
-		reason:    reason,
-		expiresAt: expiresAt,
-	}
-	fs.debugf("kernel cache bypass armed path=%s ino=%d rev=%d size=%d reason=%s", localPath, ino, revision, size, reason)
-	fs.scheduleKernelCacheBypassSweepLocked(expiresAt)
-}
-
-// scheduleKernelCacheBypassSweepLocked schedules or advances the single cleanup
-// timer used to reclaim expired markers that are never reopened. Caller
-// must hold kernelCacheBypassMu.
-func (fs *Dat9FS) scheduleKernelCacheBypassSweepLocked(expiresAt time.Time) {
-	if fs == nil || expiresAt.IsZero() {
-		return
-	}
-	if fs.kernelCacheBypassSweepTimer != nil && !fs.kernelCacheBypassSweepAt.IsZero() && !expiresAt.Before(fs.kernelCacheBypassSweepAt) {
-		return
-	}
-	delay := time.Until(expiresAt)
-	if delay < 0 {
-		delay = 0
-	}
-	fs.kernelCacheBypassSweepAt = expiresAt
-	if fs.kernelCacheBypassSweepTimer == nil {
-		fs.kernelCacheBypassSweepTimer = time.AfterFunc(delay, func() {
-			fs.sweepKernelCacheBypass()
-		})
-		return
-	}
-	// Ignore Reset's boolean result deliberately: if a previous callback is
-	// already running, sweepKernelCacheBypass re-checks all current markers under
-	// the same mutex and only deletes markers whose own expiresAt has passed.
-	fs.kernelCacheBypassSweepTimer.Reset(delay)
-}
-
-// rescheduleKernelCacheBypassSweepLocked resets the single sweeper to the
-// earliest live marker, or stops it when no markers remain. Caller must hold
-// kernelCacheBypassMu.
-func (fs *Dat9FS) rescheduleKernelCacheBypassSweepLocked() {
-	var next time.Time
-	for _, marker := range fs.kernelCacheBypass {
-		if marker.expiresAt.IsZero() {
-			continue
-		}
-		if next.IsZero() || marker.expiresAt.Before(next) {
-			next = marker.expiresAt
-		}
-	}
-	if next.IsZero() {
-		if fs.kernelCacheBypassSweepTimer != nil {
-			fs.kernelCacheBypassSweepTimer.Stop()
-			fs.kernelCacheBypassSweepTimer = nil
-		}
-		fs.kernelCacheBypassSweepAt = time.Time{}
-		return
-	}
-	fs.kernelCacheBypassSweepAt = time.Time{}
-	fs.scheduleKernelCacheBypassSweepLocked(next)
-}
-
-// sweepKernelCacheBypass removes expired markers from the timer callback. A
-// stale callback is benign: every marker's current expiresAt is checked under
-// kernelCacheBypassMu before deletion, so a re-armed marker survives and the
-// sweeper reschedules itself to the next live deadline.
-func (fs *Dat9FS) sweepKernelCacheBypass() {
-	if fs == nil {
-		return
-	}
-	now := time.Now()
-	fs.kernelCacheBypassMu.Lock()
-	defer fs.kernelCacheBypassMu.Unlock()
-	fs.kernelCacheBypassSweepAt = time.Time{}
-	for ino, marker := range fs.kernelCacheBypass {
-		if marker.expiresAt.IsZero() {
-			continue
-		}
-		if now.Before(marker.expiresAt) {
-			continue
-		}
-		delete(fs.kernelCacheBypass, ino)
-		fs.debugf("kernel cache bypass expired path=%s ino=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.revision, marker.size, marker.reason)
-	}
-	fs.rescheduleKernelCacheBypassSweepLocked()
-}
-
-// clearKernelCacheBypassMarkers stops the cleanup sweeper and drops all marker
-// state during graceful shutdown.
-func (fs *Dat9FS) clearKernelCacheBypassMarkers() {
-	if fs == nil {
-		return
-	}
-	fs.kernelCacheBypassMu.Lock()
-	defer fs.kernelCacheBypassMu.Unlock()
-	if fs.kernelCacheBypassSweepTimer != nil {
-		fs.kernelCacheBypassSweepTimer.Stop()
-		fs.kernelCacheBypassSweepTimer = nil
-	}
-	fs.kernelCacheBypassSweepAt = time.Time{}
-	for ino := range fs.kernelCacheBypass {
-		delete(fs.kernelCacheBypass, ino)
-	}
-}
-
-// kernelCacheBypassActive reports whether a clean read-only open on fh should
-// temporarily bypass the kernel page cache. Expired markers are reclaimed
-// opportunistically here in addition to the timer-driven cleanup path.
-func (fs *Dat9FS) kernelCacheBypassActive(fh *FileHandle) bool {
-	if fs == nil || fh == nil || fh.Ino == 0 {
-		return false
-	}
-	now := time.Now()
-	fs.kernelCacheBypassMu.Lock()
-	defer fs.kernelCacheBypassMu.Unlock()
-	marker, ok := fs.kernelCacheBypass[fh.Ino]
-	if !ok {
-		return false
-	}
-	if !marker.expiresAt.IsZero() && now.After(marker.expiresAt) {
-		delete(fs.kernelCacheBypass, fh.Ino)
-		fs.debugf("kernel cache bypass expired path=%s ino=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.revision, marker.size, marker.reason)
-		fs.rescheduleKernelCacheBypassSweepLocked()
-		return false
-	}
-	return marker.ino == fh.Ino
-}
-
-func (fs *Dat9FS) finishSyncCommitKernelCacheBoundary(ino uint64, localPath string, revision, size int64) {
-	if fs == nil || ino == 0 {
-		return
-	}
-	// InodeNotify is best-effort: Linux may still serve stale page/attr cache
-	// immediately after a truncate-first close-sync/write-sync commit even when
-	// the notification call reports success. Keep the per-inode
-	// short-window bypass armed until its TTL expires; this remains narrower
-	// than making every clean reader on sync-durability mounts DIRECT_IO.
-	fs.armKernelCacheBypass(ino, localPath, revision, size, "sync-commit")
-	fs.notifyInodeSync(ino)
 }
 
 func (fs *Dat9FS) localEntry(localPath string, info os.FileInfo, incrementLookup bool) (*InodeEntry, gofuse.Status) {
@@ -6608,13 +6432,12 @@ func (fs *Dat9FS) notifyEntry(parentIno uint64, name string) {
 // invalidation form, while off=0/len=0 invalidates cached data. A data-only
 // invalidation can leave a just-truncated 0-byte i_size cached across a later
 // close-sync remote commit, making immediate close-to-open reads observe EOF.
-func (fs *Dat9FS) invalidateInodeKernelCaches(ino uint64) bool {
+func (fs *Dat9FS) invalidateInodeKernelCaches(ino uint64) {
 	if fs.server == nil {
-		return false
+		return
 	}
-	attrErr := fs.server.InodeNotify(ino, -1, 0)
-	dataErr := fs.server.InodeNotify(ino, 0, 0)
-	return attrErr == gofuse.OK && dataErr == gofuse.OK
+	_ = fs.server.InodeNotify(ino, -1, 0)
+	_ = fs.server.InodeNotify(ino, 0, 0)
 }
 
 // notifyInode tells the kernel to invalidate cached attributes and data
@@ -6631,7 +6454,7 @@ func (fs *Dat9FS) notifyInode(ino uint64) {
 	fs.notifyWg.Add(1)
 	go func() {
 		defer fs.notifyWg.Done()
-		_ = fs.invalidateInodeKernelCaches(ino)
+		fs.invalidateInodeKernelCaches(ino)
 	}()
 }
 
@@ -6650,7 +6473,7 @@ func (fs *Dat9FS) notifyInodeSync(ino uint64) {
 		testHookNotifyInodeSync(ino)
 		return
 	}
-	_ = fs.invalidateInodeKernelCaches(ino)
+	fs.invalidateInodeKernelCaches(ino)
 }
 
 func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name string, out *gofuse.EntryOut) (status gofuse.Status) {
@@ -10915,7 +10738,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			// open/00.t test 43). Use a synchronous InodeNotify (not the
 			// async notifyInode goroutine) to guarantee the cache is
 			// invalidated before Open returns to the kernel.
-			_ = fs.invalidateInodeKernelCaches(input.NodeId)
+			fs.invalidateInodeKernelCaches(input.NodeId)
 			fs.armKernelCacheBypass(input.NodeId, p, fh.BaseRev, 0, "open-truncate")
 			if fh.WritePolicy != WritePolicyWriteSync && fs.shadowStore != nil && fs.pendingIndex != nil {
 				if err := fs.shadowStore.WriteFull(p, nil, fh.BaseRev); err != nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -29,6 +29,10 @@ import (
 // candidate after discovery but before the second TryLock in candidateLoop.
 var testHookAfterSamePathDirtyHandleScan func(path string)
 
+// testHookNotifyInodeSyncResult lets cache-boundary tests cover the production
+// notify-success branch without mounting a real FUSE server.
+var testHookNotifyInodeSyncResult func(ino uint64) bool
+
 // Dat9FS implements the go-fuse RawFileSystem interface, bridging FUSE
 // operations to the dat9 HTTP API via the Go SDK client.
 type Dat9FS struct {
@@ -323,6 +327,7 @@ type kernelCacheBypassMarker struct {
 	size       int64
 	reason     string
 	expiresAt  time.Time
+	timer      *time.Timer
 }
 
 type layerSymlinkState struct {
@@ -1702,7 +1707,17 @@ func (fs *Dat9FS) openFlagsForHandle(fh *FileHandle) uint32 {
 	return flags
 }
 
+// armKernelCacheBypass records a short-lived per-inode cache-bypass marker for
+// close-to-open readers that must not trust stale kernel pages immediately
+// after a truncate-first sync commit.
 func (fs *Dat9FS) armKernelCacheBypass(ino uint64, localPath string, revision, size int64, reason string) uint64 {
+	return fs.armKernelCacheBypassUntil(ino, localPath, revision, size, reason, time.Now().Add(kernelCacheBypassFallbackTTL))
+}
+
+// armKernelCacheBypassUntil is the testable form of armKernelCacheBypass with
+// an explicit expiry. Re-arming the same inode reuses its cleanup timer so a
+// hot write-sync path has one bounded timer instead of one timer per commit.
+func (fs *Dat9FS) armKernelCacheBypassUntil(ino uint64, localPath string, revision, size int64, reason string, expiresAt time.Time) uint64 {
 	if fs == nil || ino == 0 {
 		return 0
 	}
@@ -1713,6 +1728,10 @@ func (fs *Dat9FS) armKernelCacheBypass(ino uint64, localPath string, revision, s
 	}
 	fs.kernelCacheBypassSeq++
 	gen := fs.kernelCacheBypassSeq
+	var timer *time.Timer
+	if previous, ok := fs.kernelCacheBypass[ino]; ok {
+		timer = previous.timer
+	}
 	fs.kernelCacheBypass[ino] = kernelCacheBypassMarker{
 		ino:        ino,
 		path:       localPath,
@@ -1720,12 +1739,64 @@ func (fs *Dat9FS) armKernelCacheBypass(ino uint64, localPath string, revision, s
 		revision:   revision,
 		size:       size,
 		reason:     reason,
-		expiresAt:  time.Now().Add(kernelCacheBypassFallbackTTL),
+		expiresAt:  expiresAt,
+		timer:      timer,
 	}
 	fs.debugf("kernel cache bypass armed path=%s ino=%d gen=%d rev=%d size=%d reason=%s", localPath, ino, gen, revision, size, reason)
+	fs.scheduleKernelCacheBypassCleanupLocked(ino, expiresAt)
 	return gen
 }
 
+// scheduleKernelCacheBypassCleanupLocked schedules or resets the per-inode
+// cleanup timer for the marker currently stored in kernelCacheBypass. Caller
+// must hold kernelCacheBypassMu.
+func (fs *Dat9FS) scheduleKernelCacheBypassCleanupLocked(ino uint64, expiresAt time.Time) {
+	if fs == nil || ino == 0 || expiresAt.IsZero() {
+		return
+	}
+	marker, ok := fs.kernelCacheBypass[ino]
+	if !ok {
+		return
+	}
+	delay := time.Until(expiresAt)
+	if delay < 0 {
+		delay = 0
+	}
+	if marker.timer == nil {
+		marker.timer = time.AfterFunc(delay, func() {
+			fs.expireKernelCacheBypass(ino)
+		})
+		fs.kernelCacheBypass[ino] = marker
+		return
+	}
+	marker.timer.Reset(delay)
+	fs.kernelCacheBypass[ino] = marker
+}
+
+// expireKernelCacheBypass removes an expired marker from the timer callback.
+// If a race re-armed the inode to a later expiry before this callback acquired
+// the lock, the same coalesced timer is reset to the newer deadline.
+func (fs *Dat9FS) expireKernelCacheBypass(ino uint64) {
+	if fs == nil || ino == 0 {
+		return
+	}
+	now := time.Now()
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	marker, ok := fs.kernelCacheBypass[ino]
+	if !ok {
+		return
+	}
+	if !marker.expiresAt.IsZero() && now.Before(marker.expiresAt) {
+		fs.scheduleKernelCacheBypassCleanupLocked(ino, marker.expiresAt)
+		return
+	}
+	delete(fs.kernelCacheBypass, ino)
+	fs.debugf("kernel cache bypass expired path=%s ino=%d gen=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.generation, marker.revision, marker.size, marker.reason)
+}
+
+// clearKernelCacheBypassGeneration removes only the named marker generation.
+// This protects a newer same-inode marker from an older timer or cleanup path.
 func (fs *Dat9FS) clearKernelCacheBypassGeneration(ino, generation uint64) {
 	if fs == nil || ino == 0 || generation == 0 {
 		return
@@ -1736,10 +1807,32 @@ func (fs *Dat9FS) clearKernelCacheBypassGeneration(ino, generation uint64) {
 	if !ok || marker.generation != generation {
 		return
 	}
+	if marker.timer != nil {
+		marker.timer.Stop()
+	}
 	delete(fs.kernelCacheBypass, ino)
 	fs.debugf("kernel cache bypass cleared path=%s ino=%d gen=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.generation, marker.revision, marker.size, marker.reason)
 }
 
+// clearKernelCacheBypassMarkers stops all marker timers and drops their state
+// during graceful shutdown.
+func (fs *Dat9FS) clearKernelCacheBypassMarkers() {
+	if fs == nil {
+		return
+	}
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	for ino, marker := range fs.kernelCacheBypass {
+		if marker.timer != nil {
+			marker.timer.Stop()
+		}
+		delete(fs.kernelCacheBypass, ino)
+	}
+}
+
+// kernelCacheBypassActive reports whether a clean read-only open on fh should
+// temporarily bypass the kernel page cache. Expired markers are reclaimed
+// opportunistically here in addition to the timer-driven cleanup path.
 func (fs *Dat9FS) kernelCacheBypassActive(fh *FileHandle) bool {
 	if fs == nil || fh == nil || fh.Ino == 0 {
 		return false
@@ -1752,6 +1845,9 @@ func (fs *Dat9FS) kernelCacheBypassActive(fh *FileHandle) bool {
 		return false
 	}
 	if !marker.expiresAt.IsZero() && now.After(marker.expiresAt) {
+		if marker.timer != nil {
+			marker.timer.Stop()
+		}
 		delete(fs.kernelCacheBypass, fh.Ino)
 		fs.debugf("kernel cache bypass expired path=%s ino=%d gen=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.generation, marker.revision, marker.size, marker.reason)
 		return false
@@ -1763,10 +1859,13 @@ func (fs *Dat9FS) finishSyncCommitKernelCacheBoundary(ino uint64, localPath stri
 	if fs == nil || ino == 0 {
 		return
 	}
-	gen := fs.armKernelCacheBypass(ino, localPath, revision, size, "sync-commit")
-	if fs.notifyInodeSync(ino) {
-		fs.clearKernelCacheBypassGeneration(ino, gen)
-	}
+	// InodeNotify is best-effort: Linux may still serve stale page/attr cache
+	// immediately after a truncate-first close-sync/write-sync commit even when
+	// the notification call reports success. Keep the per-inode/generation
+	// short-window bypass armed until its TTL expires; this remains narrower
+	// than making every clean reader on sync-durability mounts DIRECT_IO.
+	fs.armKernelCacheBypass(ino, localPath, revision, size, "sync-commit")
+	_ = fs.notifyInodeSync(ino)
 }
 
 func (fs *Dat9FS) localEntry(localPath string, info os.FileInfo, incrementLookup bool) (*InodeEntry, gofuse.Status) {
@@ -6543,6 +6642,9 @@ func (fs *Dat9FS) notifyInodeSync(ino uint64) bool {
 	fs.notifyCount.Add(1)
 	if fs.perf != nil {
 		fs.perf.notifyInode.add(1)
+	}
+	if testHookNotifyInodeSyncResult != nil {
+		return testHookNotifyInodeSyncResult(ino)
 	}
 	return fs.invalidateInodeKernelCaches(ino)
 }
@@ -14435,6 +14537,8 @@ func (fs *Dat9FS) FlushAll() {
 
 	// Wait for any inflight async kernel notifications to complete.
 	fs.notifyWg.Wait()
+
+	fs.clearKernelCacheBypassMarkers()
 
 	// Stop git-workspace background probe/retry loops before exit.
 	fs.stopGitWorkspaceBackground()

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -29,9 +29,9 @@ import (
 // candidate after discovery but before the second TryLock in candidateLoop.
 var testHookAfterSamePathDirtyHandleScan func(path string)
 
-// testHookNotifyInodeSyncResult lets cache-boundary tests cover the production
-// notify-success branch without mounting a real FUSE server.
-var testHookNotifyInodeSyncResult func(ino uint64) bool
+// testHookNotifyInodeSync lets cache-boundary tests observe the production
+// synchronous notify path without mounting a real FUSE server.
+var testHookNotifyInodeSync func(ino uint64)
 
 // Dat9FS implements the go-fuse RawFileSystem interface, bridging FUSE
 // operations to the dat9 HTTP API via the Go SDK client.
@@ -59,21 +59,25 @@ type Dat9FS struct {
 	// stream is current, revision-bound file stat hits are enabled only when
 	// MountOptions.TrustLocalEvents explicitly allows process-local SSE
 	// freshness for this deployment.
-	statCacheUnverified  atomic.Bool
-	readSlots            chan struct{}
-	dirtyMu              sync.Mutex
-	dirtyInodes          map[uint64]dirtyInodeState
-	dirtySeq             uint64
-	kernelCacheBypassMu  sync.Mutex
-	kernelCacheBypass    map[uint64]kernelCacheBypassMarker
-	kernelCacheBypassSeq uint64
-	modeSeq              atomic.Uint64
-	specialMu            sync.RWMutex
-	specialByPath        map[string]uint64
-	uid                  uint32
-	gid                  uint32
-	opts                 *MountOptions
-	debouncer            *flushDebouncer
+	statCacheUnverified atomic.Bool
+	readSlots           chan struct{}
+	dirtyMu             sync.Mutex
+	dirtyInodes         map[uint64]dirtyInodeState
+	dirtySeq            uint64
+	kernelCacheBypassMu sync.Mutex
+	kernelCacheBypass   map[uint64]kernelCacheBypassMarker
+	// A single coalesced timer sweeps expired kernelCacheBypass markers. Readers
+	// also reclaim expired markers lazily; this timer only bounds map growth when
+	// a sync-written inode is never reopened.
+	kernelCacheBypassSweepTimer *time.Timer
+	kernelCacheBypassSweepAt    time.Time
+	modeSeq                     atomic.Uint64
+	specialMu                   sync.RWMutex
+	specialByPath               map[string]uint64
+	uid                         uint32
+	gid                         uint32
+	opts                        *MountOptions
+	debouncer                   *flushDebouncer
 
 	// Write-back cache: Flush writes small files to local disk, Release
 	// triggers async upload. Nil when CacheDir is not configured.
@@ -320,14 +324,12 @@ type dirtyInodeState struct {
 }
 
 type kernelCacheBypassMarker struct {
-	ino        uint64
-	path       string
-	generation uint64
-	revision   int64
-	size       int64
-	reason     string
-	expiresAt  time.Time
-	timer      *time.Timer
+	ino       uint64
+	path      string
+	revision  int64
+	size      int64
+	reason    string
+	expiresAt time.Time
 }
 
 type layerSymlinkState struct {
@@ -1710,122 +1712,125 @@ func (fs *Dat9FS) openFlagsForHandle(fh *FileHandle) uint32 {
 // armKernelCacheBypass records a short-lived per-inode cache-bypass marker for
 // close-to-open readers that must not trust stale kernel pages immediately
 // after a truncate-first sync commit.
-func (fs *Dat9FS) armKernelCacheBypass(ino uint64, localPath string, revision, size int64, reason string) uint64 {
-	return fs.armKernelCacheBypassUntil(ino, localPath, revision, size, reason, time.Now().Add(kernelCacheBypassFallbackTTL))
+func (fs *Dat9FS) armKernelCacheBypass(ino uint64, localPath string, revision, size int64, reason string) {
+	fs.armKernelCacheBypassUntil(ino, localPath, revision, size, reason, time.Now().Add(kernelCacheBypassFallbackTTL))
 }
 
 // armKernelCacheBypassUntil is the testable form of armKernelCacheBypass with
-// an explicit expiry. Re-arming the same inode reuses its cleanup timer so a
-// hot write-sync path has one bounded timer instead of one timer per commit.
-func (fs *Dat9FS) armKernelCacheBypassUntil(ino uint64, localPath string, revision, size int64, reason string, expiresAt time.Time) uint64 {
+// an explicit expiry. Re-arming markers uses one coalesced mount-level sweeper
+// rather than one timer per commit or inode.
+func (fs *Dat9FS) armKernelCacheBypassUntil(ino uint64, localPath string, revision, size int64, reason string, expiresAt time.Time) {
 	if fs == nil || ino == 0 {
-		return 0
+		return
 	}
 	fs.kernelCacheBypassMu.Lock()
 	defer fs.kernelCacheBypassMu.Unlock()
 	if fs.kernelCacheBypass == nil {
 		fs.kernelCacheBypass = make(map[uint64]kernelCacheBypassMarker)
 	}
-	fs.kernelCacheBypassSeq++
-	gen := fs.kernelCacheBypassSeq
-	var timer *time.Timer
-	if previous, ok := fs.kernelCacheBypass[ino]; ok {
-		timer = previous.timer
-	}
 	fs.kernelCacheBypass[ino] = kernelCacheBypassMarker{
-		ino:        ino,
-		path:       localPath,
-		generation: gen,
-		revision:   revision,
-		size:       size,
-		reason:     reason,
-		expiresAt:  expiresAt,
-		timer:      timer,
+		ino:       ino,
+		path:      localPath,
+		revision:  revision,
+		size:      size,
+		reason:    reason,
+		expiresAt: expiresAt,
 	}
-	fs.debugf("kernel cache bypass armed path=%s ino=%d gen=%d rev=%d size=%d reason=%s", localPath, ino, gen, revision, size, reason)
-	fs.scheduleKernelCacheBypassCleanupLocked(ino, expiresAt)
-	return gen
+	fs.debugf("kernel cache bypass armed path=%s ino=%d rev=%d size=%d reason=%s", localPath, ino, revision, size, reason)
+	fs.scheduleKernelCacheBypassSweepLocked(expiresAt)
 }
 
-// scheduleKernelCacheBypassCleanupLocked schedules or resets the per-inode
-// cleanup timer for the marker currently stored in kernelCacheBypass. Caller
+// scheduleKernelCacheBypassSweepLocked schedules or advances the single cleanup
+// timer used to reclaim expired markers that are never reopened. Caller
 // must hold kernelCacheBypassMu.
-func (fs *Dat9FS) scheduleKernelCacheBypassCleanupLocked(ino uint64, expiresAt time.Time) {
-	if fs == nil || ino == 0 || expiresAt.IsZero() {
+func (fs *Dat9FS) scheduleKernelCacheBypassSweepLocked(expiresAt time.Time) {
+	if fs == nil || expiresAt.IsZero() {
 		return
 	}
-	marker, ok := fs.kernelCacheBypass[ino]
-	if !ok {
+	if fs.kernelCacheBypassSweepTimer != nil && !fs.kernelCacheBypassSweepAt.IsZero() && !expiresAt.Before(fs.kernelCacheBypassSweepAt) {
 		return
 	}
 	delay := time.Until(expiresAt)
 	if delay < 0 {
 		delay = 0
 	}
-	if marker.timer == nil {
-		marker.timer = time.AfterFunc(delay, func() {
-			fs.expireKernelCacheBypass(ino)
+	fs.kernelCacheBypassSweepAt = expiresAt
+	if fs.kernelCacheBypassSweepTimer == nil {
+		fs.kernelCacheBypassSweepTimer = time.AfterFunc(delay, func() {
+			fs.sweepKernelCacheBypass()
 		})
-		fs.kernelCacheBypass[ino] = marker
 		return
 	}
-	marker.timer.Reset(delay)
-	fs.kernelCacheBypass[ino] = marker
+	// Ignore Reset's boolean result deliberately: if a previous callback is
+	// already running, sweepKernelCacheBypass re-checks all current markers under
+	// the same mutex and only deletes markers whose own expiresAt has passed.
+	fs.kernelCacheBypassSweepTimer.Reset(delay)
 }
 
-// expireKernelCacheBypass removes an expired marker from the timer callback.
-// If a race re-armed the inode to a later expiry before this callback acquired
-// the lock, the same coalesced timer is reset to the newer deadline.
-func (fs *Dat9FS) expireKernelCacheBypass(ino uint64) {
-	if fs == nil || ino == 0 {
+// rescheduleKernelCacheBypassSweepLocked resets the single sweeper to the
+// earliest live marker, or stops it when no markers remain. Caller must hold
+// kernelCacheBypassMu.
+func (fs *Dat9FS) rescheduleKernelCacheBypassSweepLocked() {
+	var next time.Time
+	for _, marker := range fs.kernelCacheBypass {
+		if marker.expiresAt.IsZero() {
+			continue
+		}
+		if next.IsZero() || marker.expiresAt.Before(next) {
+			next = marker.expiresAt
+		}
+	}
+	if next.IsZero() {
+		if fs.kernelCacheBypassSweepTimer != nil {
+			fs.kernelCacheBypassSweepTimer.Stop()
+			fs.kernelCacheBypassSweepTimer = nil
+		}
+		fs.kernelCacheBypassSweepAt = time.Time{}
+		return
+	}
+	fs.kernelCacheBypassSweepAt = time.Time{}
+	fs.scheduleKernelCacheBypassSweepLocked(next)
+}
+
+// sweepKernelCacheBypass removes expired markers from the timer callback. A
+// stale callback is benign: every marker's current expiresAt is checked under
+// kernelCacheBypassMu before deletion, so a re-armed marker survives and the
+// sweeper reschedules itself to the next live deadline.
+func (fs *Dat9FS) sweepKernelCacheBypass() {
+	if fs == nil {
 		return
 	}
 	now := time.Now()
 	fs.kernelCacheBypassMu.Lock()
 	defer fs.kernelCacheBypassMu.Unlock()
-	marker, ok := fs.kernelCacheBypass[ino]
-	if !ok {
-		return
+	fs.kernelCacheBypassSweepAt = time.Time{}
+	for ino, marker := range fs.kernelCacheBypass {
+		if marker.expiresAt.IsZero() {
+			continue
+		}
+		if now.Before(marker.expiresAt) {
+			continue
+		}
+		delete(fs.kernelCacheBypass, ino)
+		fs.debugf("kernel cache bypass expired path=%s ino=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.revision, marker.size, marker.reason)
 	}
-	if !marker.expiresAt.IsZero() && now.Before(marker.expiresAt) {
-		fs.scheduleKernelCacheBypassCleanupLocked(ino, marker.expiresAt)
-		return
-	}
-	delete(fs.kernelCacheBypass, ino)
-	fs.debugf("kernel cache bypass expired path=%s ino=%d gen=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.generation, marker.revision, marker.size, marker.reason)
+	fs.rescheduleKernelCacheBypassSweepLocked()
 }
 
-// clearKernelCacheBypassGeneration removes only the named marker generation.
-// This protects a newer same-inode marker from an older timer or cleanup path.
-func (fs *Dat9FS) clearKernelCacheBypassGeneration(ino, generation uint64) {
-	if fs == nil || ino == 0 || generation == 0 {
-		return
-	}
-	fs.kernelCacheBypassMu.Lock()
-	defer fs.kernelCacheBypassMu.Unlock()
-	marker, ok := fs.kernelCacheBypass[ino]
-	if !ok || marker.generation != generation {
-		return
-	}
-	if marker.timer != nil {
-		marker.timer.Stop()
-	}
-	delete(fs.kernelCacheBypass, ino)
-	fs.debugf("kernel cache bypass cleared path=%s ino=%d gen=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.generation, marker.revision, marker.size, marker.reason)
-}
-
-// clearKernelCacheBypassMarkers stops all marker timers and drops their state
-// during graceful shutdown.
+// clearKernelCacheBypassMarkers stops the cleanup sweeper and drops all marker
+// state during graceful shutdown.
 func (fs *Dat9FS) clearKernelCacheBypassMarkers() {
 	if fs == nil {
 		return
 	}
 	fs.kernelCacheBypassMu.Lock()
 	defer fs.kernelCacheBypassMu.Unlock()
-	for ino, marker := range fs.kernelCacheBypass {
-		if marker.timer != nil {
-			marker.timer.Stop()
-		}
+	if fs.kernelCacheBypassSweepTimer != nil {
+		fs.kernelCacheBypassSweepTimer.Stop()
+		fs.kernelCacheBypassSweepTimer = nil
+	}
+	fs.kernelCacheBypassSweepAt = time.Time{}
+	for ino := range fs.kernelCacheBypass {
 		delete(fs.kernelCacheBypass, ino)
 	}
 }
@@ -1845,11 +1850,9 @@ func (fs *Dat9FS) kernelCacheBypassActive(fh *FileHandle) bool {
 		return false
 	}
 	if !marker.expiresAt.IsZero() && now.After(marker.expiresAt) {
-		if marker.timer != nil {
-			marker.timer.Stop()
-		}
 		delete(fs.kernelCacheBypass, fh.Ino)
-		fs.debugf("kernel cache bypass expired path=%s ino=%d gen=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.generation, marker.revision, marker.size, marker.reason)
+		fs.debugf("kernel cache bypass expired path=%s ino=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.revision, marker.size, marker.reason)
+		fs.rescheduleKernelCacheBypassSweepLocked()
 		return false
 	}
 	return marker.ino == fh.Ino
@@ -1861,11 +1864,11 @@ func (fs *Dat9FS) finishSyncCommitKernelCacheBoundary(ino uint64, localPath stri
 	}
 	// InodeNotify is best-effort: Linux may still serve stale page/attr cache
 	// immediately after a truncate-first close-sync/write-sync commit even when
-	// the notification call reports success. Keep the per-inode/generation
+	// the notification call reports success. Keep the per-inode
 	// short-window bypass armed until its TTL expires; this remains narrower
 	// than making every clean reader on sync-durability mounts DIRECT_IO.
 	fs.armKernelCacheBypass(ino, localPath, revision, size, "sync-commit")
-	_ = fs.notifyInodeSync(ino)
+	fs.notifyInodeSync(ino)
 }
 
 func (fs *Dat9FS) localEntry(localPath string, info os.FileInfo, incrementLookup bool) (*InodeEntry, gofuse.Status) {
@@ -6638,15 +6641,16 @@ func (fs *Dat9FS) notifyInode(ino uint64) {
 // remote commits are close-to-open barriers: the next opener may otherwise
 // observe stale size/page-cache state even though the remote commit has
 // completed.
-func (fs *Dat9FS) notifyInodeSync(ino uint64) bool {
+func (fs *Dat9FS) notifyInodeSync(ino uint64) {
 	fs.notifyCount.Add(1)
 	if fs.perf != nil {
 		fs.perf.notifyInode.add(1)
 	}
-	if testHookNotifyInodeSyncResult != nil {
-		return testHookNotifyInodeSyncResult(ino)
+	if testHookNotifyInodeSync != nil {
+		testHookNotifyInodeSync(ino)
+		return
 	}
-	return fs.invalidateInodeKernelCaches(ino)
+	_ = fs.invalidateInodeKernelCaches(ino)
 }
 
 func (fs *Dat9FS) Lookup(cancel <-chan struct{}, header *gofuse.InHeader, name string, out *gofuse.EntryOut) (status gofuse.Status) {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -8331,11 +8331,19 @@ func TestOpenReadOnlySyncDurabilityKeepsCacheWithoutBypassMarker(t *testing.T) {
 	}
 }
 
+func cleanupKernelCacheBypassAfterTest(t *testing.T, fs *Dat9FS) {
+	t.Helper()
+	t.Cleanup(func() {
+		fs.clearKernelCacheBypassMarkers()
+	})
+}
+
 func TestOpenReadOnlySyncDurabilityBypassMarkerUsesDirectIO(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
 	opts.WritePolicy = WritePolicyCloseSync
 	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
 
 	markedIno := fs.inodes.Lookup("/sync-visible.txt", false, 17, time.Now())
 	fs.inodes.UpdateRevision(markedIno, 7)
@@ -8374,6 +8382,7 @@ func TestKernelCacheBypassMarkerIsInodeScopedAcrossRecreate(t *testing.T) {
 	opts.setDefaults()
 	opts.WritePolicy = WritePolicyCloseSync
 	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
 
 	oldIno := fs.inodes.Lookup("/recreate.txt", false, 0, time.Now())
 	fs.armKernelCacheBypass(oldIno, "/recreate.txt", 1, 0, "test")
@@ -8401,6 +8410,7 @@ func TestKernelCacheBypassMarkerFollowsRenamedInode(t *testing.T) {
 	opts.setDefaults()
 	opts.WritePolicy = WritePolicyCloseSync
 	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
 
 	ino := fs.inodes.Lookup("/old.txt", false, 5, time.Now())
 	fs.armKernelCacheBypass(ino, "/old.txt", 2, 5, "test")
@@ -8424,6 +8434,7 @@ func TestSyncCommitNotifyFailureLeavesPerInodeBypass(t *testing.T) {
 	opts.setDefaults()
 	opts.WritePolicy = WritePolicyCloseSync
 	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
 
 	ino := fs.inodes.Lookup("/notify-fallback.txt", false, 21, time.Now())
 	fs.inodes.UpdateRevision(ino, 9)
@@ -8450,18 +8461,18 @@ func TestSyncCommitNotifySuccessLeavesPerInodeBypassUntilTTL(t *testing.T) {
 	opts.setDefaults()
 	opts.WritePolicy = WritePolicyCloseSync
 	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
 
 	ino := fs.inodes.Lookup("/notify-success.txt", false, 21, time.Now())
 	fs.inodes.UpdateRevision(ino, 9)
 
 	var notified atomic.Bool
-	t.Cleanup(func() { testHookNotifyInodeSyncResult = nil })
-	testHookNotifyInodeSyncResult = func(gotIno uint64) bool {
+	t.Cleanup(func() { testHookNotifyInodeSync = nil })
+	testHookNotifyInodeSync = func(gotIno uint64) {
 		if gotIno != ino {
 			t.Fatalf("notify ino = %d, want %d", gotIno, ino)
 		}
 		notified.Store(true)
-		return true
 	}
 
 	fs.finishSyncCommitKernelCacheBoundary(ino, "/notify-success.txt", 9, 21)
@@ -8495,19 +8506,15 @@ func TestSyncCommitNotifySuccessLeavesPerInodeBypassUntilTTL(t *testing.T) {
 	}
 }
 
-func TestKernelCacheBypassMarkerExpiresAndClearsByGeneration(t *testing.T) {
+func TestKernelCacheBypassMarkerExpiresAndClears(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
 	opts.WritePolicy = WritePolicyCloseSync
 	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
 
 	ino := fs.inodes.Lookup("/short-window.txt", false, 8, time.Now())
-	oldGen := fs.armKernelCacheBypass(ino, "/short-window.txt", 1, 8, "old")
-	newGen := fs.armKernelCacheBypass(ino, "/short-window.txt", 2, 8, "new")
-	fs.clearKernelCacheBypassGeneration(ino, oldGen)
-	if !fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/short-window.txt"}) {
-		t.Fatal("clearing an older generation removed the active marker")
-	}
+	fs.armKernelCacheBypass(ino, "/short-window.txt", 2, 8, "test")
 
 	fs.kernelCacheBypassMu.Lock()
 	marker := fs.kernelCacheBypass[ino]
@@ -8518,62 +8525,64 @@ func TestKernelCacheBypassMarkerExpiresAndClearsByGeneration(t *testing.T) {
 	if fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/short-window.txt"}) {
 		t.Fatal("expired marker stayed active")
 	}
-	fs.clearKernelCacheBypassGeneration(ino, newGen)
 }
 
-func TestKernelCacheBypassTTLDoesNotClearNewerGeneration(t *testing.T) {
+func TestKernelCacheBypassStaleSweepDoesNotClearRenewedMarker(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
 	opts.WritePolicy = WritePolicyCloseSync
 	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
 
-	ino := fs.inodes.Lookup("/generation-safe.txt", false, 8, time.Now())
-	fs.armKernelCacheBypassUntil(ino, "/generation-safe.txt", 1, 8, "old", time.Now().Add(10*time.Millisecond))
-	newGen := fs.armKernelCacheBypassUntil(ino, "/generation-safe.txt", 2, 8, "new", time.Now().Add(5*time.Second))
-	defer fs.clearKernelCacheBypassGeneration(ino, newGen)
-
-	time.Sleep(50 * time.Millisecond)
-	deadline := time.Now().Add(time.Second)
-	for {
-		fs.kernelCacheBypassMu.Lock()
-		marker, ok := fs.kernelCacheBypass[ino]
-		fs.kernelCacheBypassMu.Unlock()
-		if ok && marker.revision == 2 {
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("newer kernel cache bypass marker did not survive older generation cleanup")
-		}
-		time.Sleep(5 * time.Millisecond)
+	expiredIno := fs.inodes.Lookup("/expired-marker.txt", false, 0, time.Now())
+	liveIno := fs.inodes.Lookup("/renewed-marker.txt", false, 8, time.Now())
+	fs.armKernelCacheBypassUntil(liveIno, "/renewed-marker.txt", 2, 8, "new", time.Now().Add(5*time.Second))
+	fs.kernelCacheBypassMu.Lock()
+	fs.kernelCacheBypass[expiredIno] = kernelCacheBypassMarker{
+		ino:       expiredIno,
+		path:      "/expired-marker.txt",
+		revision:  1,
+		size:      0,
+		reason:    "expired-test",
+		expiresAt: time.Now().Add(-time.Second),
 	}
+	fs.kernelCacheBypassMu.Unlock()
 
-	if !fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/generation-safe.txt"}) {
-		t.Fatal("older marker TTL cleanup deleted the newer generation")
+	fs.sweepKernelCacheBypass()
+
+	if fs.kernelCacheBypassActive(&FileHandle{Ino: expiredIno, Path: "/expired-marker.txt"}) {
+		t.Fatal("sweeper did not delete the expired marker")
+	}
+	if !fs.kernelCacheBypassActive(&FileHandle{Ino: liveIno, Path: "/renewed-marker.txt"}) {
+		t.Fatal("stale sweeper callback deleted a renewed marker before its expiry")
+	}
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	if fs.kernelCacheBypassSweepTimer == nil {
+		t.Fatal("sweeper did not reschedule itself for the remaining live marker")
 	}
 }
 
-func TestKernelCacheBypassRearmReusesTimerAndKeepsOneMarker(t *testing.T) {
+func TestKernelCacheBypassRearmKeepsSingleSweepTimerAndOneMarker(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
 	opts.WritePolicy = WritePolicyWriteSync
 	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
 
 	ino := fs.inodes.Lookup("/hot-writer.txt", false, 8, time.Now())
-	firstGen := fs.armKernelCacheBypassUntil(ino, "/hot-writer.txt", 1, 8, "first", time.Now().Add(time.Second))
+	fs.armKernelCacheBypassUntil(ino, "/hot-writer.txt", 1, 8, "first", time.Now().Add(time.Second))
 
 	fs.kernelCacheBypassMu.Lock()
-	firstMarker := fs.kernelCacheBypass[ino]
-	firstTimer := firstMarker.timer
+	firstTimer := fs.kernelCacheBypassSweepTimer
 	fs.kernelCacheBypassMu.Unlock()
 	if firstTimer == nil {
-		t.Fatal("first marker did not create a cleanup timer")
+		t.Fatal("first marker did not create a cleanup sweeper")
 	}
 
-	var lastGen uint64
 	for i := 0; i < 64; i++ {
-		lastGen = fs.armKernelCacheBypassUntil(ino, "/hot-writer.txt", int64(i+2), int64(i+9), "write-sync", time.Now().Add(time.Second))
+		fs.armKernelCacheBypassUntil(ino, "/hot-writer.txt", int64(i+2), int64(i+9), "write-sync", time.Now().Add(time.Second))
 	}
-	defer fs.clearKernelCacheBypassGeneration(ino, lastGen)
 
 	fs.kernelCacheBypassMu.Lock()
 	defer fs.kernelCacheBypassMu.Unlock()
@@ -8581,11 +8590,11 @@ func TestKernelCacheBypassRearmReusesTimerAndKeepsOneMarker(t *testing.T) {
 		t.Fatalf("marker count = %d, want 1 for repeated same-inode rearm", got)
 	}
 	marker := fs.kernelCacheBypass[ino]
-	if marker.generation == firstGen {
-		t.Fatal("marker generation did not advance on rearm")
+	if marker.revision != 65 {
+		t.Fatalf("marker revision = %d, want latest rearm revision 65", marker.revision)
 	}
-	if marker.timer != firstTimer {
-		t.Fatal("rearm allocated a new cleanup timer instead of reusing the inode timer")
+	if fs.kernelCacheBypassSweepTimer != firstTimer {
+		t.Fatal("rearm allocated a new cleanup sweeper instead of reusing the mount timer")
 	}
 }
 
@@ -8594,6 +8603,7 @@ func TestKernelCacheBypassMarkersExpireWithoutReopen(t *testing.T) {
 	opts.setDefaults()
 	opts.WritePolicy = WritePolicyCloseSync
 	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
 
 	const markerCount = 128
 	expiresAt := time.Now().Add(10 * time.Millisecond)
@@ -26355,6 +26365,7 @@ func TestSetAttr_NoKernelNotify(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
 	fs := NewDat9FS(newTestClient("http://localhost"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
 
 	ino := fs.inodes.Lookup("/trunc.txt", false, 100, time.Now())
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -8563,6 +8563,57 @@ func TestKernelCacheBypassStaleSweepDoesNotClearRenewedMarker(t *testing.T) {
 	}
 }
 
+func TestKernelCacheBypassTimerFireConcurrentRearmKeepsRenewedMarker(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.WritePolicy = WritePolicyWriteSync
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	cleanupKernelCacheBypassAfterTest(t, fs)
+
+	ino := fs.inodes.Lookup("/timer-race.txt", false, 8, time.Now())
+	enteredSweep := make(chan struct{})
+	releaseSweep := make(chan struct{})
+	var hookOnce sync.Once
+	var releaseOnce sync.Once
+	releaseHook := func() {
+		releaseOnce.Do(func() {
+			close(releaseSweep)
+		})
+	}
+	defer releaseHook()
+	t.Cleanup(func() { testHookBeforeKernelCacheBypassSweep = nil })
+	testHookBeforeKernelCacheBypassSweep = func() {
+		hookOnce.Do(func() {
+			close(enteredSweep)
+			<-releaseSweep
+		})
+	}
+
+	fs.armKernelCacheBypassUntil(ino, "/timer-race.txt", 1, 8, "old", time.Now().Add(10*time.Millisecond))
+	select {
+	case <-enteredSweep:
+	case <-time.After(time.Second):
+		t.Fatal("cleanup sweeper did not fire")
+	}
+
+	fs.armKernelCacheBypassUntil(ino, "/timer-race.txt", 2, 9, "new", time.Now().Add(time.Second))
+	releaseHook()
+	time.Sleep(50 * time.Millisecond)
+
+	if !fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/timer-race.txt"}) {
+		t.Fatal("timer callback racing with re-arm deleted the renewed marker")
+	}
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	marker := fs.kernelCacheBypass[ino]
+	if marker.revision != 2 || marker.size != 9 {
+		t.Fatalf("marker = (rev=%d size=%d), want renewed marker (rev=2 size=9)", marker.revision, marker.size)
+	}
+	if fs.kernelCacheBypassSweepTimer == nil {
+		t.Fatal("cleanup sweeper was not rescheduled for the renewed marker")
+	}
+}
+
 func TestKernelCacheBypassRearmKeepsSingleSweepTimerAndOneMarker(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -8445,6 +8445,56 @@ func TestSyncCommitNotifyFailureLeavesPerInodeBypass(t *testing.T) {
 	}
 }
 
+func TestSyncCommitNotifySuccessLeavesPerInodeBypassUntilTTL(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.WritePolicy = WritePolicyCloseSync
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+
+	ino := fs.inodes.Lookup("/notify-success.txt", false, 21, time.Now())
+	fs.inodes.UpdateRevision(ino, 9)
+
+	var notified atomic.Bool
+	t.Cleanup(func() { testHookNotifyInodeSyncResult = nil })
+	testHookNotifyInodeSyncResult = func(gotIno uint64) bool {
+		if gotIno != ino {
+			t.Fatalf("notify ino = %d, want %d", gotIno, ino)
+		}
+		notified.Store(true)
+		return true
+	}
+
+	fs.finishSyncCommitKernelCacheBoundary(ino, "/notify-success.txt", 9, 21)
+
+	if !notified.Load() {
+		t.Fatal("notify success hook was not called")
+	}
+	if !fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/notify-success.txt"}) {
+		t.Fatal("notify success cleared the per-inode bypass marker before TTL")
+	}
+	var out gofuse.OpenOut
+	st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: ino},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &out)
+	if st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	if out.OpenFlags != gofuse.FOPEN_DIRECT_IO {
+		t.Fatalf("open flags = %d, want FOPEN_DIRECT_IO while notify-success short window is active", out.OpenFlags)
+	}
+
+	fs.kernelCacheBypassMu.Lock()
+	marker := fs.kernelCacheBypass[ino]
+	marker.expiresAt = time.Now().Add(-time.Second)
+	fs.kernelCacheBypass[ino] = marker
+	fs.kernelCacheBypassMu.Unlock()
+
+	if fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/notify-success.txt"}) {
+		t.Fatal("notify-success marker stayed active after TTL")
+	}
+}
+
 func TestKernelCacheBypassMarkerExpiresAndClearsByGeneration(t *testing.T) {
 	opts := &MountOptions{}
 	opts.setDefaults()
@@ -8469,6 +8519,103 @@ func TestKernelCacheBypassMarkerExpiresAndClearsByGeneration(t *testing.T) {
 		t.Fatal("expired marker stayed active")
 	}
 	fs.clearKernelCacheBypassGeneration(ino, newGen)
+}
+
+func TestKernelCacheBypassTTLDoesNotClearNewerGeneration(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.WritePolicy = WritePolicyCloseSync
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+
+	ino := fs.inodes.Lookup("/generation-safe.txt", false, 8, time.Now())
+	fs.armKernelCacheBypassUntil(ino, "/generation-safe.txt", 1, 8, "old", time.Now().Add(10*time.Millisecond))
+	newGen := fs.armKernelCacheBypassUntil(ino, "/generation-safe.txt", 2, 8, "new", time.Now().Add(5*time.Second))
+	defer fs.clearKernelCacheBypassGeneration(ino, newGen)
+
+	time.Sleep(50 * time.Millisecond)
+	deadline := time.Now().Add(time.Second)
+	for {
+		fs.kernelCacheBypassMu.Lock()
+		marker, ok := fs.kernelCacheBypass[ino]
+		fs.kernelCacheBypassMu.Unlock()
+		if ok && marker.revision == 2 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("newer kernel cache bypass marker did not survive older generation cleanup")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if !fs.kernelCacheBypassActive(&FileHandle{Ino: ino, Path: "/generation-safe.txt"}) {
+		t.Fatal("older marker TTL cleanup deleted the newer generation")
+	}
+}
+
+func TestKernelCacheBypassRearmReusesTimerAndKeepsOneMarker(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.WritePolicy = WritePolicyWriteSync
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+
+	ino := fs.inodes.Lookup("/hot-writer.txt", false, 8, time.Now())
+	firstGen := fs.armKernelCacheBypassUntil(ino, "/hot-writer.txt", 1, 8, "first", time.Now().Add(time.Second))
+
+	fs.kernelCacheBypassMu.Lock()
+	firstMarker := fs.kernelCacheBypass[ino]
+	firstTimer := firstMarker.timer
+	fs.kernelCacheBypassMu.Unlock()
+	if firstTimer == nil {
+		t.Fatal("first marker did not create a cleanup timer")
+	}
+
+	var lastGen uint64
+	for i := 0; i < 64; i++ {
+		lastGen = fs.armKernelCacheBypassUntil(ino, "/hot-writer.txt", int64(i+2), int64(i+9), "write-sync", time.Now().Add(time.Second))
+	}
+	defer fs.clearKernelCacheBypassGeneration(ino, lastGen)
+
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	if got := len(fs.kernelCacheBypass); got != 1 {
+		t.Fatalf("marker count = %d, want 1 for repeated same-inode rearm", got)
+	}
+	marker := fs.kernelCacheBypass[ino]
+	if marker.generation == firstGen {
+		t.Fatal("marker generation did not advance on rearm")
+	}
+	if marker.timer != firstTimer {
+		t.Fatal("rearm allocated a new cleanup timer instead of reusing the inode timer")
+	}
+}
+
+func TestKernelCacheBypassMarkersExpireWithoutReopen(t *testing.T) {
+	opts := &MountOptions{}
+	opts.setDefaults()
+	opts.WritePolicy = WritePolicyCloseSync
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+
+	const markerCount = 128
+	expiresAt := time.Now().Add(10 * time.Millisecond)
+	for i := 0; i < markerCount; i++ {
+		p := fmt.Sprintf("/bulk-sync-%03d.txt", i)
+		ino := fs.inodes.Lookup(p, false, int64(i+1), time.Now())
+		fs.armKernelCacheBypassUntil(ino, p, int64(i+1), int64(i+1), "bulk-test", expiresAt)
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		fs.kernelCacheBypassMu.Lock()
+		remaining := len(fs.kernelCacheBypass)
+		fs.kernelCacheBypassMu.Unlock()
+		if remaining == 0 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("expired kernel cache bypass markers not cleaned without reopening; remaining=%d", remaining)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
 }
 
 func TestOpenReadOnlyCacheableFileSkipsPrefetcher(t *testing.T) {

--- a/pkg/fuse/kernel_cache_bypass.go
+++ b/pkg/fuse/kernel_cache_bypass.go
@@ -1,0 +1,191 @@
+package fuse
+
+import "time"
+
+// testHookNotifyInodeSync lets cache-boundary tests observe the production
+// synchronous notify path without mounting a real FUSE server.
+var testHookNotifyInodeSync func(ino uint64)
+
+// testHookBeforeKernelCacheBypassSweep lets race-focused tests pause a real
+// cleanup timer callback before it inspects current markers.
+var testHookBeforeKernelCacheBypassSweep func()
+
+const kernelCacheBypassFallbackTTL = 2 * time.Second
+
+type kernelCacheBypassMarker struct {
+	ino       uint64
+	path      string
+	revision  int64
+	size      int64
+	reason    string
+	expiresAt time.Time
+}
+
+// armKernelCacheBypass records a short-lived per-inode cache-bypass marker for
+// close-to-open readers that must not trust stale kernel pages immediately
+// after a truncate-first sync commit.
+func (fs *Dat9FS) armKernelCacheBypass(ino uint64, localPath string, revision, size int64, reason string) {
+	fs.armKernelCacheBypassUntil(ino, localPath, revision, size, reason, time.Now().Add(kernelCacheBypassFallbackTTL))
+}
+
+// armKernelCacheBypassUntil is the testable form of armKernelCacheBypass with
+// an explicit expiry. Re-arming markers uses one coalesced mount-level sweeper
+// rather than one timer per commit or inode.
+func (fs *Dat9FS) armKernelCacheBypassUntil(ino uint64, localPath string, revision, size int64, reason string, expiresAt time.Time) {
+	if fs == nil || ino == 0 {
+		return
+	}
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	if fs.kernelCacheBypass == nil {
+		fs.kernelCacheBypass = make(map[uint64]kernelCacheBypassMarker)
+	}
+	fs.kernelCacheBypass[ino] = kernelCacheBypassMarker{
+		ino:       ino,
+		path:      localPath,
+		revision:  revision,
+		size:      size,
+		reason:    reason,
+		expiresAt: expiresAt,
+	}
+	fs.debugf("kernel cache bypass armed path=%s ino=%d rev=%d size=%d reason=%s", localPath, ino, revision, size, reason)
+	fs.scheduleKernelCacheBypassSweepLocked(expiresAt)
+}
+
+// scheduleKernelCacheBypassSweepLocked schedules or advances the single cleanup
+// timer used to reclaim expired markers that are never reopened. Caller
+// must hold kernelCacheBypassMu.
+func (fs *Dat9FS) scheduleKernelCacheBypassSweepLocked(expiresAt time.Time) {
+	if fs == nil || expiresAt.IsZero() {
+		return
+	}
+	// Invariant: when kernelCacheBypassSweepTimer is non-nil,
+	// kernelCacheBypassSweepAt is the deadline of a pending sweep. A later marker
+	// does not need to reset that timer because the pending sweep re-derives the
+	// earliest remaining live expiry under the mutex before rescheduling.
+	if fs.kernelCacheBypassSweepTimer != nil && !fs.kernelCacheBypassSweepAt.IsZero() && !expiresAt.Before(fs.kernelCacheBypassSweepAt) {
+		return
+	}
+	delay := time.Until(expiresAt)
+	if delay < 0 {
+		delay = 0
+	}
+	fs.kernelCacheBypassSweepAt = expiresAt
+	if fs.kernelCacheBypassSweepTimer == nil {
+		fs.kernelCacheBypassSweepTimer = time.AfterFunc(delay, func() {
+			fs.sweepKernelCacheBypass()
+		})
+		return
+	}
+	// Ignore Reset's boolean result deliberately: if a previous callback is
+	// already running, sweepKernelCacheBypass re-checks all current markers under
+	// the same mutex and only deletes markers whose own expiresAt has passed.
+	fs.kernelCacheBypassSweepTimer.Reset(delay)
+}
+
+// rescheduleKernelCacheBypassSweepLocked resets the single sweeper to the
+// earliest live marker, or stops it when no markers remain. Caller must hold
+// kernelCacheBypassMu.
+func (fs *Dat9FS) rescheduleKernelCacheBypassSweepLocked() {
+	var next time.Time
+	for _, marker := range fs.kernelCacheBypass {
+		if marker.expiresAt.IsZero() {
+			continue
+		}
+		if next.IsZero() || marker.expiresAt.Before(next) {
+			next = marker.expiresAt
+		}
+	}
+	if next.IsZero() {
+		if fs.kernelCacheBypassSweepTimer != nil {
+			fs.kernelCacheBypassSweepTimer.Stop()
+			fs.kernelCacheBypassSweepTimer = nil
+		}
+		fs.kernelCacheBypassSweepAt = time.Time{}
+		return
+	}
+	fs.kernelCacheBypassSweepAt = time.Time{}
+	fs.scheduleKernelCacheBypassSweepLocked(next)
+}
+
+// sweepKernelCacheBypass removes expired markers from the timer callback. A
+// stale callback is benign: every marker's current expiresAt is checked under
+// kernelCacheBypassMu before deletion, so a re-armed marker survives and the
+// sweeper reschedules itself to the next live deadline.
+func (fs *Dat9FS) sweepKernelCacheBypass() {
+	if fs == nil {
+		return
+	}
+	if testHookBeforeKernelCacheBypassSweep != nil {
+		testHookBeforeKernelCacheBypassSweep()
+	}
+	now := time.Now()
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	fs.kernelCacheBypassSweepAt = time.Time{}
+	for ino, marker := range fs.kernelCacheBypass {
+		if marker.expiresAt.IsZero() {
+			continue
+		}
+		if now.Before(marker.expiresAt) {
+			continue
+		}
+		delete(fs.kernelCacheBypass, ino)
+		fs.debugf("kernel cache bypass expired path=%s ino=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.revision, marker.size, marker.reason)
+	}
+	fs.rescheduleKernelCacheBypassSweepLocked()
+}
+
+// clearKernelCacheBypassMarkers stops the cleanup sweeper and drops all marker
+// state during graceful shutdown.
+func (fs *Dat9FS) clearKernelCacheBypassMarkers() {
+	if fs == nil {
+		return
+	}
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	if fs.kernelCacheBypassSweepTimer != nil {
+		fs.kernelCacheBypassSweepTimer.Stop()
+		fs.kernelCacheBypassSweepTimer = nil
+	}
+	fs.kernelCacheBypassSweepAt = time.Time{}
+	for ino := range fs.kernelCacheBypass {
+		delete(fs.kernelCacheBypass, ino)
+	}
+}
+
+// kernelCacheBypassActive reports whether a clean read-only open on fh should
+// temporarily bypass the kernel page cache. Expired markers are reclaimed
+// opportunistically here in addition to the timer-driven cleanup path.
+func (fs *Dat9FS) kernelCacheBypassActive(fh *FileHandle) bool {
+	if fs == nil || fh == nil || fh.Ino == 0 {
+		return false
+	}
+	now := time.Now()
+	fs.kernelCacheBypassMu.Lock()
+	defer fs.kernelCacheBypassMu.Unlock()
+	marker, ok := fs.kernelCacheBypass[fh.Ino]
+	if !ok {
+		return false
+	}
+	if !marker.expiresAt.IsZero() && now.After(marker.expiresAt) {
+		delete(fs.kernelCacheBypass, fh.Ino)
+		fs.debugf("kernel cache bypass expired path=%s ino=%d rev=%d size=%d reason=%s", marker.path, marker.ino, marker.revision, marker.size, marker.reason)
+		fs.rescheduleKernelCacheBypassSweepLocked()
+		return false
+	}
+	return marker.ino == fh.Ino
+}
+
+func (fs *Dat9FS) finishSyncCommitKernelCacheBoundary(ino uint64, localPath string, revision, size int64) {
+	if fs == nil || ino == 0 {
+		return
+	}
+	// InodeNotify is best-effort: Linux may still serve stale page/attr cache
+	// immediately after a truncate-first close-sync/write-sync commit even when
+	// the notification call reports success. Keep the per-inode
+	// short-window bypass armed until its TTL expires; this remains narrower
+	// than making every clean reader on sync-durability mounts DIRECT_IO.
+	fs.armKernelCacheBypass(ino, localPath, revision, size, "sync-commit")
+	fs.notifyInodeSync(ino)
+}


### PR DESCRIPTION
Follow-up for PR #880 post-merge review comment https://github.com/mem9-ai/drive9/pull/880#issuecomment-5521182507.

## Summary
- keep the per-inode/generation kernel-cache bypass marker armed for its short TTL after close-sync/write-sync commits, even when synchronous InodeNotify reports success
- coalesce cleanup to one resettable timer per inode and stop timers on generation cleanup / FlushAll, so hot write-sync re-arm does not allocate one timer per commit
- keep expired marker cleanup generation-safe: older callbacks cannot delete newer markers, and no-reopen marker maps still drain after TTL
- preserve the narrowed Direct IO policy: unrelated ordinary clean read-only handles still use FOPEN_KEEP_CACHE
- extend regression/E2E coverage for notify-success, O_TRUNC immediate reads, SetAttr truncate, rename/unlink/recreate isolation, unrelated-file isolation, TTL recovery, repeated re-arm timer reuse, and marker-map cleanup under many no-reopen inodes

## Validation
- go test ./pkg/fuse -run 'TestOpenReadOnlySyncDurability|TestSyncCommit|TestKernelCacheBypass|TestSetAttr_NoKernelNotify' -count=1\n- go test -race ./pkg/fuse -run 'TestSyncCommitNotifySuccessLeavesPerInodeBypassUntilTTL|TestKernelCacheBypassMarkerExpiresAndClearsByGeneration|TestKernelCacheBypassTTLDoesNotClearNewerGeneration|TestKernelCacheBypassRearmReusesTimerAndKeepsOneMarker|TestKernelCacheBypassMarkersExpireWithoutReopen|TestOpenReadOnlySyncDurabilityBypassMarkerUsesDirectIO|TestOpenReadOnlySyncDurabilityKeepsCacheWithoutBypassMarker' -count=1\n- go test ./pkg/fuse -skip 'WaitMount' -count=1\n- make lint\n- bash -n e2e/fuse-supervision-test.sh && git diff --check\n\n## Scope\nThis PR only fixes the #880 post-merge Direct IO marker semantics and cleanup. It does not address #875 SQLite WAL fsync O(n²) write amplification.\n\nDo not merge automatically; waiting for review and qiffang approval.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency when reading files after synchronization and cache invalidation.
  - Ensured recently committed, recreated, and unrelated file contents remain readable and correct after cache updates.

- **Tests**
  - Expanded end-to-end and automated coverage for cache invalidation, file recreation, unrelated files, concurrent updates, and expiration-related behavior.
  - Added verification that clean reads continue to return committed content after cache bypass intervals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->