### PR TITLE
fix(fuse): restore evicted WriteBuffer parts on WAL back-write

### DIFF
--- a/pkg/fuse/append_log.go
+++ b/pkg/fuse/append_log.go
@@ -681,12 +681,7 @@ func (fs *Dat9FS) rotateAppendLogGenerationShadowLocked(fh *FileHandle, path str
 	}
 	fh.ShadowReady = true
 	fh.ShadowSpill = true
-	if fh.Dirty != nil {
-		wb := fh.Dirty
-		wb.OnPartFull = func(partIdx int, _ []byte) {
-			wb.EvictPart(partIdx)
-		}
-	}
+	fs.bindShadowSpillEvictionLocked(fh)
 	fs.recordAppendLogGenerationResetShadowReady()
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -11736,6 +11736,42 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		bytesRead = n
 		return gofuse.ReadResultData(data), gofuse.OK
 	}
+	// Post-Fsync rebaseline leaves Dirty != nil with LoadPart. Large unlinks
+	// pin UnlinkedShadowGen instead of UnlinkedData; serve that private
+	// backing before falling through to a remote GET of the deleted path.
+	if fh.Unlinked && fh.UnlinkedShadowGen != 0 {
+		offset := int64(input.Offset)
+		unlinkedSize := fh.UnlinkedSize
+		gen := fh.UnlinkedShadowGen
+		if offset >= unlinkedSize {
+			fh.Unlock()
+			source = "unlinked-shadow-eof"
+			bytesRead = 0
+			return gofuse.ReadResultData(nil), gofuse.OK
+		}
+		end := offset + int64(input.Size)
+		if end > unlinkedSize {
+			end = unlinkedSize
+		}
+		fh.Unlock()
+		if fs.shadowStore == nil {
+			source = "unlinked-shadow-missing-store"
+			return nil, gofuse.EIO
+		}
+		result := make([]byte, end-offset)
+		n, err := fs.shadowStore.ReadAtGen(gen, offset, result)
+		if err != nil && (!errors.Is(err, io.EOF) || n != len(result)) {
+			source = "unlinked-shadow-error"
+			return nil, gofuse.EIO
+		}
+		if n != len(result) {
+			source = "unlinked-shadow-short"
+			return nil, gofuse.EIO
+		}
+		source = "unlinked-shadow"
+		bytesRead = n
+		return gofuse.ReadResultData(result), gofuse.OK
+	}
 	fs.refreshCleanCommittedRevisionForHandleLocked(fh)
 
 	if fh.ShadowSpill && fs.shadowStore != nil && fh.Dirty != nil && isSQLitePersistentJournalPath(fh.Path) && fh.Dirty.Size() == 0 && !fh.Dirty.hasDirtyPartMarks() && !fh.ZeroBase && fh.Flags&syscall.O_TRUNC == 0 {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3124,10 +3124,21 @@ func (fs *Dat9FS) markHandleRemoteCommittedLocked(fh *FileHandle, revision int64
 // buffer. A successful Fsync/Flush must not leave uploadedParts/RestorePart
 // pointing at a shadow that the commit path is about to delete (#900).
 func (fs *Dat9FS) rebaselineCommittedDirtyBufferLocked(fh *FileHandle) {
-	if fh == nil || fh.Dirty == nil || fh.Dirty.HasDirtyParts() || !fh.Dirty.needsCommitRebaseline() {
+	if fh == nil || fh.Dirty == nil || fh.Dirty.HasDirtyParts() {
 		return
 	}
-	fs.rebindCleanWriteBufferToRemoteLocked(fh, fh.Dirty.Size())
+	if fh.Dirty.needsCommitRebaseline() {
+		// Evicted parts are gone from memory; the next same-FD write must
+		// load the just-committed remote object instead of a deleted shadow.
+		fs.rebindCleanWriteBufferToRemoteLocked(fh, fh.Dirty.Size())
+		return
+	}
+	// Create installs RestorePart/OnPartFull even for tiny files that never
+	// evicted. Clearing those callbacks is enough: keep the in-memory image
+	// so a later write does not GET a path the commit just deleted (unlink)
+	// or that the test server never served.
+	fh.Dirty.RestorePart = nil
+	fh.Dirty.OnPartFull = nil
 }
 
 func (fs *Dat9FS) seedReadCacheFromShadowGenerationLocked(path string, size int64, revision int64, shadowGen uint64) bool {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -213,6 +213,55 @@ func (fs *Dat9FS) newWriteBuffer(path string, maxSize, partSize int64) *WriteBuf
 	return wb
 }
 
+// bindShadowSpillEvictionLocked evicts completed WriteBuffer parts to keep
+// Dirty memory bounded and restores them from the shadow file on back-write.
+// SQLite WAL is not pure append at this granularity; recreating an evicted
+// part as zeros (#898) poisons later Dirty consumers (header reads, rewrite
+// snapshots if spill is dropped, same-path-dirty fallback).
+func (fs *Dat9FS) bindShadowSpillEvictionLocked(fh *FileHandle) {
+	if fh == nil || fh.Dirty == nil || !fh.ShadowSpill {
+		return
+	}
+	wb := fh.Dirty
+	wb.OnPartFull = func(partIdx int, _ []byte) {
+		wb.EvictPart(partIdx)
+	}
+	if fs == nil || fs.shadowStore == nil {
+		wb.RestorePart = nil
+		return
+	}
+	store := fs.shadowStore
+	wb.RestorePart = func(partNum int) ([]byte, error) {
+		return restoreWriteBufferPartFromShadow(store, wb, partNum)
+	}
+}
+
+func restoreWriteBufferPartFromShadow(store *ShadowStore, wb *WriteBuffer, partNum int) ([]byte, error) {
+	if store == nil || wb == nil || partNum < 1 || wb.partSize <= 0 {
+		return nil, fmt.Errorf("invalid shadow part restore")
+	}
+	partStart := int64(partNum-1) * wb.partSize
+	end := partStart + wb.partSize
+	if wb.totalSize > 0 && partStart >= wb.totalSize {
+		return nil, fmt.Errorf("part %d starts at %d beyond size %d", partNum, partStart, wb.totalSize)
+	}
+	if wb.totalSize > 0 && end > wb.totalSize {
+		end = wb.totalSize
+	}
+	if end <= partStart {
+		return nil, fmt.Errorf("empty part %d", partNum)
+	}
+	buf := make([]byte, end-partStart)
+	n, err := store.ReadAt(wb.path, partStart, buf)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, err
+	}
+	if n != len(buf) {
+		return nil, fmt.Errorf("shadow part %d short read n=%d want=%d", partNum, n, len(buf))
+	}
+	return buf, nil
+}
+
 // inlineThreshold returns a small-file cutoff suitable for performance
 // heuristics (read-cache prefetch sizing, debounce flush timing, write-
 // buffer fast-path bounds). It mirrors the server's inline_threshold once
@@ -2188,10 +2237,7 @@ func (fs *Dat9FS) truncateWritableHandleLocked(fh *FileHandle, newSize int64) (f
 	if newSize == 0 {
 		fh.Dirty.ResetStreamingState()
 		if fh.ShadowSpill {
-			wb := fh.Dirty
-			wb.OnPartFull = func(partIdx int, data []byte) {
-				wb.EvictPart(partIdx)
-			}
+			fs.bindShadowSpillEvictionLocked(fh)
 		}
 		if fh.Streamer != nil {
 			streamer := fh.Streamer
@@ -2246,8 +2292,7 @@ func (fs *Dat9FS) applySQLiteZeroTruncateLocked(fh *FileHandle) bool {
 	fh.Dirty.ResetStreamingState()
 	fh.Dirty.ResetSequentialState(0)
 	if fh.ShadowSpill {
-		wb := fh.Dirty
-		wb.OnPartFull = func(partIdx int, _ []byte) { wb.EvictPart(partIdx) }
+		fs.bindShadowSpillEvictionLocked(fh)
 	}
 	fh.OrigSize = 0
 	// The initiating FD owns the truncate mutation. A sibling remains a
@@ -11223,11 +11268,7 @@ func (fs *Dat9FS) Create(cancel <-chan struct{}, input *gofuse.CreateIn, name st
 	}
 
 	if fh.ShadowSpill {
-		// ShadowSpill mode: shadow is the authoritative data source.
-		// OnPartFull evicts memory immediately — no StreamUploader needed.
-		wb.OnPartFull = func(partIdx int, data []byte) {
-			wb.EvictPart(partIdx)
-		}
+		fs.bindShadowSpillEvictionLocked(fh)
 	} else if fh.WritePolicy != WritePolicyWriteSync && !fs.layerEnabled() && !fs.appendLogNewPathActive(childP) {
 		// Normal mode: attach streaming uploader for sequential write streaming.
 		fh.Streamer = NewStreamUploader(fs.client, childP, expectedRevisionForHandle(fh), fs.remoteRoot())
@@ -11442,11 +11483,7 @@ func (fs *Dat9FS) Open(cancel <-chan struct{}, input *gofuse.OpenIn, out *gofuse
 			}
 
 			if fh.ShadowSpill {
-				// ShadowSpill mode: shadow is the authoritative data source.
-				wb := fh.Dirty
-				wb.OnPartFull = func(partIdx int, data []byte) {
-					wb.EvictPart(partIdx)
-				}
+				fs.bindShadowSpillEvictionLocked(fh)
 			} else if fh.WritePolicy != WritePolicyWriteSync && !fs.layerEnabled() && !fs.appendLogPathConfigured(p) {
 				// Normal mode: attach streaming uploader with OnPartFull wiring.
 				fh.Streamer = NewStreamUploader(fs.client, p, expectedRevisionForHandle(fh), fs.remoteRoot())

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3111,11 +3111,23 @@ func (fs *Dat9FS) markHandleRemoteCommittedLocked(fh *FileHandle, revision int64
 	if fh.ZeroBase && fh.Dirty != nil && fh.Dirty.Size() > 0 {
 		fh.ZeroBase = false
 	}
+	fs.rebaselineCommittedDirtyBufferLocked(fh)
 	fs.removeHandleStagingLocked(fh)
 	fh.ShadowReady = false
 	fh.ShadowSpill = false
 	fh.ShadowCommitReady = false
 	fh.ShadowCommitSeq = 0
+}
+
+// rebaselineCommittedDirtyBufferLocked replaces a clean live WriteBuffer that
+// still carries ShadowSpill eviction/restore bookkeeping with a remote-backed
+// buffer. A successful Fsync/Flush must not leave uploadedParts/RestorePart
+// pointing at a shadow that the commit path is about to delete (#900).
+func (fs *Dat9FS) rebaselineCommittedDirtyBufferLocked(fh *FileHandle) {
+	if fh == nil || fh.Dirty == nil || fh.Dirty.HasDirtyParts() || !fh.Dirty.needsCommitRebaseline() {
+		return
+	}
+	fs.rebindCleanWriteBufferToRemoteLocked(fh, fh.Dirty.Size())
 }
 
 func (fs *Dat9FS) seedReadCacheFromShadowGenerationLocked(path string, size int64, revision int64, shadowGen uint64) bool {
@@ -3873,6 +3885,7 @@ func (fs *Dat9FS) finalizeHandleFlushLocked(fh *FileHandle, expectedRevision int
 			fh.OrigSize = size
 			if fh.DirtySeq == 0 {
 				fh.appendLogAdoptCommittedBaseline(fh.BaseRev, size)
+				fs.rebaselineCommittedDirtyBufferLocked(fh)
 			} else {
 				fh.appendLogRebindLayout(fh.BaseRev, size)
 			}
@@ -12454,10 +12467,23 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 	if fh.Flags&uint32(syscall.O_APPEND) != 0 {
 		writeOffset = fh.Dirty.Size()
 	}
+	writeLen := int64(len(data))
+	if fh.Dirty != nil && writeOffset+writeLen > fh.Dirty.maxSize {
+		source = "dirty-write-error"
+		return 0, gofuse.Status(syscall.EFBIG)
+	}
 
 	// ShadowSpill: write shadow FIRST, before Dirty. If shadow fails, return
 	// EIO without touching Dirty — OnPartFull may evict the part, so writing
 	// Dirty first could lose data if shadow then fails.
+	// Restore evicted Dirty parts before mutating shadow so a restore failure
+	// cannot leave authoritative staging bytes from a Write the caller saw fail.
+	if fh.ShadowSpill && fh.ShadowReady && fs.shadowStore != nil && fh.Dirty != nil {
+		if err := fh.Dirty.EnsurePartsForWrite(writeOffset, writeLen); err != nil {
+			source = "dirty-restore-error"
+			return 0, gofuse.EIO
+		}
+	}
 	if fh.ShadowSpill && fh.ShadowReady && fs.shadowStore != nil {
 		shadowStart := time.Now()
 		unlockShadowWrite := fs.lockHandleRemoteCommitPathLocked(fh)
@@ -12486,7 +12512,10 @@ func (fs *Dat9FS) Write(cancel <-chan struct{}, input *gofuse.WriteIn, data []by
 	n, err := fh.Dirty.Write(writeOffset, data)
 	if err != nil {
 		source = "dirty-write-error"
-		return 0, gofuse.Status(syscall.EFBIG)
+		if errors.Is(err, syscall.EFBIG) {
+			return 0, gofuse.Status(syscall.EFBIG)
+		}
+		return 0, gofuse.EIO
 	}
 	fh.appendLogRecordUserWrite(preWriteSize, writeOffset, int64(n))
 	if fs.appendLogPathConfigured(fh.Path) && !fh.IsNew && n > 0 && writeOffset != preWriteSize {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7531,32 +7531,36 @@ func (fs *Dat9FS) loadUnlinkedHandlePart(fh *FileHandle, offset, length int64) (
 	if fh == nil || !fh.Unlinked || length <= 0 {
 		return nil, false, nil
 	}
+	anonSize := fh.UnlinkedSize
+	if anonSize < 0 {
+		anonSize = 0
+	}
+	if offset >= anonSize {
+		return nil, true, nil
+	}
+	want := length
+	if remaining := anonSize - offset; remaining < want {
+		want = remaining
+	}
+	if want <= 0 {
+		return nil, true, nil
+	}
 	if fh.UnlinkedShadowGen != 0 && fs != nil && fs.shadowStore != nil {
-		buf := make([]byte, length)
+		buf := make([]byte, want)
 		n, err := fs.shadowStore.ReadAtGen(fh.UnlinkedShadowGen, offset, buf)
 		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, true, err
 		}
-		if n < 0 {
-			n = 0
+		if int64(n) != want {
+			return nil, true, fmt.Errorf("unlinked shadow gen %d short read n=%d want=%d off=%d", fh.UnlinkedShadowGen, n, want, offset)
 		}
-		if n > len(buf) {
-			n = len(buf)
-		}
-		return buf[:n], true, nil
+		return buf, true, nil
 	}
 	if fh.UnlinkedData != nil {
-		if offset >= int64(len(fh.UnlinkedData)) {
-			return nil, true, nil
+		if offset >= int64(len(fh.UnlinkedData)) || offset+want > int64(len(fh.UnlinkedData)) {
+			return nil, true, fmt.Errorf("unlinked snapshot short read want=%d have=%d off=%d", want, len(fh.UnlinkedData), offset)
 		}
-		end := offset + length
-		if end > int64(len(fh.UnlinkedData)) {
-			end = int64(len(fh.UnlinkedData))
-		}
-		if end <= offset {
-			return nil, true, nil
-		}
-		return append([]byte(nil), fh.UnlinkedData[offset:end]...), true, nil
+		return append([]byte(nil), fh.UnlinkedData[offset:offset+want]...), true, nil
 	}
 	return nil, false, nil
 }

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -2784,6 +2784,9 @@ func (fs *Dat9FS) rebindCleanWriteBufferToRemoteLocked(fh *FileHandle, committed
 		if length <= 0 {
 			return nil, nil
 		}
+		if data, handled, err := fs.loadUnlinkedHandlePart(fh, offset, length); handled {
+			return data, err
+		}
 
 		lpCtx, lpCf := context.WithTimeout(context.Background(), fuseTimeout)
 		defer lpCf()
@@ -3204,6 +3207,9 @@ func (fs *Dat9FS) preloadWritableHandle(ctx context.Context, fh *FileHandle) gof
 		}
 		if length <= 0 {
 			return nil, nil
+		}
+		if data, handled, err := fs.loadUnlinkedHandlePart(fh, offset, length); handled {
+			return data, err
 		}
 
 		lpCtx, lpCf := context.WithTimeout(context.Background(), fuseTimeout)
@@ -7377,7 +7383,8 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 				continue
 			}
 			fh.Lock()
-			handleNeedsSnapshot := cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh)
+			handleNeedsSnapshot := cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) ||
+				remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh)
 			if handleNeedsSnapshot {
 				needsSnapshot = true
 				snapshotNeedCount++
@@ -7440,6 +7447,8 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 					fh.UnlinkedShadowGen = gen
 					fh.UnlinkedSnapshot = true
 				}
+			} else if snapshotOK && remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh) {
+				attachUnlinkedSnapshotLocked(fh, snapshot, snapshotShadowGen, size)
 			}
 		} else if snapshotOK {
 			if snapshotShadowGen != 0 && cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) {
@@ -7469,6 +7478,75 @@ func cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh *FileHandle) bool {
 		fh.UnlinkedData == nil &&
 		fh.UnlinkedShadowGen == 0 &&
 		!fh.UnlinkedSnapshot
+}
+
+// remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked is the post-#900
+// rebaseline case: a clean WriteBuffer whose bytes live only on the
+// committed pathname via LoadPart. Unlink must snapshot that object before
+// DELETE, or a later same-FD write GETs the deleted path and returns EIO.
+func remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh *FileHandle) bool {
+	return fh != nil &&
+		fh.Dirty != nil &&
+		!fh.Dirty.HasDirtyParts() &&
+		fh.DirtySeq == 0 &&
+		fh.Dirty.LoadPart != nil &&
+		fh.Dirty.remoteSize > 0 &&
+		!fh.ShadowSpill &&
+		fh.LocalFile == nil &&
+		fh.Layer != PathLayerGitWorkspace &&
+		fh.UnlinkedData == nil &&
+		fh.UnlinkedShadowGen == 0 &&
+		!fh.UnlinkedSnapshot
+}
+
+func attachUnlinkedSnapshotLocked(fh *FileHandle, snapshot []byte, snapshotShadowGen uint64, size int64) {
+	if fh == nil {
+		return
+	}
+	if snapshotShadowGen != 0 {
+		fh.UnlinkedData = nil
+		fh.UnlinkedSnapshot = true
+		fh.UnlinkedShadowGen = snapshotShadowGen
+		fh.UnlinkedSize = size
+		return
+	}
+	fh.UnlinkedData = append(fh.UnlinkedData[:0], snapshot...)
+	fh.UnlinkedSnapshot = true
+	fh.UnlinkedSize = int64(len(snapshot))
+}
+
+func (fs *Dat9FS) loadUnlinkedHandlePart(fh *FileHandle, offset, length int64) ([]byte, bool, error) {
+	if fh == nil || !fh.Unlinked || length <= 0 {
+		return nil, false, nil
+	}
+	if fh.UnlinkedShadowGen != 0 && fs != nil && fs.shadowStore != nil {
+		buf := make([]byte, length)
+		n, err := fs.shadowStore.ReadAtGen(fh.UnlinkedShadowGen, offset, buf)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return nil, true, err
+		}
+		if n < 0 {
+			n = 0
+		}
+		if n > len(buf) {
+			n = len(buf)
+		}
+		return buf[:n], true, nil
+	}
+	if fh.UnlinkedData != nil {
+		if offset >= int64(len(fh.UnlinkedData)) {
+			return nil, true, nil
+		}
+		end := offset + length
+		if end > int64(len(fh.UnlinkedData)) {
+			end = int64(len(fh.UnlinkedData))
+		}
+		if end <= offset {
+			return nil, true, nil
+		}
+		return append([]byte(nil), fh.UnlinkedData[offset:end]...), true, nil
+	}
+	return nil, false, nil
 }
 
 // unmarkOpenHandlesAfterFailedUnlink rolls back markOpenHandlesUnlinked when

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7375,9 +7375,9 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 	snapshotOK := false
 	var snapshot []byte
 	snapshotShadowGen := uint64(0)
+	snapshotNeedCount := 0
 	if snapshotRemote {
 		needsSnapshot := false
-		snapshotNeedCount := 0
 		for _, fh := range handles {
 			if fh == nil {
 				continue
@@ -7428,6 +7428,7 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		}
 	}
 
+	attachedSnapshotPins := 0
 	for _, fh := range handles {
 		if fh == nil {
 			continue
@@ -7449,6 +7450,9 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 				}
 			} else if snapshotOK && remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh) {
 				attachUnlinkedSnapshotLocked(fh, snapshot, snapshotShadowGen, size)
+				if snapshotShadowGen != 0 && fh.UnlinkedShadowGen == snapshotShadowGen {
+					attachedSnapshotPins++
+				}
 			}
 		} else if snapshotOK {
 			if snapshotShadowGen != 0 && cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) {
@@ -7456,6 +7460,7 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 				fh.UnlinkedSnapshot = true
 				fh.UnlinkedShadowGen = snapshotShadowGen
 				fh.UnlinkedSize = size
+				attachedSnapshotPins++
 			} else {
 				fh.UnlinkedData = append(fh.UnlinkedData[:0], snapshot...)
 				fh.UnlinkedSnapshot = true
@@ -7465,6 +7470,11 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 			fh.UnlinkedSize = size
 		}
 		fh.Unlock()
+	}
+	if snapshotShadowGen != 0 && fs.shadowStore != nil && attachedSnapshotPins < snapshotNeedCount {
+		for i := attachedSnapshotPins; i < snapshotNeedCount; i++ {
+			fs.shadowStore.Unpin(snapshotShadowGen)
+		}
 	}
 	fs.openHandles.UnlinkPath(p)
 	return handles, true, nil
@@ -7485,10 +7495,12 @@ func cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh *FileHandle) bool {
 // committed pathname via LoadPart. Unlink must snapshot that object before
 // DELETE, or a later same-FD write GETs the deleted path and returns EIO.
 func remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh *FileHandle) bool {
+	// Attach even if a concurrent write dirtied the buffer during the
+	// snapshot GET: unloaded parts still depend on the committed pathname,
+	// and LoadPart/Read must use the private backing after DELETE. Dirty
+	// overlays stay in fh.Dirty and are preferred by Read when present.
 	return fh != nil &&
 		fh.Dirty != nil &&
-		!fh.Dirty.HasDirtyParts() &&
-		fh.DirtySeq == 0 &&
 		fh.Dirty.LoadPart != nil &&
 		fh.Dirty.remoteSize > 0 &&
 		!fh.ShadowSpill &&
@@ -11730,16 +11742,21 @@ func (fs *Dat9FS) Read(cancel <-chan struct{}, input *gofuse.ReadIn, buf []byte)
 		bytesRead = n
 		return gofuse.ReadResultData(data[:n]), gofuse.OK
 	}
-	if data, n, ok := readUnlinkedData(fh, int64(input.Offset), input.Size); ok {
-		fh.Unlock()
-		source = "unlinked-snapshot"
-		bytesRead = n
-		return gofuse.ReadResultData(data), gofuse.OK
+	preferDirtyOverlay := fh.Dirty != nil && fh.Dirty.HasDirtyParts()
+	if !preferDirtyOverlay {
+		if data, n, ok := readUnlinkedData(fh, int64(input.Offset), input.Size); ok {
+			fh.Unlock()
+			source = "unlinked-snapshot"
+			bytesRead = n
+			return gofuse.ReadResultData(data), gofuse.OK
+		}
 	}
 	// Post-Fsync rebaseline leaves Dirty != nil with LoadPart. Large unlinks
 	// pin UnlinkedShadowGen instead of UnlinkedData; serve that private
 	// backing before falling through to a remote GET of the deleted path.
-	if fh.Unlinked && fh.UnlinkedShadowGen != 0 {
+	// Skip when Dirty already has an overlay so concurrent unlink-window
+	// writes remain visible.
+	if !preferDirtyOverlay && fh.Unlinked && fh.UnlinkedShadowGen != 0 {
 		offset := int64(input.Offset)
 		unlinkedSize := fh.UnlinkedSize
 		gen := fh.UnlinkedShadowGen

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2222,6 +2222,151 @@ func TestWriteBuffer_EvictPart(t *testing.T) {
 	}
 }
 
+// TestWriteBuffer_RestorePartReloadsEvictedBytes covers issue #898: SQLite WAL
+// is not pure append at FUSE granularity. A back-write into an evicted part
+// must overlay the original bytes, not zero-fill the rest of the part.
+func TestWriteBuffer_RestorePartReloadsEvictedBytes(t *testing.T) {
+	const partSize int64 = 64
+	wb := NewWriteBuffer("/kv.db-wal", 1<<20, partSize)
+	wb.SetSmallFileMax(32)
+	wb.sequential = true
+	wb.uploadedParts = make(map[int]bool)
+
+	original := make([]byte, 3*partSize)
+	for i := range original {
+		original[i] = byte(i + 1)
+	}
+	saved := map[int][]byte{}
+	wb.OnPartFull = func(partIdx int, data []byte) {
+		cp := make([]byte, len(data))
+		copy(cp, data)
+		saved[partIdx] = cp
+		wb.EvictPart(partIdx)
+	}
+	wb.RestorePart = func(partNum int) ([]byte, error) {
+		data, ok := saved[partNum-1]
+		if !ok {
+			return nil, fmt.Errorf("missing part %d", partNum)
+		}
+		cp := make([]byte, len(data))
+		copy(cp, data)
+		return cp, nil
+	}
+
+	if _, err := wb.Write(0, original); err != nil {
+		t.Fatalf("sequential write: %v", err)
+	}
+	if !wb.uploadedParts[0] || !wb.uploadedParts[1] {
+		t.Fatalf("expected parts 0 and 1 evicted, got %v", wb.uploadedParts)
+	}
+
+	overlay := []byte("WAL!")
+	off := partSize + 8
+	if _, err := wb.Write(off, overlay); err != nil {
+		t.Fatalf("back-write: %v", err)
+	}
+	part, ok := wb.parts[1]
+	if !ok {
+		t.Fatal("part 1 should be restored")
+	}
+	if int64(len(part)) != partSize {
+		t.Fatalf("restored part len=%d, want %d", len(part), partSize)
+	}
+	want := append([]byte(nil), original[partSize:2*partSize]...)
+	copy(want[8:8+len(overlay)], overlay)
+	if !bytes.Equal(part, want) {
+		t.Fatalf("restored part = %v, want original bytes with overlay", part)
+	}
+}
+
+func TestWriteBuffer_RestorePartErrorFailsBackWrite(t *testing.T) {
+	const partSize int64 = 64
+	wb := NewWriteBuffer("/kv.db-wal", 1<<20, partSize)
+	wb.SetSmallFileMax(32)
+	wb.sequential = true
+	wb.uploadedParts = make(map[int]bool)
+	wb.OnPartFull = func(partIdx int, _ []byte) {
+		wb.EvictPart(partIdx)
+	}
+	wb.RestorePart = func(partNum int) ([]byte, error) {
+		return nil, fmt.Errorf("shadow missing part %d", partNum)
+	}
+
+	if _, err := wb.Write(0, bytes.Repeat([]byte{0x11}, int(2*partSize))); err != nil {
+		t.Fatalf("sequential write: %v", err)
+	}
+	if _, err := wb.Write(8, []byte("x")); err == nil {
+		t.Fatal("back-write into unrestorable evicted part should fail")
+	}
+}
+
+func TestShadowSpillBackWriteRestoresFromShadow(t *testing.T) {
+	store, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	const path = "/kv.db-wal"
+	const partSize int64 = 64
+	if err := store.Ensure(path, 0, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	wb := NewWriteBuffer(path, 1<<20, partSize)
+	wb.SetSmallFileMax(32)
+	wb.sequential = true
+	wb.uploadedParts = make(map[int]bool)
+	fh := &FileHandle{Path: path, Dirty: wb, ShadowSpill: true, ShadowReady: true}
+	fs := &Dat9FS{shadowStore: store}
+	fs.bindShadowSpillEvictionLocked(fh)
+
+	original := make([]byte, 3*partSize)
+	for i := range original {
+		original[i] = byte(i + 3)
+	}
+	if _, err := store.WriteAt(path, 0, original, 0); err != nil {
+		t.Fatalf("shadow sequential write: %v", err)
+	}
+	if _, err := wb.Write(0, original); err != nil {
+		t.Fatalf("dirty sequential write: %v", err)
+	}
+	if wb.RestorePart == nil {
+		t.Fatal("spill bind should install RestorePart")
+	}
+	if !wb.uploadedParts[0] || !wb.uploadedParts[1] {
+		t.Fatalf("expected parts 0 and 1 evicted, got %v", wb.uploadedParts)
+	}
+
+	overlay := []byte{0xAA, 0xBB, 0xCC, 0xDD}
+	off := partSize + 4
+	if _, err := store.WriteAt(path, off, overlay, 0); err != nil {
+		t.Fatalf("shadow back-write: %v", err)
+	}
+	if _, err := wb.Write(off, overlay); err != nil {
+		t.Fatalf("dirty back-write: %v", err)
+	}
+
+	part, ok := wb.parts[1]
+	if !ok {
+		t.Fatal("part 1 should be restored from shadow")
+	}
+	want := append([]byte(nil), original[partSize:2*partSize]...)
+	copy(want[4:8], overlay)
+	if !bytes.Equal(part, want) {
+		t.Fatalf("dirty part after restore = %v, want shadow overlay %v", part, want)
+	}
+
+	got := make([]byte, len(original))
+	n, err := store.ReadAt(path, 0, got)
+	if err != nil || n != len(got) {
+		t.Fatalf("shadow read: n=%d err=%v", n, err)
+	}
+	if !bytes.Equal(got[partSize:partSize+4], original[partSize:partSize+4]) || !bytes.Equal(got[off:off+int64(len(overlay))], overlay) {
+		t.Fatalf("shadow lost original prefix or overlay")
+	}
+}
+
 func TestWriteBuffer_ResetSequentialState(t *testing.T) {
 	wb := NewWriteBuffer("/test", streamingWriteMaxSize, DefaultPartSize)
 	wb.sequential = true

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2635,6 +2635,182 @@ func newStrictSmallPartSpillFS(t *testing.T, baseURL, filePath string, partSize 
 	return fs, createOut.Fh, createOut.NodeId, shadow
 }
 
+func TestWriteBuffer_ShrinkDropsEvictedPartsBeyondSize(t *testing.T) {
+	const partSize int64 = 64
+	wb := NewWriteBuffer("/spill.bin", 1<<20, partSize)
+	wb.SetSmallFileMax(32)
+	wb.sequential = true
+	wb.uploadedParts = make(map[int]bool)
+	saved := map[int][]byte{}
+	wb.OnPartFull = func(partIdx int, data []byte) {
+		cp := make([]byte, len(data))
+		copy(cp, data)
+		saved[partIdx] = cp
+		wb.EvictPart(partIdx)
+	}
+	wb.RestorePart = func(partNum int) ([]byte, error) {
+		data, ok := saved[partNum-1]
+		if !ok {
+			return nil, fmt.Errorf("missing part %d", partNum)
+		}
+		return append([]byte(nil), data...), nil
+	}
+	original := bytes.Repeat([]byte{0x44}, int(3*partSize))
+	if _, err := wb.Write(0, original); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if !wb.uploadedParts[1] {
+		t.Fatal("expected part 1 evicted")
+	}
+	if err := wb.Truncate(partSize); err != nil {
+		t.Fatalf("truncate: %v", err)
+	}
+	if wb.uploadedParts[1] {
+		t.Fatal("truncate should drop evicted parts at/after the new size")
+	}
+	tail := []byte("tail")
+	if _, err := wb.Write(partSize, tail); err != nil {
+		t.Fatalf("append after shrink: %v", err)
+	}
+	if err := wb.EnsureLoaded(0); err != nil {
+		t.Fatalf("load retained part 0: %v", err)
+	}
+	got := make([]byte, partSize+int64(len(tail)))
+	if n := wb.ReadAt(0, got); n != len(got) {
+		t.Fatalf("ReadAt n=%d", n)
+	}
+	want := append(bytes.Repeat([]byte{0x44}, int(partSize)), tail...)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("after shrink+append = %x, want %x", got, want)
+	}
+}
+
+func TestShadowSpillShrinkThenAppendAtEvictedBoundary(t *testing.T) {
+	const filePath = "/spill-shrink.bin"
+	const partSize int64 = 64
+	original := bytes.Repeat([]byte{0x55}, int(3*partSize))
+	tail := []byte("tail")
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.RawQuery == "list=1" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	fs, fhID, nodeID, _ := newStrictSmallPartSpillFS(t, ts.URL, filePath, partSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}, original); st != gofuse.OK {
+		t.Fatalf("seed Write: %v", st)
+	}
+	var attrOut gofuse.AttrOut
+	if st := fs.SetAttr(nil, &gofuse.SetAttrIn{
+		SetAttrInCommon: gofuse.SetAttrInCommon{
+			InHeader: gofuse.InHeader{NodeId: nodeID},
+			Valid:    gofuse.FATTR_SIZE | gofuse.FATTR_FH,
+			Fh:       fhID,
+			Size:     uint64(partSize),
+		},
+	}, &attrOut); st != gofuse.OK {
+		t.Fatalf("truncate: %v", st)
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: uint64(partSize),
+	}, tail); st != gofuse.OK {
+		t.Fatalf("append after shrink: %v", st)
+	}
+	buf := make([]byte, int(partSize)+len(tail))
+	result, st := fs.Read(nil, &gofuse.ReadIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Size: uint32(len(buf))}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read after shrink+append: %v", st)
+	}
+	got, _ := result.Bytes(buf)
+	want := append(bytes.Repeat([]byte{0x55}, int(partSize)), tail...)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("after shrink+append = %x, want %x", got, want)
+	}
+}
+
+func TestShadowSpillFsyncUnlinkSameHandleWriteStaysLocal(t *testing.T) {
+	const filePath = "/spill-unlink.bin"
+	const partSize int64 = 64
+	original := bytes.Repeat([]byte{0x66}, int(3*partSize))
+	overlay := []byte{0xAA, 0xBB}
+
+	var mu sync.Mutex
+	var committed []byte
+	var puts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := strings.TrimPrefix(r.URL.Path, "/v1/fs")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+		case r.Method == http.MethodGet:
+			mu.Lock()
+			body := append([]byte(nil), committed...)
+			mu.Unlock()
+			if len(body) == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write(body)
+		case r.Method == http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			puts.Add(1)
+			mu.Lock()
+			committed = append([]byte(nil), body...)
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": 1})
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			committed = nil
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+		_ = p
+	}))
+	defer ts.Close()
+
+	fs, fhID, nodeID, _ := newStrictSmallPartSpillFS(t, ts.URL, filePath, partSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}, original); st != gofuse.OK {
+		t.Fatalf("seed Write: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("Fsync: %v", st)
+	}
+	if got := puts.Load(); got != 1 {
+		t.Fatalf("puts after fsync = %d, want 1", got)
+	}
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, strings.TrimPrefix(filePath, "/")); st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: 8}, overlay); st != gofuse.OK {
+		t.Fatalf("write after unlink: %v", st)
+	}
+	if got := puts.Load(); got != 1 {
+		t.Fatalf("write-after-unlink resurrected remote path (puts=%d)", got)
+	}
+	fh, _ := fs.fileHandles.Get(fhID)
+	fh.Lock()
+	got := make([]byte, 8+len(overlay))
+	n := fh.Dirty.ReadAt(0, got)
+	fh.Unlock()
+	want := append(bytes.Repeat([]byte{0x66}, 8), overlay...)
+	if n != len(got) || !bytes.Equal(got, want) {
+		t.Fatalf("anonymous fd bytes = %x (n=%d), want %x", got[:n], n, want)
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("Flush after unlink: %v", st)
+	}
+	if got := puts.Load(); got != 1 {
+		t.Fatalf("flush after unlink uploaded (puts=%d)", got)
+	}
+}
+
 func TestWriteBuffer_ResetSequentialState(t *testing.T) {
 	wb := NewWriteBuffer("/test", streamingWriteMaxSize, DefaultPartSize)
 	wb.sequential = true

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2880,6 +2880,119 @@ func TestUnlinkedRemoteBackedDirtyReadUsesPinnedShadowGen(t *testing.T) {
 	}
 }
 
