### PR TITLE
feat(cli): opt-in privacy-preserving command telemetry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -169,15 +169,25 @@ to keep issue structure and required context consistent.
 - Help, version, commandless usage, unknown commands, every `drive9 update`
   form, and internal mount processes (`mount supervise`, `--supervised`,
   `--supervise-foreground`) are excluded before telemetry reads
-  `~/.drive9/config` or `.telemetry-installation-id`.
+  `~/.drive9/config` or `.telemetry-installation-id`. The `admin` subtree also
+  opts out of a bare `help` operand (`drive9 admin tenant create help` is a help
+  request there) via `bareHelp`; `fs grep help` is a real operand and still
+  reports.
+- Placement fields describe the command's own context. A command that addresses
+  a named context (`drive9 fs cat prod:/file`) reports no provider/region and
+  `profile_source: unknown`, because the active context does not describe it.
 - One user command must produce at most one event. Every process drive9 spawns
   itself — background mounts, supervisors, detached hydration — must go through
   `telemetryDisabledEnv`, and the generated systemd unit sets
   `Environment=DRIVE9_TELEMETRY=off`.
 - Flag names come from argv, so a flag value must never be recorded as a name:
-  a dash token directly after another dash token is treated as a value.
-  `telemetryFlagNames` documents the tradeoff; do not "fix" the resulting
-  under-reporting by guessing arity.
+  a dash token directly after another dash token is treated as a value, and
+  `telemetryKnownFlagNames` (guarded by
+  `TestTelemetryKnownFlagNamesCoverEveryDefinedFlag`) drops anything that is not
+  a flag the CLI defines. A dash-shaped operand that happens to spell a real flag
+  is still reported; that is an analytics-fidelity limit, not a privacy one,
+  because the recorded string is always a known flag name. Do not "fix" the
+  remaining under-reporting by guessing arity.
 - `cmd/drive9/telemetry.go` holds a hand-maintained copy of the command tree, and
   `cmd/drive9/telemetry_drift_test.go` compares it against the real dispatchers.
   Adding a command or subcommand means updating the tree; the test fails

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ pkg/
   tenant/               Tenant schema management
   pathutil/             Path canonicalization and validation
   semantic/             Durable background task types
+  telemetry/            Privacy-preserving CLI command telemetry client
   traceid/              Trace ID helpers
 internal/
   testtidb/             TiDB test helpers (shared across packages)
@@ -152,6 +153,50 @@ to keep issue structure and required context consistent.
 - `drive9 fs find ... -tag key=value` is an exact key/value match.
 - `drive9 fs find ... -tag key` means tag-key existence match.
 - `-tag` does not support fuzzy, prefix, contains, or regex matching.
+
+### CLI telemetry
+
+- Telemetry is opt-in and off by default. Nothing is sent, and no telemetry
+  state file is read or written, unless the user sets `DRIVE9_TELEMETRY=on` or
+  `"telemetry": {"enabled": true}` in `~/.drive9/config`. `cli.TelemetryPreference`
+  is the only reader of that preference; the field must stay on `cli.Config` so
+  `saveConfig` round-trips it. Do not add a build, install-source, or CI
+  heuristic that enables it implicitly, and do not add a telemetry management
+  command.
+- Opted-in commands post one best-effort `drive9.command.finished` event to the
+  shared ti-cli telemetry ingestion endpoint (`POST /v1/telemetry/batch`, `202`
+  is the only success status, 1s timeout, no retries, no local queue).
+- Help, version, commandless usage, unknown commands, every `drive9 update`
+  form, and internal mount processes (`mount supervise`, `--supervised`,
+  `--supervise-foreground`) are excluded before telemetry reads
+  `~/.drive9/config` or `.telemetry-installation-id`.
+- One user command must produce at most one event. Every process drive9 spawns
+  itself — background mounts, supervisors, detached hydration — must go through
+  `telemetryDisabledEnv`, and the generated systemd unit sets
+  `Environment=DRIVE9_TELEMETRY=off`.
+- Flag names come from argv, so a flag value must never be recorded as a name:
+  a dash token directly after another dash token is treated as a value.
+  `telemetryFlagNames` documents the tradeoff; do not "fix" the resulting
+  under-reporting by guessing arity.
+- `cmd/drive9/telemetry.go` holds a hand-maintained copy of the command tree, and
+  `cmd/drive9/telemetry_drift_test.go` compares it against the real dispatchers.
+  Adding a command or subcommand means updating the tree; the test fails
+  otherwise.
+- The shared ingestion service must allow `drive9.command.finished`,
+  `drive9_[A-Za-z0-9_-]{22}` installation IDs, `drive9` command paths of up to
+  four segments, the `drive9/` User-Agent, and must widen its `command_path`
+  pattern from `{0,2}` to `{0,3}` subcommand segments. It validates with
+  `DisallowUnknownFields`, so no product-discriminator field can be added to the
+  payload until the backend accepts one.
+- Events must never include flag values, credentials, paths, file contents,
+  command output, API payloads, context names, or tenant IDs. `pkg/telemetry`
+  sends no caller-supplied free text: `DRIVE9_TELEMETRY_TAG`/`_EXTRA` were
+  removed for that reason and must not come back without a key allowlist.
+- The shared ingestion service rate-limits per client IP (60/min, burst 120) and
+  drops whole batches when its in-memory buffer is full. The CLI sends one event
+  per command and never retries, so bursts (agent loops, many users behind one
+  NAT) lose events by design; that is a backend capacity question, not something
+  to fix with client-side retries or a local queue.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ VERSION ?=
 GIT_HASH ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 GIT_BRANCH ?= $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)
 BUILD_TIME ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
+INSTALL_SOURCE ?=
+# Empty for development builds on purpose: only release artifacts carry an
+# ingestion endpoint, so a dev binary can never post to production. Override it
+# to package a release build against another endpoint (e.g. staging).
+TELEMETRY_ENDPOINT ?=
+RELEASE_TELEMETRY_ENDPOINT = https://tdc-telemetry.tidbcloud.com/v1/telemetry/batch
 
 CLI_TARGETS ?= linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64
 MIGRATION_TARGETS ?= linux/amd64 linux/arm64
@@ -53,7 +59,9 @@ TEST_PKGS ?= ./...
 BUILDINFO_LDFLAGS = -X github.com/mem9-ai/drive9/pkg/buildinfo.Version=$(if $(VERSION),$(VERSION),dev) \
 	-X github.com/mem9-ai/drive9/pkg/buildinfo.GitHash=$(GIT_HASH) \
 	-X github.com/mem9-ai/drive9/pkg/buildinfo.GitBranch=$(GIT_BRANCH) \
-	-X github.com/mem9-ai/drive9/pkg/buildinfo.BuildTime=$(BUILD_TIME)
+	-X github.com/mem9-ai/drive9/pkg/buildinfo.BuildTime=$(BUILD_TIME) \
+	-X github.com/mem9-ai/drive9/pkg/buildinfo.InstallSource=$(INSTALL_SOURCE) \
+	-X github.com/mem9-ai/drive9/pkg/buildinfo.TelemetryEndpoint=$(TELEMETRY_ENDPOINT)
 
 .PHONY: mod test test-failpoint test-podman fmt lint install-lint build build-server build-cli build-cli-release build-migration build-migration-release build-migration-kube-plugin build-migration-kube-plugin-release run-server-local e2e-local sdk-integration-tests docker-build docker-build-migration docker-push-migration-multi
 
@@ -196,7 +204,7 @@ build-cli-release:
 		fi; \
 		out="$(DIST_DIR)/$(CLI_NAME)-$${os}-$${arch}$$ext"; \
 		echo "Building $$(basename "$$out")..."; \
-		$(MAKE) --no-print-directory build-cli GOOS="$$os" GOARCH="$$arch" CLI_BIN="$$out" VERSION="$(VERSION)"; \
+		$(MAKE) --no-print-directory build-cli GOOS="$$os" GOARCH="$$arch" CLI_BIN="$$out" VERSION="$(VERSION)" INSTALL_SOURCE=github-release TELEMETRY_ENDPOINT="$(if $(TELEMETRY_ENDPOINT),$(TELEMETRY_ENDPOINT),$(RELEASE_TELEMETRY_ENDPOINT))"; \
 	done; \
 	cd $(DIST_DIR) && sha256sum $(CLI_NAME)-* > checksums.txt && printf '%s\n' "$(VERSION)" > version
 

--- a/README.md
+++ b/README.md
@@ -246,6 +246,61 @@ cat ~/drive9/run-42.txt
 - It targets agent workspace workloads, not full general-purpose POSIX compatibility.
 - Search and semantic metadata exist, but Drive9 is not a vector-memory product.
 
+## Telemetry
+
+Drive9 CLI telemetry is opt-in and disabled by default: nothing is collected or
+sent unless you enable it explicitly.
+
+Enable it for one machine by adding a `telemetry` section to your existing
+`~/.drive9/config` (keep the fields already in that file):
+
+```json
+{
+  "telemetry": { "enabled": true }
+}
+```
+
+Or for a single process:
+
+```bash
+DRIVE9_TELEMETRY=on drive9 ...
+```
+
+When enabled, the CLI sends one anonymous `drive9.command.finished` event per
+finished command through the same product-owned ingestion service used by ti-cli.
+
+Collected:
+
+- command and flag names, never flag values
+- exit codes and duration
+- Drive9 version, OS, and architecture
+
+Never collected:
+
+- credentials or tokens
+- SQL text
+- file paths or contents
+- command output or API response payloads
+- tenant IDs or other cloud resource IDs
+
+While enabled, the CLI keeps one anonymous, machine-local installation ID in
+`~/.drive9/.telemetry-installation-id` (`0600`); delete that file to start over
+with a new ID. Telemetry is skipped for help, version, commandless usage,
+unknown commands, `drive9 update`, and the background mount workers Drive9
+starts on your behalf.
+
+To disable it again, set `"telemetry": { "enabled": false }` or:
+
+```bash
+DRIVE9_TELEMETRY=off drive9 ...
+```
+
+Set `DRIVE9_TELEMETRY_DEBUG=1` to see why an event was skipped or dropped on
+stderr. Released binaries already contain the ingestion endpoint: the on/off
+switch above is the only setting. Only source builds have no endpoint baked in,
+so local testing of the delivery path also needs
+`DRIVE9_ALLOW_TEST_ENDPOINTS=1` plus `DRIVE9_TEST_TELEMETRY_ENDPOINT`.
+
 ## Documentation
 
 - [LayerFS V1 design](docs/design/layered-filesystem-v1-design.md)

--- a/README.md
+++ b/README.md
@@ -273,7 +273,12 @@ Collected:
 
 - command and flag names, never flag values
 - exit codes and duration
-- Drive9 version, OS, and architecture
+- Drive9 version, OS, architecture, and how the CLI was installed
+- the active context's cloud provider and region, from a fixed allowlist
+  (unrecognised values are dropped, and commands addressing another context
+  report neither)
+- whether the credentials came from the config file, the environment, or an
+  explicit flag
 
 Never collected:
 

--- a/cmd/drive9/cli/config.go
+++ b/cmd/drive9/cli/config.go
@@ -55,10 +55,20 @@ type Context struct {
 	LabelHint     string        `json:"label_hint,omitempty"`
 }
 
