### PR TITLE
fix(fuse): rebind stale clean same-path SQLite read candidates

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -4632,6 +4632,46 @@ func (fs *Dat9FS) readSQLitePersistentJournalVisibleRange(path string, skip *Fil
 	return nil, 0, false, gofuse.OK, ""
 }
 
+// rebindStaleCleanSamePathReadCandidateLocked refreshes a clean same-path read
+// candidate whose loaded WriteBuffer is older than the latest committed
+// revision. It keeps DirtySeq unchanged so the candidate remains eligible for
+// the local same-path fast path, and returns false when the candidate is stale
+// but unsafe to rebind so the caller can skip it and fall back to
+// shadowStore/remote.
+func (fs *Dat9FS) rebindStaleCleanSamePathReadCandidateLocked(fh *FileHandle) bool {
+	if fs == nil || fh == nil || fh.Dirty == nil || fh.Dirty.HasDirtyParts() {
+		return false
+	}
+	revision, committedSize, hasSize := fs.latestCommittedRevisionWithSize(fh.Path)
+	if revision <= 0 || revision <= fh.BaseRev {
+		return true
+	}
+	if fh.WriteBackSeq != 0 || fh.ShadowCommitReady || fh.ShadowCommitSeq != 0 ||
+		fh.IsNew || fh.ZeroBase || fh.Unlinked || fh.UnlinkedSnapshot ||
+		fh.UnlinkedData != nil || fh.ShadowReady || fh.ShadowSpill ||
+		fh.Streamer != nil {
+		return false
+	}
+	if fs.pendingIndex != nil && fh.PendingIndexGen != 0 &&
+		fs.pendingIndex.Generation(fh.Path) == fh.PendingIndexGen {
+		return false
+	}
+	if fs.shadowStore != nil && fh.ShadowStageGen != 0 &&
+		fs.shadowStore.ActiveGeneration(fh.Path) == fh.ShadowStageGen {
+		return false
+	}
+	if !hasSize {
+		committedSize = fs.committedHandleSizeLocked(fh)
+	}
+	fh.BaseRev = revision
+	if hasSize && fh.Dirty.Size() >= committedSize {
+		fh.OrigSize = committedSize
+		fh.appendLogRebindLayout(revision, committedSize)
+	}
+	fs.rebindCleanWriteBufferToRemoteLocked(fh, committedSize)
+	return true
+}
+
 func (fs *Dat9FS) readSamePathDirtyHandleAllowJournalsOnce(path string, skip *FileHandle, offset int64, reqSize uint32) ([]byte, int, bool, gofuse.Status, bool) {
 	if fs == nil || fs.openHandles == nil || path == "" || reqSize == 0 {
 		return nil, 0, false, gofuse.OK, false
@@ -4683,6 +4723,13 @@ restartLoop:
 				src.Unlock()
 				pending = true
 				continue restartLoop
+			}
+			if !src.Dirty.HasDirtyParts() &&
+				(fs.shadowStore == nil || (!src.ShadowReady && !src.ShadowSpill)) {
+				if !fs.rebindStaleCleanSamePathReadCandidateLocked(src) {
+					src.Unlock()
+					continue
+				}
 			}
 			size := src.Dirty.Size()
 			if offset >= size {

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -12837,6 +12837,149 @@ func TestReadSQLiteSamePathDirtyHandleSkipsIncompleteCandidate(t *testing.T) {
 	}
 }
 
+func TestReadSQLiteSamePathDirtyRebindsStaleCleanSibling(t *testing.T) {
+	const (
+		filePath = "/workload.db"
+		partSize = int64(4096)
+		fileSize = 2 * partSize
+	)
+	oldData := bytes.Repeat([]byte{'A'}, int(fileSize))
+	newData := bytes.Repeat([]byte{'B'}, int(fileSize))
+	var remoteGets atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/fs"+filePath {
+			http.NotFound(w, r)
+			return
+		}
+		remoteGets.Add(1)
+		w.Header().Set("Content-Length", strconv.FormatInt(fileSize, 10))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newData)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{TrustLocalEvents: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup(filePath, false, fileSize, time.Now())
+	fs.inodes.UpdateRevision(ino, 2)
+
+	stale := &FileHandle{
+		Ino:      ino,
+		Path:     filePath,
+		BaseRev:  2,
+		OrigSize: fileSize,
+		Dirty:    fs.newWriteBuffer(filePath, maxPreloadSize, partSize),
+	}
+	if _, err := stale.Dirty.Write(0, oldData); err != nil {
+		t.Fatalf("seed stale buffer: %v", err)
+	}
+	stale.Dirty.ClearDirty()
+	stale.DirtySeq = fs.markDirtySize(ino, fileSize)
+	fs.openHandles.Add(stale)
+	defer fs.openHandles.Remove(stale)
+
+	fs.recordCommittedRevisionWithSize(filePath, 3, fileSize)
+	fs.inodes.UpdateRevision(ino, 3)
+	fs.inodes.UpdateSize(ino, fileSize)
+
+	readPart := func(offset int64) []byte {
+		t.Helper()
+		got, n, ok, st := fs.readSamePathDirtyHandle(filePath, nil, offset, uint32(partSize))
+		if !ok || st != gofuse.OK {
+			t.Fatalf("read offset=%d ok=%t status=%v, want true/OK", offset, ok, st)
+		}
+		if n != int(partSize) {
+			t.Fatalf("read offset=%d bytes=%d, want %d", offset, n, partSize)
+		}
+		return append([]byte(nil), got[:n]...)
+	}
+	if got := readPart(0); !bytes.Equal(got, newData[:partSize]) {
+		t.Fatalf("first read of part0 = %q, want newData prefix", got)
+	}
+	if got := readPart(0); !bytes.Equal(got, newData[:partSize]) {
+		t.Fatalf("second read of part0 = %q, want newData prefix", got)
+	}
+	if got := readPart(partSize); !bytes.Equal(got, newData[partSize:]) {
+		t.Fatalf("read of part1 = %q, want newData suffix", got)
+	}
+	if got := remoteGets.Load(); got != 2 {
+		t.Fatalf("remote gets = %d, want 2: one per distinct part, not one per FUSE read", got)
+	}
+	if got := stale.BaseRev; got != 3 {
+		t.Fatalf("stale sibling BaseRev = %d, want 3 after rebind", got)
+	}
+}
+
+func TestReadSQLiteSamePathDirtySkipsUnsafeStaleSibling(t *testing.T) {
+	const (
+		filePath = "/workload.db"
+		partSize = int64(4096)
+		fileSize = 2 * partSize
+	)
+	oldData := bytes.Repeat([]byte{'A'}, int(fileSize))
+	newData := bytes.Repeat([]byte{'B'}, int(fileSize))
+	var remoteGets atomic.Int64
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/fs"+filePath {
+			http.NotFound(w, r)
+			return
+		}
+		remoteGets.Add(1)
+		w.Header().Set("Content-Length", strconv.FormatInt(fileSize, 10))
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(newData)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{TrustLocalEvents: true}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup(filePath, false, fileSize, time.Now())
+	fs.inodes.UpdateRevision(ino, 2)
+
+	stale := &FileHandle{
+		Ino:      ino,
+		Path:     filePath,
+		BaseRev:  0,
+		OrigSize: fileSize,
+		IsNew:    true,
+		Dirty:    fs.newWriteBuffer(filePath, maxPreloadSize, partSize),
+	}
+	if _, err := stale.Dirty.Write(0, oldData); err != nil {
+		t.Fatalf("seed stale buffer: %v", err)
+	}
+	stale.Dirty.ClearDirty()
+	stale.DirtySeq = fs.markDirtySize(ino, fileSize)
+	fs.openHandles.Add(stale)
+	defer fs.openHandles.Remove(stale)
+
+	fs.recordCommittedRevisionWithSize(filePath, 3, fileSize)
+	fs.inodes.UpdateRevision(ino, 3)
+	fs.inodes.UpdateSize(ino, fileSize)
+
+	if _, _, ok, st := fs.readSamePathDirtyHandle(filePath, nil, 0, uint32(partSize)); ok || st != gofuse.OK {
+		t.Fatalf("unsafe stale sibling claimed=%t status=%v, want false/OK", ok, st)
+	}
+
+	reader := &FileHandle{Ino: ino, Path: filePath, BaseRev: 3, OrigSize: fileSize}
+	readerID := fs.allocateFileHandle(reader)
+	defer fs.deleteFileHandle(readerID, reader)
+	got, st, err := readDat9FSTestRange(fs, ino, readerID, 0, int(partSize))
+	if err != nil {
+		t.Fatalf("read fallback: %v", err)
+	}
+	if st != gofuse.OK {
+		t.Fatalf("read fallback status = %v, want OK", st)
+	}
+	if !bytes.Equal(got, newData[:partSize]) {
+		t.Fatalf("read fallback bytes = %q, want newData prefix", got)
+	}
+	if remoteGets.Load() == 0 {
+		t.Fatal("unsafe stale sibling skipped but fallback never consulted remote")
+	}
+}
+
 func TestReadCloseSyncSamePathDirtyWriterUsesDirtyBuffer(t *testing.T) {
 	var remoteReads atomic.Int64
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Fixes https://github.com/mem9-ai/drive9/issues/894

## Summary
A clean SQLite main-DB read on the same mount can be served from an older sibling WriteBuffer after a later fsync-committed WAL checkpoint, producing a stale read.

## Root cause
readSamePathDirtyHandleAllowJournalsOnce selects any same-path handle with DirtySeq > 0 and serves its loaded WriteBuffer without checking whether that buffer is older than the latest committed revision. A long-lived checkpoint sidecar handle keeps the pre-checkpoint image loaded and is selected for subsequent reads.

## Change
Add a read-path-specific rebindStaleCleanSamePathReadCandidateLocked helper. For a clean candidate whose BaseRev is below the latest committed revision, it rebinds the buffer to the new revision while keeping DirtySeq unchanged so the local same-path fast path remains usable. Unsafe candidates (new, zero-base, unlinked, shadow-backed, streamed, or pending-staged) are skipped and fall back to shadowStore/remote.

## Scope
- pkg/fuse/dat9fs.go only (47 production lines added)
- No server, CSI, schema, lock-model, or gVisor change

## Tests
- TestReadSQLiteSamePathDirtyRebindsStaleCleanSibling: three reads over two parts assert two remote part loads and local buffer reuse.
- TestReadSQLiteSamePathDirtySkipsUnsafeStaleSibling: unsafe candidate is skipped and the read falls back to remote.

Tests were not executed locally on macOS. gofmt, git diff --check, go vet ./pkg/fuse, and go build ./cmd/drive9 ./pkg/fuse pass. Unified regression/race and the 10MiB checkpoint02 e2e run are planned after development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved same-path reads to refresh stale, clean file data after newer changes are committed.
  * Safely skips stale file handles that cannot be refreshed and continues with an available fallback.
  * Prevented unnecessary repeated remote fetches when reading refreshed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->