### PR TITLE
fix(fuse): keep Fsync bytes across multi-handle unlink mark retries

### DIFF
--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -40,6 +40,11 @@ var testHookBeforeGVisorShadowSpillFlushFence func(path string)
 // Unlinked transition atomic for the whole open-handle set.
 var testHookBeforeUnlinkedTransition func()
 
+// testHookAfterUnlinkHandleSetLockAttempt fires after a failed TryLock of
+// the whole captured handle set, before the retry sleep. Tests use it to
+// handshake that attach has entered lock contention.
+var testHookAfterUnlinkHandleSetLockAttempt func()
+
 // Dat9FS implements the go-fuse RawFileSystem interface, bridging FUSE
 // operations to the dat9 HTTP API via the Go SDK client.
 type Dat9FS struct {
@@ -469,7 +474,7 @@ const flushLockTimeout = 60 * time.Second
 // whole captured handle set. The set is acquired with TryLock only: a
 // failed attempt drops every lock already taken and retries, so Unlink
 // never blocks holding a partial set against sibling-mode cleanup.
-const unlinkHandleSetLockTimeout = 15 * time.Second
+var unlinkHandleSetLockTimeout = 15 * time.Second
 
 const (
 	// lookupTransientRetryCount is the number of detached retries after the
@@ -7602,8 +7607,17 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		}
 	}
 
+	if testHookBeforeUnlinkedTransition != nil {
+		testHookBeforeUnlinkedTransition()
+	}
 	failClosed := false
-	_, _ = fs.attachAndMarkOpenHandles(handles, p, snapshot, snapshotShadowGen, size, revision, snapshotOK, failClosed)
+	_, attachFailed := fs.attachAndMarkOpenHandles(handles, p, snapshot, snapshotShadowGen, size, revision, snapshotOK, failClosed)
+	if attachFailed {
+		// Lock timeout (failClosed is false, so attach itself does not
+		// fail). Keep the path index and leave handles linked so Unlink
+		// cannot DELETE/whiteout a name the still-open fd can republish.
+		return nil, false, syscall.EIO
+	}
 	fs.openHandles.UnlinkPath(p)
 	return handles, true, nil
 }
