### PR TITLE
fix(fuse): keep Fsync-successful bytes across unlink snapshot races

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -5449,11 +5449,8 @@ func (fs *Dat9FS) snapshotOpenHandlesForPath(ctx context.Context, localPath stri
 		}
 		inodeSize := fs.inodeSnapshotSize(fh.Ino)
 		inodeRevision := int64(0)
-		if fs.gvisorCompatibilityEnabled() {
-			entry, ok := fs.inodes.GetEntry(fh.Ino)
-			if ok && entry != nil {
-				inodeRevision = entry.Revision
-			}
+		if entry, ok := fs.inodes.GetEntry(fh.Ino); ok && entry != nil {
+			inodeRevision = entry.Revision
 		}
 		fh.Lock()
 		handlePath := fh.Path
@@ -5464,6 +5461,9 @@ func (fs *Dat9FS) snapshotOpenHandlesForPath(ctx context.Context, localPath stri
 			continue
 		}
 		size, inodeRevision = fs.committedOpenHandleSnapshotState(fh.Ino, localPath, size, inodeRevision)
+		if _, identRev := fs.pathUnlinkedSnapshotIdentity(localPath); identRev > inodeRevision {
+			inodeRevision = identRev
+		}
 		candidates = append(candidates, candidate{fh: fh, size: size, revision: inodeRevision})
 	}
 	if len(candidates) == 0 {
@@ -5490,7 +5490,8 @@ func (fs *Dat9FS) snapshotOpenHandlesForPath(ctx context.Context, localPath stri
 		inodeSize := fs.inodeSnapshotSize(cand.fh.Ino)
 		cand.fh.Lock()
 		_, eligible := unlinkSnapshotSizeLocked(cand.fh, inodeSize)
-		if cand.fh.Path == localPath && eligible {
+		if cand.fh.Path == localPath && eligible &&
+			!unlinkedSnapshotStaleLocked(cand.fh, cand.revision, cand.size) {
 			cand.fh.UnlinkedData = cloneBytes(data)
 			clearReadTargetForLockedHandle(cand.fh)
 		}
@@ -7363,35 +7364,42 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		return nil, false, nil
 	}
 
-	var size int64
-	var revision int64
-	if ino, ok := fs.inodes.GetInode(p); ok {
-		if entry, ok := fs.inodes.GetEntry(ino); ok {
-			size = entry.Size
-			revision = entry.Revision
-		}
-	}
+	size, revision := fs.pathUnlinkedSnapshotIdentity(p)
 
 	snapshotOK := false
 	var snapshot []byte
 	snapshotShadowGen := uint64(0)
 	snapshotNeedCount := 0
 	if snapshotRemote {
-		needsSnapshot := false
-		for _, fh := range handles {
-			if fh == nil {
-				continue
+		const maxUnlinkedRemoteSnapshotAttempts = 3
+		var staleAfterFetch bool
+		for attempt := 0; attempt < maxUnlinkedRemoteSnapshotAttempts; attempt++ {
+			if snapshotShadowGen != 0 {
+				fs.discardUnlinkedSnapshotPins(snapshotShadowGen, snapshotNeedCount)
+				snapshotShadowGen = 0
 			}
-			fh.Lock()
-			handleNeedsSnapshot := cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) ||
-				remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh)
-			if handleNeedsSnapshot {
-				needsSnapshot = true
-				snapshotNeedCount++
+			snapshot = nil
+			snapshotOK = false
+			snapshotErr = nil
+			staleAfterFetch = false
+			size, revision = fs.pathUnlinkedSnapshotIdentity(p)
+			needsSnapshot := false
+			snapshotNeedCount = 0
+			for _, fh := range handles {
+				if fh == nil {
+					continue
+				}
+				fh.Lock()
+				if cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) ||
+					remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh) {
+					needsSnapshot = true
+					snapshotNeedCount++
+				}
+				fh.Unlock()
 			}
-			fh.Unlock()
-		}
-		if needsSnapshot {
+			if !needsSnapshot {
+				break
+			}
 			if size == 0 {
 				snapshotOK = true
 			} else if size <= maxPathTruncateInMemoryBytes {
@@ -7419,12 +7427,31 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 					safeLogPrintf("open-unlink large snapshot failed for %s: %v", p, err)
 				}
 			}
-			if needsSnapshot && !snapshotOK && fs.gvisorCompatibilityEnabled() {
-				if snapshotErr == nil {
-					snapshotErr = syscall.EIO
-				}
-				return nil, false, snapshotErr
+			if !snapshotOK {
+				break
 			}
+			if fs.unlinkedRemoteSnapshotStale(p, handles, revision, size) {
+				staleAfterFetch = true
+				continue
+			}
+			break
+		}
+		if staleAfterFetch {
+			if snapshotShadowGen != 0 {
+				fs.discardUnlinkedSnapshotPins(snapshotShadowGen, snapshotNeedCount)
+				snapshotShadowGen = 0
+			}
+			snapshot = nil
+			snapshotOK = false
+			snapshotErr = syscall.EIO
+			safeLogPrintf("open-unlink snapshot stale after concurrent commit for %s", p)
+			return nil, false, snapshotErr
+		}
+		if snapshotNeedCount > 0 && !snapshotOK && fs.gvisorCompatibilityEnabled() {
+			if snapshotErr == nil {
+				snapshotErr = syscall.EIO
+			}
+			return nil, false, snapshotErr
 		}
 	}
 
@@ -7448,7 +7475,8 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 					fh.UnlinkedShadowGen = gen
 					fh.UnlinkedSnapshot = true
 				}
