### PR TITLE
fix(client): send first-hop Range on inline range reads (#895)

### DIFF
--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -1515,13 +1515,15 @@ func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, lengt
 		}
 
 	case resp.StatusCode == http.StatusPartialContent:
-		if err := validatePartialContentRange(resp, offset); err != nil {
+		end, err := validatePartialContentRange(resp, offset, offset+length-1)
+		if err != nil {
 			_ = resp.Body.Close()
 			return nil, fmt.Errorf("read %s: %w", path, err)
 		}
 		// First-hop Range honored. The body already starts at offset, so
-		// bound it to length without skipping the offset a second time.
-		return &limitedReadCloser{r: io.LimitReader(resp.Body, length), c: resp.Body}, nil
+		// bound it to the declared response range without skipping the
+		// offset a second time.
+		return &limitedReadCloser{r: io.LimitReader(resp.Body, end-offset+1), c: resp.Body}, nil
 
 	case resp.StatusCode == http.StatusRequestedRangeNotSatisfiable:
 		_ = resp.Body.Close()
@@ -1601,43 +1603,53 @@ func (c *Client) sliceBody(rc io.ReadCloser, offset, length int64) (io.ReadClose
 }
 
 // validatePartialContentRange checks that a first-hop 206 response carries a
-// well-formed Content-Range starting at the requested offset. The caller
-// bounds the length via io.LimitReader, so a server-clamped end (EOF) is
-// allowed here.
-func validatePartialContentRange(resp *http.Response, offset int64) error {
+// well-formed Content-Range starting at the requested offset and not extending
+// past the requested end. It returns the declared response end so the caller
+// can bound the body to the declared range. A server-clamped end (EOF) is
+// allowed.
+func validatePartialContentRange(resp *http.Response, offset, requestedEnd int64) (int64, error) {
 	contentRange := resp.Header.Get("Content-Range")
 	if contentRange == "" {
-		return fmt.Errorf("206 response missing Content-Range for offset %d", offset)
+		return 0, fmt.Errorf("206 response missing Content-Range for offset %d", offset)
 	}
 	rest, ok := strings.CutPrefix(contentRange, "bytes ")
 	if !ok {
-		return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+		return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
 	}
 	byteRange, complete, ok := strings.Cut(rest, "/")
 	if !ok {
-		return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+		return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
 	}
+	completeSize := int64(-1)
 	if complete != "*" {
-		if _, err := strconv.ParseInt(complete, 10, 64); err != nil {
-			return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+		var err error
+		completeSize, err = strconv.ParseInt(complete, 10, 64)
+		if err != nil || completeSize < 0 {
+			return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
 		}
 	}
 	startStr, endStr, ok := strings.Cut(byteRange, "-")
 	if !ok || startStr == "" || endStr == "" {
-		return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+		return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
 	}
 	start, err := strconv.ParseInt(startStr, 10, 64)
 	if err != nil {
-		return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+		return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
 	}
 	end, err := strconv.ParseInt(endStr, 10, 64)
 	if err != nil || end < start {
-		return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+		return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
 	}
 	if start != offset {
-		return fmt.Errorf("unexpected Content-Range %q for offset %d", contentRange, offset)
+		return 0, fmt.Errorf("unexpected Content-Range %q for offset %d", contentRange, offset)
 	}
-	return nil
+	if end > requestedEnd {
+		return 0, fmt.Errorf("Content-Range %q extends past requested end %d for offset %d", contentRange, requestedEnd, offset)
+	}
+	if completeSize >= 0 && completeSize <= end {
+		return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+	}
+	return end, nil
 }
 
 type limitedReadCloser struct {

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1599,15 +1600,41 @@ func (c *Client) sliceBody(rc io.ReadCloser, offset, length int64) (io.ReadClose
 	return &limitedReadCloser{r: io.LimitReader(rc, length), c: rc}, nil
 }
 
-// validatePartialContentRange checks that a first-hop 206 response starts at
-// the requested offset. The caller bounds the length via io.LimitReader, so a
-// server-clamped end (EOF) is allowed here.
+// validatePartialContentRange checks that a first-hop 206 response carries a
+// well-formed Content-Range starting at the requested offset. The caller
+// bounds the length via io.LimitReader, so a server-clamped end (EOF) is
+// allowed here.
 func validatePartialContentRange(resp *http.Response, offset int64) error {
 	contentRange := resp.Header.Get("Content-Range")
 	if contentRange == "" {
 		return fmt.Errorf("206 response missing Content-Range for offset %d", offset)
 	}
-	if !strings.HasPrefix(contentRange, fmt.Sprintf("bytes %d-", offset)) {
+	rest, ok := strings.CutPrefix(contentRange, "bytes ")
+	if !ok {
+		return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+	}
+	byteRange, complete, ok := strings.Cut(rest, "/")
+	if !ok {
+		return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+	}
+	if complete != "*" {
+		if _, err := strconv.ParseInt(complete, 10, 64); err != nil {
+			return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+		}
+	}
+	startStr, endStr, ok := strings.Cut(byteRange, "-")
+	if !ok || startStr == "" || endStr == "" {
+		return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+	}
+	start, err := strconv.ParseInt(startStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+	}
+	end, err := strconv.ParseInt(endStr, 10, 64)
+	if err != nil || end < start {
+		return fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+	}
+	if start != offset {
 		return fmt.Errorf("unexpected Content-Range %q for offset %d", contentRange, offset)
 	}
 	return nil

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -1604,9 +1604,10 @@ func (c *Client) sliceBody(rc io.ReadCloser, offset, length int64) (io.ReadClose
 
 // validatePartialContentRange checks that a first-hop 206 response carries a
 // well-formed Content-Range starting at the requested offset and not extending
-// past the requested end. It returns the declared response end so the caller
-// can bound the body to the declared range. A server-clamped end (EOF) is
-// allowed.
+// past the requested end. Byte positions and the complete length must be
+// strict decimal digits, with `*` allowed for the complete length. It returns
+// the declared response end so the caller can bound the body to the declared
+// range. A server-clamped end (EOF) is allowed.
 func validatePartialContentRange(resp *http.Response, offset, requestedEnd int64) (int64, error) {
 	contentRange := resp.Header.Get("Content-Range")
 	if contentRange == "" {
@@ -1622,14 +1623,17 @@ func validatePartialContentRange(resp *http.Response, offset, requestedEnd int64
 	}
 	completeSize := int64(-1)
 	if complete != "*" {
+		if !isDecimalDigits(complete) {
+			return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
+		}
 		var err error
 		completeSize, err = strconv.ParseInt(complete, 10, 64)
-		if err != nil || completeSize < 0 {
+		if err != nil {
 			return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
 		}
 	}
 	startStr, endStr, ok := strings.Cut(byteRange, "-")
-	if !ok || startStr == "" || endStr == "" {
+	if !ok || !isDecimalDigits(startStr) || !isDecimalDigits(endStr) {
 		return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
 	}
 	start, err := strconv.ParseInt(startStr, 10, 64)
@@ -1650,6 +1654,21 @@ func validatePartialContentRange(resp *http.Response, offset, requestedEnd int64
 		return 0, fmt.Errorf("invalid Content-Range %q for offset %d", contentRange, offset)
 	}
 	return end, nil
+}
+
+// isDecimalDigits reports whether s is a non-empty sequence of ASCII digits.
+// HTTP byte-range positions and complete lengths are digit sequences; signed
+// values are not valid.
+func isDecimalDigits(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if s[i] < '0' || s[i] > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 type limitedReadCloser struct {

--- a/pkg/client/transfer.go
+++ b/pkg/client/transfer.go
@@ -1345,7 +1345,7 @@ func newMultipartAbortContext(parent context.Context, timeout time.Duration) (co
 
 // ReadStream reads a file, following 302 redirects for large files.
 func (c *Client) ReadStream(ctx context.Context, path string) (io.ReadCloser, error) {
-	resp, err := c.readWithoutRedirect(ctx, path)
+	resp, err := c.readWithoutRedirect(ctx, path, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1382,7 +1382,7 @@ func (c *Client) ReadStream(ctx context.Context, path string) (io.ReadCloser, er
 	}
 }
 
-func (c *Client) readWithoutRedirect(ctx context.Context, path string) (*http.Response, error) {
+func (c *Client) readWithoutRedirect(ctx context.Context, path, rangeHeader string) (*http.Response, error) {
 	// Disable redirect following so we can detect 302
 	noRedirectClient := *c.httpClient
 	noRedirectClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
@@ -1396,6 +1396,9 @@ func (c *Client) readWithoutRedirect(ctx context.Context, path string) (*http.Re
 	if c.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+c.apiKey)
 	}
+	if rangeHeader != "" {
+		req.Header.Set("Range", rangeHeader)
+	}
 
 	return noRedirectClient.Do(req)
 }
@@ -1408,7 +1411,7 @@ func (c *Client) ResolveReadTarget(ctx context.Context, path string) (*ReadTarge
 }
 
 func (c *Client) resolveReadTarget(ctx context.Context, path string) (*ReadTarget, error) {
-	resp, err := c.readWithoutRedirect(ctx, path)
+	resp, err := c.readWithoutRedirect(ctx, path, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1451,11 +1454,12 @@ func (c *Client) downloadToFileSequential(ctx context.Context, remotePath string
 }
 
 // ReadStreamRange reads at most length bytes from a remote file starting at
-// offset. For large files the server returns a 302 redirect to a presigned S3
-// URL; this method resolves that redirect and issues an HTTP Range request so
-// only the requested bytes are transferred. For inline small files, the server
-// sends the full body and this method returns a reader limited to the requested
-// slice.
+// offset. The Range header is sent on the first hop so inline-served files
+// such as append-log WALs transfer only the requested bytes. For large files
+// the server returns a 302 redirect to a presigned S3 URL; this method
+// resolves that redirect and repeats the Range request. A first-hop 200 (small
+// inline file or an old server that ignores Range) falls back to slicing the
+// full body.
 func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, length int64) (io.ReadCloser, error) {
 	if offset < 0 {
 		return nil, fmt.Errorf("offset must be >= 0")
@@ -1470,7 +1474,7 @@ func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, lengt
 		return nil, fmt.Errorf("offset + length overflows int64")
 	}
 
-	resp, err := c.readWithoutRedirect(ctx, path)
+	resp, err := c.readWithoutRedirect(ctx, path, fmt.Sprintf("bytes=%d-%d", offset, offset+length-1))
 	if err != nil {
 		return nil, err
 	}
@@ -1509,12 +1513,26 @@ func (c *Client) ReadStreamRange(ctx context.Context, path string, offset, lengt
 			return c.sliceBody(resp2.Body, offset, length)
 		}
 
+	case resp.StatusCode == http.StatusPartialContent:
+		if err := validatePartialContentRange(resp, offset); err != nil {
+			_ = resp.Body.Close()
+			return nil, fmt.Errorf("read %s: %w", path, err)
+		}
+		// First-hop Range honored. The body already starts at offset, so
+		// bound it to length without skipping the offset a second time.
+		return &limitedReadCloser{r: io.LimitReader(resp.Body, length), c: resp.Body}, nil
+
+	case resp.StatusCode == http.StatusRequestedRangeNotSatisfiable:
+		_ = resp.Body.Close()
+		return io.NopCloser(bytes.NewReader(nil)), nil
+
 	case resp.StatusCode >= 300:
 		defer func() { _ = resp.Body.Close() }()
 		return nil, readError(resp)
 
 	default:
-		// Small file: full body returned. Skip to offset and limit.
+		// 200: server ignored Range (small inline file or old server).
+		// Skip to offset and limit the read.
 		return c.sliceBody(resp.Body, offset, length)
 	}
 }
@@ -1579,6 +1597,20 @@ func (c *Client) sliceBody(rc io.ReadCloser, offset, length int64) (io.ReadClose
 		}
 	}
 	return &limitedReadCloser{r: io.LimitReader(rc, length), c: rc}, nil
+}
+
+// validatePartialContentRange checks that a first-hop 206 response starts at
+// the requested offset. The caller bounds the length via io.LimitReader, so a
+// server-clamped end (EOF) is allowed here.
+func validatePartialContentRange(resp *http.Response, offset int64) error {
+	contentRange := resp.Header.Get("Content-Range")
+	if contentRange == "" {
+		return fmt.Errorf("206 response missing Content-Range for offset %d", offset)
+	}
+	if !strings.HasPrefix(contentRange, fmt.Sprintf("bytes %d-", offset)) {
+		return fmt.Errorf("unexpected Content-Range %q for offset %d", contentRange, offset)
+	}
+	return nil
 }
 
 type limitedReadCloser struct {

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1656,6 +1656,9 @@ func TestReadStreamRangeFirstHop206BadContentRange(t *testing.T) {
 		{name: "trailing-junk", contentRange: "bytes 5-8/64junk"},
 		{name: "missing-bytes-prefix", contentRange: "chunks 5-8/64"},
 		{name: "empty-complete", contentRange: "bytes 5-8/"},
+		{name: "complete-before-end", contentRange: "bytes 5-8/4"},
+		{name: "negative-complete", contentRange: "bytes 5-8/-1"},
+		{name: "wider-than-requested", contentRange: "bytes 5-100/200"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1528,6 +1528,198 @@ func TestReadStreamRangeLargeFileTreats416AsEOF(t *testing.T) {
 	}
 }
 
+func TestReadStreamRangeFirstHop206ZeroOffset(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/fs/wal" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Range"); got != "bytes=0-3" {
+			http.Error(w, "wrong range: "+got, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Range", "bytes 0-3/64")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("head"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	rc, err := c.ReadStreamRange(context.Background(), "/wal", 0, 4)
+	if err != nil {
+		t.Fatalf("ReadStreamRange: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, _ := io.ReadAll(rc)
+	if string(data) != "head" {
+		t.Errorf("got %q, want %q", data, "head")
+	}
+}
+
+func TestReadStreamRangeFirstHop206NonZeroOffset(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/fs/wal" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Range"); got != "bytes=5-8" {
+			http.Error(w, "wrong range: "+got, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Range", "bytes 5-8/64")
+		w.WriteHeader(http.StatusPartialContent)
+		// Only the requested slice is sent; slicing it a second time would
+		// skip the offset again and return nothing.
+		_, _ = w.Write([]byte("body"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	rc, err := c.ReadStreamRange(context.Background(), "/wal", 5, 4)
+	if err != nil {
+		t.Fatalf("ReadStreamRange: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, _ := io.ReadAll(rc)
+	if string(data) != "body" {
+		t.Errorf("got %q, want %q", data, "body")
+	}
+}
+
+func TestReadStreamRangeFirstHop416EOF(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/fs/wal" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Range", "bytes */64")
+		w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	rc, err := c.ReadStreamRange(context.Background(), "/wal", 100, 4)
+	if err != nil {
+		t.Fatalf("ReadStreamRange: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, err := io.ReadAll(rc)
+	if err != nil {
+		t.Fatalf("ReadAll: %v", err)
+	}
+	if len(data) != 0 {
+		t.Fatalf("expected empty body, got %q", data)
+	}
+}
+
+func TestReadStreamRangeFirstHop200Fallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/fs/small.txt" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Range"); got != "bytes=3-6" {
+			http.Error(w, "wrong range: "+got, http.StatusBadRequest)
+			return
+		}
+		// 200: server ignored Range (small inline file or old server).
+		_, _ = w.Write([]byte("0123456789"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	rc, err := c.ReadStreamRange(context.Background(), "/small.txt", 3, 4)
+	if err != nil {
+		t.Fatalf("ReadStreamRange: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, _ := io.ReadAll(rc)
+	if string(data) != "3456" {
+		t.Errorf("got %q, want %q", data, "3456")
+	}
+}
+
+func TestReadStreamRangeFirstHop206BadContentRange(t *testing.T) {
+	tests := []struct {
+		name         string
+		contentRange string
+	}{
+		{name: "missing"},
+		{name: "wrong-start", contentRange: "bytes 0-3/64"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/fs/wal" {
+					http.NotFound(w, r)
+					return
+				}
+				if tt.contentRange != "" {
+					w.Header().Set("Content-Range", tt.contentRange)
+				}
+				w.WriteHeader(http.StatusPartialContent)
+				_, _ = w.Write([]byte("x"))
+			}))
+			defer srv.Close()
+
+			c := New(srv.URL, "")
+			rc, err := c.ReadStreamRange(context.Background(), "/wal", 5, 4)
+			if err == nil {
+				_ = rc.Close()
+				t.Fatal("ReadStreamRange error = nil, want Content-Range validation failure")
+			}
+			if !strings.Contains(err.Error(), "read /wal:") {
+				t.Fatalf("error %q should include the path", err)
+			}
+		})
+	}
+}
+
+func TestReadStreamRangeFirstHopBoundedTransfer(t *testing.T) {
+	const (
+		walSize = 1 << 20
+		offset  = walSize - 4096
+		length  = 4096
+	)
+	wal := bytes.Repeat([]byte("w"), walSize)
+	var wrote atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/fs/main.db-wal" {
+			http.NotFound(w, r)
+			return
+		}
+		want := fmt.Sprintf("bytes=%d-%d", offset, offset+length-1)
+		if got := r.Header.Get("Range"); got != want {
+			http.Error(w, "wrong range: "+got, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", offset, offset+length-1, walSize))
+		w.WriteHeader(http.StatusPartialContent)
+		n, _ := w.Write(wal[offset:])
+		wrote.Add(int64(n))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	rc, err := c.ReadStreamRange(context.Background(), "/main.db-wal", offset, length)
+	if err != nil {
+		t.Fatalf("ReadStreamRange: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, _ := io.ReadAll(rc)
+	if !bytes.Equal(data, wal[offset:]) {
+		t.Fatalf("read %d bytes, want exactly the %d-byte requested slice", len(data), length)
+	}
+	if got := wrote.Load(); got != length {
+		t.Fatalf("server wrote %d bytes, want exactly %d", got, length)
+	}
+}
+
 func TestReadAtCtxUsesRangeAndReturnsBytes(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1659,6 +1659,7 @@ func TestReadStreamRangeFirstHop206BadContentRange(t *testing.T) {
 		{name: "complete-before-end", contentRange: "bytes 5-8/4"},
 		{name: "negative-complete", contentRange: "bytes 5-8/-1"},
 		{name: "wider-than-requested", contentRange: "bytes 5-100/200"},
+		{name: "signed-fields", contentRange: "bytes +5-+8/+64"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1730,6 +1731,37 @@ func TestReadStreamRangeFirstHopBoundedTransfer(t *testing.T) {
 	}
 	if got := wrote.Load(); got != 2*length {
 		t.Fatalf("server wrote %d bytes, want exactly %d", got, 2*length)
+	}
+}
+
+func TestReadStreamRangeFirstHop206ShorterDeclaredRange(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/fs/wal" {
+			http.NotFound(w, r)
+			return
+		}
+		if got := r.Header.Get("Range"); got != "bytes=5-8" {
+			http.Error(w, "wrong range: "+got, http.StatusBadRequest)
+			return
+		}
+		// The response declares only one byte but streams four: the client
+		// must expose only the declared byte.
+		w.Header().Set("Content-Range", "bytes 5-5/64")
+		w.WriteHeader(http.StatusPartialContent)
+		_, _ = w.Write([]byte("old!"))
+	}))
+	defer srv.Close()
+
+	c := New(srv.URL, "")
+	rc, err := c.ReadStreamRange(context.Background(), "/wal", 5, 4)
+	if err != nil {
+		t.Fatalf("ReadStreamRange: %v", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	data, _ := io.ReadAll(rc)
+	if string(data) != "o" {
+		t.Fatalf("got %q, want exactly the one declared byte %q", data, "o")
 	}
 }
 

--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1650,6 +1650,12 @@ func TestReadStreamRangeFirstHop206BadContentRange(t *testing.T) {
 	}{
 		{name: "missing"},
 		{name: "wrong-start", contentRange: "bytes 0-3/64"},
+		{name: "non-numeric-end", contentRange: "bytes 5-x/64"},
+		{name: "end-before-start", contentRange: "bytes 5-4/64"},
+		{name: "open-ended", contentRange: "bytes 5-/64"},
+		{name: "trailing-junk", contentRange: "bytes 5-8/64junk"},
+		{name: "missing-bytes-prefix", contentRange: "chunks 5-8/64"},
+		{name: "empty-complete", contentRange: "bytes 5-8/"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1682,8 +1688,10 @@ func TestReadStreamRangeFirstHop206BadContentRange(t *testing.T) {
 func TestReadStreamRangeFirstHopBoundedTransfer(t *testing.T) {
 	const (
 		walSize = 1 << 20
-		offset  = walSize - 4096
 		length  = 4096
+		// Place the read mid-file so the server can stream twice the
+		// requested length past the advertised end.
+		offset = walSize - 2*length
 	)
 	wal := bytes.Repeat([]byte("w"), walSize)
 	var wrote atomic.Int64
@@ -1699,6 +1707,8 @@ func TestReadStreamRangeFirstHopBoundedTransfer(t *testing.T) {
 		}
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", offset, offset+length-1, walSize))
 		w.WriteHeader(http.StatusPartialContent)
+		// Deliberately write past the advertised end: the client must bound
+		// its own read to the requested length.
 		n, _ := w.Write(wal[offset:])
 		wrote.Add(int64(n))
 	}))
@@ -1712,11 +1722,11 @@ func TestReadStreamRangeFirstHopBoundedTransfer(t *testing.T) {
 	defer func() { _ = rc.Close() }()
 
 	data, _ := io.ReadAll(rc)
-	if !bytes.Equal(data, wal[offset:]) {
+	if !bytes.Equal(data, wal[offset:offset+length]) {
 		t.Fatalf("read %d bytes, want exactly the %d-byte requested slice", len(data), length)
 	}
-	if got := wrote.Load(); got != length {
-		t.Fatalf("server wrote %d bytes, want exactly %d", got, length)
+	if got := wrote.Load(); got != 2*length {
+		t.Fatalf("server wrote %d bytes, want exactly %d", got, 2*length)
 	}
 }
 

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -1708,6 +1708,88 @@ func TestDat9FSReadSQLitePersistentJournalBypassesSmallReadCache(t *testing.T) {
 	recorder.Check(t)
 }
 
+func TestDat9FSReadSQLiteJournalSendsFirstHopRange(t *testing.T) {
+	const (
+		path       = "/repo/workload.db-wal"
+		walSize    = 40 << 10 // below the 4 MiB Prefetcher threshold
+		readOffset = walSize - 4096
+		readLength = 4096
+	)
+	wal := bytes.Repeat([]byte("w"), walSize)
+	var recorder testErrorRecorder
+	var mu sync.Mutex
+	var rangeHeaders []string
+	var wroteBytes int
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/fs"+path {
+			recorder.Recordf("unexpected request %s %s", r.Method, r.URL.Path)
+			http.Error(w, "unexpected request", http.StatusBadRequest)
+			return
+		}
+		rangeHeader := r.Header.Get("Range")
+		mu.Lock()
+		rangeHeaders = append(rangeHeaders, rangeHeader)
+		mu.Unlock()
+		if rangeHeader == "" {
+			// Range omitted: emulate a full-body 200 so the regression is
+			// observable in the response byte count.
+			n, _ := w.Write(wal)
+			mu.Lock()
+			wroteBytes += n
+			mu.Unlock()
+			return
+		}
+		var start, end int
+		if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil || start < 0 || end < start || end >= walSize {
+			http.Error(w, "bad range: "+rangeHeader, http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, walSize))
+		w.WriteHeader(http.StatusPartialContent)
+		n, _ := w.Write(wal[start : end+1])
+		mu.Lock()
+		wroteBytes += n
+		mu.Unlock()
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	ino := fs.inodes.Lookup(path, false, walSize, time.Now())
+	fs.inodes.UpdateRevision(ino, 3)
+	fh := openDat9FSTestHandle(t, fs, ino, path)
+	defer fs.fileHandles.Delete(fh)
+
+	got, st, err := readDat9FSTestRange(fs, ino, fh, readOffset, readLength)
+	if err != nil || st != gofuse.OK {
+		t.Fatalf("Read = %d/%v, want OK", st, err)
+	}
+	if !bytes.Equal(got, wal[readOffset:]) {
+		t.Fatalf("Read returned %d bytes, want the requested %d-byte slice", len(got), readLength)
+	}
+	mu.Lock()
+	wantPrefix := fmt.Sprintf("bytes=%d-", readOffset)
+	found := false
+	for _, rh := range rangeHeaders {
+		if strings.HasPrefix(rh, wantPrefix) {
+			found = true
+			break
+		}
+	}
+	mu.Unlock()
+	if !found {
+		t.Fatalf("WAL GET Range headers = %v, want one starting with %q", rangeHeaders, wantPrefix)
+	}
+	mu.Lock()
+	gotWrote := wroteBytes
+	mu.Unlock()
+	if gotWrote != readLength {
+		t.Fatalf("server wrote %d bytes, want exactly %d", gotWrote, readLength)
+	}
+	recorder.Check(t)
+}
+
 func TestDat9FSReadSQLiteMainDatabaseBypassesSmallReadCacheWithOpenSidecar(t *testing.T) {
 	const path = "/repo/workload.db"
 	var reads atomic.Int32


### PR DESCRIPTION
Issue: #895

## Problem

`ReadStreamRange` sent the Range header only on the 302/307 second hop.
Append-log WAL files are served inline on the first hop as 200, so every
nonzero-offset page read streamed the body from byte zero and discarded the
prefix in `sliceBody`. A 49 MiB WAL checkpoint turned into tens of GiB of
transfer and exceeded SQLite's 300 s busy timeout.

## Change

- Send `Range: bytes=start-end` on the initial `/v1/fs` GET.
- First-hop 206: validate Content-Range start and bound with `LimitReader`
  (no double slicing).
- First-hop 416: treat as EOF.
- First-hop 200: keep `sliceBody` fallback for small inline files and old
  servers.
- 302/307 redirect path unchanged.

The fs-repo server already honors Range on append-log reads; this fixes the
client-side omission only.

## Tests

- pkg/client: first-hop 206 at offset 0 and nonzero offset, 416, 200
  fallback, bad Content-Range, bounded-transfer byte count.
- pkg/fuse: nonzero-offset 4 KiB WAL read carries Range and the fake server
  writes exactly 4 KiB.

## Deferred

Full regression, FUSE e2e, and the hosted >40 MiB WAL checkpoint acceptance
run (issue criteria 3-6) are executed separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ranged file reads by requesting only the requested byte range in the initial server response.
  * Correctly handles partial-content responses and treats unsatisfiable ranges as empty reads.
  * Safely handles servers that ignore range requests while returning only the requested data.
* **Tests**
  * Added coverage for ranged reads, response validation, fallback behavior, and bounded data transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->