+func TestUnlinkSnapshotConcurrentWriteKeepsOverlayAndBaseline(t *testing.T) {
+	const filePath = "/spill-unlink-race.bin"
+	const partSize int64 = 64
+	original := bytes.Repeat([]byte{0x88}, int(3*partSize))
+	overlay := []byte{0xAA, 0xBB}
+
+	var mu sync.Mutex
+	var committed []byte
+	var puts atomic.Int32
+	var fileGets atomic.Int32
+	snapshotStarted := make(chan struct{})
+	snapshotRelease := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+		case r.Method == http.MethodGet:
+			mu.Lock()
+			body := append([]byte(nil), committed...)
+			mu.Unlock()
+			if len(body) == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			if fileGets.Add(1) == 1 {
+				close(snapshotStarted)
+				<-snapshotRelease
+			}
+			_, _ = w.Write(body)
+		case r.Method == http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			puts.Add(1)
+			mu.Lock()
+			committed = append([]byte(nil), body...)
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": 1})
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			committed = nil
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	fs, fhID, nodeID, _ := newStrictSmallPartSpillFS(t, ts.URL, filePath, partSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}, original); st != gofuse.OK {
+		t.Fatalf("seed Write: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("Fsync: %v", st)
+	}
+
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, strings.TrimPrefix(filePath, "/"))
+	}()
+	select {
+	case <-snapshotStarted:
+	case st := <-unlinkDone:
+		t.Fatalf("Unlink finished before snapshot GET: %v", st)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for unlink snapshot GET")
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: 8}, overlay); st != gofuse.OK {
+		close(snapshotRelease)
+		t.Fatalf("concurrent write during unlink snapshot: %v", st)
+	}
+	close(snapshotRelease)
+	st := <-unlinkDone
+	if st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+
+	prefixBuf := make([]byte, 16)
+	prefixResult, rst := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Size: uint32(len(prefixBuf)),
+	}, prefixBuf)
+	if rst != gofuse.OK {
+		t.Fatalf("Read overlay after unlink: %v", rst)
+	}
+	gotPrefix, _ := prefixResult.Bytes(prefixBuf)
+	wantPrefix := append(bytes.Repeat([]byte{0x88}, 8), overlay...)
+	wantPrefix = append(wantPrefix, bytes.Repeat([]byte{0x88}, 6)...)
+	if !bytes.Equal(gotPrefix, wantPrefix) {
+		t.Fatalf("overlay read = %x, want %x", gotPrefix, wantPrefix)
+	}
+
+	tailBuf := make([]byte, 16)
+	tailResult, rst := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: uint64(2 * partSize), Size: uint32(len(tailBuf)),
+	}, tailBuf)
+	if rst != gofuse.OK {
+		t.Fatalf("Read untouched part after unlink: %v", rst)
+	}
+	gotTail, _ := tailResult.Bytes(tailBuf)
+	if !bytes.Equal(gotTail, original[2*partSize:2*partSize+16]) {
+		t.Fatalf("untouched part = %x, want baseline", gotTail)
+	}
+	if puts.Load() != 1 {
+		t.Fatalf("concurrent unlink/write resurrected path (puts=%d)", puts.Load())
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("Flush: %v", st)
+	}
+	if puts.Load() != 1 {
+		t.Fatalf("Release/Flush uploaded after unlink (puts=%d)", puts.Load())
+	}
+}
+
 func TestWriteBuffer_ResetSequentialState(t *testing.T) {
 	wb := NewWriteBuffer("/test", streamingWriteMaxSize, DefaultPartSize)
 	wb.sequential = true

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2880,6 +2880,49 @@ func TestUnlinkedRemoteBackedDirtyReadUsesPinnedShadowGen(t *testing.T) {
 	}
 }
 