@@ -7628,6 +7642,9 @@ func (fs *Dat9FS) attachAndMarkOpenHandles(handles []*FileHandle, p string, snap
 	for {
 		ordered, ok := tryLockFileHandlesInOrder(handles)
 		if !ok {
+			if testHookAfterUnlinkHandleSetLockAttempt != nil {
+				testHookAfterUnlinkHandleSetLockAttempt()
+			}
 			if !time.Now().Before(deadline) {
 				return 0, true
 			}
@@ -9683,7 +9700,10 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		if info.IsDir() {
 			return gofuse.Status(syscall.EISDIR)
 		}
-		_, preserveOpen, _ := fs.markOpenHandlesUnlinked(ctx, childP, false)
+		_, preserveOpen, markErr := fs.markOpenHandlesUnlinked(ctx, childP, false)
+		if markErr != nil {
+			return httpToFuseStatus(markErr)
+		}
 		if err := overlay.Remove(childP); err != nil {
 			return localErrToFuseStatus(err)
 		}
@@ -9718,7 +9738,10 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// write fails, the directory entry still exists authoritatively, so
 		// the marking is rolled back — otherwise every later write/flush on
 		// those handles would keep being suppressed and silently drop data.
-		markedGitHandles, _, _ := fs.markOpenHandlesUnlinked(ctx, childP, false)
+		markedGitHandles, _, markErr := fs.markOpenHandlesUnlinked(ctx, childP, false)
+		if markErr != nil {
+			return httpToFuseStatus(markErr)
+		}
 		st := fs.putGitWhiteout(ctx, childP)
 		if st != gofuse.OK {
 			fs.unmarkOpenHandlesAfterFailedUnlink(childP, markedGitHandles)
@@ -9728,7 +9751,9 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// whiteout request was in flight escaped the first mark; mark them
 		// now so their later write/flush/release is suppressed too and the
 		// overlay entry cannot be upserted back over the whiteout.
-		_, _, _ = fs.markOpenHandlesUnlinked(ctx, childP, false)
+		if _, _, markErr := fs.markOpenHandlesUnlinked(ctx, childP, false); markErr != nil {
+			return httpToFuseStatus(markErr)
+		}
 		parentPath, _ := fs.inodes.GetPath(header.NodeId)
 		fs.dirCache.Remove(parentPath, name)
 		fs.touchDirectoryChangeTime(parentPath, time.Now())
@@ -9938,7 +9963,10 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	// marking; mark them now (no remote snapshot — the path is already gone)
 	// so their Flush/Fsync/Release guards see fh.Unlinked and cannot
 	// resurrect the path.
-	if _, anyOpen, _ := fs.markOpenHandlesUnlinked(ctx, childP, false); anyOpen {
+	if _, anyOpen, markErr := fs.markOpenHandlesUnlinked(ctx, childP, false); markErr != nil {
+		status = httpToFuseStatus(markErr)
+		return status
+	} else if anyOpen {
 		preserveOpen = true
 	}
 

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -34,9 +34,10 @@ var testHookAfterSamePathDirtyHandleScan func(path string)
 // acquires the same-path remote commit fence.
 var testHookBeforeGVisorShadowSpillFlushFence func(path string)
 
-// testHookBeforeUnlinkedTransition lets tests run a same-FD Write+Fsync after
-// snapshot attach but before fh.Unlinked is set. Production keeps the
-// identity check, attach, and Unlinked transition under one fh.mu hold.
+// testHookBeforeUnlinkedTransition lets tests run Write+Fsync after the
+// unlink snapshot is fetched but before the captured handle set is locked
+// for attach + Unlinked. Production keeps identity check, attach, and the
+// Unlinked transition atomic for the whole open-handle set.
 var testHookBeforeUnlinkedTransition func()
 
 // Dat9FS implements the go-fuse RawFileSystem interface, bridging FUSE
@@ -1457,18 +1458,15 @@ func (fs *Dat9FS) layerDirHasOpenChild(prefix string) bool {
 	return false
 }
 
-// discardUnlinkedHandleStateLocked drops staged dirty/pending state for a
-// handle whose path was unlinked while open. Caller must hold fh.Lock.
-// Returning early from Flush/Release without this would re-stage write-back
-// and re-upload the file, leaving an orphan that makes parent rmdir ENOTEMPTY
-// (pjdfstest unlink/14.t).
+// cancelUnlinkedRemotePublishLocked drops path-keyed staging that would
+// resurrect an unlinked pathname. Caller must hold fh.Lock.
 //
-// Path-keyed cleanup is strictly ownership-scoped: POSIX allows recreating
-// the pathname while the old unlinked fd is still open, and path-global
-// removes would then destroy the replacement file's staged state (B5). Each
-// store entry is removed only if it is still the exact generation/inode this
-// handle staged; anything newer belongs to a replacement and is left alone.
-func (fs *Dat9FS) discardUnlinkedHandleStateLocked(fh *FileHandle) {
+// It does not clear fh.Dirty: Fsync/Flush after unlink — including during a
+// mark pass that may still retry — must keep write-after-unlink bytes
+// readable on the anonymous fd. Path-keyed cleanup is ownership-scoped:
+// POSIX allows recreating the pathname while the old unlinked fd is still
+// open, and path-global removes would destroy the replacement (B5).
+func (fs *Dat9FS) cancelUnlinkedRemotePublishLocked(fh *FileHandle) {
 	if fh == nil || !fh.Unlinked {
 		return
 	}
@@ -1476,14 +1474,6 @@ func (fs *Dat9FS) discardUnlinkedHandleStateLocked(fh *FileHandle) {
 	// owns one. Otherwise it would stay held until the final Release and
 	// block same-path create/write for RemoteCommitWaitTimeout.
 	fs.releaseHandleRemoteCommitPathLocked(fh)
-	if fh.Dirty != nil {
-		fh.Dirty.ClearDirty()
-	}
-	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
-	fh.DirtySeq = 0
-	fh.WriteBackSeq = 0
-	fh.ShadowCommitReady = false
-	fh.ShadowCommitSeq = 0
 	path := fh.Path
 	if path == "" {
 		return
@@ -1507,6 +1497,27 @@ func (fs *Dat9FS) discardUnlinkedHandleStateLocked(fh *FileHandle) {
 	if fs.commitQueue != nil {
 		fs.commitQueue.CancelPathIfInode(path, fh.Ino)
 	}
+}
+
+// discardUnlinkedHandleStateLocked drops staged dirty/pending state for a
+// handle whose path was unlinked while open. Caller must hold fh.Lock.
+// Use this on Release (the fd is going away). Fsync/Flush must call
+// cancelUnlinkedRemotePublishLocked instead so a successful write-after-
+// unlink remains readable, and so a retry/rollback of a partial unlink
+// mark cannot lose bytes whose Write and Fsync already returned OK.
+func (fs *Dat9FS) discardUnlinkedHandleStateLocked(fh *FileHandle) {
+	if fh == nil || !fh.Unlinked {
+		return
+	}
+	fs.cancelUnlinkedRemotePublishLocked(fh)
+	if fh.Dirty != nil {
+		fh.Dirty.ClearDirty()
+	}
+	fs.clearDirtySize(fh.Ino, fh.DirtySeq)
+	fh.DirtySeq = 0
+	fh.WriteBackSeq = 0
+	fh.ShadowCommitReady = false
+	fh.ShadowCommitSeq = 0
 }
 
 // removeHandleStagingLocked removes path-keyed staging state owned by fh.
@@ -7490,6 +7501,14 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		const maxUnlinkedRemoteSnapshotAttempts = 3
 		var staleAfterFetch bool
 		for attempt := 0; attempt < maxUnlinkedRemoteSnapshotAttempts; attempt++ {
+			for _, fh := range handles {
+				if fh == nil {
+					continue
+				}
+				fh.Lock()
+				dropStalePreinstalledUnlinkSnapshotLocked(fh)
+				fh.Unlock()
+			}
 			if snapshotShadowGen != 0 {
 				fs.discardUnlinkedSnapshotPins(snapshotShadowGen, snapshotNeedCount)
 				snapshotShadowGen = 0
@@ -7549,35 +7568,15 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 					continue
 				}
 			}
-			attachedSnapshotPins := 0
-			var markedThisPass []*FileHandle
-			attachFailed := false
-			for _, fh := range handles {
-				if fh == nil {
+			if testHookBeforeUnlinkedTransition != nil {
+				testHookBeforeUnlinkedTransition()
+				if snapshotOK && fs.unlinkedRemoteSnapshotStale(p, handles, revision, size) {
+					staleAfterFetch = true
 					continue
 				}
-				fh.Lock()
-				pin, fail := fs.attachUnlinkedHandleSnapshotLocked(fh, p, snapshot, snapshotShadowGen, size, revision, snapshotOK)
-				if !fail && testHookBeforeUnlinkedTransition != nil {
-					fh.Unlock()
-					testHookBeforeUnlinkedTransition()
-					fh.Lock()
-					pin, fail = fs.attachUnlinkedHandleSnapshotLocked(fh, p, snapshot, snapshotShadowGen, size, revision, snapshotOK)
-				}
-				if fail {
-					attachFailed = true
-					fh.Unlock()
-					break
-				}
-				if pin {
-					attachedSnapshotPins++
-				}
-				fh.Unlinked = true
-				markedThisPass = append(markedThisPass, fh)
-				fh.Unlock()
 			}
+			attachedSnapshotPins, attachFailed := fs.attachAndMarkOpenHandles(handles, p, snapshot, snapshotShadowGen, size, revision, snapshotOK, true)
 			if attachFailed {
-				fs.unmarkOpenHandlesAfterFailedUnlink(p, markedThisPass)
 				staleAfterFetch = true
 				continue
 			}
@@ -7604,17 +7603,51 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		}
 	}
 
-	for _, fh := range handles {
-		if fh == nil {
-			continue
-		}
-		fh.Lock()
-		_, _ = fs.attachUnlinkedHandleSnapshotLocked(fh, p, snapshot, snapshotShadowGen, size, revision, snapshotOK)
-		fh.Unlinked = true
-		fh.Unlock()
-	}
+	_, _ = fs.attachAndMarkOpenHandles(handles, p, snapshot, snapshotShadowGen, size, revision, snapshotOK, false)
 	fs.openHandles.UnlinkPath(p)
 	return handles, true, nil
+}
+
+// attachAndMarkOpenHandles attaches unlink snapshots and sets Unlinked on the
+// whole captured handle set under one multi-handle lock hold. If failClosed
+// is set and any handle cannot take the snapshot, no handle is left Unlinked
+// and attached snapshot state from this pass is rolled back.
+func (fs *Dat9FS) attachAndMarkOpenHandles(handles []*FileHandle, p string, snapshot []byte, snapshotShadowGen uint64, size, revision int64, snapshotOK bool, failClosed bool) (attachedPins int, failed bool) {
+	ordered := lockFileHandlesInOrder(handles)
+	defer unlockFileHandles(ordered)
+	for _, fh := range ordered {
+		pin, fail := fs.attachUnlinkedHandleSnapshotLocked(fh, p, snapshot, snapshotShadowGen, size, revision, snapshotOK)
+		if fail && failClosed {
+			for _, h := range ordered {
+				fs.rollbackUnlinkedSnapshotAttachLocked(h, snapshotShadowGen)
+			}
+			return 0, true
+		}
+		if pin {
+			attachedPins++
+		}
+	}
+	for _, fh := range ordered {
+		fh.Unlinked = true
+	}
+	return attachedPins, false
+}
+
+func (fs *Dat9FS) rollbackUnlinkedSnapshotAttachLocked(fh *FileHandle, snapshotShadowGen uint64) {
+	if fh == nil || fh.Unlinked {
+		return
+	}
+	fh.UnlinkedData = nil
+	fh.UnlinkedSnapshot = false
+	fh.UnlinkedSize = 0
+	fh.UnlinkedSnapshotRev = 0
+	fh.UnlinkedSnapshotSize = 0
+	if gen := fh.UnlinkedShadowGen; gen != 0 {
+		fh.UnlinkedShadowGen = 0
+		if gen != snapshotShadowGen && fs != nil && fs.shadowStore != nil {
+			fs.shadowStore.Unpin(gen)
+		}
+	}
 }
 
 func (fs *Dat9FS) attachUnlinkedHandleSnapshotLocked(fh *FileHandle, p string, snapshot []byte, snapshotShadowGen uint64, size, revision int64, snapshotOK bool) (attachedPin bool, fail bool) {
@@ -7838,8 +7871,8 @@ func (fs *Dat9FS) loadUnlinkedHandlePart(fh *FileHandle, offset, length int64) (
 // unmarkOpenHandlesAfterFailedUnlink rolls back markOpenHandlesUnlinked when
 // the remote DELETE fails: the directory entry still exists remotely, so the
 // handles must return to normal — otherwise every later Flush/Fsync/Release
-// takes the unlinked-discard branch and silently drops their dirty/staged
-// data. handles must be the exact set snapshotted before the mark pass;
+// skips remote publish. Fsync/Flush keep Dirty, but Release would still
+// discard. handles must be the exact set snapshotted before the mark pass;
 // handles released in between are skipped via the inode-index liveness check
 // in RelinkPath (their Release already ran the normal lifecycle).
 //
@@ -13079,8 +13112,9 @@ func (fs *Dat9FS) syncWriteHandleToRemoteLocked(ctx context.Context, fh *FileHan
 		// Write-after-unlink on a write-sync handle: POSIX requires the write
 		// to succeed on the anonymous fd (the data is already in the Dirty
 		// buffer and remains readable), but it must NOT recreate the deleted
-		// pathname remotely. Flush/Fsync/Release discard staged state via the
-		// unlinked guards; the write-sync Write path must not upload either.
+		// pathname remotely. Flush/Fsync cancel path-keyed staging via the
+		// unlinked guards without dropping Dirty; Release discards on close.
+		// The write-sync Write path must not upload either.
 		return gofuse.OK
 	}
 	if handled, status, _ := fs.routeAppendLogLocked(ctx, fh); handled {
@@ -13314,8 +13348,9 @@ func (fs *Dat9FS) syncHandleToRemoteWithoutAppendLogLocked(ctx context.Context, 
 		return gofuse.OK
 	}
 	if fh.Unlinked {
-		// Path was removed while open; never re-upload discarded content.
-		fs.discardUnlinkedHandleStateLocked(fh)
+		// Path was removed while open; never re-upload. Keep Dirty so a
+		// successful write-after-unlink stays readable on this fd.
+		fs.cancelUnlinkedRemotePublishLocked(fh)
 		return gofuse.OK
 	}
 	if fs.clearStaleSQLitePersistentJournalEmptyCreateLocked(fh) {
@@ -13381,7 +13416,7 @@ func (fs *Dat9FS) syncHandleToRemoteWithoutAppendLogLocked(ctx context.Context, 
 			fs.recordAppendLogFullRewrite(uint64(size))
 		}
 		if fh.Unlinked {
-			fs.discardUnlinkedHandleStateLocked(fh)
+			fs.cancelUnlinkedRemotePublishLocked(fh)
 			return gofuse.OK
 		}
 		if fh.Path != handlePath || fh.DirtySeq != mutationSeq {
@@ -13583,10 +13618,11 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 
 	// Unlink-while-open: never re-stage write-back or upload. Doing so
 	// resurrects the path after Unlink's remote DELETE and makes parent
-	// rmdir return ENOTEMPTY (pjdfstest unlink/14.t).
+	// rmdir return ENOTEMPTY (pjdfstest unlink/14.t). Keep Dirty so
+	// write-after-unlink remains readable if unlink later retries.
 	if fh.Unlinked {
 		phase = "unlinked-discard"
-		fs.discardUnlinkedHandleStateLocked(fh)
+		fs.cancelUnlinkedRemotePublishLocked(fh)
 		return gofuse.OK
 	}
 	if fs.discardSupersededMutationLocked(fh) {
@@ -13837,11 +13873,11 @@ func (fs *Dat9FS) Flush(cancel <-chan struct{}, input *gofuse.FlushIn) (status g
 			}
 			// If Unlink completed while remoteCommitLock was released (it
 			// serializes DELETE after our PUT via the same lock), the path is
-			// already deleted. Discard local staging and do not re-publish
-			// handle committed state.
+			// already deleted. Cancel path-keyed staging and do not re-publish
+			// handle committed state. Keep Dirty for anonymous-fd reads.
 			if fh.Unlinked {
 				phase = "unlinked-after-shadowspill-upload"
-				fs.discardUnlinkedHandleStateLocked(fh)
+				fs.cancelUnlinkedRemotePublishLocked(fh)
 				return gofuse.OK
 			}
 			if gvisorCompat && (fh.Path != handlePath || fh.DirtySeq != mutationSeq) {
@@ -14018,9 +14054,10 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 	// Unlink-while-open: never stage/enqueue/upload. Fsync can otherwise
 	// re-enter commitQueue after Unlink's ordered drain and resurrect the
 	// deleted path (write → unlink → fsync → close → rmdir ENOTEMPTY).
+	// Keep Dirty so a successful write-after-unlink stays readable.
 	if fh.Unlinked {
 		phase = "unlinked-discard"
-		fs.discardUnlinkedHandleStateLocked(fh)
+		fs.cancelUnlinkedRemotePublishLocked(fh)
 		return gofuse.OK
 	}
 	if fs.discardSupersededMutationLocked(fh) {
@@ -14216,11 +14253,11 @@ func (fs *Dat9FS) Fsync(cancel <-chan struct{}, input *gofuse.FsyncIn) (status g
 		}
 		// If Unlink completed while remoteCommitLock was released (it
 		// serializes DELETE after our PUT via the same lock), the path is
-		// already deleted. Discard local staging and do not re-publish
-		// handle committed state.
+		// already deleted. Cancel path-keyed staging and do not re-publish
+		// handle committed state. Keep Dirty for anonymous-fd reads.
 		if fh.Unlinked {
 			phase = "unlinked-after-shadowspill-upload"
-			fs.discardUnlinkedHandleStateLocked(fh)
+			fs.cancelUnlinkedRemotePublishLocked(fh)
 			return gofuse.OK
 		}
 		if gvisorCompat && (fh.Path != handlePath || fh.DirtySeq != mutationSeq) {
@@ -15025,7 +15062,7 @@ func (fs *Dat9FS) flushHandleDebounced(ctx context.Context, fh *FileHandle, forc
 		// debounced PUT resurrects a just-deleted path and parent rmdir
 		// fails with ENOTEMPTY (pjdfstest unlink/14.t).
 		if handle.Unlinked {
-			fs.discardUnlinkedHandleStateLocked(handle)
+			fs.cancelUnlinkedRemotePublishLocked(handle)
 			handle.Unlock()
 			return
 		}
@@ -15208,7 +15245,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	}
 	if fh.Unlinked {
 		phase = "unlinked-discard"
-		fs.discardUnlinkedHandleStateLocked(fh)
+		fs.cancelUnlinkedRemotePublishLocked(fh)
 		return gofuse.OK
 	}
 	if fs.discardSupersededMutationLocked(fh) {
@@ -15379,7 +15416,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		}
 		if fh.Unlinked {
 			phase = "unlinked-after-streaming"
-			fs.discardUnlinkedHandleStateLocked(fh)
+			fs.cancelUnlinkedRemotePublishLocked(fh)
 			return gofuse.OK
 		}
 		if fh.Path != mutationPath || fh.DirtySeq != mutationSeq {
@@ -15463,7 +15500,7 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 		}
 		if fh.Unlinked {
 			phase = "unlinked-after-upload-all"
-			fs.discardUnlinkedHandleStateLocked(fh)
+			fs.cancelUnlinkedRemotePublishLocked(fh)
 			return gofuse.OK
 		}
 		if fh.Path != mutationPath || fh.DirtySeq != mutationSeq {
@@ -15751,10 +15788,11 @@ func (fs *Dat9FS) flushHandle(ctx context.Context, fh *FileHandle) (status gofus
 	}
 	// If Unlink completed after we released remoteCommitLock (it serializes
 	// DELETE after our PUT via the same lock), the path is already deleted.
-	// Discard local staging and do not re-publish handle committed state.
+	// Cancel path-keyed staging and do not re-publish handle committed state.
+	// Keep Dirty so the anonymous fd can still read the bytes just uploaded.
 	if fh.Unlinked {
 		phase = "unlinked-after-upload"
-		fs.discardUnlinkedHandleStateLocked(fh)
+		fs.cancelUnlinkedRemotePublishLocked(fh)
 		return gofuse.OK
 	}
 	if err := fs.applyPendingModeWithTimeoutLocked(fh); err != nil {

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7622,6 +7622,30 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 	return handles, true, nil
 }
 
+// forceMarkOpenHandlesUnlinkedAfterCommit marks still-linked open handles
+// for p after DELETE/whiteout has already committed. It locks one handle at
+// a time so it cannot form the whole-set ABBA deadlock; partial Unlinked is
+// required here because the name is gone and a later Flush must not publish.
+func (fs *Dat9FS) forceMarkOpenHandlesUnlinkedAfterCommit(p string) bool {
+	if fs == nil || fs.openHandles == nil || p == "" {
+		return false
+	}
+	handles := fs.openHandles.SnapshotPath(p)
+	any := false
+	for _, fh := range handles {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		_, _ = fs.attachUnlinkedHandleSnapshotLocked(fh, p, nil, 0, 0, 0, false)
+		fh.Unlinked = true
+		fh.Unlock()
+		any = true
+	}
+	fs.openHandles.UnlinkPath(p)
+	return any
+}
+
 // attachAndMarkOpenHandles attaches unlink snapshots and sets Unlinked on the
 // whole captured handle set under one multi-handle lock hold. The set is
 // acquired with TryLock only; a failed attempt drops every lock already
@@ -9752,7 +9776,10 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// now so their later write/flush/release is suppressed too and the
 		// overlay entry cannot be upserted back over the whiteout.
 		if _, _, markErr := fs.markOpenHandlesUnlinked(ctx, childP, false); markErr != nil {
-			return httpToFuseStatus(markErr)
+			// Whiteout already committed. Do not return EIO with unmarked
+			// fds: an in-memory Dirty git handle can still upsert over the
+			// whiteout. Mark one-at-a-time instead of aborting Unlink.
+			fs.forceMarkOpenHandlesUnlinkedAfterCommit(childP)
 		}
 		parentPath, _ := fs.inodes.GetPath(header.NodeId)
 		fs.dirCache.Remove(parentPath, name)
@@ -9964,8 +9991,9 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	// so their Flush/Fsync/Release guards see fh.Unlinked and cannot
 	// resurrect the path.
 	if _, anyOpen, markErr := fs.markOpenHandlesUnlinked(ctx, childP, false); markErr != nil {
-		status = httpToFuseStatus(markErr)
-		return status
+		if fs.forceMarkOpenHandlesUnlinkedAfterCommit(childP) {
+			preserveOpen = true
+		}
 	} else if anyOpen {
 		preserveOpen = true
 	}

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -7645,7 +7645,7 @@ func (fs *Dat9FS) forceMarkOpenHandlesUnlinkedAfterCommit(p string) bool {
 		}
 		fh.Lock()
 		_, _ = fs.attachUnlinkedHandleSnapshotLocked(fh, p, nil, 0, 0, 0, false)
-		fh.Unlinked = true
+		fs.markHandleUnlinkedLocked(fh)
 		fh.Unlock()
 		any = true
 	}
@@ -7717,7 +7717,7 @@ func (fs *Dat9FS) attachAndMarkOpenHandlesLocked(ordered []*FileHandle, p string
 		}
 	}
 	for _, fh := range ordered {
-		fh.Unlinked = true
+		fs.markHandleUnlinkedLocked(fh)
 	}
 	return attachedPins, false
 }
@@ -8001,6 +8001,7 @@ func (fs *Dat9FS) unmarkOpenHandlesAfterFailedUnlink(p string, handles []*FileHa
 			continue
 		}
 		fh.Unlinked = false
+		fh.UnlinkedAttempt = 0
 		fh.UnlinkedData = nil
 		fh.UnlinkedSnapshot = false
 		fh.UnlinkedSize = 0

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -185,11 +185,15 @@ type Dat9FS struct {
 	gitOverlayWG      sync.WaitGroup
 	gitOverlaySeq     atomic.Uint64
 	gitOverlayPending map[string]map[string]pendingGitOverlayEntry
-	layerMu           sync.RWMutex
-	layerWhiteouts    map[string]struct{}
-	layerFiles        map[string]uint32
-	layerDirs         map[string]uint32
-	layerSymlinks     map[string]layerSymlinkState
+	// gitOverlayUnlinkBlocked counts in-flight git Unlink operations per
+	// overlay path. Upserts that reserved a queue slot during Unlink must
+	// not publish after waiting for the whiteout slot.
+	gitOverlayUnlinkBlocked map[string]int
+	layerMu                 sync.RWMutex
+	layerWhiteouts          map[string]struct{}
+	layerFiles              map[string]uint32
+	layerDirs               map[string]uint32
+	layerSymlinks           map[string]layerSymlinkState
 	// layerAbandoned is set when the layer-event watcher observes a
 	// rollback event, signalling that the mounted layer is now abandoned.
 	// Subsequent write ops short-circuit with errLayerRolledBack (→ ESTALE)
@@ -9762,6 +9766,10 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 		// write fails, the directory entry still exists authoritatively, so
 		// the marking is rolled back — otherwise every later write/flush on
 		// those handles would keep being suppressed and silently drop data.
+		if rt, rel, ok := fs.gitWorkspaceForPath(ctx, childP); ok && rel != "" {
+			fs.blockGitOverlayUnlinkPublish(rt.workspace.WorkspaceID, rel)
+			defer fs.unblockGitOverlayUnlinkPublish(rt.workspace.WorkspaceID, rel)
+		}
 		markedGitHandles, _, markErr := fs.markOpenHandlesUnlinked(ctx, childP, false)
 		if markErr != nil {
 			return httpToFuseStatus(markErr)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -186,14 +186,17 @@ type Dat9FS struct {
 	gitOverlaySeq     atomic.Uint64
 	gitOverlayPending map[string]map[string]pendingGitOverlayEntry
 	// gitOverlayUnlinkBlocked counts in-flight git Unlink operations per
-	// overlay path. Upserts that reserved a queue slot during Unlink must
-	// not publish after waiting for the whiteout slot.
-	gitOverlayUnlinkBlocked map[string]int
-	layerMu                 sync.RWMutex
-	layerWhiteouts          map[string]struct{}
-	layerFiles              map[string]uint32
-	layerDirs               map[string]uint32
-	layerSymlinks           map[string]layerSymlinkState
+	// overlay path. Attempt/committed gens stamp queued upserts so they
+	// stay suppressed after a successful whiteout even once Unlink returns,
+	// without swallowing Fsync after a failed delete.
+	gitOverlayUnlinkBlocked   map[string]int
+	gitOverlayUnlinkAttempt   map[string]uint64
+	gitOverlayUnlinkCommitted map[string]uint64
+	layerMu                   sync.RWMutex
+	layerWhiteouts            map[string]struct{}
+	layerFiles                map[string]uint32
+	layerDirs                 map[string]uint32
+	layerSymlinks             map[string]layerSymlinkState
 	// layerAbandoned is set when the layer-event watcher observes a
 	// rollback event, signalling that the mounted layer is now abandoned.
 	// Subsequent write ops short-circuit with errLayerRolledBack (→ ESTALE)

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -180,11 +180,15 @@ type Dat9FS struct {
 	// gitOverlayTail serializes background git workspace overlay commits so
 	// compound operations such as rename copy+whiteout reach the backend in
 	// the same order they became visible locally.
-	gitOverlayMu      sync.Mutex
-	gitOverlayTail    chan struct{}
-	gitOverlayWG      sync.WaitGroup
-	gitOverlaySeq     atomic.Uint64
-	gitOverlayPending map[string]map[string]pendingGitOverlayEntry
+	gitOverlayMu   sync.Mutex
+	gitOverlayTail chan struct{}
+	gitOverlayWG   sync.WaitGroup
+	gitOverlaySeq  atomic.Uint64
+	// gitOverlayPending records, per workspace and path, the ordered list of
+	// live-relevant local overlay applies that have not been confirmed on the
+	// remote, so a workspace refresh can replay every one of them — not just
+	// the top of the stack. Seq order matches apply order.
+	gitOverlayPending map[string]map[string][]pendingGitOverlayEntry
 	// gitOverlayUnlinkBlocked counts in-flight git Unlink operations per
 	// overlay path. Attempt/committed gens stamp queued upserts so they
 	// stay suppressed after a successful whiteout even once Unlink returns,
@@ -440,7 +444,7 @@ func NewDat9FS(c *client.Client, opts *MountOptions) *Dat9FS {
 		localOverlay:      NewLocalOverlay(opts.LocalRoot),
 		git:               newGitWorkspaceLayer(),
 		gitCheckpoints:    newFlushDebouncer(gitCheckpointDebounce),
-		gitOverlayPending: make(map[string]map[string]pendingGitOverlayEntry),
+		gitOverlayPending: make(map[string]map[string][]pendingGitOverlayEntry),
 		readFlight:        NewSingleFlight(),
 		remoteReadTimeout: fuseTimeout,
 		xattrs:            NewXAttrStore(),

--- a/pkg/fuse/dat9fs.go
+++ b/pkg/fuse/dat9fs.go
@@ -465,6 +465,12 @@ const fuseTimeout = 30 * time.Second
 // the lock holder releases fh.mu during the actual HTTP transfer.
 const flushLockTimeout = 60 * time.Second
 
+// unlinkHandleSetLockTimeout bounds how long Unlink waits to TryLock the
+// whole captured handle set. The set is acquired with TryLock only: a
+// failed attempt drops every lock already taken and retries, so Unlink
+// never blocks holding a partial set against sibling-mode cleanup.
+const unlinkHandleSetLockTimeout = 15 * time.Second
+
 const (
 	// lookupTransientRetryCount is the number of detached retries after the
 	// initial Lookup StatCtx attempt fails with a transient error.
@@ -7482,14 +7488,7 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 	if len(handles) == 0 {
 		return nil, false, nil
 	}
-	for _, fh := range handles {
-		if fh == nil {
-			continue
-		}
-		fh.Lock()
-		dropStalePreinstalledUnlinkSnapshotLocked(fh)
-		fh.Unlock()
-	}
+	dropStalePreinstalledUnlinkSnapshots(handles)
 
 	size, revision := fs.pathUnlinkedSnapshotIdentity(p)
 
@@ -7501,14 +7500,10 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		const maxUnlinkedRemoteSnapshotAttempts = 3
 		var staleAfterFetch bool
 		for attempt := 0; attempt < maxUnlinkedRemoteSnapshotAttempts; attempt++ {
-			for _, fh := range handles {
-				if fh == nil {
-					continue
-				}
-				fh.Lock()
-				dropStalePreinstalledUnlinkSnapshotLocked(fh)
-				fh.Unlock()
-			}
+			// Drop before unlinkedRemoteSnapshotStale: that check treats a
+			// handle with any preinstalled snapshot as not-needing, so a
+			// stale UnlinkedData would otherwise hide a concurrent commit.
+			dropStalePreinstalledUnlinkSnapshots(handles)
 			if snapshotShadowGen != 0 {
 				fs.discardUnlinkedSnapshotPins(snapshotShadowGen, snapshotNeedCount)
 				snapshotShadowGen = 0
@@ -7575,8 +7570,12 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 					continue
 				}
 			}
-			attachedSnapshotPins, attachFailed := fs.attachAndMarkOpenHandles(handles, p, snapshot, snapshotShadowGen, size, revision, snapshotOK, true)
+			failClosed := true
+			attachedSnapshotPins, attachFailed := fs.attachAndMarkOpenHandles(handles, p, snapshot, snapshotShadowGen, size, revision, snapshotOK, failClosed)
 			if attachFailed {
+				if attachedSnapshotPins > snapshotNeedCount {
+					snapshotNeedCount = attachedSnapshotPins
+				}
 				staleAfterFetch = true
 				continue
 			}
@@ -7603,25 +7602,67 @@ func (fs *Dat9FS) markOpenHandlesUnlinked(ctx context.Context, p string, snapsho
 		}
 	}
 
-	_, _ = fs.attachAndMarkOpenHandles(handles, p, snapshot, snapshotShadowGen, size, revision, snapshotOK, false)
+	failClosed := false
+	_, _ = fs.attachAndMarkOpenHandles(handles, p, snapshot, snapshotShadowGen, size, revision, snapshotOK, failClosed)
 	fs.openHandles.UnlinkPath(p)
 	return handles, true, nil
 }
 
 // attachAndMarkOpenHandles attaches unlink snapshots and sets Unlinked on the
-// whole captured handle set under one multi-handle lock hold. If failClosed
-// is set and any handle cannot take the snapshot, no handle is left Unlinked
-// and attached snapshot state from this pass is rolled back.
+// whole captured handle set under one multi-handle lock hold. The set is
+// acquired with TryLock only; a failed attempt drops every lock already
+// taken and retries, so this never blocks holding a partial set against
+// sibling-mode cleanup (layer flush/Fsync holds one fh.mu then Lock()s
+// other same-inode handles). If failClosed is set and any handle cannot
+// take the snapshot, no handle is left Unlinked and attached snapshot
+// state from this pass is rolled back.
+//
+// Shadow pin ownership: snapshotShadowGen pins are created for
+// snapshotNeedCount and released by the mark loop via
+// discardUnlinkedSnapshotPins (or leftover unpin after a successful attach).
+// Per-handle pins from PinIfExists belong to the handle and are unpinned by
+// rollbackUnlinkedSnapshotAttachLocked / unmark / Release. Do not unify those
+// two Unpin rules.
 func (fs *Dat9FS) attachAndMarkOpenHandles(handles []*FileHandle, p string, snapshot []byte, snapshotShadowGen uint64, size, revision int64, snapshotOK bool, failClosed bool) (attachedPins int, failed bool) {
-	ordered := lockFileHandlesInOrder(handles)
-	defer unlockFileHandles(ordered)
+	deadline := time.Now().Add(unlinkHandleSetLockTimeout)
+	for {
+		ordered, ok := tryLockFileHandlesInOrder(handles)
+		if !ok {
+			if !time.Now().Before(deadline) {
+				return 0, true
+			}
+			time.Sleep(time.Millisecond)
+			continue
+		}
+		attachedPins, failed = fs.attachAndMarkOpenHandlesLocked(ordered, p, snapshot, snapshotShadowGen, size, revision, snapshotOK, failClosed)
+		unlockFileHandles(ordered)
+		return attachedPins, failed
+	}
+}
+
+func (fs *Dat9FS) attachAndMarkOpenHandlesLocked(ordered []*FileHandle, p string, snapshot []byte, snapshotShadowGen uint64, size, revision int64, snapshotOK bool, failClosed bool) (attachedPins int, failed bool) {
+	if failClosed && snapshotOK {
+		// Re-check path identity while every captured fh.mu is held. A
+		// concurrent Fsync may have published a new committed revision
+		// while its handle lock was released around the PUT; the writer's
+		// BaseRev adoption is blocked here, so only the path map sees it.
+		// Do not call unlinkedRemoteSnapshotStale here: it takes fh.Lock
+		// per handle and would self-deadlock under this multi-hold.
+		curSize, curRev := fs.pathUnlinkedSnapshotIdentity(p)
+		if revision > 0 && curRev > 0 && curRev != revision {
+			return 0, true
+		}
+		if size > 0 && curSize > 0 && curSize != size {
+			return 0, true
+		}
+	}
 	for _, fh := range ordered {
 		pin, fail := fs.attachUnlinkedHandleSnapshotLocked(fh, p, snapshot, snapshotShadowGen, size, revision, snapshotOK)
 		if fail && failClosed {
 			for _, h := range ordered {
 				fs.rollbackUnlinkedSnapshotAttachLocked(h, snapshotShadowGen)
 			}
-			return 0, true
+			return attachedPins, true
 		}
 		if pin {
 			attachedPins++
@@ -7633,6 +7674,11 @@ func (fs *Dat9FS) attachAndMarkOpenHandles(handles []*FileHandle, p string, snap
 	return attachedPins, false
 }
 
+// rollbackUnlinkedSnapshotAttachLocked drops snapshot state attached in a
+// fail-closed mark pass that did not set Unlinked. Shared snapshotShadowGen
+// pins stay with the mark loop (discardUnlinkedSnapshotPins on retry);
+// only a per-handle PinIfExists generation is unpinned here. Already
+// Unlinked handles are left alone — those pins are committed to the fd.
 func (fs *Dat9FS) rollbackUnlinkedSnapshotAttachLocked(fh *FileHandle, snapshotShadowGen uint64) {
 	if fh == nil || fh.Unlinked {
 		return
@@ -7644,9 +7690,20 @@ func (fs *Dat9FS) rollbackUnlinkedSnapshotAttachLocked(fh *FileHandle, snapshotS
 	fh.UnlinkedSnapshotSize = 0
 	if gen := fh.UnlinkedShadowGen; gen != 0 {
 		fh.UnlinkedShadowGen = 0
-		if gen != snapshotShadowGen && fs != nil && fs.shadowStore != nil {
+		if gen != snapshotShadowGen && fs.shadowStore != nil {
 			fs.shadowStore.Unpin(gen)
 		}
+	}
+}
+
+func dropStalePreinstalledUnlinkSnapshots(handles []*FileHandle) {
+	for _, fh := range handles {
+		if fh == nil {
+			continue
+		}
+		fh.Lock()
+		dropStalePreinstalledUnlinkSnapshotLocked(fh)
+		fh.Unlock()
 	}
 }
 
@@ -7769,10 +7826,12 @@ func (fs *Dat9FS) pathUnlinkedSnapshotIdentity(p string) (size, rev int64) {
 	if fs == nil || p == "" {
 		return 0, 0
 	}
-	if ino, ok := fs.inodes.GetInode(p); ok {
-		if entry, ok := fs.inodes.GetEntry(ino); ok && entry != nil {
-			size = entry.Size
-			rev = entry.Revision
+	if fs.inodes != nil {
+		if ino, ok := fs.inodes.GetInode(p); ok {
+			if entry, ok := fs.inodes.GetEntry(ino); ok && entry != nil {
+				size = entry.Size
+				rev = entry.Revision
+			}
 		}
 	}
 	if cr := fs.latestCommittedRevision(p); cr > rev {
@@ -7901,9 +7960,10 @@ func (fs *Dat9FS) unmarkOpenHandlesAfterFailedUnlink(p string, handles []*FileHa
 		fh.UnlinkedSnapshotSize = 0
 		if gen := fh.UnlinkedShadowGen; gen != 0 && fs.shadowStore != nil {
 			fh.UnlinkedShadowGen = 0
-			// The mark-time pin is simply dropped: with the deferred commit
-			// point, the staged shadow was never removed or retired, so the
-			// handle keeps reading it by path like any normal handle.
+			// Unmark always unpins: attach already consumed a pin for this
+			// fd (shared snapshotShadowGen or PinIfExists). Unlike
+			// rollbackUnlinkedSnapshotAttachLocked, the mark loop will not
+			// discardUnlinkedSnapshotPins for a completed mark pass.
 			fs.shadowStore.Unpin(gen)
 		}
 		fh.Unlock()
@@ -9703,9 +9763,10 @@ func (fs *Dat9FS) Unlink(cancel <-chan struct{}, header *gofuse.InHeader, name s
 	//
 	// Two ordering constraints force this position:
 	//
-	// 1. markOpenHandlesUnlinked takes fh.mu per handle, and every other code
-	//    path acquires fh.mu before remoteCommitLock (Write, Flush, the
-	//    debounced callback — see the B13 note in flushHandleDebounced).
+	// 1. markOpenHandlesUnlinked takes fh.mu for the whole captured handle
+	//    set (pointer order), and every other code path acquires fh.mu before
+	//    remoteCommitLock (Write, Flush, the debounced callback — see the
+	//    B13 note in flushHandleDebounced).
 	//    Running it while holding remoteCommitLock inverts that order: a
 	//    same-path flush holding fh.mu and waiting on remoteCommitLock would
 	//    deadlock with Unlink holding remoteCommitLock and waiting on fh.mu

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -3414,28 +3415,27 @@ func TestAttachAndMarkRetriesInsteadOfDeadlockingSiblingModeClear(t *testing.T) 
 	if len(ordered) != 2 {
 		t.Fatalf("lock order len = %d, want 2", len(ordered))
 	}
-	first, second := ordered[0], ordered[1]
+	_, second := ordered[0], ordered[1]
 
 	second.Lock()
+	entered := make(chan struct{})
+	var enterOnce sync.Once
+	testHookAfterUnlinkHandleSetLockAttempt = func() {
+		enterOnce.Do(func() { close(entered) })
+	}
+	t.Cleanup(func() { testHookAfterUnlinkHandleSetLockAttempt = nil })
+
 	attachDone := make(chan struct{})
 	go func() {
 		defer close(attachDone)
 		snapshotOK, failClosed := false, false
 		_, _ = fs.attachAndMarkOpenHandles([]*FileHandle{fhA, fhB}, "/a.bin", nil, 0, 0, 0, snapshotOK, failClosed)
 	}()
-
-	deadline := time.Now().Add(2 * time.Second)
-	for {
-		if first.TryLock() {
-			first.Unlock()
-			break
-		}
-		if time.Now().After(deadline) {
-			t.Fatal("attachAndMark still holding the first handle while waiting for the second")
-		}
-		time.Sleep(time.Millisecond)
+	select {
+	case <-entered:
+	case <-time.After(2 * time.Second):
+		t.Fatal("attachAndMark never reported a failed set-lock attempt")
 	}
-
 	siblingDone := make(chan struct{})
 	go func() {
 		defer close(siblingDone)
@@ -3451,6 +3451,43 @@ func TestAttachAndMarkRetriesInsteadOfDeadlockingSiblingModeClear(t *testing.T) 
 	case <-attachDone:
 	case <-time.After(2 * time.Second):
 		t.Fatal("attachAndMark deadlocked after sibling unlock")
+	}
+}
+
+func TestMarkOpenHandlesUnlinkedFailClosedKeepsPathIndexOnLockTimeout(t *testing.T) {
+	const path = "/a.bin"
+	fhA := &FileHandle{Ino: 1, Path: path}
+	fhB := &FileHandle{Ino: 1, Path: path}
+	fs := &Dat9FS{openHandles: NewOpenHandleIndex()}
+	fs.openHandles.Add(fhA)
+	fs.openHandles.Add(fhB)
+	ordered := fileHandlesLockOrder([]*FileHandle{fhA, fhB})
+	second := ordered[1]
+
+	oldTimeout := unlinkHandleSetLockTimeout
+	unlinkHandleSetLockTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { unlinkHandleSetLockTimeout = oldTimeout })
+
+	testHookBeforeUnlinkedTransition = func() {
+		second.Lock()
+	}
+	t.Cleanup(func() {
+		testHookBeforeUnlinkedTransition = nil
+		second.Unlock()
+	})
+
+	marked, anyOpen, err := fs.markOpenHandlesUnlinked(context.Background(), path, false)
+	if !errors.Is(err, syscall.EIO) {
+		t.Fatalf("markOpenHandlesUnlinked err = %v, want EIO", err)
+	}
+	if anyOpen || marked != nil {
+		t.Fatalf("marked/anyOpen = %v/%t, want nil/false", marked, anyOpen)
+	}
+	if fhA.Unlinked || fhB.Unlinked {
+		t.Fatal("lock timeout must not set Unlinked")
+	}
+	if got := fs.openHandles.SnapshotPath(path); len(got) != 2 {
+		t.Fatalf("SnapshotPath len = %d, want 2 (index must be kept)", len(got))
 	}
 }
 

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -3355,6 +3355,180 @@ func TestUnlinkMarkWindowConcurrentFsyncKeepsOverlay(t *testing.T) {
 	}
 }
 
+func TestAttachAndMarkOpenHandlesDoesNotPartiallyUnlink(t *testing.T) {
+	wb1 := NewWriteBuffer("/a.bin", 1<<20, 64)
+	wb1.remoteSize = 192
+	wb1.LoadPart = func(int) ([]byte, error) { return []byte("x"), nil }
+	fh1 := &FileHandle{Dirty: wb1, BaseRev: 1, Path: "/a.bin"}
+	wb2 := NewWriteBuffer("/a.bin", 1<<20, 64)
+	wb2.remoteSize = 192
+	wb2.LoadPart = func(int) ([]byte, error) { return []byte("x"), nil }
+	fh2 := &FileHandle{Dirty: wb2, BaseRev: 2, Path: "/a.bin"}
+	fs := &Dat9FS{}
+	snapshot := bytes.Repeat([]byte{0x88}, 192)
+	_, fail := fs.attachAndMarkOpenHandles([]*FileHandle{fh1, fh2}, "/a.bin", snapshot, 0, 192, 1, true, true)
+	if !fail {
+		t.Fatal("stale second handle must fail closed")
+	}
+	if fh1.Unlinked || fh2.Unlinked {
+		t.Fatal("no handle may be Unlinked when the set cannot commit")
+	}
+	if len(fh1.UnlinkedData) != 0 || len(fh2.UnlinkedData) != 0 {
+		t.Fatal("failed mark pass must not leave a partial snapshot attached")
+	}
+}
+
+func TestUnlinkTwoHandleMarkRetryKeepsFsyncedOverlays(t *testing.T) {
+	const filePath = "/spill-two-fd-unlink-fsync.bin"
+	const partSize int64 = 64
+	original := bytes.Repeat([]byte{0x88}, int(3*partSize))
+	overlayA := []byte{0xAA, 0xBB}
+	overlayB := []byte{0xCC, 0xDD}
+
+	var mu sync.Mutex
+	var committed []byte
+	var revision int64
+	var puts atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Query().Has("list"):
+			_ = json.NewEncoder(w).Encode(map[string]any{"entries": []any{}})
+		case r.Method == http.MethodGet:
+			mu.Lock()
+			body := append([]byte(nil), committed...)
+			mu.Unlock()
+			if len(body) == 0 {
+				http.NotFound(w, r)
+				return
+			}
+			_, _ = w.Write(body)
+		case r.Method == http.MethodPut:
+			body, _ := io.ReadAll(r.Body)
+			got, err := strconv.ParseInt(r.Header.Get("X-Dat9-Expected-Revision"), 10, 64)
+			if err != nil {
+				http.Error(w, "revision", http.StatusBadRequest)
+				return
+			}
+			mu.Lock()
+			if got != revision {
+				mu.Unlock()
+				http.Error(w, "revision conflict", http.StatusConflict)
+				return
+			}
+			committed = append([]byte(nil), body...)
+			revision++
+			rev := revision
+			mu.Unlock()
+			puts.Add(1)
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Dat9-Revision", strconv.FormatInt(rev, 10))
+			_ = json.NewEncoder(w).Encode(map[string]any{"status": "ok", "revision": rev})
+		case r.Method == http.MethodDelete:
+			mu.Lock()
+			committed = nil
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusOK)
+		}
+	}))
+	defer ts.Close()
+
+	fs, fhIDA, nodeID, _ := newStrictSmallPartSpillFS(t, ts.URL, filePath, partSize)
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhIDA}, original); st != gofuse.OK {
+		t.Fatalf("seed Write: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhIDA}); st != gofuse.OK {
+		t.Fatalf("seed Fsync: %v", st)
+	}
+
+	var openOut gofuse.OpenOut
+	if st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: nodeID},
+		Flags:    uint32(syscall.O_RDWR),
+	}, &openOut); st != gofuse.OK {
+		t.Fatalf("Open second fd: %v", st)
+	}
+	fhIDB := openOut.Fh
+
+	var once sync.Once
+	testHookBeforeUnlinkedTransition = func() {
+		once.Do(func() {
+			if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhIDA, Offset: 8}, overlayA); st != gofuse.OK {
+				t.Errorf("fd A write: %v", st)
+				return
+			}
+			if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhIDA}); st != gofuse.OK {
+				t.Errorf("fd A Fsync: %v", st)
+				return
+			}
+			if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhIDB, Offset: 8}, overlayB); st != gofuse.OK {
+				t.Errorf("fd B write: %v", st)
+				return
+			}
+			if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhIDB}); st != gofuse.OK {
+				t.Errorf("fd B Fsync: %v", st)
+			}
+		})
+	}
+	t.Cleanup(func() { testHookBeforeUnlinkedTransition = nil })
+
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: 1}, strings.TrimPrefix(filePath, "/")); st != gofuse.OK {
+		t.Fatalf("Unlink: %v", st)
+	}
+
+	readPrefix := func(fhID uint64) []byte {
+		t.Helper()
+		buf := make([]byte, 16)
+		result, rst := fs.Read(nil, &gofuse.ReadIn{
+			InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhID, Size: uint32(len(buf)),
+		}, buf)
+		if rst != gofuse.OK {
+			t.Fatalf("Read fh=%d: %v", fhID, rst)
+		}
+		got, _ := result.Bytes(buf)
+		return append([]byte(nil), got...)
+	}
+	gotA := readPrefix(fhIDA)
+	gotB := readPrefix(fhIDB)
+	wantB := append(bytes.Repeat([]byte{0x88}, 8), overlayB...)
+	wantB = append(wantB, bytes.Repeat([]byte{0x88}, 6)...)
+	if !bytes.Equal(gotB, wantB) {
+		t.Fatalf("fd B read = %x, want fsynced overlay %x", gotB, wantB)
+	}
+	if !bytes.Equal(gotA, gotB) && !bytes.Equal(gotA, append(append(bytes.Repeat([]byte{0x88}, 8), overlayA...), bytes.Repeat([]byte{0x88}, 6)...)) {
+		t.Fatalf("fd A read = %x, want fd B overlay %x or fd A overlay", gotA, wantB)
+	}
+	if puts.Load() < 3 {
+		t.Fatalf("puts = %d, want >=3 (seed + both mark-window fsyncs)", puts.Load())
+	}
+
+	afterOverlay := []byte{0x11, 0x22}
+	if _, st := fs.Write(nil, &gofuse.WriteIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhIDA, Offset: 8}, afterOverlay); st != gofuse.OK {
+		t.Fatalf("write-after-unlink: %v", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhIDA}); st != gofuse.OK {
+		t.Fatalf("fsync-after-unlink: %v", st)
+	}
+	gotAfter := readPrefix(fhIDA)
+	wantAfter := append(bytes.Repeat([]byte{0x88}, 8), afterOverlay...)
+	wantAfter = append(wantAfter, bytes.Repeat([]byte{0x88}, 6)...)
+	if !bytes.Equal(gotAfter, wantAfter) {
+		t.Fatalf("fd A after unlink fsync = %x, want %x", gotAfter, wantAfter)
+	}
+
+	putsAfterUnlink := puts.Load()
+	if st := fs.Flush(nil, &gofuse.FlushIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhIDA}); st != gofuse.OK {
+		t.Fatalf("Flush A: %v", st)
+	}
+	if st := fs.Flush(nil, &gofuse.FlushIn{InHeader: gofuse.InHeader{NodeId: nodeID}, Fh: fhIDB}); st != gofuse.OK {
+		t.Fatalf("Flush B: %v", st)
+	}
+	if puts.Load() != putsAfterUnlink {
+		t.Fatalf("flush after unlink resurrected path (puts=%d -> %d)", putsAfterUnlink, puts.Load())
+	}
+}
+
 func TestAttachUnlinkedHandleSnapshotDoesNotMarkWhenStale(t *testing.T) {
 	wb := NewWriteBuffer("/a.bin", 1<<20, 64)
 	wb.remoteSize = 192

--- a/pkg/fuse/fuse_test.go
+++ b/pkg/fuse/fuse_test.go
@@ -3366,7 +3366,8 @@ func TestAttachAndMarkOpenHandlesDoesNotPartiallyUnlink(t *testing.T) {
 	fh2 := &FileHandle{Dirty: wb2, BaseRev: 2, Path: "/a.bin"}
 	fs := &Dat9FS{}
 	snapshot := bytes.Repeat([]byte{0x88}, 192)
-	_, fail := fs.attachAndMarkOpenHandles([]*FileHandle{fh1, fh2}, "/a.bin", snapshot, 0, 192, 1, true, true)
+	snapshotOK, failClosed := true, true
+	_, fail := fs.attachAndMarkOpenHandles([]*FileHandle{fh1, fh2}, "/a.bin", snapshot, 0, 192, 1, snapshotOK, failClosed)
 	if !fail {
 		t.Fatal("stale second handle must fail closed")
 	}
@@ -3375,6 +3376,81 @@ func TestAttachAndMarkOpenHandlesDoesNotPartiallyUnlink(t *testing.T) {
 	}
 	if len(fh1.UnlinkedData) != 0 || len(fh2.UnlinkedData) != 0 {
 		t.Fatal("failed mark pass must not leave a partial snapshot attached")
+	}
+}
+
+func TestAttachAndMarkOpenHandlesFailsClosedOnPathIdentityAdvance(t *testing.T) {
+	wb := NewWriteBuffer("/a.bin", 1<<20, 64)
+	wb.remoteSize = 192
+	wb.LoadPart = func(int) ([]byte, error) { return []byte("x"), nil }
+	fh := &FileHandle{Dirty: wb, BaseRev: 1, Path: "/a.bin"}
+	fs := &Dat9FS{
+		committedRev:  map[string]int64{"/a.bin": 2},
+		committedSize: map[string]int64{"/a.bin": 192},
+	}
+	snapshot := bytes.Repeat([]byte{0x88}, 192)
+	snapshotOK, failClosed := true, true
+	_, fail := fs.attachAndMarkOpenHandles([]*FileHandle{fh}, "/a.bin", snapshot, 0, 192, 1, snapshotOK, failClosed)
+	if !fail {
+		t.Fatal("path identity ahead of the fetched snapshot must fail closed")
+	}
+	if fh.Unlinked {
+		t.Fatal("must not set Unlinked when path identity advanced under the set lock")
+	}
+	if len(fh.UnlinkedData) != 0 {
+		t.Fatal("must not attach a snapshot after a path-identity fail-closed")
+	}
+}
+
+func TestAttachAndMarkRetriesInsteadOfDeadlockingSiblingModeClear(t *testing.T) {
+	const ino uint64 = 42
+	fhA := &FileHandle{Ino: ino, Path: "/a.bin", HasPendingMode: true, PendingMode: 0o644, PendingModeGen: 1}
+	fhB := &FileHandle{Ino: ino, Path: "/a.bin", HasPendingMode: true, PendingMode: 0o644, PendingModeGen: 1}
+	fs := &Dat9FS{fileHandles: NewHandleTable[*FileHandle]()}
+	fs.fileHandles.Allocate(fhA)
+	fs.fileHandles.Allocate(fhB)
+
+	ordered := fileHandlesLockOrder([]*FileHandle{fhA, fhB})
+	if len(ordered) != 2 {
+		t.Fatalf("lock order len = %d, want 2", len(ordered))
+	}
+	first, second := ordered[0], ordered[1]
+
+	second.Lock()
+	attachDone := make(chan struct{})
+	go func() {
+		defer close(attachDone)
+		snapshotOK, failClosed := false, false
+		_, _ = fs.attachAndMarkOpenHandles([]*FileHandle{fhA, fhB}, "/a.bin", nil, 0, 0, 0, snapshotOK, failClosed)
+	}()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		if first.TryLock() {
+			first.Unlock()
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("attachAndMark still holding the first handle while waiting for the second")
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	siblingDone := make(chan struct{})
+	go func() {
+		defer close(siblingDone)
+		fs.clearPendingModeForInodeGeneration(ino, second, 0o644, 1)
+	}()
+	select {
+	case <-siblingDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("clearPendingModeForInodeGeneration deadlocked with attachAndMark")
+	}
+	second.Unlock()
+	select {
+	case <-attachDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("attachAndMark deadlocked after sibling unlock")
 	}
 }
 

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -4267,12 +4267,7 @@ func (fs *Dat9FS) applyGitOverlayMirrorEntry(fh *FileHandle, size int64) {
 	if fs == nil || fh == nil || fh.Layer != PathLayerGitWorkspace || fh.GitWorkspaceID == "" || fh.GitRelPath == "" {
 		return
 	}
-	if fh.Unlinked {
-		// Open-unlink: the whiteout written by the gitEntry unlink path must
-		// stay authoritative in the live overlay and the pending map. An
-		// upsert mirror here would resurrect the deleted name in lookups,
-		// readdir and reads on the active mount even though the remote PUT
-		// is already suppressed by the git flush guards.
+	if fs.gitOverlayShouldSuppressPublishLocked(fh) {
 		return
 	}
 	entry := client.GitOverlayEntry{
@@ -4304,7 +4299,7 @@ func (fs *Dat9FS) applyGitOverlayMirrorEntryUnlessWhiteout(fh *FileHandle, size 
 	if fs == nil || fh == nil || fh.Layer != PathLayerGitWorkspace || fh.GitWorkspaceID == "" || fh.GitRelPath == "" {
 		return
 	}
-	if fh.Unlinked {
+	if fs.gitOverlayShouldSuppressPublishLocked(fh) {
 		return
 	}
 	entry := client.GitOverlayEntry{
@@ -4319,7 +4314,7 @@ func (fs *Dat9FS) applyGitOverlayMirrorEntryUnlessWhiteout(fh *FileHandle, size 
 		UpdatedAt:      time.Now(),
 	}
 	if _, blocked := fs.applyGitOverlayEntryUnlessWhiteout(fh.GitWorkspaceID, entry); blocked {
-		fh.Unlinked = true
+		fs.markHandleUnlinkedLocked(fh)
 		return
 	}
 	// Capture the pending seq so registration-time whiteout adoption can drop
@@ -4467,36 +4462,66 @@ func (fs *Dat9FS) noteGitOverlayUnlinkCommitted(workspaceID, rel string) {
 	fs.gitOverlayMu.Unlock()
 }
 
-func (fs *Dat9FS) gitOverlayShouldDropQueuedPublish(op, workspaceID, rel string, reservedAttempt uint64) bool {
-	if op == "whiteout" || reservedAttempt == 0 {
-		return false
+func (fs *Dat9FS) markHandleUnlinkedLocked(fh *FileHandle) {
+	if fh == nil {
+		return
 	}
-	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
+	fh.Unlinked = true
+	if fh.Layer != PathLayerGitWorkspace || fh.GitWorkspaceID == "" || fh.GitRelPath == "" {
+		return
+	}
+	key := gitOverlayUnlinkBlockKey(fh.GitWorkspaceID, fh.GitRelPath)
 	fs.gitOverlayMu.Lock()
-	committed := fs.gitOverlayUnlinkCommitted[key]
+	if fs.gitOverlayUnlinkBlocked[key] > 0 {
+		fh.UnlinkedAttempt = fs.gitOverlayUnlinkAttempt[key]
+	} else {
+		fh.UnlinkedAttempt = fs.gitOverlayUnlinkCommitted[key]
+	}
 	fs.gitOverlayMu.Unlock()
-	return committed >= reservedAttempt
 }
 
-func (fs *Dat9FS) gitOverlayUnlinkHasCommitted(workspaceID, rel string) bool {
-	if fs == nil || workspaceID == "" || rel == "" {
+func (fs *Dat9FS) gitOverlayShouldSuppressPublish(op, workspaceID, rel string, reservedAttempt uint64, fh *FileHandle) bool {
+	if op == "whiteout" {
 		return false
 	}
-	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
-	fs.gitOverlayMu.Lock()
-	committed := fs.gitOverlayUnlinkCommitted[key]
-	fs.gitOverlayMu.Unlock()
-	return committed > 0
+	var markAttempt uint64
+	var unlinked bool
+	if fh != nil {
+		fh.Lock()
+		markAttempt = fh.UnlinkedAttempt
+		unlinked = fh.Unlinked
+		if workspaceID == "" {
+			workspaceID = fh.GitWorkspaceID
+		}
+		if rel == "" {
+			rel = fh.GitRelPath
+		}
+		fh.Unlock()
+	}
+	return fs.gitOverlayShouldSuppressPublishState(workspaceID, rel, reservedAttempt, unlinked, markAttempt)
 }
 
-func gitOverlayHandleUnlinked(fh *FileHandle) bool {
+func (fs *Dat9FS) gitOverlayShouldSuppressPublishLocked(fh *FileHandle) bool {
 	if fh == nil {
 		return false
 	}
-	fh.Lock()
-	unlinked := fh.Unlinked
-	fh.Unlock()
-	return unlinked
+	return fs.gitOverlayShouldSuppressPublishState(fh.GitWorkspaceID, fh.GitRelPath, 0, fh.Unlinked, fh.UnlinkedAttempt)
+}
+
+func (fs *Dat9FS) gitOverlayShouldSuppressPublishState(workspaceID, rel string, reservedAttempt uint64, unlinked bool, markAttempt uint64) bool {
+	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
+	fs.gitOverlayMu.Lock()
+	attempt := fs.gitOverlayUnlinkAttempt[key]
+	committed := fs.gitOverlayUnlinkCommitted[key]
+	blocked := fs.gitOverlayUnlinkBlocked[key]
+	fs.gitOverlayMu.Unlock()
+	if reservedAttempt > 0 && committed >= reservedAttempt {
+		return true
+	}
+	if blocked > 0 && attempt > 0 && committed >= attempt {
+		return true
+	}
+	return unlinked && markAttempt > 0 && committed >= markAttempt
 }
 
 func (fs *Dat9FS) putGitOverlayRemote(ctx context.Context, workspaceID string, req client.GitOverlayEntryRequest) (*client.GitOverlayEntry, error) {
@@ -4538,19 +4563,9 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		testHookAfterGitOverlayAttemptSample(req.Op)
 	}
 	dropQueued := func() bool {
-		if req.Op == "whiteout" {
-			return false
-		}
-		if fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedAttempt) {
-			return true
-		}
-		// Unlinked is set before whiteout commits and rolled back on failure.
-		// Only treat it as a publish barrier after a whiteout has landed.
-		return gitOverlayHandleUnlinked(fh) && fs.gitOverlayUnlinkHasCommitted(workspaceID, req.Path)
+		return fs.gitOverlayShouldSuppressPublish(req.Op, workspaceID, req.Path, reservedAttempt, fh)
 	}
 	if fs.gitOverlayWriteBackEnabled(policy, forceSync) {
-		pendingSeq := fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
-		fs.applyGitOverlayEntry(workspaceID, *localEntry)
 		prev, done := fs.reserveGitOverlayCommitSlot()
 		if testHookAfterGitOverlaySlotReserved != nil {
 			testHookAfterGitOverlaySlotReserved(req.Op)
@@ -4571,6 +4586,8 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 			if dropQueued() {
 				return
 			}
+			pendingSeq := fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
+			fs.applyGitOverlayEntry(workspaceID, *localEntry)
 			timeout := releaseTimeout(req.SizeBytes)
 			commitCtx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
@@ -4736,14 +4753,7 @@ func (fs *Dat9FS) flushGitLocalFileHandleLockedWithPolicy(ctx context.Context, f
 	if fh == nil || fh.Layer != PathLayerGitWorkspace || fh.LocalFile == nil {
 		return gofuse.OK
 	}
-	if fh.Unlinked {
-		// Open-unlink: the gitEntry unlink path marked this handle when it
-		// wrote the whiteout. Suppress the overlay upsert so the whiteout is
-		// not shadowed by a recreate from the anonymous fd. The fd's data
-		// stays in LocalFile untouched for reads (POSIX write/read
-		// after-unlink) — unlike Flush/Release on remote-DELETE handles,
-		// nothing is discarded here because a write-sync Write also routes
-		// through this function and its bytes must remain readable.
+	if fs.gitOverlayShouldSuppressPublishLocked(fh) {
 		return gofuse.OK
 	}
 	if fh.DirtySeq == 0 && !fh.HasPendingMode {
@@ -4790,13 +4800,7 @@ func (fs *Dat9FS) flushGitHandleLockedWithPolicy(ctx context.Context, fh *FileHa
 	if fh == nil || fh.Layer != PathLayerGitWorkspace {
 		return gofuse.OK
 	}
-	if fh.Unlinked {
-		// Open-unlink: suppress the overlay upsert — the whiteout written by
-		// the gitEntry unlink path must not be shadowed by a recreate from
-		// the anonymous fd. Its data stays in the Dirty buffer / LocalFile
-		// for reads (POSIX write/read-after-unlink); nothing is discarded
-		// here because write-sync Writes also route through this function
-		// and their bytes must remain readable.
+	if fs.gitOverlayShouldSuppressPublishLocked(fh) {
 		return gofuse.OK
 	}
 	if fh.LocalFile != nil {
@@ -5193,7 +5197,7 @@ func (fs *Dat9FS) registerGitWorkspaceHandle(fh *FileHandle, rt *gitWorkspaceRun
 	defer fs.openHandles.mu.Unlock()
 	marked := false
 	if e, ok := rt.overlayEntry(rel); ok && e.Op == "whiteout" {
-		fh.Unlinked = true
+		fs.markHandleUnlinkedLocked(fh)
 		marked = true
 	}
 	fs.openHandles.addLocked(fh)

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -110,8 +110,13 @@ type gitWorkspaceRuntime struct {
 	nodes     map[string]client.GitTreeNode
 	children  map[string][]client.GitTreeNode
 	overlay   map[string]client.GitOverlayEntry
-	loadedAt  time.Time
-	restored  bool
+	// overlayGen is the per-path local apply generation of overlay, bumped by
+	// every live-overlay mutation under mu. A request that undoes its own
+	// local write compares its generation against this map so a same-path
+	// recreate that applied later keeps its entry.
+	overlayGen map[string]uint64
+	loadedAt   time.Time
+	restored   bool
 
 	localTreeCommit   string
 	localNodes        map[string]client.GitTreeNode
@@ -4213,20 +4218,69 @@ func gitOverlayEntryFromRequest(workspaceID string, req client.GitOverlayEntryRe
 	}
 }
 
-func (fs *Dat9FS) applyGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) {
+// setOverlayEntryLocked installs entry as the live overlay entry and returns
+// the path's new local apply generation. Caller must hold rt.mu for writing.
+func (rt *gitWorkspaceRuntime) setOverlayEntryLocked(entry client.GitOverlayEntry) uint64 {
+	rt.overlay[entry.Path] = entry
+	if rt.overlayGen == nil {
+		rt.overlayGen = make(map[string]uint64)
+	}
+	rt.overlayGen[entry.Path]++
+	return rt.overlayGen[entry.Path]
+}
+
+// applyGitOverlayEntry mirrors entry into the live overlay and returns the
+// local apply generation this write installed for the path (0 when no runtime
+// matched). Every live-overlay mutation bumps that generation, so a caller
+// that may later need to undo its own write can prove ownership: a same-path
+// recreate that applied after it must survive the cleanup.
+func (fs *Dat9FS) applyGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) uint64 {
 	if fs == nil || fs.git == nil {
-		return
+		return 0
 	}
 	fs.git.mu.Lock()
 	defer fs.git.mu.Unlock()
 	for _, rt := range fs.git.workspaces {
-		if rt.workspace.WorkspaceID == workspaceID {
-			rt.mu.Lock()
-			rt.overlay[entry.Path] = entry
-			rt.mu.Unlock()
-			break
+		if rt == nil || rt.workspace.WorkspaceID != workspaceID {
+			continue
 		}
+		rt.mu.Lock()
+		defer rt.mu.Unlock()
+		return rt.setOverlayEntryLocked(entry)
 	}
+	return 0
+}
+
+// restoreGitOverlayWhiteoutOwned replaces the live entry for rel with a
+// whiteout only while gen is still that path's latest local apply generation.
+// It is the ownership-scoped form of the write-back drop cleanup: the request
+// being cleaned up may only undo its own local write, so a later legitimate
+// same-path recreate keeps its live upsert (the remote PUT it already made is
+// authoritative). Returns whether the whiteout was installed.
+func (fs *Dat9FS) restoreGitOverlayWhiteoutOwned(workspaceID, rel string, gen uint64) bool {
+	if fs == nil || fs.git == nil || rel == "" || gen == 0 {
+		return false
+	}
+	fs.git.mu.Lock()
+	defer fs.git.mu.Unlock()
+	for _, rt := range fs.git.workspaces {
+		if rt == nil || rt.workspace.WorkspaceID != workspaceID {
+			continue
+		}
+		rt.mu.Lock()
+		defer rt.mu.Unlock()
+		if rt.overlayGen[rel] != gen {
+			return false
+		}
+		rt.setOverlayEntryLocked(client.GitOverlayEntry{
+			WorkspaceID: workspaceID,
+			Path:        rel,
+			Op:          "whiteout",
+			Kind:        "file",
+		})
+		return true
+	}
+	return false
 }
 
 // applyGitOverlayEntryUnlessWhiteout mirrors entry into the live overlay only
@@ -4256,7 +4310,7 @@ func (fs *Dat9FS) applyGitOverlayEntryUnlessWhiteout(workspaceID string, entry c
 			rt.mu.Unlock()
 			return false, true
 		}
-		rt.overlay[entry.Path] = entry
+		rt.setOverlayEntryLocked(entry)
 		rt.mu.Unlock()
 		return true, false
 	}
@@ -4571,10 +4625,10 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		// so a later drop cannot resurrect a whiteout. Whiteout itself must
 		// apply before Unlink returns.
 		deferLocal := req.Op != "whiteout" && fs.gitOverlayUnlinkAttemptIfBlocked(workspaceID, req.Path) > 0
-		var pendingSeq uint64
+		var pendingSeq, localGen uint64
 		if !deferLocal {
 			pendingSeq = fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
-			fs.applyGitOverlayEntry(workspaceID, *localEntry)
+			localGen = fs.applyGitOverlayEntry(workspaceID, *localEntry)
 			if req.Op == "whiteout" {
 				fs.noteGitOverlayUnlinkCommitted(workspaceID, req.Path)
 			}
@@ -4600,12 +4654,7 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 				if !deferLocal {
 					fs.forgetPendingGitOverlayEntry(workspaceID, req.Path, pendingSeq)
 					if req.Op != "whiteout" {
-						fs.applyGitOverlayEntry(workspaceID, client.GitOverlayEntry{
-							WorkspaceID: workspaceID,
-							Path:        req.Path,
-							Op:          "whiteout",
-							Kind:        "file",
-						})
+						fs.restoreGitOverlayWhiteoutOwned(workspaceID, req.Path, localGen)
 					}
 				}
 				return

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -4433,17 +4433,6 @@ func (fs *Dat9FS) unblockGitOverlayUnlinkPublish(workspaceID, rel string) {
 	fs.gitOverlayMu.Unlock()
 }
 
-func (fs *Dat9FS) gitOverlayUnlinkBlocksPublish(workspaceID, rel string) bool {
-	if fs == nil || workspaceID == "" || rel == "" {
-		return false
-	}
-	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
-	fs.gitOverlayMu.Lock()
-	n := fs.gitOverlayUnlinkBlocked[key]
-	fs.gitOverlayMu.Unlock()
-	return n > 0
-}
-
 func (fs *Dat9FS) gitOverlayUnlinkAttemptIfBlocked(workspaceID, rel string) uint64 {
 	if fs == nil || workspaceID == "" || rel == "" {
 		return 0

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -44,6 +44,16 @@ const gitLocalObjectMaxPackBytes int64 = 256 << 20
 
 var gitCleanTreeDefaultMtime = time.Unix(1, 0).UTC()
 
+// errGitOverlayPublishSuppressed means an overlay upsert was queued during
+// Unlink and must not publish after the whiteout slot. Flush treats it as
+// success without clearing Dirty.
+var errGitOverlayPublishSuppressed = errors.New("git overlay publish suppressed")
+
+// testHookAfterGitOverlaySlotReserved fires after reserveGitOverlayCommitSlot
+// in putGitOverlayWithPolicy. Tests use it to observe that a Flush upsert
+// has joined the overlay queue behind an in-flight whiteout.
+var testHookAfterGitOverlaySlotReserved func(op string)
+
 // testHookAfterEmptyLocalScan runs after an empty-list leader scans local
 // markers and before it relocks to decide whether to disarm. Tests only.
 var testHookAfterEmptyLocalScan func()
@@ -4383,6 +4393,48 @@ func (fs *Dat9FS) reserveGitOverlayCommitSlot() (<-chan struct{}, chan struct{})
 	return prev, done
 }
 
+func gitOverlayUnlinkBlockKey(workspaceID, rel string) string {
+	return workspaceID + "\x00" + rel
+}
+
+func (fs *Dat9FS) blockGitOverlayUnlinkPublish(workspaceID, rel string) {
+	if fs == nil || workspaceID == "" || rel == "" {
+		return
+	}
+	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
+	fs.gitOverlayMu.Lock()
+	if fs.gitOverlayUnlinkBlocked == nil {
+		fs.gitOverlayUnlinkBlocked = make(map[string]int)
+	}
+	fs.gitOverlayUnlinkBlocked[key]++
+	fs.gitOverlayMu.Unlock()
+}
+
+func (fs *Dat9FS) unblockGitOverlayUnlinkPublish(workspaceID, rel string) {
+	if fs == nil || workspaceID == "" || rel == "" {
+		return
+	}
+	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
+	fs.gitOverlayMu.Lock()
+	if n := fs.gitOverlayUnlinkBlocked[key]; n <= 1 {
+		delete(fs.gitOverlayUnlinkBlocked, key)
+	} else {
+		fs.gitOverlayUnlinkBlocked[key] = n - 1
+	}
+	fs.gitOverlayMu.Unlock()
+}
+
+func (fs *Dat9FS) gitOverlayUnlinkBlocksPublish(workspaceID, rel string) bool {
+	if fs == nil || workspaceID == "" || rel == "" {
+		return false
+	}
+	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
+	fs.gitOverlayMu.Lock()
+	n := fs.gitOverlayUnlinkBlocked[key]
+	fs.gitOverlayMu.Unlock()
+	return n > 0
+}
+
 func (fs *Dat9FS) putGitOverlayRemote(ctx context.Context, workspaceID string, req client.GitOverlayEntryRequest) (*client.GitOverlayEntry, error) {
 	if fs == nil || fs.client == nil {
 		return nil, syscall.EIO
@@ -4418,6 +4470,9 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		pendingSeq := fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
 		fs.applyGitOverlayEntry(workspaceID, *localEntry)
 		prev, done := fs.reserveGitOverlayCommitSlot()
+		if testHookAfterGitOverlaySlotReserved != nil {
+			testHookAfterGitOverlaySlotReserved(req.Op)
+		}
 		if fs.perfEnabled() {
 			fs.perf.gitOverlayEnqueue.add(1)
 		}
@@ -4428,6 +4483,9 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 				<-prev
 			}
 			defer close(done)
+			if req.Op != "whiteout" && fs.gitOverlayUnlinkBlocksPublish(workspaceID, req.Path) {
+				return
+			}
 			timeout := releaseTimeout(req.SizeBytes)
 			commitCtx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()
@@ -4443,10 +4501,16 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		fs.perf.gitOverlaySync.add(1)
 	}
 	prev, done := fs.reserveGitOverlayCommitSlot()
+	if testHookAfterGitOverlaySlotReserved != nil {
+		testHookAfterGitOverlaySlotReserved(req.Op)
+	}
 	if prev != nil {
 		<-prev
 	}
 	defer close(done)
+	if req.Op != "whiteout" && fs.gitOverlayUnlinkBlocksPublish(workspaceID, req.Path) {
+		return nil, errGitOverlayPublishSuppressed
+	}
 	entry, err := fs.putGitOverlayRemote(ctx, workspaceID, req)
 	if err != nil {
 		return nil, err
@@ -4607,6 +4671,9 @@ func (fs *Dat9FS) flushGitLocalFileHandleLockedWithPolicy(ctx context.Context, f
 	fh.Unlock()
 	_, err = fs.putGitOverlayWithPolicy(ctx, fh.GitWorkspaceID, req, fh.WritePolicy, forceSync)
 	fh.Lock()
+	if errors.Is(err, errGitOverlayPublishSuppressed) {
+		return gofuse.OK
+	}
 	if err != nil {
 		return httpToFuseStatus(err)
 	}
@@ -4656,6 +4723,9 @@ func (fs *Dat9FS) flushGitHandleLockedWithPolicy(ctx context.Context, fh *FileHa
 		fh.Unlock()
 		_, err := fs.putGitOverlayWithPolicy(ctx, fh.GitWorkspaceID, req, fh.WritePolicy, forceSync)
 		fh.Lock()
+		if errors.Is(err, errGitOverlayPublishSuppressed) {
+			return gofuse.OK
+		}
 		if err != nil {
 			return httpToFuseStatus(err)
 		}
@@ -4679,6 +4749,9 @@ func (fs *Dat9FS) flushGitHandleLockedWithPolicy(ctx context.Context, fh *FileHa
 	fh.Unlock()
 	_, err := fs.putGitOverlayWithPolicy(ctx, fh.GitWorkspaceID, req, fh.WritePolicy, forceSync)
 	fh.Lock()
+	if errors.Is(err, errGitOverlayPublishSuppressed) {
+		return gofuse.OK
+	}
 	if err != nil {
 		return httpToFuseStatus(err)
 	}

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -64,6 +64,12 @@ var testHookAfterGitOverlaySlotWait func(op string)
 // Unlink after a handle has captured bytes but before it joins the queue.
 var testHookAfterGitOverlayAttemptSample func(op string)
 
+// testHookAfterGitOverlayStaleCheck fires after the write-back staleness check
+// passed and before the request applies its live overlay entry. Tests use it to
+// run Unlink plus a same-path recreate in that window, which the check cannot
+// cover because it is not atomic with the apply.
+var testHookAfterGitOverlayStaleCheck func(op string)
+
 // testHookAfterEmptyLocalScan runs after an empty-list leader scans local
 // markers and before it relocks to decide whether to disarm. Tests only.
 var testHookAfterEmptyLocalScan func()
@@ -4230,21 +4236,40 @@ func (rt *gitWorkspaceRuntime) setOverlayEntryLocked(entry client.GitOverlayEntr
 	rt.overlayWriter[entry.Path] = writer
 }
 
+// gitOverlayLocalWrite is the undo record for one write-back local apply: the
+// writer token it installed plus the live entry it replaced. The request keeps
+// it so its drop cleanup can put the previous state back instead of forcing a
+// whiteout — the check that decided this request was not stale cannot be made
+// atomic with the apply, so it may have overwritten a newer same-path write.
+type gitOverlayLocalWrite struct {
+	writer     uint64
+	prev       client.GitOverlayEntry
+	hadPrev    bool
+	prevWriter uint64
+}
+
+func (w gitOverlayLocalWrite) installed() bool { return w.writer != 0 }
+
+func cloneGitOverlayEntry(entry client.GitOverlayEntry) client.GitOverlayEntry {
+	entry.Content = append([]byte(nil), entry.Content...)
+	return entry
+}
+
 // applyGitOverlayEntry mirrors entry into the live overlay as a fresh local
-// writer and returns the token it recorded (0 when no runtime matched).
-// Callers that may later need to undo their own write — the write-back drop
-// cleanup — apply with their own token via applyGitOverlayEntryAs and hand it
-// back to restoreGitOverlayWhiteoutOwned.
-func (fs *Dat9FS) applyGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) uint64 {
+// writer and returns the undo record for it (zero when no runtime matched).
+func (fs *Dat9FS) applyGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) gitOverlayLocalWrite {
 	if fs == nil {
-		return 0
+		return gitOverlayLocalWrite{}
 	}
 	return fs.applyGitOverlayEntryAs(workspaceID, entry, fs.gitOverlaySeq.Add(1))
 }
 
-func (fs *Dat9FS) applyGitOverlayEntryAs(workspaceID string, entry client.GitOverlayEntry, writer uint64) uint64 {
+// applyGitOverlayEntryAs mirrors entry into the live overlay on behalf of
+// writer and records the entry it replaced, so undoGitOverlayLocalWrite can
+// restore it if this request turns out to be stale.
+func (fs *Dat9FS) applyGitOverlayEntryAs(workspaceID string, entry client.GitOverlayEntry, writer uint64) gitOverlayLocalWrite {
 	if fs == nil || fs.git == nil {
-		return 0
+		return gitOverlayLocalWrite{}
 	}
 	fs.git.mu.Lock()
 	defer fs.git.mu.Unlock()
@@ -4254,20 +4279,25 @@ func (fs *Dat9FS) applyGitOverlayEntryAs(workspaceID string, entry client.GitOve
 		}
 		rt.mu.Lock()
 		defer rt.mu.Unlock()
+		rec := gitOverlayLocalWrite{writer: writer}
+		if prev, ok := rt.overlay[entry.Path]; ok {
+			rec.prev = cloneGitOverlayEntry(prev)
+			rec.hadPrev = true
+			rec.prevWriter = rt.overlayWriter[entry.Path]
+		}
 		rt.setOverlayEntryLocked(entry, writer)
-		return writer
+		return rec
 	}
-	return 0
+	return gitOverlayLocalWrite{}
 }
 
-// restoreGitOverlayWhiteoutOwned replaces the live entry for rel with a
-// whiteout only while writer is still the path's local writer token. It is the
-// ownership-scoped form of the write-back drop cleanup: the dropped request
-// may only undo its own local write, so a same-path recreate that wrote later
-// keeps its live upsert (the remote PUT it already made is authoritative).
-// Returns whether the whiteout was installed.
-func (fs *Dat9FS) restoreGitOverlayWhiteoutOwned(workspaceID, rel string, writer uint64) bool {
-	if fs == nil || fs.git == nil || rel == "" || writer == 0 {
+// undoGitOverlayLocalWrite puts back the live entry the request replaced, but
+// only while its writer token is still current: a same-path recreate that wrote
+// later keeps its own entry (the remote PUT it already made is authoritative).
+// Without a previous entry the path is left as a whiteout, which is the state
+// that made this request stale in the first place.
+func (fs *Dat9FS) undoGitOverlayLocalWrite(workspaceID, rel string, rec gitOverlayLocalWrite) bool {
+	if fs == nil || fs.git == nil || rel == "" || !rec.installed() {
 		return false
 	}
 	fs.git.mu.Lock()
@@ -4278,15 +4308,19 @@ func (fs *Dat9FS) restoreGitOverlayWhiteoutOwned(workspaceID, rel string, writer
 		}
 		rt.mu.Lock()
 		defer rt.mu.Unlock()
-		if rt.overlayWriter[rel] != writer {
+		if rt.overlayWriter[rel] != rec.writer {
 			return false
+		}
+		if rec.hadPrev {
+			rt.setOverlayEntryLocked(rec.prev, rec.prevWriter)
+			return true
 		}
 		rt.setOverlayEntryLocked(client.GitOverlayEntry{
 			WorkspaceID: workspaceID,
 			Path:        rel,
 			Op:          "whiteout",
 			Kind:        "file",
-		}, writer)
+		}, rec.writer)
 		return true
 	}
 	return false
@@ -4651,10 +4685,14 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		// not apply at all: applying late would overwrite a legitimate
 		// same-path recreate and hand this request the current writer token.
 		deferLocal := req.Op != "whiteout" && fs.gitOverlayUnlinkAttemptIfBlocked(workspaceID, req.Path) > 0
-		var pendingSeq, localWriter uint64
+		var pendingSeq uint64
+		var localWrite gitOverlayLocalWrite
 		if !deferLocal && !fs.gitOverlayShouldSuppressPublish(req.Op, workspaceID, req.Path, reservedAttempt, fh) {
+			if testHookAfterGitOverlayStaleCheck != nil {
+				testHookAfterGitOverlayStaleCheck(req.Op)
+			}
 			pendingSeq = fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
-			localWriter = fs.applyGitOverlayEntryAs(workspaceID, *localEntry, pendingSeq)
+			localWrite = fs.applyGitOverlayEntryAs(workspaceID, *localEntry, pendingSeq)
 			if req.Op == "whiteout" {
 				fs.noteGitOverlayUnlinkCommitted(workspaceID, req.Path)
 			}
@@ -4680,7 +4718,7 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 				if pendingSeq != 0 {
 					fs.forgetPendingGitOverlayEntry(workspaceID, req.Path, pendingSeq)
 					if req.Op != "whiteout" {
-						fs.restoreGitOverlayWhiteoutOwned(workspaceID, req.Path, localWriter)
+						fs.undoGitOverlayLocalWrite(workspaceID, req.Path, localWrite)
 					}
 				}
 				return

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -4478,6 +4478,17 @@ func (fs *Dat9FS) gitOverlayShouldDropQueuedPublish(op, workspaceID, rel string,
 	return committed >= reservedAttempt
 }
 
+func (fs *Dat9FS) gitOverlayUnlinkHasCommitted(workspaceID, rel string) bool {
+	if fs == nil || workspaceID == "" || rel == "" {
+		return false
+	}
+	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
+	fs.gitOverlayMu.Lock()
+	committed := fs.gitOverlayUnlinkCommitted[key]
+	fs.gitOverlayMu.Unlock()
+	return committed > 0
+}
+
 func gitOverlayHandleUnlinked(fh *FileHandle) bool {
 	if fh == nil {
 		return false
@@ -4527,10 +4538,15 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		testHookAfterGitOverlayAttemptSample(req.Op)
 	}
 	dropQueued := func() bool {
-		if req.Op != "whiteout" && gitOverlayHandleUnlinked(fh) {
+		if req.Op == "whiteout" {
+			return false
+		}
+		if fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedAttempt) {
 			return true
 		}
-		return fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedAttempt)
+		// Unlinked is set before whiteout commits and rolled back on failure.
+		// Only treat it as a publish barrier after a whiteout has landed.
+		return gitOverlayHandleUnlinked(fh) && fs.gitOverlayUnlinkHasCommitted(workspaceID, req.Path)
 	}
 	if fs.gitOverlayWriteBackEnabled(policy, forceSync) {
 		pendingSeq := fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -4411,6 +4411,10 @@ func (fs *Dat9FS) blockGitOverlayUnlinkPublish(workspaceID, rel string) {
 	if fs.gitOverlayUnlinkBlocked == nil {
 		fs.gitOverlayUnlinkBlocked = make(map[string]int)
 	}
+	if fs.gitOverlayUnlinkAttempt == nil {
+		fs.gitOverlayUnlinkAttempt = make(map[string]uint64)
+	}
+	fs.gitOverlayUnlinkAttempt[key]++
 	fs.gitOverlayUnlinkBlocked[key]++
 	fs.gitOverlayMu.Unlock()
 }
@@ -4440,11 +4444,44 @@ func (fs *Dat9FS) gitOverlayUnlinkBlocksPublish(workspaceID, rel string) bool {
 	return n > 0
 }
 
-func (fs *Dat9FS) gitOverlayShouldDropQueuedPublish(op, workspaceID, rel string, reservedDuringUnlink bool) bool {
-	if op == "whiteout" {
+func (fs *Dat9FS) gitOverlayUnlinkAttemptIfBlocked(workspaceID, rel string) uint64 {
+	if fs == nil || workspaceID == "" || rel == "" {
+		return 0
+	}
+	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
+	fs.gitOverlayMu.Lock()
+	var stamp uint64
+	if fs.gitOverlayUnlinkBlocked[key] > 0 {
+		stamp = fs.gitOverlayUnlinkAttempt[key]
+	}
+	fs.gitOverlayMu.Unlock()
+	return stamp
+}
+
+func (fs *Dat9FS) noteGitOverlayUnlinkCommitted(workspaceID, rel string) {
+	if fs == nil || workspaceID == "" || rel == "" {
+		return
+	}
+	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
+	fs.gitOverlayMu.Lock()
+	if fs.gitOverlayUnlinkCommitted == nil {
+		fs.gitOverlayUnlinkCommitted = make(map[string]uint64)
+	}
+	if attempt := fs.gitOverlayUnlinkAttempt[key]; attempt > fs.gitOverlayUnlinkCommitted[key] {
+		fs.gitOverlayUnlinkCommitted[key] = attempt
+	}
+	fs.gitOverlayMu.Unlock()
+}
+
+func (fs *Dat9FS) gitOverlayShouldDropQueuedPublish(op, workspaceID, rel string, reservedAttempt uint64) bool {
+	if op == "whiteout" || reservedAttempt == 0 {
 		return false
 	}
-	return reservedDuringUnlink || fs.gitOverlayUnlinkBlocksPublish(workspaceID, rel)
+	key := gitOverlayUnlinkBlockKey(workspaceID, rel)
+	fs.gitOverlayMu.Lock()
+	committed := fs.gitOverlayUnlinkCommitted[key]
+	fs.gitOverlayMu.Unlock()
+	return committed >= reservedAttempt
 }
 
 func (fs *Dat9FS) putGitOverlayRemote(ctx context.Context, workspaceID string, req client.GitOverlayEntryRequest) (*client.GitOverlayEntry, error) {
@@ -4478,7 +4515,10 @@ func (fs *Dat9FS) putGitOverlay(ctx context.Context, workspaceID string, req cli
 func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID string, req client.GitOverlayEntryRequest, policy WritePolicy, forceSync bool) (*client.GitOverlayEntry, error) {
 	req = normalizeGitOverlayRequest(req)
 	localEntry := gitOverlayEntryFromRequest(workspaceID, req)
-	reservedDuringUnlink := req.Op != "whiteout" && fs.gitOverlayUnlinkBlocksPublish(workspaceID, req.Path)
+	reservedAttempt := fs.gitOverlayUnlinkAttemptIfBlocked(workspaceID, req.Path)
+	if req.Op == "whiteout" {
+		reservedAttempt = 0
+	}
 	if fs.gitOverlayWriteBackEnabled(policy, forceSync) {
 		pendingSeq := fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
 		fs.applyGitOverlayEntry(workspaceID, *localEntry)
@@ -4499,7 +4539,7 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 				testHookAfterGitOverlaySlotWait(req.Op)
 			}
 			defer close(done)
-			if fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedDuringUnlink) {
+			if fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedAttempt) {
 				return
 			}
 			timeout := releaseTimeout(req.SizeBytes)
@@ -4508,6 +4548,9 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 			if _, err := fs.putGitOverlayRemote(commitCtx, workspaceID, req); err != nil {
 				safeLogPrintf("git workspace overlay async commit failed workspace=%s path=%s op=%s: %v", workspaceID, req.Path, req.Op, err)
 			} else {
+				if req.Op == "whiteout" {
+					fs.noteGitOverlayUnlinkCommitted(workspaceID, req.Path)
+				}
 				fs.forgetPendingGitOverlayEntry(workspaceID, req.Path, pendingSeq)
 			}
 		}()
@@ -4527,12 +4570,15 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		testHookAfterGitOverlaySlotWait(req.Op)
 	}
 	defer close(done)
-	if fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedDuringUnlink) {
+	if fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedAttempt) {
 		return nil, errGitOverlayPublishSuppressed
 	}
 	entry, err := fs.putGitOverlayRemote(ctx, workspaceID, req)
 	if err != nil {
 		return nil, err
+	}
+	if req.Op == "whiteout" {
+		fs.noteGitOverlayUnlinkCommitted(workspaceID, req.Path)
 	}
 	fs.forgetPendingGitOverlayEntry(workspaceID, entry.Path, 0)
 	fs.applyGitOverlayEntry(workspaceID, *entry)

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -116,14 +116,13 @@ type gitWorkspaceRuntime struct {
 	nodes     map[string]client.GitTreeNode
 	children  map[string][]client.GitTreeNode
 	overlay   map[string]client.GitOverlayEntry
-	// overlayWriter records, per path, the gitOverlaySeq token of the local
-	// writer that installed the live entry, under mu. A request that must undo
-	// its own live write compares that token so a same-path recreate that
-	// wrote later keeps its entry; the token is carried across runtime
-	// refresh by mergePendingGitOverlayEntries.
-	overlayWriter map[string]uint64
-	loadedAt      time.Time
-	restored      bool
+	// overlayApplies is the per-path stack of live-overlay applies, under mu.
+	// The live entry is always the top node's entry; a write-back request that
+	// turns out stale only pops its own node, so it can neither hide a
+	// same-path recreate nor restore another dropped request's state.
+	overlayApplies map[string][]gitOverlayApply
+	loadedAt       time.Time
+	restored       bool
 
 	localTreeCommit   string
 	localNodes        map[string]client.GitTreeNode
@@ -4225,51 +4224,125 @@ func gitOverlayEntryFromRequest(workspaceID string, req client.GitOverlayEntryRe
 	}
 }
 
-// setOverlayEntryLocked installs entry as the live overlay entry on behalf of
-// writer (a gitOverlaySeq token) and records that writer for the path. Caller
-// must hold rt.mu for writing.
-func (rt *gitWorkspaceRuntime) setOverlayEntryLocked(entry client.GitOverlayEntry, writer uint64) {
-	rt.overlay[entry.Path] = entry
-	if rt.overlayWriter == nil {
-		rt.overlayWriter = make(map[string]uint64)
-	}
-	rt.overlayWriter[entry.Path] = writer
+// gitOverlayApply is one node of a path's live-overlay apply stack: the entry a
+// writer installed plus whether that writer can still be withdrawn. The base
+// node holds the state that existed before the first stacked apply, and
+// permanent nodes are never removed — a committed write, a whiteout, or any
+// apply that no request can undo. The live overlay entry is always the top
+// node's entry.
+type gitOverlayApply struct {
+	token     uint64
+	entry     client.GitOverlayEntry
+	hadEntry  bool
+	permanent bool
 }
-
-// gitOverlayLocalWrite is the undo record for one write-back local apply: the
-// writer token it installed plus the live entry it replaced. The request keeps
-// it so its drop cleanup can put the previous state back instead of forcing a
-// whiteout — the check that decided this request was not stale cannot be made
-// atomic with the apply, so it may have overwritten a newer same-path write.
-type gitOverlayLocalWrite struct {
-	writer     uint64
-	prev       client.GitOverlayEntry
-	hadPrev    bool
-	prevWriter uint64
-}
-
-func (w gitOverlayLocalWrite) installed() bool { return w.writer != 0 }
 
 func cloneGitOverlayEntry(entry client.GitOverlayEntry) client.GitOverlayEntry {
 	entry.Content = append([]byte(nil), entry.Content...)
 	return entry
 }
 
-// applyGitOverlayEntry mirrors entry into the live overlay as a fresh local
-// writer and returns the undo record for it (zero when no runtime matched).
-func (fs *Dat9FS) applyGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) gitOverlayLocalWrite {
+// pushOverlayApplyLocked installs entry as the live overlay entry for its path
+// on behalf of token. A non-permanent node can be popped again by
+// dropOverlayApplyLocked; a permanent one cannot. Caller must hold rt.mu for
+// writing.
+func (rt *gitWorkspaceRuntime) pushOverlayApplyLocked(entry client.GitOverlayEntry, token uint64, permanent bool) {
+	if rt.overlayApplies == nil {
+		rt.overlayApplies = make(map[string][]gitOverlayApply)
+	}
+	rel := entry.Path
+	stack := rt.overlayApplies[rel]
+	if len(stack) == 0 {
+		base, ok := rt.overlay[rel]
+		if ok {
+			base = cloneGitOverlayEntry(base)
+		}
+		stack = append(stack, gitOverlayApply{entry: base, hadEntry: ok, permanent: true})
+	}
+	stack = append(stack, gitOverlayApply{token: token, entry: entry, hadEntry: true, permanent: permanent})
+	rt.overlayApplies[rel] = stack
+	rt.pruneOverlayAppliesLocked(rel)
+}
+
+// commitOverlayApplyLocked makes token's apply permanent: its remote write
+// landed, so neither it nor anything under it can be withdrawn.
+func (rt *gitWorkspaceRuntime) commitOverlayApplyLocked(rel string, token uint64) {
+	stack := rt.overlayApplies[rel]
+	for i := range stack {
+		if stack[i].token != token {
+			continue
+		}
+		stack[i].permanent = true
+		rt.overlayApplies[rel] = stack
+		rt.pruneOverlayAppliesLocked(rel)
+		return
+	}
+}
+
+// dropOverlayApplyLocked removes token's apply because its request turned out
+// to be stale. Only that node goes away: the live entry falls back to the
+// newest remaining node, so a chain of dropped writes cannot restore each
+// other's state.
+func (rt *gitWorkspaceRuntime) dropOverlayApplyLocked(rel string, token uint64) {
+	stack := rt.overlayApplies[rel]
+	for i := range stack {
+		if stack[i].token != token {
+			continue
+		}
+		stack = append(stack[:i], stack[i+1:]...)
+		rt.overlayApplies[rel] = stack
+		rt.pruneOverlayAppliesLocked(rel)
+		return
+	}
+}
+
+// pruneOverlayAppliesLocked drops stack nodes that can never become the live
+// entry again and materializes the current top. Everything below the topmost
+// permanent node is unreachable; a stack that is down to that node alone is
+// collapsed back into the plain overlay map.
+func (rt *gitWorkspaceRuntime) pruneOverlayAppliesLocked(rel string) {
+	stack := rt.overlayApplies[rel]
+	if len(stack) == 0 {
+		return
+	}
+	keep := 0
+	for i := len(stack) - 1; i >= 0; i-- {
+		if stack[i].permanent {
+			keep = i
+			break
+		}
+	}
+	stack = stack[keep:]
+	if len(stack) == 1 {
+		node := stack[0]
+		if node.hadEntry {
+			rt.overlay[rel] = node.entry
+		} else {
+			delete(rt.overlay, rel)
+		}
+		delete(rt.overlayApplies, rel)
+		return
+	}
+	rt.overlayApplies[rel] = stack
+	rt.overlay[rel] = stack[len(stack)-1].entry
+}
+
+// applyGitOverlayEntry installs entry as the path's settled live overlay entry:
+// a whiteout, a committed sync write, or a mirror/read-through cache fill that
+// no request will withdraw.
+func (fs *Dat9FS) applyGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) {
 	if fs == nil {
-		return gitOverlayLocalWrite{}
+		return
 	}
-	return fs.applyGitOverlayEntryAs(workspaceID, entry, fs.gitOverlaySeq.Add(1))
+	fs.pushGitOverlayApply(workspaceID, entry, fs.gitOverlaySeq.Add(1), true)
 }
 
-// applyGitOverlayEntryAs mirrors entry into the live overlay on behalf of
-// writer and records the entry it replaced, so undoGitOverlayLocalWrite can
-// restore it if this request turns out to be stale.
-func (fs *Dat9FS) applyGitOverlayEntryAs(workspaceID string, entry client.GitOverlayEntry, writer uint64) gitOverlayLocalWrite {
+// pushGitOverlayApply installs entry for a write-back request identified by
+// token, which dropGitOverlayApply takes back when the request is dropped and
+// commitGitOverlayApply keeps once its remote write lands.
+func (fs *Dat9FS) pushGitOverlayApply(workspaceID string, entry client.GitOverlayEntry, token uint64, permanent bool) {
 	if fs == nil || fs.git == nil {
-		return gitOverlayLocalWrite{}
+		return
 	}
 	fs.git.mu.Lock()
 	defer fs.git.mu.Unlock()
@@ -4279,26 +4352,16 @@ func (fs *Dat9FS) applyGitOverlayEntryAs(workspaceID string, entry client.GitOve
 		}
 		rt.mu.Lock()
 		defer rt.mu.Unlock()
-		rec := gitOverlayLocalWrite{writer: writer}
-		if prev, ok := rt.overlay[entry.Path]; ok {
-			rec.prev = cloneGitOverlayEntry(prev)
-			rec.hadPrev = true
-			rec.prevWriter = rt.overlayWriter[entry.Path]
-		}
-		rt.setOverlayEntryLocked(entry, writer)
-		return rec
+		rt.pushOverlayApplyLocked(entry, token, permanent)
+		return
 	}
-	return gitOverlayLocalWrite{}
 }
 
-// undoGitOverlayLocalWrite puts back the live entry the request replaced, but
-// only while its writer token is still current: a same-path recreate that wrote
-// later keeps its own entry (the remote PUT it already made is authoritative).
-// Without a previous entry the path is left as a whiteout, which is the state
-// that made this request stale in the first place.
-func (fs *Dat9FS) undoGitOverlayLocalWrite(workspaceID, rel string, rec gitOverlayLocalWrite) bool {
-	if fs == nil || fs.git == nil || rel == "" || !rec.installed() {
-		return false
+// commitGitOverlayApply keeps the apply of a write-back request whose remote
+// write landed.
+func (fs *Dat9FS) commitGitOverlayApply(workspaceID, rel string, token uint64) {
+	if fs == nil || fs.git == nil || rel == "" {
+		return
 	}
 	fs.git.mu.Lock()
 	defer fs.git.mu.Unlock()
@@ -4308,22 +4371,30 @@ func (fs *Dat9FS) undoGitOverlayLocalWrite(workspaceID, rel string, rec gitOverl
 		}
 		rt.mu.Lock()
 		defer rt.mu.Unlock()
-		if rt.overlayWriter[rel] != rec.writer {
-			return false
-		}
-		if rec.hadPrev {
-			rt.setOverlayEntryLocked(rec.prev, rec.prevWriter)
-			return true
-		}
-		rt.setOverlayEntryLocked(client.GitOverlayEntry{
-			WorkspaceID: workspaceID,
-			Path:        rel,
-			Op:          "whiteout",
-			Kind:        "file",
-		}, rec.writer)
-		return true
+		rt.commitOverlayApplyLocked(rel, token)
+		return
 	}
-	return false
+}
+
+// dropGitOverlayApply withdraws the apply of a stale write-back request. Every
+// dropped request pops exactly its own node, so consecutive dropped writes
+// cannot restore one another, and a same-path writer that landed later keeps
+// its entry.
+func (fs *Dat9FS) dropGitOverlayApply(workspaceID, rel string, token uint64) {
+	if fs == nil || fs.git == nil || rel == "" || token == 0 {
+		return
+	}
+	fs.git.mu.Lock()
+	defer fs.git.mu.Unlock()
+	for _, rt := range fs.git.workspaces {
+		if rt == nil || rt.workspace.WorkspaceID != workspaceID {
+			continue
+		}
+		rt.mu.Lock()
+		defer rt.mu.Unlock()
+		rt.dropOverlayApplyLocked(rel, token)
+		return
+	}
 }
 
 // applyGitOverlayEntryUnlessWhiteout mirrors entry into the live overlay only
@@ -4353,7 +4424,7 @@ func (fs *Dat9FS) applyGitOverlayEntryUnlessWhiteout(workspaceID string, entry c
 			rt.mu.Unlock()
 			return false, true
 		}
-		rt.setOverlayEntryLocked(entry, fs.gitOverlaySeq.Add(1))
+		rt.pushOverlayApplyLocked(entry, fs.gitOverlaySeq.Add(1), true)
 		rt.mu.Unlock()
 		return true, false
 	}
@@ -4480,7 +4551,7 @@ func (fs *Dat9FS) mergePendingGitOverlayEntries(workspaceID string, rt *gitWorks
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
 	for _, entry := range pending {
-		rt.setOverlayEntryLocked(entry.entry, entry.seq)
+		rt.pushOverlayApplyLocked(entry.entry, entry.seq, false)
 	}
 }
 
@@ -4682,17 +4753,16 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		// so a later drop cannot resurrect a whiteout. Whiteout itself must
 		// apply before Unlink returns. A request that is already stale here —
 		// its fd was marked for an unlink attempt that has committed — must
-		// not apply at all: applying late would overwrite a legitimate
-		// same-path recreate and hand this request the current writer token.
+		// not apply at all, so it cannot even momentarily hide a same-path
+		// recreate.
 		deferLocal := req.Op != "whiteout" && fs.gitOverlayUnlinkAttemptIfBlocked(workspaceID, req.Path) > 0
 		var pendingSeq uint64
-		var localWrite gitOverlayLocalWrite
 		if !deferLocal && !fs.gitOverlayShouldSuppressPublish(req.Op, workspaceID, req.Path, reservedAttempt, fh) {
 			if testHookAfterGitOverlayStaleCheck != nil {
 				testHookAfterGitOverlayStaleCheck(req.Op)
 			}
 			pendingSeq = fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
-			localWrite = fs.applyGitOverlayEntryAs(workspaceID, *localEntry, pendingSeq)
+			fs.pushGitOverlayApply(workspaceID, *localEntry, pendingSeq, false)
 			if req.Op == "whiteout" {
 				fs.noteGitOverlayUnlinkCommitted(workspaceID, req.Path)
 			}
@@ -4717,15 +4787,13 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 			if dropQueued() {
 				if pendingSeq != 0 {
 					fs.forgetPendingGitOverlayEntry(workspaceID, req.Path, pendingSeq)
-					if req.Op != "whiteout" {
-						fs.undoGitOverlayLocalWrite(workspaceID, req.Path, localWrite)
-					}
+					fs.dropGitOverlayApply(workspaceID, req.Path, pendingSeq)
 				}
 				return
 			}
 			if deferLocal {
 				pendingSeq = fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
-				fs.applyGitOverlayEntryAs(workspaceID, *localEntry, pendingSeq)
+				fs.pushGitOverlayApply(workspaceID, *localEntry, pendingSeq, false)
 			}
 			timeout := releaseTimeout(req.SizeBytes)
 			commitCtx, cancel := context.WithTimeout(context.Background(), timeout)
@@ -4737,6 +4805,7 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 					fs.noteGitOverlayUnlinkCommitted(workspaceID, req.Path)
 				}
 				fs.forgetPendingGitOverlayEntry(workspaceID, req.Path, pendingSeq)
+				fs.commitGitOverlayApply(workspaceID, req.Path, pendingSeq)
 			}
 		}()
 		return localEntry, nil

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -4410,6 +4410,13 @@ func (fs *Dat9FS) dropGitOverlayApply(workspaceID, rel string, token uint64) {
 // blockedByWhiteout reports that a whiteout is currently authoritative and the
 // entry was dropped; applied reports the entry was stored.
 func (fs *Dat9FS) applyGitOverlayEntryUnlessWhiteout(workspaceID string, entry client.GitOverlayEntry) (applied, blockedByWhiteout bool) {
+	return fs.applyGitOverlayEntryUnlessWhiteoutWithToken(workspaceID, entry, fs.gitOverlaySeq.Add(1))
+}
+
+// applyGitOverlayEntryUnlessWhiteoutWithToken is applyGitOverlayEntryUnlessWhiteout
+// with a caller-allocated apply token, so the caller can reuse the same token
+// for the matching pending-map record.
+func (fs *Dat9FS) applyGitOverlayEntryUnlessWhiteoutWithToken(workspaceID string, entry client.GitOverlayEntry, token uint64) (applied, blockedByWhiteout bool) {
 	if fs == nil || fs.git == nil {
 		return false, false
 	}
@@ -4424,7 +4431,7 @@ func (fs *Dat9FS) applyGitOverlayEntryUnlessWhiteout(workspaceID string, entry c
 			rt.mu.Unlock()
 			return false, true
 		}
-		rt.pushOverlayApplyLocked(entry, fs.gitOverlaySeq.Add(1), true)
+		rt.pushOverlayApplyLocked(entry, token, true)
 		rt.mu.Unlock()
 		return true, false
 	}
@@ -4449,8 +4456,14 @@ func (fs *Dat9FS) applyGitOverlayMirrorEntry(fh *FileHandle, size int64) {
 		ChecksumSHA256: "",
 		UpdatedAt:      time.Now(),
 	}
-	fs.rememberPendingGitOverlayEntry(fh.GitWorkspaceID, entry)
-	fs.applyGitOverlayEntry(fh.GitWorkspaceID, entry)
+	// One seq stamps both the pending record and the runtime apply token, so
+	// pending order always matches apply order. The mirror's permanent push
+	// prunes every older apply from the runtime stack; the mirror remember
+	// drops their pending records the same way. Remember first: a refresh
+	// landing between the two still replays the entry into the new runtime.
+	seq := fs.gitOverlaySeq.Add(1)
+	fs.rememberPendingGitOverlayMirror(fh.GitWorkspaceID, entry, seq)
+	fs.pushGitOverlayApply(fh.GitWorkspaceID, entry, seq, true)
 }
 
 // applyGitOverlayMirrorEntryUnlessWhiteout is the open-time variant of
@@ -4481,35 +4494,86 @@ func (fs *Dat9FS) applyGitOverlayMirrorEntryUnlessWhiteout(fh *FileHandle, size 
 		ChecksumSHA256: "",
 		UpdatedAt:      time.Now(),
 	}
-	if _, blocked := fs.applyGitOverlayEntryUnlessWhiteout(fh.GitWorkspaceID, entry); blocked {
+	// The seq is allocated at apply time and shared by the runtime apply
+	// token and the pending record, so a pending registration that straggles
+	// behind a same-path recreate keeps its older (apply-time) position
+	// instead of overwriting the recreate's newer record.
+	seq := fs.gitOverlaySeq.Add(1)
+	if _, blocked := fs.applyGitOverlayEntryUnlessWhiteoutWithToken(fh.GitWorkspaceID, entry, seq); blocked {
 		fs.markHandleUnlinkedLocked(fh)
 		return
 	}
 	// Capture the pending seq so registration-time whiteout adoption can drop
 	// only THIS handle's stale pending entry — a legitimate same-path
 	// recreate re-remembers the path with a newer seq and must survive.
-	fh.GitPendingMirrorSeq = fs.rememberPendingGitOverlayEntry(fh.GitWorkspaceID, entry)
+	fh.GitPendingMirrorSeq = seq
+	fs.rememberPendingGitOverlayMirror(fh.GitWorkspaceID, entry, seq)
 }
 
+// rememberPendingGitOverlayEntry records a write-back apply that has not been
+// confirmed on the remote, so mergePendingGitOverlayEntries can replay it into
+// a refreshed runtime. The per-path pending list is kept in seq (apply) order;
+// a write-back apply is non-permanent, so it stacks on top of every earlier
+// record without invalidating them.
 func (fs *Dat9FS) rememberPendingGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) uint64 {
 	if fs == nil {
 		return 0
 	}
 	seq := fs.gitOverlaySeq.Add(1)
 	fs.gitOverlayMu.Lock()
-	if fs.gitOverlayPending == nil {
-		fs.gitOverlayPending = make(map[string]map[string]pendingGitOverlayEntry)
+	defer fs.gitOverlayMu.Unlock()
+	byPath := fs.pendingGitOverlayByPathLocked(workspaceID)
+	list := byPath[entry.Path]
+	pos := len(list)
+	for pos > 0 && list[pos-1].seq > seq {
+		pos--
 	}
-	byPath := fs.gitOverlayPending[workspaceID]
-	if byPath == nil {
-		byPath = make(map[string]pendingGitOverlayEntry)
-		fs.gitOverlayPending[workspaceID] = byPath
-	}
-	byPath[entry.Path] = pendingGitOverlayEntry{seq: seq, entry: entry}
-	fs.gitOverlayMu.Unlock()
+	list = append(list, pendingGitOverlayEntry{})
+	copy(list[pos+1:], list[pos:])
+	list[pos] = pendingGitOverlayEntry{seq: seq, entry: entry}
+	byPath[entry.Path] = list
 	return seq
 }
 
+// rememberPendingGitOverlayMirror records a dirty-mirror apply with its
+// apply-time seq. A mirror apply is permanent, so its runtime push prunes
+// every older apply for the path from the runtime stack; the pending list
+// mirrors that prune by dropping every older record for the path. Records
+// with a newer seq — a same-path recreate that landed after this apply —
+// survive.
+func (fs *Dat9FS) rememberPendingGitOverlayMirror(workspaceID string, entry client.GitOverlayEntry, seq uint64) {
+	if fs == nil || seq == 0 {
+		return
+	}
+	fs.gitOverlayMu.Lock()
+	defer fs.gitOverlayMu.Unlock()
+	byPath := fs.pendingGitOverlayByPathLocked(workspaceID)
+	list := byPath[entry.Path]
+	pos := 0
+	for pos < len(list) && list[pos].seq < seq {
+		pos++
+	}
+	list = append([]pendingGitOverlayEntry{{seq: seq, entry: entry}}, list[pos:]...)
+	byPath[entry.Path] = list
+}
+
+func (fs *Dat9FS) pendingGitOverlayByPathLocked(workspaceID string) map[string][]pendingGitOverlayEntry {
+	if fs.gitOverlayPending == nil {
+		fs.gitOverlayPending = make(map[string]map[string][]pendingGitOverlayEntry)
+	}
+	byPath := fs.gitOverlayPending[workspaceID]
+	if byPath == nil {
+		byPath = make(map[string][]pendingGitOverlayEntry)
+		fs.gitOverlayPending[workspaceID] = byPath
+	}
+	return byPath
+}
+
+// forgetPendingGitOverlayEntry drops one pending record: exactly the record
+// stamped with seq (a stale request withdrawing its own apply, or whiteout
+// adoption dropping one handle's stale mirror record). seq == 0 drops every
+// record for the path (a sync write landed on the remote and supersedes all
+// older local state).
 func (fs *Dat9FS) forgetPendingGitOverlayEntry(workspaceID, relPath string, seq uint64) {
 	if fs == nil || relPath == "" {
 		return
@@ -4520,29 +4584,74 @@ func (fs *Dat9FS) forgetPendingGitOverlayEntry(workspaceID, relPath string, seq 
 	if byPath == nil {
 		return
 	}
-	pending, ok := byPath[relPath]
-	if !ok || (seq != 0 && pending.seq != seq) {
+	if seq == 0 {
+		delete(byPath, relPath)
+	} else if list := byPath[relPath]; len(list) > 0 {
+		for i := range list {
+			if list[i].seq != seq {
+				continue
+			}
+			list = append(list[:i], list[i+1:]...)
+			break
+		}
+		if len(list) == 0 {
+			delete(byPath, relPath)
+		} else {
+			byPath[relPath] = list
+		}
+	}
+	if len(byPath) == 0 {
+		delete(fs.gitOverlayPending, workspaceID)
+	}
+}
+
+// forgetPendingGitOverlayEntriesThrough drops every pending record for the
+// path up to and including seq. A write-back request whose remote write just
+// landed is made permanent in the runtime, which prunes every apply below it;
+// the pending list mirrors that prune. Newer records still in flight survive.
+func (fs *Dat9FS) forgetPendingGitOverlayEntriesThrough(workspaceID, relPath string, seq uint64) {
+	if fs == nil || relPath == "" || seq == 0 {
 		return
 	}
-	delete(byPath, relPath)
+	fs.gitOverlayMu.Lock()
+	defer fs.gitOverlayMu.Unlock()
+	byPath := fs.gitOverlayPending[workspaceID]
+	if byPath == nil {
+		return
+	}
+	list := byPath[relPath]
+	pos := 0
+	for pos < len(list) && list[pos].seq <= seq {
+		pos++
+	}
+	if pos > 0 {
+		list = append([]pendingGitOverlayEntry(nil), list[pos:]...)
+	}
+	if len(list) == 0 {
+		delete(byPath, relPath)
+	} else {
+		byPath[relPath] = list
+	}
 	if len(byPath) == 0 {
 		delete(fs.gitOverlayPending, workspaceID)
 	}
 }
 
 // mergePendingGitOverlayEntries replays the in-flight write-back entries into a
-// freshly loaded runtime so local state survives a refresh. Each replayed entry
-// keeps its own pending seq as the live writer token: the request that queued it
-// can still recognise and clean up its own entry after the refresh, while a
-// newer same-path writer keeps its token and therefore its entry.
+// freshly loaded runtime so local state survives a refresh. Each path replays
+// its whole pending list in seq (apply) order — a valid recreate sitting under
+// a stale top-of-stack apply must not be lost. Every replayed entry keeps its
+// own pending seq as the live writer token: the request that queued it can
+// still recognise and commit or clean up its own entry after the refresh,
+// while a newer same-path writer keeps its token and therefore its entry.
 func (fs *Dat9FS) mergePendingGitOverlayEntries(workspaceID string, rt *gitWorkspaceRuntime) {
 	if fs == nil || rt == nil {
 		return
 	}
 	fs.gitOverlayMu.Lock()
-	pending := make(map[string]pendingGitOverlayEntry, len(fs.gitOverlayPending[workspaceID]))
-	for rel, entry := range fs.gitOverlayPending[workspaceID] {
-		pending[rel] = entry
+	pending := make(map[string][]pendingGitOverlayEntry, len(fs.gitOverlayPending[workspaceID]))
+	for rel, list := range fs.gitOverlayPending[workspaceID] {
+		pending[rel] = append([]pendingGitOverlayEntry(nil), list...)
 	}
 	fs.gitOverlayMu.Unlock()
 	if len(pending) == 0 {
@@ -4550,8 +4659,10 @@ func (fs *Dat9FS) mergePendingGitOverlayEntries(workspaceID string, rt *gitWorks
 	}
 	rt.mu.Lock()
 	defer rt.mu.Unlock()
-	for _, entry := range pending {
-		rt.pushOverlayApplyLocked(entry.entry, entry.seq, false)
+	for _, list := range pending {
+		for _, entry := range list {
+			rt.pushOverlayApplyLocked(entry.entry, entry.seq, false)
+		}
 	}
 }
 
@@ -4804,7 +4915,7 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 				if req.Op == "whiteout" {
 					fs.noteGitOverlayUnlinkCommitted(workspaceID, req.Path)
 				}
-				fs.forgetPendingGitOverlayEntry(workspaceID, req.Path, pendingSeq)
+				fs.forgetPendingGitOverlayEntriesThrough(workspaceID, req.Path, pendingSeq)
 				fs.commitGitOverlayApply(workspaceID, req.Path, pendingSeq)
 			}
 		}()

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -4566,6 +4566,19 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		return fs.gitOverlayShouldSuppressPublish(req.Op, workspaceID, req.Path, reservedAttempt, fh)
 	}
 	if fs.gitOverlayWriteBackEnabled(policy, forceSync) {
+		// Keep local overlay visibility for the common write-back path.
+		// Defer upsert apply only while an unlink is in flight on this path,
+		// so a later drop cannot resurrect a whiteout. Whiteout itself must
+		// apply before Unlink returns.
+		deferLocal := req.Op != "whiteout" && fs.gitOverlayUnlinkAttemptIfBlocked(workspaceID, req.Path) > 0
+		var pendingSeq uint64
+		if !deferLocal {
+			pendingSeq = fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
+			fs.applyGitOverlayEntry(workspaceID, *localEntry)
+			if req.Op == "whiteout" {
+				fs.noteGitOverlayUnlinkCommitted(workspaceID, req.Path)
+			}
+		}
 		prev, done := fs.reserveGitOverlayCommitSlot()
 		if testHookAfterGitOverlaySlotReserved != nil {
 			testHookAfterGitOverlaySlotReserved(req.Op)
@@ -4584,10 +4597,23 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 			}
 			defer close(done)
 			if dropQueued() {
+				if !deferLocal {
+					fs.forgetPendingGitOverlayEntry(workspaceID, req.Path, pendingSeq)
+					if req.Op != "whiteout" {
+						fs.applyGitOverlayEntry(workspaceID, client.GitOverlayEntry{
+							WorkspaceID: workspaceID,
+							Path:        req.Path,
+							Op:          "whiteout",
+							Kind:        "file",
+						})
+					}
+				}
 				return
 			}
-			pendingSeq := fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
-			fs.applyGitOverlayEntry(workspaceID, *localEntry)
+			if deferLocal {
+				pendingSeq = fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
+				fs.applyGitOverlayEntry(workspaceID, *localEntry)
+			}
 			timeout := releaseTimeout(req.SizeBytes)
 			commitCtx, cancel := context.WithTimeout(context.Background(), timeout)
 			defer cancel()

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -110,13 +110,14 @@ type gitWorkspaceRuntime struct {
 	nodes     map[string]client.GitTreeNode
 	children  map[string][]client.GitTreeNode
 	overlay   map[string]client.GitOverlayEntry
-	// overlayGen is the per-path local apply generation of overlay, bumped by
-	// every live-overlay mutation under mu. A request that undoes its own
-	// local write compares its generation against this map so a same-path
-	// recreate that applied later keeps its entry.
-	overlayGen map[string]uint64
-	loadedAt   time.Time
-	restored   bool
+	// overlayWriter records, per path, the gitOverlaySeq token of the local
+	// writer that installed the live entry, under mu. A request that must undo
+	// its own live write compares that token so a same-path recreate that
+	// wrote later keeps its entry; the token is carried across runtime
+	// refresh by mergePendingGitOverlayEntries.
+	overlayWriter map[string]uint64
+	loadedAt      time.Time
+	restored      bool
 
 	localTreeCommit   string
 	localNodes        map[string]client.GitTreeNode
@@ -690,7 +691,7 @@ func (fs *Dat9FS) ensureGitWorkspacesWithRefresh(ctx context.Context, force bool
 		// Preserve in-memory size fills across force-refresh (blobless trees often
 		// arrive with SizeBytes=-1; losing fills causes phantom git status dirty).
 		fs.carryGitKnownSizesIntoRuntime(rt)
-		fs.mergePendingGitOverlayEntries(ws.WorkspaceID, rt.overlay)
+		fs.mergePendingGitOverlayEntries(ws.WorkspaceID, rt)
 		loaded = append(loaded, rt)
 	}
 	var incomplete error
@@ -4218,23 +4219,30 @@ func gitOverlayEntryFromRequest(workspaceID string, req client.GitOverlayEntryRe
 	}
 }
 
-// setOverlayEntryLocked installs entry as the live overlay entry and returns
-// the path's new local apply generation. Caller must hold rt.mu for writing.
-func (rt *gitWorkspaceRuntime) setOverlayEntryLocked(entry client.GitOverlayEntry) uint64 {
+// setOverlayEntryLocked installs entry as the live overlay entry on behalf of
+// writer (a gitOverlaySeq token) and records that writer for the path. Caller
+// must hold rt.mu for writing.
+func (rt *gitWorkspaceRuntime) setOverlayEntryLocked(entry client.GitOverlayEntry, writer uint64) {
 	rt.overlay[entry.Path] = entry
-	if rt.overlayGen == nil {
-		rt.overlayGen = make(map[string]uint64)
+	if rt.overlayWriter == nil {
+		rt.overlayWriter = make(map[string]uint64)
 	}
-	rt.overlayGen[entry.Path]++
-	return rt.overlayGen[entry.Path]
+	rt.overlayWriter[entry.Path] = writer
 }
 
-// applyGitOverlayEntry mirrors entry into the live overlay and returns the
-// local apply generation this write installed for the path (0 when no runtime
-// matched). Every live-overlay mutation bumps that generation, so a caller
-// that may later need to undo its own write can prove ownership: a same-path
-// recreate that applied after it must survive the cleanup.
+// applyGitOverlayEntry mirrors entry into the live overlay as a fresh local
+// writer and returns the token it recorded (0 when no runtime matched).
+// Callers that may later need to undo their own write — the write-back drop
+// cleanup — apply with their own token via applyGitOverlayEntryAs and hand it
+// back to restoreGitOverlayWhiteoutOwned.
 func (fs *Dat9FS) applyGitOverlayEntry(workspaceID string, entry client.GitOverlayEntry) uint64 {
+	if fs == nil {
+		return 0
+	}
+	return fs.applyGitOverlayEntryAs(workspaceID, entry, fs.gitOverlaySeq.Add(1))
+}
+
+func (fs *Dat9FS) applyGitOverlayEntryAs(workspaceID string, entry client.GitOverlayEntry, writer uint64) uint64 {
 	if fs == nil || fs.git == nil {
 		return 0
 	}
@@ -4246,19 +4254,20 @@ func (fs *Dat9FS) applyGitOverlayEntry(workspaceID string, entry client.GitOverl
 		}
 		rt.mu.Lock()
 		defer rt.mu.Unlock()
-		return rt.setOverlayEntryLocked(entry)
+		rt.setOverlayEntryLocked(entry, writer)
+		return writer
 	}
 	return 0
 }
 
 // restoreGitOverlayWhiteoutOwned replaces the live entry for rel with a
-// whiteout only while gen is still that path's latest local apply generation.
-// It is the ownership-scoped form of the write-back drop cleanup: the request
-// being cleaned up may only undo its own local write, so a later legitimate
-// same-path recreate keeps its live upsert (the remote PUT it already made is
-// authoritative). Returns whether the whiteout was installed.
-func (fs *Dat9FS) restoreGitOverlayWhiteoutOwned(workspaceID, rel string, gen uint64) bool {
-	if fs == nil || fs.git == nil || rel == "" || gen == 0 {
+// whiteout only while writer is still the path's local writer token. It is the
+// ownership-scoped form of the write-back drop cleanup: the dropped request
+// may only undo its own local write, so a same-path recreate that wrote later
+// keeps its live upsert (the remote PUT it already made is authoritative).
+// Returns whether the whiteout was installed.
+func (fs *Dat9FS) restoreGitOverlayWhiteoutOwned(workspaceID, rel string, writer uint64) bool {
+	if fs == nil || fs.git == nil || rel == "" || writer == 0 {
 		return false
 	}
 	fs.git.mu.Lock()
@@ -4269,7 +4278,7 @@ func (fs *Dat9FS) restoreGitOverlayWhiteoutOwned(workspaceID, rel string, gen ui
 		}
 		rt.mu.Lock()
 		defer rt.mu.Unlock()
-		if rt.overlayGen[rel] != gen {
+		if rt.overlayWriter[rel] != writer {
 			return false
 		}
 		rt.setOverlayEntryLocked(client.GitOverlayEntry{
@@ -4277,7 +4286,7 @@ func (fs *Dat9FS) restoreGitOverlayWhiteoutOwned(workspaceID, rel string, gen ui
 			Path:        rel,
 			Op:          "whiteout",
 			Kind:        "file",
-		})
+		}, writer)
 		return true
 	}
 	return false
@@ -4310,7 +4319,7 @@ func (fs *Dat9FS) applyGitOverlayEntryUnlessWhiteout(workspaceID string, entry c
 			rt.mu.Unlock()
 			return false, true
 		}
-		rt.setOverlayEntryLocked(entry)
+		rt.setOverlayEntryLocked(entry, fs.gitOverlaySeq.Add(1))
 		rt.mu.Unlock()
 		return true, false
 	}
@@ -4416,14 +4425,28 @@ func (fs *Dat9FS) forgetPendingGitOverlayEntry(workspaceID, relPath string, seq 
 	}
 }
 
-func (fs *Dat9FS) mergePendingGitOverlayEntries(workspaceID string, overlay map[string]client.GitOverlayEntry) {
-	if fs == nil || len(overlay) == 0 && fs.gitOverlayPending == nil {
+// mergePendingGitOverlayEntries replays the in-flight write-back entries into a
+// freshly loaded runtime so local state survives a refresh. Each replayed entry
+// keeps its own pending seq as the live writer token: the request that queued it
+// can still recognise and clean up its own entry after the refresh, while a
+// newer same-path writer keeps its token and therefore its entry.
+func (fs *Dat9FS) mergePendingGitOverlayEntries(workspaceID string, rt *gitWorkspaceRuntime) {
+	if fs == nil || rt == nil {
 		return
 	}
 	fs.gitOverlayMu.Lock()
-	defer fs.gitOverlayMu.Unlock()
-	for rel, pending := range fs.gitOverlayPending[workspaceID] {
-		overlay[rel] = pending.entry
+	pending := make(map[string]pendingGitOverlayEntry, len(fs.gitOverlayPending[workspaceID]))
+	for rel, entry := range fs.gitOverlayPending[workspaceID] {
+		pending[rel] = entry
+	}
+	fs.gitOverlayMu.Unlock()
+	if len(pending) == 0 {
+		return
+	}
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	for _, entry := range pending {
+		rt.setOverlayEntryLocked(entry.entry, entry.seq)
 	}
 }
 
@@ -4623,12 +4646,15 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		// Keep local overlay visibility for the common write-back path.
 		// Defer upsert apply only while an unlink is in flight on this path,
 		// so a later drop cannot resurrect a whiteout. Whiteout itself must
-		// apply before Unlink returns.
+		// apply before Unlink returns. A request that is already stale here —
+		// its fd was marked for an unlink attempt that has committed — must
+		// not apply at all: applying late would overwrite a legitimate
+		// same-path recreate and hand this request the current writer token.
 		deferLocal := req.Op != "whiteout" && fs.gitOverlayUnlinkAttemptIfBlocked(workspaceID, req.Path) > 0
-		var pendingSeq, localGen uint64
-		if !deferLocal {
+		var pendingSeq, localWriter uint64
+		if !deferLocal && !fs.gitOverlayShouldSuppressPublish(req.Op, workspaceID, req.Path, reservedAttempt, fh) {
 			pendingSeq = fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
-			localGen = fs.applyGitOverlayEntry(workspaceID, *localEntry)
+			localWriter = fs.applyGitOverlayEntryAs(workspaceID, *localEntry, pendingSeq)
 			if req.Op == "whiteout" {
 				fs.noteGitOverlayUnlinkCommitted(workspaceID, req.Path)
 			}
@@ -4651,17 +4677,17 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 			}
 			defer close(done)
 			if dropQueued() {
-				if !deferLocal {
+				if pendingSeq != 0 {
 					fs.forgetPendingGitOverlayEntry(workspaceID, req.Path, pendingSeq)
 					if req.Op != "whiteout" {
-						fs.restoreGitOverlayWhiteoutOwned(workspaceID, req.Path, localGen)
+						fs.restoreGitOverlayWhiteoutOwned(workspaceID, req.Path, localWriter)
 					}
 				}
 				return
 			}
 			if deferLocal {
 				pendingSeq = fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
-				fs.applyGitOverlayEntry(workspaceID, *localEntry)
+				fs.applyGitOverlayEntryAs(workspaceID, *localEntry, pendingSeq)
 			}
 			timeout := releaseTimeout(req.SizeBytes)
 			commitCtx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -54,6 +54,11 @@ var errGitOverlayPublishSuppressed = errors.New("git overlay publish suppressed"
 // has joined the overlay queue behind an in-flight whiteout.
 var testHookAfterGitOverlaySlotReserved func(op string)
 
+// testHookAfterGitOverlaySlotWait fires after a queued overlay request has
+// waited for the previous slot. Tests use it to resume Flush only after
+// Unlink has fully returned and dropped the live block count.
+var testHookAfterGitOverlaySlotWait func(op string)
+
 // testHookAfterEmptyLocalScan runs after an empty-list leader scans local
 // markers and before it relocks to decide whether to disarm. Tests only.
 var testHookAfterEmptyLocalScan func()
@@ -4435,6 +4440,13 @@ func (fs *Dat9FS) gitOverlayUnlinkBlocksPublish(workspaceID, rel string) bool {
 	return n > 0
 }
 
+func (fs *Dat9FS) gitOverlayShouldDropQueuedPublish(op, workspaceID, rel string, reservedDuringUnlink bool) bool {
+	if op == "whiteout" {
+		return false
+	}
+	return reservedDuringUnlink || fs.gitOverlayUnlinkBlocksPublish(workspaceID, rel)
+}
+
 func (fs *Dat9FS) putGitOverlayRemote(ctx context.Context, workspaceID string, req client.GitOverlayEntryRequest) (*client.GitOverlayEntry, error) {
 	if fs == nil || fs.client == nil {
 		return nil, syscall.EIO
@@ -4466,6 +4478,7 @@ func (fs *Dat9FS) putGitOverlay(ctx context.Context, workspaceID string, req cli
 func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID string, req client.GitOverlayEntryRequest, policy WritePolicy, forceSync bool) (*client.GitOverlayEntry, error) {
 	req = normalizeGitOverlayRequest(req)
 	localEntry := gitOverlayEntryFromRequest(workspaceID, req)
+	reservedDuringUnlink := req.Op != "whiteout" && fs.gitOverlayUnlinkBlocksPublish(workspaceID, req.Path)
 	if fs.gitOverlayWriteBackEnabled(policy, forceSync) {
 		pendingSeq := fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
 		fs.applyGitOverlayEntry(workspaceID, *localEntry)
@@ -4482,8 +4495,11 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 			if prev != nil {
 				<-prev
 			}
+			if testHookAfterGitOverlaySlotWait != nil {
+				testHookAfterGitOverlaySlotWait(req.Op)
+			}
 			defer close(done)
-			if req.Op != "whiteout" && fs.gitOverlayUnlinkBlocksPublish(workspaceID, req.Path) {
+			if fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedDuringUnlink) {
 				return
 			}
 			timeout := releaseTimeout(req.SizeBytes)
@@ -4507,8 +4523,11 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 	if prev != nil {
 		<-prev
 	}
+	if testHookAfterGitOverlaySlotWait != nil {
+		testHookAfterGitOverlaySlotWait(req.Op)
+	}
 	defer close(done)
-	if req.Op != "whiteout" && fs.gitOverlayUnlinkBlocksPublish(workspaceID, req.Path) {
+	if fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedDuringUnlink) {
 		return nil, errGitOverlayPublishSuppressed
 	}
 	entry, err := fs.putGitOverlayRemote(ctx, workspaceID, req)

--- a/pkg/fuse/git_workspace.go
+++ b/pkg/fuse/git_workspace.go
@@ -59,6 +59,11 @@ var testHookAfterGitOverlaySlotReserved func(op string)
 // Unlink has fully returned and dropped the live block count.
 var testHookAfterGitOverlaySlotWait func(op string)
 
+// testHookAfterGitOverlayAttemptSample fires after sampling the unlink
+// attempt id and before reserving the overlay slot. Tests use it to run
+// Unlink after a handle has captured bytes but before it joins the queue.
+var testHookAfterGitOverlayAttemptSample func(op string)
+
 // testHookAfterEmptyLocalScan runs after an empty-list leader scans local
 // markers and before it relocks to decide whether to disarm. Tests only.
 var testHookAfterEmptyLocalScan func()
@@ -4473,6 +4478,16 @@ func (fs *Dat9FS) gitOverlayShouldDropQueuedPublish(op, workspaceID, rel string,
 	return committed >= reservedAttempt
 }
 
+func gitOverlayHandleUnlinked(fh *FileHandle) bool {
+	if fh == nil {
+		return false
+	}
+	fh.Lock()
+	unlinked := fh.Unlinked
+	fh.Unlock()
+	return unlinked
+}
+
 func (fs *Dat9FS) putGitOverlayRemote(ctx context.Context, workspaceID string, req client.GitOverlayEntryRequest) (*client.GitOverlayEntry, error) {
 	if fs == nil || fs.client == nil {
 		return nil, syscall.EIO
@@ -4498,15 +4513,24 @@ func (fs *Dat9FS) putGitOverlay(ctx context.Context, workspaceID string, req cli
 	if fs != nil && fs.opts != nil && fs.opts.WritePolicy != "" {
 		policy = fs.opts.WritePolicy
 	}
-	return fs.putGitOverlayWithPolicy(ctx, workspaceID, req, policy, false)
+	return fs.putGitOverlayWithPolicy(ctx, workspaceID, req, policy, false, nil)
 }
 
-func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID string, req client.GitOverlayEntryRequest, policy WritePolicy, forceSync bool) (*client.GitOverlayEntry, error) {
+func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID string, req client.GitOverlayEntryRequest, policy WritePolicy, forceSync bool, fh *FileHandle) (*client.GitOverlayEntry, error) {
 	req = normalizeGitOverlayRequest(req)
 	localEntry := gitOverlayEntryFromRequest(workspaceID, req)
 	reservedAttempt := fs.gitOverlayUnlinkAttemptIfBlocked(workspaceID, req.Path)
 	if req.Op == "whiteout" {
 		reservedAttempt = 0
+	}
+	if testHookAfterGitOverlayAttemptSample != nil {
+		testHookAfterGitOverlayAttemptSample(req.Op)
+	}
+	dropQueued := func() bool {
+		if req.Op != "whiteout" && gitOverlayHandleUnlinked(fh) {
+			return true
+		}
+		return fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedAttempt)
 	}
 	if fs.gitOverlayWriteBackEnabled(policy, forceSync) {
 		pendingSeq := fs.rememberPendingGitOverlayEntry(workspaceID, *localEntry)
@@ -4528,7 +4552,7 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 				testHookAfterGitOverlaySlotWait(req.Op)
 			}
 			defer close(done)
-			if fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedAttempt) {
+			if dropQueued() {
 				return
 			}
 			timeout := releaseTimeout(req.SizeBytes)
@@ -4559,7 +4583,7 @@ func (fs *Dat9FS) putGitOverlayWithPolicy(ctx context.Context, workspaceID strin
 		testHookAfterGitOverlaySlotWait(req.Op)
 	}
 	defer close(done)
-	if fs.gitOverlayShouldDropQueuedPublish(req.Op, workspaceID, req.Path, reservedAttempt) {
+	if dropQueued() {
 		return nil, errGitOverlayPublishSuppressed
 	}
 	entry, err := fs.putGitOverlayRemote(ctx, workspaceID, req)
@@ -4679,7 +4703,7 @@ func (fs *Dat9FS) syncGitDirtyMirrorRoot(workspaceID string, rt *gitWorkspaceRun
 			BaseObjectSHA: base,
 			Content:       data,
 			SizeBytes:     int64(len(data)),
-		}, WritePolicyWriteSync, true)
+		}, WritePolicyWriteSync, true, nil)
 		cancel()
 		if err != nil {
 			safeLogPrintf("git workspace dirty mirror sync failed workspace=%s root=%s path=%s: %v", workspaceID, dirtyRoot, rel, err)
@@ -4723,7 +4747,7 @@ func (fs *Dat9FS) flushGitLocalFileHandleLockedWithPolicy(ctx context.Context, f
 		SizeBytes:     int64(len(data)),
 	}
 	fh.Unlock()
-	_, err = fs.putGitOverlayWithPolicy(ctx, fh.GitWorkspaceID, req, fh.WritePolicy, forceSync)
+	_, err = fs.putGitOverlayWithPolicy(ctx, fh.GitWorkspaceID, req, fh.WritePolicy, forceSync, fh)
 	fh.Lock()
 	if errors.Is(err, errGitOverlayPublishSuppressed) {
 		return gofuse.OK
@@ -4775,7 +4799,7 @@ func (fs *Dat9FS) flushGitHandleLockedWithPolicy(ctx context.Context, fh *FileHa
 			SizeBytes:     fh.OrigSize,
 		}
 		fh.Unlock()
-		_, err := fs.putGitOverlayWithPolicy(ctx, fh.GitWorkspaceID, req, fh.WritePolicy, forceSync)
+		_, err := fs.putGitOverlayWithPolicy(ctx, fh.GitWorkspaceID, req, fh.WritePolicy, forceSync, fh)
 		fh.Lock()
 		if errors.Is(err, errGitOverlayPublishSuppressed) {
 			return gofuse.OK
@@ -4801,7 +4825,7 @@ func (fs *Dat9FS) flushGitHandleLockedWithPolicy(ctx context.Context, fh *FileHa
 		SizeBytes:     int64(len(data)),
 	}
 	fh.Unlock()
-	_, err := fs.putGitOverlayWithPolicy(ctx, fh.GitWorkspaceID, req, fh.WritePolicy, forceSync)
+	_, err := fs.putGitOverlayWithPolicy(ctx, fh.GitWorkspaceID, req, fh.WritePolicy, forceSync, fh)
 	fh.Lock()
 	if errors.Is(err, errGitOverlayPublishSuppressed) {
 		return gofuse.OK

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -4794,7 +4794,25 @@ func TestGitWorkspaceFlushQueuedDuringWhiteoutDoesNotUpsert(t *testing.T) {
 			upsertOnce.Do(func() { close(upsertQueued) })
 		}
 	}
-	t.Cleanup(func() { testHookAfterGitOverlaySlotReserved = nil })
+	flushWaited := make(chan struct{})
+	releaseFlush := make(chan struct{})
+	var waitOnce sync.Once
+	testHookAfterGitOverlaySlotWait = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		waitOnce.Do(func() { close(flushWaited) })
+		<-releaseFlush
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlaySlotReserved = nil
+		testHookAfterGitOverlaySlotWait = nil
+		select {
+		case <-releaseFlush:
+		default:
+			close(releaseFlush)
+		}
+	})
 
 	flushDone := make(chan gofuse.Status, 1)
 	go func() {
@@ -4808,10 +4826,16 @@ func TestGitWorkspaceFlushQueuedDuringWhiteoutDoesNotUpsert(t *testing.T) {
 
 	close(postWait)
 	unlinkSt := <-unlinkDone
-	flushSt := <-flushDone
 	if unlinkSt != gofuse.OK {
 		t.Fatalf("Unlink status = %v, want OK", unlinkSt)
 	}
+	select {
+	case <-flushWaited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Flush never resumed after the whiteout slot")
+	}
+	close(releaseFlush)
+	flushSt := <-flushDone
 	if flushSt != gofuse.OK {
 		t.Fatalf("Flush status = %v, want OK", flushSt)
 	}
@@ -4824,6 +4848,41 @@ func TestGitWorkspaceFlushQueuedDuringWhiteoutDoesNotUpsert(t *testing.T) {
 	}
 	if !ok || entry.Op != "whiteout" {
 		t.Fatalf("overlay entry = %+v, %v — want whiteout preserved", entry, ok)
+	}
+
+	testHookAfterGitOverlaySlotReserved = nil
+	testHookAfterGitOverlaySlotWait = nil
+	var recreate gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT | syscall.O_TRUNC),
+		Mode:     0o644,
+	}, "sync.txt", &recreate); st != gofuse.OK {
+		t.Fatalf("recreate after unlink = %v, want OK", st)
+	}
+	v3 := []byte("git-v3")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: recreate.NodeId},
+		Fh:       recreate.Fh,
+		Size:     uint32(len(v3)),
+	}, v3); st != gofuse.OK {
+		t.Fatalf("recreate Write = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: recreate.NodeId},
+		Fh:       recreate.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("recreate Fsync = %v, want OK", st)
+	}
+	fixture.mu.Lock()
+	entry, ok = fixture.overlay["sync.txt"]
+	putsAfterCreate := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if putsAfterCreate <= puts {
+		t.Fatalf("recreate overlay puts = %d, want > %d", putsAfterCreate, puts)
+	}
+	if !ok || entry.Op != "upsert" {
+		t.Fatalf("overlay after recreate = %+v, %v — want upsert", entry, ok)
 	}
 }
 

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -6299,12 +6299,191 @@ func TestGitWorkspaceWriteBackRecreateAfterStaleCheckKeepsRecreatedFile(t *testi
 	}
 }
 
-// TestGitWorkspaceRefreshMergeCarriesWriterToken: a refresh rebuilds the
-// runtime and replays in-flight write-back entries into it. The replayed entry
-// must keep the writer token of the request that queued it, otherwise that
-// request can no longer recognise its own live entry and its drop cleanup
+// TestGitWorkspaceWriteBackDroppedRequestsDoNotRestoreEachOther: two stale
+// requests on the same path can both pass the staleness check and apply before
+// either is dropped. Each drop must remove only its own live entry, so the
+// later drop cannot put back the entry of the request that was already dropped
+// — that would leave the deleted name visible locally while the remote holds
+// the whiteout.
+func TestGitWorkspaceWriteBackDroppedRequestsDoNotRestoreEachOther(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{
+		LocalRoot:           t.TempDir(),
+		WritePolicy:         WritePolicyWriteBack,
+		SyncMode:            SyncInteractive,
+		EnableGitWorkspaces: true,
+	}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	fs.syncMode = SyncInteractive
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	// A second handle on the same path, so two stale requests can overlap.
+	var openOut gofuse.OpenOut
+	if st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Flags:    uint32(syscall.O_RDWR),
+	}, &openOut); st != gofuse.OK {
+		t.Fatalf("Open status = %v, want OK", st)
+	}
+	for _, w := range []struct {
+		fh   uint64
+		body []byte
+	}{
+		{createOut.Fh, []byte("git-v2-stale-a")},
+		{openOut.Fh, []byte("git-v2-stale-b")},
+	} {
+		if _, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       w.fh,
+			Size:     uint32(len(w.body)),
+		}, w.body); st != gofuse.OK {
+			t.Fatalf("Write %q status = %v, want OK", w.body, st)
+		}
+	}
+
+	// Both requests pass the staleness check and park there.
+	checked := make(chan struct{})
+	releaseChecks := make(chan struct{})
+	var checkMu sync.Mutex
+	checkCount := 0
+	testHookAfterGitOverlayStaleCheck = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		checkMu.Lock()
+		checkCount++
+		seen := checkCount
+		checkMu.Unlock()
+		if seen == 2 {
+			close(checked)
+		}
+		<-releaseChecks
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlayStaleCheck = nil
+		select {
+		case <-releaseChecks:
+		default:
+			close(releaseChecks)
+		}
+	})
+
+	firstDone := make(chan gofuse.Status, 1)
+	secondDone := make(chan gofuse.Status, 1)
+	go func() {
+		firstDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	go func() {
+		secondDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       openOut.Fh,
+		})
+	}()
+	select {
+	case <-checked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("both stale Fsyncs never reached the overlay staleness check")
+	}
+
+	// Unlink commits: both requests are stale from here on.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	// Let the first request apply and park it on its overlay slot, so the
+	// second one applies on top of it and the queue drains first -> second.
+	resumed := make(chan struct{})
+	releaseDrop := make(chan struct{})
+	waitOnce := sync.Once{}
+	testHookAfterGitOverlaySlotWait = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		waitOnce.Do(func() { close(resumed) })
+		<-releaseDrop
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlaySlotWait = nil
+		select {
+		case <-releaseDrop:
+		default:
+			close(releaseDrop)
+		}
+	})
+
+	close(releaseChecks)
+	select {
+	case <-resumed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("first stale Fsync never resumed after its overlay slot wait")
+	}
+	close(releaseDrop)
+	if st := <-firstDone; st != gofuse.OK {
+		t.Fatalf("first Fsync status = %v, want OK", st)
+	}
+	if st := <-secondDone; st != gofuse.OK {
+		t.Fatalf("second Fsync status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	fixture.mu.Lock()
+	remote, remoteOK := fixture.overlay["sync.txt"]
+	puts := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if !remoteOK || remote.Op != "whiteout" {
+		t.Fatalf("remote overlay = %+v, %v — want whiteout", remote, remoteOK)
+	}
+	if puts != 2 {
+		t.Fatalf("overlay puts = %d, want 2 (seed + whiteout); stale upserts must not publish", puts)
+	}
+	rt, _, _ := fs.gitWorkspaceForPath(context.Background(), "/repo")
+	if rt == nil {
+		t.Fatal("git workspace runtime missing")
+	}
+	live, liveOK := rt.overlayEntry("sync.txt")
+	if !liveOK || live.Op != "whiteout" {
+		t.Fatalf("live overlay = %+v, %v — want whiteout; dropped requests restored each other", live, liveOK)
+	}
+}
+
+// TestGitWorkspaceRefreshMergeKeepsWithdrawableApply: a refresh rebuilds the
+// runtime and replays in-flight write-back entries into it. A replayed entry
+// must stay withdrawable by the request that queued it, otherwise its drop
 // silently leaves the stale upsert (and the deleted name) visible locally.
-func TestGitWorkspaceRefreshMergeCarriesWriterToken(t *testing.T) {
+func TestGitWorkspaceRefreshMergeKeepsWithdrawableApply(t *testing.T) {
 	fixture := newGitWorkspaceFixture(t)
 	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
 	opts.setDefaults()
@@ -6317,7 +6496,6 @@ func TestGitWorkspaceRefreshMergeCarriesWriterToken(t *testing.T) {
 		t.Fatal("workspace ws1 not loaded")
 	}
 
-	// A write-back upsert is queued and applied, then the request parks.
 	upsert := client.GitOverlayEntry{
 		WorkspaceID: "ws1",
 		Path:        "race.txt",
@@ -6328,10 +6506,6 @@ func TestGitWorkspaceRefreshMergeCarriesWriterToken(t *testing.T) {
 		Content:     []byte("git-"),
 	}
 	seq := fs.rememberPendingGitOverlayEntry("ws1", upsert)
-	rec := fs.applyGitOverlayEntryAs("ws1", upsert, seq)
-	if rec.writer != seq {
-		t.Fatalf("apply writer token = %d, want %d", rec.writer, seq)
-	}
 
 	// Refresh: a fresh runtime loaded from the server (whiteout already
 	// committed) replaces the old one, and the pending replay runs into it.
@@ -6350,20 +6524,19 @@ func TestGitWorkspaceRefreshMergeCarriesWriterToken(t *testing.T) {
 	fs.git.workspaces = []*gitWorkspaceRuntime{fresh}
 	fs.git.mu.Unlock()
 
-	// The queued request must still be able to clean up its own entry.
-	if !fs.undoGitOverlayLocalWrite("ws1", "race.txt", rec) {
-		t.Fatal("owner lost its live entry across refresh; drop cleanup would leave the stale upsert")
-	}
+	// The queued request must still be able to withdraw its own entry.
+	fs.dropGitOverlayApply("ws1", "race.txt", seq)
 	live, _ := fresh.overlayEntry("race.txt")
 	if live.Op != "whiteout" {
-		t.Fatalf("live overlay op = %q, want whiteout after owner cleanup", live.Op)
+		t.Fatalf("live overlay op = %q, want whiteout after the owner dropped its apply", live.Op)
 	}
 
 	// A newer same-path writer that survived the refresh keeps its entry: the
-	// stale owner must not white it out.
+	// stale request's drop must not remove it.
 	recreate := upsert
 	recreate.Content = []byte("git-2")
-	if fs.rememberPendingGitOverlayEntry("ws1", recreate) == 0 {
+	newerSeq := fs.rememberPendingGitOverlayEntry("ws1", recreate)
+	if newerSeq == 0 {
 		t.Fatal("recreate pending seq missing")
 	}
 	recreated := &gitWorkspaceRuntime{
@@ -6375,9 +6548,7 @@ func TestGitWorkspaceRefreshMergeCarriesWriterToken(t *testing.T) {
 	fs.git.mu.Lock()
 	fs.git.workspaces = []*gitWorkspaceRuntime{recreated}
 	fs.git.mu.Unlock()
-	if fs.undoGitOverlayLocalWrite("ws1", "race.txt", rec) {
-		t.Fatal("stale owner whited out a newer recreated entry")
-	}
+	fs.dropGitOverlayApply("ws1", "race.txt", seq)
 	live, _ = recreated.overlayEntry("race.txt")
 	if live.Op != "upsert" || string(live.Content) != string(recreate.Content) {
 		t.Fatalf("live overlay = %+v — want the recreated upsert preserved", live)

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -5670,6 +5670,176 @@ func TestGitWorkspaceWriteBackUnlinkDoesNotLeavePendingUpsert(t *testing.T) {
 	}
 }
 
+// TestGitWorkspaceWriteBackStaleDropKeepsRecreatedLiveUpsert: the write-back
+// drop cleanup may only undo the local overlay write the dropped request
+// itself installed. When a legitimate same-path recreate (new handle) applies
+// its live upsert after that write and before the stale request resumes, the
+// cleanup must leave the recreate's entry alone — otherwise the deleted name
+// stays hidden locally even though its new content is already remote.
+func TestGitWorkspaceWriteBackStaleDropKeepsRecreatedLiveUpsert(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{
+		LocalRoot:           t.TempDir(),
+		WritePolicy:         WritePolicyWriteBack,
+		SyncMode:            SyncInteractive,
+		EnableGitWorkspaces: true,
+	}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	fs.syncMode = SyncInteractive
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	stale := []byte("git-v2-stale")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(stale)),
+	}, stale); st != gofuse.OK {
+		t.Fatalf("Write stale status = %v, want OK", st)
+	}
+
+	// Park the stale Fsync after it sampled the unlink attempt, so the unlink
+	// completes while the request is still on its way into the overlay queue.
+	sampled := make(chan struct{})
+	releaseStale := make(chan struct{})
+	var sampleOnce sync.Once
+	testHookAfterGitOverlayAttemptSample = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		sampleOnce.Do(func() { close(sampled) })
+		<-releaseStale
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlayAttemptSample = nil
+		select {
+		case <-releaseStale:
+		default:
+			close(releaseStale)
+		}
+	})
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	select {
+	case <-sampled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale Fsync never sampled overlay unlink attempt")
+	}
+
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	// Park the stale request after it reserved and waited its overlay slot, so
+	// the recreate below applies its own live upsert first.
+	resumed := make(chan struct{})
+	releaseDrop := make(chan struct{})
+	var waitOnce sync.Once
+	testHookAfterGitOverlaySlotWait = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		waitOnce.Do(func() { close(resumed) })
+		<-releaseDrop
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlaySlotWait = nil
+		select {
+		case <-releaseDrop:
+		default:
+			close(releaseDrop)
+		}
+	})
+
+	close(releaseStale)
+	select {
+	case <-resumed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale Fsync never resumed after its overlay slot wait")
+	}
+
+	var recreate gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT | syscall.O_TRUNC),
+		Mode:     0o644,
+	}, "sync.txt", &recreate); st != gofuse.OK {
+		t.Fatalf("recreate Create = %v, want OK", st)
+	}
+	v3 := []byte("replacement-v3")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: recreate.NodeId},
+		Fh:       recreate.Fh,
+		Size:     uint32(len(v3)),
+	}, v3); st != gofuse.OK {
+		t.Fatalf("recreate Write = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: recreate.NodeId},
+		Fh:       recreate.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("recreate Fsync = %v, want OK", st)
+	}
+
+	// The recreate request is queued behind the parked stale request; let the
+	// stale one finish, then drain both.
+	close(releaseDrop)
+	if st := <-fsyncDone; st != gofuse.OK {
+		t.Fatalf("stale Fsync status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	fixture.mu.Lock()
+	remote, remoteOK := fixture.overlay["sync.txt"]
+	fixture.mu.Unlock()
+	if !remoteOK || remote.Op != "upsert" || string(remote.Content) != string(v3) {
+		t.Fatalf("remote overlay = %+v, %v — want recreate upsert %q", remote, remoteOK, v3)
+	}
+	rt, _, _ := fs.gitWorkspaceForPath(context.Background(), "/repo")
+	if rt == nil {
+		t.Fatal("git workspace runtime missing")
+	}
+	live, liveOK := rt.overlayEntry("sync.txt")
+	if !liveOK || live.Op != "upsert" || string(live.Content) != string(v3) {
+		t.Fatalf("live overlay = %+v, %v — want recreate upsert %q (stale cleanup must not hide it)", live, liveOK, v3)
+	}
+}
+
 // TestGitWorkspaceOpenStraddlingWhiteoutMarkedUnlinked: an Open whose overlay
 // read snapshots the pre-whiteout state, but whose handle registers only after
 // the unlink's whiteout and post-commit pass have both completed, must still

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -6146,6 +6146,159 @@ func TestGitWorkspaceWriteBackRefreshDuringStaleDropKeepsWhiteout(t *testing.T) 
 	}
 }
 
+// TestGitWorkspaceWriteBackRecreateAfterStaleCheckKeepsRecreatedFile: the
+// write-back staleness check and the live apply cannot be atomic, so a request
+// that passes the check can still be overtaken by Unlink plus a same-path
+// recreate before it applies. Its drop cleanup must put back the entry it
+// replaced instead of forcing a whiteout over the recreated file.
+func TestGitWorkspaceWriteBackRecreateAfterStaleCheckKeepsRecreatedFile(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{
+		LocalRoot:           t.TempDir(),
+		WritePolicy:         WritePolicyWriteBack,
+		SyncMode:            SyncInteractive,
+		EnableGitWorkspaces: true,
+	}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	fs.syncMode = SyncInteractive
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	stale := []byte("git-v2-stale")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(stale)),
+	}, stale); st != gofuse.OK {
+		t.Fatalf("Write stale status = %v, want OK", st)
+	}
+
+	checked := make(chan struct{})
+	releaseStale := make(chan struct{})
+	var checkOnce sync.Once
+	testHookAfterGitOverlayStaleCheck = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		park := false
+		checkOnce.Do(func() {
+			park = true
+			close(checked)
+		})
+		if park {
+			<-releaseStale
+		}
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlayStaleCheck = nil
+		select {
+		case <-releaseStale:
+		default:
+			close(releaseStale)
+		}
+	})
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	select {
+	case <-checked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale Fsync never passed the overlay staleness check")
+	}
+
+	// Unlink and a full recreate land while the stale request is parked after
+	// its check but before its apply.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	var recreate gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT | syscall.O_TRUNC),
+		Mode:     0o644,
+	}, "sync.txt", &recreate); st != gofuse.OK {
+		t.Fatalf("recreate Create = %v, want OK", st)
+	}
+	v3 := []byte("replacement-v3")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: recreate.NodeId},
+		Fh:       recreate.Fh,
+		Size:     uint32(len(v3)),
+	}, v3); st != gofuse.OK {
+		t.Fatalf("recreate Write = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: recreate.NodeId},
+		Fh:       recreate.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("recreate Fsync = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+	fixture.mu.Lock()
+	putsBeforeStale := fixture.overlayPuts
+	fixture.mu.Unlock()
+
+	close(releaseStale)
+	if st := <-fsyncDone; st != gofuse.OK {
+		t.Fatalf("stale Fsync status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	fixture.mu.Lock()
+	remote, remoteOK := fixture.overlay["sync.txt"]
+	putsAfterStale := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if putsAfterStale != putsBeforeStale {
+		t.Fatalf("overlay puts = %d, want %d — stale upsert must not publish", putsAfterStale, putsBeforeStale)
+	}
+	if !remoteOK || remote.Op != "upsert" || string(remote.Content) != string(v3) {
+		t.Fatalf("remote overlay = %+v, %v — want recreate upsert %q", remote, remoteOK, v3)
+	}
+	rt, _, _ := fs.gitWorkspaceForPath(context.Background(), "/repo")
+	if rt == nil {
+		t.Fatal("git workspace runtime missing")
+	}
+	live, liveOK := rt.overlayEntry("sync.txt")
+	if !liveOK || live.Op != "upsert" || string(live.Content) != string(v3) {
+		t.Fatalf("live overlay = %+v, %v — want recreate upsert %q (cleanup must restore what it replaced)", live, liveOK, v3)
+	}
+}
+
 // TestGitWorkspaceRefreshMergeCarriesWriterToken: a refresh rebuilds the
 // runtime and replays in-flight write-back entries into it. The replayed entry
 // must keep the writer token of the request that queued it, otherwise that
@@ -6175,8 +6328,9 @@ func TestGitWorkspaceRefreshMergeCarriesWriterToken(t *testing.T) {
 		Content:     []byte("git-"),
 	}
 	seq := fs.rememberPendingGitOverlayEntry("ws1", upsert)
-	if got := fs.applyGitOverlayEntryAs("ws1", upsert, seq); got != seq {
-		t.Fatalf("apply writer token = %d, want %d", got, seq)
+	rec := fs.applyGitOverlayEntryAs("ws1", upsert, seq)
+	if rec.writer != seq {
+		t.Fatalf("apply writer token = %d, want %d", rec.writer, seq)
 	}
 
 	// Refresh: a fresh runtime loaded from the server (whiteout already
@@ -6197,7 +6351,7 @@ func TestGitWorkspaceRefreshMergeCarriesWriterToken(t *testing.T) {
 	fs.git.mu.Unlock()
 
 	// The queued request must still be able to clean up its own entry.
-	if !fs.restoreGitOverlayWhiteoutOwned("ws1", "race.txt", seq) {
+	if !fs.undoGitOverlayLocalWrite("ws1", "race.txt", rec) {
 		t.Fatal("owner lost its live entry across refresh; drop cleanup would leave the stale upsert")
 	}
 	live, _ := fresh.overlayEntry("race.txt")
@@ -6221,7 +6375,7 @@ func TestGitWorkspaceRefreshMergeCarriesWriterToken(t *testing.T) {
 	fs.git.mu.Lock()
 	fs.git.workspaces = []*gitWorkspaceRuntime{recreated}
 	fs.git.mu.Unlock()
-	if fs.restoreGitOverlayWhiteoutOwned("ws1", "race.txt", seq) {
+	if fs.undoGitOverlayLocalWrite("ws1", "race.txt", rec) {
 		t.Fatal("stale owner whited out a newer recreated entry")
 	}
 	live, _ = recreated.overlayEntry("race.txt")

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -5840,6 +5840,396 @@ func TestGitWorkspaceWriteBackStaleDropKeepsRecreatedLiveUpsert(t *testing.T) {
 	}
 }
 
+// TestGitWorkspaceWriteBackLateStaleDropKeepsRecreatedFile: a stale request
+// that resumes only after the name was fully recreated must not write its own
+// live entry at all. Its apply would overwrite the recreate and hand this
+// request the current writer token, so the drop cleanup could not tell that it
+// no longer owns the path and would hide the recreated file locally.
+func TestGitWorkspaceWriteBackLateStaleDropKeepsRecreatedFile(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{
+		LocalRoot:           t.TempDir(),
+		WritePolicy:         WritePolicyWriteBack,
+		SyncMode:            SyncInteractive,
+		EnableGitWorkspaces: true,
+	}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	fs.syncMode = SyncInteractive
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	stale := []byte("git-v2-stale")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(stale)),
+	}, stale); st != gofuse.OK {
+		t.Fatalf("Write stale status = %v, want OK", st)
+	}
+
+	sampled := make(chan struct{})
+	releaseStale := make(chan struct{})
+	var sampleOnce sync.Once
+	testHookAfterGitOverlayAttemptSample = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		park := false
+		sampleOnce.Do(func() {
+			park = true
+			close(sampled)
+		})
+		if park {
+			<-releaseStale
+		}
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlayAttemptSample = nil
+		select {
+		case <-releaseStale:
+		default:
+			close(releaseStale)
+		}
+	})
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	select {
+	case <-sampled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale Fsync never sampled overlay unlink attempt")
+	}
+
+	// Unlink commits while the stale request is still parked before its apply.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	// The name is fully recreated, remote PUT included, before the stale
+	// request resumes.
+	var recreate gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT | syscall.O_TRUNC),
+		Mode:     0o644,
+	}, "sync.txt", &recreate); st != gofuse.OK {
+		t.Fatalf("recreate Create = %v, want OK", st)
+	}
+	v3 := []byte("replacement-v3")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: recreate.NodeId},
+		Fh:       recreate.Fh,
+		Size:     uint32(len(v3)),
+	}, v3); st != gofuse.OK {
+		t.Fatalf("recreate Write = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: recreate.NodeId},
+		Fh:       recreate.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("recreate Fsync = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+	fixture.mu.Lock()
+	putsBeforeStale := fixture.overlayPuts
+	fixture.mu.Unlock()
+
+	close(releaseStale)
+	if st := <-fsyncDone; st != gofuse.OK {
+		t.Fatalf("stale Fsync status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	fixture.mu.Lock()
+	remote, remoteOK := fixture.overlay["sync.txt"]
+	putsAfterStale := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if putsAfterStale != putsBeforeStale {
+		t.Fatalf("overlay puts = %d, want %d — stale upsert must not publish", putsAfterStale, putsBeforeStale)
+	}
+	if !remoteOK || remote.Op != "upsert" || string(remote.Content) != string(v3) {
+		t.Fatalf("remote overlay = %+v, %v — want recreate upsert %q", remote, remoteOK, v3)
+	}
+	rt, _, _ := fs.gitWorkspaceForPath(context.Background(), "/repo")
+	if rt == nil {
+		t.Fatal("git workspace runtime missing")
+	}
+	live, liveOK := rt.overlayEntry("sync.txt")
+	if !liveOK || live.Op != "upsert" || string(live.Content) != string(v3) {
+		t.Fatalf("live overlay = %+v, %v — want recreate upsert %q (late stale request must not apply or undo)", live, liveOK, v3)
+	}
+}
+
+// TestGitWorkspaceWriteBackRefreshDuringStaleDropKeepsWhiteout: a workspace
+// refresh that lands between a stale request's enqueue and its drop must not
+// let the deleted name reappear locally. The refreshed runtime replays
+// in-flight write-back state, and the stale request's cleanup must still be
+// able to remove it (or must never have contributed it in the first place).
+func TestGitWorkspaceWriteBackRefreshDuringStaleDropKeepsWhiteout(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{
+		LocalRoot:           t.TempDir(),
+		WritePolicy:         WritePolicyWriteBack,
+		SyncMode:            SyncInteractive,
+		EnableGitWorkspaces: true,
+	}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	fs.syncMode = SyncInteractive
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	stale := []byte("git-v2-stale")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(stale)),
+	}, stale); st != gofuse.OK {
+		t.Fatalf("Write stale status = %v, want OK", st)
+	}
+
+	sampled := make(chan struct{})
+	releaseStale := make(chan struct{})
+	var sampleOnce sync.Once
+	testHookAfterGitOverlayAttemptSample = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		park := false
+		sampleOnce.Do(func() {
+			park = true
+			close(sampled)
+		})
+		if park {
+			<-releaseStale
+		}
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlayAttemptSample = nil
+		select {
+		case <-releaseStale:
+		default:
+			close(releaseStale)
+		}
+	})
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	select {
+	case <-sampled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale Fsync never sampled overlay unlink attempt")
+	}
+
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	// Park the stale request once it has its overlay slot, then refresh the
+	// workspace underneath it.
+	resumed := make(chan struct{})
+	releaseDrop := make(chan struct{})
+	var waitOnce sync.Once
+	testHookAfterGitOverlaySlotWait = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		waitOnce.Do(func() { close(resumed) })
+		<-releaseDrop
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlaySlotWait = nil
+		select {
+		case <-releaseDrop:
+		default:
+			close(releaseDrop)
+		}
+	})
+
+	close(releaseStale)
+	select {
+	case <-resumed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale Fsync never resumed after its overlay slot wait")
+	}
+
+	if err := fs.ensureGitWorkspacesWithRefresh(context.Background(), true); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	close(releaseDrop)
+	if st := <-fsyncDone; st != gofuse.OK {
+		t.Fatalf("stale Fsync status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	fixture.mu.Lock()
+	remote, remoteOK := fixture.overlay["sync.txt"]
+	fixture.mu.Unlock()
+	if !remoteOK || remote.Op != "whiteout" {
+		t.Fatalf("remote overlay = %+v, %v — want whiteout", remote, remoteOK)
+	}
+	rt, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo")
+	if !ok || rt == nil {
+		t.Fatal("git workspace runtime missing after refresh")
+	}
+	live, liveOK := rt.overlayEntry("sync.txt")
+	if !liveOK || live.Op != "whiteout" {
+		t.Fatalf("live overlay = %+v, %v — want whiteout; stale upsert reappeared locally after refresh", live, liveOK)
+	}
+}
+
+// TestGitWorkspaceRefreshMergeCarriesWriterToken: a refresh rebuilds the
+// runtime and replays in-flight write-back entries into it. The replayed entry
+// must keep the writer token of the request that queued it, otherwise that
+// request can no longer recognise its own live entry and its drop cleanup
+// silently leaves the stale upsert (and the deleted name) visible locally.
+func TestGitWorkspaceRefreshMergeCarriesWriterToken(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	rt, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/race.txt")
+	if !ok {
+		t.Fatal("workspace ws1 not loaded")
+	}
+
+	// A write-back upsert is queued and applied, then the request parks.
+	upsert := client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "race.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+		SizeBytes:   4,
+		Content:     []byte("git-"),
+	}
+	seq := fs.rememberPendingGitOverlayEntry("ws1", upsert)
+	if got := fs.applyGitOverlayEntryAs("ws1", upsert, seq); got != seq {
+		t.Fatalf("apply writer token = %d, want %d", got, seq)
+	}
+
+	// Refresh: a fresh runtime loaded from the server (whiteout already
+	// committed) replaces the old one, and the pending replay runs into it.
+	fresh := &gitWorkspaceRuntime{
+		workspace: rt.workspace,
+		localRoot: rt.localRoot,
+		overlay: map[string]client.GitOverlayEntry{
+			"race.txt": {WorkspaceID: "ws1", Path: "race.txt", Op: "whiteout", Kind: "file"},
+		},
+	}
+	fs.mergePendingGitOverlayEntries("ws1", fresh)
+	if live, _ := fresh.overlayEntry("race.txt"); live.Op != "upsert" {
+		t.Fatalf("replayed overlay op = %q, want upsert", live.Op)
+	}
+	fs.git.mu.Lock()
+	fs.git.workspaces = []*gitWorkspaceRuntime{fresh}
+	fs.git.mu.Unlock()
+
+	// The queued request must still be able to clean up its own entry.
+	if !fs.restoreGitOverlayWhiteoutOwned("ws1", "race.txt", seq) {
+		t.Fatal("owner lost its live entry across refresh; drop cleanup would leave the stale upsert")
+	}
+	live, _ := fresh.overlayEntry("race.txt")
+	if live.Op != "whiteout" {
+		t.Fatalf("live overlay op = %q, want whiteout after owner cleanup", live.Op)
+	}
+
+	// A newer same-path writer that survived the refresh keeps its entry: the
+	// stale owner must not white it out.
+	recreate := upsert
+	recreate.Content = []byte("git-2")
+	if fs.rememberPendingGitOverlayEntry("ws1", recreate) == 0 {
+		t.Fatal("recreate pending seq missing")
+	}
+	recreated := &gitWorkspaceRuntime{
+		workspace: rt.workspace,
+		localRoot: rt.localRoot,
+		overlay:   map[string]client.GitOverlayEntry{},
+	}
+	fs.mergePendingGitOverlayEntries("ws1", recreated)
+	fs.git.mu.Lock()
+	fs.git.workspaces = []*gitWorkspaceRuntime{recreated}
+	fs.git.mu.Unlock()
+	if fs.restoreGitOverlayWhiteoutOwned("ws1", "race.txt", seq) {
+		t.Fatal("stale owner whited out a newer recreated entry")
+	}
+	live, _ = recreated.overlayEntry("race.txt")
+	if live.Op != "upsert" || string(live.Content) != string(recreate.Content) {
+		t.Fatalf("live overlay = %+v — want the recreated upsert preserved", live)
+	}
+}
+
 // TestGitWorkspaceOpenStraddlingWhiteoutMarkedUnlinked: an Open whose overlay
 // read snapshots the pre-whiteout state, but whose handle registers only after
 // the unlink's whiteout and post-commit pass have both completed, must still
@@ -6325,12 +6715,15 @@ func TestGitWorkspaceRegistrationDropsStalePendingMirrorEntry(t *testing.T) {
 
 	// A workspace refresh merging pending entries over the server state must
 	// keep the authoritative whiteout.
-	serverOverlay := map[string]client.GitOverlayEntry{
+	rt.mu.Lock()
+	rt.overlay = map[string]client.GitOverlayEntry{
 		"race.txt": {WorkspaceID: "ws1", Path: "race.txt", Op: "whiteout", Kind: "file"},
 	}
-	fs.mergePendingGitOverlayEntries("ws1", serverOverlay)
-	if got := serverOverlay["race.txt"].Op; got != "whiteout" {
-		t.Fatalf("merged overlay op = %q, want whiteout; stale mirror pending resurrected path", got)
+	rt.mu.Unlock()
+	fs.mergePendingGitOverlayEntries("ws1", rt)
+	merged, _ := rt.overlayEntry("race.txt")
+	if merged.Op != "whiteout" {
+		t.Fatalf("merged overlay op = %q, want whiteout; stale mirror pending resurrected path", merged.Op)
 	}
 }
 

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -64,6 +64,7 @@ type gitWorkspaceFixture struct {
 	failTree              bool
 	failOverlay           bool
 	failOverlayPut        bool
+	failWhiteoutAfterWait bool
 }
 
 type gitStateOnlyFixture struct {
@@ -451,6 +452,19 @@ func (f *gitWorkspaceFixture) handleOverlay(w http.ResponseWriter, r *http.Reque
 				f.overlayPostEnteredOnce.Do(func() { close(entered) })
 			}
 			<-wait
+		}
+		if req.Op == "whiteout" {
+			f.mu.Lock()
+			failWhiteout := f.failWhiteoutAfterWait
+			if failWhiteout {
+				f.failWhiteoutAfterWait = false
+			}
+			f.mu.Unlock()
+			if failWhiteout {
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(map[string]string{"error": "whiteout unavailable"})
+				return
+			}
 		}
 		entry := client.GitOverlayEntry{
 			WorkspaceID:    "ws1",
@@ -4883,6 +4897,169 @@ func TestGitWorkspaceFlushQueuedDuringWhiteoutDoesNotUpsert(t *testing.T) {
 	}
 	if !ok || entry.Op != "upsert" {
 		t.Fatalf("overlay after recreate = %+v, %v — want upsert", entry, ok)
+	}
+}
+
+func TestGitWorkspaceQueuedFsyncAfterFailedWhiteoutStillPublishes(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyCloseSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+
+	postWait := make(chan struct{})
+	postEntered := make(chan struct{})
+	fixture.mu.Lock()
+	fixture.overlayPostWait = postWait
+	fixture.overlayPostEntered = postEntered
+	fixture.failWhiteoutAfterWait = true
+	fixture.mu.Unlock()
+
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt")
+	}()
+	select {
+	case <-postEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("whiteout POST never parked")
+	}
+
+	rt, rel, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/sync.txt")
+	if !ok {
+		t.Fatal("git workspace path missing")
+	}
+	mirror, ok := fs.gitWorkspaceDirtyMirrorPath(rt, rel)
+	if !ok {
+		t.Fatal("dirty mirror path missing")
+	}
+	_ = os.Remove(mirror)
+	if err := os.MkdirAll(mirror, 0o755); err != nil {
+		t.Fatalf("mkdir dirty-mirror leaf: %v", err)
+	}
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup during in-flight whiteout = %v, want OK", st)
+	}
+	var open2 gofuse.OpenOut
+	if st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_TRUNC),
+	}, &open2); st != gofuse.OK {
+		t.Fatalf("Open memory-fallback handle = %v, want OK", st)
+	}
+	v2 := []byte("git-v2")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Fh:       open2.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write v2 status = %v, want OK", st)
+	}
+
+	upsertQueued := make(chan struct{})
+	var upsertOnce sync.Once
+	testHookAfterGitOverlaySlotReserved = func(op string) {
+		if op == "upsert" {
+			upsertOnce.Do(func() { close(upsertQueued) })
+		}
+	}
+	fsyncWaited := make(chan struct{})
+	releaseFsync := make(chan struct{})
+	var waitOnce sync.Once
+	testHookAfterGitOverlaySlotWait = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		waitOnce.Do(func() { close(fsyncWaited) })
+		<-releaseFsync
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlaySlotReserved = nil
+		testHookAfterGitOverlaySlotWait = nil
+		select {
+		case <-releaseFsync:
+		default:
+			close(releaseFsync)
+		}
+	})
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+			Fh:       open2.Fh,
+		})
+	}()
+	select {
+	case <-upsertQueued:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Fsync never reserved an overlay upsert slot behind the whiteout")
+	}
+
+	close(postWait)
+	unlinkSt := <-unlinkDone
+	if unlinkSt == gofuse.OK {
+		t.Fatal("Unlink status = OK, want error after rejected whiteout")
+	}
+	escaped, ok := fs.fileHandles.Get(open2.Fh)
+	if !ok {
+		t.Fatal("escaped handle missing")
+	}
+	escaped.Lock()
+	unlinked := escaped.Unlinked
+	escaped.Unlock()
+	if unlinked {
+		t.Fatal("handle must stay linked after failed unlink")
+	}
+
+	select {
+	case <-fsyncWaited:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Fsync never resumed after the failed whiteout slot")
+	}
+	close(releaseFsync)
+	fsyncSt := <-fsyncDone
+	if fsyncSt != gofuse.OK {
+		t.Fatalf("Fsync status = %v, want OK after failed unlink", fsyncSt)
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	puts := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if puts != 2 {
+		t.Fatalf("overlay puts = %d, want 2 (seed + v2 fsync)", puts)
+	}
+	if !ok || entry.Op != "upsert" || string(entry.Content) != string(v2) {
+		t.Fatalf("overlay entry = %+v, %v — want upsert %q", entry, ok, v2)
 	}
 }
 

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -17,6 +17,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"testing"
 	"time"
@@ -4526,6 +4527,176 @@ func TestGitWorkspaceUnlinkMarksHandlesOpenedDuringWhiteout(t *testing.T) {
 	fixture.mu.Unlock()
 	if putsFinal != putsAfterWhiteout {
 		t.Fatalf("overlay puts after whiteout = %d, after writes = %d — handle opened during whiteout resurrected the entry", putsAfterWhiteout, putsFinal)
+	}
+	if !ok || entry.Op != "whiteout" {
+		t.Fatalf("overlay entry = %+v, %v — want whiteout preserved", entry, ok)
+	}
+}
+
+func TestGitWorkspaceUnlinkPass2LockTimeoutDoesNotUpsertOverWhiteout(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyCloseSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+
+	postWait := make(chan struct{})
+	postEntered := make(chan struct{})
+	fixture.mu.Lock()
+	fixture.overlayPostWait = postWait
+	fixture.overlayPostEntered = postEntered
+	fixture.mu.Unlock()
+
+	oldTimeout := unlinkHandleSetLockTimeout
+	unlinkHandleSetLockTimeout = 50 * time.Millisecond
+	t.Cleanup(func() { unlinkHandleSetLockTimeout = oldTimeout })
+
+	var escapedFh atomic.Uint64
+	var markPass atomic.Int32
+	contending := make(chan struct{})
+	testHookBeforeUnlinkedTransition = func() {
+		if markPass.Add(1) != 2 {
+			return
+		}
+		fh, ok := fs.fileHandles.Get(escapedFh.Load())
+		if !ok || fh == nil {
+			return
+		}
+		locked := make(chan struct{})
+		go func() {
+			fh.Lock()
+			close(locked)
+			<-contending
+			fh.Unlock()
+		}()
+		<-locked
+	}
+	t.Cleanup(func() {
+		testHookBeforeUnlinkedTransition = nil
+		select {
+		case <-contending:
+		default:
+			close(contending)
+		}
+	})
+
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt")
+	}()
+	select {
+	case <-postEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("whiteout POST never parked")
+	}
+
+	rt, rel, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/sync.txt")
+	if !ok {
+		t.Fatal("git workspace path missing")
+	}
+	mirror, ok := fs.gitWorkspaceDirtyMirrorPath(rt, rel)
+	if !ok {
+		t.Fatal("dirty mirror path missing")
+	}
+	_ = os.Remove(mirror)
+	if err := os.MkdirAll(mirror, 0o755); err != nil {
+		t.Fatalf("mkdir dirty-mirror leaf: %v", err)
+	}
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup during in-flight whiteout = %v, want OK", st)
+	}
+	var open2 gofuse.OpenOut
+	if st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_TRUNC),
+	}, &open2); st != gofuse.OK {
+		t.Fatalf("Open memory-fallback handle = %v, want OK", st)
+	}
+	escaped, ok := fs.fileHandles.Get(open2.Fh)
+	if !ok || escaped == nil {
+		t.Fatal("escaped handle missing")
+	}
+	escaped.Lock()
+	localFile := escaped.LocalFile
+	hasDirty := escaped.Dirty != nil
+	escaped.Unlock()
+	if localFile != nil || !hasDirty {
+		t.Fatalf("LocalFile/Dirty = %v/%t, want nil/true (memory fallback)", localFile, hasDirty)
+	}
+	escapedFh.Store(open2.Fh)
+	v2 := []byte("git-v2-must-stay-local")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Fh:       open2.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write on memory-fallback handle = %v, want OK", st)
+	}
+
+	close(postWait)
+	select {
+	case st := <-unlinkDone:
+		t.Fatalf("Unlink returned %v before pass-2 lock contention was released", st)
+	case <-time.After(80 * time.Millisecond):
+	}
+	close(contending)
+	st := <-unlinkDone
+	if st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK after post-commit force-mark", st)
+	}
+
+	escaped, ok = fs.fileHandles.Get(open2.Fh)
+	if !ok {
+		t.Fatal("escaped handle missing after unlink")
+	}
+	escaped.Lock()
+	unlinked := escaped.Unlinked
+	escaped.Unlock()
+	if !unlinked {
+		t.Fatal("escaped memory-fallback handle not marked unlinked after pass-2 timeout")
+	}
+
+	fixture.mu.Lock()
+	putsAfterUnlink := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if st := fs.Flush(nil, &gofuse.FlushIn{Fh: open2.Fh}); st != gofuse.OK {
+		t.Fatalf("Flush after unlink = %v, want OK", st)
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	putsFinal := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if putsFinal != putsAfterUnlink {
+		t.Fatalf("overlay puts = %d -> %d — Flush upserted over committed whiteout", putsAfterUnlink, putsFinal)
 	}
 	if !ok || entry.Op != "whiteout" {
 		t.Fatalf("overlay entry = %+v, %v — want whiteout preserved", entry, ok)

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -4343,8 +4343,8 @@ func TestGitWorkspaceWriteSyncWriteAfterUnlinkDoesNotResurrectOverlay(t *testing
 	fs.gitOverlayMu.Lock()
 	var pendingUpsert any
 	if byPath := fs.gitOverlayPending["ws1"]; byPath != nil {
-		if pe, ok := byPath["sync.txt"]; ok {
-			pendingUpsert = pe.entry
+		if list := byPath["sync.txt"]; len(list) > 0 {
+			pendingUpsert = list[0].entry
 		}
 	}
 	fs.gitOverlayMu.Unlock()
@@ -5646,8 +5646,11 @@ func TestGitWorkspaceWriteBackUnlinkDoesNotLeavePendingUpsert(t *testing.T) {
 	fs.gitOverlayMu.Lock()
 	pendingOp := ""
 	if byPath := fs.gitOverlayPending[wsID]; byPath != nil {
-		if pending, ok := byPath[rel]; ok {
-			pendingOp = pending.entry.Op
+		for _, pending := range byPath[rel] {
+			if pending.entry.Op == "upsert" {
+				pendingOp = "upsert"
+				break
+			}
 		}
 	}
 	fs.gitOverlayMu.Unlock()
@@ -6479,6 +6482,285 @@ func TestGitWorkspaceWriteBackDroppedRequestsDoNotRestoreEachOther(t *testing.T)
 	}
 }
 
+// TestGitWorkspaceWriteBackRefreshReplaysStackedPendingRecreate: a workspace
+// refresh rebuilds the runtime from the server and replays the pending map
+// into it. The replay must cover the whole per-path pending list, not just
+// the top entry: here a valid recreate's write-back request sits UNDER a
+// stale request that applied later. Replaying only the stale top leaves the
+// recreate's token missing from the new runtime, so its landed remote write
+// cannot become visible locally, and the stale request's later drop falls
+// back to the whiteout — hiding a file the server already has.
+func TestGitWorkspaceWriteBackRefreshReplaysStackedPendingRecreate(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{
+		LocalRoot:           t.TempDir(),
+		WritePolicy:         WritePolicyWriteBack,
+		SyncMode:            SyncInteractive,
+		EnableGitWorkspaces: true,
+	}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	fs.syncMode = SyncInteractive
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	stale := []byte("git-v2-stale")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(stale)),
+	}, stale); st != gofuse.OK {
+		t.Fatalf("Write stale status = %v, want OK", st)
+	}
+
+	// Park the old handle's Fsync right after it passes the staleness check,
+	// before it applies.
+	checked := make(chan struct{})
+	releaseStale := make(chan struct{})
+	var checkOnce sync.Once
+	testHookAfterGitOverlayStaleCheck = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		park := false
+		checkOnce.Do(func() {
+			park = true
+			close(checked)
+		})
+		if park {
+			<-releaseStale
+		}
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlayStaleCheck = nil
+		select {
+		case <-releaseStale:
+		default:
+			close(releaseStale)
+		}
+	})
+
+	staleDone := make(chan gofuse.Status, 1)
+	go func() {
+		staleDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	select {
+	case <-checked:
+	case <-time.After(5 * time.Second):
+		t.Fatal("stale Fsync never passed the overlay staleness check")
+	}
+
+	// The unlink commits while the stale request is parked.
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	// A legitimate recreate applies locally but parks at its overlay slot,
+	// before its remote write lands.
+	slotWait := make(chan struct{})
+	releaseSlot := make(chan struct{})
+	var slotOnce sync.Once
+	testHookAfterGitOverlaySlotWait = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		park := false
+		slotOnce.Do(func() {
+			park = true
+			close(slotWait)
+		})
+		if park {
+			<-releaseSlot
+		}
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlaySlotWait = nil
+		select {
+		case <-releaseSlot:
+		default:
+			close(releaseSlot)
+		}
+	})
+
+	var recreate gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT | syscall.O_TRUNC),
+		Mode:     0o644,
+	}, "sync.txt", &recreate); st != gofuse.OK {
+		t.Fatalf("recreate Create = %v, want OK", st)
+	}
+	v3 := []byte("replacement-v3")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: recreate.NodeId},
+		Fh:       recreate.Fh,
+		Size:     uint32(len(v3)),
+	}, v3); st != gofuse.OK {
+		t.Fatalf("recreate Write = %v, want OK", st)
+	}
+	recreateDone := make(chan gofuse.Status, 1)
+	go func() {
+		recreateDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: recreate.NodeId},
+			Fh:       recreate.Fh,
+		})
+	}()
+	select {
+	case <-slotWait:
+	case <-time.After(5 * time.Second):
+		t.Fatal("recreate Fsync never reached its overlay slot wait")
+	}
+
+	// The stale request resumes and applies on top of the recreate.
+	close(releaseStale)
+	if st := <-staleDone; st != gofuse.OK {
+		t.Fatalf("stale Fsync status = %v, want OK", st)
+	}
+
+	// Refresh while the recreate's remote write is still parked: the server
+	// shows only the whiteout, and the pending replay must rebuild the whole
+	// list — the recreate's entry under the stale one — into the new runtime.
+	if err := fs.ensureGitWorkspacesWithRefresh(context.Background(), true); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+
+	// The recreate's remote write lands; the refreshed runtime must still
+	// hold its token so the commit keeps the recreated entry. The stale
+	// request then withdraws its own apply.
+	close(releaseSlot)
+	if st := <-recreateDone; st != gofuse.OK {
+		t.Fatalf("recreate Fsync status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	fixture.mu.Lock()
+	remote, remoteOK := fixture.overlay["sync.txt"]
+	fixture.mu.Unlock()
+	if !remoteOK || remote.Op != "upsert" || string(remote.Content) != string(v3) {
+		t.Fatalf("remote overlay = %+v, %v — want recreate upsert %q", remote, remoteOK, v3)
+	}
+	rt, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo")
+	if !ok || rt == nil {
+		t.Fatal("git workspace runtime missing after refresh")
+	}
+	live, liveOK := rt.overlayEntry("sync.txt")
+	if !liveOK || live.Op != "upsert" || string(live.Content) != string(v3) {
+		t.Fatalf("live overlay = %+v, %v — want recreate upsert %q; refresh replay lost the pending recreate under the stale top", live, liveOK, v3)
+	}
+	fs.gitOverlayMu.Lock()
+	pendingLeft := len(fs.gitOverlayPending["ws1"]["sync.txt"])
+	fs.gitOverlayMu.Unlock()
+	if pendingLeft != 0 {
+		t.Fatalf("pending list length = %d, want 0 after the recreate committed and the stale request dropped", pendingLeft)
+	}
+}
+
+// TestGitWorkspaceRefreshMergeReplaysWholePendingStack: the pending map holds
+// every live-relevant local apply per path in apply order, and the refresh
+// replay rebuilds all of them. A valid recreate sitting under a stale
+// top-of-stack apply survives the refresh: its commit keeps its entry and
+// the stale request's drop falls back to it, never to the whiteout.
+func TestGitWorkspaceRefreshMergeReplaysWholePendingStack(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), EnableGitWorkspaces: true}
+	opts.setDefaults()
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	rt, _, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/race.txt")
+	if !ok {
+		t.Fatal("workspace ws1 not loaded")
+	}
+
+	// The recreate applied first (lower), the stale request on top of it.
+	recreate := client.GitOverlayEntry{
+		WorkspaceID: "ws1",
+		Path:        "race.txt",
+		Op:          "upsert",
+		Kind:        "file",
+		Mode:        "100644",
+		SizeBytes:   4,
+		Content:     []byte("new-"),
+	}
+	recreateSeq := fs.rememberPendingGitOverlayEntry("ws1", recreate)
+	stale := recreate
+	stale.Content = []byte("old!")
+	staleSeq := fs.rememberPendingGitOverlayEntry("ws1", stale)
+
+	fresh := &gitWorkspaceRuntime{
+		workspace: rt.workspace,
+		localRoot: rt.localRoot,
+		overlay: map[string]client.GitOverlayEntry{
+			"race.txt": {WorkspaceID: "ws1", Path: "race.txt", Op: "whiteout", Kind: "file"},
+		},
+	}
+	fs.mergePendingGitOverlayEntries("ws1", fresh)
+	fs.git.mu.Lock()
+	fs.git.workspaces = []*gitWorkspaceRuntime{fresh}
+	fs.git.mu.Unlock()
+
+	live, _ := fresh.overlayEntry("race.txt")
+	if live.Op != "upsert" || string(live.Content) != "old!" {
+		t.Fatalf("live overlay after replay = %+v — want the stale top entry", live)
+	}
+
+	// The recreate's remote write lands first: its token must exist in the
+	// refreshed runtime, and its pending records are pruned with it.
+	fs.forgetPendingGitOverlayEntriesThrough("ws1", "race.txt", recreateSeq)
+	fs.commitGitOverlayApply("ws1", "race.txt", recreateSeq)
+	live, _ = fresh.overlayEntry("race.txt")
+	if live.Op != "upsert" || string(live.Content) != "old!" {
+		t.Fatalf("live overlay after recreate commit = %+v — want the stale top still on top", live)
+	}
+
+	// The stale request withdraws its own apply: the stack must fall back to
+	// the recreate's committed entry, not to the whiteout.
+	fs.forgetPendingGitOverlayEntry("ws1", "race.txt", staleSeq)
+	fs.dropGitOverlayApply("ws1", "race.txt", staleSeq)
+	live, _ = fresh.overlayEntry("race.txt")
+	if live.Op != "upsert" || string(live.Content) != "new-" {
+		t.Fatalf("live overlay after stale drop = %+v — want the recreate's committed upsert", live)
+	}
+	fs.gitOverlayMu.Lock()
+	left := len(fs.gitOverlayPending["ws1"]["race.txt"])
+	fs.gitOverlayMu.Unlock()
+	if left != 0 {
+		t.Fatalf("pending list length = %d, want 0", left)
+	}
+}
+
 // TestGitWorkspaceRefreshMergeKeepsWithdrawableApply: a refresh rebuilds the
 // runtime and replays in-flight write-back entries into it. A replayed entry
 // must stay withdrawable by the request that queued it, otherwise its drop
