### PR TITLE
feat: support append-log defaults in mount profiles

### DIFF
--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -61,6 +61,8 @@ type mountBackgroundRequest struct {
 
 var startMountBackground = startMountBackgroundImpl
 var startMountSupervisedBackground = startMountSupervisedBackgroundImpl
+var runSuperviseForeground = runSuperviseForegroundImpl
+var mountProfileAppendLogSupported = probeMountProfileAppendLogSupport
 
 // MountCmd handles the "drive9 mount" command.
 //
@@ -479,6 +481,10 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 		}
 	}
 	*profile = profileCfg.Name
+	if err := validateMountPolicyPatterns(profileCfg.AppendLogPatterns); err != nil {
+		return err
+	}
+	effectiveAppendLogPatterns = mergeProfileValues(profileCfg.AppendLogPatterns, effectiveAppendLogPatterns)
 	effectiveLocalOnlyPatterns := mergeProfileValues(profileCfg.LocalOnlyPatterns, envLocalOnlyPatterns, localOnlyPatterns)
 	effectiveRemoteOnlyPatterns := mergeProfileValues(profileCfg.RemoteOnlyPatterns, envRemoteOnlyPatterns, remoteOnlyPatterns)
 	effectivePackPaths := mergeProfileValues(profileCfg.PackPaths)
@@ -592,6 +598,18 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	}
 	if err := validateMountProfileFlags(profileCfg.Name, normalizedLocalRoot, effectiveLocalOnlyPatterns, effectiveRemoteOnlyPatterns, effectivePackPaths); err != nil {
 		return err
+	}
+	if resolved == MountModeFUSE && runtime.GOOS != "windows" && len(profileCfg.AppendLogPatterns) > 0 {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		supported := mountProfileAppendLogSupported(ctx, serverVal, apiKeyVal, tokenVal)
+		cancel()
+		if !supported {
+			// Keep explicit rules; FUSE retains its existing capability and layout guards.
+			effectiveAppendLogPatterns = mergeProfileValues(envAppendLogPatterns, appendLogPatterns)
+			if !*supervised {
+				fmt.Fprintf(os.Stderr, "drive9: warning: profile %q [append-log] ignored: backend append-log support is unavailable or could not be confirmed; using normal writes for profile-selected files\n", profileCfg.Name)
+			}
+		}
 	}
 
 	autoUnpack := overlayProfile && len(effectivePackPaths) > 0 && !*noAutoUnpack
@@ -948,7 +966,7 @@ func startMountSupervisedBackgroundImpl(req mountSuperviseStartRequest) error {
 	return nil
 }
 