+func TestLoadUnlinkedHandlePartShortShadowGenFailsClosed(t *testing.T) {
+	const filePath = "/anon-short.bin"
+	store, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(store.Close)
+	if err := store.WriteFull(filePath, []byte("abc"), 1); err != nil {
+		t.Fatal(err)
+	}
+	gen := store.Pin(filePath)
+	store.Remove(filePath)
+
+	opts := &MountOptions{FlushDebounce: 0}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient("http://127.0.0.1:1"), opts)
+	fs.shadowStore = store
+
+	wb := NewWriteBuffer(filePath, 1<<20, 8)
+	wb.SetSmallFileMax(4)
+	wb.totalSize = 8
+	wb.remoteSize = 8
+	fh := &FileHandle{
+		Path: filePath, Dirty: wb,
+		Unlinked: true, UnlinkedSnapshot: true,
+		UnlinkedShadowGen: gen, UnlinkedSize: 8,
+	}
+	wb.LoadPart = func(partNum int) ([]byte, error) {
+		offset := int64(partNum-1) * wb.PartSize()
+		data, handled, err := fs.loadUnlinkedHandlePart(fh, offset, wb.PartSize())
+		if !handled {
+			return nil, fmt.Errorf("unlinked backing not handled")
+		}
+		return data, err
+	}
+	if err := wb.EnsureLoaded(0); err == nil {
+		t.Fatal("EnsureLoaded accepted a 3-byte UnlinkedShadowGen for an 8-byte part")
+	}
+	if wb.IsPartLoaded(0) {
+		t.Fatal("short private backing must not be stored as a loaded part")
+	}
+}
+
 func TestUnlinkSnapshotConcurrentWriteKeepsOverlayAndBaseline(t *testing.T) {
 	const filePath = "/spill-unlink-race.bin"
 	const partSize int64 = 64

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2788,6 +2788,17 @@ func TestShadowSpillFsyncUnlinkSameHandleWriteStaysLocal(t *testing.T) {
 	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, strings.TrimPrefix(filePath, "/")); st != gofuse.OK {
 		t.Fatalf("Unlink: %v", st)
 	}
+	readBuf := make([]byte, 16)
+	readResult, st := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Size: uint32(len(readBuf)),
+	}, readBuf)
+	if st != gofuse.OK {
+		t.Fatalf("Read after unlink before write: %v", st)
+	}
+	gotRead, _ := readResult.Bytes(readBuf)
+	if !bytes.Equal(gotRead, original[:16]) {
+		t.Fatalf("Read after unlink = %x, want committed prefix", gotRead)
+	}
 	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: 8}, overlay); st != gofuse.OK {
 		t.Fatalf("write after unlink: %v", st)
 	}