+// TelemetryConfig is the persisted CLI telemetry opt-in stored in
+// ~/.drive9/config. A nil Enabled means the user never expressed a preference.
+type TelemetryConfig struct {
+	Enabled *bool `json:"enabled,omitempty"`
+}
+
 type Config struct {
 	Server         string              `json:"server"`
 	CurrentContext string              `json:"current_context,omitempty"`
 	Contexts       map[string]*Context `json:"contexts"`
+	// Telemetry must stay part of this struct: loadConfig/saveConfig round-trip
+	// the whole document, so an unlisted field would be dropped on the next
+	// `ctx` mutation and silently reset the user's choice.
+	Telemetry *TelemetryConfig `json:"telemetry,omitempty"`
 }
 
 func configDir() string {

--- a/cmd/drive9/cli/exit.go
+++ b/cmd/drive9/cli/exit.go
@@ -1,0 +1,48 @@
+package cli
+
+import "os"
+
+// exitHook is the process exit path used by command handlers. main installs a
+// hook so that process-level observers (CLI telemetry) can act on the real exit
+// code; the default keeps the package usable on its own, e.g. in tests.
+var exitHook = os.Exit
+
+// SetExitHook installs fn as the exit path for command handlers and returns a
+// function that restores the previous hook.
+func SetExitHook(fn func(code int)) func() {
+	previous := exitHook
+	exitHook = fn
+	return func() { exitHook = previous }
+}
+
+// exitProcess terminates the process through the installed hook. Handlers must
+// use it instead of os.Exit so that no exit path bypasses process observers.
+func exitProcess(code int) {
+	exitHook(code)
+}
+
+// UsageError reports a command-line usage failure that the flag package already
+// reported to stderr. Reported() is true so the top-level handler exits with
+// the requested code without printing the message a second time.
+type UsageError struct {
+	Err  error
+	Code int
+}
+
+func (e UsageError) Error() string {
+	if e.Err == nil {
+		return "invalid usage"
+	}
+	return e.Err.Error()
+}
+
+func (e UsageError) Unwrap() error { return e.Err }
+
+func (e UsageError) Reported() bool { return true }
+
+func (e UsageError) ExitCode() int {
+	if e.Code <= 0 {
+		return 2
+	}
+	return e.Code
+}

--- a/cmd/drive9/cli/git.go
+++ b/cmd/drive9/cli/git.go
@@ -687,7 +687,9 @@ func startGitHydrateBackground(ctx context.Context, target string, resolved moun
 	cmd := exec.CommandContext(ctx, os.Args[0], "git", "hydrate", "--timeout="+gitHydrateTimeout.String(), target)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
-	cmd.Env = os.Environ()
+	// Detached hydration is internal work started by `git clone`/`worktree add`;
+	// those commands report themselves, so the child must stay silent.
+	cmd.Env = telemetryDisabledEnv(os.Environ())
 	if err := cmd.Start(); err != nil {
 		_ = logFile.Close()
 		return err

--- a/cmd/drive9/cli/mount.go
+++ b/cmd/drive9/cli/mount.go
@@ -146,7 +146,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	if authLocal {
 		originalArgs = append([]string{"--auth=local"}, args...)
 	}
-	fs := flag.NewFlagSet("mount", flag.ExitOnError)
+	fs := flag.NewFlagSet("mount", flag.ContinueOnError)
 	server := fs.String("server", "", "drive9 server URL (overrides $DRIVE9_SERVER and config)")
 	apiKey := fs.String("api-key", "", "owner API key (overrides $DRIVE9_API_KEY and config)")
 	mode := fs.String("mode", "auto", "mount mode: auto, fuse, or webdav")
@@ -229,7 +229,8 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 	}
 
 	if err := fs.Parse(args); err != nil {
-		return err
+		// The flag package already printed the error and the command usage.
+		return UsageError{Err: err}
 	}
 	gvisorCompatGiven := flagProvided(fs, "gvisor-compat")
 	if !gvisorCompatGiven {
@@ -267,7 +268,7 @@ func fsMountCmdWithBackground(args []string, background bool) error {
 		}
 	default:
 		fs.Usage()
-		os.Exit(2)
+		exitProcess(2)
 	}
 
 	envAppendLogPatterns, err := consumeMountPolicyPatternsEnv(EnvMountAppendLogPatterns)
@@ -1295,7 +1296,9 @@ func mountBackgroundEnv(environ []string, req mountBackgroundRequest) []string {
 	} else if req.APIKey != "" {
 		out = append(out, EnvAPIKey+"="+req.APIKey)
 	}
-	return out
+	// Spawned mount processes are internal: never let them report their own
+	// command-completion events.
+	return telemetryDisabledEnv(out)
 }
 
 func openMountBackgroundLog(mountPoint string) (string, *os.File, error) {

--- a/cmd/drive9/cli/mount_drain.go
+++ b/cmd/drive9/cli/mount_drain.go
@@ -30,7 +30,7 @@ func MountDrainCmd(args []string) error {
 }
 
 func runMountDrain(args []string, deps mountDrainDeps) error {
-	fs := flag.NewFlagSet("mount drain", flag.ExitOnError)
+	fs := flag.NewFlagSet("mount drain", flag.ContinueOnError)
 	timeout := fs.Duration("timeout", mountcontrol.DefaultDrainTimeout, "maximum time to wait for pending writes to drain")
 	jsonOutput := fs.Bool("json", false, "output drain result as JSON")
 	fs.Usage = func() {
@@ -38,7 +38,8 @@ func runMountDrain(args []string, deps mountDrainDeps) error {
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
-		return err
+		// The flag package already printed the error and the command usage.
+		return UsageError{Err: err}
 	}
 	if fs.NArg() != 1 {
 		fs.Usage()

--- a/cmd/drive9/cli/mount_supervise.go
+++ b/cmd/drive9/cli/mount_supervise.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/mountstate"
 	"github.com/mem9-ai/drive9/pkg/mountsupervisor"
+	"github.com/mem9-ai/drive9/pkg/telemetry"
 )
 
 // runMountSupervise is the hidden supervisor entrypoint:
@@ -133,7 +134,7 @@ func runMountSupervise(args []string) error {
 		MountPoint:          *mountPoint,
 		Executable:          exe,
 		WorkerArgs:          workerArgs,
-		Env:                 os.Environ(),
+		Env:                 telemetryDisabledEnv(os.Environ()),
 		LogPath:             *logPath,
 		Stdout:              stdout,
 		Stderr:              stderr,
@@ -529,6 +530,8 @@ func runMountSystemdUnit(args []string) error {
 	execStart := systemdEscapePercents(shellJoin(startArgs))
 	execStop := systemdEscapePercents(shellJoin([]string{exe, "umount", "--timeout", "60s", mountPoint}))
 	desc := systemdEscapePercents(fmt.Sprintf("drive9 FUSE mount for %s", mountPoint))
+	// The unit re-runs this binary for ExecStart/ExecStop without a user typing
+	// anything, so the whole unit opts out of telemetry.
 	unit := fmt.Sprintf(`[Unit]
 Description=%s
 After=network-online.target
@@ -536,6 +539,7 @@ Wants=network-online.target
 
 [Service]
 Type=simple
+Environment=%s=off
 ExecStart=%s
 ExecStop=%s
 Restart=on-failure
@@ -545,7 +549,7 @@ TimeoutStopSec=70
 
 [Install]
 WantedBy=default.target
-`, desc, execStart, execStop)
+`, desc, telemetry.EnvironmentVariable, execStart, execStop)
 
 	if !install {
 		fmt.Print(unit)

--- a/cmd/drive9/cli/mount_test.go
+++ b/cmd/drive9/cli/mount_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mem9-ai/drive9/pkg/client"
 	"github.com/mem9-ai/drive9/pkg/mountstate"
+	"github.com/mem9-ai/drive9/pkg/telemetry"
 )
 
 func fakeLookPath(binMap map[string]bool) func(string) (string, error) {
@@ -1154,10 +1155,23 @@ func TestMountBackgroundEnvSnapshotsCredentials(t *testing.T) {
 		envMountGVisorCompat + "=true",
 		EnvServer + "=https://drive9.example",
 		EnvVaultToken + "=jwt-token",
+		// Background mounts are internal processes: they must never report
+		// their own telemetry events.
+		telemetry.EnvironmentVariable + "=off",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("env = %v, want %v", got, want)
 	}
+}
+
+func TestMountBackgroundEnvOverridesInheritedTelemetryOptIn(t *testing.T) {
+	got := mountBackgroundEnv([]string{"PATH=/bin", telemetry.EnvironmentVariable + "=on"}, mountBackgroundRequest{})
+	for _, kv := range got {
+		if kv == telemetry.EnvironmentVariable+"=off" {
+			return
+		}
+	}
+	t.Fatalf("env = %v, want an explicit telemetry opt-out", got)
 }
 
 func TestWorkerArgsForSupervisePreservesGVisorCompat(t *testing.T) {

--- a/cmd/drive9/cli/mount_vault.go
+++ b/cmd/drive9/cli/mount_vault.go
@@ -28,7 +28,7 @@ func VaultMountCmd(args []string) error {
 }
 
 func vaultMountCmd(args []string, background bool) error {
-	fs := flag.NewFlagSet("mount vault", flag.ExitOnError)
+	fs := flag.NewFlagSet("mount vault", flag.ContinueOnError)
 	server := fs.String("server", "", "drive9 server URL (overrides $DRIVE9_SERVER and config)")
 	apiKey := fs.String("api-key", "", "owner API key (overrides $DRIVE9_API_KEY and config)")
 	foreground := fs.Bool("foreground", false, "run in the foreground and block until unmounted")
@@ -42,11 +42,12 @@ func vaultMountCmd(args []string, background bool) error {
 	}
 
 	if err := fs.Parse(args); err != nil {
-		return err
+		// The flag package already printed the error and the command usage.
+		return UsageError{Err: err}
 	}
 	if fs.NArg() < 1 {
 		fs.Usage()
-		os.Exit(2)
+		exitProcess(2)
 	}
 	if fs.NArg() != 1 {
 		return fmt.Errorf("drive9 mount vault: exactly one mountpoint required")

--- a/cmd/drive9/cli/mount_webdav.go
+++ b/cmd/drive9/cli/mount_webdav.go
@@ -82,7 +82,7 @@ func webdavMount(c *client.Client, mountPoint string, remoteRoot string) error {
 		signals:    signalChannel(),
 		runMount:   runWebDAVMountCmd,
 		unmount:    webdavUnmount,
-		exit:       os.Exit,
+		exit:       exitProcess,
 		newPrefix:  newWebDAVNoncePrefix,
 		remoteRoot: remoteRoot,
 	})
@@ -112,7 +112,7 @@ func webdavMountWithDeps(c *client.Client, mountPoint string, deps webdavMountDe
 		deps.unmount = webdavUnmount
 	}
 	if deps.exit == nil {
-		deps.exit = os.Exit
+		deps.exit = exitProcess
 	}
 	if deps.newPrefix == nil {
 		deps.newPrefix = newWebDAVNoncePrefix

--- a/cmd/drive9/cli/telemetry.go
+++ b/cmd/drive9/cli/telemetry.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"os"
+	"strings"
+
+	"github.com/mem9-ai/drive9/pkg/telemetry"
+)
+
+// telemetryDisabledEnv returns environ with telemetry switched off, for
+// processes drive9 spawns itself (background mounts, supervisors, detached
+// hydration). The invocation that started them is reported by the foreground
+// process, so counting the child as well would double-count one user command —
+// and a supervised worker lives as long as the mount, which would also pollute
+// the duration distribution with mount lifetimes.
+func telemetryDisabledEnv(environ []string) []string {
+	out := make([]string, 0, len(environ)+1)
+	for _, kv := range environ {
+		if strings.HasPrefix(kv, telemetry.EnvironmentVariable+"=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, telemetry.EnvironmentVariable+"=off")
+}
+
+// TelemetryPreference reports the persisted telemetry opt-in from
+// ~/.drive9/config. The second result is false when the user has never
+// recorded a preference, and also when the config cannot be read or parsed —
+// an unreadable config must never turn telemetry on.
+func TelemetryPreference() (enabled bool, recorded bool) {
+	cfg := loadConfig()
+	pref := cfg.Telemetry
+	if pref == nil || pref.Enabled == nil {
+		return false, false
+	}
+	return *pref.Enabled, true
+}
+
+// TelemetryContextMetadata returns allowlisted placement fields from the
+// active context without exposing credentials, context names, or tokens.
+func TelemetryContextMetadata() (cloudProvider, region, profileSource string) {
+	cfg := loadConfig()
+	ctx := cfg.currentContextEntry()
+	if ctx != nil {
+		cloudProvider = strings.TrimSpace(ctx.CloudProvider)
+		region = strings.TrimSpace(ctx.Region)
+	}
+	switch {
+	case strings.TrimSpace(os.Getenv(EnvAPIKey)) != "" || strings.TrimSpace(os.Getenv(EnvVaultToken)) != "":
+		profileSource = "env"
+	case ctx != nil:
+		profileSource = "default"
+	default:
+		profileSource = "unknown"
+	}
+	return cloudProvider, region, profileSource
+}

--- a/cmd/drive9/cli/telemetry_test.go
+++ b/cmd/drive9/cli/telemetry_test.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestTelemetryPreferenceReadsConfig(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		config       string
+		writeConfig  bool
+		wantEnabled  bool
+		wantRecorded bool
+	}{
+		{name: "recorded enable", config: `{"telemetry":{"enabled":true}}`, writeConfig: true, wantEnabled: true, wantRecorded: true},
+		{name: "recorded disable", config: `{"telemetry":{"enabled":false}}`, writeConfig: true, wantRecorded: true},
+		{name: "absent section", config: `{"contexts":{}}`, writeConfig: true},
+		{name: "empty section", config: `{"telemetry":{}}`, writeConfig: true},
+		{name: "missing file"},
+		{name: "malformed json", config: `{"telemetry":`, writeConfig: true},
+		{name: "wrong value type", config: `{"telemetry":{"enabled":"yes"}}`, writeConfig: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			if test.writeConfig {
+				writeCLITestConfig(t, home, test.config)
+			}
+			enabled, recorded := TelemetryPreference()
+			if enabled != test.wantEnabled || recorded != test.wantRecorded {
+				t.Fatalf("TelemetryPreference() = %t, %t; want %t, %t", enabled, recorded, test.wantEnabled, test.wantRecorded)
+			}
+		})
+	}
+}
+
+// TestTelemetryPreferenceSurvivesConfigRewrites guards the footgun that makes
+// the preference part of the Config struct: ctx mutations rewrite the whole
+// document, and an unlisted field would be dropped, silently resetting the
+// user's opt-in.
+func TestTelemetryPreferenceSurvivesConfigRewrites(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	writeCLITestConfig(t, home, `{"current_context":"a","contexts":{"a":{"type":"owner","api_key":"k","server":"https://s"}},"telemetry":{"enabled":true}}`)
+
+	cfg := loadConfig()
+	cfg.Contexts["b"] = &Context{Type: PrincipalOwner, APIKey: "k2", Server: "https://s"}
+	if err := saveConfig(cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	enabled, recorded := TelemetryPreference()
+	if !recorded || !enabled {
+		t.Fatalf("TelemetryPreference() = %t, %t after a config rewrite", enabled, recorded)
+	}
+	data, err := os.ReadFile(configPath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), `"telemetry"`) {
+		t.Fatalf("config rewrite dropped the telemetry preference: %s", data)
+	}
+}
+
+func writeCLITestConfig(t *testing.T, home, content string) {
+	t.Helper()
+	dir := filepath.Join(home, ".drive9")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTelemetryContextMetadataOmitsSecretsAndNames(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(EnvAPIKey, "")
+	t.Setenv(EnvVaultToken, "")
+	dir := filepath.Join(home, ".drive9")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	cfg := Config{
+		CurrentContext: "prod-secret-name",
+		Contexts: map[string]*Context{
+			"prod-secret-name": {
+				Type:          PrincipalOwner,
+				APIKey:        "drive9_must-not-leak",
+				CloudProvider: "aws",
+				Region:        "aws-ap-southeast-1",
+			},
+		},
+	}
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config"), append(data, '\n'), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	provider, region, source := TelemetryContextMetadata()
+	if provider != "aws" || region != "aws-ap-southeast-1" || source != "default" {
+		t.Fatalf("provider=%q region=%q source=%q", provider, region, source)
+	}
+	joined := provider + region + source
+	if strings.Contains(joined, "drive9_must-not-leak") || strings.Contains(joined, "prod-secret-name") {
+		t.Fatalf("telemetry metadata leaked identity: %q %q %q", provider, region, source)
+	}
+}
+
+func TestTelemetryContextMetadataUsesEnvSource(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(EnvAPIKey, "drive9_env_key")
+	t.Setenv(EnvVaultToken, "")
+
+	_, _, source := TelemetryContextMetadata()
+	if source != "env" {
+		t.Fatalf("source = %q, want env", source)
+	}
+}

--- a/cmd/drive9/main.go
+++ b/cmd/drive9/main.go
@@ -63,6 +63,18 @@ var umountHandler = cli.UmountCmd
 var updateHandler = cli.Update
 
 func main() {
+	// Command handlers exit through the cli package; give them the same
+	// telemetry-aware exit path this package uses.
+	restoreExitHook := cli.SetExitHook(exitWithCode)
+	defer restoreExitHook()
+
+	withCLITelemetry(os.Args[1:], runCLI)
+}
+
+// runCLI performs one CLI invocation inside the telemetry-aware wrapper, so
+// startup failures report the same way a command failure does. It must not call
+// os.Exit directly: every exit goes through exitWithCode.
+func runCLI() {
 	if logger.CLIEnabled() {
 		if l, err := logger.NewCLILogger(); err == nil {
 			cliLogger = l
@@ -76,13 +88,15 @@ func main() {
 	stopCPUProfile, err := startCPUProfileFromEnv()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "drive9: %v\n", err)
-		os.Exit(1)
+		exitWithCode(1)
+		return
 	}
 	cpuProfileStop = stopCPUProfile
 	defer cpuProfileStop()
 
 	if len(os.Args) < 2 {
 		usage(2)
+		return
 	}
 
 	dispatch(os.Args[1], os.Args[2:])
@@ -401,7 +415,11 @@ func fatal(cmd string, err error) {
 			msg = m
 		}
 	}
-	fmt.Fprintf(os.Stderr, "%s: %v\n", cmd, msg)
+	// Errors that already printed their own message (and usage) are reported
+	// only through the exit code.
+	if reported, ok := err.(interface{ Reported() bool }); !ok || !reported.Reported() {
+		fmt.Fprintf(os.Stderr, "%s: %v\n", cmd, msg)
+	}
 	type exitCoder interface{ ExitCode() int }
 	if ec, ok := err.(exitCoder); ok && ec.ExitCode() > 0 {
 		exitWithCode(ec.ExitCode())

--- a/cmd/drive9/telemetry.go
+++ b/cmd/drive9/telemetry.go
@@ -27,7 +27,12 @@ type telemetryNode struct {
 	defaultName string
 	excluded    bool
 	leaf        bool
-	children    map[string]*telemetryNode
+	// bareHelp marks command trees whose leaf parsers treat a bare "help"
+	// operand as a help request (`drive9 admin tenant create help` is a
+	// successful help invocation). It is inherited by descendants. Commands like
+	// `fs grep` do not set it, because there "help" is a legitimate operand.
+	bareHelp bool
+	children map[string]*telemetryNode
 }
 
 var telemetryLeaf = &telemetryNode{}
@@ -43,7 +48,8 @@ var telemetryCommands = &telemetryNode{
 		"version": {excluded: true},
 		"help":    {excluded: true},
 		"admin": {
-			aliases: map[string]string{"tenants": "tenant"},
+			aliases:  map[string]string{"tenants": "tenant"},
+			bareHelp: true,
 			children: map[string]*telemetryNode{
 				"tenant": {
 					children: map[string]*telemetryNode{
@@ -233,7 +239,7 @@ func resolveTelemetryCommand(args []string) telemetryInvocation {
 	if len(args) == 0 || hasTelemetryExclusionFlag(args) || hasInternalProcessFlag(args) {
 		return telemetryInvocation{}
 	}
-	path, rest, ok := telemetryCommands.resolve(args, []string{"drive9"})
+	path, rest, ok := telemetryCommands.resolve(args, []string{"drive9"}, false)
 	if !ok || len(path) == 0 {
 		return telemetryInvocation{}
 	}
@@ -244,17 +250,18 @@ func resolveTelemetryCommand(args []string) telemetryInvocation {
 	}
 }
 
-func (n *telemetryNode) resolve(args []string, path []string) ([]string, []string, bool) {
+func (n *telemetryNode) resolve(args []string, path []string, bareHelp bool) ([]string, []string, bool) {
 	if n == nil || n.excluded {
 		return nil, nil, false
 	}
+	bareHelp = bareHelp || n.bareHelp
 	if len(args) == 0 {
 		if n.defaultName != "" {
 			child := n.lookupChild(n.defaultName)
 			if child == nil {
 				return nil, nil, false
 			}
-			return child.resolve(nil, append(path, n.defaultName))
+			return child.resolve(nil, append(path, n.defaultName), bareHelp)
 		}
 		if len(n.children) > 0 && !n.leaf {
 			return nil, nil, false
@@ -269,11 +276,15 @@ func (n *telemetryNode) resolve(args []string, path []string) ([]string, []strin
 		if child == nil {
 			return nil, nil, false
 		}
-		return child.resolve(args[1:], append(path, childName))
+		return child.resolve(args[1:], append(path, childName), bareHelp)
 	}
-	// Everything left belongs to a leaf command, so it is an argument — even
-	// when it spells "help" or "version" (`drive9 fs grep help`).
+	// Everything left belongs to a leaf command, so it is normally an argument —
+	// even when it spells "version" (`drive9 fs grep help`). Trees that do treat
+	// a bare "help" as a help request opt out through bareHelp.
 	if n.leaf || len(n.children) == 0 {
+		if bareHelp && hasBareHelpOperand(args) {
+			return nil, nil, false
+		}
 		return path, args, true
 	}
 	// Unknown token on a namespace command: help/version or a command we do not
@@ -328,6 +339,46 @@ func hasTelemetryExclusionFlag(args []string) bool {
 			continue
 		}
 		if !hasValue || strings.EqualFold(value, "true") || value == "1" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasBareHelpOperand reports whether a leaf command's arguments contain a bare
+// "help" that its parser would treat as a help request. A "help" consumed as a
+// flag's value (`--server help`) does not count.
+func hasBareHelpOperand(args []string) bool {
+	previousWasFlag := false
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		if !strings.HasPrefix(arg, "-") {
+			if arg == "help" && !previousWasFlag {
+				return true
+			}
+			previousWasFlag = false
+			continue
+		}
+		// An inline "--flag=value" token consumes nothing after it.
+		previousWasFlag = !strings.Contains(arg, "=")
+	}
+	return false
+}
+
+// hasContextScopedOperand reports whether argv addresses a named context
+// (name:/path). Such a command is served by that context's client, so the
+// active context's placement must not be reported as if it were its own.
+func hasContextScopedOperand(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			continue
+		}
+		if strings.HasPrefix(arg, "-") || strings.Contains(arg, "://") {
+			continue
+		}
+		if index := strings.Index(arg, ":/"); index > 0 {
 			return true
 		}
 	}
@@ -467,6 +518,11 @@ func finishCLITelemetry(session *telemetry.Session, inv telemetryInvocation, arg
 		return
 	}
 	provider, region, source := cli.TelemetryContextMetadata()
+	if hasContextScopedOperand(args) {
+		// The command ran against another context; the active context's
+		// placement does not describe it, and reporting it would be wrong.
+		provider, region, source = "", "", "unknown"
+	}
 	session.Finish(telemetry.EventInput{
 		CommandPath:   inv.commandPath,
 		FlagNames:     telemetryFlagNames(inv.flagArgs),

--- a/cmd/drive9/telemetry.go
+++ b/cmd/drive9/telemetry.go
@@ -388,6 +388,12 @@ func telemetryFlagNames(args []string) []string {
 		if !telemetryFlagNamePattern.MatchString(name) {
 			continue
 		}
+		// Closed allowlist: a dash-prefixed token that is not a flag this CLI
+		// defines is user input — an unknown or mistyped flag, or a value the
+		// command rejects — and must never be reported.
+		if _, known := telemetryKnownFlagNames[name]; !known {
+			continue
+		}
 		if _, ok := seen[name]; ok {
 			continue
 		}

--- a/cmd/drive9/telemetry.go
+++ b/cmd/drive9/telemetry.go
@@ -1,0 +1,492 @@
+package main
+
+import (
+	"os"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mem9-ai/drive9/cmd/drive9/cli"
+	"github.com/mem9-ai/drive9/pkg/buildinfo"
+	"github.com/mem9-ai/drive9/pkg/telemetry"
+)
+
+const (
+	maxTelemetryCommandSegments = 4 // "drive9" + up to 3 subcommands
+	testEndpointsEnv            = "DRIVE9_ALLOW_TEST_ENDPOINTS"
+	testEndpointEnv             = "DRIVE9_TEST_TELEMETRY_ENDPOINT"
+	telemetryDebugEnv           = "DRIVE9_TELEMETRY_DEBUG"
+)
+
+var telemetryFlagNamePattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+
+type telemetryNode struct {
+	aliases     map[string]string
+	defaultName string
+	excluded    bool
+	leaf        bool
+	children    map[string]*telemetryNode
+}
+
+var telemetryLeaf = &telemetryNode{}
+
+var telemetryCommands = &telemetryNode{
+	children: map[string]*telemetryNode{
+		"create":  telemetryLeaf,
+		"delete":  telemetryLeaf,
+		"pack":    telemetryLeaf,
+		"unpack":  telemetryLeaf,
+		"umount":  telemetryLeaf,
+		"update":  {excluded: true},
+		"version": {excluded: true},
+		"help":    {excluded: true},
+		"admin": {
+			aliases: map[string]string{"tenants": "tenant"},
+			children: map[string]*telemetryNode{
+				"tenant": {
+					children: map[string]*telemetryNode{
+						"create":    telemetryLeaf,
+						"list":      telemetryLeaf,
+						"get":       telemetryLeaf,
+						"delete":    telemetryLeaf,
+						"set-quota": telemetryLeaf,
+						"extract-config": {
+							children: map[string]*telemetryNode{
+								"get": telemetryLeaf,
+								"set": telemetryLeaf,
+							},
+						},
+						"embedding-config": {
+							children: map[string]*telemetryNode{
+								"get": telemetryLeaf,
+								"set": telemetryLeaf,
+							},
+						},
+						"object-namespace": {
+							children: map[string]*telemetryNode{
+								"get":   telemetryLeaf,
+								"set":   telemetryLeaf,
+								"clear": telemetryLeaf,
+							},
+						},
+						"pool": {
+							children: map[string]*telemetryNode{
+								"create": telemetryLeaf,
+								"get":    telemetryLeaf,
+								"update": telemetryLeaf,
+								"delete": telemetryLeaf,
+							},
+						},
+					},
+				},
+				"pool": {
+					children: map[string]*telemetryNode{
+						"create": telemetryLeaf,
+						"get":    telemetryLeaf,
+						"update": telemetryLeaf,
+						"delete": telemetryLeaf,
+					},
+				},
+				"object-backend": {
+					aliases: map[string]string{"list": "ls", "delete": "rm"},
+					children: map[string]*telemetryNode{
+						"add":    telemetryLeaf,
+						"get":    telemetryLeaf,
+						"ls":     telemetryLeaf,
+						"update": telemetryLeaf,
+						"rm":     telemetryLeaf,
+					},
+				},
+			},
+		},
+		"ctx": {
+			defaultName: "show",
+			aliases:     map[string]string{"list": "ls"},
+			children: map[string]*telemetryNode{
+				"show":   telemetryLeaf,
+				"add":    telemetryLeaf,
+				"import": telemetryLeaf,
+				"fork":   telemetryLeaf,
+				"ls":     telemetryLeaf,
+				"use":    telemetryLeaf,
+				"rm":     telemetryLeaf,
+			},
+		},
+		"fs": {
+			children: map[string]*telemetryNode{
+				"cp":       telemetryLeaf,
+				"cat":      telemetryLeaf,
+				"ls":       telemetryLeaf,
+				"stat":     telemetryLeaf,
+				"mv":       telemetryLeaf,
+				"rm":       telemetryLeaf,
+				"mkdir":    telemetryLeaf,
+				"chmod":    telemetryLeaf,
+				"setmeta":  telemetryLeaf,
+				"symlink":  telemetryLeaf,
+				"hardlink": telemetryLeaf,
+				"sh":       telemetryLeaf,
+				"grep":     telemetryLeaf,
+				"find":     telemetryLeaf,
+				"archive":  telemetryLeaf,
+				"layer": {
+					aliases: map[string]string{"ls": "list", "get": "status", "rm": "delete"},
+					children: map[string]*telemetryNode{
+						"create":     telemetryLeaf,
+						"list":       telemetryLeaf,
+						"status":     telemetryLeaf,
+						"diff":       telemetryLeaf,
+						"checkpoint": telemetryLeaf,
+						"rollback":   telemetryLeaf,
+						"commit":     telemetryLeaf,
+						"fork":       telemetryLeaf,
+						"chain":      telemetryLeaf,
+						"delete":     telemetryLeaf,
+					},
+				},
+			},
+		},
+		"token": {
+			aliases: map[string]string{"ls": "list"},
+			children: map[string]*telemetryNode{
+				"issue":  telemetryLeaf,
+				"revoke": telemetryLeaf,
+				"list":   telemetryLeaf,
+				"forget": telemetryLeaf,
+			},
+		},
+		"vault": {
+			children: map[string]*telemetryNode{
+				"set":    telemetryLeaf,
+				"get":    telemetryLeaf,
+				"put":    telemetryLeaf,
+				"with":   telemetryLeaf,
+				"ls":     telemetryLeaf,
+				"rm":     telemetryLeaf,
+				"grant":  telemetryLeaf,
+				"revoke": telemetryLeaf,
+				"audit":  telemetryLeaf,
+			},
+		},
+		"journal": {
+			children: map[string]*telemetryNode{
+				"new":    telemetryLeaf,
+				"append": telemetryLeaf,
+				"cat":    telemetryLeaf,
+				"find":   telemetryLeaf,
+				"verify": telemetryLeaf,
+				"seal":   telemetryLeaf,
+			},
+		},
+		"git": {
+			children: map[string]*telemetryNode{
+				"clone":   telemetryLeaf,
+				"hydrate": telemetryLeaf,
+				"worktree": {
+					children: map[string]*telemetryNode{
+						"add":    telemetryLeaf,
+						"remove": telemetryLeaf,
+					},
+				},
+			},
+		},
+		"region": {
+			aliases: map[string]string{"ls": "list"},
+			children: map[string]*telemetryNode{
+				"list": telemetryLeaf,
+			},
+		},
+		"profile": {
+			children: map[string]*telemetryNode{
+				"show": telemetryLeaf,
+			},
+		},
+		"mount": {
+			leaf: true,
+			children: map[string]*telemetryNode{
+				"vault":        telemetryLeaf,
+				"drain":        telemetryLeaf,
+				"status":       telemetryLeaf,
+				"health":       telemetryLeaf,
+				"ensure":       telemetryLeaf,
+				"systemd-unit": telemetryLeaf,
+				"supervise":    {excluded: true},
+			},
+		},
+		"doctor": {
+			children: map[string]*telemetryNode{
+				"fuse": telemetryLeaf,
+			},
+		},
+	},
+}
+
+type telemetryInvocation struct {
+	commandPath string
+	flagArgs    []string
+	eligible    bool
+}
+
+func resolveTelemetryCommand(args []string) telemetryInvocation {
+	if len(args) == 0 || hasTelemetryExclusionFlag(args) || hasInternalProcessFlag(args) {
+		return telemetryInvocation{}
+	}
+	path, rest, ok := telemetryCommands.resolve(args, []string{"drive9"})
+	if !ok || len(path) == 0 {
+		return telemetryInvocation{}
+	}
+	return telemetryInvocation{
+		commandPath: canonicalTelemetryCommandPath(path),
+		flagArgs:    rest,
+		eligible:    true,
+	}
+}
+
+func (n *telemetryNode) resolve(args []string, path []string) ([]string, []string, bool) {
+	if n == nil || n.excluded {
+		return nil, nil, false
+	}
+	if len(args) == 0 {
+		if n.defaultName != "" {
+			child := n.lookupChild(n.defaultName)
+			if child == nil {
+				return nil, nil, false
+			}
+			return child.resolve(nil, append(path, n.defaultName))
+		}
+		if len(n.children) > 0 && !n.leaf {
+			return nil, nil, false
+		}
+		return path, nil, true
+	}
+	tok := args[0]
+	// A known subcommand always wins: `mount supervise` is a subcommand even
+	// though `mount` also accepts positional arguments.
+	if childName, ok := n.childName(tok); ok {
+		child := n.lookupChild(childName)
+		if child == nil {
+			return nil, nil, false
+		}
+		return child.resolve(args[1:], append(path, childName))
+	}
+	// Everything left belongs to a leaf command, so it is an argument — even
+	// when it spells "help" or "version" (`drive9 fs grep help`).
+	if n.leaf || len(n.children) == 0 {
+		return path, args, true
+	}
+	// Unknown token on a namespace command: help/version or a command we do not
+	// know about. Either way there is nothing to report.
+	return nil, nil, false
+}
+
+func (n *telemetryNode) childName(tok string) (string, bool) {
+	if n.aliases != nil {
+		if canonical, ok := n.aliases[tok]; ok {
+			tok = canonical
+		}
+	}
+	if _, ok := n.children[tok]; ok {
+		return tok, true
+	}
+	return "", false
+}
+
+func (n *telemetryNode) lookupChild(name string) *telemetryNode {
+	if n.children == nil {
+		return nil
+	}
+	return n.children[name]
+}
+
+func canonicalTelemetryCommandPath(path []string) string {
+	if len(path) <= maxTelemetryCommandSegments {
+		return strings.Join(path, " ")
+	}
+	head := append([]string(nil), path[:maxTelemetryCommandSegments-1]...)
+	tail := strings.Join(path[maxTelemetryCommandSegments-1:], "-")
+	return strings.Join(append(head, tail), " ")
+}
+
+// hasTelemetryExclusionFlag reports whether argv asks for help or version
+// before any "--" terminator. Bare "help"/"version" words are command tokens,
+// not flag values: they are recognized while the command path is resolved, so
+// `drive9 fs find -name version` still reports normally.
+func hasTelemetryExclusionFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			continue
+		}
+		name, value, hasValue := strings.Cut(strings.TrimLeft(arg, "-"), "=")
+		switch strings.ToLower(name) {
+		case "h", "help", "v", "version":
+		default:
+			continue
+		}
+		if !hasValue || strings.EqualFold(value, "true") || value == "1" {
+			return true
+		}
+	}
+	return false
+}
+
+// hasInternalProcessFlag reports whether argv belongs to a drive9 process that
+// drive9 itself spawned instead of a command the user typed. The mount
+// supervisor, its workers, and the generated systemd unit all re-exec this
+// binary, and the invocation that started them has already been counted.
+func hasInternalProcessFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		if !strings.HasPrefix(arg, "-") {
+			continue
+		}
+		name, _, _ := strings.Cut(strings.TrimLeft(arg, "-"), "=")
+		switch name {
+		case "supervised", "supervise-foreground":
+			return true
+		}
+	}
+	return false
+}
+
+// telemetryFlagNames extracts flag names from argv without any knowledge of the
+// command's flag schema. A dash-prefixed token that directly follows another
+// dash-prefixed token is treated as that flag's value and never recorded: a
+// value-taking flag consumes the next argv entry unconditionally, and that
+// value may itself start with a dash. The cost is under-reporting flags written
+// back to back, which is the safe direction — guessing arity instead would let
+// a flag value be recorded as a flag name.
+func telemetryFlagNames(args []string) []string {
+	names := make([]string, 0)
+	seen := map[string]struct{}{}
+	previousWasFlag := false
+	for _, arg := range args {
+		if arg == "--" {
+			break
+		}
+		if !strings.HasPrefix(arg, "-") || arg == "-" {
+			previousWasFlag = false
+			continue
+		}
+		if previousWasFlag {
+			// Ambiguous token: the previous flag may have consumed it as a
+			// value. Only an inline "--flag=value" form proves it did not.
+			previousWasFlag = strings.Contains(arg, "=")
+			continue
+		}
+		// An inline "--flag=value" token consumes nothing after it.
+		previousWasFlag = !strings.Contains(arg, "=")
+		name := strings.TrimLeft(arg, "-")
+		name, _, _ = strings.Cut(name, "=")
+		name = strings.ToLower(strings.TrimSpace(name))
+		if !telemetryFlagNamePattern.MatchString(name) {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		names = append(names, name)
+	}
+	return names
+}
+
+func effectiveTelemetryEndpoint() string {
+	if endpoint := strings.TrimSpace(buildinfo.TelemetryEndpoint); endpoint != "" {
+		return endpoint
+	}
+	if isReleaseInstallSource(buildinfo.InstallSource) {
+		return ""
+	}
+	if os.Getenv(testEndpointsEnv) != "1" {
+		return ""
+	}
+	return strings.TrimSpace(os.Getenv(testEndpointEnv))
+}
+
+func isReleaseInstallSource(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "archive", "github-release", "homebrew", "scoop":
+		return true
+	default:
+		return false
+	}
+}
+
+func telemetryDebugEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(telemetryDebugEnv))) {
+	case "1", "true", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func telemetryProfileSource(args []string, fallback string) string {
+	for _, name := range telemetryFlagNames(args) {
+		if name == "api-key" {
+			return "explicit"
+		}
+	}
+	return fallback
+}
+
+func startCLITelemetry(args []string) (*telemetry.Session, telemetryInvocation) {
+	inv := resolveTelemetryCommand(args)
+	if !inv.eligible {
+		return nil, inv
+	}
+	session := telemetry.Start(telemetry.Config{
+		Eligible:      true,
+		Endpoint:      effectiveTelemetryEndpoint(),
+		Version:       buildinfo.Version,
+		OS:            runtime.GOOS,
+		Arch:          runtime.GOARCH,
+		InstallSource: buildinfo.InstallSource,
+		Preference:    cli.TelemetryPreference,
+		Debug:         telemetryDebugEnabled(),
+		DebugWriter:   os.Stderr,
+	})
+	return session, inv
+}
+
+func finishCLITelemetry(session *telemetry.Session, inv telemetryInvocation, args []string, exitCode int, duration time.Duration) {
+	if session == nil || !inv.eligible {
+		return
+	}
+	provider, region, source := cli.TelemetryContextMetadata()
+	session.Finish(telemetry.EventInput{
+		CommandPath:   inv.commandPath,
+		FlagNames:     telemetryFlagNames(inv.flagArgs),
+		ExitCode:      exitCode,
+		Duration:      duration,
+		CloudProvider: provider,
+		RegionCode:    region,
+		ProfileSource: telemetryProfileSource(args, source),
+	})
+}
+
+func withCLITelemetry(args []string, run func()) {
+	started := time.Now()
+	session, inv := startCLITelemetry(args)
+	var once sync.Once
+	finish := func(code int) {
+		once.Do(func() {
+			finishCLITelemetry(session, inv, args, code, time.Since(started))
+		})
+	}
+	origExit := exitFunc
+	exitFunc = func(code int) {
+		finish(code)
+		origExit(code)
+	}
+	defer func() { exitFunc = origExit }()
+	run()
+	finish(0)
+}

--- a/cmd/drive9/telemetry_drift_test.go
+++ b/cmd/drive9/telemetry_drift_test.go
@@ -4,8 +4,11 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -108,4 +111,153 @@ func dispatcherCaseLabels(file, function string) ([]string, error) {
 		})
 	}
 	return labels, nil
+}
+
+// TestTelemetryKnownFlagNamesCoverEveryDefinedFlag keeps the closed flag-name
+// allowlist in sync with the CLI. Telemetry records flag names from argv, so an
+// unknown name must be dropped (it is user input); this test makes sure a real
+// flag is never dropped silently — add it to telemetryKnownFlagNames instead.
+//
+// The set is derived from source because flags are declared in two styles: a
+// flag.FlagSet per command, and hand-rolled parsers that compare argv tokens
+// against string literals.
+func TestTelemetryKnownFlagNamesCoverEveryDefinedFlag(t *testing.T) {
+	defined := map[string]string{}
+	for _, file := range telemetryFlagDefinitionFiles(t) {
+		parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+		if err != nil {
+			t.Fatalf("%s: %v", file, err)
+		}
+		ast.Inspect(parsed, func(n ast.Node) bool {
+			switch node := n.(type) {
+			case *ast.CallExpr:
+				if name, ok := flagSetDefinitionName(node); ok {
+					defined[name] = file
+				}
+			case *ast.CaseClause:
+				for _, expr := range node.List {
+					if name, ok := dashPrefixedLiteral(expr); ok {
+						defined[name] = file
+					}
+				}
+			case *ast.BinaryExpr:
+				if node.Op != token.EQL && node.Op != token.NEQ {
+					return true
+				}
+				for _, expr := range []ast.Expr{node.X, node.Y} {
+					if name, ok := dashPrefixedLiteral(expr); ok {
+						defined[name] = file
+					}
+				}
+			}
+			return true
+		})
+	}
+	if len(defined) < 100 {
+		t.Fatalf("only %d flag names were derived; the scan is broken", len(defined))
+	}
+	var missing, stale []string
+	for name, file := range defined {
+		if _, known := telemetryKnownFlagNames[name]; !known {
+			missing = append(missing, name+" ("+file+")")
+		}
+	}
+	for name := range telemetryKnownFlagNames {
+		if _, ok := defined[name]; !ok {
+			stale = append(stale, name)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(stale)
+	if len(missing) > 0 {
+		t.Errorf("flags are defined but missing from telemetryKnownFlagNames (their names would be dropped): %s", strings.Join(missing, ", "))
+	}
+	if len(stale) > 0 {
+		t.Errorf("telemetryKnownFlagNames lists names no flag defines any more (they could record user input): %s", strings.Join(stale, ", "))
+	}
+	for name := range telemetryKnownFlagNames {
+		if !telemetryFlagNamePattern.MatchString(name) {
+			t.Errorf("telemetryKnownFlagNames entry %q cannot match the runtime pattern", name)
+		}
+	}
+}
+
+// telemetryFlagDefinitionFiles lists the non-test Go sources that can declare a
+// flag or parse one by hand.
+func telemetryFlagDefinitionFiles(t *testing.T) []string {
+	t.Helper()
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cliFiles, err := filepath.Glob("cli/*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	all := append(files, cliFiles...)
+	kept := make([]string, 0, len(all))
+	for _, file := range all {
+		if !strings.HasSuffix(file, "_test.go") {
+			kept = append(kept, file)
+		}
+	}
+	return kept
+}
+
+// flagSetDefinitionName recognizes a flag.FlagSet definition such as
+// fs.String("json", false, "..."), fs.DurationVar(&d, "timeout", ...), or
+// fs.Var(v, "tag", "..."), by method name, arity, and a variable receiver (a
+// package-qualified call like zap.String("command", ...) is not a flag).
+func flagSetDefinitionName(call *ast.CallExpr) (string, bool) {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	if _, ok := selector.X.(*ast.Ident); !ok {
+		return "", false
+	}
+	wantArgs, ok := telemetryFlagDefinitionMethods[selector.Sel.Name]
+	if !ok || len(call.Args) != wantArgs {
+		return "", false
+	}
+	nameIndex := 0
+	if selector.Sel.Name == "Var" || strings.HasSuffix(selector.Sel.Name, "Var") {
+		nameIndex = 1
+	}
+	literal, ok := call.Args[nameIndex].(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	if err != nil {
+		return "", false
+	}
+	return strings.ToLower(value), true
+}
+
+// telemetryFlagDefinitionMethods maps a flag-defining method to its arity.
+var telemetryFlagDefinitionMethods = map[string]int{
+	"String": 3, "Bool": 3, "Int": 3, "Int64": 3, "Uint": 3, "Uint64": 3,
+	"Duration": 3, "Float64": 3, "Text": 3, "Var": 3, "Func": 2,
+	"StringVar": 4, "BoolVar": 4, "IntVar": 4, "Int64Var": 4, "UintVar": 4,
+	"Uint64Var": 4, "DurationVar": 4, "Float64Var": 4, "TextVar": 4,
+}
+
+// dashPrefixedLiteral normalizes a "-flag" / "--flag" / "--flag=value" string
+// literal the same way telemetry does at runtime.
+func dashPrefixedLiteral(expr ast.Expr) (string, bool) {
+	literal, ok := expr.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return "", false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	if err != nil || !strings.HasPrefix(value, "-") {
+		return "", false
+	}
+	name, _, _ := strings.Cut(strings.TrimLeft(value, "-"), "=")
+	name = strings.ToLower(name)
+	if !telemetryFlagNamePattern.MatchString(name) {
+		return "", false
+	}
+	return name, true
 }

--- a/cmd/drive9/telemetry_drift_test.go
+++ b/cmd/drive9/telemetry_drift_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// telemetryDispatchSources maps each command dispatcher to its position in the
+// telemetry tree. The tree is hand-maintained, so this test exists to make drift
+// loud: adding a command or subcommand to a dispatcher without teaching
+// telemetry about it fails here instead of silently dropping its events.
+var telemetryDispatchSources = []struct {
+	file     string
+	function string
+	path     []string
+}{
+	{file: "main.go", function: "dispatch"},
+	{file: "main.go", function: "runFS", path: []string{"fs"}},
+	{file: "cli/mount.go", function: "MountCmd", path: []string{"mount"}},
+	{file: "cli/ctx.go", function: "Ctx", path: []string{"ctx"}},
+	{file: "cli/secret.go", function: "Secret", path: []string{"vault"}},
+	{file: "cli/token.go", function: "Token", path: []string{"token"}},
+	{file: "cli/journal.go", function: "Journal", path: []string{"journal"}},
+	{file: "cli/git.go", function: "Git", path: []string{"git"}},
+	{file: "cli/git.go", function: "gitWorktree", path: []string{"git", "worktree"}},
+	{file: "cli/region.go", function: "Region", path: []string{"region"}},
+	{file: "cli/profile.go", function: "Profile", path: []string{"profile"}},
+	{file: "cli/doctor.go", function: "runDoctor", path: []string{"doctor"}},
+	{file: "cli/layer.go", function: "Layer", path: []string{"fs", "layer"}},
+	{file: "cli/admin.go", function: "Admin", path: []string{"admin"}},
+	{file: "cli/admin.go", function: "adminTenant", path: []string{"admin", "tenant"}},
+	{file: "cli/admin.go", function: "adminTenantPool", path: []string{"admin", "tenant", "pool"}},
+	{file: "cli/admin_object_backend.go", function: "adminObjectBackend", path: []string{"admin", "object-backend"}},
+	{file: "cli/admin_extract_config.go", function: "adminTenantExtractConfig", path: []string{"admin", "tenant", "extract-config"}},
+	{file: "cli/admin_embedding_config.go", function: "adminTenantEmbeddingConfig", path: []string{"admin", "tenant", "embedding-config"}},
+	{file: "cli/admin_object_backend.go", function: "adminTenantObjectNamespace", path: []string{"admin", "tenant", "object-namespace"}},
+}
+
+// telemetryDispatcherCommandPattern matches command tokens only; flag labels
+// ("--json"), modes, and platform names never look like this.
+var telemetryDispatcherCommandPattern = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+
+func TestTelemetryTreeCoversEveryDispatchedCommand(t *testing.T) {
+	for _, source := range telemetryDispatchSources {
+		tokens, err := dispatcherCaseLabels(source.file, source.function)
+		if err != nil {
+			t.Fatalf("%s: %v", source.file, err)
+		}
+		if len(tokens) == 0 {
+			t.Fatalf("%s: dispatcher %s has no case labels; the test mapping is stale", source.file, source.function)
+		}
+		node := telemetryCommands
+		for _, segment := range source.path {
+			name, ok := node.childName(segment)
+			if !ok {
+				t.Fatalf("telemetry tree is missing the %q namespace", segment)
+			}
+			node = node.lookupChild(name)
+		}
+		for _, tok := range tokens {
+			// help/version are namespace tokens: any token a namespace does not
+			// know resolves to ineligible, so the tree does not list them.
+			if tok == "help" || tok == "version" {
+				continue
+			}
+			if _, ok := node.childName(tok); !ok {
+				t.Errorf("telemetry tree %v is missing the %q command; add it to telemetryCommands or exclude it explicitly",
+					append(append([]string{"drive9"}, source.path...), tok), tok)
+			}
+		}
+	}
+}
+
+// dispatcherCaseLabels returns the string literals of every case clause in the
+// named function.
+func dispatcherCaseLabels(file, function string) ([]string, error) {
+	parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	var labels []string
+	for _, decl := range parsed.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != function || fn.Body == nil {
+			continue
+		}
+		ast.Inspect(fn.Body, func(n ast.Node) bool {
+			clause, ok := n.(*ast.CaseClause)
+			if !ok {
+				return true
+			}
+			for _, expr := range clause.List {
+				literal, ok := expr.(*ast.BasicLit)
+				if !ok || literal.Kind != token.STRING {
+					continue
+				}
+				value, err := strconv.Unquote(literal.Value)
+				if err != nil || !telemetryDispatcherCommandPattern.MatchString(value) {
+					continue
+				}
+				labels = append(labels, value)
+			}
+			return true
+		})
+	}
+	return labels, nil
+}

--- a/cmd/drive9/telemetry_flags.go
+++ b/cmd/drive9/telemetry_flags.go
@@ -1,0 +1,69 @@
+package main
+
+// telemetryKnownFlagNames is every flag the CLI defines, in the normalized form
+// telemetry reports (no leading dashes, lower case, no inline value).
+//
+// Flag names are the only argv-derived data telemetry sends, so this is a closed
+// allowlist: a dash-prefixed token that is not one of these names is user input
+// (a mistyped or unknown flag, or a value the command would reject) and must
+// never be reported. Dropping an unknown name can only lose analytics, never
+// leak a value.
+//
+// TestTelemetryKnownFlagNamesCoverEveryDefinedFlag re-derives this set from the
+// source with go/ast and fails when a new flag is missing here.
+var telemetryKnownFlagNames = map[string]struct{}{
+	"access-key-id": {}, "account-id": {}, "actor": {}, "adopt": {},
+	"adopt-worker-creation": {}, "adopt-worker-pid": {}, "after": {}, "agent": {},
+	"alert-file": {}, "alert-webhook": {}, "allow": {}, "allow-other": {},
+	"api-base": {}, "api-key": {}, "api-key-file": {}, "append": {},
+	"append-log": {}, "attr-ttl": {}, "auth": {}, "b": {},
+	"base-url": {}, "blobless": {}, "bucket": {}, "cache-dir": {},
+	"cache-size": {}, "cascade": {}, "check": {}, "checkpoint": {},
+	"clear-description": {}, "clear-tags": {}, "cloud-provider": {}, "color": {},
+	"commit-queue-max-pending": {}, "credential-kind": {}, "cursor": {}, "d": {},
+	"debug": {}, "description": {}, "detach": {}, "details": {},
+	"dir-cache-max-entries": {}, "dir-ttl": {}, "direct-mount-strict": {}, "disk-read-cache-free-ratio": {},
+	"disk-read-cache-size-mb": {}, "durability": {}, "enabled": {}, "endpoint": {},
+	"entries": {}, "entry-ttl": {}, "env": {}, "exclude": {},
+	"external-id": {}, "f": {}, "fast": {}, "file": {},
+	"flat": {}, "flush-debounce": {}, "follow": {}, "force": {},
+	"force-path-style": {}, "foreground": {}, "format": {}, "from": {},
+	"from-file": {}, "fuse-sync-read": {}, "gvisor-compat": {}, "h": {},
+	"health-failures": {}, "health-interval": {}, "health-timeout": {}, "help": {},
+	"hydrate": {}, "id": {}, "idempotency-key": {}, "include": {},
+	"include-quota": {}, "install": {}, "jobs": {}, "json": {},
+	"json-array": {}, "k": {}, "kind": {}, "l": {},
+	"label": {}, "layer": {}, "legacy-dir-stat-fallback": {}, "length": {},
+	"limit": {}, "local-only": {}, "local-root": {}, "local-root-meta": {},
+	"log": {}, "long": {}, "lookup-retry-count": {}, "lookup-retry-timeout": {},
+	"m": {}, "manifest-url": {}, "max-file-count": {}, "max-file-size": {},
+	"max-media-llm-files": {}, "max-restarts": {}, "max-session-ttl": {}, "max-storage-size": {},
+	"max-video-llm-files": {}, "media-type": {}, "meta": {}, "mode": {},
+	"model": {}, "mount": {}, "mount-kind": {}, "mountpoint": {},
+	"name": {}, "namespace-id": {}, "newer": {}, "no-auto-pack": {},
+	"no-auto-unpack": {}, "no-force-path-style": {}, "no-pager": {}, "no-replace": {},
+	"no-supervise": {}, "o": {}, "offset": {}, "older": {},
+	"output": {}, "pack": {}, "pack-path": {}, "pack-paths-json": {},
+	"page": {}, "page-size": {}, "parallel-read-block-size-mb": {}, "parallel-read-concurrency": {},
+	"perf-addr": {}, "perf-cpu-duration": {}, "perf-cpu-interval": {}, "perf-dir": {},
+	"perf-heap-interval": {}, "perf-interval": {}, "perf-max-profile-files": {}, "perf-max-sample-files": {},
+	"perf-max-samples": {}, "perm": {}, "plain": {}, "pool-size": {},
+	"prefix": {}, "print": {}, "profile": {}, "prompt": {},
+	"protocol": {}, "q": {}, "query": {}, "r": {},
+	"read-cache-max-file-mb": {}, "read-cache-ttl": {}, "read-concurrency": {}, "read-only": {},
+	"readdir-prefetch": {}, "readdir-prefetch-max-bytes": {}, "readdir-prefetch-max-file-bytes": {}, "readdir-prefetch-max-files": {},
+	"readdir-prefetch-timeout": {}, "recursive": {}, "region": {}, "region-code": {},
+	"remote-only": {}, "remote-root": {}, "reset": {}, "restart": {},
+	"restart-backoff-max": {}, "restart-window": {}, "resume": {}, "reveal": {},
+	"role-arn": {}, "s": {}, "sanitized-args-json": {}, "scheme": {},
+	"scoped": {}, "secret": {}, "secret-access-key": {}, "server": {},
+	"since": {}, "size": {}, "source": {}, "status": {},
+	"stdout": {}, "stop-timeout": {}, "sts-endpoint": {}, "subject": {},
+	"supervise-foreground": {}, "supervised": {}, "t": {}, "tag": {},
+	"tenant-id": {}, "tidbcloud-private-key": {}, "tidbcloud-public-key": {}, "tidbcloud-spending-limit": {},
+	"timeout": {}, "title": {}, "token-only": {}, "tree": {},
+	"trust-process-local-events": {}, "ttl": {}, "type": {}, "unpack": {},
+	"until": {}, "upload-concurrency": {}, "v": {}, "version": {},
+	"wait": {}, "write-cache-free-ratio": {}, "write-cache-size-mb": {}, "writeback-batch-max-bytes": {},
+	"writeback-batch-max-files": {}, "writeback-batch-window": {}, "y": {}, "yes": {},
+}

--- a/cmd/drive9/telemetry_test.go
+++ b/cmd/drive9/telemetry_test.go
@@ -52,6 +52,12 @@ func TestResolveTelemetryCommandEligibility(t *testing.T) {
 		{name: "value that looks like the version command", args: []string{"fs", "find", "-name", "version", ":/"}, wantEligible: true, wantPath: "drive9 fs find", wantFlags: "name"},
 		{name: "value that looks like help", args: []string{"fs", "grep", "help", ":/"}, wantEligible: true, wantPath: "drive9 fs grep"},
 		{name: "context named version", args: []string{"ctx", "use", "version"}, wantEligible: true, wantPath: "drive9 ctx use"},
+		// admin leaf parsers treat a bare "help" operand as a help request.
+		{name: "admin leaf help operand", args: []string{"admin", "tenant", "create", "help"}},
+		{name: "admin nested leaf help operand", args: []string{"admin", "tenant", "pool", "create", "help"}},
+		{name: "admin object backend help operand", args: []string{"admin", "object-backend", "add", "help"}},
+		{name: "admin help consumed as a flag value", args: []string{"admin", "tenant", "create", "--server", "help"}, wantEligible: true, wantPath: "drive9 admin tenant create", wantFlags: "server"},
+		{name: "admin normal invocation", args: []string{"admin", "tenant", "create", "--json"}, wantEligible: true, wantPath: "drive9 admin tenant create", wantFlags: "json"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -140,6 +146,87 @@ func TestTelemetryFlagNamesNeverRecordFlagValues(t *testing.T) {
 			got := strings.Join(telemetryFlagNames(test.args), ",")
 			if got != test.want {
 				t.Fatalf("flag names = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWithCLITelemetryReportsUnknownPlacementForContextScopedCommands(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		args         []string
+		wantProvider string
+		wantRegion   string
+		wantSource   string
+	}{
+		{
+			name:         "active context",
+			args:         []string{"fs", "cat", ":/file"},
+			wantProvider: "aws",
+			wantRegion:   "aws-ap-southeast-1",
+			wantSource:   "default",
+		},
+		{
+			name:       "named context",
+			args:       []string{"fs", "cat", "prod:/file"},
+			wantSource: "unknown",
+		},
+		{
+			name:         "object store location keeps the active context",
+			args:         []string{"fs", "cat", "s3://bucket/key"},
+			wantProvider: "aws",
+			wantRegion:   "aws-ap-southeast-1",
+			wantSource:   "default",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("DRIVE9_TELEMETRY", "on")
+			t.Setenv("DRIVE9_ALLOW_TEST_ENDPOINTS", "1")
+			t.Setenv(cli.EnvAPIKey, "")
+			t.Setenv(cli.EnvVaultToken, "")
+			writeConfigFile(t, home, `{"current_context":"dev","contexts":{"dev":{"type":"owner","api_key":"k","server":"https://s","cloud_provider":"aws","region":"aws-ap-southeast-1"}}}`)
+
+			requests := make(chan []byte, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				body, _ := io.ReadAll(request.Body)
+				requests <- body
+				writer.WriteHeader(http.StatusAccepted)
+			}))
+			defer server.Close()
+			t.Setenv("DRIVE9_TEST_TELEMETRY_ENDPOINT", server.URL+"/v1/telemetry/batch")
+
+			origVersion, origSource := buildinfo.Version, buildinfo.InstallSource
+			t.Cleanup(func() { buildinfo.Version, buildinfo.InstallSource = origVersion, origSource })
+			buildinfo.Version = "0.2.0"
+			buildinfo.InstallSource = "local"
+
+			origExit, origStop := exitFunc, cpuProfileStop
+			t.Cleanup(func() { exitFunc, cpuProfileStop = origExit, origStop })
+			cpuProfileStop = func() {}
+			exitFunc = func(int) {}
+
+			withCLITelemetry(test.args, func() {})
+
+			var payload struct {
+				Events []struct {
+					CloudProvider string `json:"cloud_provider"`
+					RegionCode    string `json:"region_code"`
+					ProfileSource string `json:"profile_source"`
+				} `json:"events"`
+			}
+			select {
+			case body := <-requests:
+				if err := json.Unmarshal(body, &payload); err != nil {
+					t.Fatal(err)
+				}
+			default:
+				t.Fatal("no telemetry event was sent")
+			}
+			event := payload.Events[0]
+			if event.CloudProvider != test.wantProvider || event.RegionCode != test.wantRegion || event.ProfileSource != test.wantSource {
+				t.Fatalf("placement = %q/%q/%q, want %q/%q/%q", event.CloudProvider, event.RegionCode, event.ProfileSource, test.wantProvider, test.wantRegion, test.wantSource)
 			}
 		})
 	}

--- a/cmd/drive9/telemetry_test.go
+++ b/cmd/drive9/telemetry_test.go
@@ -122,6 +122,18 @@ func TestTelemetryFlagNamesNeverRecordFlagValues(t *testing.T) {
 			args: []string{"-l", "--", "--secret"},
 			want: "l",
 		},
+		{
+			// A dash-prefixed token that is not a flag this CLI defines is user
+			// input — here a pattern the command would reject — never a name.
+			name: "unknown flag-shaped token is dropped",
+			args: []string{"-my-private-pattern"},
+			want: "",
+		},
+		{
+			name: "mistyped flag name is dropped",
+			args: []string{"--api-key-secret123"},
+			want: "",
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/drive9/telemetry_test.go
+++ b/cmd/drive9/telemetry_test.go
@@ -1,0 +1,405 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mem9-ai/drive9/cmd/drive9/cli"
+	"github.com/mem9-ai/drive9/pkg/buildinfo"
+	"github.com/mem9-ai/drive9/pkg/telemetry"
+)
+
+func TestResolveTelemetryCommandEligibility(t *testing.T) {
+	tests := []struct {
+		name         string
+		args         []string
+		wantEligible bool
+		wantPath     string
+		wantFlags    string
+	}{
+		{name: "commandless", args: nil},
+		{name: "help flag", args: []string{"--help"}},
+		{name: "help command", args: []string{"help"}},
+		{name: "version", args: []string{"--version"}},
+		{name: "update", args: []string{"update", "--check"}},
+		{name: "unknown command", args: []string{"nope"}},
+		{name: "unknown subcommand", args: []string{"fs", "nope"}},
+		{name: "fs parent only", args: []string{"fs"}},
+		{name: "subcommand help", args: []string{"fs", "ls", "--help"}},
+		{name: "internal mount supervise", args: []string{"mount", "supervise", "--ready-file", "x"}},
+		{name: "internal supervised worker", args: []string{"mount", "--foreground", "--supervised", ":/", "/mnt"}},
+		{name: "internal supervise foreground", args: []string{"mount", "--supervise-foreground", ":/", "/mnt"}},
+		{name: "fs ls", args: []string{"fs", "ls", "-l", ":/"}, wantEligible: true, wantPath: "drive9 fs ls", wantFlags: "l"},
+		{name: "fs cat flags without values", args: []string{"fs", "cat", "--json", ":/secret/path"}, wantEligible: true, wantPath: "drive9 fs cat", wantFlags: "json"},
+		{name: "ctx default show", args: []string{"ctx"}, wantEligible: true, wantPath: "drive9 ctx show"},
+		{name: "ctx list alias", args: []string{"ctx", "list", "--json"}, wantEligible: true, wantPath: "drive9 ctx ls", wantFlags: "json"},
+		{name: "fs layer create", args: []string{"fs", "layer", "create", "--json", "base"}, wantEligible: true, wantPath: "drive9 fs layer create", wantFlags: "json"},
+		{name: "fs layer ls alias", args: []string{"fs", "layer", "ls"}, wantEligible: true, wantPath: "drive9 fs layer list"},
+		{name: "mount leaf with path", args: []string{"mount", "--mode=fuse", ":/", "./mnt"}, wantEligible: true, wantPath: "drive9 mount", wantFlags: "mode"},
+		{name: "mount vault", args: []string{"mount", "vault", "./mnt"}, wantEligible: true, wantPath: "drive9 mount vault"},
+		{name: "git worktree add", args: []string{"git", "worktree", "add", "--fast", "a", "b"}, wantEligible: true, wantPath: "drive9 git worktree add", wantFlags: "fast"},
+		{name: "admin tenant pool create flattened", args: []string{"admin", "tenant", "pool", "create", "--pool-size", "2"}, wantEligible: true, wantPath: "drive9 admin tenant pool-create", wantFlags: "pool-size"},
+		{name: "stop at double dash", args: []string{"vault", "with", "/n/vault/x", "--", "echo", "--secret"}, wantEligible: true, wantPath: "drive9 vault with"},
+		// "version" and "help" are only special in command position: a value or
+		// a path that happens to spell them must still be reported.
+		{name: "value that looks like the version command", args: []string{"fs", "find", "-name", "version", ":/"}, wantEligible: true, wantPath: "drive9 fs find", wantFlags: "name"},
+		{name: "value that looks like help", args: []string{"fs", "grep", "help", ":/"}, wantEligible: true, wantPath: "drive9 fs grep"},
+		{name: "context named version", args: []string{"ctx", "use", "version"}, wantEligible: true, wantPath: "drive9 ctx use"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := resolveTelemetryCommand(test.args)
+			if got.eligible != test.wantEligible {
+				t.Fatalf("eligible = %t, want %t path=%q", got.eligible, test.wantEligible, got.commandPath)
+			}
+			if !test.wantEligible {
+				if got.commandPath != "" {
+					t.Fatalf("ineligible command path = %q", got.commandPath)
+				}
+				return
+			}
+			if got.commandPath != test.wantPath {
+				t.Fatalf("command path = %q, want %q", got.commandPath, test.wantPath)
+			}
+			if test.wantFlags != "" {
+				gotFlags := strings.Join(telemetryFlagNames(got.flagArgs), ",")
+				if gotFlags != test.wantFlags {
+					t.Fatalf("flag names = %q, want %q", gotFlags, test.wantFlags)
+				}
+			}
+			if strings.Contains(got.commandPath, "/secret/path") {
+				t.Fatalf("command path leaked user input: %q", got.commandPath)
+			}
+		})
+	}
+}
+
+func TestTelemetryFlagNamesNeverRecordFlagValues(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "value that starts with a dash",
+			args: []string{"--subject", "-secret-project"},
+			want: "subject",
+		},
+		{
+			name: "value that starts with a double dash",
+			args: []string{"--description", "--private-note"},
+			want: "description",
+		},
+		{
+			name: "value with inline equals",
+			args: []string{"--manifest-url=-internal-host"},
+			want: "manifest-url",
+		},
+		{
+			name: "positional arguments are never flags",
+			args: []string{"-l", ":/secret", "./mnt"},
+			want: "l",
+		},
+		{
+			name: "flags after an inline value still count",
+			args: []string{"--json=true", "--long"},
+			want: "json,long",
+		},
+		{
+			name: "flags separated by values still count",
+			args: []string{"-name", "report", "-tag", "k=v"},
+			want: "name,tag",
+		},
+		{
+			name: "everything after a terminator is ignored",
+			args: []string{"-l", "--", "--secret"},
+			want: "l",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := strings.Join(telemetryFlagNames(test.args), ",")
+			if got != test.want {
+				t.Fatalf("flag names = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
+func TestWithCLITelemetrySendsAllowlistedEventAndDoesNotChangeExit(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DRIVE9_TELEMETRY", "on")
+	t.Setenv("DRIVE9_ALLOW_TEST_ENDPOINTS", "1")
+	t.Setenv("CI", "")
+	t.Setenv("GITHUB_ACTIONS", "")
+
+	origVersion := buildinfo.Version
+	origSource := buildinfo.InstallSource
+	origEndpoint := buildinfo.TelemetryEndpoint
+	t.Cleanup(func() {
+		buildinfo.Version = origVersion
+		buildinfo.InstallSource = origSource
+		buildinfo.TelemetryEndpoint = origEndpoint
+	})
+	buildinfo.Version = "0.2.0"
+	buildinfo.InstallSource = "local"
+
+	requests := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost || request.URL.Path != "/v1/telemetry/batch" {
+			t.Errorf("unexpected request %s %s", request.Method, request.URL.Path)
+		}
+		body, _ := io.ReadAll(request.Body)
+		requests <- body
+		writer.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+	t.Setenv("DRIVE9_TEST_TELEMETRY_ENDPOINT", server.URL+"/v1/telemetry/batch")
+
+	origExit := exitFunc
+	origStop := cpuProfileStop
+	t.Cleanup(func() {
+		exitFunc = origExit
+		cpuProfileStop = origStop
+	})
+	cpuProfileStop = func() {}
+	var exitCodes []int
+	exitFunc = func(code int) { exitCodes = append(exitCodes, code) }
+
+	withCLITelemetry([]string{"fs", "ls", "-l", ":/secret"}, func() {
+		exitWithCode(2)
+	})
+
+	if len(exitCodes) != 1 || exitCodes[0] != 2 {
+		t.Fatalf("exit codes = %v, want [2]", exitCodes)
+	}
+	select {
+	case body := <-requests:
+		if strings.Contains(string(body), ":/secret") {
+			t.Fatalf("payload leaked path: %s", body)
+		}
+		var payload struct {
+			Events []struct {
+				CommandPath string   `json:"command_path"`
+				FlagNames   []string `json:"flag_names"`
+				ExitCode    int      `json:"exit_code"`
+				EventName   string   `json:"event_name"`
+			} `json:"events"`
+		}
+		if err := json.Unmarshal(body, &payload); err != nil {
+			t.Fatal(err)
+		}
+		if len(payload.Events) != 1 || payload.Events[0].CommandPath != "drive9 fs ls" || payload.Events[0].ExitCode != 2 || payload.Events[0].EventName != "drive9.command.finished" {
+			t.Fatalf("unexpected payload: %s", body)
+		}
+		if strings.Join(payload.Events[0].FlagNames, ",") != "l" {
+			t.Fatalf("flag names = %#v", payload.Events[0].FlagNames)
+		}
+	default:
+		t.Fatal("eligible command did not send telemetry")
+	}
+
+	idPath := filepath.Join(home, ".drive9", ".telemetry-installation-id")
+	data, err := os.ReadFile(idPath)
+	if err != nil {
+		t.Fatalf("read installation ID: %v", err)
+	}
+	if !strings.HasPrefix(strings.TrimSpace(string(data)), "drive9_") {
+		t.Fatalf("installation ID = %q", data)
+	}
+}
+
+func TestWithCLITelemetryHonorsConfigOptInAndEnvironmentOverride(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		config     string
+		env        string
+		wantEvents int
+	}{
+		{name: "config opt in", config: `{"telemetry":{"enabled":true}}`, wantEvents: 1},
+		{name: "config opt out", config: `{"telemetry":{"enabled":false}}`, wantEvents: 0},
+		{name: "no preference", config: `{"contexts":{}}`, wantEvents: 0},
+		{name: "malformed config fails closed", config: `{"telemetry":`, wantEvents: 0},
+		{name: "environment overrides config opt out", config: `{"telemetry":{"enabled":false}}`, env: "on", wantEvents: 1},
+		{name: "environment overrides config opt in", config: `{"telemetry":{"enabled":true}}`, env: "off", wantEvents: 0},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("DRIVE9_ALLOW_TEST_ENDPOINTS", "1")
+			if test.env == "" {
+				t.Setenv("DRIVE9_TELEMETRY", "")
+			} else {
+				t.Setenv("DRIVE9_TELEMETRY", test.env)
+			}
+			writeConfigFile(t, home, test.config)
+
+			requests := make(chan []byte, 4)
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				body, _ := io.ReadAll(request.Body)
+				requests <- body
+				writer.WriteHeader(http.StatusAccepted)
+			}))
+			defer server.Close()
+			t.Setenv("DRIVE9_TEST_TELEMETRY_ENDPOINT", server.URL+"/v1/telemetry/batch")
+
+			origVersion := buildinfo.Version
+			origSource := buildinfo.InstallSource
+			t.Cleanup(func() {
+				buildinfo.Version = origVersion
+				buildinfo.InstallSource = origSource
+			})
+			buildinfo.Version = "0.2.0"
+			buildinfo.InstallSource = "local"
+
+			origExit := exitFunc
+			origStop := cpuProfileStop
+			t.Cleanup(func() {
+				exitFunc = origExit
+				cpuProfileStop = origStop
+			})
+			cpuProfileStop = func() {}
+			exitFunc = func(int) {}
+
+			withCLITelemetry([]string{"region", "list", "--json"}, func() {})
+
+			got := 0
+			for {
+				select {
+				case <-requests:
+					got++
+					continue
+				default:
+				}
+				break
+			}
+			if got != test.wantEvents {
+				t.Fatalf("events = %d, want %d", got, test.wantEvents)
+			}
+		})
+	}
+}
+
+func TestWithCLITelemetryExcludedCommandsDoNotReadState(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DRIVE9_TELEMETRY", "on")
+	t.Setenv("DRIVE9_ALLOW_TEST_ENDPOINTS", "1")
+	t.Setenv("DRIVE9_TEST_TELEMETRY_ENDPOINT", "https://example.invalid/v1/telemetry/batch")
+
+	config := `{"telemetry":` // deliberately invalid: reading it must not be attempted
+	writeConfigFile(t, home, config)
+
+	origExit := exitFunc
+	origStop := cpuProfileStop
+	t.Cleanup(func() {
+		exitFunc = origExit
+		cpuProfileStop = origStop
+	})
+	cpuProfileStop = func() {}
+	exitFunc = func(int) {}
+
+	for _, args := range [][]string{
+		{"--help"},
+		{"update", "--check"},
+		{"version"},
+		{"fs", "ls", "--help"},
+		{"mount", "supervise", "--mountpoint", "/mnt"},
+		{"mount", "--supervised", ":/", "/mnt"},
+	} {
+		withCLITelemetry(args, func() {})
+		got, err := os.ReadFile(filepath.Join(home, ".drive9", "config"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if string(got) != config {
+			t.Fatalf("excluded %v rewrote config", args)
+		}
+		if _, err := os.Stat(telemetry.InstallationIDPath(home)); !os.IsNotExist(err) {
+			t.Fatalf("excluded %v created identity", args)
+		}
+	}
+}
+
+func TestWithCLITelemetryDeliveryFailureDoesNotChangeResult(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("DRIVE9_TELEMETRY", "on")
+	t.Setenv("DRIVE9_ALLOW_TEST_ENDPOINTS", "1")
+	t.Setenv("DRIVE9_TEST_TELEMETRY_ENDPOINT", "http://127.0.0.1:1/v1/telemetry/batch")
+
+	origVersion := buildinfo.Version
+	origSource := buildinfo.InstallSource
+	t.Cleanup(func() {
+		buildinfo.Version = origVersion
+		buildinfo.InstallSource = origSource
+	})
+	buildinfo.Version = "0.2.0"
+	buildinfo.InstallSource = "local"
+
+	origExit := exitFunc
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+	origStop := cpuProfileStop
+	t.Cleanup(func() {
+		exitFunc = origExit
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+		cpuProfileStop = origStop
+	})
+	cpuProfileStop = func() {}
+	var exitCodes []int
+	exitFunc = func(code int) { exitCodes = append(exitCodes, code) }
+
+	withCLITelemetry([]string{"region", "list", "--json"}, func() {})
+	if len(exitCodes) != 0 {
+		t.Fatalf("delivery failure changed exit: %v", exitCodes)
+	}
+}
+
+// TestCommandHandlersExitThroughTheHook guards the invariant that command
+// handlers never call os.Exit directly: usage failures must stay observable by
+// the telemetry hook, which is what makes exit codes reportable at all.
+func TestCommandHandlersExitThroughTheHook(t *testing.T) {
+	t.Run("flag parse failure carries exit code 2", func(t *testing.T) {
+		err := cli.MountCmd([]string{"--not-a-flag"})
+		var usage cli.UsageError
+		if !errors.As(err, &usage) {
+			t.Fatalf("error = %v, want a cli.UsageError", err)
+		}
+		if usage.ExitCode() != 2 || !usage.Reported() {
+			t.Fatalf("usage error = %+v, want exit code 2 and already reported", usage)
+		}
+	})
+
+	t.Run("missing argument exits through the installed hook", func(t *testing.T) {
+		var recorded []int
+		restore := cli.SetExitHook(func(code int) { recorded = append(recorded, code) })
+		t.Cleanup(restore)
+
+		_ = cli.VaultMountCmd(nil)
+
+		if len(recorded) != 1 || recorded[0] != 2 {
+			t.Fatalf("exit codes = %v, want [2]", recorded)
+		}
+	})
+}
+
+func writeConfigFile(t *testing.T, home, content string) {
+	t.Helper()
+	dir := filepath.Join(home, ".drive9")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config"), []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/buildinfo/buildinfo.go
+++ b/pkg/buildinfo/buildinfo.go
@@ -9,10 +9,12 @@ import (
 )
 
 var (
-	Version   = "dev"
-	GitHash   = "unknown"
-	GitBranch = "unknown"
-	BuildTime = "unknown"
+	Version           = "dev"
+	GitHash           = "unknown"
+	GitBranch         = "unknown"
+	BuildTime         = "unknown"
+	InstallSource     = ""
+	TelemetryEndpoint = ""
 )
 
 type Info struct {

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -1,0 +1,522 @@
+// Package telemetry collects privacy-preserving CLI command completion events.
+//
+// Telemetry is opt-in: it stays disabled unless the user enables it with
+// DRIVE9_TELEMETRY=on or the "telemetry" section of the CLI config file
+// (~/.drive9/config). Events are posted to the product-owned ingestion service
+// shared with ti-cli and stored in the shared telemetry TiDB cluster. The
+// package never captures flag values, credentials, paths, file contents,
+// command output, or resource IDs.
+package telemetry
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+const (
+	EnvironmentVariable  = "DRIVE9_TELEMETRY"
+	dirName              = ".drive9"
+	installationIDFile   = ".telemetry-installation-id"
+	eventName            = "drive9.command.finished"
+	schemaVersion        = 2
+	installationIDPrefix = "drive9_"
+	maxFlagNames         = 64
+	maxCommandPathBytes  = 128
+	// deliveryTimeout bounds the whole best-effort POST. Delivery happens on the
+	// command's exit path, so this is also the worst-case latency added to an
+	// opted-in command: dropping one event is preferable to a visibly slow CLI.
+	deliveryTimeout = 1 * time.Second
+)
+
+// These patterns mirror the ingestion service contract. A payload that fails
+// any of them is rejected as a whole, so the client drops such an event (or
+// field) locally instead of spending a request on a guaranteed rejection.
+var (
+	installationIDPattern = regexp.MustCompile(`^drive9_[A-Za-z0-9_-]{22}$`)
+	eventIDPattern        = regexp.MustCompile(`^[A-Za-z0-9_-]{16,64}$`)
+	commandPathPattern    = regexp.MustCompile(`^drive9(?: [a-z][a-z0-9-]{0,63}){0,3}$`)
+	flagNamePattern       = regexp.MustCompile(`^[a-z][a-z0-9-]{0,63}$`)
+	cliVersionPattern     = regexp.MustCompile(`^[A-Za-z0-9][A-Za-z0-9.+_-]{0,63}$`)
+)
+
+var allowedRegions = map[string]struct{}{
+	"":                        {},
+	"unknown":                 {},
+	"aws-us-east-1":           {},
+	"aws-us-west-2":           {},
+	"aws-eu-central-1":        {},
+	"aws-ap-northeast-1":      {},
+	"aws-ap-southeast-1":      {},
+	"ali-ap-southeast-1":      {},
+	"alicloud-ap-southeast-1": {},
+}
+
+// allowedOperatingSystems and allowedArchitectures mirror the ingestion
+// service allowlists. A build outside them sends no events.
+var allowedOperatingSystems = map[string]struct{}{
+	"aix": {}, "android": {}, "darwin": {}, "dragonfly": {}, "freebsd": {},
+	"illumos": {}, "ios": {}, "js": {}, "linux": {}, "netbsd": {},
+	"openbsd": {}, "plan9": {}, "solaris": {}, "wasip1": {}, "windows": {},
+}
+
+var allowedArchitectures = map[string]struct{}{
+	"386": {}, "amd64": {}, "arm": {}, "arm64": {}, "loong64": {},
+	"mips": {}, "mips64": {}, "mips64le": {}, "mipsle": {}, "ppc64": {},
+	"ppc64le": {}, "riscv64": {}, "s390x": {}, "wasm": {},
+}
+
+// Config controls whether a process starts a telemetry session.
+type Config struct {
+	Eligible      bool
+	HomeDir       string
+	Endpoint      string
+	Version       string
+	OS            string
+	Arch          string
+	InstallSource string
+	Environment   map[string]string
+	// Preference reports the persisted user opt-in (for the CLI: the
+	// "telemetry" section of ~/.drive9/config). recorded is false when the user
+	// never expressed a preference, and also when the preference cannot be read
+	// or parsed: an unreadable preference must never enable telemetry.
+	Preference  func() (enabled bool, recorded bool)
+	Client      *http.Client
+	Debug       bool
+	DebugWriter io.Writer
+	Now         func() time.Time
+}
+
+// EventInput is the allowlisted completion payload for one command invocation.
+type EventInput struct {
+	CommandPath   string
+	FlagNames     []string
+	ExitCode      int
+	Duration      time.Duration
+	CloudProvider string
+	RegionCode    string
+	ProfileSource string
+}
+
+// Session is a started telemetry identity used to send one completion event.
+type Session struct {
+	installationID string
+	endpoint       string
+	version        string
+	os             string
+	arch           string
+	installSource  string
+	client         *http.Client
+	debug          bool
+	debugWriter    io.Writer
+	now            func() time.Time
+}
+
+type batchRequest struct {
+	SchemaVersion int         `json:"schema_version"`
+	SentAt        string      `json:"sent_at"`
+	Events        []wireEvent `json:"events"`
+}
+
+type wireEvent struct {
+	EventID                 string   `json:"event_id"`
+	EventName               string   `json:"event_name"`
+	OccurredAt              string   `json:"occurred_at"`
+	AnonymousInstallationID string   `json:"anonymous_installation_id"`
+	CommandPath             string   `json:"command_path"`
+	FlagNames               []string `json:"flag_names"`
+	ExitCode                int      `json:"exit_code"`
+	DurationMS              int64    `json:"duration_ms"`
+	CloudProvider           string   `json:"cloud_provider"`
+	RegionCode              string   `json:"region_code"`
+	CLIVersion              string   `json:"cli_version"`
+	OS                      string   `json:"os"`
+	Arch                    string   `json:"arch"`
+	InstallSource           string   `json:"install_source"`
+	ProfileSource           string   `json:"profile_source"`
+}
+
+// InstallationIDPath is the machine-generated pseudonymous identity file.
+func InstallationIDPath(homeDir string) string {
+	return filepath.Join(homeDir, dirName, installationIDFile)
+}
+
+// Start resolves enablement and loads or creates the installation ID.
+// It returns nil when telemetry must stay disabled.
+func Start(cfg Config) *Session {
+	if !cfg.Eligible || strings.TrimSpace(cfg.Endpoint) == "" {
+		return nil
+	}
+	if !resolveEnabled(cfg) {
+		return nil
+	}
+	homeDir := strings.TrimSpace(cfg.HomeDir)
+	if homeDir == "" {
+		var err error
+		homeDir, err = os.UserHomeDir()
+		if err != nil {
+			debug(cfg.Debug, cfg.DebugWriter, "telemetry disabled because its local identity is unavailable")
+			return nil
+		}
+	}
+	id, err := loadOrCreateInstallationID(homeDir)
+	if err != nil {
+		debug(cfg.Debug, cfg.DebugWriter, "telemetry disabled because its local identity is unavailable")
+		return nil
+	}
+	client := cfg.Client
+	if client == nil {
+		client = &http.Client{
+			Timeout: deliveryTimeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Session{
+		installationID: id,
+		endpoint:       cfg.Endpoint,
+		version:        cfg.Version,
+		os:             cfg.OS,
+		arch:           cfg.Arch,
+		installSource:  cfg.InstallSource,
+		client:         client,
+		debug:          cfg.Debug,
+		debugWriter:    cfg.DebugWriter,
+		now:            now,
+	}
+}
+
+// Finish posts one allowlisted completion event. Delivery is best-effort and
+// must not change command output or exit status.
+func (s *Session) Finish(input EventInput) {
+	if s == nil {
+		return
+	}
+	commandPath := input.CommandPath
+	if commandPath == "" || len(commandPath) > maxCommandPathBytes || !commandPathPattern.MatchString(commandPath) {
+		debug(s.debug, s.debugWriter, "telemetry event was dropped because its command path is unsupported")
+		return
+	}
+	osName := runtimeValue(s.os, runtime.GOOS)
+	if _, ok := allowedOperatingSystems[osName]; !ok {
+		debug(s.debug, s.debugWriter, "telemetry event was dropped because its operating system is unsupported")
+		return
+	}
+	archName := runtimeValue(s.arch, runtime.GOARCH)
+	if _, ok := allowedArchitectures[archName]; !ok {
+		debug(s.debug, s.debugWriter, "telemetry event was dropped because its architecture is unsupported")
+		return
+	}
+	now := s.now().UTC()
+	eventID, err := randomIdentifier("")
+	if err != nil || !eventIDPattern.MatchString(eventID) {
+		debug(s.debug, s.debugWriter, "telemetry event was dropped before delivery")
+		return
+	}
+	durationMS := input.Duration.Milliseconds()
+	if durationMS < 0 {
+		durationMS = 0
+	}
+	if durationMS > 86_400_000 {
+		durationMS = 86_400_000
+	}
+	exitCode := input.ExitCode
+	if exitCode < 0 {
+		exitCode = 0
+	}
+	if exitCode > 255 {
+		exitCode = 255
+	}
+	event := wireEvent{
+		EventID:                 eventID,
+		EventName:               eventName,
+		OccurredAt:              now.Format(time.RFC3339Nano),
+		AnonymousInstallationID: s.installationID,
+		CommandPath:             commandPath,
+		FlagNames:               normalizedFlagNames(input.FlagNames),
+		ExitCode:                exitCode,
+		DurationMS:              durationMS,
+		CloudProvider:           normalizedProvider(input.CloudProvider),
+		RegionCode:              normalizedRegion(input.CloudProvider, input.RegionCode),
+		CLIVersion:              normalizedVersion(s.version),
+		OS:                      osName,
+		Arch:                    archName,
+		InstallSource:           normalizedInstallSource(s.installSource),
+		ProfileSource:           normalizedProfileSource(input.ProfileSource),
+	}
+	payload, err := json.Marshal(batchRequest{
+		SchemaVersion: schemaVersion,
+		SentAt:        now.Format(time.RFC3339Nano),
+		Events:        []wireEvent{event},
+	})
+	if err != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), deliveryTimeout)
+	defer cancel()
+	request, err := http.NewRequestWithContext(ctx, http.MethodPost, s.endpoint, bytes.NewReader(payload))
+	if err != nil {
+		debug(s.debug, s.debugWriter, "telemetry event was dropped before delivery")
+		return
+	}
+	request.Header.Set("Content-Type", "application/json")
+	request.Header.Set("User-Agent", "drive9/"+normalizedVersion(s.version))
+	response, err := s.client.Do(request)
+	if err != nil {
+		debug(s.debug, s.debugWriter, "telemetry delivery failed; the command result was not affected")
+		return
+	}
+	_, _ = io.Copy(io.Discard, io.LimitReader(response.Body, 4096))
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusAccepted {
+		debug(s.debug, s.debugWriter, "telemetry delivery was rejected; the command result was not affected")
+	}
+}
+
+// normalizedFlagNames keeps only names the ingestion service accepts, so one
+// malformed entry cannot cost the whole event.
+func normalizedFlagNames(names []string) []string {
+	out := make([]string, 0, len(names))
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		if !flagNamePattern.MatchString(name) {
+			continue
+		}
+		if _, duplicate := seen[name]; duplicate {
+			continue
+		}
+		seen[name] = struct{}{}
+		out = append(out, name)
+		if len(out) == maxFlagNames {
+			break
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+func resolveEnabled(cfg Config) bool {
+	raw, exists := envValue(cfg.Environment, EnvironmentVariable)
+	if exists && strings.TrimSpace(raw) != "" {
+		enabled, valid := parseOverride(raw)
+		if !valid {
+			return false
+		}
+		return enabled
+	}
+	if cfg.Preference != nil {
+		if enabled, recorded := cfg.Preference(); recorded {
+			return enabled
+		}
+	}
+	// Disabled by default: no build, install source, or environment heuristic
+	// may enable telemetry on the user's behalf.
+	return false
+}
+
+// loadOrCreateInstallationID publishes a fresh pseudonymous identity when none
+// exists yet. Concurrent processes converge on the published value.
+func loadOrCreateInstallationID(homeDir string) (string, error) {
+	path := InstallationIDPath(homeDir)
+	id, exists, err := readInstallationID(path)
+	if err != nil || exists {
+		return id, err
+	}
+	id, err = randomIdentifier(installationIDPrefix)
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	temp, err := os.CreateTemp(dir, ".telemetry-installation-id.tmp-*")
+	if err != nil {
+		return "", err
+	}
+	tempPath := temp.Name()
+	defer func() { _ = os.Remove(tempPath) }()
+	if err := temp.Chmod(0o600); err != nil {
+		_ = temp.Close()
+		return "", err
+	}
+	if _, err := temp.WriteString(id + "\n"); err != nil {
+		_ = temp.Close()
+		return "", err
+	}
+	if err := temp.Sync(); err != nil {
+		_ = temp.Close()
+		return "", err
+	}
+	if err := temp.Close(); err != nil {
+		return "", err
+	}
+	// Link publishes without clobbering an identity another process just wrote.
+	// Rename is the fallback for filesystems without hard links (FAT/exFAT, some
+	// SMB/NFS home directories), where link fails with a non-ErrExist error.
+	if err := os.Link(tempPath, path); err != nil && !errors.Is(err, os.ErrExist) {
+		if renameErr := os.Rename(tempPath, path); renameErr != nil {
+			return "", err
+		}
+	}
+	// Read back instead of trusting the local value: the loser of a race must
+	// adopt the published identity, and a path that exists but yields nothing
+	// must fail closed rather than send an empty installation ID.
+	persisted, exists, err := readInstallationID(path)
+	if err != nil {
+		return "", err
+	}
+	if !exists {
+		return "", fmt.Errorf("telemetry installation ID could not be persisted")
+	}
+	return persisted, nil
+}
+
+func readInstallationID(path string) (string, bool, error) {
+	// Lstat, not Stat: a symlink at this path is not an identity we created.
+	info, err := os.Lstat(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", true, err
+	}
+	if !info.Mode().IsRegular() {
+		return "", true, fmt.Errorf("invalid telemetry installation ID file")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", true, err
+	}
+	id := strings.TrimSuffix(string(data), "\n")
+	if strings.Contains(id, "\n") || !installationIDPattern.MatchString(id) {
+		return "", true, fmt.Errorf("invalid telemetry installation ID")
+	}
+	return id, true, nil
+}
+
+func randomIdentifier(prefix string) (string, error) {
+	var value [16]byte
+	if _, err := rand.Read(value[:]); err != nil {
+		return "", err
+	}
+	return prefix + base64.RawURLEncoding.EncodeToString(value[:]), nil
+}
+
+func envValue(env map[string]string, key string) (string, bool) {
+	if env != nil {
+		value, ok := env[key]
+		return value, ok
+	}
+	return os.LookupEnv(key)
+}
+
+func parseOverride(value string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "on", "true", "yes", "1":
+		return true, true
+	case "off", "false", "no", "0":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func normalizedInstallSource(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "archive", "github-release":
+		return "github-release"
+	case "homebrew", "scoop", "source", "dev", "unknown":
+		return strings.ToLower(strings.TrimSpace(value))
+	case "local":
+		return "dev"
+	default:
+		return "unknown"
+	}
+}
+
+func normalizedProvider(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "aws":
+		return "aws"
+	case "alibaba_cloud", "alicloud", "alibaba", "ali":
+		return "alibaba_cloud"
+	case "":
+		return ""
+	default:
+		return "unknown"
+	}
+}
+
+func normalizedRegion(provider, value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if _, ok := allowedRegions[value]; ok {
+		return value
+	}
+	composed := value
+	switch normalizedProvider(provider) {
+	case "aws":
+		if !strings.HasPrefix(value, "aws-") {
+			composed = "aws-" + value
+		}
+	case "alibaba_cloud":
+		if !strings.HasPrefix(value, "ali-") && !strings.HasPrefix(value, "alicloud-") {
+			composed = "ali-" + value
+		}
+	}
+	if _, ok := allowedRegions[composed]; ok {
+		return composed
+	}
+	return "unknown"
+}
+
+func normalizedVersion(value string) string {
+	value = strings.TrimPrefix(strings.TrimSpace(value), "v")
+	if !cliVersionPattern.MatchString(value) {
+		return "unknown"
+	}
+	return value
+}
+
+func normalizedProfileSource(value string) string {
+	switch value {
+	case "default", "explicit", "env":
+		return value
+	default:
+		return "unknown"
+	}
+}
+
+func runtimeValue(value, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func debug(enabled bool, writer io.Writer, message string) {
+	if enabled && writer != nil {
+		_, _ = fmt.Fprintln(writer, "drive9 [DEBUG]: "+message)
+	}
+}

--- a/pkg/telemetry/telemetry.go
+++ b/pkg/telemetry/telemetry.go
@@ -370,11 +370,20 @@ func loadOrCreateInstallationID(homeDir string) (string, error) {
 		return "", err
 	}
 	// Link publishes without clobbering an identity another process just wrote.
-	// Rename is the fallback for filesystems without hard links (FAT/exFAT, some
-	// SMB/NFS home directories), where link fails with a non-ErrExist error.
 	if err := os.Link(tempPath, path); err != nil && !errors.Is(err, os.ErrExist) {
-		if renameErr := os.Rename(tempPath, path); renameErr != nil {
+		// Fallback for filesystems without hard links (FAT/exFAT, some SMB/NFS
+		// home directories). Claim the path exclusively first: renaming straight
+		// over it would let two concurrent processes replace each other's
+		// identity and then report events under different IDs. Replacing our own
+		// placeholder afterwards keeps the content publish atomic.
+		claimed, claimErr := claimInstallationIDPath(path)
+		if claimErr != nil {
 			return "", err
+		}
+		if claimed {
+			if renameErr := os.Rename(tempPath, path); renameErr != nil {
+				return "", renameErr
+			}
 		}
 	}
 	// Read back instead of trusting the local value: the loser of a race must
@@ -388,6 +397,23 @@ func loadOrCreateInstallationID(homeDir string) (string, error) {
 		return "", fmt.Errorf("telemetry installation ID could not be persisted")
 	}
 	return persisted, nil
+}
+
+// claimInstallationIDPath creates path only when nothing is there yet. It is
+// how an identity is published on filesystems without hard links: the loser of
+// a race leaves the winner's file untouched instead of replacing it.
+func claimInstallationIDPath(path string) (bool, error) {
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if errors.Is(err, os.ErrExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if err := file.Close(); err != nil {
+		return false, err
+	}
+	return true, nil
 }
 
 func readInstallationID(path string) (string, bool, error) {

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -1,0 +1,548 @@
+package telemetry
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestStartResolutionAndStateCreation(t *testing.T) {
+	enabled := true
+	disabled := false
+	tests := []struct {
+		name        string
+		version     string
+		env         map[string]string
+		preference  *bool
+		wantSession bool
+	}{
+		{name: "release default", version: "0.2.0", wantSession: false},
+		{name: "release default in CI", version: "0.2.0", env: map[string]string{"CI": "true"}, wantSession: false},
+		{name: "development default", version: "dev", wantSession: false},
+		{name: "recorded disable", version: "0.2.0", preference: &disabled, wantSession: false},
+		{name: "recorded enable", version: "0.2.0", preference: &enabled, wantSession: true},
+		{name: "recorded enable on development build", version: "dev", preference: &enabled, wantSession: true},
+		{name: "environment enable on release build", version: "0.2.0", env: map[string]string{EnvironmentVariable: "on"}, wantSession: true},
+		{name: "environment enable overrides development", version: "dev", env: map[string]string{EnvironmentVariable: "yes"}, wantSession: true},
+		{name: "environment enable overrides recorded disable", version: "0.2.0", env: map[string]string{EnvironmentVariable: "true"}, preference: &disabled, wantSession: true},
+		{name: "environment disable overrides recorded enable", version: "0.2.0", env: map[string]string{EnvironmentVariable: "no"}, preference: &enabled, wantSession: false},
+		{name: "empty environment value falls back to preference", version: "0.2.0", env: map[string]string{EnvironmentVariable: ""}, preference: &enabled, wantSession: true},
+		{name: "invalid environment fails closed", version: "0.2.0", env: map[string]string{EnvironmentVariable: "sometimes"}, preference: &enabled, wantSession: false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			environment := test.env
+			if environment == nil {
+				environment = map[string]string{}
+			}
+			session := Start(Config{
+				Eligible:      true,
+				HomeDir:       home,
+				Endpoint:      "https://telemetry.example.test/v1/telemetry/batch",
+				Version:       test.version,
+				InstallSource: "archive",
+				Environment:   environment,
+				Preference:    recordedPreference(test.preference),
+			})
+			if (session != nil) != test.wantSession {
+				t.Fatalf("session present = %t, want %t", session != nil, test.wantSession)
+			}
+			_, err := os.Stat(InstallationIDPath(home))
+			if test.wantSession && err != nil {
+				t.Fatalf("installation ID was not created: %v", err)
+			}
+			if !test.wantSession && !os.IsNotExist(err) {
+				t.Fatalf("disabled telemetry created installation ID: %v", err)
+			}
+		})
+	}
+}
+
+func TestStartShortCircuitsBeforeStateReads(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		eligible bool
+		endpoint string
+		env      map[string]string
+	}{
+		{name: "ineligible", endpoint: "https://telemetry.example.test", env: map[string]string{EnvironmentVariable: "on"}},
+		{name: "missing endpoint", eligible: true, env: map[string]string{EnvironmentVariable: "on"}},
+		{name: "explicit disable", eligible: true, endpoint: "https://telemetry.example.test", env: map[string]string{EnvironmentVariable: "off"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			before := "invalid-identity\n"
+			writeTestFile(t, InstallationIDPath(home), before, 0o600)
+			preferenceReads := 0
+			session := Start(Config{
+				Eligible:      test.eligible,
+				HomeDir:       home,
+				Endpoint:      test.endpoint,
+				Version:       "0.2.0",
+				InstallSource: "archive",
+				Environment:   test.env,
+				Preference: func() (bool, bool) {
+					preferenceReads++
+					return true, true
+				},
+			})
+			if session != nil {
+				t.Fatal("expected telemetry to stay disabled")
+			}
+			if preferenceReads != 0 {
+				t.Fatalf("preference was read %d times before enablement was settled", preferenceReads)
+			}
+			assertFileContent(t, InstallationIDPath(home), before)
+		})
+	}
+}
+
+func TestMissingPreferenceFailsClosed(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		preference func() (bool, bool)
+	}{
+		{name: "unrecorded", preference: func() (bool, bool) { return false, false }},
+		{name: "unreadable", preference: nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			home := t.TempDir()
+			session := Start(Config{
+				Eligible:      true,
+				HomeDir:       home,
+				Endpoint:      "https://telemetry.example.test",
+				Version:       "0.2.0",
+				InstallSource: "archive",
+				Environment:   map[string]string{},
+				Preference:    test.preference,
+			})
+			if session != nil {
+				t.Fatal("telemetry was enabled without a recorded opt-in")
+			}
+			if _, err := os.Stat(InstallationIDPath(home)); !os.IsNotExist(err) {
+				t.Fatalf("disabled telemetry created identity: %v", err)
+			}
+		})
+	}
+}
+
+func TestDefaultDisabledKeepsStateUntouched(t *testing.T) {
+	for _, installSource := range []string{"archive", "github-release", "homebrew", "scoop", "source", "local", "unknown", ""} {
+		t.Run("install_source="+installSource, func(t *testing.T) {
+			home := t.TempDir()
+			cfg := Config{Eligible: true, HomeDir: home, Endpoint: "https://telemetry.example.test", Version: "0.2.0", InstallSource: installSource, Environment: map[string]string{}}
+			if session := Start(cfg); session != nil {
+				t.Fatalf("install source %q enabled telemetry without opt-in", installSource)
+			}
+			if _, err := os.Stat(InstallationIDPath(home)); !os.IsNotExist(err) {
+				t.Fatalf("install source %q created identity: %v", installSource, err)
+			}
+		})
+	}
+}
+
+func TestOptInCreatesIdentityAndUserCanResetIt(t *testing.T) {
+	home := t.TempDir()
+	cfg := Config{Eligible: true, HomeDir: home, Endpoint: "https://telemetry.example.test", Version: "0.2.0", InstallSource: "github-release", Environment: map[string]string{EnvironmentVariable: "on"}}
+	first := Start(cfg)
+	if first == nil {
+		t.Fatal("environment opt-in should enable telemetry")
+	}
+	if err := os.Remove(InstallationIDPath(home)); err != nil {
+		t.Fatal(err)
+	}
+	second := Start(cfg)
+	if second == nil || second.installationID == first.installationID {
+		t.Fatalf("identity reset did not create a new ID: first=%q second=%v", first.installationID, second)
+	}
+}
+
+func TestInvalidEnvironmentOverrideFailsClosedWithRedactedDebug(t *testing.T) {
+	home := t.TempDir()
+	identity := "invalid-identity\n"
+	writeTestFile(t, InstallationIDPath(home), identity, 0o600)
+	var diagnostic strings.Builder
+	session := Start(Config{
+		Eligible:      true,
+		HomeDir:       home,
+		Endpoint:      "https://telemetry.example.test",
+		Version:       "0.2.0",
+		InstallSource: "archive",
+		Environment:   map[string]string{EnvironmentVariable: "secret-invalid-value"},
+		Preference:    func() (bool, bool) { return true, true },
+		Debug:         true,
+		DebugWriter:   &diagnostic,
+	})
+	if session != nil {
+		t.Fatal("invalid override should disable telemetry")
+	}
+	if diagnostic.Len() != 0 {
+		t.Fatalf("unexpected debug diagnostic %q", diagnostic.String())
+	}
+	assertFileContent(t, InstallationIDPath(home), identity)
+}
+
+func TestInstallationIDIsPrivateStableAndRaceSafe(t *testing.T) {
+	home := t.TempDir()
+	const workers = 32
+	ids := make(chan string, workers)
+	var wait sync.WaitGroup
+	for range workers {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			session := Start(Config{
+				Eligible:      true,
+				HomeDir:       home,
+				Endpoint:      "https://telemetry.example.test",
+				Version:       "0.2.0",
+				InstallSource: "archive",
+				Environment:   map[string]string{EnvironmentVariable: "on"},
+			})
+			if session == nil {
+				ids <- ""
+				return
+			}
+			ids <- session.installationID
+		}()
+	}
+	wait.Wait()
+	close(ids)
+	var expected string
+	for id := range ids {
+		if !installationIDPattern.MatchString(id) {
+			t.Fatalf("invalid installation ID %q", id)
+		}
+		if expected == "" {
+			expected = id
+		} else if id != expected {
+			t.Fatalf("concurrent initialization returned %q and %q", expected, id)
+		}
+	}
+	data, err := os.ReadFile(InstallationIDPath(home))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.TrimSpace(string(data)) != expected {
+		t.Fatalf("persisted ID = %q, want %q", data, expected)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(InstallationIDPath(home))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if info.Mode().Perm() != 0o600 {
+			t.Fatalf("installation ID mode = %o, want 0600", info.Mode().Perm())
+		}
+	}
+}
+
+func TestInstallationIDPathThatCannotBeReadFailsClosed(t *testing.T) {
+	t.Run("malformed", func(t *testing.T) {
+		home := t.TempDir()
+		before := "drive9_not-valid!\n"
+		writeTestFile(t, InstallationIDPath(home), before, 0o600)
+		if session := Start(enabledConfig(home)); session != nil {
+			t.Fatal("malformed identity should disable telemetry")
+		}
+		assertFileContent(t, InstallationIDPath(home), before)
+	})
+	t.Run("unreadable state", func(t *testing.T) {
+		home := t.TempDir()
+		if err := os.MkdirAll(InstallationIDPath(home), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if session := Start(enabledConfig(home)); session != nil {
+			t.Fatal("unreadable identity state should disable telemetry")
+		}
+		info, err := os.Stat(InstallationIDPath(home))
+		if err != nil || !info.IsDir() {
+			t.Fatalf("identity state was overwritten: info=%v err=%v", info, err)
+		}
+	})
+	t.Run("dangling symlink", func(t *testing.T) {
+		home := t.TempDir()
+		dir := filepath.Join(home, dirName)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(filepath.Join(dir, "missing"), InstallationIDPath(home)); err != nil {
+			t.Fatal(err)
+		}
+		if session := Start(enabledConfig(home)); session != nil {
+			t.Fatalf("dangling symlink produced a session with ID %q", session.installationID)
+		}
+	})
+	t.Run("symlink to a valid identity", func(t *testing.T) {
+		home := t.TempDir()
+		dir := filepath.Join(home, dirName)
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		target := filepath.Join(home, "elsewhere")
+		writeTestFile(t, target, "drive9_0123456789abcdefghijkl\n", 0o600)
+		if err := os.Symlink(target, InstallationIDPath(home)); err != nil {
+			t.Fatal(err)
+		}
+		if session := Start(enabledConfig(home)); session != nil {
+			t.Fatal("symlinked identity should not be adopted")
+		}
+	})
+}
+
+func TestFinishSendsOnlyAllowlistedEventFields(t *testing.T) {
+	requests := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.Method != http.MethodPost || request.URL.Path != "/v1/telemetry/batch" {
+			t.Errorf("unexpected request %s %s", request.Method, request.URL.Path)
+		}
+		if got := request.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("Content-Type = %q", got)
+		}
+		if got := request.Header.Get("User-Agent"); got != "drive9/0.2.0" {
+			t.Errorf("User-Agent = %q", got)
+		}
+		body, _ := io.ReadAll(request.Body)
+		requests <- body
+		writer.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	cfg := enabledConfig(home)
+	cfg.Endpoint = server.URL + "/v1/telemetry/batch"
+	cfg.Now = func() time.Time { return time.Date(2026, 7, 28, 1, 2, 3, 0, time.UTC) }
+	session := Start(cfg)
+	session.Finish(EventInput{
+		CommandPath:   "drive9 fs cat",
+		FlagNames:     []string{"json", "api-key", "server", "json", "Not A Flag"},
+		ExitCode:      2,
+		Duration:      182 * time.Millisecond,
+		CloudProvider: "aws",
+		RegionCode:    "aws-ap-southeast-1",
+		ProfileSource: "explicit",
+	})
+	body := <-requests
+	for _, prohibited := range []string{"SELECT secret_value", "private-key-value", "tenant-123", "profile-name", "/secret/path", "Not A Flag"} {
+		if strings.Contains(string(body), prohibited) {
+			t.Fatalf("payload contains prohibited value %q: %s", prohibited, body)
+		}
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		t.Fatal(err)
+	}
+	if decoded["schema_version"].(float64) != 2 {
+		t.Fatalf("schema_version = %#v", decoded["schema_version"])
+	}
+	events := decoded["events"].([]any)
+	if len(events) != 1 {
+		t.Fatalf("events = %#v", events)
+	}
+	event := events[0].(map[string]any)
+	wantKeys := []string{
+		"anonymous_installation_id", "arch", "cli_version", "cloud_provider",
+		"command_path", "duration_ms", "event_id", "event_name", "exit_code",
+		"flag_names", "install_source", "occurred_at", "os", "profile_source",
+		"region_code",
+	}
+	if len(event) != len(wantKeys) {
+		t.Fatalf("event has %d fields, want %d: %#v", len(event), len(wantKeys), event)
+	}
+	for _, key := range wantKeys {
+		if _, ok := event[key]; !ok {
+			t.Fatalf("event is missing %q: %#v", key, event)
+		}
+	}
+	if event["event_name"] != "drive9.command.finished" || event["command_path"] != "drive9 fs cat" {
+		t.Fatalf("unexpected event: %#v", event)
+	}
+	if event["exit_code"].(float64) != 2 || event["duration_ms"].(float64) != 182 {
+		t.Fatalf("unexpected outcome fields: %#v", event)
+	}
+	if !strings.HasPrefix(event["anonymous_installation_id"].(string), "drive9_") {
+		t.Fatalf("installation id = %v", event["anonymous_installation_id"])
+	}
+	flags := event["flag_names"].([]any)
+	if len(flags) != 3 || flags[0] != "api-key" || flags[1] != "json" || flags[2] != "server" {
+		t.Fatalf("flag names were not canonicalized: %#v", flags)
+	}
+}
+
+func TestFinishDropsEventsTheIngestionContractWouldReject(t *testing.T) {
+	requests := make(chan []byte, 4)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, req *http.Request) {
+		body, _ := io.ReadAll(req.Body)
+		requests <- body
+		writer.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	for _, test := range []struct {
+		name   string
+		config func(*Config)
+		input  EventInput
+	}{
+		{name: "path deeper than the contract allows", input: EventInput{CommandPath: "drive9 admin tenant pool create"}},
+		{name: "path containing user input", input: EventInput{CommandPath: "drive9 fs cat /secret"}},
+		{name: "unsupported operating system", config: func(cfg *Config) { cfg.OS = "plan9x" }, input: EventInput{CommandPath: "drive9 fs ls"}},
+		{name: "unsupported architecture", config: func(cfg *Config) { cfg.Arch = "sparc" }, input: EventInput{CommandPath: "drive9 fs ls"}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := enabledConfig(t.TempDir())
+			cfg.Endpoint = server.URL
+			if test.config != nil {
+				test.config(&cfg)
+			}
+			Start(cfg).Finish(test.input)
+			select {
+			case got := <-requests:
+				t.Fatalf("unsupported event was sent: %s", got)
+			default:
+			}
+		})
+	}
+}
+
+func TestFinishClampsAndNormalizesFields(t *testing.T) {
+	requests := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		body, _ := io.ReadAll(request.Body)
+		requests <- body
+		writer.WriteHeader(http.StatusAccepted)
+	}))
+	defer server.Close()
+
+	home := t.TempDir()
+	cfg := enabledConfig(home)
+	cfg.Endpoint = server.URL
+	cfg.Version = "-not-a-version"
+	Start(cfg).Finish(EventInput{
+		CommandPath: "drive9 admin tenant pool-create",
+		ExitCode:    9001,
+		Duration:    -time.Second,
+	})
+	body := <-requests
+	var payload struct {
+		Events []struct {
+			CLIVersion string   `json:"cli_version"`
+			ExitCode   int      `json:"exit_code"`
+			DurationMS int64    `json:"duration_ms"`
+			FlagNames  []string `json:"flag_names"`
+		} `json:"events"`
+	}
+	if err := json.Unmarshal(body, &payload); err != nil {
+		t.Fatal(err)
+	}
+	event := payload.Events[0]
+	if event.CLIVersion != "unknown" {
+		t.Fatalf("cli_version = %q", event.CLIVersion)
+	}
+	if event.ExitCode != 255 || event.DurationMS != 0 || event.FlagNames == nil || len(event.FlagNames) != 0 {
+		t.Fatalf("unexpected event: %s", body)
+	}
+}
+
+func TestNormalizedRegionUsesAllowlist(t *testing.T) {
+	if got := normalizedRegion("aws", "us-east-1"); got != "aws-us-east-1" {
+		t.Fatalf("composed region = %q", got)
+	}
+	if got := normalizedRegion("aws", "custom-lab"); got != "unknown" {
+		t.Fatalf("unknown region = %q", got)
+	}
+}
+
+func TestDeliveryFailuresAreSilentByDefault(t *testing.T) {
+	for _, status := range []int{http.StatusBadRequest, http.StatusTooManyRequests, http.StatusInternalServerError} {
+		server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+			writer.WriteHeader(status)
+			_, _ = writer.Write([]byte("sensitive backend response"))
+		}))
+		home := t.TempDir()
+		cfg := enabledConfig(home)
+		cfg.Endpoint = server.URL
+		var debug strings.Builder
+		cfg.DebugWriter = &debug
+		Start(cfg).Finish(EventInput{CommandPath: "drive9 fs ls"})
+		server.Close()
+		if debug.Len() != 0 {
+			t.Fatalf("status %d produced normal output: %q", status, debug.String())
+		}
+	}
+}
+
+func TestDeliveryDoesNotFollowRedirects(t *testing.T) {
+	redirected := false
+	sink := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		redirected = true
+		writer.WriteHeader(http.StatusAccepted)
+	}))
+	defer sink.Close()
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, _ *http.Request) {
+		writer.Header().Set("Location", sink.URL)
+		writer.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	defer server.Close()
+	cfg := enabledConfig(t.TempDir())
+	cfg.Endpoint = server.URL
+	Start(cfg).Finish(EventInput{CommandPath: "drive9 fs ls"})
+	if redirected {
+		t.Fatal("telemetry followed a redirect away from its configured endpoint")
+	}
+}
+
+func TestDeliveryTimeoutIsBounded(t *testing.T) {
+	if deliveryTimeout > 1500*time.Millisecond {
+		t.Fatalf("delivery timeout = %s, want a bounded exit-path budget", deliveryTimeout)
+	}
+}
+
+func enabledConfig(home string) Config {
+	return Config{
+		Eligible:      true,
+		HomeDir:       home,
+		Endpoint:      "https://telemetry.example.test/v1/telemetry/batch",
+		Version:       "0.2.0",
+		OS:            "linux",
+		Arch:          "amd64",
+		InstallSource: "archive",
+		Environment:   map[string]string{EnvironmentVariable: "on"},
+	}
+}
+
+func recordedPreference(value *bool) func() (bool, bool) {
+	if value == nil {
+		return func() (bool, bool) { return false, false }
+	}
+	return func() (bool, bool) { return *value, true }
+}
+
+func writeTestFile(t *testing.T, path, content string, mode os.FileMode) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), mode); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertFileContent(t *testing.T, path, want string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != want {
+		t.Fatalf("%s changed: got %q, want %q", path, data, want)
+	}
+}

--- a/pkg/telemetry/telemetry_test.go
+++ b/pkg/telemetry/telemetry_test.go
@@ -546,3 +546,20 @@ func assertFileContent(t *testing.T, path, want string) {
 		t.Fatalf("%s changed: got %q, want %q", path, data, want)
 	}
 }
+
+func TestClaimInstallationIDPathIsExclusive(t *testing.T) {
+	path := filepath.Join(t.TempDir(), installationIDFile)
+	claimed, err := claimInstallationIDPath(path)
+	if err != nil || !claimed {
+		t.Fatalf("first claim = %t, %v; want true, nil", claimed, err)
+	}
+	claimed, err = claimInstallationIDPath(path)
+	if err != nil || claimed {
+		t.Fatalf("second claim = %t, %v; want false, nil", claimed, err)
+	}
+	if info, err := os.Stat(path); err != nil {
+		t.Fatal(err)
+	} else if info.Mode().Perm() != 0o600 && runtime.GOOS != "windows" {
+		t.Fatalf("claimed file mode = %o, want 0600", info.Mode().Perm())
+	}
+}


### PR DESCRIPTION
> **Aligned with [tidbcloud/ti-cli](https://github.com/tidbcloud/ti-cli).** This is not a new telemetry system: it implements the same privacy contract as ti-cli and posts to the same product-owned ingestion service ([`internal/telemetrybackend`](https://github.com/tidbcloud/ti-cli/tree/main/internal/telemetrybackend)) and TiDB cluster, so both CLIs land in one `telemetry_events` table. The client mirrors ti-cli's [`internal/telemetry/telemetry.go`](https://github.com/tidbcloud/ti-cli/blob/main/internal/telemetry/telemetry.go) — same enablement precedence shape (environment override → persisted preference → default, with drive9 choosing the stricter `off` default), same `~/.<product>/` identity file, same schema v2 payload, same best-effort delivery rules — and this repo runs no second backend. The only backend work required is the small allowlist widening for `drive9` listed under [Backend prerequisite](#backend-prerequisite-needed-before-events-can-be-stored-not-before-merging).

## Summary

Adds **opt-in, privacy-preserving command telemetry** to the `drive9` CLI. When a user opts in, each eligible command posts exactly one `drive9.command.finished` event to the telemetry ingestion service shared with `ti-cli` (same TiDB cluster, no second backend in this repo).

Telemetry is **disabled by default**: nothing is sent, and no telemetry state is read or written, unless the user explicitly enables it. No build type, install source, or CI heuristic can turn it on.

## How users opt in / out

| Priority | Switch | Meaning |
| --- | --- | --- |
| 1 | `DRIVE9_TELEMETRY=on\|true\|yes\|1` / `off\|false\|no\|0` | per-process override; empty value = "not set"; an invalid value fails closed |
| 2 | `"telemetry": {"enabled": true\|false}` in `~/.drive9/config` | persisted choice, next to the existing contexts |
| 3 | — | **disabled** |

```jsonc
// ~/.drive9/config
{ "current_context": "...", "contexts": { "...": {} }, "telemetry": { "enabled": true } }
```

The preference intentionally lives in the existing `~/.drive9/config` (not a new file), and stays a field on `cli.Config` so `saveConfig` round-trips it — otherwise any `ctx` mutation would silently drop the user's choice. `TestTelemetryPreferenceSurvivesConfigRewrites` guards that.

## Event payload

Allowlisted fields only:

- `command_path` — built from a hardcoded command tree (`drive9 fs layer create`), never from argv
- `flag_names` — names only, deduplicated, `^[a-z][a-z0-9-]{0,63}$`, max 64
- `exit_code`, `duration_ms`
- `cli_version`, `os`, `arch`, `install_source`
- `cloud_provider` / `region_code` — allowlisted values read from the command's own context; unknown values collapse to `unknown`, and a command addressing another context (`prod:/file`) reports neither
- `profile_source` — `default` / `explicit` / `env` / `unknown`
- `anonymous_installation_id` — `drive9_` + 22 base64url chars, generated once at `~/.drive9/.telemetry-installation-id` (mode `0600`)
- plus envelope fields `schema_version` (2), `sent_at`, `event_id`, `occurred_at`

**Never collected:** flag values, credentials or tokens, SQL text, file paths, file contents, command output, API payloads, context names, tenant IDs, hostnames. There is no free-text escape hatch: the earlier `DRIVE9_TELEMETRY_TAG` / `_EXTRA` channel was removed entirely, because a key deny-list could not make it safe.

### Flag names can never be values

Two independent defenses keep user data out of `flag_names`:

1. **A dash token that directly follows another dash token is treated as that flag's value and is not recorded.** Flag names come from argv without a per-command schema, and a value-taking flag consumes the next argv entry unconditionally, so this is the only sound reading. `--flag=value` forms are unaffected. The cost is under-reporting flags written back-to-back (`-l --json` records `l` only); the alternative — guessing arity — would let a value be recorded as a name.
2. **A closed allowlist of flag names the CLI actually defines** (`cmd/drive9/telemetry_flags.go`). A dash-prefixed token that is not one of them is user input — a mistyped or unknown flag, or a value the command would reject, e.g. `drive9 fs grep -my-pattern` — and is dropped. Dropping an unknown name can only lose analytics, never leak a value. `TestTelemetryKnownFlagNamesCoverEveryDefinedFlag` re-derives the set from source with `go/ast` (both `flag.FlagSet` definitions and hand-rolled parsers that compare argv against literals) and fails when a flag is missing from the allowlist or stale in it, so the list cannot silently rot.

Tests cover `--subject -secret-project`, `--description --private-note`, the inline forms, and unknown flag-shaped tokens.

## Exclusions

No event is emitted, and no telemetry state is touched, for:

- help / version in any form, commandless usage, unknown commands
- a bare `help` operand on the trees whose parsers treat it as help (`drive9 admin tenant create help`), while `drive9 fs grep help` stays a real operand
- every `drive9 update` form
- internal mount machinery: `mount supervise`, `--supervised`, `--supervise-foreground`
- every process drive9 spawns itself (background mount, supervisor and its workers, detached `git hydrate`, generated systemd units) — they get `DRIVE9_TELEMETRY=off` via `telemetryDisabledEnv`, and the generated unit carries `Environment=DRIVE9_TELEMETRY=off`

One user command therefore produces **at most one** event, and mount commands no longer report a second event with a mount-lifetime duration.

## Delivery contract

One `POST` per eligible command, `1s` total budget (client timeout and request context), `202 Accepted` is the only success status, no retries, no local queue, redirects refused, response body drained and discarded. Delivery runs on the exit path, so the budget is also the worst-case latency added to a command; a dropped event is preferable to a visibly slow CLI. Failures never change stdout, stderr, or the exit status.

Client-side validation mirrors the ingestion contract (`event_id`, `command_path`, `cli_version`, `flag_names`, `os`/`arch` allowlists) so an event that would be rejected as a whole is dropped locally instead of costing a guaranteed-400 request.

## Exit paths

`main()` now runs inside the telemetry wrapper, and command handlers exit through `cli.SetExitHook` / `exitProcess` instead of `os.Exit`. The three `flag.ExitOnError` flag sets became `flag.ContinueOnError` returning `cli.UsageError`, which keeps the previous behavior exactly (same message + usage printed once, same exit code 2) while making the exit observable — `drive9 mount --bogus-flag` and `drive9 mount vault` now report `exit_code: 2` instead of silently bypassing telemetry.

## Command tree drift guard

`cmd/drive9/telemetry.go` mirrors the CLI's dispatch tables by hand. `cmd/drive9/telemetry_drift_test.go` extracts the `case` labels from the real dispatchers with `go/ast` and fails when the tree does not know a command or subcommand. Verified by temporarily adding a fake `fs frobnicate` case, which the test caught.

## Build / release wiring

- `make build-cli-release` bakes `INSTALL_SOURCE=github-release` and the ingestion endpoint (`https://tdc-telemetry.tidbcloud.com/v1/telemetry/batch`); `TELEMETRY_ENDPOINT=` can override it (e.g. staging).
- Development builds (`make build`, `make build-cli`) carry **no** endpoint, so a dev binary can never post to production.
- Release artifacts ignore `DRIVE9_ALLOW_TEST_ENDPOINTS` / `DRIVE9_TEST_TELEMETRY_ENDPOINT`; those two exist only so source builds can exercise the delivery path against a local sink.

## Backend prerequisite (needed before events can be stored, not before merging)

The shared ingestion service currently accepts only `ti` / `tdc`, so drive9 events are rejected with `400` and dropped silently by the CLI (visible with `DRIVE9_TELEMETRY_DEBUG=1` as `telemetry delivery was rejected`). Four gates must be widened in `tidbcloud/ti-cli` — none of them requires a schema migration:

1. [`internal/telemetrybackend/server.go`](https://github.com/tidbcloud/ti-cli/blob/main/internal/telemetrybackend/server.go) — `validUserAgent`: accept the `drive9/` prefix (today only `ti/` and `tdc/` are allowed, so every drive9 request is rejected before any field is looked at).
2. [`internal/telemetrybackend/event.go`](https://github.com/tidbcloud/ti-cli/blob/main/internal/telemetrybackend/event.go) — `installationIDPattern`: `^(?:ti|tdc|drive9)_[A-Za-z0-9_-]{16,96}$`.
3. Same file — event-name check: allow `drive9.command.finished` alongside `ti.command.finished` / `tdc.command.finished`.
4. Same file — `commandPathPattern`: allow the `drive9` prefix and widen the subcommand depth from `{0,2}` to `{0,3}` — drive9 flattens deep paths into up to four tokens (`drive9 admin tenant pool-create`).

Because validation is whole-batch and all-or-nothing, any single gate still closed means 100% loss. This is safe to merge before that change lands: with telemetry off by default nobody sends anything, and opted-in users simply see events rejected until the backend is updated.

## Tests and verification

Unit tests (`pkg/telemetry`, `cmd/drive9`, `cmd/drive9/cli`) cover enablement precedence (including invalid values and unreadable preferences failing closed), identity creation/permissions/concurrency, the exact payload key set and normalization, contract-rejection paths, delivery silence and no-redirect behavior, resolver eligibility, flag-name soundness and the flag allowlist, config round-trip, the exit hook, and both drift guards (command tree, flag names).

End-to-end with a real release-style binary against a local sink:

| Scenario | Events |
| --- | --- |
| release build, no opt-in | 0 (and no state file written) |
| `DRIVE9_TELEMETRY=on` / config `enabled: true` | 1 |
| config `enabled: true` + `DRIVE9_TELEMETRY=off` | 0 |
| `--help`, `version`, unknown command, `update --check` | 0 |
| `mount --foreground --supervised`, `mount --supervise-foreground` | 0 |
| `mount --bogus-flag`, `mount vault` (usage errors) | 1 each, `exit_code: 2` |
| `token issue --subject -secret-project` | 1, `flag_names: ["subject"]` |
| `fs grep -my-private-pattern` | 1, `flag_names: []` (unknown token = user input, dropped) |
| `mount --bogus-flag` | 1, `exit_code: 2`, `flag_names: []` |
| `fs find -name version`, `fs grep help` | 1 each (previously suppressed) |

| `admin tenant create help` | 0 |
| `fs cat prod:/file` | 1, no provider/region, `profile_source: unknown` |

Latency: against an endpoint that accepts and never answers, command time is a constant ~1.02s (previously ~3.0s); with telemetry off it is unchanged.

Notes for reviewers: `golangci-lint` v2.5.0 as installed in `bin/` was built with go1.26 and panics against this repo's go1.27 toolchain, so the local gate here was `gofmt` + `go vet` + the package tests; CI lint is the real check. `TestProcessMatchesIdentitySelf` fails in my local sandbox only because `/bin/ps` is blocked there — it is unrelated to this change.

## Follow-ups (not in this PR)

- The ti-cli change above (its own PR: code + [`client_contract_test.go`](https://github.com/tidbcloud/ti-cli/blob/main/internal/telemetrybackend/client_contract_test.go) fixtures + [`docs/telemetry-backend-design.md`](https://github.com/tidbcloud/ti-cli/blob/main/docs/telemetry-backend-design.md)); optionally a `product` column so drive9 and ti traffic can be separated in dashboards (`DisallowUnknownFields` means the payload cannot carry a discriminator field before the backend accepts one).
- Shared-service rate limits (per-IP 60/min, burst 120, global 10k-event buffer, whole-batch drops) are a capacity question for that service; the client deliberately does not retry or spool locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional CLI telemetry, disabled by default.
  - Enable telemetry with `DRIVE9_TELEMETRY=on` or the CLI configuration file.
  - Reports limited command completion information, such as command path, platform, exit status, and approved environment metadata.
  - Excludes sensitive data, credentials, context names, flag values, help, version, and internal commands.
  - Telemetry failures never affect command results.

- **Documentation**
  - Added configuration, privacy, debugging, and endpoint guidance for CLI telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->