-			} else if snapshotOK && remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh) {
+			} else if snapshotOK && remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh) &&
+				!unlinkedSnapshotStaleLocked(fh, revision, size) {
 				attachUnlinkedSnapshotLocked(fh, snapshot, snapshotShadowGen, size)
 				if snapshotShadowGen != 0 && fh.UnlinkedShadowGen == snapshotShadowGen {
 					attachedSnapshotPins++
@@ -7525,6 +7553,71 @@ func attachUnlinkedSnapshotLocked(fh *FileHandle, snapshot []byte, snapshotShado
 	fh.UnlinkedData = append(fh.UnlinkedData[:0], snapshot...)
 	fh.UnlinkedSnapshot = true
 	fh.UnlinkedSize = int64(len(snapshot))
+}
+
+func (fs *Dat9FS) pathUnlinkedSnapshotIdentity(p string) (size, rev int64) {
+	if fs == nil || p == "" {
+		return 0, 0
+	}
+	if ino, ok := fs.inodes.GetInode(p); ok {
+		if entry, ok := fs.inodes.GetEntry(ino); ok && entry != nil {
+			size = entry.Size
+			rev = entry.Revision
+		}
+	}
+	if cr := fs.latestCommittedRevision(p); cr > rev {
+		rev = cr
+	}
+	return size, rev
+}
+
+func (fs *Dat9FS) discardUnlinkedSnapshotPins(gen uint64, pins int) {
+	if fs == nil || fs.shadowStore == nil || gen == 0 {
+		return
+	}
+	for i := 0; i < pins; i++ {
+		fs.shadowStore.Unpin(gen)
+	}
+}
+
+func (fs *Dat9FS) unlinkedRemoteSnapshotStale(p string, handles []*FileHandle, snapshotRev, snapshotSize int64) bool {
+	size, rev := fs.pathUnlinkedSnapshotIdentity(p)
+	if snapshotRev > 0 && rev > 0 && rev != snapshotRev {
+		return true
+	}
+	if snapshotSize > 0 && size > 0 && size != snapshotSize {
+		return true
+	}
+	for _, fh := range handles {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		stale := unlinkedSnapshotStaleLocked(fh, snapshotRev, snapshotSize)
+		fh.Unlock()
+		if stale {
+			return true
+		}
+	}
+	return false
+}
+
+func unlinkedSnapshotStaleLocked(fh *FileHandle, snapshotRev, snapshotSize int64) bool {
+	if fh == nil {
+		return false
+	}
+	if !cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) &&
+		!remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh) {
+		return false
+	}
+	if snapshotRev > 0 && fh.BaseRev > 0 && fh.BaseRev != snapshotRev {
+		return true
+	}
+	if fh.Dirty != nil && !fh.Dirty.HasDirtyParts() && fh.Dirty.remoteSize > 0 &&
+		snapshotSize > 0 && fh.Dirty.remoteSize != snapshotSize {
+		return true
+	}
+	return false
 }
 
 func (fs *Dat9FS) loadUnlinkedHandlePart(fh *FileHandle, offset, length int64) ([]byte, bool, error) {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -3116,6 +3116,7 @@ func (fs *Dat9FS) markHandleRemoteCommittedLocked(fh *FileHandle, revision int64
 	}
 	fs.rebaselineCommittedDirtyBufferLocked(fh)
 	fs.removeHandleStagingLocked(fh)
+	clearPreinstalledUnlinkSnapshotLocked(fh)
 	fh.ShadowReady = false
 	fh.ShadowSpill = false
 	fh.ShadowCommitReady = false
@@ -3914,6 +3915,7 @@ func (fs *Dat9FS) finalizeHandleFlushLocked(fh *FileHandle, expectedRevision int
 			fs.recordCommittedRevision(fh.Path, revision)
 		}
 		fs.refreshCommittedRevisionForOpenHandles(fh.Path, revision, fh)
+		clearPreinstalledUnlinkSnapshotLocked(fh)
 	} else {
 		// The flush succeeded, but it was unconditional, so the precise
 		// post-commit revision is unknown. Clear the cached revision instead of
@@ -5493,6 +5495,10 @@ func (fs *Dat9FS) snapshotOpenHandlesForPath(ctx context.Context, localPath stri
 		if cand.fh.Path == localPath && eligible &&
 			!unlinkedSnapshotStaleLocked(cand.fh, cand.revision, cand.size) {
 			cand.fh.UnlinkedData = cloneBytes(data)
+			cand.fh.UnlinkedSnapshot = true
+			cand.fh.UnlinkedSize = int64(len(data))
+			cand.fh.UnlinkedSnapshotRev = cand.revision
+			cand.fh.UnlinkedSnapshotSize = cand.size
 			clearReadTargetForLockedHandle(cand.fh)
 		}
 		cand.fh.Unlock()
@@ -7363,6 +7369,14 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 	if len(handles) == 0 {
 		return nil, false, nil
 	}
+	for _, fh := range handles {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		dropStalePreinstalledUnlinkSnapshotLocked(fh)
+		fh.Unlock()
+	}
 
 	size, revision := fs.pathUnlinkedSnapshotIdentity(p)
 
@@ -7451,13 +7465,33 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		}
 	}
 