@@ -2808,6 +2819,64 @@ func TestShadowSpillFsyncUnlinkSameHandleWriteStaysLocal(t *testing.T) {
 	}
 	if got := puts.Load(); got != 1 {
 		t.Fatalf("flush after unlink uploaded (puts=%d)", got)
+	}
+}
+
+func TestUnlinkedRemoteBackedDirtyReadUsesPinnedShadowGen(t *testing.T) {
+	const filePath = "/anon-large.bin"
+	data := bytes.Repeat([]byte{0x77}, 256)
+	store, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(store.Close)
+	if err := store.WriteFull(filePath, data, 1); err != nil {
+		t.Fatal(err)
+	}
+	gen := store.Pin(filePath)
+	store.Remove(filePath)
+
+	var remoteGets atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet {
+			remoteGets.Add(1)
+			http.NotFound(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	opts := &MountOptions{FlushDebounce: 0}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(ts.URL), opts)
+	fs.shadowStore = store
+
+	wb := NewWriteBuffer(filePath, 1<<20, 64)
+	wb.totalSize = int64(len(data))
+	wb.remoteSize = int64(len(data))
+	wb.LoadPart = func(int) ([]byte, error) {
+		t.Error("LoadPart must not fetch the deleted path")
+		return nil, fmt.Errorf("deleted")
+	}
+	fh := &FileHandle{
+		Path: filePath, Dirty: wb, DirtySeq: 0,
+		Unlinked: true, UnlinkedSnapshot: true,
+		UnlinkedShadowGen: gen, UnlinkedSize: int64(len(data)),
+	}
+	fhID := fs.allocateFileHandle(fh)
+
+	buf := make([]byte, 32)
+	result, st := fs.Read(nil, &gofuse.ReadIn{Fh: fhID, Size: uint32(len(buf))}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read after unlink before write: %v", st)
+	}
+	got, _ := result.Bytes(buf)
+	if !bytes.Equal(got, data[:32]) {
+		t.Fatalf("Read = %x, want pinned shadow prefix", got)
+	}
+	if remoteGets.Load() != 0 {
+		t.Fatalf("Read hit remote GET %d times after unlink", remoteGets.Load())
 	}
 }
 

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -2422,7 +2422,7 @@ func TestShadowSpillFsyncRebaselineAllowsSameHandleBackWrite(t *testing.T) {
 				http.NotFound(w, r)
 				return
 			}
-			w.Write(body)
+			_, _ = w.Write(body)
 		case http.MethodPut:
 			body, _ := io.ReadAll(r.Body)
 			got, err := strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64)
