### PR TITLE
fix(fuse): rebase grown same-path commits onto landed revision (#896)

### DIFF
--- a/pkg/client/transfer_test.go
+++ b/pkg/client/transfer_test.go
@@ -1699,7 +1699,9 @@ func TestReadStreamRangeFirstHopBoundedTransfer(t *testing.T) {
 	)
 	wal := bytes.Repeat([]byte("w"), walSize)
 	var wrote atomic.Int64
+	wroteDone := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(wroteDone)
 		if r.URL.Path != "/v1/fs/main.db-wal" {
 			http.NotFound(w, r)
 			return
@@ -1726,6 +1728,13 @@ func TestReadStreamRangeFirstHopBoundedTransfer(t *testing.T) {
 	defer func() { _ = rc.Close() }()
 
 	data, _ := io.ReadAll(rc)
+	// Keep the body open until the oversized Write finishes; otherwise the
+	// handler can still be in Write when we sample `wrote`.
+	select {
+	case <-wroteDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first-hop handler to finish")
+	}
 	if !bytes.Equal(data, wal[offset:offset+length]) {
 		t.Fatalf("read %d bytes, want exactly the %d-byte requested slice", len(data), length)
 	}

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -2221,13 +2221,6 @@ func committedRevisionForExpectedRevision(expectedRevision, committedRev int64) 
 	return 0
 }
 
-func (cq *CommitQueue) recordLandedFromSuccess(entry *CommitEntry, committedRev int64) {
-	if cq == nil || entry == nil {
-		return
-	}
-	cq.rememberLanded(entry.Path, committedRev, entry.Size)
-}
-
 // uploadEntry uploads entry data to the server. Returns (committedRev, error).
 // committedRev > 0 only when the server-returned revision is available
 // (direct PUT). Multipart/streaming uploads return 0 because the current

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -171,6 +171,11 @@ type CommitQueue struct {
 	// aliases for live-handle mutations. It is enabled only for gVisor mounts.
 	serializeMutationInodes bool
 
+	// landed records the last successful commit for each path so a later
+	// same-path growth (issue #896) can rebase onto that revision without
+	// being treated as a stale #876 snapshot.
+	landed map[string]pathCommitLandmark
+
 	// PathLock serializes upload and cleanup against Dat9FS same-path shadow
 	// mutations. When unset, the queue still serializes same-path entries.
 	PathLock func(path string) func()
@@ -219,6 +224,7 @@ func NewCommitQueue(c *client.Client, shadows *ShadowStore, index *PendingIndex,
 		inFlight:          make(map[string]*CommitEntry),
 		immediate:         make(map[*CommitEntry]struct{}),
 		queuedByPath:      make(map[string]map[*CommitEntry]struct{}),
+		landed:            make(map[string]pathCommitLandmark),
 		delayed:           make(map[*CommitEntry]*time.Timer),
 		workCh:            make(chan *CommitEntry, bufSize),
 		zeroTruncateDelay: zeroTruncateCommitQueueDelay,
@@ -320,6 +326,7 @@ func (cq *CommitQueue) Enqueue(entry *CommitEntry) error {
 	}
 	cq.queue = append(cq.queue, entry)
 	cq.addQueuedLocked(entry)
+	cq.supersedeOlderQueuedLocked(entry)
 	if cq.perf != nil {
 		cq.perf.commitEnqueue.add(1)
 	}
@@ -486,6 +493,12 @@ func (cq *CommitQueue) PendingStats() (count int, bytes int64) {
 		bytes += e.Size
 	}
 	return
+}
+
+// pathCommitLandmark is the last commit this queue itself landed for a path.
+type pathCommitLandmark struct {
+	rev  int64
+	size int64
 }
 
 type CommitQueueSnapshot struct {
@@ -1358,6 +1371,95 @@ func (cq *CommitQueue) canBeginInFlightLocked(entry *CommitEntry) bool {
 	return true
 }
 
+func commitEntryIsOlderSamePath(old, newer *CommitEntry) bool {
+	if old == nil || newer == nil || old == newer {
+		return false
+	}
+	if newer.MutationSeq > 0 && old.MutationSeq > 0 {
+		return old.MutationSeq < newer.MutationSeq
+	}
+	if newer.ShadowGen > 0 && old.ShadowGen > 0 && old.ShadowGen != newer.ShadowGen {
+		return old.ShadowGen < newer.ShadowGen
+	}
+	return old.Size < newer.Size
+}
+
+func (cq *CommitQueue) supersedeOlderQueuedLocked(entry *CommitEntry) {
+	if cq == nil || entry == nil || entry.Path == "" {
+		return
+	}
+	for _, queued := range cq.queue {
+		if queued == nil || queued == entry || queued.Path != entry.Path || queued.canceled {
+			continue
+		}
+		if cq.inFlight[queued.Path] == queued {
+			continue
+		}
+		if !commitEntryIsOlderSamePath(queued, entry) {
+			continue
+		}
+		queued.canceled = true
+		cq.stopDelayedLocked(queued)
+		if queued.cancelCommit != nil {
+			queued.cancelCommit()
+		}
+		if queued.cancelUpload != nil {
+			queued.cancelUpload()
+		}
+		safeLogPrintf("commit queue: superseded older queued commit for %s (old seq=%d size=%d -> new seq=%d size=%d)", entry.Path, queued.MutationSeq, queued.Size, entry.MutationSeq, entry.Size)
+	}
+}
+
+func (cq *CommitQueue) rememberLanded(path string, rev, size int64) {
+	if cq == nil || path == "" || rev <= 0 {
+		return
+	}
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	if cq.landed == nil {
+		cq.landed = make(map[string]pathCommitLandmark)
+	}
+	prev := cq.landed[path]
+	if rev >= prev.rev {
+		cq.landed[path] = pathCommitLandmark{rev: rev, size: size}
+	}
+}
+
+func (cq *CommitQueue) landedCommit(path string) pathCommitLandmark {
+	if cq == nil {
+		return pathCommitLandmark{}
+	}
+	cq.mu.Lock()
+	defer cq.mu.Unlock()
+	return cq.landed[path]
+}
+
+// maybeRebaseGrownPayloadOntoWatermark detects issue #896: a later same-path
+// mutation grew the file after this queue already landed a smaller snapshot.
+// Those bytes are newer than the watermark, so CAS should overwrite that
+// revision instead of being fenced as a stale #876 checkpoint snapshot.
+func (cq *CommitQueue) maybeRebaseGrownPayloadOntoWatermark(entry *CommitEntry, watermark int64) bool {
+	if cq == nil || entry == nil || watermark <= 0 {
+		return false
+	}
+	payloadBase := entry.payloadBaseRevision()
+	if payloadBase >= watermark {
+		return false
+	}
+	landed := cq.landedCommit(entry.Path)
+	if landed.rev != watermark || entry.Size <= landed.size {
+		return false
+	}
+	if entry.BaseRev < watermark {
+		entry.BaseRev = watermark
+	}
+	if entry.Kind == PendingNew {
+		entry.Kind = PendingOverwrite
+	}
+	safeLogPrintf("commit queue: rebasing grown payload for %s onto rev %d (size %d -> %d)", entry.Path, watermark, landed.size, entry.Size)
+	return true
+}
+
 func (cq *CommitQueue) oldestQueuedForPathLocked(path string) *CommitEntry {
 	if cq == nil || path == "" {
 		return nil
@@ -1883,9 +1985,14 @@ func (cq *CommitQueue) validateEntryPayloadFresh(entry *CommitEntry) error {
 	payloadBaseRev := entry.payloadBaseRevision()
 	watermark := cq.effectiveDurableWatermark(entry)
 	if watermark > 0 && payloadBaseRev >= 0 && payloadBaseRev < watermark {
-		entry.DisableAutoResolveLWW = true
-		return fmt.Errorf("%w: %s payload base rev %d is older than durable watermark rev %d",
-			errCommitPayloadStale, entry.Path, payloadBaseRev, watermark)
+		if cq.maybeRebaseGrownPayloadOntoWatermark(entry, watermark) {
+			// Keep going: this is a later growth of the same path, not a
+			// stale sibling snapshot of an older checkpoint.
+		} else {
+			entry.DisableAutoResolveLWW = true
+			return fmt.Errorf("%w: %s payload base rev %d is older than durable watermark rev %d",
+				errCommitPayloadStale, entry.Path, payloadBaseRev, watermark)
+		}
 	}
 	if entry.ShadowGen != 0 && cq != nil && cq.shadows != nil {
 		if activeGen := cq.shadows.ActiveGeneration(entry.Path); activeGen != entry.ShadowGen {
@@ -2114,6 +2221,13 @@ func committedRevisionForExpectedRevision(expectedRevision, committedRev int64) 
 	return 0
 }
 
+func (cq *CommitQueue) recordLandedFromSuccess(entry *CommitEntry, committedRev int64) {
+	if cq == nil || entry == nil {
+		return
+	}
+	cq.rememberLanded(entry.Path, committedRev, entry.Size)
+}
+
 // uploadEntry uploads entry data to the server. Returns (committedRev, error).
 // committedRev > 0 only when the server-returned revision is available
 // (direct PUT). Multipart/streaming uploads return 0 because the current
@@ -2123,17 +2237,20 @@ func (cq *CommitQueue) uploadEntry(ctx context.Context, entry *CommitEntry) (int
 		return 0, fmt.Errorf("no shadow store")
 	}
 
-	expectedRevision := entry.BaseRev
 	layerRef := cq.layerRefSnapshot()
-	if entry.Kind == PendingOverwrite && expectedRevision <= 0 && layerRef == "" {
-		return 0, fmt.Errorf("missing base revision for overwrite: %s", entry.Path)
-	}
 	apiPath := cq.remotePath(entry.Path)
 	if layerRef != "" {
-		return cq.uploadLayerEntry(ctx, layerRef, entry, apiPath, expectedRevision)
+		if err := cq.validateEntryPayloadFresh(entry); err != nil {
+			return 0, err
+		}
+		return cq.uploadLayerEntry(ctx, layerRef, entry, apiPath, entry.BaseRev)
 	}
 	if err := cq.validateEntryPayloadFresh(entry); err != nil {
 		return 0, err
+	}
+	expectedRevision := entry.BaseRev
+	if entry.Kind == PendingOverwrite && expectedRevision <= 0 {
+		return 0, fmt.Errorf("missing base revision for overwrite: %s", entry.Path)
 	}
 
 	// ShadowSpill entries: stream directly from shadow file to avoid loading
@@ -2305,6 +2422,7 @@ func (cq *CommitQueue) onCommitSuccessWithOptions(entry *CommitEntry, expectedRe
 	if layerRef == "" {
 		committedRev = committedRevisionForExpectedRevision(expectedRevision, committedRev)
 	}
+	cq.rememberLanded(entry.Path, committedRev, entry.Size)
 	if cq.OnUploaded != nil {
 		cq.OnUploaded(entry, committedRev)
 	}
@@ -2699,6 +2817,45 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 		}
 	}()
 	if stat.Size != localSize {
+		if localSize > stat.Size && cq.maybeRebaseGrownPayloadOntoWatermark(entry, stat.Revision) {
+			safeLogPrintf("commit queue: ShadowSpill growth overwrite for %s (local %d bytes vs server %d bytes at rev %d)", entry.Path, localSize, stat.Size, stat.Revision)
+			if fd != nil {
+				_ = fd.Close()
+				fd = nil
+			}
+			if release != nil {
+				release()
+				release = nil
+			}
+			uploadCtx, uploadCancel, ok := cq.entryUploadContext(entryCtx, entry, releaseTimeout(entry.Size))
+			if !ok {
+				cq.removeFromQueue(entry)
+				return
+			}
+			uploadStart := time.Now()
+			committedRev, uploadErr := uploadFromShadowRemoteWithRevisionAndGeneration(uploadCtx, cq.client, cq.shadows, entry.Path, apiPath, entry.BaseRev, entry.ShadowGen)
+			uploadCancel()
+			if cq.perf != nil {
+				var bytes uint64
+				if entry.Size > 0 {
+					bytes = uint64(entry.Size)
+				}
+				cq.perf.recordRemoteOp(perfRemoteWrite, uploadErr, time.Since(uploadStart), bytes)
+			}
+			if cq.isEntryCanceled(entry) {
+				cq.removeFromQueue(entry)
+				return
+			}
+			if uploadErr != nil {
+				safeLogPrintf("commit queue: ShadowSpill growth overwrite failed for %s: %v", entry.Path, uploadErr)
+				cq.onCommitTerminalFailure(entry)
+				return
+			}
+			if err := cq.onCommitSuccess(entry, entry.BaseRev, committedRev); err != nil {
+				cq.onCommitPostUploadFailure(entry, err)
+			}
+			return
+		}
 		safeLogPrintf("commit queue: ShadowSpill conflict for %s is genuine (local %d bytes vs server %d bytes), terminal failure", entry.Path, localSize, stat.Size)
 		cq.onCommitTerminalFailure(entry)
 		return

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -3,6 +3,8 @@ package fuse
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math"
@@ -500,6 +502,7 @@ type pathCommitLandmark struct {
 	rev        int64
 	size       int64
 	resourceID string
+	checksum   string
 }
 
 type CommitQueueSnapshot struct {
@@ -1417,7 +1420,27 @@ func (cq *CommitQueue) supersedeOlderQueuedLocked(entry *CommitEntry) {
 	cq.rebuildQueuedIndexLocked()
 }
 
-func (cq *CommitQueue) rememberLanded(path string, rev, size int64, resourceID string) {
+func payloadChecksum(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+func (cq *CommitQueue) checksumLandedPayload(entry *CommitEntry) string {
+	const maxHashBytes = 1 << 20
+	if cq == nil || entry == nil || cq.shadows == nil || entry.ShadowGen == 0 {
+		return ""
+	}
+	if entry.Size < 0 || entry.Size > maxHashBytes {
+		return ""
+	}
+	data, err := cq.shadows.ReadAllIfGeneration(entry.Path, entry.ShadowGen)
+	if err != nil || int64(len(data)) != entry.Size {
+		return ""
+	}
+	return payloadChecksum(data)
+}
+
+func (cq *CommitQueue) rememberLanded(path string, rev, size int64, resourceID, checksum string) {
 	if cq == nil || path == "" || rev <= 0 {
 		return
 	}
@@ -1428,29 +1451,16 @@ func (cq *CommitQueue) rememberLanded(path string, rev, size int64, resourceID s
 	prev := cq.landed[path]
 	persist := false
 	if rev >= prev.rev {
-		cq.landed[path] = pathCommitLandmark{rev: rev, size: size, resourceID: resourceID}
+		cq.landed[path] = pathCommitLandmark{rev: rev, size: size, resourceID: resourceID, checksum: checksum}
 		persist = true
 	}
 	idx := cq.index
 	cq.mu.Unlock()
 	if persist && idx != nil {
-		if err := idx.PutLanded(path, rev, size, resourceID); err != nil {
+		if err := idx.PutLanded(path, rev, size, resourceID, checksum); err != nil {
 			safeLogPrintf("commit queue: persist landed snapshot for %s: %v", path, err)
 		}
 	}
-}
-
-func (cq *CommitQueue) captureLandedResourceID(path string) string {
-	if cq == nil || cq.client == nil || path == "" {
-		return ""
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	st, err := cq.client.StatCtx(ctx, cq.remotePath(path))
-	if err != nil || st == nil {
-		return ""
-	}
-	return st.ResourceID
 }
 
 func (cq *CommitQueue) landedCommit(path string) pathCommitLandmark {
@@ -1495,15 +1505,26 @@ func (cq *CommitQueue) maybeRebaseGrownPayloadOntoWatermark(entry *CommitEntry, 
 // after a restart. The smaller remote image must match the snapshot this
 // client previously landed; a strictly larger local pending create against
 // an unrelated smaller remote file must stay conflicted.
-func (cq *CommitQueue) maybeRebaseGrownPayloadAgainstRemote(entry *CommitEntry, serverRev, serverSize int64, serverResourceID string) bool {
-	proof, ok := cq.durableLanded(entry.Path)
-	if !ok || proof.rev != serverRev || proof.size != serverSize {
+func landedIdentityMatches(proof pathCommitLandmark, serverRev, serverSize int64, serverResourceID string, serverBody []byte) bool {
+	if proof.rev != serverRev || proof.size != serverSize {
 		return false
 	}
-	// {rev,size} is not identity: delete/recreate can reuse revision 1 and
-	// the same byte length. Require the resource id of the exact object
-	// this mount landed. Missing identity fails closed.
-	if proof.resourceID == "" || serverResourceID == "" || proof.resourceID != serverResourceID {
+	if proof.resourceID != "" && serverResourceID != "" {
+		return proof.resourceID == serverResourceID
+	}
+	if proof.checksum == "" || int64(len(serverBody)) != proof.size {
+		return false
+	}
+	return payloadChecksum(serverBody) == proof.checksum
+}
+
+// maybeRebaseGrownPayloadAgainstRemote reconstructs the #896 growth rebase
+// after a restart. The smaller remote image must match the snapshot this
+// client previously landed (resource id when both sides have it, otherwise
+// the SHA-256 of the landed bytes). Missing identity fails closed.
+func (cq *CommitQueue) maybeRebaseGrownPayloadAgainstRemote(entry *CommitEntry, serverRev, serverSize int64, serverResourceID string, serverBody []byte) bool {
+	proof, ok := cq.durableLanded(entry.Path)
+	if !ok || !landedIdentityMatches(proof, serverRev, serverSize, serverResourceID, serverBody) {
 		return false
 	}
 	return cq.rebaseGrownPayload(entry, serverRev, serverSize)
@@ -2482,7 +2503,7 @@ func (cq *CommitQueue) onCommitSuccessWithOptions(entry *CommitEntry, expectedRe
 	if layerRef == "" {
 		committedRev = committedRevisionForExpectedRevision(expectedRevision, committedRev)
 	}
-	cq.rememberLanded(entry.Path, committedRev, entry.Size, cq.captureLandedResourceID(entry.Path))
+	cq.rememberLanded(entry.Path, committedRev, entry.Size, "", cq.checksumLandedPayload(entry))
 	if cq.OnUploaded != nil {
 		cq.OnUploaded(entry, committedRev)
 	}
@@ -2696,7 +2717,19 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 		return
 	}
 	serverRev := stat.Revision
-	if cq.maybeRebaseGrownPayloadAgainstRemote(entry, serverRev, stat.Size, stat.ResourceID) {
+	readCtx, readCancel := context.WithTimeout(context.Background(), uploadTimeout)
+	readStart := time.Now()
+	serverData, err := cq.client.ReadCtx(readCtx, apiPath)
+	readCancel()
+	if cq.perf != nil {
+		cq.perf.recordRemoteOp(perfRemoteRead, err, time.Since(readStart), uint64(len(serverData)))
+	}
+	if err != nil {
+		safeLogPrintf("commit queue: auto-resolve failed for %s: read server: %v", entry.Path, err)
+		cq.onCommitTerminalFailure(entry)
+		return
+	}
+	if cq.maybeRebaseGrownPayloadAgainstRemote(entry, serverRev, stat.Size, stat.ResourceID, serverData) {
 		if cq.discardSupersededEntry(entry) {
 			return
 		}
@@ -2734,19 +2767,6 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 		if err := cq.onCommitSuccess(entry, entry.BaseRev, committedRev); err != nil {
 			cq.onCommitPostUploadFailure(entry, err)
 		}
-		return
-	}
-
-	readCtx, readCancel := context.WithTimeout(context.Background(), uploadTimeout)
-	readStart := time.Now()
-	serverData, err := cq.client.ReadCtx(readCtx, apiPath)
-	readCancel()
-	if cq.perf != nil {
-		cq.perf.recordRemoteOp(perfRemoteRead, err, time.Since(readStart), uint64(len(serverData)))
-	}
-	if err != nil {
-		safeLogPrintf("commit queue: auto-resolve failed for %s: read server: %v", entry.Path, err)
-		cq.onCommitTerminalFailure(entry)
 		return
 	}
 
@@ -2917,7 +2937,13 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 		}
 	}()
 	if stat.Size != localSize {
-		if localSize > stat.Size && cq.maybeRebaseGrownPayloadAgainstRemote(entry, stat.Revision, stat.Size, stat.ResourceID) {
+		var remoteBody []byte
+		if localSize > stat.Size && stat.Size >= 0 && stat.Size <= 1<<20 {
+			readCtx, readCancel := context.WithTimeout(context.Background(), 10*time.Second)
+			remoteBody, _ = cq.client.ReadCtx(readCtx, apiPath)
+			readCancel()
+		}
+		if localSize > stat.Size && cq.maybeRebaseGrownPayloadAgainstRemote(entry, stat.Revision, stat.Size, stat.ResourceID, remoteBody) {
 			safeLogPrintf("commit queue: ShadowSpill growth overwrite for %s (local %d bytes vs server %d bytes at rev %d)", entry.Path, localSize, stat.Size, stat.Revision)
 			if fd != nil {
 				_ = fd.Close()

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1388,14 +1388,14 @@ func (cq *CommitQueue) supersedeOlderQueuedLocked(entry *CommitEntry) {
 	if cq == nil || entry == nil || entry.Path == "" {
 		return
 	}
+	remaining := cq.queue[:0]
+	changed := false
 	for _, queued := range cq.queue {
-		if queued == nil || queued == entry || queued.Path != entry.Path || queued.canceled {
+		if queued == nil {
 			continue
 		}
-		if cq.inFlight[queued.Path] == queued {
-			continue
-		}
-		if !commitEntryIsOlderSamePath(queued, entry) {
+		if queued == entry || queued.Path != entry.Path || queued.canceled || cq.inFlight[queued.Path] == queued || !commitEntryIsOlderSamePath(queued, entry) {
+			remaining = append(remaining, queued)
 			continue
 		}
 		queued.canceled = true
@@ -1406,8 +1406,14 @@ func (cq *CommitQueue) supersedeOlderQueuedLocked(entry *CommitEntry) {
 		if queued.cancelUpload != nil {
 			queued.cancelUpload()
 		}
+		changed = true
 		safeLogPrintf("commit queue: superseded older queued commit for %s (old seq=%d size=%d -> new seq=%d size=%d)", entry.Path, queued.MutationSeq, queued.Size, entry.MutationSeq, entry.Size)
 	}
+	if !changed {
+		return
+	}
+	cq.queue = remaining
+	cq.rebuildQueuedIndexLocked()
 }
 
 func (cq *CommitQueue) rememberLanded(path string, rev, size int64) {
@@ -1447,16 +1453,39 @@ func (cq *CommitQueue) maybeRebaseGrownPayloadOntoWatermark(entry *CommitEntry, 
 		return false
 	}
 	landed := cq.landedCommit(entry.Path)
-	if landed.rev != watermark || entry.Size <= landed.size {
+	if landed.rev != watermark {
 		return false
 	}
-	if entry.BaseRev < watermark {
-		entry.BaseRev = watermark
+	return cq.rebaseGrownPayload(entry, watermark, landed.size)
+}
+
+// maybeRebaseGrownPayloadAgainstRemote reconstructs the #896 growth rebase
+// after a restart, when this process has no in-memory landed snapshot. A
+// strictly larger local payload against a smaller remote image is same-path
+// growth, not an #876 stale checkpoint (those bytes are smaller/older).
+func (cq *CommitQueue) maybeRebaseGrownPayloadAgainstRemote(entry *CommitEntry, serverRev, serverSize int64) bool {
+	if !cq.rebaseGrownPayload(entry, serverRev, serverSize) {
+		return false
+	}
+	cq.rememberLanded(entry.Path, serverRev, serverSize)
+	return true
+}
+
+func (cq *CommitQueue) rebaseGrownPayload(entry *CommitEntry, priorRev, priorSize int64) bool {
+	if cq == nil || entry == nil || priorRev <= 0 || entry.Size <= priorSize {
+		return false
+	}
+	payloadBase := entry.payloadBaseRevision()
+	if payloadBase >= priorRev && entry.Kind != PendingNew {
+		return false
+	}
+	if entry.BaseRev < priorRev {
+		entry.BaseRev = priorRev
 	}
 	if entry.Kind == PendingNew {
 		entry.Kind = PendingOverwrite
 	}
-	safeLogPrintf("commit queue: rebasing grown payload for %s onto rev %d (size %d -> %d)", entry.Path, watermark, landed.size, entry.Size)
+	safeLogPrintf("commit queue: rebasing grown payload for %s onto rev %d (size %d -> %d)", entry.Path, priorRev, priorSize, entry.Size)
 	return true
 }
 
@@ -2629,6 +2658,46 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 		return
 	}
 	serverRev := stat.Revision
+	if cq.maybeRebaseGrownPayloadAgainstRemote(entry, serverRev, stat.Size) {
+		if cq.discardSupersededEntry(entry) {
+			return
+		}
+		if cq.isEntryCanceled(entry) {
+			cq.removeFromQueue(entry)
+			return
+		}
+		uploadCtx, uploadCancel, ok := cq.entryUploadContext(entryCtx, entry, releaseTimeout(int64(len(localData))))
+		if !ok {
+			cq.removeFromQueue(entry)
+			return
+		}
+		uploadStart := time.Now()
+		var committedRev int64
+		var uploadErr error
+		threshold := cq.directPutThreshold()
+		if len(localData) == 0 || (threshold > 0 && int64(len(localData)) < threshold) {
+			committedRev, uploadErr = cq.client.WriteCtxConditionalWithRevision(uploadCtx, apiPath, localData, entry.BaseRev)
+		} else {
+			uploadErr = uploadBufferedRemoteFile(uploadCtx, cq.client, apiPath, localData, entry.BaseRev)
+		}
+		uploadCancel()
+		if cq.perf != nil {
+			cq.perf.recordRemoteOp(perfRemoteWrite, uploadErr, time.Since(uploadStart), uint64(len(localData)))
+		}
+		if cq.isEntryCanceled(entry) {
+			cq.removeFromQueue(entry)
+			return
+		}
+		if uploadErr != nil {
+			safeLogPrintf("commit queue: grown-payload overwrite failed for %s: %v", entry.Path, uploadErr)
+			cq.onCommitTerminalFailure(entry)
+			return
+		}
+		if err := cq.onCommitSuccess(entry, entry.BaseRev, committedRev); err != nil {
+			cq.onCommitPostUploadFailure(entry, err)
+		}
+		return
+	}
 
 	readCtx, readCancel := context.WithTimeout(context.Background(), uploadTimeout)
 	readStart := time.Now()
@@ -2810,7 +2879,7 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 		}
 	}()
 	if stat.Size != localSize {
-		if localSize > stat.Size && cq.maybeRebaseGrownPayloadOntoWatermark(entry, stat.Revision) {
+		if localSize > stat.Size && cq.maybeRebaseGrownPayloadAgainstRemote(entry, stat.Revision, stat.Size) {
 			safeLogPrintf("commit queue: ShadowSpill growth overwrite for %s (local %d bytes vs server %d bytes at rev %d)", entry.Path, localSize, stat.Size, stat.Revision)
 			if fd != nil {
 				_ = fd.Close()

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -497,8 +497,9 @@ func (cq *CommitQueue) PendingStats() (count int, bytes int64) {
 
 // pathCommitLandmark is the last commit this queue itself landed for a path.
 type pathCommitLandmark struct {
-	rev  int64
-	size int64
+	rev        int64
+	size       int64
+	resourceID string
 }
 
 type CommitQueueSnapshot struct {
@@ -1416,7 +1417,7 @@ func (cq *CommitQueue) supersedeOlderQueuedLocked(entry *CommitEntry) {
 	cq.rebuildQueuedIndexLocked()
 }
 
-func (cq *CommitQueue) rememberLanded(path string, rev, size int64) {
+func (cq *CommitQueue) rememberLanded(path string, rev, size int64, resourceID string) {
 	if cq == nil || path == "" || rev <= 0 {
 		return
 	}
@@ -1427,16 +1428,29 @@ func (cq *CommitQueue) rememberLanded(path string, rev, size int64) {
 	prev := cq.landed[path]
 	persist := false
 	if rev >= prev.rev {
-		cq.landed[path] = pathCommitLandmark{rev: rev, size: size}
+		cq.landed[path] = pathCommitLandmark{rev: rev, size: size, resourceID: resourceID}
 		persist = true
 	}
 	idx := cq.index
 	cq.mu.Unlock()
 	if persist && idx != nil {
-		if err := idx.PutLanded(path, rev, size); err != nil {
+		if err := idx.PutLanded(path, rev, size, resourceID); err != nil {
 			safeLogPrintf("commit queue: persist landed snapshot for %s: %v", path, err)
 		}
 	}
+}
+
+func (cq *CommitQueue) captureLandedResourceID(path string) string {
+	if cq == nil || cq.client == nil || path == "" {
+		return ""
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	st, err := cq.client.StatCtx(ctx, cq.remotePath(path))
+	if err != nil || st == nil {
+		return ""
+	}
+	return st.ResourceID
 }
 
 func (cq *CommitQueue) landedCommit(path string) pathCommitLandmark {
@@ -1481,9 +1495,15 @@ func (cq *CommitQueue) maybeRebaseGrownPayloadOntoWatermark(entry *CommitEntry, 
 // after a restart. The smaller remote image must match the snapshot this
 // client previously landed; a strictly larger local pending create against
 // an unrelated smaller remote file must stay conflicted.
-func (cq *CommitQueue) maybeRebaseGrownPayloadAgainstRemote(entry *CommitEntry, serverRev, serverSize int64) bool {
+func (cq *CommitQueue) maybeRebaseGrownPayloadAgainstRemote(entry *CommitEntry, serverRev, serverSize int64, serverResourceID string) bool {
 	proof, ok := cq.durableLanded(entry.Path)
 	if !ok || proof.rev != serverRev || proof.size != serverSize {
+		return false
+	}
+	// {rev,size} is not identity: delete/recreate can reuse revision 1 and
+	// the same byte length. Require the resource id of the exact object
+	// this mount landed. Missing identity fails closed.
+	if proof.resourceID == "" || serverResourceID == "" || proof.resourceID != serverResourceID {
 		return false
 	}
 	return cq.rebaseGrownPayload(entry, serverRev, serverSize)
@@ -2462,7 +2482,7 @@ func (cq *CommitQueue) onCommitSuccessWithOptions(entry *CommitEntry, expectedRe
 	if layerRef == "" {
 		committedRev = committedRevisionForExpectedRevision(expectedRevision, committedRev)
 	}
-	cq.rememberLanded(entry.Path, committedRev, entry.Size)
+	cq.rememberLanded(entry.Path, committedRev, entry.Size, cq.captureLandedResourceID(entry.Path))
 	if cq.OnUploaded != nil {
 		cq.OnUploaded(entry, committedRev)
 	}
@@ -2676,7 +2696,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 		return
 	}
 	serverRev := stat.Revision
-	if cq.maybeRebaseGrownPayloadAgainstRemote(entry, serverRev, stat.Size) {
+	if cq.maybeRebaseGrownPayloadAgainstRemote(entry, serverRev, stat.Size, stat.ResourceID) {
 		if cq.discardSupersededEntry(entry) {
 			return
 		}
@@ -2897,7 +2917,7 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 		}
 	}()
 	if stat.Size != localSize {
-		if localSize > stat.Size && cq.maybeRebaseGrownPayloadAgainstRemote(entry, stat.Revision, stat.Size) {
+		if localSize > stat.Size && cq.maybeRebaseGrownPayloadAgainstRemote(entry, stat.Revision, stat.Size, stat.ResourceID) {
 			safeLogPrintf("commit queue: ShadowSpill growth overwrite for %s (local %d bytes vs server %d bytes at rev %d)", entry.Path, localSize, stat.Size, stat.Revision)
 			if fd != nil {
 				_ = fd.Close()

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1421,13 +1421,21 @@ func (cq *CommitQueue) rememberLanded(path string, rev, size int64) {
 		return
 	}
 	cq.mu.Lock()
-	defer cq.mu.Unlock()
 	if cq.landed == nil {
 		cq.landed = make(map[string]pathCommitLandmark)
 	}
 	prev := cq.landed[path]
+	persist := false
 	if rev >= prev.rev {
 		cq.landed[path] = pathCommitLandmark{rev: rev, size: size}
+		persist = true
+	}
+	idx := cq.index
+	cq.mu.Unlock()
+	if persist && idx != nil {
+		if err := idx.PutLanded(path, rev, size); err != nil {
+			safeLogPrintf("commit queue: persist landed snapshot for %s: %v", path, err)
+		}
 	}
 }
 
@@ -1438,6 +1446,16 @@ func (cq *CommitQueue) landedCommit(path string) pathCommitLandmark {
 	cq.mu.Lock()
 	defer cq.mu.Unlock()
 	return cq.landed[path]
+}
+
+func (cq *CommitQueue) durableLanded(path string) (pathCommitLandmark, bool) {
+	if mem := cq.landedCommit(path); mem.rev > 0 {
+		return mem, true
+	}
+	if cq != nil && cq.index != nil {
+		return cq.index.GetLanded(path)
+	}
+	return pathCommitLandmark{}, false
 }
 
 // maybeRebaseGrownPayloadOntoWatermark detects issue #896: a later same-path
@@ -1460,15 +1478,15 @@ func (cq *CommitQueue) maybeRebaseGrownPayloadOntoWatermark(entry *CommitEntry, 
 }
 
 // maybeRebaseGrownPayloadAgainstRemote reconstructs the #896 growth rebase
-// after a restart, when this process has no in-memory landed snapshot. A
-// strictly larger local payload against a smaller remote image is same-path
-// growth, not an #876 stale checkpoint (those bytes are smaller/older).
+// after a restart. The smaller remote image must match the snapshot this
+// client previously landed; a strictly larger local pending create against
+// an unrelated smaller remote file must stay conflicted.
 func (cq *CommitQueue) maybeRebaseGrownPayloadAgainstRemote(entry *CommitEntry, serverRev, serverSize int64) bool {
-	if !cq.rebaseGrownPayload(entry, serverRev, serverSize) {
+	proof, ok := cq.durableLanded(entry.Path)
+	if !ok || proof.rev != serverRev || proof.size != serverSize {
 		return false
 	}
-	cq.rememberLanded(entry.Path, serverRev, serverSize)
-	return true
+	return cq.rebaseGrownPayload(entry, serverRev, serverSize)
 }
 
 func (cq *CommitQueue) rebaseGrownPayload(entry *CommitEntry, priorRev, priorSize int64) bool {

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1498,7 +1498,33 @@ func (cq *CommitQueue) maybeRebaseGrownPayloadOntoWatermark(entry *CommitEntry, 
 	if landed.rev != watermark {
 		return false
 	}
-	return cq.rebaseGrownPayload(entry, watermark, landed.size)
+	rev, size, resourceID, body, ok := cq.readRemoteSnapshot(entry.Path)
+	if !ok {
+		return false
+	}
+	return cq.maybeRebaseGrownPayloadAgainstRemote(entry, rev, size, resourceID, body)
+}
+
+func (cq *CommitQueue) readRemoteSnapshot(path string) (rev, size int64, resourceID string, body []byte, ok bool) {
+	if cq == nil || cq.client == nil || path == "" {
+		return 0, 0, "", nil, false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	apiPath := cq.remotePath(path)
+	st, err := cq.client.StatCtx(ctx, apiPath)
+	if err != nil || st == nil {
+		return 0, 0, "", nil, false
+	}
+	rev, size, resourceID = st.Revision, st.Size, st.ResourceID
+	if st.Size < 0 || st.Size > 1<<20 {
+		return rev, size, resourceID, nil, resourceID != ""
+	}
+	body, err = cq.client.ReadCtx(ctx, apiPath)
+	if err != nil {
+		return rev, size, resourceID, nil, resourceID != ""
+	}
+	return rev, size, resourceID, body, true
 }
 
 // maybeRebaseGrownPayloadAgainstRemote reconstructs the #896 growth rebase

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -609,9 +609,10 @@ func (idx *PendingIndex) MarkConflictIfGeneration(remotePath string, expectedGen
 }
 
 type pendingLandedMeta struct {
-	Path string `json:"path"`
-	Rev  int64  `json:"rev"`
-	Size int64  `json:"size"`
+	Path       string `json:"path"`
+	Rev        int64  `json:"rev"`
+	Size       int64  `json:"size"`
+	ResourceID string `json:"resource_id,omitempty"`
 }
 
 func (idx *PendingIndex) landedFile(remotePath string) string {
@@ -621,13 +622,13 @@ func (idx *PendingIndex) landedFile(remotePath string) string {
 // PutLanded durably records the last snapshot this mount successfully
 // committed for path. Crash recovery uses it to prove a smaller remote
 // image is the same image this client landed, not an unrelated create.
-func (idx *PendingIndex) PutLanded(remotePath string, rev, size int64) error {
+func (idx *PendingIndex) PutLanded(remotePath string, rev, size int64, resourceID string) error {
 	if idx == nil || remotePath == "" || rev <= 0 {
 		return nil
 	}
 	pl := idx.acquirePathLock(remotePath)
 	defer idx.releasePathLock(remotePath, pl)
-	raw, err := json.Marshal(pendingLandedMeta{Path: remotePath, Rev: rev, Size: size})
+	raw, err := json.Marshal(pendingLandedMeta{Path: remotePath, Rev: rev, Size: size, ResourceID: resourceID})
 	if err != nil {
 		return fmt.Errorf("pending index marshal landed: %w", err)
 	}
@@ -653,7 +654,7 @@ func (idx *PendingIndex) GetLanded(remotePath string) (pathCommitLandmark, bool)
 	if meta.Rev <= 0 {
 		return pathCommitLandmark{}, false
 	}
-	return pathCommitLandmark{rev: meta.Rev, size: meta.Size}, true
+	return pathCommitLandmark{rev: meta.Rev, size: meta.Size, resourceID: meta.ResourceID}, true
 }
 
 // Count returns the number of pending entries.

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -608,6 +608,54 @@ func (idx *PendingIndex) MarkConflictIfGeneration(remotePath string, expectedGen
 	return false, nil
 }
 
+type pendingLandedMeta struct {
+	Path string `json:"path"`
+	Rev  int64  `json:"rev"`
+	Size int64  `json:"size"`
+}
+
+func (idx *PendingIndex) landedFile(remotePath string) string {
+	return filepath.Join(idx.dir, hashPath(remotePath)+".landed")
+}
+
+// PutLanded durably records the last snapshot this mount successfully
+// committed for path. Crash recovery uses it to prove a smaller remote
+// image is the same image this client landed, not an unrelated create.
+func (idx *PendingIndex) PutLanded(remotePath string, rev, size int64) error {
+	if idx == nil || remotePath == "" || rev <= 0 {
+		return nil
+	}
+	pl := idx.acquirePathLock(remotePath)
+	defer idx.releasePathLock(remotePath, pl)
+	raw, err := json.Marshal(pendingLandedMeta{Path: remotePath, Rev: rev, Size: size})
+	if err != nil {
+		return fmt.Errorf("pending index marshal landed: %w", err)
+	}
+	if err := atomicWrite(idx.landedFile(remotePath), raw); err != nil {
+		return fmt.Errorf("pending index write landed: %w", err)
+	}
+	return nil
+}
+
+// GetLanded returns the durable last-landed snapshot for path, if any.
+func (idx *PendingIndex) GetLanded(remotePath string) (pathCommitLandmark, bool) {
+	if idx == nil || remotePath == "" {
+		return pathCommitLandmark{}, false
+	}
+	raw, err := os.ReadFile(idx.landedFile(remotePath))
+	if err != nil {
+		return pathCommitLandmark{}, false
+	}
+	var meta pendingLandedMeta
+	if err := json.Unmarshal(raw, &meta); err != nil {
+		return pathCommitLandmark{}, false
+	}
+	if meta.Rev <= 0 {
+		return pathCommitLandmark{}, false
+	}
+	return pathCommitLandmark{rev: meta.Rev, size: meta.Size}, true
+}
+
 // Count returns the number of pending entries.
 func (idx *PendingIndex) Count() int {
 	idx.mu.RLock()

--- a/pkg/fuse/pending_index.go
+++ b/pkg/fuse/pending_index.go
@@ -613,6 +613,7 @@ type pendingLandedMeta struct {
 	Rev        int64  `json:"rev"`
 	Size       int64  `json:"size"`
 	ResourceID string `json:"resource_id,omitempty"`
+	Checksum   string `json:"checksum,omitempty"`
 }
 
 func (idx *PendingIndex) landedFile(remotePath string) string {
@@ -622,13 +623,13 @@ func (idx *PendingIndex) landedFile(remotePath string) string {
 // PutLanded durably records the last snapshot this mount successfully
 // committed for path. Crash recovery uses it to prove a smaller remote
 // image is the same image this client landed, not an unrelated create.
-func (idx *PendingIndex) PutLanded(remotePath string, rev, size int64, resourceID string) error {
+func (idx *PendingIndex) PutLanded(remotePath string, rev, size int64, resourceID, checksum string) error {
 	if idx == nil || remotePath == "" || rev <= 0 {
 		return nil
 	}
 	pl := idx.acquirePathLock(remotePath)
 	defer idx.releasePathLock(remotePath, pl)
-	raw, err := json.Marshal(pendingLandedMeta{Path: remotePath, Rev: rev, Size: size, ResourceID: resourceID})
+	raw, err := json.Marshal(pendingLandedMeta{Path: remotePath, Rev: rev, Size: size, ResourceID: resourceID, Checksum: checksum})
 	if err != nil {
 		return fmt.Errorf("pending index marshal landed: %w", err)
 	}
@@ -654,7 +655,7 @@ func (idx *PendingIndex) GetLanded(remotePath string) (pathCommitLandmark, bool)
 	if meta.Rev <= 0 {
 		return pathCommitLandmark{}, false
 	}
-	return pathCommitLandmark{rev: meta.Rev, size: meta.Size, resourceID: meta.ResourceID}, true
+	return pathCommitLandmark{rev: meta.Rev, size: meta.Size, resourceID: meta.ResourceID, checksum: meta.Checksum}, true
 }
 
 // Count returns the number of pending entries.

--- a/pkg/fuse/writeback_generation_fence_test.go
+++ b/pkg/fuse/writeback_generation_fence_test.go
@@ -1566,3 +1566,205 @@ func TestShadowSpillDirectPUTCleanupKeepsNewerGeneration(t *testing.T) {
 		t.Fatalf("shadow generation = %d, want fresh generation %d", got, freshShadowGen)
 	}
 }
+
+func TestCommitQueueRebasesGrownPayloadAfterSmallerSamePathCommit(t *testing.T) {
+	const path = "/kv-1g.db"
+	header := make([]byte, 4096)
+	for i := range header {
+		header[i] = 'H'
+	}
+	grown := make([]byte, 4096+8192)
+	copy(grown, header)
+	for i := 4096; i < len(grown); i++ {
+		grown[i] = 'G'
+	}
+
+	server, ts := newCASFileServer(t, path, 0, nil)
+	defer ts.Close()
+
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1 << 20)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	var watermark atomic.Int64
+	cq.DurableWatermark = func(string) int64 { return watermark.Load() }
+	cq.OnSuccess = func(_ *CommitEntry, rev int64) {
+		watermark.Store(rev)
+	}
+
+	if err := shadow.WriteFull(path, header, 0); err != nil {
+		t.Fatal(err)
+	}
+	headerGen := shadow.ActiveGeneration(path)
+	headerPending, err := pending.PutWithBaseRev(path, int64(len(header)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              path,
+		BaseRev:           0,
+		PayloadBaseRev:    0,
+		PayloadBaseRevSet: true,
+		Size:              int64(len(header)),
+		Kind:              PendingNew,
+		MutationSeq:       1,
+		ShadowGen:         headerGen,
+		PendingIndexGen:   headerPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitCommitQueueIdle(t, cq)
+
+	rev, body, _ := server.snapshot()
+	if rev != 1 || string(body) != string(header) {
+		t.Fatalf("after header commit rev=%d body=%q, want rev=1 header", rev, body)
+	}
+
+	if err := shadow.WriteFull(path, grown, 0); err != nil {
+		t.Fatal(err)
+	}
+	grownGen := shadow.ActiveGeneration(path)
+	grownPending, err := pending.PutWithBaseRev(path, int64(len(grown)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              path,
+		BaseRev:           0,
+		PayloadBaseRev:    0,
+		PayloadBaseRevSet: true,
+		Size:              int64(len(grown)),
+		Kind:              PendingNew,
+		MutationSeq:       2,
+		ShadowGen:         grownGen,
+		PendingIndexGen:   grownPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitCommitQueueIdle(t, cq)
+
+	rev, body, puts := server.snapshot()
+	if rev != 2 {
+		t.Fatalf("after growth commit rev=%d, want 2", rev)
+	}
+	if string(body) != string(grown) {
+		t.Fatalf("after growth commit body len=%d, want grown %d bytes", len(body), len(grown))
+	}
+	if len(puts) != 2 {
+		t.Fatalf("PUT count = %d, want 2 (header then growth)", len(puts))
+	}
+}
+
+func TestCommitQueueSupersedesOlderSamePathQueuedCommit(t *testing.T) {
+	const path = "/grow.bin"
+	small := []byte("tiny")
+	large := []byte("this-is-the-full-image")
+
+	server, ts := newCASFileServer(t, path, 0, nil)
+	defer ts.Close()
+
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1 << 20)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	cq.PathLock = func(string) func() {
+		select {
+		case <-started:
+		default:
+			close(started)
+			<-release
+		}
+		return func() {}
+	}
+
+	if err := shadow.WriteFull(path, small, 0); err != nil {
+		t.Fatal(err)
+	}
+	smallGen := shadow.ActiveGeneration(path)
+	smallPending, err := pending.PutWithBaseRev(path, int64(len(small)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:            path,
+		Size:            int64(len(small)),
+		Kind:            PendingNew,
+		MutationSeq:     1,
+		ShadowGen:       smallGen,
+		PendingIndexGen: smallPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("small commit did not start")
+	}
+
+	if err := shadow.WriteFull(path, large, 0); err != nil {
+		t.Fatal(err)
+	}
+	largeGen := shadow.ActiveGeneration(path)
+	largePending, err := pending.PutWithBaseRev(path, int64(len(large)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:            path,
+		Size:            int64(len(large)),
+		Kind:            PendingNew,
+		MutationSeq:     2,
+		ShadowGen:       largeGen,
+		PendingIndexGen: largePending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	close(release)
+	waitCommitQueueIdle(t, cq)
+
+	_, body, puts := server.snapshot()
+	if string(body) != string(large) {
+		t.Fatalf("body = %q, want large image", body)
+	}
+	if len(puts) < 1 {
+		t.Fatal("expected at least one PUT")
+	}
+	if string(puts[len(puts)-1].body) != string(large) {
+		t.Fatalf("last PUT body = %q, want large image", puts[len(puts)-1].body)
+	}
+}
+
+func waitCommitQueueIdle(t *testing.T, cq *CommitQueue) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		n, _ := cq.PendingStats()
+		if n == 0 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	n, _ := cq.PendingStats()
+	t.Fatalf("commit queue still pending=%d", n)
+}

--- a/pkg/fuse/writeback_generation_fence_test.go
+++ b/pkg/fuse/writeback_generation_fence_test.go
@@ -1688,6 +1688,99 @@ func TestCommitQueueRebasesGrownPayloadAfterSmallerSamePathCommit(t *testing.T) 
 	}
 }
 
+func TestCommitQueueSameProcessGrowthDoesNotOverwriteRecreatedSameRevSize(t *testing.T) {
+	const path = "/kv-1g.db"
+	header := bytes.Repeat([]byte("H"), 4096)
+	grown := append(bytes.Repeat([]byte("H"), 4096), bytes.Repeat([]byte("G"), 8192)...)
+	recreated := bytes.Repeat([]byte("X"), 4096)
+
+	server, ts := newCASFileServer(t, path, 0, nil)
+	defer ts.Close()
+
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1 << 20)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	var watermark atomic.Int64
+	cq.DurableWatermark = func(string) int64 { return watermark.Load() }
+	cq.OnSuccess = func(_ *CommitEntry, rev int64) {
+		watermark.Store(rev)
+	}
+
+	if err := shadow.WriteFull(path, header, 0); err != nil {
+		t.Fatal(err)
+	}
+	headerGen := shadow.ActiveGeneration(path)
+	headerPending, err := pending.PutWithBaseRev(path, int64(len(header)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              path,
+		BaseRev:           0,
+		PayloadBaseRev:    0,
+		PayloadBaseRevSet: true,
+		Size:              int64(len(header)),
+		Kind:              PendingNew,
+		MutationSeq:       1,
+		ShadowGen:         headerGen,
+		PendingIndexGen:   headerPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitCommitQueueIdle(t, cq)
+	server.recreate(recreated)
+
+	if err := shadow.WriteFull(path, grown, 0); err != nil {
+		t.Fatal(err)
+	}
+	grownGen := shadow.ActiveGeneration(path)
+	grownPending, err := pending.PutWithBaseRev(path, int64(len(grown)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              path,
+		BaseRev:           0,
+		PayloadBaseRev:    0,
+		PayloadBaseRevSet: true,
+		Size:              int64(len(grown)),
+		Kind:              PendingNew,
+		MutationSeq:       2,
+		ShadowGen:         grownGen,
+		PendingIndexGen:   grownPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitCommitQueueIdle(t, cq)
+
+	rev, body, puts := server.snapshot()
+	if rev != 1 || string(body) != string(recreated) {
+		t.Fatalf("remote rev=%d, want recreated 4KiB image at rev=1", rev)
+	}
+	for _, put := range puts {
+		if string(put.body) == string(grown) {
+			t.Fatal("same-process growth overwrote a delete/recreate with the same rev and size")
+		}
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending entry missing after same-process recreate conflict")
+	}
+	if meta.Kind != PendingConflict {
+		t.Fatalf("pending kind = %v, want PendingConflict", meta.Kind)
+	}
+}
+
 func TestCommitQueueSupersedesOlderSamePathQueuedCommit(t *testing.T) {
 	const path = "/grow.bin"
 	small := []byte("tiny")

--- a/pkg/fuse/writeback_generation_fence_test.go
+++ b/pkg/fuse/writeback_generation_fence_test.go
@@ -1830,6 +1830,54 @@ func TestCommitQueueRecoversGrownPayloadAfterSmallerCommitAndRestart(t *testing.
 	}
 }
 
+func TestCommitQueueRecoveredPendingNewDoesNotOverwriteUnrelatedRemote(t *testing.T) {
+	const path = "/kv-1g.db"
+	remote := []byte("external")
+	local := bytes.Repeat([]byte("L"), 4096)
+
+	server, ts := newCASFileServer(t, path, 1, remote)
+	defer ts.Close()
+
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := shadow.WriteFull(path, local, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(path, int64(len(local)), PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1 << 20)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.RecoverPending()
+	waitCommitQueueIdle(t, cq)
+
+	rev, body, puts := server.snapshot()
+	if rev != 1 || string(body) != string(remote) {
+		t.Fatalf("remote rev=%d body=%q, want rev=1 external image", rev, body)
+	}
+	for _, put := range puts {
+		if string(put.body) == string(local) {
+			t.Fatal("recovered PendingNew overwrote an unrelated smaller remote file")
+		}
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending entry missing after unrelated remote conflict")
+	}
+	if meta.Kind != PendingConflict {
+		t.Fatalf("pending kind = %v, want PendingConflict", meta.Kind)
+	}
+}
+
 func TestCommitQueueSupersedeRemovesDelayedZeroTruncate(t *testing.T) {
 	const path = "/grow.bin"
 	large := []byte("this-is-the-full-image")

--- a/pkg/fuse/writeback_generation_fence_test.go
+++ b/pkg/fuse/writeback_generation_fence_test.go
@@ -124,10 +124,12 @@ type casFileServer struct {
 	t    *testing.T
 	path string
 
-	mu       sync.Mutex
-	revision int64
-	body     []byte
-	puts     []casFilePut
+	mu         sync.Mutex
+	revision   int64
+	body       []byte
+	resourceID string
+	nextRes    int
+	puts       []casFilePut
 }
 
 type casFilePut struct {
@@ -143,6 +145,10 @@ func newCASFileServer(t *testing.T, path string, revision int64, body []byte) (*
 		path:     path,
 		revision: revision,
 		body:     append([]byte(nil), body...),
+	}
+	if revision > 0 || len(body) > 0 {
+		s.nextRes = 1
+		s.resourceID = "res-1"
 	}
 	ts := httptest.NewServer(http.HandlerFunc(s.serveHTTP))
 	return s, ts
@@ -170,6 +176,10 @@ func (s *casFileServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 		s.revision++
 		s.body = append([]byte(nil), body...)
+		if s.resourceID == "" {
+			s.nextRes++
+			s.resourceID = fmt.Sprintf("res-%d", s.nextRes)
+		}
 		s.puts = append(s.puts, casFilePut{
 			expected: expected,
 			revision: s.revision,
@@ -181,10 +191,14 @@ func (s *casFileServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		s.mu.Lock()
 		revision := s.revision
 		size := len(s.body)
+		resourceID := s.resourceID
 		s.mu.Unlock()
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", size))
 		w.Header().Set("X-Dat9-IsDir", "false")
 		w.Header().Set("X-Dat9-Revision", fmt.Sprintf("%d", revision))
+		if resourceID != "" {
+			w.Header().Set("X-Dat9-Resource-ID", resourceID)
+		}
 		w.WriteHeader(http.StatusOK)
 	case http.MethodGet:
 		s.mu.Lock()
@@ -194,6 +208,15 @@ func (s *casFileServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
+}
+
+func (s *casFileServer) recreate(body []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.revision = 1
+	s.body = append([]byte(nil), body...)
+	s.nextRes++
+	s.resourceID = fmt.Sprintf("res-%d", s.nextRes)
 }
 
 func (s *casFileServer) snapshot() (int64, []byte, []casFilePut) {
@@ -1872,6 +1895,83 @@ func TestCommitQueueRecoveredPendingNewDoesNotOverwriteUnrelatedRemote(t *testin
 	meta, ok := pending.GetMeta(path)
 	if !ok {
 		t.Fatal("pending entry missing after unrelated remote conflict")
+	}
+	if meta.Kind != PendingConflict {
+		t.Fatalf("pending kind = %v, want PendingConflict", meta.Kind)
+	}
+}
+
+func TestCommitQueueRecoveredGrowthDoesNotOverwriteRecreatedSameRevSize(t *testing.T) {
+	const path = "/kv-1g.db"
+	header := bytes.Repeat([]byte("H"), 4096)
+	grown := append(bytes.Repeat([]byte("H"), 4096), bytes.Repeat([]byte("G"), 8192)...)
+	recreated := bytes.Repeat([]byte("X"), 4096)
+
+	server, ts := newCASFileServer(t, path, 0, nil)
+	defer ts.Close()
+
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1 << 20)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	if err := shadow.WriteFull(path, header, 0); err != nil {
+		t.Fatal(err)
+	}
+	headerGen := shadow.ActiveGeneration(path)
+	headerPending, err := pending.PutWithBaseRev(path, int64(len(header)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              path,
+		BaseRev:           0,
+		PayloadBaseRev:    0,
+		PayloadBaseRevSet: true,
+		Size:              int64(len(header)),
+		Kind:              PendingNew,
+		MutationSeq:       1,
+		ShadowGen:         headerGen,
+		PendingIndexGen:   headerPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitCommitQueueIdle(t, cq)
+
+	if err := shadow.WriteFull(path, grown, 0); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev(path, int64(len(grown)), PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+	cq.DrainAll()
+	server.recreate(recreated)
+
+	recovered := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	recovered.client.SetSmallFileThresholdForTests(1 << 20)
+	recovered.RecoverPending()
+	waitCommitQueueIdle(t, recovered)
+
+	rev, body, puts := server.snapshot()
+	if rev != 1 || string(body) != string(recreated) {
+		t.Fatalf("remote rev=%d body[0]=%q, want recreated 4KiB image at rev=1", rev, body[:1])
+	}
+	for _, put := range puts {
+		if string(put.body) == string(grown) {
+			t.Fatal("recovered growth overwrote a delete/recreate with the same rev and size")
+		}
+	}
+	meta, ok := pending.GetMeta(path)
+	if !ok {
+		t.Fatal("pending entry missing after recreate conflict")
 	}
 	if meta.Kind != PendingConflict {
 		t.Fatalf("pending kind = %v, want PendingConflict", meta.Kind)

--- a/pkg/fuse/writeback_generation_fence_test.go
+++ b/pkg/fuse/writeback_generation_fence_test.go
@@ -1,6 +1,7 @@
 package fuse
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -1752,6 +1753,161 @@ func TestCommitQueueSupersedesOlderSamePathQueuedCommit(t *testing.T) {
 	}
 	if string(puts[len(puts)-1].body) != string(large) {
 		t.Fatalf("last PUT body = %q, want large image", puts[len(puts)-1].body)
+	}
+}
+
+func TestCommitQueueRecoversGrownPayloadAfterSmallerCommitAndRestart(t *testing.T) {
+	const path = "/kv-1g.db"
+	header := bytes.Repeat([]byte("H"), 4096)
+	grown := append(bytes.Repeat([]byte("H"), 4096), bytes.Repeat([]byte("G"), 8192)...)
+
+	server, ts := newCASFileServer(t, path, 0, nil)
+	defer ts.Close()
+
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1 << 20)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	if err := shadow.WriteFull(path, header, 0); err != nil {
+		t.Fatal(err)
+	}
+	headerGen := shadow.ActiveGeneration(path)
+	headerPending, err := pending.PutWithBaseRev(path, int64(len(header)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:              path,
+		BaseRev:           0,
+		PayloadBaseRev:    0,
+		PayloadBaseRevSet: true,
+		Size:              int64(len(header)),
+		Kind:              PendingNew,
+		MutationSeq:       1,
+		ShadowGen:         headerGen,
+		PendingIndexGen:   headerPending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	waitCommitQueueIdle(t, cq)
+
+	if err := shadow.WriteFull(path, grown, 0); err != nil {
+		t.Fatal(err)
+	}
+	grownPending, err := pending.PutWithBaseRev(path, int64(len(grown)), PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grownPending == 0 {
+		t.Fatal("grown pending generation missing")
+	}
+	cq.DrainAll()
+
+	recovered := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	recovered.client.SetSmallFileThresholdForTests(1 << 20)
+	recovered.RecoverPending()
+	waitCommitQueueIdle(t, recovered)
+
+	rev, body, _ := server.snapshot()
+	if rev != 2 {
+		t.Fatalf("after recovery rev=%d, want 2", rev)
+	}
+	if string(body) != string(grown) {
+		t.Fatalf("after recovery body len=%d, want grown %d bytes", len(body), len(grown))
+	}
+	meta, ok := pending.GetMeta(path)
+	if ok && meta.Kind == PendingConflict {
+		t.Fatal("grown payload was marked conflicted after restart")
+	}
+}
+
+func TestCommitQueueSupersedeRemovesDelayedZeroTruncate(t *testing.T) {
+	const path = "/grow.bin"
+	large := []byte("this-is-the-full-image")
+
+	server, ts := newCASFileServer(t, path, 7, []byte("old"))
+	defer ts.Close()
+
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow.Close()
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := newTestClient(ts.URL)
+	c.SetSmallFileThresholdForTests(1 << 20)
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 8)
+	cq.zeroTruncateDelay = time.Hour
+
+	if err := shadow.WriteFull(path, nil, 7); err != nil {
+		t.Fatal(err)
+	}
+	truncGen := shadow.ActiveGeneration(path)
+	truncPending, err := pending.PutWithBaseRev(path, 0, PendingOverwrite, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:                 path,
+		BaseRev:              7,
+		Size:                 0,
+		Kind:                 PendingOverwrite,
+		MutationSeq:          1,
+		ShadowGen:            truncGen,
+		PendingIndexGen:      truncPending,
+		CoalesceZeroTruncate: true,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := shadow.WriteFull(path, large, 7); err != nil {
+		t.Fatal(err)
+	}
+	largeGen := shadow.ActiveGeneration(path)
+	largePending, err := pending.PutWithBaseRev(path, int64(len(large)), PendingOverwrite, 7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := cq.Enqueue(&CommitEntry{
+		Path:            path,
+		BaseRev:         7,
+		Size:            int64(len(large)),
+		Kind:            PendingOverwrite,
+		MutationSeq:     2,
+		ShadowGen:       largeGen,
+		PendingIndexGen: largePending,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	if err := cq.WaitIdle(ctx); err != nil {
+		t.Fatalf("WaitIdle: %v", err)
+	}
+	if cq.HasPath(path) {
+		t.Fatal("superseded delayed zero-truncate still occupies the path")
+	}
+	n, _ := cq.PendingStats()
+	if n != 0 {
+		t.Fatalf("PendingStats count=%d, want 0", n)
+	}
+	_, body, _ := server.snapshot()
+	if string(body) != string(large) {
+		t.Fatalf("body = %q, want large image", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #896: interactive writeback can acknowledge a ~1GiB SQLite `kvtest init` and then persist only a 4096-byte empty database.

What happens today:

1. SQLite creates a 4KiB header; the commit queue uploads it as rev=1.
2. The same path then grows (pager spill / one huge `BEGIN`/`COMMIT`).
3. `#876`'s durable-watermark fence treats `payloadBaseRev=0` as older than watermark 1 and rejects the grown payload as stale, **or** a ShadowSpill 409 sees local 1GiB vs remote 4KiB and goes terminal.
4. A later 4KiB upload wins as rev=2. Next open: `no such table: kv`.

This is not `#876` (stale checkpoint bytes + raised BaseRev, CAS 200) and not `#894` (stale local read, remote correct). Ordinary `4KiB fsync` then `1GiB write` already worked because those two generations were strictly serialized with an updated BaseRev.

## Approach (no CAS/LWW weakening)

- Record the last **landed** `{rev, size}` per path on commit success.
- If a later entry is **strictly larger** than that landed snapshot and `payloadBaseRev < watermark`, **rebase CAS** onto the watermark (`PendingNew` → `PendingOverwrite`) instead of fencing it as a stale `#876` sibling.
- `#876` still fences when the watermark did **not** come from this queue's smaller landing (external/sibling fsync) or when the later entry is not larger.
- Supersede older **queued** (not in-flight) same-path entries when a newer seq/gen/size is enqueued.
- ShadowSpill 409: if local size > server size and the growth rebase applies, overwrite with `expected=serverRev` instead of terminal-fail.

## Tests

- `TestCommitQueueRebasesGrownPayloadAfterSmallerSamePathCommit`
- `TestCommitQueueSupersedesOlderSamePathQueuedCommit`

Existing `#876` watermark/LWW tests are unchanged in intent.

## Risk

Interactive same-path growth now overwrites the small landed revision. Truncate-down is not treated as growth (`entry.Size <= landed.size` still fences). Fsync path already succeeded for 1GiB kvtest and is not given a weaker CAS.