+	attachFailed := false
+	for _, fh := range handles {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		dropStalePreinstalledUnlinkSnapshotLocked(fh)
+		needs := cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) ||
+			remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh)
+		if needs && snapshotOK && unlinkedSnapshotStaleLocked(fh, revision, size) {
+			attachFailed = true
+		}
+		fh.Unlock()
+	}
+	if attachFailed {
+		if snapshotShadowGen != 0 {
+			fs.discardUnlinkedSnapshotPins(snapshotShadowGen, snapshotNeedCount)
+		}
+		return nil, false, syscall.EIO
+	}
+
 	attachedSnapshotPins := 0
 	for _, fh := range handles {
 		if fh == nil {
 			continue
 		}
 		fh.Lock()
-		fh.Unlinked = true
 		if fh.Dirty != nil {
 			fh.UnlinkedSize = fh.Dirty.Size()
 			// Dirty ShadowSpill handles keep their authoritative data in the
@@ -7470,29 +7504,27 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 				if gen, ok := fs.shadowStore.PinIfExists(p); ok {
 					fh.UnlinkedShadowGen = gen
 					fh.UnlinkedSnapshot = true
+					fh.UnlinkedSnapshotRev = revision
+					fh.UnlinkedSnapshotSize = fh.UnlinkedSize
 				}
 			} else if snapshotOK && remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh) &&
 				!unlinkedSnapshotStaleLocked(fh, revision, size) {
-				attachUnlinkedSnapshotLocked(fh, snapshot, snapshotShadowGen, size)
+				attachUnlinkedSnapshotLocked(fh, snapshot, snapshotShadowGen, size, revision)
 				if snapshotShadowGen != 0 && fh.UnlinkedShadowGen == snapshotShadowGen {
 					attachedSnapshotPins++
 				}
 			}
 		} else if snapshotOK {
 			if snapshotShadowGen != 0 && cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) {
-				fh.UnlinkedData = nil
-				fh.UnlinkedSnapshot = true
-				fh.UnlinkedShadowGen = snapshotShadowGen
-				fh.UnlinkedSize = size
+				attachUnlinkedSnapshotLocked(fh, nil, snapshotShadowGen, size, revision)
 				attachedSnapshotPins++
 			} else {
-				fh.UnlinkedData = append(fh.UnlinkedData[:0], snapshot...)
-				fh.UnlinkedSnapshot = true
-				fh.UnlinkedSize = int64(len(snapshot))
+				attachUnlinkedSnapshotLocked(fh, snapshot, 0, size, revision)
 			}
-		} else {
+		} else if fh.UnlinkedSize == 0 {
 			fh.UnlinkedSize = size
 		}
+		fh.Unlinked = true
 		fh.Unlock()
 	}
 	if snapshotShadowGen != 0 && fs.shadowStore != nil && attachedSnapshotPins < snapshotNeedCount {
@@ -7535,7 +7567,7 @@ func remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh *FileHandle) bool {
 		!fh.UnlinkedSnapshot
 }
 