@@ -2508,7 +2508,7 @@ func TestShadowSpillFsyncThenAppendDoesNotZeroPrefix(t *testing.T) {
 				http.NotFound(w, r)
 				return
 			}
-			w.Write(body)
+			_, _ = w.Write(body)
 		case http.MethodPut:
 			body, _ := io.ReadAll(r.Body)
 			mu.Lock()

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -3,17 +3,22 @@ package fuse
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
 
+	gofuse "github.com/hanwen/go-fuse/v2/fuse"
 	"github.com/mem9-ai/drive9/pkg/client"
 )
 
@@ -2365,6 +2370,269 @@ func TestShadowSpillBackWriteRestoresFromShadow(t *testing.T) {
 	if !bytes.Equal(got[partSize:partSize+4], original[partSize:partSize+4]) || !bytes.Equal(got[off:off+int64(len(overlay))], overlay) {
 		t.Fatalf("shadow lost original prefix or overlay")
 	}
+}
+
+func TestMarkHandleRemoteCommittedRebaselinesEvictedSpillBuffer(t *testing.T) {
+	const partSize int64 = 64
+	wb := NewWriteBuffer("/spill.bin", 1<<20, partSize)
+	wb.SetSmallFileMax(32)
+	wb.totalSize = 3 * partSize
+	wb.uploadedParts = map[int]bool{0: true, 1: true}
+	wb.RestorePart = func(int) ([]byte, error) { return nil, fmt.Errorf("stale shadow") }
+	wb.OnPartFull = func(int, []byte) {}
+	fh := &FileHandle{
+		Ino: 1, Path: "/spill.bin", Dirty: wb,
+		ShadowSpill: true, ShadowReady: true, IsNew: true,
+	}
+	fs := &Dat9FS{inodes: NewInodeToPath(), openHandles: NewOpenHandleIndex()}
+	fs.inodes.Lookup("/spill.bin", false, 0, time.Now())
+	fs.markHandleRemoteCommittedLocked(fh, 1)
+	if fh.ShadowSpill || fh.Dirty.RestorePart != nil || fh.Dirty.OnPartFull != nil || len(fh.Dirty.uploadedParts) != 0 {
+		t.Fatalf("committed handle still has spill eviction state: spill=%t restore=%t onFull=%t uploaded=%v",
+			fh.ShadowSpill, fh.Dirty.RestorePart != nil, fh.Dirty.OnPartFull != nil, fh.Dirty.uploadedParts)
+	}
+	if fh.Dirty.remoteSize != 3*partSize || fh.Dirty.Size() != 3*partSize {
+		t.Fatalf("rebased size/remoteSize = %d/%d, want %d", fh.Dirty.Size(), fh.Dirty.remoteSize, 3*partSize)
+	}
+	if fh.Dirty.LoadPart == nil {
+		t.Fatal("rebased buffer should load committed parts from remote")
+	}
+}
+
+func TestShadowSpillFsyncRebaselineAllowsSameHandleBackWrite(t *testing.T) {
+	const filePath = "/spill.bin"
+	const partSize int64 = 64
+	original := bytes.Repeat([]byte{0x11}, int(3*partSize))
+	overlay := []byte{0xAA, 0xBB, 0xCC, 0xDD}
+
+	var mu sync.Mutex
+	var committed []byte
+	var puts [][]byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			mu.Lock()
+			body := append([]byte(nil), committed...)
+			mu.Unlock()
+			if len(body) == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			w.Write(body)
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			got, err := strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			wantRev := int64(len(puts))
+			if got != wantRev {
+				http.Error(w, "revision conflict", http.StatusConflict)
+				return
+			}
+			puts = append(puts, append([]byte(nil), body...))
+			committed = append([]byte(nil), body...)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": int64(len(puts))})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	fs, fhID, nodeID, shadow := newStrictSmallPartSpillFS(t, ts.URL, filePath, partSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}, original); st != gofuse.OK {
+		t.Fatalf("seed Write: %v", st)
+	}
+	fh, _ := fs.fileHandles.Get(fhID)
+	fh.Lock()
+	evicted := len(fh.Dirty.uploadedParts) > 0
+	fh.Unlock()
+	if !evicted {
+		t.Fatal("expected ShadowSpill eviction before fsync")
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("first Fsync: %v", st)
+	}
+	if shadow.Has(filePath) {
+		t.Fatal("shadow staging should be removed after successful fsync")
+	}
+	fh.Lock()
+	if fh.ShadowSpill || fh.Dirty.RestorePart != nil || len(fh.Dirty.uploadedParts) != 0 {
+		t.Fatalf("after fsync spill=%t restore=%t uploaded=%v", fh.ShadowSpill, fh.Dirty.RestorePart != nil, fh.Dirty.uploadedParts)
+	}
+	fh.Unlock()
+
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: 8}, overlay); st != gofuse.OK {
+		t.Fatalf("same-handle back-write after fsync: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("second Fsync: %v", st)
+	}
+	mu.Lock()
+	got := append([]byte(nil), committed...)
+	mu.Unlock()
+	want := append([]byte(nil), original...)
+	copy(want[8:8+len(overlay)], overlay)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("committed after back-write = %x, want original+overlay %x", got, want)
+	}
+}
+
+func TestShadowSpillFsyncThenAppendDoesNotZeroPrefix(t *testing.T) {
+	const filePath = "/spill-append.bin"
+	const partSize int64 = 64
+	original := bytes.Repeat([]byte{0x22}, int(3*partSize))
+	tail := []byte("tail")
+
+	var mu sync.Mutex
+	var committed []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			if r.URL.RawQuery == "list=1" {
+				_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+				return
+			}
+			mu.Lock()
+			body := append([]byte(nil), committed...)
+			mu.Unlock()
+			if len(body) == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			w.Write(body)
+		case http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			mu.Lock()
+			committed = append([]byte(nil), body...)
+			rev := int64(1)
+			if len(committed) > len(original) {
+				rev = 2
+			}
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": rev})
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	fs, fhID, nodeID, _ := newStrictSmallPartSpillFS(t, ts.URL, filePath, partSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}, original); st != gofuse.OK {
+		t.Fatalf("seed Write: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("first Fsync: %v", st)
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: uint64(len(original)),
+	}, tail); st != gofuse.OK {
+		t.Fatalf("append after fsync: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("second Fsync: %v", st)
+	}
+	mu.Lock()
+	got := append([]byte(nil), committed...)
+	mu.Unlock()
+	want := append(append([]byte(nil), original...), tail...)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("second commit = %x, want original+tail without zero prefix", got)
+	}
+}
+
+func TestShadowSpillRestoreFailureDoesNotMutateShadow(t *testing.T) {
+	const filePath = "/spill-fail.bin"
+	const partSize int64 = 64
+	original := bytes.Repeat([]byte{0x33}, int(3*partSize))
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodGet && r.URL.RawQuery == "list=1" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+			return
+		}
+		if r.Method == http.MethodPut {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": 1})
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+
+	fs, fhID, nodeID, shadow := newStrictSmallPartSpillFS(t, ts.URL, filePath, partSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}, original); st != gofuse.OK {
+		t.Fatalf("seed Write: %v", st)
+	}
+	fh, _ := fs.fileHandles.Get(fhID)
+	fh.Lock()
+	fh.Dirty.RestorePart = func(int) ([]byte, error) { return nil, fmt.Errorf("injected restore failure") }
+	fh.Unlock()
+
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: 8}, []byte("FAIL")); st != gofuse.EIO {
+		t.Fatalf("restore-failure Write status = %v, want EIO", st)
+	}
+	got := make([]byte, len(original))
+	n, err := shadow.ReadAt(filePath, 0, got)
+	if err != nil || n != len(got) {
+		t.Fatalf("shadow read: n=%d err=%v", n, err)
+	}
+	if !bytes.Equal(got, original) {
+		t.Fatalf("failed Write mutated shadow: got %x", got)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("Fsync after failed write: %v", st)
+	}
+}
+
+func newStrictSmallPartSpillFS(t *testing.T, baseURL, filePath string, partSize int64) (*Dat9FS, uint64, uint64, *ShadowStore) {
+	t.Helper()
+	opts := &MountOptions{FlushDebounce: 0}
+	opts.setDefaults()
+	fs := NewDat9FS(newTestClient(baseURL), opts)
+	fs.syncMode = SyncStrict
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(shadow.Close)
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+
+	var createOut gofuse.CreateOut
+	st := fs.Create(nil, &gofuse.CreateIn{InHeader: gofuse.InHeader{NodeId: 1}}, strings.TrimPrefix(filePath, "/"), &createOut)
+	if st != gofuse.OK {
+		t.Fatalf("Create: %v", st)
+	}
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("created handle missing")
+	}
+	fh.Lock()
+	fh.Dirty = NewWriteBuffer(filePath, streamingWriteMaxSize, partSize)
+	fh.Dirty.SetSmallFileMax(partSize / 2)
+	fh.Dirty.sequential = true
+	fh.Dirty.uploadedParts = make(map[int]bool)
+	if !fh.ShadowSpill {
+		fh.Unlock()
+		t.Fatal("created handle should be ShadowSpill")
+	}
+	fs.bindShadowSpillEvictionLocked(fh)
+	fh.Unlock()
+	return fs, createOut.Fh, createOut.NodeId, shadow
 }
 
 func TestWriteBuffer_ResetSequentialState(t *testing.T) {

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -496,13 +496,7 @@ func (wb *WriteBuffer) EnsurePartsForWrite(offset, length int64) error {
 }
 
 func (wb *WriteBuffer) needsCommitRebaseline() bool {
-	if wb == nil {
-		return false
-	}
-	if wb.RestorePart != nil || wb.OnPartFull != nil {
-		return true
-	}
-	return len(wb.uploadedParts) > 0
+	return wb != nil && len(wb.uploadedParts) > 0
 }
 
 func (wb *WriteBuffer) restoreEvictedPart(partIdx int) ([]byte, bool, error) {

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -438,6 +438,15 @@ func (wb *WriteBuffer) ensurePart(partIdx int) error {
 	// overlay cannot zero-fill the rest of the part. Fall back to the
 	// historical zero-fill only when no restorer exists (streamer-only).
 	if wb.uploadedParts != nil && wb.uploadedParts[partIdx] {
+		partStart := int64(partIdx) * wb.partSize
+		if partStart >= wb.totalSize {
+			// Truncate/shrink dropped this part from the logical file. A later
+			// append at the new EOF must create a fresh part, not restore
+			// truncated-away bytes (and not fail the write).
+			delete(wb.uploadedParts, partIdx)
+			wb.parts[partIdx] = nil
+			return nil
+		}
 		data, restored, err := wb.restoreEvictedPart(partIdx)
 		if err != nil {
 			return err
@@ -500,6 +509,10 @@ func (wb *WriteBuffer) needsCommitRebaseline() bool {
 }
 
 func (wb *WriteBuffer) restoreEvictedPart(partIdx int) ([]byte, bool, error) {
+	partStart := int64(partIdx) * wb.partSize
+	if wb.partSize > 0 && partStart >= wb.totalSize {
+		return nil, false, nil
+	}
 	if wb.RestorePart != nil {
 		data, err := wb.RestorePart(partIdx + 1)
 		if err != nil {
@@ -592,6 +605,11 @@ func (wb *WriteBuffer) Truncate(size int64) error {
 				wb.curMemory -= int64(len(wb.parts[idx]))
 				delete(wb.parts, idx)
 				delete(wb.dirtyParts, idx)
+			}
+		}
+		for idx := range wb.uploadedParts {
+			if int64(idx)*wb.partSize >= size {
+				delete(wb.uploadedParts, idx)
 			}
 		}
 

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -474,6 +474,37 @@ func (wb *WriteBuffer) ensurePart(partIdx int) error {
 	return nil
 }
 
+// EnsurePartsForWrite loads or restores every part overlapping [offset, offset+length)
+// so a later Write cannot fail mid-overlay after the caller has already mutated
+// an authoritative shadow. offset/length that do not touch any part are a no-op.
+func (wb *WriteBuffer) EnsurePartsForWrite(offset, length int64) error {
+	if wb == nil || length <= 0 || wb.partSize <= 0 {
+		return nil
+	}
+	end := offset + length
+	if end <= offset {
+		return nil
+	}
+	first := int(offset / wb.partSize)
+	last := int((end - 1) / wb.partSize)
+	for i := first; i <= last; i++ {
+		if err := wb.ensurePart(i); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (wb *WriteBuffer) needsCommitRebaseline() bool {
+	if wb == nil {
+		return false
+	}
+	if wb.RestorePart != nil || wb.OnPartFull != nil {
+		return true
+	}
+	return len(wb.uploadedParts) > 0
+}
+
 func (wb *WriteBuffer) restoreEvictedPart(partIdx int) ([]byte, bool, error) {
 	if wb.RestorePart != nil {
 		data, err := wb.RestorePart(partIdx + 1)

--- a/pkg/fuse/write.go
+++ b/pkg/fuse/write.go
@@ -47,6 +47,10 @@ type WriteBuffer struct {
 
 	// Callback (optional)
 	LoadPart LoadPartFunc // called to lazily load part data
+	// RestorePart reloads an evicted part from local authoritative storage
+	// (ShadowSpill). partNum is 1-based. Unlike LoadPart, it is not gated on
+	// remoteSize: the part may exist only in the local shadow.
+	RestorePart LoadPartFunc
 
 	// remoteSize is the original remote file size, set when lazy loading
 	// is configured. ensurePart() only calls LoadPart for parts whose
@@ -86,6 +90,7 @@ type writeBufferSnapshot struct {
 	dirtyParts    map[int]bool
 	touched       bool
 	LoadPart      LoadPartFunc
+	RestorePart   LoadPartFunc
 	remoteSize    int64
 	curMemory     int64
 	appendCursor  int64
@@ -109,6 +114,7 @@ func (wb *WriteBuffer) snapshot() *writeBufferSnapshot {
 		dirtyParts:    cloneBoolMap(wb.dirtyParts),
 		touched:       wb.touched,
 		LoadPart:      wb.LoadPart,
+		RestorePart:   wb.RestorePart,
 		remoteSize:    wb.remoteSize,
 		curMemory:     wb.curMemory,
 		appendCursor:  wb.appendCursor,
@@ -132,6 +138,7 @@ func (wb *WriteBuffer) restore(snapshot *writeBufferSnapshot) {
 	wb.dirtyParts = cloneBoolMap(snapshot.dirtyParts)
 	wb.touched = snapshot.touched
 	wb.LoadPart = snapshot.LoadPart
+	wb.RestorePart = snapshot.RestorePart
 	wb.remoteSize = snapshot.remoteSize
 	wb.curMemory = snapshot.curMemory
 	wb.appendCursor = snapshot.appendCursor
@@ -426,13 +433,23 @@ func (wb *WriteBuffer) ensurePart(partIdx int) error {
 		return nil
 	}
 
-	// Check if this part was evicted after streaming upload.
-	// Recreate as zero-filled — the original data is gone (already on S3).
-	// Only the newly written bytes will be meaningful; other bytes are zeros.
+	// A previously evicted part is being touched again. Prefer restoring the
+	// original bytes (ShadowSpill shadow or lazy remote load) so a non-tail
+	// overlay cannot zero-fill the rest of the part. Fall back to the
+	// historical zero-fill only when no restorer exists (streamer-only).
 	if wb.uploadedParts != nil && wb.uploadedParts[partIdx] {
+		data, restored, err := wb.restoreEvictedPart(partIdx)
+		if err != nil {
+			return err
+		}
+		if restored {
+			wb.parts[partIdx] = data
+			wb.curMemory += int64(len(data))
+			return nil
+		}
 		safeLogPrintf("WARNING: back-write to evicted part %d of %s — "+
 			"non-written bytes will be zero (original data already uploaded to S3)", partIdx, wb.path)
-		data := make([]byte, wb.partSize)
+		data = make([]byte, wb.partSize)
 		wb.parts[partIdx] = data
 		wb.curMemory += wb.partSize
 		return nil
@@ -455,6 +472,33 @@ func (wb *WriteBuffer) ensurePart(partIdx int) error {
 	// Create empty part
 	wb.parts[partIdx] = nil // will be grown as needed in Write
 	return nil
+}
+
+func (wb *WriteBuffer) restoreEvictedPart(partIdx int) ([]byte, bool, error) {
+	if wb.RestorePart != nil {
+		data, err := wb.RestorePart(partIdx + 1)
+		if err != nil {
+			return nil, false, fmt.Errorf("restore evicted part %d of %s: %w", partIdx+1, wb.path, err)
+		}
+		if len(data) == 0 {
+			return nil, false, fmt.Errorf("restored evicted part %d of %s is empty", partIdx+1, wb.path)
+		}
+		return data, true, nil
+	}
+	if wb.LoadPart != nil {
+		partStart := int64(partIdx) * wb.partSize
+		if partStart < wb.remoteSize {
+			data, err := wb.LoadPart(partIdx + 1)
+			if err != nil {
+				return nil, false, err
+			}
+			if len(data) == 0 {
+				return nil, false, fmt.Errorf("loaded evicted part %d of %s is empty", partIdx+1, wb.path)
+			}
+			return data, true, nil
+		}
+	}
+	return nil, false, nil
 }
 
 // markDirty marks all parts that overlap with [start, end) as dirty.
@@ -871,6 +915,15 @@ func (wb *WriteBuffer) LoadMissingParts() error {
 			continue
 		}
 		if wb.uploadedParts != nil && wb.uploadedParts[idx] {
+			data, restored, err := wb.restoreEvictedPart(idx)
+			if err != nil {
+				return err
+			}
+			if restored {
+				wb.parts[idx] = data
+				wb.curMemory += int64(len(data))
+				continue
+			}
 			return fmt.Errorf("part %d was evicted after streaming upload and cannot be refetched", idx+1)
 		}
 		if wb.LoadPart == nil {
@@ -934,10 +987,11 @@ func (wb *WriteBuffer) ResetStreamingState() {
 }
 
 // EvictPart releases the memory for a 0-based part index after it has been
-// uploaded via streaming. The part is recorded in uploadedParts so that
-// subsequent reads/writes know it was already handled.
-// If a back-write later touches this part, ensurePart will recreate it
-// as a zero-filled slice and log a warning.
+// uploaded via streaming or spilled to shadow. The part is recorded in
+// uploadedParts so that subsequent reads/writes know it was already handled.
+// If a back-write later touches this part, ensurePart restores it via
+// RestorePart/LoadPart when configured; otherwise it recreates a zero-filled
+// slice and logs a warning.
 func (wb *WriteBuffer) EvictPart(partIdx int) {
 	if wb.uploadedParts == nil {
 		wb.uploadedParts = make(map[int]bool)


### PR DESCRIPTION
Refs #898

## Summary
SQLite WAL is not pure append at FUSE part granularity. ShadowSpill evicts completed WriteBuffer parts, and a later non-tail write into an evicted part used to recreate that part as zeros. That is the `back-write to evicted part` warning and the Dirty hole mashenjun reproduced.

This does not auto-close #898: later byte-level evidence shows the remote WAL matched local shadow and WAL reads used `source=shadow-spill`. The remaining corruption is on the main DB commit-queue / checkpoint path.

## Change
- `ensurePart` restores an evicted part via `RestorePart` (local shadow) or `LoadPart` before applying the overlay.
- ShadowSpill Create/Open/truncate/WAL generation-reset wires `RestorePart` to read the part from the shadow file (writes already hit shadow first).
- Restore failure returns an error instead of silently zero-filling.
- Streamer-only buffers with no restorer keep the previous zero-fill warning.

Does not change sequential append, eviction, or append-log tail vs rewrite routing (`appendSafe` is still cleared on non-tail writes).

## Tests
- `TestWriteBuffer_RestorePartReloadsEvictedBytes`
- `TestWriteBuffer_RestorePartErrorFailsBackWrite`
- `TestShadowSpillBackWriteRestoresFromShadow`

`go test ./pkg/fuse -run 'TestWriteBuffer_RestorePart|TestWriteBuffer_EvictPart|TestShadowSpillBackWriteRestoresFromShadow|TestWriteBufferCanMaterializeFull|TestAppendLogGenerationReset'` pass.

A 1GiB WAL e2e on the original mount flags is still the field confirmation; this PR closes the zero-fill mechanism with a small-part unit gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved existing data during back-writes and appends after buffered data was evicted.
  - Restored evicted content before applying updates, preventing previously written bytes from being replaced with zeros.
  - Improved write validation and error handling for oversized writes, failed restores, and incomplete reads.
  - Ensured successful synchronization and commits correctly reset temporary eviction state for subsequent writes.
  - Preserved retained data when files are truncated and later extended.
  - Ensured reads and writes continue to work correctly after an unlinked file is modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->