-func runSuperviseForeground(req mountSuperviseStartRequest) error {
+func runSuperviseForegroundImpl(req mountSuperviseStartRequest) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return err
@@ -979,6 +997,17 @@ func runSuperviseForeground(req mountSuperviseStartRequest) error {
 	applyScrubbedMountEnv(scrubbed)
 	_ = exe
 	return runMountSupervise(supArgs[2:])
+}
+
+func probeMountProfileAppendLogSupport(ctx context.Context, server, apiKey, token string) bool {
+	var c *client.Client
+	if token != "" {
+		c = client.NewWithToken(server, token)
+	} else {
+		c = client.New(server, apiKey)
+	}
+	c.Warm(ctx)
+	return c.CachedAppendLogSupported()
 }
 
 // applyScrubbedMountEnv unsets mount credential env vars then applies scrubbed.

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -274,7 +274,8 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	if err != nil {
 		return err
 	}
-	effectiveAppendLogPatterns := mergeProfileValues(envAppendLogPatterns, appendLogPatterns)
+	explicitAppendLogPatterns := mergeProfileValues(envAppendLogPatterns, appendLogPatterns)
+	effectiveAppendLogPatterns := explicitAppendLogPatterns
 
 	if objectLoc != nil {
 		if len(effectiveAppendLogPatterns) > 0 {
@@ -605,7 +606,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 		cancel()
 		if !supported {
 			// Keep explicit rules; FUSE retains its existing capability and layout guards.
-			effectiveAppendLogPatterns = mergeProfileValues(envAppendLogPatterns, appendLogPatterns)
+			effectiveAppendLogPatterns = explicitAppendLogPatterns
 			if !*supervised {
 				fmt.Fprintf(os.Stderr, "drive9: warning: profile %q [append-log] ignored: backend append-log support is unavailable or could not be confirmed; using normal writes for profile-selected files\n", profileCfg.Name)
 			}

--- a/cmd/drive9/cli/mount_profile_append_log_test.go
+++ b/cmd/drive9/cli/mount_profile_append_log_test.go
@@ -1,0 +1,327 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"reflect"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Existing mount tests stub the mount itself and do not exercise status I/O.
+func stubMountProfileAppendLogProbe(t *testing.T) {
+	t.Helper()
+	old := mountProfileAppendLogSupported
+	t.Cleanup(func() { mountProfileAppendLogSupported = old })
+	mountProfileAppendLogSupported = func(context.Context, string, string, string) bool { return true }
+}
+
+func setupMountProfileAppendLogTest(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("Drive9 FUSE is unavailable on Windows")
+	}
+	t.Setenv("HOME", t.TempDir())
+	setResolverEnv(t, nil)
+	t.Setenv(EnvMountAppendLogPatterns, "")
+	t.Setenv(EnvMountLocalOnlyPatterns, "")
+	t.Setenv(EnvMountRemoteOnlyPatterns, "")
+	t.Setenv("DRIVE9_MOUNT_SUPERVISE", "")
+}
+
+func captureProfileMountOptions(t *testing.T) **mountFuseOptions {
+	t.Helper()
+	var got *mountFuseOptions
+	old := mountFuse
+	t.Cleanup(func() { mountFuse = old })
+	mountFuse = func(opts *mountFuseOptions) error {
+		copy := *opts
+		got = &copy
+		return nil
+	}
+	return &got
+}
+
+func TestMountProfileAppendLogCapabilities(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		body   string
+		status int
+		want   bool
+	}{
+		{"supported", `{"storage_capabilities":{"append_log_v1":true},"migration_capabilities":{},"max_upload_bytes":1000000,"inline_threshold":50000}`, 200, true},
+		{"false", `{"storage_capabilities":{"append_log_v1":false}}`, 200, false},
+		{"empty", `{"storage_capabilities":{}}`, 200, false},
+		{"missing", `{}`, 200, false},
+		{"invalid-json", `{`, 200, false},
+		{"invalid-thresholds", `{"storage_capabilities":{"append_log_v1":true},"migration_capabilities":{}}`, 200, false},
+		{"server-error", `{}`, 503, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setupMountProfileAppendLogTest(t)
+			var calls atomic.Int32
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls.Add(1)
+				if r.URL.Path != "/v1/status" || r.Header.Get("Authorization") != "Bearer sk-test" {
+					t.Errorf("unexpected status request: %s, auth=%q", r.URL.Path, r.Header.Get("Authorization"))
+				}
+				w.WriteHeader(tc.status)
+				_, _ = fmt.Fprint(w, tc.body)
+			}))
+			t.Cleanup(srv.Close)
+			got := captureProfileMountOptions(t)
+			stderr, err := captureStderrE(t, func() error {
+				return MountCmd([]string{"--foreground", "--mode=fuse", "--server", srv.URL, "--api-key=sk-test", t.TempDir()})
+			})
+			if err != nil || *got == nil {
+				t.Fatalf("mount = %v, opts = %v", err, *got)
+			}
+			var want []string
+			if tc.want {
+				want = []string{"**/*-wal"}
+			}
+			if !reflect.DeepEqual((*got).AppendLogPatterns, want) {
+				t.Fatalf("patterns = %v, want %v", (*got).AppendLogPatterns, want)
+			}
+			wantWarnings := 1
+			if tc.want {
+				wantWarnings = 0
+			}
+			if n := strings.Count(stderr, "[append-log] ignored:"); n != wantWarnings {
+				t.Fatalf("warnings = %d, stderr = %q", n, stderr)
+			}
+			if calls.Load() != 1 {
+				t.Fatalf("status requests = %d, want 1", calls.Load())
+			}
+		})
+	}
+}
+
+func TestMountProfileAppendLogSources(t *testing.T) {
+	for _, supported := range []bool{true, false} {
+		t.Run(fmt.Sprint(supported), func(t *testing.T) {
+			setupMountProfileAppendLogTest(t)
+			writeTestProfile(t, "custom", "[append-log]\n**/profile.log\n**/shared.log\n")
+			t.Setenv(EnvMountAppendLogPatterns, "**/env.log\n**/shared.log")
+			setResolverEnv(t, map[string]string{EnvVaultToken: "delegated-test"})
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("Authorization") != "Bearer delegated-test" {
+					t.Errorf("wrong delegated identity: %q", r.Header.Get("Authorization"))
+				}
+				_, _ = fmt.Fprintf(w, `{"storage_capabilities":{"append_log_v1":%t}}`, supported)
+			}))
+			t.Cleanup(srv.Close)
+			got := captureProfileMountOptions(t)
+			err := MountCmd([]string{"--foreground", "--mode=fuse", "--server", srv.URL, "--profile=custom", "--append-log=**/flag.log", "--append-log=**/shared.log", t.TempDir()})
+			if err != nil || *got == nil {
+				t.Fatalf("mount = %v, opts = %v", err, *got)
+			}
+			want := []string{"**/env.log", "**/shared.log", "**/flag.log"}
+			if supported {
+				want = []string{"**/profile.log", "**/shared.log", "**/env.log", "**/flag.log"}
+			}
+			if !reflect.DeepEqual((*got).AppendLogPatterns, want) {
+				t.Fatalf("patterns = %v, want %v", (*got).AppendLogPatterns, want)
+			}
+		})
+	}
+}
+
+func TestMountProfileAppendLogSkipsProbe(t *testing.T) {
+	for _, tc := range []struct {
+		name, body string
+		wantError  bool
+	}{
+		{"none", "", false},
+		{"custom-empty", "[local]\n**/scratch/**\n", false},
+		{"custom-invalid", "[append-log]\n**/../wal\n", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setupMountProfileAppendLogTest(t)
+			if tc.body != "" {
+				writeTestProfile(t, tc.name, tc.body)
+			}
+			old := mountProfileAppendLogSupported
+			t.Cleanup(func() { mountProfileAppendLogSupported = old })
+			mountProfileAppendLogSupported = func(context.Context, string, string, string) bool {
+				t.Fatal("unexpected capability probe")
+				return false
+			}
+			got := captureProfileMountOptions(t)
+			stderr, err := captureStderrE(t, func() error {
+				return MountCmd([]string{"--foreground", "--mode=fuse", "--server=https://unused.invalid", "--api-key=sk-test", "--profile=" + tc.name, "--append-log=**/explicit.log", t.TempDir()})
+			})
+			if (err != nil) != tc.wantError {
+				t.Fatalf("mount error = %v", err)
+			}
+			if strings.Contains(stderr, "[append-log] ignored:") {
+				t.Fatalf("unexpected warning: %s", stderr)
+			}
+			if !tc.wantError && (*got == nil || !reflect.DeepEqual((*got).AppendLogPatterns, []string{"**/explicit.log"})) {
+				t.Fatalf("explicit rules lost: %v", *got)
+			}
+		})
+	}
+}
+
+func TestMountProfileAppendLogProbeFailures(t *testing.T) {
+	for _, kind := range []string{"timeout", "connection"} {
+		t.Run(kind, func(t *testing.T) {
+			setupMountProfileAppendLogTest(t)
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { <-r.Context().Done() }))
+			t.Cleanup(srv.Close)
+			if kind == "connection" {
+				srv.Close()
+			}
+			old := mountProfileAppendLogSupported
+			t.Cleanup(func() { mountProfileAppendLogSupported = old })
+			mountProfileAppendLogSupported = func(ctx context.Context, server, apiKey, token string) bool {
+				deadline, ok := ctx.Deadline()
+				if !ok || time.Until(deadline) > 5*time.Second {
+					t.Fatal("mount preflight needs a bounded deadline")
+				}
+				ctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+				defer cancel()
+				return old(ctx, server, apiKey, token)
+			}
+			got := captureProfileMountOptions(t)
+			stderr, err := captureStderrE(t, func() error {
+				return MountCmd([]string{"--foreground", "--mode=fuse", "--server", srv.URL, "--api-key=sk-test", t.TempDir()})
+			})
+			if err != nil || *got == nil || len((*got).AppendLogPatterns) != 0 {
+				t.Fatalf("mount = %v, opts = %v", err, *got)
+			}
+			if strings.Count(stderr, "[append-log] ignored:") != 1 {
+				t.Fatalf("missing warning: %q", stderr)
+			}
+		})
+	}
+}
+
+func TestMountProfileAppendLogWarningBeforeStart(t *testing.T) {
+	for _, mode := range []string{"foreground", "background", "legacy", "supervise-foreground", "worker"} {
+		t.Run(mode, func(t *testing.T) {
+			setupMountProfileAppendLogTest(t)
+			oldProbe := mountProfileAppendLogSupported
+			oldFuse, oldBackground, oldSupervised, oldForeground := mountFuse, startMountBackground, startMountSupervisedBackground, runSuperviseForeground
+			t.Cleanup(func() {
+				mountProfileAppendLogSupported = oldProbe
+				mountFuse = oldFuse
+				startMountBackground = oldBackground
+				startMountSupervisedBackground = oldSupervised
+				runSuperviseForeground = oldForeground
+			})
+			probed := false
+			mountProfileAppendLogSupported = func(context.Context, string, string, string) bool { probed = true; return false }
+			stderr, err := os.CreateTemp(t.TempDir(), "stderr")
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldStderr := os.Stderr
+			os.Stderr = stderr
+			t.Cleanup(func() { os.Stderr = oldStderr; _ = stderr.Close() })
+			stopped := errors.New("mount start reached")
+			check := func(actual string) error {
+				if actual != mode || !probed {
+					t.Fatalf("start = %s, probe = %t", actual, probed)
+				}
+				data, err := os.ReadFile(stderr.Name())
+				if err != nil {
+					t.Fatal(err)
+				}
+				want := 1
+				if mode == "worker" {
+					want = 0
+				}
+				if n := strings.Count(string(data), "[append-log] ignored:"); n != want {
+					t.Fatalf("warnings before start = %d, want %d: %s", n, want, data)
+				}
+				return stopped
+			}
+			mountFuse = func(opts *mountFuseOptions) error {
+				if len(opts.AppendLogPatterns) != 0 {
+					t.Fatal("unsupported profile rules reached FUSE")
+				}
+				if opts.Supervised {
+					return check("worker")
+				}
+				return check("foreground")
+			}
+			startMountBackground = func(mountBackgroundRequest) error { return check("legacy") }
+			startMountSupervisedBackground = func(mountSuperviseStartRequest) error { return check("background") }
+			runSuperviseForeground = func(mountSuperviseStartRequest) error { return check("supervise-foreground") }
+			args := []string{"--mode=fuse", "--server=https://unused.invalid", "--api-key=sk-test"}
+			switch mode {
+			case "foreground":
+				args = append(args, "--foreground")
+			case "legacy":
+				args = append(args, "--no-supervise")
+			case "supervise-foreground":
+				args = append(args, "--supervise-foreground")
+			case "worker":
+				args = append(args, "--foreground", "--supervised")
+			}
+			if err := MountCmd(append(args, t.TempDir())); !errors.Is(err, stopped) {
+				t.Fatalf("mount error = %v", err)
+			}
+		})
+	}
+}
+
+func TestMountProfileAppendLogWorkerReloads(t *testing.T) {
+	setupMountProfileAppendLogTest(t)
+	writeTestProfile(t, "custom", "[append-log]\n**/original.log\n")
+	t.Setenv(EnvMountAppendLogPatterns, "**/env.log")
+	var supported atomic.Bool
+	supported.Store(true)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = fmt.Fprintf(w, `{"storage_capabilities":{"append_log_v1":%t}}`, supported.Load())
+	}))
+	t.Cleanup(srv.Close)
+	var req mountSuperviseStartRequest
+	old := startMountSupervisedBackground
+	t.Cleanup(func() { startMountSupervisedBackground = old })
+	startMountSupervisedBackground = func(r mountSuperviseStartRequest) error { req = r; return nil }
+	got := captureProfileMountOptions(t)
+	if err := MountCmd([]string{"--mode=fuse", "--server", srv.URL, "--api-key=sk-test", "--profile=custom", t.TempDir()}); err != nil {
+		t.Fatal(err)
+	}
+	if *got != nil {
+		t.Fatal("parent mounted in process")
+	}
+	if strings.Contains(strings.Join(req.OriginalArgs, " "), "original.log") {
+		t.Fatal("profile pattern materialized as flag")
+	}
+	if !containsString(req.OriginalArgs, "--append-log=**/env.log") {
+		t.Fatal("env pattern not snapshotted")
+	}
+	if err := os.WriteFile(profileConfigPath("custom"), []byte("[append-log]\n**/updated.log\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	args := workerArgsForSupervise(req.OriginalArgs)
+	for _, enabled := range []bool{true, false} {
+		supported.Store(enabled)
+		setResolverEnv(t, map[string]string{EnvServer: req.Server, EnvAPIKey: req.APIKey})
+		stderr, err := captureStderrE(t, func() error { return MountCmd(args[1:]) })
+		if err != nil || *got == nil {
+			t.Fatalf("worker mount = %v, opts = %v", err, *got)
+		}
+		want := []string{"**/env.log"}
+		if enabled {
+			want = []string{"**/updated.log", "**/env.log"}
+		}
+		if !reflect.DeepEqual((*got).AppendLogPatterns, want) {
+			t.Fatalf("worker patterns = %v, want %v", (*got).AppendLogPatterns, want)
+		}
+		if strings.Contains(stderr, "[append-log] ignored:") {
+			t.Fatalf("worker repeated warning: %s", stderr)
+		}
+	}
+}

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -1386,8 +1386,10 @@ func TestMountCmdIgnoresGVisorCompatEnvironmentForNonFUSEMounts(t *testing.T) {
 			return nil
 		}
 		t.Setenv("HOME", t.TempDir())
-		t.Setenv(EnvServer, "https://drive9.example")
-		t.Setenv(EnvAPIKey, "sk-test")
+		setResolverEnv(t, map[string]string{
+			EnvServer: "https://drive9.example",
+			EnvAPIKey: "sk-test",
+		})
 
 		if err := MountCmd([]string{
 			"--foreground",

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -891,6 +891,7 @@ func TestResolveMountCredentials_MissingServer(t *testing.T) {
 }
 
 func TestMountCmdStartsBackgroundByDefault(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldStartMountBackground := startMountBackground
 	oldStartSupervised := startMountSupervisedBackground
 	oldMountFuse := mountFuse
@@ -946,6 +947,7 @@ func TestMountCmdStartsBackgroundByDefault(t *testing.T) {
 }
 
 func TestMountCmdNoSuperviseUsesLegacyBackground(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldStartMountBackground := startMountBackground
 	oldStartSupervised := startMountSupervisedBackground
 	oldMountFuse := mountFuse
@@ -997,6 +999,7 @@ func TestMountCmdNoSuperviseUsesLegacyBackground(t *testing.T) {
 }
 
 func TestMountCmdVaultStartsBackgroundByDefault(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("vault FUSE mounts are unsupported on Windows")
 	}
@@ -1206,6 +1209,7 @@ func TestConsumeAppendLogPatternsEnv(t *testing.T) {
 }
 
 func TestMountCmdPassesLegacyDirStatFallbackOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1240,6 +1244,7 @@ func TestMountCmdPassesLegacyDirStatFallbackOption(t *testing.T) {
 }
 
 func TestMountCmdLeavesLegacyDirStatFallbackDisabledByDefault(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1269,6 +1274,7 @@ func TestMountCmdLeavesLegacyDirStatFallbackDisabledByDefault(t *testing.T) {
 }
 
 func TestMountCmdResolvesGVisorCompat(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	tests := []struct {
 		name     string
 		env      string
@@ -1409,6 +1415,7 @@ func TestMountCmdRejectsInvalidGVisorCompatEnvironment(t *testing.T) {
 }
 
 func TestMountCmdPassesLayerRefOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1443,6 +1450,7 @@ func TestMountCmdPassesLayerRefOption(t *testing.T) {
 }
 
 func TestMountCmdCheckpointRequiresLayer(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 	mountFuse = func(opts *mountFuseOptions) error {
@@ -1467,6 +1475,7 @@ func TestMountCmdCheckpointRequiresLayer(t *testing.T) {
 }
 
 func TestMountCmdPassesTrustLocalEventsOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1497,6 +1506,7 @@ func TestMountCmdPassesTrustLocalEventsOption(t *testing.T) {
 }
 
 func TestMountCmdLeavesTrustLocalEventsDisabledByDefault(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1539,6 +1549,7 @@ func TestMountCmdRejectsTrustLocalEventsWithWebDAV(t *testing.T) {
 }
 
 func TestMountCmdPassesReadCacheMaxFileOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1569,6 +1580,7 @@ func TestMountCmdPassesReadCacheMaxFileOption(t *testing.T) {
 }
 
 func TestMountCmdLeavesReadCacheTTLUnsetByDefault(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1598,6 +1610,7 @@ func TestMountCmdLeavesReadCacheTTLUnsetByDefault(t *testing.T) {
 }
 
 func TestMountCmdPassesReadCacheTTLOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1628,6 +1641,7 @@ func TestMountCmdPassesReadCacheTTLOption(t *testing.T) {
 }
 
 func TestMountCmdReadCacheTTLZeroDisablesTimeExpiry(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1699,6 +1713,7 @@ func TestMountCmdRejectsZeroDiskReadCacheFreeRatio(t *testing.T) {
 }
 
 func TestMountCmdPassesReadConcurrencyOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1729,6 +1744,7 @@ func TestMountCmdPassesReadConcurrencyOption(t *testing.T) {
 }
 
 func TestMountCmdPassesParallelReadOptions(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1763,6 +1779,7 @@ func TestMountCmdPassesParallelReadOptions(t *testing.T) {
 }
 
 func TestMountCmdPassesUploadConcurrencyOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1849,6 +1866,7 @@ func TestMountCmdRejectsInvalidUploadConcurrency(t *testing.T) {
 }
 
 func TestMountCmdPassesDirCacheMaxEntriesOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1878,6 +1896,7 @@ func TestMountCmdPassesDirCacheMaxEntriesOption(t *testing.T) {
 }
 
 func TestMountCmdPassesCommitQueueMaxPendingOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1939,6 +1958,7 @@ func TestMountCmdRejectsInvalidCommitQueueMaxPending(t *testing.T) {
 }
 
 func TestMountCmdPassesFuseSyncReadOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1969,6 +1989,7 @@ func TestMountCmdPassesFuseSyncReadOption(t *testing.T) {
 }
 
 func TestMountCmdMapsDirectMountStrictOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2049,6 +2070,7 @@ func TestMountCmdRejectsDirectMountStrictOutsideLinux(t *testing.T) {
 }
 
 func TestMountCmdMapsDurabilityOption(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2121,6 +2143,7 @@ func TestMountCmdMapsDurabilityOption(t *testing.T) {
 }
 
 func TestMountCmdPassesContinuousPerfOptions(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2167,6 +2190,7 @@ func TestMountCmdPassesContinuousPerfOptions(t *testing.T) {
 }
 
 func TestMountCmdPerfDirSetsDefaultProfilingOptions(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2220,6 +2244,7 @@ func TestMountCmdPerfDirSetsDefaultProfilingOptions(t *testing.T) {
 }
 
 func TestMountCmdPerfDirKeepsAdvancedControls(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2378,6 +2403,7 @@ func TestMountCmdRejectsInvalidPerfRetentionFileCounts(t *testing.T) {
 }
 
 func TestMountCmdPerfCPUIntervalUsesDefaultDuration(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2412,6 +2438,7 @@ func TestMountCmdPerfCPUIntervalUsesDefaultDuration(t *testing.T) {
 }
 
 func TestMountCmdPerfCPUDurationUsesDefaultInterval(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2461,6 +2488,7 @@ func TestMountCmdRejectsPerfCPUDurationNotLessThanInterval(t *testing.T) {
 }
 
 func TestMountCmdLeavesDefaultTTLsUnsetForFuseDefaults(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2493,6 +2521,7 @@ func TestMountCmdLeavesDefaultTTLsUnsetForFuseDefaults(t *testing.T) {
 }
 
 func TestMountCmdPreservesExplicitTTLs(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2532,6 +2561,7 @@ func TestMountCmdPreservesExplicitTTLs(t *testing.T) {
 }
 
 func TestMountCmdCodingAgentProfilePassesPolicyOptions(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2577,6 +2607,7 @@ func TestMountCmdCodingAgentProfilePassesPolicyOptions(t *testing.T) {
 }
 
 func TestMountCmdCodingAgentProfileMergesPolicyEnvironment(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2620,6 +2651,7 @@ func TestMountCmdCodingAgentProfileMergesPolicyEnvironment(t *testing.T) {
 }
 
 func TestMountCmdPassesAppendLogPatterns(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2654,6 +2686,7 @@ func TestMountCmdPassesAppendLogPatterns(t *testing.T) {
 }
 
 func TestMountCmdMaterializesAppendLogEnvironmentInSupervisedArgs(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("supervised mounts are disabled on Windows")
 	}
@@ -2724,6 +2757,7 @@ func TestMountCmdRejectsAppendLogOutsideDrive9FUSE(t *testing.T) {
 }
 
 func TestMountCmdMaterializesPolicyEnvironmentInSupervisedArgs(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("supervised mounts are disabled on Windows")
 	}
@@ -2765,6 +2799,7 @@ func TestMountCmdMaterializesPolicyEnvironmentInSupervisedArgs(t *testing.T) {
 }
 
 func TestMountCmdPortableProfilePassesCodingAgentPolicyAndAllLocalPackPath(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -2808,6 +2843,7 @@ func TestMountCmdPortableProfilePassesCodingAgentPolicyAndAllLocalPackPath(t *te
 }
 
 func TestMountCmdCodingAgentProfileGeneratesDefaultLocalRoot(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 

--- a/cmd/drive9/cli/pack_test.go
+++ b/cmd/drive9/cli/pack_test.go
@@ -958,6 +958,7 @@ func TestPackAuthFromMountStateUsesCredentialSnapshot(t *testing.T) {
 }
 
 func TestMountCmdUnpacksBeforeFuseMount(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 
@@ -1009,6 +1010,7 @@ func TestMountCmdUnpacksBeforeFuseMount(t *testing.T) {
 }
 
 func TestMountCmdAutoUnpacksCodingAgentPackBeforeFuseMount(t *testing.T) {
+	stubMountProfileAppendLogProbe(t)
 	oldMountFuse := mountFuse
 	t.Cleanup(func() { mountFuse = oldMountFuse })
 	writeTestProfile(t, "with-pack", "[pack]\n.git\n")

--- a/cmd/drive9/cli/profile.go
+++ b/cmd/drive9/cli/profile.go
@@ -20,6 +20,7 @@ type profileConfig struct {
 	Source             string
 	LocalOnlyPatterns  []string
 	RemoteOnlyPatterns []string
+	AppendLogPatterns  []string
 	PackPaths          []string
 }
 
@@ -144,6 +145,7 @@ func builtinCodingAgentProfile() profileConfig {
 		Source:             "builtin:coding-agent",
 		LocalOnlyPatterns:  builtinCodingAgentLocalOnlyPatterns(),
 		RemoteOnlyPatterns: nil,
+		AppendLogPatterns:  []string{"**/*-wal"},
 		PackPaths:          nil,
 	}
 }
@@ -215,7 +217,7 @@ func parseProfileConfig(name, source, body string) (profileConfig, error) {
 		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
 			section = strings.ToLower(strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(line, "["), "]")))
 			switch section {
-			case "local", "remote", "pack":
+			case "local", "remote", "pack", "append-log":
 			default:
 				return profileConfig{}, fmt.Errorf("profile %q line %d: unknown section [%s]", name, lineNo+1, section)
 			}
@@ -228,6 +230,8 @@ func parseProfileConfig(name, source, body string) (profileConfig, error) {
 			cfg.RemoteOnlyPatterns = append(cfg.RemoteOnlyPatterns, line)
 		case "pack":
 			cfg.PackPaths = append(cfg.PackPaths, line)
+		case "append-log":
+			cfg.AppendLogPatterns = append(cfg.AppendLogPatterns, line)
 		}
 	}
 	return cfg, nil
@@ -242,6 +246,7 @@ func formatProfileConfig(cfg profileConfig) string {
 	writeProfileSection(&b, "local", cfg.LocalOnlyPatterns, "no local-only overlay paths")
 	writeProfileSection(&b, "remote", cfg.RemoteOnlyPatterns, "no remote override paths")
 	writeProfileSection(&b, "pack", cfg.PackPaths, "no automatic pack paths")
+	writeProfileSection(&b, "append-log", cfg.AppendLogPatterns, "no append-log optimization paths")
 	return b.String()
 }
 

--- a/cmd/drive9/cli/profile_test.go
+++ b/cmd/drive9/cli/profile_test.go
@@ -2,9 +2,80 @@ package cli
 
 import (
 	"reflect"
+	"sort"
 	"strings"
 	"testing"
 )
+
+func TestProfileAppendLogRoundTrip(t *testing.T) {
+	writeTestProfile(t, "verdent", "# custom\n[local]\n**/.cache/**\n[append-log]\n# WAL files\n **/*-wal \n\n**/events.log\n[remote]\n**/.cache/keep/**\n[pack]\n.git\n")
+	cfg, err := loadProfileConfig("verdent")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := formatProfileConfig(cfg)
+	for _, want := range []string{"[append-log]\n**/*-wal\n**/events.log\n", "[local]\n**/.cache/**", "[remote]\n**/.cache/keep/**", "[pack]\n.git"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("profile output = %q, want %q", out, want)
+		}
+	}
+	roundTrip, err := parseProfileConfig(cfg.Name, cfg.Source, out)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(roundTrip, cfg) {
+		t.Fatalf("round trip = %#v, want %#v", roundTrip, cfg)
+	}
+}
+
+func TestProfileAppendLogDefaults(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	for _, name := range []string{"", "coding-agent", "portable", "none", "interactive"} {
+		cfg, err := loadProfileConfig(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want := "[append-log]\n# no append-log optimization paths\n"
+		if name == "" || name == "coding-agent" {
+			want = "[append-log]\n**/*-wal\n"
+		}
+		if out := formatProfileConfig(cfg); !strings.Contains(out, want) {
+			t.Fatalf("profile %q output = %q, want %q", name, out, want)
+		}
+	}
+}
+
+func TestProfileAppendLogCustomReplacesBuiltin(t *testing.T) {
+	for _, body := range []string{"[local]\n**/scratch/**\n", "[append-log]\n**/events.log\n"} {
+		writeTestProfile(t, "coding-agent", body)
+		cfg, err := loadProfileConfig("coding-agent")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if out := formatProfileConfig(cfg); strings.Contains(out, "**/*-wal") {
+			t.Fatalf("custom profile inherited builtin append-log rule: %q", out)
+		}
+	}
+}
+
+func TestProfileAppendLogFormattingDoesNotMutateConfig(t *testing.T) {
+	cfg, err := parseProfileConfig("custom", "test", "[append-log]\n**/z.log\n**/a.log\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	before := formatProfileConfig(cfg)
+	after, err := parseProfileConfig(cfg.Name, cfg.Source, before)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reflect.DeepEqual(cfg, after) {
+		t.Fatal("formatter mutated source rules or failed to sort output")
+	}
+	sort.Strings(cfg.AppendLogPatterns)
+	if !reflect.DeepEqual(cfg, after) {
+		t.Fatalf("formatted config = %#v, want %#v", after, cfg)
+	}
+}
 
 func TestLoadProfileConfigDefaultCodingAgentHasNoPackPaths(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())

--- a/docs/design/pack-unpack-profile-spec.md
+++ b/docs/design/pack-unpack-profile-spec.md
@@ -53,11 +53,12 @@ The archive is uploaded to Drive9. It is not stored inside the local root.
 
 ### Profiles
 
-A profile controls three things:
+A profile controls four things:
 
 - `[local]`: paths that should live in the local overlay;
 - `[remote]`: overrides that force paths back to Drive9-managed remote storage;
 - `[pack]`: local overlay paths that should be included when packing.
+- `[append-log]`: remote-persistent file patterns eligible for append-log sync optimization.
 
 The built-in profiles are:
 
@@ -69,6 +70,49 @@ The built-in profiles are:
 
 `coding-agent` is optimized for interactive local performance. `portable` is
 optimized for moving that local overlay state across machines.
+
+### Append-log defaults
+
+The built-in `coding-agent` profile includes:
+
+```ini
+[append-log]
+**/*-wal
+```
+
+This matches SQLite WAL files such as `db-wal`, `state.db-wal`, and
+`state.sqlite-wal` at the mount root or in subdirectories. It does not match
+database main files or `-shm` files. Other built-in profiles have no default
+append-log rules. These patterns enable the existing synchronization optimization;
+they do not change local/remote routing, durability, or flush timing. Local-only
+files, Git workspaces, and layer mounts retain their existing exclusions.
+
+For Drive9 FUSE mounts, the CLI checks the backend's `append_log_v1` capability
+before starting the mount, with a five-second timeout. When the capability is
+false, missing, or cannot be confirmed, it ignores the profile's append-log rules
+and prints one warning to the caller's stderr, including before background
+mounts detach. Ordinary mount startup continues. Supervised workers check again
+on startup without repeating the warning. No probe is made for empty profile rules.
+
+When supported, rules are combined in profile, environment, then flag order and
+deduplicated. Explicit `DRIVE9_MOUNT_APPEND_LOG_PATTERNS` and `--append-log` rules
+retain their existing behavior and FUSE capability guards even if profile rules
+are ignored. Invalid patterns remain configuration errors. Disabling this
+optimization does not change how existing append-log file layouts are handled.
+
+`drive9 profile show` includes `[append-log]` without contacting the server.
+To customize a profile for Verdent, for example:
+
+```bash
+mkdir -p ~/.drive9/profiles
+drive9 profile show coding-agent > ~/.drive9/profiles/verdent
+```
+
+Edit the exported file's `[append-log]` section and mount with `--profile verdent`.
+Each section accepts one pattern per line, blank lines, and whole-line `#`
+comments. A user profile file completely replaces the same-named built-in
+profile; omitting `[append-log]` from a custom `coding-agent` file disables its
+profile defaults. Profiles do not inherit from each other.
 
 ## Default Archive Location
 

--- a/pkg/fuse/append_log.go
+++ b/pkg/fuse/append_log.go
@@ -1104,7 +1104,13 @@ func (fs *Dat9FS) tryAppendLogPathTruncate(ctx context.Context, entry *InodeEntr
 	if fs == nil || fs.client == nil || entry == nil || entry.Revision <= 0 || !fs.appendLogPathConfigured(entry.Path) {
 		return false, gofuse.OK
 	}
+	return fs.rewriteAppendLogPathTruncate(ctx, entry, ino, pid, newSize, data)
+}
 
+// rewriteAppendLogPathTruncate verifies the physical layout and revision before
+// rewriting a configured path or one rejected with append_log_unsupported.
+// The caller holds the path commit lock and supplies a committed inode entry.
+func (fs *Dat9FS) rewriteAppendLogPathTruncate(ctx context.Context, entry *InodeEntry, ino uint64, pid uint32, newSize int64, data []byte) (bool, gofuse.Status) {
 	apiPath := fs.remotePath(entry.Path)
 	statStart := fs.perfStart()
 	stat, err := fs.client.StatCtx(ctx, apiPath)

--- a/pkg/fuse/append_log_rewrite_test.go
+++ b/pkg/fuse/append_log_rewrite_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"runtime"
@@ -784,42 +785,46 @@ func TestAppendLogGenericUnsupportedReroutesOnceToFullPUT(t *testing.T) {
 }
 
 func TestAppendLogGenericUnsupportedReroutesUnmatchedPhysicalAppendLayout(t *testing.T) {
-	var putCalls int
-	fs, fh, closeServer := newAppendLogEngineFixture(t, false, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method != http.MethodPut {
-			t.Errorf("method = %s, want PUT", r.Method)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		putCalls++
-		body, _ := io.ReadAll(r.Body)
-		if got := string(body); got != "pretail" {
-			t.Errorf("full rewrite body = %q, want pretail", got)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-		_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 6})
-	})
-	defer closeServer()
-	fs.appendLogMatcher = NewAppendLogMatcher([]string{"/configured/**"})
-	if fs.appendLogPathConfigured(fh.Path) {
-		t.Fatal("fixture path unexpectedly matches append-log policy")
-	}
+	for _, patterns := range [][]string{{"/configured/**"}, nil} {
+		t.Run(fmt.Sprint(patterns), func(t *testing.T) {
+			var putCalls int
+			fs, fh, closeServer := newAppendLogEngineFixture(t, false, func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPut {
+					t.Errorf("method = %s, want PUT", r.Method)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				putCalls++
+				body, _ := io.ReadAll(r.Body)
+				if got := string(body); got != "pretail" {
+					t.Errorf("full rewrite body = %q, want pretail", got)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 6})
+			})
+			defer closeServer()
+			fs.appendLogMatcher = NewAppendLogMatcher(patterns)
+			if fs.appendLogPathConfigured(fh.Path) {
+				t.Fatal("fixture path unexpectedly matches append-log policy")
+			}
 
-	fh.Lock()
-	handled, status := fs.routeAppendLogGenericUnsupportedLocked(
-		context.Background(),
-		fh,
-		fh.Path,
-		fh.DirtySeq,
-		&client.StatusError{StatusCode: http.StatusBadRequest, Code: client.AppendLogCodeUnsupported},
-	)
-	fh.Unlock()
-	if !handled || status != gofuse.OK || putCalls != 1 {
-		t.Fatalf("handled/status/puts = %t/%d/%d, want true/OK/1", handled, status, putCalls)
-	}
-	if got := fh.appendLogLayoutAt(6, 7); got != client.ContentLayoutAppendLog {
-		t.Fatalf("observed layout = %q, want append_log", got)
+			fh.Lock()
+			handled, status := fs.routeAppendLogGenericUnsupportedLocked(
+				context.Background(),
+				fh,
+				fh.Path,
+				fh.DirtySeq,
+				&client.StatusError{StatusCode: http.StatusBadRequest, Code: client.AppendLogCodeUnsupported},
+			)
+			fh.Unlock()
+			if !handled || status != gofuse.OK || putCalls != 1 {
+				t.Fatalf("handled/status/puts = %t/%d/%d, want true/OK/1", handled, status, putCalls)
+			}
+			if got := fh.appendLogLayoutAt(6, 7); got != client.ContentLayoutAppendLog {
+				t.Fatalf("observed layout = %q, want append_log", got)
+			}
+		})
 	}
 }
 
@@ -862,6 +867,118 @@ func TestAppendLogPathTruncateReusesSetAttrCommitLock(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("append-log truncate attempted to reacquire SetAttr's path lock")
+	}
+}
+
+func TestAppendLogPathTruncateWithoutRulesFallsBackToConditionalPUT(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		size         int64
+		headRevision int64
+		initStatus   int
+		putStatus    int
+		wantHeads    int
+		wantPuts     int
+		wantSuccess  bool
+	}{
+		{"shrink", 5, 5, 400, 200, 1, 1, true},
+		{"grow", 12, 5, 400, 200, 1, 1, true},
+		{"streamed-grow", maxPathTruncateInMemoryBytes + 1, 5, 400, 200, 1, 1, true},
+		{"stale-revision", 5, 6, 400, 200, 1, 0, false},
+		{"put-conflict", 5, 5, 400, 409, 1, 1, false},
+		{"put-unsupported-no-retry", 5, 5, 400, 400, 1, 1, false},
+		{"unrelated-error-no-fallback", 5, 5, 503, 200, 0, 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			original := []byte("abcdefgh")
+			var initCalls, headCalls, putCalls int
+			fs, _, closeServer := newAppendLogEngineFixture(t, false, func(w http.ResponseWriter, r *http.Request) {
+				switch r.Method {
+				case http.MethodGet:
+					http.ServeContent(w, r, "db-wal", time.Time{}, bytes.NewReader(original))
+				case http.MethodPost:
+					initCalls++
+					if r.URL.Path != "/v2/uploads/initiate" {
+						t.Errorf("unexpected POST %s", r.URL)
+					}
+					code := client.AppendLogCodeUnsupported
+					if tc.initStatus != http.StatusBadRequest {
+						code = "unavailable"
+					}
+					w.WriteHeader(tc.initStatus)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "code": code})
+				case http.MethodHead:
+					headCalls++
+					w.Header().Set("Content-Length", fmt.Sprint(len(original)))
+					w.Header().Set("X-Dat9-Revision", fmt.Sprint(tc.headRevision))
+					w.Header().Set("X-Dat9-Content-Layout", string(client.ContentLayoutAppendLog))
+				case http.MethodPut:
+					putCalls++
+					if r.Header.Get("X-Dat9-Expected-Revision") != "5" || r.ContentLength != tc.size {
+						t.Errorf("PUT revision/size = %q/%d, want 5/%d", r.Header.Get("X-Dat9-Expected-Revision"), r.ContentLength, tc.size)
+					}
+					prefix := make([]byte, min(tc.size, int64(len(original))))
+					if _, err := io.ReadFull(r.Body, prefix); err != nil || !bytes.Equal(prefix, original[:len(prefix)]) {
+						t.Errorf("PUT prefix = %q, error = %v", prefix, err)
+					}
+					if tc.size <= maxPathTruncateInMemoryBytes {
+						tail, err := io.ReadAll(r.Body)
+						if err != nil || int64(len(tail)) != tc.size-int64(len(prefix)) || bytes.Count(tail, []byte{0}) != len(tail) {
+							t.Errorf("PUT zero fill = %v, error = %v", tail, err)
+						}
+					} else if n, err := io.Copy(io.Discard, r.Body); err != nil || n != tc.size-int64(len(prefix)) {
+						t.Errorf("PUT streamed tail size = %d, error = %v", n, err)
+					}
+					w.WriteHeader(tc.putStatus)
+					if tc.putStatus != http.StatusOK {
+						code := client.AppendLogCodeConflict
+						if tc.putStatus == http.StatusBadRequest {
+							code = client.AppendLogCodeUnsupported
+						}
+						_ = json.NewEncoder(w).Encode(map[string]string{"error": code, "code": code})
+						return
+					}
+					_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 6})
+				default:
+					t.Errorf("unexpected request %s %s", r.Method, r.URL)
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			})
+			defer closeServer()
+			fs.appendLogMatcher = NewAppendLogMatcher(nil)
+			fs.client.SetSmallFileThresholdForTests(1)
+			ino := fs.inodes.Lookup("/db-wal", false, int64(len(original)), time.Now())
+			fs.inodes.UpdateRevision(ino, 5)
+			if len(fs.fileHandlesForInode(ino)) != 0 {
+				t.Fatal("path truncate must not have an open handle")
+			}
+			input := &gofuse.SetAttrIn{}
+			input.NodeId = ino
+			input.Valid = gofuse.FATTR_SIZE
+			input.Size = uint64(tc.size)
+			var out gofuse.AttrOut
+			status := fs.SetAttr(nil, input, &out)
+			if (status == gofuse.OK) != tc.wantSuccess {
+				t.Fatalf("SetAttr status = %v, want success = %t", status, tc.wantSuccess)
+			}
+			if initCalls != 1 || headCalls != tc.wantHeads || putCalls != tc.wantPuts {
+				t.Fatalf("init/head/put calls = %d/%d/%d, want 1/%d/%d", initCalls, headCalls, putCalls, tc.wantHeads, tc.wantPuts)
+			}
+			entry, ok := fs.inodes.GetEntry(ino)
+			if !ok {
+				t.Fatal("inode disappeared after truncate")
+			}
+			wantRevision, wantSize := int64(5), int64(len(original))
+			if tc.wantSuccess {
+				wantRevision, wantSize = 6, tc.size
+				if out.Size != uint64(tc.size) {
+					t.Fatalf("SetAttr returned size %d, want %d", out.Size, tc.size)
+				}
+			}
+			if entry.Revision != wantRevision || entry.Size != wantSize {
+				t.Fatalf("inode revision/size = %d/%d, want %d/%d", entry.Revision, entry.Size, wantRevision, wantSize)
+			}
+		})
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3623,6 +3623,13 @@ func (fs *Dat9FS) applyRemoteTruncate(ctx context.Context, entry *InodeEntry, in
 	}
 	fs.perfRecordRemote(perfRemoteWrite, writeStart, err, uint64(newSize))
 	if err != nil {
+		if appendLogErrorCode(err) == client.AppendLogCodeUnsupported && entry.Revision > 0 {
+			// A filtered profile must not disable writes to an existing append-log layout.
+			// Reuse the conditional rewrite once; never retry the rejected generic upload.
+			if handled, status := fs.rewriteAppendLogPathTruncate(ctx, entry, ino, pid, newSize, data); handled {
+				return status
+			}
+		}
 		return httpToFuseStatus(err)
 	}
 

--- a/pkg/fuse/local_policy_test.go
+++ b/pkg/fuse/local_policy_test.go
@@ -187,6 +187,8 @@ func TestAppendLogPolicyMatchesSQLiteWALGlob(t *testing.T) {
 		path string
 		want bool
 	}{
+		{"/db-wal", true},
+		{"/repo/db-wal", true},
 		{"/repro.db-wal", true},
 		{"/issue-validation/run/case/repro.db-wal", true},
 		{"/repo/other.sqlite-wal", true},


### PR DESCRIPTION
FUSE users currently need explicit append-log flags to optimize SQLite WAL files. Add an `[append-log]` profile section and default `coding-agent` to `**/*-wal`, with parsing, display, and deduplicated merging of profile, environment, and flag rules.

Before mounting or detaching, check the existing backend `append_log_v1` capability. If unavailable or unconfirmed, ignore profile-derived rules and warn the caller while preserving explicit rules and existing FUSE capability guards. Supervised workers recheck without repeating the warning. Existing append-log files retain a conditional PUT fallback for path-based truncation even when profile rules have been filtered out.

Validation:

1. CLI, client, and pathfilter package tests passed; client tests used a temporary local TiDB instance.
2. `make lint` (0 issues), `make build-cli`, gofmt, and `git diff --check` passed. Profile export/reload was verified.
3. Added FUSE regression coverage for empty-match path truncation, size changes, conflicts, and bounded fallback. FUSE runtime validation is deferred to Linux/CI: local macOS FUSE regressions were explicitly excluded after an initial run hit disk free-space guards. The new truncation tests have not been executed.
4. Real directory-bucket backend E2E has not been run. The server contract was checked read-only in the fs repository; no server changes are included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added append-log pattern support to mount profiles, including a default for the coding-agent profile.
  * Append-log rules can be combined from profiles, environment settings, and command-line options.
  * Mounts now detect backend support before enabling append-log optimization.

* **Bug Fixes**
  * Unsupported backends now fall back to standard writes with a warning.
  * Improved handling of truncation and existing append-log files.

* **Documentation**
  * Documented append-log settings, defaults, capability checks, and rule precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->