-func attachUnlinkedSnapshotLocked(fh *FileHandle, snapshot []byte, snapshotShadowGen uint64, size int64) {
+func attachUnlinkedSnapshotLocked(fh *FileHandle, snapshot []byte, snapshotShadowGen uint64, size, rev int64) {
 	if fh == nil {
 		return
 	}
@@ -7544,11 +7576,43 @@ func attachUnlinkedSnapshotLocked(fh *FileHandle, snapshot []byte, snapshotShado
 		fh.UnlinkedSnapshot = true
 		fh.UnlinkedShadowGen = snapshotShadowGen
 		fh.UnlinkedSize = size
+		fh.UnlinkedSnapshotRev = rev
+		fh.UnlinkedSnapshotSize = size
 		return
 	}
 	fh.UnlinkedData = append(fh.UnlinkedData[:0], snapshot...)
 	fh.UnlinkedSnapshot = true
 	fh.UnlinkedSize = int64(len(snapshot))
+	fh.UnlinkedSnapshotRev = rev
+	fh.UnlinkedSnapshotSize = fh.UnlinkedSize
+}
+
+func clearPreinstalledUnlinkSnapshotLocked(fh *FileHandle) {
+	if fh == nil || fh.Unlinked {
+		return
+	}
+	fh.UnlinkedData = nil
+	fh.UnlinkedSnapshot = false
+	fh.UnlinkedSnapshotRev = 0
+	fh.UnlinkedSnapshotSize = 0
+}
+
+func dropStalePreinstalledUnlinkSnapshotLocked(fh *FileHandle) {
+	if fh == nil || fh.Unlinked || (fh.UnlinkedData == nil && !fh.UnlinkedSnapshot) {
+		return
+	}
+	stale := false
+	if fh.UnlinkedSnapshotRev > 0 && fh.BaseRev > 0 && fh.UnlinkedSnapshotRev != fh.BaseRev {
+		stale = true
+	}
+	if fh.UnlinkedSnapshotSize > 0 && fh.Dirty != nil && !fh.Dirty.HasDirtyParts() &&
+		fh.Dirty.remoteSize > 0 && fh.Dirty.remoteSize != fh.UnlinkedSnapshotSize {
+		stale = true
+	}
+	if !stale {
+		return
+	}
+	clearPreinstalledUnlinkSnapshotLocked(fh)
 }
 
 func (fs *Dat9FS) pathUnlinkedSnapshotIdentity(p string) (size, rev int64) {
@@ -7683,6 +7747,8 @@ func (fs *Dat9FS) unmarkOpenHandlesAfterFailedUnlink(p string, handles []*FileHa
 		fh.UnlinkedData = nil
 		fh.UnlinkedSnapshot = false
 		fh.UnlinkedSize = 0
+		fh.UnlinkedSnapshotRev = 0
+		fh.UnlinkedSnapshotSize = 0
 		if gen := fh.UnlinkedShadowGen; gen != 0 && fs.shadowStore != nil {
 			fh.UnlinkedShadowGen = 0
 			// The mark-time pin is simply dropped: with the deferred commit

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7601,10 +7601,7 @@ func dropStalePreinstalledUnlinkSnapshotLocked(fh *FileHandle) {
 	if fh == nil || fh.Unlinked || (fh.UnlinkedData == nil && !fh.UnlinkedSnapshot) {
 		return
 	}
-	stale := false
-	if fh.UnlinkedSnapshotRev > 0 && fh.BaseRev > 0 && fh.UnlinkedSnapshotRev != fh.BaseRev {
-		stale = true
-	}
+	stale := fh.UnlinkedSnapshotRev > 0 && fh.BaseRev > 0 && fh.UnlinkedSnapshotRev != fh.BaseRev
 	if fh.UnlinkedSnapshotSize > 0 && fh.Dirty != nil && !fh.Dirty.HasDirtyParts() &&
 		fh.Dirty.remoteSize > 0 && fh.Dirty.remoteSize != fh.UnlinkedSnapshotSize {
 		stale = true

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -34,6 +34,11 @@ var testHookAfterSamePathDirtyHandleScan func(path string)
 // acquires the same-path remote commit fence.
 var testHookBeforeGVisorShadowSpillFlushFence func(path string)
 
+// testHookBeforeUnlinkedTransition lets tests run a same-FD Write+Fsync after
+// snapshot attach but before fh.Unlinked is set. Production keeps the
+// identity check, attach, and Unlinked transition under one fh.mu hold.
+var testHookBeforeUnlinkedTransition func()
+
 // Dat9FS implements the go-fuse RawFileSystem interface, bridging FUSE
 // operations to the dat9 HTTP API via the Go SDK client.
 type Dat9FS struct {
@@ -7411,44 +7416,81 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 				}
 				fh.Unlock()
 			}
-			if !needsSnapshot {
-				break
-			}
-			if size == 0 {
-				snapshotOK = true
-			} else if size <= maxPathTruncateInMemoryBytes {
-				readStart := fs.perfStart()
-				data, err := fs.client.ReadAtCtx(ctx, fs.remotePath(p), 0, size)
-				if err == nil && int64(len(data)) == size {
-					snapshot = data
+			if needsSnapshot {
+				if size == 0 {
 					snapshotOK = true
-				} else if err == nil {
-					err = io.ErrUnexpectedEOF
-					snapshotErr = err
-					safeLogPrintf("open-unlink snapshot short read for %s: got=%d want=%d", p, len(data), size)
+				} else if size <= maxPathTruncateInMemoryBytes {
+					readStart := fs.perfStart()
+					data, err := fs.client.ReadAtCtx(ctx, fs.remotePath(p), 0, size)
+					if err == nil && int64(len(data)) == size {
+						snapshot = data
+						snapshotOK = true
+					} else if err == nil {
+						err = io.ErrUnexpectedEOF
+						snapshotErr = err
+						safeLogPrintf("open-unlink snapshot short read for %s: got=%d want=%d", p, len(data), size)
+					} else {
+						snapshotErr = err
+						safeLogPrintf("open-unlink snapshot failed for %s: %v", p, err)
+					}
+					fs.perfRecordRemote(perfRemoteRead, readStart, err, uint64(len(data)))
 				} else {
-					snapshotErr = err
-					safeLogPrintf("open-unlink snapshot failed for %s: %v", p, err)
+					gen, err := fs.snapshotUnlinkedRemoteToShadow(ctx, p, size, revision, snapshotNeedCount)
+					if err == nil {
+						snapshotShadowGen = gen
+						snapshotOK = true
+					} else {
+						snapshotErr = err
+						safeLogPrintf("open-unlink large snapshot failed for %s: %v", p, err)
+					}
 				}
-				fs.perfRecordRemote(perfRemoteRead, readStart, err, uint64(len(data)))
-			} else {
-				gen, err := fs.snapshotUnlinkedRemoteToShadow(ctx, p, size, revision, snapshotNeedCount)
-				if err == nil {
-					snapshotShadowGen = gen
-					snapshotOK = true
-				} else {
-					snapshotErr = err
-					safeLogPrintf("open-unlink large snapshot failed for %s: %v", p, err)
+				if !snapshotOK {
+					break
+				}
+				if fs.unlinkedRemoteSnapshotStale(p, handles, revision, size) {
+					staleAfterFetch = true
+					continue
 				}
 			}
-			if !snapshotOK {
-				break
+			attachedSnapshotPins := 0
+			var markedThisPass []*FileHandle
+			attachFailed := false
+			for _, fh := range handles {
+				if fh == nil {
+					continue
+				}
+				fh.Lock()
+				pin, fail := fs.attachUnlinkedHandleSnapshotLocked(fh, p, snapshot, snapshotShadowGen, size, revision, snapshotOK)
+				if !fail && testHookBeforeUnlinkedTransition != nil {
+					fh.Unlock()
+					testHookBeforeUnlinkedTransition()
+					fh.Lock()
+					pin, fail = fs.attachUnlinkedHandleSnapshotLocked(fh, p, snapshot, snapshotShadowGen, size, revision, snapshotOK)
+				}
+				if fail {
+					attachFailed = true
+					fh.Unlock()
+					break
+				}
+				if pin {
+					attachedSnapshotPins++
+				}
+				fh.Unlinked = true
+				markedThisPass = append(markedThisPass, fh)
+				fh.Unlock()
 			}
-			if fs.unlinkedRemoteSnapshotStale(p, handles, revision, size) {
+			if attachFailed {
+				fs.unmarkOpenHandlesAfterFailedUnlink(p, markedThisPass)
 				staleAfterFetch = true
 				continue
 			}
-			break
+			if snapshotShadowGen != 0 && fs.shadowStore != nil && attachedSnapshotPins < snapshotNeedCount {
+				for i := attachedSnapshotPins; i < snapshotNeedCount; i++ {
+					fs.shadowStore.Unpin(snapshotShadowGen)
+				}
+			}
+			fs.openHandles.UnlinkPath(p)
+			return handles, true, nil
 		}
 		if staleAfterFetch {
 			if snapshotShadowGen != 0 {
@@ -7465,75 +7507,56 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		}
 	}
 
-	attachFailed := false
 	for _, fh := range handles {
 		if fh == nil {
 			continue
 		}
 		fh.Lock()
-		dropStalePreinstalledUnlinkSnapshotLocked(fh)
-		needs := cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) ||
-			remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh)
-		if needs && snapshotOK && unlinkedSnapshotStaleLocked(fh, revision, size) {
-			attachFailed = true
-		}
-		fh.Unlock()
-	}
-	if attachFailed {
-		if snapshotShadowGen != 0 {
-			fs.discardUnlinkedSnapshotPins(snapshotShadowGen, snapshotNeedCount)
-		}
-		return nil, false, syscall.EIO
-	}
-
-	attachedSnapshotPins := 0
-	for _, fh := range handles {
-		if fh == nil {
-			continue
-		}
-		fh.Lock()
-		if fh.Dirty != nil {
-			fh.UnlinkedSize = fh.Dirty.Size()
-			// Dirty ShadowSpill handles keep their authoritative data in the
-			// staged shadow, not in the Dirty buffer (parts were evicted).
-			// Pin that shadow as the handle's private read backing until
-			// Release: the unlink-time Remove then retires it (the fd stays
-			// readable via ReadAtGen) instead of deleting it, and a same-path
-			// replacement gets a fresh shadow file.
-			if fh.ShadowSpill && fh.UnlinkedShadowGen == 0 && fs.shadowStore != nil {
-				if gen, ok := fs.shadowStore.PinIfExists(p); ok {
-					fh.UnlinkedShadowGen = gen
-					fh.UnlinkedSnapshot = true
-					fh.UnlinkedSnapshotRev = revision
-					fh.UnlinkedSnapshotSize = fh.UnlinkedSize
-				}
-			} else if snapshotOK && remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh) &&
-				!unlinkedSnapshotStaleLocked(fh, revision, size) {
-				attachUnlinkedSnapshotLocked(fh, snapshot, snapshotShadowGen, size, revision)
-				if snapshotShadowGen != 0 && fh.UnlinkedShadowGen == snapshotShadowGen {
-					attachedSnapshotPins++
-				}
-			}
-		} else if snapshotOK {
-			if snapshotShadowGen != 0 && cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) {
-				attachUnlinkedSnapshotLocked(fh, nil, snapshotShadowGen, size, revision)
-				attachedSnapshotPins++
-			} else {
-				attachUnlinkedSnapshotLocked(fh, snapshot, 0, size, revision)
-			}
-		} else if fh.UnlinkedSize == 0 {
-			fh.UnlinkedSize = size
-		}
+		_, _ = fs.attachUnlinkedHandleSnapshotLocked(fh, p, snapshot, snapshotShadowGen, size, revision, snapshotOK)
 		fh.Unlinked = true
 		fh.Unlock()
 	}
-	if snapshotShadowGen != 0 && fs.shadowStore != nil && attachedSnapshotPins < snapshotNeedCount {
-		for i := attachedSnapshotPins; i < snapshotNeedCount; i++ {
-			fs.shadowStore.Unpin(snapshotShadowGen)
-		}
-	}
 	fs.openHandles.UnlinkPath(p)
 	return handles, true, nil
+}
+
+func (fs *Dat9FS) attachUnlinkedHandleSnapshotLocked(fh *FileHandle, p string, snapshot []byte, snapshotShadowGen uint64, size, revision int64, snapshotOK bool) (attachedPin bool, fail bool) {
+	if fh == nil {
+		return false, false
+	}
+	dropStalePreinstalledUnlinkSnapshotLocked(fh)
+	needs := cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) ||
+		remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh)
+	if needs && !fh.ShadowSpill && (!snapshotOK || unlinkedSnapshotStaleLocked(fh, revision, size)) {
+		return false, true
+	}
+	if fh.Dirty != nil {
+		fh.UnlinkedSize = fh.Dirty.Size()
+		if fh.ShadowSpill && fh.UnlinkedShadowGen == 0 && fs.shadowStore != nil {
+			if gen, ok := fs.shadowStore.PinIfExists(p); ok {
+				fh.UnlinkedShadowGen = gen
+				fh.UnlinkedSnapshot = true
+				fh.UnlinkedSnapshotRev = revision
+				fh.UnlinkedSnapshotSize = fh.UnlinkedSize
+			}
+		} else if snapshotOK && remoteBackedDirtyHandleNeedsUnlinkedSnapshotLocked(fh) &&
+			!unlinkedSnapshotStaleLocked(fh, revision, size) {
+			attachUnlinkedSnapshotLocked(fh, snapshot, snapshotShadowGen, size, revision)
+			if snapshotShadowGen != 0 && fh.UnlinkedShadowGen == snapshotShadowGen {
+				attachedPin = true
+			}
+		}
+	} else if snapshotOK {
+		if snapshotShadowGen != 0 && cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh) {
+			attachUnlinkedSnapshotLocked(fh, nil, snapshotShadowGen, size, revision)
+			attachedPin = true
+		} else {
+			attachUnlinkedSnapshotLocked(fh, snapshot, 0, size, revision)
+		}
+	} else if fh.UnlinkedSize == 0 {
+		fh.UnlinkedSize = size
+	}
+	return attachedPin, false
 }
 
 func cleanRemoteHandleNeedsUnlinkedSnapshotLocked(fh *FileHandle) bool {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7439,13 +7439,9 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		if staleAfterFetch {
 			if snapshotShadowGen != 0 {
 				fs.discardUnlinkedSnapshotPins(snapshotShadowGen, snapshotNeedCount)
-				snapshotShadowGen = 0
 			}
-			snapshot = nil
-			snapshotOK = false
-			snapshotErr = syscall.EIO
 			safeLogPrintf("open-unlink snapshot stale after concurrent commit for %s", p)
-			return nil, false, snapshotErr
+			return nil, false, syscall.EIO
 		}
 		if snapshotNeedCount > 0 && !snapshotOK && fs.gvisorCompatibilityEnabled() {
 			if snapshotErr == nil {

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -3036,6 +3036,143 @@ func TestUnlinkSnapshotConcurrentWriteKeepsOverlayAndBaseline(t *testing.T) {
 	}
 }
 
+func TestUnlinkSnapshotConcurrentFsyncKeepsCommittedOverlay(t *testing.T) {
+	const filePath = "/spill-unlink-fsync-race.bin"
+	const partSize int64 = 64
+	original := bytes.Repeat([]byte{0x88}, int(3*partSize))
+	overlay := []byte{0xAA, 0xBB}
+
+	var mu sync.Mutex
+	var committed []byte
+	var revision int64
+	var puts atomic.Int32
+	var fileGets atomic.Int32
+	snapshotStarted := make(chan struct{})
+	snapshotRelease := make(chan struct{})
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+		case r.Method == http.MethodGet:
+			mu.Lock()
+			body := append([]byte(nil), committed...)
+			mu.Unlock()
+			if len(body) == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			if fileGets.Add(1) == 1 {
+				close(snapshotStarted)
+				<-snapshotRelease
+			}
+			_, _ = w.Write(body)
+		case r.Method == http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			got, err := strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			if got != revision {
+				mu.Unlock()
+				http.Error(w, "revision conflict", http.StatusConflict)
+				return
+			}
+			committed = append([]byte(nil), body...)
+			revision++
+			rev := revision
+			mu.Unlock()
+			puts.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": rev})
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			committed = nil
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	fs, fhID, nodeID, _ := newStrictSmallPartSpillFS(t, ts.URL, filePath, partSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}, original); st != gofuse.OK {
+		t.Fatalf("seed Write: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("first Fsync: %v", st)
+	}
+
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, strings.TrimPrefix(filePath, "/"))
+	}()
+	select {
+	case <-snapshotStarted:
+	case st := <-unlinkDone:
+		t.Fatalf("Unlink finished before snapshot GET: %v", st)
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for unlink snapshot GET")
+	}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: 8}, overlay); st != gofuse.OK {
+		close(snapshotRelease)
+		t.Fatalf("concurrent write during unlink snapshot: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		close(snapshotRelease)
+		t.Fatalf("concurrent Fsync during unlink snapshot: %v", st)
+	}
+	close(snapshotRelease)
+	st := <-unlinkDone
+	if st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+
+	prefixBuf := make([]byte, 16)
+	prefixResult, rst := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Size: uint32(len(prefixBuf)),
+	}, prefixBuf)
+	if rst != gofuse.OK {
+		t.Fatalf("Read after unlink: %v", rst)
+	}
+	gotPrefix, _ := prefixResult.Bytes(prefixBuf)
+	wantPrefix := append(bytes.Repeat([]byte{0x88}, 8), overlay...)
+	wantPrefix = append(wantPrefix, bytes.Repeat([]byte{0x88}, 6)...)
+	if !bytes.Equal(gotPrefix, wantPrefix) {
+		t.Fatalf("open-fd read = %x, want fsynced overlay %x", gotPrefix, wantPrefix)
+	}
+	if puts.Load() != 2 {
+		t.Fatalf("puts = %d, want 2 (seed fsync + concurrent fsync)", puts.Load())
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("Flush: %v", st)
+	}
+	if puts.Load() != 2 {
+		t.Fatalf("flush after unlink resurrected path (puts=%d)", puts.Load())
+	}
+}
+
+func TestUnlinkedSnapshotStaleLockedDetectsRebaseline(t *testing.T) {
+	wb := NewWriteBuffer("/a.bin", 1<<20, 64)
+	wb.remoteSize = 192
+	wb.LoadPart = func(int) ([]byte, error) { return []byte("x"), nil }
+	fh := &FileHandle{Dirty: wb, BaseRev: 2}
+	if !unlinkedSnapshotStaleLocked(fh, 1, 192) {
+		t.Fatal("BaseRev ahead of snapshot revision must be stale")
+	}
+	fh.BaseRev = 1
+	if unlinkedSnapshotStaleLocked(fh, 1, 192) {
+		t.Fatal("matching BaseRev should not be stale")
+	}
+	wb.remoteSize = 200
+	if !unlinkedSnapshotStaleLocked(fh, 1, 192) {
+		t.Fatal("clean remoteSize change after Fsync rebase must be stale")
+	}
+}
+
 func TestWriteBuffer_ResetSequentialState(t *testing.T) {
 	wb := NewWriteBuffer("/test", streamingWriteMaxSize, DefaultPartSize)
 	wb.sequential = true

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -3257,6 +3257,122 @@ func TestUnlinkAfterPreinstalledSnapshotKeepsLaterFsync(t *testing.T) {
 	}
 }
 
