### PR TITLE
fix(fuse): sync pending-new rename on close-sync mounts

### DIFF
--- a/docs/design/fuse-durability-policy.md
+++ b/docs/design/fuse-durability-policy.md
@@ -117,6 +117,10 @@ Therefore:
 
 - `close-sync` is primarily enforced in `Flush`;
 - `write-sync` is enforced at the end of `Write`;
+- pending-new `rename(2)` (`write tmp; mv tmp final`) is also remote-durable
+  on `close-sync` and `write-sync` before rename returns. Upload failure
+  surfaces as `EAGAIN` and keeps the local shadow. Writeback/`auto`/
+  `interactive`/`fsync` mounts still enqueue that rename asynchronously;
 - `Release` handles cleanup and fallback synchronization, but it is not the
   primary close-sync error propagation point.
 

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1697,9 +1697,9 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 				if entry == nil {
 					continue
 				}
-				if errors.Is(cq.validateEntryPayloadFresh(entry), errCommitPayloadStale) {
-					safeLogPrintf("commit queue: stale batched payload rejected for %s: %v", entry.Path, err)
-					cq.onCommitTerminalFailure(entry, err)
+				if verr := cq.validateEntryPayloadFresh(entry); errors.Is(verr, errCommitPayloadStale) {
+					safeLogPrintf("commit queue: stale batched payload rejected for %s: %v", entry.Path, verr)
+					cq.onCommitTerminalFailure(entry, verr)
 					cq.endInFlight(entry)
 					continue
 				}
@@ -2768,10 +2768,6 @@ func (cq *CommitQueue) onCommitPostUploadFailure(entry *CommitEntry, err error) 
 }
 
 func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry, lastErr error) {
-	if cq.perf != nil {
-		cq.perf.commitFailure.add(1)
-		cq.perf.commitTerminalFailure.add(1)
-	}
 	// Mark the entry as conflicted in the pending index so that crash
 	// recovery (RecoverPending) skips it instead of retrying forever.
 	// Preserve both the shadow file and the pending metadata so the user
@@ -2786,6 +2782,7 @@ func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry, lastErr error
 			if err != nil {
 				safeLogPrintf("commit queue: failed to mark conflict for %s: %v (entry remains queued)", entry.Path, err)
 				cq.removeFromQueue(entry)
+				cq.recordCommitTerminalFailure(entry, lastErr)
 				return
 			}
 			if !marked {
@@ -2799,6 +2796,7 @@ func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry, lastErr error
 			// silently dropping it.
 			safeLogPrintf("commit queue: failed to mark conflict for %s: %v (entry remains queued)", entry.Path, err)
 			cq.removeFromQueue(entry)
+			cq.recordCommitTerminalFailure(entry, lastErr)
 			return
 		}
 	}
@@ -2814,7 +2812,14 @@ func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry, lastErr error
 	// Remove from queue AFTER all cleanup so WaitPath sees the entry
 	// until bookkeeping is complete.
 	cq.removeFromQueue(entry)
+	cq.recordCommitTerminalFailure(entry, lastErr)
+}
 
+func (cq *CommitQueue) recordCommitTerminalFailure(entry *CommitEntry, lastErr error) {
+	if cq.perf != nil {
+		cq.perf.commitFailure.add(1)
+		cq.perf.commitTerminalFailure.add(1)
+	}
 	// Alertable FUSE-local error. Collectors should match
 	// "drive9: error event=commit_terminal_failure" on stderr / mount-log
 	// files (typically ~/.cache/drive9/mount-logs/). The drive9 server never

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1489,7 +1489,7 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 		}
 		if errors.Is(err, errCommitPayloadStale) {
 			safeLogPrintf("commit queue: stale payload rejected for %s: %v", entry.Path, err)
-			cq.onCommitTerminalFailure(entry)
+			cq.onCommitTerminalFailure(entry, err)
 			unlockPath()
 			return
 		}
@@ -1503,19 +1503,19 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 			cq.mu.Unlock()
 			if abandoned {
 				safeLogPrintf("commit queue: layer abandoned, terminal failure for %s", entry.Path)
-				cq.onCommitTerminalFailure(entry)
+				cq.onCommitTerminalFailure(entry, err)
 				unlockPath()
 				return
 			}
 			if entry.DisableAutoResolveLWW {
 				safeLogPrintf("commit queue: fenced conflict for %s at base revision %d, keeping terminal", entry.Path, entry.BaseRev)
-				cq.onCommitTerminalFailure(entry)
+				cq.onCommitTerminalFailure(entry, err)
 				unlockPath()
 				return
 			}
 			if err := cq.validateEntryPayloadFresh(entry); err != nil {
 				safeLogPrintf("commit queue: conflict auto-resolve rejected stale payload for %s: %v", entry.Path, err)
-				cq.onCommitTerminalFailure(entry)
+				cq.onCommitTerminalFailure(entry, err)
 				unlockPath()
 				return
 			}
@@ -1534,7 +1534,7 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 		cq.onCommitPostUploadFailure(entry, lastErr)
 		return
 	}
-	cq.onCommitTerminalFailure(entry)
+	cq.onCommitTerminalFailure(entry, lastErr)
 }
 
 type commitBatchConfig struct {
@@ -1699,7 +1699,7 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 				}
 				if errors.Is(cq.validateEntryPayloadFresh(entry), errCommitPayloadStale) {
 					safeLogPrintf("commit queue: stale batched payload rejected for %s: %v", entry.Path, err)
-					cq.onCommitTerminalFailure(entry)
+					cq.onCommitTerminalFailure(entry, err)
 					cq.endInFlight(entry)
 					continue
 				}