@@ -6725,8 +7007,7 @@ func TestApplyGitOverlayMirrorEntryUnlessWhiteout(t *testing.T) {
 	pendingHas := func(rel string) bool {
 		fs.gitOverlayMu.Lock()
 		defer fs.gitOverlayMu.Unlock()
-		_, ok := fs.gitOverlayPending["ws1"][rel]
-		return ok
+		return len(fs.gitOverlayPending["ws1"][rel]) > 0
 	}
 	overlayOp := func(rel string) (string, bool) {
 		rt, relPath, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/"+rel)
@@ -6964,7 +7245,7 @@ func TestPrepareGitOpenHandleTruncOnWhiteoutAdoptsUnlinked(t *testing.T) {
 		t.Fatalf("local overlay entry = %+v, %v — want whiteout preserved (mirror resurrected it)", entry, found)
 	}
 	fs.gitOverlayMu.Lock()
-	_, pending := fs.gitOverlayPending["ws1"]["trunc.txt"]
+	pending := len(fs.gitOverlayPending["ws1"]["trunc.txt"]) > 0
 	fs.gitOverlayMu.Unlock()
 	if pending {
 		t.Fatal("blocked mirror left a pending overlay entry")
@@ -7032,7 +7313,7 @@ func TestGitWorkspaceRegistrationDropsStalePendingMirrorEntry(t *testing.T) {
 		t.Fatal("handle not marked unlinked at registration")
 	}
 	fs.gitOverlayMu.Lock()
-	_, pending := fs.gitOverlayPending["ws1"]["race.txt"]
+	pending := len(fs.gitOverlayPending["ws1"]["race.txt"]) > 0
 	fs.gitOverlayMu.Unlock()
 	if pending {
 		t.Fatal("stale pending mirror upsert survived registration")
@@ -7401,13 +7682,13 @@ func TestGitWorkspaceStraddleAdoptionPreservesSamePathRecreate(t *testing.T) {
 	// straddler's stale size-0 entry is dropped seq-scoped; the recreate's
 	// newer-seq entry survives).
 	fs.gitOverlayMu.Lock()
-	pending, hasPending := fs.gitOverlayPending["ws1"]["recreate.txt"]
+	pendingList := fs.gitOverlayPending["ws1"]["recreate.txt"]
 	fs.gitOverlayMu.Unlock()
-	if !hasPending {
-		t.Fatal("adoption cleanup deleted the recreate's pending entry")
+	if len(pendingList) != 1 {
+		t.Fatalf("pending list after cleanup = %+v — want exactly the recreate's entry", pendingList)
 	}
-	if pending.entry.Op != "upsert" || pending.entry.SizeBytes != int64(len(replacement)) {
-		t.Fatalf("pending entry after cleanup = %+v — want recreate upsert (size %d)", pending.entry, len(replacement))
+	if pendingList[0].entry.Op != "upsert" || pendingList[0].entry.SizeBytes != int64(len(replacement)) {
+		t.Fatalf("pending entry after cleanup = %+v — want recreate upsert (size %d)", pendingList[0].entry, len(replacement))
 	}
 	entry, found := rt.overlayEntry("recreate.txt")
 	if !found || entry.Op != "upsert" || entry.SizeBytes != int64(len(replacement)) {

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -5167,6 +5167,137 @@ func TestGitWorkspaceFsyncAfterAttemptSampleLosesToSuccessfulUnlink(t *testing.T
 	}
 }
 
+func TestGitWorkspaceFsyncDuringUnlinkMarkPublishesIfWhiteoutFails(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyCloseSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+	v2 := []byte("git-v2")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write v2 status = %v, want OK", st)
+	}
+
+	fsyncSampled := make(chan struct{})
+	whiteoutSampled := make(chan struct{})
+	releaseFsync := make(chan struct{})
+	releaseWhiteout := make(chan struct{})
+	var fsyncOnce, whiteoutOnce sync.Once
+	testHookAfterGitOverlayAttemptSample = func(op string) {
+		switch op {
+		case "upsert":
+			fsyncOnce.Do(func() { close(fsyncSampled) })
+			<-releaseFsync
+		case "whiteout":
+			whiteoutOnce.Do(func() { close(whiteoutSampled) })
+			<-releaseWhiteout
+		}
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlayAttemptSample = nil
+		select {
+		case <-releaseFsync:
+		default:
+			close(releaseFsync)
+		}
+		select {
+		case <-releaseWhiteout:
+		default:
+			close(releaseWhiteout)
+		}
+	})
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	select {
+	case <-fsyncSampled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Fsync never sampled overlay unlink attempt")
+	}
+
+	fixture.mu.Lock()
+	fixture.failWhiteoutAfterWait = true
+	fixture.mu.Unlock()
+
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt")
+	}()
+	select {
+	case <-whiteoutSampled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Unlink whiteout never sampled overlay attempt")
+	}
+
+	close(releaseFsync)
+	fsyncSt := <-fsyncDone
+	if fsyncSt != gofuse.OK {
+		t.Fatalf("Fsync status = %v, want OK while unlink is still pending", fsyncSt)
+	}
+	close(releaseWhiteout)
+	unlinkSt := <-unlinkDone
+	if unlinkSt == gofuse.OK {
+		t.Fatal("Unlink status = OK, want error after rejected whiteout")
+	}
+
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	unlinked := fh.Unlinked
+	fh.Unlock()
+	if unlinked {
+		t.Fatal("handle must stay linked after failed unlink")
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	puts := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if puts != 2 {
+		t.Fatalf("overlay puts = %d, want 2 (seed + v2 fsync)", puts)
+	}
+	if !ok || entry.Op != "upsert" || string(entry.Content) != string(v2) {
+		t.Fatalf("overlay entry = %+v, %v — want upsert %q", entry, ok, v2)
+	}
+}
+
 // TestGitWorkspaceOpenStraddlingWhiteoutMarkedUnlinked: an Open whose overlay
 // read snapshots the pre-whiteout state, but whose handle registers only after
 // the unlink's whiteout and post-commit pass have both completed, must still

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -5063,6 +5063,110 @@ func TestGitWorkspaceQueuedFsyncAfterFailedWhiteoutStillPublishes(t *testing.T) 
 	}
 }
 
+func TestGitWorkspaceFsyncAfterAttemptSampleLosesToSuccessfulUnlink(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyCloseSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+	v2 := []byte("git-v2-must-stay-local")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write v2 status = %v, want OK", st)
+	}
+
+	sampled := make(chan struct{})
+	releaseFsync := make(chan struct{})
+	var sampleOnce sync.Once
+	testHookAfterGitOverlayAttemptSample = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		sampleOnce.Do(func() { close(sampled) })
+		<-releaseFsync
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlayAttemptSample = nil
+		select {
+		case <-releaseFsync:
+		default:
+			close(releaseFsync)
+		}
+	})
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	select {
+	case <-sampled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Fsync never sampled overlay unlink attempt")
+	}
+
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	close(releaseFsync)
+	if st := <-fsyncDone; st != gofuse.OK {
+		t.Fatalf("Fsync status = %v, want OK", st)
+	}
+
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	unlinked := fh.Unlinked
+	fh.Unlock()
+	if !unlinked {
+		t.Fatal("handle not marked unlinked")
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	puts := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if puts != 2 {
+		t.Fatalf("overlay puts = %d, want 2 (seed + whiteout, no v2 upsert)", puts)
+	}
+	if !ok || entry.Op != "whiteout" {
+		t.Fatalf("overlay entry = %+v, %v — want whiteout", entry, ok)
+	}
+}
+
 // TestGitWorkspaceOpenStraddlingWhiteoutMarkedUnlinked: an Open whose overlay
 // read snapshots the pre-whiteout state, but whose handle registers only after
 // the unlink's whiteout and post-commit pass have both completed, must still

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -5298,6 +5298,378 @@ func TestGitWorkspaceFsyncDuringUnlinkMarkPublishesIfWhiteoutFails(t *testing.T)
 	}
 }
 