+func TestUnlinkMarkWindowConcurrentFsyncKeepsOverlay(t *testing.T) {
+	const filePath = "/spill-mark-window-fsync.bin"
+	const partSize int64 = 64
+	original := bytes.Repeat([]byte{0x88}, int(3*partSize))
+	overlay := []byte{0xAA, 0xBB}
+
+	var mu sync.Mutex
+	var committed []byte
+	var revision int64
+	var puts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+		case r.Method == http.MethodGet:
+			mu.Lock()
+			body := append([]byte(nil), committed...)
+			mu.Unlock()
+			if len(body) == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write(body)
+		case r.Method == http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			got, err := strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			if got != revision {
+				mu.Unlock()
+				http.Error(w, "revision conflict", http.StatusConflict)
+				return
+			}
+			committed = append([]byte(nil), body...)
+			revision++
+			rev := revision
+			mu.Unlock()
+			puts.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": rev})
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			committed = nil
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	fs, fhID, nodeID, _ := newStrictSmallPartSpillFS(t, ts.URL, filePath, partSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}, original); st != gofuse.OK {
+		t.Fatalf("seed Write: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("first Fsync: %v", st)
+	}
+
+	var once sync.Once
+	testHookBeforeUnlinkedTransition = func() {
+		once.Do(func() {
+			if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: 8}, overlay); st != gofuse.OK {
+				t.Errorf("mark-window write: %v", st)
+				return
+			}
+			if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+				t.Errorf("mark-window Fsync: %v", st)
+			}
+		})
+	}
+	t.Cleanup(func() { testHookBeforeUnlinkedTransition = nil })
+
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, strings.TrimPrefix(filePath, "/")); st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+	prefixBuf := make([]byte, 16)
+	prefixResult, rst := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Size: uint32(len(prefixBuf)),
+	}, prefixBuf)
+	if rst != gofuse.OK {
+		t.Fatalf("Read after unlink: %v", rst)
+	}
+	gotPrefix, _ := prefixResult.Bytes(prefixBuf)
+	wantPrefix := append(bytes.Repeat([]byte{0x88}, 8), overlay...)
+	wantPrefix = append(wantPrefix, bytes.Repeat([]byte{0x88}, 6)...)
+	if !bytes.Equal(gotPrefix, wantPrefix) {
+		t.Fatalf("open-fd read = %x, want fsynced overlay %x", gotPrefix, wantPrefix)
+	}
+	if puts.Load() != 2 {
+		t.Fatalf("puts = %d, want 2 (seed + mark-window fsync)", puts.Load())
+	}
+}
+
+func TestAttachUnlinkedHandleSnapshotDoesNotMarkWhenStale(t *testing.T) {
+	wb := NewWriteBuffer("/a.bin", 1<<20, 64)
+	wb.remoteSize = 192
+	wb.LoadPart = func(int) ([]byte, error) { return []byte("x"), nil }
+	fh := &FileHandle{Dirty: wb, BaseRev: 2, Path: "/a.bin"}
+	fs := &Dat9FS{}
+	_, fail := fs.attachUnlinkedHandleSnapshotLocked(fh, "/a.bin", bytes.Repeat([]byte{0x88}, 192), 0, 192, 1, true)
+	if !fail {
+		t.Fatal("stale snapshot must fail closed")
+	}
+	if fh.Unlinked {
+		t.Fatal("must not set Unlinked when attach snapshot is stale")
+	}
+	if len(fh.UnlinkedData) != 0 {
+		t.Fatal("must not keep a stale in-memory snapshot")
+	}
+}
+
 func TestUnlinkedSnapshotStaleLockedDetectsRebaseline(t *testing.T) {
 	wb := NewWriteBuffer("/a.bin", 1<<20, 64)
 	wb.remoteSize = 192

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -3155,6 +3155,108 @@ func TestUnlinkSnapshotConcurrentFsyncKeepsCommittedOverlay(t *testing.T) {
 	}
 }
 