@@ -1774,14 +1774,14 @@ func (cq *CommitQueue) commitBatch(entries []*CommitEntry) {
 			unlockPath := cq.lockPath(entry.Path)
 			if entry.DisableAutoResolveLWW {
 				safeLogPrintf("commit queue: fenced batch conflict for %s at base revision %d, keeping terminal", entry.Path, entry.BaseRev)
-				cq.onCommitTerminalFailure(entry)
+				cq.onCommitTerminalFailure(entry, resultErr)
 				unlockPath()
 				cq.endInFlight(entry)
 				continue
 			}
 			if err := cq.validateEntryPayloadFresh(entry); err != nil {
 				safeLogPrintf("commit queue: batch conflict auto-resolve rejected stale payload for %s: %v", entry.Path, err)
-				cq.onCommitTerminalFailure(entry)
+				cq.onCommitTerminalFailure(entry, err)
 				unlockPath()
 				cq.endInFlight(entry)
 				continue
@@ -2418,7 +2418,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 	// check nor LWW can be trusted. Keep layer conflicts terminal.
 	if cq.layerRefSnapshot() != "" {
 		safeLogPrintf("commit queue: auto-resolve unsupported for layer mount, terminal failure for %s", entry.Path)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, nil)
 		return
 	}
 
@@ -2432,7 +2432,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 	}
 
 	if cq.shadows == nil {
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, nil)
 		return
 	}
 
@@ -2448,11 +2448,11 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 		}
 		if errors.Is(err, errCommitPayloadStale) {
 			safeLogPrintf("commit queue: auto-resolve rejected stale payload for %s: %v", entry.Path, err)
-			cq.onCommitTerminalFailure(entry)
+			cq.onCommitTerminalFailure(entry, err)
 			return
 		}
 		safeLogPrintf("commit queue: auto-resolve failed for %s: read shadow: %v", entry.Path, err)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, err)
 		return
 	}
 	apiPath := cq.remotePath(entry.Path)
@@ -2504,7 +2504,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 			}
 			if uploadErr != nil {
 				safeLogPrintf("commit queue: create retry failed for %s: %v", entry.Path, uploadErr)
-				cq.onCommitTerminalFailure(entry)
+				cq.onCommitTerminalFailure(entry, uploadErr)
 				return
 			}
 			safeLogPrintf("commit queue: auto-resolved conflict for %s via create retry (no remote file)", entry.Path)
@@ -2514,7 +2514,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 			return
 		}
 		safeLogPrintf("commit queue: auto-resolve failed for %s: stat: %v", entry.Path, err)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, err)
 		return
 	}
 	serverRev := stat.Revision
@@ -2528,7 +2528,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 	}
 	if err != nil {
 		safeLogPrintf("commit queue: auto-resolve failed for %s: read server: %v", entry.Path, err)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, err)
 		return
 	}
 
@@ -2544,17 +2544,17 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 	// Branch 2: LWW — re-upload local shadow with new base revision.
 	if entry.DisableAutoResolveLWW {
 		safeLogPrintf("commit queue: fenced conflict for %s will not LWW-rebase payload from base rev %d onto server rev %d", entry.Path, entry.payloadBaseRevision(), serverRev)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, nil)
 		return
 	}
 	if entry.PayloadBaseRevSet && entry.payloadBaseRevision() < serverRev {
 		safeLogPrintf("commit queue: refusing LWW rebase for %s: payload base rev %d is older than server rev %d", entry.Path, entry.payloadBaseRevision(), serverRev)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, nil)
 		return
 	}
 	if err := cq.validateEntryPayloadFresh(entry); err != nil {
 		safeLogPrintf("commit queue: auto-resolve rejected stale payload for %s before LWW: %v", entry.Path, err)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, err)
 		return
 	}
 	if cq.discardSupersededEntry(entry) {
@@ -2581,7 +2581,7 @@ func (cq *CommitQueue) tryAutoResolveConflict(entryCtx context.Context, entry *C
 	}
 	if err != nil {
 		safeLogPrintf("commit queue: auto-resolve LWW re-upload failed for %s: %v", entry.Path, err)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, err)
 		return
 	}
 	if cq.isEntryCanceled(entry) {
@@ -2607,12 +2607,12 @@ const shadowSpillCompareChunk = 8 << 20
 // LWW re-upload is intentionally not attempted for large files.
 func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context, entry *CommitEntry) {
 	if cq.shadows == nil || cq.client == nil {
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, nil)
 		return
 	}
 	if err := cq.validateEntryPayloadFresh(entry); err != nil {
 		safeLogPrintf("commit queue: ShadowSpill stale payload rejected for %s: %v", entry.Path, err)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, err)
 		return
 	}
 	apiPath := cq.remotePath(entry.Path)
@@ -2660,7 +2660,7 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 			}
 			if uploadErr != nil {
 				safeLogPrintf("commit queue: ShadowSpill create retry failed for %s: %v", entry.Path, uploadErr)
-				cq.onCommitTerminalFailure(entry)
+				cq.onCommitTerminalFailure(entry, uploadErr)
 				return
 			}
 			safeLogPrintf("commit queue: auto-resolved ShadowSpill conflict for %s via create retry (no remote file)", entry.Path)
@@ -2670,7 +2670,7 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 			return
 		}
 		safeLogPrintf("commit queue: ShadowSpill auto-resolve failed for %s: stat: %v", entry.Path, err)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, err)
 		return
 	}
 
@@ -2687,7 +2687,7 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 		} else {
 			safeLogPrintf("commit queue: ShadowSpill auto-resolve failed for %s: open shadow: %v", entry.Path, err)
 		}
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, err)
 		return
 	}
 	defer func() {
@@ -2700,7 +2700,7 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 	}()
 	if stat.Size != localSize {
 		safeLogPrintf("commit queue: ShadowSpill conflict for %s is genuine (local %d bytes vs server %d bytes), terminal failure", entry.Path, localSize, stat.Size)
-		cq.onCommitTerminalFailure(entry)
+		cq.onCommitTerminalFailure(entry, nil)
 		return
 	}
 
@@ -2726,7 +2726,7 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 		}
 		if err != nil {
 			safeLogPrintf("commit queue: ShadowSpill auto-resolve failed for %s: read server @%d: %v", entry.Path, off, err)
-			cq.onCommitTerminalFailure(entry)
+			cq.onCommitTerminalFailure(entry, err)
 			return
 		}
 		ln, err := fd.ReadAt(buf[:n], off)
@@ -2737,12 +2737,12 @@ func (cq *CommitQueue) tryResolveShadowSpillIdempotent(entryCtx context.Context,
 				return
 			}
 			safeLogPrintf("commit queue: ShadowSpill auto-resolve failed for %s: read shadow @%d: n=%d err=%v", entry.Path, off, ln, err)