+func TestGitWorkspaceFsyncAfterUnlinkMarkPublishesIfWhiteoutFails(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyCloseSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+	v2 := []byte("git-v2")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write v2 status = %v, want OK", st)
+	}
+
+	postWait := make(chan struct{})
+	postEntered := make(chan struct{})
+	fixture.mu.Lock()
+	fixture.overlayPostWait = postWait
+	fixture.overlayPostEntered = postEntered
+	fixture.failWhiteoutAfterWait = true
+	fixture.mu.Unlock()
+
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt")
+	}()
+	select {
+	case <-postEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("whiteout POST never parked")
+	}
+
+	upsertQueued := make(chan struct{})
+	var upsertOnce sync.Once
+	testHookAfterGitOverlaySlotReserved = func(op string) {
+		if op == "upsert" {
+			upsertOnce.Do(func() { close(upsertQueued) })
+		}
+	}
+	t.Cleanup(func() { testHookAfterGitOverlaySlotReserved = nil })
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	select {
+	case <-upsertQueued:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Fsync returned without enqueueing; tentative Unlinked swallowed it")
+	}
+	close(postWait)
+	if st := <-unlinkDone; st == gofuse.OK {
+		t.Fatal("Unlink status = OK, want error after rejected whiteout")
+	}
+	if st := <-fsyncDone; st != gofuse.OK {
+		t.Fatalf("Fsync after unlink mark = %v, want OK", st)
+	}
+
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	unlinked := fh.Unlinked
+	fh.Unlock()
+	if unlinked {
+		t.Fatal("handle must stay linked after failed unlink")
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	puts := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if puts != 2 {
+		t.Fatalf("overlay puts = %d, want 2 (seed + v2 fsync)", puts)
+	}
+	if !ok || entry.Op != "upsert" || string(entry.Content) != string(v2) {
+		t.Fatalf("overlay entry = %+v, %v — want upsert %q", entry, ok, v2)
+	}
+}
+
+func TestGitWorkspaceRecreateFailedUnlinkDoesNotSwallowFsync(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyCloseSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	createAndSync := func(name, body string) gofuse.CreateOut {
+		t.Helper()
+		var out gofuse.CreateOut
+		if st := fs.Create(nil, &gofuse.CreateIn{
+			InHeader: gofuse.InHeader{NodeId: repoIno},
+			Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT | syscall.O_TRUNC),
+			Mode:     0o644,
+		}, name, &out); st != gofuse.OK {
+			t.Fatalf("Create status = %v, want OK", st)
+		}
+		data := []byte(body)
+		if _, st := fs.Write(nil, &gofuse.WriteIn{
+			InHeader: gofuse.InHeader{NodeId: out.NodeId},
+			Fh:       out.Fh,
+			Size:     uint32(len(data)),
+		}, data); st != gofuse.OK {
+			t.Fatalf("Write status = %v, want OK", st)
+		}
+		if st := fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: out.NodeId},
+			Fh:       out.Fh,
+		}); st != gofuse.OK {
+			t.Fatalf("Fsync status = %v, want OK", st)
+		}
+		return out
+	}
+
+	first := createAndSync("sync.txt", "git-v0")
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st != gofuse.OK {
+		t.Fatalf("first Unlink status = %v, want OK", st)
+	}
+	fs.Release(nil, &gofuse.ReleaseIn{Fh: first.Fh})
+
+	second := createAndSync("sync.txt", "git-v1")
+	v2 := []byte("git-v2")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: second.NodeId},
+		Fh:       second.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write v2 status = %v, want OK", st)
+	}
+
+	fsyncSampled := make(chan struct{})
+	whiteoutSampled := make(chan struct{})
+	releaseFsync := make(chan struct{})
+	releaseWhiteout := make(chan struct{})
+	var fsyncOnce, whiteoutOnce sync.Once
+	testHookAfterGitOverlayAttemptSample = func(op string) {
+		switch op {
+		case "upsert":
+			fsyncOnce.Do(func() { close(fsyncSampled) })
+			<-releaseFsync
+		case "whiteout":
+			whiteoutOnce.Do(func() { close(whiteoutSampled) })
+			<-releaseWhiteout
+		}
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlayAttemptSample = nil
+		select {
+		case <-releaseFsync:
+		default:
+			close(releaseFsync)
+		}
+		select {
+		case <-releaseWhiteout:
+		default:
+			close(releaseWhiteout)
+		}
+	})
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: second.NodeId},
+			Fh:       second.Fh,
+		})
+	}()
+	select {
+	case <-fsyncSampled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Fsync never sampled overlay unlink attempt")
+	}
+
+	fixture.mu.Lock()
+	fixture.failWhiteoutAfterWait = true
+	fixture.mu.Unlock()
+
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt")
+	}()
+	select {
+	case <-whiteoutSampled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("second Unlink whiteout never sampled overlay attempt")
+	}
+
+	close(releaseFsync)
+	if st := <-fsyncDone; st != gofuse.OK {
+		t.Fatalf("Fsync status = %v, want OK", st)
+	}
+	close(releaseWhiteout)
+	if st := <-unlinkDone; st == gofuse.OK {
+		t.Fatal("second Unlink status = OK, want error after rejected whiteout")
+	}
+
+	fh, ok := fs.fileHandles.Get(second.Fh)
+	if !ok {
+		t.Fatal("recreate handle missing")
+	}
+	fh.Lock()
+	unlinked := fh.Unlinked
+	fh.Unlock()
+	if unlinked {
+		t.Fatal("recreate handle must stay linked after failed unlink")
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	fixture.mu.Unlock()
+	if !ok || entry.Op != "upsert" || string(entry.Content) != string(v2) {
+		t.Fatalf("overlay entry = %+v, %v — want upsert %q", entry, ok, v2)
+	}
+}
+
+func TestGitWorkspaceWriteBackUnlinkDoesNotLeavePendingUpsert(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{
+		LocalRoot:           t.TempDir(),
+		WritePolicy:         WritePolicyWriteBack,
+		SyncMode:            SyncInteractive,
+		EnableGitWorkspaces: true,
+	}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	fs.syncMode = SyncInteractive
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+	v2 := []byte("git-v2-must-stay-local")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write v2 status = %v, want OK", st)
+	}
+
+	sampled := make(chan struct{})
+	releaseFsync := make(chan struct{})
+	var sampleOnce sync.Once
+	testHookAfterGitOverlayAttemptSample = func(op string) {
+		if op != "upsert" {
+			return
+		}
+		sampleOnce.Do(func() { close(sampled) })
+		<-releaseFsync
+	}
+	t.Cleanup(func() {
+		testHookAfterGitOverlayAttemptSample = nil
+		select {
+		case <-releaseFsync:
+		default:
+			close(releaseFsync)
+		}
+	})
+
+	fsyncDone := make(chan gofuse.Status, 1)
+	go func() {
+		fsyncDone <- fs.Fsync(nil, &gofuse.FsyncIn{
+			InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+			Fh:       createOut.Fh,
+		})
+	}()
+	select {
+	case <-sampled:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Fsync never sampled overlay unlink attempt")
+	}
+	if st := fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt"); st != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", st)
+	}
+	close(releaseFsync)
+	if st := <-fsyncDone; st != gofuse.OK {
+		t.Fatalf("Fsync status = %v, want OK", st)
+	}
+	fs.drainGitOverlayWrites()
+
+	fh, ok := fs.fileHandles.Get(createOut.Fh)
+	if !ok {
+		t.Fatal("handle missing")
+	}
+	fh.Lock()
+	wsID := fh.GitWorkspaceID
+	rel := fh.GitRelPath
+	fh.Unlock()
+	fs.gitOverlayMu.Lock()
+	pendingOp := ""
+	if byPath := fs.gitOverlayPending[wsID]; byPath != nil {
+		if pending, ok := byPath[rel]; ok {
+			pendingOp = pending.entry.Op
+		}
+	}
+	fs.gitOverlayMu.Unlock()
+	if pendingOp == "upsert" {
+		t.Fatalf("pending overlay still upsert after unlink suppressed writeback fsync")
+	}
+	rt, _, _ := fs.gitWorkspaceForPath(context.Background(), "/repo")
+	if rt == nil {
+		t.Fatal("git workspace runtime missing")
+	}
+	live, ok := rt.overlayEntry(rel)
+	if !ok || live.Op != "whiteout" {
+		t.Fatalf("live overlay = %+v, %v — want whiteout", live, ok)
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	fixture.mu.Unlock()
+	if !ok || entry.Op != "whiteout" {
+		t.Fatalf("remote overlay = %+v, %v — want whiteout", entry, ok)
+	}
+}
+
 // TestGitWorkspaceOpenStraddlingWhiteoutMarkedUnlinked: an Open whose overlay
 // read snapshots the pre-whiteout state, but whose handle registers only after
 // the unlink's whiteout and post-commit pass have both completed, must still