+func TestUnlinkAfterPreinstalledSnapshotKeepsLaterFsync(t *testing.T) {
+	const filePath = "/spill-preinstall-fsync.bin"
+	const partSize int64 = 64
+	original := bytes.Repeat([]byte{0x88}, int(3*partSize))
+	overlay := []byte{0xAA, 0xBB}
+
+	var mu sync.Mutex
+	var committed []byte
+	var revision int64
+	var puts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+		case r.Method == http.MethodGet:
+			mu.Lock()
+			body := append([]byte(nil), committed...)
+			mu.Unlock()
+			if len(body) == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write(body)
+		case r.Method == http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			got, err := strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			if got != revision {
+				mu.Unlock()
+				http.Error(w, "revision conflict", http.StatusConflict)
+				return
+			}
+			committed = append([]byte(nil), body...)
+			revision++
+			rev := revision
+			mu.Unlock()
+			puts.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": rev})
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			committed = nil
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	fs, fhID, nodeID, _ := newStrictSmallPartSpillFS(t, ts.URL, filePath, partSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}, original); st != gofuse.OK {
+		t.Fatalf("seed Write: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("first Fsync: %v", st)
+	}
+	if err := fs.snapshotOpenHandlesBeforeUnlink(context.Background(), filePath); err != nil {
+		t.Fatalf("preinstall unlink snapshot: %v", err)
+	}
+	fh, ok := fs.fileHandles.Get(fhID)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	if len(fh.UnlinkedData) == 0 {
+		fh.Unlock()
+		t.Fatal("expected preinstalled UnlinkedData")
+	}
+	fh.Unlock()
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Offset: 8}, overlay); st != gofuse.OK {
+		t.Fatalf("write after preinstall: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID}); st != gofuse.OK {
+		t.Fatalf("Fsync after preinstall: %v", st)
+	}
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, strings.TrimPrefix(filePath, "/")); st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+	prefixBuf := make([]byte, 16)
+	prefixResult, rst := fs.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Size: uint32(len(prefixBuf)),
+	}, prefixBuf)
+	if rst != gofuse.OK {
+		t.Fatalf("Read after unlink: %v", rst)
+	}
+	gotPrefix, _ := prefixResult.Bytes(prefixBuf)
+	wantPrefix := append(bytes.Repeat([]byte{0x88}, 8), overlay...)
+	wantPrefix = append(wantPrefix, bytes.Repeat([]byte{0x88}, 6)...)
+	if !bytes.Equal(gotPrefix, wantPrefix) {
+		t.Fatalf("open-fd read = %x, want fsynced overlay %x", gotPrefix, wantPrefix)
+	}
+	if puts.Load() != 2 {
+		t.Fatalf("puts = %d, want 2", puts.Load())
+	}
+}
+
 func TestUnlinkedSnapshotStaleLockedDetectsRebaseline(t *testing.T) {
 	wb := NewWriteBuffer("/a.bin", 1<<20, 64)
 	wb.remoteSize = 192

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -62,18 +62,20 @@ type FileHandle struct {
 	// adoption uses it to drop only THIS handle's stale pending entry — a
 	// legitimate same-path recreate re-remembers the path with a newer seq
 	// and must survive the cleanup.
-	GitPendingMirrorSeq uint64
-	PendingMode         uint32 // mode change deferred because a dirty handle was open
-	HasPendingMode      bool   // true when PendingMode should be applied on Release
-	PendingModeGen      uint64 // generation for PendingMode, used to avoid clearing newer chmods
-	PreviousMode        uint32 // mode before PendingMode was set (for rollback on flush failure)
-	HasPreviousMode     bool   // true when previous mode state was snapshotted
-	PreviousModeKnown   bool   // true when PreviousMode was authoritative
-	Unlinked            bool   // true after the directory entry was removed while this handle stayed open
-	UnlinkedSnapshot    bool   // true when UnlinkedData is an authoritative read snapshot
-	UnlinkedData        []byte // read-only snapshot for open-but-unlinked remote files
-	UnlinkedShadowGen   uint64 // generation pin for large open-unlink snapshots stored in ShadowStore
-	UnlinkedSize        int64
+	GitPendingMirrorSeq  uint64
+	PendingMode          uint32 // mode change deferred because a dirty handle was open
+	HasPendingMode       bool   // true when PendingMode should be applied on Release
+	PendingModeGen       uint64 // generation for PendingMode, used to avoid clearing newer chmods
+	PreviousMode         uint32 // mode before PendingMode was set (for rollback on flush failure)
+	HasPreviousMode      bool   // true when previous mode state was snapshotted
+	PreviousModeKnown    bool   // true when PreviousMode was authoritative
+	Unlinked             bool   // true after the directory entry was removed while this handle stayed open
+	UnlinkedSnapshot     bool   // true when UnlinkedData is an authoritative read snapshot
+	UnlinkedData         []byte // read-only snapshot for open-but-unlinked remote files
+	UnlinkedShadowGen    uint64 // generation pin for large open-unlink snapshots stored in ShadowStore
+	UnlinkedSize         int64
+	UnlinkedSnapshotRev  int64 // committed revision captured with UnlinkedData / UnlinkedShadowGen
+	UnlinkedSnapshotSize int64 // committed size captured with that snapshot identity
 	// Staging generations recorded when this handle staged path-keyed state.
 	// discardUnlinkedHandleStateLocked uses them for ownership-scoped cleanup:
 	// after a pathname is unlinked and recreated, path-global removes would


### PR DESCRIPTION
Follow-up to #900.

A same-FD Write + strict Fsync during Unlink's remote snapshot GET can commit a newer generation. Attaching the in-flight pre-Fsync image then loses those bytes on the still-open fd, and DELETE removes the object Fsync just published.

Changes:
- Revalidate path/handle committed revision and size after the snapshot GET.
- Retry the snapshot from the new generation; fail closed if it stays stale.
- snapshotOpenHandlesBeforeUnlink refuses to install a snapshot whose revision no longer matches BaseRev, so markOpenHandlesUnlinked can fetch the committed image.
- Regression: TestUnlinkSnapshotConcurrentFsyncKeepsCommittedOverlay. Existing Write-only unlink overlay coverage stays green.

Does not claim to close #898.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unlink handling during concurrent file writes and sync operations.
  * Prevented outdated snapshots from overwriting committed changes or causing deleted files to reappear.
  * Unlink operations now retry snapshot retrieval when needed and report an error if a consistent snapshot cannot be obtained.

* **Tests**
  * Added coverage for concurrent sync and unlink behavior.
  * Added validation for detecting outdated snapshots after filesystem changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->