-			cq.onCommitTerminalFailure(entry)
+			cq.onCommitTerminalFailure(entry, err)
 			return
 		}
 		if int64(len(serverChunk)) != n || !bytes.Equal(serverChunk, buf[:n]) {
 			safeLogPrintf("commit queue: ShadowSpill conflict for %s is genuine (content differs @%d), terminal failure", entry.Path, off)
-			cq.onCommitTerminalFailure(entry)
+			cq.onCommitTerminalFailure(entry, nil)
 			return
 		}
 	}
@@ -2767,9 +2767,10 @@ func (cq *CommitQueue) onCommitPostUploadFailure(entry *CommitEntry, err error) 
 	safeLogPrintf("commit queue: post-upload failure for %s; local pending state preserved for retry: %v", entry.Path, err)
 }
 
-func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry) {
+func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry, lastErr error) {
 	if cq.perf != nil {
 		cq.perf.commitFailure.add(1)
+		cq.perf.commitTerminalFailure.add(1)
 	}
 	// Mark the entry as conflicted in the pending index so that crash
 	// recovery (RecoverPending) skips it instead of retrying forever.
@@ -2814,5 +2815,9 @@ func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry) {
 	// until bookkeeping is complete.
 	cq.removeFromQueue(entry)
 
-	safeLogPrintf("commit queue: terminal failure for %s — local data preserved for manual recovery", entry.Path)
+	// Alertable FUSE-local error. Collectors should match
+	// "drive9: error event=commit_terminal_failure" on stderr / mount-log
+	// files (typically ~/.cache/drive9/mount-logs/). The drive9 server never
+	// sees this line; collect it outside the sandbox. lastErr may be nil.
+	safeLogPrintf("drive9: error event=commit_terminal_failure path=%s err=%v detail=local_data_preserved", entry.Path, lastErr)
 }