--- a/pkg/fuse/git_workspace_test.go
+++ b/pkg/fuse/git_workspace_test.go
@@ -4703,6 +4703,130 @@ func TestGitWorkspaceUnlinkPass2LockTimeoutDoesNotUpsertOverWhiteout(t *testing.
 	}
 }
 
+func TestGitWorkspaceFlushQueuedDuringWhiteoutDoesNotUpsert(t *testing.T) {
+	fixture := newGitWorkspaceFixture(t)
+	opts := &MountOptions{LocalRoot: t.TempDir(), WritePolicy: WritePolicyCloseSync, EnableGitWorkspaces: true}
+	opts.setDefaults()
+
+	fs := NewDat9FS(fixture.client(), opts)
+	if err := fs.ensureGitWorkspaces(context.Background()); err != nil {
+		t.Fatalf("ensureGitWorkspaces: %v", err)
+	}
+	repoIno := fs.inodes.Lookup("/repo", true, 0, time.Now())
+
+	var createOut gofuse.CreateOut
+	if st := fs.Create(nil, &gofuse.CreateIn{
+		InHeader: gofuse.InHeader{NodeId: repoIno},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_CREAT),
+		Mode:     0o644,
+	}, "sync.txt", &createOut); st != gofuse.OK {
+		t.Fatalf("Create status = %v, want OK", st)
+	}
+	v1 := []byte("git-v1")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+		Size:     uint32(len(v1)),
+	}, v1); st != gofuse.OK {
+		t.Fatalf("Write v1 status = %v, want OK", st)
+	}
+	if st := fs.Fsync(nil, &gofuse.FsyncIn{
+		InHeader: gofuse.InHeader{NodeId: createOut.NodeId},
+		Fh:       createOut.Fh,
+	}); st != gofuse.OK {
+		t.Fatalf("Fsync v1 status = %v, want OK", st)
+	}
+
+	postWait := make(chan struct{})
+	postEntered := make(chan struct{})
+	fixture.mu.Lock()
+	fixture.overlayPostWait = postWait
+	fixture.overlayPostEntered = postEntered
+	fixture.mu.Unlock()
+
+	unlinkDone := make(chan gofuse.Status, 1)
+	go func() {
+		unlinkDone <- fs.Unlink(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt")
+	}()
+	select {
+	case <-postEntered:
+	case <-time.After(5 * time.Second):
+		t.Fatal("whiteout POST never parked")
+	}
+
+	rt, rel, ok := fs.gitWorkspaceForPath(context.Background(), "/repo/sync.txt")
+	if !ok {
+		t.Fatal("git workspace path missing")
+	}
+	mirror, ok := fs.gitWorkspaceDirtyMirrorPath(rt, rel)
+	if !ok {
+		t.Fatal("dirty mirror path missing")
+	}
+	_ = os.Remove(mirror)
+	if err := os.MkdirAll(mirror, 0o755); err != nil {
+		t.Fatalf("mkdir dirty-mirror leaf: %v", err)
+	}
+
+	var lookupOut gofuse.EntryOut
+	if st := fs.Lookup(nil, &gofuse.InHeader{NodeId: repoIno}, "sync.txt", &lookupOut); st != gofuse.OK {
+		t.Fatalf("Lookup during in-flight whiteout = %v, want OK", st)
+	}
+	var open2 gofuse.OpenOut
+	if st := fs.Open(nil, &gofuse.OpenIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Flags:    uint32(syscall.O_RDWR | syscall.O_TRUNC),
+	}, &open2); st != gofuse.OK {
+		t.Fatalf("Open memory-fallback handle = %v, want OK", st)
+	}
+	v2 := []byte("git-v2-must-stay-local")
+	if _, st := fs.Write(nil, &gofuse.WriteIn{
+		InHeader: gofuse.InHeader{NodeId: lookupOut.NodeId},
+		Fh:       open2.Fh,
+		Size:     uint32(len(v2)),
+	}, v2); st != gofuse.OK {
+		t.Fatalf("Write on memory-fallback handle = %v, want OK", st)
+	}
+
+	upsertQueued := make(chan struct{})
+	var upsertOnce sync.Once
+	testHookAfterGitOverlaySlotReserved = func(op string) {
+		if op == "upsert" {
+			upsertOnce.Do(func() { close(upsertQueued) })
+		}
+	}
+	t.Cleanup(func() { testHookAfterGitOverlaySlotReserved = nil })
+
+	flushDone := make(chan gofuse.Status, 1)
+	go func() {
+		flushDone <- fs.Flush(nil, &gofuse.FlushIn{Fh: open2.Fh})
+	}()
+	select {
+	case <-upsertQueued:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Flush never reserved an overlay upsert slot behind the whiteout")
+	}
+
+	close(postWait)
+	unlinkSt := <-unlinkDone
+	flushSt := <-flushDone
+	if unlinkSt != gofuse.OK {
+		t.Fatalf("Unlink status = %v, want OK", unlinkSt)
+	}
+	if flushSt != gofuse.OK {
+		t.Fatalf("Flush status = %v, want OK", flushSt)
+	}
+	fixture.mu.Lock()
+	entry, ok := fixture.overlay["sync.txt"]
+	puts := fixture.overlayPuts
+	fixture.mu.Unlock()
+	if puts != 2 {
+		t.Fatalf("overlay puts = %d, want 2 (seed + whiteout, no upsert)", puts)
+	}
+	if !ok || entry.Op != "whiteout" {
+		t.Fatalf("overlay entry = %+v, %v — want whiteout preserved", entry, ok)
+	}
+}
+
 // TestGitWorkspaceOpenStraddlingWhiteoutMarkedUnlinked: an Open whose overlay
 // read snapshots the pre-whiteout state, but whose handle registers only after
 // the unlink's whiteout and post-commit pass have both completed, must still

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -79,11 +79,12 @@ type FileHandle struct {
 	UnlinkedSnapshotRev  int64 // committed revision captured with UnlinkedData / UnlinkedShadowGen
 	UnlinkedSnapshotSize int64 // committed size captured with that snapshot identity
 	// Staging generations recorded when this handle staged path-keyed state.
-	// discardUnlinkedHandleStateLocked uses them for ownership-scoped cleanup:
-	// after a pathname is unlinked and recreated, path-global removes would
-	// destroy the replacement file's staged state, so only store generations
-	// this handle actually created may be removed (gens are monotonic per
-	// store, so a stale value simply never matches).
+	// cancelUnlinkedRemotePublishLocked and discardUnlinkedHandleStateLocked
+	// use them for ownership-scoped cleanup: after a pathname is unlinked
+	// and recreated, path-global removes would destroy the replacement
+	// file's staged state, so only store generations this handle actually
+	// created may be removed (gens are monotonic per store, so a stale
+	// value simply never matches).
 	WriteBackGen    uint64 // writeBack generation staged by this handle (0 = none)
 	PendingIndexGen uint64 // pendingIndex generation staged by this handle (0 = none)
 	ShadowStageGen  uint64 // shadowStore content generation staged by this handle (0 = none)
@@ -120,10 +121,11 @@ func (fh *FileHandle) TryLock() bool { return fh.mu.TryLock() }
 // Unlock releases the file handle mutex.
 func (fh *FileHandle) Unlock() { fh.mu.Unlock() }
 
-// lockFileHandlesInOrder locks each unique handle in a stable pointer order
-// so a multi-handle unlink mark cannot deadlock with itself. The returned
-// slice is what unlockFileHandles must unlock (reverse order).
-func lockFileHandlesInOrder(handles []*FileHandle) []*FileHandle {
+// fileHandlesLockOrder returns unique handles in a stable pointer order.
+// Pointer identity is the total order: Go's GC does not move heap objects,
+// so addresses stay stable for the lifetime of any later held locks. Ino
+// and Path are shared across open fds of the same file and must not be used.
+func fileHandlesLockOrder(handles []*FileHandle) []*FileHandle {
 	seen := make(map[*FileHandle]struct{}, len(handles))
 	ordered := make([]*FileHandle, 0, len(handles))
 	for _, fh := range handles {
@@ -139,10 +141,25 @@ func lockFileHandlesInOrder(handles []*FileHandle) []*FileHandle {
 	sort.Slice(ordered, func(i, j int) bool {
 		return uintptr(unsafe.Pointer(ordered[i])) < uintptr(unsafe.Pointer(ordered[j]))
 	})
-	for _, fh := range ordered {
-		fh.Lock()
-	}
 	return ordered
+}
+
+// tryLockFileHandlesInOrder TryLocks each unique handle in pointer order.
+// If any TryLock fails it releases every lock already taken and returns
+// false, so the caller never blocks while holding a partial set. That
+// avoids deadlock with sibling-mode cleanup, which holds one fh.mu and
+// then Lock()s other same-inode handles (clearPendingModeForInodeGeneration).
+func tryLockFileHandlesInOrder(handles []*FileHandle) ([]*FileHandle, bool) {
+	ordered := fileHandlesLockOrder(handles)
+	for i, fh := range ordered {
+		if !fh.TryLock() {
+			for j := i - 1; j >= 0; j-- {
+				ordered[j].Unlock()
+			}
+			return nil, false
+		}
+	}
+	return ordered, true
 }
 
 func unlockFileHandles(ordered []*FileHandle) {

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -3,9 +3,11 @@ package fuse
 import (
 	"context"
 	"os"
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/mem9-ai/drive9/pkg/client"
 )
@@ -117,6 +119,37 @@ func (fh *FileHandle) TryLock() bool { return fh.mu.TryLock() }
 
 // Unlock releases the file handle mutex.
 func (fh *FileHandle) Unlock() { fh.mu.Unlock() }
+
+// lockFileHandlesInOrder locks each unique handle in a stable pointer order
+// so a multi-handle unlink mark cannot deadlock with itself. The returned
+// slice is what unlockFileHandles must unlock (reverse order).
+func lockFileHandlesInOrder(handles []*FileHandle) []*FileHandle {
+	seen := make(map[*FileHandle]struct{}, len(handles))
+	ordered := make([]*FileHandle, 0, len(handles))
+	for _, fh := range handles {
+		if fh == nil {
+			continue
+		}
+		if _, ok := seen[fh]; ok {
+			continue
+		}
+		seen[fh] = struct{}{}
+		ordered = append(ordered, fh)
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		return uintptr(unsafe.Pointer(ordered[i])) < uintptr(unsafe.Pointer(ordered[j]))
+	})
+	for _, fh := range ordered {
+		fh.Lock()
+	}
+	return ordered
+}
+
+func unlockFileHandles(ordered []*FileHandle) {
+	for i := len(ordered) - 1; i >= 0; i-- {
+		ordered[i].Unlock()
+	}
+}
 
 // LockWithTimeout attempts to acquire the file handle mutex within the given
 // deadline. Returns true if the lock was acquired, false if the deadline

--- a/pkg/fuse/handle.go
+++ b/pkg/fuse/handle.go
@@ -72,6 +72,7 @@ type FileHandle struct {
 	HasPreviousMode      bool   // true when previous mode state was snapshotted
 	PreviousModeKnown    bool   // true when PreviousMode was authoritative
 	Unlinked             bool   // true after the directory entry was removed while this handle stayed open
+	UnlinkedAttempt      uint64 // git overlay unlink attempt that marked this fd (0 = none)
 	UnlinkedSnapshot     bool   // true when UnlinkedData is an authoritative read snapshot
 	UnlinkedData         []byte // read-only snapshot for open-but-unlinked remote files
 	UnlinkedShadowGen    uint64 // generation pin for large open-unlink snapshots stored in ShadowStore


### PR DESCRIPTION
Follow-up to #905 (post-merge review).

`markOpenHandlesUnlinked` attached and marked handles one at a time. After fd A was `Unlinked=true` and unlocked, a same-FD `Write+Fsync` took the unlinked-discard path and cleared `Dirty`. If fd B then committed a newer generation, the mark pass retried; rollback could not restore A's discarded overlay. Unlink returned OK while A's still-open fd read the pre-Fsync snapshot.

Changes:
- Identity check, snapshot attach, and `Unlinked` now commit for the whole captured handle set under one lock hold. A failed attach rolls this pass back without leaving any handle `Unlinked`.
- Fsync/Flush on an unlinked fd cancel path-keyed staging (no path resurrection) but keep `Dirty`, so a successful write-after-unlink stays readable if unlink later retries.
- Release still discards on close.

Regressions:
- `TestAttachAndMarkOpenHandlesDoesNotPartiallyUnlink`
- `TestUnlinkTwoHandleMarkRetryKeepsFsyncedOverlays`

Does not claim to close #898.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved unsynced and fsynced changes for open files after unlinking.
  * Prevented post-unlink flushes from recreating removed paths, including Git workspace overlays.
  * Improved multi-handle unlink handling to avoid partial transitions and preserve updates during concurrent operations.
  * Prevented potential deadlocks when multiple open handles are updated concurrently.
  * Ensured unlink operations fail safely when handle coordination times out.

* **Tests**
  * Added coverage for rollback behavior, lock coordination, whiteout preservation, and concurrent writes, fsyncs, and unlink operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->