--- a/pkg/fuse/commit_queue.go
+++ b/pkg/fuse/commit_queue.go
@@ -1503,7 +1503,7 @@ func (cq *CommitQueue) commitOne(entry *CommitEntry) {
 			cq.mu.Unlock()
 			if abandoned {
 				safeLogPrintf("commit queue: layer abandoned, terminal failure for %s", entry.Path)
-				cq.onCommitTerminalFailure(entry, err)
+				cq.onCommitTerminalFailure(entry, fmt.Errorf("%w: %v", errLayerRolledBack, err))
 				unlockPath()
 				return
 			}
@@ -2780,7 +2780,7 @@ func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry, lastErr error
 		if entry.PendingIndexGen != 0 {
 			marked, err := cq.index.MarkConflictIfGeneration(entry.Path, entry.PendingIndexGen)
 			if err != nil {
-				safeLogPrintf("commit queue: failed to mark conflict for %s: %v (entry remains queued)", entry.Path, err)
+				safeLogPrintf("commit queue: failed to mark conflict for %s: %v (pending data preserved; in-memory queue entry removed)", entry.Path, err)
 				cq.removeFromQueue(entry)
 				cq.recordCommitTerminalFailure(entry, lastErr)
 				return
@@ -2791,10 +2791,9 @@ func (cq *CommitQueue) onCommitTerminalFailure(entry *CommitEntry, lastErr error
 				return
 			}
 		} else if err := cq.index.MarkConflict(entry.Path); err != nil {
-			// Conflict marker not durable — leave the entry queued so
-			// RecoverPending can retry on next startup rather than
-			// silently dropping it.
-			safeLogPrintf("commit queue: failed to mark conflict for %s: %v (entry remains queued)", entry.Path, err)
+			// Conflict marker not durable. The in-memory queue entry is still
+			// removed; RecoverPending can retry from preserved pending/shadow.
+			safeLogPrintf("commit queue: failed to mark conflict for %s: %v (pending data preserved; in-memory queue entry removed)", entry.Path, err)
 			cq.removeFromQueue(entry)
 			cq.recordCommitTerminalFailure(entry, lastErr)
 			return
@@ -2824,5 +2823,20 @@ func (cq *CommitQueue) recordCommitTerminalFailure(entry *CommitEntry, lastErr e
 	// "drive9: error event=commit_terminal_failure" on stderr / mount-log
 	// files (typically ~/.cache/drive9/mount-logs/). The drive9 server never
 	// sees this line; collect it outside the sandbox. lastErr may be nil.
-	safeLogPrintf("drive9: error event=commit_terminal_failure path=%s err=%v detail=local_data_preserved", entry.Path, lastErr)
+	// reason= distinguishes retryable upload loss from concurrency conflict
+	// and layer-abandonment so alert severity can differ.
+	safeLogPrintf("drive9: error event=commit_terminal_failure path=%s reason=%s err=%v detail=local_data_preserved", entry.Path, classifyCommitTerminalReason(lastErr), lastErr)
+}
+
+func classifyCommitTerminalReason(lastErr error) string {
+	switch {
+	case lastErr == nil:
+		return "conflict"
+	case errors.Is(lastErr, errLayerRolledBack):
+		return "abandoned"
+	case errors.Is(lastErr, client.ErrConflict), errors.Is(lastErr, errCommitPayloadStale):
+		return "conflict"
+	default:
+		return "upload_failure"
+	}
 }

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -1912,8 +1912,8 @@ func TestCommitQueueNonConflictErrorUnchanged(t *testing.T) {
 			t.Fatalf("terminal failure log missing %q:\n%s", want, logged)
 		}
 	}
-	if strings.Count(logged, "drive9: error event=commit_terminal_failure path=/500.txt") != 1 {
-		t.Fatalf("want exactly one alertable terminal-failure line for /500.txt, got:\n%s", logged)
+	if strings.Count(logged, "drive9: error event=commit_terminal_failure path=/500.txt reason=upload_failure") != 1 {
+		t.Fatalf("want exactly one alertable upload_failure line for /500.txt, got:\n%s", logged)
 	}
 	for _, line := range strings.Split(logged, "\n") {
 		if strings.Contains(line, "upload attempt") && strings.Contains(line, "drive9: error") {
@@ -1926,6 +1926,25 @@ func TestCommitQueueNonConflictErrorUnchanged(t *testing.T) {
 	}
 	if got := snap.Counters["commit_failure"]; got != 1 {
 		t.Fatalf("commit_failure = %d, want 1", got)
+	}
+}
+
+func TestClassifyCommitTerminalReason(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string
+	}{
+		{nil, "conflict"},
+		{errLayerRolledBack, "abandoned"},
+		{fmt.Errorf("%w: 409", errLayerRolledBack), "abandoned"},
+		{client.ErrConflict, "conflict"},
+		{errCommitPayloadStale, "conflict"},
+		{fmt.Errorf("HTTP 503"), "upload_failure"},
+	}
+	for _, tc := range cases {
+		if got := classifyCommitTerminalReason(tc.err); got != tc.want {
+			t.Errorf("classifyCommitTerminalReason(%v) = %q, want %q", tc.err, got, tc.want)
+		}
 	}
 }
 

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -1840,6 +1841,16 @@ func TestCommitQueueAutoResolveLWWSecond409Fallback(t *testing.T) {
 
 // Test axis 4: Non-conflict errors (500) still follow existing retry + terminal failure.
 func TestCommitQueueNonConflictErrorUnchanged(t *testing.T) {
+	var logBuf bytes.Buffer
+	oldWriter := log.Writer()
+	oldFlags := log.Flags()
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(oldWriter)
+		log.SetFlags(oldFlags)
+	})
+
 	var calls int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		calls++
@@ -1847,7 +1858,7 @@ func TestCommitQueueNonConflictErrorUnchanged(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	shadow, err := NewShadowStore(t.TempDir())
+	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1865,6 +1876,8 @@ func TestCommitQueueNonConflictErrorUnchanged(t *testing.T) {
 	}
 
 	cq := NewCommitQueue(newTestClient(ts.URL), shadow, pending, nil, 1, 8)
+	perf := newFusePerfCounters(true)
+	cq.SetPerfCounters(perf)
 	if err := cq.Enqueue(&CommitEntry{
 		Path:    "/500.txt",
 		BaseRev: 5,
@@ -1886,6 +1899,32 @@ func TestCommitQueueNonConflictErrorUnchanged(t *testing.T) {
 	meta, ok := pending.GetMeta("/500.txt")
 	if !ok || meta.Kind != PendingConflict {
 		t.Fatalf("pending entry should be PendingConflict, got kind=%v ok=%v", meta.Kind, ok)
+	}
+
+	logged := logBuf.String()
+	for _, want := range []string{
+		"drive9: error",
+		"event=commit_terminal_failure",
+		"path=/500.txt",
+	} {
+		if !strings.Contains(logged, want) {
+			t.Fatalf("terminal failure log missing %q:\n%s", want, logged)
+		}
+	}
+	if strings.Count(logged, "drive9: error event=commit_terminal_failure") != 1 {
+		t.Fatalf("want exactly one alertable terminal-failure line, got:\n%s", logged)
+	}
+	for _, line := range strings.Split(logged, "\n") {
+		if strings.Contains(line, "upload attempt") && strings.Contains(line, "drive9: error") {
+			t.Fatalf("retry attempts must not be logged as drive9: error: %s", line)
+		}
+	}
+	snap := perf.snapshot()
+	if got := snap.Counters["commit_terminal_failure"]; got != 1 {
+		t.Fatalf("commit_terminal_failure = %d, want 1", got)
+	}
+	if got := snap.Counters["commit_failure"]; got != 1 {
+		t.Fatalf("commit_failure = %d, want 1", got)
 	}
 }
 

--- a/pkg/fuse/commit_queue_test.go
+++ b/pkg/fuse/commit_queue_test.go
@@ -1858,6 +1858,7 @@ func TestCommitQueueNonConflictErrorUnchanged(t *testing.T) {
 	}))
 	defer ts.Close()
 
+	// Disable free-ratio quota so this test is hermetic on low-disk hosts.
 	shadow, err := NewShadowStoreWithQuota(t.TempDir(), 0, 0)
 	if err != nil {
 		t.Fatal(err)
@@ -1911,8 +1912,8 @@ func TestCommitQueueNonConflictErrorUnchanged(t *testing.T) {
 			t.Fatalf("terminal failure log missing %q:\n%s", want, logged)
 		}
 	}
-	if strings.Count(logged, "drive9: error event=commit_terminal_failure") != 1 {
-		t.Fatalf("want exactly one alertable terminal-failure line, got:\n%s", logged)
+	if strings.Count(logged, "drive9: error event=commit_terminal_failure path=/500.txt") != 1 {
+		t.Fatalf("want exactly one alertable terminal-failure line for /500.txt, got:\n%s", logged)
 	}
 	for _, line := range strings.Split(logged, "\n") {
 		if strings.Contains(line, "upload attempt") && strings.Contains(line, "drive9: error") {
@@ -1925,6 +1926,56 @@ func TestCommitQueueNonConflictErrorUnchanged(t *testing.T) {
 	}
 	if got := snap.Counters["commit_failure"]; got != 1 {
 		t.Fatalf("commit_failure = %d, want 1", got)
+	}
+}
+
+func TestOnCommitTerminalFailureStaleGenerationSkipsAlert(t *testing.T) {
+	var logBuf bytes.Buffer
+	oldWriter := log.Writer()
+	oldFlags := log.Flags()
+	log.SetOutput(&logBuf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(oldWriter)
+		log.SetFlags(oldFlags)
+	})
+
+	pending, err := NewPendingIndex(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldGen, err := pending.PutWithBaseRev("/stale.txt", 4, PendingNew, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pending.PutWithBaseRev("/stale.txt", 5, PendingNew, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	cq := NewCommitQueue(nil, nil, pending, nil, 1, 8)
+	defer cq.DrainAll()
+	perf := newFusePerfCounters(true)
+	cq.SetPerfCounters(perf)
+	cq.onCommitTerminalFailure(&CommitEntry{
+		Path:            "/stale.txt",
+		Kind:            PendingNew,
+		PendingIndexGen: oldGen,
+	}, fmt.Errorf("upload failed"))
+
+	logged := logBuf.String()
+	if strings.Contains(logged, "event=commit_terminal_failure") {
+		t.Fatalf("stale generation must not emit alertable terminal-failure:\n%s", logged)
+	}
+	snap := perf.snapshot()
+	if got := snap.Counters["commit_terminal_failure"]; got != 0 {
+		t.Fatalf("commit_terminal_failure = %d, want 0", got)
+	}
+	if got := snap.Counters["commit_failure"]; got != 0 {
+		t.Fatalf("commit_failure = %d, want 0", got)
+	}
+	meta, ok := pending.GetMeta("/stale.txt")
+	if !ok || meta.Kind == PendingConflict {
+		t.Fatalf("newer pending must not be marked conflict, kind=%v ok=%v", meta.Kind, ok)
 	}
 }
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -10101,11 +10101,16 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 		}
 		fs.bindCommitEntryToPath(entry, newP, meta.BaseRev)
 		commitPendingRenameNow := func() error {
-			timeout := uploadTimeout
 			if entry.ShadowSpill {
-				timeout = releaseTimeout(entry.Size)
+				// Spill uploads need a size-aware budget and must not inherit
+				// the 30s FUSE request deadline. Non-spill commits keep the
+				// request context so git/small-file renames stay interruptible
+				// when gVisor compatibility is off.
+				commitCtx, commitCancel := context.WithTimeout(context.WithoutCancel(ctx), releaseTimeout(entry.Size))
+				defer commitCancel()
+				return fs.commitQueue.commitNowPathLocked(commitCtx, entry)
 			}
-			commitCtx, commitCancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+			commitCtx, commitCancel := fs.namespaceMutationCommitContext(ctx)
 			defer commitCancel()
 			return fs.commitQueue.commitNowPathLocked(commitCtx, entry)
 		}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1893,6 +1893,18 @@ func (fs *Dat9FS) mountWritePolicy() WritePolicy {
 	return fs.opts.WritePolicy
 }
 
+// mountWritePolicyDurableRename reports whether pending-new rename(2) must
+// commit remotely before returning. Rename has no open-file WritePolicy, so
+// this uses the mount policy rather than a handle.
+func (fs *Dat9FS) mountWritePolicyDurableRename() bool {
+	switch fs.mountWritePolicy() {
+	case WritePolicyCloseSync, WritePolicyWriteSync:
+		return true
+	default:
+		return false
+	}
+}
+
 func isGitLooseObjectFinalPath(p string) bool {
 	const marker = "/.git/objects/"
 
@@ -4005,7 +4017,7 @@ func (fs *Dat9FS) stagePathTruncateToZeroLocked(ctx context.Context, entry *Inod
 		safeLogPrintf("path truncate async enqueue failed for %s: %v, falling back to sync commit", entry.Path, err)
 		if commitErr := fs.commitQueue.commitNowPathLocked(ctx, commit); commitErr != nil {
 			if errors.Is(commitErr, errCommitPayloadStale) {
-				fs.commitQueue.onCommitTerminalFailure(commit)
+				fs.commitQueue.onCommitTerminalFailure(commit, commitErr)
 			} else {
 				cleanupCommitStaging()
 			}
@@ -10092,12 +10104,14 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 			defer commitCancel()
 			return fs.commitQueue.commitNowPathLocked(commitCtx, entry)
 		}
-		if isGitLooseObjectFinalPath(newP) {
-			// Git treats a successful tmp_obj_* -> <sha> rename as making the
-			// object database complete. Do not acknowledge that rename while the
-			// content-addressed object is only queued for best-effort upload.
+		// Git treats a successful tmp_obj_* -> <sha> rename as making the
+		// object database complete. Close-sync/write-sync mounts have the same
+		// durability contract for ordinary pending-new mv: rename(2) must not
+		// return success while the final path is only queued for upload.
+		syncRename := isGitLooseObjectFinalPath(newP) || fs.mountWritePolicyDurableRename()
+		if syncRename {
 			if commitErr := commitPendingRenameNow(); commitErr != nil {
-				return pendingRenameHandled, fmt.Errorf("sync commit git loose object rename %s: %w", newP, commitErr)
+				return pendingRenameHandled, fmt.Errorf("sync commit pending-new rename %s: %w", newP, commitErr)
 			}
 		} else if err := fs.commitQueue.Enqueue(entry); err != nil {
 			safeLogPrintf("rename: enqueue pending-new commit for %s failed, falling back to sync commit: %v", newP, err)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -1894,8 +1894,9 @@ func (fs *Dat9FS) mountWritePolicy() WritePolicy {
 }
 
 // mountWritePolicyDurableRename reports whether pending-new rename(2) must
-// commit remotely before returning. Rename has no open-file WritePolicy, so
-// this uses the mount policy rather than a handle.
+// commit remotely before returning. Open handles of oldP carry WritePolicy,
+// but rename is not an fd operation; the mount policy is the proxy for the
+// pending-new states that reach this path (writeback stays async by design).
 func (fs *Dat9FS) mountWritePolicyDurableRename() bool {
 	switch fs.mountWritePolicy() {
 	case WritePolicyCloseSync, WritePolicyWriteSync:
@@ -10100,7 +10101,11 @@ func (fs *Dat9FS) renamePendingNewCommit(ctx context.Context, input *gofuse.Rena
 		}
 		fs.bindCommitEntryToPath(entry, newP, meta.BaseRev)
 		commitPendingRenameNow := func() error {
-			commitCtx, commitCancel := fs.namespaceMutationCommitContext(ctx)
+			timeout := uploadTimeout
+			if entry.ShadowSpill {
+				timeout = releaseTimeout(entry.Size)
+			}
+			commitCtx, commitCancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
 			defer commitCancel()
 			return fs.commitQueue.commitNowPathLocked(commitCtx, entry)
 		}

--- a/pkg/fuse/dat9fs_test.go
+++ b/pkg/fuse/dat9fs_test.go
@@ -21908,6 +21908,289 @@ func TestRenamePendingNewCommitGitLooseObjectSyncFailureKeepsRecoverableShadow(t
 	}
 }
 
+func TestRenamePendingNewCommitCloseSyncUploadsBeforeReturning(t *testing.T) {
+	testRenamePendingNewCommitDurablePolicyUploadsBeforeReturning(t, WritePolicyCloseSync)
+}
+
+func TestRenamePendingNewCommitWriteSyncUploadsBeforeReturning(t *testing.T) {
+	testRenamePendingNewCommitDurablePolicyUploadsBeforeReturning(t, WritePolicyWriteSync)
+}
+
+func TestRenamePendingNewCommitWriteBackAllowsAsyncUploadAfterReturning(t *testing.T) {
+	oldP := "/app/file.txt.tmp.xxx"
+	newP := "/app/file.txt"
+	data := []byte("new-content-should-be-remote")
+	const putDelay = 300 * time.Millisecond
+
+	var finalPuts atomic.Int32
+	var renameCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+newP:
+			time.Sleep(putDelay)
+			finalPuts.Add(1)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			if string(body) != string(data) {
+				http.Error(w, "unexpected body", http.StatusBadRequest)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+		case r.Method == http.MethodPost && r.URL.RawQuery == "rename":
+			renameCalls.Add(1)
+			http.Error(w, "server rename should not be used for pending-new temp files", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	fs, cq, _, _ := newPendingNewRenameTestFS(t, ts.URL, WritePolicyWriteBack, oldP, data)
+	defer cq.DrainAll()
+	dirIno := fs.inodes.Lookup("/app", true, 0, time.Now())
+
+	st := fs.Rename(nil, &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Newdir:   dirIno,
+	}, "file.txt.tmp.xxx", "file.txt")
+	if st != gofuse.OK {
+		t.Fatalf("Rename: %v", st)
+	}
+	if got := finalPuts.Load(); got != 0 {
+		t.Fatalf("writeback Rename returned with final path PUTs = %d, want 0 (async)", got)
+	}
+	if got := renameCalls.Load(); got != 0 {
+		t.Fatalf("remote rename calls = %d, want 0", got)
+	}
+
+	cq.DrainAll()
+	if got := finalPuts.Load(); got < 1 {
+		t.Fatalf("final path PUTs after drain = %d, want >= 1", got)
+	}
+}
+
+func testRenamePendingNewCommitDurablePolicyUploadsBeforeReturning(t *testing.T, policy WritePolicy) {
+	t.Helper()
+	oldP := "/app/file.txt.tmp.xxx"
+	newP := "/app/file.txt"
+	data := []byte("new-content-should-be-remote")
+	const putDelay = 300 * time.Millisecond
+
+	var finalPuts atomic.Int32
+	var renameCalls atomic.Int32
+	var mu sync.Mutex
+	var finalBody []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+newP:
+			time.Sleep(putDelay)
+			finalPuts.Add(1)
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+			mu.Lock()
+			finalBody = append([]byte(nil), body...)
+			mu.Unlock()
+			_ = json.NewEncoder(w).Encode(map[string]int64{"revision": 1})
+		case r.Method == http.MethodPost && r.URL.RawQuery == "rename":
+			renameCalls.Add(1)
+			http.Error(w, "server rename should not be used for pending-new temp files", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	fs, cq, shadow, pending := newPendingNewRenameTestFS(t, ts.URL, policy, oldP, data)
+	defer cq.DrainAll()
+	dirIno := fs.inodes.Lookup("/app", true, 0, time.Now())
+
+	st := fs.Rename(nil, &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Newdir:   dirIno,
+	}, "file.txt.tmp.xxx", "file.txt")
+	if st != gofuse.OK {
+		t.Fatalf("Rename: %v", st)
+	}
+	if got := finalPuts.Load(); got < 1 {
+		t.Fatalf("%s Rename returned with final path PUTs = %d, want >= 1", policy, got)
+	}
+	if got := renameCalls.Load(); got != 0 {
+		t.Fatalf("remote rename calls = %d, want 0", got)
+	}
+	mu.Lock()
+	gotBody := string(finalBody)
+	mu.Unlock()
+	if gotBody != string(data) {
+		t.Fatalf("final upload body = %q, want %q", gotBody, string(data))
+	}
+	if pending.HasPending(oldP) {
+		t.Fatal("old temp path still pending")
+	}
+	if pending.HasPending(newP) {
+		t.Fatal("final path still pending after sync upload")
+	}
+	if shadow.Has(oldP) {
+		t.Fatal("old temp shadow still exists")
+	}
+	if shadow.Has(newP) {
+		t.Fatal("final shadow still exists after sync upload")
+	}
+}
+
+func TestRenamePendingNewCommitCloseSyncFailureReturnsErrorAndKeepsShadow(t *testing.T) {
+	testRenamePendingNewCommitDurablePolicyFailureReturnsErrorAndKeepsShadow(t, WritePolicyCloseSync)
+}
+
+func TestRenamePendingNewCommitWriteSyncFailureReturnsErrorAndKeepsShadow(t *testing.T) {
+	testRenamePendingNewCommitDurablePolicyFailureReturnsErrorAndKeepsShadow(t, WritePolicyWriteSync)
+}
+
+func testRenamePendingNewCommitDurablePolicyFailureReturnsErrorAndKeepsShadow(t *testing.T, policy WritePolicy) {
+	t.Helper()
+	oldP := "/app/file.txt.tmp.xxx"
+	newP := "/app/file.txt"
+	finalName := "file.txt"
+	data := []byte("new-content-should-be-remote")
+
+	var finalPuts atomic.Int32
+	var renameCalls atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPut && r.URL.Path == "/v1/fs"+newP:
+			finalPuts.Add(1)
+			http.Error(w, "storage backend unavailable", http.StatusServiceUnavailable)
+		case r.Method == http.MethodPost && r.URL.RawQuery == "rename":
+			renameCalls.Add(1)
+			http.Error(w, "server rename should not be used for pending-new temp files", http.StatusInternalServerError)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer ts.Close()
+
+	shadowDir := t.TempDir()
+	pendingDir := t.TempDir()
+	fs, cq, shadow, pending := newPendingNewRenameTestFSAt(t, ts.URL, policy, oldP, data, shadowDir, pendingDir)
+	dirIno := fs.inodes.Lookup("/app", true, 0, time.Now())
+
+	st := fs.Rename(nil, &gofuse.RenameIn{
+		InHeader: gofuse.InHeader{NodeId: dirIno},
+		Newdir:   dirIno,
+	}, "file.txt.tmp.xxx", finalName)
+	if st != gofuse.Status(syscall.EAGAIN) {
+		t.Fatalf("%s Rename status = %v, want EAGAIN", policy, st)
+	}
+	cq.DrainAll()
+	shadow.Close()
+
+	if got := finalPuts.Load(); got < 1 {
+		t.Fatalf("final path PUTs = %d, want >= 1", got)
+	}
+	if got := renameCalls.Load(); got != 0 {
+		t.Fatalf("remote rename calls = %d, want 0", got)
+	}
+	if pending.HasPending(oldP) {
+		t.Fatal("old temp path still pending")
+	}
+	if !pending.HasPending(newP) {
+		t.Fatal("final path should stay pending after sync upload failure")
+	}
+
+	pending2, err := NewPendingIndex(pendingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := pending2.RecoverFromDisk(); err != nil {
+		t.Fatalf("RecoverFromDisk: %v", err)
+	}
+	shadow2, err := NewShadowStoreWithQuota(shadowDir, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer shadow2.Close()
+	if !shadow2.Has(newP) {
+		t.Fatal("recovered shadow missing final path")
+	}
+
+	opts := &MountOptions{WritePolicy: policy}
+	opts.setDefaults()
+	fs2 := NewDat9FS(newTestClient(ts.URL), opts)
+	fs2.shadowStore = shadow2
+	fs2.pendingIndex = pending2
+	dirIno2 := fs2.inodes.Lookup("/app", true, 0, time.Now())
+	var entryOut gofuse.EntryOut
+	st = fs2.Lookup(nil, &gofuse.InHeader{NodeId: dirIno2}, finalName, &entryOut)
+	if st != gofuse.OK {
+		t.Fatalf("Lookup recovered file: %v, want OK", st)
+	}
+	if entryOut.Size != uint64(len(data)) {
+		t.Fatalf("Lookup size = %d, want %d", entryOut.Size, len(data))
+	}
+
+	var openOut gofuse.OpenOut
+	st = fs2.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: entryOut.NodeId},
+		Flags:    uint32(syscall.O_RDONLY),
+	}, &openOut)
+	if st != gofuse.OK {
+		t.Fatalf("Open recovered file: %v", st)
+	}
+	buf := make([]byte, len(data)+8)
+	result, st := fs2.Read(nil, &gofuse.ReadIn{
+		InHeader: gofuse.InHeader{NodeId: entryOut.NodeId},
+		Fh:       openOut.Fh,
+		Size:     uint32(len(buf)),
+	}, buf)
+	if st != gofuse.OK {
+		t.Fatalf("Read recovered file: %v", st)
+	}
+	got, _ := result.Bytes(buf)
+	if string(got) != string(data) {
+		t.Fatalf("Read recovered file = %q, want %q", string(got), string(data))
+	}
+}
+
+func newPendingNewRenameTestFS(t *testing.T, serverURL string, policy WritePolicy, oldP string, data []byte) (*Dat9FS, *CommitQueue, *ShadowStore, *PendingIndex) {
+	t.Helper()
+	return newPendingNewRenameTestFSAt(t, serverURL, policy, oldP, data, t.TempDir(), t.TempDir())
+}
+
+func newPendingNewRenameTestFSAt(t *testing.T, serverURL string, policy WritePolicy, oldP string, data []byte, shadowDir, pendingDir string) (*Dat9FS, *CommitQueue, *ShadowStore, *PendingIndex) {
+	t.Helper()
+	opts := &MountOptions{WritePolicy: policy}
+	opts.setDefaults()
+	c := newTestClient(serverURL)
+	fs := NewDat9FS(c, opts)
+
+	shadow, err := NewShadowStoreWithQuota(shadowDir, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { shadow.Close() })
+	pending, err := NewPendingIndex(pendingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fs.shadowStore = shadow
+	fs.pendingIndex = pending
+	cq := NewCommitQueue(c, shadow, pending, nil, 1, 16)
+	fs.commitQueue = cq
+
+	if err := shadow.WriteFull(oldP, data, 0); err != nil {
+		t.Fatalf("WriteFull old shadow: %v", err)
+	}
+	if _, err := pending.PutWithBaseRev(oldP, int64(len(data)), PendingNew, 0); err != nil {
+		t.Fatalf("PutWithBaseRev old pending: %v", err)
+	}
+	return fs, cq, shadow, pending
+}
+
 func TestRenamePendingNewCommitFallsBackWhenFinalTargetExists(t *testing.T) {
 	oldP := "/repo/.git/config.lock"
 	newP := "/repo/.git/config"

--- a/pkg/fuse/drain.go
+++ b/pkg/fuse/drain.go
@@ -335,8 +335,8 @@ func drainPendingWorkError(p mountcontrol.DrainPending) error {
 // drainPendingHasUndrainedWork is true when drain cannot report a clean pause.
 // commit_queue_conflicts is included so writeback mounts still fail drain after
 // an async commit terminal-failure. Close-sync/write-sync pending-new rename
-// failures are returned to the caller as EAGAIN and no longer require drain to
-// become visible.
+// failures return EAGAIN to the caller and do not require drain to become
+// visible; leftover pending is recovered on remount.
 func drainPendingHasUndrainedWork(p mountcontrol.DrainPending) bool {
 	return p.DirtyHandles != 0 ||
 		p.CommitQueuePending != 0 ||

--- a/pkg/fuse/drain.go
+++ b/pkg/fuse/drain.go
@@ -332,6 +332,11 @@ func drainPendingWorkError(p mountcontrol.DrainPending) error {
 	)
 }
 
+// drainPendingHasUndrainedWork is true when drain cannot report a clean pause.
+// commit_queue_conflicts is included so writeback mounts still fail drain after
+// an async commit terminal-failure. Close-sync/write-sync pending-new rename
+// failures are returned to the caller as EAGAIN and no longer require drain to
+// become visible.
 func drainPendingHasUndrainedWork(p mountcontrol.DrainPending) bool {
 	return p.DirtyHandles != 0 ||
 		p.CommitQueuePending != 0 ||

--- a/pkg/fuse/perf.go
+++ b/pkg/fuse/perf.go
@@ -140,11 +140,12 @@ type fusePerfCounters struct {
 	readRetrySuccess     atomicUint64
 	readRetryExhausted   atomicUint64
 
-	commitEnqueue      atomicUint64
-	commitEnqueueError atomicUint64
-	commitRetry        atomicUint64
-	commitSuccess      atomicUint64
-	commitFailure      atomicUint64
+	commitEnqueue         atomicUint64
+	commitEnqueueError    atomicUint64
+	commitRetry           atomicUint64
+	commitSuccess         atomicUint64
+	commitFailure         atomicUint64
+	commitTerminalFailure atomicUint64
 
 	uploaderSubmit       atomicUint64
 	uploaderSyncFallback atomicUint64
@@ -556,6 +557,7 @@ func (p *fusePerfCounters) snapshot() fusePerfSnapshot {
 	snap.Counters["commit_retry"] = p.commitRetry.load()
 	snap.Counters["commit_success"] = p.commitSuccess.load()
 	snap.Counters["commit_failure"] = p.commitFailure.load()
+	snap.Counters["commit_terminal_failure"] = p.commitTerminalFailure.load()
 	snap.Counters["uploader_submit"] = p.uploaderSubmit.load()
 	snap.Counters["uploader_sync_fallback"] = p.uploaderSyncFallback.load()
 	snap.Counters["uploader_success"] = p.uploaderSuccess.load()
@@ -652,9 +654,9 @@ func (p *fusePerfCounters) printSummary(w io.Writer) {
 	writePerfLine(w, "drive9: perf retries lookup_total=%d lookup_success=%d lookup_exhausted=%d read_total=%d read_success=%d read_exhausted=%d\n",
 		snap.Counters["lookup_retry_total"], snap.Counters["lookup_retry_success"], snap.Counters["lookup_retry_exhausted"],
 		snap.Counters["read_retry_total"], snap.Counters["read_retry_success"], snap.Counters["read_retry_exhausted"])
-	writePerfLine(w, "drive9: perf commit enqueue=%d enqueue_errors=%d retries=%d success=%d failure=%d drain_count=%d drain_total=%s\n",
+	writePerfLine(w, "drive9: perf commit enqueue=%d enqueue_errors=%d retries=%d success=%d failure=%d terminal_failure=%d drain_count=%d drain_total=%s\n",
 		snap.Counters["commit_enqueue"], snap.Counters["commit_enqueue_error"], snap.Counters["commit_retry"],
-		snap.Counters["commit_success"], snap.Counters["commit_failure"],
+		snap.Counters["commit_success"], snap.Counters["commit_failure"], snap.Counters["commit_terminal_failure"],
 		snap.Counters["commit_drain_count"], time.Duration(snap.Counters["commit_drain_total_ns"]).Truncate(time.Millisecond))
 	writePerfLine(w, "drive9: perf flush_detail stage_shadow_count=%d stage_shadow_avg=%s stage_shadow_max=%s snapshot_wb_count=%d snapshot_wb_avg=%s snapshot_wb_max=%s\n",
 		snap.Counters["flush_stage_shadow_count"],


### PR DESCRIPTION
## Summary

Close-sync/write-sync mounts still treated ordinary pending-new `rename(2)` as best-effort. Agent `write tmp; mv tmp final` returned success as soon as the local shadow moved, while the final-path PUT sat in `CommitQueue`. After ~1 minute of upload failure, `onCommitTerminalFailure` dequeued the entry and marked conflict. Sandbox TTL / undrained umount then deleted the shadow. Remote kept the old file: silent rollback.

Git loose-object `tmp_obj_* -> <sha>` already committed synchronously. This extends that contract to close-sync/write-sync using the **mount** write policy (rename has no open-file WritePolicy).

Writeback stays asynchronous. Server CAS / multi-mount policy is unchanged. This does not address sandbox `rm -rf` of whole trees.

## Change

- `renamePendingNewCommit` calls `commitNowPathLocked` before returning when `WritePolicyCloseSync` or `WritePolicyWriteSync` (same path as git loose objects).
- Sync upload failure returns `EAGAIN`; local shadow/pending stay recoverable. It does **not** go through `onCommitTerminalFailure`.
- Enqueue-failure fallback to sync commit is unchanged for writeback.
- Existing-target pending-new rename still uses remote rename fallback (no mistaken create).
- `onCommitTerminalFailure` now takes the causing error and logs a stable FUSE-local alert line:

  `drive9: error event=commit_terminal_failure path=... err=...`

  Collect FUSE stderr or `~/.cache/drive9/mount-logs/` **outside** the sandbox. Retry `upload attempt N/5` lines are not `drive9: error`. The drive9 server never sees this log.
- Perf snapshot gains `commit_terminal_failure` (writeback async drops still need this). `commit_failure` is unchanged.
- `drive9 mount drain` already fails when `commit_queue_conflicts != 0`. Close-sync rename failure no longer depends on drain to become visible.

## Tests

- `TestRenamePendingNewCommitCloseSyncUploadsBeforeReturning`
- `TestRenamePendingNewCommitWriteSyncUploadsBeforeReturning`
- `TestRenamePendingNewCommitWriteBackAllowsAsyncUploadAfterReturning`
- `TestRenamePendingNewCommitCloseSyncFailureReturnsErrorAndKeepsShadow`
- `TestRenamePendingNewCommitWriteSyncFailureReturnsErrorAndKeepsShadow`
- Existing git-loose / target-exists rename tests
- `TestCommitQueueNonConflictErrorUnchanged` asserts the alertable log line
- `TestFlush_CloseSyncUploadsBeforeReturning`

```bash
go test ./pkg/fuse/ -count=1   -run 'TestRenamePendingNewCommitCloseSyncUploadsBeforeReturning|TestRenamePendingNewCommitCloseSyncFailureReturnsErrorAndKeepsShadow|TestRenamePendingNewCommitWriteSyncUploadsBeforeReturning|TestRenamePendingNewCommitSyncCommitsGitLooseObjectFinalPath|TestRenamePendingNewCommitGitLooseObjectSyncFailureKeepsRecoverableShadow|TestRenamePendingNewCommitFallsBackWhenFinalTargetExists|TestFlush_CloseSyncUploadsBeforeReturning|TestCommitQueueNonConflictErrorUnchanged'
```

## Out of scope

- kimi `rm -rf output/app` / whole-tree DELETE at 09-04 02:24, 09-05 07:36, 09-05 08:07
- actionCard zero PUT/rename (dropped before the request)
- Changing writeback default to sync

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renaming newly created files now completes remote uploads before returning when durable write settings are enabled.
  * Write-back settings continue to defer uploads until queued work is processed.
  * Failed synchronous uploads return a retryable error while preserving local data for recovery.
  * Added monitoring for terminal commit failures, including counters and alertable diagnostics.

* **Bug Fixes**
  * Terminal commit failures now retain the triggering error for clearer troubleshooting.
  * Stale-generation failures no longer generate misleading alerts or affect newer pending data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->